### PR TITLE
avoid stupid clanker type widening

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -119,13 +119,21 @@
     "iterate/no-implied-eval": "error",
     "prefer-const": "off",
     "iterate/prefer-const": "error",
+    "iterate/isolated-codemode": [
+      "error",
+      {
+        "selectors": [":function[codemode]"],
+        "overrideGlobals": {
+          "crypto": "readonly",
+          "fetch": "readonly",
+          "console": "readonly",
+          "setTimeout": "readonly"
+        }
+      }
+    ],
     "unicorn-js/isolated-functions": [
       "error",
       {
-        "selectors": [
-          "CallExpression[callee.object.object.name=\"fixture\"][callee.object.property.name=\"codemode\"] > :function",
-          "CallExpression[callee.object.callee.object.object.name=\"fixture\"][callee.object.callee.object.property.name=\"codemode\"] > :function"
-        ],
         "overrideGlobals": {
           "crypto": "readonly",
           "fetch": "readonly",

--- a/apps/os/e2e/test-support/codemode-builder.ts
+++ b/apps/os/e2e/test-support/codemode-builder.ts
@@ -145,7 +145,7 @@ type OptionalProjectDeep<T> = T extends (
   ? (params: Omit<P, "projectSlugOrId"> & { projectSlugOrId?: string }) => R
   : { [K in keyof T]: OptionalProjectDeep<T[K]> };
 
-type Stubify<T> = {
+type Stubify<T> = PromiseLike<T> & {
   [K in keyof T]: T[K] extends (...args: infer A) => infer R
     ? (
         ...args: A

--- a/apps/os/e2e/vitest/e2e-test-map.e2e.test.ts
+++ b/apps/os/e2e/vitest/e2e-test-map.e2e.test.ts
@@ -398,7 +398,7 @@ describe("e2e test map", () => {
       args: ["-c", `http.extraHeader=${authHeader}`, "clone", repo.remote, localRepoDir],
       cwd: temp.path,
     });
-    await writeFile(join(localRepoDir, "proofFileName"), proof);
+    await writeFile(join(localRepoDir, "normal-git-proof.txt"), proof);
     await gitLocalCli({
       args: ["-C", localRepoDir, "add", "normal-git-proof.txt"],
       cwd: temp.path,

--- a/apps/os/e2e/vitest/e2e-test-map.e2e.test.ts
+++ b/apps/os/e2e/vitest/e2e-test-map.e2e.test.ts
@@ -389,50 +389,23 @@ describe("e2e test map", () => {
     });
 
     await using temp = await createTempDirectory("os-codemode-repo-");
-    const localRepoDir = join(temp.path, "codemode-create-repo");
     const repo = created.success().repo;
     const authHeader = repo.git.authorizationHeader;
 
-    await gitLocalCli({
-      args: ["-c", `http.extraHeader=${authHeader}`, "clone", repo.remote, localRepoDir],
-      cwd: temp.path,
-    });
-    await writeFile(join(localRepoDir, "normal-git-proof.txt"), proof);
-    await gitLocalCli({
-      args: ["-C", localRepoDir, "add", "normal-git-proof.txt"],
-      cwd: temp.path,
-    });
-    await gitLocalCli({
-      args: [
-        "-C",
-        localRepoDir,
-        "-c",
-        "user.name=Codemode E2E",
-        "-c",
-        "user.email=codemode-e2e@iterate.com",
-        "commit",
-        "-m",
-        "Add normal git proof",
-      ],
-      cwd: temp.path,
-    });
-    await gitLocalCli({
-      args: [
-        "-C",
-        localRepoDir,
-        "-c",
-        `http.extraHeader=${authHeader}`,
-        "push",
-        "origin",
-        repo.defaultBranch,
-      ],
-      cwd: temp.path,
-    });
+    await temp.exec(
+      `git config --global http.extraHeader "${authHeader}" && git config --global user.name "Codemode E2E" && git config --global user.email codemode-e2e@iterate.com`,
+    );
+    await temp.exec(`git clone ${repo.remote} codemode-create-repo`);
+    const repoExec = temp.getExec("codemode-create-repo");
+    await writeFile(join(temp.path, "codemode-create-repo", "normal-git-proof.txt"), proof);
+    await repoExec(`git add normal-git-proof.txt`);
+    await repoExec(`git commit -m "Add normal git proof"`);
+    await repoExec(`git push origin ${repo.defaultBranch}`);
 
-    expect(await readFile(join(localRepoDir, "normal-git-proof.txt"), "utf8")).toBe(proof);
     expect(
-      await gitLocalCli({ args: ["-C", localRepoDir, "status", "--short"], cwd: temp.path }),
-    ).toBe("");
+      await readFile(join(temp.path, "codemode-create-repo", "normal-git-proof.txt"), "utf8"),
+    ).toBe(proof);
+    expect(await repoExec(`git status --short`)).toBe("");
 
     const pulled = await fixture.codemode.execute(async (ctx) => {
       const repo = await ctx.repos.get({ slug: "codemode-create-repo" }).getInfo();
@@ -510,10 +483,7 @@ describe("e2e test map", () => {
         commit,
         proof,
         pushed,
-        repo: {
-          defaultBranch: repo.defaultBranch,
-          slug: repo.slug,
-        },
+        repo: { defaultBranch: repo.defaultBranch, slug: repo.slug },
         status: await ctx.workspace.git.status({ dir }),
       };
     });
@@ -541,27 +511,35 @@ describe("e2e test map", () => {
   });
 });
 
+function getExec(home: string, cwd: string) {
+  return async (command: string) => {
+    const result = await x("sh", ["-c", command], {
+      throwOnError: true,
+      nodeOptions: {
+        cwd,
+        env: {
+          ...process.env,
+          GIT_CONFIG_GLOBAL: join(home, ".gitconfig"),
+          GIT_CONFIG_NOSYSTEM: "1",
+          GIT_TERMINAL_PROMPT: "0",
+          HOME: home,
+          XDG_CONFIG_HOME: home,
+        },
+        stdio: "pipe",
+      },
+    });
+    return result.stdout.trim();
+  };
+}
+
 async function createTempDirectory(prefix: string) {
   const path = await mkdtemp(join(tmpdir(), prefix));
   return {
     path,
+    exec: getExec(path, path),
+    getExec: (subdir: string) => getExec(path, join(path, subdir)),
     async [Symbol.asyncDispose]() {
       await rm(path, { force: true, recursive: true });
     },
   };
-}
-
-async function gitLocalCli(input: { args: string[]; cwd: string }) {
-  const result = await x("git", input.args, {
-    throwOnError: true,
-    nodeOptions: {
-      cwd: input.cwd,
-      env: {
-        ...process.env,
-        GIT_TERMINAL_PROMPT: "0",
-      },
-      stdio: "pipe",
-    },
-  });
-  return result.stdout.trim();
 }

--- a/apps/os/e2e/vitest/e2e-test-map.e2e.test.ts
+++ b/apps/os/e2e/vitest/e2e-test-map.e2e.test.ts
@@ -1,5 +1,9 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { x } from "tinyexec";
 import { describe, expect, test, vi, expectTypeOf } from "vitest";
 import { z } from "zod";
 import { CodemodeProcessorContract } from "@iterate-com/shared/stream-processors/codemode/contract";
@@ -172,7 +176,7 @@ describe("e2e test map", () => {
         type: "events.iterate.com/codemode/tool-provider-registered",
         payload: {
           instructions:
-            "Use ctx.mcp.publicTunnelSearch for test web search. Call ctx.mcp.publicTunnelSearch.listTools() to inspect available tools, then call ctx.mcp.publicTunnelSearch.my_funky_search({ query, numResults }).",
+            "Use ctx.mcp.publicTunnelSearch for test web search. Call ctx.mcp.publicTunnelSearch.listTools() to inspect available tools, then call ctx.mcp.publicTunnelSearch.my_funky_search({ query }).",
           invocation: {
             kind: "rpc",
             callable: {
@@ -202,22 +206,19 @@ describe("e2e test map", () => {
         mcp: {
           publicTunnelSearch: {
             listTools: () => Promise<{ tools: unknown[] }>;
-            my_funky_search: (input: { numResults: number; query: string }) => Promise<unknown>;
+            my_funky_search: (input: { query: string }) => Promise<unknown>;
           };
         };
       }>()
       .execute(async (ctx) => {
         const { tools } = await ctx.mcp.publicTunnelSearch.listTools();
-        const search = await ctx.mcp.publicTunnelSearch.my_funky_search({
-          numResults: 2,
-          query: "public tunnel mcp",
-        });
-        return { search, tools };
+        const search = await ctx.mcp.publicTunnelSearch.my_funky_search({ query: "abc123" });
+        return { tools, search };
       });
 
     expect(result.success()).toMatchObject({
-      search: { result: "search result for public tunnel mcp" },
       tools: [{ description: "Search the web", name: "my_funky_search" }],
+      search: { result: "search result for abc123" },
     });
   });
 
@@ -341,6 +342,126 @@ describe("e2e test map", () => {
     expect(result.success()).toContain(`"name": "captun"`);
   });
 
+  test("codemode-create repo can be cloned as normal", async () => {
+    await using fixture = await createTestProjectFixture({
+      processors: [CodemodeProcessorContract],
+    });
+    const repoSlug = "codemode-create-repo";
+    const proofFileName = "normal-git-proof.txt";
+    const proof = `normal git proof for ${fixture.project.slug}\n`;
+
+    await fixture.append({
+      event: {
+        type: "events.iterate.com/codemode/tool-provider-registered",
+        payload: createExampleRpcProviderRegistration({
+          exportName: "ReposCapability",
+          instructions:
+            "Use ctx.repos.create({ slug }) to create a Repo, ctx.repos.get({ slug }).getInfo() to inspect one, and ctx.repos.list({}) to list Repos.",
+          path: ["repos"],
+          projectId: fixture.project.id,
+        }),
+      },
+    });
+
+    const created = await fixture.codemode.execute(async (ctx) => {
+      const repo = await ctx.repos.create({ slug: "codemode-create-repo" }).getInfo();
+      const credentials = await ctx.repos.get({ slug: "codemode-create-repo" }).getCredentials();
+
+      await ctx.workspace.git.clone({
+        url: repo.remote,
+        dir: "/codemode-create-repo",
+        branch: repo.defaultBranch,
+        depth: 1,
+        ...credentials,
+      });
+
+      return {
+        initialReadme: await ctx.workspace.readFile("/codemode-create-repo/README.md"),
+        repo,
+        status: await ctx.workspace.git.status({ dir: "/codemode-create-repo" }),
+      };
+    });
+
+    expect(created.success()).toMatchObject({
+      initialReadme: expect.stringContaining(`Project ID: ${fixture.project.id}`),
+      repo: {
+        defaultBranch: "main",
+        slug: repoSlug,
+      },
+      status: [],
+    });
+
+    await using temp = await createTempDirectory("os-codemode-repo-");
+    const localRepoDir = join(temp.path, repoSlug);
+    const repo = created.success().repo;
+    const authHeader = repo.git.authorizationHeader;
+
+    await runGit({
+      args: ["-c", `http.extraHeader=${authHeader}`, "clone", repo.remote, localRepoDir],
+      cwd: temp.path,
+    });
+    await writeFile(join(localRepoDir, proofFileName), proof);
+    await runGit({ args: ["-C", localRepoDir, "add", proofFileName], cwd: temp.path });
+    await runGit({
+      args: [
+        "-C",
+        localRepoDir,
+        "-c",
+        "user.name=Codemode E2E",
+        "-c",
+        "user.email=codemode-e2e@iterate.com",
+        "commit",
+        "-m",
+        "Add normal git proof",
+      ],
+      cwd: temp.path,
+    });
+    await runGit({
+      args: [
+        "-C",
+        localRepoDir,
+        "-c",
+        `http.extraHeader=${authHeader}`,
+        "push",
+        "origin",
+        repo.defaultBranch,
+      ],
+      cwd: temp.path,
+    });
+
+    expect(await readFile(join(localRepoDir, proofFileName), "utf8")).toBe(proof);
+    expect(await runGit({ args: ["-C", localRepoDir, "status", "--short"], cwd: temp.path })).toBe(
+      "",
+    );
+
+    const pulled = await fixture.codemode.execute(async (ctx) => {
+      const repo = await ctx.repos.get({ slug: "codemode-create-repo" }).getInfo();
+      const password = repo.token.includes("?expires=")
+        ? repo.token.split("?expires=")[0]
+        : repo.token;
+      const auth = { username: "x", password };
+      const pull = await ctx.workspace.git.pull({
+        dir: "/codemode-create-repo",
+        remote: "origin",
+        ref: repo.defaultBranch,
+        author: { name: "Codemode", email: "codemode@iterate.com" },
+        ...auth,
+      });
+
+      return {
+        proof: await ctx.workspace.readFile("/codemode-create-repo/normal-git-proof.txt"),
+        pull,
+        status: await ctx.workspace.git.status({ dir: "/codemode-create-repo" }),
+      };
+    });
+
+    expect(pulled.success()).toMatchObject({
+      proof,
+      pull: { pulled: true },
+      status: [],
+    });
+  });
+
   test("can update iterate config repo via workspace", async () => {
     await using fixture = await createTestProjectFixture({
       processors: [CodemodeProcessorContract],
@@ -427,3 +548,28 @@ describe("e2e test map", () => {
     await vi.waitFor(getHtml, { timeout: 15_000 });
   });
 });
+
+async function createTempDirectory(prefix: string) {
+  const path = await mkdtemp(join(tmpdir(), prefix));
+  return {
+    path,
+    async [Symbol.asyncDispose]() {
+      await rm(path, { force: true, recursive: true });
+    },
+  };
+}
+
+async function runGit(input: { args: string[]; cwd: string }) {
+  const result = await x("git", input.args, {
+    throwOnError: true,
+    nodeOptions: {
+      cwd: input.cwd,
+      env: {
+        ...process.env,
+        GIT_TERMINAL_PROMPT: "0",
+      },
+      stdio: "pipe",
+    },
+  });
+  return result.stdout.trim();
+}

--- a/apps/os/e2e/vitest/e2e-test-map.e2e.test.ts
+++ b/apps/os/e2e/vitest/e2e-test-map.e2e.test.ts
@@ -363,14 +363,13 @@ describe("e2e test map", () => {
 
     const created = await fixture.codemode.execute(async (ctx) => {
       const repo = await ctx.repos.create({ slug: "codemode-create-repo" }).getInfo();
-      const credentials = await ctx.repos.get({ slug: "codemode-create-repo" }).getCredentials();
 
       await ctx.workspace.git.clone({
         url: repo.remote,
         dir: "/codemode-create-repo",
         branch: repo.defaultBranch,
         depth: 1,
-        ...credentials,
+        ...repo.credentials,
       });
 
       return {
@@ -436,15 +435,13 @@ describe("e2e test map", () => {
     ).toBe("");
 
     const pulled = await fixture.codemode.execute(async (ctx) => {
-      const repo = ctx.repos.get({ slug: "codemode-create-repo" });
-      const repoInfo = await repo.getInfo();
-      const auth = await repo.getCredentials();
+      const repo = await ctx.repos.get({ slug: "codemode-create-repo" }).getInfo();
       const pull = await ctx.workspace.git.pull({
         dir: "/codemode-create-repo",
         remote: "origin",
-        ref: repoInfo.defaultBranch,
+        ref: repo.defaultBranch,
         author: { name: "Codemode", email: "codemode@iterate.com" },
-        ...auth,
+        ...repo.credentials,
       });
 
       return {
@@ -483,17 +480,13 @@ describe("e2e test map", () => {
       const proof = `hello from iterate config ${Date.now()}`;
       const repo = await ctx.repos.ensureIterateConfigInfo({ projectSlug: null });
       const dir = `/iterate-config-${Date.now()}`;
-      const password = repo.token.includes("?expires=")
-        ? repo.token.split("?expires=")[0]
-        : repo.token;
-      const auth = { username: "x", password };
 
       await ctx.workspace.git.clone({
         url: repo.remote,
         dir,
         branch: repo.defaultBranch,
         depth: 1,
-        ...auth,
+        ...repo.credentials,
       });
 
       await ctx.workspace.writeFile(
@@ -510,7 +503,7 @@ describe("e2e test map", () => {
         dir,
         remote: "origin",
         ref: repo.defaultBranch,
-        ...auth,
+        ...repo.credentials,
       });
 
       return {

--- a/apps/os/e2e/vitest/e2e-test-map.e2e.test.ts
+++ b/apps/os/e2e/vitest/e2e-test-map.e2e.test.ts
@@ -346,9 +346,7 @@ describe("e2e test map", () => {
     await using fixture = await createTestProjectFixture({
       processors: [CodemodeProcessorContract],
     });
-    const repoSlug = "codemode-create-repo";
-    const proofFileName = "normal-git-proof.txt";
-    const proof = `normal git proof for ${fixture.project.slug}\n`;
+    const proof = `normal git proof for ${fixture.project.slug}`;
 
     await fixture.append({
       event: {
@@ -386,23 +384,26 @@ describe("e2e test map", () => {
       initialReadme: expect.stringContaining(`Project ID: ${fixture.project.id}`),
       repo: {
         defaultBranch: "main",
-        slug: repoSlug,
+        slug: "codemode-create-repo",
       },
       status: [],
     });
 
     await using temp = await createTempDirectory("os-codemode-repo-");
-    const localRepoDir = join(temp.path, repoSlug);
+    const localRepoDir = join(temp.path, "codemode-create-repo");
     const repo = created.success().repo;
     const authHeader = repo.git.authorizationHeader;
 
-    await runGit({
+    await gitLocalCli({
       args: ["-c", `http.extraHeader=${authHeader}`, "clone", repo.remote, localRepoDir],
       cwd: temp.path,
     });
-    await writeFile(join(localRepoDir, proofFileName), proof);
-    await runGit({ args: ["-C", localRepoDir, "add", proofFileName], cwd: temp.path });
-    await runGit({
+    await writeFile(join(localRepoDir, "proofFileName"), proof);
+    await gitLocalCli({
+      args: ["-C", localRepoDir, "add", "normal-git-proof.txt"],
+      cwd: temp.path,
+    });
+    await gitLocalCli({
       args: [
         "-C",
         localRepoDir,
@@ -416,7 +417,7 @@ describe("e2e test map", () => {
       ],
       cwd: temp.path,
     });
-    await runGit({
+    await gitLocalCli({
       args: [
         "-C",
         localRepoDir,
@@ -429,21 +430,19 @@ describe("e2e test map", () => {
       cwd: temp.path,
     });
 
-    expect(await readFile(join(localRepoDir, proofFileName), "utf8")).toBe(proof);
-    expect(await runGit({ args: ["-C", localRepoDir, "status", "--short"], cwd: temp.path })).toBe(
-      "",
-    );
+    expect(await readFile(join(localRepoDir, "normal-git-proof.txt"), "utf8")).toBe(proof);
+    expect(
+      await gitLocalCli({ args: ["-C", localRepoDir, "status", "--short"], cwd: temp.path }),
+    ).toBe("");
 
     const pulled = await fixture.codemode.execute(async (ctx) => {
-      const repo = await ctx.repos.get({ slug: "codemode-create-repo" }).getInfo();
-      const password = repo.token.includes("?expires=")
-        ? repo.token.split("?expires=")[0]
-        : repo.token;
-      const auth = { username: "x", password };
+      const repo = ctx.repos.get({ slug: "codemode-create-repo" });
+      const repoInfo = await repo.getInfo();
+      const auth = await repo.getCredentials();
       const pull = await ctx.workspace.git.pull({
         dir: "/codemode-create-repo",
         remote: "origin",
-        ref: repo.defaultBranch,
+        ref: repoInfo.defaultBranch,
         author: { name: "Codemode", email: "codemode@iterate.com" },
         ...auth,
       });
@@ -559,7 +558,7 @@ async function createTempDirectory(prefix: string) {
   };
 }
 
-async function runGit(input: { args: string[]; cwd: string }) {
+async function gitLocalCli(input: { args: string[]; cwd: string }) {
   const result = await x("git", input.args, {
     throwOnError: true,
     nodeOptions: {

--- a/apps/os/src/domains/repos/durable-objects/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/durable-objects/repo-durable-object.ts
@@ -53,6 +53,7 @@ export type RepoInfo = {
   slug: string;
   token: string;
   tokenExpiresAt: string | null;
+  credentials: { username: string; password: string };
 };
 
 export type CreateRepoInput = {
@@ -260,6 +261,7 @@ export class RepoDurableObject extends RepoBase<RepoEnv> {
       slug: repo.slug,
       token,
       tokenExpiresAt,
+      credentials: { username: "x", password: stripArtifactTokenQuery(token) },
     };
   }
 

--- a/apps/os/src/domains/repos/entrypoints/repo-capability.ts
+++ b/apps/os/src/domains/repos/entrypoints/repo-capability.ts
@@ -57,11 +57,6 @@ export class RepoHandle extends RpcTarget {
     return await this.#repo.getInfo();
   }
 
-  async getCredentials() {
-    const info = await this.getInfo();
-    return { username: "x", password: info.token.split("?expires=")[0] };
-  }
-
   async refreshWriteToken(): Promise<RepoInfo> {
     return await this.#repo.refreshWriteToken();
   }

--- a/apps/os/src/domains/repos/entrypoints/repo-capability.ts
+++ b/apps/os/src/domains/repos/entrypoints/repo-capability.ts
@@ -57,6 +57,11 @@ export class RepoHandle extends RpcTarget {
     return await this.#repo.getInfo();
   }
 
+  async getCredentials() {
+    const info = await this.getInfo();
+    return { username: "x", password: info.token.split("?expires=")[0] };
+  }
+
   async refreshWriteToken(): Promise<RepoInfo> {
     return await this.#repo.refreshWriteToken();
   }

--- a/apps/os/src/domains/workspaces/durable-objects/workspace-durable-object.ts
+++ b/apps/os/src/domains/workspaces/durable-objects/workspace-durable-object.ts
@@ -11,7 +11,7 @@ export type WorkspaceStructuredName = {
 
 export type CloudflareShellState = import("@cloudflare/shell").StateBackend & {
   git: import("@cloudflare/shell/git").Git;
-} & Record<string, unknown>;
+};
 
 const WorkspaceStructuredName = z.object({
   projectId: z.string().trim().min(1),

--- a/apps/os/src/domains/workspaces/entrypoints/workspace-capability.ts
+++ b/apps/os/src/domains/workspaces/entrypoints/workspace-capability.ts
@@ -46,7 +46,7 @@ export class WorkspaceCapability extends WorkerEntrypoint<
     return await callMethod({
       method,
       namespace: "ctx.workspace",
-      target: state,
+      target: state as {},
       args: input.args,
     });
   }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 import esquery from "esquery";
+import unicorn from "eslint-plugin-unicorn";
 
 const LIFECYCLE_HOOKS = new Set(["beforeAll", "beforeEach", "afterAll", "afterEach"]);
 const VI_MOCK_CALLS = new Set(["vi.mock", "vi.doMock"]);
@@ -101,6 +102,31 @@ function isFunctionLikeDeclaration(node) {
     );
   });
 }
+
+const isolatedCodemodeRule = {
+  ...unicorn.rules["isolated-functions"],
+  create(context) {
+    const original = unicorn.rules["isolated-functions"].create(context);
+    for (const codemodeSelector of [":function[codemode]", ":function[codemode]:exit"]) {
+      if (codemodeSelector in original) {
+        const cb = original[codemodeSelector];
+        delete original[codemodeSelector];
+        const suffix = codemodeSelector.match(/:exit$/)?.[0] || "";
+        const nonClashingCatchallFunctionSelector = `FunctionExpression[random!="${Math.random()}"]${suffix}`;
+        original[nonClashingCatchallFunctionSelector] = (node, ...args) => {
+          const parentCallee = node.parent?.callee;
+          if (!parentCallee) return;
+          if (!context.sourceCode.getText(parentCallee).match(/\bcodemode\b/i)) return;
+          if (!context.sourceCode.getText(parentCallee).match(/\bfixture\b/i)) return;
+          return cb(node, ...args);
+        };
+        original[`Arrow${nonClashingCatchallFunctionSelector}`] =
+          original[nonClashingCatchallFunctionSelector];
+      }
+    }
+    return original;
+  },
+};
 
 /** @param {import("estree").CallExpression} node */
 function getMatcherCall(node) {
@@ -308,6 +334,7 @@ const plugin = {
               };
             },
           },
+          "isolated-codemode": isolatedCodemodeRule,
           "relative-import-extensions": {
             meta: {
               type: "problem",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-codegen": "0.34.1",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-unicorn": "github:mmkal/eslint-plugin-unicorn#4b6340834f94ebb53a1aee5b91dd5c0e103249b3",
+    "eslint-plugin-unicorn": "^64.0.0",
     "esquery": "1.6.0",
     "husky": "9.1.7",
     "is-ci": "4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ importers:
         specifier: ^2.32.0
         version: 2.32.0(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-unicorn:
-        specifier: github:mmkal/eslint-plugin-unicorn#4b6340834f94ebb53a1aee5b91dd5c0e103249b3
-        version: https://codeload.github.com/mmkal/eslint-plugin-unicorn/tar.gz/4b6340834f94ebb53a1aee5b91dd5c0e103249b3(eslint@9.39.3(jiti@2.6.1))
+        specifier: ^64.0.0
+        version: 64.0.0(eslint@9.39.3(jiti@2.6.1))
       esquery:
         specifier: 1.6.0
         version: 1.6.0
@@ -1803,6 +1803,10 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
@@ -3251,12 +3255,16 @@ packages:
   '@httptoolkit/websocket-stream@6.0.1':
     resolution: {integrity: sha512-A0NOZI+Glp3Xgcz6Na7i7o09+/+xm2m0UCU8gdtM2nIv6/cjLmhMZMqehSpTlgbx9omtLmV8LVqOskPEyWnmZQ==}
 
-  '@humanfs/core@0.19.1':
-    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
 
-  '@humanfs/node@0.16.7':
-    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
     engines: {node: '>=18.18.0'}
 
   '@humanwhocodes/module-importer@1.0.1':
@@ -6633,6 +6641,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
@@ -7179,8 +7190,8 @@ packages:
       ajv:
         optional: true
 
-  ajv@6.14.0:
-    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -7405,8 +7416,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.0:
-    resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
+  baseline-browser-mapping@2.10.32:
+    resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -7581,8 +7592,8 @@ packages:
     resolution: {integrity: sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A==}
     engines: {node: '>=v18.0.0'}
 
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -7595,8 +7606,8 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
-  builtin-modules@5.0.0:
-    resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==}
+  builtin-modules@5.2.0:
+    resolution: {integrity: sha512-02yxLeyxF4dNl6SlY6/5HfRSrSdZ/sCPoxy2kZNP5dZZX8LSAD9aE2gtJIUgWrsQTiMPl3mxESyrobSwvRGisQ==}
     engines: {node: '>=18.20'}
 
   bun-ffi-structs@0.1.2:
@@ -7671,8 +7682,8 @@ packages:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
 
-  caniuse-lite@1.0.30001776:
-    resolution: {integrity: sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==}
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   capnweb@0.8.0:
     resolution: {integrity: sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==}
@@ -7932,8 +7943,8 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
-  core-js-compat@3.48.0:
-    resolution: {integrity: sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==}
+  core-js-compat@3.49.0:
+    resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
   core-js-pure@3.49.0:
     resolution: {integrity: sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==}
@@ -8610,8 +8621,8 @@ packages:
   effect@3.19.19:
     resolution: {integrity: sha512-Yc8U/SVXo2dHnaP7zNBlAo83h/nzSJpi7vph6Hzyl4ulgMBIgPmz3UzOjb9sBgpFE00gC0iETR244sfXDNLHRg==}
 
-  electron-to-chromium@1.5.307:
-    resolution: {integrity: sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==}
+  electron-to-chromium@1.5.362:
+    resolution: {integrity: sha512-PUY2DrLvkjkUuWqq+KPL2iWshrJsZOcIojzRQ7eXFacc9dWga7MGMJAa15VbiejSZB1PAXaRLAiKgruHP8LB1w==}
 
   embla-carousel-react@8.6.0:
     resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
@@ -8840,9 +8851,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-unicorn@https://codeload.github.com/mmkal/eslint-plugin-unicorn/tar.gz/4b6340834f94ebb53a1aee5b91dd5c0e103249b3:
-    resolution: {tarball: https://codeload.github.com/mmkal/eslint-plugin-unicorn/tar.gz/4b6340834f94ebb53a1aee5b91dd5c0e103249b3}
-    version: 62.0.0
+  eslint-plugin-unicorn@64.0.0:
+    resolution: {integrity: sha512-rNZwalHh8i0UfPlhNwg5BTUO1CMdKNmjqe+TgzOTZnpKoi8VBgsW7u9qCHIdpxEzZ1uwrJrPF0uRb7l//K38gA==}
     engines: {node: ^20.10.0 || >=21.0.0}
     peerDependencies:
       eslint: '>=9.38.0'
@@ -9318,8 +9328,8 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
-  globals@16.5.0:
-    resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
+  globals@17.6.0:
+    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -10810,8 +10820,9 @@ packages:
   node-pty@1.2.0-beta.11:
     resolution: {integrity: sha512-THcUyu1WwdgoIyUvgXOZ70EOMXzheGa0q3tbEb5kUIfKgcpBJ+AJ9Q1kq0bKtYmQzr77usXiTORZTLmAUQlnoQ==}
 
-  node-releases@2.0.36:
-    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+  node-releases@2.0.46:
+    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
+    engines: {node: '>=18'}
 
   nodemon@3.1.14:
     resolution: {integrity: sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==}
@@ -11650,8 +11661,8 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
-  regjsparser@0.13.0:
-    resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
+  regjsparser@0.13.1:
+    resolution: {integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==}
     hasBin: true
 
   rehype-harden@1.1.8:
@@ -11884,6 +11895,11 @@ packages:
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -14168,7 +14184,7 @@ snapshots:
 
   '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -14187,7 +14203,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -14210,7 +14226,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -14247,7 +14263,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -14277,6 +14293,8 @@ snapshots:
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -14404,14 +14422,14 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@base-ui/react@1.2.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -15219,7 +15237,7 @@ snapshots:
   '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -15234,8 +15252,8 @@ snapshots:
 
   '@eslint/eslintrc@3.3.5':
     dependencies:
-      ajv: 6.14.0
-      debug: 4.4.3(supports-color@5.5.0)
+      ajv: 6.15.0
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -15578,12 +15596,17 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@humanfs/core@0.19.1': {}
-
-  '@humanfs/node@0.16.7':
+  '@humanfs/core@0.19.2':
     dependencies:
-      '@humanfs/core': 0.19.1
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
       '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
 
   '@humanwhocodes/module-importer@1.0.1': {}
 
@@ -19362,6 +19385,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/estree@1.0.9': {}
+
   '@types/geojson@7946.0.16': {}
 
   '@types/glob@7.1.3':
@@ -19488,7 +19513,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -19510,9 +19535,9 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       minimatch: 10.2.4
-      semver: 7.7.4
+      semver: 7.8.1
       tinyglobby: 0.2.16
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -20020,7 +20045,7 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
-  ajv@6.14.0:
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -20530,7 +20555,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.0: {}
+  baseline-browser-mapping@2.10.32: {}
 
   basic-ftp@5.2.0: {}
 
@@ -20798,13 +20823,13 @@ snapshots:
 
   brotli-wasm@3.0.1: {}
 
-  browserslist@4.28.1:
+  browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001776
-      electron-to-chromium: 1.5.307
-      node-releases: 2.0.36
-      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+      baseline-browser-mapping: 2.10.32
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.362
+      node-releases: 2.0.46
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-from@1.1.2: {}
 
@@ -20819,7 +20844,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  builtin-modules@5.0.0: {}
+  builtin-modules@5.2.0: {}
 
   bun-ffi-structs@0.1.2(typescript@5.9.3):
     dependencies:
@@ -20893,7 +20918,7 @@ snapshots:
 
   camelcase@8.0.0: {}
 
-  caniuse-lite@1.0.30001776: {}
+  caniuse-lite@1.0.30001793: {}
 
   capnweb@0.8.0: {}
 
@@ -21182,9 +21207,9 @@ snapshots:
 
   cookie@1.1.1: {}
 
-  core-js-compat@3.48.0:
+  core-js-compat@3.49.0:
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.2
 
   core-js-pure@3.49.0: {}
 
@@ -21500,6 +21525,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -21753,7 +21782,7 @@ snapshots:
       fast-check: 3.23.2
     optional: true
 
-  electron-to-chromium@1.5.307: {}
+  electron-to-chromium@1.5.362: {}
 
   embla-carousel-react@8.6.0(react@19.2.4):
     dependencies:
@@ -22142,26 +22171,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-unicorn@https://codeload.github.com/mmkal/eslint-plugin-unicorn/tar.gz/4b6340834f94ebb53a1aee5b91dd5c0e103249b3(eslint@9.39.3(jiti@2.6.1)):
+  eslint-plugin-unicorn@64.0.0(eslint@9.39.3(jiti@2.6.1)):
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@2.6.1))
-      '@eslint/plugin-kit': 0.4.1
       change-case: 5.4.4
       ci-info: 4.4.0
       clean-regexp: 1.0.0
-      core-js-compat: 3.48.0
+      core-js-compat: 3.49.0
       eslint: 9.39.3(jiti@2.6.1)
-      esquery: 1.6.0
       find-up-simple: 1.0.1
-      globals: 16.5.0
+      globals: 17.6.0
       indent-string: 5.0.0
       is-builtin-module: 5.0.0
       jsesc: 3.1.0
       pluralize: 8.0.0
       regexp-tree: 0.1.27
-      regjsparser: 0.13.0
-      semver: 7.7.4
+      regjsparser: 0.13.1
+      semver: 7.8.1
       strip-indent: 4.1.1
 
   eslint-scope@8.4.0:
@@ -22185,14 +22212,14 @@ snapshots:
       '@eslint/eslintrc': 3.3.5
       '@eslint/js': 9.39.3
       '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.7
+      '@humanfs/node': 0.16.8
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
-      ajv: 6.14.0
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -22722,7 +22749,7 @@ snapshots:
 
   globals@14.0.0: {}
 
-  globals@16.5.0: {}
+  globals@17.6.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -23135,7 +23162,7 @@ snapshots:
 
   is-builtin-module@5.0.0:
     dependencies:
-      builtin-modules: 5.0.0
+      builtin-modules: 5.2.0
 
   is-callable@1.2.7: {}
 
@@ -24232,7 +24259,7 @@ snapshots:
 
   micromark@2.11.4:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -24729,7 +24756,7 @@ snapshots:
       node-addon-api: 7.1.1
     optional: true
 
-  node-releases@2.0.36: {}
+  node-releases@2.0.46: {}
 
   nodemon@3.1.14:
     dependencies:
@@ -25718,7 +25745,7 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
-  regjsparser@0.13.0:
+  regjsparser@0.13.1:
     dependencies:
       jsesc: 3.1.0
 
@@ -26038,6 +26065,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  semver@7.8.1: {}
 
   send@0.19.2:
     dependencies:
@@ -27011,9 +27040,9 @@ snapshots:
 
   until-async@3.0.2: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.1):
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are mostly test helpers, repo info shape, lint config, and e2e coverage; runtime behavior is limited to exposing credentials on repo info and a workspace dispatch cast.
> 
> **Overview**
> This PR tightens **codemode e2e typing** and **repo git auth**, and adjusts **lint** for codemode scripts.
> 
> **Type inference:** `Stubify` in the codemode test builder is now `PromiseLike<T> & { ... }` so promise-pipelined RPC stubs (e.g. `ctx.repos.create({ slug }).getInfo()`) type-check without widening to loose `any`-like shapes. Workspace shell state typing drops the open `Record<string, unknown>` index; workspace capability calls use a narrow `as {}` at the dispatch boundary.
> 
> **Repos:** `RepoInfo` gains a **`credentials`** object (`username` / `password` from the artifact token) so tests and codemode scripts spread `...repo.credentials` into git clone/pull/push instead of hand-parsing tokens.
> 
> **E2E:** New coverage proves a **codemode-created repo** can be cloned, committed, and pushed with normal host `git`, then pulled back inside the workspace. MCP tunnel test expectations are simplified (query-only search). Iterate-config workspace test uses `repo.credentials`.
> 
> **Lint:** Adds **`iterate/isolated-codemode`** (unicorn isolated-functions scoped to `:function[codemode]`), removes the old fixture-specific selectors from **`unicorn-js/isolated-functions`**, and bumps **`eslint-plugin-unicorn`** to **^64.0.0** (published) with a custom rule wrapper for fixture+codemode call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40aed58aba842bac6506b74983749938cea2248f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-05-29T14:27:44.658Z",
      "headSha": "40aed58aba842bac6506b74983749938cea2248f",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26634949906",
      "shortSha": "40aed58"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `40aed58`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/26634949906)
Updated: 2026-05-29T14:27:44.658Z
<!-- /CLOUDFLARE_PREVIEW -->