### PR TITLE
Fix OS stream live subscriptions

### DIFF
--- a/apps/os/src/domains/streams/entrypoints/streams-capability.ts
+++ b/apps/os/src/domains/streams/entrypoints/streams-capability.ts
@@ -1,6 +1,6 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
-import { withStreamConnectionFromWorkers } from "@iterate-com/streams/workers/connect";
 import { createStreamSubscription } from "@iterate-com/streams/subscription";
+import type { StreamRpc } from "@iterate-com/streams/types";
 import {
   type Event,
   type EventInput,
@@ -434,16 +434,12 @@ async function* liveNamespaceStreamEvents(args: {
       namespace: args.namespace,
       path: args.path,
     }),
-  );
-  using connection = await withStreamConnectionFromWorkers({
-    url: "https://stream.local/",
-    fetch: (request) => fetchDurableObjectWebSocket(streamStub, request),
-  });
+  ) as unknown as StreamRpc;
   let handle: { unsubscribe(): void } | undefined;
   await using subscription = createStreamSubscription({
     onDispose: () => handle?.unsubscribe(),
   });
-  handle = await connection.stream.subscribe({
+  handle = await streamStub.subscribe({
     processEventBatch: subscription.processEventBatch,
     replayAfterOffset: toNewAfterOffset(args.afterOffset),
   });
@@ -453,21 +449,6 @@ async function* liveNamespaceStreamEvents(args: {
       yield toLegacyEvent(event, args.path);
     }
   }
-}
-
-function fetchDurableObjectWebSocket(
-  stub: DurableObjectStub<StreamDurableObject>,
-  request: Request,
-) {
-  const url = new URL(request.url);
-  if (url.protocol === "wss:") url.protocol = "https:";
-  if (url.protocol === "ws:") url.protocol = "http:";
-  return stub.fetch(
-    new Request(url, {
-      headers: new Headers(request.headers),
-      method: request.method,
-    }),
-  );
 }
 
 function eventsToNdjsonStream(events: AsyncIterable<Event>) {

--- a/apps/os/src/orpc/routers/streams.ts
+++ b/apps/os/src/orpc/routers/streams.ts
@@ -1,6 +1,6 @@
 import { ORPCError } from "@orpc/server";
-import { withStreamConnectionFromWorkers } from "@iterate-com/streams/workers/connect";
 import { createStreamSubscription } from "@iterate-com/streams/subscription";
+import type { StreamRpc } from "@iterate-com/streams/types";
 import type { AppContext } from "~/context.ts";
 import {
   getStreamsCapability,
@@ -10,7 +10,6 @@ import {
   getStreamDurableObjectName,
   toLegacyEvent,
   toNewAfterOffset,
-  type StreamDurableObject,
   type StreamDurableObjectNamespace,
 } from "~/domains/streams/new-stream-runtime.ts";
 import { os, projectScopeMiddleware } from "~/orpc/orpc.ts";
@@ -125,11 +124,7 @@ async function* subscribeProjectStreamEvents(input: {
       namespace: input.projectId,
       path: streamPath,
     }),
-  );
-  using connection = await withStreamConnectionFromWorkers({
-    url: "https://stream.local/",
-    fetch: (request) => fetchDurableObjectWebSocket(streamStub, request),
-  });
+  ) as unknown as StreamRpc;
   let handle: { unsubscribe(): void } | undefined;
   await using subscription = createStreamSubscription({
     onDispose: () => handle?.unsubscribe(),
@@ -142,7 +137,7 @@ async function* subscribeProjectStreamEvents(input: {
   try {
     if (input.signal?.aborted) return;
     input.signal?.addEventListener("abort", onAbort, { once: true });
-    handle = await connection.stream.subscribe({
+    handle = await streamStub.subscribe({
       processEventBatch: subscription.processEventBatch,
       replayAfterOffset: toNewAfterOffset(input.afterOffset),
     });
@@ -156,21 +151,6 @@ async function* subscribeProjectStreamEvents(input: {
   } finally {
     input.signal?.removeEventListener("abort", onAbort);
   }
-}
-
-function fetchDurableObjectWebSocket(
-  stub: DurableObjectStub<StreamDurableObject>,
-  request: Request,
-) {
-  const url = new URL(request.url);
-  if (url.protocol === "wss:") url.protocol = "https:";
-  if (url.protocol === "ws:") url.protocol = "http:";
-  return stub.fetch(
-    new Request(url, {
-      headers: new Headers(request.headers),
-      method: request.method,
-    }),
-  );
 }
 
 function requireStreamNamespace(context: AppContext): StreamDurableObjectNamespace {


### PR DESCRIPTION
## Summary
- replace the broken stream live-subscription WebSocket/fetch bridge with direct Stream Durable Object RPC subscribe calls
- remove the dead stream.local stub.fetch path from the oRPC stream route and StreamsCapability

## Production diagnosis
- failing trace: f69e6f4e938d2049ae7aad22dbfa813e
- request: GET https://os.iterate.com/api/projects/prj_d871bac9722d45aba4e3dbb50057900d/streams/event-stream/%2F?afterOffset=start
- failing span: StreamDurableObject GET https://stream.local/
- error: Handler does not export a fetch() function.

## Verification
- pnpm --dir apps/os typecheck
- pnpm --dir apps/os test
- pnpm lint
- pnpm format:check
- manually deployed to apps/os prd
- verified https://os.iterate.com/api/projects/iterate/streams/event-stream/%2F?afterOffset=start returns stream events
- post-deploy trace window from 2026-06-08T21:24:00Z showed 0 occurrences of the fetch handler error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how live project event streams are wired in production APIs; scope is limited to subscription transport but affects real-time streaming behavior.
> 
> **Overview**
> **Live stream subscriptions** in OS no longer open a Workers WebSocket connection to `stream.local` via `withStreamConnectionFromWorkers` and a `stub.fetch` shim. Both `liveNamespaceStreamEvents` in **StreamsCapability** and `subscribeProjectStreamEvents` in the **oRPC streams router** now treat the Stream Durable Object stub as **`StreamRpc`** and call **`subscribe`** directly, with the same `createStreamSubscription` batch handling and legacy event mapping.
> 
> The duplicated **`fetchDurableObjectWebSocket`** helpers are removed from both call sites. This addresses the production failure where live NDJSON/event-stream requests hit a DO **`GET https://stream.local/`** path that has no **`fetch`** handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d93a37350f835e7de7739539a2c8b8e96f5291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->