### PR TITLE
[codex] Block OpenAI processor side effects

### DIFF
--- a/apps/os/src/domains/streams/durable-objects/stream-processor-runner.ts
+++ b/apps/os/src/domains/streams/durable-objects/stream-processor-runner.ts
@@ -106,7 +106,7 @@ type OsProcessorBinding = {
   deps: unknown;
 };
 
-const PROCESSOR_RUNNER_SNAPSHOT_KEY = "snapshot:v4";
+const PROCESSOR_RUNNER_SNAPSHOT_KEY = "snapshot:v5";
 
 export class StreamProcessorRunner extends DurableObject {
   #stream: RpcStub<StreamRpc> | undefined;
@@ -258,6 +258,7 @@ function getOsProcessor(args: {
     return {
       processor: adaptSharedProcessor(
         createCodemodeProcessor(codemodeProcessorDeps({ ...args, projectId, streamPath })),
+        { detachedSideEffects: true },
       ),
       deps: {
         env: args.env,
@@ -486,6 +487,7 @@ type SharedProcessorAdapterDeps = {
 
 function adaptSharedProcessor(
   sharedProcessor: SharedProcessor<any>,
+  options: { detachedSideEffects?: boolean } = {},
 ): Processor<any, SharedProcessorAdapterDeps> {
   return {
     contract: sharedProcessor.contract,
@@ -515,7 +517,9 @@ function adaptSharedProcessor(
                 streamPath: deps.streamPath,
               }) as never,
               signal: abortController.signal,
-              waitUntil: (promise) => args.keepAlive(promise),
+              ...(options.detachedSideEffects === true
+                ? { waitUntil: (promise: Promise<unknown>) => args.keepAlive(promise) }
+                : {}),
             });
           });
         },

--- a/packages/streams/src/workers/durable-objects/stream-processor-runner.ts
+++ b/packages/streams/src/workers/durable-objects/stream-processor-runner.ts
@@ -21,7 +21,7 @@ import type { Processor } from "../../processor.ts";
 type HostedProcessor = Processor<any, undefined>;
 type HostedProcessorRunnerSnapshot = Snapshot<unknown>;
 
-const PROCESSOR_RUNNER_SNAPSHOT_KEY = "snapshot:v4";
+const PROCESSOR_RUNNER_SNAPSHOT_KEY = "snapshot:v5";
 
 export class StreamProcessorRunner extends DurableObject {
   #stream: RetainedStreamRpc | undefined;


### PR DESCRIPTION
## Summary

Follow-up to #1389. The final production audit found that `/agents/demo` could still hit `Too many concurrent dynamic workers` after the first fix because old OpenAI WebSocket request work was still allowed to run detached from the processor checkpoint.

This keeps codemode detached, because codemode scripts can append function-call events that the same processor must continue processing, but stops passing a `waitUntil` escape hatch to other shared processors. OpenAI WebSocket work now runs inside `blockProcessorUntil`, so the runner does not checkpoint past an LLM request while its WebSocket side effects are still running in the background.

The snapshot key is bumped to `snapshot:v5` so production processor runners rebuild away from v4 snapshots that may have checkpointed while detached OpenAI work was still active.

## Validation

Local:

- `pnpm --filter @iterate-com/os test:codemode-session`
- `pnpm --filter @iterate-com/os typecheck`
- `pnpm --filter @iterate-com/streams test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test`

Production, after `doppler run --config prd -- pnpm cf:deploy`:

- `/agents/demo` direct `ctx.chat.sendMessage` proof succeeded: script `codex-demo-chat-provider-v5-1780959670`, request offset 605, function call offset 606, assistant response offset 607, script completed offset 610 in 4550ms.
- Original Slack thread `C08R1SMTZGD / 1780956206.696999` replied with exact marker `warm-ok-v5b-1780959744`. Webhook ack was 1665ms, reply timestamp was 1780959749.256209 for event timestamp 1780959744.585654, about 4.7s end-to-end.

## Notes

The earlier PR already fixed Slack commit-before-eyes ordering, Slack first-attach lookback, non-blocking Slack webhook ingress, processor replay from stream start, and historical side-effect gating. This PR tightens the remaining OS adapter behavior so OpenAI processor work cannot keep running detached after the runner has checkpointed.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-08T23:11:37.292Z",
      "headSha": "7f10a49cdac0151c647fecc3fc5fff92d5b315ec",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27172539483",
      "shortSha": "7f10a49"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `7f10a49`
Preview: https://os.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27172539483)
Updated: 2026-06-08T23:11:37.292Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes processor checkpoint timing for OpenAI and other shared processors in production; mitigated by codemode-only detached behavior and a snapshot version bump forcing clean rebuilds.
> 
> **Overview**
> Tightens **shared processor side-effect lifecycle** in the OS stream adapter so checkpoints cannot advance while detached background work (notably OpenAI WebSocket) is still running.
> 
> `adaptSharedProcessor` now takes an optional **`detachedSideEffects`** flag: only when true does it pass **`waitUntil` → `keepAlive`** into `afterAppend`. **Codemode** is the sole processor that opts in, so scripts can still fire detached appends the same runner must continue processing. **All other shared processors** (including OpenAI WS) no longer get that escape hatch—side effects run under **`blockProcessorUntil`** until they finish.
> 
> Processor runner snapshots are bumped from **`snapshot:v4` to `snapshot:v5`** in both OS and `@iterate-com/streams` so production runners rebuild away from v4 state that may have checkpointed past in-flight detached OpenAI work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f10a49cdac0151c647fecc3fc5fff92d5b315ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->