### PR TITLE
[codex] Fix stream pending state

### DIFF
--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -1,5 +1,4 @@
 import {
-  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -77,19 +76,14 @@ export function ProjectStreamView({
   );
   const [submitError, setSubmitError] = useState<string | undefined>();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [pendingSubmission, setPendingSubmission] = useState<{ baseEventCount: number } | null>(
-    null,
-  );
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const isAwaitingResult = pendingSubmission != null;
 
   async function submit() {
     const trimmed = composerText.trim();
     if (!trimmed) return;
     setIsSubmitting(true);
     setSubmitError(undefined);
-    setPendingSubmission({ baseEventCount: eventCount });
     try {
       if (composerMode === "message" && messageComposer) {
         await messageComposer.onSubmit(trimmed);
@@ -103,7 +97,6 @@ export function ProjectStreamView({
       setComposerText("");
     } catch (error) {
       setSubmitError(error instanceof Error ? error.message : String(error));
-      setPendingSubmission(null);
     } finally {
       setIsSubmitting(false);
       window.requestAnimationFrame(() => {
@@ -111,14 +104,6 @@ export function ProjectStreamView({
       });
     }
   }
-
-  useEffect(() => {
-    if (pendingSubmission == null || eventCount <= pendingSubmission.baseEventCount) {
-      return;
-    }
-
-    setPendingSubmission(null);
-  }, [eventCount, pendingSubmission]);
 
   useLayoutEffect(() => {
     const frame = window.requestAnimationFrame(() => {
@@ -133,7 +118,7 @@ export function ProjectStreamView({
     return () => {
       window.cancelAnimationFrame(frame);
     };
-  }, [eventCount, isAwaitingResult, submitError]);
+  }, [eventCount, isSubmitting, submitError]);
 
   return (
     <section className="flex min-h-0 flex-1 flex-col bg-white">
@@ -157,7 +142,7 @@ export function ProjectStreamView({
             snapshot={snapshot}
           />
         )}
-        {isAwaitingResult ? <PendingResultRow /> : null}
+        {isSubmitting ? <PendingResultRow /> : null}
         <form
           className="border-t p-3"
           onSubmit={(event) => {


### PR DESCRIPTION
## What changed

- Removed the event-count based pending submission state from `ProjectStreamView`.
- The pending result row now follows the submit request lifecycle directly via `isSubmitting`.

## Why

This addresses the Bugbot comments from #1397:

- Idempotent appends could leave the spinner stuck forever because the stream count did not increase.
- Unrelated stream events could clear the spinner early because the stream count increased for a different reason.

## Validation

- `pnpm --dir apps/os typecheck`
- `pnpm lint`
- `pnpm format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI state change in the project stream composer; no auth, data, or API changes.
> 
> **Overview**
> Fixes incorrect **pending result** behavior in `ProjectStreamView` by dropping event-count–based tracking (`pendingSubmission` / `isAwaitingResult`) and the `useEffect` that cleared it when `eventCount` rose.
> 
> The **“Waiting for result”** row and scroll-to-bottom layout now follow **`isSubmitting`** for the whole submit/async append lifecycle, so the spinner no longer sticks when appends are idempotent (no new events) or clears early when unrelated events arrive on the stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0b50fffa331bd0e9a7c3c04c9ad6bb886a30408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->