### PR TITLE
Align OS MCP auth and project-selection flow

### DIFF
--- a/apps/auth/src/routes/_auth/project-access.tsx
+++ b/apps/auth/src/routes/_auth/project-access.tsx
@@ -9,12 +9,21 @@ import {
   CardTitle,
 } from "@iterate-com/ui/components/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@iterate-com/ui/components/avatar";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@iterate-com/ui/components/dialog";
 import { Separator } from "@iterate-com/ui/components/separator";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { Field, FieldError, FieldGroup, FieldLabel } from "@iterate-com/ui/components/field";
 import { Input } from "@iterate-com/ui/components/input";
+import { NativeSelect, NativeSelectOption } from "@iterate-com/ui/components/native-select";
 import { z } from "zod/v4";
 import { authClient, useSession } from "../../utils/auth-client.ts";
 import { getInitials } from "../../utils/initials.ts";
@@ -32,12 +41,20 @@ const CreateOrganizationInput = z.object({
   name: z.string().trim().min(1, "Organization name is required").max(100),
 });
 
+const CreateProjectInput = z.object({
+  organizationSlug: z.string().trim().min(1, "Organization is required"),
+  name: z.string().trim().min(1, "Project name is required").max(100),
+});
+
 function RouteComponent() {
   const { client_id, scope } = Route.useSearch();
   const navigate = Route.useNavigate();
   const session = useSession();
   const [selectedProjectIds, setSelectedProjectIds] = useState<string[] | null>(null);
   const [organizationName, setOrganizationName] = useState("");
+  const [projectName, setProjectName] = useState("");
+  const [selectedOrganizationSlug, setSelectedOrganizationSlug] = useState("");
+  const [isCreateProjectDialogOpen, setIsCreateProjectDialogOpen] = useState(false);
   const hasOAuthClientId = Boolean(client_id);
   const needsProjectSelection =
     scope?.split(" ").includes(ITERATE_PROJECT_SELECTION_SCOPE) ?? false;
@@ -84,6 +101,24 @@ function RouteComponent() {
 
         window.location.href = result.url;
       }
+    },
+  });
+
+  const createProjectMutation = useMutation({
+    mutationFn: (input: z.infer<typeof CreateProjectInput>) => orpcClient.project.create(input),
+    onSuccess: async (project) => {
+      setProjectName("");
+      setIsCreateProjectDialogOpen(false);
+      setSelectedProjectIds((current) => {
+        const existingProjectIds =
+          projectSelectionQuery.data?.flatMap((selection) =>
+            selection.projects.map((project) => project.id),
+          ) ?? [];
+        const next = new Set(current ?? existingProjectIds);
+        next.add(project.id);
+        return Array.from(next);
+      });
+      await projectSelectionQuery.refetch();
     },
   });
 
@@ -182,15 +217,43 @@ function RouteComponent() {
   const allProjectIds = projectSelections.flatMap((selection) =>
     selection.projects.map((project) => project.id),
   );
+  const hasProjects = allProjectIds.length > 0;
   const effectiveSelectedProjectIds = selectedProjectIds ?? allProjectIds;
   const canContinue = effectiveSelectedProjectIds.length > 0;
   const isCreatingFirstOrganization = organizations.length === 0;
   const parsedOrganization = CreateOrganizationInput.safeParse({ name: organizationName });
+  const effectiveOrganizationSlug =
+    selectedOrganizationSlug ||
+    organizations[0]?.slug ||
+    projectSelections[0]?.organization.slug ||
+    "";
+  const parsedProject = CreateProjectInput.safeParse({
+    organizationSlug: effectiveOrganizationSlug,
+    name: projectName,
+  });
   const isSubmitting =
     createOrganizationMutation.isPending ||
+    createProjectMutation.isPending ||
     saveSelectionMutation.isPending ||
     denyMutation.isPending ||
     switchAccount.isPending;
+
+  const createProjectFormProps = {
+    organizations,
+    projectName,
+    selectedOrganizationSlug: effectiveOrganizationSlug,
+    isSubmitting,
+    isCreating: createProjectMutation.isPending,
+    isValid: parsedProject.success,
+    error: !parsedProject.success && projectName.length > 0 ? parsedProject.error.issues : null,
+    mutationError: createProjectMutation.isError ? createProjectMutation.error.message : null,
+    onProjectNameChange: setProjectName,
+    onOrganizationSlugChange: setSelectedOrganizationSlug,
+    onSubmit: () => {
+      if (!parsedProject.success) return;
+      createProjectMutation.mutate(parsedProject.data);
+    },
+  };
 
   if (isCreatingFirstOrganization) {
     return (
@@ -273,6 +336,62 @@ function RouteComponent() {
     );
   }
 
+  if (!hasProjects) {
+    return (
+      <div className="flex min-h-screen items-center justify-center p-4">
+        <Card className="w-full max-w-sm">
+          <CardHeader className="text-center">
+            {client?.logo_uri && (
+              <img src={client.logo_uri} alt="" className="mx-auto size-12 rounded-lg" />
+            )}
+            <CardTitle className="text-xl">Create a project</CardTitle>
+            <CardDescription className="text-xs">
+              Create your first project before choosing access for{" "}
+              {client?.client_name ?? "this application"}.
+            </CardDescription>
+          </CardHeader>
+          <Separator />
+          <CardContent className="space-y-4">
+            <div className="flex items-center gap-3 rounded-xl border bg-muted/30 p-4">
+              <Avatar>
+                {user.image && <AvatarImage src={user.image} alt={user.name ?? user.email} />}
+                <AvatarFallback>{initials}</AvatarFallback>
+              </Avatar>
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium">{user.name ?? "User"}</p>
+                <p className="truncate text-xs text-muted-foreground">{user.email}</p>
+              </div>
+            </div>
+            <CreateProjectForm
+              {...createProjectFormProps}
+              id="create-first-project-form"
+              showSubmitButton={false}
+            />
+          </CardContent>
+          <Separator />
+          <CardFooter className="gap-3">
+            <Button
+              className="flex-1"
+              variant="outline"
+              disabled={isSubmitting}
+              onClick={() => denyMutation.mutate()}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              form="create-first-project-form"
+              className="flex-1"
+              disabled={!parsedProject.success || isSubmitting}
+            >
+              {createProjectMutation.isPending ? "Creating..." : "Create project"}
+            </Button>
+          </CardFooter>
+        </Card>
+      </div>
+    );
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
       <Card className="w-full max-w-sm">
@@ -310,48 +429,67 @@ function RouteComponent() {
         </CardContent>
         <Separator />
         <CardContent className="space-y-3">
-          <div className="flex items-start justify-between gap-3">
-            <div>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
               <p className="text-sm font-medium">Select one or more projects</p>
               <p className="text-xs text-muted-foreground">
                 The access token will include these as `project:&lt;id&gt;` entries in its `scopes`
                 claim.
               </p>
             </div>
-            <div className="flex gap-2">
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                disabled={isSubmitting}
-                onClick={() => setSelectedProjectIds(allProjectIds)}
-              >
-                All
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                disabled={isSubmitting}
-                onClick={() => setSelectedProjectIds([])}
-              >
-                None
-              </Button>
+            <div className="flex shrink-0 flex-wrap justify-end gap-2">
+              <Dialog open={isCreateProjectDialogOpen} onOpenChange={setIsCreateProjectDialogOpen}>
+                <DialogTrigger
+                  render={
+                    <Button type="button" size="sm" variant="outline" disabled={isSubmitting}>
+                      New project
+                    </Button>
+                  }
+                />
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Create project</DialogTitle>
+                    <DialogDescription>
+                      Create another project, then choose whether to include it in this access
+                      grant.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <CreateProjectForm {...createProjectFormProps} />
+                </DialogContent>
+              </Dialog>
+              <div className="flex gap-1">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  disabled={isSubmitting}
+                  onClick={() => setSelectedProjectIds(allProjectIds)}
+                >
+                  All
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  disabled={isSubmitting}
+                  onClick={() => setSelectedProjectIds([])}
+                >
+                  None
+                </Button>
+              </div>
             </div>
           </div>
-          {projectSelections.length === 0 ? (
-            <p className="text-sm text-muted-foreground">You do not have any projects to share.</p>
-          ) : (
-            <div className="space-y-3">
-              {projectSelections.map((selection) => (
-                <section key={selection.organization.id} className="space-y-2">
-                  <div>
-                    <p className="text-sm font-medium">{selection.organization.name}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {selection.projects.length} project
-                      {selection.projects.length === 1 ? "" : "s"}
-                    </p>
-                  </div>
+          <div className="space-y-3">
+            {projectSelections.map((selection) => (
+              <section key={selection.organization.id} className="space-y-2">
+                <div>
+                  <p className="text-sm font-medium">{selection.organization.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {selection.projects.length} project
+                    {selection.projects.length === 1 ? "" : "s"}
+                  </p>
+                </div>
+                {selection.projects.length > 0 ? (
                   <div className="space-y-2">
                     {selection.projects.map((project) => {
                       const checked = effectiveSelectedProjectIds.includes(project.id);
@@ -386,10 +524,10 @@ function RouteComponent() {
                       );
                     })}
                   </div>
-                </section>
-              ))}
-            </div>
-          )}
+                ) : null}
+              </section>
+            ))}
+          </div>
         </CardContent>
         <Separator />
         <CardFooter className="gap-3">
@@ -411,5 +549,73 @@ function RouteComponent() {
         </CardFooter>
       </Card>
     </div>
+  );
+}
+
+function CreateProjectForm(props: {
+  id?: string;
+  className?: string;
+  organizations: { id: string; name: string; slug: string }[];
+  projectName: string;
+  selectedOrganizationSlug: string;
+  isSubmitting: boolean;
+  isCreating: boolean;
+  isValid: boolean;
+  error: z.core.$ZodIssue[] | null;
+  mutationError: string | null;
+  showSubmitButton?: boolean;
+  onProjectNameChange: (value: string) => void;
+  onOrganizationSlugChange: (value: string) => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <form
+      id={props.id}
+      className={props.className ? `space-y-3 ${props.className}` : "space-y-3"}
+      onSubmit={(event) => {
+        event.preventDefault();
+        props.onSubmit();
+      }}
+    >
+      <FieldGroup>
+        <Field>
+          <FieldLabel htmlFor="project-organization">Organization</FieldLabel>
+          <NativeSelect
+            id="project-organization"
+            className="w-full"
+            value={props.selectedOrganizationSlug}
+            onChange={(event) => props.onOrganizationSlugChange(event.target.value)}
+            disabled={props.organizations.length === 0 || props.isSubmitting}
+          >
+            {props.organizations.map((organization) => (
+              <NativeSelectOption key={organization.id} value={organization.slug}>
+                {organization.name}
+              </NativeSelectOption>
+            ))}
+          </NativeSelect>
+        </Field>
+        <Field data-invalid={Boolean(props.error)}>
+          <FieldLabel htmlFor="project-name">Project name</FieldLabel>
+          <Input
+            id="project-name"
+            name="project-name"
+            placeholder="MCP Alpha"
+            value={props.projectName}
+            onChange={(event) => props.onProjectNameChange(event.target.value)}
+            aria-invalid={Boolean(props.error)}
+            disabled={props.isSubmitting}
+          />
+          {props.error ? <FieldError errors={props.error} /> : null}
+        </Field>
+      </FieldGroup>
+      {props.mutationError ? (
+        <p className="text-sm text-destructive">{props.mutationError}</p>
+      ) : null}
+      {(props.showSubmitButton ?? true) ? (
+        <Button type="submit" size="sm" disabled={!props.isValid || props.isSubmitting}>
+          {props.isCreating ? "Creating..." : "Create project"}
+        </Button>
+      ) : null}
+    </form>
   );
 }

--- a/apps/auth/src/routes/_auth/project-access.tsx
+++ b/apps/auth/src/routes/_auth/project-access.tsx
@@ -222,11 +222,7 @@ function RouteComponent() {
   const canContinue = effectiveSelectedProjectIds.length > 0;
   const isCreatingFirstOrganization = organizations.length === 0;
   const parsedOrganization = CreateOrganizationInput.safeParse({ name: organizationName });
-  const effectiveOrganizationSlug =
-    selectedOrganizationSlug ||
-    organizations[0]?.slug ||
-    projectSelections[0]?.organization.slug ||
-    "";
+  const effectiveOrganizationSlug = selectedOrganizationSlug || organizations[0]?.slug || "";
   const parsedProject = CreateProjectInput.safeParse({
     organizationSlug: effectiveOrganizationSlug,
     name: projectName,
@@ -270,16 +266,13 @@ function RouteComponent() {
           </CardHeader>
           <Separator />
           <CardContent className="space-y-4">
-            <div className="flex items-center gap-3 rounded-xl border bg-muted/30 p-4">
-              <Avatar>
-                {user.image && <AvatarImage src={user.image} alt={user.name ?? user.email} />}
-                <AvatarFallback>{initials}</AvatarFallback>
-              </Avatar>
-              <div className="min-w-0">
-                <p className="truncate text-sm font-medium">{user.name ?? "User"}</p>
-                <p className="truncate text-xs text-muted-foreground">{user.email}</p>
-              </div>
-            </div>
+            <SignedInUserRow
+              user={user}
+              initials={initials}
+              isSubmitting={isSubmitting}
+              isSwitching={switchAccount.isPending}
+              onSwitch={() => switchAccount.mutate()}
+            />
 
             <form
               className="space-y-4"
@@ -352,16 +345,13 @@ function RouteComponent() {
           </CardHeader>
           <Separator />
           <CardContent className="space-y-4">
-            <div className="flex items-center gap-3 rounded-xl border bg-muted/30 p-4">
-              <Avatar>
-                {user.image && <AvatarImage src={user.image} alt={user.name ?? user.email} />}
-                <AvatarFallback>{initials}</AvatarFallback>
-              </Avatar>
-              <div className="min-w-0">
-                <p className="truncate text-sm font-medium">{user.name ?? "User"}</p>
-                <p className="truncate text-xs text-muted-foreground">{user.email}</p>
-              </div>
-            </div>
+            <SignedInUserRow
+              user={user}
+              initials={initials}
+              isSubmitting={isSubmitting}
+              isSwitching={switchAccount.isPending}
+              onSwitch={() => switchAccount.mutate()}
+            />
             <CreateProjectForm
               {...createProjectFormProps}
               id="create-first-project-form"
@@ -406,26 +396,13 @@ function RouteComponent() {
         </CardHeader>
         <Separator />
         <CardContent>
-          <div className="flex items-center justify-between">
-            <div className="flex min-w-0 items-center gap-3">
-              <Avatar>
-                {user.image && <AvatarImage src={user.image} alt={user.name ?? user.email} />}
-                <AvatarFallback>{initials}</AvatarFallback>
-              </Avatar>
-              <div className="min-w-0">
-                <p className="truncate text-sm font-medium">{user.name ?? "User"}</p>
-                <p className="truncate text-xs text-muted-foreground">{user.email}</p>
-              </div>
-            </div>
-            <Button
-              variant="ghost"
-              size="sm"
-              disabled={isSubmitting}
-              onClick={() => switchAccount.mutate()}
-            >
-              {switchAccount.isPending ? "Switching..." : "Switch"}
-            </Button>
-          </div>
+          <SignedInUserRow
+            user={user}
+            initials={initials}
+            isSubmitting={isSubmitting}
+            isSwitching={switchAccount.isPending}
+            onSwitch={() => switchAccount.mutate()}
+          />
         </CardContent>
         <Separator />
         <CardContent className="space-y-3">
@@ -548,6 +525,38 @@ function RouteComponent() {
           </Button>
         </CardFooter>
       </Card>
+    </div>
+  );
+}
+
+function SignedInUserRow(props: {
+  user: {
+    name?: string | null;
+    email: string;
+    image?: string | null;
+  };
+  initials: string;
+  isSubmitting: boolean;
+  isSwitching: boolean;
+  onSwitch: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-xl border bg-muted/30 p-4">
+      <div className="flex min-w-0 items-center gap-3">
+        <Avatar>
+          {props.user.image && (
+            <AvatarImage src={props.user.image} alt={props.user.name ?? props.user.email} />
+          )}
+          <AvatarFallback>{props.initials}</AvatarFallback>
+        </Avatar>
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">{props.user.name ?? "User"}</p>
+          <p className="truncate text-xs text-muted-foreground">{props.user.email}</p>
+        </div>
+      </div>
+      <Button variant="ghost" size="sm" disabled={props.isSubmitting} onClick={props.onSwitch}>
+        {props.isSwitching ? "Switching..." : "Switch"}
+      </Button>
     </div>
   );
 }

--- a/apps/os/CONTEXT.md
+++ b/apps/os/CONTEXT.md
@@ -83,8 +83,10 @@ The Worker environment binding used by server code to obtain Project Durable Obj
 _Avoid_: project context, resolved project
 
 **Project MCP Route**:
-The OS `/mcp` resource for project-scoped MCP sessions. The selected Project
-comes from OAuth token project claims or an admin-token `?project=...` selector.
+The OS `/mcp` resource for project-scoped MCP sessions. OAuth access tokens
+expose projects granted by token claims and scopes; admin-token sessions expose
+all projects. Project-scoped tools such as `exec_js` select the Project per
+invocation.
 _Avoid_: Project MCP hostname, ingress MCP alias
 
 **Ingress Hostname**:
@@ -553,9 +555,11 @@ _Avoid_: Project MCP Server Connection, project MCP route, inbound MCP
 - Every Project has a **Slug Project Ingress Host** derived from the current **Project Slug**.
 - The **Stable Project Ingress Host** remains routable even when the slug-derived host changes.
 - Custom hostname, default-host, dashboard-host, and stream-host lifecycle are future ingress work, not current routing behavior.
-- A **Project MCP Route** identifies exactly one **Project**.
-- A **Project MCP Route** is selected through OS `/mcp`, using auth-worker
-  project claims or an admin-token `?project=...` selector.
+- A **Project MCP Route** may expose one or more authorized **Projects**.
+- A **Project MCP Route** is served through OS `/mcp`, using auth-worker project
+  claims and scopes or an admin token that exposes all projects.
+- Project-scoped MCP tools select one **Project** per invocation before touching
+  project-local capabilities.
 - OS exposes one global MCP resource at `/mcp`; it does not expose per-project
   MCP hostnames.
 - The OS Worker classifies every request by **Ingress Hostname** before invoking the **OS App**.
@@ -637,7 +641,9 @@ _Avoid_: Project MCP Server Connection, project MCP route, inbound MCP
 - Project MCP server `exec_js` starts a **Script Execution** and therefore requires a **Script**.
 - Browser session creation and Project MCP server `exec_js` share the same internal attach-or-create and stream append behavior.
 - A **Project Route** resolves its **Project Slug** to the stable **Project ID** before initializing a **Codemode Session**.
-- A **Project MCP Route** resolves to the stable **Project ID** from token claims or an admin-token project selector before initializing a **Codemode Session**.
+- A **Project MCP Route** resolves to the stable **Project ID** from token claims
+  or the tool invocation's selected project slug before initializing a
+  **Codemode Session**.
 - A **User** acts through their **Active Organization** when managing **Projects**.
 - A signed-in **User** without an **Active Organization** must create or select an **Organization** before using OS.
 - A remote OAuth MCP client calls OS with an **OAuth Access Token**.
@@ -1018,7 +1024,7 @@ The provider composition case targets provider-to-provider Tool Function Calls: 
 > **Domain expert:** "No. The concept is **Codemode Session**. Browser UI creates explicit Codemode Sessions with their own Event Stream Paths; Project MCP server connections reuse the MCP connection's existing Event Stream Path."
 
 > **Dev:** "Should MCP `exec_js` take a project selector?"
-> **Domain expert:** "Only when the OAuth token or admin caller has multiple project choices. MCP is project-scoped after the **OS MCP Handler** resolves the selected **Project**."
+> **Domain expert:** "Only when the OAuth token or admin caller has multiple project choices. The tool schema exposes a project slug enum, and `exec_js` resolves that slug to the stable **Project ID** before running codemode."
 
 > **Dev:** "Does a Codemode Session init with the project slug?"
 > **Domain expert:** "No. Routes use **Project Slug**, but Codemode Session init uses the stable **Project ID** resolved from that route."
@@ -1075,7 +1081,7 @@ The provider composition case targets provider-to-provider Tool Function Calls: 
 > **Domain expert:** "Not yet. Keep it exported from the main OS Worker while Project ingress depends on **Loopback Fetch Callables** with dynamic props."
 
 > **Dev:** "Does `/mcp` on a Project-owned hostname route to the Project MCP server?"
-> **Domain expert:** "No. MCP is served by the OS app at `/mcp`; project selection comes from token claims or an admin-token project selector."
+> **Domain expert:** "No. MCP is served by the OS app at `/mcp`; OAuth sessions expose token-granted projects, admin-token sessions expose all projects, and project-scoped tools select one project per invocation."
 
 > **Dev:** "Does the Project Durable Object need to understand MCP protocol paths?"
 > **Domain expert:** "No. The OS `/mcp` handler owns protocol paths, OAuth metadata, browser setup instructions, and unsupported-path responses."

--- a/apps/os/README.md
+++ b/apps/os/README.md
@@ -44,8 +44,7 @@ pnpm typecheck           # TypeScript
 pnpm test                # unit tests
 pnpm e2e -t "OS preview smoke"
                          # deployed preview smoke
-pnpm cli claude-mcp --project-slug-or-id bob
-                         # open Claude against one project MCP server in your local Doppler config
+pnpm cli claude-mcp      # open Claude against the OS MCP server in your local Doppler config
 pnpm sqlfu:generate      # regenerate sqlfu migrations/query wrappers
 pnpm sqlfu:check         # compare migrations to definitions.sql
 pnpm cf:deploy           # production deploy
@@ -56,11 +55,11 @@ that config; otherwise it enters Doppler using the local `apps/os` setup. Use
 `doppler run --config <config> -- <command>` when you want preview/prd app
 config explicitly.
 
-For example, to open Claude against the production MCP server for project
-`bob`, using the production `APP_CONFIG_ADMIN_API_SECRET`:
+For example, to open Claude against the production MCP server using the
+production `APP_CONFIG_ADMIN_API_SECRET`:
 
 ```bash
-doppler run --config prd -- pnpm cli claude-mcp --project-slug-or-id bob
+doppler run --config prd -- pnpm cli claude-mcp
 ```
 
 The script pattern is documented in

--- a/apps/os/docs/debugging-deployed-os-workers.md
+++ b/apps/os/docs/debugging-deployed-os-workers.md
@@ -99,8 +99,8 @@ doppler run --config prd -- pnpm cli rpc project streams read \
 
 ### Project MCP
 
-The OS MCP resource is served by the OS app at `/mcp`; select a project with
-the CLI's `--project-slug-or-id` flag.
+The OS MCP resource is served by the OS app at `/mcp`. Admin-token sessions
+expose all projects and the `exec_js` tool requires a project slug when it runs.
 
 ```txt
 https://os.iterate.com/mcp
@@ -110,7 +110,7 @@ Start Claude with that MCP server preconfigured:
 
 ```bash
 cd apps/os
-doppler run --config prd -- pnpm cli claude-mcp --project-slug-or-id iterate
+doppler run --config prd -- pnpm cli claude-mcp
 ```
 
 For previews, run under the preview Doppler config.
@@ -118,13 +118,13 @@ For previews, run under the preview Doppler config.
 ```bash
 doppler run --config preview_3 -- pnpm cli rpc projects list
 doppler run --config preview_3 -- \
-  pnpm cli claude-mcp --project-slug-or-id <existing-preview-project-slug>
+  pnpm cli claude-mcp
 ```
 
 Or leave it running in tmux:
 
 ```bash
-tmux new -s os-iterate-mcp 'cd apps/os && doppler run --config prd -- pnpm cli claude-mcp --project-slug-or-id iterate'
+tmux new -s os-iterate-mcp 'cd apps/os && doppler run --config prd -- pnpm cli claude-mcp'
 ```
 
 ## Authentication

--- a/apps/os/scripts/claude-mcp.test.ts
+++ b/apps/os/scripts/claude-mcp.test.ts
@@ -30,7 +30,7 @@ describe("assertMcpAdminBearerAccepted", () => {
 
     await expect(
       assertMcpAdminBearerAccepted({
-        mcpUrl: "https://os.iterate.com/mcp?project=iterate",
+        mcpUrl: "https://os.iterate.com/mcp",
         token: "wrong",
       }),
     ).rejects.toThrow(/APP_CONFIG_ADMIN_API_SECRET/);
@@ -44,7 +44,7 @@ describe("assertMcpAdminBearerAccepted", () => {
 
     await expect(
       assertMcpAdminBearerAccepted({
-        mcpUrl: "https://os.iterate.com/mcp?project=demo",
+        mcpUrl: "https://os.iterate.com/mcp",
         token: "secret",
       }),
     ).resolves.toBeUndefined();

--- a/apps/os/scripts/claude-mcp.ts
+++ b/apps/os/scripts/claude-mcp.ts
@@ -14,7 +14,8 @@ const ClaudeMcpInput = z.object({
     .trim()
     .min(1)
     .regex(/^[a-zA-Z0-9_-]+$/, "Project slug or ID must be hostname-safe")
-    .describe("OS project slug or ID used for the admin-token MCP project selector"),
+    .optional()
+    .describe("Deprecated; admin-token MCP sessions now expose all projects."),
   baseHost: z
     .string()
     .trim()
@@ -35,15 +36,12 @@ export const claudeMcpScript = os
   .input(ClaudeMcpInput)
   .meta({
     description:
-      "Print the Claude Code command for one remote OS project MCP server (after Doppler admin-token preflight)",
+      "Print the Claude Code command for the remote OS MCP server (after Doppler admin-token preflight)",
   })
   .handler(async ({ input }) => {
     const adminToken = requireEnv("APP_CONFIG_ADMIN_API_SECRET");
     const baseUrl = input.baseHost ? normalizeBaseUrl(input.baseHost) : defaultBaseUrlFromEnv();
-    const mcpUrl = buildProjectMcpUrl({
-      baseUrl,
-      projectSlugOrId: input.projectSlugOrId,
-    });
+    const mcpUrl = buildProjectMcpUrl({ baseUrl });
     await assertMcpAdminBearerAccepted({ mcpUrl, token: adminToken });
     const command = buildClaudeShellCommand([
       "--mcp-config",
@@ -77,9 +75,8 @@ function requireEnv(name: string) {
   return value;
 }
 
-function buildProjectMcpUrl(input: { baseUrl: string; projectSlugOrId: string }) {
+function buildProjectMcpUrl(input: { baseUrl: string }) {
   const url = new URL("/mcp", normalizeBaseUrl(input.baseUrl));
-  url.searchParams.set("project", input.projectSlugOrId);
   return url.toString();
 }
 

--- a/apps/os/src/app.ts
+++ b/apps/os/src/app.ts
@@ -44,7 +44,7 @@ export const DEFAULT_GOOGLE_OAUTH_SCOPES = [
 ];
 
 export const AppConfig = BaseAppConfig.extend({
-  baseUrl: publicValue(z.url()).optional(),
+  baseUrl: publicValue(z.url().optional()),
   adminApiSecret: redacted(z.string().trim().min(1)).optional(),
   iterateAuth: z
     .object({

--- a/apps/os/src/domains/inbound-mcp-server/durable-objects/project-mcp-server-connection.ts
+++ b/apps/os/src/domains/inbound-mcp-server/durable-objects/project-mcp-server-connection.ts
@@ -568,7 +568,7 @@ export class ProjectMcpServerConnection extends McpAgent<
     requestedProject: string | undefined,
     options: { requireProjectInput: boolean },
   ) {
-    if (!options.requireProjectInput && projects.length === 1 && !requestedProject) {
+    if (!options.requireProjectInput && !requestedProject) {
       return projects[0];
     }
 

--- a/apps/os/src/domains/inbound-mcp-server/durable-objects/project-mcp-server-connection.ts
+++ b/apps/os/src/domains/inbound-mcp-server/durable-objects/project-mcp-server-connection.ts
@@ -168,7 +168,9 @@ export class ProjectMcpServerConnection extends McpAgent<
   async init() {
     const auth = this.requireAuthProps();
     const availableProjects = this.resolveAvailableProjects(auth);
-    const schema = this.createExecJsInputSchema(availableProjects);
+    const requireProjectInput =
+      auth.authType === "admin_api_secret" || availableProjects.length > 1;
+    const schema = this.createExecJsInputSchema(availableProjects, { requireProjectInput });
     const providerDocs = [
       ...createDefaultOutboundMcpProviderRegistrations(),
       ...this.createStaticCodemodeToolProviders(this.authForProject(auth, availableProjects[0])),
@@ -199,7 +201,7 @@ export class ProjectMcpServerConnection extends McpAgent<
         const project = typeof parsedInput.project === "string" ? parsedInput.project : undefined;
         const auth = this.authForProject(
           this.requireAuthProps(),
-          this.resolveToolProject(availableProjects, project),
+          this.resolveToolProject(availableProjects, project, { requireProjectInput }),
         );
         this.requireScope(auth, requiredToolScope);
         const providers = this.createStaticCodemodeToolProviders(auth);
@@ -376,14 +378,18 @@ export class ProjectMcpServerConnection extends McpAgent<
     try {
       const streamPath = await this.getSessionStreamPath();
       const auth = this.requireAuthProps();
-      if (!auth.projectId) {
+      const projectId =
+        typeof payload.projectId === "string"
+          ? payload.projectId
+          : (auth.projectId ?? this.resolveAvailableProjects(auth)[0]?.id);
+      if (!projectId) {
         return;
       }
 
       await getStreamsCapability({
         exports: this.workerExports(),
         props: streamCapabilityProps({
-          projectId: auth.projectId,
+          projectId,
           streamPath,
         }),
       }).append({
@@ -535,11 +541,11 @@ export class ProjectMcpServerConnection extends McpAgent<
     throw new Error("MCP token does not grant access to any projects.");
   }
 
-  private createExecJsInputSchema(projects: ProjectMcpServerConnectionProject[]) {
-    const projectDescription =
-      projects.length === 1
-        ? undefined
-        : `Project slug or ID. One of: ${projects.map((project) => project.slug).join(", ")}`;
+  private createExecJsInputSchema(
+    projects: ProjectMcpServerConnectionProject[],
+    options: { requireProjectInput: boolean },
+  ) {
+    const projectSlugs = Array.from(new Set(projects.map((project) => project.slug))).sort();
 
     return z.object({
       code: z
@@ -547,9 +553,11 @@ export class ProjectMcpServerConnection extends McpAgent<
         .describe(
           "JavaScript async arrow function to execute, e.g. `async (ctx) => { return await ctx.os.listProcedures(); }`",
         ),
-      ...(projectDescription
+      ...(options.requireProjectInput
         ? {
-            project: z.string().describe(projectDescription),
+            project: z
+              .enum(projectSlugs as [string, ...string[]])
+              .describe("Project slug to run this code against."),
           }
         : {}),
     });
@@ -558,21 +566,18 @@ export class ProjectMcpServerConnection extends McpAgent<
   private resolveToolProject(
     projects: ProjectMcpServerConnectionProject[],
     requestedProject: string | undefined,
+    options: { requireProjectInput: boolean },
   ) {
-    if (projects.length === 1 && !requestedProject) {
+    if (!options.requireProjectInput && projects.length === 1 && !requestedProject) {
       return projects[0];
     }
 
     const normalizedRequestedProject = requestedProject?.trim();
     if (!normalizedRequestedProject) {
-      throw new Error("This MCP token grants multiple projects. Pass a project slug or ID.");
+      throw new Error("Pass a project slug.");
     }
 
-    const project = projects.find(
-      (candidate) =>
-        candidate.id === normalizedRequestedProject ||
-        candidate.slug === normalizedRequestedProject,
-    );
+    const project = projects.find((candidate) => candidate.slug === normalizedRequestedProject);
     if (!project) {
       throw new Error(`MCP token does not grant access to project: ${normalizedRequestedProject}`);
     }

--- a/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
@@ -1,10 +1,14 @@
 import { createIterateAuth } from "@iterate-com/auth/server";
-import { ITERATE_PROJECT_SELECTION_SCOPE } from "@iterate-com/shared/auth-claims";
+import {
+  ITERATE_PROJECT_SELECTION_SCOPE,
+  hasWildcardProjectScope,
+  listProjectScopeIds,
+} from "@iterate-com/shared/auth-claims";
 import { McpAgent } from "agents/mcp";
 import { createD1Client } from "sqlfu";
 import type { AppConfig } from "~/app.ts";
 import { principalFromAccessToken, type Principal } from "~/auth/principal.ts";
-import { getProjectById, getProjectBySlug } from "~/db/queries/.generated/index.ts";
+import { listAllProjects } from "~/db/queries/.generated/index.ts";
 import { isBrowserMcpInstructionsRequest } from "~/domains/inbound-mcp-server/mcp-instructions-request.ts";
 import type {
   ProjectMcpServerConnectionProject,
@@ -73,17 +77,24 @@ export async function handleMcpFetch(input: McpHandlerInput): Promise<Response |
     return unauthorizedMcpResponse(input, "Missing or invalid bearer token");
   }
 
+  const scopes = readAccessTokenScopes(accessToken);
   const principal = principalFromAccessToken(accessToken);
-  const projects = principal.projects.map((project) => {
+  const grantedProjectIds = new Set(listProjectScopeIds(scopes));
+  const hasWildcardProjects = hasWildcardProjectScope(scopes);
+  const projects = principal.projects.flatMap((project) => {
+    if (!hasWildcardProjects && !grantedProjectIds.has(project.id)) return [];
+
     const organization = principal.organizations.find((org) => org.id === project.organizationId);
-    return {
-      id: project.id,
-      slug: project.slug,
-      organizationId: project.organizationId,
-      organizationPermissions: [],
-      organizationRole: organization?.role ?? null,
-      organizationSlug: organization?.slug ?? null,
-    } satisfies ProjectMcpServerConnectionProject;
+    return [
+      {
+        id: project.id,
+        slug: project.slug,
+        organizationId: project.organizationId,
+        organizationPermissions: [],
+        organizationRole: organization?.role ?? null,
+        organizationSlug: organization?.slug ?? null,
+      } satisfies ProjectMcpServerConnectionProject,
+    ];
   });
 
   if (projects.length === 0) {
@@ -98,7 +109,7 @@ export async function handleMcpFetch(input: McpHandlerInput): Promise<Response |
     clientId: accessToken.azp ?? null,
     principal,
     projects,
-    scopes: readAccessTokenScopes(accessToken),
+    scopes,
   });
 
   return withCorsHeaders(await mcpHandler.fetch(input.request, input.env, input.ctx));
@@ -109,22 +120,11 @@ async function authenticateAdminMcpRequest(input: McpHandlerInput) {
   const expectedToken = input.config.adminApiSecret?.exposeSecret();
   if (!token || !expectedToken || token !== expectedToken) return null;
 
-  const url = new URL(input.request.url);
-  const projectSlugOrId = url.searchParams.get("project")?.trim();
-  if (!projectSlugOrId) {
-    return new Response("Admin MCP requests must include ?project=<slug-or-id>.", {
-      status: 400,
-      headers: mcpCorsHeaders,
-    });
-  }
-
   const db = createD1Client(input.env.DB);
-  const project =
-    (await getProjectById(db, { id: projectSlugOrId })) ??
-    (await getProjectBySlug(db, { slug: projectSlugOrId }));
-  if (!project) {
-    return new Response(`Project not found: ${projectSlugOrId}`, {
-      status: 404,
+  const projects = await listAllProjects(db, { limit: 10_000, offset: 0 });
+  if (projects.length === 0) {
+    return new Response("No projects are available to this admin MCP token.", {
+      status: 403,
       headers: mcpCorsHeaders,
     });
   }
@@ -136,18 +136,16 @@ async function authenticateAdminMcpRequest(input: McpHandlerInput) {
     orgPermissions: ["admin:api"],
     orgRole: "admin",
     orgSlug: null,
-    projectId: project.id,
-    projectSlug: project.slug,
-    projects: [
-      {
-        id: project.id,
-        slug: project.slug,
-        organizationId: "admin-api",
-        organizationPermissions: ["admin:api"],
-        organizationRole: "admin",
-        organizationSlug: null,
-      },
-    ],
+    projectId: null,
+    projectSlug: null,
+    projects: projects.map((project) => ({
+      id: project.id,
+      slug: project.slug,
+      organizationId: "admin-api",
+      organizationPermissions: ["admin:api"],
+      organizationRole: "admin",
+      organizationSlug: null,
+    })),
     scopes: ["profile"],
     userId: "admin-api-secret",
   } satisfies ProjectMcpServerConnectionProps;

--- a/apps/os/src/durable-objects/iterate-mcp-server-test-entry.ts
+++ b/apps/os/src/durable-objects/iterate-mcp-server-test-entry.ts
@@ -93,38 +93,30 @@ export default {
 function propsForRequest(request: Request): ProjectMcpServerConnectionProps {
   const mode = new URL(request.url).searchParams.get("mode");
   if (mode === "multi" || mode === "admin") {
+    const isAdmin = mode === "admin";
+    const orgFields = {
+      organizationId: isAdmin ? "admin-api" : "org_test",
+      organizationPermissions: isAdmin ? ["admin:api"] : [],
+      organizationRole: "admin",
+      organizationSlug: isAdmin ? null : "test-org",
+    } as const;
     return {
-      authType: mode === "admin" ? "admin_api_secret" : "oauth_access_token",
+      authType: isAdmin ? "admin_api_secret" : "oauth_access_token",
       clientId: "mcp-client-test",
-      orgId: mode === "admin" ? "admin-api" : "org_test",
-      orgPermissions: mode === "admin" ? ["admin:api"] : [],
-      orgRole: mode === "admin" ? "admin" : null,
-      orgSlug: mode === "admin" ? null : "test-org",
+      orgId: isAdmin ? "admin-api" : "org_test",
+      orgPermissions: isAdmin ? ["admin:api"] : [],
+      orgRole: isAdmin ? "admin" : null,
+      orgSlug: isAdmin ? null : "test-org",
       projectId: null,
       projectSlug: null,
       projects: [
-        {
-          id: "proj__test__inboundmcp",
-          slug: "mcp-project",
-          organizationId: mode === "admin" ? "admin-api" : "org_test",
-          organizationPermissions: mode === "admin" ? ["admin:api"] : [],
-          organizationRole: mode === "admin" ? "admin" : "admin",
-          organizationSlug: mode === "admin" ? null : "test-org",
-        },
-        {
-          id: "proj__test__other",
-          slug: "other-project",
-          organizationId: mode === "admin" ? "admin-api" : "org_test",
-          organizationPermissions: mode === "admin" ? ["admin:api"] : [],
-          organizationRole: mode === "admin" ? "admin" : "admin",
-          organizationSlug: mode === "admin" ? null : "test-org",
-        },
+        { id: "proj__test__inboundmcp", slug: "mcp-project", ...orgFields },
+        { id: "proj__test__other", slug: "other-project", ...orgFields },
       ],
-      scopes:
-        mode === "admin"
-          ? ["profile"]
-          : ["profile", "project", "project:proj__test__inboundmcp", "project:proj__test__other"],
-      userId: mode === "admin" ? "admin-api-secret" : "user_test",
+      scopes: isAdmin
+        ? ["profile"]
+        : ["profile", "project", "project:proj__test__inboundmcp", "project:proj__test__other"],
+      userId: isAdmin ? "admin-api-secret" : "user_test",
     };
   }
 

--- a/apps/os/src/durable-objects/iterate-mcp-server-test-entry.ts
+++ b/apps/os/src/durable-objects/iterate-mcp-server-test-entry.ts
@@ -85,17 +85,58 @@ export class TestLeafProvider extends WorkerEntrypoint {
 export default {
   fetch(request, env, ctx) {
     const ctxWithProps = ctx as ExecutionContext & { props?: ProjectMcpServerConnectionProps };
-    ctxWithProps.props = {
-      clientId: "mcp-client-test",
-      orgId: "org_test",
-      orgPermissions: [],
-      orgRole: "admin",
-      orgSlug: "test-org",
-      projectId: "proj__test__inboundmcp",
-      projectSlug: "mcp-project",
-      scopes: ["profile"],
-      userId: "user_test",
-    };
+    ctxWithProps.props = propsForRequest(request);
     return mcpHandler.fetch(request, env, ctx);
   },
 } satisfies ExportedHandler<Env>;
+
+function propsForRequest(request: Request): ProjectMcpServerConnectionProps {
+  const mode = new URL(request.url).searchParams.get("mode");
+  if (mode === "multi" || mode === "admin") {
+    return {
+      authType: mode === "admin" ? "admin_api_secret" : "oauth_access_token",
+      clientId: "mcp-client-test",
+      orgId: mode === "admin" ? "admin-api" : "org_test",
+      orgPermissions: mode === "admin" ? ["admin:api"] : [],
+      orgRole: mode === "admin" ? "admin" : null,
+      orgSlug: mode === "admin" ? null : "test-org",
+      projectId: null,
+      projectSlug: null,
+      projects: [
+        {
+          id: "proj__test__inboundmcp",
+          slug: "mcp-project",
+          organizationId: mode === "admin" ? "admin-api" : "org_test",
+          organizationPermissions: mode === "admin" ? ["admin:api"] : [],
+          organizationRole: mode === "admin" ? "admin" : "admin",
+          organizationSlug: mode === "admin" ? null : "test-org",
+        },
+        {
+          id: "proj__test__other",
+          slug: "other-project",
+          organizationId: mode === "admin" ? "admin-api" : "org_test",
+          organizationPermissions: mode === "admin" ? ["admin:api"] : [],
+          organizationRole: mode === "admin" ? "admin" : "admin",
+          organizationSlug: mode === "admin" ? null : "test-org",
+        },
+      ],
+      scopes:
+        mode === "admin"
+          ? ["profile"]
+          : ["profile", "project", "project:proj__test__inboundmcp", "project:proj__test__other"],
+      userId: mode === "admin" ? "admin-api-secret" : "user_test",
+    };
+  }
+
+  return {
+    clientId: "mcp-client-test",
+    orgId: "org_test",
+    orgPermissions: [],
+    orgRole: "admin",
+    orgSlug: "test-org",
+    projectId: "proj__test__inboundmcp",
+    projectSlug: "mcp-project",
+    scopes: ["profile", "project", "project:proj__test__inboundmcp"],
+    userId: "user_test",
+  };
+}

--- a/apps/os/src/durable-objects/iterate-mcp-server.test.ts
+++ b/apps/os/src/durable-objects/iterate-mcp-server.test.ts
@@ -24,8 +24,9 @@ describe("ProjectMcpServerConnection inbound MCP", () => {
     try {
       await client.connect(transport);
 
-      await expect(client.listTools()).resolves.toMatchObject({
-        tools: expect.arrayContaining([expect.objectContaining({ name: "exec_js" })]),
+      const execJsTool = findExecJsTool(await client.listTools());
+      expect(execJsTool.inputSchema).toMatchObject({
+        properties: expect.not.objectContaining({ project: expect.anything() }),
       });
 
       const result = await client.callTool({
@@ -230,6 +231,98 @@ describe("ProjectMcpServerConnection inbound MCP", () => {
       await closeMcpClient({ client, transport });
     }
   });
+
+  test("requires a literal project slug when OAuth grants multiple projects", async () => {
+    const transport = new StreamableHTTPClientTransport(
+      new URL("https://os.iterate.test/mcp?mode=multi"),
+      {
+        fetch: (input, init) => SELF.fetch(new Request(input, init)),
+      },
+    );
+    const client = new Client({ name: "mcp-multi-project-e2e", version: "1.0.0" });
+
+    try {
+      await client.connect(transport);
+
+      const execJsTool = findExecJsTool(await client.listTools());
+      expect(execJsTool.inputSchema).toMatchObject({
+        properties: {
+          project: {
+            enum: ["mcp-project", "other-project"],
+            type: "string",
+          },
+        },
+        required: expect.arrayContaining(["code", "project"]),
+      });
+
+      const result = await client.callTool({
+        name: "exec_js",
+        arguments: {
+          project: "other-project",
+          code: `async () => ({ project: "other-project" })`,
+        },
+      });
+
+      expect(result.isError).not.toBe(true);
+      expect(parseRunCodeResult(result.content)).toEqual({ project: "other-project" });
+
+      const sessionId = transport.sessionId;
+      expect(sessionId).toBeTruthy();
+      const streamPath = mcpSessionStreamPath("mcp-multi-project-e2e", sessionId ?? "");
+      const events = await readCurrentStreamEvents(streamPath, "proj__test__other");
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "events.iterate.com/mcp-server/tool-invocation-started",
+            payload: expect.objectContaining({
+              projectId: "proj__test__other",
+              projectSlug: "other-project",
+            }),
+          }),
+        ]),
+      );
+    } finally {
+      await closeMcpClient({ client, transport });
+    }
+  });
+
+  test("requires project even for admin-token MCP sessions", async () => {
+    const transport = new StreamableHTTPClientTransport(
+      new URL("https://os.iterate.test/mcp?mode=admin"),
+      {
+        fetch: (input, init) => SELF.fetch(new Request(input, init)),
+      },
+    );
+    const client = new Client({ name: "mcp-admin-project-e2e", version: "1.0.0" });
+
+    try {
+      await client.connect(transport);
+
+      const execJsTool = findExecJsTool(await client.listTools());
+      expect(execJsTool.inputSchema).toMatchObject({
+        properties: {
+          project: {
+            enum: ["mcp-project", "other-project"],
+            type: "string",
+          },
+        },
+        required: expect.arrayContaining(["code", "project"]),
+      });
+
+      const missingProjectResult = await client.callTool({
+        name: "exec_js",
+        arguments: {
+          code: `async () => ({ ok: true })`,
+        },
+      });
+      expect(missingProjectResult.isError).toBe(true);
+      expect(extractTextContent(missingProjectResult.content).join("\n")).toContain(
+        "Invalid arguments for tool exec_js",
+      );
+    } finally {
+      await closeMcpClient({ client, transport });
+    }
+  });
 });
 
 async function closeMcpClient(input: { client: Client; transport: StreamableHTTPClientTransport }) {
@@ -256,10 +349,10 @@ function extractTextContent(content: unknown) {
   );
 }
 
-async function readCurrentStreamEvents(streamPath: StreamPath) {
+async function readCurrentStreamEvents(streamPath: StreamPath, namespace = projectId) {
   const stream = await getInitializedStreamStub({
     durableObjectNamespace: (env as TestEnv).STREAM,
-    namespace: projectId,
+    namespace,
     path: streamPath,
   });
   const events = await stream.history({ before: "end" });
@@ -272,6 +365,12 @@ async function readCurrentStreamEvents(streamPath: StreamPath) {
   } finally {
     disposeRpcResult(events);
   }
+}
+
+function findExecJsTool(response: Awaited<ReturnType<Client["listTools"]>>) {
+  const tool = response.tools.find((candidate) => candidate.name === "exec_js");
+  if (!tool) throw new Error("exec_js tool not found");
+  return tool;
 }
 
 function mcpSessionStreamPath(clientName: string, sessionId: string) {

--- a/apps/os/src/entry.workerd.ts
+++ b/apps/os/src/entry.workerd.ts
@@ -106,8 +106,14 @@ export default {
         if (durableObjectDebugResponse) return durableObjectDebugResponse;
 
         const db = createD1Client(env.DB);
+        const requestConfig = config.baseUrl
+          ? config
+          : {
+              ...config,
+              baseUrl: new URL(request.url).origin as AppConfig["baseUrl"],
+            };
         const projectHostnameBases = config.projectHostnameBases;
-        const appHostname = config.baseUrl ? new URL(config.baseUrl).hostname : null;
+        const appHostname = requestConfig.baseUrl ? new URL(requestConfig.baseUrl).hostname : null;
         const ingressMatch = await matchIngressRequest({
           request,
           lookupRule: async (host) => {
@@ -144,7 +150,7 @@ export default {
         const envWithArtifacts = env as Env & { ARTIFACTS?: CloudflareArtifactsBinding };
         const context: AppContext = {
           manifest,
-          config,
+          config: requestConfig,
           rawRequest: request,
           db,
           doCatalog: env.DB,

--- a/apps/os/src/routes/_app/projects/$projectSlug/mcp.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/mcp.tsx
@@ -66,7 +66,7 @@ function ProjectMcpPage() {
     config.baseUrl && config.baseUrl !== "https://os.iterate.com"
       ? ` --base-host ${config.baseUrl}`
       : "";
-  const cliCommand = `cd apps/os && pnpm cli claude-mcp --project-slug-or-id ${project.slug}${cliBaseHostFlag}`;
+  const cliCommand = `cd apps/os && pnpm cli claude-mcp${cliBaseHostFlag}`;
   const cliCommandHint =
     config.baseUrl === "https://os.iterate.com"
       ? "Run from the repo root. Uses the admin token for auth and disables all other MCP servers. For production, prefix with: doppler run --project os --config prd --"


### PR DESCRIPTION
## Summary
- Update OS MCP to expose authorized projects through OAuth claims or admin token access, with `exec_js` selecting a project per invocation.
- Remove the old `?project=` / `--project-slug-or-id` MCP path and refresh the related docs and CLI guidance.
- Expand MCP tests to cover single-project, multi-project OAuth, and admin-token project selection.

## Testing
- `scripts/claude-mcp.test.ts` passes.
- `iterate-mcp-server` coverage was updated for the new project-selection behavior and admin-token flow.
- Local formatting ran through the commit hook; one deeper Cloudflare DO test path still has environment-specific runtime friction outside the main assertions.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-02T13:18:10.347Z",
      "headSha": "ff59f41e9bd750d10c4e3e330384b31769435903",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/26821672037",
      "shortSha": "ff59f41"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `ff59f41`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/26821672037)
Updated: 2026-06-02T13:18:10.347Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication, authorization, and project selection for MCP and OAuth consent—admin tokens gain broad project access and exec_js routing depends on new scope and slug rules.
> 
> **Overview**
> **OS MCP** no longer pins a single project via `?project=` or `--project-slug-or-id`. OAuth sessions expose only projects allowed by token **scopes**; **admin** sessions see **all** projects from D1. **`exec_js`** takes an optional **`project`** slug (enum) when the caller has multiple grants or uses the admin token, and resolves that slug before codemode runs. Docs, **CONTEXT.md**, the project MCP UI, and **`claude-mcp`** were updated accordingly; tests cover single-, multi-project OAuth, and admin flows. **`baseUrl`** can fall back to the request origin when unset.
> 
> **Auth OAuth project-access** adds a **create first project** step when the user has an organization but no projects, plus **New project** (dialog) during grant selection, with shared **`CreateProjectForm`** / **`SignedInUserRow`** and auto-selecting newly created projects for the grant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff59f41e9bd750d10c4e3e330384b31769435903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->