### PR TITLE
Auth worker is the sole project-id minter; OS adopts prj_

### DIFF
--- a/apps/os/src/domains/projects/project-directory.ts
+++ b/apps/os/src/domains/projects/project-directory.ts
@@ -6,7 +6,6 @@
 
 import { RpcTarget } from "cloudflare:workers";
 import { ORPCError } from "@orpc/server";
-import { isValidTypeId, typeid } from "@iterate-com/shared/typeid";
 import { createAuthWorkerServiceClient } from "~/auth/auth-worker-service.ts";
 import type { AppContext } from "~/context.ts";
 import {
@@ -21,6 +20,7 @@ import {
   getProjectDurableObjectName,
   type ProjectDurableObject,
 } from "~/domains/projects/durable-objects/project-durable-object.ts";
+import { isProjectId, mintProjectId } from "~/domains/projects/project-id.ts";
 
 type ProjectRow = {
   id: string;
@@ -88,19 +88,46 @@ export class ProjectsCapability extends RpcTarget {
     organizationSlug?: string;
   }): Promise<ProjectWithIngressUrl> {
     const context = this.props.context;
+
+    // A user may pass `id` only to (re-)adopt a project they already own in
+    // auth — the "create from auth scope" recovery flow after a db reset
+    // replays their signed project claims. Any other id is refused.
     const authProject =
       context.principal?.type === "user" && input.id
         ? getAccessibleSignedProject({ context, projectId: input.id })
         : null;
-
     if (context.principal?.type === "user" && input.id && !authProject) {
       throw new ORPCError("FORBIDDEN", {
         message: `Project ${input.id} is not available to this user.`,
       });
     }
 
-    const id = authProject?.id ?? resolveProjectId({ id: input.id, context });
-    let slug = authProject?.slug ?? input.slug;
+    // Resolve the canonical (id, slug). The auth worker is the id authority:
+    // for a brand-new user project we let it mint (prj_…) and adopt what it
+    // returns, so OS never invents an id that could collide. OS mints only in
+    // the operator path, where there is no auth org to own the project.
+    let id: string;
+    let slug: string;
+    if (authProject) {
+      id = authProject.id;
+      slug = authProject.slug;
+    } else if (context.principal?.type === "user") {
+      const organizationSlug = resolveOrganizationSlugForCreate(context, input.organizationSlug);
+      const authWorker = createAuthWorkerServiceClient(context);
+      const createdAuthProject = await authWorker.internal.project.createForOrganization({
+        organizationSlug,
+        name: input.slug,
+        slug: input.slug,
+      });
+      id = createdAuthProject.id;
+      slug = createdAuthProject.slug;
+    } else {
+      id = resolveOperatorProjectId(input.id);
+      slug = input.slug;
+    }
+
+    // Idempotent on id: re-adoption or a retried operator create returns the
+    // existing row rather than failing.
     const existingById = await getProjectById(context.db, { id });
     if (existingById) {
       if (existingById.slug !== slug) {
@@ -109,24 +136,6 @@ export class ProjectsCapability extends RpcTarget {
         });
       }
       return await toProjectWithIngressUrl(context, existingById);
-    }
-
-    if (context.principal?.type === "user" && !authProject) {
-      const organizationSlug = resolveOrganizationSlugForCreate(context, input.organizationSlug);
-      const authWorker = createAuthWorkerServiceClient(context);
-      const createdAuthProject = await authWorker.internal.project.createForOrganization({
-        id,
-        organizationSlug,
-        name: slug,
-        slug,
-        metadata: { osProjectId: id },
-      });
-      if (createdAuthProject.id !== id) {
-        throw new Error(
-          `Auth project creation returned ${createdAuthProject.id} instead of requested ${id}.`,
-        );
-      }
-      slug = createdAuthProject.slug;
     }
 
     const existing = await getProjectBySlug(context.db, { slug });
@@ -239,10 +248,8 @@ export async function requireProject(input: {
     throw new ORPCError("BAD_REQUEST", { message: "Project ID or slug is required" });
   }
 
-  // A project id may carry either prefix depending on who minted it: `proj_…`
-  // (OS typeid) OR `prj_…` (auth worker's generateId("prj"), adopted by OS's
-  // "create from auth scope" recovery flow). The old `startsWith("proj_")`-only
-  // check misclassified `prj_…` ids as slugs → "Project prj_… not found".
+  // isProjectId recognises both the canonical `prj_` and legacy `proj_`
+  // prefixes; anything else is treated as a slug. Shared so this can't drift.
   const project = isProjectId(projectIdOrSlug)
     ? await getProjectById(input.context.db, { id: projectIdOrSlug })
     : await getProjectBySlug(input.context.db, { slug: projectIdOrSlug });
@@ -265,27 +272,19 @@ export async function requireProject(input: {
   });
 }
 
-// `proj_…` = OS typeid; `prj_…` = auth worker's generateId("prj"). Both are
-// real ids; anything else is a slug. (Duplicated from project-access.ts — the
-// follow-up PR moves id minting to auth and consolidates this into one helper.)
-function isProjectId(value: string) {
-  return value.startsWith("proj_") || value.startsWith("prj_");
-}
-
-function resolveProjectId(input: { id?: string; context: Pick<AppContext, "config"> }) {
-  if (input.id) {
-    if (!isValidTypeId(input.id, "proj")) {
-      throw new ORPCError("BAD_REQUEST", {
-        message: "Project ID must be a valid TypeID with prefix proj.",
-      });
-    }
-    return input.id;
+// Operator/admin create has no auth organization to own the project, so OS
+// mints the id itself — using auth's `prj_` format so there's one id space. A
+// caller-supplied id must already be a project id (we never coin a new prefix).
+function resolveOperatorProjectId(id: string | undefined): string {
+  if (id === undefined) {
+    return mintProjectId();
   }
-
-  return typeid({
-    env: { TYPEID_PREFIX: input.context.config.typeIdPrefix },
-    prefix: "proj",
-  });
+  if (!isProjectId(id)) {
+    throw new ORPCError("BAD_REQUEST", {
+      message: "Project ID must start with prj_ (or legacy proj_).",
+    });
+  }
+  return id;
 }
 
 function projectDurableObject(context: AppContext, projectId: string) {

--- a/apps/os/src/domains/projects/project-id.ts
+++ b/apps/os/src/domains/projects/project-id.ts
@@ -1,0 +1,35 @@
+// One home for "what is a project id, and who is allowed to mint one".
+//
+// The **auth worker is the canonical minter** of project ids: every project
+// lives in an organization there, and minting in one place is what keeps the
+// id space free of collisions. Auth mints with `generateId("prj")` →
+// `prj_<uuid>` (see apps/auth .../routers/_shared.ts).
+//
+// OS only mints in the operator/recovery path, where there is no auth
+// organization to own the project (admin-created projects). It uses the SAME
+// `prj_` prefix and format so there is a single id space — never a second
+// `proj_` typeid namespace that resolvers then have to special-case.
+//
+// `proj_` is the LEGACY OS-typeid prefix. We no longer mint it, but older rows
+// may still carry it, so `isProjectId` keeps recognising it.
+
+export const PROJECT_ID_PREFIX = "prj";
+
+/**
+ * Mint a project id in the auth worker's format. Use ONLY where OS legitimately
+ * owns minting (operator/admin create with no auth org). For normal user
+ * creates, let the auth worker mint and adopt the id it returns.
+ */
+export function mintProjectId(): string {
+  return `${PROJECT_ID_PREFIX}_${crypto.randomUUID().replace(/-/g, "")}`;
+}
+
+/**
+ * True when `value` is a project id rather than a slug. `prj_` is the canonical
+ * auth-minted prefix; `proj_` is the legacy OS typeid still present on old rows.
+ * Shared by every slug-or-id resolver so they can't drift (the drift is exactly
+ * what produced the "Project prj_… not found" prod bug).
+ */
+export function isProjectId(value: string): boolean {
+  return value.startsWith("prj_") || value.startsWith("proj_");
+}

--- a/apps/os/src/orpc/project-access.ts
+++ b/apps/os/src/orpc/project-access.ts
@@ -1,6 +1,7 @@
 import { ORPCError } from "@orpc/server";
 import type { AppContext } from "~/context.ts";
 import { getProjectById, getProjectBySlug } from "~/db/queries/.generated/index.ts";
+import { isProjectId } from "~/domains/projects/project-id.ts";
 
 /**
  * Confirms a caller can access an ownerless project before exposing
@@ -105,8 +106,4 @@ async function resolveProjectBySlugOrId(input: { context: AppContext; projectSlu
   }
 
   return project;
-}
-
-function isProjectId(value: string) {
-  return value.startsWith("proj_") || value.startsWith("prj_");
 }


### PR DESCRIPTION
The proper follow-up to the #1412 hotfix. That hotfix taught resolvers to accept `prj_` ids; this removes the root cause — **two minters, two prefixes** — so the id space can't drift again.

## Background

Two places minted project ids with different prefixes:

| Minter | Prefix | Via |
| --- | --- | --- |
| auth worker | `prj_…` | `generateId("prj")` |
| OS | `proj_…` | typeid `proj` |

OS would mint a `proj_` id and ask auth to honour it. But the **"create from auth scope" recovery flow** (one-click create after a prd db reset) adopts the auth-minted `prj_…` id — and one OS resolver classified `prj_` as a *slug*, producing `Project prj_… not found`.

## Change: auth is the id authority

`ProjectsCapability.create` now resolves the id by who owns the project:

```ts
if (authProject) {
  // Recovery / re-adopt: the user already owns this prj_ id in auth.
  ({ id, slug } = authProject);
} else if (context.principal?.type === "user") {
  // New user project: auth mints the canonical id, OS adopts it.
  const created = await authWorker.internal.project.createForOrganization({
    organizationSlug, name: input.slug, slug: input.slug,
  });            // <-- no `id` passed; auth returns prj_…
  ({ id, slug } = created);
} else {
  // Operator/admin: no auth org owns it, so OS mints — but with auth's
  // prj_ format, not a second proj_ namespace.
  id = resolveOperatorProjectId(input.id);
  slug = input.slug;
}
```

The contract already anticipated this — `createForOrganization.id` is optional and documented as *"If omitted, auth generates a prj_* ID."* OS simply stops passing it.

## One id space, one helper

New `apps/os/src/domains/projects/project-id.ts`:

```ts
export function mintProjectId() {            // operator/recovery only
  return `prj_${crypto.randomUUID().replace(/-/g, "")}`;   // auth's format
}
export function isProjectId(value: string) { // prj_ canonical, proj_ legacy
  return value.startsWith("prj_") || value.startsWith("proj_");
}
```

`isProjectId` now has exactly one definition, used by both `requireProject` (`project-directory.ts`) and `resolveProjectBySlugOrId` (`project-access.ts`). The duplicated copies (and the `proj_` typeid minting + its `isValidTypeId`/`typeid` imports) are gone.

## Things that are now possible / safer

- **No id collisions** — a single minter owns the namespace.
- **No prefix drift** — every slug-or-id resolver shares one `isProjectId`; adding a resolver can't reintroduce the bug.
- **Legacy rows still resolve** — `proj_…` ids created before this change keep working (`isProjectId` recognises both).

## Notes

- Dropped the write-only `metadata: { osProjectId: id }` (never read).
- `apps/auth` keeps honouring a caller-supplied `id` for other callers (e.g. the public `project.create`); OS just no longer relies on it.

✅ `pnpm typecheck`, `pnpm lint`, `pnpm format` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core project creation and id resolution paths that affect every dashboard create and slug/id lookup; legacy `proj_` rows remain supported via shared `isProjectId`.
> 
> **Overview**
> Makes the **auth worker the sole authority** for minting user project ids (`prj_…`), so OS stops pre-minting `proj_` typeids and adopting mismatched ids.
> 
> **`ProjectsCapability.create`** now branches on principal: recovery re-adopts the user’s existing auth project; **user creates** call `createForOrganization` **without** an `id` and adopt the returned `prj_` id/slug; **operator/admin** paths mint via `mintProjectId()` in the same `prj_` format (or validate a supplied id). The old flow that minted OS ids, passed them to auth, and enforced `createdAuthProject.id === id` is removed, along with unused `metadata: { osProjectId }`.
> 
> Adds **`project-id.ts`** with shared **`isProjectId`** (`prj_` + legacy `proj_`) and **`mintProjectId`**, wired into **`requireProject`** and **`project-access`** so slug-vs-id resolution can’t drift again. Operator minting drops typeid/`proj_` validation in favor of `resolveOperatorProjectId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 998f142e7082803c0b592e5430299a10dd6abc3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T06:07:05.369Z",
      "headSha": "998f142e7082803c0b592e5430299a10dd6abc3a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27256528108",
      "shortSha": "998f142"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `998f142`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27256528108)
Updated: 2026-06-10T06:07:05.369Z
<!-- /CLOUDFLARE_PREVIEW -->