### PR TITLE
[codex] Fix OS2 project wildcard DNS provisioning

### DIFF
--- a/apps/os2/src/domains/projects/cloudflare-dns.test.ts
+++ b/apps/os2/src/domains/projects/cloudflare-dns.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createProjectWildcardCNAMERecord } from "./cloudflare-dns.ts";
+
+describe("project Cloudflare DNS provisioning", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("copies the existing proxied wildcard DNS record type for project wildcards", async () => {
+    const requests: Array<{ body?: unknown; method: string; url: string }> = [];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        requests.push({
+          body: init?.body == null ? undefined : JSON.parse(String(init.body)),
+          method: init?.method ?? "GET",
+          url,
+        });
+
+        if (url.includes("/zones?")) {
+          return jsonResponse({
+            result: [{ id: "zone_123", name: "iterate2.app", status: "active" }],
+            success: true,
+          });
+        }
+
+        if (url.includes("/dns_records?")) {
+          return jsonResponse({
+            result: [
+              {
+                content: "192.0.2.1",
+                id: "source_record",
+                name: "*.iterate2.app",
+                proxied: true,
+                ttl: 1,
+                type: "A",
+              },
+            ],
+            success: true,
+          });
+        }
+
+        return jsonResponse({
+          result: {
+            ...(init?.body == null ? {} : JSON.parse(String(init.body))),
+            id: "target_record",
+          },
+          success: true,
+        });
+      }),
+    );
+
+    const result = await createProjectWildcardCNAMERecord({
+      apiToken: "token",
+      projectHostnameBase: "iterate2.app",
+      projectId: "proj_123",
+      projectSlug: "demo",
+    });
+
+    const createRequest = requests.find((request) => request.method === "POST");
+    expect(createRequest?.body).toMatchObject({
+      content: "192.0.2.1",
+      name: "*.demo.iterate2.app",
+      proxied: true,
+      ttl: 1,
+      type: "A",
+    });
+    expect(result?.record.type).toBe("A");
+    expect(result?.target).toBe("192.0.2.1");
+  });
+});
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    status: 200,
+  });
+}

--- a/apps/os2/src/domains/projects/cloudflare-dns.ts
+++ b/apps/os2/src/domains/projects/cloudflare-dns.ts
@@ -42,30 +42,33 @@ export async function createProjectWildcardCNAMERecord(input: {
   // DNS automation is intentionally optional so local/test configs can create
   // Projects without Cloudflare credentials.
   if (!input.apiToken) {
-    console.log("[ProjectDNS] Skipping wildcard CNAME creation: cloudflare.apiToken is absent.");
+    console.log(
+      "[ProjectDNS] Skipping wildcard DNS record creation: cloudflare.apiToken is absent.",
+    );
     return null;
   }
 
   // Local workerd hostnames are not Cloudflare-managed DNS zones.
   if (!base || base === "localhost" || base.endsWith(".localhost")) {
-    console.log(`[ProjectDNS] Skipping wildcard CNAME creation for local base '${base}'.`);
+    console.log(`[ProjectDNS] Skipping wildcard DNS record creation for local base '${base}'.`);
     return null;
   }
 
   const zone = await resolveZone({ apiToken: input.apiToken, zoneName: base });
   const sourceRecordName = `*.${base}`;
-  const sourceRecord = await getRequiredCNAMERecord({
+  const sourceRecord = await getRequiredProxiedDnsRecord({
     apiToken: input.apiToken,
     name: sourceRecordName,
     zoneId: zone.id,
   });
   const targetRecordName = `*.${input.projectSlug}.${base}`;
-  const targetRecord = await createCNAMERecord({
+  const targetRecord = await createDnsRecord({
     apiToken: input.apiToken,
     comment: `Managed by apps/os2 for project ${input.projectId}`,
     content: sourceRecord.content,
     name: targetRecordName,
     proxied: sourceRecord.proxied ?? true,
+    type: sourceRecord.type,
     zoneId: zone.id,
   });
 
@@ -89,25 +92,27 @@ async function resolveZone(input: { apiToken: string; zoneName: string }) {
   return zone;
 }
 
-async function getRequiredCNAMERecord(input: { apiToken: string; name: string; zoneId: string }) {
+async function getRequiredProxiedDnsRecord(input: {
+  apiToken: string;
+  name: string;
+  zoneId: string;
+}) {
   const records = await cloudflareFetch<CloudflareDnsRecord[]>({
     apiToken: input.apiToken,
-    path: `/zones/${input.zoneId}/dns_records?type=CNAME&name=${encodeURIComponent(
-      input.name,
-    )}&per_page=1`,
+    path: `/zones/${input.zoneId}/dns_records?name=${encodeURIComponent(input.name)}&per_page=20`,
   });
-  const record = records[0];
-  if (!record) throw new Error(`Cloudflare CNAME '${input.name}' was not found.`);
-  if (record.type !== "CNAME") throw new Error(`Cloudflare record '${input.name}' is not CNAME.`);
+  const record = records.find((candidate) => candidate.proxied);
+  if (!record) throw new Error(`Cloudflare proxied DNS record '${input.name}' was not found.`);
   return record;
 }
 
-async function createCNAMERecord(input: {
+async function createDnsRecord(input: {
   apiToken: string;
   comment: string;
   content: string;
   name: string;
   proxied: boolean;
+  type: string;
   zoneId: string;
 }) {
   // This is deliberately create-only happy-path DNS provisioning. If the target
@@ -121,7 +126,7 @@ async function createCNAMERecord(input: {
       name: input.name,
       proxied: input.proxied,
       ttl: 1,
-      type: "CNAME",
+      type: input.type,
     },
     method: "POST",
     path: `/zones/${input.zoneId}/dns_records`,

--- a/apps/os2/src/domains/projects/durable-objects/project-durable-object.ts
+++ b/apps/os2/src/domains/projects/durable-objects/project-durable-object.ts
@@ -303,7 +303,7 @@ export class ProjectDurableObject extends ProjectBase<ProjectEnv> {
     await this.writeProjectCreatedLifecycleEvent(summary);
     void this.createProjectWildcardCNAMERecord(summary).catch((error) => {
       console.error(
-        `[ProjectDNS] Wildcard CNAME fire-and-forget task failed for ${summary.id}:`,
+        `[ProjectDNS] Wildcard DNS record fire-and-forget task failed for ${summary.id}:`,
         error,
       );
     });
@@ -860,7 +860,7 @@ export class ProjectDurableObject extends ProjectBase<ProjectEnv> {
         summary,
       });
     } catch (error) {
-      console.error(`[ProjectDNS] Wildcard CNAME creation failed for ${summary.id}:`, error);
+      console.error(`[ProjectDNS] Wildcard DNS record creation failed for ${summary.id}:`, error);
       await this.writeProjectCNAMERecordCreationFailedLifecycleEvent({
         base,
         error,


### PR DESCRIPTION
## Summary

Fix OS2 project wildcard DNS provisioning so it copies the existing proxied wildcard DNS record for the project hostname base instead of requiring that source record to be a CNAME.

## Root Cause

Production `*.iterate2.app` is managed as a proxied dummy `A` record to `192.0.2.1` by the app route setup. The project provisioning path queried Cloudflare with `type=CNAME`, so it reported `Cloudflare CNAME '*.iterate2.app' was not found` even though the route DNS record existed.

## Changes

- Look up the existing proxied wildcard DNS record by name, regardless of record type.
- Create project wildcard records using the same type, content, and proxied setting as the source record.
- Adjust runtime log text from CNAME-specific wording to DNS-record wording.
- Add a unit test covering the production `A 192.0.2.1` source-record shape.

## Validation

- `pnpm --dir apps/os2 exec vitest run src/domains/projects/cloudflare-dns.test.ts`
- `pnpm --dir apps/os2 typecheck`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os2": {
      "appDisplayName": "OS",
      "appSlug": "os2",
      "status": "released",
      "updatedAt": "2026-05-14T13:31:50.630Z",
      "headSha": "8f66d492c3425144f7dcbb5a9a41c4a445dad5ff",
      "message": "Preview app released.",
      "publicUrl": "https://os2.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25861999298",
      "shortSha": "8f66d49"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `8f66d49`
Preview: https://os2.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25861999298)
Updated: 2026-05-14T13:31:50.630Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Cloudflare DNS provisioning behavior for project wildcard records (querying different records and creating non-CNAME types), which could impact routing if the wrong source record is selected or created in production zones.
> 
> **Overview**
> Project wildcard DNS provisioning now **copies the existing proxied `*.{base}` record regardless of type** and creates the project wildcard record (`*.{slug}.{base}`) with the same `type`, `content`, and proxied setting, instead of always looking for/creating a CNAME.
> 
> Log/error messages in `project-durable-object.ts` and `cloudflare-dns.ts` were generalized from *CNAME-specific* wording to *DNS record* wording, and a new Vitest unit test covers the production-like case where the source wildcard is a proxied `A` record.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f66d492c3425144f7dcbb5a9a41c4a445dad5ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->