### PR TITLE
[codex] stream processor: crisp batch model

### DIFF
--- a/apps/os/tasks/stream-processor-class-design-notes.md
+++ b/apps/os/tasks/stream-processor-class-design-notes.md
@@ -32,6 +32,10 @@ questions as design work, not half-wired runtime behavior.
   - `processEventBatch(...)` — async batch-level side effects (e.g. one SQLite transaction over
     the already-deduped new events). The default implementation calls `processEvent(...)` once
     per reduced event; overrides call `super.processEventBatch(args)` to keep that behavior.
+- A fourth, optional `prepare()` hook runs once before the checkpoint is first read (via either
+  `snapshot()` or the first batch). Use it for setup that can invalidate the stored checkpoint —
+  e.g. schema migrations that reset projection tables — so it always lands before the resume
+  cursor is decided.
 - The checkpoint (reduced state + offset) is written only after `processEventBatch` and all
   `blockProcessorWhile` work succeed.
 - Hooks receive plain state/event types and must treat them as immutable; there is no

--- a/apps/os/tasks/stream-processor-class-design-notes.md
+++ b/apps/os/tasks/stream-processor-class-design-notes.md
@@ -20,13 +20,20 @@ questions as design work, not half-wired runtime behavior.
   - optional `readState` and `writeState`
 - If no state storage is passed, the base uses an in-memory snapshot. That keeps tests and
   stateless experiments cheap.
-- `processEventBatch({ events, streamMaxOffset })` is the public sink.
+- `processEventBatch({ events, streamMaxOffset })` is the public sink. It is not overridable
+  (enforced by lint): the serialization guarantee lives there and must stay on the base class.
 - The base serializes batches in memory. A later batch never starts until the previous batch has
   either completed or failed.
-- The base reduces every new event in the batch first, then calls `processEvent(...)` once per
-  reduced event.
-- `processEvent(...)` is synchronous. Async side effects must be registered through one of the
-  provided helpers.
+- Subclasses extend up to three hooks, all of which run inside the serialized section:
+  - `reduce(...)` — pure projection of one consumed event into the next state;
+  - `processEvent(...)` — synchronous per-event side effects;
+  - `processBatch(...)` — async batch-level side effects (e.g. one SQLite transaction over the
+    already-deduped new events). The default implementation calls `processEvent(...)` once per
+    reduced event; overrides call `super.processBatch(args)` to keep that behavior.
+- The checkpoint (reduced state + offset) is written only after `processBatch` and all
+  `blockProcessorWhile` work succeed.
+- Hooks receive plain state/event types and must treat them as immutable; there is no
+  `DeepReadonly` wrapper because it forced a cast in every real subclass.
 - Subclass overrides annotate their args as
   `Parameters<StreamProcessor<Contract>["method"]>[0]` — the single sanctioned spelling,
   enforced by the `iterate/stream-processor-override-args` lint rule. The arg shapes are
@@ -92,14 +99,16 @@ The stream core is not an ordinary subscription processor:
 - it owns stream runtime state
 - it triggers stream-internal side effects such as child-stream propagation
 
-For that reason the class exposes explicit inline methods used by the `Stream` Durable Object:
+For that reason `CoreStreamProcessor` itself (not the base class) exposes explicit inline methods
+used by the `Stream` Durable Object, built on the protected `reduceRawEvent` helper:
 
 - `validateAppend({ event, state })`
 - `reduceEvent({ event, state })`
 - `processReducedEvent({ event, previousState, state })`
 
-Open question: should the inline core eventually have a sibling base class, or is this explicit
-inline surface enough?
+The base class stays a pure batch/checkpoint model; the inline surface is a core-processor
+specialty. Open question: should the inline core eventually have a sibling base class, or is this
+explicit inline surface enough?
 
 ## Open Decisions
 

--- a/apps/os/tasks/stream-processor-class-design-notes.md
+++ b/apps/os/tasks/stream-processor-class-design-notes.md
@@ -20,17 +20,19 @@ questions as design work, not half-wired runtime behavior.
   - optional `readState` and `writeState`
 - If no state storage is passed, the base uses an in-memory snapshot. That keeps tests and
   stateless experiments cheap.
-- `processEventBatch({ events, streamMaxOffset })` is the public sink. It is not overridable
-  (enforced by lint): the serialization guarantee lives there and must stay on the base class.
+- `ingest({ events, streamMaxOffset })` is the host-facing sink — deliberately named outside the
+  `process*` hook family. It is not overridable (enforced by lint): the serialization guarantee
+  lives there and must stay on the base class.
 - The base serializes batches in memory. A later batch never starts until the previous batch has
   either completed or failed.
-- Subclasses extend up to three hooks, all of which run inside the serialized section:
+- The `process*` family is the authoring surface. Subclasses extend up to three hooks, all of
+  which run inside the serialized section:
   - `reduce(...)` — pure projection of one consumed event into the next state;
-  - `processEvent(...)` — synchronous per-event side effects;
-  - `processBatch(...)` — async batch-level side effects (e.g. one SQLite transaction over the
-    already-deduped new events). The default implementation calls `processEvent(...)` once per
-    reduced event; overrides call `super.processBatch(args)` to keep that behavior.
-- The checkpoint (reduced state + offset) is written only after `processBatch` and all
+  - `processEvent(...)` — synchronous per-event side effects; what most processors implement;
+  - `processEventBatch(...)` — async batch-level side effects (e.g. one SQLite transaction over
+    the already-deduped new events). The default implementation calls `processEvent(...)` once
+    per reduced event; overrides call `super.processEventBatch(args)` to keep that behavior.
+- The checkpoint (reduced state + offset) is written only after `processEventBatch` and all
   `blockProcessorWhile` work succeed.
 - Hooks receive plain state/event types and must treat them as immutable; there is no
   `DeepReadonly` wrapper because it forced a cast in every real subclass.
@@ -38,6 +40,23 @@ questions as design work, not half-wired runtime behavior.
   `Parameters<StreamProcessor<Contract>["method"]>[0]` — the single sanctioned spelling,
   enforced by the `iterate/stream-processor-override-args` lint rule. The arg shapes are
   deliberately not exported as named types.
+
+## Consumes Semantics
+
+`contract.consumes` is both a type-level and (eventually) delivery-level filter. The planned
+subscription filtering will use it to only deliver named event types, with `"*"` as the explicit
+opt-in for everything:
+
+- named only — the hook event type is the exact union of those events; exhaustive switches can
+  end in `assertNever(event)`;
+- `["*"]` only — plain `StreamEvent` (real `type` string, `unknown` payload), for generic
+  projectors;
+- `["*", ...named]` — the named union plus `WildcardConsumedEvent`, whose `type` is the literal
+  `"*"`. Named events keep exact payload inference; the wildcard branch is reachable (never-free)
+  with an `unknown` payload. To string-match a specific event type, name it in `consumes` instead
+  of comparing inside the wildcard branch.
+
+`emits` must always be named — `"*"` is rejected at the definition site.
 
 ## Async Side Effects
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -111,6 +111,11 @@ function compactTypeText(text) {
 }
 
 /**
+ * Extracts the contract type argument from `class X extends StreamProcessor<Contract, ...>`.
+ * Text-based on purpose (no type checker in lint): it reads the first type argument up to a
+ * `,`, `>`, or newline, which works because contracts are concrete `typeof` aliases by
+ * convention — a contract type expression containing its own `<`/`,` would not be matched.
+ *
  * @param {import("eslint").Rule.RuleContext} context
  * @param {import("estree").ClassDeclaration | import("estree").ClassExpression} node
  */

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,7 @@ import unicorn from "eslint-plugin-unicorn";
 const LIFECYCLE_HOOKS = new Set(["beforeAll", "beforeEach", "afterAll", "afterEach"]);
 const VI_MOCK_CALLS = new Set(["vi.mock", "vi.doMock"]);
 const PROPERTY_MATCHERS = new Set(["toBe", "toEqual", "toStrictEqual"]);
-const STREAM_PROCESSOR_OVERRIDE_METHODS = new Set(["reduce", "processEvent", "processEventBatch"]);
+const STREAM_PROCESSOR_OVERRIDE_METHODS = new Set(["reduce", "processEvent", "processBatch"]);
 
 /** @param {string} name */
 const getExpectedName = (name) => {
@@ -379,11 +379,10 @@ const plugin = {
 
                   for (const element of node.body.body) {
                     const methodName = getClassElementName(element);
-                    if (methodName === "processEvents") {
+                    if (methodName === "processEvents" || methodName === "processEventBatch") {
                       context.report({
                         node: element,
-                        message:
-                          "Use processEventBatch, not processEvents, in StreamProcessor subclasses.",
+                        message: `Override processBatch, not ${methodName}: processEventBatch is the serialized public sink and must stay on the base class.`,
                       });
                       continue;
                     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,8 @@ import unicorn from "eslint-plugin-unicorn";
 const LIFECYCLE_HOOKS = new Set(["beforeAll", "beforeEach", "afterAll", "afterEach"]);
 const VI_MOCK_CALLS = new Set(["vi.mock", "vi.doMock"]);
 const PROPERTY_MATCHERS = new Set(["toBe", "toEqual", "toStrictEqual"]);
-const STREAM_PROCESSOR_OVERRIDE_METHODS = new Set(["reduce", "processEvent", "processBatch"]);
+const STREAM_PROCESSOR_OVERRIDE_METHODS = new Set(["reduce", "processEvent", "processEventBatch"]);
+const STREAM_PROCESSOR_FORBIDDEN_METHODS = new Set(["ingest", "processEvents", "processBatch"]);
 
 /** @param {string} name */
 const getExpectedName = (name) => {
@@ -379,10 +380,10 @@ const plugin = {
 
                   for (const element of node.body.body) {
                     const methodName = getClassElementName(element);
-                    if (methodName === "processEvents" || methodName === "processEventBatch") {
+                    if (methodName && STREAM_PROCESSOR_FORBIDDEN_METHODS.has(methodName)) {
                       context.report({
                         node: element,
-                        message: `Override processBatch, not ${methodName}: processEventBatch is the serialized public sink and must stay on the base class.`,
+                        message: `Do not define ${methodName} on StreamProcessor subclasses: ingest is the serialized host-facing sink; override processEventBatch (or processEvent/reduce) instead.`,
                       });
                       continue;
                     }

--- a/packages/streams/src/browser/processor-state-storage.test.ts
+++ b/packages/streams/src/browser/processor-state-storage.test.ts
@@ -1,0 +1,192 @@
+// Regression tests for the shared processor_state checkpoint table and for the
+// browser-raw-events schema version reset, running against real SQLite via
+// node:sqlite. The key regression: bumping BROWSER_RAW_EVENTS_SCHEMA_VERSION
+// drops the events table, so it must also clear the processor_state checkpoint —
+// a stale checkpoint over an empty mirror would skip historical replay and then
+// wedge on the append-continuity trigger.
+
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import type { StreamEvent } from "../shared/event.ts";
+import {
+  BROWSER_RAW_EVENTS_SCHEMA_VERSION,
+  BrowserRawEventsContract,
+  BrowserRawEventsProcessor,
+  ensureBrowserRawEventsSchema,
+  type BrowserRawEventsState,
+} from "../processors/browser-raw-events/implementation.ts";
+import {
+  browserProcessorStateStorage,
+  deleteBrowserProcessorState,
+} from "./processor-state-storage.ts";
+import type { SqlClient, SqlValue } from "./stream-browser-db.ts";
+
+// node:sqlite rejects the number[] member of SqlValue; these tests never use it.
+type ScalarSqlValue = Exclude<SqlValue, number[]>;
+
+// Minimal SqlClient over node:sqlite. Each call to wrap() returns a distinct
+// client object, which matters: createSchemaEnsurer memoizes per client, so a
+// fresh client simulates a fresh page load over the same persisted database.
+function wrap(db: DatabaseSync): SqlClient {
+  return {
+    exec: async (sql, params = []) => {
+      return db.prepare(sql).all(...(params as ScalarSqlValue[])) as Record<string, SqlValue>[];
+    },
+    batch: async (statements, options) => {
+      if (options?.transaction) db.exec("BEGIN");
+      try {
+        for (const statement of statements) {
+          db.prepare(statement.sql).run(...((statement.params ?? []) as ScalarSqlValue[]));
+        }
+        if (options?.transaction) db.exec("COMMIT");
+      } catch (error) {
+        if (options?.transaction) db.exec("ROLLBACK");
+        throw error;
+      }
+    },
+  };
+}
+
+const iterateContext = () => ({ stream: { append() {}, appendBatch() {} } });
+
+function rawEvent(offset: number): StreamEvent {
+  return { type: "test/raw", payload: { offset }, offset, createdAt: new Date(0).toISOString() };
+}
+
+function createRawEventsProcessor(sql: SqlClient) {
+  const storage = browserProcessorStateStorage<BrowserRawEventsState>({
+    sql,
+    processorSlug: BrowserRawEventsContract.slug,
+  });
+  return new BrowserRawEventsProcessor({
+    iterateContext: iterateContext(),
+    sql,
+    readState: storage.readState,
+    writeState: storage.writeState,
+  });
+}
+
+describe("browserProcessorStateStorage", () => {
+  it("round-trips snapshots keyed by slug and subscription key", async () => {
+    const sql = wrap(new DatabaseSync(":memory:"));
+    const a = browserProcessorStateStorage<{ n: number }>({
+      sql,
+      processorSlug: "proc-a",
+      subscriptionKey: "sub-1",
+    });
+    const b = browserProcessorStateStorage<{ n: number }>({
+      sql,
+      processorSlug: "proc-a",
+      subscriptionKey: "sub-2",
+    });
+
+    expect(await a.readState()).toBeUndefined();
+
+    await a.writeState({ offset: 3, state: { n: 1 } });
+    await b.writeState({ offset: 9, state: { n: 2 } });
+    await a.writeState({ offset: 4, state: { n: 5 } });
+
+    expect(await a.readState()).toEqual({ offset: 4, state: { n: 5 } });
+    expect(await b.readState()).toEqual({ offset: 9, state: { n: 2 } });
+  });
+
+  it("deletes one subscription key, or every row for a slug when the key is omitted", async () => {
+    const sql = wrap(new DatabaseSync(":memory:"));
+    const write = (slug: string, key: string) =>
+      browserProcessorStateStorage({ sql, processorSlug: slug, subscriptionKey: key }).writeState({
+        offset: 1,
+        state: {},
+      });
+    const read = (slug: string, key: string) =>
+      browserProcessorStateStorage({ sql, processorSlug: slug, subscriptionKey: key }).readState();
+
+    await write("proc-a", "sub-1");
+    await write("proc-a", "sub-2");
+    await write("proc-b", "sub-1");
+
+    await deleteBrowserProcessorState({ sql, processorSlug: "proc-a", subscriptionKey: "sub-1" });
+    expect(await read("proc-a", "sub-1")).toBeUndefined();
+    expect(await read("proc-a", "sub-2")).toBeDefined();
+
+    await deleteBrowserProcessorState({ sql, processorSlug: "proc-a" });
+    expect(await read("proc-a", "sub-2")).toBeUndefined();
+    expect(await read("proc-b", "sub-1")).toBeDefined();
+  });
+});
+
+describe("browser raw events schema version reset", () => {
+  it("mirrors a batch and checkpoints through processor_state", async () => {
+    const sql = wrap(new DatabaseSync(":memory:"));
+    const processor = createRawEventsProcessor(sql);
+
+    await processor.ingest({ events: [rawEvent(1), rawEvent(2)], streamMaxOffset: 2 });
+
+    expect(await processor.snapshot()).toMatchObject({ offset: 2 });
+    const rows = await sql.exec(`SELECT offset FROM events ORDER BY offset`);
+    expect(rows.map((row) => Number(row.offset))).toEqual([1, 2]);
+  });
+
+  it("clears the checkpoint together with the dropped table on a version bump (regression)", async () => {
+    const db = new DatabaseSync(":memory:");
+
+    // First "page load": mirror two events at the current schema version.
+    const firstLoad = createRawEventsProcessor(wrap(db));
+    await firstLoad.ingest({ events: [rawEvent(1), rawEvent(2)], streamMaxOffset: 2 });
+    expect(await firstLoad.snapshot()).toMatchObject({ offset: 2 });
+
+    // Simulate the deployed BROWSER_RAW_EVENTS_SCHEMA_VERSION moving past what
+    // this database was built with.
+    db.exec(`PRAGMA user_version = ${BROWSER_RAW_EVENTS_SCHEMA_VERSION - 1}`);
+
+    // Second "page load" (fresh SqlClient, so the schema ensurer re-runs): the
+    // version reset must clear the checkpoint, not just drop the table.
+    // Before the fix this snapshot reported offset 2 over an empty mirror, so
+    // the server skipped historical replay and the first new insert hit the
+    // append-continuity trigger.
+    const secondLoad = createRawEventsProcessor(wrap(db));
+    expect(await secondLoad.snapshot()).toMatchObject({ offset: 0 });
+
+    // Full replay from the server rebuilds the mirror from offset 1.
+    await secondLoad.ingest({
+      events: [rawEvent(1), rawEvent(2), rawEvent(3)],
+      streamMaxOffset: 3,
+    });
+    const sql = wrap(db);
+    const rows = await sql.exec(`SELECT offset FROM events ORDER BY offset`);
+    expect(rows.map((row) => Number(row.offset))).toEqual([1, 2, 3]);
+    const [version] = await sql.exec(`PRAGMA user_version`);
+    expect(Number(version?.user_version)).toBe(BROWSER_RAW_EVENTS_SCHEMA_VERSION);
+  });
+
+  it("leaves the mirror and checkpoint untouched when the version matches", async () => {
+    const db = new DatabaseSync(":memory:");
+
+    const firstLoad = createRawEventsProcessor(wrap(db));
+    await firstLoad.ingest({ events: [rawEvent(1), rawEvent(2)], streamMaxOffset: 2 });
+
+    const secondLoad = createRawEventsProcessor(wrap(db));
+    expect(await secondLoad.snapshot()).toMatchObject({ offset: 2 });
+
+    // Resume after the checkpoint: replayed offsets dedupe, new offsets append.
+    await secondLoad.ingest({
+      events: [rawEvent(2), rawEvent(3)],
+      streamMaxOffset: 3,
+    });
+    const rows = await wrap(db).exec(`SELECT offset FROM events ORDER BY offset`);
+    expect(rows.map((row) => Number(row.offset))).toEqual([1, 2, 3]);
+  });
+
+  it("the continuity trigger rejects a gap in mirrored offsets", async () => {
+    const sql = wrap(new DatabaseSync(":memory:"));
+    await ensureBrowserRawEventsSchema(sql);
+
+    const insert = (offset: number) =>
+      sql.exec(`INSERT INTO events (local_index, raw_jsonb) VALUES (?, jsonb(?))`, [
+        offset - 1,
+        JSON.stringify(rawEvent(offset)),
+      ]);
+
+    await insert(1);
+    await expect(insert(3)).rejects.toThrow(/append continuously/);
+  });
+});

--- a/packages/streams/src/browser/processor-state-storage.test.ts
+++ b/packages/streams/src/browser/processor-state-storage.test.ts
@@ -158,6 +158,28 @@ describe("browser raw events schema version reset", () => {
     expect(Number(version?.user_version)).toBe(BROWSER_RAW_EVENTS_SCHEMA_VERSION);
   });
 
+  it("resets before the checkpoint is read even when ingest is called without snapshot", async () => {
+    const db = new DatabaseSync(":memory:");
+
+    const firstLoad = createRawEventsProcessor(wrap(db));
+    await firstLoad.ingest({ events: [rawEvent(1), rawEvent(2)], streamMaxOffset: 2 });
+
+    db.exec(`PRAGMA user_version = ${BROWSER_RAW_EVENTS_SCHEMA_VERSION - 1}`);
+
+    // Straight to ingest, no snapshot() first: prepare() must still run the
+    // version reset before the stale checkpoint is memoized. Without that,
+    // offsets 1-2 are filtered out against the stale cursor and inserting
+    // offset 3 into the freshly-reset table trips the continuity trigger.
+    const secondLoad = createRawEventsProcessor(wrap(db));
+    await secondLoad.ingest({
+      events: [rawEvent(1), rawEvent(2), rawEvent(3)],
+      streamMaxOffset: 3,
+    });
+
+    const rows = await wrap(db).exec(`SELECT offset FROM events ORDER BY offset`);
+    expect(rows.map((row) => Number(row.offset))).toEqual([1, 2, 3]);
+  });
+
   it("leaves the mirror and checkpoint untouched when the version matches", async () => {
     const db = new DatabaseSync(":memory:");
 

--- a/packages/streams/src/browser/processor-state-storage.ts
+++ b/packages/streams/src/browser/processor-state-storage.ts
@@ -1,3 +1,10 @@
+// Shared checkpoint table for browser-hosted stream processors: one row per
+// (processor slug, subscription key) holding the JSON reduced state and the
+// max processed offset. Keeping checkpoints here — separate from each
+// processor's projection tables — gives every processor the same resume and
+// reset story; the cost is that projection writes and the checkpoint are not
+// in one transaction, so processors must tolerate at-least-once redelivery.
+
 import type { StreamProcessorSnapshot, StreamProcessorStateStorage } from "../stream-processor.ts";
 import { createSchemaEnsurer } from "./ensure-schema-once.ts";
 import type { SqlClient } from "./stream-browser-db.ts";
@@ -25,6 +32,10 @@ export const ensureBrowserProcessorStateSchema = createSchemaEnsurer({
     ),
 });
 
+/**
+ * `readState`/`writeState` backed by the shared `processor_state` table, ready
+ * to pass into a `StreamProcessor` constructor.
+ */
 export function browserProcessorStateStorage<State>(args: {
   sql: SqlClient;
   processorSlug: string;

--- a/packages/streams/src/browser/stream-browser-store.ts
+++ b/packages/streams/src/browser/stream-browser-store.ts
@@ -290,10 +290,12 @@ function createStreamRuntime(
   // Discard the local mirror when the server has fewer committed events than we do — a
   // reset/rewind makes our stored suffix impossible.
   async function reconcileLocalMirrorWithServer(rpc: RpcStub<StreamRpc>) {
+    // Deliberately a throwaway instance: processors memoize their checkpoint on
+    // first read, so the real instance must be created after any discard below.
     const processor = args.createProcessor({ stream: rpc, sql, subscriptionKey });
     const checkpoint = await processor.snapshot();
     const localMaxOffset = checkpoint.offset;
-    if (localMaxOffset < 0) return;
+    if (localMaxOffset <= 0) return; // fresh mirror: nothing to discard
     const { coreProcessorState } = await rpc.runtimeState();
     if (coreProcessorState.maxOffset >= localMaxOffset) return;
     console.warn(

--- a/packages/streams/src/browser/stream-browser-store.ts
+++ b/packages/streams/src/browser/stream-browser-store.ts
@@ -35,10 +35,7 @@ const LIVE_PROGRESS_NOTIFICATION_MS = 16;
 
 type BrowserHostedProcessor = {
   snapshot(): Promise<StreamProcessorSnapshot<unknown>>;
-  processEventBatch(args: {
-    events: readonly StreamEvent[];
-    streamMaxOffset: number;
-  }): Promise<void>;
+  ingest(args: { events: readonly StreamEvent[]; streamMaxOffset: number }): Promise<void>;
 };
 
 export type StreamBrowserSnapshot = {
@@ -375,7 +372,7 @@ function createStreamRuntime(
         return {
           replayAfterOffset: checkpoint.offset,
           processEventBatch: (batch: { events: readonly StreamEvent[]; streamMaxOffset: number }) =>
-            processor.processEventBatch(batch),
+            processor.ingest(batch),
         };
       })
       .then((ready) => {

--- a/packages/streams/src/browser/stream-browser-store.ts
+++ b/packages/streams/src/browser/stream-browser-store.ts
@@ -33,6 +33,11 @@ import {
 
 const LIVE_PROGRESS_NOTIFICATION_MS = 16;
 
+/**
+ * The slice of `StreamProcessor` the browser runtime drives: read the
+ * checkpoint to pick the replay cursor, then feed delivered batches into
+ * `ingest`. Structural so views construct whatever processor class they like.
+ */
 type BrowserHostedProcessor = {
   snapshot(): Promise<StreamProcessorSnapshot<unknown>>;
   ingest(args: { events: readonly StreamEvent[]; streamMaxOffset: number }): Promise<void>;

--- a/packages/streams/src/processors/browser-event-feed/implementation.ts
+++ b/packages/streams/src/processors/browser-event-feed/implementation.ts
@@ -31,6 +31,10 @@ export class BrowserEventFeedProcessor extends StreamProcessor<
 > {
   readonly contract = BrowserEventFeedContract;
 
+  protected override async prepare(): Promise<void> {
+    await ensureBrowserEventFeedSchema(this.deps.sql);
+  }
+
   protected override reduce(
     args: Parameters<StreamProcessor<BrowserEventFeedContract>["reduce"]>[0],
   ): FeedState {
@@ -43,7 +47,6 @@ export class BrowserEventFeedProcessor extends StreamProcessor<
     const { ops } = planFeedOps(args.previousState, args.events);
 
     if (ops.length > 0) {
-      await ensureBrowserEventFeedSchema(this.deps.sql);
       await this.deps.sql.batch(ops.map(feedOpToStatement), { transaction: true });
     }
 

--- a/packages/streams/src/processors/browser-event-feed/implementation.ts
+++ b/packages/streams/src/processors/browser-event-feed/implementation.ts
@@ -27,22 +27,20 @@ export class BrowserEventFeedProcessor extends StreamProcessor<
   protected override reduce(
     args: Parameters<StreamProcessor<BrowserEventFeedContract>["reduce"]>[0],
   ): FeedState {
-    return planFeedOps(args.state as FeedState, [args.event]).endState;
+    return planFeedOps(args.state, [args.event]).endState;
   }
 
-  override async processEventBatch(
-    args: Parameters<StreamProcessor<BrowserEventFeedContract>["processEventBatch"]>[0],
+  protected override async processBatch(
+    args: Parameters<StreamProcessor<BrowserEventFeedContract>["processBatch"]>[0],
   ): Promise<void> {
-    const checkpoint = await this.snapshot();
-    const events = args.events.filter((event) => event.offset > checkpoint.offset);
-    const { ops } = planFeedOps(checkpoint.state as FeedState, events);
+    const { ops } = planFeedOps(args.previousState, args.events);
 
     if (ops.length > 0) {
       await ensureBrowserEventFeedSchema(this.deps.sql);
       await this.deps.sql.batch(ops.map(feedOpToStatement), { transaction: true });
     }
 
-    await super.processEventBatch(args);
+    await super.processBatch(args);
   }
 }
 

--- a/packages/streams/src/processors/browser-event-feed/implementation.ts
+++ b/packages/streams/src/processors/browser-event-feed/implementation.ts
@@ -30,8 +30,8 @@ export class BrowserEventFeedProcessor extends StreamProcessor<
     return planFeedOps(args.state, [args.event]).endState;
   }
 
-  protected override async processBatch(
-    args: Parameters<StreamProcessor<BrowserEventFeedContract>["processBatch"]>[0],
+  protected override async processEventBatch(
+    args: Parameters<StreamProcessor<BrowserEventFeedContract>["processEventBatch"]>[0],
   ): Promise<void> {
     const { ops } = planFeedOps(args.previousState, args.events);
 
@@ -40,7 +40,7 @@ export class BrowserEventFeedProcessor extends StreamProcessor<
       await this.deps.sql.batch(ops.map(feedOpToStatement), { transaction: true });
     }
 
-    await super.processBatch(args);
+    await super.processEventBatch(args);
   }
 }
 

--- a/packages/streams/src/processors/browser-event-feed/implementation.ts
+++ b/packages/streams/src/processors/browser-event-feed/implementation.ts
@@ -18,6 +18,13 @@ export type BrowserEventFeedProcessorDeps = {
   sql: SqlClient;
 };
 
+/**
+ * Folds stream events into grouped `feed_items` rows for the browser feed UI.
+ * The grouping logic lives in the pure `planFeedOps` helper: `reduce` runs it
+ * one event at a time to advance state, and `processEventBatch` runs it over
+ * the whole batch (from the same batch-entry state) to produce one SQLite
+ * transaction — keeping the two in lockstep by construction.
+ */
 export class BrowserEventFeedProcessor extends StreamProcessor<
   BrowserEventFeedContract,
   BrowserEventFeedProcessorDeps

--- a/packages/streams/src/processors/browser-raw-events/implementation.ts
+++ b/packages/streams/src/processors/browser-raw-events/implementation.ts
@@ -28,24 +28,18 @@ export class BrowserRawEventsProcessor extends StreamProcessor<
     return await super.snapshot();
   }
 
-  override async processEventBatch(
-    args: Parameters<StreamProcessor<BrowserRawEventsContract>["processEventBatch"]>[0],
+  protected override async processBatch(
+    args: Parameters<StreamProcessor<BrowserRawEventsContract>["processBatch"]>[0],
   ): Promise<void> {
-    const checkpoint = await this.snapshot();
-    const events = args.events.filter((event) => event.offset > checkpoint.offset);
-
-    if (events.length > 0) {
-      await ensureBrowserRawEventsSchema(this.deps.sql);
-      await this.deps.sql.batch(
-        events.map((event) => ({
-          sql: `INSERT INTO events (local_index, raw_jsonb) VALUES (?, jsonb(?))`,
-          params: [event.offset - 1, JSON.stringify(event)] satisfies SqlValue[],
-        })),
-        { transaction: true },
-      );
-    }
-
-    await super.processEventBatch(args);
+    await ensureBrowserRawEventsSchema(this.deps.sql);
+    await this.deps.sql.batch(
+      args.events.map((event) => ({
+        sql: `INSERT INTO events (local_index, raw_jsonb) VALUES (?, jsonb(?))`,
+        params: [event.offset - 1, JSON.stringify(event)] satisfies SqlValue[],
+      })),
+      { transaction: true },
+    );
+    await super.processBatch(args);
   }
 }
 

--- a/packages/streams/src/processors/browser-raw-events/implementation.ts
+++ b/packages/streams/src/processors/browser-raw-events/implementation.ts
@@ -26,17 +26,16 @@ export class BrowserRawEventsProcessor extends StreamProcessor<
   readonly contract = BrowserRawEventsContract;
 
   // The schema ensurer also handles version resets (drop table + clear checkpoint),
-  // so it must run before the first checkpoint read — otherwise a stale checkpoint
-  // gets memoized and reported to the server as the replay cursor.
-  override async snapshot() {
+  // so it must run before the checkpoint is first read — otherwise a stale offset
+  // gets memoized and reported to the server as the replay cursor, and the first
+  // insert into the freshly-reset table trips the continuity trigger.
+  protected override async prepare(): Promise<void> {
     await ensureBrowserRawEventsSchema(this.deps.sql);
-    return await super.snapshot();
   }
 
   protected override async processEventBatch(
     args: Parameters<StreamProcessor<BrowserRawEventsContract>["processEventBatch"]>[0],
   ): Promise<void> {
-    await ensureBrowserRawEventsSchema(this.deps.sql);
     await this.deps.sql.batch(
       args.events.map((event) => ({
         sql: `INSERT INTO events (local_index, raw_jsonb) VALUES (?, jsonb(?))`,

--- a/packages/streams/src/processors/browser-raw-events/implementation.ts
+++ b/packages/streams/src/processors/browser-raw-events/implementation.ts
@@ -14,6 +14,11 @@ export type BrowserRawEventsProcessorDeps = {
   sql: SqlClient;
 };
 
+/**
+ * Mirrors raw stream events into the browser's `events` SQLite table, one
+ * transaction per delivered batch. Stateless apart from the checkpoint: the
+ * table itself is the projection.
+ */
 export class BrowserRawEventsProcessor extends StreamProcessor<
   BrowserRawEventsContract,
   BrowserRawEventsProcessorDeps

--- a/packages/streams/src/processors/browser-raw-events/implementation.ts
+++ b/packages/streams/src/processors/browser-raw-events/implementation.ts
@@ -28,8 +28,8 @@ export class BrowserRawEventsProcessor extends StreamProcessor<
     return await super.snapshot();
   }
 
-  protected override async processBatch(
-    args: Parameters<StreamProcessor<BrowserRawEventsContract>["processBatch"]>[0],
+  protected override async processEventBatch(
+    args: Parameters<StreamProcessor<BrowserRawEventsContract>["processEventBatch"]>[0],
   ): Promise<void> {
     await ensureBrowserRawEventsSchema(this.deps.sql);
     await this.deps.sql.batch(
@@ -39,7 +39,7 @@ export class BrowserRawEventsProcessor extends StreamProcessor<
       })),
       { transaction: true },
     );
-    await super.processBatch(args);
+    await super.processEventBatch(args);
   }
 }
 

--- a/packages/streams/src/processors/core/implementation.ts
+++ b/packages/streams/src/processors/core/implementation.ts
@@ -3,7 +3,8 @@
 // of through a subscription runner, because stream bookkeeping must be updated
 // before committed events are delivered to subscribers.
 
-import type { StreamEventInput } from "../../shared/event.ts";
+import type { StreamEvent, StreamEventInput } from "../../shared/event.ts";
+import type { ConsumedEvent } from "../../shared/stream-processors.ts";
 import { StreamProcessor } from "../../stream-processor.ts";
 import {
   CoreProcessorContract,
@@ -44,8 +45,36 @@ export class CoreStreamProcessor extends StreamProcessor<CoreProcessorContract> 
     }
   }
 
+  // The Stream Durable Object runs this processor inline during append with
+  // externally-owned state (its own KV/SQL recovery path), so these two methods
+  // take and return state explicitly instead of using the batch/checkpoint
+  // lifecycle that ordinary hosted processors get from the base class.
+  reduceEvent(args: { event: StreamEvent; state: CoreProcessorState }): CoreProcessorState {
+    return this.reduceRawEvent(args)?.state ?? args.state;
+  }
+
+  processReducedEvent(args: {
+    event: StreamEvent;
+    previousState: CoreProcessorState;
+    state: CoreProcessorState;
+  }): void {
+    this.processEvent({
+      event: args.event as ConsumedEvent<CoreProcessorContract>,
+      previousState: args.previousState,
+      state: args.state,
+      checkpointOffset: args.event.offset,
+      streamMaxOffset: args.event.offset,
+      blockProcessorWhile: () => {
+        throw new Error(
+          "blockProcessorWhile is unavailable when processing a reduced event inline",
+        );
+      },
+      runInBackground: (work) => this.runInBackground(work),
+    });
+  }
+
   public override reduce(args: Parameters<StreamProcessor<CoreProcessorContract>["reduce"]>[0]) {
-    const state = args.state as CoreProcessorState;
+    const state = args.state;
     let next: CoreProcessorState = {
       ...state,
       eventCount: state.eventCount + 1,

--- a/packages/streams/src/processors/core/implementation.ts
+++ b/packages/streams/src/processors/core/implementation.ts
@@ -17,21 +17,18 @@ export type CoreProcessorContract = typeof CoreProcessorContract;
 export class CoreStreamProcessor extends StreamProcessor<CoreProcessorContract> {
   readonly contract = CoreProcessorContract;
 
-  // This is an extra method that other stream processors don't have that is called straight
-  // from the durable object. It lets us reject events before they are appended to the stream.
-  //
-  // The idea is that we have a single stream/paused event that is used _by any other processor_
-  // to tell this stream processor to stop accepting events. That event, alongside its counterparty stream/resumed
-  // is reduced into state.paused.
-  //
-  // That way the complicated
-  // loop detection / circuit breaker logic that we will no doubt need can live in other processors.
-
-  // Over time we might make stream/paused more expressive to allow blocking of just certain events from certain
-  // processors.
-  //
-  // This validateAppend method is also where we will implement permissions in the future to ensure not everyone
-  // can append every conceivable event to a stream.
+  /**
+   * Pre-append gate, called by the Durable Object before an event is committed.
+   * Core-only: no other processor can reject appends.
+   *
+   * The pause door is deliberately dumb: any processor can append
+   * `stream/paused` / `stream/resumed`, which reduce into `state.paused`, so
+   * complicated policies (loop detection, circuit breakers) live in those
+   * processors rather than here. Resume/error/woken events pass through a
+   * paused stream so it can recover. This is also where append permissions
+   * will eventually live, and `stream/paused` may grow more expressive (e.g.
+   * blocking only certain events from certain processors).
+   */
   validateAppend(args: { event: StreamEventInput; state: CoreProcessorState }): void {
     if (!args.state.paused) return;
 
@@ -46,13 +43,21 @@ export class CoreStreamProcessor extends StreamProcessor<CoreProcessorContract> 
   }
 
   // The Stream Durable Object runs this processor inline during append with
-  // externally-owned state (its own KV/SQL recovery path), so these two methods
-  // take and return state explicitly instead of using the batch/checkpoint
-  // lifecycle that ordinary hosted processors get from the base class.
+  // externally-owned state (its own KV/SQL recovery path), so the two methods
+  // below take and return state explicitly instead of using the batch/
+  // checkpoint lifecycle that ordinary hosted processors get from the base
+  // class.
+
+  /** Reduce one committed event against caller-owned state. */
   reduceEvent(args: { event: StreamEvent; state: CoreProcessorState }): CoreProcessorState {
     return this.reduceRawEvent(args)?.state ?? args.state;
   }
 
+  /**
+   * Run `processEvent` side effects for one already-reduced event. Inline
+   * appends are synchronous, so blocking work is unavailable here — side
+   * effects must use `runInBackground` and be idempotent.
+   */
   processReducedEvent(args: {
     event: StreamEvent;
     previousState: CoreProcessorState;
@@ -73,7 +78,9 @@ export class CoreStreamProcessor extends StreamProcessor<CoreProcessorContract> 
     });
   }
 
-  public override reduce(args: Parameters<StreamProcessor<CoreProcessorContract>["reduce"]>[0]) {
+  // The exit parse validates every state transition and applies schema
+  // transforms (e.g. dropping unsupported subscription transports).
+  override reduce(args: Parameters<StreamProcessor<CoreProcessorContract>["reduce"]>[0]) {
     const state = args.state;
     let next: CoreProcessorState = {
       ...state,
@@ -219,37 +226,35 @@ export class CoreStreamProcessor extends StreamProcessor<CoreProcessorContract> 
     return this.contract.stateSchema.parse(next);
   }
 
+  // Stream-internal side effects. Today that is one thing: when a stream is
+  // created, announce it to every ancestor stream so each maintains its
+  // childPaths. The appends are idempotency-keyed and run in the background,
+  // so replays and partial failures are safe.
   protected override processEvent(
     args: Parameters<StreamProcessor<CoreProcessorContract>["processEvent"]>[0],
   ): void {
-    switch (args.event.type) {
-      case "events.iterate.com/stream/created": {
-        if (args.state.path === "/") return;
+    if (args.event.type !== "events.iterate.com/stream/created") return;
+    if (args.state.path === "/") return;
 
-        const pathSegments = args.state.path.split("/").filter(Boolean);
-        const ancestorPaths = ["/"];
-        for (let index = 1; index < pathSegments.length; index += 1) {
-          ancestorPaths.push(`/${pathSegments.slice(0, index).join("/")}`);
-        }
-
-        args.runInBackground(async () => {
-          await Promise.all(
-            ancestorPaths.map((ancestorPath) =>
-              this.ctx.stream.append({
-                streamPath: ancestorPath,
-                event: {
-                  type: "events.iterate.com/stream/child-stream-created",
-                  idempotencyKey: `child-stream-created:${ancestorPath}:${args.state.path}`,
-                  payload: { childPath: args.state.path },
-                },
-              }),
-            ),
-          );
-        });
-        return;
-      }
-      default:
-        return;
+    const pathSegments = args.state.path.split("/").filter(Boolean);
+    const ancestorPaths = ["/"];
+    for (let index = 1; index < pathSegments.length; index += 1) {
+      ancestorPaths.push(`/${pathSegments.slice(0, index).join("/")}`);
     }
+
+    args.runInBackground(async () => {
+      await Promise.all(
+        ancestorPaths.map((ancestorPath) =>
+          this.ctx.stream.append({
+            streamPath: ancestorPath,
+            event: {
+              type: "events.iterate.com/stream/child-stream-created",
+              idempotencyKey: `child-stream-created:${ancestorPath}:${args.state.path}`,
+              payload: { childPath: args.state.path },
+            },
+          }),
+        ),
+      );
+    });
   }
 }

--- a/packages/streams/src/shared/stream-processors.ts
+++ b/packages/streams/src/shared/stream-processors.ts
@@ -1332,6 +1332,11 @@ function shouldRunAfterAppendDuringCatchUp(args: {
   );
 }
 
+/**
+ * Enforces the invariant that reduced processor state is object-shaped (so
+ * state slices can evolve safely and hooks never branch on primitive state).
+ * Runners and the `StreamProcessor` class call this after every reduce.
+ */
 export function assertObjectProcessorState(args: { processorSlug: string; value: unknown }) {
   if (typeof args.value === "object" && args.value !== null && !Array.isArray(args.value)) {
     return;
@@ -1340,6 +1345,13 @@ export function assertObjectProcessorState(args: { processorSlug: string; value:
   throw new Error(`Processor "${args.processorSlug}" state must be an object.`);
 }
 
+/**
+ * Resolve the payload schema a processor should use for an incoming event:
+ * the named definition (from local `events` or `processorDeps`) when the type
+ * is listed in `consumes`, a permissive `z.unknown()` definition when the
+ * contract consumes `"*"`, and `undefined` when the event is not consumed at
+ * all. This is the runtime counterpart of `ConsumedEvent<Contract>`.
+ */
 export function getConsumedEventDefinition(args: {
   contract: {
     events: EventCatalog;

--- a/packages/streams/src/shared/stream-processors.ts
+++ b/packages/streams/src/shared/stream-processors.ts
@@ -193,6 +193,28 @@ export type InputFromDefinitionForType<Definition, Type extends string> =
     : never;
 
 /**
+ * An event delivered through the `"*"` wildcard that is not individually named
+ * in `consumes`. Its `type` is typed as the literal `"*"` — mirroring the
+ * contract entry it matched — so that narrowing over named consumed events
+ * stays exact and the fallthrough branch is reachable instead of `never`:
+ *
+ * ```ts
+ * switch (event.type) {
+ *   case "events.iterate.com/stream/paused":
+ *     event.payload.reason; // fully typed
+ *     break;
+ *   default:
+ *     event.payload; // unknown — wildcard event, runtime type string varies
+ * }
+ * ```
+ *
+ * At runtime `type` holds the actual event type string; the `"*"` literal is a
+ * type-level marker only. To compare against a specific event type, name it in
+ * `consumes` instead of string-matching inside the wildcard branch.
+ */
+export type WildcardConsumedEvent = StreamEvent<"*", unknown> & { payload: unknown };
+
+/**
  * Build the union of stream events corresponding to a `consumes` string
  * array. This is what makes reducer/`afterAppend` narrowing work:
  *
@@ -203,6 +225,13 @@ export type InputFromDefinitionForType<Definition, Type extends string> =
  *   }
  * }
  * ```
+ *
+ * `consumes` semantics by shape:
+ * - named only — exact union of those events; exhaustive switches can end in
+ *   `assertNever(event)`;
+ * - `["*"]` only — plain `StreamEvent` (real `type` string, `unknown` payload);
+ * - `["*", ...named]` — named union plus {@link WildcardConsumedEvent} for
+ *   everything else.
  */
 export type EventFromTypes<
   Events extends EventCatalog,
@@ -211,7 +240,7 @@ export type EventFromTypes<
 > = "*" extends Types[number]
   ? Exclude<Types[number], "*"> extends never
     ? StreamEvent
-    : EventFromType<Events, ProcessorDeps, Exclude<Types[number], "*">>
+    : EventFromType<Events, ProcessorDeps, Exclude<Types[number], "*">> | WildcardConsumedEvent
   : EventFromType<Events, ProcessorDeps, Types[number]>;
 
 export type EventFromType<

--- a/packages/streams/src/stream-processor-class.test.ts
+++ b/packages/streams/src/stream-processor-class.test.ts
@@ -1,0 +1,471 @@
+// Runtime regression tests for the class-based StreamProcessor in
+// stream-processor.ts: batch serialization, checkpoint semantics, blocking vs
+// background side effects, storage retry, and wildcard consume behavior.
+// Compile-time inference is covered separately in stream-processor-types.test.ts.
+
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { defineProcessorContract } from "./shared/stream-processors.ts";
+import type { StreamEvent } from "./shared/event.ts";
+import { StreamProcessor, type StreamProcessorSnapshot } from "./stream-processor.ts";
+
+const iso = new Date(0).toISOString();
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const iterateContext = () => ({ stream: { append() {}, appendBatch() {} } });
+
+// ---------------------------------------------------------------------------
+// counter — a named-only contract with spy hooks injected through deps
+// ---------------------------------------------------------------------------
+
+const CounterContract = defineProcessorContract({
+  slug: "test.counter",
+  version: "0.1.0",
+  description: "Counts amounts for StreamProcessor behavior tests.",
+  stateSchema: z.object({ total: z.number().default(0) }),
+  initialState: {},
+  events: {
+    "test/add": { payloadSchema: z.object({ amount: z.number() }) },
+    "test/ignored": { payloadSchema: z.object({}) },
+  },
+  consumes: ["test/add"],
+  emits: [],
+});
+type CounterContract = typeof CounterContract;
+type CounterState = { total: number };
+type CounterSnapshot = StreamProcessorSnapshot<CounterState>;
+
+type SideEffectHelpers = {
+  blockProcessorWhile: (work: () => Promise<unknown>) => void;
+  runInBackground: (work: () => Promise<unknown>) => void;
+};
+
+type CounterDeps = {
+  onProcessEvent?: (
+    args: {
+      event: StreamEvent;
+      previousState: CounterState;
+      state: CounterState;
+      checkpointOffset: number;
+      streamMaxOffset: number;
+    } & SideEffectHelpers,
+  ) => void;
+  onProcessEventBatch?: (
+    args: {
+      events: readonly StreamEvent[];
+      reducedEvents: readonly {
+        event: StreamEvent;
+        previousState: CounterState;
+        state: CounterState;
+      }[];
+      previousState: CounterState;
+      state: CounterState;
+      streamMaxOffset: number;
+      checkpointOffset: number;
+    } & SideEffectHelpers,
+  ) => void | Promise<void>;
+};
+
+class CounterProcessor extends StreamProcessor<CounterContract, CounterDeps> {
+  readonly contract = CounterContract;
+
+  protected override reduce(args: Parameters<StreamProcessor<CounterContract>["reduce"]>[0]) {
+    return { total: args.state.total + args.event.payload.amount };
+  }
+
+  protected override processEvent(
+    args: Parameters<StreamProcessor<CounterContract>["processEvent"]>[0],
+  ): void {
+    this.deps.onProcessEvent?.(args);
+  }
+
+  protected override async processEventBatch(
+    args: Parameters<StreamProcessor<CounterContract>["processEventBatch"]>[0],
+  ): Promise<void> {
+    await this.deps.onProcessEventBatch?.(args);
+    await super.processEventBatch(args);
+  }
+}
+
+function add(offset: number, amount: number): StreamEvent {
+  return { type: "test/add", payload: { amount }, offset, createdAt: iso };
+}
+
+function ignored(offset: number): StreamEvent {
+  return { type: "test/ignored", payload: {}, offset, createdAt: iso };
+}
+
+describe("reduce and checkpoint", () => {
+  it("reduces consumed events into state and checkpoints once per batch", async () => {
+    const writes: CounterSnapshot[] = [];
+    const processor = new CounterProcessor({
+      iterateContext: iterateContext(),
+      writeState: (snapshot) => void writes.push(snapshot),
+    });
+
+    await processor.ingest({ events: [add(1, 5), add(2, 7)], streamMaxOffset: 2 });
+
+    expect(processor.state).toEqual({ total: 12 });
+    expect(processor.checkpointOffset).toBe(2);
+    expect(writes).toEqual([{ offset: 2, state: { total: 12 } }]);
+  });
+
+  it("resumes from readState, parsing the stored state through the schema", async () => {
+    const processor = new CounterProcessor({
+      iterateContext: iterateContext(),
+      // `total` is omitted: the schema default must fill it in on load.
+      readState: () => ({ offset: 5, state: {} as CounterState }),
+    });
+
+    await processor.ingest({ events: [add(4, 100), add(5, 100), add(6, 3)], streamMaxOffset: 6 });
+
+    // Offsets 4 and 5 are at or below the checkpoint and must not re-reduce.
+    expect(processor.state).toEqual({ total: 3 });
+    expect(processor.checkpointOffset).toBe(6);
+  });
+
+  it("does not write a checkpoint for a fully-replayed batch", async () => {
+    const writes: CounterSnapshot[] = [];
+    const hooks = vi.fn();
+    const processor = new CounterProcessor({
+      iterateContext: iterateContext(),
+      writeState: (snapshot) => void writes.push(snapshot),
+      onProcessEvent: hooks,
+      onProcessEventBatch: hooks,
+    });
+
+    await processor.ingest({ events: [add(1, 1)], streamMaxOffset: 1 });
+    expect(writes).toHaveLength(1);
+    expect(hooks).toHaveBeenCalledTimes(2);
+
+    await processor.ingest({ events: [add(1, 1)], streamMaxOffset: 1 });
+    expect(writes).toHaveLength(1);
+    expect(hooks).toHaveBeenCalledTimes(2);
+    expect(processor.state).toEqual({ total: 1 });
+  });
+
+  it("advances the checkpoint past events it does not consume, without hooks", async () => {
+    const writes: CounterSnapshot[] = [];
+    const onProcessEvent = vi.fn();
+    const processor = new CounterProcessor({
+      iterateContext: iterateContext(),
+      writeState: (snapshot) => void writes.push(snapshot),
+      onProcessEvent,
+    });
+
+    await processor.ingest({ events: [ignored(1)], streamMaxOffset: 1 });
+
+    expect(processor.state).toEqual({ total: 0 });
+    expect(processor.checkpointOffset).toBe(1);
+    expect(writes).toEqual([{ offset: 1, state: { total: 0 } }]);
+    expect(onProcessEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe("hook wiring", () => {
+  it("default processEventBatch calls processEvent once per reduced event with per-event states", async () => {
+    const calls: { offset: number; previousTotal: number; total: number; checkpoint: number }[] =
+      [];
+    const processor = new CounterProcessor({
+      iterateContext: iterateContext(),
+      onProcessEvent: (args) => {
+        calls.push({
+          offset: args.event.offset,
+          previousTotal: args.previousState.total,
+          total: args.state.total,
+          checkpoint: args.checkpointOffset,
+        });
+      },
+    });
+
+    await processor.ingest({ events: [add(1, 5), add(2, 7)], streamMaxOffset: 9 });
+
+    expect(calls).toEqual([
+      { offset: 1, previousTotal: 0, total: 5, checkpoint: 2 },
+      { offset: 2, previousTotal: 5, total: 12, checkpoint: 2 },
+    ]);
+  });
+
+  it("processEventBatch sees deduped events plus batch-entry and batch-exit state", async () => {
+    const batches: { offsets: number[]; previousTotal: number; total: number }[] = [];
+    const processor = new CounterProcessor({
+      iterateContext: iterateContext(),
+      readState: () => ({ offset: 1, state: { total: 1 } }),
+      onProcessEventBatch: (args) => {
+        batches.push({
+          offsets: args.events.map((event) => event.offset),
+          previousTotal: args.previousState.total,
+          total: args.state.total,
+        });
+        expect(args.reducedEvents).toHaveLength(2);
+      },
+    });
+
+    await processor.ingest({ events: [add(1, 99), add(2, 2), add(3, 3)], streamMaxOffset: 3 });
+
+    expect(batches).toEqual([{ offsets: [2, 3], previousTotal: 1, total: 6 }]);
+  });
+});
+
+describe("batch serialization", () => {
+  it("a later batch never starts until the previous one finished", async () => {
+    const order: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    const processor = new CounterProcessor({
+      iterateContext: iterateContext(),
+      onProcessEventBatch: async (args) => {
+        const firstOffset = args.events[0]!.offset;
+        order.push(`start:${firstOffset}`);
+        if (firstOffset === 1) await gate;
+        order.push(`end:${firstOffset}`);
+      },
+    });
+
+    const first = processor.ingest({ events: [add(1, 1)], streamMaxOffset: 1 });
+    const second = processor.ingest({ events: [add(2, 1)], streamMaxOffset: 2 });
+    await tick();
+    expect(order).toEqual(["start:1"]);
+
+    release();
+    await Promise.all([first, second]);
+    expect(order).toEqual(["start:1", "end:1", "start:2", "end:2"]);
+  });
+
+  it("a failed batch is not checkpointed, does not poison the queue, and can be redelivered", async () => {
+    const writes: CounterSnapshot[] = [];
+    let failNext = true;
+    const processor = new CounterProcessor({
+      iterateContext: iterateContext(),
+      writeState: (snapshot) => void writes.push(snapshot),
+      onProcessEventBatch: () => {
+        if (failNext) {
+          failNext = false;
+          throw new Error("batch boom");
+        }
+      },
+    });
+
+    await expect(processor.ingest({ events: [add(1, 5)], streamMaxOffset: 1 })).rejects.toThrow(
+      "batch boom",
+    );
+    expect(writes).toEqual([]);
+    expect(processor.checkpointOffset).toBe(0);
+
+    // At-least-once: the same batch redelivers and reduces from the old state.
+    await processor.ingest({ events: [add(1, 5)], streamMaxOffset: 1 });
+    expect(processor.state).toEqual({ total: 5 });
+    expect(writes).toEqual([{ offset: 1, state: { total: 5 } }]);
+  });
+});
+
+describe("blocking and background side effects", () => {
+  it("blockProcessorWhile holds the checkpoint until the work completes", async () => {
+    const writes: CounterSnapshot[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    const processor = new CounterProcessor({
+      iterateContext: iterateContext(),
+      writeState: (snapshot) => void writes.push(snapshot),
+      onProcessEvent: ({ blockProcessorWhile }) => blockProcessorWhile(() => gate),
+    });
+
+    const processed = processor.ingest({ events: [add(1, 1)], streamMaxOffset: 1 });
+    await tick();
+    expect(writes).toEqual([]);
+
+    release();
+    await processed;
+    expect(writes).toEqual([{ offset: 1, state: { total: 1 } }]);
+  });
+
+  it("failed blocking work fails the batch and skips the checkpoint", async () => {
+    const writes: CounterSnapshot[] = [];
+    let failNext = true;
+    const processor = new CounterProcessor({
+      iterateContext: iterateContext(),
+      writeState: (snapshot) => void writes.push(snapshot),
+      onProcessEvent: ({ blockProcessorWhile }) => {
+        blockProcessorWhile(async () => {
+          if (failNext) {
+            failNext = false;
+            throw new Error("side effect failed");
+          }
+        });
+      },
+    });
+
+    await expect(processor.ingest({ events: [add(1, 1)], streamMaxOffset: 1 })).rejects.toThrow(
+      "side effect failed",
+    );
+    expect(writes).toEqual([]);
+
+    await processor.ingest({ events: [add(1, 1)], streamMaxOffset: 1 });
+    expect(writes).toEqual([{ offset: 1, state: { total: 1 } }]);
+  });
+
+  it("settles blocking work registered before a hook throw instead of abandoning it", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    let blockingWorkFinished = false;
+    const processor = new CounterProcessor({
+      iterateContext: iterateContext(),
+      onProcessEvent: ({ event, blockProcessorWhile }) => {
+        if (event.offset === 1) {
+          blockProcessorWhile(() =>
+            gate.then(() => {
+              blockingWorkFinished = true;
+            }),
+          );
+        }
+        if (event.offset === 2) throw new Error("hook boom");
+      },
+    });
+
+    const outcome = processor.ingest({ events: [add(1, 1), add(2, 1)], streamMaxOffset: 2 }).then(
+      () => "resolved",
+      (error: unknown) => (error as Error).message,
+    );
+
+    // The hook for offset 2 already threw, but the batch must not settle until
+    // the blocking work from offset 1 has settled too.
+    expect(await Promise.race([outcome, tick().then(() => "pending")])).toBe("pending");
+
+    release();
+    expect(await outcome).toBe("hook boom");
+    expect(blockingWorkFinished).toBe(true);
+  });
+
+  it("runInBackground does not hold the checkpoint and logs failures", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const writes: CounterSnapshot[] = [];
+    const processor = new CounterProcessor({
+      iterateContext: iterateContext(),
+      writeState: (snapshot) => void writes.push(snapshot),
+      onProcessEvent: ({ runInBackground }) => {
+        runInBackground(async () => {
+          throw new Error("background fail");
+        });
+      },
+    });
+
+    await processor.ingest({ events: [add(1, 1)], streamMaxOffset: 1 });
+    expect(writes).toHaveLength(1);
+
+    await tick();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "stream processor background work failed",
+      expect.any(Error),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("routes async work through the host's keepAliveWhile", async () => {
+    const keepAliveWhile = vi.fn((work: () => Promise<unknown>) => void work());
+    const processor = new CounterProcessor({
+      iterateContext: iterateContext(),
+      keepAliveWhile,
+      onProcessEvent: ({ blockProcessorWhile, runInBackground }) => {
+        blockProcessorWhile(async () => {});
+        runInBackground(async () => {});
+      },
+    });
+
+    await processor.ingest({ events: [add(1, 1)], streamMaxOffset: 1 });
+    expect(keepAliveWhile).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("state storage", () => {
+  it("retries a failed readState on the next batch instead of caching the rejection", async () => {
+    let attempts = 0;
+    const processor = new CounterProcessor({
+      iterateContext: iterateContext(),
+      readState: () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("storage offline");
+        return { offset: 3, state: { total: 9 } };
+      },
+    });
+
+    await expect(processor.ingest({ events: [add(4, 1)], streamMaxOffset: 4 })).rejects.toThrow(
+      "storage offline",
+    );
+
+    await processor.ingest({ events: [add(4, 1)], streamMaxOffset: 4 });
+    expect(attempts).toBe(2);
+    expect(processor.state).toEqual({ total: 10 });
+    expect(processor.checkpointOffset).toBe(4);
+  });
+
+  it("falls back to in-memory snapshots when no storage is provided", async () => {
+    const processor = new CounterProcessor({ iterateContext: iterateContext() });
+
+    await processor.ingest({ events: [add(1, 5)], streamMaxOffset: 1 });
+
+    expect(await processor.snapshot()).toEqual({ offset: 1, state: { total: 5 } });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wildcard consume runtime semantics
+// ---------------------------------------------------------------------------
+
+const WildcardContract = defineProcessorContract({
+  slug: "test.wildcard-runtime",
+  version: "0.1.0",
+  description: "Mixed wildcard consumption for runtime behavior tests.",
+  stateSchema: z.object({
+    named: z.number().default(0),
+    other: z.number().default(0),
+  }),
+  initialState: {},
+  events: {
+    "test/named": { payloadSchema: z.object({ value: z.number() }) },
+  },
+  consumes: ["*", "test/named"],
+  emits: [],
+});
+type WildcardContract = typeof WildcardContract;
+
+class WildcardProcessor extends StreamProcessor<WildcardContract> {
+  readonly contract = WildcardContract;
+
+  protected override reduce(args: Parameters<StreamProcessor<WildcardContract>["reduce"]>[0]) {
+    switch (args.event.type) {
+      case "test/named":
+        return { ...args.state, named: args.state.named + args.event.payload.value };
+      default:
+        return { ...args.state, other: args.state.other + 1 };
+    }
+  }
+}
+
+describe("wildcard consumption", () => {
+  it("validates named event payloads and passes unnamed events through", async () => {
+    const processor = new WildcardProcessor({ iterateContext: iterateContext() });
+
+    await processor.ingest({
+      events: [
+        { type: "test/named", payload: { value: 5 }, offset: 1, createdAt: iso },
+        { type: "test/unrelated", payload: { anything: ["goes"] }, offset: 2, createdAt: iso },
+        { type: "test/named", payload: { value: 2 }, offset: 3, createdAt: iso },
+      ],
+      streamMaxOffset: 3,
+    });
+
+    expect(processor.state).toEqual({ named: 7, other: 1 });
+  });
+
+  it("rejects the batch when a named event payload fails its schema", async () => {
+    const processor = new WildcardProcessor({ iterateContext: iterateContext() });
+
+    await expect(
+      processor.ingest({
+        events: [{ type: "test/named", payload: { value: "nope" }, offset: 1, createdAt: iso }],
+        streamMaxOffset: 1,
+      }),
+    ).rejects.toThrow();
+    expect(processor.checkpointOffset).toBe(0);
+  });
+});

--- a/packages/streams/src/stream-processor-types.test.ts
+++ b/packages/streams/src/stream-processor-types.test.ts
@@ -2,7 +2,7 @@ import { describe, expectTypeOf, it } from "vitest";
 import { z } from "zod";
 import { defineProcessorContract, type EmittedInput } from "./shared/stream-processors.ts";
 import type { StreamEvent } from "./shared/event.ts";
-import { type DeepReadonly, StreamProcessor } from "./stream-processor.ts";
+import { StreamProcessor } from "./stream-processor.ts";
 
 const DependencyProcessorContract = defineProcessorContract({
   slug: "test.dependency",
@@ -42,7 +42,7 @@ const TypeInferenceProcessorContract = defineProcessorContract({
 });
 
 type TypeInferenceProcessorContract = typeof TypeInferenceProcessorContract;
-type TypeInferenceProcessorState = DeepReadonly<{ count: number }>;
+type TypeInferenceProcessorState = { count: number };
 
 class TypeInferenceProcessor extends StreamProcessor<TypeInferenceProcessorContract> {
   readonly contract = TypeInferenceProcessorContract;
@@ -87,12 +87,19 @@ class TypeInferenceProcessor extends StreamProcessor<TypeInferenceProcessorContr
     expectTypeOf(args.event.payload.localValue).toEqualTypeOf<number>();
   }
 
-  override async processEventBatch(
-    args: Parameters<StreamProcessor<TypeInferenceProcessorContract>["processEventBatch"]>[0],
+  protected override async processBatch(
+    args: Parameters<StreamProcessor<TypeInferenceProcessorContract>["processBatch"]>[0],
   ): Promise<void> {
     expectTypeOf(args.events).toEqualTypeOf<readonly StreamEvent[]>();
+    expectTypeOf(args.previousState).toEqualTypeOf<TypeInferenceProcessorState>();
+    expectTypeOf(args.state).toEqualTypeOf<TypeInferenceProcessorState>();
     expectTypeOf(args.streamMaxOffset).toEqualTypeOf<number>();
-    await super.processEventBatch(args);
+    for (const reducedEvent of args.reducedEvents) {
+      if (reducedEvent.event.type === "events.test/local/input") {
+        expectTypeOf(reducedEvent.event.payload.localValue).toEqualTypeOf<number>();
+      }
+    }
+    await super.processBatch(args);
   }
 }
 

--- a/packages/streams/src/stream-processor-types.test.ts
+++ b/packages/streams/src/stream-processor-types.test.ts
@@ -1,6 +1,11 @@
 import { describe, expectTypeOf, it } from "vitest";
 import { z } from "zod";
-import { defineProcessorContract, type EmittedInput } from "./shared/stream-processors.ts";
+import {
+  defineProcessorContract,
+  type ConsumedEvent,
+  type EmittedInput,
+  type WildcardConsumedEvent,
+} from "./shared/stream-processors.ts";
 import type { StreamEvent } from "./shared/event.ts";
 import { StreamProcessor } from "./stream-processor.ts";
 
@@ -87,8 +92,8 @@ class TypeInferenceProcessor extends StreamProcessor<TypeInferenceProcessorContr
     expectTypeOf(args.event.payload.localValue).toEqualTypeOf<number>();
   }
 
-  protected override async processBatch(
-    args: Parameters<StreamProcessor<TypeInferenceProcessorContract>["processBatch"]>[0],
+  protected override async processEventBatch(
+    args: Parameters<StreamProcessor<TypeInferenceProcessorContract>["processEventBatch"]>[0],
   ): Promise<void> {
     expectTypeOf(args.events).toEqualTypeOf<readonly StreamEvent[]>();
     expectTypeOf(args.previousState).toEqualTypeOf<TypeInferenceProcessorState>();
@@ -99,7 +104,7 @@ class TypeInferenceProcessor extends StreamProcessor<TypeInferenceProcessorContr
         expectTypeOf(reducedEvent.event.payload.localValue).toEqualTypeOf<number>();
       }
     }
-    await super.processBatch(args);
+    await super.processEventBatch(args);
   }
 }
 
@@ -135,5 +140,119 @@ describe("StreamProcessor class type inference", () => {
     void localOutput;
     void wrongType;
     void wrongDependencyPayload;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// consumes wildcard semantics
+// ---------------------------------------------------------------------------
+
+const WildcardOnlyContract = defineProcessorContract({
+  slug: "test.wildcard-only",
+  version: "0.1.0",
+  description: "Consumes every stream event without naming any.",
+  stateSchema: z.object({}),
+  initialState: {},
+  events: {},
+  consumes: ["*"],
+  emits: [],
+});
+
+const MixedWildcardContract = defineProcessorContract({
+  slug: "test.mixed-wildcard",
+  version: "0.1.0",
+  description: "Consumes every stream event, with typed payloads for named ones.",
+  stateSchema: z.object({ seen: z.number() }),
+  initialState: { seen: 0 },
+  events: {
+    "events.test/mixed/named": {
+      payloadSchema: z.object({ reason: z.string() }),
+    },
+  },
+  consumes: ["*", "events.test/mixed/named"],
+  emits: [],
+});
+
+type MixedWildcardContract = typeof MixedWildcardContract;
+
+class MixedWildcardProcessor extends StreamProcessor<MixedWildcardContract> {
+  readonly contract = MixedWildcardContract;
+
+  protected override reduce(args: Parameters<StreamProcessor<MixedWildcardContract>["reduce"]>[0]) {
+    // Offsets and metadata are available on every member of the union.
+    expectTypeOf(args.event.offset).toEqualTypeOf<number>();
+
+    switch (args.event.type) {
+      case "events.test/mixed/named":
+        // Named events keep exact payload inference despite the wildcard.
+        expectTypeOf(args.event.payload.reason).toEqualTypeOf<string>();
+        return { seen: args.state.seen + 1 };
+
+      default:
+        // The wildcard branch is reachable (not never) with an unknown payload.
+        expectTypeOf(args.event).toEqualTypeOf<WildcardConsumedEvent>();
+        expectTypeOf(args.event.payload).toEqualTypeOf<unknown>();
+        return args.state;
+    }
+  }
+}
+
+describe("consumes wildcard typing", () => {
+  it("['*'] alone consumes plain StreamEvents", () => {
+    expectTypeOf<ConsumedEvent<typeof WildcardOnlyContract>>().toEqualTypeOf<StreamEvent>();
+  });
+
+  it("['*', ...named] is the named union plus the wildcard member", () => {
+    new MixedWildcardProcessor({ iterateContext: { stream: { append() {}, appendBatch() {} } } });
+
+    type Consumed = ConsumedEvent<MixedWildcardContract>;
+    expectTypeOf<
+      Extract<Consumed, { type: "events.test/mixed/named" }>["payload"]
+    >().toEqualTypeOf<{
+      reason: string;
+    }>();
+    expectTypeOf<Extract<Consumed, { type: "*" }>>().toEqualTypeOf<WildcardConsumedEvent>();
+  });
+
+  it("named-only contracts stay exhaustive: no wildcard member sneaks in", () => {
+    type Consumed = ConsumedEvent<typeof DependencyProcessorContract>;
+    expectTypeOf<Extract<Consumed, { type: "*" }>>().toEqualTypeOf<never>();
+    expectTypeOf<Consumed["type"]>().toEqualTypeOf<"events.test/dependency/input">();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// contract definition guards
+// ---------------------------------------------------------------------------
+
+describe("contract definition guards", () => {
+  it("rejects consumes typos and wildcard emits at the definition site", () => {
+    defineProcessorContract({
+      slug: "test.bad-consumes",
+      version: "0.1.0",
+      description: "Typo in consumes fails to compile.",
+      stateSchema: z.object({}),
+      initialState: {},
+      events: {
+        "events.test/guard/known": { payloadSchema: z.object({}) },
+      },
+      // @ts-expect-error unresolvable event type string in consumes
+      consumes: ["events.test/guard/unknown"],
+      emits: [],
+    });
+
+    defineProcessorContract({
+      slug: "test.bad-emits",
+      version: "0.1.0",
+      description: "Wildcard emits fails to compile; emits must be named.",
+      stateSchema: z.object({}),
+      initialState: {},
+      events: {
+        "events.test/guard/known": { payloadSchema: z.object({}) },
+      },
+      consumes: ["events.test/guard/known"],
+      // @ts-expect-error "*" is not a valid emits entry
+      emits: ["*"],
+    });
   });
 });

--- a/packages/streams/src/stream-processor.ts
+++ b/packages/streams/src/stream-processor.ts
@@ -12,10 +12,21 @@ import {
   type ProcessorState,
 } from "./shared/stream-processors.ts";
 
+/**
+ * Platform capabilities the host hands every processor, exposed to subclasses
+ * as `this.ctx`. Today that is just the stream append surface; richer hosts can
+ * substitute their own context type via the class's `IterateContext` parameter.
+ */
 export type StreamProcessorIterateContext = {
   stream: ProcessorStream;
 };
 
+/**
+ * The structural slice of a processor contract that the class needs. Contracts
+ * built with `defineProcessorContract(...)` satisfy this; the full contract
+ * type flows through the `Contract` type parameter so event/state inference
+ * reaches the hooks.
+ */
 export type StreamProcessorContract = {
   slug: string;
   stateSchema: z.ZodType;
@@ -25,6 +36,12 @@ export type StreamProcessorContract = {
   consumes: readonly string[];
 };
 
+/**
+ * Host-provided constructor dependencies shared by every processor:
+ * the iterate context, optional checkpoint storage (`readState`/`writeState`),
+ * and an optional `keepAliveWhile` hook for hosts whose runtime would otherwise
+ * shut down while async work is in flight (e.g. a Durable Object).
+ */
 export type StreamProcessorBaseDeps<Contract, IterateContext> = {
   iterateContext: IterateContext;
   keepAliveWhile?: (work: () => Promise<unknown>) => void;
@@ -77,6 +94,10 @@ type ProcessEventBatchArgs<Contract> = SideEffectHelpers & {
   checkpointOffset: number;
 };
 
+/**
+ * A durable checkpoint: the reduced state plus the highest stream offset that
+ * has been fully reduced and processed. Written atomically per batch.
+ */
 export type StreamProcessorSnapshot<State> = {
   offset: number;
   state: State;
@@ -84,11 +105,22 @@ export type StreamProcessorSnapshot<State> = {
 
 type MaybePromise<T> = T | Promise<T>;
 
+/**
+ * Where checkpoints live. Hosts inject these; when omitted the processor keeps
+ * an in-memory snapshot, which is enough for tests and stateless experiments.
+ * `readState` is called once, lazily, before the first batch; `writeState` is
+ * called after each successful batch.
+ */
 export type StreamProcessorStateStorage<State> = {
   readState?: () => MaybePromise<StreamProcessorSnapshot<State> | undefined>;
   writeState?: (snapshot: StreamProcessorSnapshot<State>) => MaybePromise<void>;
 };
 
+/**
+ * Constructor args are the base deps plus the subclass's own `Deps` flattened
+ * into one object, e.g. `new BrowserRawEventsProcessor({ iterateContext, sql,
+ * readState, writeState })`.
+ */
 export type StreamProcessorConstructorArgs<
   Contract extends StreamProcessorContract,
   Deps extends object,
@@ -146,6 +178,7 @@ export abstract class StreamProcessor<
 
   constructor(args: StreamProcessorConstructorArgs<Contract, Deps, IterateContext>) {
     super();
+    // Base deps are destructured out; everything else is the subclass's Deps.
     const { iterateContext, keepAliveWhile, readState, writeState, ...deps } = args;
     this.ctx = iterateContext;
     this.deps = deps as Deps;
@@ -158,14 +191,17 @@ export abstract class StreamProcessor<
       });
   }
 
+  /** Current reduced state. Initial state until the first batch loads/reduces. */
   get state(): ProcessorState<Contract> {
     return this.#getState();
   }
 
+  /** Highest stream offset this processor has durably processed through. */
   get checkpointOffset(): number {
     return this.#checkpointOffset;
   }
 
+  /** Loads (once) and returns the current checkpoint. Hosts use the offset as the replay cursor. */
   async snapshot(): Promise<StreamProcessorSnapshot<ProcessorState<Contract>>> {
     await this.#loadState();
     return {
@@ -185,7 +221,10 @@ export abstract class StreamProcessor<
     return await next;
   }
 
-  /** Pure projection of one consumed event into the next state. Defaults to identity. */
+  /**
+   * Pure projection of one consumed event into the next state. Defaults to
+   * identity; returning `null`/`undefined` also keeps the current state.
+   */
   protected reduce(args: ReduceArgs<Contract>): ProcessorState<Contract> | null | undefined {
     return args.state;
   }
@@ -296,6 +335,9 @@ export abstract class StreamProcessor<
     await this.#saveSnapshot();
   }
 
+  // keepAliveWhile is fire-and-forget from the host's point of view (it only
+  // keeps the runtime alive while the work runs), so this bridges the work's
+  // result/failure back into a promise the batch loop can await.
   async #runKeepAliveBackedWork(work: () => Promise<unknown>): Promise<unknown> {
     if (this.#keepAliveWhile === undefined) return await work();
 

--- a/packages/streams/src/stream-processor.ts
+++ b/packages/streams/src/stream-processor.ts
@@ -64,7 +64,7 @@ type ProcessEventArgs<Contract> = ReducedEvent<Contract> &
     checkpointOffset: number;
   };
 
-type ProcessBatchArgs<Contract> = SideEffectHelpers & {
+type ProcessEventBatchArgs<Contract> = SideEffectHelpers & {
   /** New events past the checkpoint, in stream order, consumed or not. */
   events: readonly StreamEvent[];
   /** The consumed subset of `events`, each with its reduction result. */
@@ -98,22 +98,25 @@ export type StreamProcessorConstructorArgs<
 /**
  * Class-based stream processor.
  *
- * The model in one sentence: the host pushes ordered event batches into
- * `processEventBatch`, the base reduces each new event into state, hands the
- * batch to `processBatch` for side effects, and checkpoints state + offset once
- * all blocking work has completed.
+ * The model in one sentence: the host feeds ordered event batches into
+ * `ingest`, the base reduces each new event into state, hands the batch to the
+ * `process*` hooks for side effects, and checkpoints state + offset once all
+ * blocking work has completed.
  *
+ * `ingest` is host plumbing; the `process*` family is the authoring surface.
  * Subclasses override up to three hooks:
  *
  * - `reduce` — pure projection of one consumed event into the next state
- * - `processEvent` — synchronous per-event side effects
- * - `processBatch` — batch-level side effects (e.g. one SQLite transaction);
- *   the default implementation calls `processEvent` once per reduced event
+ * - `processEvent` — synchronous per-event side effects; what most processors
+ *   implement
+ * - `processEventBatch` — batch-level side effects (e.g. one SQLite
+ *   transaction); the default implementation calls `processEvent` once per
+ *   reduced event
  *
  * Every hook runs inside the serialized batch section: a later batch never
  * starts until the previous one has completed or failed, and the checkpoint is
  * only written after the hooks (plus any `blockProcessorWhile` work) succeed.
- * `processEventBatch` itself must not be overridden.
+ * `ingest` itself must not be overridden.
  */
 // Extending RpcTarget is a convenience for exposing processors directly over Cap'n Web.
 // The processing model should not fundamentally depend on RPC; we may remove this base
@@ -174,13 +177,10 @@ export abstract class StreamProcessor<
   /**
    * The host-facing sink. Batches are serialized in memory: a later batch never
    * starts until the previous one completed or failed. Do not override this —
-   * extend `processBatch` instead.
+   * extend `processEventBatch` instead.
    */
-  async processEventBatch(args: {
-    events: readonly StreamEvent[];
-    streamMaxOffset: number;
-  }): Promise<void> {
-    const next = this.#processing.then(() => this.#processEventBatch(args));
+  async ingest(args: { events: readonly StreamEvent[]; streamMaxOffset: number }): Promise<void> {
+    const next = this.#processing.then(() => this.#ingest(args));
     this.#processing = next.catch(() => undefined);
     return await next;
   }
@@ -190,16 +190,16 @@ export abstract class StreamProcessor<
     return args.state;
   }
 
-  /** Synchronous per-event side-effect hook, called by the default `processBatch`. */
+  /** Synchronous per-event side-effect hook, called by the default `processEventBatch`. */
   protected processEvent(_args: ProcessEventArgs<Contract>): void {}
 
   /**
    * Batch-level side-effect hook. Runs inside the serialized section, after the
    * whole batch has been reduced and before the checkpoint is written, so an
    * override can e.g. commit all projection writes in one SQLite transaction.
-   * Call `super.processBatch(args)` to keep the per-event `processEvent` calls.
+   * Call `super.processEventBatch(args)` to keep the per-event `processEvent` calls.
    */
-  protected async processBatch(args: ProcessBatchArgs<Contract>): Promise<void> {
+  protected async processEventBatch(args: ProcessEventBatchArgs<Contract>): Promise<void> {
     for (const reducedEvent of args.reducedEvents) {
       this.processEvent({
         ...reducedEvent,
@@ -247,10 +247,7 @@ export abstract class StreamProcessor<
     });
   }
 
-  async #processEventBatch(args: {
-    events: readonly StreamEvent[];
-    streamMaxOffset: number;
-  }): Promise<void> {
+  async #ingest(args: { events: readonly StreamEvent[]; streamMaxOffset: number }): Promise<void> {
     await this.#loadState();
 
     const previousState = this.#getState();
@@ -274,7 +271,7 @@ export abstract class StreamProcessor<
 
     const blockingWork: Promise<unknown>[] = [];
     try {
-      await this.processBatch({
+      await this.processEventBatch({
         events,
         reducedEvents,
         previousState,

--- a/packages/streams/src/stream-processor.ts
+++ b/packages/streams/src/stream-processor.ts
@@ -145,6 +145,9 @@ export type StreamProcessorConstructorArgs<
  *   transaction); the default implementation calls `processEvent` once per
  *   reduced event
  *
+ * plus an optional one-time `prepare` for setup that must land before the
+ * checkpoint is first read (e.g. schema migrations that reset it).
+ *
  * Every hook runs inside the serialized batch section: a later batch never
  * starts until the previous one has completed or failed, and the checkpoint is
  * only written after the hooks (plus any `blockProcessorWhile` work) succeed.
@@ -220,6 +223,15 @@ export abstract class StreamProcessor<
     this.#processing = next.catch(() => undefined);
     return await next;
   }
+
+  /**
+   * One-time async setup, run before the checkpoint is first read — whether
+   * that happens via `snapshot()` or the first ingested batch. Override for
+   * work that can invalidate the stored checkpoint, such as schema migrations
+   * that reset projection tables, so it always lands before the resume cursor
+   * is decided. Failures reject the triggering call and retry on the next one.
+   */
+  protected async prepare(): Promise<void> {}
 
   /**
    * Pure projection of one consumed event into the next state. Defaults to
@@ -357,6 +369,7 @@ export abstract class StreamProcessor<
 
   async #loadState(): Promise<void> {
     this.#loaded ??= (async () => {
+      await this.prepare();
       const snapshot = await this.#readState();
       if (snapshot === undefined) {
         this.#state ??= getInitialProcessorState(this.contract);

--- a/packages/streams/src/stream-processor.ts
+++ b/packages/streams/src/stream-processor.ts
@@ -12,14 +12,6 @@ import {
   type ProcessorState,
 } from "./shared/stream-processors.ts";
 
-export type DeepReadonly<T> = T extends (...args: never[]) => unknown
-  ? T
-  : T extends readonly (infer Item)[]
-    ? readonly DeepReadonly<Item>[]
-    : T extends object
-      ? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
-      : T;
-
 export type StreamProcessorIterateContext = {
   stream: ProcessorStream;
 };
@@ -33,8 +25,6 @@ export type StreamProcessorContract = {
   consumes: readonly string[];
 };
 
-type ProcessorEvent<Contract> = ConsumedEvent<Contract>;
-
 export type StreamProcessorBaseDeps<Contract, IterateContext> = {
   iterateContext: IterateContext;
   keepAliveWhile?: (work: () => Promise<unknown>) => void;
@@ -43,26 +33,48 @@ export type StreamProcessorBaseDeps<Contract, IterateContext> = {
 // These arg shapes are intentionally not exported: subclass overrides annotate their
 // args as `Parameters<StreamProcessor<Contract>["method"]>[0]` (enforced by the
 // `iterate/stream-processor-override-args` lint rule) so there is exactly one spelling.
+//
+// State and events are passed by reference. Hooks must treat them as immutable:
+// `reduce` returns a new state object instead of mutating its input.
 type ReducedEvent<Contract> = {
-  event: DeepReadonly<ProcessorEvent<Contract>>;
-  previousState: DeepReadonly<ProcessorState<Contract>>;
-  state: DeepReadonly<ProcessorState<Contract>>;
+  event: ConsumedEvent<Contract>;
+  previousState: ProcessorState<Contract>;
+  state: ProcessorState<Contract>;
 };
 
 type ReduceArgs<Contract> = {
-  event: DeepReadonly<ProcessorEvent<Contract>>;
-  state: DeepReadonly<ProcessorState<Contract>>;
+  event: ConsumedEvent<Contract>;
+  state: ProcessorState<Contract>;
 };
 
-type ProcessEventArgs<Contract> = ReducedEvent<Contract> & {
-  streamMaxOffset: number;
-  /**
-   * The offset this batch will checkpoint through once all blocking work
-   * completes — the last event offset in the batch, not this event's offset.
-   */
-  checkpointOffset: number;
+type SideEffectHelpers = {
+  /** Hold the checkpoint (and the next batch) until this work completes. */
   blockProcessorWhile: (work: () => Promise<unknown>) => void;
+  /** Fire-and-forget work; failures are caught and logged. */
   runInBackground: (work: () => Promise<unknown>) => void;
+};
+
+type ProcessEventArgs<Contract> = ReducedEvent<Contract> &
+  SideEffectHelpers & {
+    streamMaxOffset: number;
+    /**
+     * The offset this batch will checkpoint through once all blocking work
+     * completes — the last event offset in the batch, not this event's offset.
+     */
+    checkpointOffset: number;
+  };
+
+type ProcessBatchArgs<Contract> = SideEffectHelpers & {
+  /** New events past the checkpoint, in stream order, consumed or not. */
+  events: readonly StreamEvent[];
+  /** The consumed subset of `events`, each with its reduction result. */
+  reducedEvents: readonly ReducedEvent<Contract>[];
+  /** Processor state when the batch started. */
+  previousState: ProcessorState<Contract>;
+  /** Processor state after every event in the batch has been reduced. */
+  state: ProcessorState<Contract>;
+  streamMaxOffset: number;
+  checkpointOffset: number;
 };
 
 export type StreamProcessorSnapshot<State> = {
@@ -81,11 +93,28 @@ export type StreamProcessorConstructorArgs<
   Contract extends StreamProcessorContract,
   Deps extends object,
   IterateContext = StreamProcessorIterateContext,
-> = {
-  processorKey?: string;
-} & StreamProcessorBaseDeps<Contract, IterateContext> &
-  Deps;
+> = StreamProcessorBaseDeps<Contract, IterateContext> & Deps;
 
+/**
+ * Class-based stream processor.
+ *
+ * The model in one sentence: the host pushes ordered event batches into
+ * `processEventBatch`, the base reduces each new event into state, hands the
+ * batch to `processBatch` for side effects, and checkpoints state + offset once
+ * all blocking work has completed.
+ *
+ * Subclasses override up to three hooks:
+ *
+ * - `reduce` — pure projection of one consumed event into the next state
+ * - `processEvent` — synchronous per-event side effects
+ * - `processBatch` — batch-level side effects (e.g. one SQLite transaction);
+ *   the default implementation calls `processEvent` once per reduced event
+ *
+ * Every hook runs inside the serialized batch section: a later batch never
+ * starts until the previous one has completed or failed, and the checkpoint is
+ * only written after the hooks (plus any `blockProcessorWhile` work) succeed.
+ * `processEventBatch` itself must not be overridden.
+ */
 // Extending RpcTarget is a convenience for exposing processors directly over Cap'n Web.
 // The processing model should not fundamentally depend on RPC; we may remove this base
 // class dependency once processor hosting has settled.
@@ -97,7 +126,6 @@ export abstract class StreamProcessor<
   abstract readonly contract: Contract;
   protected readonly ctx: IterateContext;
   protected readonly deps: Deps;
-  readonly #processorKey: string | undefined;
 
   #checkpointOffset = 0;
   // eslint-disable-next-line no-unused-private-class-members -- oxlint false positive: #loadState reads and assigns this via ??=.
@@ -115,10 +143,9 @@ export abstract class StreamProcessor<
 
   constructor(args: StreamProcessorConstructorArgs<Contract, Deps, IterateContext>) {
     super();
-    const { iterateContext, keepAliveWhile, processorKey, readState, writeState, ...deps } = args;
+    const { iterateContext, keepAliveWhile, readState, writeState, ...deps } = args;
     this.ctx = iterateContext;
     this.deps = deps as Deps;
-    this.#processorKey = processorKey;
     this.#keepAliveWhile = keepAliveWhile;
     this.#readState = readState ?? (() => this.#memorySnapshot);
     this.#writeState =
@@ -128,26 +155,27 @@ export abstract class StreamProcessor<
       });
   }
 
-  protected get processorKey(): string {
-    return this.#processorKey ?? this.contract.slug;
-  }
-
-  get state(): DeepReadonly<ProcessorState<Contract>> {
-    return this.#getState() as DeepReadonly<ProcessorState<Contract>>;
+  get state(): ProcessorState<Contract> {
+    return this.#getState();
   }
 
   get checkpointOffset(): number {
     return this.#checkpointOffset;
   }
 
-  async snapshot(): Promise<StreamProcessorSnapshot<DeepReadonly<ProcessorState<Contract>>>> {
+  async snapshot(): Promise<StreamProcessorSnapshot<ProcessorState<Contract>>> {
     await this.#loadState();
     return {
       offset: this.#checkpointOffset,
-      state: this.state,
+      state: this.#getState(),
     };
   }
 
+  /**
+   * The host-facing sink. Batches are serialized in memory: a later batch never
+   * starts until the previous one completed or failed. Do not override this —
+   * extend `processBatch` instead.
+   */
   async processEventBatch(args: {
     events: readonly StreamEvent[];
     streamMaxOffset: number;
@@ -157,18 +185,39 @@ export abstract class StreamProcessor<
     return await next;
   }
 
+  /** Pure projection of one consumed event into the next state. Defaults to identity. */
   protected reduce(args: ReduceArgs<Contract>): ProcessorState<Contract> | null | undefined {
-    return args.state as ProcessorState<Contract>;
+    return args.state;
   }
 
-  reduceEvent(args: {
-    event: StreamEvent;
-    state: ProcessorState<Contract>;
-  }): ProcessorState<Contract> {
-    return (this.#reduce(args)?.state ?? args.state) as ProcessorState<Contract>;
+  /** Synchronous per-event side-effect hook, called by the default `processBatch`. */
+  protected processEvent(_args: ProcessEventArgs<Contract>): void {}
+
+  /**
+   * Batch-level side-effect hook. Runs inside the serialized section, after the
+   * whole batch has been reduced and before the checkpoint is written, so an
+   * override can e.g. commit all projection writes in one SQLite transaction.
+   * Call `super.processBatch(args)` to keep the per-event `processEvent` calls.
+   */
+  protected async processBatch(args: ProcessBatchArgs<Contract>): Promise<void> {
+    for (const reducedEvent of args.reducedEvents) {
+      this.processEvent({
+        ...reducedEvent,
+        streamMaxOffset: args.streamMaxOffset,
+        checkpointOffset: args.checkpointOffset,
+        blockProcessorWhile: args.blockProcessorWhile,
+        runInBackground: args.runInBackground,
+      });
+    }
   }
 
-  #reduce(args: {
+  /**
+   * Reduce one raw stream event against explicit state, without touching the
+   * processor's own state or checkpoint. Returns `undefined` for events this
+   * processor does not consume. Used by the batch loop and by processors that
+   * are also run inline with externally-owned state (the stream core).
+   */
+  protected reduceRawEvent(args: {
     event: StreamEvent;
     state: ProcessorState<Contract>;
   }): ReducedEvent<Contract> | undefined {
@@ -183,39 +232,18 @@ export abstract class StreamProcessor<
     const event = getEventSchema({
       type: args.event.type,
       payloadSchema: eventDefinition.payloadSchema,
-    }).parse(args.event) as DeepReadonly<ProcessorEvent<Contract>>;
+    }).parse(args.event) as ConsumedEvent<Contract>;
 
-    const previousState = args.state as DeepReadonly<ProcessorState<Contract>>;
-    const state = this.reduce({ event, state: previousState }) ?? previousState;
+    const state = this.reduce({ event, state: args.state }) ?? args.state;
     assertObjectProcessorState({ processorSlug: this.contract.slug, value: state });
 
-    return {
-      event,
-      previousState,
-      state: state as DeepReadonly<ProcessorState<Contract>>,
-    };
+    return { event, previousState: args.state, state };
   }
 
-  protected processEvent(_args: ProcessEventArgs<Contract>): void {}
-
-  processReducedEvent(
-    args: Omit<ReducedEvent<Contract>, "event"> & {
-      event: StreamEvent;
-      checkpointOffset?: number;
-      streamMaxOffset?: number;
-    },
-  ): void {
-    this.processEvent({
-      ...args,
-      event: args.event as DeepReadonly<ProcessorEvent<Contract>>,
-      checkpointOffset: args.checkpointOffset ?? args.event.offset,
-      streamMaxOffset: args.streamMaxOffset ?? args.event.offset,
-      blockProcessorWhile: () => {
-        throw new Error(
-          "blockProcessorWhile is unavailable when processing a reduced event inline",
-        );
-      },
-      runInBackground: (work) => this.#runInBackground(work),
+  /** Fire-and-forget async work backed by the host's keep-alive, with failures logged. */
+  protected runInBackground(work: () => Promise<unknown>): void {
+    this.#runKeepAliveBackedWork(work).catch((error: unknown) => {
+      console.error("stream processor background work failed", error);
     });
   }
 
@@ -225,61 +253,50 @@ export abstract class StreamProcessor<
   }): Promise<void> {
     await this.#loadState();
 
-    const batchPreviousState = this.#getState();
-    let nextState = batchPreviousState;
+    const previousState = this.#getState();
+    let state = previousState;
     let checkpointOffset = this.#checkpointOffset;
+    const events: StreamEvent[] = [];
     const reducedEvents: ReducedEvent<Contract>[] = [];
 
-    for (const rawEvent of args.events) {
-      if (rawEvent.offset <= checkpointOffset) continue;
+    for (const event of args.events) {
+      if (event.offset <= checkpointOffset) continue;
+      events.push(event);
+      checkpointOffset = event.offset;
 
-      const reduction = this.#reduce({
-        event: rawEvent,
-        state: nextState,
-      });
-      checkpointOffset = rawEvent.offset;
-
+      const reduction = this.reduceRawEvent({ event, state });
       if (reduction === undefined) continue;
-
       reducedEvents.push(reduction);
-      nextState = reduction.state as ProcessorState<Contract>;
+      state = reduction.state;
     }
 
-    if (checkpointOffset === this.#checkpointOffset) return;
+    if (events.length === 0) return;
 
-    if (reducedEvents.length > 0) {
-      const blockingWork: Promise<unknown>[] = [];
-      try {
-        for (const reducedEvent of reducedEvents) {
-          this.processEvent({
-            ...reducedEvent,
-            checkpointOffset,
-            streamMaxOffset: args.streamMaxOffset,
-            blockProcessorWhile: (work) => {
-              blockingWork.push(this.#runKeepAliveBackedWork(work));
-            },
-            runInBackground: (work) => this.#runInBackground(work),
-          });
-        }
-      } catch (error) {
-        // A processEvent throw fails the batch, but work already registered for
-        // earlier events must still be settled so it cannot reject unobserved.
-        await Promise.allSettled(blockingWork);
-        throw error;
-      }
-
+    const blockingWork: Promise<unknown>[] = [];
+    try {
+      await this.processBatch({
+        events,
+        reducedEvents,
+        previousState,
+        state,
+        streamMaxOffset: args.streamMaxOffset,
+        checkpointOffset,
+        blockProcessorWhile: (work) => {
+          blockingWork.push(this.#runKeepAliveBackedWork(work));
+        },
+        runInBackground: (work) => this.runInBackground(work),
+      });
       await Promise.all(blockingWork);
+    } catch (error) {
+      // A failed batch must still settle work it already registered so nothing
+      // rejects unobserved. The checkpoint is not written; the batch retries.
+      await Promise.allSettled(blockingWork);
+      throw error;
     }
 
-    this.#state = nextState;
+    this.#state = state;
     this.#checkpointOffset = checkpointOffset;
     await this.#saveSnapshot();
-  }
-
-  #runInBackground(work: () => Promise<unknown>): void {
-    this.#runKeepAliveBackedWork(work).catch((error: unknown) => {
-      console.error("stream processor background work failed", error);
-    });
   }
 
   async #runKeepAliveBackedWork(work: () => Promise<unknown>): Promise<unknown> {


### PR DESCRIPTION
## Summary

Stacked on #1401. Tightens the class-based `StreamProcessor` into a model that's explainable in one sentence: *the host feeds ordered event batches into `ingest`, the base reduces each new event into state, hands the batch to the `process*` hooks for side effects, and checkpoints once all blocking work completes.*

### Naming: `ingest` vs the `process*` hook family

The host-facing serialized sink is now `ingest` — deliberately outside the hook family. The authoring surface is a consistent `process*` trio: `reduce` (pure state projection), `processEvent` (per-event side effects, what most processors implement), and `processEventBatch` (batch-level side effects, default loops `processEvent`). The lint rule forbids defining `ingest`/`processEvents`/`processBatch` on subclasses and arg-checks the three real hooks.

### Serialization guarantee actually holds for subclasses

Previously the prescribed extension pattern (override the public batch method, do SQL writes, call `super`) ran subclass writes *outside* the serialization queue — racing the DO pump's fire-and-forget batch delivery and surviving only via idempotent writes. The batch hook now runs *inside* the serialized section, after reduce and before the checkpoint write; overriding `ingest` is a lint error. Browser processors lose their snapshot-then-filter dance: `args.events` arrives pre-deduped with batch-entry state attached.

### No more `DeepReadonly`

It forced an escape-hatch cast in every real subclass (feed: `as FeedState`, core: a Zod parse used as a typecast on the append hot path). Hooks receive plain `ProcessorState`/`ConsumedEvent` and must treat them as immutable.

### Honest wildcard consume types

`consumes: ["*", ...named]` previously inferred the named-only union, so the switch fallthrough was typed `never` while being reachable at runtime — an `assertNever` there would have thrown on every unnamed event. The union now includes `WildcardConsumedEvent` (type-level literal `"*"`): named events keep exact payload narrowing, the wildcard branch is reachable with an `unknown` payload. `["*"]` alone stays plain `StreamEvent`; named-only contracts stay exhaustive; `"*"` in `emits` is rejected at the definition site. This lines up with the planned consumes-driven subscription filtering.

### Base class is a pure batch model

The inline DO surface (`reduceEvent`, `processReducedEvent`) moved onto `CoreStreamProcessor` — its only user — built on the protected `reduceRawEvent` helper. Unused `processorKey` removed.

### Regression tests

- `stream-processor-class.test.ts`: batch serialization, checkpoint semantics (one write per batch, no write on failure, at-least-once redelivery), offset dedupe, `blockProcessorWhile`/`runInBackground`/`keepAliveWhile` behavior, blocking-work settlement on hook throw, `readState` failure retry, wildcard runtime semantics.
- `browser/processor-state-storage.test.ts` (real SQLite via `node:sqlite`): `processor_state` round-trip and delete semantics, the schema-version-bump checkpoint regression from #1401's cleanup commit, replay dedupe through the continuity trigger.
- `stream-processor-types.test.ts`: wildcard-only / mixed / named-only consume inference, consumes-typo and wildcard-emits rejection.

## Validation

- `pnpm --dir packages/streams typecheck && pnpm --dir packages/streams test` (62 tests)
- `pnpm --dir packages/streams/example-app typecheck`
- `pnpm --dir apps/os typecheck`
- `pnpm lint && pnpm format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stream processing checkpoints, browser SQLite mirror replay, and core inline append paths—behavior changes are covered by new tests but affect durable resume semantics.
> 
> **Overview**
> Refines the class-based **`StreamProcessor`** around a single host entrypoint **`ingest`** (serialized batches, checkpoint after blocking work) and a protected **`process*`** hook surface (`reduce`, `processEvent`, `processEventBatch`), plus optional **`prepare()`** before the first checkpoint read.
> 
> **Serialization & browser processors:** Subclass batch side effects now run inside the base serialization queue; ESLint blocks overriding **`ingest`** / legacy **`processEvents`** / **`processBatch`**. The browser runtime calls **`ingest`** instead of invoking the processor’s batch method directly. Raw-events and event-feed processors move schema setup to **`prepare()`**, drop per-batch snapshot filtering, and write from pre-deduped **`args.events`** with **`previousState`** on batch hooks.
> 
> **Types & core:** Removes **`DeepReadonly`** from hook args; mixed **`consumes: ["*", ...named]`** adds **`WildcardConsumedEvent`** so wildcard branches are reachable. **`CoreStreamProcessor`** owns inline **`reduceEvent`** / **`processReducedEvent`** on **`reduceRawEvent`**; unused **`processorKey`** is removed.
> 
> **Tests & docs:** Adds runtime tests for batch/checkpoint/side effects and SQLite regressions for **`processor_state`** and schema-version checkpoint clears; design notes updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c5de67321275482228daad06fa8f0276d41f92f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-09T21:23:17.027Z",
      "headSha": "48f23d72baa92094616fb380792669b7a2cdf802",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27236052398",
      "shortSha": "48f23d7"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `48f23d7`
Preview: https://os.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27236052398)
Updated: 2026-06-09T21:23:17.027Z
<!-- /CLOUDFLARE_PREVIEW -->