### PR TITLE
[codex] Add package-project codemode runs with egress-only secrets

### DIFF
--- a/apps/codemode-contract/src/index.ts
+++ b/apps/codemode-contract/src/index.ts
@@ -86,9 +86,7 @@ export const CodemodeSecretRecord = z.object({
 });
 export type CodemodeSecretRecord = z.infer<typeof CodemodeSecretRecord>;
 
-export const CodemodeSecretDetail = CodemodeSecretRecord.extend({
-  value: z.string(),
-});
+export const CodemodeSecretDetail = CodemodeSecretRecord;
 export type CodemodeSecretDetail = z.infer<typeof CodemodeSecretDetail>;
 
 export const CodemodeRun = z.object({

--- a/apps/codemode-contract/src/index.ts
+++ b/apps/codemode-contract/src/index.ts
@@ -44,6 +44,39 @@ export const CodemodeSource = z.discriminatedUnion("type", [
 ]);
 export type CodemodeSource = z.infer<typeof CodemodeSource>;
 
+export const CodemodeCompiledScriptInput = z.object({
+  type: z.literal("compiled-script"),
+  script: z.string().trim().min(1, "Script is required"),
+});
+export type CodemodeCompiledScriptInput = z.infer<typeof CodemodeCompiledScriptInput>;
+
+export const CodemodePackageProjectInput = z.object({
+  type: z.literal("package-project"),
+  entryPoint: z.string().trim().min(1, "Entry point is required"),
+  files: z.record(z.string(), z.string()).superRefine((files, context) => {
+    if (Object.keys(files).length === 0) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "At least one file is required",
+      });
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(files, "package.json")) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "package.json is required for package-project inputs",
+      });
+    }
+  }),
+});
+export type CodemodePackageProjectInput = z.infer<typeof CodemodePackageProjectInput>;
+
+export const CodemodeInput = z.discriminatedUnion("type", [
+  CodemodeCompiledScriptInput,
+  CodemodePackageProjectInput,
+]);
+export type CodemodeInput = z.infer<typeof CodemodeInput>;
+
 export const CodemodeSecretRecord = z.object({
   id: z.string(),
   key: z.string(),
@@ -61,7 +94,7 @@ export type CodemodeSecretDetail = z.infer<typeof CodemodeSecretDetail>;
 export const CodemodeRun = z.object({
   id: z.string(),
   runnerKind: CodemodeRunnerKind,
-  code: z.string(),
+  input: CodemodeInput,
   sources: z.array(CodemodeSource),
   result: z.string(),
   error: z.string().nullable(),
@@ -71,6 +104,7 @@ export type CodemodeRun = z.infer<typeof CodemodeRun>;
 export const CodemodeRunRecord = z.object({
   id: z.string(),
   runnerKind: CodemodeRunnerKind,
+  input: CodemodeInput,
   codeSnippet: z.string(),
   sources: z.array(CodemodeSource),
   result: z.string(),
@@ -165,7 +199,7 @@ export const codemodeContract = oc.router({
     })
     .input(
       z.object({
-        code: z.string().trim().min(1, "Code is required"),
+        input: CodemodeInput,
         sources: z.array(CodemodeSource).optional().default([]),
       }),
     )

--- a/apps/codemode/e2e/vitest/live.e2e.test.ts
+++ b/apps/codemode/e2e/vitest/live.e2e.test.ts
@@ -7,15 +7,55 @@ import { codemodeContract } from "@iterate-com/codemode-contract";
 import type { appRouter } from "~/orpc/root.ts";
 
 type OrpcClient = RouterClient<typeof appRouter>;
+const defaultOpenAiSecretKey = "openai.apiKey";
+
+function requireCodemodeBaseUrl() {
+  const baseUrl = process.env.CODEMODE_BASE_URL?.trim().replace(/\/+$/, "");
+
+  if (!baseUrl) {
+    throw new Error("CODEMODE_BASE_URL is required for codemode e2e tests.");
+  }
+
+  return baseUrl;
+}
+
+function requireOpenAiApiKey() {
+  const openAiApiKey = process.env.OPENAI_API_KEY?.trim();
+
+  if (!openAiApiKey) {
+    throw new Error("OPENAI_API_KEY is required for the codemode OpenAI e2e proofs.");
+  }
+
+  return openAiApiKey;
+}
+
+async function createClient(baseUrl: string) {
+  return createORPCClient(
+    new OpenAPILink(codemodeContract, {
+      url: `${baseUrl}/api`,
+    }),
+  ) as OrpcClient;
+}
+
+async function ensureOpenAiSecret(client: OrpcClient) {
+  const openAiApiKey = requireOpenAiApiKey();
+  const existingSecrets = await client.secrets.list({ limit: 100, offset: 0 });
+  const existing = existingSecrets.secrets.find((secret) => secret.key === defaultOpenAiSecretKey);
+
+  if (existing) {
+    await client.secrets.remove({ id: existing.id });
+  }
+
+  return client.secrets.create({
+    key: defaultOpenAiSecretKey,
+    value: openAiApiKey,
+    description: "Shared OpenAI API key for codemode live e2e and preview proofs",
+  });
+}
 
 describe("live codemode", () => {
   it("serves the new run page", async () => {
-    const baseUrl = process.env.CODEMODE_BASE_URL?.trim().replace(/\/+$/, "");
-    if (!baseUrl) {
-      throw new Error(
-        "CODEMODE_BASE_URL is required. Example: CODEMODE_BASE_URL=https://codemode-stg.iterate.com pnpm test:e2e",
-      );
-    }
+    const baseUrl = requireCodemodeBaseUrl();
 
     const response = await fetch(`${baseUrl}/runs-v2-new`);
     expect(response.status).toBe(200);
@@ -27,16 +67,8 @@ describe("live codemode", () => {
   });
 
   it("returns a sentinel from getIterateSecret instead of the stored secret value", async () => {
-    const baseUrl = process.env.CODEMODE_BASE_URL?.trim().replace(/\/+$/, "");
-    if (!baseUrl) {
-      throw new Error("CODEMODE_BASE_URL is required for codemode e2e tests.");
-    }
-
-    const client: OrpcClient = createORPCClient(
-      new OpenAPILink(codemodeContract, {
-        url: `${baseUrl}/api`,
-      }),
-    );
+    const baseUrl = requireCodemodeBaseUrl();
+    const client = await createClient(baseUrl);
 
     const nonce = randomUUID().slice(0, 8);
     const secretKey = `openai.apiKey.e2e.${nonce}`;
@@ -49,6 +81,11 @@ describe("live codemode", () => {
     });
 
     try {
+      const foundSecret = await client.secrets.find({ id: secret.id });
+      expect(foundSecret.key).toBe(secretKey);
+      expect(JSON.stringify(foundSecret)).not.toContain(actualSecretValue);
+      expect("value" in (foundSecret as object)).toBe(false);
+
       const run = await client.runV2({
         input: {
           type: "package-project",
@@ -86,16 +123,8 @@ export default async function ({ getIterateSecret }) {
   });
 
   it("ignores a user-supplied executor.js module and still runs the generated executor", async () => {
-    const baseUrl = process.env.CODEMODE_BASE_URL?.trim().replace(/\/+$/, "");
-    if (!baseUrl) {
-      throw new Error("CODEMODE_BASE_URL is required for codemode e2e tests.");
-    }
-
-    const client: OrpcClient = createORPCClient(
-      new OpenAPILink(codemodeContract, {
-        url: `${baseUrl}/api`,
-      }),
-    );
+    const baseUrl = requireCodemodeBaseUrl();
+    const client = await createClient(baseUrl);
 
     const run = await client.runV2({
       input: {
@@ -138,55 +167,36 @@ export default async function () {
   });
 
   it("bundles a package-project snippet, reads the OpenAI key from codemode secrets, and gets a model response", async () => {
-    const baseUrl = process.env.CODEMODE_BASE_URL?.trim().replace(/\/+$/, "");
-    const openAiApiKey = process.env.OPENAI_API_KEY?.trim();
+    const baseUrl = requireCodemodeBaseUrl();
+    const openAiApiKey = requireOpenAiApiKey();
+    const client = await createClient(baseUrl);
 
-    if (!baseUrl) {
-      throw new Error("CODEMODE_BASE_URL is required for codemode e2e tests.");
-    }
-
-    if (!openAiApiKey) {
-      throw new Error("OPENAI_API_KEY is required for the codemode OpenAI proof e2e.");
-    }
-
-    const client: OrpcClient = createORPCClient(
-      new OpenAPILink(codemodeContract, {
-        url: `${baseUrl}/api`,
-      }),
-    );
+    await ensureOpenAiSecret(client);
 
     const nonce = randomUUID().slice(0, 8);
-    const secretKey = `openai.apiKey.e2e.${nonce}`;
     const expectedReply = `codemode-openai-proof-${nonce}`;
-    const secret = await client.secrets.create({
-      key: secretKey,
-      value: openAiApiKey,
-      description: "Temporary OpenAI API key for codemode package-project e2e proof",
-    });
-
-    try {
-      const run = await client.runV2({
-        input: {
-          type: "package-project",
-          entryPoint: "src/index.ts",
-          files: {
-            "package.json": JSON.stringify(
-              {
-                name: "codemode-openai-proof",
-                private: true,
-                type: "module",
-                dependencies: {
-                  openai: "^6.0.0",
-                },
+    const run = await client.runV2({
+      input: {
+        type: "package-project",
+        entryPoint: "src/index.ts",
+        files: {
+          "package.json": JSON.stringify(
+            {
+              name: "codemode-openai-proof",
+              private: true,
+              type: "module",
+              dependencies: {
+                openai: "^6.0.0",
               },
-              null,
-              2,
-            ),
-            "src/index.ts": `
+            },
+            null,
+            2,
+          ),
+          "src/index.ts": `
 import OpenAI from "openai";
 
 export default async function ({ getIterateSecret }) {
-  const visibleValue = await getIterateSecret({ secretKey: ${JSON.stringify(secretKey)} });
+  const visibleValue = await getIterateSecret({ secretKey: ${JSON.stringify(defaultOpenAiSecretKey)} });
   const client = new OpenAI({
     apiKey: visibleValue,
   });
@@ -201,30 +211,27 @@ export default async function ({ getIterateSecret }) {
     message: response.output_text ?? null,
   };
 }
-              `.trim(),
-          },
+          `.trim(),
         },
-        sources: [],
-      });
+      },
+      sources: [],
+    });
 
-      expect(run.error).toBeNull();
+    expect(run.error).toBeNull();
 
-      const result = JSON.parse(run.result) as {
-        message?: string | null;
-        visibleValue?: string | null;
-      };
-      expect(result.visibleValue).toBe(
-        `getIterateSecret({ secretKey: ${JSON.stringify(secretKey)} })`,
-      );
-      expect(run.result).not.toContain(openAiApiKey);
-      expect(result.message).toContain(expectedReply);
+    const result = JSON.parse(run.result) as {
+      message?: string | null;
+      visibleValue?: string | null;
+    };
+    expect(result.visibleValue).toBe(
+      `getIterateSecret({ secretKey: ${JSON.stringify(defaultOpenAiSecretKey)} })`,
+    );
+    expect(run.result).not.toContain(openAiApiKey);
+    expect(result.message).toContain(expectedReply);
 
-      const savedRun = await client.runs.find({ id: run.id });
-      expect(savedRun.error).toBeNull();
-      expect(savedRun.result).not.toContain(openAiApiKey);
-      expect(savedRun.result).toContain(expectedReply);
-    } finally {
-      await client.secrets.remove({ id: secret.id });
-    }
+    const savedRun = await client.runs.find({ id: run.id });
+    expect(savedRun.error).toBeNull();
+    expect(savedRun.result).not.toContain(openAiApiKey);
+    expect(savedRun.result).toContain(expectedReply);
   }, 120_000);
 });

--- a/apps/codemode/e2e/vitest/live.e2e.test.ts
+++ b/apps/codemode/e2e/vitest/live.e2e.test.ts
@@ -1,4 +1,8 @@
+import { randomUUID } from "node:crypto";
+import { createORPCClient } from "@orpc/client";
+import { OpenAPILink } from "@orpc/openapi-client/fetch";
 import { describe, expect, it } from "vitest";
+import { codemodeContract } from "@iterate-com/codemode-contract";
 
 describe("live codemode", () => {
   it("serves the new run page", async () => {
@@ -17,4 +21,85 @@ describe("live codemode", () => {
     expect(body).toContain("Run codemode");
     expect(body).toContain("Reset starter");
   });
+
+  it("bundles a package-project snippet, reads the OpenAI key from codemode secrets, and gets a model response", async () => {
+    const baseUrl = process.env.CODEMODE_BASE_URL?.trim().replace(/\/+$/, "");
+    const openAiApiKey = process.env.OPENAI_API_KEY?.trim();
+
+    if (!baseUrl) {
+      throw new Error("CODEMODE_BASE_URL is required for codemode e2e tests.");
+    }
+
+    if (!openAiApiKey) {
+      throw new Error("OPENAI_API_KEY is required for the codemode OpenAI proof e2e.");
+    }
+
+    const client = createORPCClient(
+      new OpenAPILink(codemodeContract, {
+        url: `${baseUrl}/api`,
+      }),
+    );
+
+    const nonce = randomUUID().slice(0, 8);
+    const secretKey = `openai.apiKey.e2e.${nonce}`;
+    const expectedReply = `codemode-openai-proof-${nonce}`;
+    const secret = await client.secrets.create({
+      key: secretKey,
+      value: openAiApiKey,
+      description: "Temporary OpenAI API key for codemode package-project e2e proof",
+    });
+
+    try {
+      const run = await client.runV2({
+        input: {
+          type: "package-project",
+          entryPoint: "src/index.ts",
+          files: {
+            "package.json": JSON.stringify(
+              {
+                name: "codemode-openai-proof",
+                private: true,
+                type: "module",
+                dependencies: {
+                  openai: "^6.0.0",
+                },
+              },
+              null,
+              2,
+            ),
+            "src/index.ts": `
+import OpenAI from "openai";
+
+export default async function ({ getIterateSecret }) {
+  const client = new OpenAI({
+    apiKey: await getIterateSecret({ secretKey: ${JSON.stringify(secretKey)} }),
+  });
+
+  const response = await client.responses.create({
+    model: "gpt-4.1-mini",
+    input: ${JSON.stringify(`Reply with exactly ${expectedReply} and nothing else.`)},
+  });
+
+  return {
+    message: response.output_text ?? null,
+  };
+}
+              `.trim(),
+          },
+        },
+        sources: [],
+      });
+
+      expect(run.error).toBeNull();
+
+      const result = JSON.parse(run.result) as { message?: string | null };
+      expect(result.message).toContain(expectedReply);
+
+      const savedRun = await client.runs.find({ id: run.id });
+      expect(savedRun.error).toBeNull();
+      expect(savedRun.result).toContain(expectedReply);
+    } finally {
+      await client.secrets.remove({ id: secret.id });
+    }
+  }, 120_000);
 });

--- a/apps/codemode/e2e/vitest/live.e2e.test.ts
+++ b/apps/codemode/e2e/vitest/live.e2e.test.ts
@@ -1,8 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { createORPCClient } from "@orpc/client";
 import { OpenAPILink } from "@orpc/openapi-client/fetch";
+import type { RouterClient } from "@orpc/server";
 import { describe, expect, it } from "vitest";
 import { codemodeContract } from "@iterate-com/codemode-contract";
+import type { appRouter } from "~/orpc/root.ts";
+
+type OrpcClient = RouterClient<typeof appRouter>;
 
 describe("live codemode", () => {
   it("serves the new run page", async () => {
@@ -22,6 +26,65 @@ describe("live codemode", () => {
     expect(body).toContain("Reset starter");
   });
 
+  it("returns a sentinel from getIterateSecret instead of the stored secret value", async () => {
+    const baseUrl = process.env.CODEMODE_BASE_URL?.trim().replace(/\/+$/, "");
+    if (!baseUrl) {
+      throw new Error("CODEMODE_BASE_URL is required for codemode e2e tests.");
+    }
+
+    const client: OrpcClient = createORPCClient(
+      new OpenAPILink(codemodeContract, {
+        url: `${baseUrl}/api`,
+      }),
+    );
+
+    const nonce = randomUUID().slice(0, 8);
+    const secretKey = `openai.apiKey.e2e.${nonce}`;
+    const actualSecretValue = `sk-live-proof-${nonce}`;
+    const expectedSentinel = `getIterateSecret({ secretKey: ${JSON.stringify(secretKey)} })`;
+    const secret = await client.secrets.create({
+      key: secretKey,
+      value: actualSecretValue,
+      description: "Temporary secret for codemode sentinel visibility proof",
+    });
+
+    try {
+      const run = await client.runV2({
+        input: {
+          type: "package-project",
+          entryPoint: "src/index.ts",
+          files: {
+            "package.json": JSON.stringify(
+              {
+                name: "codemode-secret-sentinel-proof",
+                private: true,
+                type: "module",
+              },
+              null,
+              2,
+            ),
+            "src/index.ts": `
+export default async function ({ getIterateSecret }) {
+  return {
+    visibleValue: await getIterateSecret({ secretKey: ${JSON.stringify(secretKey)} }),
+  };
+}
+              `.trim(),
+          },
+        },
+        sources: [],
+      });
+
+      expect(run.error).toBeNull();
+
+      const result = JSON.parse(run.result) as { visibleValue?: string | null };
+      expect(result.visibleValue).toBe(expectedSentinel);
+      expect(run.result).not.toContain(actualSecretValue);
+    } finally {
+      await client.secrets.remove({ id: secret.id });
+    }
+  });
+
   it("bundles a package-project snippet, reads the OpenAI key from codemode secrets, and gets a model response", async () => {
     const baseUrl = process.env.CODEMODE_BASE_URL?.trim().replace(/\/+$/, "");
     const openAiApiKey = process.env.OPENAI_API_KEY?.trim();
@@ -34,7 +97,7 @@ describe("live codemode", () => {
       throw new Error("OPENAI_API_KEY is required for the codemode OpenAI proof e2e.");
     }
 
-    const client = createORPCClient(
+    const client: OrpcClient = createORPCClient(
       new OpenAPILink(codemodeContract, {
         url: `${baseUrl}/api`,
       }),
@@ -71,8 +134,9 @@ describe("live codemode", () => {
 import OpenAI from "openai";
 
 export default async function ({ getIterateSecret }) {
+  const visibleValue = await getIterateSecret({ secretKey: ${JSON.stringify(secretKey)} });
   const client = new OpenAI({
-    apiKey: await getIterateSecret({ secretKey: ${JSON.stringify(secretKey)} }),
+    apiKey: visibleValue,
   });
 
   const response = await client.responses.create({
@@ -81,6 +145,7 @@ export default async function ({ getIterateSecret }) {
   });
 
   return {
+    visibleValue,
     message: response.output_text ?? null,
   };
 }
@@ -92,11 +157,19 @@ export default async function ({ getIterateSecret }) {
 
       expect(run.error).toBeNull();
 
-      const result = JSON.parse(run.result) as { message?: string | null };
+      const result = JSON.parse(run.result) as {
+        message?: string | null;
+        visibleValue?: string | null;
+      };
+      expect(result.visibleValue).toBe(
+        `getIterateSecret({ secretKey: ${JSON.stringify(secretKey)} })`,
+      );
+      expect(run.result).not.toContain(openAiApiKey);
       expect(result.message).toContain(expectedReply);
 
       const savedRun = await client.runs.find({ id: run.id });
       expect(savedRun.error).toBeNull();
+      expect(savedRun.result).not.toContain(openAiApiKey);
       expect(savedRun.result).toContain(expectedReply);
     } finally {
       await client.secrets.remove({ id: secret.id });

--- a/apps/codemode/e2e/vitest/live.e2e.test.ts
+++ b/apps/codemode/e2e/vitest/live.e2e.test.ts
@@ -166,6 +166,40 @@ export default async function () {
     expect(run.result).not.toContain("user executor should never run");
   });
 
+  it("runs a package project whose entry point bundles to executor.js without self-importing", async () => {
+    const baseUrl = requireCodemodeBaseUrl();
+    const client = await createClient(baseUrl);
+
+    const run = await client.runV2({
+      input: {
+        type: "package-project",
+        entryPoint: "executor.ts",
+        files: {
+          "package.json": JSON.stringify(
+            {
+              name: "codemode-entrypoint-executor-proof",
+              private: true,
+              type: "module",
+            },
+            null,
+            2,
+          ),
+          "executor.ts": `
+export default async function () {
+  return {
+    message: "executor entrypoint ran",
+  };
+}
+          `.trim(),
+        },
+      },
+      sources: [],
+    });
+
+    expect(run.error).toBeNull();
+    expect(run.result).toContain("executor entrypoint ran");
+  });
+
   it("bundles a package-project snippet, reads the OpenAI key from codemode secrets, and gets a model response", async () => {
     const baseUrl = requireCodemodeBaseUrl();
     const openAiApiKey = requireOpenAiApiKey();

--- a/apps/codemode/e2e/vitest/live.e2e.test.ts
+++ b/apps/codemode/e2e/vitest/live.e2e.test.ts
@@ -85,6 +85,58 @@ export default async function ({ getIterateSecret }) {
     }
   });
 
+  it("ignores a user-supplied executor.js module and still runs the generated executor", async () => {
+    const baseUrl = process.env.CODEMODE_BASE_URL?.trim().replace(/\/+$/, "");
+    if (!baseUrl) {
+      throw new Error("CODEMODE_BASE_URL is required for codemode e2e tests.");
+    }
+
+    const client: OrpcClient = createORPCClient(
+      new OpenAPILink(codemodeContract, {
+        url: `${baseUrl}/api`,
+      }),
+    );
+
+    const run = await client.runV2({
+      input: {
+        type: "package-project",
+        entryPoint: "src/index.ts",
+        files: {
+          "package.json": JSON.stringify(
+            {
+              name: "codemode-executor-collision-proof",
+              private: true,
+              type: "module",
+            },
+            null,
+            2,
+          ),
+          "executor.js": `
+export default {
+  async evaluate() {
+    return {
+      result: "user executor should never run",
+    };
+  },
+};
+          `.trim(),
+          "src/index.ts": `
+export default async function () {
+  return {
+    message: "generated executor still won",
+  };
+}
+          `.trim(),
+        },
+      },
+      sources: [],
+    });
+
+    expect(run.error).toBeNull();
+    expect(run.result).toContain("generated executor still won");
+    expect(run.result).not.toContain("user executor should never run");
+  });
+
   it("bundles a package-project snippet, reads the OpenAI key from codemode secrets, and gets a model response", async () => {
     const baseUrl = process.env.CODEMODE_BASE_URL?.trim().replace(/\/+$/, "");
     const openAiApiKey = process.env.OPENAI_API_KEY?.trim();

--- a/apps/codemode/package.json
+++ b/apps/codemode/package.json
@@ -18,7 +18,7 @@
     "typecheck": "tsc --noEmit",
     "test": "pnpm typecheck",
     "test:e2e": "node -e \"if (!process.env.CODEMODE_BASE_URL) { console.error('CODEMODE_BASE_URL is required for codemode e2e tests'); process.exit(1); }\" && vitest run --config ./e2e/vitest.config.ts",
-    "test:e2e:doppler": "node -e \"if (!process.env.CODEMODE_BASE_URL) { console.error('CODEMODE_BASE_URL is required for codemode e2e tests'); process.exit(1); }\" && doppler run --project ai-engineer-workshop --config dev_jonas -- pnpm exec vitest run --config ./e2e/vitest.config.ts"
+    "test:e2e:doppler": "node -e \"if (!process.env.CODEMODE_BASE_URL) { console.error('CODEMODE_BASE_URL is required for codemode e2e tests'); process.exit(1); } if (!process.env.DOPPLER_PROJECT || !process.env.DOPPLER_CONFIG) { console.error('DOPPLER_PROJECT and DOPPLER_CONFIG are required for codemode e2e Doppler runs'); process.exit(1); }\" && doppler run --project \"$DOPPLER_PROJECT\" --config \"$DOPPLER_CONFIG\" -- pnpm exec vitest run --config ./e2e/vitest.config.ts"
   },
   "dependencies": {
     "@cloudflare/codemode": "^0.3.2",

--- a/apps/codemode/package.json
+++ b/apps/codemode/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@cloudflare/codemode": "^0.3.2",
+    "@cloudflare/worker-bundler": "^0.0.4",
     "@iterate-com/codemode-contract": "workspace:*",
     "@iterate-com/events-contract": "workspace:*",
     "@iterate-com/example-contract": "workspace:*",

--- a/apps/codemode/package.json
+++ b/apps/codemode/package.json
@@ -17,7 +17,8 @@
     "rpc": "pnpm cli rpc",
     "typecheck": "tsc --noEmit",
     "test": "pnpm typecheck",
-    "test:e2e": "node -e \"if (!process.env.CODEMODE_BASE_URL) { console.error('CODEMODE_BASE_URL is required for codemode e2e tests'); process.exit(1); }\" && vitest run --config ./e2e/vitest.config.ts"
+    "test:e2e": "node -e \"if (!process.env.CODEMODE_BASE_URL) { console.error('CODEMODE_BASE_URL is required for codemode e2e tests'); process.exit(1); }\" && vitest run --config ./e2e/vitest.config.ts",
+    "test:e2e:doppler": "node -e \"if (!process.env.CODEMODE_BASE_URL) { console.error('CODEMODE_BASE_URL is required for codemode e2e tests'); process.exit(1); }\" && doppler run --project ai-engineer-workshop --config dev_jonas -- pnpm exec vitest run --config ./e2e/vitest.config.ts"
   },
   "dependencies": {
     "@cloudflare/codemode": "^0.3.2",

--- a/apps/codemode/src/lib/codemode-input.test.ts
+++ b/apps/codemode/src/lib/codemode-input.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import {
+  CODEMODE_PACKAGE_PROJECT_STARTER,
+  DEFAULT_CODEMODE_INPUT,
+  formatCodemodeInputForDisplay,
+  formatCodemodeProjectFilesYaml,
+  parseCodemodeProjectFilesYaml,
+  parseStoredCodemodeInput,
+  serializeCodemodeInput,
+} from "~/lib/codemode-input.ts";
+
+describe("codemode input helpers", () => {
+  test("round-trips structured inputs through storage serialization", () => {
+    const serialized = serializeCodemodeInput(CODEMODE_PACKAGE_PROJECT_STARTER);
+
+    expect(parseStoredCodemodeInput(serialized)).toEqual(CODEMODE_PACKAGE_PROJECT_STARTER);
+  });
+
+  test("treats legacy stored snippets as compiled-script inputs", () => {
+    expect(parseStoredCodemodeInput("async ({ ctx }) => ctx.fetch('https://example.com')")).toEqual(
+      {
+        type: "compiled-script",
+        script: "async ({ ctx }) => ctx.fetch('https://example.com')",
+      },
+    );
+  });
+
+  test("parses project file YAML blocks into string maps", () => {
+    const yamlText = formatCodemodeProjectFilesYaml(CODEMODE_PACKAGE_PROJECT_STARTER.files);
+    const parsed = parseCodemodeProjectFilesYaml(yamlText);
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      throw new Error(parsed.error);
+    }
+
+    expect(parsed.files["package.json"]).toContain('"openai": "^6.0.0"');
+    expect(parsed.files["src/index.ts"]).toContain("getIterateSecret");
+  });
+
+  test("formats inputs for display", () => {
+    expect(formatCodemodeInputForDisplay(DEFAULT_CODEMODE_INPUT)).toContain("async ({ ctx }) =>");
+    expect(formatCodemodeInputForDisplay(CODEMODE_PACKAGE_PROJECT_STARTER)).toContain(
+      "entryPoint: src/index.ts",
+    );
+  });
+});

--- a/apps/codemode/src/lib/codemode-input.ts
+++ b/apps/codemode/src/lib/codemode-input.ts
@@ -1,0 +1,133 @@
+import YAML from "yaml";
+import {
+  type CodemodeInput,
+  CodemodeInput as CodemodeInputSchema,
+} from "@iterate-com/codemode-contract";
+import { CODEMODE_V2_STARTER } from "~/lib/codemode-v2.ts";
+
+export const CODEMODE_PACKAGE_PROJECT_STARTER = CodemodeInputSchema.parse({
+  type: "package-project",
+  entryPoint: "src/index.ts",
+  files: {
+    "package.json": JSON.stringify(
+      {
+        name: "codemode-openai-demo",
+        private: true,
+        type: "module",
+        dependencies: {
+          openai: "^6.0.0",
+        },
+      },
+      null,
+      2,
+    ),
+    "src/index.ts": `import OpenAI from "openai";
+
+export default async function ({ ctx, getIterateSecret }) {
+  const client = new OpenAI({
+    apiKey: await getIterateSecret({ secretKey: "openai.apiKey" }),
+  });
+
+  const routes = await ctx.ingressProxy.routes.list({ limit: 1, offset: 0 });
+  const response = await client.responses.create({
+    model: "gpt-4.1-mini",
+    input: "Reply with the single word ready.",
+  });
+
+  return {
+    routeCount: routes.total,
+    modelReply: response.output_text ?? null,
+  };
+}
+`,
+  },
+}) as Extract<CodemodeInput, { type: "package-project" }>;
+
+export const DEFAULT_CODEMODE_INPUT = CodemodeInputSchema.parse({
+  type: "compiled-script",
+  script: CODEMODE_V2_STARTER,
+}) as Extract<CodemodeInput, { type: "compiled-script" }>;
+
+export function serializeCodemodeInput(input: CodemodeInput) {
+  return JSON.stringify(input);
+}
+
+export function parseStoredCodemodeInput(value: string): CodemodeInput {
+  try {
+    return CodemodeInputSchema.parse(JSON.parse(value));
+  } catch {
+    return CodemodeInputSchema.parse({
+      type: "compiled-script",
+      script: value,
+    });
+  }
+}
+
+export function resolveCodemodeEditorInput(options: {
+  input?: string;
+  code?: string;
+}): CodemodeInput {
+  if (options.input?.trim().length) {
+    return parseStoredCodemodeInput(options.input);
+  }
+
+  if (options.code?.trim().length) {
+    return CodemodeInputSchema.parse({
+      type: "compiled-script",
+      script: options.code,
+    });
+  }
+
+  return DEFAULT_CODEMODE_INPUT;
+}
+
+export function formatCodemodeProjectFilesYaml(files: Record<string, string>) {
+  return YAML.stringify(files).trim();
+}
+
+export function parseCodemodeProjectFilesYaml(input: string) {
+  try {
+    const parsed = YAML.parse(input) as unknown;
+    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {
+        ok: false as const,
+        error: "Files YAML must be an object keyed by relative file path.",
+      };
+    }
+
+    const files = Object.fromEntries(
+      Object.entries(parsed).map(([key, value]) => {
+        if (typeof value !== "string") {
+          throw new Error(`File "${key}" must be a string block.`);
+        }
+
+        return [key, value];
+      }),
+    );
+
+    return {
+      ok: true as const,
+      files,
+    };
+  } catch (error) {
+    return {
+      ok: false as const,
+      error: error instanceof Error ? error.message : "Invalid files YAML",
+    };
+  }
+}
+
+export function formatCodemodeInputForDisplay(input: CodemodeInput) {
+  if (input.type === "compiled-script") {
+    return input.script;
+  }
+
+  return YAML.stringify({
+    entryPoint: input.entryPoint,
+    files: input.files,
+  }).trim();
+}
+
+export function codemodeInputLanguage(input: CodemodeInput) {
+  return input.type === "compiled-script" ? ("typescript" as const) : ("text" as const);
+}

--- a/apps/codemode/src/lib/codemode-links.ts
+++ b/apps/codemode/src/lib/codemode-links.ts
@@ -1,9 +1,10 @@
-import type { CodemodeSource } from "@iterate-com/codemode-contract";
+import type { CodemodeInput, CodemodeSource } from "@iterate-com/codemode-contract";
 import { z } from "zod";
+import { resolveCodemodeEditorInput, serializeCodemodeInput } from "~/lib/codemode-input.ts";
 import { formatCodemodeSourcesYaml } from "~/lib/codemode-sources.ts";
-import { CODEMODE_V2_STARTER } from "~/lib/codemode-v2.ts";
 
 export const CodemodeNewRunSearch = z.object({
+  input: z.string().optional(),
   code: z.string().optional(),
   sources: z.string().optional(),
 });
@@ -12,22 +13,29 @@ export const CodemodeExamplesSearch = z.object({
   q: z.string().optional(),
 });
 
-export function buildCodemodeNewRunSearch(options: { code: string; sources: CodemodeSource[] }) {
+export function buildCodemodeNewRunSearch(options: {
+  input?: CodemodeInput;
+  code?: string;
+  sources: CodemodeSource[];
+}) {
+  const input = options.input ?? resolveCodemodeEditorInput({ code: options.code });
+
   return {
-    code: options.code,
+    input: serializeCodemodeInput(input),
     sources: formatCodemodeSourcesYaml(options.sources),
   };
 }
 
 export function buildCodemodeNewRunHref(options: {
   origin: string;
-  code: string;
+  input?: CodemodeInput;
+  code?: string;
   sources: CodemodeSource[];
 }) {
   const search = new URLSearchParams(buildCodemodeNewRunSearch(options));
   return `${options.origin}/runs-v2-new?${search.toString()}`;
 }
 
-export function resolveCodemodeEditorCode(code?: string) {
-  return code?.trim().length ? code : CODEMODE_V2_STARTER;
+export function resolveCodemodeSearchInput(search: { input?: string; code?: string }) {
+  return resolveCodemodeEditorInput(search);
 }

--- a/apps/codemode/src/lib/codemode-secret-injection.ts
+++ b/apps/codemode/src/lib/codemode-secret-injection.ts
@@ -16,6 +16,10 @@ export type ParsedSecret = {
   secretKey: string;
 };
 
+export function formatIterateSecretReference(secretKey: string) {
+  return `getIterateSecret({ secretKey: ${JSON.stringify(secretKey)} })`;
+}
+
 type ReplaceMagicStringsResult =
   | { ok: true; result: string }
   | { ok: false; error: CodemodeSecretError };
@@ -57,6 +61,21 @@ export function parseMagicString(match: string): ParsedSecret | null {
   } catch {
     return null;
   }
+}
+
+export function parseGetIterateSecretInput(input: unknown): ParsedSecret {
+  const secretKey =
+    typeof input === "object" && input !== null && "secretKey" in input
+      ? input.secretKey
+      : undefined;
+
+  if (typeof secretKey !== "string" || secretKey.trim().length === 0) {
+    throw new Error("secretKey is required");
+  }
+
+  return {
+    secretKey,
+  };
 }
 
 async function lookupCodemodeSecret(db: D1Database, secretKey: string) {

--- a/apps/codemode/src/lib/codemode/executor.ts
+++ b/apps/codemode/src/lib/codemode/executor.ts
@@ -1,5 +1,6 @@
 import { RpcTarget } from "cloudflare:workers";
 import { normalizeCode, sanitizeToolName } from "@cloudflare/codemode";
+import type { Modules } from "@cloudflare/worker-bundler";
 
 export interface ExecuteResult {
   result: unknown;
@@ -20,7 +21,14 @@ export interface DynamicWorkerExecutorOptions {
   loader: WorkerLoader;
   timeout?: number;
   globalOutbound?: Fetcher | null;
-  modules?: Record<string, string>;
+  modules?: Modules;
+}
+
+export interface WorkerBundleDefinition {
+  mainModule: string;
+  modules: Modules;
+  compatibilityDate?: string;
+  compatibilityFlags?: string[];
 }
 
 function stringifyRpcEnvelope(value: unknown) {
@@ -40,6 +48,143 @@ function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
     Symbol.asyncIterator in value &&
     typeof (value as AsyncIterable<unknown>)[Symbol.asyncIterator] === "function"
   );
+}
+
+function createImportPath(fromModule: string, toModule: string) {
+  const fromParts = fromModule.split("/");
+  fromParts.pop();
+  const toParts = toModule.split("/");
+  let sharedIndex = 0;
+
+  while (sharedIndex < fromParts.length && sharedIndex < toParts.length) {
+    if (fromParts[sharedIndex] !== toParts[sharedIndex]) {
+      break;
+    }
+
+    sharedIndex += 1;
+  }
+
+  const parentSegments = fromParts.slice(sharedIndex).map(() => "..");
+  const childSegments = toParts.slice(sharedIndex);
+  const relativePath = [...parentSegments, ...childSegments].join("/");
+
+  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+}
+
+function createInlineUserModuleSource(code: string) {
+  return `export default ${normalizeCode(code)};`;
+}
+
+function indent(value: string, spaces: number) {
+  const prefix = " ".repeat(spaces);
+  return value
+    .split("\n")
+    .map((line) => `${prefix}${line}`)
+    .join("\n");
+}
+
+function createExecutorModule(options: {
+  providers: ResolvedProvider[];
+  sandboxPrelude?: string;
+  timeoutMs: number;
+  userModulePath: string;
+  getSecretProviderName?: string;
+}) {
+  const importPath = createImportPath("executor.js", options.userModulePath);
+  const getSecretProviderName = options.getSecretProviderName ?? null;
+  const sandboxPrelude = options.sandboxPrelude?.trim().length
+    ? indent(options.sandboxPrelude.trim(), 4)
+    : "    const ctx = { fetch: (...args) => fetch(...args) };";
+
+  return [
+    'import { WorkerEntrypoint } from "cloudflare:workers";',
+    `import userDefault, * as userModule from "${importPath}";`,
+    "",
+    "function __createRemoteAsyncIterator(target) {",
+    "  return {",
+    "    [Symbol.asyncIterator]() {",
+    "      return this;",
+    "    },",
+    "    async next() {",
+    "      const resJson = await target.next();",
+    "      const data = JSON.parse(resJson);",
+    "      if (data.error) throw new Error(data.error);",
+    "      return data.result;",
+    "    },",
+    "    async return(value) {",
+    "      const resJson = await target.return(JSON.stringify(value ?? null));",
+    "      const data = JSON.parse(resJson);",
+    "      if (data.error) throw new Error(data.error);",
+    "      return data.result ?? { value, done: true };",
+    "    },",
+    "    async throw(error) {",
+    "      const resJson = await target.throw(JSON.stringify({ message: String(error) }));",
+    "      const data = JSON.parse(resJson);",
+    "      if (data.error) throw new Error(data.error);",
+    "      return data.result;",
+    "    },",
+    "  };",
+    "}",
+    "",
+    "function __stringifyLogValue(value) {",
+    "  if (typeof value === 'string') return value;",
+    "  if (typeof value === 'undefined') return 'undefined';",
+    "  try {",
+    "    return JSON.stringify(value, null, 2);",
+    "  } catch {",
+    "    return String(value);",
+    "  }",
+    "}",
+    "",
+    "function __resolveUserFn() {",
+    "  if (typeof userDefault === 'function') return userDefault;",
+    "  if (typeof userModule.run === 'function') return userModule.run;",
+    "  throw new Error(",
+    '    "Codemode entrypoint must export a default function or a named run() function.",',
+    "  );",
+    "}",
+    "",
+    "export default class CodeExecutor extends WorkerEntrypoint {",
+    "  async evaluate(__dispatchers = {}) {",
+    "    const __logs = [];",
+    '    console.log = (...a) => { __logs.push(a.map(__stringifyLogValue).join(" ")); };',
+    '    console.warn = (...a) => { __logs.push("[warn] " + a.map(__stringifyLogValue).join(" ")); };',
+    '    console.error = (...a) => { __logs.push("[error] " + a.map(__stringifyLogValue).join(" ")); };',
+    ...options.providers.map((provider) => {
+      if (provider.mode === "stream") {
+        return `    const ${provider.name} = new Proxy({}, {\n      get: (_, toolName) => async (args) => {\n        const target = await __dispatchers.${provider.name}.stream(String(toolName), JSON.stringify(args ?? {}));\n        return __createRemoteAsyncIterator(target);\n      }\n    });`;
+      }
+
+      if (provider.positionalArgs) {
+        return `    const ${provider.name} = new Proxy({}, {\n      get: (_, toolName) => async (...args) => {\n        const resJson = await __dispatchers.${provider.name}.call(String(toolName), JSON.stringify(args));\n        const data = JSON.parse(resJson);\n        if (data.error) throw new Error(data.error);\n        return data.result;\n      }\n    });`;
+      }
+
+      return `    const ${provider.name} = new Proxy({}, {\n      get: (_, toolName) => async (args) => {\n        const resJson = await __dispatchers.${provider.name}.call(String(toolName), JSON.stringify(args ?? {}));\n        const data = JSON.parse(resJson);\n        if (data.error) throw new Error(data.error);\n        return data.result;\n      }\n    });`;
+    }),
+    sandboxPrelude,
+    getSecretProviderName == null
+      ? ""
+      : `    const getIterateSecret = async (args) => ${getSecretProviderName}.getIterateSecret(args ?? {});`,
+    "",
+    "    try {",
+    "      const __userFn = __resolveUserFn();",
+    "      const result = await Promise.race([",
+    getSecretProviderName == null
+      ? "        __userFn({ ctx }),"
+      : "        __userFn({ ctx, getIterateSecret }),",
+    `        new Promise((_, reject) => setTimeout(() => reject(new Error("Execution timed out")), ${options.timeoutMs})),`,
+    "      ]);",
+    "      return { result, logs: __logs };",
+    "    } catch (error) {",
+    "      return {",
+    "        result: undefined,",
+    "        error: error instanceof Error ? error.message : String(error),",
+    "        logs: __logs,",
+    "      };",
+    "    }",
+    "  }",
+    "}",
+  ].join("\n");
 }
 
 class RemoteAsyncIteratorDispatcher extends RpcTarget {
@@ -148,149 +293,60 @@ export class DynamicWorkerExecutor {
   #loader: WorkerLoader;
   #timeout: number;
   #globalOutbound: Fetcher | null | undefined;
-  #modules: Record<string, string>;
+  #modules: Modules;
 
   constructor(options: DynamicWorkerExecutorOptions) {
     this.#loader = options.loader;
     this.#timeout = options.timeout ?? 30_000;
     this.#globalOutbound = options.globalOutbound ?? null;
-
-    const { "executor.js": _executorModule, ...safeModules } = options.modules ?? {};
-    this.#modules = safeModules;
+    this.#modules = options.modules ?? {};
   }
 
   async execute(code: string, providers: ResolvedProvider[]): Promise<ExecuteResult> {
-    const normalized = normalizeCode(code);
-    const timeoutMs = this.#timeout;
-    const reservedNames = new Set(["__dispatchers", "__logs"]);
-    const validIdentifier = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
-    const seenNames = new Set<string>();
+    return this.executeWorkerBundle(
+      {
+        mainModule: "executor.js",
+        modules: {
+          "executor.js": createExecutorModule({
+            providers,
+            timeoutMs: this.#timeout,
+            userModulePath: "user-inline.js",
+          }),
+          "user-inline.js": createInlineUserModuleSource(code),
+        },
+      },
+      providers,
+    );
+  }
 
-    for (const provider of providers) {
-      if (reservedNames.has(provider.name)) {
-        return { result: undefined, error: `Provider name "${provider.name}" is reserved` };
-      }
-
-      if (!validIdentifier.test(provider.name)) {
-        return {
-          result: undefined,
-          error: `Provider name "${provider.name}" is not a valid JavaScript identifier`,
-        };
-      }
-
-      if (seenNames.has(provider.name)) {
-        return { result: undefined, error: `Duplicate provider name "${provider.name}"` };
-      }
-
-      seenNames.add(provider.name);
-    }
-
-    const executorModule = [
-      'import { WorkerEntrypoint } from "cloudflare:workers";',
-      "",
-      "function __createRemoteAsyncIterator(target) {",
-      "  return {",
-      "    [Symbol.asyncIterator]() {",
-      "      return this;",
-      "    },",
-      "    async next() {",
-      "      const resJson = await target.next();",
-      "      const data = JSON.parse(resJson);",
-      "      if (data.error) throw new Error(data.error);",
-      "      return data.result;",
-      "    },",
-      "    async return(value) {",
-      "      const resJson = await target.return(JSON.stringify(value ?? null));",
-      "      const data = JSON.parse(resJson);",
-      "      if (data.error) throw new Error(data.error);",
-      "      return data.result ?? { value, done: true };",
-      "    },",
-      "    async throw(error) {",
-      "      const resJson = await target.throw(JSON.stringify({ message: String(error) }));",
-      "      const data = JSON.parse(resJson);",
-      "      if (data.error) throw new Error(data.error);",
-      "      return data.result;",
-      "    },",
-      "  };",
-      "}",
-      "",
-      "function __stringifyLogValue(value) {",
-      "  if (typeof value === 'string') return value;",
-      "  if (typeof value === 'undefined') return 'undefined';",
-      "  try {",
-      "    return JSON.stringify(value, null, 2);",
-      "  } catch {",
-      "    return String(value);",
-      "  }",
-      "}",
-      "",
-      "export default class CodeExecutor extends WorkerEntrypoint {",
-      "  async evaluate(__dispatchers = {}) {",
-      "    const __logs = [];",
-      '    console.log = (...a) => { __logs.push(a.map(__stringifyLogValue).join(" ")); };',
-      '    console.warn = (...a) => { __logs.push("[warn] " + a.map(__stringifyLogValue).join(" ")); };',
-      '    console.error = (...a) => { __logs.push("[error] " + a.map(__stringifyLogValue).join(" ")); };',
-      ...providers.map((provider) => {
-        if (provider.mode === "stream") {
-          return `    const ${provider.name} = new Proxy({}, {\n      get: (_, toolName) => async (args) => {\n        const target = await __dispatchers.${provider.name}.stream(String(toolName), JSON.stringify(args ?? {}));\n        return __createRemoteAsyncIterator(target);\n      }\n    });`;
-        }
-
-        if (provider.positionalArgs) {
-          return `    const ${provider.name} = new Proxy({}, {\n      get: (_, toolName) => async (...args) => {\n        const resJson = await __dispatchers.${provider.name}.call(String(toolName), JSON.stringify(args));\n        const data = JSON.parse(resJson);\n        if (data.error) throw new Error(data.error);\n        return data.result;\n      }\n    });`;
-        }
-
-        return `    const ${provider.name} = new Proxy({}, {\n      get: (_, toolName) => async (args) => {\n        const resJson = await __dispatchers.${provider.name}.call(String(toolName), JSON.stringify(args ?? {}));\n        const data = JSON.parse(resJson);\n        if (data.error) throw new Error(data.error);\n        return data.result;\n      }\n    });`;
-      }),
-      "",
-      "    try {",
-      "      const result = await Promise.race([",
-      "        (",
-      normalized,
-      "        )(),",
-      `        new Promise((_, reject) => setTimeout(() => reject(new Error("Execution timed out")), ${timeoutMs}))`,
-      "      ]);",
-      "      return { result, logs: __logs };",
-      "    } catch (error) {",
-      "      return {",
-      "        result: undefined,",
-      "        error: error instanceof Error ? error.message : String(error),",
-      "        logs: __logs,",
-      "      };",
-      "    }",
-      "  }",
-      "}",
-    ].join("\n");
-
-    const dispatchers: Record<string, ToolDispatcher> = {};
-
-    for (const provider of providers) {
-      const sanitizedFns: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
-
-      for (const [name, fn] of Object.entries(provider.fns)) {
-        sanitizedFns[sanitizeToolName(name)] = fn;
-      }
-
-      dispatchers[provider.name] = new ToolDispatcher(sanitizedFns, {
-        mode: provider.mode,
-        positionalArgs: provider.positionalArgs,
-      });
+  async executeWorkerBundle(
+    bundle: WorkerBundleDefinition,
+    providers: ResolvedProvider[],
+  ): Promise<ExecuteResult> {
+    const validationError = validateProviderNames(providers);
+    if (validationError) {
+      return { result: undefined, error: validationError };
     }
 
     const entrypoint = this.#loader
       .get(`codemode-${crypto.randomUUID()}`, () => ({
-        compatibilityDate: "2025-06-01",
-        compatibilityFlags: ["nodejs_compat", "global_fetch_strictly_public"],
-        mainModule: "executor.js",
+        compatibilityDate: bundle.compatibilityDate ?? "2025-06-01",
+        compatibilityFlags: bundle.compatibilityFlags ?? [
+          "nodejs_compat",
+          "global_fetch_strictly_public",
+        ],
+        mainModule: bundle.mainModule,
         modules: {
           ...this.#modules,
-          "executor.js": executorModule,
+          ...bundle.modules,
         },
         globalOutbound: this.#globalOutbound,
       }))
       .getEntrypoint() as unknown as {
       evaluate(input: Record<string, ToolDispatcher>): Promise<ExecuteResult>;
     };
-    const response = await entrypoint.evaluate(dispatchers);
+
+    const response = await entrypoint.evaluate(buildDispatchers(providers));
 
     if (response.error) {
       return {
@@ -305,4 +361,70 @@ export class DynamicWorkerExecutor {
       logs: response.logs,
     };
   }
+}
+
+export function buildCodemodeExecutionBundle(options: {
+  userModulePath: string;
+  userModules: Modules;
+  providers: ResolvedProvider[];
+  sandboxPrelude?: string;
+  timeoutMs?: number;
+  getSecretProviderName?: string;
+}): WorkerBundleDefinition {
+  return {
+    mainModule: "executor.js",
+    modules: {
+      "executor.js": createExecutorModule({
+        providers: options.providers,
+        sandboxPrelude: options.sandboxPrelude,
+        timeoutMs: options.timeoutMs ?? 30_000,
+        userModulePath: options.userModulePath,
+        getSecretProviderName: options.getSecretProviderName,
+      }),
+      ...options.userModules,
+    },
+  };
+}
+
+function validateProviderNames(providers: ResolvedProvider[]) {
+  const reservedNames = new Set(["__dispatchers", "__logs"]);
+  const validIdentifier = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+  const seenNames = new Set<string>();
+
+  for (const provider of providers) {
+    if (reservedNames.has(provider.name)) {
+      return `Provider name "${provider.name}" is reserved`;
+    }
+
+    if (!validIdentifier.test(provider.name)) {
+      return `Provider name "${provider.name}" is not a valid JavaScript identifier`;
+    }
+
+    if (seenNames.has(provider.name)) {
+      return `Duplicate provider name "${provider.name}"`;
+    }
+
+    seenNames.add(provider.name);
+  }
+
+  return null;
+}
+
+function buildDispatchers(providers: ResolvedProvider[]) {
+  const dispatchers: Record<string, ToolDispatcher> = {};
+
+  for (const provider of providers) {
+    const sanitizedFns: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+
+    for (const [name, fn] of Object.entries(provider.fns)) {
+      sanitizedFns[sanitizeToolName(name)] = fn;
+    }
+
+    dispatchers[provider.name] = new ToolDispatcher(sanitizedFns, {
+      mode: provider.mode,
+      positionalArgs: provider.positionalArgs,
+    });
+  }
+
+  return dispatchers;
 }

--- a/apps/codemode/src/lib/codemode/executor.ts
+++ b/apps/codemode/src/lib/codemode/executor.ts
@@ -374,6 +374,7 @@ export function buildCodemodeExecutionBundle(options: {
   return {
     mainModule: "executor.js",
     modules: {
+      ...options.userModules,
       "executor.js": createExecutorModule({
         providers: options.providers,
         sandboxPrelude: options.sandboxPrelude,
@@ -381,7 +382,6 @@ export function buildCodemodeExecutionBundle(options: {
         userModulePath: options.userModulePath,
         getSecretProviderName: options.getSecretProviderName,
       }),
-      ...options.userModules,
     },
   };
 }

--- a/apps/codemode/src/lib/codemode/executor.ts
+++ b/apps/codemode/src/lib/codemode/executor.ts
@@ -31,6 +31,9 @@ export interface WorkerBundleDefinition {
   compatibilityFlags?: string[];
 }
 
+const INTERNAL_EXECUTOR_MODULE_PATH = "__codemode_executor__.js";
+const INLINE_USER_MODULE_PATH = "__codemode_user_inline__.js";
+
 function stringifyRpcEnvelope(value: unknown) {
   return JSON.stringify({ result: value });
 }
@@ -90,7 +93,7 @@ function createExecutorModule(options: {
   userModulePath: string;
   getSecretProviderName?: string;
 }) {
-  const importPath = createImportPath("executor.js", options.userModulePath);
+  const importPath = createImportPath(INTERNAL_EXECUTOR_MODULE_PATH, options.userModulePath);
   const getSecretProviderName = options.getSecretProviderName ?? null;
   const sandboxPrelude = options.sandboxPrelude?.trim().length
     ? indent(options.sandboxPrelude.trim(), 4)
@@ -305,14 +308,14 @@ export class DynamicWorkerExecutor {
   async execute(code: string, providers: ResolvedProvider[]): Promise<ExecuteResult> {
     return this.executeWorkerBundle(
       {
-        mainModule: "executor.js",
+        mainModule: INTERNAL_EXECUTOR_MODULE_PATH,
         modules: {
-          "executor.js": createExecutorModule({
+          [INTERNAL_EXECUTOR_MODULE_PATH]: createExecutorModule({
             providers,
             timeoutMs: this.#timeout,
-            userModulePath: "user-inline.js",
+            userModulePath: INLINE_USER_MODULE_PATH,
           }),
-          "user-inline.js": createInlineUserModuleSource(code),
+          [INLINE_USER_MODULE_PATH]: createInlineUserModuleSource(code),
         },
       },
       providers,
@@ -371,11 +374,17 @@ export function buildCodemodeExecutionBundle(options: {
   timeoutMs?: number;
   getSecretProviderName?: string;
 }): WorkerBundleDefinition {
+  if (INTERNAL_EXECUTOR_MODULE_PATH in options.userModules) {
+    throw new Error(
+      `Codemode package-project cannot define reserved internal module ${JSON.stringify(INTERNAL_EXECUTOR_MODULE_PATH)}.`,
+    );
+  }
+
   return {
-    mainModule: "executor.js",
+    mainModule: INTERNAL_EXECUTOR_MODULE_PATH,
     modules: {
       ...options.userModules,
-      "executor.js": createExecutorModule({
+      [INTERNAL_EXECUTOR_MODULE_PATH]: createExecutorModule({
         providers: options.providers,
         sandboxPrelude: options.sandboxPrelude,
         timeoutMs: options.timeoutMs ?? 30_000,

--- a/apps/codemode/src/lib/execute-code-v2.ts
+++ b/apps/codemode/src/lib/execute-code-v2.ts
@@ -1,8 +1,14 @@
-import type { CodemodeSource } from "@iterate-com/codemode-contract";
+import { normalizeCode } from "@cloudflare/codemode";
+import { createWorker } from "@cloudflare/worker-bundler";
+import type { CodemodeInput, CodemodeSource } from "@iterate-com/codemode-contract";
 import type { AppConfig } from "~/app.ts";
-import { DynamicWorkerExecutor } from "~/lib/codemode/executor.ts";
+import {
+  buildCodemodeExecutionBundle,
+  DynamicWorkerExecutor,
+  type ResolvedProvider,
+  type WorkerBundleDefinition,
+} from "~/lib/codemode/executor.ts";
 import { buildCodemodeContextFromSources } from "~/lib/codemode-contract-runtime.ts";
-import { buildCodemodeWrapperSource } from "~/lib/codemode-v2.ts";
 
 export interface CodemodeExecutionResult {
   result: string;
@@ -21,9 +27,98 @@ function stringifyUnknown(value: unknown) {
   }
 }
 
+function mergeCompatibilityFlags(...groups: Array<string[] | undefined>) {
+  return [...new Set(groups.flatMap((group) => group ?? []))];
+}
+
+function isModuleScript(script: string) {
+  return /^\s*(import|export)\b/m.test(script);
+}
+
+function buildCompiledScriptModuleSource(script: string) {
+  if (isModuleScript(script)) {
+    return script;
+  }
+
+  return `export default ${normalizeCode(script)};`;
+}
+
+async function lookupCodemodeSecret(db: D1Database, secretKey: string) {
+  const row = await db
+    .prepare("select value from codemode_secrets where key = ?1 limit 1")
+    .bind(secretKey)
+    .first<{ value: string }>();
+
+  return row?.value ?? null;
+}
+
+function createRuntimeProvider(db: D1Database): ResolvedProvider {
+  return {
+    name: "codemodeRuntime",
+    fns: {
+      getIterateSecret: async (input) => {
+        const secretKey =
+          typeof input === "object" && input !== null && "secretKey" in input
+            ? input.secretKey
+            : undefined;
+
+        if (typeof secretKey !== "string" || secretKey.trim().length === 0) {
+          throw new Error("secretKey is required");
+        }
+
+        const secretValue = await lookupCodemodeSecret(db, secretKey);
+        if (secretValue == null) {
+          throw new Error(`Secret '${secretKey}' not found`);
+        }
+
+        return secretValue;
+      },
+    },
+  };
+}
+
+async function bundleCodemodeInput(options: {
+  input: CodemodeInput;
+  providers: ResolvedProvider[];
+  sandboxPrelude: string;
+}): Promise<WorkerBundleDefinition> {
+  if (options.input.type === "compiled-script") {
+    return buildCodemodeExecutionBundle({
+      userModulePath: "user-script.js",
+      userModules: {
+        "user-script.js": buildCompiledScriptModuleSource(options.input.script),
+      },
+      providers: options.providers,
+      sandboxPrelude: options.sandboxPrelude,
+      getSecretProviderName: "codemodeRuntime",
+    });
+  }
+
+  const bundle = await createWorker({
+    files: options.input.files,
+    entryPoint: options.input.entryPoint,
+  });
+
+  return {
+    ...buildCodemodeExecutionBundle({
+      userModulePath: bundle.mainModule,
+      userModules: bundle.modules,
+      providers: options.providers,
+      sandboxPrelude: options.sandboxPrelude,
+      getSecretProviderName: "codemodeRuntime",
+    }),
+    compatibilityDate: bundle.wranglerConfig?.compatibilityDate ?? "2025-06-01",
+    compatibilityFlags: mergeCompatibilityFlags(
+      ["nodejs_compat", "global_fetch_strictly_public"],
+      bundle.wranglerConfig?.compatibilityFlags,
+    ),
+  };
+}
+
 export async function executeCodemodeFunction(options: {
-  code: string;
+  input: CodemodeInput;
   config: AppConfig;
+  db: D1Database;
   loader: WorkerLoader;
   outbound: Fetcher;
   sources?: CodemodeSource[];
@@ -37,17 +132,19 @@ export async function executeCodemodeFunction(options: {
         input instanceof Request ? new Request(input, init) : new Request(input, init),
       ),
   });
+
+  const providers = [...contractContext.providers, createRuntimeProvider(options.db)];
+  const bundle = await bundleCodemodeInput({
+    input: options.input,
+    providers,
+    sandboxPrelude: contractContext.sandboxPrelude,
+  });
+
   const executor = new DynamicWorkerExecutor({
     loader: options.loader,
     globalOutbound: options.outbound,
   });
-  const response = await executor.execute(
-    buildCodemodeWrapperSource({
-      userCode: options.code,
-      sandboxPrelude: contractContext.sandboxPrelude,
-    }),
-    contractContext.providers,
-  );
+  const response = await executor.executeWorkerBundle(bundle, providers);
 
   return {
     result: typeof response.result === "undefined" ? "" : stringifyUnknown(response.result),

--- a/apps/codemode/src/lib/execute-code-v2.ts
+++ b/apps/codemode/src/lib/execute-code-v2.ts
@@ -9,6 +9,10 @@ import {
   type WorkerBundleDefinition,
 } from "~/lib/codemode/executor.ts";
 import { buildCodemodeContextFromSources } from "~/lib/codemode-contract-runtime.ts";
+import {
+  formatIterateSecretReference,
+  parseGetIterateSecretInput,
+} from "~/lib/codemode-secret-injection.ts";
 
 export interface CodemodeExecutionResult {
   result: string;
@@ -43,35 +47,13 @@ function buildCompiledScriptModuleSource(script: string) {
   return `export default ${normalizeCode(script)};`;
 }
 
-async function lookupCodemodeSecret(db: D1Database, secretKey: string) {
-  const row = await db
-    .prepare("select value from codemode_secrets where key = ?1 limit 1")
-    .bind(secretKey)
-    .first<{ value: string }>();
-
-  return row?.value ?? null;
-}
-
-function createRuntimeProvider(db: D1Database): ResolvedProvider {
+function createRuntimeProvider(): ResolvedProvider {
   return {
     name: "codemodeRuntime",
     fns: {
       getIterateSecret: async (input) => {
-        const secretKey =
-          typeof input === "object" && input !== null && "secretKey" in input
-            ? input.secretKey
-            : undefined;
-
-        if (typeof secretKey !== "string" || secretKey.trim().length === 0) {
-          throw new Error("secretKey is required");
-        }
-
-        const secretValue = await lookupCodemodeSecret(db, secretKey);
-        if (secretValue == null) {
-          throw new Error(`Secret '${secretKey}' not found`);
-        }
-
-        return secretValue;
+        const { secretKey } = parseGetIterateSecretInput(input);
+        return formatIterateSecretReference(secretKey);
       },
     },
   };
@@ -118,7 +100,6 @@ async function bundleCodemodeInput(options: {
 export async function executeCodemodeFunction(options: {
   input: CodemodeInput;
   config: AppConfig;
-  db: D1Database;
   loader: WorkerLoader;
   outbound: Fetcher;
   sources?: CodemodeSource[];
@@ -133,7 +114,7 @@ export async function executeCodemodeFunction(options: {
       ),
   });
 
-  const providers = [...contractContext.providers, createRuntimeProvider(options.db)];
+  const providers = [...contractContext.providers, createRuntimeProvider()];
   const bundle = await bundleCodemodeInput({
     input: options.input,
     providers,

--- a/apps/codemode/src/lib/runs.ts
+++ b/apps/codemode/src/lib/runs.ts
@@ -5,6 +5,7 @@ import {
   CodemodeRunnerKind,
   CodemodeSource,
 } from "@iterate-com/codemode-contract";
+import { formatCodemodeInputForDisplay, parseStoredCodemodeInput } from "~/lib/codemode-input.ts";
 import { summarizeCodeSnippet, summarizeError, summarizeResult } from "~/lib/run-preview.ts";
 
 const StoredRun = z.object({
@@ -24,11 +25,13 @@ export const LIST_RUNS_INPUT = {
 
 export function parseCodemodeRunRecord(row: unknown) {
   const parsed = StoredRun.parse(row);
+  const input = parseStoredCodemodeInput(parsed.codeSnippet);
 
   return CodemodeRunRecord.parse({
     id: parsed.id,
     runnerKind: parsed.runnerKind,
-    codeSnippet: parsed.codeSnippet,
+    input,
+    codeSnippet: formatCodemodeInputForDisplay(input),
     sources: CodemodeSource.array().parse(JSON.parse(parsed.sourcesJson)),
     result: parsed.result,
     logs: z.array(z.string()).parse(JSON.parse(parsed.logsJson)),

--- a/apps/codemode/src/orpc/routers/run.ts
+++ b/apps/codemode/src/orpc/routers/run.ts
@@ -3,6 +3,7 @@ import type { CodemodeRun } from "@iterate-com/codemode-contract";
 import { ORPCError } from "@orpc/server";
 import type { AppContext } from "~/context.ts";
 import { codemodeRunsTable } from "~/db/schema.ts";
+import { serializeCodemodeInput } from "~/lib/codemode-input.ts";
 import { buildCodemodeContextFromSources } from "~/lib/codemode-contract-runtime.ts";
 import { executeCodemodeFunction } from "~/lib/execute-code-v2.ts";
 import { parseCodemodeRunRecord, summarizeCodemodeRun } from "~/lib/runs.ts";
@@ -16,7 +17,7 @@ async function saveRun(context: AppContext, run: CodemodeRun, logs: string[]) {
   await context.db.insert(codemodeRunsTable).values({
     id: run.id,
     runnerKind: run.runnerKind,
-    codeSnippet: run.code,
+    codeSnippet: serializeCodemodeInput(run.input),
     sourcesJson: JSON.stringify(run.sources),
     result: run.result,
     logsJson: JSON.stringify(logs),
@@ -44,16 +45,17 @@ export const runRouter = {
   runV2: os.runV2.handler(async ({ context, input }) => {
     try {
       const execution = await executeCodemodeFunction({
-        code: input.code,
+        input: input.input,
         loader: context.env.LOADER,
         outbound: context.env.OUTBOUND,
+        db: context.env.DB,
         config: context.config,
         sources: input.sources,
       });
       const run: CodemodeRun = {
         id: createRunId(),
         runnerKind: "deterministic-v2",
-        code: input.code,
+        input: input.input,
         sources: input.sources,
         result: execution.result,
         error: execution.error,

--- a/apps/codemode/src/orpc/routers/run.ts
+++ b/apps/codemode/src/orpc/routers/run.ts
@@ -48,7 +48,6 @@ export const runRouter = {
         input: input.input,
         loader: context.env.LOADER,
         outbound: context.env.OUTBOUND,
-        db: context.env.DB,
         config: context.config,
         sources: input.sources,
       });

--- a/apps/codemode/src/orpc/routers/secrets.ts
+++ b/apps/codemode/src/orpc/routers/secrets.ts
@@ -79,7 +79,6 @@ export const secretsRouter = {
       return {
         id: secret.id,
         key: secret.key,
-        value: secret.value,
         description: secret.description,
         createdAt: secret.createdAt,
         updatedAt: secret.updatedAt,

--- a/apps/codemode/src/routeTree.gen.ts
+++ b/apps/codemode/src/routeTree.gen.ts
@@ -291,3 +291,12 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
+}

--- a/apps/codemode/src/routes/_app/runs-v2-new.tsx
+++ b/apps/codemode/src/routes/_app/runs-v2-new.tsx
@@ -34,12 +34,20 @@ import {
 } from "~/lib/codemode-sources.ts";
 import { orpc, orpcClient } from "~/orpc/client.ts";
 
-const RunFunctionForm = z.object({
-  mode: z.enum(["compiled-script", "package-project"]),
-  compiledScript: z.string().trim().min(1, "Script is required"),
-  packageEntryPoint: z.string().trim().min(1, "Entry point is required"),
-  packageFilesYaml: z.string().trim().min(1, "Files YAML is required"),
-});
+const RunFunctionForm = z.discriminatedUnion("mode", [
+  z.object({
+    mode: z.literal("compiled-script"),
+    compiledScript: z.string().trim().min(1, "Script is required"),
+    packageEntryPoint: z.string(),
+    packageFilesYaml: z.string(),
+  }),
+  z.object({
+    mode: z.literal("package-project"),
+    compiledScript: z.string(),
+    packageEntryPoint: z.string().trim().min(1, "Entry point is required"),
+    packageFilesYaml: z.string().trim().min(1, "Files YAML is required"),
+  }),
+]);
 
 export const Route = createFileRoute("/_app/runs-v2-new")({
   staticData: {

--- a/apps/codemode/src/routes/_app/runs-v2-new.tsx
+++ b/apps/codemode/src/routes/_app/runs-v2-new.tsx
@@ -6,6 +6,7 @@ import { ChevronLeft, ChevronRight, Eye, Sparkles } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@iterate-com/ui/components/button";
 import { Field, FieldDescription, FieldError, FieldLabel } from "@iterate-com/ui/components/field";
+import { Input } from "@iterate-com/ui/components/input";
 import {
   Sheet,
   SheetContent,
@@ -15,6 +16,14 @@ import {
 } from "@iterate-com/ui/components/sheet";
 import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
 import { z } from "zod";
+import type { CodemodeInput } from "@iterate-com/codemode-contract";
+import {
+  CODEMODE_PACKAGE_PROJECT_STARTER,
+  DEFAULT_CODEMODE_INPUT,
+  formatCodemodeProjectFilesYaml,
+  parseCodemodeProjectFilesYaml,
+} from "~/lib/codemode-input.ts";
+import { CodemodeNewRunSearch, resolveCodemodeSearchInput } from "~/lib/codemode-links.ts";
 import {
   CODEMODE_SOURCE_PRESETS,
   DEFAULT_CODEMODE_SOURCES,
@@ -23,12 +32,13 @@ import {
   parseCodemodeSourcesYaml,
   type CodemodeUiSource,
 } from "~/lib/codemode-sources.ts";
-import { CodemodeNewRunSearch, resolveCodemodeEditorCode } from "~/lib/codemode-links.ts";
-import { CODEMODE_V2_STARTER } from "~/lib/codemode-v2.ts";
 import { orpc, orpcClient } from "~/orpc/client.ts";
 
 const RunFunctionForm = z.object({
-  code: z.string().trim().min(1, "Code is required"),
+  mode: z.enum(["compiled-script", "package-project"]),
+  compiledScript: z.string().trim().min(1, "Script is required"),
+  packageEntryPoint: z.string().trim().min(1, "Entry point is required"),
+  packageFilesYaml: z.string().trim().min(1, "Files YAML is required"),
 });
 
 export const Route = createFileRoute("/_app/runs-v2-new")({
@@ -48,6 +58,7 @@ function NewRunPage() {
   const [sourcesYaml, setSourcesYaml] = useState(
     () => search.sources ?? DEFAULT_CODEMODE_SOURCES_YAML,
   );
+  const initialInput = resolveCodemodeSearchInput(search);
   const parsedSources = parseSourcesYamlSafely(sourcesYaml);
   const selectedSources = parsedSources.ok ? parsedSources.sources : DEFAULT_CODEMODE_SOURCES;
 
@@ -62,16 +73,15 @@ function NewRunPage() {
   });
 
   const runMutation = useMutation({
-    mutationFn: (input: { code: string; sources: CodemodeUiSource[] }) => orpcClient.runV2(input),
+    mutationFn: (input: { input: CodemodeInput; sources: CodemodeUiSource[] }) =>
+      orpcClient.runV2(input),
     onError: (error) => {
       toast.error(readErrorMessage(error));
     },
   });
 
   const form = useForm({
-    defaultValues: {
-      code: resolveCodemodeEditorCode(search.code),
-    },
+    defaultValues: createFormDefaults(initialInput),
     validators: {
       onChange: RunFunctionForm,
       onSubmit: RunFunctionForm,
@@ -82,8 +92,14 @@ function NewRunPage() {
         return;
       }
 
+      const input = buildCodemodeInputFromForm(value);
+      if (!input.ok) {
+        toast.error(input.error);
+        return;
+      }
+
       const run = await runMutation.mutateAsync({
-        code: value.code.trim(),
+        input: input.value,
         sources: parsedSources.sources,
       });
 
@@ -104,6 +120,21 @@ function NewRunPage() {
     toast.success(`Added ${readSourceTitle(source)}`);
   };
 
+  const resetStarter = () => {
+    const mode = form.getFieldValue("mode");
+
+    if (mode === "package-project") {
+      form.setFieldValue("packageEntryPoint", CODEMODE_PACKAGE_PROJECT_STARTER.entryPoint);
+      form.setFieldValue(
+        "packageFilesYaml",
+        formatCodemodeProjectFilesYaml(CODEMODE_PACKAGE_PROJECT_STARTER.files),
+      );
+      return;
+    }
+
+    form.setFieldValue("compiledScript", DEFAULT_CODEMODE_INPUT.script);
+  };
+
   return (
     <section className="space-y-6 p-4">
       <div className="flex items-start justify-between gap-4">
@@ -113,9 +144,9 @@ function NewRunPage() {
             <span>Codemode</span>
           </div>
           <p className="max-w-4xl text-sm text-muted-foreground">
-            Write the codemode function in TypeScript. Define <code>ctx</code> with YAML on the
-            right. The YAML is the real source model, and the type sheet updates from the current
-            valid source set.
+            Switch between a single compiled script and a package-backed file tree. Both run with
+            the same injected <code>ctx</code>, and package mode can bundle npm imports like{" "}
+            <code>openai</code>.
           </p>
         </div>
 
@@ -130,13 +161,7 @@ function NewRunPage() {
           <Button type="button" variant="outline" render={<Link to="/examples" />}>
             Examples
           </Button>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => {
-              form.setFieldValue("code", CODEMODE_V2_STARTER);
-            }}
-          >
+          <Button type="button" variant="outline" onClick={resetStarter}>
             Reset starter
           </Button>
           <Button
@@ -171,9 +196,36 @@ function NewRunPage() {
         >
           <div className="space-y-3">
             <div className="flex items-center justify-between gap-3">
-              <div>
-                <FieldLabel htmlFor="codemode-source">Codemode snippet</FieldLabel>
-                <FieldDescription>Return a value to save it with the run.</FieldDescription>
+              <div className="space-y-2">
+                <div>
+                  <FieldLabel>Runtime input</FieldLabel>
+                  <FieldDescription>
+                    Choose whether codemode should run a single module or bundle a package project.
+                  </FieldDescription>
+                </div>
+
+                <form.Subscribe selector={(state) => state.values.mode}>
+                  {(mode) => (
+                    <div className="inline-flex rounded-lg border bg-muted/40 p-1">
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant={mode === "compiled-script" ? "secondary" : "ghost"}
+                        onClick={() => form.setFieldValue("mode", "compiled-script")}
+                      >
+                        Compiled script
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant={mode === "package-project" ? "secondary" : "ghost"}
+                        onClick={() => form.setFieldValue("mode", "package-project")}
+                      >
+                        Package project
+                      </Button>
+                    </div>
+                  )}
+                </form.Subscribe>
               </div>
 
               <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting] as const}>
@@ -185,24 +237,81 @@ function NewRunPage() {
               </form.Subscribe>
             </div>
 
-            <form.Field name="code">
-              {(field) => {
-                const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
+            <form.Subscribe selector={(state) => state.values.mode}>
+              {(mode) =>
+                mode === "package-project" ? (
+                  <div className="space-y-3">
+                    <Field>
+                      <FieldLabel htmlFor="package-entry-point">Entry point</FieldLabel>
+                      <FieldDescription>
+                        This file is imported as the project entry. Export a default async function
+                        or a named <code>run</code>.
+                      </FieldDescription>
+                      <form.Field name="packageEntryPoint">
+                        {(field) => (
+                          <Input
+                            id="package-entry-point"
+                            value={field.state.value}
+                            onChange={(event) => field.handleChange(event.target.value)}
+                          />
+                        )}
+                      </form.Field>
+                    </Field>
 
-                return (
-                  <Field data-invalid={isInvalid}>
-                    <SourceCodeBlock
-                      code={field.state.value}
-                      language="typescript"
-                      editable={true}
-                      onChange={field.handleChange}
-                      className="min-h-[42rem]"
-                    />
-                    {isInvalid ? <FieldError errors={field.state.meta.errors} /> : null}
-                  </Field>
-                );
-              }}
-            </form.Field>
+                    <form.Field name="packageFilesYaml">
+                      {(field) => {
+                        const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
+
+                        return (
+                          <Field data-invalid={isInvalid}>
+                            <FieldLabel htmlFor="package-files">Project files YAML</FieldLabel>
+                            <FieldDescription>
+                              Include <code>package.json</code> plus source files. Use{" "}
+                              <code>
+                                getIterateSecret(&#123; secretKey: &quot;...&quot; &#125;)
+                              </code>{" "}
+                              inside your entry function for API keys.
+                            </FieldDescription>
+                            <SourceCodeBlock
+                              code={field.state.value}
+                              language="text"
+                              editable={true}
+                              onChange={field.handleChange}
+                              className="min-h-[42rem]"
+                            />
+                            {isInvalid ? <FieldError errors={field.state.meta.errors} /> : null}
+                          </Field>
+                        );
+                      }}
+                    </form.Field>
+                  </div>
+                ) : (
+                  <form.Field name="compiledScript">
+                    {(field) => {
+                      const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
+
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="codemode-source">Compiled script</FieldLabel>
+                          <FieldDescription>
+                            Paste a bundled module or a bare async function. Export default or a
+                            named <code>run</code> for full module mode.
+                          </FieldDescription>
+                          <SourceCodeBlock
+                            code={field.state.value}
+                            language="typescript"
+                            editable={true}
+                            onChange={field.handleChange}
+                            className="min-h-[42rem]"
+                          />
+                          {isInvalid ? <FieldError errors={field.state.meta.errors} /> : null}
+                        </Field>
+                      );
+                    }}
+                  </form.Field>
+                )
+              }
+            </form.Subscribe>
           </div>
 
           {isSourcesOpen ? (
@@ -293,6 +402,54 @@ function NewRunPage() {
   );
 }
 
+function createFormDefaults(input: CodemodeInput) {
+  if (input.type === "package-project") {
+    return {
+      mode: input.type,
+      compiledScript: DEFAULT_CODEMODE_INPUT.script,
+      packageEntryPoint: input.entryPoint,
+      packageFilesYaml: formatCodemodeProjectFilesYaml(input.files),
+    } as const;
+  }
+
+  return {
+    mode: input.type,
+    compiledScript: input.script,
+    packageEntryPoint: CODEMODE_PACKAGE_PROJECT_STARTER.entryPoint,
+    packageFilesYaml: formatCodemodeProjectFilesYaml(CODEMODE_PACKAGE_PROJECT_STARTER.files),
+  } as const;
+}
+
+function buildCodemodeInputFromForm(value: z.infer<typeof RunFunctionForm>) {
+  if (value.mode === "package-project") {
+    const parsedFiles = parseCodemodeProjectFilesYaml(value.packageFilesYaml);
+
+    if (!parsedFiles.ok) {
+      return {
+        ok: false as const,
+        error: parsedFiles.error,
+      };
+    }
+
+    return {
+      ok: true as const,
+      value: {
+        type: "package-project" as const,
+        entryPoint: value.packageEntryPoint.trim(),
+        files: parsedFiles.files,
+      },
+    };
+  }
+
+  return {
+    ok: true as const,
+    value: {
+      type: "compiled-script" as const,
+      script: value.compiledScript.trim(),
+    },
+  };
+}
+
 function parseSourcesYamlSafely(yamlText: string) {
   try {
     return {
@@ -318,6 +475,7 @@ function readSourceTitle(source: CodemodeUiSource) {
 
   return source.namespace?.trim() || source.url;
 }
+
 function readErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error);
 }

--- a/apps/codemode/src/routes/_app/runs/$runId.tsx
+++ b/apps/codemode/src/routes/_app/runs/$runId.tsx
@@ -2,6 +2,7 @@ import { Link, createFileRoute } from "@tanstack/react-router";
 import { Button } from "@iterate-com/ui/components/button";
 import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
 import { cn } from "@iterate-com/ui/lib/utils";
+import { codemodeInputLanguage } from "~/lib/codemode-input.ts";
 import { buildCodemodeNewRunSearch } from "~/lib/codemode-links.ts";
 import { formatCodemodeSourcesYaml } from "~/lib/codemode-sources.ts";
 import { summarizeCodeSnippet } from "~/lib/run-preview.ts";
@@ -57,7 +58,7 @@ function RunDetailPage() {
               <Link
                 to="/runs-v2-new"
                 search={buildCodemodeNewRunSearch({
-                  code: run.codeSnippet,
+                  input: run.input,
                   sources: run.sources,
                 })}
               />
@@ -100,7 +101,11 @@ function RunDetailPage() {
 
       <div className="space-y-2 border-t pt-6">
         <p className="text-sm font-medium">Code</p>
-        <SourceCodeBlock code={run.codeSnippet} language="typescript" className="min-h-[20rem]" />
+        <SourceCodeBlock
+          code={run.codeSnippet}
+          language={codemodeInputLanguage(run.input)}
+          className="min-h-[20rem]"
+        />
       </div>
 
       <div className="space-y-2 border-t pt-6">

--- a/apps/codemode/src/routes/_app/secrets.$secretId.tsx
+++ b/apps/codemode/src/routes/_app/secrets.$secretId.tsx
@@ -25,15 +25,12 @@ function SecretDetailPage() {
     <section className="max-w-md space-y-4 p-4">
       <div className="space-y-1">
         <p className="text-sm font-semibold">{secret.key}</p>
-        <p className="text-sm text-muted-foreground">Secret detail.</p>
+        <p className="text-sm text-muted-foreground">
+          Secret metadata only. Raw values are never returned after creation.
+        </p>
       </div>
 
       <div className="space-y-4 rounded-lg border p-4">
-        <div className="space-y-1">
-          <p className="text-xs text-muted-foreground">Value</p>
-          <p className="font-mono text-sm break-all">{secret.value}</p>
-        </div>
-
         {secret.description ? (
           <div className="space-y-1">
             <p className="text-xs text-muted-foreground">Description</p>

--- a/apps/codemode/src/routes/_app/secrets.index.tsx
+++ b/apps/codemode/src/routes/_app/secrets.index.tsx
@@ -130,7 +130,9 @@ function SecretsIndexPage() {
                     aria-invalid={isInvalid}
                     placeholder="token-or-password"
                   />
-                  <FieldDescription>Shown only on the detail page.</FieldDescription>
+                  <FieldDescription>
+                    Stored now, but never returned by codemode after creation.
+                  </FieldDescription>
                   {isInvalid ? <FieldError errors={field.state.meta.errors} /> : null}
                 </Field>
               );

--- a/apps/events/src/durable-objects/scheduling.test.ts
+++ b/apps/events/src/durable-objects/scheduling.test.ts
@@ -202,12 +202,14 @@ describe("scheduler control events", () => {
 
     await runDurableObjectAlarm(streamStub);
 
-    const history = await streamStub.history();
-    const finishedEvent = history.find(
-      (event) => event.type === SCHEDULE_INTERNAL_EXECUTION_FINISHED_TYPE,
-    );
+    const finishedEvent = await waitForCondition(async () => {
+      const history = await streamStub.history();
+      return (
+        history.find((event) => event.type === SCHEDULE_INTERNAL_EXECUTION_FINISHED_TYPE) || false
+      );
+    });
 
-    expect(finishedEvent?.payload).toEqual({
+    expect(finishedEvent.payload).toEqual({
       slug,
       outcome: "failed",
       nextRunAt: null,
@@ -234,12 +236,14 @@ describe("scheduler control events", () => {
 
     await runDurableObjectAlarm(streamStub);
 
-    const history = await streamStub.history();
-    const finishedEvent = history.find(
-      (event) => event.type === SCHEDULE_INTERNAL_EXECUTION_FINISHED_TYPE,
-    );
+    const finishedEvent = await waitForCondition(async () => {
+      const history = await streamStub.history();
+      return (
+        history.find((event) => event.type === SCHEDULE_INTERNAL_EXECUTION_FINISHED_TYPE) || false
+      );
+    });
 
-    expect(finishedEvent?.payload).toEqual({
+    expect(finishedEvent.payload).toEqual({
       slug,
       outcome: "failed",
       nextRunAt: null,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
       '@cloudflare/codemode':
         specifier: ^0.3.2
         version: 0.3.2(ai@6.0.33(zod@4.3.6))(zod@4.3.6)
+      '@cloudflare/worker-bundler':
+        specifier: ^0.0.4
+        version: 0.0.4
       '@iterate-com/codemode-contract':
         specifier: workspace:*
         version: link:../codemode-contract
@@ -1918,7 +1921,7 @@ importers:
         version: 3.19.19
       evlog:
         specifier: ^1.8.0
-        version: 1.11.0(nitro@3.0.260311-beta(@libsql/client@0.17.0)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(chokidar@5.0.0)(dotenv@17.3.1)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260317.1)(@libsql/client@0.17.0)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.11)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1))(jiti@2.6.1)(lru-cache@11.2.6)(miniflare@4.20260205.0)(mysql2@3.18.2(@types/node@25.3.3))(rollup@4.59.0)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(react@19.2.4)
+        version: 1.11.0(nitro@3.0.260311-beta(@libsql/client@0.17.0)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(chokidar@5.0.0)(dotenv@17.3.1)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260317.1)(@libsql/client@0.17.0)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.11)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1))(jiti@2.6.1)(lru-cache@11.2.6)(miniflare@4.20260205.0)(mysql2@3.18.2(@types/node@25.3.3))(rollup@4.59.0)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(ofetch@2.0.0-alpha.3)(react@19.2.4)
       hono:
         specifier: ^4.10.7
         version: 4.12.5
@@ -2594,7 +2597,7 @@ importers:
         version: 1.2.15(rollup@4.59.0)
       evlog:
         specifier: ^1.8.0
-        version: 1.11.0(nitro@3.0.260311-beta(@libsql/client@0.17.0)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(chokidar@5.0.0)(dotenv@17.3.1)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260317.1)(@libsql/client@0.17.0)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.11)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1))(jiti@2.6.1)(lru-cache@11.2.6)(miniflare@4.20260205.0)(mysql2@3.18.2(@types/node@25.3.3))(rollup@4.59.0)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(react@19.2.4)
+        version: 1.11.0(nitro@3.0.260311-beta(@libsql/client@0.17.0)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(chokidar@5.0.0)(dotenv@17.3.1)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260317.1)(@libsql/client@0.17.0)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.11)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1))(jiti@2.6.1)(lru-cache@11.2.6)(miniflare@4.20260205.0)(mysql2@3.18.2(@types/node@25.3.3))(rollup@4.59.0)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(ofetch@2.0.0-alpha.3)(react@19.2.4)
       hono:
         specifier: ^4.12.5
         version: 4.12.5
@@ -3499,6 +3502,10 @@ packages:
       '@vitest/runner': ^4.1.0
       '@vitest/snapshot': ^4.1.0
       vitest: ^4.1.0
+
+  '@cloudflare/worker-bundler@0.0.4':
+    resolution: {integrity: sha512-v+WyDWgD7wpcnJr8YAAsGBWMfEZf/mHNTQ+Cye0b0luD+6fN8/5AZIo3RB0444JFGaD2ZZGai5kxgpJrypsbEA==}
+    engines: {node: '>=22'}
 
   '@cloudflare/workerd-darwin-64@1.20260205.0':
     resolution: {integrity: sha512-ToOItqcirmWPwR+PtT+Q4bdjTn/63ZxhJKEfW4FNn7FxMTS1Tw5dml0T0mieOZbCpcvY8BdvPKFCSlJuI8IVHQ==}
@@ -11511,6 +11518,11 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
 
+  esbuild-wasm@0.27.4:
+    resolution: {integrity: sha512-3xhVMcJ8Odvb1QjlWnjBGSYVYESsi3/oJYwLyVvbHOb2CiV4mFtD6x8Lk6JFnRxwEE3fUeVuJLbIxyVQWa867g==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
     engines: {node: '>=12'}
@@ -14931,6 +14943,10 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve.exports@2.0.3:
+    resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
+    engines: {node: '>=10'}
+
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
@@ -18060,6 +18076,15 @@ snapshots:
       - '@cloudflare/workers-types'
       - bufferutil
       - utf-8-validate
+
+  '@cloudflare/worker-bundler@0.0.4':
+    dependencies:
+      es-module-lexer: 2.0.0
+      esbuild-wasm: 0.27.4
+      resolve.exports: 2.0.3
+      semver: 7.7.4
+      smol-toml: 1.6.1
+      sucrase: 3.35.1
 
   '@cloudflare/workerd-darwin-64@1.20260205.0':
     optional: true
@@ -25206,7 +25231,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@vitest/ui@4.0.15)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(msw@2.12.10(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/ui@4.0.15)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(msw@2.12.10(@types/node@25.3.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -27073,6 +27098,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esbuild-wasm@0.27.4: {}
+
   esbuild@0.18.20:
     optionalDependencies:
       '@esbuild/android-arm': 0.18.20
@@ -27454,9 +27481,10 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
-  evlog@1.11.0(nitro@3.0.260311-beta(@libsql/client@0.17.0)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(chokidar@5.0.0)(dotenv@17.3.1)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260317.1)(@libsql/client@0.17.0)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.11)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1))(jiti@2.6.1)(lru-cache@11.2.6)(miniflare@4.20260205.0)(mysql2@3.18.2(@types/node@25.3.3))(rollup@4.59.0)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(react@19.2.4):
+  evlog@1.11.0(nitro@3.0.260311-beta(@libsql/client@0.17.0)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(chokidar@5.0.0)(dotenv@17.3.1)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260317.1)(@libsql/client@0.17.0)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.11)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1))(jiti@2.6.1)(lru-cache@11.2.6)(miniflare@4.20260205.0)(mysql2@3.18.2(@types/node@25.3.3))(rollup@4.59.0)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(ofetch@2.0.0-alpha.3)(react@19.2.4):
     optionalDependencies:
       nitro: 3.0.260311-beta(@libsql/client@0.17.0)(aws4fetch@1.0.20)(better-sqlite3@12.6.2)(chokidar@5.0.0)(dotenv@17.3.1)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260317.1)(@libsql/client@0.17.0)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.11)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1))(jiti@2.6.1)(lru-cache@11.2.6)(miniflare@4.20260205.0)(mysql2@3.18.2(@types/node@25.3.3))(rollup@4.59.0)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      ofetch: 2.0.0-alpha.3
       react: 19.2.4
 
   execa@9.6.1:
@@ -31489,6 +31517,8 @@ snapshots:
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve.exports@2.0.3: {}
 
   resolve@1.22.11:
     dependencies:


### PR DESCRIPTION
## What changed
- added structured codemode inputs so runs can execute either a raw compiled script or a package-backed project with `package.json`, files, and an entry point
- bundled package-project inputs with `@cloudflare/worker-bundler` and updated the codemode UI and run persistence to handle both modes
- changed `getIterateSecret(...)` so codemode snippets only receive the sentinel string and never the real secret value
- kept real secret resolution in the codemode outbound worker, which substitutes sentinel references only at egress time
- added live codemode e2e coverage proving both that snippets only see the sentinel and that an `openai` package-project can still call OpenAI successfully via the outbound gateway

## Why
The previous codemode secret path exposed the actual secret value to user code. That breaks the intended isolation boundary. Codemode should behave like the events dynamic worker flow: snippets can reference secrets, but only outbound egress resolves them.

This PR also finishes the package-project execution shape so codemode snippets can import packages such as the OpenAI SDK and run them through the worker bundler.

## Impact
- codemode users can switch between compiled-script and package-project inputs
- package-project snippets can import `openai`
- secrets remain opaque to user code and are only materialized in outbound requests
- the live e2e proof now covers the real OpenAI flow end to end

## Validation
- `pnpm --filter @iterate-com/codemode typecheck`
- `CODEMODE_BASE_URL=http://localhost:5173 OPENAI_API_KEY=... pnpm test:e2e`
- direct proof run returned a sentinel `visibleValue` and a successful OpenAI response from the same snippet
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iterate/iterate/pull/1259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes codemode execution/bundling and secret-handling boundaries, including API contract changes and removal of secret values from responses. Mistakes could break run execution, persistence/backward compatibility, or inadvertently leak secrets.
> 
> **Overview**
> Adds a new structured `CodemodeInput` (either `compiled-script` or `package-project` with `package.json` + file map) and updates the `runV2` contract, UI, and run persistence to send/store this input instead of a raw code string.
> 
> Switches execution to bundle package-project inputs via `@cloudflare/worker-bundler` and refactors the dynamic worker executor to run arbitrary module bundles with a generated internal executor module, including safeguards against user module collisions.
> 
> Hardens secrets by removing secret `value` from the `secrets.find` response/UI and by making `getIterateSecret(...)` return only a sentinel string to user code; real secret substitution remains in the outbound egress path. Adds unit tests for input serialization/YAML parsing and live e2e tests proving sentinel-only visibility, executor-collision resistance, and an end-to-end OpenAI package-project call without leaking the API key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00b6c246be942a6f35fdbefb28e9938e3e5a4607. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW_ENVIRONMENTS -->
## Preview Environments
<!-- CLOUDFLARE_PREVIEW_ENVIRONMENTS_STATE -->
<!--
{
  "events": {
    "appDisplayName": "Events",
    "appSlug": "events",
    "status": "released",
    "updatedAt": "2026-04-09T15:09:03.097Z",
    "leasedUntil": null,
    "headSha": "9d9e139d3d3b8b8040c2ee528f4d36d4a3bb5d98",
    "message": "Semaphore lease was already gone.",
    "previewEnvironmentAlchemyStageName": null,
    "previewEnvironmentDopplerConfigName": null,
    "previewEnvironmentIdentifier": null,
    "previewEnvironmentSemaphoreLeaseId": null,
    "previewEnvironmentSlug": null,
    "previewEnvironmentType": null,
    "publicUrl": "https://events-preview-1.iterate.workers.dev",
    "runUrl": "https://github.com/iterate/iterate/actions/runs/24148647827",
    "shortSha": "9d9e139"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_ENVIRONMENTS_STATE -->

### Events
Status: released
Commit: `9d9e139`
Preview: https://events-preview-1.iterate.workers.dev
Summary: Semaphore lease was already gone.
[Workflow run](https://github.com/iterate/iterate/actions/runs/24148647827)
Updated: 2026-04-09T15:09:03.097Z
<!-- /CLOUDFLARE_PREVIEW_ENVIRONMENTS -->