### PR TITLE
[codex] Add event schema metadata examples

### DIFF
--- a/apps/events/src/components/processor-doc-page.tsx
+++ b/apps/events/src/components/processor-doc-page.tsx
@@ -32,10 +32,24 @@ export function ProcessorOverviewPage({ processor }: { processor: ProcessorDoc }
 
 export function ProcessorEventPage({ event }: { event: ProcessorEventDoc }) {
   const processor = getProcessorDocBySlug(event.processor.slug);
-  const defaultEventExample = {
-    type: event.type,
-    payload: {},
-  };
+  const eventExamples =
+    event.examples.length > 0
+      ? event.examples.map((example) => ({
+          description: example.description,
+          event: {
+            type: event.type,
+            payload: example.payload,
+          },
+        }))
+      : [
+          {
+            description: "Minimal event input",
+            event: {
+              type: event.type,
+              payload: {},
+            },
+          },
+        ];
 
   return (
     <DocsChrome event={event} processor={processor}>
@@ -50,20 +64,27 @@ export function ProcessorEventPage({ event }: { event: ProcessorEventDoc }) {
           ) : null}
         </div>
 
-        <div className="space-y-2 rounded-lg border bg-card p-4">
+        <div className="space-y-2">
           <p className="text-xs uppercase tracking-wide text-muted-foreground">
             Payload JSON schema
           </p>
           <JsonSchemaDocViewer schema={event.payloadJsonSchema} />
         </div>
 
-        <div className="space-y-2 rounded-lg border bg-card p-4">
+        <div className="space-y-2">
           <p className="text-xs uppercase tracking-wide text-muted-foreground">
-            Example event input
+            {eventExamples.length === 1 ? "Example event input" : "Example event inputs"}
           </p>
-          <pre className="overflow-x-auto whitespace-pre-wrap wrap-break-word rounded-md bg-muted p-3 font-mono text-xs">
-            {JSON.stringify(defaultEventExample, null, 2)}
-          </pre>
+          <div className="space-y-3">
+            {eventExamples.map((example) => (
+              <div key={example.description} className="space-y-2">
+                <p className="text-sm text-muted-foreground">{example.description}</p>
+                <pre className="overflow-x-auto whitespace-pre-wrap wrap-break-word rounded-md bg-muted p-3 font-mono text-xs">
+                  {JSON.stringify(example.event, null, 2)}
+                </pre>
+              </div>
+            ))}
+          </div>
         </div>
       </section>
     </DocsChrome>

--- a/apps/events/src/lib/processor-docs.test.ts
+++ b/apps/events/src/lib/processor-docs.test.ts
@@ -16,9 +16,36 @@ describe("processor docs", () => {
     expect(event?.payloadJsonSchema).toMatchObject({
       type: "object",
       properties: {
-        content: { type: "string" },
+        content: {
+          type: "string",
+          description: "Model-visible user context to append to agent history.",
+        },
       },
+      examples: [
+        {
+          content: "Summarize the deployment logs.",
+        },
+        {
+          content: "Actually, focus only on failed checks.",
+          triggerLlmRequest: { behaviour: "interrupt-current-request" },
+        },
+      ],
     });
+    expect(event?.examples).toEqual([
+      {
+        description: "User input that uses the default automatic LLM request behaviour.",
+        payload: {
+          content: "Summarize the deployment logs.",
+        },
+      },
+      {
+        description: "User input that interrupts the current request before starting a new one.",
+        payload: {
+          content: "Actually, focus only on failed checks.",
+          triggerLlmRequest: { behaviour: "interrupt-current-request" },
+        },
+      },
+    ]);
   });
 
   test("resolves descriptions for agent consumed dependency events", () => {

--- a/apps/events/src/lib/processor-docs.ts
+++ b/apps/events/src/lib/processor-docs.ts
@@ -28,8 +28,14 @@ export type ProcessorEventDoc = {
   type: string;
   eventSlug: string;
   description?: string;
+  examples: ProcessorEventExampleDoc[];
   payloadJsonSchema: unknown;
   href: string;
+};
+
+export type ProcessorEventExampleDoc = {
+  description: string;
+  payload: unknown;
 };
 
 export type ProcessorDoc = {
@@ -101,14 +107,22 @@ function buildProcessorDocs(): ProcessorDoc[] {
 
 function buildBaseProcessorDoc(contract: ProcessorContractForDocs): ProcessorDoc {
   const href = `/${contract.slug}/`;
-  const events = Object.entries(contract.events).map(([type, event]) => ({
-    processor: contract,
-    type,
-    eventSlug: eventSlugFromType({ processorSlug: contract.slug, type }),
-    ...(event.description == null ? {} : { description: event.description }),
-    payloadJsonSchema: eventPayloadJsonSchema(event.payloadSchema as z.ZodType),
-    href: `${href}${eventSlugFromType({ processorSlug: contract.slug, type })}/`,
-  }));
+  const events = Object.entries(contract.events).map(([type, event]) => {
+    const examples = eventExamples(event.examples);
+
+    return {
+      processor: contract,
+      type,
+      eventSlug: eventSlugFromType({ processorSlug: contract.slug, type }),
+      ...(event.description == null ? {} : { description: event.description }),
+      examples,
+      payloadJsonSchema: eventPayloadJsonSchema({
+        examples,
+        payloadSchema: event.payloadSchema as z.ZodType,
+      }),
+      href: `${href}${eventSlugFromType({ processorSlug: contract.slug, type })}/`,
+    };
+  });
 
   return {
     contract,
@@ -153,11 +167,44 @@ function hasProcessorSlug(value: unknown): value is { slug: string } {
   );
 }
 
-function eventPayloadJsonSchema(payloadSchema: z.ZodType) {
-  return z.toJSONSchema(payloadSchema, {
+function eventExamples(examples: unknown): ProcessorEventExampleDoc[] {
+  if (!Array.isArray(examples)) return [];
+
+  return examples
+    .map((example) => {
+      if (
+        typeof example === "object" &&
+        example !== null &&
+        "description" in example &&
+        "payload" in example &&
+        typeof example.description === "string"
+      ) {
+        return {
+          description: example.description,
+          payload: example.payload,
+        };
+      }
+
+      return null;
+    })
+    .filter((example): example is ProcessorEventExampleDoc => example != null);
+}
+
+function eventPayloadJsonSchema(args: {
+  examples: readonly { payload: unknown }[];
+  payloadSchema: z.ZodType;
+}) {
+  const jsonSchema = z.toJSONSchema(args.payloadSchema, {
     io: "input",
     unrepresentable: "any",
   });
+
+  if (args.examples.length === 0) return jsonSchema;
+
+  return {
+    ...jsonSchema,
+    examples: args.examples.map((example) => example.payload),
+  };
 }
 
 function eventSlugFromType(args: { processorSlug: string; type: string }) {

--- a/packages/shared/src/stream-processors/agent/contract.ts
+++ b/packages/shared/src/stream-processors/agent/contract.ts
@@ -53,21 +53,43 @@ export const AgentProcessorContract = defineProcessorContract({
     },
     "events.iterate.com/agent/input-added": {
       description: "A curated model-visible row of agent context.",
-      payloadSchema: z.object({
-        content: z.string(),
-        triggerLlmRequest: z
-          .discriminatedUnion("behaviour", [
-            z.object({ behaviour: z.literal("auto") }),
-            z.object({ behaviour: z.literal("dont-trigger-request") }),
-            z.object({ behaviour: z.literal("interrupt-current-request") }),
-            z.object({ behaviour: z.literal("after-current-request") }),
-            z.object({
-              behaviour: z.literal("trigger-request-within-time-period"),
-              withinMs: z.number().int().nonnegative(),
-            }),
-          ])
-          .default({ behaviour: "auto" }),
-      }),
+      examples: [
+        {
+          description: "User input that uses the default automatic LLM request behaviour.",
+          payload: {
+            content: "Summarize the deployment logs.",
+          },
+        },
+        {
+          description: "User input that interrupts the current request before starting a new one.",
+          payload: {
+            content: "Actually, focus only on failed checks.",
+            triggerLlmRequest: { behaviour: "interrupt-current-request" },
+          },
+        },
+      ],
+      payloadSchema: z
+        .object({
+          content: z.string().describe("Model-visible user context to append to agent history."),
+          triggerLlmRequest: z
+            .discriminatedUnion("behaviour", [
+              z.object({ behaviour: z.literal("auto") }),
+              z.object({ behaviour: z.literal("dont-trigger-request") }),
+              z.object({ behaviour: z.literal("interrupt-current-request") }),
+              z.object({ behaviour: z.literal("after-current-request") }),
+              z.object({
+                behaviour: z.literal("trigger-request-within-time-period"),
+                withinMs: z
+                  .number()
+                  .int()
+                  .nonnegative()
+                  .describe("Maximum delay before the queued LLM request should start."),
+              }),
+            ])
+            .describe("How this input should affect LLM request scheduling.")
+            .default({ behaviour: "auto" }),
+        })
+        .describe("Payload for an agent input row."),
     },
     "events.iterate.com/agent/output-added": {
       description: "A model-visible assistant output row.",

--- a/packages/shared/src/stream-processors/stream-processor.ts
+++ b/packages/shared/src/stream-processors/stream-processor.ts
@@ -6,6 +6,7 @@ import type {
   DerivedIdempotencyKeyArgs,
   EventCatalog,
   EventDefinition,
+  EventExample,
   FirstAttachAfterAppendPolicy,
   Processor,
   ProcessorContractInput,
@@ -37,6 +38,7 @@ export function createEvent<
 >(args: {
   type: Type;
   description?: string;
+  examples?: readonly EventExample<z.input<PayloadSchema>>[];
   payloadSchema: PayloadSchema;
 }): {
   [Key in Type]: EventDefinition<Type, z.output<PayloadSchema>, z.input<PayloadSchema>>;
@@ -44,6 +46,7 @@ export function createEvent<
   return {
     [args.type]: {
       ...(args.description == null ? {} : { description: args.description }),
+      ...(args.examples == null ? {} : { examples: args.examples }),
       payloadSchema: args.payloadSchema,
     },
   } as unknown as {
@@ -829,6 +832,7 @@ export type {
   EmittedInput,
   EventCatalog,
   EventDefinition,
+  EventExample,
   FirstAttachAfterAppendPolicy,
   Processor,
   ProcessorContractInput,

--- a/packages/shared/src/stream-processors/stream-processor.type.test.ts
+++ b/packages/shared/src/stream-processors/stream-processor.type.test.ts
@@ -258,6 +258,72 @@ describe("stream processor contract types", () => {
     >().toEqualTypeOf<{ value: number }>();
   });
 
+  it("types event examples as payload-schema inputs", () => {
+    const contract = defineProcessorContract({
+      slug: "examples",
+      version: "1.0.0",
+      description: "Validates authored examples against payload schemas.",
+      stateSchema: z.object({}).default({}),
+      events: {
+        "example-input": {
+          description: "Example input.",
+          examples: [
+            {
+              description: "Valid example",
+              payload: { content: "hello", trigger: { behaviour: "auto" } },
+            },
+          ],
+          payloadSchema: z.object({
+            content: z.string(),
+            trigger: z
+              .discriminatedUnion("behaviour", [
+                z.object({ behaviour: z.literal("auto") }),
+                z.object({
+                  behaviour: z.literal("within"),
+                  withinMs: z.number().int().nonnegative(),
+                }),
+              ])
+              .default({ behaviour: "auto" }),
+          }),
+        },
+      },
+      consumes: ["example-input"],
+      emits: ["example-input"],
+    });
+
+    type ExamplePayload = NonNullable<
+      (typeof contract.events)["example-input"]["examples"]
+    >[number]["payload"];
+    expectTypeOf<ExamplePayload>().toMatchTypeOf<{
+      content: string;
+      trigger?: { behaviour: "auto" } | { behaviour: "within"; withinMs: number } | undefined;
+    }>();
+
+    defineProcessorContract({
+      slug: "bad-examples",
+      version: "1.0.0",
+      description: "Rejects examples that do not match payload schema input.",
+      stateSchema: z.object({}).default({}),
+      events: {
+        // @ts-expect-error examples[].payload.content must be a string.
+        "bad-example-input": {
+          description: "Bad example input.",
+          examples: [
+            {
+              description: "Invalid example",
+              payload: { content: 123 },
+            },
+          ],
+          payloadSchema: z.object({
+            content: z.string(),
+          }),
+        },
+      },
+      consumes: ["bad-example-input"],
+      emits: ["bad-example-input"],
+    });
+  });
+
   it("fails closed for widened event catalogs and widened event arrays", () => {
     const widenedEvents: EventCatalog = {
       "widened-event": {

--- a/packages/shared/src/stream-processors/types.ts
+++ b/packages/shared/src/stream-processors/types.ts
@@ -34,12 +34,18 @@ export type DerivedIdempotencyKeyArgs = {
   event: Pick<StreamEvent, "streamPath" | "offset">;
 };
 
+export type EventExample<Payload = unknown> = {
+  description: string;
+  payload: Payload;
+};
+
 export type EventDefinition<
   _Type extends string = string,
   PayloadOutput = unknown,
   PayloadInput = PayloadOutput,
 > = {
   description?: string;
+  examples?: readonly EventExample<PayloadInput>[];
   payloadSchema: z.ZodType<PayloadOutput, PayloadInput>;
 };
 
@@ -47,6 +53,20 @@ export type EventCatalog = Record<string, EventDefinition<string, unknown, unkno
 
 export type NoInferValue<Value> = [Value][Value extends unknown ? 0 : never];
 export type ProcessorStateObject = Record<string, unknown>;
+
+type EventDefinitionWithPayloadExamples<Value> = Value extends {
+  payloadSchema: infer PayloadSchema extends z.ZodType;
+}
+  ? Value extends { examples: infer Examples }
+    ? Examples extends readonly EventExample<z.input<PayloadSchema>>[]
+      ? Value
+      : never
+    : Value
+  : never;
+
+export type EventCatalogWithPayloadExamples<Events extends EventCatalog> = {
+  [Key in keyof Events]: EventDefinitionWithPayloadExamples<Events[Key]>;
+};
 
 /**
  * Type-level event lookup for string-keyed processor contracts.
@@ -329,7 +349,7 @@ export type ProcessorContractInput<
   stateSchema: z.output<StateSchema> extends Record<string, unknown> ? StateSchema : never;
   initialState?: z.input<StateSchema>;
   processorDeps: ProcessorDeps;
-  events: Events;
+  events: Events & EventCatalogWithPayloadExamples<Events>;
   consumes: Consumes & ResolvedEventTypesOnly<Events, ProcessorDeps, Consumes>;
   emits: Emits & ResolvedEventTypesOnly<Events, ProcessorDeps, Emits>;
   reduce?: ProcessorContractShape<StateSchema, Events, ProcessorDeps, Consumes, Emits>["reduce"];
@@ -347,7 +367,7 @@ export type ProcessorContractInputWithoutDeps<
   stateSchema: z.output<StateSchema> extends Record<string, unknown> ? StateSchema : never;
   initialState?: z.input<StateSchema>;
   processorDeps?: never;
-  events: Events;
+  events: Events & EventCatalogWithPayloadExamples<Events>;
   consumes: Consumes & ResolvedEventTypesOnly<Events, readonly [], Consumes>;
   emits: Emits & ResolvedEventTypesOnly<Events, readonly [], Emits>;
   reduce?: ProcessorContractShape<StateSchema, Events, readonly [], Consumes, Emits>["reduce"];


### PR DESCRIPTION
## What changed

- Adds `examples` metadata to stream processor event definitions, typed against each event payload schema input.
- Carries authored examples into event docs and JSON Schema output.
- Adds field descriptions and examples for `events.iterate.com/agent/input-added`.
- Renders event docs examples as authored event inputs while keeping the schema/example sections unwrapped by outer cards.

## Why

Processor docs need schema metadata that can explain individual fields and show real event inputs without letting examples drift from the payload schema types.

## Validation

- `pnpm --dir apps/events typecheck`
- `pnpm --dir packages/shared exec vitest run src/stream-processors/stream-processor.type.test.ts --config src/stream-processors/vitest.type.config.ts`
- `pnpm --dir apps/events test -- src/lib/processor-docs.test.ts`
- `pnpm --dir apps/events build`
- Browser checked `http://127.0.0.1:5173/agent/input-added/` with agent-browser; confirmed field description and both example event inputs render.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "events": {
      "appDisplayName": "Events",
      "appSlug": "events",
      "status": "released",
      "updatedAt": "2026-05-05T19:15:33.527Z",
      "headSha": "0bb27239f263003efb8fb837ef218d091ab40ae6",
      "message": "Preview app released.",
      "publicUrl": "https://events.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25395632654",
      "shortSha": "0bb2723"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Events
Status: released
Commit: `0bb2723`
Preview: https://events.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25395632654)
Updated: 2026-05-05T19:15:33.527Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `examples` field to the shared stream-processor event definition types and enforces its shape at compile time, which could ripple into contract authoring across processors. Also changes docs generation/rendering to include examples in JSON Schema and UI output, so reviewers should watch for schema/output regressions.
> 
> **Overview**
> Adds first-class `examples` metadata to stream-processor event definitions (new `EventExample` type, `examples` support in `createEvent`, and compile-time enforcement that example payloads match the event payload schema input).
> 
> Propagates authored examples into the Events app processor docs (`ProcessorEventDoc.examples`) and into the generated JSON Schema via the `examples` field, and updates the event doc page to render one or more labeled example event inputs (with a fallback minimal example).
> 
> Enhances `agent`’s `input-added` contract with field-level descriptions plus two concrete examples, and extends tests to assert the new schema/examples behavior and typechecking guarantees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bb27239f263003efb8fb837ef218d091ab40ae6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->