### PR TITLE
[codex] Improve docs schema union labels

### DIFF
--- a/apps/events/src/lib/json-schema-docs.ts
+++ b/apps/events/src/lib/json-schema-docs.ts
@@ -1,0 +1,112 @@
+const combiners = ["anyOf", "oneOf"] as const;
+
+type JsonSchemaRecord = Record<string, unknown>;
+type DiscriminatorValue = boolean | number | string;
+
+export function addDiscriminatorTitlesToJsonSchema(schema: unknown): unknown {
+  return visitJsonSchemaValue(schema);
+}
+
+function visitJsonSchemaValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => visitJsonSchemaValue(item));
+  }
+
+  if (!isRecord(value)) return value;
+
+  const schema: JsonSchemaRecord = Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [key, visitJsonSchemaValue(child)]),
+  );
+
+  for (const combiner of combiners) {
+    const options = schema[combiner];
+    if (Array.isArray(options)) {
+      schema[combiner] = addDiscriminatorTitlesToCombinerOptions(options);
+    }
+  }
+
+  return schema;
+}
+
+function addDiscriminatorTitlesToCombinerOptions(options: unknown[]) {
+  const discriminator = findSharedDiscriminator(options);
+  if (discriminator == null) return options;
+
+  return options.map((option, index) => {
+    if (!isRecord(option) || typeof option.title === "string") return option;
+
+    return {
+      ...option,
+      title: String(discriminator.values[index]),
+    };
+  });
+}
+
+function findSharedDiscriminator(options: unknown[]) {
+  const candidatesByOption = options.map(discriminatorCandidatesForOption);
+  if (
+    candidatesByOption.length === 0 ||
+    candidatesByOption.some((candidates) => candidates.size === 0)
+  ) {
+    return null;
+  }
+
+  const [firstCandidates, ...remainingCandidates] = candidatesByOption;
+  for (const key of firstCandidates.keys()) {
+    const values = candidatesByOption.map((candidates) => candidates.get(key));
+    if (values.some((value) => value == null)) continue;
+    if (new Set(values).size !== values.length) continue;
+    if (remainingCandidates.every((candidates) => candidates.has(key))) {
+      return {
+        key,
+        values: values as DiscriminatorValue[],
+      };
+    }
+  }
+
+  return null;
+}
+
+function discriminatorCandidatesForOption(option: unknown) {
+  const candidates = new Map<string, DiscriminatorValue>();
+  if (!isRecord(option)) return candidates;
+
+  const properties = option.properties;
+  if (!isRecord(properties)) return candidates;
+
+  for (const [key, propertySchema] of Object.entries(properties)) {
+    if (requiresProperty(option, key)) {
+      const value = discriminatorValue(propertySchema);
+      if (value != null) candidates.set(key, value);
+    }
+  }
+
+  return candidates;
+}
+
+function requiresProperty(schema: JsonSchemaRecord, key: string) {
+  const required = schema.required;
+  return Array.isArray(required) && required.includes(key);
+}
+
+function discriminatorValue(schema: unknown): DiscriminatorValue | null {
+  if (!isRecord(schema)) return null;
+
+  const constValue = schema.const;
+  if (isDiscriminatorValue(constValue)) return constValue;
+
+  const enumValue = schema.enum;
+  if (Array.isArray(enumValue) && enumValue.length === 1 && isDiscriminatorValue(enumValue[0])) {
+    return enumValue[0];
+  }
+
+  return null;
+}
+
+function isDiscriminatorValue(value: unknown): value is DiscriminatorValue {
+  return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+}
+
+function isRecord(value: unknown): value is JsonSchemaRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/events/src/lib/processor-docs.test.ts
+++ b/apps/events/src/lib/processor-docs.test.ts
@@ -20,6 +20,15 @@ describe("processor docs", () => {
           type: "string",
           description: "Model-visible user context to append to agent history.",
         },
+        triggerLlmRequest: {
+          oneOf: [
+            { title: "auto" },
+            { title: "dont-trigger-request" },
+            { title: "interrupt-current-request" },
+            { title: "after-current-request" },
+            { title: "trigger-request-within-time-period" },
+          ],
+        },
       },
       examples: [
         {

--- a/apps/events/src/lib/processor-docs.ts
+++ b/apps/events/src/lib/processor-docs.ts
@@ -7,6 +7,7 @@ import { SchedulingProcessorContract } from "@iterate-com/shared/stream-processo
 import { SlackThreadProcessorContract } from "@iterate-com/shared/stream-processors/slack-thread/contract";
 import { SlackProcessorContract } from "@iterate-com/shared/stream-processors/slack/contract";
 import { WebchatProcessorContract } from "@iterate-com/shared/stream-processors/webchat/contract";
+import { addDiscriminatorTitlesToJsonSchema } from "~/lib/json-schema-docs.ts";
 import { CoreStreamProcessorContract } from "~/stream-processors/core/contract.ts";
 
 const processorContracts = [
@@ -194,12 +195,17 @@ function eventPayloadJsonSchema(args: {
   examples: readonly { payload: unknown }[];
   payloadSchema: z.ZodType;
 }) {
-  const jsonSchema = z.toJSONSchema(args.payloadSchema, {
-    io: "input",
-    unrepresentable: "any",
-  });
+  const jsonSchema = addDiscriminatorTitlesToJsonSchema(
+    z.toJSONSchema(args.payloadSchema, {
+      io: "input",
+      unrepresentable: "any",
+    }),
+  );
 
   if (args.examples.length === 0) return jsonSchema;
+  if (typeof jsonSchema !== "object" || jsonSchema === null || Array.isArray(jsonSchema)) {
+    return jsonSchema;
+  }
 
   return {
     ...jsonSchema,


### PR DESCRIPTION
## What changed

- Adds an Events-docs-local JSON Schema normalizer that walks generated schemas and adds `title` annotations to `oneOf`/`anyOf` object variants when all variants share a required discriminator field with distinct `const`/single-value `enum` values.
- Wires the normalizer into processor docs JSON Schema generation, after Zod emits JSON Schema and before examples are attached.
- Extends the processor docs test to assert readable `triggerLlmRequest` union titles.

## Why

`cf-json-schema-viz` uses schema `title` for union selector labels, while Zod emits discriminated unions as object-valued `oneOf` branches without titles. That made every option render as `object` on the docs page.

Relevant first-party docs:

- Zod JSON Schema metadata: https://zod.dev/json-schema#metadata
- JSON Schema annotations (`title`, `description`, `examples`): https://json-schema.org/understanding-json-schema/reference/annotations

## Validation

- `pnpm --dir apps/events typecheck`
- `pnpm --dir apps/events test -- src/lib/processor-docs.test.ts`
- `pnpm --dir apps/events build`
- Browser checked `http://127.0.0.1:5175/agent/input-added/`; the `triggerLlmRequest` selector now shows behaviour labels and the timed variant renders `withinMs`.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "events": {
      "appDisplayName": "Events",
      "appSlug": "events",
      "status": "released",
      "updatedAt": "2026-05-05T20:17:09.920Z",
      "headSha": "09c782cdebafe474006dd6609a83b471961ceee4",
      "message": "Preview app released.",
      "publicUrl": "https://events.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25398833959",
      "shortSha": "09c782c"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Events
Status: released
Commit: `09c782c`
Preview: https://events.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25398833959)
Updated: 2026-05-05T20:17:09.920Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the docs-facing JSON Schema output by adding `title` annotations to `oneOf`/`anyOf` branches; main risk is unexpected schema normalization affecting how docs render certain unions.
> 
> **Overview**
> Adds a JSON Schema normalizer (`addDiscriminatorTitlesToJsonSchema`) that recursively walks generated schemas and auto-populates missing `title` fields for `oneOf`/`anyOf` branches when all variants share a required discriminator property with distinct `const`/single-value `enum` values.
> 
> Wires this normalization into `processor-docs` JSON Schema generation (before attaching `examples`) and extends the processor docs test to assert readable union option titles for the agent `triggerLlmRequest` payload schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c782cdebafe474006dd6609a83b471961ceee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->