### PR TITLE
[codex] Catch up stream core state on wake

### DIFF
--- a/packages/streams/src/processors/core/contract.test.ts
+++ b/packages/streams/src/processors/core/contract.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { coreProcessorContract } from "./contract.ts";
-import { assertStreamAppendAllowed, getAncestorStreamPaths } from "./implementation.ts";
+import {
+  assertStreamAppendAllowed,
+  catchUpCoreProcessorState,
+  getAncestorStreamPaths,
+  reduceCoreProcessorStateFromEvents,
+} from "./implementation.ts";
 
 const reduce = coreProcessorContract.reduce;
 if (reduce === undefined) throw new Error("core processor must have a reducer");
@@ -177,5 +182,83 @@ describe("core processor contract", () => {
     expect(state.metadata).toEqual({ title: "Demo stream" });
     expect(state.maxOffset).toBe(3);
     expect(getAncestorStreamPaths("/a/b/c")).toEqual(["/", "/a", "/a/b"]);
+  });
+
+  it("rebuilds state by replaying committed events", () => {
+    const state = reduceCoreProcessorStateFromEvents([
+      {
+        offset: 1,
+        type: "events.iterate.com/stream/created",
+        payload: { namespace: "default", path: "/agents" },
+        createdAt: "2026-06-01T12:00:00.000Z",
+      },
+      {
+        offset: 2,
+        type: "events.iterate.com/stream/woken",
+        payload: { incarnationId: "incarnation-1" },
+        createdAt: "2026-06-01T12:00:00.001Z",
+      },
+      {
+        offset: 3,
+        type: "events.iterate.com/stream/child-stream-created",
+        idempotencyKey: "child-stream-created:/agents:/agents/debug",
+        payload: { childPath: "/agents/debug" },
+        createdAt: "2026-06-01T12:00:01.000Z",
+      },
+    ]);
+
+    expect(state).toMatchObject({
+      namespace: "default",
+      path: "/agents",
+      incarnationId: "incarnation-1",
+      eventCount: 3,
+      maxOffset: 3,
+      childPaths: ["/agents/debug"],
+    });
+  });
+
+  it("catches up stored state from events after the stored max offset", () => {
+    const stored = reduceCoreProcessorStateFromEvents([
+      {
+        offset: 1,
+        type: "events.iterate.com/stream/created",
+        payload: { namespace: "default", path: "/agents" },
+        createdAt: "2026-06-01T12:00:00.000Z",
+      },
+      {
+        offset: 2,
+        type: "events.iterate.com/stream/woken",
+        payload: { incarnationId: "incarnation-1" },
+        createdAt: "2026-06-01T12:00:00.001Z",
+      },
+    ]);
+
+    const state = catchUpCoreProcessorState({
+      state: stored,
+      events: [
+        {
+          offset: 1,
+          type: "events.iterate.com/stream/created",
+          payload: { namespace: "wrong", path: "/wrong" },
+          createdAt: "2026-06-01T12:00:00.000Z",
+        },
+        {
+          offset: 3,
+          type: "events.iterate.com/stream/child-stream-created",
+          idempotencyKey: "child-stream-created:/agents:/agents/debug",
+          payload: { childPath: "/agents/debug" },
+          createdAt: "2026-06-01T12:00:01.000Z",
+        },
+      ],
+    });
+
+    expect(state).toMatchObject({
+      namespace: "default",
+      path: "/agents",
+      incarnationId: "incarnation-1",
+      eventCount: 3,
+      maxOffset: 3,
+      childPaths: ["/agents/debug"],
+    });
   });
 });

--- a/packages/streams/src/processors/core/implementation.ts
+++ b/packages/streams/src/processors/core/implementation.ts
@@ -3,8 +3,9 @@
 // of through a subscription runner, because stream bookkeeping must be updated
 // before committed events are delivered to subscribers.
 
-import type { StreamEventInput } from "../../shared/event.ts";
+import type { StreamEvent, StreamEventInput } from "../../shared/event.ts";
 import { implementBuiltinProcessor } from "../../processor.ts";
+import { getInitialProcessorState, runProcessorReduce } from "../../shared/stream-processors.ts";
 import { coreProcessorContract, type CoreProcessorState } from "./contract.ts";
 
 export const coreProcessor = implementBuiltinProcessor(
@@ -45,4 +46,33 @@ export function getAncestorStreamPaths(path: string): string[] {
     ancestors.push(`/${segments.slice(0, index).join("/")}`);
   }
   return ancestors;
+}
+
+export function catchUpCoreProcessorState(args: {
+  state: CoreProcessorState;
+  events: readonly StreamEvent[];
+}): CoreProcessorState {
+  let state = args.state;
+  for (const event of args.events) {
+    if (event.offset <= state.maxOffset) continue;
+    const reduction = runProcessorReduce({
+      processor: { contract: coreProcessorContract },
+      event,
+      state,
+    });
+    if (reduction === undefined) {
+      throw new Error(`core processor cannot reduce event type "${event.type}"`);
+    }
+    state = coreProcessorContract.stateSchema.parse(reduction.state);
+  }
+  return state;
+}
+
+export function reduceCoreProcessorStateFromEvents(
+  events: readonly StreamEvent[],
+): CoreProcessorState {
+  return catchUpCoreProcessorState({
+    state: getInitialProcessorState(coreProcessorContract),
+    events,
+  });
 }

--- a/packages/streams/src/workers/durable-objects/stream.ts
+++ b/packages/streams/src/workers/durable-objects/stream.ts
@@ -10,7 +10,11 @@ import { getInitialProcessorState, runProcessorReduce } from "../../shared/strea
 import { makeRpcTargetClass } from "../../shared/rpc-target.ts";
 import type { StreamCoreProcessorState } from "../../types.ts";
 import type { ProcessorStream } from "../../processor-runner.ts";
-import { getAncestorStreamPaths, coreProcessor } from "../../processors/core/implementation.ts";
+import {
+  getAncestorStreamPaths,
+  catchUpCoreProcessorState,
+  coreProcessor,
+} from "../../processors/core/implementation.ts";
 import { coreProcessorContract, type CoreProcessorState } from "../../processors/core/contract.ts";
 import type { StreamProcessorRunnerRpc, StreamRpc, SubscriptionSink } from "../../types.ts";
 
@@ -74,13 +78,42 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
 
   protected readCoreProcessorState(): StreamCoreProcessorState {
     const stored = this.ctx.storage.kv.get<unknown>("state");
-    return stored === undefined
-      ? getInitialProcessorState(coreProcessorContract)
-      : coreProcessorContract.stateSchema.parse(stored);
+    const storedState =
+      stored === undefined
+        ? getInitialProcessorState(coreProcessorContract)
+        : coreProcessorContract.stateSchema.parse(stored);
+    const state = this.#catchUpCoreProcessorState(storedState);
+
+    if (state.maxOffset !== storedState.maxOffset) {
+      this.writeCoreProcessorState(state);
+    }
+    return state;
   }
 
   protected writeCoreProcessorState(state: StreamCoreProcessorState): void {
     this.ctx.storage.kv.put("state", state);
+  }
+
+  #catchUpCoreProcessorState(state: StreamCoreProcessorState): StreamCoreProcessorState {
+    const highestOffset = this.#readHighestEventOffset();
+    if (highestOffset <= state.maxOffset) return state;
+
+    return catchUpCoreProcessorState({
+      state,
+      events: this.#readEventsInRange({
+        afterOffset: state.maxOffset,
+        beforeOffset: highestOffset + 1,
+        limit: highestOffset - state.maxOffset,
+      }),
+    });
+  }
+
+  #readHighestEventOffset(): number {
+    return (
+      this.ctx.storage.sql
+        .exec<{ offset: number | null }>("select max(offset) as offset from events")
+        .toArray()[0]?.offset ?? 0
+    );
   }
 
   #appendEventRows(events: StreamEvent[]): void {


### PR DESCRIPTION
## Summary

Fixes a production regression where existing `Stream` Durable Objects could wake with core state behind their committed SQL event log. On the next append, the stale `maxOffset` caused the stream to assign an already-used offset and fail with `UNIQUE constraint failed: events.offset`.

This PR makes stream construction catch core state up from the event log every time:

- load KV core state, or the core initial state if KV is missing
- read the highest committed event offset from SQL
- synchronously reduce committed events with `offset > state.maxOffset`
- write the caught-up state back to KV only when it advanced

There is no legacy `processor_state` path anymore. The event log is the source of truth for catching up core state.

## Root Cause

`97cb7194b` moved Stream Durable Object core state to KV-backed `state`, but existing and partially-updated streams could still have committed events beyond the stored core state's `maxOffset`. When those streams woke, the next append reused an existing event offset and SQLite rejected the insert.

## Production Evidence

Before this fix, production calls against the `iterate` project failed with `Non-error of type undefined thrown`, and `wrangler tail os-prd` showed:

```text
Error: UNIQUE constraint failed: events.offset: SQLITE_CONSTRAINT_PRIMARYKEY
```

The failure reproduced on agent message send and on existing Slack parent streams such as `/agents/slack` and `/agents/slack/c08r1smtzgd`.

## Verification

- `pnpm --dir packages/streams test`
- `pnpm --dir packages/streams typecheck`
- `git diff --check HEAD`
- Temporarily deployed this branch to `prd` to stop the active outage before opening this PR.
- Verified a fresh production agent under `iterate` responds to `pong`.
- Verified the affected Slack stream tree wakes and reads in production.
- Replayed the missing Slack webhook for `C08R1SMTZGD` / `1780924432.372929`; production routed it through `/integrations/slack`, the Slack agent processed it, and the bot posted `Hello!` in the original thread.

## Deployment Note

The production hot deploy was operationally necessary because main-based CI had already redeployed over the first local hotfix. This PR is the durable path to get the same fix into `main` so future CI deploys do not regress production again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches Stream DO boot and offset assignment on the append path; incorrect replay or persistence could still corrupt offsets or duplicate events in production.
> 
> **Overview**
> **Stream Durable Objects** now reconcile KV core processor state with the committed SQL event log on wake, fixing streams that had events but missing or stale KV `state` after the KV migration.
> 
> On `readCoreProcessorState`, the DO loads KV (or initial state), replays any SQL events with `offset > maxOffset` through the core reducer via new helpers **`catchUpCoreProcessorState`** and **`reduceCoreProcessorStateFromEvents`**, and **writes KV back** when `maxOffset` advances so recovery is lazy per wake.
> 
> Contract tests cover full replay from events and incremental catch-up that **ignores events at or below** the stored `maxOffset`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1abff8696a474ed07c5bb2d1a9c017c75a2be8ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->