### PR TITLE
[codex] rewrite events circuit breaker as token bucket

### DIFF
--- a/apps/events-contract/src/circuit-breaker-types.ts
+++ b/apps/events-contract/src/circuit-breaker-types.ts
@@ -32,7 +32,8 @@ export const CircuitBreakerState = z.object({
   paused: z.boolean(),
   pauseReason: z.string().nullable(),
   pausedAt: z.string().nullable(),
-  recentEventTimestamps: z.array(z.string()),
+  availableTokens: z.number(),
+  lastRefillAtMs: z.number().int().nonnegative().nullable(),
 });
 export type CircuitBreakerState = z.infer<typeof CircuitBreakerState>;
 

--- a/apps/events-contract/src/types.test.ts
+++ b/apps/events-contract/src/types.test.ts
@@ -13,7 +13,8 @@ describe("StreamState", () => {
           paused: false,
           pauseReason: null,
           pausedAt: null,
-          recentEventTimestamps: [],
+          availableTokens: 100,
+          lastRefillAtMs: null,
         },
         "jsonata-transformer": {
           transformersBySlug: {},
@@ -21,6 +22,13 @@ describe("StreamState", () => {
       },
     });
 
+    expect(parsed.processors["circuit-breaker"]).toEqual({
+      paused: false,
+      pauseReason: null,
+      pausedAt: null,
+      availableTokens: 100,
+      lastRefillAtMs: null,
+    });
     expect(parsed.processors["dynamic-worker"]).toEqual({
       workersBySlug: {},
     });

--- a/apps/events/e2e/vitest/auth.e2.test.ts
+++ b/apps/events/e2e/vitest/auth.e2.test.ts
@@ -59,7 +59,7 @@ describe.sequential("events auth-adjacent e2e", () => {
         eventCount: 2,
         childPaths: [],
         metadata: {},
-        processors: expectedProcessorsWithRecentEventCount(2),
+        processors: expectedProcessorsWithTokenBucketCircuitBreaker(),
       });
       expect(await projectStateResponse.json()).toEqual({
         projectSlug: "team-a",
@@ -67,7 +67,7 @@ describe.sequential("events auth-adjacent e2e", () => {
         eventCount: 2,
         childPaths: [],
         metadata: {},
-        processors: expectedProcessorsWithRecentEventCount(2),
+        processors: expectedProcessorsWithTokenBucketCircuitBreaker(),
       });
 
       const defaultProjectHistoryResponse = await app.fetch(`/api/streams/${routePathFor(path)}`);
@@ -123,13 +123,14 @@ function routePathFor(path: StreamPath) {
   return path === "/" ? "%2F" : path.slice(1).replaceAll("/", "%2F");
 }
 
-function expectedProcessorsWithRecentEventCount(count: number) {
+function expectedProcessorsWithTokenBucketCircuitBreaker() {
   return {
     "circuit-breaker": {
       paused: false,
       pauseReason: null,
       pausedAt: null,
-      recentEventTimestamps: Array.from({ length: count }, () => expect.any(String)),
+      availableTokens: expect.any(Number),
+      lastRefillAtMs: expect.any(Number),
     },
     "external-subscriber": {
       subscribersBySlug: {},

--- a/apps/events/e2e/vitest/curl-smoketest.e2e.test.ts
+++ b/apps/events/e2e/vitest/curl-smoketest.e2e.test.ts
@@ -131,7 +131,8 @@ curl -sS "$BASE_URL/api/streams/__state/%2F" -H "x-iterate-project: $PROJECT_SLU
           paused: false,
           pauseReason: null,
           pausedAt: null,
-          recentEventTimestamps: ["<ts>", "<ts>"],
+          availableTokens: expect.any(Number),
+          lastRefillAtMs: expect.any(Number),
         },
         "external-subscriber": {
           subscribersBySlug: {},
@@ -156,7 +157,8 @@ curl -sS "$BASE_URL/api/streams/__state/%2F" -H "x-iterate-project: $PROJECT_SLU
           paused: false,
           pauseReason: null,
           pausedAt: null,
-          recentEventTimestamps: ["<ts>", "<ts>"],
+          availableTokens: expect.any(Number),
+          lastRefillAtMs: expect.any(Number),
         },
         "external-subscriber": {
           subscribersBySlug: {},

--- a/apps/events/e2e/vitest/dynamic-worker-poc.e2e.test.ts
+++ b/apps/events/e2e/vitest/dynamic-worker-poc.e2e.test.ts
@@ -125,7 +125,8 @@ describe("dynamic worker processor", () => {
             paused: false,
             pauseReason: null,
             pausedAt: null,
-            recentEventTimestamps: Array.from({ length: 7 }, () => expect.any(String)),
+            availableTokens: expect.any(Number),
+            lastRefillAtMs: expect.any(Number),
           },
           "dynamic-worker": {
             workersBySlug: {

--- a/apps/events/e2e/vitest/runtime-smoke.e2e.test.ts
+++ b/apps/events/e2e/vitest/runtime-smoke.e2e.test.ts
@@ -145,7 +145,7 @@ describeRuntimeSmoke("events runtime smoke", () => {
         eventCount: 2,
         childPaths: [],
         metadata: {},
-        processors: expectedProcessorsWithRecentEventCount(2),
+        processors: expectedProcessorsWithTokenBucketCircuitBreaker(),
       });
 
       const rootHistoryResponse = await app.fetch("/api/streams/%2F");
@@ -216,13 +216,14 @@ function expectedStoredOffset(value: number) {
   return value + 1;
 }
 
-function expectedProcessorsWithRecentEventCount(count: number) {
+function expectedProcessorsWithTokenBucketCircuitBreaker() {
   return {
     "circuit-breaker": {
       paused: false,
       pauseReason: null,
       pausedAt: null,
-      recentEventTimestamps: Array.from({ length: count }, () => expect.any(String)),
+      availableTokens: expect.any(Number),
+      lastRefillAtMs: expect.any(Number),
     },
     "external-subscriber": {
       subscribersBySlug: {},

--- a/apps/events/e2e/vitest/stream.e2e.test.ts
+++ b/apps/events/e2e/vitest/stream.e2e.test.ts
@@ -381,7 +381,7 @@ describe.sequential("events stream e2e", () => {
         streamPath: path,
         type: "https://events.iterate.com/events/stream/paused",
         payload: {
-          reason: "circuit breaker tripped: 100 events in under 1 second",
+          reason: "circuit breaker tripped: burst rate limit exceeded",
         },
       });
 
@@ -512,7 +512,7 @@ describe.sequential("events stream e2e", () => {
         eventCount: 1,
         childPaths: [],
         metadata: {},
-        processors: expectedProcessorsWithRecentEventCount(1),
+        processors: expectedProcessorsWithTokenBucketCircuitBreaker(),
       });
       expect(await collectStreamEvents(app, { path })).toEqual([]);
       expect(await collectAllStreamEvents(app, { path })).toMatchObject([
@@ -621,7 +621,7 @@ describe.sequential("events stream e2e", () => {
         eventCount: 1,
         childPaths: [],
         metadata: {},
-        processors: expectedProcessorsWithRecentEventCount(1),
+        processors: expectedProcessorsWithTokenBucketCircuitBreaker(),
       });
     },
     testTimeoutMs,
@@ -702,7 +702,7 @@ describe.sequential("events stream e2e", () => {
         metadata: {
           owner: "second",
         },
-        processors: expectedProcessorsWithRecentEventCount(4),
+        processors: expectedProcessorsWithTokenBucketCircuitBreaker(),
       });
     },
     testTimeoutMs,
@@ -1381,13 +1381,14 @@ function expectedStoredOffset(value: number) {
   return value + 1;
 }
 
-function expectedProcessorsWithRecentEventCount(count: number) {
+function expectedProcessorsWithTokenBucketCircuitBreaker() {
   return {
     "circuit-breaker": {
       paused: false,
       pauseReason: null,
       pausedAt: null,
-      recentEventTimestamps: Array.from({ length: count }, () => expect.any(String)),
+      availableTokens: expect.any(Number),
+      lastRefillAtMs: expect.any(Number),
     },
     "external-subscriber": {
       subscribersBySlug: {},
@@ -1501,7 +1502,7 @@ async function tripCircuitBreaker(appFixture: Events2AppFixture, path: StreamPat
       typeof event.payload === "object" &&
       event.payload !== null &&
       "reason" in event.payload &&
-      event.payload.reason === "circuit breaker tripped: 100 events in under 1 second",
+      event.payload.reason === "circuit breaker tripped: burst rate limit exceeded",
   );
 }
 

--- a/apps/events/src/durable-objects/circuit-breaker.test.ts
+++ b/apps/events/src/durable-objects/circuit-breaker.test.ts
@@ -7,19 +7,22 @@ import {
 import { circuitBreakerProcessor } from "./circuit-breaker.ts";
 
 describe("circuitBreaker", () => {
-  test("reduce tracks recent event timestamps", () => {
+  test("reduce spends a token for the first event", () => {
     const state = structuredClone(circuitBreakerProcessor.initialState);
 
     const nextState = circuitBreakerProcessor.reduce!({
       state,
-      event: createEvent({ createdAt: "2026-04-02T12:00:00.000Z" }),
+      event: createEvent({
+        createdAt: "2026-04-02T12:00:00.000Z",
+      }),
     });
 
     expect(nextState).toEqual({
-      recentEventTimestamps: ["2026-04-02T12:00:00.000Z"],
       paused: false,
       pauseReason: null,
       pausedAt: null,
+      availableTokens: 99,
+      lastRefillAtMs: Date.parse("2026-04-02T12:00:00.000Z"),
     });
   });
 
@@ -78,7 +81,8 @@ describe("circuitBreaker", () => {
       paused: true,
       pauseReason: "too hot",
       pausedAt: "2026-04-02T12:00:00.000Z",
-      recentEventTimestamps: ["2026-04-02T12:00:00.000Z"],
+      availableTokens: 100,
+      lastRefillAtMs: Date.parse("2026-04-02T12:00:00.000Z"),
     });
 
     const resumedState = circuitBreakerProcessor.reduce!({
@@ -94,16 +98,71 @@ describe("circuitBreaker", () => {
       paused: false,
       pauseReason: null,
       pausedAt: null,
-      recentEventTimestamps: ["2026-04-02T12:00:05.000Z"],
+      availableTokens: 100,
+      lastRefillAtMs: Date.parse("2026-04-02T12:00:05.000Z"),
     });
   });
 
-  test("afterAppend auto-appends a pause event when 100 events arrive in under one second", async () => {
-    const appended: EventInput[] = [];
+  test("reduce refills the bucket over time", () => {
+    const state = circuitBreakerProcessor.reduce!({
+      state: structuredClone(circuitBreakerProcessor.initialState),
+      event: createEvent({
+        createdAt: "2026-04-02T12:00:00.000Z",
+      }),
+    });
+
+    const nextState = circuitBreakerProcessor.reduce!({
+      state,
+      event: createEvent({
+        createdAt: "2026-04-02T12:00:00.500Z",
+        offset: 2,
+      }),
+    });
+
+    expect(nextState).toEqual({
+      paused: false,
+      pauseReason: null,
+      pausedAt: null,
+      availableTokens: 99,
+      lastRefillAtMs: Date.parse("2026-04-02T12:00:00.500Z"),
+    });
+  });
+
+  test("reduce drives the bucket negative during a rapid burst", () => {
+    let state = structuredClone(circuitBreakerProcessor.initialState);
+
+    for (let index = 0; index < 101; index += 1) {
+      state = circuitBreakerProcessor.reduce!({
+        state,
+        event: createEvent({
+          createdAt: "2026-04-02T12:00:00.000Z",
+          offset: index + 1,
+        }),
+      });
+    }
+
+    expect(state.availableTokens).toBeLessThan(0);
+  });
+
+  test("reduce stays within budget for slower sustained traffic", () => {
+    let state = structuredClone(circuitBreakerProcessor.initialState);
     const base = Date.parse("2026-04-02T12:00:00.000Z");
-    const recentEventTimestamps = Array.from({ length: 100 }, (_, index) =>
-      new Date(base + index * 9).toISOString(),
-    );
+
+    for (let index = 0; index < 105; index += 1) {
+      state = circuitBreakerProcessor.reduce!({
+        state,
+        event: createEvent({
+          createdAt: new Date(base + index * 20).toISOString(),
+          offset: index + 1,
+        }),
+      });
+    }
+
+    expect(state.availableTokens).toBeGreaterThanOrEqual(0);
+  });
+
+  test("afterAppend auto-appends a pause event when the bucket goes negative", async () => {
+    const appended: EventInput[] = [];
 
     await circuitBreakerProcessor.afterAppend?.({
       append: (event) => {
@@ -113,14 +172,13 @@ describe("circuitBreaker", () => {
           payload: event.payload,
         });
       },
-      event: createEvent({
-        createdAt: recentEventTimestamps[99],
-      }),
+      event: createEvent(),
       state: {
         paused: false,
         pauseReason: null,
         pausedAt: null,
-        recentEventTimestamps,
+        availableTokens: -1,
+        lastRefillAtMs: Date.parse("2026-04-02T12:00:00.000Z"),
       },
     });
 
@@ -128,29 +186,25 @@ describe("circuitBreaker", () => {
       {
         type: "https://events.iterate.com/events/stream/paused",
         payload: {
-          reason: "circuit breaker tripped: 100 events in under 1 second",
+          reason: "circuit breaker tripped: burst rate limit exceeded",
         },
       },
     ]);
   });
 
   test("afterAppend rejects when append fails", async () => {
-    const base = Date.parse("2026-04-02T12:00:00.000Z");
-    const recentEventTimestamps = Array.from({ length: 100 }, (_, index) =>
-      new Date(base + index * 9).toISOString(),
-    );
-
     await expect(
       circuitBreakerProcessor.afterAppend?.({
         append: () => {
           throw new Error("sqlite write failed");
         },
-        event: createEvent({ createdAt: recentEventTimestamps[99] }),
+        event: createEvent(),
         state: {
           paused: false,
           pauseReason: null,
           pausedAt: null,
-          recentEventTimestamps,
+          availableTokens: -1,
+          lastRefillAtMs: Date.parse("2026-04-02T12:00:00.000Z"),
         },
       }),
     ).rejects.toThrow("sqlite write failed");

--- a/apps/events/src/durable-objects/circuit-breaker.ts
+++ b/apps/events/src/durable-objects/circuit-breaker.ts
@@ -13,9 +13,24 @@ const refillRatePerMs = maxEventsPerSecond / 1_000;
  * Rate-limiting circuit breaker for event streams.
  *
  * Uses a token bucket so the reducer can approximate burst rate limiting with
- * constant-size state. Each event spends one token, and the bucket refills at
- * `maxEventsPerSecond`. When a write pushes the bucket below zero, the stream
- * auto-appends "stream/paused".
+ * constant-size state.
+ *
+ * The mental model is:
+ * - the bucket starts full, so a stream can absorb a short burst immediately
+ * - tokens refill continuously at `maxEventsPerSecond`
+ * - every appended event spends one token
+ * - if an event arrives after the bucket is already empty, the reducer records
+ *   a negative balance and `afterAppend` turns that into `stream/paused`
+ *
+ * In practice this means the processor allows roughly `maxEventsPerSecond`
+ * sustained throughput with a burst budget of about the same size, while only
+ * persisting two rate-limiter fields:
+ * - `availableTokens`
+ * - `lastRefillAtMs`
+ *
+ * That tradeoff is deliberate. This is a circuit breaker, not billing-grade
+ * metering, so approximate burst control with O(1) state is a better fit than
+ * storing one timestamp per recent event.
  *
  * Token bucket gives a bounded burst budget with O(1) state rather than an
  * exact sliding window that grows with the threshold. Primary references:
@@ -67,6 +82,10 @@ export const circuitBreakerProcessor = defineBuiltinProcessor<CircuitBreakerStat
       };
     }
 
+    // Rebuild the current bucket level from the last persisted balance plus
+    // the time that has elapsed since then. We cap at `maxEventsPerSecond`
+    // because idle time should restore the full burst budget, not accumulate
+    // unbounded credit.
     const refilledTokens =
       state.lastRefillAtMs == null
         ? maxEventsPerSecond
@@ -77,6 +96,9 @@ export const circuitBreakerProcessor = defineBuiltinProcessor<CircuitBreakerStat
 
     return {
       ...state,
+      // Spending one token here means the reducer has already decided whether
+      // this append stayed within budget. `afterAppend` only has to look for a
+      // negative balance and emit the pause event.
       availableTokens: refilledTokens - 1,
       lastRefillAtMs: createdAtMs,
     };

--- a/apps/events/src/durable-objects/circuit-breaker.ts
+++ b/apps/events/src/durable-objects/circuit-breaker.ts
@@ -6,12 +6,21 @@ import {
 } from "@iterate-com/events-contract";
 import { defineBuiltinProcessor } from "@iterate-com/events-contract/sdk";
 
+const maxEventsPerSecond = 100;
+const refillRatePerMs = maxEventsPerSecond / 1_000;
+
 /**
  * Rate-limiting circuit breaker for event streams.
  *
- * Tracks the last 100 event timestamps in state. When all 100 fall within a
- * single second, it auto-appends a "stream/paused" event, which causes
- * `beforeAppend` to reject all subsequent writes (except "stream/resumed").
+ * Uses a token bucket so the reducer can approximate burst rate limiting with
+ * constant-size state. Each event spends one token, and the bucket refills at
+ * `maxEventsPerSecond`. When a write pushes the bucket below zero, the stream
+ * auto-appends "stream/paused".
+ *
+ * Token bucket gives a bounded burst budget with O(1) state rather than an
+ * exact sliding window that grows with the threshold. Primary references:
+ * - RFC 1363: https://datatracker.ietf.org/doc/rfc1363/
+ * - RFC 3290 Appendix A: https://datatracker.ietf.org/doc/html/rfc3290
  *
  * This prevents runaway producers from flooding a stream while still allowing
  * an operator to resume manually.
@@ -22,7 +31,8 @@ export const circuitBreakerProcessor = defineBuiltinProcessor<CircuitBreakerStat
     paused: false,
     pauseReason: null,
     pausedAt: null,
-    recentEventTimestamps: [],
+    availableTokens: maxEventsPerSecond,
+    lastRefillAtMs: null,
   },
 
   beforeAppend({ event, state }) {
@@ -35,13 +45,15 @@ export const circuitBreakerProcessor = defineBuiltinProcessor<CircuitBreakerStat
   },
 
   reduce({ event, state }) {
+    const createdAtMs = Date.parse(event.createdAt);
     const pausedEvent = StreamPausedEvent.safeParse(event);
     if (pausedEvent.success) {
       return {
         paused: true,
         pauseReason: pausedEvent.data.payload.reason ?? null,
         pausedAt: event.createdAt,
-        recentEventTimestamps: [event.createdAt],
+        availableTokens: maxEventsPerSecond,
+        lastRefillAtMs: createdAtMs,
       };
     }
 
@@ -50,26 +62,33 @@ export const circuitBreakerProcessor = defineBuiltinProcessor<CircuitBreakerStat
         paused: false,
         pauseReason: null,
         pausedAt: null,
-        recentEventTimestamps: [event.createdAt],
+        availableTokens: maxEventsPerSecond,
+        lastRefillAtMs: createdAtMs,
       };
     }
 
+    const refilledTokens =
+      state.lastRefillAtMs == null
+        ? maxEventsPerSecond
+        : Math.min(
+            maxEventsPerSecond,
+            state.availableTokens + (createdAtMs - state.lastRefillAtMs) * refillRatePerMs,
+          );
+
     return {
       ...state,
-      recentEventTimestamps: [...state.recentEventTimestamps, event.createdAt].slice(-100),
+      availableTokens: refilledTokens - 1,
+      lastRefillAtMs: createdAtMs,
     };
   },
 
   async afterAppend({ append, state }) {
-    if (state.paused || state.recentEventTimestamps.length < 100) return;
-
-    const first = Date.parse(state.recentEventTimestamps[0]);
-    const last = Date.parse(state.recentEventTimestamps[state.recentEventTimestamps.length - 1]);
-    if (last - first >= 1_000) return;
+    if (state.paused) return;
+    if (state.availableTokens >= 0) return;
 
     await append({
       type: "https://events.iterate.com/events/stream/paused",
-      payload: { reason: "circuit breaker tripped: 100 events in under 1 second" },
+      payload: { reason: "circuit breaker tripped: burst rate limit exceeded" },
     });
   },
 }));

--- a/apps/events/src/lib/event-type-pages.ts
+++ b/apps/events/src/lib/event-type-pages.ts
@@ -452,7 +452,7 @@ export const streamPausedPage = {
   type: "https://events.iterate.com/events/stream/paused",
   summary: "Built-in control event that marks a stream as temporarily rejecting new events.",
   payloadExample: {
-    reason: "circuit breaker tripped: 100 events in under 1 second",
+    reason: "circuit breaker tripped: burst rate limit exceeded",
   },
   details: [
     "While paused, the durable object rejects all new appends except `stream/resumed`.",


### PR DESCRIPTION
## What changed

This rewrites the `apps/events` circuit breaker processor to use a reducer-only token bucket instead of storing recent timestamps.

The processor state is now constant-size:
- `availableTokens`
- `lastRefillAtMs`
- existing pause metadata

Each append spends one token, the bucket refills over time, and the stream auto-pauses when a burst drives the balance below zero.

## Why it changed

The previous implementation kept per-event timestamp history in reduced state. That approach does not scale cleanly as the threshold increases, and it made the processor state noisier than it needed to be.

A token bucket gives the right behavior for this circuit breaker:
- fast bursts trip the stream
- slower sustained traffic stays within budget
- higher limits like `1000 rps` can be supported by changing constants rather than growing state linearly with the threshold

## Impact

This is an intentional breaking change to the circuit breaker state shape.

User-visible behavior is now approximate burst limiting rather than an exact sliding-window rule, and the pause reason text was updated to:

`circuit breaker tripped: burst rate limit exceeded`

## Validation

- `pnpm --dir apps/events exec vitest run src/durable-objects/circuit-breaker.test.ts`
- `pnpm --dir apps/events typecheck`
- `pnpm --dir apps/events-contract typecheck`

## Root cause

The old design encoded rate limiting as an exact sliding window over persisted timestamps. That made the state size proportional to the configured threshold, which is the wrong tradeoff for a circuit breaker.

<!-- CLOUDFLARE_PREVIEW_ENVIRONMENTS -->
## Preview Environments
<!-- CLOUDFLARE_PREVIEW_ENVIRONMENTS_STATE -->
<!--
{
  "events": {
    "appDisplayName": "Events",
    "appSlug": "events",
    "status": "released",
    "updatedAt": "2026-04-08T16:51:53.421Z",
    "leasedUntil": null,
    "headSha": "bd999ca747480d377fadc6f45725b3643732f629",
    "message": "Preview environment released.",
    "previewEnvironmentAlchemyStageName": null,
    "previewEnvironmentDopplerConfigName": null,
    "previewEnvironmentIdentifier": null,
    "previewEnvironmentSemaphoreLeaseId": null,
    "previewEnvironmentSlug": null,
    "previewEnvironmentType": null,
    "publicUrl": "https://events-preview-1.iterate.workers.dev",
    "runUrl": "https://github.com/iterate/iterate/actions/runs/24145909431",
    "shortSha": "bd999ca"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_ENVIRONMENTS_STATE -->

### Events
Status: released
Commit: `bd999ca`
Preview: https://events-preview-1.iterate.workers.dev
Summary: Preview environment released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/24145909431)
Updated: 2026-04-08T16:51:53.421Z
<!-- /CLOUDFLARE_PREVIEW_ENVIRONMENTS -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iterate/iterate/pull/1261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core stream write-path rate limiting and the persisted `circuit-breaker` reduced-state shape; mistakes could cause unintended pausing (or failure to pause) and require state migration/rehydration compatibility.
> 
> **Overview**
> Rewrites the stream `circuit-breaker` processor from a sliding-window timestamp list to a constant-size token bucket (`availableTokens`, `lastRefillAtMs`) and updates the auto-pause trigger to fire when the bucket goes negative.
> 
> Updates the contract schema and all affected unit/e2e assertions to match the new state shape, and changes the emitted pause reason string to `circuit breaker tripped: burst rate limit exceeded` (including docs/event type page examples).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd999ca747480d377fadc6f45725b3643732f629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->