### PR TITLE
Stream views: pretty feed, raw filter, state panel; fix splat links

### DIFF
--- a/apps/os/src/components/path-breadcrumbs.tsx
+++ b/apps/os/src/components/path-breadcrumbs.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useMemo, useState } from "react";
 import { Link, useMatches, useNavigate } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
+import { CheckIcon, ChevronDownIcon } from "lucide-react";
 import type { StreamPath as StreamPathType } from "@iterate-com/shared/streams/types";
 import {
   Breadcrumb,
@@ -20,7 +21,7 @@ import type {
   RouteBreadcrumbLoaderData,
   RouteBreadcrumbStaticData,
 } from "~/lib/route-breadcrumbs.ts";
-import { streamPathAncestors, streamPathChild } from "~/lib/stream-links.ts";
+import { streamPathAncestors, streamPathChild, streamPathParent } from "~/lib/stream-links.ts";
 
 const CHILD_STREAM_SEGMENT_PATTERN = /^[a-z0-9_-]+$/;
 
@@ -87,9 +88,17 @@ export function PathBreadcrumbs() {
         {parentCrumbs.map((crumb) => (
           <Fragment key={crumb.id}>
             <BreadcrumbItem className="hidden md:inline-flex">
-              <BreadcrumbLink render={renderCrumbLink({ crumb, streamBreadcrumb })}>
-                <BreadcrumbLabel crumb={crumb} />
-              </BreadcrumbLink>
+              {crumb.streamPath != null && crumb.streamPath !== "/" && streamBreadcrumb ? (
+                <StreamSegmentNavigator
+                  label={crumb.label}
+                  segmentPath={crumb.streamPath}
+                  streamBreadcrumb={streamBreadcrumb}
+                />
+              ) : (
+                <BreadcrumbLink render={renderCrumbLink({ crumb, streamBreadcrumb })}>
+                  <BreadcrumbLabel crumb={crumb} />
+                </BreadcrumbLink>
+              )}
             </BreadcrumbItem>
             <BreadcrumbSeparator className="hidden md:block" />
           </Fragment>
@@ -105,9 +114,20 @@ export function PathBreadcrumbs() {
         )}
 
         <BreadcrumbItem>
-          <BreadcrumbPage className="max-w-[16rem] truncate">
-            <BreadcrumbLabel crumb={lastCrumb} />
-          </BreadcrumbPage>
+          {lastCrumb.streamPath != null && lastCrumb.streamPath !== "/" && streamBreadcrumb ? (
+            <BreadcrumbPage className="max-w-[16rem]">
+              <StreamSegmentNavigator
+                isCurrent
+                label={lastCrumb.label}
+                segmentPath={lastCrumb.streamPath}
+                streamBreadcrumb={streamBreadcrumb}
+              />
+            </BreadcrumbPage>
+          ) : (
+            <BreadcrumbPage className="max-w-[16rem] truncate">
+              <BreadcrumbLabel crumb={lastCrumb} />
+            </BreadcrumbPage>
+          )}
         </BreadcrumbItem>
         {streamBreadcrumb ? <StreamChildrenBreadcrumb streamBreadcrumb={streamBreadcrumb} /> : null}
       </BreadcrumbList>
@@ -140,6 +160,77 @@ function renderCrumbLink({
   }
 
   return <Link to={crumb.to ?? "/"} />;
+}
+
+/**
+ * Breadcrumb segment for one level of a stream path. Opens a popover listing
+ * the sibling streams at that depth, so any segment can be swapped without
+ * walking back up through the streams index.
+ */
+function StreamSegmentNavigator({
+  isCurrent = false,
+  label,
+  segmentPath,
+  streamBreadcrumb,
+}: {
+  isCurrent?: boolean;
+  label: string;
+  segmentPath: StreamPathType;
+  streamBreadcrumb: NonNullable<RouteBreadcrumbLoaderData["streamBreadcrumb"]>;
+}) {
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const streamsQuery = useQuery(projectStreamsListQueryOptions(streamBreadcrumb.projectId));
+  const siblingPaths = useMemo(() => {
+    const parentPath = streamPathParent(segmentPath);
+    const paths = (streamsQuery.data?.streams ?? [])
+      .map((stream) => stream.streamPath)
+      .filter((path) => isImmediateChild({ childPath: path, parentPath }));
+    if (!paths.includes(segmentPath)) paths.push(segmentPath);
+    return paths.toSorted((left, right) => left.localeCompare(right));
+  }, [segmentPath, streamsQuery.data?.streams]);
+
+  function navigateToSibling(path: StreamPathType) {
+    setOpen(false);
+    if (path === segmentPath && isCurrent) return;
+    void navigate({
+      to: "/projects/$projectSlug/streams/$",
+      params: {
+        projectSlug: streamBreadcrumb.projectSlug,
+        _splat: path,
+      },
+    });
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        className={`flex min-w-0 items-center gap-0.5 rounded-sm font-mono text-sm transition-colors ${
+          isCurrent ? "text-foreground" : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        <span className="min-w-0 truncate">{label}</span>
+        <ChevronDownIcon aria-hidden="true" className="size-3 shrink-0 opacity-50" />
+      </PopoverTrigger>
+      <PopoverContent align="start" sideOffset={8} className="w-64 gap-0 p-0">
+        <div className="max-h-64 overflow-y-auto p-1">
+          {siblingPaths.map((path) => (
+            <button
+              key={path}
+              type="button"
+              className="flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left font-mono text-xs outline-hidden select-none hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground"
+              onClick={() => navigateToSibling(path)}
+            >
+              <span className="min-w-0 truncate">/{getStreamSegmentLabel(path)}</span>
+              {path === segmentPath ? (
+                <CheckIcon aria-hidden="true" className="size-3.5 shrink-0" />
+              ) : null}
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
 }
 
 function StreamChildrenBreadcrumb({

--- a/apps/os/src/components/project-stream-view.lazy.tsx
+++ b/apps/os/src/components/project-stream-view.lazy.tsx
@@ -1,0 +1,28 @@
+import { Suspense, lazy, type ComponentProps } from "react";
+
+type ProjectStreamViewComponent = typeof import("./project-stream-view.tsx").ProjectStreamView;
+
+// Keep the stream view (CodeMirror, ai-elements feed, streams browser runtime)
+// out of the server bundle: the worker script has a 10 MiB upload limit and
+// the stream routes are ssr:false, so the server never renders it anyway.
+const LazyProjectStreamView = lazy(async () => {
+  if (import.meta.env.SSR) {
+    return { default: (() => null) as unknown as ProjectStreamViewComponent };
+  }
+  const module = await import("./project-stream-view.tsx");
+  return { default: module.ProjectStreamView };
+});
+
+export function ProjectStreamView(props: ComponentProps<ProjectStreamViewComponent>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="grid min-h-0 flex-1 place-items-center p-6 text-sm text-muted-foreground">
+          Loading stream view
+        </div>
+      }
+    >
+      <LazyProjectStreamView {...props} />
+    </Suspense>
+  );
+}

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -128,10 +128,19 @@ export function ProjectStreamView({
   const [rawText, setRawText] = useState(DEFAULT_RAW_EVENT_YAML);
   const [submitError, setSubmitError] = useState<string | undefined>();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  // Only auto-scroll the raw view to the bottom when the viewport is already
+  // pinned there. Yanking a scrolled-up reader back to the bottom on every
+  // append shifts the virtualized window far enough that the whole visible
+  // range re-queries and flashes grey skeletons before SQLite returns the new
+  // rows. Lives here (not in the raw view) so the composer can re-pin it.
+  const rawStickToBottomRef = useRef(true);
 
   async function runSubmit(action: () => Promise<void>) {
     setIsSubmitting(true);
     setSubmitError(undefined);
+    // The user just appended from the composer at the bottom, so follow the
+    // new event down even if they had scrolled up earlier.
+    rawStickToBottomRef.current = true;
     try {
       await action();
     } catch (error) {
@@ -199,7 +208,11 @@ export function ProjectStreamView({
           reductionKey={`${projectSlugOrId}:${streamPathText}`}
         />
       ) : activeTab === "raw" ? (
-        <ProjectStreamRawView database={store.streamDatabase} emptyLabel={connectionLabel} />
+        <ProjectStreamRawView
+          database={store.streamDatabase}
+          emptyLabel={connectionLabel}
+          stickToBottomRef={rawStickToBottomRef}
+        />
       ) : (
         <ProjectStreamStateView store={store} />
       )}
@@ -420,9 +433,11 @@ const ALL_EVENT_TYPES = "__all__";
 function ProjectStreamRawView({
   database,
   emptyLabel,
+  stickToBottomRef,
 }: {
   database: StreamBrowserDatabase;
   emptyLabel: string;
+  stickToBottomRef: RefObject<boolean>;
 }) {
   const [eventTypeFilter, setEventTypeFilter] = useState<string>(ALL_EVENT_TYPES);
   const typeFilter = eventTypeFilter === ALL_EVENT_TYPES ? null : eventTypeFilter;
@@ -440,11 +455,6 @@ function ProjectStreamRawView({
   const eventCount = Number(countResult.data[0]?.count ?? 0);
   const [expandedOffsets, setExpandedOffsets] = useState<ReadonlySet<number>>(new Set());
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  // Only auto-scroll to the bottom when the viewport is already pinned there.
-  // Yanking a scrolled-up reader back to the bottom on every append shifts the
-  // virtualized window far enough that the whole visible range re-queries and
-  // flashes grey skeletons before SQLite returns the new rows.
-  const stickToBottomRef = useRef(true);
 
   useLayoutEffect(() => {
     if (!stickToBottomRef.current) return;

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -467,7 +467,7 @@ function ProjectStreamRawView({
     return () => {
       window.cancelAnimationFrame(frame);
     };
-  }, [eventCount]);
+  }, [eventCount, stickToBottomRef]);
 
   function toggleOffset(offset: number) {
     setExpandedOffsets((previous) => {

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -1,20 +1,24 @@
 import {
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
   useState,
   useSyncExternalStore,
-  type RefObject,
   type ReactNode,
+  type RefObject,
 } from "react";
+import { Link } from "@tanstack/react-router";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { Spinner } from "@iterate-com/ui/components/spinner";
 import {
   acquireStreamRuntime,
   type StreamBrowserSnapshot,
+  type StreamBrowserStore,
+  type StreamRuntimeState,
 } from "@iterate-com/streams/browser/stream-browser-store";
 import { useStreamQuery } from "@iterate-com/streams/browser/hooks/use-stream-query";
 import type {
+  SqliteQueryStatus,
   StreamBrowserDatabase,
   StreamEventRow,
 } from "@iterate-com/streams/browser/stream-browser-db";
@@ -26,7 +30,33 @@ import {
   type BrowserRawEventsState,
 } from "@iterate-com/streams/processors/browser-raw-events/implementation";
 import { StreamEventInput } from "@iterate-com/streams/shared/event";
-import type { StreamPath } from "@iterate-com/shared/streams/types";
+import {
+  getInitialProcessorState,
+  runProcessorReduce,
+  type StreamEvent,
+} from "@iterate-com/streams/shared/stream-processors";
+import type { Event, StreamPath } from "@iterate-com/shared/streams/types";
+import { SerializedObjectCodeBlock } from "@iterate-com/ui/components/serialized-object-code-block";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@iterate-com/ui/components/select";
+import { Tabs, TabsList, TabsTrigger } from "@iterate-com/ui/components/tabs";
+import type { EventsStreamViewState } from "@iterate-com/ui/components/events/feed-items";
+import {
+  EventsStreamComposer,
+  type EventsStreamComposerMode,
+} from "@iterate-com/ui/components/events/stream-composer";
+import {
+  EventsStreamView,
+  type EventsStreamElementType,
+  type EventsStreamRendererMode,
+} from "@iterate-com/ui/components/events/stream-feed";
+import { EventsStreamLayoutMessageInput } from "@iterate-com/ui/components/events/stream-layout";
+import { StreamViewProcessorContract } from "@iterate-com/ui/components/events/stream-view-processor/contract";
 import { parse as parseYaml } from "yaml";
 
 type ProjectStreamMessageComposer = {
@@ -34,11 +64,17 @@ type ProjectStreamMessageComposer = {
   onSubmit: (message: string) => Promise<void>;
 };
 
+type ProjectStreamViewTab = "feed" | "raw" | "state";
+
+const DEFAULT_RAW_EVENT_YAML =
+  "type: events.iterate.com/os/manual-event\npayload:\n  message: Hello from OS\n";
+
 export function ProjectStreamView({
   defaultComposerMode,
   emptyLabel = "No events in this stream yet.",
   headerAccessory,
   messageComposer,
+  projectSlug,
   projectSlugOrId,
   streamPath,
 }: {
@@ -83,59 +119,338 @@ export function ProjectStreamView({
   );
   const countResult = useStreamQuery(store.streamDatabase, `SELECT COUNT(*) AS count FROM events`);
   const eventCount = Number(countResult.data[0]?.count ?? 0);
-  const composerMode = defaultComposerMode ?? (messageComposer ? "message" : "raw");
-  const [composerText, setComposerText] = useState(
-    composerMode === "raw"
-      ? "type: events.iterate.com/os/manual-event\npayload:\n  message: Hello from OS\n"
-      : "",
+
+  const [activeTab, setActiveTab] = useState<ProjectStreamViewTab>("feed");
+  const [composerMode, setComposerMode] = useState<EventsStreamComposerMode>(
+    defaultComposerMode ?? (messageComposer ? "message" : "raw"),
   );
+  const [messageText, setMessageText] = useState("");
+  const [rawText, setRawText] = useState(DEFAULT_RAW_EVENT_YAML);
   const [submitError, setSubmitError] = useState<string | undefined>();
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function runSubmit(action: () => Promise<void>) {
+    setIsSubmitting(true);
+    setSubmitError(undefined);
+    try {
+      await action();
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function submitMessage() {
+    const trimmed = messageText.trim();
+    if (!trimmed || messageComposer == null) return;
+    await runSubmit(async () => {
+      await messageComposer.onSubmit(trimmed);
+      setMessageText("");
+    });
+  }
+
+  async function submitRawEvents() {
+    const trimmed = rawText.trim();
+    if (!trimmed) return;
+    await runSubmit(async () => {
+      const parsed = parseYaml(trimmed) as unknown;
+      const events = (Array.isArray(parsed) ? parsed : [parsed]).map((event) =>
+        StreamEventInput.parse(event),
+      );
+      await store.appendBatch({ events });
+    });
+  }
+
+  const connectionLabel =
+    snapshot.connectionError ??
+    (snapshot.connectionStatus === "subscribed" ? emptyLabel : snapshot.connectionStatus);
+
+  return (
+    <section className="flex min-h-0 flex-1 flex-col bg-background">
+      <header className="flex shrink-0 flex-wrap items-center justify-between gap-x-4 gap-y-2 border-b px-4 py-2">
+        <div className="min-w-0">
+          <h1 className="truncate font-mono text-sm font-semibold">{streamPathText}</h1>
+          <StreamStatus count={eventCount} snapshot={snapshot} />
+        </div>
+        <Tabs
+          value={activeTab}
+          onValueChange={(value) => setActiveTab(value as ProjectStreamViewTab)}
+        >
+          <TabsList className="h-8">
+            <TabsTrigger value="feed" className="px-3 text-xs">
+              Feed
+            </TabsTrigger>
+            <TabsTrigger value="raw" className="px-3 text-xs">
+              Raw
+            </TabsTrigger>
+            <TabsTrigger value="state" className="px-3 text-xs">
+              State
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </header>
+      {headerAccessory == null ? null : <div className="shrink-0 border-b">{headerAccessory}</div>}
+      {activeTab === "feed" ? (
+        <ProjectStreamFeedView
+          database={store.streamDatabase}
+          emptyLabel={connectionLabel}
+          projectSlug={projectSlug}
+          reductionKey={`${projectSlugOrId}:${streamPathText}`}
+        />
+      ) : activeTab === "raw" ? (
+        <ProjectStreamRawView database={store.streamDatabase} emptyLabel={connectionLabel} />
+      ) : (
+        <ProjectStreamStateView store={store} />
+      )}
+      {activeTab === "state" ? null : (
+        <EventsStreamLayoutMessageInput className="px-3 py-3">
+          {submitError == null ? null : (
+            <p className="mb-2 truncate font-mono text-xs text-destructive" role="alert">
+              {submitError}
+            </p>
+          )}
+          <EventsStreamComposer
+            mode={composerMode}
+            onModeChange={setComposerMode}
+            {...(messageComposer == null
+              ? {}
+              : {
+                  message: {
+                    value: messageText,
+                    onValueChange: setMessageText,
+                    onSubmit: submitMessage,
+                    ...(messageComposer.placeholder == null
+                      ? {}
+                      : { placeholder: messageComposer.placeholder }),
+                  },
+                })}
+            raw={{
+              value: rawText,
+              onValueChange: setRawText,
+              onSubmit: submitRawEvents,
+            }}
+            isSubmitting={isSubmitting}
+          />
+        </EventsStreamLayoutMessageInput>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Feed view: semantic chat-style elements reduced from raw events
+// ---------------------------------------------------------------------------
+
+function ProjectStreamFeedView({
+  database,
+  emptyLabel,
+  projectSlug,
+  reductionKey,
+}: {
+  database: StreamBrowserDatabase;
+  emptyLabel: string;
+  projectSlug: string;
+  reductionKey: string;
+}) {
+  const feed = useStreamFeedState({ database, reductionKey });
+  const [rendererMode, setRendererMode] = useState<EventsStreamRendererMode>("raw-pretty");
+  const [hiddenElementTypes, setHiddenElementTypes] = useState<EventsStreamElementType[]>([]);
+  const [openEventOffset, setOpenEventOffset] = useState<number | undefined>(undefined);
+
+  const displayState = useMemo(
+    () => applyRendererMode({ viewState: feed.viewState, events: feed.events, rendererMode }),
+    [feed.viewState, feed.events, rendererMode],
+  );
+
+  return (
+    <EventsStreamView
+      className="min-h-0 flex-1"
+      viewState={displayState}
+      events={feed.events}
+      emptyLabel={emptyLabel}
+      isPending={feed.status === "pending" && feed.events.length === 0}
+      {...(feed.error == null ? {} : { errorLabel: feed.error })}
+      {...(openEventOffset == null ? {} : { openEventOffset })}
+      onOpenEventOffsetChange={setOpenEventOffset}
+      hiddenElementTypes={hiddenElementTypes}
+      onHiddenElementTypesChange={setHiddenElementTypes}
+      rendererMode={rendererMode}
+      onRendererModeChange={setRendererMode}
+      renderStreamPathLink={({ path, children, className }) => (
+        <Link
+          to="/projects/$projectSlug/streams/$"
+          params={{ projectSlug, _splat: path }}
+          {...(className == null ? {} : { className })}
+        >
+          {children}
+        </Link>
+      )}
+    />
+  );
+}
+
+type StreamFeedReduction = {
+  status: SqliteQueryStatus;
+  error?: string;
+  viewState: EventsStreamViewState;
+  events: Event[];
+};
+
+type StreamFeedReductionCache = {
+  key: string;
+  rowCount: number;
+  lastOffset: number;
+  viewState: EventsStreamViewState;
+  events: Event[];
+};
+
+/**
+ * Reduce the SQLite raw-event mirror into renderable stream view state.
+ *
+ * The reduction is incremental: appends only reduce the new tail rows on top
+ * of the cached state, so live streams don't replay the whole history on every
+ * event. Any non-append change (clear, reset, truncation) recomputes from
+ * scratch.
+ */
+function useStreamFeedState(args: {
+  database: StreamBrowserDatabase;
+  reductionKey: string;
+}): StreamFeedReduction {
+  const rowsResult = useStreamQuery(
+    args.database,
+    `SELECT offset, json(raw_jsonb) AS raw_json FROM events ORDER BY local_index ASC`,
+  );
+  const cacheRef = useRef<StreamFeedReductionCache | null>(null);
+
+  return useMemo(() => {
+    const cached = cacheRef.current?.key === args.reductionKey ? cacheRef.current : null;
+
+    if (rowsResult.status !== "ok") {
+      return {
+        status: rowsResult.status,
+        ...(rowsResult.error == null ? {} : { error: rowsResult.error.message }),
+        viewState: cached?.viewState ?? initialStreamViewState(),
+        events: cached?.events ?? [],
+      };
+    }
+
+    const rows = rowsResult.data;
+    const canExtend =
+      cached != null &&
+      rows.length >= cached.rowCount &&
+      (cached.rowCount === 0 || Number(rows[cached.rowCount - 1]?.offset) === cached.lastOffset);
+
+    const startIndex = canExtend ? cached.rowCount : 0;
+    let viewState = canExtend ? cached.viewState : initialStreamViewState();
+    const events = canExtend ? [...cached.events] : [];
+
+    for (let index = startIndex; index < rows.length; index++) {
+      const rawJson = rows[index]?.raw_json;
+      if (typeof rawJson !== "string") continue;
+      let event: Event;
+      try {
+        event = JSON.parse(rawJson) as Event;
+      } catch {
+        continue;
+      }
+      events.push(event);
+      const reduction = runProcessorReduce({
+        processor: { contract: StreamViewProcessorContract },
+        event: event as unknown as StreamEvent,
+        state: viewState,
+      });
+      viewState = reduction?.state ?? viewState;
+    }
+
+    cacheRef.current = {
+      key: args.reductionKey,
+      rowCount: rows.length,
+      lastOffset: events.length === 0 ? -1 : events[events.length - 1]!.offset,
+      viewState,
+      events,
+    };
+
+    return { status: "ok", viewState, events };
+  }, [rowsResult, args.reductionKey]);
+}
+
+function initialStreamViewState(): EventsStreamViewState {
+  return getInitialProcessorState(StreamViewProcessorContract);
+}
+
+/**
+ * The reducer always produces both raw groups and semantic elements; renderer
+ * modes are pure view-time filters over that single view state.
+ */
+function applyRendererMode(args: {
+  viewState: EventsStreamViewState;
+  events: readonly Event[];
+  rendererMode: EventsStreamRendererMode;
+}): EventsStreamViewState {
+  if (args.rendererMode === "pretty") {
+    return {
+      ...args.viewState,
+      slots: {
+        ...args.viewState.slots,
+        feed: args.viewState.slots.feed.filter((element) => element.type !== "grouped-raw-event"),
+      },
+    };
+  }
+
+  if (args.rendererMode === "raw-single-json") {
+    return {
+      ...args.viewState,
+      slots: {
+        ...args.viewState.slots,
+        feed: [{ type: "raw-json-dump", id: "raw-json-dump", props: { events: [...args.events] } }],
+      },
+    };
+  }
+
+  return args.viewState;
+}
+
+// ---------------------------------------------------------------------------
+// Raw view: virtualized event rows with an event-type filter
+// ---------------------------------------------------------------------------
+
+const ALL_EVENT_TYPES = "__all__";
+
+function ProjectStreamRawView({
+  database,
+  emptyLabel,
+}: {
+  database: StreamBrowserDatabase;
+  emptyLabel: string;
+}) {
+  const [eventTypeFilter, setEventTypeFilter] = useState<string>(ALL_EVENT_TYPES);
+  const typeFilter = eventTypeFilter === ALL_EVENT_TYPES ? null : eventTypeFilter;
+  const typesResult = useStreamQuery(
+    database,
+    `SELECT type, COUNT(*) AS count FROM events GROUP BY type ORDER BY type ASC`,
+  );
+  const countResult = useStreamQuery(
+    database,
+    typeFilter == null
+      ? `SELECT COUNT(*) AS count FROM events`
+      : `SELECT COUNT(*) AS count FROM events WHERE type = ?`,
+    typeFilter == null ? [] : [typeFilter],
+  );
+  const eventCount = Number(countResult.data[0]?.count ?? 0);
+  const [expandedOffsets, setExpandedOffsets] = useState<ReadonlySet<number>>(new Set());
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLTextAreaElement>(null);
   // Only auto-scroll to the bottom when the viewport is already pinned there.
   // Yanking a scrolled-up reader back to the bottom on every append shifts the
   // virtualized window far enough that the whole visible range re-queries and
   // flashes grey skeletons before SQLite returns the new rows.
   const stickToBottomRef = useRef(true);
 
-  async function submit() {
-    const trimmed = composerText.trim();
-    if (!trimmed) return;
-    setIsSubmitting(true);
-    setSubmitError(undefined);
-    // The user just appended from the composer at the bottom, so follow the
-    // new event down even if they had scrolled up earlier.
-    stickToBottomRef.current = true;
-    try {
-      if (composerMode === "message" && messageComposer) {
-        await messageComposer.onSubmit(trimmed);
-      } else {
-        const parsed = parseYaml(trimmed) as unknown;
-        const events = (Array.isArray(parsed) ? parsed : [parsed]).map((event) =>
-          StreamEventInput.parse(event),
-        );
-        await store.appendBatch({ events });
-      }
-      setComposerText(composerMode === "raw" ? composerText : "");
-    } catch (error) {
-      setSubmitError(error instanceof Error ? error.message : String(error));
-    } finally {
-      setIsSubmitting(false);
-      window.requestAnimationFrame(() => {
-        inputRef.current?.focus();
-      });
-    }
-  }
-
   useLayoutEffect(() => {
     if (!stickToBottomRef.current) return;
     const frame = window.requestAnimationFrame(() => {
       const scrollContainer = scrollContainerRef.current;
-      if (scrollContainer == null) {
-        return;
-      }
-
+      if (scrollContainer == null) return;
       scrollContainer.scrollTop = scrollContainer.scrollHeight;
     });
 
@@ -144,14 +459,46 @@ export function ProjectStreamView({
     };
   }, [eventCount]);
 
+  function toggleOffset(offset: number) {
+    setExpandedOffsets((previous) => {
+      const next = new Set(previous);
+      if (next.has(offset)) {
+        next.delete(offset);
+      } else {
+        next.add(offset);
+      }
+      return next;
+    });
+  }
+
   return (
-    <section className="flex min-h-0 flex-1 flex-col bg-white">
-      <header className="shrink-0 border-b px-4 py-3">
-        <h1 className="truncate font-mono text-sm font-semibold">{streamPathText}</h1>
-        <StreamStatus count={eventCount} snapshot={snapshot} />
-      </header>
-      {headerAccessory == null ? null : <div className="shrink-0 border-b">{headerAccessory}</div>}
-      <main
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b px-4 py-2">
+        <Select
+          value={eventTypeFilter}
+          onValueChange={(value) => setEventTypeFilter(value ?? ALL_EVENT_TYPES)}
+        >
+          <SelectTrigger size="sm" className="min-w-0 max-w-full font-mono text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_EVENT_TYPES}>All event types</SelectItem>
+            {typesResult.data.map((row) => (
+              <SelectItem
+                key={String(row.type)}
+                value={String(row.type)}
+                className="font-mono text-xs"
+              >
+                {String(row.type)} ({Number(row.count).toLocaleString()})
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <span className="shrink-0 font-mono text-xs text-muted-foreground">
+          {eventCount.toLocaleString()} events
+        </span>
+      </div>
+      <div
         ref={scrollContainerRef}
         className="min-h-0 flex-1 overflow-y-auto"
         onScroll={(event) => {
@@ -169,44 +516,18 @@ export function ProjectStreamView({
           </Centered>
         ) : (
           <VirtualEventRows
-            database={store.streamDatabase}
-            emptyLabel={emptyLabel}
+            key={eventTypeFilter}
+            database={database}
+            emptyLabel={typeFilter == null ? emptyLabel : "No events match this type."}
             eventCount={eventCount}
+            expandedOffsets={expandedOffsets}
+            onToggleOffset={toggleOffset}
             scrollElementRef={scrollContainerRef}
-            snapshot={snapshot}
+            typeFilter={typeFilter}
           />
         )}
-        {isSubmitting ? <PendingResultRow /> : null}
-        <form
-          className="border-t p-3"
-          onSubmit={(event) => {
-            event.preventDefault();
-            void submit();
-          }}
-        >
-          <textarea
-            ref={inputRef}
-            className="block max-h-48 min-h-20 w-full resize-y rounded-md border px-3 py-2 font-mono text-[13px] outline-none focus:border-slate-400"
-            placeholder={messageComposer?.placeholder ?? "YAML event"}
-            spellCheck={false}
-            value={composerText}
-            onChange={(event) => setComposerText(event.currentTarget.value)}
-          />
-          <div className="mt-2 flex items-center justify-between gap-3">
-            <output className="min-w-0 truncate font-mono text-xs text-red-700">
-              {submitError ?? ""}
-            </output>
-            <button
-              className="rounded-md bg-slate-950 px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
-              disabled={isSubmitting}
-              type="submit"
-            >
-              {isSubmitting ? "Sending" : composerMode === "message" ? "Send" : "Append"}
-            </button>
-          </div>
-        </form>
-      </main>
-    </section>
+      </div>
+    </div>
   );
 }
 
@@ -214,32 +535,43 @@ function VirtualEventRows({
   database,
   emptyLabel,
   eventCount,
+  expandedOffsets,
+  onToggleOffset,
   scrollElementRef,
-  snapshot,
+  typeFilter,
 }: {
   database: StreamBrowserDatabase;
   emptyLabel: string;
   eventCount: number;
+  expandedOffsets: ReadonlySet<number>;
+  onToggleOffset: (offset: number) => void;
   scrollElementRef: RefObject<HTMLDivElement | null>;
-  snapshot: StreamBrowserSnapshot;
+  typeFilter: string | null;
 }) {
   const virtualizer = useVirtualizer({
     count: eventCount,
     getScrollElement: () => scrollElementRef.current,
-    estimateSize: () => 44,
+    estimateSize: () => 36,
     overscan: 24,
   });
 
   const virtualItems = virtualizer.getVirtualItems();
   const first = virtualItems[0]?.index ?? 0;
   const last = virtualItems.at(-1)?.index ?? -1;
+  const windowSize = Math.max(0, last + 1 - first);
   const rowsResult = useStreamQuery(
     database,
-    `SELECT local_index, offset, type, idempotency_key, created_at, inserted_at, json(raw_jsonb) AS raw_json
-     FROM events
-     WHERE local_index >= ? AND local_index < ?
-     ORDER BY local_index ASC`,
-    [first, last + 1],
+    typeFilter == null
+      ? `SELECT local_index, offset, type, idempotency_key, created_at, inserted_at, json(raw_jsonb) AS raw_json
+         FROM events
+         WHERE local_index >= ? AND local_index < ?
+         ORDER BY local_index ASC`
+      : `SELECT local_index, offset, type, idempotency_key, created_at, inserted_at, json(raw_jsonb) AS raw_json
+         FROM events
+         WHERE type = ?
+         ORDER BY local_index ASC
+         LIMIT ? OFFSET ?`,
+    typeFilter == null ? [first, last + 1] : [typeFilter, windowSize, first],
   );
   // Retain the last committed rows across range re-queries. When the visible
   // window shifts (append grows the list, or a scroll moves it), the range SQL
@@ -251,20 +583,16 @@ function VirtualEventRows({
   const rowsByIndex = useMemo(() => {
     if (rowsResult.status !== "ok") return lastRowsRef.current;
     const rows = new Map<number, StreamEventRow>();
-    for (const row of rowsResult.data) {
-      if (typeof row.local_index === "number") rows.set(row.local_index, row as StreamEventRow);
-    }
+    rowsResult.data.forEach((row, position) => {
+      const index = typeFilter == null ? Number(row.local_index) : first + position;
+      if (Number.isFinite(index)) rows.set(index, row as StreamEventRow);
+    });
     lastRowsRef.current = rows;
     return rows;
-  }, [rowsResult.data, rowsResult.status]);
+  }, [rowsResult.data, rowsResult.status, typeFilter, first]);
 
   if (eventCount === 0) {
-    return (
-      <Centered>
-        {snapshot.connectionError ??
-          (snapshot.connectionStatus === "subscribed" ? emptyLabel : snapshot.connectionStatus)}
-      </Centered>
-    );
+    return <Centered>{emptyLabel}</Centered>;
   }
 
   return (
@@ -274,24 +602,23 @@ function VirtualEventRows({
           const row = rowsByIndex.get(item.index);
           return (
             <article
-              className="absolute left-0 top-0 w-full border-b py-2 font-mono text-xs"
+              className="absolute left-0 top-0 w-full border-b bg-background py-1.5 font-mono text-xs"
+              // measureElement reads data-index to attribute heights to rows;
+              // without it expanded rows keep their estimated size and the
+              // JSON paints over the rows below.
+              data-index={item.index}
               key={item.key}
-              ref={row ? virtualizer.measureElement : undefined}
+              ref={virtualizer.measureElement}
               style={{ transform: `translateY(${item.start}px)` }}
             >
               {row ? (
-                <details>
-                  <summary className="grid cursor-pointer grid-cols-[64px_minmax(0,1fr)_auto] gap-3 text-slate-600">
-                    <span>#{row.offset}</span>
-                    <span className="truncate">{row.type}</span>
-                    <time>{row.created_at}</time>
-                  </summary>
-                  <pre className="mt-2 overflow-auto whitespace-pre-wrap break-words text-slate-800">
-                    {JSON.stringify(JSON.parse(row.raw_json), null, 2)}
-                  </pre>
-                </details>
+                <RawEventRow
+                  expanded={expandedOffsets.has(Number(row.offset))}
+                  onToggle={() => onToggleOffset(Number(row.offset))}
+                  row={row}
+                />
               ) : (
-                <div className="h-6 rounded bg-slate-100" />
+                <div className="h-6 rounded bg-muted" />
               )}
             </article>
           );
@@ -301,18 +628,113 @@ function VirtualEventRows({
   );
 }
 
-function PendingResultRow() {
+function RawEventRow({
+  expanded,
+  onToggle,
+  row,
+}: {
+  expanded: boolean;
+  onToggle: () => void;
+  row: StreamEventRow;
+}) {
   return (
-    <div className="flex items-center gap-2 border-t px-4 py-3 font-mono text-xs text-slate-500">
-      <Spinner className="size-3.5" />
-      <span>Waiting for result</span>
+    <>
+      <button
+        aria-expanded={expanded}
+        className="grid w-full cursor-pointer grid-cols-[64px_minmax(0,1fr)_auto] items-baseline gap-3 text-left text-muted-foreground hover:text-foreground"
+        onClick={onToggle}
+        type="button"
+      >
+        <span>#{row.offset}</span>
+        <span className="truncate">{row.type}</span>
+        <time>{row.created_at}</time>
+      </button>
+      {expanded ? (
+        <SerializedObjectCodeBlock className="my-2" data={parseRawEventJson(row.raw_json)} />
+      ) : null}
+    </>
+  );
+}
+
+function parseRawEventJson(rawJson: string): unknown {
+  try {
+    return JSON.parse(rawJson);
+  } catch {
+    return rawJson;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// State view: live reduced + runtime processor state via runtimeState() RPC
+// ---------------------------------------------------------------------------
+
+const STATE_POLL_INTERVAL_MS = 1_000;
+
+function ProjectStreamStateView({ store }: { store: StreamBrowserStore }) {
+  const [runtimeState, setRuntimeState] = useState<StreamRuntimeState | null>(null);
+  const [error, setError] = useState<string | undefined>();
+
+  useEffect(() => {
+    let disposed = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const poll = async () => {
+      try {
+        const state = await store.runtimeState();
+        if (!disposed) {
+          // Keep the previous object identity when nothing changed so the
+          // code block doesn't rebuild (and lose scroll) every poll tick.
+          setRuntimeState((previous) =>
+            previous != null && JSON.stringify(previous) === JSON.stringify(state)
+              ? previous
+              : state,
+          );
+          setError(undefined);
+        }
+      } catch (caught) {
+        if (!disposed) setError(caught instanceof Error ? caught.message : String(caught));
+      }
+      if (!disposed) timer = setTimeout(() => void poll(), STATE_POLL_INTERVAL_MS);
+    };
+    void poll();
+
+    return () => {
+      disposed = true;
+      if (timer !== undefined) clearTimeout(timer);
+    };
+  }, [store]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b px-4 py-2">
+        <span className="text-xs font-semibold text-muted-foreground">Reduced processor state</span>
+        <output className="font-mono text-xs text-muted-foreground">
+          {runtimeState == null ? "loading" : "live"}
+        </output>
+      </div>
+      {error == null ? null : (
+        <p className="border-b px-4 py-2 text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        {runtimeState == null ? (
+          <Centered>Reading runtime state…</Centered>
+        ) : (
+          <SerializedObjectCodeBlock data={runtimeState} />
+        )}
+      </div>
     </div>
   );
 }
 
+// ---------------------------------------------------------------------------
+// Shared bits
+// ---------------------------------------------------------------------------
+
 function StreamStatus({ count, snapshot }: { count: number; snapshot: StreamBrowserSnapshot }) {
   return (
-    <p className="mt-1 flex gap-3 font-mono text-[11px] text-slate-500">
+    <p className="mt-0.5 flex gap-3 font-mono text-[11px] text-muted-foreground">
       <span>{snapshot.connectionStatus}</span>
       <span>{snapshot.subscriptionStatus}</span>
       <span>{count.toLocaleString()} events</span>
@@ -322,7 +744,7 @@ function StreamStatus({ count, snapshot }: { count: number; snapshot: StreamBrow
 
 function Centered({ children }: { children: ReactNode }) {
   return (
-    <div className="grid min-h-0 flex-1 place-items-center p-6 text-sm text-slate-500">
+    <div className="grid min-h-0 flex-1 place-items-center p-6 text-sm text-muted-foreground">
       {children}
     </div>
   );

--- a/apps/os/src/components/stream-debug-link.tsx
+++ b/apps/os/src/components/stream-debug-link.tsx
@@ -1,8 +1,8 @@
 import { ExternalLink } from "lucide-react";
+import { Link } from "@tanstack/react-router";
 import type { StreamPath } from "@iterate-com/shared/streams/types";
 import { buttonVariants } from "@iterate-com/ui/components/button";
 import { cn } from "@iterate-com/ui/lib/utils";
-import { buildProjectStreamViewerUrl } from "~/lib/stream-viewer-url.ts";
 
 export function StreamDebugLink({
   className,
@@ -16,22 +16,15 @@ export function StreamDebugLink({
   streamPath: StreamPath;
 }) {
   return (
-    <a
+    <Link
       className={cn(buttonVariants({ variant: "outline", size: "sm" }), className)}
-      href={buildProjectStreamViewerUrl({
-        baseUrl: currentOrigin(),
-        projectSlug,
-        streamPath,
-      })}
+      to="/projects/$projectSlug/streams/$"
+      params={{ projectSlug, _splat: streamPath }}
       target="_blank"
       rel="noreferrer"
     >
       <ExternalLink data-icon="inline-start" />
       {label}
-    </a>
+    </Link>
   );
-}
-
-function currentOrigin() {
-  return typeof window === "undefined" ? undefined : window.location.origin;
 }

--- a/apps/os/src/lib/stream-links.ts
+++ b/apps/os/src/lib/stream-links.ts
@@ -24,6 +24,12 @@ export function streamPathChild(input: { parent: StreamPath; childSegment: strin
   return StreamPath.parse(`${parent}/${segment}`);
 }
 
+export function streamPathParent(path: StreamPath) {
+  const segments = path.split("/").filter(Boolean);
+  if (segments.length <= 1) return StreamPath.parse("/");
+  return StreamPath.parse(`/${segments.slice(0, -1).join("/")}`);
+}
+
 export function streamPathAncestors(path: StreamPath) {
   if (path === "/") return ["/" as StreamPath];
 

--- a/apps/os/src/lib/stream-viewer-url.test.ts
+++ b/apps/os/src/lib/stream-viewer-url.test.ts
@@ -20,4 +20,14 @@ describe("stream viewer URLs", () => {
       }),
     ).toBe("/projects/project%2Fslash/streams/spaces%20and/slashes");
   });
+
+  it("links the root stream to the %2F splat, not the streams index", () => {
+    expect(
+      buildProjectStreamViewerUrl({
+        baseUrl: "https://os.iterate.com",
+        projectSlug: "test",
+        streamPath: "/",
+      }),
+    ).toBe("https://os.iterate.com/projects/test/streams/%2F");
+  });
 });

--- a/apps/os/src/lib/stream-viewer-url.ts
+++ b/apps/os/src/lib/stream-viewer-url.ts
@@ -22,11 +22,13 @@ export function projectStreamViewerPathname(input: {
   const streamSplat = streamPathSplat(input.streamPath);
   const basePath = ["projects", input.projectSlug, "streams"].map(encodeURIComponent).join("/");
 
-  return streamSplat ? `/${basePath}/${streamSplat}` : `/${basePath}/`;
+  return `/${basePath}/${streamSplat}`;
 }
 
 function streamPathSplat(streamPath: StreamPath | string) {
-  if (streamPath === "/") return "";
+  // The root stream must stay distinguishable from the streams index route
+  // (`/streams/`), so it keeps an encoded slash as its splat segment.
+  if (streamPath === "/") return "%2F";
   return streamPath
     .replace(/^\/+/, "")
     .split("/")

--- a/apps/os/src/routes/_app/projects/$projectSlug/agents/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/agents/index.tsx
@@ -18,7 +18,6 @@ import {
   projectAgentPresetsQueryOptions,
   projectAgentsListQueryOptions,
 } from "~/lib/project-route-query.ts";
-import { streamPathToSplat } from "~/lib/stream-links.ts";
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/agents/")({
   loader: async ({ context }) => {
@@ -196,7 +195,9 @@ function ProjectAgentsIndexPage() {
                         to="/projects/$projectSlug/agents/streams/$"
                         params={{
                           projectSlug: params.projectSlug,
-                          _splat: streamPathToSplat(agent.agentPath),
+                          // params.stringify on the route converts StreamPath ->
+                          // splat; passing a pre-splatted string would double-encode.
+                          _splat: agent.agentPath,
                         }}
                       >
                         <EventsStreamPathLabel path={agent.agentPath} className="min-w-0" />

--- a/apps/os/src/routes/_app/projects/$projectSlug/agents/streams/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/agents/streams/$.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { ProjectStreamView } from "~/components/project-stream-view.tsx";
+import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import {
   projectAgentRuntimeStateQueryOptions,
   projectAgentsListQueryOptions,

--- a/apps/os/src/routes/_app/projects/$projectSlug/codemode-sessions/$codemodeSessionName.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/codemode-sessions/$codemodeSessionName.tsx
@@ -9,7 +9,7 @@ import {
 } from "@iterate-com/ui/components/collapsible";
 import { z } from "zod";
 import { ExistingCodemodeSessionControls } from "~/components/codemode-session-controls.tsx";
-import { ProjectStreamView } from "~/components/project-stream-view.tsx";
+import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import { projectCodemodeSessionQueryOptions } from "~/lib/project-route-query.ts";
 
 const Search = z.object({

--- a/apps/os/src/routes/_app/projects/$projectSlug/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/index.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { StreamPath } from "@iterate-com/shared/streams/types";
-import { ProjectStreamView } from "~/components/project-stream-view.tsx";
+import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import { projectLifecycleStateQueryOptions } from "~/lib/project-route-query.ts";
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/")({

--- a/apps/os/src/routes/_app/projects/$projectSlug/streams/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/streams/$.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { createBrowserOpenApiClient } from "~/orpc/client.ts";
-import { ProjectStreamView } from "~/components/project-stream-view.tsx";
+import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import { breadcrumbLoaderData } from "~/lib/route-breadcrumbs.ts";
 import { streamPathFromSplat, streamPathToSplat } from "~/lib/stream-links.ts";
 

--- a/apps/os/src/routes/_app/projects/$projectSlug/streams/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/streams/index.tsx
@@ -23,7 +23,7 @@ import {
 import { toast } from "@iterate-com/ui/components/sonner";
 import { StreamDebugLink } from "~/components/stream-debug-link.tsx";
 import { projectStreamsListQueryOptions } from "~/lib/project-route-query.ts";
-import { streamPathFromInput, streamPathToSplat } from "~/lib/stream-links.ts";
+import { streamPathFromInput } from "~/lib/stream-links.ts";
 import { orpc } from "~/orpc/client.ts";
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/streams/")({
@@ -63,7 +63,9 @@ function ProjectStreamsIndexPage() {
           to: "/projects/$projectSlug/streams/$",
           params: {
             projectSlug: params.projectSlug,
-            _splat: streamPathToSplat(input.streamPath),
+            // The route's params.stringify converts StreamPath -> splat; passing
+            // a pre-splatted string here would get sliced a second time.
+            _splat: input.streamPath,
           },
         });
       },
@@ -202,7 +204,7 @@ function ProjectStreamsIndexPage() {
                         to="/projects/$projectSlug/streams/$"
                         params={{
                           projectSlug: params.projectSlug,
-                          _splat: streamPathToSplat(stream.streamPath),
+                          _splat: stream.streamPath,
                         }}
                       >
                         <EventsStreamPathLabel path={stream.streamPath} className="min-w-0" />


### PR DESCRIPTION
## What

Rebuilds the sqlite-backed stream views in apps/os around the shared `packages/ui` events components, taking the layout/affordances from the `packages/streams` example app, and fixes the stream splat-link encoding bug.

### ProjectStreamView: three tabs

- **Feed** — pretty ai-elements chat view: reduces the local SQLite raw-event mirror through `StreamViewProcessorContract` (incrementally — appends only reduce new tail rows against cached state) and renders `EventsStreamView`: message/agent/codemode cards, grouped raw event lines, the event inspector sheet, element-type filtering, and renderer modes (Raw + Pretty / Pretty / Raw YAML) applied as pure view-time filters.
- **Raw** — virtualized rows kept, but:
  - fixes the expanded-JSON-overlays-rows bug: rows were missing `data-index`, so TanStack Virtual's `measureElement` never attributed heights and expanded rows kept their 44px estimate
  - expansion renders `SerializedObjectCodeBlock` (YAML/JSON toggle) instead of a bare `<pre>`, and survives scrolling
  - adds an event-type filter select with per-type counts, backed by filtered SQL
- **State** — polls `runtimeState()` every second and shows the reduced core processor + runtime state in a serialized code block.
- Composer is now the shared `EventsStreamComposer` (Message/Raw tabs, YAML `appendBatch`).

### Splat link fixes

- `streams/` and `agents/` index pages passed `streamPathToSplat()` into `Link` params, but the route's `params.stringify` splats again — slicing a character off every linked path (root `%2F` → `2F`). They now pass the `StreamPath` directly.
- `buildProjectStreamViewerUrl` built root-stream URLs as `/streams/`, which lands on the streams *index* route; it now emits `/streams/%2F` (test added).

### Breadcrumbs

Each stream path segment in the breadcrumb is now a popover navigator listing sibling streams at that depth (current one checkmarked), alongside the existing Children popover.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm format` clean
- apps/os vitest suite: 35 files / 171 tests passing, including new root-splat URL test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI refactor in stream viewing/navigation with routing encoding fixes that affect all stream deep links; behavior is mostly client-side but incorrect splat handling previously broke paths including root streams.
> 
> **Overview**
> Rebuilds **OS project stream pages** around shared `packages/ui` events components and fixes stream URL/splat routing bugs.
> 
> **`ProjectStreamView`** is now **Feed / Raw / State** tabs: Feed incrementally reduces the local SQLite mirror through `StreamViewProcessorContract` and renders **`EventsStreamView`** (renderer modes, inspector, filters); Raw keeps virtualization with **event-type filtering**, **`data-index` + `measureElement`** for expanded rows, and **`SerializedObjectCodeBlock`**; State polls **`runtimeState()`** into a code block. The bottom composer is **`EventsStreamComposer`** (hidden on State). Stream routes load the view via **`project-stream-view.lazy.tsx`** to keep heavy client bundles off the worker.
> 
> **Routing fixes:** list/create links and **`StreamDebugLink`** pass **`StreamPath`** into `_splat` (route `stringify` already splats—pre-splatted values were mangled, including root **`%2F` → `2F`**). **`buildProjectStreamViewerUrl`** now emits **`/streams/%2F`** for the root stream so it does not hit the streams index (test added).
> 
> **Breadcrumbs:** each non-root path segment is a **popover** of sibling streams at that depth (`streamPathParent`); **`StreamChildrenBreadcrumb`** unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f08d422726e12deecfdf14116df3689795a742d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T09:49:28.082Z",
      "headSha": "9f08d422726e12deecfdf14116df3689795a742d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27267576542",
      "shortSha": "9f08d42"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `9f08d42`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27267576542)
Updated: 2026-06-10T09:49:28.082Z
<!-- /CLOUDFLARE_PREVIEW -->