### PR TITLE
[codex] Fix Cap'n Web REPL pipelining

### DIFF
--- a/apps/os/docs/doppler-backed-scripts.md
+++ b/apps/os/docs/doppler-backed-scripts.md
@@ -37,6 +37,15 @@ doppler run --config prd -- pnpm cli rpc --help
 doppler run --config preview_3 -- pnpm cli rpc --help
 ```
 
+Local operational commands should also live under `pnpm cli`, not as
+environment-pinning package scripts. For example, the Iterate config base
+Artifact repair command runs through the local script router:
+
+```bash
+pnpm cli artifacts seed-config-base
+doppler run --project os --config dev_jonas -- pnpm cli artifacts seed-config-base
+```
+
 Do not put `--project os` or `--config prd` in the default script. That makes
 plain local commands surprisingly target production and bypasses the user's
 local Doppler setup.

--- a/apps/os/package.json
+++ b/apps/os/package.json
@@ -31,7 +31,6 @@
     "test:project-mcp-server-connection": "OS_ITERATE_MCP_SERVER_TEST_APP_ROOT=$PWD pnpm --dir ../../packages/shared exec vitest run --config ../../apps/os/src/durable-objects/iterate-mcp-server.vitest.config.ts",
     "e2e": "vitest --config e2e/vitest.config.ts",
     "example:workspace-codemode-preview": "tsx ./e2e/workspace-codemode-preview-example.ts",
-    "artifacts:seed-config-base": "tsx ./scripts/seed-iterate-config-base-repo.ts",
     "auth:sync-clients": "tsx ./scripts/sync-auth-clients.ts",
     "benchmark:agent-stream": "tsx ./scripts/benchmark-agent-stream.ts",
     "benchmark:intercept-tunnel": "tsx ./scripts/benchmark-project-egress-intercept-tunnel.ts",

--- a/apps/os/scripts/router.ts
+++ b/apps/os/scripts/router.ts
@@ -5,6 +5,7 @@ import { os } from "@orpc/server";
 import { z } from "zod";
 
 import { claudeMcpScript } from "./claude-mcp.ts";
+import { seedIterateConfigBaseRepoScript } from "./seed-iterate-config-base-repo.ts";
 
 const DEFAULT_APP_CONFIG_BASE_URL = "https://os.iterate.com";
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
@@ -26,6 +27,9 @@ const StreamTuiInput = z.object({
 });
 
 export const router = os.router({
+  artifacts: {
+    "seed-config-base": seedIterateConfigBaseRepoScript,
+  },
   "claude-mcp": claudeMcpScript,
   "stream-tui": os
     .input(StreamTuiInput)

--- a/apps/os/scripts/seed-iterate-config-base-repo.ts
+++ b/apps/os/scripts/seed-iterate-config-base-repo.ts
@@ -6,6 +6,9 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { os as orpc } from "@orpc/server";
+import { z } from "zod";
+
 import { ITERATE_CONFIG_BASE_REPO_ARTIFACT_NAME } from "../src/domains/repos/iterate-config-repo.ts";
 import {
   REPO_DEFAULT_BRANCH,
@@ -24,6 +27,7 @@ type Options = {
   holderDir: string;
   namespace: string;
   repoName: string;
+  verifyFork: boolean;
 };
 
 type ArtifactRepoAccess = {
@@ -31,13 +35,60 @@ type ArtifactRepoAccess = {
   token?: string;
 };
 
-async function main() {
-  const options = parseOptions(process.argv.slice(2));
+const SeedConfigBaseInput = z.object({
+  accountId: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe("Cloudflare account ID. Defaults to CLOUDFLARE_ACCOUNT_ID."),
+  apiToken: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe(
+      "Cloudflare API token. Defaults to CLOUDFLARE_API_TOKEN_DEV_JONAS or CLOUDFLARE_API_TOKEN.",
+    ),
+  holder: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe("Source directory. Defaults to apps/os/iterate-config-repo."),
+  namespace: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe("Cloudflare Artifacts namespace. Defaults to the active Doppler/Alchemy stage."),
+  repo: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe("Base Artifact repo name. Defaults to iterate-config-base."),
+  verifyFork: z
+    .boolean()
+    .default(true)
+    .describe("Create and delete a temporary fork to prove project setup can fork the base repo."),
+});
+
+export const seedIterateConfigBaseRepoScript = orpc
+  .input(SeedConfigBaseInput)
+  .meta({
+    description:
+      "Seed the Iterate config base Artifact repo and verify that new project artifact forks work",
+  })
+  .handler(async ({ input }) => seedIterateConfigBaseRepoForCli(resolveOptions(input)));
+
+async function seedIterateConfigBaseRepoForCli(options: Options) {
   const holderDir = path.resolve(options.holderDir);
   if (!fs.existsSync(holderDir) || !fs.statSync(holderDir).isDirectory()) {
     throw new Error(`Iterate config repo holder is not a directory: ${holderDir}`);
   }
 
+  console.info(`Using Cloudflare Artifacts namespace ${options.namespace}`);
   const artifact = await getOrCreateArtifactRepo(options);
   const token = artifact.token ?? (await createArtifactToken(options));
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "iterate-config-base-"));
@@ -53,41 +104,40 @@ async function main() {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 
-  console.info(`Seeded ${options.namespace}/${options.repoName} from ${holderDir}`);
-}
+  await verifyArtifactGitAccess({
+    remote: artifact.remote,
+    repoName: options.repoName,
+    token,
+  });
 
-function parseOptions(args: string[]): Options {
-  const values = new Map<string, string>();
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    if (arg === "--") continue;
-    if (!arg?.startsWith("--")) {
-      throw new Error(`Unexpected argument: ${arg ?? ""}`);
-    }
-
-    const value = args[index + 1];
-    if (!value || value.startsWith("--")) {
-      throw new Error(`Missing value for ${arg}`);
-    }
-
-    values.set(arg.slice(2), value);
-    index += 1;
+  if (options.verifyFork) {
+    await verifyArtifactFork(options);
   }
 
+  console.info(`Seeded ${options.namespace}/${options.repoName} from ${holderDir}`);
   return {
-    accountId: values.get("account-id") ?? requireEnv("CLOUDFLARE_ACCOUNT_ID"),
+    namespace: options.namespace,
+    repo: options.repoName,
+    verifiedFork: options.verifyFork,
+  };
+}
+
+function resolveOptions(input: z.infer<typeof SeedConfigBaseInput>): Options {
+  return {
+    accountId: input.accountId ?? requireEnv("CLOUDFLARE_ACCOUNT_ID"),
     apiToken:
-      values.get("api-token") ??
+      input.apiToken ??
       process.env.CLOUDFLARE_API_TOKEN_DEV_JONAS ??
       requireEnv("CLOUDFLARE_API_TOKEN"),
-    holderDir: values.get("holder") ?? DEFAULT_HOLDER_DIR,
+    holderDir: input.holder ?? DEFAULT_HOLDER_DIR,
     namespace:
-      values.get("namespace") ??
+      input.namespace ??
       process.env.OS_ARTIFACTS_NAMESPACE ??
       inferArtifactsNamespaceFromAlchemyStage() ??
       inferArtifactsNamespaceFromBaseUrl() ??
       requireEnv("OS_ARTIFACTS_NAMESPACE"),
-    repoName: values.get("repo") ?? ITERATE_CONFIG_BASE_REPO_ARTIFACT_NAME,
+    repoName: input.repo ?? ITERATE_CONFIG_BASE_REPO_ARTIFACT_NAME,
+    verifyFork: input.verifyFork,
   };
 }
 
@@ -156,6 +206,69 @@ async function createArtifactToken(options: Options): Promise<string> {
   }
 
   return readToken(token.result ?? token);
+}
+
+async function verifyArtifactFork(options: Options) {
+  const forkName = `${options.repoName}-verify-${Date.now()}-${process.pid}`;
+  let forkCreated = false;
+  try {
+    const forked = await forkArtifactRepo(options, forkName);
+    forkCreated = true;
+    const token = await createArtifactToken({ ...options, repoName: forkName });
+    await verifyArtifactGitAccess({
+      remote: forked.remote,
+      repoName: forkName,
+      token,
+    });
+    console.info(`Verified fork ${options.namespace}/${forkName}`);
+  } finally {
+    if (forkCreated) {
+      await deleteArtifactRepo(options, forkName);
+    }
+  }
+}
+
+async function forkArtifactRepo(options: Options, forkName: string): Promise<ArtifactRepoAccess> {
+  const forked = await artifactsApi(
+    options,
+    "POST",
+    `/repos/${encodeURIComponent(options.repoName)}/fork`,
+    {
+      default_branch_only: true,
+      description: `Temporary fork verification for ${options.repoName}`,
+      name: forkName,
+      read_only: false,
+    },
+  );
+  if (!forked.success) {
+    throw new Error(`Failed to fork Artifact repo: ${JSON.stringify(forked)}`);
+  }
+
+  return readArtifactRepoAccess(forked.result ?? forked);
+}
+
+async function deleteArtifactRepo(options: Options, repoName: string) {
+  const deleted = await artifactsApi(options, "DELETE", `/repos/${encodeURIComponent(repoName)}`);
+  if (!deleted.success) {
+    throw new Error(`Failed to delete verification Artifact repo: ${JSON.stringify(deleted)}`);
+  }
+}
+
+async function verifyArtifactGitAccess(input: { remote: string; repoName: string; token: string }) {
+  try {
+    const refs = execFileSync("git", ["ls-remote", input.remote, "HEAD"], {
+      encoding: "utf8",
+      env: gitAuthEnv(input.token),
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+    if (!refs) {
+      throw new Error("git ls-remote returned no refs");
+    }
+    console.info(`Verified Git access for ${input.repoName}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Could not verify Git access for ${input.repoName}: ${message}`);
+  }
 }
 
 async function artifactsApi(
@@ -241,6 +354,15 @@ function runGit(cwd: string, args: string[]) {
   execFileSync("git", args, { cwd, stdio: "inherit" });
 }
 
+function gitAuthEnv(token: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    GIT_CONFIG_COUNT: "1",
+    GIT_CONFIG_KEY_0: "http.extraHeader",
+    GIT_CONFIG_VALUE_0: `Authorization: Bearer ${token}`,
+  };
+}
+
 function remoteWithToken(input: { remote: string; token: string }) {
   const url = new URL(input.remote);
   url.username = "x";
@@ -283,5 +405,3 @@ function requireEnv(name: string) {
 
   return value;
 }
-
-await main();

--- a/apps/os/src/capnweb/README.md
+++ b/apps/os/src/capnweb/README.md
@@ -13,14 +13,10 @@ The design goal is a single scoped capability tree that can be used from:
 The same authoring model should work everywhere:
 
 ```ts
-using project = await ctx.project;
-using workspace = await project.workspace;
-using git = await workspace.git;
-await git.add({ dir, filepath: "worker.js" });
-await git.push({ dir, remote: "origin", ref });
+await ctx.project.workspace.git.add({ dir, filepath: "worker.js" });
+await ctx.project.workspace.git.push({ dir, remote: "origin", ref });
 
-using worker = await project.worker;
-await worker.someTool({ value: 1 });
+await ctx.project.worker.someTool({ value: 1 });
 ```
 
 ## Entrypoints
@@ -153,8 +149,7 @@ Default `invoke` is `"target"`:
   target: { type: "dynamic-worker", script: toolsWorkerSource },
 }
 
-using tools = await ctx.tools;
-await tools.echo({ text: "hi" });
+await ctx.tools.echo({ text: "hi" });
 ```
 
 Use `invoke: "method"` when the mount itself should be callable:
@@ -200,9 +195,8 @@ export default class Worker extends WorkerEntrypoint {
   }
 
   async postDailyReport(input) {
-    const ctx = await this.env.ITERATE.context;
-    using slack = await ctx.slack;
-    return await slack.chat.postMessage(input);
+    const ctx = liftLocalProxies(await this.env.ITERATE.context);
+    return await ctx.slack.chat.postMessage(input);
   }
 }
 ```
@@ -256,8 +250,7 @@ export default class SlackTarget extends WorkerEntrypoint {
 Mounted with `call: ["sdk"]`, this lets callers write:
 
 ```ts
-using slack = await ctx.slack;
-await slack.chat.postMessage({ channel: "C123", text: "hi" });
+await ctx.slack.chat.postMessage({ channel: "C123", text: "hi" });
 ```
 
 Only marker values get this local path-proxy behavior. Normal Cap'n Web and
@@ -283,7 +276,7 @@ function with `{ ctx, env, vars }` and exits:
 ```bash
 doppler run --project os --config preview_5 -- pnpm exec tsx src/capnweb/cli.ts \
   --project-id proj_123 \
-  -e 'async ({ ctx }) => await (await ctx.project).describe()'
+  -e 'async ({ ctx }) => await ctx.project.describe()'
 ```
 
 `src/capnweb/repl.ts` is the persistent Node REPL. It opens the same Cap'n Web
@@ -295,8 +288,7 @@ doppler run --project os --config preview_5 -- pnpm exec tsx src/capnweb/repl.ts
 ```
 
 ```js
-using project = await ctx.project;
-await project.describe();
+await ctx.project.describe();
 let stream = new ReadableStream();
 stream instanceof ReadableStream;
 ```

--- a/apps/os/src/capnweb/browser-repl.test.ts
+++ b/apps/os/src/capnweb/browser-repl.test.ts
@@ -1,6 +1,7 @@
 import { RpcStub, RpcTarget } from "capnweb";
 import { describe, expect, test, vi } from "vitest";
 import {
+  BROWSER_REPL_EXAMPLES,
   DEFAULT_BROWSER_REPL_CODE,
   evalBrowserReplCode,
   evalBrowserReplSessionCode,
@@ -48,5 +49,46 @@ describe("browser Cap'n Web REPL", () => {
         scope,
       }),
     ).resolves.toBe(42);
+  });
+
+  test("provideCapability example registers and calls a browser-owned target", async () => {
+    const providedTargets = new Map<string, unknown>();
+    const alert = vi.fn();
+    const project = {
+      connections: {
+        get(connectionKey: string) {
+          return providedTargets.get(connectionKey);
+        },
+      },
+      provideCapability(input: { connectionKey: string; rpcTarget: unknown }) {
+        providedTargets.set(input.connectionKey, input.rpcTarget);
+        return { connectionKey: input.connectionKey, ok: true };
+      },
+    };
+    const ctx = {
+      projects: {
+        get(projectId: string) {
+          if (projectId !== "proj_123") throw new Error(`Unexpected project ${projectId}`);
+          return project;
+        },
+        list() {
+          return { projects: [{ id: "proj_123" }], total: 1 };
+        },
+      },
+    };
+
+    const example = BROWSER_REPL_EXAMPLES.find((candidate) => {
+      return candidate.id === "provide-alert-capability";
+    });
+    if (!example) throw new Error("Missing provideCapability browser REPL example.");
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: example.code,
+        ctx,
+        scope: { alert, RpcTarget },
+      }),
+    ).resolves.toBe("alerted");
+    expect(alert).toHaveBeenCalledWith("The answer is 42");
   });
 });

--- a/apps/os/src/capnweb/browser-repl.test.ts
+++ b/apps/os/src/capnweb/browser-repl.test.ts
@@ -49,6 +49,42 @@ describe("browser Cap'n Web REPL", () => {
         scope,
       }),
     ).resolves.toBe(42);
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: "const secondAnswer = answer + 1",
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: "secondAnswer",
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toBe(42);
+  });
+
+  test("session snippets persist multiple top-level variables across lines", async () => {
+    const scope: Record<string, unknown> = {};
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: "const first = 20\nconst second = 22",
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: "first + second",
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toBe(42);
   });
 
   test("session snippets persist function and class declarations", async () => {
@@ -98,6 +134,29 @@ describe("browser Cap'n Web REPL", () => {
         scope,
       }),
     ).resolves.toBe(42);
+  });
+
+  test("session snippets do not rewrite nested local declarations", async () => {
+    const scope: Record<string, unknown> = {};
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: `
+function answer() {
+  const nested = 42;
+  return nested;
+}
+if (answer() !== 42) throw new Error("nested local declaration broke");
+const persisted = answer();
+`.trim(),
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(scope).toHaveProperty("answer");
+    expect(scope).toHaveProperty("persisted", 42);
+    expect(scope).not.toHaveProperty("nested");
   });
 
   test("session snippets cannot shadow injected ctx or env bindings", async () => {

--- a/apps/os/src/capnweb/browser-repl.test.ts
+++ b/apps/os/src/capnweb/browser-repl.test.ts
@@ -1,6 +1,10 @@
 import { RpcStub, RpcTarget } from "capnweb";
 import { describe, expect, test, vi } from "vitest";
-import { DEFAULT_BROWSER_REPL_CODE, evalBrowserReplCode } from "./browser-repl.ts";
+import {
+  DEFAULT_BROWSER_REPL_CODE,
+  evalBrowserReplCode,
+  evalBrowserReplSessionCode,
+} from "./browser-repl.ts";
 import { liftLocalProxies } from "./local-proxy-wrapper.js";
 
 describe("browser Cap'n Web REPL", () => {
@@ -24,5 +28,25 @@ describe("browser Cap'n Web REPL", () => {
       items: [{ id: "proj_123" }],
     });
     expect(list).toHaveBeenCalledWith({ limit: 5 });
+  });
+
+  test("session snippets can reference previous local variables", async () => {
+    const scope: Record<string, unknown> = {};
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: "const answer = 41",
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: "answer + 1",
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toBe(42);
   });
 });

--- a/apps/os/src/capnweb/browser-repl.test.ts
+++ b/apps/os/src/capnweb/browser-repl.test.ts
@@ -51,6 +51,86 @@ describe("browser Cap'n Web REPL", () => {
     ).resolves.toBe(42);
   });
 
+  test("session snippets persist function and class declarations", async () => {
+    const scope: Record<string, unknown> = {};
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: "function answer() { return 42; }",
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      evalBrowserReplSessionCode({
+        code: "answer()",
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toBe(42);
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: "class Box { value() { return answer(); } }",
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      evalBrowserReplSessionCode({
+        code: "new Box().value()",
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toBe(42);
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: "async function asyncAnswer() { return answer(); }",
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      evalBrowserReplSessionCode({
+        code: "await asyncAnswer()",
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toBe(42);
+  });
+
+  test("session snippets cannot shadow injected ctx or env bindings", async () => {
+    const scope: Record<string, unknown> = {};
+    const ctx = { marker: "injected ctx" };
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: "const ctx = { marker: 'shadowed' }",
+        ctx,
+        scope,
+      }),
+    ).rejects.toThrow('REPL binding "ctx" is reserved.');
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: "ctx.marker",
+        ctx,
+        scope,
+      }),
+    ).resolves.toBe("injected ctx");
+    expect(scope).not.toHaveProperty("ctx");
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: "function env() {}",
+        ctx,
+        scope,
+      }),
+    ).rejects.toThrow('REPL binding "env" is reserved.');
+    expect(scope).not.toHaveProperty("env");
+  });
+
   test("provideCapability example registers and calls a browser-owned target", async () => {
     const providedTargets = new Map<string, unknown>();
     const alert = vi.fn();

--- a/apps/os/src/capnweb/browser-repl.test.ts
+++ b/apps/os/src/capnweb/browser-repl.test.ts
@@ -1,0 +1,28 @@
+import { RpcStub, RpcTarget } from "capnweb";
+import { describe, expect, test, vi } from "vitest";
+import { DEFAULT_BROWSER_REPL_CODE, evalBrowserReplCode } from "./browser-repl.ts";
+import { liftLocalProxies } from "./local-proxy-wrapper.js";
+
+describe("browser Cap'n Web REPL", () => {
+  test("default snippet uses Cap'n Web promise pipelining", async () => {
+    const list = vi.fn().mockResolvedValue({ items: [{ id: "proj_123" }] });
+    class Projects extends RpcTarget {
+      list(input: { limit: number }) {
+        return list(input);
+      }
+    }
+
+    class Context extends RpcTarget {
+      get projects() {
+        return new Projects();
+      }
+    }
+
+    const ctx = liftLocalProxies(new RpcStub(new Context()));
+
+    await expect(evalBrowserReplCode({ code: DEFAULT_BROWSER_REPL_CODE, ctx })).resolves.toEqual({
+      items: [{ id: "proj_123" }],
+    });
+    expect(list).toHaveBeenCalledWith({ limit: 5 });
+  });
+});

--- a/apps/os/src/capnweb/browser-repl.ts
+++ b/apps/os/src/capnweb/browser-repl.ts
@@ -1,0 +1,27 @@
+export const DEFAULT_BROWSER_REPL_CODE = "await ctx.projects.list({ limit: 5 })";
+
+export async function evalBrowserReplCode(input: { code: string; ctx: unknown; env?: object }) {
+  return await compileBrowserReplFunction(input.code)(input.ctx, input.env ?? {});
+}
+
+export function compileBrowserReplFunction(code: string) {
+  try {
+    // oxlint-disable-next-line no-new-func -- This helper backs the explicit browser-local REPL.
+    return new Function("ctx", "env", `return (async () => (${code}))()`) as ReplFunction;
+  } catch {
+    // oxlint-disable-next-line no-new-func -- Statement-mode fallback for the explicit browser-local REPL.
+    return new Function("ctx", "env", `return (async () => {${code}})()`) as ReplFunction;
+  }
+}
+
+type ReplFunction = (ctx: unknown, env: object) => Promise<unknown>;
+
+export function formatBrowserReplResult(result: unknown) {
+  if (result === undefined) return "undefined";
+  if (typeof result === "string") return result;
+  try {
+    return JSON.stringify(result, null, 2);
+  } catch {
+    return String(result);
+  }
+}

--- a/apps/os/src/capnweb/browser-repl.ts
+++ b/apps/os/src/capnweb/browser-repl.ts
@@ -92,26 +92,164 @@ function startsWithTopLevelDeclaration(code: string) {
 }
 
 function transformTopLevelDeclarations(code: string) {
-  return code
-    .replace(
-      /(^|[;\n]\s*)(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=/g,
-      (_match, prefix: string, name: string) => `${prefix}${scopeAssignmentTarget(name)} =`,
-    )
-    .replace(
-      /(^|[;\n]\s*)async\s+function\s+([A-Za-z_$][\w$]*)\s*\(/g,
-      (_match, prefix: string, name: string) =>
-        `${prefix}${scopeAssignmentTarget(name)} = async function ${name}(`,
-    )
-    .replace(
-      /(^|[;\n]\s*)function\s+([A-Za-z_$][\w$]*)\s*\(/g,
-      (_match, prefix: string, name: string) =>
-        `${prefix}${scopeAssignmentTarget(name)} = function ${name}(`,
-    )
-    .replace(
-      /(^|[;\n]\s*)class\s+([A-Za-z_$][\w$]*)\b/g,
-      (_match, prefix: string, name: string) =>
-        `${prefix}${scopeAssignmentTarget(name)} = class ${name}`,
-    );
+  const replacements: Array<{ end: number; start: number; text: string }> = [];
+  let state:
+    | "code"
+    | "line-comment"
+    | "block-comment"
+    | "single-quote"
+    | "double-quote"
+    | "template" = "code";
+  let braceDepth = 0;
+  let bracketDepth = 0;
+  let parenDepth = 0;
+
+  for (let index = 0; index < code.length; index += 1) {
+    const char = code[index];
+    const next = code[index + 1];
+
+    if (state === "line-comment") {
+      if (char === "\n") state = "code";
+      continue;
+    }
+    if (state === "block-comment") {
+      if (char === "*" && next === "/") {
+        state = "code";
+        index += 1;
+      }
+      continue;
+    }
+    if (state === "single-quote") {
+      if (char === "\\") index += 1;
+      else if (char === "'") state = "code";
+      continue;
+    }
+    if (state === "double-quote") {
+      if (char === "\\") index += 1;
+      else if (char === '"') state = "code";
+      continue;
+    }
+    if (state === "template") {
+      if (char === "\\") index += 1;
+      else if (char === "`") state = "code";
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      state = "line-comment";
+      index += 1;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      state = "block-comment";
+      index += 1;
+      continue;
+    }
+    if (char === "'") {
+      state = "single-quote";
+      continue;
+    }
+    if (char === '"') {
+      state = "double-quote";
+      continue;
+    }
+    if (char === "`") {
+      state = "template";
+      continue;
+    }
+
+    if (char === "{") braceDepth += 1;
+    else if (char === "}") braceDepth = Math.max(0, braceDepth - 1);
+    else if (char === "[") bracketDepth += 1;
+    else if (char === "]") bracketDepth = Math.max(0, bracketDepth - 1);
+    else if (char === "(") parenDepth += 1;
+    else if (char === ")") parenDepth = Math.max(0, parenDepth - 1);
+
+    if (braceDepth !== 0 || bracketDepth !== 0 || parenDepth !== 0) continue;
+    if (!isTopLevelStatementBoundary(code, index)) continue;
+
+    const replacement = readTopLevelDeclarationReplacement(code, index);
+    if (!replacement) continue;
+
+    replacements.push(replacement);
+    index = replacement.end - 1;
+  }
+
+  let transformed = code;
+  for (const replacement of replacements.toReversed()) {
+    transformed =
+      transformed.slice(0, replacement.start) +
+      replacement.text +
+      transformed.slice(replacement.end);
+  }
+
+  return transformed;
+}
+
+function readTopLevelDeclarationReplacement(
+  code: string,
+  index: number,
+): { end: number; start: number; text: string } | null {
+  const source = code.slice(index);
+  const variable = /^(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=/.exec(source);
+  if (variable?.[1]) {
+    const equalsIndex = index + variable[0].length - 1;
+    return {
+      start: index,
+      end: equalsIndex,
+      text: `${scopeAssignmentTarget(variable[1])} `,
+    };
+  }
+
+  const asyncFunction = /^async\s+function\s+([A-Za-z_$][\w$]*)\s*\(/.exec(source);
+  if (asyncFunction?.[1]) {
+    const parenIndex = index + asyncFunction[0].length - 1;
+    return {
+      start: index,
+      end: parenIndex,
+      text: `${scopeAssignmentTarget(asyncFunction[1])} = async function ${asyncFunction[1]}`,
+    };
+  }
+
+  const namedFunction = /^function\s+([A-Za-z_$][\w$]*)\s*\(/.exec(source);
+  if (namedFunction?.[1]) {
+    const parenIndex = index + namedFunction[0].length - 1;
+    return {
+      start: index,
+      end: parenIndex,
+      text: `${scopeAssignmentTarget(namedFunction[1])} = function ${namedFunction[1]}`,
+    };
+  }
+
+  const namedClass = /^class\s+([A-Za-z_$][\w$]*)\b/.exec(source);
+  if (namedClass?.[1]) {
+    return {
+      start: index,
+      end: index + namedClass[0].length,
+      text: `${scopeAssignmentTarget(namedClass[1])} = class ${namedClass[1]}`,
+    };
+  }
+
+  return null;
+}
+
+function isTopLevelStatementBoundary(code: string, index: number) {
+  if (!isIdentifierStart(code[index] ?? "")) return false;
+
+  let previous = index - 1;
+  let crossedLineBreak = false;
+  while (previous >= 0 && /\s/.test(code[previous] ?? "")) {
+    crossedLineBreak ||= code[previous] === "\n" || code[previous] === "\r";
+    previous -= 1;
+  }
+  if (previous < 0) return true;
+  if (crossedLineBreak) return true;
+
+  return [";", "}"].includes(code[previous] ?? "");
+}
+
+function isIdentifierStart(value: string) {
+  return /^[A-Za-z_$]$/.test(value);
 }
 
 function scopeAssignmentTarget(name: string) {

--- a/apps/os/src/capnweb/browser-repl.ts
+++ b/apps/os/src/capnweb/browser-repl.ts
@@ -1,20 +1,48 @@
 export const DEFAULT_BROWSER_REPL_CODE = "await ctx.projects.list({ limit: 5 })";
 
 export async function evalBrowserReplCode(input: { code: string; ctx: unknown; env?: object }) {
-  return await compileBrowserReplFunction(input.code)(input.ctx, input.env ?? {});
+  return await compileBrowserReplFunction(input.code)(input.ctx, input.env ?? {}, {});
+}
+
+export async function evalBrowserReplSessionCode(input: {
+  code: string;
+  ctx: unknown;
+  env?: object;
+  scope: Record<string, unknown>;
+}) {
+  return await compileBrowserReplFunction(input.code)(input.ctx, input.env ?? {}, input.scope);
 }
 
 export function compileBrowserReplFunction(code: string) {
+  const expressionSource = `return (async () => (${code}))()`;
   try {
     // oxlint-disable-next-line no-new-func -- This helper backs the explicit browser-local REPL.
-    return new Function("ctx", "env", `return (async () => (${code}))()`) as ReplFunction;
+    return new Function(
+      "ctx",
+      "env",
+      "scope",
+      `with (scope) { ${expressionSource} }`,
+    ) as ReplFunction;
   } catch {
+    const statementSource = transformTopLevelDeclarations(code);
     // oxlint-disable-next-line no-new-func -- Statement-mode fallback for the explicit browser-local REPL.
-    return new Function("ctx", "env", `return (async () => {${code}})()`) as ReplFunction;
+    return new Function(
+      "ctx",
+      "env",
+      "scope",
+      `with (scope) { return (async () => {${statementSource}})() }`,
+    ) as ReplFunction;
   }
 }
 
-type ReplFunction = (ctx: unknown, env: object) => Promise<unknown>;
+type ReplFunction = (ctx: unknown, env: object, scope: Record<string, unknown>) => Promise<unknown>;
+
+function transformTopLevelDeclarations(code: string) {
+  return code
+    .replace(/(^|[;\n]\s*)(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=/g, "$1scope.$2 =")
+    .replace(/(^|[;\n]\s*)function\s+([A-Za-z_$][\w$]*)\s*\(/g, "$1scope.$2 = function (")
+    .replace(/(^|[;\n]\s*)class\s+([A-Za-z_$][\w$]*)\b/g, "$1scope.$2 = class $2");
+}
 
 export function formatBrowserReplResult(result: unknown) {
   if (result === undefined) return "undefined";

--- a/apps/os/src/capnweb/browser-repl.ts
+++ b/apps/os/src/capnweb/browser-repl.ts
@@ -1,5 +1,45 @@
 export const DEFAULT_BROWSER_REPL_CODE = "await ctx.projects.list({ limit: 5 })";
 
+export type BrowserReplExample = {
+  code: string;
+  description: string;
+  id: string;
+  title: string;
+};
+
+// These are intentionally ordinary REPL snippets for now. They should
+// eventually become living tests: the actual e2e test snippets appear here, and
+// this replaces codemode snippets entirely.
+export const BROWSER_REPL_EXAMPLES: BrowserReplExample[] = [
+  {
+    id: "provide-alert-capability",
+    title: "Provide and call a project capability",
+    description:
+      "Registers a browser-owned RpcTarget with a project, then immediately calls it back through ctx.projects.get(...).connections.",
+    code: `
+const projectPage = await ctx.projects.list({ limit: 1 });
+const selectedProjectId =
+  typeof projectId === "string" ? projectId : projectPage.projects[0]?.id;
+if (!selectedProjectId) throw new Error("Create a project before running this snippet.");
+const project = ctx.projects.get(selectedProjectId);
+
+class AnswerCapability extends RpcTarget {
+  async run() {
+    alert("The answer is 42");
+    return "alerted";
+  }
+}
+
+await project.provideCapability({
+  connectionKey: "answer",
+  rpcTarget: new AnswerCapability(),
+});
+
+return await project.connections.get("answer").run();
+`.trim(),
+  },
+];
+
 export async function evalBrowserReplCode(input: { code: string; ctx: unknown; env?: object }) {
   return await compileBrowserReplFunction(input.code)(input.ctx, input.env ?? {}, {});
 }

--- a/apps/os/src/capnweb/browser-repl.ts
+++ b/apps/os/src/capnweb/browser-repl.ts
@@ -54,6 +54,10 @@ export async function evalBrowserReplSessionCode(input: {
 }
 
 export function compileBrowserReplFunction(code: string) {
+  if (startsWithTopLevelDeclaration(code)) {
+    return compileBrowserReplStatements(code);
+  }
+
   const expressionSource = `return (async () => (${code}))()`;
   try {
     // oxlint-disable-next-line no-new-func -- This helper backs the explicit browser-local REPL.
@@ -64,24 +68,58 @@ export function compileBrowserReplFunction(code: string) {
       `with (scope) { ${expressionSource} }`,
     ) as ReplFunction;
   } catch {
-    const statementSource = transformTopLevelDeclarations(code);
-    // oxlint-disable-next-line no-new-func -- Statement-mode fallback for the explicit browser-local REPL.
-    return new Function(
-      "ctx",
-      "env",
-      "scope",
-      `with (scope) { return (async () => {${statementSource}})() }`,
-    ) as ReplFunction;
+    return compileBrowserReplStatements(code);
   }
 }
 
 type ReplFunction = (ctx: unknown, env: object, scope: Record<string, unknown>) => Promise<unknown>;
 
+const RESERVED_TOP_LEVEL_BINDINGS = new Set(["ctx", "env", "scope"]);
+
+function compileBrowserReplStatements(code: string) {
+  const statementSource = transformTopLevelDeclarations(code);
+  // oxlint-disable-next-line no-new-func -- Statement-mode fallback for the explicit browser-local REPL.
+  return new Function(
+    "ctx",
+    "env",
+    "scope",
+    `with (scope) { return (async () => {${statementSource}})() }`,
+  ) as ReplFunction;
+}
+
+function startsWithTopLevelDeclaration(code: string) {
+  return /^\s*(?:async\s+function|function|class)\s+[A-Za-z_$][\w$]*/.test(code);
+}
+
 function transformTopLevelDeclarations(code: string) {
   return code
-    .replace(/(^|[;\n]\s*)(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=/g, "$1scope.$2 =")
-    .replace(/(^|[;\n]\s*)function\s+([A-Za-z_$][\w$]*)\s*\(/g, "$1scope.$2 = function (")
-    .replace(/(^|[;\n]\s*)class\s+([A-Za-z_$][\w$]*)\b/g, "$1scope.$2 = class $2");
+    .replace(
+      /(^|[;\n]\s*)(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=/g,
+      (_match, prefix: string, name: string) => `${prefix}${scopeAssignmentTarget(name)} =`,
+    )
+    .replace(
+      /(^|[;\n]\s*)async\s+function\s+([A-Za-z_$][\w$]*)\s*\(/g,
+      (_match, prefix: string, name: string) =>
+        `${prefix}${scopeAssignmentTarget(name)} = async function ${name}(`,
+    )
+    .replace(
+      /(^|[;\n]\s*)function\s+([A-Za-z_$][\w$]*)\s*\(/g,
+      (_match, prefix: string, name: string) =>
+        `${prefix}${scopeAssignmentTarget(name)} = function ${name}(`,
+    )
+    .replace(
+      /(^|[;\n]\s*)class\s+([A-Za-z_$][\w$]*)\b/g,
+      (_match, prefix: string, name: string) =>
+        `${prefix}${scopeAssignmentTarget(name)} = class ${name}`,
+    );
+}
+
+function scopeAssignmentTarget(name: string) {
+  if (RESERVED_TOP_LEVEL_BINDINGS.has(name)) {
+    throw new Error(`REPL binding ${JSON.stringify(name)} is reserved.`);
+  }
+
+  return `scope.${name}`;
 }
 
 export function formatBrowserReplResult(result: unknown) {

--- a/apps/os/src/capnweb/cli.ts
+++ b/apps/os/src/capnweb/cli.ts
@@ -59,7 +59,7 @@ function parseJsonObject(value: string) {
 
 function printUsage() {
   console.log(`Usage:
-  doppler run -- pnpm exec tsx src/capnweb/cli.ts --project-id <proj_...> -e "async ({ ctx }) => await (await ctx.project).describe()"
-  doppler run -- pnpm exec tsx src/capnweb/cli.ts -e "async ({ ctx }) => await (await ctx.projects).list()"
+  doppler run -- pnpm exec tsx src/capnweb/cli.ts --project-id <proj_...> -e "async ({ ctx }) => await ctx.project.describe()"
+  doppler run -- pnpm exec tsx src/capnweb/cli.ts -e "async ({ ctx }) => await ctx.projects.list()"
 `);
 }

--- a/apps/os/src/capnweb/e2e/captnweb-scripts.ts
+++ b/apps/os/src/capnweb/e2e/captnweb-scripts.ts
@@ -65,20 +65,19 @@ export default {
     const eventType = url.searchParams.get("eventType");
     const marker = url.searchParams.get("marker");
     const executionMode = url.searchParams.get("executionMode");
-    using streams = await ctx.streams;
-    const beforeStreams = await streams.list();
+    const beforeStreams = await ctx.streams.list();
     const listUntilStreamAppears = async () => {
       for (let attempt = 0; attempt < 8; attempt++) {
-        const listedStreams = await streams.list();
+        const listedStreams = await ctx.streams.list();
         if (listedStreams.some((stream) => stream.streamPath === streamPath)) {
           return listedStreams;
         }
         // Deployed stream listing can lag a successful append/read by a short interval.
         await new Promise((resolve) => setTimeout(resolve, 250));
       }
-      return streams.list();
+      return ctx.streams.list();
     };
-    const appended = await streams.append({
+    const appended = await ctx.streams.append({
       streamPath,
       event: {
         type: eventType,
@@ -86,7 +85,7 @@ export default {
       },
     });
     const afterStreams = await listUntilStreamAppears();
-    const events = await streams.read({ afterOffset: "start", streamPath });
+    const events = await ctx.streams.read({ afterOffset: "start", streamPath });
     return Response.json({
       appended: {
         eventType: appended.type,
@@ -124,9 +123,10 @@ export default {
 export const describeProjectThroughProjects = capnwebScript
   .vars<{ executionMode: string; projectId: string }>()
   .define(async ({ ctx, vars }) => {
-    using projects = await ctx.projects;
-    using project = await projects.get(vars.projectId);
-    return { ...(await project.describe()), executionMode: vars.executionMode };
+    return {
+      ...(await ctx.projects.get(vars.projectId).describe()),
+      executionMode: vars.executionMode,
+    };
   });
 
 /**
@@ -145,15 +145,14 @@ export const appendAndReadProjectStream = capnwebScript
     streamPath: string;
   }>()
   .define(async ({ ctx, vars }) => {
-    using streams = await ctx.streams;
-    const appended = await streams.append({
+    const appended = await ctx.streams.append({
       event: {
         type: vars.eventType,
         payload: { executionMode: vars.executionMode, marker: vars.marker },
       },
       streamPath: vars.streamPath,
     });
-    const events = await streams.read({ afterOffset: "start", streamPath: vars.streamPath });
+    const events = await ctx.streams.read({ afterOffset: "start", streamPath: vars.streamPath });
     return { appended, events, executionMode: vars.executionMode };
   });
 
@@ -168,12 +167,11 @@ export const appendAndReadProjectStream = capnwebScript
 export const callProjectConnection = capnwebScript
   .vars<{ connectionKey: string; methodName: string; source: string }>()
   .define(async ({ ctx, vars }) => {
-    using project = await ctx.project;
-    using connections = await project.connections;
-    using connection = await connections.get(vars.connectionKey);
     // The built-in type proves `ctx.project.connections` exists. The method name
     // is intentionally provided by the test-owned RpcTarget at runtime.
-    return await (connection as Record<string, any>)[vars.methodName]({ source: vars.source });
+    return await (ctx.project.connections.get(vars.connectionKey) as any)[vars.methodName]({
+      source: vars.source,
+    });
   });
 
 /**
@@ -194,37 +192,32 @@ export const updateIterateConfigAndCallWorker = capnwebScript
     workerSource: string;
   }>()
   .define(async ({ ctx, vars }) => {
-    using project = await ctx.project;
-    using repos = await project.repos;
-    using workspace = await project.workspace;
     // This is the intended project-scoped git path for codemode and tests:
     // the IterateContext shortcut resolves to ctx.projects.get(id).
-    using git = await workspace.git;
-    const repo = await repos.ensureIterateConfigInfo({ projectSlug: null });
+    const repo = await ctx.project.repos.ensureIterateConfigInfo({ projectSlug: null });
 
-    await git.clone({
+    await ctx.project.workspace.git.clone({
       branch: repo.defaultBranch,
       depth: 1,
       dir: vars.dir,
       url: repo.remote,
       ...repo.credentials,
     });
-    await workspace.writeFile(vars.dir + "/worker.js", vars.workerSource);
-    await git.add({ dir: vars.dir, filepath: "worker.js" });
-    await git.commit({
+    await ctx.project.workspace.writeFile(vars.dir + "/worker.js", vars.workerSource);
+    await ctx.project.workspace.git.add({ dir: vars.dir, filepath: "worker.js" });
+    await ctx.project.workspace.git.commit({
       author: { name: "Capnweb", email: "captnweb-e2e@iterate.com" },
       dir: vars.dir,
       message: `Add capnweb worker proof from ${vars.executionMode}`,
     });
-    await git.push({
+    await ctx.project.workspace.git.push({
       dir: vars.dir,
       ref: repo.defaultBranch,
       remote: "origin",
       ...repo.credentials,
     });
 
-    using worker = (await project.worker) as any;
-    const calledTool = await worker.someFunction({
+    const calledTool = await (ctx.project.worker as any).someFunction({
       echo: vars.marker,
       executionMode: vars.executionMode,
     });
@@ -232,7 +225,7 @@ export const updateIterateConfigAndCallWorker = capnwebScript
     return {
       calledTool,
       executionMode: vars.executionMode,
-      project: await project.describe(),
+      project: await ctx.project.describe(),
       repoSlug: repo.slug,
       workspaceGitPath: "ctx.project.workspace.git",
     };
@@ -256,9 +249,7 @@ export const callUpdatedIterateConfigWorker = capnwebScript
     streamPath: string;
   }>()
   .define(async ({ ctx, vars }) => {
-    using project = await ctx.project;
-    using worker = (await project.worker) as any;
-    const streamFetchResponse = await worker.fetch(
+    const streamFetchResponse = await (ctx.project.worker as any).fetch(
       new Request(
         `https://iterate-config.local/capnweb-fetch/${vars.marker}?${new URLSearchParams({
           eventType: vars.eventType,
@@ -275,12 +266,14 @@ export const callUpdatedIterateConfigWorker = capnwebScript
     }
 
     const streamFetch = await streamFetchResponse.json();
-    const called = await worker.someFunction({
+    const called = await (ctx.project.worker as any).someFunction({
       echo: vars.marker,
       executionMode: vars.executionMode,
     });
-    using streams = await ctx.streams;
-    const streamEvents = await streams.read({ afterOffset: "start", streamPath: vars.streamPath });
+    const streamEvents = await ctx.streams.read({
+      afterOffset: "start",
+      streamPath: vars.streamPath,
+    });
 
     return { called, streamEvents, streamFetch };
   });
@@ -303,12 +296,11 @@ export const fetchAndEgressProject = capnwebScript
     secretKey: string;
   }>()
   .define(async ({ ctx, vars }) => {
-    using project = await ctx.project;
     const expectedHomepageText = "Hello from the project config worker";
     let ingress = { status: 0, text: "" };
     for (let attempt = 0; attempt < 12; attempt++) {
       // ctx.project.fetch is the Project Durable Object ingress fetch.
-      const response = await project.fetch(new Request(vars.ingressUrl + "/"));
+      const response = await ctx.project.fetch(new Request(vars.ingressUrl + "/"));
       ingress = {
         status: response.status,
         text: await response.text(),
@@ -327,7 +319,7 @@ export const fetchAndEgressProject = capnwebScript
     const secretReference = `Bearer getSecret({ key: ${JSON.stringify(vars.secretKey)} })`;
     // ctx.project.egressFetch is the Project Durable Object egress path,
     // including project secret substitution.
-    const egressResponse = await project.egressFetch(
+    const egressResponse = await ctx.project.egressFetch(
       new Request(vars.echoUrl, {
         headers: {
           authorization: `Bearer ${vars.echoAuthToken}`,

--- a/apps/os/src/capnweb/e2e/captnweb-slack-sdk.e2e.test.ts
+++ b/apps/os/src/capnweb/e2e/captnweb-slack-sdk.e2e.test.ts
@@ -92,8 +92,7 @@ describe("capnweb Slack SDK mount proof", () => {
         workerSource,
       });
 
-      using worker = (await projectContext.worker) as any;
-      const result = await worker.postDailyReport({
+      const result = await (projectContext.worker as any).postDailyReport({
         channel: "CFAKE",
         text: "daily report from iterate-config",
       });
@@ -222,12 +221,11 @@ function slackConfigWorkerSource(input: { connectionKey: string }) {
       }
 
       async postDailyReport(input) {
-        const ctx = await this.env.ITERATE.context;
+        const ctx = liftLocalProxies(await this.env.ITERATE.context);
         // ctx.slack is a mounted localProxyCaller marker. The config worker
         // lifts that marker into the SDK-shaped path proxy, so this tool can
         // call the natural Slack SDK shape without knowing the Slack hierarchy.
-        using slack = liftLocalProxies(await ctx.slack);
-        return await slack.chat.postMessage({
+        return await ctx.slack.chat.postMessage({
           channel: input.channel,
           text: input.text,
         });
@@ -245,27 +243,23 @@ async function updateIterateConfigWorker(input: {
   dir: string;
   workerSource: string;
 }) {
-  using project = await input.ctx.project;
-  using repos = await project.repos;
-  using workspace = await project.workspace;
-  using git = await workspace.git;
-  const repo = await repos.ensureIterateConfigInfo({ projectSlug: null });
+  const repo = await input.ctx.project.repos.ensureIterateConfigInfo({ projectSlug: null });
 
-  await git.clone({
+  await input.ctx.project.workspace.git.clone({
     branch: repo.defaultBranch,
     depth: 1,
     dir: input.dir,
     url: repo.remote,
     ...repo.credentials,
   });
-  await workspace.writeFile(input.dir + "/worker.js", input.workerSource);
-  await git.add({ dir: input.dir, filepath: "worker.js" });
-  await git.commit({
+  await input.ctx.project.workspace.writeFile(input.dir + "/worker.js", input.workerSource);
+  await input.ctx.project.workspace.git.add({ dir: input.dir, filepath: "worker.js" });
+  await input.ctx.project.workspace.git.commit({
     author: { name: "Capnweb", email: "captnweb-slack-e2e@iterate.com" },
     dir: input.dir,
     message: "Add Slack SDK Capnweb proof worker",
   });
-  await git.push({
+  await input.ctx.project.workspace.git.push({
     dir: input.dir,
     ref: repo.defaultBranch,
     remote: "origin",
@@ -291,8 +285,7 @@ async function projectEgressFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
 ) {
-  using project = await ctx.project;
-  return await project.egressFetch(new Request(input, init));
+  return await ctx.project.egressFetch(new Request(input, init));
 }
 
 function withRootIterateContextFromNode(input: {

--- a/apps/os/src/capnweb/e2e/captnweb.browser.test.ts
+++ b/apps/os/src/capnweb/e2e/captnweb.browser.test.ts
@@ -1,10 +1,11 @@
 import { afterAll, describe, expect, it } from "vitest";
 import { commands } from "vitest/browser";
-import { newWebSocketRpcSession, type RpcStub } from "capnweb";
+import { newWebSocketRpcSession, RpcTarget, type RpcStub } from "capnweb";
 import {
   EXAMPLE_EGRESS_SECRET_KEY,
   EXAMPLE_EGRESS_SECRET_MATERIAL,
 } from "../../domains/secrets/example-secret.ts";
+import { BROWSER_REPL_EXAMPLES, evalBrowserReplSessionCode } from "../browser-repl.ts";
 import { liftLocalProxies } from "../local-proxy-wrapper.js";
 import type { IterateContext } from "../iterate-context-capability.ts";
 import type { ProjectCapabilityApi } from "../../domains/projects/durable-objects/project-durable-object.ts";
@@ -160,6 +161,42 @@ describe("capnweb browser execution mode", () => {
       ]),
     );
   }, 120_000);
+
+  it("runs the provideCapability browser REPL example and calls the provided target", async () => {
+    using root = await withRootIterateFromBrowser();
+    using projects = await root.projects;
+    const project = await projects.create({
+      slug: `captnweb-repl-example-${uniqueSuffix()}`.slice(0, 40),
+    });
+    createdProjectIds.push(project.id);
+
+    using iterate = await withIterateFromBrowser({ ingressUrl: project.ingressUrl });
+    const example = BROWSER_REPL_EXAMPLES.find((candidate) => {
+      return candidate.id === "provide-alert-capability";
+    });
+    if (!example) throw new Error("Missing provideCapability browser REPL example.");
+
+    const alertMessages: string[] = [];
+    const originalAlert = globalThis.alert;
+    globalThis.alert = (message?: unknown) => {
+      alertMessages.push(String(message));
+    };
+
+    try {
+      await expect(
+        evalBrowserReplSessionCode({
+          code: example.code,
+          ctx: iterate.ctx,
+          env: {},
+          scope: { projectId: project.id, RpcTarget },
+        }),
+      ).resolves.toBe("alerted");
+    } finally {
+      globalThis.alert = originalAlert;
+    }
+
+    expect(alertMessages).toEqual(["The answer is 42"]);
+  }, 60_000);
 });
 
 async function runBrowserCapnwebScript(input: {

--- a/apps/os/src/capnweb/e2e/captnweb.e2e.test.ts
+++ b/apps/os/src/capnweb/e2e/captnweb.e2e.test.ts
@@ -155,7 +155,7 @@ describe("capnweb", () => {
 
     const output = await runCapnwebRepl({
       input: [
-        "const description = await (await ctx.project).describe()",
+        "const description = await ctx.project.describe()",
         "description.id",
         "let localStream = new ReadableStream()",
         "localStream instanceof ReadableStream",
@@ -498,8 +498,7 @@ describe("capnweb", () => {
 
         async echo(input) {
           const ctx = await this.env.ITERATE.context;
-          using streams = await ctx.streams;
-          const streamList = await streams.list();
+          const streamList = await ctx.streams.list();
           return {
             kind: "target-method",
             input,
@@ -950,8 +949,7 @@ async function projectEgressFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
 ) {
-  using project = await ctx.project;
-  return await project.egressFetch(new Request(input, init));
+  return await ctx.project.egressFetch(new Request(input, init));
 }
 
 async function runCapnwebScriptInDynamicWorker(input: {
@@ -1062,7 +1060,7 @@ function serializeCapnwebScriptForDynamicWorker(fn: { toString(): string }) {
   // The awkward case is Vitest/Vite/esbuild transforming this test module
   // before fn.toString() runs. If esbuild lowers:
   //
-  //   using project = await ctx.project
+  //   const project = await ctx.project
   //
   // then the function string contains calls to module-scoped helpers like
   // __using(...) and __callDispose(...), but fn.toString() does not include the

--- a/apps/os/src/capnweb/local-proxy-wrapper.js
+++ b/apps/os/src/capnweb/local-proxy-wrapper.js
@@ -1,4 +1,12 @@
 export const LOCAL_PROXY_CALLER_MARK = "__localProxyCaller";
+const TRANSPARENT_RPC_ROOTS = new Set([
+  "project",
+  "projects",
+  "repos",
+  "streams",
+  "worker",
+  "workspace",
+]);
 
 /**
  * This file is intentionally a small JavaScript indulgence.
@@ -38,9 +46,9 @@ export const LOCAL_PROXY_CALLER_MARK = "__localProxyCaller";
  *
  *      const ctx = liftLocalProxies(await env.ITERATE.context)
  *
- * 3. When `await ctx.slack` resolves to the marker, this wrapper swaps it for a
- *    local path proxy. Every property read just records another path segment,
- *    and the final function call invokes:
+ * 3. When `ctx.slack.chat.postMessage(...)` reaches a marker, this wrapper
+ *    uses a local path proxy. Every property read after the marker root records
+ *    another path segment, and the final function call invokes:
  *
  *      call({ path: ["chat", "postMessage"], args: [{ channel, text }] })
  *
@@ -48,7 +56,7 @@ export const LOCAL_PROXY_CALLER_MARK = "__localProxyCaller";
  * model clean. No marker means no SDK path proxy. If this helper is absent,
  * callers can still use the boring explicit shape, for example:
  *
- *   await ctx.slack.call({ path: ["chat", "postMessage"], args: [{ channel, text }] })
+ *   await (await ctx.slack).call({ path: ["chat", "postMessage"], args: [{ channel, text }] })
  */
 export function localProxyCaller(call) {
   return { [LOCAL_PROXY_CALLER_MARK]: true, call };
@@ -81,6 +89,7 @@ function lift(value) {
   if ((typeof value !== "object" && typeof value !== "function") || value === null) {
     return value;
   }
+  if (isThenable(value)) return pendingValueProxy(value, value, []);
 
   // This Proxy is client-side only. Cloudflare Workers RPC and Cap'n Web both
   // already use JavaScript Proxy objects for remote stubs:
@@ -104,27 +113,82 @@ function lift(value) {
           );
       }
 
-      if (typeof target.then === "function") {
-        return lift(target.then((resolved) => Reflect.get(adapt(resolved), key)));
-      }
-
       const member = Reflect.get(target, key, receiver);
-      if (
-        isLocalProxyCaller(member) ||
-        (member && typeof member === "object" && typeof member.then === "function")
-      ) {
+      if (typeof key === "string" && TRANSPARENT_RPC_ROOTS.has(key)) {
+        return member;
+      }
+      if (isLocalProxyCaller(member) || isThenable(member)) {
         return lift(member);
       }
       return member;
     },
 
     apply(target, thisArg, args) {
-      if (typeof target.then === "function") {
-        return lift(target.then((resolved) => Reflect.apply(adapt(resolved), undefined, args)));
-      }
       return lift(Reflect.apply(target, thisArg, args));
     },
   });
+}
+
+function isThenable(value) {
+  return (
+    value !== null &&
+    (typeof value === "object" || typeof value === "function") &&
+    typeof value.then === "function"
+  );
+}
+
+function pendingValueProxy(value, rootPromise, path) {
+  const fn = (...args) => invokePendingValue(value, rootPromise, path, args);
+  return new Proxy(fn, {
+    get(target, key, receiver) {
+      if (key === "then") {
+        return (onFulfilled, onRejected) =>
+          rootPromise.then(
+            (resolved) => {
+              const next = isLocalProxyCaller(resolved)
+                ? pathProxy(resolved.call, path)
+                : path.length === 0
+                  ? resolved
+                  : (value ?? resolvePath(resolved, path));
+              return Promise.resolve(next).then((final) =>
+                onFulfilled ? onFulfilled(adapt(final)) : adapt(final),
+              );
+            },
+            (error) => onRejected?.(error),
+          );
+      }
+
+      if (typeof key === "symbol" || key in target) {
+        return Reflect.get(target, key, receiver);
+      }
+
+      const member = value == null ? undefined : Reflect.get(value, key);
+      return pendingValueProxy(member, rootPromise, [...path, key]);
+    },
+
+    apply(_target, _thisArg, args) {
+      return invokePendingValue(value, rootPromise, path, args);
+    },
+  });
+}
+
+function invokePendingValue(value, rootPromise, path, args) {
+  return lift(
+    rootPromise.then((resolved) => {
+      if (isLocalProxyCaller(resolved)) {
+        return callLocalProxyCaller(resolved, { path, args });
+      }
+      return Reflect.apply(value ?? resolvePath(resolved, path), undefined, args);
+    }),
+  );
+}
+
+function resolvePath(value, path) {
+  let current = value;
+  for (const part of path) {
+    current = Reflect.get(current, part);
+  }
+  return current;
 }
 
 function pathProxy(call, path = []) {
@@ -133,8 +197,7 @@ function pathProxy(call, path = []) {
   // The path proxy is a local convenience object, not the server capability
   // itself. Disposing it should release the by-reference `call` stub when the
   // underlying RPC implementation exposes a disposer. If it does not, disposal
-  // is intentionally a no-op so `using sdk = await ctx.slack` works in both
-  // Node and dynamic workers.
+  // is intentionally a no-op.
   Object.defineProperty(fn, Symbol.dispose, {
     configurable: true,
     value() {

--- a/apps/os/src/capnweb/local-proxy-wrapper.test.ts
+++ b/apps/os/src/capnweb/local-proxy-wrapper.test.ts
@@ -11,7 +11,7 @@ describe("liftLocalProxies", () => {
     }
 
     class Projects extends RpcTarget {
-      get(id: string) {
+      get(_id: string) {
         return new Project();
       }
 

--- a/apps/os/src/capnweb/local-proxy-wrapper.test.ts
+++ b/apps/os/src/capnweb/local-proxy-wrapper.test.ts
@@ -1,0 +1,85 @@
+import { RpcPromise, RpcStub, RpcTarget } from "capnweb";
+import { describe, expect, test } from "vitest";
+import { liftLocalProxies, localProxyCaller } from "./local-proxy-wrapper.js";
+
+describe("liftLocalProxies", () => {
+  test("preserves direct calls through Cap'n Web promise properties", async () => {
+    class Project extends RpcTarget {
+      describe() {
+        return { id: "proj_123" };
+      }
+    }
+
+    class Projects extends RpcTarget {
+      get(id: string) {
+        return new Project();
+      }
+
+      list(input: { limit: number }) {
+        return { items: [{ id: "proj_123" }], limit: input.limit };
+      }
+    }
+
+    class Context extends RpcTarget {
+      get projects() {
+        return new Projects();
+      }
+    }
+
+    const ctx = liftLocalProxies(new RpcStub(new Context())) as {
+      projects: {
+        get(id: string): { describe(): Promise<unknown> };
+        list(input: { limit: number }): Promise<unknown>;
+      };
+    };
+
+    expect(ctx.projects).toBeInstanceOf(RpcPromise);
+    await expect(ctx.projects.list({ limit: 5 })).resolves.toEqual({
+      items: [{ id: "proj_123" }],
+      limit: 5,
+    });
+
+    await expect(ctx.projects.get("proj_123").describe()).resolves.toEqual({ id: "proj_123" });
+  });
+
+  test("supports pipelined SDK-shaped calls through a pending local proxy marker", async () => {
+    const call = async (input: { args: unknown[]; path: string[] }) => input;
+    const ctx = liftLocalProxies({
+      slack: Promise.resolve(localProxyCaller(call)),
+    }) as unknown as {
+      slack: {
+        chat: {
+          postMessage(input: { text: string }): Promise<unknown>;
+        };
+      };
+    };
+
+    await expect(ctx.slack.chat.postMessage({ text: "hi" })).resolves.toEqual({
+      args: [{ text: "hi" }],
+      path: ["chat", "postMessage"],
+    });
+  });
+
+  test("supports SDK-shaped calls through a Cap'n Web promise marker", async () => {
+    const call = async (input: { args: unknown[]; path: string[] }) => input;
+
+    class Context extends RpcTarget {
+      get slack() {
+        return localProxyCaller(call);
+      }
+    }
+
+    const ctx = liftLocalProxies(new RpcStub(new Context())) as unknown as {
+      slack: {
+        chat: {
+          postMessage(input: { text: string }): Promise<unknown>;
+        };
+      };
+    };
+
+    await expect(ctx.slack.chat.postMessage({ text: "hello" })).resolves.toEqual({
+      args: [{ text: "hello" }],
+      path: ["chat", "postMessage"],
+    });
+  });
+});

--- a/apps/os/src/capnweb/node-client.ts
+++ b/apps/os/src/capnweb/node-client.ts
@@ -64,8 +64,7 @@ export async function projectEgressFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
 ) {
-  using project = await ctx.project;
-  return await project.egressFetch(new Request(input, init));
+  return await ctx.project.egressFetch(new Request(input, init));
 }
 
 async function projectContext(input: {

--- a/apps/os/src/capnweb/repl.ts
+++ b/apps/os/src/capnweb/repl.ts
@@ -29,12 +29,12 @@ async function main() {
   // `useGlobal: true` matters for Cap'n Web: object literals created inside a
   // separate vm context have a different Object prototype, and Cap'n Web's
   // serializer rejects them as non-plain objects. Running in Node's global realm
-  // keeps `await projects.list({ limit: 1 })` serializable while still letting
+  // keeps `await ctx.projects.list({ limit: 1 })` serializable while still letting
   // variables remain live across expressions:
   //
-  //   using project = await ctx.project
+  //   const project = await ctx.project
   //   stream = new ReadableStream()
-  //   await (await ctx.streams).list()
+  //   await ctx.streams.list()
   //
   // That persistence is exactly what /run cannot provide because /run returns
   // JSON and tears down the dynamic worker after each invocation.
@@ -74,10 +74,8 @@ function printUsage() {
   doppler run -- pnpm exec tsx src/capnweb/repl.ts --project-id <proj_...>
 
 Examples inside the REPL:
-  using projects = await ctx.projects
-  await projects.list({ limit: 5 })
+  await ctx.projects.list({ limit: 5 })
 
-  using project = await ctx.project
-  await project.describe()
+  await ctx.project.describe()
 `);
 }

--- a/apps/os/src/capnweb/root-context-fetch.ts
+++ b/apps/os/src/capnweb/root-context-fetch.ts
@@ -140,8 +140,7 @@ function rootRunWorkerSrc(input: { dynamicMountRoots: string[]; functionSource: 
   }
 
   async function projectEgressFetch(ctx, ...args) {
-    using project = await ctx.project;
-    return await project.egressFetch(new Request(args[0], args[1]));
+    return await ctx.project.egressFetch(new Request(args[0], args[1]));
   }
 
   async function runWithProjectEgressFetch(ctx, run) {

--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -1,5 +1,6 @@
+import { useMemo, useState } from "react";
 import { Link, useMatchRoute } from "@tanstack/react-router";
-import { Building2, ChevronsUpDown, ExternalLink, LogOut, UserCircle } from "lucide-react";
+import { Bug, Building2, ChevronsUpDown, ExternalLink, LogOut, UserCircle } from "lucide-react";
 import type { PublicAppConfig } from "@iterate-com/shared/apps/config";
 import { useConfig } from "@iterate-com/ui/apps/config";
 import { useQuery } from "@tanstack/react-query";
@@ -12,6 +13,15 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@iterate-com/ui/components/dropdown-menu";
+import { ScrollArea } from "@iterate-com/ui/components/scroll-area";
+import { SerializedObjectCodeBlock } from "@iterate-com/ui/components/serialized-object-code-block";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@iterate-com/ui/components/sheet";
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -92,36 +102,85 @@ function AppSidebarOrganization({ organizationSlug }: AppSidebarProps) {
 }
 
 function AppSidebarUser() {
-  const { session, signOut } = useAuthClient();
+  const { loading, session, signOut } = useAuthClient();
+  const config = useConfig<PublicConfig>();
+  const [debugOpen, setDebugOpen] = useState(false);
   const user = session?.authenticated ? session.user : null;
   const label = user?.name ?? user?.email ?? "Account";
+  const debugInfo = useMemo(
+    () => ({
+      auth: {
+        loading,
+        session,
+      },
+      config,
+      browser:
+        typeof window === "undefined"
+          ? null
+          : {
+              href: window.location.href,
+              origin: window.location.origin,
+              pathname: window.location.pathname,
+              timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+              userAgent: window.navigator.userAgent,
+            },
+    }),
+    [config, loading, session],
+  );
 
   return (
-    <SidebarMenu>
-      <SidebarMenuItem>
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            render={
-              <SidebarMenuButton className="h-10 gap-2 data-popup-open:bg-sidebar-accent data-popup-open:text-sidebar-accent-foreground">
-                <UserCircle className="size-4" />
-                <span className="truncate">{label}</span>
-                <ChevronsUpDown className="ml-auto size-4" />
-              </SidebarMenuButton>
-            }
-          />
-          <DropdownMenuContent side="top" align="start" className="w-56">
-            <DropdownMenuGroup>
-              <DropdownMenuLabel className="truncate">{label}</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => void signOut()}>
-                <LogOut />
-                <span>Sign out</span>
-              </DropdownMenuItem>
-            </DropdownMenuGroup>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </SidebarMenuItem>
-    </SidebarMenu>
+    <>
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <SidebarMenuButton className="h-10 gap-2 data-popup-open:bg-sidebar-accent data-popup-open:text-sidebar-accent-foreground">
+                  <UserCircle className="size-4" />
+                  <span className="truncate">{label}</span>
+                  <ChevronsUpDown className="ml-auto size-4" />
+                </SidebarMenuButton>
+              }
+            />
+            <DropdownMenuContent side="top" align="start" className="w-56">
+              <DropdownMenuGroup>
+                <DropdownMenuLabel className="truncate">{label}</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => setDebugOpen(true)}>
+                  <Bug />
+                  <span>View debug info</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => void signOut()}>
+                  <LogOut />
+                  <span>Sign out</span>
+                </DropdownMenuItem>
+              </DropdownMenuGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </SidebarMenuItem>
+      </SidebarMenu>
+
+      <Sheet open={debugOpen} onOpenChange={setDebugOpen}>
+        <SheetContent className="w-full gap-0 data-[side=right]:sm:w-[min(92vw,44rem)] data-[side=right]:sm:max-w-[min(92vw,44rem)]">
+          <SheetHeader className="border-b px-4 py-3 pr-14">
+            <SheetTitle>Debug info</SheetTitle>
+            <SheetDescription>
+              Current client session, app config, and browser context.
+            </SheetDescription>
+          </SheetHeader>
+          <ScrollArea className="min-h-0 flex-1">
+            <div className="p-4">
+              <SerializedObjectCodeBlock
+                data={debugInfo}
+                className="min-h-[calc(100svh-8rem)]"
+                initialFormat="json"
+                showToggle
+              />
+            </div>
+          </ScrollArea>
+        </SheetContent>
+      </Sheet>
+    </>
   );
 }
 
@@ -158,7 +217,7 @@ function AppSidebarNav() {
                 render={<Link to="/capnweb-repl" />}
                 isActive={Boolean(matchRoute({ to: "/capnweb-repl", fuzzy: false }))}
               >
-                <span>Capnweb REPL</span>
+                <span>Repl</span>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>

--- a/apps/os/src/domains/repos/README.md
+++ b/apps/os/src/domains/repos/README.md
@@ -261,12 +261,27 @@ The base repo is populated from the checked-in holder directory:
 apps/os/iterate-config-repo
 ```
 
-Run the seed script from `apps/os` with Cloudflare credentials and the exact
-Artifacts namespace configured in `alchemy.run.ts`:
+Run the seed command from `apps/os` in the Doppler config that owns the
+environment:
 
 ```sh
-pnpm artifacts:seed-config-base -- --namespace <worker-name>-repos
+pnpm cli artifacts seed-config-base
 ```
+
+The command resolves the Artifacts namespace from the active Doppler/Alchemy
+stage, pushes the checked-in holder tree to `iterate-config-base`, verifies Git
+access to the base repo, then creates and deletes a temporary fork to prove the
+same Artifact fork path used by new Project setup works.
+
+Target another environment explicitly with Doppler:
+
+```sh
+doppler run --project os --config dev_jonas -- pnpm cli artifacts seed-config-base
+doppler run --project os --config dev_localhost -- pnpm cli artifacts seed-config-base
+```
+
+Pass `--namespace <worker-name>-repos` only when repairing an environment whose
+namespace cannot be inferred from its Doppler config.
 
 The holder must contain `iterate.config.jsonc`. The file can stay a placeholder
 until project config semantics exist.

--- a/apps/os/src/domains/repos/durable-objects/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/durable-objects/repo-durable-object.ts
@@ -211,7 +211,7 @@ export class RepoDurableObject extends RepoLifecycleBase<RepoEnv> {
   }
 
   private async currentRepo() {
-    return (await this.getRepoRunnerState()).state.repo;
+    return (await this.getRepoRunnerState()).state?.repo ?? null;
   }
 
   private async getRepoRunnerState() {
@@ -377,7 +377,7 @@ type RepoInfoSource = {
 };
 
 type RepoProcessorRuntimeState = {
-  state: { repo: RepoInfoSource | null };
+  state: { repo: RepoInfoSource | null } | null;
   reducedThroughOffset: number;
 };
 

--- a/apps/os/src/domains/streams/durable-objects/stream-processor-runner.ts
+++ b/apps/os/src/domains/streams/durable-objects/stream-processor-runner.ts
@@ -166,7 +166,7 @@ export class StreamProcessorRunner extends DurableObject {
       deps: processor.deps,
       storage: {
         load: () => this.ctx.storage.kv.get<RunnerSnapshot>("snapshot"),
-        save: (snapshot) => void this.ctx.storage.kv.put("snapshot", snapshot),
+        save: (snapshot) => this.ctx.storage.kv.put("snapshot", snapshot),
       },
       stream: this.#stream,
       sideEffectAnchor: {
@@ -191,7 +191,8 @@ export class StreamProcessorRunner extends DurableObject {
     });
   }
 
-  runtimeState() {
+  async runtimeState() {
+    await this.#processing;
     const processorSlug = this.ctx.storage.kv.get<string>("processorSlug");
     const snapshot = this.ctx.storage.kv.get<RunnerSnapshot>("snapshot");
     return {

--- a/apps/os/src/routes/_app/capnweb-repl.tsx
+++ b/apps/os/src/routes/_app/capnweb-repl.tsx
@@ -1,11 +1,19 @@
 import { useEffect, useRef, useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import { newWebSocketRpcSession, type RpcStub } from "capnweb";
-import { Play } from "lucide-react";
+import { newWebSocketRpcSession, RpcTarget, type RpcStub } from "capnweb";
+import { BookOpen, Play } from "lucide-react";
 import { Button } from "@iterate-com/ui/components/button";
 import { ScrollArea } from "@iterate-com/ui/components/scroll-area";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@iterate-com/ui/components/sheet";
 import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
 import {
+  BROWSER_REPL_EXAMPLES,
   DEFAULT_BROWSER_REPL_CODE,
   evalBrowserReplSessionCode,
   formatBrowserReplResult,
@@ -31,8 +39,9 @@ function CapnwebReplPage() {
   const [ctx, setCtx] = useState<RpcStub<IterateContext> | null>(null);
   const [status, setStatus] = useState("Connecting...");
   const [entries, setEntries] = useState<ReplEntry[]>([]);
+  const [examplesOpen, setExamplesOpen] = useState(false);
   const envRef = useRef<Record<string, unknown>>({});
-  const scopeRef = useRef<Record<string, unknown>>({});
+  const scopeRef = useRef<Record<string, unknown>>({ RpcTarget });
 
   useEffect(() => {
     const wsUrl = new URL("/api/captnweb", window.location.href);
@@ -86,6 +95,11 @@ function CapnwebReplPage() {
     }
   }
 
+  function selectExample(exampleCode: string) {
+    setCode(exampleCode);
+    setExamplesOpen(false);
+  }
+
   return (
     <main className="flex h-full min-h-0 flex-col bg-background">
       <section className="flex min-h-0 flex-1 flex-col">
@@ -132,18 +146,57 @@ function CapnwebReplPage() {
               onModEnter={() => void run()}
               showCopyButton={false}
             />
-            <Button
-              className="self-end"
-              disabled={!ctx || status === "Running..." || code.trim() === ""}
-              onClick={() => void run()}
-              size="sm"
-            >
-              <Play data-icon="inline-start" />
-              Run
-            </Button>
+            <div className="flex items-center justify-end gap-2">
+              <Button variant="outline" onClick={() => setExamplesOpen(true)} size="sm">
+                <BookOpen data-icon="inline-start" />
+                Examples
+              </Button>
+              <Button
+                disabled={!ctx || status === "Running..." || code.trim() === ""}
+                onClick={() => void run()}
+                size="sm"
+              >
+                <Play data-icon="inline-start" />
+                Run
+              </Button>
+            </div>
           </div>
         </div>
       </section>
+      <Sheet open={examplesOpen} onOpenChange={setExamplesOpen}>
+        <SheetContent className="w-full gap-0 data-[side=right]:sm:w-[min(92vw,48rem)] data-[side=right]:sm:max-w-[min(92vw,48rem)]">
+          <SheetHeader className="border-b px-4 py-3 pr-14">
+            <SheetTitle>Examples</SheetTitle>
+            <SheetDescription>Runnable snippets for the current REPL session.</SheetDescription>
+          </SheetHeader>
+          <ScrollArea className="min-h-0 flex-1">
+            <div className="flex flex-col gap-4 p-4">
+              {BROWSER_REPL_EXAMPLES.map((example) => (
+                <article key={example.id} className="flex flex-col gap-3 rounded-md border p-3">
+                  <div className="flex flex-col gap-1">
+                    <h3 className="text-sm font-medium">{example.title}</h3>
+                    <p className="text-sm text-muted-foreground">{example.description}</p>
+                  </div>
+                  <SourceCodeBlock
+                    code={example.code}
+                    className="h-80"
+                    language="typescript"
+                    showCopyButton
+                  />
+                  <Button
+                    className="self-end"
+                    onClick={() => selectExample(example.code)}
+                    size="sm"
+                    variant="outline"
+                  >
+                    Use snippet
+                  </Button>
+                </article>
+              ))}
+            </div>
+          </ScrollArea>
+        </SheetContent>
+      </Sheet>
     </main>
   );
 }

--- a/apps/os/src/routes/_app/capnweb-repl.tsx
+++ b/apps/os/src/routes/_app/capnweb-repl.tsx
@@ -3,6 +3,11 @@ import { createFileRoute } from "@tanstack/react-router";
 import { newWebSocketRpcSession, type RpcStub } from "capnweb";
 import { Button } from "@iterate-com/ui/components/button";
 import { useAuthClient } from "~/auth/client-context.ts";
+import {
+  DEFAULT_BROWSER_REPL_CODE,
+  evalBrowserReplCode,
+  formatBrowserReplResult,
+} from "~/capnweb/browser-repl.ts";
 import { liftLocalProxies } from "~/capnweb/local-proxy-wrapper.js";
 import type { IterateContext } from "~/capnweb/iterate-context-capability.ts";
 
@@ -15,7 +20,7 @@ export const Route = createFileRoute("/_app/capnweb-repl")({
 
 function CapnwebReplPage() {
   const { session } = useAuthClient();
-  const [code, setCode] = useState("await ctx.projects.list({ limit: 5 })");
+  const [code, setCode] = useState(DEFAULT_BROWSER_REPL_CODE);
   const [ctx, setCtx] = useState<RpcStub<IterateContext> | null>(null);
   const [status, setStatus] = useState("Connecting...");
   const [output, setOutput] = useState("");
@@ -46,8 +51,8 @@ function CapnwebReplPage() {
     if (!ctx) return;
     setStatus("Running...");
     try {
-      const result = await evalInBrowser({ code, ctx });
-      setOutput(formatResult(result));
+      const result = await evalBrowserReplCode({ code, ctx });
+      setOutput(formatBrowserReplResult(result));
       setStatus("Connected");
     } catch (error) {
       setOutput(error instanceof Error ? (error.stack ?? error.message) : String(error));
@@ -101,31 +106,4 @@ function CapnwebReplPage() {
       </section>
     </main>
   );
-}
-
-async function evalInBrowser(input: { code: string; ctx: RpcStub<IterateContext> }) {
-  const env = {};
-  return await compileBrowserReplFunction(input.code)(input.ctx, env);
-}
-
-function compileBrowserReplFunction(code: string) {
-  try {
-    // oxlint-disable-next-line no-new-func -- This page is explicitly a browser-local REPL.
-    return new Function("ctx", "env", `return (async () => (${code}))()`) as ReplFunction;
-  } catch {
-    // oxlint-disable-next-line no-new-func -- Statement-mode fallback for the browser-local REPL.
-    return new Function("ctx", "env", `return (async () => {${code}})()`) as ReplFunction;
-  }
-}
-
-type ReplFunction = (ctx: RpcStub<IterateContext>, env: object) => Promise<unknown>;
-
-function formatResult(result: unknown) {
-  if (result === undefined) return "undefined";
-  if (typeof result === "string") return result;
-  try {
-    return JSON.stringify(result, null, 2);
-  } catch {
-    return String(result);
-  }
 }

--- a/apps/os/src/routes/_app/capnweb-repl.tsx
+++ b/apps/os/src/routes/_app/capnweb-repl.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { newWebSocketRpcSession, type RpcStub } from "capnweb";
+import { Play } from "lucide-react";
 import { Button } from "@iterate-com/ui/components/button";
-import { useAuthClient } from "~/auth/client-context.ts";
+import { ScrollArea } from "@iterate-com/ui/components/scroll-area";
+import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
 import {
   DEFAULT_BROWSER_REPL_CODE,
-  evalBrowserReplCode,
+  evalBrowserReplSessionCode,
   formatBrowserReplResult,
 } from "~/capnweb/browser-repl.ts";
 import { liftLocalProxies } from "~/capnweb/local-proxy-wrapper.js";
@@ -13,17 +15,24 @@ import type { IterateContext } from "~/capnweb/iterate-context-capability.ts";
 
 export const Route = createFileRoute("/_app/capnweb-repl")({
   staticData: {
-    breadcrumb: "Capnweb REPL",
+    breadcrumb: "Repl",
   },
   component: CapnwebReplPage,
 });
 
+type ReplEntry = {
+  code: string;
+  output: string;
+  status: "error" | "success";
+};
+
 function CapnwebReplPage() {
-  const { session } = useAuthClient();
   const [code, setCode] = useState(DEFAULT_BROWSER_REPL_CODE);
   const [ctx, setCtx] = useState<RpcStub<IterateContext> | null>(null);
   const [status, setStatus] = useState("Connecting...");
-  const [output, setOutput] = useState("");
+  const [entries, setEntries] = useState<ReplEntry[]>([]);
+  const envRef = useRef<Record<string, unknown>>({});
+  const scopeRef = useRef<Record<string, unknown>>({});
 
   useEffect(() => {
     const wsUrl = new URL("/api/captnweb", window.location.href);
@@ -36,7 +45,7 @@ function CapnwebReplPage() {
       env?: object;
     };
     globals.ctx = lifted;
-    globals.env = {};
+    globals.env = envRef.current;
     setCtx(lifted);
     setStatus("Connected");
     return () => {
@@ -48,61 +57,92 @@ function CapnwebReplPage() {
   }, []);
 
   async function run() {
-    if (!ctx) return;
+    const trimmedCode = code.trim();
+    if (!ctx || trimmedCode === "") return;
     setStatus("Running...");
     try {
-      const result = await evalBrowserReplCode({ code, ctx });
-      setOutput(formatBrowserReplResult(result));
+      const result = await evalBrowserReplSessionCode({
+        code: trimmedCode,
+        ctx,
+        env: envRef.current,
+        scope: scopeRef.current,
+      });
+      setEntries((current) => [
+        ...current,
+        { code: trimmedCode, output: formatBrowserReplResult(result), status: "success" },
+      ]);
+      setCode("");
       setStatus("Connected");
     } catch (error) {
-      setOutput(error instanceof Error ? (error.stack ?? error.message) : String(error));
+      setEntries((current) => [
+        ...current,
+        {
+          code: trimmedCode,
+          output: error instanceof Error ? (error.stack ?? error.message) : String(error),
+          status: "error",
+        },
+      ]);
       setStatus("Connected");
     }
   }
 
-  const scopes =
-    session?.authenticated === true
-      ? {
-          organizations: session.session.organizations.map(({ id, role, slug }) => ({
-            id,
-            role,
-            slug,
-          })),
-          projects: session.session.projects.map(({ id, organizationId, slug }) => ({
-            id,
-            organizationId,
-            slug,
-          })),
-        }
-      : null;
-
   return (
-    <main className="flex h-full min-h-0 flex-col gap-4 p-4">
-      <section className="space-y-2">
-        <div className="flex items-center justify-between gap-3">
-          <h1 className="text-lg font-semibold">Capnweb REPL</h1>
-          <span className="text-sm text-muted-foreground">{status}</span>
-        </div>
-        <pre className="max-h-44 overflow-auto rounded-md border bg-muted p-3 text-xs">
-          {JSON.stringify(scopes, null, 2)}
-        </pre>
-      </section>
+    <main className="flex h-full min-h-0 flex-col bg-background">
+      <section className="flex min-h-0 flex-1 flex-col">
+        <ScrollArea className="min-h-0 flex-1">
+          <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 px-4 py-5">
+            {entries.length === 0 ? (
+              <div className="rounded-md border bg-muted/40 px-3 py-2 font-mono text-sm text-muted-foreground">
+                iterate&gt;
+              </div>
+            ) : (
+              entries.map((entry, index) => (
+                <div key={index} className="flex flex-col gap-2 font-mono text-sm">
+                  <pre className="overflow-x-auto whitespace-pre-wrap text-foreground">
+                    <span className="select-none text-muted-foreground">iterate&gt; </span>
+                    {entry.code}
+                  </pre>
+                  <pre
+                    className={
+                      entry.status === "error"
+                        ? "overflow-x-auto whitespace-pre-wrap text-destructive"
+                        : "overflow-x-auto whitespace-pre-wrap text-muted-foreground"
+                    }
+                  >
+                    {entry.output}
+                  </pre>
+                </div>
+              ))
+            )}
+          </div>
+        </ScrollArea>
 
-      <section className="grid min-h-0 flex-1 gap-3 lg:grid-cols-2">
-        <div className="flex min-h-0 flex-col gap-2">
-          <textarea
-            className="min-h-72 flex-1 resize-none rounded-md border bg-background p-3 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
-            spellCheck={false}
-            value={code}
-            onChange={(event) => setCode(event.target.value)}
-          />
-          <Button className="self-start" disabled={!ctx || status === "Running..."} onClick={run}>
-            Run
-          </Button>
+        <div className="border-t bg-background">
+          <div className="mx-auto flex w-full max-w-5xl flex-col gap-2 px-4 py-3">
+            <div className="flex items-center justify-between gap-3">
+              <span className="font-mono text-xs text-muted-foreground">iterate&gt;</span>
+              <span className="text-xs text-muted-foreground">{status}</span>
+            </div>
+            <SourceCodeBlock
+              code={code}
+              className="min-h-24"
+              editable
+              language="typescript"
+              onChange={setCode}
+              onModEnter={() => void run()}
+              showCopyButton={false}
+            />
+            <Button
+              className="self-end"
+              disabled={!ctx || status === "Running..." || code.trim() === ""}
+              onClick={() => void run()}
+              size="sm"
+            >
+              <Play data-icon="inline-start" />
+              Run
+            </Button>
+          </div>
         </div>
-        <pre className="min-h-72 overflow-auto rounded-md border bg-muted p-3 text-sm">
-          {output || "Result appears here."}
-        </pre>
       </section>
     </main>
   );

--- a/apps/os/tasks/workspace-codemode-implementation-log.md
+++ b/apps/os/tasks/workspace-codemode-implementation-log.md
@@ -61,7 +61,7 @@ real preview MCP codemode session can use a simple JavaScript block to:
   but not sufficient.
 - Preview project creation can fail if the Artifacts namespace is missing the
   `iterate-config-base` source repo. The checked-in
-  `artifacts:seed-config-base` script is the intended repair path; the deployed
+  `pnpm cli artifacts seed-config-base` command is the intended repair path; the deployed
   worker no longer exposes a seed/debug route.
 - Cloudflare Artifacts write token TTLs must be at most 31,536,000 seconds. The
   repo write-token TTL is set to one year so project `iterate-config` creation


### PR DESCRIPTION
## Summary

- Fix the Cap'n Web browser REPL so `await ctx.projects.list(...)` works through normal promise pipelining.
- Preserve built-in Cap'n Web roots as real RPC promises while adding marker-aware pipelining for custom SDK-shaped roots like `ctx.slack.chat.postMessage(...)`.
- Update Cap'n Web scripts, examples, and docs to use the intended pipelined style instead of `await (await ctx...).method(...)`.
- Rework the UI REPL into a single-column, session-like transcript with CodeMirror input and persistent local variables across submissions.
- Move auth/session debug context out of the REPL and into a sidebar user-menu sheet under `View debug info`.

## Root Cause

`liftLocalProxies` was wrapping unresolved RPC promise properties too broadly. That erased the callable shape needed for pipelined expressions in the browser REPL and made `ctx.projects.list` non-callable.

## Validation

- `pnpm --dir apps/os exec vitest run src/capnweb/browser-repl.test.ts src/capnweb/local-proxy-wrapper.test.ts`
- `pnpm --dir apps/os typecheck`

Full `e2e:capnweb` was not run locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core client-side Cap'n Web proxy behavior and browser REPL code execution (`new Function`); artifact seed still force-pushes to Cloudflare namespaces when run operationally.
> 
> **Overview**
> Fixes Cap'n Web **promise pipelining** in the browser REPL by narrowing `liftLocalProxies`: built-in roots (`projects`, `project`, `streams`, etc.) stay real RPC promises, while **marker-backed SDK paths** (e.g. `ctx.slack.chat.postMessage`) still get local path proxies on pending values. Docs, e2e scripts, and CLI examples are updated to the pipelined style (`ctx.project.describe()` instead of `await (await ctx.project).describe()`).
> 
> The **Repl** UI becomes a single-column transcript with CodeMirror input, **session-persistent** top-level bindings via new `browser-repl` helpers (with tests), an **Examples** sheet, and a browser e2e for `provideCapability`. Auth/debug context moves to the sidebar user menu **View debug info** sheet.
> 
> **`pnpm cli artifacts seed-config-base`** replaces the standalone package script: oRPC-routed seeding adds Git access checks and optional temporary fork verification; related docs/READMEs are updated. Small infra fixes: stream-processor snapshot save is awaited, `runtimeState()` waits for in-flight processing, and repo runner state tolerates a null snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c4b6dc9c125b82a46a9922f5ba308a5e986558f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-08T22:04:12.024Z",
      "headSha": "05b34191149a860038f821a91a9475d3e1b1f887",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27169282397",
      "shortSha": "05b3419"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `05b3419`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27169282397)
Updated: 2026-06-08T22:04:12.024Z
<!-- /CLOUDFLARE_PREVIEW -->