### PR TITLE
Fix MCP OAuth resource handling

### DIFF
--- a/apps/auth/src/routes/_auth/project-access.tsx
+++ b/apps/auth/src/routes/_auth/project-access.tsx
@@ -1,6 +1,10 @@
 import { Button } from "@iterate-com/ui/components/button";
 import { ITERATE_PROJECT_SELECTION_SCOPE } from "@iterate-com/shared/auth-claims";
 import {
+  OAUTH_RESOURCE_PARAMETER,
+  copyMissingSearchParams,
+} from "@iterate-com/shared/oauth-resource";
+import {
   Card,
   CardContent,
   CardDescription,
@@ -134,7 +138,7 @@ function RouteComponent() {
         throw new Error("Could not continue the OAuth redirect");
       }
 
-      window.location.href = result.url;
+      window.location.href = preserveOAuthResourceSearchParam(result.url);
       return result;
     },
   });
@@ -559,6 +563,15 @@ function SignedInUserRow(props: {
       </Button>
     </div>
   );
+}
+
+function preserveOAuthResourceSearchParam(rawUrl: string) {
+  return copyMissingSearchParams({
+    targetUrl: rawUrl,
+    sourceSearch: window.location.search,
+    paramNames: [OAUTH_RESOURCE_PARAMETER],
+    baseUrl: window.location.origin,
+  }).toString();
 }
 
 function CreateProjectForm(props: {

--- a/apps/auth/src/server/auth.ts
+++ b/apps/auth/src/server/auth.ts
@@ -6,8 +6,14 @@ import { generateDefaultAvatar } from "@iterate-com/shared/default-avatar";
 import { env } from "./env.ts";
 import { getAuthPlugins } from "./auth-plugins.ts";
 
+const LOCAL_OAUTH_CLIENT_ORIGINS = [
+  "http://localhost:6274",
+  "http://127.0.0.1:6274",
+  "http://[::1]:6274",
+] as const;
+
 export function getAllowedBrowserOrigins() {
-  return [env.VITE_AUTH_APP_ORIGIN, env.VITE_PUBLIC_URL];
+  return [env.VITE_AUTH_APP_ORIGIN, env.VITE_PUBLIC_URL, ...LOCAL_OAUTH_CLIENT_ORIGINS];
 }
 
 function isAllowedBrowserOrigin(origin: string | null | undefined) {

--- a/apps/auth/src/server/oauth-resources.ts
+++ b/apps/auth/src/server/oauth-resources.ts
@@ -1,3 +1,5 @@
+import { expandOAuthResourceAudienceVariants } from "@iterate-com/shared/oauth-resource";
+
 export function getOsResourceBases() {
   return [
     "https://os.iterate.com",
@@ -11,7 +13,7 @@ export function getOsResourceBases() {
 }
 
 export function getOsMcpResourceBases() {
-  return [
+  return expandOAuthResourceAudienceVariants([
     "https://mcp.iterate.com",
     "https://mcp.iterate-dev-jonas.com",
     "https://mcp.iterate-dev-misha.com",
@@ -20,5 +22,5 @@ export function getOsMcpResourceBases() {
       (previewNumber) => `https://mcp.iterate-preview-${previewNumber}.com`,
     ),
     "http://localhost:7301/api/__mcp",
-  ];
+  ]);
 }

--- a/apps/auth/src/server/worker.ts
+++ b/apps/auth/src/server/worker.ts
@@ -1,5 +1,9 @@
 import { contextStorage } from "hono/context-storage";
 import {
+  OAUTH_RESOURCE_PARAMETER,
+  copyMissingSearchParams,
+} from "@iterate-com/shared/oauth-resource";
+import {
   oauthProviderOpenIdConfigMetadata,
   oauthProviderAuthServerMetadata,
 } from "@better-auth/oauth-provider";
@@ -44,6 +48,9 @@ app.get("/api/auth/.well-known/oauth-authorization-server", (c) =>
 );
 app.get(`/.well-known/oauth-authorization-server${AUTH_ISSUER_PATH}`, (c) =>
   oauthProviderAuthServerMetadata(auth)(c.req.raw),
+);
+app.all("/api/auth/oauth2/authorize", async (c) =>
+  preserveOAuthResourceRedirect(c.req.raw, await auth.handler(c.req.raw)),
 );
 app.all("/api/auth/*", (c) => auth.handler(c.req.raw));
 
@@ -114,5 +121,46 @@ app.all("*", (c) =>
     },
   }),
 );
+
+export function preserveOAuthResourceRedirect(request: Request, response: Response) {
+  return preserveRedirectSearchParams(request, response, [OAUTH_RESOURCE_PARAMETER]);
+}
+
+function preserveRedirectSearchParams(
+  request: Request,
+  response: Response,
+  paramNames: Iterable<string>,
+) {
+  if (!isRedirectStatus(response.status)) return response;
+
+  const requestUrl = new URL(request.url);
+  const location = response.headers.get("Location");
+  if (!location) return response;
+
+  const redirectUrl = copyMissingSearchParams({
+    targetUrl: location,
+    sourceSearch: requestUrl.searchParams,
+    paramNames,
+    baseUrl: requestUrl,
+  });
+  const originalRedirectUrl = new URL(location, requestUrl);
+  if (redirectUrl.href === originalRedirectUrl.href) return response;
+
+  const headers = new Headers(response.headers);
+  headers.set(
+    "Location",
+    location.startsWith("/") ? `${redirectUrl.pathname}${redirectUrl.search}` : redirectUrl.href,
+  );
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function isRedirectStatus(status: number) {
+  return status >= 300 && status < 400;
+}
 
 export default app;

--- a/apps/os/src/auth/middleware.ts
+++ b/apps/os/src/auth/middleware.ts
@@ -1,4 +1,5 @@
 import { createIterateAuth, type AuthenticatedSession } from "@iterate-com/auth/server";
+import { oauthResourceAudienceVariants } from "@iterate-com/shared/oauth-resource";
 import { createMiddleware } from "@tanstack/react-start";
 import type { AppContext } from "~/context.ts";
 import { resolveMcpBaseUrl } from "~/lib/mcp-base-url.ts";
@@ -163,7 +164,9 @@ export function createOsIterateAuth(context: AppContext, request: Request) {
     mcpBaseUrl: context.config.mcp?.baseUrl,
     requestUrl: request.url,
   });
-  const resources = mcpResource ? [resource, mcpResource] : [resource];
+  const resources = mcpResource
+    ? [resource, ...oauthResourceAudienceVariants(mcpResource)]
+    : [resource];
 
   return createIterateAuth({
     issuer: config.issuer,

--- a/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
@@ -4,6 +4,7 @@ import {
   hasWildcardProjectScope,
   listProjectScopeIds,
 } from "@iterate-com/shared/auth-claims";
+import { oauthResourceAudienceVariants } from "@iterate-com/shared/oauth-resource";
 import { McpAgent } from "agents/mcp";
 import { createD1Client } from "sqlfu";
 import type { AppConfig } from "~/app.ts";
@@ -192,7 +193,7 @@ function createMcpIterateAuth(input: McpHandlerInput) {
     clientId: config.clientId,
     clientSecret: config.clientSecret.exposeSecret(),
     redirectURI: `${baseUrl}/api/iterate-auth/callback`,
-    resource: canonicalMcpResourceUrl(input),
+    resource: oauthResourceAudienceVariants(canonicalMcpResourceUrl(input)),
   });
 }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -107,6 +107,7 @@
     "./codemode/json-schema-types": "./src/codemode/json-schema-types.ts",
     "./project-ingress": "./src/project-ingress.ts",
     "./auth-claims": "./src/auth-claims.ts",
+    "./oauth-resource": "./src/oauth-resource.ts",
     "./bearer": "./src/bearer.ts",
     "./slug": "./src/slug.ts",
     "./default-avatar": "./src/default-avatar.ts",

--- a/packages/shared/src/oauth-resource.test.ts
+++ b/packages/shared/src/oauth-resource.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  copyMissingSearchParams,
+  expandOAuthResourceAudienceVariants,
+  normalizeOAuthResourceUrl,
+  oauthResourceAudienceVariants,
+} from "./oauth-resource.ts";
+
+describe("OAuth resource helpers", () => {
+  it("adds root URL slash variants for resource audiences", () => {
+    expect(oauthResourceAudienceVariants("https://mcp.iterate.com")).toEqual([
+      "https://mcp.iterate.com",
+      "https://mcp.iterate.com/",
+    ]);
+  });
+
+  it("does not add slash variants for resource audiences with paths", () => {
+    expect(oauthResourceAudienceVariants("http://localhost:7301/api/__mcp/")).toEqual([
+      "http://localhost:7301/api/__mcp",
+    ]);
+  });
+
+  it("deduplicates expanded resource audience variants", () => {
+    expect(
+      expandOAuthResourceAudienceVariants(["https://mcp.iterate.com", "https://mcp.iterate.com/"]),
+    ).toEqual(["https://mcp.iterate.com", "https://mcp.iterate.com/"]);
+  });
+
+  it("normalizes resource URLs before comparing audiences", () => {
+    expect(normalizeOAuthResourceUrl("https://mcp.iterate.com/?ignored=true#fragment")).toBe(
+      "https://mcp.iterate.com",
+    );
+  });
+
+  it("copies missing search params without overwriting existing target params", () => {
+    const url = copyMissingSearchParams({
+      targetUrl: "/continue?resource=https%3A%2F%2Fexisting.example",
+      sourceSearch:
+        "?resource=https%3A%2F%2Fmcp.iterate.com&resource=https%3A%2F%2Fmcp.iterate.com%2F&state=abc",
+      paramNames: ["resource", "state"],
+      baseUrl: "https://auth.iterate.com",
+    });
+
+    expect(url.href).toBe(
+      "https://auth.iterate.com/continue?resource=https%3A%2F%2Fexisting.example&state=abc",
+    );
+  });
+
+  it("copies all source values when the target is missing a search param", () => {
+    const url = copyMissingSearchParams({
+      targetUrl: "/continue",
+      sourceSearch:
+        "?resource=https%3A%2F%2Fmcp.iterate.com&resource=https%3A%2F%2Fmcp.iterate.com%2F",
+      paramNames: ["resource"],
+      baseUrl: "https://auth.iterate.com",
+    });
+
+    expect(url.searchParams.getAll("resource")).toEqual([
+      "https://mcp.iterate.com",
+      "https://mcp.iterate.com/",
+    ]);
+  });
+});

--- a/packages/shared/src/oauth-resource.ts
+++ b/packages/shared/src/oauth-resource.ts
@@ -1,0 +1,43 @@
+export const OAUTH_RESOURCE_PARAMETER = "resource";
+
+export function expandOAuthResourceAudienceVariants(resources: Iterable<string>) {
+  return [...new Set(Array.from(resources).flatMap(oauthResourceAudienceVariants))];
+}
+
+export function oauthResourceAudienceVariants(resource: string) {
+  const canonicalResource = normalizeOAuthResourceUrl(resource);
+  const parsed = new URL(canonicalResource);
+  if (parsed.pathname !== "/") return [canonicalResource];
+  return [canonicalResource, `${parsed.origin}/`];
+}
+
+export function normalizeOAuthResourceUrl(resource: string) {
+  const parsed = new URL(resource);
+  parsed.search = "";
+  parsed.hash = "";
+  parsed.pathname = parsed.pathname.replace(/\/+$/, "") || "/";
+  return parsed.toString().replace(/\/$/, "");
+}
+
+export function copyMissingSearchParams(input: {
+  targetUrl: string | URL;
+  sourceSearch: string | URLSearchParams;
+  paramNames: Iterable<string>;
+  baseUrl?: string | URL;
+}) {
+  const targetUrl = new URL(input.targetUrl, input.baseUrl);
+  const sourceSearchParams =
+    input.sourceSearch instanceof URLSearchParams
+      ? input.sourceSearch
+      : new URLSearchParams(input.sourceSearch);
+
+  for (const paramName of input.paramNames) {
+    if (targetUrl.searchParams.has(paramName)) continue;
+
+    for (const value of sourceSearchParams.getAll(paramName)) {
+      targetUrl.searchParams.append(paramName, value);
+    }
+  }
+
+  return targetUrl;
+}


### PR DESCRIPTION
## Summary
- preserve the OAuth resource parameter across auth redirects and project-selection continuation
- accept root MCP resource audiences with and without the trailing slash
- move OAuth resource URL/search-param helpers into shared utilities with focused coverage

## Tests
- pnpm format
- pnpm --dir packages/shared exec vitest run src/oauth-resource.test.ts
- pnpm --dir packages/shared typecheck
- pnpm --dir apps/auth typecheck
- pnpm exec vitest run src/domains/inbound-mcp-server/mcp-handler.test.ts src/lib/project-host-routing.test.ts scripts/claude-mcp.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth authorize redirects, token resource audiences, and CORS/trusted origins—security-sensitive but narrowly scoped with unit tests.
> 
> **Overview**
> Fixes MCP OAuth by keeping the **`resource`** query parameter through auth redirects and treating root MCP audience URLs with and without a trailing slash as equivalent.
> 
> Adds **`@iterate-com/shared/oauth-resource`** with helpers to normalize resource URLs, expand slash variants for audiences, and copy missing search params without clobbering existing values. The auth worker wraps **`/api/auth/oauth2/authorize`** so redirect **`Location`** headers retain **`resource`**; project-access continuation applies the same when sending users back into the flow. Auth registers allowed MCP OAuth client origins on **`localhost:6274`** (and loopback variants). OS and inbound MCP auth now register MCP resources using the expanded audience list; auth MCP resource bases use the same expansion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f7e2f9a7932a6dc90e5ddeacbd50e5f5665f7fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-08T15:55:22.030Z",
      "headSha": "2f7e2f9a7932a6dc90e5ddeacbd50e5f5665f7fe",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27149258641",
      "shortSha": "2f7e2f9"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `2f7e2f9`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27149258641)
Updated: 2026-06-08T15:55:22.030Z
<!-- /CLOUDFLARE_PREVIEW -->