### PR TITLE
ITE-3074 Stripe payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,31 @@ SLACK_SIGNING_SECRET
 ```
 
 You can get them from the slack app settings page.
+
+# Stripe payments
+
+We're using a new stripe product that lets us easily charge a margin on top of tokens.
+
+The primary integration points are
+
+- After an LLM request, we need to send token utilization along with a stripe customer ID to a stripe API
+- When an organization gets created, we need to create the stripe customer and subscription
+
+We use the better-auth stripe plugin with stripe customers associated to our homegrown organization model (because we are not using the better-auth organization plugin for some reason).
+
+### Using stripe in local development
+
+Add a webhook destination to our dev sandbox [here](https://dashboard.stripe.com/acct_1SE8neK5uSY4fgf4/test/workbench/webhooks)
+
+The URL should be `https://{ITERATE_USER}.dev.iterate.com/api/auth/stripe/webhook`
+
+Then set the `STRIPE_WEBHOOK_SECRET` env var in your `dev_personal` doppler config to the one for the new webhook destination.
+
+```bash
+
+brew install stripe/stripe-cli/stripe
+stripe login
+
+# Note that it will take a few seconds for the webhook to arrive
+stripe trigger v1.billing.meter.no_meter_found
+```

--- a/apps/os/app/components/organization-switcher.tsx
+++ b/apps/os/app/components/organization-switcher.tsx
@@ -1,0 +1,105 @@
+import { ChevronsUpDown, Plus } from "lucide-react";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { useNavigate } from "react-router";
+import { useTRPC } from "../lib/trpc.ts";
+import { useOrganizationId } from "../hooks/use-estate.ts";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu.tsx";
+import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "./ui/sidebar.tsx";
+
+export function OrganizationSwitcher() {
+  const trpc = useTRPC();
+  const navigate = useNavigate();
+  const currentOrganizationId = useOrganizationId();
+  const { data: organizations } = useSuspenseQuery(trpc.organization.list.queryOptions());
+
+  const currentOrganization = organizations.find((org) => org.id === currentOrganizationId);
+
+  // If there are no organizations, show a prompt to create one
+  if (organizations.length === 0) {
+    return (
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton size="lg" onClick={() => navigate("/new-organization")}>
+            <div className="flex aspect-square size-8 items-center justify-center rounded-lg border border-dashed">
+              <Plus className="size-4" />
+            </div>
+            <div className="grid flex-1 text-left text-sm leading-tight">
+              <span className="truncate font-semibold">Create Organization</span>
+              <span className="truncate text-xs text-muted-foreground">Get started</span>
+            </div>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    );
+  }
+
+  const handleOrganizationSwitch = (organizationId: string) => {
+    // Navigate to the organization page (which will redirect to first estate)
+    navigate(`/${organizationId}`);
+  };
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <SidebarMenuButton
+              size="lg"
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            >
+              <div className="bg-black flex aspect-square size-8 items-center justify-center rounded-lg">
+                <img src="/logo.svg" alt="𝑖" className="size-6 text-white" />
+              </div>
+              <div className="grid flex-1 text-left text-sm leading-tight">
+                <span className="truncate font-semibold">iterate</span>
+                <span className="truncate text-xs">
+                  {currentOrganization?.name || "Select Organization"}
+                </span>
+              </div>
+              <ChevronsUpDown className="ml-auto" />
+            </SidebarMenuButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+            align="start"
+            side="bottom"
+            sideOffset={4}
+          >
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              Organizations
+            </DropdownMenuLabel>
+            {organizations.map((org) => (
+              <DropdownMenuItem
+                key={org.id}
+                onClick={() => handleOrganizationSwitch(org.id)}
+                className="gap-2 p-2"
+              >
+                <div className="flex size-6 items-center justify-center rounded-sm border">
+                  <span className="text-xs font-semibold">{org.name.charAt(0).toUpperCase()}</span>
+                </div>
+                <div className="flex flex-col">
+                  <span className="font-medium">{org.name}</span>
+                  <span className="text-xs text-muted-foreground capitalize">{org.role}</span>
+                </div>
+              </DropdownMenuItem>
+            ))}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem className="gap-2 p-2" onClick={() => navigate("/new-organization")}>
+              <div className="flex size-6 items-center justify-center rounded-md border border-dashed">
+                <Plus className="size-4" />
+              </div>
+              <div className="font-medium text-muted-foreground">Add organization</div>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+}

--- a/apps/os/app/routes.ts
+++ b/apps/os/app/routes.ts
@@ -1,4 +1,4 @@
-import { type RouteConfig, index, route } from "@react-router/dev/routes";
+import { type RouteConfig, index, prefix, route } from "@react-router/dev/routes";
 
 export default [
   // Public routes (no auth required)
@@ -7,6 +7,9 @@ export default [
 
   // Root index - will handle redirect logic to org/estate routes
   index("./routes/root-redirect.tsx"),
+
+  // New organization creation
+  route("/new-organization", "./routes/new-organization.tsx"),
 
   // Admin routes (admin only, no estate context required)
   route("/admin", "./routes/admin-layout.tsx", [
@@ -18,16 +21,25 @@ export default [
     route("estates", "./routes/admin-estates.tsx"),
   ]),
 
-  // Protected routes with org/estate prefix
-  route(":organizationId/:estateId", "./routes/estate-layout.tsx", [
-    index("./routes/home.tsx"),
-    route("integrations", "./routes/integrations.tsx"),
-    route("integrations/mcp-params", "./routes/integrations.mcp-params.tsx"),
-    route("integrations/redirect", "./routes/integrations.redirect.tsx"),
-    route("estate", "./routes/estate.tsx"),
-    route("agents", "./routes/agents-index.tsx"),
-    route("agents/start-slack", "./routes/agents.start-slack.tsx"),
-    route("agents/:agentClassName/:durableObjectName", "./routes/agents.tsx"),
+  // All organization routes (with or without estate context)
+  route(":organizationId", "./routes/org-layout.tsx", [
+    // Organization-level routes
+    index("./routes/org-redirect.tsx"),
+    route("settings", "./routes/org-settings.tsx"),
+    route("team", "./routes/org-team.tsx"),
+
+    // Estate-specific routes
+    ...prefix(":estateId", [
+      // Estate-specific routes
+      index("./routes/home.tsx"),
+      route("integrations", "./routes/integrations.tsx"),
+      route("integrations/mcp-params", "./routes/integrations.mcp-params.tsx"),
+      route("integrations/redirect", "./routes/integrations.redirect.tsx"),
+      route("estate", "./routes/estate.tsx"),
+      route("agents", "./routes/agents-index.tsx"),
+      route("agents/start-slack", "./routes/agents.start-slack.tsx"),
+      route("agents/:agentClassName/:durableObjectName", "./routes/agents.tsx"),
+    ]),
   ]),
 
   // Catch-all route for 404

--- a/apps/os/app/routes/admin-db-tools.tsx
+++ b/apps/os/app/routes/admin-db-tools.tsx
@@ -44,7 +44,7 @@ export default function AdminDBToolsPage() {
   };
 
   return (
-    <div className="container max-w-2xl p-6 space-y-6">
+    <div className="p-6 space-y-6">
       <div>
         <h2 className="text-2xl font-semibold">Database Tools</h2>
         <p className="text-sm text-muted-foreground">Destructive operations</p>

--- a/apps/os/app/routes/admin-estates.tsx
+++ b/apps/os/app/routes/admin-estates.tsx
@@ -95,7 +95,7 @@ export default function AdminEstatesPage() {
   };
 
   return (
-    <div className="container mx-auto p-6 space-y-6">
+    <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-2xl font-bold">Estates</h2>

--- a/apps/os/app/routes/admin-session-info.tsx
+++ b/apps/os/app/routes/admin-session-info.tsx
@@ -6,7 +6,7 @@ export default function SessionInfoPage() {
   const { data: sessionInfo } = useSuspenseQuery(trpc.admin.getSessionInfo.queryOptions());
 
   return (
-    <div className="container mx-auto p-6 space-y-6">
+    <div className="p-6 space-y-6">
       <div>
         <h2 className="text-2xl font-bold">Session Information</h2>
         <p className="text-muted-foreground">Current user and session details</p>

--- a/apps/os/app/routes/admin-slack-notification.tsx
+++ b/apps/os/app/routes/admin-slack-notification.tsx
@@ -28,7 +28,7 @@ export default function SlackNotificationPage() {
   });
 
   return (
-    <div className="container mx-auto p-6 space-y-6">
+    <div className="p-6 space-y-6">
       <div>
         <h2 className="text-2xl font-bold">Test Slack Notifications</h2>
         <p className="text-muted-foreground">Send test messages to iterate's Slack workspace</p>

--- a/apps/os/app/routes/agents.start-slack.tsx
+++ b/apps/os/app/routes/agents.start-slack.tsx
@@ -84,8 +84,8 @@ export default function StartSlackPage() {
   };
 
   return (
-    <div className="flex flex-1 flex-col gap-4 p-4 pt-4">
-      <div className="max-w-2xl mx-auto w-full space-y-6">
+    <div className="p-6">
+      <div className="space-y-6">
         <div>
           <h1 className="text-2xl font-bold flex items-center gap-2">
             <MessageSquarePlus className="h-6 w-6" />

--- a/apps/os/app/routes/estate.tsx
+++ b/apps/os/app/routes/estate.tsx
@@ -461,9 +461,9 @@ function EstateContent() {
   };
 
   return (
-    <div className="max-w-4xl mx-auto px-8 pt-16 pb-8">
+    <div className="p-6">
       {/* Editable Title */}
-      <div className="mb-12">
+      <div className="mb-8">
         <EditableTitle
           value={estate.name}
           isEditing={isEditing}

--- a/apps/os/app/routes/integrations.mcp-params.tsx
+++ b/apps/os/app/routes/integrations.mcp-params.tsx
@@ -128,7 +128,7 @@ export default function MCPParams() {
   };
 
   return (
-    <div className="max-w-2xl mx-auto p-6">
+    <div className="p-6">
       <div className="mb-8">
         <h1 className="text-3xl font-bold mb-2">Configure MCP Server</h1>
         <p className="text-muted-foreground text-lg">

--- a/apps/os/app/routes/integrations.tsx
+++ b/apps/os/app/routes/integrations.tsx
@@ -137,7 +137,7 @@ export default function Integrations() {
 
   if (isLoading) {
     return (
-      <div className="max-w-6xl mx-auto p-6">
+      <div className="p-6">
         <div className="mb-8">
           <h1 className="text-3xl font-bold mb-2">Integrations</h1>
           <p className="text-muted-foreground text-lg">
@@ -164,7 +164,7 @@ export default function Integrations() {
 
   if (error) {
     return (
-      <div className="max-w-6xl mx-auto p-6">
+      <div className="p-6">
         <div className="mb-8">
           <h1 className="text-3xl font-bold mb-2">Integrations</h1>
           <p className="text-muted-foreground text-lg">
@@ -177,7 +177,7 @@ export default function Integrations() {
   }
 
   return (
-    <div className="max-w-6xl mx-auto p-6">
+    <div className="p-6">
       {/* Header */}
       <div className="mb-8">
         <h1 className="text-3xl font-bold mb-2">Integrations</h1>

--- a/apps/os/app/routes/new-organization.tsx
+++ b/apps/os/app/routes/new-organization.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import { Loader2 } from "lucide-react";
+import { useMutation } from "@tanstack/react-query";
+import { useTRPC } from "../lib/trpc.ts";
+import { Button } from "../components/ui/button.tsx";
+import { Input } from "../components/ui/input.tsx";
+import { Label } from "../components/ui/label.tsx";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../components/ui/card.tsx";
+import type { Route } from "./+types/new-organization";
+
+export function meta(_args: Route.MetaArgs) {
+  return [
+    { title: "Create Organization - Iterate" },
+    { name: "description", content: "Create a new organization" },
+  ];
+}
+
+export default function NewOrganization() {
+  const navigate = useNavigate();
+  const trpc = useTRPC();
+  const [organizationName, setOrganizationName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const createOrganization = useMutation(
+    trpc.organization.create.mutationOptions({
+      onSuccess: (data) => {
+        // Navigate to the new organization's first estate
+        navigate(`/${data.organization.id}/${data.estate.id}`);
+      },
+      onError: (error) => {
+        setError(error.message);
+      },
+    }),
+  );
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!organizationName.trim()) {
+      setError("Organization name is required");
+      return;
+    }
+
+    createOrganization.mutate({ name: organizationName });
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Create Organization</CardTitle>
+          <CardDescription>Create a new organization to get started with iterate</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="organizationName">Organization Name</Label>
+              <Input
+                id="organizationName"
+                type="text"
+                placeholder="My Company"
+                value={organizationName}
+                onChange={(e) => setOrganizationName(e.target.value)}
+                disabled={createOrganization.isPending}
+                autoFocus
+              />
+            </div>
+
+            {error && <div className="text-sm text-destructive">{error}</div>}
+
+            <Button type="submit" className="w-full" disabled={createOrganization.isPending}>
+              {createOrganization.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Creating...
+                </>
+              ) : (
+                "Create Organization"
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/os/app/routes/org-redirect.tsx
+++ b/apps/os/app/routes/org-redirect.tsx
@@ -1,0 +1,23 @@
+import { redirect } from "react-router";
+import { eq } from "drizzle-orm";
+import { getDb } from "../../backend/db/client.ts";
+import { estate } from "../../backend/db/schema.ts";
+
+export async function loader({ params }: { params: { organizationId: string } }) {
+  const { organizationId } = params;
+
+  // Get first estate for this org
+  const firstEstate = await getDb().query.estate.findFirst({
+    where: eq(estate.organizationId, organizationId),
+  });
+
+  if (!firstEstate) {
+    throw redirect("/no-access");
+  }
+
+  throw redirect(`/${organizationId}/${firstEstate.id}`);
+}
+
+export default function OrgRedirect() {
+  return null; // Never renders
+}

--- a/apps/os/app/routes/org-settings.tsx
+++ b/apps/os/app/routes/org-settings.tsx
@@ -1,0 +1,165 @@
+import { useState, Suspense } from "react";
+import { Settings, Loader2, Save } from "lucide-react";
+import { useSuspenseQuery, useMutation } from "@tanstack/react-query";
+import { useTRPC } from "../lib/trpc.ts";
+import { Button } from "../components/ui/button.tsx";
+import { Input } from "../components/ui/input.tsx";
+import { Label } from "../components/ui/label.tsx";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../components/ui/card.tsx";
+import type { Route } from "./+types/org-settings";
+
+export function meta(_args: Route.MetaArgs) {
+  return [
+    { title: "Organization Settings - Iterate" },
+    { name: "description", content: "Manage your organization settings" },
+  ];
+}
+
+function OrganizationSettingsContent({ organizationId }: { organizationId: string }) {
+  const trpc = useTRPC();
+  const { data: organization } = useSuspenseQuery(
+    trpc.organization.get.queryOptions({ organizationId }),
+  );
+
+  const [organizationName, setOrganizationName] = useState(organization.name);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const updateOrganization = useMutation(
+    trpc.organization.updateName.mutationOptions({
+      onSuccess: (data) => {
+        setSuccessMessage("Organization name updated successfully");
+        setOrganizationName(data.name);
+        setError(null);
+
+        // Clear success message after 3 seconds
+        setTimeout(() => setSuccessMessage(null), 3000);
+      },
+      onError: (error) => {
+        setError(error.message);
+        setSuccessMessage(null);
+      },
+    }),
+  );
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccessMessage(null);
+
+    if (!organizationName.trim()) {
+      setError("Organization name is required");
+      return;
+    }
+
+    if (organizationName === organization.name) {
+      setError("No changes to save");
+      return;
+    }
+
+    updateOrganization.mutate({
+      organizationId,
+      name: organizationName,
+    });
+  };
+
+  const hasChanges = organizationName !== organization.name;
+
+  return (
+    <div className="p-6">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-4">Organization Settings</h1>
+        <p className="text-muted-foreground text-lg">
+          Manage your organization configuration and preferences
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <Settings className="h-6 w-6 text-muted-foreground" />
+            <div>
+              <CardTitle>General Settings</CardTitle>
+              <CardDescription>Update your organization name and other details</CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="organizationName">Organization Name</Label>
+              <Input
+                id="organizationName"
+                type="text"
+                placeholder="My Company"
+                value={organizationName}
+                onChange={(e) => {
+                  setOrganizationName(e.target.value);
+                  setError(null);
+                  setSuccessMessage(null);
+                }}
+                disabled={updateOrganization.isPending}
+              />
+            </div>
+
+            {error && (
+              <div className="text-sm text-destructive bg-destructive/10 p-3 rounded-md">
+                {error}
+              </div>
+            )}
+
+            {successMessage && (
+              <div className="text-sm p-3 rounded-md border bg-card">{successMessage}</div>
+            )}
+
+            <Button type="submit" disabled={updateOrganization.isPending || !hasChanges}>
+              {updateOrganization.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                <>
+                  <Save className="mr-2 h-4 w-4" />
+                  Save Changes
+                </>
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default function OrganizationSettings({ params }: Route.ComponentProps) {
+  const { organizationId } = params;
+
+  if (!organizationId) {
+    return (
+      <div className="p-6">
+        <div className="text-center text-destructive">Organization ID is required</div>
+      </div>
+    );
+  }
+
+  return (
+    <Suspense
+      fallback={
+        <div className="p-6">
+          <div className="flex items-center justify-center h-64">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        </div>
+      }
+    >
+      <OrganizationSettingsContent organizationId={organizationId} />
+    </Suspense>
+  );
+}

--- a/apps/os/app/routes/org-team.tsx
+++ b/apps/os/app/routes/org-team.tsx
@@ -1,0 +1,168 @@
+import { Suspense } from "react";
+import { UserCog, Loader2 } from "lucide-react";
+import { useSuspenseQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useTRPC } from "../lib/trpc.ts";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../components/ui/table.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../components/ui/select.tsx";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../components/ui/card.tsx";
+import type { Route } from "./+types/org-team";
+
+export function meta(_args: Route.MetaArgs) {
+  return [
+    { title: "Team Members - Iterate" },
+    { name: "description", content: "Manage your organization team members" },
+  ];
+}
+
+const roleLabels: Record<string, string> = {
+  owner: "Owner",
+  admin: "Admin",
+  member: "Member",
+  guest: "Guest",
+};
+
+function OrganizationTeamContent({ organizationId }: { organizationId: string }) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const { data: currentUser } = useSuspenseQuery(trpc.user.me.queryOptions());
+  const { data: members } = useSuspenseQuery(
+    trpc.organization.listMembers.queryOptions({ organizationId }),
+  );
+
+  const updateRole = useMutation(
+    trpc.organization.updateMemberRole.mutationOptions({
+      onSuccess: () => {
+        // Invalidate the members query to refetch the data
+        queryClient.invalidateQueries({
+          queryKey: trpc.organization.listMembers.queryKey({ organizationId }),
+        });
+      },
+    }),
+  );
+
+  const handleRoleChange = (userId: string, role: string) => {
+    updateRole.mutate({
+      organizationId,
+      userId,
+      role: role as "member" | "admin" | "owner" | "guest",
+    });
+  };
+
+  return (
+    <div className="p-6">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-4">Team Members</h1>
+        <p className="text-muted-foreground text-lg">
+          Manage your organization team members and their roles
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <UserCog className="h-6 w-6 text-muted-foreground" />
+            <div>
+              <CardTitle>Members</CardTitle>
+              <CardDescription>
+                {members.length} {members.length === 1 ? "member" : "members"}
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Email</TableHead>
+                <TableHead>Role</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {members.map((member) => {
+                const isCurrentUser = member.userId === currentUser.id;
+                return (
+                  <TableRow key={member.id}>
+                    <TableCell className="font-medium">
+                      {member.name}
+                      {isCurrentUser && (
+                        <span className="ml-2 text-xs text-muted-foreground">(You)</span>
+                      )}
+                    </TableCell>
+                    <TableCell>{member.email}</TableCell>
+                    <TableCell>
+                      {isCurrentUser ? (
+                        <span className="text-sm">{roleLabels[member.role]}</span>
+                      ) : (
+                        <Select
+                          value={member.role}
+                          onValueChange={(value) => handleRoleChange(member.userId, value)}
+                          disabled={updateRole.isPending}
+                        >
+                          <SelectTrigger className="w-[120px]">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="owner">Owner</SelectItem>
+                            <SelectItem value="admin">Admin</SelectItem>
+                            <SelectItem value="member">Member</SelectItem>
+                            <SelectItem value="guest">Guest</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default function OrganizationTeam({ params }: Route.ComponentProps) {
+  const { organizationId } = params;
+
+  if (!organizationId) {
+    return (
+      <div className="p-6">
+        <div className="text-center text-destructive">Organization ID is required</div>
+      </div>
+    );
+  }
+
+  return (
+    <Suspense
+      fallback={
+        <div className="p-6">
+          <div className="flex items-center justify-center h-64">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        </div>
+      }
+    >
+      <OrganizationTeamContent organizationId={organizationId} />
+    </Suspense>
+  );
+}

--- a/apps/os/backend/agent/slack-agent.ts
+++ b/apps/os/backend/agent/slack-agent.ts
@@ -22,11 +22,7 @@ import type {
 } from "./agent-core.ts";
 import type { DOToolDefinitions } from "./do-tools.ts";
 import { iterateAgentTools } from "./iterate-agent-tools.ts";
-import {
-  CORE_AGENT_SLICES,
-  IterateAgent,
-  type AgentInstanceDatabaseRecord,
-} from "./iterate-agent.ts";
+import { CORE_AGENT_SLICES, IterateAgent } from "./iterate-agent.ts";
 import { slackAgentTools } from "./slack-agent-tools.ts";
 import { slackSlice, type SlackSliceState } from "./slack-slice.ts";
 import { shouldIncludeEventInConversation, shouldUnfurlSlackMessage } from "./slack-agent-utils.ts";
@@ -56,6 +52,7 @@ export type SlackAgentSlices = typeof slackAgentSlices;
 
 type ToolsInterface = typeof slackAgentTools.$infer.interface;
 type Inputs = typeof slackAgentTools.$infer.inputTypes;
+import type { AgentInitParams } from "./iterate-agent.ts";
 
 export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsInterface {
   static getNamespace() {
@@ -113,7 +110,7 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
   }
 
   // This gets run between the synchronous durable object constructor and the asynchronous onStart method of the agents SDK
-  async initAfterConstructorBeforeOnStart(params: { record: AgentInstanceDatabaseRecord }) {
+  async initAfterConstructorBeforeOnStart(params: AgentInitParams) {
     await super.initAfterConstructorBeforeOnStart(params);
 
     if (params.record.durableObjectName.includes("mock_slack")) {

--- a/apps/os/backend/auth/auth.ts
+++ b/apps/os/backend/auth/auth.ts
@@ -2,15 +2,27 @@ import { betterAuth } from "better-auth";
 import { admin } from "better-auth/plugins";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { typeid } from "typeid-js";
+import { waitUntil } from "cloudflare:workers";
+import { stripe } from "@better-auth/stripe";
 import { type DB } from "../db/client.ts";
 import * as schema from "../db/schema.ts";
 import { env } from "../../env.ts";
+import { createStripeCustomerAndSubscriptionForOrganization } from "../integrations/stripe/stripe.ts";
 import { logger } from "../tag-logger.ts";
+import { stripeClient } from "../integrations/stripe/stripe.ts";
 import { integrationsPlugin } from "./integrations.ts";
 import { createUserOrganizationAndEstate } from "./hooks.ts";
 
 export const getAuth = (db: DB) =>
   betterAuth({
+    baseURL: env.VITE_PUBLIC_URL,
+    trustedOrigins: [
+      env.VITE_PUBLIC_URL,
+      // This is needed for the stripe webhook to work in dev mode
+      ...(env.VITE_PUBLIC_URL.startsWith("http://localhost")
+        ? [`https://${env.ITERATE_USER}.dev.iterate.com`]
+        : []),
+    ],
     database: drizzleAdapter(db, {
       provider: "pg",
       schema,
@@ -26,7 +38,23 @@ export const getAuth = (db: DB) =>
     ...(import.meta.env.VITE_ENABLE_TEST_ADMIN_USER
       ? { emailAndPassword: { enabled: true } }
       : ({} as never)), // need to cast to never to make typescript think we can call APIs like `auth.api.createUser` - but this will fail at runtime if we try to use it in production
-    plugins: [admin(), integrationsPlugin()],
+    plugins: [
+      admin(),
+      integrationsPlugin(),
+      // We don't use any of the better auth stripe plugin's database schema or
+      // subscription / plan management features
+      // But it's handy just for the webhook handling and for creating a customer portal
+      // session etc
+      stripe({
+        stripeClient,
+        stripeWebhookSecret: env.STRIPE_WEBHOOK_SECRET,
+        // we do this manually in the user creation hook
+        createCustomerOnSignUp: false,
+        onEvent: async (event) => {
+          logger.debug("Stripe webhook received", event);
+        },
+      }),
+    ],
     socialProviders: {
       google: {
         scope: [
@@ -56,10 +84,16 @@ export const getAuth = (db: DB) =>
       user: {
         create: {
           after: async (user) => {
-            await createUserOrganizationAndEstate(db, user.id, user.name).catch((error) => {
-              logger.error(error);
-              logger.error("❌ Error creating organization and estate", user);
-            });
+            const organization = await createUserOrganizationAndEstate(db, user.id, user.name);
+
+            // Create Stripe customer and subscribe in the background (non-blocking)
+            waitUntil(
+              createStripeCustomerAndSubscriptionForOrganization(db, organization, user).catch(
+                () => {
+                  // Error is already logged in the helper function
+                },
+              ),
+            );
           },
         },
       },

--- a/apps/os/backend/auth/hooks.ts
+++ b/apps/os/backend/auth/hooks.ts
@@ -7,61 +7,67 @@ import { logger } from "../tag-logger.ts";
 import { sendNotificationToIterateSlack } from "../integrations/slack/slack-utils.ts";
 
 // Function to create organization and estate for new users
-export const createUserOrganizationAndEstate = async (db: DB, userId: string, userName: string) => {
+export const createUserOrganizationAndEstate = async (
+  db: DB,
+  userId: string,
+  userName: string,
+): Promise<typeof schema.organization.$inferSelect> => {
   const existingMembership = await db.query.organizationUserMembership.findFirst({
     where: (membership, { eq }) => eq(membership.userId, userId),
+    with: {
+      organization: true,
+    },
   });
 
   // Only create organization and estate for new users
-  if (!existingMembership) {
-    // Use a transaction to ensure atomicity
-    const result = await db.transaction(async (tx) => {
-      // Create organization
-      const organizationResult = await tx
-        .insert(schema.organization)
-        .values({
-          name: `${userName}'s Organization`,
-        })
-        .returning();
-
-      const organization = organizationResult[0];
-
-      if (!organization) {
-        throw new Error("Failed to create organization");
-      }
-
-      // Create organization membership for the user
-      await tx.insert(schema.organizationUserMembership).values({
-        organizationId: organization.id,
-        userId: userId,
-        role: "owner",
-      });
-
-      // Create estate
-      const [estate] = await tx
-        .insert(schema.estate)
-        .values({
-          name: `${userName}'s Estate`,
-          organizationId: organization.id,
-        })
-        .returning();
-
-      if (!estate) {
-        throw new Error("Failed to create estate");
-      }
-      return { organization, estate };
-    });
-
-    // Send Slack notification to our own slack instance
-    // In production ITERATE_NOTIFICATION_ESTATE_ID is set to iterate's own iterate estate id
-    if (env.ITERATE_NOTIFICATION_ESTATE_ID) {
-      waitUntil(
-        sendEstateCreatedNotificationToSlack(result.organization, result.estate).catch((error) => {
-          logger.error("Failed to send Slack notification for new estate", error);
-        }),
-      );
-    }
+  if (existingMembership) {
+    return existingMembership.organization;
   }
+
+  // Perform sequential inserts without opening a new transaction to avoid
+  // cross-transaction FK visibility issues with the user record.
+  // If the auth layer wraps this in a transaction, these operations will be part of it.
+  const organizationResult = await db
+    .insert(schema.organization)
+    .values({ name: `${userName}'s Organization` })
+    .returning();
+
+  const organization = organizationResult[0];
+
+  if (!organization) {
+    throw new Error("Failed to create organization");
+  }
+
+  await db.insert(schema.organizationUserMembership).values({
+    organizationId: organization.id,
+    userId: userId,
+    role: "owner",
+  });
+
+  const [estate] = await db
+    .insert(schema.estate)
+    .values({
+      name: `${userName}'s Estate`,
+      organizationId: organization.id,
+    })
+    .returning();
+
+  if (!estate) {
+    throw new Error("Failed to create estate");
+  }
+
+  const result = { organization, estate };
+
+  // Send Slack notification to our own slack instance
+  // In production ITERATE_NOTIFICATION_ESTATE_ID is set to iterate's own iterate estate id
+  if (env.ITERATE_NOTIFICATION_ESTATE_ID) {
+    waitUntil(
+      sendEstateCreatedNotificationToSlack(result.organization, result.estate).catch((error) => {
+        logger.error("Failed to send Slack notification for new estate", error);
+      }),
+    );
+  }
+  return result.organization;
 };
 
 async function sendEstateCreatedNotificationToSlack(

--- a/apps/os/backend/db/migrations/0015_modern_the_watchers.sql
+++ b/apps/os/backend/db/migrations/0015_modern_the_watchers.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "session" DROP CONSTRAINT "session_impersonated_by_user_id_fk";
+--> statement-breakpoint
+ALTER TABLE "organization" ADD COLUMN "stripe_customer_id" text;--> statement-breakpoint
+ALTER TABLE "session" ADD CONSTRAINT "session_impersonated_by_user_id_fk" FOREIGN KEY ("impersonated_by") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/os/backend/db/migrations/meta/0015_snapshot.json
+++ b/apps/os/backend/db/migrations/meta/0015_snapshot.json
@@ -1,0 +1,1729 @@
+{
+  "id": "4da91cc2-a621-4ecd-ac09-ac9883cabf1b",
+  "prevId": "3f65fd7d-f7d0-4f86-99d2-0ae4499f2794",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_instance": {
+      "name": "agent_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "estate_id": {
+          "name": "estate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_name": {
+          "name": "class_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durable_object_name": {
+          "name": "durable_object_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durable_object_id": {
+          "name": "durable_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_instance_durable_object_name_index": {
+          "name": "agent_instance_durable_object_name_index",
+          "columns": [
+            {
+              "expression": "durable_object_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_instance_durable_object_id_index": {
+          "name": "agent_instance_durable_object_id_index",
+          "columns": [
+            {
+              "expression": "durable_object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_instance_estate_id_index": {
+          "name": "agent_instance_estate_id_index",
+          "columns": [
+            {
+              "expression": "estate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_instance_class_name_index": {
+          "name": "agent_instance_class_name_index",
+          "columns": [
+            {
+              "expression": "class_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_instance_estate_id_estate_id_fk": {
+          "name": "agent_instance_estate_id_estate_id_fk",
+          "tableFrom": "agent_instance",
+          "tableTo": "estate",
+          "columnsFrom": [
+            "estate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_instance_route": {
+      "name": "agent_instance_route",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "routing_key": {
+          "name": "routing_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_instance_id": {
+          "name": "agent_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_instance_route_routing_key_agent_instance_id_index": {
+          "name": "agent_instance_route_routing_key_agent_instance_id_index",
+          "columns": [
+            {
+              "expression": "routing_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_instance_route_agent_instance_id_agent_instance_id_fk": {
+          "name": "agent_instance_route_agent_instance_id_agent_instance_id_fk",
+          "tableFrom": "agent_instance_route",
+          "tableTo": "agent_instance",
+          "columnsFrom": [
+            "agent_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.builds": {
+      "name": "builds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_message": {
+          "name": "commit_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iterate_workflow_run_id": {
+          "name": "iterate_workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_iterate_id": {
+          "name": "webhook_iterate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estate_id": {
+          "name": "estate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "builds_estate_id_estate_id_fk": {
+          "name": "builds_estate_id_estate_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "estate",
+          "columnsFrom": [
+            "estate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dynamic_client_info": {
+      "name": "dynamic_client_info",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_info": {
+          "name": "client_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dynamic_client_info_provider_id_user_id_index": {
+          "name": "dynamic_client_info_provider_id_user_id_index",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dynamic_client_info_user_id_user_id_fk": {
+          "name": "dynamic_client_info_user_id_user_id_fk",
+          "tableFrom": "dynamic_client_info",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.estate": {
+      "name": "estate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_repo_id": {
+          "name": "connected_repo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_repo_ref": {
+          "name": "connected_repo_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_repo_path": {
+          "name": "connected_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "estate_organization_id_organization_id_fk": {
+          "name": "estate_organization_id_organization_id_fk",
+          "tableFrom": "estate",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.estate_accounts_permissions": {
+      "name": "estate_accounts_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "estate_id": {
+          "name": "estate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "estate_accounts_permissions_estate_id_account_id_index": {
+          "name": "estate_accounts_permissions_estate_id_account_id_index",
+          "columns": [
+            {
+              "expression": "estate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "estate_accounts_permissions_estate_id_estate_id_fk": {
+          "name": "estate_accounts_permissions_estate_id_estate_id_fk",
+          "tableFrom": "estate_accounts_permissions",
+          "tableTo": "estate",
+          "columnsFrom": [
+            "estate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "estate_accounts_permissions_account_id_account_id_fk": {
+          "name": "estate_accounts_permissions_account_id_account_id_fk",
+          "tableFrom": "estate_accounts_permissions",
+          "tableTo": "account",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'started'"
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_ai_file_id": {
+          "name": "open_ai_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estate_id": {
+          "name": "estate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "files_estate_id_estate_id_fk": {
+          "name": "files_estate_id_estate_id_fk",
+          "tableFrom": "files",
+          "tableTo": "estate",
+          "columnsFrom": [
+            "estate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.iterate_config": {
+      "name": "iterate_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estate_id": {
+          "name": "estate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "iterate_config_estate_id_index": {
+          "name": "iterate_config_estate_id_index",
+          "columns": [
+            {
+              "expression": "estate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "iterate_config_estate_id_estate_id_fk": {
+          "name": "iterate_config_estate_id_estate_id_fk",
+          "tableFrom": "iterate_config",
+          "tableTo": "estate",
+          "columnsFrom": [
+            "estate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_connection_param": {
+      "name": "mcp_connection_param",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_key": {
+          "name": "connection_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estate_id": {
+          "name": "estate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "param_key": {
+          "name": "param_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "param_value": {
+          "name": "param_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "param_type": {
+          "name": "param_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_connection_param_estate_id_connection_key_param_key_param_type_index": {
+          "name": "mcp_connection_param_estate_id_connection_key_param_key_param_type_index",
+          "columns": [
+            {
+              "expression": "estate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "param_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "param_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_connection_param_estate_id_index": {
+          "name": "mcp_connection_param_estate_id_index",
+          "columns": [
+            {
+              "expression": "estate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_connection_param_connection_key_index": {
+          "name": "mcp_connection_param_connection_key_index",
+          "columns": [
+            {
+              "expression": "connection_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_connection_param_estate_id_estate_id_fk": {
+          "name": "mcp_connection_param_estate_id_estate_id_fk",
+          "tableFrom": "mcp_connection_param",
+          "tableTo": "estate",
+          "columnsFrom": [
+            "estate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_user_membership": {
+      "name": "organization_user_membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_user_membership_user_id_organization_id_index": {
+          "name": "organization_user_membership_user_id_organization_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_user_membership_organization_id_organization_id_fk": {
+          "name": "organization_user_membership_organization_id_organization_id_fk",
+          "tableFrom": "organization_user_membership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_user_membership_user_id_user_id_fk": {
+          "name": "organization_user_membership_user_id_user_id_fk",
+          "tableFrom": "organization_user_membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_estate_mapping": {
+      "name": "provider_estate_mapping",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_estate_id": {
+          "name": "internal_estate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_estate_mapping_provider_id_external_id_index": {
+          "name": "provider_estate_mapping_provider_id_external_id_index",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_estate_mapping_internal_estate_id_estate_id_fk": {
+          "name": "provider_estate_mapping_internal_estate_id_estate_id_fk",
+          "tableFrom": "provider_estate_mapping",
+          "tableTo": "estate",
+          "columnsFrom": [
+            "internal_estate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_user_mapping": {
+      "name": "provider_user_mapping",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_user_id": {
+          "name": "internal_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_user_mapping_provider_id_external_id_index": {
+          "name": "provider_user_mapping_provider_id_external_id_index",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_user_mapping_internal_user_id_user_id_fk": {
+          "name": "provider_user_mapping_internal_user_id_user_id_fk",
+          "tableFrom": "provider_user_mapping",
+          "tableTo": "user",
+          "columnsFrom": [
+            "internal_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_impersonated_by_user_id_fk": {
+          "name": "session_impersonated_by_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "impersonated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_webhook_event": {
+      "name": "slack_webhook_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_ts": {
+          "name": "thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtype": {
+          "name": "subtype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user": {
+          "name": "user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estate_id": {
+          "name": "estate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_or_thread_messages": {
+          "name": "channel_or_thread_messages",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_webhook_event_estate_id_index": {
+          "name": "slack_webhook_event_estate_id_index",
+          "columns": [
+            {
+              "expression": "estate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_webhook_event_estate_id_estate_id_fk": {
+          "name": "slack_webhook_event_estate_id_estate_id_fk",
+          "tableFrom": "slack_webhook_event",
+          "tableTo": "estate",
+          "columnsFrom": [
+            "estate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/os/backend/db/migrations/meta/_journal.json
+++ b/apps/os/backend/db/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1759420792283,
       "tag": "0014_natural_ricochet",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1759526372429,
+      "tag": "0015_modern_the_watchers",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/os/backend/db/schema.ts
+++ b/apps/os/backend/db/schema.ts
@@ -164,6 +164,7 @@ export const estateRelations = relations(estate, ({ one, many }) => ({
 export const organization = pgTable("organization", (t) => ({
   id: iterateId("org"),
   name: t.text().notNull(),
+  stripeCustomerId: t.text(),
   ...withTimestamps,
 }));
 export const organizationRelations = relations(organization, ({ many }) => ({

--- a/apps/os/backend/integrations/slack/slack.ts
+++ b/apps/os/backend/integrations/slack/slack.ts
@@ -222,7 +222,7 @@ export async function reactToSlackWebhook(
             name: "eyes",
           })
           .then(
-            () => logger.log("[SlackAgent] Added eyes reaction"),
+            () => logger.info("[SlackAgent] Added eyes reaction"),
             (error) => logger.error("[SlackAgent] Failed to add eyes reaction", error),
           );
       }
@@ -246,7 +246,7 @@ export async function syncSlackUsersInBackground(db: DB, botToken: string, estat
     );
 
     if (validMembers.length === 0) {
-      logger.log("No valid Slack members to sync");
+      logger.info("No valid Slack members to sync");
       return;
     }
 
@@ -318,7 +318,7 @@ export async function syncSlackUsersInBackground(db: DB, botToken: string, estat
         });
       }
 
-      logger.log(`Upserting ${mappingsToUpsert.length} provider mappings`);
+      logger.info(`Upserting ${mappingsToUpsert.length} provider mappings`);
 
       if (mappingsToUpsert.length > 0) {
         await tx
@@ -333,7 +333,7 @@ export async function syncSlackUsersInBackground(db: DB, botToken: string, estat
       }
 
       // Step 4: Upsert organization memberships
-      logger.log(`Upserting ${organizationMembershipsToUpsert.length} organization memberships`);
+      logger.info(`Upserting ${organizationMembershipsToUpsert.length} organization memberships`);
 
       if (organizationMembershipsToUpsert.length > 0) {
         await tx

--- a/apps/os/backend/integrations/stripe/stripe.ts
+++ b/apps/os/backend/integrations/stripe/stripe.ts
@@ -1,0 +1,309 @@
+import Stripe from "stripe";
+import { eq } from "drizzle-orm";
+import type { DB } from "../../db/client.ts";
+import * as schema from "../../db/schema.ts";
+import { env } from "../../../env.ts";
+import { logger } from "../../tag-logger.ts";
+
+export const stripeClient = new Stripe(env.STRIPE_SECRET_KEY, {
+  apiVersion: "2025-09-30.clover",
+});
+
+const V2_STRIPE_VERSION = "2025-09-30.preview";
+
+type Organization = {
+  id: string;
+  name: string;
+};
+
+type User = {
+  id: string;
+  name: string;
+  email: string;
+};
+
+type StripeV2Method = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+
+/**
+ * Makes a JSON request to the Stripe v2 API
+ */
+async function stripeV2JSON<T = unknown>(
+  method: StripeV2Method,
+  path: string,
+  payload?: unknown,
+): Promise<T> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${env.STRIPE_SECRET_KEY}`,
+    "Stripe-Version": V2_STRIPE_VERSION,
+  };
+
+  const init: RequestInit = { method, headers };
+
+  if (payload !== undefined && method !== "GET") {
+    headers["Content-Type"] = "application/json";
+    init.body = JSON.stringify(payload);
+  }
+
+  const response = await fetch(`https://api.stripe.com${path}`, init);
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Stripe API error: ${response.status} ${response.statusText} - ${body}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+/**
+ * Creates a Stripe customer for the organization
+ */
+export async function createStripeCustomer(organization: Organization, user: User) {
+  const customer = await stripeClient.customers.create({
+    email: user.email,
+    name: organization.name,
+    description: `Owned by ${user.name} <${user.email}>`,
+    metadata: {
+      userId: user.id,
+      organizationId: organization.id,
+    },
+  });
+
+  logger.info("Stripe customer created", customer);
+  return customer;
+}
+
+type CadenceInterval = "month" | "year";
+
+/**
+ * Subscribes a customer to a pricing plan with the given cadence
+ * Based on Stripe's Billing v2 API
+ * And specifically this ruby script in #ext-stripe
+ * https://iterate-com.slack.com/archives/C09J7C445A9/p1759503324919989
+ */
+export async function subscribeCustomerToPricingPlan(
+  customerId: string,
+  pricingPlanId: string,
+  cadenceInterval: CadenceInterval = "month",
+) {
+  logger.info("Starting subscription flow", { customerId, pricingPlanId, cadenceInterval });
+
+  // 1) Resolve pricing plan version
+  const plan = await stripeV2JSON<{ latest_version: string }>(
+    "GET",
+    `/v2/billing/pricing_plans/${pricingPlanId}`,
+  );
+  const planVersion = plan.latest_version;
+
+  if (!planVersion) {
+    throw new Error("Could not determine pricing_plan_version");
+  }
+
+  logger.info("Resolved pricing plan", { id: pricingPlanId, version: planVersion });
+
+  // 2) Resolve payment method (optional)
+  const paymentMethods = await stripeClient.customers.listPaymentMethods(customerId);
+  const paymentMethod = paymentMethods.data[0];
+
+  // 3) Create Billing Profile
+  const billingProfilePayload: { customer: string; default_payment_method?: string } = {
+    customer: customerId,
+  };
+
+  if (paymentMethod) {
+    billingProfilePayload.default_payment_method = paymentMethod.id;
+  }
+
+  const billingProfile = await stripeV2JSON<{ id: string }>(
+    "POST",
+    "/v2/billing/profiles",
+    billingProfilePayload,
+  );
+  logger.info("Created billing profile", billingProfile);
+
+  // 4) Create Cadence
+  const today = new Date();
+  const dayOfMonth = today.getDate();
+
+  const cadenceBillingCycle =
+    cadenceInterval === "month"
+      ? {
+          type: "month",
+          interval_count: 1,
+          month: { day_of_month: dayOfMonth, time: { hour: 0, minute: 0, second: 0 } },
+        }
+      : {
+          type: "year",
+          interval_count: 1,
+          year: {
+            month_of_year: today.getMonth() + 1, // JS months are 0-indexed
+            day_of_month: dayOfMonth,
+            time: { hour: 0, minute: 0, second: 0 },
+          },
+        };
+
+  const cadence = await stripeV2JSON<{ id: string }>("POST", "/v2/billing/cadences", {
+    payer: {
+      billing_profile: billingProfile.id,
+    },
+    billing_cycle: cadenceBillingCycle,
+  });
+  logger.info("Created cadence", cadence);
+
+  // 5) Create Billing Intent with subscribe action
+  const billingIntent = await stripeV2JSON<{ id: string }>("POST", "/v2/billing/intents", {
+    cadence: cadence.id,
+    currency: "usd",
+    actions: [
+      {
+        type: "subscribe",
+        subscribe: {
+          type: "pricing_plan_subscription_details",
+          billing_details: {
+            proration_behavior: "no_adjustment",
+          },
+          effective_at: {
+            type: "current_billing_period_start",
+          },
+          pricing_plan_subscription_details: {
+            pricing_plan: pricingPlanId,
+            pricing_plan_version: planVersion,
+            component_configurations: [],
+          },
+        },
+      },
+    ],
+  });
+  logger.info("Created billing intent", billingIntent);
+
+  // 6) Reserve the billing intent
+  const reserved = await stripeV2JSON<{ amount_details: { total: number } }>(
+    "POST",
+    `/v2/billing/intents/${billingIntent.id}/reserve`,
+    {},
+  );
+  logger.info("Reserved billing intent", reserved);
+
+  let committed;
+
+  // If there's a payment method, create and confirm a payment intent
+  // Otherwise, the customer will receive an invoice via email
+  if (paymentMethod) {
+    // 7) Create a payment intent
+    const paymentIntent = await stripeClient.paymentIntents.create({
+      amount: reserved.amount_details.total,
+      currency: "usd",
+      customer: customerId,
+      payment_method: paymentMethod.id,
+    });
+    logger.info("Created payment intent", paymentIntent);
+
+    // 8) Confirm the payment intent
+    const confirmedPaymentIntent = await stripeClient.paymentIntents.confirm(paymentIntent.id, {
+      return_url: env.VITE_PUBLIC_URL,
+    });
+    logger.info("Confirmed payment intent", confirmedPaymentIntent);
+
+    // 9) Commit the billing intent
+    committed = await stripeV2JSON("POST", `/v2/billing/intents/${billingIntent.id}/commit`, {
+      payment_intent: confirmedPaymentIntent.id,
+    });
+  } else {
+    // 9) Commit the billing intent without payment (will send invoice)
+    committed = await stripeV2JSON("POST", `/v2/billing/intents/${billingIntent.id}/commit`, {});
+  }
+
+  logger.info("Committed billing intent", committed);
+
+  return {
+    pricingPlan: {
+      id: pricingPlanId,
+      version: planVersion,
+    },
+    cadence,
+    billingIntent,
+    reserved,
+    committed,
+  };
+}
+
+/**
+ * Creates a Stripe customer for the organization and subscribes them to the pricing plan.
+ * Also updates the organization record with the Stripe customer ID.
+ * This is the complete flow used when a new organization is created.
+ */
+export async function createStripeCustomerAndSubscriptionForOrganization(
+  db: DB,
+  organization: Organization,
+  user: User,
+) {
+  try {
+    // Create the customer first
+    const customer = await createStripeCustomer(organization, user);
+
+    // Immediately save the customer ID to the database
+    await db
+      .update(schema.organization)
+      .set({
+        stripeCustomerId: customer.id,
+      })
+      .where(eq(schema.organization.id, organization.id));
+
+    // Then subscribe the customer to the pricing plan
+    await subscribeCustomerToPricingPlan(customer.id, env.STRIPE_PRICING_PLAN_ID, "month");
+
+    return customer;
+  } catch (error) {
+    logger.error("Failed to create Stripe customer and subscription", error);
+    throw error;
+  }
+}
+
+/**
+ * Track token usage with Stripe meter events
+ */
+export async function trackTokenUsageInStripe(params: {
+  stripeCustomerId: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+}): Promise<void> {
+  const { stripeCustomerId, model, inputTokens, outputTokens } = params;
+
+  const inputPayload = {
+    event_name: "token-billing-tokens",
+    payload: {
+      stripe_customer_id: stripeCustomerId,
+      model: `openai/${model}`,
+      token_type: "input",
+      value: `${inputTokens}`,
+    },
+  };
+
+  const outputPayload = {
+    event_name: "token-billing-tokens",
+    payload: {
+      stripe_customer_id: stripeCustomerId,
+      model: `openai/${model}`,
+      token_type: "output",
+      value: `${outputTokens}`,
+    },
+  };
+
+  const payloads = [inputPayload, outputPayload];
+
+  const results = await Promise.allSettled([
+    stripeV2JSON("POST", "/v2/billing/meter_events", inputPayload),
+    stripeV2JSON("POST", "/v2/billing/meter_events", outputPayload),
+  ]);
+
+  results.forEach((result, index) => {
+    if (result.status === "fulfilled") {
+      logger.info("Stripe meter event success");
+    } else {
+      logger.error("Stripe meter event failed", {
+        error: result.reason,
+        payload: payloads[index],
+      });
+    }
+  });
+}

--- a/apps/os/backend/integrations/stripe/trpc-procedures.ts
+++ b/apps/os/backend/integrations/stripe/trpc-procedures.ts
@@ -1,0 +1,57 @@
+import { z } from "zod/v4";
+import { eq } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { protectedProcedure, router } from "../../trpc/trpc.ts";
+import { schema } from "../../db/client.ts";
+import { env } from "../../../env.ts";
+import { stripeClient } from "./stripe.ts";
+
+export const stripeRouter = router({
+  createBillingPortalSession: protectedProcedure
+    .input(
+      z.object({
+        organizationId: z.string(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      // Verify the user is a member of this organization and get the organization in one query
+      const organization = await ctx.db.query.organization.findFirst({
+        where: eq(schema.organization.id, input.organizationId),
+        with: {
+          members: {
+            where: eq(schema.organizationUserMembership.userId, ctx.user.id),
+          },
+        },
+      });
+
+      if (!organization) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `Organization ${input.organizationId} not found`,
+        });
+      }
+
+      if (!organization.members || organization.members.length === 0) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: `User ${ctx.user.id} does not have access to this organization ${input.organizationId}`,
+        });
+      }
+
+      if (!organization.stripeCustomerId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Organization ${input.organizationId} does not have a Stripe customer ID`,
+        });
+      }
+
+      const session = await stripeClient.billingPortal.sessions.create({
+        customer: organization.stripeCustomerId,
+        return_url: `${env.VITE_PUBLIC_URL}/${input.organizationId}`,
+      });
+
+      return {
+        url: session.url,
+      };
+    }),
+});

--- a/apps/os/backend/trpc/root.ts
+++ b/apps/os/backend/trpc/root.ts
@@ -1,4 +1,5 @@
 import { agentsRouter } from "../agent/agents-router.ts";
+import { stripeRouter } from "../integrations/stripe/trpc-procedures.ts";
 import { router } from "./trpc.ts";
 import { integrationsRouter } from "./routers/integrations.ts";
 import { estateRouter } from "./routers/estate.ts";
@@ -6,6 +7,7 @@ import { estatesRouter } from "./routers/estates.ts";
 import { userRouter } from "./routers/user.ts";
 import { testingRouter } from "./routers/testing.ts";
 import { adminRouter } from "./routers/admin.ts";
+import { organizationRouter } from "./routers/organization.ts";
 
 export const appRouter = router({
   integrations: integrationsRouter,
@@ -15,6 +17,8 @@ export const appRouter = router({
   user: userRouter,
   admin: adminRouter,
   testing: testingRouter,
+  stripe: stripeRouter,
+  organization: organizationRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/os/backend/trpc/routers/organization.ts
+++ b/apps/os/backend/trpc/routers/organization.ts
@@ -1,0 +1,186 @@
+import { z } from "zod/v4";
+import { eq } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { waitUntil } from "cloudflare:workers";
+import { protectedProcedure, router, orgProtectedProcedure, orgAdminProcedure } from "../trpc.ts";
+import { schema } from "../../db/client.ts";
+import { createStripeCustomerAndSubscriptionForOrganization } from "../../integrations/stripe/stripe.ts";
+
+export const organizationRouter = router({
+  // List all organizations the user has access to
+  list: protectedProcedure.query(async ({ ctx }) => {
+    const userOrganizations = await ctx.db.query.organizationUserMembership.findMany({
+      where: eq(schema.organizationUserMembership.userId, ctx.user.id),
+      with: {
+        organization: true,
+      },
+    });
+
+    return userOrganizations.map(({ organization, role }) => ({
+      id: organization.id,
+      name: organization.name,
+      role,
+      stripeCustomerId: organization.stripeCustomerId,
+      createdAt: organization.createdAt,
+      updatedAt: organization.updatedAt,
+    }));
+  }),
+
+  // Create a new organization
+  create: protectedProcedure
+    .input(
+      z.object({
+        name: z.string().min(1, "Organization name is required"),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      // Create the organization
+      const [organization] = await ctx.db
+        .insert(schema.organization)
+        .values({ name: input.name })
+        .returning();
+
+      if (!organization) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to create organization",
+        });
+      }
+
+      // Make the current user the owner
+      await ctx.db.insert(schema.organizationUserMembership).values({
+        organizationId: organization.id,
+        userId: ctx.user.id,
+        role: "owner",
+      });
+
+      // Create a default estate for this organization
+      const [estate] = await ctx.db
+        .insert(schema.estate)
+        .values({
+          name: `${input.name} Estate`,
+          organizationId: organization.id,
+        })
+        .returning();
+
+      if (!estate) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to create default estate",
+        });
+      }
+
+      // Create Stripe customer and subscribe in the background (non-blocking)
+      waitUntil(
+        createStripeCustomerAndSubscriptionForOrganization(ctx.db, organization, ctx.user).catch(
+          () => {
+            // Error is already logged in the helper function
+          },
+        ),
+      );
+
+      return {
+        organization,
+        estate,
+      };
+    }),
+
+  // Get organization by ID
+  get: orgProtectedProcedure.query(async ({ ctx }) => {
+    return ctx.organization;
+  }),
+
+  // Update organization name
+  updateName: orgAdminProcedure
+    .input(
+      z.object({
+        name: z.string().min(1, "Organization name is required"),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const [updatedOrganization] = await ctx.db
+        .update(schema.organization)
+        .set({ name: input.name })
+        .where(eq(schema.organization.id, ctx.organization.id))
+        .returning();
+
+      if (!updatedOrganization) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to update organization",
+        });
+      }
+
+      return updatedOrganization;
+    }),
+
+  // List all members of an organization
+  listMembers: orgProtectedProcedure.query(async ({ ctx }) => {
+    const members = await ctx.db.query.organizationUserMembership.findMany({
+      where: eq(schema.organizationUserMembership.organizationId, ctx.organization.id),
+      with: {
+        user: true,
+      },
+    });
+
+    return members.map((m) => ({
+      id: m.id,
+      userId: m.user.id,
+      name: m.user.name,
+      email: m.user.email,
+      image: m.user.image,
+      role: m.role,
+      createdAt: m.createdAt,
+    }));
+  }),
+
+  // Update a member's role
+  updateMemberRole: orgAdminProcedure
+    .input(
+      z.object({
+        userId: z.string(),
+        role: z.enum(["member", "admin", "owner", "guest"]),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      // Prevent users from changing their own role
+      if (input.userId === ctx.user.id) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "You cannot change your own role",
+        });
+      }
+
+      // Get the membership to update
+      const membershipToUpdate = await ctx.db.query.organizationUserMembership.findFirst({
+        where: (membership, { and, eq }) =>
+          and(
+            eq(membership.organizationId, ctx.organization.id),
+            eq(membership.userId, input.userId),
+          ),
+      });
+
+      if (!membershipToUpdate) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Member not found in this organization",
+        });
+      }
+
+      // Update the member's role
+      const [updatedMembership] = await ctx.db
+        .update(schema.organizationUserMembership)
+        .set({ role: input.role })
+        .where(eq(schema.organizationUserMembership.id, membershipToUpdate.id))
+        .returning();
+
+      if (!updatedMembership) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to update member role",
+        });
+      }
+
+      return updatedMembership;
+    }),
+});

--- a/apps/os/backend/worker.ts
+++ b/apps/os/backend/worker.ts
@@ -7,6 +7,7 @@ import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import { WorkerEntrypoint, waitUntil } from "cloudflare:workers";
 import { PostHog } from "posthog-node";
+import { cors } from "hono/cors";
 import type { CloudflareEnv } from "../env.ts";
 import { getDb, type DB } from "./db/client.ts";
 import { uploadFileHandler, uploadFileFromURLHandler, getFileHandler } from "./file-handlers.ts";
@@ -39,7 +40,16 @@ export type Variables = {
 };
 
 const app = new Hono<{ Bindings: CloudflareEnv; Variables: Variables }>();
+app.use("*", cors({ origin: (c) => c }));
 app.use(contextStorage());
+
+app.use(
+  "*",
+  cors({
+    credentials: true,
+    origin: (c) => c,
+  }),
+);
 
 // Error tracking with PostHog
 app.onError((err, c) => {

--- a/apps/os/env.ts
+++ b/apps/os/env.ts
@@ -25,6 +25,9 @@ export type CloudflareEnv = Env & {
   REPLICATE_API_TOKEN: string;
   ITERATE_USER: string;
   ITERATE_NOTIFICATION_ESTATE_ID?: string;
+  STRIPE_SECRET_KEY: string;
+  STRIPE_WEBHOOK_SECRET: string;
+  STRIPE_PRICING_PLAN_ID: string;
 };
 
 export const env = _env as CloudflareEnv;

--- a/apps/os/package.json
+++ b/apps/os/package.json
@@ -20,6 +20,7 @@
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
+    "@better-auth/stripe": "^1.3.25",
     "@cfworker/json-schema": "^4.1.1",
     "@clack/prompts": "^0.11.0",
     "@cloudflare/sandbox": "^0.3.2",
@@ -80,6 +81,7 @@
     "replicate": "^1.2.0",
     "sonner": "^2.0.7",
     "streamdown": "^1.3.0",
+    "stripe": "^19.0.0",
     "superjson": "^2.2.2",
     "tailwind-merge": "^3.3.1",
     "tiny-invariant": "^1.3.3",

--- a/estates/iterate/apps/website/backend/components/SiteHeader.tsx
+++ b/estates/iterate/apps/website/backend/components/SiteHeader.tsx
@@ -12,15 +12,17 @@ export default function SiteHeader() {
           </div>
           <div className="flex items-center gap-4">
             <Navigation />
-            <a
-              href="https://github.com/iterate-com/iterate"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-gray-600 hover:text-gray-900 transition-colors"
-              aria-label="View source on GitHub"
-            >
-              <GitHubIcon size={20} />
-            </a>
+            <div className="flex items-center gap-2">
+              <a
+                href="https://github.com/iterate-com/iterate"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-gray-600 hover:text-gray-900 transition-colors"
+                aria-label="View source on GitHub"
+              >
+                <GitHubIcon size={20} />
+              </a>
+            </div>
           </div>
         </nav>
       </div>

--- a/estates/iterate/apps/website/backend/routes/index.tsx
+++ b/estates/iterate/apps/website/backend/routes/index.tsx
@@ -88,6 +88,29 @@ export default function Home() {
           </div>
         </div>
 
+        {/* Pricing section */}
+        <section className="mt-20 mb-20" id="pricing">
+          <h2 className="text-2xl font-bold mb-8">Super simple pricing</h2>
+          <div className="max-w-3xl">
+            <div className="border border-black p-8 bg-white">
+              <div className="text-3xl font-bold mb-6">Raw token cost + 50%</div>
+              <div className="space-y-4 text-gray-700">
+                <p className="text-lg">
+                  <strong>$50 free usage per month</strong> during beta
+                </p>
+                <p>Charged at the end of each month. No surprises, no hidden fees.</p>
+                <div className="mt-6 pt-6 border-t border-gray-200">
+                  <p className="text-sm text-gray-600">
+                    <strong>Why we think this is fair:</strong> You can see all the tokens and
+                    traces yourself. You have full control over the system prompt, so if you think
+                    we're not being economical with tokens, you can customize it however you like.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
         <section className="mt-2 sm:mt-4 mb-20">
           <h2 className="text-2xl font-bold mb-8">How I work</h2>
           <div className="prose text-gray-700">
@@ -101,8 +124,26 @@ export default function Home() {
                 Linear, Notion, and more.
               </li>
               <li>
-                <strong>Fine-tune my behaviour:</strong> Customise me using natural language, just
-                add rules/*.md in a git repo you control.
+                <strong>Cursor rules for the entire company:</strong> Add rules and tools in your
+                own GitHub repository (see our{" "}
+                <a
+                  href="https://github.com/iterate-com/estate-template"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-gray-900"
+                >
+                  template repo
+                </a>{" "}
+                or{" "}
+                <a
+                  href="https://github.com/iterate-com/iterate/tree/main/estates/iterate"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-gray-900"
+                >
+                  iterate's own iterate repo
+                </a>
+                ).
               </li>
             </ul>
           </div>
@@ -133,56 +174,6 @@ export default function Home() {
             </ul>
           </div>
         </section>
-
-        {/* Pricing (commented out)
-<section className="mb-24" id="pricing">
-  <h2 className="text-2xl font-bold mb-8">Pricing</h2>
-  <div className="brutal-card brutal-dots p-6 w-full">
-      <div className="text-3xl font-semibold mb-4">$100/month + API cost</div>
-      <div className="mb-6 text-gray-700">
-        <p className="font-semibold mb-3">One plan. Everything included:</p>
-        <ul className="space-y-2 text-gray-600">
-          <li className="flex items-start">
-            <span className="mr-2">•</span>
-            <span>System prompts, rules and context fully customisable in your own git repo</span>
-          </li>
-          <li className="flex items-start">
-            <span className="mr-2">•</span>
-            <span>Free bespoke installation and setup with the former co-founder of Monzo</span>
-          </li>
-          <li className="flex items-start">
-            <span className="mr-2">•</span>
-            <span>Extend with your own MCP servers</span>
-          </li>
-        </ul>
-      </div>
-      <div className="flex items-center gap-3 sm:gap-5">
-        <Button 
-          className="w-64" 
-          size="lg"
-          onClick={() => setIsCalendarOpen(true)}
-        >
-          <span>Free installation</span>
-          <span className="hidden sm:flex items-center gap-2 ml-3">
-            <kbd className="keycap keycap-invert" data-key="cmd">⌘</kbd>
-            <kbd className="keycap keycap-invert" data-key="k">K</kbd>
-          </span>
-        </Button>
-        Easter egg Add to Slack button:
-        {showSlackButton && (
-          <Button 
-            variant="ghost"
-            size="sm"
-            className="text-xs text-gray-500 hover:text-gray-700"
-            onClick={() => window.location.href = 'https://bios.iterate.iterate.com/claim'}
-          >
-            Add to Slack (beta)
-          </Button>
-        )}
-      </div>
-  </div>
-</section>
-        */}
 
         {/* Team section */}
         <div className="mb-20">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
 
   apps/os:
     dependencies:
+      '@better-auth/stripe':
+        specifier: ^1.3.25
+        version: 1.3.25(better-auth@1.3.11(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(stripe@19.0.0(@types/node@24.4.0))
       '@cfworker/json-schema':
         specifier: ^4.1.1
         version: 4.1.1
@@ -243,6 +246,9 @@ importers:
       streamdown:
         specifier: ^1.3.0
         version: 1.3.0(@types/react@19.1.13)(react@19.1.1)
+      stripe:
+        specifier: ^19.0.0
+        version: 19.0.0(@types/node@24.4.0)
       superjson:
         specifier: ^2.2.2
         version: 2.2.2
@@ -686,6 +692,12 @@ packages:
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@better-auth/stripe@1.3.25':
+    resolution: {integrity: sha512-bEN8/6fMhrCHbn27FDlBaZNg/9IevxOeYuSsqKTCUZ9sQeLyrlVEMaz1PLEl07UYv/9PG6WkRlUKbrbZ+JaqpQ==}
+    peerDependencies:
+      better-auth: 1.3.25
+      stripe: ^18
 
   '@better-auth/utils@0.3.0':
     resolution: {integrity: sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==}
@@ -7553,6 +7565,15 @@ packages:
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
 
+  stripe@19.0.0:
+    resolution: {integrity: sha512-4HG17r7mui4Awic75DVSFVmH4EIXqNvoo3T2cYrVhcwovQz3gzQIPUiqzLzGcgxdUd9CB8zCntKzm0o63tUBgw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@types/node': '>=16'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   strtok3@9.1.1:
     resolution: {integrity: sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw==}
     engines: {node: '>=16'}
@@ -8592,6 +8613,13 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@better-auth/stripe@1.3.25(better-auth@1.3.11(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(stripe@19.0.0(@types/node@24.4.0))':
+    dependencies:
+      better-auth: 1.3.11(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      defu: 6.1.4
+      stripe: 19.0.0(@types/node@24.4.0)
+      zod: 4.1.11
 
   '@better-auth/utils@0.3.0': {}
 
@@ -16399,6 +16427,12 @@ snapshots:
   strip-literal@3.0.0:
     dependencies:
       js-tokens: 9.0.1
+
+  stripe@19.0.0(@types/node@24.4.0):
+    dependencies:
+      qs: 6.14.0
+    optionalDependencies:
+      '@types/node': 24.4.0
 
   strtok3@9.1.1:
     dependencies:

--- a/vibe-rules/llms.ts
+++ b/vibe-rules/llms.ts
@@ -368,6 +368,7 @@ import { env, type CloudflareEnv } from "../env.ts";
     rule: dedent`
       - In general, logs in production are not looked at, so don't add them unless we specifically need them for debugging something.
       - Do not use the \`console\` object, use the \`logger\` object from \`apps/os/backend/tag-logger.ts\`.
+      - Use logger.info instead of logger.log
     `,
     globs: ["apps/os/backend/**/*.ts"],
     eslint: {
@@ -396,6 +397,17 @@ import { env, type CloudflareEnv } from "../env.ts";
       The source of truth for all rules is \`vibe-rules/llms.ts\`. When you need to update rules, edit that file.
     `,
     alwaysApply: true,
+  },
+  {
+    name: "design-system",
+    rule: dedent`
+      We like using vanilla shadcn style. 
+
+      Don't add unnecessary tailwind classes all over the place with random colours of even gradients.
+
+      We rely on tailwind's builtin theming, so any colours you do use must come from the theme.
+    `,
+    globs: ["**/*.tsx"],
   },
 ];
 


### PR DESCRIPTION
## High-level changes
**Stripe payment integration** 
  - Adds new `stripe_customer_id` column to `organization` table
  - Implements stripe's experimental "LLM token-markup metered charging"
  - Doesn't use openai's proxy for metering - just sends the meter readings ourselves (to retain the ability to do bring your own key)
  - Doesn't use better auth stripe plugin for anything because it only supports the legacy subscriptions . Will use it for webhook consumption - which we aren't consuming, yet
  - Subscription status is NOT yet synced to our database
**Organization management in web UI** 
- New org switcher, settings page, team members management
- Cleaned up sidebar
- UI for adding an organization 
- The main sidebar no longer assumes it's "inside" a UI - this allows us to put organisation specific
- For now, I just assume that each organisation has one estate and wouldn't encourage users to add another. Once we do allow users to do that, we can just show them all in the sidebar or introduce a new nested estate layout

## Small notes (AI generated)
- Database: Added `stripe_customer_id` to organization table
- Logging: Switched from `console.log`/`logger.log` to `logger.info`
- UI polish: Removed unnecessary containers, improved spacing throughout
- New routes: `/new-organization`, `/org/:orgId/settings`, `/org/:orgId/team`
- Renamed: `EstateLayout` → `OrganizationLayout`
- Dev tooling: Stripe webhook setup for local dev with Stripe CLI
- Background jobs: Customer/subscription creation via `waitUntil()`
- Dependencies: Added `@better-auth/stripe` and updated `stripe` package

https://github.com/user-attachments/assets/93e7f04f-a60a-40b7-a945-2e558da37509

