### PR TITLE
Make DO tool factory typesafe

### DIFF
--- a/apps/os/backend/agent/default-context-rules.ts
+++ b/apps/os/backend/agent/default-context-rules.ts
@@ -7,11 +7,9 @@ import { defineRule, matchers } from "./context.ts";
 import { slackAgentTools } from "./slack-agent-tools.ts";
 import { createDOToolFactory } from "./do-tools.ts";
 import { iterateAgentTools } from "./iterate-agent-tools.ts";
-import type { IterateAgent } from "./iterate-agent.ts";
-import type { SlackAgent } from "./slack-agent.ts";
 
-const iterateAgentTool = createDOToolFactory<IterateAgent>()(iterateAgentTools);
-const slackAgentTool = createDOToolFactory<SlackAgent>()(slackAgentTools);
+const iterateAgentTool = createDOToolFactory(iterateAgentTools);
+const slackAgentTool = createDOToolFactory(slackAgentTools);
 
 const defaultSlackAgentPrompt = dedent`
   You are @iterate, a helpful slackbot made by iterate.com.
@@ -203,7 +201,6 @@ export const defaultContextRules = async () => [
         ),
       }),
       iterateAgentTool.generateImage(),
-      iterateAgentTool.editImage(),
       slackAgentTool.sendSlackMessage({
         overrideInputJSONSchema: z.toJSONSchema(
           slackAgentTools.sendSlackMessage.input.pick({

--- a/apps/os/sdk/index.ts
+++ b/apps/os/sdk/index.ts
@@ -1,4 +1,7 @@
 import dedent from "dedent";
+import { createDOToolFactory } from "../backend/agent/do-tools.ts";
+import { iterateAgentTools } from "../backend/agent/iterate-agent-tools.ts";
+import { slackAgentTools } from "../backend/agent/slack-agent-tools.ts";
 
 export {
   contextRulesFromFiles,
@@ -13,3 +16,8 @@ export { dedent };
 export type { ToolSpec } from "../backend/agent/tool-schemas.ts";
 export type { PromptFragment } from "../backend/agent/prompt-fragments.ts";
 export type { ContextRule } from "../backend/agent/context.ts";
+
+export const tools = {
+  ...createDOToolFactory(iterateAgentTools),
+  ...createDOToolFactory(slackAgentTools),
+};


### PR DESCRIPTION
Resolves [ITE-2918: Make DO tool factory typesafe](https://linear.app/iterate-com/issue/ITE-2918/make-do-tool-factory-typesafe)

@mmkal I was debating between some things:
- Make the class name optional and default to something?
- Not even pass a class name, just have all the iterate agent and slack agent tools.

Would be great to hear your opinion! :)