### PR TITLE
comment out agent-browser install

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -195,7 +195,8 @@ RUN curl -fsSL https://opencode.ai/install | bash -s -- --version ${SANDBOX_OPEN
 ENV PATH="/home/iterate/.opencode/bin:$PATH"
 
 # Pre-download Chromium for agent-browser (pinned to version bundled with agent-browser@0.13.0)
-RUN agent-browser install
+# Comment out for now because our images are exceeding 8GB
+# RUN agent-browser install
 
 # Ensure wrapper scripts win after all PATH modifications.
 ENV PATH="/home/iterate/.iterate/bin:/home/iterate/.local/bin:$PATH"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the sandbox image build to no longer prefetch Chromium for `agent-browser`, which reduces image size but may surface runtime download/startup failures or slower first use if Chromium isn’t otherwise available.
> 
> **Overview**
> Disables the Docker build step that ran `agent-browser install` (Chromium pre-download), leaving it commented out to keep the sandbox image under the 8GB limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31104150a2407676077a31b3b59b752f1a489e92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->