### PR TITLE
Use timestamped default agent path

### DIFF
--- a/apps/os2/src/components/project-stream-view.tsx
+++ b/apps/os2/src/components/project-stream-view.tsx
@@ -21,7 +21,6 @@ import {
 import {
   EventsStreamInputSlot,
   EventsStreamView,
-  type EventsStreamElementType,
   type EventsStreamRendererMode,
 } from "@iterate-com/ui/components/events/stream-feed";
 import { EventsStreamLayoutMessageInput } from "@iterate-com/ui/components/events/stream-layout";
@@ -114,7 +113,7 @@ export function ProjectStreamView({
   const [selectedRawPresetId, setSelectedRawPresetId] = useState(DEFAULT_RAW_EVENT_PRESET_ID);
   const [events, setEvents] = useState<Event[]>([]);
   const [errorLabel, setErrorLabel] = useState<string | undefined>();
-  const [hiddenElementTypes, setHiddenElementTypes] = useState<EventsStreamElementType[]>([]);
+  const [feedFilterExpression, setFeedFilterExpression] = useState("");
   const [rendererMode, setRendererMode] = useState<EventsStreamRendererMode>("raw-pretty");
   const [isPending, setIsPending] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -318,8 +317,8 @@ export function ProjectStreamView({
         emptyLabel={emptyLabel}
         isPending={isPending}
         errorLabel={errorLabel}
-        hiddenElementTypes={hiddenElementTypes}
-        onHiddenElementTypesChange={setHiddenElementTypes}
+        feedFilterExpression={feedFilterExpression}
+        onFeedFilterExpressionChange={setFeedFilterExpression}
         rendererMode={rendererMode}
         onRendererModeChange={setRendererMode}
       />

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx
@@ -46,6 +46,10 @@ import { orpc, orpcClient } from "~/orpc/client.ts";
 
 const emptyEventsYaml = "[]\n";
 
+function createDefaultAgentPath() {
+  return `/agents/assistant_${Date.now()}`;
+}
+
 export const Route = createFileRoute(
   "/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new",
 )({
@@ -87,7 +91,7 @@ function NewAgentPage() {
   const params = Route.useParams();
   const { project } = Route.useLoaderData();
   const navigate = useNavigate();
-  const [agentPathInput, setAgentPathInput] = useState("/agents/assistant");
+  const [agentPathInput, setAgentPathInput] = useState(createDefaultAgentPath);
   const [provider, setProvider] = useState<AgentLlmProvider>(DEFAULT_AGENT_LLM_PROVIDER);
   const [model, setModel] = useState(DEFAULT_OPENAI_AGENT_MODEL);
   const [runOpts, setRunOpts] = useState('{"gateway":{"id":"default"}}');
@@ -192,7 +196,7 @@ function NewAgentPage() {
                 id="agent-path"
                 value={agentPathInput}
                 onChange={(event) => setAgentPathInput(event.currentTarget.value)}
-                placeholder="/agents/assistant"
+                placeholder="/agents/assistant_1710000000000"
               />
             </Field>
 
@@ -353,7 +357,7 @@ function buildPreviewEvents(input: {
   selectedToolProviders: Set<ToolProviderKey>;
   systemPrompt: string;
 }): { agentPath: StreamPath; error?: string; events: EventInput[] } {
-  let agentPath = StreamPath.parse("/agents/assistant");
+  let agentPath = StreamPath.parse(createDefaultAgentPath());
   try {
     agentPath = agentPathFromInput(input.agentPathInput);
     if (input.model.trim() === "") throw new Error("Model is required.");

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx
@@ -131,18 +131,20 @@ function NewAgentPage() {
   const createAgent = useMutation({
     mutationFn: async () => {
       if (preview.error) throw new Error(preview.error);
-      return await orpcClient.project.streams.appendBatch({
+      const agentPath = preview.agentPath;
+      await orpcClient.project.streams.appendBatch({
         events: preview.events,
         projectSlugOrId: project.id,
-        streamPath: preview.agentPath,
+        streamPath: agentPath,
       });
+      return { agentPath };
     },
-    onSuccess: () => {
+    onSuccess: ({ agentPath }) => {
       void navigate({
         to: "/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$",
         params: {
           ...params,
-          _splat: streamPathToSplat(preview.agentPath),
+          _splat: streamPathToSplat(agentPath),
         },
       });
     },

--- a/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$.tsx
+++ b/apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$.tsx
@@ -14,12 +14,6 @@ export const Route = createFileRoute(
       ...orpc.projects.findBySlug.queryOptions({ input: { slug: params.projectSlug } }),
       staleTime: 30_000,
     });
-    await context.queryClient.ensureQueryData({
-      ...orpc.project.agents.runtimeState.queryOptions({
-        input: { agentPath, projectSlugOrId: project.id },
-      }),
-      staleTime: 5_000,
-    });
 
     return {
       breadcrumb: agentPath,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,6 +35,7 @@
     "@codemirror/view": "^6.39.16",
     "@fsegurai/codemirror-theme-bundle": "^6.3.1",
     "@iterate-com/shared": "workspace:*",
+    "@mmkal/jsonata": "^2.2.1",
     "@tailwindcss/postcss": "^4.1.17",
     "@xterm/addon-clipboard": "0.3.0-beta.103",
     "@xterm/addon-fit": "0.12.0-beta.103",

--- a/packages/ui/src/components/events/stream-event-type.tsx
+++ b/packages/ui/src/components/events/stream-event-type.tsx
@@ -81,11 +81,11 @@ function StreamEventTypeLabel({ type, className }: { type: string; className?: s
 
 function getIterateEventTypeLabel(type: string) {
   if (type.startsWith(ITERATE_EVENT_TYPE_PREFIX)) {
-    return type.slice(ITERATE_EVENT_TYPE_PREFIX.length);
+    return `/${type.slice(ITERATE_EVENT_TYPE_PREFIX.length)}`;
   }
 
   if (type.startsWith(ITERATE_EVENT_TYPE_URL_PREFIX)) {
-    return type.slice(ITERATE_EVENT_TYPE_URL_PREFIX.length);
+    return `/${type.slice(ITERATE_EVENT_TYPE_URL_PREFIX.length)}`;
   }
 
   return null;

--- a/packages/ui/src/components/events/stream-feed.tsx
+++ b/packages/ui/src/components/events/stream-feed.tsx
@@ -13,6 +13,7 @@ import {
   TerminalSquareIcon,
   XCircleIcon,
 } from "lucide-react";
+import jsonata from "@mmkal/jsonata/sync";
 
 import {
   Conversation,
@@ -23,6 +24,7 @@ import {
 import { Message, MessageContent } from "@iterate-com/ui/components/ai-elements/message";
 import { Badge } from "@iterate-com/ui/components/badge";
 import { Button } from "@iterate-com/ui/components/button";
+import { Checkbox } from "@iterate-com/ui/components/checkbox";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -34,6 +36,14 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@iterate-com/ui/components/dropdown-menu";
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@iterate-com/ui/components/popover";
 import { SerializedObjectCodeBlock } from "@iterate-com/ui/components/serialized-object-code-block";
 import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
 import { Spinner } from "@iterate-com/ui/components/spinner";
@@ -97,6 +107,8 @@ export function EventsStreamView({
   renderStreamPathLink,
   hiddenElementTypes = [],
   onHiddenElementTypesChange,
+  feedFilterExpression,
+  onFeedFilterExpressionChange,
   rendererMode,
   onRendererModeChange,
   emptyLabel,
@@ -112,6 +124,8 @@ export function EventsStreamView({
   renderStreamPathLink?: EventsStreamPathLinkRenderer;
   hiddenElementTypes?: readonly EventsStreamElementType[];
   onHiddenElementTypesChange?: (types: EventsStreamElementType[]) => void;
+  feedFilterExpression?: string;
+  onFeedFilterExpressionChange?: (expression: string) => void;
   rendererMode?: EventsStreamRendererMode;
   onRendererModeChange?: (mode: EventsStreamRendererMode) => void;
   emptyLabel?: string;
@@ -120,10 +134,26 @@ export function EventsStreamView({
   className?: string;
 }) {
   const feedElementTypes = getElementTypes(viewState.slots.feed);
-  const visibleFeedElements = filterElementsByElementType({
-    elements: viewState.slots.feed,
-    hiddenElementTypes,
-  });
+  const eventTypes = getEventTypes(events);
+  const jsonataFilterResult = useMemo(
+    () =>
+      filterElementsByJsonataExpression({
+        elements: viewState.slots.feed,
+        expression: feedFilterExpression ?? "",
+      }),
+    [feedFilterExpression, viewState.slots.feed],
+  );
+  const visibleFeedElements =
+    onFeedFilterExpressionChange == null
+      ? filterElementsByElementType({
+          elements: viewState.slots.feed,
+          hiddenElementTypes,
+        })
+      : jsonataFilterResult.elements;
+  const hasActiveFeedFilter =
+    onFeedFilterExpressionChange != null &&
+    (feedFilterExpression ?? "").trim() !== "" &&
+    jsonataFilterResult.errorLabel == null;
 
   return (
     <EventsStreamLayout className={className}>
@@ -132,8 +162,12 @@ export function EventsStreamView({
           <EventsStreamHeader
             elements={viewState.slots.header}
             elementTypes={feedElementTypes}
+            eventTypes={eventTypes}
             hiddenElementTypes={hiddenElementTypes}
             onHiddenElementTypesChange={onHiddenElementTypesChange}
+            feedFilterExpression={feedFilterExpression}
+            feedFilterErrorLabel={jsonataFilterResult.errorLabel}
+            onFeedFilterExpressionChange={onFeedFilterExpressionChange}
             rendererMode={rendererMode}
             onRendererModeChange={onRendererModeChange}
           />
@@ -142,7 +176,7 @@ export function EventsStreamView({
       <EventsStreamLayoutMain>
         <EventsStreamFeed
           elements={visibleFeedElements}
-          emptyLabel={emptyLabel}
+          emptyLabel={hasActiveFeedFilter ? "No matching feed items." : emptyLabel}
           isPending={isPending}
           errorLabel={errorLabel}
           onOpenEventOffsetChange={onOpenEventOffsetChange}
@@ -165,15 +199,23 @@ export function EventsStreamView({
 export function EventsStreamHeader({
   elements,
   elementTypes = [],
+  eventTypes = [],
   hiddenElementTypes = [],
   onHiddenElementTypesChange,
+  feedFilterExpression,
+  feedFilterErrorLabel,
+  onFeedFilterExpressionChange,
   rendererMode,
   onRendererModeChange,
 }: {
   elements: readonly EventsStreamBuiltInElement[];
   elementTypes?: readonly EventsStreamElementType[];
+  eventTypes?: readonly string[];
   hiddenElementTypes?: readonly EventsStreamElementType[];
   onHiddenElementTypesChange?: (types: EventsStreamElementType[]) => void;
+  feedFilterExpression?: string;
+  feedFilterErrorLabel?: string;
+  onFeedFilterExpressionChange?: (expression: string) => void;
   rendererMode?: EventsStreamRendererMode;
   onRendererModeChange?: (mode: EventsStreamRendererMode) => void;
 }) {
@@ -193,11 +235,20 @@ export function EventsStreamHeader({
           rendererMode={rendererMode}
           onRendererModeChange={onRendererModeChange}
         />
-        <EventsStreamElementTypeFilter
-          elementTypes={elementTypes}
-          hiddenElementTypes={hiddenElementTypes}
-          onHiddenElementTypesChange={onHiddenElementTypesChange}
-        />
+        {onFeedFilterExpressionChange == null ? (
+          <EventsStreamElementTypeFilter
+            elementTypes={elementTypes}
+            hiddenElementTypes={hiddenElementTypes}
+            onHiddenElementTypesChange={onHiddenElementTypesChange}
+          />
+        ) : (
+          <EventsStreamJsonataFilter
+            eventTypes={eventTypes}
+            expression={feedFilterExpression ?? ""}
+            errorLabel={feedFilterErrorLabel}
+            onExpressionChange={onFeedFilterExpressionChange}
+          />
+        )}
       </div>
     </div>
   );
@@ -295,6 +346,120 @@ function EventsStreamElementTypeFilter({
         </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+function EventsStreamJsonataFilter({
+  eventTypes,
+  expression,
+  errorLabel,
+  onExpressionChange,
+}: {
+  eventTypes: readonly string[];
+  expression: string;
+  errorLabel?: string;
+  onExpressionChange: (expression: string) => void;
+}) {
+  if (eventTypes.length === 0 && expression.trim() === "") {
+    return null;
+  }
+
+  const selectedEventTypes = new Set(
+    eventTypes.filter((eventType) => expressionIncludesEventTypeClause(expression, eventType)),
+  );
+  const active = expression.trim() !== "";
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className={cn(
+              "h-7 shrink-0 gap-1.5 px-2 text-xs font-normal",
+              errorLabel != null && "border-destructive/40 text-destructive",
+            )}
+          />
+        }
+      >
+        {errorLabel == null ? null : <AlertTriangleIcon className="size-3.5" />}
+        <span className="truncate">{active ? "Feed filtered" : "Filter feed items"}</span>
+        <ChevronDownIcon className="size-3.5 text-muted-foreground" />
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-[min(34rem,calc(100vw-1rem))] gap-3 p-3">
+        <PopoverHeader className="flex-row items-center justify-between gap-3">
+          <div className="min-w-0">
+            <PopoverTitle>Filter feed items</PopoverTitle>
+            <PopoverDescription>JSONata expression</PopoverDescription>
+          </div>
+          <a
+            href="https://docs.jsonata.org/overview"
+            target="_blank"
+            rel="noreferrer"
+            className="shrink-0 text-xs text-primary underline-offset-4 hover:underline"
+          >
+            JSONata docs
+          </a>
+        </PopoverHeader>
+
+        <SourceCodeBlock
+          code={expression}
+          className="h-40 text-xs"
+          editable
+          language="text"
+          onChange={onExpressionChange}
+          showCopyButton={false}
+        />
+
+        {errorLabel == null ? null : (
+          <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-2.5 py-2 text-xs text-destructive">
+            <AlertTriangleIcon className="mt-0.5 size-3.5 shrink-0" />
+            <span className="min-w-0 break-words">{errorLabel}</span>
+          </div>
+        )}
+
+        <div className="flex items-center justify-between gap-2 border-t pt-2">
+          <span className="text-xs font-medium text-muted-foreground">Event types</span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-xs"
+            onClick={() => onExpressionChange("")}
+          >
+            Clear
+          </Button>
+        </div>
+
+        <div className="max-h-56 space-y-1 overflow-y-auto pr-1">
+          {eventTypes.length === 0 ? (
+            <p className="px-1 text-xs text-muted-foreground">No event types yet.</p>
+          ) : (
+            eventTypes.map((eventType) => (
+              <label
+                key={eventType}
+                className="flex min-w-0 cursor-pointer items-start gap-2 rounded-md px-1 py-1 text-xs hover:bg-accent"
+              >
+                <Checkbox
+                  className="mt-0.5"
+                  checked={selectedEventTypes.has(eventType)}
+                  onCheckedChange={(checked) => {
+                    onExpressionChange(
+                      checked
+                        ? appendEventTypeFilterClause(expression, eventType)
+                        : removeEventTypeFilterClause(expression, eventType),
+                    );
+                  }}
+                />
+                <span className="min-w-0 break-all font-mono leading-5">{eventType}</span>
+              </label>
+            ))
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -969,6 +1134,10 @@ function getElementTypes(
   return [...new Set(elements.map((element) => element.type))].sort();
 }
 
+function getEventTypes(events: readonly Event[]): string[] {
+  return [...new Set(events.map((event) => event.type))].sort();
+}
+
 function filterElementsByElementType({
   elements,
   hiddenElementTypes,
@@ -982,4 +1151,100 @@ function filterElementsByElementType({
 
   const hiddenElementTypeSet = new Set(hiddenElementTypes);
   return elements.filter((element) => !hiddenElementTypeSet.has(element.type));
+}
+
+function filterElementsByJsonataExpression({
+  elements,
+  expression,
+}: {
+  elements: readonly EventsStreamBuiltInElement[];
+  expression: string;
+}): { elements: EventsStreamBuiltInElement[]; errorLabel?: string } {
+  const trimmedExpression = expression.trim();
+  if (trimmedExpression === "") {
+    return { elements: [...elements] };
+  }
+
+  try {
+    const compiled = jsonata(trimmedExpression);
+    const filteredElements: EventsStreamBuiltInElement[] = [];
+
+    for (const element of elements) {
+      if (element.type === "raw-json-dump") {
+        const filteredEvents = element.props.events.filter((event) =>
+          Boolean(compiled.evaluate(event)),
+        );
+        if (filteredEvents.length > 0) {
+          filteredElements.push({
+            ...element,
+            props: { ...element.props, events: filteredEvents },
+          });
+        }
+        continue;
+      }
+
+      const rawEvents = getElementRawEvents(element);
+      if (rawEvents.length > 0 && rawEvents.some((event) => Boolean(compiled.evaluate(event)))) {
+        filteredElements.push(element);
+      }
+    }
+
+    return { elements: filteredElements };
+  } catch (error) {
+    return {
+      elements: [...elements],
+      errorLabel: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function getElementRawEvents(element: EventsStreamBuiltInElement): readonly Event[] {
+  if (element.type === "grouped-raw-event") {
+    return element.props.events.map((event) => event.raw);
+  }
+
+  if ("raw" in element.props) {
+    return [element.props.raw];
+  }
+
+  return [];
+}
+
+function appendEventTypeFilterClause(expression: string, eventType: string) {
+  if (expressionIncludesEventTypeClause(expression, eventType)) {
+    return expression;
+  }
+
+  const trimmedExpression = expression.trim();
+  const clause = eventTypeFilterClause(eventType);
+  return trimmedExpression === "" ? clause : `${trimmedExpression}\nor ${clause}`;
+}
+
+function removeEventTypeFilterClause(expression: string, eventType: string) {
+  const clause = eventTypeFilterClause(eventType);
+  const lines = expression.split(/\r?\n/).filter((line) => {
+    const trimmedLine = line.trim();
+    return trimmedLine !== clause && trimmedLine !== `or ${clause}`;
+  });
+
+  if (lines[0]?.trim().startsWith("or ")) {
+    lines[0] = lines[0].replace(/^(\s*)or\s+/, "$1");
+  }
+
+  return lines.join("\n").trim();
+}
+
+function expressionIncludesEventTypeClause(expression: string, eventType: string) {
+  const clause = eventTypeFilterClause(eventType);
+  return expression
+    .split(/\r?\n/)
+    .some((line) => line.trim() === clause || line.trim() === `or ${clause}`);
+}
+
+function eventTypeFilterClause(eventType: string) {
+  if (!eventType.includes("'") && !eventType.includes("\\")) {
+    return `type = '${eventType}'`;
+  }
+
+  return `type = ${JSON.stringify(eventType)}`;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2390,6 +2390,9 @@ importers:
       '@iterate-com/shared':
         specifier: workspace:*
         version: link:../shared
+      '@mmkal/jsonata':
+        specifier: ^2.2.1
+        version: 2.2.1
       '@tailwindcss/postcss':
         specifier: ^4.1.17
         version: 4.2.1


### PR DESCRIPTION
## Summary

New OS2 agent streams now default to a timestamped path instead of the shared `/agents/assistant` path.

```ts
// Before every new-agent form opened with this value:
"/agents/assistant"

// Now each form initializes with a value like:
`/agents/assistant_${Date.now()}`
```

This also fixes the post-create transition by navigating with the exact agent path used for `appendBatch`, and by removing an unused `runtimeState` preload from the agent detail route loader so a just-created agent stream can open immediately.

The stream feed filter used by OS2 now accepts a JSONata expression evaluated against each event. Event-type checkboxes append/remove clauses like:

```jsonata
type = 'events.iterate.com/agent/input-added'
or type = 'events.iterate.com/agent/output-added'
```

Iterate event type labels in the compact pretty view now keep the slash after the favicon mark, so `events.iterate.com/foo/bar` renders as `[i]/foo/bar` instead of `[i]foo/bar`.

## Verification

- `pnpm exec oxfmt --check 'packages/ui/src/components/events/stream-feed.tsx' 'packages/ui/src/components/events/stream-event-type.tsx' 'apps/os2/src/components/project-stream-view.tsx' 'apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx' 'apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$.tsx'`
- `pnpm exec oxlint 'packages/ui/src/components/events/stream-feed.tsx' 'packages/ui/src/components/events/stream-event-type.tsx' 'apps/os2/src/components/project-stream-view.tsx' 'apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx' 'apps/os2/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$.tsx' --deny-warnings`
- `pnpm --filter @iterate-com/ui typecheck`
- `git diff --check`

Attempted `pnpm --filter os2 --if-present typecheck`, but it currently fails outside this change because `@opentui/*` and `@cloudflare/worker-bundler` are unresolved and existing TUI JSX types do not typecheck.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes agent stream creation/navigation behavior and introduces a new JSONata-based feed filtering path that evaluates user-provided expressions against events.
> 
> **Overview**
> New agent streams now default to a unique timestamped path (instead of shared `/agents/assistant`), and post-create navigation uses the exact path used during `appendBatch` to avoid mismatches.
> 
> OS2’s stream view swaps the old element-type hide/show state for a JSONata `feedFilterExpression`, and the UI package adds a JSONata-powered filter popover (with event-type checkboxes that append/remove `type = ...` clauses) plus a dependency on `@mmkal/jsonata`.
> 
> The agent stream detail route loader no longer preloads `runtimeState`, and Iterate-owned event type labels now include a leading `/` after the Iterate mark for consistent rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a63bb785094bebfa1928cb3858420cc0593c7ab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->