### PR TITLE
fix regression where prompt fragments from matched context rules are ignored

### DIFF
--- a/apps/os/backend/agent/context-schemas.ts
+++ b/apps/os/backend/agent/context-schemas.ts
@@ -1,7 +1,7 @@
 import type { RequireAtLeastOne } from "type-fest";
 import { z } from "zod";
 import { PromptFragment } from "./prompt-fragments.ts";
-import { MCPServer, ToolSpec, type MCPServerInput } from "./tool-schemas.ts";
+import { ToolSpec } from "./tool-schemas.ts";
 
 export type ContextRuleMatcher =
   | { type: "always" }
@@ -90,7 +90,6 @@ export type TimeWindow = z.infer<typeof TimeWindow>;
 export type ContextItem = RequireAtLeastOne<{
   prompt: PromptFragment;
   tools: ToolSpec[];
-  mcpServers: MCPServerInput[];
 }> & {
   key: string;
   description?: string;
@@ -100,7 +99,6 @@ export const ContextItem = z.object({
   description: z.string().optional(),
   prompt: PromptFragment.optional(),
   tools: z.array(ToolSpec).optional(),
-  mcpServers: z.array(MCPServer).optional(),
 }) satisfies z.ZodType<{
   [K in keyof ContextItem]: ContextItem[K];
 }>;

--- a/apps/os/backend/agent/default-context-rules.ts
+++ b/apps/os/backend/agent/default-context-rules.ts
@@ -3,9 +3,7 @@
 import dedent from "dedent";
 import { z } from "zod/v4";
 import { defineRule, matchers } from "./context.ts";
-
-// not typesafe version
-// const trpcCallableBuilder = makeTrpcCallable<any>();
+import { slackAgentTools } from "./slack-agent-tools.ts";
 
 const defaultSlackAgentPrompt = dedent`
   You are @iterate, a helpful slackbot made by iterate.com.
@@ -142,16 +140,6 @@ const defaultSlackAgentPrompt = dedent`
 `;
 export const defaultContextRules = async () => [
   defineRule({
-    key: "reverse-tool",
-    match: matchers.always(),
-    tools: [
-      {
-        type: "agent_durable_object_tool",
-        methodName: "reverse",
-      },
-    ],
-  }),
-  defineRule({
     key: "@iterate-com/slack-default-context-rules",
     prompt: defaultSlackAgentPrompt,
     match: matchers.forAgentClass("SlackAgent"),
@@ -212,7 +200,7 @@ export const defaultContextRules = async () => [
       //   methodName: "searchWeb",
       // },
 
-      // TRPC tools
+      // TRPC tools (to be replaced with durable object versions)
       // trpcCallableBuilder.firstparty.imageGenerator.generateImage.toolSpec({
       //   overrideName: "generate_image",
       // }),
@@ -223,7 +211,7 @@ export const defaultContextRules = async () => [
         type: "agent_durable_object_tool",
         methodName: "sendSlackMessage",
         overrideInputJSONSchema: z.toJSONSchema(
-          (await import("./slack-agent-tools.ts")).slackAgentTools.sendSlackMessage.input.pick({
+          slackAgentTools.sendSlackMessage.input.pick({
             text: true,
             ephemeral: true,
             user: true,


### PR DESCRIPTION
not sure if this is the "correct" solution (i vaguely recall you said ephemeralPromptFragments are bad now @mmkal ?)

but it means our agent works again 😌 

i also removed the mcpServers property from context ruels as we're not using it and i'm very glad about that - it's a step in the right direction, where everything is based on strings (i.e. flat files in a filesystem)