### PR TITLE
Type codemode e2e script contexts

### DIFF
--- a/apps/os/e2e/test-support/codemode-builder.ts
+++ b/apps/os/e2e/test-support/codemode-builder.ts
@@ -1,0 +1,156 @@
+// I wrote this by hand
+
+import type { Event } from "@iterate-com/shared/streams/types";
+import type { ReceiveFunctionCallResultInput } from "../../src/domains/codemode/durable-objects/codemode-session.ts";
+import { streamProjectEventsUntil, type OsClient } from "./os-client.ts";
+import type { AiCapability, ReposCapability, WorkspaceDurableObject } from "~/entry.workerd.ts";
+
+type OptionalProjectDeep<T> = T extends (
+  params: infer P extends { projectSlugOrId: string },
+) => infer R
+  ? (params: Omit<P, "projectSlugOrId"> & { projectSlugOrId?: string }) => R
+  : { [K in keyof T]: OptionalProjectDeep<T[K]> };
+
+type Stubify<T> = {
+  [K in keyof T]: T[K] extends (...args: infer A) => infer R
+    ? (
+        ...args: A
+      ) => Awaited<R> extends import("cloudflare:workers").RpcTarget
+        ? Stubify<Awaited<R>>
+        : Promise<Awaited<R>>
+    : Stubify<T[K]>;
+};
+
+export type DefaultCtx = {
+  os: OptionalProjectDeep<OsClient>;
+  ai: AiCapability;
+  codemode: { vars: {} };
+  env: {};
+  repos: Stubify<ReposCapability>;
+  workspace: Stubify<ReturnType<WorkspaceDurableObject["getShellState"]>>;
+};
+
+type ExecuteScriptParams = Parameters<OsClient["project"]["codemode"]["executeScript"]>[0];
+export type CodemodeBuilderOptions = Omit<ExecuteScriptParams, "code">;
+
+export class CodemodeBuilder<Ctx = DefaultCtx> {
+  constructor(
+    readonly os: OsClient,
+    readonly options: CodemodeBuilderOptions,
+  ) {}
+
+  stringify<Result>(fn: (ctx: Ctx) => Promise<Result>) {
+    const code = fn.toString();
+    return code.startsWith("async ") ? code : `async ${code}`;
+  }
+
+  define<Result>(fn: (ctx: Ctx) => Promise<Result>) {
+    return {
+      code: this.stringify(fn),
+      $ctx: {} as Ctx,
+      $type: {} as Result,
+    };
+  }
+
+  async start<NewCtx extends Ctx = {} extends Ctx ? any : Ctx, Result = {}>(
+    fn: (ctx: NewCtx) => Promise<Result>,
+  ) {
+    return this.os.project.codemode.executeScript({
+      code: this.context<NewCtx>().stringify(fn),
+      ...this.options,
+    });
+  }
+
+  async execute<NewCtx extends Ctx = Ctx, Result = {}>(fn: { (ctx: NewCtx): Promise<Result> }) {
+    const started = await this.start(fn);
+    const startedPayload = started.event.payload as { scriptExecutionId: string };
+    const isCompletedScriptExecution = (
+      event: Event,
+    ): event is Event & { payload: ReceiveFunctionCallResultInput } =>
+      event.type === "events.iterate.com/codemode/script-execution-completed" &&
+      (event.payload as ReceiveFunctionCallResultInput).scriptExecutionId ===
+        startedPayload.scriptExecutionId;
+
+    const events = await streamProjectEventsUntil({
+      afterOffset: started.event.offset > 1 ? started.event.offset - 1 : "start",
+      client: this.os,
+      projectSlugOrId: this.options.projectSlugOrId,
+      streamPath: started.streamPath,
+      // todo: proper strongly-typed version of this read-until helper
+      predicate: isCompletedScriptExecution,
+    });
+    const completed = events.find(isCompletedScriptExecution);
+    if (!completed) {
+      throw new Error(
+        `Expected completed script execution ${startedPayload.scriptExecutionId} in stream batch.`,
+      );
+    }
+    const payload = completed.payload;
+    return {
+      /** Raw payload from the completed event. Use `.success()` instead if you expect a successful result. */
+      payload,
+      /** Asserts that the script executed successfully and returns the strongly-typed result */
+      success: () => {
+        if (payload.outcome?.status !== "returned") {
+          throw new Error(`codemode: ${payload.outcome?.status}: ${payload.outcome.error}`, {
+            cause: completed,
+          });
+        }
+        return payload.outcome.value as Result;
+      },
+      /** The full completed event object, including the payload. */
+      event: completed as Omit<typeof completed, "payload"> & {
+        payload: ReceiveFunctionCallResultInput;
+      },
+      /** All events in the stream batch, including the completed event. */
+      events,
+      /**
+       * a snapshot-friendly copy of the completed event payload. optionally pass in key-value pairs to replace in the whole payload
+       * note: each `value` is replaced with `<key>` so `{ requestId: "abc123" }` replaces all `abc123` occurrences in the whole payload with `<requestId>`
+       */
+      snapshot: (redactions: Record<string, string> = {}) => {
+        let json = JSON.stringify(completed.payload);
+        // sort by length descending to avoid replacing substrings
+        const entries = Object.entries(redactions).sort((a, b) => b[0].length - a[0].length);
+        for (const [key, value] of entries) {
+          json = json.replaceAll(value, `<${key}>`);
+        }
+        const snapshottable = JSON.parse(json) as typeof payload;
+        snapshottable.durationMs = 999;
+        snapshottable.scriptExecutionId = "<script-execution-id>";
+        snapshottable.functionCallId = "<function-call-id>";
+        return snapshottable;
+      },
+    };
+  }
+
+  /** Type-only method to set the type of the codemode function's context parameter */
+  context<NewCtx, Mode extends "extend" | "replace" = "extend">() {
+    type ReplacementCtx = Mode extends "extend" ? NewCtx & Ctx : NewCtx;
+    return this as CodemodeBuilder<ReplacementCtx>;
+  }
+
+  /**
+   * Set a string template variable for the codemode function.
+   * This will be available to the codemode function as `ctx.codemode.vars.YOUR_VAR`.
+   */
+  var<Key extends string, Value extends string>(key: Key, value: Value) {
+    if (key.trim() === "") {
+      throw new Error("Codemode var key must not be blank.");
+    }
+
+    type OldCodemode = Ctx extends { codemode: infer OldCodemode } ? OldCodemode : {};
+    type OldVars = OldCodemode extends { vars: infer OldVars } ? OldVars : {};
+    type NewCtx = Ctx & { codemode: OldCodemode & { vars: OldVars & Record<Key, Value> } };
+    return new CodemodeBuilder<NewCtx>(this.os, {
+      ...this.options,
+      events: [
+        ...(this.options.events || []),
+        {
+          type: "events.iterate.com/codemode/vars-updated",
+          payload: { vars: { [key]: value } },
+        },
+      ],
+    });
+  }
+}

--- a/apps/os/e2e/test-support/codemode-builder.ts
+++ b/apps/os/e2e/test-support/codemode-builder.ts
@@ -111,7 +111,7 @@ export class CodemodeBuilder<Ctx = DefaultCtx> {
       snapshot: (redactions: Record<string, string> = {}) => {
         let json = JSON.stringify(completed.payload);
         // sort by length descending to avoid replacing substrings
-        const entries = Object.entries(redactions).sort((a, b) => b[0].length - a[0].length);
+        const entries = Object.entries(redactions).sort((a, b) => b[1].length - a[1].length);
         for (const [key, value] of entries) {
           json = json.replaceAll(value, `<${key}>`);
         }

--- a/apps/os/e2e/test-support/codemode-builder.ts
+++ b/apps/os/e2e/test-support/codemode-builder.ts
@@ -5,34 +5,6 @@ import type { ReceiveFunctionCallResultInput } from "../../src/domains/codemode/
 import { streamProjectEventsUntil, type OsClient } from "./os-client.ts";
 import type { AiCapability, ReposCapability, WorkspaceDurableObject } from "~/entry.workerd.ts";
 
-type OptionalProjectDeep<T> = T extends (
-  params: infer P extends { projectSlugOrId: string },
-) => infer R
-  ? (params: Omit<P, "projectSlugOrId"> & { projectSlugOrId?: string }) => R
-  : { [K in keyof T]: OptionalProjectDeep<T[K]> };
-
-type Stubify<T> = {
-  [K in keyof T]: T[K] extends (...args: infer A) => infer R
-    ? (
-        ...args: A
-      ) => Awaited<R> extends import("cloudflare:workers").RpcTarget
-        ? Stubify<Awaited<R>>
-        : Promise<Awaited<R>>
-    : Stubify<T[K]>;
-};
-
-export type DefaultCtx = {
-  os: OptionalProjectDeep<OsClient>;
-  ai: AiCapability;
-  codemode: { vars: {} };
-  env: {};
-  repos: Stubify<ReposCapability>;
-  workspace: Stubify<ReturnType<WorkspaceDurableObject["getShellState"]>>;
-};
-
-type ExecuteScriptParams = Parameters<OsClient["project"]["codemode"]["executeScript"]>[0];
-export type CodemodeBuilderOptions = Omit<ExecuteScriptParams, "code">;
-
 export class CodemodeBuilder<Ctx = DefaultCtx> {
   constructor(
     readonly os: OsClient,
@@ -154,3 +126,31 @@ export class CodemodeBuilder<Ctx = DefaultCtx> {
     });
   }
 }
+
+export type DefaultCtx = {
+  os: OptionalProjectDeep<OsClient>;
+  ai: AiCapability;
+  codemode: { vars: {} };
+  env: {};
+  repos: Stubify<ReposCapability>;
+  workspace: Stubify<ReturnType<WorkspaceDurableObject["getShellState"]>>;
+};
+
+type ExecuteScriptParams = Parameters<OsClient["project"]["codemode"]["executeScript"]>[0];
+export type CodemodeBuilderOptions = Omit<ExecuteScriptParams, "code">;
+
+type OptionalProjectDeep<T> = T extends (
+  params: infer P extends { projectSlugOrId: string },
+) => infer R
+  ? (params: Omit<P, "projectSlugOrId"> & { projectSlugOrId?: string }) => R
+  : { [K in keyof T]: OptionalProjectDeep<T[K]> };
+
+type Stubify<T> = {
+  [K in keyof T]: T[K] extends (...args: infer A) => infer R
+    ? (
+        ...args: A
+      ) => Awaited<R> extends import("cloudflare:workers").RpcTarget
+        ? Stubify<Awaited<R>>
+        : Promise<Awaited<R>>
+    : Stubify<T[K]>;
+};

--- a/apps/os/e2e/test-support/create-test-project.ts
+++ b/apps/os/e2e/test-support/create-test-project.ts
@@ -13,6 +13,7 @@ import {
   streamProjectEventsUntil,
   requireAdminBearerToken,
 } from "./os-client.ts";
+import type { AiCapability, ReposCapability, WorkspaceDurableObject } from "~/entry.workerd.ts";
 
 type Fetch = Parameters<typeof createCaptunTunnel>[0]["fetch"];
 
@@ -120,7 +121,30 @@ export async function createTestProjectFixture<
     };
   };
 
-  class CodemodeBuilder<Ctx = {}, This = {}> {
+  type OptionalProjectDeep<T> = T extends (
+    params: infer P extends { projectSlugOrId: string },
+  ) => infer R
+    ? (params: Omit<P, "projectSlugOrId"> & { projectSlugOrId?: string }) => R
+    : { [K in keyof T]: OptionalProjectDeep<T[K]> };
+
+  type Stubify<T> = {
+    [K in keyof T]: T[K] extends (...args: infer A) => infer R
+      ? (
+          ...args: A
+        ) => Awaited<R> extends import("cloudflare:workers").RpcTarget
+          ? Stubify<Awaited<R>>
+          : Promise<Awaited<R>>
+      : Stubify<T[K]>;
+  };
+
+  type DefaultCtx = {
+    os: OptionalProjectDeep<typeof project.os>;
+    ai: AiCapability;
+    repos: Stubify<ReposCapability>;
+    workspace: Stubify<ReturnType<WorkspaceDurableObject["getShellState"]>>;
+  };
+
+  class CodemodeBuilder<Ctx = DefaultCtx, This = {}> {
     _bound: This;
     _options: Omit<ExecuteScriptParams, "code">;
 
@@ -154,14 +178,15 @@ export async function createTestProjectFixture<
       return startCodemodeScript(this.define(fn), this._options);
     }
 
-    execute<NewCtx extends Ctx = {} extends Ctx ? any : Ctx, Result = {}>(fn: {
+    execute<NewCtx extends Ctx = Ctx, Result = {}>(fn: {
       (this: This, ctx: NewCtx): Promise<Result>;
     }) {
       return executeCodemodeScript(this.define(fn), this._options);
     }
     /** Type-only method to set the type of the codemode function's context parameter */
-    context<NewCtx>() {
-      return this as CodemodeBuilder<unknown, This> as CodemodeBuilder<NewCtx, This>;
+    context<NewCtx, Mode extends "extend" | "replace" = "extend">() {
+      type ReplacementCtx = Mode extends "extend" ? NewCtx & This : NewCtx;
+      return this as CodemodeBuilder<unknown, This> as CodemodeBuilder<ReplacementCtx, This>;
     }
     /**
      * Set some serializable data as the codemode function's `this` binding. Useful when your script needs to access something from outside its scope

--- a/apps/os/e2e/test-support/create-test-project.ts
+++ b/apps/os/e2e/test-support/create-test-project.ts
@@ -12,6 +12,7 @@ import {
   uniqueSuffix,
   streamProjectEventsUntil,
   requireAdminBearerToken,
+  type OsClient,
 } from "./os-client.ts";
 import type { AiCapability, ReposCapability, WorkspaceDurableObject } from "~/entry.workerd.ts";
 
@@ -44,199 +45,16 @@ export async function createTestProjectFixture<
     await project[Symbol.asyncDispose]();
     throw error;
   }
-  const fixture = project;
-  type ExecuteScriptParams = Parameters<
-    Awaited<ReturnType<typeof createTestProject>>["os"]["project"]["codemode"]["executeScript"]
-  >[0];
-
-  const startCodemodeScript = async <Result>(
-    script: { code: string; $type: Result },
-    opts: Omit<ExecuteScriptParams, "code">,
-  ) => {
-    const started = await project.os.project.codemode.executeScript({
-      code: script.code,
-      ...opts,
-    });
-
-    return {
-      ...script,
-      ...started,
-    };
-  };
-
-  const executeCodemodeScript = async <Result>(
-    script: { code: string; $type: Result },
-    opts: Omit<ExecuteScriptParams, "code">,
-  ) => {
-    const started = await startCodemodeScript(script, opts);
-    const startedPayload = started.event.payload as { scriptExecutionId: string };
-    const isCompletedScriptExecution = (
-      event: Event,
-    ): event is Event & { payload: ReceiveFunctionCallResultInput } =>
-      event.type === "events.iterate.com/codemode/script-execution-completed" &&
-      (event.payload as ReceiveFunctionCallResultInput).scriptExecutionId ===
-        startedPayload.scriptExecutionId;
-
-    const events = await streamProjectEventsUntil({
-      afterOffset: started.event.offset > 1 ? started.event.offset - 1 : "start",
-      client: fixture.client,
-      projectSlugOrId: fixture.project.id,
-      streamPath: started.streamPath,
-      // todo: proper strongly-typed version of this read-until helper
-      predicate: isCompletedScriptExecution,
-    });
-    const completed = events.find(isCompletedScriptExecution);
-    if (!completed) {
-      throw new Error(
-        `Expected completed script execution ${startedPayload.scriptExecutionId} in stream batch.`,
-      );
-    }
-    const payload = completed.payload;
-    return {
-      payload,
-      success: () => {
-        if (payload.outcome?.status !== "returned") {
-          throw new Error(`codemode: ${payload.outcome?.status}: ${payload.outcome.error}`, {
-            cause: completed,
-          });
-        }
-        return payload.outcome.value as Result;
-      },
-      event: completed as Omit<typeof completed, "payload"> & {
-        payload: ReceiveFunctionCallResultInput;
-      },
-      events,
-      /** get a snapshot-friendly copy of the completed event payload. optionally pass in key-value pairs to replace in the whole payload */
-      snapshot: (swaps: Record<string, string> = {}) => {
-        let json = JSON.stringify(completed.payload);
-        for (const [key, value] of Object.entries(swaps)) {
-          json = json.replaceAll(value, `<${key}>`);
-        }
-        const snapshottable = JSON.parse(json) as typeof payload;
-        snapshottable.durationMs = 999;
-        snapshottable.scriptExecutionId = "<script-execution-id>";
-        snapshottable.functionCallId = "<function-call-id>";
-        return snapshottable;
-      },
-    };
-  };
-
-  type OptionalProjectDeep<T> = T extends (
-    params: infer P extends { projectSlugOrId: string },
-  ) => infer R
-    ? (params: Omit<P, "projectSlugOrId"> & { projectSlugOrId?: string }) => R
-    : { [K in keyof T]: OptionalProjectDeep<T[K]> };
-
-  type Stubify<T> = {
-    [K in keyof T]: T[K] extends (...args: infer A) => infer R
-      ? (
-          ...args: A
-        ) => Awaited<R> extends import("cloudflare:workers").RpcTarget
-          ? Stubify<Awaited<R>>
-          : Promise<Awaited<R>>
-      : Stubify<T[K]>;
-  };
-
-  type DefaultCtx = {
-    os: OptionalProjectDeep<typeof project.os>;
-    ai: AiCapability;
-    repos: Stubify<ReposCapability>;
-    workspace: Stubify<ReturnType<WorkspaceDurableObject["getShellState"]>>;
-  };
-
-  class CodemodeBuilder<Ctx = DefaultCtx, This = {}> {
-    _bound: This;
-    _options: Omit<ExecuteScriptParams, "code">;
-
-    constructor(params: { options: Omit<ExecuteScriptParams, "code">; bound: This }) {
-      this._bound = params.bound;
-      this._options = params.options;
-    }
-
-    stringify<Result>(fn: { (this: This, ctx: Ctx): Promise<Result> }) {
-      let code = fn.toString();
-      if (!code.startsWith("async")) {
-        code = `async ${code}`;
-      }
-      return {
-        code,
-        $ctx: {} as Ctx,
-        $type: {} as Result,
-      };
-    }
-
-    options(newOptions: Partial<typeof this._options>) {
-      return new CodemodeBuilder<Ctx, This>({
-        options: { ...this._options, ...newOptions },
-        bound: this._bound,
-      });
-    }
-
-    start<NewCtx extends Ctx = {} extends Ctx ? any : Ctx, Result = {}>(fn: {
-      (this: This, ctx: NewCtx): Promise<Result>;
-    }) {
-      return startCodemodeScript(this.define(fn), this._options);
-    }
-
-    execute<NewCtx extends Ctx = Ctx, Result = {}>(fn: {
-      (this: This, ctx: NewCtx): Promise<Result>;
-    }) {
-      return executeCodemodeScript(this.define(fn), this._options);
-    }
-    /** Type-only method to set the type of the codemode function's context parameter */
-    context<NewCtx, Mode extends "extend" | "replace" = "extend">() {
-      type ReplacementCtx = Mode extends "extend" ? NewCtx & This : NewCtx;
-      return this as CodemodeBuilder<unknown, This> as CodemodeBuilder<ReplacementCtx, This>;
-    }
-    /**
-     * Set some serializable data as the codemode function's `this` binding. Useful when your script needs to access something from outside its scope
-     * @example
-     * ```ts
-     * using publicTunnel = await createPublicTunnel({ fetch: async () => new Response("ok") });
-     *
-     * const result = await fixture.codemode
-     *   .bind({ baseUrl: publicTunnel.url })
-     *   .execute(async function () {
-     *     const response = await fetch(`${this.baseUrl}/foobar`);
-     *     return response.json();
-     *   });
-     * ```
-     */
-    bind<NewThis>(bound: NewThis) {
-      try {
-        return new CodemodeBuilder<Ctx, NewThis>({
-          options: this._options,
-          bound: structuredClone(bound),
-        });
-      } catch (error) {
-        throw new Error(`Binding value passed to .bind() must be serializable`, { cause: error });
-      }
-    }
-    define<NewCtx extends Ctx = {} extends Ctx ? any : Ctx, Result = {}>(fn: {
-      (this: This, ctx: NewCtx): Promise<Result>;
-    }) {
-      const script = this.context<NewCtx>().stringify<Result>(fn);
-      const boundJson = JSON.stringify(this._bound || {});
-      if (boundJson !== "{}") {
-        const indentedCode = script.code.replace(/\n/g, "\n  ");
-        script.code = [
-          `async (ctx) => {`,
-          `  return await (${indentedCode}).bind(${boundJson})(ctx)`,
-          `}`,
-        ].join("\n");
-      }
-      return script;
-    }
-  }
 
   return {
     ...project,
     /** recommended test stream path - arbitrary, but by convention mirrors test file + name as its path (`/${relativeFilePath}/${describeSlug}/${testSlug}`)  */
     streamPath,
     slugPrefix,
-    codemode: new CodemodeBuilder({
-      options: { projectSlugOrId: project.project.slug, providers: [], streamPath },
-      bound: {},
+    codemode: new CodemodeBuilder(project.os, {
+      projectSlugOrId: project.project.slug,
+      providers: [],
+      streamPath,
     }),
     /** strongly-typed event constructor for the given processor contracts */
     event: (event: ProcessorContractEvent<ProcessorContracts>) => event,
@@ -259,6 +77,153 @@ export async function createTestProjectFixture<
       }
     },
   };
+}
+
+type OptionalProjectDeep<T> = T extends (
+  params: infer P extends { projectSlugOrId: string },
+) => infer R
+  ? (params: Omit<P, "projectSlugOrId"> & { projectSlugOrId?: string }) => R
+  : { [K in keyof T]: OptionalProjectDeep<T[K]> };
+
+type Stubify<T> = {
+  [K in keyof T]: T[K] extends (...args: infer A) => infer R
+    ? (
+        ...args: A
+      ) => Awaited<R> extends import("cloudflare:workers").RpcTarget
+        ? Stubify<Awaited<R>>
+        : Promise<Awaited<R>>
+    : Stubify<T[K]>;
+};
+
+type DefaultCtx = {
+  os: OptionalProjectDeep<OsClient>;
+  ai: AiCapability;
+  env: {};
+  repos: Stubify<ReposCapability>;
+  workspace: Stubify<ReturnType<WorkspaceDurableObject["getShellState"]>>;
+};
+
+type ExecuteScriptParams = Parameters<OsClient["project"]["codemode"]["executeScript"]>[0];
+type CodemodeBuilderOptions = Omit<ExecuteScriptParams, "code">;
+
+class CodemodeBuilder<Ctx = DefaultCtx> {
+  constructor(
+    readonly os: OsClient,
+    readonly options: CodemodeBuilderOptions,
+  ) {}
+
+  stringify<Result>(fn: (ctx: Ctx) => Promise<Result>) {
+    const code = fn.toString();
+    return code.startsWith("async ") ? code : `async ${code}`;
+  }
+
+  define<Result>(fn: (ctx: Ctx) => Promise<Result>) {
+    return {
+      code: this.stringify(fn),
+      $ctx: {} as Ctx,
+      $type: {} as Result,
+    };
+  }
+
+  async start<NewCtx extends Ctx = {} extends Ctx ? any : Ctx, Result = {}>(
+    fn: (ctx: NewCtx) => Promise<Result>,
+  ) {
+    return this.os.project.codemode.executeScript({
+      code: this.context<NewCtx>().stringify(fn),
+      ...this.options,
+    });
+  }
+
+  async execute<NewCtx extends Ctx = Ctx, Result = {}>(fn: { (ctx: NewCtx): Promise<Result> }) {
+    const started = await this.start(fn);
+    const startedPayload = started.event.payload as { scriptExecutionId: string };
+    const isCompletedScriptExecution = (
+      event: Event,
+    ): event is Event & { payload: ReceiveFunctionCallResultInput } =>
+      event.type === "events.iterate.com/codemode/script-execution-completed" &&
+      (event.payload as ReceiveFunctionCallResultInput).scriptExecutionId ===
+        startedPayload.scriptExecutionId;
+
+    const events = await streamProjectEventsUntil({
+      afterOffset: started.event.offset > 1 ? started.event.offset - 1 : "start",
+      client: this.os,
+      projectSlugOrId: this.options.projectSlugOrId,
+      streamPath: started.streamPath,
+      // todo: proper strongly-typed version of this read-until helper
+      predicate: isCompletedScriptExecution,
+    });
+    const completed = events.find(isCompletedScriptExecution);
+    if (!completed) {
+      throw new Error(
+        `Expected completed script execution ${startedPayload.scriptExecutionId} in stream batch.`,
+      );
+    }
+    const payload = completed.payload;
+    return {
+      /** Raw payload from the completed event. Use `.success()` instead if you expect a successful result. */
+      payload,
+      /** Asserts that the script executed successfully and returns the strongly-typed result */
+      success: () => {
+        if (payload.outcome?.status !== "returned") {
+          throw new Error(`codemode: ${payload.outcome?.status}: ${payload.outcome.error}`, {
+            cause: completed,
+          });
+        }
+        return payload.outcome.value as Result;
+      },
+      /** The full completed event object, including the payload. */
+      event: completed as Omit<typeof completed, "payload"> & {
+        payload: ReceiveFunctionCallResultInput;
+      },
+      /** All events in the stream batch, including the completed event. */
+      events,
+      /**
+       * a snapshot-friendly copy of the completed event payload. optionally pass in key-value pairs to replace in the whole payload
+       * note: each `value` is replaced with `<key>` so `{ requestId: "abc123" }` replaces all `abc123` occurrences in the whole payload with `<requestId>`
+       */
+      snapshot: (redactions: Record<string, string> = {}) => {
+        let json = JSON.stringify(completed.payload);
+        // sort by length descending to avoid replacing substrings
+        const entries = Object.entries(redactions).sort((a, b) => b[0].length - a[0].length);
+        for (const [key, value] of entries) {
+          json = json.replaceAll(value, `<${key}>`);
+        }
+        const snapshottable = JSON.parse(json) as typeof payload;
+        snapshottable.durationMs = 999;
+        snapshottable.scriptExecutionId = "<script-execution-id>";
+        snapshottable.functionCallId = "<function-call-id>";
+        return snapshottable;
+      },
+    };
+  }
+  /** Type-only method to set the type of the codemode function's context parameter */
+  context<NewCtx, Mode extends "extend" | "replace" = "extend">() {
+    type ReplacementCtx = Mode extends "extend" ? NewCtx & Ctx : NewCtx;
+    return this as CodemodeBuilder<ReplacementCtx>;
+  }
+
+  /**
+   * Set an environment variable for the codemode function.
+   * This will be available to the codemode function as `ctx.env.YOUR_ENV_VAR`.
+   */
+  env<Key extends string, Value extends string>(key: Key, value: Value) {
+    if (key.trim() === "") {
+      throw new Error("Codemode env key must not be blank.");
+    }
+
+    type OldEnv = Ctx extends { env: infer OldEnv } ? OldEnv : never;
+    type NewCtx = Ctx & { env: OldEnv & Record<Key, Value> };
+    return new CodemodeBuilder<NewCtx>(this.os, {
+      ...this.options,
+      events: [
+        ...(this.options.events || []),
+        {
+          type: "events.iterate.com/codemode/env-updated",
+          payload: { env: { [key]: value } },
+        },
+      ],
+    });
+  }
 }
 
 type ProcessorContractEvent<ProcessorContracts extends ProcessorContractShape[]> =

--- a/apps/os/e2e/test-support/create-test-project.ts
+++ b/apps/os/e2e/test-support/create-test-project.ts
@@ -1,20 +1,17 @@
 import path from "node:path";
-import type { Event, EventInput } from "@iterate-com/shared/streams/types";
+import type { EventInput } from "@iterate-com/shared/streams/types";
 import type { Project } from "@iterate-com/os-contract";
 import { createCaptunTunnel } from "captun";
 import { expect } from "vitest";
 import { slugify } from "@iterate-com/shared/slug";
 import type { ProcessorContractShape } from "@iterate-com/shared/stream-processors";
-import type { ReceiveFunctionCallResultInput } from "../../src/domains/codemode/durable-objects/codemode-session.ts";
 import {
   createAdminOsClient,
   requireBaseUrl,
   uniqueSuffix,
-  streamProjectEventsUntil,
   requireAdminBearerToken,
-  type OsClient,
 } from "./os-client.ts";
-import type { AiCapability, ReposCapability, WorkspaceDurableObject } from "~/entry.workerd.ts";
+import { CodemodeBuilder } from "./codemode-builder.ts";
 
 type Fetch = Parameters<typeof createCaptunTunnel>[0]["fetch"];
 
@@ -77,155 +74,6 @@ export async function createTestProjectFixture<
       }
     },
   };
-}
-
-type OptionalProjectDeep<T> = T extends (
-  params: infer P extends { projectSlugOrId: string },
-) => infer R
-  ? (params: Omit<P, "projectSlugOrId"> & { projectSlugOrId?: string }) => R
-  : { [K in keyof T]: OptionalProjectDeep<T[K]> };
-
-type Stubify<T> = {
-  [K in keyof T]: T[K] extends (...args: infer A) => infer R
-    ? (
-        ...args: A
-      ) => Awaited<R> extends import("cloudflare:workers").RpcTarget
-        ? Stubify<Awaited<R>>
-        : Promise<Awaited<R>>
-    : Stubify<T[K]>;
-};
-
-type DefaultCtx = {
-  os: OptionalProjectDeep<OsClient>;
-  ai: AiCapability;
-  codemode: { vars: {} };
-  env: {};
-  repos: Stubify<ReposCapability>;
-  workspace: Stubify<ReturnType<WorkspaceDurableObject["getShellState"]>>;
-};
-
-type ExecuteScriptParams = Parameters<OsClient["project"]["codemode"]["executeScript"]>[0];
-type CodemodeBuilderOptions = Omit<ExecuteScriptParams, "code">;
-
-class CodemodeBuilder<Ctx = DefaultCtx> {
-  constructor(
-    readonly os: OsClient,
-    readonly options: CodemodeBuilderOptions,
-  ) {}
-
-  stringify<Result>(fn: (ctx: Ctx) => Promise<Result>) {
-    const code = fn.toString();
-    return code.startsWith("async ") ? code : `async ${code}`;
-  }
-
-  define<Result>(fn: (ctx: Ctx) => Promise<Result>) {
-    return {
-      code: this.stringify(fn),
-      $ctx: {} as Ctx,
-      $type: {} as Result,
-    };
-  }
-
-  async start<NewCtx extends Ctx = {} extends Ctx ? any : Ctx, Result = {}>(
-    fn: (ctx: NewCtx) => Promise<Result>,
-  ) {
-    return this.os.project.codemode.executeScript({
-      code: this.context<NewCtx>().stringify(fn),
-      ...this.options,
-    });
-  }
-
-  async execute<NewCtx extends Ctx = Ctx, Result = {}>(fn: { (ctx: NewCtx): Promise<Result> }) {
-    const started = await this.start(fn);
-    const startedPayload = started.event.payload as { scriptExecutionId: string };
-    const isCompletedScriptExecution = (
-      event: Event,
-    ): event is Event & { payload: ReceiveFunctionCallResultInput } =>
-      event.type === "events.iterate.com/codemode/script-execution-completed" &&
-      (event.payload as ReceiveFunctionCallResultInput).scriptExecutionId ===
-        startedPayload.scriptExecutionId;
-
-    const events = await streamProjectEventsUntil({
-      afterOffset: started.event.offset > 1 ? started.event.offset - 1 : "start",
-      client: this.os,
-      projectSlugOrId: this.options.projectSlugOrId,
-      streamPath: started.streamPath,
-      // todo: proper strongly-typed version of this read-until helper
-      predicate: isCompletedScriptExecution,
-    });
-    const completed = events.find(isCompletedScriptExecution);
-    if (!completed) {
-      throw new Error(
-        `Expected completed script execution ${startedPayload.scriptExecutionId} in stream batch.`,
-      );
-    }
-    const payload = completed.payload;
-    return {
-      /** Raw payload from the completed event. Use `.success()` instead if you expect a successful result. */
-      payload,
-      /** Asserts that the script executed successfully and returns the strongly-typed result */
-      success: () => {
-        if (payload.outcome?.status !== "returned") {
-          throw new Error(`codemode: ${payload.outcome?.status}: ${payload.outcome.error}`, {
-            cause: completed,
-          });
-        }
-        return payload.outcome.value as Result;
-      },
-      /** The full completed event object, including the payload. */
-      event: completed as Omit<typeof completed, "payload"> & {
-        payload: ReceiveFunctionCallResultInput;
-      },
-      /** All events in the stream batch, including the completed event. */
-      events,
-      /**
-       * a snapshot-friendly copy of the completed event payload. optionally pass in key-value pairs to replace in the whole payload
-       * note: each `value` is replaced with `<key>` so `{ requestId: "abc123" }` replaces all `abc123` occurrences in the whole payload with `<requestId>`
-       */
-      snapshot: (redactions: Record<string, string> = {}) => {
-        let json = JSON.stringify(completed.payload);
-        // sort by length descending to avoid replacing substrings
-        const entries = Object.entries(redactions).sort((a, b) => b[0].length - a[0].length);
-        for (const [key, value] of entries) {
-          json = json.replaceAll(value, `<${key}>`);
-        }
-        const snapshottable = JSON.parse(json) as typeof payload;
-        snapshottable.durationMs = 999;
-        snapshottable.scriptExecutionId = "<script-execution-id>";
-        snapshottable.functionCallId = "<function-call-id>";
-        return snapshottable;
-      },
-    };
-  }
-  /** Type-only method to set the type of the codemode function's context parameter */
-  context<NewCtx, Mode extends "extend" | "replace" = "extend">() {
-    type ReplacementCtx = Mode extends "extend" ? NewCtx & Ctx : NewCtx;
-    return this as CodemodeBuilder<ReplacementCtx>;
-  }
-
-  /**
-   * Set a string template variable for the codemode function.
-   * This will be available to the codemode function as `ctx.codemode.vars.YOUR_VAR`.
-   */
-  var<Key extends string, Value extends string>(key: Key, value: Value) {
-    if (key.trim() === "") {
-      throw new Error("Codemode var key must not be blank.");
-    }
-
-    type OldCodemode = Ctx extends { codemode: infer OldCodemode } ? OldCodemode : {};
-    type OldVars = OldCodemode extends { vars: infer OldVars } ? OldVars : {};
-    type NewCtx = Ctx & { codemode: OldCodemode & { vars: OldVars & Record<Key, Value> } };
-    return new CodemodeBuilder<NewCtx>(this.os, {
-      ...this.options,
-      events: [
-        ...(this.options.events || []),
-        {
-          type: "events.iterate.com/codemode/vars-updated",
-          payload: { vars: { [key]: value } },
-        },
-      ],
-    });
-  }
 }
 
 type ProcessorContractEvent<ProcessorContracts extends ProcessorContractShape[]> =

--- a/apps/os/e2e/test-support/create-test-project.ts
+++ b/apps/os/e2e/test-support/create-test-project.ts
@@ -98,6 +98,7 @@ type Stubify<T> = {
 type DefaultCtx = {
   os: OptionalProjectDeep<OsClient>;
   ai: AiCapability;
+  codemode: { vars: {} };
   env: {};
   repos: Stubify<ReposCapability>;
   workspace: Stubify<ReturnType<WorkspaceDurableObject["getShellState"]>>;
@@ -203,23 +204,24 @@ class CodemodeBuilder<Ctx = DefaultCtx> {
   }
 
   /**
-   * Set an environment variable for the codemode function.
-   * This will be available to the codemode function as `ctx.env.YOUR_ENV_VAR`.
+   * Set a string template variable for the codemode function.
+   * This will be available to the codemode function as `ctx.codemode.vars.YOUR_VAR`.
    */
-  env<Key extends string, Value extends string>(key: Key, value: Value) {
+  var<Key extends string, Value extends string>(key: Key, value: Value) {
     if (key.trim() === "") {
-      throw new Error("Codemode env key must not be blank.");
+      throw new Error("Codemode var key must not be blank.");
     }
 
-    type OldEnv = Ctx extends { env: infer OldEnv } ? OldEnv : never;
-    type NewCtx = Ctx & { env: OldEnv & Record<Key, Value> };
+    type OldCodemode = Ctx extends { codemode: infer OldCodemode } ? OldCodemode : {};
+    type OldVars = OldCodemode extends { vars: infer OldVars } ? OldVars : {};
+    type NewCtx = Ctx & { codemode: OldCodemode & { vars: OldVars & Record<Key, Value> } };
     return new CodemodeBuilder<NewCtx>(this.os, {
       ...this.options,
       events: [
         ...(this.options.events || []),
         {
-          type: "events.iterate.com/codemode/env-updated",
-          payload: { env: { [key]: value } },
+          type: "events.iterate.com/codemode/vars-updated",
+          payload: { vars: { [key]: value } },
         },
       ],
     });

--- a/apps/os/e2e/vitest/e2e-test-map.e2e.test.ts
+++ b/apps/os/e2e/vitest/e2e-test-map.e2e.test.ts
@@ -77,9 +77,9 @@ describe("e2e test map", () => {
     });
 
     const result = await fixture.codemode
-      .env("PUBLIC_TUNNEL_URL", publicTunnel.url)
+      .var("PUBLIC_TUNNEL_URL", publicTunnel.url)
       .execute(async (ctx) => {
-        const response = await fetch(`${ctx.env.PUBLIC_TUNNEL_URL}/anything`, {
+        const response = await fetch(`${ctx.codemode.vars.PUBLIC_TUNNEL_URL}/anything`, {
           headers: { Authorization: "Bearer getSecret('blabla')" },
         });
         return response.json();

--- a/apps/os/e2e/vitest/e2e-test-map.e2e.test.ts
+++ b/apps/os/e2e/vitest/e2e-test-map.e2e.test.ts
@@ -122,9 +122,11 @@ describe("e2e test map", () => {
       },
     });
 
-    const result = await fixture.codemode.execute(async (ctx: any) => {
-      return ctx.petstore.getInventory();
-    });
+    const result = await fixture.codemode
+      .context<{ petstore: { getInventory: () => Promise<unknown> } }>()
+      .execute(async (ctx) => {
+        return ctx.petstore.getInventory();
+      });
 
     expect(result.success()).toMatchObject({
       available: expect.any(Number),
@@ -139,22 +141,12 @@ describe("e2e test map", () => {
     });
     mcpServer.registerTool(
       "my_funky_search",
-      {
-        description: "Search the web",
-        inputSchema: {
-          numResults: z.number(),
-          query: z.string(),
-        },
-      },
-      ({ numResults, query }) => {
-        const structuredContent = {
-          numResults,
-          query,
-          result: "search result",
-        };
+      { description: "Search the web", inputSchema: { query: z.string() } },
+      ({ query }) => {
+        const data = { result: `search result for ${query}` };
         return {
-          content: [{ text: JSON.stringify(structuredContent), type: "text" }],
-          structuredContent,
+          content: [{ text: JSON.stringify(data), type: "text" }],
+          structuredContent: data,
         };
       },
     );
@@ -205,24 +197,27 @@ describe("e2e test map", () => {
       },
     });
 
-    const result = await fixture.codemode.execute(async (ctx: any) => {
-      const tools = await ctx.mcp.publicTunnelSearch.listTools();
-      const search = await ctx.mcp.publicTunnelSearch.my_funky_search({
-        numResults: 2,
-        query: "public tunnel mcp",
+    const result = await fixture.codemode
+      .context<{
+        mcp: {
+          publicTunnelSearch: {
+            listTools: () => Promise<{ tools: unknown[] }>;
+            my_funky_search: (input: { numResults: number; query: string }) => Promise<unknown>;
+          };
+        };
+      }>()
+      .execute(async (ctx) => {
+        const { tools } = await ctx.mcp.publicTunnelSearch.listTools();
+        const search = await ctx.mcp.publicTunnelSearch.my_funky_search({
+          numResults: 2,
+          query: "public tunnel mcp",
+        });
+        return { search, tools };
       });
-      return { search, tools };
-    });
 
     expect(result.success()).toMatchObject({
-      search: {
-        numResults: 2,
-        query: "public tunnel mcp",
-        result: "search result",
-      },
-      tools: {
-        tools: [{ description: "Search the web", name: "my_funky_search" }],
-      },
+      search: { result: "search result for public tunnel mcp" },
+      tools: [{ description: "Search the web", name: "my_funky_search" }],
     });
   });
 
@@ -243,7 +238,7 @@ describe("e2e test map", () => {
       },
     });
 
-    const result = await fixture.codemode.execute(async (ctx: any) => {
+    const result = await fixture.codemode.execute(async (ctx) => {
       return await ctx.os.project.get({});
     });
 
@@ -270,7 +265,7 @@ describe("e2e test map", () => {
       },
     });
 
-    const result = await fixture.codemode.execute(async (ctx: any) => {
+    const result = await fixture.codemode.execute(async (ctx) => {
       const ai = await ctx.ai.run("@cf/meta/llama-3.1-8b-instruct", {
         prompt: "What is one plus two",
       });
@@ -302,7 +297,7 @@ describe("e2e test map", () => {
       },
     });
 
-    const result = await fixture.codemode.execute(async (ctx: any) => {
+    const result = await fixture.codemode.execute(async (ctx) => {
       const slug = `pipeline-${Date.now()}`;
       // look ma, no intermediate await!
       return await ctx.repos.create({ slug }).getInfo();
@@ -317,11 +312,11 @@ describe("e2e test map", () => {
   test("can use workspace tools", async () => {
     await using fixture = await createTestProjectFixture({});
 
-    await fixture.codemode.execute(async (ctx: any) => {
+    await fixture.codemode.execute(async (ctx) => {
       await ctx.workspace.writeFile("greeting.txt", "hiya");
     });
 
-    const result = await fixture.codemode.execute(async (ctx: any) => {
+    const result = await fixture.codemode.execute(async (ctx) => {
       const text = await ctx.workspace.readFile("greeting.txt");
       return { text };
     });
@@ -334,7 +329,7 @@ describe("e2e test map", () => {
   test("workspace can clone public github repo", async () => {
     await using fixture = await createTestProjectFixture({});
 
-    const result = await fixture.codemode.execute(async (ctx: any) => {
+    const result = await fixture.codemode.execute(async (ctx) => {
       await ctx.workspace.git.clone({
         dir: "/captun",
         depth: 1,
@@ -364,7 +359,7 @@ describe("e2e test map", () => {
       },
     });
 
-    const result = await fixture.codemode.execute(async (ctx: any) => {
+    const result = await fixture.codemode.execute(async (ctx) => {
       const proof = `hello from iterate config ${Date.now()}`;
       const repo = await ctx.repos.ensureIterateConfigInfo({ projectSlug: null });
       const dir = `/iterate-config-${Date.now()}`;

--- a/apps/os/e2e/vitest/e2e-test-map.e2e.test.ts
+++ b/apps/os/e2e/vitest/e2e-test-map.e2e.test.ts
@@ -77,9 +77,9 @@ describe("e2e test map", () => {
     });
 
     const result = await fixture.codemode
-      .bind({ baseUrl: publicTunnel.url })
-      .execute(async function () {
-        const response = await fetch(`${this.baseUrl}/anything`, {
+      .env("PUBLIC_TUNNEL_URL", publicTunnel.url)
+      .execute(async (ctx) => {
+        const response = await fetch(`${ctx.env.PUBLIC_TUNNEL_URL}/anything`, {
           headers: { Authorization: "Bearer getSecret('blabla')" },
         });
         return response.json();

--- a/apps/os/src/domains/codemode/durable-objects/codemode-session.ts
+++ b/apps/os/src/domains/codemode/durable-objects/codemode-session.ts
@@ -849,7 +849,7 @@ function createCloudflareCodemodeScriptExecutor(input: {
   loader: WorkerLoader | undefined;
   outboundFetch: Fetcher;
 }): CodemodeScriptExecutor {
-  return async ({ code, logger, scriptExecutionId, session }) => {
+  return async ({ code, env, logger, scriptExecutionId, session }) => {
     if (!input.loader) {
       return {
         result: undefined,
@@ -869,7 +869,10 @@ function createCloudflareCodemodeScriptExecutor(input: {
             "executor.js": buildScriptExecutorModule(),
             "user-code.js": buildUserCodeModule(code),
           },
-          env: input.env,
+          env: {
+            ...(input.env || {}),
+            ...env,
+          },
           globalOutbound: input.outboundFetch,
         })
         .getEntrypoint() as unknown as CodemodeExecutorEntrypoint;
@@ -1047,12 +1050,12 @@ function __stringify(value) {
 	        return {
 	          log: (...args) => console.log(...args),
 	          warn: (...args) => console.warn(...args),
-          error: (...args) => console.error(...args),
-        };
-      }
-      if (key === "env" && path.length === 0) return options.env;
-      if (typeof key !== "string") return undefined;
-      return make([...path, key]);
+            error: (...args) => console.error(...args),
+          };
+        }
+        if (key === "env" && path.length === 0) return options.env;
+        if (typeof key !== "string") return undefined;
+        return make([...path, key]);
 	    },
 	    apply: (_target, _thisArg, args) => {
 	      return trackCallResult(options.codemodeSessionCapability.callFunction({

--- a/apps/os/src/domains/codemode/durable-objects/codemode-session.ts
+++ b/apps/os/src/domains/codemode/durable-objects/codemode-session.ts
@@ -131,6 +131,7 @@ type CodemodeExecutorEntrypoint = {
     capability: CodemodeSessionCapabilityTarget,
     logger: CodemodeLoggerTarget,
     scriptExecutionId: string,
+    vars: Record<string, string>,
   ): Promise<{ error?: string; result: unknown }>;
 };
 type DisposableRpcValue = {
@@ -844,12 +845,12 @@ function resolveProcessorStreamPath(input: { basePath: StreamPath; pathInput?: s
 }
 
 function createCloudflareCodemodeScriptExecutor(input: {
-  env?: Record<string, unknown>;
+  env: Record<string, unknown>;
   getSessionCapability?: () => CodemodeProcessorSession;
   loader: WorkerLoader | undefined;
   outboundFetch: Fetcher;
 }): CodemodeScriptExecutor {
-  return async ({ code, env, logger, scriptExecutionId, session }) => {
+  return async ({ code, logger, scriptExecutionId, session, vars }) => {
     if (!input.loader) {
       return {
         result: undefined,
@@ -869,10 +870,7 @@ function createCloudflareCodemodeScriptExecutor(input: {
             "executor.js": buildScriptExecutorModule(),
             "user-code.js": buildUserCodeModule(code),
           },
-          env: {
-            ...(input.env || {}),
-            ...env,
-          },
+          env: input.env,
           globalOutbound: input.outboundFetch,
         })
         .getEntrypoint() as unknown as CodemodeExecutorEntrypoint;
@@ -886,6 +884,7 @@ function createCloudflareCodemodeScriptExecutor(input: {
         new CodemodeSessionCapabilityTarget(input.getSessionCapability?.() ?? session),
         new CodemodeLoggerTarget(logger),
         scriptExecutionId,
+        vars,
       );
       try {
         // `evaluate()` is itself a Workers RPC call into the dynamic executor.
@@ -1054,6 +1053,7 @@ function __stringify(value) {
           };
         }
         if (key === "env" && path.length === 0) return options.env;
+        if (key === "vars" && path.length === 1 && path[0] === "codemode") return options.vars;
         if (typeof key !== "string") return undefined;
         return make([...path, key]);
 	    },
@@ -1070,7 +1070,7 @@ function __stringify(value) {
 }
 
 	export default class CodeExecutor extends WorkerEntrypoint {
-	  async evaluate(__codemodeSessionCapability, __logger, __scriptExecutionId) {
+	  async evaluate(__codemodeSessionCapability, __logger, __scriptExecutionId, __codemodeVars) {
 	    const __pendingLogs = [];
 	    const __emitLog = (level, args) => {
 	      const message = args.map(__stringify).join(" ");
@@ -1102,6 +1102,7 @@ function __stringify(value) {
 	      codemodeSessionCapability: __codemodeSessionCapability,
 	      env: this.env,
 	      scriptExecutionId: __scriptExecutionId,
+	      vars: __codemodeVars,
 	    });
 
 	    try {

--- a/apps/os/src/domains/workspaces/durable-objects/workspace-durable-object.ts
+++ b/apps/os/src/domains/workspaces/durable-objects/workspace-durable-object.ts
@@ -11,7 +11,7 @@ export type WorkspaceStructuredName = {
 
 export type CloudflareShellState = import("@cloudflare/shell").StateBackend & {
   git: import("@cloudflare/shell/git").Git;
-};
+} & Record<string, unknown>;
 
 const WorkspaceStructuredName = z.object({
   projectId: z.string().trim().min(1),

--- a/apps/os/src/domains/workspaces/durable-objects/workspace-durable-object.ts
+++ b/apps/os/src/domains/workspaces/durable-objects/workspace-durable-object.ts
@@ -9,7 +9,9 @@ export type WorkspaceStructuredName = {
   workspaceId: string;
 };
 
-export type CloudflareShellState = Record<string, (...args: unknown[]) => Promise<unknown>>;
+export type CloudflareShellState = import("@cloudflare/shell").StateBackend & {
+  git: import("@cloudflare/shell/git").Git;
+};
 
 const WorkspaceStructuredName = z.object({
   projectId: z.string().trim().min(1),
@@ -138,16 +140,19 @@ export function getWorkspaceDurableObjectName(name: WorkspaceStructuredName) {
 }
 
 function createPlainMethodObject(target: object): CloudflareShellState {
-  const methods: CloudflareShellState = {};
+  const methods = {} as CloudflareShellState;
   let prototype: object | null = Object.getPrototypeOf(target);
 
   while (prototype !== null && prototype !== Object.prototype) {
     for (const name of Object.getOwnPropertyNames(prototype)) {
-      if (name === "constructor" || methods[name] !== undefined) continue;
+      if (name === "constructor" || methods[name as keyof CloudflareShellState] !== undefined)
+        continue;
 
       const value = (target as Record<string, unknown>)[name];
       if (typeof value === "function") {
-        methods[name] = async (...args: unknown[]) => await value.apply(target, args);
+        Object.assign(methods, {
+          [name]: async (...args: unknown[]) => await value.apply(target, args),
+        });
       }
     }
 

--- a/apps/os/src/durable-objects/codemode-session.test.ts
+++ b/apps/os/src/durable-objects/codemode-session.test.ts
@@ -337,6 +337,44 @@ describe("CodemodeSession", () => {
     });
   });
 
+  test("exposes codemode vars separately from the dynamic worker env", async () => {
+    const streamPath = `/codemode-session-tests/${crypto.randomUUID()}` as StreamPath;
+    const session = await initializeSession(streamPath);
+
+    const created = await session.createSession({
+      events: codemodeSessionStartupEvents({
+        events: [
+          {
+            type: "events.iterate.com/codemode/vars-updated",
+            payload: { vars: { PUBLIC_TUNNEL_URL: "https://tunnel.example" } },
+          },
+        ],
+        providers: [],
+        streamPath,
+      }),
+      code: `async (ctx) => {
+  return {
+    dynamicWorkerEnvHasProjectBinding: "PROJECT" in ctx.env,
+    dynamicWorkerEnvHasTemplateVar: "PUBLIC_TUNNEL_URL" in ctx.env,
+    publicTunnelUrl: ctx.codemode.vars.PUBLIC_TUNNEL_URL,
+  };
+}`,
+    });
+    const scriptExecutionId = scriptExecutionIdFromEvent(created.scriptExecutionEvent);
+    const completed = await waitForScriptExecutionCompleted({ scriptExecutionId, streamPath });
+
+    expect(completed.payload).toMatchObject({
+      outcome: {
+        status: "returned",
+        value: {
+          dynamicWorkerEnvHasProjectBinding: true,
+          dynamicWorkerEnvHasTemplateVar: false,
+          publicTunnelUrl: "https://tunnel.example",
+        },
+      },
+    });
+  });
+
   test("runs default workspace state and git shell operations", async () => {
     const streamPath = `/codemode-session-tests/${crypto.randomUUID()}` as StreamPath;
     const session = await initializeSession(streamPath);

--- a/apps/os/src/durable-objects/mock-artifacts-binding.ts
+++ b/apps/os/src/durable-objects/mock-artifacts-binding.ts
@@ -100,8 +100,10 @@ async function prepareMockIterateConfigWorkspace(input: {
   });
 }
 
-function readWorkspaceStateMethod(input: {
-  method: string;
+function readWorkspaceStateMethod<
+  K extends keyof Awaited<ReturnType<WorkspaceDurableObject["cloudflareShellState"]>>,
+>(input: {
+  method: K;
   state: Awaited<ReturnType<WorkspaceDurableObject["cloudflareShellState"]>>;
 }) {
   const method = input.state[input.method];

--- a/packages/shared/src/stream-processors/codemode/code-executor.ts
+++ b/packages/shared/src/stream-processors/codemode/code-executor.ts
@@ -25,9 +25,9 @@ export type CodemodeScriptExecutionResult = {
  */
 export type CodemodeScriptExecutor = (args: {
   code: string;
-  env: Record<string, string>;
   logger: CodemodeProcessorLogger;
   scriptExecutionId: string;
   session: CodemodeProcessorSession;
   signal: AbortSignal;
+  vars: Record<string, string>;
 }) => Promise<CodemodeScriptExecutionResult>;

--- a/packages/shared/src/stream-processors/codemode/code-executor.ts
+++ b/packages/shared/src/stream-processors/codemode/code-executor.ts
@@ -25,6 +25,7 @@ export type CodemodeScriptExecutionResult = {
  */
 export type CodemodeScriptExecutor = (args: {
   code: string;
+  env: Record<string, string>;
   logger: CodemodeProcessorLogger;
   scriptExecutionId: string;
   session: CodemodeProcessorSession;

--- a/packages/shared/src/stream-processors/codemode/contract.test.ts
+++ b/packages/shared/src/stream-processors/codemode/contract.test.ts
@@ -55,22 +55,22 @@ describe("CodemodeProcessorContract", () => {
     });
   });
 
-  it("merges codemode env updates into processor state", () => {
+  it("merges codemode var updates into processor state", () => {
     const state = reduceCodemodeEvents({
       state: getInitialProcessorState(CodemodeProcessorContract),
       events: [
         committedEvent({
-          type: "events.iterate.com/codemode/env-updated",
-          payload: { env: { PUBLIC_TUNNEL_URL: "https://tunnel.example", RETRIES: "2" } },
+          type: "events.iterate.com/codemode/vars-updated",
+          payload: { vars: { PUBLIC_TUNNEL_URL: "https://tunnel.example", RETRIES: "2" } },
         }),
         committedEvent({
-          type: "events.iterate.com/codemode/env-updated",
-          payload: { env: { PUBLIC_TUNNEL_URL: "https://new-tunnel.example" } },
+          type: "events.iterate.com/codemode/vars-updated",
+          payload: { vars: { PUBLIC_TUNNEL_URL: "https://new-tunnel.example" } },
         }),
       ],
     });
 
-    expect(state.env).toEqual({
+    expect(state.vars).toEqual({
       PUBLIC_TUNNEL_URL: "https://new-tunnel.example",
       RETRIES: "2",
     });

--- a/packages/shared/src/stream-processors/codemode/contract.test.ts
+++ b/packages/shared/src/stream-processors/codemode/contract.test.ts
@@ -55,6 +55,27 @@ describe("CodemodeProcessorContract", () => {
     });
   });
 
+  it("merges codemode env updates into processor state", () => {
+    const state = reduceCodemodeEvents({
+      state: getInitialProcessorState(CodemodeProcessorContract),
+      events: [
+        committedEvent({
+          type: "events.iterate.com/codemode/env-updated",
+          payload: { env: { PUBLIC_TUNNEL_URL: "https://tunnel.example", RETRIES: "2" } },
+        }),
+        committedEvent({
+          type: "events.iterate.com/codemode/env-updated",
+          payload: { env: { PUBLIC_TUNNEL_URL: "https://new-tunnel.example" } },
+        }),
+      ],
+    });
+
+    expect(state.env).toEqual({
+      PUBLIC_TUNNEL_URL: "https://new-tunnel.example",
+      RETRIES: "2",
+    });
+  });
+
   it("tracks requested and completed function calls by functionCallId", () => {
     const state = reduceCodemodeEvents({
       state: getInitialProcessorState(CodemodeProcessorContract),

--- a/packages/shared/src/stream-processors/codemode/contract.ts
+++ b/packages/shared/src/stream-processors/codemode/contract.ts
@@ -12,7 +12,7 @@ import { standardProcessorBehavior } from "../core/standard-processor-behavior.t
 const CodemodeId = z.string().trim().min(1);
 const CodemodePath = z.array(z.string().min(1)).min(1);
 const CodemodeFunctionPath = z.array(z.string().min(1));
-const CodemodeEnv = z.record(z.string().min(1), z.string());
+const CodemodeVars = z.record(z.string().min(1), z.string());
 const ToolProviderInvocation = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("event"),
@@ -51,7 +51,7 @@ export const CodemodeProcessorContract = defineProcessorContract({
     ...standardProcessorBehavior.stateShape,
     sessionStarted: z.boolean().default(false),
     sessionCapabilityCallable: Callable.optional(),
-    env: CodemodeEnv.default({}),
+    vars: CodemodeVars.default({}),
     toolProviders: z.record(z.string(), ToolProviderRegistration).default({}),
     scriptExecutions: z
       .record(
@@ -116,10 +116,11 @@ export const CodemodeProcessorContract = defineProcessorContract({
       description: "Model-visible instructions and invocation mode for codemode tool functions.",
       payloadSchema: ToolProviderRegistration,
     },
-    "events.iterate.com/codemode/env-updated": {
-      description: "String environment variables that are exposed to codemode scripts on ctx.env.",
+    "events.iterate.com/codemode/vars-updated": {
+      description:
+        "String template variables that are exposed to codemode scripts on ctx.codemode.vars.",
       payloadSchema: z.object({
-        env: CodemodeEnv,
+        vars: CodemodeVars,
       }),
     },
     "events.iterate.com/codemode/script-execution-requested": {
@@ -237,7 +238,7 @@ export const CodemodeProcessorContract = defineProcessorContract({
     ...standardProcessorBehavior.consumes,
     "events.iterate.com/codemode/session-started",
     "events.iterate.com/codemode/tool-provider-registered",
-    "events.iterate.com/codemode/env-updated",
+    "events.iterate.com/codemode/vars-updated",
     "events.iterate.com/codemode/script-execution-requested",
     "events.iterate.com/codemode/script-execution-completed",
     "events.iterate.com/codemode/function-call-requested",
@@ -274,12 +275,12 @@ export const CodemodeProcessorContract = defineProcessorContract({
             [toolProviderRegistryKey(event.payload.path)]: event.payload,
           },
         };
-      case "events.iterate.com/codemode/env-updated":
+      case "events.iterate.com/codemode/vars-updated":
         return {
           ...nextState,
-          env: {
-            ...nextState.env,
-            ...event.payload.env,
+          vars: {
+            ...nextState.vars,
+            ...event.payload.vars,
           },
         };
       case "events.iterate.com/codemode/script-execution-requested":

--- a/packages/shared/src/stream-processors/codemode/contract.ts
+++ b/packages/shared/src/stream-processors/codemode/contract.ts
@@ -12,6 +12,7 @@ import { standardProcessorBehavior } from "../core/standard-processor-behavior.t
 const CodemodeId = z.string().trim().min(1);
 const CodemodePath = z.array(z.string().min(1)).min(1);
 const CodemodeFunctionPath = z.array(z.string().min(1));
+const CodemodeEnv = z.record(z.string().min(1), z.string());
 const ToolProviderInvocation = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("event"),
@@ -50,6 +51,7 @@ export const CodemodeProcessorContract = defineProcessorContract({
     ...standardProcessorBehavior.stateShape,
     sessionStarted: z.boolean().default(false),
     sessionCapabilityCallable: Callable.optional(),
+    env: CodemodeEnv.default({}),
     toolProviders: z.record(z.string(), ToolProviderRegistration).default({}),
     scriptExecutions: z
       .record(
@@ -113,6 +115,12 @@ export const CodemodeProcessorContract = defineProcessorContract({
     "events.iterate.com/codemode/tool-provider-registered": {
       description: "Model-visible instructions and invocation mode for codemode tool functions.",
       payloadSchema: ToolProviderRegistration,
+    },
+    "events.iterate.com/codemode/env-updated": {
+      description: "String environment variables that are exposed to codemode scripts on ctx.env.",
+      payloadSchema: z.object({
+        env: CodemodeEnv,
+      }),
     },
     "events.iterate.com/codemode/script-execution-requested": {
       description: "A codemode script should run against the stream's documented functions.",
@@ -229,6 +237,7 @@ export const CodemodeProcessorContract = defineProcessorContract({
     ...standardProcessorBehavior.consumes,
     "events.iterate.com/codemode/session-started",
     "events.iterate.com/codemode/tool-provider-registered",
+    "events.iterate.com/codemode/env-updated",
     "events.iterate.com/codemode/script-execution-requested",
     "events.iterate.com/codemode/script-execution-completed",
     "events.iterate.com/codemode/function-call-requested",
@@ -263,6 +272,14 @@ export const CodemodeProcessorContract = defineProcessorContract({
           toolProviders: {
             ...nextState.toolProviders,
             [toolProviderRegistryKey(event.payload.path)]: event.payload,
+          },
+        };
+      case "events.iterate.com/codemode/env-updated":
+        return {
+          ...nextState,
+          env: {
+            ...nextState.env,
+            ...event.payload.env,
           },
         };
       case "events.iterate.com/codemode/script-execution-requested":

--- a/packages/shared/src/stream-processors/codemode/implementation.test.ts
+++ b/packages/shared/src/stream-processors/codemode/implementation.test.ts
@@ -124,6 +124,36 @@ describe("createCodemodeProcessor", () => {
     );
   });
 
+  it("passes codemode env state to the script executor", async () => {
+    const appended: StreamEventInput[] = [];
+    const scriptExecutor = vi.fn(async () => ({ result: { ok: true } }));
+    const processor = createCodemodeProcessor({
+      ...baseDeps(),
+      scriptExecutor,
+    });
+
+    await processor.implementation.afterAppend?.({
+      event: consumedCodemodeEvent({
+        type: "events.iterate.com/codemode/script-execution-requested",
+        payload: { code: "async (ctx) => ctx.env.PUBLIC_TUNNEL_URL", scriptExecutionId: "scr-1" },
+        offset: 7,
+      }),
+      previousState: registeredState({ sessionStarted: true }),
+      state: registeredState({
+        env: { PUBLIC_TUNNEL_URL: "https://tunnel.example" },
+        sessionStarted: true,
+      }),
+      streamApi: testStreamApi({ appended, storedEvents: [] }),
+      signal: new AbortController().signal,
+    });
+
+    expect(scriptExecutor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: { PUBLIC_TUNNEL_URL: "https://tunnel.example" },
+      }),
+    );
+  });
+
   it("can continue requested script work through waitUntil after accepting the stream event", async () => {
     const appended: StreamEventInput[] = [];
     const scriptResult = Promise.withResolvers<{ result: unknown }>();

--- a/packages/shared/src/stream-processors/codemode/implementation.test.ts
+++ b/packages/shared/src/stream-processors/codemode/implementation.test.ts
@@ -124,7 +124,7 @@ describe("createCodemodeProcessor", () => {
     );
   });
 
-  it("passes codemode env state to the script executor", async () => {
+  it("passes codemode vars state to the script executor", async () => {
     const appended: StreamEventInput[] = [];
     const scriptExecutor = vi.fn(async () => ({ result: { ok: true } }));
     const processor = createCodemodeProcessor({
@@ -135,13 +135,16 @@ describe("createCodemodeProcessor", () => {
     await processor.implementation.afterAppend?.({
       event: consumedCodemodeEvent({
         type: "events.iterate.com/codemode/script-execution-requested",
-        payload: { code: "async (ctx) => ctx.env.PUBLIC_TUNNEL_URL", scriptExecutionId: "scr-1" },
+        payload: {
+          code: "async (ctx) => ctx.codemode.vars.PUBLIC_TUNNEL_URL",
+          scriptExecutionId: "scr-1",
+        },
         offset: 7,
       }),
       previousState: registeredState({ sessionStarted: true }),
       state: registeredState({
-        env: { PUBLIC_TUNNEL_URL: "https://tunnel.example" },
         sessionStarted: true,
+        vars: { PUBLIC_TUNNEL_URL: "https://tunnel.example" },
       }),
       streamApi: testStreamApi({ appended, storedEvents: [] }),
       signal: new AbortController().signal,
@@ -149,7 +152,7 @@ describe("createCodemodeProcessor", () => {
 
     expect(scriptExecutor).toHaveBeenCalledWith(
       expect.objectContaining({
-        env: { PUBLIC_TUNNEL_URL: "https://tunnel.example" },
+        vars: { PUBLIC_TUNNEL_URL: "https://tunnel.example" },
       }),
     );
   });

--- a/packages/shared/src/stream-processors/codemode/implementation.ts
+++ b/packages/shared/src/stream-processors/codemode/implementation.ts
@@ -57,7 +57,7 @@ export function createCodemodeProcessor(deps: CodemodeProcessorDeps) {
         case CoreProcessorRegisteredEventType:
         case "events.iterate.com/codemode/session-started":
         case "events.iterate.com/codemode/tool-provider-registered":
-        case "events.iterate.com/codemode/env-updated":
+        case "events.iterate.com/codemode/vars-updated":
         case "events.iterate.com/codemode/script-execution-completed":
         case "events.iterate.com/codemode/function-call-requested":
         case "events.iterate.com/codemode/function-call-completed":
@@ -134,11 +134,11 @@ async function executeRequestedScript(args: {
   try {
     result = await args.deps.scriptExecutor({
       code: args.event.payload.code,
-      env: args.state.env,
       logger,
       scriptExecutionId: args.event.payload.scriptExecutionId,
       session,
       signal: args.signal,
+      vars: args.state.vars,
     });
   } catch (error) {
     result = { result: undefined, error: serializeError(error) };

--- a/packages/shared/src/stream-processors/codemode/implementation.ts
+++ b/packages/shared/src/stream-processors/codemode/implementation.ts
@@ -57,6 +57,7 @@ export function createCodemodeProcessor(deps: CodemodeProcessorDeps) {
         case CoreProcessorRegisteredEventType:
         case "events.iterate.com/codemode/session-started":
         case "events.iterate.com/codemode/tool-provider-registered":
+        case "events.iterate.com/codemode/env-updated":
         case "events.iterate.com/codemode/script-execution-completed":
         case "events.iterate.com/codemode/function-call-requested":
         case "events.iterate.com/codemode/function-call-completed":
@@ -133,6 +134,7 @@ async function executeRequestedScript(args: {
   try {
     result = await args.deps.scriptExecutor({
       code: args.event.payload.code,
+      env: args.state.env,
       logger,
       scriptExecutionId: args.event.payload.scriptExecutionId,
       session,


### PR DESCRIPTION
## Summary

Adds a default TypeScript context for codemode scripts in the OS e2e test fixture so common providers can be used without annotating `ctx` as `any`.

The fixture now models the built-in OS, AI, repos, and workspace provider surfaces, and keeps `.context<...>()` available for tests that register ad hoc providers such as Petstore or public-tunnel MCP tools.

Example:

```ts
await fixture.codemode.execute(async (ctx) => {
  await ctx.workspace.writeFile("greeting.txt", "hiya");
  return await ctx.os.project.get({});
});

await fixture.codemode
  .context<{ petstore: { getInventory: () => Promise<unknown> } }>()
  .execute(async (ctx) => ctx.petstore.getInventory());
```

## Testing

- `pnpm --dir packages/shared exec vitest run --environment node src/stream-processors/codemode/contract.test.ts src/stream-processors/codemode/implementation.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm --dir packages/shared typecheck`
- `git diff --check && git diff --staged --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches codemode processor contract (0.4.0), dynamic worker evaluation, and session execution paths; behavior change for how test scripts pass external URLs/secrets into scripts.
> 
> **Overview**
> Introduces **codemode template variables** via a new `events.iterate.com/codemode/vars-updated` event: processor state merges string vars, the script executor receives them, and dynamic workers expose them on **`ctx.codemode.vars`** (kept separate from **`ctx.env`** bindings like `PROJECT`).
> 
> Refactors OS e2e support by moving **`CodemodeBuilder`** into its own module with a default typed script context (`os`, `ai`, `repos`, `workspace`, etc.), **`.var(key, value)`** to append var events before execution, and **`.context<...>()`** for ad hoc providers. The fixture drops the old **`.bind()`** / inlined builder; tests use vars and explicit context types instead of `any`.
> 
> Tightens workspace/shell typing (`CloudflareShellState`, mock artifact helpers) and adds unit/e2e coverage for var merge, executor wiring, and env vs vars separation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b1f929674cb15a80b3e89d345440fce69a4bb08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-05-28T11:44:53.097Z",
      "headSha": "0b1f929674cb15a80b3e89d345440fce69a4bb08",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26522583518",
      "shortSha": "0b1f929"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `0b1f929`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/26522583518)
Updated: 2026-05-28T11:44:53.097Z
<!-- /CLOUDFLARE_PREVIEW -->
