### PR TITLE
[codex] Move OS MCP to canonical MCP base URL

### DIFF
--- a/apps/os/README.md
+++ b/apps/os/README.md
@@ -62,6 +62,12 @@ production `APP_CONFIG_ADMIN_API_SECRET`:
 doppler run --config prd -- pnpm cli claude-mcp
 ```
 
+The canonical MCP endpoint comes from `APP_CONFIG_MCP__BASE_URL`, for example
+`https://mcp.iterate.com` in production or
+`https://mcp.iterate-dev-jonas.com` in local tunnel configs. `APP_CONFIG_BASE_URL`
+remains the dashboard URL. Localhost-oriented dev defaults MCP to
+`<APP_CONFIG_BASE_URL>/api/__mcp`, for example `http://localhost:5176/api/__mcp`.
+
 The script pattern is documented in
 [`docs/doppler-backed-scripts.md`](./docs/doppler-backed-scripts.md).
 

--- a/apps/os/alchemy.run.ts
+++ b/apps/os/alchemy.run.ts
@@ -48,6 +48,7 @@ const db = await D1Database("os-db", {
 // iterate-preview-N.com zone (`os.iterate-preview-N.com`) so project/MCP hosts
 // can own the iterate-preview-N.app zone cleanly.
 const projectHostnameBases = ctx.runtimeConfig.projectHostnameBases ?? [];
+const mcpRouteHostname = routeHostnameForUrl(ctx.runtimeConfig.mcp?.baseUrl);
 const artifactsAccountId = requireEnv("CLOUDFLARE_ACCOUNT_ID");
 const artifactsNamespace = `${ctx.workerName}-repos`;
 const outboundMcpFromOurClientCapability =
@@ -148,7 +149,10 @@ const { worker, afterFinalize } = await IterateApp(ctx, {
   // subrequests bypass Worker routes and go to origin, which breaks auth-worker
   // discovery on production iterate.com hostnames.
   compatibilityFlags: ["global_fetch_strictly_public"],
-  extraRouteHostnames: projectHostnameBases.flatMap(projectRouteHostnamesForBase),
+  extraRouteHostnames: [
+    ...(mcpRouteHostname ? [mcpRouteHostname] : []),
+    ...projectHostnameBases.flatMap(projectRouteHostnamesForBase),
+  ],
 });
 
 export { worker };
@@ -166,6 +170,11 @@ if (!ctx.app.local) process.exit(0);
  */
 function projectRouteHostnamesForBase(base: string) {
   return [base, `*.${base}`];
+}
+
+function routeHostnameForUrl(url: string | undefined) {
+  if (!url) return undefined;
+  return new URL(url).hostname;
 }
 
 function requireEnv(name: string) {

--- a/apps/os/docs/architecture-and-operations.md
+++ b/apps/os/docs/architecture-and-operations.md
@@ -155,8 +155,8 @@ Primary surfaces:
 - UI: project codemode session pages.
 - oRPC: `project.codemode.createSession`,
   `project.codemode.executeScript`, and `project.streams` reads.
-- MCP: `exec_js` on a project MCP route, such as
-  `https://mcp__demo.iterate.app`.
+- MCP: `exec_js` on the canonical MCP endpoint, such as
+  `https://mcp.iterate.com`.
 
 Default providers are registered for every session. The important built-ins are
 `ctx.fetch`, `ctx.console`, `ctx.streams`, worker AI examples, OpenAPI examples,
@@ -267,7 +267,7 @@ Full browser smoke with Clerk and `agent-browser`:
 Codemode MCP provider-stack smoke:
 
 ```bash
-OS_E2E_MCP_URL=https://mcp__demo.iterate-preview-2.app \
+OS_E2E_MCP_URL=https://mcp.iterate-preview-2.com \
 doppler run --project os --config preview_2 -- pnpm e2e -t "project MCP exec_js"
 ```
 

--- a/apps/os/docs/debugging-deployed-os-workers.md
+++ b/apps/os/docs/debugging-deployed-os-workers.md
@@ -103,7 +103,7 @@ The OS MCP resource is served by the OS app at `/mcp`. Admin-token sessions
 expose all projects and the `exec_js` tool requires a project slug when it runs.
 
 ```txt
-https://os.iterate.com/mcp
+https://mcp.iterate.com
 ```
 
 Start Claude with that MCP server preconfigured:

--- a/apps/os/e2e/vitest/codemode-mcp-provider-stack.e2e.test.ts
+++ b/apps/os/e2e/vitest/codemode-mcp-provider-stack.e2e.test.ts
@@ -246,6 +246,7 @@ function requireMcpUrl(input: { projectSlug: string }) {
   if (override) return new URL(override);
 
   const mcpUrl = buildProjectMcpUrl({
+    mcpBaseUrl: process.env.APP_CONFIG_MCP__BASE_URL,
     projectHostnameBases: requireProjectHostnameBases(),
     projectSlug: input.projectSlug,
   });

--- a/apps/os/e2e/vitest/preview-smoke.e2e.test.ts
+++ b/apps/os/e2e/vitest/preview-smoke.e2e.test.ts
@@ -135,15 +135,15 @@ async function seedProject(input: { adminApiSecret: string; baseUrl: URL }) {
 function projectMcpUrlFor(input: { baseUrl: URL; project: Project }) {
   const previewMatch = /^os\.iterate-preview-(\d+)\.com$/.exec(input.baseUrl.hostname);
   if (previewMatch) {
-    return new URL(`https://mcp__${input.project.slug}.iterate-preview-${previewMatch[1]}.app/`);
+    return new URL(`https://mcp.iterate-preview-${previewMatch[1]}.com/`);
   }
 
   if (input.baseUrl.hostname === "os.iterate.com") {
-    return new URL(`https://mcp__${input.project.slug}.iterate.app/`);
+    return new URL("https://mcp.iterate.com/");
   }
 
   throw new Error(
-    `Cannot derive project MCP URL for ${input.project.slug} from OS base ${input.baseUrl}. Set OS_PROJECT_MCP_URL explicitly.`,
+    `Cannot derive the MCP URL from OS base ${input.baseUrl}. Set OS_PROJECT_MCP_URL explicitly.`,
   );
 }
 
@@ -156,8 +156,7 @@ async function seedProjectMcpUrl(input: { adminApiSecret: string; baseUrl: URL }
   return projectMcpUrlFor({ baseUrl: input.baseUrl, project });
 }
 
-// TODO: Re-enable once preview smoke follows the canonical /mcp route instead of
-// the retired project MCP hostname flow.
+// TODO: Re-enable once preview smoke has a stable deployed-preview auth fixture.
 test.skip("OS preview smoke", async () => {
   const baseUrl = requireBaseUrl();
   const projectMcpUrlOverride = readProjectMcpUrlOverride();

--- a/apps/os/e2e/workspace-codemode-preview-example.ts
+++ b/apps/os/e2e/workspace-codemode-preview-example.ts
@@ -103,15 +103,15 @@ async function fetchProjectBySlug(input: { adminApiSecret: string; baseUrl: URL;
 function projectMcpUrlFor(input: { baseUrl: URL; project: Project }) {
   const previewMatch = /^os\.iterate-preview-(\d+)\.com$/.exec(input.baseUrl.hostname);
   if (previewMatch) {
-    return new URL(`https://mcp__${input.project.slug}.iterate-preview-${previewMatch[1]}.app/`);
+    return new URL(`https://mcp.iterate-preview-${previewMatch[1]}.com/`);
   }
 
   if (input.baseUrl.hostname === "os.iterate.com") {
-    return new URL(`https://mcp__${input.project.slug}.iterate.app/`);
+    return new URL("https://mcp.iterate.com/");
   }
 
   throw new Error(
-    `Cannot derive project MCP URL for ${input.project.slug} from ${input.baseUrl}. Set APP_CONFIG_BASE_URL to a known OS deployment.`,
+    `Cannot derive the MCP URL from ${input.baseUrl}. Set APP_CONFIG_MCP__BASE_URL or pass a known OS deployment.`,
   );
 }
 

--- a/apps/os/scripts/claude-mcp.test.ts
+++ b/apps/os/scripts/claude-mcp.test.ts
@@ -30,7 +30,7 @@ describe("assertMcpAdminBearerAccepted", () => {
 
     await expect(
       assertMcpAdminBearerAccepted({
-        mcpUrl: "https://os.iterate.com/mcp",
+        mcpUrl: "https://mcp.iterate.com",
         token: "wrong",
       }),
     ).rejects.toThrow(/APP_CONFIG_ADMIN_API_SECRET/);
@@ -44,7 +44,7 @@ describe("assertMcpAdminBearerAccepted", () => {
 
     await expect(
       assertMcpAdminBearerAccepted({
-        mcpUrl: "https://os.iterate.com/mcp",
+        mcpUrl: "https://mcp.iterate.com",
         token: "secret",
       }),
     ).resolves.toBeUndefined();

--- a/apps/os/scripts/claude-mcp.ts
+++ b/apps/os/scripts/claude-mcp.ts
@@ -3,8 +3,9 @@ import process from "node:process";
 
 import { os } from "@orpc/server";
 import { z } from "zod";
+import { resolveMcpBaseUrl } from "~/lib/mcp-base-url.ts";
 
-const DEFAULT_BASE_URL = "https://os.iterate.com";
+const DEFAULT_MCP_BASE_URL = "https://mcp.iterate.com";
 const SERVER_NAME = "iterate";
 const DEFAULT_INITIAL_PROMPT = "describe the MCP tools you have available";
 
@@ -21,9 +22,7 @@ const ClaudeMcpInput = z.object({
     .trim()
     .min(1)
     .optional()
-    .describe(
-      "Deprecated. OS base hostname or URL, e.g. os.iterate.com (default: APP_CONFIG_BASE_URL or https://os.iterate.com)",
-    ),
+    .describe("MCP base hostname or URL, e.g. mcp.iterate.com or mcp.example.com/iterate."),
   prompt: z
     .string()
     .trim()
@@ -40,8 +39,7 @@ export const claudeMcpScript = os
   })
   .handler(async ({ input }) => {
     const adminToken = requireEnv("APP_CONFIG_ADMIN_API_SECRET");
-    const baseUrl = input.baseHost ? normalizeBaseUrl(input.baseHost) : defaultBaseUrlFromEnv();
-    const mcpUrl = buildProjectMcpUrl({ baseUrl });
+    const mcpUrl = input.baseHost ? mcpUrlFromBaseHost(input.baseHost) : defaultMcpUrlFromEnv();
     await assertMcpAdminBearerAccepted({ mcpUrl, token: adminToken });
     const command = buildClaudeShellCommand([
       "--mcp-config",
@@ -63,8 +61,14 @@ export const claudeMcpScript = os
     );
   });
 
-function defaultBaseUrlFromEnv() {
-  return normalizeBaseUrl(process.env.APP_CONFIG_BASE_URL?.trim() || DEFAULT_BASE_URL);
+function defaultMcpUrlFromEnv() {
+  const resolvedMcpBaseUrl = resolveMcpBaseUrl({
+    appBaseUrl: process.env.APP_CONFIG_BASE_URL,
+    mcpBaseUrl: process.env.APP_CONFIG_MCP__BASE_URL,
+  });
+  if (resolvedMcpBaseUrl) return resolvedMcpBaseUrl;
+
+  return normalizeBaseUrl(DEFAULT_MCP_BASE_URL);
 }
 
 function requireEnv(name: string) {
@@ -75,9 +79,8 @@ function requireEnv(name: string) {
   return value;
 }
 
-function buildProjectMcpUrl(input: { baseUrl: string }) {
-  const url = new URL("/mcp", normalizeBaseUrl(input.baseUrl));
-  return url.toString();
+function mcpUrlFromBaseHost(value: string) {
+  return normalizeBaseUrl(value);
 }
 
 function normalizeBaseUrl(value: string) {
@@ -87,7 +90,10 @@ function normalizeBaseUrl(value: string) {
     throw new Error("--base-host must not include a query or hash.");
   }
 
-  return parsed.origin;
+  parsed.search = "";
+  parsed.hash = "";
+  parsed.pathname = parsed.pathname.replace(/\/+$/, "") || "/";
+  return parsed.toString().replace(/\/$/, "");
 }
 
 export async function assertMcpAdminBearerAccepted(input: { mcpUrl: string; token: string }) {

--- a/apps/os/scripts/sync-auth-clients.ts
+++ b/apps/os/scripts/sync-auth-clients.ts
@@ -6,6 +6,7 @@ import { SERVICE_TOKEN_HEADER, type AuthContractClient } from "@iterate-com/auth
 type Target = {
   dopplerConfig: string;
   baseUrl: string;
+  mcpBaseUrl: string;
   projectHostnameBase: string;
 };
 
@@ -13,29 +14,34 @@ const targets: Target[] = [
   {
     dopplerConfig: "dev_jonas",
     baseUrl: "https://os.iterate-dev-jonas.com",
+    mcpBaseUrl: "https://mcp.iterate-dev-jonas.com",
     projectHostnameBase: "iterate-dev-jonas.app",
   },
   {
     dopplerConfig: "dev_misha",
     baseUrl: "https://os.iterate-dev-misha.com",
+    mcpBaseUrl: "https://mcp.iterate-dev-misha.com",
     projectHostnameBase: "iterate-dev-misha.app",
   },
   {
     dopplerConfig: "dev_rahul",
     baseUrl: "https://os.iterate-dev-rahul.com",
+    mcpBaseUrl: "https://mcp.iterate-dev-rahul.com",
     projectHostnameBase: "iterate-dev-rahul.app",
   },
-  ...[2, 3, 4, 5, 6, 7, 8, 9].map(
+  ...[1, 2, 3, 4, 5, 6, 7, 8, 9].map(
     (previewNumber) =>
       ({
         dopplerConfig: `preview_${previewNumber}`,
         baseUrl: `https://os.iterate-preview-${previewNumber}.com`,
+        mcpBaseUrl: `https://mcp.iterate-preview-${previewNumber}.com`,
         projectHostnameBase: `iterate-preview-${previewNumber}.app`,
       }) satisfies Target,
   ),
   {
     dopplerConfig: "prd",
     baseUrl: "https://os.iterate.com",
+    mcpBaseUrl: "https://mcp.iterate.com",
     projectHostnameBase: "iterate.app",
   },
 ];
@@ -106,6 +112,7 @@ for (const target of targets) {
 
   setDopplerSecrets(target, {
     APP_CONFIG_BASE_URL: target.baseUrl,
+    APP_CONFIG_MCP__BASE_URL: target.mcpBaseUrl,
     APP_CONFIG_PROJECT_HOSTNAME_BASES: JSON.stringify([target.projectHostnameBase]),
     ITERATE_OAUTH_ISSUER: authIssuer,
     ITERATE_OAUTH_CLIENT_ID: webClient.clientId,

--- a/apps/os/src/app.ts
+++ b/apps/os/src/app.ts
@@ -45,6 +45,11 @@ export const DEFAULT_GOOGLE_OAUTH_SCOPES = [
 
 export const AppConfig = BaseAppConfig.extend({
   baseUrl: publicValue(z.url().optional()),
+  mcp: z
+    .object({
+      baseUrl: publicValue(z.url()),
+    })
+    .optional(),
   adminApiSecret: redacted(z.string().trim().min(1)).optional(),
   iterateAuth: z
     .object({

--- a/apps/os/src/auth/middleware.ts
+++ b/apps/os/src/auth/middleware.ts
@@ -1,6 +1,7 @@
 import { createIterateAuth, type AuthenticatedSession } from "@iterate-com/auth/server";
 import { createMiddleware } from "@tanstack/react-start";
 import type { AppContext } from "~/context.ts";
+import { resolveMcpBaseUrl } from "~/lib/mcp-base-url.ts";
 import {
   adminPrincipal,
   principalFromAccessToken,
@@ -150,13 +151,19 @@ function createOsIterateAuth(context: AppContext, request: Request) {
 
   const requestOrigin = new URL(request.url).origin;
   const resource = (config.resource ?? context.config.baseUrl ?? requestOrigin).replace(/\/+$/, "");
+  const mcpResource = resolveMcpBaseUrl({
+    appBaseUrl: context.config.baseUrl,
+    mcpBaseUrl: context.config.mcp?.baseUrl,
+    requestUrl: request.url,
+  });
+  const resources = mcpResource ? [resource, mcpResource] : [resource];
 
   return createIterateAuth({
     issuer: config.issuer,
     clientId: config.clientId,
     clientSecret: config.clientSecret.exposeSecret(),
     redirectURI: `${(context.config.baseUrl ?? requestOrigin).replace(/\/+$/, "")}/api/iterate-auth/callback`,
-    resource: [resource, `${resource}/mcp`],
+    resource: resources,
     logoutReturnToOrigins: context.config.baseUrl ? [context.config.baseUrl] : undefined,
   });
 }

--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -160,6 +160,7 @@ function AppSidebarNav() {
         <ProjectSidebarGroup
           key={project.id}
           customHostname={project.customHostname}
+          mcpBaseUrl={config.mcp?.baseUrl}
           projectSlug={project.slug}
           baseUrl={config.baseUrl}
           projectHostnameBases={config.projectHostnameBases}
@@ -172,16 +173,18 @@ function AppSidebarNav() {
 function ProjectSidebarGroup({
   baseUrl,
   customHostname,
+  mcpBaseUrl,
   projectHostnameBases,
   projectSlug,
 }: {
   baseUrl?: string;
   customHostname: string | null;
+  mcpBaseUrl?: string;
   projectHostnameBases: readonly string[];
   projectSlug: string;
 }) {
   const matchRoute = useMatchRoute();
-  const mcpUrl = buildProjectMcpUrl({ baseUrl, projectSlug, projectHostnameBases });
+  const mcpUrl = buildProjectMcpUrl({ baseUrl, mcpBaseUrl, projectSlug, projectHostnameBases });
   const customWorkerUrl = buildProjectWorkerUrl({
     projectSlug,
     customHostname,

--- a/apps/os/src/domains/inbound-mcp-server/entrypoints/project-mcp-server-entrypoint.ts
+++ b/apps/os/src/domains/inbound-mcp-server/entrypoints/project-mcp-server-entrypoint.ts
@@ -14,7 +14,7 @@ export class ProjectMcpServerEntrypoint extends WorkerEntrypoint {
       return new Response(null, { headers: mcpCorsHeaders });
     }
 
-    return new Response("Project MCP hostnames have moved to the OS /mcp endpoint.", {
+    return new Response("Project MCP hostnames have moved to the canonical MCP endpoint.", {
       status: 410,
       headers: mcpCorsHeaders,
     });

--- a/apps/os/src/domains/inbound-mcp-server/mcp-handler.test.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-handler.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { matchMcpRequestUrl } from "./mcp-url-routing.ts";
+
+describe("matchMcpRequestUrl", () => {
+  it("matches the root of the configured MCP host", () => {
+    expect(
+      matchMcpRequestUrl({
+        mcpBaseUrl: "https://mcp.iterate.com",
+        requestUrl: "https://mcp.iterate.com/",
+      }),
+    ).toEqual({ relativePathname: "/" });
+  });
+
+  it("matches paths relative to a path-mounted MCP base URL", () => {
+    expect(
+      matchMcpRequestUrl({
+        mcpBaseUrl: "http://localhost:5176/api/__mcp",
+        requestUrl: "http://localhost:5176/api/__mcp/.well-known/oauth-protected-resource",
+      }),
+    ).toEqual({ relativePathname: "/.well-known/oauth-protected-resource" });
+  });
+
+  it("defaults localhost app URLs to /api/__mcp", () => {
+    expect(
+      matchMcpRequestUrl({
+        appBaseUrl: "http://localhost:5176",
+        requestUrl: "http://localhost:5176/api/__mcp",
+      }),
+    ).toEqual({ relativePathname: "/" });
+  });
+
+  it("does not match the old dashboard /mcp URL unless it is explicitly configured", () => {
+    expect(
+      matchMcpRequestUrl({
+        mcpBaseUrl: "https://mcp.iterate.com",
+        requestUrl: "https://os.iterate.com/mcp",
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/os/src/domains/inbound-mcp-server/mcp-handler.test.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-handler.test.ts
@@ -29,6 +29,15 @@ describe("matchMcpRequestUrl", () => {
     ).toEqual({ relativePathname: "/" });
   });
 
+  it("treats localhost and loopback addresses as equivalent for local defaults", () => {
+    expect(
+      matchMcpRequestUrl({
+        appBaseUrl: "http://localhost:5176",
+        requestUrl: "http://127.0.0.1:5176/api/__mcp",
+      }),
+    ).toEqual({ relativePathname: "/" });
+  });
+
   it("does not match the old dashboard /mcp URL unless it is explicitly configured", () => {
     expect(
       matchMcpRequestUrl({

--- a/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
@@ -10,6 +10,12 @@ import type { AppConfig } from "~/app.ts";
 import { principalFromAccessToken, type Principal } from "~/auth/principal.ts";
 import { listAllProjects } from "~/db/queries/.generated/index.ts";
 import { isBrowserMcpInstructionsRequest } from "~/domains/inbound-mcp-server/mcp-instructions-request.ts";
+import {
+  matchMcpRequestUrl,
+  normalizeMcpBaseUrl,
+  stripTrailingSlash,
+} from "~/domains/inbound-mcp-server/mcp-url-routing.ts";
+import { resolveMcpBaseUrl } from "~/lib/mcp-base-url.ts";
 import type {
   ProjectMcpServerConnectionProject,
   ProjectMcpServerConnectionProps,
@@ -22,7 +28,10 @@ type McpHandlerInput = {
   config: AppConfig;
 };
 
-const mcpHandler = McpAgent.serve("/mcp", { binding: "PROJECT_MCP_SERVER_CONNECTION" });
+const internalMcpHandlerPath = "/__iterate/internal-mcp";
+const mcpHandler = McpAgent.serve(internalMcpHandlerPath, {
+  binding: "PROJECT_MCP_SERVER_CONNECTION",
+});
 
 export const mcpCorsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -33,18 +42,18 @@ export const mcpCorsHeaders = {
 };
 
 export async function handleMcpFetch(input: McpHandlerInput): Promise<Response | null> {
-  const url = new URL(input.request.url);
-  if (!isMcpPath(url.pathname)) return null;
+  const routeMatch = matchConfiguredMcpBaseUrl(input);
+  if (!routeMatch) return null;
 
   if (input.request.method === "OPTIONS") {
     return new Response(null, { headers: mcpCorsHeaders });
   }
 
-  if (isMcpProtectedResourceMetadataPath(url.pathname)) {
+  if (isMcpProtectedResourceMetadataPath(routeMatch.relativePathname)) {
     return Response.json(buildProtectedResourceMetadata(input), { headers: mcpCorsHeaders });
   }
 
-  if (url.pathname !== "/mcp") {
+  if (routeMatch.relativePathname !== "/") {
     return new Response("Not found", { status: 404, headers: mcpCorsHeaders });
   }
 
@@ -61,7 +70,9 @@ export async function handleMcpFetch(input: McpHandlerInput): Promise<Response |
       props?: ProjectMcpServerConnectionProps;
     };
     ctxWithProps.props = adminProps;
-    return withCorsHeaders(await mcpHandler.fetch(input.request, input.env, input.ctx));
+    return withCorsHeaders(
+      await mcpHandler.fetch(mcpHandlerRequest(input.request), input.env, input.ctx),
+    );
   }
 
   const auth = createMcpIterateAuth(input);
@@ -112,7 +123,9 @@ export async function handleMcpFetch(input: McpHandlerInput): Promise<Response |
     scopes,
   });
 
-  return withCorsHeaders(await mcpHandler.fetch(input.request, input.env, input.ctx));
+  return withCorsHeaders(
+    await mcpHandler.fetch(mcpHandlerRequest(input.request), input.env, input.ctx),
+  );
 }
 
 async function authenticateAdminMcpRequest(input: McpHandlerInput) {
@@ -151,15 +164,22 @@ async function authenticateAdminMcpRequest(input: McpHandlerInput) {
   } satisfies ProjectMcpServerConnectionProps;
 }
 
-function isMcpPath(pathname: string) {
-  return pathname === "/mcp" || isMcpProtectedResourceMetadataPath(pathname);
+function isMcpProtectedResourceMetadataPath(pathname: string) {
+  return pathname === "/.well-known/oauth-protected-resource";
 }
 
-function isMcpProtectedResourceMetadataPath(pathname: string) {
-  return (
-    pathname === "/.well-known/oauth-protected-resource" ||
-    pathname === "/.well-known/oauth-protected-resource/mcp"
-  );
+function matchConfiguredMcpBaseUrl(input: McpHandlerInput) {
+  return matchMcpRequestUrl({
+    appBaseUrl: input.config.baseUrl,
+    mcpBaseUrl: input.config.mcp?.baseUrl,
+    requestUrl: input.request.url,
+  });
+}
+
+function mcpHandlerRequest(request: Request) {
+  const url = new URL(request.url);
+  url.pathname = internalMcpHandlerPath;
+  return new Request(url, request);
 }
 
 function createMcpIterateAuth(input: McpHandlerInput) {
@@ -226,7 +246,14 @@ function readBearerToken(headerValue: string | null) {
 }
 
 function canonicalMcpResourceUrl(input: McpHandlerInput) {
-  return `${getRequestBaseUrl(input)}/mcp`;
+  const rawUrl = resolveMcpBaseUrl({
+    appBaseUrl: input.config.baseUrl,
+    mcpBaseUrl: input.config.mcp?.baseUrl,
+    requestUrl: input.request.url,
+  });
+  if (!rawUrl) throw new Error("APP_CONFIG_MCP__BASE_URL is required for MCP requests.");
+  const baseUrl = normalizeMcpBaseUrl(rawUrl);
+  return stripTrailingSlash(baseUrl.toString());
 }
 
 function getRequestBaseUrl(input: McpHandlerInput) {
@@ -235,8 +262,8 @@ function getRequestBaseUrl(input: McpHandlerInput) {
 
 function unauthorizedMcpResponse(input: McpHandlerInput, message: string) {
   const metadataUrl = new URL(
-    "/.well-known/oauth-protected-resource/mcp",
-    input.config.baseUrl ?? input.request.url,
+    ".well-known/oauth-protected-resource",
+    `${canonicalMcpResourceUrl(input)}/`,
   ).toString();
   return new Response(message, {
     status: 401,
@@ -250,8 +277,8 @@ function unauthorizedMcpResponse(input: McpHandlerInput, message: string) {
 function mcpInstructionsPageResponse(input: McpHandlerInput) {
   const mcpUrl = canonicalMcpResourceUrl(input);
   const metadataUrl = new URL(
-    "/.well-known/oauth-protected-resource/mcp",
-    input.config.baseUrl ?? input.request.url,
+    ".well-known/oauth-protected-resource",
+    `${canonicalMcpResourceUrl(input)}/`,
   ).toString();
   const claudeCommand = `claude mcp add --transport http iterate ${mcpUrl}`;
 

--- a/apps/os/src/domains/inbound-mcp-server/mcp-instructions-request.test.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-instructions-request.test.ts
@@ -10,7 +10,7 @@ function request(input: { accept?: string; authorization?: string; method?: stri
     headers.set("authorization", input.authorization);
   }
 
-  return new Request("https://os.iterate.com/mcp", {
+  return new Request("https://mcp.iterate.com/", {
     method: input.method ?? "GET",
     headers,
   });

--- a/apps/os/src/domains/inbound-mcp-server/mcp-url-routing.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-url-routing.ts
@@ -14,7 +14,7 @@ export function matchMcpRequestUrl(input: {
 
   const requestUrl = new URL(input.requestUrl);
   const baseUrl = normalizeMcpBaseUrl(mcpBaseUrl);
-  if (requestUrl.origin !== baseUrl.origin) return null;
+  if (!sameOriginOrLocalhostEquivalent(requestUrl, baseUrl)) return null;
 
   const basePathname = stripTrailingSlash(baseUrl.pathname);
   const requestPathname = stripTrailingSlash(requestUrl.pathname);
@@ -44,4 +44,19 @@ export function normalizeMcpBaseUrl(rawUrl: string) {
 
 export function stripTrailingSlash(pathname: string) {
   return pathname.replace(/\/+$/, "");
+}
+
+function sameOriginOrLocalhostEquivalent(requestUrl: URL, baseUrl: URL) {
+  if (requestUrl.origin === baseUrl.origin) return true;
+
+  return (
+    requestUrl.protocol === baseUrl.protocol &&
+    requestUrl.port === baseUrl.port &&
+    isLocalhostEquivalent(requestUrl.hostname) &&
+    isLocalhostEquivalent(baseUrl.hostname)
+  );
+}
+
+function isLocalhostEquivalent(hostname: string) {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
 }

--- a/apps/os/src/domains/inbound-mcp-server/mcp-url-routing.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-url-routing.ts
@@ -1,0 +1,47 @@
+import { resolveMcpBaseUrl } from "~/lib/mcp-base-url.ts";
+
+export function matchMcpRequestUrl(input: {
+  appBaseUrl?: string;
+  mcpBaseUrl?: string;
+  requestUrl: string;
+}) {
+  const mcpBaseUrl = resolveMcpBaseUrl({
+    appBaseUrl: input.appBaseUrl,
+    mcpBaseUrl: input.mcpBaseUrl,
+    requestUrl: input.requestUrl,
+  });
+  if (!mcpBaseUrl) return null;
+
+  const requestUrl = new URL(input.requestUrl);
+  const baseUrl = normalizeMcpBaseUrl(mcpBaseUrl);
+  if (requestUrl.origin !== baseUrl.origin) return null;
+
+  const basePathname = stripTrailingSlash(baseUrl.pathname);
+  const requestPathname = stripTrailingSlash(requestUrl.pathname);
+  const isRootMount = basePathname === "";
+  const matchesBasePath =
+    isRootMount ||
+    requestPathname === basePathname ||
+    requestUrl.pathname.startsWith(`${basePathname}/`);
+  if (!matchesBasePath) return null;
+
+  const relativePathname = isRootMount
+    ? requestUrl.pathname
+    : requestUrl.pathname.slice(basePathname.length) || "/";
+
+  return {
+    relativePathname: relativePathname.startsWith("/") ? relativePathname : `/${relativePathname}`,
+  };
+}
+
+export function normalizeMcpBaseUrl(rawUrl: string) {
+  const url = new URL(rawUrl);
+  url.search = "";
+  url.hash = "";
+  url.pathname = stripTrailingSlash(url.pathname) || "/";
+  return url;
+}
+
+export function stripTrailingSlash(pathname: string) {
+  return pathname.replace(/\/+$/, "");
+}

--- a/apps/os/src/lib/mcp-base-url.ts
+++ b/apps/os/src/lib/mcp-base-url.ts
@@ -1,0 +1,37 @@
+const localDevelopmentMcpPath = "/api/__mcp";
+
+export function resolveMcpBaseUrl(input: {
+  appBaseUrl?: string;
+  mcpBaseUrl?: string;
+  requestUrl?: string;
+}) {
+  const explicitMcpBaseUrl = input.mcpBaseUrl?.trim();
+  if (explicitMcpBaseUrl) return normalizeUrlWithoutSearchOrHash(explicitMcpBaseUrl);
+
+  const localBaseUrl = input.appBaseUrl?.trim() || input.requestUrl?.trim();
+  if (!localBaseUrl) return null;
+
+  const parsed = new URL(localBaseUrl);
+  if (!isLocalhostHostname(parsed.hostname)) return null;
+
+  return normalizeUrlWithoutSearchOrHash(
+    new URL(localDevelopmentMcpPath, parsed.origin).toString(),
+  );
+}
+
+export function normalizeUrlWithoutSearchOrHash(value: string) {
+  const url = new URL(value);
+  url.search = "";
+  url.hash = "";
+  url.pathname = url.pathname.replace(/\/+$/, "") || "/";
+  return url.toString().replace(/\/$/, "");
+}
+
+function isLocalhostHostname(hostname: string) {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname === "[::1]"
+  );
+}

--- a/apps/os/src/lib/project-host-routing.test.ts
+++ b/apps/os/src/lib/project-host-routing.test.ts
@@ -64,24 +64,44 @@ describe("project host routing", () => {
     expect(isReservedProjectHostname("alpha.example.com", ["os.iterate.com"])).toBe(false);
   });
 
-  it("builds the canonical MCP URL from the OS base URL", () => {
+  it("builds the canonical MCP URL from the MCP base URL", () => {
     expect(
       buildProjectMcpUrl({
-        baseUrl: "https://os.iterate.com",
+        mcpBaseUrl: "https://mcp.iterate.com",
         projectSlug: "demo",
         projectHostnameBases: ["iterate.app"],
       }),
-    ).toBe("https://os.iterate.com/mcp");
+    ).toBe("https://mcp.iterate.com");
     expect(
       buildProjectMcpUrl({
-        baseUrl: "https://os.iterate-preview-3.com",
+        mcpBaseUrl: "https://mcp.iterate-preview-3.com",
         projectSlug: "demo",
         projectHostnameBases: ["*.iterate-preview-3.app"],
       }),
-    ).toBe("https://os.iterate-preview-3.com/mcp");
+    ).toBe("https://mcp.iterate-preview-3.com");
   });
 
-  it("does not invent MCP URLs without an OS base URL", () => {
+  it("preserves path-mounted MCP base URLs", () => {
+    expect(
+      buildProjectMcpUrl({
+        mcpBaseUrl: "http://localhost:5176/api/__mcp/",
+        projectSlug: "demo",
+        projectHostnameBases: ["iterate.localhost"],
+      }),
+    ).toBe("http://localhost:5176/api/__mcp");
+  });
+
+  it("defaults localhost deployments to the local MCP path", () => {
+    expect(
+      buildProjectMcpUrl({
+        baseUrl: "http://localhost:5176",
+        projectSlug: "demo",
+        projectHostnameBases: ["iterate.localhost"],
+      }),
+    ).toBe("http://localhost:5176/api/__mcp");
+  });
+
+  it("does not invent MCP URLs without an MCP base URL", () => {
     expect(buildProjectMcpUrl({ projectSlug: "demo", projectHostnameBases: [] })).toBeNull();
   });
 });

--- a/apps/os/src/lib/project-host-routing.ts
+++ b/apps/os/src/lib/project-host-routing.ts
@@ -1,3 +1,5 @@
+import { resolveMcpBaseUrl } from "~/lib/mcp-base-url.ts";
+
 const projectSlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const hostnamePattern =
   /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
@@ -52,14 +54,17 @@ export function resolveProjectSlugFromHostname(
 
 export function buildProjectMcpUrl(input: {
   baseUrl?: string;
+  mcpBaseUrl?: string;
   projectSlug: string;
   projectHostnameBases: readonly string[];
 }) {
-  const baseUrl = input.baseUrl?.trim();
-  if (!baseUrl) return null;
-
   try {
-    return new URL("/mcp", baseUrl).toString();
+    return (
+      resolveMcpBaseUrl({
+        appBaseUrl: input.baseUrl,
+        mcpBaseUrl: input.mcpBaseUrl,
+      }) ?? null
+    );
   } catch {
     return null;
   }

--- a/apps/os/src/routes/_app/projects/$projectSlug/mcp.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/mcp.tsx
@@ -45,6 +45,7 @@ function ProjectMcpPage() {
   });
   const mcpUrl = buildProjectMcpUrl({
     baseUrl: config.baseUrl,
+    mcpBaseUrl: config.mcp?.baseUrl,
     projectSlug: project.slug,
     projectHostnameBases: config.projectHostnameBases,
   });
@@ -55,7 +56,7 @@ function ProjectMcpPage() {
       <section className="max-w-md space-y-3 p-4">
         <h2 className="text-sm font-semibold">MCP</h2>
         <p className="text-sm text-muted-foreground">
-          This deployment does not have a project hostname base configured.
+          This deployment does not have an MCP base URL configured.
         </p>
       </section>
     );
@@ -63,8 +64,8 @@ function ProjectMcpPage() {
 
   const claudeCommand = `claude mcp add --transport http ${project.slug} ${mcpUrl}`;
   const cliBaseHostFlag =
-    config.baseUrl && config.baseUrl !== "https://os.iterate.com"
-      ? ` --base-host ${config.baseUrl}`
+    config.mcp?.baseUrl && config.mcp.baseUrl !== "https://mcp.iterate.com"
+      ? ` --base-host ${config.mcp.baseUrl}`
       : "";
   const cliCommand = `cd apps/os && pnpm cli claude-mcp${cliBaseHostFlag}`;
   const cliCommandHint =

--- a/apps/os/tasks/workspace-codemode-implementation-log.md
+++ b/apps/os/tasks/workspace-codemode-implementation-log.md
@@ -122,7 +122,7 @@ inbound MCP provider stack already loaded.
 Real MCP codemode proof:
 
 ```sh
-OS_E2E_MCP_URL=https://mcp__workspace-mcp-proof-3dbbcbf7.iterate-preview-2.app/ \
+OS_E2E_MCP_URL=https://mcp.iterate-preview-2.com/ \
   pnpm --dir apps/os exec tsx /tmp/os-workspace-mcp-proof.ts
 ```
 

--- a/docs/adr/0001-replace-clerk-with-auth-worker.md
+++ b/docs/adr/0001-replace-clerk-with-auth-worker.md
@@ -27,9 +27,10 @@ not just MCP.
    and hands them in so it can derive Durable Object names and infrastructure from the ID
    before the auth record exists. The auth app stores the ID opaquely.
 
-3. **Single MCP endpoint at `os.iterate.com/mcp`.** Per-project MCP hostnames
-   (`mcp__<slug>.iterate.app`) are removed. The `.well-known/oauth-protected-resource`
-   metadata at `os.iterate.com` points to the auth worker.
+3. **Single MCP endpoint.** Per-project MCP hostnames (`mcp__<slug>.iterate.app`)
+   are removed. This ADR originally placed the endpoint at `os.iterate.com/mcp`;
+   the canonical endpoint later moved to `mcp.iterate.com`. The
+   `.well-known/oauth-protected-resource` metadata points to the auth worker.
 
 4. **One auth middleware, one principal model.** A single middleware resolves any request
    (web cookie, MCP bearer, admin API secret) into a Principal (User or Admin). User

--- a/docs/devops-cloudflare-doppler-alchemy-setup.md
+++ b/docs/devops-cloudflare-doppler-alchemy-setup.md
@@ -128,12 +128,15 @@ OS dev configs usually mirror production with two hostnames:
 | Role               | Pattern                            | Example                      |
 | ------------------ | ---------------------------------- | ---------------------------- |
 | Dashboard          | `os.iterate-dev-<user>.com`        | `os.iterate-dev-jonas.com`   |
+| MCP server         | `mcp.iterate-dev-<user>.com`       | `mcp.iterate-dev-jonas.com`  |
 | Project subdomains | `<project>.iterate-dev-<user>.app` | `demo.iterate-dev-jonas.app` |
 
 When `APP_CONFIG_BASE_URL` points at a real hostname, Alchemy creates the
 Cloudflare Tunnel, DNS records, and local `cloudflared` process. If
 `APP_CONFIG_BASE_URL` is absent or localhost-oriented, Vite runs locally without
-a tunnel.
+a tunnel. For localhost-oriented dev, OS defaults MCP to `/api/__mcp` on the
+configured app base URL, such as `http://localhost:5176/api/__mcp`; `mcp.localhost`
+is not portable across local resolvers.
 
 ## Environment Configs
 
@@ -151,6 +154,8 @@ For OS, domain identity comes from App Config:
 
 - `APP_CONFIG_BASE_URL`: canonical dashboard URL, such as
   `https://os.iterate.com`.
+- `APP_CONFIG_MCP__BASE_URL`: canonical MCP server URL, such as
+  `https://mcp.iterate.com`.
 - `APP_CONFIG_PROJECT_HOSTNAME_BASES`: project host bases, such as
   `["iterate.app"]`.
 
@@ -174,8 +179,9 @@ Current preview slots are `preview_1` through `preview_9`. Each slot needs two
 Cloudflare zones in the dev/preview account:
 
 - `iterate-preview-N.com` for dashboard hosts such as
-  `os.iterate-preview-N.com`.
-- `iterate-preview-N.app` for project/MCP hosts such as
+  `os.iterate-preview-N.com` and MCP hosts such as
+  `mcp.iterate-preview-N.com`.
+- `iterate-preview-N.app` for project hosts such as
   `<project>.iterate-preview-N.app`.
 
 Use the repo preview CLI for PRs so Semaphore owns the lease:
@@ -288,6 +294,7 @@ OS routing has two layers:
 `apps/os/alchemy.run.ts` manages routes derived from App Config:
 
 - `APP_CONFIG_BASE_URL` -> dashboard host, such as `os.iterate.com`.
+- `APP_CONFIG_MCP__BASE_URL` -> MCP host, such as `mcp.iterate.com`.
 - `APP_CONFIG_PROJECT_HOSTNAME_BASES` -> project host base and wildcard, such
   as `iterate.app` and `*.iterate.app`.
 
@@ -301,6 +308,7 @@ Production manual routes on `iterate.com`:
 | ------------------- | ----------------- | -------------------------------------------- |
 | `iterate.com/*`     | `os-prd`          | Apex website served by the `iterate` project |
 | `*.iterate.com/*`   | `os-prd`          | Single-label project app subdomains          |
+| `mcp.iterate.com/*` | `os-prd`          | MCP server, Alchemy-managed                  |
 | `os.iterate.com/*`  | `os-prd`          | OS dashboard, Alchemy-managed                |
 | `www.iterate.com/*` | `iterate-website` | Marketing site                               |
 

--- a/docs/plan-replace-clerk-with-auth-worker.md
+++ b/docs/plan-replace-clerk-with-auth-worker.md
@@ -1,7 +1,9 @@
 # Plan: Replace Clerk with Auth Worker
 
 Replaces Clerk entirely in `apps/os` with the Iterate Auth Worker (`apps/auth`).
-Unifies MCP under a single `os.iterate.com/mcp` endpoint. Restructures URLs.
+Unifies MCP under a single endpoint. This historical plan originally used
+`os.iterate.com/mcp`; the canonical endpoint later moved to `mcp.iterate.com`
+without keeping the old route as public compatibility.
 
 See: [ADR: Replace Clerk with Auth Worker](adr/0001-replace-clerk-with-auth-worker.md)
 
@@ -31,10 +33,12 @@ See: [ADR: Replace Clerk with Auth Worker](adr/0001-replace-clerk-with-auth-work
                  |                            |
                  |  /projects/:slug  (UI)     |
                  |  /org/:slug       (org)    |
-                 |  /mcp             (MCP)    |
                  |  /api/orpc/*      (API)    |
                  |  /api/iterate-auth/* (OAuth|
                  |                   callback)|
+                 +---------------------------+
+                 |    mcp.iterate.com         |
+                 |    /              (MCP)    |
                  +---------------------------+
                               |
                     +---------+---------+
@@ -240,7 +244,8 @@ already exists — just unify it with the new principal model.
 
 ### Phase C: MCP endpoint migration
 
-Move MCP from per-project hostnames to `os.iterate.com/mcp`.
+Move MCP from per-project hostnames to a single endpoint. This phase used
+`os.iterate.com/mcp`; the canonical endpoint is now `mcp.iterate.com`.
 
 #### C1: Create `/mcp` route handler
 
@@ -260,7 +265,7 @@ Handles `GET`, `POST`, `DELETE`, `OPTIONS` at `/mcp`.
 
 ```json
 {
-  "resource": "https://os.iterate.com/mcp",
+  "resource": "https://mcp.iterate.com",
   "authorization_servers": ["https://auth.iterate.com/api/auth"],
   "scopes_supported": ["openid", "profile", "email", "offline_access", "project"],
   "bearer_methods_supported": ["header"]
@@ -286,7 +291,7 @@ fields. Fill from Principal instead.
 
 **Files:**
 
-- `apps/os/scripts/claude-mcp.ts` — update URL to `os.iterate.com/mcp`
+- `apps/os/scripts/claude-mcp.ts` — update URL to the canonical MCP endpoint
 - MCP settings page — update instructions and endpoint URL display
 
 ---
@@ -482,14 +487,14 @@ Phase F is last.
   targets, then writes the resulting web/MCP client credentials and OS URL
   config back to Doppler. It is intended to run through the production auth
   worker Doppler config so preview/dev OS can target `https://auth.iterate.com`.
-- Migrated inbound MCP to the OS `/mcp` resource. `entry.workerd.ts` now handles
+- Migrated inbound MCP to a single MCP resource. `entry.workerd.ts` now handles
   `/mcp` and `/.well-known/oauth-protected-resource/mcp`, verifies auth-worker
   bearer tokens against the MCP audience, and passes the token's project claims
   into `ProjectMcpServerConnection`. The MCP tool schema requires a `project`
   argument only when the token grants multiple projects.
 - Removed per-project MCP host registration and replaced the old Clerk-based
   project MCP entrypoint with a tombstone response. The CLI and UI now point to
-  the OS base URL `/mcp`; the CLI keeps its admin-token preflight by adding a
+  the canonical MCP endpoint; the CLI keeps its admin-token preflight by adding a
   `?project=<slug-or-id>` selector.
 - Removed OS's Clerk runtime config, Alchemy bindings, dependencies,
   `sync-clerk-apps.ts`, and the last runtime Clerk API lookup. Remaining

--- a/packages/shared/src/alchemy/iterate-app.ts
+++ b/packages/shared/src/alchemy/iterate-app.ts
@@ -132,11 +132,12 @@ export async function IterateApp<B extends Bindings>(
   if (app.local && baseUrlHostname && !baseUrlHostname.startsWith("localhost") && worker.url) {
     tunnelVitePort = Number(new URL(worker.url).port || "5173");
 
-    // Wildcard hostnames from extraRouteHostnames (e.g. *.iterate.app)
-    const wildcardHosts = (props.extraRouteHostnames ?? []).filter((h) => h.startsWith("*."));
+    const tunnelExtraHosts = (props.extraRouteHostnames ?? []).filter(
+      (hostname) => hostname !== baseUrlHostname,
+    );
 
     console.log(
-      `Creating dev tunnel: ${[baseUrlHostname, ...wildcardHosts].join(", ")} -> localhost:${tunnelVitePort}`,
+      `Creating dev tunnel: ${[baseUrlHostname, ...tunnelExtraHosts].join(", ")} -> localhost:${tunnelVitePort}`,
     );
 
     const tunnel = await Tunnel(`dev-tunnel-${app.stage}`, {
@@ -147,7 +148,7 @@ export async function IterateApp<B extends Bindings>(
       delete: false,
       ingress: [
         { hostname: baseUrlHostname, service: `http://localhost:${tunnelVitePort}` },
-        ...wildcardHosts.map((hostname) => ({
+        ...tunnelExtraHosts.map((hostname) => ({
           hostname,
           service: `http://localhost:${tunnelVitePort}`,
         })),
@@ -158,16 +159,18 @@ export async function IterateApp<B extends Bindings>(
 
     const cloudflareApi = await createCloudflareApi({});
     await Promise.all(
-      wildcardHosts.map(async (hostname) => {
-        const { zoneId } = await findActiveZoneForHostname(cloudflareApi, hostname);
-        await ensureDevTunnelWildcardDnsRecord({
-          cloudflareApi,
-          zoneId,
-          name: hostname,
-          target: `${tunnel.tunnelId}.cfargotunnel.com`,
-          comment: `Managed by ${manifest.slug} dev tunnel (${app.stage}).`,
-        });
-      }),
+      tunnelExtraHosts
+        .filter((hostname) => hostname.startsWith("*."))
+        .map(async (hostname) => {
+          const { zoneId } = await findActiveZoneForHostname(cloudflareApi, hostname);
+          await ensureDevTunnelWildcardDnsRecord({
+            cloudflareApi,
+            zoneId,
+            name: hostname,
+            target: `${tunnel.tunnelId}.cfargotunnel.com`,
+            comment: `Managed by ${manifest.slug} dev tunnel (${app.stage}).`,
+          });
+        }),
     );
 
     tunnelToken = tunnel.token.unencrypted;


### PR DESCRIPTION
## Summary

- move OS inbound MCP to an explicit `APP_CONFIG_MCP__BASE_URL` canonical URL
- route MCP requests by configured URL prefix, with no public `APP_CONFIG_BASE_URL + /mcp` fallback
- default localhost-only MCP to `<APP_CONFIG_BASE_URL>/api/__mcp`
- add the MCP hostname to OS Alchemy routes and local tunnel ingress
- update CLI, UI, auth resource config, e2e helpers, sync-auth-clients, and docs

## Validation

- `pnpm --dir apps/os test`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --dir packages/shared exec vitest run src/alchemy/iterate-app.test.ts`
- `git diff --check`

## Notes

This PR does not mutate live Doppler secrets. Deployed configs need `APP_CONFIG_MCP__BASE_URL` set separately, for example `https://mcp.iterate.com` in production and `https://mcp.iterate-dev-jonas.com` for Jonas dev tunnel config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking URL and OAuth resource changes across auth, ingress, and Cloudflare routes; deployed environments need `APP_CONFIG_MCP__BASE_URL` set or MCP clients will fail.
> 
> **Overview**
> Moves inbound OS MCP off the dashboard path (`os.iterate.com/mcp`) and per-project `mcp__<slug>.*` hostnames onto an explicit **`APP_CONFIG_MCP__BASE_URL`** (e.g. `https://mcp.iterate.com`), with **`APP_CONFIG_BASE_URL`** staying the dashboard only.
> 
> **Routing and handler:** Requests match the configured MCP URL prefix via new `resolveMcpBaseUrl` / `matchMcpRequestUrl`; localhost-only dev defaults to `<app base>/api/__mcp` with no public `baseUrl + /mcp` fallback. `handleMcpFetch` serves OAuth metadata and the MCP root on that prefix and rewrites to an internal `McpAgent` path; legacy project MCP entrypoints return **410**.
> 
> **Deploy and auth:** Alchemy adds the MCP hostname to Worker routes; dev tunnel ingress treats the dashboard host separately from extra route hostnames. App config gains `mcp.baseUrl`; Iterate Auth registers both dashboard and MCP OAuth resources. `sync-auth-clients` writes `APP_CONFIG_MCP__BASE_URL` per target (including `preview_1`).
> 
> **Call sites:** Sidebar, project MCP page, `claude-mcp`, e2e helpers, and docs now point at the shared canonical endpoint instead of deriving URLs from the OS base or project slug.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd408094a0de20009373cca3d0323a07f976bdcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "example": {
      "appDisplayName": "Example",
      "appSlug": "example",
      "status": "released",
      "updatedAt": "2026-06-08T11:23:00.408Z",
      "headSha": "cd408094a0de20009373cca3d0323a07f976bdcf",
      "message": "Preview app released.",
      "publicUrl": "https://example.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27133054589",
      "shortSha": "cd40809"
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-08T11:23:04.899Z",
      "headSha": "cd408094a0de20009373cca3d0323a07f976bdcf",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27133054589",
      "shortSha": "cd40809"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-06-08T11:23:00.587Z",
      "headSha": "cd408094a0de20009373cca3d0323a07f976bdcf",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27133054589",
      "shortSha": "cd40809"
    },
    "events": {
      "appDisplayName": "Events",
      "appSlug": "events",
      "status": "released",
      "updatedAt": "2026-06-08T11:22:48.869Z",
      "headSha": "cd408094a0de20009373cca3d0323a07f976bdcf",
      "message": "Preview app released.",
      "publicUrl": "https://events.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27133054589",
      "shortSha": "cd40809"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Events
Status: released
Commit: `cd40809`
Preview: https://events.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27133054589)
Updated: 2026-06-08T11:22:48.869Z

### Example
Status: released
Commit: `cd40809`
Preview: https://example.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27133054589)
Updated: 2026-06-08T11:23:00.408Z

### OS
Status: released
Commit: `cd40809`
Preview: https://os.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27133054589)
Updated: 2026-06-08T11:23:04.899Z

### Semaphore
Status: released
Commit: `cd40809`
Preview: https://semaphore.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27133054589)
Updated: 2026-06-08T11:23:00.587Z
<!-- /CLOUDFLARE_PREVIEW -->