### PR TITLE
[codex] Include anchor event in side-effect grace

### DIFF
--- a/packages/streams/src/processor-runner.ts
+++ b/packages/streams/src/processor-runner.ts
@@ -248,7 +248,6 @@ function makeShouldApplySideEffects(anchor: ProcessorSideEffectAnchor | undefine
   return (args: { event: Pick<StreamEvent, "offset" | "createdAt">; gracePeriodMs?: number }) => {
     if (anchor === undefined) return true;
     if (args.event.offset > anchor.offset) return true;
-    if (args.event.offset === anchor.offset) return false;
 
     const gracePeriodMs = args.gracePeriodMs ?? 0;
     if (gracePeriodMs <= 0) return false;

--- a/packages/streams/src/stream-processor.test.ts
+++ b/packages/streams/src/stream-processor.test.ts
@@ -386,7 +386,7 @@ describe("projector processor (consumes everything, writes to a db port)", () =>
       streamMaxOffset: 11,
     });
 
-    expect(written).toEqual([9, 11]);
+    expect(written).toEqual([9, 10, 11]);
   });
 });
 


### PR DESCRIPTION
## What changed

Allow the stream processor side-effect gate to include the exact subscription anchor event when the processor has a positive grace/lookback window and the event timestamp is inside that window.

Processors without grace still suppress the anchor event.

## Root cause

Slack first attach uses a 60s lookback so a freshly created routed Slack-agent stream can process the webhook that caused the stream to exist. The production failure landed on the exact first-attach boundary:

- `/integrations/slack` received message `C08R1SMTZGD / 1780986448.407439` and routed it to `/agents/slack/c08r1smtzgd/ts-1780986448-407439`.
- The routed stream had `slack/webhook-received` at offset 14.
- The agent host attached with side-effect anchor offset 14.
- `makeShouldApplySideEffects` returned `false` immediately for `event.offset === anchor.offset`, before consulting the 60s lookback.
- Result: no `agent/input-added`, no eyes reaction, no LLM, no Slack reply.

## Production validation

Deployed this branch to `prd` via `doppler run --config prd -- pnpm cf:deploy`.

Proof after deploy:

- Synthetic fresh routed Slack stream `/agents/slack/c08r1smtzgd/ts-1780986789-129901` hit the same boundary shape: `slack/webhook-received` at offset 14 and `agent/input-added` at offset 18.
- Replayed the real missed Slack event for `C08R1SMTZGD / 1780986448.407439` with a fresh Slack event id. The webhook acked in 1628ms, the LLM completed in 2341ms, Slack `chat.postMessage` returned `ok: true` in 1128ms, and the thread now has bot reply `1780986838.405339`: `Hi! How can I help?`.

## Checks

- `pnpm --filter @iterate-com/streams test`
- `pnpm --filter @iterate-com/streams typecheck`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subscription side-effect boundaries used by processors with lookback (e.g. Slack agents); behavior at exact anchor offset shifts only when grace is configured.
> 
> **Overview**
> Fixes a bug where **`makeShouldApplySideEffects`** always blocked side effects on the subscription anchor offset before evaluating grace/lookback.
> 
> The early **`event.offset === anchor.offset → false`** return is removed. Events after the anchor still run side effects; at or before the anchor, behavior is unchanged when **`gracePeriodMs`** is 0, but with a positive grace window the anchor event can qualify if its timestamp falls inside **`anchorTime - gracePeriodMs`**.
> 
> This unblocks first-attach Slack routing (e.g. 60s lookback) when the webhook that created the stream is exactly the anchor event. The stream processor test now expects offset **10** to be written alongside **9** and **11** under a 6s grace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf8fd9e191f6006cd46ccdc93658ddea418c4655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->