### PR TITLE
agents: upgrade default model to kimi-k2.6

### DIFF
--- a/apps/agents/e2e/vitest/iterate-agent-agent-loop.e2e.test.ts
+++ b/apps/agents/e2e/vitest/iterate-agent-agent-loop.e2e.test.ts
@@ -4,7 +4,7 @@
  * `env.AI.run()` routed through the `e2e` AI Gateway → emits an
  * `agent-input-added` event with role `assistant` carrying the model's reply.
  *
- * Runs one scenario today (`kimi` → `@cf/moonshotai/kimi-k2.5`), with the
+ * Runs one scenario today (`kimi` → `@cf/moonshotai/kimi-k2.6`), with the
  * test scaffolding shaped as a `Promise.all` over `SCENARIOS` so `openai/*` and
  * `anthropic/*` rows can be added back once caching works for them (see the
  * comment above `SCENARIOS` below).
@@ -66,7 +66,7 @@ const AGENT_INPUT_CONTENT = "What is the capital of France? Answer with one word
 // `cf-aig-authorization: Bearer $CLOUDFLARE_API_TOKEN` — that path supports
 // both Unified Billing and caching for every provider. Then add
 // `openai/gpt-5.4` and `anthropic/claude-opus-4.7` back to this list.
-const SCENARIOS = [{ label: "kimi", model: "@cf/moonshotai/kimi-k2.5" }] as const;
+const SCENARIOS = [{ label: "kimi", model: "@cf/moonshotai/kimi-k2.6" }] as const;
 
 describe.sequential("agents iterate-agent agent loop e2e", () => {
   test.skipIf(process.env.AGENTS_E2E_ITERATE_AGENT !== "1")(

--- a/apps/agents/src/durable-objects/agent-processor.ts
+++ b/apps/agents/src/durable-objects/agent-processor.ts
@@ -128,13 +128,13 @@ export const IterateAgentProcessorState = z.object({
       }),
     )
     .default([]),
-  llmConfig: LlmConfig.default({ model: "@cf/moonshotai/kimi-k2.5", runOpts: {} }),
+  llmConfig: LlmConfig.default({ model: "@cf/moonshotai/kimi-k2.6", runOpts: {} }),
 });
 export type IterateAgentProcessorState = z.infer<typeof IterateAgentProcessorState>;
 
 export const iterateAgentProcessorInitialState: IterateAgentProcessorState = {
   history: [],
-  llmConfig: { model: "@cf/moonshotai/kimi-k2.5", runOpts: {} },
+  llmConfig: { model: "@cf/moonshotai/kimi-k2.6", runOpts: {} },
 };
 
 const CodemodeBlockAddedEvent = z.object({

--- a/apps/agents/src/lib/worker-env.d.ts
+++ b/apps/agents/src/lib/worker-env.d.ts
@@ -3,7 +3,7 @@ import type { worker } from "../../alchemy.run.ts";
 // Alchemy's `Ai()` binding defaults its model-list generic to `Record<string, any>`, which
 // strips per-model typing off `env.AI.run(...)`. Cloudflare's own docs show the canonical
 // shape as `AI: Ai`, which defaults to the workerd-generated `AiModels` map (with full typed
-// overloads for every supported model, including `@cf/moonshotai/kimi-k2.5`).
+// overloads for every supported model, including `@cf/moonshotai/kimi-k2.6`).
 // See https://developers.cloudflare.com/workers-ai/configuration/bindings/.
 export type CloudflareEnv = Omit<typeof worker.Env, "AI"> & {
   LOADER: WorkerLoader;


### PR DESCRIPTION
## Summary

Bumps the `IterateAgent` processor default model + e2e scenario + env typedoc from `@cf/moonshotai/kimi-k2.5` to `@cf/moonshotai/kimi-k2.6`.

Both versions are live on Workers AI — verified against the CF models API on the production account:

\`\`\`
$ curl -sS "…/accounts/\$ACC/ai/models/search?search=kimi" | jq -r '.result[].name'
@cf/moonshotai/kimi-k2.5
@cf/moonshotai/kimi-k2.6
\`\`\`

## Test plan

- [x] `pnpm agents typecheck` clean
- [ ] CI `test` + `specs` green
- [ ] Post-merge: re-run the deployed-agents multi-turn + codemode demo against `agents.iterate.com` with the new default model, verify Paris/Berlin/codemode all still work.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iterate/iterate/pull/1277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk model-version bump, but it changes the default LLM used in production and may subtly affect responses/cost/latency.
> 
> **Overview**
> Updates the `IterateAgent` default Workers AI model from `@cf/moonshotai/kimi-k2.5` to `@cf/moonshotai/kimi-k2.6` (Durable Object processor state + initial state).
> 
> Aligns the agent-loop e2e scenario and the Workers AI env type doc comment to reference `kimi-k2.6`, keeping tests/documentation consistent with the new default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 012c77890e16bd7f4fd015c15a1f034b9f01a404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW_ENVIRONMENTS -->
## Preview Environments
<!-- CLOUDFLARE_PREVIEW_ENVIRONMENTS_STATE -->
<!--
{
  "agents": {
    "appDisplayName": "Agents",
    "appSlug": "agents",
    "status": "released",
    "updatedAt": "2026-04-21T23:01:39.493Z",
    "leasedUntil": null,
    "headSha": "012c77890e16bd7f4fd015c15a1f034b9f01a404",
    "message": "Preview environment released.",
    "previewEnvironmentAlchemyStageName": null,
    "previewEnvironmentDopplerConfigName": null,
    "previewEnvironmentIdentifier": null,
    "previewEnvironmentSemaphoreLeaseId": null,
    "previewEnvironmentSlug": null,
    "previewEnvironmentType": null,
    "publicUrl": "https://agents-preview-1.iterate.workers.dev",
    "runUrl": "https://github.com/iterate/iterate/actions/runs/24750596271",
    "shortSha": "012c778"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_ENVIRONMENTS_STATE -->

### Agents
Status: released
Commit: `012c778`
Preview: https://agents-preview-1.iterate.workers.dev
Summary: Preview environment released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/24750596271)
Updated: 2026-04-21T23:01:39.493Z
<!-- /CLOUDFLARE_PREVIEW_ENVIRONMENTS -->