### PR TITLE
disable `curly`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -103,7 +103,7 @@ export default defineConfig([
       "default-param-last": "error",
       "no-else-return": "off",
       "prefer-arrow-callback": "off",
-      curly: ["error", "all"],
+      curly: "off",
 
       // Import rules
       "import/extensions": ["error", "ignorePackages"],


### PR DESCRIPTION
I forgot about this but it still bugs me. Nick L's justification for re-enabling was a paper he read that proved definitively that code that always uses curlies was easier to read than code that didn't

here's the sample code lol

<img width="1830" height="1066" alt="image" src="https://github.com/user-attachments/assets/a4c1f4e3-456d-4c3a-a6a6-a87609f1e143" />

doesn't apply to us. i like short, get-out-of-the-way early returns - we can use our own judgement on this stuff
