### PR TITLE
[codex] Unredact TypeID config prefixes

### DIFF
--- a/apps/example/src/app.test.ts
+++ b/apps/example/src/app.test.ts
@@ -1,0 +1,18 @@
+import { inspect } from "node:util";
+import { describe, expect, it } from "vitest";
+import { AppConfig } from "./app.ts";
+
+describe("AppConfig", () => {
+  it("keeps TypeID prefix visible because it is not a secret", () => {
+    const parsed = AppConfig.parse({
+      pirateSecret: "ahoy",
+      posthog: {
+        apiKey: "phc_public_key",
+      },
+    });
+
+    expect(parsed.typeId.prefix).toBe("example");
+    expect(inspect(parsed)).toContain("prefix: 'example'");
+    expect(inspect(parsed)).toContain("pirateSecret: Redacted {}");
+  });
+});

--- a/apps/example/src/app.ts
+++ b/apps/example/src/app.ts
@@ -8,13 +8,11 @@ export const AppConfig = BaseAppConfig.extend({
   typeId: z.preprocess(
     (value) => value ?? {},
     z.object({
-      prefix: redacted(
-        z
-          .string()
-          .trim()
-          .regex(/^[a-z]+$/)
-          .default("example"),
-      ),
+      prefix: z
+        .string()
+        .trim()
+        .regex(/^[a-z]+$/)
+        .default("example"),
     }),
   ),
   posthog: z.object({

--- a/apps/example/src/orpc/routers/things.ts
+++ b/apps/example/src/orpc/routers/things.ts
@@ -7,7 +7,7 @@ import { os } from "~/orpc/orpc.ts";
 
 function createThingId(config: AppConfig) {
   return typeid({
-    env: { TYPEID_PREFIX: config.typeId.prefix.exposeSecret() },
+    env: { TYPEID_PREFIX: config.typeId.prefix },
     prefix: "thing",
   });
 }

--- a/apps/os/src/app.test.ts
+++ b/apps/os/src/app.test.ts
@@ -1,3 +1,4 @@
+import { inspect } from "node:util";
 import { describe, expect, it } from "vitest";
 import { parseAppConfigFromEnv } from "@iterate-com/shared/apps/config";
 import { AppConfig } from "./app.ts";
@@ -7,6 +8,19 @@ const baseConfig = {
 };
 
 describe("AppConfig", () => {
+  it("keeps TypeID prefix visible because it is not a secret", () => {
+    const parsed = parseAppConfigFromEnv({
+      configSchema: AppConfig,
+      prefix: "APP_CONFIG_",
+      env: {
+        APP_CONFIG: JSON.stringify(baseConfig),
+      },
+    });
+
+    expect(parsed.typeIdPrefix).toBe("os");
+    expect(inspect(parsed)).toContain("typeIdPrefix: 'os'");
+  });
+
   it("accepts an optional admin API secret for proof and automation clients", () => {
     expect(
       parseAppConfigFromEnv({

--- a/apps/os/src/app.ts
+++ b/apps/os/src/app.ts
@@ -87,13 +87,11 @@ export const AppConfig = BaseAppConfig.extend({
     })
     .default({}),
   slackBotToken: redacted(z.string().trim().min(1)).optional(),
-  typeIdPrefix: redacted(
-    z
-      .string()
-      .trim()
-      .regex(/^[a-z]+$/, "Type ID prefix must contain lowercase letters only")
-      .default("os"),
-  ),
+  typeIdPrefix: z
+    .string()
+    .trim()
+    .regex(/^[a-z]+$/, "Type ID prefix must contain lowercase letters only")
+    .default("os"),
   posthog: z
     .object({
       apiKey: publicValue(z.string().trim().min(1)),

--- a/apps/os/src/capnweb/projects-capability.ts
+++ b/apps/os/src/capnweb/projects-capability.ts
@@ -299,7 +299,7 @@ function resolveProjectId(input: { id?: string; context: Pick<AppContext, "confi
   }
 
   return typeid({
-    env: { TYPEID_PREFIX: input.context.config.typeIdPrefix.exposeSecret() },
+    env: { TYPEID_PREFIX: input.context.config.typeIdPrefix },
     prefix: "proj",
   });
 }

--- a/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
@@ -1097,7 +1097,7 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
 
   private createTypeId(prefix: string) {
     return typeid({
-      env: { TYPEID_PREFIX: this.getAppConfig().typeIdPrefix.exposeSecret() },
+      env: { TYPEID_PREFIX: this.getAppConfig().typeIdPrefix },
       prefix,
     });
   }

--- a/apps/os/src/domains/secrets/entrypoints/secrets-capability.ts
+++ b/apps/os/src/domains/secrets/entrypoints/secrets-capability.ts
@@ -157,7 +157,7 @@ export class SecretsCapability extends WorkerEntrypoint<
       env: this.env as unknown as Record<string, unknown>,
       prefix: "APP_CONFIG_",
     });
-    return projectSecretId({ typeIdPrefix: config.typeIdPrefix.exposeSecret() });
+    return projectSecretId({ typeIdPrefix: config.typeIdPrefix });
   }
 }
 

--- a/apps/os/src/domains/secrets/integration-api.ts
+++ b/apps/os/src/domains/secrets/integration-api.ts
@@ -113,7 +113,7 @@ async function handleSlackCallback(input: {
     webhookProviderIdentifier: tokenData.team.id,
   });
   await upsertProjectSecret(input.context.db, {
-    id: projectSecretId({ typeIdPrefix: input.context.config.typeIdPrefix.exposeSecret() }),
+    id: projectSecretId({ typeIdPrefix: input.context.config.typeIdPrefix }),
     key: providerSecretKey("slack"),
     material: tokenData.access_token,
     metadata: {
@@ -221,7 +221,7 @@ async function handleGoogleCallback(input: {
     scopes: tokenData.scope ?? config.scopes.join(" "),
   });
   await upsertProjectSecret(input.context.db, {
-    id: projectSecretId({ typeIdPrefix: input.context.config.typeIdPrefix.exposeSecret() }),
+    id: projectSecretId({ typeIdPrefix: input.context.config.typeIdPrefix }),
     key: providerSecretKey("google"),
     material: tokenData.access_token,
     metadata: {

--- a/apps/os/src/domains/secrets/oauth.ts
+++ b/apps/os/src/domains/secrets/oauth.ts
@@ -174,7 +174,7 @@ export async function getFreshGoogleAccessToken(input: {
   }
 
   await upsertProjectSecret(input.db, {
-    id: projectSecretId({ typeIdPrefix: input.config.typeIdPrefix.exposeSecret() }),
+    id: projectSecretId({ typeIdPrefix: input.config.typeIdPrefix }),
     key: providerSecretKey("google"),
     material: tokenData.access_token,
     metadata: {


### PR DESCRIPTION
## Summary

- Make OS `typeIdPrefix` and example `typeId.prefix` plain private config strings instead of redacted values.
- Remove `.exposeSecret()` calls from TypeID generation call sites that consume those prefixes.
- Add app config regression tests proving TypeID prefixes inspect visibly while actual secrets remain redacted.

## Root Cause

`typeIdPrefix` was wrapped in `redacted(...)`, so config inspection during `pnpm dev` printed `typeIdPrefix: Redacted {}` even though the value is an environment identifier, not a credential.

## Validation

- `pnpm --dir apps/os exec vitest run src/app.test.ts`
- `pnpm --dir apps/example exec vitest run src/app.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/example typecheck`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "example": {
      "appDisplayName": "Example",
      "appSlug": "example",
      "status": "released",
      "updatedAt": "2026-06-09T18:11:14.994Z",
      "headSha": "76c61e5b9d1645b3ac737419b8d84da316a33c2c",
      "message": "Preview app released.",
      "publicUrl": "https://example.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27218659485",
      "shortSha": "76c61e5"
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-09T18:11:21.121Z",
      "headSha": "76c61e5b9d1645b3ac737419b8d84da316a33c2c",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27218659485",
      "shortSha": "76c61e5"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Example
Status: released
Commit: `76c61e5`
Preview: https://example.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27218659485)
Updated: 2026-06-09T18:11:14.994Z

### OS
Status: released
Commit: `76c61e5`
Preview: https://os.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27218659485)
Updated: 2026-06-09T18:11:21.121Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to config typing/inspection and prefix plumbing; no credential handling or auth logic changes.
> 
> **Overview**
> **TypeID environment prefixes are no longer treated as secrets** in OS (`typeIdPrefix`) and the example app (`typeId.prefix`). They are plain validated strings with the same defaults, so `node:util` inspection during dev shows values like `'os'` / `'example'` instead of `Redacted {}`.
> 
> **Call sites** that build TypeIDs (projects, project DO routes, secrets, OAuth upserts, example things) now pass the prefix string directly and drop `.exposeSecret()`.
> 
> **Regression tests** in `apps/os` and `apps/example` assert prefixes appear in `inspect()` output while real secrets (e.g. `pirateSecret`) stay redacted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76c61e5b9d1645b3ac737419b8d84da316a33c2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->