### PR TITLE
Restore OS CLI Doppler bootstrap from closed #1352

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,30 @@ Monorepo for Iterate's Cloudflare Workers platform. **`apps/os`** is the main ap
 
 ## Talking to OS
 
-Run these from `apps/os`. Wrap in `doppler run --project os --config <config> -- …` to target a specific environment; the config supplies URLs and secrets.
+Run these from `apps/os`. Plain `pnpm cli ...` uses your local Doppler setup
+for `apps/os`. Wrap in `doppler run --config <config> -- ...` to target a
+specific environment; the config supplies URLs and secrets. More on this script
+pattern: [Doppler-backed scripts](apps/os/docs/doppler-backed-scripts.md).
 
 ### oRPC API
 
-OS exposes oRPC at `/api/orpc/`. The app CLI discovers procedures remotely and authenticates with the config's shared API secret:
+OS exposes oRPC at `/api/orpc/`. The app CLI discovers procedures remotely and authenticates with the config's admin API secret:
 
 ```bash
-# production (default when no DOPPLER_CONFIG is set)
+# your local Doppler setup, normally dev_<you>
 pnpm cli rpc --help
 
-# preview slot 2
-doppler run --project os --config preview_2 -- \
-  sh -c 'OS_BASE_URL="$APP_CONFIG_BASE_URL" pnpm cli rpc --help'
+# production
+doppler run --config prd -- pnpm cli rpc --help
+
+# preview slot 3
+doppler run --config preview_3 -- pnpm cli rpc --help
 
 # local dev server (while pnpm dev is running)
-doppler run --project os --config dev_jonas -- \
-  pnpm cli rpc --base-url http://localhost:5183 --help
+doppler run --config dev_jonas -- pnpm cli --base-url http://localhost:5173 rpc --help
+
+# localhost-oriented config (while pnpm dev:localhost is running)
+doppler run --config dev_localhost -- pnpm cli rpc --help
 ```
 
 Replace `--help` with a procedure path to call it.
@@ -38,8 +45,7 @@ Replace `--help` with a procedure path to call it.
 Open Claude Code against a deployed project's MCP server:
 
 ```bash
-doppler run --project os --config prd -- \
-  pnpm cli claude-mcp --project-slug-or-id my-project
+doppler run --config prd -- pnpm cli claude-mcp --project-slug-or-id my-project
 ```
 
 The Doppler config picks the environment (prod, preview, your dev tunnel). `APP_CONFIG_PROJECT_HOSTNAME_BASES` in the config sets the project hostname base (e.g. `iterate.app`, `iterate-preview-3.app`); override with `--base-host` if needed.
@@ -117,3 +123,5 @@ Dev server, Doppler, Cloudflare, previews, and deploys:
 
 - [OS app](apps/os/AGENTS.md)
 - [OS architecture & operations](apps/os/docs/architecture-and-operations.md)
+- [Debugging deployed OS workers](apps/os/docs/debugging-deployed-os-workers.md)
+- [Doppler-backed scripts](apps/os/docs/doppler-backed-scripts.md)

--- a/apps/os/README.md
+++ b/apps/os/README.md
@@ -41,22 +41,26 @@ pnpm typecheck           # TypeScript
 pnpm test                # unit tests
 pnpm test:e2e:preview    # deployed preview smoke
 pnpm cli claude-mcp --project-slug-or-id bob
-                         # open Claude against one project MCP server
+                         # open Claude against one project MCP server in your local Doppler config
 pnpm sqlfu:generate      # regenerate sqlfu migrations/query wrappers
 pnpm sqlfu:check         # compare migrations to definitions.sql
 pnpm cf:deploy           # production deploy
 ```
 
-Use `doppler run --project os --config <config> -- <command>` when a command
-needs deployed secrets or preview/prd app config.
+`pnpm cli` uses `scripts/cli.ts`: if already inside `doppler run`, it preserves
+that config; otherwise it enters Doppler using the local `apps/os` setup. Use
+`doppler run --config <config> -- <command>` when you want preview/prd app
+config explicitly.
 
 For example, to open Claude against the production MCP server for project
 `bob`, using the production `APP_CONFIG_ADMIN_API_SECRET`:
 
 ```bash
-doppler run --project os --config prd -- \
-  pnpm cli claude-mcp --project-slug-or-id bob
+doppler run --config prd -- pnpm cli claude-mcp --project-slug-or-id bob
 ```
+
+The script pattern is documented in
+[`docs/doppler-backed-scripts.md`](./docs/doppler-backed-scripts.md).
 
 ## Important Files
 
@@ -74,6 +78,8 @@ doppler run --project os --config prd -- \
 
 ## Read Next
 
+- [Debugging Deployed OS Workers](./docs/debugging-deployed-os-workers.md)
+- [Doppler-Backed Scripts](./docs/doppler-backed-scripts.md)
 - [Architecture And Operations](./docs/architecture-and-operations.md)
 - [Preview Agent Browser Smoke](./docs/preview-agent-browser-smoke.md)
 - [Codemode Subrequest Depth](./docs/codemode-subrequest-depth.md)

--- a/apps/os/scripts/claude-mcp.test.ts
+++ b/apps/os/scripts/claude-mcp.test.ts
@@ -1,6 +1,21 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { assertMcpAdminBearerAccepted } from "./claude-mcp.ts";
+import { assertMcpAdminBearerAccepted, buildClaudeShellCommand } from "./claude-mcp.ts";
+
+describe("buildClaudeShellCommand", () => {
+  it("quotes JSON mcp config for shell copy-paste", () => {
+    const command = buildClaudeShellCommand([
+      "--mcp-config",
+      '{"mcpServers":{"iterate":{"type":"http"}}}',
+      "--strict-mcp-config",
+      "hello world",
+    ]);
+
+    expect(command).toBe(
+      'claude --mcp-config \'{"mcpServers":{"iterate":{"type":"http"}}}\' --strict-mcp-config \'hello world\'',
+    );
+  });
+});
 
 describe("assertMcpAdminBearerAccepted", () => {
   afterEach(() => {

--- a/apps/os/scripts/claude-mcp.ts
+++ b/apps/os/scripts/claude-mcp.ts
@@ -35,9 +35,9 @@ export const claudeMcpScript = os
   .input(ClaudeMcpInput)
   .meta({
     description:
-      "Open Claude Code against one remote OS project MCP server using the Doppler admin token",
+      "Print the Claude Code command for one remote OS project MCP server (after Doppler admin-token preflight)",
   })
-  .handler(async ({ input, signal }) => {
+  .handler(async ({ input }) => {
     const adminToken = requireEnv("APP_CONFIG_ADMIN_API_SECRET");
     const baseHost = input.baseHost ?? defaultBaseHostFromEnv();
     const mcpUrl = buildProjectMcpUrl({
@@ -45,7 +45,7 @@ export const claudeMcpScript = os
       projectSlugOrId: input.projectSlugOrId,
     });
     await assertMcpAdminBearerAccepted({ mcpUrl, token: adminToken });
-    const args = [
+    const command = buildClaudeShellCommand([
       "--mcp-config",
       buildClaudeMcpConfig({
         mcpUrl,
@@ -54,24 +54,21 @@ export const claudeMcpScript = os
       "--strict-mcp-config",
       "--dangerously-skip-permissions",
       input.prompt,
-    ];
+    ]);
 
-    console.info("[claude-mcp] Starting Claude with remote OS MCP server:");
-    console.info(`  MCP URL: ${mcpUrl}`);
-    console.info(`  MCP server name: ${SERVER_NAME}`);
-    console.info("  Auth: Doppler OS admin token");
-    console.info("");
-
-    const result = await runClaude(args, signal);
-
-    if (result.type === "signal") {
-      process.exit(result.exitCode);
-    }
+    console.info(
+      [
+        "Here's the command you should run. It's an interactive TUI application so you may want to run it in tmux:",
+        "",
+        command,
+      ].join("\n"),
+    );
 
     return {
       ok: true as const,
       mcpUrl,
       serverName: SERVER_NAME,
+      command,
     };
   });
 
@@ -154,6 +151,18 @@ export async function assertMcpAdminBearerAccepted(input: { mcpUrl: string; toke
       `MCP preflight failed (${response.status}) for ${input.mcpUrl}: ${body || response.statusText}`,
     );
   }
+}
+
+export function buildClaudeShellCommand(args: string[]) {
+  return ["claude", ...args].map(shellQuoteArg).join(" ");
+}
+
+function shellQuoteArg(arg: string) {
+  if (/^[\w./:@%+=,-]+$/.test(arg)) {
+    return arg;
+  }
+
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
 }
 
 function buildClaudeMcpConfig(input: { mcpUrl: string; token: string }) {

--- a/apps/os/scripts/cli.ts
+++ b/apps/os/scripts/cli.ts
@@ -1,0 +1,40 @@
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const args = process.argv.slice(2);
+
+/**
+ * `pnpm cli` should mean "run the OS CLI for the current Doppler environment".
+ *
+ * If the caller is already inside `doppler run`, preserve that exact config:
+ *
+ *   doppler run --config prd -- pnpm cli rpc --help
+ *   doppler run --config preview_3 -- pnpm cli rpc --help
+ *
+ * If not, enter Doppler without naming a project or config. Doppler then uses
+ * the user's local `doppler setup` for `apps/os`, normally `dev_<user>`.
+ */
+if (!process.env.DOPPLER_CONFIG) {
+  run("doppler", ["run", "--", "tsx", fileURLToPath(import.meta.url), ...args], process.env);
+}
+
+run("iterate-app-cli", args, process.env);
+
+function run(command: string, commandArgs: string[], env: NodeJS.ProcessEnv): never {
+  const result = spawnSync(command, commandArgs, {
+    env,
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    console.error(result.error);
+    process.exit(1);
+  }
+
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+  }
+
+  process.exit(result.status ?? 1);
+}

--- a/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/mcp.tsx
+++ b/apps/os/src/routes/_app/orgs/$organizationSlug/projects/$projectSlug/mcp.tsx
@@ -66,8 +66,8 @@ function ProjectMcpPage() {
   const cliCommand = `cd apps/os && pnpm cli claude-mcp --project-slug-or-id ${project.slug}${cliBaseHostFlag}`;
   const cliCommandHint =
     baseHost === "iterate.app"
-      ? "Run from the repo root. Uses the admin token for auth and disables all other MCP servers. For production, prefix with: doppler run --project os --config prd --"
-      : "Run from the repo root. Uses the admin token for auth and disables all other MCP servers.";
+      ? "Run from the repo root. Prints a Claude Code command (with MCP preflight). For production, prefix with: doppler run --config prd --"
+      : "Run from the repo root. Prints a Claude Code command (with MCP preflight).";
 
   return (
     <section className="max-w-md space-y-4 p-4">

--- a/packages/shared/src/apps/cli.ts
+++ b/packages/shared/src/apps/cli.ts
@@ -79,7 +79,10 @@ export async function runAppCli() {
   }
 
   const apiBaseUrlInput =
-    baseUrlFlag ?? process.env[config.remote.baseUrlEnvVar] ?? config.remote.defaultBaseUrl;
+    baseUrlFlag ??
+    process.env.APP_CONFIG_BASE_URL ??
+    process.env[config.remote.baseUrlEnvVar] ??
+    config.remote.defaultBaseUrl;
   const rpcRequested = firstNonFlagArgument(process.argv.slice(2)) === REMOTE_GROUP_NAME;
 
   const remoteRouterResult = await loadRemoteRouter({
@@ -373,12 +376,13 @@ function resolveSharedApiSecretBearerHeaders(params: {
   const token =
     params.env[`${params.envPrefix}_API_KEY`]?.trim() ||
     params.env[`${params.envPrefix}_API_TOKEN`]?.trim() ||
+    params.env.APP_CONFIG_ADMIN_API_SECRET?.trim() ||
     params.env.APP_CONFIG_SHARED_API_SECRET?.trim() ||
     readSharedApiSecretFromAppConfig(params.env.APP_CONFIG);
 
   if (!token) {
     throw new Error(
-      `RPC commands require ${params.envPrefix}_API_KEY, ${params.envPrefix}_API_TOKEN, APP_CONFIG_SHARED_API_SECRET, or APP_CONFIG.sharedApiSecret.`,
+      `RPC commands require ${params.envPrefix}_API_KEY, ${params.envPrefix}_API_TOKEN, APP_CONFIG_ADMIN_API_SECRET, APP_CONFIG_SHARED_API_SECRET, or APP_CONFIG.sharedApiSecret.`,
     );
   }
 


### PR DESCRIPTION
## Summary

- Adds `apps/os/scripts/cli.ts` so `pnpm cli` matches the pattern documented in #1357 and referenced by #1358's `package.json` (`tsx ./scripts/cli.ts`)
- Updates `iterate-app-cli` to prefer `APP_CONFIG_BASE_URL` and accept `APP_CONFIG_ADMIN_API_SECRET` from Doppler (no `OS_BASE_URL` shim for preview/prd)
- Aligns root `README.md` / `AGENTS.md` / `CLAUDE.md` and `apps/os/README.md` with the Doppler-backed workflow and links to `apps/os/docs/debugging-deployed-os-workers.md` and `apps/os/docs/doppler-backed-scripts.md`

## Context

#1352 was closed when #1358 merged. #1357 landed the docs; #1358 pointed `package.json` at `scripts/cli.ts` but the file and shared CLI env fallbacks from `7bffb62cb` never reached `main`.

## Test plan

- [x] `pnpm --dir packages/shared exec vitest run src/apps/cli.test.ts`
- [x] `pnpm --dir packages/shared typecheck`
- [ ] From `apps/os`: `pnpm cli rpc --help` (local Doppler setup)
- [ ] `doppler run --config prd -- pnpm cli rpc --help` (no `OS_BASE_URL` override)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how the OS CLI resolves base URLs and bearer tokens (including preferring `APP_CONFIG_*` values), which can break deployed/preview operational workflows if envs are misconfigured.
> 
> **Overview**
> Restores the **Doppler-backed `pnpm cli` workflow** by adding `apps/os/scripts/cli.ts`, which re-enters `doppler run` when `DOPPLER_CONFIG` isn’t set and otherwise preserves the caller’s Doppler config before delegating to `iterate-app-cli`.
> 
> Updates `iterate-app-cli` to prefer `APP_CONFIG_BASE_URL` when discovering the remote oRPC router and to accept `APP_CONFIG_ADMIN_API_SECRET` as a valid bearer token source (in addition to the shared secret/app config).
> 
> Adjusts the `claude-mcp` script to **preflight the admin token and print a shell-quoted `claude` command** (instead of directly launching Claude), adds tests for the quoting helper, and refreshes README guidance/links to match the new Doppler usage patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da058af761a304dfd8db35dde1e7cdc47dcf70d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "example": {
      "appDisplayName": "Example",
      "appSlug": "example",
      "status": "released",
      "updatedAt": "2026-05-21T10:39:31.484Z",
      "headSha": "0072d19f7cc5560afe89e693ba3c596faf8601bd",
      "message": "Preview app released.",
      "publicUrl": "https://example.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26220148791",
      "shortSha": "0072d19"
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "cleanup-failed",
      "updatedAt": "2026-05-21T10:39:21.681Z",
      "headSha": "da058af761a304dfd8db35dde1e7cdc47dcf70d6",
      "message": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\nWARNING: UNKNOWN APP CONFIG OVERRIDE\nUnknown config key \"xAiApiKey\" from env var \"APP_CONFIG_X_AI_API_KEY\". This env var is not consumed by the config schema.\nDeployment will continue, but this config value is being ignored by the typed runtime config.\nAdd the key to the app config schema or remove the env var from Doppler.\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\nWARNING: UNKNOWN APP CONFIG OVERRIDE\nUnknown config key \"geminiApiKey\" from env var \"APP_CONFIG_GEMINI_API_KEY\". This env var is not consumed by the config schema.\nDeployment will continue, but this config value is being ignored by the typed runtime config.\nAdd the key to the app config schema or remove the env var from Doppler.\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:499\n  configSchema.parse(rawConfig);\n               ^\n\nZodError: [\n  {\n    \"expected\": \"object\",\n    \"code\": \"invalid_type\",\n    \"path\": [\n      \"clerk\"\n    ],\n    \"message\": \"Invalid input: expected object, received undefined\"\n  }\n]\n    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:499:16)\n    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:49:28)\n    at <anonymous> (/home/runner/work/iterate/iterate/apps/os/alchemy.run.ts:19:19)\n\nNode.js v24.15.0",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26220526260",
      "shortSha": "da058af"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-05-21T10:39:30.960Z",
      "headSha": "0072d19f7cc5560afe89e693ba3c596faf8601bd",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26220148791",
      "shortSha": "0072d19"
    },
    "events": {
      "appDisplayName": "Events",
      "appSlug": "events",
      "status": "released",
      "updatedAt": "2026-05-21T10:39:19.414Z",
      "headSha": "0072d19f7cc5560afe89e693ba3c596faf8601bd",
      "message": "Preview app released.",
      "publicUrl": "https://events.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26220148791",
      "shortSha": "0072d19"
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_3",
    "leasedUntil": 1779363087477,
    "leaseId": "4179f0c9-a320-4bad-92f4-5954df421b3f",
    "slug": "preview-3",
    "type": "environment-config-lease"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
Lease: `preview-3`
Doppler config: `preview_3`
Type: `environment-config-lease`
Leased until: 2026-05-21T11:31:27.477Z

### Events
Status: released
Commit: `0072d19`
Preview: https://events.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/26220148791)
Updated: 2026-05-21T10:39:19.414Z

### Example
Status: released
Commit: `0072d19`
Preview: https://example.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/26220148791)
Updated: 2026-05-21T10:39:31.484Z

### OS
Status: cleanup failed
Commit: `da058af`
Preview: https://os.iterate-preview-3.com
Summary: ZodError: [
[Workflow run](https://github.com/iterate/iterate/actions/runs/26220526260)
Updated: 2026-05-21T10:39:21.681Z

<details>
<summary>Failure details</summary>

<pre>!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING: UNKNOWN APP CONFIG OVERRIDE
Unknown config key "xAiApiKey" from env var "APP_CONFIG_X_AI_API_KEY". This env var is not consumed by the config schema.
Deployment will continue, but this config value is being ignored by the typed runtime config.
Add the key to the app config schema or remove the env var from Doppler.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING: UNKNOWN APP CONFIG OVERRIDE
Unknown config key "geminiApiKey" from env var "APP_CONFIG_GEMINI_API_KEY". This env var is not consumed by the config schema.
Deployment will continue, but this config value is being ignored by the typed runtime config.
Add the key to the app config schema or remove the env var from Doppler.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:499
  configSchema.parse(rawConfig);
               ^

ZodError: [
  {
    "expected": "object",
    "code": "invalid_type",
    "path": [
      "clerk"
    ],
    "message": "Invalid input: expected object, received undefined"
  }
]
    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/apps/config.ts:499:16)
    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:49:28)
    at &lt;anonymous&gt; (/home/runner/work/iterate/iterate/apps/os/alchemy.run.ts:19:19)

Node.js v24.15.0</pre>

</details>

### Semaphore
Status: released
Commit: `0072d19`
Preview: https://semaphore.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/26220148791)
Updated: 2026-05-21T10:39:30.960Z
<!-- /CLOUDFLARE_PREVIEW -->