### PR TITLE
[codex] Fix Cap'n Web REPL ctx state

### DIFF
--- a/apps/os/src/routes/_app/capnweb-repl.tsx
+++ b/apps/os/src/routes/_app/capnweb-repl.tsx
@@ -49,7 +49,7 @@ function CapnwebReplPage() {
     };
     globals.ctx = lifted;
     globals.env = envRef.current;
-    setCtx(lifted);
+    setCtx(() => lifted);
     setStatus("Connected");
     return () => {
       delete globals.ctx;


### PR DESCRIPTION
## What changed

- Store the callable Cap'n Web `ctx` stub in React state with a setter function.

## Why

The REPL wraps `newWebSocketRpcSession(...)`, which returns a callable RPC stub. Passing that stub directly to `setCtx` made React treat it as an updater function and invoke the RPC root. That caused the default snippet `await ctx.projects.list({ limit: 5 })` to fail with `TypeError: '' is not a function`.

## Validation

- Reproduced the failure in headless Chromium against `pnpm dev:localhost` with the local Cap'n Web endpoint.
- Confirmed the fixed headless-browser harness returns `{ projects: [], total: 0 }`.
- `pnpm exec vitest run src/capnweb/browser-repl.test.ts src/capnweb/local-proxy-wrapper.test.ts`
- `pnpm typecheck`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-09T06:47:20.195Z",
      "headSha": "99e97193f224737339bbd856ebea233370dad00a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27188778305",
      "shortSha": "99e9719"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `99e9719`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27188778305)
Updated: 2026-06-09T06:47:20.195Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line React state fix in the dev REPL route; no auth, data, or production API behavior changes.
> 
> **Overview**
> Fixes the Cap'n Web REPL connection effect so the **callable** `RpcStub` for `ctx` is stored in React state correctly.
> 
> `setCtx(lifted)` is changed to **`setCtx(() => lifted)`** because React interprets a function passed to `setState` as an updater and would call it. That accidentally invoked the RPC root and broke the default snippet (`await ctx.projects.list(...)`). Wrapping the stub in an updater that returns it stores the stub as state without invoking it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99e97193f224737339bbd856ebea233370dad00a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->