### PR TITLE
Fix prod OS auth login

### DIFF
--- a/apps/auth/src/server/orpc/routers/internal.ts
+++ b/apps/auth/src/server/orpc/routers/internal.ts
@@ -268,7 +268,7 @@ const ensureOAuthClient = os.internal.oauth.ensureClient
       return {
         clientId: existing.clientId,
         clientName: input.clientName,
-        clientSecret: existing.clientSecret,
+        clientSecret: existingClientSecret,
         redirectURIs: redirectURIs,
       };
     }
@@ -335,7 +335,7 @@ const ensureOAuthClient = os.internal.oauth.ensureClient
       return {
         clientId: existingByClientId.clientId,
         clientName: input.clientName,
-        clientSecret: existingByClientId.clientSecret,
+        clientSecret: existingClientSecret,
         redirectURIs,
       };
     }

--- a/apps/os/alchemy.run.ts
+++ b/apps/os/alchemy.run.ts
@@ -134,6 +134,11 @@ const { worker, afterFinalize } = await IterateApp(ctx, {
       : { DEBUG_APPEND_CHAIN_SUBSCRIBER: debugAppendChainSubscriber }),
     ...(slackBotToken == null ? {} : { APP_CONFIG_SLACK_BOT_TOKEN: alchemy.secret(slackBotToken) }),
   },
+  // OS fetches the auth worker's OIDC metadata and token/userinfo endpoints on
+  // auth.iterate.com from inside the Worker. Without this flag, same-zone
+  // subrequests bypass Worker routes and go to origin, which breaks auth-worker
+  // discovery on production iterate.com hostnames.
+  compatibilityFlags: ["global_fetch_strictly_public"],
   extraRouteHostnames: projectHostnameBases.flatMap(projectRouteHostnamesForBase),
 });
 


### PR DESCRIPTION
## Summary
- enable `global_fetch_strictly_public` for the OS worker so prod same-zone subrequests to `auth.iterate.com` reach the auth worker
- keep OAuth client sync from writing Better Auth's hashed stored client secret back into Doppler

## Verification
- `pnpm --dir apps/auth typecheck`
- `pnpm --dir apps/os typecheck`
- deployed `apps/os` to Doppler `prd` with `doppler run --project os --config prd -- pnpm exec tsx ./alchemy.run.ts`
- browser-control check: logged out to `/sign-in`, then `/api/iterate-auth/login` completed OAuth and landed on `https://os.iterate.com/org/tungtung`

## Notes
- rotated the prod OS OAuth client secret once before the clean deploy because the previous sync had propagated the stored hash as the client secret
- deploy still prints existing non-blocking unknown Doppler config warnings for stale keys (`APP_CONFIG_CLERK`, `APP_CONFIG_X_AI_API_KEY`, `APP_CONFIG_GEMINI_API_KEY`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production auth discovery and OAuth credential propagation; scope is small but login and secret handling are sensitive.
> 
> **Overview**
> Fixes **production OS OAuth login** by routing in-Worker fetches to `auth.iterate.com` through the auth Worker, and stops **OAuth client sync** from pushing Better Auth’s **hashed DB secret** back into Doppler.
> 
> The OS Worker enables Cloudflare **`global_fetch_strictly_public`** so same-zone subrequests for OIDC discovery and token/userinfo no longer bypass Worker routes and hit origin (which broke auth on production `iterate.com` hostnames).
> 
> In **`ensureOAuthClient`**, when an existing client is reused without rotation, the API now returns **`input.existingClientSecret`** (the plaintext from env/Doppler) instead of the stored **`clientSecret`** from the database, so `sync-auth-clients` and similar flows keep the real client secret in Doppler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00583b39160b06c90b93a80466e5fdffd4faf76a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->