### PR TITLE
render slack webhooks in agent detail

### DIFF
--- a/apps/os/app/routes/agents.tsx
+++ b/apps/os/app/routes/agents.tsx
@@ -1363,27 +1363,6 @@ function CoreEventRenderer({
               </div>
             );
 
-          case "app_mention":
-            return (
-              <div className="space-y-3">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium">App mentioned by</span>
-                  <Badge variant="outline" className="text-xs">
-                    {isFromBot
-                      ? "Agent (Bot)"
-                      : formatSlackUser(
-                          slackEvent.user || slackEvent.bot_profile?.name || "unknown",
-                        )}
-                  </Badge>
-                </div>
-                {slackEvent.text && (
-                  <div className="bg-muted/50 p-3 rounded-md border">
-                    <div className="text-sm whitespace-pre-wrap break-words">{slackEvent.text}</div>
-                  </div>
-                )}
-              </div>
-            );
-
           default:
             return (
               <div className="text-sm">


### PR DESCRIPTION
Resolves [ITE-2982: Agent detail: Slack webhooks](https://linear.app/iterate-com/issue/ITE-2982/agent-detail-slack-webhooks)

It shows all user webhooks and there's a toggle to turn on the agent's own webhooks if you want to (they were initially hidden in the previous codebase but I thought it might be useful to see)