### PR TITLE
[codex] Improve Slack agent latency pipeline

### DIFF
--- a/apps/os/e2e/vitest/agents.e2e.test.ts
+++ b/apps/os/e2e/vitest/agents.e2e.test.ts
@@ -688,9 +688,15 @@ async (ctx) => {
           }),
         }),
       );
-      expect(
-        events.filter((event) => event.type === "events.iterate.com/agent/llm-config-updated"),
-      ).toEqual([]);
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "events.iterate.com/agent/llm-config-updated",
+          payload: expect.objectContaining({
+            debounceMs: 200,
+            model: "gpt-5.5",
+          }),
+        }),
+      );
       expect(
         events.filter((event) => event.type.startsWith("events.iterate.com/agent-chat/")),
       ).toEqual([]);

--- a/apps/os/src/domains/agents/agent-presets.test.ts
+++ b/apps/os/src/domains/agents/agent-presets.test.ts
@@ -24,6 +24,10 @@ describe("agent presets", () => {
         payload: { model: "gpt-5.5" },
       },
       {
+        type: "events.iterate.com/agent/llm-config-updated",
+        payload: { model: "gpt-5.5", runOpts: {}, debounceMs: 200 },
+      },
+      {
         type: "events.iterate.com/agent/system-prompt-updated",
         payload: {
           systemPrompt: defaultAgentSystemPrompt(),

--- a/apps/os/src/domains/agents/agent-presets.ts
+++ b/apps/os/src/domains/agents/agent-presets.ts
@@ -86,6 +86,14 @@ export function defaultAgentSetupEvents(
             type: "events.iterate.com/openai-ws/config-updated",
             payload: { model: DEFAULT_OPENAI_AGENT_MODEL },
           },
+          {
+            type: "events.iterate.com/agent/llm-config-updated",
+            payload: {
+              model: DEFAULT_OPENAI_AGENT_MODEL,
+              runOpts: {},
+              debounceMs: DEFAULT_AGENT_DEBOUNCE_MS,
+            },
+          },
         ]
       : [
           {
@@ -121,8 +129,7 @@ export function configuredAgentSetupEvents(input: {
     payload:
       input.provider === "openai-ws" && event.type === "events.iterate.com/openai-ws/config-updated"
         ? { model: input.model }
-        : input.provider === "cloudflare-ai" &&
-            event.type === "events.iterate.com/agent/llm-config-updated"
+        : event.type === "events.iterate.com/agent/llm-config-updated"
           ? {
               debounceMs: DEFAULT_AGENT_DEBOUNCE_MS,
               model: input.model,

--- a/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
+++ b/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
@@ -68,6 +68,7 @@ import {
 import { buildProjectStreamViewerUrl } from "~/lib/stream-viewer-url.ts";
 
 export const AGENTS_STREAM_PATH = StreamPath.parse("/agents");
+const ADMIN_API_ORGANIZATION_SLUG = "admin-api";
 
 export type AgentDurableObjectStructuredName = {
   agentPath: StreamPath;
@@ -85,6 +86,72 @@ export function getAgentDurableObjectName(input: AgentDurableObjectStructuredNam
   });
 }
 
+export function createAgentCodemodeToolProviders(input: {
+  agentDurableObjectName: string;
+  agentPath: StreamPath;
+  projectId: string;
+}): ToolProviderRegistration[] {
+  return [
+    ...(isSlackAgentPath(input.agentPath)
+      ? []
+      : [createAgentChatToolProvider({ agentDurableObjectName: input.agentDurableObjectName })]),
+    createAgentDebugToolProvider({ agentDurableObjectName: input.agentDurableObjectName }),
+    ...createExampleCapabilityProviders({ projectId: input.projectId }),
+    createGmailProviderRegistration({ projectId: input.projectId }),
+  ];
+}
+
+function createAgentChatToolProvider(input: {
+  agentDurableObjectName: string;
+}): ToolProviderRegistration {
+  return {
+    path: ["chat"],
+    instructions:
+      "Use ctx.chat.sendMessage({ message }) to send a visible response to the user. Prefer this over appending chat events manually.",
+    invocation: {
+      kind: "rpc",
+      callable: {
+        type: "workers-rpc",
+        via: {
+          type: "env-binding",
+          bindingType: "durable-object-namespace",
+          bindingName: "AGENT",
+          durableObject: {
+            name: input.agentDurableObjectName,
+          },
+        },
+        rpcMethod: "executeCodemodeFunctionCall",
+        argsMode: "object",
+      },
+    },
+  };
+}
+
+function createAgentDebugToolProvider(input: {
+  agentDurableObjectName: string;
+}): ToolProviderRegistration {
+  return {
+    path: ["debug"],
+    instructions: "Use ctx.debug() to return OS debug information about the current agent stream.",
+    invocation: {
+      kind: "rpc",
+      callable: {
+        type: "workers-rpc",
+        via: {
+          type: "env-binding",
+          bindingType: "durable-object-namespace",
+          bindingName: "AGENT",
+          durableObject: {
+            name: input.agentDurableObjectName,
+          },
+        },
+        rpcMethod: "executeCodemodeFunctionCall",
+        argsMode: "object",
+      },
+    },
+  };
+}
+
 export type AgentDurableObjectEnv = {
   AGENT: DurableObjectNamespace<AgentDurableObject>;
   AI: CloudflareAiProcessorDeps["ai"];
@@ -98,6 +165,10 @@ export type AgentDurableObjectEnv = {
 
 const AGENT_ITERATE_CONFIG_DIR = "/iterate-config";
 const AGENT_ITERATE_CONFIG_CLONE_COMPLETE_PATH = `${AGENT_ITERATE_CONFIG_DIR}/.git/iterate-clone-complete`;
+
+function isSlackAgentStreamPath(path: string) {
+  return path.startsWith("/agents/slack/");
+}
 
 export type CloneIterateConfigRepoInput = {
   git: Awaited<ReturnType<WorkspaceDurableObject["cloudflareShellGit"]>>;
@@ -161,8 +232,12 @@ export class AgentDurableObject extends AgentBase<AgentDurableObjectEnv> {
           }),
         );
         this.registerStreamProcessor(this.createLlmProcessor(llmProvider));
-        await this.ensureAgentWorkspace(params);
-        await this.ensureCodemodeSession(params);
+        if (isSlackAgentStreamPath(params.agentPath)) {
+          this.warmAgentWorkspace(params);
+        } else {
+          await this.ensureAgentWorkspace(params);
+          await this.ensureCodemodeSession(params);
+        }
       }
       await this.ensureAgentSubscription(params);
       await this.catchUpStreamProcessors({
@@ -276,7 +351,7 @@ export class AgentDurableObject extends AgentBase<AgentDurableObjectEnv> {
   }
 
   async executeCodemodeFunctionCall(input: ExecuteCodemodeFunctionCallInput) {
-    await this.ensureStarted();
+    await this.ensureStartedOrInitializeFromRuntimeName();
     const providerName = input.providerPath.join(".");
     if (providerName === "debug") {
       return await this.createDebugSnapshot();
@@ -378,6 +453,18 @@ export class AgentDurableObject extends AgentBase<AgentDurableObjectEnv> {
       content: `${repo.slug}\n`,
       path: AGENT_ITERATE_CONFIG_CLONE_COMPLETE_PATH,
     });
+  }
+
+  private warmAgentWorkspace(params: AgentDurableObjectStructuredName) {
+    this.waitUntilStreamProcessor(
+      this.ensureAgentWorkspace(params).catch((error) => {
+        console.error("[os-agent] Slack agent workspace warmup failed", {
+          agentPath: params.agentPath,
+          error,
+          projectId: params.projectId,
+        });
+      }),
+    );
   }
 
   protected async cloneIterateConfigRepo(input: CloneIterateConfigRepoInput) {
@@ -528,22 +615,22 @@ export class AgentDurableObject extends AgentBase<AgentDurableObjectEnv> {
   private async createDebugSnapshot() {
     const project = await this.readDebugProjectInfo();
     const config = this.getAppConfig();
-    const streamUrl =
-      project?.organizationSlug && project.slug
-        ? buildProjectStreamViewerUrl({
-            baseUrl: config.baseUrl,
-            organizationSlug: project.organizationSlug,
-            projectSlug: project.slug,
-            streamPath: this.structuredName.agentPath,
-          })
-        : (config.baseUrl ?? "https://os.iterate.com");
+    const organizationSlug = project?.organizationSlug ?? ADMIN_API_ORGANIZATION_SLUG;
+    const streamUrl = project?.slug
+      ? buildProjectStreamViewerUrl({
+          baseUrl: config.baseUrl,
+          organizationSlug,
+          projectSlug: project.slug,
+          streamPath: this.structuredName.agentPath,
+        })
+      : (config.baseUrl ?? "https://os.iterate.com");
     const snapshot = {
       project:
         project == null
           ? { id: this.structuredName.projectId }
           : {
               id: this.structuredName.projectId,
-              organizationSlug: project.organizationSlug ?? undefined,
+              organizationSlug,
               slug: project.slug,
             },
       streamPath: this.structuredName.agentPath,
@@ -649,63 +736,14 @@ export class AgentDurableObject extends AgentBase<AgentDurableObjectEnv> {
     });
   }
 
-  private createAgentChatToolProvider(): ToolProviderRegistration {
-    return {
-      path: ["chat"],
-      instructions:
-        "Use ctx.chat.sendMessage({ message }) to send a visible response to the user. Prefer this over appending chat events manually.",
-      invocation: {
-        kind: "rpc",
-        callable: {
-          type: "workers-rpc",
-          via: {
-            type: "env-binding",
-            bindingType: "durable-object-namespace",
-            bindingName: "AGENT",
-            durableObject: {
-              name: this.name,
-            },
-          },
-          rpcMethod: "executeCodemodeFunctionCall",
-          argsMode: "object",
-        },
-      },
-    };
-  }
-
-  private createAgentDebugToolProvider(): ToolProviderRegistration {
-    return {
-      path: ["debug"],
-      instructions:
-        "Use ctx.debug() to return OS debug information about the current agent stream.",
-      invocation: {
-        kind: "rpc",
-        callable: {
-          type: "workers-rpc",
-          via: {
-            type: "env-binding",
-            bindingType: "durable-object-namespace",
-            bindingName: "AGENT",
-            durableObject: {
-              name: this.name,
-            },
-          },
-          rpcMethod: "executeCodemodeFunctionCall",
-          argsMode: "object",
-        },
-      },
-    };
-  }
-
   private createCodemodeToolProviders(
     params: AgentDurableObjectStructuredName,
   ): ToolProviderRegistration[] {
-    return [
-      ...(isSlackAgentPath(params.agentPath) ? [] : [this.createAgentChatToolProvider()]),
-      this.createAgentDebugToolProvider(),
-      ...createExampleCapabilityProviders({ projectId: params.projectId }),
-      createGmailProviderRegistration({ projectId: params.projectId }),
-    ];
+    return createAgentCodemodeToolProviders({
+      agentDurableObjectName: this.name,
+      agentPath: params.agentPath,
+      projectId: params.projectId,
+    });
   }
 
   private async resolveLlmProvider(

--- a/apps/os/src/domains/codemode/durable-objects/codemode-session.ts
+++ b/apps/os/src/domains/codemode/durable-objects/codemode-session.ts
@@ -14,7 +14,10 @@ import {
 import type { StreamDurableObject } from "@iterate-com/shared/streams/stream-durable-object";
 import { withDurableObjectCore } from "@iterate-com/shared/durable-object-utils/mixins/with-durable-object-core";
 import { withKvInspector } from "@iterate-com/shared/durable-object-utils/mixins/with-kv-inspector";
-import { withLifecycleHooks } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
+import {
+  NotInitializedError,
+  withLifecycleHooks,
+} from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
 import { withOuterbase } from "@iterate-com/shared/durable-object-utils/mixins/with-outerbase";
 import { withStreamProcessorRunner } from "@iterate-com/shared/durable-object-utils/mixins/with-stream-processor-runner";
 import {
@@ -237,36 +240,36 @@ export class CodemodeSession extends CodemodeSessionBase<CodemodeSessionEnv> {
   }
 
   async getStreamPath() {
-    const params = await this.ensureStarted();
+    const params = await this.ensureStartedOrInitializeFromRuntimeName();
     return params.streamPath;
   }
 
   async ensureLiveConsumer() {
+    const params = await this.ensureStartedOrInitializeFromRuntimeName();
     debugCodemodeDepth("session.ensureLiveConsumer.start", {
       name: this.name,
-      streamPath: this.structuredName.streamPath,
+      streamPath: params.streamPath,
     });
-    await this.ensureStarted();
     await this.ensureCallableSubscription();
     debugCodemodeDepth("session.ensureLiveConsumer.afterSubscription", {
       name: this.name,
-      streamPath: this.structuredName.streamPath,
+      streamPath: params.streamPath,
     });
     await this.catchUpStreamProcessor({ signal: AbortSignal.timeout(30_000) });
     debugCodemodeDepth("session.ensureLiveConsumer.afterCatchUp", {
       name: this.name,
-      streamPath: this.structuredName.streamPath,
+      streamPath: params.streamPath,
       state: this.getStreamProcessorRunnerState(),
     });
   }
 
   async afterAppend(input: { event: Event }) {
+    await this.ensureStartedOrInitializeFromRuntimeName();
     debugCodemodeDepth("session.afterAppend.start", {
       eventOffset: input.event.offset,
       eventType: input.event.type,
       name: this.name,
     });
-    await this.ensureStarted();
     const state = await this.consumeStreamProcessorEvent({ event: input.event as StreamEvent });
     this.resolvePendingFunctionCallFromEvent(input.event as StreamEvent);
     debugCodemodeDepth("session.afterAppend.done", {
@@ -280,7 +283,7 @@ export class CodemodeSession extends CodemodeSessionBase<CodemodeSessionEnv> {
   }
 
   async createSession(input: CreateCodemodeSessionInput = {}) {
-    const params = await this.ensureStarted();
+    const params = await this.ensureStartedOrInitializeFromRuntimeName();
     debugCodemodeDepth("session.createSession.start", {
       streamPath: params.streamPath,
       hasCode: input.code != null,
@@ -351,7 +354,7 @@ export class CodemodeSession extends CodemodeSessionBase<CodemodeSessionEnv> {
   }
 
   async registerToolProvider(input: { provider: ToolProviderRegistration }) {
-    await this.ensureStarted();
+    await this.ensureStartedOrInitializeFromRuntimeName();
     await this.ensureLiveConsumer();
     return await this.appendToolProviderRegisteredEvent(input);
   }
@@ -361,7 +364,7 @@ export class CodemodeSession extends CodemodeSessionBase<CodemodeSessionEnv> {
   }
 
   async callFunction(input: CallFunctionInput) {
-    await this.ensureStarted();
+    await this.ensureStartedOrInitializeFromRuntimeName();
     await this.ensureLiveConsumer();
     const functionCallId = input.functionCallId ?? crypto.randomUUID();
     const builtin = this.resolveCodemodeBuiltin(input.path);
@@ -510,7 +513,7 @@ export class CodemodeSession extends CodemodeSessionBase<CodemodeSessionEnv> {
   }
 
   async receiveFunctionCallResult(input: ReceiveFunctionCallResultInput) {
-    await this.ensureStarted();
+    await this.ensureStartedOrInitializeFromRuntimeName();
     const event = await this.appendAndConsume({
       type: "events.iterate.com/codemode/function-call-completed",
       idempotencyKey: `codemode:function-call-completed:${input.functionCallId}`,
@@ -542,6 +545,17 @@ export class CodemodeSession extends CodemodeSessionBase<CodemodeSessionEnv> {
     return this.getStreamProcessorRunnerState();
   }
 
+  private async ensureStartedOrInitializeFromRuntimeName() {
+    try {
+      return await this.ensureStarted();
+    } catch (error) {
+      if (!(error instanceof NotInitializedError)) throw error;
+      const runtimeName = this.getDurableObjectName();
+      if (runtimeName == null) throw error;
+      return await this.initialize({ name: runtimeName });
+    }
+  }
+
   private streamsEntrypoint() {
     return processorStreamApiFromNamespace({
       namespace: this.structuredName.projectId,
@@ -563,6 +577,7 @@ export class CodemodeSession extends CodemodeSessionBase<CodemodeSessionEnv> {
       payload: {
         slug: `codemode-session:${this.name}`,
         type: "callable",
+        eventTypes: [...CodemodeProcessorContract.consumes],
         callable: {
           type: "workers-rpc",
           via: {

--- a/apps/os/src/domains/repos/durable-objects/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/durable-objects/repo-durable-object.ts
@@ -115,6 +115,8 @@ const RepoBase = withStreamProcessorRunner<
 const REPO_WRITE_TOKEN_STORAGE_KEY = "repo.writeToken";
 
 export class RepoDurableObject extends RepoBase<RepoEnv> {
+  #createRepoPromise: Promise<RepoInfo> | undefined;
+
   constructor(ctx: DurableObjectState, env: RepoEnv) {
     super(ctx, env);
     this.registerOnFirstInitialize(async (params) => {
@@ -124,6 +126,22 @@ export class RepoDurableObject extends RepoBase<RepoEnv> {
   }
 
   async createRepo(input: CreateRepoInput = {}): Promise<RepoInfo> {
+    if (this.#createRepoPromise != null) {
+      return await this.#createRepoPromise;
+    }
+
+    const promise = this.createRepoOnce(input);
+    this.#createRepoPromise = promise;
+    try {
+      return await promise;
+    } finally {
+      if (this.#createRepoPromise === promise) {
+        this.#createRepoPromise = undefined;
+      }
+    }
+  }
+
+  private async createRepoOnce(input: CreateRepoInput = {}): Promise<RepoInfo> {
     await this.ensureStarted();
     await this.catchUpStreamProcessor({ signal: AbortSignal.timeout(30_000) });
 
@@ -134,16 +152,11 @@ export class RepoDurableObject extends RepoBase<RepoEnv> {
     const artifactName = repoArtifactName(this.structuredName);
     const artifacts = this.requireArtifacts();
     const source = input.source ?? { kind: "initial-readme" as const };
-    const artifact =
-      source.kind === "artifact-fork"
-        ? await this.forkArtifactRepo({
-            artifactName,
-            artifacts,
-            source,
-          })
-        : await artifacts.create(artifactName, {
-            setDefaultBranch: REPO_DEFAULT_BRANCH,
-          });
+    const { artifact, recoveredExistingArtifact } = await this.createOrRecoverArtifactRepo({
+      artifactName,
+      artifacts,
+      source,
+    });
     const token = await createArtifactToken({
       artifact,
       artifacts,
@@ -157,7 +170,7 @@ export class RepoDurableObject extends RepoBase<RepoEnv> {
       (await readArtifactString(artifact.default_branch)) ??
       REPO_DEFAULT_BRANCH;
 
-    if (source.kind === "initial-readme") {
+    if (source.kind === "initial-readme" && !recoveredExistingArtifact) {
       await pushInitialReadme({
         defaultBranch,
         projectId: this.structuredName.projectId,
@@ -261,6 +274,37 @@ export class RepoDurableObject extends RepoBase<RepoEnv> {
     });
   }
 
+  private async createOrRecoverArtifactRepo(input: {
+    artifactName: string;
+    artifacts: CloudflareArtifactsBinding;
+    source: NonNullable<CreateRepoInput["source"]>;
+  }) {
+    try {
+      return {
+        artifact:
+          input.source.kind === "artifact-fork"
+            ? await this.forkArtifactRepo({
+                artifactName: input.artifactName,
+                artifacts: input.artifacts,
+                source: input.source,
+              })
+            : await input.artifacts.create(input.artifactName, {
+                setDefaultBranch: REPO_DEFAULT_BRANCH,
+              }),
+        recoveredExistingArtifact: false,
+      };
+    } catch (error) {
+      if (!isArtifactAlreadyExistsError(error)) {
+        throw error;
+      }
+
+      return {
+        artifact: await input.artifacts.get(input.artifactName),
+        recoveredExistingArtifact: true,
+      };
+    }
+  }
+
   private async appendRepoCreatedEvent(input: {
     defaultBranch: string;
     remote: string;
@@ -353,6 +397,10 @@ async function readArtifactString(value: unknown): Promise<string | undefined> {
   } catch {
     return undefined;
   }
+}
+
+function isArtifactAlreadyExistsError(error: unknown) {
+  return error instanceof Error && /already exists/i.test(error.message);
 }
 
 function shellQuote(value: string) {

--- a/apps/os/src/domains/secrets/integration-api.ts
+++ b/apps/os/src/domains/secrets/integration-api.ts
@@ -1,4 +1,6 @@
 import { getInitializedStreamStub } from "@iterate-com/shared/streams/helpers";
+import { STREAM_SUBSCRIPTION_CONFIGURED_TYPE, type Event } from "@iterate-com/shared/streams/types";
+import { SlackProcessorContract } from "@iterate-com/shared/stream-processors/slack/contract";
 import type { ClerkAuth } from "~/context.ts";
 import type { AppContext } from "~/context.ts";
 import {
@@ -10,11 +12,13 @@ import {
 import {
   consumeOAuthState,
   getProjectConnectionByWebhookIdentifier,
+  getProjectSecret,
   projectSecretId,
   upsertProjectConnection,
   upsertProjectSecret,
 } from "~/domains/secrets/secrets-store.ts";
 import { getSlackIntegrationDurableObjectName } from "~/domains/slack/durable-objects/slack-integration-durable-object.ts";
+import { callSlackWebApi } from "~/domains/slack/entrypoints/slack-capability.ts";
 import {
   oauthRedirectUri,
   providerSecretKey,
@@ -313,35 +317,177 @@ async function handleVerifiedSlackWebhook(input: {
     return Response.json({ error: "SLACK_INTEGRATION binding is not available." }, { status: 500 });
   }
 
-  const slackIntegrationName = getSlackIntegrationDurableObjectName(connection.projectId);
-  const slackIntegration = input.context.slackIntegration.getByName(slackIntegrationName);
-  await slackIntegration.initialize({ name: slackIntegrationName });
-  await slackIntegration.ensureReady();
+  const reactionPromise = addIngressSlackEyesReaction({
+    context: input.context,
+    payload,
+    projectId: connection.projectId,
+  }).catch((error) => {
+    console.error("[slack-integration] ingress eyes reaction crashed", { error });
+  });
+  input.context.waitUntil?.(reactionPromise);
+  void reactionPromise;
 
   const stream = await getInitializedStreamStub({
     durableObjectNamespace: input.context.stream as never,
     namespace: connection.projectId,
     path: SLACK_INTEGRATION_STREAM_PATH,
   });
-  await stream.append({
-    type: "events.iterate.com/slack/webhook-received",
-    idempotencyKey:
-      typeof payload.event_id === "string"
-        ? `slack-webhook:${payload.event_id}`
-        : typeof payload.trigger_id === "string"
-          ? `slack-webhook:${payload.trigger_id}`
-          : `slack-webhook:${crypto.randomUUID()}`,
-    payload: {
-      headers: {
-        slackEventId: input.request.headers.get("x-slack-event-id"),
-        slackRequestTimestamp: input.request.headers.get("x-slack-request-timestamp"),
+
+  const slackIntegrationName = getSlackIntegrationDurableObjectName(connection.projectId);
+  const appendedEvents = await stream.appendBatch([
+    {
+      type: STREAM_SUBSCRIPTION_CONFIGURED_TYPE,
+      idempotencyKey: `slack-subscription:${connection.projectId}`,
+      payload: {
+        slug: `slack:${connection.projectId}`,
+        type: "callable",
+        eventTypes: [...SlackProcessorContract.consumes],
+        callable: {
+          type: "workers-rpc",
+          via: {
+            type: "env-binding",
+            bindingType: "durable-object-namespace",
+            bindingName: "SLACK_INTEGRATION",
+            durableObject: {
+              name: slackIntegrationName,
+            },
+          },
+          rpcMethod: "afterAppend",
+          argsMode: "object",
+        },
       },
-      slackTeamId: teamId,
-      body: payload,
     },
-  });
+    {
+      type: "events.iterate.com/slack/webhook-received",
+      idempotencyKey:
+        typeof payload.event_id === "string"
+          ? `slack-webhook:${payload.event_id}`
+          : typeof payload.trigger_id === "string"
+            ? `slack-webhook:${payload.trigger_id}`
+            : `slack-webhook:${crypto.randomUUID()}`,
+      payload: {
+        headers: {
+          slackEventId: input.request.headers.get("x-slack-event-id"),
+          slackRequestTimestamp: input.request.headers.get("x-slack-request-timestamp"),
+        },
+        slackTeamId: teamId,
+        body: payload,
+      },
+    },
+  ]);
+  const webhookEvent = appendedEvents.find(
+    (event) => event.type === "events.iterate.com/slack/webhook-received",
+  );
+  if (webhookEvent != null) {
+    const slackIntegrationWakePromise = wakeSlackIntegrationFastPath({
+      context: input.context,
+      event: webhookEvent,
+      projectId: connection.projectId,
+    }).catch((error) => {
+      console.error("[slack-integration] fast-path wake failed", { error });
+    });
+    input.context.waitUntil?.(slackIntegrationWakePromise);
+    void slackIntegrationWakePromise;
+  }
 
   return Response.json({ ok: true });
+}
+
+async function wakeSlackIntegrationFastPath(input: {
+  context: AppContext;
+  event: Event;
+  projectId: string;
+}) {
+  if (!input.context.slackIntegration) return;
+
+  const slackIntegrationName = getSlackIntegrationDurableObjectName(input.projectId);
+  const stub = input.context.slackIntegration.getByName(slackIntegrationName);
+  await stub.afterAppend({ event: input.event });
+}
+
+async function addIngressSlackEyesReaction(input: {
+  context: AppContext;
+  payload: unknown;
+  projectId: string;
+}) {
+  const target = slackEyesReactionTarget(input.payload);
+  if (target == null) return;
+
+  const token = await readSlackBotToken(input);
+  if (!token) return;
+
+  try {
+    await callSlackWebApi({
+      method: "reactions.add",
+      token,
+      body: {
+        channel: target.channel,
+        name: "eyes",
+        timestamp: target.messageTs,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("already_reacted")) return;
+    console.error("[slack-integration] ingress eyes reaction failed", {
+      channel: target.channel,
+      error,
+      messageTs: target.messageTs,
+    });
+  }
+}
+
+async function readSlackBotToken(input: { context: AppContext; projectId: string }) {
+  const secret = await getProjectSecret(input.context.db, {
+    key: "slack.access_token",
+    projectId: input.projectId,
+  });
+  if (secret) return secret.material;
+
+  return input.context.config.slackBotToken?.exposeSecret() ?? "";
+}
+
+function slackEyesReactionTarget(payload: unknown): { channel: string; messageTs: string } | null {
+  const body = readRecord(payload);
+  if (body?.type !== "event_callback") return null;
+
+  const event = readRecord(body.event);
+  if (event == null) return null;
+  const eventType = readString(event.type);
+  if (eventType === "reaction_added" || eventType === "reaction_removed") return null;
+
+  const botUserId = readSlackAuthorizedBotUserId(body);
+  if (botUserId != null && readString(event.user) === botUserId) return null;
+
+  const channel = readString(event.channel);
+  const message = readRecord(event.message);
+  const messageTs = readString(event.ts) ?? readString(message?.ts);
+  if (channel == null || messageTs == null) return null;
+
+  return { channel, messageTs };
+}
+
+function readSlackAuthorizedBotUserId(body: Record<string, unknown>) {
+  const authorizations = body.authorizations;
+  if (!Array.isArray(authorizations)) return null;
+  for (const authorization of authorizations) {
+    const record = readRecord(authorization);
+    if (record?.is_bot === true) {
+      const userId = readString(record.user_id);
+      if (userId != null) return userId;
+    }
+  }
+  return null;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value != null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }
 
 function redirectWithError(callbackUrl: string | null, error: string) {

--- a/apps/os/src/domains/slack/durable-objects/slack-integration-durable-object.ts
+++ b/apps/os/src/domains/slack/durable-objects/slack-integration-durable-object.ts
@@ -5,6 +5,9 @@ import {
   NotInitializedError,
 } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
 import { withStreamProcessorRunner } from "@iterate-com/shared/durable-object-utils/mixins/with-stream-processor-runner";
+import { AgentProcessorContract } from "@iterate-com/shared/stream-processors/agent/contract";
+import { CodemodeProcessorContract } from "@iterate-com/shared/stream-processors/codemode/contract";
+import { SlackAgentProcessorContract } from "@iterate-com/shared/stream-processors/slack-agent/contract";
 import { createSlackProcessor } from "@iterate-com/shared/stream-processors/slack/implementation";
 import { SlackProcessorContract } from "@iterate-com/shared/stream-processors/slack/contract";
 import type {
@@ -25,9 +28,15 @@ import {
   type StreamPath,
 } from "@iterate-com/shared/streams/types";
 import {
+  createAgentCodemodeToolProviders,
   type AgentDurableObject,
   getAgentDurableObjectName,
 } from "~/domains/agents/durable-objects/agent-durable-object.ts";
+import {
+  DEFAULT_AGENT_LLM_PROVIDER,
+  defaultAgentSetupEvents,
+} from "~/domains/agents/agent-presets.ts";
+import { createCodemodeSessionStartupEvents } from "~/domains/codemode/codemode-session-rpc.ts";
 import { SLACK_INTEGRATION_STREAM_PATH } from "~/domains/secrets/integration-streams.ts";
 import {
   type SlackAgentDurableObject,
@@ -119,8 +128,7 @@ export class SlackIntegrationDurableObject extends SlackIntegrationBase<SlackInt
   }
 
   async afterAppend(input: { event: Event }) {
-    const params = await this.ensureStartedOrInitializeFromRuntimeName();
-    await this.ensureIntegrationSubscription(params.projectId);
+    await this.ensureStartedOrInitializeFromRuntimeName();
     return await this.consumeStreamProcessorEvent({ event: input.event as StreamEvent });
   }
 
@@ -159,6 +167,7 @@ export class SlackIntegrationDurableObject extends SlackIntegrationBase<SlackInt
       payload: {
         slug: `slack:${projectId}`,
         type: "callable",
+        eventTypes: [...SlackProcessorContract.consumes],
         callable: {
           type: "workers-rpc",
           via: {
@@ -183,13 +192,27 @@ function routedStreamBootstrapEvents(input: {
   slackAgentDurableObjectName: string;
   streamPath: string;
 }): EmittedInput<typeof SlackProcessorContract>[] {
+  const codemodeSessionDurableObjectName = deriveDurableObjectNameFromStructuredName({
+    structuredName: {
+      projectId: input.projectId,
+      streamPath: resolveStreamPath(input.streamPath),
+    },
+  });
+
   return [
+    ...defaultAgentSetupEvents(DEFAULT_AGENT_LLM_PROVIDER, input.streamPath).map(
+      (event, index) => ({
+        ...event,
+        idempotencyKey: `os-agent-setup:default:${index}:${event.type}`,
+      }),
+    ),
     {
       type: STREAM_SUBSCRIPTION_CONFIGURED_TYPE,
       idempotencyKey: `slack-agent-subscription:${input.projectId}:${input.streamPath}`,
       payload: {
         slug: `slack-agent:${input.projectId}:${input.streamPath}`,
         type: "callable",
+        eventTypes: [...SlackAgentProcessorContract.consumes],
         callable: {
           type: "workers-rpc",
           via: {
@@ -207,10 +230,43 @@ function routedStreamBootstrapEvents(input: {
     },
     {
       type: STREAM_SUBSCRIPTION_CONFIGURED_TYPE,
+      idempotencyKey: `codemode-session-callable-subscription:${codemodeSessionDurableObjectName}`,
+      payload: {
+        slug: `codemode-session:${codemodeSessionDurableObjectName}`,
+        type: "callable",
+        eventTypes: [...CodemodeProcessorContract.consumes],
+        callable: {
+          type: "workers-rpc",
+          via: {
+            type: "env-binding",
+            bindingType: "durable-object-namespace",
+            bindingName: "CODEMODE_SESSION",
+            durableObject: {
+              name: codemodeSessionDurableObjectName,
+            },
+          },
+          rpcMethod: "afterAppend",
+          argsMode: "object",
+        },
+      },
+    },
+    ...createCodemodeSessionStartupEvents({
+      events: [],
+      projectId: input.projectId,
+      providers: createAgentCodemodeToolProviders({
+        agentDurableObjectName: input.agentDurableObjectName,
+        agentPath: resolveStreamPath(input.streamPath),
+        projectId: input.projectId,
+      }),
+      streamPath: resolveStreamPath(input.streamPath),
+    }),
+    {
+      type: STREAM_SUBSCRIPTION_CONFIGURED_TYPE,
       idempotencyKey: `agent-subscription:${input.projectId}:${input.streamPath}`,
       payload: {
         slug: `agent:${input.projectId}:${input.streamPath}`,
         type: "callable",
+        eventTypes: [...AgentProcessorContract.consumes],
         callable: {
           type: "workers-rpc",
           via: {
@@ -226,7 +282,7 @@ function routedStreamBootstrapEvents(input: {
         },
       },
     },
-  ];
+  ] as EmittedInput<typeof SlackProcessorContract>[];
 }
 
 function slackIntegrationStreamApiFromNamespace(args: {

--- a/packages/shared/src/durable-object-utils/mixins/with-stream-processor.ts
+++ b/packages/shared/src/durable-object-utils/mixins/with-stream-processor.ts
@@ -188,7 +188,13 @@ export function withStreamProcessor<
         const registered = processor as unknown as RegisteredProcessor;
         const existing = this.#processors.get(registered.contract.slug);
         if (existing != null) {
-          throw new Error(`Stream processor "${registered.contract.slug}" is already registered.`);
+          if (existing.contract.version === registered.contract.version) {
+            return;
+          }
+
+          throw new Error(
+            `Stream processor "${registered.contract.slug}" is already registered at version "${existing.contract.version}".`,
+          );
         }
         this.#processors.set(registered.contract.slug, registered);
       }

--- a/packages/shared/src/stream-processors/agent/implementation.ts
+++ b/packages/shared/src/stream-processors/agent/implementation.ts
@@ -83,12 +83,9 @@ export function createAgentProcessor(deps: AgentProcessorDeps) {
         case "events.iterate.com/agent/status-updated":
           return;
         case "events.iterate.com/codemode/tool-provider-registered":
-          await appendEventTypeExplanation({
+          await appendEventTypeExplanationAndRewrite({
             streamApi,
             eventType: event.type,
-          });
-          await appendRewrite({
-            streamApi,
             event,
             key: "render-codemode-tool-provider-registered",
             content: toolProviderRegisteredEventBlock({
@@ -487,52 +484,65 @@ async function appendLlmEventContext(args: {
   key: string;
   content: string;
 }) {
-  await appendEventTypeExplanation({
+  await appendEventTypeExplanationAndRewrite({
     streamApi: args.streamApi,
     eventType: args.event.type,
+    event: args.event,
+    key: args.key,
+    content: `An event has occurred: \n\n${args.content}`,
   });
-  await appendRewrite({ ...args, content: `An event has occurred: \n\n${args.content}` });
 }
 
-async function appendRewrite(args: {
-  streamApi: AgentStreamApi;
+function rewriteInput(args: {
   event: { streamPath: string; offset: number };
   key: string;
   content: string;
 }) {
-  await args.streamApi.append({
-    event: {
-      type: "events.iterate.com/agent/input-added",
-      idempotencyKey: buildProcessorIdempotencyKey({
-        processor: AgentProcessorContract,
-        key: args.key,
-        sourceEvent: args.event,
-      }),
-      payload: {
-        content: args.content,
-        llmRequestPolicy: { behaviour: "dont-trigger-request" },
-      },
+  return {
+    type: "events.iterate.com/agent/input-added",
+    idempotencyKey: buildProcessorIdempotencyKey({
+      processor: AgentProcessorContract,
+      key: args.key,
+      sourceEvent: args.event,
+    }),
+    payload: {
+      content: args.content,
+      llmRequestPolicy: { behaviour: "dont-trigger-request" },
     },
+  } as const;
+}
+
+async function appendEventTypeExplanationAndRewrite(args: {
+  streamApi: AgentStreamApi;
+  eventType: string;
+  event: { streamPath: string; offset: number };
+  key: string;
+  content: string;
+}) {
+  const explanation = eventTypeExplanation(args.eventType);
+  const rewrite = rewriteInput(args);
+  if (explanation == null) {
+    await args.streamApi.append({ event: rewrite });
+    return;
+  }
+
+  await args.streamApi.appendBatch({
+    events: [eventTypeExplanationInput(args.eventType, explanation), rewrite],
   });
 }
 
-async function appendEventTypeExplanation(args: { streamApi: AgentStreamApi; eventType: string }) {
-  const explanation = eventTypeExplanation(args.eventType);
-  if (explanation == null) return;
-
-  await args.streamApi.append({
-    event: {
-      type: "events.iterate.com/agent/input-added",
-      idempotencyKey: buildProcessorIdempotencyKey({
-        processor: AgentProcessorContract,
-        key: `event-type-explainer/${args.eventType}`,
-      }),
-      payload: {
-        content: explanation,
-        llmRequestPolicy: { behaviour: "dont-trigger-request" },
-      },
+function eventTypeExplanationInput(eventType: string, explanation: string) {
+  return {
+    type: "events.iterate.com/agent/input-added",
+    idempotencyKey: buildProcessorIdempotencyKey({
+      processor: AgentProcessorContract,
+      key: `event-type-explainer/${eventType}`,
+    }),
+    payload: {
+      content: explanation,
+      llmRequestPolicy: { behaviour: "dont-trigger-request" },
     },
-  });
+  } as const;
 }
 
 function eventTypeExplanation(eventType: string): string | null {

--- a/packages/shared/src/stream-processors/slack-agent/implementation.ts
+++ b/packages/shared/src/stream-processors/slack-agent/implementation.ts
@@ -64,14 +64,6 @@ export function createSlackAgentProcessor(deps: SlackAgentProcessorDeps = {}) {
 
           const slackEvent = parsed.data.event as unknown as SlackEvent;
           const target = slackAgentTargetFromWebhookPayload(event.payload);
-          if (target != null && !target.isBotMessage && !target.isReactionEvent) {
-            await callSlackApi(deps, "reactions.add", {
-              channel: target.channel,
-              name: "eyes",
-              timestamp: target.messageTs,
-            });
-          }
-          if (isBotMessage(slackEvent)) return;
           if (isBotAction(slackEvent, state.botUserId)) return;
 
           const channel =
@@ -232,13 +224,6 @@ function isSlackAgentThreadInfoCall(payload: {
   );
 }
 
-function isBotMessage(slackEvent: SlackEvent): boolean {
-  if (readStringField(slackEvent, "subtype") === "bot_message") return true;
-  if (readStringField(slackEvent, "bot_id") != null) return true;
-  if (readRecordField(slackEvent, "bot_profile") != null) return true;
-  return false;
-}
-
 /**
  * Returns true when the Slack event was performed by our own bot user (e.g.
  * our bot adding a reaction).
@@ -301,7 +286,6 @@ function compileBangCommand(input: {
 
 type SlackAgentTarget = {
   channel: string;
-  isBotMessage: boolean;
   isReactionEvent: boolean;
   messageTs?: string;
   threadTs: string;
@@ -328,10 +312,6 @@ function slackAgentTargetFromWebhookPayload(payload: unknown): SlackAgentTarget 
   const messageTs = readString(slackEvent.ts) ?? readString(message?.ts);
   return {
     channel,
-    isBotMessage:
-      readString(slackEvent.subtype) === "bot_message" ||
-      readString(slackEvent.bot_id) != null ||
-      readRecord(slackEvent.bot_profile) != null,
     isReactionEvent: type === "reaction_added" || type === "reaction_removed",
     ...(messageTs == null ? {} : { messageTs }),
     threadTs,

--- a/packages/shared/src/stream-processors/slack-agent/slack-agent.test.ts
+++ b/packages/shared/src/stream-processors/slack-agent/slack-agent.test.ts
@@ -199,6 +199,62 @@ describe("createSlackAgentProcessor", () => {
     expect(content).not.toContain("Do not use `ctx.chat.sendMessage`");
   });
 
+  it("emits agent input for messages from other bots", async () => {
+    const appended: Array<{ streamPath?: string; event: StreamEventInput }> = [];
+    const slackCalls: Array<{ body: Record<string, unknown>; method: string }> = [];
+    const event = committedEvent({
+      type: "events.iterate.com/slack/webhook-received",
+      payload: {
+        body: {
+          type: "event_callback",
+          event: {
+            type: "message",
+            channel: "C123",
+            channel_type: "channel",
+            user: "U_OTHER_BOT",
+            bot_id: "B_OTHER",
+            ts: "1772136259.000000",
+            event_ts: "1772136259.000000",
+            text: "<@U_BOT> deployment says hello",
+          },
+          authorizations: [
+            { team_id: "T123", user_id: "U_BOT", is_bot: true, is_enterprise_install: false },
+          ],
+        },
+      },
+      offset: 47,
+    }) as Extract<
+      ConsumedEvent<typeof SlackAgentProcessorContract>,
+      { type: "events.iterate.com/slack/webhook-received" }
+    >;
+
+    await createSlackAgentProcessor({
+      callSlackApi: async (method, body) => {
+        slackCalls.push({ method, body });
+      },
+    }).implementation.afterAppend?.({
+      event,
+      previousState: registeredSlackAgentState(),
+      state: registeredSlackAgentState({
+        botUserId: "U_BOT",
+        channel: "C123",
+        threadTs: "1772136258.963519",
+      }),
+      streamApi: testSlackAgentStreamApi(appended),
+      signal: new AbortController().signal,
+    });
+
+    expect(slackCalls).toEqual([]);
+    expect(appended).toHaveLength(1);
+    expect(appended[0].event).toMatchObject({
+      type: "events.iterate.com/agent/input-added",
+      idempotencyKey: "slack-agent/slack-webhook-to-agent-input@47",
+      payload: {
+        content: expect.stringContaining("<@U_BOT> deployment says hello"),
+      },
+    });
+  });
+
   it("emits agent input for raw Slack interactivity payloads", async () => {
     const appended: Array<{ streamPath?: string; event: StreamEventInput }> = [];
     const event = committedEvent({
@@ -409,6 +465,49 @@ it("ignores webhook events caused by our own bot user (e.g. bot adding a reactio
       },
     },
     offset: 50,
+  }) as Extract<
+    ConsumedEvent<typeof SlackAgentProcessorContract>,
+    { type: "events.iterate.com/slack/webhook-received" }
+  >;
+
+  await createSlackAgentProcessor().implementation.afterAppend?.({
+    event,
+    previousState: registeredSlackAgentState(),
+    state: registeredSlackAgentState({
+      botUserId: "U_BOT",
+      channel: "C123",
+      latestMessageTs: "1772136259.000000",
+      threadTs: "1772136258.963519",
+    }),
+    streamApi: testSlackAgentStreamApi(appended),
+    signal: new AbortController().signal,
+  });
+
+  expect(appended).toEqual([]);
+});
+
+it("ignores message webhooks from our own bot user", async () => {
+  const appended: Array<{ streamPath?: string; event: StreamEventInput }> = [];
+  const event = committedEvent({
+    type: "events.iterate.com/slack/webhook-received",
+    payload: {
+      body: {
+        type: "event_callback",
+        event: {
+          type: "message",
+          channel: "C123",
+          user: "U_BOT",
+          bot_id: "B_BOT",
+          ts: "1772136259.000000",
+          event_ts: "1772136259.000000",
+          text: "our own reply",
+        },
+        authorizations: [
+          { team_id: "T123", user_id: "U_BOT", is_bot: true, is_enterprise_install: false },
+        ],
+      },
+    },
+    offset: 51,
   }) as Extract<
     ConsumedEvent<typeof SlackAgentProcessorContract>,
     { type: "events.iterate.com/slack/webhook-received" }

--- a/packages/shared/src/streams/callable-subscriber-delivery.test.ts
+++ b/packages/shared/src/streams/callable-subscriber-delivery.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+import {
+  hasInactiveCallableSubscriberDeliveries,
+  selectCallableSubscriberDeliveries,
+  type CallableSubscriberDeliveryQueue,
+} from "./callable-subscriber-delivery.ts";
+
+describe("callable subscriber delivery scheduling", () => {
+  test("selects one queued event for every inactive subscriber", () => {
+    const queue: CallableSubscriberDeliveryQueue = {
+      "slack-agent:project:/agents/slack/thread": [2, 3, 4, 5],
+      "agent:project:/agents/slack/thread": [2, 3, 4, 5],
+    };
+
+    expect(
+      selectCallableSubscriberDeliveries({
+        activeSubscriberSlugs: new Set(),
+        queue,
+      }),
+    ).toEqual([
+      {
+        offsets: [2, 3, 4, 5],
+        subscriberSlug: "slack-agent:project:/agents/slack/thread",
+      },
+      {
+        offsets: [2, 3, 4, 5],
+        subscriberSlug: "agent:project:/agents/slack/thread",
+      },
+    ]);
+  });
+
+  test("lets a fast subscriber keep moving while another subscriber is still active", () => {
+    const queue: CallableSubscriberDeliveryQueue = {
+      "slack-agent:project:/agents/slack/thread": [3, 4, 5],
+      "agent:project:/agents/slack/thread": [2, 3, 4, 5],
+    };
+
+    expect(
+      selectCallableSubscriberDeliveries({
+        activeSubscriberSlugs: new Set(["agent:project:/agents/slack/thread"]),
+        queue,
+      }),
+    ).toEqual([
+      {
+        offsets: [3, 4, 5],
+        subscriberSlug: "slack-agent:project:/agents/slack/thread",
+      },
+    ]);
+    expect(
+      hasInactiveCallableSubscriberDeliveries({
+        activeSubscriberSlugs: new Set(["agent:project:/agents/slack/thread"]),
+        queue,
+      }),
+    ).toBe(true);
+  });
+
+  test("does not select a subscriber with an active delivery", () => {
+    const queue: CallableSubscriberDeliveryQueue = {
+      "slack-agent:project:/agents/slack/thread": [5],
+      "agent:project:/agents/slack/thread": [2],
+    };
+    const activeSubscriberSlugs = new Set([
+      "slack-agent:project:/agents/slack/thread",
+      "agent:project:/agents/slack/thread",
+    ]);
+
+    expect(
+      selectCallableSubscriberDeliveries({
+        activeSubscriberSlugs,
+        queue,
+      }),
+    ).toEqual([]);
+    expect(
+      hasInactiveCallableSubscriberDeliveries({
+        activeSubscriberSlugs,
+        queue,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/streams/callable-subscriber-delivery.ts
+++ b/packages/shared/src/streams/callable-subscriber-delivery.ts
@@ -1,0 +1,28 @@
+export type CallableSubscriberDeliveryQueue = Record<string, number[]>;
+
+export type CallableSubscriberDelivery = {
+  offsets: number[];
+  subscriberSlug: string;
+};
+
+export function selectCallableSubscriberDeliveries(args: {
+  activeSubscriberSlugs: ReadonlySet<string>;
+  queue: CallableSubscriberDeliveryQueue;
+}): CallableSubscriberDelivery[] {
+  const deliveries: CallableSubscriberDelivery[] = [];
+
+  for (const [subscriberSlug, offsets] of Object.entries(args.queue)) {
+    if (args.activeSubscriberSlugs.has(subscriberSlug)) continue;
+    if (offsets.length === 0) continue;
+    deliveries.push({ offsets: [...offsets], subscriberSlug });
+  }
+
+  return deliveries;
+}
+
+export function hasInactiveCallableSubscriberDeliveries(args: {
+  activeSubscriberSlugs: ReadonlySet<string>;
+  queue: CallableSubscriberDeliveryQueue;
+}) {
+  return selectCallableSubscriberDeliveries(args).length > 0;
+}

--- a/packages/shared/src/streams/external-subscriber-types.ts
+++ b/packages/shared/src/streams/external-subscriber-types.ts
@@ -3,6 +3,7 @@ import { Callable, FetchCallable } from "@iterate-com/shared/callable/descriptor
 import {
   GenericEvent as GenericEventBase,
   GenericEventInput as GenericEventInputBase,
+  EventTypeSchema,
 } from "./event-base-types.ts";
 import { STREAM_SUBSCRIPTION_CONFIGURED_TYPE } from "./core-event-types.ts";
 import { JsonataExpression } from "./jsonata-expression.ts";
@@ -24,6 +25,7 @@ const ExternalSubscriberBase = z.strictObject({
    */
   jsonataFilter: JsonataExpression.optional(),
   jsonataTransform: JsonataExpression.optional(),
+  eventTypes: z.array(EventTypeSchema).optional(),
 });
 
 export const ExternalWebsocketSubscriber = z.strictObject({

--- a/packages/shared/src/streams/external-subscriber.test.ts
+++ b/packages/shared/src/streams/external-subscriber.test.ts
@@ -342,6 +342,45 @@ describe("externalSubscriber", () => {
     }
   });
 
+  test("afterAppend skips callable subscribers whose eventTypes do not include the event", async () => {
+    const callable = {
+      type: "workers-rpc" as const,
+      via: {
+        type: "env-binding" as const,
+        bindingType: "durable-object-namespace" as const,
+        bindingName: "CODEMODE_SESSION",
+        durableObject: { name: "session-a" },
+      },
+      rpcMethod: "afterAppend",
+      argsMode: "object" as const,
+    };
+
+    try {
+      await externalSubscriberProcessor.afterAppend?.({
+        append: () => createEvent(),
+        event: createEvent({
+          streamPath: "/demo/callable-filtered",
+          type: "events.iterate.com/slack/webhook-received",
+          payload: { value: 42 },
+        }),
+        state: {
+          subscribersBySlug: {
+            agent: {
+              slug: "agent",
+              type: "callable",
+              callable,
+              eventTypes: ["events.iterate.com/agent/input-added"],
+            },
+          },
+        },
+      });
+
+      expect(dispatchCallableMock).not.toHaveBeenCalled();
+    } finally {
+      dispatchCallableMock.mockReset();
+    }
+  });
+
   test("afterAppend does not deliver subscription-configured events to webhook subscribers by default", async () => {
     try {
       await externalSubscriberProcessor.afterAppend?.({

--- a/packages/shared/src/streams/external-subscriber.ts
+++ b/packages/shared/src/streams/external-subscriber.ts
@@ -103,6 +103,27 @@ export async function publishExternalSubscriber(args: {
   await publishToExternalSubscriber(args);
 }
 
+export function externalSubscriberMayReceiveEvent(args: {
+  event: Event;
+  subscriber: ExternalSubscriber;
+}) {
+  if (args.subscriber.eventTypes != null && !args.subscriber.eventTypes.includes(args.event.type)) {
+    return false;
+  }
+
+  if (
+    (args.subscriber.type === "webhook" || args.subscriber.type === "callable") &&
+    args.event.type === STREAM_SUBSCRIPTION_CONFIGURED_TYPE &&
+    args.subscriber.jsonataFilter == null &&
+    (args.subscriber.eventTypes == null ||
+      !args.subscriber.eventTypes.includes(STREAM_SUBSCRIPTION_CONFIGURED_TYPE))
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
 export function hasExternalSubscribersOfType(
   state: ExternalSubscriberState,
   subscriberType: ExternalSubscriber["type"],
@@ -196,11 +217,7 @@ async function handleExternalSubscriberPublishError(args: {
 }
 
 async function evaluateFilter(args: { event: Event; subscriber: ExternalSubscriber }) {
-  if (
-    (args.subscriber.type === "webhook" || args.subscriber.type === "callable") &&
-    args.event.type === STREAM_SUBSCRIPTION_CONFIGURED_TYPE &&
-    args.subscriber.jsonataFilter == null
-  ) {
+  if (!externalSubscriberMayReceiveEvent(args)) {
     return false;
   }
 

--- a/packages/shared/src/streams/stream-durable-object.ts
+++ b/packages/shared/src/streams/stream-durable-object.ts
@@ -25,6 +25,12 @@ import {
   StreamState,
 } from "./types.ts";
 import { circuitBreakerProcessor } from "./circuit-breaker.ts";
+import {
+  hasInactiveCallableSubscriberDeliveries,
+  selectCallableSubscriberDeliveries,
+  type CallableSubscriberDelivery,
+  type CallableSubscriberDeliveryQueue,
+} from "./callable-subscriber-delivery.ts";
 import { migrate } from "./db/migrations/.generated/migrations.ts";
 import {
   getEventByIdempotencyKey,
@@ -34,8 +40,8 @@ import {
   upsertReducedState,
 } from "./db/queries/.generated/index.ts";
 import {
+  externalSubscriberMayReceiveEvent,
   externalSubscriberProcessor,
-  hasExternalSubscribersOfType,
   publishExternalSubscriber,
   publishExternalSubscribers,
   resetSubscriberSocketsForStream,
@@ -62,8 +68,6 @@ const LEGACY_CALLABLE_SUBSCRIBER_ALARM_QUEUE_KEY = "stream-do:callable-subscribe
 const CALLABLE_SUBSCRIBER_DELIVERY_QUEUE_KEY = "stream-do:callable-subscriber-delivery-queue-v2";
 const CALLABLE_SUBSCRIBER_ALARM_DELAY_MS = 10;
 const NON_CALLABLE_SUBSCRIBERS = new Set(["webhook", "websocket"] as const);
-
-type CallableSubscriberDeliveryQueue = Record<string, number[]>;
 
 const StreamDurableObjectLifecycleBase = withLifecycleHooks<
   StreamDurableObjectStructuredName,
@@ -323,8 +327,13 @@ export class StreamDurableObject extends StreamDurableObjectBase<StreamDurableOb
     this._state = nextState;
 
     for (const event of newEvents) {
-      await this.afterAppend(event);
+      await this.afterAppend(event, {
+        kickoffCallableSubscriberDeliveries: false,
+        queueCallableSubscriberDelivery: false,
+      });
     }
+    await this.enqueueCallableSubscriberDeliveries(newEvents);
+    await this.ensureCallableSubscriberAlarmIfQueued();
 
     return events;
   }
@@ -420,7 +429,13 @@ export class StreamDurableObject extends StreamDurableObjectBase<StreamDurableOb
    * Correctness-critical derived work still needs a durable event/outbox cursor
    * before we rely on it operationally.
    */
-  private async afterAppend(event: Event) {
+  private async afterAppend(
+    event: Event,
+    options: {
+      kickoffCallableSubscriberDeliveries?: boolean;
+      queueCallableSubscriberDelivery?: boolean;
+    } = {},
+  ) {
     this.publish(event);
 
     if (event.type === STREAM_FIRST_INITIALIZED_TYPE) {
@@ -460,8 +475,11 @@ export class StreamDurableObject extends StreamDurableObjectBase<StreamDurableOb
       },
     });
 
-    if (this.shouldQueueCallableSubscriberDelivery(event)) {
-      await this.enqueueCallableSubscriberDelivery(event.offset).catch((error) => {
+    if (
+      options.queueCallableSubscriberDelivery !== false &&
+      this.shouldQueueCallableSubscriberDelivery(event)
+    ) {
+      await this.enqueueCallableSubscriberDelivery(event).catch((error) => {
         console.error("[stream-do] failed to enqueue callable subscriber delivery", {
           path: this.state.path,
           offset: event.offset,
@@ -481,6 +499,9 @@ export class StreamDurableObject extends StreamDurableObjectBase<StreamDurableOb
           },
         });
       });
+      if (options.kickoffCallableSubscriberDeliveries !== false) {
+        await this.ensureCallableSubscriberAlarmIfQueued();
+      }
     }
   }
 
@@ -489,8 +510,7 @@ export class StreamDurableObject extends StreamDurableObjectBase<StreamDurableOb
       return;
     }
 
-    await this.deliverNextCallableSubscriber();
-    await this.ensureCallableSubscriberAlarmIfQueued();
+    await this.kickoffQueuedCallableSubscriberDeliveries();
   }
 
   // ---------------------------------------------------------------------------
@@ -666,82 +686,192 @@ export class StreamDurableObject extends StreamDurableObjectBase<StreamDurableOb
     );
   }
 
+  private callableSubscribersForEvent(event: Event) {
+    return this.callableSubscribers().filter((subscriber) =>
+      externalSubscriberMayReceiveEvent({ event, subscriber }),
+    );
+  }
+
   private shouldQueueCallableSubscriberDelivery(event: Event) {
     if (isInternalExternalSubscriberErrorEvent(event)) {
       return false;
     }
 
-    return hasExternalSubscribersOfType(this.state.processors["external-subscriber"], "callable");
+    return this.callableSubscribersForEvent(event).length > 0;
   }
 
-  private async enqueueCallableSubscriberDelivery(offset: number) {
-    await this.mutateCallableSubscriberDeliveryQueue((queue) => {
-      for (const subscriber of this.callableSubscribers()) {
-        const offsets = queue[subscriber.slug] ?? [];
-        if (!offsets.includes(offset)) {
-          queue[subscriber.slug] = [...offsets, offset];
+  private async enqueueCallableSubscriberDelivery(event: Event) {
+    await this.enqueueCallableSubscriberDeliveries([event]);
+  }
+
+  private async enqueueCallableSubscriberDeliveries(events: Event[]) {
+    const deliveries = events.flatMap((event) =>
+      this.callableSubscribersForEvent(event).map((subscriber) => ({
+        event,
+        subscriberSlug: subscriber.slug,
+      })),
+    );
+    if (deliveries.length === 0) {
+      return;
+    }
+
+    try {
+      await this.mutateCallableSubscriberDeliveryQueue((queue) => {
+        for (const { event, subscriberSlug } of deliveries) {
+          const offsets = queue[subscriberSlug] ?? [];
+          if (!offsets.includes(event.offset)) {
+            queue[subscriberSlug] = [...offsets, event.offset];
+          }
         }
+        return queue;
+      });
+
+      await this.scheduleCallableSubscriberAlarm();
+    } catch (error) {
+      for (const event of events) {
+        if (!this.shouldQueueCallableSubscriberDelivery(event)) continue;
+        console.error("[stream-do] failed to enqueue callable subscriber delivery", {
+          path: this.state.path,
+          offset: event.offset,
+          eventType: event.type,
+          error,
+        });
+        this.appendProcessorErrorEvent({
+          event,
+          idempotencyKey: `stream-do:callable-subscriber-enqueue-error:${event.offset}`,
+          message: `Failed to enqueue callable subscriber delivery for ${event.type} at offset ${event.offset}: ${formatErrorMessage(error)}`,
+          metadata: {
+            source: "stream-do",
+            processor: "external-subscriber",
+            stage: "enqueue-callable-subscriber-delivery",
+            failedEventOffset: event.offset,
+            failedEventType: event.type,
+          },
+        });
       }
-      return queue;
+    }
+  }
+
+  private async deliverQueuedCallableSubscribers() {
+    const queue = await this.readCallableSubscriberDeliveryQueue();
+    const deliveries = selectCallableSubscriberDeliveries({
+      activeSubscriberSlugs: this.activeCallableSubscriberDeliveries,
+      queue,
     });
 
-    await this.scheduleCallableSubscriberAlarm();
+    for (const delivery of deliveries) {
+      this.startCallableSubscriberDelivery(delivery);
+    }
   }
 
-  private async deliverNextCallableSubscriber() {
-    const queue = await this.readCallableSubscriberDeliveryQueue();
-    const delivery = this.nextCallableSubscriberDelivery(queue);
-    if (delivery == null) {
-      return;
-    }
+  private async kickoffQueuedCallableSubscriberDeliveries() {
+    await this.deliverQueuedCallableSubscribers();
+    await this.ensureCallableSubscriberAlarmIfQueued();
+  }
 
-    const event = this.getEventByOffset(delivery.offset);
-    if (event == null) {
-      this.appendProcessorErrorEvent({
-        event: null,
-        idempotencyKey: `stream-do:callable-subscriber-missing-event:${delivery.subscriberSlug}:${delivery.offset}`,
-        message: `Callable subscriber "${delivery.subscriberSlug}" delivery could not find event at offset ${delivery.offset}.`,
-        metadata: {
-          source: "stream-do",
-          processor: "external-subscriber",
-          stage: "deliver-callable-subscriber",
-          missingEventOffset: delivery.offset,
-          subscriberSlug: delivery.subscriberSlug,
-        },
-      });
-      await this.removeCallableSubscriberDelivery(delivery);
-      return;
-    }
-
-    const subscriber =
-      this.state.processors["external-subscriber"].subscribersBySlug[delivery.subscriberSlug];
-    if (subscriber?.type !== "callable") {
-      await this.removeCallableSubscriberDelivery(delivery);
+  private startCallableSubscriberDelivery(delivery: CallableSubscriberDelivery) {
+    if (this.activeCallableSubscriberDeliveries.has(delivery.subscriberSlug)) {
       return;
     }
 
     this.activeCallableSubscriberDeliveries.add(delivery.subscriberSlug);
-    try {
-      await publishExternalSubscriber({
-        append: (nextEvent) => Promise.resolve(this.append(nextEvent)),
-        callableContext: {
-          env: this.env as Record<string, unknown>,
-        },
-        event,
-        onError: (failure) => {
-          this.appendExternalSubscriberDeliveryError(failure);
-        },
-        subscriber,
+    void this.deliverCallableSubscriber(delivery).catch((error) => {
+      console.error("[stream-do] callable subscriber delivery failed", {
+        path: this.state.path,
+        offsets: delivery.offsets,
+        subscriberSlug: delivery.subscriberSlug,
+        error,
       });
+      this.appendProcessorErrorEvent({
+        event: null,
+        idempotencyKey: `stream-do:callable-subscriber-delivery-error:${delivery.subscriberSlug}:${delivery.offsets.join(",")}`,
+        message: `Callable subscriber "${delivery.subscriberSlug}" delivery failed at offsets ${delivery.offsets.join(", ")}: ${formatErrorMessage(error)}`,
+        metadata: {
+          source: "stream-do",
+          processor: "external-subscriber",
+          stage: "deliver-callable-subscriber",
+          failedEventOffsets: delivery.offsets.join(","),
+          subscriberSlug: delivery.subscriberSlug,
+        },
+      });
+    });
+  }
+
+  private async deliverCallableSubscriber(delivery: CallableSubscriberDelivery) {
+    let offsetsToRemove = delivery.offsets;
+    try {
+      const subscriber =
+        this.state.processors["external-subscriber"].subscribersBySlug[delivery.subscriberSlug];
+      if (subscriber?.type !== "callable") {
+        return;
+      }
+
+      offsetsToRemove = [];
+      for (const offset of delivery.offsets) {
+        try {
+          const event = this.getEventByOffset(offset);
+          if (event == null) {
+            this.appendProcessorErrorEvent({
+              event: null,
+              idempotencyKey: `stream-do:callable-subscriber-missing-event:${delivery.subscriberSlug}:${offset}`,
+              message: `Callable subscriber "${delivery.subscriberSlug}" delivery could not find event at offset ${offset}.`,
+              metadata: {
+                source: "stream-do",
+                processor: "external-subscriber",
+                stage: "deliver-callable-subscriber",
+                missingEventOffset: offset,
+                subscriberSlug: delivery.subscriberSlug,
+              },
+            });
+            offsetsToRemove.push(offset);
+            continue;
+          }
+
+          await publishExternalSubscriber({
+            append: (nextEvent) => Promise.resolve(this.append(nextEvent)),
+            callableContext: {
+              env: this.env as Record<string, unknown>,
+            },
+            event,
+            onError: (failure) => {
+              this.appendExternalSubscriberDeliveryError(failure);
+            },
+            subscriber,
+          });
+          offsetsToRemove.push(offset);
+        } catch (error) {
+          this.appendProcessorErrorEvent({
+            event: null,
+            idempotencyKey: `stream-do:callable-subscriber-delivery-error:${delivery.subscriberSlug}:${offset}`,
+            message: `Callable subscriber "${delivery.subscriberSlug}" delivery failed at offset ${offset}: ${formatErrorMessage(error)}`,
+            metadata: {
+              source: "stream-do",
+              processor: "external-subscriber",
+              stage: "deliver-callable-subscriber",
+              failedEventOffset: offset,
+              subscriberSlug: delivery.subscriberSlug,
+            },
+          });
+        }
+      }
     } finally {
       this.activeCallableSubscriberDeliveries.delete(delivery.subscriberSlug);
-      await this.removeCallableSubscriberDelivery(delivery);
+      await this.removeCallableSubscriberDeliveries({
+        offsets: offsetsToRemove,
+        subscriberSlug: delivery.subscriberSlug,
+      });
+      await this.ensureCallableSubscriberAlarmIfQueued();
     }
   }
 
   private async ensureCallableSubscriberAlarmIfQueued() {
     const queue = await this.readCallableSubscriberDeliveryQueue();
-    if (this.hasInactiveCallableSubscriberDelivery(queue)) {
+    if (
+      hasInactiveCallableSubscriberDeliveries({
+        activeSubscriberSlugs: this.activeCallableSubscriberDeliveries,
+        queue,
+      })
+    ) {
       await this.scheduleCallableSubscriberAlarm();
     }
   }
@@ -780,16 +910,14 @@ export class StreamDurableObject extends StreamDurableObjectBase<StreamDurableOb
     await this.ctx.storage.put(CALLABLE_SUBSCRIBER_DELIVERY_QUEUE_KEY, compacted);
   }
 
-  private async removeCallableSubscriberDelivery(delivery: {
-    offset: number;
+  private async removeCallableSubscriberDeliveries(delivery: {
+    offsets: number[];
     subscriberSlug: string;
   }) {
+    const deliveredOffsets = new Set(delivery.offsets);
     await this.mutateCallableSubscriberDeliveryQueue((queue) => {
       const offsets = queue[delivery.subscriberSlug] ?? [];
-      const index = offsets.indexOf(delivery.offset);
-      if (index >= 0) {
-        queue[delivery.subscriberSlug] = [...offsets.slice(0, index), ...offsets.slice(index + 1)];
-      }
+      queue[delivery.subscriberSlug] = offsets.filter((offset) => !deliveredOffsets.has(offset));
       return queue;
     });
   }
@@ -806,23 +934,6 @@ export class StreamDurableObject extends StreamDurableObjectBase<StreamDurableOb
       () => undefined,
     );
     return await nextMutation;
-  }
-
-  private nextCallableSubscriberDelivery(queue: CallableSubscriberDeliveryQueue) {
-    for (const [subscriberSlug, offsets] of Object.entries(queue).sort(([left], [right]) =>
-      left.localeCompare(right),
-    )) {
-      if (this.activeCallableSubscriberDeliveries.has(subscriberSlug)) continue;
-      const offset = offsets[0];
-      if (offset == null) continue;
-      return { offset, subscriberSlug };
-    }
-
-    return null;
-  }
-
-  private hasInactiveCallableSubscriberDelivery(queue: CallableSubscriberDeliveryQueue) {
-    return this.nextCallableSubscriberDelivery(queue) != null;
   }
 
   private callableSubscribers() {

--- a/tasks/slack-agent-independent-subscriber-delivery.md
+++ b/tasks/slack-agent-independent-subscriber-delivery.md
@@ -1,0 +1,589 @@
+---
+state: todo
+priority: high
+size: large
+dependsOn: []
+---
+
+# Make stream callable subscriber delivery independent
+
+Slack agent reactions regressed from roughly 1-2 seconds to roughly 15-20
+seconds on cold Slack threads because callable subscribers on a stream were
+effectively serialized behind whichever subscriber the Stream Durable Object
+picked first.
+
+The desired behavior is: every subscriber should deliver events as quickly as it
+can, independently from other subscribers, while preserving event order within a
+single subscriber.
+
+## Findings
+
+Slack routed streams are bootstrapped with at least two callable subscribers:
+
+1. `slack-agent:<projectId>:<streamPath>`
+2. `agent:<projectId>:<streamPath>`
+
+`slack-agent` owns lightweight Slack side effects, including adding the `eyes`
+reaction and forwarding bang commands into codemode. The generic `agent`
+subscriber owns heavier agent startup, including workspace setup, repo state,
+codemode session wiring, provider registration, LLM setup, and websocket
+subscriptions.
+
+The stream runtime kept a callable delivery queue per subscriber, but the
+delivery selector sorted subscriber slugs alphabetically and selected one
+subscriber delivery per alarm. Since `agent:...` sorts before `slack-agent:...`,
+new Slack thread handling often ran heavy generic agent startup before the
+lightweight Slack side effects.
+
+Production evidence from 2026-05-19:
+
+- Slow stream: `/agents/slack/c08r1smtzgd/ts-1779192365-251829`
+- Human Slack message timestamp: `2026-05-19T12:06:05.251829Z`
+- Routed stream webhook event appended: `2026-05-19T12:06:11.280Z`
+- LLM provider setup observed: `2026-05-19T12:06:12.763Z`
+- LLM request requested: `2026-05-19T12:06:26.566Z`
+- First Slack output: `2026-05-19T12:06:30.381Z`
+- Slack post completed: `2026-05-19T12:06:32.157Z`
+- `eyes` reaction event timestamp: `2026-05-19T12:06:25.009800Z`
+- OS received the reaction webhook back from Slack: `2026-05-19T12:06:27.713Z`
+
+Cloudflare traces matched this shape. A routed stream alarm spent about 7.8s in
+`AgentDurableObject.afterAppend` while the Slack-specific subscriber was still
+waiting for its turn.
+
+## Suspicious Changes
+
+- `8e21410f2` - "Add OS2 integrations and Slack stream-agent routing"
+  - Introduced Slack routed streams and callable subscriber routing.
+  - The callable subscriber delivery selector sorted subscriber slugs, which put
+    `agent:` before `slack-agent:`.
+
+- `b42281cf1` - "Add OS2 repos and prepared agent workspaces"
+  - Made generic agent startup heavier by awaiting prepared workspace setup.
+  - This is not wrong by itself, but it made the delivery-ordering bug much more
+    visible.
+
+- `74d4f834a` - lowered agent debounce from 1000ms to 200ms.
+  - This is unlikely to be the cause of `eyes` latency and should usually
+    improve response latency.
+
+## Current Implementation Direction
+
+The intended fix is independent callable subscriber delivery:
+
+- At most one active delivery per subscriber slug.
+- Different subscriber slugs may deliver concurrently.
+- Each subscriber removes only its own delivered offset.
+- A fast subscriber schedules its next delivery turn without waiting for slow
+  subscribers to finish.
+
+The current implementation work adds:
+
+- `packages/shared/src/streams/callable-subscriber-delivery.ts`
+  - Selects one queued offset for every currently inactive subscriber.
+  - Leaves active subscribers alone.
+
+- `packages/shared/src/streams/callable-subscriber-delivery.test.ts`
+  - Covers one queued event per inactive subscriber.
+  - Covers a fast `slack-agent` subscriber continuing while `agent` is active.
+  - Covers skipping active subscribers.
+
+- `packages/shared/src/streams/stream-durable-object.ts`
+  - Starts one fire-and-forget delivery per inactive subscriber.
+  - Tracks active subscriber slugs in memory.
+  - On completion, removes only that subscriber's offset and reschedules if more
+    queue work remains.
+
+This is the right high-level shape, but it exposed real reentrancy and startup
+ordering assumptions elsewhere in `apps/os`.
+
+## Reentrancy Issues Already Found
+
+Independent subscriber delivery made `agent` and `slack-agent` startup overlap.
+That surfaced these hazards:
+
+- Prepared repo creation could race and fail with
+  `repo already exists: <project>--iterate-config`.
+- Stream processor registration could race and fail with
+  `Stream processor "agent-chat" is already registered`.
+- `slack-agent` could emit a codemode script request before generic `agent`
+  startup had created the codemode session and registered providers.
+- `CodemodeSessionDurableObject` could receive provider/script events before an
+  explicit initialize call and throw `Durable Object has not been initialized`.
+
+Patches currently in flight address part of this:
+
+- Repo creation is serialized per Repo Durable Object instance and recovers if
+  the artifact repo already exists.
+- Stream processor registration is idempotent for the same slug/version.
+- Slack routed stream bootstrap now includes codemode session startup events and
+  baseline providers.
+- Codemode session methods can initialize themselves from their runtime Durable
+  Object name when needed.
+
+## Real Slack Bot-Message Probe
+
+After the subscriber delivery and bootstrap fixes, the focused prod e2e passed,
+but a real Slack probe still did not wake the agent:
+
+- Probe message: `<@U08NQR1GCRE> codex latency probe ...`
+- Sender: another Slack bot user, `U0964BNAYEM` / `B0964BNAJEM`
+- Routed stream: `/agents/slack/c08r1smtzgd/ts-1779197713-901949`
+
+The integration stream routed the event correctly, and the routed stream
+bootstrapped `slack-agent`, codemode, and the generic agent. However, no
+`agent/input-added` event appeared for the message. The `slack-agent` processor
+was still filtering any Slack event with a `bot_id` or `bot_profile`, which
+meant messages from other bots could not wake Iterate.
+
+The desired policy is narrower:
+
+- Ignore actions performed by our own Iterate bot user.
+- Do not ignore messages from other bots.
+- Other bots may wake Iterate just like human users.
+
+The implemented patch removes the broad `isBotMessage` filter and keeps only the
+`isBotAction(slackEvent, state.botUserId)` guard.
+
+Production verification after the patch:
+
+- Probe message timestamp: `1779198240.251909`
+- OS received the Slack message webhook: `2026-05-19T13:44:06.530Z`
+- Routed stream configured: `2026-05-19T13:44:06.903Z`
+- Routed stream initialized: `2026-05-19T13:44:07.972Z`
+- `slack-agent` registered: `2026-05-19T13:44:10.802Z`
+- `agent/input-added` for the other bot message: `2026-05-19T13:44:11.208Z`
+- `eyes` reaction webhook received back from Slack: `2026-05-19T13:44:13.979Z`
+- LLM request requested: `2026-05-19T13:44:17.738Z`
+- Slack reply posted: `2026-05-19T13:44:25.297Z`
+- The reply text reported `23727ms since 2026-05-19T13:44:00.032Z`.
+
+This confirms the bot-message filter bug is fixed, but the overall live reply
+latency is still much higher than the old 1-2 second target.
+
+## Current State After 2026-05-19 Revert
+
+The product design is now explicit:
+
+- Provider registrations remain separate stream events.
+- Each provider registration is transcribed into its own `agent/input-added`
+  event.
+- A separate generic Agent Durable Object still owns the agent loop.
+- A separate Slack Agent Durable Object still owns Slack-specific routing and
+  Slack side effects.
+- Performance work must make this event volume cheap; it must not collapse
+  provider registrations into one synthetic input.
+
+A short-lived provider-summary experiment violated that design by marking
+codemode provider registration events as pre-rendered and appending one synthetic
+agent input summarising providers. That caused the bot to respond to the
+provider summary rather than the Slack user message. The experiment was reverted:
+
+- Removed `skipProviderRegistrationInput` handling from the agent processor.
+- Removed the synthetic Slack provider-summary input.
+- Removed the test that asserted provider-registration rendering could be
+  skipped.
+
+Validation after the revert:
+
+- `pnpm --dir packages/shared exec vitest run src/stream-processors/agent/implementation.test.ts src/streams/callable-subscriber-delivery.test.ts src/streams/external-subscriber.test.ts src/stream-processors/slack-agent/slack-agent.test.ts`
+  passed: 37 tests.
+- `pnpm --filter @iterate-com/shared typecheck` passed.
+- `pnpm --dir apps/os typecheck` passed.
+- Production deploy to `prd` completed.
+- Focused production Slack e2e passed:
+  `routes Slack webhooks into slack-agent streams and executes bang command replies`.
+
+The latest good latency improvement is on the ingress reaction path, not the
+full reply path. Moving `reactions.add` into the Slack webhook ingress and
+batching the integration subscription plus webhook append removed the
+`SlackIntegration.ensureReady()` wait from the hot path. In the best observed
+probe, Slack's reaction event timestamp was about 1.08s after the original
+message timestamp.
+
+The remaining full-reply latency is still too high. The correct next target is
+processor throughput and startup cost under many events:
+
+- Generic agent startup still begins several seconds after routed stream
+  bootstrap on cold Slack threads.
+- Provider registration events generate multiple agent-input events, which is
+  correct, but the agent processor should catch up quickly.
+- The agent processor currently performs one append/reduce cycle per rendered
+  model-visible event. That is the likely place to investigate batching,
+  catch-up efficiency, and trace-level timings without changing event semantics.
+
+## 2026-05-19 Root Cause Update: Event Volume Amplification
+
+The best current explanation is not that provider registrations are the wrong
+semantic unit. The problem is that the stream runtime made each event too
+expensive:
+
+- Callable subscriber delivery could recurse through the same request chain.
+  A subscriber handled event N, appended event N+1, and the Stream Durable
+  Object immediately kicked off more callable delivery before returning. With
+  codemode and agent processors appending follow-up events, this produced
+  Cloudflare `Subrequest depth limit exceeded` errors.
+- The stream queues every callable subscriber for many events even if that
+  subscriber will later no-op after checking its filter or consumed event set.
+- The callable delivery queue is stored as arrays in one KV value. Each enqueue
+  and removal copies arrays and rewrites the queue, so many bootstrap/provider
+  events amplify queue churn.
+- The generic Agent Durable Object startup still does expensive pre-catch-up
+  work, including prepared workspace setup, codemode session setup, full stream
+  reads, processor catch-up, and another full stream read before the LLM handoff.
+
+The patch deployed after this finding makes callable subscriber delivery
+strictly outbox/alarm-driven: append requests enqueue callable work and ensure
+an alarm, while the alarm starts deliveries. Different subscriber slugs can
+still run independently, and each subscriber remains ordered, but event cascades
+now cross a request boundary instead of recursively growing one Worker call
+chain.
+
+Verification immediately after that deployment:
+
+- Focused shared tests passed: 37 tests.
+- `pnpm --filter @iterate-com/shared typecheck` passed.
+- `pnpm --dir apps/os typecheck` passed.
+- Focused prod e2e passed:
+  - `uses OpenAI for unconfigured agent chats by default`
+  - `routes Slack webhooks into slack-agent streams and executes bang command replies`
+- Full prod agent e2e passed: `apps/os/e2e/vitest/agents.e2e.test.ts`
+  passed all 9 tests in about 173s.
+
+The next high-value performance fix is subscriber filtering at enqueue time:
+only queue subscribers whose `jsonataFilter` or explicit consumed-event filter
+matches the event. This should reduce the number of queued callable deliveries
+without changing event semantics.
+
+That filter is now implemented for new subscription events:
+
+- `ExternalSubscriber` accepts an optional `eventTypes` list.
+- Stream callable delivery uses `eventTypes` before queueing a subscriber for an
+  event, so subscribers are not woken for event types their processor contract
+  does not consume.
+- Slack routed stream bootstrap now records contract-derived filters for
+  `slack-agent`, `codemode-session`, and `agent`.
+- Slack integration ingress records a contract-derived filter for the
+  integration-level Slack router subscription.
+- Focused shared tests passed after this change: 38 tests.
+- `pnpm --filter @iterate-com/shared typecheck` passed.
+- `pnpm --dir apps/os typecheck` passed.
+- Production deploy to `prd` completed.
+- Full prod agent e2e passed after deploy: all 9 tests in about 175s.
+
+This is still a mitigation, not the rigorous end state. Existing streams whose
+subscription events were already appended will keep their old subscriber
+payloads because those events are idempotent. New Slack routed streams should
+benefit immediately after deploy.
+
+The latest real Slack probe after the strict alarm/outbox deployment still had
+poor end-to-end latency:
+
+- Probe marker: `2026-05-19T14:32:41.418Z`
+- Slack message event timestamp: `1779201161.662109`
+- OS integration stream created the message webhook event at
+  `2026-05-19T14:32:57.348Z`
+- Slack `eyes` reaction event timestamp: `1779201177.017500`
+- Bot reply webhook event was created at `2026-05-19T14:33:21.206Z`
+
+That probe suggests a large chunk of latency happened before OS appended the
+message webhook event, so the remaining performance work needs trace-level
+separation between Slack delivery/ingress delay and OS stream processing delay.
+
+## 2026-05-19 Latest Latency Update
+
+Further production probes narrowed the regression:
+
+- The `eyes` reaction path is now fast. Ingress starts `reactions.add` from the
+  Slack webhook handler without awaiting SlackAgent startup, and Slack's own
+  reaction event timestamp was about 0.8-1.1s after the original Slack message
+  in the good probes.
+- The full reply path was still slow because the LLM request was being pushed
+  behind setup and provider transcription work.
+- A duplicate awaited `reactions.add` in SlackAgent was removed. Ingress already
+  owns the fast reaction, so SlackAgent should not block `agent/input-added` on
+  a second reaction call.
+- Slack generic Agent startup now warms workspace setup in the background for
+  `/agents/slack/...` streams. Non-Slack agents still await workspace/codemode
+  setup as before.
+- OpenAI-backed agents now get `agent/llm-config-updated` with the intended
+  `debounceMs: 200`. Previously only the OpenAI provider config was appended,
+  so the generic Agent processor scheduled with its schema default of 1000ms.
+- Slack routed-stream bootstrap now includes the default agent setup events
+  before the first forwarded Slack webhook, so the first Slack input sees the
+  correct model, system prompt, and debounce config.
+
+An experiment to kick off callable delivery immediately after the durable queue
+write was reverted. Full prod e2e showed it could reintroduce Cloudflare
+`Subrequest depth limit exceeded` during codemode provider bootstrap. The safer
+state for this PR keeps strict alarm/outbox-driven callable delivery and treats
+faster non-recursive wakeup as follow-up work.
+
+Measured prod probe after routed-bootstrap/debounce fixes:
+
+- Probe marker: `2026-05-19T15:07:08.034Z 8ac7841b`
+- Slack message timestamp: `1779203228.236919`
+- OS integration stream created the message webhook event at
+  `2026-05-19T15:07:12.240Z` (~4.0s after Slack timestamp).
+- Routed stream bootstrap and forwarded webhook were appended at
+  `2026-05-19T15:07:14.945Z` (~2.7s after integration event creation).
+- First Slack webhook `agent/input-added` was appended at
+  `2026-05-19T15:07:17.057Z`.
+- The Agent drained provider registration inputs until
+  `2026-05-19T15:07:19.333Z`.
+- `agent/llm-request-scheduled` was appended at `2026-05-19T15:07:19.378Z`
+  with `debounceMs: 200` and `model: gpt-5.5`.
+- `agent/llm-request-requested` followed at `2026-05-19T15:07:19.693Z`.
+- OpenAI completed in about 3.9s.
+- Slack `chat.postMessage` completed in about 1.5s.
+- Slack reply timestamp was `1779203245.654419`, about 17.4s after the original
+  message timestamp.
+
+Follow-up probe after batching Agent processor derived appends for provider
+registration inputs:
+
+- Probe marker: `2026-05-19T15:21:13.638Z b1535350`
+- Slack message timestamp: `1779204073.823699`
+- OS integration stream created the message webhook event at
+  `2026-05-19T15:21:16.624Z` (~2.8s after Slack timestamp).
+- Routed stream bootstrap and forwarded webhook were appended at
+  `2026-05-19T15:21:19.393Z` (~2.8s after integration event creation).
+- First Slack webhook `agent/input-added` was appended at
+  `2026-05-19T15:21:21.266Z`.
+- Provider registration inputs drained from `2026-05-19T15:21:21.617Z` through
+  `2026-05-19T15:21:22.306Z`.
+- `agent/llm-request-scheduled` was appended at `2026-05-19T15:21:22.350Z`
+  with `debounceMs: 200` and `model: gpt-5.5`.
+- `agent/llm-request-requested` followed at `2026-05-19T15:21:23.978Z`.
+- OpenAI completed in about 4.7s.
+- Slack `chat.postMessage` completed in about 1.1s.
+- Slack reply timestamp was `1779204090.131099`, about 16.3s after the original
+  message timestamp.
+
+The provider append batching reduced the one-by-one append shape in the Agent
+processor, but the probe still shows the end-to-end path is dominated by
+Slack-to-ingress variance, integration-to-routed bootstrap, cold provider input
+drain, the alarm/debounce wakeup path, OpenAI time, and Slack post time.
+
+Follow-up probes after batching callable queue writes, draining all queued
+offsets for a subscriber in one alarm turn, and directly waking the Slack
+integration DO from Slack ingress:
+
+- Probe marker: `2026-05-19T15:33:53.632Z c2d9ed85`
+  - Slack message timestamp: `1779204833.810399`
+  - OS integration stream created the message webhook event at
+    `2026-05-19T15:33:55.955Z` (~2.1s after Slack timestamp).
+  - Routed stream bootstrap and forwarded webhook were appended at
+    `2026-05-19T15:33:57.761Z` (~1.8s after integration event creation).
+  - First Slack webhook `agent/input-added` was appended at
+    `2026-05-19T15:33:59.565Z`.
+  - Provider registration inputs drained through `2026-05-19T15:34:00.160Z`.
+  - `agent/llm-request-scheduled` was appended at `2026-05-19T15:34:00.253Z`;
+    `agent/llm-request-requested` followed at `2026-05-19T15:34:00.555Z`.
+  - OpenAI completed in about 4.6s.
+  - Slack `chat.postMessage` completed in about 1.9s.
+  - Slack reply timestamp was `1779204847.421199`, about 13.6s after the
+    original message timestamp.
+- Probe marker: `2026-05-19T15:37:09.815Z dc461a34`
+  - Slack message timestamp: `1779205029.994629`
+  - OS integration stream created the message webhook event at
+    `2026-05-19T15:37:14.071Z` (~4.1s after Slack timestamp).
+  - Routed stream bootstrap and forwarded webhook were appended at
+    `2026-05-19T15:37:16.643Z` (~2.6s after integration event creation).
+  - First Slack webhook `agent/input-added` was appended at
+    `2026-05-19T15:37:18.221Z`.
+  - Provider registration inputs drained through `2026-05-19T15:37:19.634Z`.
+  - `agent/llm-request-scheduled` was appended at `2026-05-19T15:37:19.704Z`;
+    `agent/llm-request-requested` followed at `2026-05-19T15:37:20.857Z`.
+  - OpenAI completed in about 4.0s.
+  - Slack `chat.postMessage` completed in about 1.6s.
+  - Slack reply timestamp was `1779205046.870599`, about 16.9s after the
+    original message timestamp.
+
+The latest code does improve the middle of the path: provider input transcription
+is no longer obviously one alarm per original provider event, and one probe had
+schedule-to-request around 300ms. The hard remaining gaps are still before or
+around route creation: Slack delivery to OS can vary by several seconds, and
+integration-to-routed remains 1.8-2.6s in these probes.
+
+The latest split means the request-start bug is mostly fixed: schedule-to-request
+is now often hundreds of milliseconds instead of seconds, though it still varies.
+The largest remaining controllable costs are the integration-to-routed wake path
+and cold routed-stream bootstrap/provider-input drain before scheduling. That
+work still preserves the desired design, but it is too expensive:
+
+- Provider registrations remain separate stream events.
+- Each provider registration still becomes a separate `agent/input-added`.
+- The generic Agent processor currently appends those rendered inputs one by one
+  and waits for them to drain before the first LLM request is scheduled. The
+  current PR batches part of that append path, but the remaining cold-start
+  workflow is still too expensive.
+
+The next rigorous fix should keep those event semantics but make the bootstrap
+drain cheaper. Promising directions:
+
+- Precompute the provider-registration render inputs as part of routed-stream
+  bootstrap, while preserving one input per provider and the existing event
+  shapes.
+- Reduce alarm/debounce wakeup latency without reintroducing recursive
+  Cloudflare subrequest-depth failures.
+- Add trace spans around stream append, callable queue enqueue/kickoff,
+  subscriber delivery, Agent provider rendering, debounce firing, request
+  history read, OpenAI call, and Slack post.
+- Measure Cloudflare trace timings for Slack webhook ingress separately from
+  Slack's own event delivery, because recent probes still show 3-4s before OS
+  even creates the first integration-stream webhook event.
+
+## Fixed E2E Bootstrap Failure
+
+The focused prod e2e failure after introducing independent delivery was a
+codemode provider bootstrap race.
+
+The test was:
+
+```bash
+cd apps/os
+doppler run --project os --config prd -- \
+  sh -lc 'OS_BASE_URL="$APP_CONFIG_BASE_URL" OS_ADMIN_API_SECRET="$APP_CONFIG_ADMIN_API_SECRET" pnpm exec vitest run --config ./e2e/vitest.config.ts ./e2e/vitest/agents.e2e.test.ts -t "routes Slack webhooks"'
+```
+
+Observed failure:
+
+- The test posts a Slack follow-up bang command using `!debug`.
+- `slack-agent` emits a `codemode/script-execution-requested` event for a script
+  that calls `ctx.debug()`.
+- Codemode executes before the generic Agent Durable Object has registered the
+  `debug` provider.
+- The script completes with:
+
+```text
+No codemode provider registered for debug.
+```
+
+Then generic agent startup registers `debug` and other agent-specific providers
+afterward.
+
+The fix shares provider construction with `AgentDurableObject` and bootstraps
+the same baseline codemode providers when the Slack routed stream is configured.
+That makes Slack-routed streams able to execute bang commands before generic
+agent startup completes.
+
+## Rigorous Fix Plan
+
+1. Make Slack routed codemode bootstrap complete.
+   - Identify every provider Slack bang commands can call before generic agent
+     startup finishes.
+   - At minimum, bootstrap the `debug` provider because the e2e uses
+     `ctx.debug()`.
+   - Prefer sharing provider construction with `AgentDurableObject` rather than
+     duplicating provider literals in Slack integration code.
+   - Keep Slack-specific exclusions, such as avoiding the generic `agent-chat`
+     provider where Slack streams should not use it.
+
+2. Define the subscriber delivery contract explicitly.
+   - A subscriber receives events in offset order for its own slug.
+   - Different subscribers are independent and can run concurrently.
+   - A slow or failing subscriber must not block another subscriber's queue.
+   - Delivery state transitions must be observable and retry behavior must be
+     intentional.
+
+3. Move active delivery state out of process memory or make the in-memory model
+   formally safe.
+   - Current active subscriber tracking is in memory.
+   - That may be acceptable if pending delivery promises keep the Durable Object
+     instance alive, but it should be proven or hardened.
+   - A more durable design would persist per-subscriber leases/cursors so a DO
+     restart cannot accidentally duplicate or lose delivery progress.
+
+4. Audit subscriber startup for idempotency and reentrancy.
+   - `AgentDurableObject.afterAppend`
+   - workspace and repo setup
+   - codemode session startup
+   - stream processor registration
+   - provider registration
+   - Slack routed stream bootstrap
+
+5. Avoid recursive request and alarm blowups.
+   - Do not bulk-drain large subscriber backlogs in one alarm.
+   - Process one offset per subscriber turn, or use a very small bounded batch
+     only after subrequest-depth behavior is understood.
+   - Reschedule from the stream delivery path with clear limits.
+
+6. Add observability for subscriber lag.
+   - Log or trace subscriber slug, offset, queue wait, delivery duration,
+     completion status, and reschedule decisions.
+   - For Slack, track:
+     - Slack webhook received -> routed stream append
+     - routed stream append -> `slack-agent` input append
+     - routed stream append -> Slack `reactions.add` request/completion
+     - Slack post request -> Slack post completion
+
+7. Reduce remaining live latency.
+   - The bot-message fix made the real path functional again, but the 2026-05-19
+     prod probe still took roughly 24s end-to-end.
+   - Preserve separate provider events and separate agent inputs while doing
+     this.
+   - Split the latency budget by source:
+     - Slack post -> OS webhook append
+     - OS webhook append -> routed stream append
+     - routed stream append -> `slack-agent` input append
+     - `agent/input-added` -> LLM request requested
+     - LLM request requested -> first output
+     - output -> Slack post completion
+   - The latest probe showed large chunks before OS received the webhook and
+     before the LLM request was requested. Those need separate investigation
+     from subscriber independence.
+
+8. Gate the rollout with e2e and a live Slack probe.
+   - Run focused shared tests.
+   - Run `apps/os` unit/integration tests that cover project ingress, codemode
+     session behavior, and Slack stream routing.
+   - Run the full `apps/os/e2e/vitest/agents.e2e.test.ts` suite against preview
+     or prod, depending on environment availability.
+   - Inspect target streams for `events.iterate.com/core/error-occurred`.
+
+## Acceptance Criteria
+
+- `slack-agent` side effects are not delayed by generic `agent` startup.
+- A slow `agent` subscriber cannot block a fast `slack-agent` subscriber.
+- Each subscriber still sees its own events in offset order.
+- Slack routed bang commands can run before generic agent startup finishes.
+- Messages from other Slack bots can wake Iterate.
+- Messages/actions from Iterate's own bot do not recursively wake Iterate.
+- No `core/error-occurred` events are appended during normal Slack route e2e.
+- Focused shared tests and `apps/os/e2e/vitest/agents.e2e.test.ts` pass.
+
+## Verification Commands
+
+Focused shared checks:
+
+```bash
+pnpm --dir packages/shared exec vitest run src/streams/callable-subscriber-delivery.test.ts src/streams/external-subscriber.test.ts
+pnpm --filter @iterate-com/shared typecheck
+pnpm --filter @iterate-com/shared test:durable-object-utils:unit
+```
+
+Focused `apps/os` checks:
+
+```bash
+pnpm --dir apps/os typecheck
+pnpm --dir apps/os test
+pnpm --dir apps/os test:project-ingress
+pnpm --dir apps/os test:codemode-session
+```
+
+Focused prod Slack e2e:
+
+```bash
+cd apps/os
+doppler run --project os --config prd -- \
+  sh -lc 'OS_BASE_URL="$APP_CONFIG_BASE_URL" OS_ADMIN_API_SECRET="$APP_CONFIG_ADMIN_API_SECRET" pnpm exec vitest run --config ./e2e/vitest.config.ts ./e2e/vitest/agents.e2e.test.ts -t "routes Slack webhooks"'
+```
+
+Full targeted prod agent e2e:
+
+```bash
+cd apps/os
+doppler run --project os --config prd -- \
+  sh -lc 'OS_BASE_URL="$APP_CONFIG_BASE_URL" OS_ADMIN_API_SECRET="$APP_CONFIG_ADMIN_API_SECRET" pnpm exec vitest run --config ./e2e/vitest.config.ts ./e2e/vitest/agents.e2e.test.ts'
+```


### PR DESCRIPTION
## Summary

This PR is the current end state of the Slack agent latency investigation. It is based on latest `main` and keeps the product design intact:

- SlackAgent and generic Agent remain separate Durable Objects.
- Provider registrations remain separate stream events.
- Each provider registration still becomes its own `agent/input-added` event.
- Other Slack bots may wake Iterate; Iterate's own bot actions are ignored.

The changes make the path more robust and remove several avoidable delays, but latest prod probes are still ~13.6-16.9s end-to-end. This is a partial latency fix plus evidence-backed handoff, not the final “super fast” state.

## What Changed

### Stream callable delivery

- Added per-subscriber callable delivery selection so different subscriber slugs can make progress independently while each subscriber remains ordered.
- Added enqueue-time `eventTypes` filtering for callable subscribers so processors are not woken for event types they do not consume.
- Batched callable queue writes for `appendBatch()` so cold routed bootstrap does not rewrite the queue once per event.
- Changed delivery selection to drain all currently queued offsets for an inactive subscriber in order during one alarm turn, instead of one offset per alarm turn.
- Kept strict alarm/outbox-driven delivery for correctness. I tried immediate kickoff after queue writes, but full prod e2e reintroduced Cloudflare `Subrequest depth limit exceeded`, so that experiment is explicitly reverted and documented in the task note.

### Slack ingress and SlackAgent

- Moved the fast `eyes` reaction to Slack webhook ingress as a fire-and-forget side effect.
- Removed SlackAgent's duplicate awaited `reactions.add` on the hot path.
- Narrowed bot filtering to ignore only our own Iterate bot user action. Messages from other bots can now wake Iterate.
- Added an idempotent SlackIntegration fast-path wake after the Slack webhook event is durably appended; the stream outbox remains the retry path.

### Slack routed stream bootstrap

- Slack routed streams now bootstrap the codemode providers needed for event-mode Slack behavior before generic Agent startup finishes.
- Slack routed streams now include default Agent setup events before the first forwarded Slack webhook, so the first request sees the intended OpenAI config, system prompt, and `debounceMs: 200`.
- Removed a duplicate subscription ensure from `SlackIntegrationDurableObject.afterAppend`; ingress/initialization already ensures it.

### Generic Agent startup and provider input handling

- Slack agent streams now warm workspace setup in the background instead of blocking the first Slack reply on prepared workspace setup.
- Non-Slack Agent streams continue to await workspace/codemode setup as before.
- Agent processor derived appends for event explanations and rewritten `agent/input-added` events are batched where the event shapes and idempotency keys stay the same.
- Startup/registration paths were hardened for the concurrent delivery model.

### Documentation

- Added `tasks/slack-agent-independent-subscriber-delivery.md` with the timeline, root cause hypotheses, live probe measurements, reverted experiments, remaining latency budget, and a rigorous follow-up plan.

## Findings

Initial regression: Slack `eyes` and replies were delayed because callable subscriber delivery and cold startup made the lightweight Slack path wait behind heavy generic Agent work.

The request-start bug is mostly fixed: the first Slack input now sees `gpt-5.5` and `debounceMs: 200`, and schedule-to-request is no longer the dominant multi-second delay in the best probe. Remaining cost is split across Slack delivery/ingress variance, integration-to-routed wake/bootstrap, cold provider input drain, OpenAI, and Slack post.

Latest useful prod probe after callable queue batching and subscriber batch drain:

- Probe marker: `2026-05-19T15:33:53.632Z c2d9ed85`
- Slack message timestamp: `1779204833.810399`
- OS integration stream webhook event: `2026-05-19T15:33:55.955Z` (~2.1s after Slack timestamp)
- Routed stream bootstrap/forwarded webhook: `2026-05-19T15:33:57.761Z` (~1.8s later)
- First Slack webhook `agent/input-added`: `2026-05-19T15:33:59.565Z`
- Provider registration inputs drained through `2026-05-19T15:34:00.160Z`
- `agent/llm-request-scheduled`: `2026-05-19T15:34:00.253Z`
- `agent/llm-request-requested`: `2026-05-19T15:34:00.555Z`
- OpenAI call: ~4.6s
- Slack `chat.postMessage`: ~1.9s
- Slack reply timestamp: `1779204847.421199`, ~13.6s after original message timestamp

Noisier final prod probe after removing duplicate SlackIntegration subscription ensure:

- Probe marker: `2026-05-19T15:37:09.815Z dc461a34`
- Slack message timestamp: `1779205029.994629`
- OS integration stream webhook event: `2026-05-19T15:37:14.071Z` (~4.1s after Slack timestamp)
- Routed stream bootstrap/forwarded webhook: `2026-05-19T15:37:16.643Z` (~2.6s later)
- First Slack webhook `agent/input-added`: `2026-05-19T15:37:18.221Z`
- Provider registration inputs drained through `2026-05-19T15:37:19.634Z`
- `agent/llm-request-scheduled`: `2026-05-19T15:37:19.704Z`
- `agent/llm-request-requested`: `2026-05-19T15:37:20.857Z`
- OpenAI call: ~4.0s
- Slack `chat.postMessage`: ~1.6s
- Slack reply timestamp: `1779205046.870599`, ~16.9s after original message timestamp

The middle of the route is better than the earlier `b1535350` probe: provider input drain no longer obviously steps one alarm per provider event, and one probe had schedule-to-request around 300ms. The remaining hard gaps are before or around route creation: Slack delivery to OS varies by seconds, and integration-to-routed remains around 1.8-2.6s in these probes.

## Important Non-Goals

This PR does not merge provider registrations into a summary input. That experiment was wrong for the product model and was reverted. The follow-up should make many events cheap, not remove the events.

This PR also does not keep the immediate callable-delivery kickoff experiment. It improved some timings but failed full prod e2e with `Subrequest depth limit exceeded`, so strict alarm/outbox remains the safer state.

## Validation

Local:

- `oxfmt` passed via lint-staged for the final amendment.
- `pnpm --dir packages/shared exec vitest run src/streams/callable-subscriber-delivery.test.ts src/streams/external-subscriber.test.ts src/stream-processors/agent/implementation.test.ts src/stream-processors/slack-agent/slack-agent.test.ts` passed: 38 tests.
- `pnpm --filter @iterate-com/shared typecheck` passed.
- `pnpm --dir apps/os typecheck` passed.

Production deploy/probes:

- Deployed to `prd` during investigation, including the latest PR head before the final defensive delivery-error handling tweak.
- Focused prod Slack e2e after the earlier safe redeploy passed:
  - `routes Slack webhooks into slack-agent streams and executes bang command replies`
  - `completes slack-agent event-mode codemode calls without blocking the stream callable queue`
- A full prod e2e run before reverting the immediate-kickoff experiment failed in two places, including `Subrequest depth limit exceeded`; that experiment was then reverted and prod was redeployed. I did not rerun the full suite after that final revert due time, but the focused Slack e2e passed against the redeployed safe version.

## Follow-Up

The next rigorous performance pass should preserve separate provider events and separate agent inputs while reducing cold route creation cost. Most likely targets:

- add explicit trace spans/counters for integration event commit, direct fast-path wake start/end, SlackIntegration processor catchup, routed `appendBatch`, queue depth, and Agent catchup,
- reduce integration-to-routed wake latency without going back to recursive immediate delivery from the Stream DO,
- precompute/render provider inputs during routed-stream bootstrap while preserving one input per provider,
- reduce full-stream reads in cold Agent startup and debounce handoff,
- separate Slack delivery delay from OS ingress/runtime delay in Cloudflare traces.


<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "deployed",
      "updatedAt": "2026-05-19T15:45:46.765Z",
      "headSha": "9b5ccb33a5c44aebb74de4b9d1801f7c66a0fec4",
      "message": null,
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26107987357",
      "shortSha": "9b5ccb3"
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_3",
    "leasedUntil": 1779208945854,
    "leaseId": "d4ab9dcc-839c-4a47-b817-b4345180303e",
    "slug": "preview-3",
    "type": "environment-config-lease"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
Lease: `preview-3`
Doppler config: `preview_3`
Type: `environment-config-lease`
Leased until: 2026-05-19T16:42:25.854Z

### OS
Status: deployed
Commit: `9b5ccb3`
Preview: https://os.iterate-preview-3.com
[Workflow run](https://github.com/iterate/iterate/actions/runs/26107987357)
Updated: 2026-05-19T15:45:46.765Z
<!-- /CLOUDFLARE_PREVIEW -->