### PR TITLE
[codex] tidy CI sandbox deployment flow

### DIFF
--- a/.github/ts-workflows/utils/cloudflare-app-workflow.ts
+++ b/.github/ts-workflows/utils/cloudflare-app-workflow.ts
@@ -10,9 +10,12 @@ declare const appDisplayName: string;
 declare const publicUrl: string;
 declare const runUrl: string;
 declare const shortSha: string;
+declare const slackChannelName: string;
 
 export async function createCloudflareAppWorkflow(meta: ImportMeta, app: CloudflareApp) {
   const isNewStyleApp = isNewStyleCloudflareAppSlug(app.slug);
+  const successSlackChannelName = isNewStyleApp ? "#ci" : "#building";
+  const failureSlackChannelName = isNewStyleApp ? "#ci" : "#error-pulse";
 
   return workflow({
     name: `Deploy ${app.displayName}`,
@@ -125,6 +128,7 @@ export async function createCloudflareAppWorkflow(meta: ImportMeta, app: Cloudfl
                 publicUrl: "${{ needs.deploy.outputs.public_url }}",
                 runUrl: "${{ needs.variables.outputs.run_url }}",
                 shortSha: "${{ needs.variables.outputs.short_sha }}",
+                slackChannelName: successSlackChannelName,
               },
             },
             async function notify_slack_on_success() {
@@ -139,7 +143,9 @@ export async function createCloudflareAppWorkflow(meta: ImportMeta, app: Cloudfl
                 .join(" · ");
 
               await slack.chat.postMessage({
-                channel: slackChannelIds["#building"],
+                channel:
+                  slackChannelIds[slackChannelName as keyof typeof slackChannelIds] ??
+                  slackChannelName,
                 text: message,
               });
             },
@@ -159,6 +165,7 @@ export async function createCloudflareAppWorkflow(meta: ImportMeta, app: Cloudfl
                 appDisplayName: app.displayName,
                 runUrl: "${{ needs.variables.outputs.run_url }}",
                 shortSha: "${{ needs.variables.outputs.short_sha }}",
+                slackChannelName: failureSlackChannelName,
               },
             },
             async function notify_slack_on_failure() {
@@ -171,7 +178,9 @@ export async function createCloudflareAppWorkflow(meta: ImportMeta, app: Cloudfl
               ].join(" ");
 
               await slack.chat.postMessage({
-                channel: slackChannelIds["#error-pulse"],
+                channel:
+                  slackChannelIds[slackChannelName as keyof typeof slackChannelIds] ??
+                  slackChannelName,
                 text: message,
               });
             },

--- a/.github/ts-workflows/utils/slack.ts
+++ b/.github/ts-workflows/utils/slack.ts
@@ -23,6 +23,7 @@ export const slackChannelIds = {
   "#misha-test": "C09B4EGQT7E",
   "#error-pulse": "C09K1CTN4M7",
   "#building": "C06LU7PGK0S",
+  "#ci": "C0B3QJSU32A",
 };
 
 export const slackUsers = [

--- a/.github/ts-workflows/workflows/ci.ts
+++ b/.github/ts-workflows/workflows/ci.ts
@@ -3,20 +3,14 @@ import * as utils from "../utils/index.ts";
 
 /**
  * Production rollout strategy (main branch):
- * 1) Deploy OS worker fast with current env vars (deploy-os-early)
- * 2) Build new sandbox image
- * 3) Run Fly sandbox tests against the new image
- * 4) Promote FLY_DEFAULT_IMAGE in Doppler + deploy OS worker again
- *
- * This keeps the worker rollout fast while still gating env-var promotion
- * and final deploy on post-build sandbox verification.
+ * 1) Deploy OS worker and app with current env vars.
+ * 2) Leave FLY_DEFAULT_IMAGE unchanged so production keeps using the current sandbox image.
  */
 export default {
   name: "CI",
   permissions: {
     contents: "read",
     deployments: "write",
-    "id-token": "write", // Required for Depot OIDC auth in called workflows
   },
   on: {
     push: {
@@ -33,84 +27,20 @@ export default {
           run: [
             "cat <<'EOF' >> \"$GITHUB_STEP_SUMMARY\"",
             "## Rollout Strategy",
-            "1. Deploy OS worker quickly with current environment variables.",
-            "2. Build new sandbox image.",
-            "3. Run Fly sandbox tests against the new image.",
-            "4. If tests pass, update Doppler FLY_DEFAULT_IMAGE and deploy OS worker again.",
+            "1. Deploy OS worker and app with current environment variables.",
+            "2. Leave FLY_DEFAULT_IMAGE unchanged; sandbox image promotion is not part of CI.",
             "EOF",
-          ].join("\n"),
-        },
-      ],
-    },
-    "deploy-os-early": {
-      uses: "./.github/workflows/deploy.yml",
-      needs: ["variables"],
-      secrets: "inherit",
-      with: {
-        deploy_iterate_com: false,
-      },
-    },
-    "build-sandbox-image": {
-      uses: "./.github/workflows/build-sandbox-image.yml",
-      needs: ["variables", "deploy-os-early"],
-      secrets: "inherit",
-      with: {
-        doppler_config: "prd",
-        docker_platform: "linux/amd64",
-        skip_load: false,
-        update_doppler: false,
-      },
-    },
-    "test-sandbox-fly": {
-      needs: ["variables", "build-sandbox-image"],
-      uses: "./.github/workflows/sandbox-test-fly.yml",
-      secrets: "inherit",
-      with: {
-        doppler_config: "prd",
-        fly_image_tag: "${{ needs.build-sandbox-image.outputs.fly_image_tag }}",
-      },
-    },
-    "promote-fly-default-image": {
-      needs: ["variables", "build-sandbox-image", "test-sandbox-fly"],
-      ...utils.runsOnDepotUbuntu,
-      steps: [
-        ...utils.setupDoppler({ config: "prd" }),
-        {
-          name: "Update Doppler FLY_DEFAULT_IMAGE",
-          env: {
-            DOPPLER_TOKEN: "${{ secrets.DOPPLER_TOKEN }}",
-            FLY_IMAGE_TAG: "${{ needs.build-sandbox-image.outputs.fly_image_tag }}",
-          },
-          run: [
-            "set -euo pipefail",
-            'echo "Promoting FLY_DEFAULT_IMAGE=${FLY_IMAGE_TAG} to os dev/preview/prd base configs"',
-            "for cfg in dev preview prd; do",
-            '  doppler secrets set FLY_DEFAULT_IMAGE="${FLY_IMAGE_TAG}" --project os --config "${cfg}"',
-            "done",
           ].join("\n"),
         },
       ],
     },
     deploy: {
       uses: "./.github/workflows/deploy.yml",
-      needs: [
-        "variables",
-        "deploy-os-early",
-        "build-sandbox-image",
-        "test-sandbox-fly",
-        "promote-fly-default-image",
-      ],
+      needs: ["variables"],
       secrets: "inherit",
     },
     slack_failure: {
-      needs: [
-        "variables",
-        "deploy-os-early",
-        "build-sandbox-image",
-        "test-sandbox-fly",
-        "promote-fly-default-image",
-        "deploy",
-      ],
+      needs: ["variables", "deploy"],
       if: `always() && contains(needs.*.result, 'failure')`,
       ...utils.runsOnDepotUbuntu,
       env: { NEEDS: "${{ toJson(needs) }}" },
@@ -123,9 +53,7 @@ export default {
           const failedJobs = Object.entries(needs)
             .filter(([_, { result }]: [string, any]) => result === "failure")
             .map(([name]) => name);
-          const outputs = needs.variables?.outputs as Record<string, string>;
-          const outputsString = new URLSearchParams(outputs).toString().replaceAll("&", ", ");
-          let message = `🚨 ${failedJobs.join(", ")} failed on \${{ github.ref_name }}. ${outputsString}.`;
+          let message = `🚨 ${failedJobs.join(", ")} failed on \${{ github.ref_name }}.`;
           message +=
             " <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Run>";
           message += "\n@iterate please investigate";

--- a/.github/ts-workflows/workflows/sandbox-test.ts
+++ b/.github/ts-workflows/workflows/sandbox-test.ts
@@ -15,23 +15,6 @@ export default workflow({
     "id-token": "write",
   },
   on: {
-    push: {
-      branches: ["main"],
-      paths: [
-        "sandbox/**",
-        "apps/daemon/**",
-        "packages/pidnap/**",
-        ".github/workflows/sandbox-test.yml",
-      ],
-    },
-    pull_request: {
-      paths: [
-        "sandbox/**",
-        "apps/daemon/**",
-        "packages/pidnap/**",
-        ".github/workflows/sandbox-test.yml",
-      ],
-    },
     workflow_dispatch: {
       inputs: {
         ref: {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ name: CI
 permissions:
   contents: read
   deployments: write
-  id-token: write
 on:
   push:
     branches:
@@ -18,79 +17,17 @@ jobs:
         run: |-
           cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
           ## Rollout Strategy
-          1. Deploy OS worker quickly with current environment variables.
-          2. Build new sandbox image.
-          3. Run Fly sandbox tests against the new image.
-          4. If tests pass, update Doppler FLY_DEFAULT_IMAGE and deploy OS worker again.
+          1. Deploy OS worker and app with current environment variables.
+          2. Leave FLY_DEFAULT_IMAGE unchanged; sandbox image promotion is not part of CI.
           EOF
-  deploy-os-early:
-    uses: ./.github/workflows/deploy.yml
-    needs:
-      - variables
-    secrets: inherit
-    with:
-      deploy_iterate_com: false
-  build-sandbox-image:
-    uses: ./.github/workflows/build-sandbox-image.yml
-    needs:
-      - variables
-      - deploy-os-early
-    secrets: inherit
-    with:
-      doppler_config: prd
-      docker_platform: linux/amd64
-      skip_load: false
-      update_doppler: false
-  test-sandbox-fly:
-    needs:
-      - variables
-      - build-sandbox-image
-    uses: ./.github/workflows/sandbox-test-fly.yml
-    secrets: inherit
-    with:
-      doppler_config: prd
-      fly_image_tag: ${{ needs.build-sandbox-image.outputs.fly_image_tag }}
-  promote-fly-default-image:
-    needs:
-      - variables
-      - build-sandbox-image
-      - test-sandbox-fly
-    runs-on: depot-ubuntu-24.04-32
-    steps:
-      - name: Install Doppler CLI
-        run: |-
-          for i in 1 2 3; do curl -sfLS https://cli.doppler.com/install.sh | sh -s -- --no-package-manager && break; echo "Attempt $i failed, retrying in 5s..."; sleep 5; done
-          doppler --version || { echo 'Failed to install Doppler CLI after 3 attempts'; exit 1; }
-      - name: Setup Doppler
-        run: doppler setup --config prd --project os
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-      - name: Update Doppler FLY_DEFAULT_IMAGE
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-          FLY_IMAGE_TAG: ${{ needs.build-sandbox-image.outputs.fly_image_tag }}
-        run: |-
-          set -euo pipefail
-          echo "Promoting FLY_DEFAULT_IMAGE=${FLY_IMAGE_TAG} to os dev/preview/prd base configs"
-          for cfg in dev preview prd; do
-            doppler secrets set FLY_DEFAULT_IMAGE="${FLY_IMAGE_TAG}" --project os --config "${cfg}"
-          done
   deploy:
     uses: ./.github/workflows/deploy.yml
     needs:
       - variables
-      - deploy-os-early
-      - build-sandbox-image
-      - test-sandbox-fly
-      - promote-fly-default-image
     secrets: inherit
   slack_failure:
     needs:
       - variables
-      - deploy-os-early
-      - build-sandbox-image
-      - test-sandbox-fly
-      - promote-fly-default-image
       - deploy
     if: always() && contains(needs.*.result, 'failure')
     runs-on: depot-ubuntu-24.04-32
@@ -130,9 +67,7 @@ jobs:
               const failedJobs = Object.entries(needs)
                 .filter(([_, { result }]) => result === "failure")
                 .map(([name]) => name);
-              const outputs = needs.variables?.outputs;
-              const outputsString = new URLSearchParams(outputs).toString().replaceAll("&", ", ");
-              let message = `🚨 ${failedJobs.join(", ")} failed on \${{ github.ref_name }}. ${outputsString}.`;
+              let message = `🚨 ${failedJobs.join(", ")} failed on \${{ github.ref_name }}.`;
               message +=
                 " <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Run>";
               message += "\n@iterate please investigate";

--- a/.github/workflows/deploy-agents.yml
+++ b/.github/workflows/deploy-agents.yml
@@ -117,6 +117,7 @@ jobs:
             const publicUrl = "${{ needs.deploy.outputs.public_url }}";
             const runUrl = "${{ needs.variables.outputs.run_url }}";
             const shortSha = "${{ needs.variables.outputs.short_sha }}";
+            const slackChannelName = "#ci";
             const __handler = async function notify_slack_on_success() {
               const { getSlackClient, slackChannelIds } =
                 await require(".github/ts-workflows/workflows/deploy-agents.ts.utilsslackts-64e60416ee9563c2f22509a2a7a4ac68-tsx-shim.cjs" /* <-- shimmed module of "../utils/slack.ts" that actions/github-script can require */).load();
@@ -130,7 +131,7 @@ jobs:
                 .join(" · ");
 
               await slack.chat.postMessage({
-                channel: slackChannelIds["#building"],
+                channel: slackChannelIds[slackChannelName] ?? slackChannelName,
                 text: message,
               });
             };
@@ -170,6 +171,7 @@ jobs:
             const appDisplayName = "Agents";
             const runUrl = "${{ needs.variables.outputs.run_url }}";
             const shortSha = "${{ needs.variables.outputs.short_sha }}";
+            const slackChannelName = "#ci";
             const __handler = async function notify_slack_on_failure() {
               const { getSlackClient, slackChannelIds } =
                 await require(".github/ts-workflows/workflows/deploy-agents.ts.utilsslackts-64e60416ee9563c2f22509a2a7a4ac68-tsx-shim.cjs" /* <-- shimmed module of "../utils/slack.ts" that actions/github-script can require */).load();
@@ -181,7 +183,7 @@ jobs:
               ].join(" ");
 
               await slack.chat.postMessage({
-                channel: slackChannelIds["#error-pulse"],
+                channel: slackChannelIds[slackChannelName] ?? slackChannelName,
                 text: message,
               });
             };

--- a/.github/workflows/deploy-events.yml
+++ b/.github/workflows/deploy-events.yml
@@ -116,6 +116,7 @@ jobs:
             const publicUrl = "${{ needs.deploy.outputs.public_url }}";
             const runUrl = "${{ needs.variables.outputs.run_url }}";
             const shortSha = "${{ needs.variables.outputs.short_sha }}";
+            const slackChannelName = "#building";
             const __handler = async function notify_slack_on_success() {
               const { getSlackClient, slackChannelIds } =
                 await require(".github/ts-workflows/workflows/deploy-events.ts.utilsslackts-64e60416ee9563c2f22509a2a7a4ac68-tsx-shim.cjs" /* <-- shimmed module of "../utils/slack.ts" that actions/github-script can require */).load();
@@ -129,7 +130,7 @@ jobs:
                 .join(" · ");
 
               await slack.chat.postMessage({
-                channel: slackChannelIds["#building"],
+                channel: slackChannelIds[slackChannelName] ?? slackChannelName,
                 text: message,
               });
             };
@@ -169,6 +170,7 @@ jobs:
             const appDisplayName = "Events";
             const runUrl = "${{ needs.variables.outputs.run_url }}";
             const shortSha = "${{ needs.variables.outputs.short_sha }}";
+            const slackChannelName = "#error-pulse";
             const __handler = async function notify_slack_on_failure() {
               const { getSlackClient, slackChannelIds } =
                 await require(".github/ts-workflows/workflows/deploy-events.ts.utilsslackts-64e60416ee9563c2f22509a2a7a4ac68-tsx-shim.cjs" /* <-- shimmed module of "../utils/slack.ts" that actions/github-script can require */).load();
@@ -180,7 +182,7 @@ jobs:
               ].join(" ");
 
               await slack.chat.postMessage({
-                channel: slackChannelIds["#error-pulse"],
+                channel: slackChannelIds[slackChannelName] ?? slackChannelName,
                 text: message,
               });
             };

--- a/.github/workflows/deploy-example.yml
+++ b/.github/workflows/deploy-example.yml
@@ -117,6 +117,7 @@ jobs:
             const publicUrl = "${{ needs.deploy.outputs.public_url }}";
             const runUrl = "${{ needs.variables.outputs.run_url }}";
             const shortSha = "${{ needs.variables.outputs.short_sha }}";
+            const slackChannelName = "#ci";
             const __handler = async function notify_slack_on_success() {
               const { getSlackClient, slackChannelIds } =
                 await require(".github/ts-workflows/workflows/deploy-example.ts.utilsslackts-64e60416ee9563c2f22509a2a7a4ac68-tsx-shim.cjs" /* <-- shimmed module of "../utils/slack.ts" that actions/github-script can require */).load();
@@ -130,7 +131,7 @@ jobs:
                 .join(" · ");
 
               await slack.chat.postMessage({
-                channel: slackChannelIds["#building"],
+                channel: slackChannelIds[slackChannelName] ?? slackChannelName,
                 text: message,
               });
             };
@@ -170,6 +171,7 @@ jobs:
             const appDisplayName = "Example";
             const runUrl = "${{ needs.variables.outputs.run_url }}";
             const shortSha = "${{ needs.variables.outputs.short_sha }}";
+            const slackChannelName = "#ci";
             const __handler = async function notify_slack_on_failure() {
               const { getSlackClient, slackChannelIds } =
                 await require(".github/ts-workflows/workflows/deploy-example.ts.utilsslackts-64e60416ee9563c2f22509a2a7a4ac68-tsx-shim.cjs" /* <-- shimmed module of "../utils/slack.ts" that actions/github-script can require */).load();
@@ -181,7 +183,7 @@ jobs:
               ].join(" ");
 
               await slack.chat.postMessage({
-                channel: slackChannelIds["#error-pulse"],
+                channel: slackChannelIds[slackChannelName] ?? slackChannelName,
                 text: message,
               });
             };

--- a/.github/workflows/deploy-os2.yml
+++ b/.github/workflows/deploy-os2.yml
@@ -117,6 +117,7 @@ jobs:
             const publicUrl = "${{ needs.deploy.outputs.public_url }}";
             const runUrl = "${{ needs.variables.outputs.run_url }}";
             const shortSha = "${{ needs.variables.outputs.short_sha }}";
+            const slackChannelName = "#ci";
             const __handler = async function notify_slack_on_success() {
               const { getSlackClient, slackChannelIds } =
                 await require(".github/ts-workflows/workflows/deploy-os2.ts.utilsslackts-64e60416ee9563c2f22509a2a7a4ac68-tsx-shim.cjs" /* <-- shimmed module of "../utils/slack.ts" that actions/github-script can require */).load();
@@ -130,7 +131,7 @@ jobs:
                 .join(" · ");
 
               await slack.chat.postMessage({
-                channel: slackChannelIds["#building"],
+                channel: slackChannelIds[slackChannelName] ?? slackChannelName,
                 text: message,
               });
             };
@@ -170,6 +171,7 @@ jobs:
             const appDisplayName = "OS";
             const runUrl = "${{ needs.variables.outputs.run_url }}";
             const shortSha = "${{ needs.variables.outputs.short_sha }}";
+            const slackChannelName = "#ci";
             const __handler = async function notify_slack_on_failure() {
               const { getSlackClient, slackChannelIds } =
                 await require(".github/ts-workflows/workflows/deploy-os2.ts.utilsslackts-64e60416ee9563c2f22509a2a7a4ac68-tsx-shim.cjs" /* <-- shimmed module of "../utils/slack.ts" that actions/github-script can require */).load();
@@ -181,7 +183,7 @@ jobs:
               ].join(" ");
 
               await slack.chat.postMessage({
-                channel: slackChannelIds["#error-pulse"],
+                channel: slackChannelIds[slackChannelName] ?? slackChannelName,
                 text: message,
               });
             };

--- a/.github/workflows/deploy-semaphore.yml
+++ b/.github/workflows/deploy-semaphore.yml
@@ -117,6 +117,7 @@ jobs:
             const publicUrl = "${{ needs.deploy.outputs.public_url }}";
             const runUrl = "${{ needs.variables.outputs.run_url }}";
             const shortSha = "${{ needs.variables.outputs.short_sha }}";
+            const slackChannelName = "#ci";
             const __handler = async function notify_slack_on_success() {
               const { getSlackClient, slackChannelIds } =
                 await require(".github/ts-workflows/workflows/deploy-semaphore.ts.utilsslackts-64e60416ee9563c2f22509a2a7a4ac68-tsx-shim.cjs" /* <-- shimmed module of "../utils/slack.ts" that actions/github-script can require */).load();
@@ -130,7 +131,7 @@ jobs:
                 .join(" · ");
 
               await slack.chat.postMessage({
-                channel: slackChannelIds["#building"],
+                channel: slackChannelIds[slackChannelName] ?? slackChannelName,
                 text: message,
               });
             };
@@ -170,6 +171,7 @@ jobs:
             const appDisplayName = "Semaphore";
             const runUrl = "${{ needs.variables.outputs.run_url }}";
             const shortSha = "${{ needs.variables.outputs.short_sha }}";
+            const slackChannelName = "#ci";
             const __handler = async function notify_slack_on_failure() {
               const { getSlackClient, slackChannelIds } =
                 await require(".github/ts-workflows/workflows/deploy-semaphore.ts.utilsslackts-64e60416ee9563c2f22509a2a7a4ac68-tsx-shim.cjs" /* <-- shimmed module of "../utils/slack.ts" that actions/github-script can require */).load();
@@ -181,7 +183,7 @@ jobs:
               ].join(" ");
 
               await slack.chat.postMessage({
-                channel: slackChannelIds["#error-pulse"],
+                channel: slackChannelIds[slackChannelName] ?? slackChannelName,
                 text: message,
               });
             };

--- a/.github/workflows/sandbox-test.yml
+++ b/.github/workflows/sandbox-test.yml
@@ -5,20 +5,6 @@ permissions:
   contents: read
   id-token: write
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - sandbox/**
-      - apps/daemon/**
-      - packages/pidnap/**
-      - .github/workflows/sandbox-test.yml
-  pull_request:
-    paths:
-      - sandbox/**
-      - apps/daemon/**
-      - packages/pidnap/**
-      - .github/workflows/sandbox-test.yml
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
## Summary

- Route new-style Cloudflare app deployment Slack notifications to `#ci`.
- Simplify main CI to deploy the existing OS app/worker without building, testing, promoting, or redeploying a new sandbox image.
- Stop the sandbox build/provider-test workflow from running automatically on push/PR while leaving it manually dispatchable.

## Impact

Production keeps using the existing sandbox image because CI no longer updates `FLY_DEFAULT_IMAGE` in Doppler. The old OS deployment path remains wired through the main CI deploy job.

## Validation

- `node cli.ts from-ts --dry-run` from `.github/ts-workflows`
- Parsed changed workflow YAML with `yaml`
- `pnpm build` in `.github/ts-workflows` is currently blocked by an existing `workflows/integration.ts` error: `runsOnDepotUbuntuForContainerThings` is missing from workflow utils.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production CI behavior by removing sandbox image build/test/promotion steps and altering Slack notification routing, which could affect rollout gating and alert visibility. No application runtime logic changes, but mistakes here can impact deployments and operational response.
> 
> **Overview**
> Main `CI` is simplified to only run the existing `deploy.yml` path (removing the OS early deploy, sandbox image build/tests, Doppler `FLY_DEFAULT_IMAGE` promotion, and redeploy), and the Slack failure message is trimmed to omit variables outputs.
> 
> Cloudflare app deploy workflows now choose Slack channels dynamically: *new-style apps* notify `#ci` on both success and failure, while legacy apps keep `#building`/`#error-pulse`; Slack posting now falls back to using the raw channel name if it’s not in `slackChannelIds` (which now includes `#ci`).
> 
> The `Sandbox Build + Provider Tests` workflow is no longer triggered on push/PR and is left as `workflow_dispatch` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b9936dc798024811bee2c8958fdaa862bfde80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->