### PR TITLE
[codex] rename stream offset cursors

### DIFF
--- a/ai-engineer-workshop/lib/test-helpers.ts
+++ b/ai-engineer-workshop/lib/test-helpers.ts
@@ -68,7 +68,7 @@ export async function useProcessorTestHarness<TState>({
   async function collectEvents() {
     const events: Event[] = [];
 
-    for await (const event of await client.stream({ path, before: "end" }, {})) {
+    for await (const event of await client.stream({ path, beforeOffset: "end" }, {})) {
       events.push(event);
     }
 
@@ -113,14 +113,16 @@ export async function useProcessorTestHarness<TState>({
       };
 
       try {
-        await consume(await client.stream({ path, before: "end" }, { signal: controller.signal }));
+        await consume(
+          await client.stream({ path, beforeOffset: "end" }, { signal: controller.signal }),
+        );
 
         if (matchedEvent == null) {
           await consume(
             await client.stream(
               {
                 path,
-                after: lastOffset ?? "start",
+                afterOffset: lastOffset ?? "start",
               },
               { signal: controller.signal },
             ),

--- a/ai-engineer-workshop/test-helpers.ts
+++ b/ai-engineer-workshop/test-helpers.ts
@@ -71,7 +71,10 @@ export function createWorkshopTestHarness({
     },
     async collectEvents(streamPath: StreamPath) {
       const events: Event[] = [];
-      for await (const event of await client.stream({ path: streamPath, before: "end" }, {})) {
+      for await (const event of await client.stream(
+        { path: streamPath, beforeOffset: "end" },
+        {},
+      )) {
         events.push(event);
       }
       return events;

--- a/ai-engineer-workshop/workshop/03-nano-agent-with-persistent-history.ts
+++ b/ai-engineer-workshop/workshop/03-nano-agent-with-persistent-history.ts
@@ -33,7 +33,7 @@ export const handler = os.handler(async ({ context, input }) => {
   const history: ResponseInput = [];
   let lastSeenOffset: number | undefined;
 
-  for await (const event of await client.stream({ path: streamPath, before: "end" }, {})) {
+  for await (const event of await client.stream({ path: streamPath, beforeOffset: "end" }, {})) {
     lastSeenOffset = event.offset;
     updateHistoryFromEvent(history, event);
   }
@@ -41,7 +41,7 @@ export const handler = os.handler(async ({ context, input }) => {
   context.logger.info(`Watching ${streamPath} with ${history.length} history items`);
 
   for await (const event of await client.stream(
-    { path: streamPath, after: lastSeenOffset ?? "start" },
+    { path: streamPath, afterOffset: lastSeenOffset ?? "start" },
     {},
   )) {
     if (event.offset === lastSeenOffset) continue;

--- a/ai-engineer-workshop/workshop/04-nano-agent-with-persistent-history.ts
+++ b/ai-engineer-workshop/workshop/04-nano-agent-with-persistent-history.ts
@@ -33,7 +33,7 @@ export const handler = os.handler(async ({ context, input }) => {
   const history: ResponseInput = [];
   let lastSeenOffset: number | undefined;
 
-  for await (const event of await client.stream({ path: streamPath, before: "end" }, {})) {
+  for await (const event of await client.stream({ path: streamPath, beforeOffset: "end" }, {})) {
     lastSeenOffset = event.offset;
     updateHistoryFromEvent(history, event);
   }
@@ -41,7 +41,7 @@ export const handler = os.handler(async ({ context, input }) => {
   context.logger.info(`Watching ${streamPath} with ${history.length} history items`);
 
   for await (const event of await client.stream(
-    { path: streamPath, after: lastSeenOffset ?? "start" },
+    { path: streamPath, afterOffset: lastSeenOffset ?? "start" },
     {},
   )) {
     if (event.offset === lastSeenOffset) continue;

--- a/ai-engineer-workshop/workshop2/03-nano-agent-with-persistent-history.ts
+++ b/ai-engineer-workshop/workshop2/03-nano-agent-with-persistent-history.ts
@@ -34,7 +34,7 @@ try {
   const history: ResponseInput = [];
   let lastSeenOffset: number | undefined;
 
-  for await (const event of await client.stream({ path: streamPath, before: "end" }, {})) {
+  for await (const event of await client.stream({ path: streamPath, beforeOffset: "end" }, {})) {
     lastSeenOffset = event.offset;
     updateHistoryFromEvent(history, event);
   }
@@ -42,7 +42,7 @@ try {
   console.log(`Watching ${streamPath} with ${history.length} history items`);
 
   for await (const event of await client.stream(
-    { path: streamPath, after: lastSeenOffset ?? "start" },
+    { path: streamPath, afterOffset: lastSeenOffset ?? "start" },
     {},
   )) {
     if (event.offset === lastSeenOffset) continue;

--- a/ai-engineer-workshop/workshop2/04-nano-agent-with-persistent-history.ts
+++ b/ai-engineer-workshop/workshop2/04-nano-agent-with-persistent-history.ts
@@ -34,7 +34,7 @@ try {
   const history: ResponseInput = [];
   let lastSeenOffset: number | undefined;
 
-  for await (const event of await client.stream({ path: streamPath, before: "end" }, {})) {
+  for await (const event of await client.stream({ path: streamPath, beforeOffset: "end" }, {})) {
     lastSeenOffset = event.offset;
     updateHistoryFromEvent(history, event);
   }
@@ -42,7 +42,7 @@ try {
   console.log(`Watching ${streamPath} with ${history.length} history items`);
 
   for await (const event of await client.stream(
-    { path: streamPath, after: lastSeenOffset ?? "start" },
+    { path: streamPath, afterOffset: lastSeenOffset ?? "start" },
     {},
   )) {
     if (event.offset === lastSeenOffset) continue;

--- a/apps/events-contract/src/orpc-contract.test.ts
+++ b/apps/events-contract/src/orpc-contract.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   EventInput,
   InvalidEventAppendedEventInput,
+  StreamQuery,
   StreamMetadataUpdatedEventInput,
   StreamPath,
 } from "./types.ts";
@@ -65,6 +66,25 @@ const clientBuiltInEvent: ClientAppendArgs = {
 };
 
 void clientBuiltInEvent;
+
+assert.deepEqual(
+  StreamQuery.parse({
+    afterOffset: 1,
+    beforeOffset: 2,
+  }),
+  {
+    afterOffset: 1,
+    beforeOffset: 2,
+  },
+);
+
+assert.equal(
+  StreamQuery.safeParse({
+    after: 1,
+    before: 2,
+  }).success,
+  false,
+);
 
 assert.equal(
   EventInput.safeParse({

--- a/apps/events-contract/src/orpc-contract.ts
+++ b/apps/events-contract/src/orpc-contract.ts
@@ -95,7 +95,7 @@ export const eventsContract = oc.router({
       operationId: "streamEvents",
       method: "GET",
       path: "/streams/{+path}",
-      description: `Reads events from a stream using exclusive \`after\` / \`before\` cursors. \`start\` and \`end\` are virtual bookends outside the event space. Omitting \`before\` keeps the connection open for future events; setting \`before\` returns a finite stream. ${PathMungingDescription} For example, \`GET /api/streams/team/inbox\`, \`GET /api/streams/team%2Finbox\`, and \`GET /api/streams/%2Fteam%2Finbox\` all target the same stream. The root stream is addressed canonically as \`GET /api/streams/%2F\`.`,
+      description: `Reads events from a stream using exclusive \`afterOffset\` / \`beforeOffset\` cursors. They are strictly non-inclusive: \`afterOffset=1&beforeOffset=2\` returns no events, which is expected because offset 1 is excluded and offset 2 is also excluded. \`start\` and \`end\` are virtual bookends outside the event space. Omitting \`beforeOffset\` keeps the connection open for future events; setting \`beforeOffset\` returns a finite stream. ${PathMungingDescription} For example, \`GET /api/streams/team/inbox\`, \`GET /api/streams/team%2Finbox\`, and \`GET /api/streams/%2Fteam%2Finbox\` all target the same stream. The root stream is addressed canonically as \`GET /api/streams/%2F\`.`,
       tags: ["/streams"],
     })
     .input(

--- a/apps/events-contract/src/sdk.test.ts
+++ b/apps/events-contract/src/sdk.test.ts
@@ -520,6 +520,43 @@ async function testProcessorRuntimeStopDuringHistoryDoesNotEnterLivePhase() {
   assert.equal(client.liveStreamStarted, false);
 }
 
+async function testStreamQueryOffsetsAreStrictlyExclusive() {
+  const streamPath = StreamPath.parse("/exclusive");
+  const client = new MockEventsClient({
+    [streamPath]: [
+      makeInitializedEvent({ streamPath, offset: 1 }),
+      makeGenericEvent({
+        streamPath,
+        offset: 2,
+        type: "tick",
+        payload: { source: "history-2" },
+      }),
+      makeGenericEvent({
+        streamPath,
+        offset: 3,
+        type: "tick",
+        payload: { source: "history-3" },
+      }),
+    ],
+  });
+
+  const historyStream = await client.stream(
+    {
+      path: streamPath,
+      afterOffset: 1,
+      beforeOffset: 2,
+    },
+    {},
+  );
+
+  const history: Event[] = [];
+  for await (const event of historyStream) {
+    history.push(event);
+  }
+
+  assert.deepEqual(history, []);
+}
+
 async function testPushRuntimeCatchesUpAndAppendsWithCanonicalProcessorContract() {
   const streamPath = StreamPath.parse("/push/demo");
   const client = new MockEventsClient({
@@ -892,20 +929,20 @@ class MockEventsClient {
   }
 
   async stream(
-    input: { path: StreamPathType; after?: StreamCursor; before?: StreamCursor },
+    input: { path: StreamPathType; afterOffset?: StreamCursor; beforeOffset?: StreamCursor },
     options: { signal?: AbortSignal },
   ) {
     const pathEvents = this.#eventsByPath.get(input.path) ?? [];
     const endOffset = pathEvents.at(-1)?.offset ?? 0;
     const history = (this.#eventsByPath.get(input.path) ?? []).filter(
       (event) =>
-        event.offset > resolveAfterCursor(input.after, endOffset) &&
-        event.offset < resolveBeforeCursor(input.before, endOffset),
+        event.offset > resolveAfterCursor(input.afterOffset, endOffset) &&
+        event.offset < resolveBeforeCursor(input.beforeOffset, endOffset),
     );
 
     return this.#iterate({
       history,
-      live: input.before == null,
+      live: input.beforeOffset == null,
       path: input.path,
       signal: options.signal,
     });
@@ -1005,10 +1042,10 @@ class SlowHistoryEventsClient {
   }
 
   async stream(
-    input: { path: StreamPathType; after?: StreamCursor; before?: StreamCursor },
+    input: { path: StreamPathType; afterOffset?: StreamCursor; beforeOffset?: StreamCursor },
     options: { signal?: AbortSignal },
   ) {
-    if (input.before == null) {
+    if (input.beforeOffset == null) {
       this.liveStreamStarted = true;
       return waitForever(options.signal);
     }
@@ -1044,15 +1081,15 @@ class SlowPatternHistoryEventsClient extends MockEventsClient {
   }
 
   override async stream(
-    input: { path: StreamPathType; after?: StreamCursor; before?: StreamCursor },
+    input: { path: StreamPathType; afterOffset?: StreamCursor; beforeOffset?: StreamCursor },
     options: { signal?: AbortSignal },
   ) {
-    if (input.path === this.#childPath && input.before == null) {
+    if (input.path === this.#childPath && input.beforeOffset == null) {
       this.childLiveStreamStarted = true;
       return waitForever(options.signal);
     }
 
-    if (input.path === this.#childPath && input.before != null) {
+    if (input.path === this.#childPath && input.beforeOffset != null) {
       return this.#childHistory(options.signal);
     }
 
@@ -1072,16 +1109,20 @@ class SlowPatternHistoryEventsClient extends MockEventsClient {
 
 class InclusiveOffsetMockEventsClient extends MockEventsClient {
   override async stream(
-    input: { path: StreamPathType; after?: StreamCursor; before?: StreamCursor },
+    input: { path: StreamPathType; afterOffset?: StreamCursor; beforeOffset?: StreamCursor },
     options: { signal?: AbortSignal },
   ) {
     const inclusiveAfter =
-      typeof input.after !== "number" ? input.after : input.after <= 1 ? "start" : input.after - 1;
+      typeof input.afterOffset !== "number"
+        ? input.afterOffset
+        : input.afterOffset <= 1
+          ? "start"
+          : input.afterOffset - 1;
 
     return super.stream(
       {
         ...input,
-        after: inclusiveAfter,
+        afterOffset: inclusiveAfter,
       },
       options,
     );
@@ -1277,6 +1318,7 @@ await testProcessorAppendResolvesCurrentAbsoluteAndRelativePaths();
 await testProcessorAppendRejectsInvalidRelativePaths();
 await testProcessorRuntimeStopDuringHistoryDoesNotEnterLivePhase();
 await testPatternRuntimeStopDuringHistoryWaitsForChildrenToExit();
+await testStreamQueryOffsetsAreStrictlyExclusive();
 await testPushRuntimeCatchesUpAndAppendsWithCanonicalProcessorContract();
 await testPushRuntimeSerializesOutOfOrderDeliveriesWithoutDoubleReducingHistory();
 await testPushRuntimeSkipsInclusiveCatchUpEventsAtLastProcessedOffset();

--- a/apps/events-contract/src/sdk.ts
+++ b/apps/events-contract/src/sdk.ts
@@ -86,7 +86,7 @@ type PullSubscriptionEventsClient = {
     event: Event;
   }>;
   stream: (
-    input: { path: StreamPath; after?: StreamCursor; before?: StreamCursor },
+    input: { path: StreamPath; afterOffset?: StreamCursor; beforeOffset?: StreamCursor },
     options: { signal?: AbortSignal },
   ) => Promise<AsyncIterable<Event>>;
 };
@@ -153,7 +153,7 @@ export class PullSubscriptionProcessorRuntime<State> {
       const historyStream = await this.#eventsClient.stream(
         {
           path: this.#streamPath,
-          before: "end",
+          beforeOffset: "end",
         },
         { signal: this.#controller.signal },
       );
@@ -184,7 +184,7 @@ export class PullSubscriptionProcessorRuntime<State> {
       const liveStream = await this.#eventsClient.stream(
         {
           path: this.#streamPath,
-          after: toLiveTailCursor(lastOffset),
+          afterOffset: toLiveTailCursor(lastOffset),
         },
         {
           signal: this.#controller.signal,
@@ -340,8 +340,8 @@ export class PushSubscriptionProcessorRuntime<State> {
     const historyStream = await this.#eventsClient.stream(
       {
         path: this.#streamPath,
-        after: this.#lastOffset > 0 ? this.#lastOffset : "start",
-        before: targetOffset,
+        afterOffset: this.#lastOffset > 0 ? this.#lastOffset : "start",
+        beforeOffset: targetOffset,
       },
       {},
     );
@@ -420,7 +420,7 @@ export class PullSubscriptionPatternProcessorRuntime<State> {
       const historyStream = await this.#eventsClient.stream(
         {
           path: "/",
-          before: "end",
+          beforeOffset: "end",
         },
         { signal: this.#controller.signal },
       );
@@ -449,7 +449,7 @@ export class PullSubscriptionPatternProcessorRuntime<State> {
       const liveStream = await this.#eventsClient.stream(
         {
           path: "/",
-          after: toLiveTailCursor(lastOffset),
+          afterOffset: toLiveTailCursor(lastOffset),
         },
         {
           signal: this.#controller.signal,

--- a/apps/events-contract/src/types.ts
+++ b/apps/events-contract/src/types.ts
@@ -54,10 +54,12 @@ export const StreamCursor = z.union([
 ]);
 export type StreamCursor = z.infer<typeof StreamCursor>;
 
-export const StreamQuery = z.object({
-  after: StreamCursor.optional(),
-  before: StreamCursor.optional(),
-});
+export const StreamQuery = z
+  .object({
+    afterOffset: StreamCursor.optional(),
+    beforeOffset: StreamCursor.optional(),
+  })
+  .strict();
 export type StreamQuery = z.infer<typeof StreamQuery>;
 
 const StreamInitializedEventInput = GenericEventInputBase.extend({

--- a/apps/events/e2e/vitest/curl-smoketest.e2e.test.ts
+++ b/apps/events/e2e/vitest/curl-smoketest.e2e.test.ts
@@ -15,7 +15,7 @@
  *   curl -sS "$BASE_URL/api/streams/__state/$STREAM_RPATH"
  *   echo
  *   echo '---'
- *   curl -sS -N "$BASE_URL/api/streams/$STREAM_CURL_PATH?before=end"
+ *   curl -sS -N "$BASE_URL/api/streams/$STREAM_CURL_PATH?beforeOffset=end"
  *   echo
  *   echo '---'
  *   curl -sS "$BASE_URL/api/streams/__children/%2F" >/dev/null
@@ -75,7 +75,7 @@ echo '---'
 retry_json_get "$BASE_URL/api/streams/__state/$STREAM_RPATH" -H "x-iterate-project: $PROJECT_SLUG"
 echo
 echo '---'
-curl -sS -N "$BASE_URL/api/streams/$STREAM_CURL_PATH?before=end" -H "x-iterate-project: $PROJECT_SLUG"
+curl -sS -N "$BASE_URL/api/streams/$STREAM_CURL_PATH?beforeOffset=end" -H "x-iterate-project: $PROJECT_SLUG"
 echo
 echo '---'
 curl -sS "$BASE_URL/api/streams/__children/%2F" -H "x-iterate-project: $PROJECT_SLUG" >/dev/null

--- a/apps/events/e2e/vitest/dynamic-worker-egress.e2e.test.ts
+++ b/apps/events/e2e/vitest/dynamic-worker-egress.e2e.test.ts
@@ -257,7 +257,7 @@ async function waitForEchoEvent(path: StreamPath, ordinal: number) {
 
 async function readHistory(path: StreamPath) {
   return (await collectAsyncIterableUntilIdle({
-    iterable: await app.client.stream({ path, before: "end" }),
+    iterable: await app.client.stream({ path, beforeOffset: "end" }),
     idleMs: 500,
   })) as Event[];
 }

--- a/apps/events/e2e/vitest/dynamic-worker-restart.local.e2e.test.ts
+++ b/apps/events/e2e/vitest/dynamic-worker-restart.local.e2e.test.ts
@@ -307,7 +307,7 @@ async function waitForEventCounts(args: {
 async function readHistory(path: StreamPath) {
   const app = createEvents2AppFixture({ baseURL: localBaseUrl });
   return (await collectAsyncIterableUntilIdle({
-    iterable: await app.client.stream({ path, before: "end" }),
+    iterable: await app.client.stream({ path, beforeOffset: "end" }),
     idleMs: 500,
   })) as Event[];
 }

--- a/apps/events/e2e/vitest/runtime-smoke.e2e.test.ts
+++ b/apps/events/e2e/vitest/runtime-smoke.e2e.test.ts
@@ -105,7 +105,7 @@ describeRuntimeSmoke("events runtime smoke", () => {
       await waitForStream(path);
 
       const rootEvents = await collectAsyncIterableUntilIdle({
-        iterable: await app.client.stream({ path: "/", before: "end" }),
+        iterable: await app.client.stream({ path: "/", beforeOffset: "end" }),
         idleMs: rootHistoryIdleTimeoutMs,
       });
       expect(rootEvents[0]).toMatchObject({
@@ -121,7 +121,7 @@ describeRuntimeSmoke("events runtime smoke", () => {
       const events = await collectAsyncIterableUntilIdle({
         iterable: await app.client.stream({
           path,
-          before: "end",
+          beforeOffset: "end",
         }),
         idleMs: historyIdleTimeoutMs,
       });
@@ -148,7 +148,7 @@ describeRuntimeSmoke("events runtime smoke", () => {
         processors: expectedProcessorsWithTokenBucketCircuitBreaker(),
       });
 
-      const rootHistoryResponse = await app.fetch("/api/streams/%2F?before=end");
+      const rootHistoryResponse = await app.fetch("/api/streams/%2F?beforeOffset=end");
       expect(rootHistoryResponse.status).toBe(200);
       expect(await rootHistoryResponse.text()).toContain(
         "https://events.iterate.com/events/stream/initialized",
@@ -165,7 +165,7 @@ describeRuntimeSmoke("events runtime smoke", () => {
       const liveStream = await app.client.stream(
         {
           path,
-          after: expectedOffset(1),
+          afterOffset: expectedOffset(1),
         },
         { signal: controller.signal },
       );

--- a/apps/events/e2e/vitest/scheduling-delayed-controls.e2e.test.ts
+++ b/apps/events/e2e/vitest/scheduling-delayed-controls.e2e.test.ts
@@ -198,7 +198,7 @@ async function readHistory(path: StreamPath) {
   const events = await collectAsyncIterableUntilIdle({
     iterable: await app.client.stream({
       path,
-      before: "end",
+      beforeOffset: "end",
     }),
     idleMs: historyIdleTimeoutMs,
   });

--- a/apps/events/e2e/vitest/scheduling-recurring-restart.e2e.test.ts
+++ b/apps/events/e2e/vitest/scheduling-recurring-restart.e2e.test.ts
@@ -199,7 +199,7 @@ async function readHistory(path: StreamPath) {
   const events = await collectAsyncIterableUntilIdle({
     iterable: await app.client.stream({
       path,
-      before: "end",
+      beforeOffset: "end",
     }),
     idleMs: historyIdleTimeoutMs,
   });
@@ -219,7 +219,7 @@ async function readHistoryIncludingWake(path: StreamPath) {
   const events = await collectAsyncIterableUntilIdle({
     iterable: await app.client.stream({
       path,
-      before: "end",
+      beforeOffset: "end",
     }),
     idleMs: historyIdleTimeoutMs,
   });

--- a/apps/events/e2e/vitest/scheduling.e2e.test.ts
+++ b/apps/events/e2e/vitest/scheduling.e2e.test.ts
@@ -228,7 +228,7 @@ async function readHistory(path: StreamPath) {
   const events = await collectAsyncIterableUntilIdle({
     iterable: await app.client.stream({
       path,
-      before: "end",
+      beforeOffset: "end",
     }),
     idleMs: historyIdleTimeoutMs,
   });

--- a/apps/events/e2e/vitest/stream.e2e.test.ts
+++ b/apps/events/e2e/vitest/stream.e2e.test.ts
@@ -576,7 +576,7 @@ describe.sequential("events stream e2e", () => {
       const stream = await app.client.stream(
         {
           path,
-          after: first.event.offset,
+          afterOffset: first.event.offset,
         },
         { signal: controller.signal },
       );
@@ -630,7 +630,7 @@ describe.sequential("events stream e2e", () => {
     "root uses the same stream and state procedures as every other path",
     async () => {
       const rootHistory = await collectAsyncIterableUntilIdle({
-        iterable: await app.client.stream({ path: "/", before: "end" }),
+        iterable: await app.client.stream({ path: "/", beforeOffset: "end" }),
         idleMs: historyIdleTimeoutMs,
       });
 
@@ -640,7 +640,7 @@ describe.sequential("events stream e2e", () => {
         metadata: {},
       });
 
-      const escapedRootHistoryResponse = await app.fetch("/api/streams/%2F?before=end");
+      const escapedRootHistoryResponse = await app.fetch("/api/streams/%2F?beforeOffset=end");
       expect(escapedRootHistoryResponse.status).toBe(200);
       expect(await escapedRootHistoryResponse.text()).toContain(
         "https://events.iterate.com/events/stream/initialized",
@@ -721,8 +721,8 @@ describe.sequential("events stream e2e", () => {
         },
       });
 
-      const rawHistoryResponse = await app.fetch(`/api/streams${path}?before=end`);
-      const escapedHistoryResponse = await app.fetch(`/api/streams/${routePath}?before=end`);
+      const rawHistoryResponse = await app.fetch(`/api/streams${path}?beforeOffset=end`);
+      const escapedHistoryResponse = await app.fetch(`/api/streams/${routePath}?beforeOffset=end`);
 
       expect(rawHistoryResponse.status).toBe(200);
       expect(await escapedHistoryResponse.text()).toEqual(await rawHistoryResponse.text());
@@ -1099,7 +1099,7 @@ describe.sequential("events stream e2e", () => {
 
       const resumed = await collectStreamEvents(app, {
         path,
-        after: expectedOffset(1),
+        afterOffset: expectedOffset(1),
       });
 
       expect(resumed.map((event) => event.payload)).toEqual([{ step: 2 }, { step: 3 }]);
@@ -1180,7 +1180,7 @@ describe.sequential("events stream e2e", () => {
           payload: { invalid: true },
         }),
       });
-      const historyResponse = await app.fetch("/api/streams/e2e/__reserved?before=end");
+      const historyResponse = await app.fetch("/api/streams/e2e/__reserved?beforeOffset=end");
       const stateResponse = await app.fetch("/api/streams/__state/e2e/__reserved");
 
       expect(appendResponse.status).toBe(200);
@@ -1405,14 +1405,14 @@ async function collectStreamEvents(
   appFixture: Events2AppFixture,
   options: {
     path: StreamPath;
-    after?: number;
+    afterOffset?: number;
   },
 ) {
   const events = await collectAsyncIterableUntilIdle({
     iterable: await appFixture.client.stream({
       path: options.path,
-      after: options.after,
-      before: "end",
+      afterOffset: options.afterOffset,
+      beforeOffset: "end",
     }),
     idleMs: historyIdleTimeoutMs,
   });
@@ -1430,14 +1430,14 @@ async function collectAllStreamEvents(
   appFixture: Events2AppFixture,
   options: {
     path: StreamPath;
-    after?: number;
+    afterOffset?: number;
   },
 ) {
   return await collectAsyncIterableUntilIdle({
     iterable: await appFixture.client.stream({
       path: options.path,
-      after: options.after,
-      before: "end",
+      afterOffset: options.afterOffset,
+      beforeOffset: "end",
     }),
     idleMs: historyIdleTimeoutMs,
   });

--- a/apps/events/scripts/lib/dynamic-openai-proof.ts
+++ b/apps/events/scripts/lib/dynamic-openai-proof.ts
@@ -169,7 +169,7 @@ async function waitForEvent(args: {
 
 async function collectHistory(client: EventsClient, path: string) {
   return (await collectAsyncIterableUntilIdle({
-    iterable: (await client.stream({ path, before: "end" })) as AsyncIterable<Event>,
+    iterable: (await client.stream({ path, beforeOffset: "end" })) as AsyncIterable<Event>,
     idleMs: 500,
   })) as Event[];
 }

--- a/apps/events/scripts/lib/pushed-processor-proof.ts
+++ b/apps/events/scripts/lib/pushed-processor-proof.ts
@@ -155,7 +155,7 @@ async function waitForEvent(args: {
 
 async function collectHistory(client: EventsClient, path: string) {
   return (await collectAsyncIterableUntilIdle({
-    iterable: (await client.stream({ path, before: "end" })) as AsyncIterable<Event>,
+    iterable: (await client.stream({ path, beforeOffset: "end" })) as AsyncIterable<Event>,
     idleMs: 500,
   })) as Event[];
 }

--- a/apps/events/src/orpc/routers/streams.ts
+++ b/apps/events/src/orpc/routers/streams.ts
@@ -42,8 +42,8 @@ export const streamsRouter = {
     });
 
     const stream = await streamStub.stream({
-      after: input.after,
-      before: input.before,
+      after: input.afterOffset,
+      before: input.beforeOffset,
     });
 
     for await (const event of decodeEventStream(stream, signal)) {


### PR DESCRIPTION
## What changed
- renamed the stream query cursor fields in `apps/events-contract` from `after` / `before` to `afterOffset` / `beforeOffset`
- updated the oRPC contract, SDK stream input types, and internal call sites to use the new names consistently
- tightened `StreamQuery` with `.strict()` so stale `after` / `before` inputs are rejected instead of being silently ignored
- added tests that cover the renamed shape and the exclusive window behavior

## Why
The stream procedure is offset-based, so the old names were ambiguous. The new names make the API intent explicit and reduce the chance that callers misread the cursor semantics.

## Developer impact
Callers of the `apps/events-contract` stream procedure now need to pass `afterOffset` and `beforeOffset` instead of `after` and `before`.

## Root cause
The old parameter names were generic enough to suggest broader cursor semantics, and the schema was lenient about unknown keys, which meant stale query names could be accepted and ignored.

## Validation
- `pnpm test` in `apps/events-contract`
- explicit test coverage that `afterOffset: 1` and `beforeOffset: 2` returns no events because both bounds are exclusive
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iterate/iterate/pull/1263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the public stream query contract and makes `StreamQuery` strict, so any callers still sending `after`/`before` will now fail instead of being ignored.
> 
> **Overview**
> Renames the stream query cursor fields from `after`/`before` to **`afterOffset`/`beforeOffset`** across the events oRPC contract, SDK types/runtimes, workshop helpers, and server router wiring.
> 
> Tightens validation by making `StreamQuery` `.strict()` so stale cursor keys are rejected, updates docs/examples (curl + e2e tests), and adds/extends tests to assert the **strictly-exclusive** offset window semantics (e.g., `afterOffset=1&beforeOffset=2` returns no events).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8c8fcd88e3674ff6f53e0bea464eacb7b4b120c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW_ENVIRONMENTS -->
## Preview Environments
<!-- CLOUDFLARE_PREVIEW_ENVIRONMENTS_STATE -->
<!--
{
  "events": {
    "appDisplayName": "Events",
    "appSlug": "events",
    "status": "released",
    "updatedAt": "2026-04-13T09:07:05.744Z",
    "leasedUntil": null,
    "headSha": "e8c8fcd88e3674ff6f53e0bea464eacb7b4b120c",
    "message": "Semaphore lease was already gone.",
    "previewEnvironmentAlchemyStageName": null,
    "previewEnvironmentDopplerConfigName": null,
    "previewEnvironmentIdentifier": null,
    "previewEnvironmentSemaphoreLeaseId": null,
    "previewEnvironmentSlug": null,
    "previewEnvironmentType": null,
    "publicUrl": "https://events-preview-2.iterate.workers.dev",
    "runUrl": "https://github.com/iterate/iterate/actions/runs/24148743725",
    "shortSha": "e8c8fcd"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_ENVIRONMENTS_STATE -->

### Events
Status: released
Commit: `e8c8fcd`
Preview: https://events-preview-2.iterate.workers.dev
Summary: Semaphore lease was already gone.
[Workflow run](https://github.com/iterate/iterate/actions/runs/24148743725)
Updated: 2026-04-13T09:07:05.744Z
<!-- /CLOUDFLARE_PREVIEW_ENVIRONMENTS -->