### PR TITLE
[codex] Fix OS2 artifact seed namespace inference

### DIFF
--- a/apps/os2/scripts/seed-iterate-config-base-repo.ts
+++ b/apps/os2/scripts/seed-iterate-config-base-repo.ts
@@ -60,6 +60,7 @@ function parseOptions(args: string[]): Options {
   const values = new Map<string, string>();
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
+    if (arg === "--") continue;
     if (!arg?.startsWith("--")) {
       throw new Error(`Unexpected argument: ${arg ?? ""}`);
     }
@@ -83,10 +84,19 @@ function parseOptions(args: string[]): Options {
     namespace:
       values.get("namespace") ??
       process.env.OS2_ARTIFACTS_NAMESPACE ??
+      inferArtifactsNamespaceFromAlchemyStage() ??
       inferArtifactsNamespaceFromBaseUrl() ??
       requireEnv("OS2_ARTIFACTS_NAMESPACE"),
     repoName: values.get("repo") ?? ITERATE_CONFIG_BASE_REPO_ARTIFACT_NAME,
   };
+}
+
+function inferArtifactsNamespaceFromAlchemyStage() {
+  const stage = process.env.ALCHEMY_STAGE?.trim();
+  if (!stage) return null;
+  if (stage === "prd") return "os2-prd-repos";
+  if (stage === "preview") return "os2-preview-1-repos";
+  return `${slugify(`os2-${stage}`)}-repos`;
 }
 
 function inferArtifactsNamespaceFromBaseUrl() {
@@ -97,8 +107,22 @@ function inferArtifactsNamespaceFromBaseUrl() {
   const previewMatch = /^os2\.iterate-preview-(\d+)\.com$/.exec(hostname);
   if (previewMatch) return `os2-preview-${previewMatch[1]}-repos`;
 
-  if (hostname === "os2.iterate.com") return "os2-repos";
+  const devMatch = /^os\.iterate-dev-([^.]+)\.com$/.exec(hostname);
+  if (devMatch) return `os2-dev-${devMatch[1]}-repos`;
+
+  if (hostname === "os.iterate2.com" || hostname === "os2.iterate.com") {
+    return "os2-prd-repos";
+  }
   return null;
+}
+
+function slugify(input: string) {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 async function getOrCreateArtifactRepo(options: Options): Promise<ArtifactRepoAccess> {


### PR DESCRIPTION
## Summary

Fix the OS2 `iterate-config-base` seeding script so it targets the same Artifacts namespaces used by OS2 deployments and artifact viewers.

## What changed

- Prefer `ALCHEMY_STAGE` when inferring the Artifacts namespace.
- Map `prd` to `os2-prd-repos` instead of the old `os2-repos` namespace.
- Map root `preview` to `os2-preview-1-repos`.
- Normalize staged names like `dev_jonas` to `os2-dev-jonas-repos`.
- Support the documented pnpm argument separator form: `pnpm artifacts:seed-config-base -- --namespace ...`.

## Why

The previous fallback could seed the base config into the wrong namespace/account combination. In particular, production could drift toward the old `os2-repos` namespace, and dev environments like `dev_jonas` did not infer `os2-dev-jonas-repos`.

## Validation

- `pnpm --dir apps/os2 typecheck`
- `doppler run --project os2 --config dev_jonas -- pnpm --dir apps/os2 artifacts:seed-config-base -- --namespace os2-dev-jonas-repos`
- Verified Cloudflare Artifacts API finds `iterate-config-base` in the corrected prod, preview, and dev namespaces after reseeding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how the seeding script selects the target Artifacts namespace, which can redirect writes to different repos/environments if mappings or env vars are wrong.
> 
> **Overview**
> Updates the OS2 `seed-iterate-config-base-repo.ts` script to **prefer `ALCHEMY_STAGE`** when inferring the Cloudflare Artifacts namespace, with new mappings for `prd` → `os2-prd-repos`, `preview` → `os2-preview-1-repos`, and slugified stage names (e.g., `dev_jonas` → `os2-dev-jonas-repos`).
> 
> Extends the base-URL fallback inference to recognize `os.iterate2.com`/`os2.iterate.com` as prod and `os.iterate-dev-*.com` as dev namespaces, and updates CLI parsing to ignore the `--` argument separator so `pnpm ... -- --namespace ...` works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7157fc9f23b32b8d7eb631ea56a9786a0c9df112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->