### PR TITLE
Add os2 wildcard DNS record

### DIFF
--- a/apps/os2/alchemy.run.ts
+++ b/apps/os2/alchemy.run.ts
@@ -1,5 +1,13 @@
 import alchemy, { type Scope } from "alchemy";
-import { D1Database, DurableObjectNamespace, TanStackStart, Worker } from "alchemy/cloudflare";
+import {
+  D1Database,
+  DnsRecords,
+  DurableObjectNamespace,
+  TanStackStart,
+  Worker,
+  createCloudflareApi,
+  findZoneForHostname,
+} from "alchemy/cloudflare";
 import { CloudflareStateStore, SQLiteStateStore } from "alchemy/state";
 import { compileRawAppConfigFromEnv, parseAppConfigFromEnv } from "@iterate-com/shared/apps/config";
 import { slugify } from "@iterate-com/shared/slugify";
@@ -78,6 +86,9 @@ const workerRouteHosts = [
       .map((hostname) => `*.${hostname}`),
   ]),
 ];
+const projectWildcardHosts = projectHostnameBases
+  .filter((hostname) => !hostname.endsWith(".workers.dev"))
+  .map((hostname) => `*.${hostname}`);
 
 const db = await D1Database("os-db", {
   name: `${workerName}-db`,
@@ -150,6 +161,30 @@ export const worker = await TanStackStart(APP_NAME, {
     command: "pnpm exec vite dev --config vite.config.ts",
   },
 });
+
+const cloudflareApi = await createCloudflareApi({});
+if (!worker.url) {
+  throw new Error("Worker URL is required to create project wildcard DNS records.");
+}
+const workerHostname = new URL(worker.url).hostname;
+await Promise.all(
+  projectWildcardHosts.map(async (hostname) => {
+    const { zoneId } = await findZoneForHostname(cloudflareApi, hostname);
+    return DnsRecords(`project-wildcard-dns-${slugify(hostname)}`, {
+      zoneId,
+      records: [
+        {
+          type: "CNAME",
+          name: hostname,
+          content: workerHostname,
+          proxied: true,
+          ttl: 1,
+          comment: `Managed by ${APP_NAME} Alchemy for project hostname routing.`,
+        },
+      ],
+    });
+  }),
+);
 
 console.dir(
   {


### PR DESCRIPTION
## Summary\n- manage a proxied wildcard CNAME for os2 project host routing via Alchemy\n- point *.os2.iterate.com at the os2 worker so Cloudflare Total TLS can issue the wildcard edge certificate\n\n## Verification\n- pnpm -C apps/os2 typecheck\n- deployed apps/os2 with os2/prd Doppler\n- curl -H 'Accept: text/html' https://banana.os2.iterate.com/mcp returns HTTP 200\n- curl -H 'Accept: application/json, text/event-stream' https://banana.os2.iterate.com/mcp reaches MCP transport and returns expected missing-session error
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iterate/iterate/pull/1288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces automated creation of proxied wildcard CNAME DNS records pointing project subdomains at the worker, which can affect external traffic routing and TLS issuance if misconfigured.
> 
> **Overview**
> Adds automatic management of **proxied wildcard CNAME DNS records** for OS2 project host routing.
> 
> `alchemy.run.ts` now derives `*.{projectHost}` entries from `WORKER_ROUTES`, looks up the correct Cloudflare zone via `findZoneForHostname`, and creates the corresponding `DnsRecords` pointing at the deployed worker hostname (failing fast if `worker.url` is missing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 934152e4afbc8c91b8846cbaafc8a79c1cc1f756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW_ENVIRONMENTS -->
## Preview Environments
<!-- CLOUDFLARE_PREVIEW_ENVIRONMENTS_STATE -->
<!--
{
  "os2": {
    "appDisplayName": "OS",
    "appSlug": "os2",
    "status": "released",
    "updatedAt": "2026-04-27T21:44:51.962Z",
    "leasedUntil": null,
    "headSha": "934152e4afbc8c91b8846cbaafc8a79c1cc1f756",
    "message": "Preview environment released.",
    "previewEnvironmentAlchemyStageName": null,
    "previewEnvironmentDopplerConfigName": null,
    "previewEnvironmentIdentifier": null,
    "previewEnvironmentSemaphoreLeaseId": null,
    "previewEnvironmentSlug": null,
    "previewEnvironmentType": null,
    "publicUrl": "https://os2-preview-1.iterate.com",
    "runUrl": "https://github.com/iterate/iterate/actions/runs/25020810717",
    "shortSha": "934152e"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_ENVIRONMENTS_STATE -->

### OS
Status: released
Commit: `934152e`
Preview: https://os2-preview-1.iterate.com
Summary: Preview environment released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25020810717)
Updated: 2026-04-27T21:44:51.962Z
<!-- /CLOUDFLARE_PREVIEW_ENVIRONMENTS -->