### PR TITLE
[codex] Fix sandbox Fly image startup on Fly

### DIFF
--- a/.github/ts-workflows/workflows/sandbox-test.ts
+++ b/.github/ts-workflows/workflows/sandbox-test.ts
@@ -136,7 +136,7 @@ export default workflow({
             '    SANDBOX_TEST_SNAPSHOT_ID="${FLY_IMAGE_TAG}" \\',
             '    FLY_DEFAULT_IMAGE="${FLY_IMAGE_TAG}" \\',
             '    DOPPLER_TOKEN="${DOPPLER_TOKEN}" \\',
-            '    doppler run -- env RUN_SANDBOX_TESTS=true SANDBOX_TEST_PROVIDER=fly SANDBOX_TEST_SNAPSHOT_ID="$FLY_IMAGE_TAG" FLY_DEFAULT_IMAGE="$FLY_IMAGE_TAG" pnpm sandbox test test/provider-base-image.test.ts --maxWorkers=1',
+            '    doppler run -- env RUN_SANDBOX_TESTS=true SANDBOX_TEST_PROVIDER=fly SANDBOX_TEST_SNAPSHOT_ID="$FLY_IMAGE_TAG" FLY_DEFAULT_IMAGE="$FLY_IMAGE_TAG" pnpm sandbox test test/provider-base-image.test.ts test/fly-daemon-smoke.test.ts --maxWorkers=1',
             '  ) >"${fly_log}" 2>&1 &',
             '  fly_pid="$!"',
             "fi",
@@ -191,7 +191,10 @@ export default workflow({
           env: {
             DOPPLER_TOKEN: "${{ secrets.DOPPLER_TOKEN }}",
           },
-          run: "doppler run -- pnpm sandbox fly:cleanup -- --timeframe 0s --action delete --prefix test-base-image-test --all",
+          run: [
+            "doppler run -- pnpm sandbox fly:cleanup -- --timeframe 0s --action delete --prefix test-base-image-test --all",
+            "doppler run -- pnpm sandbox fly:cleanup -- --timeframe 0s --action delete --prefix test-fly-daemon-smoke --all",
+          ].join("\n"),
         },
       ],
     },

--- a/.github/workflows/sandbox-test.yml
+++ b/.github/workflows/sandbox-test.yml
@@ -120,7 +120,7 @@ jobs:
               SANDBOX_TEST_SNAPSHOT_ID="${FLY_IMAGE_TAG}" \
               FLY_DEFAULT_IMAGE="${FLY_IMAGE_TAG}" \
               DOPPLER_TOKEN="${DOPPLER_TOKEN}" \
-              doppler run -- env RUN_SANDBOX_TESTS=true SANDBOX_TEST_PROVIDER=fly SANDBOX_TEST_SNAPSHOT_ID="$FLY_IMAGE_TAG" FLY_DEFAULT_IMAGE="$FLY_IMAGE_TAG" pnpm sandbox test test/provider-base-image.test.ts --maxWorkers=1
+              doppler run -- env RUN_SANDBOX_TESTS=true SANDBOX_TEST_PROVIDER=fly SANDBOX_TEST_SNAPSHOT_ID="$FLY_IMAGE_TAG" FLY_DEFAULT_IMAGE="$FLY_IMAGE_TAG" pnpm sandbox test test/provider-base-image.test.ts test/fly-daemon-smoke.test.ts --maxWorkers=1
             ) >"${fly_log}" 2>&1 &
             fly_pid="$!"
           fi
@@ -167,4 +167,6 @@ jobs:
         if: always()
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-        run: doppler run -- pnpm sandbox fly:cleanup -- --timeframe 0s --action delete --prefix test-base-image-test --all
+        run: |-
+          doppler run -- pnpm sandbox fly:cleanup -- --timeframe 0s --action delete --prefix test-base-image-test --all
+          doppler run -- pnpm sandbox fly:cleanup -- --timeframe 0s --action delete --prefix test-fly-daemon-smoke --all

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -175,7 +175,8 @@ RUN mkdir -p /home/iterate/.local/bin && \
     cd /tmp/gogcli && \
     git checkout ${SANDBOX_GOGCLI_REF} && \
     go build -o /home/iterate/.local/bin/gog ./cmd/gog && \
-    rm -rf /tmp/gogcli
+    go clean -cache -modcache && \
+    rm -rf /tmp/gogcli /home/iterate/go/pkg /home/iterate/go/src /home/iterate/.cache/go-build
 
 # Install Archil client (persistent POSIX volumes backed by S3/R2)
 # Installs to /usr/bin/archil by default (system path)
@@ -240,6 +241,14 @@ RUN pnpm install --frozen-lockfile --offline
 # Run post-repo-sync steps (cacheable - only reruns when source changes)
 RUN bash "$ITERATE_REPO/sandbox/after-repo-sync-steps.sh"
 
+# Drop build/install caches that duplicate runtime payloads and can push Fly
+# over its 8GB unpack limit. Keep OpenCode and Playwright browser payloads.
+RUN sudo rm -rf \
+    /home/iterate/.local/share/pnpm/store \
+    /home/iterate/.cache/uv \
+    /home/iterate/.cache/node/corepack \
+    /home/iterate/.npm \
+    /tmp/*
 
 
 ARG GIT_SHA=unknown

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -89,7 +89,7 @@ RUN corepack enable
 # Global npm tools (as root for system-wide access)
 RUN corepack prepare pnpm@10.24.0 --activate && \
     npm install -g tsx serve && \
-    rm -rf /home/iterate/.cache/node/corepack /home/iterate/.npm
+    rm -rf /root/.cache/node/corepack /root/.npm
 
 # Configure UTF-8 locale (required for btop and other CLI tools)
 RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
@@ -220,10 +220,18 @@ RUN set -e && \
 ENV ITERATE_REPO=/home/iterate/src/github.com/iterate/iterate
 WORKDIR /home/iterate/src/github.com/iterate/iterate
 
+# pnpm reads npm-style config env vars. Keep build-time and runtime pnpm store
+# paths aligned with the Docker volume mounted at /home/iterate/.pnpm-store.
+ENV npm_config_store_dir=/home/iterate/.pnpm-store
+
 # Copy lockfile first so BuildKit can reuse the dependency step when source-only
 # files change. The pnpm store itself stays in a cache mount, not the image.
 COPY --chown=iterate:iterate package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY --chown=iterate:iterate patches ./patches
+RUN --mount=type=cache,target=/home/iterate/.pnpm-store,uid=1001,gid=1001,sharing=locked \
+    ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then PNPM_ARCH="x64"; else PNPM_ARCH="arm64"; fi && \
+    pnpm fetch --config.platform=linux --config.arch="$PNPM_ARCH" --config.libc=glibc
 
 # Copy repo, exclude git metadata from context.
 # If .git is a worktree file, replace with dir
@@ -233,12 +241,9 @@ RUN if [ -f .git ]; then rm .git && mkdir .git; fi
 # Ensure shell scripts are executable (git may not preserve permissions on all platforms)
 RUN chmod +x sandbox/*.sh sandbox/providers/docker/*.sh
 
-# Keep pnpm fetch/install and post-sync outputs in a single layer so the store
-# and temporary build files do not remain in the image Fly has to unpack.
-RUN --mount=type=cache,target=/home/iterate/.pnpm-store,uid=1000,gid=1000,sharing=locked \
-    ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" = "amd64" ]; then PNPM_ARCH="x64"; else PNPM_ARCH="arm64"; fi && \
-    pnpm fetch --config.platform=linux --config.arch="$PNPM_ARCH" --config.libc=glibc && \
+# Keep install and post-sync outputs in a single layer so the mounted pnpm
+# store and temporary build files do not remain in the image Fly has to unpack.
+RUN --mount=type=cache,target=/home/iterate/.pnpm-store,uid=1001,gid=1001,sharing=locked \
     pnpm install --frozen-lockfile --offline && \
     bash "$ITERATE_REPO/sandbox/after-repo-sync-steps.sh" && \
     sudo rm -rf \

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -88,7 +88,8 @@ RUN corepack enable
 
 # Global npm tools (as root for system-wide access)
 RUN corepack prepare pnpm@10.24.0 --activate && \
-    npm install -g tsx serve
+    npm install -g tsx serve && \
+    rm -rf /home/iterate/.cache/node/corepack /home/iterate/.npm
 
 # Configure UTF-8 locale (required for btop and other CLI tools)
 RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
@@ -120,7 +121,8 @@ RUN sudo mkdir -p /opt/mitmproxy /opt/uv/python && \
     UV_TOOL_DIR=/opt/mitmproxy/tools UV_TOOL_BIN_DIR=/opt/mitmproxy/bin \
     UV_PYTHON_INSTALL_DIR=/opt/uv/python \
     uv tool install --python 3.12 mitmproxy==${SANDBOX_MITMPROXY_VERSION} && \
-    chmod -R a+rX /opt/mitmproxy /opt/uv
+    chmod -R a+rX /opt/mitmproxy /opt/uv && \
+    rm -rf /home/iterate/.cache/uv
 ENV PATH="/opt/mitmproxy/bin:$PATH"
 
 # Generate mitmproxy CA certificate at build time.
@@ -218,14 +220,10 @@ RUN set -e && \
 ENV ITERATE_REPO=/home/iterate/src/github.com/iterate/iterate
 WORKDIR /home/iterate/src/github.com/iterate/iterate
 
-# Copy lockfile first (dependency layer)
-# This way, unless the dependencies change, we don't have to download from pnpm
-# TODO: consider BuildKit cache mount for pnpm store to speed CI builds.
+# Copy lockfile first so BuildKit can reuse the dependency step when source-only
+# files change. The pnpm store itself stays in a cache mount, not the image.
 COPY --chown=iterate:iterate package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY --chown=iterate:iterate patches ./patches
-RUN ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" = "amd64" ]; then PNPM_ARCH="x64"; else PNPM_ARCH="arm64"; fi && \
-    pnpm fetch --config.platform=linux --config.arch="$PNPM_ARCH" --config.libc=glibc
 
 # Copy repo, exclude git metadata from context.
 # If .git is a worktree file, replace with dir
@@ -235,17 +233,15 @@ RUN if [ -f .git ]; then rm .git && mkdir .git; fi
 # Ensure shell scripts are executable (git may not preserve permissions on all platforms)
 RUN chmod +x sandbox/*.sh sandbox/providers/docker/*.sh
 
-# Install dependencies (cacheable - only reruns when lockfile changes)
-RUN pnpm install --frozen-lockfile --offline
-
-# Run post-repo-sync steps (cacheable - only reruns when source changes)
-RUN bash "$ITERATE_REPO/sandbox/after-repo-sync-steps.sh"
-
-# Drop build/install caches that duplicate runtime payloads and can push Fly
-# over its 8GB unpack limit. Keep OpenCode and Playwright browser payloads.
-RUN sudo rm -rf \
-    /home/iterate/.local/share/pnpm/store \
-    /home/iterate/.cache/uv \
+# Keep pnpm fetch/install and post-sync outputs in a single layer so the store
+# and temporary build files do not remain in the image Fly has to unpack.
+RUN --mount=type=cache,target=/home/iterate/.pnpm-store,uid=1000,gid=1000,sharing=locked \
+    ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then PNPM_ARCH="x64"; else PNPM_ARCH="arm64"; fi && \
+    pnpm fetch --config.platform=linux --config.arch="$PNPM_ARCH" --config.libc=glibc && \
+    pnpm install --frozen-lockfile --offline && \
+    bash "$ITERATE_REPO/sandbox/after-repo-sync-steps.sh" && \
+    sudo rm -rf \
     /home/iterate/.cache/node/corepack \
     /home/iterate/.npm \
     /tmp/*

--- a/sandbox/providers/fly/provider.ts
+++ b/sandbox/providers/fly/provider.ts
@@ -401,6 +401,71 @@ async function getMachineForDebug(params: {
   }
 }
 
+async function listAppMachines(params: {
+  env: FlyEnv;
+  appName: string;
+}): Promise<Array<Record<string, unknown>> | null> {
+  const { env, appName } = params;
+  try {
+    const payload = await flyApi<unknown>({
+      env,
+      method: "GET",
+      path: `/v1/apps/${encodeURIComponent(appName)}/machines`,
+    });
+    return Array.isArray(payload) ? payload.map(asRecord) : [];
+  } catch (error) {
+    if (isNotFoundError(error) || isGraphQlNotFoundError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function waitForNoSandboxMachines(params: {
+  env: FlyEnv;
+  appName: string;
+  timeoutMs: number;
+}): Promise<void> {
+  const { env, appName, timeoutMs } = params;
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const machines = await listAppMachines({ env, appName });
+    if (!machines) return;
+
+    const sandboxMachine = resolveSandboxMachine(machines);
+    if (!sandboxMachine) return;
+
+    await sleep(WAIT_RETRY_DELAY_MS);
+  }
+
+  throw new Error(`Timed out waiting for Fly app ${appName} to clear sandbox machines`);
+}
+
+async function cleanupFailedCreateAttempt(params: {
+  env: FlyEnv;
+  appName: string;
+  machineId?: string;
+}): Promise<void> {
+  const { env, appName, machineId } = params;
+
+  if (machineId) {
+    try {
+      await flyApi({
+        env,
+        method: "DELETE",
+        path: `/v1/apps/${encodeURIComponent(appName)}/machines/${encodeURIComponent(machineId)}?force=true`,
+      });
+    } catch (error) {
+      if (!isMachineNotFoundError(error) && !isNotFoundError(error)) {
+        throw error;
+      }
+    }
+  }
+
+  await waitForNoSandboxMachines({ env, appName, timeoutMs: CREATE_RETRY_BACKOFF_MS });
+}
+
 async function ensureFlyAppExists(params: { env: FlyEnv; appName: string }): Promise<void> {
   const { env, appName } = params;
   try {
@@ -805,11 +870,11 @@ export class FlyProvider extends SandboxProvider {
           },
         });
 
-        await new FlySandbox({
+        await cleanupFailedCreateAttempt({
           env: this.env,
           appName,
           machineId,
-        }).delete();
+        });
         await sleep(CREATE_RETRY_BACKOFF_MS);
       }
     }

--- a/sandbox/providers/fly/provider.ts
+++ b/sandbox/providers/fly/provider.ts
@@ -17,6 +17,8 @@ const WAIT_TIMEOUT_SECONDS = 300;
 const MAX_WAIT_TIMEOUT_SECONDS = 60;
 const WAIT_RETRY_DELAY_MS = 1_000;
 const WAIT_NOT_FOUND_GRACE_SECONDS = 45;
+const CREATE_RETRY_LIMIT = 2;
+const CREATE_RETRY_BACKOFF_MS = 30_000;
 const DEFAULT_WEB_INTERNAL_PORT = 8080;
 const DEFAULT_SERVICE_PORTS: number[] = [];
 const DEFAULT_FLY_ORG = "iterate";
@@ -347,6 +349,14 @@ function isMachineStillActiveError(error: unknown): boolean {
 function isMachineNotFoundError(error: unknown): boolean {
   const message = String(error).toLowerCase();
   return message.includes("(404)") && message.includes("machine not found");
+}
+
+function isRetryableCreateError(error: unknown): boolean {
+  const message = String(error).toLowerCase();
+  return (
+    message.includes("disappeared while waiting for 'started'") ||
+    (message.includes("machine not found") && message.includes("waiting for 'started'"))
+  );
 }
 
 function logFlyWaitEvent(params: {
@@ -713,8 +723,6 @@ export class FlyProvider extends SandboxProvider {
         opts.envVars?.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS ?? ".fly.dev",
     };
 
-    await ensureFlyAppExists({ env: this.env, appName });
-    await ensureFlyIngress({ env: this.env, appName });
     const snapshotId = opts.providerSnapshotId ?? this.defaultSnapshotId;
     if (snapshotId.includes("registry.fly.io/iterate-sandbox-image:")) {
       throw new Error(
@@ -722,53 +730,91 @@ export class FlyProvider extends SandboxProvider {
       );
     }
 
-    const createPayload = await flyApi<unknown>({
-      env: this.env,
-      method: "POST",
-      path: `/v1/apps/${encodeURIComponent(appName)}/machines`,
-      body: {
-        name: FLY_MACHINE_NAME,
-        region: jsonEnvVar.parse(RegionConfig, this.env.REGION_CONFIG).flyIoRegion,
-        skip_launch: false,
-        config: {
-          image: snapshotId,
-          env: envVars,
-          guest: {
-            cpu_kind: "shared",
-            cpus: this.env.FLY_DEFAULT_CPUS,
-            memory_mb: this.env.FLY_DEFAULT_MEMORY_MB,
-          },
-          restart: { policy: "always" },
-          services: buildServices(),
-          metadata: {
-            "com.iterate.sandbox": "true",
-            "com.iterate.machine_type": "fly",
-            "com.iterate.external_id": opts.externalId,
-          },
-          ...(hasEntrypointArguments ? { init: { exec: entrypointArguments } } : {}),
-        },
-      },
-    });
+    // Freshly-pushed Fly registry tags can occasionally produce a machine id and
+    // then vanish before the machine becomes visible. Retry once after cleanup.
+    for (let attempt = 1; attempt <= CREATE_RETRY_LIMIT; attempt += 1) {
+      await ensureFlyAppExists({ env: this.env, appName });
+      await ensureFlyIngress({ env: this.env, appName });
 
-    const machineId = resolveMachineId(createPayload);
-    logFlyWaitEvent({
-      level: "log",
-      event: "machine-created",
-      appName,
-      machineId,
-      state: "created",
-      extra: {
-        snapshotId,
-        reportedState: asString(asRecord(createPayload).state) ?? "unknown",
-      },
-    });
-    await waitForState({ env: this.env, appName, machineId, state: "started" });
+      let machineId: string | undefined;
+      try {
+        const createPayload = await flyApi<unknown>({
+          env: this.env,
+          method: "POST",
+          path: `/v1/apps/${encodeURIComponent(appName)}/machines`,
+          body: {
+            name: FLY_MACHINE_NAME,
+            region: jsonEnvVar.parse(RegionConfig, this.env.REGION_CONFIG).flyIoRegion,
+            skip_launch: false,
+            config: {
+              image: snapshotId,
+              env: envVars,
+              guest: {
+                cpu_kind: "shared",
+                cpus: this.env.FLY_DEFAULT_CPUS,
+                memory_mb: this.env.FLY_DEFAULT_MEMORY_MB,
+              },
+              restart: { policy: "always" },
+              services: buildServices(),
+              metadata: {
+                "com.iterate.sandbox": "true",
+                "com.iterate.machine_type": "fly",
+                "com.iterate.external_id": opts.externalId,
+              },
+              ...(hasEntrypointArguments ? { init: { exec: entrypointArguments } } : {}),
+            },
+          },
+        });
 
-    return new FlySandbox({
-      env: this.env,
-      appName,
-      machineId,
-    });
+        machineId = resolveMachineId(createPayload);
+        logFlyWaitEvent({
+          level: "log",
+          event: "machine-created",
+          appName,
+          machineId,
+          state: "created",
+          extra: {
+            snapshotId,
+            reportedState: asString(asRecord(createPayload).state) ?? "unknown",
+            attempt,
+          },
+        });
+        await waitForState({ env: this.env, appName, machineId, state: "started" });
+
+        return new FlySandbox({
+          env: this.env,
+          appName,
+          machineId,
+        });
+      } catch (error) {
+        if (attempt >= CREATE_RETRY_LIMIT || !isRetryableCreateError(error)) {
+          throw error;
+        }
+
+        logFlyWaitEvent({
+          level: "warn",
+          event: "create-retry",
+          appName,
+          machineId: machineId ?? "unknown",
+          state: "started",
+          extra: {
+            attempt,
+            maxAttempts: CREATE_RETRY_LIMIT,
+            backoffMs: CREATE_RETRY_BACKOFF_MS,
+            error: String(error),
+          },
+        });
+
+        await new FlySandbox({
+          env: this.env,
+          appName,
+          machineId,
+        }).delete();
+        await sleep(CREATE_RETRY_BACKOFF_MS);
+      }
+    }
+
+    throw new Error(`Fly create exhausted retries for app ${appName}`);
   }
 
   get(providerId: string): FlySandbox | null {

--- a/sandbox/test/fly-daemon-smoke.test.ts
+++ b/sandbox/test/fly-daemon-smoke.test.ts
@@ -1,0 +1,65 @@
+import { describe } from "vitest";
+import { RUN_SANDBOX_TESTS, TEST_CONFIG, test } from "./helpers.ts";
+
+const TEST_RUN_SUFFIX = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+const TEST_EXTERNAL_ID = `test-fly-daemon-smoke-${TEST_RUN_SUFFIX}`;
+const TEST_ID = `fly-daemon-smoke-${TEST_RUN_SUFFIX}`;
+const FLY_DAEMON_SMOKE_TIMEOUT_MS = 420_000;
+
+describe.runIf(RUN_SANDBOX_TESTS && TEST_CONFIG.provider === "fly")("Fly Daemon Smoke", () => {
+  test.scoped({
+    sandboxOptions: {
+      externalId: TEST_EXTERNAL_ID,
+      id: TEST_ID,
+      name: "Fly Daemon Smoke",
+      envVars: {},
+    },
+  });
+
+  test(
+    "default sandbox entrypoint boots pidnap and daemon services",
+    async ({ sandbox, expect }) => {
+      await expect
+        .poll(
+          async () => {
+            try {
+              return await sandbox.exec([
+                "sh",
+                "-c",
+                "curl -sSf --max-time 5 http://127.0.0.1:3001/api/health",
+              ]);
+            } catch {
+              return "";
+            }
+          },
+          { timeout: 180_000, interval: 1_000 },
+        )
+        .toContain('"status":"ok"');
+
+      await expect
+        .poll(
+          async () => {
+            try {
+              return await sandbox.exec([
+                "sh",
+                "-c",
+                "curl -I -sSf --max-time 5 http://127.0.0.1:3000 | head -n 1",
+              ]);
+            } catch {
+              return "";
+            }
+          },
+          { timeout: 180_000, interval: 1_000 },
+        )
+        .toContain("200");
+
+      const pidnapRunning = await sandbox.exec([
+        "sh",
+        "-c",
+        "ps -ef | grep -v grep | grep -q 'pidnap/src/cli.ts' && echo yes || echo no",
+      ]);
+      expect(pidnapRunning.trim()).toBe("yes");
+    },
+    FLY_DAEMON_SMOKE_TIMEOUT_MS,
+  );
+});

--- a/sandbox/test/provider-base-image.test.ts
+++ b/sandbox/test/provider-base-image.test.ts
@@ -13,7 +13,10 @@ const PREVIEW_BODY = "preview-ok";
 const TEST_RUN_SUFFIX = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 const TEST_EXTERNAL_ID = `test-base-image-test-${TEST_RUN_SUFFIX}`;
 const TEST_ID = `base-image-test-${TEST_RUN_SUFFIX}`;
-const PROVIDER_API_TEST_TIMEOUT_MS = TEST_CONFIG.provider === "fly" ? 180_000 : 120_000;
+// Fly cold pulls of newly-pushed multi-arch sandbox images can take several
+// minutes before the machine reaches "started". Keep the test timeout above
+// the provider's own 300s start wait so we fail on the real provider error.
+const PROVIDER_API_TEST_TIMEOUT_MS = TEST_CONFIG.provider === "fly" ? 420_000 : 120_000;
 
 describe
   .runIf(RUN_SANDBOX_TESTS)


### PR DESCRIPTION
## What changed

This work targets the actual reason `test-sandbox-fly` was red on `main`.

The earlier approach in this PR removed caches in a later Docker layer. That made the final filesystem look smaller locally, but it did **not** reduce the bytes Fly had to unpack.

This PR now does two things:
- restructures the sandbox image build so pnpm fetch/install + post-sync work happen in one BuildKit cache-mounted step, preventing the pnpm store from being baked into a shipped image layer
- raises the Fly-specific base-image smoke-test timeout so the test no longer fails before the provider's own startup wait budget is exhausted
- retries a transient Fly machine-creation failure mode where a freshly created machine disappears before it becomes visible on the Machines API

Concrete code changes:
- move `pnpm fetch`, `pnpm install --offline`, post-sync steps, and cleanup into a single `RUN --mount=type=cache` step in `sandbox/Dockerfile`
- stop baking pnpm store bytes into a standalone image layer that Fly must unpack
- clean `uv`, `npm`, and `corepack` caches in the same layers that create them
- increase Fly-specific timeout in `sandbox/test/provider-base-image.test.ts` from `180_000` to `420_000`
- keep Playwright browser payloads, OpenCode payloads, Claude, Codex, and other installed CLIs intact

## Root cause

### What was broken

`test-sandbox-fly` was failing because Fly could not reliably get the sandbox image to `started`.

Earlier evidence from Fly logs on April 13, 2026 showed:
- `Not enough space to unpack image, possibly exceeds maximum of 8GB uncompressed`

### Why the first fix did not work

The first iteration in this PR deleted large caches only **after** they had already been written into earlier Docker layers.

That meant:
- `du -sx /` inside a finished container looked smaller
- but `docker history` still showed the large bytes in the image Fly had to pull/unpack
- the cleanup layer itself was effectively `0B`, so it did not help Fly

The clearest example was the pnpm dependency layer:
- earlier build history showed a `pnpm fetch` layer around `4.67GB`
- later cache deletion did not remove that weight from the shipped image

## Investigation summary

### Failure scope

- failing workflow/job: `Sandbox Build + Provider Tests` → `build-and-docker-tests`
- failing lane: `Run provider tests (Docker + Fly in parallel)`
- Docker provider tests were passing; the Fly provider lane was red
- this was not branch-only: the same Fly lane was also failing on `main`

### Key observations

Before the current Dockerfile fix:
- Fly PR/CI runs either failed with the known unpack-limit symptom, or the machine disappeared while waiting for `started`
- local rootfs measurements were misleading because they did not match image-layer weight

After the current Dockerfile fix:
- Fly no longer failed immediately while unpacking the image
- the image successfully prepared and booted on Fly
- the remaining failure moved to test timeout budget rather than platform startup failure

## Validation

### Real Fly image build

Built and pushed from this branch on April 14, 2026:
- image tag: `registry.fly.io/iterate-sandbox:sha-df4b827-dirty`
- Depot build: `z6trlcbhz3`

### Fly provider smoke test: first run after image fix

Ran:

```bash
RUN_SANDBOX_TESTS=true \
SANDBOX_TEST_PROVIDER=fly \
SANDBOX_TEST_SNAPSHOT_ID=registry.fly.io/iterate-sandbox:sha-df4b827-dirty \
FLY_DEFAULT_IMAGE=registry.fly.io/iterate-sandbox:sha-df4b827-dirty \
doppler run --config prd --project os -- \
pnpm sandbox test test/provider-base-image.test.ts --maxWorkers=1
```

Observed from Fly logs / machine status:
- `Pulling container image registry.fly.io/iterate-sandbox@sha256:03ea60a1c138...`
- `Successfully prepared image ... (3m39.205685162s)`
- `Machine created and started in 3m47.404s`

Result:
- the machine **did reach `started` on Fly**
- but the test still failed because the spec timeout was `180s`, shorter than the cold-start envelope for the first pull of this image

### Fly provider smoke test: after timeout fix

After raising the Fly-specific spec timeout to `420_000`, reran the same Fly smoke test against the same image tag.

Result:
- `wait-succeeded` for `state=started` after `115s`
- `test/provider-base-image.test.ts` passed
- total test duration: about `157.8s`

This establishes:
- the image now boots successfully on Fly
- the earlier red test was then caused by the test timeout being too short for the provider's real cold-start behavior

### Runtime verification inside a live Fly machine

Created a temporary Fly machine directly with the fixed image and verified the baked tools from inside the running VM.

Verified binaries inside Fly:
- `opencode --version` → `1.2.15`
- `claude --version` → `2.1.50 (Claude Code)`
- `codex --version` → `codex-cli 0.98.0`
- `agent-browser --version` → `0.13.0`

Verified `opencode run` behavior inside Fly:
- with the repo's normal `~/.config/opencode/opencode.json`, a raw temp machine without model creds fails as expected with `x-api-key header is required`
- with `ANTHROPIC_API_KEY` injected, `opencode run "Reply with exactly OK"` succeeded inside the Fly machine and returned `OK`

So the baked CLIs are present and functional in a real Fly VM. `opencode` specifically works end-to-end when the model credential required by the bundled config is available.

### Default daemon stack validation on Fly

I also created a real Fly machine from the fixed image with the normal sandbox entrypoint and verified the daemon stack itself, not just a `sleep infinity` VM.

Observed on April 14, 2026:
- Fly reached `started` after `227s`
- `curl http://127.0.0.1:3001/api/health` returned `{"status":"ok",...}`
- `curl -I http://127.0.0.1:3000` returned `HTTP/1.1 200 OK`
- the process list showed `pidnap` running and `pnpm exec vite preview --host 0.0.0.0 --port 3000`

So the default sandbox stack now boots successfully on Fly: the VM starts, `entry.sh` hands off to `pidnap`, the daemon backend becomes healthy, and the daemon frontend serves normally.

## Why this should fix the PR

This PR now addresses both failure layers that mattered:
- image-layer bloat that prevented Fly from unpacking / starting the machine reliably
- an undersized Fly test timeout that could still fail even once the image booted successfully

## Residual risk

- cold first-pull startup on Fly is still relatively slow for this image family
- the image now boots, but the startup envelope is not tiny; future size growth could reintroduce pressure
- additional trimming may still be worthwhile later, but is no longer required to make the Fly smoke test pass

## Commands used

```bash
# build + push image to Fly registry
SANDBOX_SKIP_LOAD=true SANDBOX_UPDATE_DOPPLER=false pnpm sandbox build

# validate exact Fly image tag
RUN_SANDBOX_TESTS=true \
SANDBOX_TEST_PROVIDER=fly \
SANDBOX_TEST_SNAPSHOT_ID=registry.fly.io/iterate-sandbox:sha-df4b827-dirty \
FLY_DEFAULT_IMAGE=registry.fly.io/iterate-sandbox:sha-df4b827-dirty \
doppler run --config prd --project os -- \
pnpm sandbox test test/provider-base-image.test.ts --maxWorkers=1

# inspect Fly logs for temp validation apps
doppler run --config prd --project os -- fly logs -a <app-name> --no-tail

# verify tools in a live Fly machine
doppler run --config prd --project os -- fly ssh console -a <app-name> -u iterate -C 'bash -lc ...'
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the sandbox image build layering/caching and Fly machine creation retry behavior, which can affect CI reliability and runtime provisioning. Changes are bounded to build/test infra and Fly provider create-path, with explicit timeouts and guarded retries.
> 
> **Overview**
> Improves Fly sandbox stability by restructuring the `sandbox/Dockerfile` to keep pnpm fetch/install and post-sync work inside BuildKit cache mounts (and cleaning npm/corepack/uv/go caches in-layer) so large dependency/store bytes aren’t baked into shipped image layers.
> 
> Hardens Fly provisioning and CI: `FlyProvider.create` now retries a specific transient “machine disappears while waiting for started” failure with cleanup/backoff, and the sandbox test workflow runs a new `test/fly-daemon-smoke.test.ts` plus cleans up its leftover machines. Fly-specific smoke timeouts are increased (e.g. base image test to `420_000`) to match real cold-start behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85d7b3ee05824264411116bd8aa7d2e9308706fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

