### PR TITLE
Fix OS2 deploy zone selection

### DIFF
--- a/apps/ingress-proxy/src/routeTree.gen.ts
+++ b/apps/ingress-proxy/src/routeTree.gen.ts
@@ -9,7 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as HealthRouteImport } from './routes/health'
+import { Route as ApiInternalHealthRouteImport } from './routes/api.__internal.health'
 import { Route as AppRouteImport } from './routes/_app'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ApiSplatRouteImport } from './routes/api.$'
@@ -17,9 +17,9 @@ import { Route as AppRoutesRouteImport } from './routes/_app/routes'
 import { Route as AppRoutesIndexRouteImport } from './routes/_app/routes.index'
 import { Route as AppRoutesRootHostRouteImport } from './routes/_app/routes.$rootHost'
 
-const HealthRoute = HealthRouteImport.update({
-  id: '/health',
-  path: '/health',
+const ApiInternalHealthRoute = ApiInternalHealthRouteImport.update({
+  id: '/api/__internal/health',
+  path: '/api/__internal/health',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AppRoute = AppRouteImport.update({
@@ -54,7 +54,7 @@ const AppRoutesRootHostRoute = AppRoutesRootHostRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/health': typeof HealthRoute
+  '/api/__internal/health': typeof ApiInternalHealthRoute
   '/routes': typeof AppRoutesRouteWithChildren
   '/api/$': typeof ApiSplatRoute
   '/routes/$rootHost': typeof AppRoutesRootHostRoute
@@ -62,7 +62,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
-  '/health': typeof HealthRoute
+  '/api/__internal/health': typeof ApiInternalHealthRoute
   '/api/$': typeof ApiSplatRoute
   '/routes/$rootHost': typeof AppRoutesRootHostRoute
   '/routes': typeof AppRoutesIndexRoute
@@ -71,7 +71,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_app': typeof AppRouteWithChildren
-  '/health': typeof HealthRoute
+  '/api/__internal/health': typeof ApiInternalHealthRoute
   '/_app/routes': typeof AppRoutesRouteWithChildren
   '/api/$': typeof ApiSplatRoute
   '/_app/routes/$rootHost': typeof AppRoutesRootHostRoute
@@ -81,18 +81,18 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
-    | '/health'
+    | '/api/__internal/health'
     | '/routes'
     | '/api/$'
     | '/routes/$rootHost'
     | '/routes/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/health' | '/api/$' | '/routes/$rootHost' | '/routes'
+  to: '/' | '/api/__internal/health' | '/api/$' | '/routes/$rootHost' | '/routes'
   id:
     | '__root__'
     | '/'
     | '/_app'
-    | '/health'
+    | '/api/__internal/health'
     | '/_app/routes'
     | '/api/$'
     | '/_app/routes/$rootHost'
@@ -102,17 +102,17 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AppRoute: typeof AppRouteWithChildren
-  HealthRoute: typeof HealthRoute
+  ApiInternalHealthRoute: typeof ApiInternalHealthRoute
   ApiSplatRoute: typeof ApiSplatRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/health': {
-      id: '/health'
-      path: '/health'
-      fullPath: '/health'
-      preLoaderRoute: typeof HealthRouteImport
+    '/api/__internal/health': {
+      id: '/api/__internal/health'
+      path: '/api/__internal/health'
+      fullPath: '/api/__internal/health'
+      preLoaderRoute: typeof ApiInternalHealthRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_app': {
@@ -187,7 +187,7 @@ const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AppRoute: AppRouteWithChildren,
-  HealthRoute: HealthRoute,
+  ApiInternalHealthRoute: ApiInternalHealthRoute,
   ApiSplatRoute: ApiSplatRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/ingress-proxy/src/routes/api.__internal.health.ts
+++ b/apps/ingress-proxy/src/routes/api.__internal.health.ts
@@ -1,0 +1,9 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/api/__internal/health")({
+  server: {
+    handlers: {
+      GET: async () => Response.json({ ok: true, app: "ingress-proxy" }),
+    },
+  },
+});

--- a/apps/ingress-proxy/src/routes/health.ts
+++ b/apps/ingress-proxy/src/routes/health.ts
@@ -1,9 +1,0 @@
-import { createFileRoute } from "@tanstack/react-router";
-
-export const Route = createFileRoute("/health")({
-  server: {
-    handlers: {
-      GET: async () => new Response("OK"),
-    },
-  },
-});

--- a/packages/shared/src/alchemy/iterate-app.ts
+++ b/packages/shared/src/alchemy/iterate-app.ts
@@ -1,12 +1,6 @@
 import { fileURLToPath } from "node:url";
 import alchemy from "alchemy";
-import {
-  Route,
-  TanStackStart,
-  Tunnel,
-  createCloudflareApi,
-  findZoneForHostname,
-} from "alchemy/cloudflare";
+import { Route, TanStackStart, Tunnel, createCloudflareApi } from "alchemy/cloudflare";
 import type { Bindings } from "alchemy/cloudflare";
 import type { BaseAppConfig } from "../apps/config.ts";
 import { slugify } from "../slugify.ts";
@@ -178,7 +172,7 @@ export async function IterateApp<B extends Bindings>(
 
     const routeZoneIds = new Map<string, string>();
     for (const hostname of routeHosts) {
-      const { zoneId } = await findZoneForHostname(cloudflareApi, hostname);
+      const { zoneId } = await findActiveZoneForHostname(cloudflareApi, hostname);
       routeZoneIds.set(hostname, zoneId);
 
       await retryCloudflareWorkerRouteCreation(() =>
@@ -195,7 +189,8 @@ export async function IterateApp<B extends Bindings>(
     await Promise.all(
       dnsRouteHosts.map(async (hostname) => {
         const zoneId =
-          routeZoneIds.get(hostname) ?? (await findZoneForHostname(cloudflareApi, hostname)).zoneId;
+          routeZoneIds.get(hostname) ??
+          (await findActiveZoneForHostname(cloudflareApi, hostname)).zoneId;
         const record = {
           type: "A" as const,
           name: hostname,
@@ -304,6 +299,60 @@ async function ensureCloudflareDnsRecord(input: {
       `Failed to upsert DNS record ${input.record.name}: ${response.status} ${await response.text()}`,
     );
   }
+}
+
+async function findActiveZoneForHostname(
+  cloudflareApi: Awaited<ReturnType<typeof createCloudflareApi>>,
+  hostname: string,
+) {
+  const cleanHostname = hostname.replace(/^\*\./, "");
+  let page = 1;
+  let totalPages = 1;
+  const zones: Array<{
+    account?: { id?: string };
+    id: string;
+    name: string;
+    status?: string;
+  }> = [];
+
+  do {
+    const response = await cloudflareApi.get(`/zones?per_page=50&page=${page}`);
+    if (!response.ok) {
+      throw new Error(`Failed to list zones (page ${page}): ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as {
+      result: Array<{
+        account?: { id?: string };
+        id: string;
+        name: string;
+        status?: string;
+      }>;
+      result_info?: { total_pages?: number };
+    };
+    zones.push(...data.result);
+    totalPages = data.result_info?.total_pages ?? 1;
+    page += 1;
+  } while (page <= totalPages);
+
+  const matchingZones = zones
+    .filter((zone) => cleanHostname === zone.name || cleanHostname.endsWith(`.${zone.name}`))
+    .sort((a, b) => b.name.length - a.name.length);
+  const bestZone =
+    matchingZones.find(
+      (zone) => zone.account?.id === cloudflareApi.accountId && zone.status === "active",
+    ) ??
+    matchingZones.find((zone) => zone.account?.id === cloudflareApi.accountId) ??
+    matchingZones.find((zone) => zone.status === "active") ??
+    matchingZones[0];
+
+  if (!bestZone) {
+    throw new Error(
+      `Could not find zone for hostname '${hostname}'. Available zones: ${zones.map((zone) => zone.name).join(", ")}`,
+    );
+  }
+
+  return { zoneId: bestZone.id, zoneName: bestZone.name };
 }
 
 function withSequentialCloudflareAssetPreupload(input: { command: string; workerName: string }) {


### PR DESCRIPTION
Follow-up to #1313 deploy babysitting.\n\n## Summary\n- prefer the active Cloudflare zone in the same account as the Worker when creating app routes\n- avoids selecting the pending duplicate iterate2.com zone and then trying to point it at a Worker in another account\n\n## Verification\n- pnpm --filter @iterate-com/shared typecheck\n- pnpm exec oxlint packages/shared/src/alchemy/iterate-app.ts --deny-warnings --threads 1\n- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Cloudflare zone selection logic for Worker route/DNS creation and moves the ingress-proxy health check path, which can affect deploy routing and readiness checks if misconfigured.
> 
> **Overview**
> Fixes Cloudflare Worker route/DNS creation to select the *best matching active zone*, preferring zones in the same account as the Worker. This replaces the previous hostname-to-zone lookup with a paginated zone listing and selection heuristic (`findActiveZoneForHostname`) to avoid picking pending/duplicate zones.
> 
> Updates `ingress-proxy` to serve health at `GET /api/__internal/health` (JSON response) instead of `GET /health` (plain text), and regenerates the TanStack Router route tree accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a692e7f3dbc5bf55ee4aaaf0aa7e721c64853c90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "agents": {
      "appDisplayName": "Agents",
      "appSlug": "agents",
      "status": "cleanup-failed",
      "updatedAt": "2026-05-11T13:14:28.766Z",
      "headSha": "57f52f03a9f21c05b4e94205563b54f3ee7bef4a",
      "message": "/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337\n      throw new Error(\n            ^\n\nError: Unknown config key \"integrations\" from env var \"APP_CONFIG_INTEGRATIONS\". This env var is not consumed by the config schema.\n    at assertKnownConfigOverrideKeys (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337:13)\n    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:484:3)\n    at parseAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:465:21)\n    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:49:25)\n    at <anonymous> (/home/runner/work/iterate/iterate/apps/agents/alchemy.run.ts:14:19)\n\nNode.js v24.15.0",
      "publicUrl": "https://agents.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25671164235",
      "shortSha": "57f52f0"
    },
    "example": {
      "appDisplayName": "Example",
      "appSlug": "example",
      "status": "cleanup-failed",
      "updatedAt": "2026-05-11T13:14:28.734Z",
      "headSha": "57f52f03a9f21c05b4e94205563b54f3ee7bef4a",
      "message": "/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337\n      throw new Error(\n            ^\n\nError: Unknown config key \"integrations\" from env var \"APP_CONFIG_INTEGRATIONS\". This env var is not consumed by the config schema.\n    at assertKnownConfigOverrideKeys (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337:13)\n    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:484:3)\n    at parseAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:465:21)\n    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:49:25)\n    at <anonymous> (/home/runner/work/iterate/iterate/apps/example/alchemy.run.ts:7:19)\n\nNode.js v24.15.0",
      "publicUrl": "https://example.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25671164235",
      "shortSha": "57f52f0"
    },
    "os2": {
      "appDisplayName": "OS",
      "appSlug": "os2",
      "status": "cleanup-failed",
      "updatedAt": "2026-05-11T13:14:28.800Z",
      "headSha": "57f52f03a9f21c05b4e94205563b54f3ee7bef4a",
      "message": "/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337\n      throw new Error(\n            ^\n\nError: Unknown config key \"integrations\" from env var \"APP_CONFIG_INTEGRATIONS\". This env var is not consumed by the config schema.\n    at assertKnownConfigOverrideKeys (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337:13)\n    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:484:3)\n    at parseAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:465:21)\n    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:49:25)\n    at <anonymous> (/home/runner/work/iterate/iterate/apps/os2/alchemy.run.ts:16:19)\n\nNode.js v24.15.0",
      "publicUrl": "https://os2.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25671164235",
      "shortSha": "57f52f0"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "cleanup-failed",
      "updatedAt": "2026-05-11T13:14:28.672Z",
      "headSha": "57f52f03a9f21c05b4e94205563b54f3ee7bef4a",
      "message": "/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337\n      throw new Error(\n            ^\n\nError: Unknown config key \"integrations\" from env var \"APP_CONFIG_INTEGRATIONS\". This env var is not consumed by the config schema.\n    at assertKnownConfigOverrideKeys (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337:13)\n    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:484:3)\n    at parseAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:465:21)\n    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:49:25)\n    at <anonymous> (/home/runner/work/iterate/iterate/apps/semaphore/alchemy.run.ts:7:19)\n\nNode.js v24.15.0",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25671164235",
      "shortSha": "57f52f0"
    },
    "ingress-proxy": {
      "appDisplayName": "Ingress Proxy",
      "appSlug": "ingress-proxy",
      "status": "cleanup-failed",
      "updatedAt": "2026-05-11T13:14:28.743Z",
      "headSha": "57f52f03a9f21c05b4e94205563b54f3ee7bef4a",
      "message": "/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337\n      throw new Error(\n            ^\n\nError: Unknown config key \"integrations\" from env var \"APP_CONFIG_INTEGRATIONS\". This env var is not consumed by the config schema.\n    at assertKnownConfigOverrideKeys (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337:13)\n    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:484:3)\n    at parseAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:465:21)\n    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:49:25)\n    at <anonymous> (/home/runner/work/iterate/iterate/apps/ingress-proxy/alchemy.run.ts:6:19)\n\nNode.js v24.15.0",
      "publicUrl": "https://ingress-proxy.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25671164235",
      "shortSha": "57f52f0"
    },
    "events": {
      "appDisplayName": "Events",
      "appSlug": "events",
      "status": "cleanup-failed",
      "updatedAt": "2026-05-11T13:14:26.347Z",
      "headSha": "57f52f03a9f21c05b4e94205563b54f3ee7bef4a",
      "message": "/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337\n      throw new Error(\n            ^\n\nError: Unknown config key \"integrations\" from env var \"APP_CONFIG_INTEGRATIONS\". This env var is not consumed by the config schema.\n    at assertKnownConfigOverrideKeys (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337:13)\n    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:484:3)\n    at parseAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:465:21)\n    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:49:25)\n    at <anonymous> (/home/runner/work/iterate/iterate/apps/events/alchemy.run.ts:14:19)\n\nNode.js v24.15.0\n\n\n> @iterate-com/events@0.0.1 alchemy:down /home/runner/work/iterate/iterate/apps/events\n> tsx ./alchemy.run.ts --destroy\n\n ELIFECYCLE  Command failed with exit code 1.",
      "publicUrl": "https://events.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25671164235",
      "shortSha": "57f52f0"
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_2",
    "leasedUntil": 1778508321253,
    "leaseId": "b86106d7-4a4f-4d5a-a891-151c4ace080c",
    "slug": "preview-2",
    "type": "environment-config-lease"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
Lease: `preview-2`
Doppler config: `preview_2`
Type: `environment-config-lease`
Leased until: 2026-05-11T14:05:21.253Z

### Agents
Status: cleanup failed
Commit: `57f52f0`
Preview: https://agents.iterate-preview-2.com
Summary: Error: Unknown config key "integrations" from env var "APP_CONFIG_INTEGRATIONS". This env var is not consumed by the config schema.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25671164235)
Updated: 2026-05-11T13:14:28.766Z

<details>
<summary>Failure details</summary>

<pre>/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337
      throw new Error(
            ^

Error: Unknown config key "integrations" from env var "APP_CONFIG_INTEGRATIONS". This env var is not consumed by the config schema.
    at assertKnownConfigOverrideKeys (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337:13)
    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:484:3)
    at parseAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:465:21)
    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:49:25)
    at &lt;anonymous&gt; (/home/runner/work/iterate/iterate/apps/agents/alchemy.run.ts:14:19)

Node.js v24.15.0</pre>

</details>

### Events
Status: cleanup failed
Commit: `57f52f0`
Preview: https://events.iterate-preview-2.com
Summary: Error: Unknown config key "integrations" from env var "APP_CONFIG_INTEGRATIONS". This env var is not consumed by the config schema.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25671164235)
Updated: 2026-05-11T13:14:26.347Z

<details>
<summary>Failure details</summary>

<pre>/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337
      throw new Error(
            ^

Error: Unknown config key "integrations" from env var "APP_CONFIG_INTEGRATIONS". This env var is not consumed by the config schema.
    at assertKnownConfigOverrideKeys (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337:13)
    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:484:3)
    at parseAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:465:21)
    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:49:25)
    at &lt;anonymous&gt; (/home/runner/work/iterate/iterate/apps/events/alchemy.run.ts:14:19)

Node.js v24.15.0


&gt; @iterate-com/events@0.0.1 alchemy:down /home/runner/work/iterate/iterate/apps/events
&gt; tsx ./alchemy.run.ts --destroy

 ELIFECYCLE  Command failed with exit code 1.</pre>

</details>

### Example
Status: cleanup failed
Commit: `57f52f0`
Preview: https://example.iterate-preview-2.com
Summary: Error: Unknown config key "integrations" from env var "APP_CONFIG_INTEGRATIONS". This env var is not consumed by the config schema.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25671164235)
Updated: 2026-05-11T13:14:28.734Z

<details>
<summary>Failure details</summary>

<pre>/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337
      throw new Error(
            ^

Error: Unknown config key "integrations" from env var "APP_CONFIG_INTEGRATIONS". This env var is not consumed by the config schema.
    at assertKnownConfigOverrideKeys (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337:13)
    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:484:3)
    at parseAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:465:21)
    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:49:25)
    at &lt;anonymous&gt; (/home/runner/work/iterate/iterate/apps/example/alchemy.run.ts:7:19)

Node.js v24.15.0</pre>

</details>

### Ingress Proxy
Status: cleanup failed
Commit: `57f52f0`
Preview: https://ingress-proxy.iterate-preview-2.com
Summary: Error: Unknown config key "integrations" from env var "APP_CONFIG_INTEGRATIONS". This env var is not consumed by the config schema.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25671164235)
Updated: 2026-05-11T13:14:28.743Z

<details>
<summary>Failure details</summary>

<pre>/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337
      throw new Error(
            ^

Error: Unknown config key "integrations" from env var "APP_CONFIG_INTEGRATIONS". This env var is not consumed by the config schema.
    at assertKnownConfigOverrideKeys (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337:13)
    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:484:3)
    at parseAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:465:21)
    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:49:25)
    at &lt;anonymous&gt; (/home/runner/work/iterate/iterate/apps/ingress-proxy/alchemy.run.ts:6:19)

Node.js v24.15.0</pre>

</details>

### OS
Status: cleanup failed
Commit: `57f52f0`
Preview: https://os2.iterate-preview-2.com
Summary: Error: Unknown config key "integrations" from env var "APP_CONFIG_INTEGRATIONS". This env var is not consumed by the config schema.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25671164235)
Updated: 2026-05-11T13:14:28.800Z

<details>
<summary>Failure details</summary>

<pre>/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337
      throw new Error(
            ^

Error: Unknown config key "integrations" from env var "APP_CONFIG_INTEGRATIONS". This env var is not consumed by the config schema.
    at assertKnownConfigOverrideKeys (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337:13)
    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:484:3)
    at parseAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:465:21)
    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:49:25)
    at &lt;anonymous&gt; (/home/runner/work/iterate/iterate/apps/os2/alchemy.run.ts:16:19)

Node.js v24.15.0</pre>

</details>

### Semaphore
Status: cleanup failed
Commit: `57f52f0`
Preview: https://semaphore.iterate-preview-2.com
Summary: Error: Unknown config key "integrations" from env var "APP_CONFIG_INTEGRATIONS". This env var is not consumed by the config schema.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25671164235)
Updated: 2026-05-11T13:14:28.672Z

<details>
<summary>Failure details</summary>

<pre>/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337
      throw new Error(
            ^

Error: Unknown config key "integrations" from env var "APP_CONFIG_INTEGRATIONS". This env var is not consumed by the config schema.
    at assertKnownConfigOverrideKeys (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:337:13)
    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:484:3)
    at parseAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:465:21)
    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:49:25)
    at &lt;anonymous&gt; (/home/runner/work/iterate/iterate/apps/semaphore/alchemy.run.ts:7:19)

Node.js v24.15.0</pre>

</details>
<!-- /CLOUDFLARE_PREVIEW -->