### PR TITLE
MCP connections UI

### DIFF
--- a/apps/os/app/hooks/use-slack-connection.ts
+++ b/apps/os/app/hooks/use-slack-connection.ts
@@ -8,12 +8,12 @@ export function useSlackConnection() {
   const estateId = useEstateId();
   const trpc = useTRPC();
 
-  const { data: integrations, refetch } = useSuspenseQuery(
+  const { data, refetch } = useSuspenseQuery(
     trpc.integrations.list.queryOptions({ estateId: estateId }),
   );
 
   // Check if Slack bot is connected at the estate level
-  const slackBotIntegration = integrations.find((i) => i.id === "slack-bot");
+  const slackBotIntegration = data.oauthIntegrations.find((i) => i.id === "slack-bot");
   const isConnected = slackBotIntegration?.isConnected || false;
   const isEstateWide = slackBotIntegration?.isEstateWide || false;
   const isPersonal = slackBotIntegration?.isPersonal || false;

--- a/apps/os/backend/trpc/routers/integrations.ts
+++ b/apps/os/backend/trpc/routers/integrations.ts
@@ -78,6 +78,8 @@ export const integrationsRouter = router({
       .from(account)
       .where(eq(account.userId, ctx.user.id));
 
+    const knownOAuthProviders = ["github-app", "slack-bot", "google", "slack"];
+
     // Group accounts by provider and track connection type
     const accountsByProvider: Record<
       string,
@@ -139,7 +141,92 @@ export const integrationsRouter = router({
       };
     });
 
-    return integrations;
+    // Get MCP connections
+    // 1. Get param-based MCP connections from mcpConnectionParam
+    const mcpParams = await ctx.db.query.mcpConnectionParam.findMany({
+      where: eq(schemas.mcpConnectionParam.estateId, estateId),
+    });
+
+    // Group by connectionKey
+    const mcpParamsByKey = mcpParams.reduce(
+      (acc, param) => {
+        if (!acc[param.connectionKey]) {
+          acc[param.connectionKey] = {
+            connectionKey: param.connectionKey,
+            params: [],
+            createdAt: param.createdAt,
+          };
+        }
+        acc[param.connectionKey].params.push({
+          key: param.paramKey,
+          type: param.paramType,
+        });
+        // Keep the earliest createdAt
+        if (param.createdAt < acc[param.connectionKey].createdAt) {
+          acc[param.connectionKey].createdAt = param.createdAt;
+        }
+        return acc;
+      },
+      {} as Record<
+        string,
+        { connectionKey: string; params: Array<{ key: string; type: string }>; createdAt: Date }
+      >,
+    );
+
+    // 2. Get OAuth-based MCP connections (accounts with providerId not in known list)
+    // OAuth connections are always personal since they're user-specific authentication
+    const mcpOAuthConnections = [
+      ...estateAccounts
+        .filter(({ account: acc }) => acc && !knownOAuthProviders.includes(acc.providerId))
+        .map(({ account: acc }) => ({
+          type: "mcp-oauth" as const,
+          id: acc!.id,
+          name: acc!.providerId,
+          providerId: acc!.providerId,
+          mode: "personal" as const,
+          scope: acc!.scope,
+          connectedAt: acc!.createdAt,
+        })),
+      ...personalAccounts
+        .filter((acc) => !knownOAuthProviders.includes(acc.providerId))
+        .filter((acc) => !estateAccounts.some(({ account: estateAcc }) => estateAcc?.id === acc.id))
+        .map((acc) => ({
+          type: "mcp-oauth" as const,
+          id: acc.id,
+          name: acc.providerId,
+          providerId: acc.providerId,
+          mode: "personal" as const,
+          scope: acc.scope,
+          connectedAt: acc.createdAt,
+        })),
+    ];
+
+    // Format param-based MCP connections
+    const mcpParamConnections = Object.values(mcpParamsByKey).map((conn) => {
+      const [serverUrl, mode, userId] = conn.connectionKey.split("::");
+      let displayName = serverUrl;
+      try {
+        displayName = new URL(serverUrl).hostname;
+      } catch {
+        // If URL parsing fails, use serverUrl as is
+      }
+
+      return {
+        type: "mcp-params" as const,
+        id: conn.connectionKey,
+        name: displayName,
+        serverUrl,
+        mode,
+        userId: userId || null,
+        paramCount: conn.params.length,
+        connectedAt: conn.createdAt,
+      };
+    });
+
+    return {
+      oauthIntegrations: integrations,
+      mcpConnections: [...mcpOAuthConnections, ...mcpParamConnections],
+    };
   }),
 
   // Get details for a specific integration
@@ -574,6 +661,166 @@ export const integrationsRouter = router({
         personalDisconnected,
         totalDisconnected: estateDisconnected + personalDisconnected,
       };
+    }),
+
+  disconnectMCP: estateProtectedProcedure
+    .input(
+      z.object({
+        connectionId: z.string(),
+        connectionType: z.enum(["mcp-oauth", "mcp-params"]),
+        mode: z.enum(["company", "personal"]),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { estateId, connectionId, connectionType } = input;
+
+      if (connectionType === "mcp-params") {
+        // Delete from mcpConnectionParam table
+        await ctx.db
+          .delete(schemas.mcpConnectionParam)
+          .where(eq(schemas.mcpConnectionParam.connectionKey, connectionId));
+      } else {
+        // Delete from account table (OAuth)
+        // First check if this account is linked to this estate
+        const estatePermission = await ctx.db.query.estateAccountsPermissions.findFirst({
+          where: and(
+            eq(estateAccountsPermissions.estateId, estateId),
+            eq(estateAccountsPermissions.accountId, connectionId),
+          ),
+        });
+
+        // Remove estate permission if it exists
+        if (estatePermission) {
+          await ctx.db
+            .delete(estateAccountsPermissions)
+            .where(
+              and(
+                eq(estateAccountsPermissions.estateId, estateId),
+                eq(estateAccountsPermissions.accountId, connectionId),
+              ),
+            );
+        }
+
+        // Check if account is used by other estates
+        const otherEstates = await ctx.db.query.estateAccountsPermissions.findFirst({
+          where: eq(estateAccountsPermissions.accountId, connectionId),
+        });
+
+        // Only delete the account if it's not used by any other estate
+        if (!otherEstates) {
+          // Also check if the account belongs to the current user
+          const acc = await ctx.db.query.account.findFirst({
+            where: eq(account.id, connectionId),
+          });
+
+          if (acc && acc.userId === ctx.user.id) {
+            await ctx.db.delete(account).where(eq(account.id, connectionId));
+          }
+        }
+      }
+
+      return { success: true };
+    }),
+
+  getMCPConnectionDetails: estateProtectedProcedure
+    .input(
+      z.object({
+        connectionId: z.string(),
+        connectionType: z.enum(["mcp-oauth", "mcp-params"]),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const { estateId, connectionId, connectionType } = input;
+
+      if (connectionType === "mcp-params") {
+        // Get params for param-based connection
+        const params = await ctx.db.query.mcpConnectionParam.findMany({
+          where: and(
+            eq(schemas.mcpConnectionParam.estateId, estateId),
+            eq(schemas.mcpConnectionParam.connectionKey, connectionId),
+          ),
+        });
+
+        return {
+          type: "params" as const,
+          params: params.map((p) => ({
+            key: p.paramKey,
+            value: p.paramValue,
+            type: p.paramType,
+          })),
+        };
+      } else {
+        // Get dynamic client info for OAuth connection
+        const acc = await ctx.db.query.account.findFirst({
+          where: eq(account.id, connectionId),
+        });
+
+        if (!acc) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Connection not found",
+          });
+        }
+
+        const dynamicClient = await ctx.db.query.dynamicClientInfo.findFirst({
+          where: and(
+            eq(schemas.dynamicClientInfo.providerId, acc.providerId),
+            eq(schemas.dynamicClientInfo.userId, acc.userId),
+          ),
+        });
+
+        return {
+          type: "oauth" as const,
+          providerId: acc.providerId,
+          scope: acc.scope,
+          clientInfo: dynamicClient?.clientInfo || null,
+          connectedAt: acc.createdAt,
+        };
+      }
+    }),
+
+  updateMCPConnectionParams: estateProtectedProcedure
+    .input(
+      z.object({
+        connectionKey: z.string(),
+        params: z.array(
+          z.object({
+            key: z.string(),
+            value: z.string(),
+            type: z.enum(["header", "query_param"]),
+          }),
+        ),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { estateId, connectionKey, params } = input;
+
+      await ctx.db.transaction(async (tx) => {
+        // Delete existing params
+        await tx
+          .delete(schemas.mcpConnectionParam)
+          .where(
+            and(
+              eq(schemas.mcpConnectionParam.estateId, estateId),
+              eq(schemas.mcpConnectionParam.connectionKey, connectionKey),
+            ),
+          );
+
+        // Insert new params
+        if (params.length > 0) {
+          await tx.insert(schemas.mcpConnectionParam).values(
+            params.map((param) => ({
+              estateId,
+              connectionKey,
+              paramKey: param.key,
+              paramValue: param.value,
+              paramType: param.type,
+            })),
+          );
+        }
+      });
+
+      return { success: true };
     }),
 
   saveMCPConnectionParams: estateProtectedProcedure


### PR DESCRIPTION
Fixes [ITE-3099: MCP connections UI](https://linear.app/iterate-com/issue/ITE-3099/mcp-connections-ui)

### TLDR
Users can now view, manage, and edit all MCP server connections (both OAuth and parameter-based) directly from the integrations page. Connections are organized by Personal vs Estate-wide mode with inline editing for parameter-based connections.

### Problem
MCP connections were being created and stored in the database (mcpConnectionParam table for param-based, account table for OAuth-based) but there was no UI to:
- View which MCP servers are connected
- Distinguish between personal and company/estate-wide connections
- Edit authentication parameters for param-based connections
- View OAuth client details for OAuth-based connections
- Disconnect unwanted MCP connections

### Approach
**Backend (apps/os/backend/trpc/routers/integrations.ts):**
- Extended integrations.list endpoint to return both oauthIntegrations (GitHub, Slack, Google) and mcpConnections (MCP servers)
- Query mcpConnectionParam table and group by connectionKey to find param-based connections
- Query account table filtering out known OAuth providers to find MCP OAuth connections
- Parse connectionKey format (serverUrl::mode::userId) to extract connection metadata
- Mark all OAuth-based MCP connections as "personal" mode (user-specific authentication)
- Added disconnectMCP endpoint with proper cleanup of both mcpConnectionParam and account tables
- Added getMCPConnectionDetails to fetch connection parameters or OAuth client info
- Added updateMCPConnectionParams to enable editing of parameter-based connections

**Frontend (apps/os/app/routes/integrations.tsx):**

- Split page into two sections: Core Integrations (cards) and MCP Servers (table)
- Table with columns: Server (monospace URL), Type (OAuth/Params badge), Connected (full timestamp), Actions
- Smart tabs: Personal (default) and Estate-wide, only shown when both modes have connections
- Click row to open details dialog:

- Param-based: Editable form with add/remove/edit params (headers and query params)
- OAuth: Read-only display of provider ID, scopes, client ID, and connection timestamp
- Red destructive disconnect button with confirmation AlertDialog
- Fixed use-slack-connection.ts hook to handle new data structure with oauthIntegrations property

https://github.com/user-attachments/assets/b9da3a20-db11-4a26-abf4-8576b05a8bd8