### PR TITLE
[codex] warn for unknown app config overrides

### DIFF
--- a/packages/shared/src/alchemy/init.ts
+++ b/packages/shared/src/alchemy/init.ts
@@ -1,7 +1,7 @@
 import alchemy, { type Scope } from "alchemy";
 import { CloudflareStateStore, SQLiteStateStore } from "alchemy/state";
 import { z } from "zod";
-import { compileRawAppConfigFromEnv, parseAppConfigFromEnv } from "../apps/config.ts";
+import { compileRawAppConfigFromEnv } from "../apps/config.ts";
 import type { AppManifest } from "../apps/types.ts";
 import { slugify } from "../slugify.ts";
 
@@ -46,17 +46,12 @@ export async function initAlchemy<TSchema extends z.ZodTypeAny>(
   const alchemyEnv = AlchemyEnv.parse(env);
   if (alchemyEnv.ALCHEMY_LOCAL) delete env.CI;
 
-  const runtimeConfig = parseAppConfigFromEnv({
-    configSchema,
-    prefix: "APP_CONFIG_",
-    env,
-  }) as z.output<TSchema>;
-
   const rawRuntimeConfig = compileRawAppConfigFromEnv({
     configSchema,
     prefix: "APP_CONFIG_",
     env,
   }) as Record<string, unknown>;
+  const runtimeConfig = configSchema.parse(rawRuntimeConfig) as z.output<TSchema>;
 
   const stateStore = (scope: Scope) =>
     scope.local

--- a/packages/shared/src/apps/config.test.ts
+++ b/packages/shared/src/apps/config.test.ts
@@ -1,5 +1,5 @@
 import { inspect } from "node:util";
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import { z } from "zod";
 import {
   BaseAppConfig,
@@ -131,15 +131,71 @@ describe("parseAppConfigFromEnv", () => {
     });
   });
 
-  it("throws for unknown APP_CONFIG_* keys instead of silently ignoring them", () => {
+  it("warns loudly for unknown APP_CONFIG_* keys instead of failing deployment", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      expect(
+        parseTestAppConfigFromEnv({
+          APP_CONFIG_LOGGING: JSON.stringify({
+            stdoutFormat: "raw",
+          }),
+        }),
+      ).toEqual({
+        logs: { stdoutFormat: "pretty", filtering: { rules: [] } },
+        public: { somePublicKey: "default-public-key" },
+        logger: { stdout: false },
+        someOtherThing: "default-other-thing",
+      });
+
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn.mock.calls[0]?.[0]).toContain("WARNING: UNKNOWN APP CONFIG OVERRIDE");
+      expect(warn.mock.calls[0]?.[0]).toContain(
+        'Unknown config key "logging" from env var "APP_CONFIG_LOGGING". This env var is not consumed by the config schema.',
+      );
+      expect(warn.mock.calls[0]?.[0]).toContain(
+        "Deployment will continue, but this config value is being ignored by the typed runtime config.",
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("warns loudly for unknown nested APP_CONFIG_* keys instead of failing deployment", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      expect(
+        parseTestAppConfigFromEnv({
+          APP_CONFIG_INTEGRATIONS: JSON.stringify({
+            posthog: {
+              projectApiKey: "phc_example",
+            },
+          }),
+        }),
+      ).toEqual({
+        logs: { stdoutFormat: "pretty", filtering: { rules: [] } },
+        public: { somePublicKey: "default-public-key" },
+        logger: { stdout: false },
+        someOtherThing: "default-other-thing",
+      });
+
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn.mock.calls[0]?.[0]).toContain(
+        'Unknown config key "integrations" from env var "APP_CONFIG_INTEGRATIONS". This env var is not consumed by the config schema.',
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("still throws when a nested override targets a non-object config field", () => {
     expect(() =>
       parseTestAppConfigFromEnv({
-        APP_CONFIG_LOGGING: JSON.stringify({
-          stdoutFormat: "raw",
-        }),
+        APP_CONFIG_SOME_OTHER_THING__NESTED: "bad",
       }),
     ).toThrow(
-      'Unknown config key "logging" from env var "APP_CONFIG_LOGGING". This env var is not consumed by the config schema.',
+      'Config override "someOtherThing" from env var "APP_CONFIG_SOME_OTHER_THING" targets nested keys on a non-object config field.',
     );
   });
 

--- a/packages/shared/src/apps/config.ts
+++ b/packages/shared/src/apps/config.ts
@@ -308,7 +308,7 @@ function unwrapConfigSchema(schema: z.ZodTypeAny): z.ZodTypeAny {
   return current;
 }
 
-function assertKnownConfigOverrideKeys(options: {
+function warnForUnknownConfigOverrideKeys(options: {
   configSchema: z.ZodTypeAny;
   overrides: unknown;
   prefix: string;
@@ -334,15 +334,23 @@ function assertKnownConfigOverrideKeys(options: {
     const childPath = [...path, key];
     const childSchema = configSchema.shape[key] as z.ZodTypeAny | undefined;
     if (!childSchema) {
-      throw new Error(
-        `Unknown config key "${formatConfigPath(childPath)}" from env var "${formatEnvOverrideKey(
-          options.prefix,
-          childPath,
-        )}". This env var is not consumed by the config schema.`,
+      console.warn(
+        [
+          "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
+          "WARNING: UNKNOWN APP CONFIG OVERRIDE",
+          `Unknown config key "${formatConfigPath(childPath)}" from env var "${formatEnvOverrideKey(
+            options.prefix,
+            childPath,
+          )}". This env var is not consumed by the config schema.`,
+          "Deployment will continue, but this config value is being ignored by the typed runtime config.",
+          "Add the key to the app config schema or remove the env var from Doppler.",
+          "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
+        ].join("\n"),
       );
+      continue;
     }
 
-    assertKnownConfigOverrideKeys({
+    warnForUnknownConfigOverrideKeys({
       configSchema: childSchema,
       overrides: value,
       prefix: options.prefix,
@@ -453,9 +461,9 @@ export interface CompileRawAppConfigFromEnvOptions<TSchema extends z.ZodTypeAny>
  * - `APP_CONFIG_LOGS__STDOUT_FORMAT=raw` -> `logs.stdoutFormat`
  * - `APP_CONFIG_POSTHOG='{"apiKey":"phc_xxx"}'` -> `posthog`
  *
- * Prefixed overrides are validated against `configSchema` before the final
- * merge so typos fail early during bootstrap and in runtime entrypoints,
- * instead of being silently ignored.
+ * Prefixed overrides are checked against `configSchema` before the final
+ * merge so typos are loudly reported during bootstrap and in runtime
+ * entrypoints, instead of being silently ignored.
  */
 export function parseAppConfigFromEnv<TSchema extends z.ZodTypeAny>({
   configSchema,
@@ -481,7 +489,7 @@ export function compileRawAppConfigFromEnv<TSchema extends z.ZodTypeAny>({
   const baseConfig = parseRawAppConfig(configEnv[baseKey], baseKey);
   const overrides = unflattenEnv(prefix, configEnv);
 
-  assertKnownConfigOverrideKeys({
+  warnForUnknownConfigOverrideKeys({
     configSchema,
     overrides,
     prefix,


### PR DESCRIPTION
## What changed

Unknown `APP_CONFIG_*` overrides now emit a loud warning instead of throwing during config compilation. The warning keeps the existing unknown key/env var detail, explicitly says deployment will continue, and tells the operator to either add the key to the app config schema or remove it from Doppler.

`initAlchemy` now compiles raw app config once and parses the typed runtime config from that result, avoiding duplicate warnings during deploy startup.

## Why

Adding a new Doppler app config variable such as `APP_CONFIG_INTEGRATIONS` could fail every deployment job before the receiving app schema consumed the key. We still want visibility into ignored config, but deployment should not be blocked by introducing a new key.

## Validation

- `pnpm --filter @iterate-com/shared exec vitest run src/apps/config.test.ts`
- `pnpm --filter @iterate-com/shared typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime config compilation behavior so unknown `APP_CONFIG_*` keys no longer fail fast, which could allow misconfigurations to slip through if warnings are missed. Touches shared bootstrap/config parsing used across apps, so impact is broad despite being a small diff.
> 
> **Overview**
> Unknown `APP_CONFIG_*` overrides are no longer treated as fatal during config compilation; they now emit a loud `console.warn` and are ignored, while invalid nested overrides on non-object fields still throw.
> 
> `initAlchemy` is updated to compile raw config once via `compileRawAppConfigFromEnv` and then parse the typed config from that result, avoiding duplicate warnings during startup. Tests are updated/added to assert the new warning behavior for unknown top-level and nested keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4e9e7d828134c23cd50284e7834c663e3de2b8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "agents": {
      "appDisplayName": "Agents",
      "appSlug": "agents",
      "status": "released",
      "updatedAt": "2026-05-11T13:50:59.384Z",
      "headSha": "b4e9e7d828134c23cd50284e7834c663e3de2b8f",
      "message": "Preview app released.",
      "publicUrl": "https://agents.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25673390457",
      "shortSha": "b4e9e7d"
    },
    "example": {
      "appDisplayName": "Example",
      "appSlug": "example",
      "status": "released",
      "updatedAt": "2026-05-11T13:50:59.199Z",
      "headSha": "b4e9e7d828134c23cd50284e7834c663e3de2b8f",
      "message": "Preview app released.",
      "publicUrl": "https://example.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25673390457",
      "shortSha": "b4e9e7d"
    },
    "os2": {
      "appDisplayName": "OS",
      "appSlug": "os2",
      "status": "released",
      "updatedAt": "2026-05-11T13:51:01.712Z",
      "headSha": "b4e9e7d828134c23cd50284e7834c663e3de2b8f",
      "message": "Preview app released.",
      "publicUrl": "https://os2.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25673390457",
      "shortSha": "b4e9e7d"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-05-11T13:50:58.866Z",
      "headSha": "b4e9e7d828134c23cd50284e7834c663e3de2b8f",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25673390457",
      "shortSha": "b4e9e7d"
    },
    "ingress-proxy": {
      "appDisplayName": "Ingress Proxy",
      "appSlug": "ingress-proxy",
      "status": "released",
      "updatedAt": "2026-05-11T13:50:59.182Z",
      "headSha": "b4e9e7d828134c23cd50284e7834c663e3de2b8f",
      "message": "Preview app released.",
      "publicUrl": "https://ingress-proxy.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25673390457",
      "shortSha": "b4e9e7d"
    },
    "events": {
      "appDisplayName": "Events",
      "appSlug": "events",
      "status": "released",
      "updatedAt": "2026-05-11T13:50:46.612Z",
      "headSha": "b4e9e7d828134c23cd50284e7834c663e3de2b8f",
      "message": "Preview app released.",
      "publicUrl": "https://events.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25673390457",
      "shortSha": "b4e9e7d"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Agents
Status: released
Commit: `b4e9e7d`
Preview: https://agents.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25673390457)
Updated: 2026-05-11T13:50:59.384Z

### Events
Status: released
Commit: `b4e9e7d`
Preview: https://events.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25673390457)
Updated: 2026-05-11T13:50:46.612Z

### Example
Status: released
Commit: `b4e9e7d`
Preview: https://example.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25673390457)
Updated: 2026-05-11T13:50:59.199Z

### Ingress Proxy
Status: released
Commit: `b4e9e7d`
Preview: https://ingress-proxy.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25673390457)
Updated: 2026-05-11T13:50:59.182Z

### OS
Status: released
Commit: `b4e9e7d`
Preview: https://os2.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25673390457)
Updated: 2026-05-11T13:51:01.712Z

### Semaphore
Status: released
Commit: `b4e9e7d`
Preview: https://semaphore.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25673390457)
Updated: 2026-05-11T13:50:58.866Z
<!-- /CLOUDFLARE_PREVIEW -->