### PR TITLE
Bypass Clerk for OS2 admin API token

### DIFF
--- a/apps/os2/src/orpc/auth.ts
+++ b/apps/os2/src/orpc/auth.ts
@@ -33,6 +33,13 @@ function authenticateAdminApiSecret(context: AppContext): ActiveOrganizationAuth
   return adminApiActiveOrganization;
 }
 
+export function isAdminApiSecretRequest(context: Pick<AppContext, "config">, request: Request) {
+  const expectedToken = context.config.adminApiSecret?.exposeSecret();
+  const providedToken = readBearerToken(request.headers.get("authorization"));
+
+  return !!expectedToken && providedToken === expectedToken;
+}
+
 export function resolveActiveOrganizationAuth(context: AppContext): ActiveOrganizationAuth | null {
   if (context.auth?.isAuthenticated && context.auth.orgId && context.auth.orgSlug) {
     return normalizeActiveOrganizationAuth(context.auth);

--- a/apps/os2/src/routes/api.$.ts
+++ b/apps/os2/src/routes/api.$.ts
@@ -1,23 +1,28 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { auth } from "@clerk/tanstack-react-start/server";
 import { handleIntegrationApiRequest } from "~/domains/secrets/integration-api.ts";
+import { isAdminApiSecretRequest } from "~/orpc/auth.ts";
 import { orpcOpenApiHandler } from "~/orpc/handler.ts";
 
 export const Route = createFileRoute("/api/$")({
   server: {
     handlers: {
       ANY: async ({ context, request }) => {
-        const clerkAuth = await auth();
-        const integrationResponse = await handleIntegrationApiRequest({
-          auth: clerkAuth,
-          context: {
-            ...context,
+        const adminApiRequest = isAdminApiSecretRequest(context, request);
+        const clerkAuth = adminApiRequest ? undefined : await auth();
+
+        if (clerkAuth) {
+          const integrationResponse = await handleIntegrationApiRequest({
             auth: clerkAuth,
-            rawRequest: request,
-          },
-          request,
-        });
-        if (integrationResponse) return integrationResponse;
+            context: {
+              ...context,
+              auth: clerkAuth,
+              rawRequest: request,
+            },
+            request,
+          });
+          if (integrationResponse) return integrationResponse;
+        }
 
         const { matched, response } = await orpcOpenApiHandler.handle(request, {
           prefix: "/api",

--- a/apps/os2/src/routes/api.orpc.$.ts
+++ b/apps/os2/src/routes/api.orpc.$.ts
@@ -1,12 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { auth } from "@clerk/tanstack-react-start/server";
+import { isAdminApiSecretRequest } from "~/orpc/auth.ts";
 import { orpcRpcHandler } from "~/orpc/handler.ts";
 
 export const Route = createFileRoute("/api/orpc/$")({
   server: {
     handlers: {
       ANY: async ({ context, request }) => {
-        const clerkAuth = await auth();
+        const clerkAuth = isAdminApiSecretRequest(context, request) ? undefined : await auth();
         const { matched, response } = await orpcRpcHandler.handle(request, {
           prefix: "/api/orpc",
           context: {


### PR DESCRIPTION
Fixes production admin-token API calls returning 500 because Clerk tries to parse the admin bearer token as a JWT before OS2's admin auth middleware can handle it.\n\nValidation: pnpm --dir apps/os2 typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request authentication flow for `/api` routes by conditionally skipping Clerk based on a bearer token, which could affect authorization behavior if the token detection is wrong or misconfigured.
> 
> **Overview**
> Fixes admin-token API calls failing in production by **detecting admin-secret bearer requests early and bypassing Clerk auth** (which otherwise attempts to parse the token as a JWT).
> 
> Adds `isAdminApiSecretRequest()` and updates the `/api/$` and `/api/orpc/$` handlers to only run `handleIntegrationApiRequest` and `auth()` when the request is *not* using the admin API secret, while still passing `auth`/`rawRequest` into the oRPC handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32652314bafaf9d1f229857749271acfd80df956. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->