### PR TITLE
[codex] Polish OS2 projects copy

### DIFF
--- a/apps/agents/src/routes/index.tsx
+++ b/apps/agents/src/routes/index.tsx
@@ -277,11 +277,14 @@ function SelectedAgentStreamView({
         />
         <EventsStreamLayoutMessageInput>
           <EventsStreamComposer
-            value={composerText}
-            onValueChange={setComposerText}
-            onSubmit={submitComposer}
+            mode="message"
+            message={{
+              value: composerText,
+              onValueChange: setComposerText,
+              onSubmit: submitComposer,
+              placeholder: "Message this agent",
+            }}
             isSubmitting={appendMessage.isPending}
-            placeholder="Message this agent"
           />
         </EventsStreamLayoutMessageInput>
       </div>

--- a/apps/events/src/lib/clean-stream-view-reducer.test.ts
+++ b/apps/events/src/lib/clean-stream-view-reducer.test.ts
@@ -7,6 +7,7 @@ import {
 import { getAdjacentEventOffset } from "@iterate-com/ui/components/events/event-inspector-sheet";
 import {
   processEventsWithViewReducer,
+  prettyEventsStreamViewReducer,
   rawJsonDumpEventsStreamViewReducer,
   rawPrettyEventsStreamViewReducer,
 } from "@iterate-com/ui/components/events/feed-processors";
@@ -61,6 +62,45 @@ describe("clean stream view reducers", () => {
         type: "event-counter",
         props: {
           count: 1,
+        },
+      },
+    ]);
+  });
+
+  test("pretty emits semantic items without grouped raw events", () => {
+    const viewState = processEventsWithViewReducer({
+      reducer: prettyEventsStreamViewReducer,
+      events: [
+        event({
+          offset: 1,
+          type: "events.iterate.com/agent-chat/user-message-added",
+          payload: { channel: "web", content: "hello" },
+        }),
+        event({
+          offset: 2,
+          type: "events.iterate.com/example/no-renderer",
+        }),
+      ],
+    });
+
+    expect(viewState.slots.feed).toMatchObject([
+      {
+        type: "message",
+        id: "message-user-1",
+        props: {
+          role: "user",
+          text: "hello",
+        },
+      },
+    ]);
+    expect(viewState.slots.feed).not.toContainEqual(
+      expect.objectContaining({ type: "grouped-raw-event" }),
+    );
+    expect(viewState.slots.header).toMatchObject([
+      {
+        type: "event-counter",
+        props: {
+          count: 2,
         },
       },
     ]);

--- a/apps/os2-contract/src/index.ts
+++ b/apps/os2-contract/src/index.ts
@@ -506,6 +506,20 @@ export const osContract = oc.router({
           }),
         )
         .output(z.object({ event: Event })),
+      appendBatch: oc
+        .route({
+          method: "POST",
+          path: "/projects/{projectSlugOrId}/streams/event-batches/{+streamPath}",
+          description: "Append multiple events to a project stream in order",
+          tags: ["/project", "/streams"],
+        })
+        .input(
+          ProjectScopedInput.extend({
+            streamPath: StreamPath,
+            events: z.array(EventInput),
+          }),
+        )
+        .output(z.object({ events: z.array(Event) })),
       read: oc
         .route({
           method: "GET",

--- a/apps/os2/CONTEXT.md
+++ b/apps/os2/CONTEXT.md
@@ -30,6 +30,10 @@ _Avoid_: Member, account
 A Clerk-issued OAuth access token used by a remote MCP client to call OS2 as a protected resource.
 _Avoid_: MCP JWT, session token
 
+**Clerk Session Token**:
+A Clerk-issued session token used by first-party or e2e clients to call OS2 as an authenticated Clerk User.
+_Avoid_: testing token, OAuth token
+
 **Project**:
 An OS2-managed app surface owned by exactly one Clerk Organization.
 _Avoid_: App, site, workspace
@@ -503,21 +507,22 @@ _Avoid_: Project MCP Server Connection, project MCP route, inbound MCP
 - The **Codemode Session Control Plane** compiles a requested **Script Execution** into a script-execution-requested Event Input internally.
 - When a **Codemode Example Stack**, custom Event Inputs, and a **Script** are combined, OS2 appends example Event Inputs, custom Event Inputs, then the script-execution-requested event.
 - Browser UI creates **Codemode Sessions** through a session-first command where the **Script** is optional.
-- Project MCP server `run_code` starts a **Script Execution** and therefore requires a **Script**.
-- Browser session creation and Project MCP server `run_code` share the same internal attach-or-create and stream append behavior.
+- Project MCP server `exec_js` starts a **Script Execution** and therefore requires a **Script**.
+- Browser session creation and Project MCP server `exec_js` share the same internal attach-or-create and stream append behavior.
 - A **Project Route** resolves its **Project Slug** to the stable **Project ID** before initializing a **Codemode Session**.
 - A **Project MCP Route** resolves to the stable **Project ID** through project ingress before initializing a **Codemode Session**.
 - A **Clerk User** acts through their **Active Organization** when managing **Projects**.
 - A signed-in **Clerk User** without an **Active Organization** must create or select a **Clerk Organization** before using OS2.
-- A remote MCP client calls OS2 with a **Clerk OAuth Token**, not a Clerk session token.
-- OS2 accepts Clerk's OAuth token contract for MCP; JWT token format is the preferred Clerk environment setting, not the domain boundary.
+- A remote OAuth MCP client calls OS2 with a **Clerk OAuth Token**.
+- A first-party or e2e MCP client may call OS2 with a **Clerk Session Token** when it needs browserless user authentication.
+- OS2 accepts Clerk user-token contracts for MCP; JWT token format is the preferred Clerk environment setting, not the domain boundary.
 - The browser UI explicitly creates and selects **Codemode Sessions** for a **Project**.
 - Browser oRPC calls identify the **Project** with `projectSlugOrId`; handlers resolve that value to the stable Project ID before touching capabilities or Durable Objects.
 - Browser oRPC may pass an **Event Stream Path** when creating a **Codemode Session**; if it does not, OS2 generates one for the Project.
 - The **Codemode Session Creation Form** may include an optional **Event Stream Path** so users can attach the codemode processor to an existing stream.
 - Creating a **Codemode Session** is attach-or-create for the pair of **Project ID** and **Event Stream Path**.
 - A **Project MCP Server Connection** already has an **Event Stream Path**; when it runs codemode, the **Codemode Session** uses that same Event Stream Path.
-- Project MCP server `run_code` may include Event Inputs, such as Tool Provider registration events, which are appended to the **Codemode Session** before the **Script Execution** starts.
+- Project MCP server `exec_js` may include Event Inputs, such as Tool Provider registration events, which are appended to the **Codemode Session** before the **Script Execution** starts.
 - An **Outbound MCP From Our Client Capability** can be registered as a Tool Provider; it is unrelated to **Project MCP Server Connection** identity.
 - A **Codemode Session** is initialized with exactly one stable **Project ID** and exactly one **Event Stream Path**.
 - An **Event Stream Path** may exist before a **Codemode Session** is attached to it.
@@ -886,7 +891,7 @@ The provider composition case targets provider-to-provider Tool Function Calls: 
 > **Dev:** "Is there a separate Project Run Code Session concept above Codemode Session?"
 > **Domain expert:** "No. The concept is **Codemode Session**. Browser UI creates explicit Codemode Sessions with their own Event Stream Paths; Project MCP server connections reuse the MCP connection's existing Event Stream Path."
 
-> **Dev:** "Should MCP `run_code` take a project selector?"
+> **Dev:** "Should MCP `exec_js` take a project selector?"
 > **Domain expert:** "No. MCP is project-scoped: the **Project MCP Route** identifies the **Project**. Browser oRPC gets the project from the **Project Route** and resolves the stable **Project ID**."
 
 > **Dev:** "Does a Codemode Session init with the project slug?"
@@ -920,7 +925,7 @@ The provider composition case targets provider-to-provider Tool Function Calls: 
 > **Domain expert:** "Show Clerk's organization selection or creation flow before rendering the **OS2 App**."
 
 > **Dev:** "Does the MCP server require a Clerk JWT?"
-> **Domain expert:** "No. The MCP server requires a valid **Clerk OAuth Token**. JWT is the preferred Clerk token format for cheaper verification, but OS2 should not model MCP auth as JWT-only."
+> **Domain expert:** "No. The MCP server requires a valid OS2 admin token or Clerk user token. OAuth MCP clients use a **Clerk OAuth Token**; browserless first-party and e2e clients may use a **Clerk Session Token**. JWT is the preferred Clerk token format for cheaper verification, but OS2 should not model MCP auth as JWT-only."
 
 > **Dev:** "Should a request for a Project-owned hostname hit the OS2 App auth middleware before project routing?"
 > **Domain expert:** "No. The OS2 Worker first classifies the **Ingress Hostname**. If it is a **Project-Owned Hostname**, the request becomes **Project Ingress** before OS2 App auth runs."
@@ -999,7 +1004,7 @@ The provider composition case targets provider-to-provider Tool Function Calls: 
 - "session id" and "stream path" were conflated. Resolved: **Project ID** plus **Event Stream Path** is the **Codemode Session** identity.
 - "app" can mean the OS2 product or a managed project surface. Resolved: use **OS2 App** for this dashboard and **Project** for the managed app surface.
 - "personal organization" is misleading because Clerk treats personal accounts separately from organizations. Resolved: use **Personal Account** for Clerk's non-organization user context.
-- "MCP JWT" is too narrow for Clerk OAuth Applications. Resolved: use **Clerk OAuth Token** for MCP bearer tokens, regardless of Clerk's token format setting.
+- "MCP JWT" is too narrow for Clerk OAuth Applications and Clerk session-based e2e. Resolved: use **Clerk OAuth Token** for OAuth MCP bearer tokens and **Clerk Session Token** for first-party/e2e bearer tokens, regardless of Clerk's token format setting.
 - "project URL" was ambiguous between stable IDs and slugs. Resolved: use **Project Route** for the user-facing organization-slug/project-slug URL.
 - "MCP" can mean OS2 as an MCP server or OS2 as a client of another MCP server. Resolved: use **Project MCP Server Entry Point** plus **Project MCP Server Connection** for external clients connected to OS2, and **Outbound MCP From Our Client Capability** for OS2 connecting to external MCP servers as codemode Tool Providers.
 - "`IterateMcpServer`" names the product, not the domain concept. Resolved: use `ProjectMcpServerConnection` for the Durable Object class/catalog name.

--- a/apps/os2/README.md
+++ b/apps/os2/README.md
@@ -40,6 +40,8 @@ pnpm dev:localhost       # localhost-oriented config
 pnpm typecheck           # TypeScript
 pnpm test                # unit tests
 pnpm test:e2e:preview    # deployed preview smoke
+pnpm cli claude-mcp --project-slug-or-id bob
+                         # open Claude against one project MCP server
 pnpm sqlfu:generate      # regenerate sqlfu migrations/query wrappers
 pnpm sqlfu:check         # compare migrations to definitions.sql
 pnpm cf:deploy           # production deploy
@@ -47,6 +49,14 @@ pnpm cf:deploy           # production deploy
 
 Use `doppler run --project os2 --config <config> -- <command>` when a command
 needs deployed secrets or preview/prd app config.
+
+For example, to open Claude against the production MCP server for project
+`bob`, using the production `APP_CONFIG_ADMIN_API_SECRET`:
+
+```bash
+doppler run --project os2 --config prd -- \
+  pnpm cli claude-mcp --project-slug-or-id bob
+```
 
 ## Important Files
 

--- a/apps/os2/docs/adr/0001-use-clerk-as-mcp-oauth-server.md
+++ b/apps/os2/docs/adr/0001-use-clerk-as-mcp-oauth-server.md
@@ -2,4 +2,10 @@
 
 OS2 uses Clerk as the OAuth authorization server for MCP clients, and the OS2 Worker acts only as the OAuth protected resource server. This follows Clerk's first-party MCP guidance, where MCP clients discover Clerk through protected-resource metadata, use Clerk OAuth Applications for authorization, and send Clerk-issued bearer tokens to `/mcp`; OS2 verifies those tokens before invoking MCP tools. We are not using Cloudflare's Worker OAuth provider pattern because that would make OS2 re-issue its own OAuth tokens on top of Clerk, splitting consent, revocation, and client registration across two systems.
 
+For first-party and e2e clients that are not OAuth MCP clients, OS2 may also
+accept Clerk session tokens for the same Clerk user identity. Clerk session
+tokens do not carry OAuth scopes, so OS2 authorizes them through Clerk user and
+organization membership plus the project access check instead of MCP OAuth
+scope checks. OS2 admin tokens remain a deployment smoke-test escape hatch.
+
 Sources: Clerk MCP guide https://clerk.com/docs/nextjs/guides/ai/mcp/build-mcp-server, Clerk OAuth guide https://clerk.com/docs/guides/configure/auth-strategies/oauth/how-clerk-implements-oauth, Cloudflare McpAgent API https://developers.cloudflare.com/agents/api-reference/mcp-agent-api/

--- a/apps/os2/docs/architecture-and-operations.md
+++ b/apps/os2/docs/architecture-and-operations.md
@@ -128,8 +128,9 @@ Current direct debug fetch routes include:
 OS2 has two MCP flows:
 
 - Inbound MCP: external MCP clients connect to a project MCP hostname. The
-  request enters `ProjectMcpServerEntrypoint`, authenticates with Clerk OAuth,
-  and delegates session state to `ProjectMcpServerConnection`.
+  request enters `ProjectMcpServerEntrypoint`, authenticates with an OS2 admin
+  token or a Clerk user token, and delegates session state to
+  `ProjectMcpServerConnection`.
 - Outbound MCP: a codemode session uses an external MCP server as a Tool
   Provider. `OutboundMcpFromOurClientCapability` owns the client connection and
   exposes `executeCodemodeFunctionCall(...)`.
@@ -139,8 +140,10 @@ is not itself a codemode Tool Provider.
 
 Project MCP hostnames expose RFC 9728 protected-resource metadata at
 `/.well-known/oauth-protected-resource`, pointing clients at Clerk as the
-authorization server. The MCP entrypoint verifies Clerk-issued OAuth bearer
-tokens before it passes identity props to the MCP session Durable Object.
+authorization server. The MCP entrypoint accepts Clerk OAuth access tokens for
+OAuth MCP clients and Clerk session tokens for first-party/e2e clients. If a
+Clerk token has no active organization claim, OS2 checks the user's Clerk
+organization memberships before running the project access check.
 
 ## Codemode
 
@@ -152,7 +155,7 @@ Primary surfaces:
 - UI: project codemode session pages.
 - oRPC: `project.codemode.createSession`,
   `project.codemode.executeScript`, and `project.streams` reads.
-- MCP: `run_code` on a project MCP route, such as
+- MCP: `exec_js` on a project MCP route, such as
   `https://mcp__demo.iterate2.app`.
 
 Default providers are registered for every session. The important built-ins are
@@ -233,6 +236,10 @@ Useful first-party references:
   `https://clerk.com/docs/organizations/overview`
 - Clerk OAuth token verification:
   `https://clerk.com/docs/guides/configure/auth-strategies/oauth/verify-oauth-tokens`
+- Clerk request authentication and accepted token types:
+  `https://clerk.com/docs/reference/backend/authenticate-request`
+- Clerk test session-token flow:
+  `https://clerk.com/docs/testing/overview`
 - Clerk CLI:
   `https://clerk.com/docs/cli`
 
@@ -255,6 +262,20 @@ Codemode MCP provider-stack smoke:
 OS2_E2E_MCP_URL=https://mcp__demo.iterate-preview-2.app \
 doppler run --project os2 --config preview_2 -- pnpm test:e2e:codemode-mcp
 ```
+
+The MCP smoke accepts either:
+
+- `OS2_E2E_MCP_BEARER_TOKEN`: an explicit Clerk OAuth access token or Clerk
+  session token for a user whose Clerk organization has access to the project.
+- `OS2_E2E_ADMIN_API_SECRET`, `OS2_ADMIN_API_SECRET`, or
+  `APP_CONFIG_ADMIN_API_SECRET`: an OS2 admin token for deployment-level smoke
+  tests that do not need user/project membership setup.
+
+For browserless Clerk e2e, do not pass a Clerk Testing Token as the bearer
+token. Clerk Testing Tokens are only bot-detection bypass tokens for Frontend
+API requests. Create a Clerk user, create a session for that user, create a
+session token from that session, and pass the returned session token as
+`Authorization: Bearer <session_token>` through `OS2_E2E_MCP_BEARER_TOKEN`.
 
 When `APP_CONFIG_SLACK_BOT_TOKEN` is present in the test process, the codemode
 MCP test discovers `#slack-agent-e2e-test` and includes a real

--- a/apps/os2/e2e/vitest/codemode-mcp-provider-stack.e2e.test.ts
+++ b/apps/os2/e2e/vitest/codemode-mcp-provider-stack.e2e.test.ts
@@ -9,6 +9,10 @@
  *   OS2_E2E_MCP_BEARER_TOKEN=... \
  *   pnpm test:e2e:codemode-mcp
  *
+ * OS2_E2E_MCP_BEARER_TOKEN may be a Clerk OAuth access token, a Clerk session
+ * token, or an OS2 admin token. Clerk Testing Tokens are not bearer auth tokens;
+ * they only bypass Clerk bot detection for Frontend API requests.
+ *
  * If APP_CONFIG_SLACK_BOT_TOKEN is available to the test process, the test
  * discovers the shared Slack e2e channel and proves real
  * ctx.slack.chat.postMessage.
@@ -20,7 +24,7 @@ import { describe, expect, it } from "vitest";
 const maybeMcpUrl = process.env.OS2_E2E_MCP_URL?.trim();
 const describeIfMcpTarget = maybeMcpUrl ? describe : describe.skip;
 
-describeIfMcpTarget("project MCP run_code static codemode provider stack", () => {
+describeIfMcpTarget("project MCP exec_js static codemode provider stack", () => {
   it("executes real codemode calls across built-in, RPC, OpenAPI, stream, and optional Slack providers", async () => {
     const mcpUrl = requireMcpUrl();
     const bearerToken = requireBearerToken();
@@ -38,13 +42,13 @@ describeIfMcpTarget("project MCP run_code static codemode provider stack", () =>
       await client.connect(transport);
 
       const tools = await client.listTools();
-      const runCode = tools.tools.find((tool) => tool.name === "run_code");
+      const runCode = tools.tools.find((tool) => tool.name === "exec_js");
       expect(runCode).toBeTruthy();
       expect(JSON.stringify(runCode?.inputSchema)).toContain("code");
       expect(JSON.stringify(runCode?.inputSchema)).not.toContain("providers");
 
       const result = await client.callTool({
-        name: "run_code",
+        name: "exec_js",
         arguments: {
           code: buildCodemodeProofScript({ slackChannelId }),
         },
@@ -329,7 +333,7 @@ function parseRunCodeResult(text: string) {
   const marker = "Result:";
   const index = text.lastIndexOf(marker);
   if (index === -1) {
-    throw new Error(`run_code did not return a Result block:\n${text}`);
+    throw new Error(`exec_js did not return a Result block:\n${text}`);
   }
   return JSON.parse(text.slice(index + marker.length).trim()) as {
     ai: { model: string };

--- a/apps/os2/runtime-smoke.test.ts
+++ b/apps/os2/runtime-smoke.test.ts
@@ -31,7 +31,6 @@ const smokeEnv = {
       secretKey: "sk_test_runtime_smoke",
       jwtKey: "runtime-smoke-jwt-key",
     },
-    mcpProofSecret: "runtime-smoke-proof-secret",
     openAiApiKey: "runtime-smoke-openai-key",
   }),
 };

--- a/apps/os2/scripts/claude-mcp.ts
+++ b/apps/os2/scripts/claude-mcp.ts
@@ -1,0 +1,130 @@
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+import { os } from "@orpc/server";
+import { z } from "zod";
+
+const DEFAULT_BASE_HOST = "iterate2.app";
+const SERVER_NAME = "iterate";
+const DEFAULT_INITIAL_PROMPT = "describe the MCP tools you have available";
+
+const ClaudeMcpInput = z.object({
+  projectSlugOrId: z
+    .string()
+    .trim()
+    .min(1)
+    .regex(/^[a-zA-Z0-9_-]+$/, "Project slug or ID must be hostname-safe")
+    .describe("OS2 project slug or ID used in the mcp__<project> hostname"),
+  baseHost: z
+    .string()
+    .trim()
+    .min(1)
+    .default(DEFAULT_BASE_HOST)
+    .describe("Project hostname base, e.g. iterate2.app"),
+  prompt: z
+    .string()
+    .trim()
+    .min(1)
+    .default(DEFAULT_INITIAL_PROMPT)
+    .describe("Initial prompt passed to Claude before entering interactive mode"),
+});
+
+export const claudeMcpScript = os
+  .input(ClaudeMcpInput)
+  .meta({
+    description:
+      "Open Claude Code against one remote OS2 project MCP server using the Doppler admin token",
+  })
+  .handler(async ({ input, signal }) => {
+    const adminToken = requireEnv("APP_CONFIG_ADMIN_API_SECRET");
+    const mcpUrl = buildProjectMcpUrl({
+      baseHost: input.baseHost,
+      projectSlugOrId: input.projectSlugOrId,
+    });
+    const args = [
+      "--mcp-config",
+      buildClaudeMcpConfig({
+        mcpUrl,
+        token: adminToken,
+      }),
+      "--strict-mcp-config",
+      "--dangerously-skip-permissions",
+      input.prompt,
+    ];
+
+    console.info("[claude-mcp] Starting Claude with remote OS2 MCP server:");
+    console.info(`  MCP URL: ${mcpUrl}`);
+    console.info(`  MCP server name: ${SERVER_NAME}`);
+    console.info("  Auth: Doppler OS2 admin token");
+    console.info("");
+
+    runClaude(args, signal);
+
+    return {
+      ok: true as const,
+      mcpUrl,
+      serverName: SERVER_NAME,
+    };
+  });
+
+function requireEnv(name: string) {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`claude-mcp requires ${name} in the current environment.`);
+  }
+  return value;
+}
+
+function buildProjectMcpUrl(input: { baseHost: string; projectSlugOrId: string }) {
+  const baseHost = normalizeBaseHost(input.baseHost);
+  return `https://mcp__${input.projectSlugOrId}.${baseHost}/`;
+}
+
+function normalizeBaseHost(value: string) {
+  const parsed = new URL(/^https?:\/\//.test(value) ? value : `https://${value}`);
+
+  if (parsed.pathname !== "/" || parsed.search || parsed.hash) {
+    throw new Error("--base-host must be a hostname, not a URL with a path/query/hash.");
+  }
+
+  return parsed.host;
+}
+
+function buildClaudeMcpConfig(input: { mcpUrl: string; token: string }) {
+  const config = {
+    mcpServers: {
+      [SERVER_NAME]: {
+        type: "http",
+        url: input.mcpUrl,
+        headers: {
+          Authorization: `Bearer ${input.token}`,
+        },
+      },
+    },
+  };
+
+  return JSON.stringify(config);
+}
+
+function runClaude(args: string[], signal: AbortSignal | undefined) {
+  if (signal?.aborted) {
+    return;
+  }
+
+  const result = spawnSync("claude", args, {
+    env: process.env,
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.signal) {
+    return;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`claude exited with code ${result.status ?? "unknown"}.`);
+  }
+}

--- a/apps/os2/scripts/router.ts
+++ b/apps/os2/scripts/router.ts
@@ -1,0 +1,7 @@
+import { os } from "@orpc/server";
+
+import { claudeMcpScript } from "./claude-mcp.ts";
+
+export const router = os.router({
+  "claude-mcp": claudeMcpScript,
+});

--- a/apps/os2/scripts/sync-clerk-apps.ts
+++ b/apps/os2/scripts/sync-clerk-apps.ts
@@ -1,4 +1,4 @@
-import { createPublicKey, randomBytes } from "node:crypto";
+import { createPublicKey } from "node:crypto";
 import { execFileSync, spawnSync } from "node:child_process";
 import { deriveClerkFrontendApiUrl } from "../src/lib/clerk-frontend-api.ts";
 
@@ -249,33 +249,6 @@ function setDopplerSecrets(target: Target, instance: ClerkInstance, jwtKey: stri
       );
     }
   }
-}
-
-function readExistingDopplerSecret(config: string, key: string) {
-  const result = spawnSync(
-    "doppler",
-    [
-      "run",
-      "--project",
-      "os2",
-      "--config",
-      config,
-      "--",
-      "node",
-      "-e",
-      `process.stdout.write(process.env[${JSON.stringify(key)}] || "")`,
-    ],
-    {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    },
-  );
-
-  if (result.status !== 0) {
-    return null;
-  }
-
-  return result.stdout.trim() || null;
 }
 
 function exec(command: string, args: string[]) {

--- a/apps/os2/scripts/sync-clerk-apps.ts
+++ b/apps/os2/scripts/sync-clerk-apps.ts
@@ -216,11 +216,6 @@ async function getJwtPublicKey(publishableKey: string) {
 function setDopplerSecrets(target: Target, instance: ClerkInstance, jwtKey: string | Buffer) {
   const secrets = new Map([
     ["APP_CONFIG_BASE_URL", target.baseUrl],
-    [
-      "APP_CONFIG_MCP_PROOF_SECRET",
-      readExistingDopplerSecret(target.dopplerConfig, "APP_CONFIG_MCP_PROOF_SECRET") ??
-        randomBytes(32).toString("base64url"),
-    ],
     ["APP_CONFIG_PROJECT_HOSTNAME_BASES", JSON.stringify([target.projectHostnameBase])],
     ["APP_CONFIG_CLERK__PUBLISHABLE_KEY", instance.publishable_key],
     ["APP_CONFIG_CLERK__SECRET_KEY", instance.secret_key!],

--- a/apps/os2/src/app.test.ts
+++ b/apps/os2/src/app.test.ts
@@ -8,7 +8,6 @@ const baseConfig = {
     secretKey: "sk_test_example",
     jwtKey: "jwt-key",
   },
-  mcpProofSecret: "proof-secret",
   openAiApiKey: "openai-api-key",
 };
 

--- a/apps/os2/src/app.ts
+++ b/apps/os2/src/app.ts
@@ -26,7 +26,6 @@ export const AppConfig = BaseAppConfig.extend({
         scopes.filter((scope): scope is "email" | "profile" => scope !== "openid"),
       ),
   }),
-  mcpProofSecret: redacted(z.string().trim().min(1)),
   openAiApiKey: redacted(z.string().trim().min(1)),
   projectHostnameBases: publicValue(z.array(z.string().trim().min(1)).default([])),
   slackBotToken: redacted(z.string().trim().min(1)).optional(),

--- a/apps/os2/src/components/project-stream-view.tsx
+++ b/apps/os2/src/components/project-stream-view.tsx
@@ -1,12 +1,16 @@
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
-import { Event, type StreamPath } from "@iterate-com/shared/streams/types";
+import { Event, EventInput, type StreamPath } from "@iterate-com/shared/streams/types";
 import {
   processEventsWithViewReducer,
   selectEventsStreamViewReducer,
 } from "@iterate-com/ui/components/events/feed-processors";
 import type { EventsStreamInputAction } from "@iterate-com/ui/components/events/feed-items";
-import { EventsStreamComposer } from "@iterate-com/ui/components/events/stream-composer";
+import {
+  EventsStreamComposer,
+  type EventsStreamComposerMode,
+  type EventsStreamComposerRawPreset,
+} from "@iterate-com/ui/components/events/stream-composer";
 import {
   EventsStreamInputSlot,
   EventsStreamView,
@@ -15,6 +19,7 @@ import {
 } from "@iterate-com/ui/components/events/stream-feed";
 import { EventsStreamLayoutMessageInput } from "@iterate-com/ui/components/events/stream-layout";
 import { EventsStreamPathLabel } from "@iterate-com/ui/components/events/stream-path-label";
+import { parse as parseYaml } from "yaml";
 import { EventsDebugLink } from "~/components/events-debug-link.tsx";
 import { createBrowserOpenApiClient } from "~/orpc/client.ts";
 import { streamPathToSplat } from "~/lib/stream-links.ts";
@@ -23,6 +28,42 @@ type ProjectStreamMessageComposer = {
   placeholder?: string;
   onSubmit: (message: string) => Promise<void>;
 };
+
+const DEFAULT_RAW_EVENT_PRESET_ID = "manual-event";
+
+const defaultRawEventPresets: readonly EventsStreamComposerRawPreset[] = [
+  {
+    id: DEFAULT_RAW_EVENT_PRESET_ID,
+    label: "Manual event",
+    value: [
+      "type: events.iterate.com/os2/manual-event",
+      "payload:",
+      "  message: Hello from the stream composer",
+      "",
+    ].join("\n"),
+  },
+  {
+    id: "stream-error",
+    label: "Stream error",
+    value: [
+      "type: events.iterate.com/core/error-occurred",
+      "payload:",
+      "  message: Something notable happened",
+      "",
+    ].join("\n"),
+  },
+  {
+    id: "metadata-updated",
+    label: "Metadata updated",
+    value: [
+      "type: events.iterate.com/core/metadata-updated",
+      "payload:",
+      "  metadata:",
+      "    source: manual",
+      "",
+    ].join("\n"),
+  },
+];
 
 export function ProjectStreamView({
   emptyLabel = "No events in this stream yet.",
@@ -41,7 +82,13 @@ export function ProjectStreamView({
   projectSlugOrId: string;
   streamPath: StreamPath;
 }) {
+  const hasMessageComposer = messageComposer != null;
   const [composerText, setComposerText] = useState("");
+  const [composerMode, setComposerMode] = useState<EventsStreamComposerMode>(
+    hasMessageComposer ? "message" : "raw",
+  );
+  const [rawComposerText, setRawComposerText] = useState(defaultRawEventPresets[0]?.value ?? "");
+  const [selectedRawPresetId, setSelectedRawPresetId] = useState(DEFAULT_RAW_EVENT_PRESET_ID);
   const [events, setEvents] = useState<Event[]>([]);
   const [errorLabel, setErrorLabel] = useState<string | undefined>();
   const [hiddenElementTypes, setHiddenElementTypes] = useState<EventsStreamElementType[]>([]);
@@ -118,9 +165,37 @@ export function ProjectStreamView({
     }
   }
 
+  async function submitRawEvents() {
+    const trimmed = rawComposerText.trim();
+    if (!trimmed) return;
+
+    setIsSubmitting(true);
+    try {
+      const inputEvents = parseRawEventInputs(trimmed);
+      await createBrowserOpenApiClient().project.streams.appendBatch({
+        events: inputEvents,
+        projectSlugOrId,
+        streamPath,
+      });
+    } catch (error) {
+      setErrorLabel(error instanceof Error ? error.message : String(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function selectRawPreset(presetId: string) {
+    setSelectedRawPresetId(presetId);
+    const preset = defaultRawEventPresets.find((candidate) => candidate.id === presetId);
+    if (preset != null) {
+      setRawComposerText(preset.value);
+    }
+  }
+
   function handleInputAction(action: EventsStreamInputAction) {
     if (action.type === "prefill-agent-message") {
       setComposerText(action.text);
+      setComposerMode("message");
     }
   }
 
@@ -164,22 +239,36 @@ export function ProjectStreamView({
         onRendererModeChange={setRendererMode}
       />
 
-      {messageComposer ? (
-        <EventsStreamLayoutMessageInput>
-          <EventsStreamInputSlot
-            className="mb-3"
-            elements={viewState.slots.input}
-            onAction={handleInputAction}
-          />
-          <EventsStreamComposer
-            value={composerText}
-            onValueChange={setComposerText}
-            onSubmit={submitMessage}
-            isSubmitting={isSubmitting}
-            placeholder={messageComposer.placeholder ?? "Message this stream"}
-          />
-        </EventsStreamLayoutMessageInput>
-      ) : null}
+      <EventsStreamLayoutMessageInput>
+        <EventsStreamInputSlot
+          className="mb-3"
+          elements={viewState.slots.input}
+          onAction={handleInputAction}
+        />
+        <EventsStreamComposer
+          mode={composerMode}
+          onModeChange={setComposerMode}
+          message={
+            hasMessageComposer
+              ? {
+                  value: composerText,
+                  onValueChange: setComposerText,
+                  onSubmit: submitMessage,
+                  placeholder: messageComposer.placeholder ?? "Message this stream",
+                }
+              : undefined
+          }
+          raw={{
+            value: rawComposerText,
+            onValueChange: setRawComposerText,
+            onSubmit: submitRawEvents,
+            presets: defaultRawEventPresets,
+            selectedPresetId: selectedRawPresetId,
+            onSelectedPresetIdChange: selectRawPreset,
+          }}
+          isSubmitting={isSubmitting}
+        />
+      </EventsStreamLayoutMessageInput>
     </section>
   );
 }
@@ -188,4 +277,11 @@ function appendStreamEvent(events: Event[], event: Event): Event[] {
   if (events.some((candidate) => candidate.offset === event.offset)) return events;
 
   return [...events, event].toSorted((left, right) => left.offset - right.offset);
+}
+
+function parseRawEventInputs(value: string): EventInput[] {
+  const parsed = parseYaml(value) as unknown;
+  const inputEvents = Array.isArray(parsed) ? parsed : [parsed];
+
+  return inputEvents.map((inputEvent) => EventInput.parse(inputEvent));
 }

--- a/apps/os2/src/domains/agents/agent-presets.test.ts
+++ b/apps/os2/src/domains/agents/agent-presets.test.ts
@@ -39,6 +39,26 @@ describe("agent presets", () => {
     ).toBe(nestedPreset);
   });
 
+  it("ignores invalid stored preset paths while selecting a prefix preset", () => {
+    const validPreset = {
+      basePath: "/agents/alice",
+      events: defaultAgentSetupEvents("cloudflare-ai"),
+    };
+
+    expect(
+      selectAgentPathPrefixPreset({
+        agentPath: "/agents/alice/bla",
+        presets: [
+          {
+            basePath: "/alice",
+            events: defaultAgentSetupEvents("openai-ws"),
+          },
+          validPreset,
+        ],
+      }),
+    ).toBe(validPreset);
+  });
+
   it("reads the latest configured preset per base path", () => {
     const first = presetConfiguredEvent({
       basePath: "/agents/alice",

--- a/apps/os2/src/domains/agents/agent-presets.test.ts
+++ b/apps/os2/src/domains/agents/agent-presets.test.ts
@@ -10,11 +10,15 @@ import {
 } from "./agent-presets.ts";
 
 describe("agent presets", () => {
-  it("normalizes preset paths under /agents", () => {
-    expect(normalizeAgentPresetBasePath("alice/bla")).toBe("/agents/alice/bla");
-    expect(normalizeAgentPresetBasePath("/alice/bla/")).toBe("/agents/alice/bla");
-    expect(normalizeAgentPresetBasePath("/agents/alice/bla/")).toBe("/agents/alice/bla");
-    expect(normalizeAgentPresetBasePath("/")).toBe("/agents");
+  it("accepts full preset paths under /agents", () => {
+    expect(normalizeAgentPresetBasePath("/agents")).toBe("/agents");
+    expect(normalizeAgentPresetBasePath("/agents/alice/bla")).toBe("/agents/alice/bla");
+    expect(() => normalizeAgentPresetBasePath("alice/bla")).toThrow(
+      "Agent preset path must be /agents or start with /agents/.",
+    );
+    expect(() => normalizeAgentPresetBasePath("/alice/bla")).toThrow(
+      "Agent preset path must be /agents or start with /agents/.",
+    );
   });
 
   it("selects the longest matching path-prefix preset", () => {

--- a/apps/os2/src/domains/agents/agent-presets.test.ts
+++ b/apps/os2/src/domains/agents/agent-presets.test.ts
@@ -4,6 +4,7 @@ import {
   defaultAgentSetupEvents,
   defaultAgentSystemPrompt,
   normalizeAgentPresetBasePath,
+  parseAgentRunOptsJson,
   presetConfiguredEvent,
   readAgentPathPrefixPresets,
   selectAgentPathPrefixPreset,
@@ -102,6 +103,11 @@ describe("agent presets", () => {
   it("keeps the default system prompt on ctx.chat.sendMessage", () => {
     expect(defaultAgentSystemPrompt()).toContain("ctx.chat.sendMessage({ message:");
     expect(defaultAgentSystemPrompt()).not.toContain("ctx.streams.append");
+  });
+
+  it("distinguishes invalid run options JSON from non-object run options", () => {
+    expect(() => parseAgentRunOptsJson("[1, 2]")).toThrow("Run options must be a JSON object.");
+    expect(() => parseAgentRunOptsJson("{")).toThrow("Run options must be valid JSON.");
   });
 });
 

--- a/apps/os2/src/domains/agents/agent-presets.test.ts
+++ b/apps/os2/src/domains/agents/agent-presets.test.ts
@@ -79,6 +79,26 @@ describe("agent presets", () => {
     ]);
   });
 
+  it("ignores configured preset events with invalid base paths", () => {
+    const invalid = presetConfiguredEvent({
+      basePath: "/alice",
+      events: defaultAgentSetupEvents("openai-ws"),
+    });
+    const valid = presetConfiguredEvent({
+      basePath: "/agents/alice",
+      events: defaultAgentSetupEvents("cloudflare-ai"),
+    });
+
+    expect(
+      readAgentPathPrefixPresets([committedEvent(invalid, 1), committedEvent(valid, 2)]),
+    ).toEqual([
+      {
+        basePath: "/agents/alice",
+        events: defaultAgentSetupEvents("cloudflare-ai"),
+      },
+    ]);
+  });
+
   it("keeps the default system prompt on ctx.chat.sendMessage", () => {
     expect(defaultAgentSystemPrompt()).toContain("ctx.chat.sendMessage({ message:");
     expect(defaultAgentSystemPrompt()).not.toContain("ctx.streams.append");

--- a/apps/os2/src/domains/agents/agent-presets.ts
+++ b/apps/os2/src/domains/agents/agent-presets.ts
@@ -119,6 +119,16 @@ export function normalizeAgentPresetBasePath(input: string): StreamPath {
 }
 
 export function presetMatchesAgentPath(input: { agentPath: string; basePath: string }) {
-  const basePath = normalizeAgentPresetBasePath(input.basePath);
+  const basePath = tryNormalizeAgentPresetBasePath(input.basePath);
+  if (basePath == null) return false;
+
   return input.agentPath === basePath || input.agentPath.startsWith(`${basePath}/`);
+}
+
+function tryNormalizeAgentPresetBasePath(input: string): StreamPath | null {
+  try {
+    return normalizeAgentPresetBasePath(input);
+  } catch {
+    return null;
+  }
 }

--- a/apps/os2/src/domains/agents/agent-presets.ts
+++ b/apps/os2/src/domains/agents/agent-presets.ts
@@ -111,14 +111,11 @@ export function selectAgentPathPrefixPreset(input: {
 }
 
 export function normalizeAgentPresetBasePath(input: string): StreamPath {
-  const trimmed = input.trim();
-  const withSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
-  const withoutTrailing = withSlash.replace(/\/+$/, "");
-  const basePath = withoutTrailing === "" ? "/agents" : withoutTrailing;
+  const basePath = StreamPath.parse(input.trim());
   if (basePath === "/agents" || basePath.startsWith("/agents/")) {
-    return StreamPath.parse(basePath);
+    return basePath;
   }
-  return StreamPath.parse(`/agents/${basePath.replace(/^\/+/, "")}`);
+  throw new Error("Agent preset path must be /agents or start with /agents/.");
 }
 
 export function presetMatchesAgentPath(input: { agentPath: string; basePath: string }) {

--- a/apps/os2/src/domains/agents/agent-presets.ts
+++ b/apps/os2/src/domains/agents/agent-presets.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
-import { StreamPath, type EventInput } from "@iterate-com/shared/streams/types";
+import { parse as parseYaml } from "yaml";
+import { EventInput, StreamPath } from "@iterate-com/shared/streams/types";
 
 export const OS2_AGENT_LLM_PROVIDER_SELECTED_EVENT_TYPE =
   "events.iterate.com/os2-agent/llm-provider-selected";
@@ -69,6 +70,54 @@ export function defaultAgentSetupEvents(provider: AgentLlmProvider): AgentPreset
   ];
 }
 
+export function configuredAgentSetupEvents(input: {
+  idempotencyKeyPrefix?: string;
+  model: string;
+  provider: AgentLlmProvider;
+  runOpts: Record<string, unknown>;
+  systemPrompt: string;
+}): EventInput[] {
+  return defaultAgentSetupEvents(input.provider).map((event, index) => ({
+    ...(input.idempotencyKeyPrefix == null
+      ? {}
+      : { idempotencyKey: `${input.idempotencyKeyPrefix}:${index}:${event.type}` }),
+    type: event.type,
+    payload:
+      input.provider === "openai-ws" && event.type === "events.iterate.com/openai-ws/config-updated"
+        ? { model: input.model }
+        : input.provider === "cloudflare-ai" &&
+            event.type === "events.iterate.com/agent/llm-config-updated"
+          ? {
+              debounceMs: 1000,
+              model: input.model,
+              runOpts: input.runOpts,
+            }
+          : event.type === "events.iterate.com/agent/system-prompt-updated"
+            ? { systemPrompt: input.systemPrompt }
+            : event.payload,
+  }));
+}
+
+export function parseAgentPresetEventsYaml(value: string): AgentPresetEvent[] {
+  return AgentPresetEvent.array().parse(parseAgentEventsYaml(value));
+}
+
+export function parseAgentEventInputsYaml(value: string): EventInput[] {
+  return EventInput.array().parse(parseAgentEventsYaml(value));
+}
+
+export function parseAgentRunOptsJson(value: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Run options must be a JSON object.");
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    throw new Error("Run options must be valid JSON.");
+  }
+}
+
 export function presetConfiguredEvent(input: AgentPathPrefixPreset): EventInput {
   return {
     type: OS2_AGENT_PATH_PREFIX_PRESET_CONFIGURED_EVENT_TYPE,
@@ -131,4 +180,8 @@ function tryNormalizeAgentPresetBasePath(input: string): StreamPath | null {
   } catch {
     return null;
   }
+}
+
+function parseAgentEventsYaml(value: string) {
+  return parseYaml(value.trim() || "[]") as unknown;
 }

--- a/apps/os2/src/domains/agents/agent-presets.ts
+++ b/apps/os2/src/domains/agents/agent-presets.ts
@@ -107,15 +107,16 @@ export function parseAgentEventInputsYaml(value: string): EventInput[] {
 }
 
 export function parseAgentRunOptsJson(value: string): Record<string, unknown> {
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(value);
-    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
-      throw new Error("Run options must be a JSON object.");
-    }
-    return parsed as Record<string, unknown>;
+    parsed = JSON.parse(value);
   } catch {
     throw new Error("Run options must be valid JSON.");
   }
+  if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Run options must be a JSON object.");
+  }
+  return parsed as Record<string, unknown>;
 }
 
 export function presetConfiguredEvent(input: AgentPathPrefixPreset): EventInput {

--- a/apps/os2/src/domains/agents/agent-presets.ts
+++ b/apps/os2/src/domains/agents/agent-presets.ts
@@ -136,8 +136,10 @@ export function readAgentPathPrefixPresets(
     if (event.type !== OS2_AGENT_PATH_PREFIX_PRESET_CONFIGURED_EVENT_TYPE) continue;
     const parsed = AgentPathPrefixPreset.safeParse(event.payload);
     if (!parsed.success) continue;
-    presetsByBasePath.set(normalizeAgentPresetBasePath(parsed.data.basePath), {
-      basePath: normalizeAgentPresetBasePath(parsed.data.basePath),
+    const basePath = tryNormalizeAgentPresetBasePath(parsed.data.basePath);
+    if (basePath == null) continue;
+    presetsByBasePath.set(basePath, {
+      basePath,
       events: parsed.data.events,
     });
   }

--- a/apps/os2/src/domains/inbound-mcp-server/durable-objects/project-mcp-server-connection.ts
+++ b/apps/os2/src/domains/inbound-mcp-server/durable-objects/project-mcp-server-connection.ts
@@ -56,6 +56,7 @@ export interface ProjectMcpServerConnectionProps extends Record<string, unknown>
   orgPermissions: string[];
   scopes: string[];
   clientId: string | null;
+  clerkTokenType?: string;
 }
 
 export type ProjectMcpServerConnectionStructuredName = {
@@ -435,6 +436,10 @@ export class ProjectMcpServerConnection extends McpAgent<
   }
 
   private requireScope(props: ProjectMcpServerConnectionProps, scope: string) {
+    if (props.clerkTokenType && props.clerkTokenType !== "oauth_token") {
+      return;
+    }
+
     if (!props.scopes.includes(scope)) {
       throw new Error(`MCP token is missing required scope: ${scope}`);
     }

--- a/apps/os2/src/domains/inbound-mcp-server/durable-objects/project-mcp-server-connection.ts
+++ b/apps/os2/src/domains/inbound-mcp-server/durable-objects/project-mcp-server-connection.ts
@@ -34,14 +34,12 @@ export { StreamsCapability } from "~/domains/streams/entrypoints/streams-capabil
  * Code execution is delegated to the project/stream-scoped CodemodeSession DO.
  *
  * Tools:
- * - run_code: Execute JavaScript in an isolated dynamic worker sandbox
- * - reveal_secret: Return a dedicated deploy-time proof secret
+ * - exec_js: Execute JavaScript in an isolated dynamic worker sandbox
  */
 
 interface McpServerEnv {
   CODEMODE_SESSION: CodemodeSessionNamespace;
   DO_CATALOG: D1Database;
-  MCP_PROOF_SECRET: string;
   MOCK_PROVIDER_BASE_URL?: string;
   PROJECT_MCP_SERVER_CONNECTION: DurableObjectNamespace;
 }
@@ -145,52 +143,7 @@ export class ProjectMcpServerConnection extends McpAgent<
 
   async init() {
     this.server.registerTool(
-      "reveal_secret",
-      {
-        title: "Reveal secret",
-        description:
-          "Return the dedicated MCP proof secret configured on this deployment. " +
-          "This is intentionally not a production credential.",
-        inputSchema: z.object({}),
-      },
-      async () => {
-        const invocationId = `mcp_tool_${crypto.randomUUID()}`;
-        const startedAt = Date.now();
-        const auth = this.requireProjectAuthProps();
-        this.requireScope(auth, requiredToolScope);
-
-        await this.emitLifecycleEvent("tool-invocation-started", {
-          auth: summarizeAuthProps(auth),
-          input: {},
-          invocationId,
-          projectId: auth.projectId,
-          projectSlug: auth.projectSlug,
-          toolName: "reveal_secret",
-        });
-
-        const response = {
-          content: [{ type: "text" as const, text: this.env.MCP_PROOF_SECRET }],
-          isError: false,
-        };
-
-        await this.emitLifecycleEvent("tool-invocation-finished", {
-          auth: summarizeAuthProps(auth),
-          durationMs: Date.now() - startedAt,
-          input: {},
-          invocationId,
-          output: response,
-          projectId: auth.projectId,
-          projectSlug: auth.projectSlug,
-          result: this.env.MCP_PROOF_SECRET,
-          toolName: "reveal_secret",
-        });
-
-        return response;
-      },
-    );
-
-    this.server.registerTool(
-      "run_code",
+      "exec_js",
       {
         title: "Run code",
         description:
@@ -212,7 +165,7 @@ export class ProjectMcpServerConnection extends McpAgent<
         const invocationId = `mcp_tool_${crypto.randomUUID()}`;
         const startedAt = Date.now();
         const streamPath = await this.getSessionStreamPath();
-        debugCodemodeDepth("mcp.run_code.start", {
+        debugCodemodeDepth("mcp.exec_js.start", {
           invocationId,
           providerCount: staticProviders.length,
           sessionId: this.getSessionId(),
@@ -226,15 +179,15 @@ export class ProjectMcpServerConnection extends McpAgent<
           projectId: auth.projectId,
           projectSlug: auth.projectSlug,
           streamPath,
-          toolName: "run_code",
+          toolName: "exec_js",
         });
-        debugCodemodeDepth("mcp.run_code.afterStartedLifecycle", {
+        debugCodemodeDepth("mcp.exec_js.afterStartedLifecycle", {
           invocationId,
           elapsedMs: Date.now() - startedAt,
         });
 
         try {
-          debugCodemodeDepth("mcp.run_code.beforeStartSession", {
+          debugCodemodeDepth("mcp.exec_js.beforeStartSession", {
             invocationId,
             elapsedMs: Date.now() - startedAt,
           });
@@ -246,7 +199,7 @@ export class ProjectMcpServerConnection extends McpAgent<
             providers: staticProviders,
             streamPath,
           });
-          debugCodemodeDepth("mcp.run_code.afterStartSession", {
+          debugCodemodeDepth("mcp.exec_js.afterStartSession", {
             invocationId,
             elapsedMs: Date.now() - startedAt,
             offset: started.event.offset,
@@ -289,12 +242,12 @@ export class ProjectMcpServerConnection extends McpAgent<
             scriptExecutionId: (started.event.payload as { scriptExecutionId?: unknown })
               .scriptExecutionId,
             streamPath,
-            toolName: "run_code",
+            toolName: "exec_js",
           });
 
           return response;
         } catch (error) {
-          debugCodemodeDepth("mcp.run_code.error", {
+          debugCodemodeDepth("mcp.exec_js.error", {
             invocationId,
             elapsedMs: Date.now() - startedAt,
             error: serializeError(error),
@@ -312,7 +265,7 @@ export class ProjectMcpServerConnection extends McpAgent<
             projectId: auth.projectId,
             projectSlug: auth.projectSlug,
             streamPath,
-            toolName: "run_code",
+            toolName: "exec_js",
           });
 
           throw error;

--- a/apps/os2/src/domains/inbound-mcp-server/durable-objects/project-mcp-server-connection.ts
+++ b/apps/os2/src/domains/inbound-mcp-server/durable-objects/project-mcp-server-connection.ts
@@ -54,7 +54,7 @@ export interface ProjectMcpServerConnectionProps extends Record<string, unknown>
   orgPermissions: string[];
   scopes: string[];
   clientId: string | null;
-  clerkTokenType?: string;
+  clerkTokenType?: "admin_api_secret" | "oauth_token" | "session_token";
 }
 
 export type ProjectMcpServerConnectionStructuredName = {
@@ -389,7 +389,7 @@ export class ProjectMcpServerConnection extends McpAgent<
   }
 
   private requireScope(props: ProjectMcpServerConnectionProps, scope: string) {
-    if (props.clerkTokenType && props.clerkTokenType !== "oauth_token") {
+    if (props.clerkTokenType === "session_token" || props.clerkTokenType === "admin_api_secret") {
       return;
     }
 

--- a/apps/os2/src/domains/inbound-mcp-server/entrypoints/project-mcp-server-entrypoint.ts
+++ b/apps/os2/src/domains/inbound-mcp-server/entrypoints/project-mcp-server-entrypoint.ts
@@ -232,34 +232,43 @@ async function findMcpProjectMembershipAccess(input: {
   clerk: ClerkClient;
   project: DurableObjectStub<ProjectDurableObject>;
 }) {
-  const memberships = await input.clerk.users.getOrganizationMembershipList({
-    limit: 100,
-    userId: input.auth.userId,
-  });
+  const limit = 100;
+  let offset = 0;
 
-  for (const membership of memberships.data) {
-    const project = await tryCheckMcpProjectAccess({
-      auth: input.auth,
-      orgId: membership.organization.id,
-      project: input.project,
+  while (true) {
+    const memberships = await input.clerk.users.getOrganizationMembershipList({
+      limit,
+      offset,
+      userId: input.auth.userId,
     });
-    if (!project) {
-      continue;
+
+    for (const membership of memberships.data) {
+      const project = await tryCheckMcpProjectAccess({
+        auth: input.auth,
+        orgId: membership.organization.id,
+        project: input.project,
+      });
+      if (!project) {
+        continue;
+      }
+
+      return {
+        auth: {
+          ...input.auth,
+          orgId: membership.organization.id,
+          orgPermissions: membership.permissions,
+          orgRole: membership.role,
+          orgSlug: membership.organization.slug ?? null,
+        },
+        project,
+      };
     }
 
-    return {
-      auth: {
-        ...input.auth,
-        orgId: membership.organization.id,
-        orgPermissions: membership.permissions,
-        orgRole: membership.role,
-        orgSlug: membership.organization.slug ?? null,
-      },
-      project,
-    };
+    offset += memberships.data.length;
+    if (memberships.data.length === 0 || offset >= memberships.totalCount) {
+      return null;
+    }
   }
-
-  return null;
 }
 
 async function tryCheckMcpProjectAccess(input: {

--- a/apps/os2/src/domains/inbound-mcp-server/entrypoints/project-mcp-server-entrypoint.ts
+++ b/apps/os2/src/domains/inbound-mcp-server/entrypoints/project-mcp-server-entrypoint.ts
@@ -205,6 +205,13 @@ async function resolveMcpProjectAccess(input: {
     }
   }
 
+  if (input.auth.clerkTokenType !== "session_token") {
+    return new Response("MCP user is not a member of an organization with access to this project", {
+      status: 403,
+      headers: mcpCorsHeaders,
+    });
+  }
+
   const membershipAccess = await findMcpProjectMembershipAccess({
     auth: input.auth,
     clerk: createClerkClientForApp(),

--- a/apps/os2/src/domains/inbound-mcp-server/entrypoints/project-mcp-server-entrypoint.ts
+++ b/apps/os2/src/domains/inbound-mcp-server/entrypoints/project-mcp-server-entrypoint.ts
@@ -1,5 +1,5 @@
 import { env as workerEnv, WorkerEntrypoint } from "cloudflare:workers";
-import { createClerkClient, verifyToken } from "@clerk/backend";
+import { createClerkClient, verifyToken, type ClerkClient } from "@clerk/backend";
 import { generateProtectedResourceMetadata } from "@clerk/mcp-tools/server";
 import { parseAppConfigFromEnv } from "@iterate-com/shared/apps/config";
 import { McpAgent } from "agents/mcp";
@@ -60,16 +60,19 @@ export class ProjectMcpServerEntrypoint extends WorkerEntrypoint<
       return mcpAuth;
     }
 
-    const project = await resolveMcpProject({
+    const access = await resolveMcpProjectAccess({
       auth: mcpAuth,
       project: this.env.PROJECT.getByName(getProjectDurableObjectName(this.ctx.props.projectId)),
     });
+    if (access instanceof Response) {
+      return access;
+    }
 
     const ctxWithProps = this.ctx as ExecutionContext & { props?: ProjectMcpServerConnectionProps };
     ctxWithProps.props = {
-      ...mcpAuth,
-      projectId: project.id,
-      projectSlug: project.slug,
+      ...access.auth,
+      projectId: access.project.id,
+      projectSlug: access.project.slug,
     };
 
     return await mcpHandler.fetch(request, this.env, this.ctx);
@@ -114,43 +117,35 @@ async function authenticateMcpRequest(request: Request) {
   }
 
   try {
-    const clerk = createClerkClient({
-      secretKey: config.clerk.secretKey.exposeSecret(),
-      publishableKey: config.clerk.publishableKey,
-      jwtKey: config.clerk.jwtKey.exposeSecret(),
-    });
+    const clerk = createClerkClientForApp();
     const requestState = await clerk.authenticateRequest(request, {
-      acceptsToken: "oauth_token",
+      acceptsToken: ["oauth_token", "session_token"],
     });
-    const oauthAuth = requestState.toAuth();
+    const clerkAuth = requestState.toAuth();
 
-    if (!oauthAuth.isAuthenticated) {
+    if (!clerkAuth?.isAuthenticated) {
       return unauthorizedMcpResponse(request, "Invalid bearer token");
     }
 
     const claims = await tryReadJwtClaims(token);
-    const userId = oauthAuth.userId;
-    const orgId = readOrganizationIdClaim(claims);
+    const userId = readStringProperty(clerkAuth, "userId");
+    const tokenType = readStringProperty(clerkAuth, "tokenType") ?? undefined;
 
     if (!userId) {
-      return unauthorizedMcpResponse(request, "MCP token is missing Clerk user subject");
-    }
-
-    if (!orgId) {
-      return new Response("MCP token is missing active Clerk Organization", {
-        status: 403,
-        headers: mcpCorsHeaders,
-      });
+      return unauthorizedMcpResponse(request, "MCP token must identify a Clerk user");
     }
 
     return {
       userId,
-      orgId,
-      orgRole: readOrganizationRoleClaim(claims),
-      orgSlug: readOrganizationSlugClaim(claims),
-      orgPermissions: readOrganizationPermissionsClaim(claims),
-      scopes: oauthAuth.scopes.length > 0 ? oauthAuth.scopes : readScopeClaims(claims),
-      clientId: oauthAuth.clientId ?? readStringClaim(claims, "client_id"),
+      orgId: readStringProperty(clerkAuth, "orgId") ?? readOrganizationIdClaim(claims),
+      orgRole: readStringProperty(clerkAuth, "orgRole") ?? readOrganizationRoleClaim(claims),
+      orgSlug: readStringProperty(clerkAuth, "orgSlug") ?? readOrganizationSlugClaim(claims),
+      orgPermissions:
+        readStringArrayProperty(clerkAuth, "orgPermissions") ??
+        readOrganizationPermissionsClaim(claims),
+      scopes: readStringArrayProperty(clerkAuth, "scopes") ?? readScopeClaims(claims),
+      clientId: readStringProperty(clerkAuth, "clientId") ?? readStringClaim(claims, "client_id"),
+      clerkTokenType: tokenType,
       projectId: null,
       projectSlug: null,
     } satisfies ProjectMcpServerConnectionProps;
@@ -179,26 +174,101 @@ function authenticateSharedSecret(token: string): ProjectMcpServerConnectionProp
     projectSlug: null,
     scopes: ["profile"],
     userId: "admin-api-secret",
+    clerkTokenType: "admin_api_secret",
   };
 }
 
-async function resolveMcpProject(input: {
+async function resolveMcpProjectAccess(input: {
   auth: ProjectMcpServerConnectionProps;
   project: DurableObjectStub<ProjectDurableObject>;
-}): Promise<ProjectSummary> {
+}): Promise<{ auth: ProjectMcpServerConnectionProps; project: ProjectSummary } | Response> {
   if (input.auth.clientId === "admin-api-secret") {
-    return await input.project.getSummary();
+    return { auth: input.auth, project: await input.project.getSummary() };
   }
 
-  if (!input.auth.orgId) {
-    throw new Error("MCP OAuth auth is missing an organization id.");
-  }
-
-  return await input.project.checkAccess({
-    principal: {
+  if (input.auth.orgId) {
+    const project = await tryCheckMcpProjectAccess({
+      auth: input.auth,
       orgId: input.auth.orgId,
-      userId: input.auth.userId,
-    },
+      project: input.project,
+    });
+    if (project) {
+      return { auth: input.auth, project };
+    }
+  }
+
+  const membershipAccess = await findMcpProjectMembershipAccess({
+    auth: input.auth,
+    clerk: createClerkClientForApp(),
+    project: input.project,
+  });
+  if (membershipAccess) {
+    return membershipAccess;
+  }
+
+  return new Response("MCP user is not a member of an organization with access to this project", {
+    status: 403,
+    headers: mcpCorsHeaders,
+  });
+}
+
+async function findMcpProjectMembershipAccess(input: {
+  auth: ProjectMcpServerConnectionProps;
+  clerk: ClerkClient;
+  project: DurableObjectStub<ProjectDurableObject>;
+}) {
+  const memberships = await input.clerk.users.getOrganizationMembershipList({
+    limit: 100,
+    userId: input.auth.userId,
+  });
+
+  for (const membership of memberships.data) {
+    const project = await tryCheckMcpProjectAccess({
+      auth: input.auth,
+      orgId: membership.organization.id,
+      project: input.project,
+    });
+    if (!project) {
+      continue;
+    }
+
+    return {
+      auth: {
+        ...input.auth,
+        orgId: membership.organization.id,
+        orgPermissions: membership.permissions,
+        orgRole: membership.role,
+        orgSlug: membership.organization.slug ?? null,
+      },
+      project,
+    };
+  }
+
+  return null;
+}
+
+async function tryCheckMcpProjectAccess(input: {
+  auth: ProjectMcpServerConnectionProps;
+  orgId: string;
+  project: DurableObjectStub<ProjectDurableObject>;
+}) {
+  try {
+    return await input.project.checkAccess({
+      principal: {
+        orgId: input.orgId,
+        userId: input.auth.userId,
+      },
+    });
+  } catch {
+    return null;
+  }
+}
+
+function createClerkClientForApp(): ClerkClient {
+  return createClerkClient({
+    secretKey: config.clerk.secretKey.exposeSecret(),
+    publishableKey: config.clerk.publishableKey,
+    jwtKey: config.clerk.jwtKey.exposeSecret(),
   });
 }
 
@@ -287,6 +357,25 @@ function readStringClaim(claims: Record<string, unknown>, key: string) {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
+function readStringProperty(value: unknown, key: string) {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  return readStringClaim(value, key);
+}
+
+function readStringArrayProperty(value: unknown, key: string) {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const propertyValue = value[key];
+  return Array.isArray(propertyValue)
+    ? propertyValue.filter((entry) => typeof entry === "string")
+    : null;
+}
+
 function readOrganizationIdClaim(claims: Record<string, unknown>) {
   const organization = readRecordClaim(claims, "o");
   return readStringClaim(organization, "id") ?? readStringClaim(claims, "org_id");
@@ -327,7 +416,9 @@ function readScopeClaims(claims: Record<string, unknown>) {
 
 function readRecordClaim(claims: Record<string, unknown>, key: string): Record<string, unknown> {
   const value = claims[key];
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
+  return isRecord(value) ? value : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/apps/os2/src/domains/inbound-mcp-server/entrypoints/project-mcp-server-entrypoint.ts
+++ b/apps/os2/src/domains/inbound-mcp-server/entrypoints/project-mcp-server-entrypoint.ts
@@ -129,7 +129,7 @@ async function authenticateMcpRequest(request: Request) {
 
     const claims = await tryReadJwtClaims(token);
     const userId = readStringProperty(clerkAuth, "userId");
-    const tokenType = readStringProperty(clerkAuth, "tokenType") ?? undefined;
+    const tokenType = readClerkTokenType(clerkAuth);
 
     if (!userId) {
       return unauthorizedMcpResponse(request, "MCP token must identify a Clerk user");
@@ -176,6 +176,14 @@ function authenticateSharedSecret(token: string): ProjectMcpServerConnectionProp
     userId: "admin-api-secret",
     clerkTokenType: "admin_api_secret",
   };
+}
+
+function readClerkTokenType(clerkAuth: unknown): ProjectMcpServerConnectionProps["clerkTokenType"] {
+  const tokenType = readStringProperty(clerkAuth, "tokenType");
+  if (tokenType === "oauth_token" || tokenType === "session_token") {
+    return tokenType;
+  }
+  return undefined;
 }
 
 async function resolveMcpProjectAccess(input: {

--- a/apps/os2/src/domains/streams/entrypoints/streams-capability.ts
+++ b/apps/os2/src/domains/streams/entrypoints/streams-capability.ts
@@ -49,6 +49,10 @@ type StreamAppendInput = StreamPathInput & {
   event: EventInput;
 };
 
+type StreamAppendBatchInput = StreamPathInput & {
+  events: EventInput[];
+};
+
 type StreamReadInput = StreamPathInput & {
   afterOffset?: StreamCursor;
   beforeOffset?: StreamCursor;
@@ -63,7 +67,7 @@ type StreamListChildrenInput = StreamPathInput;
 type StreamCatalogRecord = D1ObjectCatalogRecord<StreamDurableObjectStructuredName>;
 type StreamsCapabilityClient = Pick<
   StreamsCapability,
-  "append" | "create" | "getState" | "list" | "listChildren" | "read" | "stream"
+  "append" | "appendBatch" | "create" | "getState" | "list" | "listChildren" | "read" | "stream"
 >;
 
 /**
@@ -88,6 +92,8 @@ export class StreamsCapability extends WorkerEntrypoint<
     switch (input.functionPath.join(".")) {
       case "append":
         return await this.append(options as StreamAppendInput);
+      case "appendBatch":
+        return await this.appendBatch(options as StreamAppendBatchInput);
       case "create":
         return await this.create(options as StreamPathInput);
       case "list":
@@ -131,6 +137,26 @@ export class StreamsCapability extends WorkerEntrypoint<
       namespace: this.ctx.props.namespace,
     });
     return event;
+  }
+
+  async appendBatch(input: StreamAppendBatchInput): Promise<Event[]> {
+    const path = this.resolveNamespacePath(input);
+    this.assertMayAppend(path);
+    return await appendNamespaceStreamEventBatch({
+      durableObjectNamespace: this.env.STREAM,
+      path,
+      namespace: this.ctx.props.namespace,
+      events: input.events.map(
+        (event) =>
+          ({
+            ...event,
+            metadata: {
+              ...(event.metadata ?? {}),
+              ...(this.ctx.props.appendMetadata ?? {}),
+            },
+          }) as EventInput,
+      ),
+    });
   }
 
   async create(input: StreamPathInput) {
@@ -370,6 +396,16 @@ async function appendNamespaceStreamEvent(args: {
 }) {
   const stub = await getInitializedNamespaceStreamStub(args);
   return await stub.append(args.event);
+}
+
+async function appendNamespaceStreamEventBatch(args: {
+  durableObjectNamespace: DurableObjectNamespace<StreamDurableObject>;
+  namespace: string;
+  path: StreamPath;
+  events: EventInput[];
+}) {
+  const stub = await getInitializedNamespaceStreamStub(args);
+  return await stub.appendBatch(args.events);
 }
 
 async function readNamespaceStreamEvents(args: {

--- a/apps/os2/src/durable-objects/iterate-mcp-server.test.ts
+++ b/apps/os2/src/durable-objects/iterate-mcp-server.test.ts
@@ -25,14 +25,11 @@ describe("ProjectMcpServerConnection inbound MCP", () => {
       await client.connect(transport);
 
       await expect(client.listTools()).resolves.toMatchObject({
-        tools: expect.arrayContaining([
-          expect.objectContaining({ name: "run_code" }),
-          expect.objectContaining({ name: "reveal_secret" }),
-        ]),
+        tools: expect.arrayContaining([expect.objectContaining({ name: "exec_js" })]),
       });
 
       const result = await client.callTool({
-        name: "run_code",
+        name: "exec_js",
         arguments: {
           code: `async (ctx) => {
   const message = \`hello from \${"inbound mcp"}\`;
@@ -63,7 +60,7 @@ describe("ProjectMcpServerConnection inbound MCP", () => {
             payload: expect.objectContaining({
               projectId: "proj__test__inboundmcp",
               streamPath,
-              toolName: "run_code",
+              toolName: "exec_js",
             }),
           }),
           expect.objectContaining({
@@ -89,7 +86,7 @@ describe("ProjectMcpServerConnection inbound MCP", () => {
             payload: expect.objectContaining({
               projectId: "proj__test__inboundmcp",
               streamPath,
-              toolName: "run_code",
+              toolName: "exec_js",
             }),
           }),
         ]),
@@ -99,7 +96,7 @@ describe("ProjectMcpServerConnection inbound MCP", () => {
     }
   });
 
-  test("auto-loads static codemode tool providers for run_code", async () => {
+  test("auto-loads static codemode tool providers for exec_js", async () => {
     const transport = new StreamableHTTPClientTransport(
       new URL("https://mcp-project.iterate-preview-test.app/mcp"),
       {
@@ -112,7 +109,7 @@ describe("ProjectMcpServerConnection inbound MCP", () => {
       await client.connect(transport);
 
       const result = await client.callTool({
-        name: "run_code",
+        name: "exec_js",
         arguments: {
           code: `async (ctx) => {
   const operations = await ctx.integrations.http.catalog.listOperations();
@@ -286,7 +283,7 @@ function parseRunCodeResult(content: unknown) {
   const text = extractTextContent(content).join("\n");
   const marker = "Result: ";
   const index = text.indexOf(marker);
-  if (index === -1) throw new Error(`run_code result did not contain "${marker}": ${text}`);
+  if (index === -1) throw new Error(`exec_js result did not contain "${marker}": ${text}`);
   return JSON.parse(text.slice(index + marker.length));
 }
 

--- a/apps/os2/src/durable-objects/iterate-mcp-server.wrangler.vitest.jsonc
+++ b/apps/os2/src/durable-objects/iterate-mcp-server.wrangler.vitest.jsonc
@@ -3,9 +3,7 @@
   "main": "iterate-mcp-server-test-entry.ts",
   "compatibility_date": "2026-04-27",
   "compatibility_flags": ["nodejs_compat"],
-  "vars": {
-    "MCP_PROOF_SECRET": "mcp-proof-secret-test",
-  },
+  "vars": {},
   "durable_objects": {
     "bindings": [
       {

--- a/apps/os2/src/durable-objects/project-ingress.test.ts
+++ b/apps/os2/src/durable-objects/project-ingress.test.ts
@@ -121,10 +121,7 @@ describe("Project ingress routing", () => {
     try {
       await client.connect(transport);
       await expect(client.listTools()).resolves.toMatchObject({
-        tools: expect.arrayContaining([
-          expect.objectContaining({ name: "run_code" }),
-          expect.objectContaining({ name: "reveal_secret" }),
-        ]),
+        tools: expect.arrayContaining([expect.objectContaining({ name: "exec_js" })]),
       });
     } finally {
       await client.close();

--- a/apps/os2/src/durable-objects/project-ingress.wrangler.vitest.jsonc
+++ b/apps/os2/src/durable-objects/project-ingress.wrangler.vitest.jsonc
@@ -4,8 +4,7 @@
   "compatibility_date": "2026-04-27",
   "compatibility_flags": ["nodejs_compat"],
   "vars": {
-    "APP_CONFIG": "{\"adminApiSecret\":\"project-ingress-admin-secret\",\"clerk\":{\"publishableKey\":\"pk_test_ZHVtbXkuY2xlcmsuYWNjb3VudHMuZGV2JA\",\"secretKey\":\"sk_test_project_ingress\",\"jwtKey\":\"project-ingress-jwt-key\"},\"mcpProofSecret\":\"project-ingress-proof-secret\",\"openAiApiKey\":\"openai-test-key\",\"projectHostnameBases\":[\"iterate.localhost\"],\"typeIdPrefix\":\"os\"}",
-    "MCP_PROOF_SECRET": "project-ingress-proof-secret",
+    "APP_CONFIG": "{\"adminApiSecret\":\"project-ingress-admin-secret\",\"clerk\":{\"publishableKey\":\"pk_test_ZHVtbXkuY2xlcmsuYWNjb3VudHMuZGV2JA\",\"secretKey\":\"sk_test_project_ingress\",\"jwtKey\":\"project-ingress-jwt-key\"},\"openAiApiKey\":\"openai-test-key\",\"projectHostnameBases\":[\"iterate.localhost\"],\"typeIdPrefix\":\"os\"}",
   },
   "durable_objects": {
     "bindings": [

--- a/apps/os2/src/lib/agent-links.test.ts
+++ b/apps/os2/src/lib/agent-links.test.ts
@@ -1,15 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { agentPathFromInput, agentPathFromSplat, agentPathToSplat } from "./agent-links.ts";
+import { agentPathFromInput } from "./agent-links.ts";
 
 describe("agent links", () => {
-  it("normalizes entered paths under /agents", () => {
-    expect(agentPathFromInput("alice/bla")).toBe("/agents/alice/bla");
-    expect(agentPathFromInput("/alice/bla/")).toBe("/agents/alice/bla");
-    expect(agentPathFromInput("/agents/alice/bla/")).toBe("/agents/alice/bla");
-  });
-
-  it("round trips route splats without duplicating the /agents prefix", () => {
-    expect(agentPathFromSplat("alice/bla")).toBe("/agents/alice/bla");
-    expect(agentPathToSplat("/agents/alice/bla")).toBe("alice/bla");
+  it("accepts entered full agent paths", () => {
+    expect(agentPathFromInput("/agents/alice/bla")).toBe("/agents/alice/bla");
+    expect(() => agentPathFromInput("alice/bla")).toThrow("Agent path must start with /agents/.");
+    expect(() => agentPathFromInput("/alice/bla")).toThrow("Agent path must start with /agents/.");
   });
 });

--- a/apps/os2/src/lib/agent-links.ts
+++ b/apps/os2/src/lib/agent-links.ts
@@ -1,28 +1,9 @@
 import { StreamPath } from "@iterate-com/shared/streams/types";
 
 export function agentPathFromInput(value: string) {
-  const relativePath = normalizeAgentRelativePath(value);
-  if (!relativePath) throw new Error("Agent path must include a name.");
-  return StreamPath.parse(`/agents/${relativePath}`);
-}
-
-export function agentPathFromSplat(value: string | undefined) {
-  const relativePath = normalizeAgentRelativePath(value ?? "");
-  if (!relativePath) throw new Error("Agent path must include a name.");
-  return StreamPath.parse(`/agents/${relativePath}`);
-}
-
-export function agentPathToSplat(path: string) {
-  const relativePath = normalizeAgentRelativePath(path);
-  return relativePath || "default";
-}
-
-function normalizeAgentRelativePath(value: string) {
-  const trimmed = value.trim();
-  if (!trimmed) return "";
-
-  const withoutSlashes = trimmed.replace(/^\/+/, "").replace(/\/+$/, "");
-  if (withoutSlashes === "agents") return "";
-  if (withoutSlashes.startsWith("agents/")) return withoutSlashes.slice("agents/".length);
-  return withoutSlashes;
+  const path = StreamPath.parse(value.trim());
+  if (!path.startsWith("/agents/")) {
+    throw new Error("Agent path must start with /agents/.");
+  }
+  return path;
 }

--- a/apps/os2/src/orpc/routers/streams.ts
+++ b/apps/os2/src/orpc/routers/streams.ts
@@ -29,6 +29,16 @@ export const projectStreamsRouter = {
       });
       return { event };
     }),
+  appendBatch: os.project.streams.appendBatch
+    .use(projectScopeMiddleware)
+    .handler(async ({ context, input }) => {
+      const project = requireProjectScope(context);
+      const events = await getProjectStreamsCapability(context, project.id).appendBatch({
+        events: input.events,
+        streamPath: input.streamPath,
+      });
+      return { events };
+    }),
   read: os.project.streams.read.use(projectScopeMiddleware).handler(async ({ context, input }) => {
     const project = requireProjectScope(context);
     const events = await getProjectStreamsCapability(context, project.id).read({

--- a/apps/os2/src/routeTree.gen.ts
+++ b/apps/os2/src/routeTree.gen.ts
@@ -40,6 +40,7 @@ import { Route as AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRouteImpo
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugStreamsSplatRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/streams/$'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsNewRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/new'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/$codemodeSessionName'
+import { Route as AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/$'
 
 const OrganizationRoute = OrganizationRouteImport.update({
@@ -228,6 +229,13 @@ const AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsCodemodeSessionN
         AppOrgsOrganizationSlugProjectsProjectSlugRouteRoute,
     } as any,
   )
+const AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute =
+  AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRouteImport.update({
+    id: '/new',
+    path: '/new',
+    getParentRoute: () =>
+      AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRoute,
+  } as any)
 const AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRoute =
   AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRouteImport.update({
     id: '/$',
@@ -262,6 +270,7 @@ export interface FileRoutesByFullPath {
   '/orgs/$organizationSlug/projects/$projectSlug/settings': typeof AppOrgsOrganizationSlugProjectsProjectSlugSettingsRoute
   '/orgs/$organizationSlug/projects/$projectSlug/': typeof AppOrgsOrganizationSlugProjectsProjectSlugIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/agents/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRoute
+  '/orgs/$organizationSlug/projects/$projectSlug/agents/new': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute
   '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/$codemodeSessionName': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRoute
   '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/new': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsNewRoute
   '/orgs/$organizationSlug/projects/$projectSlug/streams/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugStreamsSplatRoute
@@ -290,6 +299,7 @@ export interface FileRoutesByTo {
   '/orgs/$organizationSlug/projects/$projectSlug/settings': typeof AppOrgsOrganizationSlugProjectsProjectSlugSettingsRoute
   '/orgs/$organizationSlug/projects/$projectSlug': typeof AppOrgsOrganizationSlugProjectsProjectSlugIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/agents/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRoute
+  '/orgs/$organizationSlug/projects/$projectSlug/agents/new': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute
   '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/$codemodeSessionName': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRoute
   '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/new': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsNewRoute
   '/orgs/$organizationSlug/projects/$projectSlug/streams/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugStreamsSplatRoute
@@ -325,6 +335,7 @@ export interface FileRoutesById {
   '/_app/orgs/$organizationSlug/projects/$projectSlug/settings': typeof AppOrgsOrganizationSlugProjectsProjectSlugSettingsRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/': typeof AppOrgsOrganizationSlugProjectsProjectSlugIndexRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRoute
+  '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/$codemodeSessionName': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/new': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsNewRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/streams/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugStreamsSplatRoute
@@ -360,6 +371,7 @@ export interface FileRouteTypes {
     | '/orgs/$organizationSlug/projects/$projectSlug/settings'
     | '/orgs/$organizationSlug/projects/$projectSlug/'
     | '/orgs/$organizationSlug/projects/$projectSlug/agents/$'
+    | '/orgs/$organizationSlug/projects/$projectSlug/agents/new'
     | '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/$codemodeSessionName'
     | '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/new'
     | '/orgs/$organizationSlug/projects/$projectSlug/streams/$'
@@ -388,6 +400,7 @@ export interface FileRouteTypes {
     | '/orgs/$organizationSlug/projects/$projectSlug/settings'
     | '/orgs/$organizationSlug/projects/$projectSlug'
     | '/orgs/$organizationSlug/projects/$projectSlug/agents/$'
+    | '/orgs/$organizationSlug/projects/$projectSlug/agents/new'
     | '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/$codemodeSessionName'
     | '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/new'
     | '/orgs/$organizationSlug/projects/$projectSlug/streams/$'
@@ -422,6 +435,7 @@ export interface FileRouteTypes {
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/settings'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/$'
+    | '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/$codemodeSessionName'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/new'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/streams/$'
@@ -664,6 +678,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRouteImport
       parentRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugRouteRoute
     }
+    '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new': {
+      id: '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new'
+      path: '/new'
+      fullPath: '/orgs/$organizationSlug/projects/$projectSlug/agents/new'
+      preLoaderRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRouteImport
+      parentRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRoute
+    }
     '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/$': {
       id: '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/$'
       path: '/$'
@@ -676,6 +697,7 @@ declare module '@tanstack/react-router' {
 
 interface AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRouteChildren {
   AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRoute
+  AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute
   AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRoute
 }
 
@@ -683,6 +705,8 @@ const AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRouteChildren: AppOrg
   {
     AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRoute:
       AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRoute,
+    AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute:
+      AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute,
     AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRoute:
       AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRoute,
   }

--- a/apps/os2/src/routeTree.gen.ts
+++ b/apps/os2/src/routeTree.gen.ts
@@ -40,8 +40,9 @@ import { Route as AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRouteImpo
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugStreamsSplatRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/streams/$'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsNewRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/new'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/$codemodeSessionName'
+import { Route as AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewPresetRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new'
-import { Route as AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/$'
+import { Route as AppOrgsOrganizationSlugProjectsProjectSlugAgentsStreamsSplatRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$'
 
 const OrganizationRoute = OrganizationRouteImport.update({
   id: '/organization',
@@ -229,6 +230,13 @@ const AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsCodemodeSessionN
         AppOrgsOrganizationSlugProjectsProjectSlugRouteRoute,
     } as any,
   )
+const AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewPresetRoute =
+  AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewPresetRouteImport.update({
+    id: '/new-preset',
+    path: '/new-preset',
+    getParentRoute: () =>
+      AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRoute,
+  } as any)
 const AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute =
   AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRouteImport.update({
     id: '/new',
@@ -236,13 +244,15 @@ const AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute =
     getParentRoute: () =>
       AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRoute,
   } as any)
-const AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRoute =
-  AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRouteImport.update({
-    id: '/$',
-    path: '/$',
-    getParentRoute: () =>
-      AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRoute,
-  } as any)
+const AppOrgsOrganizationSlugProjectsProjectSlugAgentsStreamsSplatRoute =
+  AppOrgsOrganizationSlugProjectsProjectSlugAgentsStreamsSplatRouteImport.update(
+    {
+      id: '/streams/$',
+      path: '/streams/$',
+      getParentRoute: () =>
+        AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRoute,
+    } as any,
+  )
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -269,14 +279,15 @@ export interface FileRoutesByFullPath {
   '/orgs/$organizationSlug/projects/$projectSlug/mcp': typeof AppOrgsOrganizationSlugProjectsProjectSlugMcpRoute
   '/orgs/$organizationSlug/projects/$projectSlug/settings': typeof AppOrgsOrganizationSlugProjectsProjectSlugSettingsRoute
   '/orgs/$organizationSlug/projects/$projectSlug/': typeof AppOrgsOrganizationSlugProjectsProjectSlugIndexRoute
-  '/orgs/$organizationSlug/projects/$projectSlug/agents/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRoute
   '/orgs/$organizationSlug/projects/$projectSlug/agents/new': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute
+  '/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewPresetRoute
   '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/$codemodeSessionName': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRoute
   '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/new': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsNewRoute
   '/orgs/$organizationSlug/projects/$projectSlug/streams/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugStreamsSplatRoute
   '/orgs/$organizationSlug/projects/$projectSlug/agents/': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/streams/': typeof AppOrgsOrganizationSlugProjectsProjectSlugStreamsIndexRoute
+  '/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsStreamsSplatRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -298,14 +309,15 @@ export interface FileRoutesByTo {
   '/orgs/$organizationSlug/projects/$projectSlug/mcp': typeof AppOrgsOrganizationSlugProjectsProjectSlugMcpRoute
   '/orgs/$organizationSlug/projects/$projectSlug/settings': typeof AppOrgsOrganizationSlugProjectsProjectSlugSettingsRoute
   '/orgs/$organizationSlug/projects/$projectSlug': typeof AppOrgsOrganizationSlugProjectsProjectSlugIndexRoute
-  '/orgs/$organizationSlug/projects/$projectSlug/agents/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRoute
   '/orgs/$organizationSlug/projects/$projectSlug/agents/new': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute
+  '/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewPresetRoute
   '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/$codemodeSessionName': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRoute
   '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/new': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsNewRoute
   '/orgs/$organizationSlug/projects/$projectSlug/streams/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugStreamsSplatRoute
   '/orgs/$organizationSlug/projects/$projectSlug/agents': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/streams': typeof AppOrgsOrganizationSlugProjectsProjectSlugStreamsIndexRoute
+  '/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsStreamsSplatRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -334,14 +346,15 @@ export interface FileRoutesById {
   '/_app/orgs/$organizationSlug/projects/$projectSlug/mcp': typeof AppOrgsOrganizationSlugProjectsProjectSlugMcpRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/settings': typeof AppOrgsOrganizationSlugProjectsProjectSlugSettingsRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/': typeof AppOrgsOrganizationSlugProjectsProjectSlugIndexRoute
-  '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute
+  '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewPresetRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/$codemodeSessionName': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/new': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsNewRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/streams/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugStreamsSplatRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsIndexRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/streams/': typeof AppOrgsOrganizationSlugProjectsProjectSlugStreamsIndexRoute
+  '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsStreamsSplatRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -370,14 +383,15 @@ export interface FileRouteTypes {
     | '/orgs/$organizationSlug/projects/$projectSlug/mcp'
     | '/orgs/$organizationSlug/projects/$projectSlug/settings'
     | '/orgs/$organizationSlug/projects/$projectSlug/'
-    | '/orgs/$organizationSlug/projects/$projectSlug/agents/$'
     | '/orgs/$organizationSlug/projects/$projectSlug/agents/new'
+    | '/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset'
     | '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/$codemodeSessionName'
     | '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/new'
     | '/orgs/$organizationSlug/projects/$projectSlug/streams/$'
     | '/orgs/$organizationSlug/projects/$projectSlug/agents/'
     | '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/'
     | '/orgs/$organizationSlug/projects/$projectSlug/streams/'
+    | '/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -399,14 +413,15 @@ export interface FileRouteTypes {
     | '/orgs/$organizationSlug/projects/$projectSlug/mcp'
     | '/orgs/$organizationSlug/projects/$projectSlug/settings'
     | '/orgs/$organizationSlug/projects/$projectSlug'
-    | '/orgs/$organizationSlug/projects/$projectSlug/agents/$'
     | '/orgs/$organizationSlug/projects/$projectSlug/agents/new'
+    | '/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset'
     | '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/$codemodeSessionName'
     | '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/new'
     | '/orgs/$organizationSlug/projects/$projectSlug/streams/$'
     | '/orgs/$organizationSlug/projects/$projectSlug/agents'
     | '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions'
     | '/orgs/$organizationSlug/projects/$projectSlug/streams'
+    | '/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$'
   id:
     | '__root__'
     | '/'
@@ -434,14 +449,15 @@ export interface FileRouteTypes {
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/mcp'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/settings'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/'
-    | '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/$'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new'
+    | '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/$codemodeSessionName'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/new'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/streams/$'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/streams/'
+    | '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -678,6 +694,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRouteImport
       parentRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugRouteRoute
     }
+    '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset': {
+      id: '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset'
+      path: '/new-preset'
+      fullPath: '/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset'
+      preLoaderRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewPresetRouteImport
+      parentRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRoute
+    }
     '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new': {
       id: '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new'
       path: '/new'
@@ -685,30 +708,33 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRouteImport
       parentRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRoute
     }
-    '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/$': {
-      id: '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/$'
-      path: '/$'
-      fullPath: '/orgs/$organizationSlug/projects/$projectSlug/agents/$'
-      preLoaderRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRouteImport
+    '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$': {
+      id: '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$'
+      path: '/streams/$'
+      fullPath: '/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$'
+      preLoaderRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsStreamsSplatRouteImport
       parentRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRoute
     }
   }
 }
 
 interface AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRouteChildren {
-  AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRoute
   AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute
+  AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewPresetRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewPresetRoute
   AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRoute
+  AppOrgsOrganizationSlugProjectsProjectSlugAgentsStreamsSplatRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsStreamsSplatRoute
 }
 
 const AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRouteChildren: AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRouteChildren =
   {
-    AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRoute:
-      AppOrgsOrganizationSlugProjectsProjectSlugAgentsSplatRoute,
     AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute:
       AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute,
+    AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewPresetRoute:
+      AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewPresetRoute,
     AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRoute:
       AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRoute,
+    AppOrgsOrganizationSlugProjectsProjectSlugAgentsStreamsSplatRoute:
+      AppOrgsOrganizationSlugProjectsProjectSlugAgentsStreamsSplatRoute,
   }
 
 const AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRouteWithChildren =

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/index.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/index.tsx
@@ -182,7 +182,20 @@ function ProjectAgentsIndexPage() {
   return (
     <section className="w-full space-y-4 p-4">
       <div className="flex justify-end">
-        <EventsDebugLink label="Open namespace in Events" namespace={project.id} streamPath="/" />
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            onClick={() =>
+              void navigate({
+                to: "/orgs/$organizationSlug/projects/$projectSlug/agents/new",
+                params,
+              })
+            }
+          >
+            New agent
+          </Button>
+          <EventsDebugLink label="Open namespace in Events" namespace={project.id} streamPath="/" />
+        </div>
       </div>
       <form
         className="flex w-full flex-col gap-2 md:flex-row"

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/index.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/index.tsx
@@ -1,13 +1,10 @@
 import { useMemo, useState } from "react";
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Button } from "@iterate-com/ui/components/button";
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@iterate-com/ui/components/empty";
 import { EventsStreamPathLabel } from "@iterate-com/ui/components/events/stream-path-label";
-import { Field, FieldDescription, FieldLabel } from "@iterate-com/ui/components/field";
 import { Input } from "@iterate-com/ui/components/input";
-import { NativeSelect, NativeSelectOption } from "@iterate-com/ui/components/native-select";
-import { toast } from "@iterate-com/ui/components/sonner";
 import {
   Table,
   TableBody,
@@ -16,15 +13,9 @@ import {
   TableHeader,
   TableRow,
 } from "@iterate-com/ui/components/table";
-import { Textarea } from "@iterate-com/ui/components/textarea";
 import { EventsDebugLink } from "~/components/events-debug-link.tsx";
-import {
-  defaultAgentSystemPrompt,
-  normalizeAgentPresetBasePath,
-  type AgentLlmProvider,
-} from "~/domains/agents/agent-presets.ts";
-import { agentPathFromInput, agentPathToSplat } from "~/lib/agent-links.ts";
-import { orpc, orpcClient } from "~/orpc/client.ts";
+import { streamPathToSplat } from "~/lib/stream-links.ts";
+import { orpc } from "~/orpc/client.ts";
 
 export const Route = createFileRoute("/_app/orgs/$organizationSlug/projects/$projectSlug/agents/")({
   loader: async ({ context, params }) => {
@@ -55,14 +46,8 @@ type SortDirection = "asc" | "desc";
 function ProjectAgentsIndexPage() {
   const params = Route.useParams();
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const { project } = Route.useLoaderData();
   const [filter, setFilter] = useState("");
-  const [presetBasePath, setPresetBasePath] = useState("/agents");
-  const [presetProvider, setPresetProvider] = useState<AgentLlmProvider>("openai-ws");
-  const [presetModel, setPresetModel] = useState("gpt-5.5");
-  const [presetSystemPrompt, setPresetSystemPrompt] = useState(defaultAgentSystemPrompt());
-  const [presetRunOpts, setPresetRunOpts] = useState('{"gateway":{"id":"default"}}');
   const [sort, setSort] = useState<{ key: SortKey; direction: SortDirection }>({
     key: "lastWokenAt",
     direction: "desc",
@@ -82,46 +67,6 @@ function ProjectAgentsIndexPage() {
     ...presetsQueryOptions,
     staleTime: 10_000,
   });
-  const createAgent = useMutation({
-    mutationFn: async (input: { agentPath: string; projectSlugOrId: string }) =>
-      await orpcClient.project.agents.runtimeState(input),
-    onSuccess: async (_state, input) => {
-      await queryClient.invalidateQueries({ queryKey: agentsQueryOptions.queryKey });
-      setFilter("");
-      void navigate({
-        to: "/orgs/$organizationSlug/projects/$projectSlug/agents/$",
-        params: {
-          organizationSlug: params.organizationSlug,
-          projectSlug: params.projectSlug,
-          _splat: agentPathToSplat(input.agentPath),
-        },
-      });
-    },
-    onError: (error) => {
-      toast.error(error instanceof Error ? error.message : "Could not create agent.");
-    },
-  });
-  const configurePreset = useMutation({
-    mutationFn: async () => {
-      const basePath = normalizeAgentPresetBasePath(presetBasePath);
-      return await orpcClient.project.agents.configurePreset({
-        basePath,
-        events: [],
-        model: presetModel.trim(),
-        projectSlugOrId: project.id,
-        provider: presetProvider,
-        runOpts: presetProvider === "cloudflare-ai" ? parsePresetRunOpts(presetRunOpts) : {},
-        systemPrompt: presetSystemPrompt.trim(),
-      });
-    },
-    onSuccess: async (result) => {
-      await queryClient.invalidateQueries({ queryKey: presetsQueryOptions.queryKey });
-      toast.success(`Configured ${result.basePath}.`);
-    },
-    onError: (error) => {
-      toast.error(error instanceof Error ? error.message : "Could not configure preset.");
-    },
-  });
   const agents = useMemo(() => data?.agents ?? [], [data?.agents]);
   const presets = useMemo(() => presetsData?.presets ?? [], [presetsData?.presets]);
   const visibleAgents = useMemo(() => {
@@ -139,46 +84,6 @@ function ProjectAgentsIndexPage() {
       });
   }, [agents, filter, sort]);
 
-  function submitCreateAgent() {
-    try {
-      createAgent.mutate({
-        agentPath: agentPathFromInput(filter),
-        projectSlugOrId: project.id,
-      });
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Agent path is invalid.");
-    }
-  }
-
-  function selectPresetProvider(provider: AgentLlmProvider) {
-    setPresetProvider(provider);
-    setPresetModel((current) => {
-      if (provider === "openai-ws" && current === "@cf/meta/llama-3.1-8b-instruct") {
-        return "gpt-5.5";
-      }
-      if (provider === "cloudflare-ai" && current === "gpt-5.5") {
-        return "@cf/meta/llama-3.1-8b-instruct";
-      }
-      return current;
-    });
-  }
-
-  function submitConfigurePreset() {
-    if (presetModel.trim() === "") {
-      toast.error("Model is required.");
-      return;
-    }
-    if (presetSystemPrompt.trim() === "") {
-      toast.error("System prompt is required.");
-      return;
-    }
-    try {
-      configurePreset.mutate();
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Preset is invalid.");
-    }
-  }
-
   return (
     <section className="w-full space-y-4 p-4">
       <div className="flex justify-end">
@@ -194,19 +99,25 @@ function ProjectAgentsIndexPage() {
           >
             New agent
           </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() =>
+              void navigate({
+                to: "/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset",
+                params,
+              })
+            }
+          >
+            New preset
+          </Button>
           <EventsDebugLink label="Open namespace in Events" namespace={project.id} streamPath="/" />
         </div>
       </div>
-      <form
-        className="flex w-full flex-col gap-2 md:flex-row"
-        onSubmit={(event) => {
-          event.preventDefault();
-          submitCreateAgent();
-        }}
-      >
+      <div className="flex w-full flex-col gap-2 md:flex-row">
         <Input
           className="h-9 flex-1"
-          placeholder="Filter or create agent path..."
+          placeholder="Filter agent paths..."
           value={filter}
           onChange={(event) => setFilter(event.currentTarget.value)}
         />
@@ -219,83 +130,17 @@ function ProjectAgentsIndexPage() {
           >
             Reset
           </Button>
-          <Button type="submit" className="flex-1 md:flex-none" disabled={createAgent.isPending}>
-            {createAgent.isPending ? "Creating..." : "Create agent"}
-          </Button>
         </div>
-      </form>
+      </div>
 
-      <form
-        className="space-y-4 rounded-lg border p-4"
-        onSubmit={(event) => {
-          event.preventDefault();
-          submitConfigurePreset();
-        }}
-      >
-        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_14rem_14rem]">
-          <Field>
-            <FieldLabel htmlFor="agent-preset-base-path">Path prefix</FieldLabel>
-            <Input
-              id="agent-preset-base-path"
-              value={presetBasePath}
-              onChange={(event) => setPresetBasePath(event.currentTarget.value)}
-              placeholder="/agents"
-            />
-            <FieldDescription>
-              Inputs such as /alice/bla/ are saved as /agents/alice/bla.
-            </FieldDescription>
-          </Field>
-          <Field>
-            <FieldLabel htmlFor="agent-preset-provider">Provider</FieldLabel>
-            <NativeSelect
-              id="agent-preset-provider"
-              value={presetProvider}
-              onChange={(event) =>
-                selectPresetProvider(event.currentTarget.value as AgentLlmProvider)
-              }
-            >
-              <NativeSelectOption value="openai-ws">OpenAI WebSocket</NativeSelectOption>
-              <NativeSelectOption value="cloudflare-ai">Cloudflare AI Gateway</NativeSelectOption>
-            </NativeSelect>
-          </Field>
-          <Field>
-            <FieldLabel htmlFor="agent-preset-model">Model</FieldLabel>
-            <Input
-              id="agent-preset-model"
-              value={presetModel}
-              onChange={(event) => setPresetModel(event.currentTarget.value)}
-            />
-          </Field>
-        </div>
-        <Field>
-          <FieldLabel htmlFor="agent-preset-system-prompt">System prompt</FieldLabel>
-          <Textarea
-            id="agent-preset-system-prompt"
-            className="min-h-24 font-mono text-xs"
-            value={presetSystemPrompt}
-            onChange={(event) => setPresetSystemPrompt(event.currentTarget.value)}
-          />
-        </Field>
-        {presetProvider === "cloudflare-ai" ? (
-          <Field>
-            <FieldLabel htmlFor="agent-preset-run-opts">Run options JSON</FieldLabel>
-            <Textarea
-              id="agent-preset-run-opts"
-              className="min-h-20 font-mono text-xs"
-              value={presetRunOpts}
-              onChange={(event) => setPresetRunOpts(event.currentTarget.value)}
-            />
-          </Field>
-        ) : null}
+      <div className="space-y-3">
         <div className="flex items-center justify-between gap-3">
-          <div className="min-w-0 text-xs text-muted-foreground">
+          <h2 className="text-sm font-semibold">Presets</h2>
+          <span className="text-xs text-muted-foreground">
             {presets.length === 0
-              ? "No path-prefix presets configured."
-              : `${presets.length} path-prefix preset${presets.length === 1 ? "" : "s"} configured.`}
-          </div>
-          <Button type="submit" disabled={configurePreset.isPending}>
-            {configurePreset.isPending ? "Saving..." : "Save preset"}
-          </Button>
+              ? "No presets configured."
+              : `${presets.length} preset${presets.length === 1 ? "" : "s"} configured.`}
+          </span>
         </div>
         {presets.length > 0 ? (
           <div className="space-y-2">
@@ -312,7 +157,7 @@ function ProjectAgentsIndexPage() {
             ))}
           </div>
         ) : null}
-      </form>
+      </div>
 
       {agents.length === 0 ? (
         <Empty className="rounded-lg border">
@@ -362,11 +207,11 @@ function ProjectAgentsIndexPage() {
                     <TableCell className="min-w-[28rem] py-3">
                       <Link
                         className="block min-w-0 rounded-sm text-sm font-medium hover:underline"
-                        to="/orgs/$organizationSlug/projects/$projectSlug/agents/$"
+                        to="/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$"
                         params={{
                           organizationSlug: params.organizationSlug,
                           projectSlug: params.projectSlug,
-                          _splat: agentPathToSplat(agent.agentPath),
+                          _splat: streamPathToSplat(agent.agentPath),
                         }}
                       >
                         <EventsStreamPathLabel path={agent.agentPath} className="min-w-0" />
@@ -450,16 +295,4 @@ function formatRelativeTime(value: string) {
   const count = Math.round(absoluteSeconds / unit.seconds);
   const suffix = count === 1 ? unit.label : `${unit.label}s`;
   return seconds < 0 ? `in ${count} ${suffix}` : `${count} ${suffix} ago`;
-}
-
-function parsePresetRunOpts(value: string): Record<string, unknown> {
-  try {
-    const parsed = JSON.parse(value);
-    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
-      throw new Error("Run options must be a JSON object.");
-    }
-    return parsed as Record<string, unknown>;
-  } catch {
-    throw new Error("Run options must be valid JSON.");
-  }
 }

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset.tsx
@@ -1,0 +1,313 @@
+import { useCallback, useMemo, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Save } from "lucide-react";
+import { parse as parseYaml } from "yaml";
+import { EventInput, StreamPath } from "@iterate-com/shared/streams/types";
+import { Button } from "@iterate-com/ui/components/button";
+import { Field, FieldDescription, FieldGroup, FieldLabel } from "@iterate-com/ui/components/field";
+import { Input } from "@iterate-com/ui/components/input";
+import { NativeSelect, NativeSelectOption } from "@iterate-com/ui/components/native-select";
+import { SerializedObjectCodeBlock } from "@iterate-com/ui/components/serialized-object-code-block";
+import { toast } from "@iterate-com/ui/components/sonner";
+import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
+import { Textarea } from "@iterate-com/ui/components/textarea";
+import {
+  AgentPresetEvent,
+  type AgentLlmProvider,
+  defaultAgentSetupEvents,
+  defaultAgentSystemPrompt,
+  normalizeAgentPresetBasePath,
+} from "~/domains/agents/agent-presets.ts";
+import { orpc, orpcClient } from "~/orpc/client.ts";
+
+const emptyEventsYaml = "[]\n";
+
+export const Route = createFileRoute(
+  "/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset",
+)({
+  loader: async ({ context, params }) => {
+    const project = await context.queryClient.ensureQueryData({
+      ...orpc.projects.findBySlug.queryOptions({ input: { slug: params.projectSlug } }),
+      staleTime: 30_000,
+    });
+
+    return {
+      breadcrumb: "New Preset",
+      project,
+    };
+  },
+  component: NewAgentPresetPage,
+});
+
+function NewAgentPresetPage() {
+  const params = Route.useParams();
+  const { project } = Route.useLoaderData();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [basePathInput, setBasePathInput] = useState("/agents");
+  const [provider, setProvider] = useState<AgentLlmProvider>("openai-ws");
+  const [model, setModel] = useState("gpt-5.5");
+  const [runOpts, setRunOpts] = useState('{"gateway":{"id":"default"}}');
+  const [systemPrompt, setSystemPrompt] = useState(defaultAgentSystemPrompt());
+  const [customEventsYaml, setCustomEventsYaml] = useState(emptyEventsYaml);
+
+  const preview = useMemo(
+    () =>
+      buildPresetPreview({
+        basePathInput,
+        customEventsYaml,
+        model,
+        provider,
+        runOpts,
+        systemPrompt,
+      }),
+    [basePathInput, customEventsYaml, model, provider, runOpts, systemPrompt],
+  );
+
+  const presetsQueryOptions = orpc.project.agents.listPresets.queryOptions({
+    input: { projectSlugOrId: project.id },
+  });
+  const savePreset = useMutation({
+    mutationFn: async () => {
+      if (preview.error) throw new Error(preview.error);
+      return await orpcClient.project.agents.configurePreset({
+        basePath: preview.basePath,
+        events: preview.customEvents,
+        model: model.trim(),
+        projectSlugOrId: project.id,
+        provider,
+        runOpts: provider === "cloudflare-ai" ? parseRunOpts(runOpts) : {},
+        systemPrompt: systemPrompt.trim(),
+      });
+    },
+    onSuccess: async (result) => {
+      await queryClient.invalidateQueries({ queryKey: presetsQueryOptions.queryKey });
+      toast.success(`Configured ${result.basePath}.`);
+      void navigate({
+        to: "/orgs/$organizationSlug/projects/$projectSlug/agents",
+        params,
+      });
+    },
+    onError: (error) => toast.error(error instanceof Error ? error.message : String(error)),
+  });
+
+  const submit = useCallback(() => {
+    savePreset.mutate();
+  }, [savePreset]);
+
+  function selectProvider(nextProvider: AgentLlmProvider) {
+    setProvider(nextProvider);
+    setModel((current) => {
+      if (nextProvider === "openai-ws" && current === "@cf/meta/llama-3.1-8b-instruct") {
+        return "gpt-5.5";
+      }
+      if (nextProvider === "cloudflare-ai" && current === "gpt-5.5") {
+        return "@cf/meta/llama-3.1-8b-instruct";
+      }
+      return current;
+    });
+  }
+
+  return (
+    <section className="w-full max-w-7xl space-y-4 p-4">
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold">New Agent Preset</h2>
+        <p className="text-sm text-muted-foreground">
+          Assemble the events that will seed matching agent streams.
+        </p>
+      </div>
+
+      <div className="grid min-h-0 gap-4 xl:grid-cols-[minmax(0,0.95fr)_minmax(440px,1.05fr)]">
+        <div className="space-y-4">
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor="agent-preset-base-path">Path prefix</FieldLabel>
+              <Input
+                id="agent-preset-base-path"
+                value={basePathInput}
+                onChange={(event) => setBasePathInput(event.currentTarget.value)}
+                placeholder="/agents"
+              />
+            </Field>
+
+            <div className="grid gap-3 md:grid-cols-[14rem_minmax(0,1fr)]">
+              <Field>
+                <FieldLabel htmlFor="agent-preset-provider">Provider</FieldLabel>
+                <NativeSelect
+                  id="agent-preset-provider"
+                  value={provider}
+                  onChange={(event) =>
+                    selectProvider(event.currentTarget.value as AgentLlmProvider)
+                  }
+                >
+                  <NativeSelectOption value="openai-ws">OpenAI WebSocket</NativeSelectOption>
+                  <NativeSelectOption value="cloudflare-ai">
+                    Cloudflare AI Gateway
+                  </NativeSelectOption>
+                </NativeSelect>
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="agent-preset-model">Model</FieldLabel>
+                <Input
+                  id="agent-preset-model"
+                  value={model}
+                  onChange={(event) => setModel(event.currentTarget.value)}
+                />
+              </Field>
+            </div>
+
+            {provider === "cloudflare-ai" ? (
+              <Field>
+                <FieldLabel htmlFor="agent-preset-run-opts">Run options JSON</FieldLabel>
+                <Textarea
+                  id="agent-preset-run-opts"
+                  className="min-h-20 font-mono text-xs"
+                  value={runOpts}
+                  onChange={(event) => setRunOpts(event.currentTarget.value)}
+                />
+              </Field>
+            ) : null}
+
+            <Field>
+              <FieldLabel htmlFor="agent-preset-system-prompt">System prompt</FieldLabel>
+              <Textarea
+                id="agent-preset-system-prompt"
+                className="min-h-32 font-mono text-xs"
+                value={systemPrompt}
+                onChange={(event) => setSystemPrompt(event.currentTarget.value)}
+              />
+            </Field>
+
+            <Field>
+              <FieldLabel htmlFor="agent-preset-custom-events">Custom events</FieldLabel>
+              <SourceCodeBlock
+                code={customEventsYaml}
+                className="min-h-44"
+                editable
+                language="yaml"
+                onChange={setCustomEventsYaml}
+              />
+              <FieldDescription>
+                YAML array of extra EventInput objects appended after provider setup.
+              </FieldDescription>
+            </Field>
+          </FieldGroup>
+        </div>
+
+        <aside className="min-h-[42rem] space-y-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-1">
+              <p className="text-sm font-semibold">Preset event preview</p>
+              <p className="text-sm text-muted-foreground">
+                YAML preview of events saved for {preview.basePath}.
+              </p>
+            </div>
+            <Button onClick={submit} disabled={savePreset.isPending || preview.error != null}>
+              <Save className="size-4" />
+              {savePreset.isPending ? "Saving..." : "Save preset"}
+            </Button>
+          </div>
+
+          {preview.error ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+              {preview.error}
+            </div>
+          ) : (
+            <SerializedObjectCodeBlock
+              data={preview.events}
+              className="h-[42rem]"
+              initialFormat="yaml"
+              showToggle
+            />
+          )}
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function buildPresetPreview(input: {
+  basePathInput: string;
+  customEventsYaml: string;
+  model: string;
+  provider: AgentLlmProvider;
+  runOpts: string;
+  systemPrompt: string;
+}): {
+  basePath: StreamPath;
+  customEvents: AgentPresetEvent[];
+  error?: string;
+  events: EventInput[];
+} {
+  let basePath = StreamPath.parse("/agents");
+  try {
+    basePath = normalizeAgentPresetBasePath(input.basePathInput);
+    if (input.model.trim() === "") throw new Error("Model is required.");
+    if (input.systemPrompt.trim() === "") throw new Error("System prompt is required.");
+    const customEvents = parseCustomEvents(input.customEventsYaml);
+    const runOpts = input.provider === "cloudflare-ai" ? parseRunOpts(input.runOpts) : {};
+
+    return {
+      basePath,
+      customEvents,
+      events: [
+        ...agentSetupEvents({
+          model: input.model.trim(),
+          provider: input.provider,
+          runOpts,
+          systemPrompt: input.systemPrompt.trim(),
+        }),
+        ...customEvents,
+      ],
+    };
+  } catch (error) {
+    return {
+      basePath,
+      customEvents: [],
+      error: error instanceof Error ? error.message : String(error),
+      events: [],
+    };
+  }
+}
+
+function agentSetupEvents(input: {
+  model: string;
+  provider: AgentLlmProvider;
+  runOpts: Record<string, unknown>;
+  systemPrompt: string;
+}): EventInput[] {
+  return defaultAgentSetupEvents(input.provider).map((event) => ({
+    type: event.type,
+    payload:
+      input.provider === "openai-ws" && event.type === "events.iterate.com/openai-ws/config-updated"
+        ? { model: input.model }
+        : input.provider === "cloudflare-ai" &&
+            event.type === "events.iterate.com/agent/llm-config-updated"
+          ? {
+              debounceMs: 1000,
+              model: input.model,
+              runOpts: input.runOpts,
+            }
+          : event.type === "events.iterate.com/agent/system-prompt-updated"
+            ? { systemPrompt: input.systemPrompt }
+            : event.payload,
+  }));
+}
+
+function parseCustomEvents(value: string) {
+  const parsed = parseYaml(value.trim() || "[]") as unknown;
+  return AgentPresetEvent.array().parse(parsed);
+}
+
+function parseRunOpts(value: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Run options must be a JSON object.");
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    throw new Error("Run options must be valid JSON.");
+  }
+}

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset.tsx
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Save } from "lucide-react";
-import { parse as parseYaml } from "yaml";
 import { EventInput, StreamPath } from "@iterate-com/shared/streams/types";
 import { Button } from "@iterate-com/ui/components/button";
 import { Field, FieldDescription, FieldGroup, FieldLabel } from "@iterate-com/ui/components/field";
@@ -15,9 +14,11 @@ import { Textarea } from "@iterate-com/ui/components/textarea";
 import {
   AgentPresetEvent,
   type AgentLlmProvider,
-  defaultAgentSetupEvents,
+  configuredAgentSetupEvents,
   defaultAgentSystemPrompt,
   normalizeAgentPresetBasePath,
+  parseAgentPresetEventsYaml,
+  parseAgentRunOptsJson,
 } from "~/domains/agents/agent-presets.ts";
 import { orpc, orpcClient } from "~/orpc/client.ts";
 
@@ -77,7 +78,7 @@ function NewAgentPresetPage() {
         model: model.trim(),
         projectSlugOrId: project.id,
         provider,
-        runOpts: provider === "cloudflare-ai" ? parseRunOpts(runOpts) : {},
+        runOpts: provider === "cloudflare-ai" ? parseAgentRunOptsJson(runOpts) : {},
         systemPrompt: systemPrompt.trim(),
       });
     },
@@ -245,14 +246,14 @@ function buildPresetPreview(input: {
     basePath = normalizeAgentPresetBasePath(input.basePathInput);
     if (input.model.trim() === "") throw new Error("Model is required.");
     if (input.systemPrompt.trim() === "") throw new Error("System prompt is required.");
-    const customEvents = parseCustomEvents(input.customEventsYaml);
-    const runOpts = input.provider === "cloudflare-ai" ? parseRunOpts(input.runOpts) : {};
+    const customEvents = parseAgentPresetEventsYaml(input.customEventsYaml);
+    const runOpts = input.provider === "cloudflare-ai" ? parseAgentRunOptsJson(input.runOpts) : {};
 
     return {
       basePath,
       customEvents,
       events: [
-        ...agentSetupEvents({
+        ...configuredAgentSetupEvents({
           model: input.model.trim(),
           provider: input.provider,
           runOpts,
@@ -268,46 +269,5 @@ function buildPresetPreview(input: {
       error: error instanceof Error ? error.message : String(error),
       events: [],
     };
-  }
-}
-
-function agentSetupEvents(input: {
-  model: string;
-  provider: AgentLlmProvider;
-  runOpts: Record<string, unknown>;
-  systemPrompt: string;
-}): EventInput[] {
-  return defaultAgentSetupEvents(input.provider).map((event) => ({
-    type: event.type,
-    payload:
-      input.provider === "openai-ws" && event.type === "events.iterate.com/openai-ws/config-updated"
-        ? { model: input.model }
-        : input.provider === "cloudflare-ai" &&
-            event.type === "events.iterate.com/agent/llm-config-updated"
-          ? {
-              debounceMs: 1000,
-              model: input.model,
-              runOpts: input.runOpts,
-            }
-          : event.type === "events.iterate.com/agent/system-prompt-updated"
-            ? { systemPrompt: input.systemPrompt }
-            : event.payload,
-  }));
-}
-
-function parseCustomEvents(value: string) {
-  const parsed = parseYaml(value.trim() || "[]") as unknown;
-  return AgentPresetEvent.array().parse(parsed);
-}
-
-function parseRunOpts(value: string): Record<string, unknown> {
-  try {
-    const parsed = JSON.parse(value);
-    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
-      throw new Error("Run options must be a JSON object.");
-    }
-    return parsed as Record<string, unknown>;
-  } catch {
-    throw new Error("Run options must be valid JSON.");
   }
 }

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx
@@ -1,0 +1,526 @@
+import { useCallback, useMemo, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Play, RotateCcw } from "lucide-react";
+import { parse as parseYaml } from "yaml";
+import { deriveDurableObjectNameFromStructuredName } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
+import {
+  EventInput,
+  STREAM_SUBSCRIPTION_CONFIGURED_TYPE,
+  StreamPath,
+} from "@iterate-com/shared/streams/types";
+import type { ToolProviderRegistration } from "@iterate-com/shared/stream-processors/codemode/contract";
+import { Button } from "@iterate-com/ui/components/button";
+import { Checkbox } from "@iterate-com/ui/components/checkbox";
+import { Field, FieldDescription, FieldGroup, FieldLabel } from "@iterate-com/ui/components/field";
+import { Input } from "@iterate-com/ui/components/input";
+import { NativeSelect, NativeSelectOption } from "@iterate-com/ui/components/native-select";
+import { SerializedObjectCodeBlock } from "@iterate-com/ui/components/serialized-object-code-block";
+import { toast } from "@iterate-com/ui/components/sonner";
+import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
+import { Textarea } from "@iterate-com/ui/components/textarea";
+import { CodemodeAdHocProviderFields } from "~/components/codemode-session-controls.tsx";
+import {
+  type CodemodeAdHocProviderFieldsValue,
+  buildAdHocProviderInputs,
+  createEmptyAdHocProviderFields,
+} from "~/domains/codemode/ad-hoc-provider-inputs.ts";
+import { createDefaultCodemodeProviderRegistrations } from "~/domains/codemode/default-provider-registrations.ts";
+import { createExampleCapabilityProviders } from "~/domains/codemode/example-provider-registrations.ts";
+import {
+  codemodeProviderRegistrationEvents,
+  providersForCodemodeProviderInputs,
+} from "~/domains/codemode/examples.ts";
+import {
+  type AgentLlmProvider,
+  defaultAgentSetupEvents,
+  defaultAgentSystemPrompt,
+} from "~/domains/agents/agent-presets.ts";
+import { agentPathFromInput } from "~/lib/agent-links.ts";
+import { streamPathToSplat } from "~/lib/stream-links.ts";
+import { orpc, orpcClient } from "~/orpc/client.ts";
+
+const emptyEventsYaml = "[]\n";
+
+export const Route = createFileRoute(
+  "/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new",
+)({
+  loader: async ({ context, params }) => {
+    const project = await context.queryClient.ensureQueryData({
+      ...orpc.projects.findBySlug.queryOptions({ input: { slug: params.projectSlug } }),
+      staleTime: 30_000,
+    });
+
+    return {
+      breadcrumb: "New Agent",
+      project,
+    };
+  },
+  component: NewAgentPage,
+});
+
+type ToolProviderKey = "default" | "rpcTour" | "adHoc";
+
+const toolProviderOptions = [
+  {
+    key: "default",
+    label: "Default runtime tools",
+    description: "fetch, streams, Slack",
+  },
+  {
+    key: "rpcTour",
+    label: "RPC capability tour",
+    description: "Workers AI, repos, workspace, subagents, OS2 oRPC, Slack",
+  },
+  {
+    key: "adHoc",
+    label: "Ad-hoc providers",
+    description: "Outbound MCP and OpenAPI forms below",
+  },
+] satisfies Array<{ description: string; key: ToolProviderKey; label: string }>;
+
+function NewAgentPage() {
+  const params = Route.useParams();
+  const { project } = Route.useLoaderData();
+  const navigate = useNavigate();
+  const [agentPathInput, setAgentPathInput] = useState("assistant");
+  const [provider, setProvider] = useState<AgentLlmProvider>("openai-ws");
+  const [model, setModel] = useState("gpt-5.5");
+  const [runOpts, setRunOpts] = useState('{"gateway":{"id":"default"}}');
+  const [systemPrompt, setSystemPrompt] = useState(defaultAgentSystemPrompt());
+  const [customEventsYaml, setCustomEventsYaml] = useState(emptyEventsYaml);
+  const [selectedToolProviders, setSelectedToolProviders] = useState<Set<ToolProviderKey>>(
+    () => new Set(["default", "rpcTour", "adHoc"]),
+  );
+  const [adHocProviderFields, setAdHocProviderFields] = useState(createEmptyAdHocProviderFields);
+
+  const preview = useMemo(
+    () =>
+      buildPreviewEvents({
+        agentPathInput,
+        adHocProviderFields,
+        customEventsYaml,
+        model,
+        projectId: project.id,
+        provider,
+        runOpts,
+        selectedToolProviders,
+        systemPrompt,
+      }),
+    [
+      adHocProviderFields,
+      agentPathInput,
+      customEventsYaml,
+      model,
+      project.id,
+      provider,
+      runOpts,
+      selectedToolProviders,
+      systemPrompt,
+    ],
+  );
+
+  const createAgent = useMutation({
+    mutationFn: async () => {
+      if (preview.error) throw new Error(preview.error);
+      return await orpcClient.project.streams.appendBatch({
+        events: preview.events,
+        projectSlugOrId: project.id,
+        streamPath: preview.agentPath,
+      });
+    },
+    onSuccess: () => {
+      void navigate({
+        to: "/orgs/$organizationSlug/projects/$projectSlug/streams/$",
+        params: {
+          ...params,
+          _splat: streamPathToSplat(preview.agentPath),
+        },
+      });
+    },
+    onError: (error) => toast.error(error instanceof Error ? error.message : String(error)),
+  });
+
+  const submit = useCallback(() => {
+    createAgent.mutate();
+  }, [createAgent]);
+
+  function selectProvider(nextProvider: AgentLlmProvider) {
+    setProvider(nextProvider);
+    setModel((current) => {
+      if (nextProvider === "openai-ws" && current === "@cf/meta/llama-3.1-8b-instruct") {
+        return "gpt-5.5";
+      }
+      if (nextProvider === "cloudflare-ai" && current === "gpt-5.5") {
+        return "@cf/meta/llama-3.1-8b-instruct";
+      }
+      return current;
+    });
+  }
+
+  function toggleToolProvider(key: ToolProviderKey) {
+    setSelectedToolProviders((current) => {
+      const next = new Set(current);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }
+
+  return (
+    <section className="w-full max-w-7xl space-y-4 p-4">
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold">New Agent</h2>
+        <p className="text-sm text-muted-foreground">
+          Assemble the events that will be appended to the agent stream.
+        </p>
+      </div>
+
+      <div className="grid min-h-0 gap-4 xl:grid-cols-[minmax(0,0.95fr)_minmax(440px,1.05fr)]">
+        <div className="space-y-4">
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor="agent-path">Agent path</FieldLabel>
+              <Input
+                id="agent-path"
+                value={agentPathInput}
+                onChange={(event) => setAgentPathInput(event.currentTarget.value)}
+                placeholder="assistant"
+              />
+              <FieldDescription>
+                Inputs such as alice/bla are saved as /agents/alice/bla.
+              </FieldDescription>
+            </Field>
+
+            <div className="grid gap-3 md:grid-cols-[14rem_minmax(0,1fr)]">
+              <Field>
+                <FieldLabel htmlFor="agent-provider">Provider</FieldLabel>
+                <NativeSelect
+                  id="agent-provider"
+                  value={provider}
+                  onChange={(event) =>
+                    selectProvider(event.currentTarget.value as AgentLlmProvider)
+                  }
+                >
+                  <NativeSelectOption value="openai-ws">OpenAI WebSocket</NativeSelectOption>
+                  <NativeSelectOption value="cloudflare-ai">
+                    Cloudflare AI Gateway
+                  </NativeSelectOption>
+                </NativeSelect>
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="agent-model">Model</FieldLabel>
+                <Input
+                  id="agent-model"
+                  value={model}
+                  onChange={(event) => setModel(event.currentTarget.value)}
+                />
+              </Field>
+            </div>
+
+            {provider === "cloudflare-ai" ? (
+              <Field>
+                <FieldLabel htmlFor="agent-run-opts">Run options JSON</FieldLabel>
+                <Textarea
+                  id="agent-run-opts"
+                  className="min-h-20 font-mono text-xs"
+                  value={runOpts}
+                  onChange={(event) => setRunOpts(event.currentTarget.value)}
+                />
+              </Field>
+            ) : null}
+
+            <Field>
+              <FieldLabel htmlFor="agent-system-prompt">System prompt</FieldLabel>
+              <Textarea
+                id="agent-system-prompt"
+                className="min-h-32 font-mono text-xs"
+                value={systemPrompt}
+                onChange={(event) => setSystemPrompt(event.currentTarget.value)}
+              />
+            </Field>
+
+            <Field>
+              <FieldLabel htmlFor="agent-custom-events">Custom events</FieldLabel>
+              <SourceCodeBlock
+                code={customEventsYaml}
+                className="min-h-44"
+                editable
+                language="yaml"
+                onChange={setCustomEventsYaml}
+              />
+              <FieldDescription>
+                YAML array of EventInput objects appended before tool-provider registrations.
+              </FieldDescription>
+            </Field>
+          </FieldGroup>
+
+          <div className="space-y-3 rounded-lg border bg-card p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div className="space-y-1">
+                <p className="text-sm font-medium">Tool providers</p>
+                <p className="text-sm text-muted-foreground">
+                  Selected providers compile into codemode tool registration events.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setSelectedToolProviders(new Set(["default", "rpcTour", "adHoc"]));
+                  setAdHocProviderFields(createEmptyAdHocProviderFields());
+                }}
+              >
+                <RotateCcw className="size-4" />
+                Reset
+              </Button>
+            </div>
+
+            <div className="grid gap-2">
+              {toolProviderOptions.map((option) => (
+                <label
+                  key={option.key}
+                  className="flex items-start gap-3 rounded-md border p-3 text-sm"
+                >
+                  <Checkbox
+                    checked={selectedToolProviders.has(option.key)}
+                    onCheckedChange={() => toggleToolProvider(option.key)}
+                  />
+                  <span className="min-w-0 space-y-1">
+                    <span className="block font-medium">{option.label}</span>
+                    <span className="block text-muted-foreground">{option.description}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+
+            {selectedToolProviders.has("adHoc") ? (
+              <CodemodeAdHocProviderFields
+                value={adHocProviderFields}
+                onChange={setAdHocProviderFields}
+              />
+            ) : null}
+          </div>
+        </div>
+
+        <aside className="min-h-[42rem] space-y-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-1">
+              <p className="text-sm font-semibold">Event preview</p>
+              <p className="text-sm text-muted-foreground">
+                YAML preview of events appendBatch will append to {preview.agentPath}.
+              </p>
+            </div>
+            <Button onClick={submit} disabled={createAgent.isPending || preview.error != null}>
+              <Play className="size-4" />
+              {createAgent.isPending ? "Creating..." : "Create agent"}
+            </Button>
+          </div>
+
+          {preview.error ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+              {preview.error}
+            </div>
+          ) : (
+            <SerializedObjectCodeBlock
+              data={preview.events}
+              className="h-[42rem]"
+              initialFormat="yaml"
+              showToggle
+            />
+          )}
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function buildPreviewEvents(input: {
+  adHocProviderFields: CodemodeAdHocProviderFieldsValue;
+  agentPathInput: string;
+  customEventsYaml: string;
+  model: string;
+  projectId: string;
+  provider: AgentLlmProvider;
+  runOpts: string;
+  selectedToolProviders: Set<ToolProviderKey>;
+  systemPrompt: string;
+}): { agentPath: StreamPath; error?: string; events: EventInput[] } {
+  let agentPath = StreamPath.parse("/agents/assistant");
+  try {
+    agentPath = agentPathFromInput(input.agentPathInput);
+    if (input.model.trim() === "") throw new Error("Model is required.");
+    if (input.systemPrompt.trim() === "") throw new Error("System prompt is required.");
+    const customEvents = parseCustomEvents(input.customEventsYaml);
+    const runOpts = input.provider === "cloudflare-ai" ? parseRunOpts(input.runOpts) : {};
+    const providers = [
+      ...(input.selectedToolProviders.has("default")
+        ? createDefaultCodemodeProviderRegistrations({
+            projectId: input.projectId,
+            streamPath: agentPath,
+          })
+        : []),
+      ...(input.selectedToolProviders.has("rpcTour")
+        ? createExampleCapabilityProviders({ projectId: input.projectId })
+        : []),
+      createAgentChatToolProvider({
+        agentPath,
+        projectId: input.projectId,
+      }),
+      ...(input.selectedToolProviders.has("adHoc")
+        ? providersForCodemodeProviderInputs({
+            projectId: input.projectId,
+            providers: buildAdHocProviderInputs(input.adHocProviderFields),
+          })
+        : []),
+    ];
+
+    return {
+      agentPath,
+      events: [
+        ...agentSetupEvents({
+          model: input.model.trim(),
+          provider: input.provider,
+          runOpts,
+          systemPrompt: input.systemPrompt.trim(),
+        }),
+        ...customEvents,
+        ...codemodeProviderRegistrationEvents(dedupeToolProviders(providers)),
+        agentSubscriptionConfiguredEvent({
+          agentPath,
+          projectId: input.projectId,
+        }),
+      ],
+    };
+  } catch (error) {
+    return {
+      agentPath,
+      error: error instanceof Error ? error.message : String(error),
+      events: [],
+    };
+  }
+}
+
+function agentSetupEvents(input: {
+  model: string;
+  provider: AgentLlmProvider;
+  runOpts: Record<string, unknown>;
+  systemPrompt: string;
+}): EventInput[] {
+  return defaultAgentSetupEvents(input.provider).map((event, index) => ({
+    idempotencyKey: `os2-agent-new:setup:${index}:${event.type}`,
+    type: event.type,
+    payload:
+      input.provider === "openai-ws" && event.type === "events.iterate.com/openai-ws/config-updated"
+        ? { model: input.model }
+        : input.provider === "cloudflare-ai" &&
+            event.type === "events.iterate.com/agent/llm-config-updated"
+          ? {
+              debounceMs: 1000,
+              model: input.model,
+              runOpts: input.runOpts,
+            }
+          : event.type === "events.iterate.com/agent/system-prompt-updated"
+            ? { systemPrompt: input.systemPrompt }
+            : event.payload,
+  }));
+}
+
+function agentSubscriptionConfiguredEvent(input: {
+  agentPath: StreamPath;
+  projectId: string;
+}): EventInput {
+  const durableObjectName = deriveDurableObjectNameFromStructuredName({
+    structuredName: {
+      agentPath: input.agentPath,
+      projectId: input.projectId,
+    },
+  });
+  return {
+    idempotencyKey: `stream-processor-websocket-subscription:AGENT:${durableObjectName}:${input.agentPath}:agent:${input.projectId}:${input.agentPath}`,
+    type: STREAM_SUBSCRIPTION_CONFIGURED_TYPE,
+    payload: {
+      slug: `agent:${input.projectId}:${input.agentPath}`,
+      type: "websocket",
+      callable: {
+        type: "fetch",
+        via: {
+          type: "env-binding",
+          bindingType: "durable-object-namespace",
+          bindingName: "AGENT",
+          durableObject: {
+            name: durableObjectName,
+          },
+        },
+        fetchRequest: {
+          path: {
+            base: "/stream-subscription",
+            mode: "replace",
+          },
+        },
+      },
+    },
+  };
+}
+
+function createAgentChatToolProvider(input: {
+  agentPath: StreamPath;
+  projectId: string;
+}): ToolProviderRegistration {
+  return {
+    path: ["chat"],
+    instructions:
+      "Use ctx.chat.sendMessage({ message }) to send a visible response to the user. Prefer this over appending chat events manually.",
+    invocation: {
+      kind: "rpc",
+      callable: {
+        type: "workers-rpc",
+        via: {
+          type: "env-binding",
+          bindingType: "durable-object-namespace",
+          bindingName: "AGENT",
+          durableObject: {
+            name: deriveDurableObjectNameFromStructuredName({
+              structuredName: {
+                agentPath: input.agentPath,
+                projectId: input.projectId,
+              },
+            }),
+          },
+        },
+        rpcMethod: "executeCodemodeFunctionCall",
+        argsMode: "object",
+      },
+    },
+  };
+}
+
+function dedupeToolProviders(providers: ToolProviderRegistration[]) {
+  const byPath = new Map<string, ToolProviderRegistration>();
+  for (const provider of providers) {
+    const key = provider.path.join("/");
+    if (!byPath.has(key)) byPath.set(key, provider);
+  }
+  return [...byPath.values()];
+}
+
+function parseCustomEvents(value: string) {
+  const parsed = parseYaml(value.trim() || "[]") as unknown;
+  return EventInput.array().parse(parsed);
+}
+
+function parseRunOpts(value: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Run options must be a JSON object.");
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    throw new Error("Run options must be valid JSON.");
+  }
+}

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx
@@ -281,9 +281,11 @@ function NewAgentPage() {
               {toolProviderOptions.map((option) => (
                 <label
                   key={option.key}
+                  htmlFor={`agent-tool-provider-${option.key}`}
                   className="flex items-start gap-3 rounded-md border p-3 text-sm"
                 >
                   <Checkbox
+                    id={`agent-tool-provider-${option.key}`}
                     checked={selectedToolProviders.has(option.key)}
                     onCheckedChange={() => toggleToolProvider(option.key)}
                   />

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx
@@ -83,7 +83,7 @@ function NewAgentPage() {
   const params = Route.useParams();
   const { project } = Route.useLoaderData();
   const navigate = useNavigate();
-  const [agentPathInput, setAgentPathInput] = useState("assistant");
+  const [agentPathInput, setAgentPathInput] = useState("/agents/assistant");
   const [provider, setProvider] = useState<AgentLlmProvider>("openai-ws");
   const [model, setModel] = useState("gpt-5.5");
   const [runOpts, setRunOpts] = useState('{"gateway":{"id":"default"}}');
@@ -131,7 +131,7 @@ function NewAgentPage() {
     },
     onSuccess: () => {
       void navigate({
-        to: "/orgs/$organizationSlug/projects/$projectSlug/streams/$",
+        to: "/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$",
         params: {
           ...params,
           _splat: streamPathToSplat(preview.agentPath),
@@ -188,11 +188,8 @@ function NewAgentPage() {
                 id="agent-path"
                 value={agentPathInput}
                 onChange={(event) => setAgentPathInput(event.currentTarget.value)}
-                placeholder="assistant"
+                placeholder="/agents/assistant"
               />
-              <FieldDescription>
-                Inputs such as alice/bla are saved as /agents/alice/bla.
-              </FieldDescription>
             </Field>
 
             <div className="grid gap-3 md:grid-cols-[14rem_minmax(0,1fr)]">

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Play, RotateCcw } from "lucide-react";
-import { parse as parseYaml } from "yaml";
 import { deriveDurableObjectNameFromStructuredName } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
 import {
   EventInput,
@@ -33,8 +32,10 @@ import {
 } from "~/domains/codemode/examples.ts";
 import {
   type AgentLlmProvider,
-  defaultAgentSetupEvents,
+  configuredAgentSetupEvents,
   defaultAgentSystemPrompt,
+  parseAgentEventInputsYaml,
+  parseAgentRunOptsJson,
 } from "~/domains/agents/agent-presets.ts";
 import { agentPathFromInput } from "~/lib/agent-links.ts";
 import { streamPathToSplat } from "~/lib/stream-links.ts";
@@ -354,8 +355,8 @@ function buildPreviewEvents(input: {
     agentPath = agentPathFromInput(input.agentPathInput);
     if (input.model.trim() === "") throw new Error("Model is required.");
     if (input.systemPrompt.trim() === "") throw new Error("System prompt is required.");
-    const customEvents = parseCustomEvents(input.customEventsYaml);
-    const runOpts = input.provider === "cloudflare-ai" ? parseRunOpts(input.runOpts) : {};
+    const customEvents = parseAgentEventInputsYaml(input.customEventsYaml);
+    const runOpts = input.provider === "cloudflare-ai" ? parseAgentRunOptsJson(input.runOpts) : {};
     const providers = [
       ...(input.selectedToolProviders.has("default")
         ? createDefaultCodemodeProviderRegistrations({
@@ -381,7 +382,8 @@ function buildPreviewEvents(input: {
     return {
       agentPath,
       events: [
-        ...agentSetupEvents({
+        ...configuredAgentSetupEvents({
+          idempotencyKeyPrefix: "os2-agent-new:setup",
           model: input.model.trim(),
           provider: input.provider,
           runOpts,
@@ -402,31 +404,6 @@ function buildPreviewEvents(input: {
       events: [],
     };
   }
-}
-
-function agentSetupEvents(input: {
-  model: string;
-  provider: AgentLlmProvider;
-  runOpts: Record<string, unknown>;
-  systemPrompt: string;
-}): EventInput[] {
-  return defaultAgentSetupEvents(input.provider).map((event, index) => ({
-    idempotencyKey: `os2-agent-new:setup:${index}:${event.type}`,
-    type: event.type,
-    payload:
-      input.provider === "openai-ws" && event.type === "events.iterate.com/openai-ws/config-updated"
-        ? { model: input.model }
-        : input.provider === "cloudflare-ai" &&
-            event.type === "events.iterate.com/agent/llm-config-updated"
-          ? {
-              debounceMs: 1000,
-              model: input.model,
-              runOpts: input.runOpts,
-            }
-          : event.type === "events.iterate.com/agent/system-prompt-updated"
-            ? { systemPrompt: input.systemPrompt }
-            : event.payload,
-  }));
 }
 
 function agentSubscriptionConfiguredEvent(input: {
@@ -505,21 +482,4 @@ function dedupeToolProviders(providers: ToolProviderRegistration[]) {
     if (!byPath.has(key)) byPath.set(key, provider);
   }
   return [...byPath.values()];
-}
-
-function parseCustomEvents(value: string) {
-  const parsed = parseYaml(value.trim() || "[]") as unknown;
-  return EventInput.array().parse(parsed);
-}
-
-function parseRunOpts(value: string): Record<string, unknown> {
-  try {
-    const parsed = JSON.parse(value);
-    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
-      throw new Error("Run options must be a JSON object.");
-    }
-    return parsed as Record<string, unknown>;
-  } catch {
-    throw new Error("Run options must be valid JSON.");
-  }
 }

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$.tsx
@@ -1,40 +1,40 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ProjectStreamView } from "~/components/project-stream-view.tsx";
-import { agentPathFromSplat } from "~/lib/agent-links.ts";
+import { streamPathFromSplat } from "~/lib/stream-links.ts";
 import { orpc } from "~/orpc/client.ts";
 
-export const Route = createFileRoute("/_app/orgs/$organizationSlug/projects/$projectSlug/agents/$")(
-  {
-    ssr: false,
-    loader: async ({ context, params }) => {
-      const agentPath = agentPathFromSplat(params._splat);
-      const project = await context.queryClient.ensureQueryData({
-        ...orpc.projects.findBySlug.queryOptions({ input: { slug: params.projectSlug } }),
-        staleTime: 30_000,
-      });
-      await context.queryClient.ensureQueryData({
-        ...orpc.project.agents.runtimeState.queryOptions({
-          input: { agentPath, projectSlugOrId: project.id },
-        }),
-        staleTime: 5_000,
-      });
+export const Route = createFileRoute(
+  "/_app/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$",
+)({
+  ssr: false,
+  loader: async ({ context, params }) => {
+    const agentPath = streamPathFromSplat(params._splat);
+    const project = await context.queryClient.ensureQueryData({
+      ...orpc.projects.findBySlug.queryOptions({ input: { slug: params.projectSlug } }),
+      staleTime: 30_000,
+    });
+    await context.queryClient.ensureQueryData({
+      ...orpc.project.agents.runtimeState.queryOptions({
+        input: { agentPath, projectSlugOrId: project.id },
+      }),
+      staleTime: 5_000,
+    });
 
-      return {
-        breadcrumb: agentPath,
-        project,
+    return {
+      breadcrumb: agentPath,
+      project,
+      streamPath: agentPath,
+      streamBreadcrumb: {
+        organizationSlug: params.organizationSlug,
+        projectId: project.id,
+        projectSlug: params.projectSlug,
         streamPath: agentPath,
-        streamBreadcrumb: {
-          organizationSlug: params.organizationSlug,
-          projectId: project.id,
-          projectSlug: params.projectSlug,
-          streamPath: agentPath,
-        },
-      };
-    },
-    component: ProjectAgentDetailPage,
+      },
+    };
   },
-);
+  component: ProjectAgentDetailPage,
+});
 
 function ProjectAgentDetailPage() {
   const params = Route.useParams();

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/index.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/index.tsx
@@ -123,7 +123,7 @@ function ProjectsIndexPage() {
       <div className="space-y-1">
         <h2 className="text-sm font-semibold">Projects</h2>
         <p className="text-sm text-muted-foreground">
-          CRUD backed by sqlfu + D1, with type IDs and JSON metadata.
+          Create projects and manage their routing metadata.
         </p>
       </div>
 

--- a/apps/os2/tasks/codemode-session-night-plan.md
+++ b/apps/os2/tasks/codemode-session-night-plan.md
@@ -94,7 +94,7 @@ End state for this slice:
 4. A script can call a bridge-backed Tool Function through `ctx.provider.fn()`.
 5. A provider can call another provider through the same Codemode Session
    Capability.
-6. Inbound MCP `run_code` can start a Script Execution on a Codemode Session
+6. Inbound MCP `exec_js` can start a Script Execution on a Codemode Session
    using the MCP session's existing Event Stream Path.
 7. Outbound MCP client connections can be registered as Tool Providers without
    confusing them with inbound MCP server sessions.
@@ -244,12 +244,12 @@ input.
 Questions to resolve:
 
 - Does each inbound MCP session map to one Codemode Session?
-- Does each `run_code` tool call create only a new Script Execution on that
+- Does each `exec_js` tool call create only a new Script Execution on that
   Codemode Session?
 - How does the Project MCP Endpoint resolve the stable Project ID from the request route?
   Resolved: route slugs identify the Project route; the handler looks up the
   Project row and initializes CodemodeSession with stable `project.id`.
-- Should MCP `run_code` return final text only, event offsets, the Event Stream
+- Should MCP `exec_js` return final text only, event offsets, the Event Stream
   Path, or a combination?
 - Should MCP expose tools to register Provider Descriptors, or should provider
   setup be Project/session state managed elsewhere?
@@ -344,5 +344,5 @@ These are intentionally ordered so each answer narrows later work.
 - [ ] Add explicit codemode event schemas.
 - [ ] Add runtime limit/cycle tests.
 - [ ] Wire browser Run Code route to explicit Codemode Session creation/selection.
-- [ ] Move inbound MCP `run_code` onto the MCP-session Event Stream Path.
+- [ ] Move inbound MCP `exec_js` onto the MCP-session Event Stream Path.
 - [ ] Delete or deprecate compatibility `codemode.execute`.

--- a/packages/shared/src/streams/helpers.ts
+++ b/packages/shared/src/streams/helpers.ts
@@ -31,6 +31,7 @@ export type StreamDurableObjectName = {
 export type StreamDurableObjectStub = {
   initialize(params: { name: string }): Promise<unknown>;
   append(event: EventInput): Promise<Event>;
+  appendBatch(events: EventInput[]): Promise<Event[]>;
   destroy(args?: { destroyChildren?: boolean }): Promise<DestroyStreamResult>;
   history(args?: { after?: StreamCursor; before?: StreamCursor }): Promise<Event[]>;
   historyIfInitialized(args?: { after?: StreamCursor; before?: StreamCursor }): Promise<Event[]>;

--- a/packages/shared/src/streams/stream-durable-object.ts
+++ b/packages/shared/src/streams/stream-durable-object.ts
@@ -264,6 +264,14 @@ export class StreamDurableObject extends StreamDurableObjectBase<StreamDurableOb
     return event;
   }
 
+  async appendBatch(inputEvents: EventInput[]): Promise<Event[]> {
+    const events: Event[] = [];
+    for (const inputEvent of inputEvents) {
+      events.push(await this.append(inputEvent));
+    }
+    return events;
+  }
+
   /**
    * Validate-or-throw boundary. Enforces core invariants and runs builtin
    * processor gates before any state mutation occurs:

--- a/packages/shared/src/streams/stream-durable-object.ts
+++ b/packages/shared/src/streams/stream-durable-object.ts
@@ -235,7 +235,7 @@ export class StreamDurableObject extends StreamDurableObjectBase<StreamDurableOb
       }
     }
 
-    const nextOffset = this.beforeAppend(input);
+    const nextOffset = this.beforeAppend(input, this.state);
 
     const event = {
       streamPath: this.state.path,
@@ -244,7 +244,7 @@ export class StreamDurableObject extends StreamDurableObjectBase<StreamDurableOb
       createdAt: new Date().toISOString(),
     };
 
-    const nextState = this.reduce(event);
+    const nextState = this.reduce(this.state, event);
 
     this.client.transaction((tx) => {
       insertEvent(tx, {
@@ -265,10 +265,62 @@ export class StreamDurableObject extends StreamDurableObjectBase<StreamDurableOb
   }
 
   async appendBatch(inputEvents: EventInput[]): Promise<Event[]> {
+    const inputs = inputEvents.map((inputEvent) => EventInput.parse(inputEvent));
     const events: Event[] = [];
-    for (const inputEvent of inputEvents) {
-      events.push(await this.append(inputEvent));
+    const newEvents: Event[] = [];
+    const newEventsByIdempotencyKey = new Map<string, Event>();
+
+    this.ensureInitializedStreamStorage();
+    let nextState = this.state;
+
+    for (const input of inputs) {
+      if (input.idempotencyKey != null) {
+        const existingEvent =
+          newEventsByIdempotencyKey.get(input.idempotencyKey) ??
+          this.getEventByIdempotencyKey(input.idempotencyKey);
+        if (existingEvent != null) {
+          events.push(existingEvent);
+          continue;
+        }
+      }
+
+      const nextOffset = this.beforeAppend(input, nextState);
+      const event = {
+        streamPath: nextState.path,
+        ...input,
+        offset: nextOffset,
+        createdAt: new Date().toISOString(),
+      };
+
+      nextState = this.reduce(nextState, event);
+      events.push(event);
+      newEvents.push(event);
+      if (event.idempotencyKey != null) {
+        newEventsByIdempotencyKey.set(event.idempotencyKey, event);
+      }
     }
+
+    if (newEvents.length === 0) return events;
+
+    this.client.transaction((tx) => {
+      for (const event of newEvents) {
+        insertEvent(tx, {
+          offset: event.offset,
+          type: event.type,
+          payload: JSON.stringify(event.payload),
+          metadata: event.metadata === undefined ? null : JSON.stringify(event.metadata),
+          idempotencyKey: event.idempotencyKey ?? null,
+          createdAt: event.createdAt,
+        });
+      }
+      upsertReducedState(tx, { json: JSON.stringify(nextState) });
+    });
+    this._state = nextState;
+
+    for (const event of newEvents) {
+      this.afterAppend(event);
+    }
+
     return events;
   }
 
@@ -283,12 +335,12 @@ export class StreamDurableObject extends StreamDurableObjectBase<StreamDurableOb
    * before this method is called — by the time we get here, the input is
    * known to be a genuinely new event.
    */
-  private beforeAppend(input: EventInput): number {
-    if (input.type === STREAM_FIRST_INITIALIZED_TYPE && this.state.eventCount > 0) {
+  private beforeAppend(input: EventInput, state: StreamState): number {
+    if (input.type === STREAM_FIRST_INITIALIZED_TYPE && state.eventCount > 0) {
       throw new Error("stream-initialized may only be appended once");
     }
 
-    const nextOffset = this.state.eventCount + 1;
+    const nextOffset = state.eventCount + 1;
 
     if (input.offset != null && input.offset !== nextOffset) {
       throw new StreamOffsetPreconditionError(
@@ -299,12 +351,12 @@ export class StreamDurableObject extends StreamDurableObjectBase<StreamDurableOb
     assertValidCoreEventInput({
       input,
       nextOffset,
-      streamPath: this.state.path,
+      streamPath: state.path,
     });
 
     runBuiltinBeforeAppend({
       event: input,
-      processors: this.state.processors,
+      processors: state.processors,
     });
 
     return nextOffset;
@@ -319,15 +371,15 @@ export class StreamDurableObject extends StreamDurableObjectBase<StreamDurableOb
    * mirrors the processor `reduce` hook but for the privileged top-level
    * fields that are not modeled as processor state.
    */
-  private reduce(event: Event): StreamState {
-    if (this.state.path !== event.streamPath) {
+  private reduce(state: StreamState, event: Event): StreamState {
+    if (state.path !== event.streamPath) {
       throw new Error(
-        `This should never happen. Somebody is trying to append an event to the wrong stream. Stream has path ${this.state.path}, but the event has path ${event.streamPath}.`,
+        `This should never happen. Somebody is trying to append an event to the wrong stream. Stream has path ${state.path}, but the event has path ${event.streamPath}.`,
       );
     }
 
     let nextState = reduceStreamCore({
-      state: this.state,
+      state,
       event,
     });
 

--- a/packages/ui/src/components/events/README.md
+++ b/packages/ui/src/components/events/README.md
@@ -54,13 +54,12 @@ Current primary reducers:
   feed item. Consecutive unsupported events with the same type may collapse into
   a grouped summary only when each event produced no other feed item, but the
   group keeps every raw event for inspector navigation.
+- `prettyEventsStreamViewReducer` emits the same semantic feed elements without
+  grouped raw event rows.
 - `rawJsonDumpEventsStreamViewReducer` emits one `raw-json-dump` item.
 
-`rawEventsStreamViewReducer` and `prettyEventsStreamViewReducer` may remain as
-debugging helpers while the UI settles, but they are not the target product
-shape and should not appear in the visible renderer-mode controls. If an old
-clean-renderer link carries `renderer=raw` or `renderer=pretty`, the clean view
-falls back to `raw-pretty`.
+`rawEventsStreamViewReducer` remains a helper for terminal/debug clients and is
+not exposed in the browser renderer-mode controls.
 
 All reducers also share small cross-slot projections:
 

--- a/packages/ui/src/components/events/feed-element-renderers/grouped-raw-event-line.tsx
+++ b/packages/ui/src/components/events/feed-element-renderers/grouped-raw-event-line.tsx
@@ -23,6 +23,9 @@ export function GroupedRawEventLine({
   return (
     <div className="flex justify-end">
       <RawEventLineFrame>
+        <RawEventInspectButton onClick={openFirstEvent} className="shrink-0 tabular-nums">
+          #{firstOffset}
+        </RawEventInspectButton>
         <RawEventTypeInspectButton type={element.props.eventType} onClick={openFirstEvent} />
         {showCount ? (
           <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px]">

--- a/packages/ui/src/components/events/feed-items.ts
+++ b/packages/ui/src/components/events/feed-items.ts
@@ -386,6 +386,7 @@ export type EventsStreamSlotName = keyof EventsStreamSlots;
  * the event log, then project them into slots.
  */
 export type EventsStreamActivityState = {
+  eventCount: number;
   currentLlmRequestId: string | null;
   latestStreamError: {
     message: string;

--- a/packages/ui/src/components/events/feed-processors.ts
+++ b/packages/ui/src/components/events/feed-processors.ts
@@ -168,10 +168,6 @@ function createEventsStreamViewReducer(args: {
       });
       const activity = reduceActivityState({ event, state });
 
-      if (feedItems === state.slots.feed && activity === state.activity) {
-        return undefined;
-      }
-
       return createEventsStreamViewState({ feed: feedItems, activity });
     },
   };

--- a/packages/ui/src/components/events/feed-processors.ts
+++ b/packages/ui/src/components/events/feed-processors.ts
@@ -35,7 +35,7 @@ const CODEMODE_SCRIPT_EXECUTION_COMPLETED_TYPE =
  * "raw-pretty" is the default interleaved view; "raw-single-json" dumps every
  * event as a single YAML/JSON block.
  */
-export const eventsStreamRendererModes = ["raw-pretty", "raw-single-json"] as const;
+export const eventsStreamRendererModes = ["raw-pretty", "pretty", "raw-single-json"] as const;
 export type EventsStreamRendererMode = (typeof eventsStreamRendererModes)[number];
 
 export const eventsStreamRendererModeOptions: ReadonlyArray<{
@@ -43,6 +43,7 @@ export const eventsStreamRendererModeOptions: ReadonlyArray<{
   label: string;
 }> = [
   { value: "raw-pretty", label: "Raw + Pretty" },
+  { value: "pretty", label: "Pretty" },
   { value: "raw-single-json", label: "Raw YAML" },
 ];
 
@@ -52,6 +53,8 @@ export function selectEventsStreamViewReducer(
   switch (mode) {
     case "raw-pretty":
       return rawPrettyEventsStreamViewReducer;
+    case "pretty":
+      return prettyEventsStreamViewReducer;
     case "raw-single-json":
       return rawJsonDumpEventsStreamViewReducer;
   }
@@ -61,6 +64,7 @@ function createInitialEventsStreamViewState(): EventsStreamViewState {
   return createEventsStreamViewState({
     feed: [],
     activity: {
+      eventCount: 0,
       currentLlmRequestId: null,
       latestStreamError: null,
     },
@@ -73,7 +77,7 @@ function createEventsStreamViewState(args: {
 }): EventsStreamViewState {
   const slots = {
     feed: args.feed,
-    header: createHeaderSlotElements({ activity: args.activity, feed: args.feed }),
+    header: createHeaderSlotElements(args.activity),
     input: createInputSlotElements(args.activity),
   };
 
@@ -173,12 +177,11 @@ function createEventsStreamViewReducer(args: {
   };
 }
 
-function createHeaderSlotElements(args: {
-  activity: EventsStreamViewState["activity"];
-  feed: readonly EventsStreamBuiltInElement[];
-}): EventsStreamBuiltInElement[] {
+function createHeaderSlotElements(
+  activity: EventsStreamViewState["activity"],
+): EventsStreamBuiltInElement[] {
   const elements: EventsStreamBuiltInElement[] = [];
-  const eventCount = countRawEventsInFeed(args.feed);
+  const eventCount = activity.eventCount;
 
   if (eventCount > 0) {
     elements.push({
@@ -190,36 +193,19 @@ function createHeaderSlotElements(args: {
     });
   }
 
-  if (args.activity.currentLlmRequestId != null) {
+  if (activity.currentLlmRequestId != null) {
     elements.push({
       type: "activity",
       id: "activity",
       props: {
         status: "working",
         label: "Agent working",
-        detail: args.activity.currentLlmRequestId,
+        detail: activity.currentLlmRequestId,
       },
     });
   }
 
   return elements;
-}
-
-function countRawEventsInFeed(elements: readonly EventsStreamBuiltInElement[]) {
-  let count = 0;
-
-  for (const element of elements) {
-    if (element.type === "grouped-raw-event") {
-      count += element.props.count;
-      continue;
-    }
-
-    if (element.type === "raw-json-dump") {
-      count += element.props.events.length;
-    }
-  }
-
-  return count;
 }
 
 function createInputSlotElements(
@@ -291,11 +277,16 @@ function reduceActivityState(args: {
   event: Event;
   state: EventsStreamViewState;
 }): EventsStreamViewState["activity"] {
+  const activity = {
+    ...args.state.activity,
+    eventCount: args.state.activity.eventCount + 1,
+  };
+
   if (args.event.type === STREAM_ERROR_OCCURRED_TYPE) {
     const message = readStringPayloadField(args.event, "message") ?? "Stream error";
 
     return {
-      ...args.state.activity,
+      ...activity,
       latestStreamError: {
         message,
         offset: args.event.offset,
@@ -308,13 +299,13 @@ function reduceActivityState(args: {
 
   if (args.event.type === AGENT_LLM_REQUEST_REQUESTED_TYPE) {
     return {
-      ...args.state.activity,
+      ...activity,
       currentLlmRequestId: String(llmRequestId ?? args.event.offset),
     };
   }
 
   if (requestId == null && llmRequestId == null) {
-    return args.state.activity;
+    return activity;
   }
 
   const currentRequestId = requestId ?? String(llmRequestId);
@@ -323,10 +314,10 @@ function reduceActivityState(args: {
     (args.event.type === AGENT_LLM_REQUEST_COMPLETED_TYPE ||
       args.event.type === AGENT_LLM_REQUEST_CANCELLED_TYPE)
   ) {
-    return { ...args.state.activity, currentLlmRequestId: null };
+    return { ...activity, currentLlmRequestId: null };
   }
 
-  return args.state.activity;
+  return activity;
 }
 
 function reduceEventToSemanticFeedItems(event: Event): EventsStreamBuiltInElement[] {

--- a/packages/ui/src/components/events/stream-composer.tsx
+++ b/packages/ui/src/components/events/stream-composer.tsx
@@ -2,45 +2,144 @@ import {
   PromptInput,
   PromptInputBody,
   PromptInputFooter,
+  PromptInputSelect,
+  PromptInputSelectContent,
+  PromptInputSelectItem,
+  PromptInputSelectTrigger,
   PromptInputSubmit,
   PromptInputTextarea,
+  PromptInputTools,
 } from "@iterate-com/ui/components/ai-elements/prompt-input";
+import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
+import { Tabs, TabsList, TabsTrigger } from "@iterate-com/ui/components/tabs";
 
 /**
- * Minimal stream composer for hosts that only need to append one user message.
+ * Minimal stream composer for hosts that need message and/or raw event input.
  *
  * The events app keeps its richer JSON/YAML/template composer locally. This
- * package component is intentionally just the shared chat affordance.
+ * package component is intentionally a controlled, lightweight shared affordance.
  */
-export function EventsStreamComposer({
-  value,
-  onValueChange,
-  onSubmit,
-  isSubmitting = false,
-  placeholder = "Message this stream",
-}: {
+export type EventsStreamComposerMode = "message" | "raw";
+
+export type EventsStreamComposerRawPreset = {
+  id: string;
+  label: string;
+  value: string;
+};
+
+export type EventsStreamComposerMessageConfig = {
   value: string;
   onValueChange: (value: string) => void;
   onSubmit: () => void | Promise<void>;
-  isSubmitting?: boolean;
   placeholder?: string;
+};
+
+export type EventsStreamComposerRawConfig = {
+  value: string;
+  onValueChange: (value: string) => void;
+  onSubmit: () => void | Promise<void>;
+  presets?: readonly EventsStreamComposerRawPreset[];
+  selectedPresetId?: string;
+  onSelectedPresetIdChange?: (presetId: string) => void;
+};
+
+export function EventsStreamComposer({
+  mode,
+  onModeChange,
+  message,
+  raw,
+  isSubmitting = false,
+}: {
+  mode: EventsStreamComposerMode;
+  onModeChange?: (mode: EventsStreamComposerMode) => void;
+  message?: EventsStreamComposerMessageConfig;
+  raw?: EventsStreamComposerRawConfig;
+  isSubmitting?: boolean;
 }) {
+  const availableModes = [
+    ...(message == null ? [] : (["message"] satisfies EventsStreamComposerMode[])),
+    ...(raw == null ? [] : (["raw"] satisfies EventsStreamComposerMode[])),
+  ];
+  const activeMode = availableModes.includes(mode) ? mode : availableModes[0];
+  const selectedRawPreset =
+    raw?.presets?.find((preset) => preset.id === raw.selectedPresetId) ?? raw?.presets?.[0];
+  const activeValue = activeMode === "raw" ? raw?.value : message?.value;
+  const activeSubmit = activeMode === "raw" ? raw?.onSubmit : message?.onSubmit;
+
+  if (activeMode == null || activeSubmit == null || activeValue == null) {
+    return null;
+  }
+
+  const submit = () => {
+    void activeSubmit();
+  };
+
   return (
-    <PromptInput className="relative w-full" onSubmit={onSubmit}>
+    <PromptInput className="relative w-full" onSubmit={submit}>
       <PromptInputBody>
-        <PromptInputTextarea
-          value={value}
-          onChange={(event) => onValueChange(event.currentTarget.value)}
-          placeholder={placeholder}
-          className="min-h-11 max-h-[35vh] text-sm leading-5"
-        />
+        {activeMode === "raw" && raw != null ? (
+          <SourceCodeBlock
+            code={raw.value}
+            language="yaml"
+            editable
+            onChange={raw.onValueChange}
+            onModEnter={raw.onSubmit}
+            showCopyButton={false}
+            className="min-h-36 max-h-[35vh] w-full"
+          />
+        ) : message != null ? (
+          <PromptInputTextarea
+            value={message.value}
+            onChange={(event) => message.onValueChange(event.currentTarget.value)}
+            placeholder={message.placeholder ?? "Message this stream"}
+            className="min-h-11 max-h-[35vh] text-sm leading-5"
+          />
+        ) : null}
       </PromptInputBody>
-      <PromptInputFooter className="justify-end border-t p-2.5">
+      <PromptInputFooter className="items-center justify-between gap-2 border-t p-2.5">
+        <PromptInputTools className="min-w-0 flex-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            {availableModes.length > 1 ? (
+              <Tabs
+                value={activeMode}
+                onValueChange={(value) => onModeChange?.(value as EventsStreamComposerMode)}
+              >
+                <TabsList className="h-8">
+                  <TabsTrigger value="message" className="px-2 text-xs">
+                    Message
+                  </TabsTrigger>
+                  <TabsTrigger value="raw" className="px-2 text-xs">
+                    Raw
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
+            ) : null}
+
+            {activeMode === "raw" && raw?.presets != null && raw.presets.length > 0 ? (
+              <PromptInputSelect
+                value={selectedRawPreset?.id}
+                onValueChange={(value) => raw.onSelectedPresetIdChange?.(value as string)}
+              >
+                <PromptInputSelectTrigger className="h-8 max-w-full min-w-0 text-xs sm:max-w-[18rem]">
+                  <span className="truncate">{selectedRawPreset?.label ?? "Event preset"}</span>
+                </PromptInputSelectTrigger>
+                <PromptInputSelectContent align="start" className="w-fit">
+                  {raw.presets.map((preset) => (
+                    <PromptInputSelectItem key={preset.id} value={preset.id}>
+                      {preset.label}
+                    </PromptInputSelectItem>
+                  ))}
+                </PromptInputSelectContent>
+              </PromptInputSelect>
+            ) : null}
+          </div>
+        </PromptInputTools>
         <PromptInputSubmit
-          disabled={isSubmitting || value.trim().length === 0}
+          className="shrink-0"
+          disabled={isSubmitting || activeValue.trim().length === 0}
           onClick={(event) => {
             event.preventDefault();
-            void onSubmit();
+            submit();
           }}
           status={isSubmitting ? "submitted" : "ready"}
         />


### PR DESCRIPTION
## What changed

Updated the OS2 projects page helper copy from implementation-focused wording to clearer user-facing text.

## Impact

This is a minimal UI copy change only. It does not change routing, data fetching, or behavior.

## Validation

- `pnpm --dir apps/os2 typecheck`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os2": {
      "appDisplayName": "OS",
      "appSlug": "os2",
      "status": "released",
      "updatedAt": "2026-05-11T12:21:06.640Z",
      "headSha": "1845f5e0ecec1a32bcd9c43e0d6ff96ca81beb13",
      "message": "Preview app released.",
      "publicUrl": "https://os2.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25669346647",
      "shortSha": "1845f5e"
    },
    "events": {
      "appDisplayName": "Events",
      "appSlug": "events",
      "status": "released",
      "updatedAt": "2026-05-11T12:20:50.444Z",
      "headSha": "4bae81d49218ff3863700dfc1a791822530baa91",
      "message": "Preview app released.",
      "publicUrl": "https://events.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25665833092",
      "shortSha": "4bae81d"
    },
    "agents": {
      "appDisplayName": "Agents",
      "appSlug": "agents",
      "status": "released",
      "updatedAt": "2026-05-11T12:21:04.346Z",
      "headSha": "981f1d36337746509aecee4333e39b1769de2346",
      "message": "Preview app released.",
      "publicUrl": "https://agents.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25667623050",
      "shortSha": "981f1d3"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Agents
Status: released
Commit: `981f1d3`
Preview: https://agents.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25667623050)
Updated: 2026-05-11T12:21:04.346Z

### Events
Status: released
Commit: `4bae81d`
Preview: https://events.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25665833092)
Updated: 2026-05-11T12:20:50.444Z

### OS
Status: released
Commit: `1845f5e`
Preview: https://os2.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25669346647)
Updated: 2026-05-11T12:21:06.640Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk: changes inbound MCP authentication/authorization to accept Clerk session tokens and alters tool exposure/behavior (`run_code`→`exec_js`), which impacts security and client compatibility. Also introduces a new batch stream append path that affects event ordering/idempotency across multiple subsystems.
> 
> **Overview**
> **Stream + UI updates:** Adds `appendBatch` for project streams (API contract, oRPC router, streams capability, and stream DO) and updates the OS2 `ProjectStreamView`/shared `EventsStreamComposer` to support *message vs raw YAML event* modes with presets, submitting raw events via the new batch endpoint.
> 
> **Agents UX overhaul:** Reworks the OS2 agents index to remove inline create/configure forms and instead adds dedicated routes for `agents/new` and `agents/new-preset`, plus a new `agents/streams/$` detail route; new pages build YAML previews and create agents/presets by appending setup + custom + provider registration events via `appendBatch`.
> 
> **MCP/auth changes:** Renames inbound MCP tool `run_code`→`exec_js`, removes `reveal_secret`/`mcpProofSecret` plumbing, and broadens MCP entrypoint auth to accept Clerk `session_token` in addition to `oauth_token` (with org-membership fallback checks) while relaxing scope enforcement for session/admin tokens; docs/tests updated accordingly, and Events UI gains a new `pretty` renderer mode with header event counts tracked via reducer activity state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1845f5e0ecec1a32bcd9c43e0d6ff96ca81beb13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->