### PR TITLE
Ensure iterate config seed branch ref

### DIFF
--- a/apps/os2/src/domains/repos/iterate-config-base-seed.ts
+++ b/apps/os2/src/domains/repos/iterate-config-base-seed.ts
@@ -116,12 +116,13 @@ export async function seedIterateConfigBaseRepo(input: {
         email: "support@iterate.com",
       },
     });
+    await ensureBranchRef({ branch: defaultBranch, git });
   } catch (error) {
     if (!isNothingToCommitError(error)) throw error;
     committed = false;
   }
 
-  if (committed || created) {
+  if (committed) {
     await git.push({
       dir: ITERATE_CONFIG_REPO_DIR,
       force: true,
@@ -138,6 +139,17 @@ export async function seedIterateConfigBaseRepo(input: {
     defaultBranch,
     remote,
   };
+}
+
+async function ensureBranchRef(input: { branch: string; git: ReturnType<typeof createGit> }) {
+  try {
+    await input.git.branch({
+      dir: ITERATE_CONFIG_REPO_DIR,
+      name: input.branch,
+    });
+  } catch (error) {
+    if (!isBranchExistsError(error)) throw error;
+  }
 }
 
 async function getOrCreateBaseArtifact(artifacts: CloudflareArtifactsBinding): Promise<{
@@ -161,6 +173,10 @@ async function getOrCreateBaseArtifact(artifacts: CloudflareArtifactsBinding): P
 
 function isNothingToCommitError(error: unknown) {
   return error instanceof Error && /nothing to commit|no changes/i.test(error.message);
+}
+
+function isBranchExistsError(error: unknown) {
+  return error instanceof Error && /already exists/i.test(error.message);
 }
 
 async function readArtifactString(value: unknown): Promise<string | null> {


### PR DESCRIPTION
Fix the production seed endpoint for an empty Artifacts repo by ensuring the local default branch ref exists before pushing, and by skipping push when there is no commit.\n\nValidation: pnpm --dir apps/os2 typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts git seeding/push behavior for the iterate config base repo, which can affect production initialization flows for empty repos. Risk is limited but could impact whether seeding updates are pushed if branch/ref handling is incorrect.
> 
> **Overview**
> Fixes the iterate config base repo seeding flow for empty/new Artifact repos by creating/ensuring a local ref for the `defaultBranch` (via new `ensureBranchRef`) after committing.
> 
> Changes push behavior to occur **only when a commit was actually created**, instead of also pushing on `created` repos with no changes, and adds a small helper (`isBranchExistsError`) to ignore benign branch-already-exists errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a403baf13803a737115e48c840236ba89478e29f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->