### PR TITLE
Disable automatic specs workflow runs

### DIFF
--- a/.github/ts-workflows/workflows/spec.ts
+++ b/.github/ts-workflows/workflows/spec.ts
@@ -5,7 +5,7 @@ import * as utils from "../utils/index.ts";
 export default workflow({
   name: "specs",
   on: {
-    push: {},
+    workflow_dispatch: {},
   },
   env: {
     SLACK_CLIENT_ID: "fake123",

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -2,7 +2,7 @@
 
 name: specs
 on:
-  push: {}
+  workflow_dispatch: {}
 env:
   SLACK_CLIENT_ID: fake123
   DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}


### PR DESCRIPTION
## Summary
- make the standalone  workflow manual-only
- stop running that workflow on every push to 
- keep the workflow available via 

## Testing
- not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes GitHub Actions triggers for the `specs` workflow, with no production code or data handling impact.
> 
> **Overview**
> Disables automatic runs of the `specs` GitHub Actions workflow by replacing the `push` trigger with `workflow_dispatch` (manual runs only).
> 
> Regenerates the generated `spec.yml` accordingly, with no changes to the job steps/behavior aside from the trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 118b109285257dd0304bb850856bffb396f50c0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->