### PR TITLE
[codex] Improve browser CapnWeb REPL output

### DIFF
--- a/apps/os/src/capnweb/browser-repl.test.ts
+++ b/apps/os/src/capnweb/browser-repl.test.ts
@@ -74,8 +74,10 @@ describe("browser Cap'n Web REPL", () => {
         scope: {},
       }),
     ).resolves.toEqual({
+      consoleOutput: "",
       code: DEFAULT_BROWSER_REPL_CODE,
       output: JSON.stringify({ projects: [{ id: "proj_123" }], total: 1, limit: 5 }, null, 2),
+      outputLanguage: "json",
       status: "success",
     });
   });
@@ -107,7 +109,7 @@ describe("browser Cap'n Web REPL", () => {
         ctx: {},
         scope,
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(41);
 
     await expect(
       evalBrowserReplSessionCode({
@@ -123,7 +125,7 @@ describe("browser Cap'n Web REPL", () => {
         ctx: {},
         scope,
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(42);
 
     await expect(
       evalBrowserReplSessionCode({
@@ -143,7 +145,7 @@ describe("browser Cap'n Web REPL", () => {
         ctx: {},
         scope,
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(22);
 
     await expect(
       evalBrowserReplSessionCode({
@@ -154,16 +156,107 @@ describe("browser Cap'n Web REPL", () => {
     ).resolves.toBe(42);
   });
 
-  test("session snippets persist function and class declarations", async () => {
+  test("session snippets use the final top-level expression as the result", async () => {
     const scope: Record<string, unknown> = {};
 
     await expect(
       evalBrowserReplSessionCode({
-        code: "function answer() { return 42; }",
+        code: `
+const project = { total: 2 }
+project.total + 40
+`.trim(),
         ctx: {},
         scope,
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(42);
+
+    expect(scope.project).toEqual({ total: 2 });
+  });
+
+  test("session snippets keep multiline calls as one final expression", async () => {
+    const scope: Record<string, unknown> = {};
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: `
+const increment = (value) => value + 1
+increment
+(41)
+`.trim(),
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toBe(42);
+  });
+
+  test("session snippets keep operator-start continuations in the final expression", async () => {
+    await expect(
+      evalBrowserReplSessionCode({
+        code: `
+40
++ 2
+`.trim(),
+        ctx: {},
+        scope: {},
+      }),
+    ).resolves.toBe(42);
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: `
+const project = { stats: { total: 42 } }
+project.stats
+?.total
+`.trim(),
+        ctx: {},
+        scope: {},
+      }),
+    ).resolves.toBe(42);
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: `
+true
+? 42
+: 0
+`.trim(),
+        ctx: {},
+        scope: {},
+      }),
+    ).resolves.toBe(42);
+  });
+
+  test("session snippets do not rewrite do-while statements as expressions", async () => {
+    const scope: Record<string, unknown> = {};
+
+    await expect(
+      evalBrowserReplSessionCode({
+        code: `
+let count = 0
+do {
+  count += 1
+} while (false)
+count
+`.trim(),
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toBe(1);
+
+    expect(scope.count).toBe(1);
+  });
+
+  test("session snippets persist function and class declarations", async () => {
+    const scope: Record<string, unknown> = {};
+
+    const answerResult = await evalBrowserReplSessionCode({
+      code: "function answer() { return 42; }",
+      ctx: {},
+      scope,
+    });
+    expect(answerResult).toBe(scope.answer);
+    expect(answerResult).toEqual(expect.any(Function));
+
     await expect(
       evalBrowserReplSessionCode({
         code: "answer()",
@@ -172,13 +265,14 @@ describe("browser Cap'n Web REPL", () => {
       }),
     ).resolves.toBe(42);
 
-    await expect(
-      evalBrowserReplSessionCode({
-        code: "class Box { value() { return answer(); } }",
-        ctx: {},
-        scope,
-      }),
-    ).resolves.toBeUndefined();
+    const boxResult = await evalBrowserReplSessionCode({
+      code: "class Box { value() { return answer(); } }",
+      ctx: {},
+      scope,
+    });
+    expect(boxResult).toBe(scope.Box);
+    expect(boxResult).toEqual(expect.any(Function));
+
     await expect(
       evalBrowserReplSessionCode({
         code: "new Box().value()",
@@ -187,13 +281,14 @@ describe("browser Cap'n Web REPL", () => {
       }),
     ).resolves.toBe(42);
 
-    await expect(
-      evalBrowserReplSessionCode({
-        code: "async function asyncAnswer() { return answer(); }",
-        ctx: {},
-        scope,
-      }),
-    ).resolves.toBeUndefined();
+    const asyncAnswerResult = await evalBrowserReplSessionCode({
+      code: "async function asyncAnswer() { return answer(); }",
+      ctx: {},
+      scope,
+    });
+    expect(asyncAnswerResult).toBe(scope.asyncAnswer);
+    expect(asyncAnswerResult).toEqual(expect.any(Function));
+
     await expect(
       evalBrowserReplSessionCode({
         code: "await asyncAnswer()",
@@ -219,7 +314,7 @@ const persisted = answer();
         ctx: {},
         scope,
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(42);
 
     expect(scope).toHaveProperty("answer");
     expect(scope).toHaveProperty("persisted", 42);
@@ -255,6 +350,79 @@ const persisted = answer();
       }),
     ).rejects.toThrow('REPL binding "env" is reserved.');
     expect(scope).not.toHaveProperty("env");
+  });
+
+  test("route entry runner exposes the last result through aliases", async () => {
+    const scope: Record<string, unknown> = {};
+
+    await expect(
+      runBrowserReplEntry({
+        code: "const answer = 42",
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toMatchObject({
+      output: "42",
+      outputLanguage: "json",
+      status: "success",
+    });
+    expect(scope.answer).toBe(42);
+    expect(scope.$_).toBe(42);
+    expect(scope._).toBe(42);
+
+    await expect(
+      runBrowserReplEntry({
+        code: "$_ + _",
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toMatchObject({
+      output: "84",
+      outputLanguage: "json",
+      status: "success",
+    });
+    expect(scope.$_).toBe(84);
+    expect(scope._).toBe(84);
+  });
+
+  test("route entry runner captures console output for the submitted prompt", async () => {
+    const scope: Record<string, unknown> = {};
+
+    await expect(
+      runBrowserReplEntry({
+        code: `console.log("project", { id: "proj_123" }); console.warn("careful"); return 42`,
+        ctx: {},
+        scope,
+      }),
+    ).resolves.toMatchObject({
+      consoleOutput: `project {\n  "id": "proj_123"\n}\nwarn: careful`,
+      output: "42",
+      outputLanguage: "json",
+      status: "success",
+    });
+  });
+
+  test("route entry runner delegates non-captured console methods", async () => {
+    const scope: Record<string, unknown> = {};
+    const trace = vi.spyOn(console, "trace").mockImplementation(() => {});
+
+    try {
+      await expect(
+        runBrowserReplEntry({
+          code: `console.trace("kept"); return 42`,
+          ctx: {},
+          scope,
+        }),
+      ).resolves.toMatchObject({
+        consoleOutput: "",
+        output: "42",
+        outputLanguage: "json",
+        status: "success",
+      });
+      expect(trace).toHaveBeenCalledWith("kept");
+    } finally {
+      trace.mockRestore();
+    }
   });
 
   test("provideCapability example registers and calls a browser-owned target", async () => {

--- a/apps/os/src/capnweb/browser-repl.ts
+++ b/apps/os/src/capnweb/browser-repl.ts
@@ -9,7 +9,9 @@ export type BrowserReplExample = {
 
 export type BrowserReplEntry = {
   code: string;
+  consoleOutput: string;
   output: string;
+  outputLanguage: "json" | "text";
   status: "error" | "success";
 };
 
@@ -66,6 +68,9 @@ export async function runBrowserReplEntry(input: {
   scope: Record<string, unknown>;
 }): Promise<BrowserReplEntry> {
   const trimmedCode = input.code.trim();
+  const consoleLogs: BrowserReplConsoleLog[] = [];
+  const previousConsole = input.scope.console;
+  input.scope.console = createBrowserReplConsole(consoleLogs);
   try {
     const result = await evalBrowserReplSessionCode({
       code: trimmedCode,
@@ -73,17 +78,30 @@ export async function runBrowserReplEntry(input: {
       env: input.env,
       scope: input.scope,
     });
+    input.scope.$_ = result;
+    input.scope._ = result;
+    const formattedResult = formatBrowserReplResult(result);
     return {
       code: trimmedCode,
-      output: formatBrowserReplResult(result),
+      consoleOutput: formatBrowserReplConsoleOutput(consoleLogs),
+      output: formattedResult.text,
+      outputLanguage: formattedResult.language,
       status: "success",
     };
   } catch (error) {
     return {
       code: trimmedCode,
+      consoleOutput: formatBrowserReplConsoleOutput(consoleLogs),
       output: error instanceof Error ? (error.stack ?? error.message) : String(error),
+      outputLanguage: "text",
       status: "error",
     };
+  } finally {
+    if (previousConsole === undefined) {
+      delete input.scope.console;
+    } else {
+      input.scope.console = previousConsole;
+    }
   }
 }
 
@@ -108,16 +126,16 @@ export function compileBrowserReplFunction(code: string) {
 
 type ReplFunction = (ctx: unknown, env: object, scope: Record<string, unknown>) => Promise<unknown>;
 
-const RESERVED_TOP_LEVEL_BINDINGS = new Set(["ctx", "env", "scope"]);
+const RESERVED_TOP_LEVEL_BINDINGS = new Set(["ctx", "env", "scope", "console", "$_", "_"]);
 
 function compileBrowserReplStatements(code: string) {
-  const statementSource = transformTopLevelDeclarations(code);
+  const statementSource = transformTopLevelStatements(code);
   // oxlint-disable-next-line no-new-func -- Statement-mode fallback for the explicit browser-local REPL.
   return new Function(
     "ctx",
     "env",
     "scope",
-    `with (scope) { return (async () => {${statementSource}})() }`,
+    `with (scope) { return (async () => { let __replLastValue; ${statementSource}; return __replLastValue })() }`,
   ) as ReplFunction;
 }
 
@@ -125,8 +143,9 @@ function startsWithTopLevelDeclaration(code: string) {
   return /^\s*(?:async\s+function|function|class)\s+[A-Za-z_$][\w$]*/.test(code);
 }
 
-function transformTopLevelDeclarations(code: string) {
+function transformTopLevelStatements(code: string) {
   const replacements: Array<{ end: number; start: number; text: string }> = [];
+
   let state:
     | "code"
     | "line-comment"
@@ -209,6 +228,9 @@ function transformTopLevelDeclarations(code: string) {
     index = replacement.end - 1;
   }
 
+  const finalExpressionReplacement = readFinalTopLevelExpressionReplacement(code);
+  if (finalExpressionReplacement) replacements.push(finalExpressionReplacement);
+
   let transformed = code;
   for (const replacement of replacements.toReversed()) {
     transformed =
@@ -218,6 +240,179 @@ function transformTopLevelDeclarations(code: string) {
   }
 
   return transformed;
+}
+
+function readFinalTopLevelExpressionReplacement(
+  code: string,
+): { end: number; start: number; text: string } | null {
+  const ranges = readTopLevelStatementRanges(code);
+  const finalRange = ranges.at(-1);
+  if (!finalRange) return null;
+
+  const statement = code.slice(finalRange.start, finalRange.end).trim();
+  if (!statement) return null;
+  if (!isTopLevelExpressionStatement(statement)) return null;
+
+  return {
+    start: finalRange.start,
+    end: finalRange.end,
+    text: `__replLastValue = ${code.slice(finalRange.start, finalRange.end)}`,
+  };
+}
+
+function readTopLevelStatementRanges(code: string) {
+  const ranges: Array<{ end: number; start: number }> = [];
+  let statementStart: number | null = null;
+  let state:
+    | "code"
+    | "line-comment"
+    | "block-comment"
+    | "single-quote"
+    | "double-quote"
+    | "template" = "code";
+  let braceDepth = 0;
+  let bracketDepth = 0;
+  let parenDepth = 0;
+
+  for (let index = 0; index < code.length; index += 1) {
+    const char = code[index];
+    const next = code[index + 1];
+
+    if (state === "line-comment") {
+      if (char === "\n") state = "code";
+      continue;
+    }
+    if (state === "block-comment") {
+      if (char === "*" && next === "/") {
+        state = "code";
+        index += 1;
+      }
+      continue;
+    }
+    if (state === "single-quote") {
+      if (char === "\\") index += 1;
+      else if (char === "'") state = "code";
+      continue;
+    }
+    if (state === "double-quote") {
+      if (char === "\\") index += 1;
+      else if (char === '"') state = "code";
+      continue;
+    }
+    if (state === "template") {
+      if (char === "\\") index += 1;
+      else if (char === "`") state = "code";
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      state = "line-comment";
+      index += 1;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      state = "block-comment";
+      index += 1;
+      continue;
+    }
+    if (char === "'") {
+      state = "single-quote";
+      continue;
+    }
+    if (char === '"') {
+      state = "double-quote";
+      continue;
+    }
+    if (char === "`") {
+      state = "template";
+      continue;
+    }
+
+    if (braceDepth === 0 && bracketDepth === 0 && parenDepth === 0) {
+      if (statementStart === null && !/\s/.test(char)) statementStart = index;
+
+      if (statementStart !== null && char === ";") {
+        ranges.push({ start: statementStart, end: index });
+        statementStart = null;
+      } else if (
+        statementStart !== null &&
+        (char === "\n" || char === "\r") &&
+        canEndTopLevelStatementAtLineBreak(code, statementStart, index)
+      ) {
+        ranges.push({ start: statementStart, end: index });
+        statementStart = null;
+      }
+    }
+
+    if (char === "{") braceDepth += 1;
+    else if (char === "}") braceDepth = Math.max(0, braceDepth - 1);
+    else if (char === "[") bracketDepth += 1;
+    else if (char === "]") bracketDepth = Math.max(0, bracketDepth - 1);
+    else if (char === "(") parenDepth += 1;
+    else if (char === ")") parenDepth = Math.max(0, parenDepth - 1);
+  }
+
+  if (statementStart !== null) {
+    const end = trimEndIndex(code);
+    if (end > statementStart) ranges.push({ start: statementStart, end });
+  }
+
+  return ranges;
+}
+
+function canEndTopLevelStatementAtLineBreak(code: string, start: number, end: number) {
+  const statement = code.slice(start, end).trimEnd();
+  if (!statement) return false;
+  if (isLineBreakContinuation(code, end)) return false;
+  return !/[([{:.,=?!+\-*/%&|^~<>]$/.test(statement);
+}
+
+function isLineBreakContinuation(code: string, index: number) {
+  const next = nextNonWhitespaceCharacter(code, index);
+  return next !== null && LINE_BREAK_CONTINUATION_STARTS.has(next);
+}
+
+const LINE_BREAK_CONTINUATION_STARTS = new Set([
+  "%",
+  "&",
+  "(",
+  "*",
+  "+",
+  "-",
+  ".",
+  "/",
+  ":",
+  "<",
+  "=",
+  ">",
+  "?",
+  "[",
+  "^",
+  "`",
+  "|",
+]);
+
+function nextNonWhitespaceCharacter(code: string, index: number) {
+  for (let nextIndex = index + 1; nextIndex < code.length; nextIndex += 1) {
+    const char = code[nextIndex];
+    if (char && !/\s/.test(char)) return char;
+  }
+
+  return null;
+}
+
+function trimEndIndex(code: string) {
+  let end = code.length;
+  while (end > 0 && /\s/.test(code[end - 1] ?? "")) end -= 1;
+  if (code[end - 1] === ";") end -= 1;
+  while (end > 0 && /\s/.test(code[end - 1] ?? "")) end -= 1;
+  return end;
+}
+
+function isTopLevelExpressionStatement(statement: string) {
+  return !/^(?:async\s+function|break|class|const|continue|debugger|do|export|for|function|if|import|let|return|switch|throw|try|var|while|with)\b/.test(
+    statement,
+  );
 }
 
 function readTopLevelDeclarationReplacement(
@@ -231,7 +426,7 @@ function readTopLevelDeclarationReplacement(
     return {
       start: index,
       end: equalsIndex,
-      text: `${scopeAssignmentTarget(variable[1])} `,
+      text: `__replLastValue = ${scopeAssignmentTarget(variable[1])} `,
     };
   }
 
@@ -241,7 +436,7 @@ function readTopLevelDeclarationReplacement(
     return {
       start: index,
       end: parenIndex,
-      text: `${scopeAssignmentTarget(asyncFunction[1])} = async function ${asyncFunction[1]}`,
+      text: `__replLastValue = ${scopeAssignmentTarget(asyncFunction[1])} = async function ${asyncFunction[1]}`,
     };
   }
 
@@ -251,7 +446,7 @@ function readTopLevelDeclarationReplacement(
     return {
       start: index,
       end: parenIndex,
-      text: `${scopeAssignmentTarget(namedFunction[1])} = function ${namedFunction[1]}`,
+      text: `__replLastValue = ${scopeAssignmentTarget(namedFunction[1])} = function ${namedFunction[1]}`,
     };
   }
 
@@ -260,7 +455,7 @@ function readTopLevelDeclarationReplacement(
     return {
       start: index,
       end: index + namedClass[0].length,
-      text: `${scopeAssignmentTarget(namedClass[1])} = class ${namedClass[1]}`,
+      text: `__replLastValue = ${scopeAssignmentTarget(namedClass[1])} = class ${namedClass[1]}`,
     };
   }
 
@@ -294,12 +489,69 @@ function scopeAssignmentTarget(name: string) {
   return `scope.${name}`;
 }
 
-export function formatBrowserReplResult(result: unknown) {
-  if (result === undefined) return "undefined";
-  if (typeof result === "string") return result;
+export function formatBrowserReplResult(result: unknown): {
+  language: "json" | "text";
+  text: string;
+} {
+  if (result === undefined) return { language: "text", text: "undefined" };
+  if (typeof result === "string") return { language: "text", text: result };
+  if (typeof result === "function") return { language: "text", text: String(result) };
   try {
-    return JSON.stringify(result, null, 2);
+    const json = JSON.stringify(result, null, 2);
+    if (json !== undefined) return { language: "json", text: json };
+    return { language: "text", text: String(result) };
   } catch {
-    return String(result);
+    return { language: "text", text: String(result) };
   }
+}
+
+type BrowserReplConsoleLog = {
+  args: unknown[];
+  method: BrowserReplConsoleMethod;
+};
+
+type BrowserReplConsoleMethod = "debug" | "error" | "info" | "log" | "table" | "warn";
+
+function createBrowserReplConsole(logs: BrowserReplConsoleLog[]) {
+  const capturedMethods = new Map<BrowserReplConsoleMethod, (...args: unknown[]) => void>();
+  const capture = (method: BrowserReplConsoleMethod) => {
+    return (...args: unknown[]) => {
+      logs.push({ args, method });
+    };
+  };
+
+  for (const method of BROWSER_REPL_CONSOLE_METHODS) {
+    capturedMethods.set(method, capture(method));
+  }
+
+  return new Proxy(globalThis.console, {
+    get(consoleTarget, key, receiver) {
+      if (typeof key === "string" && isBrowserReplConsoleMethod(key)) {
+        return capturedMethods.get(key);
+      }
+
+      const value = Reflect.get(consoleTarget, key, receiver);
+      if (typeof value === "function") return value.bind(consoleTarget);
+      return value;
+    },
+  });
+}
+
+const BROWSER_REPL_CONSOLE_METHODS = ["debug", "error", "info", "log", "table", "warn"] as const;
+
+function isBrowserReplConsoleMethod(value: string): value is BrowserReplConsoleMethod {
+  return BROWSER_REPL_CONSOLE_METHODS.includes(value as BrowserReplConsoleMethod);
+}
+
+function formatBrowserReplConsoleOutput(logs: BrowserReplConsoleLog[]) {
+  return logs
+    .map((log) => {
+      const prefix = log.method === "log" ? "" : `${log.method}: `;
+      return `${prefix}${log.args.map(formatBrowserReplConsoleArg).join(" ")}`;
+    })
+    .join("\n");
+}
+
+function formatBrowserReplConsoleArg(arg: unknown) {
+  return formatBrowserReplResult(arg).text;
 }

--- a/apps/os/src/routes/_app/capnweb-repl.tsx
+++ b/apps/os/src/routes/_app/capnweb-repl.tsx
@@ -1,9 +1,15 @@
 import { useEffect, useRef, useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { newWebSocketRpcSession, RpcTarget, type RpcStub } from "capnweb";
-import { BookOpen, Play } from "lucide-react";
+import { BookOpen, ChevronDown, CircleHelp, Play } from "lucide-react";
 import { Button } from "@iterate-com/ui/components/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@iterate-com/ui/components/collapsible";
 import { ScrollArea } from "@iterate-com/ui/components/scroll-area";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@iterate-com/ui/components/tooltip";
 import {
   Sheet,
   SheetContent,
@@ -90,20 +96,29 @@ function CapnwebReplPage() {
               </div>
             ) : (
               entries.map((entry, index) => (
-                <div key={index} className="flex flex-col gap-2 font-mono text-sm">
-                  <pre className="overflow-x-auto whitespace-pre-wrap text-foreground">
-                    <span className="select-none text-muted-foreground">iterate&gt; </span>
-                    {entry.code}
-                  </pre>
-                  <pre
-                    className={
-                      entry.status === "error"
-                        ? "overflow-x-auto whitespace-pre-wrap text-destructive"
-                        : "overflow-x-auto whitespace-pre-wrap text-muted-foreground"
-                    }
-                  >
-                    {entry.output}
-                  </pre>
+                <div key={index} className="flex flex-col gap-2">
+                  <div className="flex items-center gap-2 font-mono text-xs text-muted-foreground">
+                    <span className="select-none">iterate&gt;</span>
+                  </div>
+                  <SourceCodeBlock
+                    code={entry.code}
+                    className="max-h-80"
+                    language="typescript"
+                    showCopyButton
+                  />
+                  {entry.consoleOutput ? (
+                    <ReplCollapsibleCodeBlock
+                      code={entry.consoleOutput}
+                      language="text"
+                      title="Console"
+                    />
+                  ) : null}
+                  <ReplCollapsibleCodeBlock
+                    code={entry.output}
+                    language={entry.outputLanguage}
+                    title={entry.status === "error" ? "Error" : "Result"}
+                    variant={entry.status === "error" ? "error" : "default"}
+                  />
                 </div>
               ))
             )}
@@ -113,7 +128,27 @@ function CapnwebReplPage() {
         <div className="border-t bg-background">
           <div className="mx-auto flex w-full max-w-5xl flex-col gap-2 px-4 py-3">
             <div className="flex items-center justify-between gap-3">
-              <span className="font-mono text-xs text-muted-foreground">iterate&gt;</span>
+              <div className="flex items-center gap-2">
+                <span className="font-mono text-xs text-muted-foreground">iterate&gt;</span>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        className="flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden"
+                        aria-label="REPL result aliases"
+                      />
+                    }
+                  >
+                    <CircleHelp className="size-3.5" />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>
+                      Use <code>$_</code> or <code>_</code> for the last successful result.
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </div>
               <span className="text-xs text-muted-foreground">{status}</span>
             </div>
             <SourceCodeBlock
@@ -123,7 +158,7 @@ function CapnwebReplPage() {
               language="typescript"
               onChange={setCode}
               onModEnter={() => void run()}
-              showCopyButton={false}
+              showCopyButton
             />
             <div className="flex items-center justify-end gap-2">
               <Button variant="outline" onClick={() => setExamplesOpen(true)} size="sm">
@@ -177,5 +212,41 @@ function CapnwebReplPage() {
         </SheetContent>
       </Sheet>
     </main>
+  );
+}
+
+function ReplCollapsibleCodeBlock(input: {
+  code: string;
+  language: "json" | "text" | "typescript";
+  title: string;
+  variant?: "default" | "error";
+}) {
+  return (
+    <Collapsible defaultOpen>
+      <div className="flex items-center justify-between gap-2">
+        <CollapsibleTrigger
+          className={
+            input.variant === "error"
+              ? "group flex items-center gap-1 text-xs font-medium text-destructive"
+              : "group flex items-center gap-1 text-xs font-medium text-muted-foreground"
+          }
+        >
+          <ChevronDown className="size-3 -rotate-90 transition-transform [[data-panel-open]_&]:rotate-0" />
+          {input.title}
+        </CollapsibleTrigger>
+      </div>
+      <CollapsibleContent>
+        <SourceCodeBlock
+          code={input.code}
+          className={
+            input.variant === "error"
+              ? "mt-1 max-h-96 [&_.cm-content]:text-destructive"
+              : "mt-1 max-h-96"
+          }
+          language={input.language}
+          showCopyButton
+        />
+      </CollapsibleContent>
+    </Collapsible>
   );
 }


### PR DESCRIPTION
## Summary

Improves the browser CapnWeb REPL so prompt history and outputs are easier to inspect and reuse.

## Changes

- Render submitted prompts, console output, results, and errors with the shared `SourceCodeBlock` CodeMirror component so each block has copy affordances.
- Wrap console output and results in collapsible sections.
- Capture per-run `console.log`, `console.info`, `console.warn`, `console.error`, `console.debug`, and `console.table` output.
- Make top-level declarations return their assigned value, so `const a = 123` prints `123`.
- Store the last successful result in `$_` and `_`, with a compact tooltip affordance near the REPL prompt.
- Add unit coverage for declaration output, last-result aliases, and captured console output.

## Validation

- `pnpm --dir apps/os exec vitest run src/capnweb/browser-repl.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm exec oxlint apps/os/src/capnweb/browser-repl.ts apps/os/src/capnweb/browser-repl.test.ts apps/os/src/routes/_app/capnweb-repl.tsx --deny-warnings`
- `pnpm exec oxfmt apps/os/src/capnweb/browser-repl.ts apps/os/src/capnweb/browser-repl.test.ts apps/os/src/routes/_app/capnweb-repl.tsx`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-09T09:35:46.910Z",
      "headSha": "d5004263c556ac63b1c9b19b88b3138d81ab8315",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27196974307",
      "shortSha": "d500426"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `d500426`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27196974307)
Updated: 2026-06-09T09:35:46.910Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes REPL code transformation and `new Function` execution semantics in the browser; mistakes could mis-evaluate user snippets, though scope is limited to the dev REPL and coverage was expanded.
> 
> **Overview**
> Improves the browser Cap’n Web REPL so each run is easier to read, reuse, and debug.
> 
> **Evaluation & results:** Statement-mode snippets now return meaningful values—top-level declarations assign `__replLastValue`, and the last top-level expression becomes the run result (with line-break continuation handling for multiline calls, optional chaining, ternaries, and exclusions for `do`/`while`). Successful runs stash that value on `$_` and `_` in session scope. `formatBrowserReplResult` now returns `{ text, language }` so JSON vs plain text can be highlighted correctly.
> 
> **Console:** Per-run `console` is proxied to capture `log`/`info`/`warn`/`error`/`debug`/`table` into `consoleOutput` on `BrowserReplEntry`, while other methods (e.g. `trace`) still hit the real console.
> 
> **UI:** History and the input use `SourceCodeBlock` with copy buttons; console and result/error blocks are collapsible. A tooltip documents `$_` / `_`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5004263c556ac63b1c9b19b88b3138d81ab8315. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->