### PR TITLE
[codex] add example sandbox poc

### DIFF
--- a/apps/example/Dockerfile.sandbox
+++ b/apps/example/Dockerfile.sandbox
@@ -1,0 +1,3 @@
+FROM docker.io/cloudflare/sandbox:0.9.4
+
+EXPOSE 8080

--- a/apps/example/README.md
+++ b/apps/example/README.md
@@ -7,6 +7,7 @@ Minimal full-stack app: TanStack Start + oRPC over OpenAPI/HTTP + Drizzle, dual-
 - **API:** oRPC over OpenAPI/HTTP at `/api`
 - **Confetti:** websocket at `/api/confetti`
 - **Durable Object:** counter demo at `/api/durable-counter` with WebSocket sync at `/api/durable-counter/websocket`
+- **Sandbox:** Cloudflare Sandbox SDK proof of concept at `/sandbox`, backed by a local Cloudflare Container in `pnpm cf:dev`
 - **Frontend:** TanStack Start in SPA mode + TanStack Router + TanStack Query
 - **DB:** Drizzle ORM — better-sqlite3 (Node), D1 (Workers). Shared `BaseSQLiteDatabase<"sync" | "async">` type.
 - **Observability:** Node and Workers both use the shared `withEvlog()` runtime wrapper; shared `useEvlog()` only enriches a request-scoped log
@@ -26,7 +27,9 @@ Minimal full-stack app: TanStack Start + oRPC over OpenAPI/HTTP + Drizzle, dual-
 - `src/router.tsx` — TanStack Router setup plus SSR Query integration
 - `src/routes/api.$.ts` — OpenAPI oRPC catch-all route mounted at `/api`
 - `src/routes/api.confetti.ts` — confetti websocket route
+- `src/routes/_app/sandbox.tsx` — Sandbox SDK UI for editing and running JavaScript inside the sandbox container
 - `src/routes/__root.tsx` — root route with sidebar shell, SSR-loaded public config, shared app providers, and devtools
+- `Dockerfile.sandbox` — local/prod Cloudflare Sandbox SDK container image definition
 - `vite.config.ts` — Node dev/build via Nitro
 - `vite.cf.config.ts` — Cloudflare dev/build (uses Alchemy plugin)
 - PostHog source maps: `vite.config.ts` / `vite.cf.config.ts` pass `apiKey`, `projectId`, `releaseName: manifest.slug`, and `releaseVersion: "latest"` into `posthogSourcemaps` from `@iterate-com/shared/posthog/vite-plugin` (Doppler example `dev`, personal dev configs like `dev_jonas`, and `prd`, not `APP_CONFIG`)
@@ -93,6 +96,68 @@ pnpm cf:deploy    # Deploy to Cloudflare
 ```
 
 Pin the port with `PORT` or `NITRO_PORT` (default **3000** when unset). The Node bundle uses **srvx**; it prints `➜ Listening on: …` unless `TEST` is set (then the banner is hidden). The `start` script unsets `TEST` so Doppler does not suppress it. Request **evlog** lines match `pnpm dev` once you send traffic.
+
+## Cloudflare Sandbox POC
+
+This app includes a deliberately small Cloudflare Sandbox SDK proof of concept.
+It exists to prove the app can:
+
+- start a Cloudflare Sandbox container through the Worker runtime
+- write a user-editable JavaScript file into `/workspace`
+- execute that file with `sandbox.exec()`
+- return stdout, stderr, exit code, and duration to the UI
+- make public internet requests from inside the sandbox
+
+Start it with Cloudflare local dev:
+
+```bash
+PORT=5174 pnpm --dir apps/example cf:dev
+```
+
+Open:
+
+```text
+http://127.0.0.1:5174/sandbox
+```
+
+The default sample writes `/workspace/user-code.mjs`, runs it with Node, and
+fetches `https://example.com`. A successful run shows `exit 0` and
+`egressStatus: 200`.
+
+API endpoints:
+
+- `GET /api/sandbox` writes and executes `/workspace/status.mjs`, then returns
+  the Node version, platform, arch, and cwd from inside the sandbox.
+- `POST /api/sandbox/run` accepts `{ "code": "..." }`, writes it to
+  `/workspace/user-code.mjs`, executes it with Node, and returns command output.
+- `POST /api/sandbox/destroy` destroys the named sandbox instance so the next
+  status/run call starts fresh.
+
+The sandbox binding is defined in `alchemy.run.ts` using Alchemy's
+`Container<Sandbox>` resource. The Worker entrypoint exports Cloudflare's
+`Sandbox` class and uses `getSandbox(env.SANDBOX, "example-poc", ...)`.
+
+### Apple Silicon / OrbStack Sidecar Override
+
+On Apple Silicon, `pnpm cf:dev` sets `MINIFLARE_CONTAINER_EGRESS_IMAGE` to the
+arm64 `cloudflare/proxy-everything` digest before starting Alchemy. This is a
+workaround for a known Cloudflare local-dev sidecar issue where the amd64 egress
+sidecar fails under OrbStack with:
+
+```text
+Fatal error:  setsockoptint: protocol not available
+```
+
+This is intentionally an environment variable in `cf:dev`, not a pre-dev patch
+script and not a mutation of `node_modules`.
+
+Deep-dive docs:
+
+- `docs/cloudflare-sandbox-sdk-local-dev.md`
+- Cloudflare outbound traffic docs: https://developers.cloudflare.com/containers/platform-details/outbound-traffic/
+- Cloudflare Sandbox SDK getting started: https://developers.cloudflare.com/sandbox/get-started/
+- Upstream issue: https://github.com/cloudflare/sandbox-sdk/issues/522
+- Related Workers SDK issue: https://github.com/cloudflare/workers-sdk/issues/12965
 
 ## Runtime config
 

--- a/apps/example/alchemy.run.ts
+++ b/apps/example/alchemy.run.ts
@@ -1,8 +1,9 @@
-import { D1Database, DurableObjectNamespace, Worker } from "alchemy/cloudflare";
+import { Container, D1Database, DurableObjectNamespace, Worker } from "alchemy/cloudflare";
 import { initAlchemy } from "@iterate-com/shared/alchemy/init";
 import { IterateApp } from "@iterate-com/shared/alchemy/iterate-app";
 import manifest, { AppConfig } from "./src/app.ts";
 import type { ExampleCounter } from "./src/durable-objects/example-counter.ts";
+import type { Sandbox } from "@cloudflare/sandbox";
 
 const ctx = await initAlchemy(manifest, AppConfig, process.env);
 
@@ -25,10 +26,25 @@ const exampleCounterWorker = await Worker("example-counter-do", {
   },
 });
 
+const sandbox = await Container<Sandbox>("sandbox", {
+  className: "Sandbox",
+  build: {
+    context: ".",
+    dockerfile: "Dockerfile.sandbox",
+  },
+  instanceType: "lite",
+  maxInstances: 1,
+  adopt: true,
+  dev: {
+    remote: false,
+  },
+});
+
 const { worker, afterFinalize } = await IterateApp(ctx, {
   bindings: {
     DB: db,
     EXAMPLE_COUNTER: exampleCounterWorker.bindings.EXAMPLE_COUNTER,
+    SANDBOX: sandbox,
   },
   build: "pnpm exec vite build --config vite.cf.config.ts",
   dev: { command: "pnpm exec vite dev --config vite.cf.config.ts" },

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -15,7 +15,7 @@
     "preview": "doppler run -- vite preview",
     "rpc": "pnpm cli rpc",
     "start": "pnpm cli start",
-    "cf:dev": "doppler run --project example -- tsx ./alchemy.run.ts",
+    "cf:dev": "if [ \"$(uname -m)\" = \"arm64\" ] || [ \"$(uname -m)\" = \"aarch64\" ]; then export MINIFLARE_CONTAINER_EGRESS_IMAGE=cloudflare/proxy-everything@sha256:78c7910f4575a511d928d7824b1cbcaec6b7c4bf4dbb3fafaeeae3104030e73c; fi; doppler run --project example -- tsx ./alchemy.run.ts",
     "cf:deploy": "doppler run --project example --config prd -- pnpm exec tsx ./alchemy.run.ts",
     "cf:destroy": "doppler run --project example --config prd -- pnpm exec tsx ./alchemy.run.ts --destroy",
     "deploy": "pnpm cf:deploy",
@@ -33,6 +33,7 @@
     }
   },
   "dependencies": {
+    "@cloudflare/sandbox": "0.9.4",
     "@iterate-com/example-contract": "workspace:*",
     "@iterate-com/shared": "workspace:*",
     "@iterate-com/ui": "workspace:*",

--- a/apps/example/src/components/app-sidebar.tsx
+++ b/apps/example/src/components/app-sidebar.tsx
@@ -14,6 +14,7 @@ const items = [
   { to: "/confetti", label: "Confetti" },
   { to: "/durable-object", label: "Durable Object" },
   { to: "/log-stream", label: "Log Stream" },
+  { to: "/sandbox", label: "Sandbox" },
   { to: "/things", label: "Things" },
 ] as const;
 

--- a/apps/example/src/entry.workerd.ts
+++ b/apps/example/src/entry.workerd.ts
@@ -1,4 +1,5 @@
 import { env as workerEnv } from "cloudflare:workers";
+import { getSandbox } from "@cloudflare/sandbox";
 import { parseAppConfigFromEnv } from "@iterate-com/shared/apps/config";
 import { withEvlog } from "@iterate-com/shared/apps/logging/with-evlog";
 import handler from "@tanstack/react-start/server-entry";
@@ -9,6 +10,8 @@ import manifest, { AppConfig } from "~/app.ts";
 import type { AppContext } from "~/context.ts";
 import * as schema from "~/db/schema.ts";
 
+export { Sandbox } from "@cloudflare/sandbox";
+
 const config = parseAppConfigFromEnv({
   configSchema: AppConfig,
   prefix: "APP_CONFIG_",
@@ -16,6 +19,21 @@ const config = parseAppConfigFromEnv({
 });
 const db = drizzleWorkerd(workerEnv.DB, { schema });
 const durableCounterPrefix = "/api/durable-counter";
+const sandboxPrefix = "/api/sandbox";
+const sandboxId = "example-poc";
+const sandboxCwd = "/workspace";
+const sandboxStatusPath = `${sandboxCwd}/status.mjs`;
+const sandboxUserCodePath = `${sandboxCwd}/user-code.mjs`;
+const sandboxStatusCommand = `node ${sandboxStatusPath}`;
+const sandboxUserCodeCommand = `node ${sandboxUserCodePath}`;
+const sandboxStatusCode = `
+console.log(JSON.stringify({
+  node: process.version,
+  platform: process.platform,
+  arch: process.arch,
+  cwd: process.cwd(),
+}));
+`;
 
 export default {
   async fetch(request: Request, env: Env, cfCtx: ExecutionContext) {
@@ -33,6 +51,10 @@ export default {
           url.pathname.startsWith(`${durableCounterPrefix}/`)
         ) {
           return env.EXAMPLE_COUNTER.getByName("default").fetch(request);
+        }
+
+        if (url.pathname === sandboxPrefix || url.pathname.startsWith(`${sandboxPrefix}/`)) {
+          return handleSandboxRequest(request, env);
         }
 
         const context: AppContext = {
@@ -55,3 +77,104 @@ export default {
     );
   },
 };
+
+async function handleSandboxRequest(request: Request, env: Env) {
+  const url = new URL(request.url);
+  const sandbox = getSandbox(env.SANDBOX, sandboxId, {
+    normalizeId: true,
+    sleepAfter: "2m",
+    containerTimeouts: {
+      instanceGetTimeoutMS: 60_000,
+    },
+  });
+
+  try {
+    if (request.method === "GET" && url.pathname === sandboxPrefix) {
+      await sandbox.writeFile(sandboxStatusPath, sandboxStatusCode);
+      const result = await sandbox.exec(sandboxStatusCommand, {
+        cwd: sandboxCwd,
+        timeout: 10_000,
+      });
+
+      return jsonResponse({
+        sandboxId,
+        status: result.success ? "ready" : "error",
+        stdout: result.stdout,
+        stderr: result.stderr,
+        exitCode: result.exitCode,
+      });
+    }
+
+    if (request.method === "POST" && url.pathname === `${sandboxPrefix}/run`) {
+      const body = await readJsonObject(request);
+      const code = typeof body.code === "string" ? body.code : "";
+      if (code.trim().length === 0) {
+        return jsonResponse({ error: "JavaScript code is required." }, { status: 400 });
+      }
+      if (code.length > 20_000) {
+        return jsonResponse(
+          { error: "JavaScript code must be 20,000 characters or fewer." },
+          {
+            status: 400,
+          },
+        );
+      }
+
+      const startedAt = Date.now();
+      await sandbox.writeFile(sandboxUserCodePath, code);
+      const result = await sandbox.exec(sandboxUserCodeCommand, {
+        cwd: sandboxCwd,
+        env: {
+          CI: "1",
+          FORCE_COLOR: "0",
+        },
+        timeout: 10_000,
+      });
+
+      return jsonResponse({
+        sandboxId,
+        command: sandboxUserCodeCommand,
+        durationMs: Date.now() - startedAt,
+        success: result.success,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        exitCode: result.exitCode,
+      });
+    }
+
+    if (request.method === "POST" && url.pathname === `${sandboxPrefix}/destroy`) {
+      await sandbox.destroy();
+      return jsonResponse({
+        sandboxId,
+        destroyed: true,
+      });
+    }
+
+    return jsonResponse({ error: "Sandbox endpoint not found." }, { status: 404 });
+  } catch (error) {
+    return jsonResponse(
+      {
+        error: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 },
+    );
+  }
+}
+
+async function readJsonObject(request: Request) {
+  const parsed = (await request.json().catch(() => null)) as unknown;
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return {};
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      ...init?.headers,
+    },
+  });
+}

--- a/apps/example/src/routeTree.gen.ts
+++ b/apps/example/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as ApiOrpcWsRouteImport } from './routes/api.orpc-ws'
 import { Route as ApiConfettiRouteImport } from './routes/api.confetti'
 import { Route as ApiSplatRouteImport } from './routes/api.$'
 import { Route as AppThingsRouteImport } from './routes/_app/things'
+import { Route as AppSandboxRouteImport } from './routes/_app/sandbox'
 import { Route as AppLogStreamRouteImport } from './routes/_app/log-stream'
 import { Route as AppDurableObjectRouteImport } from './routes/_app/durable-object'
 import { Route as AppDebugRouteImport } from './routes/_app/debug'
@@ -56,6 +57,11 @@ const ApiSplatRoute = ApiSplatRouteImport.update({
 const AppThingsRoute = AppThingsRouteImport.update({
   id: '/things',
   path: '/things',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppSandboxRoute = AppSandboxRouteImport.update({
+  id: '/sandbox',
+  path: '/sandbox',
   getParentRoute: () => AppRoute,
 } as any)
 const AppLogStreamRoute = AppLogStreamRouteImport.update({
@@ -100,6 +106,7 @@ export interface FileRoutesByFullPath {
   '/debug': typeof AppDebugRoute
   '/durable-object': typeof AppDurableObjectRoute
   '/log-stream': typeof AppLogStreamRoute
+  '/sandbox': typeof AppSandboxRoute
   '/things': typeof AppThingsRouteWithChildren
   '/api/$': typeof ApiSplatRoute
   '/api/confetti': typeof ApiConfettiRoute
@@ -115,6 +122,7 @@ export interface FileRoutesByTo {
   '/debug': typeof AppDebugRoute
   '/durable-object': typeof AppDurableObjectRoute
   '/log-stream': typeof AppLogStreamRoute
+  '/sandbox': typeof AppSandboxRoute
   '/api/$': typeof ApiSplatRoute
   '/api/confetti': typeof ApiConfettiRoute
   '/api/orpc-ws': typeof ApiOrpcWsRoute
@@ -131,6 +139,7 @@ export interface FileRoutesById {
   '/_app/debug': typeof AppDebugRoute
   '/_app/durable-object': typeof AppDurableObjectRoute
   '/_app/log-stream': typeof AppLogStreamRoute
+  '/_app/sandbox': typeof AppSandboxRoute
   '/_app/things': typeof AppThingsRouteWithChildren
   '/api/$': typeof ApiSplatRoute
   '/api/confetti': typeof ApiConfettiRoute
@@ -148,6 +157,7 @@ export interface FileRouteTypes {
     | '/debug'
     | '/durable-object'
     | '/log-stream'
+    | '/sandbox'
     | '/things'
     | '/api/$'
     | '/api/confetti'
@@ -163,6 +173,7 @@ export interface FileRouteTypes {
     | '/debug'
     | '/durable-object'
     | '/log-stream'
+    | '/sandbox'
     | '/api/$'
     | '/api/confetti'
     | '/api/orpc-ws'
@@ -178,6 +189,7 @@ export interface FileRouteTypes {
     | '/_app/debug'
     | '/_app/durable-object'
     | '/_app/log-stream'
+    | '/_app/sandbox'
     | '/_app/things'
     | '/api/$'
     | '/api/confetti'
@@ -247,6 +259,13 @@ declare module '@tanstack/react-router' {
       path: '/things'
       fullPath: '/things'
       preLoaderRoute: typeof AppThingsRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/sandbox': {
+      id: '/_app/sandbox'
+      path: '/sandbox'
+      fullPath: '/sandbox'
+      preLoaderRoute: typeof AppSandboxRouteImport
       parentRoute: typeof AppRoute
     }
     '/_app/log-stream': {
@@ -320,6 +339,7 @@ interface AppRouteChildren {
   AppDebugRoute: typeof AppDebugRoute
   AppDurableObjectRoute: typeof AppDurableObjectRoute
   AppLogStreamRoute: typeof AppLogStreamRoute
+  AppSandboxRoute: typeof AppSandboxRoute
   AppThingsRoute: typeof AppThingsRouteWithChildren
 }
 
@@ -328,6 +348,7 @@ const AppRouteChildren: AppRouteChildren = {
   AppDebugRoute: AppDebugRoute,
   AppDurableObjectRoute: AppDurableObjectRoute,
   AppLogStreamRoute: AppLogStreamRoute,
+  AppSandboxRoute: AppSandboxRoute,
   AppThingsRoute: AppThingsRouteWithChildren,
 }
 

--- a/apps/example/src/routes/_app/sandbox.tsx
+++ b/apps/example/src/routes/_app/sandbox.tsx
@@ -1,0 +1,311 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useForm } from "@tanstack/react-form";
+import { createFileRoute } from "@tanstack/react-router";
+import { Button } from "@iterate-com/ui/components/button";
+import { Field, FieldDescription, FieldGroup, FieldLabel } from "@iterate-com/ui/components/field";
+import { Textarea } from "@iterate-com/ui/components/textarea";
+import { toast } from "@iterate-com/ui/components/sonner";
+
+type SandboxStatusResponse = {
+  sandboxId: string;
+  status: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};
+
+type SandboxRunResponse = {
+  sandboxId: string;
+  command: string;
+  durationMs: number;
+  success: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};
+
+const DEFAULT_CODE = `const facts = {
+  message: "hello from the Cloudflare sandbox",
+  node: process.version,
+  cwd: process.cwd(),
+  random: Math.random(),
+};
+
+const response = await fetch("https://example.com");
+facts.egressStatus = response.status;
+
+console.log(JSON.stringify(facts, null, 2));
+`;
+
+const sandboxStatusQueryKey = ["sandbox", "status"] as const;
+
+export const Route = createFileRoute("/_app/sandbox")({
+  ssr: false,
+  staticData: {
+    breadcrumb: "Sandbox",
+  },
+  component: SandboxPage,
+});
+
+function SandboxPage() {
+  const queryClient = useQueryClient();
+  const status = useQuery({
+    queryKey: sandboxStatusQueryKey,
+    queryFn: fetchSandboxStatus,
+    retry: false,
+  });
+  const runCode = useMutation({
+    mutationFn: runSandboxCode,
+    onSuccess: (result) => {
+      toast[result.success ? "success" : "error"](
+        result.success ? "Sandbox code finished" : "Sandbox code exited non-zero",
+      );
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+  const destroySandbox = useMutation({
+    mutationFn: destroySandboxContainer,
+    onSuccess: async () => {
+      runCode.reset();
+      await queryClient.invalidateQueries({ queryKey: sandboxStatusQueryKey });
+      toast.success("Sandbox destroyed");
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+  const form = useForm({
+    defaultValues: {
+      code: DEFAULT_CODE,
+    },
+    onSubmit: async ({ value }) => {
+      await runCode.mutateAsync(value.code);
+    },
+  });
+
+  const result = runCode.data;
+  const busy = status.isPending || runCode.isPending || destroySandbox.isPending;
+
+  return (
+    <div className="flex min-h-full flex-1 flex-col lg:flex-row">
+      <section className="w-full border-b p-4 lg:max-w-md lg:border-b-0 lg:border-r">
+        <div className="max-w-md space-y-6">
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <StatusDot status={status.data?.status ?? (status.isError ? "error" : "pending")} />
+              <h2 className="text-sm font-semibold">Cloudflare sandbox</h2>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Runs JavaScript inside a local Cloudflare Sandbox container when this app is started
+              with the Cloudflare dev command.
+            </p>
+          </div>
+
+          {status.isError ? (
+            <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+              {status.error.message}
+            </div>
+          ) : (
+            <SandboxStatus status={status.data} />
+          )}
+
+          <form
+            className="space-y-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void form.handleSubmit();
+            }}
+          >
+            <FieldGroup>
+              <form.Field name="code">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor={field.name}>JavaScript</FieldLabel>
+                    <Textarea
+                      id={field.name}
+                      name={field.name}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) => field.handleChange(event.target.value)}
+                      className="min-h-64 font-mono text-xs"
+                      spellCheck={false}
+                    />
+                    <FieldDescription>
+                      Written to <code>/workspace/user-code.mjs</code> and executed with Node.
+                    </FieldDescription>
+                  </Field>
+                )}
+              </form.Field>
+            </FieldGroup>
+
+            <div className="flex flex-wrap gap-2">
+              <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting] as const}>
+                {([canSubmit, isSubmitting]) => (
+                  <Button type="submit" disabled={!canSubmit || isSubmitting || busy}>
+                    {runCode.isPending ? "Running..." : "Run code"}
+                  </Button>
+                )}
+              </form.Subscribe>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={busy}
+                onClick={() => {
+                  form.setFieldValue("code", DEFAULT_CODE);
+                  runCode.reset();
+                }}
+              >
+                Reset editor
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                disabled={busy}
+                onClick={() => destroySandbox.mutate()}
+              >
+                Destroy sandbox
+              </Button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <section className="min-h-0 flex-1 p-4">
+        <div className="flex h-full min-h-[360px] flex-col rounded-lg border bg-card">
+          <div className="flex items-center justify-between gap-3 border-b px-4 py-3 text-sm">
+            <div className="font-medium">Output</div>
+            {result && (
+              <span className="text-muted-foreground">
+                exit {result.exitCode} · {result.durationMs}ms
+              </span>
+            )}
+          </div>
+          <div className="min-h-0 flex-1 overflow-auto p-4">
+            {result ? (
+              <SandboxOutput result={result} />
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Run the sample to create a sandbox and execute code in the container.
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function SandboxStatus({ status }: { status?: SandboxStatusResponse }) {
+  if (!status) {
+    return (
+      <div className="rounded-lg border p-3 text-sm text-muted-foreground">
+        Starting sandbox container...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2 rounded-lg border p-3 text-sm">
+      <div className="flex items-center justify-between gap-3">
+        <span className="font-medium">Sandbox ID</span>
+        <span className="font-mono text-xs text-muted-foreground">{status.sandboxId}</span>
+      </div>
+      <pre className="overflow-x-auto whitespace-pre-wrap font-mono text-xs leading-5 text-muted-foreground">
+        {status.stdout || status.stderr}
+      </pre>
+    </div>
+  );
+}
+
+function SandboxOutput({ result }: { result: SandboxRunResponse }) {
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        <StatusDot status={result.success ? "ready" : "error"} />
+        <span className="font-medium">{result.success ? "Completed" : "Exited non-zero"}</span>
+        <span className="text-muted-foreground">{result.command}</span>
+      </div>
+      {result.stdout && (
+        <div className="space-y-2">
+          <p className="text-xs font-medium uppercase text-muted-foreground">stdout</p>
+          <pre className="whitespace-pre-wrap font-mono text-xs leading-5">{result.stdout}</pre>
+        </div>
+      )}
+      {result.stderr && (
+        <div className="space-y-2">
+          <p className="text-xs font-medium uppercase text-muted-foreground">stderr</p>
+          <pre className="whitespace-pre-wrap font-mono text-xs leading-5 text-destructive">
+            {result.stderr}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusDot({ status }: { status: string }) {
+  const color =
+    status === "ready"
+      ? "bg-green-500"
+      : status === "error"
+        ? "bg-red-500"
+        : "animate-pulse bg-yellow-500";
+
+  return <div className={`size-2 rounded-full ${color}`} />;
+}
+
+async function fetchSandboxStatus() {
+  const response = await fetch("/api/sandbox", {
+    headers: {
+      accept: "application/json",
+    },
+  });
+
+  return parseJsonResponse<SandboxStatusResponse>(response, "Sandbox status request failed");
+}
+
+async function runSandboxCode(code: string) {
+  const response = await fetch("/api/sandbox/run", {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ code }),
+  });
+
+  return parseJsonResponse<SandboxRunResponse>(response, "Sandbox run request failed");
+}
+
+async function destroySandboxContainer() {
+  const response = await fetch("/api/sandbox/destroy", {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+    },
+  });
+
+  return parseJsonResponse<{ destroyed: true }>(response, "Sandbox destroy request failed");
+}
+
+async function parseJsonResponse<T>(response: Response, fallbackMessage: string): Promise<T> {
+  const parsed = (await response.json().catch(() => null)) as unknown;
+
+  if (!response.ok) {
+    const message = readErrorMessage(parsed) ?? `${fallbackMessage}: ${response.status}`;
+    throw new Error(message);
+  }
+
+  return parsed as T;
+}
+
+function readErrorMessage(value: unknown) {
+  if (typeof value !== "object" || value === null || !("error" in value)) {
+    return null;
+  }
+
+  const error = value.error;
+  return typeof error === "string" ? error : null;
+}

--- a/docs/cloudflare-sandbox-sdk-local-dev.md
+++ b/docs/cloudflare-sandbox-sdk-local-dev.md
@@ -1,0 +1,355 @@
+# Cloudflare Sandbox SDK Local Dev On Apple Silicon
+
+This documents the local development failure mode we hit while wiring
+`apps/example` to Cloudflare's Sandbox SDK on an Apple Silicon Mac using
+OrbStack Docker.
+
+Last validated: 2026-05-06.
+
+## TL;DR
+
+Cloudflare Sandbox SDK local dev works in this repo on OrbStack, but Apple
+Silicon needs an arm64 egress sidecar override:
+
+```bash
+MINIFLARE_CONTAINER_EGRESS_IMAGE=cloudflare/proxy-everything@sha256:78c7910f4575a511d928d7824b1cbcaec6b7c4bf4dbb3fafaeeae3104030e73c \
+  pnpm --dir apps/example cf:dev
+```
+
+`apps/example/package.json` applies this automatically for `arm64`/`aarch64`
+hosts. Do not replace it with a node_modules patch or a pre-dev package patch.
+
+## What Is Going On
+
+Cloudflare Containers local dev starts two Docker containers for a sandbox:
+
+- the actual sandbox container image
+- an egress sidecar image, `cloudflare/proxy-everything`, that mirrors
+  Cloudflare's outbound traffic interception locally
+
+Cloudflare's Containers docs describe this local development behavior: outbound
+interception spawns a sidecar process inside the container network namespace and
+uses `TPROXY` rules to route matching traffic to local Workerd.
+
+Relevant docs:
+
+- https://developers.cloudflare.com/containers/platform-details/outbound-traffic/
+- https://developers.cloudflare.com/sandbox/get-started/
+- https://developers.cloudflare.com/sandbox/api/commands/
+
+The problem is not the Sandbox SDK API usage. The same failure reproduces with
+Cloudflare's minimal Sandbox SDK template on affected machines.
+
+## Symptom
+
+Cloudflare local dev starts, then sandbox requests hang or return 500. Docker
+shows an exited `proxy-everything` sidecar:
+
+```bash
+docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Names}}\t{{.Status}}' |
+  rg 'proxy-everything|workerd-example'
+```
+
+Sidecar logs show:
+
+```text
+TLS interception enabled, CA written to /ca/ca.crt
+Fatal error:  setsockoptint: protocol not available
+```
+
+The sandbox container may then loop through errors like "No such container"
+because the sidecar failed before the local container runtime finished wiring
+the sandbox network.
+
+## Root Cause
+
+On Apple Silicon, Cloudflare's local-dev tooling pulls/runs the
+`cloudflare/proxy-everything` egress sidecar as `linux/amd64`. Under OrbStack's
+amd64 emulation path, that sidecar fails while setting socket options for the
+TPROXY-based egress interception path.
+
+The same sidecar image has an arm64 manifest. Running that arm64 manifest works
+on the same OrbStack install:
+
+```bash
+docker manifest inspect cloudflare/proxy-everything:3cb1195 |
+  rg -n 'architecture|digest|platform' -C 2
+```
+
+At the time this was debugged:
+
+- amd64 digest:
+  `sha256:6b7ab58f31166045c25047ab81d707e6d7746efe6047eb9b06f43afd64cfc1c9`
+- arm64 digest:
+  `sha256:78c7910f4575a511d928d7824b1cbcaec6b7c4bf4dbb3fafaeeae3104030e73c`
+
+Direct repro:
+
+```bash
+docker run --rm --platform linux/amd64 --cap-add NET_ADMIN \
+  cloudflare/proxy-everything:3cb1195 \
+  /proxy-everything \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --proxy-to 127.0.0.1 \
+  --proxy-to-port 8081 \
+  --tls-intercept \
+  --disable-ipv6
+```
+
+On the affected OrbStack setup, that exits with:
+
+```text
+Fatal error:  setsockoptint: protocol not available
+```
+
+The arm64 digest starts:
+
+```bash
+docker run --rm --cap-add NET_ADMIN \
+  cloudflare/proxy-everything@sha256:78c7910f4575a511d928d7824b1cbcaec6b7c4bf4dbb3fafaeeae3104030e73c \
+  /proxy-everything \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --proxy-to 127.0.0.1 \
+  --proxy-to-port 8081 \
+  --tls-intercept \
+  --disable-ipv6
+```
+
+Expected output starts with:
+
+```text
+Proxy address: 127.0.0.3, Port: 41209
+```
+
+## Known Upstream Reports
+
+This is known upstream, not specific to this repo:
+
+- Exact Sandbox SDK / OrbStack / Apple Silicon issue:
+  https://github.com/cloudflare/sandbox-sdk/issues/522
+- Related Workers SDK sidecar issue:
+  https://github.com/cloudflare/workers-sdk/issues/12965
+- Related tag/digest image lookup issue:
+  https://github.com/cloudflare/workers-sdk/issues/13672
+- PR related to the tag/digest lookup issue:
+  https://github.com/cloudflare/workers-sdk/pull/13720
+
+Cloudflare may eventually fix the platform selection. When they do, remove the
+arm64 `MINIFLARE_CONTAINER_EGRESS_IMAGE` override from `apps/example`.
+
+## Repo Workaround
+
+`apps/example/package.json` sets the override only on arm64/aarch64 hosts:
+
+```bash
+if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
+  export MINIFLARE_CONTAINER_EGRESS_IMAGE=cloudflare/proxy-everything@sha256:78c7910f4575a511d928d7824b1cbcaec6b7c4bf4dbb3fafaeeae3104030e73c
+fi
+doppler run --project example -- tsx ./alchemy.run.ts
+```
+
+This is intentionally an environment variable, not a mutation of
+`node_modules`. Cloudflare's local-dev code already reads
+`MINIFLARE_CONTAINER_EGRESS_IMAGE`.
+
+## OrbStack Cleanup We Performed
+
+The broken sidecar was not caused by OrbStack's Docker TCP API listener, but the
+local Docker daemon was exposing an unauthenticated local TCP API. We removed it.
+
+Current expected config:
+
+```bash
+cat ~/.orbstack/config/docker.json
+```
+
+```json
+{
+  "hosts": ["unix:///var/run/docker.sock"]
+}
+```
+
+We also disabled LAN exposure:
+
+```bash
+orbctl config get docker.expose_ports_to_lan
+orbctl config get machines.expose_ports_to_lan
+```
+
+Expected:
+
+```text
+false
+false
+```
+
+Rosetta did not fix the Cloudflare sidecar issue under OrbStack, so it was
+restored to its previous setting:
+
+```bash
+orbctl config get rosetta
+```
+
+Expected on this machine:
+
+```text
+true
+```
+
+## About `DOCKER_INSECURE_NO_IPTABLES_RAW`
+
+`docker info` may still show:
+
+```text
+WARNING: DOCKER_INSECURE_NO_IPTABLES_RAW is set
+```
+
+That variable is set inside OrbStack's Docker host for `dockerd`; it is not from
+the user's shell environment. On the machine we debugged, the OrbStack kernel
+did have raw table support:
+
+```bash
+docker run --rm --privileged --pid=host alpine:3.22 sh -lc '
+  pid=$(pidof dockerd)
+  tr "\0" "\n" < /proc/$pid/environ | sort | grep DOCKER_INSECURE_NO_IPTABLES_RAW || true
+  zcat /proc/config.gz 2>/dev/null | grep CONFIG_IP_NF_RAW || true
+'
+```
+
+Observed:
+
+```text
+DOCKER_INSECURE_NO_IPTABLES_RAW=1
+CONFIG_IP_NF_RAW=y
+```
+
+Docker added this env var as a workaround for kernels without
+`CONFIG_IP_NF_RAW`. Moby currently does not expose it as a `daemon.json` option:
+
+- https://github.com/moby/moby/pull/49621
+- https://github.com/moby/moby/issues/49651
+
+That warning is worth tracking, but direct testing showed it was not the cause
+of the Cloudflare sidecar crash: arm64 `proxy-everything` worked with the
+warning still present, while amd64 `proxy-everything` failed.
+
+## How To Verify `apps/example`
+
+Start Cloudflare local dev:
+
+```bash
+PORT=5174 pnpm --dir apps/example cf:dev
+```
+
+Open:
+
+```text
+http://127.0.0.1:5174/sandbox
+```
+
+Expected UI:
+
+- left sidebar contains `Sandbox`
+- the page status shows sandbox id `example-poc`
+- clicking `Run code` eventually shows `exit 0`
+- stdout contains Node version, `/workspace`, and `egressStatus: 200`
+
+API smoke:
+
+```bash
+curl -sS -m 120 http://127.0.0.1:5174/api/sandbox
+```
+
+Expected shape:
+
+```json
+{
+  "sandboxId": "example-poc",
+  "status": "ready",
+  "stdout": "{\"node\":\"v20.20.2\",\"platform\":\"linux\",\"arch\":\"x64\",\"cwd\":\"/workspace\"}",
+  "stderr": "",
+  "exitCode": 0
+}
+```
+
+Run code with internet egress:
+
+```bash
+curl -sS -m 120 \
+  -X POST http://127.0.0.1:5174/api/sandbox/run \
+  -H 'content-type: application/json' \
+  --data '{"code":"const res = await fetch(\"https://example.com\"); console.log(JSON.stringify({ sum: 2 + 3, status: res.status, node: process.version, cwd: process.cwd() }, null, 2));"}'
+```
+
+Expected:
+
+```json
+{
+  "sandboxId": "example-poc",
+  "command": "node /workspace/user-code.mjs",
+  "success": true,
+  "stdout": "{\n  \"sum\": 5,\n  \"status\": 200,\n  \"node\": \"v20.20.2\",\n  \"cwd\": \"/workspace\"\n}",
+  "stderr": "",
+  "exitCode": 0
+}
+```
+
+## Troubleshooting
+
+If `cf:dev` starts but sandbox requests hang:
+
+1. Check for a failed sidecar:
+
+   ```bash
+   docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Names}}\t{{.Status}}' |
+     rg 'proxy-everything|workerd-example'
+   ```
+
+2. Check sidecar logs:
+
+   ```bash
+   docker logs <proxy-container-id> 2>&1 | tail -100
+   ```
+
+3. If logs include `setsockoptint: protocol not available`, confirm the arm64
+   override is present in the `cf:dev` environment:
+
+   ```bash
+   pnpm --dir apps/example cf:dev
+   ```
+
+   The startup output should include:
+
+   ```text
+   cloudflare/proxy-everything@sha256:78c7910f4575a511d928d7824b1cbcaec6b7c4bf4dbb3fafaeeae3104030e73c
+   ```
+
+4. Remove stale failed containers if needed:
+
+   ```bash
+   docker rm -f $(docker ps -aq --filter name=workerd-example-dev) 2>/dev/null || true
+   ```
+
+5. Clear a stale sidecar image if Docker appears to reuse the wrong platform:
+
+   ```bash
+   docker image rm -f cloudflare/proxy-everything:3cb1195 2>/dev/null || true
+   ```
+
+6. Restart:
+
+   ```bash
+   PORT=5174 pnpm --dir apps/example cf:dev
+   ```
+
+## What Not To Do
+
+- Do not patch Wrangler or `@cloudflare/vite-plugin` in `node_modules`.
+- Do not set `enableInternet = false`; this POC intentionally proves public
+  internet egress.
+- Do not assume `DOCKER_INSECURE_NO_IPTABLES_RAW` is the cause of the sandbox
+  crash without reproducing the sidecar directly.
+- Do not pin the arm64 sidecar for every platform. Keep the override scoped to
+  Apple Silicon hosts unless Cloudflare changes the local-dev behavior.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1262,6 +1262,9 @@ importers:
 
   apps/example:
     dependencies:
+      '@cloudflare/sandbox':
+        specifier: 0.9.4
+        version: 0.9.4(@opencode-ai/sdk@1.2.16)
       '@iterate-com/example-contract':
         specifier: workspace:*
         version: link:../example-contract
@@ -3965,6 +3968,20 @@ packages:
 
   '@cloudflare/sandbox@0.8.14':
     resolution: {integrity: sha512-tIXw1jBJjNouN7NEIPQbmuwbe7p1ikhhV6D83Lkkxif5FKgflzDwXl4diu9yfrho8Lc16rBnJ+Ieb5nFbunSWg==}
+    peerDependencies:
+      '@openai/agents': ^0.3.3
+      '@opencode-ai/sdk': ^1.1.40
+      '@xterm/xterm': '>=5.0.0'
+    peerDependenciesMeta:
+      '@openai/agents':
+        optional: true
+      '@opencode-ai/sdk':
+        optional: true
+      '@xterm/xterm':
+        optional: true
+
+  '@cloudflare/sandbox@0.9.4':
+    resolution: {integrity: sha512-T7Z90ZlVaODyFJdwU7wxXN6ZWO9O9NEy95I45Uyliqjy5cGEsStJG1FNFhvIOJp+u0qFuN4/8b+StAiM78Lf3w==}
     peerDependencies:
       '@openai/agents': ^0.3.3
       '@opencode-ai/sdk': ^1.1.40
@@ -11558,6 +11575,9 @@ packages:
 
   caniuse-lite@1.0.30001776:
     resolution: {integrity: sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==}
+
+  capnweb@0.6.1:
+    resolution: {integrity: sha512-fmhV26QPd1ewf5R74h55oVZnGwIcSaRMzbfLQUy8+zOBjuTmT3KXoT8wxHvnp1m9Ht9BoUUS5ZwNLoVLfQTyBg==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -19554,6 +19574,15 @@ snapshots:
     dependencies:
       '@cloudflare/containers': 0.3.3
       aws4fetch: 1.0.20
+      hono: 4.12.15
+    optionalDependencies:
+      '@opencode-ai/sdk': 1.2.16
+
+  '@cloudflare/sandbox@0.9.4(@opencode-ai/sdk@1.2.16)':
+    dependencies:
+      '@cloudflare/containers': 0.3.3
+      aws4fetch: 1.0.20
+      capnweb: 0.6.1
       hono: 4.12.15
     optionalDependencies:
       '@opencode-ai/sdk': 1.2.16
@@ -28896,6 +28925,8 @@ snapshots:
   camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001776: {}
+
+  capnweb@0.6.1: {}
 
   ccount@2.0.1: {}
 


### PR DESCRIPTION
## What changed

- Added a Cloudflare Sandbox SDK proof of concept to `apps/example` with a `/sandbox` UI for running editable JavaScript inside a sandbox container.
- Wired an Alchemy `Container<Sandbox>` binding, Worker API endpoints, and a small sandbox Dockerfile based on `cloudflare/sandbox:0.9.4`.
- Added the Apple Silicon/OrbStack egress sidecar override for `MINIFLARE_CONTAINER_EGRESS_IMAGE` so local internet egress works without patching `node_modules`.
- Documented the setup, root cause, upstream issues, OrbStack cleanup, and verification workflow in `docs/cloudflare-sandbox-sdk-local-dev.md` and `apps/example/README.md`.

## Why

This gives `apps/example` a concrete local proof of concept for spinning up a Cloudflare Sandbox SDK container, writing code into it, executing that code, and verifying outbound internet access from inside the sandbox.

The OrbStack failure was caused by Cloudflare local dev running the `cloudflare/proxy-everything` egress sidecar as `linux/amd64` on Apple Silicon. Under OrbStack's amd64 emulation path that sidecar fails with `setsockoptint: protocol not available`; the arm64 image digest works on the same machine.

## Validation

- `pnpm install --frozen-lockfile --filter @iterate-com/example`
- `pnpm --dir apps/example typecheck`
- `pnpm --dir apps/example test -- --runInBand`
- `pnpm format docs/cloudflare-sandbox-sdk-local-dev.md apps/example/README.md`
- Browser smoke at `http://127.0.0.1:5174/sandbox`
- API smoke for `GET /api/sandbox` and `POST /api/sandbox/run`, including a sandbox `fetch("https://example.com")` returning status `200`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "example": {
      "appDisplayName": "Example",
      "appSlug": "example",
      "status": "deploy-failed",
      "updatedAt": "2026-05-06T13:41:34.725Z",
      "headSha": "ef0880d76e9c837aea6952afbe26490f6657e20b",
      "message": "Attention: To help improve Alchemy, we collect anonymous usage, performance, and error data.\nYou can opt out by setting the ALCHEMY_TELEMETRY_DISABLED or DO_NOT_TRACK environment variable to a truthy value.\n/home/runner/work/iterate/iterate/node_modules/.pnpm/alchemy@0.83.3_@aws-sdk+client-s3@3.1002.0_@cloudflare+vite-plugin@1.33.2_vite@8.0.0_@t_6f8cb53753ade652b25f074ab725c7fb/node_modules/alchemy/src/cloudflare/container.ts:1135\n  throw Error(\n        ^\n\nError: Failed to get container credentials: Authentication error\n    at getContainerCredentials (/home/runner/work/iterate/iterate/node_modules/.pnpm/alchemy@0.83.3_@aws-sdk+client-s3@3.1002.0_@cloudflare+vite-plugin@1.33.2_vite@8.0.0_@t_6f8cb53753ade652b25f074ab725c7fb/node_modules/alchemy/src/cloudflare/container.ts:1135:9)\n    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)\n    at async Container (/home/runner/work/iterate/iterate/node_modules/.pnpm/alchemy@0.83.3_@aws-sdk+client-s3@3.1002.0_@cloudflare+vite-plugin@1.33.2_vite@8.0.0_@t_6f8cb53753ade652b25f074ab725c7fb/node_modules/alchemy/src/cloudflare/container.ts:252:23)\n    at async <anonymous> (/home/runner/work/iterate/iterate/apps/example/alchemy.run.ts:29:17)\n\nNode.js v24.15.0\n\nAlchemy (v0.83.3)\nApp: example\nPhase: up\nStage: preview_2\n[skipped]   example-db Skipped Resource (no changes)\n[updating]  example-counter-do Updating Resource...\nAlchemy (v0.83.3)\nApp: example\nPhase: up\nStage: preview_2\n[skipped]   example-counter-do > url Skipped Resource (no changes)\n[updated]   example-counter-do Updated Resource",
      "publicUrl": "https://example.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25438867011",
      "shortSha": "ef0880d"
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_2",
    "leasedUntil": 1778078491587,
    "leaseId": "70ff009d-6bdf-46df-b01e-a752cc33d392",
    "slug": "preview-2",
    "type": "environment-config-lease"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
Lease: `preview-2`
Doppler config: `preview_2`
Type: `environment-config-lease`
Leased until: 2026-05-06T14:41:31.587Z

### Example
Status: deploy failed
Commit: `ef0880d`
Preview: https://example.iterate-preview-2.com
Summary: Error: Failed to get container credentials: Authentication error
[Workflow run](https://github.com/iterate/iterate/actions/runs/25438867011)
Updated: 2026-05-06T13:41:34.725Z

<details>
<summary>Failure details</summary>

<pre>Attention: To help improve Alchemy, we collect anonymous usage, performance, and error data.
You can opt out by setting the ALCHEMY_TELEMETRY_DISABLED or DO_NOT_TRACK environment variable to a truthy value.
/home/runner/work/iterate/iterate/node_modules/.pnpm/alchemy@0.83.3_@aws-sdk+client-s3@3.1002.0_@cloudflare+vite-plugin@1.33.2_vite@8.0.0_@t_6f8cb53753ade652b25f074ab725c7fb/node_modules/alchemy/src/cloudflare/container.ts:1135
  throw Error(
        ^

Error: Failed to get container credentials: Authentication error
    at getContainerCredentials (/home/runner/work/iterate/iterate/node_modules/.pnpm/alchemy@0.83.3_@aws-sdk+client-s3@3.1002.0_@cloudflare+vite-plugin@1.33.2_vite@8.0.0_@t_6f8cb53753ade652b25f074ab725c7fb/node_modules/alchemy/src/cloudflare/container.ts:1135:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async Container (/home/runner/work/iterate/iterate/node_modules/.pnpm/alchemy@0.83.3_@aws-sdk+client-s3@3.1002.0_@cloudflare+vite-plugin@1.33.2_vite@8.0.0_@t_6f8cb53753ade652b25f074ab725c7fb/node_modules/alchemy/src/cloudflare/container.ts:252:23)
    at async &lt;anonymous&gt; (/home/runner/work/iterate/iterate/apps/example/alchemy.run.ts:29:17)

Node.js v24.15.0

Alchemy (v0.83.3)
App: example
Phase: up
Stage: preview_2
[skipped]   example-db Skipped Resource (no changes)
[updating]  example-counter-do Updating Resource...
Alchemy (v0.83.3)
App: example
Phase: up
Stage: preview_2
[skipped]   example-counter-do &gt; url Skipped Resource (no changes)
[updated]   example-counter-do Updated Resource</pre>

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new sandbox execution surface (`/api/sandbox/*`) that writes and runs user-supplied code in a container; while scoped to the example app, it introduces new runtime/container behavior and failure modes in Cloudflare dev/deploy paths.
> 
> **Overview**
> Adds a Cloudflare Sandbox SDK POC to `apps/example`, including a new `/sandbox` page that edits/runs JavaScript and displays stdout/stderr plus a sidebar nav entry.
> 
> Wires a new `Container<Sandbox>` binding via Alchemy (built from new `Dockerfile.sandbox`) and adds Worker endpoints under `GET /api/sandbox`, `POST /api/sandbox/run`, and `POST /api/sandbox/destroy` to write files, execute Node commands, and reset the container.
> 
> Updates local dev ergonomics by auto-setting `MINIFLARE_CONTAINER_EGRESS_IMAGE` on arm64/aarch64 for OrbStack compatibility, and documents setup/troubleshooting in `apps/example/README.md` and `docs/cloudflare-sandbox-sdk-local-dev.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef0880d76e9c837aea6952afbe26490f6657e20b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->