### PR TITLE
[codex] add app config durable object mixin

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -25,6 +25,7 @@
     "./test-helpers": "./src/test-helpers/index.ts",
     "./test-support/vitest-e2e": "./src/test-support/vitest-e2e/index.ts",
     "./durable-object-utils/mixins/with-d1-object-catalog": "./src/durable-object-utils/mixins/with-d1-object-catalog.ts",
+    "./durable-object-utils/mixins/with-app-config": "./src/durable-object-utils/mixins/with-app-config.ts",
     "./durable-object-utils/mixins/with-durable-object-core": "./src/durable-object-utils/mixins/with-durable-object-core.ts",
     "./durable-object-utils/mixins/with-lifecycle-hooks": "./src/durable-object-utils/mixins/with-lifecycle-hooks.ts",
     "./durable-object-utils/mixins/with-multiplexed-alarms": "./src/durable-object-utils/mixins/with-multiplexed-alarms.ts",

--- a/packages/shared/src/durable-object-utils/README.md
+++ b/packages/shared/src/durable-object-utils/README.md
@@ -5,6 +5,7 @@ Utilities here are experimental helpers for composing Cloudflare Durable Object 
 ## Current Scope
 
 - `mixins/with-durable-object-core.ts` is the root adapter for mixins that need Cloudflare's protected Durable Object `ctx` APIs. It exposes small protected capabilities for local SQLite, synchronous KV, and the single platform alarm slot.
+- `mixins/with-app-config.ts` parses typed app runtime config from `APP_CONFIG` / `APP_CONFIG_*` Cloudflare env vars and exposes it as protected `this.config`.
 - `mixins/with-lifecycle-hooks.ts` adds named initialization state and tiny lifecycle hooks for SQLite-backed Durable Objects.
 - `mixins/with-d1-object-catalog.ts` best-effort mirrors initialized objects into D1 tables owned by the mixin, with optional secondary indexes derived from init params.
 - `mixins/with-multiplexed-alarms.ts` stores many logical one-shot alarms behind Cloudflare's single Durable Object alarm slot.
@@ -74,6 +75,36 @@ That keeps storage access inside the mixin method and lets plain helper
 functions operate on plain data. Use the raw protected handles only when a mixin
 owns durable schema/state and needs several related storage operations in one
 method, such as the scheduler or multiplexed alarm dispatcher.
+
+Use `withAppConfig(AppConfig)` when a Durable Object needs the same app runtime
+config shape as the worker entrypoint:
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+import { z } from "zod";
+import { BaseAppConfig } from "@iterate-com/shared/apps/config";
+import { withAppConfig } from "@iterate-com/shared/durable-object-utils/mixins/with-app-config";
+
+const AppConfig = BaseAppConfig.extend({
+  apiBaseUrl: z.string().trim().min(1),
+});
+
+type AppConfig = z.output<typeof AppConfig>;
+
+const RoomBase = withAppConfig(AppConfig)(DurableObject);
+
+class Room extends RoomBase<Env> {
+  getApiBaseUrl() {
+    return this.config.apiBaseUrl;
+  }
+}
+```
+
+`this.config` is protected, not public, because app config can include redacted
+secrets or internal URLs. The mixin uses the shared `APP_CONFIG` parser and
+caches the parsed object for one Durable Object wake. `APP_CONFIG_FOO__BAR`
+overrides `foo.bar`, and unknown override keys fail schema validation instead
+of being silently ignored.
 
 Simple mixin return types mostly follow this pattern:
 

--- a/packages/shared/src/durable-object-utils/mixins/with-app-config.ts
+++ b/packages/shared/src/durable-object-utils/mixins/with-app-config.ts
@@ -1,0 +1,87 @@
+/// <reference types="@cloudflare/workers-types" />
+
+import { z } from "zod";
+import { parseAppConfigFromEnv } from "../../apps/config.ts";
+import type {
+  Constructor,
+  DurableObjectClass,
+  MembersOf,
+  ReqEnvOf,
+  RuntimeDurableObjectConstructor,
+  StaticSide,
+} from "./mixin-types.ts";
+
+const APP_CONFIG_ENV_PREFIX = "APP_CONFIG_";
+
+type CloudflareEnvObject = Record<string, unknown>;
+
+/**
+ * Type-only protected surface for app runtime config.
+ *
+ * The real protected getter is installed by `withAppConfig()` below. Keeping
+ * config protected matters because app config can include redacted secrets and
+ * internal URLs; Durable Object public members can become remotely callable.
+ */
+export abstract class AppConfigProtected<TConfig> {
+  protected get config(): TConfig {
+    throw new Error("AppConfigProtected is type-only and should never run.");
+  }
+}
+
+type WithAppConfigResult<TBase extends DurableObjectClass, TSchema extends z.ZodTypeAny> =
+  // Preserve the generic Durable Object constructor so this remains legal:
+  //
+  //   const Base = withAppConfig(AppConfig)(DurableObject);
+  //   class Room extends Base<Env> {}
+  //
+  // `ReqEnvOf<TBase>` keeps env requirements from earlier mixins, and
+  // `MembersOf<TBase>` keeps their instance surface available after this mixin.
+  StaticSide<TBase> &
+    DurableObjectClass<ReqEnvOf<TBase>, MembersOf<TBase> & AppConfigProtected<z.output<TSchema>>> &
+    Constructor<AppConfigProtected<z.output<TSchema>>>;
+
+/**
+ * Adds protected typed app config to a Durable Object.
+ *
+ * Protected subclass/mixin surface: `this.config`.
+ *
+ * Config is parsed from the Cloudflare env using the app runtime convention:
+ * `APP_CONFIG` provides the base JSON object and `APP_CONFIG_*` variables
+ * override nested fields. Parsing delegates to the shared app config parser, so
+ * unknown override keys and schema validation failures throw during the first
+ * `this.config` access for each Durable Object wake.
+ *
+ * The parsed object is cached only in memory for the current wake. Durable
+ * state still belongs in Durable Object storage; this helper is for runtime
+ * env/config access.
+ */
+export function withAppConfig<TSchema extends z.ZodTypeAny>(configSchema: TSchema) {
+  return function <TBase extends DurableObjectClass>(
+    Base: TBase,
+  ): WithAppConfigResult<TBase, TSchema> {
+    const BaseWithDurableObject = Base as unknown as RuntimeDurableObjectConstructor;
+
+    abstract class AppConfigMixin extends BaseWithDurableObject {
+      #appConfig: z.output<TSchema> | undefined;
+
+      protected get config(): z.output<TSchema> {
+        this.#appConfig ??= parseAppConfigFromEnv({
+          configSchema,
+          prefix: APP_CONFIG_ENV_PREFIX,
+          // Cloudflare envs are object bags of bindings and vars. The config
+          // parser ignores non-string values, so service bindings remain safe to
+          // pass through here.
+          env: this.env as CloudflareEnvObject,
+        });
+
+        return this.#appConfig;
+      }
+    }
+
+    // TypeScript cannot infer that a class-expression wrapper preserves the
+    // generic `Base<Env>` constructor while adding a protected getter. The
+    // result type above publishes that composed shape and keeps config off the
+    // public Durable Object RPC surface.
+    return AppConfigMixin as unknown as WithAppConfigResult<TBase, TSchema>;
+  };
+}

--- a/packages/shared/src/durable-object-utils/mixins/with-app-config.type.test.ts
+++ b/packages/shared/src/durable-object-utils/mixins/with-app-config.type.test.ts
@@ -1,0 +1,110 @@
+import { DurableObject } from "cloudflare:workers";
+import { describe, expectTypeOf, it } from "vitest";
+import { z } from "zod";
+import { withAppConfig as publicWithAppConfig } from "@iterate-com/shared/durable-object-utils/mixins/with-app-config";
+import { BaseAppConfig, redacted } from "../../apps/config.ts";
+import { withDurableObjectCore } from "./with-durable-object-core.ts";
+import { withLifecycleHooks } from "./with-lifecycle-hooks.ts";
+import { withAppConfig } from "./with-app-config.ts";
+
+const AppConfig = BaseAppConfig.extend({
+  apiBaseUrl: z.string().trim().min(1),
+  token: redacted(z.string().trim().min(1)),
+  feature: z.object({
+    enabled: z.boolean(),
+  }),
+});
+
+type AppConfig = z.output<typeof AppConfig>;
+
+type Env = {
+  APP_CONFIG: string;
+  OTHER_BINDING: Fetcher;
+};
+
+const AppConfigBase = withAppConfig(AppConfig)(DurableObject);
+
+class AppConfigRoom extends AppConfigBase<Env> {
+  readConfig() {
+    const config = this.config;
+
+    expectTypeOf(config).toEqualTypeOf<AppConfig>();
+
+    return {
+      apiBaseUrl: config.apiBaseUrl,
+      enabled: config.feature.enabled,
+      token: config.token,
+    };
+  }
+}
+
+describe("withAppConfig types", () => {
+  it("adds protected typed config while preserving Base<Env>", () => {
+    const room = {} as AppConfigRoom;
+
+    expectTypeOf(room.readConfig()).toEqualTypeOf<{
+      apiBaseUrl: string;
+      enabled: boolean;
+      token: AppConfig["token"];
+    }>();
+
+    // @ts-expect-error config is protected and must not be part of the public Durable Object API.
+    room.config;
+  });
+
+  it("preserves static members from the wrapped base class", () => {
+    class RootWithStatic<RootEnv> extends DurableObject<RootEnv> {
+      static rootStatic() {
+        return "root-static";
+      }
+    }
+
+    const StaticBase = withAppConfig(AppConfig)(RootWithStatic);
+
+    class StaticRoom extends StaticBase<Env> {}
+
+    expectTypeOf(StaticRoom.rootStatic()).toEqualTypeOf<string>();
+  });
+
+  it("preserves members from lower mixins", () => {
+    type RoomInit = {
+      name: string;
+      ownerUserId: string;
+    };
+
+    const Base = withAppConfig(AppConfig)(
+      withLifecycleHooks<RoomInit>()(withDurableObjectCore(DurableObject)),
+    );
+
+    class Room extends Base<Env> {
+      readBoth() {
+        return {
+          ownerUserId: this.initParams.ownerUserId,
+          apiBaseUrl: this.config.apiBaseUrl,
+        };
+      }
+    }
+
+    const room = {} as Room;
+
+    expectTypeOf(room.assertInitialized()).toEqualTypeOf<RoomInit>();
+    expectTypeOf(room.readBoth()).toEqualTypeOf<{
+      ownerUserId: string;
+      apiBaseUrl: string;
+    }>();
+  });
+
+  it("works through the package export path", () => {
+    const PublicBase = publicWithAppConfig(AppConfig)(DurableObject);
+
+    class PublicRoom extends PublicBase<Env> {
+      readBaseUrl() {
+        return this.config.baseUrl;
+      }
+    }
+
+    const room = {} as PublicRoom;
+
+    expectTypeOf(room.readBaseUrl()).toEqualTypeOf<string | undefined>();
+  });
+});

--- a/packages/shared/src/durable-object-utils/mixins/with-app-config.unit.test.ts
+++ b/packages/shared/src/durable-object-utils/mixins/with-app-config.unit.test.ts
@@ -1,0 +1,63 @@
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { AppConfigTestRoom } from "../test-harness/initialize-fronting-worker.ts";
+
+const testEnv = env as {
+  APP_CONFIG_ROOMS: DurableObjectNamespace<AppConfigTestRoom>;
+};
+
+describe("withAppConfig", () => {
+  it("parses APP_CONFIG and APP_CONFIG_* overrides from the Cloudflare env", async () => {
+    const room = testEnv.APP_CONFIG_ROOMS.getByName(`app-config-${crypto.randomUUID()}`);
+
+    await expect(room.getConfigForTest()).resolves.toEqual({
+      serviceName: "override-service",
+      feature: {
+        enabled: true,
+        limit: 4,
+      },
+      integrations: {
+        posthog: {
+          projectApiKey: "override-posthog-key",
+          captureEndpoint: "https://base.example.com/capture",
+          sampling: {
+            enabled: true,
+            rate: 0.5,
+          },
+        },
+      },
+      limits: {
+        queue: {
+          maxBatchSize: 25,
+          tags: ["override", "nested"],
+        },
+      },
+      optionalText: "default-text",
+    });
+  });
+
+  it("documents nested APP_CONFIG_* path and JSON object override semantics", async () => {
+    const room = testEnv.APP_CONFIG_ROOMS.getByName(`app-config-nested-${crypto.randomUUID()}`);
+
+    const config = await room.getConfigForTest();
+
+    expect(config.integrations.posthog).toEqual({
+      projectApiKey: "override-posthog-key",
+      captureEndpoint: "https://base.example.com/capture",
+      sampling: {
+        enabled: true,
+        rate: 0.5,
+      },
+    });
+    expect(config.limits.queue).toEqual({
+      maxBatchSize: 25,
+      tags: ["override", "nested"],
+    });
+  });
+
+  it("caches parsed config for one Durable Object wake", async () => {
+    const room = testEnv.APP_CONFIG_ROOMS.getByName(`app-config-cache-${crypto.randomUUID()}`);
+
+    await expect(room.getConfigReferenceStableForTest()).resolves.toBe(true);
+  });
+});

--- a/packages/shared/src/durable-object-utils/test-harness/initialize-fronting-worker.ts
+++ b/packages/shared/src/durable-object-utils/test-harness/initialize-fronting-worker.ts
@@ -11,6 +11,8 @@
  */
 
 import { DurableObject } from "cloudflare:workers";
+import { z } from "zod";
+import { withAppConfig } from "../mixins/with-app-config.ts";
 import {
   listD1ObjectCatalogRecordsByIndex,
   withD1ObjectCatalog,
@@ -53,7 +55,11 @@ type Env = {
   INSPECTORS: DurableObjectNamespace<InspectorTestRoom>;
   LISTED_ROOMS: DurableObjectNamespace<ListedRoom>;
   PUBLIC_ROUTE_ROOMS: DurableObjectNamespace<PublicRouteTestRoom>;
+  APP_CONFIG_ROOMS: DurableObjectNamespace<AppConfigTestRoom>;
   DO_CATALOG: D1Database;
+  APP_CONFIG?: string;
+  APP_CONFIG_SERVICE_NAME?: string;
+  APP_CONFIG_FEATURE__ENABLED?: string;
 };
 
 const DurableObjectCore = withDurableObjectCore(DurableObject);
@@ -676,6 +682,45 @@ export class InspectorTestRoom extends InspectorBase<Env> {
       "msg_1",
       "hello",
     );
+  }
+}
+
+const TestAppConfig = z.object({
+  serviceName: z.string().trim().min(1),
+  feature: z.object({
+    enabled: z.boolean(),
+    limit: z.number(),
+  }),
+  integrations: z.object({
+    posthog: z.object({
+      projectApiKey: z.string().trim().min(1),
+      captureEndpoint: z.url(),
+      sampling: z.object({
+        enabled: z.boolean(),
+        rate: z.number(),
+      }),
+    }),
+  }),
+  limits: z.object({
+    queue: z.object({
+      maxBatchSize: z.number(),
+      tags: z.array(z.string()),
+    }),
+  }),
+  optionalText: z.string().default("default-text"),
+});
+
+type TestAppConfig = z.output<typeof TestAppConfig>;
+
+const AppConfigRoomBase = withAppConfig(TestAppConfig)(DurableObjectCore);
+
+export class AppConfigTestRoom extends AppConfigRoomBase<Env> {
+  getConfigForTest(): TestAppConfig {
+    return this.config;
+  }
+
+  getConfigReferenceStableForTest(): boolean {
+    return this.config === this.config;
   }
 }
 

--- a/packages/shared/src/durable-object-utils/vitest.unit.config.ts
+++ b/packages/shared/src/durable-object-utils/vitest.unit.config.ts
@@ -50,7 +50,47 @@ writeFileSync(
             name: "PUBLIC_ROUTE_ROOMS",
             class_name: "PublicRouteTestRoom",
           },
+          {
+            name: "APP_CONFIG_ROOMS",
+            class_name: "AppConfigTestRoom",
+          },
         ],
+      },
+      vars: {
+        APP_CONFIG: JSON.stringify({
+          serviceName: "base-service",
+          feature: {
+            enabled: false,
+            limit: 4,
+          },
+          integrations: {
+            posthog: {
+              projectApiKey: "base-posthog-key",
+              captureEndpoint: "https://base.example.com/capture",
+              sampling: {
+                enabled: false,
+                rate: 0.25,
+              },
+            },
+          },
+          limits: {
+            queue: {
+              maxBatchSize: 10,
+              tags: ["base"],
+            },
+          },
+        }),
+        APP_CONFIG_SERVICE_NAME: "override-service",
+        APP_CONFIG_FEATURE__ENABLED: "true",
+        APP_CONFIG_INTEGRATIONS__POSTHOG__PROJECT_API_KEY: "override-posthog-key",
+        APP_CONFIG_INTEGRATIONS__POSTHOG__SAMPLING: JSON.stringify({
+          enabled: true,
+          rate: 0.5,
+        }),
+        APP_CONFIG_LIMITS__QUEUE: JSON.stringify({
+          maxBatchSize: 25,
+          tags: ["override", "nested"],
+        }),
       },
       d1_databases: [
         {
@@ -71,6 +111,7 @@ writeFileSync(
             "InspectorTestRoom",
             "ListedRoom",
             "PublicRouteTestRoom",
+            "AppConfigTestRoom",
           ],
         },
       ],


### PR DESCRIPTION
## What changed

Adds `withAppConfig(AppConfig)` under `packages/shared/src/durable-object-utils/mixins`.

The mixin parses app runtime config from Cloudflare env using the existing `APP_CONFIG` / `APP_CONFIG_*` convention, delegates validation and override semantics to the shared app config parser, caches parsed config for one Durable Object wake, and exposes it as protected typed `this.config`.

Also adds the package export, durable-object-utils README guidance, type tests, and worker-pool unit tests using a dedicated test Durable Object.

## Why

Durable Objects that need app runtime config should be able to use the same typed config schema as the app worker without reparsing env manually or exposing config through public DO RPC surface.

## Validation

- `pnpm --dir packages/shared test:durable-object-utils`
- `pnpm --dir packages/shared typecheck`
- `pnpm exec oxlint packages/shared/src/durable-object-utils --threads 1 --deny-warnings`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are additive (new mixin + docs/tests) and reuse the existing `parseAppConfigFromEnv` logic; impact is limited to consumers that opt into the new export.
> 
> **Overview**
> Adds a new Durable Object mixin, `withAppConfig(schema)`, which lazily parses worker-style runtime config from `APP_CONFIG`/`APP_CONFIG_*` env vars, caches it for the current DO wake, and exposes it as a *protected* typed `this.config` to avoid leaking config/secrets on the public DO surface.
> 
> Exports the mixin from `@iterate-com/shared`, documents intended usage in the durable-object-utils README, and extends the DO utils test harness + Vitest worker-pool config with a dedicated `AppConfigTestRoom` plus unit/type tests covering override semantics, caching, and type preservation through mixin composition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e5200267aff286456440766b6a7b0266486cd76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->