### PR TITLE
Fix 5-min logout, deploy-time JWKS, and stream append skeleton flash

### DIFF
--- a/apps/auth/src/lib/server.ts
+++ b/apps/auth/src/lib/server.ts
@@ -251,21 +251,37 @@ function createOAuthInfra(config: IterateAuthConfig, jwks: JWKS): OAuthInfra {
     return _as;
   }
 
-  async function doRefresh(tokenSet: TokenSet): Promise<TokenSet | null> {
-    if (!tokenSet.refreshToken) return null;
-    const as = await getAuthorizationServer();
-    const response = await oauth.refreshTokenGrantRequest(
-      as,
-      oauthClient,
-      clientAuth,
-      tokenSet.refreshToken,
-      {
-        ...httpOptions(),
-        additionalParameters: { resource: resource() },
-      },
-    );
-    const result = await oauth.processRefreshTokenResponse(as, oauthClient, response);
-    return toTokenSet(result, tokenSet);
+  // The auth server rotates refresh tokens on every use and treats reuse of a
+  // rotated token as theft (revoking the whole token family). Concurrent
+  // requests carrying the same cookie must therefore share one refresh
+  // flight per refresh token instead of racing the token endpoint.
+  const refreshFlights = new Map<string, Promise<TokenSet | null>>();
+
+  function doRefresh(tokenSet: TokenSet): Promise<TokenSet | null> {
+    const refreshToken = tokenSet.refreshToken;
+    if (!refreshToken) return Promise.resolve(null);
+
+    const existing = refreshFlights.get(refreshToken);
+    if (existing) return existing;
+
+    const flight = (async () => {
+      const as = await getAuthorizationServer();
+      const response = await oauth.refreshTokenGrantRequest(
+        as,
+        oauthClient,
+        clientAuth,
+        refreshToken,
+        {
+          ...httpOptions(),
+          additionalParameters: { resource: resource() },
+        },
+      );
+      const result = await oauth.processRefreshTokenResponse(as, oauthClient, response);
+      return toTokenSet(result, tokenSet);
+    })();
+    refreshFlights.set(refreshToken, flight);
+    void flight.catch(() => {}).finally(() => refreshFlights.delete(refreshToken));
+    return flight;
   }
 
   async function getUserInfo(accessToken: string): Promise<UserInfoClaims | null> {
@@ -350,15 +366,34 @@ export function createAuthMiddleware(config: IterateAuthConfig, infra: OAuthInfr
 
       if (!tokenSet.idToken) return { session: null, responseHeaders: new Headers() };
 
+      // WebSocket upgrades can't carry Set-Cookie back to the browser, so a
+      // refresh here would rotate the refresh token into a response the
+      // client can never store — burning the session. Upgrades authenticate
+      // with the current access token only; once it expires they fail until
+      // a regular request refreshes the cookie and the client reconnects.
+      const isWebSocketUpgrade = headers.get("upgrade")?.toLowerCase() === "websocket";
+      const accessTokenExpired = tokenSet.accessTokenExpiresAt <= Date.now();
+      const accessTokenExpiresSoon = tokenSet.accessTokenExpiresAt <= Date.now() + REFRESH_SKEW_MS;
+
       let refreshed = false;
-      try {
-        if (tokenSet.accessTokenExpiresAt <= Date.now() + REFRESH_SKEW_MS) {
+      if (accessTokenExpiresSoon && !isWebSocketUpgrade) {
+        try {
           const newTokenSet = await doRefresh(tokenSet);
-          if (!newTokenSet) return { session: null, responseHeaders: new Headers() };
-          tokenSet = newTokenSet;
-          refreshed = true;
+          if (newTokenSet) {
+            tokenSet = newTokenSet;
+            refreshed = true;
+          } else if (accessTokenExpired) {
+            return { session: null, responseHeaders: new Headers() };
+          }
+        } catch {
+          // A failed refresh while the current access token is still valid is
+          // not fatal: serve this request with the existing token and let a
+          // later request retry the refresh.
+          if (accessTokenExpired) {
+            return { session: null, responseHeaders: new Headers() };
+          }
         }
-      } catch {
+      } else if (accessTokenExpired) {
         return { session: null, responseHeaders: new Headers() };
       }
 

--- a/apps/auth/src/lib/server.ts
+++ b/apps/auth/src/lib/server.ts
@@ -23,6 +23,34 @@ export const DEFAULT_AUTH_HANDLER_BASE_PATH = "/api/iterate-auth";
 const SCOPES = ["openid", "profile", "email", "offline_access"] as const;
 const REFRESH_SKEW_MS = 30_000;
 
+/**
+ * Collapses concurrent calls keyed by the same string into a single in-flight
+ * promise. The OAuth refresh-token grant rotates the refresh token and revokes
+ * the whole family if a rotated token is presented twice, so two requests
+ * carrying the same session cookie must not both hit the token endpoint —
+ * otherwise the loser's "reuse" nukes the session and logs the user out. The
+ * entry is removed once settled so the next (rotated) token starts fresh.
+ */
+export function createSingleFlight<T>(): (key: string, fn: () => Promise<T>) => Promise<T> {
+  const inFlight = new Map<string, Promise<T>>();
+  return (key, fn) => {
+    const existing = inFlight.get(key);
+    if (existing) return existing;
+    // Clear inside the awaited promise's own finally so the entry is gone the
+    // moment callers observe the result — the next (rotated-token) cycle starts
+    // clean, while everyone racing the current cycle still shares this flight.
+    const flight = (async () => {
+      try {
+        return await fn();
+      } finally {
+        inFlight.delete(key);
+      }
+    })();
+    inFlight.set(key, flight);
+    return flight;
+  };
+}
+
 export type IterateAuthConfig = {
   issuer?: string;
   clientId: string;
@@ -255,16 +283,13 @@ function createOAuthInfra(config: IterateAuthConfig, jwks: JWKS): OAuthInfra {
   // rotated token as theft (revoking the whole token family). Concurrent
   // requests carrying the same cookie must therefore share one refresh
   // flight per refresh token instead of racing the token endpoint.
-  const refreshFlights = new Map<string, Promise<TokenSet | null>>();
+  const refreshSingleFlight = createSingleFlight<TokenSet | null>();
 
   function doRefresh(tokenSet: TokenSet): Promise<TokenSet | null> {
     const refreshToken = tokenSet.refreshToken;
     if (!refreshToken) return Promise.resolve(null);
 
-    const existing = refreshFlights.get(refreshToken);
-    if (existing) return existing;
-
-    const flight = (async () => {
+    return refreshSingleFlight(refreshToken, async () => {
       const as = await getAuthorizationServer();
       const response = await oauth.refreshTokenGrantRequest(
         as,
@@ -278,10 +303,7 @@ function createOAuthInfra(config: IterateAuthConfig, jwks: JWKS): OAuthInfra {
       );
       const result = await oauth.processRefreshTokenResponse(as, oauthClient, response);
       return toTokenSet(result, tokenSet);
-    })();
-    refreshFlights.set(refreshToken, flight);
-    void flight.catch(() => {}).finally(() => refreshFlights.delete(refreshToken));
-    return flight;
+    });
   }
 
   async function getUserInfo(accessToken: string): Promise<UserInfoClaims | null> {

--- a/apps/auth/src/server/auth-plugins.ts
+++ b/apps/auth/src/server/auth-plugins.ts
@@ -184,7 +184,10 @@ export function getAuthPlugins(env: Record<string, unknown>) {
         },
       },
       silenceWarnings: { openidConfig: true, oauthAuthServerConfig: true },
-      accessTokenExpiresIn: 5 * 60,
+      // Long enough that refresh (which rotates the refresh token and treats
+      // rotated-token reuse as theft) is rare, short enough that org/project
+      // claim changes propagate within half an hour.
+      accessTokenExpiresIn: 30 * 60,
       scopes: ["openid", "profile", "email", "offline_access", ITERATE_PROJECT_SELECTION_SCOPE],
       validAudiences,
       allowDynamicClientRegistration: true,

--- a/apps/os/README.md
+++ b/apps/os/README.md
@@ -91,6 +91,7 @@ The script pattern is documented in
 - [Doppler-Backed Scripts](./docs/doppler-backed-scripts.md)
 - [Architecture And Operations](./docs/architecture-and-operations.md)
 - [Preview Agent Browser Smoke](./docs/preview-agent-browser-smoke.md)
+- [Headless Local Debugging](./docs/headless-local-debugging.md)
 - [Codemode Subrequest Depth](./docs/codemode-subrequest-depth.md)
 - [ADR: Replace Clerk With Auth Worker](../../docs/adr/0001-replace-clerk-with-auth-worker.md)
 - [Domain Context](./CONTEXT.md)

--- a/apps/os/alchemy.run.ts
+++ b/apps/os/alchemy.run.ts
@@ -19,16 +19,58 @@ import type { WorkspaceDurableObject } from "./src/domains/workspaces/durable-ob
 import type { OutboundMcpFromOurClientCapability } from "./src/domains/outbound-mcp-client/entrypoints/outbound-mcp-from-our-client-capability.ts";
 import type { StreamProcessorRunner } from "./src/domains/streams/durable-objects/stream-processor-runner.ts";
 
+const resolvedAuthIssuer =
+  process.env.APP_CONFIG_ITERATE_AUTH__ISSUER ?? process.env.ITERATE_OAUTH_ISSUER;
+
+// A static JWKS lets the worker verify auth JWTs without any runtime
+// roundtrip to the auth worker, including on cold isolate starts. Fetch it
+// from the issuer at deploy time; an explicit env value overrides. A static
+// JWKS only verifies tokens from the issuer it was exported from, so a
+// loopback issuer (local dev auth server with its own keys) never uses a
+// Doppler-provided production JWKS. Key rotation in auth requires an OS
+// redeploy. On fetch failure the worker falls back to remote JWKS at runtime.
+async function resolveStaticAuthJwks(issuer: string | undefined) {
+  if (!issuer) return undefined;
+
+  let issuerUrl: URL;
+  try {
+    issuerUrl = new URL(issuer);
+  } catch {
+    return undefined;
+  }
+  const issuerIsLoopback = ["localhost", "127.0.0.1", "::1"].includes(issuerUrl.hostname);
+
+  const explicit = process.env.APP_CONFIG_ITERATE_AUTH__JWKS ?? process.env.ITERATE_AUTH_JWKS;
+  if (explicit && !issuerIsLoopback) return explicit;
+
+  try {
+    const response = await fetch(`${issuer.replace(/\/+$/, "")}/jwks`, {
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const jwks = (await response.json()) as { keys?: unknown[] };
+    if (!Array.isArray(jwks.keys) || jwks.keys.length === 0) {
+      throw new Error("JWKS response has no keys");
+    }
+    return JSON.stringify(jwks);
+  } catch (error) {
+    console.warn(
+      `[alchemy.run] Could not fetch JWKS from ${issuer} at deploy time; ` +
+        `the worker will fetch it at runtime instead.`,
+      error instanceof Error ? error.message : error,
+    );
+    return undefined;
+  }
+}
+
 const env = {
   ...process.env,
-  APP_CONFIG_ITERATE_AUTH__ISSUER:
-    process.env.APP_CONFIG_ITERATE_AUTH__ISSUER ?? process.env.ITERATE_OAUTH_ISSUER,
+  APP_CONFIG_ITERATE_AUTH__ISSUER: resolvedAuthIssuer,
   APP_CONFIG_ITERATE_AUTH__CLIENT_ID:
     process.env.APP_CONFIG_ITERATE_AUTH__CLIENT_ID ?? process.env.ITERATE_OAUTH_CLIENT_ID,
   APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET:
     process.env.APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET ?? process.env.ITERATE_OAUTH_CLIENT_SECRET,
-  APP_CONFIG_ITERATE_AUTH__JWKS:
-    process.env.APP_CONFIG_ITERATE_AUTH__JWKS ?? process.env.ITERATE_AUTH_JWKS,
+  APP_CONFIG_ITERATE_AUTH__JWKS: await resolveStaticAuthJwks(resolvedAuthIssuer),
   APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN:
     process.env.APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN ?? process.env.ITERATE_AUTH_SERVICE_TOKEN,
 };

--- a/apps/os/docs/headless-local-debugging.md
+++ b/apps/os/docs/headless-local-debugging.md
@@ -1,0 +1,178 @@
+# Headless local debugging (drive the full OS + Auth stack)
+
+How to reproduce UI/auth bugs against a **local** OS + Auth stack with a
+scripted headless browser: sign in via test OTP, create orgs/projects, drive
+OAuth, and read server state directly. Complements
+[preview-agent-browser-smoke.md](./preview-agent-browser-smoke.md), which drives
+a _deployed_ preview against _production_ auth.
+
+## When to use which environment
+
+- **Deployed preview** (`os.iterate-preview-N.com`): uses production auth. No
+  test OTP — you sign in as a real allowlisted user. Best for final proof.
+- **Local stack** (this doc): `pnpm dev` runs OS on the `os.iterate-dev-<you>`
+  Cloudflare dev tunnel and Auth on `http://localhost:7101`, against a local D1
+  (miniflare) you can read and write directly. Best for fast iteration and for
+  bugs that need many synthetic events / fresh orgs.
+
+## Bring up the local stack
+
+```bash
+pnpm dev   # monorepo root: starts apps/auth (localhost:7101) AND apps/os (dev tunnel)
+```
+
+`pnpm dev` exports `ITERATE_OAUTH_ISSUER=http://localhost:7101/api/auth` and
+points OS at it. OS still serves on its **dev tunnel hostname**
+(`https://os.iterate-dev-<you>.com`), not `localhost` — the OAuth `redirect_uri`
+is the tunnel callback, so drive the browser against the tunnel host, not
+`localhost:5173`.
+
+Gotchas:
+
+- The Doppler scope for `apps/auth` must resolve to a config that exists. If
+  `pnpm dev` dies with `Could not find requested config 'dev_<you>'`, point it
+  at the shared dev config: `doppler configure set config dev --scope apps/auth`.
+- A loopback issuer signs tokens with the **local** auth keys, so a static
+  production JWKS can't verify them. `apps/os/alchemy.run.ts` detects a loopback
+  issuer and skips the static JWKS (falls back to runtime JWKS fetch).
+
+## Headless browser without touching the user's Chrome
+
+`~/.zshrc` sets `AGENT_BROWSER_AUTO_CONNECT=1`, which attaches to the user's
+real Chrome (prompts + reads their tabs). For autonomous work launch a
+dedicated, isolated, headless Chrome for Testing and drive it over CDP:
+
+```bash
+agent-browser install   # one-time: bundled Chrome for Testing
+BIN="$HOME/.agent-browser/browsers/chrome-149.0.7827.54/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+nohup "$BIN" --headless=new --remote-debugging-port=9444 --user-data-dir=/tmp/ab-own about:blank >/tmp/ab-own.log 2>&1 & disown
+
+# AUTO_CONNECT=0 overrides the .zshrc default so it never touches the user's Chrome.
+# Use an isolated --session so refs/cookies don't collide with other work.
+export AGENT_BROWSER_AUTO_CONNECT=0
+ab() { agent-browser --session dbg --cdp 9444 "$@"; }
+ab open https://os.iterate-dev-<you>.com/
+```
+
+- The browser keeps its profile in `--user-data-dir`, so an `iterate_session`
+  cookie survives a _page reload_ but a fresh Chrome process is a clean slate.
+- `ab state save /tmp/dbg-state.json` / `state load` persists cookies +
+  localStorage across Chrome restarts (Chrome for Testing is occasionally
+  OOM-killed by local dev rebuilds — save state once logged in).
+- Do **not** `agent-browser close` the `--cdp` instance (it kills the browser).
+  Clean up with `pkill -f ab-own`.
+
+## Sign in with a test user (OTP)
+
+Local/non-prod auth enables email OTP and a deterministic code:
+
+- Any email matching `/\+.*test@/i` skips email send and accepts OTP **`424242`**
+  (see `apps/auth/src/server/auth-plugins.ts`).
+- Sign-_up_ is gated by `SIGNUP_ALLOWLIST` (auth Doppler). The local list allows
+  `*@nustom.com`, `testuser+*@gmail.com`, etc. A brand-new email outside the
+  allowlist returns `403 "Sign up is not available for this email address"`, so
+  use e.g. `testuser+<scenario>@gmail.com`.
+
+Flow (snapshot between steps; refs go stale on every navigation):
+
+```bash
+ab open https://os.iterate-dev-<you>.com/
+ab find role button click --name "Continue with Iterate"     # OS -> auth /login
+ab find role button click --name "Continue with email"
+ab fill "input[type=email]" "testuser+dbg@gmail.com"
+ab find role button click --name "Send verification code"
+ab fill "input[autocomplete=one-time-code]" "424242"
+ab find role button click --name "Continue with email"        # -> /project-access or /consent
+```
+
+If the OTP form rejects a code, the OTP really is in the DB — read it (below) to
+confirm; "Invalid OTP" usually means a stale verification row, "Forbidden"/403
+means the allowlist rejected sign-up.
+
+### Consent step quirk
+
+The better-auth oauth-provider consent button posts via a client plugin that
+reconstructs the signed query from `window.location.search`. If clicking
+"Allow access" loops back to `/consent`, drive the endpoint directly from the
+page context and follow its redirect:
+
+```bash
+cat <<'EOF' | ab eval --stdin
+(async () => {
+  const sp = new URLSearchParams(window.location.search);
+  const signed = new URLSearchParams();
+  for (const [k, v] of sp.entries()) { signed.append(k, v); if (k === "sig") break; }
+  const res = await fetch("/api/auth/oauth2/consent", {
+    method: "POST", headers: { "content-type": "application/json" }, credentials: "include",
+    body: JSON.stringify({ accept: true, oauth_query: signed.toString() }),
+  });
+  const data = await res.json();
+  if (data.url) window.location.href = data.url;   // -> OS /api/iterate-auth/callback
+  return { status: res.status, url: data.url };
+})()
+EOF
+```
+
+## Create orgs and projects
+
+- **Org**: the post-login `/project-access` page has a "Create organization"
+  form; fill it and submit. Or call the auth contract
+  (`internal.organization.createForUser`) with a service token.
+- **Project**: the OS UI route is `/projects/new`, but you can create directly
+  against the OS oRPC REST surface from the authenticated page:
+
+```bash
+cat <<'EOF' | ab eval --stdin
+(async () => {
+  const res = await fetch("/api/projects", {
+    method: "POST", headers: { "content-type": "application/json" }, credentials: "include",
+    body: JSON.stringify({ slug: "dbgproj" }),
+  });
+  return { status: res.status, body: await res.text() };
+})()
+EOF
+```
+
+Project claims only land in the JWT on the next token refresh (or a fresh
+sign-in), so a just-created project is visible to the creating session via its
+seeded query cache but not to a cold reload until the access token reissues.
+
+## Read local server state directly
+
+Local D1 lives as miniflare SQLite files. There is one file per database; grep
+the tables to tell auth from OS:
+
+```bash
+ls .alchemy/miniflare/v3/d1/miniflare-D1DatabaseObject/*.sqlite
+# auth DB has: user, account, organization, member, oauthClient, oauthRefreshToken, verification
+# OS DB has:   projects, ingress_routes, project_connections, ...
+
+DB=.alchemy/miniflare/v3/d1/miniflare-D1DatabaseObject/<hash>.sqlite
+sqlite3 "$DB" "SELECT identifier, value FROM verification ORDER BY rowid DESC LIMIT 3"   # pending OTPs (value is 'otp:attempts')
+sqlite3 "$DB" "SELECT clientId, substr(token,1,10), revoked, expiresAt FROM oauthRefreshToken ORDER BY createdAt DESC"
+sqlite3 "$DB" "SELECT clientId, substr(clientSecret,1,12) FROM oauthClient"
+```
+
+Refresh/OTP tokens are stored **hashed/encoded**, so a value read here is not the
+literal bearer the client holds — useful for state/rotation inspection, not for
+replaying a token by hand.
+
+## Instrumenting UI behaviour
+
+`ab eval --stdin` runs arbitrary JS in the page. For transient visual bugs,
+prefer a `MutationObserver` (fires regardless of tab focus) over `requestAnimationFrame`
+/ `setInterval` sampling — a backgrounded headless tab throttles timers to ~1s,
+which is too coarse to catch sub-second flashes. Example: count skeleton churn
+and row add/remove around an action, then read the tallies back in a second
+`eval`.
+
+## Inspecting the session without logging out
+
+```bash
+cat <<'EOF' | ab eval --stdin
+fetch("/api/iterate-auth/session", { credentials: "include" }).then(r => r.json())
+EOF
+```
+
+Returns the decoded `expiresAt`, organizations, and projects the OS worker sees
+— the fastest way to confirm what a token actually carries after a refresh.

--- a/apps/os/src/auth/iterate-auth-single-flight.test.ts
+++ b/apps/os/src/auth/iterate-auth-single-flight.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSingleFlight } from "@iterate-com/auth/server";
+
+// Proves the fix for the ~5-minute logout: the OAuth refresh-token grant rotates
+// the refresh token and revokes the whole family if a rotated token is presented
+// twice. A normal page load fires several concurrent requests; once the access
+// token is near expiry they all tried to refresh with the same cookie token, and
+// the losers' "reuse" nuked the session. createSingleFlight collapses concurrent
+// refreshes for one token into a single token-endpoint call.
+
+describe("createSingleFlight", () => {
+  it("collapses concurrent calls for the same key into one invocation", async () => {
+    const singleFlight = createSingleFlight<string>();
+    let resolve!: (value: string) => void;
+    const fn = vi.fn(() => new Promise<string>((r) => (resolve = r)));
+
+    const a = singleFlight("token-1", fn);
+    const b = singleFlight("token-1", fn);
+    const c = singleFlight("token-1", fn);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    resolve("rotated");
+    await expect(Promise.all([a, b, c])).resolves.toEqual(["rotated", "rotated", "rotated"]);
+  });
+
+  it("runs independent keys independently", async () => {
+    const singleFlight = createSingleFlight<string>();
+    const fn = vi.fn(async (value: string) => value);
+
+    const [one, two] = await Promise.all([
+      singleFlight("token-1", () => fn("one")),
+      singleFlight("token-2", () => fn("two")),
+    ]);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect([one, two]).toEqual(["one", "two"]);
+  });
+
+  it("clears the entry after settling so a rotated token refreshes again", async () => {
+    const singleFlight = createSingleFlight<number>();
+    const fn = vi.fn(async () => 1);
+
+    await singleFlight("token-1", fn);
+    await singleFlight("token-1", fn);
+
+    // Same key, but the first flight already settled — a real second refresh runs.
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates rejection to all waiters and lets the next call retry", async () => {
+    const singleFlight = createSingleFlight<string>();
+    const failing = vi.fn(async () => {
+      throw new Error("refresh failed");
+    });
+
+    const a = singleFlight("token-1", failing);
+    const b = singleFlight("token-1", failing);
+    await expect(a).rejects.toThrow("refresh failed");
+    await expect(b).rejects.toThrow("refresh failed");
+    expect(failing).toHaveBeenCalledTimes(1);
+
+    // Failure cleared the entry, so a subsequent attempt is allowed to retry.
+    const recovering = vi.fn(async () => "ok");
+    await expect(singleFlight("token-1", recovering)).resolves.toBe("ok");
+    expect(recovering).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -93,12 +93,20 @@ export function ProjectStreamView({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  // Only auto-scroll to the bottom when the viewport is already pinned there.
+  // Yanking a scrolled-up reader back to the bottom on every append shifts the
+  // virtualized window far enough that the whole visible range re-queries and
+  // flashes grey skeletons before SQLite returns the new rows.
+  const stickToBottomRef = useRef(true);
 
   async function submit() {
     const trimmed = composerText.trim();
     if (!trimmed) return;
     setIsSubmitting(true);
     setSubmitError(undefined);
+    // The user just appended from the composer at the bottom, so follow the
+    // new event down even if they had scrolled up earlier.
+    stickToBottomRef.current = true;
     try {
       if (composerMode === "message" && messageComposer) {
         await messageComposer.onSubmit(trimmed);
@@ -121,6 +129,7 @@ export function ProjectStreamView({
   }
 
   useLayoutEffect(() => {
+    if (!stickToBottomRef.current) return;
     const frame = window.requestAnimationFrame(() => {
       const scrollContainer = scrollContainerRef.current;
       if (scrollContainer == null) {
@@ -133,7 +142,7 @@ export function ProjectStreamView({
     return () => {
       window.cancelAnimationFrame(frame);
     };
-  }, [eventCount, isSubmitting, submitError]);
+  }, [eventCount]);
 
   return (
     <section className="flex min-h-0 flex-1 flex-col bg-white">
@@ -142,7 +151,16 @@ export function ProjectStreamView({
         <StreamStatus count={eventCount} snapshot={snapshot} />
       </header>
       {headerAccessory == null ? null : <div className="shrink-0 border-b">{headerAccessory}</div>}
-      <main ref={scrollContainerRef} className="min-h-0 flex-1 overflow-y-auto">
+      <main
+        ref={scrollContainerRef}
+        className="min-h-0 flex-1 overflow-y-auto"
+        onScroll={(event) => {
+          const el = event.currentTarget;
+          // Within ~80px of the bottom counts as "pinned"; expanding a row or a
+          // late virtualizer measurement can leave a few px of slack.
+          stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+        }}
+      >
         {countResult.status !== "ok" ? (
           <Centered>
             {countResult.status === "error"
@@ -223,13 +241,22 @@ function VirtualEventRows({
      ORDER BY local_index ASC`,
     [first, last + 1],
   );
+  // Retain the last committed rows across range re-queries. When the visible
+  // window shifts (append grows the list, or a scroll moves it), the range SQL
+  // query is recreated and briefly reports `pending` carrying a *different*
+  // range's rows. Rendering straight from that pending data blanks every
+  // already-visible row to a grey skeleton for a frame. Keeping the last "ok"
+  // rows means only genuinely-new indices fall back to a skeleton.
+  const lastRowsRef = useRef<Map<number, StreamEventRow>>(new Map());
   const rowsByIndex = useMemo(() => {
+    if (rowsResult.status !== "ok") return lastRowsRef.current;
     const rows = new Map<number, StreamEventRow>();
     for (const row of rowsResult.data) {
       if (typeof row.local_index === "number") rows.set(row.local_index, row as StreamEventRow);
     }
+    lastRowsRef.current = rows;
     return rows;
-  }, [rowsResult.data]);
+  }, [rowsResult.data, rowsResult.status]);
 
   if (eventCount === 0) {
     return (


### PR DESCRIPTION
Follow-up to #1408. Three reliability fixes on the OS/auth path, one branch.

## 1. ~5-minute logout (root cause from library source)

`@better-auth/oauth-provider`'s refresh-token grant **rotates** the refresh token on every use and, on reuse of an already-rotated token, **revokes the entire token family** (`handleRefreshTokenGrant` → `createRefreshToken` marks the old token `revoked`, and a later reuse deletes all of the user+client's refresh tokens). A normal OS page load fires several concurrent requests; once the 5-minute access token was within the 30s refresh skew, each request independently hit the token endpoint with the same cookie token — the first rotated it, the rest looked like theft and nuked the session → logout, repeating roughly every 5 minutes.

Fixes (`apps/auth/src/lib/server.ts`, the SDK OS bundles):
- **Single-flight refresh** per refresh token — concurrent refreshes collapse to one token-endpoint call (`createSingleFlight`, extracted + unit-tested).
- **Never refresh on WebSocket upgrades** — an upgrade response can't carry `Set-Cookie`, so refreshing there would rotate the token into a response the browser can't store and strand the session (this is also the **REPL websocket failure**: once the access token went stale, the capnweb upgrade tried to refresh, failed, and 401'd).
- **Tolerate a failed refresh while the access token is still valid** — serve the request and let a later one retry, instead of dropping the session on any hiccup.
- **Access-token TTL 5m → 30m** (`auth-plugins.ts`) so refresh is rare. Tradeoff: org/project claim changes propagate within ≤30m (mitigated for the creator by client cache seeding).

## 2. Deploy-time JWKS (`apps/os/alchemy.run.ts`)

#1408 verified JWTs locally from a static JWKS but relied on a hand-set Doppler secret. Now the alchemy script **fetches `<issuer>/jwks` at deploy time** into `APP_CONFIG` (typesafe), so key rotation only needs an OS redeploy. A loopback issuer (local dev auth, own keys) skips the static JWKS; a failed fetch falls back to runtime JWKS. **Verified**: preview-5 deploy log shows the JWKS baked into config and the worker healthy with zero auth-worker roundtrips.

## 3. Stream append skeleton flash (`apps/os/.../project-stream-view.tsx`)

On append the virtualized window shifted (the list grows and the view force-scrolled to the bottom), which re-created the visible-range SQL query. `stream-browser-db.query()` seeds a new range query as `pending` carrying a *different* range's rows, so `rowsByIndex` missed the visible indices and every visible row blanked to a grey `bg-slate-100` skeleton for a frame — the "skeleton flash + all rows redraw". Fixes: retain the last committed rows across range re-queries (only genuinely-new indices fall back to a skeleton), and only auto-scroll to the bottom when already pinned there (don't yank a scrolled-up reader and trigger a full-window re-query).

## Proof status (being precise)

- **Refresh single-flight**: proven by `apps/os/src/auth/iterate-auth-single-flight.test.ts` (deterministic) + root cause read from the oauth-provider source. The end-to-end "wait 5 minutes in a browser" proof was **not** completed: production auth is Google-only (no headless sign-in) and doesn't honor service-token impersonation at the public `oauth2/authorize`, and the fixed local stack now issues 30m tokens. Worth a manual 5-min check after this deploys to prod auth.
- **Deploy-time JWKS**: verified on a real preview-5 deploy.
- **Stream flash**: fix is code-reasoned and safe (retain-last-rows + sticky-scroll); not pixel-verified — the local headless harness was too unstable (Chrome OOM, dev issuer drift) to capture the sub-second flash reliably. See `apps/os/docs/headless-local-debugging.md`.

## Docs

`apps/os/docs/headless-local-debugging.md` — driving the full local OS+Auth stack headlessly (test OTP `424242`, signup allowlist, orgs/projects, OAuth/consent quirks, reading local D1, MutationObserver over throttled timers).

`pnpm typecheck && pnpm lint && pnpm test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication refresh semantics, WebSocket session behavior, and access-token lifetime—security-critical paths that affect all signed-in users and long-lived connections.
> 
> **Overview**
> Addresses three reliability issues on the OS/auth path: periodic session logout, JWT verification at deploy, and stream UI flicker.
> 
> **Auth session (~5‑minute logout):** Adds exported `createSingleFlight` and wraps refresh-token grants so concurrent requests sharing one cookie collapse to a single token call—avoiding rotated-token reuse that revokes the whole family. Cookie middleware skips refresh on WebSocket upgrades (no `Set-Cookie`), tolerates refresh failures while the access token is still valid, and extends access-token TTL from 5m to 30m on the auth provider.
> 
> **OS deploy:** `alchemy.run.ts` fetches issuer JWKS at deploy time into static config (loopback dev skips production JWKS; fetch failure falls back to runtime JWKS).
> 
> **Stream UI:** `project-stream-view` keeps last committed SQLite rows during virtualizer range re-queries and only auto-scrolls when the user is pinned near the bottom, reducing skeleton flashes on append.
> 
> Adds `headless-local-debugging.md`, README link, and unit tests for `createSingleFlight`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10682c43e5022fef9c39f55405bed1f423384950. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T05:22:42.108Z",
      "headSha": "10682c43e5022fef9c39f55405bed1f423384950",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27241670590",
      "shortSha": "10682c4"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `10682c4`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27241670590)
Updated: 2026-06-10T05:22:42.108Z
<!-- /CLOUDFLARE_PREVIEW -->