### PR TITLE
Fix auth cutover project slug backfill migration

### DIFF
--- a/apps/os/backend/db/migrations/0037_auth_cutover.sql
+++ b/apps/os/backend/db/migrations/0037_auth_cutover.sql
@@ -20,7 +20,12 @@ ALTER TABLE "secret" DROP CONSTRAINT "secret_organization_id_organization_id_fk"
 DROP INDEX "project_organization_id_name_index";--> statement-breakpoint
 DROP INDEX "secret_organization_id_index";--> statement-breakpoint
 ALTER TABLE "project" ADD COLUMN "auth_project_id" text;--> statement-breakpoint
-ALTER TABLE "project" ADD COLUMN "auth_organization_slug" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "project" ADD COLUMN "auth_organization_slug" text;--> statement-breakpoint
+UPDATE "project"
+SET "auth_organization_slug" = "organization"."slug"
+FROM "organization"
+WHERE "project"."auth_organization_id" = "organization"."id";--> statement-breakpoint
+ALTER TABLE "project" ALTER COLUMN "auth_organization_slug" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "user" ADD COLUMN "auth_user_id" text;--> statement-breakpoint
 CREATE INDEX "billing_account_auth_organization_id_index" ON "billing_account" USING btree ("auth_organization_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "project_auth_organization_id_name_index" ON "project" USING btree ("auth_organization_id","name");--> statement-breakpoint


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> This changes a production SQL migration to add a data backfill and delayed NOT NULL constraint, which can impact existing databases and migration runtime/locking.
> 
> **Overview**
> Updates migration `0037_auth_cutover.sql` so `project.auth_organization_slug` is added as nullable, backfilled from `organization.slug` via `project.auth_organization_id`, and only then altered to `SET NOT NULL`, preventing failures when existing `project` rows are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c5d4ab887733183c2aa084e2593212b52da0240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->