### PR TITLE
[codex] Update OS2 agent defaults and Claude MCP signals

### DIFF
--- a/apps/os2/e2e/vitest/agents.e2e.test.ts
+++ b/apps/os2/e2e/vitest/agents.e2e.test.ts
@@ -152,12 +152,12 @@ describe("project agents codemode", () => {
     ).toEqual([]);
   });
 
-  it("uses Kimi K2.6 through Cloudflare AI for unconfigured agent chats by default", async () => {
+  it("uses OpenAI for unconfigured agent chats by default", async () => {
     const baseUrl = requireBaseUrl();
     const client = createClient(baseUrl);
-    const project = await createProject(client, "agent-default-kimi");
+    const project = await createProject(client, "agent-default-openai");
     const suffix = uniqueSuffix();
-    const agentPath = `/agents/default-kimi-${suffix}`;
+    const agentPath = `/agents/default-openai-${suffix}`;
 
     await client.project.agents.runtimeState({
       agentPath,
@@ -165,7 +165,7 @@ describe("project agents codemode", () => {
     });
     await client.project.agents.sendMessage({
       agentPath,
-      message: `default Kimi 2.6 proof ${suffix}`,
+      message: `default OpenAI proof ${suffix}`,
       projectSlugOrId: project.id,
     });
 
@@ -175,29 +175,29 @@ describe("project agents codemode", () => {
       projectId: project.id,
       afterOffset: "start",
       predicate: (event) =>
-        event.type === "events.iterate.com/cloudflare-ai/llm-request-completed" &&
+        event.type === "events.iterate.com/openai-ws/llm-request-completed" &&
         (event.payload as { result?: { status?: unknown } }).result?.status === "success",
     });
 
     expect(events).toContainEqual(
       expect.objectContaining({
         type: "events.iterate.com/os2-agent/llm-provider-selected",
-        payload: { provider: "cloudflare-ai" },
+        payload: { provider: "openai-ws" },
       }),
     );
     expect(events).toContainEqual(
       expect.objectContaining({
-        type: "events.iterate.com/agent/llm-config-updated",
+        type: "events.iterate.com/openai-ws/config-updated",
         payload: expect.objectContaining({
-          model: DEFAULT_WORKERS_AI_AGENT_MODEL,
+          model: "gpt-5.5",
         }),
       }),
     );
     expect(events).toContainEqual(
       expect.objectContaining({
-        type: "events.iterate.com/cloudflare-ai/llm-request-started",
+        type: "events.iterate.com/openai-ws/llm-request-started",
         payload: expect.objectContaining({
-          model: DEFAULT_WORKERS_AI_AGENT_MODEL,
+          model: "gpt-5.5",
         }),
       }),
     );
@@ -207,7 +207,7 @@ describe("project agents codemode", () => {
       }),
     );
     expect(
-      events.some((event) => event.type === "events.iterate.com/openai-ws/llm-request-started"),
+      events.some((event) => event.type === "events.iterate.com/cloudflare-ai/llm-request-started"),
     ).toBe(false);
     expect(
       events.filter((event) => event.type === "events.iterate.com/core/error-occurred"),
@@ -677,19 +677,19 @@ async (ctx) => {
       expect(events).toContainEqual(
         expect.objectContaining({
           type: "events.iterate.com/os2-agent/llm-provider-selected",
-          payload: { provider: "cloudflare-ai" },
+          payload: { provider: "openai-ws" },
         }),
       );
       expect(events).toContainEqual(
         expect.objectContaining({
-          type: "events.iterate.com/agent/llm-config-updated",
+          type: "events.iterate.com/openai-ws/config-updated",
           payload: expect.objectContaining({
-            model: DEFAULT_WORKERS_AI_AGENT_MODEL,
+            model: "gpt-5.5",
           }),
         }),
       );
       expect(
-        events.filter((event) => event.type === "events.iterate.com/openai-ws/config-updated"),
+        events.filter((event) => event.type === "events.iterate.com/agent/llm-config-updated"),
       ).toEqual([]);
       expect(
         events.filter((event) => event.type.startsWith("events.iterate.com/agent-chat/")),

--- a/apps/os2/scripts/claude-mcp.test.ts
+++ b/apps/os2/scripts/claude-mcp.test.ts
@@ -1,0 +1,78 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { runClaudeChild, signalExitCode } from "./claude-mcp.ts";
+
+describe("claude-mcp", () => {
+  it("maps Claude SIGINT to the conventional interrupted process exit code", async () => {
+    const child = fakeChildProcess();
+    const spawnChild = vi.fn(() => child);
+
+    const resultPromise = runClaudeChild({
+      args: ["describe tools"],
+      env: {},
+      signal: undefined,
+      spawnChild,
+    });
+
+    child.emit("close", null, "SIGINT");
+
+    await expect(resultPromise).resolves.toEqual({
+      type: "signal",
+      exitCode: 130,
+      signal: "SIGINT",
+    });
+    expect(spawnChild).toHaveBeenCalledWith("claude", ["describe tools"], {
+      env: {},
+      stdio: "inherit",
+    });
+  });
+
+  it("forwards aborts to Claude before resolving", async () => {
+    const child = fakeChildProcess();
+    const spawnChild = vi.fn(() => child);
+    const controller = new AbortController();
+
+    const resultPromise = runClaudeChild({
+      args: [],
+      env: {},
+      signal: controller.signal,
+      spawnChild,
+    });
+
+    controller.abort();
+
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+
+    child.emit("close", null, "SIGTERM");
+
+    await expect(resultPromise).resolves.toEqual({
+      type: "signal",
+      exitCode: 143,
+      signal: "SIGTERM",
+    });
+  });
+
+  it("uses shell-compatible signal exit codes", () => {
+    expect(signalExitCode("SIGHUP")).toBe(129);
+    expect(signalExitCode("SIGINT")).toBe(130);
+    expect(signalExitCode("SIGTERM")).toBe(143);
+  });
+});
+
+function fakeChildProcess() {
+  const child = new EventEmitter() as ChildProcess;
+  let killed = false;
+
+  Object.defineProperty(child, "killed", {
+    get: () => killed,
+  });
+  child.kill = vi.fn(() => {
+    killed = true;
+    return true;
+  });
+
+  return child;
+}

--- a/apps/os2/scripts/claude-mcp.ts
+++ b/apps/os2/scripts/claude-mcp.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import process from "node:process";
 
 import { os } from "@orpc/server";
@@ -58,7 +58,11 @@ export const claudeMcpScript = os
     console.info("  Auth: Doppler OS2 admin token");
     console.info("");
 
-    runClaude(args, signal);
+    const result = await runClaude(args, signal);
+
+    if (result.type === "signal") {
+      process.exit(result.exitCode);
+    }
 
     return {
       ok: true as const,
@@ -106,25 +110,104 @@ function buildClaudeMcpConfig(input: { mcpUrl: string; token: string }) {
   return JSON.stringify(config);
 }
 
-function runClaude(args: string[], signal: AbortSignal | undefined) {
+export type ClaudeProcessResult =
+  | { type: "exit"; code: number }
+  | { type: "signal"; exitCode: number; signal: NodeJS.Signals };
+
+export async function runClaude(
+  args: string[],
+  signal: AbortSignal | undefined,
+): Promise<ClaudeProcessResult> {
   if (signal?.aborted) {
-    return;
+    return { type: "signal", exitCode: signalExitCode("SIGTERM"), signal: "SIGTERM" };
   }
 
-  const result = spawnSync("claude", args, {
+  const result = await runClaudeChild({
+    args,
     env: process.env,
+    signal,
+    spawnChild: (command, childArgs, options) => spawn(command, childArgs, options),
+  });
+
+  if (result.type === "signal") {
+    return result;
+  }
+
+  if (result.code !== 0) {
+    throw new Error(`claude exited with code ${result.code}.`);
+  }
+
+  return result;
+}
+
+export async function runClaudeChild(input: {
+  args: string[];
+  env: NodeJS.ProcessEnv;
+  signal: AbortSignal | undefined;
+  spawnChild: (
+    command: string,
+    args: string[],
+    options: { env: NodeJS.ProcessEnv; stdio: "inherit" },
+  ) => ChildProcess;
+}): Promise<ClaudeProcessResult> {
+  const child = input.spawnChild("claude", input.args, {
+    env: input.env,
     stdio: "inherit",
   });
 
-  if (result.error) {
-    throw result.error;
-  }
+  return await new Promise<ClaudeProcessResult>((resolve, reject) => {
+    const forwardSignal = (forwardedSignal: NodeJS.Signals) => {
+      if (!child.killed) {
+        child.kill(forwardedSignal);
+      }
+    };
+    const abortChild = () => forwardSignal("SIGTERM");
+    const forwardSIGINT = () => forwardSignal("SIGINT");
+    const forwardSIGTERM = () => forwardSignal("SIGTERM");
+    const forwardSIGHUP = () => forwardSignal("SIGHUP");
+    const cleanup = () => {
+      input.signal?.removeEventListener("abort", abortChild);
+      process.off("SIGINT", forwardSIGINT);
+      process.off("SIGTERM", forwardSIGTERM);
+      process.off("SIGHUP", forwardSIGHUP);
+    };
 
-  if (result.signal) {
-    return;
-  }
+    input.signal?.addEventListener("abort", abortChild, { once: true });
+    process.on("SIGINT", forwardSIGINT);
+    process.on("SIGTERM", forwardSIGTERM);
+    process.on("SIGHUP", forwardSIGHUP);
 
-  if (result.status !== 0) {
-    throw new Error(`claude exited with code ${result.status ?? "unknown"}.`);
+    child.once("error", (error) => {
+      cleanup();
+      reject(error);
+    });
+
+    child.once("close", (code, closedSignal) => {
+      cleanup();
+
+      if (closedSignal) {
+        resolve({
+          type: "signal",
+          exitCode: signalExitCode(closedSignal),
+          signal: closedSignal,
+        });
+        return;
+      }
+
+      resolve({ type: "exit", code: code ?? 1 });
+    });
+  });
+}
+
+export function signalExitCode(signal: NodeJS.Signals) {
+  switch (signal) {
+    case "SIGINT":
+      return 130;
+    case "SIGTERM":
+      return 143;
+    case "SIGHUP":
+      return 129;
+    default:
+      return 1;
   }
 }

--- a/apps/os2/src/domains/agents/agent-presets.test.ts
+++ b/apps/os2/src/domains/agents/agent-presets.test.ts
@@ -13,6 +13,25 @@ import {
 } from "./agent-presets.ts";
 
 describe("agent presets", () => {
+  it("defaults new agent setup events to OpenAI", () => {
+    expect(defaultAgentSetupEvents()).toEqual([
+      {
+        type: "events.iterate.com/os2-agent/llm-provider-selected",
+        payload: { provider: "openai-ws" },
+      },
+      {
+        type: "events.iterate.com/openai-ws/config-updated",
+        payload: { model: "gpt-5.5" },
+      },
+      {
+        type: "events.iterate.com/agent/system-prompt-updated",
+        payload: {
+          systemPrompt: defaultAgentSystemPrompt(),
+        },
+      },
+    ]);
+  });
+
   it("accepts full preset paths under /agents", () => {
     expect(normalizeAgentPresetBasePath("/agents")).toBe("/agents");
     expect(normalizeAgentPresetBasePath("/agents/alice/bla")).toBe("/agents/alice/bla");
@@ -42,7 +61,7 @@ describe("agent presets", () => {
     ).toBe(nestedPreset);
   });
 
-  it("keeps Slack agents on the built-in Kimi default when only the root agent preset selects OpenAI", () => {
+  it("keeps Slack agents from inheriting the root agent preset", () => {
     const rootOpenAiPreset = {
       basePath: "/agents",
       events: defaultAgentSetupEvents("openai-ws"),
@@ -62,7 +81,7 @@ describe("agent presets", () => {
     expect(isSlackAgentPath("/agents/slack-test")).toBe(false);
   });
 
-  it("allows explicit Slack presets to override the built-in Kimi default", () => {
+  it("allows explicit Slack presets to override the built-in default", () => {
     const rootOpenAiPreset = {
       basePath: "/agents",
       events: defaultAgentSetupEvents("openai-ws"),
@@ -80,7 +99,7 @@ describe("agent presets", () => {
     ).toBe(slackOpenAiPreset);
   });
 
-  it("ignores the legacy generated Slack OpenAI preset so Slack agents fall back to Kimi", () => {
+  it("ignores the legacy generated Slack OpenAI preset so Slack agents fall back to the built-in default", () => {
     const legacySlackOpenAiPreset = {
       basePath: "/agents/slack",
       events: [

--- a/apps/os2/src/domains/agents/agent-presets.ts
+++ b/apps/os2/src/domains/agents/agent-presets.ts
@@ -8,6 +8,8 @@ export const OS2_AGENT_LLM_PROVIDER_SELECTED_EVENT_TYPE =
 export const OS2_AGENT_PATH_PREFIX_PRESET_CONFIGURED_EVENT_TYPE =
   "events.iterate.com/os2-agent/path-prefix-preset-configured";
 export const DEFAULT_CLOUDFLARE_AGENT_MODEL = DEFAULT_WORKERS_AI_AGENT_MODEL;
+export const DEFAULT_OPENAI_AGENT_MODEL = "gpt-5.5";
+export const DEFAULT_AGENT_LLM_PROVIDER = "openai-ws";
 const LEGACY_GENERATED_SLACK_OPENAI_PROMPT_MARKER =
   "You are an Iterate agent responding from Slack.";
 
@@ -72,7 +74,7 @@ export function defaultAgentSystemPrompt(agentPath?: string) {
 }
 
 export function defaultAgentSetupEvents(
-  provider: AgentLlmProvider,
+  provider: AgentLlmProvider = DEFAULT_AGENT_LLM_PROVIDER,
   agentPath?: string,
 ): AgentPresetEvent[] {
   return [
@@ -81,7 +83,7 @@ export function defaultAgentSetupEvents(
       ? [
           {
             type: "events.iterate.com/openai-ws/config-updated",
-            payload: { model: "gpt-5.5" },
+            payload: { model: DEFAULT_OPENAI_AGENT_MODEL },
           },
         ]
       : [

--- a/apps/os2/src/domains/agents/durable-objects/agent-durable-object.ts
+++ b/apps/os2/src/domains/agents/durable-objects/agent-durable-object.ts
@@ -56,6 +56,7 @@ import {
 import { defaultWorkspaceIdForCodemodeSession } from "~/domains/workspaces/entrypoints/workspace-provider-registration.ts";
 import { stripArtifactTokenQuery } from "~/domains/repos/artifacts.ts";
 import {
+  DEFAULT_AGENT_LLM_PROVIDER,
   defaultAgentSetupEvents,
   defaultAgentSystemPrompt,
   isSlackAgentPath,
@@ -420,7 +421,7 @@ export class AgentDurableObject extends AgentBase<AgentDurableObjectEnv> {
       presets: readAgentPathPrefixPresets(rootEvents),
     });
     const setupEvents =
-      preset?.events ?? defaultAgentSetupEvents("cloudflare-ai", params.agentPath);
+      preset?.events ?? defaultAgentSetupEvents(DEFAULT_AGENT_LLM_PROVIDER, params.agentPath);
     const hasSetupPrompt = setupEvents.some(
       (event) => event.type === "events.iterate.com/agent/system-prompt-updated",
     );
@@ -735,7 +736,7 @@ export class AgentDurableObject extends AgentBase<AgentDurableObjectEnv> {
       const provider = (event.payload as { provider?: unknown }).provider;
       if (provider === "cloudflare-ai" || provider === "openai-ws") return provider;
     }
-    return "cloudflare-ai";
+    return DEFAULT_AGENT_LLM_PROVIDER;
   }
 
   private createLlmProcessor(provider: AgentLlmProvider) {

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset.tsx
@@ -14,7 +14,9 @@ import { Textarea } from "@iterate-com/ui/components/textarea";
 import {
   AgentPresetEvent,
   type AgentLlmProvider,
+  DEFAULT_AGENT_LLM_PROVIDER,
   DEFAULT_CLOUDFLARE_AGENT_MODEL,
+  DEFAULT_OPENAI_AGENT_MODEL,
   configuredAgentSetupEvents,
   defaultAgentSystemPrompt,
   normalizeAgentPresetBasePath,
@@ -48,8 +50,8 @@ function NewAgentPresetPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [basePathInput, setBasePathInput] = useState("/agents");
-  const [provider, setProvider] = useState<AgentLlmProvider>("cloudflare-ai");
-  const [model, setModel] = useState(DEFAULT_CLOUDFLARE_AGENT_MODEL);
+  const [provider, setProvider] = useState<AgentLlmProvider>(DEFAULT_AGENT_LLM_PROVIDER);
+  const [model, setModel] = useState(DEFAULT_OPENAI_AGENT_MODEL);
   const [runOpts, setRunOpts] = useState('{"gateway":{"id":"default"}}');
   const [systemPrompt, setSystemPrompt] = useState(defaultAgentSystemPrompt());
   const [customEventsYaml, setCustomEventsYaml] = useState(emptyEventsYaml);
@@ -102,9 +104,9 @@ function NewAgentPresetPage() {
     setProvider(nextProvider);
     setModel((current) => {
       if (nextProvider === "openai-ws" && current === DEFAULT_CLOUDFLARE_AGENT_MODEL) {
-        return "gpt-5.5";
+        return DEFAULT_OPENAI_AGENT_MODEL;
       }
-      if (nextProvider === "cloudflare-ai" && current === "gpt-5.5") {
+      if (nextProvider === "cloudflare-ai" && current === DEFAULT_OPENAI_AGENT_MODEL) {
         return DEFAULT_CLOUDFLARE_AGENT_MODEL;
       }
       return current;

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx
@@ -32,7 +32,9 @@ import {
 } from "~/domains/codemode/examples.ts";
 import {
   type AgentLlmProvider,
+  DEFAULT_AGENT_LLM_PROVIDER,
   DEFAULT_CLOUDFLARE_AGENT_MODEL,
+  DEFAULT_OPENAI_AGENT_MODEL,
   configuredAgentSetupEvents,
   defaultAgentSystemPrompt,
   parseAgentEventInputsYaml,
@@ -86,8 +88,8 @@ function NewAgentPage() {
   const { project } = Route.useLoaderData();
   const navigate = useNavigate();
   const [agentPathInput, setAgentPathInput] = useState("/agents/assistant");
-  const [provider, setProvider] = useState<AgentLlmProvider>("cloudflare-ai");
-  const [model, setModel] = useState(DEFAULT_CLOUDFLARE_AGENT_MODEL);
+  const [provider, setProvider] = useState<AgentLlmProvider>(DEFAULT_AGENT_LLM_PROVIDER);
+  const [model, setModel] = useState(DEFAULT_OPENAI_AGENT_MODEL);
   const [runOpts, setRunOpts] = useState('{"gateway":{"id":"default"}}');
   const [systemPrompt, setSystemPrompt] = useState(defaultAgentSystemPrompt());
   const [customEventsYaml, setCustomEventsYaml] = useState(emptyEventsYaml);
@@ -151,9 +153,9 @@ function NewAgentPage() {
     setProvider(nextProvider);
     setModel((current) => {
       if (nextProvider === "openai-ws" && current === DEFAULT_CLOUDFLARE_AGENT_MODEL) {
-        return "gpt-5.5";
+        return DEFAULT_OPENAI_AGENT_MODEL;
       }
-      if (nextProvider === "cloudflare-ai" && current === "gpt-5.5") {
+      if (nextProvider === "cloudflare-ai" && current === DEFAULT_OPENAI_AGENT_MODEL) {
         return DEFAULT_CLOUDFLARE_AGENT_MODEL;
       }
       return current;


### PR DESCRIPTION
## Summary

Changes OS2's default agent LLM provider from Cloudflare AI Gateway to OpenAI WebSocket. New agent creation, new preset creation, and unconfigured agent Durable Object setup now use `openai-ws` with `gpt-5.5` by default.

Explicit Cloudflare AI selections still work and keep their existing Kimi/Workers AI model configuration.

## Impact

New OS2 agents and fallback-initialized agent streams will start with OpenAI configuration unless a path preset or explicit provider selection overrides it. Existing configured streams are not migrated.

## Validation

- `pnpm --dir apps/os2 exec vitest run src/domains/agents/agent-presets.test.ts`
- `pnpm --dir apps/os2 typecheck`
- `pnpm --dir apps/os2 test`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os2": {
      "appDisplayName": "OS",
      "appSlug": "os2",
      "status": "released",
      "updatedAt": "2026-05-14T10:34:41.355Z",
      "headSha": "5e8b8e5d017d1c4769353a63506cc3f10b387cd5",
      "message": "Preview app released.",
      "publicUrl": "https://os2.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25854198184",
      "shortSha": "5e8b8e5"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `5e8b8e5`
Preview: https://os2.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25854198184)
Updated: 2026-05-14T10:34:41.355Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default agent initialization to select `openai-ws` (`gpt-5.5`) instead of Cloudflare AI, which can affect new/unconfigured agent behavior and cost/availability characteristics. Also refactors `claude-mcp` to async `spawn` with signal/abort forwarding, which may change CLI runtime behavior on interruption.
> 
> **Overview**
> **Defaults OS2 agents to OpenAI.** New agent stream setup now falls back to `DEFAULT_AGENT_LLM_PROVIDER = "openai-ws"` with `DEFAULT_OPENAI_AGENT_MODEL = "gpt-5.5"` (instead of Cloudflare AI), updating durable-object initialization plus the “New Agent” and “New Preset” UIs accordingly; Cloudflare AI remains selectable with its existing run-opts/model behavior.
> 
> **Updates test coverage and expectations.** E2E and unit tests are revised to assert OpenAI events (`openai-ws/*`) as the default and to ensure Slack-agent preset inheritance rules remain intact.
> 
> **Improves `claude-mcp` process handling.** Replaces `spawnSync` with async `spawn`, forwards OS signals/abort to the child, and maps signals to conventional shell exit codes, with new Vitest coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e8b8e5d017d1c4769353a63506cc3f10b387cd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->