### PR TITLE
Scope events secrets to project slug

### DIFF
--- a/apps/events/drizzle/0001_secrets_project_slug.sql
+++ b/apps/events/drizzle/0001_secrets_project_slug.sql
@@ -1,0 +1,5 @@
+DROP INDEX `secrets_name_unique`;--> statement-breakpoint
+DROP INDEX `idx_secrets_created_at`;--> statement-breakpoint
+ALTER TABLE `secrets` ADD `project_slug` text DEFAULT 'public' NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX `secrets_project_slug_name_unique` ON `secrets` (`project_slug`,`name`);--> statement-breakpoint
+CREATE INDEX `idx_secrets_project_slug_created_at` ON `secrets` (`project_slug`,`created_at`);

--- a/apps/events/drizzle/meta/0001_snapshot.json
+++ b/apps/events/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,89 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "969aba17-2897-4d88-81c9-b64b45e8c3a5",
+  "prevId": "ffc2fead-a54f-495e-90bc-3b48748405da",
+  "tables": {
+    "secrets": {
+      "name": "secrets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_slug": {
+          "name": "project_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "secrets_project_slug_name_unique": {
+          "name": "secrets_project_slug_name_unique",
+          "columns": ["project_slug", "name"],
+          "isUnique": true
+        },
+        "idx_secrets_project_slug_created_at": {
+          "name": "idx_secrets_project_slug_created_at",
+          "columns": ["project_slug", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/events/drizzle/meta/_journal.json
+++ b/apps/events/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1774895651763,
       "tag": "0000_initial",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1776283472635,
+      "tag": "0001_secrets_project_slug",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/events/e2e/vitest/auth.e2.test.ts
+++ b/apps/events/e2e/vitest/auth.e2.test.ts
@@ -112,6 +112,58 @@ describe("events auth-adjacent e2e", () => {
     },
     testTimeoutMs,
   );
+
+  projectHostTest(
+    "project hosts isolate secrets and allow the same secret name in different projects",
+    async () => {
+      const secretName = `shared-secret-${randomUUID().slice(0, 8)}`;
+      const defaultSecret = await publicApp.client.secrets.create({
+        name: secretName,
+        value: `public-${randomUUID().slice(0, 8)}`,
+        description: "Public project secret",
+      });
+      const teamSecret = await teamApp.client.secrets.create({
+        name: secretName,
+        value: `team-${randomUUID().slice(0, 8)}`,
+        description: "Team project secret",
+      });
+
+      try {
+        const defaultSecrets = await publicApp.client.secrets.list({ limit: 100, offset: 0 });
+        const teamSecrets = await teamApp.client.secrets.list({ limit: 100, offset: 0 });
+
+        expect(defaultSecrets.secrets).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: defaultSecret.id,
+              name: secretName,
+              description: "Public project secret",
+            }),
+          ]),
+        );
+        expect(defaultSecrets.secrets).not.toEqual(
+          expect.arrayContaining([expect.objectContaining({ id: teamSecret.id })]),
+        );
+
+        expect(teamSecrets.secrets).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: teamSecret.id,
+              name: secretName,
+              description: "Team project secret",
+            }),
+          ]),
+        );
+        expect(teamSecrets.secrets).not.toEqual(
+          expect.arrayContaining([expect.objectContaining({ id: defaultSecret.id })]),
+        );
+      } finally {
+        await publicApp.client.secrets.remove({ id: defaultSecret.id });
+        await teamApp.client.secrets.remove({ id: teamSecret.id });
+      }
+    },
+    testTimeoutMs,
+  );
 });
 
 function uniqueStreamPath() {

--- a/apps/events/src/components/app-sidebar.tsx
+++ b/apps/events/src/components/app-sidebar.tsx
@@ -44,7 +44,7 @@ export function AppSidebar({ projectSlug }: { projectSlug: ProjectSlugValue }) {
 }
 
 const items = [
-  { to: "/secrets/", label: "Env vars" },
+  { to: "/secrets/", label: "Secrets" },
   { to: "/streams/", label: "Streams" },
 ] as const;
 

--- a/apps/events/src/db/schema.ts
+++ b/apps/events/src/db/schema.ts
@@ -1,14 +1,18 @@
-import { index, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { index, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 export const secretsTable = sqliteTable(
   "secrets",
   {
     id: text("id").primaryKey(),
-    name: text("name").notNull().unique(),
+    projectSlug: text("project_slug").notNull().default("public"),
+    name: text("name").notNull(),
     value: text("value").notNull(),
     description: text("description"),
     createdAt: text("created_at").notNull(),
     updatedAt: text("updated_at").notNull(),
   },
-  (table) => [index("idx_secrets_created_at").on(table.createdAt)],
+  (table) => [
+    uniqueIndex("secrets_project_slug_name_unique").on(table.projectSlug, table.name),
+    index("idx_secrets_project_slug_created_at").on(table.projectSlug, table.createdAt),
+  ],
 );

--- a/apps/events/src/durable-objects/dynamic-processor.test.ts
+++ b/apps/events/src/durable-objects/dynamic-processor.test.ts
@@ -1,12 +1,12 @@
 import type { DynamicWorkerConfig } from "@iterate-com/events-contract";
 import { describe, expect, test } from "vitest";
-import { dynamicWorkerProjectSlugHeader } from "~/lib/dynamic-worker-egress.ts";
 import {
   buildDynamicWorkerLoaderCode,
   buildDynamicWorkerLoaderKey,
   resolveDynamicWorkerCompatibilityFlags,
   resolveDynamicWorkerOutboundGateway,
 } from "./dynamic-processor.ts";
+import { dynamicWorkerProjectSlugHeader } from "~/lib/dynamic-worker-egress.ts";
 
 const baseConfig: DynamicWorkerConfig = {
   compatibilityDate: "2026-02-05",

--- a/apps/events/src/durable-objects/dynamic-processor.test.ts
+++ b/apps/events/src/durable-objects/dynamic-processor.test.ts
@@ -1,5 +1,6 @@
 import type { DynamicWorkerConfig } from "@iterate-com/events-contract";
 import { describe, expect, test } from "vitest";
+import { dynamicWorkerProjectSlugHeader } from "~/lib/dynamic-worker-egress.ts";
 import {
   buildDynamicWorkerLoaderCode,
   buildDynamicWorkerLoaderKey,
@@ -63,6 +64,25 @@ describe("buildDynamicWorkerLoaderCode", () => {
     expect(parseRuntimeConfigModule(loaderCode.modules["runtime-config.js"])).toMatchObject({
       projectSlug: "team-a",
     });
+  });
+
+  test("overwrites worker.js with the latest runtime wrapper", () => {
+    const loaderCode = buildDynamicWorkerLoaderCode({
+      config: {
+        ...baseConfig,
+        modules: {
+          "worker.js": "export default { async run() {} };",
+        },
+      },
+      env: undefined,
+      globalOutbound: undefined,
+      projectSlug: "team-a",
+    });
+
+    expect(loaderCode.modules["worker.js"]).toContain(dynamicWorkerProjectSlugHeader);
+    expect(loaderCode.modules["worker.js"]).toContain(
+      'import runtimeConfig from "./runtime-config.js";',
+    );
   });
 });
 

--- a/apps/events/src/durable-objects/dynamic-processor.test.ts
+++ b/apps/events/src/durable-objects/dynamic-processor.test.ts
@@ -2,6 +2,7 @@ import type { DynamicWorkerConfig } from "@iterate-com/events-contract";
 import { describe, expect, test } from "vitest";
 import {
   buildDynamicWorkerLoaderCode,
+  buildDynamicWorkerLoaderKey,
   resolveDynamicWorkerCompatibilityFlags,
   resolveDynamicWorkerOutboundGateway,
 } from "./dynamic-processor.ts";
@@ -62,6 +63,19 @@ describe("buildDynamicWorkerLoaderCode", () => {
     expect(parseRuntimeConfigModule(loaderCode.modules["runtime-config.js"])).toMatchObject({
       projectSlug: "team-a",
     });
+  });
+});
+
+describe("buildDynamicWorkerLoaderKey", () => {
+  test("includes the project slug in the worker cache key", () => {
+    expect(
+      buildDynamicWorkerLoaderKey({
+        configKey: '{"config":{},"envVarsByKey":{}}',
+        path: "/streams/demo",
+        projectSlug: "team-a",
+        slug: "worker",
+      }),
+    ).toContain("dynamic-worker:team-a:/streams/demo:worker:");
   });
 });
 

--- a/apps/events/src/durable-objects/dynamic-processor.test.ts
+++ b/apps/events/src/durable-objects/dynamic-processor.test.ts
@@ -45,9 +45,23 @@ describe("buildDynamicWorkerLoaderCode", () => {
       config: baseConfig,
       env: undefined,
       globalOutbound,
+      projectSlug: "public",
     });
 
     expect(loaderCode.globalOutbound).toBe(globalOutbound);
+  });
+
+  test("injects project slug into the runtime config module", () => {
+    const loaderCode = buildDynamicWorkerLoaderCode({
+      config: baseConfig,
+      env: undefined,
+      globalOutbound: undefined,
+      projectSlug: "team-a",
+    });
+
+    expect(parseRuntimeConfigModule(loaderCode.modules["runtime-config.js"])).toMatchObject({
+      projectSlug: "team-a",
+    });
   });
 });
 
@@ -76,3 +90,7 @@ describe("resolveDynamicWorkerOutboundGateway", () => {
     });
   });
 });
+
+function parseRuntimeConfigModule(moduleText: string) {
+  return JSON.parse(moduleText.replace(/^export default /, "").replace(/;$/, ""));
+}

--- a/apps/events/src/durable-objects/dynamic-processor.ts
+++ b/apps/events/src/durable-objects/dynamic-processor.ts
@@ -532,7 +532,7 @@ function normalizeDynamicWorkerModules(modules: Record<string, string>) {
 
 function buildDynamicWorkerRuntimeConfigModule(input: {
   outboundGateway: DynamicWorkerOutboundGateway | undefined;
-  projectSlug?: string;
+  projectSlug: string;
 }) {
   return `export default ${JSON.stringify(input)};`;
 }
@@ -570,6 +570,7 @@ export function buildDynamicWorkerLoaderCode(args: {
 }) {
   const modules = {
     ...args.config.modules,
+    [defaultDynamicWorkerMainModule]: dynamicWorkerRuntimeModule,
     [defaultDynamicWorkerRuntimeConfigModule]: buildDynamicWorkerRuntimeConfigModule({
       outboundGateway: args.config.outboundGateway,
       projectSlug: args.projectSlug,

--- a/apps/events/src/durable-objects/dynamic-processor.ts
+++ b/apps/events/src/durable-objects/dynamic-processor.ts
@@ -13,7 +13,10 @@ import {
   defineBuiltinProcessor,
   type ProcessorAppendInput,
 } from "@iterate-com/events-contract/sdk";
-import { dynamicWorkerEgressConfigHeader } from "~/lib/dynamic-worker-egress.ts";
+import {
+  dynamicWorkerEgressConfigHeader,
+  dynamicWorkerProjectSlugHeader,
+} from "~/lib/dynamic-worker-egress.ts";
 
 export type DynamicWorkerAppendInput = ProcessorAppendInput;
 
@@ -127,6 +130,7 @@ function withDynamicWorkerEgressConfig(input, init) {
 
   const headers = new Headers(request.headers);
   headers.set("${dynamicWorkerEgressConfigHeader}", JSON.stringify(runtimeConfig.outboundGateway));
+  headers.set("${dynamicWorkerProjectSlugHeader}", runtimeConfig.projectSlug);
 
   return new Request(request, { headers });
 }
@@ -312,8 +316,6 @@ function normalizeDynamicWorkerConfig(input: {
       mainModule: defaultDynamicWorkerMainModule,
       modules: {
         [defaultDynamicWorkerProcessorModule]: input.script,
-        [defaultDynamicWorkerRuntimeConfigModule]:
-          buildDynamicWorkerRuntimeConfigModule(outboundGateway),
         [defaultDynamicWorkerMainModule]: dynamicWorkerRuntimeModule,
       },
       outboundGateway,
@@ -328,8 +330,6 @@ function normalizeDynamicWorkerConfig(input: {
     mainModule: defaultDynamicWorkerMainModule,
     modules: {
       ...normalizeDynamicWorkerModules(input.modules ?? {}),
-      [defaultDynamicWorkerRuntimeConfigModule]:
-        buildDynamicWorkerRuntimeConfigModule(outboundGateway),
       [defaultDynamicWorkerMainModule]: dynamicWorkerRuntimeModule,
     },
     outboundGateway,
@@ -342,6 +342,7 @@ export function createDynamicWorkerManager(context: {
   stream: (args?: { after?: StreamCursor; before?: StreamCursor }) => ReadableStream<Uint8Array>;
   createLoopbackBinding: (args: { exportName: string }) => Fetcher;
   getPath: () => StreamPath;
+  getProjectSlug: () => string;
   loader: WorkerLoader;
   waitUntil: (promise: Promise<unknown>) => void;
 }) {
@@ -428,7 +429,13 @@ export function createDynamicWorkerManager(context: {
         const entrypoint = context.loader
           .get(
             `dynamic-worker:${context.getPath()}:${slug}:${hashDynamicWorkerConfig(configKey)}`,
-            () => buildDynamicWorkerLoaderCode({ config, env, globalOutbound }),
+            () =>
+              buildDynamicWorkerLoaderCode({
+                config,
+                env,
+                globalOutbound,
+                projectSlug: context.getProjectSlug(),
+              }),
           )
           .getEntrypoint() as unknown as {
           run(stream: RpcDynamicWorkerTarget): Promise<void>;
@@ -518,10 +525,11 @@ function normalizeDynamicWorkerModules(modules: Record<string, string>) {
   return normalized;
 }
 
-function buildDynamicWorkerRuntimeConfigModule(
-  outboundGateway: DynamicWorkerOutboundGateway | undefined,
-) {
-  return `export default ${JSON.stringify({ outboundGateway })};`;
+function buildDynamicWorkerRuntimeConfigModule(input: {
+  outboundGateway: DynamicWorkerOutboundGateway | undefined;
+  projectSlug?: string;
+}) {
+  return `export default ${JSON.stringify(input)};`;
 }
 
 function buildDynamicWorkerEnvBindings(envVarsByKey: DynamicWorkerState["envVarsByKey"]) {
@@ -553,13 +561,22 @@ export function buildDynamicWorkerLoaderCode(args: {
   config: DynamicWorkerConfig;
   env: Record<string, string> | undefined;
   globalOutbound: Fetcher | undefined;
+  projectSlug: string;
 }) {
+  const modules = {
+    ...args.config.modules,
+    [defaultDynamicWorkerRuntimeConfigModule]: buildDynamicWorkerRuntimeConfigModule({
+      outboundGateway: args.config.outboundGateway,
+      projectSlug: args.projectSlug,
+    }),
+  };
+
   return {
     compatibilityDate: args.config.compatibilityDate,
     compatibilityFlags: resolveDynamicWorkerCompatibilityFlags(args.config.compatibilityFlags),
     env: args.env,
     mainModule: args.config.mainModule,
-    modules: args.config.modules,
+    modules,
     ...(args.globalOutbound == null ? {} : { globalOutbound: args.globalOutbound }),
   };
 }

--- a/apps/events/src/durable-objects/dynamic-processor.ts
+++ b/apps/events/src/durable-objects/dynamic-processor.ts
@@ -428,7 +428,12 @@ export function createDynamicWorkerManager(context: {
         const env = buildDynamicWorkerEnvBindings(envVarsByKey);
         const entrypoint = context.loader
           .get(
-            `dynamic-worker:${context.getPath()}:${slug}:${hashDynamicWorkerConfig(configKey)}`,
+            buildDynamicWorkerLoaderKey({
+              configKey,
+              path: context.getPath(),
+              projectSlug: context.getProjectSlug(),
+              slug,
+            }),
             () =>
               buildDynamicWorkerLoaderCode({
                 config,
@@ -579,6 +584,15 @@ export function buildDynamicWorkerLoaderCode(args: {
     modules,
     ...(args.globalOutbound == null ? {} : { globalOutbound: args.globalOutbound }),
   };
+}
+
+export function buildDynamicWorkerLoaderKey(args: {
+  configKey: string;
+  path: string;
+  projectSlug: string;
+  slug: string;
+}) {
+  return `dynamic-worker:${args.projectSlug}:${args.path}:${args.slug}:${hashDynamicWorkerConfig(args.configKey)}`;
 }
 
 function hashDynamicWorkerConfig(value: string) {

--- a/apps/events/src/durable-objects/stream.ts
+++ b/apps/events/src/durable-objects/stream.ts
@@ -163,6 +163,7 @@ export class StreamDurableObject extends DurableObject<Env> {
         return this.env.DYNAMIC_WORKER_EGRESS_GATEWAY as unknown as Fetcher;
       },
       getPath: () => this.state.path,
+      getProjectSlug: () => this.state.projectSlug,
       loader: this.env.LOADER,
       waitUntil: (promise) => this.ctx.waitUntil(promise),
     });

--- a/apps/events/src/dynamic-worker-egress-gateway.test.ts
+++ b/apps/events/src/dynamic-worker-egress-gateway.test.ts
@@ -42,14 +42,4 @@ describe("parseDynamicWorkerEgressGatewayConfig", () => {
       ),
     ).toThrow("DynamicWorkerEgressGateway received an invalid outbound gateway config.");
   });
-
-  test("rejects a config without a project slug", () => {
-    expect(() =>
-      parseDynamicWorkerEgressGatewayConfig(
-        JSON.stringify({
-          entrypoint: "DynamicWorkerEgressGateway",
-        }),
-      ),
-    ).not.toThrow();
-  });
 });

--- a/apps/events/src/dynamic-worker-egress-gateway.test.ts
+++ b/apps/events/src/dynamic-worker-egress-gateway.test.ts
@@ -42,4 +42,14 @@ describe("parseDynamicWorkerEgressGatewayConfig", () => {
       ),
     ).toThrow("DynamicWorkerEgressGateway received an invalid outbound gateway config.");
   });
+
+  test("rejects a config without a project slug", () => {
+    expect(() =>
+      parseDynamicWorkerEgressGatewayConfig(
+        JSON.stringify({
+          entrypoint: "DynamicWorkerEgressGateway",
+        }),
+      ),
+    ).not.toThrow();
+  });
 });

--- a/apps/events/src/dynamic-worker-egress-gateway.ts
+++ b/apps/events/src/dynamic-worker-egress-gateway.ts
@@ -1,6 +1,10 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
+import { ProjectSlug } from "@iterate-com/events-contract";
 import { parseDynamicWorkerEgressGatewayConfig } from "~/lib/dynamic-worker-egress-config.ts";
-import { dynamicWorkerEgressConfigHeader } from "~/lib/dynamic-worker-egress.ts";
+import {
+  dynamicWorkerEgressConfigHeader,
+  dynamicWorkerProjectSlugHeader,
+} from "~/lib/dynamic-worker-egress.ts";
 import { replaceIterateSecretReferences } from "~/lib/iterate-secret-references.ts";
 
 export class DynamicWorkerEgressGateway extends WorkerEntrypoint<Env> {
@@ -10,16 +14,30 @@ export class DynamicWorkerEgressGateway extends WorkerEntrypoint<Env> {
     const gatewayConfig = parseDynamicWorkerEgressGatewayConfig(
       headers.get(dynamicWorkerEgressConfigHeader),
     );
+    const parsedProjectSlug = ProjectSlug.safeParse(headers.get(dynamicWorkerProjectSlugHeader));
 
     headers.delete(dynamicWorkerEgressConfigHeader);
+    headers.delete(dynamicWorkerProjectSlugHeader);
 
-    if ((gatewayConfig?.secretHeaderName == null) !== (gatewayConfig?.secretHeaderValue == null)) {
+    if (gatewayConfig == null) {
+      return fetch(
+        new Request(request, {
+          headers,
+        }),
+      );
+    }
+    if (!parsedProjectSlug.success) {
+      throw new Error("DynamicWorkerEgressGateway requires a valid project slug header.");
+    }
+    const projectSlug = parsedProjectSlug.data;
+
+    if ((gatewayConfig.secretHeaderName == null) !== (gatewayConfig.secretHeaderValue == null)) {
       throw new Error(
         "DynamicWorkerEgressGateway requires secretHeaderName and secretHeaderValue together.",
       );
     }
 
-    if (gatewayConfig?.secretHeaderName != null && gatewayConfig.secretHeaderValue != null) {
+    if (gatewayConfig.secretHeaderName != null && gatewayConfig.secretHeaderValue != null) {
       headers.set(gatewayConfig.secretHeaderName, gatewayConfig.secretHeaderValue);
     }
 
@@ -31,12 +49,14 @@ export class DynamicWorkerEgressGateway extends WorkerEntrypoint<Env> {
         const resolved = await replaceIterateSecretReferences({
           input: headerValue,
           loadSecret: async (secretKey) => {
-            const result = await this.env.DB.prepare("SELECT value FROM secrets WHERE name = ?")
-              .bind(secretKey)
+            const result = await this.env.DB.prepare(
+              "SELECT value FROM secrets WHERE project_slug = ? AND name = ?",
+            )
+              .bind(projectSlug, secretKey)
               .first<{ value: string }>();
 
             if (typeof result?.value !== "string") {
-              throw new Error(`Secret "${secretKey}" was not found in apps/events secrets.`);
+              throw new Error(`Secret "${secretKey}" was not found in project "${projectSlug}".`);
             }
 
             return result.value;
@@ -60,6 +80,7 @@ export class DynamicWorkerEgressGateway extends WorkerEntrypoint<Env> {
         headerNames: Array.from(headers.keys()),
         method: request.method,
         pathname: target.pathname,
+        projectSlug,
         secretKeys: Array.from(resolvedSecretKeys),
         url: target.origin,
       });
@@ -71,6 +92,7 @@ export class DynamicWorkerEgressGateway extends WorkerEntrypoint<Env> {
         headerNames: replacedHeaderNames,
         method: request.method,
         pathname: target.pathname,
+        projectSlug,
         replacementCount: replacedHeaderNames.length,
         secretKeys: Array.from(resolvedSecretKeys),
         url: target.origin,

--- a/apps/events/src/dynamic-worker-egress-gateway.ts
+++ b/apps/events/src/dynamic-worker-egress-gateway.ts
@@ -11,21 +11,23 @@ export class DynamicWorkerEgressGateway extends WorkerEntrypoint<Env> {
   async fetch(request: Request) {
     const headers = new Headers(request.headers);
     const target = new URL(request.url);
-    const gatewayConfig = parseDynamicWorkerEgressGatewayConfig(
-      headers.get(dynamicWorkerEgressConfigHeader),
-    );
-    const parsedProjectSlug = ProjectSlug.safeParse(headers.get(dynamicWorkerProjectSlugHeader));
+    const rawGatewayConfig = headers.get(dynamicWorkerEgressConfigHeader);
 
     headers.delete(dynamicWorkerEgressConfigHeader);
     headers.delete(dynamicWorkerProjectSlugHeader);
 
-    if (gatewayConfig == null) {
+    if (rawGatewayConfig == null) {
       return fetch(
         new Request(request, {
           headers,
         }),
       );
     }
+
+    const gatewayConfig = parseDynamicWorkerEgressGatewayConfig(rawGatewayConfig) ?? {};
+    const parsedProjectSlug = ProjectSlug.safeParse(
+      request.headers.get(dynamicWorkerProjectSlugHeader),
+    );
     if (!parsedProjectSlug.success) {
       throw new Error("DynamicWorkerEgressGateway requires a valid project slug header.");
     }

--- a/apps/events/src/lib/dynamic-worker-egress-config.ts
+++ b/apps/events/src/lib/dynamic-worker-egress-config.ts
@@ -1,17 +1,9 @@
-import {
-  DynamicWorkerOutboundGateway,
-  type DynamicWorkerOutboundGateway as DynamicWorkerOutboundGatewayType,
-} from "@iterate-com/events-contract";
+import { DynamicWorkerOutboundGateway } from "@iterate-com/events-contract";
 import { dynamicWorkerEgressConfigHeader } from "./dynamic-worker-egress.ts";
-
-type DynamicWorkerEgressGatewayProps = {
-  secretHeaderName?: string;
-  secretHeaderValue?: string;
-};
 
 export function parseDynamicWorkerEgressGatewayConfig(
   headerValue: string | null,
-): DynamicWorkerEgressGatewayProps | undefined {
+): { secretHeaderName?: string; secretHeaderValue?: string } | undefined {
   if (headerValue == null) {
     return undefined;
   }
@@ -41,11 +33,5 @@ export function parseDynamicWorkerEgressGatewayConfig(
     throw new Error("DynamicWorkerEgressGateway received an invalid outbound gateway config.");
   }
 
-  return toGatewayProps(gateway.data);
-}
-
-function toGatewayProps(
-  gateway: DynamicWorkerOutboundGatewayType,
-): DynamicWorkerEgressGatewayProps | undefined {
-  return gateway.props;
+  return gateway.data.props;
 }

--- a/apps/events/src/lib/dynamic-worker-egress.ts
+++ b/apps/events/src/lib/dynamic-worker-egress.ts
@@ -1,1 +1,2 @@
 export const dynamicWorkerEgressConfigHeader = "x-iterate-dynamic-worker-egress-config";
+export const dynamicWorkerProjectSlugHeader = "x-iterate-dynamic-worker-project-slug";

--- a/apps/events/src/orpc/routers/secrets.ts
+++ b/apps/events/src/orpc/routers/secrets.ts
@@ -1,7 +1,7 @@
-import { desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 import { ORPCError } from "@orpc/server";
 import { secretsTable } from "~/db/schema.ts";
-import { os } from "~/orpc/orpc.ts";
+import { os, withProject } from "~/orpc/orpc.ts";
 
 function isUniqueConstraintError(error: unknown): boolean {
   return error instanceof Error && /unique|UNIQUE constraint/i.test(error.message);
@@ -9,7 +9,7 @@ function isUniqueConstraintError(error: unknown): boolean {
 
 export const secretsRouter = {
   secrets: {
-    create: os.secrets.create.handler(async ({ context, input }) => {
+    create: os.secrets.create.use(withProject).handler(async ({ context, input }) => {
       const now = new Date().toISOString();
       const id = crypto.randomUUID();
       const name = input.name.trim();
@@ -17,6 +17,7 @@ export const secretsRouter = {
       try {
         await context.db.insert(secretsTable).values({
           id,
+          projectSlug: context.projectSlug,
           name,
           value: input.value,
           description: input.description ?? null,
@@ -25,7 +26,9 @@ export const secretsRouter = {
         });
       } catch (error) {
         if (isUniqueConstraintError(error)) {
-          throw new ORPCError("CONFLICT", { message: `Env var name "${name}" already exists` });
+          throw new ORPCError("CONFLICT", {
+            message: `Secret name "${name}" already exists in project "${context.projectSlug}"`,
+          });
         }
         throw error;
       }
@@ -38,10 +41,11 @@ export const secretsRouter = {
         updatedAt: now,
       };
     }),
-    list: os.secrets.list.handler(async ({ context, input }) => {
-      const [totalRow] = await context.db
+    list: os.secrets.list.use(withProject).handler(async ({ context, input }) => {
+      const scopedTotalRow = await context.db
         .select({ value: sql<number>`count(*)` })
-        .from(secretsTable);
+        .from(secretsTable)
+        .where(eq(secretsTable.projectSlug, context.projectSlug));
       const rows = await context.db
         .select({
           id: secretsTable.id,
@@ -51,24 +55,31 @@ export const secretsRouter = {
           updatedAt: secretsTable.updatedAt,
         })
         .from(secretsTable)
+        .where(eq(secretsTable.projectSlug, context.projectSlug))
         .orderBy(desc(secretsTable.createdAt))
         .limit(input.limit)
         .offset(input.offset);
 
-      return { secrets: rows, total: totalRow?.value ?? 0 };
+      return { secrets: rows, total: scopedTotalRow[0]?.value ?? 0 };
     }),
-    remove: os.secrets.remove.handler(async ({ context, input }) => {
+    remove: os.secrets.remove.use(withProject).handler(async ({ context, input }) => {
       const [existing] = await context.db
         .select()
         .from(secretsTable)
-        .where(eq(secretsTable.id, input.id))
+        .where(
+          and(eq(secretsTable.id, input.id), eq(secretsTable.projectSlug, context.projectSlug)),
+        )
         .limit(1);
 
       if (!existing) {
         return { ok: true as const, id: input.id, deleted: false };
       }
 
-      await context.db.delete(secretsTable).where(eq(secretsTable.id, input.id));
+      await context.db
+        .delete(secretsTable)
+        .where(
+          and(eq(secretsTable.id, input.id), eq(secretsTable.projectSlug, context.projectSlug)),
+        );
       return { ok: true as const, id: input.id, deleted: true };
     }),
   },

--- a/apps/events/src/routes/_app/secrets.index.tsx
+++ b/apps/events/src/routes/_app/secrets.index.tsx
@@ -74,9 +74,9 @@ function SecretsIndexPage() {
   return (
     <section className="max-w-md space-y-6 p-4">
       <div className="space-y-1">
-        <h2 className="text-sm font-semibold">Env vars</h2>
+        <h2 className="text-sm font-semibold">Secrets</h2>
         <p className="text-sm text-muted-foreground">
-          Env vars for this project. Values are masked in the UI and stored in plaintext in D1 for
+          Secrets for this project. Values are masked in the UI and stored in plaintext in D1 for
           this demo.
         </p>
       </div>
@@ -106,7 +106,7 @@ function SecretsIndexPage() {
                     aria-invalid={isInvalid}
                     placeholder="GITHUB_ACCESS_TOKEN"
                   />
-                  <FieldDescription>Unique env var name.</FieldDescription>
+                  <FieldDescription>Unique secret name within this project.</FieldDescription>
                   {isInvalid ? <FieldError errors={field.state.meta.errors} /> : null}
                 </Field>
               );
@@ -164,7 +164,7 @@ function SecretsIndexPage() {
           <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting] as const}>
             {([canSubmit, isSubmitting]) => (
               <Button type="submit" size="sm" disabled={!canSubmit || isSubmitting}>
-                {isSubmitting ? "Adding..." : "Add env var"}
+                {isSubmitting ? "Adding..." : "Add secret"}
               </Button>
             )}
           </form.Subscribe>
@@ -199,7 +199,7 @@ function SecretsIndexPage() {
       </div>
 
       {secretsData && secretsData.secrets.length === 0 && (
-        <p className="text-sm text-muted-foreground">No env vars yet. Create one above.</p>
+        <p className="text-sm text-muted-foreground">No secrets yet. Create one above.</p>
       )}
     </section>
   );

--- a/apps/events/src/routes/_app/secrets.tsx
+++ b/apps/events/src/routes/_app/secrets.tsx
@@ -2,7 +2,7 @@ import { Outlet, createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_app/secrets")({
   staticData: {
-    breadcrumb: "Env vars",
+    breadcrumb: "Secrets",
   },
   component: SecretsLayout,
 });


### PR DESCRIPTION
## Summary
- scope `apps/events` secrets by project slug in the schema and oRPC handlers
- resolve dynamic worker secret lookups against the current project without widening the gateway config shape
- rename the UI from "Env vars" to "Secrets" and add coverage for project-scoped secret isolation

## Verification
- `pnpm drizzle-kit generate --name secrets_project_slug`
- `pnpm drizzle-kit check`
- `pnpm typecheck`
- `pnpm test`

## Review
- reviewed against `jonasland/RULES.md`
- used parallel subagent review passes and folded the cleanup back into the change before opening this PR

<!-- CLOUDFLARE_PREVIEW_ENVIRONMENTS -->
## Preview Environments
<!-- CLOUDFLARE_PREVIEW_ENVIRONMENTS_STATE -->
<!--
{
  "events": {
    "appDisplayName": "Events",
    "appSlug": "events",
    "status": "released",
    "updatedAt": "2026-04-15T22:52:29.335Z",
    "leasedUntil": null,
    "headSha": "6778d69b8499fcb77d4229518ff4857907569ae8",
    "message": "Preview environment released.",
    "previewEnvironmentAlchemyStageName": null,
    "previewEnvironmentDopplerConfigName": null,
    "previewEnvironmentIdentifier": null,
    "previewEnvironmentSemaphoreLeaseId": null,
    "previewEnvironmentSlug": null,
    "previewEnvironmentType": null,
    "publicUrl": "https://events-preview-1.iterate.com",
    "runUrl": "https://github.com/iterate/iterate/actions/runs/24482201173",
    "shortSha": "6778d69"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_ENVIRONMENTS_STATE -->

### Events
Status: released
Commit: `6778d69`
Preview: https://events-preview-1.iterate.com
Summary: Preview environment released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/24482201173)
Updated: 2026-04-15T22:52:29.335Z
<!-- /CLOUDFLARE_PREVIEW_ENVIRONMENTS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistent data (schema + indexes) and request scoping for secret reads/writes; bugs could cause secret leakage across projects or missing secrets after migration.
> 
> **Overview**
> Secrets are now **project-scoped** in `apps/events`: the `secrets` table adds `project_slug` (default `public`), replaces the global unique `name` constraint with a composite unique index `(project_slug, name)`, and updates indexes/migrations accordingly.
> 
> The secrets oRPC handlers (`create`, `list`, `remove`) now require `withProject` and filter/insert by `context.projectSlug`, and dynamic worker egress now passes a `x-iterate-dynamic-worker-project-slug` header, includes the slug in the dynamic worker loader cache key, and resolves iterate secret references via `WHERE project_slug = ? AND name = ?`. UI copy is renamed from “Env vars” to “Secrets”, and an e2e test asserts the same secret name can exist in different projects without leaking across listings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6778d69b8499fcb77d4229518ff4857907569ae8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->