### PR TITLE
Bring back gmail and google calendar tools

### DIFF
--- a/apps/os/app/routes/org/estate/integrations/index.tsx
+++ b/apps/os/app/routes/org/estate/integrations/index.tsx
@@ -45,6 +45,7 @@ import {
 import { useTRPC } from "../../../../lib/trpc.ts";
 import { useEstateId } from "../../../../hooks/use-estate.ts";
 import { useSlackConnection } from "../../../../hooks/use-slack-connection.ts";
+import { authClient } from "../../../../lib/auth-client.ts";
 import type { Route } from "./+types/index.ts";
 
 export function meta(_args: Route.MetaArgs) {
@@ -158,6 +159,11 @@ export default function Integrations() {
     } else if (integrationId === "slack-bot") {
       // Use the shared Slack connection logic
       await connectSlackBot("/integrations");
+    } else if (integrationId === "google") {
+      const result = await authClient.integrations.link.google({
+        callbackURL: window.location.pathname,
+      });
+      window.location.href = result.url.toString();
     }
     // TODO: Implement OAuth flow for other integrations
     // This would redirect to the auth provider's OAuth URL

--- a/apps/os/app/routes/org/estate/integrations/redirect.tsx
+++ b/apps/os/app/routes/org/estate/integrations/redirect.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "react-router";
 import { eq } from "drizzle-orm";
 import { getDb, schema } from "../../../../../backend/db/client.ts";
-import { MCPOAuthState } from "../../../../../backend/auth/oauth-state-schemas.ts";
+import { BaseOAuthState } from "../../../../../backend/auth/oauth-state-schemas.ts";
 import type { Route } from "./+types/redirect.ts";
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -18,8 +18,8 @@ export async function loader({ request }: Route.LoaderArgs) {
     return redirect("/");
   }
 
-  const parsedState = MCPOAuthState.parse(JSON.parse(state.value));
-  return redirect(parsedState.fullUrl);
+  const parsedState = BaseOAuthState.parse(JSON.parse(state.value));
+  return redirect(parsedState.fullUrl ?? "/");
 }
 
 export default function IntegrationsRedirect() {

--- a/apps/os/backend/agent/iterate-agent-tools.ts
+++ b/apps/os/backend/agent/iterate-agent-tools.ts
@@ -188,4 +188,53 @@ export const iterateAgentTools = defineDOTools({
         .describe("Output resolution formatted as width x height"),
     }),
   },
+  callGoogleAPI: {
+    description: "Call a Google API endpoint with automatic authentication and token refresh",
+    input: z.object({
+      endpoint: z
+        .string()
+        .describe(
+          "The API endpoint path (e.g., '/gmail/v1/users/me/messages/send' or '/calendar/v3/calendars/primary/events')",
+        ),
+      method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]).describe("The HTTP method to use"),
+      body: z.any().optional().describe("The request body (will be JSON stringified)"),
+      queryParams: z
+        .record(z.string(), z.string())
+        .optional()
+        .describe("Query parameters to append to the URL"),
+      pathParams: z
+        .record(z.string(), z.string())
+        .optional()
+        .describe(
+          "Path parameters to insert into the URL. Path parameters are placeholders in the endpoint path represented as [param] that are replaced with the values in this object.",
+        ),
+      userId: z.string().describe("The user ID to use for authentication"),
+    }),
+  },
+  sendGmail: {
+    description:
+      "Send an email via Gmail. Can also reply to emails by providing threadId and inReplyTo.",
+    input: z.object({
+      to: z.string().describe("Recipient email address"),
+      subject: z.string().describe("Email subject"),
+      body: z.string().describe("Email body (plain text)"),
+      cc: z.string().optional().describe("CC email addresses (comma-separated)"),
+      bcc: z.string().optional().describe("BCC email addresses (comma-separated)"),
+      threadId: z.string().optional().describe("Thread ID to reply to (from getGmailMessage)"),
+      inReplyTo: z
+        .string()
+        .optional()
+        .describe("Message ID to reply to (from getGmailMessage headers)"),
+      userId: z.string().describe("The user ID to use for authentication"),
+    }),
+  },
+  // requires unapproved scope: gmail.modify
+  getGmailMessage: {
+    description:
+      "Get the full content of a specific Gmail message by ID. Returns the email with decoded text body.",
+    input: z.object({
+      messageId: z.string().describe("The ID of the message to retrieve"),
+      userId: z.string().describe("The user ID to use for authentication"),
+    }),
+  },
 });

--- a/apps/os/backend/auth/integrations.ts
+++ b/apps/os/backend/auth/integrations.ts
@@ -18,7 +18,7 @@ import { SlackAgent } from "../agent/slack-agent.ts";
 import { syncSlackUsersInBackground } from "../integrations/slack/slack.ts";
 import { createUserOrganizationAndEstate } from "../org-utils.ts";
 import { createStripeCustomerAndSubscriptionForOrganization } from "../integrations/stripe/stripe.ts";
-import { MCPOAuthState, SlackBotOAuthState } from "./oauth-state-schemas.ts";
+import { MCPOAuthState, SlackBotOAuthState, GoogleOAuthState } from "./oauth-state-schemas.ts";
 
 export const SLACK_BOT_SCOPES = [
   "app_mentions:read",
@@ -46,11 +46,21 @@ export const SLACK_BOT_SCOPES = [
 
 export const SLACK_USER_AUTH_SCOPES = ["openid", "profile", "email"];
 
+export const GOOGLE_INTEGRATION_SCOPES = [
+  // approved scopes
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/userinfo.profile",
+  "openid",
+  "https://www.googleapis.com/auth/gmail.send",
+  "https://www.googleapis.com/auth/calendar",
+  // unapproved scopes
+  "https://www.googleapis.com/auth/gmail.modify",
+];
+
 export const integrationsPlugin = () =>
   ({
     id: "integrations",
     endpoints: {
-      // MCP OAuth callback endpoint
       callbackMCP: createAuthEndpoint(
         "/integrations/callback/mcp",
         {
@@ -294,6 +304,58 @@ export const integrationsPlugin = () =>
           return ctx.json({ url });
         },
       ),
+      linkGoogle: createAuthEndpoint(
+        "/integrations/link/google",
+        {
+          method: "POST",
+          body: z.object({
+            callbackURL: z.string(),
+          }),
+          use: [sessionMiddleware],
+        },
+        async (ctx) => {
+          const { callbackURL } = ctx.body;
+          const session = ctx.context.session;
+
+          const { env } = getContext<{ Variables: Variables; Bindings: CloudflareEnv }>();
+
+          const state = generateRandomString(32);
+          const expiresAt = new Date(Date.now() + 10 * 60 * 1000);
+
+          const data = JSON.stringify({
+            link: {
+              userId: session.user.id,
+            },
+            callbackUrl: callbackURL,
+          } satisfies GoogleOAuthState);
+
+          await ctx.context.internalAdapter.createVerificationValue({
+            expiresAt,
+            identifier: state,
+            value: data,
+          });
+
+          const redirectURI = `${env.VITE_PUBLIC_URL}/api/auth/integrations/callback/google`;
+          const url = await createAuthorizationURL({
+            id: "google",
+            options: {
+              clientId: env.GOOGLE_CLIENT_ID,
+              clientSecret: env.GOOGLE_CLIENT_SECRET,
+              redirectURI,
+            },
+            redirectURI,
+            authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+            scopes: GOOGLE_INTEGRATION_SCOPES,
+            state,
+            additionalParams: {
+              access_type: "offline",
+              prompt: "consent",
+            },
+          });
+
+          return ctx.json({ url });
+        },
+      ),
       callbackSlack: createAuthEndpoint(
         "/integrations/callback/slack-bot",
         {
@@ -525,6 +587,160 @@ export const integrationsPlugin = () =>
           }
 
           return ctx.redirect(callbackURL || import.meta.env.VITE_PUBLIC_URL);
+        },
+      ),
+      callbackGoogle: createAuthEndpoint(
+        "/integrations/callback/google",
+        {
+          method: "GET",
+          query: z.object({
+            error: z
+              .string()
+              .meta({
+                description: "The error message, if any",
+              })
+              .optional(),
+            error_description: z
+              .string()
+              .meta({
+                description: "The error description, if any",
+              })
+              .optional(),
+            code: z.string().meta({
+              description: "The OAuth2 code",
+            }),
+            state: z.string().meta({
+              description: "The state parameter from the OAuth2 request",
+            }),
+          }),
+        },
+        async (ctx) => {
+          const value = await ctx.context.internalAdapter.findVerificationValue(ctx.query.state);
+
+          if (!value) {
+            return ctx.json({ error: "Invalid state" });
+          }
+
+          const parsedState = GoogleOAuthState.parse(JSON.parse(value.value));
+          const { link, callbackUrl: callbackURL, agentDurableObject } = parsedState;
+
+          const {
+            env,
+            var: { db },
+          } = getContext<{ Variables: Variables; Bindings: CloudflareEnv }>();
+
+          const redirectURI = `${env.VITE_PUBLIC_URL}/api/auth/integrations/callback/google`;
+
+          const tokenResponse = await fetch("https://oauth2.googleapis.com/token", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: new URLSearchParams({
+              code: ctx.query.code,
+              client_id: env.GOOGLE_CLIENT_ID,
+              client_secret: env.GOOGLE_CLIENT_SECRET,
+              redirect_uri: redirectURI,
+              grant_type: "authorization_code",
+            }),
+          });
+
+          if (!tokenResponse.ok) {
+            return ctx.json({ error: "Failed to exchange code for tokens" });
+          }
+
+          const tokens = (await tokenResponse.json()) as {
+            access_token: string;
+            refresh_token?: string;
+            expires_in?: number;
+          };
+
+          if (!tokens.access_token) {
+            return ctx.json({ error: "Failed to get access token" });
+          }
+
+          const accessTokenExpiresAt = tokens.expires_in
+            ? new Date(Date.now() + tokens.expires_in * 1000)
+            : undefined;
+
+          const userInfoResponse = await fetch("https://www.googleapis.com/oauth2/v2/userinfo", {
+            headers: {
+              Authorization: `Bearer ${tokens.access_token}`,
+            },
+          });
+
+          if (!userInfoResponse.ok) {
+            return ctx.json({ error: "Failed to get user info" });
+          }
+
+          const userInfo = (await userInfoResponse.json()) as {
+            email: string;
+            id: string;
+            name?: string;
+            picture?: string;
+          };
+
+          if (!userInfo.id) {
+            return ctx.json({ error: "Failed to get user info" });
+          }
+
+          const existingAccount = await ctx.context.internalAdapter.findAccount(userInfo.id);
+
+          if (existingAccount) {
+            await ctx.context.internalAdapter.updateAccount(existingAccount.id, {
+              accessToken: tokens.access_token,
+              refreshToken: tokens.refresh_token,
+              accessTokenExpiresAt,
+              scope: GOOGLE_INTEGRATION_SCOPES.join(" "),
+            });
+          } else {
+            const account = await ctx.context.internalAdapter.createAccount({
+              providerId: "google",
+              accountId: userInfo.id,
+              userId: link.userId,
+              accessToken: tokens.access_token,
+              refreshToken: tokens.refresh_token,
+              accessTokenExpiresAt,
+              scope: GOOGLE_INTEGRATION_SCOPES.join(" "),
+            });
+
+            if (!account) {
+              return ctx.json({ error: "Failed to create account" });
+            }
+          }
+
+          if (agentDurableObject) {
+            const params = {
+              db,
+              agentInstanceName: agentDurableObject.durableObjectName,
+            };
+            const agentStub =
+              agentDurableObject.className === "SlackAgent"
+                ? await SlackAgent.getStubByName(params)
+                : await IterateAgent.getStubByName(params);
+            await agentStub.addEvents([
+              {
+                type: "CORE:LLM_INPUT_ITEM",
+                data: {
+                  type: "message",
+                  role: "developer",
+                  content: [
+                    {
+                      type: "input_text",
+                      text: `The user with ID ${link.userId} has completed authorizing with Google.`,
+                    },
+                  ],
+                },
+                triggerLLMRequest: true,
+              },
+            ]);
+          }
+
+          if (!callbackURL) {
+            return ctx.redirect(import.meta.env.VITE_PUBLIC_URL);
+          }
+
+          return ctx.redirect(callbackURL);
         },
       ),
     },

--- a/apps/os/backend/auth/oauth-state-schemas.ts
+++ b/apps/os/backend/auth/oauth-state-schemas.ts
@@ -16,6 +16,8 @@ export type AgentDurableObjectInfo = z.infer<typeof AgentDurableObjectInfo>;
 
 export const BaseOAuthState = z.object({
   callbackUrl: z.string().optional(),
+  fullUrl: z.string().optional(),
+  agentDurableObject: AgentDurableObjectInfo.optional(),
 });
 
 export const MCPOAuthState = BaseOAuthState.extend({
@@ -24,8 +26,6 @@ export const MCPOAuthState = BaseOAuthState.extend({
   estateId: z.string(),
   userId: z.string(),
   clientId: z.string(),
-  fullUrl: z.string(),
-  agentDurableObject: AgentDurableObjectInfo,
   serverId: z.string(),
 });
 
@@ -49,8 +49,15 @@ export const SlackBotOAuthState = BaseOAuthState.extend({
     .optional(),
 });
 
+export const GoogleOAuthState = BaseOAuthState.extend({
+  link: z.object({
+    userId: z.string(),
+  }),
+});
+
 export type BaseOAuthState = z.infer<typeof BaseOAuthState>;
 export type MCPOAuthState = z.infer<typeof MCPOAuthState>;
 export type SlackDirectLoginState = z.infer<typeof SlackDirectLoginState>;
 export type SlackBotLinkState = z.infer<typeof SlackBotLinkState>;
 export type SlackBotOAuthState = z.infer<typeof SlackBotOAuthState>;
+export type GoogleOAuthState = z.infer<typeof GoogleOAuthState>;

--- a/apps/os/backend/auth/token-utils.ts
+++ b/apps/os/backend/auth/token-utils.ts
@@ -1,8 +1,12 @@
 import { eq, and } from "drizzle-orm";
 import { z } from "zod";
-import type { DB } from "../db/client.ts";
-import * as schema from "../db/schema.ts";
+import { createAuthorizationURL } from "better-auth/oauth2";
+import { generateRandomString } from "better-auth/crypto";
 import { env } from "../../env.ts";
+import * as schema from "../db/schema.ts";
+import type { DB } from "../db/client.ts";
+import type { AgentDurableObjectInfo, GoogleOAuthState } from "./oauth-state-schemas.ts";
+import { GOOGLE_INTEGRATION_SCOPES } from "./integrations.ts";
 
 export const getSlackAccessTokenForEstate = async (db: DB, estateId: string) => {
   const result = await db
@@ -100,4 +104,129 @@ export const getGithubUserAccessTokenForEstate = async (db: DB, estateId: string
     accessToken: result.accessToken,
     installationId: result.installationId,
   };
+};
+
+export const GoogleTokenResponse = z.object({
+  access_token: z.string(),
+  expires_in: z.number(),
+  scope: z.string().optional(),
+  token_type: z.string().optional(),
+});
+
+export const getGoogleAccessTokenForUser = async (db: DB, userId: string) => {
+  const [result] = await db
+    .select({
+      id: schema.account.id,
+      accessToken: schema.account.accessToken,
+      refreshToken: schema.account.refreshToken,
+      accessTokenExpiresAt: schema.account.accessTokenExpiresAt,
+    })
+    .from(schema.account)
+    .where(and(eq(schema.account.providerId, "google"), eq(schema.account.userId, userId)))
+    .limit(1);
+
+  if (!result) {
+    throw new Error(`Google access token not found for user ${userId}`);
+  }
+
+  if (result.accessTokenExpiresAt && result.accessTokenExpiresAt < new Date()) {
+    if (!result.refreshToken) {
+      throw new Error(`Google refresh token not found for user ${userId}`);
+    }
+
+    const refreshResponse = await fetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        client_id: env.GOOGLE_CLIENT_ID,
+        client_secret: env.GOOGLE_CLIENT_SECRET,
+        refresh_token: result.refreshToken,
+        grant_type: "refresh_token",
+      }),
+    });
+
+    if (!refreshResponse.ok) {
+      throw new Error(`Failed to refresh Google access token: ${refreshResponse.statusText}`);
+    }
+
+    const newTokenData = GoogleTokenResponse.parse(await refreshResponse.json());
+
+    await db
+      .update(schema.account)
+      .set({
+        accessToken: newTokenData.access_token,
+        accessTokenExpiresAt: new Date(Date.now() + newTokenData.expires_in * 1000),
+      })
+      .where(eq(schema.account.id, result.id));
+
+    return newTokenData.access_token;
+  }
+
+  if (!result.accessToken) {
+    throw new Error(`Google access token not found for user ${userId}`);
+  }
+
+  return result.accessToken;
+};
+
+export const getGoogleOAuthURL = async ({
+  db,
+  estateId,
+  userId,
+  agentDurableObject,
+  callbackUrl,
+}: {
+  db: DB;
+  estateId: string;
+  userId: string;
+  agentDurableObject: AgentDurableObjectInfo;
+  callbackUrl?: string;
+}) => {
+  const state = generateRandomString(32);
+  const redirectURI = `${env.VITE_PUBLIC_URL}/api/auth/integrations/callback/google`;
+  const fullUrl = await createAuthorizationURL({
+    id: "google",
+    options: {
+      clientId: env.GOOGLE_CLIENT_ID,
+      clientSecret: env.GOOGLE_CLIENT_SECRET,
+      redirectURI,
+    },
+    redirectURI,
+    authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+    scopes: GOOGLE_INTEGRATION_SCOPES,
+    state,
+    additionalParams: {
+      access_type: "offline",
+      prompt: "consent",
+    },
+  });
+
+  const googleOAuthState: GoogleOAuthState = {
+    link: {
+      userId,
+    },
+    callbackUrl,
+    fullUrl: fullUrl.toString(),
+    agentDurableObject,
+  };
+  await db.insert(schema.verification).values({
+    identifier: state,
+    value: JSON.stringify(googleOAuthState),
+    expiresAt: new Date(Date.now() + 10 * 60 * 1000), // 10 minutes for OAuth flow
+  });
+
+  const organization = await db.query.estate.findFirst({
+    where: eq(schema.estate.id, estateId),
+    columns: {
+      organizationId: true,
+    },
+  });
+
+  if (!organization) {
+    throw new Error("Organization not found");
+  }
+
+  return `${env.VITE_PUBLIC_URL}/${organization.organizationId}/${estateId}/integrations/redirect?key=${state}`;
 };


### PR DESCRIPTION
My idea was to make a common `callGoogleAPI` tool. We can then just override their input schema and name, and give some `passThroughArgs` for the URL and method for each tool. It worked for most of the tools, except for the following:
- `deleteCalendarEvent`, `updateCalendarEvent`, `deleteGmailLabel`, `modifyGmailLabels`: some of their parameters are actually path parameters, so I can't override the URL with a static string. Solution: implement some dynamic path resolver in the `callGoogleAPI` tool (this seems fairly reasonable to me!).
- `sendGmail`: you need to format the email into a single string and then base64encode it, which an LLM can't do
- `getGmailMessage`: you need to always base64decode a string, and sometimes the string is split into multiple parts and you have to concatenate them

I reckon that implementing the dynamic path resolver and keeping those two extra methods will be good!

Last point of contention is whether we can define the methods inline on the class or have them separately. Before, when I had 7 methods, I thought it made more sense for them to be separate, but now that we only have 3, I think it makes more sense for them to be inline.