### PR TITLE
Reduce default agent loop debounce to 200ms

### DIFF
--- a/apps/os/docs/debugging-streams.md
+++ b/apps/os/docs/debugging-streams.md
@@ -118,7 +118,7 @@ curl -fsS -X POST "https://${NAMESPACE}.events.iterate-preview-2.com/api/streams
     "payload": {
       "model": "@cf/meta/llama-3.1-8b-instruct",
       "runOpts": { "gateway": { "id": "default" } },
-      "debounceMs": 1000
+      "debounceMs": 200
     }
   }'
 ```

--- a/apps/os/src/domains/agents/agent-presets.ts
+++ b/apps/os/src/domains/agents/agent-presets.ts
@@ -10,6 +10,7 @@ export const OS_AGENT_PATH_PREFIX_PRESET_CONFIGURED_EVENT_TYPE =
 export const DEFAULT_CLOUDFLARE_AGENT_MODEL = DEFAULT_WORKERS_AI_AGENT_MODEL;
 export const DEFAULT_OPENAI_AGENT_MODEL = "gpt-5.5";
 export const DEFAULT_AGENT_LLM_PROVIDER = "openai-ws";
+export const DEFAULT_AGENT_DEBOUNCE_MS = 200;
 const LEGACY_GENERATED_SLACK_OPENAI_PROMPT_MARKER =
   "You are an Iterate agent responding from Slack.";
 
@@ -92,7 +93,7 @@ export function defaultAgentSetupEvents(
             payload: {
               model: DEFAULT_CLOUDFLARE_AGENT_MODEL,
               runOpts: { gateway: { id: "default" } },
-              debounceMs: 1000,
+              debounceMs: DEFAULT_AGENT_DEBOUNCE_MS,
             },
           },
         ]),
@@ -123,7 +124,7 @@ export function configuredAgentSetupEvents(input: {
         : input.provider === "cloudflare-ai" &&
             event.type === "events.iterate.com/agent/llm-config-updated"
           ? {
-              debounceMs: 1000,
+              debounceMs: DEFAULT_AGENT_DEBOUNCE_MS,
               model: input.model,
               runOpts: input.runOpts,
             }

--- a/apps/os/src/orpc/routers/agents.ts
+++ b/apps/os/src/orpc/routers/agents.ts
@@ -8,6 +8,7 @@ import {
 import type { Event, EventInput, StreamPath } from "@iterate-com/shared/streams/types";
 import type { StreamDurableObject } from "@iterate-com/shared/streams/stream-durable-object";
 import {
+  DEFAULT_AGENT_DEBOUNCE_MS,
   defaultAgentSetupEvents,
   normalizeAgentPresetBasePath,
   presetConfiguredEvent,
@@ -79,7 +80,7 @@ export const projectAgentsRouter = {
               ? {
                   ...event,
                   payload: {
-                    debounceMs: 1000,
+                    debounceMs: DEFAULT_AGENT_DEBOUNCE_MS,
                     model: input.model,
                     runOpts: input.runOpts,
                   },


### PR DESCRIPTION
## Summary

- Lower OS default agent LLM trigger debounce from 1000ms to 200ms via `DEFAULT_AGENT_DEBOUNCE_MS`.
- Wire the constant through agent preset setup and `configurePreset` so Cloudflare AI agents get the faster default consistently.
- Update the debugging-streams doc example.

## Test plan

- [x] `pnpm typecheck`
- [x] `apps/os` unit tests (`pnpm test` in `apps/os`)
- [ ] Preview e2e (CI `Preview / e2e` on this PR)
- [ ] Monorepo unit tests (`pnpm test`) — CI `Test` workflow


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default debounce timing for Cloudflare-backed agents, which can impact request frequency and system load/latency. Scope is small but affects runtime behavior for newly configured agents/presets.
> 
> **Overview**
> Lowers the default Cloudflare agent LLM trigger debounce from `1000ms` to `200ms` by introducing `DEFAULT_AGENT_DEBOUNCE_MS` and wiring it through both preset generation (`defaultAgentSetupEvents`/`configuredAgentSetupEvents`) and the `configurePreset` router path so presets apply the same default consistently.
> 
> Updates the streams debugging doc example to use the new `200ms` debounce value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74d4f834a6a904ce6fe838503101d92b3040e203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-05-19T11:52:25.287Z",
      "headSha": "74d4f834a6a904ce6fe838503101d92b3040e203",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26091585903",
      "shortSha": "74d4f83"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `74d4f83`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/26091585903)
Updated: 2026-05-19T11:52:25.287Z
<!-- /CLOUDFLARE_PREVIEW -->