### PR TITLE
slightly higher-level test abstractions

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -117,6 +117,19 @@
     "iterate/no-implied-eval": "error",
     "prefer-const": "off",
     "iterate/prefer-const": "error",
+    "unicorn-js/isolated-functions": [
+      "error",
+      {
+        "selectors": [
+          "CallExpression[callee.property.name=/CodemodeScript/] ArrowFunctionExpression",
+          "CallExpression[callee.property.name=/CodemodeScript/] FunctionExpression"
+        ],
+        "overrideGlobals": {
+          "fetch": "readonly",
+          "console": "readonly"
+        }
+      }
+    ],
     "unicorn-js/template-indent": "warn"
   },
   "overrides": [

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -120,10 +120,7 @@
     "unicorn-js/isolated-functions": [
       "error",
       {
-        "selectors": [
-          "CallExpression[callee.property.name=/CodemodeScript/] ArrowFunctionExpression",
-          "CallExpression[callee.property.name=/CodemodeScript/] FunctionExpression"
-        ],
+        "selectors": ["CallExpression[callee.property.name=/CodemodeScript/] :function"],
         "overrideGlobals": {
           "fetch": "readonly",
           "console": "readonly"

--- a/apps/os2/e2e/test-support/create-test-project.ts
+++ b/apps/os2/e2e/test-support/create-test-project.ts
@@ -23,60 +23,70 @@ export interface TestProjectHandle extends AsyncDisposable {
 export async function createFixture(params?: Parameters<typeof createTestProject>[0]) {
   const project = await createTestProject(params);
   const fixture = project;
-  return {
-    ...project,
-    startCodemodeScript: async <T>(
-      fn: (ctx: {}) => T | Promise<T>,
-      options?: Partial<Omit<typeof project.client.project.codemode.executeScript, "code">>,
-    ) => {
-      let code = fn.toString();
-      if (!code.startsWith("async")) {
-        code = `async ${code}`;
-      }
-      const started = await project.client.project.codemode.executeScript({
-        code,
-        projectSlugOrId: project.project.id,
-        providers: [],
-        ...options,
-      });
-      const startedPayload = started.event.payload as { scriptExecutionId: string };
-      const predicate = (event: GenericEvent) =>
+  const startCodemodeScript = async <T>(
+    fn: (ctx: {}) => T | Promise<T>,
+    options?: Partial<Omit<typeof project.client.project.codemode.executeScript, "code">>,
+  ) => {
+    let code = fn.toString();
+    if (!code.startsWith("async")) {
+      code = `async ${code}`;
+    }
+    const started = await project.client.project.codemode.executeScript({
+      code,
+      projectSlugOrId: project.project.id,
+      providers: [],
+      ...options,
+    });
+
+    return {
+      ...started,
+      $type: {} as T,
+    };
+  };
+
+  const executeCodemodeScript = async <T>(
+    fn: (ctx: {}) => T | Promise<T>,
+    options?: Partial<Omit<typeof project.client.project.codemode.executeScript, "code">>,
+  ) => {
+    const started = await startCodemodeScript(fn, options);
+    const startedPayload = started.event.payload as { scriptExecutionId: string };
+
+    const events = await readProjectStreamUntil({
+      afterOffset: started.event.offset > 1 ? started.event.offset - 1 : "start",
+      client: fixture.client,
+      projectSlugOrId: fixture.project.id,
+      streamPath: started.streamPath,
+      // todo: proper strongly-typed version of this read-until helper
+      predicate: (event): event is typeof event =>
         event.type === "events.iterate.com/codemode/script-execution-completed" &&
         (event.payload as ReceiveFunctionCallResultInput).scriptExecutionId ===
-          startedPayload.scriptExecutionId;
-      return {
-        ...started,
-        $type: {} as T,
-        awaitCompleted: async () => {
-          const events = await readProjectStreamUntil({
-            afterOffset: started.event.offset > 1 ? started.event.offset - 1 : "start",
-            client: fixture.client,
-            projectSlugOrId: fixture.project.id,
-            streamPath: started.streamPath,
-            predicate,
-          });
-          const completed = events.at(-1)!;
-          const payload = completed.payload as ReceiveFunctionCallResultInput;
-          return {
-            payload,
-            event: completed as Omit<typeof completed, "payload"> & { payload: T },
-            events,
-            /** get a snapshot-friendly copy of the completed event payload. optionally pass in key-value pairs to replace in the whole payload */
-            snapshot: (swaps: Record<string, string> = {}) => {
-              let json = JSON.stringify(completed.payload);
-              for (const [key, value] of Object.entries(swaps)) {
-                json = json.replaceAll(value, `<${key}>`);
-              }
-              const snapshottable = JSON.parse(json) as typeof payload;
-              snapshottable.durationMs = 999;
-              snapshottable.scriptExecutionId = "<script-execution-id>";
-              snapshottable.functionCallId = "<function-call-id>";
-              return snapshottable;
-            },
-          };
-        },
-      };
-    },
+          startedPayload.scriptExecutionId,
+    });
+    const completed = events.at(-1)!;
+    const payload = completed.payload as ReceiveFunctionCallResultInput;
+    return {
+      $type: {} as T,
+      payload,
+      event: completed as Omit<typeof completed, "payload"> & { payload: T },
+      events,
+      /** get a snapshot-friendly copy of the completed event payload. optionally pass in key-value pairs to replace in the whole payload */
+      snapshot: (swaps: Record<string, string> = {}) => {
+        let json = JSON.stringify(completed.payload);
+        for (const [key, value] of Object.entries(swaps)) {
+          json = json.replaceAll(value, `<${key}>`);
+        }
+        const snapshottable = JSON.parse(json) as typeof payload;
+        snapshottable.durationMs = 999;
+        snapshottable.scriptExecutionId = "<script-execution-id>";
+        snapshottable.functionCallId = "<function-call-id>";
+        return snapshottable;
+      },
+    };
+  };
+  return {
+    ...project,
+    startCodemodeScript,
+    executeCodemodeScript,
   };
 }
 

--- a/apps/os2/e2e/test-support/create-test-project.ts
+++ b/apps/os2/e2e/test-support/create-test-project.ts
@@ -1,4 +1,3 @@
-import type { GenericEvent } from "@iterate-com/shared/streams/types";
 import type { ReceiveFunctionCallResultInput } from "../../src/domains/codemode/durable-objects/codemode-session.ts";
 import {
   createAdminOs2Client,

--- a/apps/os2/e2e/test-support/create-test-project.ts
+++ b/apps/os2/e2e/test-support/create-test-project.ts
@@ -1,5 +1,5 @@
-import type { ReceiveFunctionCallResultInput } from "../../src/domains/codemode/durable-objects/codemode-session.ts";
 import type { Event } from "@iterate-com/shared/streams/types";
+import type { ReceiveFunctionCallResultInput } from "../../src/domains/codemode/durable-objects/codemode-session.ts";
 import {
   createAdminOs2Client,
   requireBaseUrl,
@@ -24,8 +24,9 @@ export async function createFixture(params?: Parameters<typeof createTestProject
   const project = await createTestProject(params);
   const fixture = project;
   const startCodemodeScript = async <T>(
-    fn: (ctx: {}) => T | Promise<T>,
-    options?: Partial<Omit<typeof project.client.project.codemode.executeScript, "code">>,
+    fn: (ctx: {}) => Promise<T>,
+    // prettier-ignore
+    opts?: Partial<Omit<Parameters<Awaited<ReturnType<typeof createTestProject>>["client"]["project"]["codemode"]["executeScript"]>[0],"code">>,
   ) => {
     let code = fn.toString();
     if (!code.startsWith("async")) {
@@ -35,7 +36,7 @@ export async function createFixture(params?: Parameters<typeof createTestProject
       code,
       projectSlugOrId: project.project.id,
       providers: [],
-      ...options,
+      ...opts,
     });
 
     return {
@@ -44,11 +45,8 @@ export async function createFixture(params?: Parameters<typeof createTestProject
     };
   };
 
-  const executeCodemodeScript = async <T>(
-    fn: (ctx: {}) => T | Promise<T>,
-    options?: Partial<Omit<typeof project.client.project.codemode.executeScript, "code">>,
-  ) => {
-    const started = await startCodemodeScript(fn, options);
+  const executeCodemodeScript = async <T>(...args: Parameters<typeof startCodemodeScript<T>>) => {
+    const started = await startCodemodeScript(...args);
     const startedPayload = started.event.payload as { scriptExecutionId: string };
     const isCompletedScriptExecution = (
       event: Event,

--- a/apps/os2/e2e/test-support/create-test-project.ts
+++ b/apps/os2/e2e/test-support/create-test-project.ts
@@ -1,5 +1,5 @@
-import type { ReceiveFunctionCallResultInput } from "../../src/domains/codemode/durable-objects/codemode-session.ts";
 import type { Event } from "@iterate-com/shared/streams/types";
+import type { ReceiveFunctionCallResultInput } from "../../src/domains/codemode/durable-objects/codemode-session.ts";
 import {
   createAdminOs2Client,
   requireBaseUrl,

--- a/apps/os2/e2e/test-support/create-test-project.ts
+++ b/apps/os2/e2e/test-support/create-test-project.ts
@@ -1,8 +1,11 @@
+import type { GenericEvent } from "@iterate-com/shared/streams/types";
+import type { ReceiveFunctionCallResultInput } from "../../src/domains/codemode/durable-objects/codemode-session.ts";
 import {
   createAdminOs2Client,
   requireBaseUrl,
   type Os2Client,
   uniqueSuffix,
+  readProjectStreamUntil,
 } from "./os2-client.ts";
 
 type TestProject = Awaited<ReturnType<Os2Client["projects"]["create"]>>;
@@ -15,6 +18,66 @@ export interface TestProjectHandle extends AsyncDisposable {
     customHostname?: string | null;
     externalEgressProxyUrl?: string | null;
   }): Promise<TestProject>;
+}
+
+export async function createFixture(params?: Parameters<typeof createTestProject>[0]) {
+  const project = await createTestProject(params);
+  const fixture = project;
+  return {
+    ...project,
+    startCodemodeScript: async <T>(
+      fn: (ctx: {}) => T | Promise<T>,
+      options?: Partial<Omit<typeof project.client.project.codemode.executeScript, "code">>,
+    ) => {
+      let code = fn.toString();
+      if (!code.startsWith("async")) {
+        code = `async ${code}`;
+      }
+      const started = await project.client.project.codemode.executeScript({
+        code,
+        projectSlugOrId: project.project.id,
+        providers: [],
+        ...options,
+      });
+      const startedPayload = started.event.payload as { scriptExecutionId: string };
+      const predicate = (event: GenericEvent) =>
+        event.type === "events.iterate.com/codemode/script-execution-completed" &&
+        (event.payload as ReceiveFunctionCallResultInput).scriptExecutionId ===
+          startedPayload.scriptExecutionId;
+      return {
+        ...started,
+        $type: {} as T,
+        awaitCompleted: async () => {
+          const events = await readProjectStreamUntil({
+            afterOffset: started.event.offset > 1 ? started.event.offset - 1 : "start",
+            client: fixture.client,
+            projectSlugOrId: fixture.project.id,
+            streamPath: started.streamPath,
+            predicate,
+          });
+          const completed = events.at(-1)!;
+          const payload = completed.payload as ReceiveFunctionCallResultInput;
+          return {
+            payload,
+            event: completed as Omit<typeof completed, "payload"> & { payload: T },
+            events,
+            /** get a snapshot-friendly copy of the completed event payload. optionally pass in key-value pairs to replace in the whole payload */
+            snapshot: (swaps: Record<string, string> = {}) => {
+              let json = JSON.stringify(completed.payload);
+              for (const [key, value] of Object.entries(swaps)) {
+                json = json.replaceAll(value, `<${key}>`);
+              }
+              const snapshottable = JSON.parse(json) as typeof payload;
+              snapshottable.durationMs = 999;
+              snapshottable.scriptExecutionId = "<script-execution-id>";
+              snapshottable.functionCallId = "<function-call-id>";
+              return snapshottable;
+            },
+          };
+        },
+      };
+    },
+  };
 }
 
 export async function createTestProject(opts?: {

--- a/apps/os2/e2e/test-support/create-test-project.ts
+++ b/apps/os2/e2e/test-support/create-test-project.ts
@@ -1,4 +1,5 @@
 import type { ReceiveFunctionCallResultInput } from "../../src/domains/codemode/durable-objects/codemode-session.ts";
+import type { Event } from "@iterate-com/shared/streams/types";
 import {
   createAdminOs2Client,
   requireBaseUrl,
@@ -49,6 +50,12 @@ export async function createFixture(params?: Parameters<typeof createTestProject
   ) => {
     const started = await startCodemodeScript(fn, options);
     const startedPayload = started.event.payload as { scriptExecutionId: string };
+    const isCompletedScriptExecution = (
+      event: Event,
+    ): event is Event & { payload: ReceiveFunctionCallResultInput } =>
+      event.type === "events.iterate.com/codemode/script-execution-completed" &&
+      (event.payload as ReceiveFunctionCallResultInput).scriptExecutionId ===
+        startedPayload.scriptExecutionId;
 
     const events = await readProjectStreamUntil({
       afterOffset: started.event.offset > 1 ? started.event.offset - 1 : "start",
@@ -56,13 +63,15 @@ export async function createFixture(params?: Parameters<typeof createTestProject
       projectSlugOrId: fixture.project.id,
       streamPath: started.streamPath,
       // todo: proper strongly-typed version of this read-until helper
-      predicate: (event): event is typeof event =>
-        event.type === "events.iterate.com/codemode/script-execution-completed" &&
-        (event.payload as ReceiveFunctionCallResultInput).scriptExecutionId ===
-          startedPayload.scriptExecutionId,
+      predicate: isCompletedScriptExecution,
     });
-    const completed = events.at(-1)!;
-    const payload = completed.payload as ReceiveFunctionCallResultInput;
+    const completed = events.find(isCompletedScriptExecution);
+    if (!completed) {
+      throw new Error(
+        `Expected completed script execution ${startedPayload.scriptExecutionId} in stream batch.`,
+      );
+    }
+    const payload = completed.payload;
     return {
       $type: {} as T,
       payload,

--- a/apps/os2/e2e/test-support/os2-client.ts
+++ b/apps/os2/e2e/test-support/os2-client.ts
@@ -122,7 +122,7 @@ export async function readProjectStreamUntil(input: {
   timeoutMs?: number;
 }) {
   const startedAt = Date.now();
-  const timeoutMs = input.timeoutMs ?? 60_000;
+  const timeoutMs = input.timeoutMs ?? 4_000;
   while (Date.now() - startedAt < timeoutMs) {
     const result = await input.client.project.streams.read({
       afterOffset: input.afterOffset,
@@ -139,7 +139,7 @@ export async function readProjectStreamUntil(input: {
     streamPath: input.streamPath,
   });
   throw new Error(
-    `Timed out waiting for project stream event. Saw: ${JSON.stringify(result.events)}`,
+    `Timed out waiting for project stream event matching ${input.predicate.toString()}. Saw: ${JSON.stringify(result.events, null, 2)}`,
   );
 }
 

--- a/apps/os2/e2e/test-support/os2-client.ts
+++ b/apps/os2/e2e/test-support/os2-client.ts
@@ -113,10 +113,10 @@ export async function createProject(client: Os2Client, slugPrefix: string) {
   });
 }
 
-export async function readProjectStreamUntil(input: {
+export async function readProjectStreamUntil<T extends Event>(input: {
   afterOffset: number | "start";
   client: Os2Client;
-  predicate(event: Event): boolean;
+  predicate: (event: Event) => event is T;
   projectSlugOrId: string;
   streamPath: string;
   timeoutMs?: number;

--- a/apps/os2/e2e/vitest/mock-internet.e2e.test.ts
+++ b/apps/os2/e2e/vitest/mock-internet.e2e.test.ts
@@ -1,12 +1,10 @@
 import { join } from "node:path";
 import { HttpResponse, http } from "@iterate-com/mock-http-proxy";
 import { useCloudflareTunnel, useCloudflareTunnelLease } from "@iterate-com/shared/test-helpers";
-import type { Event } from "@iterate-com/shared/streams/types";
-import { expect, test } from "vitest";
+import { expect, expectTypeOf, test } from "vitest";
 import { createMockInternet } from "../test-support/create-mock-internet.ts";
-import { createTestProject } from "../test-support/create-test-project.ts";
+import { createFixture } from "../test-support/create-test-project.ts";
 import { setupE2E } from "../test-support/e2e-test.ts";
-import { readProjectStreamUntil } from "../test-support/os2-client.ts";
 
 const hasAdminApiTarget =
   !!(process.env.OS2_BASE_URL?.trim() || process.env.APP_CONFIG_BASE_URL?.trim()) &&
@@ -51,70 +49,48 @@ testIfAdminApiTarget("runs codemode fetch through a mocked project egress proxy"
     publicUrl: tunnelLease.publicUrl,
   });
 
-  await using project = await createTestProject({
+  await using fixture = await createFixture({
     externalEgressProxyUrl: tunnel.publicUrl,
     slugPrefix: "mock-internet",
   });
 
-  const started = await project.client.project.codemode.executeScript({
-    code: `async () => {
-  const response = await fetch("https://example.com/os2-e2e?source=codemode");
-  return {
-    body: await response.json(),
-    mockedHeader: response.headers.get("x-e2e-mocked"),
-    status: response.status
-  };
-}`,
-    projectSlugOrId: project.project.id,
-    providers: [],
+  const script = await fixture.startCodemodeScript(async () => {
+    const response = await fetch("https://example.com/os2-e2e?source=codemode");
+    return {
+      body: (await response.json()) as { mocked: boolean; query: string; runSlug: string },
+      mockedHeader: response.headers.get("x-e2e-mocked"),
+      status: response.status,
+    };
   });
 
-  const scriptExecutionId = readScriptExecutionId(started.event);
-
-  const events = await readProjectStreamUntil({
-    afterOffset: started.event.offset > 1 ? started.event.offset - 1 : "start",
-    client: project.client,
-    projectSlugOrId: project.project.id,
-    streamPath: started.streamPath,
-    predicate: (event) =>
-      event.type === "events.iterate.com/codemode/script-execution-completed" &&
-      readPayloadRecord(event).scriptExecutionId === scriptExecutionId,
-  });
-  const completed = requiredEvent(events, "events.iterate.com/codemode/script-execution-completed");
+  const completed = await script.awaitCompleted();
 
   const har = internet.getHar();
 
-  expect(completed.payload).toMatchInlineSnapshot(
+  expectTypeOf(completed.payload).toExtend<{
+    functionCallId: string;
+    durationMs?: number;
+    scriptExecutionId?: string;
+  }>();
+  expect(completed.snapshot({ runSlug: e2e.runSlug })).toMatchInlineSnapshot(`
     {
-      durationMs: expect.any(Number),
-      scriptExecutionId: expect.any(String),
-      outcome: {
-        value: {
-          body: {
-            runSlug: expect.any(String),
-          },
-        },
-      },
-    },
-    `
-    {
-      "durationMs": Any<Number>,
+      "durationMs": 999,
+      "functionCallId": "<function-call-id>",
       "outcome": {
         "status": "returned",
         "value": {
           "body": {
             "mocked": true,
             "query": "codemode",
-            "runSlug": Any<String>,
+            "runSlug": "<runSlug>",
           },
           "mockedHeader": "yes",
           "status": 200,
         },
       },
-      "scriptExecutionId": Any<String>,
+      "scriptExecutionId": "<script-execution-id>",
     }
-  `,
-  );
+  `);
 
   expect(completed.payload).toMatchObject({
     outcome: {
@@ -129,9 +105,9 @@ testIfAdminApiTarget("runs codemode fetch through a mocked project egress proxy"
         status: 200,
       },
     },
-    scriptExecutionId,
+    scriptExecutionId: completed.payload.scriptExecutionId,
   });
-  expect(events).toContainEqual(
+  expect(completed.events).toContainEqual(
     expect.objectContaining({
       type: "events.iterate.com/codemode/function-call-completed",
       payload: expect.objectContaining({
@@ -139,9 +115,9 @@ testIfAdminApiTarget("runs codemode fetch through a mocked project egress proxy"
       }),
     }),
   );
-  expect(events.filter((event) => event.type === "events.iterate.com/core/error-occurred")).toEqual(
-    [],
-  );
+  expect(
+    completed.events.filter((event) => event.type === "events.iterate.com/core/error-occurred"),
+  ).toEqual([]);
   expect(
     har.log.entries
       .filter(
@@ -150,23 +126,3 @@ testIfAdminApiTarget("runs codemode fetch through a mocked project egress proxy"
       .map((entry) => entry.request.url),
   ).toContain("https://example.com/os2-e2e?source=codemode");
 });
-
-function readScriptExecutionId(event: Event) {
-  const scriptExecutionId = readPayloadRecord(event).scriptExecutionId;
-  if (typeof scriptExecutionId !== "string") {
-    throw new Error("Expected codemode script execution event to include scriptExecutionId.");
-  }
-  return scriptExecutionId;
-}
-
-function requiredEvent(events: readonly Event[], type: string) {
-  const event = events.find((item) => item.type === type);
-  if (!event) throw new Error(`Expected ${type}.`);
-  return event;
-}
-
-function readPayloadRecord(event: Event) {
-  return event.payload != null && typeof event.payload === "object"
-    ? (event.payload as Record<string, unknown>)
-    : {};
-}

--- a/apps/os2/e2e/vitest/mock-internet.e2e.test.ts
+++ b/apps/os2/e2e/vitest/mock-internet.e2e.test.ts
@@ -54,7 +54,7 @@ testIfAdminApiTarget("runs codemode fetch through a mocked project egress proxy"
     slugPrefix: "mock-internet",
   });
 
-  const completed = await fixture.executeCodemodeScript(async () => {
+  const completed = await fixture.executeCodemodeScript(async function () {
     const response = await fetch("https://example.com/os2-e2e?source=codemode");
     return {
       body: (await response.json()) as { mocked: boolean; query: string; runSlug: string },

--- a/apps/os2/e2e/vitest/mock-internet.e2e.test.ts
+++ b/apps/os2/e2e/vitest/mock-internet.e2e.test.ts
@@ -54,7 +54,7 @@ testIfAdminApiTarget("runs codemode fetch through a mocked project egress proxy"
     slugPrefix: "mock-internet",
   });
 
-  const script = await fixture.startCodemodeScript(async () => {
+  const completed = await fixture.executeCodemodeScript(async () => {
     const response = await fetch("https://example.com/os2-e2e?source=codemode");
     return {
       body: (await response.json()) as { mocked: boolean; query: string; runSlug: string },
@@ -62,8 +62,6 @@ testIfAdminApiTarget("runs codemode fetch through a mocked project egress proxy"
       status: response.status,
     };
   });
-
-  const completed = await script.awaitCompleted();
 
   const har = internet.getHar();
 


### PR DESCRIPTION
todo

- [x] unicorn/isolated-functions lint rule
<img width="590" height="281" alt="image" src="https://github.com/user-attachments/assets/fcb447b2-55e4-4461-b1b8-2492ce7ace51" />

- [x] executeCodemodeScript(...)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os2": {
      "appDisplayName": "OS",
      "appSlug": "os2",
      "status": "released",
      "updatedAt": "2026-05-18T10:31:21.505Z",
      "headSha": "d1ca60b4365413d164e8e662c4a8263eaba3ea09",
      "message": "Preview app released.",
      "publicUrl": "https://os2.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26027268313",
      "shortSha": "d1ca60b"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `d1ca60b`
Preview: https://os2.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/26027268313)
Updated: 2026-05-18T10:31:21.505Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes e2e test infrastructure semantics (new fixture abstraction and shorter `readProjectStreamUntil` timeout), which could introduce flakiness or hide timing issues in CI.
> 
> **Overview**
> Introduces a new `createFixture()` e2e helper that wraps `createTestProject()` with `startCodemodeScript`/`executeCodemodeScript`, including typed completion-event waiting and a `snapshot()` helper to make Codemode execution results stable for inline snapshots.
> 
> Updates `readProjectStreamUntil` to be predicate-typeguard generic, reduces the default timeout (60s -> 4s), and improves timeout error output. Refactors `mock-internet.e2e.test.ts` to use the new fixture + snapshot helper and removes bespoke stream/event parsing. Also adds an `oxlint` `unicorn-js/isolated-functions` rule targeting `*CodemodeScript*` callsites with readonly `fetch`/`console` globals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1ca60b4365413d164e8e662c4a8263eaba3ea09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->