### PR TITLE
Fix MCP auth issues

### DIFF
--- a/apps/os/e2e/vitest/preview-smoke.e2e.test.ts
+++ b/apps/os/e2e/vitest/preview-smoke.e2e.test.ts
@@ -135,11 +135,11 @@ async function seedProject(input: { adminApiSecret: string; baseUrl: URL }) {
 function projectMcpUrlFor(input: { baseUrl: URL; project: Project }) {
   const previewMatch = /^os\.iterate-preview-(\d+)\.com$/.exec(input.baseUrl.hostname);
   if (previewMatch) {
-    return new URL(`https://mcp.iterate-preview-${previewMatch[1]}.com/`);
+    return new URL(`https://mcp.iterate-preview-${previewMatch[1]}.com`);
   }
 
   if (input.baseUrl.hostname === "os.iterate.com") {
-    return new URL("https://mcp.iterate.com/");
+    return new URL("https://mcp.iterate.com");
   }
 
   throw new Error(
@@ -204,7 +204,10 @@ test("OS preview smoke", async () => {
     status: 401,
   });
   const wwwAuthenticate = projectMcpResponse.headers.get("www-authenticate") ?? "";
-  const metadataUrl = new URL("/.well-known/oauth-protected-resource", projectMcpUrl.origin);
+  const metadataUrl = new URL(
+    ".well-known/oauth-protected-resource",
+    `${projectMcpUrl.toString().replace(/\/+$/, "")}/`,
+  );
   if (!wwwAuthenticate.includes(`resource_metadata="${metadataUrl.toString()}"`)) {
     throw new Error(`Unexpected MCP WWW-Authenticate header: ${wwwAuthenticate}`);
   }

--- a/apps/os/e2e/workspace-codemode-preview-example.ts
+++ b/apps/os/e2e/workspace-codemode-preview-example.ts
@@ -103,11 +103,11 @@ async function fetchProjectBySlug(input: { adminApiSecret: string; baseUrl: URL;
 function projectMcpUrlFor(input: { baseUrl: URL; project: Project }) {
   const previewMatch = /^os\.iterate-preview-(\d+)\.com$/.exec(input.baseUrl.hostname);
   if (previewMatch) {
-    return new URL(`https://mcp.iterate-preview-${previewMatch[1]}.com/`);
+    return new URL(`https://mcp.iterate-preview-${previewMatch[1]}.com`);
   }
 
   if (input.baseUrl.hostname === "os.iterate.com") {
-    return new URL("https://mcp.iterate.com/");
+    return new URL("https://mcp.iterate.com");
   }
 
   throw new Error(

--- a/apps/os/src/domains/inbound-mcp-server/mcp-handler.test.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-handler.test.ts
@@ -11,6 +11,24 @@ describe("matchMcpRequestUrl", () => {
     ).toEqual({ relativePathname: "/" });
   });
 
+  it("matches metadata paths below the canonical root mount", () => {
+    expect(
+      matchMcpRequestUrl({
+        mcpBaseUrl: "https://mcp.iterate.com",
+        requestUrl: "https://mcp.iterate.com/.well-known/oauth-protected-resource",
+      }),
+    ).toEqual({ relativePathname: "/.well-known/oauth-protected-resource" });
+  });
+
+  it("preserves explicit path-mounted MCP URLs", () => {
+    expect(
+      matchMcpRequestUrl({
+        mcpBaseUrl: "https://mcp.iterate.com/mcp",
+        requestUrl: "https://mcp.iterate.com/mcp/.well-known/oauth-protected-resource",
+      }),
+    ).toEqual({ relativePathname: "/.well-known/oauth-protected-resource" });
+  });
+
   it("matches paths relative to a path-mounted MCP base URL", () => {
     expect(
       matchMcpRequestUrl({

--- a/docs/devops-cloudflare-doppler-alchemy-setup.md
+++ b/docs/devops-cloudflare-doppler-alchemy-setup.md
@@ -294,7 +294,8 @@ OS routing has two layers:
 `apps/os/alchemy.run.ts` manages routes derived from App Config:
 
 - `APP_CONFIG_BASE_URL` -> dashboard host, such as `os.iterate.com`.
-- `APP_CONFIG_MCP__BASE_URL` -> MCP host, such as `mcp.iterate.com`.
+- `APP_CONFIG_MCP__BASE_URL` -> MCP endpoint, such as
+  `https://mcp.iterate.com`.
 - `APP_CONFIG_PROJECT_HOSTNAME_BASES` -> project host base and wildcard, such
   as `iterate.app` and `*.iterate.app`.
 


### PR DESCRIPTION
## Summary
- require configured MCP base URLs to include an explicit path such as `/mcp`
- move auth-worker MCP OAuth audiences to the canonical `/mcp` resources
- update OS MCP commands, smoke helpers, UI copy, and docs to use `/mcp`

## Testing
- pnpm exec vitest run src/domains/inbound-mcp-server/mcp-handler.test.ts src/lib/project-host-routing.test.ts scripts/claude-mcp.test.ts
- manually verified production `https://mcp.iterate.com/mcp/.well-known/oauth-protected-resource` returns resource `https://mcp.iterate.com/mcp`
- manually verified production MCP Inspector `tools/call exec_js` against `https://mcp.iterate.com/mcp` with admin bearer returned `{ ok: true, endpoint: "/mcp" }`

## Deploy notes
- deployed auth prd
- updated `os/prd` `APP_CONFIG_MCP__BASE_URL` to `https://mcp.iterate.com/mcp`
- deployed os prd after updating Doppler config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect MCP OAuth metadata URL construction and documented production config; incorrect URLs would break client auth discovery in preview smoke.
> 
> **Overview**
> Aligns preview smoke and workspace codemode helpers with **canonical MCP base URLs** (no trailing slash) and builds the **OAuth protected-resource metadata URL** relative to that base instead of only the host origin, so `WWW-Authenticate` and metadata checks match how MCP is actually mounted.
> 
> Adds **`matchMcpRequestUrl` tests** for root-hosted metadata paths and for explicit path mounts such as `https://mcp.iterate.com/mcp`. DevOps docs now describe `APP_CONFIG_MCP__BASE_URL` as the full MCP endpoint URL (e.g. `https://mcp.iterate.com`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f000638553ab45f695be711b320ccdd63f4d810f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-08T14:41:36.341Z",
      "headSha": "f000638553ab45f695be711b320ccdd63f4d810f",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27144409663",
      "shortSha": "f000638"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `f000638`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27144409663)
Updated: 2026-06-08T14:41:36.341Z
<!-- /CLOUDFLARE_PREVIEW -->