### PR TITLE
example: add default 404 component and pretty-print OpenAPI JSON

### DIFF
--- a/apps/agents/src/orpc/handler.ts
+++ b/apps/agents/src/orpc/handler.ts
@@ -1,5 +1,8 @@
 import { EvlogHandlerPlugin } from "@iterate-com/shared/apps/logging/orpc-plugin";
-import { createOpenApiReferencePluginForApp } from "@iterate-com/shared/apps/orpc";
+import {
+  createOpenApiReferencePluginForApp,
+  prettyJsonInterceptor,
+} from "@iterate-com/shared/apps/orpc";
 import { OpenAPIHandler } from "@orpc/openapi/fetch";
 import { RPCHandler } from "@orpc/server/fetch";
 import manifest from "~/app.ts";
@@ -9,23 +12,7 @@ import { appRouter } from "~/orpc/root.ts";
 const plugins = [new EvlogHandlerPlugin<AppContext>()];
 
 export const orpcOpenApiHandler = new OpenAPIHandler(appRouter, {
-  adapterInterceptors: [
-    async (options) => {
-      const result = await options.next();
-      const type = result.response?.headers.get("content-type");
-      if (!result.matched || result.response.body === null || !type?.includes("json")) {
-        return result;
-      }
-
-      return {
-        ...result,
-        response: new Response(
-          JSON.stringify(await result.response.json(), null, 2),
-          result.response,
-        ),
-      };
-    },
-  ],
+  adapterInterceptors: [prettyJsonInterceptor],
   plugins: [
     ...plugins,
     createOpenApiReferencePluginForApp(manifest, ["/sample"], {

--- a/apps/events/src/orpc/handler.ts
+++ b/apps/events/src/orpc/handler.ts
@@ -1,4 +1,7 @@
-import { createOpenApiReferencePluginForApp } from "@iterate-com/shared/apps/orpc";
+import {
+  createOpenApiReferencePluginForApp,
+  prettyJsonInterceptor,
+} from "@iterate-com/shared/apps/orpc";
 import { EvlogHandlerPlugin } from "@iterate-com/shared/apps/logging/orpc-plugin";
 import { OpenAPIHandler } from "@orpc/openapi/fetch";
 import { experimental_RPCHandler as WebSocketRPCHandler } from "@orpc/server/crossws";
@@ -10,27 +13,7 @@ import { appRouter } from "~/orpc/root.ts";
 const plugins = [new EvlogHandlerPlugin<AppContext>()];
 
 export const orpcOpenApiHandler = new OpenAPIHandler(appRouter, {
-  adapterInterceptors: [
-    // We want nice pretty JSON to come back e.g. from
-    // curl --json '{"type": "create", "payload": {"name": "test"}}' https://events.iterate.com/api/streams/
-    // Keep prettifying at the fetch transport boundary, not in route handlers:
-    // https://orpc.dev/docs/adapters/http
-    // SSE uses `text/event-stream`, so leave those responses untouched:
-    // https://orpc.dev/docs/event-iterator
-    async (options) => {
-      const result = await options.next();
-      const type = result.response?.headers.get("content-type");
-      if (!result.matched || result.response.body === null || !type?.includes("json"))
-        return result;
-      return {
-        ...result,
-        response: new Response(
-          JSON.stringify(await result.response.json(), null, 2),
-          result.response,
-        ),
-      };
-    },
-  ],
+  adapterInterceptors: [prettyJsonInterceptor],
   plugins: [
     ...plugins,
     createOpenApiReferencePluginForApp(manifest, ["/streams", "/secrets"], {

--- a/apps/example/src/orpc/handler.ts
+++ b/apps/example/src/orpc/handler.ts
@@ -12,6 +12,21 @@ import { appRouter } from "~/orpc/root.ts";
 const plugins = [new CORSPlugin({ origin: "*" }), new EvlogHandlerPlugin<AppContext>()];
 
 export const orpcOpenApiHandler = new OpenAPIHandler(appRouter, {
+  adapterInterceptors: [
+    async (options) => {
+      const result = await options.next();
+      const type = result.response?.headers.get("content-type");
+      if (!result.matched || result.response.body === null || !type?.includes("json"))
+        return result;
+      return {
+        ...result,
+        response: new Response(
+          JSON.stringify(await result.response.json(), null, 2),
+          result.response,
+        ),
+      };
+    },
+  ],
   plugins: [
     ...plugins,
     createOpenApiReferencePluginForApp(manifest, ["/debug", "/test", "/things"], {

--- a/apps/example/src/orpc/handler.ts
+++ b/apps/example/src/orpc/handler.ts
@@ -1,4 +1,7 @@
-import { createOpenApiReferencePluginForApp } from "@iterate-com/shared/apps/orpc";
+import {
+  createOpenApiReferencePluginForApp,
+  prettyJsonInterceptor,
+} from "@iterate-com/shared/apps/orpc";
 import { EvlogHandlerPlugin } from "@iterate-com/shared/apps/logging/orpc-plugin";
 import { OpenAPIHandler } from "@orpc/openapi/fetch";
 import { onError } from "@orpc/server";
@@ -12,21 +15,7 @@ import { appRouter } from "~/orpc/root.ts";
 const plugins = [new CORSPlugin({ origin: "*" }), new EvlogHandlerPlugin<AppContext>()];
 
 export const orpcOpenApiHandler = new OpenAPIHandler(appRouter, {
-  adapterInterceptors: [
-    async (options) => {
-      const result = await options.next();
-      const type = result.response?.headers.get("content-type");
-      if (!result.matched || result.response.body === null || !type?.includes("json"))
-        return result;
-      return {
-        ...result,
-        response: new Response(
-          JSON.stringify(await result.response.json(), null, 2),
-          result.response,
-        ),
-      };
-    },
-  ],
+  adapterInterceptors: [prettyJsonInterceptor],
   plugins: [
     ...plugins,
     createOpenApiReferencePluginForApp(manifest, ["/debug", "/test", "/things"], {

--- a/apps/example/src/router.tsx
+++ b/apps/example/src/router.tsx
@@ -1,12 +1,20 @@
 import type { QueryClient } from "@tanstack/react-query";
+import type { NotFoundRouteProps } from "@tanstack/react-router";
 import { createRouter as createTanStackRouter } from "@tanstack/react-router";
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
+import { DefaultNotFoundComponent } from "@iterate-com/ui/components/route-defaults";
 import { makeQueryClient } from "./orpc/client.ts";
 import { routeTree } from "./routeTree.gen.ts";
 
 export type RouterContext = {
   queryClient: QueryClient;
 };
+
+// Cast to break circular type reference between DefaultNotFoundComponent's
+// props and the router type used in the Register augmentation below.
+const notFoundComponent = DefaultNotFoundComponent as (
+  props: NotFoundRouteProps,
+) => React.ReactNode;
 
 export function getRouter() {
   const queryClient = makeQueryClient();
@@ -17,6 +25,7 @@ export function getRouter() {
       queryClient,
     } satisfies RouterContext,
     defaultPreload: "intent",
+    defaultNotFoundComponent: notFoundComponent,
   });
 
   // Let route loaders and components share the same query client on server and client.

--- a/apps/example/src/router.tsx
+++ b/apps/example/src/router.tsx
@@ -10,8 +10,12 @@ export type RouterContext = {
   queryClient: QueryClient;
 };
 
-// Cast to break circular type reference between DefaultNotFoundComponent's
-// props and the router type used in the Register augmentation below.
+// Widen the component type to break a circular reference: the `declare module`
+// below resolves `ReturnType<typeof getRouter>`, which expands
+// `defaultNotFoundComponent`'s type, which references `RegisteredRouter`,
+// which reads `Register.router` — the very thing being defined.
+// Events/OS avoid this because their routeTree.gen.ts augments
+// `@tanstack/react-start` (under @ts-nocheck) instead of `@tanstack/react-router`.
 const notFoundComponent = DefaultNotFoundComponent as (
   props: NotFoundRouteProps,
 ) => React.ReactNode;

--- a/apps/example/src/router.tsx
+++ b/apps/example/src/router.tsx
@@ -1,5 +1,4 @@
 import type { QueryClient } from "@tanstack/react-query";
-import type { NotFoundRouteProps } from "@tanstack/react-router";
 import { createRouter as createTanStackRouter } from "@tanstack/react-router";
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
 import { DefaultNotFoundComponent } from "@iterate-com/ui/components/route-defaults";
@@ -10,16 +9,6 @@ export type RouterContext = {
   queryClient: QueryClient;
 };
 
-// Widen the component type to break a circular reference: the `declare module`
-// below resolves `ReturnType<typeof getRouter>`, which expands
-// `defaultNotFoundComponent`'s type, which references `RegisteredRouter`,
-// which reads `Register.router` — the very thing being defined.
-// Events/OS avoid this because their routeTree.gen.ts augments
-// `@tanstack/react-start` (under @ts-nocheck) instead of `@tanstack/react-router`.
-const notFoundComponent = DefaultNotFoundComponent as (
-  props: NotFoundRouteProps,
-) => React.ReactNode;
-
 export function getRouter() {
   const queryClient = makeQueryClient();
 
@@ -29,7 +18,7 @@ export function getRouter() {
       queryClient,
     } satisfies RouterContext,
     defaultPreload: "intent",
-    defaultNotFoundComponent: notFoundComponent,
+    defaultNotFoundComponent: DefaultNotFoundComponent,
   });
 
   // Let route loaders and components share the same query client on server and client.
@@ -41,10 +30,4 @@ export function getRouter() {
   });
 
   return router;
-}
-
-declare module "@tanstack/react-router" {
-  interface Register {
-    router: ReturnType<typeof getRouter>;
-  }
 }

--- a/apps/example/src/routes/_app/terminal.tsx
+++ b/apps/example/src/routes/_app/terminal.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { ClientOnly, createFileRoute } from "@tanstack/react-router";
 import { Terminal } from "@iterate-com/ui/components/terminal";
 import { z } from "zod";
@@ -22,9 +22,14 @@ function TerminalPage() {
   const { command, autorun, ptyId } = search;
   const navigate = Route.useNavigate();
 
+  // Keep a ref so the callback identity stays stable (Terminal's effect
+  // depends on onParamsChange and would tear down XTerm on every change).
+  const searchRef = useRef(search);
+  searchRef.current = search;
+
   const handleParamsChange = useCallback(
     (params: { ptyId?: string; clearCommand?: boolean }) => {
-      const next = { ...search };
+      const next = { ...searchRef.current };
       if (params.ptyId) next.ptyId = params.ptyId;
       if (params.clearCommand) {
         delete next.command;
@@ -32,7 +37,7 @@ function TerminalPage() {
       }
       navigate({ search: next, replace: true });
     },
-    [navigate, search],
+    [navigate],
   );
 
   return (

--- a/apps/example/src/routes/_app/terminal.tsx
+++ b/apps/example/src/routes/_app/terminal.tsx
@@ -18,30 +18,21 @@ export const Route = createFileRoute("/_app/terminal")({
 });
 
 function TerminalPage() {
-  const { command, autorun, ptyId } = Route.useSearch();
+  const search = Route.useSearch();
+  const { command, autorun, ptyId } = search;
   const navigate = Route.useNavigate();
 
   const handleParamsChange = useCallback(
     (params: { ptyId?: string; clearCommand?: boolean }) => {
-      navigate({
-        search: (prev) => {
-          const next = { ...prev };
-
-          if (params.ptyId) {
-            next.ptyId = params.ptyId;
-          }
-
-          if (params.clearCommand) {
-            delete next.command;
-            delete next.autorun;
-          }
-
-          return next;
-        },
-        replace: true,
-      });
+      const next = { ...search };
+      if (params.ptyId) next.ptyId = params.ptyId;
+      if (params.clearCommand) {
+        delete next.command;
+        delete next.autorun;
+      }
+      navigate({ search: next, replace: true });
     },
-    [navigate],
+    [navigate, search],
   );
 
   return (

--- a/packages/shared/src/apps/orpc.ts
+++ b/packages/shared/src/apps/orpc.ts
@@ -1,7 +1,27 @@
+import type { Context } from "@orpc/server";
+import type { FetchHandleResult, FetchHandlerInterceptorOptions } from "@orpc/server/fetch";
 import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
 import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
 import { INTERNAL_OPENAPI_TAG } from "./openapi.ts";
 import type { AppManifest } from "./types.ts";
+
+/**
+ * Adapter interceptor that pretty-prints JSON responses for curl ergonomics.
+ * Leaves SSE (`text/event-stream`) and non-JSON responses untouched.
+ */
+export async function prettyJsonInterceptor(
+  options: FetchHandlerInterceptorOptions<Context> & {
+    next(): Promise<FetchHandleResult>;
+  },
+) {
+  const result = await options.next();
+  const type = result.response?.headers.get("content-type");
+  if (!result.matched || result.response.body === null || !type?.includes("json")) return result;
+  return {
+    ...result,
+    response: new Response(JSON.stringify(await result.response.json(), null, 2), result.response),
+  };
+}
 
 type OpenApiReferencePluginOptions = {
   defaultOpenFirstTag: boolean;


### PR DESCRIPTION
## Summary
- Set `defaultNotFoundComponent` to shared `DefaultNotFoundComponent` so 404 pages show a branded component instead of the generic TanStack Router fallback
- Add `adapterInterceptor` on the OpenAPI handler to pretty-print JSON responses (`JSON.stringify(..., null, 2)`), making `curl` output human-readable

Both patterns are already in `apps/events`. Follow-up to #1279.

## Test plan
- [ ] Navigate to a non-existent route in the example app — verify branded 404 page renders
- [ ] `curl` an API endpoint — verify JSON response is pretty-printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iterate/iterate/pull/1280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly refactors/UX tweaks (response formatting and default 404) plus a small callback-stability fix in the example terminal route; minimal impact on core business logic.
> 
> **Overview**
> **Deduplicates OpenAPI JSON pretty-printing** by introducing a shared `prettyJsonInterceptor` in `packages/shared/src/apps/orpc.ts` and wiring it into the OpenAPI handlers for `agents`, `events`, and `example`.
> 
> **Improves example app UX** by setting TanStack Router’s `defaultNotFoundComponent` to the shared `DefaultNotFoundComponent`, and stabilizing the terminal page’s URL-param update callback (using a ref) to avoid tearing down the terminal on search param changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4725118c45915c3d4c23302f05e3c0fa603ec163. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW_ENVIRONMENTS -->
## Preview Environments
<!-- CLOUDFLARE_PREVIEW_ENVIRONMENTS_STATE -->
<!--
{
  "example": {
    "appDisplayName": "Example",
    "appSlug": "example",
    "status": "released",
    "updatedAt": "2026-04-24T14:32:20.240Z",
    "leasedUntil": null,
    "headSha": "4725118c45915c3d4c23302f05e3c0fa603ec163",
    "message": "Preview environment released.",
    "previewEnvironmentAlchemyStageName": null,
    "previewEnvironmentDopplerConfigName": null,
    "previewEnvironmentIdentifier": null,
    "previewEnvironmentSemaphoreLeaseId": null,
    "previewEnvironmentSlug": null,
    "previewEnvironmentType": null,
    "publicUrl": "https://example-preview-1.iterate.workers.dev",
    "runUrl": "https://github.com/iterate/iterate/actions/runs/24894357695",
    "shortSha": "4725118"
  },
  "agents": {
    "appDisplayName": "Agents",
    "appSlug": "agents",
    "status": "released",
    "updatedAt": "2026-04-24T14:32:11.243Z",
    "leasedUntil": null,
    "headSha": "0ad2ff745285a8f4db4700b8d24fc8537d85ec16",
    "message": "Preview environment released.",
    "previewEnvironmentAlchemyStageName": null,
    "previewEnvironmentDopplerConfigName": null,
    "previewEnvironmentIdentifier": null,
    "previewEnvironmentSemaphoreLeaseId": null,
    "previewEnvironmentSlug": null,
    "previewEnvironmentType": null,
    "publicUrl": "https://agents-preview-1.iterate.workers.dev",
    "runUrl": "https://github.com/iterate/iterate/actions/runs/24892863694",
    "shortSha": "0ad2ff7"
  },
  "events": {
    "appDisplayName": "Events",
    "appSlug": "events",
    "status": "released",
    "updatedAt": "2026-04-24T14:32:22.921Z",
    "leasedUntil": null,
    "headSha": "0ad2ff745285a8f4db4700b8d24fc8537d85ec16",
    "message": "Preview environment released.",
    "previewEnvironmentAlchemyStageName": null,
    "previewEnvironmentDopplerConfigName": null,
    "previewEnvironmentIdentifier": null,
    "previewEnvironmentSemaphoreLeaseId": null,
    "previewEnvironmentSlug": null,
    "previewEnvironmentType": null,
    "publicUrl": "https://events-preview-1.iterate.com",
    "runUrl": "https://github.com/iterate/iterate/actions/runs/24892863694",
    "shortSha": "0ad2ff7"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_ENVIRONMENTS_STATE -->

### Agents
Status: released
Commit: `0ad2ff7`
Preview: https://agents-preview-1.iterate.workers.dev
Summary: Preview environment released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/24892863694)
Updated: 2026-04-24T14:32:11.243Z

### Events
Status: released
Commit: `0ad2ff7`
Preview: https://events-preview-1.iterate.com
Summary: Preview environment released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/24892863694)
Updated: 2026-04-24T14:32:22.921Z

### Example
Status: released
Commit: `4725118`
Preview: https://example-preview-1.iterate.workers.dev
Summary: Preview environment released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/24894357695)
Updated: 2026-04-24T14:32:20.240Z
<!-- /CLOUDFLARE_PREVIEW_ENVIRONMENTS -->