### PR TITLE
[codex] Ensure dev tunnel wildcard CNAMEs

### DIFF
--- a/packages/shared/src/alchemy/iterate-app.ts
+++ b/packages/shared/src/alchemy/iterate-app.ts
@@ -155,6 +155,20 @@ export async function IterateApp<B extends Bindings>(
       ],
     });
 
+    const cloudflareApi = await createCloudflareApi({});
+    await Promise.all(
+      wildcardHosts.map(async (hostname) => {
+        const { zoneId } = await findActiveZoneForHostname(cloudflareApi, hostname);
+        await ensureDevTunnelWildcardDnsRecord({
+          cloudflareApi,
+          zoneId,
+          name: hostname,
+          target: `${tunnel.tunnelId}.cfargotunnel.com`,
+          comment: `Managed by ${manifest.slug} dev tunnel (${app.stage}).`,
+        });
+      }),
+    );
+
     tunnelToken = tunnel.token.unencrypted;
   }
 
@@ -304,6 +318,64 @@ async function ensureCloudflareDnsRecord(input: {
   if (!response.ok) {
     throw new Error(
       `Failed to upsert DNS record ${input.record.name}: ${response.status} ${await response.text()}`,
+    );
+  }
+}
+
+async function ensureDevTunnelWildcardDnsRecord(input: {
+  cloudflareApi: Awaited<ReturnType<typeof createCloudflareApi>>;
+  comment: string;
+  name: string;
+  target: string;
+  zoneId: string;
+}) {
+  const params = new URLSearchParams({ name: input.name, per_page: "100" });
+  const listResponse = await input.cloudflareApi.get(
+    `/zones/${input.zoneId}/dns_records?${params.toString()}`,
+  );
+  if (!listResponse.ok) {
+    throw new Error(
+      `Failed to check dev tunnel wildcard DNS record ${input.name}: ${listResponse.status} ${await listResponse.text()}`,
+    );
+  }
+
+  const listResult = (await listResponse.json()) as {
+    result?: Array<{
+      content?: string;
+      id: string;
+      name?: string;
+      proxied?: boolean;
+      type?: string;
+    }>;
+  };
+  const records = listResult.result?.filter((record) => record.name === input.name) ?? [];
+  const cname = records.find((record) => record.type === "CNAME");
+  const conflictingRecords = records.filter((record) => record.type !== "CNAME");
+
+  if (conflictingRecords.length > 0) {
+    throw new Error(
+      `Dev tunnel wildcard DNS record ${input.name} has conflicting ${[
+        ...new Set(conflictingRecords.map((record) => record.type ?? "unknown")),
+      ].join(", ")} record(s). Replace them with a proxied CNAME to ${input.target}.`,
+    );
+  }
+
+  const record = {
+    type: "CNAME" as const,
+    name: input.name,
+    content: input.target,
+    proxied: true,
+    ttl: 1,
+    comment: input.comment,
+  };
+
+  const response = cname
+    ? await input.cloudflareApi.put(`/zones/${input.zoneId}/dns_records/${cname.id}`, record)
+    : await input.cloudflareApi.post(`/zones/${input.zoneId}/dns_records`, record);
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to upsert dev tunnel wildcard DNS record ${input.name}: ${response.status} ${await response.text()}`,
     );
   }
 }


### PR DESCRIPTION
## Summary

- ensure local dev Cloudflare Tunnel wildcard hostnames have a proxied CNAME to the tunnel target
- fail startup with a clear message when conflicting DNS records exist at the wildcard name

## Why

OS2 dev tunnels can include wildcard ingress such as `*.iterate-dev-jonas.app`, but Cloudflare still needs DNS to point that wildcard hostname at `<tunnel-id>.cfargotunnel.com`. If stale A/AAAA records point at Cloudflare proxy IPs instead, requests fail with Cloudflare Error 1000 before they reach the tunnel.

## Validation

- `pnpm --dir packages/shared typecheck`
- `pnpm exec oxfmt --check packages/shared/src/alchemy/iterate-app.ts`
- manually verified OS2 dev wildcard health endpoints for Jonas, Misha, and Rahul after running their dev configs

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "agents": {
      "appDisplayName": "Agents",
      "appSlug": "agents",
      "status": "released",
      "updatedAt": "2026-05-14T14:47:41.387Z",
      "headSha": "141b2b101f19fbb88717a3532ca48f7d8ce38648",
      "message": "Preview app released.",
      "publicUrl": "https://agents.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25864311867",
      "shortSha": "141b2b1"
    },
    "example": {
      "appDisplayName": "Example",
      "appSlug": "example",
      "status": "released",
      "updatedAt": "2026-05-14T14:47:38.792Z",
      "headSha": "141b2b101f19fbb88717a3532ca48f7d8ce38648",
      "message": "Preview app released.",
      "publicUrl": "https://example.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25864311867",
      "shortSha": "141b2b1"
    },
    "os2": {
      "appDisplayName": "OS",
      "appSlug": "os2",
      "status": "released",
      "updatedAt": "2026-05-14T14:47:38.655Z",
      "headSha": "141b2b101f19fbb88717a3532ca48f7d8ce38648",
      "message": "Preview app released.",
      "publicUrl": "https://os2.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25864311867",
      "shortSha": "141b2b1"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-05-14T14:47:35.848Z",
      "headSha": "141b2b101f19fbb88717a3532ca48f7d8ce38648",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25864311867",
      "shortSha": "141b2b1"
    },
    "events": {
      "appDisplayName": "Events",
      "appSlug": "events",
      "status": "released",
      "updatedAt": "2026-05-14T14:47:22.443Z",
      "headSha": "141b2b101f19fbb88717a3532ca48f7d8ce38648",
      "message": "Preview app released.",
      "publicUrl": "https://events.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/25864311867",
      "shortSha": "141b2b1"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Agents
Status: released
Commit: `141b2b1`
Preview: https://agents.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25864311867)
Updated: 2026-05-14T14:47:41.387Z

### Events
Status: released
Commit: `141b2b1`
Preview: https://events.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25864311867)
Updated: 2026-05-14T14:47:22.443Z

### Example
Status: released
Commit: `141b2b1`
Preview: https://example.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25864311867)
Updated: 2026-05-14T14:47:38.792Z

### OS
Status: released
Commit: `141b2b1`
Preview: https://os2.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25864311867)
Updated: 2026-05-14T14:47:38.655Z

### Semaphore
Status: released
Commit: `141b2b1`
Preview: https://semaphore.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/25864311867)
Updated: 2026-05-14T14:47:35.848Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Cloudflare DNS management during local dev tunnel startup and can now fail fast on unexpected existing records, which could block dev workflows if assumptions are wrong.
> 
> **Overview**
> When running locally with a real `baseUrl` and wildcard ingress hostnames, the dev tunnel setup now **ensures each wildcard hostname has a proxied `CNAME` pointing to `<tunnel-id>.cfargotunnel.com`**.
> 
> It adds `ensureDevTunnelWildcardDnsRecord` to upsert the wildcard `CNAME` and **throws a clear startup error** if non-`CNAME` DNS records already exist for that wildcard name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 141b2b101f19fbb88717a3532ca48f7d8ce38648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->