### PR TITLE
[codex] Simplify stream composer flow

### DIFF
--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -1,12 +1,15 @@
 import {
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
   useState,
   useSyncExternalStore,
+  type RefObject,
   type ReactNode,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { Spinner } from "@iterate-com/ui/components/spinner";
 import {
   acquireStreamRuntime,
   type StreamBrowserSnapshot,
@@ -74,12 +77,19 @@ export function ProjectStreamView({
   );
   const [submitError, setSubmitError] = useState<string | undefined>();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [pendingSubmission, setPendingSubmission] = useState<{ baseEventCount: number } | null>(
+    null,
+  );
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const isAwaitingResult = pendingSubmission != null;
 
   async function submit() {
     const trimmed = composerText.trim();
     if (!trimmed) return;
     setIsSubmitting(true);
     setSubmitError(undefined);
+    setPendingSubmission({ baseEventCount: eventCount });
     try {
       if (composerMode === "message" && messageComposer) {
         await messageComposer.onSubmit(trimmed);
@@ -90,13 +100,40 @@ export function ProjectStreamView({
         );
         await store.appendBatch({ events });
       }
-      setComposerText(composerMode === "raw" ? composerText : "");
+      setComposerText("");
     } catch (error) {
       setSubmitError(error instanceof Error ? error.message : String(error));
+      setPendingSubmission(null);
     } finally {
       setIsSubmitting(false);
+      window.requestAnimationFrame(() => {
+        inputRef.current?.focus();
+      });
     }
   }
+
+  useEffect(() => {
+    if (pendingSubmission == null || eventCount <= pendingSubmission.baseEventCount) {
+      return;
+    }
+
+    setPendingSubmission(null);
+  }, [eventCount, pendingSubmission]);
+
+  useLayoutEffect(() => {
+    const frame = window.requestAnimationFrame(() => {
+      const scrollContainer = scrollContainerRef.current;
+      if (scrollContainer == null) {
+        return;
+      }
+
+      scrollContainer.scrollTop = scrollContainer.scrollHeight;
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [eventCount, isAwaitingResult, submitError]);
 
   return (
     <section className="flex min-h-0 flex-1 flex-col bg-white">
@@ -104,47 +141,52 @@ export function ProjectStreamView({
         <h1 className="truncate font-mono text-sm font-semibold">{streamPathText}</h1>
         <StreamStatus count={eventCount} snapshot={snapshot} />
       </header>
-      {countResult.status !== "ok" ? (
-        <Centered>
-          {countResult.status === "error"
-            ? (countResult.error?.message ?? "SQLite query failed")
-            : "Opening local SQLite mirror"}
-        </Centered>
-      ) : (
-        <VirtualEventRows
-          database={store.streamDatabase}
-          emptyLabel={emptyLabel}
-          eventCount={eventCount}
-          snapshot={snapshot}
-        />
-      )}
-      <form
-        className="shrink-0 border-t p-3"
-        onSubmit={(event) => {
-          event.preventDefault();
-          void submit();
-        }}
-      >
-        <textarea
-          className="block max-h-48 min-h-20 w-full resize-y rounded-md border px-3 py-2 font-mono text-[13px] outline-none focus:border-slate-400"
-          placeholder={messageComposer?.placeholder ?? "YAML event"}
-          spellCheck={false}
-          value={composerText}
-          onChange={(event) => setComposerText(event.currentTarget.value)}
-        />
-        <div className="mt-2 flex items-center justify-between gap-3">
-          <output className="min-w-0 truncate font-mono text-xs text-red-700">
-            {submitError ?? ""}
-          </output>
-          <button
-            className="rounded-md bg-slate-950 px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
-            disabled={isSubmitting}
-            type="submit"
-          >
-            {isSubmitting ? "Sending" : composerMode === "message" ? "Send" : "Append"}
-          </button>
-        </div>
-      </form>
+      <main ref={scrollContainerRef} className="min-h-0 flex-1 overflow-y-auto">
+        {countResult.status !== "ok" ? (
+          <Centered>
+            {countResult.status === "error"
+              ? (countResult.error?.message ?? "SQLite query failed")
+              : "Opening local SQLite mirror"}
+          </Centered>
+        ) : (
+          <VirtualEventRows
+            database={store.streamDatabase}
+            emptyLabel={emptyLabel}
+            eventCount={eventCount}
+            scrollElementRef={scrollContainerRef}
+            snapshot={snapshot}
+          />
+        )}
+        {isAwaitingResult ? <PendingResultRow /> : null}
+        <form
+          className="border-t p-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void submit();
+          }}
+        >
+          <textarea
+            ref={inputRef}
+            className="block max-h-48 min-h-20 w-full resize-y rounded-md border px-3 py-2 font-mono text-[13px] outline-none focus:border-slate-400"
+            placeholder={messageComposer?.placeholder ?? "YAML event"}
+            spellCheck={false}
+            value={composerText}
+            onChange={(event) => setComposerText(event.currentTarget.value)}
+          />
+          <div className="mt-2 flex items-center justify-between gap-3">
+            <output className="min-w-0 truncate font-mono text-xs text-red-700">
+              {submitError ?? ""}
+            </output>
+            <button
+              className="rounded-md bg-slate-950 px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+              disabled={isSubmitting}
+              type="submit"
+            >
+              {isSubmitting ? "Sending" : composerMode === "message" ? "Send" : "Append"}
+            </button>
+          </div>
+        </form>
+      </main>
     </section>
   );
 }
@@ -153,24 +195,21 @@ function VirtualEventRows({
   database,
   emptyLabel,
   eventCount,
+  scrollElementRef,
   snapshot,
 }: {
   database: StreamBrowserDatabase;
   emptyLabel: string;
   eventCount: number;
+  scrollElementRef: RefObject<HTMLDivElement | null>;
   snapshot: StreamBrowserSnapshot;
 }) {
-  const parentRef = useRef<HTMLDivElement>(null);
   const virtualizer = useVirtualizer({
     count: eventCount,
-    getScrollElement: () => parentRef.current,
+    getScrollElement: () => scrollElementRef.current,
     estimateSize: () => 44,
     overscan: 24,
   });
-
-  useLayoutEffect(() => {
-    if (eventCount > 0) virtualizer.scrollToIndex(eventCount - 1, { align: "end" });
-  }, [eventCount, virtualizer]);
 
   const virtualItems = virtualizer.getVirtualItems();
   const first = virtualItems[0]?.index ?? 0;
@@ -201,7 +240,7 @@ function VirtualEventRows({
   }
 
   return (
-    <div ref={parentRef} className="min-h-0 flex-1 overflow-y-auto px-4">
+    <div className="px-4">
       <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
         {virtualItems.map((item) => {
           const row = rowsByIndex.get(item.index);
@@ -230,6 +269,15 @@ function VirtualEventRows({
           );
         })}
       </div>
+    </div>
+  );
+}
+
+function PendingResultRow() {
+  return (
+    <div className="flex items-center gap-2 border-t px-4 py-3 font-mono text-xs text-slate-500">
+      <Spinner className="size-3.5" />
+      <span>Waiting for result</span>
     </div>
   );
 }

--- a/packages/ui/src/components/events/stream-feed.tsx
+++ b/packages/ui/src/components/events/stream-feed.tsx
@@ -582,6 +582,8 @@ function RawJsonDump({ element }: { element: EventsStreamRawJsonDumpElement }) {
       showToggle
       showCopyButton
       scrollToBottom
+      showLineNumbers={false}
+      plainChrome
     />
   );
 }
@@ -708,6 +710,8 @@ function MetadataUpdatedBlock({ element }: { element: EventsStreamMetadataUpdate
         initialFormat="yaml"
         showToggle
         showCopyButton
+        showLineNumbers={false}
+        plainChrome
       />
     </FeedEvent>
   );
@@ -737,6 +741,8 @@ function CodemodeBlockBlock({ element }: { element: EventsStreamCodemodeBlockEle
         language="typescript"
         className="min-h-40 max-h-128"
         showCopyButton
+        showLineNumbers={false}
+        plainChrome
       />
     </FeedEvent>
   );
@@ -771,6 +777,8 @@ function CodemodeResultBlock({ element }: { element: EventsStreamCodemodeResultE
           initialFormat="yaml"
           showToggle
           showCopyButton
+          showLineNumbers={false}
+          plainChrome
         />
         {element.props.error == null ? null : (
           <SourceCodeBlock
@@ -778,6 +786,8 @@ function CodemodeResultBlock({ element }: { element: EventsStreamCodemodeResultE
             language="text"
             className="min-h-20 max-h-48"
             showCopyButton
+            showLineNumbers={false}
+            plainChrome
           />
         )}
         {element.props.logs.length === 0 ? null : (
@@ -786,6 +796,8 @@ function CodemodeResultBlock({ element }: { element: EventsStreamCodemodeResultE
             language="text"
             className="min-h-20 max-h-56"
             showCopyButton
+            showLineNumbers={false}
+            plainChrome
           />
         )}
       </div>

--- a/packages/ui/src/components/serialized-object-code-block.tsx
+++ b/packages/ui/src/components/serialized-object-code-block.tsx
@@ -58,6 +58,7 @@ export interface SerializedObjectCodeBlockProps {
   showDebugConsoleButton?: boolean;
   scrollToBottom?: boolean;
   showLineNumbers?: boolean;
+  plainChrome?: boolean;
 }
 
 export function SerializedObjectCodeBlock({
@@ -69,6 +70,7 @@ export function SerializedObjectCodeBlock({
   showDebugConsoleButton = false,
   scrollToBottom = false,
   showLineNumbers = true,
+  plainChrome = false,
 }: SerializedObjectCodeBlockProps) {
   const [currentFormat, setCurrentFormat] = useState<SerializedFormat>(initialFormat);
   const [copiedFormat, setCopiedFormat] = useState<SerializedFormat | null>(null);
@@ -87,15 +89,25 @@ export function SerializedObjectCodeBlock({
       EditorView.editable.of(false),
       EditorView.contentAttributes.of({ tabindex: "0" }),
       EditorView.lineWrapping,
-      !showLineNumbers
+      !showLineNumbers || plainChrome
         ? EditorView.theme({
             ".cm-gutters": {
               display: "none",
             },
           })
         : [],
+      plainChrome
+        ? EditorView.theme({
+            ".cm-activeLine, .cm-activeLineGutter, .cm-selectionMatch": {
+              backgroundColor: "transparent",
+            },
+            ".cm-focused": {
+              outline: "none",
+            },
+          })
+        : [],
     ],
-    [currentFormat, showLineNumbers],
+    [currentFormat, plainChrome, showLineNumbers],
   );
 
   const handleCopy = async (format: SerializedFormat) => {
@@ -134,7 +146,10 @@ export function SerializedObjectCodeBlock({
     <div className={cn("relative flex min-h-0 flex-col", className)}>
       <div
         ref={scrollContainerRef}
-        className="cm-SerializedObjectCodeBlock min-h-0 flex-1 overflow-hidden overflow-y-auto rounded border"
+        className={cn(
+          "cm-SerializedObjectCodeBlock min-h-0 flex-1 overflow-hidden overflow-y-auto",
+          plainChrome ? "" : "rounded border",
+        )}
       >
         <CodeMirror value={code} extensions={extensions} />
       </div>

--- a/packages/ui/src/components/source-code-block.tsx
+++ b/packages/ui/src/components/source-code-block.tsx
@@ -143,6 +143,8 @@ export interface SourceCodeBlockProps {
   className?: string;
   language?: SourceCodeLanguage;
   showCopyButton?: boolean;
+  showLineNumbers?: boolean;
+  plainChrome?: boolean;
   wrapLongLines?: boolean;
   editable?: boolean;
   onChange?: (value: string) => void;
@@ -154,6 +156,8 @@ export function SourceCodeBlock({
   className,
   language = "typescript",
   showCopyButton = true,
+  showLineNumbers = true,
+  plainChrome = false,
   wrapLongLines = true,
   editable = false,
   onChange,
@@ -180,8 +184,25 @@ export function SourceCodeBlock({
       keymap.of(searchKeymap),
       EditorView.contentAttributes.of({ tabindex: "0" }),
       wrapLongLines ? EditorView.lineWrapping : [],
+      !showLineNumbers || plainChrome
+        ? EditorView.theme({
+            ".cm-gutters": {
+              display: "none",
+            },
+          })
+        : [],
+      plainChrome
+        ? EditorView.theme({
+            ".cm-activeLine, .cm-activeLineGutter, .cm-selectionMatch": {
+              backgroundColor: "transparent",
+            },
+            ".cm-focused": {
+              outline: "none",
+            },
+          })
+        : [],
     ];
-  }, [language, wrapLongLines]);
+  }, [language, plainChrome, showLineNumbers, wrapLongLines]);
 
   const handleCopy = async () => {
     try {
@@ -196,7 +217,12 @@ export function SourceCodeBlock({
 
   return (
     <div className={cn("relative flex min-h-0 flex-col", className)}>
-      <div className="min-h-0 flex-1 overflow-hidden overflow-y-auto rounded border">
+      <div
+        className={cn(
+          "min-h-0 flex-1 overflow-hidden overflow-y-auto",
+          plainChrome ? "" : "rounded border",
+        )}
+      >
         <CodeMirror
           value={code}
           extensions={extensions}


### PR DESCRIPTION
## What changed

- Moved the OS project stream composer into the stream scroll flow instead of keeping it as a fixed bottom sibling.
- Added a pending result row with a spinner while submitted output is waiting to appear in the local stream mirror.
- Clear and refocus the input after successful submit, and force the stream scroller to follow the tail.
- Added opt-in plain CodeMirror chrome for stream result blocks: no line numbers, no wrapper border, and no grey active-line background.

## Why

The command/results flow should behave like a simple append log: submit input, show pending state, insert result, clear input, and return focus to the input for the next command.

## Validation

- `pnpm --dir apps/os typecheck`
- `pnpm --dir packages/ui typecheck`
- `pnpm lint`
- `pnpm format:check`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "example": {
      "appDisplayName": "Example",
      "appSlug": "example",
      "status": "released",
      "updatedAt": "2026-06-09T10:20:11.295Z",
      "headSha": "f67d01f3cde88fa144b5915f3b4a8f9b5362dcf2",
      "message": "Preview app released.",
      "publicUrl": "https://example.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27199243526",
      "shortSha": "f67d01f"
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-09T10:20:19.688Z",
      "headSha": "f67d01f3cde88fa144b5915f3b4a8f9b5362dcf2",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27199243526",
      "shortSha": "f67d01f"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-06-09T10:20:15.020Z",
      "headSha": "f67d01f3cde88fa144b5915f3b4a8f9b5362dcf2",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27199243526",
      "shortSha": "f67d01f"
    },
    "events": {
      "appDisplayName": "Events",
      "appSlug": "events",
      "status": "released",
      "updatedAt": "2026-06-09T10:19:57.190Z",
      "headSha": "f67d01f3cde88fa144b5915f3b4a8f9b5362dcf2",
      "message": "Preview app released.",
      "publicUrl": "https://events.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27199243526",
      "shortSha": "f67d01f"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Events
Status: released
Commit: `f67d01f`
Preview: https://events.iterate-preview-6.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27199243526)
Updated: 2026-06-09T10:19:57.190Z

### Example
Status: released
Commit: `f67d01f`
Preview: https://example.iterate-preview-6.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27199243526)
Updated: 2026-06-09T10:20:11.295Z

### OS
Status: released
Commit: `f67d01f`
Preview: https://os.iterate-preview-6.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27199243526)
Updated: 2026-06-09T10:20:19.688Z

### Semaphore
Status: released
Commit: `f67d01f`
Preview: https://semaphore.iterate-preview-6.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27199243526)
Updated: 2026-06-09T10:20:15.020Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only scroll/composer UX and optional CodeMirror styling; no auth, API, or data-path changes.
> 
> **Overview**
> Reworks the OS project stream so the composer lives inside the scroll area and behaves like an append-only command log.
> 
> On submit, the UI records the current event count, shows a **“Waiting for result”** row with a spinner until the local mirror gains a new event, clears the textarea on success, refocuses the input, and keeps the shared scroller pinned to the tail (virtualized rows use the parent scroll element instead of their own). **Plain chrome** is added to `SerializedObjectCodeBlock` and `SourceCodeBlock` (`plainChrome`, optional hidden line numbers) and enabled on stream-feed code/result blocks so embedded output reads as inline feed content rather than bordered editor panels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f67d01f3cde88fa144b5915f3b4a8f9b5362dcf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->