### PR TITLE
[codex] simplify os stream rendering

### DIFF
--- a/apps/os/package.json
+++ b/apps/os/package.json
@@ -71,6 +71,7 @@
     "@tanstack/react-router-devtools": "1.166.11",
     "@tanstack/react-router-ssr-query": "^1.166.2",
     "@tanstack/react-start": "1.167.5",
+    "@tanstack/react-virtual": "^3.14.2",
     "agents": "^0.11.0",
     "capnweb": "^0.8.0",
     "captun": "https://pkg.pr.new/captun@14",

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -1,101 +1,43 @@
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
-import { Link } from "@tanstack/react-router";
-import { Event, EventInput, type StreamPath } from "@iterate-com/shared/streams/types";
 import {
-  getInitialProcessorState,
-  runProcessorReduce,
-  type ProcessorState,
-  type StreamEvent,
-} from "@iterate-com/shared/stream-processors";
-import { StreamViewProcessorContract } from "@iterate-com/ui/components/events/stream-view-processor/contract";
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+  acquireStreamRuntime,
+  type StreamBrowserSnapshot,
+} from "@iterate-com/streams/browser/stream-browser-store";
+import { useStreamQuery } from "@iterate-com/streams/browser/hooks/use-stream-query";
 import type {
-  EventsStreamInputAction,
-  EventsStreamRegisteredProcessor,
-  EventsStreamViewState,
-} from "@iterate-com/ui/components/events/feed-items";
+  StreamBrowserDatabase,
+  StreamEventRow,
+} from "@iterate-com/streams/browser/stream-browser-db";
 import {
-  EventsStreamComposer,
-  type EventsStreamComposerMode,
-  type EventsStreamComposerRawPreset,
-} from "@iterate-com/ui/components/events/stream-composer";
-import {
-  EventsStreamInputSlot,
-  EventsStreamView,
-  type EventsStreamElementType,
-  type EventsStreamRendererMode,
-} from "@iterate-com/ui/components/events/stream-feed";
-import { EventsStreamLayoutMessageInput } from "@iterate-com/ui/components/events/stream-layout";
-import { EventsStreamPathLabel } from "@iterate-com/ui/components/events/stream-path-label";
-import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
-import { EventsDebugLink } from "~/components/events-debug-link.tsx";
-import { createBrowserOpenApiClient } from "~/orpc/client.ts";
-import { streamPathToSplat } from "~/lib/stream-links.ts";
+  BROWSER_RAW_EVENTS_SCHEMA_VERSION,
+  browserRawEvents,
+  loadBrowserRawEventsCheckpoint,
+} from "@iterate-com/streams/processors/browser-raw-events/implementation";
+import { StreamEventInput } from "@iterate-com/streams/shared/event";
+import type { StreamPath } from "@iterate-com/shared/streams/types";
+import { parse as parseYaml } from "yaml";
 
 type ProjectStreamMessageComposer = {
   placeholder?: string;
   onSubmit: (message: string) => Promise<void>;
 };
 
-const DEFAULT_RAW_EVENT_PRESET_ID = "manual-event";
-
-const defaultRawEventPresets: readonly EventsStreamComposerRawPreset[] = [
-  {
-    id: DEFAULT_RAW_EVENT_PRESET_ID,
-    label: "Manual event",
-    processorSlug: "manual",
-    eventType: "events.iterate.com/os/manual-event",
-    eventDescription: "A generic event you can edit before appending it to the stream.",
-    exampleName: "Manual event",
-    value: [
-      "type: events.iterate.com/os/manual-event",
-      "payload:",
-      "  message: Hello from the stream composer",
-      "",
-    ].join("\n"),
-  },
-  {
-    id: "stream-error",
-    label: "Stream error",
-    processorSlug: "core",
-    eventType: "events.iterate.com/stream/error-occurred",
-    eventDescription: "Records a stream-level error that can be surfaced in the stream UI.",
-    eventDocsHref: "https://events.iterate.com/stream/error-occurred/",
-    exampleName: "Stream error",
-    value: [
-      "type: events.iterate.com/stream/error-occurred",
-      "payload:",
-      "  message: Something notable happened",
-      "",
-    ].join("\n"),
-  },
-  {
-    id: "metadata-updated",
-    label: "Metadata updated",
-    processorSlug: "core",
-    eventType: "events.iterate.com/stream/metadata-updated",
-    eventDescription: "Updates metadata associated with this stream.",
-    eventDocsHref: "https://events.iterate.com/stream/metadata-updated/",
-    exampleName: "Metadata updated",
-    value: [
-      "type: events.iterate.com/stream/metadata-updated",
-      "payload:",
-      "  metadata:",
-      "    source: manual",
-      "",
-    ].join("\n"),
-  },
-];
-
 export function ProjectStreamView({
   defaultComposerMode,
   emptyLabel = "No events in this stream yet.",
-  headerAccessory,
   messageComposer,
-  projectSlug,
   projectSlugOrId,
   streamPath,
 }: {
-  defaultComposerMode?: EventsStreamComposerMode;
+  defaultComposerMode?: "message" | "raw";
   emptyLabel?: string;
   headerAccessory?: ReactNode;
   messageComposer?: ProjectStreamMessageComposer;
@@ -103,334 +45,217 @@ export function ProjectStreamView({
   projectSlugOrId: string;
   streamPath: StreamPath;
 }) {
-  const hasMessageComposer = messageComposer != null;
-  const [composerText, setComposerText] = useState("");
-  const [composerMode, setComposerMode] = useState<EventsStreamComposerMode>(
-    defaultComposerMode ?? (hasMessageComposer ? "message" : "raw"),
+  const streamPathText = streamPath.toString();
+  const store = useMemo(
+    () =>
+      acquireStreamRuntime({
+        namespace: projectSlugOrId,
+        streamPath: streamPathText,
+        streamUrl: projectStreamRpcPath(projectSlugOrId, streamPathText),
+        processor: browserRawEvents,
+        schemaVersion: BROWSER_RAW_EVENTS_SCHEMA_VERSION,
+        tables: ["events"],
+        loadCheckpoint: loadBrowserRawEventsCheckpoint,
+      }),
+    [projectSlugOrId, streamPathText],
   );
-  const [rawComposerText, setRawComposerText] = useState(defaultRawEventPresets[0]?.value ?? "");
-  const [selectedRawPresetId, setSelectedRawPresetId] = useState(DEFAULT_RAW_EVENT_PRESET_ID);
-  const [events, setEvents] = useState<Event[]>([]);
-  const [errorLabel, setErrorLabel] = useState<string | undefined>();
-  const [hiddenElementTypes, setHiddenElementTypes] = useState<EventsStreamElementType[]>([]);
-  const [rendererMode, setRendererMode] = useState<EventsStreamRendererMode>("raw-pretty");
-  const [isPending, setIsPending] = useState(true);
+  const snapshot = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getServerSnapshot,
+  );
+  const countResult = useStreamQuery(store.streamDatabase, `SELECT COUNT(*) AS count FROM events`);
+  const eventCount = Number(countResult.data[0]?.count ?? 0);
+  const composerMode = defaultComposerMode ?? (messageComposer ? "message" : "raw");
+  const [composerText, setComposerText] = useState(
+    composerMode === "raw"
+      ? "type: events.iterate.com/os/manual-event\npayload:\n  message: Hello from OS\n"
+      : "",
+  );
+  const [submitError, setSubmitError] = useState<string | undefined>();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [openEventOffset, setOpenEventOffset] = useState<number | undefined>();
 
-  useEffect(() => {
-    const controller = new AbortController();
-    let isCurrent = true;
-    let iterator: AsyncIterator<Event> | undefined;
-
-    setEvents([]);
-    setErrorLabel(undefined);
-    setIsPending(true);
-
-    void (async () => {
-      try {
-        const stream = await createBrowserOpenApiClient().project.streams.streamEvents(
-          {
-            afterOffset: "start",
-            projectSlugOrId,
-            streamPath,
-          },
-          { signal: controller.signal },
-        );
-        iterator = stream[Symbol.asyncIterator]();
-
-        if (!isCurrent || controller.signal.aborted) return;
-        setIsPending(false);
-
-        for await (const value of stream) {
-          if (!isCurrent || controller.signal.aborted) return;
-          const event = Event.parse(value);
-          setEvents((previous) => appendStreamEvent(previous, event));
-        }
-      } catch (error) {
-        if (!isCurrent || controller.signal.aborted) return;
-        setErrorLabel(error instanceof Error ? error.message : String(error));
-        setIsPending(false);
-      }
-    })();
-
-    return () => {
-      isCurrent = false;
-      controller.abort();
-      void iterator?.return?.();
-    };
-  }, [projectSlugOrId, streamPath]);
-
-  const processorRef = useRef<{
-    state: ProcessorState<typeof StreamViewProcessorContract>;
-    processedCount: number;
-  }>({
-    state: getInitialProcessorState(StreamViewProcessorContract),
-    processedCount: 0,
-  });
-
-  const processorState = useMemo(() => {
-    const ref = processorRef.current;
-
-    // Reset when events are cleared (stream path change)
-    if (ref.processedCount > events.length) {
-      ref.state = getInitialProcessorState(StreamViewProcessorContract);
-      ref.processedCount = 0;
-    }
-
-    // Incremental reduce — only process new events
-    const processor = { contract: StreamViewProcessorContract };
-    for (let i = ref.processedCount; i < events.length; i++) {
-      const reduction = runProcessorReduce({
-        processor,
-        event: events[i] as unknown as StreamEvent,
-        state: ref.state,
-      });
-      ref.state = reduction?.state ?? ref.state;
-    }
-    ref.processedCount = events.length;
-    return ref.state;
-  }, [events]);
-
-  // Renderer mode is a pure view-time filter — no re-processing needed
-  const viewState = useMemo((): EventsStreamViewState => {
-    if (rendererMode === "raw-single-json") {
-      return {
-        ...processorState,
-        slots: {
-          ...processorState.slots,
-          feed:
-            events.length === 0
-              ? []
-              : [
-                  {
-                    type: "raw-json-dump",
-                    id: "raw-json-dump",
-                    props: { events: [...events] },
-                  },
-                ],
-        },
-      };
-    }
-
-    if (rendererMode === "pretty") {
-      return {
-        ...processorState,
-        slots: {
-          ...processorState.slots,
-          feed: processorState.slots.feed.filter((element) => element.type !== "grouped-raw-event"),
-        },
-      };
-    }
-
-    // raw-pretty: show everything
-    return processorState;
-  }, [processorState, rendererMode, events]);
-
-  const rawPresets = useMemo(
-    () => buildRawPresets(viewState.activity.registeredProcessors),
-    [viewState.activity.registeredProcessors],
-  );
-
-  async function submitMessage() {
-    if (!messageComposer) return;
+  async function submit() {
     const trimmed = composerText.trim();
     if (!trimmed) return;
-
     setIsSubmitting(true);
+    setSubmitError(undefined);
     try {
-      await messageComposer.onSubmit(trimmed);
-      setComposerText("");
+      if (composerMode === "message" && messageComposer) {
+        await messageComposer.onSubmit(trimmed);
+      } else {
+        const parsed = parseYaml(trimmed) as unknown;
+        const events = (Array.isArray(parsed) ? parsed : [parsed]).map((event) =>
+          StreamEventInput.parse(event),
+        );
+        await store.appendBatch({ events });
+      }
+      setComposerText(composerMode === "raw" ? composerText : "");
     } catch (error) {
-      setErrorLabel(error instanceof Error ? error.message : String(error));
+      setSubmitError(error instanceof Error ? error.message : String(error));
     } finally {
       setIsSubmitting(false);
-    }
-  }
-
-  async function submitRawEvents() {
-    const trimmed = rawComposerText.trim();
-    if (!trimmed) return;
-
-    setIsSubmitting(true);
-    try {
-      const inputEvents = parseRawEventInputs(trimmed);
-      await createBrowserOpenApiClient().project.streams.appendBatch({
-        events: inputEvents,
-        projectSlugOrId,
-        streamPath,
-      });
-    } catch (error) {
-      setErrorLabel(error instanceof Error ? error.message : String(error));
-    } finally {
-      setIsSubmitting(false);
-    }
-  }
-
-  function selectRawPreset(presetId: string) {
-    setSelectedRawPresetId(presetId);
-    const preset = rawPresets.find((candidate) => candidate.id === presetId);
-    if (preset != null) {
-      setRawComposerText(preset.value);
-    }
-  }
-
-  function handleInputAction(action: EventsStreamInputAction) {
-    if (action.type === "prefill-agent-message") {
-      setComposerText(action.text);
-      setComposerMode("message");
     }
   }
 
   return (
-    <section className="flex min-h-0 flex-1 flex-col">
-      <div className="flex shrink-0 items-center justify-between gap-3 border-b p-4">
-        <EventsStreamPathLabel path={streamPath} className="min-w-0 text-sm font-medium" />
-        <EventsDebugLink
-          className="md:shrink-0"
-          namespace={projectSlugOrId}
-          streamPath={streamPath}
+    <section className="flex min-h-0 flex-1 flex-col bg-white">
+      <header className="shrink-0 border-b px-4 py-3">
+        <h1 className="truncate font-mono text-sm font-semibold">{streamPathText}</h1>
+        <StreamStatus count={eventCount} snapshot={snapshot} />
+      </header>
+      {countResult.status !== "ok" ? (
+        <Centered>
+          {countResult.status === "error"
+            ? (countResult.error?.message ?? "SQLite query failed")
+            : "Opening local SQLite mirror"}
+        </Centered>
+      ) : (
+        <VirtualEventRows
+          database={store.streamDatabase}
+          emptyLabel={emptyLabel}
+          eventCount={eventCount}
+          snapshot={snapshot}
         />
-      </div>
-      {headerAccessory == null ? null : <div className="shrink-0 border-b">{headerAccessory}</div>}
-
-      <EventsStreamView
-        className="min-h-0 flex-1"
-        viewState={viewState}
-        events={events}
-        openEventOffset={openEventOffset}
-        onOpenEventOffsetChange={setOpenEventOffset}
-        renderStreamPathLink={({ path, children, className }) => (
-          <Link
-            className={className}
-            to="/projects/$projectSlug/streams/$"
-            params={{
-              projectSlug,
-              _splat: streamPathToSplat(path),
-            }}
+      )}
+      <form
+        className="shrink-0 border-t p-3"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void submit();
+        }}
+      >
+        <textarea
+          className="block max-h-48 min-h-20 w-full resize-y rounded-md border px-3 py-2 font-mono text-[13px] outline-none focus:border-slate-400"
+          placeholder={messageComposer?.placeholder ?? "YAML event"}
+          spellCheck={false}
+          value={composerText}
+          onChange={(event) => setComposerText(event.currentTarget.value)}
+        />
+        <div className="mt-2 flex items-center justify-between gap-3">
+          <output className="min-w-0 truncate font-mono text-xs text-red-700">
+            {submitError ?? ""}
+          </output>
+          <button
+            className="rounded-md bg-slate-950 px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+            disabled={isSubmitting}
+            type="submit"
           >
-            {children}
-          </Link>
-        )}
-        emptyLabel={emptyLabel}
-        isPending={isPending}
-        errorLabel={errorLabel}
-        hiddenElementTypes={hiddenElementTypes}
-        onHiddenElementTypesChange={setHiddenElementTypes}
-        rendererMode={rendererMode}
-        onRendererModeChange={setRendererMode}
-      />
-
-      <EventsStreamLayoutMessageInput>
-        <EventsStreamInputSlot
-          className="mb-3"
-          elements={viewState.slots.input}
-          onAction={handleInputAction}
-        />
-        <EventsStreamComposer
-          mode={composerMode}
-          onModeChange={setComposerMode}
-          message={
-            hasMessageComposer
-              ? {
-                  value: composerText,
-                  onValueChange: setComposerText,
-                  onSubmit: submitMessage,
-                  placeholder: messageComposer.placeholder ?? "Message this stream",
-                }
-              : undefined
-          }
-          raw={{
-            value: rawComposerText,
-            onValueChange: setRawComposerText,
-            onSubmit: submitRawEvents,
-            presets: rawPresets,
-            selectedPresetId: selectedRawPresetId,
-            onSelectedPresetIdChange: selectRawPreset,
-          }}
-          isSubmitting={isSubmitting}
-        />
-      </EventsStreamLayoutMessageInput>
+            {isSubmitting ? "Sending" : composerMode === "message" ? "Send" : "Append"}
+          </button>
+        </div>
+      </form>
     </section>
   );
 }
 
-function appendStreamEvent(events: Event[], event: Event): Event[] {
-  const lastEvent = events[events.length - 1];
+function VirtualEventRows({
+  database,
+  emptyLabel,
+  eventCount,
+  snapshot,
+}: {
+  database: StreamBrowserDatabase;
+  emptyLabel: string;
+  eventCount: number;
+  snapshot: StreamBrowserSnapshot;
+}) {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const virtualizer = useVirtualizer({
+    count: eventCount,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 44,
+    overscan: 24,
+  });
 
-  // Fast path: event arrives in order (the normal SSE case)
-  if (lastEvent == null || event.offset > lastEvent.offset) {
-    return [...events, event];
-  }
+  useLayoutEffect(() => {
+    if (eventCount > 0) virtualizer.scrollToIndex(eventCount - 1, { align: "end" });
+  }, [eventCount, virtualizer]);
 
-  // Duplicate
-  if (event.offset === lastEvent.offset) return events;
-  if (events.some((candidate) => candidate.offset === event.offset)) return events;
-
-  // Out-of-order fallback
-  return [...events, event].toSorted((left, right) => left.offset - right.offset);
-}
-
-function parseRawEventInputs(value: string): EventInput[] {
-  const parsed = parseYaml(value) as unknown;
-  const inputEvents = Array.isArray(parsed) ? parsed : [parsed];
-
-  return inputEvents.map((inputEvent) => EventInput.parse(inputEvent));
-}
-
-function buildRawPresets(
-  processors: readonly EventsStreamRegisteredProcessor[],
-): EventsStreamComposerRawPreset[] {
-  const processorPresets: EventsStreamComposerRawPreset[] = [];
-
-  for (const processor of processors) {
-    for (const event of processor.ownedEvents) {
-      if (event.examples != null && event.examples.length > 0) {
-        for (const example of event.examples) {
-          processorPresets.push({
-            id: `${processor.slug}/${event.type}/${example.description}`,
-            label: `${shortEventType(event.type)}: ${example.description}`,
-            processorSlug: processor.slug,
-            eventType: event.type,
-            ...(event.description == null ? {} : { eventDescription: event.description }),
-            eventDocsHref: eventDocsHref({
-              processorSlug: processor.slug,
-              eventType: event.type,
-            }),
-            exampleName: example.description,
-            value: stringifyYaml({ type: event.type, payload: example.payload }),
-          });
-        }
-      } else {
-        processorPresets.push({
-          id: `${processor.slug}/${event.type}`,
-          label: `${shortEventType(event.type)}: Empty payload`,
-          processorSlug: processor.slug,
-          eventType: event.type,
-          ...(event.description == null ? {} : { eventDescription: event.description }),
-          eventDocsHref: eventDocsHref({
-            processorSlug: processor.slug,
-            eventType: event.type,
-          }),
-          exampleName: "Empty payload",
-          value: stringifyYaml({ type: event.type, payload: {} }),
-        });
-      }
+  const virtualItems = virtualizer.getVirtualItems();
+  const first = virtualItems[0]?.index ?? 0;
+  const last = virtualItems.at(-1)?.index ?? -1;
+  const rowsResult = useStreamQuery(
+    database,
+    `SELECT local_index, offset, type, idempotency_key, created_at, inserted_at, json(raw_jsonb) AS raw_json
+     FROM events
+     WHERE local_index >= ? AND local_index < ?
+     ORDER BY local_index ASC`,
+    [first, last + 1],
+  );
+  const rowsByIndex = useMemo(() => {
+    const rows = new Map<number, StreamEventRow>();
+    for (const row of rowsResult.data) {
+      if (typeof row.local_index === "number") rows.set(row.local_index, row as StreamEventRow);
     }
+    return rows;
+  }, [rowsResult.data]);
+
+  if (eventCount === 0) {
+    return (
+      <Centered>
+        {snapshot.connectionError ??
+          (snapshot.connectionStatus === "subscribed" ? emptyLabel : snapshot.connectionStatus)}
+      </Centered>
+    );
   }
 
-  return [...defaultRawEventPresets, ...processorPresets];
+  return (
+    <div ref={parentRef} className="min-h-0 flex-1 overflow-y-auto px-4">
+      <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
+        {virtualItems.map((item) => {
+          const row = rowsByIndex.get(item.index);
+          return (
+            <article
+              className="absolute left-0 top-0 w-full border-b py-2 font-mono text-xs"
+              key={item.key}
+              ref={row ? virtualizer.measureElement : undefined}
+              style={{ transform: `translateY(${item.start}px)` }}
+            >
+              {row ? (
+                <details>
+                  <summary className="grid cursor-pointer grid-cols-[64px_minmax(0,1fr)_auto] gap-3 text-slate-600">
+                    <span>#{row.offset}</span>
+                    <span className="truncate">{row.type}</span>
+                    <time>{row.created_at}</time>
+                  </summary>
+                  <pre className="mt-2 overflow-auto whitespace-pre-wrap break-words text-slate-800">
+                    {JSON.stringify(JSON.parse(row.raw_json), null, 2)}
+                  </pre>
+                </details>
+              ) : (
+                <div className="h-6 rounded bg-slate-100" />
+              )}
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
 }
 
-function shortEventType(eventType: string): string {
-  const lastSegment = eventType.split("/").pop();
-  return lastSegment ?? eventType;
+function StreamStatus({ count, snapshot }: { count: number; snapshot: StreamBrowserSnapshot }) {
+  return (
+    <p className="mt-1 flex gap-3 font-mono text-[11px] text-slate-500">
+      <span>{snapshot.connectionStatus}</span>
+      <span>{snapshot.subscriptionStatus}</span>
+      <span>{count.toLocaleString()} events</span>
+    </p>
+  );
 }
 
-function eventDocsHref(args: { processorSlug: string; eventType: string }) {
-  const prefix = `events.iterate.com/${args.processorSlug}/`;
-  const eventSlug = args.eventType.startsWith(prefix)
-    ? args.eventType.slice(prefix.length)
-    : (args.eventType.split("/").at(-1) ?? args.eventType);
-  return `https://events.iterate.com/${args.processorSlug}/${eventSlug}/`;
+function Centered({ children }: { children: ReactNode }) {
+  return (
+    <div className="grid min-h-0 flex-1 place-items-center p-6 text-sm text-slate-500">
+      {children}
+    </div>
+  );
+}
+
+function projectStreamRpcPath(projectSlugOrId: string, streamPath: string) {
+  const normalized =
+    streamPath === "" ? "/" : streamPath.startsWith("/") ? streamPath : `/${streamPath}`;
+  return normalized === "/"
+    ? `/api/project-streams/${encodeURIComponent(projectSlugOrId)}`
+    : `/api/project-streams/${encodeURIComponent(projectSlugOrId)}/${encodeURIComponent(normalized)}`;
 }

--- a/apps/os/src/entry.workerd.ts
+++ b/apps/os/src/entry.workerd.ts
@@ -1,5 +1,9 @@
 import { env as workerEnv } from "cloudflare:workers";
-import { Stream as PackageStream } from "@iterate-com/streams/workers/durable-objects/stream";
+import { newWorkersRpcResponse } from "capnweb";
+import {
+  PublicStreamRpcTarget,
+  Stream as PackageStream,
+} from "@iterate-com/streams/workers/durable-objects/stream";
 import { parseAppConfigFromEnv } from "@iterate-com/shared/apps/config";
 import { withEvlog } from "@iterate-com/shared/apps/logging/with-evlog";
 import { NitroWebSocketResponse } from "@iterate-com/shared/nitro-ws-response";
@@ -10,6 +14,7 @@ import crossws from "crossws/adapters/cloudflare";
 import { createD1Client } from "sqlfu";
 import {
   getInitializedStreamStub,
+  getStreamDurableObjectName,
   type StreamDurableObjectNamespace,
 } from "~/domains/streams/new-stream-runtime.ts";
 import manifest, { AppConfig } from "~/app.ts";
@@ -27,9 +32,12 @@ import { getProjectPlatformHostIngressRule } from "~/ingress/project-platform-ho
 import { getProjectCustomHostnameIngressRule } from "~/ingress/project-custom-hostname-routing.ts";
 import type { ExactHostIngressRule } from "~/ingress/types.ts";
 import { DEBUG_APPEND_CHAIN_EVENT_TYPE } from "~/durable-objects/debug-append-chain-subscriber.ts";
+import { createOsIterateAuth, resolveRequestAuth } from "~/auth/middleware.ts";
 import { handleMcpFetch } from "~/domains/inbound-mcp-server/mcp-handler.ts";
 import { handleRootIterateContextFetch } from "~/capnweb/root-context-fetch.ts";
 import { getProjectDurableObjectName } from "~/domains/projects/durable-objects/project-durable-object.ts";
+import { requireProjectScopedAccess } from "~/orpc/project-access.ts";
+import { resolveStreamPath } from "~/domains/streams/entrypoints/streams-capability.ts";
 
 // Re-export rpc-targets used by OS's existing loopback callable paths.
 // Stream processor subscriptions do not use these exports; they target Durable
@@ -65,6 +73,7 @@ export { WorkspaceDurableObject } from "~/domains/workspaces/durable-objects/wor
 const CAPTUN_TUNNEL_ROUTE_PREFIX = "/__iterate/captun";
 const EGRESS_ECHO_PATH = "/api/captnweb/egress-echo";
 const PROJECT_CAPNWEB_PATH = "/__iterate/capnweb";
+const PROJECT_STREAM_RPC_PREFIX = "/api/project-streams";
 const STREAM_SUBSCRIPTION_CONFIGURED_TYPE = "events.iterate.com/stream/subscription-configured";
 
 const config = parseAppConfigFromEnv({
@@ -172,6 +181,13 @@ export default {
           workerExports: cfCtx.exports,
         };
 
+        const projectStreamRpcResponse = await handleProjectStreamRpcFetch({
+          context,
+          env,
+          request,
+        });
+        if (projectStreamRpcResponse) return projectStreamRpcResponse;
+
         const captnwebResponse = await handleRootIterateContextFetch({
           request,
           env,
@@ -201,6 +217,70 @@ export default {
     });
   },
 };
+
+async function handleProjectStreamRpcFetch(input: {
+  context: AppContext;
+  env: Env;
+  request: Request;
+}): Promise<Response | null> {
+  const route = parseProjectStreamRpcRoute(input.request);
+  if (!route) return null;
+
+  const auth = createOsIterateAuth(input.context, input.request);
+  const resolvedAuth = await resolveRequestAuth({
+    auth,
+    context: input.context,
+    request: input.request,
+  });
+  const context: AppContext = {
+    ...input.context,
+    iterateAuthSession: resolvedAuth.session,
+    principal: resolvedAuth.principal,
+    rawRequest: input.request,
+  };
+  const project = await requireProjectScopedAccess({
+    context,
+    projectSlugOrId: route.projectSlugOrId,
+  });
+  const streamPath = resolveStreamPath(route.streamPath);
+  const stream = input.env.STREAM.getByName(
+    getStreamDurableObjectName({
+      namespace: project.id,
+      path: streamPath,
+    }),
+  );
+  const response = await newWorkersRpcResponse(input.request, new PublicStreamRpcTarget(stream));
+  const setCookie = resolvedAuth.responseHeaders.get("set-cookie");
+  if (setCookie) response.headers.append("set-cookie", setCookie);
+  return response;
+}
+
+function parseProjectStreamRpcRoute(request: Request): {
+  projectSlugOrId: string;
+  streamPath: string;
+} | null {
+  const url = new URL(request.url);
+  if (
+    url.pathname !== PROJECT_STREAM_RPC_PREFIX &&
+    !url.pathname.startsWith(`${PROJECT_STREAM_RPC_PREFIX}/`)
+  ) {
+    return null;
+  }
+
+  const remainder = url.pathname.slice(PROJECT_STREAM_RPC_PREFIX.length);
+  const match = /^\/([^/]+)(?:\/(.*))?$/.exec(remainder);
+  if (!match) return null;
+  const projectSlugOrId = decodeURIComponent(match[1] ?? "").trim();
+  if (!projectSlugOrId) return null;
+  const encodedStreamPath = match[2];
+  return {
+    projectSlugOrId,
+    streamPath:
+      encodedStreamPath == null || encodedStreamPath === ""
+        ? "/"
+        : decodeURIComponent(encodedStreamPath),
+  };
+}
 
 function handleEgressEchoFetch(input: { request: Request }) {
   const url = new URL(input.request.url);

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -4,8 +4,12 @@
   "type": "module",
   "exports": {
     "./connection": "./src/connection.ts",
+    "./browser/hooks/use-stream-query": "./src/browser/hooks/use-stream-query.ts",
+    "./browser/stream-browser-db": "./src/browser/stream-browser-db.ts",
+    "./browser/stream-browser-store": "./src/browser/stream-browser-store.ts",
     "./processor": "./src/processor.ts",
     "./processor-runner": "./src/processor-runner.ts",
+    "./processors/browser-raw-events/implementation": "./src/processors/browser-raw-events/implementation.ts",
     "./processors/core/contract": "./src/processors/core/contract.ts",
     "./shared/event": "./src/shared/event.ts",
     "./shared/rpc-target": "./src/shared/rpc-target.ts",

--- a/packages/streams/src/browser/stream-browser-store.ts
+++ b/packages/streams/src/browser/stream-browser-store.ts
@@ -30,8 +30,9 @@ import {
   type StreamDatabaseInfo,
 } from "./stream-browser-db.ts";
 
-// Stream DOs are named `${namespace}:${path}`; the browser namespace is "default".
-const STREAM_NAMESPACE = "default";
+// Stream DOs are named `${namespace}:${path}`. The example app uses "default";
+// host apps can pass their own namespace, e.g. an OS project id.
+const DEFAULT_STREAM_NAMESPACE = "default";
 const LIVE_PROGRESS_NOTIFICATION_MS = 16;
 
 export type StreamBrowserSnapshot = {
@@ -53,6 +54,11 @@ export type BrowserProcessorConfig = {
   tables: string[];
   /** Durable resume cursor + reduced state, read back from this processor's own tables. */
   loadCheckpoint(sql: SqlClient): Promise<{ state: unknown; offset: number } | undefined>;
+};
+
+export type BrowserStreamConnectionConfig = {
+  namespace?: string;
+  streamUrl?: string | URL | ((args: { namespace: string; streamPath: string }) => string | URL);
 };
 
 export type StreamRuntimeState = {
@@ -80,11 +86,11 @@ export type StreamBrowserStore = Disposable & {
 
 const databaseRegistry = new Map<string, { db: StreamBrowserDatabase; refs: number }>();
 
-function acquireDatabase(streamPath: string) {
-  const key = streamPath;
+function acquireDatabase(namespace: string, streamPath: string) {
+  const key = `${namespace}\0${streamPath}`;
   let entry = databaseRegistry.get(key);
   if (entry === undefined) {
-    entry = { db: new StreamBrowserDatabase(STREAM_NAMESPACE, streamPath), refs: 0 };
+    entry = { db: new StreamBrowserDatabase(namespace, streamPath), refs: 0 };
     databaseRegistry.set(key, entry);
   }
   entry.refs += 1;
@@ -105,23 +111,36 @@ const runtimeRegistry = new Map<string, StreamBrowserStore>();
 
 /** Get (or lazily create) the shared runtime for one (path, processor). */
 export function acquireStreamRuntime(
-  args: { streamPath: string } & BrowserProcessorConfig,
+  args: { streamPath: string } & BrowserProcessorConfig & BrowserStreamConnectionConfig,
 ): StreamBrowserStore {
+  const namespace = args.namespace ?? DEFAULT_STREAM_NAMESPACE;
   const slug = args.processor.contract.slug;
-  const key = `${args.streamPath} ${slug}`;
+  const key = `${namespace} ${args.streamPath} ${slug}`;
   const existing = runtimeRegistry.get(key);
   if (existing !== undefined) return existing;
-  const runtime = createStreamRuntime({ ...args, onDispose: () => runtimeRegistry.delete(key) });
+  const runtime = createStreamRuntime({
+    ...args,
+    namespace,
+    onDispose: () => runtimeRegistry.delete(key),
+  });
   runtimeRegistry.set(key, runtime);
   return runtime;
 }
 
 function createStreamRuntime(
-  args: { streamPath: string; onDispose?: () => void } & BrowserProcessorConfig,
+  args: {
+    namespace: string;
+    streamPath: string;
+    onDispose?: () => void;
+  } & BrowserProcessorConfig &
+    BrowserStreamConnectionConfig,
 ): StreamBrowserStore {
   const { processor, schemaVersion, tables, loadCheckpoint } = args;
   const slug = processor.contract.slug;
-  const { db: streamDatabase, release: releaseDatabase } = acquireDatabase(args.streamPath);
+  const { db: streamDatabase, release: releaseDatabase } = acquireDatabase(
+    args.namespace,
+    args.streamPath,
+  );
 
   // A plain SQLite client for the processor. Each committed write nudges the reactive
   // queries (coalesced to one notify per tick so a replay storm shows partial progress).
@@ -162,7 +181,7 @@ function createStreamRuntime(
     localStorage.getItem(browserSubscriberStorageKey) ?? crypto.randomUUID();
   localStorage.setItem(browserSubscriberStorageKey, browserSubscriberId);
   // One stream subscription per (browser profile, processor); namespace keeps it distinct.
-  const subscriptionKey = `${STREAM_NAMESPACE}:${browserSubscriberId}:${slug}`;
+  const subscriptionKey = `${args.namespace}:${browserSubscriberId}:${slug}`;
   let snapshot: StreamBrowserSnapshot = {
     clearVersion: 0,
     connectionStatus: "connecting",
@@ -275,7 +294,7 @@ function createStreamRuntime(
 
   function connect() {
     if (stream !== undefined || disposed) return;
-    const streamUrl = new URL(streamRpcPath(args.streamPath), window.location.href);
+    const streamUrl = new URL(resolveStreamUrl(args), window.location.href);
 
     void withStreamConnectionFromBrowser({
       url: streamUrl,
@@ -325,7 +344,7 @@ function createStreamRuntime(
 
     writerRole = acquireWriterRole({
       lockName: streamWriterLockName({
-        namespace: STREAM_NAMESPACE,
+        namespace: args.namespace,
         streamPath: args.streamPath,
         slug,
         schemaVersion,
@@ -503,4 +522,15 @@ function errorMessage(error: unknown) {
 
 function isWriteStatement(sql: string) {
   return /^\s*(INSERT|UPDATE|DELETE|CREATE|DROP|ALTER|REPLACE|PRAGMA\s+user_version)/i.test(sql);
+}
+
+function resolveStreamUrl(args: {
+  namespace: string;
+  streamPath: string;
+  streamUrl?: BrowserStreamConnectionConfig["streamUrl"];
+}) {
+  if (typeof args.streamUrl === "function") {
+    return args.streamUrl({ namespace: args.namespace, streamPath: args.streamPath });
+  }
+  return args.streamUrl ?? streamRpcPath(args.streamPath);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -867,6 +867,9 @@ importers:
       '@tanstack/react-start':
         specifier: 1.167.5
         version: 1.167.5(crossws@0.4.4(srvx@0.11.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@tanstack/react-virtual':
+        specifier: ^3.14.2
+        version: 3.14.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       agents:
         specifier: ^0.11.0
         version: 0.11.0(@babel/core@7.29.0)(@babel/runtime@7.28.6)(@cloudflare/codemode@0.3.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@tanstack/ai@0.10.2)(ai@6.0.159(zod@4.3.6))(zod@4.3.6))(@cloudflare/workers-types@4.20260426.1)(@tanstack/ai@0.10.2)(ai@6.0.159(zod@4.3.6))(react@19.2.4)(rolldown@1.0.3)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)


### PR DESCRIPTION
## What changed

- Replaced the OS stream detail renderer with a small raw event view backed by `@iterate-com/streams` browser runtime.
- Added project-scoped Cap,'n Web stream RPC routing for OS browser clients.
- Let the streams browser runtime accept a namespace and custom stream URL, so OS can use project IDs and its own route.
- Added the browser runtime exports and `@tanstack/react-virtual` dependency needed by OS.

## Why

The old OS event stream path kept the full stream in React state and reduced it through the heavier UI event renderer. This switches it to the simpler streams package model: Cap,'n Web subscription, local SQLite mirror, and virtualized rows.

## Validation

- `pnpm --dir apps/os typecheck`
- `pnpm --dir packages/streams typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new authenticated RPC path to stream Durable Objects and materially changes stream UI behavior and append paths, though it follows the existing streams package pattern.
> 
> **Overview**
> **Replaces** the OS project stream detail page with a lightweight raw-event viewer wired to the `@iterate-com/streams` browser runtime (Cap'n Web subscription, local SQLite mirror, windowed SQL reads) and **virtualized** rows via `@tanstack/react-virtual`, instead of holding the full stream in React state and rendering through the heavy `@iterate-com/ui` events stack.
> 
> **Adds** a project-scoped stream RPC entrypoint at `/api/project-streams/{projectSlugOrId}/…` in the OS worker: resolves auth and `requireProjectScopedAccess`, maps to the project’s stream Durable Object, and serves `PublicStreamRpcTarget` over Cap'n Web (with session cookies forwarded when needed).
> 
> **Extends** the streams browser store so host apps can pass a **namespace** (e.g. project id) and a **custom stream URL**; exports browser hooks/DB/store and the `browser-raw-events` processor for OS. Raw appends in the simplified composer go through `store.appendBatch` rather than the OpenAPI append client.
> 
> **Tradeoff:** the new UI drops the old feed render modes, processor-driven raw presets, debug link, and related stream-feed chrome in favor of monospace summary rows and a single YAML/message textarea.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b821868d7aaddd21e93de0c179a1463df512eb9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-09T06:50:42.354Z",
      "headSha": "b821868d7aaddd21e93de0c179a1463df512eb9a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27169869150",
      "shortSha": "b821868"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `b821868`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27169869150)
Updated: 2026-06-09T06:50:42.354Z
<!-- /CLOUDFLARE_PREVIEW -->