### PR TITLE
[codex] Preserve callable subscriber delivery order

### DIFF
--- a/docs/slack-smoke-testing.md
+++ b/docs/slack-smoke-testing.md
@@ -1,0 +1,94 @@
+# Slack Smoke Testing
+
+This note describes the manual production smoke test for proving that a Slack
+thread can wake a routed Slack agent and produce a real Slack reply.
+
+## What This Tests
+
+The smoke test covers the OS-side production path after Slack ingress:
+
+1. A Slack thread exists in a real Slack channel.
+2. OS receives a webhook-shaped `events.iterate.com/slack/webhook-received`
+   event on the project's `/integrations/slack` stream.
+3. `SlackIntegrationDurableObject` routes that event to
+   `/agents/slack/<channel>/ts-<thread>`.
+4. `SlackAgentDurableObject` transcribes the Slack event into agent input.
+5. `AgentDurableObject` starts the LLM request.
+6. Codemode calls `ctx.slack.chat.postMessage`.
+7. A real Slack reply appears in the original thread.
+
+It does not prove Slack's Events API delivery latency unless the trigger event
+is sent by a real non-OS Slack actor and arrives through
+`/api/integrations/slack/webhook`. For local/manual timing, we usually append
+the webhook-shaped event directly so we can isolate OS routing and agent
+latency.
+
+## Important Self-Wake Rule
+
+The OS Slack bot must not wake itself. A message sent with
+`APP_CONFIG_SLACK_BOT_TOKEN` is useful for creating a real Slack thread, but it
+should not be treated as the inbound trigger.
+
+To test bot-originated wakeups, use either:
+
+- a second Slack bot/app token that is not the OS bot, or
+- a webhook-shaped event whose Slack event identity is not the OS bot.
+
+The second option is a pragmatic smoke test for OS latency. The first option is
+the full end-to-end Slack ingress test.
+
+## Prerequisites
+
+Run commands from `apps/os`.
+
+- `doppler` access to the target OS config.
+- `APP_CONFIG_ADMIN_API_SECRET` in that config.
+- `APP_CONFIG_SLACK_BOT_TOKEN` in that config.
+- The OS Slack bot is a member of `#slack-agent-e2e-test`.
+- The target app is deployed and reachable through `APP_CONFIG_BASE_URL`.
+
+For production:
+
+```bash
+doppler run --project os --config prd -- sh -c 'echo "$APP_CONFIG_BASE_URL"'
+```
+
+## Manual Smoke Process
+
+1. Resolve the Slack channel ID for `#slack-agent-e2e-test` with
+   `conversations.list`.
+2. Create a temporary OS project through the admin-authenticated oRPC API.
+3. Post a real root message to Slack with `chat.postMessage`. This creates the
+   thread the agent will reply to.
+4. Subscribe the project's `/integrations/slack` stream to the production
+   `SLACK_INTEGRATION` Durable Object.
+5. Append a webhook-shaped `events.iterate.com/slack/webhook-received` event to
+   `/integrations/slack`.
+6. Use a trigger such as:
+
+   ```text
+   !slack.chat.postMessage({ channel: "C...", thread_ts: "177...", text: "..." })
+   ```
+
+7. Poll the routed Slack-agent stream until
+   `events.iterate.com/codemode/function-call-completed` appears for
+   `slack.chat.postMessage`.
+8. Record the wall-clock duration from appending the webhook event to the
+   completed Slack function call.
+9. Inspect the routed stream for these useful timestamps:
+   - `events.iterate.com/slack/webhook-received`
+   - `events.iterate.com/agent/input-added`
+   - `events.iterate.com/openai-ws/llm-request-started`
+   - `events.iterate.com/codemode/function-call-completed`
+
+10. Remove the temporary OS project.
+
+## Timing Notes
+
+The wall-clock duration includes polling interval overhead if measured outside
+the stream. Prefer event `createdAt` deltas when comparing code changes.
+
+For the ordering hotfix, the interesting check is whether the routed stream
+shows `slack-agent:` work before the slower `agent:` subscriber processes the
+raw Slack webhook. The expected effect is a faster transition from
+`slack/webhook-received` to `agent/input-added` and then to LLM request start.

--- a/packages/shared/src/streams/stream-durable-object.ts
+++ b/packages/shared/src/streams/stream-durable-object.ts
@@ -809,9 +809,7 @@ export class StreamDurableObject extends StreamDurableObjectBase<StreamDurableOb
   }
 
   private nextCallableSubscriberDelivery(queue: CallableSubscriberDeliveryQueue) {
-    for (const [subscriberSlug, offsets] of Object.entries(queue).sort(([left], [right]) =>
-      left.localeCompare(right),
-    )) {
+    for (const [subscriberSlug, offsets] of Object.entries(queue)) {
       if (this.activeCallableSubscriberDeliveries.has(subscriberSlug)) continue;
       const offset = offsets[0];
       if (offset == null) continue;


### PR DESCRIPTION
## What changed

Removed the alphabetical sort from callable subscriber delivery selection. The stream Durable Object now picks the next inactive callable subscriber using the queue object's insertion order.

## Why

For Slack-agent streams, the alphabetical sort can choose `agent:` before `slack-agent:` even when Slack-agent was registered first. That lets the slower Agent subscriber run before Slack-agent transcribes the Slack webhook into agent input, pushing the LLM request start later.

This is intentionally a narrow hotfix. It does not add event-type filtering or change the callable delivery concurrency model.

## Validation

- `pnpm --filter @iterate-com/shared typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the selection order for callable subscriber deliveries, which can alter execution sequencing between subscribers and affect downstream processing timing/behavior. Scope is small but touches core stream delivery logic used in production.
> 
> **Overview**
> **Preserves callable subscriber delivery order** by removing the alphabetical sort when selecting the next inactive callable subscriber in `StreamDurableObject`, so deliveries follow the queue object's insertion order (e.g., ensuring `slack-agent:` can run before `agent:` when registered first).
> 
> Adds `docs/slack-smoke-testing.md`, documenting a manual production smoke test to verify Slack webhook routing through Slack agents and measure timing across key stream events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a9f4ce54345ec1984039f5d440c7af35c7fc8d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->