### PR TITLE
[codex] add codemode provider helpers and integration updates

### DIFF
--- a/apps/os2-contract/src/index.ts
+++ b/apps/os2-contract/src/index.ts
@@ -67,6 +67,15 @@ export const ProjectIntegrationConnection = z.object({
   displayName: z.string().nullable(),
   metadata: JSONObject,
   scopes: z.string().nullable(),
+  token: z
+    .object({
+      createdAt: z.string(),
+      expiresAt: z.string().nullable(),
+      hasMaterial: z.boolean(),
+      refreshTokenStored: z.boolean(),
+      updatedAt: z.string(),
+    })
+    .nullable(),
 });
 export type ProjectIntegrationConnection = z.output<typeof ProjectIntegrationConnection>;
 

--- a/apps/os2/docs/os2-rules.md
+++ b/apps/os2/docs/os2-rules.md
@@ -1,0 +1,3 @@
+# Data modelling rules
+
+- You never need to drag around a `projectId` in event payloads. Streams are scoped by a "namespace" and we use the project ID as a namespace for all streams. There are some narrow exceptions for "global" iterate-wide streams in the "global" namespace.

--- a/apps/os2/e2e/vitest/agents.e2e.test.ts
+++ b/apps/os2/e2e/vitest/agents.e2e.test.ts
@@ -530,7 +530,6 @@ async (ctx) => {
           idempotencyKey: `slack-agent-e2e-webhook:${suffix}`,
           payload: {
             slackTeamId: "T_E2E",
-            projectId: project.id,
             body: {
               type: "event_callback",
               team_id: "T_E2E",
@@ -649,7 +648,6 @@ async (ctx) => {
           idempotencyKey: `slack-agent-e2e-debug-webhook:${suffix}`,
           payload: {
             slackTeamId: "T_E2E",
-            projectId: project.id,
             body: {
               type: "event_callback",
               team_id: "T_E2E",
@@ -778,7 +776,6 @@ async (ctx) => {
         idempotencyKey: `slack-agent-e2e-thread-info-route-webhook:${suffix}`,
         payload: {
           slackTeamId: "T_E2E",
-          projectId: project.id,
           body: {
             type: "event_callback",
             team_id: "T_E2E",

--- a/apps/os2/src/domains/agents/agent-presets.test.ts
+++ b/apps/os2/src/domains/agents/agent-presets.test.ts
@@ -174,9 +174,20 @@ describe("agent presets", () => {
     const prompt = defaultAgentSystemPrompt("/agents/test");
     expect(prompt).toContain("/agents/test");
     expect(prompt).toContain("return undefined");
+    expect(prompt).toContain("If you're not sure about the shape of the result of a function call");
     expect(prompt).toContain("Promise.all");
     expect(prompt).toContain("ctx.<path>.<method>(args)");
+    expect(prompt).toContain("ctx.slack.chat.postMessage({ channel, thread_ts, text })");
     expect(prompt).toContain("ctx.streams.read()");
+  });
+
+  it("tells Slack agents not to reply to FYI-only thread events", () => {
+    const prompt = defaultAgentSystemPrompt("/agents/slack/c123/ts-1778565914-773159");
+    expect(prompt).toContain("Do not chime in just because a Slack event arrived.");
+    expect(prompt).toContain("explicitly mentioned");
+    expect(prompt).toContain("surrounding thread context clearly calls for agent action");
+    expect(prompt).toContain("async (ctx) => {}");
+    expect(prompt).toContain("Do not call `ctx.slack.chat.postMessage` for FYI-only updates.");
   });
 
   it("distinguishes invalid run options JSON from non-object run options", () => {

--- a/apps/os2/src/domains/agents/agent-presets.ts
+++ b/apps/os2/src/domains/agents/agent-presets.ts
@@ -43,11 +43,21 @@ export function defaultAgentSystemPrompt(agentPath?: string) {
     "Codemode is mandatory for user-visible answers. Reply with exactly one fenced JavaScript code block (```js) and no surrounding prose. The block must be a single async arrow function: `async (ctx) => { ... }`.",
     "",
     "The function body implicitly returns undefined — do NOT write `return undefined` or `return;`, just let the function end. Only return a value when you want the result shown back to you and another LLM turn.",
+    "If you're not sure about the shape of the result of a function call, just return it from a codemode block and you'll be shown it on your next turn.",
     "",
     "Use `Promise.all([...])` for independent concurrent operations. Use `fetch` for HTTP requests. Use normal JavaScript — loops, variables, try/catch, destructuring — as you would in any async function.",
     "",
     "## Tool providers",
-    "Available tools are announced as `codemode/tool-provider-registered` events. Call them as `ctx.<path>.<method>(args)` — e.g. `ctx.slack.chat.postMessage({ channel, text })` or `ctx.streams.read()`.",
+    "Available tools are announced as `codemode/tool-provider-registered` events. Call them as `ctx.<path>.<method>(args)` — e.g. `ctx.slack.chat.postMessage({ channel, thread_ts, text })` or `ctx.streams.read()`.",
+    ...(agentPath != null && isSlackAgentPath(agentPath)
+      ? [
+          "",
+          "## Slack replies",
+          "Slack thread events are often FYI context. Do not chime in just because a Slack event arrived.",
+          "Only post to Slack when the bot was explicitly mentioned, a user directly asks or instructs you, or the surrounding thread context clearly calls for agent action.",
+          "If no Slack reply is needed, still satisfy codemode by outputting an empty async function block: `async (ctx) => {}`. Do not call `ctx.slack.chat.postMessage` for FYI-only updates.",
+        ]
+      : []),
     "",
     "## Streams",
     "Use `ctx.streams.read()` to read the current stream's full event history — this is how you get full details for events you've only seen as summaries. Use `ctx.streams.append({ event: { type, payload } })` to append new events.",

--- a/apps/os2/src/domains/codemode/default-provider-registrations.test.ts
+++ b/apps/os2/src/domains/codemode/default-provider-registrations.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+import { createDefaultCodemodeProviderRegistrations } from "./default-provider-registrations.ts";
+
+describe("default codemode provider registrations", () => {
+  test("loads public Exa and Context7 MCP providers in every codemode session", () => {
+    const providers = createDefaultCodemodeProviderRegistrations({
+      projectId: "proj__test__defaults",
+      streamPath: "/codemode-sessions/defaults",
+    });
+
+    expect(providers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ["mcp", "exa"],
+          instructions: expect.stringContaining("ctx.mcp.exa"),
+        }),
+        expect.objectContaining({
+          path: ["mcp", "context7"],
+          instructions: expect.stringContaining("ctx.mcp.context7"),
+        }),
+      ]),
+    );
+    expect(providers.map((provider) => provider.path.join("."))).toEqual(
+      expect.arrayContaining(["mcp.exa", "mcp.context7"]),
+    );
+  });
+
+  test("tells Slack agents to stay quiet unless a reply is needed", () => {
+    const providers = createDefaultCodemodeProviderRegistrations({
+      projectId: "proj__test__defaults",
+      streamPath: "/codemode-sessions/defaults",
+    });
+
+    const slackProvider = providers.find((provider) => provider.path.join(".") === "slack");
+
+    expect(slackProvider?.instructions).toContain("explicitly mentioned");
+    expect(slackProvider?.instructions).toContain(
+      "surrounding thread context clearly calls for agent action",
+    );
+    expect(slackProvider?.instructions).toContain(
+      "If no reply is needed, do not call chat.postMessage.",
+    );
+  });
+});

--- a/apps/os2/src/domains/codemode/default-provider-registrations.ts
+++ b/apps/os2/src/domains/codemode/default-provider-registrations.ts
@@ -1,4 +1,5 @@
 import type { ToolProviderRegistration } from "@iterate-com/shared/stream-processors/codemode/contract";
+import { createOutboundMcpFromOurClientToolProviderRegistration } from "~/domains/outbound-mcp-client/utils/outbound-mcp-provider-registration.ts";
 import { createSecretsProviderRegistration } from "~/domains/secrets/secrets-provider-registration.ts";
 
 export function createDefaultCodemodeProviderRegistrations(input: {
@@ -51,7 +52,7 @@ export function createDefaultCodemodeProviderRegistrations(input: {
     {
       path: ["slack"],
       instructions:
-        "Use ctx.slack.<Slack Web API method path>(args), e.g. ctx.slack.chat.postMessage({ channel, thread_ts, text }). Best practice: use Promise.all to send an immediate acknowledgment ('On it...') while doing the real work in parallel, then send the actual result afterwards. Example: const [, data] = await Promise.all([ctx.slack.chat.postMessage({ channel, thread_ts, text: 'Looking into it...' }), fetch('https://...').then(r => r.json())]); await ctx.slack.chat.postMessage({ channel, thread_ts, text: formatResult(data) });",
+        "Use ctx.slack.<Slack Web API method path>(args), e.g. ctx.slack.chat.postMessage({ channel, thread_ts, text }). Slack agents MUST respond on the same thread_ts that received the message; otherwise they will not receive responses from that thread. Unless explicitly required, always include thread_ts in Slack replies. Do not post to Slack unless the bot was explicitly mentioned, a user directly asks or instructs you, or the surrounding thread context clearly calls for agent action. If no reply is needed, do not call chat.postMessage. For legitimate long-running Slack replies, use Promise.all to send an immediate acknowledgment while doing the real work in parallel, then send the actual result afterwards. Example: const [, data] = await Promise.all([ctx.slack.chat.postMessage({ channel, thread_ts, text: 'Looking into it...' }), fetch('https://...').then(r => r.json())]); await ctx.slack.chat.postMessage({ channel, thread_ts, text: formatResult(data) });",
       invocation: {
         kind: "rpc",
         callable: {
@@ -68,5 +69,23 @@ export function createDefaultCodemodeProviderRegistrations(input: {
       },
     },
     createSecretsProviderRegistration({ projectId: input.projectId }),
+    ...createDefaultOutboundMcpProviderRegistrations(),
+  ];
+}
+
+export function createDefaultOutboundMcpProviderRegistrations(): ToolProviderRegistration[] {
+  return [
+    createOutboundMcpFromOurClientToolProviderRegistration({
+      instructions:
+        "Use ctx.mcp.exa for Exa web search. Call ctx.mcp.exa.listTools() to inspect available tools, then call tools such as ctx.mcp.exa.web_search_exa({ query, numResults }) or ctx.mcp.exa.web_fetch_exa({ urls }).",
+      path: ["mcp", "exa"],
+      serverUrl: "https://mcp.exa.ai/mcp",
+    }),
+    createOutboundMcpFromOurClientToolProviderRegistration({
+      instructions:
+        "Use ctx.mcp.context7 for current library/framework documentation. Call ctx.mcp.context7.listTools() to inspect available tools, then call hyphenated tool names with bracket syntax, for example ctx.mcp.context7['resolve-library-id']({ libraryName, query }) and ctx.mcp.context7['query-docs']({ libraryId, query }).",
+      path: ["mcp", "context7"],
+      serverUrl: "https://mcp.context7.com/mcp",
+    }),
   ];
 }

--- a/apps/os2/src/domains/codemode/durable-objects/codemode-session.ts
+++ b/apps/os2/src/domains/codemode/durable-objects/codemode-session.ts
@@ -32,6 +32,8 @@ import type { ProcessorStreamApi, StreamEvent } from "@iterate-com/shared/stream
 import type { Callable } from "@iterate-com/shared/callable/types.ts";
 import { dispatchCallable } from "@iterate-com/shared/callable/runtime.ts";
 import { resolveStreamPath } from "~/domains/streams/entrypoints/streams-capability.ts";
+import { createOutboundMcpFromOurClientToolProviderRegistration } from "~/domains/outbound-mcp-client/utils/outbound-mcp-provider-registration.ts";
+import { createOpenApiProviderRegistration } from "~/rpc-targets/openapi-provider-registration.ts";
 
 export { OpenApiBridge } from "~/rpc-targets/openapi-bridge.ts";
 export { OutboundMcpFromOurClientCapability } from "~/domains/outbound-mcp-client/entrypoints/outbound-mcp-from-our-client-capability.ts";
@@ -45,6 +47,28 @@ export type CodemodeSessionStructuredName = {
 const CodemodeSessionStructuredName = z.object({
   projectId: z.string(),
   streamPath: StreamPath,
+});
+
+const CodemodeProviderPath = z
+  .array(z.string().min(1))
+  .min(1)
+  .refine((path) => path[0] !== "codemode", {
+    message: "Provider path cannot start with reserved segment codemode.",
+  });
+
+const ConnectToMcpServerInput = z.object({
+  headers: z.record(z.string(), z.string()).optional(),
+  instructions: z.string().optional(),
+  path: CodemodeProviderPath,
+  url: z.string().url(),
+});
+
+const ConnectToOpenApiServerInput = z.object({
+  baseUrl: z.string().url(),
+  headers: z.record(z.string(), z.string()).optional(),
+  instructions: z.string().optional(),
+  path: CodemodeProviderPath,
+  specUrl: z.string().url(),
 });
 
 export type StartScriptExecutionInput = {
@@ -333,7 +357,7 @@ export class CodemodeSession extends CodemodeSessionBase<CodemodeSessionEnv> {
     const builtin = this.resolveCodemodeBuiltin(input.path);
     if (builtin != null) {
       // Temporary duplication with the shared codemode processor. This is not
-      // the design we want long-term: `__codemode` should be owned by exactly
+      // the design we want long-term: `codemode` should be owned by exactly
       // one session capability implementation. For now the OS2 host and the
       // portable processor both need this branch so the internal path is always
       // available, still records a normal requested/completed event pair, and
@@ -354,7 +378,7 @@ export class CodemodeSession extends CodemodeSessionBase<CodemodeSessionEnv> {
       });
       const startedAt = Date.now();
       try {
-        const result = this.runCodemodeBuiltin({
+        const result = await this.runCodemodeBuiltin({
           args: input.args,
           functionCallId,
           functionPath: builtin.functionPath,
@@ -650,14 +674,14 @@ export class CodemodeSession extends CodemodeSessionBase<CodemodeSessionEnv> {
   }
 
   private resolveCodemodeBuiltin(path: string[]) {
-    if (path[0] !== "__codemode") return null;
+    if (path[0] !== "codemode") return null;
     return {
       functionPath: path.slice(1),
-      providerPath: ["__codemode"],
+      providerPath: ["codemode"],
     };
   }
 
-  private runCodemodeBuiltin(input: {
+  private async runCodemodeBuiltin(input: {
     args: unknown[];
     functionCallId: string;
     functionPath: string[];
@@ -668,6 +692,37 @@ export class CodemodeSession extends CodemodeSessionBase<CodemodeSessionEnv> {
   }) {
     const name = input.functionPath.join(".");
     if (name === "ping") return "pong";
+    if (name === "connectToMcpServer") {
+      const args = parseUnaryCodemodeBuiltinArgs({
+        args: input.args,
+        name,
+        schema: ConnectToMcpServerInput,
+      });
+      return await this.appendToolProviderRegisteredEvent({
+        provider: createOutboundMcpFromOurClientToolProviderRegistration({
+          headers: args.headers,
+          instructions: args.instructions,
+          path: args.path,
+          serverUrl: args.url,
+        }),
+      });
+    }
+    if (name === "connectToOpenApiServer") {
+      const args = parseUnaryCodemodeBuiltinArgs({
+        args: input.args,
+        name,
+        schema: ConnectToOpenApiServerInput,
+      });
+      return await this.appendToolProviderRegisteredEvent({
+        provider: createOpenApiProviderRegistration({
+          baseUrl: args.baseUrl,
+          headers: args.headers,
+          instructions: args.instructions,
+          path: args.path,
+          specUrl: args.specUrl,
+        }),
+      });
+    }
     if (name === "debugInfo") {
       return {
         args: serializeFunctionCallArgsForEvent(input.args),
@@ -682,8 +737,30 @@ export class CodemodeSession extends CodemodeSessionBase<CodemodeSessionEnv> {
       };
     }
 
-    throw new Error(`Unknown codemode builtin __codemode.${name}`);
+    throw new Error(`Unknown codemode builtin codemode.${name}`);
   }
+}
+
+function parseUnaryCodemodeBuiltinArgs<T>(input: {
+  args: unknown[];
+  name: string;
+  schema: z.ZodType<T>;
+}) {
+  if (input.args.length !== 1) {
+    throw new Error(`ctx.codemode.${input.name} requires exactly one object argument.`);
+  }
+
+  const result = input.schema.safeParse(input.args[0]);
+  if (result.success) return result.data;
+
+  throw new Error(
+    `Invalid ctx.codemode.${input.name} argument: ${result.error.issues
+      .map((issue) => {
+        const path = issue.path.length === 0 ? "input" : `input.${issue.path.join(".")}`;
+        return `${path}: ${issue.message}`;
+      })
+      .join("; ")}`,
+  );
 }
 
 function processorStreamApiFromNamespace(args: {

--- a/apps/os2/src/domains/codemode/example-provider-registrations.ts
+++ b/apps/os2/src/domains/codemode/example-provider-registrations.ts
@@ -100,7 +100,7 @@ export function createExampleCapabilityProviders(input: {
       exportName: "SlackCapability",
       activeOrganization: input.activeOrganization,
       instructions:
-        "Use ctx.slack.<Slack Web API method path>(args), for example ctx.slack.chat.postMessage({ channel, text }).",
+        "Use ctx.slack.<Slack Web API method path>(args), for example ctx.slack.chat.postMessage({ channel, thread_ts, text }). Slack agents MUST respond on the same thread_ts that received the message; otherwise they will not receive responses from that thread. Unless explicitly required, always include thread_ts in Slack replies. Do not post to Slack unless the bot was explicitly mentioned, a user directly asks or instructs you, or the surrounding thread context clearly calls for agent action.",
       path: ["slack"],
       projectId: input.projectId,
     }),

--- a/apps/os2/src/domains/codemode/examples.ts
+++ b/apps/os2/src/domains/codemode/examples.ts
@@ -155,6 +155,75 @@ const codemodeExampleSeeds = [
     ],
   },
   {
+    slug: "live-connect-openapi-petstore",
+    name: "Live-connect OpenAPI Petstore",
+    description:
+      "Register Swagger Petstore from codemode itself, then immediately call the newly mounted OpenAPI operations.",
+    providers: [],
+    code: `async (ctx) => {
+  const registration = await ctx.codemode.connectToOpenApiServer({
+    path: ["live", "petstore"],
+    specUrl: "https://petstore.swagger.io/v2/swagger.json",
+    baseUrl: "https://petstore.swagger.io/v2",
+  });
+
+  const operations = await ctx.live.petstore.listOperations();
+  const pets = await ctx.live.petstore.findPetsByStatus({ status: "available" });
+  const operationIds = operations.map((operation) => operation.operationId);
+
+  return {
+    registeredPath: registration.payload.path,
+    operationCount: operations.length,
+    hasFindPetsByStatus: operationIds.includes("findPetsByStatus"),
+    firstPet: Array.isArray(pets) ? pets[0] ?? null : pets,
+  };
+}`,
+    events: [
+      {
+        type: "events.iterate.com/codemode/example-note",
+        payload: {
+          message:
+            "Registers Swagger Petstore at ctx.live.petstore via ctx.codemode.connectToOpenApiServer, then calls listOperations and findPetsByStatus.",
+        },
+      },
+    ],
+  },
+  {
+    slug: "live-connect-cloudflare-docs-mcp",
+    name: "Live-connect Cloudflare Docs MCP",
+    description:
+      "Register Cloudflare's public documentation MCP server from codemode itself, then call a real MCP search tool.",
+    providers: [],
+    code: `async (ctx) => {
+  const registration = await ctx.codemode.connectToMcpServer({
+    path: ["live", "cloudflareDocs"],
+    url: "https://docs.mcp.cloudflare.com/mcp",
+    instructions:
+      "Use ctx.live.cloudflareDocs.search_cloudflare_documentation({ query }) to search Cloudflare docs.",
+  });
+
+  const tools = await ctx.live.cloudflareDocs.listTools();
+  const searchResult = await ctx.live.cloudflareDocs.search_cloudflare_documentation({
+    query: "Durable Objects alarms",
+  });
+
+  return {
+    registeredPath: registration.payload.path,
+    toolNames: tools.tools.map((tool) => tool.name),
+    firstResult: searchResult.content?.[0] ?? searchResult,
+  };
+}`,
+    events: [
+      {
+        type: "events.iterate.com/codemode/example-note",
+        payload: {
+          message:
+            "Registers Cloudflare Docs MCP at ctx.live.cloudflareDocs via ctx.codemode.connectToMcpServer, then calls listTools and search_cloudflare_documentation.",
+        },
+      },
+    ],
+  },
+  {
     slug: "stream-append-tool",
     name: "Append to a project stream",
     description: "Use ctx.streams.append as a normal codemode function call.",
@@ -184,7 +253,7 @@ const codemodeExampleSeeds = [
       "Sketch an event-based provider for a browser extension, OpenClaw plugin, or tab runner that can only make outbound requests.",
     providers: [{ type: "iterate-browser-extension" }],
     code: `async (ctx) => {
-  const debug = await ctx.__codemode.debugInfo({
+  const debug = await ctx.codemode.debugInfo({
     source: "codemode script before browser-extension call",
   });
   console.log("session debug", debug);
@@ -201,7 +270,7 @@ const codemodeExampleSeeds = [
         type: "events.iterate.com/codemode/example-note",
         payload: {
           message:
-            "ctx.__codemode.* is always available on the session and does not require provider registration.",
+            "ctx.codemode.* is always available on the session and does not require provider registration.",
         },
       },
       {
@@ -215,7 +284,7 @@ const codemodeExampleSeeds = [
         type: "events.iterate.com/codemode/example-note",
         payload: {
           message:
-            "A Worker-side bridge for that outbound provider can reduce session-started, invoke sessionCapabilityCallable, build a codemode ctx, and call ctx.__codemode.debugInfo() or any other session tool while handling the request.",
+            "A Worker-side bridge for that outbound provider can reduce session-started, invoke sessionCapabilityCallable, build a codemode ctx, and call ctx.codemode.debugInfo() or any other session tool while handling the request.",
         },
       },
     ],

--- a/apps/os2/src/domains/google/entrypoints/gmail-capability.ts
+++ b/apps/os2/src/domains/google/entrypoints/gmail-capability.ts
@@ -1,7 +1,9 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
+import { parseAppConfigFromEnv } from "@iterate-com/shared/apps/config";
 import { createD1Client } from "sqlfu";
 import type { ExecuteCodemodeFunctionCallInput } from "@iterate-com/shared/stream-processors/codemode/implementation";
-import { getProjectSecret } from "~/domains/secrets/secrets-store.ts";
+import { AppConfig } from "~/app.ts";
+import { getFreshGoogleAccessToken } from "~/domains/secrets/oauth.ts";
 
 type GmailCapabilityEnv = {
   DB?: D1Database;
@@ -44,14 +46,16 @@ export class GmailCapability extends WorkerEntrypoint<GmailCapabilityEnv, GmailC
       throw new Error("GmailCapability requires ctx.props.projectId.");
     }
 
-    const secret = await getProjectSecret(createD1Client(this.env.DB), {
-      key: "google.access_token",
+    const config = parseAppConfigFromEnv({
+      configSchema: AppConfig,
+      env: this.env as unknown as Record<string, unknown>,
+      prefix: "APP_CONFIG_",
+    });
+    return await getFreshGoogleAccessToken({
+      config,
+      db: createD1Client(this.env.DB),
       projectId,
     });
-    if (!secret) {
-      throw new Error("GmailCapability requires a project google.access_token Secret.");
-    }
-    return secret.material;
   }
 }
 

--- a/apps/os2/src/domains/inbound-mcp-server/durable-objects/project-mcp-server-connection.ts
+++ b/apps/os2/src/domains/inbound-mcp-server/durable-objects/project-mcp-server-connection.ts
@@ -16,6 +16,7 @@ import {
   getStreamsCapability,
   type StreamsCapabilityProps,
 } from "~/domains/streams/entrypoints/streams-capability.ts";
+import { createDefaultOutboundMcpProviderRegistrations } from "~/domains/codemode/default-provider-registrations.ts";
 import { readEventPayload, stringifyPayloadError } from "~/lib/codemode-event-payload.ts";
 import { createOpenApiProviderRegistration } from "~/rpc-targets/openapi-provider-registration.ts";
 import { createOutboundMcpFromOurClientToolProviderRegistration } from "~/domains/outbound-mcp-client/utils/outbound-mcp-provider-registration.ts";
@@ -157,7 +158,7 @@ export class ProjectMcpServerConnection extends McpAgent<
 
   async init() {
     const providers = this.createStaticCodemodeToolProviders(this.requireProjectAuthProps());
-    const providerDocs = providers
+    const providerDocs = [...createDefaultOutboundMcpProviderRegistrations(), ...providers]
       .map((p) => `- ctx.${p.path.join(".")}: ${p.instructions}`)
       .join("\n");
 
@@ -169,6 +170,7 @@ export class ProjectMcpServerConnection extends McpAgent<
           "Execute JavaScript in an isolated sandbox. The code MUST be a single async arrow function: `async (ctx) => { ... }`.",
           "",
           "The function receives a `ctx` object with registered tool providers. Use `Promise.all([...])` for concurrent operations. Use `fetch` for HTTP. The return value (or thrown error) is sent back as the tool result.",
+          "If you're not sure about the shape of the result of a function call, just return it from a codemode block and you'll be shown it on your next turn.",
           "",
           "Available tool providers on ctx:",
           providerDocs,

--- a/apps/os2/src/domains/secrets/integration-api.ts
+++ b/apps/os2/src/domains/secrets/integration-api.ts
@@ -37,6 +37,9 @@ export async function handleIntegrationApiRequest(input: {
   if (url.pathname === "/api/integrations/slack/webhook") {
     return await handleSlackWebhook(input);
   }
+  if (url.pathname === "/api/integrations/slack/interactivity-webhook") {
+    return await handleSlackInteractivityWebhook(input);
+  }
   return null;
 }
 
@@ -254,6 +257,24 @@ async function handleGoogleCallback(input: {
 }
 
 async function handleSlackWebhook(input: { context: AppContext; request: Request }) {
+  return await handleVerifiedSlackWebhook({
+    ...input,
+    parsePayload: parseSlackJsonPayload,
+  });
+}
+
+async function handleSlackInteractivityWebhook(input: { context: AppContext; request: Request }) {
+  return await handleVerifiedSlackWebhook({
+    ...input,
+    parsePayload: parseSlackInteractivityPayload,
+  });
+}
+
+async function handleVerifiedSlackWebhook(input: {
+  context: AppContext;
+  parsePayload(body: string): Record<string, unknown> | null;
+  request: Request;
+}) {
   const config = requireSlackConfig(input.context.config);
   const body = await input.request.text();
   const valid = await verifySlackSignature({
@@ -264,9 +285,9 @@ async function handleSlackWebhook(input: { context: AppContext; request: Request
   });
   if (!valid) return Response.json({ error: "Invalid Slack signature." }, { status: 401 });
 
-  const payload = parseSlackPayload(body);
+  const payload = input.parsePayload(body);
   if (!payload)
-    return Response.json({ error: "Slack webhook payload is invalid JSON." }, { status: 400 });
+    return Response.json({ error: "Slack webhook payload is invalid." }, { status: 400 });
   if (payload.type === "url_verification") {
     return Response.json({ challenge: payload.challenge });
   }
@@ -304,13 +325,14 @@ async function handleSlackWebhook(input: { context: AppContext; request: Request
     idempotencyKey:
       typeof payload.event_id === "string"
         ? `slack-webhook:${payload.event_id}`
-        : `slack-webhook:${crypto.randomUUID()}`,
+        : typeof payload.trigger_id === "string"
+          ? `slack-webhook:${payload.trigger_id}`
+          : `slack-webhook:${crypto.randomUUID()}`,
     payload: {
       headers: {
         slackEventId: input.request.headers.get("x-slack-event-id"),
         slackRequestTimestamp: input.request.headers.get("x-slack-request-timestamp"),
       },
-      projectId: connection.projectId,
       slackTeamId: teamId,
       body: payload,
     },
@@ -349,7 +371,7 @@ function readSlackTeamId(payload: Record<string, unknown>) {
   return null;
 }
 
-function parseSlackPayload(body: string) {
+function parseSlackJsonPayload(body: string) {
   try {
     const payload = JSON.parse(body) as unknown;
     if (payload && typeof payload === "object" && !Array.isArray(payload)) {
@@ -359,6 +381,12 @@ function parseSlackPayload(body: string) {
   } catch {
     return null;
   }
+}
+
+function parseSlackInteractivityPayload(body: string) {
+  const payload = new URLSearchParams(body).get("payload");
+  if (!payload) return null;
+  return parseSlackJsonPayload(payload);
 }
 
 async function verifySlackSignature(input: {

--- a/apps/os2/src/domains/secrets/oauth.test.ts
+++ b/apps/os2/src/domains/secrets/oauth.test.ts
@@ -1,0 +1,157 @@
+import { parseAppConfigFromEnv } from "@iterate-com/shared/apps/config";
+import type { Client, QueryArg, SqlQuery } from "sqlfu";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { AppConfig } from "~/app.ts";
+import { getFreshGoogleAccessToken } from "~/domains/secrets/oauth.ts";
+
+type SecretRow = {
+  id: string;
+  project_id: string;
+  key: string;
+  material: string;
+  metadata: string;
+  created_at: string;
+  updated_at: string;
+};
+
+describe("getFreshGoogleAccessToken", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("returns the stored access token when it is not near expiry", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const secret = googleSecretRow({
+      material: "stored-access-token",
+      metadata: {
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        refreshToken: "refresh-token",
+      },
+    });
+
+    await expect(
+      getFreshGoogleAccessToken({
+        config: testConfig(),
+        db: testDb({ secret }),
+        projectId: "proj_test",
+      }),
+    ).resolves.toBe("stored-access-token");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("refreshes and persists an expired access token", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        access_token: "refreshed-access-token",
+        expires_in: 3920,
+        scope:
+          "https://www.googleapis.com/auth/gmail.modify https://www.googleapis.com/auth/gmail.send",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const updates: Array<{ args: QueryArg[] }> = [];
+    const secret = googleSecretRow({
+      material: "expired-access-token",
+      metadata: {
+        email: "user@example.com",
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+        refreshToken: "refresh-token",
+      },
+    });
+
+    await expect(
+      getFreshGoogleAccessToken({
+        config: testConfig(),
+        db: testDb({ secret, updates }),
+        projectId: "proj_test",
+      }),
+    ).resolves.toBe("refreshed-access-token");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://oauth2.googleapis.com/token",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.any(URLSearchParams),
+      }),
+    );
+    const refreshRequest = fetchMock.mock.calls[0]?.[1] as { body: URLSearchParams } | undefined;
+    expect(refreshRequest?.body.get("grant_type")).toBe("refresh_token");
+    expect(refreshRequest?.body.get("refresh_token")).toBe("refresh-token");
+
+    expect(updates).toHaveLength(1);
+    const [, , , material, rawMetadata] = updates[0]!.args;
+    expect(material).toBe("refreshed-access-token");
+    expect(JSON.parse(String(rawMetadata))).toMatchObject({
+      email: "user@example.com",
+      refreshToken: "refresh-token",
+      scopes: [
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/gmail.send",
+      ],
+    });
+  });
+});
+
+function testConfig() {
+  return parseAppConfigFromEnv({
+    configSchema: AppConfig,
+    prefix: "APP_CONFIG_",
+    env: {
+      APP_CONFIG: JSON.stringify({
+        clerk: {
+          publishableKey: "pk_test_google",
+          secretKey: "sk_test_google",
+          jwtKey: "jwt-test-key",
+        },
+        integrations: {
+          google: {
+            oauthClientId: "google-client-id",
+            oauthClientSecret: "google-client-secret",
+          },
+        },
+        openAiApiKey: "openai-test-key",
+      }),
+    },
+  });
+}
+
+function googleSecretRow(input: {
+  material: string;
+  metadata: Record<string, unknown>;
+}): SecretRow {
+  return {
+    id: "sec_test",
+    project_id: "proj_test",
+    key: "google.access_token",
+    material: input.material,
+    metadata: JSON.stringify(input.metadata),
+    created_at: "2026-05-13 12:00:00",
+    updated_at: "2026-05-13 12:00:00",
+  };
+}
+
+function testDb(input: { secret: SecretRow; updates?: Array<{ args: QueryArg[] }> }): Client {
+  const db = {
+    all: async <TRow extends object>(query: SqlQuery) => {
+      if (query.name === "getProjectSecret") return [input.secret] as TRow[];
+      if (query.name === "upsertProjectSecret") {
+        input.updates?.push({ args: query.args });
+        return [
+          {
+            ...input.secret,
+            key: String(query.args[2]),
+            material: String(query.args[3]),
+            metadata: String(query.args[4]),
+            updated_at: "2026-05-13 12:01:00",
+          },
+        ] as TRow[];
+      }
+      throw new Error(`Unexpected query: ${query.name ?? query.sql}`);
+    },
+    run: async () => ({ rowsAffected: 1 }),
+  };
+  return db as unknown as Client;
+}

--- a/apps/os2/src/domains/secrets/oauth.ts
+++ b/apps/os2/src/domains/secrets/oauth.ts
@@ -6,9 +6,11 @@ import {
   deleteProjectSecret,
   getProjectConnection,
   getProjectSecret,
+  upsertProjectSecret,
 } from "~/domains/secrets/secrets-store.ts";
 
 type OAuthProvider = "google" | "slack";
+const GOOGLE_ACCESS_TOKEN_REFRESH_SKEW_MS = 5 * 60 * 1000;
 
 export function requireSlackConfig(config: AppConfig) {
   const slack = config.integrations.slack;
@@ -120,6 +122,74 @@ export async function disconnectProvider(input: {
   return { success: true };
 }
 
+export async function getFreshGoogleAccessToken(input: {
+  config: AppConfig;
+  db: Client;
+  projectId: string;
+}) {
+  const secret = await getProjectSecret(input.db, {
+    key: providerSecretKey("google"),
+    projectId: input.projectId,
+  });
+  if (!secret) {
+    throw new Error("GmailCapability requires a project google.access_token Secret.");
+  }
+
+  const expiresAt = readStringMetadata(secret.metadata, "expiresAt");
+  if (!expiresAt || Date.parse(expiresAt) > Date.now() + GOOGLE_ACCESS_TOKEN_REFRESH_SKEW_MS) {
+    return secret.material;
+  }
+
+  const refreshToken = readStringMetadata(secret.metadata, "refreshToken");
+  if (!refreshToken) {
+    throw new Error(
+      "Google access token expired and no refresh token is stored. Reconnect Google.",
+    );
+  }
+
+  const google = requireGoogleConfig(input.config);
+  const tokenResponse = await fetch("https://oauth2.googleapis.com/token", {
+    body: new URLSearchParams({
+      client_id: google.oauthClientId,
+      client_secret: google.oauthClientSecret.exposeSecret(),
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    method: "POST",
+  });
+  const tokenData = (await tokenResponse.json()) as {
+    access_token?: string;
+    error?: string;
+    error_description?: string;
+    expires_in?: number;
+    refresh_token?: string;
+    scope?: string;
+  };
+
+  if (!tokenResponse.ok || !tokenData.access_token) {
+    const reason = tokenData.error_description ?? tokenData.error ?? "google_token_refresh_failed";
+    throw new Error(`Google access token refresh failed: ${reason}`);
+  }
+
+  await upsertProjectSecret(input.db, {
+    key: providerSecretKey("google"),
+    material: tokenData.access_token,
+    metadata: {
+      ...secret.metadata,
+      expiresAt:
+        typeof tokenData.expires_in === "number"
+          ? new Date(Date.now() + tokenData.expires_in * 1000).toISOString()
+          : expiresAt,
+      refreshToken: tokenData.refresh_token ?? refreshToken,
+      ...(tokenData.scope ? { scopes: tokenData.scope.split(" ") } : {}),
+    },
+    projectId: input.projectId,
+  });
+
+  return tokenData.access_token;
+}
+
 export function providerSecretKey(provider: OAuthProvider) {
   return `${provider}.access_token`;
 }
@@ -155,4 +225,9 @@ function base64Url(bytes: Uint8Array) {
   let binary = "";
   for (const byte of bytes) binary += String.fromCharCode(byte);
   return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function readStringMetadata(metadata: Record<string, unknown>, key: string) {
+  const value = metadata[key];
+  return typeof value === "string" && value.trim() ? value : null;
 }

--- a/apps/os2/src/durable-objects/codemode-session.test.ts
+++ b/apps/os2/src/durable-objects/codemode-session.test.ts
@@ -382,7 +382,7 @@ describe("CodemodeSession", () => {
 
     const created = await session.createSession({
       events: codemodeSessionStartupEvents({
-        providers: [providerRegistration(["discord"]), providerRegistration(["slack"])],
+        providers: [providerRegistration(["discord"]), providerRegistration(["mirrorSlack"])],
         streamPath,
       }),
       code: `async (ctx) => {
@@ -408,8 +408,8 @@ describe("CodemodeSession", () => {
 
     // This block is the event-provider proof: a Discord-style stream processor
     // reduces session-started, invokes the Session Capability Callable, builds a
-    // Codemode Context, and then calls a Slack Tool Function without becoming an
-    // RPC provider itself.
+    // Codemode Context, and then calls another event-mediated Tool Function
+    // without becoming an RPC provider itself.
     const codemodeSessionCapability = await dispatchCallable({
       callable: (sessionStarted!.payload as { sessionCapabilityCallable: unknown })
         .sessionCapabilityCallable,
@@ -422,13 +422,13 @@ describe("CodemodeSession", () => {
       >[0]["codemodeSessionCapability"],
       scriptExecutionId,
     });
-    const slackCall = providerCtx.slack.chat.postMessage({
+    const slackCall = providerCtx.mirrorSlack.chat.postMessage({
       channel: "C123",
       text: "Released v1.2.3 to Discord message discord-msg-1",
     });
 
     const slackRequest = await waitForFunctionCallRequested({
-      path: ["slack", "chat", "postMessage"],
+      path: ["mirrorSlack", "chat", "postMessage"],
       streamPath,
     });
     await session.receiveFunctionCallResult({
@@ -436,8 +436,8 @@ describe("CodemodeSession", () => {
       functionPath: ["chat", "postMessage"],
       invocationKind: "event",
       outcome: { status: "returned", value: { ok: true, ts: "123.456" } },
-      path: ["slack", "chat", "postMessage"],
-      providerPath: ["slack"],
+      path: ["mirrorSlack", "chat", "postMessage"],
+      providerPath: ["mirrorSlack"],
       scriptExecutionId,
     });
     await expect(slackCall).resolves.toEqual({ ok: true, ts: "123.456" });
@@ -477,11 +477,75 @@ describe("CodemodeSession", () => {
           "event",
         ),
         functionCallRequestedWithKind(
-          ["slack", "chat", "postMessage"],
-          ["slack"],
+          ["mirrorSlack", "chat", "postMessage"],
+          ["mirrorSlack"],
           ["chat", "postMessage"],
           "event",
         ),
+      ]),
+    );
+  });
+
+  test("lets codemode helpers register MCP and OpenAPI providers", async () => {
+    const streamPath = `/codemode-session-tests/${crypto.randomUUID()}` as StreamPath;
+    const session = await initializeSession(streamPath);
+
+    const created = await session.createSession({
+      code: `async (ctx) => {
+  const mcp = await ctx.codemode.connectToMcpServer({
+    path: ["mcp", "custom"],
+    url: "https://example.com/mcp",
+  });
+  const openApi = await ctx.codemode.connectToOpenApiServer({
+    path: ["api", "custom"],
+    specUrl: "https://example.com/openapi.json",
+    baseUrl: "https://example.com",
+  });
+
+  return {
+    mcpPath: mcp.payload.path,
+    openApiPath: openApi.payload.path,
+    openApiExportName: openApi.payload.invocation.callable.via.exportName,
+  };
+}`,
+    });
+    const scriptExecutionId = scriptExecutionIdFromEvent(created.scriptExecutionEvent);
+
+    const completed = await waitForScriptExecutionCompleted({ scriptExecutionId, streamPath });
+    expect(completed.payload).toMatchObject({
+      outcome: {
+        status: "returned",
+        value: {
+          mcpPath: ["mcp", "custom"],
+          openApiPath: ["api", "custom"],
+          openApiExportName: "OpenApiBridge",
+        },
+      },
+    });
+    expect(await readCurrentStreamEvents(streamPath)).toEqual(
+      expect.arrayContaining([
+        functionCallRequested(
+          ["codemode", "connectToMcpServer"],
+          ["codemode"],
+          ["connectToMcpServer"],
+        ),
+        expect.objectContaining({
+          type: "events.iterate.com/codemode/tool-provider-registered",
+          payload: expect.objectContaining({
+            path: ["mcp", "custom"],
+          }),
+        }),
+        functionCallRequested(
+          ["codemode", "connectToOpenApiServer"],
+          ["codemode"],
+          ["connectToOpenApiServer"],
+        ),
+        expect.objectContaining({
+          type: "events.iterate.com/codemode/tool-provider-registered",
+          payload: expect.objectContaining({
+            path: ["api", "custom"],
+          }),
+        }),
       ]),
     );
   });
@@ -496,7 +560,7 @@ describe("CodemodeSession", () => {
         streamPath,
       }),
       code: `async (ctx) => {
-  const ping = await ctx.__codemode.ping();
+  const ping = await ctx.codemode.ping();
   const navigation = await ctx.iterateBrowserExtension.navigateToPage({
     url: "https://example.com",
   });
@@ -532,15 +596,15 @@ describe("CodemodeSession", () => {
       >[0]["codemodeSessionCapability"],
       scriptExecutionId,
     });
-    const debugInfo = await providerCtx.__codemode.debugInfo({
+    const debugInfo = await providerCtx.codemode.debugInfo({
       provider: "iterateBrowserExtension",
       reason: "navigateToPage completed from outbound-only provider",
     });
     expect(debugInfo).toMatchObject({
       functionPath: ["debugInfo"],
       invocationKind: "rpc",
-      path: ["__codemode", "debugInfo"],
-      providerPath: ["__codemode"],
+      path: ["codemode", "debugInfo"],
+      providerPath: ["codemode"],
       scriptExecutionId,
       streamPath,
     });
@@ -577,16 +641,16 @@ describe("CodemodeSession", () => {
     });
     expect(await readCurrentStreamEvents(streamPath)).toEqual(
       expect.arrayContaining([
-        functionCallRequested(["__codemode", "ping"], ["__codemode"], ["ping"]),
-        functionCallCompleted(["__codemode", "ping"], ["__codemode"], ["ping"]),
+        functionCallRequested(["codemode", "ping"], ["codemode"], ["ping"]),
+        functionCallCompleted(["codemode", "ping"], ["codemode"], ["ping"]),
         functionCallRequestedWithKind(
           ["iterateBrowserExtension", "navigateToPage"],
           ["iterateBrowserExtension"],
           ["navigateToPage"],
           "event",
         ),
-        functionCallRequested(["__codemode", "debugInfo"], ["__codemode"], ["debugInfo"]),
-        functionCallCompleted(["__codemode", "debugInfo"], ["__codemode"], ["debugInfo"]),
+        functionCallRequested(["codemode", "debugInfo"], ["codemode"], ["debugInfo"]),
+        functionCallCompleted(["codemode", "debugInfo"], ["codemode"], ["debugInfo"]),
       ]),
     );
   });

--- a/apps/os2/src/orpc/routers/integrations.ts
+++ b/apps/os2/src/orpc/routers/integrations.ts
@@ -4,6 +4,7 @@ import {
   createGoogleAuthorizationUrl,
   createSlackAuthorizationUrl,
   disconnectProvider,
+  providerSecretKey,
   requestBaseUrl,
 } from "~/domains/secrets/oauth.ts";
 import {
@@ -11,7 +12,7 @@ import {
   GOOGLE_DISCONNECTED_EVENT_TYPE,
   SLACK_DISCONNECTED_EVENT_TYPE,
 } from "~/domains/secrets/integration-streams.ts";
-import { getProjectConnection } from "~/domains/secrets/secrets-store.ts";
+import { getProjectConnection, getProjectSecret } from "~/domains/secrets/secrets-store.ts";
 import { os, projectScopeMiddleware } from "~/orpc/orpc.ts";
 import { requireProjectScope } from "~/orpc/project-access.ts";
 
@@ -139,8 +140,14 @@ async function connectionStatus(context: AppContext, provider: "google" | "slack
       externalId: null,
       metadata: {},
       scopes: null,
+      token: null,
     };
   }
+
+  const secret = await getProjectSecret(context.db, {
+    key: providerSecretKey(provider),
+    projectId: project.id,
+  });
 
   return {
     connected: true,
@@ -148,6 +155,15 @@ async function connectionStatus(context: AppContext, provider: "google" | "slack
     externalId: connection.externalId,
     metadata: connection.providerData,
     scopes: connection.scopes,
+    token: secret
+      ? {
+          createdAt: secret.createdAt,
+          expiresAt: readStringMetadata(secret.metadata, "expiresAt"),
+          hasMaterial: secret.material.length > 0,
+          refreshTokenStored: readStringMetadata(secret.metadata, "refreshToken") !== null,
+          updatedAt: secret.updatedAt,
+        }
+      : null,
   };
 }
 

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/integrations.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/integrations.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { ProjectIntegrationConnection } from "@iterate-com/os2-contract";
 import { Button } from "@iterate-com/ui/components/button";
 import {
   Item,
@@ -13,7 +14,7 @@ import {
 } from "@iterate-com/ui/components/item";
 import { Spinner } from "@iterate-com/ui/components/spinner";
 import { toast } from "@iterate-com/ui/components/sonner";
-import { Mail, MessageSquare } from "lucide-react";
+import { Circle, Mail, MessageSquare } from "lucide-react";
 import { z } from "zod";
 import { orpc } from "~/orpc/client.ts";
 
@@ -107,6 +108,7 @@ function ProjectIntegrationsPage() {
                 ? `Connected to ${slackConnection.displayName ?? slackConnection.externalId}`
                 : "Connect a Slack workspace to receive project webhooks and use Slack API tools."}
             </ItemDescription>
+            <IntegrationMetadata connection={slackConnection} provider="slack" />
           </ItemContent>
           <ItemActions>
             {slackConnection?.connected ? (
@@ -148,6 +150,7 @@ function ProjectIntegrationsPage() {
                 ? `Connected as ${googleConnection.displayName ?? googleConnection.externalId}`
                 : "Connect Google for Gmail, Calendar, Docs, Sheets, and Drive API tools."}
             </ItemDescription>
+            <IntegrationMetadata connection={googleConnection} provider="google" />
           </ItemContent>
           <ItemActions>
             {googleConnection?.connected ? (
@@ -180,4 +183,109 @@ function ProjectIntegrationsPage() {
       </ItemGroup>
     </section>
   );
+}
+
+function IntegrationMetadata({
+  connection,
+  provider,
+}: {
+  connection?: ProjectIntegrationConnection;
+  provider: "google" | "slack";
+}) {
+  if (!connection?.connected) return null;
+
+  const token = connection.token;
+  const scopeCount = countScopes(connection.scopes, provider === "slack" ? "," : " ");
+  const expiry = token?.expiresAt ? formatExpiry(token.expiresAt) : null;
+
+  return (
+    <div className="mt-2 grid gap-1.5 text-xs text-muted-foreground">
+      {expiry ? (
+        <IntegrationMetadataRow label="Token expiry" value={expiry.label} tone={expiry.tone} />
+      ) : (
+        <IntegrationMetadataRow label="Token expiry" value="Not provided" />
+      )}
+      <IntegrationMetadataRow
+        label="Access token"
+        value={token?.hasMaterial ? "Stored" : "Missing"}
+        tone={token?.hasMaterial ? "ok" : "danger"}
+      />
+      {provider === "google" || token?.refreshTokenStored ? (
+        <IntegrationMetadataRow
+          label="Refresh token"
+          value={token?.refreshTokenStored ? "Stored" : "Not stored"}
+          tone={provider === "google" && token?.refreshTokenStored ? "ok" : undefined}
+        />
+      ) : null}
+      {token?.createdAt ? (
+        <IntegrationMetadataRow label="Secret created" value={formatTimestamp(token.createdAt)} />
+      ) : null}
+      {token?.updatedAt ? (
+        <IntegrationMetadataRow label="Secret updated" value={formatTimestamp(token.updatedAt)} />
+      ) : null}
+      <IntegrationMetadataRow label="External ID" value={connection.externalId ?? "Unknown"} />
+      <IntegrationMetadataRow
+        label="Scopes"
+        value={scopeCount === 1 ? "1 scope" : `${scopeCount} scopes`}
+      />
+    </div>
+  );
+}
+
+function IntegrationMetadataRow({
+  label,
+  tone,
+  value,
+}: {
+  label: string;
+  tone?: "danger" | "ok" | "warning";
+  value: string;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      <Circle className={`size-2 shrink-0 fill-current ${toneClassName(tone)}`} />
+      <span className="shrink-0 text-muted-foreground/80">{label}</span>
+      <span className="truncate text-foreground">{value}</span>
+    </div>
+  );
+}
+
+function toneClassName(tone: "danger" | "ok" | "warning" | undefined) {
+  if (tone === "danger") return "text-destructive";
+  if (tone === "ok") return "text-emerald-600";
+  if (tone === "warning") return "text-amber-600";
+  return "text-muted-foreground/50";
+}
+
+function formatExpiry(value: string) {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    return { label: value, tone: undefined };
+  }
+
+  const now = Date.now();
+  const prefix = timestamp <= now ? "Expired" : "Expires";
+  const tone: "danger" | "ok" | "warning" =
+    timestamp <= now ? "danger" : timestamp - now < 10 * 60 * 1000 ? "warning" : "ok";
+  return {
+    label: `${prefix} ${formatTimestamp(value)}`,
+    tone,
+  };
+}
+
+function formatTimestamp(value: string) {
+  const timestamp = Date.parse(value.endsWith("Z") || value.includes("T") ? value : `${value}Z`);
+  if (!Number.isFinite(timestamp)) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(timestamp));
+}
+
+function countScopes(scopes: string | null, separator: "," | " ") {
+  if (!scopes) return 0;
+  return scopes
+    .split(separator)
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0).length;
 }

--- a/apps/os2/tasks/github-integration-for-os2.md
+++ b/apps/os2/tasks/github-integration-for-os2.md
@@ -1,0 +1,261 @@
+---
+state: todo
+priority: high
+size: large
+dependsOn: []
+---
+
+# GitHub Integration for OS2
+
+Captured: 2026-05-13
+
+## Objective
+
+Add a GitHub integration to OS2 that mirrors the Slack integration shape:
+
+- GitHub App installation and connection state are project-scoped.
+- Inbound GitHub webhooks are verified, resolved to the claimed project, and
+  appended to a project integration stream.
+- Codemode and agents get a GitHub API tool provider backed by Octokit and a
+  GitHub App installation.
+
+## Current Findings
+
+`apps/os` has a large GitHub module at
+`apps/os/backend/integrations/github/github.ts`. It handles GitHub App install
+callback, installation token minting, repo listing, config repo selection,
+webhook signature verification, outbox dedupe, forwarding raw webhooks to active
+machines, config repo reloads, and special machine recreation from `[refresh]`
+commit comments.
+
+Do not port that module directly. Much of it is OS1 machine lifecycle behavior.
+OS2 should use its existing stream and capability model.
+
+Relevant OS2 foundations already exist:
+
+- `project_connections` stores provider connection rows.
+- `project_connections.webhook_provider_identifier` supports globally unique
+  webhook routing claims, currently used by Slack team IDs.
+- `project_secrets` stores project secrets for Slack/Google.
+- `oauth_states` stores short-lived provider callback state.
+- `src/domains/secrets/integration-api.ts` routes Slack/Google callbacks and
+  Slack webhooks.
+- Slack appends raw webhooks to `/integrations/slack` as
+  `events.iterate.com/slack/webhook-received`.
+- `SlackCapability` exposes `ctx.slack.*` by reading a project Slack token and
+  calling the Slack Web API.
+
+## Target Shape
+
+Use provider name `github` in OS2, not legacy `github-app`.
+
+`project_connections` row:
+
+- `provider`: `github`
+- `external_id`: GitHub installation ID as a string
+- `webhook_provider_identifier`: GitHub installation ID as a string
+- `provider_data`:
+  - `installationId`
+  - `accountId`
+  - `accountLogin`
+  - `accountType`
+  - `repositorySelection`
+  - `installedByUserId`
+
+Route inbound GitHub webhooks by `payload.installation.id`. This is the GitHub
+equivalent of Slack routing by `team_id`.
+
+Do not persist GitHub installation access tokens as long-lived project secrets.
+GitHub App installation tokens expire quickly, so the GitHub codemode provider
+should mint fresh installation-scoped Octokit clients from runtime GitHub App
+config.
+
+## Runtime Config
+
+Extend `AppConfig.integrations` with GitHub App config:
+
+- `appId`
+- `appSlug`
+- `privateKey`
+- `webhookSecret`
+- `oauthClientId` if using GitHub user OAuth during install
+- `oauthClientSecret` if using GitHub user OAuth during install
+
+Prefer Octokit's GitHub App client for installation-scoped API access:
+
+- `new App({ appId, privateKey, webhooks: { secret } })`
+- `app.getInstallationOctokit(installationId)`
+
+Keep webhook signature verification explicit in the fetch handler, like Slack,
+rather than depending on Node middleware.
+
+## Integration API
+
+Add handling in `src/domains/secrets/integration-api.ts`:
+
+- `/api/integrations/github/callback`
+- `/api/integrations/github/webhook`
+
+Callback flow:
+
+- Consume `oauth_states` for provider `github`.
+- Require Clerk callback user to match the state user.
+- Read `installation_id`.
+- Build a GitHub App client.
+- Fetch installation/account metadata.
+- Check whether the installation ID is already claimed by another project.
+- Upsert the `project_connections` row.
+- Append `events.iterate.com/github/connected` to `/integrations/github`.
+- Redirect back to the original callback URL.
+
+Webhook flow:
+
+- Read the raw body.
+- Verify `x-hub-signature-256` using configured webhook secret.
+- Require `x-github-event` and `x-github-delivery`.
+- Parse JSON payload.
+- Resolve `payload.installation.id`.
+- Find the claimed project by `(provider, webhook_provider_identifier)`.
+- Append to `/integrations/github`.
+
+Suggested raw webhook event:
+
+```ts
+{
+  type: "events.iterate.com/github/webhook-received",
+  idempotencyKey: `github-webhook:${deliveryId}`,
+  payload: {
+    action,
+    body,
+    deliveryId,
+    githubEvent,
+    headers: {
+      githubDelivery,
+      githubEvent,
+    },
+    installationId,
+    repositoryFullName,
+  },
+}
+```
+
+## Project RPC and UI
+
+Add contract and router methods next to Slack/Google:
+
+- `getGithubConnection`
+- `startGithubInstallFlow`
+- `disconnectGithub`
+- `listGithubRepositories` if repo selection is needed
+
+Update the integrations page to add a GitHub card with connect, disconnect,
+connection metadata, token/material status where relevant, and scope/permission
+summary if useful.
+
+For install start, return:
+
+```txt
+https://github.com/apps/{appSlug}/installations/new?state={state}
+```
+
+## Codemode Provider
+
+Add a GitHub capability entrypoint and export it from `entry.workerd.ts`.
+
+Recommended first provider API:
+
+```ts
+ctx.github.request({
+  route: "GET /repos/{owner}/{repo}/issues",
+  owner,
+  repo,
+  per_page: 20,
+});
+
+ctx.github.paginate({
+  route: "GET /repos/{owner}/{repo}/pulls",
+  owner,
+  repo,
+  state: "open",
+});
+```
+
+Capability behavior:
+
+- Require `DB` binding and `projectId` props.
+- Read the project GitHub connection.
+- Extract `installationId`.
+- Parse OS2 `AppConfig`.
+- Create a GitHub App client.
+- Get an installation-scoped Octokit.
+- Dispatch `octokit.request(...)` or `octokit.paginate(...)`.
+- Return a stable JSON response shape.
+
+Register the provider in:
+
+- `createDefaultCodemodeProviderRegistrations`
+- `createExampleCapabilityProviders`
+- `AgentDurableObject.createCodemodeToolProviders`
+- codemode tests where provider lists are asserted
+
+## Optional GitHub Processor
+
+If GitHub webhooks should wake or drive agents, add a shared stream processor
+after the base integration works.
+
+Processor target:
+
+- Mounted on `/integrations/github`.
+- Slug: `github`.
+- Reduces connected/disconnected state.
+- Consumes `events.iterate.com/github/webhook-received`.
+- Routes pull request events to a stream like
+  `/agents/github/{owner}/{repo}/pulls/{number}`.
+- Routes issue events to a stream like
+  `/agents/github/{owner}/{repo}/issues/{number}`.
+- Forwards the original webhook unchanged to the routed stream.
+- Leaves agent semantics to a downstream GitHub agent processor or generic
+  agent setup.
+
+This should be a second slice. The first slice should prove connection,
+webhook ingestion, and API capability.
+
+## Dependencies
+
+- Add `octokit` to `apps/os2/package.json`.
+- Regenerate lockfile with pnpm.
+- If schema changes are needed, use sqlfu:
+  - update `src/db/definitions.sql`
+  - run `pnpm sqlfu:generate`
+  - check generated migrations
+
+No schema change is expected for the basic implementation because the existing
+connections/secrets/oauth tables are generic enough.
+
+## Testing Plan
+
+- App config parsing accepts GitHub runtime config.
+- Install URL generation creates a state row and correct GitHub App install URL.
+- Callback rejects missing/expired state and user mismatch.
+- Callback upserts a GitHub connection and emits a connected event.
+- Callback rejects an installation already claimed by another project.
+- Webhook handler rejects missing/invalid signature.
+- Webhook handler rejects missing delivery/event/installation ID.
+- Webhook handler appends a deduped raw event to `/integrations/github`.
+- GitHubCapability fails clearly when no project connection exists.
+- GitHubCapability uses an installation-scoped Octokit client and dispatches
+  `request` and `paginate`.
+- Integrations UI shows connected and disconnected states.
+
+## Risks and Open Questions
+
+- GitHub App permissions need deliberate design. The App settings must include
+  every REST operation agents should use, such as contents, issues, pull
+  requests, checks/actions, statuses, and metadata.
+- Decide whether GitHub user OAuth is needed during installation. A pure App
+  installation flow may be enough for project-level access.
+- Decide whether OS1 config repo behavior belongs in OS2. Current evidence says
+  no for the first slice.
+- Decide how PR/issue agent routing should work before adding a GitHub
+  processor. Slack-style routing is a good model, but GitHub route keys and
+  stream path naming need explicit product decisions.

--- a/packages/shared/src/stream-processors/agent/implementation.ts
+++ b/packages/shared/src/stream-processors/agent/implementation.ts
@@ -546,7 +546,7 @@ function eventTypeExplanation(eventType: string): string | null {
     return eventTypeExplanationBlock({
       type: eventType,
       meaning:
-        "A codemode tool provider is now available. Call it as `ctx.<path>.<method>(args)` in your codemode scripts. The event below shows the provider's path and usage instructions.",
+        "A codemode tool provider is now available. Call it as `ctx.<path>.<method>(args)` in your codemode scripts. If you're not sure about the shape of the result of a function call, just return it from a codemode block and you'll be shown it on your next turn. The event below shows the provider's path and usage instructions.",
     });
   }
   return null;

--- a/packages/shared/src/stream-processors/codemode/contract.ts
+++ b/packages/shared/src/stream-processors/codemode/contract.ts
@@ -142,7 +142,8 @@ export const CodemodeProcessorContract = defineProcessorContract({
           },
         },
         {
-          description: "Acknowledge immediately then do work in parallel (Slack best practice)",
+          description:
+            "When a Slack reply is needed, acknowledge immediately then do work in parallel",
           payload: {
             code: [
               "async (ctx) => {",

--- a/packages/shared/src/stream-processors/codemode/implementation.test.ts
+++ b/packages/shared/src/stream-processors/codemode/implementation.test.ts
@@ -351,7 +351,7 @@ describe("createCodemodeProcessor", () => {
     ]);
   });
 
-  it("serves __codemode builtins without a registered provider", async () => {
+  it("serves codemode builtins without a registered provider", async () => {
     const appended: StreamEventInput[] = [];
     const processor = createCodemodeProcessor({
       ...baseDeps(),
@@ -359,7 +359,7 @@ describe("createCodemodeProcessor", () => {
       scriptExecutor: async ({ session }) => {
         const output = await session.callFunction({
           args: [{ source: "test" }],
-          path: ["__codemode", "debugInfo"],
+          path: ["codemode", "debugInfo"],
         });
         return { result: output };
       },
@@ -369,7 +369,7 @@ describe("createCodemodeProcessor", () => {
       event: consumedCodemodeEvent({
         type: "events.iterate.com/codemode/script-execution-requested",
         payload: {
-          code: "async (ctx) => ctx.__codemode.debugInfo({ source: 'test' })",
+          code: "async (ctx) => ctx.codemode.debugInfo({ source: 'test' })",
           scriptExecutionId: "scr-debug",
         },
         offset: 17,
@@ -392,8 +392,8 @@ describe("createCodemodeProcessor", () => {
           functionCallId: "fn-debug",
           functionPath: ["debugInfo"],
           invocationKind: "rpc",
-          path: ["__codemode", "debugInfo"],
-          providerPath: ["__codemode"],
+          path: ["codemode", "debugInfo"],
+          providerPath: ["codemode"],
           scriptExecutionId: "scr-debug",
         },
       },
@@ -411,14 +411,14 @@ describe("createCodemodeProcessor", () => {
               functionCallId: "fn-debug",
               functionPath: ["debugInfo"],
               invocationKind: "rpc",
-              path: ["__codemode", "debugInfo"],
-              providerPath: ["__codemode"],
+              path: ["codemode", "debugInfo"],
+              providerPath: ["codemode"],
               scriptExecutionId: "scr-debug",
               streamPath: "/projects/prj_test/codemode-sessions/cblk_test",
             },
           },
-          path: ["__codemode", "debugInfo"],
-          providerPath: ["__codemode"],
+          path: ["codemode", "debugInfo"],
+          providerPath: ["codemode"],
           scriptExecutionId: "scr-debug",
         },
       },
@@ -433,8 +433,8 @@ describe("createCodemodeProcessor", () => {
               functionCallId: "fn-debug",
               functionPath: ["debugInfo"],
               invocationKind: "rpc",
-              path: ["__codemode", "debugInfo"],
-              providerPath: ["__codemode"],
+              path: ["codemode", "debugInfo"],
+              providerPath: ["codemode"],
               scriptExecutionId: "scr-debug",
               streamPath: "/projects/prj_test/codemode-sessions/cblk_test",
             },

--- a/packages/shared/src/stream-processors/codemode/implementation.ts
+++ b/packages/shared/src/stream-processors/codemode/implementation.ts
@@ -217,7 +217,7 @@ async function callFunction(args: {
     // Temporary duplication with the OS2 CodemodeSession host. The cleaner
     // design is for every script and provider call to go through one session
     // capability implementation. Keeping this local branch is awkward, but it
-    // makes `ctx.__codemode.*` truly always available in the portable processor
+    // makes `ctx.codemode.*` truly always available in the portable processor
     // while the host/session split is still settling.
     const requestedEvent = await args.streamApi.append({
       event: {
@@ -516,10 +516,10 @@ function isPathPrefix(prefix: readonly string[], path: readonly string[]) {
 }
 
 function resolveCodemodeBuiltin(path: readonly string[]) {
-  if (path[0] !== "__codemode") return null;
+  if (path[0] !== "codemode") return null;
   return {
     functionPath: path.slice(1),
-    providerPath: ["__codemode"],
+    providerPath: ["codemode"],
   };
 }
 
@@ -547,7 +547,7 @@ function runCodemodeBuiltin(args: {
     };
   }
 
-  throw new Error(`Unknown codemode builtin __codemode.${name}`);
+  throw new Error(`Unknown codemode builtin codemode.${name}`);
 }
 
 function serializeTraceValue(value: unknown): unknown {

--- a/packages/shared/src/stream-processors/slack-agent/implementation.ts
+++ b/packages/shared/src/stream-processors/slack-agent/implementation.ts
@@ -32,7 +32,7 @@ export function createSlackAgentProcessor(deps: SlackAgentProcessorDeps = {}) {
                 path: ["slack", "agent"],
                 invocation: { kind: "event" },
                 instructions:
-                  "Use ctx.slack.agent.threadInfo() only when you need route context that is not already in the Slack webhook payload. Normal Slack replies can use channel/thread_ts from the webhook event directly.",
+                  "Use ctx.slack.agent.threadInfo() only when you need route context that is not already in the Slack webhook payload. Slack agents MUST respond on the same thread_ts that received the message; otherwise they will not receive responses from that thread. Unless explicitly required, always include thread_ts in Slack replies. Do not post to Slack unless the bot was explicitly mentioned, a user directly asks or instructs you, or the surrounding thread context clearly calls for agent action. Normal Slack replies can use channel/thread_ts from the webhook event directly.",
               },
             },
           });
@@ -45,7 +45,22 @@ export function createSlackAgentProcessor(deps: SlackAgentProcessorDeps = {}) {
             })
             .loose()
             .safeParse(event.payload.body);
-          if (!parsed.success) return;
+          if (!parsed.success) {
+            await streamApi.append({
+              event: {
+                type: "events.iterate.com/agent/input-added",
+                idempotencyKey: buildProcessorIdempotencyKey({
+                  processor: SlackAgentProcessorContract,
+                  key: "slack-webhook-to-agent-input",
+                  sourceEvent: event,
+                }),
+                payload: {
+                  content: slackWebhookAgentInput(event.payload),
+                },
+              },
+            });
+            return;
+          }
 
           const slackEvent = parsed.data.event as unknown as SlackEvent;
           const target = slackAgentTargetFromWebhookPayload(event.payload);
@@ -198,6 +213,8 @@ async function callSlackApi(
 function slackWebhookAgentInput(payload: unknown) {
   return [
     "`events.iterate.com/slack/webhook-received` event received",
+    "",
+    "Slack reply guidance: do not chime in just because this event arrived. Reply only when the bot was explicitly mentioned, the user directly asks or instructs you, or the surrounding thread context clearly calls for agent action. If this is FYI-only, output an empty codemode block and do not call `ctx.slack.chat.postMessage`.",
     "",
     "```yaml",
     stringifyYaml(payload).trimEnd(),

--- a/packages/shared/src/stream-processors/slack-agent/slack-agent.test.ts
+++ b/packages/shared/src/stream-processors/slack-agent/slack-agent.test.ts
@@ -90,7 +90,7 @@ describe("createSlackAgentProcessor", () => {
             path: ["slack", "agent"],
             invocation: { kind: "event" },
             instructions:
-              "Use ctx.slack.agent.threadInfo() only when you need route context that is not already in the Slack webhook payload. Normal Slack replies can use channel/thread_ts from the webhook event directly.",
+              "Use ctx.slack.agent.threadInfo() only when you need route context that is not already in the Slack webhook payload. Slack agents MUST respond on the same thread_ts that received the message; otherwise they will not receive responses from that thread. Unless explicitly required, always include thread_ts in Slack replies. Do not post to Slack unless the bot was explicitly mentioned, a user directly asks or instructs you, or the surrounding thread context clearly calls for agent action. Normal Slack replies can use channel/thread_ts from the webhook event directly.",
           },
         },
       },
@@ -191,11 +191,62 @@ describe("createSlackAgentProcessor", () => {
     });
     const content = (appended[0].event.payload as { content: string }).content;
     expect(content).toContain("```yaml");
+    expect(content).toContain("Slack reply guidance");
+    expect(content).toContain("do not chime in just because this event arrived");
+    expect(content).toContain("surrounding thread context clearly calls for agent action");
     expect(content).toContain("text: please look at this");
     expect(content).toContain('thread_ts: "1772136258.963519"');
     expect(content).not.toContain("Reply requirement:");
     expect(content).not.toContain("ctx.slack.chat.postMessage({ channel, thread_ts, text })");
     expect(content).not.toContain("Do not use `ctx.chat.sendMessage`");
+  });
+
+  it("emits agent input for raw Slack interactivity payloads", async () => {
+    const appended: Array<{ streamPath?: string; event: StreamEventInput }> = [];
+    const event = committedEvent({
+      type: "events.iterate.com/slack/webhook-received",
+      payload: {
+        body: {
+          type: "block_actions",
+          team: { id: "T123" },
+          channel: { id: "C123" },
+          message: {
+            ts: "1772136259.000000",
+            thread_ts: "1772136258.963519",
+            text: "Choose one",
+          },
+          actions: [{ action_id: "approve", type: "button", value: "yes" }],
+        },
+      },
+      offset: 46,
+    }) as Extract<
+      ConsumedEvent<typeof SlackAgentProcessorContract>,
+      { type: "events.iterate.com/slack/webhook-received" }
+    >;
+
+    await createSlackAgentProcessor().implementation.afterAppend?.({
+      event,
+      previousState: registeredSlackAgentState(),
+      state: registeredSlackAgentState({
+        channel: "C123",
+        latestMessageTs: "1772136259.000000",
+        threadTs: "1772136258.963519",
+      }),
+      streamApi: testSlackAgentStreamApi(appended),
+      signal: new AbortController().signal,
+    });
+
+    expect(appended).toHaveLength(1);
+    expect(appended[0].event).toMatchObject({
+      type: "events.iterate.com/agent/input-added",
+      idempotencyKey: "slack-agent/slack-webhook-to-agent-input@46",
+      payload: {
+        content: expect.stringContaining("type: block_actions"),
+      },
+    });
+    expect((appended[0].event.payload as { content: string }).content).toContain(
+      "action_id: approve",
+    );
   });
 
   it("satisfies ctx.slack.agent.threadInfo function calls from reduced route state", async () => {

--- a/packages/shared/src/stream-processors/slack/implementation.ts
+++ b/packages/shared/src/stream-processors/slack/implementation.ts
@@ -33,124 +33,10 @@ export function createSlackProcessor(deps: SlackProcessorDeps = {}) {
            * be keyed as `channel:thread_ts`, and have we already learned where
            * that Slack thread should be forwarded?
            */
-          const parsed = z
-            .object({
-              type: z.literal("event_callback"),
-              event: z.record(z.string(), z.unknown()),
-            })
-            .loose()
-            .safeParse(event.payload.body);
-          if (!parsed.success) return;
+          const route = slackRouteFromWebhookBody(event.payload.body);
+          if (route == null) return;
 
-          const slackEvent = parsed.data.event as unknown as SlackEvent;
-          let routeKey: string | undefined;
-          let routeChannel: string | undefined;
-          let routeThreadTs: string | undefined;
-          let routeStreamPath: string | undefined;
-
-          /**
-           * Reaction webhooks put the referenced message under `item`. That
-           * `item.ts` is the message timestamp, so it can be used to look up an
-           * existing route for reactions on root Slack messages that already
-           * started an agent thread.
-           *
-           * Example:
-           *
-           * ```json
-           * {
-           *   "event": {
-           *     "type": "reaction_added",
-           *     "item": { "type": "message", "channel": "C123", "ts": "1772136258.963519" }
-           *   }
-           * }
-           * ```
-           *
-           * We do not create new routes from reaction payloads because Slack
-           * does not tell us the parent thread when the reaction is on a reply.
-           */
-          if (
-            "item" in slackEvent &&
-            typeof slackEvent.item === "object" &&
-            slackEvent.item != null &&
-            "channel" in slackEvent.item &&
-            typeof slackEvent.item.channel === "string" &&
-            "ts" in slackEvent.item &&
-            typeof slackEvent.item.ts === "string"
-          ) {
-            routeKey = `${slackEvent.item.channel}:${slackEvent.item.ts}`;
-          }
-
-          /**
-           * Message-like Slack webhooks usually carry `channel` and either
-           * `thread_ts` or `ts` at the top level. Some Slack update events wrap
-           * the actual message in `message`, so prefer `message.thread_ts` when
-           * Slack gives it to us.
-           *
-           * Example root message:
-           *
-           * ```json
-           * {
-           *   "event": {
-           *     "type": "message",
-           *     "channel": "C123",
-           *     "ts": "1772136258.963519",
-           *     "text": "hello"
-           *   }
-           * }
-           * ```
-           *
-           * Example thread reply:
-           *
-           * ```json
-           * {
-           *   "event": {
-           *     "type": "message",
-           *     "channel": "C123",
-           *     "thread_ts": "1772136258.963519",
-           *     "ts": "1772136260.000000"
-           *   }
-           * }
-           * ```
-           *
-           * This stays structural on purpose: adding a new Slack webhook type
-           * should not require teaching this processor a new `case` if Slack
-           * already provides the same channel/thread coordinates.
-           */
-          if (
-            routeKey == null &&
-            "channel" in slackEvent &&
-            typeof slackEvent.channel === "string"
-          ) {
-            let slackThreadTs: string | undefined;
-            if (
-              "message" in slackEvent &&
-              typeof slackEvent.message === "object" &&
-              slackEvent.message != null &&
-              "thread_ts" in slackEvent.message &&
-              typeof slackEvent.message.thread_ts === "string"
-            ) {
-              slackThreadTs = slackEvent.message.thread_ts;
-            }
-            if (
-              slackThreadTs == null &&
-              "thread_ts" in slackEvent &&
-              typeof slackEvent.thread_ts === "string"
-            ) {
-              slackThreadTs = slackEvent.thread_ts;
-            }
-            if (slackThreadTs == null && "ts" in slackEvent && typeof slackEvent.ts === "string") {
-              slackThreadTs = slackEvent.ts;
-            }
-            if (slackThreadTs != null) {
-              routeKey = `${slackEvent.channel}:${slackThreadTs}`;
-              routeChannel = slackEvent.channel;
-              routeThreadTs = slackThreadTs;
-              routeStreamPath = `/agents/slack/${sanitizePathPart(slackEvent.channel)}/ts-${sanitizePathPart(slackThreadTs)}`;
-            }
-          }
-
-          if (routeKey == null) return;
-          const streamPath = state.routes[routeKey] ?? routeStreamPath;
+          const streamPath = state.routes[route.key] ?? route.streamPath;
           if (streamPath == null) return;
 
           /**
@@ -158,13 +44,13 @@ export function createSlackProcessor(deps: SlackProcessorDeps = {}) {
            * "when a future Slack webhook gives us this same Slack thread key,
            * forward it to this stream path."
            */
-          if (state.routes[routeKey] == null && routeChannel != null && routeThreadTs != null) {
+          if (state.routes[route.key] == null && route.canCreateRoute) {
             const routeEvent: EmittedInput<typeof SlackProcessorContract> = {
               type: "events.iterate.com/slack/thread-route-configured",
-              idempotencyKey: `slack-route:${routeKey}`,
+              idempotencyKey: `slack-route:${route.key}`,
               payload: {
-                channel: routeChannel,
-                threadTs: routeThreadTs,
+                channel: route.channel,
+                threadTs: route.threadTs,
                 streamPath,
               },
             };
@@ -183,9 +69,9 @@ export function createSlackProcessor(deps: SlackProcessorDeps = {}) {
               streamPath,
               events: [
                 ...(deps.createRoutedStreamBootstrapEvents?.({
-                  channel: routeChannel,
+                  channel: route.channel,
                   streamPath,
-                  threadTs: routeThreadTs,
+                  threadTs: route.threadTs,
                 }) ?? []),
                 routeEvent,
                 forwardedWebhookEvent,
@@ -220,6 +106,123 @@ export function createSlackProcessor(deps: SlackProcessorDeps = {}) {
       }
     },
   });
+}
+
+type SlackRoute = {
+  canCreateRoute: boolean;
+  channel: string;
+  key: string;
+  streamPath?: string;
+  threadTs: string;
+};
+
+function slackRouteFromWebhookBody(body: unknown): SlackRoute | null {
+  const parsed = z
+    .object({
+      type: z.literal("event_callback"),
+      event: z.record(z.string(), z.unknown()),
+    })
+    .loose()
+    .safeParse(body);
+  if (parsed.success) {
+    return slackRouteFromEvent(parsed.data.event as unknown as SlackEvent);
+  }
+
+  return slackRouteFromInteraction(body);
+}
+
+function slackRouteFromEvent(slackEvent: SlackEvent): SlackRoute | null {
+  if (
+    "item" in slackEvent &&
+    typeof slackEvent.item === "object" &&
+    slackEvent.item != null &&
+    "channel" in slackEvent.item &&
+    typeof slackEvent.item.channel === "string" &&
+    "ts" in slackEvent.item &&
+    typeof slackEvent.item.ts === "string"
+  ) {
+    return {
+      canCreateRoute: false,
+      channel: slackEvent.item.channel,
+      key: `${slackEvent.item.channel}:${slackEvent.item.ts}`,
+      threadTs: slackEvent.item.ts,
+    };
+  }
+
+  if (!("channel" in slackEvent) || typeof slackEvent.channel !== "string") return null;
+
+  let slackThreadTs: string | undefined;
+  if (
+    "message" in slackEvent &&
+    typeof slackEvent.message === "object" &&
+    slackEvent.message != null &&
+    "thread_ts" in slackEvent.message &&
+    typeof slackEvent.message.thread_ts === "string"
+  ) {
+    slackThreadTs = slackEvent.message.thread_ts;
+  }
+  if (
+    slackThreadTs == null &&
+    "thread_ts" in slackEvent &&
+    typeof slackEvent.thread_ts === "string"
+  ) {
+    slackThreadTs = slackEvent.thread_ts;
+  }
+  if (slackThreadTs == null && "ts" in slackEvent && typeof slackEvent.ts === "string") {
+    slackThreadTs = slackEvent.ts;
+  }
+  if (slackThreadTs == null) return null;
+
+  return routeFromChannelAndThread({
+    canCreateRoute: true,
+    channel: slackEvent.channel,
+    threadTs: slackThreadTs,
+  });
+}
+
+function slackRouteFromInteraction(body: unknown): SlackRoute | null {
+  const interaction = readRecord(body);
+  if (interaction == null) return null;
+
+  const channel = readString(readRecord(interaction.channel)?.id);
+  const message = readRecord(interaction.message);
+  const container = readRecord(interaction.container);
+  const threadTs =
+    readString(message?.thread_ts) ??
+    readString(container?.thread_ts) ??
+    readString(message?.ts) ??
+    readString(container?.message_ts);
+  if (channel == null || threadTs == null) return null;
+
+  return routeFromChannelAndThread({
+    canCreateRoute: true,
+    channel,
+    threadTs,
+  });
+}
+
+function routeFromChannelAndThread(input: {
+  canCreateRoute: boolean;
+  channel: string;
+  threadTs: string;
+}): SlackRoute {
+  return {
+    canCreateRoute: input.canCreateRoute,
+    channel: input.channel,
+    key: `${input.channel}:${input.threadTs}`,
+    streamPath: `/agents/slack/${sanitizePathPart(input.channel)}/ts-${sanitizePathPart(input.threadTs)}`,
+    threadTs: input.threadTs,
+  };
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value != null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }
 
 function sanitizePathPart(value: string): string {

--- a/packages/shared/src/stream-processors/slack/slack.test.ts
+++ b/packages/shared/src/stream-processors/slack/slack.test.ts
@@ -162,6 +162,46 @@ describe("createSlackProcessor", () => {
     ]);
   });
 
+  it("forwards raw Slack interactivity payloads when they include message thread coordinates", async () => {
+    const appended: Array<{ streamPath?: string; event: StreamEventInput }> = [];
+    const event = webhookEvent({
+      offset: 16,
+      body: {
+        type: "block_actions",
+        team: { id: "T123" },
+        channel: { id: "C123" },
+        message: {
+          type: "message",
+          ts: "1772136259.000000",
+          thread_ts: "1772136258.963519",
+          text: "Choose one",
+        },
+        actions: [{ action_id: "approve", block_id: "decision", type: "button", value: "yes" }],
+      },
+    });
+
+    await createSlackProcessor().implementation.afterAppend?.({
+      event,
+      previousState: slackState(),
+      state: slackState({
+        routes: { "C123:1772136258.963519": "/agents/slack/c123/ts-1772136258-963519" },
+      }),
+      streamApi: testSlackStreamApi(appended),
+      signal: new AbortController().signal,
+    });
+
+    expect(appended).toEqual([
+      {
+        streamPath: "/agents/slack/c123/ts-1772136258-963519",
+        event: {
+          type: "events.iterate.com/slack/webhook-received",
+          payload: event.payload,
+          idempotencyKey: "slack/forward-slack-webhook@16",
+        },
+      },
+    ]);
+  });
+
   it("creates a route for the first message-like Slack webhook and bootstraps the routed stream in one batch", async () => {
     const appended: Array<{ streamPath?: string; event: StreamEventInput }> = [];
     const event = webhookEvent({


### PR DESCRIPTION
## What changed

- Renamed the codemode builtin control surface from `ctx.__codemode.*` to `ctx.codemode.*` in OS2 and the shared codemode processor.
- Added `ctx.codemode.connectToMcpServer(...)` and `ctx.codemode.connectToOpenApiServer(...)` helpers that append normal provider registration events.
- Added live-connect codemode examples for public Swagger Petstore OpenAPI and Cloudflare Docs MCP.
- Added default Exa/Context7 MCP providers, tightened Slack agent posting guidance, and expanded integration/token state handling for Slack/Google UI/API flows.
- Captured OS2 data-modeling guidance and a GitHub integration task.

## Why

Codemode should be able to bootstrap from the reserved `ctx.codemode` control surface without requiring pre-authored provider registration events. The integration updates make connection state and agent guidance clearer while preserving project-scoped runtime behavior.

## Validation

- `pnpm --dir apps/os2 typecheck`
- `pnpm --dir packages/shared typecheck`
- `pnpm --dir apps/os2 test`
- `pnpm --dir apps/os2 test:codemode-session`
- `pnpm --dir packages/shared exec vitest run --environment node src/stream-processors/codemode/implementation.test.ts`
- `pnpm --dir packages/shared exec vitest run src/stream-processors/codemode/implementation.test.ts src/stream-processors/slack/slack.test.ts src/stream-processors/slack-agent/slack-agent.test.ts`
- Live proof against `https://os.iterate-dev-jonas.com`: registered and called Swagger Petstore OpenAPI plus Cloudflare Docs MCP from codemode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the reserved codemode builtin surface (`__codemode`→`codemode`), adds dynamic provider registration paths, and modifies Slack webhook ingestion plus Google token refresh/persistence logic.
> 
> **Overview**
> **Codemode builtins and providers:** Renames the reserved builtin namespace from `ctx.__codemode.*` to `ctx.codemode.*` across OS2 and the shared processor/tests, and adds `ctx.codemode.connectToMcpServer` / `ctx.codemode.connectToOpenApiServer` to register new tool providers at runtime (with path validation), plus new “live-connect” examples and tests.
> 
> **Default tooling and Slack guidance:** Adds default outbound MCP providers (`ctx.mcp.exa`, `ctx.mcp.context7`) to every codemode session and strengthens Slack provider/agent instructions to avoid FYI-only replies and to always reply on the correct `thread_ts`.
> 
> **Integrations:** Extends the integrations contract/API/UI to include token metadata (expiry, refresh token stored, secret timestamps), updates Slack webhook handling to support a new interactivity webhook route with appropriate parsing and idempotency, removes redundant `projectId` from Slack webhook event payloads, and adds Google access-token refresh-on-expiry with persistence (used by Gmail capability).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f32a571aad4dacaa02405a7bc663031a6007707. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os2": {
      "appDisplayName": "OS",
      "appSlug": "os2",
      "status": "released",
      "updatedAt": "2026-05-13T12:16:43.694Z",
      "headSha": "4f32a571aad4dacaa02405a7bc663031a6007707",
      "message": "Preview app released.",
      "publicUrl": "https://os2.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25797689048",
      "shortSha": "4f32a57"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `4f32a57`
Preview: https://os2.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25797689048)
Updated: 2026-05-13T12:16:43.694Z
<!-- /CLOUDFLARE_PREVIEW -->