### PR TITLE
[codex] add hibernatable capnweb bridge

### DIFF
--- a/packages/hibernatable-capnweb/package.json
+++ b/packages/hibernatable-capnweb/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "hibernatable-capnweb",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./adapters": "./src/adapters.ts",
+    "./client": "./src/client.ts",
+    "./host": "./src/host.ts",
+    "./protocol": "./src/protocol.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "prove:miniflare": "tsx ./src/e2e/run-miniflare-proof.ts",
+    "prove:url": "tsx ./src/e2e/prove.ts",
+    "deploy:proof": "wrangler deploy --config ./src/e2e/wrangler.proof.jsonc",
+    "delete:proof": "wrangler delete --config ./src/e2e/wrangler.proof.jsonc --force"
+  },
+  "dependencies": {
+    "capnweb": "^0.8.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "catalog:cloudflare",
+    "@types/node": "^25.0.10",
+    "get-port": "^7.1.1",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3",
+    "wrangler": "catalog:cloudflare"
+  }
+}

--- a/packages/hibernatable-capnweb/src/adapters.ts
+++ b/packages/hibernatable-capnweb/src/adapters.ts
@@ -1,0 +1,45 @@
+export interface WebSocketLike {
+  readonly readyState: number;
+  send(data: string | ArrayBufferLike): void;
+  close(code?: number, reason?: string): void;
+  addEventListener(type: "open" | "close", cb: () => void, options?: unknown): void;
+  addEventListener(type: "error", cb: (event?: unknown) => void, options?: unknown): void;
+  addEventListener(
+    type: "message",
+    cb: (event: { data: unknown }) => void,
+    options?: unknown,
+  ): void;
+}
+
+export type SocketOpener = (url: string) => WebSocketLike | Promise<WebSocketLike>;
+
+export const globalWebSocket: SocketOpener = (url) => {
+  const WebSocketCtor = (globalThis as { WebSocket?: new (url: string) => WebSocketLike })
+    .WebSocket;
+  if (!WebSocketCtor) {
+    throw new Error("[capnweb] no global WebSocket; pass `open: fromWs(WS)`");
+  }
+  return new WebSocketCtor(url);
+};
+
+export const fromWs =
+  (WebSocketCtor: new (url: string) => WebSocketLike): SocketOpener =>
+  (url) =>
+    new WebSocketCtor(url);
+
+export const workersFetchWith =
+  (fetcher: typeof fetch): SocketOpener =>
+  async (url) => {
+    const response = await fetcher(url.replace(/^ws/i, "http"), {
+      headers: { Upgrade: "websocket" },
+    });
+    const webSocket = (response as unknown as { webSocket?: WebSocketLike & { accept(): void } })
+      .webSocket;
+    if (!webSocket) {
+      throw new Error(`[capnweb] no websocket upgrade from ${url} (${response.status})`);
+    }
+    webSocket.accept();
+    return webSocket;
+  };
+
+export const workersFetch = workersFetchWith(fetch);

--- a/packages/hibernatable-capnweb/src/client.ts
+++ b/packages/hibernatable-capnweb/src/client.ts
@@ -1,0 +1,189 @@
+import { newWebSocketRpcSession, type RpcStub, type RpcTarget } from "capnweb";
+import { globalWebSocket, type SocketOpener, type WebSocketLike } from "./adapters.ts";
+import * as P from "./protocol.ts";
+import { disposeStub, dupStub } from "./stub.ts";
+
+const WEB_SOCKET_OPEN = 1;
+
+export interface HibernatableCapnwebClientOptions<Local extends RpcTarget = RpcTarget> {
+  path?: string;
+  main: () => Local;
+  id?: string;
+  meta?: Record<string, unknown>;
+  open?: SocketOpener;
+  idleMs?: number;
+  heartbeatMs?: number;
+  reconnectBaseMs?: number;
+}
+
+export class HibernatableCapnwebClient<
+  Remote extends RpcTarget = RpcTarget,
+  Local extends RpcTarget = RpcTarget,
+> {
+  #control: WebSocketLike | undefined;
+  #rpc: WebSocketLike | undefined;
+  #remote: RpcStub<Remote> | undefined;
+  #connecting: Promise<RpcStub<Remote>> | undefined;
+  #idle: ReturnType<typeof setTimeout> | undefined;
+  #heartbeat: ReturnType<typeof setInterval> | undefined;
+  #backoff: number;
+  #stopped = false;
+
+  readonly #id: string;
+  readonly #controlUrl: string;
+  readonly #rpcUrl: string;
+  readonly #open: SocketOpener;
+  readonly #main: () => Local;
+  readonly #idleMs: number;
+  readonly #heartbeatMs: number;
+
+  constructor(baseUrl: string, opts: HibernatableCapnwebClientOptions<Local>) {
+    this.#open = opts.open ?? globalWebSocket;
+    this.#main = opts.main;
+    this.#id = opts.id ?? crypto.randomUUID();
+    this.#idleMs = opts.idleMs ?? 30_000;
+    this.#heartbeatMs = opts.heartbeatMs ?? 30_000;
+    this.#backoff = opts.reconnectBaseMs ?? 1_000;
+
+    const path = opts.path ?? P.DEFAULT_PATH;
+    const base = baseUrl.replace(/\/+$/, "");
+    const id = encodeURIComponent(this.#id);
+    const meta = opts.meta ? `&m=${encodeURIComponent(JSON.stringify(opts.meta))}` : "";
+    this.#controlUrl = `${base}${P.controlPath(path)}?i=${id}${meta}`;
+    this.#rpcUrl = `${base}${path}?i=${id}`;
+  }
+
+  get id() {
+    return this.#id;
+  }
+
+  get connected() {
+    return this.#remote !== undefined;
+  }
+
+  start(): void {
+    this.#stopped = false;
+    void this.#connectControl();
+  }
+
+  stop(): void {
+    this.#stopped = true;
+    this.#clearHeartbeat();
+    if (this.#idle) clearTimeout(this.#idle);
+    try {
+      this.#rpc?.close(1000, "stop");
+    } catch {}
+    try {
+      this.#control?.close(1000, "stop");
+    } catch {}
+    this.#dropRpc();
+  }
+
+  async connect(): Promise<RpcStub<Remote>> {
+    const remote = await this.#ensureRpc();
+    this.#bumpIdle();
+    return dupStub(remote);
+  }
+
+  async #connectControl(): Promise<void> {
+    if (this.#stopped) return;
+    let webSocket: WebSocketLike;
+    try {
+      webSocket = await this.#open(this.#controlUrl);
+    } catch {
+      this.#reconnect();
+      return;
+    }
+    this.#control = webSocket;
+
+    const onOpen = () => {
+      this.#backoff = 1_000;
+      this.#clearHeartbeat();
+      if (this.#heartbeatMs <= 0) return;
+      this.#heartbeat = setInterval(() => {
+        try {
+          if (webSocket.readyState === WEB_SOCKET_OPEN) webSocket.send(P.PING);
+        } catch {}
+      }, this.#heartbeatMs);
+    };
+    if (webSocket.readyState === WEB_SOCKET_OPEN) onOpen();
+    else webSocket.addEventListener("open", onOpen, { once: true });
+
+    webSocket.addEventListener("message", (event) => {
+      const data = typeof event.data === "string" ? event.data : "";
+      if (P.readSignal(data) === this.#id) void this.#ensureRpc().catch(() => {});
+    });
+    webSocket.addEventListener("close", () => {
+      this.#clearHeartbeat();
+      this.#reconnect();
+    });
+    webSocket.addEventListener("error", () => {
+      try {
+        webSocket.close();
+      } catch {}
+    });
+  }
+
+  #reconnect(): void {
+    if (this.#stopped) return;
+    setTimeout(() => void this.#connectControl(), this.#backoff);
+    this.#backoff = Math.min(this.#backoff * 2, 30_000);
+  }
+
+  #ensureRpc(): Promise<RpcStub<Remote>> {
+    if (this.#remote) return Promise.resolve(this.#remote);
+    if (this.#connecting) return this.#connecting;
+
+    this.#connecting = (async () => {
+      const webSocket = await this.#open(this.#rpcUrl);
+      this.#rpc = webSocket;
+      const remote = newWebSocketRpcSession<Remote>(
+        webSocket as unknown as WebSocket,
+        this.#main() as RpcTarget,
+      );
+      webSocket.addEventListener("message", () => this.#bumpIdle());
+      webSocket.addEventListener("close", () => this.#dropRpc());
+      webSocket.addEventListener("error", () => {
+        try {
+          webSocket.close();
+        } catch {}
+      });
+      this.#remote = remote;
+      this.#connecting = undefined;
+      this.#bumpIdle();
+      return remote;
+    })().catch((error) => {
+      this.#connecting = undefined;
+      throw error;
+    });
+
+    return this.#connecting;
+  }
+
+  #bumpIdle(): void {
+    if (this.#idleMs <= 0) return;
+    if (this.#idle) clearTimeout(this.#idle);
+    this.#idle = setTimeout(() => {
+      try {
+        this.#rpc?.close(1000, "idle");
+      } catch {}
+    }, this.#idleMs);
+  }
+
+  #dropRpc(): void {
+    if (this.#idle) {
+      clearTimeout(this.#idle);
+      this.#idle = undefined;
+    }
+    disposeStub(this.#remote);
+    this.#remote = undefined;
+    this.#rpc = undefined;
+    this.#connecting = undefined;
+  }
+
+  #clearHeartbeat(): void {
+    if (!this.#heartbeat) return;
+    clearInterval(this.#heartbeat);
+    this.#heartbeat = undefined;
+  }
+}

--- a/packages/hibernatable-capnweb/src/e2e/proof-protocol.ts
+++ b/packages/hibernatable-capnweb/src/e2e/proof-protocol.ts
@@ -1,0 +1,47 @@
+import type { RpcTarget } from "capnweb";
+
+export type PeerRecordArgs = {
+  message: string;
+  callerInstanceId: string;
+};
+
+export type PeerRecordResult = {
+  runtime: string;
+  message: string;
+  callerInstanceId: string;
+  receivedCount: number;
+};
+
+export interface ProofPeerApi extends RpcTarget {
+  record(args: PeerRecordArgs): PeerRecordResult | Promise<PeerRecordResult>;
+}
+
+export interface ProofHostApi extends RpcTarget {
+  echo(args: { message: string }):
+    | { message: string; instanceId: string }
+    | Promise<{
+        message: string;
+        instanceId: string;
+      }>;
+  callPeerFromSession(args: { message: string }): PeerRecordResult | Promise<PeerRecordResult>;
+}
+
+export type ProofStatus = {
+  instanceId: string;
+  constructorCount: number;
+  fetchCount: number;
+  webSocketMessageCount: number;
+  webSocketCloseCount: number;
+  connections: Array<{
+    id: string;
+    meta: unknown;
+    live: boolean;
+    autoResponseTimestamp: string | null;
+  }>;
+};
+
+export type CallPeerProof = {
+  before: ProofStatus;
+  result: PeerRecordResult;
+  after: ProofStatus;
+};

--- a/packages/hibernatable-capnweb/src/e2e/prove.ts
+++ b/packages/hibernatable-capnweb/src/e2e/prove.ts
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import { RpcTarget } from "capnweb";
+import { HibernatableCapnwebClient } from "../index.ts";
+import type {
+  PeerRecordArgs,
+  PeerRecordResult,
+  ProofHostApi,
+  ProofPeerApi,
+  ProofStatus,
+} from "./proof-protocol.ts";
+
+const baseHttpUrl = (process.env.HIBERNATABLE_CAPNWEB_PROOF_BASE_URL ?? process.argv[2])?.replace(
+  /\/+$/,
+  "",
+);
+
+if (!baseHttpUrl) {
+  throw new Error(
+    "Set HIBERNATABLE_CAPNWEB_PROOF_BASE_URL or pass the proof Worker URL as argv[2]",
+  );
+}
+
+const baseWsUrl = baseHttpUrl.replace(/^http/i, "ws");
+const hibernateWaitMs = Number(process.env.HIBERNATABLE_CAPNWEB_HIBERNATE_WAIT_MS ?? 12_000);
+const heartbeatMs = Number(process.env.HIBERNATABLE_CAPNWEB_HEARTBEAT_MS ?? 250);
+const requireHibernation = process.env.HIBERNATABLE_CAPNWEB_REQUIRE_HIBERNATION !== "false";
+
+class NodePeerTarget extends RpcTarget implements ProofPeerApi {
+  readonly received: PeerRecordResult[] = [];
+
+  record(args: PeerRecordArgs): PeerRecordResult {
+    const result = {
+      runtime: "node",
+      message: args.message,
+      callerInstanceId: args.callerInstanceId,
+      receivedCount: this.received.length + 1,
+    };
+    this.received.push(result);
+    return result;
+  }
+}
+
+const nodePeer = new NodePeerTarget();
+const nodeId = `node-${crypto.randomUUID()}`;
+const nodeClient = new HibernatableCapnwebClient<ProofHostApi, ProofPeerApi>(baseWsUrl, {
+  id: nodeId,
+  main: () => nodePeer,
+  meta: { runtime: "node" },
+  idleMs: 250,
+  heartbeatMs,
+});
+
+const proof: Record<string, unknown> = {};
+
+try {
+  nodeClient.start();
+
+  const connected = await waitForConnection(nodeId);
+  assert.equal(
+    connected.meta && typeof connected.meta === "object" && "runtime" in connected.meta
+      ? connected.meta.runtime
+      : undefined,
+    "node",
+  );
+  proof.nodeControlListed = connected;
+
+  if (heartbeatMs > 0) {
+    const statusBeforePing = await status();
+    await sleep(Math.max(600, heartbeatMs * 2));
+    const statusAfterPing = await status();
+    const nodeAfterPing = requiredConnection(statusAfterPing, nodeId);
+    assert.equal(statusAfterPing.webSocketMessageCount, statusBeforePing.webSocketMessageCount);
+    assert.ok(
+      nodeAfterPing.autoResponseTimestamp,
+      "expected edge auto-response timestamp after heartbeat",
+    );
+    proof.heartbeatAutoResponse = {
+      messageCountBefore: statusBeforePing.webSocketMessageCount,
+      messageCountAfter: statusAfterPing.webSocketMessageCount,
+      autoResponseTimestamp: nodeAfterPing.autoResponseTimestamp,
+    };
+  } else {
+    proof.heartbeatAutoResponse = "skipped; heartbeat disabled for production hibernation timing";
+  }
+
+  const host = await nodeClient.connect();
+  const echo = await host.echo({ message: "node -> host" });
+  assert.equal(echo.message, "node -> host");
+  proof.nodeToHostRpc = echo;
+
+  const beforeHibernate = await waitForConnectionLive(nodeId, false);
+  await sleep(hibernateWaitMs);
+  const afterHibernate = await status();
+  const observedHibernation =
+    afterHibernate.instanceId !== beforeHibernate.instanceId &&
+    afterHibernate.constructorCount > beforeHibernate.constructorCount;
+  if (requireHibernation) assert.ok(observedHibernation, "expected DO instance eviction");
+  assert.equal(requiredConnection(afterHibernate, nodeId).live, false);
+  proof.hibernateWake = {
+    observedHibernation,
+    waitMs: hibernateWaitMs,
+    before: pickStatus(beforeHibernate),
+    after: pickStatus(afterHibernate),
+  };
+
+  const hostCall = await fetchJson<{
+    before: ProofStatus;
+    result: PeerRecordResult;
+    after: ProofStatus;
+  }>(
+    `/__proof/call-peer?id=${encodeURIComponent(nodeId)}&message=${encodeURIComponent("host -> node after wake")}`,
+  );
+  assert.equal(hostCall.before.instanceId, afterHibernate.instanceId);
+  assert.equal(hostCall.result.runtime, "node");
+  assert.equal(hostCall.result.message, "host -> node after wake");
+  assert.equal(hostCall.result.callerInstanceId, afterHibernate.instanceId);
+  assert.equal(nodePeer.received.length, 1);
+  assert.equal(requiredConnection(hostCall.before, nodeId).live, false);
+  assert.equal(requiredConnection(hostCall.after, nodeId).live, true);
+  proof.hostToNodeAfterWake = hostCall;
+
+  await sleep(500);
+  const afterIdle = await status();
+  assert.equal(requiredConnection(afterIdle, nodeId).live, false);
+  proof.rpcIdleTeardown = pickStatus(afterIdle);
+
+  const statelessWorker = await fetchJson<{
+    id: string;
+    echo: { message: string; instanceId: string };
+    callback: PeerRecordResult;
+  }>("/stateless-worker-proof");
+  assert.equal(statelessWorker.echo.message, "stateless-worker -> host");
+  assert.equal(statelessWorker.callback.runtime, "stateless-worker");
+  assert.equal(statelessWorker.callback.message, "host -> stateless-worker");
+  proof.statelessWorkerClient = statelessWorker;
+
+  console.log(JSON.stringify({ ok: true, baseHttpUrl, nodeId, proof }, null, 2));
+} finally {
+  nodeClient.stop();
+}
+
+process.exit(0);
+
+async function waitForConnection(id: string) {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const current = await status();
+    const connection = current.connections.find((candidate) => candidate.id === id);
+    if (connection) return connection;
+    await sleep(50);
+  }
+  throw new Error(`timed out waiting for connection ${id}`);
+}
+
+async function waitForConnectionLive(id: string, live: boolean) {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const current = await status();
+    const connection = current.connections.find((candidate) => candidate.id === id);
+    if (connection?.live === live) return current;
+    await sleep(100);
+  }
+  throw new Error(`timed out waiting for ${id} live=${live}`);
+}
+
+async function status() {
+  return await fetchJson<ProofStatus>("/__proof/status");
+}
+
+async function fetchJson<T>(path: string): Promise<T> {
+  const response = await fetch(`${baseHttpUrl}${path}`);
+  if (!response.ok) {
+    throw new Error(`${path} failed: ${response.status} ${await response.text()}`);
+  }
+  return (await response.json()) as T;
+}
+
+function requiredConnection(status: ProofStatus, id: string) {
+  const connection = status.connections.find((candidate) => candidate.id === id);
+  assert.ok(connection, `expected ${id} in ${JSON.stringify(status.connections)}`);
+  return connection;
+}
+
+function pickStatus(value: ProofStatus) {
+  return {
+    instanceId: value.instanceId,
+    constructorCount: value.constructorCount,
+    webSocketMessageCount: value.webSocketMessageCount,
+    connections: value.connections,
+  };
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/hibernatable-capnweb/src/e2e/run-miniflare-proof.ts
+++ b/packages/hibernatable-capnweb/src/e2e/run-miniflare-proof.ts
@@ -1,0 +1,71 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { setTimeout as sleep } from "node:timers/promises";
+import getPort from "get-port";
+
+const port = await getPort({ port: 8976 });
+const baseUrl = `http://127.0.0.1:${port}`;
+const wrangler = spawn(
+  "pnpm",
+  [
+    "exec",
+    "wrangler",
+    "dev",
+    "--config",
+    "./src/e2e/wrangler.proof.jsonc",
+    "--ip",
+    "127.0.0.1",
+    "--port",
+    String(port),
+  ],
+  {
+    cwd: new URL("../../", import.meta.url),
+    env: { ...process.env, NO_COLOR: "1" },
+    stdio: ["ignore", "pipe", "pipe"],
+  },
+);
+const wranglerExit = once(wrangler, "exit").catch(() => undefined);
+
+let output = "";
+wrangler.stdout.setEncoding("utf8");
+wrangler.stderr.setEncoding("utf8");
+wrangler.stdout.on("data", (chunk) => {
+  output += chunk;
+  process.stdout.write(chunk);
+});
+wrangler.stderr.on("data", (chunk) => {
+  output += chunk;
+  process.stderr.write(chunk);
+});
+
+try {
+  await waitForReady();
+  const proof = spawn("pnpm", ["tsx", "./src/e2e/prove.ts", baseUrl], {
+    cwd: new URL("../../", import.meta.url),
+    env: {
+      ...process.env,
+      HIBERNATABLE_CAPNWEB_PROOF_BASE_URL: baseUrl,
+    },
+    stdio: "inherit",
+  });
+  const [code] = (await once(proof, "exit")) as [number | null, NodeJS.Signals | null];
+  if (code !== 0) throw new Error(`proof failed with exit code ${code}`);
+} finally {
+  wrangler.kill("SIGINT");
+  await wranglerExit;
+}
+
+async function waitForReady() {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseUrl}/__proof/status`);
+      if (response.ok) return;
+    } catch {}
+    if (output.includes("Failed") || output.includes("Error:")) {
+      throw new Error(`wrangler failed before becoming ready:\n${output}`);
+    }
+    await sleep(250);
+  }
+  throw new Error(`timed out waiting for wrangler dev:\n${output}`);
+}

--- a/packages/hibernatable-capnweb/src/e2e/worker.ts
+++ b/packages/hibernatable-capnweb/src/e2e/worker.ts
@@ -1,0 +1,427 @@
+/// <reference types="@cloudflare/workers-types" />
+
+import { RpcTarget } from "capnweb";
+import { DurableObject } from "cloudflare:workers";
+import { HibernatableCapnwebClient, HibernatableCapnwebHost, workersFetchWith } from "../index.ts";
+import type {
+  CallPeerProof,
+  PeerRecordArgs,
+  PeerRecordResult,
+  ProofHostApi,
+  ProofPeerApi,
+  ProofStatus,
+} from "./proof-protocol.ts";
+
+type Env = {
+  PROOF_DO: DurableObjectNamespace<ProofDurableObject>;
+};
+
+const PROOF_DO_NAME = "proof";
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === "OPTIONS") return cors(new Response(null, { status: 204 }));
+
+    const url = new URL(request.url);
+    if (url.pathname === "/stateless-worker-proof") {
+      return cors(json(await runStatelessWorkerProof(request, env)));
+    }
+
+    if (url.pathname === "/browser-proof") {
+      return html(browserProofHtml(url));
+    }
+
+    const id = env.PROOF_DO.idFromName(PROOF_DO_NAME);
+    return cors(await env.PROOF_DO.get(id).fetch(request));
+  },
+};
+
+export class ProofDurableObject extends DurableObject<Env> {
+  readonly #host: HibernatableCapnwebHost<ProofPeerApi, ProofHostApi>;
+  readonly #instanceId = crypto.randomUUID();
+  #constructorCount = 0;
+  #fetchCount = 0;
+  #webSocketMessageCount = 0;
+  #webSocketCloseCount = 0;
+
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    this.#host = new HibernatableCapnwebHost<ProofPeerApi, ProofHostApi>(ctx, {
+      idleMs: 250,
+      main: (_request, id) => new HostRpcTarget(this, id),
+    });
+    void ctx.blockConcurrencyWhile(async () => {
+      this.#constructorCount = ((await ctx.storage.get<number>("constructorCount")) ?? 0) + 1;
+      await ctx.storage.put("constructorCount", this.#constructorCount);
+    });
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    this.#fetchCount++;
+
+    const handled = this.#host.handle(request);
+    if (handled) return handled;
+
+    const url = new URL(request.url);
+    if (url.pathname === "/__proof/status") return json(this.#status());
+
+    if (url.pathname === "/__proof/call-peer") {
+      const id = requiredSearchParam(url, "id");
+      const message = requiredSearchParam(url, "message");
+      return json(await this.#callPeer(id, message));
+    }
+
+    return new Response("not found", { status: 404 });
+  }
+
+  webSocketMessage(webSocket: WebSocket, data: string | ArrayBuffer): void {
+    if (this.#host.message(webSocket, data)) {
+      this.#webSocketMessageCount++;
+      return;
+    }
+    webSocket.close(1008, "unknown socket");
+  }
+
+  webSocketClose(webSocket: WebSocket): void {
+    if (this.#host.closed(webSocket)) this.#webSocketCloseCount++;
+  }
+
+  webSocketError(webSocket: WebSocket): void {
+    if (this.#host.errored(webSocket)) this.#webSocketCloseCount++;
+  }
+
+  echo(message: string) {
+    return { message, instanceId: this.#instanceId };
+  }
+
+  async callPeerFromSession(id: string, message: string): Promise<PeerRecordResult> {
+    const connection = this.#host.connection(id);
+    if (!connection) throw new Error(`no control socket for ${id}`);
+    return await connection.withRemote((remote) =>
+      remote.record({ message, callerInstanceId: this.#instanceId }),
+    );
+  }
+
+  async #callPeer(id: string, message: string): Promise<CallPeerProof> {
+    const before = this.#status();
+    const result = await this.callPeerFromSession(id, message);
+    const after = this.#status();
+    return { before, result, after };
+  }
+
+  #status(): ProofStatus {
+    const controlsById = new Map(
+      this.ctx.getWebSockets("/capnweb-control").map((webSocket) => {
+        const attachment = webSocket.deserializeAttachment() as { i?: string } | null;
+        return [attachment?.i, webSocket] as const;
+      }),
+    );
+    return {
+      instanceId: this.#instanceId,
+      constructorCount: this.#constructorCount,
+      fetchCount: this.#fetchCount,
+      webSocketMessageCount: this.#webSocketMessageCount,
+      webSocketCloseCount: this.#webSocketCloseCount,
+      connections: this.#host.connections().map((connection) => {
+        const control = controlsById.get(connection.id);
+        const autoResponseTimestamp = control
+          ? (this.ctx.getWebSocketAutoResponseTimestamp(control)?.toISOString() ?? null)
+          : null;
+        return {
+          id: connection.id,
+          meta: connection.meta,
+          live: connection.live,
+          autoResponseTimestamp,
+        };
+      }),
+    };
+  }
+}
+
+class HostRpcTarget extends RpcTarget implements ProofHostApi {
+  constructor(
+    private readonly room: ProofDurableObject,
+    private readonly id: string,
+  ) {
+    super();
+  }
+
+  echo(args: { message: string }) {
+    return this.room.echo(args.message);
+  }
+
+  callPeerFromSession(args: { message: string }) {
+    return this.room.callPeerFromSession(this.id, args.message);
+  }
+}
+
+class StatelessWorkerPeerTarget extends RpcTarget implements ProofPeerApi {
+  #receivedCount = 0;
+
+  constructor(private readonly runtime: string) {
+    super();
+  }
+
+  record(args: PeerRecordArgs): PeerRecordResult {
+    this.#receivedCount++;
+    return {
+      runtime: this.runtime,
+      message: args.message,
+      callerInstanceId: args.callerInstanceId,
+      receivedCount: this.#receivedCount,
+    };
+  }
+}
+
+async function runStatelessWorkerProof(request: Request, env: Env) {
+  const url = new URL(request.url);
+  const id = `stateless-worker-${crypto.randomUUID()}`;
+  const baseUrl = `${url.protocol === "https:" ? "wss:" : "ws:"}//${url.host}`;
+  const proofObject = env.PROOF_DO.get(env.PROOF_DO.idFromName(PROOF_DO_NAME));
+  const client = new HibernatableCapnwebClient<ProofHostApi, ProofPeerApi>(baseUrl, {
+    id,
+    open: workersFetchWith((input, init) => proofObject.fetch(input, init)),
+    main: () => new StatelessWorkerPeerTarget("stateless-worker"),
+    meta: { runtime: "stateless-worker" },
+    idleMs: 0,
+    heartbeatMs: 1_000,
+  });
+
+  client.start();
+  try {
+    await waitForConnection(() => proofObject.fetch("https://proof.local/__proof/status"), id);
+    const host = await client.connect();
+    const echo = await host.echo({ message: "stateless-worker -> host" });
+    const callback = await host.callPeerFromSession({ message: "host -> stateless-worker" });
+    return { id, echo, callback };
+  } finally {
+    client.stop();
+  }
+}
+
+function browserProofHtml(url: URL) {
+  const base = `${url.protocol === "https:" ? "wss:" : "ws:"}//${url.host}`;
+  const hibernateWaitMs = Number(url.searchParams.get("wait") ?? 12_000);
+  const heartbeatMs = Number(url.searchParams.get("heartbeat") ?? 250);
+  const requireHibernation = url.searchParams.get("requireHibernation") !== "false";
+  return `<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>hibernatable-capnweb browser proof</title></head>
+  <body>
+    <pre id="out">running</pre>
+    <script type="module">
+      import { newWebSocketRpcSession, RpcTarget } from "https://esm.sh/capnweb@0.8.0";
+
+      const out = document.querySelector("#out");
+      const show = (value) => {
+        out.textContent = typeof value === "string" ? value : JSON.stringify(value, null, 2);
+      };
+
+      const PING = "ping";
+      const PONG = "pong";
+      const openSignalId = (data) => {
+        if (!data || data === PONG) return null;
+        try {
+          const message = JSON.parse(data);
+          return message?.capnweb === "open" ? message.id : null;
+        } catch {
+          return null;
+        }
+      };
+
+      class BrowserClient {
+        control;
+        rpc;
+        remote;
+        connecting;
+        heartbeat;
+        idle;
+
+        constructor(baseUrl, options) {
+          this.baseUrl = baseUrl.replace(/\\/+$/, "");
+          this.options = options;
+          this.id = options.id;
+          const meta = options.meta ? "&m=" + encodeURIComponent(JSON.stringify(options.meta)) : "";
+          this.controlUrl = this.baseUrl + "/capnweb-control?i=" + encodeURIComponent(this.id) + meta;
+          this.rpcUrl = this.baseUrl + "/capnweb?i=" + encodeURIComponent(this.id);
+        }
+
+        start() {
+          const ws = new WebSocket(this.controlUrl);
+          this.control = ws;
+          ws.addEventListener("open", () => {
+            this.heartbeat = setInterval(() => {
+              if (ws.readyState === 1) ws.send(PING);
+            }, this.options.heartbeatMs ?? 250);
+          });
+          ws.addEventListener("message", (event) => {
+            if (openSignalId(typeof event.data === "string" ? event.data : "") === this.id) {
+              this.ensureRpc().catch(() => {});
+            }
+          });
+        }
+
+        async connect() {
+          const remote = await this.ensureRpc();
+          this.bumpIdle();
+          return remote.dup?.() ?? remote;
+        }
+
+        ensureRpc() {
+          if (this.remote) return Promise.resolve(this.remote);
+          if (this.connecting) return this.connecting;
+          this.connecting = Promise.resolve().then(() => {
+            const ws = new WebSocket(this.rpcUrl);
+            this.rpc = ws;
+            const remote = newWebSocketRpcSession(ws, this.options.main());
+            ws.addEventListener("message", () => this.bumpIdle());
+            ws.addEventListener("close", () => this.dropRpc());
+            this.remote = remote;
+            this.connecting = undefined;
+            this.bumpIdle();
+            return remote;
+          }).catch((error) => {
+            this.connecting = undefined;
+            throw error;
+          });
+          return this.connecting;
+        }
+
+        bumpIdle() {
+          const idleMs = this.options.idleMs ?? 250;
+          if (idleMs <= 0) return;
+          clearTimeout(this.idle);
+          this.idle = setTimeout(() => this.rpc?.close(1000, "idle"), idleMs);
+        }
+
+        dropRpc() {
+          clearTimeout(this.idle);
+          this.remote?.[Symbol.dispose]?.();
+          this.remote = undefined;
+          this.rpc = undefined;
+          this.connecting = undefined;
+        }
+      }
+
+      class BrowserPeer extends RpcTarget {
+        count = 0;
+        record(args) {
+          this.count++;
+          return {
+            runtime: "browser",
+            message: args.message,
+            callerInstanceId: args.callerInstanceId,
+            receivedCount: this.count,
+          };
+        }
+      }
+
+      const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+      try {
+        const id = "browser-" + crypto.randomUUID();
+        const client = new BrowserClient(${JSON.stringify(base)}, {
+          id,
+          main: () => new BrowserPeer(),
+          meta: { runtime: "browser" },
+          idleMs: 250,
+          heartbeatMs: ${JSON.stringify(heartbeatMs)},
+        });
+        client.start();
+
+        show("waiting for control socket");
+        for (;;) {
+          const status = await fetch("/__proof/status").then((r) => r.json());
+          if (status.connections.some((connection) => connection.id === id)) break;
+          await sleep(50);
+        }
+
+        show("calling host from browser");
+        const host = await client.connect();
+        const echo = await host.echo({ message: "browser -> host" });
+
+        show("waiting for browser RPC burst to close");
+        let beforeHibernate;
+        for (;;) {
+          beforeHibernate = await fetch("/__proof/status").then((r) => r.json());
+          const connection = beforeHibernate.connections.find((candidate) => candidate.id === id);
+          if (connection && connection.live === false) break;
+          await sleep(100);
+        }
+
+        show("waiting for DO hibernation");
+        await sleep(${JSON.stringify(hibernateWaitMs)});
+        const afterHibernate = await fetch("/__proof/status").then((r) => r.json());
+
+        show("calling browser target after wake");
+        const call = await fetch("/__proof/call-peer?id=" + encodeURIComponent(id) + "&message=host%20-%3E%20browser").then((r) => r.json());
+        const observedHibernation =
+          beforeHibernate.instanceId !== afterHibernate.instanceId &&
+          afterHibernate.constructorCount > beforeHibernate.constructorCount;
+        const result = {
+          ok: call.result.runtime === "browser" &&
+            call.result.message === "host -> browser" &&
+            (${JSON.stringify(requireHibernation)} ? observedHibernation : true) &&
+            call.before.instanceId === afterHibernate.instanceId,
+          id,
+          observedHibernation,
+          waitMs: ${JSON.stringify(hibernateWaitMs)},
+          beforeHibernate,
+          afterHibernate,
+          call,
+          echo,
+        };
+        window.__HIBERNATABLE_CAPNWEB_BROWSER_PROOF__ = result;
+        show(result);
+      } catch (error) {
+        const result = { ok: false, error: String(error), stack: error?.stack ?? null };
+        window.__HIBERNATABLE_CAPNWEB_BROWSER_PROOF__ = result;
+        show(result);
+        throw error;
+      }
+    </script>
+  </body>
+</html>`;
+}
+
+async function waitForConnection(fetchStatus: () => Promise<Response>, id: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const status = (await fetchStatus().then((response) => response.json())) as ProofStatus;
+    if (status.connections.some((connection) => connection.id === id)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`timed out waiting for connection ${id}`);
+}
+
+function requiredSearchParam(url: URL, name: string): string {
+  const value = url.searchParams.get(name);
+  if (!value) throw new Error(`missing ${name}`);
+  return value;
+}
+
+function json(value: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(value, null, 2), {
+    ...init,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      ...init?.headers,
+    },
+  });
+}
+
+function html(value: string): Response {
+  return new Response(value, {
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+    },
+  });
+}
+
+function cors(response: Response): Response {
+  if (response.webSocket) return response;
+  const headers = new Headers(response.headers);
+  headers.set("access-control-allow-origin", "*");
+  headers.set("access-control-allow-methods", "GET,POST,OPTIONS");
+  headers.set("access-control-allow-headers", "content-type,upgrade");
+  return new Response(response.body, { ...response, headers });
+}

--- a/packages/hibernatable-capnweb/src/e2e/wrangler.proof.jsonc
+++ b/packages/hibernatable-capnweb/src/e2e/wrangler.proof.jsonc
@@ -1,0 +1,20 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "hibernatable-capnweb-proof",
+  "main": "./worker.ts",
+  "compatibility_date": "2026-04-01",
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "PROOF_DO",
+        "class_name": "ProofDurableObject",
+      },
+    ],
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["ProofDurableObject"],
+    },
+  ],
+}

--- a/packages/hibernatable-capnweb/src/host.ts
+++ b/packages/hibernatable-capnweb/src/host.ts
@@ -1,0 +1,258 @@
+/// <reference types="@cloudflare/workers-types" />
+
+import { newWebSocketRpcSession, type RpcStub, type RpcTarget } from "capnweb";
+import * as P from "./protocol.ts";
+import { disposeStub, dupStub } from "./stub.ts";
+
+export interface Connection<Remote extends RpcTarget = RpcTarget> {
+  readonly id: string;
+  readonly meta: unknown;
+  readonly live: boolean;
+  signal(): void;
+  withRemote<T>(fn: (remote: RpcStub<Remote>) => T | Promise<T>): Promise<T>;
+  close(): void;
+}
+
+export interface HibernatableCapnwebHostOptions<Local extends RpcTarget = RpcTarget> {
+  path?: string;
+  main?: (request: Request, id: string) => Local | null;
+  teardown?: "idle" | "immediate" | "peer";
+  idleMs?: number;
+  connectTimeoutMs?: number;
+}
+
+type Live<Remote extends RpcTarget> = {
+  remote: RpcStub<Remote>;
+  webSocket: WebSocket;
+  active: number;
+  idle: ReturnType<typeof setTimeout> | undefined;
+};
+
+type Pending<Remote extends RpcTarget> = {
+  promise: Promise<RpcStub<Remote>>;
+  resolve: (stub: RpcStub<Remote>) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+export class HibernatableCapnwebHost<
+  Remote extends RpcTarget = RpcTarget,
+  Local extends RpcTarget = RpcTarget,
+> {
+  readonly #live = new Map<string, Live<Remote>>();
+  readonly #pending = new Map<string, Pending<Remote>>();
+
+  readonly #path: string;
+  readonly #control: string;
+  readonly #tag: string;
+  readonly #main: (request: Request, id: string) => Local | null;
+  readonly #teardown: "idle" | "immediate" | "peer";
+  readonly #idleMs: number;
+  readonly #connectTimeoutMs: number;
+
+  constructor(
+    private readonly ctx: DurableObjectState,
+    opts: HibernatableCapnwebHostOptions<Local> = {},
+  ) {
+    this.#path = opts.path ?? P.DEFAULT_PATH;
+    this.#control = P.controlPath(this.#path);
+    this.#tag = P.controlTag(this.#path);
+    this.#main = opts.main ?? (() => null);
+    this.#teardown = opts.teardown ?? "idle";
+    this.#idleMs = opts.idleMs ?? 10_000;
+    this.#connectTimeoutMs = opts.connectTimeoutMs ?? 10_000;
+    this.ctx.setWebSocketAutoResponse(new WebSocketRequestResponsePair(P.PING, P.PONG));
+  }
+
+  handle(request: Request): Response | null {
+    const url = new URL(request.url);
+    if (url.pathname === this.#path) return this.#acceptRpc(request, url);
+    if (url.pathname === this.#control) return this.#acceptControl(url);
+    return null;
+  }
+
+  message(webSocket: WebSocket, _data?: string | ArrayBuffer): boolean {
+    return this.#owns(webSocket);
+  }
+
+  closed(webSocket: WebSocket): boolean {
+    if (!this.#owns(webSocket)) return false;
+    const id = (webSocket.deserializeAttachment() as { i?: string } | null)?.i;
+    if (id) this.#drop(id);
+    return true;
+  }
+
+  errored(webSocket: WebSocket): boolean {
+    return this.closed(webSocket);
+  }
+
+  connections(): Connection<Remote>[] {
+    return this.ctx
+      .getWebSockets(this.#tag)
+      .map((webSocket) => this.#wrap(webSocket))
+      .filter((connection): connection is Connection<Remote> => connection !== null);
+  }
+
+  connection(id: string): Connection<Remote> | undefined {
+    for (const webSocket of this.ctx.getWebSockets(this.#tag)) {
+      const attachment = webSocket.deserializeAttachment() as { i?: string } | null;
+      if (attachment?.i === id) return this.#wrap(webSocket) ?? undefined;
+    }
+    return undefined;
+  }
+
+  #acceptControl(url: URL): Response {
+    const id = url.searchParams.get("i") || crypto.randomUUID();
+    const meta = url.searchParams.get("m");
+    const { 0: client, 1: server } = new WebSocketPair();
+    this.ctx.acceptWebSocket(server, [this.#tag]);
+    server.serializeAttachment({ i: id, m: meta });
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  #acceptRpc(request: Request, url: URL): Response {
+    const id = url.searchParams.get("i");
+    if (!id) return new Response("missing connection id", { status: 400 });
+
+    const { 0: client, 1: server } = new WebSocketPair();
+    if (this.#live.has(id)) {
+      server.accept();
+      server.close(1000, "duplicate");
+      return new Response(null, { status: 101, webSocket: client });
+    }
+
+    server.accept();
+    const rawRemote = newWebSocketRpcSession(
+      server,
+      this.#main(request, id) as RpcTarget | null,
+    ) as RpcStub<Remote>;
+    const remote = dupStub(rawRemote);
+    const live: Live<Remote> = { remote, webSocket: server, active: 0, idle: undefined };
+    this.#live.set(id, live);
+
+    server.addEventListener("close", () => this.#drop(id));
+    server.addEventListener("error", () => this.#drop(id));
+
+    const pending = this.#pending.get(id);
+    if (pending) {
+      clearTimeout(pending.timer);
+      this.#pending.delete(id);
+      pending.resolve(remote);
+    }
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  #owns(webSocket: WebSocket): boolean {
+    return this.ctx.getTags(webSocket).includes(this.#tag);
+  }
+
+  #wrap(control: WebSocket): Connection<Remote> | null {
+    const attachment = control.deserializeAttachment() as { i?: string; m?: string | null } | null;
+    const id = attachment?.i;
+    if (!id) return null;
+    const host = this;
+
+    let meta: unknown = null;
+    try {
+      meta = attachment?.m ? JSON.parse(attachment.m) : null;
+    } catch {
+      meta = null;
+    }
+
+    return {
+      id,
+      meta,
+      get live() {
+        return host.#live.has(id);
+      },
+      signal() {
+        try {
+          control.send(P.openSignal(id));
+        } catch {}
+      },
+      withRemote: (fn) => this.#withRemote(id, control, fn),
+      close: () => {
+        this.#close(id, "closed");
+        try {
+          control.close(1000, "closed");
+        } catch {}
+      },
+    };
+  }
+
+  async #withRemote<T>(
+    id: string,
+    control: WebSocket,
+    fn: (remote: RpcStub<Remote>) => T | Promise<T>,
+  ): Promise<T> {
+    const remote = await this.#ensure(id, control);
+    const live = this.#live.get(id);
+    if (!live) throw new Error("[capnweb] RPC session disappeared before call");
+    live.active++;
+    if (live.idle) {
+      clearTimeout(live.idle);
+      live.idle = undefined;
+    }
+    try {
+      return await fn(remote);
+    } finally {
+      live.active--;
+      if (live.active === 0) this.#scheduleTeardown(id);
+    }
+  }
+
+  #ensure(id: string, control: WebSocket): Promise<RpcStub<Remote>> {
+    const live = this.#live.get(id);
+    if (live) return Promise.resolve(live.remote);
+
+    const pending = this.#pending.get(id);
+    if (pending) return pending.promise;
+
+    let resolve!: (stub: RpcStub<Remote>) => void;
+    let reject!: (error: unknown) => void;
+    const promise = new Promise<RpcStub<Remote>>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    const timer = setTimeout(() => {
+      this.#pending.delete(id);
+      reject(new Error("[capnweb] peer did not open an RPC session in time"));
+    }, this.#connectTimeoutMs);
+    this.#pending.set(id, { promise, resolve, timer });
+
+    try {
+      control.send(P.openSignal(id));
+    } catch {
+      // The timeout rejects if the control socket was stale.
+    }
+    return promise;
+  }
+
+  #scheduleTeardown(id: string): void {
+    if (this.#teardown === "peer") return;
+    if (this.#teardown === "immediate") {
+      this.#close(id, "idle");
+      return;
+    }
+    const live = this.#live.get(id);
+    if (!live || live.idle) return;
+    live.idle = setTimeout(() => {
+      const current = this.#live.get(id);
+      if (current && current.active === 0) this.#close(id, "idle");
+    }, this.#idleMs);
+  }
+
+  #close(id: string, reason: string): void {
+    try {
+      this.#live.get(id)?.webSocket.close(1000, reason);
+    } catch {}
+  }
+
+  #drop(id: string): void {
+    const live = this.#live.get(id);
+    if (!live) return;
+    if (live.idle) clearTimeout(live.idle);
+    disposeStub(live.remote);
+    this.#live.delete(id);
+  }
+}

--- a/packages/hibernatable-capnweb/src/index.ts
+++ b/packages/hibernatable-capnweb/src/index.ts
@@ -1,0 +1,6 @@
+export { globalWebSocket, fromWs, workersFetch, workersFetchWith } from "./adapters.ts";
+export type { SocketOpener, WebSocketLike } from "./adapters.ts";
+export { HibernatableCapnwebClient } from "./client.ts";
+export type { HibernatableCapnwebClientOptions } from "./client.ts";
+export { HibernatableCapnwebHost } from "./host.ts";
+export type { Connection, HibernatableCapnwebHostOptions } from "./host.ts";

--- a/packages/hibernatable-capnweb/src/protocol.ts
+++ b/packages/hibernatable-capnweb/src/protocol.ts
@@ -1,0 +1,20 @@
+export const DEFAULT_PATH = "/capnweb";
+
+export const controlPath = (path: string) => `${path}-control`;
+
+export const controlTag = (path: string) => `${path}-control`;
+
+export const PING = "ping";
+export const PONG = "pong";
+
+export const openSignal = (id: string) => JSON.stringify({ capnweb: "open", id });
+
+export const readSignal = (data: string): string | null => {
+  if (!data || data === PONG) return null;
+  try {
+    const message = JSON.parse(data) as { capnweb?: unknown; id?: unknown };
+    return message.capnweb === "open" && typeof message.id === "string" ? message.id : null;
+  } catch {
+    return null;
+  }
+};

--- a/packages/hibernatable-capnweb/src/stub.ts
+++ b/packages/hibernatable-capnweb/src/stub.ts
@@ -1,0 +1,11 @@
+import type { RpcStub, RpcTarget } from "capnweb";
+
+export function dupStub<T extends RpcTarget>(stub: RpcStub<T>): RpcStub<T> {
+  return ((stub as { dup?: () => RpcStub<T> }).dup?.() ?? stub) as RpcStub<T>;
+}
+
+export function disposeStub(stub: unknown): void {
+  try {
+    (stub as { [Symbol.dispose]?: () => void } | undefined)?.[Symbol.dispose]?.();
+  } catch {}
+}

--- a/packages/hibernatable-capnweb/tsconfig.json
+++ b/packages/hibernatable-capnweb/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": true,
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "types": ["@cloudflare/workers-types", "node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,7 +183,7 @@ importers:
     dependencies:
       '@better-auth/oauth-provider':
         specifier: ^1.6.9
-        version: 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.9(3ef3ed679d89d2b11c36eee8bde8d517))(better-call@1.3.5(zod@4.3.6))
+        version: 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.9(40c9f1419a70cac430d4daba56c47f79))(better-call@1.3.5(zod@4.3.6))
       '@iterate-com/auth-contract':
         specifier: workspace:*
         version: link:../auth-contract
@@ -213,10 +213,10 @@ importers:
         version: 0.83.3(patch_hash=be30e55f1a8738a1200d2ea3226d0e2e3db243b66d27c467ff15df3267dee51c)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.6.0))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1))
       auth:
         specifier: ^1.6.9
-        version: 1.6.9(368ba43a6e2f7d8ef8263b40313aa010)
+        version: 1.6.9(e10130e5cc1e62d641d687d40dfd6375)
       better-auth:
         specifier: ^1.6.9
-        version: 1.6.9(3ef3ed679d89d2b11c36eee8bde8d517)
+        version: 1.6.9(40c9f1419a70cac430d4daba56c47f79)
       hono:
         specifier: ^4.12.8
         version: 4.12.15
@@ -237,7 +237,7 @@ importers:
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       sqlfu:
         specifier: 0.0.3-14
-        version: 0.0.3-14(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(better-auth@1.6.9(3ef3ed679d89d2b11c36eee8bde8d517))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0)
+        version: 0.0.3-14(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@6.0.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@6.0.3)))(better-auth@1.6.9(40c9f1419a70cac430d4daba56c47f79))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@6.0.3))(ws@8.19.0)
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.1
@@ -1127,6 +1127,31 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/hibernatable-capnweb:
+    dependencies:
+      capnweb:
+        specifier: ^0.8.0
+        version: 0.8.0
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: catalog:cloudflare
+        version: 4.20260426.1
+      '@types/node':
+        specifier: ^25.0.10
+        version: 25.6.0
+      get-port:
+        specifier: ^7.1.1
+        version: 7.2.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      wrangler:
+        specifier: 4.85.0
+        version: 4.85.0(@cloudflare/workers-types@4.20260426.1)
+
   packages/iterate:
     dependencies:
       '@clack/prompts':
@@ -1146,7 +1171,7 @@ importers:
         version: 1.4.3
       trpc-cli:
         specifier: 0.14.0
-        version: 0.14.0(@orpc/server@1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0))(@trpc/server@11.12.0(typescript@5.9.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(effect@3.19.19)(valibot@1.2.0(typescript@5.9.3))(zod@4.1.12)
+        version: 0.14.0(@orpc/server@1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0))(@trpc/server@11.12.0(typescript@6.0.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@6.0.3)))(effect@3.19.19)(valibot@1.2.0(typescript@6.0.3))(zod@4.1.12)
       zod:
         specifier: 4.1.12
         version: 4.1.12
@@ -9789,6 +9814,10 @@ packages:
     resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
     engines: {node: '>=16'}
 
+  get-port@7.2.0:
+    resolution: {integrity: sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==}
+    engines: {node: '>=16'}
+
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
@@ -15177,12 +15206,12 @@ snapshots:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.1.1)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/oauth-provider@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.9(3ef3ed679d89d2b11c36eee8bde8d517))(better-call@1.3.5(zod@4.3.6))':
+  '@better-auth/oauth-provider@1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.9(40c9f1419a70cac430d4daba56c47f79))(better-call@1.3.5(zod@4.3.6))':
     dependencies:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.1.1)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.6.9(3ef3ed679d89d2b11c36eee8bde8d517)
+      better-auth: 1.6.9(40c9f1419a70cac430d4daba56c47f79)
       better-call: 1.3.5(zod@4.3.6)
       jose: 6.2.2
       zod: 4.3.6
@@ -20299,6 +20328,11 @@ snapshots:
       typescript: 5.9.3
     optional: true
 
+  '@trpc/server@11.12.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+    optional: true
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -20737,6 +20771,11 @@ snapshots:
       valibot: 1.2.0(typescript@5.9.3)
     optional: true
 
+  '@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@6.0.3))':
+    dependencies:
+      valibot: 1.2.0(typescript@6.0.3)
+    optional: true
+
   '@vercel/oidc@3.1.0': {}
 
   '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.28.6)(rolldown@1.0.3)(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.0(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
@@ -20859,13 +20898,13 @@ snapshots:
       msw: 2.13.3(@types/node@24.12.4)(typescript@6.0.3)
       vite: 8.0.16(@types/node@24.12.4)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/mocker@4.1.8(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.8(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.13.3(@types/node@25.6.0)(typescript@5.9.3)
+      msw: 2.13.3(@types/node@25.6.0)(typescript@6.0.3)
       vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     optional: true
 
@@ -21055,6 +21094,13 @@ snapshots:
       '@vue/compiler-ssr': 3.5.30
       '@vue/shared': 3.5.30
       vue: 3.5.30(typescript@5.9.3)
+    optional: true
+
+  '@vue/server-renderer@3.5.30(vue@3.5.30(typescript@6.0.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.30
+      '@vue/shared': 3.5.30
+      vue: 3.5.30(typescript@6.0.3)
     optional: true
 
   '@vue/shared@3.5.30':
@@ -21598,7 +21644,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  auth@1.6.9(368ba43a6e2f7d8ef8263b40313aa010):
+  auth@1.6.9(e10130e5cc1e62d641d687d40dfd6375):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
@@ -21608,7 +21654,7 @@ snapshots:
       '@better-auth/utils': 0.4.0
       '@clack/prompts': 0.11.0
       '@mrleebo/prisma-ast': 0.13.1
-      better-auth: 1.6.9(3ef3ed679d89d2b11c36eee8bde8d517)
+      better-auth: 1.6.9(40c9f1419a70cac430d4daba56c47f79)
       c12: 3.3.4
       chalk: 5.6.2
       commander: 12.1.0
@@ -21719,7 +21765,7 @@ snapshots:
       nanostores: 1.1.1
       zod: 4.3.6
 
-  better-auth@1.6.9(3ef3ed679d89d2b11c36eee8bde8d517):
+  better-auth@1.6.9(40c9f1419a70cac430d4daba56c47f79):
     dependencies:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.1.1)
       '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260426.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260426.1)(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.6.0))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1))
@@ -21748,8 +21794,8 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       solid-js: 1.9.11
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(jsdom@27.4.0(@noble/hashes@2.0.1))(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
-      vue: 3.5.30(typescript@5.9.3)
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(jsdom@27.4.0(@noble/hashes@2.0.1))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+      vue: 3.5.30(typescript@6.0.3)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -23820,6 +23866,8 @@ snapshots:
 
   get-port@7.1.0: {}
 
+  get-port@7.2.0: {}
+
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
@@ -25539,7 +25587,7 @@ snapshots:
       '@peculiar/asn1-x509': 2.6.1
       '@peculiar/x509': 1.14.3
       '@types/cors': 2.8.19
-      '@types/node': 25.6.0
+      '@types/node': 24.12.4
       async-mutex: 0.5.0
       base64-arraybuffer: 0.1.5
       body-parser: 1.20.4
@@ -25693,6 +25741,32 @@ snapshots:
       yargs: 17.7.2
     optionalDependencies:
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
+  msw@2.13.3(@types/node@25.6.0)(typescript@6.0.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@25.6.0)
+      '@mswjs/interceptors': 0.41.3
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.13.1
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.7
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 5.5.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
     optional: true
@@ -27556,23 +27630,6 @@ snapshots:
   sql.js@1.14.1:
     optional: true
 
-  sqlfu@0.0.3-14(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(better-auth@1.6.9(3ef3ed679d89d2b11c36eee8bde8d517))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0):
-    dependencies:
-      '@clack/prompts': 1.2.0
-      '@orpc/server': 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)
-      trpc-cli: 0.14.0(@orpc/server@1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0))(@trpc/server@11.12.0(typescript@5.9.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(effect@3.19.19)(valibot@1.2.0(typescript@5.9.3))(zod@4.3.6)
-      zod: 4.3.6
-    optionalDependencies:
-      better-auth: 1.6.9(3ef3ed679d89d2b11c36eee8bde8d517)
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@trpc/server'
-      - '@valibot/to-json-schema'
-      - crossws
-      - fastify
-      - valibot
-      - ws
-
   sqlfu@0.0.3-14(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(better-auth@1.6.9(4b51f78e5d74e8f767acd406c33e02b4))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0):
     dependencies:
       '@clack/prompts': 1.2.0
@@ -27615,6 +27672,23 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       better-auth: 1.6.9(ddad1f0cc1e122be2218b36e6681017f)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@trpc/server'
+      - '@valibot/to-json-schema'
+      - crossws
+      - fastify
+      - valibot
+      - ws
+
+  sqlfu@0.0.3-14(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@6.0.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@6.0.3)))(better-auth@1.6.9(40c9f1419a70cac430d4daba56c47f79))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@6.0.3))(ws@8.19.0):
+    dependencies:
+      '@clack/prompts': 1.2.0
+      '@orpc/server': 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)
+      trpc-cli: 0.14.0(@orpc/server@1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0))(@trpc/server@11.12.0(typescript@6.0.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@6.0.3)))(valibot@1.2.0(typescript@6.0.3))(zod@4.3.6)
+      zod: 4.3.6
+    optionalDependencies:
+      better-auth: 1.6.9(40c9f1419a70cac430d4daba56c47f79)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@trpc/server'
@@ -27944,17 +28018,6 @@ snapshots:
 
   trough@2.2.0: {}
 
-  trpc-cli@0.14.0(@orpc/server@1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0))(@trpc/server@11.12.0(typescript@5.9.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(effect@3.19.19)(valibot@1.2.0(typescript@5.9.3))(zod@4.1.12):
-    dependencies:
-      commander: 14.0.3
-    optionalDependencies:
-      '@orpc/server': 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)
-      '@trpc/server': 11.12.0(typescript@5.9.3)
-      '@valibot/to-json-schema': 1.5.0(valibot@1.2.0(typescript@5.9.3))
-      effect: 3.19.19
-      valibot: 1.2.0(typescript@5.9.3)
-      zod: 4.1.12
-
   trpc-cli@0.14.0(@orpc/server@1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0))(@trpc/server@11.12.0(typescript@5.9.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(effect@3.19.19)(valibot@1.2.0(typescript@5.9.3))(zod@4.3.6):
     dependencies:
       commander: 14.0.3
@@ -27975,6 +28038,27 @@ snapshots:
       '@valibot/to-json-schema': 1.5.0(valibot@1.2.0(typescript@5.9.3))
       valibot: 1.2.0(typescript@5.9.3)
       zod: 4.4.3
+
+  trpc-cli@0.14.0(@orpc/server@1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0))(@trpc/server@11.12.0(typescript@6.0.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@6.0.3)))(effect@3.19.19)(valibot@1.2.0(typescript@6.0.3))(zod@4.1.12):
+    dependencies:
+      commander: 14.0.3
+    optionalDependencies:
+      '@orpc/server': 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)
+      '@trpc/server': 11.12.0(typescript@6.0.3)
+      '@valibot/to-json-schema': 1.5.0(valibot@1.2.0(typescript@6.0.3))
+      effect: 3.19.19
+      valibot: 1.2.0(typescript@6.0.3)
+      zod: 4.1.12
+
+  trpc-cli@0.14.0(@orpc/server@1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0))(@trpc/server@11.12.0(typescript@6.0.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@6.0.3)))(valibot@1.2.0(typescript@6.0.3))(zod@4.3.6):
+    dependencies:
+      commander: 14.0.3
+    optionalDependencies:
+      '@orpc/server': 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)
+      '@trpc/server': 11.12.0(typescript@6.0.3)
+      '@valibot/to-json-schema': 1.5.0(valibot@1.2.0(typescript@6.0.3))
+      valibot: 1.2.0(typescript@6.0.3)
+      zod: 4.3.6
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -28294,6 +28378,11 @@ snapshots:
   valibot@1.2.0(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
+
+  valibot@1.2.0(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
 
   validate-npm-package-license@3.0.4:
     dependencies:
@@ -28733,10 +28822,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(jsdom@27.4.0(@noble/hashes@2.0.1))(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(jsdom@27.4.0(@noble/hashes@2.0.1))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.8(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -28789,6 +28878,17 @@ snapshots:
       '@vue/shared': 3.5.30
     optionalDependencies:
       typescript: 5.9.3
+    optional: true
+
+  vue@3.5.30(typescript@6.0.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.30
+      '@vue/compiler-sfc': 3.5.30
+      '@vue/runtime-dom': 3.5.30
+      '@vue/server-renderer': 3.5.30(vue@3.5.30(typescript@6.0.3))
+      '@vue/shared': 3.5.30
+    optionalDependencies:
+      typescript: 6.0.3
     optional: true
 
   w3c-keyname@2.2.8: {}


### PR DESCRIPTION
## What changed

Adds a new workspace package, `hibernatable-capnweb`, that bridges Cap'n Web RPC across a Durable Object that is allowed to hibernate between bursts of work.

The package exposes:

- `HibernatableCapnwebHost` for the Durable Object side.
- `HibernatableCapnwebClient` for long-lived peers in Node, browsers, Bun, Deno, and Workers.
- Runtime socket adapters: `globalWebSocket`, `fromWs`, `workersFetch`, and `workersFetchWith`.
- A Miniflare/deployed proof harness under `src/e2e`.

The important behavior is that each logical peer connection has two WebSockets:

| Socket | Accepted by | Purpose | DO pinning |
| --- | --- | --- | --- |
| `/capnweb-control` | `ctx.acceptWebSocket()` | long-lived control channel, metadata, host-to-peer "open an RPC burst" signal | hibernatable |
| `/capnweb` | `server.accept()` + `newWebSocketRpcSession()` | short-lived Cap'n Web RPC session | pins only while open |

## Durable Object host usage

```ts
import { DurableObject } from "cloudflare:workers";
import { HibernatableCapnwebHost } from "hibernatable-capnweb";
import type { RpcTarget } from "capnweb";

type PeerApi = RpcTarget & {
  run(args: { command: string }): Promise<{ stdout: string }>;
};

class HostApi extends RpcTarget {
  constructor(private readonly room: MyDO) {
    super();
  }

  ping() {
    return { ok: true };
  }
}

export class MyDO extends DurableObject {
  #peers = new HibernatableCapnwebHost<PeerApi, HostApi>(this.ctx, {
    main: () => new HostApi(this),
    teardown: "idle",
    idleMs: 10_000,
  });

  fetch(request: Request) {
    return this.#peers.handle(request) ?? new Response("not found", { status: 404 });
  }

  webSocketMessage(ws: WebSocket, data: string | ArrayBuffer) {
    this.#peers.message(ws, data);
  }

  webSocketClose(ws: WebSocket) {
    this.#peers.closed(ws);
  }

  webSocketError(ws: WebSocket) {
    this.#peers.errored(ws);
  }

  async runOnPeer(id: string, command: string) {
    const peer = this.#peers.connection(id);
    if (!peer) throw new Error(`no peer ${id}`);

    return await peer.withRemote((remote) => remote.run({ command }));
  }
}
```

`connections()` and `connection(id)` are rebuilt from hibernatable control socket attachments, so they still work when a fresh DO instance wakes up.

## Node/browser client usage

```ts
import { HibernatableCapnwebClient } from "hibernatable-capnweb";
import { RpcTarget } from "capnweb";

class PeerApi extends RpcTarget {
  async run(args: { command: string }) {
    return { stdout: `would run: ${args.command}` };
  }
}

const client = new HibernatableCapnwebClient<HostApi, PeerApi>("wss://example.com", {
  id: "agent-123",
  meta: { runtime: "node", region: "local-dev" },
  main: () => new PeerApi(),
  idleMs: 30_000,
});

client.start();

const host = await client.connect();
await host.ping();
```

For older Node versions that do not expose a global `WebSocket`:

```ts
import WebSocket from "ws";
import { HibernatableCapnwebClient, fromWs } from "hibernatable-capnweb";

const client = new HibernatableCapnwebClient<HostApi, PeerApi>("wss://example.com", {
  id: "agent-123",
  main: () => new PeerApi(),
  open: fromWs(WebSocket),
});
```

## Worker-as-client usage

When a Worker is the peer, use the fetch-upgrade adapter:

```ts
import { HibernatableCapnwebClient, workersFetch } from "hibernatable-capnweb";

const client = new HibernatableCapnwebClient<HostApi, PeerApi>("wss://example.com", {
  id: "worker-peer-123",
  main: () => new PeerApi(),
  open: workersFetch,
});
```

If the Worker is connecting directly to a bound Durable Object instead of a public URL, use `workersFetchWith()` so upgrades go through the DO stub rather than recursive public self-fetch:

```ts
const room = env.MY_DO.get(env.MY_DO.idFromName("room"));

const client = new HibernatableCapnwebClient<HostApi, PeerApi>("wss://proof.local", {
  id: "worker-peer-123",
  main: () => new PeerApi(),
  open: workersFetchWith((input, init) => room.fetch(input, init)),
});
```

## Design decisions

### Two sockets instead of one

Cap'n Web currently runs over a standard accepted WebSocket, which pins the Durable Object while the session is open. A single always-open Cap'n Web socket would keep billing/instance lifetime tied to peer reachability.

This package splits reachability from RPC work:

- The control socket is hibernatable and stores `{ id, meta }` in the socket attachment.
- The RPC socket is opened only for a burst of calls and then closed by an idle timer.

### Durable truth lives in socket attachments

Live Cap'n Web sessions stay in memory only. After hibernation, that map is empty by design. The durable source of connection state is the set of hibernatable control sockets returned by `ctx.getWebSockets(tag)`.

That means callers should use `connection(id)` or `connections()` when they need a peer handle, instead of caching `Connection` objects across hibernation.

### Host-to-peer calls are demand-dialed

When the DO needs to call a peer and no RPC session exists, `withRemote()` sends an open signal over the control socket. The peer dials `/capnweb`, exposes its `RpcTarget`, and the host resumes the call with the peer's stub.

```ts
await host.connection("agent-123")?.withRemote((remote) =>
  remote.run({ command: "git status --short" }),
);
```

### Teardown is explicit

The host defaults to `teardown: "idle"`, so RPC bursts stay warm briefly and then close. This keeps repeated calls efficient without leaving the DO pinned indefinitely. Callers can choose:

- `"idle"`: close after `idleMs` with no active calls.
- `"immediate"`: close as soon as the current call finishes.
- `"peer"`: let the client-side idle timer own teardown.

## Proof harness

The proof Worker validates three client shapes:

1. Node client using global `WebSocket`.
2. Stateless Worker client using fetch-upgrade through `workersFetchWith()`.
3. Browser client using native browser `WebSocket` and a browser-side `RpcTarget`.

The Miniflare proof additionally verifies actual instance hibernation:

- the control socket remains listed after the RPC burst closes;
- heartbeat auto-response happens without invoking `webSocketMessage`;
- after Miniflare evicts the DO instance, a fresh instance still finds the control socket attachment;
- that fresh instance calls back into the peer's `RpcTarget`.

I also deployed the proof Worker to `https://hibernatable-capnweb-proof.iterate-dev-preview.workers.dev`. The deployed runtime successfully proves Node, stateless Worker, and browser callbacks, but did not evict the DO instance during tested quiet windows. The proof harness records that as `observedHibernation: false` rather than pretending production eviction happened on demand. Miniflare does prove the hibernation path deterministically.

## Validation

Ran:

```bash
pnpm --dir packages/hibernatable-capnweb typecheck
pnpm --dir packages/hibernatable-capnweb prove:miniflare
HIBERNATABLE_CAPNWEB_PROOF_BASE_URL=https://hibernatable-capnweb-proof.iterate-dev-preview.workers.dev \
  HIBERNATABLE_CAPNWEB_HIBERNATE_WAIT_MS=5000 \
  HIBERNATABLE_CAPNWEB_HEARTBEAT_MS=0 \
  HIBERNATABLE_CAPNWEB_REQUIRE_HIBERNATION=false \
  pnpm --dir packages/hibernatable-capnweb prove:url
```

Also opened the deployed `/browser-proof?wait=5000&heartbeat=0&requireHibernation=false` page in Chrome and observed `ok: true`, with the host calling the browser `RpcTarget`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New isolated package with no production app wiring yet, but it defines critical DO WebSocket/RPC behavior and connection state across hibernation—bugs could affect future agent/peer integrations.
> 
> **Overview**
> Adds a new private workspace package **`hibernatable-capnweb`** that layers Cap'n Web RPC on top of **hibernatable Durable Object WebSockets**, so the DO is not pinned for the whole lifetime of a peer connection.
> 
> Each peer uses **two sockets**: a long-lived **`/capnweb-control`** channel accepted with `ctx.acceptWebSocket()` (metadata in attachments, ping/pong auto-response, host→peer “open RPC” signals), and a short-lived **`/capnweb`** socket for `newWebSocketRpcSession()` bursts that close on idle. **`HibernatableCapnwebHost`** wires fetch/WebSocket lifecycle hooks and exposes `connection(id).withRemote()` to demand-dial peers; **`HibernatableCapnwebClient`** keeps the control socket up with reconnect/heartbeat and opens RPC on demand.
> 
> Socket openers cover **global `WebSocket`**, **`ws`**, and **Worker fetch upgrades** (`workersFetch` / `workersFetchWith`). **`src/e2e`** adds a proof DO Worker plus Miniflare and URL-driven scripts that exercise Node, stateless Worker, browser, hibernation wake, and host→peer callbacks. **`pnpm-lock.yaml`** picks up the new package and incidental lockfile resolution churn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a33cb62635ec929386a978b473f85df8bfecb9bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->