### PR TITLE
Seed agent processor registration events

### DIFF
--- a/apps/os/src/domains/agents/agent-stream-subscriptions.ts
+++ b/apps/os/src/domains/agents/agent-stream-subscriptions.ts
@@ -3,6 +3,7 @@ import { StreamPath as StreamPathSchema } from "@iterate-com/shared/streams/type
 import { AgentChatProcessorContract } from "@iterate-com/shared/stream-processors/agent-chat/contract";
 import { AgentProcessorContract } from "@iterate-com/shared/stream-processors/agent/contract";
 import { CloudflareAiProcessorContract } from "@iterate-com/shared/stream-processors/cloudflare-ai/contract";
+import { buildProcessorRegisteredEvent } from "@iterate-com/shared/stream-processors/core/contract";
 import { OpenAiWsProcessorContract } from "@iterate-com/shared/stream-processors/openai-ws/contract";
 import type { AgentLlmProvider } from "~/domains/agents/agent-presets.ts";
 
@@ -36,6 +37,12 @@ export function agentProcessorSubscriptionConfiguredEvents(input: {
       processorSlug,
       projectId: input.projectId,
     }),
+  );
+}
+
+export function defaultAgentProcessorRegisteredEvents(provider: AgentLlmProvider): EventInput[] {
+  return defaultAgentProcessorContracts(provider).map((contract) =>
+    toEventInput(buildProcessorRegisteredEvent({ contract })),
   );
 }
 
@@ -77,4 +84,22 @@ export function agentProcessorRunnerName(input: {
     processorSlug: input.processorSlug,
     projectId: input.projectId,
   })}`;
+}
+
+type SharedProcessorContract = Parameters<typeof buildProcessorRegisteredEvent>[0]["contract"];
+
+function defaultAgentProcessorContracts(provider: AgentLlmProvider): SharedProcessorContract[] {
+  return [
+    AgentChatProcessorContract,
+    AgentProcessorContract,
+    provider === "openai-ws" ? OpenAiWsProcessorContract : CloudflareAiProcessorContract,
+  ];
+}
+
+function toEventInput(input: ReturnType<typeof buildProcessorRegisteredEvent>): EventInput {
+  return {
+    type: input.type,
+    idempotencyKey: input.idempotencyKey,
+    payload: input.payload,
+  };
 }

--- a/apps/os/src/routes/_app/projects/$projectSlug/agents/new.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/agents/new.tsx
@@ -39,6 +39,7 @@ import {
 import {
   agentProcessorSubscriptionConfiguredEvents,
   defaultAgentProcessorSlugs,
+  defaultAgentProcessorRegisteredEvents,
 } from "~/domains/agents/agent-stream-subscriptions.ts";
 import { agentPathFromInput } from "~/lib/agent-links.ts";
 import { streamPathToSplat } from "~/lib/stream-links.ts";
@@ -395,6 +396,7 @@ function buildPreviewEvents(input: {
           processorSlugs: defaultAgentProcessorSlugs(input.provider),
           projectId: input.projectId,
         }),
+        ...defaultAgentProcessorRegisteredEvents(input.provider),
         ...customEvents,
         ...codemodeProviderRegistrationEvents(dedupeToolProviders(providers)),
       ],


### PR DESCRIPTION
Follow-up to #1370.\n\nSeeds the standard shared processor registration events in the initial new-agent append batch, immediately after subscription configuration and before tool-provider registrations. This removes the visible raw-stream gap where the first processor registration only appears after the runner cold-start/replay path.\n\nProduction diagnosis showed the remaining ~1.2-2.1s floor is present even for subscriptions-only streams, so the underlying cost is Stream DO -> StreamProcessorRunner DO WebSocket/RPC startup rather than agent context rendering. This patch does not remove that platform/protocol floor; it removes the registration marker from that delayed path and saves the first registration append per shared processor.\n\nValidation:\n- pnpm --dir apps/os typecheck\n- pnpm --dir apps/os test\n- pnpm exec oxlint . --threads 1 --deny-warnings\n- pnpm format:check

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-05T14:52:58.706Z",
      "headSha": "366d125803eb174e543074cffc00594f600b5631",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27020359488",
      "shortSha": "366d125"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `366d125`
Preview: https://os.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27020359488)
Updated: 2026-06-05T14:52:58.706Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive event seeding on agent creation using existing idempotent registration builders; no auth or core runtime logic changes.
> 
> **Overview**
> Seeds **processor registration** events in the initial **new-agent** `appendBatch`, right after subscription configuration and before custom events and codemode tool-provider registrations.
> 
> Adds `defaultAgentProcessorRegisteredEvents` in `agent-stream-subscriptions.ts`, which emits registration events for the standard shared processors (agent-chat, agent, and the provider’s LLM processor via `buildProcessorRegisteredEvent`). The **New Agent** flow spreads those into the preview/create event list so registration markers appear immediately in the raw stream instead of only after the stream processor runner cold-start/replay path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 366d125803eb174e543074cffc00594f600b5631. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->