### PR TITLE
[codex] fix Cap'n Web REPL transparent roots

### DIFF
--- a/apps/os/src/capnweb/browser-repl.test.ts
+++ b/apps/os/src/capnweb/browser-repl.test.ts
@@ -7,7 +7,7 @@ import {
   evalBrowserReplSessionCode,
   runBrowserReplEntry,
 } from "./browser-repl.ts";
-import { liftLocalProxies } from "./local-proxy-wrapper.js";
+import { liftLocalProxies, localProxyCaller } from "./local-proxy-wrapper.js";
 
 describe("browser Cap'n Web REPL", () => {
   test("default snippet uses Cap'n Web promise pipelining", async () => {
@@ -32,6 +32,32 @@ describe("browser Cap'n Web REPL", () => {
     expect(list).toHaveBeenCalledWith({ limit: 5 });
   });
 
+  test("default snippet does not probe a callable RPC root then member", async () => {
+    let thenReads = 0;
+    const rpcRoot = Object.assign(() => undefined, {
+      projects: {
+        list(input: { limit: number }) {
+          return { projects: [], total: 0, limit: input.limit };
+        },
+      },
+    });
+    Object.defineProperty(rpcRoot, "then", {
+      configurable: true,
+      get() {
+        thenReads += 1;
+        throw new Error("remote then should not be read");
+      },
+    });
+
+    await expect(
+      evalBrowserReplCode({
+        code: DEFAULT_BROWSER_REPL_CODE,
+        ctx: liftLocalProxies(rpcRoot),
+      }),
+    ).resolves.toEqual({ projects: [], total: 0, limit: 5 });
+    expect(thenReads).toBe(0);
+  });
+
   test("route entry runner succeeds for the default project list snippet", async () => {
     const ctx = liftLocalProxies({
       projects: {
@@ -52,6 +78,24 @@ describe("browser Cap'n Web REPL", () => {
       output: JSON.stringify({ projects: [{ id: "proj_123" }], total: 1, limit: 5 }, null, 2),
       status: "success",
     });
+  });
+
+  test("REPL supports pre-await Slack SDK-shaped local proxy calls", async () => {
+    const call = vi.fn(async (input: { args: unknown[]; path: string[] }) => input);
+    const ctx = liftLocalProxies({
+      slack: Promise.resolve(localProxyCaller(call)),
+    });
+
+    await expect(
+      evalBrowserReplCode({
+        code: `await ctx.slack.chat.postMessage({ channel: "C123", text: "hi" })`,
+        ctx,
+      }),
+    ).resolves.toEqual({
+      args: [{ channel: "C123", text: "hi" }],
+      path: ["chat", "postMessage"],
+    });
+    expect(call).toHaveBeenCalledTimes(1);
   });
 
   test("session snippets can reference previous local variables", async () => {

--- a/apps/os/src/capnweb/browser-repl.test.ts
+++ b/apps/os/src/capnweb/browser-repl.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_BROWSER_REPL_CODE,
   evalBrowserReplCode,
   evalBrowserReplSessionCode,
+  runBrowserReplEntry,
 } from "./browser-repl.ts";
 import { liftLocalProxies } from "./local-proxy-wrapper.js";
 
@@ -29,6 +30,28 @@ describe("browser Cap'n Web REPL", () => {
       items: [{ id: "proj_123" }],
     });
     expect(list).toHaveBeenCalledWith({ limit: 5 });
+  });
+
+  test("route entry runner succeeds for the default project list snippet", async () => {
+    const ctx = liftLocalProxies({
+      projects: {
+        list(input: { limit: number }) {
+          return { projects: [{ id: "proj_123" }], total: 1, limit: input.limit };
+        },
+      },
+    });
+
+    await expect(
+      runBrowserReplEntry({
+        code: DEFAULT_BROWSER_REPL_CODE,
+        ctx,
+        scope: {},
+      }),
+    ).resolves.toEqual({
+      code: DEFAULT_BROWSER_REPL_CODE,
+      output: JSON.stringify({ projects: [{ id: "proj_123" }], total: 1, limit: 5 }, null, 2),
+      status: "success",
+    });
   });
 
   test("session snippets can reference previous local variables", async () => {

--- a/apps/os/src/capnweb/browser-repl.ts
+++ b/apps/os/src/capnweb/browser-repl.ts
@@ -7,6 +7,12 @@ export type BrowserReplExample = {
   title: string;
 };
 
+export type BrowserReplEntry = {
+  code: string;
+  output: string;
+  status: "error" | "success";
+};
+
 // These are intentionally ordinary REPL snippets for now. They should
 // eventually become living tests: the actual e2e test snippets appear here, and
 // this replaces codemode snippets entirely.
@@ -51,6 +57,34 @@ export async function evalBrowserReplSessionCode(input: {
   scope: Record<string, unknown>;
 }) {
   return await compileBrowserReplFunction(input.code)(input.ctx, input.env ?? {}, input.scope);
+}
+
+export async function runBrowserReplEntry(input: {
+  code: string;
+  ctx: unknown;
+  env?: object;
+  scope: Record<string, unknown>;
+}): Promise<BrowserReplEntry> {
+  const trimmedCode = input.code.trim();
+  try {
+    const result = await evalBrowserReplSessionCode({
+      code: trimmedCode,
+      ctx: input.ctx,
+      env: input.env,
+      scope: input.scope,
+    });
+    return {
+      code: trimmedCode,
+      output: formatBrowserReplResult(result),
+      status: "success",
+    };
+  } catch (error) {
+    return {
+      code: trimmedCode,
+      output: error instanceof Error ? (error.stack ?? error.message) : String(error),
+      status: "error",
+    };
+  }
 }
 
 export function compileBrowserReplFunction(code: string) {

--- a/apps/os/src/capnweb/e2e/captnweb.browser.test.ts
+++ b/apps/os/src/capnweb/e2e/captnweb.browser.test.ts
@@ -246,10 +246,10 @@ describe("capnweb browser execution mode", () => {
     });
 
     const connection = (await projectContext.connections.get(connectionKey)) as any;
-    const slack = liftLocalProxies(await connection.sdk()) as any;
+    const ctxWithSlack = liftLocalProxies({ slack: connection.sdk() }) as any;
 
     await expect(
-      slack.chat.postMessage({
+      ctxWithSlack.slack.chat.postMessage({
         channel: "C_BROWSER",
         text: "hello from browser",
       }),

--- a/apps/os/src/capnweb/e2e/captnweb.browser.test.ts
+++ b/apps/os/src/capnweb/e2e/captnweb.browser.test.ts
@@ -5,8 +5,12 @@ import {
   EXAMPLE_EGRESS_SECRET_KEY,
   EXAMPLE_EGRESS_SECRET_MATERIAL,
 } from "../../domains/secrets/example-secret.ts";
-import { BROWSER_REPL_EXAMPLES, evalBrowserReplSessionCode } from "../browser-repl.ts";
-import { liftLocalProxies } from "../local-proxy-wrapper.js";
+import {
+  BROWSER_REPL_EXAMPLES,
+  DEFAULT_BROWSER_REPL_CODE,
+  evalBrowserReplSessionCode,
+} from "../browser-repl.ts";
+import { liftLocalProxies, localProxyCaller } from "../local-proxy-wrapper.js";
 import type { IterateContext } from "../iterate-context-capability.ts";
 import type { ProjectCapabilityApi } from "../../domains/projects/durable-objects/project-durable-object.ts";
 import {
@@ -37,6 +41,22 @@ describe("capnweb browser execution mode", () => {
       await projects.remove({ id }).catch(() => {});
     }
   });
+
+  it("runs the default browser REPL project list expression", async () => {
+    using root = await withRootIterateFromBrowser();
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: DEFAULT_BROWSER_REPL_CODE,
+        ctx: root,
+        env: {},
+        scope: {},
+      }),
+    ).resolves.toMatchObject({
+      projects: expect.any(Array),
+      total: expect.any(Number),
+    });
+  }, 60_000);
 
   it("runs codemode-shaped scripts through browser Cap'n Web stubs", async () => {
     using root = await withRootIterateFromBrowser();
@@ -196,6 +216,48 @@ describe("capnweb browser execution mode", () => {
     }
 
     expect(alertMessages).toEqual(["The answer is 42"]);
+  }, 60_000);
+
+  it("calls a browser-owned Slack SDK-shaped local proxy marker", async () => {
+    using root = await withRootIterateFromBrowser();
+    using projects = await root.projects;
+    const project = await projects.create({
+      slug: `captnweb-browser-slack-${uniqueSuffix()}`.slice(0, 40),
+    });
+    createdProjectIds.push(project.id);
+
+    using iterate = await withIterateFromBrowser({ ingressUrl: project.ingressUrl });
+    using projectContext = await iterate.ctx.project;
+    const connectionKey = `browser-slack-sdk-${uniqueSuffix()}`;
+
+    class BrowserSlackSdkTarget extends RpcTarget {
+      sdk() {
+        return localProxyCaller(({ path, args }) => ({
+          args,
+          ok: true,
+          path,
+        }));
+      }
+    }
+
+    await projectContext.provideCapability({
+      connectionKey,
+      rpcTarget: new BrowserSlackSdkTarget(),
+    });
+
+    const connection = (await projectContext.connections.get(connectionKey)) as any;
+    const slack = liftLocalProxies(await connection.sdk()) as any;
+
+    await expect(
+      slack.chat.postMessage({
+        channel: "C_BROWSER",
+        text: "hello from browser",
+      }),
+    ).resolves.toEqual({
+      args: [{ channel: "C_BROWSER", text: "hello from browser" }],
+      ok: true,
+      path: ["chat", "postMessage"],
+    });
   }, 60_000);
 });
 

--- a/apps/os/src/capnweb/local-proxy-wrapper.js
+++ b/apps/os/src/capnweb/local-proxy-wrapper.js
@@ -1,5 +1,5 @@
 export const LOCAL_PROXY_CALLER_MARK = "__localProxyCaller";
-const TRANSPARENT_RPC_ROOTS = new Set([
+const BUILT_IN_RPC_ROOTS = new Set([
   "project",
   "projects",
   "repos",
@@ -46,9 +46,10 @@ const TRANSPARENT_RPC_ROOTS = new Set([
  *
  *      const ctx = liftLocalProxies(await env.ITERATE.context)
  *
- * 3. When `ctx.slack.chat.postMessage(...)` reaches a marker, this wrapper
- *    uses a local path proxy. Every property read after the marker root records
- *    another path segment, and the final function call invokes:
+ * 3. When `ctx.slack.chat.postMessage(...)` starts from an unresolved RPC
+ *    promise, this wrapper records the path but does not assume Slack yet. The
+ *    final function call waits for the original promise. Only if that promise
+ *    resolves to a marker do we invoke:
  *
  *      call({ path: ["chat", "postMessage"], args: [{ channel, text }] })
  *
@@ -81,6 +82,16 @@ export function callLocalProxyCaller(value, input) {
 
 function adapt(value) {
   if (!isLocalProxyCaller(value)) return value;
+  // Regression guard:
+  // - Unit: local-proxy-wrapper.test.ts
+  //   "supports SDK-shaped calls through a pending ... local proxy marker"
+  // - Browser e2e: captnweb.browser.test.ts
+  //   "calls a browser-owned Slack SDK-shaped local proxy marker"
+  //
+  // This is the only place where the helper intentionally changes a value's
+  // behavior. A marker is plain data saying "turn this one awaited value into
+  // an SDK-shaped path recorder". Ordinary Cap'n Web / Workers RPC stubs must
+  // not come through here.
   return pathProxy(value.call);
 }
 
@@ -89,44 +100,109 @@ function lift(value) {
   if ((typeof value !== "object" && typeof value !== "function") || value === null) {
     return value;
   }
-  if (isThenable(value) && typeof value !== "function") return pendingValueProxy(value, value, []);
+  // Native promises are not callable, so treating a top-level one as a pending
+  // marker candidate cannot reproduce the production REPL bug. The regression
+  // was specifically a callable Cap'n Web root (`newWebSocketRpcSession(...)`)
+  // whose synthetic `.then` member made the old helper think the whole root was
+  // a promise before `ctx.projects.list({ limit: 5 })` had a chance to dispatch.
+  //
+  // Regression guard:
+  // - local-proxy-wrapper.test.ts
+  //   "does not even read a callable RPC root then member..."
+  if (typeof value === "object" && isThenable(value)) {
+    return pendingValueProxy(value, value, []);
+  }
 
-  // This Proxy is client-side only. Cloudflare Workers RPC and Cap'n Web both
-  // already use JavaScript Proxy objects for remote stubs:
+  // This Proxy is client-side only and deliberately transparent for built-in
+  // Cap'n Web roots. The one exception is unknown top-level roots, which are
+  // how mounted provider SDKs enter the context. Example: `ctx.slack` is not a
+  // real IterateContext prototype method, it is a mounted root that resolves to
+  // localProxyCaller(...).
+  //
+  // Cloudflare Workers RPC and Cap'n Web both already use JavaScript Proxy
+  // objects for remote stubs:
   // - https://developers.cloudflare.com/workers/runtime-apis/rpc/
   // - https://github.com/cloudflare/capnweb
   //
-  // We wrap the stub/promise locally so property reads on an unresolved RPC
-  // promise still pipeline through to the eventual value, but we do not change
-  // ordinary RPC semantics. The only special case is a value marked by
-  // localProxyCaller(), which becomes an SDK-shaped local path proxy. This is
-  // why normal calls such as ctx.projects.get(id).describe() still dispatch
-  // through the runtime stub, while marker values can support Slack-style
-  // unknown paths such as ctx.slack.chat.postMessage(...).
+  // Built-in roots stay raw so normal RPC promise-pipelining remains owned by
+  // Cap'n Web:
+  //
+  //   await ctx.projects.list({ limit: 5 })
+  //   await ctx.projects.get(id).describe()
+  //
+  // Unknown roots get pending SDK recording:
+  //
+  //   await ctx.slack.chat.postMessage({ channel, text })
+  //
+  // The pending recorder still waits for `ctx.slack` to resolve before doing
+  // anything. If that value is not localProxyCaller(...), it falls back to the
+  // captured normal member/call path.
+  //
+  // Regression guard:
+  // - Unit: local-proxy-wrapper.test.ts
+  //   "does not treat ordinary callable proxy targets as promises..."
+  // - Unit: browser-repl.test.ts
+  //   "default snippet uses Cap'n Web promise pipelining"
+  // - Browser e2e: captnweb.browser.test.ts
+  //   "runs the default browser REPL project list expression"
+  //
+  // Those tests cover the production failure where the browser REPL evaluated
+  // `await ctx.projects.list({ limit: 5 })` and the wrapper accidentally
+  // treated a callable Cap'n Web root proxy's synthetic `then` member as a
+  // promise. The built-in root table is intentionally a narrow boundary: known
+  // Iterate RPC roots are left to Cap'n Web, while unknown mounted roots can
+  // still opt into the SDK recorder by resolving to localProxyCaller(...).
   return new Proxy(value, {
     get(target, key, receiver) {
+      if (key === "then" && typeof target === "function") {
+        // Promise machinery probes `.then`. Cap'n Web's callable root proxies
+        // can synthesize arbitrary string members, including `then`, but that
+        // must not make the lifted root itself thenable. This exact probe is
+        // pinned by local-proxy-wrapper.test.ts:
+        // "does not even read a callable RPC root then member..."
+        return undefined;
+      }
+
       const member = Reflect.get(target, key, receiver);
-      if (typeof key === "string" && TRANSPARENT_RPC_ROOTS.has(key)) {
+      if (typeof key === "string" && BUILT_IN_RPC_ROOTS.has(key)) {
         return member;
       }
-      if (isLocalProxyCaller(member) || isThenable(member)) {
-        return isThenable(member) ? pendingValueProxy(member, member, []) : lift(member);
-      }
-      return member;
+      return liftReturnValue(member);
     },
 
     apply(target, thisArg, args) {
-      return lift(Reflect.apply(target, thisArg, args));
+      return liftReturnValue(Reflect.apply(target, thisArg, args));
     },
   });
 }
 
+function liftReturnValue(value) {
+  if (isLocalProxyCaller(value)) return adapt(value);
+  // This is where unknown roots such as `ctx.slack` become eligible for
+  // SDK-shaped path recording. Known Iterate roots are filtered out one level
+  // above, so ordinary Cap'n Web promises below `ctx.projects` / `ctx.project`
+  // do not pass through this helper at all.
+  //
+  // Regression guard:
+  // - local-proxy-wrapper.test.ts
+  //   "supports SDK-shaped calls through a pending ... local proxy marker"
+  // - browser-repl.test.ts
+  //   "REPL supports pre-await Slack SDK-shaped local proxy calls"
+  if (isThenable(value)) return pendingValueProxy(value, value, []);
+  return value;
+}
+
 function isThenable(value) {
-  return (
-    value !== null &&
-    (typeof value === "object" || typeof value === "function") &&
-    typeof value.then === "function"
-  );
+  if (value === null || (typeof value !== "object" && typeof value !== "function")) return false;
+  try {
+    return typeof value.then === "function";
+  } catch {
+    // Unit test "does not even read a callable RPC root then member..." uses a
+    // throwing getter to make this failure mode loud. If a random object makes
+    // `.then` hostile, it is safer to leave it alone than to classify it as an
+    // SDK marker candidate.
+    return false;
+  }
 }
 
 function pendingValueProxy(value, rootPromise, path) {
@@ -154,6 +230,16 @@ function pendingValueProxy(value, rootPromise, path) {
         return Reflect.get(target, key, receiver);
       }
 
+      // This is the pending Slack SDK path recorder. The key rule is that
+      // recording does not mean execution. `ctx.slack.chat.postMessage` records
+      // ["chat", "postMessage"], but invokePendingValue below still waits for
+      // `ctx.slack` and only calls the recorded path when it resolves to a
+      // localProxyCaller marker. If it resolves to a normal RPC/JS object,
+      // fallback dispatch uses the captured member or the resolved object path.
+      //
+      // Regression guard:
+      // - captnweb.browser.test.ts
+      //   "calls a browser-owned Slack SDK-shaped local proxy marker"
       const member = value == null ? undefined : Reflect.get(value, key);
       return pendingValueProxy(member, rootPromise, [...path, key]);
     },

--- a/apps/os/src/capnweb/local-proxy-wrapper.js
+++ b/apps/os/src/capnweb/local-proxy-wrapper.js
@@ -89,7 +89,7 @@ function lift(value) {
   if ((typeof value !== "object" && typeof value !== "function") || value === null) {
     return value;
   }
-  if (isThenable(value)) return pendingValueProxy(value, value, []);
+  if (isThenable(value) && typeof value !== "function") return pendingValueProxy(value, value, []);
 
   // This Proxy is client-side only. Cloudflare Workers RPC and Cap'n Web both
   // already use JavaScript Proxy objects for remote stubs:
@@ -105,20 +105,12 @@ function lift(value) {
   // unknown paths such as ctx.slack.chat.postMessage(...).
   return new Proxy(value, {
     get(target, key, receiver) {
-      if (key === "then" && typeof target.then === "function") {
-        return (onFulfilled, onRejected) =>
-          target.then(
-            (resolved) => (onFulfilled ? onFulfilled(adapt(resolved)) : adapt(resolved)),
-            (error) => onRejected?.(error),
-          );
-      }
-
       const member = Reflect.get(target, key, receiver);
       if (typeof key === "string" && TRANSPARENT_RPC_ROOTS.has(key)) {
         return member;
       }
       if (isLocalProxyCaller(member) || isThenable(member)) {
-        return lift(member);
+        return isThenable(member) ? pendingValueProxy(member, member, []) : lift(member);
       }
       return member;
     },

--- a/apps/os/src/capnweb/local-proxy-wrapper.test.ts
+++ b/apps/os/src/capnweb/local-proxy-wrapper.test.ts
@@ -21,6 +21,27 @@ describe("liftLocalProxies", () => {
     expect(thenCalls).toBe(0);
   });
 
+  test("does not even read a callable RPC root then member while calling normal members", () => {
+    let thenReads = 0;
+    const rpcStub = Object.assign(() => undefined, {
+      projects: {
+        list: () => ({ projects: [], total: 0 }),
+      },
+    });
+    Object.defineProperty(rpcStub, "then", {
+      configurable: true,
+      get() {
+        thenReads += 1;
+        throw new Error("remote then should not be read");
+      },
+    });
+
+    const lifted = liftLocalProxies(rpcStub) as typeof rpcStub;
+
+    expect(lifted.projects.list()).toEqual({ projects: [], total: 0 });
+    expect(thenReads).toBe(0);
+  });
+
   test("preserves direct calls through Cap'n Web promise properties", async () => {
     class Project extends RpcTarget {
       describe() {
@@ -60,7 +81,7 @@ describe("liftLocalProxies", () => {
     await expect(ctx.projects.get("proj_123").describe()).resolves.toEqual({ id: "proj_123" });
   });
 
-  test("supports pipelined SDK-shaped calls through a pending local proxy marker", async () => {
+  test("supports SDK-shaped calls through a native pending local proxy marker", async () => {
     const call = async (input: { args: unknown[]; path: string[] }) => input;
     const ctx = liftLocalProxies({
       slack: Promise.resolve(localProxyCaller(call)),
@@ -78,7 +99,7 @@ describe("liftLocalProxies", () => {
     });
   });
 
-  test("supports SDK-shaped calls through a Cap'n Web promise marker", async () => {
+  test("supports SDK-shaped calls through a pending Cap'n Web local proxy marker", async () => {
     const call = async (input: { args: unknown[]; path: string[] }) => input;
 
     class Context extends RpcTarget {

--- a/apps/os/src/capnweb/local-proxy-wrapper.test.ts
+++ b/apps/os/src/capnweb/local-proxy-wrapper.test.ts
@@ -3,6 +3,24 @@ import { describe, expect, test } from "vitest";
 import { liftLocalProxies, localProxyCaller } from "./local-proxy-wrapper.js";
 
 describe("liftLocalProxies", () => {
+  test("does not treat ordinary callable proxy targets as promises just because they expose then", () => {
+    let thenCalls = 0;
+    const rpcStub = Object.assign(() => undefined, {
+      projects: {
+        list: () => ({ projects: [], total: 0 }),
+      },
+      then: () => {
+        thenCalls += 1;
+        throw new Error("remote then should not be called");
+      },
+    });
+
+    const lifted = liftLocalProxies(rpcStub) as typeof rpcStub;
+
+    expect(lifted.projects.list()).toEqual({ projects: [], total: 0 });
+    expect(thenCalls).toBe(0);
+  });
+
   test("preserves direct calls through Cap'n Web promise properties", async () => {
     class Project extends RpcTarget {
       describe() {

--- a/apps/os/src/routes/_app/capnweb-repl.tsx
+++ b/apps/os/src/routes/_app/capnweb-repl.tsx
@@ -15,8 +15,8 @@ import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
 import {
   BROWSER_REPL_EXAMPLES,
   DEFAULT_BROWSER_REPL_CODE,
-  evalBrowserReplSessionCode,
-  formatBrowserReplResult,
+  runBrowserReplEntry,
+  type BrowserReplEntry,
 } from "~/capnweb/browser-repl.ts";
 import { liftLocalProxies } from "~/capnweb/local-proxy-wrapper.js";
 import type { IterateContext } from "~/capnweb/iterate-context-capability.ts";
@@ -28,17 +28,11 @@ export const Route = createFileRoute("/_app/capnweb-repl")({
   component: CapnwebReplPage,
 });
 
-type ReplEntry = {
-  code: string;
-  output: string;
-  status: "error" | "success";
-};
-
 function CapnwebReplPage() {
   const [code, setCode] = useState(DEFAULT_BROWSER_REPL_CODE);
   const [ctx, setCtx] = useState<RpcStub<IterateContext> | null>(null);
   const [status, setStatus] = useState("Connecting...");
-  const [entries, setEntries] = useState<ReplEntry[]>([]);
+  const [entries, setEntries] = useState<BrowserReplEntry[]>([]);
   const [examplesOpen, setExamplesOpen] = useState(false);
   const envRef = useRef<Record<string, unknown>>({});
   const scopeRef = useRef<Record<string, unknown>>({ RpcTarget });
@@ -69,30 +63,15 @@ function CapnwebReplPage() {
     const trimmedCode = code.trim();
     if (!ctx || trimmedCode === "") return;
     setStatus("Running...");
-    try {
-      const result = await evalBrowserReplSessionCode({
-        code: trimmedCode,
-        ctx,
-        env: envRef.current,
-        scope: scopeRef.current,
-      });
-      setEntries((current) => [
-        ...current,
-        { code: trimmedCode, output: formatBrowserReplResult(result), status: "success" },
-      ]);
-      setCode("");
-      setStatus("Connected");
-    } catch (error) {
-      setEntries((current) => [
-        ...current,
-        {
-          code: trimmedCode,
-          output: error instanceof Error ? (error.stack ?? error.message) : String(error),
-          status: "error",
-        },
-      ]);
-      setStatus("Connected");
-    }
+    const entry = await runBrowserReplEntry({
+      code: trimmedCode,
+      ctx,
+      env: envRef.current,
+      scope: scopeRef.current,
+    });
+    setEntries((current) => [...current, entry]);
+    if (entry.status === "success") setCode("");
+    setStatus("Connected");
   }
 
   function selectExample(exampleCode: string) {


### PR DESCRIPTION
## What changed

- Fixes `liftLocalProxies` so top-level callable RPC roots are not mistaken for pending promises just because a Cap'n Web proxy exposes a callable `then` member.
- Keeps non-transparent pending members, including SDK-shaped `ctx.slack.chat.postMessage(...)`, flowing through the pending local proxy path.
- Moves the REPL route run/format logic into `browser-repl.ts` so the page behavior has a lightweight test seam.
- Adds browser e2e coverage for the default REPL expression and a browser-owned SDK-shaped marker.

## Root cause

#1385 treated all thenable values, including function-valued Cap'n Web root stubs, as pending values. In the browser REPL, `ctx.projects.list({ limit: 5 })` could therefore try to call the synthetic remote `then` member instead of transparently reading `projects`, producing `TypeError: '\ is not a function.`

## Validation

- First reproduced with a failing unit test in `src/capnweb/local-proxy-wrapper.test.ts`.
- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/os test src/capnweb/local-proxy-wrapper.test.ts src/capnweb/browser-repl.test.ts`
- `pnpm --dir apps/os test`
- `doppler run --config prd -- pnpm e2e:capnweb --project browser -t "runs the default browser REPL project list expression|calls a browser-owned Slack SDK-shaped local proxy marker"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core client-side RPC proxy behavior used by the browser REPL and SDK-shaped integrations; regressions could break project listing or Slack-style path calls, but coverage is extensive.
> 
> **Overview**
> Fixes the browser Cap'n Web REPL so **`liftLocalProxies`** no longer treats a **callable RPC session root** as a pending promise when Cap'n Web exposes a synthetic **`then`** member—restoring normal calls like `await ctx.projects.list({ limit: 5 })` instead of probing remote `then`.
> 
> The wrapper now leaves **built-in Iterate roots** (`projects`, `project`, etc.) **transparent** for Cap'n Web pipelining, while **unknown mounted roots** (e.g. **`ctx.slack`**) still use the pending **SDK-shaped `localProxyCaller`** path recorder. **`isThenable`** avoids reading hostile **`then`** getters.
> 
> Adds **`runBrowserReplEntry`** / **`BrowserReplEntry`** in **`browser-repl.ts`** and wires the REPL page through it for a testable run/format seam. Unit and browser e2e tests cover the regression, default REPL snippet, and Slack SDK-shaped proxy calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 262ae07e7600511bbd911e42892927f71cec574e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-08T22:47:03.104Z",
      "headSha": "262ae07e7600511bbd911e42892927f71cec574e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27171568597",
      "shortSha": "262ae07"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `262ae07`
Preview: https://os.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27171568597)
Updated: 2026-06-08T22:47:03.104Z
<!-- /CLOUDFLARE_PREVIEW -->