### PR TITLE
Fix: requireProject accepts prj_ project ids (prod hotfix)

### DIFF
--- a/apps/os/src/domains/projects/project-directory.ts
+++ b/apps/os/src/domains/projects/project-directory.ts
@@ -239,10 +239,13 @@ export async function requireProject(input: {
     throw new ORPCError("BAD_REQUEST", { message: "Project ID or slug is required" });
   }
 
-  const project =
-    projectIdOrSlug.startsWith("proj_") || isValidTypeId(projectIdOrSlug, "proj")
-      ? await getProjectById(input.context.db, { id: projectIdOrSlug })
-      : await getProjectBySlug(input.context.db, { slug: projectIdOrSlug });
+  // A project id may carry either prefix depending on who minted it: `proj_…`
+  // (OS typeid) OR `prj_…` (auth worker's generateId("prj"), adopted by OS's
+  // "create from auth scope" recovery flow). The old `startsWith("proj_")`-only
+  // check misclassified `prj_…` ids as slugs → "Project prj_… not found".
+  const project = isProjectId(projectIdOrSlug)
+    ? await getProjectById(input.context.db, { id: projectIdOrSlug })
+    : await getProjectBySlug(input.context.db, { slug: projectIdOrSlug });
 
   if (!project) {
     throw new ORPCError("NOT_FOUND", {
@@ -260,6 +263,13 @@ export async function requireProject(input: {
   throw new ORPCError("FORBIDDEN", {
     message: `Project ${projectIdOrSlug} not found`,
   });
+}
+
+// `proj_…` = OS typeid; `prj_…` = auth worker's generateId("prj"). Both are
+// real ids; anything else is a slug. (Duplicated from project-access.ts — the
+// follow-up PR moves id minting to auth and consolidates this into one helper.)
+function isProjectId(value: string) {
+  return value.startsWith("proj_") || value.startsWith("prj_");
 }
 
 function resolveProjectId(input: { id?: string; context: Pick<AppContext, "config"> }) {


### PR DESCRIPTION
## Problem

Prod returned **`Project prj_… not found`** for a project that demonstrably exists. `requireProject` (`apps/os/src/domains/projects/project-directory.ts`) decided id-vs-slug with:

```ts
projectIdOrSlug.startsWith("proj_") || isValidTypeId(projectIdOrSlug, "proj")
```

That only recognises OS typeids (`proj_…`). Project ids minted by the **auth worker** use `generateId("prj")` → `prj_…`. The "create from auth scope" recovery flow (one-click create after a prd db reset) adopts the auth worker's `prj_…` id, so any project created that way fell through to a **slug** lookup and 404'd.

## Fix

Recognise both prefixes as ids — same detector `project-access.ts` already uses (`resolveProjectBySlugOrId`).

## Follow-up (separate PR)

Make the **auth worker the sole minter** of project ids (OS adopts `prj_` and stops minting `proj_` typeids), and collapse the duplicated `isProjectId` helper into one shared export. Tracked separately so this stays a minimal, safe prod hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lookup fix in project resolution with no auth or data-model changes; duplicated helper noted for later cleanup.
> 
> **Overview**
> Fixes **`requireProject`** misrouting auth-minted **`prj_…`** ids as slugs, which caused **`Project prj_… not found`** in prod even when the row existed.
> 
> Id-vs-slug resolution now uses a local **`isProjectId`** helper that treats both **`proj_…`** (OS typeid) and **`prj_…`** (auth worker) as ids and loads by id; everything else still resolves by slug. This aligns with **`project-access.ts`**; consolidation into one shared helper is deferred to a follow-up PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c273816a05715c1a8900174ded3d858849f4fde4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->