### PR TITLE
fix little bugs

### DIFF
--- a/apps/os/backend/agent/default-context-rules.ts
+++ b/apps/os/backend/agent/default-context-rules.ts
@@ -91,12 +91,13 @@ const defaultSlackAgentPrompt = dedent`
   - If you are addressing the entire team / making an announcement, use "we" to refer to the team.
   - Never make up or guess facts or function tool parameters. Always be honest.  
   - Briefly acknowledge mistakes and correct yourself when you've made a mistake.
-  - Never repeat a message that has already been communicated to the user.
+  - Never repeat a message or update that has already been communicated to the user.
+    - e.g if you're blocked on an error, and have already communicated that state to the user, don't repeat that message unless the state has changed (e.g you are now unblocked). If you keep re-trying and keep hitting the same error, then do it silently. 
 
   Message formatting:
   - Use Slack-flavour markdown
   - Don't use italics for multi-line messages
-  - Links: <URL|Display Text>
+  - Always format links as inline Slack links: <URL | descriptive text> instead of showing raw URLs. If you are given a link / URL to share with a user, use that exact link. 
   - Prefer inline links like "<URL|this image> is cool". Don't do <URL|click here to open>"
   - Mentions: <@user_id>
   - Never use: Markdown tables (use lists/bullets)
@@ -117,6 +118,7 @@ const defaultSlackAgentPrompt = dedent`
   - Proceed with reasonable assumptions whenever possible - don't ask for clarification unless absolutely necessary
     - If there's a clear first/best option, use it without asking
     - Only ask clarifying questions when there are multiple equally valid options and no reasonable default
+    - Note you may be given additional context items that related to a specific MCP server once you've connected to it - when asked to do something with an MCP server, connect first BEFORE asking the user for clarification. 
   - Never ask the same clarifying questions twice.
   - When you ask for input, use sendSlackMessage({ text, endTurn: true })
 
@@ -160,7 +162,8 @@ const defaultSlackAgentPrompt = dedent`
 
   ### Generating and editing images
   - Use the generateImage tool for creating images and editing existing ones
-  - If you're asked to generate or edit an image of "me" or another Slack participant (e.g the users asks "give me a mustache"), use the participant's Slack avatar url. If the user hasn't specified what kind of modified image they want, assume they want an emoji-styled image.
+  - If you're asked to generate or edit an image of "me" or another Slack participant (e.g the users asks "give me a mustache") and haven't explicitly been given an image, always assume you should use the participant's Slack avatar url. 
+    - If the user hasn't specified what kind of modified image they want, assume they want an emoji-styled image.
 
   For generating emoji-styled images, call the generate_image tool with this exact prompt:
   "edit this image of me to be a super cute chibi twitch emote [ACTION] with a png transparent background, simple shapes, bold outline, high contrast, square composition (1:1)"

--- a/apps/os/backend/agent/slack-agent-tools.ts
+++ b/apps/os/backend/agent/slack-agent-tools.ts
@@ -46,7 +46,7 @@ export const slackAgentTools = defineDOTools({
         .default(false)
         .optional()
         .describe(
-          "Optional. Set this to end-turn only if you want to yield to the user and end your turn. For example because you've asked them for input on something or if you think you're done and there's nothing left for you to do.",
+          "Optional. Set this to true only if you want to yield to the user and end your turn. For example because you've asked them for input on something or if you think you're done and there's nothing left for you to do.",
         ),
     }),
   },


### PR DESCRIPTION
### TL;DR

fix small bugs in prompt-land 

### What changed?

- Improved link formatting instructions, requiring agents to use Slack's inline link format `<URL | descriptive text>` instead of raw URLs
- Added instruction for agents to connect to MCP servers before asking for clarification if a task relates to a specific MCP server (as they might get additional context rules on connection) 
- Clarified image generation guidance, specifically when using Slack avatar URLs
- Fixed documentation in the `sendSlackMessage` tool to clarify that `endTurn` should be set to `true` (not "end-turn")
- Enhanced guidance on message repetition, specifying that agents should not repeat error messages if the state hasn't changed
