### PR TITLE
Split voice agent stream processors

### DIFF
--- a/apps/os/alchemy.run.ts
+++ b/apps/os/alchemy.run.ts
@@ -13,7 +13,7 @@ import type { AgentDurableObject } from "./src/domains/agents/durable-objects/ag
 import type { RepoDurableObject } from "./src/domains/repos/durable-objects/repo-durable-object.ts";
 import type { SlackAgentDurableObject } from "./src/domains/slack/durable-objects/slack-agent-durable-object.ts";
 import type { SlackIntegrationDurableObject } from "./src/domains/slack/durable-objects/slack-integration-durable-object.ts";
-import type { VoiceAgentDurableObject } from "./src/domains/voice-agents/durable-objects/voice-agent-durable-object.ts";
+import type { StreamProcessorDurableObject } from "./src/domains/stream-processors/durable-objects/stream-processor-durable-object.ts";
 import type { WorkspaceDurableObject } from "./src/domains/workspaces/durable-objects/workspace-durable-object.ts";
 import type { OutboundMcpFromOurClientCapability } from "./src/domains/outbound-mcp-client/entrypoints/outbound-mcp-from-our-client-capability.ts";
 
@@ -75,8 +75,8 @@ const agent = DurableObjectNamespace<AgentDurableObject>("agent", {
   className: "AgentDurableObject",
   sqlite: true,
 });
-const voiceAgent = DurableObjectNamespace<VoiceAgentDurableObject>("voice-agent", {
-  className: "VoiceAgentDurableObject",
+const streamProcessor = DurableObjectNamespace<StreamProcessorDurableObject>("stream-processor", {
+  className: "StreamProcessorDurableObject",
   sqlite: true,
 });
 const slackIntegration = DurableObjectNamespace<SlackIntegrationDurableObject>(
@@ -112,7 +112,7 @@ const { worker, afterFinalize } = await IterateApp(ctx, {
     LOADER: WorkerLoader(),
     CODEMODE_SESSION: codemodeSession,
     AGENT: agent,
-    VOICE_AGENT: voiceAgent,
+    STREAM_PROCESSOR: streamProcessor,
     ARTIFACTS: Artifacts({ namespace: artifactsNamespace }),
     PROJECT: project,
     SLACK_AGENT: slackAgent,

--- a/apps/os/alchemy.run.ts
+++ b/apps/os/alchemy.run.ts
@@ -13,11 +13,15 @@ import type { AgentDurableObject } from "./src/domains/agents/durable-objects/ag
 import type { RepoDurableObject } from "./src/domains/repos/durable-objects/repo-durable-object.ts";
 import type { SlackAgentDurableObject } from "./src/domains/slack/durable-objects/slack-agent-durable-object.ts";
 import type { SlackIntegrationDurableObject } from "./src/domains/slack/durable-objects/slack-integration-durable-object.ts";
+import type { VoiceAgentDurableObject } from "./src/domains/voice-agents/durable-objects/voice-agent-durable-object.ts";
 import type { WorkspaceDurableObject } from "./src/domains/workspaces/durable-objects/workspace-durable-object.ts";
 import type { OutboundMcpFromOurClientCapability } from "./src/domains/outbound-mcp-client/entrypoints/outbound-mcp-from-our-client-capability.ts";
 
 const ctx = await initAlchemy(manifest, AppConfig, process.env);
 const slackBotToken = ctx.runtimeConfig.slackBotToken?.exposeSecret();
+const geminiApiKey = ctx.runtimeConfig.geminiApiKey?.exposeSecret() ?? process.env.GEMINI_API_KEY;
+const openAiApiKey = ctx.runtimeConfig.openAiApiKey.exposeSecret() ?? process.env.OPENAI_API_KEY;
+const xAiApiKey = ctx.runtimeConfig.xAiApiKey?.exposeSecret() ?? process.env.XAI_API_KEY;
 
 const db = await D1Database("os-db", {
   name: `${ctx.workerName}-db`,
@@ -71,6 +75,10 @@ const agent = DurableObjectNamespace<AgentDurableObject>("agent", {
   className: "AgentDurableObject",
   sqlite: true,
 });
+const voiceAgent = DurableObjectNamespace<VoiceAgentDurableObject>("voice-agent", {
+  className: "VoiceAgentDurableObject",
+  sqlite: true,
+});
 const slackIntegration = DurableObjectNamespace<SlackIntegrationDurableObject>(
   "slack-integration",
   {
@@ -104,6 +112,7 @@ const { worker, afterFinalize } = await IterateApp(ctx, {
     LOADER: WorkerLoader(),
     CODEMODE_SESSION: codemodeSession,
     AGENT: agent,
+    VOICE_AGENT: voiceAgent,
     ARTIFACTS: Artifacts({ namespace: artifactsNamespace }),
     PROJECT: project,
     SLACK_AGENT: slackAgent,
@@ -116,6 +125,9 @@ const { worker, afterFinalize } = await IterateApp(ctx, {
     ...(debugAppendChainSubscriber == null
       ? {}
       : { DEBUG_APPEND_CHAIN_SUBSCRIBER: debugAppendChainSubscriber }),
+    ...(geminiApiKey == null ? {} : { APP_CONFIG_GEMINI_API_KEY: alchemy.secret(geminiApiKey) }),
+    ...(openAiApiKey == null ? {} : { APP_CONFIG_OPEN_AI_API_KEY: alchemy.secret(openAiApiKey) }),
+    ...(xAiApiKey == null ? {} : { APP_CONFIG_X_AI_API_KEY: alchemy.secret(xAiApiKey) }),
     ...(slackBotToken == null ? {} : { APP_CONFIG_SLACK_BOT_TOKEN: alchemy.secret(slackBotToken) }),
   },
   extraRouteHostnames: projectHostnameBases.flatMap(projectRouteHostnamesForBase),

--- a/apps/os/public/voice-agent-poc/input-worklet.js
+++ b/apps/os/public/voice-agent-poc/input-worklet.js
@@ -1,0 +1,79 @@
+class PcmInputProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.enabled = false;
+    this.targetSampleRate = 16000;
+    this.chunkSamples = 1600;
+    this.pending = [];
+    this.output = [];
+    this.readIndex = 0;
+
+    this.port.onmessage = (event) => {
+      const message = event.data || {};
+      if (message.type === "configure") {
+        this.targetSampleRate = message.targetSampleRate || 16000;
+        const chunkMs = message.chunkMs || 100;
+        this.chunkSamples = Math.max(1, Math.round((this.targetSampleRate * chunkMs) / 1000));
+      } else if (message.type === "set-enabled") {
+        this.enabled = Boolean(message.enabled);
+        if (!this.enabled) {
+          this.pending = [];
+          this.output = [];
+          this.readIndex = 0;
+        }
+      }
+    };
+  }
+
+  process(inputs) {
+    if (!this.enabled) return true;
+
+    const input = inputs[0];
+    const channel = input && input[0];
+    if (!channel || channel.length === 0) return true;
+
+    for (let index = 0; index < channel.length; index++) {
+      this.pending.push(channel[index] || 0);
+    }
+
+    const ratio = sampleRate / this.targetSampleRate;
+    while (this.readIndex < this.pending.length) {
+      const sample = this.pending[Math.floor(this.readIndex)] || 0;
+      this.output.push(floatToInt16(sample));
+      this.readIndex += ratio;
+
+      if (this.output.length >= this.chunkSamples) {
+        this.flushOutput();
+      }
+    }
+
+    const consumed = Math.floor(this.readIndex);
+    if (consumed > 0) {
+      this.pending.splice(0, consumed);
+      this.readIndex -= consumed;
+    }
+
+    return true;
+  }
+
+  flushOutput() {
+    const samples = this.output.splice(0, this.chunkSamples);
+    const pcm = new Int16Array(samples);
+    this.port.postMessage(
+      {
+        type: "pcm",
+        sampleRate: this.targetSampleRate,
+        samples: pcm.length,
+        buffer: pcm.buffer,
+      },
+      [pcm.buffer],
+    );
+  }
+}
+
+function floatToInt16(value) {
+  const clamped = Math.max(-1, Math.min(1, value));
+  return clamped < 0 ? Math.round(clamped * 32768) : Math.round(clamped * 32767);
+}
+
+registerProcessor("pcm-input-processor", PcmInputProcessor);

--- a/apps/os/public/voice-agent-poc/output-worklet.js
+++ b/apps/os/public/voice-agent-poc/output-worklet.js
@@ -1,0 +1,92 @@
+class PcmOutputProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.sourceSampleRate = 24000;
+    this.minBufferMs = 80;
+    this.queue = [];
+    this.readIndex = 0;
+    this.started = false;
+    this.underruns = 0;
+    this.reportCounter = 0;
+
+    this.port.onmessage = (event) => {
+      const message = event.data || {};
+      if (message.type === "configure") {
+        this.sourceSampleRate = message.sourceSampleRate || 24000;
+        this.minBufferMs = message.minBufferMs || 80;
+      } else if (message.type === "enqueue") {
+        const pcm = new Int16Array(message.buffer);
+        for (let index = 0; index < pcm.length; index++) {
+          this.queue.push(pcm[index] / 32768);
+        }
+        if (!this.started && this.queuedMs() >= this.minBufferMs) {
+          this.started = true;
+        }
+      } else if (message.type === "clear") {
+        this.queue = [];
+        this.readIndex = 0;
+        this.started = false;
+      }
+    };
+  }
+
+  process(_inputs, outputs) {
+    const output = outputs[0];
+    const channelCount = output ? output.length : 0;
+    if (!output || channelCount === 0) return true;
+
+    const frameCount = output[0].length;
+    const ratio = this.sourceSampleRate / sampleRate;
+
+    for (let frame = 0; frame < frameCount; frame++) {
+      let value = 0;
+      if (this.started && this.readIndex < this.queue.length) {
+        const leftIndex = Math.floor(this.readIndex);
+        const rightIndex = Math.min(leftIndex + 1, this.queue.length - 1);
+        const fraction = this.readIndex - leftIndex;
+        const left = this.queue[leftIndex] || 0;
+        const right = this.queue[rightIndex] || left;
+        value = left + (right - left) * fraction;
+      }
+
+      for (let channel = 0; channel < channelCount; channel++) {
+        output[channel][frame] = value;
+      }
+
+      if (this.started) {
+        this.readIndex += ratio;
+      }
+    }
+
+    if (this.started && this.readIndex >= this.queue.length) {
+      this.queue = [];
+      this.readIndex = 0;
+      this.started = false;
+      this.underruns++;
+    }
+
+    const consumed = Math.floor(this.readIndex);
+    if (consumed > 0) {
+      this.queue.splice(0, consumed);
+      this.readIndex -= consumed;
+    }
+
+    this.reportCounter++;
+    if (this.reportCounter >= 30) {
+      this.reportCounter = 0;
+      this.port.postMessage({
+        type: "status",
+        queuedMs: Math.round(this.queuedMs()),
+        underruns: this.underruns,
+      });
+    }
+
+    return true;
+  }
+
+  queuedMs() {
+    return (Math.max(0, this.queue.length - this.readIndex) / this.sourceSampleRate) * 1000;
+  }
+}
+
+registerProcessor("pcm-output-processor", PcmOutputProcessor);

--- a/apps/os/scripts/gemini-live-tool-probe.ts
+++ b/apps/os/scripts/gemini-live-tool-probe.ts
@@ -15,7 +15,7 @@ const timeoutMs = Number(option("--timeout-ms") ?? "20000");
 const inputPrompt =
   option("--prompt") ??
   [
-    "Call the ask_agent function now.",
+    "Call the messageAgent function now.",
     "Use message: Fetch https://example.com and summarize the page title.",
     "Do not answer in natural language before the function call.",
   ].join(" ");
@@ -24,7 +24,7 @@ const variants: Variant[] = [
   {
     name: "live-docs-json-schema-audio",
     responseModalities: ["AUDIO"],
-    tool: askAgentTool({
+    tool: messageAgentTool({
       parameters: {
         type: "object",
         properties: {
@@ -40,12 +40,12 @@ const variants: Variant[] = [
   {
     name: "no-parameters-audio",
     responseModalities: ["AUDIO"],
-    tool: askAgentTool({}),
+    tool: messageAgentTool({}),
   },
   {
     name: "uppercase-schema-audio",
     responseModalities: ["AUDIO"],
-    tool: askAgentTool({
+    tool: messageAgentTool({
       parameters: {
         type: "OBJECT",
         properties: {
@@ -61,7 +61,7 @@ const variants: Variant[] = [
   {
     name: "tool-config-any-audio",
     responseModalities: ["AUDIO"],
-    tool: askAgentTool({
+    tool: messageAgentTool({
       parameters: {
         type: "object",
         properties: {
@@ -74,7 +74,7 @@ const variants: Variant[] = [
       toolConfig: {
         functionCallingConfig: {
           mode: "ANY",
-          allowedFunctionNames: ["ask_agent"],
+          allowedFunctionNames: ["messageAgent"],
         },
       },
     },
@@ -82,7 +82,7 @@ const variants: Variant[] = [
   {
     name: "text-modality",
     responseModalities: ["TEXT"],
-    tool: askAgentTool({
+    tool: messageAgentTool({
       parameters: {
         type: "object",
         properties: {
@@ -160,7 +160,7 @@ async function runVariant(variant: Variant) {
                 functionResponses: [
                   {
                     id: firstFunctionCallId(message.toolCall),
-                    name: "ask_agent",
+                    name: "messageAgent",
                     response: {
                       ok: true,
                       message: "Probe tool response.",
@@ -231,7 +231,7 @@ function setupMessage(variant: Variant) {
       systemInstruction: {
         parts: [
           {
-            text: "You are a tool-calling probe. When asked, call ask_agent immediately.",
+            text: "You are a tool-calling probe. When asked, call messageAgent immediately.",
           },
         ],
       },
@@ -241,12 +241,12 @@ function setupMessage(variant: Variant) {
   };
 }
 
-function askAgentTool(input: { parameters?: JsonObject }) {
+function messageAgentTool(input: { parameters?: JsonObject }) {
   return {
     functionDeclarations: [
       {
-        name: "ask_agent",
-        description: "Ask the background agent to perform work.",
+        name: "messageAgent",
+        description: "Message the background agent to perform work.",
         ...input,
       },
     ],

--- a/apps/os/scripts/gemini-live-tool-probe.ts
+++ b/apps/os/scripts/gemini-live-tool-probe.ts
@@ -1,0 +1,305 @@
+type JsonObject = Record<string, unknown>;
+
+type Variant = {
+  name: string;
+  responseModalities: string[];
+  tool: JsonObject;
+  extraSetup?: JsonObject;
+};
+
+export {};
+
+const apiKey = requireEnv("APP_CONFIG_GEMINI_API_KEY", "GEMINI_API_KEY");
+const model = option("--model") ?? "gemini-3.1-flash-live-preview";
+const timeoutMs = Number(option("--timeout-ms") ?? "20000");
+const inputPrompt =
+  option("--prompt") ??
+  [
+    "Call the ask_agent function now.",
+    "Use message: Fetch https://example.com and summarize the page title.",
+    "Do not answer in natural language before the function call.",
+  ].join(" ");
+
+const variants: Variant[] = [
+  {
+    name: "live-docs-json-schema-audio",
+    responseModalities: ["AUDIO"],
+    tool: askAgentTool({
+      parameters: {
+        type: "object",
+        properties: {
+          message: {
+            type: "string",
+            description: "The request for the background agent.",
+          },
+        },
+        required: ["message"],
+      },
+    }),
+  },
+  {
+    name: "no-parameters-audio",
+    responseModalities: ["AUDIO"],
+    tool: askAgentTool({}),
+  },
+  {
+    name: "uppercase-schema-audio",
+    responseModalities: ["AUDIO"],
+    tool: askAgentTool({
+      parameters: {
+        type: "OBJECT",
+        properties: {
+          message: {
+            type: "STRING",
+            description: "The request for the background agent.",
+          },
+        },
+        required: ["message"],
+      },
+    }),
+  },
+  {
+    name: "tool-config-any-audio",
+    responseModalities: ["AUDIO"],
+    tool: askAgentTool({
+      parameters: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+        },
+        required: ["message"],
+      },
+    }),
+    extraSetup: {
+      toolConfig: {
+        functionCallingConfig: {
+          mode: "ANY",
+          allowedFunctionNames: ["ask_agent"],
+        },
+      },
+    },
+  },
+  {
+    name: "text-modality",
+    responseModalities: ["TEXT"],
+    tool: askAgentTool({
+      parameters: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+        },
+        required: ["message"],
+      },
+    }),
+  },
+];
+
+for (const variant of variants) {
+  console.log(`\n=== ${variant.name} ===`);
+  try {
+    const result = await runVariant(variant);
+    console.log(JSON.stringify(result, null, 2));
+    if (result.toolCall != null) {
+      process.exitCode = 0;
+      break;
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.stack || error.message : error);
+    process.exitCode = 1;
+  }
+}
+
+async function runVariant(variant: Variant) {
+  const socket = await openGeminiLiveWebSocket();
+  const messages: unknown[] = [];
+  let setupComplete = false;
+  let toolCall: unknown = null;
+  let firstServerContent: unknown = null;
+
+  const waitForResult = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, timeoutMs);
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      socket.removeEventListener("message", onMessage);
+      socket.removeEventListener("error", onError);
+      socket.close();
+    };
+
+    const onError = () => {
+      cleanup();
+      reject(new Error("Gemini Live WebSocket errored."));
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      void (async () => {
+        const message = JSON.parse(await messageToText(event.data)) as JsonObject;
+        messages.push(message);
+        console.log("recv", JSON.stringify(summarizeMessage(message)));
+
+        if (message.setupComplete != null && !setupComplete) {
+          setupComplete = true;
+          socket.send(
+            JSON.stringify({
+              clientContent: {
+                turns: [{ role: "user", parts: [{ text: inputPrompt }] }],
+                turnComplete: true,
+              },
+            }),
+          );
+        }
+
+        if (message.toolCall != null) {
+          toolCall = message.toolCall;
+          socket.send(
+            JSON.stringify({
+              toolResponse: {
+                functionResponses: [
+                  {
+                    id: firstFunctionCallId(message.toolCall),
+                    name: "ask_agent",
+                    response: {
+                      ok: true,
+                      message: "Probe tool response.",
+                    },
+                  },
+                ],
+              },
+            }),
+          );
+          cleanup();
+          resolve();
+        }
+
+        if (message.serverContent != null && firstServerContent == null) {
+          firstServerContent = message.serverContent;
+        }
+      })().catch((error) => {
+        cleanup();
+        reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    };
+
+    socket.addEventListener("message", onMessage);
+    socket.addEventListener("error", onError);
+  });
+
+  socket.send(JSON.stringify(setupMessage(variant)));
+  await waitForResult;
+
+  return {
+    setupComplete,
+    toolCall,
+    firstServerContent: summarizeMessage({ serverContent: firstServerContent }).serverContent,
+    messageCount: messages.length,
+  };
+}
+
+async function messageToText(data: unknown) {
+  if (typeof data === "string") return data;
+  if (data instanceof Blob) return await data.text();
+  if (data instanceof ArrayBuffer) return new TextDecoder().decode(data);
+  if (ArrayBuffer.isView(data)) return new TextDecoder().decode(data);
+  return String(data);
+}
+
+async function openGeminiLiveWebSocket() {
+  const url = new URL(
+    "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent",
+  );
+  url.searchParams.set("key", apiKey);
+  const socket = new WebSocket(url);
+  await new Promise<void>((resolve, reject) => {
+    socket.addEventListener("open", () => resolve(), { once: true });
+    socket.addEventListener("error", () => reject(new Error("Gemini Live WebSocket failed.")), {
+      once: true,
+    });
+  });
+  return socket;
+}
+
+function setupMessage(variant: Variant) {
+  return {
+    setup: {
+      model: model.startsWith("models/") ? model : `models/${model}`,
+      generationConfig: {
+        responseModalities: variant.responseModalities,
+      },
+      systemInstruction: {
+        parts: [
+          {
+            text: "You are a tool-calling probe. When asked, call ask_agent immediately.",
+          },
+        ],
+      },
+      tools: [variant.tool],
+      ...variant.extraSetup,
+    },
+  };
+}
+
+function askAgentTool(input: { parameters?: JsonObject }) {
+  return {
+    functionDeclarations: [
+      {
+        name: "ask_agent",
+        description: "Ask the background agent to perform work.",
+        ...input,
+      },
+    ],
+  };
+}
+
+function summarizeMessage(message: JsonObject) {
+  const serverContent = message.serverContent as
+    | {
+        modelTurn?: { parts?: Array<{ text?: string; inlineData?: unknown }> };
+        turnComplete?: boolean;
+      }
+    | undefined;
+  return {
+    setupComplete: message.setupComplete != null,
+    toolCall: message.toolCall,
+    toolCallCancellation: message.toolCallCancellation,
+    serverContent:
+      serverContent == null
+        ? undefined
+        : {
+            turnComplete: serverContent.turnComplete,
+            text: serverContent.modelTurn?.parts
+              ?.map((part) => part.text)
+              .filter((text): text is string => typeof text === "string")
+              .join(""),
+            inlineDataCount: serverContent.modelTurn?.parts?.filter(
+              (part) => part.inlineData != null,
+            ).length,
+          },
+    error: message.error,
+    goAway: message.goAway,
+  };
+}
+
+function firstFunctionCallId(toolCall: unknown) {
+  const functionCalls =
+    (toolCall as { functionCalls?: Array<{ id?: string }> }).functionCalls ?? [];
+  return functionCalls[0]?.id;
+}
+
+function option(name: string) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return null;
+  const value = process.argv[index + 1];
+  if (value == null || value.startsWith("--")) throw new Error(`${name} requires a value.`);
+  return value;
+}
+
+function requireEnv(...names: string[]) {
+  for (const name of names) {
+    const value = process.env[name]?.trim();
+    if (value) return value;
+  }
+  throw new Error(`${names.join(" or ")} is required.`);
+}

--- a/apps/os/scripts/voice-agent-e2e.ts
+++ b/apps/os/scripts/voice-agent-e2e.ts
@@ -27,8 +27,14 @@ import {
 import { EventInput, StreamPath, type Event } from "@iterate-com/shared/streams/types";
 import {
   voiceAgentCircuitBreakerConfiguredEvent,
+  streamProcessorSubscriptionConfiguredEvent,
   voiceAgentSubscriptionConfiguredEvent,
 } from "~/domains/voice-agents/voice-agent-subscription.ts";
+import {
+  GEMINI_LIVE_VOICE_PROCESSOR_SLUG,
+  GROK_REALTIME_VOICE_PROCESSOR_SLUG,
+  OPENAI_REALTIME_VOICE_PROCESSOR_SLUG,
+} from "~/domains/stream-processors/stream-processor-slugs.ts";
 import type { appRouter } from "~/orpc/root.ts";
 
 type OrpcClient = RouterClient<typeof appRouter>;
@@ -103,6 +109,11 @@ async function main() {
         streamPath: options.streamPath,
       }),
       voiceAgentSubscriptionConfiguredEvent({
+        projectId: projectSlugOrId,
+        streamPath: options.streamPath,
+      }),
+      streamProcessorSubscriptionConfiguredEvent({
+        processorSlug: voiceProviderProcessorSlug(options.provider),
         projectId: projectSlugOrId,
         streamPath: options.streamPath,
       }),
@@ -453,6 +464,17 @@ function voiceOption(values: Map<string, string>) {
       return DEFAULT_OPENAI_REALTIME_VOICE;
     case VOICE_AGENT_PROVIDER_GROK_REALTIME:
       return DEFAULT_GROK_REALTIME_VOICE;
+  }
+}
+
+function voiceProviderProcessorSlug(provider: VoiceAgentProvider) {
+  switch (provider) {
+    case VOICE_AGENT_PROVIDER_GEMINI_LIVE:
+      return GEMINI_LIVE_VOICE_PROCESSOR_SLUG;
+    case VOICE_AGENT_PROVIDER_OPENAI_REALTIME:
+      return OPENAI_REALTIME_VOICE_PROCESSOR_SLUG;
+    case VOICE_AGENT_PROVIDER_GROK_REALTIME:
+      return GROK_REALTIME_VOICE_PROCESSOR_SLUG;
   }
 }
 

--- a/apps/os/scripts/voice-agent-e2e.ts
+++ b/apps/os/scripts/voice-agent-e2e.ts
@@ -1,0 +1,523 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { createORPCClient } from "@orpc/client";
+import { OpenAPILink } from "@orpc/openapi-client/fetch";
+import type { RouterClient } from "@orpc/server";
+import { osContract } from "@iterate-com/os-contract";
+import {
+  DEFAULT_GEMINI_LIVE_MODEL,
+  DEFAULT_GEMINI_LIVE_VOICE,
+  DEFAULT_GROK_REALTIME_MODEL,
+  DEFAULT_GROK_REALTIME_VOICE,
+  DEFAULT_OPENAI_REALTIME_MODEL,
+  DEFAULT_OPENAI_REALTIME_VOICE,
+  VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_INPUT_SAMPLE_RATE,
+  VOICE_AGENT_OUTPUT_SAMPLE_RATE,
+  VOICE_AGENT_PROVIDER_GEMINI_LIVE,
+  VOICE_AGENT_PROVIDER_GROK_REALTIME,
+  VOICE_AGENT_PROVIDER_OPENAI_REALTIME,
+  VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE,
+  type VoiceAgentProvider,
+} from "@iterate-com/shared/stream-processors/voice-agent/contract";
+import { EventInput, StreamPath, type Event } from "@iterate-com/shared/streams/types";
+import {
+  voiceAgentCircuitBreakerConfiguredEvent,
+  voiceAgentSubscriptionConfiguredEvent,
+} from "~/domains/voice-agents/voice-agent-subscription.ts";
+import type { appRouter } from "~/orpc/root.ts";
+
+type OrpcClient = RouterClient<typeof appRouter>;
+
+type Options = {
+  baseUrl: string;
+  chunkMs: number;
+  createProject: boolean;
+  model: string;
+  minOutputBytes: number;
+  outputPcm: string | null;
+  pcmFile: string | null;
+  play: boolean;
+  provider: VoiceAgentProvider;
+  projectSlugOrId: string | null;
+  prompt: string;
+  silenceMs: number;
+  streamPath: StreamPath;
+  timeoutMs: number;
+  voiceName: string;
+};
+
+type SeenEvents = {
+  error: string | null;
+  outputBuffers: Buffer[];
+  providerConnected: boolean;
+  setupCompleted: boolean;
+  turnCompleted: boolean;
+};
+
+const execFileAsync = promisify(execFile);
+
+async function main() {
+  const options = parseOptions(process.argv.slice(2));
+  const client = createClient(options.baseUrl);
+  const runId = `voice-agent-e2e-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+  const projectSlugOrId = options.createProject
+    ? (await createTestProject(client, runId)).id
+    : requireProjectSlugOrId(options.projectSlugOrId);
+  const pcm = options.pcmFile
+    ? await readFile(resolve(options.pcmFile))
+    : await synthesizePromptPcm(options.prompt);
+  const audio = Buffer.concat([pcm, silencePcm(options.silenceMs)]);
+
+  console.log(
+    JSON.stringify(
+      {
+        runId,
+        baseUrl: options.baseUrl,
+        provider: options.provider,
+        projectSlugOrId,
+        streamPath: options.streamPath,
+        model: options.model,
+        prompt: options.pcmFile ? `pcm-file:${options.pcmFile}` : options.prompt,
+        inputBytes: audio.byteLength,
+      },
+      null,
+      2,
+    ),
+  );
+
+  await client.project.streams.create({
+    projectSlugOrId,
+    streamPath: options.streamPath,
+  });
+  const setupEvents = await client.project.streams.appendBatch({
+    projectSlugOrId,
+    streamPath: options.streamPath,
+    events: [
+      voiceAgentCircuitBreakerConfiguredEvent({
+        projectId: projectSlugOrId,
+        streamPath: options.streamPath,
+      }),
+      voiceAgentSubscriptionConfiguredEvent({
+        projectId: projectSlugOrId,
+        streamPath: options.streamPath,
+      }),
+      EventInput.parse({
+        idempotencyKey: `${runId}:voice-agent-setup`,
+        type: VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE,
+        payload: {
+          provider: options.provider,
+          model: options.model,
+          voiceName: options.voiceName,
+          systemInstruction:
+            "You are running an automated voice test. Reply with one short sentence.",
+        },
+      }),
+    ],
+  });
+  const afterOffset = Math.max(...setupEvents.events.map((event) => event.offset));
+  const seen: SeenEvents = {
+    error: null,
+    outputBuffers: [],
+    providerConnected: false,
+    setupCompleted: false,
+    turnCompleted: false,
+  };
+
+  const watchPromise = watchStream({
+    afterOffset,
+    client,
+    projectSlugOrId,
+    seen,
+    streamPath: options.streamPath,
+    timeoutMs: options.timeoutMs,
+    minOutputBytes: options.minOutputBytes,
+  });
+
+  await appendPcmFrames({
+    audio,
+    chunkMs: options.chunkMs,
+    client,
+    projectSlugOrId,
+    runId,
+    streamPath: options.streamPath,
+  });
+
+  await watchPromise;
+
+  const output = Buffer.concat(seen.outputBuffers);
+  if (options.outputPcm) {
+    await writeFile(resolve(options.outputPcm), output);
+  }
+  if (options.play && output.byteLength > 0) {
+    await playOutputPcm(output);
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        provider: options.provider,
+        providerConnected: seen.providerConnected,
+        setupCompleted: seen.setupCompleted,
+        turnCompleted: seen.turnCompleted,
+        outputBytes: output.byteLength,
+        outputPcm: options.outputPcm,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function watchStream(input: {
+  afterOffset: number;
+  client: OrpcClient;
+  minOutputBytes: number;
+  projectSlugOrId: string;
+  seen: SeenEvents;
+  streamPath: StreamPath;
+  timeoutMs: number;
+}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), input.timeoutMs);
+  const stream = await input.client.project.streams.streamEvents(
+    {
+      afterOffset: input.afterOffset,
+      projectSlugOrId: input.projectSlugOrId,
+      streamPath: input.streamPath,
+    },
+    { signal: controller.signal },
+  );
+
+  try {
+    for await (const event of stream as AsyncIterable<Event>) {
+      console.log(`${event.offset} ${event.type}`);
+
+      if (
+        event.type === "events.iterate.com/voice-agent/gemini-live-websocket-connected" ||
+        event.type === "events.iterate.com/voice-agent/openai-realtime-websocket-connected" ||
+        event.type === "events.iterate.com/voice-agent/grok-realtime-websocket-connected"
+      ) {
+        input.seen.providerConnected = true;
+      }
+      if (
+        event.type === "events.iterate.com/voice-agent/gemini-live-setup-completed" ||
+        event.type === "events.iterate.com/voice-agent/openai-realtime-session-updated" ||
+        event.type === "events.iterate.com/voice-agent/grok-realtime-session-updated"
+      ) {
+        input.seen.setupCompleted = true;
+      }
+      if (
+        event.type === "events.iterate.com/voice-agent/gemini-live-turn-completed" ||
+        event.type === "events.iterate.com/voice-agent/openai-realtime-response-done" ||
+        event.type === "events.iterate.com/voice-agent/grok-realtime-response-done"
+      ) {
+        input.seen.turnCompleted = true;
+      }
+      if (event.type === VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE) {
+        const payload = event.payload as { dataBase64?: unknown };
+        if (typeof payload.dataBase64 === "string") {
+          input.seen.outputBuffers.push(Buffer.from(payload.dataBase64, "base64"));
+        }
+      }
+      if (event.type === "events.iterate.com/voice-agent/error-occurred") {
+        const payload = event.payload as { message?: unknown };
+        input.seen.error = typeof payload.message === "string" ? payload.message : "unknown error";
+        throw new Error(input.seen.error);
+      }
+
+      const outputBytes = input.seen.outputBuffers.reduce(
+        (total, buffer) => total + buffer.byteLength,
+        0,
+      );
+      if (
+        input.seen.setupCompleted &&
+        (outputBytes >= input.minOutputBytes || input.seen.turnCompleted)
+      ) {
+        return;
+      }
+    }
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(
+        `Timed out after ${input.timeoutMs}ms. providerConnected=${input.seen.providerConnected} setup=${input.seen.setupCompleted} outputFrames=${input.seen.outputBuffers.length}`,
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+    controller.abort();
+  }
+}
+
+async function appendPcmFrames(input: {
+  audio: Buffer;
+  chunkMs: number;
+  client: OrpcClient;
+  projectSlugOrId: string;
+  runId: string;
+  streamPath: StreamPath;
+}) {
+  const bytesPerChunk = Math.max(
+    2,
+    Math.round((VOICE_AGENT_INPUT_SAMPLE_RATE * 2 * input.chunkMs) / 1000),
+  );
+  const evenBytesPerChunk = bytesPerChunk % 2 === 0 ? bytesPerChunk : bytesPerChunk + 1;
+  let sequence = 0;
+
+  for (let start = 0; start < input.audio.byteLength; start += evenBytesPerChunk) {
+    const chunk = input.audio.subarray(
+      start,
+      Math.min(input.audio.byteLength, start + evenBytesPerChunk),
+    );
+    await input.client.project.streams.append({
+      projectSlugOrId: input.projectSlugOrId,
+      streamPath: input.streamPath,
+      event: EventInput.parse({
+        type: VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+        payload: {
+          channels: 1,
+          dataBase64: chunk.toString("base64"),
+          durationMs: Math.round((chunk.byteLength / 2 / VOICE_AGENT_INPUT_SAMPLE_RATE) * 1000),
+          encoding: "pcm_s16le",
+          sampleRate: VOICE_AGENT_INPUT_SAMPLE_RATE,
+          sequence,
+          streamId: input.runId,
+        },
+      }),
+    });
+    sequence += 1;
+    await delay(input.chunkMs);
+  }
+}
+
+async function synthesizePromptPcm(prompt: string): Promise<Buffer> {
+  const dir = await mkdtemp(join(tmpdir(), "voice-agent-e2e-"));
+  const aiffPath = join(dir, "input.aiff");
+  const pcmPath = join(dir, "input.pcm");
+  try {
+    await execFileAsync("say", ["-o", aiffPath, prompt]);
+    await execFileAsync("ffmpeg", [
+      "-y",
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-i",
+      aiffPath,
+      "-ac",
+      "1",
+      "-ar",
+      String(VOICE_AGENT_INPUT_SAMPLE_RATE),
+      "-f",
+      "s16le",
+      pcmPath,
+    ]);
+    return await readFile(pcmPath);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+function silencePcm(durationMs: number) {
+  const samples = Math.round((VOICE_AGENT_INPUT_SAMPLE_RATE * durationMs) / 1000);
+  return Buffer.alloc(samples * 2);
+}
+
+async function playOutputPcm(output: Buffer) {
+  const dir = await mkdtemp(join(tmpdir(), "voice-agent-output-"));
+  const pcmPath = join(dir, "output.pcm");
+  try {
+    await writeFile(pcmPath, output);
+    await execFileAsync("ffplay", [
+      "-autoexit",
+      "-nodisp",
+      "-loglevel",
+      "error",
+      "-f",
+      "s16le",
+      "-ar",
+      String(VOICE_AGENT_OUTPUT_SAMPLE_RATE),
+      "-ac",
+      "1",
+      pcmPath,
+    ]);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+async function createTestProject(client: OrpcClient, runId: string) {
+  return await client.projects.create({
+    slug: runId,
+  });
+}
+
+function createClient(baseUrl: string) {
+  const authHeaders = requireAuthHeaders();
+  return createORPCClient(
+    new OpenAPILink(osContract, {
+      url: `${baseUrl}/api`,
+      fetch: (input, init) => {
+        const requestInit: RequestInit = init ?? {};
+        const headers = new Headers(input instanceof Request ? input.headers : undefined);
+        for (const [key, value] of new Headers(requestInit.headers)) headers.set(key, value);
+        for (const [key, value] of Object.entries(authHeaders)) headers.set(key, value);
+        if (input instanceof Request) return fetch(new Request(input, { ...requestInit, headers }));
+        return fetch(input, { ...requestInit, headers });
+      },
+    }),
+  ) as OrpcClient;
+}
+
+function requireAuthHeaders() {
+  const bearerToken =
+    process.env.OS_E2E_ADMIN_API_SECRET?.trim() ||
+    process.env.OS_ADMIN_API_SECRET?.trim() ||
+    process.env.APP_CONFIG_ADMIN_API_SECRET?.trim() ||
+    process.env.OS_E2E_BEARER_TOKEN?.trim();
+  const cookie = process.env.OS_E2E_COOKIE?.trim();
+  if (!bearerToken && !cookie) {
+    throw new Error(
+      "OS_E2E_ADMIN_API_SECRET, OS_ADMIN_API_SECRET, APP_CONFIG_ADMIN_API_SECRET, OS_E2E_BEARER_TOKEN, or OS_E2E_COOKIE is required.",
+    );
+  }
+
+  return {
+    ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
+    ...(cookie ? { Cookie: cookie } : {}),
+  };
+}
+
+function parseOptions(args: readonly string[]): Options {
+  const values = parseArgs(args);
+  return {
+    baseUrl: stringOption(values, "base-url", process.env.OS_BASE_URL ?? "http://127.0.0.1:5176"),
+    chunkMs: numberOption(values, "chunk-ms", 100),
+    createProject: booleanOption(values, "create-project", true),
+    provider: providerOption(values),
+    model: modelOption(values),
+    minOutputBytes: numberOption(values, "min-output-bytes", 4_800),
+    outputPcm: optionalStringOption(values, "output-pcm"),
+    pcmFile: optionalStringOption(values, "pcm-file"),
+    play: booleanOption(values, "play", false),
+    projectSlugOrId: optionalStringOption(values, "project"),
+    prompt: stringOption(values, "prompt", "Please say success."),
+    silenceMs: numberOption(values, "silence-ms", 1500),
+    streamPath: StreamPath.parse(
+      stringOption(values, "stream-path", `/voice-agents/e2e-${Date.now().toString(36)}`),
+    ),
+    timeoutMs: numberOption(values, "timeout-ms", 60_000),
+    voiceName: voiceOption(values),
+  };
+}
+
+function providerOption(values: Map<string, string>): VoiceAgentProvider {
+  const raw = stringOption(values, "provider", VOICE_AGENT_PROVIDER_GEMINI_LIVE);
+  if (
+    raw === VOICE_AGENT_PROVIDER_GEMINI_LIVE ||
+    raw === VOICE_AGENT_PROVIDER_OPENAI_REALTIME ||
+    raw === VOICE_AGENT_PROVIDER_GROK_REALTIME
+  ) {
+    return raw;
+  }
+  throw new Error(
+    `--provider must be ${VOICE_AGENT_PROVIDER_GEMINI_LIVE}, ${VOICE_AGENT_PROVIDER_OPENAI_REALTIME}, or ${VOICE_AGENT_PROVIDER_GROK_REALTIME}.`,
+  );
+}
+
+function modelOption(values: Map<string, string>) {
+  const explicit = optionalStringOption(values, "model");
+  if (explicit) return explicit;
+  switch (providerOption(values)) {
+    case VOICE_AGENT_PROVIDER_GEMINI_LIVE:
+      return DEFAULT_GEMINI_LIVE_MODEL;
+    case VOICE_AGENT_PROVIDER_OPENAI_REALTIME:
+      return DEFAULT_OPENAI_REALTIME_MODEL;
+    case VOICE_AGENT_PROVIDER_GROK_REALTIME:
+      return DEFAULT_GROK_REALTIME_MODEL;
+  }
+}
+
+function voiceOption(values: Map<string, string>) {
+  const explicit = optionalStringOption(values, "voice");
+  if (explicit) return explicit;
+  switch (providerOption(values)) {
+    case VOICE_AGENT_PROVIDER_GEMINI_LIVE:
+      return DEFAULT_GEMINI_LIVE_VOICE;
+    case VOICE_AGENT_PROVIDER_OPENAI_REALTIME:
+      return DEFAULT_OPENAI_REALTIME_VOICE;
+    case VOICE_AGENT_PROVIDER_GROK_REALTIME:
+      return DEFAULT_GROK_REALTIME_VOICE;
+  }
+}
+
+function parseArgs(args: readonly string[]) {
+  const values = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--") continue;
+    if (!arg?.startsWith("--")) throw new Error(`Unexpected argument: ${arg}`);
+    const [rawKey, inlineValue] = arg.slice(2).split("=", 2);
+    const key = rawKey ?? "";
+    if (!key) throw new Error(`Invalid option: ${arg}`);
+    if (inlineValue != null) {
+      values.set(key, inlineValue);
+      continue;
+    }
+    const next = args[index + 1];
+    if (next == null || next.startsWith("--")) {
+      values.set(key, "true");
+      continue;
+    }
+    values.set(key, next);
+    index += 1;
+  }
+  return values;
+}
+
+function stringOption(values: Map<string, string>, key: string, fallback: string) {
+  const value = values.get(key) ?? fallback;
+  if (!value.trim()) throw new Error(`--${key} is required.`);
+  return value.trim();
+}
+
+function optionalStringOption(values: Map<string, string>, key: string) {
+  const value = values.get(key)?.trim();
+  return value ? value : null;
+}
+
+function numberOption(values: Map<string, string>, key: string, fallback: number) {
+  const raw = values.get(key) ?? String(fallback);
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`--${key} must be a positive number.`);
+  }
+  return value;
+}
+
+function booleanOption(values: Map<string, string>, key: string, fallback: boolean) {
+  const raw = values.get(key);
+  if (raw == null) return fallback;
+  if (["1", "true", "yes"].includes(raw)) return true;
+  if (["0", "false", "no"].includes(raw)) return false;
+  throw new Error(`--${key} must be true or false.`);
+}
+
+function requireProjectSlugOrId(value: string | null) {
+  if (!value) throw new Error("--project is required when --create-project=false.");
+  return value;
+}
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : error);
+  process.exitCode = 1;
+});

--- a/apps/os/scripts/voice-agent-e2e.ts
+++ b/apps/os/scripts/voice-agent-e2e.ts
@@ -45,7 +45,7 @@ type Options = {
   baseUrl: string;
   chunkMs: number;
   createProject: boolean;
-  expectAskAgent: boolean;
+  expectMessageAgent: boolean;
   inputMode: "audio" | "text";
   model: string;
   minOutputBytes: number;
@@ -67,7 +67,7 @@ type SeenEvents = {
   providerConnected: boolean;
   setupCompleted: boolean;
   turnCompleted: boolean;
-  askAgentInputAdded: boolean;
+  messageAgentInputAdded: boolean;
   agentOutputAdded: boolean;
   codemodeScriptCompleted: boolean;
   codeAgentVoiceTextAdded: boolean;
@@ -139,11 +139,11 @@ async function main() {
           provider: options.provider,
           model: options.model,
           voiceName: options.voiceName,
-          askAgentToolChoice: options.expectAskAgent ? "required" : "auto",
-          systemInstruction: options.expectAskAgent
+          messageAgentToolChoice: options.expectMessageAgent ? "required" : "auto",
+          systemInstruction: options.expectMessageAgent
             ? [
                 "You are running an automated voice smoke test.",
-                "If the caller asks you to fetch, inspect, calculate, run code, or do any background work, you MUST call the Ask Agent tool with the caller's request.",
+                "If the caller asks you to fetch, inspect, calculate, run code, or do any background work, you MUST call the Message Agent tool with the caller's request.",
                 "After the tool call returns, say one short sentence telling the caller that you asked the background agent.",
               ].join(" ")
             : "You are running an automated voice test. Reply with one short sentence.",
@@ -158,7 +158,7 @@ async function main() {
     providerConnected: false,
     setupCompleted: false,
     turnCompleted: false,
-    askAgentInputAdded: false,
+    messageAgentInputAdded: false,
     agentOutputAdded: false,
     codemodeScriptCompleted: false,
     codeAgentVoiceTextAdded: false,
@@ -173,7 +173,7 @@ async function main() {
     streamPath: options.streamPath,
     timeoutMs: options.timeoutMs,
     minOutputBytes: options.minOutputBytes,
-    expectAskAgent: options.expectAskAgent,
+    expectMessageAgent: options.expectMessageAgent,
   });
 
   if (options.inputMode === "audio") {
@@ -215,7 +215,7 @@ async function main() {
         turnCompleted: seen.turnCompleted,
         outputBytes: output.byteLength,
         outputPcm: options.outputPcm,
-        askAgentInputAdded: seen.askAgentInputAdded,
+        messageAgentInputAdded: seen.messageAgentInputAdded,
         agentOutputAdded: seen.agentOutputAdded,
         codemodeScriptCompleted: seen.codemodeScriptCompleted,
         codeAgentVoiceTextAdded: seen.codeAgentVoiceTextAdded,
@@ -231,7 +231,7 @@ async function watchStream(input: {
   afterOffset: number;
   client: OrpcClient;
   minOutputBytes: number;
-  expectAskAgent: boolean;
+  expectMessageAgent: boolean;
   projectSlugOrId: string;
   seen: SeenEvents;
   streamPath: StreamPath;
@@ -289,8 +289,8 @@ async function watchStream(input: {
         if (typeof payload.content === "string") {
           console.log(`  agent input: ${payload.content.slice(0, 200)}`);
         }
-        if (isAskAgentInput(payload)) {
-          input.seen.askAgentInputAdded = true;
+        if (isMessageAgentInput(payload)) {
+          input.seen.messageAgentInputAdded = true;
         }
       }
       if (event.type === "events.iterate.com/agent/output-added") {
@@ -301,7 +301,7 @@ async function watchStream(input: {
       }
       if (event.type === VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE) {
         const payload = event.payload as { source?: unknown; text?: unknown };
-        if (input.seen.askAgentInputAdded) {
+        if (input.seen.messageAgentInputAdded) {
           input.seen.codeAgentVoiceTextAdded = true;
           input.seen.codeAgentVoiceText = typeof payload.text === "string" ? payload.text : null;
           console.log(`  voice input text: ${input.seen.codeAgentVoiceText ?? "<missing>"}`);
@@ -312,10 +312,10 @@ async function watchStream(input: {
         (total, buffer) => total + buffer.byteLength,
         0,
       );
-      if (input.expectAskAgent) {
+      if (input.expectMessageAgent) {
         if (
           input.seen.setupCompleted &&
-          input.seen.askAgentInputAdded &&
+          input.seen.messageAgentInputAdded &&
           input.seen.codeAgentVoiceTextAdded
         ) {
           return;
@@ -340,7 +340,7 @@ async function watchStream(input: {
   }
 }
 
-function isAskAgentInput(payload: { llmRequestPolicy?: unknown }) {
+function isMessageAgentInput(payload: { llmRequestPolicy?: unknown }) {
   const policy = payload.llmRequestPolicy as { behaviour?: unknown } | undefined;
   return policy?.behaviour === "after-current-request";
 }
@@ -514,12 +514,12 @@ function requireAuthHeaders() {
 
 function parseOptions(args: readonly string[]): Options {
   const values = parseArgs(args);
-  const expectAskAgent = booleanOption(values, "expect-ask-agent", false);
+  const expectMessageAgent = booleanOption(values, "expect-message-agent", false);
   return {
     baseUrl: stringOption(values, "base-url", process.env.OS_BASE_URL ?? "http://127.0.0.1:5173"),
     chunkMs: numberOption(values, "chunk-ms", 100),
     createProject: booleanOption(values, "create-project", true),
-    expectAskAgent,
+    expectMessageAgent,
     inputMode: inputModeOption(values),
     provider: providerOption(values),
     model: modelOption(values),
@@ -531,15 +531,15 @@ function parseOptions(args: readonly string[]): Options {
     prompt: stringOption(
       values,
       "prompt",
-      expectAskAgent
-        ? "Ask the background agent to fetch example dot com and tell me what it says."
+      expectMessageAgent
+        ? "Message the background agent to fetch example dot com and tell me what it says."
         : "Please say success.",
     ),
     silenceMs: numberOption(values, "silence-ms", 1500),
     streamPath: StreamPath.parse(
       stringOption(values, "stream-path", `/voice-agents/e2e-${Date.now().toString(36)}`),
     ),
-    timeoutMs: numberOption(values, "timeout-ms", expectAskAgent ? 180_000 : 60_000),
+    timeoutMs: numberOption(values, "timeout-ms", expectMessageAgent ? 180_000 : 60_000),
     voiceName: voiceOption(values),
   };
 }

--- a/apps/os/scripts/voice-agent-e2e.ts
+++ b/apps/os/scripts/voice-agent-e2e.ts
@@ -8,6 +8,7 @@ import { OpenAPILink } from "@orpc/openapi-client/fetch";
 import type { RouterClient } from "@orpc/server";
 import { osContract } from "@iterate-com/os-contract";
 import {
+  AGENT_INPUT_ADDED_EVENT_TYPE,
   DEFAULT_GEMINI_LIVE_MODEL,
   DEFAULT_GEMINI_LIVE_VOICE,
   DEFAULT_GROK_REALTIME_MODEL,
@@ -15,6 +16,7 @@ import {
   DEFAULT_OPENAI_REALTIME_MODEL,
   DEFAULT_OPENAI_REALTIME_VOICE,
   VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
   VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
   VOICE_AGENT_INPUT_SAMPLE_RATE,
   VOICE_AGENT_OUTPUT_SAMPLE_RATE,
@@ -43,6 +45,7 @@ type Options = {
   baseUrl: string;
   chunkMs: number;
   createProject: boolean;
+  expectAskAgent: boolean;
   model: string;
   minOutputBytes: number;
   outputPcm: string | null;
@@ -63,6 +66,11 @@ type SeenEvents = {
   providerConnected: boolean;
   setupCompleted: boolean;
   turnCompleted: boolean;
+  askAgentInputAdded: boolean;
+  agentOutputAdded: boolean;
+  codemodeScriptCompleted: boolean;
+  codeAgentVoiceTextAdded: boolean;
+  codeAgentVoiceText: string | null;
 };
 
 const execFileAsync = promisify(execFile);
@@ -73,7 +81,7 @@ async function main() {
   const runId = `voice-agent-e2e-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
   const projectSlugOrId = options.createProject
     ? (await createTestProject(client, runId)).id
-    : requireProjectSlugOrId(options.projectSlugOrId);
+    : await resolveProjectId(client, requireProjectSlugOrId(options.projectSlugOrId));
   const pcm = options.pcmFile
     ? await readFile(resolve(options.pcmFile))
     : await synthesizePromptPcm(options.prompt);
@@ -124,8 +132,13 @@ async function main() {
           provider: options.provider,
           model: options.model,
           voiceName: options.voiceName,
-          systemInstruction:
-            "You are running an automated voice test. Reply with one short sentence.",
+          systemInstruction: options.expectAskAgent
+            ? [
+                "You are running an automated voice smoke test.",
+                "If the caller asks you to fetch, inspect, calculate, run code, or do any background work, you MUST call the Ask Agent tool with the caller's request.",
+                "After the tool call returns, say one short sentence telling the caller that you asked the background agent.",
+              ].join(" ")
+            : "You are running an automated voice test. Reply with one short sentence.",
         },
       }),
     ],
@@ -137,6 +150,11 @@ async function main() {
     providerConnected: false,
     setupCompleted: false,
     turnCompleted: false,
+    askAgentInputAdded: false,
+    agentOutputAdded: false,
+    codemodeScriptCompleted: false,
+    codeAgentVoiceTextAdded: false,
+    codeAgentVoiceText: null,
   };
 
   const watchPromise = watchStream({
@@ -147,6 +165,7 @@ async function main() {
     streamPath: options.streamPath,
     timeoutMs: options.timeoutMs,
     minOutputBytes: options.minOutputBytes,
+    expectAskAgent: options.expectAskAgent,
   });
 
   await appendPcmFrames({
@@ -178,6 +197,11 @@ async function main() {
         turnCompleted: seen.turnCompleted,
         outputBytes: output.byteLength,
         outputPcm: options.outputPcm,
+        askAgentInputAdded: seen.askAgentInputAdded,
+        agentOutputAdded: seen.agentOutputAdded,
+        codemodeScriptCompleted: seen.codemodeScriptCompleted,
+        codeAgentVoiceTextAdded: seen.codeAgentVoiceTextAdded,
+        codeAgentVoiceText: seen.codeAgentVoiceText,
       },
       null,
       2,
@@ -189,6 +213,7 @@ async function watchStream(input: {
   afterOffset: number;
   client: OrpcClient;
   minOutputBytes: number;
+  expectAskAgent: boolean;
   projectSlugOrId: string;
   seen: SeenEvents;
   streamPath: StreamPath;
@@ -241,15 +266,44 @@ async function watchStream(input: {
         input.seen.error = typeof payload.message === "string" ? payload.message : "unknown error";
         throw new Error(input.seen.error);
       }
+      if (event.type === AGENT_INPUT_ADDED_EVENT_TYPE) {
+        input.seen.askAgentInputAdded = true;
+        const payload = event.payload as { content?: unknown };
+        if (typeof payload.content === "string") {
+          console.log(`  agent input: ${payload.content.slice(0, 200)}`);
+        }
+      }
+      if (event.type === "events.iterate.com/agent/output-added") {
+        input.seen.agentOutputAdded = true;
+      }
+      if (event.type === "events.iterate.com/codemode/script-execution-completed") {
+        input.seen.codemodeScriptCompleted = true;
+      }
+      if (event.type === VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE) {
+        const payload = event.payload as { source?: unknown; text?: unknown };
+        if (input.seen.askAgentInputAdded) {
+          input.seen.codeAgentVoiceTextAdded = true;
+          input.seen.codeAgentVoiceText = typeof payload.text === "string" ? payload.text : null;
+          console.log(`  voice input text: ${input.seen.codeAgentVoiceText ?? "<missing>"}`);
+        }
+      }
 
       const outputBytes = input.seen.outputBuffers.reduce(
         (total, buffer) => total + buffer.byteLength,
         0,
       );
-      if (
-        input.seen.setupCompleted &&
-        (outputBytes >= input.minOutputBytes || input.seen.turnCompleted)
-      ) {
+      if (input.expectAskAgent) {
+        if (
+          input.seen.setupCompleted &&
+          input.seen.askAgentInputAdded &&
+          input.seen.codeAgentVoiceTextAdded
+        ) {
+          return;
+        }
+        continue;
+      }
+
+      if (input.seen.setupCompleted && outputBytes >= input.minOutputBytes) {
         return;
       }
     }
@@ -368,6 +422,14 @@ async function createTestProject(client: OrpcClient, runId: string) {
   });
 }
 
+async function resolveProjectId(client: OrpcClient, slugOrId: string) {
+  try {
+    return (await client.projects.find({ id: slugOrId })).id;
+  } catch {
+    return (await client.projects.findBySlug({ slug: slugOrId })).id;
+  }
+}
+
 function createClient(baseUrl: string) {
   const authHeaders = requireAuthHeaders();
   return createORPCClient(
@@ -406,10 +468,12 @@ function requireAuthHeaders() {
 
 function parseOptions(args: readonly string[]): Options {
   const values = parseArgs(args);
+  const expectAskAgent = booleanOption(values, "expect-ask-agent", false);
   return {
-    baseUrl: stringOption(values, "base-url", process.env.OS_BASE_URL ?? "http://127.0.0.1:5176"),
+    baseUrl: stringOption(values, "base-url", process.env.OS_BASE_URL ?? "http://127.0.0.1:5173"),
     chunkMs: numberOption(values, "chunk-ms", 100),
     createProject: booleanOption(values, "create-project", true),
+    expectAskAgent,
     provider: providerOption(values),
     model: modelOption(values),
     minOutputBytes: numberOption(values, "min-output-bytes", 4_800),
@@ -417,12 +481,18 @@ function parseOptions(args: readonly string[]): Options {
     pcmFile: optionalStringOption(values, "pcm-file"),
     play: booleanOption(values, "play", false),
     projectSlugOrId: optionalStringOption(values, "project"),
-    prompt: stringOption(values, "prompt", "Please say success."),
+    prompt: stringOption(
+      values,
+      "prompt",
+      expectAskAgent
+        ? "Ask the background agent to fetch example dot com and tell me what it says."
+        : "Please say success.",
+    ),
     silenceMs: numberOption(values, "silence-ms", 1500),
     streamPath: StreamPath.parse(
       stringOption(values, "stream-path", `/voice-agents/e2e-${Date.now().toString(36)}`),
     ),
-    timeoutMs: numberOption(values, "timeout-ms", 60_000),
+    timeoutMs: numberOption(values, "timeout-ms", expectAskAgent ? 180_000 : 60_000),
     voiceName: voiceOption(values),
   };
 }

--- a/apps/os/scripts/voice-agent-e2e.ts
+++ b/apps/os/scripts/voice-agent-e2e.ts
@@ -537,7 +537,7 @@ function parseOptions(args: readonly string[]): Options {
     ),
     silenceMs: numberOption(values, "silence-ms", 1500),
     streamPath: StreamPath.parse(
-      stringOption(values, "stream-path", `/voice-agents/e2e-${Date.now().toString(36)}`),
+      stringOption(values, "stream-path", `/agents/voice/e2e-${Date.now().toString(36)}`),
     ),
     timeoutMs: numberOption(values, "timeout-ms", expectMessageAgent ? 180_000 : 60_000),
     voiceName: voiceOption(values),

--- a/apps/os/scripts/voice-agent-e2e.ts
+++ b/apps/os/scripts/voice-agent-e2e.ts
@@ -46,6 +46,7 @@ type Options = {
   chunkMs: number;
   createProject: boolean;
   expectAskAgent: boolean;
+  inputMode: "audio" | "text";
   model: string;
   minOutputBytes: number;
   outputPcm: string | null;
@@ -82,10 +83,15 @@ async function main() {
   const projectSlugOrId = options.createProject
     ? (await createTestProject(client, runId)).id
     : await resolveProjectId(client, requireProjectSlugOrId(options.projectSlugOrId));
-  const pcm = options.pcmFile
-    ? await readFile(resolve(options.pcmFile))
-    : await synthesizePromptPcm(options.prompt);
-  const audio = Buffer.concat([pcm, silencePcm(options.silenceMs)]);
+  const audio =
+    options.inputMode === "audio"
+      ? Buffer.concat([
+          options.pcmFile
+            ? await readFile(resolve(options.pcmFile))
+            : await synthesizePromptPcm(options.prompt),
+          silencePcm(options.silenceMs),
+        ])
+      : Buffer.alloc(0);
 
   console.log(
     JSON.stringify(
@@ -96,6 +102,7 @@ async function main() {
         projectSlugOrId,
         streamPath: options.streamPath,
         model: options.model,
+        inputMode: options.inputMode,
         prompt: options.pcmFile ? `pcm-file:${options.pcmFile}` : options.prompt,
         inputBytes: audio.byteLength,
       },
@@ -132,6 +139,7 @@ async function main() {
           provider: options.provider,
           model: options.model,
           voiceName: options.voiceName,
+          askAgentToolChoice: options.expectAskAgent ? "required" : "auto",
           systemInstruction: options.expectAskAgent
             ? [
                 "You are running an automated voice smoke test.",
@@ -168,14 +176,24 @@ async function main() {
     expectAskAgent: options.expectAskAgent,
   });
 
-  await appendPcmFrames({
-    audio,
-    chunkMs: options.chunkMs,
-    client,
-    projectSlugOrId,
-    runId,
-    streamPath: options.streamPath,
-  });
+  if (options.inputMode === "audio") {
+    await appendPcmFrames({
+      audio,
+      chunkMs: options.chunkMs,
+      client,
+      projectSlugOrId,
+      runId,
+      streamPath: options.streamPath,
+    });
+  } else {
+    await appendInputText({
+      client,
+      projectSlugOrId,
+      runId,
+      streamPath: options.streamPath,
+      text: options.prompt,
+    });
+  }
 
   await watchPromise;
 
@@ -267,10 +285,12 @@ async function watchStream(input: {
         throw new Error(input.seen.error);
       }
       if (event.type === AGENT_INPUT_ADDED_EVENT_TYPE) {
-        input.seen.askAgentInputAdded = true;
-        const payload = event.payload as { content?: unknown };
+        const payload = event.payload as { content?: unknown; llmRequestPolicy?: unknown };
         if (typeof payload.content === "string") {
           console.log(`  agent input: ${payload.content.slice(0, 200)}`);
+        }
+        if (isAskAgentInput(payload)) {
+          input.seen.askAgentInputAdded = true;
         }
       }
       if (event.type === "events.iterate.com/agent/output-added") {
@@ -320,6 +340,11 @@ async function watchStream(input: {
   }
 }
 
+function isAskAgentInput(payload: { llmRequestPolicy?: unknown }) {
+  const policy = payload.llmRequestPolicy as { behaviour?: unknown } | undefined;
+  return policy?.behaviour === "after-current-request";
+}
+
 async function appendPcmFrames(input: {
   audio: Buffer;
   chunkMs: number;
@@ -359,6 +384,27 @@ async function appendPcmFrames(input: {
     sequence += 1;
     await delay(input.chunkMs);
   }
+}
+
+async function appendInputText(input: {
+  client: OrpcClient;
+  projectSlugOrId: string;
+  runId: string;
+  streamPath: StreamPath;
+  text: string;
+}) {
+  await input.client.project.streams.append({
+    projectSlugOrId: input.projectSlugOrId,
+    streamPath: input.streamPath,
+    event: EventInput.parse({
+      idempotencyKey: `${input.runId}:voice-agent-input-text`,
+      type: VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
+      payload: {
+        source: "voice-agent-e2e",
+        text: input.text,
+      },
+    }),
+  });
 }
 
 async function synthesizePromptPcm(prompt: string): Promise<Buffer> {
@@ -474,6 +520,7 @@ function parseOptions(args: readonly string[]): Options {
     chunkMs: numberOption(values, "chunk-ms", 100),
     createProject: booleanOption(values, "create-project", true),
     expectAskAgent,
+    inputMode: inputModeOption(values),
     provider: providerOption(values),
     model: modelOption(values),
     minOutputBytes: numberOption(values, "min-output-bytes", 4_800),
@@ -495,6 +542,12 @@ function parseOptions(args: readonly string[]): Options {
     timeoutMs: numberOption(values, "timeout-ms", expectAskAgent ? 180_000 : 60_000),
     voiceName: voiceOption(values),
   };
+}
+
+function inputModeOption(values: Map<string, string>) {
+  const raw = stringOption(values, "input-mode", "audio");
+  if (raw === "audio" || raw === "text") return raw;
+  throw new Error("--input-mode must be audio or text.");
 }
 
 function providerOption(values: Map<string, string>): VoiceAgentProvider {

--- a/apps/os/src/app.ts
+++ b/apps/os/src/app.ts
@@ -67,6 +67,8 @@ export const AppConfig = BaseAppConfig.extend({
       ),
   }),
   openAiApiKey: redacted(z.string().trim().min(1)),
+  geminiApiKey: redacted(z.string().trim().min(1)).optional(),
+  xAiApiKey: redacted(z.string().trim().min(1)).optional(),
   cloudflare: z
     .object({
       apiToken: redacted(z.string().trim().min(1)).optional(),

--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -308,6 +308,25 @@ function ProjectSidebarGroup({
             <SidebarMenuSubButton
               render={
                 <Link
+                  to="/orgs/$organizationSlug/projects/$projectSlug/voice-agents"
+                  params={{ organizationSlug, projectSlug }}
+                />
+              }
+              isActive={Boolean(
+                matchRoute({
+                  to: "/orgs/$organizationSlug/projects/$projectSlug/voice-agents",
+                  params: { organizationSlug, projectSlug },
+                  fuzzy: true,
+                }),
+              )}
+            >
+              <span>Voice agents</span>
+            </SidebarMenuSubButton>
+          </SidebarMenuSubItem>
+          <SidebarMenuSubItem>
+            <SidebarMenuSubButton
+              render={
+                <Link
                   to="/orgs/$organizationSlug/projects/$projectSlug/settings"
                   params={{ organizationSlug, projectSlug }}
                 />

--- a/apps/os/src/components/voice-agent-stream-console.tsx
+++ b/apps/os/src/components/voice-agent-stream-console.tsx
@@ -5,6 +5,7 @@ import {
   VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
   VOICE_AGENT_INPUT_SAMPLE_RATE,
   VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE,
   VOICE_AGENT_OUTPUT_SAMPLE_RATE,
   VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
 } from "@iterate-com/shared/stream-processors/voice-agent/contract";
@@ -210,6 +211,17 @@ export function VoiceAgentStreamConsole({
       if (typeof payload.text === "string") {
         appendTranscriptLine({
           direction: payload.direction === "input" ? "input" : "output",
+          eventOffset: event.offset,
+          text: payload.text,
+        });
+      }
+      return;
+    }
+    if (event.type === VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE) {
+      const payload = event.payload as { source?: unknown; text?: unknown };
+      if (typeof payload.text === "string") {
+        appendTranscriptLine({
+          direction: payload.source === "input-transcription" ? "input" : "output",
           eventOffset: event.offset,
           text: payload.text,
         });

--- a/apps/os/src/components/voice-agent-stream-console.tsx
+++ b/apps/os/src/components/voice-agent-stream-console.tsx
@@ -1,0 +1,791 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { Activity, Mic, Play, Square, Volume2, Waves } from "lucide-react";
+import {
+  VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_INPUT_SAMPLE_RATE,
+  VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_OUTPUT_SAMPLE_RATE,
+  VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
+} from "@iterate-com/shared/stream-processors/voice-agent/contract";
+import { STREAM_RESUMED_TYPE } from "@iterate-com/shared/streams/core-event-types";
+import { Event, EventInput, type StreamPath } from "@iterate-com/shared/streams/types";
+import { Button } from "@iterate-com/ui/components/button";
+import { Input } from "@iterate-com/ui/components/input";
+import { Switch } from "@iterate-com/ui/components/switch";
+import { toast } from "@iterate-com/ui/components/sonner";
+import { EventsDebugLink } from "~/components/events-debug-link.tsx";
+import {
+  voiceAgentCircuitBreakerConfiguredEvent,
+  voiceAgentSubscriptionConfiguredEvent,
+} from "~/domains/voice-agents/voice-agent-subscription.ts";
+import { streamPathToSplat } from "~/lib/stream-links.ts";
+import { createBrowserOpenApiClient } from "~/orpc/client.ts";
+
+const CHANNELS = 1;
+const INPUT_CHUNK_MS = 100;
+const OUTPUT_MIN_BUFFER_MS = 80;
+const OUTPUT_TONE_CHUNK_MS = 40;
+
+type VoiceAudioFramePayload = {
+  streamId: string;
+  sequence: number;
+  encoding: "pcm_s16le";
+  sampleRate: number;
+  channels: number;
+  durationMs: number;
+  dataBase64: string;
+};
+
+type AudioStats = {
+  frames: number;
+  bytes: number;
+};
+
+type TranscriptLine = {
+  id: number;
+  direction: "input" | "output";
+  text: string;
+};
+
+type VoiceAgentStreamConsoleProps = {
+  organizationSlug: string;
+  project: { id: string; slug: string };
+  projectSlug: string;
+  streamPath: StreamPath;
+  title: string;
+  enableVoiceAgentProcessor: boolean;
+};
+
+export function VoiceAgentStreamConsole({
+  enableVoiceAgentProcessor,
+  organizationSlug,
+  project,
+  projectSlug,
+  streamPath,
+  title,
+}: VoiceAgentStreamConsoleProps) {
+  const streamIdRef = useRef(crypto.randomUUID());
+  const appendQueueRef = useRef(Promise.resolve());
+  const inputSequenceRef = useRef(0);
+  const outputSequenceRef = useRef(0);
+  const playedOffsetsRef = useRef(new Set<number>());
+  const inputAudioContextRef = useRef<AudioContext | null>(null);
+  const inputNodeRef = useRef<AudioWorkletNode | null>(null);
+  const inputMonitorRef = useRef<GainNode | null>(null);
+  const micStreamRef = useRef<MediaStream | null>(null);
+  const outputAudioContextRef = useRef<AudioContext | null>(null);
+  const outputNodeRef = useRef<AudioWorkletNode | null>(null);
+
+  const [streamStatus, setStreamStatus] = useState<"connecting" | "live" | "error">("connecting");
+  const [captureStatus, setCaptureStatus] = useState<"idle" | "starting" | "capturing">("idle");
+  const [playbackReady, setPlaybackReady] = useState(false);
+  const [echoCancellation, setEchoCancellation] = useState(true);
+  const [noiseSuppression, setNoiseSuppression] = useState(true);
+  const [autoGainControl, setAutoGainControl] = useState(true);
+  const [toneSeconds, setToneSeconds] = useState(1);
+  const [inputStats, setInputStats] = useState<AudioStats>({ frames: 0, bytes: 0 });
+  const [outputStats, setOutputStats] = useState<AudioStats>({ frames: 0, bytes: 0 });
+  const [outputQueueMs, setOutputQueueMs] = useState(0);
+  const [outputUnderruns, setOutputUnderruns] = useState(0);
+  const [lastError, setLastError] = useState<string | null>(null);
+  const [providerStatus, setProviderStatus] = useState("Waiting for audio");
+  const [transcriptLines, setTranscriptLines] = useState<TranscriptLine[]>([]);
+
+  const streamHrefParams = useMemo(
+    () => ({
+      organizationSlug,
+      projectSlug,
+      _splat: streamPathToSplat(streamPath),
+    }),
+    [organizationSlug, projectSlug, streamPath],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let isCurrent = true;
+    let iterator: AsyncIterator<Event> | undefined;
+
+    setStreamStatus("connecting");
+    void (async () => {
+      try {
+        await createBrowserOpenApiClient().project.streams.create({
+          projectSlugOrId: project.id,
+          streamPath,
+        });
+
+        if (enableVoiceAgentProcessor) {
+          await ensureVoiceAgentStreamInfrastructure({
+            projectId: project.id,
+            streamPath,
+          });
+        }
+
+        const stream = await createBrowserOpenApiClient().project.streams.streamEvents(
+          {
+            afterOffset: "end",
+            projectSlugOrId: project.id,
+            streamPath,
+          },
+          { signal: controller.signal },
+        );
+        iterator = stream[Symbol.asyncIterator]();
+        if (!isCurrent || controller.signal.aborted) return;
+        setStreamStatus("live");
+
+        for await (const value of stream) {
+          if (!isCurrent || controller.signal.aborted) return;
+          const event = Event.parse(value);
+          await handleStreamEvent(event);
+        }
+      } catch (error) {
+        if (!isCurrent || controller.signal.aborted) return;
+        setStreamStatus("error");
+        setLastError(error instanceof Error ? error.message : String(error));
+      }
+    })();
+
+    return () => {
+      isCurrent = false;
+      controller.abort();
+      void iterator?.return?.();
+    };
+  }, [enableVoiceAgentProcessor, project.id, streamPath]);
+
+  useEffect(() => {
+    return () => {
+      stopCapture();
+      closeOutputAudio();
+    };
+  }, []);
+
+  async function handleStreamEvent(event: Event) {
+    if (event.type === VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE) {
+      await playOutputEvent(event);
+      return;
+    }
+    if (event.type === "events.iterate.com/voice-agent/gemini-live-websocket-connected") {
+      setProviderStatus("Gemini connected");
+      return;
+    }
+    if (event.type === "events.iterate.com/voice-agent/openai-realtime-websocket-connected") {
+      setProviderStatus("OpenAI connected");
+      return;
+    }
+    if (event.type === "events.iterate.com/voice-agent/grok-realtime-websocket-connected") {
+      setProviderStatus("Grok connected");
+      return;
+    }
+    if (event.type === "events.iterate.com/voice-agent/gemini-live-setup-completed") {
+      setProviderStatus("Gemini ready");
+      return;
+    }
+    if (event.type === "events.iterate.com/voice-agent/openai-realtime-session-updated") {
+      setProviderStatus("OpenAI ready");
+      return;
+    }
+    if (event.type === "events.iterate.com/voice-agent/grok-realtime-session-updated") {
+      setProviderStatus("Grok ready");
+      return;
+    }
+    if (event.type === VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE) {
+      clearPlayback();
+      setProviderStatus("Speaker buffer cleared");
+      return;
+    }
+    if (event.type === "events.iterate.com/voice-agent/gemini-live-output-interrupted") {
+      setProviderStatus("Gemini interrupted");
+      return;
+    }
+    if (
+      event.type === "events.iterate.com/voice-agent/gemini-live-turn-completed" ||
+      event.type === "events.iterate.com/voice-agent/openai-realtime-response-done" ||
+      event.type === "events.iterate.com/voice-agent/grok-realtime-response-done"
+    ) {
+      setProviderStatus("Turn complete");
+      return;
+    }
+    if (event.type === "events.iterate.com/voice-agent/transcription-appended") {
+      const payload = event.payload as { direction?: unknown; text?: unknown };
+      if (typeof payload.text === "string") {
+        appendTranscriptLine({
+          direction: payload.direction === "input" ? "input" : "output",
+          eventOffset: event.offset,
+          text: payload.text,
+        });
+      }
+      return;
+    }
+    if (event.type === "events.iterate.com/voice-agent/error-occurred") {
+      const payload = event.payload as { message?: unknown };
+      setLastError(typeof payload.message === "string" ? payload.message : "Voice agent error");
+    }
+  }
+
+  function appendTranscriptLine(input: {
+    direction: TranscriptLine["direction"];
+    eventOffset: number;
+    text: string;
+  }) {
+    setTranscriptLines((current) => {
+      const lastLine = current.at(-1);
+      if (lastLine?.direction === input.direction) {
+        return [
+          ...current.slice(0, -1),
+          {
+            ...lastLine,
+            text: `${lastLine.text}${input.text}`,
+          },
+        ];
+      }
+
+      return [
+        ...current,
+        {
+          id: input.eventOffset,
+          direction: input.direction,
+          text: input.text,
+        },
+      ];
+    });
+  }
+
+  async function ensureOutputAudio() {
+    if (outputAudioContextRef.current && outputNodeRef.current) {
+      if (outputAudioContextRef.current.state !== "running") {
+        await outputAudioContextRef.current.resume();
+      }
+      return outputNodeRef.current;
+    }
+
+    const context = new AudioContext();
+    await context.audioWorklet.addModule("/voice-agent-poc/output-worklet.js");
+    const node = new AudioWorkletNode(context, "pcm-output-processor", {
+      numberOfInputs: 0,
+      numberOfOutputs: 1,
+      outputChannelCount: [1],
+    });
+    node.port.postMessage({
+      type: "configure",
+      minBufferMs: OUTPUT_MIN_BUFFER_MS,
+      sourceSampleRate: VOICE_AGENT_OUTPUT_SAMPLE_RATE,
+    });
+    node.port.onmessage = (event) => {
+      if (event.data?.type === "status") {
+        setOutputQueueMs(event.data.queuedMs ?? 0);
+        setOutputUnderruns(event.data.underruns ?? 0);
+      }
+    };
+    node.connect(context.destination);
+    outputAudioContextRef.current = context;
+    outputNodeRef.current = node;
+    setPlaybackReady(true);
+    return node;
+  }
+
+  async function playOutputEvent(event: Event) {
+    if (playedOffsetsRef.current.has(event.offset)) return;
+    playedOffsetsRef.current.add(event.offset);
+
+    const payload = parseAudioPayload(event.payload);
+    if (!payload || payload.sampleRate !== VOICE_AGENT_OUTPUT_SAMPLE_RATE) return;
+
+    const node = await ensureOutputAudio();
+    const buffer = base64ToArrayBuffer(payload.dataBase64);
+    node.port.postMessage({ type: "enqueue", buffer }, [buffer]);
+    setOutputStats((stats) => ({
+      frames: stats.frames + 1,
+      bytes: stats.bytes + buffer.byteLength,
+    }));
+  }
+
+  async function startCapture() {
+    if (captureStatus !== "idle") return;
+    setCaptureStatus("starting");
+    setLastError(null);
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          echoCancellation,
+          noiseSuppression,
+          autoGainControl,
+        },
+      });
+      const context = new AudioContext();
+      await context.audioWorklet.addModule("/voice-agent-poc/input-worklet.js");
+      const source = context.createMediaStreamSource(stream);
+      const node = new AudioWorkletNode(context, "pcm-input-processor", {
+        numberOfInputs: 1,
+        numberOfOutputs: 1,
+        outputChannelCount: [1],
+      });
+      const monitor = context.createGain();
+      monitor.gain.value = 0;
+      node.port.postMessage({
+        type: "configure",
+        targetSampleRate: VOICE_AGENT_INPUT_SAMPLE_RATE,
+        chunkMs: INPUT_CHUNK_MS,
+      });
+      node.port.onmessage = (event) => {
+        if (event.data?.type !== "pcm" || !(event.data.buffer instanceof ArrayBuffer)) {
+          return;
+        }
+        appendInputFrame(event.data.buffer, event.data.samples ?? 0);
+      };
+      source.connect(node);
+      node.connect(monitor);
+      monitor.connect(context.destination);
+      node.port.postMessage({ type: "set-enabled", enabled: true });
+
+      micStreamRef.current = stream;
+      inputAudioContextRef.current = context;
+      inputNodeRef.current = node;
+      inputMonitorRef.current = monitor;
+      setCaptureStatus("capturing");
+    } catch (error) {
+      setCaptureStatus("idle");
+      setLastError(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  function stopCapture() {
+    inputNodeRef.current?.port.postMessage({ type: "set-enabled", enabled: false });
+    inputNodeRef.current?.disconnect();
+    inputNodeRef.current = null;
+    inputMonitorRef.current?.disconnect();
+    inputMonitorRef.current = null;
+    void inputAudioContextRef.current?.close();
+    inputAudioContextRef.current = null;
+    micStreamRef.current?.getTracks().forEach((track) => track.stop());
+    micStreamRef.current = null;
+    setCaptureStatus("idle");
+  }
+
+  function appendInputFrame(buffer: ArrayBuffer, sampleCount: number) {
+    const sequence = inputSequenceRef.current++;
+    const event = audioFrameEvent({
+      type: VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+      streamId: streamIdRef.current,
+      sequence,
+      sampleRate: VOICE_AGENT_INPUT_SAMPLE_RATE,
+      durationMs: Math.round((sampleCount / VOICE_AGENT_INPUT_SAMPLE_RATE) * 1000),
+      buffer,
+    });
+
+    setInputStats((stats) => ({
+      frames: stats.frames + 1,
+      bytes: stats.bytes + buffer.byteLength,
+    }));
+
+    appendQueueRef.current = appendQueueRef.current
+      .then(async () => {
+        await createBrowserOpenApiClient().project.streams.append({
+          projectSlugOrId: project.id,
+          streamPath,
+          event,
+        });
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        setLastError(message);
+        if (message.includes("stream is paused")) {
+          stopCapture();
+          setProviderStatus("Stream paused");
+        }
+      });
+  }
+
+  async function appendTone() {
+    setLastError(null);
+    await ensureOutputAudio();
+    const events = createToneEvents({
+      seconds: toneSeconds,
+      streamId: streamIdRef.current,
+      startSequence: outputSequenceRef.current,
+    });
+    outputSequenceRef.current += events.length;
+
+    try {
+      await createBrowserOpenApiClient().project.streams.appendBatch({
+        projectSlugOrId: project.id,
+        streamPath,
+        events,
+      });
+      toast.success(`Appended ${events.length} output audio frame events.`);
+    } catch (error) {
+      setLastError(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  function clearPlayback() {
+    outputNodeRef.current?.port.postMessage({ type: "clear" });
+    setOutputQueueMs(0);
+    setOutputUnderruns(0);
+  }
+
+  function closeOutputAudio() {
+    outputNodeRef.current?.disconnect();
+    outputNodeRef.current = null;
+    void outputAudioContextRef.current?.close();
+    outputAudioContextRef.current = null;
+    setPlaybackReady(false);
+  }
+
+  const canCapture = typeof navigator !== "undefined" && !!navigator.mediaDevices?.getUserMedia;
+
+  return (
+    <section className="flex min-h-0 flex-1 flex-col overflow-auto">
+      <div className="border-b px-4 py-3">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="min-w-0">
+            <h1 className="text-base font-semibold">{title}</h1>
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+              <span>{enableVoiceAgentProcessor ? providerStatus : "Stream source of truth"}</span>
+              <Link
+                className="font-medium text-foreground underline-offset-4 hover:underline"
+                to="/orgs/$organizationSlug/projects/$projectSlug/streams/$"
+                params={streamHrefParams}
+              >
+                {streamPath}
+              </Link>
+              <span>{streamStatusLabel(streamStatus)}</span>
+            </div>
+          </div>
+          <EventsDebugLink namespace={project.id} streamPath={streamPath} />
+        </div>
+      </div>
+
+      <div className="grid gap-4 p-4 xl:grid-cols-[minmax(0,1fr)_minmax(24rem,34rem)]">
+        <main className="space-y-4">
+          <section className="rounded-lg border bg-background">
+            <div className="flex flex-col gap-3 border-b p-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-sm font-semibold">Output playback</h2>
+                <p className="text-sm text-muted-foreground">
+                  Plays 24 kHz PCM output only after the stream delivers frame events.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button type="button" variant="outline" onClick={() => void ensureOutputAudio()}>
+                  <Volume2 />
+                  Enable speaker
+                </Button>
+                <Button type="button" variant="outline" onClick={() => void appendTone()}>
+                  <Play />
+                  Inject tone
+                </Button>
+                <Button type="button" variant="outline" onClick={clearPlayback}>
+                  <Square />
+                  Clear buffer
+                </Button>
+              </div>
+            </div>
+            <div className="grid gap-3 p-4 md:grid-cols-5">
+              <Metric label="Playback" value={playbackReady ? "Ready" : "Idle"} />
+              <Metric label="Output frames" value={String(outputStats.frames)} />
+              <Metric label="Output bytes" value={formatBytes(outputStats.bytes)} />
+              <Metric label="Queued" value={`${outputQueueMs} ms`} />
+              <Metric label="Underruns" value={String(outputUnderruns)} />
+            </div>
+            <div className="flex items-center gap-3 border-t p-4">
+              <label className="text-sm font-medium" htmlFor="tone-seconds">
+                Tone seconds
+              </label>
+              <Input
+                id="tone-seconds"
+                className="h-9 w-24"
+                type="number"
+                min={0.2}
+                max={5}
+                step={0.1}
+                value={toneSeconds}
+                onChange={(event) => setToneSeconds(Number(event.currentTarget.value))}
+              />
+            </div>
+          </section>
+
+          <section className="rounded-lg border bg-background">
+            <div className="flex flex-col gap-3 border-b p-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-sm font-semibold">Microphone input</h2>
+                <p className="text-sm text-muted-foreground">
+                  Captures browser mic audio as 16 kHz PCM and appends each chunk to the stream.
+                </p>
+              </div>
+              <div className="flex gap-2">
+                {captureStatus === "capturing" ? (
+                  <Button type="button" variant="outline" onClick={stopCapture}>
+                    <Square />
+                    Stop mic
+                  </Button>
+                ) : (
+                  <Button
+                    type="button"
+                    disabled={!canCapture || captureStatus === "starting"}
+                    onClick={() => void startCapture()}
+                  >
+                    <Mic />
+                    {captureStatus === "starting" ? "Starting..." : "Start mic"}
+                  </Button>
+                )}
+              </div>
+            </div>
+            <div className="grid gap-3 p-4 md:grid-cols-3">
+              <Metric label="Capture" value={captureStatusLabel(captureStatus)} />
+              <Metric label="Input frames" value={String(inputStats.frames)} />
+              <Metric label="Input bytes" value={formatBytes(inputStats.bytes)} />
+            </div>
+            <div className="grid gap-3 border-t p-4 md:grid-cols-3">
+              <ToggleRow
+                checked={echoCancellation}
+                label="Echo cancellation"
+                onCheckedChange={setEchoCancellation}
+              />
+              <ToggleRow
+                checked={noiseSuppression}
+                label="Noise suppression"
+                onCheckedChange={setNoiseSuppression}
+              />
+              <ToggleRow
+                checked={autoGainControl}
+                label="Auto gain"
+                onCheckedChange={setAutoGainControl}
+              />
+            </div>
+          </section>
+        </main>
+
+        <aside className="space-y-4">
+          <section className="min-h-[24rem] rounded-lg border bg-background p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Activity className="size-4" />
+              <h2 className="text-sm font-semibold">Status</h2>
+            </div>
+            <div className="space-y-4 text-sm">
+              <p className="text-muted-foreground">{providerStatus}</p>
+              {transcriptLines.length > 0 ? (
+                <div className="space-y-3">
+                  {transcriptLines.map((line) => (
+                    <div key={line.id} className="rounded-md border bg-muted/30 p-3">
+                      <div className="mb-1 text-xs font-medium text-muted-foreground">
+                        {line.direction === "input" ? "You" : "Agent"}
+                      </div>
+                      <p className="whitespace-pre-wrap text-foreground">{line.text}</p>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+              {lastError ? <p className="text-destructive">{lastError}</p> : null}
+            </div>
+          </section>
+
+          <section className="rounded-lg border bg-background p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Waves className="size-4" />
+              <h2 className="text-sm font-semibold">Frame contract</h2>
+            </div>
+            <dl className="space-y-3 text-sm">
+              <KeyValue label="Input" value="pcm_s16le mono, 16 kHz" />
+              <KeyValue label="Output" value="pcm_s16le mono, 24 kHz" />
+              <KeyValue label="Chunking" value="100 ms input, provider-sized output" />
+              <KeyValue label="Stream ID" value={streamIdRef.current} />
+            </dl>
+          </section>
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border bg-muted/30 px-3 py-2">
+      <div className="text-xs font-medium text-muted-foreground">{label}</div>
+      <div className="mt-1 font-mono text-sm">{value}</div>
+    </div>
+  );
+}
+
+function KeyValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
+      <dd className="mt-1 break-all font-mono text-xs text-foreground">{value}</dd>
+    </div>
+  );
+}
+
+function ToggleRow({
+  checked,
+  label,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  label: string;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className="flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-sm">
+      <span>{label}</span>
+      <Switch checked={checked} onCheckedChange={onCheckedChange} />
+    </label>
+  );
+}
+
+async function ensureVoiceAgentStreamInfrastructure(input: {
+  projectId: string;
+  streamPath: StreamPath;
+}) {
+  const events = [
+    voiceAgentCircuitBreakerConfiguredEvent({
+      projectId: input.projectId,
+      streamPath: input.streamPath,
+    }),
+    voiceAgentSubscriptionConfiguredEvent({
+      projectId: input.projectId,
+      streamPath: input.streamPath,
+    }),
+  ];
+
+  try {
+    await createBrowserOpenApiClient().project.streams.appendBatch({
+      projectSlugOrId: input.projectId,
+      streamPath: input.streamPath,
+      events,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes("stream is paused")) throw error;
+
+    await createBrowserOpenApiClient().project.streams.append({
+      projectSlugOrId: input.projectId,
+      streamPath: input.streamPath,
+      event: EventInput.parse({
+        type: STREAM_RESUMED_TYPE,
+        payload: {
+          reason: "voice agent setup resumed paused stream",
+        },
+      }),
+    });
+    await createBrowserOpenApiClient().project.streams.appendBatch({
+      projectSlugOrId: input.projectId,
+      streamPath: input.streamPath,
+      events,
+    });
+  }
+}
+
+function audioFrameEvent(input: {
+  buffer: ArrayBuffer;
+  durationMs: number;
+  sampleRate: number;
+  sequence: number;
+  streamId: string;
+  type:
+    | typeof VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE
+    | typeof VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE;
+}): EventInput {
+  const payload: VoiceAudioFramePayload = {
+    channels: CHANNELS,
+    dataBase64: arrayBufferToBase64(input.buffer),
+    durationMs: input.durationMs,
+    encoding: "pcm_s16le",
+    sampleRate: input.sampleRate,
+    sequence: input.sequence,
+    streamId: input.streamId,
+  };
+
+  return EventInput.parse({
+    type: input.type,
+    payload,
+  });
+}
+
+function createToneEvents(input: {
+  seconds: number;
+  startSequence: number;
+  streamId: string;
+}): EventInput[] {
+  const seconds = Math.min(5, Math.max(0.2, input.seconds || 1));
+  const frameSamples = Math.round((VOICE_AGENT_OUTPUT_SAMPLE_RATE * OUTPUT_TONE_CHUNK_MS) / 1000);
+  const totalSamples = Math.round(VOICE_AGENT_OUTPUT_SAMPLE_RATE * seconds);
+  const events: EventInput[] = [];
+  let sequence = input.startSequence;
+
+  for (let start = 0; start < totalSamples; start += frameSamples) {
+    const sampleCount = Math.min(frameSamples, totalSamples - start);
+    const pcm = new Int16Array(sampleCount);
+    for (let index = 0; index < sampleCount; index++) {
+      const sampleIndex = start + index;
+      const envelope = Math.min(1, sampleIndex / 480, (totalSamples - sampleIndex) / 480);
+      const value = Math.sin((2 * Math.PI * 440 * sampleIndex) / VOICE_AGENT_OUTPUT_SAMPLE_RATE);
+      pcm[index] = Math.round(value * envelope * 12000);
+    }
+    events.push(
+      audioFrameEvent({
+        buffer: pcm.buffer.slice(0),
+        durationMs: Math.round((sampleCount / VOICE_AGENT_OUTPUT_SAMPLE_RATE) * 1000),
+        sampleRate: VOICE_AGENT_OUTPUT_SAMPLE_RATE,
+        sequence,
+        streamId: input.streamId,
+        type: VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+      }),
+    );
+    sequence++;
+  }
+
+  return events;
+}
+
+function parseAudioPayload(payload: unknown): VoiceAudioFramePayload | null {
+  if (payload == null || typeof payload !== "object") return null;
+  const value = payload as Partial<VoiceAudioFramePayload>;
+  if (
+    value.encoding !== "pcm_s16le" ||
+    typeof value.dataBase64 !== "string" ||
+    typeof value.sampleRate !== "number" ||
+    typeof value.sequence !== "number"
+  ) {
+    return null;
+  }
+  return value as VoiceAudioFramePayload;
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize));
+  }
+  return btoa(binary);
+}
+
+function base64ToArrayBuffer(value: string) {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index++) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes.buffer;
+}
+
+function formatBytes(value: number) {
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`;
+  return `${(value / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function streamStatusLabel(status: "connecting" | "live" | "error") {
+  if (status === "connecting") return "Connecting";
+  if (status === "live") return "Live";
+  return "Stream error";
+}
+
+function captureStatusLabel(status: "idle" | "starting" | "capturing") {
+  if (status === "starting") return "Starting";
+  if (status === "capturing") return "Capturing";
+  return "Idle";
+}

--- a/apps/os/src/context.ts
+++ b/apps/os/src/context.ts
@@ -10,6 +10,7 @@ import type { CloudflareArtifactsBinding } from "~/domains/repos/artifacts.ts";
 import type { RepoDurableObject } from "~/domains/repos/durable-objects/repo-durable-object.ts";
 import type { SlackAgentDurableObject } from "~/domains/slack/durable-objects/slack-agent-durable-object.ts";
 import type { SlackIntegrationDurableObject } from "~/domains/slack/durable-objects/slack-integration-durable-object.ts";
+import type { VoiceAgentDurableObject } from "~/domains/voice-agents/durable-objects/voice-agent-durable-object.ts";
 
 export type ClerkAuth = Awaited<ReturnType<typeof auth>>;
 
@@ -25,6 +26,7 @@ export interface AppContext {
   workerScriptName?: string;
   rawRequest?: Request;
   agent?: DurableObjectNamespace<AgentDurableObject>;
+  voiceAgent?: DurableObjectNamespace<VoiceAgentDurableObject>;
   artifacts?: CloudflareArtifactsBinding;
   loader?: WorkerLoader;
   codemodeSession?: DurableObjectNamespace<CodemodeSession>;

--- a/apps/os/src/context.ts
+++ b/apps/os/src/context.ts
@@ -10,7 +10,7 @@ import type { CloudflareArtifactsBinding } from "~/domains/repos/artifacts.ts";
 import type { RepoDurableObject } from "~/domains/repos/durable-objects/repo-durable-object.ts";
 import type { SlackAgentDurableObject } from "~/domains/slack/durable-objects/slack-agent-durable-object.ts";
 import type { SlackIntegrationDurableObject } from "~/domains/slack/durable-objects/slack-integration-durable-object.ts";
-import type { VoiceAgentDurableObject } from "~/domains/voice-agents/durable-objects/voice-agent-durable-object.ts";
+import type { StreamProcessorDurableObject } from "~/domains/stream-processors/durable-objects/stream-processor-durable-object.ts";
 
 export type ClerkAuth = Awaited<ReturnType<typeof auth>>;
 
@@ -26,7 +26,7 @@ export interface AppContext {
   workerScriptName?: string;
   rawRequest?: Request;
   agent?: DurableObjectNamespace<AgentDurableObject>;
-  voiceAgent?: DurableObjectNamespace<VoiceAgentDurableObject>;
+  streamProcessor?: DurableObjectNamespace<StreamProcessorDurableObject>;
   artifacts?: CloudflareArtifactsBinding;
   loader?: WorkerLoader;
   codemodeSession?: DurableObjectNamespace<CodemodeSession>;

--- a/apps/os/src/domains/agents/agent-subscription.ts
+++ b/apps/os/src/domains/agents/agent-subscription.ts
@@ -1,0 +1,40 @@
+import { deriveDurableObjectNameFromStructuredName } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
+import { STREAM_SUBSCRIPTION_CONFIGURED_TYPE } from "@iterate-com/shared/streams/core-event-types";
+import type { EventInput, StreamPath } from "@iterate-com/shared/streams/types";
+
+export function agentSubscriptionConfiguredEvent(input: {
+  agentPath: StreamPath;
+  projectId: string;
+}): EventInput {
+  const durableObjectName = deriveDurableObjectNameFromStructuredName({
+    structuredName: {
+      agentPath: input.agentPath,
+      projectId: input.projectId,
+    },
+  });
+  return {
+    idempotencyKey: `stream-processor-websocket-subscription:AGENT:${durableObjectName}:${input.agentPath}:agent:${input.projectId}:${input.agentPath}`,
+    type: STREAM_SUBSCRIPTION_CONFIGURED_TYPE,
+    payload: {
+      slug: `agent:${input.projectId}:${input.agentPath}`,
+      type: "websocket",
+      callable: {
+        type: "fetch",
+        via: {
+          type: "env-binding",
+          bindingType: "durable-object-namespace",
+          bindingName: "AGENT",
+          durableObject: {
+            name: durableObjectName,
+          },
+        },
+        fetchRequest: {
+          path: {
+            base: "/stream-subscription",
+            mode: "replace",
+          },
+        },
+      },
+    },
+  };
+}

--- a/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
+++ b/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
@@ -66,6 +66,10 @@ import {
   type AgentLlmProvider,
 } from "~/domains/agents/agent-presets.ts";
 import { buildProjectStreamViewerUrl } from "~/lib/stream-viewer-url.ts";
+import {
+  isVoiceAgentPath,
+  voiceAgentCodeAgentSetupEvents,
+} from "~/domains/voice-agents/voice-agent-code-agent.ts";
 
 export const AGENTS_STREAM_PATH = StreamPath.parse("/agents");
 
@@ -427,8 +431,14 @@ export class AgentDurableObject extends AgentBase<AgentDurableObjectEnv> {
       agentPath: params.agentPath,
       presets: readAgentPathPrefixPresets(rootEvents),
     });
-    const setupEvents =
+    const baseSetupEvents =
       preset?.events ?? defaultAgentSetupEvents(DEFAULT_AGENT_LLM_PROVIDER, params.agentPath);
+    const setupEvents = isVoiceAgentPath(params.agentPath)
+      ? voiceAgentCodeAgentSetupEvents({
+          baseEvents: baseSetupEvents,
+          streamPath: params.agentPath,
+        })
+      : baseSetupEvents;
     const hasSetupPrompt = setupEvents.some(
       (event) => event.type === "events.iterate.com/agent/system-prompt-updated",
     );
@@ -884,10 +894,6 @@ function agentWorkspaceName(params: AgentDurableObjectStructuredName): Workspace
     projectId: params.projectId,
     workspaceId: defaultWorkspaceIdForCodemodeSession({ streamPath: params.agentPath }),
   };
-}
-
-function isVoiceAgentPath(agentPath: string): boolean {
-  return agentPath === "/voice-agents" || agentPath.startsWith("/voice-agents/");
 }
 
 function remoteWithToken(input: { remote: string; token: string }) {

--- a/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
+++ b/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
@@ -13,6 +13,7 @@ import {
 import { withStreamProcessor } from "@iterate-com/shared/durable-object-utils/mixins/with-stream-processor";
 import { createAgentChatProcessor } from "@iterate-com/shared/stream-processors/agent-chat/implementation";
 import { createAgentProcessor } from "@iterate-com/shared/stream-processors/agent/implementation";
+import { VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE } from "@iterate-com/shared/stream-processors/voice-agent/contract";
 import {
   type CloudflareAiProcessorDeps,
   createCloudflareAiProcessor,
@@ -299,10 +300,15 @@ export class AgentDurableObject extends AgentBase<AgentDurableObjectEnv> {
     }
 
     const message = parseChatToolMessage(input.args[0]);
-    const event = await this.appendAssistantResponse({
-      idempotencyKey: `agent-chat-tool:send-message:${input.functionCallId}`,
-      message,
-    });
+    const event = isVoiceAgentPath(this.structuredName.agentPath)
+      ? await this.appendVoiceAgentTextInput({
+          idempotencyKey: `voice-agent-chat-tool:send-message:${input.functionCallId}`,
+          message,
+        })
+      : await this.appendAssistantResponse({
+          idempotencyKey: `agent-chat-tool:send-message:${input.functionCallId}`,
+          message,
+        });
     return { event };
   }
 
@@ -646,6 +652,19 @@ export class AgentDurableObject extends AgentBase<AgentDurableObjectEnv> {
     });
   }
 
+  private async appendVoiceAgentTextInput(input: { idempotencyKey: string; message: string }) {
+    return await this.streamsEntrypoint(this.structuredName.agentPath).append({
+      event: {
+        type: VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
+        idempotencyKey: input.idempotencyKey,
+        payload: {
+          source: "code-agent",
+          text: input.message,
+        },
+      },
+    });
+  }
+
   private async appendCodemodeCompletionInput(input: {
     event: Event;
     idempotencyKey: string;
@@ -666,11 +685,14 @@ export class AgentDurableObject extends AgentBase<AgentDurableObjectEnv> {
     });
   }
 
-  private createAgentChatToolProvider(): ToolProviderRegistration {
+  private createAgentChatToolProvider(
+    params: AgentDurableObjectStructuredName,
+  ): ToolProviderRegistration {
     return {
       path: ["chat"],
-      instructions:
-        "Use ctx.chat.sendMessage({ message }) to send a visible response to the user. Prefer this over appending chat events manually.",
+      instructions: isVoiceAgentPath(params.agentPath)
+        ? "On voice-agent streams, ctx.chat.sendMessage({ message }) appends a voice-agent text input for the realtime voice operator to say aloud. Keep the message concise and directly speakable."
+        : "Use ctx.chat.sendMessage({ message }) to send a visible response to the user. Prefer this over appending chat events manually.",
       invocation: {
         kind: "rpc",
         callable: {
@@ -718,7 +740,7 @@ export class AgentDurableObject extends AgentBase<AgentDurableObjectEnv> {
     params: AgentDurableObjectStructuredName,
   ): ToolProviderRegistration[] {
     return [
-      ...(isSlackAgentPath(params.agentPath) ? [] : [this.createAgentChatToolProvider()]),
+      ...(isSlackAgentPath(params.agentPath) ? [] : [this.createAgentChatToolProvider(params)]),
       this.createAgentDebugToolProvider(),
       ...createExampleCapabilityProviders({ projectId: params.projectId }),
       createGmailProviderRegistration({ projectId: params.projectId }),

--- a/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
+++ b/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
@@ -143,15 +143,17 @@ const AgentBase = withStreamProcessor<AgentDurableObjectStructuredName, AgentDur
 })(AgentLifecycleBase);
 
 export class AgentDurableObject extends AgentBase<AgentDurableObjectEnv> {
+  #processorsRegistered = false;
   #streamSocketMessageQueue = Promise.resolve();
 
   constructor(ctx: DurableObjectState, env: AgentDurableObjectEnv) {
     super(ctx, env);
 
     this.registerOnInstanceWake(async (params) => {
-      if (params.agentPath === AGENTS_STREAM_PATH) {
+      if (!this.#processorsRegistered && params.agentPath === AGENTS_STREAM_PATH) {
         this.registerStreamProcessor(createJsonataReactorProcessor());
-      } else {
+        this.#processorsRegistered = true;
+      } else if (!this.#processorsRegistered) {
         await this.ensureAgentSetupEvents(params);
         const llmProvider = await this.resolveLlmProvider(params);
         this.registerStreamProcessor(createAgentChatProcessor());
@@ -161,7 +163,12 @@ export class AgentDurableObject extends AgentBase<AgentDurableObjectEnv> {
           }),
         );
         this.registerStreamProcessor(this.createLlmProcessor(llmProvider));
-        await this.ensureAgentWorkspace(params);
+        this.#processorsRegistered = true;
+      }
+      if (params.agentPath !== AGENTS_STREAM_PATH) {
+        if (!isVoiceAgentPath(params.agentPath)) {
+          await this.ensureAgentWorkspace(params);
+        }
         await this.ensureCodemodeSession(params);
       }
       await this.ensureAgentSubscription(params);
@@ -186,7 +193,7 @@ export class AgentDurableObject extends AgentBase<AgentDurableObjectEnv> {
       return new Response("Expected WebSocket upgrade", { status: 426 });
     }
 
-    await this.ensureStarted();
+    await this.ensureStartedOrInitializeFromRuntimeName();
 
     const pair = new WebSocketPair();
     const client = pair[0];
@@ -877,6 +884,10 @@ function agentWorkspaceName(params: AgentDurableObjectStructuredName): Workspace
     projectId: params.projectId,
     workspaceId: defaultWorkspaceIdForCodemodeSession({ streamPath: params.agentPath }),
   };
+}
+
+function isVoiceAgentPath(agentPath: string): boolean {
+  return agentPath === "/voice-agents" || agentPath.startsWith("/voice-agents/");
 }
 
 function remoteWithToken(input: { remote: string; token: string }) {

--- a/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
+++ b/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
@@ -782,13 +782,7 @@ function hasEquivalentDefaultSetupEvent(input: {
   existingEvents: readonly { payload: unknown; type: string }[];
 }) {
   if (input.event.type === "events.iterate.com/agent/system-prompt-updated") {
-    return input.existingEvents.some((event) => {
-      if (event.type !== input.event.type) return false;
-      const systemPrompt = (event.payload as { systemPrompt?: unknown }).systemPrompt;
-      return (
-        typeof systemPrompt === "string" && !systemPrompt.includes("ctx.streams.append({ event:")
-      );
-    });
+    return input.existingEvents.some((event) => event.type === input.event.type);
   }
   return input.existingEvents.some((event) => event.type === input.event.type);
 }

--- a/apps/os/src/domains/stream-processors/durable-objects/stream-processor-durable-object.ts
+++ b/apps/os/src/domains/stream-processors/durable-objects/stream-processor-durable-object.ts
@@ -36,7 +36,6 @@ import {
   getAgentDurableObjectName,
   type AgentDurableObject,
 } from "~/domains/agents/durable-objects/agent-durable-object.ts";
-import { voiceAgentCodeAgentEvents } from "~/domains/voice-agents/voice-agent-code-agent.ts";
 
 export type StreamProcessorDurableObjectStructuredName = {
   processorSlug: string;
@@ -272,18 +271,6 @@ async function ensureVoiceAgentCodeAgent(input: {
   env: StreamProcessorDurableObjectEnv;
   params: StreamProcessorDurableObjectStructuredName;
 }) {
-  const streamApi = streamApiFromNamespace({
-    durableObjectNamespace: input.env.STREAM as unknown as StreamDurableObjectNamespace,
-    namespace: input.params.projectId,
-    streamPath: input.params.streamPath,
-  });
-  await streamApi.appendBatch({
-    events: voiceAgentCodeAgentEvents({
-      projectId: input.params.projectId,
-      streamPath: input.params.streamPath,
-    }),
-  });
-
   const structuredName = {
     agentPath: input.params.streamPath,
     projectId: input.params.projectId,

--- a/apps/os/src/domains/stream-processors/durable-objects/stream-processor-durable-object.ts
+++ b/apps/os/src/domains/stream-processors/durable-objects/stream-processor-durable-object.ts
@@ -1,12 +1,21 @@
 import { z } from "zod";
 import { createIterateDurableObjectBase } from "@iterate-com/shared/durable-object-utils/iterate-durable-object";
-import {
-  deriveDurableObjectNameFromStructuredName,
-  NotInitializedError,
-} from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
+import { NotInitializedError } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
 import { withStreamProcessor } from "@iterate-com/shared/durable-object-utils/mixins/with-stream-processor";
-import { createVoiceAgentProcessor } from "@iterate-com/shared/stream-processors/voice-agent/implementation";
-import type { ProcessorStreamApi, StreamEvent } from "@iterate-com/shared/stream-processors";
+import {
+  VOICE_AGENT_PROVIDER_GEMINI_LIVE,
+  VOICE_AGENT_PROVIDER_GROK_REALTIME,
+  VOICE_AGENT_PROVIDER_OPENAI_REALTIME,
+} from "@iterate-com/shared/stream-processors/voice-agent/contract";
+import {
+  createVoiceAgentProcessor,
+  createVoiceAgentProviderProcessor,
+} from "@iterate-com/shared/stream-processors/voice-agent/implementation";
+import type {
+  Processor,
+  ProcessorStreamApi,
+  StreamEvent,
+} from "@iterate-com/shared/stream-processors";
 import {
   getInitializedStreamStub,
   type StreamDurableObjectNamespace,
@@ -15,35 +24,38 @@ import type { StreamDurableObject } from "@iterate-com/shared/streams/stream-dur
 import { StreamSocketFrame } from "@iterate-com/shared/streams/stream-socket-types";
 import type { Event, EventInput, StreamCursor } from "@iterate-com/shared/streams/types";
 import { StreamPath } from "@iterate-com/shared/streams/types";
+import {
+  GEMINI_LIVE_VOICE_PROCESSOR_SLUG,
+  GROK_REALTIME_VOICE_PROCESSOR_SLUG,
+  OPENAI_REALTIME_VOICE_PROCESSOR_SLUG,
+  streamProcessorSubscriptionSlug,
+  VOICE_AGENT_PROCESSOR_SLUG,
+} from "~/domains/stream-processors/stream-processor-slugs.ts";
 import { resolveStreamPath } from "~/domains/streams/entrypoints/streams-capability.ts";
 
-export type VoiceAgentDurableObjectStructuredName = {
+export type StreamProcessorDurableObjectStructuredName = {
+  processorSlug: string;
   projectId: string;
   streamPath: StreamPath;
 };
 
-export const VoiceAgentDurableObjectStructuredName = z.object({
+export const StreamProcessorDurableObjectStructuredName = z.object({
+  processorSlug: z.string().trim().min(1),
   projectId: z.string().trim().min(1),
   streamPath: StreamPath,
 });
 
-export function getVoiceAgentDurableObjectName(input: VoiceAgentDurableObjectStructuredName) {
-  return deriveDurableObjectNameFromStructuredName({
-    structuredName: input,
-  });
-}
-
-export type VoiceAgentDurableObjectEnv = {
+export type StreamProcessorDurableObjectEnv = {
   APP_CONFIG?: string;
   APP_CONFIG_GEMINI_API_KEY?: string;
   APP_CONFIG_OPEN_AI_API_KEY?: string;
   APP_CONFIG_X_AI_API_KEY?: string;
   DO_CATALOG: D1Database;
   STREAM: DurableObjectNamespace<StreamDurableObject>;
-  VOICE_AGENT: DurableObjectNamespace<VoiceAgentDurableObject>;
+  STREAM_PROCESSOR: DurableObjectNamespace<StreamProcessorDurableObject>;
 };
 
-type VoiceAgentStreamApi = ProcessorStreamApi<{
+type GenericStreamApi = ProcessorStreamApi<{
   emits: readonly string[];
   events: Record<string, unknown>;
   processorDeps?: readonly unknown[];
@@ -57,47 +69,51 @@ type VoiceAgentStreamApi = ProcessorStreamApi<{
   }): Promise<Event[]>;
 };
 
-const VoiceAgentLifecycleBase = createIterateDurableObjectBase<
-  typeof VoiceAgentDurableObjectStructuredName,
-  Pick<VoiceAgentDurableObjectEnv, "DO_CATALOG">
+type RegistryEntry = {
+  create(env: StreamProcessorDurableObjectEnv): Processor<unknown>;
+};
+
+const StreamProcessorLifecycleBase = createIterateDurableObjectBase<
+  typeof StreamProcessorDurableObjectStructuredName,
+  Pick<StreamProcessorDurableObjectEnv, "DO_CATALOG">
 >({
-  className: "VoiceAgentDurableObject",
+  className: "StreamProcessorDurableObject",
   getDatabase: (env) => env.DO_CATALOG,
   indexes: {
+    processorSlug: (params) => params.processorSlug,
     projectId: (params) => params.projectId,
     streamPath: (params) => params.streamPath,
   },
-  nameSchema: VoiceAgentDurableObjectStructuredName,
+  nameSchema: StreamProcessorDurableObjectStructuredName,
 });
 
-const VoiceAgentBase = withStreamProcessor<
-  VoiceAgentDurableObjectStructuredName,
-  VoiceAgentDurableObjectEnv
+const StreamProcessorBase = withStreamProcessor<
+  StreamProcessorDurableObjectStructuredName,
+  StreamProcessorDurableObjectEnv
 >({
   streamApi(args) {
-    return voiceAgentStreamApiFromNamespace({
+    return streamApiFromNamespace({
       durableObjectNamespace: args.env.STREAM as unknown as StreamDurableObjectNamespace,
       namespace: args.structuredName.projectId,
       streamPath: StreamPath.parse(String(args.streamPath)),
     });
   },
-})(VoiceAgentLifecycleBase);
+})(StreamProcessorLifecycleBase);
 
-export class VoiceAgentDurableObject extends VoiceAgentBase<VoiceAgentDurableObjectEnv> {
+export class StreamProcessorDurableObject extends StreamProcessorBase<StreamProcessorDurableObjectEnv> {
   #streamSocketMessageQueue = Promise.resolve();
 
-  constructor(ctx: DurableObjectState, env: VoiceAgentDurableObjectEnv) {
+  constructor(ctx: DurableObjectState, env: StreamProcessorDurableObjectEnv) {
     super(ctx, env);
 
     this.registerOnInstanceWake(async (params) => {
-      this.registerStreamProcessor(
-        createVoiceAgentProcessor({
-          geminiApiKey: readGeminiApiKey(this.env as Record<string, unknown>),
-          openAiApiKey: readOpenAiApiKey(this.env as Record<string, unknown>),
-          xAiApiKey: readXAiApiKey(this.env as Record<string, unknown>),
-        }),
-      );
-      await this.ensureVoiceAgentSubscription(params);
+      const entry = streamProcessorRegistry[params.processorSlug];
+      if (entry == null) {
+        throw new Error(`Unknown stream processor "${params.processorSlug}".`);
+      }
+
+      this.registerStreamProcessor(entry.create(this.env));
+      await this.ensureProcessorSubscription(params);
       await this.catchUpStreamProcessors({
         signal: AbortSignal.timeout(30_000),
         streamPath: params.streamPath,
@@ -151,12 +167,12 @@ export class VoiceAgentDurableObject extends VoiceAgentBase<VoiceAgentDurableObj
       try {
         await this.afterAppend({ event });
       } catch (error) {
-        console.error("[voice-agent] stream websocket event processing failed", {
+        console.error("[stream-processor] stream websocket event processing failed", {
           error,
           offset: event.offset,
+          processorName: this.name,
           streamPath: event.streamPath,
           type: event.type,
-          voiceAgentName: this.name,
         });
         socket.send(
           JSON.stringify({
@@ -180,12 +196,12 @@ export class VoiceAgentDurableObject extends VoiceAgentBase<VoiceAgentDurableObj
     return this.getStreamProcessorRuntimeState();
   }
 
-  private async ensureVoiceAgentSubscription(params: VoiceAgentDurableObjectStructuredName) {
+  private async ensureProcessorSubscription(params: StreamProcessorDurableObjectStructuredName) {
     await this.ensureStreamProcessorWebSocketSubscription({
-      bindingName: "VOICE_AGENT",
+      bindingName: "STREAM_PROCESSOR",
       durableObjectName: this.name,
       fetchPath: "/stream-subscription",
-      slug: `voice-agent:${params.projectId}:${params.streamPath}`,
+      slug: streamProcessorSubscriptionSlug(params),
       streamPath: params.streamPath,
     });
   }
@@ -202,11 +218,47 @@ export class VoiceAgentDurableObject extends VoiceAgentBase<VoiceAgentDurableObj
   }
 }
 
-function voiceAgentStreamApiFromNamespace(args: {
+const streamProcessorRegistry: Record<string, RegistryEntry> = {
+  [VOICE_AGENT_PROCESSOR_SLUG]: {
+    create: () => createVoiceAgentProcessor(),
+  },
+  [GEMINI_LIVE_VOICE_PROCESSOR_SLUG]: {
+    create: (env) =>
+      createVoiceAgentProviderProcessor({
+        geminiApiKey: readGeminiApiKey(env as Record<string, unknown>),
+        openAiApiKey: readOpenAiApiKey(env as Record<string, unknown>),
+        processorSlug: GEMINI_LIVE_VOICE_PROCESSOR_SLUG,
+        provider: VOICE_AGENT_PROVIDER_GEMINI_LIVE,
+        xAiApiKey: readXAiApiKey(env as Record<string, unknown>),
+      }),
+  },
+  [OPENAI_REALTIME_VOICE_PROCESSOR_SLUG]: {
+    create: (env) =>
+      createVoiceAgentProviderProcessor({
+        geminiApiKey: readGeminiApiKey(env as Record<string, unknown>),
+        openAiApiKey: readOpenAiApiKey(env as Record<string, unknown>),
+        processorSlug: OPENAI_REALTIME_VOICE_PROCESSOR_SLUG,
+        provider: VOICE_AGENT_PROVIDER_OPENAI_REALTIME,
+        xAiApiKey: readXAiApiKey(env as Record<string, unknown>),
+      }),
+  },
+  [GROK_REALTIME_VOICE_PROCESSOR_SLUG]: {
+    create: (env) =>
+      createVoiceAgentProviderProcessor({
+        geminiApiKey: readGeminiApiKey(env as Record<string, unknown>),
+        openAiApiKey: readOpenAiApiKey(env as Record<string, unknown>),
+        processorSlug: GROK_REALTIME_VOICE_PROCESSOR_SLUG,
+        provider: VOICE_AGENT_PROVIDER_GROK_REALTIME,
+        xAiApiKey: readXAiApiKey(env as Record<string, unknown>),
+      }),
+  },
+};
+
+function streamApiFromNamespace(args: {
   durableObjectNamespace: StreamDurableObjectNamespace;
   namespace: string;
   streamPath: StreamPath;
-}): VoiceAgentStreamApi {
+}): GenericStreamApi {
   return {
     async append(input) {
       const stream = await getInitializedStreamStub({
@@ -247,7 +299,7 @@ function voiceAgentStreamApiFromNamespace(args: {
     async *subscribe(input = {}) {
       void input;
       yield* [];
-      throw new Error("Voice agent processors receive live events through afterAppend RPC.");
+      throw new Error("Generic stream processors receive live events through websocket frames.");
     },
   };
 }

--- a/apps/os/src/domains/stream-processors/durable-objects/stream-processor-durable-object.ts
+++ b/apps/os/src/domains/stream-processors/durable-objects/stream-processor-durable-object.ts
@@ -32,6 +32,11 @@ import {
   VOICE_AGENT_PROCESSOR_SLUG,
 } from "~/domains/stream-processors/stream-processor-slugs.ts";
 import { resolveStreamPath } from "~/domains/streams/entrypoints/streams-capability.ts";
+import {
+  getAgentDurableObjectName,
+  type AgentDurableObject,
+} from "~/domains/agents/durable-objects/agent-durable-object.ts";
+import { voiceAgentCodeAgentEvents } from "~/domains/voice-agents/voice-agent-code-agent.ts";
 
 export type StreamProcessorDurableObjectStructuredName = {
   processorSlug: string;
@@ -50,6 +55,7 @@ export type StreamProcessorDurableObjectEnv = {
   APP_CONFIG_GEMINI_API_KEY?: string;
   APP_CONFIG_OPEN_AI_API_KEY?: string;
   APP_CONFIG_X_AI_API_KEY?: string;
+  AGENT: DurableObjectNamespace<AgentDurableObject>;
   DO_CATALOG: D1Database;
   STREAM: DurableObjectNamespace<StreamDurableObject>;
   STREAM_PROCESSOR: DurableObjectNamespace<StreamProcessorDurableObject>;
@@ -70,7 +76,10 @@ type GenericStreamApi = ProcessorStreamApi<{
 };
 
 type RegistryEntry = {
-  create(env: StreamProcessorDurableObjectEnv): Processor<unknown>;
+  create(
+    env: StreamProcessorDurableObjectEnv,
+    params: StreamProcessorDurableObjectStructuredName,
+  ): Processor<unknown>;
 };
 
 const StreamProcessorLifecycleBase = createIterateDurableObjectBase<
@@ -112,7 +121,7 @@ export class StreamProcessorDurableObject extends StreamProcessorBase<StreamProc
         throw new Error(`Unknown stream processor "${params.processorSlug}".`);
       }
 
-      this.registerStreamProcessor(entry.create(this.env));
+      this.registerStreamProcessor(entry.create(this.env, params));
       await this.ensureProcessorSubscription(params);
       await this.catchUpStreamProcessors({
         signal: AbortSignal.timeout(30_000),
@@ -220,7 +229,12 @@ export class StreamProcessorDurableObject extends StreamProcessorBase<StreamProc
 
 const streamProcessorRegistry: Record<string, RegistryEntry> = {
   [VOICE_AGENT_PROCESSOR_SLUG]: {
-    create: () => createVoiceAgentProcessor(),
+    create: (env, params) =>
+      createVoiceAgentProcessor({
+        ensureCodeAgent: async () => {
+          await ensureVoiceAgentCodeAgent({ env, params });
+        },
+      }),
   },
   [GEMINI_LIVE_VOICE_PROCESSOR_SLUG]: {
     create: (env) =>
@@ -253,6 +267,30 @@ const streamProcessorRegistry: Record<string, RegistryEntry> = {
       }),
   },
 };
+
+async function ensureVoiceAgentCodeAgent(input: {
+  env: StreamProcessorDurableObjectEnv;
+  params: StreamProcessorDurableObjectStructuredName;
+}) {
+  const streamApi = streamApiFromNamespace({
+    durableObjectNamespace: input.env.STREAM as unknown as StreamDurableObjectNamespace,
+    namespace: input.params.projectId,
+    streamPath: input.params.streamPath,
+  });
+  await streamApi.appendBatch({
+    events: voiceAgentCodeAgentEvents({
+      projectId: input.params.projectId,
+      streamPath: input.params.streamPath,
+    }),
+  });
+
+  const structuredName = {
+    agentPath: input.params.streamPath,
+    projectId: input.params.projectId,
+  };
+  const name = getAgentDurableObjectName(structuredName);
+  await input.env.AGENT.getByName(name).initialize({ name });
+}
 
 function streamApiFromNamespace(args: {
   durableObjectNamespace: StreamDurableObjectNamespace;

--- a/apps/os/src/domains/stream-processors/stream-processor-slugs.ts
+++ b/apps/os/src/domains/stream-processors/stream-processor-slugs.ts
@@ -1,0 +1,29 @@
+import { deriveDurableObjectNameFromStructuredName } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
+import type { StreamPath } from "@iterate-com/shared/streams/types";
+
+export const VOICE_AGENT_PROCESSOR_SLUG = "voice-agent";
+export const GEMINI_LIVE_VOICE_PROCESSOR_SLUG = "voice-agent/gemini-live";
+export const OPENAI_REALTIME_VOICE_PROCESSOR_SLUG = "voice-agent/openai-realtime";
+export const GROK_REALTIME_VOICE_PROCESSOR_SLUG = "voice-agent/grok-realtime";
+
+export type StreamProcessorDurableObjectStructuredName = {
+  processorSlug: string;
+  projectId: string;
+  streamPath: StreamPath;
+};
+
+export function getStreamProcessorDurableObjectName(
+  input: StreamProcessorDurableObjectStructuredName,
+) {
+  return deriveDurableObjectNameFromStructuredName({
+    structuredName: input,
+  });
+}
+
+export function streamProcessorSubscriptionSlug(input: {
+  processorSlug: string;
+  projectId: string;
+  streamPath: StreamPath;
+}) {
+  return `${input.processorSlug}:${input.projectId}:${input.streamPath}`;
+}

--- a/apps/os/src/domains/voice-agents/durable-objects/voice-agent-durable-object.ts
+++ b/apps/os/src/domains/voice-agents/durable-objects/voice-agent-durable-object.ts
@@ -1,0 +1,329 @@
+import { z } from "zod";
+import { createIterateDurableObjectBase } from "@iterate-com/shared/durable-object-utils/iterate-durable-object";
+import {
+  deriveDurableObjectNameFromStructuredName,
+  NotInitializedError,
+} from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
+import { withStreamProcessor } from "@iterate-com/shared/durable-object-utils/mixins/with-stream-processor";
+import { createVoiceAgentProcessor } from "@iterate-com/shared/stream-processors/voice-agent/implementation";
+import type { ProcessorStreamApi, StreamEvent } from "@iterate-com/shared/stream-processors";
+import {
+  getInitializedStreamStub,
+  type StreamDurableObjectNamespace,
+} from "@iterate-com/shared/streams/helpers";
+import type { StreamDurableObject } from "@iterate-com/shared/streams/stream-durable-object";
+import { StreamSocketFrame } from "@iterate-com/shared/streams/stream-socket-types";
+import type { Event, EventInput, StreamCursor } from "@iterate-com/shared/streams/types";
+import { StreamPath } from "@iterate-com/shared/streams/types";
+import { resolveStreamPath } from "~/domains/streams/entrypoints/streams-capability.ts";
+
+export type VoiceAgentDurableObjectStructuredName = {
+  projectId: string;
+  streamPath: StreamPath;
+};
+
+export const VoiceAgentDurableObjectStructuredName = z.object({
+  projectId: z.string().trim().min(1),
+  streamPath: StreamPath,
+});
+
+export function getVoiceAgentDurableObjectName(input: VoiceAgentDurableObjectStructuredName) {
+  return deriveDurableObjectNameFromStructuredName({
+    structuredName: input,
+  });
+}
+
+export type VoiceAgentDurableObjectEnv = {
+  APP_CONFIG?: string;
+  APP_CONFIG_GEMINI_API_KEY?: string;
+  APP_CONFIG_OPEN_AI_API_KEY?: string;
+  APP_CONFIG_X_AI_API_KEY?: string;
+  DO_CATALOG: D1Database;
+  STREAM: DurableObjectNamespace<StreamDurableObject>;
+  VOICE_AGENT: DurableObjectNamespace<VoiceAgentDurableObject>;
+};
+
+type VoiceAgentStreamApi = ProcessorStreamApi<{
+  emits: readonly string[];
+  events: Record<string, unknown>;
+  processorDeps?: readonly unknown[];
+}> & {
+  append(args: { event: EventInput; streamPath?: string }): Promise<Event>;
+  appendBatch(args: { events: EventInput[]; streamPath?: string }): Promise<Event[]>;
+  read(args?: {
+    streamPath?: string;
+    afterOffset?: StreamCursor;
+    beforeOffset?: StreamCursor;
+  }): Promise<Event[]>;
+};
+
+const VoiceAgentLifecycleBase = createIterateDurableObjectBase<
+  typeof VoiceAgentDurableObjectStructuredName,
+  Pick<VoiceAgentDurableObjectEnv, "DO_CATALOG">
+>({
+  className: "VoiceAgentDurableObject",
+  getDatabase: (env) => env.DO_CATALOG,
+  indexes: {
+    projectId: (params) => params.projectId,
+    streamPath: (params) => params.streamPath,
+  },
+  nameSchema: VoiceAgentDurableObjectStructuredName,
+});
+
+const VoiceAgentBase = withStreamProcessor<
+  VoiceAgentDurableObjectStructuredName,
+  VoiceAgentDurableObjectEnv
+>({
+  streamApi(args) {
+    return voiceAgentStreamApiFromNamespace({
+      durableObjectNamespace: args.env.STREAM as unknown as StreamDurableObjectNamespace,
+      namespace: args.structuredName.projectId,
+      streamPath: StreamPath.parse(String(args.streamPath)),
+    });
+  },
+})(VoiceAgentLifecycleBase);
+
+export class VoiceAgentDurableObject extends VoiceAgentBase<VoiceAgentDurableObjectEnv> {
+  #streamSocketMessageQueue = Promise.resolve();
+
+  constructor(ctx: DurableObjectState, env: VoiceAgentDurableObjectEnv) {
+    super(ctx, env);
+
+    this.registerOnInstanceWake(async (params) => {
+      this.registerStreamProcessor(
+        createVoiceAgentProcessor({
+          geminiApiKey: readGeminiApiKey(this.env as Record<string, unknown>),
+          openAiApiKey: readOpenAiApiKey(this.env as Record<string, unknown>),
+          xAiApiKey: readXAiApiKey(this.env as Record<string, unknown>),
+        }),
+      );
+      await this.ensureVoiceAgentSubscription(params);
+      await this.catchUpStreamProcessors({
+        signal: AbortSignal.timeout(30_000),
+        streamPath: params.streamPath,
+      });
+    });
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname !== "/stream-subscription") {
+      const inheritedFetch = super.fetch;
+      if (inheritedFetch == null) {
+        return new Response("Not found", { status: 404 });
+      }
+      return await inheritedFetch.call(this, request);
+    }
+
+    if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+      return new Response("Expected WebSocket upgrade", { status: 426 });
+    }
+
+    await this.ensureStartedOrInitializeFromRuntimeName();
+
+    const pair = new WebSocketPair();
+    const client = pair[0];
+    const server = pair[1];
+    this.ctx.acceptWebSocket(server);
+
+    return new Response(null, {
+      status: 101,
+      webSocket: client,
+    });
+  }
+
+  async webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    const text = streamProcessorWebSocketMessageToString(message);
+    if (text == null) return;
+
+    let json: unknown;
+    try {
+      json = JSON.parse(text);
+    } catch {
+      return;
+    }
+
+    const frame = StreamSocketFrame.safeParse(json);
+    if (!frame.success || frame.data.type !== "event") return;
+    const event = frame.data.event;
+
+    const next = this.#streamSocketMessageQueue.then(async () => {
+      try {
+        await this.afterAppend({ event });
+      } catch (error) {
+        console.error("[voice-agent] stream websocket event processing failed", {
+          error,
+          offset: event.offset,
+          streamPath: event.streamPath,
+          type: event.type,
+          voiceAgentName: this.name,
+        });
+        socket.send(
+          JSON.stringify({
+            type: "error",
+            message: error instanceof Error ? error.message : "Failed to process stream event.",
+          }),
+        );
+      }
+    });
+    this.#streamSocketMessageQueue = next.catch(() => {});
+    await next;
+  }
+
+  async afterAppend(input: { event: Event }) {
+    await this.ensureStartedOrInitializeFromRuntimeName();
+    return await this.consumeStreamProcessorEvent({ event: input.event as StreamEvent });
+  }
+
+  async getRuntimeState() {
+    await this.ensureStarted();
+    return this.getStreamProcessorRuntimeState();
+  }
+
+  private async ensureVoiceAgentSubscription(params: VoiceAgentDurableObjectStructuredName) {
+    await this.ensureStreamProcessorWebSocketSubscription({
+      bindingName: "VOICE_AGENT",
+      durableObjectName: this.name,
+      fetchPath: "/stream-subscription",
+      slug: `voice-agent:${params.projectId}:${params.streamPath}`,
+      streamPath: params.streamPath,
+    });
+  }
+
+  private async ensureStartedOrInitializeFromRuntimeName() {
+    try {
+      return await this.ensureStarted();
+    } catch (error) {
+      if (!(error instanceof NotInitializedError)) throw error;
+      const runtimeName = this.getDurableObjectName();
+      if (runtimeName == null) throw error;
+      return await this.initialize({ name: runtimeName });
+    }
+  }
+}
+
+function voiceAgentStreamApiFromNamespace(args: {
+  durableObjectNamespace: StreamDurableObjectNamespace;
+  namespace: string;
+  streamPath: StreamPath;
+}): VoiceAgentStreamApi {
+  return {
+    async append(input) {
+      const stream = await getInitializedStreamStub({
+        durableObjectNamespace: args.durableObjectNamespace,
+        namespace: args.namespace,
+        path: resolveProcessorStreamPath({
+          basePath: args.streamPath,
+          pathInput: input.streamPath,
+        }),
+      });
+      return await stream.append(input.event);
+    },
+    async appendBatch(input) {
+      const stream = await getInitializedStreamStub({
+        durableObjectNamespace: args.durableObjectNamespace,
+        namespace: args.namespace,
+        path: resolveProcessorStreamPath({
+          basePath: args.streamPath,
+          pathInput: input.streamPath,
+        }),
+      });
+      return await stream.appendBatch(input.events);
+    },
+    async read(input = {}) {
+      const stream = await getInitializedStreamStub({
+        durableObjectNamespace: args.durableObjectNamespace,
+        namespace: args.namespace,
+        path: resolveProcessorStreamPath({
+          basePath: args.streamPath,
+          pathInput: input.streamPath,
+        }),
+      });
+      return await stream.history({
+        after: input.afterOffset,
+        before: input.beforeOffset ?? "end",
+      });
+    },
+    async *subscribe(input = {}) {
+      void input;
+      yield* [];
+      throw new Error("Voice agent processors receive live events through afterAppend RPC.");
+    },
+  };
+}
+
+function resolveProcessorStreamPath(input: { basePath: StreamPath; pathInput?: string }) {
+  if (input.pathInput == null) {
+    return input.basePath;
+  }
+
+  const trimmedPath = input.pathInput.trim();
+  if (!trimmedPath) {
+    throw new Error("Stream path is required.");
+  }
+
+  if (trimmedPath.startsWith("/")) {
+    return resolveStreamPath(trimmedPath);
+  }
+
+  const relativePath = trimmedPath.replace(/^\.\//, "").replace(/^\/+/, "");
+  return StreamPath.parse(
+    input.basePath === "/" ? `/${relativePath}` : `${input.basePath}/${relativePath}`,
+  );
+}
+
+function streamProcessorWebSocketMessageToString(message: string | ArrayBuffer): string | null {
+  if (typeof message === "string") return message;
+  return new TextDecoder().decode(message);
+}
+
+function readGeminiApiKey(env: Record<string, unknown>) {
+  const override = env.APP_CONFIG_GEMINI_API_KEY;
+  if (typeof override === "string") return override;
+  const plainSecret = env.GEMINI_API_KEY;
+  if (typeof plainSecret === "string") return plainSecret;
+
+  const rawConfig = env.APP_CONFIG;
+  if (typeof rawConfig !== "string" || rawConfig.trim() === "") return "";
+
+  try {
+    const parsed = JSON.parse(rawConfig) as { geminiApiKey?: unknown };
+    return typeof parsed.geminiApiKey === "string" ? parsed.geminiApiKey : "";
+  } catch {
+    return "";
+  }
+}
+
+function readOpenAiApiKey(env: Record<string, unknown>) {
+  const override = env.APP_CONFIG_OPEN_AI_API_KEY;
+  if (typeof override === "string") return override;
+  const plainSecret = env.OPENAI_API_KEY;
+  if (typeof plainSecret === "string") return plainSecret;
+
+  const rawConfig = env.APP_CONFIG;
+  if (typeof rawConfig !== "string" || rawConfig.trim() === "") return "";
+
+  try {
+    const parsed = JSON.parse(rawConfig) as { openAiApiKey?: unknown };
+    return typeof parsed.openAiApiKey === "string" ? parsed.openAiApiKey : "";
+  } catch {
+    return "";
+  }
+}
+
+function readXAiApiKey(env: Record<string, unknown>) {
+  const override = env.APP_CONFIG_X_AI_API_KEY;
+  if (typeof override === "string") return override;
+  const plainSecret = env.XAI_API_KEY;
+  if (typeof plainSecret === "string") return plainSecret;
+
+  const rawConfig = env.APP_CONFIG;
+  if (typeof rawConfig !== "string" || rawConfig.trim() === "") return "";
+
+  try {
+    const parsed = JSON.parse(rawConfig) as { xAiApiKey?: unknown };
+    return typeof parsed.xAiApiKey === "string" ? parsed.xAiApiKey : "";
+  } catch {
+    return "";
+  }
+}

--- a/apps/os/src/domains/voice-agents/voice-agent-code-agent.ts
+++ b/apps/os/src/domains/voice-agents/voice-agent-code-agent.ts
@@ -1,30 +1,55 @@
 import { VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE } from "@iterate-com/shared/stream-processors/voice-agent/contract";
-import type { EventInput, StreamPath } from "@iterate-com/shared/streams/types";
+import type { StreamPath } from "@iterate-com/shared/streams/types";
 import {
+  type AgentPresetEvent,
   DEFAULT_AGENT_LLM_PROVIDER,
-  DEFAULT_OPENAI_AGENT_MODEL,
-  configuredAgentSetupEvents,
+  defaultAgentSetupEvents,
   defaultAgentSystemPrompt,
 } from "~/domains/agents/agent-presets.ts";
-import { agentSubscriptionConfiguredEvent } from "~/domains/agents/agent-subscription.ts";
 
-export function voiceAgentCodeAgentEvents(input: {
-  projectId: string;
+export const VOICE_AGENT_AGENT_PATH_PREFIX = "/agents/voice";
+
+export function isVoiceAgentPath(agentPath: string): boolean {
+  return (
+    agentPath === VOICE_AGENT_AGENT_PATH_PREFIX ||
+    agentPath.startsWith(`${VOICE_AGENT_AGENT_PATH_PREFIX}/`)
+  );
+}
+
+export function voiceAgentCodeAgentSetupEvents(input: {
+  baseEvents?: readonly AgentPresetEvent[];
   streamPath: StreamPath;
-}): EventInput[] {
-  return [
-    ...configuredAgentSetupEvents({
-      idempotencyKeyPrefix: `voice-agent-code-agent:setup:${input.projectId}:${input.streamPath}`,
-      model: DEFAULT_OPENAI_AGENT_MODEL,
-      provider: DEFAULT_AGENT_LLM_PROVIDER,
-      runOpts: {},
-      systemPrompt: voiceAgentCodeAgentSystemPrompt(input.streamPath),
-    }),
-    agentSubscriptionConfiguredEvent({
-      agentPath: input.streamPath,
-      projectId: input.projectId,
-    }),
-  ];
+}): AgentPresetEvent[] {
+  const systemPrompt = voiceAgentCodeAgentSystemPrompt(input.streamPath);
+  const baseEvents =
+    input.baseEvents ?? defaultAgentSetupEvents(DEFAULT_AGENT_LLM_PROVIDER, input.streamPath);
+
+  let replacedSystemPrompt = false;
+  const events = baseEvents.map((event) => {
+    if (event.type !== "events.iterate.com/agent/system-prompt-updated") {
+      return {
+        payload: event.payload,
+        type: event.type,
+      };
+    }
+    replacedSystemPrompt = true;
+    return {
+      payload: {
+        ...event.payload,
+        systemPrompt,
+      },
+      type: event.type,
+    };
+  });
+
+  if (!replacedSystemPrompt) {
+    events.push({
+      payload: { systemPrompt },
+      type: "events.iterate.com/agent/system-prompt-updated",
+    });
+  }
+
+  return events;
 }
 
 function voiceAgentCodeAgentSystemPrompt(streamPath: StreamPath) {

--- a/apps/os/src/domains/voice-agents/voice-agent-code-agent.ts
+++ b/apps/os/src/domains/voice-agents/voice-agent-code-agent.ts
@@ -1,0 +1,43 @@
+import { VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE } from "@iterate-com/shared/stream-processors/voice-agent/contract";
+import type { EventInput, StreamPath } from "@iterate-com/shared/streams/types";
+import {
+  DEFAULT_AGENT_LLM_PROVIDER,
+  DEFAULT_OPENAI_AGENT_MODEL,
+  configuredAgentSetupEvents,
+  defaultAgentSystemPrompt,
+} from "~/domains/agents/agent-presets.ts";
+import { agentSubscriptionConfiguredEvent } from "~/domains/agents/agent-subscription.ts";
+
+export function voiceAgentCodeAgentEvents(input: {
+  projectId: string;
+  streamPath: StreamPath;
+}): EventInput[] {
+  return [
+    ...configuredAgentSetupEvents({
+      idempotencyKeyPrefix: `voice-agent-code-agent:setup:${input.projectId}:${input.streamPath}`,
+      model: DEFAULT_OPENAI_AGENT_MODEL,
+      provider: DEFAULT_AGENT_LLM_PROVIDER,
+      runOpts: {},
+      systemPrompt: voiceAgentCodeAgentSystemPrompt(input.streamPath),
+    }),
+    agentSubscriptionConfiguredEvent({
+      agentPath: input.streamPath,
+      projectId: input.projectId,
+    }),
+  ];
+}
+
+function voiceAgentCodeAgentSystemPrompt(streamPath: StreamPath) {
+  return [
+    defaultAgentSystemPrompt(streamPath),
+    "",
+    "## Realtime voice operator support",
+    "You are also supporting a realtime voice operator on a phone call with an end user. The voice operator may ask you to investigate, calculate, fetch, edit files, or run code on behalf of the caller.",
+    "The voice operator is busy speaking and listening. Do not ask the voice operator to run code. Only you can run code.",
+    "When you need to respond to the voice operator, append an authoritative voice-agent text input event on the current stream from codemode:",
+    "await ctx.streams.append({ event: { type: '" +
+      VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE +
+      "', payload: { text: 'Concise speakable response for the voice operator.', source: 'code-agent' } } });",
+    "Keep voice-facing responses concise, directly speakable, and useful while the caller is waiting.",
+  ].join("\n");
+}

--- a/apps/os/src/domains/voice-agents/voice-agent-code-agent.ts
+++ b/apps/os/src/domains/voice-agents/voice-agent-code-agent.ts
@@ -38,7 +38,8 @@ function voiceAgentCodeAgentSystemPrompt(streamPath: StreamPath) {
     "await ctx.streams.append({ event: { type: '" +
       VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE +
       "', payload: { text: 'Concise speakable response for the voice operator.', source: 'code-agent' } } });",
-    "If you need more information before you can do the work, append a concise clarifying question for the voice operator to ask the caller using that same event shape.",
+    "The text you append should be the exact caller-facing thing the voice operator should say next, not private commentary about what you are doing.",
+    "If you need more information before you can do the work, append a concise clarifying question for the voice operator to ask the caller using that same event shape. For example: 'What occupation should I put on your profile?'",
     "For voice-agent streams, do not use ctx.chat.sendMessage for responses. The realtime voice model cannot consume chat responses. It consumes the voice-agent text input events you append to the stream.",
     "Keep voice-facing responses concise, directly speakable, and useful while the caller is waiting.",
   ].join("\n");

--- a/apps/os/src/domains/voice-agents/voice-agent-code-agent.ts
+++ b/apps/os/src/domains/voice-agents/voice-agent-code-agent.ts
@@ -38,6 +38,7 @@ function voiceAgentCodeAgentSystemPrompt(streamPath: StreamPath) {
     "await ctx.streams.append({ event: { type: '" +
       VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE +
       "', payload: { text: 'Concise speakable response for the voice operator.', source: 'code-agent' } } });",
+    "If you need more information before you can do the work, append a concise clarifying question for the voice operator to ask the caller using that same event shape.",
     "For voice-agent streams, do not use ctx.chat.sendMessage for responses. The realtime voice model cannot consume chat responses. It consumes the voice-agent text input events you append to the stream.",
     "Keep voice-facing responses concise, directly speakable, and useful while the caller is waiting.",
   ].join("\n");

--- a/apps/os/src/domains/voice-agents/voice-agent-code-agent.ts
+++ b/apps/os/src/domains/voice-agents/voice-agent-code-agent.ts
@@ -38,6 +38,7 @@ function voiceAgentCodeAgentSystemPrompt(streamPath: StreamPath) {
     "await ctx.streams.append({ event: { type: '" +
       VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE +
       "', payload: { text: 'Concise speakable response for the voice operator.', source: 'code-agent' } } });",
+    "For voice-agent streams, do not use ctx.chat.sendMessage for responses. The realtime voice model cannot consume chat responses. It consumes the voice-agent text input events you append to the stream.",
     "Keep voice-facing responses concise, directly speakable, and useful while the caller is waiting.",
   ].join("\n");
 }

--- a/apps/os/src/domains/voice-agents/voice-agent-subscription.ts
+++ b/apps/os/src/domains/voice-agents/voice-agent-subscription.ts
@@ -1,0 +1,55 @@
+import { deriveDurableObjectNameFromStructuredName } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
+import { STREAM_SUBSCRIPTION_CONFIGURED_TYPE } from "@iterate-com/shared/streams/core-event-types";
+import { STREAM_CIRCUIT_BREAKER_CONFIGURED_TYPE } from "@iterate-com/shared/streams/types";
+import type { EventInput, StreamPath } from "@iterate-com/shared/streams/types";
+
+export function voiceAgentSubscriptionConfiguredEvent(input: {
+  projectId: string;
+  streamPath: StreamPath;
+}): EventInput {
+  const durableObjectName = deriveDurableObjectNameFromStructuredName({
+    structuredName: {
+      projectId: input.projectId,
+      streamPath: input.streamPath,
+    },
+  });
+  return {
+    idempotencyKey: `stream-processor-websocket-subscription:VOICE_AGENT:${durableObjectName}:${input.streamPath}:voice-agent:${input.projectId}:${input.streamPath}`,
+    type: STREAM_SUBSCRIPTION_CONFIGURED_TYPE,
+    payload: {
+      slug: `voice-agent:${input.projectId}:${input.streamPath}`,
+      type: "websocket",
+      callable: {
+        type: "fetch",
+        via: {
+          type: "env-binding",
+          bindingType: "durable-object-namespace",
+          bindingName: "VOICE_AGENT",
+          durableObject: {
+            name: durableObjectName,
+          },
+        },
+        fetchRequest: {
+          path: {
+            base: "/stream-subscription",
+            mode: "replace",
+          },
+        },
+      },
+    },
+  };
+}
+
+export function voiceAgentCircuitBreakerConfiguredEvent(input: {
+  projectId: string;
+  streamPath: StreamPath;
+}): EventInput {
+  return {
+    idempotencyKey: `voice-agent-circuit-breaker:${input.projectId}:${input.streamPath}`,
+    type: STREAM_CIRCUIT_BREAKER_CONFIGURED_TYPE,
+    payload: {
+      burstCapacity: 10_000,
+      refillRatePerMinute: 6_000,
+    },
+  };
+}

--- a/apps/os/src/domains/voice-agents/voice-agent-subscription.ts
+++ b/apps/os/src/domains/voice-agents/voice-agent-subscription.ts
@@ -1,30 +1,30 @@
-import { deriveDurableObjectNameFromStructuredName } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
 import { STREAM_SUBSCRIPTION_CONFIGURED_TYPE } from "@iterate-com/shared/streams/core-event-types";
 import { STREAM_CIRCUIT_BREAKER_CONFIGURED_TYPE } from "@iterate-com/shared/streams/types";
 import type { EventInput, StreamPath } from "@iterate-com/shared/streams/types";
+import {
+  getStreamProcessorDurableObjectName,
+  streamProcessorSubscriptionSlug,
+  VOICE_AGENT_PROCESSOR_SLUG,
+  type StreamProcessorDurableObjectStructuredName,
+} from "~/domains/stream-processors/stream-processor-slugs.ts";
 
-export function voiceAgentSubscriptionConfiguredEvent(input: {
-  projectId: string;
-  streamPath: StreamPath;
-}): EventInput {
-  const durableObjectName = deriveDurableObjectNameFromStructuredName({
-    structuredName: {
-      projectId: input.projectId,
-      streamPath: input.streamPath,
-    },
-  });
+export function streamProcessorSubscriptionConfiguredEvent(
+  input: StreamProcessorDurableObjectStructuredName,
+): EventInput {
+  const durableObjectName = getStreamProcessorDurableObjectName(input);
+  const subscriptionSlug = streamProcessorSubscriptionSlug(input);
   return {
-    idempotencyKey: `stream-processor-websocket-subscription:VOICE_AGENT:${durableObjectName}:${input.streamPath}:voice-agent:${input.projectId}:${input.streamPath}`,
+    idempotencyKey: `stream-processor-websocket-subscription:STREAM_PROCESSOR:${durableObjectName}:${input.streamPath}:${subscriptionSlug}`,
     type: STREAM_SUBSCRIPTION_CONFIGURED_TYPE,
     payload: {
-      slug: `voice-agent:${input.projectId}:${input.streamPath}`,
+      slug: subscriptionSlug,
       type: "websocket",
       callable: {
         type: "fetch",
         via: {
           type: "env-binding",
           bindingType: "durable-object-namespace",
-          bindingName: "VOICE_AGENT",
+          bindingName: "STREAM_PROCESSOR",
           durableObject: {
             name: durableObjectName,
           },
@@ -38,6 +38,17 @@ export function voiceAgentSubscriptionConfiguredEvent(input: {
       },
     },
   };
+}
+
+export function voiceAgentSubscriptionConfiguredEvent(input: {
+  projectId: string;
+  streamPath: StreamPath;
+}): EventInput {
+  return streamProcessorSubscriptionConfiguredEvent({
+    processorSlug: VOICE_AGENT_PROCESSOR_SLUG,
+    projectId: input.projectId,
+    streamPath: input.streamPath,
+  });
 }
 
 export function voiceAgentCircuitBreakerConfiguredEvent(input: {

--- a/apps/os/src/entry.workerd.ts
+++ b/apps/os/src/entry.workerd.ts
@@ -46,7 +46,7 @@ export { ProjectDurableObject } from "~/domains/projects/durable-objects/project
 export { ProjectMcpServerConnection } from "~/domains/inbound-mcp-server/durable-objects/project-mcp-server-connection.ts";
 export { SlackAgentDurableObject } from "~/domains/slack/durable-objects/slack-agent-durable-object.ts";
 export { SlackIntegrationDurableObject } from "~/domains/slack/durable-objects/slack-integration-durable-object.ts";
-export { VoiceAgentDurableObject } from "~/domains/voice-agents/durable-objects/voice-agent-durable-object.ts";
+export { StreamProcessorDurableObject } from "~/domains/stream-processors/durable-objects/stream-processor-durable-object.ts";
 export { AgentCapability } from "~/domains/agents/entrypoints/agent-capability.ts";
 export { AiCapability, OrpcCapability } from "~/domains/codemode/example-capabilities.ts";
 export { FetchCapability } from "~/domains/codemode/fetch-capability.ts";
@@ -142,7 +142,7 @@ export default {
           projectHostnameBases,
           waitUntil: (promise) => cfCtx.waitUntil(promise),
           agent: env.AGENT,
-          voiceAgent: env.VOICE_AGENT,
+          streamProcessor: env.STREAM_PROCESSOR,
           artifacts: envWithArtifacts.ARTIFACTS,
           loader: env.LOADER,
           codemodeSession: env.CODEMODE_SESSION,

--- a/apps/os/src/entry.workerd.ts
+++ b/apps/os/src/entry.workerd.ts
@@ -46,6 +46,7 @@ export { ProjectDurableObject } from "~/domains/projects/durable-objects/project
 export { ProjectMcpServerConnection } from "~/domains/inbound-mcp-server/durable-objects/project-mcp-server-connection.ts";
 export { SlackAgentDurableObject } from "~/domains/slack/durable-objects/slack-agent-durable-object.ts";
 export { SlackIntegrationDurableObject } from "~/domains/slack/durable-objects/slack-integration-durable-object.ts";
+export { VoiceAgentDurableObject } from "~/domains/voice-agents/durable-objects/voice-agent-durable-object.ts";
 export { AgentCapability } from "~/domains/agents/entrypoints/agent-capability.ts";
 export { AiCapability, OrpcCapability } from "~/domains/codemode/example-capabilities.ts";
 export { FetchCapability } from "~/domains/codemode/fetch-capability.ts";
@@ -141,6 +142,7 @@ export default {
           projectHostnameBases,
           waitUntil: (promise) => cfCtx.waitUntil(promise),
           agent: env.AGENT,
+          voiceAgent: env.VOICE_AGENT,
           artifacts: envWithArtifacts.ARTIFACTS,
           loader: env.LOADER,
           codemodeSession: env.CODEMODE_SESSION,

--- a/apps/os/src/routeTree.gen.ts
+++ b/apps/os/src/routeTree.gen.ts
@@ -29,17 +29,20 @@ import { Route as AppOrgsOrganizationSlugProjectsRouteRouteImport } from './rout
 import { Route as AppOrgsOrganizationSlugProjectsIndexRouteImport } from './routes/_app/orgs/$organizationSlug/projects/index'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugRouteRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/route'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugIndexRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/index'
+import { Route as AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentPocRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agent-poc'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugSettingsRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/settings'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugMcpRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/mcp'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugIntegrationsRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/integrations'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugExamplesRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/examples'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugStreamsRouteRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/streams/route'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/route'
+import { Route as AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsIndexRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/index'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugStreamsIndexRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/streams/index'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugSecretsIndexRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/secrets/index'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugReposIndexRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/repos/index'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsIndexRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/index'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/index'
+import { Route as AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsVoiceAgentSlugRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugStreamsSplatRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/streams/$'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugSecretsSecretIdRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/secrets/$secretId'
 import { Route as AppOrgsOrganizationSlugProjectsProjectSlugReposRepoSlugRouteImport } from './routes/_app/orgs/$organizationSlug/projects/$projectSlug/repos/$repoSlug'
@@ -157,6 +160,12 @@ const AppOrgsOrganizationSlugProjectsProjectSlugIndexRoute =
     path: '/',
     getParentRoute: () => AppOrgsOrganizationSlugProjectsProjectSlugRouteRoute,
   } as any)
+const AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentPocRoute =
+  AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentPocRouteImport.update({
+    id: '/voice-agent-poc',
+    path: '/voice-agent-poc',
+    getParentRoute: () => AppOrgsOrganizationSlugProjectsProjectSlugRouteRoute,
+  } as any)
 const AppOrgsOrganizationSlugProjectsProjectSlugSettingsRoute =
   AppOrgsOrganizationSlugProjectsProjectSlugSettingsRouteImport.update({
     id: '/settings',
@@ -191,6 +200,12 @@ const AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRoute =
   AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRouteImport.update({
     id: '/agents',
     path: '/agents',
+    getParentRoute: () => AppOrgsOrganizationSlugProjectsProjectSlugRouteRoute,
+  } as any)
+const AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsIndexRoute =
+  AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsIndexRouteImport.update({
+    id: '/voice-agents/',
+    path: '/voice-agents/',
     getParentRoute: () => AppOrgsOrganizationSlugProjectsProjectSlugRouteRoute,
   } as any)
 const AppOrgsOrganizationSlugProjectsProjectSlugStreamsIndexRoute =
@@ -228,6 +243,15 @@ const AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRoute =
     getParentRoute: () =>
       AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRoute,
   } as any)
+const AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsVoiceAgentSlugRoute =
+  AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsVoiceAgentSlugRouteImport.update(
+    {
+      id: '/voice-agents/$voiceAgentSlug',
+      path: '/voice-agents/$voiceAgentSlug',
+      getParentRoute: () =>
+        AppOrgsOrganizationSlugProjectsProjectSlugRouteRoute,
+    } as any,
+  )
 const AppOrgsOrganizationSlugProjectsProjectSlugStreamsSplatRoute =
   AppOrgsOrganizationSlugProjectsProjectSlugStreamsSplatRouteImport.update({
     id: '/$',
@@ -314,6 +338,7 @@ export interface FileRoutesByFullPath {
   '/orgs/$organizationSlug/projects/$projectSlug/integrations': typeof AppOrgsOrganizationSlugProjectsProjectSlugIntegrationsRoute
   '/orgs/$organizationSlug/projects/$projectSlug/mcp': typeof AppOrgsOrganizationSlugProjectsProjectSlugMcpRoute
   '/orgs/$organizationSlug/projects/$projectSlug/settings': typeof AppOrgsOrganizationSlugProjectsProjectSlugSettingsRoute
+  '/orgs/$organizationSlug/projects/$projectSlug/voice-agent-poc': typeof AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentPocRoute
   '/orgs/$organizationSlug/projects/$projectSlug/': typeof AppOrgsOrganizationSlugProjectsProjectSlugIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/agents/new': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute
   '/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewPresetRoute
@@ -322,11 +347,13 @@ export interface FileRoutesByFullPath {
   '/orgs/$organizationSlug/projects/$projectSlug/repos/$repoSlug': typeof AppOrgsOrganizationSlugProjectsProjectSlugReposRepoSlugRoute
   '/orgs/$organizationSlug/projects/$projectSlug/secrets/$secretId': typeof AppOrgsOrganizationSlugProjectsProjectSlugSecretsSecretIdRoute
   '/orgs/$organizationSlug/projects/$projectSlug/streams/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugStreamsSplatRoute
+  '/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug': typeof AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsVoiceAgentSlugRoute
   '/orgs/$organizationSlug/projects/$projectSlug/agents/': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/repos/': typeof AppOrgsOrganizationSlugProjectsProjectSlugReposIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/secrets/': typeof AppOrgsOrganizationSlugProjectsProjectSlugSecretsIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/streams/': typeof AppOrgsOrganizationSlugProjectsProjectSlugStreamsIndexRoute
+  '/orgs/$organizationSlug/projects/$projectSlug/voice-agents/': typeof AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsStreamsSplatRoute
 }
 export interface FileRoutesByTo {
@@ -349,6 +376,7 @@ export interface FileRoutesByTo {
   '/orgs/$organizationSlug/projects/$projectSlug/integrations': typeof AppOrgsOrganizationSlugProjectsProjectSlugIntegrationsRoute
   '/orgs/$organizationSlug/projects/$projectSlug/mcp': typeof AppOrgsOrganizationSlugProjectsProjectSlugMcpRoute
   '/orgs/$organizationSlug/projects/$projectSlug/settings': typeof AppOrgsOrganizationSlugProjectsProjectSlugSettingsRoute
+  '/orgs/$organizationSlug/projects/$projectSlug/voice-agent-poc': typeof AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentPocRoute
   '/orgs/$organizationSlug/projects/$projectSlug': typeof AppOrgsOrganizationSlugProjectsProjectSlugIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/agents/new': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute
   '/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewPresetRoute
@@ -357,11 +385,13 @@ export interface FileRoutesByTo {
   '/orgs/$organizationSlug/projects/$projectSlug/repos/$repoSlug': typeof AppOrgsOrganizationSlugProjectsProjectSlugReposRepoSlugRoute
   '/orgs/$organizationSlug/projects/$projectSlug/secrets/$secretId': typeof AppOrgsOrganizationSlugProjectsProjectSlugSecretsSecretIdRoute
   '/orgs/$organizationSlug/projects/$projectSlug/streams/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugStreamsSplatRoute
+  '/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug': typeof AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsVoiceAgentSlugRoute
   '/orgs/$organizationSlug/projects/$projectSlug/agents': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/repos': typeof AppOrgsOrganizationSlugProjectsProjectSlugReposIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/secrets': typeof AppOrgsOrganizationSlugProjectsProjectSlugSecretsIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/streams': typeof AppOrgsOrganizationSlugProjectsProjectSlugStreamsIndexRoute
+  '/orgs/$organizationSlug/projects/$projectSlug/voice-agents': typeof AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsIndexRoute
   '/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsStreamsSplatRoute
 }
 export interface FileRoutesById {
@@ -391,6 +421,7 @@ export interface FileRoutesById {
   '/_app/orgs/$organizationSlug/projects/$projectSlug/integrations': typeof AppOrgsOrganizationSlugProjectsProjectSlugIntegrationsRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/mcp': typeof AppOrgsOrganizationSlugProjectsProjectSlugMcpRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/settings': typeof AppOrgsOrganizationSlugProjectsProjectSlugSettingsRoute
+  '/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agent-poc': typeof AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentPocRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/': typeof AppOrgsOrganizationSlugProjectsProjectSlugIndexRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsNewPresetRoute
@@ -399,11 +430,13 @@ export interface FileRoutesById {
   '/_app/orgs/$organizationSlug/projects/$projectSlug/repos/$repoSlug': typeof AppOrgsOrganizationSlugProjectsProjectSlugReposRepoSlugRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/secrets/$secretId': typeof AppOrgsOrganizationSlugProjectsProjectSlugSecretsSecretIdRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/streams/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugStreamsSplatRoute
+  '/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug': typeof AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsVoiceAgentSlugRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/': typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsIndexRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/repos/': typeof AppOrgsOrganizationSlugProjectsProjectSlugReposIndexRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/secrets/': typeof AppOrgsOrganizationSlugProjectsProjectSlugSecretsIndexRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/streams/': typeof AppOrgsOrganizationSlugProjectsProjectSlugStreamsIndexRoute
+  '/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/': typeof AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsIndexRoute
   '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$': typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsStreamsSplatRoute
 }
 export interface FileRouteTypes {
@@ -433,6 +466,7 @@ export interface FileRouteTypes {
     | '/orgs/$organizationSlug/projects/$projectSlug/integrations'
     | '/orgs/$organizationSlug/projects/$projectSlug/mcp'
     | '/orgs/$organizationSlug/projects/$projectSlug/settings'
+    | '/orgs/$organizationSlug/projects/$projectSlug/voice-agent-poc'
     | '/orgs/$organizationSlug/projects/$projectSlug/'
     | '/orgs/$organizationSlug/projects/$projectSlug/agents/new'
     | '/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset'
@@ -441,11 +475,13 @@ export interface FileRouteTypes {
     | '/orgs/$organizationSlug/projects/$projectSlug/repos/$repoSlug'
     | '/orgs/$organizationSlug/projects/$projectSlug/secrets/$secretId'
     | '/orgs/$organizationSlug/projects/$projectSlug/streams/$'
+    | '/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug'
     | '/orgs/$organizationSlug/projects/$projectSlug/agents/'
     | '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/'
     | '/orgs/$organizationSlug/projects/$projectSlug/repos/'
     | '/orgs/$organizationSlug/projects/$projectSlug/secrets/'
     | '/orgs/$organizationSlug/projects/$projectSlug/streams/'
+    | '/orgs/$organizationSlug/projects/$projectSlug/voice-agents/'
     | '/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -468,6 +504,7 @@ export interface FileRouteTypes {
     | '/orgs/$organizationSlug/projects/$projectSlug/integrations'
     | '/orgs/$organizationSlug/projects/$projectSlug/mcp'
     | '/orgs/$organizationSlug/projects/$projectSlug/settings'
+    | '/orgs/$organizationSlug/projects/$projectSlug/voice-agent-poc'
     | '/orgs/$organizationSlug/projects/$projectSlug'
     | '/orgs/$organizationSlug/projects/$projectSlug/agents/new'
     | '/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset'
@@ -476,11 +513,13 @@ export interface FileRouteTypes {
     | '/orgs/$organizationSlug/projects/$projectSlug/repos/$repoSlug'
     | '/orgs/$organizationSlug/projects/$projectSlug/secrets/$secretId'
     | '/orgs/$organizationSlug/projects/$projectSlug/streams/$'
+    | '/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug'
     | '/orgs/$organizationSlug/projects/$projectSlug/agents'
     | '/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions'
     | '/orgs/$organizationSlug/projects/$projectSlug/repos'
     | '/orgs/$organizationSlug/projects/$projectSlug/secrets'
     | '/orgs/$organizationSlug/projects/$projectSlug/streams'
+    | '/orgs/$organizationSlug/projects/$projectSlug/voice-agents'
     | '/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$'
   id:
     | '__root__'
@@ -509,6 +548,7 @@ export interface FileRouteTypes {
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/integrations'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/mcp'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/settings'
+    | '/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agent-poc'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new-preset'
@@ -517,11 +557,13 @@ export interface FileRouteTypes {
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/repos/$repoSlug'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/secrets/$secretId'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/streams/$'
+    | '/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/codemode-sessions/'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/repos/'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/secrets/'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/streams/'
+    | '/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/'
     | '/_app/orgs/$organizationSlug/projects/$projectSlug/agents/streams/$'
   fileRoutesById: FileRoutesById
 }
@@ -682,6 +724,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugIndexRouteImport
       parentRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugRouteRoute
     }
+    '/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agent-poc': {
+      id: '/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agent-poc'
+      path: '/voice-agent-poc'
+      fullPath: '/orgs/$organizationSlug/projects/$projectSlug/voice-agent-poc'
+      preLoaderRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentPocRouteImport
+      parentRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugRouteRoute
+    }
     '/_app/orgs/$organizationSlug/projects/$projectSlug/settings': {
       id: '/_app/orgs/$organizationSlug/projects/$projectSlug/settings'
       path: '/settings'
@@ -724,6 +773,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRouteImport
       parentRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugRouteRoute
     }
+    '/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/': {
+      id: '/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/'
+      path: '/voice-agents'
+      fullPath: '/orgs/$organizationSlug/projects/$projectSlug/voice-agents/'
+      preLoaderRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsIndexRouteImport
+      parentRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugRouteRoute
+    }
     '/_app/orgs/$organizationSlug/projects/$projectSlug/streams/': {
       id: '/_app/orgs/$organizationSlug/projects/$projectSlug/streams/'
       path: '/'
@@ -758,6 +814,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/orgs/$organizationSlug/projects/$projectSlug/agents/'
       preLoaderRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsIndexRouteImport
       parentRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugAgentsRouteRoute
+    }
+    '/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug': {
+      id: '/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug'
+      path: '/voice-agents/$voiceAgentSlug'
+      fullPath: '/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug'
+      preLoaderRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsVoiceAgentSlugRouteImport
+      parentRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugRouteRoute
     }
     '/_app/orgs/$organizationSlug/projects/$projectSlug/streams/$': {
       id: '/_app/orgs/$organizationSlug/projects/$projectSlug/streams/$'
@@ -867,14 +930,17 @@ interface AppOrgsOrganizationSlugProjectsProjectSlugRouteRouteChildren {
   AppOrgsOrganizationSlugProjectsProjectSlugIntegrationsRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugIntegrationsRoute
   AppOrgsOrganizationSlugProjectsProjectSlugMcpRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugMcpRoute
   AppOrgsOrganizationSlugProjectsProjectSlugSettingsRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugSettingsRoute
+  AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentPocRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentPocRoute
   AppOrgsOrganizationSlugProjectsProjectSlugIndexRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugIndexRoute
   AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRoute
   AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsNewRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsNewRoute
   AppOrgsOrganizationSlugProjectsProjectSlugReposRepoSlugRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugReposRepoSlugRoute
   AppOrgsOrganizationSlugProjectsProjectSlugSecretsSecretIdRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugSecretsSecretIdRoute
+  AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsVoiceAgentSlugRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsVoiceAgentSlugRoute
   AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsIndexRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsIndexRoute
   AppOrgsOrganizationSlugProjectsProjectSlugReposIndexRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugReposIndexRoute
   AppOrgsOrganizationSlugProjectsProjectSlugSecretsIndexRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugSecretsIndexRoute
+  AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsIndexRoute: typeof AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsIndexRoute
 }
 
 const AppOrgsOrganizationSlugProjectsProjectSlugRouteRouteChildren: AppOrgsOrganizationSlugProjectsProjectSlugRouteRouteChildren =
@@ -891,6 +957,8 @@ const AppOrgsOrganizationSlugProjectsProjectSlugRouteRouteChildren: AppOrgsOrgan
       AppOrgsOrganizationSlugProjectsProjectSlugMcpRoute,
     AppOrgsOrganizationSlugProjectsProjectSlugSettingsRoute:
       AppOrgsOrganizationSlugProjectsProjectSlugSettingsRoute,
+    AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentPocRoute:
+      AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentPocRoute,
     AppOrgsOrganizationSlugProjectsProjectSlugIndexRoute:
       AppOrgsOrganizationSlugProjectsProjectSlugIndexRoute,
     AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRoute:
@@ -901,12 +969,16 @@ const AppOrgsOrganizationSlugProjectsProjectSlugRouteRouteChildren: AppOrgsOrgan
       AppOrgsOrganizationSlugProjectsProjectSlugReposRepoSlugRoute,
     AppOrgsOrganizationSlugProjectsProjectSlugSecretsSecretIdRoute:
       AppOrgsOrganizationSlugProjectsProjectSlugSecretsSecretIdRoute,
+    AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsVoiceAgentSlugRoute:
+      AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsVoiceAgentSlugRoute,
     AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsIndexRoute:
       AppOrgsOrganizationSlugProjectsProjectSlugCodemodeSessionsIndexRoute,
     AppOrgsOrganizationSlugProjectsProjectSlugReposIndexRoute:
       AppOrgsOrganizationSlugProjectsProjectSlugReposIndexRoute,
     AppOrgsOrganizationSlugProjectsProjectSlugSecretsIndexRoute:
       AppOrgsOrganizationSlugProjectsProjectSlugSecretsIndexRoute,
+    AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsIndexRoute:
+      AppOrgsOrganizationSlugProjectsProjectSlugVoiceAgentsIndexRoute,
   }
 
 const AppOrgsOrganizationSlugProjectsProjectSlugRouteRouteWithChildren =

--- a/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx
+++ b/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/agents/new.tsx
@@ -3,11 +3,7 @@ import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Play, RotateCcw } from "lucide-react";
 import { deriveDurableObjectNameFromStructuredName } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
-import {
-  EventInput,
-  STREAM_SUBSCRIPTION_CONFIGURED_TYPE,
-  StreamPath,
-} from "@iterate-com/shared/streams/types";
+import { EventInput, StreamPath } from "@iterate-com/shared/streams/types";
 import type { ToolProviderRegistration } from "@iterate-com/shared/stream-processors/codemode/contract";
 import { Button } from "@iterate-com/ui/components/button";
 import { Checkbox } from "@iterate-com/ui/components/checkbox";
@@ -40,6 +36,7 @@ import {
   parseAgentEventInputsYaml,
   parseAgentRunOptsJson,
 } from "~/domains/agents/agent-presets.ts";
+import { agentSubscriptionConfiguredEvent } from "~/domains/agents/agent-subscription.ts";
 import { agentPathFromInput } from "~/lib/agent-links.ts";
 import { streamPathToSplat } from "~/lib/stream-links.ts";
 import { orpc, orpcClient } from "~/orpc/client.ts";
@@ -407,43 +404,6 @@ function buildPreviewEvents(input: {
       events: [],
     };
   }
-}
-
-function agentSubscriptionConfiguredEvent(input: {
-  agentPath: StreamPath;
-  projectId: string;
-}): EventInput {
-  const durableObjectName = deriveDurableObjectNameFromStructuredName({
-    structuredName: {
-      agentPath: input.agentPath,
-      projectId: input.projectId,
-    },
-  });
-  return {
-    idempotencyKey: `stream-processor-websocket-subscription:AGENT:${durableObjectName}:${input.agentPath}:agent:${input.projectId}:${input.agentPath}`,
-    type: STREAM_SUBSCRIPTION_CONFIGURED_TYPE,
-    payload: {
-      slug: `agent:${input.projectId}:${input.agentPath}`,
-      type: "websocket",
-      callable: {
-        type: "fetch",
-        via: {
-          type: "env-binding",
-          bindingType: "durable-object-namespace",
-          bindingName: "AGENT",
-          durableObject: {
-            name: durableObjectName,
-          },
-        },
-        fetchRequest: {
-          path: {
-            base: "/stream-subscription",
-            mode: "replace",
-          },
-        },
-      },
-    },
-  };
 }
 
 function createAgentChatToolProvider(input: {

--- a/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agent-poc.tsx
+++ b/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agent-poc.tsx
@@ -1,0 +1,622 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link, createFileRoute } from "@tanstack/react-router";
+import { Activity, Mic, Play, Square, Volume2, Waves } from "lucide-react";
+import { Event, EventInput, StreamPath } from "@iterate-com/shared/streams/types";
+import { Button } from "@iterate-com/ui/components/button";
+import { Input } from "@iterate-com/ui/components/input";
+import { Switch } from "@iterate-com/ui/components/switch";
+import { toast } from "@iterate-com/ui/components/sonner";
+import { EventsDebugLink } from "~/components/events-debug-link.tsx";
+import { createBrowserOpenApiClient, orpc } from "~/orpc/client.ts";
+import { streamPathToSplat } from "~/lib/stream-links.ts";
+
+const INPUT_AUDIO_FRAME_EVENT_TYPE = "events.iterate.com/voice-agent/input-audio-frame-appended";
+const OUTPUT_AUDIO_FRAME_EVENT_TYPE = "events.iterate.com/voice-agent/output-audio-frame-appended";
+const DEFAULT_STREAM_PATH = StreamPath.parse("/voice-agent/poc");
+const INPUT_SAMPLE_RATE = 16000;
+const OUTPUT_SAMPLE_RATE = 24000;
+const CHANNELS = 1;
+const INPUT_CHUNK_MS = 100;
+const OUTPUT_TONE_CHUNK_MS = 40;
+
+type VoiceAudioFramePayload = {
+  streamId: string;
+  sequence: number;
+  encoding: "pcm_s16le";
+  sampleRate: number;
+  channels: number;
+  durationMs: number;
+  dataBase64: string;
+};
+
+type AudioStats = {
+  frames: number;
+  bytes: number;
+};
+
+export const Route = createFileRoute(
+  "/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agent-poc",
+)({
+  ssr: false,
+  loader: async ({ context, params }) => {
+    const project = await context.queryClient.ensureQueryData({
+      ...orpc.projects.findBySlug.queryOptions({ input: { slug: params.projectSlug } }),
+      staleTime: 30_000,
+    });
+
+    return {
+      breadcrumb: "Voice POC",
+      project,
+    };
+  },
+  component: VoiceAgentPocPage,
+});
+
+function VoiceAgentPocPage() {
+  const params = Route.useParams();
+  const { project } = Route.useLoaderData();
+  const streamPath = DEFAULT_STREAM_PATH;
+  const streamIdRef = useRef(crypto.randomUUID());
+  const appendQueueRef = useRef(Promise.resolve());
+  const inputSequenceRef = useRef(0);
+  const outputSequenceRef = useRef(0);
+  const playedOffsetsRef = useRef(new Set<number>());
+  const inputAudioContextRef = useRef<AudioContext | null>(null);
+  const inputNodeRef = useRef<AudioWorkletNode | null>(null);
+  const inputMonitorRef = useRef<GainNode | null>(null);
+  const micStreamRef = useRef<MediaStream | null>(null);
+  const outputAudioContextRef = useRef<AudioContext | null>(null);
+  const outputNodeRef = useRef<AudioWorkletNode | null>(null);
+
+  const [streamStatus, setStreamStatus] = useState<"connecting" | "live" | "error">("connecting");
+  const [captureStatus, setCaptureStatus] = useState<"idle" | "starting" | "capturing">("idle");
+  const [playbackReady, setPlaybackReady] = useState(false);
+  const [echoCancellation, setEchoCancellation] = useState(true);
+  const [noiseSuppression, setNoiseSuppression] = useState(true);
+  const [autoGainControl, setAutoGainControl] = useState(true);
+  const [toneSeconds, setToneSeconds] = useState(1);
+  const [inputStats, setInputStats] = useState<AudioStats>({ frames: 0, bytes: 0 });
+  const [outputStats, setOutputStats] = useState<AudioStats>({ frames: 0, bytes: 0 });
+  const [outputQueueMs, setOutputQueueMs] = useState(0);
+  const [lastError, setLastError] = useState<string | null>(null);
+
+  const streamHrefParams = useMemo(
+    () => ({
+      organizationSlug: params.organizationSlug,
+      projectSlug: params.projectSlug,
+      _splat: streamPathToSplat(streamPath),
+    }),
+    [params.organizationSlug, params.projectSlug, streamPath],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let isCurrent = true;
+    let iterator: AsyncIterator<Event> | undefined;
+
+    setStreamStatus("connecting");
+    void (async () => {
+      try {
+        await createBrowserOpenApiClient().project.streams.create({
+          projectSlugOrId: project.id,
+          streamPath,
+        });
+
+        const stream = await createBrowserOpenApiClient().project.streams.streamEvents(
+          {
+            afterOffset: "end",
+            projectSlugOrId: project.id,
+            streamPath,
+          },
+          { signal: controller.signal },
+        );
+        iterator = stream[Symbol.asyncIterator]();
+        if (!isCurrent || controller.signal.aborted) return;
+        setStreamStatus("live");
+
+        for await (const value of stream) {
+          if (!isCurrent || controller.signal.aborted) return;
+          const event = Event.parse(value);
+          if (event.type === OUTPUT_AUDIO_FRAME_EVENT_TYPE) {
+            await playOutputEvent(event);
+          }
+        }
+      } catch (error) {
+        if (!isCurrent || controller.signal.aborted) return;
+        setStreamStatus("error");
+        setLastError(error instanceof Error ? error.message : String(error));
+      }
+    })();
+
+    return () => {
+      isCurrent = false;
+      controller.abort();
+      void iterator?.return?.();
+    };
+  }, [project.id, streamPath]);
+
+  useEffect(() => {
+    return () => {
+      stopCapture();
+      closeOutputAudio();
+    };
+  }, []);
+
+  async function ensureOutputAudio() {
+    if (outputAudioContextRef.current && outputNodeRef.current) {
+      if (outputAudioContextRef.current.state !== "running") {
+        await outputAudioContextRef.current.resume();
+      }
+      return outputNodeRef.current;
+    }
+
+    const context = new AudioContext();
+    await context.audioWorklet.addModule("/voice-agent-poc/output-worklet.js");
+    const node = new AudioWorkletNode(context, "pcm-output-processor", {
+      numberOfInputs: 0,
+      numberOfOutputs: 1,
+      outputChannelCount: [1],
+    });
+    node.port.postMessage({ type: "configure", sourceSampleRate: OUTPUT_SAMPLE_RATE });
+    node.port.onmessage = (event) => {
+      if (event.data?.type === "status") {
+        setOutputQueueMs(event.data.queuedMs ?? 0);
+      }
+    };
+    node.connect(context.destination);
+    outputAudioContextRef.current = context;
+    outputNodeRef.current = node;
+    setPlaybackReady(true);
+    return node;
+  }
+
+  async function playOutputEvent(event: Event) {
+    if (playedOffsetsRef.current.has(event.offset)) return;
+    playedOffsetsRef.current.add(event.offset);
+
+    const payload = parseAudioPayload(event.payload);
+    if (!payload || payload.sampleRate !== OUTPUT_SAMPLE_RATE) return;
+
+    const node = await ensureOutputAudio();
+    const buffer = base64ToArrayBuffer(payload.dataBase64);
+    node.port.postMessage({ type: "enqueue", buffer }, [buffer]);
+    setOutputStats((stats) => ({
+      frames: stats.frames + 1,
+      bytes: stats.bytes + buffer.byteLength,
+    }));
+  }
+
+  async function startCapture() {
+    if (captureStatus !== "idle") return;
+    setCaptureStatus("starting");
+    setLastError(null);
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          echoCancellation,
+          noiseSuppression,
+          autoGainControl,
+        },
+      });
+      const context = new AudioContext();
+      await context.audioWorklet.addModule("/voice-agent-poc/input-worklet.js");
+      const source = context.createMediaStreamSource(stream);
+      const node = new AudioWorkletNode(context, "pcm-input-processor", {
+        numberOfInputs: 1,
+        numberOfOutputs: 1,
+        outputChannelCount: [1],
+      });
+      const monitor = context.createGain();
+      monitor.gain.value = 0;
+      node.port.postMessage({
+        type: "configure",
+        targetSampleRate: INPUT_SAMPLE_RATE,
+        chunkMs: INPUT_CHUNK_MS,
+      });
+      node.port.onmessage = (event) => {
+        if (event.data?.type !== "pcm" || !(event.data.buffer instanceof ArrayBuffer)) {
+          return;
+        }
+        appendInputFrame(event.data.buffer, event.data.samples ?? 0);
+      };
+      source.connect(node);
+      node.connect(monitor);
+      monitor.connect(context.destination);
+      node.port.postMessage({ type: "set-enabled", enabled: true });
+
+      micStreamRef.current = stream;
+      inputAudioContextRef.current = context;
+      inputNodeRef.current = node;
+      inputMonitorRef.current = monitor;
+      setCaptureStatus("capturing");
+    } catch (error) {
+      setCaptureStatus("idle");
+      setLastError(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  function stopCapture() {
+    inputNodeRef.current?.port.postMessage({ type: "set-enabled", enabled: false });
+    inputNodeRef.current?.disconnect();
+    inputNodeRef.current = null;
+    inputMonitorRef.current?.disconnect();
+    inputMonitorRef.current = null;
+    void inputAudioContextRef.current?.close();
+    inputAudioContextRef.current = null;
+    micStreamRef.current?.getTracks().forEach((track) => track.stop());
+    micStreamRef.current = null;
+    setCaptureStatus("idle");
+  }
+
+  function appendInputFrame(buffer: ArrayBuffer, sampleCount: number) {
+    const sequence = inputSequenceRef.current++;
+    const event = audioFrameEvent({
+      type: INPUT_AUDIO_FRAME_EVENT_TYPE,
+      streamId: streamIdRef.current,
+      sequence,
+      sampleRate: INPUT_SAMPLE_RATE,
+      durationMs: Math.round((sampleCount / INPUT_SAMPLE_RATE) * 1000),
+      buffer,
+    });
+
+    setInputStats((stats) => ({
+      frames: stats.frames + 1,
+      bytes: stats.bytes + buffer.byteLength,
+    }));
+
+    appendQueueRef.current = appendQueueRef.current
+      .then(async () => {
+        await createBrowserOpenApiClient().project.streams.append({
+          projectSlugOrId: project.id,
+          streamPath,
+          event,
+        });
+      })
+      .catch((error) => {
+        setLastError(error instanceof Error ? error.message : String(error));
+      });
+  }
+
+  async function appendTone() {
+    setLastError(null);
+    await ensureOutputAudio();
+    const events = createToneEvents({
+      seconds: toneSeconds,
+      streamId: streamIdRef.current,
+      startSequence: outputSequenceRef.current,
+    });
+    outputSequenceRef.current += events.length;
+
+    try {
+      await createBrowserOpenApiClient().project.streams.appendBatch({
+        projectSlugOrId: project.id,
+        streamPath,
+        events,
+      });
+      toast.success(`Appended ${events.length} output audio frame events.`);
+    } catch (error) {
+      setLastError(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  function clearPlayback() {
+    outputNodeRef.current?.port.postMessage({ type: "clear" });
+    setOutputQueueMs(0);
+  }
+
+  function closeOutputAudio() {
+    outputNodeRef.current?.disconnect();
+    outputNodeRef.current = null;
+    void outputAudioContextRef.current?.close();
+    outputAudioContextRef.current = null;
+    setPlaybackReady(false);
+  }
+
+  const canCapture = typeof navigator !== "undefined" && !!navigator.mediaDevices?.getUserMedia;
+
+  return (
+    <section className="flex min-h-0 flex-1 flex-col overflow-auto">
+      <div className="border-b px-4 py-3">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="min-w-0">
+            <h1 className="text-base font-semibold">Voice Agent POC</h1>
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+              <span>Stream source of truth</span>
+              <Link
+                className="font-medium text-foreground underline-offset-4 hover:underline"
+                to="/orgs/$organizationSlug/projects/$projectSlug/streams/$"
+                params={streamHrefParams}
+              >
+                {streamPath}
+              </Link>
+              <span>{streamStatusLabel(streamStatus)}</span>
+            </div>
+          </div>
+          <EventsDebugLink namespace={project.id} streamPath={streamPath} />
+        </div>
+      </div>
+
+      <div className="grid gap-4 p-4 xl:grid-cols-[minmax(0,1fr)_minmax(20rem,24rem)]">
+        <main className="space-y-4">
+          <section className="rounded-lg border bg-background">
+            <div className="flex flex-col gap-3 border-b p-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-sm font-semibold">Output playback</h2>
+                <p className="text-sm text-muted-foreground">
+                  Appends 24 kHz PCM output events, then plays them only after the stream delivers
+                  them back.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button type="button" variant="outline" onClick={() => void ensureOutputAudio()}>
+                  <Volume2 />
+                  Enable speaker
+                </Button>
+                <Button type="button" onClick={() => void appendTone()}>
+                  <Play />
+                  Inject tone
+                </Button>
+                <Button type="button" variant="outline" onClick={clearPlayback}>
+                  <Square />
+                  Clear buffer
+                </Button>
+              </div>
+            </div>
+            <div className="grid gap-3 p-4 md:grid-cols-4">
+              <Metric label="Playback" value={playbackReady ? "Ready" : "Idle"} />
+              <Metric label="Output frames" value={String(outputStats.frames)} />
+              <Metric label="Output bytes" value={formatBytes(outputStats.bytes)} />
+              <Metric label="Queued" value={`${outputQueueMs} ms`} />
+            </div>
+            <div className="flex items-center gap-3 border-t p-4">
+              <label className="text-sm font-medium" htmlFor="tone-seconds">
+                Tone seconds
+              </label>
+              <Input
+                id="tone-seconds"
+                className="h-9 w-24"
+                type="number"
+                min={0.2}
+                max={5}
+                step={0.1}
+                value={toneSeconds}
+                onChange={(event) => setToneSeconds(Number(event.currentTarget.value))}
+              />
+            </div>
+          </section>
+
+          <section className="rounded-lg border bg-background">
+            <div className="flex flex-col gap-3 border-b p-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-sm font-semibold">Microphone input</h2>
+                <p className="text-sm text-muted-foreground">
+                  Captures browser mic audio as 16 kHz PCM and appends each chunk to the same
+                  stream.
+                </p>
+              </div>
+              <div className="flex gap-2">
+                {captureStatus === "capturing" ? (
+                  <Button type="button" variant="outline" onClick={stopCapture}>
+                    <Square />
+                    Stop mic
+                  </Button>
+                ) : (
+                  <Button
+                    type="button"
+                    disabled={!canCapture || captureStatus === "starting"}
+                    onClick={() => void startCapture()}
+                  >
+                    <Mic />
+                    {captureStatus === "starting" ? "Starting..." : "Start mic"}
+                  </Button>
+                )}
+              </div>
+            </div>
+            <div className="grid gap-3 p-4 md:grid-cols-3">
+              <Metric label="Capture" value={captureStatusLabel(captureStatus)} />
+              <Metric label="Input frames" value={String(inputStats.frames)} />
+              <Metric label="Input bytes" value={formatBytes(inputStats.bytes)} />
+            </div>
+            <div className="grid gap-3 border-t p-4 md:grid-cols-3">
+              <ToggleRow
+                checked={echoCancellation}
+                label="Echo cancellation"
+                onCheckedChange={setEchoCancellation}
+              />
+              <ToggleRow
+                checked={noiseSuppression}
+                label="Noise suppression"
+                onCheckedChange={setNoiseSuppression}
+              />
+              <ToggleRow
+                checked={autoGainControl}
+                label="Auto gain"
+                onCheckedChange={setAutoGainControl}
+              />
+            </div>
+          </section>
+        </main>
+
+        <aside className="space-y-4">
+          <section className="rounded-lg border bg-background p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Waves className="size-4" />
+              <h2 className="text-sm font-semibold">Frame contract</h2>
+            </div>
+            <dl className="space-y-3 text-sm">
+              <KeyValue label="Input" value="pcm_s16le mono, 16 kHz" />
+              <KeyValue label="Output" value="pcm_s16le mono, 24 kHz" />
+              <KeyValue label="Chunking" value="100 ms input, 40 ms output tone" />
+              <KeyValue label="Stream ID" value={streamIdRef.current} />
+            </dl>
+          </section>
+
+          <section className="rounded-lg border bg-background p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Activity className="size-4" />
+              <h2 className="text-sm font-semibold">Status</h2>
+            </div>
+            <div className="space-y-2 text-sm text-muted-foreground">
+              <p>
+                Output frames are ignored unless they arrive from the stream subscription, so the
+                tone button proves stream-mediated playback.
+              </p>
+              <p>
+                Use headphones for mic tests; browser echo controls are requested, not guaranteed.
+              </p>
+              {lastError ? <p className="text-destructive">{lastError}</p> : null}
+            </div>
+          </section>
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border bg-muted/30 px-3 py-2">
+      <div className="text-xs font-medium text-muted-foreground">{label}</div>
+      <div className="mt-1 font-mono text-sm">{value}</div>
+    </div>
+  );
+}
+
+function KeyValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
+      <dd className="mt-1 break-all font-mono text-xs text-foreground">{value}</dd>
+    </div>
+  );
+}
+
+function ToggleRow({
+  checked,
+  label,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  label: string;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className="flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-sm">
+      <span>{label}</span>
+      <Switch checked={checked} onCheckedChange={onCheckedChange} />
+    </label>
+  );
+}
+
+function audioFrameEvent(input: {
+  buffer: ArrayBuffer;
+  durationMs: number;
+  sampleRate: number;
+  sequence: number;
+  streamId: string;
+  type: typeof INPUT_AUDIO_FRAME_EVENT_TYPE | typeof OUTPUT_AUDIO_FRAME_EVENT_TYPE;
+}): EventInput {
+  const payload: VoiceAudioFramePayload = {
+    channels: CHANNELS,
+    dataBase64: arrayBufferToBase64(input.buffer),
+    durationMs: input.durationMs,
+    encoding: "pcm_s16le",
+    sampleRate: input.sampleRate,
+    sequence: input.sequence,
+    streamId: input.streamId,
+  };
+
+  return EventInput.parse({
+    type: input.type,
+    payload,
+  });
+}
+
+function createToneEvents(input: {
+  seconds: number;
+  startSequence: number;
+  streamId: string;
+}): EventInput[] {
+  const seconds = Math.min(5, Math.max(0.2, input.seconds || 1));
+  const frameSamples = Math.round((OUTPUT_SAMPLE_RATE * OUTPUT_TONE_CHUNK_MS) / 1000);
+  const totalSamples = Math.round(OUTPUT_SAMPLE_RATE * seconds);
+  const events: EventInput[] = [];
+  let sequence = input.startSequence;
+
+  for (let start = 0; start < totalSamples; start += frameSamples) {
+    const sampleCount = Math.min(frameSamples, totalSamples - start);
+    const pcm = new Int16Array(sampleCount);
+    for (let index = 0; index < sampleCount; index++) {
+      const sampleIndex = start + index;
+      const envelope = Math.min(1, sampleIndex / 480, (totalSamples - sampleIndex) / 480);
+      const value = Math.sin((2 * Math.PI * 440 * sampleIndex) / OUTPUT_SAMPLE_RATE);
+      pcm[index] = Math.round(value * envelope * 12000);
+    }
+    events.push(
+      audioFrameEvent({
+        buffer: pcm.buffer.slice(0),
+        durationMs: Math.round((sampleCount / OUTPUT_SAMPLE_RATE) * 1000),
+        sampleRate: OUTPUT_SAMPLE_RATE,
+        sequence,
+        streamId: input.streamId,
+        type: OUTPUT_AUDIO_FRAME_EVENT_TYPE,
+      }),
+    );
+    sequence++;
+  }
+
+  return events;
+}
+
+function parseAudioPayload(payload: unknown): VoiceAudioFramePayload | null {
+  if (payload == null || typeof payload !== "object") return null;
+  const value = payload as Partial<VoiceAudioFramePayload>;
+  if (
+    value.encoding !== "pcm_s16le" ||
+    typeof value.dataBase64 !== "string" ||
+    typeof value.sampleRate !== "number" ||
+    typeof value.sequence !== "number"
+  ) {
+    return null;
+  }
+  return value as VoiceAudioFramePayload;
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize));
+  }
+  return btoa(binary);
+}
+
+function base64ToArrayBuffer(value: string) {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index++) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes.buffer;
+}
+
+function formatBytes(value: number) {
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`;
+  return `${(value / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function streamStatusLabel(status: "connecting" | "live" | "error") {
+  if (status === "connecting") return "Connecting";
+  if (status === "live") return "Live";
+  return "Stream error";
+}
+
+function captureStatusLabel(status: "idle" | "starting" | "capturing") {
+  if (status === "starting") return "Starting";
+  if (status === "capturing") return "Capturing";
+  return "Idle";
+}

--- a/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agent-poc.tsx
+++ b/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agent-poc.tsx
@@ -12,7 +12,7 @@ import { streamPathToSplat } from "~/lib/stream-links.ts";
 
 const INPUT_AUDIO_FRAME_EVENT_TYPE = "events.iterate.com/voice-agent/input-audio-frame-appended";
 const OUTPUT_AUDIO_FRAME_EVENT_TYPE = "events.iterate.com/voice-agent/output-audio-frame-appended";
-const DEFAULT_STREAM_PATH = StreamPath.parse("/voice-agent/poc");
+const DEFAULT_STREAM_PATH = StreamPath.parse("/agents/voice/poc");
 const INPUT_SAMPLE_RATE = 16000;
 const OUTPUT_SAMPLE_RATE = 24000;
 const CHANNELS = 1;

--- a/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug.tsx
+++ b/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug.tsx
@@ -1,0 +1,39 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { StreamPath } from "@iterate-com/shared/streams/types";
+import { VoiceAgentStreamConsole } from "~/components/voice-agent-stream-console.tsx";
+import { orpc } from "~/orpc/client.ts";
+
+export const Route = createFileRoute(
+  "/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug",
+)({
+  ssr: false,
+  loader: async ({ context, params }) => {
+    const project = await context.queryClient.ensureQueryData({
+      ...orpc.projects.findBySlug.queryOptions({ input: { slug: params.projectSlug } }),
+      staleTime: 30_000,
+    });
+
+    return {
+      breadcrumb: params.voiceAgentSlug,
+      project,
+    };
+  },
+  component: VoiceAgentConversationPage,
+});
+
+function VoiceAgentConversationPage() {
+  const params = Route.useParams();
+  const { project } = Route.useLoaderData();
+  const streamPath = StreamPath.parse(`/voice-agents/${params.voiceAgentSlug}`);
+
+  return (
+    <VoiceAgentStreamConsole
+      enableVoiceAgentProcessor
+      organizationSlug={params.organizationSlug}
+      project={project}
+      projectSlug={params.projectSlug}
+      streamPath={streamPath}
+      title="Voice agent"
+    />
+  );
+}

--- a/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug.tsx
+++ b/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug.tsx
@@ -24,7 +24,7 @@ export const Route = createFileRoute(
 function VoiceAgentConversationPage() {
   const params = Route.useParams();
   const { project } = Route.useLoaderData();
-  const streamPath = StreamPath.parse(`/voice-agents/${params.voiceAgentSlug}`);
+  const streamPath = StreamPath.parse(`/agents/voice/${params.voiceAgentSlug}`);
 
   return (
     <VoiceAgentStreamConsole

--- a/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug.tsx
+++ b/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug.tsx
@@ -1,11 +1,17 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { StreamPath } from "@iterate-com/shared/streams/types";
+import { z } from "zod";
 import { VoiceAgentStreamConsole } from "~/components/voice-agent-stream-console.tsx";
 import { orpc } from "~/orpc/client.ts";
+
+const Search = z.object({
+  streamPath: StreamPath.optional(),
+});
 
 export const Route = createFileRoute(
   "/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug",
 )({
+  validateSearch: Search,
   ssr: false,
   loader: async ({ context, params }) => {
     const project = await context.queryClient.ensureQueryData({
@@ -23,8 +29,10 @@ export const Route = createFileRoute(
 
 function VoiceAgentConversationPage() {
   const params = Route.useParams();
+  const search = Route.useSearch();
   const { project } = Route.useLoaderData();
-  const streamPath = StreamPath.parse(`/agents/voice/${params.voiceAgentSlug}`);
+  const streamPath =
+    search.streamPath ?? StreamPath.parse(`/agents/voice/${params.voiceAgentSlug}`);
 
   return (
     <VoiceAgentStreamConsole

--- a/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/index.tsx
+++ b/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/index.tsx
@@ -36,7 +36,6 @@ import {
   streamProcessorSubscriptionConfiguredEvent,
   voiceAgentSubscriptionConfiguredEvent,
 } from "~/domains/voice-agents/voice-agent-subscription.ts";
-import { voiceAgentCodeAgentEvents } from "~/domains/voice-agents/voice-agent-code-agent.ts";
 import {
   GEMINI_LIVE_VOICE_PROCESSOR_SLUG,
   GROK_REALTIME_VOICE_PROCESSOR_SLUG,
@@ -161,10 +160,6 @@ function VoiceAgentsIndexPage() {
           }),
           streamProcessorSubscriptionConfiguredEvent({
             processorSlug: voiceProviderProcessorSlug(selectedProvider),
-            projectId: project.id,
-            streamPath,
-          }),
-          ...voiceAgentCodeAgentEvents({
             projectId: project.id,
             streamPath,
           }),

--- a/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/index.tsx
+++ b/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/index.tsx
@@ -125,7 +125,7 @@ function VoiceAgentsIndexPage() {
   const voiceAgentStreams = useMemo(
     () =>
       (data?.streams ?? [])
-        .filter((stream) => stream.streamPath.startsWith("/voice-agents/"))
+        .filter((stream) => stream.streamPath.startsWith("/agents/voice/"))
         .toSorted((left, right) => right.lastWokenAt.localeCompare(left.lastWokenAt)),
     [data?.streams],
   );
@@ -140,7 +140,7 @@ function VoiceAgentsIndexPage() {
 
     setIsCreating(true);
     const slug = `voice-${Date.now().toString(36)}`;
-    const streamPath = StreamPath.parse(`/voice-agents/${slug}`);
+    const streamPath = StreamPath.parse(`/agents/voice/${slug}`);
     try {
       await createBrowserOpenApiClient().project.streams.create({
         projectSlugOrId: project.id,
@@ -310,7 +310,7 @@ function VoiceAgentsIndexPage() {
         <Empty className="min-h-72 border">
           <EmptyHeader>
             <EmptyTitle>No voice conversations</EmptyTitle>
-            <EmptyDescription>Start one to create a /voice-agents stream.</EmptyDescription>
+            <EmptyDescription>Start one to create an /agents/voice stream.</EmptyDescription>
           </EmptyHeader>
         </Empty>
       ) : (
@@ -325,7 +325,7 @@ function VoiceAgentsIndexPage() {
             </TableHeader>
             <TableBody>
               {voiceAgentStreams.map((stream) => {
-                const slug = stream.streamPath.replace(/^\/voice-agents\//, "");
+                const slug = stream.streamPath.replace(/^\/agents\/voice\//, "");
                 return (
                   <TableRow key={stream.name}>
                     <TableCell>

--- a/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/index.tsx
+++ b/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/index.tsx
@@ -36,6 +36,7 @@ import {
   streamProcessorSubscriptionConfiguredEvent,
   voiceAgentSubscriptionConfiguredEvent,
 } from "~/domains/voice-agents/voice-agent-subscription.ts";
+import { voiceAgentCodeAgentEvents } from "~/domains/voice-agents/voice-agent-code-agent.ts";
 import {
   GEMINI_LIVE_VOICE_PROCESSOR_SLUG,
   GROK_REALTIME_VOICE_PROCESSOR_SLUG,
@@ -160,6 +161,10 @@ function VoiceAgentsIndexPage() {
           }),
           streamProcessorSubscriptionConfiguredEvent({
             processorSlug: voiceProviderProcessorSlug(selectedProvider),
+            projectId: project.id,
+            streamPath,
+          }),
+          ...voiceAgentCodeAgentEvents({
             projectId: project.id,
             streamPath,
           }),

--- a/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/index.tsx
+++ b/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/index.tsx
@@ -33,8 +33,14 @@ import { toast } from "@iterate-com/ui/components/sonner";
 import { cn } from "@iterate-com/ui/lib/utils";
 import {
   voiceAgentCircuitBreakerConfiguredEvent,
+  streamProcessorSubscriptionConfiguredEvent,
   voiceAgentSubscriptionConfiguredEvent,
 } from "~/domains/voice-agents/voice-agent-subscription.ts";
+import {
+  GEMINI_LIVE_VOICE_PROCESSOR_SLUG,
+  GROK_REALTIME_VOICE_PROCESSOR_SLUG,
+  OPENAI_REALTIME_VOICE_PROCESSOR_SLUG,
+} from "~/domains/stream-processors/stream-processor-slugs.ts";
 import { createBrowserOpenApiClient, orpc } from "~/orpc/client.ts";
 
 type ProviderOption = {
@@ -149,6 +155,11 @@ function VoiceAgentsIndexPage() {
             streamPath,
           }),
           voiceAgentSubscriptionConfiguredEvent({
+            projectId: project.id,
+            streamPath,
+          }),
+          streamProcessorSubscriptionConfiguredEvent({
+            processorSlug: voiceProviderProcessorSlug(selectedProvider),
             projectId: project.id,
             streamPath,
           }),
@@ -343,4 +354,15 @@ function VoiceAgentsIndexPage() {
       )}
     </section>
   );
+}
+
+function voiceProviderProcessorSlug(provider: VoiceAgentProvider) {
+  switch (provider) {
+    case VOICE_AGENT_PROVIDER_GEMINI_LIVE:
+      return GEMINI_LIVE_VOICE_PROCESSOR_SLUG;
+    case VOICE_AGENT_PROVIDER_OPENAI_REALTIME:
+      return OPENAI_REALTIME_VOICE_PROCESSOR_SLUG;
+    case VOICE_AGENT_PROVIDER_GROK_REALTIME:
+      return GROK_REALTIME_VOICE_PROCESSOR_SLUG;
+  }
 }

--- a/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/index.tsx
+++ b/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/index.tsx
@@ -1,0 +1,346 @@
+import { useMemo, useState } from "react";
+import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  DEFAULT_GROK_REALTIME_MODEL,
+  DEFAULT_GROK_REALTIME_VOICE,
+  DEFAULT_GEMINI_LIVE_MODEL,
+  DEFAULT_GEMINI_LIVE_VOICE,
+  DEFAULT_OPENAI_REALTIME_MODEL,
+  DEFAULT_OPENAI_REALTIME_VOICE,
+  DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION,
+  VOICE_AGENT_PROVIDER_GROK_REALTIME,
+  VOICE_AGENT_PROVIDER_GEMINI_LIVE,
+  VOICE_AGENT_PROVIDER_OPENAI_REALTIME,
+  VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE,
+  type VoiceAgentProvider,
+} from "@iterate-com/shared/stream-processors/voice-agent/contract";
+import { EventInput, StreamPath } from "@iterate-com/shared/streams/types";
+import { Button } from "@iterate-com/ui/components/button";
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@iterate-com/ui/components/empty";
+import { EventsStreamPathLabel } from "@iterate-com/ui/components/events/stream-path-label";
+import { Input } from "@iterate-com/ui/components/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@iterate-com/ui/components/table";
+import { Textarea } from "@iterate-com/ui/components/textarea";
+import { toast } from "@iterate-com/ui/components/sonner";
+import { cn } from "@iterate-com/ui/lib/utils";
+import {
+  voiceAgentCircuitBreakerConfiguredEvent,
+  voiceAgentSubscriptionConfiguredEvent,
+} from "~/domains/voice-agents/voice-agent-subscription.ts";
+import { createBrowserOpenApiClient, orpc } from "~/orpc/client.ts";
+
+type ProviderOption = {
+  provider: VoiceAgentProvider;
+  label: string;
+  model: string;
+  voiceName: string;
+};
+
+const PROVIDER_OPTIONS: ProviderOption[] = [
+  {
+    provider: VOICE_AGENT_PROVIDER_GEMINI_LIVE,
+    label: "Gemini Live",
+    model: DEFAULT_GEMINI_LIVE_MODEL,
+    voiceName: DEFAULT_GEMINI_LIVE_VOICE,
+  },
+  {
+    provider: VOICE_AGENT_PROVIDER_OPENAI_REALTIME,
+    label: "OpenAI Realtime",
+    model: DEFAULT_OPENAI_REALTIME_MODEL,
+    voiceName: DEFAULT_OPENAI_REALTIME_VOICE,
+  },
+  {
+    provider: VOICE_AGENT_PROVIDER_GROK_REALTIME,
+    label: "Grok Realtime",
+    model: DEFAULT_GROK_REALTIME_MODEL,
+    voiceName: DEFAULT_GROK_REALTIME_VOICE,
+  },
+];
+
+const DEFAULT_MODELS = Object.fromEntries(
+  PROVIDER_OPTIONS.map((option) => [option.provider, option.model]),
+) as Record<VoiceAgentProvider, string>;
+
+const DEFAULT_VOICES = Object.fromEntries(
+  PROVIDER_OPTIONS.map((option) => [option.provider, option.voiceName]),
+) as Record<VoiceAgentProvider, string>;
+
+export const Route = createFileRoute(
+  "/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/",
+)({
+  loader: async ({ context, params }) => {
+    const project = await context.queryClient.ensureQueryData({
+      ...orpc.projects.findBySlug.queryOptions({ input: { slug: params.projectSlug } }),
+      staleTime: 30_000,
+    });
+    await context.queryClient.ensureQueryData({
+      ...orpc.project.streams.list.queryOptions({ input: { projectSlugOrId: project.id } }),
+      staleTime: 10_000,
+    });
+
+    return {
+      breadcrumb: "Voice agents",
+      project,
+    };
+  },
+  component: VoiceAgentsIndexPage,
+});
+
+function VoiceAgentsIndexPage() {
+  const params = Route.useParams();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { project } = Route.useLoaderData();
+  const [isCreating, setIsCreating] = useState(false);
+  const [selectedProvider, setSelectedProvider] = useState<VoiceAgentProvider>(
+    VOICE_AGENT_PROVIDER_GEMINI_LIVE,
+  );
+  const [models, setModels] = useState<Record<VoiceAgentProvider, string>>(DEFAULT_MODELS);
+  const [voices, setVoices] = useState<Record<VoiceAgentProvider, string>>(DEFAULT_VOICES);
+  const [systemInstruction, setSystemInstruction] = useState(
+    DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION,
+  );
+  const streamsQueryOptions = orpc.project.streams.list.queryOptions({
+    input: { projectSlugOrId: project.id },
+  });
+  const { data } = useQuery({
+    ...streamsQueryOptions,
+    staleTime: 10_000,
+    refetchInterval: 5_000,
+  });
+  const voiceAgentStreams = useMemo(
+    () =>
+      (data?.streams ?? [])
+        .filter((stream) => stream.streamPath.startsWith("/voice-agents/"))
+        .toSorted((left, right) => right.lastWokenAt.localeCompare(left.lastWokenAt)),
+    [data?.streams],
+  );
+
+  async function startConversation() {
+    const model = models[selectedProvider].trim();
+    const voiceName = voices[selectedProvider].trim();
+    if (!model || !voiceName) {
+      toast.error("Model and voice are required.");
+      return;
+    }
+
+    setIsCreating(true);
+    const slug = `voice-${Date.now().toString(36)}`;
+    const streamPath = StreamPath.parse(`/voice-agents/${slug}`);
+    try {
+      await createBrowserOpenApiClient().project.streams.create({
+        projectSlugOrId: project.id,
+        streamPath,
+      });
+      await createBrowserOpenApiClient().project.streams.appendBatch({
+        projectSlugOrId: project.id,
+        streamPath,
+        events: [
+          voiceAgentCircuitBreakerConfiguredEvent({
+            projectId: project.id,
+            streamPath,
+          }),
+          voiceAgentSubscriptionConfiguredEvent({
+            projectId: project.id,
+            streamPath,
+          }),
+          EventInput.parse({
+            idempotencyKey: `voice-agent-setup:${project.id}:${streamPath}`,
+            type: VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE,
+            payload: {
+              provider: selectedProvider,
+              model,
+              voiceName,
+              systemInstruction: systemInstruction.trim() || DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION,
+            },
+          }),
+        ],
+      });
+      await queryClient.invalidateQueries({ queryKey: streamsQueryOptions.queryKey });
+      void navigate({
+        to: "/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug",
+        params: {
+          organizationSlug: params.organizationSlug,
+          projectSlug: params.projectSlug,
+          voiceAgentSlug: slug,
+        },
+      });
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not start voice agent.");
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  return (
+    <section className="w-full space-y-4 p-4">
+      <div>
+        <h1 className="text-base font-semibold">Voice agents</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Browser microphone in, stream events through a realtime voice provider, stream output
+          frames back out.
+        </p>
+      </div>
+
+      <section className="rounded-lg border bg-background p-4">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0 flex-1 space-y-4">
+            <div>
+              <h2 className="text-sm font-semibold">New conversation</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Pick the backend before the stream starts.
+              </p>
+            </div>
+
+            <div className="grid gap-3 xl:grid-cols-[minmax(14rem,18rem)_minmax(0,1fr)_minmax(0,1fr)]">
+              <div>
+                <div className="text-xs font-medium text-muted-foreground">Backend</div>
+                <div className="mt-2 grid grid-cols-1 gap-1 rounded-lg border bg-muted/30 p-1">
+                  {PROVIDER_OPTIONS.map((option) => (
+                    <button
+                      key={option.provider}
+                      type="button"
+                      aria-pressed={selectedProvider === option.provider}
+                      className={cn(
+                        "rounded-md px-3 py-2 text-left text-sm font-medium transition-colors",
+                        selectedProvider === option.provider
+                          ? "bg-background text-foreground shadow-sm"
+                          : "text-muted-foreground hover:bg-background/70 hover:text-foreground",
+                      )}
+                      onClick={() => setSelectedProvider(option.provider)}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <label
+                  className="text-xs font-medium text-muted-foreground"
+                  htmlFor="voice-agent-model"
+                >
+                  Model
+                </label>
+                <Input
+                  id="voice-agent-model"
+                  value={models[selectedProvider]}
+                  onChange={(event) =>
+                    setModels((current) => ({
+                      ...current,
+                      [selectedProvider]: event.currentTarget.value,
+                    }))
+                  }
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label
+                  className="text-xs font-medium text-muted-foreground"
+                  htmlFor="voice-agent-voice"
+                >
+                  Voice
+                </label>
+                <Input
+                  id="voice-agent-voice"
+                  value={voices[selectedProvider]}
+                  onChange={(event) =>
+                    setVoices((current) => ({
+                      ...current,
+                      [selectedProvider]: event.currentTarget.value,
+                    }))
+                  }
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <label
+                className="text-xs font-medium text-muted-foreground"
+                htmlFor="voice-agent-system-instruction"
+              >
+                System instruction
+              </label>
+              <Textarea
+                id="voice-agent-system-instruction"
+                className="min-h-20"
+                value={systemInstruction}
+                onChange={(event) => setSystemInstruction(event.currentTarget.value)}
+              />
+            </div>
+          </div>
+
+          <Button
+            type="button"
+            className="w-full lg:w-auto"
+            disabled={isCreating}
+            onClick={() => void startConversation()}
+          >
+            {isCreating ? "Starting..." : "Start conversation"}
+          </Button>
+        </div>
+      </section>
+
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold">Conversations</h2>
+        </div>
+      </div>
+
+      {voiceAgentStreams.length === 0 ? (
+        <Empty className="min-h-72 border">
+          <EmptyHeader>
+            <EmptyTitle>No voice conversations</EmptyTitle>
+            <EmptyDescription>Start one to create a /voice-agents stream.</EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        <div className="overflow-hidden rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Stream</TableHead>
+                <TableHead>Stream name</TableHead>
+                <TableHead>Last active</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {voiceAgentStreams.map((stream) => {
+                const slug = stream.streamPath.replace(/^\/voice-agents\//, "");
+                return (
+                  <TableRow key={stream.name}>
+                    <TableCell>
+                      <Link
+                        className="font-medium underline-offset-4 hover:underline"
+                        to="/orgs/$organizationSlug/projects/$projectSlug/voice-agents/$voiceAgentSlug"
+                        params={{
+                          organizationSlug: params.organizationSlug,
+                          projectSlug: params.projectSlug,
+                          voiceAgentSlug: slug,
+                        }}
+                      >
+                        <EventsStreamPathLabel path={stream.streamPath} />
+                      </Link>
+                    </TableCell>
+                    <TableCell className="font-mono text-xs text-muted-foreground">
+                      {stream.name}
+                    </TableCell>
+                    <TableCell>{new Date(stream.lastWokenAt).toLocaleString()}</TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/index.tsx
+++ b/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/index.tsx
@@ -79,6 +79,9 @@ const DEFAULT_VOICES = Object.fromEntries(
   PROVIDER_OPTIONS.map((option) => [option.provider, option.voiceName]),
 ) as Record<VoiceAgentProvider, string>;
 
+const VOICE_AGENT_STREAM_PATH_PREFIX = "/agents/voice/";
+const LEGACY_VOICE_AGENT_STREAM_PATH_PREFIX = "/voice-agents/";
+
 export const Route = createFileRoute(
   "/_app/orgs/$organizationSlug/projects/$projectSlug/voice-agents/",
 )({
@@ -125,7 +128,7 @@ function VoiceAgentsIndexPage() {
   const voiceAgentStreams = useMemo(
     () =>
       (data?.streams ?? [])
-        .filter((stream) => stream.streamPath.startsWith("/agents/voice/"))
+        .filter((stream) => isVoiceAgentStreamPath(stream.streamPath))
         .toSorted((left, right) => right.lastWokenAt.localeCompare(left.lastWokenAt)),
     [data?.streams],
   );
@@ -325,7 +328,7 @@ function VoiceAgentsIndexPage() {
             </TableHeader>
             <TableBody>
               {voiceAgentStreams.map((stream) => {
-                const slug = stream.streamPath.replace(/^\/agents\/voice\//, "");
+                const slug = voiceAgentSlugFromStreamPath(stream.streamPath);
                 return (
                   <TableRow key={stream.name}>
                     <TableCell>
@@ -337,6 +340,7 @@ function VoiceAgentsIndexPage() {
                           projectSlug: params.projectSlug,
                           voiceAgentSlug: slug,
                         }}
+                        search={{ streamPath: stream.streamPath }}
                       >
                         <EventsStreamPathLabel path={stream.streamPath} />
                       </Link>
@@ -354,6 +358,23 @@ function VoiceAgentsIndexPage() {
       )}
     </section>
   );
+}
+
+function isVoiceAgentStreamPath(streamPath: string) {
+  return (
+    streamPath.startsWith(VOICE_AGENT_STREAM_PATH_PREFIX) ||
+    streamPath.startsWith(LEGACY_VOICE_AGENT_STREAM_PATH_PREFIX)
+  );
+}
+
+function voiceAgentSlugFromStreamPath(streamPath: string) {
+  if (streamPath.startsWith(VOICE_AGENT_STREAM_PATH_PREFIX)) {
+    return streamPath.slice(VOICE_AGENT_STREAM_PATH_PREFIX.length);
+  }
+  if (streamPath.startsWith(LEGACY_VOICE_AGENT_STREAM_PATH_PREFIX)) {
+    return streamPath.slice(LEGACY_VOICE_AGENT_STREAM_PATH_PREFIX.length);
+  }
+  return streamPath;
 }
 
 function voiceProviderProcessorSlug(provider: VoiceAgentProvider) {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -73,6 +73,8 @@
     "./stream-processors/jsonata-reactor/implementation": "./src/stream-processors/jsonata-reactor/implementation.ts",
     "./stream-processors/openai-ws/contract": "./src/stream-processors/openai-ws/contract.ts",
     "./stream-processors/openai-ws/implementation": "./src/stream-processors/openai-ws/implementation.ts",
+    "./stream-processors/voice-agent/contract": "./src/stream-processors/voice-agent/contract.ts",
+    "./stream-processors/voice-agent/implementation": "./src/stream-processors/voice-agent/implementation.ts",
     "./stream-processors/scheduling/contract": "./src/stream-processors/scheduling/contract.ts",
     "./stream-processors/scheduling/implementation": "./src/stream-processors/scheduling/implementation.ts",
     "./stream-processors/slack/contract": "./src/stream-processors/slack/contract.ts",

--- a/packages/shared/src/stream-processors/voice-agent/contract.ts
+++ b/packages/shared/src/stream-processors/voice-agent/contract.ts
@@ -29,8 +29,12 @@ export const VOICE_AGENT_CONFIG_UPDATED_EVENT_TYPE =
   "events.iterate.com/voice-agent/config-updated";
 export const VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE =
   "events.iterate.com/voice-agent/input-audio-frame-appended";
+export const VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/input-text-appended";
 export const VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE =
   "events.iterate.com/voice-agent/output-audio-frame-appended";
+export const VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/output-text-appended";
 export const VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE =
   "events.iterate.com/voice-agent/speaker-buffer-clear-requested";
 
@@ -42,6 +46,17 @@ const VoiceAgentAudioFramePayload = z.object({
   channels: z.literal(1),
   durationMs: z.number().int().nonnegative(),
   dataBase64: z.string().trim().min(1),
+});
+
+const VoiceAgentInputTextPayload = z.object({
+  text: z.string().trim().min(1),
+  source: z.string().trim().min(1).optional(),
+});
+
+const VoiceAgentOutputTextPayload = z.object({
+  connectionId: z.string().min(1).optional(),
+  text: z.string().trim().min(1),
+  source: z.enum(["input-transcription", "output-transcription", "provider-text"]).optional(),
 });
 
 const GeminiSetupPayload = z.object({
@@ -135,7 +150,11 @@ export const VoiceAgentProcessorContract = defineProcessorContract({
     setup: VoiceAgentSetup.nullable().default(null),
     inputFrameCount: z.number().int().nonnegative().default(0),
     outputFrameCount: z.number().int().nonnegative().default(0),
+    inputTextCount: z.number().int().nonnegative().default(0),
+    outputTextCount: z.number().int().nonnegative().default(0),
     connection: ConnectionState,
+    lastInputText: z.string().optional(),
+    lastOutputText: z.string().optional(),
     lastInputTranscription: z.string().optional(),
     lastOutputTranscription: z.string().optional(),
   }),
@@ -160,12 +179,22 @@ export const VoiceAgentProcessorContract = defineProcessorContract({
         sampleRate: z.literal(VOICE_AGENT_INPUT_SAMPLE_RATE),
       }),
     },
+    [VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE]: {
+      description:
+        "Authoritative text input/context to send to the selected realtime voice model. Voice clients should not speak this text directly.",
+      payloadSchema: VoiceAgentInputTextPayload,
+    },
     [VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE]: {
       description:
         "One raw little-endian PCM16 mono speaker frame returned by the selected realtime voice provider.",
       payloadSchema: VoiceAgentAudioFramePayload.extend({
         sampleRate: z.literal(VOICE_AGENT_OUTPUT_SAMPLE_RATE),
       }),
+    },
+    [VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE]: {
+      description:
+        "Text produced by the selected realtime voice provider, usually a transcript or diagnostic text.",
+      payloadSchema: VoiceAgentOutputTextPayload,
     },
     "events.iterate.com/voice-agent/transcription-appended": {
       description: "Provider transcription text for either input or output audio.",
@@ -308,7 +337,9 @@ export const VoiceAgentProcessorContract = defineProcessorContract({
     VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE,
     VOICE_AGENT_CONFIG_UPDATED_EVENT_TYPE,
     VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+    VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
     VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+    VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE,
     "events.iterate.com/voice-agent/transcription-appended",
     VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
     "events.iterate.com/voice-agent/error-occurred",
@@ -341,6 +372,7 @@ export const VoiceAgentProcessorContract = defineProcessorContract({
   emits: [
     ...standardProcessorBehavior.emits,
     VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+    VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE,
     "events.iterate.com/voice-agent/transcription-appended",
     VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
     "events.iterate.com/voice-agent/error-occurred",
@@ -400,8 +432,20 @@ export const VoiceAgentProcessorContract = defineProcessorContract({
         };
       case VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE:
         return { ...nextState, inputFrameCount: nextState.inputFrameCount + 1 };
+      case VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE:
+        return {
+          ...nextState,
+          inputTextCount: nextState.inputTextCount + 1,
+          lastInputText: event.payload.text,
+        };
       case VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE:
         return { ...nextState, outputFrameCount: nextState.outputFrameCount + 1 };
+      case VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE:
+        return {
+          ...nextState,
+          outputTextCount: nextState.outputTextCount + 1,
+          lastOutputText: event.payload.text,
+        };
       case "events.iterate.com/voice-agent/transcription-appended":
         return event.payload.direction === "input"
           ? { ...nextState, lastInputTranscription: event.payload.text }

--- a/packages/shared/src/stream-processors/voice-agent/contract.ts
+++ b/packages/shared/src/stream-processors/voice-agent/contract.ts
@@ -37,6 +37,7 @@ export const VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE =
   "events.iterate.com/voice-agent/output-text-appended";
 export const VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE =
   "events.iterate.com/voice-agent/speaker-buffer-clear-requested";
+export const AGENT_INPUT_ADDED_EVENT_TYPE = "events.iterate.com/agent/input-added";
 
 const VoiceAgentAudioFramePayload = z.object({
   streamId: z.string().trim().min(1),
@@ -140,6 +141,17 @@ const ProviderConnectionIdPayload = z.object({
   connectionId: z.string().min(1),
 });
 
+const AgentInputAddedPayload = z.object({
+  content: z.string().trim().min(1),
+  llmRequestPolicy: z
+    .discriminatedUnion("behaviour", [
+      z.object({ behaviour: z.literal("dont-trigger-request") }),
+      z.object({ behaviour: z.literal("interrupt-current-request") }),
+      z.object({ behaviour: z.literal("after-current-request") }),
+    ])
+    .default({ behaviour: "after-current-request" }),
+});
+
 export const VoiceAgentProcessorContract = defineProcessorContract({
   slug: "voice-agent",
   version: "0.1.0",
@@ -224,6 +236,11 @@ export const VoiceAgentProcessorContract = defineProcessorContract({
         message: z.string().min(1),
         sourceEventOffset: z.number().int().positive().optional(),
       }),
+    },
+    [AGENT_INPUT_ADDED_EVENT_TYPE]: {
+      description:
+        "Input for the colocated code-capable agent. Grok Ask Agent tool calls append this event so the normal agent processor can do the requested work.",
+      payloadSchema: AgentInputAddedPayload,
     },
 
     // Gemini Live events.
@@ -401,6 +418,7 @@ export const VoiceAgentProcessorContract = defineProcessorContract({
     "events.iterate.com/voice-agent/grok-realtime-speech-stopped",
     "events.iterate.com/voice-agent/grok-realtime-output-audio-done",
     "events.iterate.com/voice-agent/grok-realtime-response-done",
+    AGENT_INPUT_ADDED_EVENT_TYPE,
   ],
   reduce({ contract, state, event }) {
     const nextState = standardProcessorBehavior.reduce({

--- a/packages/shared/src/stream-processors/voice-agent/contract.ts
+++ b/packages/shared/src/stream-processors/voice-agent/contract.ts
@@ -60,14 +60,14 @@ const VoiceAgentOutputTextPayload = z.object({
   source: z.enum(["input-transcription", "output-transcription", "provider-text"]).optional(),
 });
 
-const AskAgentToolChoice = z.enum(["auto", "required"]).default("auto");
+const MessageAgentToolChoice = z.enum(["auto", "required"]).default("auto");
 
 const GeminiSetupPayload = z.object({
   provider: z.literal(VOICE_AGENT_PROVIDER_GEMINI_LIVE),
   model: z.string().trim().min(1).default(DEFAULT_GEMINI_LIVE_MODEL),
   voiceName: z.string().trim().min(1).default(DEFAULT_GEMINI_LIVE_VOICE),
   systemInstruction: z.string().default(DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION),
-  askAgentToolChoice: AskAgentToolChoice,
+  messageAgentToolChoice: MessageAgentToolChoice,
 });
 
 const OpenAiSetupPayload = z.object({
@@ -75,7 +75,7 @@ const OpenAiSetupPayload = z.object({
   model: z.string().trim().min(1).default(DEFAULT_OPENAI_REALTIME_MODEL),
   voiceName: z.string().trim().min(1).default(DEFAULT_OPENAI_REALTIME_VOICE),
   systemInstruction: z.string().default(DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION),
-  askAgentToolChoice: AskAgentToolChoice,
+  messageAgentToolChoice: MessageAgentToolChoice,
 });
 
 const GrokSetupPayload = z.object({
@@ -83,7 +83,7 @@ const GrokSetupPayload = z.object({
   model: z.string().trim().min(1).default(DEFAULT_GROK_REALTIME_MODEL),
   voiceName: z.string().trim().min(1).default(DEFAULT_GROK_REALTIME_VOICE),
   systemInstruction: z.string().default(DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION),
-  askAgentToolChoice: AskAgentToolChoice,
+  messageAgentToolChoice: MessageAgentToolChoice,
 });
 
 const VoiceAgentSetup = z.discriminatedUnion("provider", [
@@ -244,7 +244,7 @@ export const VoiceAgentProcessorContract = defineProcessorContract({
     },
     [AGENT_INPUT_ADDED_EVENT_TYPE]: {
       description:
-        "Input for the colocated code-capable agent. Grok Ask Agent tool calls append this event so the normal agent processor can do the requested work.",
+        "Input for the colocated code-capable agent. Grok Message Agent tool calls append this event so the normal agent processor can do the requested work.",
       payloadSchema: AgentInputAddedPayload,
     },
 
@@ -450,7 +450,7 @@ export const VoiceAgentProcessorContract = defineProcessorContract({
             model: event.payload.model,
             voiceName: event.payload.voiceName,
             systemInstruction: event.payload.systemInstruction,
-            askAgentToolChoice: "auto" as const,
+            messageAgentToolChoice: "auto" as const,
           },
           connection: { status: "idle" as const },
         };

--- a/packages/shared/src/stream-processors/voice-agent/contract.ts
+++ b/packages/shared/src/stream-processors/voice-agent/contract.ts
@@ -1,0 +1,521 @@
+import { z } from "zod";
+import {
+  assertNever,
+  defineProcessorContract,
+  reduceProcessorEvents,
+  type StreamEvent,
+} from "../stream-processor.ts";
+import { CoreProcessorRegisteredEventType } from "../core/contract.ts";
+import { standardProcessorBehavior } from "../core/standard-processor-behavior.ts";
+
+export const VOICE_AGENT_PROVIDER_GEMINI_LIVE = "gemini-live";
+export const VOICE_AGENT_PROVIDER_OPENAI_REALTIME = "openai-realtime";
+export const VOICE_AGENT_PROVIDER_GROK_REALTIME = "grok-realtime";
+
+export const DEFAULT_GEMINI_LIVE_MODEL = "gemini-3.1-flash-live-preview";
+export const DEFAULT_GEMINI_LIVE_VOICE = "Zephyr";
+export const DEFAULT_OPENAI_REALTIME_MODEL = "gpt-realtime-mini";
+export const DEFAULT_OPENAI_REALTIME_VOICE = "marin";
+export const DEFAULT_GROK_REALTIME_MODEL = "grok-voice-latest";
+export const DEFAULT_GROK_REALTIME_VOICE = "eve";
+export const DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION =
+  "You are a helpful realtime voice agent. Keep responses concise.";
+export const VOICE_AGENT_INPUT_SAMPLE_RATE = 16_000;
+export const VOICE_AGENT_OUTPUT_SAMPLE_RATE = 24_000;
+
+export const VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/setup-configured";
+export const VOICE_AGENT_CONFIG_UPDATED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/config-updated";
+export const VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/input-audio-frame-appended";
+export const VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/output-audio-frame-appended";
+export const VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/speaker-buffer-clear-requested";
+
+const VoiceAgentAudioFramePayload = z.object({
+  streamId: z.string().trim().min(1),
+  sequence: z.number().int().nonnegative(),
+  encoding: z.literal("pcm_s16le"),
+  sampleRate: z.number().int().positive(),
+  channels: z.literal(1),
+  durationMs: z.number().int().nonnegative(),
+  dataBase64: z.string().trim().min(1),
+});
+
+const GeminiSetupPayload = z.object({
+  provider: z.literal(VOICE_AGENT_PROVIDER_GEMINI_LIVE),
+  model: z.string().trim().min(1).default(DEFAULT_GEMINI_LIVE_MODEL),
+  voiceName: z.string().trim().min(1).default(DEFAULT_GEMINI_LIVE_VOICE),
+  systemInstruction: z.string().default(DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION),
+});
+
+const OpenAiSetupPayload = z.object({
+  provider: z.literal(VOICE_AGENT_PROVIDER_OPENAI_REALTIME),
+  model: z.string().trim().min(1).default(DEFAULT_OPENAI_REALTIME_MODEL),
+  voiceName: z.string().trim().min(1).default(DEFAULT_OPENAI_REALTIME_VOICE),
+  systemInstruction: z.string().default(DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION),
+});
+
+const GrokSetupPayload = z.object({
+  provider: z.literal(VOICE_AGENT_PROVIDER_GROK_REALTIME),
+  model: z.string().trim().min(1).default(DEFAULT_GROK_REALTIME_MODEL),
+  voiceName: z.string().trim().min(1).default(DEFAULT_GROK_REALTIME_VOICE),
+  systemInstruction: z.string().default(DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION),
+});
+
+const VoiceAgentSetup = z.discriminatedUnion("provider", [
+  GeminiSetupPayload,
+  OpenAiSetupPayload,
+  GrokSetupPayload,
+]);
+
+const ProviderJson = z.json();
+
+const ConnectionState = z
+  .discriminatedUnion("status", [
+    z.object({ status: z.literal("idle") }),
+    z.object({
+      status: z.literal("connected"),
+      connectionId: z.string().min(1),
+      provider: z.union([
+        z.literal(VOICE_AGENT_PROVIDER_GEMINI_LIVE),
+        z.literal(VOICE_AGENT_PROVIDER_OPENAI_REALTIME),
+        z.literal(VOICE_AGENT_PROVIDER_GROK_REALTIME),
+      ]),
+    }),
+    z.object({
+      status: z.literal("disconnected"),
+      connectionId: z.string().min(1).optional(),
+      provider: z
+        .union([
+          z.literal(VOICE_AGENT_PROVIDER_GEMINI_LIVE),
+          z.literal(VOICE_AGENT_PROVIDER_OPENAI_REALTIME),
+          z.literal(VOICE_AGENT_PROVIDER_GROK_REALTIME),
+        ])
+        .optional(),
+      reason: z.string().optional(),
+    }),
+    z.object({ status: z.literal("error"), message: z.string().min(1) }),
+  ])
+  .default({ status: "idle" });
+
+const ProviderWebSocketConnectedPayload = z.object({
+  connectionId: z.string().min(1),
+  model: z.string().min(1),
+  url: z.string().url(),
+});
+
+const ProviderWebSocketDisconnectedPayload = z.object({
+  connectionId: z.string().min(1).optional(),
+  code: z.number().int().optional(),
+  reason: z.string().optional(),
+  wasClean: z.boolean().optional(),
+});
+
+const ProviderMessagePayload = z.object({
+  connectionId: z.string().min(1),
+  sequence: z.number().int().nonnegative(),
+  sourceEventOffset: z.number().int().positive().optional(),
+  message: ProviderJson,
+});
+
+const ProviderConnectionIdPayload = z.object({
+  connectionId: z.string().min(1),
+});
+
+export const VoiceAgentProcessorContract = defineProcessorContract({
+  slug: "voice-agent",
+  version: "0.1.0",
+  description:
+    "Forwards appended input PCM frames to Gemini Live, OpenAI Realtime, or Grok Realtime and appends returned output PCM frames back into the same stream.",
+  stateSchema: z.object({
+    ...standardProcessorBehavior.stateShape,
+    setup: VoiceAgentSetup.nullable().default(null),
+    inputFrameCount: z.number().int().nonnegative().default(0),
+    outputFrameCount: z.number().int().nonnegative().default(0),
+    connection: ConnectionState,
+    lastInputTranscription: z.string().optional(),
+    lastOutputTranscription: z.string().optional(),
+  }),
+  initialState: {
+    ...standardProcessorBehavior.initialState,
+  },
+  processorDeps: [...standardProcessorBehavior.processorDeps],
+  events: {
+    // Common voice-agent events.
+    [VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE]: {
+      description:
+        "Required voice-agent setup. Selects the realtime voice provider and provider-specific model/voice configuration before audio starts.",
+      payloadSchema: VoiceAgentSetup,
+    },
+    [VOICE_AGENT_CONFIG_UPDATED_EVENT_TYPE]: {
+      description: "Legacy Gemini Live configuration event. Prefer setup-configured.",
+      payloadSchema: GeminiSetupPayload.omit({ provider: true }),
+    },
+    [VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE]: {
+      description: "One raw little-endian PCM16 mono microphone frame appended by a client.",
+      payloadSchema: VoiceAgentAudioFramePayload.extend({
+        sampleRate: z.literal(VOICE_AGENT_INPUT_SAMPLE_RATE),
+      }),
+    },
+    [VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE]: {
+      description:
+        "One raw little-endian PCM16 mono speaker frame returned by the selected realtime voice provider.",
+      payloadSchema: VoiceAgentAudioFramePayload.extend({
+        sampleRate: z.literal(VOICE_AGENT_OUTPUT_SAMPLE_RATE),
+      }),
+    },
+    "events.iterate.com/voice-agent/transcription-appended": {
+      description: "Provider transcription text for either input or output audio.",
+      payloadSchema: z.object({
+        connectionId: z.string().min(1),
+        direction: z.enum(["input", "output"]),
+        text: z.string(),
+      }),
+    },
+    [VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE]: {
+      description:
+        "Provider-neutral command for subscribed voice clients to drop locally queued speaker audio.",
+      payloadSchema: z.object({
+        connectionId: z.string().min(1),
+        provider: z.union([
+          z.literal(VOICE_AGENT_PROVIDER_GEMINI_LIVE),
+          z.literal(VOICE_AGENT_PROVIDER_OPENAI_REALTIME),
+          z.literal(VOICE_AGENT_PROVIDER_GROK_REALTIME),
+        ]),
+        reason: z.enum(["output-interrupted", "input-speech-started"]),
+        sourceEventType: z.string().min(1),
+      }),
+    },
+    "events.iterate.com/voice-agent/error-occurred": {
+      description: "The voice-agent processor could not process or forward an audio frame.",
+      payloadSchema: z.object({
+        message: z.string().min(1),
+        sourceEventOffset: z.number().int().positive().optional(),
+      }),
+    },
+
+    // Gemini Live events.
+    "events.iterate.com/voice-agent/gemini-live-websocket-connected": {
+      description: "The backend processor opened a Gemini Live WebSocket.",
+      payloadSchema: ProviderWebSocketConnectedPayload,
+    },
+    "events.iterate.com/voice-agent/gemini-live-websocket-disconnected": {
+      description: "The Gemini Live WebSocket closed.",
+      payloadSchema: ProviderWebSocketDisconnectedPayload,
+    },
+    "events.iterate.com/voice-agent/gemini-live-setup-completed": {
+      description: "Gemini accepted the session setup message.",
+      payloadSchema: ProviderConnectionIdPayload,
+    },
+    "events.iterate.com/voice-agent/gemini-live-message-sent": {
+      description: "A JSON message was sent to Gemini Live.",
+      payloadSchema: ProviderMessagePayload,
+    },
+    "events.iterate.com/voice-agent/gemini-live-message-received": {
+      description: "A JSON message was received from Gemini Live.",
+      payloadSchema: ProviderMessagePayload.omit({ sourceEventOffset: true }),
+    },
+    "events.iterate.com/voice-agent/gemini-live-output-interrupted": {
+      description: "Gemini reported that user activity interrupted current output.",
+      payloadSchema: ProviderConnectionIdPayload,
+    },
+    "events.iterate.com/voice-agent/gemini-live-turn-completed": {
+      description: "Gemini reported that the current model turn completed.",
+      payloadSchema: ProviderConnectionIdPayload,
+    },
+
+    // OpenAI Realtime events.
+    "events.iterate.com/voice-agent/openai-realtime-websocket-connected": {
+      description: "The backend processor opened an OpenAI Realtime WebSocket.",
+      payloadSchema: ProviderWebSocketConnectedPayload,
+    },
+    "events.iterate.com/voice-agent/openai-realtime-websocket-disconnected": {
+      description: "The OpenAI Realtime WebSocket closed.",
+      payloadSchema: ProviderWebSocketDisconnectedPayload,
+    },
+    "events.iterate.com/voice-agent/openai-realtime-session-updated": {
+      description: "OpenAI accepted the session.update message.",
+      payloadSchema: ProviderConnectionIdPayload,
+    },
+    "events.iterate.com/voice-agent/openai-realtime-message-sent": {
+      description: "A JSON message was sent to OpenAI Realtime.",
+      payloadSchema: ProviderMessagePayload,
+    },
+    "events.iterate.com/voice-agent/openai-realtime-message-received": {
+      description: "A JSON message was received from OpenAI Realtime.",
+      payloadSchema: ProviderMessagePayload.omit({ sourceEventOffset: true }),
+    },
+    "events.iterate.com/voice-agent/openai-realtime-speech-started": {
+      description: "OpenAI server VAD detected speech start.",
+      payloadSchema: ProviderConnectionIdPayload,
+    },
+    "events.iterate.com/voice-agent/openai-realtime-speech-stopped": {
+      description: "OpenAI server VAD detected speech stop.",
+      payloadSchema: ProviderConnectionIdPayload,
+    },
+    "events.iterate.com/voice-agent/openai-realtime-output-audio-done": {
+      description: "OpenAI reported that output audio finished streaming.",
+      payloadSchema: ProviderConnectionIdPayload,
+    },
+    "events.iterate.com/voice-agent/openai-realtime-response-done": {
+      description: "OpenAI reported that the current response completed.",
+      payloadSchema: ProviderConnectionIdPayload,
+    },
+
+    // Grok Realtime events.
+    "events.iterate.com/voice-agent/grok-realtime-websocket-connected": {
+      description: "The backend processor opened a Grok Realtime WebSocket.",
+      payloadSchema: ProviderWebSocketConnectedPayload,
+    },
+    "events.iterate.com/voice-agent/grok-realtime-websocket-disconnected": {
+      description: "The Grok Realtime WebSocket closed.",
+      payloadSchema: ProviderWebSocketDisconnectedPayload,
+    },
+    "events.iterate.com/voice-agent/grok-realtime-session-updated": {
+      description: "Grok accepted the session.update message.",
+      payloadSchema: ProviderConnectionIdPayload,
+    },
+    "events.iterate.com/voice-agent/grok-realtime-message-sent": {
+      description: "A JSON message was sent to Grok Realtime.",
+      payloadSchema: ProviderMessagePayload,
+    },
+    "events.iterate.com/voice-agent/grok-realtime-message-received": {
+      description: "A JSON message was received from Grok Realtime.",
+      payloadSchema: ProviderMessagePayload.omit({ sourceEventOffset: true }),
+    },
+    "events.iterate.com/voice-agent/grok-realtime-speech-started": {
+      description: "Grok server VAD detected speech start.",
+      payloadSchema: ProviderConnectionIdPayload,
+    },
+    "events.iterate.com/voice-agent/grok-realtime-speech-stopped": {
+      description: "Grok server VAD detected speech stop.",
+      payloadSchema: ProviderConnectionIdPayload,
+    },
+    "events.iterate.com/voice-agent/grok-realtime-output-audio-done": {
+      description: "Grok reported that output audio finished streaming.",
+      payloadSchema: ProviderConnectionIdPayload,
+    },
+    "events.iterate.com/voice-agent/grok-realtime-response-done": {
+      description: "Grok reported that the current response completed.",
+      payloadSchema: ProviderConnectionIdPayload,
+    },
+  },
+  consumes: [
+    ...standardProcessorBehavior.consumes,
+    VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE,
+    VOICE_AGENT_CONFIG_UPDATED_EVENT_TYPE,
+    VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+    VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+    "events.iterate.com/voice-agent/transcription-appended",
+    VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
+    "events.iterate.com/voice-agent/error-occurred",
+    "events.iterate.com/voice-agent/gemini-live-websocket-connected",
+    "events.iterate.com/voice-agent/gemini-live-websocket-disconnected",
+    "events.iterate.com/voice-agent/gemini-live-setup-completed",
+    "events.iterate.com/voice-agent/gemini-live-message-sent",
+    "events.iterate.com/voice-agent/gemini-live-message-received",
+    "events.iterate.com/voice-agent/gemini-live-output-interrupted",
+    "events.iterate.com/voice-agent/gemini-live-turn-completed",
+    "events.iterate.com/voice-agent/openai-realtime-websocket-connected",
+    "events.iterate.com/voice-agent/openai-realtime-websocket-disconnected",
+    "events.iterate.com/voice-agent/openai-realtime-session-updated",
+    "events.iterate.com/voice-agent/openai-realtime-message-sent",
+    "events.iterate.com/voice-agent/openai-realtime-message-received",
+    "events.iterate.com/voice-agent/openai-realtime-speech-started",
+    "events.iterate.com/voice-agent/openai-realtime-speech-stopped",
+    "events.iterate.com/voice-agent/openai-realtime-output-audio-done",
+    "events.iterate.com/voice-agent/openai-realtime-response-done",
+    "events.iterate.com/voice-agent/grok-realtime-websocket-connected",
+    "events.iterate.com/voice-agent/grok-realtime-websocket-disconnected",
+    "events.iterate.com/voice-agent/grok-realtime-session-updated",
+    "events.iterate.com/voice-agent/grok-realtime-message-sent",
+    "events.iterate.com/voice-agent/grok-realtime-message-received",
+    "events.iterate.com/voice-agent/grok-realtime-speech-started",
+    "events.iterate.com/voice-agent/grok-realtime-speech-stopped",
+    "events.iterate.com/voice-agent/grok-realtime-output-audio-done",
+    "events.iterate.com/voice-agent/grok-realtime-response-done",
+  ],
+  emits: [
+    ...standardProcessorBehavior.emits,
+    VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+    "events.iterate.com/voice-agent/transcription-appended",
+    VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
+    "events.iterate.com/voice-agent/error-occurred",
+    "events.iterate.com/voice-agent/gemini-live-websocket-connected",
+    "events.iterate.com/voice-agent/gemini-live-websocket-disconnected",
+    "events.iterate.com/voice-agent/gemini-live-setup-completed",
+    "events.iterate.com/voice-agent/gemini-live-message-sent",
+    "events.iterate.com/voice-agent/gemini-live-message-received",
+    "events.iterate.com/voice-agent/gemini-live-output-interrupted",
+    "events.iterate.com/voice-agent/gemini-live-turn-completed",
+    "events.iterate.com/voice-agent/openai-realtime-websocket-connected",
+    "events.iterate.com/voice-agent/openai-realtime-websocket-disconnected",
+    "events.iterate.com/voice-agent/openai-realtime-session-updated",
+    "events.iterate.com/voice-agent/openai-realtime-message-sent",
+    "events.iterate.com/voice-agent/openai-realtime-message-received",
+    "events.iterate.com/voice-agent/openai-realtime-speech-started",
+    "events.iterate.com/voice-agent/openai-realtime-speech-stopped",
+    "events.iterate.com/voice-agent/openai-realtime-output-audio-done",
+    "events.iterate.com/voice-agent/openai-realtime-response-done",
+    "events.iterate.com/voice-agent/grok-realtime-websocket-connected",
+    "events.iterate.com/voice-agent/grok-realtime-websocket-disconnected",
+    "events.iterate.com/voice-agent/grok-realtime-session-updated",
+    "events.iterate.com/voice-agent/grok-realtime-message-sent",
+    "events.iterate.com/voice-agent/grok-realtime-message-received",
+    "events.iterate.com/voice-agent/grok-realtime-speech-started",
+    "events.iterate.com/voice-agent/grok-realtime-speech-stopped",
+    "events.iterate.com/voice-agent/grok-realtime-output-audio-done",
+    "events.iterate.com/voice-agent/grok-realtime-response-done",
+  ],
+  reduce({ contract, state, event }) {
+    const nextState = standardProcessorBehavior.reduce({
+      state,
+      event,
+      contract,
+    });
+
+    switch (event.type) {
+      // Common reducers.
+      case CoreProcessorRegisteredEventType:
+        return nextState;
+      case VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE:
+        return {
+          ...nextState,
+          setup: event.payload,
+          connection: { status: "idle" as const },
+        };
+      case VOICE_AGENT_CONFIG_UPDATED_EVENT_TYPE:
+        return {
+          ...nextState,
+          setup: {
+            provider: "gemini-live" as const,
+            model: event.payload.model,
+            voiceName: event.payload.voiceName,
+            systemInstruction: event.payload.systemInstruction,
+          },
+          connection: { status: "idle" as const },
+        };
+      case VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE:
+        return { ...nextState, inputFrameCount: nextState.inputFrameCount + 1 };
+      case VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE:
+        return { ...nextState, outputFrameCount: nextState.outputFrameCount + 1 };
+      case "events.iterate.com/voice-agent/transcription-appended":
+        return event.payload.direction === "input"
+          ? { ...nextState, lastInputTranscription: event.payload.text }
+          : { ...nextState, lastOutputTranscription: event.payload.text };
+      case VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE:
+        return nextState;
+      case "events.iterate.com/voice-agent/error-occurred":
+        return {
+          ...nextState,
+          connection: { status: "error" as const, message: event.payload.message },
+        };
+
+      // Gemini Live reducers.
+      case "events.iterate.com/voice-agent/gemini-live-websocket-connected":
+        return {
+          ...nextState,
+          connection: {
+            status: "connected" as const,
+            connectionId: event.payload.connectionId,
+            provider: "gemini-live" as const,
+          },
+        };
+      case "events.iterate.com/voice-agent/gemini-live-websocket-disconnected":
+        return {
+          ...nextState,
+          connection: {
+            status: "disconnected" as const,
+            connectionId: event.payload.connectionId,
+            provider: "gemini-live" as const,
+            reason: event.payload.reason,
+          },
+        };
+      case "events.iterate.com/voice-agent/gemini-live-message-sent":
+      case "events.iterate.com/voice-agent/gemini-live-message-received":
+      case "events.iterate.com/voice-agent/gemini-live-setup-completed":
+      case "events.iterate.com/voice-agent/gemini-live-output-interrupted":
+      case "events.iterate.com/voice-agent/gemini-live-turn-completed":
+        return nextState;
+
+      // OpenAI Realtime reducers.
+      case "events.iterate.com/voice-agent/openai-realtime-websocket-connected":
+        return {
+          ...nextState,
+          connection: {
+            status: "connected" as const,
+            connectionId: event.payload.connectionId,
+            provider: "openai-realtime" as const,
+          },
+        };
+      case "events.iterate.com/voice-agent/openai-realtime-websocket-disconnected":
+        return {
+          ...nextState,
+          connection: {
+            status: "disconnected" as const,
+            connectionId: event.payload.connectionId,
+            provider: "openai-realtime" as const,
+            reason: event.payload.reason,
+          },
+        };
+      case "events.iterate.com/voice-agent/openai-realtime-session-updated":
+      case "events.iterate.com/voice-agent/openai-realtime-message-sent":
+      case "events.iterate.com/voice-agent/openai-realtime-message-received":
+      case "events.iterate.com/voice-agent/openai-realtime-speech-started":
+      case "events.iterate.com/voice-agent/openai-realtime-speech-stopped":
+      case "events.iterate.com/voice-agent/openai-realtime-output-audio-done":
+      case "events.iterate.com/voice-agent/openai-realtime-response-done":
+        return nextState;
+
+      // Grok Realtime reducers.
+      case "events.iterate.com/voice-agent/grok-realtime-websocket-connected":
+        return {
+          ...nextState,
+          connection: {
+            status: "connected" as const,
+            connectionId: event.payload.connectionId,
+            provider: "grok-realtime" as const,
+          },
+        };
+      case "events.iterate.com/voice-agent/grok-realtime-websocket-disconnected":
+        return {
+          ...nextState,
+          connection: {
+            status: "disconnected" as const,
+            connectionId: event.payload.connectionId,
+            provider: "grok-realtime" as const,
+            reason: event.payload.reason,
+          },
+        };
+      case "events.iterate.com/voice-agent/grok-realtime-session-updated":
+      case "events.iterate.com/voice-agent/grok-realtime-message-sent":
+      case "events.iterate.com/voice-agent/grok-realtime-message-received":
+      case "events.iterate.com/voice-agent/grok-realtime-speech-started":
+      case "events.iterate.com/voice-agent/grok-realtime-speech-stopped":
+      case "events.iterate.com/voice-agent/grok-realtime-output-audio-done":
+      case "events.iterate.com/voice-agent/grok-realtime-response-done":
+        return nextState;
+      default:
+        return assertNever(event);
+    }
+  },
+});
+
+export function reduceVoiceAgentEvents(args: {
+  events: readonly StreamEvent[];
+  state?: VoiceAgentState;
+}): VoiceAgentState {
+  return reduceProcessorEvents({
+    contract: VoiceAgentProcessorContract,
+    events: args.events,
+    state: args.state,
+  });
+}
+
+export type VoiceAgentState = z.infer<typeof VoiceAgentProcessorContract.stateSchema>;
+export type VoiceAgentProvider = z.infer<typeof VoiceAgentSetup>["provider"];
+export type VoiceAgentSetup = z.infer<typeof VoiceAgentSetup>;
+export type VoiceAgentAudioFramePayload = z.infer<typeof VoiceAgentAudioFramePayload>;

--- a/packages/shared/src/stream-processors/voice-agent/contract.ts
+++ b/packages/shared/src/stream-processors/voice-agent/contract.ts
@@ -60,11 +60,14 @@ const VoiceAgentOutputTextPayload = z.object({
   source: z.enum(["input-transcription", "output-transcription", "provider-text"]).optional(),
 });
 
+const AskAgentToolChoice = z.enum(["auto", "required"]).default("auto");
+
 const GeminiSetupPayload = z.object({
   provider: z.literal(VOICE_AGENT_PROVIDER_GEMINI_LIVE),
   model: z.string().trim().min(1).default(DEFAULT_GEMINI_LIVE_MODEL),
   voiceName: z.string().trim().min(1).default(DEFAULT_GEMINI_LIVE_VOICE),
   systemInstruction: z.string().default(DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION),
+  askAgentToolChoice: AskAgentToolChoice,
 });
 
 const OpenAiSetupPayload = z.object({
@@ -72,6 +75,7 @@ const OpenAiSetupPayload = z.object({
   model: z.string().trim().min(1).default(DEFAULT_OPENAI_REALTIME_MODEL),
   voiceName: z.string().trim().min(1).default(DEFAULT_OPENAI_REALTIME_VOICE),
   systemInstruction: z.string().default(DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION),
+  askAgentToolChoice: AskAgentToolChoice,
 });
 
 const GrokSetupPayload = z.object({
@@ -79,6 +83,7 @@ const GrokSetupPayload = z.object({
   model: z.string().trim().min(1).default(DEFAULT_GROK_REALTIME_MODEL),
   voiceName: z.string().trim().min(1).default(DEFAULT_GROK_REALTIME_VOICE),
   systemInstruction: z.string().default(DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION),
+  askAgentToolChoice: AskAgentToolChoice,
 });
 
 const VoiceAgentSetup = z.discriminatedUnion("provider", [
@@ -445,6 +450,7 @@ export const VoiceAgentProcessorContract = defineProcessorContract({
             model: event.payload.model,
             voiceName: event.payload.voiceName,
             systemInstruction: event.payload.systemInstruction,
+            askAgentToolChoice: "auto" as const,
           },
           connection: { status: "idle" as const },
         };

--- a/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
@@ -212,10 +212,12 @@ describe("createVoiceAgentProviderProcessor", () => {
       await afterAppend;
 
       const providerText = providerSentText(socket.sent, provider);
-      expect(providerText).toContain("BACKGROUND AGENT MESSAGE TO RELAY TO THE CALLER:");
+      expect(providerText).toContain(
+        "BACKGROUND AGENT MESSAGE TO RELAY TO THE HUMAN YOU ARE SPEAKING TO:",
+      );
       expect(providerText).toContain("What occupation should I put on your profile?");
       expect(providerText).toContain("This message is not from the caller.");
-      expect(providerText).toContain("ask that question to the caller");
+      expect(providerText).toContain("ask that question to the human you are speaking to");
       expect(providerText).toContain("Do not say thanks, thank you");
     },
   );

--- a/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
@@ -171,9 +171,49 @@ describe("createVoiceAgentProviderProcessor", () => {
               call_id: "call_123",
             }),
           }),
-          { type: "response.create" },
+          expect.objectContaining({ type: "response.create" }),
         ]),
       );
+    },
+  );
+
+  it.each([
+    { label: "Gemini", provider: VOICE_AGENT_PROVIDER_GEMINI_LIVE },
+    { label: "OpenAI", provider: VOICE_AGENT_PROVIDER_OPENAI_REALTIME },
+    { label: "Grok", provider: VOICE_AGENT_PROVIDER_GROK_REALTIME },
+  ] satisfies Array<{ label: string; provider: VoiceAgentProvider }>)(
+    "wraps $label code-agent text so the voice model relays it to the caller",
+    async ({ provider }) => {
+      const socket = new FakeWebSocket();
+      const processor = providerProcessor({ provider, socket });
+
+      const afterAppend = processor.implementation.afterAppend?.({
+        event: committedEvent({
+          type: VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
+          payload: {
+            source: "code-agent",
+            text: "The weather is 18C and cloudy.",
+          },
+        }),
+        previousState: voiceAgentState(provider),
+        state: voiceAgentState(provider),
+        streamApi: testStreamApi([]),
+        signal: new AbortController().signal,
+      });
+
+      await waitFor(() => socket.sent.length === 1);
+      socket.receive(
+        provider === VOICE_AGENT_PROVIDER_GEMINI_LIVE
+          ? { setupComplete: {} }
+          : { type: "session.updated" },
+      );
+      await afterAppend;
+
+      const providerText = providerSentText(socket.sent, provider);
+      expect(providerText).toContain("BACKGROUND AGENT RESULT FOR THE CALLER:");
+      expect(providerText).toContain("The weather is 18C and cloudy.");
+      expect(providerText).toContain("This message is not from the caller.");
+      expect(providerText).toContain("Do not thank the caller for this update.");
     },
   );
 });
@@ -198,6 +238,20 @@ function providerProcessor(input: { provider: VoiceAgentProvider; socket: FakeWe
     provider: input.provider,
     xAiApiKey: "xai_test",
   });
+}
+
+function providerSentText(sent: unknown[], provider: VoiceAgentProvider) {
+  if (provider === VOICE_AGENT_PROVIDER_GEMINI_LIVE) {
+    const message = sent.find(
+      (candidate) => (candidate as { clientContent?: unknown }).clientContent != null,
+    ) as { clientContent?: { turns?: Array<{ parts?: Array<{ text?: string }> }> } } | undefined;
+    return message?.clientContent?.turns?.[0]?.parts?.[0]?.text ?? "";
+  }
+
+  const message = sent.find(
+    (candidate) => (candidate as { type?: unknown }).type === "conversation.item.create",
+  ) as { item?: { content?: Array<{ type?: string; text?: string }> } } | undefined;
+  return message?.item?.content?.find((part) => part.type === "input_text")?.text ?? "";
 }
 
 function voiceAgentState(provider: VoiceAgentProvider): VoiceAgentState {

--- a/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
@@ -97,6 +97,41 @@ describe("createVoiceAgentProviderProcessor", () => {
     );
   });
 
+  it("forces Gemini to call messageAgent when configured as required", async () => {
+    const socket = new FakeWebSocket();
+    const processor = providerProcessor({
+      provider: VOICE_AGENT_PROVIDER_GEMINI_LIVE,
+      socket,
+    });
+
+    void processor.implementation.afterAppend?.({
+      event: committedEvent({
+        type: VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
+        payload: { text: "Ask the agent to check the repo." },
+      }),
+      previousState: voiceAgentState(VOICE_AGENT_PROVIDER_GEMINI_LIVE, {
+        messageAgentToolChoice: "required",
+      }),
+      state: voiceAgentState(VOICE_AGENT_PROVIDER_GEMINI_LIVE, {
+        messageAgentToolChoice: "required",
+      }),
+      streamApi: testStreamApi([]),
+      signal: new AbortController().signal,
+    });
+
+    await waitFor(() => socket.sent.length === 1);
+    expect(socket.sent[0]).toMatchObject({
+      setup: {
+        toolConfig: {
+          functionCallingConfig: {
+            mode: "ANY",
+            allowedFunctionNames: ["messageAgent"],
+          },
+        },
+      },
+    });
+  });
+
   it.each([
     { label: "OpenAI", provider: VOICE_AGENT_PROVIDER_OPENAI_REALTIME },
     { label: "Grok", provider: VOICE_AGENT_PROVIDER_GROK_REALTIME },
@@ -259,7 +294,10 @@ function providerSentText(sent: unknown[], provider: VoiceAgentProvider) {
   return message?.item?.content?.find((part) => part.type === "input_text")?.text ?? "";
 }
 
-function voiceAgentState(provider: VoiceAgentProvider): VoiceAgentState {
+function voiceAgentState(
+  provider: VoiceAgentProvider,
+  overrides: Partial<VoiceAgentState["setup"]> = {},
+): VoiceAgentState {
   const providerDefaults = providerConfigDefaults(provider);
   return VoiceAgentProcessorContract.stateSchema.parse({
     setup: {
@@ -267,6 +305,7 @@ function voiceAgentState(provider: VoiceAgentProvider): VoiceAgentState {
       model: providerDefaults.model,
       voiceName: providerDefaults.voiceName,
       systemInstruction: "You are concise.",
+      ...overrides,
     },
   });
 }

--- a/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
@@ -194,7 +194,7 @@ describe("createVoiceAgentProviderProcessor", () => {
           type: VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
           payload: {
             source: "code-agent",
-            text: "The weather is 18C and cloudy.",
+            text: "What occupation should I put on your profile?",
           },
         }),
         previousState: voiceAgentState(provider),
@@ -212,9 +212,10 @@ describe("createVoiceAgentProviderProcessor", () => {
       await afterAppend;
 
       const providerText = providerSentText(socket.sent, provider);
-      expect(providerText).toContain("BACKGROUND AGENT RESULT FOR THE CALLER:");
-      expect(providerText).toContain("The weather is 18C and cloudy.");
+      expect(providerText).toContain("BACKGROUND AGENT MESSAGE TO RELAY TO THE CALLER:");
+      expect(providerText).toContain("What occupation should I put on your profile?");
       expect(providerText).toContain("This message is not from the caller.");
+      expect(providerText).toContain("ask that question to the caller");
       expect(providerText).toContain("Do not say thanks, thank you");
     },
   );

--- a/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
@@ -45,7 +45,7 @@ describe("createVoiceAgentProviderProcessor", () => {
           {
             functionDeclarations: [
               {
-                name: "ask_agent",
+                name: "messageAgent",
               },
             ],
           },
@@ -60,7 +60,7 @@ describe("createVoiceAgentProviderProcessor", () => {
       toolCall: {
         functionCalls: [
           {
-            name: "ask_agent",
+            name: "messageAgent",
             id: "call_123",
             args: { message: "Please inspect the failing tests." },
           },
@@ -73,7 +73,7 @@ describe("createVoiceAgentProviderProcessor", () => {
       expect.arrayContaining([
         expect.objectContaining({
           type: AGENT_INPUT_ADDED_EVENT_TYPE,
-          idempotencyKey: expect.stringContaining("gemini-live:ask-agent:call_123:agent-input"),
+          idempotencyKey: expect.stringContaining("gemini-live:message-agent:call_123:agent-input"),
           payload: {
             content: "Please inspect the failing tests.",
             llmRequestPolicy: { behaviour: "after-current-request" },
@@ -88,7 +88,7 @@ describe("createVoiceAgentProviderProcessor", () => {
             functionResponses: [
               expect.objectContaining({
                 id: "call_123",
-                name: "ask_agent",
+                name: "messageAgent",
               }),
             ],
           },
@@ -125,7 +125,7 @@ describe("createVoiceAgentProviderProcessor", () => {
           tools: [
             {
               type: "function",
-              name: "ask_agent",
+              name: "messageAgent",
             },
           ],
         },
@@ -141,7 +141,7 @@ describe("createVoiceAgentProviderProcessor", () => {
           output: [
             {
               type: "function_call",
-              name: "ask_agent",
+              name: "messageAgent",
               call_id: "call_123",
               arguments: JSON.stringify({ message: "Please inspect the failing tests." }),
             },
@@ -154,7 +154,9 @@ describe("createVoiceAgentProviderProcessor", () => {
         expect.arrayContaining([
           expect.objectContaining({
             type: AGENT_INPUT_ADDED_EVENT_TYPE,
-            idempotencyKey: expect.stringContaining(`${provider}:ask-agent:call_123:agent-input`),
+            idempotencyKey: expect.stringContaining(
+              `${provider}:message-agent:call_123:agent-input`,
+            ),
             payload: {
               content: "Please inspect the failing tests.",
               llmRequestPolicy: { behaviour: "after-current-request" },

--- a/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
@@ -213,7 +213,7 @@ describe("createVoiceAgentProviderProcessor", () => {
       expect(providerText).toContain("BACKGROUND AGENT RESULT FOR THE CALLER:");
       expect(providerText).toContain("The weather is 18C and cloudy.");
       expect(providerText).toContain("This message is not from the caller.");
-      expect(providerText).toContain("Do not thank the caller for this update.");
+      expect(providerText).toContain("Do not say thanks, thank you");
     },
   );
 });

--- a/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
@@ -322,7 +322,7 @@ function committedEvent<const Type extends string, Payload>(
     metadata: input.metadata,
     offset,
     payload: input.payload,
-    streamPath: "/voice-agents/test",
+    streamPath: "/agents/voice/test",
     type: input.type,
   };
 }

--- a/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
@@ -2,28 +2,29 @@ import { describe, expect, it } from "vitest";
 import type { ProcessorStreamApi, StreamEvent, StreamEventInput } from "../stream-processor.ts";
 import {
   AGENT_INPUT_ADDED_EVENT_TYPE,
+  DEFAULT_GEMINI_LIVE_MODEL,
+  DEFAULT_GEMINI_LIVE_VOICE,
   DEFAULT_GROK_REALTIME_MODEL,
   DEFAULT_GROK_REALTIME_VOICE,
+  DEFAULT_OPENAI_REALTIME_MODEL,
+  DEFAULT_OPENAI_REALTIME_VOICE,
   VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_PROVIDER_GEMINI_LIVE,
   VOICE_AGENT_PROVIDER_GROK_REALTIME,
+  VOICE_AGENT_PROVIDER_OPENAI_REALTIME,
   VoiceAgentProcessorContract,
+  type VoiceAgentProvider,
   type VoiceAgentState,
 } from "./contract.ts";
 import { createVoiceAgentProviderProcessor } from "./implementation.ts";
 
 describe("createVoiceAgentProviderProcessor", () => {
-  it("lets Grok ask the colocated code agent through a realtime tool call", async () => {
+  it("lets Gemini ask the colocated code agent through a Live API tool call", async () => {
     const socket = new FakeWebSocket();
     const appended: StreamEventInput[] = [];
-    const processor = createVoiceAgentProviderProcessor({
-      geminiApiKey: "",
-      openAiApiKey: "",
-      openGrokRealtimeWebSocket: async () => socket as unknown as WebSocket,
-      openOpenAiRealtimeWebSocket: undefined,
-      openGeminiLiveWebSocket: undefined,
-      processorSlug: "voice-agent/grok-realtime",
-      provider: VOICE_AGENT_PROVIDER_GROK_REALTIME,
-      xAiApiKey: "xai_test",
+    const processor = providerProcessor({
+      provider: VOICE_AGENT_PROVIDER_GEMINI_LIVE,
+      socket,
     });
 
     const afterAppend = processor.implementation.afterAppend?.({
@@ -31,38 +32,37 @@ describe("createVoiceAgentProviderProcessor", () => {
         type: VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
         payload: { text: "Ask the agent to check the repo." },
       }),
-      previousState: voiceAgentState(),
-      state: voiceAgentState(),
+      previousState: voiceAgentState(VOICE_AGENT_PROVIDER_GEMINI_LIVE),
+      state: voiceAgentState(VOICE_AGENT_PROVIDER_GEMINI_LIVE),
       streamApi: testStreamApi(appended),
       signal: new AbortController().signal,
     });
 
     await waitFor(() => socket.sent.length === 1);
     expect(socket.sent[0]).toMatchObject({
-      type: "session.update",
-      session: {
+      setup: {
         tools: [
           {
-            type: "function",
-            name: "ask_agent",
+            functionDeclarations: [
+              {
+                name: "ask_agent",
+              },
+            ],
           },
         ],
       },
     });
 
-    socket.receive({ type: "session.updated" });
+    socket.receive({ setupComplete: {} });
     await afterAppend;
 
     socket.receive({
-      type: "response.done",
-      response: {
-        status: "completed",
-        output: [
+      toolCall: {
+        functionCalls: [
           {
-            type: "function_call",
             name: "ask_agent",
-            call_id: "call_123",
-            arguments: JSON.stringify({ message: "Please inspect the failing tests." }),
+            id: "call_123",
+            args: { message: "Please inspect the failing tests." },
           },
         ],
       },
@@ -73,7 +73,7 @@ describe("createVoiceAgentProviderProcessor", () => {
       expect.arrayContaining([
         expect.objectContaining({
           type: AGENT_INPUT_ADDED_EVENT_TYPE,
-          idempotencyKey: expect.stringContaining("grok-ask-agent:call_123:agent-input"),
+          idempotencyKey: expect.stringContaining("gemini-live:ask-agent:call_123:agent-input"),
           payload: {
             content: "Please inspect the failing tests.",
             llmRequestPolicy: { behaviour: "after-current-request" },
@@ -84,27 +84,152 @@ describe("createVoiceAgentProviderProcessor", () => {
     expect(socket.sent).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          type: "conversation.item.create",
-          item: expect.objectContaining({
-            type: "function_call_output",
-            call_id: "call_123",
-          }),
+          toolResponse: {
+            functionResponses: [
+              expect.objectContaining({
+                id: "call_123",
+                name: "ask_agent",
+              }),
+            ],
+          },
         }),
-        { type: "response.create" },
       ]),
     );
   });
+
+  it.each([
+    { label: "OpenAI", provider: VOICE_AGENT_PROVIDER_OPENAI_REALTIME },
+    { label: "Grok", provider: VOICE_AGENT_PROVIDER_GROK_REALTIME },
+  ] satisfies Array<{ label: string; provider: VoiceAgentProvider }>)(
+    "lets $label ask the colocated code agent through a realtime function call",
+    async ({ provider }) => {
+      const socket = new FakeWebSocket();
+      const appended: StreamEventInput[] = [];
+      const processor = providerProcessor({ provider, socket });
+
+      const afterAppend = processor.implementation.afterAppend?.({
+        event: committedEvent({
+          type: VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
+          payload: { text: "Ask the agent to check the repo." },
+        }),
+        previousState: voiceAgentState(provider),
+        state: voiceAgentState(provider),
+        streamApi: testStreamApi(appended),
+        signal: new AbortController().signal,
+      });
+
+      await waitFor(() => socket.sent.length === 1);
+      expect(socket.sent[0]).toMatchObject({
+        type: "session.update",
+        session: {
+          tools: [
+            {
+              type: "function",
+              name: "ask_agent",
+            },
+          ],
+        },
+      });
+
+      socket.receive({ type: "session.updated" });
+      await afterAppend;
+
+      socket.receive({
+        type: "response.done",
+        response: {
+          status: "completed",
+          output: [
+            {
+              type: "function_call",
+              name: "ask_agent",
+              call_id: "call_123",
+              arguments: JSON.stringify({ message: "Please inspect the failing tests." }),
+            },
+          ],
+        },
+      });
+
+      await waitFor(() => appended.some((event) => event.type === AGENT_INPUT_ADDED_EVENT_TYPE));
+      expect(appended).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: AGENT_INPUT_ADDED_EVENT_TYPE,
+            idempotencyKey: expect.stringContaining(`${provider}:ask-agent:call_123:agent-input`),
+            payload: {
+              content: "Please inspect the failing tests.",
+              llmRequestPolicy: { behaviour: "after-current-request" },
+            },
+          }),
+        ]),
+      );
+      expect(socket.sent).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "conversation.item.create",
+            item: expect.objectContaining({
+              type: "function_call_output",
+              call_id: "call_123",
+            }),
+          }),
+          { type: "response.create" },
+        ]),
+      );
+    },
+  );
 });
 
-function voiceAgentState(): VoiceAgentState {
+function providerProcessor(input: { provider: VoiceAgentProvider; socket: FakeWebSocket }) {
+  return createVoiceAgentProviderProcessor({
+    geminiApiKey: "gemini_test",
+    openAiApiKey: "openai_test",
+    openGeminiLiveWebSocket:
+      input.provider === VOICE_AGENT_PROVIDER_GEMINI_LIVE
+        ? async () => input.socket as unknown as WebSocket
+        : undefined,
+    openGrokRealtimeWebSocket:
+      input.provider === VOICE_AGENT_PROVIDER_GROK_REALTIME
+        ? async () => input.socket as unknown as WebSocket
+        : undefined,
+    openOpenAiRealtimeWebSocket:
+      input.provider === VOICE_AGENT_PROVIDER_OPENAI_REALTIME
+        ? async () => input.socket as unknown as WebSocket
+        : undefined,
+    processorSlug: `voice-agent/${input.provider}`,
+    provider: input.provider,
+    xAiApiKey: "xai_test",
+  });
+}
+
+function voiceAgentState(provider: VoiceAgentProvider): VoiceAgentState {
+  const providerDefaults = providerConfigDefaults(provider);
   return VoiceAgentProcessorContract.stateSchema.parse({
     setup: {
-      provider: VOICE_AGENT_PROVIDER_GROK_REALTIME,
-      model: DEFAULT_GROK_REALTIME_MODEL,
-      voiceName: DEFAULT_GROK_REALTIME_VOICE,
+      provider,
+      model: providerDefaults.model,
+      voiceName: providerDefaults.voiceName,
       systemInstruction: "You are concise.",
     },
   });
+}
+
+function providerConfigDefaults(provider: VoiceAgentProvider) {
+  switch (provider) {
+    case VOICE_AGENT_PROVIDER_GEMINI_LIVE:
+      return {
+        model: DEFAULT_GEMINI_LIVE_MODEL,
+        voiceName: DEFAULT_GEMINI_LIVE_VOICE,
+      };
+    case VOICE_AGENT_PROVIDER_OPENAI_REALTIME:
+      return {
+        model: DEFAULT_OPENAI_REALTIME_MODEL,
+        voiceName: DEFAULT_OPENAI_REALTIME_VOICE,
+      };
+    case VOICE_AGENT_PROVIDER_GROK_REALTIME:
+      return {
+        model: DEFAULT_GROK_REALTIME_MODEL,
+        voiceName: DEFAULT_GROK_REALTIME_VOICE,
+      };
+  }
 }
 
 function testStreamApi(

--- a/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import type { ProcessorStreamApi, StreamEvent, StreamEventInput } from "../stream-processor.ts";
+import {
+  AGENT_INPUT_ADDED_EVENT_TYPE,
+  DEFAULT_GROK_REALTIME_MODEL,
+  DEFAULT_GROK_REALTIME_VOICE,
+  VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_PROVIDER_GROK_REALTIME,
+  VoiceAgentProcessorContract,
+  type VoiceAgentState,
+} from "./contract.ts";
+import { createVoiceAgentProviderProcessor } from "./implementation.ts";
+
+describe("createVoiceAgentProviderProcessor", () => {
+  it("lets Grok ask the colocated code agent through a realtime tool call", async () => {
+    const socket = new FakeWebSocket();
+    const appended: StreamEventInput[] = [];
+    const processor = createVoiceAgentProviderProcessor({
+      geminiApiKey: "",
+      openAiApiKey: "",
+      openGrokRealtimeWebSocket: async () => socket as unknown as WebSocket,
+      openOpenAiRealtimeWebSocket: undefined,
+      openGeminiLiveWebSocket: undefined,
+      processorSlug: "voice-agent/grok-realtime",
+      provider: VOICE_AGENT_PROVIDER_GROK_REALTIME,
+      xAiApiKey: "xai_test",
+    });
+
+    const afterAppend = processor.implementation.afterAppend?.({
+      event: committedEvent({
+        type: VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
+        payload: { text: "Ask the agent to check the repo." },
+      }),
+      previousState: voiceAgentState(),
+      state: voiceAgentState(),
+      streamApi: testStreamApi(appended),
+      signal: new AbortController().signal,
+    });
+
+    await waitFor(() => socket.sent.length === 1);
+    expect(socket.sent[0]).toMatchObject({
+      type: "session.update",
+      session: {
+        tools: [
+          {
+            type: "function",
+            name: "ask_agent",
+          },
+        ],
+      },
+    });
+
+    socket.receive({ type: "session.updated" });
+    await afterAppend;
+
+    socket.receive({
+      type: "response.done",
+      response: {
+        status: "completed",
+        output: [
+          {
+            type: "function_call",
+            name: "ask_agent",
+            call_id: "call_123",
+            arguments: JSON.stringify({ message: "Please inspect the failing tests." }),
+          },
+        ],
+      },
+    });
+
+    await waitFor(() => appended.some((event) => event.type === AGENT_INPUT_ADDED_EVENT_TYPE));
+    expect(appended).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: AGENT_INPUT_ADDED_EVENT_TYPE,
+          idempotencyKey: expect.stringContaining("grok-ask-agent:call_123:agent-input"),
+          payload: {
+            content: "Please inspect the failing tests.",
+            llmRequestPolicy: { behaviour: "after-current-request" },
+          },
+        }),
+      ]),
+    );
+    expect(socket.sent).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "conversation.item.create",
+          item: expect.objectContaining({
+            type: "function_call_output",
+            call_id: "call_123",
+          }),
+        }),
+        { type: "response.create" },
+      ]),
+    );
+  });
+});
+
+function voiceAgentState(): VoiceAgentState {
+  return VoiceAgentProcessorContract.stateSchema.parse({
+    setup: {
+      provider: VOICE_AGENT_PROVIDER_GROK_REALTIME,
+      model: DEFAULT_GROK_REALTIME_MODEL,
+      voiceName: DEFAULT_GROK_REALTIME_VOICE,
+      systemInstruction: "You are concise.",
+    },
+  });
+}
+
+function testStreamApi(
+  appended: StreamEventInput[],
+): ProcessorStreamApi<typeof VoiceAgentProcessorContract> {
+  return {
+    append: async ({ event }) => {
+      appended.push(event);
+      return committedEvent(event as StreamEventInput);
+    },
+    appendBatch: async ({ events }) => {
+      const committed: StreamEvent[] = [];
+      for (const event of events) {
+        appended.push(event);
+        committed.push(committedEvent(event as StreamEventInput));
+      }
+      return committed;
+    },
+    read: async () => [],
+    subscribe: async function* () {},
+  } as ProcessorStreamApi<typeof VoiceAgentProcessorContract>;
+}
+
+function committedEvent<const Type extends string, Payload>(
+  input: StreamEventInput<Type, Payload>,
+  offset = 1,
+): StreamEvent<Type, Payload> {
+  return {
+    createdAt: "2026-05-19T00:00:00.000Z",
+    idempotencyKey: input.idempotencyKey,
+    metadata: input.metadata,
+    offset,
+    payload: input.payload,
+    streamPath: "/voice-agents/test",
+    type: input.type,
+  };
+}
+
+async function waitFor(predicate: () => boolean) {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error("Timed out waiting for condition.");
+}
+
+class FakeWebSocket {
+  readonly sent: unknown[] = [];
+  readyState = 1;
+  #listeners = new Map<string, EventListener[]>();
+
+  send(data: string) {
+    this.sent.push(JSON.parse(data));
+  }
+
+  close() {
+    this.readyState = 3;
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.#listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.#listeners.set(type, listeners);
+  }
+
+  receive(message: unknown) {
+    for (const listener of this.#listeners.get("message") ?? []) {
+      listener({ data: JSON.stringify(message) } as MessageEvent);
+    }
+  }
+}

--- a/packages/shared/src/stream-processors/voice-agent/implementation.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.ts
@@ -623,6 +623,9 @@ async function openGeminiLiveConnection(args: {
         parts: [{ text: systemInstructionWithMessageAgent(args.setup.systemInstruction) }],
       },
       tools: [geminiMessageAgentTool()],
+      ...(args.setup.messageAgentToolChoice === "required"
+        ? { toolConfig: geminiRequiredMessageAgentToolConfig() }
+        : {}),
     },
   } satisfies JsonValue;
   const sequence = connection.sendSequence++;
@@ -1237,6 +1240,15 @@ function geminiMessageAgentTool() {
         parameters: messageAgentParameters(),
       },
     ],
+  } satisfies JsonValue;
+}
+
+function geminiRequiredMessageAgentToolConfig() {
+  return {
+    functionCallingConfig: {
+      mode: "ANY",
+      allowedFunctionNames: ["messageAgent"],
+    },
   } satisfies JsonValue;
 }
 

--- a/packages/shared/src/stream-processors/voice-agent/implementation.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.ts
@@ -541,11 +541,13 @@ function providerInputText(
 ) {
   if (event.payload.source !== "code-agent") return event.payload.text;
   return [
-    "BACKGROUND AGENT RESULT FOR THE CALLER:",
+    "BACKGROUND AGENT MESSAGE TO RELAY TO THE CALLER:",
     event.payload.text,
     "",
-    "This message is not from the caller. It is the result from the background code-capable agent you asked for help.",
-    "Tell the caller the answer directly and naturally now.",
+    "This message is not from the caller. It is from the background code-capable agent you asked for help.",
+    "Your job is to relay this message to the caller in natural speech.",
+    "If the background agent's message is a question, ask that question to the caller. Do not answer the question yourself.",
+    "If the background agent's message is an answer or update, tell the caller that answer or update directly.",
     "Do not say thanks, thank you, thanks for the update, or any other gratitude/acknowledgement phrase.",
     "Do not say the caller told you this. Do not describe the background agent as if it is another participant in the call.",
   ].join("\n");
@@ -1190,7 +1192,7 @@ async function sendOpenAiCompatibleFunctionCallOutput(args: {
 function systemInstructionWithMessageAgent(systemInstruction: string) {
   return [
     systemInstruction,
-    "You have a tool named Message Agent. Use it when the caller asks for actions, investigation, code, data lookup, or anything requiring tools. Message Agent sends the request to a code-capable background agent. After calling it, tell the caller you asked the agent and continue the conversation while it works.",
+    "You have a tool named Message Agent. Use it when the caller asks for actions, investigation, code, data lookup, or anything requiring tools. Message Agent sends the request to a code-capable background agent. After calling it, tell the caller you asked the agent and continue the conversation while it works. When the background agent replies, relay its message to the caller; if it replies with a question, ask that question to the caller rather than answering it yourself.",
   ].join("\n\n");
 }
 

--- a/packages/shared/src/stream-processors/voice-agent/implementation.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.ts
@@ -541,13 +541,13 @@ function providerInputText(
 ) {
   if (event.payload.source !== "code-agent") return event.payload.text;
   return [
-    "BACKGROUND AGENT MESSAGE TO RELAY TO THE CALLER:",
+    "BACKGROUND AGENT MESSAGE TO RELAY TO THE HUMAN YOU ARE SPEAKING TO:",
     event.payload.text,
     "",
     "This message is not from the caller. It is from the background code-capable agent you asked for help.",
-    "Your job is to relay this message to the caller in natural speech.",
-    "If the background agent's message is a question, ask that question to the caller. Do not answer the question yourself.",
-    "If the background agent's message is an answer or update, tell the caller that answer or update directly.",
+    "Your job is to relay this message to the human you are speaking to in natural speech.",
+    "If the background agent's message is a question, ask that question to the human you are speaking to. Do not answer the question yourself.",
+    "If the background agent's message is an answer or update, tell the human you are speaking to that answer or update directly.",
     "Do not say thanks, thank you, thanks for the update, or any other gratitude/acknowledgement phrase.",
     "Do not say the caller told you this. Do not describe the background agent as if it is another participant in the call.",
   ].join("\n");
@@ -1192,7 +1192,7 @@ async function sendOpenAiCompatibleFunctionCallOutput(args: {
 function systemInstructionWithMessageAgent(systemInstruction: string) {
   return [
     systemInstruction,
-    "You have a tool named Message Agent. Use it when the caller asks for actions, investigation, code, data lookup, or anything requiring tools. Message Agent sends the request to a code-capable background agent. After calling it, tell the caller you asked the agent and continue the conversation while it works. When the background agent replies, relay its message to the caller; if it replies with a question, ask that question to the caller rather than answering it yourself.",
+    "You are speaking directly with a human. In these instructions, 'the caller' means the human you are speaking to. You have a tool named Message Agent. Use it when the caller asks for actions, investigation, code, data lookup, or anything requiring tools. Message Agent sends the request to a code-capable background agent. After calling it, tell the caller you asked the agent and continue the conversation while it works. When the background agent replies, relay its message to the caller; if it replies with a question, ask that question to the caller rather than answering it yourself.",
   ].join("\n\n");
 }
 

--- a/packages/shared/src/stream-processors/voice-agent/implementation.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.ts
@@ -63,7 +63,19 @@ type GeminiServerMessage = {
     inputTranscription?: { text?: string };
     outputTranscription?: { text?: string };
   };
+  toolCall?: {
+    functionCalls?: GeminiFunctionCall[];
+  };
+  toolCallCancellation?: {
+    ids?: string[];
+  };
   goAway?: { timeLeft?: string };
+};
+
+type GeminiFunctionCall = {
+  id?: string;
+  name?: string;
+  args?: unknown;
 };
 
 type RealtimeServerMessage = {
@@ -588,8 +600,9 @@ async function openGeminiLiveConnection(args: {
       inputAudioTranscription: {},
       outputAudioTranscription: {},
       systemInstruction: {
-        parts: [{ text: args.setup.systemInstruction }],
+        parts: [{ text: systemInstructionWithAskAgent(args.setup.systemInstruction) }],
       },
+      tools: [geminiAskAgentTool()],
     },
   } satisfies JsonValue;
   const sequence = connection.sendSequence++;
@@ -625,6 +638,14 @@ async function handleGeminiMessage(args: ProviderConnectionArgs & { data: unknow
         idempotencyKey: `voice-agent:${args.connection.id}:gemini-live-setup-completed`,
         payload: { connectionId: args.connection.id },
       },
+    });
+  }
+
+  for (const functionCall of message.toolCall?.functionCalls ?? []) {
+    await handleGeminiFunctionCall({
+      connection: args.connection,
+      functionCall,
+      streamApi: args.streamApi,
     });
   }
 
@@ -724,7 +745,7 @@ async function openOpenAiRealtimeConnection(args: {
     type: "session.update",
     session: {
       type: "realtime",
-      instructions: args.setup.systemInstruction,
+      instructions: systemInstructionWithAskAgent(args.setup.systemInstruction),
       audio: {
         input: {
           format: { type: "audio/pcm", rate: 24_000 },
@@ -740,6 +761,8 @@ async function openOpenAiRealtimeConnection(args: {
           voice: args.setup.voiceName,
         },
       },
+      tools: [openAiCompatibleAskAgentTool()],
+      tool_choice: openAiCompatibleAskAgentToolChoice(args.setup.askAgentToolChoice),
     },
   } satisfies JsonValue;
   const sequence = connection.sendSequence++;
@@ -801,37 +824,15 @@ async function openGrokRealtimeConnection(args: {
   const setupMessage = {
     type: "session.update",
     session: {
-      instructions: [
-        args.setup.systemInstruction,
-        "You have a tool named Ask Agent. Use it when the caller asks for actions, investigation, code, data lookup, or anything requiring tools. Ask Agent sends the request to a code-capable background agent. After calling it, tell the caller you asked the agent and continue the conversation while it works.",
-      ].join("\n\n"),
+      instructions: systemInstructionWithAskAgent(args.setup.systemInstruction),
       voice: args.setup.voiceName,
       turn_detection: { type: "server_vad" },
       audio: {
         input: { format: { type: "audio/pcm", rate: 16_000 } },
         output: { format: { type: "audio/pcm", rate: VOICE_AGENT_OUTPUT_SAMPLE_RATE } },
       },
-      tools: [
-        {
-          type: "function",
-          name: "ask_agent",
-          description:
-            "Ask the code-capable background agent to do work or answer a question. Use for actions, investigation, code, data lookup, or anything requiring tools.",
-          parameters: {
-            type: "object",
-            additionalProperties: false,
-            properties: {
-              message: {
-                type: "string",
-                description:
-                  "The plain-language request for the background code agent. Include relevant context from the call.",
-              },
-            },
-            required: ["message"],
-          },
-        },
-      ],
-      tool_choice: "auto",
+      tools: [openAiCompatibleAskAgentTool()],
+      tool_choice: openAiCompatibleAskAgentToolChoice(args.setup.askAgentToolChoice),
     },
   } satisfies JsonValue;
   const sequence = connection.sendSequence++;
@@ -947,13 +948,11 @@ async function handleOpenAiCompatibleRealtimeMessage(
       });
       return;
     case "response.output_item.done":
-      if (args.eventPrefix === "grok-realtime") {
-        await handleGrokFunctionCallItem({
-          connection: args.connection,
-          item: message.item,
-          streamApi: args.streamApi,
-        });
-      }
+      await handleOpenAiCompatibleFunctionCallItem({
+        connection: args.connection,
+        item: message.item,
+        streamApi: args.streamApi,
+      });
       return;
     case "response.done":
       await appendProviderStatusEvent({
@@ -962,14 +961,12 @@ async function handleOpenAiCompatibleRealtimeMessage(
         sequence,
         streamApi: args.streamApi,
       });
-      if (args.eventPrefix === "grok-realtime") {
-        for (const item of message.response?.output ?? []) {
-          await handleGrokFunctionCallItem({
-            connection: args.connection,
-            item,
-            streamApi: args.streamApi,
-          });
-        }
+      for (const item of message.response?.output ?? []) {
+        await handleOpenAiCompatibleFunctionCallItem({
+          connection: args.connection,
+          item,
+          streamApi: args.streamApi,
+        });
       }
       return;
     case "error":
@@ -981,7 +978,39 @@ async function handleOpenAiCompatibleRealtimeMessage(
   }
 }
 
-async function handleGrokFunctionCallItem(args: {
+async function handleGeminiFunctionCall(args: {
+  connection: ProviderConnection;
+  functionCall: GeminiFunctionCall;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  const callId = args.functionCall.id;
+  if (callId == null || callId.trim() === "") return;
+  if (args.connection.handledToolCallIds.has(callId)) return;
+  args.connection.handledToolCallIds.add(callId);
+
+  const toolResult =
+    args.functionCall.name === "ask_agent"
+      ? await appendAskAgentInput({
+          argumentsValue: args.functionCall.args,
+          callId,
+          connection: args.connection,
+          streamApi: args.streamApi,
+        })
+      : {
+          ok: false,
+          message: `Unknown tool: ${args.functionCall.name ?? "<missing>"}`,
+        };
+
+  await sendGeminiFunctionResponse({
+    callId,
+    connection: args.connection,
+    name: args.functionCall.name ?? "unknown_tool",
+    output: toolResult,
+    streamApi: args.streamApi,
+  });
+}
+
+async function handleOpenAiCompatibleFunctionCallItem(args: {
   connection: ProviderConnection;
   item: RealtimeFunctionCallItem | undefined;
   streamApi: VoiceAgentStreamApi;
@@ -995,7 +1024,7 @@ async function handleGrokFunctionCallItem(args: {
   const toolResult =
     args.item.name === "ask_agent"
       ? await appendAskAgentInput({
-          argumentsJson: args.item.arguments,
+          argumentsValue: args.item.arguments,
           callId,
           connection: args.connection,
           streamApi: args.streamApi,
@@ -1015,18 +1044,18 @@ async function handleGrokFunctionCallItem(args: {
 }
 
 async function appendAskAgentInput(args: {
-  argumentsJson: string | undefined;
+  argumentsValue: unknown;
   callId: string;
   connection: ProviderConnection;
   streamApi: VoiceAgentStreamApi;
 }) {
-  const parsed = parseAskAgentArguments(args.argumentsJson);
+  const parsed = parseAskAgentArguments(args.argumentsValue);
   if (!parsed.ok) return parsed;
 
   await args.streamApi.append({
     event: {
       type: AGENT_INPUT_ADDED_EVENT_TYPE,
-      idempotencyKey: `voice-agent:${args.connection.id}:grok-ask-agent:${args.callId}:agent-input`,
+      idempotencyKey: `voice-agent:${args.connection.id}:${args.connection.provider}:ask-agent:${args.callId}:agent-input`,
       payload: {
         content: parsed.message,
         llmRequestPolicy: { behaviour: "after-current-request" },
@@ -1042,17 +1071,22 @@ async function appendAskAgentInput(args: {
 }
 
 function parseAskAgentArguments(
-  argumentsJson: string | undefined,
+  argumentsValue: unknown,
 ): { ok: true; message: string } | { ok: false; message: string } {
-  if (argumentsJson == null || argumentsJson.trim() === "") {
+  if (argumentsValue == null) {
     return { ok: false, message: "ask_agent requires a JSON arguments object." };
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(argumentsJson);
-  } catch {
-    return { ok: false, message: "ask_agent arguments must be valid JSON." };
+  let parsed = argumentsValue;
+  if (typeof argumentsValue === "string") {
+    if (argumentsValue.trim() === "") {
+      return { ok: false, message: "ask_agent requires a JSON arguments object." };
+    }
+    try {
+      parsed = JSON.parse(argumentsValue);
+    } catch {
+      return { ok: false, message: "ask_agent arguments must be valid JSON." };
+    }
   }
 
   const message = (parsed as { message?: unknown }).message;
@@ -1060,6 +1094,37 @@ function parseAskAgentArguments(
     return { ok: false, message: "ask_agent requires a non-empty message string." };
   }
   return { ok: true, message: message.trim() };
+}
+
+async function sendGeminiFunctionResponse(args: {
+  callId: string;
+  connection: ProviderConnection;
+  name: string;
+  output: JsonValue;
+  sequenceSourceEventOffset?: number;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  const sequence = args.connection.sendSequence++;
+  const message = {
+    toolResponse: {
+      functionResponses: [
+        {
+          id: args.callId,
+          name: args.name,
+          response: args.output,
+        },
+      ],
+    },
+  } satisfies JsonValue;
+  args.connection.socket.send(JSON.stringify(message));
+  await appendProviderMessageSent({
+    connection: args.connection,
+    eventType: providerMessageSentEventType(args.connection.provider),
+    message,
+    sequence,
+    sourceEventOffset: args.sequenceSourceEventOffset,
+    streamApi: args.streamApi,
+  });
 }
 
 async function sendOpenAiCompatibleFunctionCallOutput(args: {
@@ -1089,7 +1154,10 @@ async function sendOpenAiCompatibleFunctionCallOutput(args: {
   });
 
   const responseSequence = args.connection.sendSequence++;
-  const responseMessage = { type: "response.create" } satisfies JsonValue;
+  const responseMessage = {
+    type: "response.create",
+    response: { tool_choice: "none" },
+  } satisfies JsonValue;
   args.connection.socket.send(JSON.stringify(responseMessage));
   await appendProviderMessageSent({
     connection: args.connection,
@@ -1099,6 +1167,57 @@ async function sendOpenAiCompatibleFunctionCallOutput(args: {
     sourceEventOffset: args.sequenceSourceEventOffset,
     streamApi: args.streamApi,
   });
+}
+
+function systemInstructionWithAskAgent(systemInstruction: string) {
+  return [
+    systemInstruction,
+    "You have a tool named Ask Agent. Use it when the caller asks for actions, investigation, code, data lookup, or anything requiring tools. Ask Agent sends the request to a code-capable background agent. After calling it, tell the caller you asked the agent and continue the conversation while it works.",
+  ].join("\n\n");
+}
+
+function askAgentParameters(input: { additionalProperties?: boolean } = {}) {
+  return {
+    type: "object",
+    ...(input.additionalProperties == null
+      ? {}
+      : { additionalProperties: input.additionalProperties }),
+    properties: {
+      message: {
+        type: "string",
+        description:
+          "The plain-language request for the background code agent. Include relevant context from the call.",
+      },
+    },
+    required: ["message"],
+  } satisfies JsonValue;
+}
+
+function openAiCompatibleAskAgentTool() {
+  return {
+    type: "function",
+    name: "ask_agent",
+    description:
+      "Ask the code-capable background agent to do work or answer a question. Use for actions, investigation, code, data lookup, or anything requiring tools.",
+    parameters: askAgentParameters({ additionalProperties: false }),
+  } satisfies JsonValue;
+}
+
+function openAiCompatibleAskAgentToolChoice(choice: VoiceAgentSetup["askAgentToolChoice"]) {
+  return choice === "required" ? "required" : "auto";
+}
+
+function geminiAskAgentTool() {
+  return {
+    functionDeclarations: [
+      {
+        name: "ask_agent",
+        description:
+          "Ask the code-capable background agent to do work or answer a question. Use for actions, investigation, code, data lookup, or anything requiring tools.",
+        parameters: askAgentParameters(),
+      },
+    ],
+  } satisfies JsonValue;
 }
 
 // Shared provider helpers.

--- a/packages/shared/src/stream-processors/voice-agent/implementation.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.ts
@@ -10,7 +10,9 @@ import { CoreProcessorRegisteredEventType } from "../core/contract.ts";
 import { standardProcessorBehavior } from "../core/standard-processor-behavior.ts";
 import {
   VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
   VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE,
   VOICE_AGENT_OUTPUT_SAMPLE_RATE,
   VOICE_AGENT_PROVIDER_GEMINI_LIVE,
   VOICE_AGENT_PROVIDER_GROK_REALTIME,
@@ -92,23 +94,88 @@ export type VoiceAgentProcessorDeps = {
 
 const ProviderConnectedReadyState = 1;
 
-export function createVoiceAgentProcessor(deps: VoiceAgentProcessorDeps) {
-  let connection: ProviderConnection | null = null;
-  let openingConnection: Promise<ProviderConnection> | null = null;
-  let outputSequence = 0;
-  let lastInputStreamId = "voice-agent";
-
+export function createVoiceAgentProcessor() {
   return implementProcessor(VoiceAgentProcessorContract, {
-    async afterAppend({ event, state, streamApi, waitUntil }) {
+    async afterAppend({ state, streamApi }) {
       await standardProcessorBehavior.afterAppend({
         contract: VoiceAgentProcessorContract,
         state,
         streamApi,
       });
+    },
+  });
+}
+
+export function createVoiceAgentProviderProcessor(
+  input: VoiceAgentProcessorDeps & {
+    processorSlug: string;
+    provider: VoiceAgentProvider;
+  },
+) {
+  return createVoiceAgentRealtimeProcessor({
+    contract: {
+      ...VoiceAgentProcessorContract,
+      slug: input.processorSlug,
+      description: `${providerLabel(input.provider)} realtime voice provider adapter for the canonical voice-agent stream protocol.`,
+    } as typeof VoiceAgentProcessorContract,
+    deps: input,
+    provider: input.provider,
+  });
+}
+
+function createVoiceAgentRealtimeProcessor(args: {
+  contract: typeof VoiceAgentProcessorContract;
+  deps: VoiceAgentProcessorDeps;
+  provider: VoiceAgentProvider;
+}) {
+  let connection: ProviderConnection | null = null;
+  let openingConnection: Promise<ProviderConnection> | null = null;
+  let outputSequence = 0;
+  let lastInputStreamId = "voice-agent";
+
+  return implementProcessor(args.contract, {
+    async afterAppend({ event, state, streamApi, waitUntil }) {
+      await standardProcessorBehavior.afterAppend({
+        contract: args.contract,
+        state,
+        streamApi,
+      });
+
+      const getConnection = async (setup: VoiceAgentSetup) => {
+        if (
+          connection?.provider === setup.provider &&
+          connection.socket.readyState === ProviderConnectedReadyState
+        ) {
+          return connection;
+        }
+
+        if (openingConnection != null) {
+          return await openingConnection;
+        }
+
+        connection?.socket.close(1000, "Voice-agent provider changed.");
+        openingConnection = openProviderConnection({
+          deps: args.deps,
+          setup,
+          streamApi,
+          createOutputSequence: () => outputSequence++,
+          getLastInputStreamId: () => lastInputStreamId,
+          markConnectionClosed: (closedConnection) => {
+            if (connection?.id === closedConnection.id) connection = null;
+          },
+        });
+        try {
+          connection = await openingConnection;
+          return connection;
+        } finally {
+          openingConnection = null;
+        }
+      };
 
       switch (event.type) {
         case CoreProcessorRegisteredEventType:
         case VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE:
+        case VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE:
         case "events.iterate.com/voice-agent/transcription-appended":
         case VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE:
         case "events.iterate.com/voice-agent/error-occurred":
@@ -146,41 +213,29 @@ export function createVoiceAgentProcessor(deps: VoiceAgentProcessorDeps) {
           return;
         case VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE: {
           const task = forwardInputAudioFrame({
-            deps,
+            deps: args.deps,
             event,
-            getConnection: async (setup) => {
-              if (
-                connection?.provider === setup.provider &&
-                connection.socket.readyState === ProviderConnectedReadyState
-              ) {
-                return connection;
-              }
-
-              if (openingConnection != null) {
-                return await openingConnection;
-              }
-
-              connection?.socket.close(1000, "Voice-agent provider changed.");
-              openingConnection = openProviderConnection({
-                deps,
-                setup,
-                streamApi,
-                createOutputSequence: () => outputSequence++,
-                getLastInputStreamId: () => lastInputStreamId,
-                markConnectionClosed: (closedConnection) => {
-                  if (connection?.id === closedConnection.id) connection = null;
-                },
-              });
-              try {
-                connection = await openingConnection;
-                return connection;
-              } finally {
-                openingConnection = null;
-              }
-            },
+            getConnection,
+            provider: args.provider,
             rememberInputStreamId: (streamId) => {
               lastInputStreamId = streamId;
             },
+            state,
+            streamApi,
+          });
+          if (waitUntil == null) {
+            await task;
+          } else {
+            waitUntil(task);
+          }
+          return;
+        }
+        case VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE: {
+          const task = forwardInputText({
+            deps: args.deps,
+            event,
+            getConnection,
+            provider: args.provider,
             state,
             streamApi,
           });
@@ -205,6 +260,7 @@ async function forwardInputAudioFrame(args: {
     { type: typeof VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE }
   >;
   getConnection(setup: VoiceAgentSetup): Promise<ProviderConnection>;
+  provider: VoiceAgentProvider;
   rememberInputStreamId(streamId: string): void;
   state: VoiceAgentState;
   streamApi: VoiceAgentStreamApi;
@@ -218,6 +274,9 @@ async function forwardInputAudioFrame(args: {
       event: args.event,
       streamApi: args.streamApi,
     });
+    return;
+  }
+  if (setup.provider !== args.provider) {
     return;
   }
 
@@ -306,6 +365,131 @@ async function sendInputAudioFrame(args: {
         eventType: providerMessageSentEventType(args.connection.provider),
         message,
         sequence,
+        sourceEventOffset: args.event.offset,
+        streamApi: args.streamApi,
+      });
+      return;
+    }
+    default:
+      return assertNever(args.connection.provider);
+  }
+}
+
+async function forwardInputText(args: {
+  deps: VoiceAgentProcessorDeps;
+  event: Extract<
+    VoiceAgentConsumedEvent,
+    { type: typeof VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE }
+  >;
+  getConnection(setup: VoiceAgentSetup): Promise<ProviderConnection>;
+  provider: VoiceAgentProvider;
+  state: VoiceAgentState;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  const setup = args.state.setup;
+  if (setup == null) {
+    await appendProcessorError({
+      error: new Error(
+        "Voice-agent setup-configured event is required before appending input text.",
+      ),
+      event: args.event,
+      streamApi: args.streamApi,
+    });
+    return;
+  }
+  if (setup.provider !== args.provider) return;
+
+  const missingKeyError = missingApiKeyError({ deps: args.deps, provider: setup.provider });
+  if (missingKeyError != null) {
+    await appendProcessorError({
+      error: new Error(missingKeyError),
+      event: args.event,
+      streamApi: args.streamApi,
+    });
+    return;
+  }
+
+  let connection: ProviderConnection;
+  try {
+    connection = await args.getConnection(setup);
+    await withTimeout(
+      connection.ready,
+      30_000,
+      `Timed out waiting for ${providerLabel(setup.provider)} setup.`,
+    );
+  } catch (error) {
+    await appendProcessorError({
+      error,
+      event: args.event,
+      streamApi: args.streamApi,
+    });
+    return;
+  }
+
+  await sendInputText({
+    connection,
+    event: args.event,
+    streamApi: args.streamApi,
+  });
+}
+
+async function sendInputText(args: {
+  connection: ProviderConnection;
+  event: Extract<
+    VoiceAgentConsumedEvent,
+    { type: typeof VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE }
+  >;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  switch (args.connection.provider) {
+    case VOICE_AGENT_PROVIDER_GEMINI_LIVE: {
+      const sequence = args.connection.sendSequence++;
+      const message = {
+        clientContent: {
+          turns: [{ role: "user", parts: [{ text: args.event.payload.text }] }],
+          turnComplete: true,
+        },
+      } satisfies JsonValue;
+      args.connection.socket.send(JSON.stringify(message));
+      await appendProviderMessageSent({
+        connection: args.connection,
+        eventType: providerMessageSentEventType(args.connection.provider),
+        message,
+        sequence,
+        sourceEventOffset: args.event.offset,
+        streamApi: args.streamApi,
+      });
+      return;
+    }
+    case VOICE_AGENT_PROVIDER_OPENAI_REALTIME:
+    case VOICE_AGENT_PROVIDER_GROK_REALTIME: {
+      const itemSequence = args.connection.sendSequence++;
+      const itemMessage = {
+        type: "conversation.item.create",
+        item: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: args.event.payload.text }],
+        },
+      } satisfies JsonValue;
+      args.connection.socket.send(JSON.stringify(itemMessage));
+      await appendProviderMessageSent({
+        connection: args.connection,
+        eventType: providerMessageSentEventType(args.connection.provider),
+        message: itemMessage,
+        sequence: itemSequence,
+        sourceEventOffset: args.event.offset,
+        streamApi: args.streamApi,
+      });
+
+      const responseSequence = args.connection.sendSequence++;
+      const responseMessage = { type: "response.create" } satisfies JsonValue;
+      args.connection.socket.send(JSON.stringify(responseMessage));
+      await appendProviderMessageSent({
+        connection: args.connection,
+        eventType: providerMessageSentEventType(args.connection.provider),
+        message: responseMessage,
+        sequence: responseSequence,
         sourceEventOffset: args.event.offset,
         streamApi: args.streamApi,
       });
@@ -962,11 +1146,11 @@ async function appendTranscriptionEvents(args: {
   if (args.inputText) {
     await args.streamApi.append({
       event: {
-        type: "events.iterate.com/voice-agent/transcription-appended",
-        idempotencyKey: `voice-agent:${args.connectionId}:input-transcription:${args.sequence}`,
+        type: VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE,
+        idempotencyKey: `voice-agent:${args.connectionId}:input-transcription-output-text:${args.sequence}`,
         payload: {
           connectionId: args.connectionId,
-          direction: "input",
+          source: "input-transcription",
           text: args.inputText,
         },
       },
@@ -975,11 +1159,11 @@ async function appendTranscriptionEvents(args: {
   if (args.outputText) {
     await args.streamApi.append({
       event: {
-        type: "events.iterate.com/voice-agent/transcription-appended",
-        idempotencyKey: `voice-agent:${args.connectionId}:output-transcription:${args.sequence}`,
+        type: VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE,
+        idempotencyKey: `voice-agent:${args.connectionId}:output-transcription-output-text:${args.sequence}`,
         payload: {
           connectionId: args.connectionId,
-          direction: "output",
+          source: "output-transcription",
           text: args.outputText,
         },
       },
@@ -1022,12 +1206,12 @@ async function openFetchWebSocket(input: {
   providerLabel: string;
   url: URL;
 }): Promise<WebSocket> {
-  const response = await fetch(input.url, {
+  const response = (await fetch(input.url, {
     headers: {
       ...input.headers,
       Upgrade: "websocket",
     },
-  });
+  })) as Response & { webSocket?: WebSocket & { accept(): void } };
   if (!response.webSocket) {
     throw new Error(
       `${input.providerLabel} WebSocket upgrade failed with HTTP ${response.status}.`,
@@ -1148,7 +1332,11 @@ async function appendProcessorError(args: {
   error: unknown;
   event: Extract<
     VoiceAgentConsumedEvent,
-    { type: typeof VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE }
+    {
+      type:
+        | typeof VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE
+        | typeof VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE;
+    }
   >;
   streamApi: VoiceAgentStreamApi;
 }) {
@@ -1157,7 +1345,10 @@ async function appendProcessorError(args: {
       type: "events.iterate.com/voice-agent/error-occurred",
       idempotencyKey: buildProcessorIdempotencyKey({
         processor: VoiceAgentProcessorContract,
-        key: "input-audio-frame-forwarding-failed",
+        key:
+          args.event.type === VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE
+            ? "input-audio-frame-forwarding-failed"
+            : "input-text-forwarding-failed",
         sourceEvent: args.event,
       }),
       payload: {

--- a/packages/shared/src/stream-processors/voice-agent/implementation.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.ts
@@ -545,7 +545,9 @@ function providerInputText(
     event.payload.text,
     "",
     "This message is not from the caller. It is the result from the background code-capable agent you asked for help.",
-    "Tell the caller the answer directly and naturally now. Do not thank the caller for this update. Do not say the caller told you this.",
+    "Tell the caller the answer directly and naturally now.",
+    "Do not say thanks, thank you, thanks for the update, or any other gratitude/acknowledgement phrase.",
+    "Do not say the caller told you this. Do not describe the background agent as if it is another participant in the call.",
   ].join("\n");
 }
 

--- a/packages/shared/src/stream-processors/voice-agent/implementation.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.ts
@@ -479,7 +479,7 @@ async function sendInputText(args: {
       const sequence = args.connection.sendSequence++;
       const message = {
         clientContent: {
-          turns: [{ role: "user", parts: [{ text: args.event.payload.text }] }],
+          turns: [{ role: "user", parts: [{ text: providerInputText(args.event) }] }],
           turnComplete: true,
         },
       } satisfies JsonValue;
@@ -502,7 +502,7 @@ async function sendInputText(args: {
         item: {
           type: "message",
           role: "user",
-          content: [{ type: "input_text", text: args.event.payload.text }],
+          content: [{ type: "input_text", text: providerInputText(args.event) }],
         },
       } satisfies JsonValue;
       args.connection.socket.send(JSON.stringify(itemMessage));
@@ -531,6 +531,22 @@ async function sendInputText(args: {
     default:
       return assertNever(args.connection.provider);
   }
+}
+
+function providerInputText(
+  event: Extract<
+    VoiceAgentConsumedEvent,
+    { type: typeof VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE }
+  >,
+) {
+  if (event.payload.source !== "code-agent") return event.payload.text;
+  return [
+    "BACKGROUND AGENT RESULT FOR THE CALLER:",
+    event.payload.text,
+    "",
+    "This message is not from the caller. It is the result from the background code-capable agent you asked for help.",
+    "Tell the caller the answer directly and naturally now. Do not thank the caller for this update. Do not say the caller told you this.",
+  ].join("\n");
 }
 
 async function openProviderConnection(args: {

--- a/packages/shared/src/stream-processors/voice-agent/implementation.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.ts
@@ -9,6 +9,7 @@ import {
 import { CoreProcessorRegisteredEventType } from "../core/contract.ts";
 import { standardProcessorBehavior } from "../core/standard-processor-behavior.ts";
 import {
+  AGENT_INPUT_ADDED_EVENT_TYPE,
   VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
   VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
   VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
@@ -35,6 +36,7 @@ type ProviderConnection = {
   ready: Promise<void>;
   receiveSequence: number;
   sendSequence: number;
+  handledToolCallIds: Set<string>;
   socket: WebSocket;
   urlForLog: string;
 };
@@ -69,7 +71,18 @@ type RealtimeServerMessage = {
   delta?: string;
   transcript?: string;
   error?: { message?: string };
-  response?: { status?: string };
+  item?: RealtimeFunctionCallItem;
+  response?: {
+    output?: RealtimeFunctionCallItem[];
+    status?: string;
+  };
+};
+
+type RealtimeFunctionCallItem = {
+  type?: string;
+  name?: string;
+  call_id?: string;
+  arguments?: string;
 };
 
 type OpenAiCompatibleEventPrefix = "openai-realtime" | "grok-realtime";
@@ -780,13 +793,37 @@ async function openGrokRealtimeConnection(args: {
   const setupMessage = {
     type: "session.update",
     session: {
-      instructions: args.setup.systemInstruction,
+      instructions: [
+        args.setup.systemInstruction,
+        "You have a tool named Ask Agent. Use it when the caller asks for actions, investigation, code, data lookup, or anything requiring tools. Ask Agent sends the request to a code-capable background agent. After calling it, tell the caller you asked the agent and continue the conversation while it works.",
+      ].join("\n\n"),
       voice: args.setup.voiceName,
       turn_detection: { type: "server_vad" },
       audio: {
         input: { format: { type: "audio/pcm", rate: 16_000 } },
         output: { format: { type: "audio/pcm", rate: VOICE_AGENT_OUTPUT_SAMPLE_RATE } },
       },
+      tools: [
+        {
+          type: "function",
+          name: "ask_agent",
+          description:
+            "Ask the code-capable background agent to do work or answer a question. Use for actions, investigation, code, data lookup, or anything requiring tools.",
+          parameters: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              message: {
+                type: "string",
+                description:
+                  "The plain-language request for the background code agent. Include relevant context from the call.",
+              },
+            },
+            required: ["message"],
+          },
+        },
+      ],
+      tool_choice: "auto",
     },
   } satisfies JsonValue;
   const sequence = connection.sendSequence++;
@@ -901,6 +938,15 @@ async function handleOpenAiCompatibleRealtimeMessage(
         streamApi: args.streamApi,
       });
       return;
+    case "response.output_item.done":
+      if (args.eventPrefix === "grok-realtime") {
+        await handleGrokFunctionCallItem({
+          connection: args.connection,
+          item: message.item,
+          streamApi: args.streamApi,
+        });
+      }
+      return;
     case "response.done":
       await appendProviderStatusEvent({
         connection: args.connection,
@@ -908,6 +954,15 @@ async function handleOpenAiCompatibleRealtimeMessage(
         sequence,
         streamApi: args.streamApi,
       });
+      if (args.eventPrefix === "grok-realtime") {
+        for (const item of message.response?.output ?? []) {
+          await handleGrokFunctionCallItem({
+            connection: args.connection,
+            item,
+            streamApi: args.streamApi,
+          });
+        }
+      }
       return;
     case "error":
       throw new Error(
@@ -916,6 +971,126 @@ async function handleOpenAiCompatibleRealtimeMessage(
     default:
       return;
   }
+}
+
+async function handleGrokFunctionCallItem(args: {
+  connection: ProviderConnection;
+  item: RealtimeFunctionCallItem | undefined;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  if (args.item?.type !== "function_call") return;
+  const callId = args.item.call_id;
+  if (callId == null || callId.trim() === "") return;
+  if (args.connection.handledToolCallIds.has(callId)) return;
+  args.connection.handledToolCallIds.add(callId);
+
+  const toolResult =
+    args.item.name === "ask_agent"
+      ? await appendAskAgentInput({
+          argumentsJson: args.item.arguments,
+          callId,
+          connection: args.connection,
+          streamApi: args.streamApi,
+        })
+      : {
+          ok: false,
+          message: `Unknown tool: ${args.item.name ?? "<missing>"}`,
+        };
+
+  await sendOpenAiCompatibleFunctionCallOutput({
+    callId,
+    connection: args.connection,
+    output: toolResult,
+    sequenceSourceEventOffset: undefined,
+    streamApi: args.streamApi,
+  });
+}
+
+async function appendAskAgentInput(args: {
+  argumentsJson: string | undefined;
+  callId: string;
+  connection: ProviderConnection;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  const parsed = parseAskAgentArguments(args.argumentsJson);
+  if (!parsed.ok) return parsed;
+
+  await args.streamApi.append({
+    event: {
+      type: AGENT_INPUT_ADDED_EVENT_TYPE,
+      idempotencyKey: `voice-agent:${args.connection.id}:grok-ask-agent:${args.callId}:agent-input`,
+      payload: {
+        content: parsed.message,
+        llmRequestPolicy: { behaviour: "after-current-request" },
+      },
+    },
+  });
+
+  return {
+    ok: true,
+    message:
+      "Asked the code-capable background agent. Continue the call while it works; it will respond back into the voice stream when ready.",
+  };
+}
+
+function parseAskAgentArguments(
+  argumentsJson: string | undefined,
+): { ok: true; message: string } | { ok: false; message: string } {
+  if (argumentsJson == null || argumentsJson.trim() === "") {
+    return { ok: false, message: "ask_agent requires a JSON arguments object." };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(argumentsJson);
+  } catch {
+    return { ok: false, message: "ask_agent arguments must be valid JSON." };
+  }
+
+  const message = (parsed as { message?: unknown }).message;
+  if (typeof message !== "string" || message.trim() === "") {
+    return { ok: false, message: "ask_agent requires a non-empty message string." };
+  }
+  return { ok: true, message: message.trim() };
+}
+
+async function sendOpenAiCompatibleFunctionCallOutput(args: {
+  callId: string;
+  connection: ProviderConnection;
+  output: JsonValue;
+  sequenceSourceEventOffset?: number;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  const itemSequence = args.connection.sendSequence++;
+  const itemMessage = {
+    type: "conversation.item.create",
+    item: {
+      type: "function_call_output",
+      call_id: args.callId,
+      output: JSON.stringify(args.output),
+    },
+  } satisfies JsonValue;
+  args.connection.socket.send(JSON.stringify(itemMessage));
+  await appendProviderMessageSent({
+    connection: args.connection,
+    eventType: providerMessageSentEventType(args.connection.provider),
+    message: itemMessage,
+    sequence: itemSequence,
+    sourceEventOffset: args.sequenceSourceEventOffset,
+    streamApi: args.streamApi,
+  });
+
+  const responseSequence = args.connection.sendSequence++;
+  const responseMessage = { type: "response.create" } satisfies JsonValue;
+  args.connection.socket.send(JSON.stringify(responseMessage));
+  await appendProviderMessageSent({
+    connection: args.connection,
+    eventType: providerMessageSentEventType(args.connection.provider),
+    message: responseMessage,
+    sequence: responseSequence,
+    sourceEventOffset: args.sequenceSourceEventOffset,
+    streamApi: args.streamApi,
+  });
 }
 
 // Shared provider helpers.
@@ -947,6 +1122,7 @@ async function createProviderConnection(args: {
     ready,
     receiveSequence: 0,
     sendSequence: 0,
+    handledToolCallIds: new Set(),
     socket,
     urlForLog: args.urlForLog,
   };

--- a/packages/shared/src/stream-processors/voice-agent/implementation.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.ts
@@ -1,0 +1,1257 @@
+import { z } from "zod";
+import {
+  assertNever,
+  buildProcessorIdempotencyKey,
+  implementProcessor,
+  type ConsumedEvent,
+  type ProcessorStreamApi,
+} from "../stream-processor.ts";
+import { CoreProcessorRegisteredEventType } from "../core/contract.ts";
+import { standardProcessorBehavior } from "../core/standard-processor-behavior.ts";
+import {
+  VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_OUTPUT_SAMPLE_RATE,
+  VOICE_AGENT_PROVIDER_GEMINI_LIVE,
+  VOICE_AGENT_PROVIDER_GROK_REALTIME,
+  VOICE_AGENT_PROVIDER_OPENAI_REALTIME,
+  VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
+  VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE,
+  type VoiceAgentProvider,
+  VoiceAgentProcessorContract,
+  type VoiceAgentSetup,
+  type VoiceAgentState,
+} from "./contract.ts";
+
+type VoiceAgentStreamApi = ProcessorStreamApi<typeof VoiceAgentProcessorContract>;
+type VoiceAgentConsumedEvent = ConsumedEvent<typeof VoiceAgentProcessorContract>;
+type JsonValue = z.infer<ReturnType<typeof z.json>>;
+
+type ProviderConnection = {
+  id: string;
+  provider: VoiceAgentProvider;
+  ready: Promise<void>;
+  receiveSequence: number;
+  sendSequence: number;
+  socket: WebSocket;
+  urlForLog: string;
+};
+
+type ProviderConnectionArgs = {
+  connection: ProviderConnection;
+  createOutputSequence(): number;
+  getLastInputStreamId(): string;
+  resolveReady(): void;
+  streamApi: VoiceAgentStreamApi;
+};
+
+type GeminiServerMessage = {
+  setupComplete?: Record<string, unknown>;
+  serverContent?: {
+    modelTurn?: {
+      parts?: Array<{
+        inlineData?: { data?: string; mimeType?: string };
+        text?: string;
+      }>;
+    };
+    interrupted?: boolean;
+    turnComplete?: boolean;
+    inputTranscription?: { text?: string };
+    outputTranscription?: { text?: string };
+  };
+  goAway?: { timeLeft?: string };
+};
+
+type RealtimeServerMessage = {
+  type?: string;
+  delta?: string;
+  transcript?: string;
+  error?: { message?: string };
+  response?: { status?: string };
+};
+
+type OpenAiCompatibleEventPrefix = "openai-realtime" | "grok-realtime";
+type OpenAiCompatibleStatusEventSuffix =
+  | "session-updated"
+  | "speech-started"
+  | "speech-stopped"
+  | "output-audio-done"
+  | "response-done";
+type OpenAiCompatibleStatusEventType =
+  | `events.iterate.com/voice-agent/openai-realtime-${OpenAiCompatibleStatusEventSuffix}`
+  | `events.iterate.com/voice-agent/grok-realtime-${OpenAiCompatibleStatusEventSuffix}`;
+
+export type VoiceAgentProcessorDeps = {
+  geminiApiKey: string;
+  openAiApiKey: string;
+  xAiApiKey: string;
+  openGeminiLiveWebSocket?: (input: { apiKey: string }) => Promise<WebSocket>;
+  openOpenAiRealtimeWebSocket?: (input: { apiKey: string; model: string }) => Promise<WebSocket>;
+  openGrokRealtimeWebSocket?: (input: { apiKey: string; model: string }) => Promise<WebSocket>;
+};
+
+const ProviderConnectedReadyState = 1;
+
+export function createVoiceAgentProcessor(deps: VoiceAgentProcessorDeps) {
+  let connection: ProviderConnection | null = null;
+  let openingConnection: Promise<ProviderConnection> | null = null;
+  let outputSequence = 0;
+  let lastInputStreamId = "voice-agent";
+
+  return implementProcessor(VoiceAgentProcessorContract, {
+    async afterAppend({ event, state, streamApi, waitUntil }) {
+      await standardProcessorBehavior.afterAppend({
+        contract: VoiceAgentProcessorContract,
+        state,
+        streamApi,
+      });
+
+      switch (event.type) {
+        case CoreProcessorRegisteredEventType:
+        case VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE:
+        case "events.iterate.com/voice-agent/transcription-appended":
+        case VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE:
+        case "events.iterate.com/voice-agent/error-occurred":
+        case "events.iterate.com/voice-agent/gemini-live-websocket-connected":
+        case "events.iterate.com/voice-agent/gemini-live-websocket-disconnected":
+        case "events.iterate.com/voice-agent/gemini-live-setup-completed":
+        case "events.iterate.com/voice-agent/gemini-live-message-sent":
+        case "events.iterate.com/voice-agent/gemini-live-message-received":
+        case "events.iterate.com/voice-agent/gemini-live-output-interrupted":
+        case "events.iterate.com/voice-agent/gemini-live-turn-completed":
+        case "events.iterate.com/voice-agent/openai-realtime-websocket-connected":
+        case "events.iterate.com/voice-agent/openai-realtime-websocket-disconnected":
+        case "events.iterate.com/voice-agent/openai-realtime-session-updated":
+        case "events.iterate.com/voice-agent/openai-realtime-message-sent":
+        case "events.iterate.com/voice-agent/openai-realtime-message-received":
+        case "events.iterate.com/voice-agent/openai-realtime-speech-started":
+        case "events.iterate.com/voice-agent/openai-realtime-speech-stopped":
+        case "events.iterate.com/voice-agent/openai-realtime-output-audio-done":
+        case "events.iterate.com/voice-agent/openai-realtime-response-done":
+        case "events.iterate.com/voice-agent/grok-realtime-websocket-connected":
+        case "events.iterate.com/voice-agent/grok-realtime-websocket-disconnected":
+        case "events.iterate.com/voice-agent/grok-realtime-session-updated":
+        case "events.iterate.com/voice-agent/grok-realtime-message-sent":
+        case "events.iterate.com/voice-agent/grok-realtime-message-received":
+        case "events.iterate.com/voice-agent/grok-realtime-speech-started":
+        case "events.iterate.com/voice-agent/grok-realtime-speech-stopped":
+        case "events.iterate.com/voice-agent/grok-realtime-output-audio-done":
+        case "events.iterate.com/voice-agent/grok-realtime-response-done":
+          return;
+        case VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE:
+        case "events.iterate.com/voice-agent/config-updated":
+          connection?.socket.close(1000, "Voice-agent setup changed.");
+          connection = null;
+          openingConnection = null;
+          return;
+        case VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE: {
+          const task = forwardInputAudioFrame({
+            deps,
+            event,
+            getConnection: async (setup) => {
+              if (
+                connection?.provider === setup.provider &&
+                connection.socket.readyState === ProviderConnectedReadyState
+              ) {
+                return connection;
+              }
+
+              if (openingConnection != null) {
+                return await openingConnection;
+              }
+
+              connection?.socket.close(1000, "Voice-agent provider changed.");
+              openingConnection = openProviderConnection({
+                deps,
+                setup,
+                streamApi,
+                createOutputSequence: () => outputSequence++,
+                getLastInputStreamId: () => lastInputStreamId,
+                markConnectionClosed: (closedConnection) => {
+                  if (connection?.id === closedConnection.id) connection = null;
+                },
+              });
+              try {
+                connection = await openingConnection;
+                return connection;
+              } finally {
+                openingConnection = null;
+              }
+            },
+            rememberInputStreamId: (streamId) => {
+              lastInputStreamId = streamId;
+            },
+            state,
+            streamApi,
+          });
+          if (waitUntil == null) {
+            await task;
+          } else {
+            waitUntil(task);
+          }
+          return;
+        }
+        default:
+          return assertNever(event);
+      }
+    },
+  });
+}
+
+async function forwardInputAudioFrame(args: {
+  deps: VoiceAgentProcessorDeps;
+  event: Extract<
+    VoiceAgentConsumedEvent,
+    { type: typeof VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE }
+  >;
+  getConnection(setup: VoiceAgentSetup): Promise<ProviderConnection>;
+  rememberInputStreamId(streamId: string): void;
+  state: VoiceAgentState;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  const setup = args.state.setup;
+  if (setup == null) {
+    await appendProcessorError({
+      error: new Error(
+        "Voice-agent setup-configured event is required before appending input audio.",
+      ),
+      event: args.event,
+      streamApi: args.streamApi,
+    });
+    return;
+  }
+
+  const missingKeyError = missingApiKeyError({ deps: args.deps, provider: setup.provider });
+  if (missingKeyError != null) {
+    await appendProcessorError({
+      error: new Error(missingKeyError),
+      event: args.event,
+      streamApi: args.streamApi,
+    });
+    return;
+  }
+
+  args.rememberInputStreamId(args.event.payload.streamId);
+
+  let connection: ProviderConnection;
+  try {
+    connection = await args.getConnection(setup);
+    await withTimeout(
+      connection.ready,
+      30_000,
+      `Timed out waiting for ${providerLabel(setup.provider)} setup.`,
+    );
+  } catch (error) {
+    await appendProcessorError({
+      error,
+      event: args.event,
+      streamApi: args.streamApi,
+    });
+    return;
+  }
+
+  await sendInputAudioFrame({
+    connection,
+    event: args.event,
+    streamApi: args.streamApi,
+  });
+}
+
+async function sendInputAudioFrame(args: {
+  connection: ProviderConnection;
+  event: Extract<
+    VoiceAgentConsumedEvent,
+    { type: typeof VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE }
+  >;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  const sequence = args.connection.sendSequence++;
+  switch (args.connection.provider) {
+    case VOICE_AGENT_PROVIDER_GEMINI_LIVE: {
+      const message = {
+        realtimeInput: {
+          audio: {
+            data: args.event.payload.dataBase64,
+            mimeType: `audio/pcm;rate=${args.event.payload.sampleRate}`,
+          },
+        },
+      } satisfies JsonValue;
+      args.connection.socket.send(JSON.stringify(message));
+      await appendProviderMessageSent({
+        connection: args.connection,
+        eventType: providerMessageSentEventType(args.connection.provider),
+        message,
+        sequence,
+        sourceEventOffset: args.event.offset,
+        streamApi: args.streamApi,
+      });
+      return;
+    }
+    case VOICE_AGENT_PROVIDER_OPENAI_REALTIME:
+    case VOICE_AGENT_PROVIDER_GROK_REALTIME: {
+      const message = {
+        type: "input_audio_buffer.append",
+        audio:
+          args.connection.provider === VOICE_AGENT_PROVIDER_OPENAI_REALTIME
+            ? resamplePcm16Base64({
+                dataBase64: args.event.payload.dataBase64,
+                fromSampleRate: args.event.payload.sampleRate,
+                toSampleRate: 24_000,
+              })
+            : args.event.payload.dataBase64,
+      } satisfies JsonValue;
+      args.connection.socket.send(JSON.stringify(message));
+      await appendProviderMessageSent({
+        connection: args.connection,
+        eventType: providerMessageSentEventType(args.connection.provider),
+        message,
+        sequence,
+        sourceEventOffset: args.event.offset,
+        streamApi: args.streamApi,
+      });
+      return;
+    }
+    default:
+      return assertNever(args.connection.provider);
+  }
+}
+
+async function openProviderConnection(args: {
+  deps: VoiceAgentProcessorDeps;
+  setup: VoiceAgentSetup;
+  streamApi: VoiceAgentStreamApi;
+  createOutputSequence(): number;
+  getLastInputStreamId(): string;
+  markConnectionClosed(connection: ProviderConnection): void;
+}): Promise<ProviderConnection> {
+  const setup = args.setup;
+  switch (setup.provider) {
+    case VOICE_AGENT_PROVIDER_GEMINI_LIVE:
+      return await openGeminiLiveConnection({ ...args, setup });
+    case VOICE_AGENT_PROVIDER_OPENAI_REALTIME:
+      return await openOpenAiRealtimeConnection({ ...args, setup });
+    case VOICE_AGENT_PROVIDER_GROK_REALTIME:
+      return await openGrokRealtimeConnection({ ...args, setup });
+    default:
+      return assertNever(setup);
+  }
+}
+
+// Gemini Live handlers.
+
+async function openGeminiLiveConnection(args: {
+  deps: VoiceAgentProcessorDeps;
+  setup: Extract<VoiceAgentSetup, { provider: typeof VOICE_AGENT_PROVIDER_GEMINI_LIVE }>;
+  streamApi: VoiceAgentStreamApi;
+  createOutputSequence(): number;
+  getLastInputStreamId(): string;
+  markConnectionClosed(connection: ProviderConnection): void;
+}): Promise<ProviderConnection> {
+  const connection = await createProviderConnection({
+    openSocket:
+      args.deps.openGeminiLiveWebSocket == null
+        ? () => openGeminiLiveWebSocket({ apiKey: args.deps.geminiApiKey })
+        : () => args.deps.openGeminiLiveWebSocket?.({ apiKey: args.deps.geminiApiKey }),
+    provider: VOICE_AGENT_PROVIDER_GEMINI_LIVE,
+    setup: args.setup,
+    streamApi: args.streamApi,
+    urlForLog: geminiLiveUrl({ apiKey: "" }).toString(),
+    onMessage: handleGeminiMessage,
+    markConnectionClosed: args.markConnectionClosed,
+    createOutputSequence: args.createOutputSequence,
+    getLastInputStreamId: args.getLastInputStreamId,
+  });
+
+  await appendProviderConnected({
+    connection,
+    eventType: "events.iterate.com/voice-agent/gemini-live-websocket-connected",
+    model: args.setup.model,
+    streamApi: args.streamApi,
+  });
+
+  const setupMessage = {
+    setup: {
+      model: normalizeGeminiModelName(args.setup.model),
+      generationConfig: {
+        responseModalities: ["AUDIO"],
+        speechConfig: {
+          voiceConfig: {
+            prebuiltVoiceConfig: { voiceName: args.setup.voiceName },
+          },
+        },
+      },
+      inputAudioTranscription: {},
+      outputAudioTranscription: {},
+      systemInstruction: {
+        parts: [{ text: args.setup.systemInstruction }],
+      },
+    },
+  } satisfies JsonValue;
+  const sequence = connection.sendSequence++;
+  connection.socket.send(JSON.stringify(setupMessage));
+  await appendProviderMessageSent({
+    connection,
+    eventType: "events.iterate.com/voice-agent/gemini-live-message-sent",
+    message: setupMessage,
+    sequence,
+    streamApi: args.streamApi,
+  });
+
+  return connection;
+}
+
+async function handleGeminiMessage(args: ProviderConnectionArgs & { data: unknown }) {
+  const text = await websocketMessageToText(args.data);
+  const message = JSON.parse(text) as GeminiServerMessage;
+  const sequence = args.connection.receiveSequence++;
+  await appendProviderMessageReceived({
+    connection: args.connection,
+    eventType: providerMessageReceivedEventType(args.connection.provider),
+    message: message as JsonValue,
+    sequence,
+    streamApi: args.streamApi,
+  });
+
+  if (message.setupComplete != null) {
+    args.resolveReady();
+    await args.streamApi.append({
+      event: {
+        type: "events.iterate.com/voice-agent/gemini-live-setup-completed",
+        idempotencyKey: `voice-agent:${args.connection.id}:gemini-live-setup-completed`,
+        payload: { connectionId: args.connection.id },
+      },
+    });
+  }
+
+  const serverContent = message.serverContent;
+  if (serverContent == null) return;
+
+  for (const part of serverContent.modelTurn?.parts ?? []) {
+    const dataBase64 = part.inlineData?.data;
+    if (!dataBase64) continue;
+    await appendOutputAudioFrame({
+      connection: args.connection,
+      createOutputSequence: args.createOutputSequence,
+      dataBase64,
+      getLastInputStreamId: args.getLastInputStreamId,
+      streamApi: args.streamApi,
+    });
+  }
+
+  if (serverContent.interrupted) {
+    const sourceEventType = "events.iterate.com/voice-agent/gemini-live-output-interrupted";
+    await args.streamApi.append({
+      event: {
+        type: sourceEventType,
+        idempotencyKey: `voice-agent:${args.connection.id}:gemini-live-output-interrupted:${sequence}`,
+        payload: { connectionId: args.connection.id },
+      },
+    });
+    await appendSpeakerBufferClearRequested({
+      connection: args.connection,
+      reason: "output-interrupted",
+      sequence,
+      sourceEventType,
+      streamApi: args.streamApi,
+    });
+  }
+
+  if (serverContent.turnComplete) {
+    await args.streamApi.append({
+      event: {
+        type: "events.iterate.com/voice-agent/gemini-live-turn-completed",
+        idempotencyKey: `voice-agent:${args.connection.id}:gemini-live-turn-completed:${sequence}`,
+        payload: { connectionId: args.connection.id },
+      },
+    });
+  }
+
+  await appendTranscriptionEvents({
+    connectionId: args.connection.id,
+    inputText: serverContent.inputTranscription?.text,
+    sequence,
+    outputText: serverContent.outputTranscription?.text,
+    streamApi: args.streamApi,
+  });
+}
+
+// OpenAI Realtime handlers.
+
+async function openOpenAiRealtimeConnection(args: {
+  deps: VoiceAgentProcessorDeps;
+  setup: Extract<VoiceAgentSetup, { provider: typeof VOICE_AGENT_PROVIDER_OPENAI_REALTIME }>;
+  streamApi: VoiceAgentStreamApi;
+  createOutputSequence(): number;
+  getLastInputStreamId(): string;
+  markConnectionClosed(connection: ProviderConnection): void;
+}): Promise<ProviderConnection> {
+  const connection = await createProviderConnection({
+    openSocket:
+      args.deps.openOpenAiRealtimeWebSocket == null
+        ? () =>
+            openOpenAiRealtimeWebSocket({
+              apiKey: args.deps.openAiApiKey,
+              model: args.setup.model,
+            })
+        : () =>
+            args.deps.openOpenAiRealtimeWebSocket?.({
+              apiKey: args.deps.openAiApiKey,
+              model: args.setup.model,
+            }),
+    provider: VOICE_AGENT_PROVIDER_OPENAI_REALTIME,
+    setup: args.setup,
+    streamApi: args.streamApi,
+    urlForLog: openAiRealtimeUrl({ model: args.setup.model }).toString(),
+    onMessage: handleOpenAiRealtimeMessage,
+    markConnectionClosed: args.markConnectionClosed,
+    createOutputSequence: args.createOutputSequence,
+    getLastInputStreamId: args.getLastInputStreamId,
+  });
+
+  await appendProviderConnected({
+    connection,
+    eventType: "events.iterate.com/voice-agent/openai-realtime-websocket-connected",
+    model: args.setup.model,
+    streamApi: args.streamApi,
+  });
+
+  const setupMessage = {
+    type: "session.update",
+    session: {
+      type: "realtime",
+      instructions: args.setup.systemInstruction,
+      audio: {
+        input: {
+          format: { type: "audio/pcm", rate: 24_000 },
+          turn_detection: {
+            type: "server_vad",
+            create_response: true,
+            interrupt_response: true,
+          },
+          transcription: { model: "gpt-4o-mini-transcribe" },
+        },
+        output: {
+          format: { type: "audio/pcm", rate: VOICE_AGENT_OUTPUT_SAMPLE_RATE },
+          voice: args.setup.voiceName,
+        },
+      },
+    },
+  } satisfies JsonValue;
+  const sequence = connection.sendSequence++;
+  connection.socket.send(JSON.stringify(setupMessage));
+  await appendProviderMessageSent({
+    connection,
+    eventType: "events.iterate.com/voice-agent/openai-realtime-message-sent",
+    message: setupMessage,
+    sequence,
+    streamApi: args.streamApi,
+  });
+
+  return connection;
+}
+
+async function handleOpenAiRealtimeMessage(args: ProviderConnectionArgs & { data: unknown }) {
+  await handleOpenAiCompatibleRealtimeMessage({
+    ...args,
+    eventPrefix: "openai-realtime",
+  });
+}
+
+// Grok Realtime handlers.
+
+async function openGrokRealtimeConnection(args: {
+  deps: VoiceAgentProcessorDeps;
+  setup: Extract<VoiceAgentSetup, { provider: typeof VOICE_AGENT_PROVIDER_GROK_REALTIME }>;
+  streamApi: VoiceAgentStreamApi;
+  createOutputSequence(): number;
+  getLastInputStreamId(): string;
+  markConnectionClosed(connection: ProviderConnection): void;
+}): Promise<ProviderConnection> {
+  const connection = await createProviderConnection({
+    openSocket:
+      args.deps.openGrokRealtimeWebSocket == null
+        ? () => openGrokRealtimeWebSocket({ apiKey: args.deps.xAiApiKey, model: args.setup.model })
+        : () =>
+            args.deps.openGrokRealtimeWebSocket?.({
+              apiKey: args.deps.xAiApiKey,
+              model: args.setup.model,
+            }),
+    provider: VOICE_AGENT_PROVIDER_GROK_REALTIME,
+    setup: args.setup,
+    streamApi: args.streamApi,
+    urlForLog: grokRealtimeUrl({ model: args.setup.model }).toString(),
+    onMessage: handleGrokRealtimeMessage,
+    markConnectionClosed: args.markConnectionClosed,
+    createOutputSequence: args.createOutputSequence,
+    getLastInputStreamId: args.getLastInputStreamId,
+  });
+
+  await appendProviderConnected({
+    connection,
+    eventType: "events.iterate.com/voice-agent/grok-realtime-websocket-connected",
+    model: args.setup.model,
+    streamApi: args.streamApi,
+  });
+
+  const setupMessage = {
+    type: "session.update",
+    session: {
+      instructions: args.setup.systemInstruction,
+      voice: args.setup.voiceName,
+      turn_detection: { type: "server_vad" },
+      audio: {
+        input: { format: { type: "audio/pcm", rate: 16_000 } },
+        output: { format: { type: "audio/pcm", rate: VOICE_AGENT_OUTPUT_SAMPLE_RATE } },
+      },
+    },
+  } satisfies JsonValue;
+  const sequence = connection.sendSequence++;
+  connection.socket.send(JSON.stringify(setupMessage));
+  await appendProviderMessageSent({
+    connection,
+    eventType: "events.iterate.com/voice-agent/grok-realtime-message-sent",
+    message: setupMessage,
+    sequence,
+    streamApi: args.streamApi,
+  });
+
+  return connection;
+}
+
+async function handleGrokRealtimeMessage(args: ProviderConnectionArgs & { data: unknown }) {
+  await handleOpenAiCompatibleRealtimeMessage({
+    ...args,
+    eventPrefix: "grok-realtime",
+  });
+}
+
+async function handleOpenAiCompatibleRealtimeMessage(
+  args: ProviderConnectionArgs & {
+    data: unknown;
+    eventPrefix: OpenAiCompatibleEventPrefix;
+  },
+) {
+  const text = await websocketMessageToText(args.data);
+  const message = JSON.parse(text) as RealtimeServerMessage;
+  const sequence = args.connection.receiveSequence++;
+  await appendProviderMessageReceived({
+    connection: args.connection,
+    eventType: providerMessageReceivedEventType(args.connection.provider),
+    message: message as JsonValue,
+    sequence,
+    streamApi: args.streamApi,
+  });
+
+  switch (message.type) {
+    case "session.updated":
+      args.resolveReady();
+      await args.streamApi.append({
+        event: {
+          type: openAiCompatibleEventType(args.eventPrefix, "session-updated"),
+          idempotencyKey: `voice-agent:${args.connection.id}:${args.eventPrefix}-session-updated`,
+          payload: { connectionId: args.connection.id },
+        },
+      });
+      return;
+    case "response.output_audio.delta":
+    case "response.audio.delta":
+      if (typeof message.delta === "string") {
+        await appendOutputAudioFrame({
+          connection: args.connection,
+          createOutputSequence: args.createOutputSequence,
+          dataBase64: message.delta,
+          getLastInputStreamId: args.getLastInputStreamId,
+          streamApi: args.streamApi,
+        });
+      }
+      return;
+    case "conversation.item.input_audio_transcription.completed":
+      await appendTranscriptionEvents({
+        connectionId: args.connection.id,
+        inputText: message.transcript,
+        sequence,
+        streamApi: args.streamApi,
+      });
+      return;
+    case "response.output_audio_transcript.delta":
+    case "response.audio_transcript.delta":
+      await appendTranscriptionEvents({
+        connectionId: args.connection.id,
+        outputText: message.delta,
+        sequence,
+        streamApi: args.streamApi,
+      });
+      return;
+    case "input_audio_buffer.speech_started":
+      {
+        const sourceEventType = openAiCompatibleEventType(args.eventPrefix, "speech-started");
+        await appendProviderStatusEvent({
+          connection: args.connection,
+          eventType: sourceEventType,
+          sequence,
+          streamApi: args.streamApi,
+        });
+        await appendSpeakerBufferClearRequested({
+          connection: args.connection,
+          reason: "input-speech-started",
+          sequence,
+          sourceEventType,
+          streamApi: args.streamApi,
+        });
+      }
+      return;
+    case "input_audio_buffer.speech_stopped":
+      await appendProviderStatusEvent({
+        connection: args.connection,
+        eventType: openAiCompatibleEventType(args.eventPrefix, "speech-stopped"),
+        sequence,
+        streamApi: args.streamApi,
+      });
+      return;
+    case "response.output_audio.done":
+    case "response.audio.done":
+      await appendProviderStatusEvent({
+        connection: args.connection,
+        eventType: openAiCompatibleEventType(args.eventPrefix, "output-audio-done"),
+        sequence,
+        streamApi: args.streamApi,
+      });
+      return;
+    case "response.done":
+      await appendProviderStatusEvent({
+        connection: args.connection,
+        eventType: openAiCompatibleEventType(args.eventPrefix, "response-done"),
+        sequence,
+        streamApi: args.streamApi,
+      });
+      return;
+    case "error":
+      throw new Error(
+        message.error?.message ?? `${providerLabel(args.connection.provider)} returned an error.`,
+      );
+    default:
+      return;
+  }
+}
+
+// Shared provider helpers.
+
+async function createProviderConnection(args: {
+  openSocket(): Promise<WebSocket> | undefined;
+  provider: VoiceAgentProvider;
+  setup: VoiceAgentSetup;
+  streamApi: VoiceAgentStreamApi;
+  urlForLog: string;
+  onMessage(args: ProviderConnectionArgs & { data: unknown }): Promise<void>;
+  createOutputSequence(): number;
+  getLastInputStreamId(): string;
+  markConnectionClosed(connection: ProviderConnection): void;
+}): Promise<ProviderConnection> {
+  const connectionId = crypto.randomUUID();
+  let resolveReady: () => void = () => {};
+  let rejectReady: (error: Error) => void = () => {};
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+  const socket = await args.openSocket();
+  if (socket == null) throw new Error(`Could not open ${providerLabel(args.provider)} WebSocket.`);
+
+  const connection: ProviderConnection = {
+    id: connectionId,
+    provider: args.provider,
+    ready,
+    receiveSequence: 0,
+    sendSequence: 0,
+    socket,
+    urlForLog: args.urlForLog,
+  };
+
+  socket.addEventListener("message", (event) => {
+    void args
+      .onMessage({
+        connection,
+        createOutputSequence: args.createOutputSequence,
+        data: event.data,
+        getLastInputStreamId: args.getLastInputStreamId,
+        resolveReady,
+        streamApi: args.streamApi,
+      })
+      .catch((error) => {
+        void args.streamApi.append({
+          event: {
+            type: "events.iterate.com/voice-agent/error-occurred",
+            idempotencyKey: `voice-agent:${connection.id}:message-handler-error:${connection.receiveSequence}`,
+            payload: {
+              message: stringifyError(error),
+            },
+          },
+        });
+      });
+  });
+  socket.addEventListener("close", (event) => {
+    args.markConnectionClosed(connection);
+    rejectReady(
+      new Error(
+        event.reason || `${providerLabel(args.provider)} WebSocket closed before setup completed.`,
+      ),
+    );
+    const eventType = providerDisconnectedEventType(args.provider);
+    void args.streamApi.append({
+      event: {
+        type: eventType,
+        idempotencyKey: `voice-agent:${connection.id}:${eventType.split("/").at(-1)}`,
+        payload: {
+          connectionId,
+          code: event.code,
+          reason: event.reason || undefined,
+          wasClean: event.wasClean,
+        },
+      },
+    });
+  });
+  socket.addEventListener("error", () => {
+    args.markConnectionClosed(connection);
+    rejectReady(
+      new Error(`${providerLabel(args.provider)} WebSocket errored before setup completed.`),
+    );
+  });
+
+  return connection;
+}
+
+async function appendProviderConnected(args: {
+  connection: ProviderConnection;
+  eventType:
+    | "events.iterate.com/voice-agent/gemini-live-websocket-connected"
+    | "events.iterate.com/voice-agent/openai-realtime-websocket-connected"
+    | "events.iterate.com/voice-agent/grok-realtime-websocket-connected";
+  model: string;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  await args.streamApi.append({
+    event: {
+      type: args.eventType,
+      idempotencyKey: `voice-agent:${args.connection.id}:${args.eventType.split("/").at(-1)}`,
+      payload: {
+        connectionId: args.connection.id,
+        model: args.model,
+        url: args.connection.urlForLog,
+      },
+    },
+  });
+}
+
+async function appendProviderMessageSent(args: {
+  connection: ProviderConnection;
+  eventType:
+    | "events.iterate.com/voice-agent/gemini-live-message-sent"
+    | "events.iterate.com/voice-agent/openai-realtime-message-sent"
+    | "events.iterate.com/voice-agent/grok-realtime-message-sent";
+  message: JsonValue;
+  sequence: number;
+  sourceEventOffset?: number;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  await args.streamApi.append({
+    event: {
+      type: args.eventType,
+      idempotencyKey: `voice-agent:${args.connection.id}:${args.eventType.split("/").at(-1)}:${args.sequence}`,
+      payload: {
+        connectionId: args.connection.id,
+        sequence: args.sequence,
+        sourceEventOffset: args.sourceEventOffset,
+        message: args.message,
+      },
+    },
+  });
+}
+
+async function appendProviderMessageReceived(args: {
+  connection: ProviderConnection;
+  eventType:
+    | "events.iterate.com/voice-agent/gemini-live-message-received"
+    | "events.iterate.com/voice-agent/openai-realtime-message-received"
+    | "events.iterate.com/voice-agent/grok-realtime-message-received";
+  message: JsonValue;
+  sequence: number;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  await args.streamApi.append({
+    event: {
+      type: args.eventType,
+      idempotencyKey: `voice-agent:${args.connection.id}:${args.eventType.split("/").at(-1)}:${args.sequence}`,
+      payload: {
+        connectionId: args.connection.id,
+        sequence: args.sequence,
+        message: args.message,
+      },
+    },
+  });
+}
+
+async function appendProviderStatusEvent(args: {
+  connection: ProviderConnection;
+  eventType: OpenAiCompatibleStatusEventType;
+  sequence: number;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  await args.streamApi.append({
+    event: {
+      type: args.eventType,
+      idempotencyKey: `voice-agent:${args.connection.id}:${args.eventType.split("/").at(-1)}:${args.sequence}`,
+      payload: { connectionId: args.connection.id },
+    },
+  });
+}
+
+async function appendSpeakerBufferClearRequested(args: {
+  connection: ProviderConnection;
+  reason: "output-interrupted" | "input-speech-started";
+  sequence: number;
+  sourceEventType: string;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  await args.streamApi.append({
+    event: {
+      type: VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
+      idempotencyKey: `voice-agent:${args.connection.id}:speaker-buffer-clear-requested:${args.sequence}:${args.sourceEventType}`,
+      payload: {
+        connectionId: args.connection.id,
+        provider: args.connection.provider,
+        reason: args.reason,
+        sourceEventType: args.sourceEventType,
+      },
+    },
+  });
+}
+
+async function appendOutputAudioFrame(args: {
+  connection: ProviderConnection;
+  createOutputSequence(): number;
+  dataBase64: string;
+  getLastInputStreamId(): string;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  const bytes = base64ByteLength(args.dataBase64);
+  const sequence = args.createOutputSequence();
+  await args.streamApi.append({
+    event: {
+      type: VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+      idempotencyKey: `voice-agent:${args.connection.id}:output-audio:${sequence}`,
+      payload: {
+        channels: 1,
+        dataBase64: args.dataBase64,
+        durationMs: Math.round((bytes / 2 / VOICE_AGENT_OUTPUT_SAMPLE_RATE) * 1000),
+        encoding: "pcm_s16le",
+        sampleRate: VOICE_AGENT_OUTPUT_SAMPLE_RATE,
+        sequence,
+        streamId: args.getLastInputStreamId(),
+      },
+    },
+  });
+}
+
+async function appendTranscriptionEvents(args: {
+  connectionId: string;
+  inputText?: string;
+  sequence: number;
+  outputText?: string;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  if (args.inputText) {
+    await args.streamApi.append({
+      event: {
+        type: "events.iterate.com/voice-agent/transcription-appended",
+        idempotencyKey: `voice-agent:${args.connectionId}:input-transcription:${args.sequence}`,
+        payload: {
+          connectionId: args.connectionId,
+          direction: "input",
+          text: args.inputText,
+        },
+      },
+    });
+  }
+  if (args.outputText) {
+    await args.streamApi.append({
+      event: {
+        type: "events.iterate.com/voice-agent/transcription-appended",
+        idempotencyKey: `voice-agent:${args.connectionId}:output-transcription:${args.sequence}`,
+        payload: {
+          connectionId: args.connectionId,
+          direction: "output",
+          text: args.outputText,
+        },
+      },
+    });
+  }
+}
+
+async function openGeminiLiveWebSocket(input: { apiKey: string }): Promise<WebSocket> {
+  return await openFetchWebSocket({
+    headers: {},
+    providerLabel: "Gemini Live",
+    url: geminiLiveUrl({ apiKey: input.apiKey }),
+  });
+}
+
+async function openOpenAiRealtimeWebSocket(input: {
+  apiKey: string;
+  model: string;
+}): Promise<WebSocket> {
+  return await openFetchWebSocket({
+    headers: { Authorization: `Bearer ${input.apiKey}` },
+    providerLabel: "OpenAI Realtime",
+    url: openAiRealtimeUrl({ model: input.model }),
+  });
+}
+
+async function openGrokRealtimeWebSocket(input: {
+  apiKey: string;
+  model: string;
+}): Promise<WebSocket> {
+  return await openFetchWebSocket({
+    headers: { Authorization: `Bearer ${input.apiKey}` },
+    providerLabel: "Grok Realtime",
+    url: grokRealtimeUrl({ model: input.model }),
+  });
+}
+
+async function openFetchWebSocket(input: {
+  headers: Record<string, string>;
+  providerLabel: string;
+  url: URL;
+}): Promise<WebSocket> {
+  const response = await fetch(input.url, {
+    headers: {
+      ...input.headers,
+      Upgrade: "websocket",
+    },
+  });
+  if (!response.webSocket) {
+    throw new Error(
+      `${input.providerLabel} WebSocket upgrade failed with HTTP ${response.status}.`,
+    );
+  }
+  response.webSocket.accept();
+  return response.webSocket;
+}
+
+function geminiLiveUrl(input: { apiKey: string }) {
+  const url = new URL(
+    "https://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent",
+  );
+  if (input.apiKey) {
+    url.searchParams.set("key", input.apiKey);
+  }
+  return url;
+}
+
+function openAiRealtimeUrl(input: { model: string }) {
+  const url = new URL("https://api.openai.com/v1/realtime");
+  url.searchParams.set("model", input.model);
+  return url;
+}
+
+function grokRealtimeUrl(input: { model: string }) {
+  const url = new URL("https://api.x.ai/v1/realtime");
+  url.searchParams.set("model", input.model);
+  return url;
+}
+
+function normalizeGeminiModelName(model: string) {
+  return model.startsWith("models/") ? model : `models/${model}`;
+}
+
+function missingApiKeyError(input: {
+  deps: VoiceAgentProcessorDeps;
+  provider: VoiceAgentProvider;
+}) {
+  switch (input.provider) {
+    case VOICE_AGENT_PROVIDER_GEMINI_LIVE:
+      return input.deps.geminiApiKey.trim() === ""
+        ? "APP_CONFIG_GEMINI_API_KEY is not configured."
+        : null;
+    case VOICE_AGENT_PROVIDER_OPENAI_REALTIME:
+      return input.deps.openAiApiKey.trim() === ""
+        ? "APP_CONFIG_OPEN_AI_API_KEY is not configured."
+        : null;
+    case VOICE_AGENT_PROVIDER_GROK_REALTIME:
+      return input.deps.xAiApiKey.trim() === ""
+        ? "APP_CONFIG_X_AI_API_KEY is not configured."
+        : null;
+    default:
+      return assertNever(input.provider);
+  }
+}
+
+function providerDisconnectedEventType(provider: VoiceAgentProvider) {
+  switch (provider) {
+    case VOICE_AGENT_PROVIDER_GEMINI_LIVE:
+      return "events.iterate.com/voice-agent/gemini-live-websocket-disconnected";
+    case VOICE_AGENT_PROVIDER_OPENAI_REALTIME:
+      return "events.iterate.com/voice-agent/openai-realtime-websocket-disconnected";
+    case VOICE_AGENT_PROVIDER_GROK_REALTIME:
+      return "events.iterate.com/voice-agent/grok-realtime-websocket-disconnected";
+    default:
+      return assertNever(provider);
+  }
+}
+
+function providerMessageSentEventType(provider: VoiceAgentProvider) {
+  switch (provider) {
+    case VOICE_AGENT_PROVIDER_GEMINI_LIVE:
+      return "events.iterate.com/voice-agent/gemini-live-message-sent";
+    case VOICE_AGENT_PROVIDER_OPENAI_REALTIME:
+      return "events.iterate.com/voice-agent/openai-realtime-message-sent";
+    case VOICE_AGENT_PROVIDER_GROK_REALTIME:
+      return "events.iterate.com/voice-agent/grok-realtime-message-sent";
+    default:
+      return assertNever(provider);
+  }
+}
+
+function providerMessageReceivedEventType(provider: VoiceAgentProvider) {
+  switch (provider) {
+    case VOICE_AGENT_PROVIDER_GEMINI_LIVE:
+      return "events.iterate.com/voice-agent/gemini-live-message-received";
+    case VOICE_AGENT_PROVIDER_OPENAI_REALTIME:
+      return "events.iterate.com/voice-agent/openai-realtime-message-received";
+    case VOICE_AGENT_PROVIDER_GROK_REALTIME:
+      return "events.iterate.com/voice-agent/grok-realtime-message-received";
+    default:
+      return assertNever(provider);
+  }
+}
+
+function openAiCompatibleEventType(
+  prefix: OpenAiCompatibleEventPrefix,
+  suffix: OpenAiCompatibleStatusEventSuffix,
+): OpenAiCompatibleStatusEventType {
+  return `events.iterate.com/voice-agent/${prefix}-${suffix}`;
+}
+
+function providerLabel(provider: VoiceAgentProvider) {
+  switch (provider) {
+    case VOICE_AGENT_PROVIDER_GEMINI_LIVE:
+      return "Gemini Live";
+    case VOICE_AGENT_PROVIDER_OPENAI_REALTIME:
+      return "OpenAI Realtime";
+    case VOICE_AGENT_PROVIDER_GROK_REALTIME:
+      return "Grok Realtime";
+    default:
+      return assertNever(provider);
+  }
+}
+
+async function appendProcessorError(args: {
+  error: unknown;
+  event: Extract<
+    VoiceAgentConsumedEvent,
+    { type: typeof VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE }
+  >;
+  streamApi: VoiceAgentStreamApi;
+}) {
+  await args.streamApi.append({
+    event: {
+      type: "events.iterate.com/voice-agent/error-occurred",
+      idempotencyKey: buildProcessorIdempotencyKey({
+        processor: VoiceAgentProcessorContract,
+        key: "input-audio-frame-forwarding-failed",
+        sourceEvent: args.event,
+      }),
+      payload: {
+        message: stringifyError(args.error),
+        sourceEventOffset: args.event.offset,
+      },
+    },
+  });
+}
+
+async function websocketMessageToText(message: unknown): Promise<string> {
+  if (typeof message === "string") return message;
+  if (message instanceof ArrayBuffer) return new TextDecoder().decode(message);
+  if (message instanceof Uint8Array) return new TextDecoder().decode(message);
+  if (message instanceof Blob) return await message.text();
+  throw new Error(`Unsupported WebSocket message type: ${typeof message}`);
+}
+
+function base64ByteLength(base64: string) {
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+  return Math.max(0, Math.floor((base64.length * 3) / 4) - padding);
+}
+
+function resamplePcm16Base64(input: {
+  dataBase64: string;
+  fromSampleRate: number;
+  toSampleRate: number;
+}) {
+  if (input.fromSampleRate === input.toSampleRate) return input.dataBase64;
+
+  const bytes = base64ToUint8Array(input.dataBase64);
+  const sourceSampleCount = Math.floor(bytes.byteLength / 2);
+  const source = new Int16Array(sourceSampleCount);
+  const sourceView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  for (let index = 0; index < source.length; index += 1) {
+    source[index] = sourceView.getInt16(index * 2, true);
+  }
+
+  const targetSampleCount = Math.max(
+    1,
+    Math.round(source.length * (input.toSampleRate / input.fromSampleRate)),
+  );
+  const target = new Int16Array(targetSampleCount);
+  for (let index = 0; index < target.length; index += 1) {
+    const sourcePosition = index * (input.fromSampleRate / input.toSampleRate);
+    const leftIndex = Math.min(source.length - 1, Math.floor(sourcePosition));
+    const rightIndex = Math.min(source.length - 1, leftIndex + 1);
+    const fraction = sourcePosition - leftIndex;
+    const left = source[leftIndex] ?? 0;
+    const right = source[rightIndex] ?? left;
+    target[index] = Math.round(left + (right - left) * fraction);
+  }
+
+  const outputBytes = new Uint8Array(target.byteLength);
+  const outputView = new DataView(outputBytes.buffer);
+  for (let index = 0; index < target.length; index += 1) {
+    outputView.setInt16(index * 2, target[index] ?? 0, true);
+  }
+  return uint8ArrayToBase64(outputBytes);
+}
+
+function base64ToUint8Array(base64: string) {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function uint8ArrayToBase64(bytes: Uint8Array) {
+  const chunkSize = 0x8000;
+  let binary = "";
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    const chunk = bytes.subarray(index, index + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout != null) clearTimeout(timeout);
+  }
+}
+
+function stringifyError(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/shared/src/stream-processors/voice-agent/implementation.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.ts
@@ -618,9 +618,9 @@ async function openGeminiLiveConnection(args: {
       inputAudioTranscription: {},
       outputAudioTranscription: {},
       systemInstruction: {
-        parts: [{ text: systemInstructionWithAskAgent(args.setup.systemInstruction) }],
+        parts: [{ text: systemInstructionWithMessageAgent(args.setup.systemInstruction) }],
       },
-      tools: [geminiAskAgentTool()],
+      tools: [geminiMessageAgentTool()],
     },
   } satisfies JsonValue;
   const sequence = connection.sendSequence++;
@@ -763,7 +763,7 @@ async function openOpenAiRealtimeConnection(args: {
     type: "session.update",
     session: {
       type: "realtime",
-      instructions: systemInstructionWithAskAgent(args.setup.systemInstruction),
+      instructions: systemInstructionWithMessageAgent(args.setup.systemInstruction),
       audio: {
         input: {
           format: { type: "audio/pcm", rate: 24_000 },
@@ -779,8 +779,8 @@ async function openOpenAiRealtimeConnection(args: {
           voice: args.setup.voiceName,
         },
       },
-      tools: [openAiCompatibleAskAgentTool()],
-      tool_choice: openAiCompatibleAskAgentToolChoice(args.setup.askAgentToolChoice),
+      tools: [openAiCompatibleMessageAgentTool()],
+      tool_choice: openAiCompatibleMessageAgentToolChoice(args.setup.messageAgentToolChoice),
     },
   } satisfies JsonValue;
   const sequence = connection.sendSequence++;
@@ -842,15 +842,15 @@ async function openGrokRealtimeConnection(args: {
   const setupMessage = {
     type: "session.update",
     session: {
-      instructions: systemInstructionWithAskAgent(args.setup.systemInstruction),
+      instructions: systemInstructionWithMessageAgent(args.setup.systemInstruction),
       voice: args.setup.voiceName,
       turn_detection: { type: "server_vad" },
       audio: {
         input: { format: { type: "audio/pcm", rate: 16_000 } },
         output: { format: { type: "audio/pcm", rate: VOICE_AGENT_OUTPUT_SAMPLE_RATE } },
       },
-      tools: [openAiCompatibleAskAgentTool()],
-      tool_choice: openAiCompatibleAskAgentToolChoice(args.setup.askAgentToolChoice),
+      tools: [openAiCompatibleMessageAgentTool()],
+      tool_choice: openAiCompatibleMessageAgentToolChoice(args.setup.messageAgentToolChoice),
     },
   } satisfies JsonValue;
   const sequence = connection.sendSequence++;
@@ -1007,8 +1007,8 @@ async function handleGeminiFunctionCall(args: {
   args.connection.handledToolCallIds.add(callId);
 
   const toolResult =
-    args.functionCall.name === "ask_agent"
-      ? await appendAskAgentInput({
+    args.functionCall.name === "messageAgent"
+      ? await appendMessageAgentInput({
           argumentsValue: args.functionCall.args,
           callId,
           connection: args.connection,
@@ -1040,8 +1040,8 @@ async function handleOpenAiCompatibleFunctionCallItem(args: {
   args.connection.handledToolCallIds.add(callId);
 
   const toolResult =
-    args.item.name === "ask_agent"
-      ? await appendAskAgentInput({
+    args.item.name === "messageAgent"
+      ? await appendMessageAgentInput({
           argumentsValue: args.item.arguments,
           callId,
           connection: args.connection,
@@ -1061,19 +1061,19 @@ async function handleOpenAiCompatibleFunctionCallItem(args: {
   });
 }
 
-async function appendAskAgentInput(args: {
+async function appendMessageAgentInput(args: {
   argumentsValue: unknown;
   callId: string;
   connection: ProviderConnection;
   streamApi: VoiceAgentStreamApi;
 }) {
-  const parsed = parseAskAgentArguments(args.argumentsValue);
+  const parsed = parseMessageAgentArguments(args.argumentsValue);
   if (!parsed.ok) return parsed;
 
   await args.streamApi.append({
     event: {
       type: AGENT_INPUT_ADDED_EVENT_TYPE,
-      idempotencyKey: `voice-agent:${args.connection.id}:${args.connection.provider}:ask-agent:${args.callId}:agent-input`,
+      idempotencyKey: `voice-agent:${args.connection.id}:${args.connection.provider}:message-agent:${args.callId}:agent-input`,
       payload: {
         content: parsed.message,
         llmRequestPolicy: { behaviour: "after-current-request" },
@@ -1088,28 +1088,28 @@ async function appendAskAgentInput(args: {
   };
 }
 
-function parseAskAgentArguments(
+function parseMessageAgentArguments(
   argumentsValue: unknown,
 ): { ok: true; message: string } | { ok: false; message: string } {
   if (argumentsValue == null) {
-    return { ok: false, message: "ask_agent requires a JSON arguments object." };
+    return { ok: false, message: "messageAgent requires a JSON arguments object." };
   }
 
   let parsed = argumentsValue;
   if (typeof argumentsValue === "string") {
     if (argumentsValue.trim() === "") {
-      return { ok: false, message: "ask_agent requires a JSON arguments object." };
+      return { ok: false, message: "messageAgent requires a JSON arguments object." };
     }
     try {
       parsed = JSON.parse(argumentsValue);
     } catch {
-      return { ok: false, message: "ask_agent arguments must be valid JSON." };
+      return { ok: false, message: "messageAgent arguments must be valid JSON." };
     }
   }
 
   const message = (parsed as { message?: unknown }).message;
   if (typeof message !== "string" || message.trim() === "") {
-    return { ok: false, message: "ask_agent requires a non-empty message string." };
+    return { ok: false, message: "messageAgent requires a non-empty message string." };
   }
   return { ok: true, message: message.trim() };
 }
@@ -1187,14 +1187,14 @@ async function sendOpenAiCompatibleFunctionCallOutput(args: {
   });
 }
 
-function systemInstructionWithAskAgent(systemInstruction: string) {
+function systemInstructionWithMessageAgent(systemInstruction: string) {
   return [
     systemInstruction,
-    "You have a tool named Ask Agent. Use it when the caller asks for actions, investigation, code, data lookup, or anything requiring tools. Ask Agent sends the request to a code-capable background agent. After calling it, tell the caller you asked the agent and continue the conversation while it works.",
+    "You have a tool named Message Agent. Use it when the caller asks for actions, investigation, code, data lookup, or anything requiring tools. Message Agent sends the request to a code-capable background agent. After calling it, tell the caller you asked the agent and continue the conversation while it works.",
   ].join("\n\n");
 }
 
-function askAgentParameters(input: { additionalProperties?: boolean } = {}) {
+function messageAgentParameters(input: { additionalProperties?: boolean } = {}) {
   return {
     type: "object",
     ...(input.additionalProperties == null
@@ -1211,28 +1211,28 @@ function askAgentParameters(input: { additionalProperties?: boolean } = {}) {
   } satisfies JsonValue;
 }
 
-function openAiCompatibleAskAgentTool() {
+function openAiCompatibleMessageAgentTool() {
   return {
     type: "function",
-    name: "ask_agent",
+    name: "messageAgent",
     description:
       "Ask the code-capable background agent to do work or answer a question. Use for actions, investigation, code, data lookup, or anything requiring tools.",
-    parameters: askAgentParameters({ additionalProperties: false }),
+    parameters: messageAgentParameters({ additionalProperties: false }),
   } satisfies JsonValue;
 }
 
-function openAiCompatibleAskAgentToolChoice(choice: VoiceAgentSetup["askAgentToolChoice"]) {
+function openAiCompatibleMessageAgentToolChoice(choice: VoiceAgentSetup["messageAgentToolChoice"]) {
   return choice === "required" ? "required" : "auto";
 }
 
-function geminiAskAgentTool() {
+function geminiMessageAgentTool() {
   return {
     functionDeclarations: [
       {
-        name: "ask_agent",
+        name: "messageAgent",
         description:
           "Ask the code-capable background agent to do work or answer a question. Use for actions, investigation, code, data lookup, or anything requiring tools.",
-        parameters: askAgentParameters(),
+        parameters: messageAgentParameters(),
       },
     ],
   } satisfies JsonValue;

--- a/packages/shared/src/stream-processors/voice-agent/implementation.ts
+++ b/packages/shared/src/stream-processors/voice-agent/implementation.ts
@@ -107,7 +107,9 @@ export type VoiceAgentProcessorDeps = {
 
 const ProviderConnectedReadyState = 1;
 
-export function createVoiceAgentProcessor() {
+export function createVoiceAgentProcessor(input: { ensureCodeAgent?: () => Promise<void> } = {}) {
+  let ensureCodeAgentPromise: Promise<void> | null = null;
+
   return implementProcessor(VoiceAgentProcessorContract, {
     async afterAppend({ state, streamApi }) {
       await standardProcessorBehavior.afterAppend({
@@ -115,6 +117,12 @@ export function createVoiceAgentProcessor() {
         state,
         streamApi,
       });
+      if (input.ensureCodeAgent == null) return;
+      ensureCodeAgentPromise ??= input.ensureCodeAgent().catch((error) => {
+        ensureCodeAgentPromise = null;
+        throw error;
+      });
+      await ensureCodeAgentPromise;
     },
   });
 }

--- a/patches/alchemy@0.83.3.patch
+++ b/patches/alchemy@0.83.3.patch
@@ -46,6 +46,14 @@ diff --git a/lib/cloudflare/worker-metadata.js b/lib/cloudflare/worker-metadata.
 index d521d20..e1ff04d 100644
 --- a/lib/cloudflare/worker-metadata.js
 +++ b/lib/cloudflare/worker-metadata.js
+@@ -112,6 +112,6 @@ export async function prepareWorkerMetadata(api, props) {
+             ...(newMigrationTag ? [`alchemy:migration-tag:${newMigrationTag}`] : []),
+             ...(props.tags ?? []),
+-        ],
++        ].slice(0, 10),
+         migrations: {
+             old_tag: oldMigrationTag,
+             new_tag: newMigrationTag,
 @@ -330,6 +330,13 @@ export async function prepareWorkerMetadata(api, props) {
                  name: bindingName,
              });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ overrides:
 
 patchedDependencies:
   alchemy@0.83.3:
-    hash: 4f4e3f291738147e60197a07d2861d64fa7222159f05999c8fc5642a49f52dc8
+    hash: 78e6710c1d83ed1b62fd9fb0719192d24b6762adefd1209102b292e251649847
     path: patches/alchemy@0.83.3.patch
 
 importers:
@@ -202,7 +202,7 @@ importers:
         version: 1.167.5(crossws@0.4.4(srvx@0.11.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       alchemy:
         specifier: ^0.83.3
-        version: 0.83.3(patch_hash=4f4e3f291738147e60197a07d2861d64fa7222159f05999c8fc5642a49f52dc8)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.6.0))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1))
+        version: 0.83.3(patch_hash=78e6710c1d83ed1b62fd9fb0719192d24b6762adefd1209102b292e251649847)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.6.0))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1))
       auth:
         specifier: ^1.6.9
         version: 1.6.9(8a23030e3aa900351c58bd3530d16a6d)
@@ -452,7 +452,7 @@ importers:
         version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.28.6)(rolldown@1.0.0-rc.16)(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       alchemy:
         specifier: ^0.83.3
-        version: 0.83.3(patch_hash=4f4e3f291738147e60197a07d2861d64fa7222159f05999c8fc5642a49f52dc8)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1))
+        version: 0.83.3(patch_hash=78e6710c1d83ed1b62fd9fb0719192d24b6762adefd1209102b292e251649847)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1))
       esbuild:
         specifier: ^0.27.4
         version: 0.27.4
@@ -607,7 +607,7 @@ importers:
         version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.28.6)(rolldown@1.0.0-rc.16)(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       alchemy:
         specifier: ^0.83.3
-        version: 0.83.3(patch_hash=4f4e3f291738147e60197a07d2861d64fa7222159f05999c8fc5642a49f52dc8)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1))
+        version: 0.83.3(patch_hash=78e6710c1d83ed1b62fd9fb0719192d24b6762adefd1209102b292e251649847)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1))
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
@@ -925,7 +925,7 @@ importers:
         version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.28.6)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       alchemy:
         specifier: ^0.83.3
-        version: 0.83.3(patch_hash=4f4e3f291738147e60197a07d2861d64fa7222159f05999c8fc5642a49f52dc8)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.6.0))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1))
+        version: 0.83.3(patch_hash=78e6710c1d83ed1b62fd9fb0719192d24b6762adefd1209102b292e251649847)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.6.0))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1))
       esbuild:
         specifier: ^0.27.4
         version: 0.27.4
@@ -1059,7 +1059,7 @@ importers:
         version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.28.6)(rolldown@1.0.0-rc.16)(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       alchemy:
         specifier: ^0.83.3
-        version: 0.83.3(patch_hash=4f4e3f291738147e60197a07d2861d64fa7222159f05999c8fc5642a49f52dc8)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1))
+        version: 0.83.3(patch_hash=78e6710c1d83ed1b62fd9fb0719192d24b6762adefd1209102b292e251649847)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1))
       esbuild:
         specifier: ^0.27.4
         version: 0.27.4
@@ -1227,7 +1227,7 @@ importers:
         version: 8.16.0
       alchemy:
         specifier: ^0.83.3
-        version: 0.83.3(patch_hash=4f4e3f291738147e60197a07d2861d64fa7222159f05999c8fc5642a49f52dc8)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1))
+        version: 0.83.3(patch_hash=78e6710c1d83ed1b62fd9fb0719192d24b6762adefd1209102b292e251649847)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1))
       croner:
         specifier: ^10.0.1
         version: 10.0.1
@@ -19791,7 +19791,7 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  alchemy@0.83.3(patch_hash=4f4e3f291738147e60197a07d2861d64fa7222159f05999c8fc5642a49f52dc8)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)):
+  alchemy@0.83.3(patch_hash=78e6710c1d83ed1b62fd9fb0719192d24b6762adefd1209102b292e251649847)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)):
     dependencies:
       '@aws-sdk/credential-providers': 3.1002.0
       '@cloudflare/unenv-preset': 2.7.7(unenv@2.0.0-rc.21)(workerd@1.20260424.1)
@@ -19861,7 +19861,7 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  alchemy@0.83.3(patch_hash=4f4e3f291738147e60197a07d2861d64fa7222159f05999c8fc5642a49f52dc8)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)):
+  alchemy@0.83.3(patch_hash=78e6710c1d83ed1b62fd9fb0719192d24b6762adefd1209102b292e251649847)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.3.3))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)):
     dependencies:
       '@aws-sdk/credential-providers': 3.1002.0
       '@cloudflare/unenv-preset': 2.7.7(unenv@2.0.0-rc.21)(workerd@1.20260424.1)
@@ -19931,7 +19931,7 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  alchemy@0.83.3(patch_hash=4f4e3f291738147e60197a07d2861d64fa7222159f05999c8fc5642a49f52dc8)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.6.0))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)):
+  alchemy@0.83.3(patch_hash=78e6710c1d83ed1b62fd9fb0719192d24b6762adefd1209102b292e251649847)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.6.0))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)):
     dependencies:
       '@aws-sdk/credential-providers': 3.1002.0
       '@cloudflare/unenv-preset': 2.7.7(unenv@2.0.0-rc.21)(workerd@1.20260424.1)


### PR DESCRIPTION
## Summary
- replace the voice-agent-specific Durable Object binding with a generic STREAM_PROCESSOR runner and registry
- subscribe both the passive voice-agent protocol processor and the selected provider adapter for new voice-agent streams
- add canonical input/output text events and forward input text to Gemini Live, OpenAI Realtime, and Grok Realtime adapters
- wire new voice-agent streams to the existing AGENT Durable Object from the passive voice-agent processor side effect
- expose `messageAgent` realtime tools for Gemini Live, OpenAI Realtime, and Grok Realtime that append `events.iterate.com/agent/input-added`
- wrap code-agent text before sending it to voice providers so the realtime model relays it to the human it is speaking to, including clarifying questions, rather than answering it itself
- add local smoke modes and a direct Gemini Live tool probe for proving provider tool-call wiring outside the full stream path

## Verification
- pnpm --filter os typecheck
- pnpm --dir packages/shared test:stream-processors
- pnpm format:check packages/shared/src/stream-processors/voice-agent/contract.ts packages/shared/src/stream-processors/voice-agent/implementation.ts packages/shared/src/stream-processors/voice-agent/implementation.test.ts apps/os/scripts/voice-agent-e2e.ts apps/os/scripts/gemini-live-tool-probe.ts apps/os/src/domains/voice-agents/voice-agent-code-agent.ts
- pnpm lint packages/shared/src/stream-processors/voice-agent/contract.ts packages/shared/src/stream-processors/voice-agent/implementation.ts packages/shared/src/stream-processors/voice-agent/implementation.test.ts apps/os/scripts/voice-agent-e2e.ts apps/os/scripts/gemini-live-tool-probe.ts apps/os/src/domains/voice-agents/voice-agent-code-agent.ts
- focused prompt-handoff checks after follow-ups: packages/shared/src/stream-processors/voice-agent/implementation.ts, packages/shared/src/stream-processors/voice-agent/implementation.test.ts, apps/os/src/domains/voice-agents/voice-agent-code-agent.ts

## Local realtime e2e
Ran the original audio in/out smoke against local OS before the message-agent bridge:

- Gemini Live: passed, provider connected, setup completed, output audio/text returned, outputBytes=10084
- OpenAI Realtime: passed, provider connected, setup completed, output audio/text returned, outputBytes=19200
- Grok Realtime: passed, provider connected, setup completed, output audio/text returned, outputBytes=26880

Ran direct Gemini Live tool probe against Doppler config dev_localhost:

```bash
doppler run --project os --config dev_localhost -- tsx scripts/gemini-live-tool-probe.ts --timeout-ms 12000
```

Observed Gemini `toolCall.functionCalls[0].name === "messageAgent"` using the docs-shaped function declaration.

Ran text-mode message-agent bridge smokes against local OS at http://127.0.0.1:5176 with Doppler config dev_localhost:

```bash
doppler run --project os --config dev_localhost -- tsx scripts/voice-agent-e2e.ts \
  --base-url http://127.0.0.1:5176 \
  --provider gemini-live \
  --input-mode text \
  --expect-message-agent \
  --prompt "Call the messageAgent function now. Use message: Fetch example.com and tell me what it says. Do not answer in natural language before the function call." \
  --timeout-ms 180000
```

Gemini result: `ok: true`, stream `/voice-agents/e2e-mpd08lmh`, `messageAgentInputAdded: true`, `agentOutputAdded: true`, `codeAgentVoiceTextAdded: true`, `codeAgentVoiceText: "Example.com says: Example Domain. This domain is for use in documentation examples without needing permission. Avoid use in operations."`

```bash
doppler run --project os --config dev_localhost -- tsx scripts/voice-agent-e2e.ts \
  --base-url http://127.0.0.1:5176 \
  --provider openai-realtime \
  --input-mode text \
  --expect-message-agent \
  --prompt "Call the messageAgent function now. Use message: Fetch example.com and tell me what it says. Do not answer in natural language before the function call." \
  --timeout-ms 180000
```

OpenAI result: `ok: true`, stream `/voice-agents/e2e-mpd0dax0`, `messageAgentInputAdded: true`, `agentOutputAdded: true`, `codeAgentVoiceTextAdded: true`, `codeAgentVoiceText: "Example.com says: Example Domain. This domain is for use in documentation examples without needing permission. Avoid use in operations."`

```bash
doppler run --project os --config dev_localhost -- tsx scripts/voice-agent-e2e.ts \
  --base-url http://127.0.0.1:5176 \
  --provider grok-realtime \
  --input-mode text \
  --expect-message-agent \
  --prompt "Call the messageAgent function now. Use message: Fetch example.com and tell me what it says. Do not answer in natural language before the function call." \
  --timeout-ms 180000
```

Grok regression result: `ok: true`, stream `/voice-agents/e2e-mpd0du05`, `messageAgentInputAdded: true`, `agentOutputAdded: true`, `codeAgentVoiceTextAdded: true`, `codeAgentVoiceText: "Example.com says: Example Domain. This domain is for use in documentation examples without needing permission. Avoid use in operations."`

Prompt-handoff regression coverage now verifies that if the background agent appends a caller-facing question such as `What occupation should I put on your profile?`, all three provider adapters send it with instructions to ask the human they are speaking to rather than answer it themselves.

Note: the original audio CLI returned ok=true based on output audio, but turnCompleted=false for the first three provider runs. The audio in/out proof works; the script should not currently treat provider turn-complete events as a reliable completion condition.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "deployed",
      "updatedAt": "2026-05-19T22:07:36.660Z",
      "headSha": "637cd1a2a5f74c02d3b760d9101ca04f4c5f9e2e",
      "message": null,
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26128070081",
      "shortSha": "637cd1a"
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_6",
    "leasedUntil": 1779231900080,
    "leaseId": "ec3a397d-4574-4970-93d0-25d379a2df68",
    "slug": "preview-6",
    "type": "environment-config-lease"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
Lease: `preview-6`
Doppler config: `preview_6`
Type: `environment-config-lease`
Leased until: 2026-05-19T23:05:00.080Z

### OS
Status: deployed
Commit: `637cd1a`
Preview: https://os.iterate-preview-6.com
[Workflow run](https://github.com/iterate/iterate/actions/runs/26128070081)
Updated: 2026-05-19T22:07:36.660Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it refactors durable-object bindings/subscriptions and realtime voice processing/tool-calling paths, which can break live voice sessions or agent handoff if misconfigured.
> 
> **Overview**
> **Stream processor refactor:** Replaces the voice-agent-specific Durable Object binding (`VOICE_AGENT`) with a generic `STREAM_PROCESSOR` Durable Object that selects a processor via `processorSlug`, and updates OS runtime/context/exports accordingly.
> 
> **Voice agent pipeline split:** New voice-agent streams now subscribe to *two* processors: a canonical `voice-agent` protocol processor plus a provider-specific adapter (`voice-agent/gemini-live`, `voice-agent/openai-realtime`, `voice-agent/grok-realtime`), with new slugs/helpers to generate subscription names.
> 
> **Text + tool-call bridge:** Introduces canonical `voice-agent` input/output text events, forwards input text to providers, exposes a `messageAgent` tool for Gemini/OpenAI/Grok that appends `events.iterate.com/agent/input-added`, and wraps `code-agent` text so providers relay it to the human (not answer/acknowledge).
> 
> **OS/UI/scripts updates:** Voice-agent routes and tooling move to `/agents/voice/*` (while listing supports legacy `/voice-agents/*`), the stream console displays the new output-text events, and new/updated scripts (`voice-agent-e2e` text mode + expectations, `gemini-live-tool-probe`) validate provider tool-calling. Also updates the Alchemy patch to cap tags and include `artifacts` bindings in metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 637cd1a2a5f74c02d3b760d9101ca04f4c5f9e2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->