### PR TITLE
[codex] Add codemode to Cloudflare preview registry

### DIFF
--- a/.github/workflows/cloudflare-previews.yml
+++ b/.github/workflows/cloudflare-previews.yml
@@ -29,6 +29,8 @@ jobs:
             github.log = { ...console, debug: () => {} };
             const vars = { github, context, core, glob, io, require };
             const previewPaths = [
+              "apps/codemode/**",
+              "apps/codemode-contract/**",
               "apps/example/**",
               "apps/events/**",
               "apps/semaphore/**",
@@ -72,6 +74,155 @@ jobs:
               return files.some((file) => matchesPreviewPath(file.filename)) ? "true" : "false";
             };
             return __handler(vars);
+  preview-codemode:
+    needs:
+      - scope
+    if: needs.scope.outputs.should_run == 'true' && github.event.action != 'closed'
+    name: Preview / codemode deploy
+    runs-on: ubuntu-24.04
+    concurrency:
+      group: cloudflare-preview-lifecycle-codemode-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Install Doppler CLI
+        run: |-
+          for i in 1 2 3; do curl -sfLS https://cli.doppler.com/install.sh | sh -s -- --no-package-manager && break; echo "Attempt $i failed, retrying in 5s..."; sleep 5; done
+          doppler --version || { echo 'Failed to install Doppler CLI after 3 attempts'; exit 1; }
+        if: github.event.pull_request.head.repo.fork != true
+      - if: github.event.pull_request.head.repo.fork == true
+        name: Preview / codemode deploy for forks
+        env:
+          GITHUB_TOKEN: ${{ secrets.ITERATE_BOT_GITHUB_TOKEN || github.token }}
+          SEMAPHORE_BASE_URL: https://semaphore.iterate.com
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |-
+          set -euo pipefail
+          pnpm preview deploy \
+            --app "codemode" \
+            --github-token "$GITHUB_TOKEN" \
+            --pull-request-head-ref-name "${{ github.event.pull_request.head.ref }}" \
+            --pull-request-head-sha "${{ github.event.pull_request.head.sha }}" \
+            --pull-request-base-sha "${{ github.event.pull_request.base.sha }}" \
+            --pull-request-number "${{ github.event.pull_request.number }}" \
+            --repository-full-name "${{ github.repository }}" \
+            --is-fork "${{ github.event.pull_request.head.repo.fork && 'true' || 'false' }}" \
+            --workflow-run-url "$WORKFLOW_RUN_URL" \
+            --semaphore-base-url "$SEMAPHORE_BASE_URL"
+      - if: github.event.pull_request.head.repo.fork != true
+        name: Preview / codemode deploy
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ITERATE_BOT_GITHUB_TOKEN || github.token }}
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |-
+          set -euo pipefail
+          doppler run --project os --config prd -- pnpm preview deploy \
+            --app "codemode" \
+            --github-token "$GITHUB_TOKEN" \
+            --pull-request-head-ref-name "${{ github.event.pull_request.head.ref }}" \
+            --pull-request-head-sha "${{ github.event.pull_request.head.sha }}" \
+            --pull-request-base-sha "${{ github.event.pull_request.base.sha }}" \
+            --pull-request-number "${{ github.event.pull_request.number }}" \
+            --repository-full-name "${{ github.repository }}" \
+            --is-fork "${{ github.event.pull_request.head.repo.fork && 'true' || 'false' }}" \
+            --workflow-run-url "$WORKFLOW_RUN_URL"
+  e2e-codemode:
+    needs:
+      - preview-codemode
+    if: needs.scope.outputs.should_run == 'true' && github.event.action != 'closed' && github.event.pull_request.head.repo.fork != true
+    name: Preview / codemode e2e
+    runs-on: ubuntu-24.04
+    concurrency:
+      group: cloudflare-preview-lifecycle-codemode-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Install Doppler CLI
+        run: |-
+          for i in 1 2 3; do curl -sfLS https://cli.doppler.com/install.sh | sh -s -- --no-package-manager && break; echo "Attempt $i failed, retrying in 5s..."; sleep 5; done
+          doppler --version || { echo 'Failed to install Doppler CLI after 3 attempts'; exit 1; }
+        if: github.event.pull_request.head.repo.fork != true
+      - if: github.event.pull_request.head.repo.fork != true
+        name: Preview / codemode e2e
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ITERATE_BOT_GITHUB_TOKEN || github.token }}
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |-
+          set -euo pipefail
+          doppler run --project os --config prd -- pnpm preview test \
+            --app "codemode" \
+            --github-token "$GITHUB_TOKEN" \
+            --pull-request-head-sha "${{ github.event.pull_request.head.sha }}" \
+            --pull-request-number "${{ github.event.pull_request.number }}" \
+            --repository-full-name "${{ github.repository }}" \
+            --workflow-run-url "$WORKFLOW_RUN_URL"
+  cleanup-codemode:
+    needs:
+      - scope
+    if: needs.scope.outputs.should_run == 'true' && github.event.action == 'closed' && github.event.pull_request.head.repo.fork != true
+    name: Preview / codemode cleanup
+    runs-on: ubuntu-24.04
+    concurrency:
+      group: cloudflare-preview-lifecycle-codemode-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Install Doppler CLI
+        run: |-
+          for i in 1 2 3; do curl -sfLS https://cli.doppler.com/install.sh | sh -s -- --no-package-manager && break; echo "Attempt $i failed, retrying in 5s..."; sleep 5; done
+          doppler --version || { echo 'Failed to install Doppler CLI after 3 attempts'; exit 1; }
+        if: github.event.pull_request.head.repo.fork != true
+      - if: github.event.pull_request.head.repo.fork != true
+        name: Preview / codemode cleanup
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ITERATE_BOT_GITHUB_TOKEN || github.token }}
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |-
+          set -euo pipefail
+          doppler run --project os --config prd -- pnpm preview cleanup \
+            --app "codemode" \
+            --github-token "$GITHUB_TOKEN" \
+            --pull-request-number "${{ github.event.pull_request.number }}" \
+            --repository-full-name "${{ github.repository }}"
   preview-example:
     needs:
       - scope

--- a/apps/codemode/e2e/vitest/live.e2e.test.ts
+++ b/apps/codemode/e2e/vitest/live.e2e.test.ts
@@ -54,6 +54,18 @@ async function ensureOpenAiSecret(client: OrpcClient) {
 }
 
 describe("live codemode", () => {
+  it("lists the OpenAI package-project example", async () => {
+    const baseUrl = requireCodemodeBaseUrl();
+
+    const response = await fetch(`${baseUrl}/examples`);
+    expect(response.status).toBe(200);
+
+    const body = await response.text();
+    expect(body).toContain("OpenAI Package Project");
+    expect(body).toContain("Package project");
+    expect(body).toContain("openai.apiKey");
+  });
+
   it("serves the new run page", async () => {
     const baseUrl = requireCodemodeBaseUrl();
 

--- a/apps/codemode/package.json
+++ b/apps/codemode/package.json
@@ -18,6 +18,7 @@
     "typecheck": "tsc --noEmit",
     "test": "pnpm typecheck",
     "test:e2e": "node -e \"if (!process.env.CODEMODE_BASE_URL) { console.error('CODEMODE_BASE_URL is required for codemode e2e tests'); process.exit(1); }\" && vitest run --config ./e2e/vitest.config.ts",
+    "test:e2e:preview": "pnpm test:e2e",
     "test:e2e:doppler": "node -e \"if (!process.env.CODEMODE_BASE_URL) { console.error('CODEMODE_BASE_URL is required for codemode e2e tests'); process.exit(1); } if (!process.env.DOPPLER_PROJECT || !process.env.DOPPLER_CONFIG) { console.error('DOPPLER_PROJECT and DOPPLER_CONFIG are required for codemode e2e Doppler runs'); process.exit(1); }\" && doppler run --project \"$DOPPLER_PROJECT\" --config \"$DOPPLER_CONFIG\" -- pnpm exec vitest run --config ./e2e/vitest.config.ts"
   },
   "dependencies": {

--- a/apps/codemode/src/lib/codemode-input.ts
+++ b/apps/codemode/src/lib/codemode-input.ts
@@ -3,45 +3,10 @@ import {
   type CodemodeInput,
   CodemodeInput as CodemodeInputSchema,
 } from "@iterate-com/codemode-contract";
+import { CODEMODE_OPENAI_PACKAGE_PROJECT_INPUT } from "~/lib/codemode-package-project-openai.ts";
 import { CODEMODE_V2_STARTER } from "~/lib/codemode-v2.ts";
 
-export const CODEMODE_PACKAGE_PROJECT_STARTER = CodemodeInputSchema.parse({
-  type: "package-project",
-  entryPoint: "src/index.ts",
-  files: {
-    "package.json": JSON.stringify(
-      {
-        name: "codemode-openai-demo",
-        private: true,
-        type: "module",
-        dependencies: {
-          openai: "^6.0.0",
-        },
-      },
-      null,
-      2,
-    ),
-    "src/index.ts": `import OpenAI from "openai";
-
-export default async function ({ ctx, getIterateSecret }) {
-  const client = new OpenAI({
-    apiKey: await getIterateSecret({ secretKey: "openai.apiKey" }),
-  });
-
-  const routes = await ctx.ingressProxy.routes.list({ limit: 1, offset: 0 });
-  const response = await client.responses.create({
-    model: "gpt-4.1-mini",
-    input: "Reply with the single word ready.",
-  });
-
-  return {
-    routeCount: routes.total,
-    modelReply: response.output_text ?? null,
-  };
-}
-`,
-  },
-}) as Extract<CodemodeInput, { type: "package-project" }>;
+export const CODEMODE_PACKAGE_PROJECT_STARTER = CODEMODE_OPENAI_PACKAGE_PROJECT_INPUT;
 
 export const DEFAULT_CODEMODE_INPUT = CodemodeInputSchema.parse({
   type: "compiled-script",

--- a/apps/codemode/src/lib/codemode-package-project-openai.ts
+++ b/apps/codemode/src/lib/codemode-package-project-openai.ts
@@ -1,0 +1,40 @@
+import {
+  type CodemodeInput,
+  CodemodeInput as CodemodeInputSchema,
+} from "@iterate-com/codemode-contract";
+
+export const CODEMODE_OPENAI_PACKAGE_PROJECT_INPUT = CodemodeInputSchema.parse({
+  type: "package-project",
+  entryPoint: "src/index.ts",
+  files: {
+    "package.json": JSON.stringify(
+      {
+        name: "codemode-openai-demo",
+        private: true,
+        type: "module",
+        dependencies: {
+          openai: "^6.0.0",
+        },
+      },
+      null,
+      2,
+    ),
+    "src/index.ts": `import OpenAI from "openai";
+
+export default async function ({ getIterateSecret }) {
+  const client = new OpenAI({
+    apiKey: await getIterateSecret({ secretKey: "openai.apiKey" }),
+  });
+
+  const response = await client.responses.create({
+    model: "gpt-4.1-mini",
+    input: "Reply with the single word ready.",
+  });
+
+  return {
+    modelReply: response.output_text ?? null,
+  };
+}
+`,
+  },
+}) as Extract<CodemodeInput, { type: "package-project" }>;

--- a/apps/codemode/src/lib/codemode-v2.test.ts
+++ b/apps/codemode/src/lib/codemode-v2.test.ts
@@ -1,5 +1,10 @@
+import type { CodemodeInput } from "@iterate-com/codemode-contract";
 import { describe, expect, test } from "vitest";
-import { buildCodemodeWrapperSource, CODEMODE_V2_STARTER } from "~/lib/codemode-v2.ts";
+import {
+  buildCodemodeWrapperSource,
+  CODEMODE_EXAMPLES,
+  CODEMODE_V2_STARTER,
+} from "~/lib/codemode-v2.ts";
 
 describe("buildCodemodeWrapperSource", () => {
   test("wraps the user function with the injected nested ctx object", () => {
@@ -20,5 +25,19 @@ describe("buildCodemodeWrapperSource", () => {
     expect(CODEMODE_V2_STARTER).toContain("ctx.events.append");
     expect(CODEMODE_V2_STARTER).toContain("ctx.semaphore.resources.list");
     expect(CODEMODE_V2_STARTER).toContain("ctx.ingressProxy.routes.list");
+  });
+
+  test("includes a package-project OpenAI example", () => {
+    const example = CODEMODE_EXAMPLES.find(({ id }) => id === "openai-package-project");
+    const input = example?.input as Extract<CodemodeInput, { type: "package-project" }>;
+
+    expect(example).toBeDefined();
+    expect(example?.title).toBe("OpenAI Package Project");
+    expect(input.type).toBe("package-project");
+    expect(input.files["package.json"]).toContain('"openai": "^6.0.0"');
+    expect(input.files["src/index.ts"]).toContain(
+      'getIterateSecret({ secretKey: "openai.apiKey" })',
+    );
+    expect(input.files["src/index.ts"]).toContain("client.responses.create");
   });
 });

--- a/apps/codemode/src/lib/codemode-v2.ts
+++ b/apps/codemode/src/lib/codemode-v2.ts
@@ -1,3 +1,4 @@
+import type { CodemodeInput } from "@iterate-com/codemode-contract";
 import {
   AGENTUTIL_GEOCODE_OPENAPI_SOURCE,
   AGENTUTIL_WEATHER_OPENAPI_SOURCE,
@@ -13,16 +14,27 @@ import {
   WEATHER_OPENAPI_SOURCE,
   type CodemodeUiSource,
 } from "~/lib/codemode-sources.ts";
+import { CODEMODE_OPENAI_PACKAGE_PROJECT_INPUT } from "~/lib/codemode-package-project-openai.ts";
 
 export interface CodemodeExampleSnippet {
   id: string;
   title: string;
   description: string;
   code: string;
+  input?: CodemodeInput;
   sources: CodemodeUiSource[];
 }
 
 export const CODEMODE_EXAMPLES: CodemodeExampleSnippet[] = [
+  {
+    id: "openai-package-project",
+    title: "OpenAI Package Project",
+    description:
+      "Bundle a package.json project, use the openai.apiKey codemode secret as apiKey, and make an OpenAI Responses API call.",
+    input: CODEMODE_OPENAI_PACKAGE_PROJECT_INPUT,
+    sources: [],
+    code: CODEMODE_OPENAI_PACKAGE_PROJECT_INPUT.files["src/index.ts"]!,
+  },
   {
     id: "postman-echo-inline",
     title: "Inline Echo Debug",
@@ -474,4 +486,6 @@ ${indent(options.sandboxPrelude.trim(), 2)}
 }`.trim();
 }
 
-export const CODEMODE_V2_STARTER = CODEMODE_EXAMPLES[0]!.code;
+export const CODEMODE_V2_STARTER = CODEMODE_EXAMPLES.find(
+  (example) => example.id === "postman-echo-inline",
+)!.code;

--- a/apps/codemode/src/routes/_app/examples.tsx
+++ b/apps/codemode/src/routes/_app/examples.tsx
@@ -10,6 +10,11 @@ import {
   buildCodemodeNewRunSearch,
   CodemodeExamplesSearch,
 } from "~/lib/codemode-links.ts";
+import {
+  codemodeInputLanguage,
+  formatCodemodeInputForDisplay,
+  resolveCodemodeEditorInput,
+} from "~/lib/codemode-input.ts";
 import { formatCodemodeSourcesYaml } from "~/lib/codemode-sources.ts";
 import { CODEMODE_EXAMPLES } from "~/lib/codemode-v2.ts";
 
@@ -31,7 +36,7 @@ function ExamplesPage() {
         const haystack = [
           example.title,
           example.description,
-          example.code,
+          formatExampleInputForDisplay(example),
           formatCodemodeSourcesYaml(example.sources),
         ]
           .join("\n")
@@ -87,6 +92,11 @@ function ExamplesPage() {
               <div className="space-y-1">
                 <p className="text-sm font-medium">{example.title}</p>
                 <p className="text-sm text-muted-foreground">{example.description}</p>
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                  {resolveExampleInput(example).type === "package-project"
+                    ? "Package project"
+                    : "Compiled script"}
+                </p>
               </div>
 
               <div className="flex flex-wrap gap-2">
@@ -97,6 +107,7 @@ function ExamplesPage() {
                     <Link
                       to="/runs-v2-new"
                       search={buildCodemodeNewRunSearch({
+                        input: example.input,
                         code: example.code,
                         sources: example.sources,
                       })}
@@ -109,7 +120,14 @@ function ExamplesPage() {
                 <Button
                   type="button"
                   variant="ghost"
-                  onClick={() => void copyExampleLink(example.code, example.sources, example.title)}
+                  onClick={() =>
+                    void copyExampleLink({
+                      code: example.code,
+                      input: example.input,
+                      sources: example.sources,
+                      title: example.title,
+                    })
+                  }
                 >
                   <Copy className="size-4" />
                   Copy deep link
@@ -131,9 +149,13 @@ function ExamplesPage() {
 
               <div className="space-y-1">
                 <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  Code
+                  Codemode Input
                 </p>
-                <SourceCodeBlock code={example.code} language="typescript" className="min-h-52" />
+                <SourceCodeBlock
+                  code={formatExampleInputForDisplay(example)}
+                  language={codemodeInputLanguage(resolveExampleInput(example))}
+                  className="min-h-52"
+                />
               </div>
             </div>
           </article>
@@ -143,21 +165,31 @@ function ExamplesPage() {
   );
 }
 
-async function copyExampleLink(
-  code: string,
-  sources: (typeof CODEMODE_EXAMPLES)[number]["sources"],
-  title: string,
-) {
+function resolveExampleInput(example: (typeof CODEMODE_EXAMPLES)[number]) {
+  return example.input ?? resolveCodemodeEditorInput({ code: example.code });
+}
+
+function formatExampleInputForDisplay(example: (typeof CODEMODE_EXAMPLES)[number]) {
+  return formatCodemodeInputForDisplay(resolveExampleInput(example));
+}
+
+async function copyExampleLink(input: {
+  code: string;
+  input?: (typeof CODEMODE_EXAMPLES)[number]["input"];
+  sources: (typeof CODEMODE_EXAMPLES)[number]["sources"];
+  title: string;
+}) {
   try {
     await navigator.clipboard.writeText(
       buildCodemodeNewRunHref({
         origin: window.location.origin,
-        code,
-        sources,
+        input: input.input,
+        code: input.code,
+        sources: input.sources,
       }),
     );
-    toast.success(`Copied deep link for "${title}"`);
+    toast.success(`Copied deep link for "${input.title}"`);
   } catch {
-    toast.error(`Failed to copy deep link for "${title}"`);
+    toast.error(`Failed to copy deep link for "${input.title}"`);
   }
 }

--- a/docs/cloudflare-preview-and-deploy-cheatsheet.md
+++ b/docs/cloudflare-preview-and-deploy-cheatsheet.md
@@ -2,7 +2,7 @@
 
 ## Cheat sheet
 
-- In scope apps: `example`, `events`, `semaphore`, `ingress-proxy`
+- In scope apps: `codemode`, `example`, `events`, `semaphore`, `ingress-proxy`
 - PR previews are owned by one workflow: `Cloudflare Previews`
 - Production deploys are owned by per-app workflows:
   - `Deploy Example`

--- a/scripts/preview/apps.ts
+++ b/scripts/preview/apps.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 
-export const CloudflarePreviewAppSlug = z.enum(["example", "events", "semaphore", "ingress-proxy"]);
+export const CloudflarePreviewAppSlug = z.enum([
+  "codemode",
+  "example",
+  "events",
+  "semaphore",
+  "ingress-proxy",
+]);
 
 export type CloudflarePreviewAppSlug = z.infer<typeof CloudflarePreviewAppSlug>;
 
@@ -16,6 +22,16 @@ export type CloudflarePreviewApp = {
 };
 
 export const cloudflarePreviewApps = {
+  codemode: {
+    slug: "codemode",
+    displayName: "Codemode",
+    appPath: "apps/codemode",
+    dopplerProject: "codemode",
+    paths: ["apps/codemode/**", "apps/codemode-contract/**"],
+    previewResourceType: "codemode-preview-environment",
+    previewTestBaseUrlEnvVar: "CODEMODE_BASE_URL",
+    previewTestCommandArgs: ["pnpm", "test:e2e:preview"],
+  },
   example: {
     slug: "example",
     displayName: "Example",

--- a/scripts/preview/preview-inventory.test.ts
+++ b/scripts/preview/preview-inventory.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { ensurePreviewInventory } from "./preview-inventory.ts";
+
+describe("ensurePreviewInventory", () => {
+  it("adds missing preview slots for a new preview app type", async () => {
+    const add = vi.fn(async () => undefined);
+    const list = vi.fn(async () => []);
+
+    await ensurePreviewInventory({
+      appSlug: "codemode",
+      client: { add, list },
+      count: 3,
+      type: "codemode-preview-environment",
+    });
+
+    expect(list).toHaveBeenCalledWith({
+      type: "codemode-preview-environment",
+    });
+    expect(add.mock.calls).toEqual([
+      [
+        {
+          slug: "codemode-preview-1",
+          type: "codemode-preview-environment",
+        },
+      ],
+      [
+        {
+          slug: "codemode-preview-2",
+          type: "codemode-preview-environment",
+        },
+      ],
+      [
+        {
+          slug: "codemode-preview-3",
+          type: "codemode-preview-environment",
+        },
+      ],
+    ]);
+  });
+
+  it("skips existing slots and ignores duplicate add conflicts", async () => {
+    const add = vi.fn(async ({ slug }: { slug: string; type: string }) => {
+      if (slug === "codemode-preview-3") {
+        throw new Error("Resource already exists for this type and slug.");
+      }
+    });
+    const list = vi.fn(async () => [
+      { slug: "codemode-preview-1" },
+      { slug: "codemode-preview-4" },
+    ]);
+
+    await ensurePreviewInventory({
+      appSlug: "codemode",
+      client: { add, list },
+      count: 4,
+      type: "codemode-preview-environment",
+    });
+
+    expect(add.mock.calls).toEqual([
+      [
+        {
+          slug: "codemode-preview-2",
+          type: "codemode-preview-environment",
+        },
+      ],
+      [
+        {
+          slug: "codemode-preview-3",
+          type: "codemode-preview-environment",
+        },
+      ],
+    ]);
+  });
+});

--- a/scripts/preview/preview-inventory.ts
+++ b/scripts/preview/preview-inventory.ts
@@ -1,0 +1,45 @@
+export const DEFAULT_PREVIEW_RESOURCE_COUNT = 10;
+
+export type PreviewInventoryClient = {
+  add: (input: { slug: string; type: string }) => Promise<unknown>;
+  list: (input: { type: string }) => Promise<Array<{ slug: string }>>;
+};
+
+export async function ensurePreviewInventory(input: {
+  appSlug: string;
+  client: PreviewInventoryClient;
+  count?: number;
+  type: string;
+}) {
+  const existingResources = await input.client.list({ type: input.type });
+  const existingSlugs = new Set(existingResources.map((resource) => resource.slug));
+  const count = input.count ?? DEFAULT_PREVIEW_RESOURCE_COUNT;
+
+  for (let slot = 1; slot <= count; slot += 1) {
+    const slug = `${input.appSlug}-preview-${slot}`;
+    if (existingSlugs.has(slug)) {
+      continue;
+    }
+
+    try {
+      await input.client.add({
+        slug,
+        type: input.type,
+      });
+      existingSlugs.add(slug);
+    } catch (error) {
+      if (!isPreviewInventoryConflictError(error)) {
+        throw error;
+      }
+    }
+  }
+}
+
+export function isPreviewInventoryConflictError(error: unknown) {
+  return (
+    error instanceof Error &&
+    /Resource already exists for this type and slug|Cannot add a resource while an older lease is still active for this slug/i.test(
+      error.message,
+    )
+  );
+}

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -19,6 +19,7 @@ const defaultPreviewTestMaxAttempts = 2;
 const defaultPreviewTestRetryDelayMs = 5_000;
 
 export type PreviewSemaphoreResourceClient = {
+  ensurePreviewInventory: (input: { appSlug: string; type: string }) => Promise<void>;
   acquire: (input: { leaseMs: number; type: string; waitMs?: number }) => Promise<{
     expiresAt: number;
     leaseId: string;
@@ -526,6 +527,10 @@ async function createPreviewEnvironment(
     const semaphore = params.createPreviewSemaphoreResourceClient({
       semaphoreApiToken: params.semaphoreApiToken,
       semaphoreBaseUrl: params.semaphoreBaseUrl,
+    });
+    await semaphore.ensurePreviewInventory({
+      appSlug: params.appSlug,
+      type: params.previewResourceType,
     });
     lease = await semaphore.acquire({
       type: params.previewResourceType,

--- a/scripts/preview/router.ts
+++ b/scripts/preview/router.ts
@@ -3,6 +3,7 @@ import { os } from "@orpc/server";
 import { z } from "zod";
 import { createSemaphoreClient } from "../../apps/semaphore-contract/src/client.ts";
 import { CloudflarePreviewAppSlug, cloudflarePreviewApps } from "./apps.ts";
+import { ensurePreviewInventory } from "./preview-inventory.ts";
 import {
   cleanupCloudflarePreviewForPullRequest,
   createCloudflarePreviewCleanupInputSchema,
@@ -45,12 +46,23 @@ function createPreviewSemaphoreClient(input: {
     apiKey: input.semaphoreApiToken,
     baseURL: input.semaphoreBaseUrl,
   });
+  const list = ({ type }: { type: string }) => semaphore.resources.list({ type });
+  const add = ({ slug, type }: { slug: string; type: string }) =>
+    semaphore.resources.add({ type, slug, data: {} });
+
   return {
+    ensurePreviewInventory: async ({ appSlug, type }: { appSlug: string; type: string }) => {
+      await ensurePreviewInventory({
+        appSlug,
+        client: { add, list },
+        type,
+      });
+    },
     acquire: ({ leaseMs, type, waitMs }: { leaseMs: number; type: string; waitMs?: number }) =>
       semaphore.resources.acquire({ leaseMs, type, waitMs }),
     release: ({ leaseId, slug, type }: { leaseId: string; slug: string; type: string }) =>
       semaphore.resources.release({ leaseId, slug, type }),
-    list: ({ type }: { type: string }) => semaphore.resources.list({ type }),
+    list,
   };
 }
 


### PR DESCRIPTION
## What changed
- added `codemode` to the Cloudflare preview app registry
- generated the preview workflow so codemode now gets deploy, e2e, and cleanup jobs on PRs
- added a `test:e2e:preview` codemode script so preview runs use the same app-local interface as the other previewed apps

## Why
Codemode was merged to `main`, but it was not part of the preview registry, so PRs could not get an automated Cloudflare preview or preview e2e coverage for codemode changes.

## Validation
- `pnpm --dir ./.github/ts-workflows generate`
- `doppler run --project codemode --config stg_1 -- env CODEMODE_BASE_URL=https://codemode-preview-1.iterate.workers.dev pnpm --dir ./apps/codemode test:e2e:preview`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iterate/iterate/pull/1264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the PR preview pipeline and preview resource allocation logic, which can impact CI reliability and preview environment creation/cleanup across apps. App-level changes are mostly additive (new examples/test coverage) but are exercised in live preview e2e.
> 
> **Overview**
> Adds `codemode` to the Cloudflare preview system: the preview registry now includes `codemode` (and its contract), and the generated `Cloudflare Previews` workflow gains `preview/e2e/cleanup` jobs for it.
> 
> Introduces automatic preview slot seeding via `ensurePreviewInventory`, invoked before acquiring Semaphore leases, to create missing `${app}-preview-N` resources and ignore expected “already exists/active lease” conflicts.
> 
> Updates Codemode to support and validate this flow: adds a `test:e2e:preview` script, extends live e2e to assert the new OpenAI *package-project* example appears on `/examples`, and updates the examples UI/deep links to carry and display full `CodemodeInput` (compiled script vs package project).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89e6f81dfb6a79e7bc3af5a911a5e8dd6755ddae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW_ENVIRONMENTS -->
## Preview Environments
<!-- CLOUDFLARE_PREVIEW_ENVIRONMENTS_STATE -->
<!--
{
  "codemode": {
    "appDisplayName": "Codemode",
    "appSlug": "codemode",
    "status": "released",
    "updatedAt": "2026-04-10T08:44:48.828Z",
    "leasedUntil": null,
    "headSha": "89e6f81dfb6a79e7bc3af5a911a5e8dd6755ddae",
    "message": "Preview environment released.",
    "previewEnvironmentAlchemyStageName": null,
    "previewEnvironmentDopplerConfigName": null,
    "previewEnvironmentIdentifier": null,
    "previewEnvironmentSemaphoreLeaseId": null,
    "previewEnvironmentSlug": null,
    "previewEnvironmentType": null,
    "publicUrl": "https://codemode-preview-1.iterate.workers.dev",
    "runUrl": "https://github.com/iterate/iterate/actions/runs/24232768237",
    "shortSha": "89e6f81"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_ENVIRONMENTS_STATE -->

### Codemode
Status: released
Commit: `89e6f81`
Preview: https://codemode-preview-1.iterate.workers.dev
Summary: Preview environment released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/24232768237)
Updated: 2026-04-10T08:44:48.828Z
<!-- /CLOUDFLARE_PREVIEW_ENVIRONMENTS -->