### PR TITLE
[codex] Add os2 project home stream page

### DIFF
--- a/apps/os2-contract/src/index.ts
+++ b/apps/os2-contract/src/index.ts
@@ -292,6 +292,15 @@ export const osContract = oc.router({
       })
       .input(ProjectScopedInput)
       .output(Project),
+    lifecycleState: oc
+      .route({
+        method: "GET",
+        path: "/projects/{projectSlugOrId}/lifecycle-state",
+        description: "Read Project Durable Object lifecycle processor state",
+        tags: ["/project"],
+      })
+      .input(ProjectScopedInput)
+      .output(z.unknown()),
     codemode: {
       listSessions: oc
         .route({

--- a/apps/os2/src/components/app-sidebar.tsx
+++ b/apps/os2/src/components/app-sidebar.tsx
@@ -132,6 +132,25 @@ function ProjectSidebarGroup({
             <SidebarMenuSubButton
               render={
                 <Link
+                  to="/orgs/$organizationSlug/projects/$projectSlug"
+                  params={{ organizationSlug, projectSlug }}
+                />
+              }
+              isActive={Boolean(
+                matchRoute({
+                  to: "/orgs/$organizationSlug/projects/$projectSlug",
+                  params: { organizationSlug, projectSlug },
+                  fuzzy: false,
+                }),
+              )}
+            >
+              <span>Home</span>
+            </SidebarMenuSubButton>
+          </SidebarMenuSubItem>
+          <SidebarMenuSubItem>
+            <SidebarMenuSubButton
+              render={
+                <Link
                   to="/orgs/$organizationSlug/projects/$projectSlug/agents"
                   params={{ organizationSlug, projectSlug }}
                 />

--- a/apps/os2/src/domains/projects/stream-processors/project-lifecycle.ts
+++ b/apps/os2/src/domains/projects/stream-processors/project-lifecycle.ts
@@ -7,7 +7,7 @@ import {
 } from "@iterate-com/shared/stream-processors";
 import { StreamPath } from "@iterate-com/shared/streams/types";
 
-export const PROJECT_LIFECYCLE_STREAM_PATH = StreamPath.parse("/project");
+export const PROJECT_LIFECYCLE_STREAM_PATH = StreamPath.parse("/");
 
 export const projectLifecycleEventTypes = {
   projectCreated: "events.iterate.com/os2/project-created",

--- a/apps/os2/src/orpc/routers/projects.ts
+++ b/apps/os2/src/orpc/routers/projects.ts
@@ -283,6 +283,14 @@ export const projectsRouter = {
       const row = requireProjectScope(context);
       return toProject(row);
     }),
+    lifecycleState: os.project.lifecycleState
+      .use(projectScopeMiddleware)
+      .handler(async ({ context }) => {
+        const project = requireProjectScope(context);
+        return await requireProjectDurableObjectNamespace(context)
+          .getByName(getProjectDurableObjectName(project.id))
+          .getProjectLifecycleRunnerState();
+      }),
     codemode: {
       ...projectCodemodeRouter,
       listSessions: os.project.codemode.listSessions

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/index.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/index.tsx
@@ -1,11 +1,58 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { StreamPath } from "@iterate-com/shared/streams/types";
+import { ProjectStreamView } from "~/components/project-stream-view.tsx";
+import { orpc } from "~/orpc/client.ts";
 
 export const Route = createFileRoute("/_app/orgs/$organizationSlug/projects/$projectSlug/")({
-  loader: ({ params }) => {
-    throw redirect({
-      to: "/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions",
-      params,
-      replace: true,
+  ssr: false,
+  loader: async ({ context, params }) => {
+    const project = await context.queryClient.ensureQueryData({
+      ...orpc.projects.findBySlug.queryOptions({ input: { slug: params.projectSlug } }),
+      staleTime: 30_000,
     });
+    await context.queryClient.ensureQueryData({
+      ...orpc.project.lifecycleState.queryOptions({ input: { projectSlugOrId: project.id } }),
+      staleTime: 5_000,
+    });
+
+    return {
+      breadcrumb: "Home",
+      project,
+    };
   },
+  component: ProjectHomePage,
 });
+
+function ProjectHomePage() {
+  const params = Route.useParams();
+  const { project } = Route.useLoaderData();
+  const lifecycleStateQuery = useQuery({
+    ...orpc.project.lifecycleState.queryOptions({ input: { projectSlugOrId: project.id } }),
+    refetchInterval: 2_500,
+    staleTime: 1_000,
+  });
+
+  return (
+    <section className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden md:grid-cols-[minmax(18rem,24rem)_minmax(0,1fr)]">
+      <aside className="min-h-0 overflow-auto border-b p-4 md:border-r md:border-b-0">
+        <div className="space-y-3">
+          <div>
+            <h2 className="text-sm font-semibold">Reduced State</h2>
+            <p className="text-sm text-muted-foreground">Project lifecycle processor</p>
+          </div>
+          <pre className="max-h-[calc(100vh-12rem)] overflow-auto rounded-lg border bg-muted p-3 font-mono text-xs whitespace-pre-wrap">
+            {JSON.stringify(lifecycleStateQuery.data ?? null, null, 2)}
+          </pre>
+        </div>
+      </aside>
+      <ProjectStreamView
+        emptyLabel="No events in the project root stream yet."
+        organizationSlug={params.organizationSlug}
+        projectSlug={params.projectSlug}
+        projectSlugOrId={project.id}
+        streamPath={StreamPath.parse("/")}
+      />
+    </section>
+  );
+}


### PR DESCRIPTION
## What changed

- Added a real OS2 project home route at `/orgs/:organizationSlug/projects/:projectSlug`.
- The page shows the project lifecycle reduced state on the left and the root `/` project event stream on the right.
- Added an oRPC lifecycle state endpoint backed by the Project Durable Object processor state.
- Added a project sidebar Home link.
- Changed the project lifecycle stream path from `/project` to `/` so lifecycle events publish to the root stream.

## Validation

- `pnpm --dir apps/os2 typecheck`
- `pnpm --dir apps/os2 test:project-ingress`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os2": {
      "appDisplayName": "OS",
      "appSlug": "os2",
      "status": "released",
      "updatedAt": "2026-05-11T10:50:22.214Z",
      "headSha": "0a93c52d1c88c0b3853f1c92f55073c38a80e38c",
      "message": "Preview app released.",
      "publicUrl": "https://os2.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25664360542",
      "shortSha": "0a93c52"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `0a93c52`
Preview: https://os2.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25664360542)
Updated: 2026-05-11T10:50:22.214Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the project lifecycle stream path to the root stream (`/`), which can affect event routing/subscriptions for existing projects, and introduces a new DO-backed endpoint that is polled frequently from the UI.
> 
> **Overview**
> Adds a new **Project Home** route at `/orgs/:organizationSlug/projects/:projectSlug` that displays the root (`/`) project event stream alongside the project lifecycle processor *reduced state*, and updates the sidebar to include a **Home** link for each project.
> 
> Extends the oRPC surface with `GET /projects/{projectSlugOrId}/lifecycle-state` to expose Project Durable Object lifecycle runner state, and switches the lifecycle processor stream path from `/project` to `/` so lifecycle events are published/consumed on the root stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a93c52d1c88c0b3853f1c92f55073c38a80e38c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->