### PR TITLE
Fix itx project REPL connect 404 on prj_ project ids

### DIFF
--- a/apps/os/src/itx/fetch.ts
+++ b/apps/os/src/itx/fetch.ts
@@ -25,6 +25,7 @@ import type { AppContext } from "~/context.ts";
 import { createOsIterateAuth, resolveRequestAuth } from "~/auth/middleware.ts";
 import type { Principal } from "~/auth/principal.ts";
 import { getProjectById, getProjectBySlug } from "~/db/queries/.generated/index.ts";
+import { isProjectId } from "~/domains/projects/project-id.ts";
 
 export const ITX_PREFIX = "/api/itx";
 
@@ -162,7 +163,11 @@ async function resolveAccessibleContextId(input: {
     }
   }
 
-  const row = input.idOrSlug.startsWith("proj_")
+  // Classify by prefix: auth mints the canonical "prj_" id, "proj_" is the
+  // legacy OS typeid prefix, anything else is a slug. Treating a "prj_" id as a
+  // slug is what 404'd the project REPL connect — the global REPL hits the
+  // bare-prefix branch above and so was never affected.
+  const row = isProjectId(input.idOrSlug)
     ? await getProjectById(input.context.db, { id: input.idOrSlug })
     : await getProjectBySlug(input.context.db, { slug: input.idOrSlug });
   if (!row) return null;

--- a/apps/os/src/itx/handle.ts
+++ b/apps/os/src/itx/handle.ts
@@ -44,6 +44,7 @@ import {
   getProjectDurableObjectName,
   type ProjectDurableObject,
 } from "~/domains/projects/durable-objects/project-durable-object.ts";
+import { isProjectId, mintProjectId } from "~/domains/projects/project-id.ts";
 import { getStreamsCapability } from "~/domains/streams/entrypoints/streams-capability.ts";
 import { getReposCapability } from "~/domains/repos/entrypoints/repo-capability.ts";
 
@@ -502,12 +503,14 @@ export class ItxProjects extends RpcTarget {
   async create(input: { id?: string; slug: string }) {
     this.requireAllAccess("create projects");
     const db = this.db();
-    const id =
-      input.id ??
-      typeid({
-        env: { TYPEID_PREFIX: this.runtime.config.typeIdPrefix },
-        prefix: "proj",
-      });
+    // Auth is the canonical id minter ("prj_"); this admin-only path mints in
+    // the same format only for the operator/recovery case where there is no
+    // auth org to own the project. A supplied id must already be a project id
+    // (legacy "proj_" still accepted), never a slug.
+    if (input.id !== undefined && !isProjectId(input.id)) {
+      throw new Error("Project ID must start with prj_ (or legacy proj_).");
+    }
+    const id = input.id ?? mintProjectId();
 
     const existingById = await getProjectById(db, { id });
     if (existingById) {
@@ -544,7 +547,7 @@ export class ItxProjects extends RpcTarget {
 
   private async requireProjectRow(projectIdOrSlug: string) {
     const db = this.db();
-    const row = projectIdOrSlug.startsWith("proj_")
+    const row = isProjectId(projectIdOrSlug)
       ? await getProjectById(db, { id: projectIdOrSlug })
       : await getProjectBySlug(db, { slug: projectIdOrSlug });
     if (!row) throw new Error(`Project ${projectIdOrSlug} not found.`);


### PR DESCRIPTION
## The bug

`https://os.iterate.com/projects/iterate/repl` failed with **WebSocket connection failed**, while `https://os.iterate.com/itx-repl` worked.

## Root cause

The project REPL connects to `/api/itx/<project-id>`. In `resolveAccessibleContextId` (and the itx handle's `requireProjectRow`), the id-vs-slug classification only recognized the legacy `proj_` prefix:

```ts
const row = idOrSlug.startsWith("proj_")
  ? getProjectById(...)      // only proj_ treated as id
  : getProjectBySlug(...);   // prj_… falls here → slug miss → null → 404
```

The recreated `iterate` project has an **auth-minted `prj_…` id**, so the connect resolved to a slug lookup, missed, returned 404, and the WebSocket upgrade failed. The global REPL hits the bare-prefix branch (`subpath === ""`) and never classifies an id, which is why it worked.

This is the same prefix-drift class of bug fixed for the oRPC project flows in the auth-mints-ids cleanup (#1412/#1413) — these two itx call sites were just not on that path.

## Fix

- Route both classifications (`fetch.ts` connect/run resolver and `handle.ts` `requireProjectRow`) through the shared `isProjectId` helper from `domains/projects/project-id.ts`, so `prj_` and legacy `proj_` both resolve.
- Switch the itx handle's admin-only `create()` off the legacy `proj_` typeid minter to `mintProjectId()` (`prj_`), matching the now-canonical id format everywhere else (the `ctx_` child-context typeid is unchanged).

`pnpm typecheck`, `pnpm lint`, `pnpm format` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth-boundary project resolution for itx WebSocket connect and run; behavior change is narrow (correct id classification) but affects all project-scoped itx entrypoints.
> 
> **Overview**
> Fixes **project REPL WebSocket 404s** when connecting with auth-minted **`prj_…` ids** by routing itx project resolution through shared **`isProjectId`** instead of only treating **`proj_`** as an id (so **`prj_`** was misclassified as a slug).
> 
> **`resolveAccessibleContextId`** in `fetch.ts` and **`requireProjectRow`** in `handle.ts` now use that helper for id-vs-slug lookup on `/api/itx/:projectIdOrSlug` and run scripts. Admin-only **`projects.create()`** mints **`prj_`** via **`mintProjectId()`** (replacing legacy **`proj_` typeid**), validates optional **`input.id`** with **`isProjectId`**, and drops the old typeid minter import for projects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12e69c5efd5b1c5fe3ee22b1278c4210fd7b59fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->