### PR TITLE
Fix agent init params hydration after durable object alarms

### DIFF
--- a/apps/os/backend/agent/slack-agent.ts
+++ b/apps/os/backend/agent/slack-agent.ts
@@ -108,8 +108,8 @@ export class SlackAgent extends IterateAgent<SlackAgentSlices> implements ToolsI
   }
 
   // This gets run between the synchronous durable object constructor and the asynchronous onStart method of the agents SDK
-  async initAfterConstructorBeforeOnStart(params: AgentInitParams) {
-    await super.initAfterConstructorBeforeOnStart(params);
+  async initIterateAgent(params: AgentInitParams) {
+    await super.initIterateAgent(params);
 
     if (params.record.durableObjectName.includes("mock_slack")) {
       this.slackAPI = createSlackAPIMock<WebClient>();


### PR DESCRIPTION
This PR fixes a longstanding issue we had with durable object alarms when using the agents SDK's `this.schedule` method

If the alarm wakes a DO from hibernation, that object would not have the estate, iterateAgent, organization and iterateConfig database records set 

This PR is basically a fancy version of the workaround Sunil suggests [here](https://github.com/cloudflare/partykit/issues/32)

While I was at it, I slightly tidied up and clarified a the flow of the code a bit. It also reduces the number of DB and parent worker <> DO roundtrips

- the weird partykit magic fetch call that eventually triggers `onStart()` is now called from within the new `initIterateAgent(params)` (prev called `initAfterConstructorBeforeOnStart`)
- `AgentInitParams` (i.e. the control plane database records for estate, organization, agent instance and iterate config) are now stored in DO storage; onAlarm() rehydrates via storage and re-runs initIterateAgent
- stub getters now do single joined selects (estate/org/iterateConfig); fewer DB roundtrips; route create path wrapped in transaction
- net effect: alarms wake DOs into fully hydrated agents (all DB records) with onStart executed—same as when created via stub management