### PR TITLE
Add repo token refresh and artifact handle RPC

### DIFF
--- a/apps/os/src/domains/repos/durable-objects/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/durable-objects/repo-durable-object.ts
@@ -20,6 +20,7 @@ import {
   REPO_DEFAULT_BRANCH,
   REPO_README_PATH,
   REPO_WRITE_TOKEN_TTL_SECONDS,
+  type CloudflareArtifactRepo,
   type CloudflareArtifactsBinding,
   artifactRemoteUrl,
   createArtifactToken,
@@ -113,6 +114,7 @@ const RepoBase = withStreamProcessorRunner<
 })(RepoLifecycleBase);
 
 const REPO_WRITE_TOKEN_STORAGE_KEY = "repo.writeToken";
+const REPO_WRITE_TOKEN_EXPIRES_AT_STORAGE_KEY = "repo.writeTokenExpiresAt";
 
 export class RepoDurableObject extends RepoBase<RepoEnv> {
   constructor(ctx: DurableObjectState, env: RepoEnv) {
@@ -186,6 +188,41 @@ export class RepoDurableObject extends RepoBase<RepoEnv> {
     return await this.requireInfo();
   }
 
+  async refreshWriteToken(): Promise<RepoInfo> {
+    await this.ensureStarted();
+    await this.catchUpStreamProcessor({ signal: AbortSignal.timeout(30_000) });
+
+    if (this.currentRepo() === null) {
+      throw new Error(`Repo ${this.structuredName.repoSlug} has not been created.`);
+    }
+
+    const artifactName = repoArtifactName(this.structuredName);
+    const artifacts = this.requireArtifacts();
+    const token = await createArtifactToken({
+      artifact: await artifacts.get(artifactName),
+      artifacts,
+      name: artifactName,
+      scope: "write",
+      ttlSeconds: REPO_WRITE_TOKEN_TTL_SECONDS,
+    });
+
+    await this.ctx.storage.put(REPO_WRITE_TOKEN_STORAGE_KEY, token.plaintext);
+    await this.ctx.storage.put(REPO_WRITE_TOKEN_EXPIRES_AT_STORAGE_KEY, token.expiresAt);
+
+    return await this.requireInfo();
+  }
+
+  async getArtifact(): Promise<CloudflareArtifactRepo> {
+    await this.ensureStarted();
+    await this.catchUpStreamProcessor({ signal: AbortSignal.timeout(30_000) });
+
+    if (this.currentRepo() === null) {
+      throw new Error(`Repo ${this.structuredName.repoSlug} has not been created.`);
+    }
+
+    return this.requireArtifacts().get(repoArtifactName(this.structuredName));
+  }
+
   async afterAppend(input: { event: Event }) {
     await this.ensureStarted();
     return await this.consumeStreamProcessorEvent({ event: input.event as StreamEvent });
@@ -206,6 +243,10 @@ export class RepoDurableObject extends RepoBase<RepoEnv> {
       throw new Error(`Repo ${this.structuredName.repoSlug} write token is not available.`);
     }
 
+    const tokenExpiresAt =
+      (await this.ctx.storage.get<string | null>(REPO_WRITE_TOKEN_EXPIRES_AT_STORAGE_KEY)) ??
+      repo.tokenExpiresAt;
+
     return {
       defaultBranch: repo.defaultBranch,
       git: gitInfo({
@@ -218,7 +259,7 @@ export class RepoDurableObject extends RepoBase<RepoEnv> {
       remote: repo.remote,
       slug: repo.slug,
       token,
-      tokenExpiresAt: repo.tokenExpiresAt,
+      tokenExpiresAt,
     };
   }
 

--- a/apps/os/src/domains/repos/entrypoints/repo-capability.ts
+++ b/apps/os/src/domains/repos/entrypoints/repo-capability.ts
@@ -55,6 +55,14 @@ export class RepoHandle extends RpcTarget {
   async getInfo(): Promise<RepoInfo> {
     return await this.#repo.getInfo();
   }
+
+  async refreshWriteToken(): Promise<RepoInfo> {
+    return await this.#repo.refreshWriteToken();
+  }
+
+  getArtifact() {
+    return this.#repo.getArtifact();
+  }
 }
 
 export class ReposCapability extends WorkerEntrypoint<ReposCapabilityEnv, ReposCapabilityProps> {


### PR DESCRIPTION
## Summary
- Add `refreshWriteToken()` on `RepoDurableObject` / `RepoHandle` to mint a new write token and update the stored credentials returned by `getInfo()`.
- Add pipelinable `getArtifact()` to return the raw Cloudflare Artifacts repo handle so codemode can call binding methods like `createToken()`, `listTokens()`, and `revokeToken()` directly.

## Test plan
- [x] `pnpm --dir apps/os typecheck`
- [ ] Call `ctx.repos.get({ slug }).refreshWriteToken()` from codemode and verify `getInfo()` returns updated token/expiry
- [ ] Call `ctx.repos.get({ slug }).getArtifact().createToken("write", 3600)` without awaiting the artifact stub and verify token mint succeeds


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new RPC surfaces that mint and expose repository write tokens and returns a raw Cloudflare Artifacts repo handle; misuse or unexpected token lifetimes could affect repo write access.
> 
> **Overview**
> Adds `refreshWriteToken()` to `RepoDurableObject`/`RepoHandle`, minting a new write-scoped artifact token, persisting both token and expiry in DO storage, and returning updated `RepoInfo`.
> 
> Adds `getArtifact()` RPC to return the underlying `CloudflareArtifactRepo` handle (pipelinable from codemode), and updates `getInfo()` to prefer the stored `tokenExpiresAt` (falling back to stream state) so refreshed expiry is reflected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff45f22428846946dcc0340195f69d96c1b3e61a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-05-21T11:07:48.657Z",
      "headSha": "ff45f22428846946dcc0340195f69d96c1b3e61a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26221960695",
      "shortSha": "ff45f22"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `ff45f22`
Preview: https://os.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/26221960695)
Updated: 2026-05-21T11:07:48.657Z
<!-- /CLOUDFLARE_PREVIEW -->