### PR TITLE
avoid ts-expect-error on SlackAgent.getStubByName

### DIFF
--- a/apps/os/backend/agent/agents-router.ts
+++ b/apps/os/backend/agent/agents-router.ts
@@ -35,21 +35,17 @@ const agentStubProcedure = protectedProcedure
   .use(async ({ input, ctx, next }) => {
     const estateId = input.estateId;
 
+    const getOrCreateStubParams: Parameters<typeof IterateAgent.getOrCreateStubByName>[0] = {
+      db: ctx.db,
+      estateId,
+      agentInstanceName: input.agentInstanceName,
+      reason: input.reason || "Created via agents router",
+    };
     // Always use getOrCreateStubByName - agents are created on demand
-    const agent = await (input.agentClassName === "SlackAgent"
-      ? // @ts-expect-error - TODO couldn't get types to line up
-        SlackAgent.getOrCreateStubByName({
-          db: ctx.db,
-          estateId,
-          agentInstanceName: input.agentInstanceName,
-          reason: input.reason || "Created via agents router",
-        })
-      : IterateAgent.getOrCreateStubByName({
-          db: ctx.db,
-          estateId,
-          agentInstanceName: input.agentInstanceName,
-          reason: input.reason || "Created via agents router",
-        }));
+    const agent =
+      input.agentClassName === "SlackAgent"
+        ? await SlackAgent.getOrCreateStubByName(getOrCreateStubParams)
+        : await IterateAgent.getOrCreateStubByName(getOrCreateStubParams);
 
     // agent is "any" at this point - that's no good! we want it to be correctly inferred as "some subclass of IterateAgent"
 

--- a/apps/os/backend/agent/iterate-agent.ts
+++ b/apps/os/backend/agent/iterate-agent.ts
@@ -133,22 +133,19 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
   override observability = undefined;
 
   // Resolve the DO namespace for the concrete subclass at runtime
-  static getNamespace<T extends typeof IterateAgent>(
-    this: T,
-  ): DurableObjectNamespace<InstanceType<T>> {
-    return env.ITERATE_AGENT as unknown as DurableObjectNamespace<InstanceType<T>>;
+  static getNamespace() {
+    return env.ITERATE_AGENT;
   }
 
   // Internal helper to get stub from existing database record
-  static async getStubFromDatabaseRecord<T extends typeof IterateAgent>(
-    this: T,
+  static async getStubFromDatabaseRecord(
     record: AgentInstanceDatabaseRecord,
     options?: {
       jurisdiction?: DurableObjectJurisdiction;
       locationHint?: DurableObjectLocationHint;
       props?: Record<string, unknown>;
     },
-  ): Promise<DurableObjectStub<InstanceType<T>>> {
+  ) {
     // Stolen from agents SDK
     let namespace = this.getNamespace();
     if (options?.jurisdiction) {
@@ -178,13 +175,7 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
   }
 
   // Get stub for existing agent by name (does not create)
-  static async getStubByName<T extends typeof IterateAgent>(
-    this: T,
-    params: {
-      db: DB;
-      agentInstanceName: string;
-    },
-  ): Promise<DurableObjectStub<InstanceType<T>>> {
+  static async getStubByName(params: { db: DB; agentInstanceName: string }) {
     const { db, agentInstanceName } = params;
     const className = this.name;
 
@@ -203,14 +194,7 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
   }
 
   // Get stubs for agents by routing key (does not create)
-  static async getStubsByRoute<T extends typeof IterateAgent>(
-    this: T,
-    params: {
-      db: DB;
-      routingKey: string;
-      estateId?: string;
-    },
-  ): Promise<DurableObjectStub<InstanceType<T>>[]> {
+  static async getStubsByRoute(params: { db: DB; routingKey: string; estateId?: string }) {
     const { db, routingKey, estateId } = params;
     const className = this.name;
 
@@ -231,19 +215,16 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
       matchingAgents.map((record) => this.getStubFromDatabaseRecord(record)),
     );
 
-    return stubs;
+    return stubs as unknown[] as DurableObjectStub<IterateAgent>[];
   }
 
   // Get or create stub by name
-  static async getOrCreateStubByName<T extends typeof IterateAgent>(
-    this: T,
-    params: {
-      db: DB;
-      estateId: string;
-      agentInstanceName: string;
-      reason?: string;
-    },
-  ): Promise<DurableObjectStub<InstanceType<T>>> {
+  static async getOrCreateStubByName(params: {
+    db: DB;
+    estateId: string;
+    agentInstanceName: string;
+    reason?: string;
+  }) {
     const { db, estateId, agentInstanceName, reason } = params;
     const className = this.name;
 
@@ -283,16 +264,13 @@ export class IterateAgent<Slices extends readonly AgentCoreSlice[] = CoreAgentSl
   }
 
   // Get or create stub by route
-  static async getOrCreateStubByRoute<T extends typeof IterateAgent>(
-    this: T,
-    params: {
-      db: DB;
-      estateId: string;
-      agentInstanceName: string;
-      route: string;
-      reason?: string;
-    },
-  ): Promise<DurableObjectStub<InstanceType<T>>> {
+  static async getOrCreateStubByRoute(params: {
+    db: DB;
+    estateId: string;
+    agentInstanceName: string;
+    route: string;
+    reason?: string;
+  }) {
     const { db, estateId, agentInstanceName, route, reason } = params;
 
     // First check if an agent already exists for this route

--- a/apps/os/backend/agent/slack-agent.ts
+++ b/apps/os/backend/agent/slack-agent.ts
@@ -43,10 +43,14 @@ type ToolsInterface = typeof slackAgentTools.$infer.interface;
 type Inputs = typeof slackAgentTools.$infer.inputTypes;
 
 export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsInterface {
-  static getNamespace<T extends typeof IterateAgent>(
-    this: T,
-  ): DurableObjectNamespace<InstanceType<T>> {
-    return env.SLACK_AGENT as unknown as DurableObjectNamespace<InstanceType<T>>;
+  static getNamespace() {
+    // cast necessary to avoid typescript error:
+    // Class static side 'typeof SlackAgent' incorrectly extends base class static side 'typeof IterateAgent'.
+    // The types returned by 'getNamespace()' are incompatible between these types.
+
+    // tradeoff: types for some other static methods inherited from IterateAgent like getOrCreateStubByName
+    // are for IterateAgent, rather than SlackAgent, so a cast is necessary if you want to call slack-specific methods on a stub.
+    return env.SLACK_AGENT as unknown as typeof env.ITERATE_AGENT;
   }
 
   protected slackAPI!: WebClient;

--- a/apps/os/backend/integrations/slack/slack.ts
+++ b/apps/os/backend/integrations/slack/slack.ts
@@ -94,7 +94,6 @@ slackApp.post("/webhook", async (c) => {
     }
   }
 
-  // @ts-expect-error - TODO couldn't get types to line up
   const agentStub = await SlackAgent.getOrCreateStubByRoute({
     db,
     estateId,

--- a/apps/os/backend/worker.ts
+++ b/apps/os/backend/worker.ts
@@ -55,20 +55,10 @@ app.all("/api/agents/:estateId/:className/:agentInstanceName", async (c) => {
   }
 
   try {
-    let agentStub: DurableObjectStub;
-    if (agentClassName === "SlackAgent") {
-      // Use SlackAgent's inherited method
-      // @ts-expect-error - TODO couldn't get types to line up
-      agentStub = await SlackAgent.getStubByName({
-        db: c.var.db,
-        agentInstanceName,
-      });
-    } else {
-      agentStub = await IterateAgent.getStubByName({
-        db: c.var.db,
-        agentInstanceName,
-      });
-    }
+    const agentStub =
+      agentClassName === "SlackAgent"
+        ? await SlackAgent.getStubByName({ db: c.var.db, agentInstanceName })
+        : await IterateAgent.getStubByName({ db: c.var.db, agentInstanceName });
     return agentStub.fetch(c.req.raw);
   } catch (error) {
     const message = (error as Error).message || "Unknown error";


### PR DESCRIPTION
@jonastemplestein your generics tricks and this-binding were too much for the compiler to keep track of - I simplified and accepted the tradeoff that calling certain static methods on `SlackAgent` gives you a stub typed for an `IterateAgent` rather than `SlackAgent`. That was a problem in zero of the places we use it so far, and if a future case arises, it's solveable by a pretty innocuous explicit cast like `SlackAgent.getStub(...) as DurableObjectStub<SlackAgent>`