### PR TITLE
[codex] port stream tui to os2

### DIFF
--- a/apps/os2/package.json
+++ b/apps/os2/package.json
@@ -39,7 +39,7 @@
   "iterateAppCli": {
     "remote": {
       "auth": "shared-api-secret-bearer",
-      "defaultBaseUrl": "https://os2.iterate.com"
+      "defaultBaseUrl": "https://os.iterate2.com"
     }
   },
   "dependencies": {
@@ -51,6 +51,8 @@
     "@iterate-com/shared": "workspace:*",
     "@iterate-com/ui": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@opentui/core": "0.1.102",
+    "@opentui/react": "0.1.102",
     "@orpc/client": "1.13.14",
     "@orpc/contract": "1.13.14",
     "@orpc/openapi": "1.13.14",

--- a/apps/os2/scripts/event-stream-terminal.tsx
+++ b/apps/os2/scripts/event-stream-terminal.tsx
@@ -1,0 +1,893 @@
+#!/usr/bin/env bun
+/** @jsxImportSource @opentui/react */
+// oxlint-disable react/only-export-components -- CLI entrypoint, not a Vite Fast Refresh module.
+/**
+ * React/OpenTUI terminal UI for inspecting and appending to an iterate event
+ * stream. Event interpretation is shared with the browser renderer via
+ * `EventsStreamViewReducer`; this file only owns terminal runtime state,
+ * keyboard routing, and stream-scoped side effects.
+ */
+import { Event, StreamPath, type EventInput } from "@iterate-com/shared/streams/types";
+import type { EventsStreamViewState } from "@iterate-com/ui/components/events/feed-items";
+import {
+  reduceStreamViewEvents,
+  StreamViewProcessorContract,
+} from "@iterate-com/ui/components/events/stream-view-processor/contract";
+import { getInitialProcessorState } from "@iterate-com/shared/stream-processors";
+import { createCliRenderer, type KeyEvent } from "@opentui/core";
+import { createRoot, useKeyboard, useRenderer } from "@opentui/react";
+import { createORPCClient } from "@orpc/client";
+import { OpenAPILink } from "@orpc/openapi-client/fetch";
+import { ORPCError } from "@orpc/server";
+import type { RouterClient } from "@orpc/server";
+import { osContract } from "@iterate-com/os2-contract";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { appRouter } from "../src/orpc/root.ts";
+import {
+  acceptedSlashInput,
+  findSlashCommand as findDiscoveredSlashCommand,
+  formatSlashCommandLabelSegments,
+  parseSlashAutocompleteQuery,
+  suggestSlashCommands,
+} from "../src/stream-tui/command-discovery.ts";
+import {
+  MissingCommandArgumentsError,
+  parseSlashCommandInput,
+  parseSlashInvocation,
+} from "../src/stream-tui/command-invocation.ts";
+import {
+  commandEntries,
+  runCommand as runTuiCommand,
+  type AppContext,
+  type CommandEntry,
+  type StreamApi,
+  type StreamSummary,
+} from "../src/stream-tui/command-router.ts";
+import { TuiEventsStreamView } from "../src/stream-tui/react-stream-renderers.tsx";
+import {
+  formatCommandDocsForTui,
+  getRawEventRowTargetsForTui,
+  getRawEventSummariesForTui,
+  type TuiSlashSuggestion,
+} from "../src/stream-tui/react-stream-view-model.ts";
+import {
+  focusStreamTuiComposer,
+  focusStreamTuiFeed,
+  focusStreamTuiHeader,
+  initialStreamTuiNavigationState,
+  setStreamTuiView,
+  type StreamTuiView,
+} from "../src/stream-tui/navigation-state.ts";
+import { resolveStreamPath as resolveStreamPathForCurrent } from "../src/stream-tui/stream-paths.ts";
+import { getDefaultExpandedStreamPaths, getStreamTreeRows } from "../src/stream-tui/stream-tree.ts";
+
+if (!process.stdin.isTTY || !process.stdout.isTTY) {
+  throw new Error("stream-tui requires an interactive terminal.");
+}
+
+const args = parseArgs(process.argv.slice(2));
+type OrpcClient = RouterClient<typeof appRouter>;
+const ROOT_STREAM_PATH = StreamPath.parse("/");
+
+const feedModes = {
+  raw: { label: "Raw" },
+  mixed: { label: "Mixed" },
+  pretty: { label: "Pretty" },
+} as const;
+type FeedMode = keyof typeof feedModes;
+
+function applyFeedMode(state: EventsStreamViewState, mode: FeedMode): EventsStreamViewState {
+  if (mode === "pretty") {
+    return {
+      ...state,
+      slots: {
+        ...state.slots,
+        feed: state.slots.feed.filter((el) => el.type !== "grouped-raw-event"),
+      },
+    };
+  }
+  if (mode === "raw") {
+    return {
+      ...state,
+      slots: {
+        ...state.slots,
+        feed: state.slots.feed.filter((el) => el.type === "grouped-raw-event"),
+      },
+    };
+  }
+  return state;
+}
+
+function StreamTerminalApp() {
+  const renderer = useRenderer();
+  const client = useMemo(() => createOs2Client(args.baseUrl), []);
+  const [currentStreamPath, setCurrentStreamPath] = useState(args.streamPath ?? ROOT_STREAM_PATH);
+  const [currentFeedMode, setCurrentFeedMode] = useState<FeedMode>("mixed");
+  const [rawEvents, setRawEvents] = useState<Event[]>([]);
+  const [viewState, setViewState] = useState<EventsStreamViewState>(() =>
+    getInitialProcessorState(StreamViewProcessorContract),
+  );
+  const [status, setStatus] = useState("connecting");
+  const [appendStatus, setAppendStatus] = useState("");
+  const [pulseOn, setPulseOn] = useState(true);
+  const [composerValue, setComposerValue] = useState("");
+  const [composerRevision, setComposerRevision] = useState(0);
+  const [selectedOffset, setSelectedOffset] = useState<number | undefined>();
+  const [detailEventOffset, setDetailEventOffset] = useState<number | undefined>();
+  const [navigationState, setNavigationState] = useState(() =>
+    args.streamPath == null
+      ? focusStreamTuiFeed(setStreamTuiView(initialStreamTuiNavigationState, "streams"))
+      : initialStreamTuiNavigationState,
+  );
+  const [streamSummaries, setStreamSummaries] = useState<StreamSummary[]>([]);
+  const [selectedStreamPath, setSelectedStreamPath] = useState<StreamPath | undefined>(
+    args.streamPath ?? ROOT_STREAM_PATH,
+  );
+  const [expandedStreamPaths, setExpandedStreamPaths] = useState<Set<StreamPath>>(
+    () => new Set(getDefaultExpandedStreamPaths(args.streamPath ?? ROOT_STREAM_PATH)),
+  );
+  const [streamSearchOpen, setStreamSearchOpen] = useState(false);
+  const [streamSearchQuery, setStreamSearchQuery] = useState("");
+  const [selectedSlashCommandPath, setSelectedSlashCommandPath] = useState<string | undefined>();
+  const [lastSpaceTimestamp, setLastSpaceTimestamp] = useState(0);
+  const [streamRestartNonce, setStreamRestartNonce] = useState(0);
+  const activeAbortController = useRef<AbortController | undefined>(undefined);
+
+  useEffect(() => {
+    const interval = setInterval(() => setPulseOn((previous) => !previous), 700);
+    interval.unref();
+    return () => clearInterval(interval);
+  }, []);
+
+  const replaceComposerValue = useCallback((value: string) => {
+    setComposerValue(value);
+    setComposerRevision((previous) => previous + 1);
+  }, []);
+
+  useEffect(() => {
+    setViewState(applyFeedMode(reduceStreamViewEvents(rawEvents), currentFeedMode));
+  }, [currentFeedMode, rawEvents]);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    activeAbortController.current?.abort();
+    activeAbortController.current = abortController;
+    setRawEvents([]);
+    setSelectedOffset(undefined);
+    setDetailEventOffset(undefined);
+    setStatus("connecting");
+
+    void (async () => {
+      try {
+        const stream = await client.project.streams.streamEvents(
+          {
+            afterOffset: "start",
+            projectSlugOrId: args.projectSlugOrId,
+            streamPath: currentStreamPath,
+          },
+          { signal: abortController.signal },
+        );
+        setStatus("streaming");
+
+        for await (const value of stream) {
+          if (abortController.signal.aborted) return;
+          const event = Event.parse(value);
+          setRawEvents((previous) => [...previous, event]);
+        }
+
+        setStatus("stream closed");
+      } catch (error) {
+        if (abortController.signal.aborted) return;
+        setStatus(`stream error: ${formatError(error)}`);
+      }
+    })();
+
+    return () => abortController.abort();
+  }, [client, currentStreamPath, streamRestartNonce]);
+
+  const resolveStreamPath = useCallback(
+    (streamPath?: string) => resolveStreamPathForCurrent({ currentStreamPath, streamPath }),
+    [currentStreamPath],
+  );
+
+  const navigateToStream = useCallback((streamPath: StreamPath) => {
+    setCurrentStreamPath(streamPath);
+    setSelectedStreamPath(streamPath);
+    setExpandedStreamPaths(
+      (previous) => new Set([...previous, ...getDefaultExpandedStreamPaths(streamPath)]),
+    );
+    setStreamSearchOpen(false);
+    setStreamSearchQuery("");
+    setNavigationState((previous) => setStreamTuiView(previous, "feed"));
+    setAppendStatus(`opened ${streamPath}`);
+  }, []);
+
+  const restartStream = useCallback(() => {
+    setStreamRestartNonce((previous) => previous + 1);
+  }, []);
+
+  const streamApi = useMemo<StreamApi>(
+    () => ({
+      append: async (input) => {
+        const result = await client.project.streams.append({
+          projectSlugOrId: args.projectSlugOrId,
+          streamPath: resolveStreamPath(input.streamPath),
+          event: input.event,
+        });
+        return result.event;
+      },
+      getState: async (input = {}) =>
+        client.project.streams.getState({
+          projectSlugOrId: args.projectSlugOrId,
+          streamPath: resolveStreamPath(input.streamPath),
+        }),
+      listChildren: async (input = {}) => {
+        const { streams } = await client.project.streams.list({
+          projectSlugOrId: args.projectSlugOrId,
+        });
+        const basePath = resolveStreamPath(input.streamPath);
+        return streams
+          .filter((stream) => basePath === "/" || stream.streamPath.startsWith(`${basePath}/`))
+          .map((stream) => ({
+            path: stream.streamPath,
+            createdAt: stream.createdAt,
+          }));
+      },
+      resolvePath: resolveStreamPath,
+    }),
+    [client, resolveStreamPath],
+  );
+
+  useEffect(() => {
+    if (args.streamPath != null) return;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const streams = await streamApi.listChildren({ streamPath: "/" });
+        if (cancelled) return;
+        setStreamSummaries(streams);
+        setSelectedStreamPath(ROOT_STREAM_PATH);
+        setAppendStatus(`${streams.length} stream${streams.length === 1 ? "" : "s"}`);
+      } catch (error) {
+        if (cancelled) return;
+        setAppendStatus(`stream tree error: ${formatError(error)}`);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [streamApi]);
+
+  const setActiveView = useCallback((view: StreamTuiView) => {
+    setNavigationState((previous) => setStreamTuiView(previous, view));
+  }, []);
+
+  const switchFeedMode = useCallback((mode: FeedMode) => {
+    setCurrentFeedMode(mode);
+    setSelectedOffset(undefined);
+    setDetailEventOffset(undefined);
+    setNavigationState((previous) => setStreamTuiView(previous, "feed"));
+    setAppendStatus(`${feedModes[mode].label} mode`);
+  }, []);
+
+  const focusInput = useCallback(() => {
+    setStreamSearchOpen(false);
+    setNavigationState((previous) => focusStreamTuiComposer(previous));
+  }, []);
+
+  const focusFeed = useCallback(() => {
+    setNavigationState((previous) => focusStreamTuiFeed(previous));
+    if (navigationState.view === "streams") {
+      setSelectedStreamPath((previous) => previous ?? currentStreamPath);
+      return;
+    }
+    const rawRows = getRawEventRowTargetsForTui(viewState.slots.feed);
+    setSelectedOffset((previous) => previous ?? rawRows[rawRows.length - 1]?.offset);
+  }, [currentStreamPath, navigationState.view, viewState.slots.feed]);
+
+  const focusHeader = useCallback(() => {
+    setNavigationState((previous) => focusStreamTuiHeader(previous));
+  }, []);
+
+  const appContext = useMemo<AppContext>(
+    () => ({
+      get streamPath() {
+        return currentStreamPath;
+      },
+      get reducedState() {
+        return viewState;
+      },
+      streamApi,
+      setActiveView,
+      switchFeedMode,
+      setStreamSummaries(streams, filter) {
+        setStreamSummaries(streams);
+        setSelectedStreamPath(currentStreamPath);
+        setExpandedStreamPaths(
+          (previous) => new Set([...previous, ...getDefaultExpandedStreamPaths(currentStreamPath)]),
+        );
+        setStreamSearchOpen((filter ?? "").length > 0);
+        setStreamSearchQuery(filter ?? "");
+      },
+      navigateToStream,
+      restartStream,
+      prefillInput(value) {
+        replaceComposerValue(value);
+        focusInput();
+      },
+      collapseVisibleFeedItems() {},
+      expandVisibleFeedItems() {},
+      openEventDetail(offset) {
+        setDetailEventOffset(offset);
+        setSelectedOffset(offset);
+        setNavigationState((previous) => setStreamTuiView(previous, "feed"));
+        focusFeed();
+      },
+      exit() {
+        activeAbortController.current?.abort();
+        renderer.destroy();
+      },
+      toast: {
+        info(message) {
+          setAppendStatus(message);
+        },
+        success(message) {
+          setAppendStatus(message);
+        },
+        error(message) {
+          setAppendStatus(`error: ${message}`);
+        },
+      },
+    }),
+    [
+      currentStreamPath,
+      focusFeed,
+      focusInput,
+      navigateToStream,
+      replaceComposerValue,
+      renderer,
+      restartStream,
+      setActiveView,
+      streamApi,
+      switchFeedMode,
+      viewState,
+    ],
+  );
+
+  const slashUi = useMemo(() => {
+    const resolvedCommand = getResolvedSlashCommand(composerValue);
+    if (resolvedCommand != null) {
+      return {
+        suggestions: [] satisfies TuiSlashSuggestion[],
+        commandDocs: formatCommandDocsForTui(resolvedCommand),
+      };
+    }
+
+    const suggestions = suggestSlashCommands({
+      commands: commandEntries,
+      input: composerValue,
+      limit: 8,
+    });
+    return {
+      suggestions: suggestions.map((command) => ({
+        path: command.path,
+        segments: formatSlashCommandLabelSegments({ command, input: composerValue }),
+      })),
+      commandDocs: [] as string[],
+    };
+  }, [composerValue]);
+
+  useEffect(() => {
+    const query = parseSlashAutocompleteQuery(composerValue);
+    if (slashUi.suggestions.length === 0) {
+      setSelectedSlashCommandPath(undefined);
+      return;
+    }
+
+    setSelectedSlashCommandPath((previous) =>
+      previous != null && slashUi.suggestions.some((command) => command.path === previous)
+        ? previous
+        : slashUi.suggestions[0]?.path,
+    );
+    void query;
+  }, [composerValue, slashUi.suggestions]);
+
+  const visibleStreamRows = useMemo(
+    () =>
+      getStreamTreeRows({
+        streams: streamSummaries,
+        currentStreamPath,
+        expandedPaths: expandedStreamPaths,
+        searchQuery: streamSearchOpen ? streamSearchQuery : "",
+        selectedPath: selectedStreamPath,
+      }),
+    [
+      currentStreamPath,
+      expandedStreamPaths,
+      selectedStreamPath,
+      streamSearchOpen,
+      streamSearchQuery,
+      streamSummaries,
+    ],
+  );
+
+  const runSlashCommand = useCallback(
+    async (content: string) => {
+      if (!content.startsWith("/")) return false;
+      const invocation = parseSlashInvocation(content);
+      if (invocation == null) return false;
+
+      const command = findDiscoveredSlashCommand({
+        commands: commandEntries,
+        slash: invocation.slash,
+      });
+      if (command == null) {
+        setAppendStatus(`unknown command /${invocation.slash}`);
+        return true;
+      }
+
+      try {
+        setAppendStatus("");
+        await runTuiCommand({
+          appContext,
+          command,
+          inputValue: parseSlashCommandInput({
+            commandTitle: command.title,
+            slashName: command.slash.name,
+            input: command.input,
+            rawArgs: invocation.rawArgs,
+          }),
+        });
+      } catch (error) {
+        if (error instanceof MissingCommandArgumentsError) {
+          replaceComposerValue(`/${error.slashName} `);
+          focusInput();
+          return true;
+        }
+        setAppendStatus(`error: ${formatError(error)}`);
+      }
+
+      setAppendStatus((previous) => previous || `/${invocation.slash}`);
+      return true;
+    },
+    [appContext, focusInput, replaceComposerValue],
+  );
+
+  const appendInput = useCallback(
+    async (value: string) => {
+      const content = value.trim();
+      if (content.length === 0) return;
+
+      replaceComposerValue("");
+      if (await runSlashCommand(content)) return;
+
+      setAppendStatus("sending");
+      const event: EventInput = {
+        type: "events.iterate.com/agent-chat/user-message-added",
+        payload: { channel: "tui", content },
+      };
+
+      try {
+        const appendedEvent = await streamApi.append({ event });
+        setAppendStatus(`sent offset ${appendedEvent.offset}`);
+      } catch (error) {
+        setAppendStatus(`append error: ${formatError(error)}`);
+      }
+    },
+    [replaceComposerValue, runSlashCommand, streamApi],
+  );
+
+  const selectAdjacentFeedItem = useCallback(
+    (direction: -1 | 1) => {
+      const rawRows = getRawEventRowTargetsForTui(viewState.slots.feed);
+      if (rawRows.length === 0) return;
+      const currentIndex = rawRows.findIndex((row) =>
+        selectedOffset == null ? false : row.offsets.has(selectedOffset),
+      );
+      const nextIndex =
+        currentIndex === -1 ? (direction === 1 ? 0 : rawRows.length - 1) : currentIndex + direction;
+      if (nextIndex < 0 || nextIndex >= rawRows.length) return;
+      setSelectedOffset(rawRows[nextIndex]?.offset);
+    },
+    [selectedOffset, viewState.slots.feed],
+  );
+
+  const navigateDetailEvent = useCallback(
+    (direction: -1 | 1) => {
+      const rawSummaries = getRawEventSummariesForTui(viewState.slots.feed);
+      const currentIndex = rawSummaries.findIndex((item) => item.offset === detailEventOffset);
+      const next = rawSummaries[currentIndex + direction];
+      if (next == null) return;
+      setDetailEventOffset(next.offset);
+      setSelectedOffset(next.offset);
+    },
+    [detailEventOffset, viewState.slots.feed],
+  );
+
+  const selectAdjacentStreamRow = useCallback(
+    (direction: -1 | 1) => {
+      if (visibleStreamRows.length === 0) return;
+      const currentIndex = visibleStreamRows.findIndex((row) => row.path === selectedStreamPath);
+      const nextIndex =
+        currentIndex === -1
+          ? direction === 1
+            ? 0
+            : visibleStreamRows.length - 1
+          : (currentIndex + direction + visibleStreamRows.length) % visibleStreamRows.length;
+      setSelectedStreamPath(visibleStreamRows[nextIndex]?.path);
+    },
+    [selectedStreamPath, visibleStreamRows],
+  );
+
+  const openSelectedStreamPath = useCallback(() => {
+    if (selectedStreamPath == null) return;
+    navigateToStream(selectedStreamPath);
+  }, [navigateToStream, selectedStreamPath]);
+
+  const toggleSelectedStreamPath = useCallback(() => {
+    const selectedRow = visibleStreamRows.find((row) => row.path === selectedStreamPath);
+    if (selectedRow == null) return;
+    if (!selectedRow.hasChildren) {
+      openSelectedStreamPath();
+      return;
+    }
+    setExpandedStreamPaths((previous) => {
+      const next = new Set(previous);
+      if (selectedRow.expanded) next.delete(selectedRow.path);
+      else next.add(selectedRow.path);
+      return next;
+    });
+  }, [openSelectedStreamPath, selectedStreamPath, visibleStreamRows]);
+
+  const setSelectedStreamExpanded = useCallback(
+    (expanded: boolean) => {
+      if (selectedStreamPath == null) return;
+      setExpandedStreamPaths((previous) => {
+        const next = new Set(previous);
+        if (expanded) next.add(selectedStreamPath);
+        else next.delete(selectedStreamPath);
+        return next;
+      });
+    },
+    [selectedStreamPath],
+  );
+
+  const handleSlashAutocompleteKey = useCallback(
+    (key: KeyEvent) => {
+      if (slashUi.commandDocs.length > 0) {
+        if (key.name === "escape") {
+          replaceComposerValue("");
+          return true;
+        }
+        return false;
+      }
+      if (slashUi.suggestions.length === 0) return false;
+
+      if (key.name === "escape") {
+        replaceComposerValue("");
+        setSelectedSlashCommandPath(undefined);
+        return true;
+      }
+
+      if (key.name === "tab" || key.name === "down" || key.name === "up") {
+        const currentIndex = slashUi.suggestions.findIndex(
+          (command) => command.path === selectedSlashCommandPath,
+        );
+        const direction = key.name === "up" || key.shift ? -1 : 1;
+        const nextIndex =
+          currentIndex === -1
+            ? direction === 1
+              ? 0
+              : slashUi.suggestions.length - 1
+            : (currentIndex + direction + slashUi.suggestions.length) % slashUi.suggestions.length;
+        setSelectedSlashCommandPath(slashUi.suggestions[nextIndex]?.path);
+        return true;
+      }
+
+      if (key.name === "return") {
+        const command = commandEntries.find((entry) => entry.path === selectedSlashCommandPath);
+        if (command != null) {
+          const nextValue = acceptedSlashInput(command);
+          if (command.input?.positional?.required !== true) {
+            void appendInput(nextValue);
+          } else {
+            replaceComposerValue(nextValue);
+          }
+        }
+        return true;
+      }
+
+      return false;
+    },
+    [
+      appendInput,
+      replaceComposerValue,
+      selectedSlashCommandPath,
+      slashUi.commandDocs.length,
+      slashUi.suggestions,
+    ],
+  );
+
+  const handleStreamsViewKey = useCallback(
+    (key: KeyEvent) => {
+      if (key.name === "escape") {
+        if (streamSearchOpen) {
+          setStreamSearchOpen(false);
+          setStreamSearchQuery("");
+          return true;
+        }
+        return false;
+      }
+      if (key.name === "down") {
+        selectAdjacentStreamRow(1);
+        return true;
+      }
+      if (key.name === "up") {
+        selectAdjacentStreamRow(-1);
+        return true;
+      }
+      if (key.name === "return") {
+        openSelectedStreamPath();
+        return true;
+      }
+
+      if (streamSearchOpen) {
+        if (key.name === "backspace") {
+          setStreamSearchQuery((previous) => previous.slice(0, -1));
+          return true;
+        }
+        if (isPrintableCharacter(key.sequence)) {
+          setStreamSearchQuery((previous) => previous + key.sequence);
+          return true;
+        }
+        return true;
+      }
+
+      if (key.sequence === " ") {
+        const now = Date.now();
+        if (now - lastSpaceTimestamp < 300) {
+          setExpandedStreamPaths((previous) => {
+            const next = new Set(previous);
+            if (selectedStreamPath != null) {
+              next.add(selectedStreamPath);
+              for (const stream of streamSummaries) {
+                if (stream.path.startsWith(`${selectedStreamPath}/`)) next.add(stream.path);
+              }
+            }
+            return next;
+          });
+          setLastSpaceTimestamp(0);
+        } else {
+          toggleSelectedStreamPath();
+          setLastSpaceTimestamp(now);
+        }
+        return true;
+      }
+
+      if (key.name === "right") {
+        setSelectedStreamExpanded(true);
+        return true;
+      }
+      if (key.name === "left") {
+        setSelectedStreamExpanded(false);
+        return true;
+      }
+      if (isPrintableCharacter(key.sequence)) {
+        setStreamSearchOpen(true);
+        setStreamSearchQuery(key.sequence);
+        return true;
+      }
+      return false;
+    },
+    [
+      lastSpaceTimestamp,
+      openSelectedStreamPath,
+      selectAdjacentStreamRow,
+      selectedStreamPath,
+      setSelectedStreamExpanded,
+      streamSearchOpen,
+      streamSummaries,
+      toggleSelectedStreamPath,
+    ],
+  );
+
+  useKeyboard((key) => {
+    if (handleSlashAutocompleteKey(key)) {
+      key.preventDefault();
+      key.stopPropagation();
+      return;
+    }
+
+    if (key.name === "tab") {
+      const regions = ["header", "feed", "composer"] as const;
+      const currentIndex = regions.indexOf(navigationState.focus);
+      const next = regions[(currentIndex + (key.shift ? -1 : 1) + regions.length) % regions.length];
+      if (next === "composer") focusInput();
+      else if (next === "feed") focusFeed();
+      else focusHeader();
+      key.preventDefault();
+      key.stopPropagation();
+      return;
+    }
+
+    if (
+      navigationState.focus === "feed" &&
+      navigationState.view === "streams" &&
+      handleStreamsViewKey(key)
+    ) {
+      key.preventDefault();
+      key.stopPropagation();
+      return;
+    }
+
+    if (navigationState.focus !== "feed") {
+      if (key.name === "escape") {
+        setNavigationState((previous) => setStreamTuiView(previous, "feed"));
+        focusInput();
+        key.preventDefault();
+        key.stopPropagation();
+      }
+      return;
+    }
+
+    if (key.name === "escape") {
+      if (detailEventOffset != null) {
+        setDetailEventOffset(undefined);
+      } else {
+        setNavigationState((previous) => setStreamTuiView(previous, "feed"));
+        focusInput();
+      }
+      key.preventDefault();
+      key.stopPropagation();
+      return;
+    }
+
+    if (detailEventOffset != null) {
+      if (key.name === "left") navigateDetailEvent(-1);
+      if (key.name === "right") navigateDetailEvent(1);
+      return;
+    }
+
+    if (key.name === "down") {
+      selectAdjacentFeedItem(1);
+      key.preventDefault();
+      return;
+    }
+    if (key.name === "up") {
+      selectAdjacentFeedItem(-1);
+      key.preventDefault();
+      return;
+    }
+    if (
+      (key.name === "return" || key.name === "right" || key.name === "space") &&
+      selectedOffset != null
+    ) {
+      setDetailEventOffset(selectedOffset);
+      key.preventDefault();
+    }
+  });
+
+  const composerPlaceholder =
+    navigationState.focus === "composer"
+      ? "Type a message or / for commands"
+      : "Tab to return to input";
+
+  return (
+    <TuiEventsStreamView
+      streamPath={currentStreamPath}
+      viewState={viewState}
+      modeLabel={feedModes[currentFeedMode].label}
+      status={status}
+      appendStatus={appendStatus}
+      pulseOn={pulseOn}
+      focusedRegion={navigationState.focus}
+      activeView={navigationState.view}
+      detailEventOffset={detailEventOffset}
+      selectedOffset={selectedOffset}
+      streamRows={visibleStreamRows}
+      streamSearchOpen={streamSearchOpen}
+      streamSearchQuery={streamSearchQuery}
+      composerValue={composerValue}
+      composerRevision={composerRevision}
+      composerPlaceholder={composerPlaceholder}
+      slashSuggestions={slashUi.suggestions}
+      selectedSlashCommandPath={selectedSlashCommandPath}
+      commandDocs={slashUi.commandDocs}
+      onComposerInput={setComposerValue}
+      onComposerSubmit={appendInput}
+    />
+  );
+}
+
+const renderer = await createCliRenderer({
+  exitOnCtrlC: true,
+  targetFps: 30,
+  screenMode: "alternate-screen",
+  consoleMode: "disabled",
+});
+createRoot(renderer).render(<StreamTerminalApp />);
+
+function getResolvedSlashCommand(input: string): CommandEntry | undefined {
+  if (!input.startsWith("/") || !input.includes(" ")) return undefined;
+  const invocation = parseSlashInvocation(input);
+  if (invocation == null) return undefined;
+  return findDiscoveredSlashCommand({ commands: commandEntries, slash: invocation.slash });
+}
+
+function isPrintableCharacter(sequence: string) {
+  return sequence.length === 1 && sequence >= " " && sequence !== "\u007f";
+}
+
+function formatError(error: unknown) {
+  if (error instanceof ORPCError) return `${error.code}: ${error.message}`;
+  return error instanceof Error ? error.message : String(error);
+}
+
+function parseArgs(argv: string[]) {
+  const baseUrl = readFlag(argv, "--base-url");
+  const projectSlugOrId = readFlag(argv, "--project-slug-or-id");
+  const streamPath = readFlag(argv, "--stream-path");
+
+  if (baseUrl == null || projectSlugOrId == null) {
+    throw new Error(
+      "Usage: bun scripts/event-stream-terminal.tsx --base-url <url> --project-slug-or-id <slug-or-id> [--stream-path <path>]",
+    );
+  }
+
+  return {
+    baseUrl: baseUrl.replace(/\/+$/, ""),
+    projectSlugOrId,
+    streamPath: streamPath == null ? undefined : StreamPath.parse(streamPath),
+  };
+}
+
+function readFlag(argv: string[], flagName: string) {
+  const index = argv.indexOf(flagName);
+  if (index === -1) return undefined;
+
+  const value = argv[index + 1];
+  if (value == null || value.startsWith("--")) {
+    throw new Error(`${flagName} requires a value.`);
+  }
+  return value;
+}
+
+function createOs2Client(baseUrl: string): OrpcClient {
+  const authHeaders = requireAuthHeaders();
+  return createORPCClient(
+    new OpenAPILink(osContract, {
+      url: new URL("/api", `${baseUrl}/`).toString(),
+      fetch: (input, init) => {
+        const requestInit: RequestInit = init ?? {};
+        const headers = new Headers(input instanceof Request ? input.headers : undefined);
+        for (const [key, value] of new Headers(requestInit.headers)) headers.set(key, value);
+        for (const [key, value] of Object.entries(authHeaders)) headers.set(key, value);
+        if (input instanceof Request) {
+          return fetch(new Request(input, { ...requestInit, headers }));
+        }
+        return fetch(input, { ...requestInit, headers });
+      },
+    }),
+  ) as OrpcClient;
+}
+
+function requireAuthHeaders() {
+  const bearerToken =
+    process.env.OS2_E2E_ADMIN_API_SECRET?.trim() ||
+    process.env.OS2_ADMIN_API_SECRET?.trim() ||
+    process.env.APP_CONFIG_ADMIN_API_SECRET?.trim() ||
+    process.env.OS2_E2E_BEARER_TOKEN?.trim();
+  const cookie = process.env.OS2_E2E_COOKIE?.trim();
+  if (!bearerToken && !cookie) {
+    throw new Error(
+      "OS2_E2E_ADMIN_API_SECRET, OS2_ADMIN_API_SECRET, APP_CONFIG_ADMIN_API_SECRET, OS2_E2E_BEARER_TOKEN, or OS2_E2E_COOKIE is required.",
+    );
+  }
+
+  return {
+    ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
+    ...(cookie ? { Cookie: cookie } : {}),
+  };
+}

--- a/apps/os2/scripts/router.ts
+++ b/apps/os2/scripts/router.ts
@@ -1,7 +1,66 @@
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { os } from "@orpc/server";
+import { z } from "zod";
 
 import { claudeMcpScript } from "./claude-mcp.ts";
 
+const DEFAULT_OS2_BASE_URL = "https://os.iterate2.com";
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+
+const StreamTuiInput = z.object({
+  projectSlugOrId: z.string().trim().min(1).describe("OS2 project slug or ID"),
+  streamPath: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe("Project stream path, e.g. /agents/demo. Omit to start in stream tree view."),
+  osBaseUrl: z
+    .string()
+    .trim()
+    .url()
+    .default(process.env.OS2_BASE_URL || DEFAULT_OS2_BASE_URL)
+    .describe("OS2 base URL"),
+});
+
 export const router = os.router({
   "claude-mcp": claudeMcpScript,
+  "stream-tui": os
+    .input(StreamTuiInput)
+    .meta({
+      description: "Open an OpenTUI project stream viewer",
+    })
+    .handler(async ({ input }) => {
+      const scriptPath = join(scriptsDir, "event-stream-terminal.tsx");
+      const streamPathArgs = input.streamPath ? ["--stream-path", input.streamPath] : [];
+      // OpenTUI is currently Bun-only: https://opentui.com/docs/getting-started/
+      await runInheritedProcess("bun", [
+        scriptPath,
+        "--base-url",
+        input.osBaseUrl,
+        "--project-slug-or-id",
+        input.projectSlugOrId,
+        ...streamPathArgs,
+      ]);
+
+      return { ok: true as const };
+    }),
 });
+
+async function runInheritedProcess(command: string, args: string[]): Promise<void> {
+  const child = spawn(command, args, {
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  const exitCode = await new Promise<number | null>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", (code) => resolve(code));
+  });
+
+  if (exitCode !== 0) {
+    throw new Error(`${command} exited with code ${exitCode ?? "unknown"}.`);
+  }
+}

--- a/apps/os2/src/stream-tui/CONTEXT.md
+++ b/apps/os2/src/stream-tui/CONTEXT.md
@@ -1,0 +1,66 @@
+# Stream TUI
+
+This folder contains the pure Modules behind `apps/os2`'s OpenTUI stream CLI. The CLI script is the OpenTUI Adapter; it should call these Modules instead of owning command discovery, navigation, path semantics, and test harness details directly.
+
+## Language
+
+**Stream TUI**:
+The terminal UI for looking at one event stream, appending input, and navigating local stream tools.
+
+**OpenTUI Adapter**:
+The renderable/input Implementation that translates Module outputs into `@opentui/core` renderables.
+
+**Slash Discovery Module**:
+The pure Module that turns command records plus the current composer text into slash suggestions.
+
+**Command Router Module**:
+The Module that owns the local oRPC-style command hierarchy, command handlers, input schemas, and TUI metadata.
+
+**Command Invocation Module**:
+The pure Module that parses a submitted slash command into command input.
+
+**Stream Context Module**:
+The pure Module that resolves current-stream-relative paths and formats paths back for command input.
+
+**Navigation Module**:
+The pure Module that owns view and focus state transitions. Panel state should
+only return here once the Adapter renders a real panel.
+
+**Feed Formatting Module**:
+The pure Module that prepares reduced feed items for terminal display without creating OpenTUI renderables.
+
+**Pilotty Command Module**:
+The pure Module that builds repeatable `pilotty` command invocations for agent/manual terminal automation.
+
+**Terminal Automation Run**:
+A manual or agent-driven run that drives the **Stream TUI** through a managed PTY session and records visible behavior.
+_Avoid_: checked-in spec, unit test
+
+**Terminal Behavior Spec**:
+A checked-in black-box test that launches the **Stream TUI** and asserts user-visible workflow behavior.
+_Avoid_: Browser spec, unit test, renderer invariant
+
+**Terminal Rendering Spec**:
+A checked-in test that asserts terminal screen invariants such as sticky scroll, wrapping, cursor state, colour, or scrollback.
+_Avoid_: command parser test, reducer test
+
+**Pilotty Session**:
+A named managed PTY session used by a **Terminal Automation Run** to isolate one running terminal app.
+_Avoid_: tmux pane, shell session
+
+## Relationships
+
+- A **Terminal Automation Run** owns exactly one **Pilotty Session** per scenario.
+- A **Pilotty Session** is created before user-visible assertions and killed during cleanup.
+- A **Terminal Automation Run** should inspect visible text or screen snapshots, not internal reducer state.
+- **Terminal Behavior Specs** use Microsoft TUI Test and launch the real `stream-tui` CLI command through a PTY.
+- **Terminal Rendering Specs** are expected to use a screen-aware runner such as Termless if its spike succeeds.
+
+## Rules
+
+- Keep OpenTUI imports in the Adapter unless a Module is explicitly about rendering.
+- Keep command discovery slash-first; terminal-wide shortcuts are optional polish.
+- Let the local oRPC command router remain the source of truth for command hierarchy, handlers, input schemas, and TUI metadata.
+- Prefer unit tests for Modules, **Terminal Behavior Specs** for workflows, and **Terminal Rendering Specs** for screen invariants.
+- In `pilotty`, flags go before positionals: `pilotty spawn --name stream-tui pnpm --dir apps/os2 ...`.
+- Do not add a command result envelope. Commands call app context for UI effects and rely on oRPC/Zod errors for failures.

--- a/apps/os2/src/stream-tui/command-discovery.test.ts
+++ b/apps/os2/src/stream-tui/command-discovery.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "vitest";
+import {
+  acceptedSlashInput,
+  findSlashCommand,
+  formatSlashCommandLabel,
+  formatSlashCommandLabelSegments,
+  parseSlashAutocompleteQuery,
+  suggestSlashCommands,
+  type SlashCommandRecord,
+} from "./command-discovery.ts";
+
+const commands: SlashCommandRecord[] = [
+  {
+    path: "append.message",
+    title: "Append message",
+    description: "Append an agent-style user message",
+    slash: { name: "append.message", aliases: ["message", "m"] },
+    input: { positional: { name: "content", required: true } },
+  },
+  {
+    path: "stream.reset",
+    title: "Reset stream",
+    description: "Destroy stream data",
+    slash: { name: "stream.reset", aliases: ["reset"] },
+    input: { flags: [{ name: "destroyChildren", flag: "--no-children", value: false }] },
+  },
+  {
+    path: "view.state",
+    title: "Show reduced state",
+    description: "Inspect reducer state",
+    slash: { name: "view.state", aliases: ["state"] },
+  },
+  {
+    path: "feed.expand",
+    title: "Expand all feed items",
+    description: "Expand every raw event card",
+    slash: { name: "feed.expand", aliases: ["expand"] },
+  },
+  {
+    path: "view.hidden",
+    title: "Hidden command",
+    slash: { name: "hidden" },
+    menu: { hidden: true },
+  },
+];
+
+describe("parseSlashAutocompleteQuery", () => {
+  test("only parses the slash command word before arguments are being entered", () => {
+    expect(parseSlashAutocompleteQuery("/m")).toBe("m");
+    expect(parseSlashAutocompleteQuery("/message hello")).toBeUndefined();
+    expect(parseSlashAutocompleteQuery("plain message")).toBeUndefined();
+  });
+});
+
+describe("suggestSlashCommands", () => {
+  test("prioritizes exact aliases for short queries", () => {
+    expect(
+      suggestSlashCommands({ commands, input: "/m", limit: 8 }).map((command) => command.path),
+    ).toEqual(["append.message", "stream.reset", "feed.expand"]);
+  });
+
+  test("still includes short substring matches for discovery", () => {
+    expect(
+      suggestSlashCommands({ commands, input: "/p", limit: 8 }).map((command) => command.path),
+    ).toContain("feed.expand");
+  });
+
+  test("supports small fuzzy queries across command path characters", () => {
+    expect(
+      suggestSlashCommands({ commands, input: "/pd", limit: 8 }).map((command) => command.path),
+    ).toEqual(["feed.expand", "append.message"]);
+  });
+
+  test("hides commands marked hidden", () => {
+    expect(
+      suggestSlashCommands({ commands, input: "/", limit: 8 }).map((command) => command.path),
+    ).toEqual(["append.message", "feed.expand", "stream.reset", "view.state"]);
+  });
+});
+
+describe("slash command helpers", () => {
+  test("finds commands by slash alias and formats the accepted input", () => {
+    const command = findSlashCommand({ commands, slash: "m" });
+
+    expect(command?.path).toBe("append.message");
+    expect(command).toBeDefined();
+
+    const messageCommand = command!;
+    expect(acceptedSlashInput(messageCommand)).toBe("/append.message ");
+    expect(formatSlashCommandLabel(messageCommand)).toBe(
+      "/append.message   Append an agent-style user message",
+    );
+  });
+
+  test("marks fuzzy-matched command path characters for rendering", () => {
+    const expandCommand = commands.find((command) => command.path === "feed.expand");
+
+    expect(expandCommand).toBeDefined();
+    expect(
+      formatSlashCommandLabelSegments({ command: expandCommand!, input: "/pd" }).filter(
+        (segment) => segment.matched,
+      ),
+    ).toEqual([
+      { text: "p", matched: true },
+      { text: "d", matched: true },
+    ]);
+  });
+
+  test("only commands with required positional input are accepted as a prefill", () => {
+    const resetCommand = findSlashCommand({ commands, slash: "reset" });
+
+    expect(resetCommand).toBeDefined();
+    expect(acceptedSlashInput(resetCommand!)).toBe("/stream.reset");
+  });
+});

--- a/apps/os2/src/stream-tui/command-discovery.ts
+++ b/apps/os2/src/stream-tui/command-discovery.ts
@@ -1,0 +1,201 @@
+export type SlashCommandRecord = {
+  path: string;
+  title: string;
+  description?: string;
+  slash: {
+    name: string;
+    aliases?: string[];
+  };
+  menu?: {
+    hidden?: boolean;
+  };
+  input?: SlashCommandInputMeta;
+};
+
+export type SlashCommandInputMeta = {
+  positional?: {
+    name: string;
+    required: boolean;
+    placeholder?: string;
+  };
+  options?: SlashCommandStringOptionMeta[];
+  flags?: SlashCommandBooleanFlagMeta[];
+};
+
+export type SlashCommandStringOptionMeta = {
+  name: string;
+  flag: `--${string}`;
+};
+
+export type SlashCommandBooleanFlagMeta = {
+  name: string;
+  flag: `--${string}`;
+  value: boolean;
+};
+
+export type SlashCommandLabelSegment = {
+  text: string;
+  matched: boolean;
+};
+
+export type FuzzyMatchRange = {
+  start: number;
+  end: number;
+};
+
+/**
+ * Extract the slash query from an input string like "/vie" → "vie".
+ * Returns undefined if the input isn't a slash query (no leading "/" or has spaces).
+ */
+export function parseSlashAutocompleteQuery(input: string) {
+  if (!input.startsWith("/")) return undefined;
+
+  const query = input.slice(1);
+  if (query.includes(" ")) return undefined;
+
+  return query.toLowerCase();
+}
+
+/** Find a command by exact slash name or alias match. */
+export function findSlashCommand<TCommand extends SlashCommandRecord>(args: {
+  commands: readonly TCommand[];
+  slash: string;
+}) {
+  const slash = args.slash.toLowerCase();
+  return args.commands.find((command) => {
+    const meta = command.slash;
+    return (
+      meta.name.toLowerCase() === slash ||
+      meta.aliases?.some((alias) => alias.toLowerCase() === slash) === true
+    );
+  });
+}
+
+/**
+ * Return up to `limit` commands matching the slash query in the input,
+ * ranked by match quality (exact > prefix > substring > fuzzy).
+ * Aliases are scored but don't create duplicate entries.
+ */
+export function suggestSlashCommands<TCommand extends SlashCommandRecord>(args: {
+  commands: readonly TCommand[];
+  input: string;
+  limit: number;
+}) {
+  const query = parseSlashAutocompleteQuery(args.input);
+  if (query == null) return [];
+
+  return args.commands
+    .filter((command) => !command.menu?.hidden)
+    .map((command) => ({
+      command,
+      score: scoreSlashCommand({ command, query }),
+    }))
+    .filter((suggestion) => suggestion.score > 0)
+    .sort(
+      (left, right) =>
+        right.score - left.score || left.command.path.localeCompare(right.command.path),
+    )
+    .slice(0, args.limit)
+    .map((suggestion) => suggestion.command);
+}
+
+export function acceptedSlashInput(command: SlashCommandRecord) {
+  return `/${command.slash.name}${commandNeedsInput(command) ? " " : ""}`;
+}
+
+export function formatSlashCommandLabel(command: SlashCommandRecord) {
+  return formatSlashCommandLabelSegments({ command, input: "" })
+    .map((segment) => segment.text)
+    .join("");
+}
+
+export function formatSlashCommandLabelSegments(args: {
+  command: SlashCommandRecord;
+  input: string;
+}): SlashCommandLabelSegment[] {
+  const path = `/${args.command.slash.name}`;
+  const description = args.command.description ?? args.command.title;
+  const query = parseSlashAutocompleteQuery(args.input) ?? "";
+  const ranges = query.length === 0 ? [] : fuzzyMatchRanges(args.command.slash.name, query);
+
+  return [
+    ...splitMatchedSegments({
+      text: path.padEnd(17),
+      ranges: ranges.map((range) => ({ start: range.start + 1, end: range.end + 1 })),
+    }),
+    { text: ` ${description}`, matched: false },
+  ];
+}
+
+function scoreSlashCommand(args: { command: SlashCommandRecord; query: string }) {
+  if (args.query.length === 0) return 1;
+
+  const slash = args.command.slash.name.toLowerCase();
+  const aliases = args.command.slash.aliases?.map((alias) => alias.toLowerCase()) ?? [];
+  const title = args.command.title.toLowerCase();
+
+  if (slash === args.query) return 100;
+  if (aliases.includes(args.query)) return 90;
+  if (slash.startsWith(args.query)) return 80;
+  if (aliases.some((alias) => alias.startsWith(args.query))) return 70;
+  if (slash.includes(args.query)) return 40;
+  if (aliases.some((alias) => alias.includes(args.query))) return 35;
+  if (title.includes(args.query)) return 20;
+  if (aliases.some((alias) => fuzzyMatchRanges(alias, args.query).length > 0)) return 45;
+  if (fuzzyMatchRanges(slash, args.query).length > 0) return 18;
+  if (fuzzyMatchRanges(title, args.query).length > 0) return 10;
+  return 0;
+}
+
+function commandNeedsInput(command: SlashCommandRecord) {
+  return command.input?.positional?.required === true;
+}
+
+/**
+ * Find character ranges in `value` that match `query` — first tries contiguous
+ * substring, then falls back to sparse character-by-character fuzzy match.
+ * Returns empty array if no match.
+ */
+export function fuzzyMatchRanges(value: string, query: string): FuzzyMatchRange[] {
+  const normalizedValue = value.toLowerCase();
+  const normalizedQuery = query.toLowerCase();
+  const contiguousIndex = normalizedValue.indexOf(normalizedQuery);
+
+  if (contiguousIndex !== -1) {
+    return [{ start: contiguousIndex, end: contiguousIndex + normalizedQuery.length }];
+  }
+
+  const ranges: Array<{ start: number; end: number }> = [];
+  let cursor = 0;
+
+  for (const char of normalizedQuery) {
+    const index = normalizedValue.indexOf(char, cursor);
+    if (index === -1) return [];
+
+    ranges.push({ start: index, end: index + 1 });
+    cursor = index + 1;
+  }
+
+  return ranges;
+}
+
+/** Split text into segments tagged as matched or unmatched based on fuzzy match ranges. */
+export function splitMatchedSegments(args: { text: string; ranges: readonly FuzzyMatchRange[] }) {
+  const segments: SlashCommandLabelSegment[] = [];
+  let cursor = 0;
+
+  for (const range of args.ranges) {
+    if (range.start > cursor) {
+      segments.push({ text: args.text.slice(cursor, range.start), matched: false });
+    }
+
+    segments.push({ text: args.text.slice(range.start, range.end), matched: true });
+    cursor = range.end;
+  }
+
+  if (cursor < args.text.length) {
+    segments.push({ text: args.text.slice(cursor), matched: false });
+  }
+
+  return segments.filter((segment) => segment.text.length > 0);
+}

--- a/apps/os2/src/stream-tui/command-invocation.test.ts
+++ b/apps/os2/src/stream-tui/command-invocation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import {
+  MissingCommandArgumentsError,
+  parseSlashCommandInput,
+  parseSlashInvocation,
+  readStringOption,
+  removeStringOption,
+} from "./command-invocation.ts";
+
+describe("parseSlashInvocation", () => {
+  test("splits the slash name from raw arguments", () => {
+    expect(parseSlashInvocation("/message hello world")).toEqual({
+      slash: "message",
+      rawArgs: "hello world",
+    });
+    expect(parseSlashInvocation("hello world")).toBeUndefined();
+  });
+});
+
+describe("parseSlashCommandInput", () => {
+  test("parses message content and stream override", () => {
+    expect(
+      parseSlashCommandInput({
+        commandTitle: "Append message",
+        slashName: "message",
+        input: {
+          positional: { name: "content", required: true },
+          options: [{ name: "streamPath", flag: "--stream" }],
+        },
+        rawArgs: "hello --stream ./child",
+      }),
+    ).toEqual({ content: "hello", streamPath: "./child" });
+  });
+
+  test("parses reset flags with children enabled by default", () => {
+    expect(
+      parseSlashCommandInput({
+        commandTitle: "Reset stream",
+        slashName: "reset",
+        input: {
+          options: [{ name: "streamPath", flag: "--stream" }],
+          flags: [{ name: "destroyChildren", flag: "--no-children", value: false }],
+        },
+        rawArgs: "--no-children --stream ./child",
+      }),
+    ).toEqual({ destroyChildren: false, streamPath: "./child" });
+  });
+
+  test("throws a typed error for missing required arguments", () => {
+    expect(() =>
+      parseSlashCommandInput({
+        commandTitle: "Append message",
+        slashName: "message",
+        input: { positional: { name: "content", required: true } },
+        rawArgs: "",
+      }),
+    ).toThrow(MissingCommandArgumentsError);
+  });
+});
+
+describe("string options", () => {
+  test("supports quoted and unquoted values", () => {
+    expect(readStringOption("--stream './child stream'", "--stream")).toBe("./child stream");
+    expect(removeStringOption("hello --stream ./child", "--stream")).toBe("hello");
+  });
+});

--- a/apps/os2/src/stream-tui/command-invocation.ts
+++ b/apps/os2/src/stream-tui/command-invocation.ts
@@ -1,0 +1,111 @@
+import type { SlashCommandInputMeta } from "./command-discovery.ts";
+
+export class MissingCommandArgumentsError extends Error {
+  readonly slashName: string;
+
+  constructor(args: { commandTitle: string; slashName: string }) {
+    super(`${args.commandTitle} needs input`);
+    this.slashName = args.slashName;
+  }
+}
+
+export type ParsedSlashInvocation = {
+  slash: string;
+  rawArgs: string;
+};
+
+export function parseSlashInvocation(input: string): ParsedSlashInvocation | undefined {
+  if (!input.startsWith("/")) return undefined;
+
+  const [slash = "", ...args] = input.slice(1).trim().split(/\s+/);
+  return { slash, rawArgs: args.join(" ") };
+}
+
+export function parseSlashCommandInput(args: {
+  commandTitle: string;
+  slashName: string;
+  input?: SlashCommandInputMeta;
+  rawArgs: string;
+}) {
+  if (args.input == null) {
+    if (args.rawArgs.trim().length > 0) {
+      throw new Error(`/${args.slashName} takes no arguments`);
+    }
+
+    return undefined;
+  }
+
+  let remainingArgs = args.rawArgs.trim();
+  const input: Record<string, unknown> = {};
+
+  for (const option of args.input.options ?? []) {
+    input[option.name] = readStringOption(remainingArgs, option.flag);
+    remainingArgs = removeStringOption(remainingArgs, option.flag);
+  }
+
+  for (const flag of args.input.flags ?? []) {
+    if (hasFlag(remainingArgs, flag.flag)) {
+      input[flag.name] = flag.value;
+      remainingArgs = removeFlag(remainingArgs, flag.flag);
+    }
+  }
+
+  const positional = args.input.positional;
+  if (positional != null) {
+    if (remainingArgs.length === 0 && positional.required) {
+      throw new MissingCommandArgumentsError({
+        commandTitle: args.commandTitle,
+        slashName: args.slashName,
+      });
+    }
+
+    if (remainingArgs.length > 0) {
+      input[positional.name] = remainingArgs;
+    }
+  } else if (remainingArgs.length > 0) {
+    throw new Error(`/${args.slashName} takes no positional arguments`);
+  }
+
+  return input;
+}
+
+export function readStringOption(rawArgs: string, optionName: string) {
+  return matchStringOption(rawArgs, optionName)?.value;
+}
+
+export function removeStringOption(rawArgs: string, optionName: string) {
+  const match = matchStringOption(rawArgs, optionName);
+  if (match == null) return rawArgs;
+
+  return `${rawArgs.slice(0, match.start)} ${rawArgs.slice(match.end)}`.trim();
+}
+
+function matchStringOption(rawArgs: string, optionName: string) {
+  const pattern = new RegExp(
+    `(?:^|\\s)${escapeRegExp(optionName)}(?:=|\\s+)(?:"([^"]+)"|'([^']+)'|(\\S+))`,
+  );
+  const match = pattern.exec(rawArgs);
+  if (match == null || match.index == null) return undefined;
+
+  return {
+    start: match.index,
+    end: match.index + match[0].length,
+    value: match[1] ?? match[2] ?? match[3] ?? "",
+  };
+}
+
+function hasFlag(rawArgs: string, flagName: string) {
+  return rawArgs.split(/\s+/).includes(flagName);
+}
+
+function removeFlag(rawArgs: string, flagName: string) {
+  return rawArgs
+    .split(/\s+/)
+    .filter((part) => part !== flagName)
+    .join(" ")
+    .trim();
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/apps/os2/src/stream-tui/command-router.test.ts
+++ b/apps/os2/src/stream-tui/command-router.test.ts
@@ -1,0 +1,151 @@
+import { StreamPath } from "@iterate-com/shared/streams/types";
+import { getInitialProcessorState } from "@iterate-com/shared/stream-processors";
+import { StreamViewProcessorContract } from "@iterate-com/ui/components/events/stream-view-processor/contract";
+import { describe, expect, test } from "vitest";
+import {
+  commandEntries,
+  runCommand,
+  type AppContext,
+  type StreamSummary,
+} from "./command-router.ts";
+import type { StreamTuiView } from "./navigation-state.ts";
+
+function createTestAppContext() {
+  let activeView: StreamTuiView = "feed";
+  let feedMode: "raw" | "mixed" | "pretty" = "mixed";
+  let inputValue = "";
+  let streams: StreamSummary[] = [];
+  let toastMessage = "";
+
+  const context: AppContext = {
+    get streamPath() {
+      return StreamPath.parse("/test");
+    },
+    get reducedState() {
+      return getInitialProcessorState(StreamViewProcessorContract);
+    },
+    streamApi: {
+      append: async () => {
+        throw new Error("append was not expected");
+      },
+      getState: async () => {
+        throw new Error("getState was not expected");
+      },
+      listChildren: async () => streams,
+      resolvePath: (streamPath) => StreamPath.parse(streamPath ?? "/test"),
+    },
+    setActiveView(view) {
+      activeView = view;
+    },
+    switchFeedMode(mode) {
+      feedMode = mode;
+    },
+    setStreamSummaries(nextStreams) {
+      streams = nextStreams;
+    },
+    navigateToStream() {
+      throw new Error("navigateToStream was not expected");
+    },
+    restartStream() {
+      throw new Error("restartStream was not expected");
+    },
+    prefillInput(value) {
+      inputValue = value;
+    },
+    collapseVisibleFeedItems() {
+      toastMessage = "collapsed";
+    },
+    expandVisibleFeedItems() {
+      toastMessage = "expanded";
+    },
+    openEventDetail() {
+      throw new Error("openEventDetail was not expected");
+    },
+    exit() {
+      throw new Error("exit was not expected");
+    },
+    toast: {
+      info(message) {
+        toastMessage = message;
+      },
+      success(message) {
+        toastMessage = message;
+      },
+      error(message) {
+        toastMessage = message;
+      },
+    },
+  };
+
+  return {
+    context,
+    get activeView() {
+      return activeView;
+    },
+    get feedMode() {
+      return feedMode;
+    },
+    get inputValue() {
+      return inputValue;
+    },
+    get toastMessage() {
+      return toastMessage;
+    },
+  };
+}
+
+describe("commandEntries", () => {
+  test("keeps the command hierarchy and slash metadata inspectable", () => {
+    expect(commandEntries.map((command) => command.path)).toContain("append.message");
+    expect(commandEntries.find((command) => command.path === "append.message")).toMatchObject({
+      slash: { name: "append.message", aliases: ["message", "m"] },
+      input: { positional: { name: "content", required: true } },
+    });
+    expect(commandEntries.map((command) => command.path)).not.toContain("stream.reset");
+    expect(commandEntries.find((command) => command.path === "view.pretty")).toMatchObject({
+      slash: { name: "view.pretty", aliases: ["pretty"] },
+    });
+  });
+});
+
+describe("runCommand", () => {
+  test("runs view commands through the shared app context", async () => {
+    const app = createTestAppContext();
+    const command = commandEntries.find((entry) => entry.path === "view.state");
+
+    expect(command).toBeDefined();
+    await runCommand({ appContext: app.context, command: command!, inputValue: undefined });
+
+    expect(app.activeView).toBe("state");
+  });
+
+  test("runs command helpers without a separate result envelope", async () => {
+    const app = createTestAppContext();
+    const command = commandEntries.find((entry) => entry.path === "view.commands");
+
+    expect(command).toBeDefined();
+    await runCommand({ appContext: app.context, command: command!, inputValue: undefined });
+
+    expect(app.inputValue).toBe("/");
+  });
+
+  test("switches to pretty-only feed mode", async () => {
+    const app = createTestAppContext();
+    const command = commandEntries.find((entry) => entry.path === "view.pretty");
+
+    expect(command).toBeDefined();
+    await runCommand({ appContext: app.context, command: command!, inputValue: undefined });
+
+    expect(app.feedMode).toBe("pretty");
+  });
+
+  test("keeps chat as an alias for pretty-only feed mode", async () => {
+    const app = createTestAppContext();
+    const command = commandEntries.find((entry) => entry.path === "view.chat");
+
+    expect(command).toBeDefined();
+    await runCommand({ appContext: app.context, command: command!, inputValue: undefined });
+
+    expect(app.feedMode).toBe("pretty");
+  });
+});

--- a/apps/os2/src/stream-tui/command-router.ts
+++ b/apps/os2/src/stream-tui/command-router.ts
@@ -1,0 +1,440 @@
+import type { Event, EventInput, StreamPath } from "@iterate-com/shared/streams/types";
+import type { EventsStreamViewState } from "@iterate-com/ui/components/events/feed-items";
+import { call, isProcedure, os, type AnyProcedure } from "@orpc/server";
+import { z } from "zod";
+import type { SlashCommandRecord } from "./command-discovery.ts";
+import type { StreamTuiView } from "./navigation-state.ts";
+
+export type StreamSummary = {
+  path: StreamPath;
+  createdAt: string;
+};
+
+export type TuiCommandMeta = {
+  title: string;
+  description?: string;
+  category?: string;
+  slash?: {
+    name: string;
+    aliases?: string[];
+  };
+  keybind?: string;
+  menu?: {
+    hidden?: boolean;
+    suggested?: boolean;
+  };
+  input?: SlashCommandRecord["input"];
+};
+
+export type StreamApi = {
+  append: (args: { event: EventInput; streamPath?: string }) => Promise<Event>;
+  getState: (args?: { streamPath?: string }) => Promise<unknown>;
+  listChildren: (args?: { streamPath?: string }) => Promise<StreamSummary[]>;
+  resolvePath: (streamPath?: string) => StreamPath;
+};
+
+export type AppContext = {
+  get streamPath(): StreamPath;
+  get reducedState(): EventsStreamViewState;
+  streamApi: StreamApi;
+  setActiveView: (view: StreamTuiView) => void;
+  switchFeedMode: (mode: "raw" | "mixed" | "pretty") => void;
+  setStreamSummaries: (streams: StreamSummary[], filter?: string) => void;
+  navigateToStream: (streamPath: StreamPath) => void;
+  restartStream: () => void;
+  prefillInput: (value: string) => void;
+  collapseVisibleFeedItems: () => void;
+  expandVisibleFeedItems: () => void;
+  openEventDetail: (offset: number) => void;
+  exit: () => void;
+  toast: {
+    info: (message: string) => void;
+    success: (message: string) => void;
+    error: (message: string) => void;
+  };
+};
+
+export type CommandEntry = SlashCommandRecord & {
+  pathSegments: string[];
+  meta: TuiCommandMeta;
+  procedure: CommandProcedure;
+};
+
+type CommandProcedure = AnyProcedure;
+
+const commandBase = os.$context<AppContext>().$meta<{ tui: TuiCommandMeta }>({
+  tui: { title: "Untitled command" },
+});
+
+// Local TUI commands are modeled as oRPC procedures so hierarchy, input
+// schemas, handlers, and display metadata live in one inspectable shape. This
+// follows OpenCode's "one command registry feeds command discovery" model,
+// while keeping this first pass slash-first and React/OpenTUI-agnostic:
+// https://github.com/sst/opencode/blob/dev/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
+const commandRouter = {
+  view: {
+    feed: commandBase
+      .meta({
+        tui: {
+          title: "Show feed",
+          description: "Return to the event feed",
+          category: "View",
+          slash: { name: "view.feed", aliases: ["feed"] },
+        },
+      })
+      .handler(({ context }) => {
+        context.setActiveView("feed");
+      }),
+    raw: commandBase
+      .meta({
+        tui: {
+          title: "Raw mode",
+          description: "Show one raw YAML card per event",
+          category: "View",
+          slash: { name: "view.raw", aliases: ["raw"] },
+        },
+      })
+      .handler(({ context }) => {
+        context.switchFeedMode("raw");
+      }),
+    mixed: commandBase
+      .meta({
+        tui: {
+          title: "Mixed mode",
+          description: "Summary rows + pretty renderers (default)",
+          category: "View",
+          slash: { name: "view.mixed", aliases: ["mixed"] },
+        },
+      })
+      .handler(({ context }) => {
+        context.switchFeedMode("mixed");
+      }),
+    pretty: commandBase
+      .meta({
+        tui: {
+          title: "Pretty mode",
+          description: "Pretty renderers only; hide raw event rows",
+          category: "View",
+          slash: { name: "view.pretty", aliases: ["pretty"] },
+        },
+      })
+      .handler(({ context }) => {
+        context.switchFeedMode("pretty");
+      }),
+    chat: commandBase
+      .meta({
+        tui: {
+          title: "Chat mode",
+          description: "Pretty renderers only (for conversational streams)",
+          category: "View",
+          slash: { name: "view.chat", aliases: ["chat"] },
+        },
+      })
+      .handler(({ context }) => {
+        context.switchFeedMode("pretty");
+      }),
+    state: commandBase
+      .meta({
+        tui: {
+          title: "Show reduced state",
+          description: "Inspect the current reducer state",
+          category: "View",
+          slash: { name: "view.state", aliases: ["state"] },
+        },
+      })
+      .handler(({ context }) => {
+        context.setActiveView("state");
+      }),
+    commands: commandBase
+      .meta({
+        tui: {
+          title: "Show command autocomplete",
+          description: "Open slash command suggestions in the input",
+          category: "View",
+          slash: { name: "view.commands", aliases: ["help", "commands"] },
+        },
+      })
+      .handler(({ context }) => {
+        context.prefillInput("/");
+      }),
+    streams: commandBase
+      .meta({
+        tui: {
+          title: "Show streams",
+          description: "Show the most recently loaded stream list",
+          category: "View",
+          slash: { name: "view.streams", aliases: ["streams-view"] },
+          menu: { hidden: true },
+        },
+      })
+      .handler(({ context }) => {
+        context.setActiveView("streams");
+      }),
+  },
+  append: {
+    message: commandBase
+      .input(
+        z.object({
+          content: z.string().trim().min(1).meta({ positional: true }).describe("Message text"),
+          streamPath: z
+            .string()
+            .trim()
+            .min(1)
+            .optional()
+            .describe("Defaults to the current stream; absolute and dot-relative paths work."),
+        }),
+      )
+      .meta({
+        tui: {
+          title: "Append message",
+          description: "Append an agent-style user message",
+          category: "Append",
+          slash: { name: "append.message", aliases: ["message", "m"] },
+          input: {
+            positional: { name: "content", required: true },
+            options: [{ name: "streamPath", flag: "--stream" }],
+          },
+        },
+      })
+      .handler(async ({ context, input }) => {
+        const event: EventInput = {
+          type: "events.iterate.com/agent-chat/user-message-added",
+          payload: { channel: "tui", content: input.content },
+        };
+        const appended = await context.streamApi.append({ event, streamPath: input.streamPath });
+        context.toast.success(`sent offset ${appended.offset}`);
+      }),
+    debugInfoRequest: commandBase
+      .meta({
+        tui: {
+          title: "Append debug info request",
+          description: "Ask the agent processor to append debugging details",
+          category: "Append",
+          slash: { name: "append.debug", aliases: ["debug"] },
+        },
+      })
+      .handler(async ({ context }) => {
+        const appended = await context.streamApi.append({
+          event: { type: "debug-info-requested", payload: {} },
+        });
+        context.toast.success(`sent offset ${appended.offset}`);
+      }),
+    error: commandBase
+      .input(
+        z.object({
+          message: z.string().trim().min(1).meta({ positional: true }).describe("Error message"),
+          streamPath: z.string().trim().min(1).optional(),
+        }),
+      )
+      .meta({
+        tui: {
+          title: "Append error",
+          description: "Append a built-in error event",
+          category: "Append",
+          slash: { name: "append.error", aliases: ["error", "e"] },
+          input: {
+            positional: { name: "message", required: true },
+            options: [{ name: "streamPath", flag: "--stream" }],
+          },
+        },
+      })
+      .handler(async ({ context, input }) => {
+        const appended = await context.streamApi.append({
+          streamPath: input.streamPath,
+          event: {
+            type: "https://events.iterate.com/events/stream/error-occurred",
+            payload: { message: input.message },
+          },
+        });
+        context.toast.success(`sent offset ${appended.offset}`);
+      }),
+  },
+  stream: {
+    open: commandBase
+      .input(
+        z.object({
+          streamPath: z
+            .string()
+            .trim()
+            .min(1)
+            .meta({ positional: true })
+            .describe("Absolute, dot-relative, or bare child stream path"),
+        }),
+      )
+      .meta({
+        tui: {
+          title: "Open stream",
+          description: "Navigate to another stream",
+          category: "Stream",
+          slash: { name: "stream.open", aliases: ["open"] },
+          input: { positional: { name: "streamPath", required: true } },
+        },
+      })
+      .handler(async ({ context, input }) => {
+        const streamPath = context.streamApi.resolvePath(input.streamPath);
+        await context.streamApi.getState({ streamPath });
+        context.navigateToStream(streamPath);
+      }),
+    child: commandBase
+      .input(
+        z.object({
+          streamPath: z
+            .string()
+            .trim()
+            .min(1)
+            .meta({ positional: true })
+            .describe("Child stream path"),
+        }),
+      )
+      .meta({
+        tui: {
+          title: "Create/open child stream",
+          description: "Touch a child stream and navigate to it",
+          category: "Stream",
+          slash: { name: "stream.child", aliases: ["child"] },
+          input: { positional: { name: "streamPath", required: true } },
+        },
+      })
+      .handler(async ({ context, input }) => {
+        const streamPath = context.streamApi.resolvePath(input.streamPath);
+        await context.streamApi.getState({ streamPath });
+        context.navigateToStream(streamPath);
+      }),
+    children: commandBase
+      .meta({
+        tui: {
+          title: "Show children",
+          description: "Show streams under the current path",
+          category: "Stream",
+          slash: { name: "stream.children", aliases: ["children"] },
+        },
+      })
+      .handler(async ({ context }) => {
+        const children = await context.streamApi.listChildren({ streamPath: "/" });
+        const filter = context.streamPath === "/" ? "" : context.streamPath + "/";
+        context.setStreamSummaries(children, filter);
+        context.toast.info(`${children.length} stream${children.length === 1 ? "" : "s"}`);
+        context.setActiveView("streams");
+      }),
+  },
+  streams: {
+    tree: commandBase
+      .meta({
+        tui: {
+          title: "Show stream tree",
+          description: "Show all streams as a tree",
+          category: "Stream",
+          slash: { name: "streams.tree", aliases: ["streams", "tree"] },
+        },
+      })
+      .handler(async ({ context }) => {
+        const children = await context.streamApi.listChildren({ streamPath: "/" });
+        context.setStreamSummaries(children);
+        context.toast.info(`${children.length} stream${children.length === 1 ? "" : "s"}`);
+        context.setActiveView("streams");
+      }),
+  },
+  exit: commandBase
+    .meta({
+      tui: {
+        title: "Exit",
+        description: "Quit the TUI",
+        category: "App",
+        slash: { name: "exit", aliases: ["quit"] },
+      },
+    })
+    .handler(({ context }) => {
+      context.exit();
+    }),
+  event: {
+    details: commandBase
+      .input(
+        z.object({
+          offset: z
+            .string()
+            .trim()
+            .min(1)
+            .meta({ positional: true })
+            .describe("Event offset number"),
+        }),
+      )
+      .meta({
+        tui: {
+          title: "Event details",
+          description: "Open the raw event payload inspector",
+          category: "Event",
+          slash: { name: "event.details", aliases: ["details", "inspect"] },
+          input: { positional: { name: "offset", required: true } },
+        },
+      })
+      .handler(({ context, input }) => {
+        const offset = Number.parseInt(input.offset, 10);
+        if (Number.isNaN(offset)) throw new Error(`Invalid offset: ${input.offset}`);
+        context.openEventDetail(offset);
+      }),
+  },
+};
+
+export const commandEntries = collectCommandEntries(commandRouter);
+
+export async function runCommand(args: {
+  appContext: AppContext;
+  command: CommandEntry;
+  inputValue: unknown;
+}) {
+  await call(args.command.procedure, args.inputValue, {
+    context: args.appContext,
+    path: args.command.pathSegments,
+  });
+}
+
+function collectCommandEntries(
+  router: Record<string, unknown>,
+  prefix: string[] = [],
+): CommandEntry[] {
+  const entries: CommandEntry[] = [];
+
+  for (const [key, value] of Object.entries(router)) {
+    const pathSegments = [...prefix, key];
+
+    if (isProcedure(value)) {
+      const path = pathSegments.join(".");
+      const meta = readCommandMeta(value);
+      if (meta.slash == null) {
+        throw new Error(`Command ${path} is missing meta.tui.slash.`);
+      }
+
+      entries.push({
+        path,
+        pathSegments,
+        title: meta.title,
+        description: meta.description,
+        slash: meta.slash,
+        menu: meta.menu,
+        input: meta.input,
+        meta,
+        procedure: value,
+      });
+      continue;
+    }
+
+    if (isRecord(value)) {
+      entries.push(...collectCommandEntries(value, pathSegments));
+    }
+  }
+
+  return entries;
+}
+
+function readCommandMeta(procedure: CommandProcedure) {
+  const meta = procedure["~orpc"].meta as { tui?: TuiCommandMeta };
+  if (meta.tui == null) {
+    throw new Error("Command procedure is missing meta.tui.");
+  }
+
+  return meta.tui;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/os2/src/stream-tui/feed-formatting.test.ts
+++ b/apps/os2/src/stream-tui/feed-formatting.test.ts
@@ -1,0 +1,93 @@
+import { Event, StreamPath } from "@iterate-com/shared/streams/types";
+import { describe, expect, test } from "vitest";
+import {
+  formatElapsedTime,
+  getElapsedByOffset,
+  orderEventKeysForYamlDisplay,
+  rightAlign,
+  wrapLine,
+} from "./feed-formatting.ts";
+
+describe("feed formatting", () => {
+  test("orders raw event YAML fields and hides streamPath", () => {
+    const event = Event.parse({
+      streamPath: StreamPath.parse("/demo"),
+      type: "demo",
+      payload: { ok: true },
+      offset: 1,
+      createdAt: "2026-04-29T00:00:00.000Z",
+    });
+
+    expect(orderEventKeysForYamlDisplay(event)).toEqual({
+      type: "demo",
+      payload: { ok: true },
+      offset: 1,
+      createdAt: "2026-04-29T00:00:00.000Z",
+    });
+  });
+
+  test("calculates elapsed labels across raw feed items", () => {
+    expect(
+      getElapsedByOffset([
+        {
+          type: "grouped-raw-event",
+          id: "1",
+          props: {
+            eventType: "first",
+            count: 1,
+            firstTimestamp: 1_000,
+            lastTimestamp: 1_000,
+            events: [
+              {
+                streamPath: StreamPath.parse("/demo"),
+                offset: 1,
+                eventType: "first",
+                createdAt: "2026-04-29T00:00:00.000Z",
+                timestamp: 1_000,
+                raw: Event.parse({
+                  streamPath: StreamPath.parse("/demo"),
+                  type: "first",
+                  payload: {},
+                  offset: 1,
+                  createdAt: "2026-04-29T00:00:00.000Z",
+                }),
+              },
+            ],
+          },
+        },
+        {
+          type: "grouped-raw-event",
+          id: "2",
+          props: {
+            eventType: "second",
+            count: 1,
+            firstTimestamp: 2_250,
+            lastTimestamp: 2_250,
+            events: [
+              {
+                streamPath: StreamPath.parse("/demo"),
+                offset: 2,
+                eventType: "second",
+                createdAt: "2026-04-29T00:00:01.250Z",
+                timestamp: 2_250,
+                raw: Event.parse({
+                  streamPath: StreamPath.parse("/demo"),
+                  type: "second",
+                  payload: {},
+                  offset: 2,
+                  createdAt: "2026-04-29T00:00:01.250Z",
+                }),
+              },
+            ],
+          },
+        },
+      ]),
+    ).toEqual(new Map([[2, "+1.2s"]]));
+  });
+
+  test("wraps, aligns, and formats elapsed durations", () => {
+    expect(wrapLine("abcdef", 2)).toEqual(["ab", "cd", "ef"]);
+    expect(rightAlign("abcdef", 4)).toBe("cdef");
+    expect(formatElapsedTime(61_500)).toBe("+1m1s");
+  });
+});

--- a/apps/os2/src/stream-tui/feed-formatting.ts
+++ b/apps/os2/src/stream-tui/feed-formatting.ts
@@ -1,0 +1,90 @@
+import type { Event } from "@iterate-com/shared/streams/types";
+import type {
+  EventsStreamBuiltInElement,
+  EventsStreamRawEventSummary,
+} from "@iterate-com/ui/components/events/feed-items";
+
+/** Build a map of offset → elapsed time label (e.g. "+2.3s") for consecutive events. */
+export function getElapsedByOffset(feedItems: readonly EventsStreamBuiltInElement[]) {
+  const elapsedByOffset = new Map<number, string>();
+  const rawEvents = feedItems
+    .flatMap((item) => (item.type === "grouped-raw-event" ? item.props.events : []))
+    .sort((a, b) => a.offset - b.offset);
+
+  for (const [index, item] of rawEvents.entries()) {
+    const previousItem = rawEvents[index - 1];
+    if (previousItem == null) continue;
+
+    elapsedByOffset.set(item.offset, formatElapsedTime(item.timestamp - previousItem.timestamp));
+  }
+
+  return elapsedByOffset;
+}
+
+export function formatEventSummary(item: EventsStreamRawEventSummary, elapsedLabel?: string) {
+  return [item.offset, item.eventType, elapsedLabel, formatTime(item.timestamp)]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+/** Reorder event keys for readable YAML: type, payload, metadata first, then the rest. */
+export function orderEventKeysForYamlDisplay(event: Event): Record<string, unknown> {
+  const eventRecord = event as Record<string, unknown>;
+  const orderedEvent: Record<string, unknown> = {};
+
+  for (const key of ["type", "payload", "metadata", "idempotencyKey", "offset", "createdAt"]) {
+    if (key in eventRecord) {
+      orderedEvent[key] = eventRecord[key];
+    }
+  }
+
+  for (const [key, value] of Object.entries(eventRecord)) {
+    if (key === "streamPath" || key in orderedEvent) {
+      continue;
+    }
+
+    orderedEvent[key] = value;
+  }
+
+  return orderedEvent;
+}
+
+/** Hard-wrap a string at `width` characters, returning one or more lines. */
+export function wrapLine(value: string, width: number) {
+  if (value.length <= width) return [value];
+
+  const lines: string[] = [];
+  for (let index = 0; index < value.length; index += width) {
+    lines.push(value.slice(index, index + width));
+  }
+  return lines;
+}
+
+/** Right-align text to `width` chars, truncating from the left if too long. */
+export function rightAlign(value: string, width: number) {
+  const trimmed = value.length > width ? value.slice(value.length - width) : value;
+  return trimmed.padStart(width);
+}
+
+export function formatTime(timestamp: number) {
+  return new Date(timestamp).toLocaleTimeString();
+}
+
+export function formatElapsedTime(durationMs: number) {
+  const normalizedDurationMs = Math.max(0, Math.floor(durationMs));
+
+  if (normalizedDurationMs < 1_000) {
+    return `+${normalizedDurationMs}ms`;
+  }
+
+  if (normalizedDurationMs < 60_000) {
+    const seconds = Math.floor(normalizedDurationMs / 100) / 10;
+    return `+${seconds.toFixed(1).replace(/\.0$/, "")}s`;
+  }
+
+  const totalSeconds = Math.floor(normalizedDurationMs / 1_000);
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  return `+${totalMinutes}m${seconds}s`;
+}

--- a/apps/os2/src/stream-tui/navigation-state.test.ts
+++ b/apps/os2/src/stream-tui/navigation-state.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import {
+  focusStreamTuiComposer,
+  focusStreamTuiFeed,
+  focusStreamTuiHeader,
+  initialStreamTuiNavigationState,
+  setStreamTuiView,
+} from "./navigation-state.ts";
+
+describe("stream TUI navigation state", () => {
+  test("switching views returns focus to the composer", () => {
+    const feedFocused = focusStreamTuiFeed(initialStreamTuiNavigationState);
+
+    expect(setStreamTuiView(feedFocused, "state")).toEqual({
+      view: "state",
+      focus: "composer",
+    });
+  });
+
+  test("feed and composer focus are explicit state transitions", () => {
+    const feedFocused = focusStreamTuiFeed(initialStreamTuiNavigationState);
+
+    expect(feedFocused.focus).toBe("feed");
+    expect(focusStreamTuiComposer(feedFocused).focus).toBe("composer");
+    expect(focusStreamTuiHeader(feedFocused).focus).toBe("header");
+  });
+});

--- a/apps/os2/src/stream-tui/navigation-state.ts
+++ b/apps/os2/src/stream-tui/navigation-state.ts
@@ -1,0 +1,44 @@
+export type StreamTuiView = "feed" | "state" | "streams";
+export type StreamTuiFocus = "composer" | "feed" | "header";
+
+export type StreamTuiNavigationState = {
+  view: StreamTuiView;
+  focus: StreamTuiFocus;
+};
+
+export const initialStreamTuiNavigationState: StreamTuiNavigationState = {
+  view: "feed",
+  focus: "composer",
+};
+
+export function setStreamTuiView(
+  state: StreamTuiNavigationState,
+  view: StreamTuiView,
+): StreamTuiNavigationState {
+  return {
+    ...state,
+    view,
+    focus: "composer",
+  };
+}
+
+export function focusStreamTuiFeed(state: StreamTuiNavigationState): StreamTuiNavigationState {
+  return {
+    ...state,
+    focus: "feed",
+  };
+}
+
+export function focusStreamTuiComposer(state: StreamTuiNavigationState): StreamTuiNavigationState {
+  return {
+    ...state,
+    focus: "composer",
+  };
+}
+
+export function focusStreamTuiHeader(state: StreamTuiNavigationState): StreamTuiNavigationState {
+  return {
+    ...state,
+    focus: "header",
+  };
+}

--- a/apps/os2/src/stream-tui/pilotty-command.test.ts
+++ b/apps/os2/src/stream-tui/pilotty-command.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { buildStreamTuiPilottySpawnArgs } from "./pilotty-command.ts";
+
+describe("buildStreamTuiPilottySpawnArgs", () => {
+  test("places pilotty flags before the spawned command positionals", () => {
+    expect(
+      buildStreamTuiPilottySpawnArgs({
+        sessionName: "stream-tui",
+        cwd: "/repo",
+        projectSlugOrId: "public",
+        streamPath: "/demo",
+      }),
+    ).toEqual([
+      "spawn",
+      "--name",
+      "stream-tui",
+      "--cwd",
+      "/repo",
+      "pnpm",
+      "--dir",
+      "apps/os2",
+      "cli",
+      "stream-tui",
+      "--project-slug-or-id",
+      "public",
+      "--stream-path",
+      "/demo",
+    ]);
+  });
+});

--- a/apps/os2/src/stream-tui/pilotty-command.ts
+++ b/apps/os2/src/stream-tui/pilotty-command.ts
@@ -1,0 +1,25 @@
+export type StreamTuiPilottySpawnArgs = {
+  sessionName: string;
+  cwd: string;
+  projectSlugOrId: string;
+  streamPath: string;
+};
+
+export function buildStreamTuiPilottySpawnArgs(args: StreamTuiPilottySpawnArgs) {
+  return [
+    "spawn",
+    "--name",
+    args.sessionName,
+    "--cwd",
+    args.cwd,
+    "pnpm",
+    "--dir",
+    "apps/os2",
+    "cli",
+    "stream-tui",
+    "--project-slug-or-id",
+    args.projectSlugOrId,
+    "--stream-path",
+    args.streamPath,
+  ];
+}

--- a/apps/os2/src/stream-tui/react-stream-renderers.tsx
+++ b/apps/os2/src/stream-tui/react-stream-renderers.tsx
@@ -1,0 +1,857 @@
+/** @jsxImportSource @opentui/react */
+import type { StreamPath } from "@iterate-com/shared/streams/types";
+import { StyledText, TextAttributes, bg, fg, type ScrollBoxRenderable } from "@opentui/core";
+import type {
+  EventsStreamBuiltInElement,
+  EventsStreamCodemodeBlockElement,
+  EventsStreamCodemodeResultElement,
+  EventsStreamErrorElement,
+  EventsStreamGroupedRawEventElement,
+  EventsStreamLlmRequestBoundaryElement,
+  EventsStreamMessageElement,
+  EventsStreamMetadataUpdatedElement,
+  EventsStreamPromptContextElement,
+  EventsStreamRawEventSummary,
+  EventsStreamSystemPromptElement,
+  EventsStreamViewState,
+} from "@iterate-com/ui/components/events/feed-items";
+import { useTerminalDimensions } from "@opentui/react";
+import { Fragment, useEffect, useRef } from "react";
+import { stringify as stringifyYaml } from "yaml";
+import type { StreamTuiView } from "./navigation-state.ts";
+import {
+  formatElapsedTime,
+  formatTime,
+  getElapsedByOffset,
+  orderEventKeysForYamlDisplay,
+  rightAlign,
+  wrapLine,
+} from "./feed-formatting.ts";
+import { getRawEventSummariesForTui, type TuiSlashSuggestion } from "./react-stream-view-model.ts";
+import type { StreamTreeRow } from "./stream-tree.ts";
+
+const TUI_COLORS = {
+  bg: "#0b0f14",
+  surface: "#27272a",
+  surfaceDark: "#111827",
+  surfaceCard: "#0f172a",
+  surfaceMuted: "#27272a",
+  selected: "#1f2937",
+  border: "#3f3f46",
+  accent: "#22c55e",
+  accentDim: "#16a34a",
+  warning: "#facc15",
+  text: "#e5e7eb",
+  textSecondary: "#9ca3af",
+  textBody: "#d1d5db",
+  textMuted: "#6b7280",
+  textDim: "#71717a",
+  textSubdued: "#94a3b8",
+  agent: "#a78bfa",
+  danger: "#ef4444",
+} as const;
+
+export function TuiEventsStreamView(props: {
+  streamPath: StreamPath;
+  viewState: EventsStreamViewState;
+  modeLabel: string;
+  status: string;
+  appendStatus: string;
+  pulseOn: boolean;
+  focusedRegion: "header" | "feed" | "composer";
+  activeView: StreamTuiView;
+  detailEventOffset?: number;
+  selectedOffset?: number;
+  streamRows: readonly StreamTreeRow[];
+  streamSearchOpen: boolean;
+  streamSearchQuery: string;
+  composerValue: string;
+  composerRevision: number;
+  composerPlaceholder: string;
+  slashSuggestions: readonly TuiSlashSuggestion[];
+  selectedSlashCommandPath?: string;
+  commandDocs: readonly string[];
+  onComposerInput: (value: string) => void;
+  onComposerSubmit: (value: string) => void;
+}) {
+  const { width } = useTerminalDimensions();
+  // Full terminal width minus scrollbox borders and content padding, with one
+  // extra right gutter so right-aligned feed rows do not touch the scrollbar.
+  const contentWidth = Math.max(20, width - 5);
+  const rawSummaries = getRawSummaries(props.viewState.slots.feed);
+  const detailEvent =
+    props.detailEventOffset == null
+      ? undefined
+      : rawSummaries.find((summary) => summary.offset === props.detailEventOffset);
+
+  return (
+    <box width="100%" height="100%" flexDirection="column" backgroundColor={TUI_COLORS.bg}>
+      <TuiEventsStreamHeader
+        streamPath={props.streamPath}
+        viewState={props.viewState}
+        modeLabel={props.modeLabel}
+        status={props.status}
+        appendStatus={props.appendStatus}
+        pulseOn={props.pulseOn}
+        focused={props.focusedRegion === "header"}
+        activeView={props.activeView}
+        detailEventOffset={props.detailEventOffset}
+      />
+      <TuiEventsStreamFeed
+        viewState={props.viewState}
+        activeView={props.activeView}
+        detailEvent={detailEvent}
+        selectedOffset={props.selectedOffset}
+        streamRows={props.streamRows}
+        streamSearchOpen={props.streamSearchOpen}
+        streamSearchQuery={props.streamSearchQuery}
+        focused={props.focusedRegion === "feed"}
+        contentWidth={contentWidth}
+      />
+      <TuiSlashPanel
+        suggestions={props.slashSuggestions}
+        selectedPath={props.selectedSlashCommandPath}
+        commandDocs={props.commandDocs}
+      />
+      <TuiComposer
+        value={props.composerValue}
+        revision={props.composerRevision}
+        placeholder={props.composerPlaceholder}
+        focused={props.focusedRegion === "composer"}
+        onInput={props.onComposerInput}
+        onSubmit={props.onComposerSubmit}
+      />
+    </box>
+  );
+}
+
+function TuiEventsStreamHeader(props: {
+  streamPath: StreamPath;
+  viewState: EventsStreamViewState;
+  modeLabel: string;
+  status: string;
+  appendStatus: string;
+  pulseOn: boolean;
+  focused: boolean;
+  activeView: StreamTuiView;
+  detailEventOffset?: number;
+}) {
+  const eventCount = countRawEvents(props.viewState.slots.feed);
+  const title =
+    props.detailEventOffset == null
+      ? props.activeView === "streams"
+        ? "Streams"
+        : props.activeView === "state"
+          ? "State"
+          : props.streamPath
+      : `Event ${props.detailEventOffset}`;
+  const statusColor =
+    props.status === "streaming"
+      ? props.pulseOn
+        ? TUI_COLORS.accent
+        : TUI_COLORS.accentDim
+      : TUI_COLORS.warning;
+  const parts = [
+    props.modeLabel,
+    `${eventCount} event${eventCount === 1 ? "" : "s"}`,
+    `${props.viewState.slots.feed.length} item${props.viewState.slots.feed.length === 1 ? "" : "s"}`,
+    props.status === "streaming" ? "" : props.status,
+    props.appendStatus,
+  ].filter(Boolean);
+
+  return (
+    <box
+      width="100%"
+      height={3}
+      border
+      borderStyle="single"
+      borderColor={props.focused ? TUI_COLORS.accent : TUI_COLORS.border}
+      focusedBorderColor={TUI_COLORS.accent}
+      backgroundColor={TUI_COLORS.surface}
+      flexDirection="row"
+      paddingLeft={1}
+      paddingRight={1}
+      gap={1}
+      focused={props.focused}
+    >
+      <text width={6} content={getBrandMarkText()} />
+      <text flexGrow={1} fg={TUI_COLORS.text} content={title} />
+      <text fg={TUI_COLORS.textSecondary} content={parts.join(" · ")} />
+      <text width={2} fg={statusColor}>
+        ●
+      </text>
+    </box>
+  );
+}
+
+function TuiEventsStreamFeed(props: {
+  viewState: EventsStreamViewState;
+  activeView: StreamTuiView;
+  detailEvent?: EventsStreamRawEventSummary;
+  selectedOffset?: number;
+  streamRows: readonly StreamTreeRow[];
+  streamSearchOpen: boolean;
+  streamSearchQuery: string;
+  focused: boolean;
+  contentWidth: number;
+}) {
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const feedItemCount = props.viewState.slots.feed.length;
+
+  useEffect(() => {
+    if (props.activeView !== "feed" || props.detailEvent != null) return;
+    const scrollbox = scrollRef.current;
+    if (scrollbox == null) return;
+
+    const scrollIntoPosition = () => {
+      if (props.focused && props.selectedOffset != null) {
+        scrollbox.scrollChildIntoView(`raw-event-${props.selectedOffset}`);
+        return;
+      }
+
+      scrollbox.scrollTo(scrollbox.scrollHeight);
+    };
+
+    const frames = [
+      setTimeout(scrollIntoPosition, 0),
+      setTimeout(scrollIntoPosition, 16),
+      setTimeout(scrollIntoPosition, 33),
+    ];
+
+    return () => {
+      for (const frame of frames) clearTimeout(frame);
+    };
+  }, [feedItemCount, props.activeView, props.detailEvent, props.focused, props.selectedOffset]);
+
+  return (
+    <scrollbox
+      ref={scrollRef}
+      width="100%"
+      flexGrow={1}
+      border
+      borderStyle="single"
+      borderColor={props.focused ? TUI_COLORS.accent : TUI_COLORS.surfaceMuted}
+      focusedBorderColor={TUI_COLORS.accent}
+      backgroundColor={TUI_COLORS.bg}
+      stickyScroll={props.activeView === "feed" && props.detailEvent == null}
+      stickyStart="bottom"
+      contentOptions={{ flexDirection: "column", paddingLeft: 1, paddingRight: 1 }}
+      focused={props.focused}
+    >
+      {props.activeView === "state" ? (
+        <TuiStateView viewState={props.viewState} contentWidth={props.contentWidth} />
+      ) : props.activeView === "streams" ? (
+        <TuiStreamsView
+          rows={props.streamRows}
+          searchOpen={props.streamSearchOpen}
+          searchQuery={props.streamSearchQuery}
+          contentWidth={props.contentWidth}
+        />
+      ) : props.detailEvent == null ? (
+        <TuiEventsStreamFeedSlot
+          elements={props.viewState.slots.feed}
+          selectedOffset={props.selectedOffset}
+          contentWidth={props.contentWidth}
+        />
+      ) : (
+        <TuiEventDetailView
+          event={props.detailEvent}
+          rawSummaries={getRawSummaries(props.viewState.slots.feed)}
+          contentWidth={props.contentWidth}
+        />
+      )}
+    </scrollbox>
+  );
+}
+
+function TuiEventsStreamFeedSlot(props: {
+  elements: readonly EventsStreamBuiltInElement[];
+  selectedOffset?: number;
+  contentWidth: number;
+}) {
+  const elapsedByOffset = getElapsedByOffset(props.elements);
+  let lastDateStr: string | undefined;
+
+  if (props.elements.length === 0) {
+    return <text fg={TUI_COLORS.textBody}>Waiting for events...</text>;
+  }
+
+  return (
+    <>
+      {props.elements.map((element) => {
+        const timestamp = getElementTimestamp(element);
+        const dateStr =
+          timestamp == null
+            ? undefined
+            : new Date(timestamp).toLocaleDateString(undefined, {
+                weekday: "long",
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              });
+        const boundary =
+          dateStr != null && lastDateStr != null && dateStr !== lastDateStr ? dateStr : undefined;
+        if (dateStr != null) lastDateStr = dateStr;
+
+        return (
+          <Fragment key={element.id}>
+            {boundary == null ? null : (
+              <TuiTimelineRule
+                label={boundary}
+                color={TUI_COLORS.textDim}
+                contentWidth={props.contentWidth}
+              />
+            )}
+            <TuiEventsStreamFeedElementRenderer
+              element={element}
+              selectedOffset={props.selectedOffset}
+              elapsedByOffset={elapsedByOffset}
+              contentWidth={props.contentWidth}
+            />
+          </Fragment>
+        );
+      })}
+    </>
+  );
+}
+
+function TuiEventsStreamFeedElementRenderer(props: {
+  element: EventsStreamBuiltInElement;
+  selectedOffset?: number;
+  elapsedByOffset: ReadonlyMap<number, string>;
+  contentWidth: number;
+}) {
+  switch (props.element.type) {
+    case "message":
+      return <TuiMessageItem element={props.element} contentWidth={props.contentWidth} />;
+    case "prompt-context":
+      return <TuiPromptContextItem element={props.element} contentWidth={props.contentWidth} />;
+    case "agent-output":
+      return (
+        <TuiSimpleBlock
+          label={`Agent output · ${formatTime(props.element.props.timestamp)}`}
+          text={props.element.props.text}
+          color={TUI_COLORS.agent}
+          contentWidth={props.contentWidth}
+          maxLines={12}
+        />
+      );
+    case "system-prompt":
+      return <TuiSystemPromptItem element={props.element} contentWidth={props.contentWidth} />;
+    case "llm-request-boundary":
+      return (
+        <TuiLlmRequestBoundaryItem element={props.element} contentWidth={props.contentWidth} />
+      );
+    case "lifecycle":
+      return (
+        <TuiTimelineRule
+          label={`${props.element.props.label} · ${formatTime(props.element.props.timestamp)}`}
+          contentWidth={props.contentWidth}
+        />
+      );
+    case "error":
+      return <TuiErrorItem element={props.element} contentWidth={props.contentWidth} />;
+    case "metadata-updated":
+      return <TuiMetadataItem element={props.element} contentWidth={props.contentWidth} />;
+    case "codemode-block":
+      return <TuiCodemodeBlockItem element={props.element} contentWidth={props.contentWidth} />;
+    case "codemode-result":
+      return <TuiCodemodeResultItem element={props.element} contentWidth={props.contentWidth} />;
+    case "grouped-raw-event":
+      return (
+        <TuiGroupedRawEventItem
+          element={props.element}
+          selectedOffset={props.selectedOffset}
+          elapsedLabel={props.elapsedByOffset.get(props.element.props.events[0]?.offset ?? -1)}
+          contentWidth={props.contentWidth}
+        />
+      );
+    case "child-stream-created":
+      return (
+        <TuiOneLine
+          text={`+ Child stream: ${props.element.props.childPath} · ${formatTime(
+            props.element.props.timestamp,
+          )}`}
+          color={TUI_COLORS.textSubdued}
+        />
+      );
+    case "raw-json-dump":
+      return (
+        <TuiSimpleBlock
+          label="Raw stream JSON"
+          text={stringifyYaml(props.element.props.events).trimEnd()}
+          color={TUI_COLORS.textSubdued}
+          contentWidth={props.contentWidth}
+        />
+      );
+    default:
+      return <TuiOneLine text={`Unknown stream element: ${props.element.type}`} />;
+  }
+}
+
+function TuiMessageItem(props: { element: EventsStreamMessageElement; contentWidth: number }) {
+  const isUser = props.element.props.role === "user";
+  const label = isUser ? "You" : "Agent";
+  const color = isUser ? TUI_COLORS.accent : TUI_COLORS.agent;
+  const header = `${label} · ${formatTime(props.element.props.timestamp)}`;
+
+  const lines = props.element.props.text
+    .split("\n")
+    .flatMap((line) => wrapLine(line, props.contentWidth - 2));
+
+  return (
+    <box width="100%" flexDirection="column" paddingTop={1}>
+      <text fg={color}>
+        <b>{isUser ? rightAlign(header, props.contentWidth) : header}</b>
+      </text>
+      {lines.map((line, index) => (
+        <text
+          key={`${props.element.id}-${index}`}
+          fg={TUI_COLORS.text}
+          content={isUser ? rightAlign(line, props.contentWidth) : `  ${line}`}
+        />
+      ))}
+    </box>
+  );
+}
+
+function TuiPromptContextItem(props: {
+  element: EventsStreamPromptContextElement;
+  contentWidth: number;
+}) {
+  const source = props.element.props.source == null ? "" : ` · from ${props.element.props.source}`;
+  const trigger = props.element.props.llmRequestPolicy.behaviour;
+  const label = `Prompt context${source} · ${trigger} · ${formatTime(props.element.props.timestamp)}`;
+
+  return (
+    <TuiSimpleBlock
+      label={label}
+      text={props.element.props.text}
+      color={trigger === "dont-trigger-request" ? TUI_COLORS.textDim : "#b45309"}
+      contentWidth={props.contentWidth}
+      maxLines={12}
+      align="right"
+    />
+  );
+}
+
+function TuiSystemPromptItem(props: {
+  element: EventsStreamSystemPromptElement;
+  contentWidth: number;
+}) {
+  return (
+    <TuiSimpleBlock
+      label={`⚙ System prompt updated · ${formatTime(props.element.props.timestamp)}`}
+      text={props.element.props.text}
+      color={TUI_COLORS.textSubdued}
+      contentWidth={props.contentWidth}
+      maxLines={12}
+    />
+  );
+}
+
+function TuiLlmRequestBoundaryItem(props: {
+  element: EventsStreamLlmRequestBoundaryElement;
+  contentWidth: number;
+}) {
+  const label =
+    props.element.props.phase === "started"
+      ? "LLM request started"
+      : props.element.props.outcome === "cancelled"
+        ? "LLM request cancelled"
+        : props.element.props.outcome === "failed"
+          ? "LLM request failed"
+          : "LLM request completed";
+
+  return (
+    <TuiTimelineRule
+      label={`${label} · ${props.element.props.requestId} · ${formatTime(
+        props.element.props.timestamp,
+      )}`}
+      color={TUI_COLORS.textDim}
+      contentWidth={props.contentWidth}
+    />
+  );
+}
+
+function TuiErrorItem(props: { element: EventsStreamErrorElement; contentWidth: number }) {
+  return (
+    <TuiSimpleBlock
+      label={`⚠ Error · ${formatTime(props.element.props.timestamp)}`}
+      text={props.element.props.message}
+      color={TUI_COLORS.danger}
+      contentWidth={props.contentWidth}
+    />
+  );
+}
+
+function TuiMetadataItem(props: {
+  element: EventsStreamMetadataUpdatedElement;
+  contentWidth: number;
+}) {
+  return (
+    <TuiSimpleBlock
+      label={`Metadata updated · ${props.element.props.path} · ${formatTime(
+        props.element.props.timestamp,
+      )}`}
+      text={stringifyYaml(props.element.props.metadata).trimEnd()}
+      color={TUI_COLORS.textSubdued}
+      contentWidth={props.contentWidth}
+      maxLines={12}
+    />
+  );
+}
+
+function TuiCodemodeBlockItem(props: {
+  element: EventsStreamCodemodeBlockElement;
+  contentWidth: number;
+}) {
+  return (
+    <TuiSimpleBlock
+      label={`Codemode block · ${formatTime(props.element.props.timestamp)}`}
+      text={props.element.props.script}
+      color={TUI_COLORS.textSubdued}
+      contentWidth={props.contentWidth}
+      maxLines={18}
+    />
+  );
+}
+
+function TuiCodemodeResultItem(props: {
+  element: EventsStreamCodemodeResultElement;
+  contentWidth: number;
+}) {
+  const details = [
+    stringifyYaml(props.element.props.result).trimEnd(),
+    props.element.props.error == null ? undefined : `error:\n${props.element.props.error}`,
+    props.element.props.logs.length === 0
+      ? undefined
+      : `logs:\n${props.element.props.logs.join("\n")}`,
+  ].filter(Boolean);
+
+  return (
+    <TuiSimpleBlock
+      label={`Codemode ${props.element.props.success ? "succeeded" : "failed"} · ${
+        props.element.props.durationMs
+      }ms · ${formatTime(props.element.props.timestamp)}`}
+      text={details.join("\n\n")}
+      color={props.element.props.success ? TUI_COLORS.textSubdued : TUI_COLORS.danger}
+      contentWidth={props.contentWidth}
+      maxLines={18}
+    />
+  );
+}
+
+function TuiGroupedRawEventItem(props: {
+  element: EventsStreamGroupedRawEventElement;
+  selectedOffset?: number;
+  elapsedLabel?: string;
+  contentWidth: number;
+}) {
+  const firstEvent = props.element.props.events[0];
+  if (firstEvent == null) return null;
+
+  const countLabel = props.element.props.count > 1 ? `×${props.element.props.count}` : undefined;
+  const selected =
+    props.selectedOffset != null &&
+    props.element.props.events.some((event) => event.offset === props.selectedOffset);
+  const renderableId = `raw-event-${selected ? props.selectedOffset : firstEvent.offset}`;
+  const rangeLabel =
+    props.element.props.count > 1 &&
+    props.element.props.firstTimestamp !== props.element.props.lastTimestamp
+      ? `to ${formatTime(props.element.props.lastTimestamp)}`
+      : undefined;
+  const summary = [
+    firstEvent.offset,
+    props.element.props.eventType,
+    countLabel,
+    props.elapsedLabel,
+    formatTime(props.element.props.firstTimestamp),
+    rangeLabel,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  return (
+    <text
+      id={renderableId}
+      fg={selected ? TUI_COLORS.text : TUI_COLORS.textDim}
+      bg={selected ? TUI_COLORS.selected : undefined}
+      content={rightAlign(summary, props.contentWidth)}
+    />
+  );
+}
+
+function TuiTimelineRule(props: { label: string; contentWidth: number; color?: string }) {
+  const label = ` ${props.label} `;
+  const lineLen = Math.max(0, props.contentWidth - label.length);
+  const left = "─".repeat(Math.floor(lineLen / 2));
+  const right = "─".repeat(Math.ceil(lineLen / 2));
+  return <text fg={props.color ?? TUI_COLORS.textDim} content={`${left}${label}${right}`} />;
+}
+
+function TuiSimpleBlock(props: {
+  label: string;
+  text: string;
+  color: string;
+  contentWidth: number;
+  maxLines?: number;
+  align?: "left" | "right";
+}) {
+  const lines = props.text.split("\n").flatMap((line) => wrapLine(line, props.contentWidth - 2));
+  const visibleLines = props.maxLines == null ? lines : lines.slice(0, props.maxLines);
+  const hiddenCount = lines.length - visibleLines.length;
+  const align = (value: string) =>
+    props.align === "right" ? rightAlign(value, props.contentWidth) : value;
+
+  return (
+    <box width="100%" flexDirection="column" paddingTop={1}>
+      <text fg={props.color}>
+        <b>{align(props.label)}</b>
+      </text>
+      {visibleLines.map((line, index) => (
+        <text key={`${props.label}-${index}`} fg={props.color} content={align(`  ${line}`)} />
+      ))}
+      {hiddenCount > 0 ? (
+        <text fg={TUI_COLORS.textDim} content={align(`  ... ${hiddenCount} more lines`)} />
+      ) : null}
+    </box>
+  );
+}
+
+function TuiOneLine(props: { text: string; color?: string }) {
+  return <text fg={props.color ?? TUI_COLORS.textSubdued} content={props.text} />;
+}
+
+function TuiStateView(props: { viewState: EventsStreamViewState; contentWidth: number }) {
+  const yaml = stringifyYaml(props.viewState).trimEnd();
+  return (
+    <box width="100%" flexDirection="column">
+      {yaml
+        .split("\n")
+        .flatMap((line, index) =>
+          wrapLine(line, props.contentWidth).map((wrapped, wrappedIndex) => (
+            <text key={`${index}-${wrappedIndex}`} fg={TUI_COLORS.textSubdued} content={wrapped} />
+          )),
+        )}
+    </box>
+  );
+}
+
+function TuiStreamsView(props: {
+  rows: readonly StreamTreeRow[];
+  searchOpen: boolean;
+  searchQuery: string;
+  contentWidth: number;
+}) {
+  const help = props.searchOpen
+    ? `Streams focus: filter: ${props.searchQuery}|`
+    : "Streams focus: up/down navigate · left/right expand · space toggle · enter open · type to filter";
+
+  if (props.rows.length === 0) {
+    return (
+      <box width="100%" flexDirection="column">
+        <text fg={TUI_COLORS.textDim} content={help} />
+        <text fg={TUI_COLORS.textDim} content="No streams loaded. Type /streams to load." />
+      </box>
+    );
+  }
+
+  return (
+    <box width="100%" flexDirection="column">
+      <text fg={TUI_COLORS.textDim} content={help} />
+      {props.rows.map((row) => (
+        <TuiStreamRow key={row.path} row={row} contentWidth={props.contentWidth} />
+      ))}
+    </box>
+  );
+}
+
+function TuiStreamRow(props: { row: StreamTreeRow; contentWidth: number }) {
+  const prefix = `${"  ".repeat(props.row.depth)}${
+    props.row.hasChildren ? (props.row.expanded ? "▾" : "▸") : " "
+  } `;
+  const label = props.row.labelSegments.map((segment) => segment.text).join("");
+  const suffix = [
+    props.row.current ? "●" : "",
+    props.row.createdAt == null ? "" : formatTime(new Date(props.row.createdAt).getTime()),
+  ]
+    .filter(Boolean)
+    .join("  ");
+  const gap = Math.max(2, props.contentWidth - prefix.length - label.length - suffix.length);
+
+  return (
+    <text
+      fg={props.row.current ? TUI_COLORS.text : TUI_COLORS.textSubdued}
+      bg={props.row.selected ? TUI_COLORS.selected : undefined}
+    >
+      <span>{prefix}</span>
+      {props.row.labelSegments.map((segment, index) =>
+        segment.matched ? (
+          <b key={index}>{segment.text}</b>
+        ) : (
+          <span key={index}>{segment.text}</span>
+        ),
+      )}
+      <span>{" ".repeat(gap)}</span>
+      <span>{suffix}</span>
+    </text>
+  );
+}
+
+function TuiEventDetailView(props: {
+  event: EventsStreamRawEventSummary;
+  rawSummaries: readonly EventsStreamRawEventSummary[];
+  contentWidth: number;
+}) {
+  const index = props.rawSummaries.findIndex((summary) => summary.offset === props.event.offset);
+  const previous = props.rawSummaries[index - 1];
+  const next = props.rawSummaries[index + 1];
+  const event = props.event.raw;
+  const meta = [
+    `offset ${event.offset}`,
+    event.createdAt,
+    previous == null
+      ? undefined
+      : `since prev: ${formatElapsedTime(Date.parse(event.createdAt) - Date.parse(previous.createdAt))}`,
+    next == null
+      ? undefined
+      : `until next: ${formatElapsedTime(Date.parse(next.createdAt) - Date.parse(event.createdAt))}`,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  const yaml = stringifyYaml(orderEventKeysForYamlDisplay(event)).trimEnd();
+
+  return (
+    <box width="100%" flexDirection="column">
+      <text fg={TUI_COLORS.text} content={event.type} />
+      <text fg={TUI_COLORS.textSubdued} content={meta} />
+      <text fg={TUI_COLORS.textDim} content="left prev · right next · esc close" />
+      <text fg={TUI_COLORS.textDim} content={"-".repeat(props.contentWidth)} />
+      {yaml
+        .split("\n")
+        .flatMap((line, index) =>
+          wrapLine(line, props.contentWidth - 2).map((wrapped, wrappedIndex) => (
+            <text
+              key={`${index}-${wrappedIndex}`}
+              fg={TUI_COLORS.textBody}
+              bg={TUI_COLORS.surfaceCard}
+              content={` ${wrapped}`}
+            />
+          )),
+        )}
+    </box>
+  );
+}
+
+function TuiSlashPanel(props: {
+  suggestions: readonly TuiSlashSuggestion[];
+  selectedPath?: string;
+  commandDocs: readonly string[];
+}) {
+  const lines = props.commandDocs.length > 0 ? props.commandDocs : props.suggestions;
+  if (lines.length === 0) return <box height={0} />;
+
+  return (
+    <box
+      width="100%"
+      height={Math.min(lines.length, 8)}
+      flexDirection="column"
+      paddingLeft={1}
+      paddingRight={1}
+      backgroundColor={TUI_COLORS.surfaceDark}
+    >
+      {props.commandDocs.length > 0
+        ? props.commandDocs.map((line, index) => (
+            <text
+              key={`${line}-${index}`}
+              fg={index === 0 ? TUI_COLORS.text : TUI_COLORS.textSubdued}
+            >
+              {index === 0 ? <b>{line}</b> : line}
+            </text>
+          ))
+        : props.suggestions.map((suggestion) => (
+            <text
+              key={suggestion.path}
+              fg={suggestion.path === props.selectedPath ? TUI_COLORS.text : TUI_COLORS.textSubdued}
+              bg={suggestion.path === props.selectedPath ? TUI_COLORS.selected : undefined}
+              attributes={suggestion.path === props.selectedPath ? TextAttributes.BOLD : undefined}
+            >
+              {suggestion.segments.map((segment, index) =>
+                segment.matched ? (
+                  <b key={index}>{segment.text}</b>
+                ) : (
+                  <span key={index}>{segment.text}</span>
+                ),
+              )}
+            </text>
+          ))}
+    </box>
+  );
+}
+
+function TuiComposer(props: {
+  value: string;
+  revision: number;
+  placeholder: string;
+  focused: boolean;
+  onInput: (value: string) => void;
+  onSubmit: (value: string) => void;
+}) {
+  return (
+    <box
+      width="100%"
+      height={3}
+      border
+      borderStyle="single"
+      borderColor={props.focused ? TUI_COLORS.accent : TUI_COLORS.surfaceMuted}
+      focusedBorderColor={TUI_COLORS.accent}
+      backgroundColor={TUI_COLORS.bg}
+      paddingLeft={1}
+      paddingRight={1}
+      focused={props.focused}
+    >
+      <input
+        key={props.revision}
+        width="100%"
+        value={props.value}
+        placeholder={props.placeholder}
+        focused={props.focused}
+        backgroundColor="transparent"
+        focusedBackgroundColor="transparent"
+        textColor={TUI_COLORS.text}
+        focusedTextColor={TUI_COLORS.text}
+        placeholderColor={TUI_COLORS.textMuted}
+        cursorColor={TUI_COLORS.accent}
+        onInput={props.onInput}
+        onSubmit={(value) => {
+          if (typeof value === "string") props.onSubmit(value);
+        }}
+      />
+    </box>
+  );
+}
+
+const getRawSummaries = getRawEventSummariesForTui;
+
+function getBrandMarkText() {
+  return new StyledText([
+    fg("#000000")(bg(TUI_COLORS.surface)("▐")),
+    bg("#000000")(fg("#ffffff")(" 𝑖 ")),
+    fg("#000000")(bg(TUI_COLORS.surface)("▌")),
+  ]);
+}
+
+function getElementTimestamp(element: EventsStreamBuiltInElement) {
+  if ("timestamp" in element.props) return element.props.timestamp as number;
+  if ("firstTimestamp" in element.props) return element.props.firstTimestamp as number;
+  return undefined;
+}
+
+function countRawEvents(elements: readonly EventsStreamBuiltInElement[]) {
+  let count = 0;
+  for (const element of elements) {
+    if (element.type === "grouped-raw-event") count += element.props.count;
+    if (element.type === "raw-json-dump") count += element.props.events.length;
+  }
+  return count;
+}

--- a/apps/os2/src/stream-tui/react-stream-view-model.ts
+++ b/apps/os2/src/stream-tui/react-stream-view-model.ts
@@ -1,0 +1,61 @@
+import type { EventsStreamBuiltInElement } from "@iterate-com/ui/components/events/feed-items";
+
+export type TuiSlashSuggestion = {
+  path: string;
+  segments: { text: string; matched: boolean }[];
+};
+
+export function getRawEventSummariesForTui(elements: readonly EventsStreamBuiltInElement[]) {
+  return elements
+    .flatMap((element) => (element.type === "grouped-raw-event" ? element.props.events : []))
+    .sort((a, b) => a.offset - b.offset);
+}
+
+/**
+ * Navigation targets for the visible feed, not the underlying event log.
+ *
+ * A grouped raw-event element may represent thousands of events but occupies
+ * one row on screen, so up/down should move across groups one row at a time.
+ * The detail inspector still uses `getRawEventSummariesForTui` because left/
+ * right there navigates the underlying event log.
+ */
+export function getRawEventRowTargetsForTui(elements: readonly EventsStreamBuiltInElement[]) {
+  return elements.flatMap((element) => {
+    if (element.type !== "grouped-raw-event") return [];
+    const firstEvent = element.props.events[0];
+    if (firstEvent == null) return [];
+
+    return [
+      {
+        offset: firstEvent.offset,
+        offsets: new Set(element.props.events.map((event) => event.offset)),
+      },
+    ];
+  });
+}
+
+export function formatCommandDocsForTui(command: {
+  slash: { name: string };
+  description?: string;
+  title: string;
+  input?: {
+    positional?: { name: string; required?: boolean; placeholder?: string };
+    options?: readonly { flag: string; name: string }[];
+    flags?: readonly { flag: string }[];
+  };
+}) {
+  const lines = [`/${command.slash.name}  ${command.description ?? command.title}`];
+  if (command.input?.positional) {
+    const positional = command.input.positional;
+    lines.push(
+      `  <${positional.name}>${positional.required ? "" : "?"} ${positional.placeholder ?? ""}`,
+    );
+  }
+  for (const option of command.input?.options ?? []) {
+    lines.push(`  ${option.flag} <${option.name}>`);
+  }
+  for (const flag of command.input?.flags ?? []) {
+    lines.push(`  ${flag.flag}`);
+  }
+  return lines;
+}

--- a/apps/os2/src/stream-tui/stream-paths.test.ts
+++ b/apps/os2/src/stream-tui/stream-paths.test.ts
@@ -1,0 +1,39 @@
+import { StreamPath } from "@iterate-com/shared/streams/types";
+import { describe, expect, test } from "vitest";
+import { formatRelativeStreamPath, resolveStreamPath } from "./stream-paths.ts";
+
+describe("resolveStreamPath", () => {
+  test("defaults to the current stream and resolves dot-relative children", () => {
+    const currentStreamPath = StreamPath.parse("/team/alpha");
+
+    expect(resolveStreamPath({ currentStreamPath })).toBe("/team/alpha");
+    expect(resolveStreamPath({ currentStreamPath, streamPath: "child" })).toBe("/team/alpha/child");
+    expect(resolveStreamPath({ currentStreamPath, streamPath: "../beta" })).toBe("/team/beta");
+    expect(resolveStreamPath({ currentStreamPath, streamPath: "/absolute" })).toBe("/absolute");
+  });
+
+  test("rejects relative paths without a current stream", () => {
+    expect(() => resolveStreamPath({ streamPath: "child" })).toThrow(
+      "Relative stream path requires a current stream.",
+    );
+  });
+});
+
+describe("formatRelativeStreamPath", () => {
+  test("formats sibling and child paths relative to the current stream", () => {
+    const currentStreamPath = StreamPath.parse("/team/alpha");
+
+    expect(
+      formatRelativeStreamPath({
+        currentStreamPath,
+        streamPath: StreamPath.parse("/team/alpha/child"),
+      }),
+    ).toBe("child");
+    expect(
+      formatRelativeStreamPath({
+        currentStreamPath,
+        streamPath: StreamPath.parse("/team/beta"),
+      }),
+    ).toBe("../beta");
+  });
+});

--- a/apps/os2/src/stream-tui/stream-paths.ts
+++ b/apps/os2/src/stream-tui/stream-paths.ts
@@ -1,0 +1,60 @@
+import { StreamPath } from "@iterate-com/shared/streams/types";
+
+export function resolveStreamPath(args: { currentStreamPath?: StreamPath; streamPath?: string }) {
+  const pathText = args.streamPath?.trim();
+  if (pathText == null || pathText.length === 0) {
+    if (args.currentStreamPath == null) {
+      throw new Error("Stream path is required because no current stream is bound.");
+    }
+
+    return args.currentStreamPath;
+  }
+
+  if (pathText.startsWith("/")) {
+    return StreamPath.parse(pathText);
+  }
+
+  if (args.currentStreamPath == null) {
+    throw new Error("Relative stream path requires a current stream.");
+  }
+
+  const relativePath = pathText.startsWith(".") ? pathText : `./${pathText}`;
+  const segments = args.currentStreamPath === "/" ? [] : args.currentStreamPath.slice(1).split("/");
+
+  for (const segment of relativePath.split("/")) {
+    if (segment === "" || segment === ".") {
+      continue;
+    }
+
+    if (segment === "..") {
+      segments.pop();
+      continue;
+    }
+
+    segments.push(segment);
+  }
+
+  return StreamPath.parse(`/${segments.join("/")}`);
+}
+
+export function formatRelativeStreamPath(args: {
+  currentStreamPath: StreamPath;
+  streamPath: StreamPath;
+}) {
+  if (args.streamPath === args.currentStreamPath) return ".";
+
+  const currentSegments =
+    args.currentStreamPath === "/" ? [] : args.currentStreamPath.slice(1).split("/");
+  const targetSegments = args.streamPath === "/" ? [] : args.streamPath.slice(1).split("/");
+
+  while (
+    currentSegments.length > 0 &&
+    targetSegments.length > 0 &&
+    currentSegments[0] === targetSegments[0]
+  ) {
+    currentSegments.shift();
+    targetSegments.shift();
+  }
+
+  return [...currentSegments.map(() => ".."), ...targetSegments].join("/") || ".";
+}

--- a/apps/os2/src/stream-tui/stream-tree.test.ts
+++ b/apps/os2/src/stream-tui/stream-tree.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "vitest";
+import { StreamPath } from "@iterate-com/shared/streams/types";
+import {
+  getDefaultExpandedStreamPaths,
+  getStreamTreeRows,
+  rankStreamPaths,
+} from "./stream-tree.ts";
+import type { StreamSummary } from "./command-router.ts";
+
+const streams: StreamSummary[] = [
+  { path: StreamPath.parse("/agents"), createdAt: "2026-04-29T10:00:00.000Z" },
+  { path: StreamPath.parse("/agents/demo"), createdAt: "2026-04-29T10:01:00.000Z" },
+  { path: StreamPath.parse("/agents/demo/runs"), createdAt: "2026-04-29T10:02:00.000Z" },
+  { path: StreamPath.parse("/agents/prod"), createdAt: "2026-04-29T10:03:00.000Z" },
+  { path: StreamPath.parse("/events"), createdAt: "2026-04-29T10:04:00.000Z" },
+];
+
+describe("getDefaultExpandedStreamPaths", () => {
+  test("expands root, ancestors, and the current stream", () => {
+    expect([...getDefaultExpandedStreamPaths(StreamPath.parse("/agents/demo/runs"))]).toEqual([
+      "/",
+      "/agents",
+      "/agents/demo",
+      "/agents/demo/runs",
+    ]);
+  });
+});
+
+describe("getStreamTreeRows", () => {
+  test("renders a collapsed tree with the current stream path expanded", () => {
+    expect(
+      getStreamTreeRows({
+        streams,
+        currentStreamPath: StreamPath.parse("/agents/demo"),
+        expandedPaths: new Set(),
+        searchQuery: "",
+        selectedPath: StreamPath.parse("/agents/demo"),
+      }).map((row) => ({
+        path: row.path,
+        depth: row.depth,
+        current: row.current,
+        selected: row.selected,
+      })),
+    ).toEqual([
+      { path: "/", depth: 0, current: false, selected: false },
+      { path: "/agents", depth: 1, current: false, selected: false },
+      { path: "/agents/demo", depth: 2, current: true, selected: true },
+      { path: "/agents/demo/runs", depth: 3, current: false, selected: false },
+      { path: "/agents/prod", depth: 2, current: false, selected: false },
+      { path: "/events", depth: 1, current: false, selected: false },
+    ]);
+  });
+
+  test("fuzzy search keeps matching branches expanded in place", () => {
+    expect(
+      getStreamTreeRows({
+        streams,
+        currentStreamPath: StreamPath.parse("/events"),
+        expandedPaths: new Set(),
+        searchQuery: "pd",
+        selectedPath: StreamPath.parse("/agents/prod"),
+      }).map((row) => ({
+        path: row.path,
+        matched: row.labelSegments
+          .filter((segment) => segment.matched)
+          .map((segment) => segment.text),
+      })),
+    ).toEqual([
+      { path: "/", matched: [] },
+      { path: "/agents", matched: [] },
+      { path: "/agents/prod", matched: ["p", "d"] },
+    ]);
+  });
+});
+
+describe("rankStreamPaths", () => {
+  test("prefers segment prefixes over loose fuzzy matches", () => {
+    expect(
+      rankStreamPaths({
+        paths: streams.map((stream) => stream.path),
+        query: "pro",
+      }).map((result) => result.path),
+    ).toEqual(["/agents/prod"]);
+  });
+});

--- a/apps/os2/src/stream-tui/stream-tree.ts
+++ b/apps/os2/src/stream-tui/stream-tree.ts
@@ -1,0 +1,232 @@
+import { StreamPath, type StreamPath as StreamPathType } from "@iterate-com/shared/streams/types";
+import {
+  fuzzyMatchRanges,
+  splitMatchedSegments,
+  type FuzzyMatchRange,
+  type SlashCommandLabelSegment,
+} from "./command-discovery.ts";
+import type { StreamSummary } from "./command-router.ts";
+
+export type StreamTreeNode = {
+  path: StreamPathType;
+  createdAt: string | undefined;
+  children: StreamTreeNode[];
+};
+
+export type StreamTreeRow = {
+  path: StreamPathType;
+  createdAt: string | undefined;
+  depth: number;
+  expanded: boolean;
+  hasChildren: boolean;
+  current: boolean;
+  selected: boolean;
+  labelSegments: SlashCommandLabelSegment[];
+};
+
+const segmentCollator = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: "base",
+});
+
+export function getDefaultExpandedStreamPaths(currentStreamPath: StreamPathType) {
+  return new Set<StreamPathType>([
+    "/",
+    ...getAncestorStreamPaths(currentStreamPath),
+    currentStreamPath,
+  ]);
+}
+
+export function getStreamTreeRows(args: {
+  streams: readonly StreamSummary[];
+  currentStreamPath: StreamPathType;
+  expandedPaths: ReadonlySet<StreamPathType>;
+  searchQuery: string;
+  selectedPath?: StreamPathType;
+}) {
+  const search = rankStreamPaths({
+    paths: materializeStreamPaths([
+      args.currentStreamPath,
+      ...args.streams.map((stream) => stream.path),
+    ]),
+    query: args.searchQuery,
+  });
+  const visiblePaths =
+    args.searchQuery.trim().length === 0
+      ? undefined
+      : new Set<StreamPathType>([
+          "/",
+          ...search.map((result) => result.path),
+          ...search.flatMap((result) => getAncestorStreamPaths(result.path)),
+        ]);
+  const forcedExpandedPaths =
+    visiblePaths == null
+      ? getDefaultExpandedStreamPaths(args.currentStreamPath)
+      : new Set<StreamPathType>(
+          [...visiblePaths].flatMap((path) => [path, ...getAncestorStreamPaths(path)]),
+        );
+  const rows: StreamTreeRow[] = [];
+  const scoreByPath = new Map(search.map((result) => [result.path, result.score]));
+  const matchRangesByPath = new Map(search.map((result) => [result.path, result.ranges]));
+  const root = buildStreamTree({
+    streams: args.streams,
+    currentStreamPath: args.currentStreamPath,
+    scoreByPath,
+  });
+
+  appendRows({
+    rows,
+    node: root,
+    depth: 0,
+    currentStreamPath: args.currentStreamPath,
+    expandedPaths: new Set([...args.expandedPaths, ...forcedExpandedPaths]),
+    visiblePaths,
+    selectedPath: args.selectedPath,
+    matchRangesByPath,
+  });
+
+  return rows;
+}
+
+export function rankStreamPaths(args: { paths: readonly StreamPathType[]; query: string }) {
+  const query = args.query.trim().toLowerCase();
+  if (query.length === 0) {
+    return args.paths.map((path) => ({ path, score: 1, ranges: [] as FuzzyMatchRange[] }));
+  }
+
+  return args.paths
+    .map((path) => ({
+      path,
+      score: scoreStreamPath({ path, query }),
+      ranges: fuzzyMatchRanges(path, query),
+    }))
+    .filter((result) => result.score > 0)
+    .sort((left, right) => right.score - left.score || left.path.localeCompare(right.path));
+}
+
+function buildStreamTree(args: {
+  streams: readonly StreamSummary[];
+  currentStreamPath: StreamPathType;
+  scoreByPath: ReadonlyMap<StreamPathType, number>;
+}) {
+  const createdAtByPath = new Map(args.streams.map((stream) => [stream.path, stream.createdAt]));
+  const allPaths = materializeStreamPaths([args.currentStreamPath, ...createdAtByPath.keys()]);
+  const nodes = new Map<StreamPathType, StreamTreeNode>(
+    allPaths.map((path) => [path, { path, createdAt: createdAtByPath.get(path), children: [] }]),
+  );
+
+  for (const path of allPaths) {
+    if (path === "/") continue;
+    nodes.get(getParentStreamPath(path))?.children.push(nodes.get(path)!);
+  }
+
+  for (const node of nodes.values()) {
+    node.children.sort((left, right) => {
+      const scoreDifference =
+        (args.scoreByPath.get(right.path) ?? 0) - (args.scoreByPath.get(left.path) ?? 0);
+      if (scoreDifference !== 0) return scoreDifference;
+
+      return segmentCollator.compare(getPathSegment(left.path), getPathSegment(right.path));
+    });
+  }
+
+  return nodes.get("/")!;
+}
+
+function appendRows(args: {
+  rows: StreamTreeRow[];
+  node: StreamTreeNode;
+  depth: number;
+  currentStreamPath: StreamPathType;
+  expandedPaths: ReadonlySet<StreamPathType>;
+  visiblePaths?: ReadonlySet<StreamPathType>;
+  selectedPath?: StreamPathType;
+  matchRangesByPath: ReadonlyMap<StreamPathType, readonly FuzzyMatchRange[]>;
+}) {
+  if (args.visiblePaths != null && !args.visiblePaths.has(args.node.path)) {
+    return;
+  }
+
+  const expanded = args.expandedPaths.has(args.node.path);
+  args.rows.push({
+    path: args.node.path,
+    createdAt: args.node.createdAt,
+    depth: args.depth,
+    expanded,
+    hasChildren: args.node.children.length > 0,
+    current: args.node.path === args.currentStreamPath,
+    selected: args.node.path === args.selectedPath,
+    labelSegments: splitMatchedSegments({
+      text: args.node.path,
+      ranges: args.matchRangesByPath.get(args.node.path) ?? [],
+    }),
+  });
+
+  if (!expanded) return;
+
+  for (const child of args.node.children) {
+    appendRows({
+      ...args,
+      node: child,
+      depth: args.depth + 1,
+    });
+  }
+}
+
+function scoreStreamPath(args: { path: StreamPathType; query: string }) {
+  const path = args.path.toLowerCase();
+  const segment = getPathSegment(args.path).toLowerCase();
+
+  if (path === args.query) return 100;
+  if (segment === args.query) return 95;
+  if (path.startsWith(args.query)) return 80;
+  if (segment.startsWith(args.query)) return 75;
+  if (path.includes(args.query)) return 45;
+  if (segment.includes(args.query)) return 40;
+  return fuzzyMatchRanges(path, args.query).length > 0 ? 20 : 0;
+}
+
+function materializeStreamPaths(streamPaths: readonly StreamPathType[]) {
+  const allPaths = new Set<StreamPathType>(["/"]);
+
+  for (const path of streamPaths) {
+    allPaths.add(path);
+
+    for (const ancestorPath of getAncestorStreamPaths(path)) {
+      allPaths.add(ancestorPath);
+    }
+  }
+
+  return Array.from(allPaths).sort(compareStreamPaths);
+}
+
+function getAncestorStreamPaths(path: StreamPathType) {
+  if (path === "/") return [];
+
+  const segments = path.split("/").filter(Boolean);
+  return segments
+    .slice(0, -1)
+    .map((_, index) => StreamPath.parse(`/${segments.slice(0, index + 1).join("/")}`));
+}
+
+function getParentStreamPath(path: StreamPathType) {
+  if (path === "/") return "/";
+
+  const parentPath = path.slice(0, path.lastIndexOf("/"));
+  return parentPath.length === 0 ? "/" : StreamPath.parse(parentPath);
+}
+
+function getPathDepth(path: StreamPathType) {
+  return path === "/" ? 0 : path.split("/").length - 1;
+}
+
+function getPathSegment(path: StreamPathType) {
+  return path === "/" ? "/" : (path.split("/").at(-1) ?? "/");
+}
+
+function compareStreamPaths(left: StreamPathType, right: StreamPathType) {
+  const depthDifference = getPathDepth(left) - getPathDepth(right);
+  if (depthDifference !== 0) return depthDifference;
+
+  return segmentCollator.compare(left, right);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1775,6 +1775,12 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@opentui/core':
+        specifier: 0.1.102
+        version: 0.1.102(stage-js@1.0.2)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+      '@opentui/react':
+        specifier: 0.1.102
+        version: 0.1.102(react-devtools-core@7.0.1)(react@19.2.4)(stage-js@1.0.2)(typescript@5.9.3)(web-tree-sitter@0.25.10)(ws@8.19.0)
       '@orpc/client':
         specifier: 1.13.14
         version: 1.13.14(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
## Summary

- Port the OpenTUI stream viewer from `apps/agents` into `apps/os2`.
- Add the `apps/os2` local CLI command `stream-tui`, backed by an authenticated os2 OpenAPI client.
- Make `--stream-path` optional for os2; when omitted, the TUI starts in stream tree view instead of prompting.
- Update the os2 CLI default base URL to `https://os.iterate2.com`.

## Notes

This is still a stream-oriented terminal UI rather than a dedicated agent-chat-only interface. It uses os2 `project.streams.*` APIs for streaming, appending, state reads, and stream catalog loading.

## Validation

- `pnpm --dir apps/os2 typecheck`
- `pnpm --dir apps/os2 exec vitest run src/stream-tui`
- `pnpm --dir apps/os2 cli stream-tui --help`
- Smoke-launched `stream-tui` without `--stream-path`; it reached the TUI entrypoint and failed only because the shell was non-interactive, confirming the CLI did not prompt for the optional stream path.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os2": {
      "appDisplayName": "OS",
      "appSlug": "os2",
      "status": "released",
      "updatedAt": "2026-05-14T09:05:11.727Z",
      "headSha": "a80d34b53b585bf0ca4f85cae6a1981e87ffdb26",
      "message": "Preview app released.",
      "publicUrl": "https://os2.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25851421543",
      "shortSha": "a80d34b"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `a80d34b`
Preview: https://os2.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25851421543)
Updated: 2026-05-14T09:05:11.727Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new interactive CLI that authenticates to OS2 and streams/appends project events; risk comes from new network/auth header handling and terminal input routing, though it’s isolated to tooling.
> 
> **Overview**
> Introduces an OpenTUI-based terminal UI in `apps/os2` for streaming, inspecting, and appending events to OS2 project streams, including feed mode switching, event detail inspection, and a browsable/searchable stream tree when `--stream-path` is omitted.
> 
> Adds a local CLI command `stream-tui` (wired in `scripts/router.ts`) that spawns the Bun entrypoint and uses an authenticated oRPC OpenAPI client to call `project.streams.*` endpoints.
> 
> Refactors/lands the TUI logic as a set of new `src/stream-tui/*` modules (slash command discovery/invocation, command registry, navigation, stream path resolution, stream tree ranking, and terminal renderers) with Vitest coverage, and updates the CLI default base URL to `https://os.iterate2.com` plus new `@opentui/*` deps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a80d34b53b585bf0ca4f85cae6a1981e87ffdb26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->