### PR TITLE
[codex] Set OpenAI agent debounce explicitly

### DIFF
--- a/apps/os/src/domains/agents/agent-presets.test.ts
+++ b/apps/os/src/domains/agents/agent-presets.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Event } from "@iterate-com/shared/streams/types";
 import {
+  configuredAgentSetupEvents,
   defaultAgentSetupEvents,
   defaultAgentSystemPrompt,
   isSlackAgentPath,
@@ -24,9 +25,43 @@ describe("agent presets", () => {
         payload: { model: "gpt-5.5" },
       },
       {
+        type: "events.iterate.com/agent/llm-config-updated",
+        payload: { model: "gpt-5.5", runOpts: {}, debounceMs: 200 },
+      },
+      {
         type: "events.iterate.com/agent/system-prompt-updated",
         payload: {
           systemPrompt: defaultAgentSystemPrompt(),
+        },
+      },
+    ]);
+  });
+
+  it("configures OpenAI agent scheduling debounce explicitly", () => {
+    expect(
+      configuredAgentSetupEvents({
+        model: "gpt-5.5-mini",
+        provider: "openai-ws",
+        runOpts: { ignored: true },
+        systemPrompt: "Use OpenAI quickly.",
+      }),
+    ).toEqual([
+      {
+        type: "events.iterate.com/os-agent/llm-provider-selected",
+        payload: { provider: "openai-ws" },
+      },
+      {
+        type: "events.iterate.com/openai-ws/config-updated",
+        payload: { model: "gpt-5.5-mini" },
+      },
+      {
+        type: "events.iterate.com/agent/llm-config-updated",
+        payload: { model: "gpt-5.5-mini", runOpts: {}, debounceMs: 200 },
+      },
+      {
+        type: "events.iterate.com/agent/system-prompt-updated",
+        payload: {
+          systemPrompt: "Use OpenAI quickly.",
         },
       },
     ]);

--- a/apps/os/src/domains/agents/agent-presets.ts
+++ b/apps/os/src/domains/agents/agent-presets.ts
@@ -22,6 +22,7 @@ export const AgentPresetEvent = z.object({
   payload: z.record(z.string(), z.unknown()),
 });
 export type AgentPresetEvent = z.infer<typeof AgentPresetEvent>;
+type AgentSetupEventInput = AgentPresetEvent & Pick<EventInput, "idempotencyKey">;
 
 export const AgentPathPrefixPreset = z.object({
   basePath: z.string().trim().min(1),
@@ -86,6 +87,14 @@ export function defaultAgentSetupEvents(
             type: "events.iterate.com/openai-ws/config-updated",
             payload: { model: DEFAULT_OPENAI_AGENT_MODEL },
           },
+          {
+            type: "events.iterate.com/agent/llm-config-updated",
+            payload: {
+              model: DEFAULT_OPENAI_AGENT_MODEL,
+              runOpts: {},
+              debounceMs: DEFAULT_AGENT_DEBOUNCE_MS,
+            },
+          },
         ]
       : [
           {
@@ -112,7 +121,7 @@ export function configuredAgentSetupEvents(input: {
   provider: AgentLlmProvider;
   runOpts: Record<string, unknown>;
   systemPrompt: string;
-}): EventInput[] {
+}): AgentSetupEventInput[] {
   return defaultAgentSetupEvents(input.provider).map((event, index) => ({
     ...(input.idempotencyKeyPrefix == null
       ? {}
@@ -121,12 +130,11 @@ export function configuredAgentSetupEvents(input: {
     payload:
       input.provider === "openai-ws" && event.type === "events.iterate.com/openai-ws/config-updated"
         ? { model: input.model }
-        : input.provider === "cloudflare-ai" &&
-            event.type === "events.iterate.com/agent/llm-config-updated"
+        : event.type === "events.iterate.com/agent/llm-config-updated"
           ? {
               debounceMs: DEFAULT_AGENT_DEBOUNCE_MS,
               model: input.model,
-              runOpts: input.runOpts,
+              runOpts: input.provider === "cloudflare-ai" ? input.runOpts : {},
             }
           : event.type === "events.iterate.com/agent/system-prompt-updated"
             ? { systemPrompt: input.systemPrompt }

--- a/apps/os/src/orpc/routers/agents.ts
+++ b/apps/os/src/orpc/routers/agents.ts
@@ -8,8 +8,7 @@ import {
 import type { Event, EventInput, StreamPath } from "@iterate-com/shared/streams/types";
 import type { StreamDurableObject } from "@iterate-com/shared/streams/stream-durable-object";
 import {
-  DEFAULT_AGENT_DEBOUNCE_MS,
-  defaultAgentSetupEvents,
+  configuredAgentSetupEvents,
   normalizeAgentPresetBasePath,
   presetConfiguredEvent,
   readAgentPathPrefixPresets,
@@ -71,24 +70,12 @@ export const projectAgentsRouter = {
       const project = requireProjectScope(context);
       const basePath = normalizeAgentPresetBasePath(input.basePath);
       const events = [
-        ...defaultAgentSetupEvents(input.provider as AgentLlmProvider).map((event) =>
-          input.provider === "openai-ws" &&
-          event.type === "events.iterate.com/openai-ws/config-updated"
-            ? { ...event, payload: { model: input.model } }
-            : input.provider === "cloudflare-ai" &&
-                event.type === "events.iterate.com/agent/llm-config-updated"
-              ? {
-                  ...event,
-                  payload: {
-                    debounceMs: DEFAULT_AGENT_DEBOUNCE_MS,
-                    model: input.model,
-                    runOpts: input.runOpts,
-                  },
-                }
-              : event.type === "events.iterate.com/agent/system-prompt-updated"
-                ? { ...event, payload: { systemPrompt: input.systemPrompt } }
-                : event,
-        ),
+        ...configuredAgentSetupEvents({
+          model: input.model,
+          provider: input.provider as AgentLlmProvider,
+          runOpts: input.runOpts,
+          systemPrompt: input.systemPrompt,
+        }),
         ...input.events,
       ];
       await appendAgentsRootEvent({


### PR DESCRIPTION
## Summary

This mini PR makes OpenAI-backed agents explicitly configure the Agent scheduler debounce.

OpenAI setup already wrote `openai-ws/config-updated`, but the Agent scheduler reads `agent/llm-config-updated`. Because OpenAI setup did not write that event, default and configured OpenAI agents fell back to the shared processor default of `1000ms` instead of the app-level `DEFAULT_AGENT_DEBOUNCE_MS = 200`.

## Changes

- Add `agent/llm-config-updated` to default OpenAI setup events with `debounceMs: 200`.
- Reuse `configuredAgentSetupEvents()` from the oRPC preset route so configured OpenAI presets get the same scheduler config as the UI path.
- Add focused preset coverage for OpenAI debounce config.

## Validation

- `pnpm --dir apps/os test src/domains/agents/agent-presets.test.ts`
- `pnpm --dir apps/os typecheck`
- `git diff --check`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-05-19T20:01:41.193Z",
      "headSha": "8700f0c917a3c3a49a26597977a70127715cb54b",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26121050624",
      "shortSha": "8700f0c"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `8700f0c`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/26121050624)
Updated: 2026-05-19T20:01:41.193Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the initialization event stream for OpenAI agents/presets and centralizes preset event generation in the API route, which could affect scheduling behavior and compatibility with existing presets.
> 
> **Overview**
> **OpenAI agent setup now explicitly configures scheduler debounce.** `defaultAgentSetupEvents()` adds an `events.iterate.com/agent/llm-config-updated` event for `openai-ws` with `debounceMs: 200` (and empty `runOpts`) so the agent scheduler reads the intended debounce.
> 
> **Preset configuration reuses shared setup generation.** The oRPC `configurePreset` handler switches to `configuredAgentSetupEvents()` (instead of duplicating logic) and `configuredAgentSetupEvents()` now ensures OpenAI uses `{}` for `runOpts` while still setting `debounceMs`.
> 
> **Tests updated/added** to assert the new OpenAI default/setup event sequence and explicit debounce behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8700f0c917a3c3a49a26597977a70127715cb54b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->