### PR TITLE
[codex] Fix Cloudflare preview deployment wiring

### DIFF
--- a/apps/os/e2e/preview-smoke.ts
+++ b/apps/os/e2e/preview-smoke.ts
@@ -33,14 +33,59 @@ type Project = {
 };
 
 async function expectStatus(input: { method?: string; status: number; url: URL }) {
-  const response = await fetch(input.url, {
-    method: input.method ?? "GET",
-    redirect: "manual",
+  const response = await fetchWithTransientRetry({
+    init: {
+      method: input.method ?? "GET",
+      redirect: "manual",
+    },
+    url: input.url,
   });
   if (response.status !== input.status) {
     throw new Error(`Expected ${input.status} from ${input.url}; received ${response.status}.`);
   }
   return response;
+}
+
+async function fetchWithTransientRetry(input: {
+  attempts?: number;
+  init?: RequestInit;
+  retryDelayMs?: number;
+  url: URL;
+}) {
+  const attempts = input.attempts ?? 6;
+  const retryDelayMs = input.retryDelayMs ?? 5_000;
+  let lastResponse: Response | null = null;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const response = await fetch(input.url, {
+      ...input.init,
+      redirect: input.init?.redirect ?? "manual",
+    });
+    lastResponse = response;
+    if (![502, 503, 504].includes(response.status) || attempt === attempts) {
+      return response;
+    }
+
+    response.body?.cancel().catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+  }
+
+  if (lastResponse) return lastResponse;
+  throw new Error(`No response received from ${input.url}`);
+}
+
+async function expectOkText(input: { headers?: HeadersInit; url: URL }) {
+  const response = await fetchWithTransientRetry({
+    init: {
+      headers: input.headers,
+      redirect: "manual",
+    },
+    url: input.url,
+  });
+  if (!response.ok) {
+    throw new Error(`Expected ok response from ${input.url}; received ${response.status}.`);
+  }
+  return await response.text();
 }
 
 async function fetchProjectBySlug(input: { adminApiSecret: string; baseUrl: URL; slug: string }) {
@@ -139,16 +184,10 @@ if (!projectMcpUrl) {
   process.exit(0);
 }
 
-const instructionsResponse = await fetch(projectMcpUrl, {
+const instructionsHtml = await expectOkText({
   headers: { accept: "text/html" },
-  redirect: "manual",
+  url: projectMcpUrl,
 });
-if (!instructionsResponse.ok) {
-  throw new Error(
-    `Expected MCP instructions page from ${projectMcpUrl}; received ${instructionsResponse.status}.`,
-  );
-}
-const instructionsHtml = await instructionsResponse.text();
 if (!instructionsHtml.includes("Connect an MCP client to this project endpoint")) {
   throw new Error(`MCP instructions page did not contain setup text: ${instructionsHtml}`);
 }

--- a/docs/cloudflare-preview-environments.md
+++ b/docs/cloudflare-preview-environments.md
@@ -54,11 +54,12 @@ Semaphore database exactly match that seed for `environment-config-lease`, so
 review the live rows with `preview status` / `preview reconcile` before and
 after using it.
 
-As of 2026-05-05, `preview reconcile` against production Semaphore returned
-eight healthy resources:
+As of 2026-05-18, `preview reconcile` against production Semaphore returned
+nine healthy resources:
 
 | Semaphore slug | Doppler config | Cloudflare zones checked                         |
 | -------------- | -------------- | ------------------------------------------------ |
+| `preview-1`    | `preview_1`    | `iterate-preview-1.com`, `iterate-preview-1.app` |
 | `preview-2`    | `preview_2`    | `iterate-preview-2.com`, `iterate-preview-2.app` |
 | `preview-3`    | `preview_3`    | `iterate-preview-3.com`, `iterate-preview-3.app` |
 | `preview-4`    | `preview_4`    | `iterate-preview-4.com`, `iterate-preview-4.app` |
@@ -114,7 +115,7 @@ Do not paste the token into scripts or docs.
   `environment-config-lease` row against the preview-managed Doppler projects
   and the Cloudflare zone pair for that slot, such as
   `iterate-preview-N.com` / `iterate-preview-N.app`.
-- The current source-code seed contains `preview_2` through `preview_9`. Treat
+- The current source-code seed contains `preview_1` through `preview_9`. Treat
   it as a recreate script input, not as runtime deploy state.
 - The seed is exact for `environment-config-lease`: drifted resources are
   deleted and missing resources are recreated with the source-code data.
@@ -125,7 +126,7 @@ Do not paste the token into scripts or docs.
 - Preview app configs inherit Cloudflare credentials from `_shared/preview`.
   Do not set app-local `CLOUDFLARE_ACCOUNT_ID` or `CLOUDFLARE_API_TOKEN`
   overrides; the preview domain pairs live in account
-  `376ef7ed81b0573f93524de763666c15`.
+  `cc7f6f461fbe823c199da2b27f9e0ff3`.
 - If two apps are affected by a PR, or one affected app has an explicit deploy
   dependency, they are deployed together under the same environment config
   lease. If one selected app fails, the overall preview is unhealthy and the

--- a/docs/os-environments.md
+++ b/docs/os-environments.md
@@ -34,7 +34,7 @@ the active app config. App configs must not define local
 The current account split is:
 
 - `_shared/dev`, `_shared/dev_*`, and `_shared/prd` use account `04b3b57291ef2626c6a8daa9d47065a7`
-- `_shared/preview` uses account `376ef7ed81b0573f93524de763666c15`
+- `_shared/preview` uses account `cc7f6f461fbe823c199da2b27f9e0ff3`
 
 The API token (`cfut_...` user token) must have:
 
@@ -104,10 +104,10 @@ Vite picks a free port automatically (defaults to 5173, increments if taken). Th
 ## Preview environments
 
 Preview environments use a shared Semaphore-controlled environment config lease inventory. The
-current inventory is `preview-2` through `preview-9`, each with
-`data.dopplerConfig` pointing at `preview_2` through `preview_9`. `preview_1`
-and `preview_10` are not leased because their os domain pairs are not fully
-configured in the right Cloudflare account.
+current inventory is `preview-1` through `preview-9`, each with
+`data.dopplerConfig` pointing at `preview_1` through `preview_9`. `preview_10`
+is not leased because its os domain pair is not fully configured in the right
+Cloudflare account.
 
 ### How it works
 

--- a/packages/shared/src/alchemy/iterate-app.test.ts
+++ b/packages/shared/src/alchemy/iterate-app.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { selectBestCloudflareZoneForHostname } from "./iterate-app.ts";
+
+describe("selectBestCloudflareZoneForHostname", () => {
+  it("prefers an active delegated zone over a moved zone in the configured account", () => {
+    expect(
+      selectBestCloudflareZoneForHostname({
+        accountId: "preview-account",
+        hostname: "os.iterate-preview-2.com",
+        zones: [
+          {
+            account: { id: "preview-account" },
+            id: "moved-zone",
+            name: "iterate-preview-2.com",
+            status: "moved",
+          },
+          {
+            account: { id: "delegated-account" },
+            id: "active-zone",
+            name: "iterate-preview-2.com",
+            status: "active",
+          },
+        ],
+      })?.id,
+    ).toBe("active-zone");
+  });
+
+  it("still prefers an active zone in the configured account when one exists", () => {
+    expect(
+      selectBestCloudflareZoneForHostname({
+        accountId: "preview-account",
+        hostname: "*.iterate-preview-2.app",
+        zones: [
+          {
+            account: { id: "other-account" },
+            id: "other-active-zone",
+            name: "iterate-preview-2.app",
+            status: "active",
+          },
+          {
+            account: { id: "preview-account" },
+            id: "preview-active-zone",
+            name: "iterate-preview-2.app",
+            status: "active",
+          },
+        ],
+      })?.id,
+    ).toBe("preview-active-zone");
+  });
+});

--- a/packages/shared/src/alchemy/iterate-app.ts
+++ b/packages/shared/src/alchemy/iterate-app.ts
@@ -384,15 +384,9 @@ async function findActiveZoneForHostname(
   cloudflareApi: Awaited<ReturnType<typeof createCloudflareApi>>,
   hostname: string,
 ) {
-  const cleanHostname = hostname.replace(/^\*\./, "");
   let page = 1;
   let totalPages = 1;
-  const zones: Array<{
-    account?: { id?: string };
-    id: string;
-    name: string;
-    status?: string;
-  }> = [];
+  const zones: CloudflareZone[] = [];
 
   do {
     const response = await cloudflareApi.get(`/zones?per_page=50&page=${page}`);
@@ -414,16 +408,11 @@ async function findActiveZoneForHostname(
     page += 1;
   } while (page <= totalPages);
 
-  const matchingZones = zones
-    .filter((zone) => cleanHostname === zone.name || cleanHostname.endsWith(`.${zone.name}`))
-    .sort((a, b) => b.name.length - a.name.length);
-  const bestZone =
-    matchingZones.find(
-      (zone) => zone.account?.id === cloudflareApi.accountId && zone.status === "active",
-    ) ??
-    matchingZones.find((zone) => zone.account?.id === cloudflareApi.accountId) ??
-    matchingZones.find((zone) => zone.status === "active") ??
-    matchingZones[0];
+  const bestZone = selectBestCloudflareZoneForHostname({
+    accountId: cloudflareApi.accountId,
+    hostname,
+    zones,
+  });
 
   if (!bestZone) {
     throw new Error(
@@ -432,6 +421,33 @@ async function findActiveZoneForHostname(
   }
 
   return { zoneId: bestZone.id, zoneName: bestZone.name };
+}
+
+type CloudflareZone = {
+  account?: { id?: string };
+  id: string;
+  name: string;
+  status?: string;
+};
+
+export function selectBestCloudflareZoneForHostname(input: {
+  accountId: string;
+  hostname: string;
+  zones: CloudflareZone[];
+}) {
+  const cleanHostname = input.hostname.replace(/^\*\./, "");
+  const matchingZones = input.zones
+    .filter((zone) => cleanHostname === zone.name || cleanHostname.endsWith(`.${zone.name}`))
+    .sort((a, b) => b.name.length - a.name.length);
+
+  return (
+    matchingZones.find(
+      (zone) => zone.account?.id === input.accountId && zone.status === "active",
+    ) ??
+    matchingZones.find((zone) => zone.status === "active") ??
+    matchingZones.find((zone) => zone.account?.id === input.accountId) ??
+    matchingZones[0]
+  );
 }
 
 function withSequentialCloudflareAssetPreupload(input: { command: string; workerName: string }) {

--- a/scripts/preview/preview-inventory.test.ts
+++ b/scripts/preview/preview-inventory.test.ts
@@ -1,9 +1,26 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE,
+  environmentConfigLeaseInventory,
   parseEnvironmentConfigLeaseData,
   syncPreviewInventory,
 } from "./preview-inventory.ts";
+
+describe("environmentConfigLeaseInventory", () => {
+  it("matches the currently provisioned preview slot range", () => {
+    expect(environmentConfigLeaseInventory.map((resource) => resource.slug)).toEqual([
+      "preview-1",
+      "preview-2",
+      "preview-3",
+      "preview-4",
+      "preview-5",
+      "preview-6",
+      "preview-7",
+      "preview-8",
+      "preview-9",
+    ]);
+  });
+});
 
 describe("syncPreviewInventory", () => {
   it("adds missing shared environment config lease resources", async () => {

--- a/scripts/preview/preview-inventory.ts
+++ b/scripts/preview/preview-inventory.ts
@@ -12,7 +12,7 @@ export type EnvironmentConfigLeaseInventoryItem = {
 
 // This is the deliberate seed used when recreating the Semaphore inventory.
 // The live Semaphore database remains the source of truth for deploys.
-const seededPreviewEnvironmentNumbers = [2, 3, 4, 5, 6, 7, 8, 9] as const;
+const seededPreviewEnvironmentNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
 
 export const environmentConfigLeaseInventory = seededPreviewEnvironmentNumbers.map(
   (leaseNumber) => {

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   batchPreviewAppsByDependencies,
   expandPreviewDependencies,
+  resolvePreviewReadinessUrls,
   resolvePreviewCompareBaseSha,
   selectPreviewAppsNeedingRetry,
 } from "./preview.ts";
@@ -53,6 +54,17 @@ describe("preview workflow scope", () => {
       ".github/ts-workflows/workflows/cloudflare-previews.ts",
     );
     expect(cloudflarePreviewSharedPaths).toContain(".github/workflows/cloudflare-previews.yml");
+  });
+});
+
+describe("preview readiness URLs", () => {
+  it("checks the deployed app URL without probing synthetic project hostnames", () => {
+    expect(
+      resolvePreviewReadinessUrls({
+        publicUrl: "https://os.iterate-preview-2.com",
+        projectHostnameBases: ["iterate-preview-2.app", "*.iterate-preview-2.app"],
+      }).map((url) => url.toString()),
+    ).toEqual(["https://os.iterate-preview-2.com/api/__internal/health"]);
   });
 });
 

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -569,7 +569,6 @@ async function deployPreviewApp(input: {
   }
 
   const readiness = await waitForPreviewAppReadiness({
-    projectHostnameBases: appConfig.projectHostnameBases,
     publicUrl: appConfig.baseUrl,
     signal: input.signal,
     timeoutMs: defaultPreviewReadyTimeoutMs,
@@ -887,18 +886,13 @@ async function mapWithConcurrency<T, Result>(
 }
 
 async function waitForPreviewAppReadiness(params: {
-  projectHostnameBases: readonly string[];
   publicUrl: string;
   signal?: AbortSignal;
   timeoutMs: number;
 }) {
-  const urls = [
-    new URL(defaultPreviewReadyUrlPath, params.publicUrl),
-    ...params.projectHostnameBases.map(
-      (base) =>
-        new URL(defaultPreviewReadyUrlPath, `https://project.${normalizeHostnameBase(base)}`),
-    ),
-  ];
+  const urls = resolvePreviewReadinessUrls({
+    publicUrl: params.publicUrl,
+  });
 
   for (const url of urls) {
     const readiness = await waitForHttpReadiness({
@@ -912,8 +906,13 @@ async function waitForPreviewAppReadiness(params: {
   return { ok: true as const };
 }
 
-function normalizeHostnameBase(base: string) {
-  return base.trim().replace(/^\*\./, "");
+export function resolvePreviewReadinessUrls(params: {
+  projectHostnameBases?: readonly string[];
+  publicUrl: string;
+}) {
+  // Project hostname bases are routed by app data and wildcard DNS, so a
+  // synthetic host like project.<base> is not a reliable app-health signal.
+  return [new URL(defaultPreviewReadyUrlPath, params.publicUrl)];
 }
 
 async function waitForHttpReadiness(params: { signal?: AbortSignal; timeoutMs: number; url: URL }) {

--- a/scripts/preview/reconcile-environment-config-leases.test.ts
+++ b/scripts/preview/reconcile-environment-config-leases.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { reconcileEnvironmentConfigLeaseResources } from "./reconcile-environment-config-leases.ts";
+import {
+  evaluateCloudflareZoneCheck,
+  reconcileEnvironmentConfigLeaseResources,
+} from "./reconcile-environment-config-leases.ts";
 import { ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE } from "./preview-inventory.ts";
 
 describe("reconcileEnvironmentConfigLeaseResources", () => {
@@ -102,5 +105,48 @@ describe("reconcileEnvironmentConfigLeaseResources", () => {
         message: "iterate-preview-3.app: zone not found in Cloudflare account cf-account",
       },
     ]);
+  });
+});
+
+describe("evaluateCloudflareZoneCheck", () => {
+  it("rejects a moved same-account zone when DNS is delegated to a different active zone", () => {
+    expect(
+      evaluateCloudflareZoneCheck({
+        accountId: "preview-account",
+        domain: "iterate-preview-2.com",
+        zones: [
+          {
+            account: { id: "preview-account" },
+            name: "iterate-preview-2.com",
+            status: "moved",
+          },
+          {
+            account: { id: "delegated-account" },
+            name: "iterate-preview-2.com",
+            status: "active",
+          },
+        ],
+      }),
+    ).toEqual({
+      ok: false,
+      message:
+        "active zone belongs to Cloudflare account delegated-account, expected preview-account",
+    });
+  });
+
+  it("accepts an active zone in the expected account", () => {
+    expect(
+      evaluateCloudflareZoneCheck({
+        accountId: "preview-account",
+        domain: "iterate-preview-2.com",
+        zones: [
+          {
+            account: { id: "preview-account" },
+            name: "iterate-preview-2.com",
+            status: "active",
+          },
+        ],
+      }),
+    ).toEqual({ ok: true });
   });
 });

--- a/scripts/preview/reconcile-environment-config-leases.ts
+++ b/scripts/preview/reconcile-environment-config-leases.ts
@@ -84,6 +84,7 @@ const CloudflareZonesResponse = z
               })
               .passthrough()
               .optional(),
+            status: z.string().optional(),
           })
           .passthrough(),
       )
@@ -360,17 +361,54 @@ async function checkCloudflareZoneWithApi(input: {
     };
   }
 
-  const matchingZone = parsed.result.find(
-    (zone) => zone.name === input.domain && zone.account?.id === input.accountId,
-  );
-  if (matchingZone == null) {
+  return evaluateCloudflareZoneCheck({
+    accountId: input.accountId,
+    domain: input.domain,
+    zones: parsed.result,
+  });
+}
+
+export function evaluateCloudflareZoneCheck(input: {
+  accountId: string;
+  domain: string;
+  zones: Array<{
+    account?: { id?: string };
+    name: string;
+    status?: string;
+  }>;
+}): CheckResult {
+  const matchingZones = input.zones.filter((zone) => zone.name === input.domain);
+  const matchingActiveZone = matchingZones.find((zone) => zone.status === "active");
+  const matchingAccountZone = matchingZones.find((zone) => zone.account?.id === input.accountId);
+  if (matchingActiveZone?.account?.id === input.accountId) {
+    return { ok: true };
+  }
+
+  if (matchingActiveZone) {
+    return {
+      ok: false,
+      message: `active zone belongs to Cloudflare account ${matchingActiveZone.account?.id ?? "unknown"}, expected ${input.accountId}`,
+    };
+  }
+
+  if (matchingAccountZone) {
+    return {
+      ok: false,
+      message: `zone in Cloudflare account ${input.accountId} is ${matchingAccountZone.status ?? "not active"}`,
+    };
+  }
+
+  if (matchingZones.length === 0) {
     return {
       ok: false,
       message: `zone not found in Cloudflare account ${input.accountId}`,
     };
   }
 
-  return { ok: true };
+  return {
+    ok: false,
+    message: `zone exists but not in Cloudflare account ${input.accountId}`,
+  };
 }
 
 function commandFailureSummary(result: { stderr: string; stdout: string }) {


### PR DESCRIPTION
## Summary

- Fix Cloudflare zone selection so preview deploys prefer active delegated zones instead of moved same-account zones.
- Harden `preview reconcile` to report moved-zone/account drift and update the preview inventory/docs to `preview_1` through `preview_9`.
- Make OS preview smoke tolerate transient 502/503/504 responses from fresh MCP wildcard hostnames.
- Remove synthetic project-host readiness probes from the preview deployer.

## Root Cause

The preview-managed app Doppler configs had app-local `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN` overrides pointing at the old preview account. `_shared/preview_N` pointed at the active account, but the app-local overrides won. New OS DNS records were written into a moved Cloudflare zone, so `os.iterate-preview-N.com` could fail DNS even after deploy completed.

I removed those app-local Cloudflare credential overrides for `os`, `events`, `semaphore`, `example`, and `agents` across `preview_1` through `preview_9`, so the apps inherit `_shared/preview_N` again.

## Validation

- `doppler run --project _shared --config prd -- pnpm preview reconcile` -> 9 resources, 0 issues.
- Deployed `apps/os` to `preview_1` through `preview_9` from this branch.
- Verified authoritative DNS and `/api/__internal/health` for all 9 `os.iterate-preview-N.com` domains.
- Ran `apps/os` `test:e2e:preview` for all 9 Doppler configs with fresh MCP smoke project slugs; all passed.
- `packages/shared/node_modules/.bin/vitest run scripts/preview/preview.test.ts scripts/preview/preview-inventory.test.ts scripts/preview/reconcile-environment-config-leases.test.ts packages/shared/src/apps/new-style-cloudflare-apps.test.ts packages/shared/src/alchemy/iterate-app.test.ts`
- `pnpm --filter @iterate-com/shared --filter @iterate-com/os typecheck`
- `pnpm exec oxfmt --check ...` for touched TS files.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "agents": {
      "appDisplayName": "Agents",
      "appSlug": "agents",
      "status": "released",
      "updatedAt": "2026-05-19T05:57:06.368Z",
      "headSha": "f52573a0ca9ab072ff53718fa74afe24a8348694",
      "message": "Preview app released.",
      "publicUrl": "https://agents.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26065714767",
      "shortSha": "f52573a"
    },
    "example": {
      "appDisplayName": "Example",
      "appSlug": "example",
      "status": "released",
      "updatedAt": "2026-05-19T05:57:07.013Z",
      "headSha": "f52573a0ca9ab072ff53718fa74afe24a8348694",
      "message": "Preview app released.",
      "publicUrl": "https://example.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26065714767",
      "shortSha": "f52573a"
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-05-19T05:57:09.385Z",
      "headSha": "f52573a0ca9ab072ff53718fa74afe24a8348694",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26065714767",
      "shortSha": "f52573a"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-05-19T05:57:05.336Z",
      "headSha": "f52573a0ca9ab072ff53718fa74afe24a8348694",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26065714767",
      "shortSha": "f52573a"
    },
    "events": {
      "appDisplayName": "Events",
      "appSlug": "events",
      "status": "released",
      "updatedAt": "2026-05-19T05:56:54.154Z",
      "headSha": "f52573a0ca9ab072ff53718fa74afe24a8348694",
      "message": "Preview app released.",
      "publicUrl": "https://events.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26065714767",
      "shortSha": "f52573a"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Agents
Status: released
Commit: `f52573a`
Preview: https://agents.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/26065714767)
Updated: 2026-05-19T05:57:06.368Z

### Events
Status: released
Commit: `f52573a`
Preview: https://events.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/26065714767)
Updated: 2026-05-19T05:56:54.154Z

### Example
Status: released
Commit: `f52573a`
Preview: https://example.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/26065714767)
Updated: 2026-05-19T05:57:07.013Z

### OS
Status: released
Commit: `f52573a`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/26065714767)
Updated: 2026-05-19T05:57:09.385Z

### Semaphore
Status: released
Commit: `f52573a`
Preview: https://semaphore.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/26065714767)
Updated: 2026-05-19T05:57:05.336Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches preview deployment/readiness and Cloudflare zone-selection logic used during CI deploys, which could affect preview reliability and DNS/route provisioning if incorrect. Changes are well-covered by new unit tests but still impact infra-critical paths.
> 
> **Overview**
> **Preview deployments now avoid false readiness failures and pick better Cloudflare zones.** The preview deployer stops probing synthetic `project.<base>` hostnames and only waits on the app’s deployed `publicUrl` health endpoint via `resolvePreviewReadinessUrls` (with new tests).
> 
> **Cloudflare zone handling is hardened.** `IterateApp` factors zone choice into `selectBestCloudflareZoneForHostname`, preferring *active* zones (even if delegated to a different account) over same-account `moved` zones; `preview reconcile` now parses zone `status` and reports account/status drift via `evaluateCloudflareZoneCheck` (with new tests).
> 
> **Preview environment inventory/docs are updated.** The seeded Semaphore inventory expands to `preview-1` through `preview-9` (with a test), and docs update the preview slot list and the `_shared/preview` Cloudflare account ID.
> 
> **OS preview smoke is more resilient.** The MCP instructions fetch and status checks now retry transient `502/503/504` responses to reduce flakiness on newly-provisioned wildcard hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f52573a0ca9ab072ff53718fa74afe24a8348694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->