### PR TITLE
[codex] Fix Slack agent catch-up

### DIFF
--- a/apps/os/src/domains/secrets/integration-api.ts
+++ b/apps/os/src/domains/secrets/integration-api.ts
@@ -321,7 +321,6 @@ async function handleVerifiedSlackWebhook(input: {
     initialize(input: { name: string }): Promise<unknown>;
   };
   await slackIntegration.initialize({ name: slackIntegrationName });
-  await slackIntegration.ensureReady();
 
   const stream = await getInitializedStreamStub({
     durableObjectNamespace: input.context.stream as never,
@@ -345,6 +344,11 @@ async function handleVerifiedSlackWebhook(input: {
       body: payload,
     },
   });
+  input.context.waitUntil?.(
+    slackIntegration.ensureReady().catch((error) => {
+      console.error("[slack-integration-webhook] background catch-up failed", error);
+    }),
+  );
 
   return Response.json({ ok: true });
 }

--- a/apps/os/src/domains/streams/durable-objects/stream-processor-runner.ts
+++ b/apps/os/src/domains/streams/durable-objects/stream-processor-runner.ts
@@ -106,6 +106,8 @@ type OsProcessorBinding = {
   deps: unknown;
 };
 
+const PROCESSOR_RUNNER_SNAPSHOT_KEY = "snapshot:v4";
+
 export class StreamProcessorRunner extends DurableObject {
   #stream: RpcStub<StreamRpc> | undefined;
   #runner: ProcessorRunner | undefined;
@@ -165,13 +167,13 @@ export class StreamProcessorRunner extends DurableObject {
       processor: processor.processor,
       deps: processor.deps,
       storage: {
-        load: () => this.ctx.storage.kv.get<RunnerSnapshot>("snapshot"),
-        save: (snapshot) => this.ctx.storage.kv.put("snapshot", snapshot),
+        load: () => this.ctx.storage.kv.get<RunnerSnapshot>(PROCESSOR_RUNNER_SNAPSHOT_KEY),
+        save: (snapshot) => this.ctx.storage.kv.put(PROCESSOR_RUNNER_SNAPSHOT_KEY, snapshot),
       },
       stream: this.#stream,
       sideEffectAnchor: {
-        offset: args.subscriptionConfiguredEvent.offset,
-        createdAt: args.subscriptionConfiguredEvent.createdAt,
+        offset: args.streamMaxOffset,
+        createdAt: new Date().toISOString(),
       },
     });
 
@@ -187,14 +189,14 @@ export class StreamProcessorRunner extends DurableObject {
     this.#subscriptionHandle = await (this.#stream as OutboundStreamRpc).subscribeOutbound({
       subscriptionKey: args.subscriptionKey,
       processEventBatch,
-      replayAfterOffset: snapshot?.offset ?? args.subscriptionConfiguredEvent.offset,
+      replayAfterOffset: snapshot?.offset ?? 0,
     });
   }
 
   async runtimeState() {
     await this.#processing;
     const processorSlug = this.ctx.storage.kv.get<string>("processorSlug");
-    const snapshot = this.ctx.storage.kv.get<RunnerSnapshot>("snapshot");
+    const snapshot = this.ctx.storage.kv.get<RunnerSnapshot>(PROCESSOR_RUNNER_SNAPSHOT_KEY);
     return {
       processorSlug,
       snapshot,
@@ -421,6 +423,8 @@ const AgentHostProcessorContract = {
 function createAgentHostProcessor(): Processor<any, AgentHostProcessorDeps> {
   return implementProcessor(AgentHostProcessorContract as any, (deps: AgentHostProcessorDeps) => ({
     afterAppend(args) {
+      if (!args.shouldApplySideEffects({ event: args.event as StreamEvent })) return;
+
       const event = toLegacyEvent(args.event as StreamEvent, deps.streamPath);
       // Wake this stream's agent WITHOUT blocking the host's checkpoint. The agent's
       // onInstanceWake waits for every processor on the stream (including this agent-host) to
@@ -488,6 +492,16 @@ function adaptSharedProcessor(
     build(deps: SharedProcessorAdapterDeps) {
       return {
         afterAppend(args: any) {
+          if (
+            !shouldApplySharedProcessorSideEffects({
+              event: args.event as StreamEvent,
+              sharedProcessor,
+              shouldApplySideEffects: args.shouldApplySideEffects,
+            })
+          ) {
+            return;
+          }
+
           const abortController = new AbortController();
           args.blockProcessorUntil(async () => {
             await sharedProcessor.implementation.afterAppend?.({
@@ -508,6 +522,20 @@ function adaptSharedProcessor(
       };
     },
   } as unknown as Processor<any, SharedProcessorAdapterDeps>;
+}
+
+function shouldApplySharedProcessorSideEffects(args: {
+  event: StreamEvent;
+  sharedProcessor: SharedProcessor<any>;
+  shouldApplySideEffects(input: { event: StreamEvent; gracePeriodMs?: number }): boolean;
+}) {
+  const policy = args.sharedProcessor.implementation.firstAttachAfterAppend;
+  if (policy?.mode === "all") return true;
+  if (policy?.mode === "none") return args.shouldApplySideEffects({ event: args.event });
+  return args.shouldApplySideEffects({
+    event: args.event,
+    gracePeriodMs: policy?.milliseconds ?? 250,
+  });
 }
 
 function codemodeProcessorDeps(args: {

--- a/apps/os/src/durable-objects/codemode-session.test.ts
+++ b/apps/os/src/durable-objects/codemode-session.test.ts
@@ -232,6 +232,45 @@ describe("CodemodeSession", () => {
     expect(runnerState.reducedThroughOffset).toBeGreaterThanOrEqual(event.offset);
   });
 
+  test("reduces tool providers appended before the codemode processor subscribes", async () => {
+    const streamPath = `/codemode-session-tests/${crypto.randomUUID()}` as StreamPath;
+    const stream = await getInitializedStreamStub({
+      durableObjectNamespace: (env as TestEnv).STREAM,
+      namespace: projectId,
+      path: streamPath,
+    });
+    await stream.append({
+      type: "events.iterate.com/codemode/tool-provider-registered",
+      payload: createExampleRpcProviderRegistration({
+        exportName: "AiCapability",
+        instructions: "Use ctx.preexistingAi.run(model, input).",
+        path: ["preexistingAi"],
+        projectId,
+      }),
+    });
+
+    const session = await initializeSession(streamPath);
+    const created = await session.createSession({
+      code: `async (ctx) => {
+  return await ctx.preexistingAi.run("test-model", { prompt: "hello" });
+}`,
+    });
+
+    const scriptExecutionId = scriptExecutionIdFromEvent(created.scriptExecutionEvent);
+    const completed = await waitForScriptExecutionCompleted({ scriptExecutionId, streamPath });
+    expect(completed.payload).toMatchObject({
+      outcome: {
+        status: "returned",
+        value: expect.objectContaining({ model: "test-model" }),
+      },
+    });
+    expect(await readCurrentStreamEvents(streamPath)).toEqual(
+      expect.arrayContaining([
+        functionCallRequested(["preexistingAi", "run"], ["preexistingAi"], ["run"]),
+      ]),
+    );
+  });
+
   test("runs loopback RPC capability examples with live handles and callbacks", async () => {
     const streamPath = `/codemode-session-tests/${crypto.randomUUID()}` as StreamPath;
     const session = await initializeSession(streamPath);

--- a/packages/shared/src/stream-processors/slack-agent/implementation.ts
+++ b/packages/shared/src/stream-processors/slack-agent/implementation.ts
@@ -11,6 +11,8 @@ export type SlackAgentProcessorDeps = {
 
 export function createSlackAgentProcessor(deps: SlackAgentProcessorDeps = {}) {
   return implementProcessor(SlackAgentProcessorContract, {
+    firstAttachAfterAppend: { mode: "lookback", milliseconds: 60_000 },
+
     async afterAppend({ event, state, streamApi }) {
       await standardProcessorBehavior.afterAppend({
         contract: SlackAgentProcessorContract,
@@ -64,13 +66,6 @@ export function createSlackAgentProcessor(deps: SlackAgentProcessorDeps = {}) {
 
           const slackEvent = parsed.data.event as unknown as SlackEvent;
           const target = slackAgentTargetFromWebhookPayload(event.payload);
-          if (target != null && !target.isBotMessage && !target.isReactionEvent) {
-            await callSlackApi(deps, "reactions.add", {
-              channel: target.channel,
-              name: "eyes",
-              timestamp: target.messageTs,
-            });
-          }
           if (isBotMessage(slackEvent)) return;
           if (isBotAction(slackEvent, state.botUserId)) return;
 
@@ -102,6 +97,7 @@ export function createSlackAgentProcessor(deps: SlackAgentProcessorDeps = {}) {
                 },
               },
             });
+            await addEyesReactionForMessageTarget(deps, target);
             return;
           }
 
@@ -118,6 +114,7 @@ export function createSlackAgentProcessor(deps: SlackAgentProcessorDeps = {}) {
               },
             },
           });
+          await addEyesReactionForMessageTarget(deps, target);
           return;
         }
         case "events.iterate.com/codemode/function-call-requested":
@@ -182,6 +179,18 @@ export function createSlackAgentProcessor(deps: SlackAgentProcessorDeps = {}) {
           return;
       }
     },
+  });
+}
+
+async function addEyesReactionForMessageTarget(
+  deps: SlackAgentProcessorDeps,
+  target: SlackAgentTarget | null,
+) {
+  if (target == null || target.isBotMessage || target.isReactionEvent) return;
+  await callSlackApi(deps, "reactions.add", {
+    channel: target.channel,
+    name: "eyes",
+    timestamp: target.messageTs,
   });
 }
 

--- a/packages/shared/src/stream-processors/slack-agent/slack-agent.test.ts
+++ b/packages/shared/src/stream-processors/slack-agent/slack-agent.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { GenericMessageEvent } from "@slack/types";
 import {
+  catchUpProcessorFromStream,
+  createStoredProcessorState,
   getInitialProcessorState,
   reduceProcessorEvents,
   type ConsumedEvent,
@@ -197,6 +199,89 @@ describe("createSlackAgentProcessor", () => {
     expect(content).not.toContain("Reply requirement:");
     expect(content).not.toContain("ctx.slack.chat.postMessage({ channel, thread_ts, text })");
     expect(content).not.toContain("Do not use `ctx.chat.sendMessage`");
+  });
+
+  it("commits agent input before adding the Slack eyes reaction", async () => {
+    const calls: unknown[] = [];
+    const appended: Array<{ streamPath?: string; event: StreamEventInput }> = [];
+    const event = webhookEvent({
+      offset: 43,
+      text: "please look at this",
+    });
+
+    await createSlackAgentProcessor({
+      callSlackApi: async (method, body) => {
+        calls.push(["slack", method, body]);
+      },
+    }).implementation.afterAppend?.({
+      event,
+      previousState: registeredSlackAgentState(),
+      state: registeredSlackAgentState({
+        channel: "C123",
+        latestMessageTs: "1772136259.000000",
+        threadTs: "1772136258.963519",
+      }),
+      streamApi: {
+        ...testSlackAgentStreamApi(appended),
+        append: async ({ event, streamPath }) => {
+          calls.push(["append", event.type, event.idempotencyKey]);
+          appended.push({ event, streamPath });
+          return committedEvent(event, streamPath);
+        },
+      },
+      signal: new AbortController().signal,
+    });
+
+    expect(calls).toEqual([
+      [
+        "append",
+        "events.iterate.com/agent/input-added",
+        "slack-agent/slack-webhook-to-agent-input@43",
+      ],
+      [
+        "slack",
+        "reactions.add",
+        {
+          channel: "C123",
+          name: "eyes",
+          timestamp: "1772136259.000000",
+        },
+      ],
+    ]);
+  });
+
+  it("runs Slack webhook afterAppend during delayed first attach", async () => {
+    const appended: Array<{ streamPath?: string; event: StreamEventInput }> = [];
+    const processor = createSlackAgentProcessor();
+    const route = routeEvent();
+    const webhook = webhookEvent({
+      offset: 2,
+      text: "please look at this",
+    });
+
+    const storedState = await catchUpProcessorFromStream({
+      processor,
+      storedState: createStoredProcessorState({ contract: SlackAgentProcessorContract }),
+      saveStoredProcessorState: async () => {},
+      streamApi: {
+        ...testSlackAgentStreamApi(appended),
+        read: async () => [route, webhook],
+      },
+      signal: new AbortController().signal,
+      now: new Date("2026-01-01T00:00:30.000Z"),
+    });
+
+    expect(storedState.afterAppendCompletedThroughOffset).toBe(2);
+    const slackSpecificAppends = appended.filter(
+      ({ event }) => event.type !== "events.iterate.com/core/stream-processor-registered",
+    );
+    expect(slackSpecificAppends.map(({ event }) => event.type)).toEqual([
+      "events.iterate.com/codemode/tool-provider-registered",
+      "events.iterate.com/agent/input-added",
+    ]);
+    expect(slackSpecificAppends[1].event).toMatchObject({
+      idempotencyKey: "slack-agent/slack-webhook-to-agent-input@2",
+    });
   });
 
   it("emits agent input for raw Slack interactivity payloads", async () => {

--- a/packages/streams/src/workers/durable-objects/stream-processor-runner.ts
+++ b/packages/streams/src/workers/durable-objects/stream-processor-runner.ts
@@ -21,6 +21,8 @@ import type { Processor } from "../../processor.ts";
 type HostedProcessor = Processor<any, undefined>;
 type HostedProcessorRunnerSnapshot = Snapshot<unknown>;
 
+const PROCESSOR_RUNNER_SNAPSHOT_KEY = "snapshot:v4";
+
 export class StreamProcessorRunner extends DurableObject {
   #stream: RetainedStreamRpc | undefined;
   #runner: ProcessorRunner | undefined;
@@ -69,13 +71,14 @@ export class StreamProcessorRunner extends DurableObject {
       processor,
       deps: undefined,
       storage: {
-        load: () => this.ctx.storage.kv.get<HostedProcessorRunnerSnapshot>("snapshot"),
-        save: (snapshot) => void this.ctx.storage.kv.put("snapshot", snapshot),
+        load: () =>
+          this.ctx.storage.kv.get<HostedProcessorRunnerSnapshot>(PROCESSOR_RUNNER_SNAPSHOT_KEY),
+        save: (snapshot) => void this.ctx.storage.kv.put(PROCESSOR_RUNNER_SNAPSHOT_KEY, snapshot),
       },
       stream: this.#stream,
       sideEffectAnchor: {
-        offset: args.subscriptionConfiguredEvent.offset,
-        createdAt: args.subscriptionConfiguredEvent.createdAt,
+        offset: args.streamMaxOffset,
+        createdAt: new Date().toISOString(),
       },
     });
     const snapshot = await this.#runner.snapshot();
@@ -91,7 +94,7 @@ export class StreamProcessorRunner extends DurableObject {
     this.#subscriptionHandle = await (this.#stream as OutboundStreamRpc).subscribeOutbound({
       subscriptionKey: args.subscriptionKey,
       processEventBatch,
-      replayAfterOffset: snapshot?.offset ?? args.subscriptionConfiguredEvent.offset,
+      replayAfterOffset: snapshot?.offset ?? 0,
     });
   }
 
@@ -99,7 +102,9 @@ export class StreamProcessorRunner extends DurableObject {
   runtimeState() {
     return {
       processorSlug: this.ctx.storage.kv.get<string>("processorSlug"),
-      snapshot: this.ctx.storage.kv.get<HostedProcessorRunnerSnapshot>("snapshot"),
+      snapshot: this.ctx.storage.kv.get<HostedProcessorRunnerSnapshot>(
+        PROCESSOR_RUNNER_SNAPSHOT_KEY,
+      ),
     };
   }
 }


### PR DESCRIPTION
## Summary

Fixes the Slack agent path that could acknowledge a Slack message with an eyes reaction before the durable agent input was actually committed. Also fixes processor bootstrap/replay so agent processors rebuild state from the full stream history without replaying historical side effects.

## Root cause

The reported production Slack stream had the webhook and route events, plus the bot eyes reaction, but no durable `agent/input-added` and no LLM request. Slack ingress was also blocking on integration catch-up in the request path, which made the webhook slow enough to risk Slack retries. Separately, normal agent streams could miss providers appended before a processor subscription and retain bad snapshots, causing `No codemode provider registered for chat.sendMessage`.

## Changes

- Move Slack eyes reactions until after the matching durable agent input append succeeds.
- Give Slack first attach a 60s lookback so delayed subscription setup can process the just-arrived webhook.
- Stop Slack ingress from blocking on integration catch-up; it now appends the webhook first and catches up in `waitUntil`.
- Rebuild processor state from stream start on first subscription, with a v4 snapshot key to invalidate bad production snapshots.
- Anchor side-effect gating to the current subscription boundary and have OS shared processors/agent-host honor historical side-effect suppression.
- Add regression tests for Slack append-before-eyes ordering, Slack delayed first attach, and codemode providers registered before processor subscription.

## Validation

Local:

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test`

Production, after `doppler run --config prd -- pnpm cf:deploy`:

- `/agents/demo` direct `ctx.chat.sendMessage` proof succeeded: `function-call-requested` offset 553, assistant response offset 554, function completed offset 555, script completed offset 557 in 4400ms.
- Original Slack thread `C08R1SMTZGD / 1780956206.696999` replied with exact marker `warm-ok-v4b-1780958658`. Webhook ack was 230ms, reply timestamp was 1780958661.954079 for event timestamp 1780958658.077789, about 3.9s end-to-end.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-08T22:54:40.493Z",
      "headSha": "9f844f1d27d905aced868bba3adbdd7390ef1ad2",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27171783321",
      "shortSha": "9f844f1"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `9f844f1`
Preview: https://os.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27171783321)
Updated: 2026-06-08T22:54:40.493Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches Slack ingress, durable processor replay/snapshot semantics, and side-effect gating on agent and integration paths—incorrect behavior could drop agent inputs or duplicate Slack API calls.
> 
> **Overview**
> Fixes Slack agent catch-up where users could see an **eyes** reaction before durable `agent/input-added` was committed, and where delayed processor subscription could skip webhooks and miss codemode providers.
> 
> **Slack ingress and agent processor:** Webhook handling no longer blocks on `ensureReady()`; it appends to the stream first and runs integration catch-up in `waitUntil`. The Slack agent processor adds a **60s first-attach lookback** (`firstAttachAfterAppend`) so late subscriptions still run `afterAppend` on recent webhooks, and moves **eyes** reactions to **after** successful `agent/input-added` (and bang-command) appends.
> 
> **Processor runner bootstrap:** Runner snapshots move to `snapshot:v4`, side-effect anchoring uses `streamMaxOffset` at subscribe time, and outbound replay defaults to `snapshot?.offset ?? 0` so state rebuilds from full history without re-firing old side effects. OS **agent-host** and **shared processors** gate `afterAppend` via `shouldApplySideEffects`, with optional per-processor lookback through `firstAttachAfterAppend`.
> 
> Regression tests cover append-before-eyes ordering, delayed Slack first attach, and codemode tool providers registered before subscription.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f844f1d27d905aced868bba3adbdd7390ef1ad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->