### PR TITLE
identifiers.md

### DIFF
--- a/docs/identifiers.md
+++ b/docs/identifiers.md
@@ -1,0 +1,6 @@
+slug: subdomain-safe
+id: typeid, always with prefix
+key: arbitrary string that uniquely identifies a value
+path: url-style path (with leading /)
+
+name in *general* is a user-facing string, a display name. Durable Objects are an exception and we should to call them durableObjectName so we don't confuse ourselves. Our DO names will often be composed of an id, and some other idenifiers. Or, often better, generate a typeid for the durable object name, and store it in an external record (e.g. D1 or a parent DO).

--- a/docs/identifiers.md
+++ b/docs/identifiers.md
@@ -3,4 +3,4 @@ id: typeid, always with prefix
 key: arbitrary string that uniquely identifies a value
 path: url-style path (with leading /)
 
-name in *general* is a user-facing string, a display name. Durable Objects are an exception and we should to call them durableObjectName so we don't confuse ourselves. Our DO names will often be composed of an id, and some other idenifiers. Or, often better, generate a typeid for the durable object name, and store it in an external record (e.g. D1 or a parent DO).
+name in _general_ is a user-facing string, a display name. Durable Objects are an exception and we should to call them durableObjectName so we don't confuse ourselves. Our DO names will often be composed of an id, and some other idenifiers. Or, often better, generate a typeid for the durable object name, and store it in an external record (e.g. D1 or a parent DO).


### PR DESCRIPTION
Add documentation for identifiers used in Durable Objects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change introducing naming/identifier conventions; no runtime code paths affected.
> 
> **Overview**
> Adds `docs/identifiers.md` to define common identifier terms (`slug`, `id`, `key`, `path`) and to clarify that Durable Objects should use `durableObjectName` (often derived from IDs/typeids) to avoid confusion with user-facing display names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c684386f9c63a4635a3c325f6f2941e6447313e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->