### PR TITLE
Force push iterate config base seed

### DIFF
--- a/apps/os2/src/domains/repos/iterate-config-base-seed.ts
+++ b/apps/os2/src/domains/repos/iterate-config-base-seed.ts
@@ -124,6 +124,7 @@ export async function seedIterateConfigBaseRepo(input: {
   if (committed || created) {
     await git.push({
       dir: ITERATE_CONFIG_REPO_DIR,
+      force: true,
       remote: "origin",
       ref: defaultBranch,
       username: "x",


### PR DESCRIPTION
One-line parity fix so the Worker-side iterate-config base seeder force-pushes the default branch like the standalone seed script. This lets the prd seed hook initialize an empty Artifacts repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables `--force` pushes during seeding, which can overwrite remote branch history if the target repo is not empty or diverged. Scope is small and limited to the iterate-config base seeding path.
> 
> **Overview**
> Ensures the worker-side iterate config base seeder force-pushes (`force: true`) when pushing the seeded commit to the default branch, aligning behavior with the standalone seed script and allowing initialization of empty Artifacts repos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3ff80e9eec3f70db71395b33becf1bf09dc804e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->