### PR TITLE
Allow other bots to trigger the Slack agent

### DIFF
--- a/apps/os/src/domains/slack/stream-processors/slack-agent/contract.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack-agent/contract.ts
@@ -29,6 +29,7 @@ export const SlackAgentProcessorContract = defineProcessorContract({
   version: "0.1.0",
   description: "Handles Slack-specific behavior for one routed Slack agent stream.",
   stateSchema: z.object({
+    botBotId: z.string().optional(),
     botUserId: z.string().optional(),
     channel: z.string().optional(),
     latestMessageTs: z.string().optional(),

--- a/apps/os/src/domains/slack/stream-processors/slack-agent/implementation.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack-agent/implementation.ts
@@ -52,8 +52,10 @@ export class SlackAgentProcessor extends StreamProcessor<
         const target = slackTargetFromPayload(event.payload);
         if (target == null) return state;
         const botUserId = state.botUserId ?? botUserIdFromPayload(event.payload);
+        const botBotId = state.botBotId ?? botBotIdFromPayload(event.payload);
         return {
           ...state,
+          ...(botBotId == null ? {} : { botBotId }),
           ...(botUserId == null ? {} : { botUserId }),
           channel: target.channel,
           ...(target.messageTs == null ? {} : { latestMessageTs: target.messageTs }),
@@ -126,7 +128,8 @@ export class SlackAgentProcessor extends StreamProcessor<
 
         const slackEvent = parsed.data.event;
         const target = slackAgentTargetFromWebhookPayload(event.payload);
-        if (isBotMessage(slackEvent)) return;
+        const botBotId = state.botBotId ?? botBotIdFromPayload(event.payload);
+        if (isOwnBotMessage(slackEvent, botBotId)) return;
         if (isBotAction(slackEvent, state.botUserId)) return;
 
         const channel = target?.channel ?? state.channel ?? readStringField(slackEvent, "channel");
@@ -300,6 +303,18 @@ function isBotMessage(slackEvent: Record<string, unknown>): boolean {
   return false;
 }
 
+// Returns true only when the message came from our own bot (same bot_id as the
+// authorized app). Falls back to blocking all bots when our bot_id is unknown.
+function isOwnBotMessage(
+  slackEvent: Record<string, unknown>,
+  botBotId: string | undefined,
+): boolean {
+  if (botBotId == null) return isBotMessage(slackEvent);
+  const msgBotId = readStringField(slackEvent, "bot_id");
+  if (msgBotId == null) return false;
+  return msgBotId === botBotId;
+}
+
 /**
  * Returns true when the Slack event was performed by our own bot user (e.g.
  * our bot adding a reaction).
@@ -405,6 +420,16 @@ function botUserIdFromPayload(payload: unknown): string | undefined {
     (auth) => readRecord(auth)?.is_bot === true && typeof readRecord(auth)?.user_id === "string",
   );
   return botAuth == null ? undefined : readString(readRecord(botAuth)?.user_id);
+}
+
+function botBotIdFromPayload(payload: unknown): string | undefined {
+  const body = readRecord(readRecord(payload)?.body);
+  const authorizations = body?.authorizations;
+  if (!Array.isArray(authorizations)) return undefined;
+  const botAuth = authorizations.find(
+    (auth) => readRecord(auth)?.is_bot === true && typeof readRecord(auth)?.bot_id === "string",
+  );
+  return botAuth == null ? undefined : readString(readRecord(botAuth)?.bot_id);
 }
 
 function slackAgentTargetFromWebhookPayload(payload: unknown): SlackAgentTarget | null {

--- a/apps/os/src/domains/slack/stream-processors/slack-agent/slack-agent.test.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack-agent/slack-agent.test.ts
@@ -378,6 +378,92 @@ describe("SlackAgentProcessor", () => {
 
     expect(appended).toEqual([]);
   });
+
+  it("ignores messages posted by our own bot", async () => {
+    const { appended, processor } = createProcessor();
+
+    await processor.ingest({
+      events: [
+        committedEvent({
+          offset: 51,
+          type: "events.iterate.com/slack/webhook-received",
+          payload: {
+            body: {
+              type: "event_callback",
+              event: {
+                type: "message",
+                subtype: "bot_message",
+                bot_id: "B_OUR_BOT",
+                channel: "C123",
+                ts: "1772136259.000000",
+                thread_ts: "1772136258.963519",
+                text: "I am the bot replying",
+              },
+              authorizations: [
+                {
+                  team_id: "T123",
+                  user_id: "U_BOT",
+                  bot_id: "B_OUR_BOT",
+                  is_bot: true,
+                  is_enterprise_install: false,
+                },
+              ],
+            },
+          },
+        }),
+      ],
+      streamMaxOffset: 51,
+    });
+    await flushBackgroundWork();
+
+    expect(appended).toEqual([]);
+  });
+
+  it("forwards messages posted by other bots to the agent", async () => {
+    const { appended, processor } = createProcessor();
+
+    await processor.ingest({
+      events: [
+        committedEvent({
+          offset: 52,
+          type: "events.iterate.com/slack/webhook-received",
+          payload: {
+            body: {
+              type: "event_callback",
+              event: {
+                type: "message",
+                subtype: "bot_message",
+                bot_id: "B_OTHER_BOT",
+                channel: "C123",
+                ts: "1772136259.000000",
+                thread_ts: "1772136258.963519",
+                text: "I am another bot mentioning @iterate",
+              },
+              authorizations: [
+                {
+                  team_id: "T123",
+                  user_id: "U_BOT",
+                  bot_id: "B_OUR_BOT",
+                  is_bot: true,
+                  is_enterprise_install: false,
+                },
+              ],
+            },
+          },
+        }),
+      ],
+      streamMaxOffset: 52,
+    });
+    await flushBackgroundWork();
+
+    expect(appended).toEqual([
+      expect.objectContaining({
+        event: expect.objectContaining({
+          type: "events.iterate.com/agent/input-added",
+        }),
+      }),
+    ]);
+  });
 });
 
 function createProcessor(


### PR DESCRIPTION
## Summary

- `isBotMessage()` previously blocked **all** Slack bot messages unconditionally, so bots like GitHub, Zapier, or CI notifications posting into a thread could never reach the iterate agent
- Now the input filter (`isOwnBotMessage`) only drops messages whose `bot_id` matches our own bot's ID, read from the Slack webhook `authorizations` payload
- `isBotMessage()` is retained for the eyes-reaction guard (`#addEyesReactionForMessageTarget`) where adding reactions to any bot message is still undesirable
- `botBotId` is persisted to state alongside the existing `botUserId`
- Fallback: when `botBotId` is unknown (unusual — Slack includes authorizations on every webhook), blocks all bots conservatively

## Test plan

- [ ] Two new unit tests in `slack-agent.test.ts`: own-bot messages are dropped, other-bot messages produce `agent/input-added`
- [ ] All 14 slack-agent tests pass
- [ ] Deploy to prd, reconnect iterate project Slack, verify a bot post in the channel reaches the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which Slack webhooks become agent input and could increase noise or unintended agent runs from other bots; own-bot filtering and unknown-`bot_id` fallback limit regressions.
> 
> **Overview**
> **Slack agent webhook input** no longer drops every bot message. The filter now uses **`isOwnBotMessage`**: only messages whose `bot_id` matches the app’s bot (from webhook `authorizations`) are ignored, so third-party bots (GitHub, Zapier, etc.) can produce **`agent/input-added`**.
> 
> **`botBotId`** is stored in processor state (alongside **`botUserId`**) and set on **`slack/webhook-received`**. If **`botBotId`** is missing, behavior falls back to the old rule and blocks all bot messages.
> 
> **`isBotMessage`** is unchanged for the eyes-reaction path, which still skips reactions on any bot message. Unit tests cover own-bot drops vs other-bot forwards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8c2de6fa32e27c2cd2e705066579888dbff9b21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T09:38:08.485Z",
      "headSha": "f8c2de6fa32e27c2cd2e705066579888dbff9b21",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27266384761",
      "shortSha": "f8c2de6"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `f8c2de6`
Preview: https://os.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27266384761)
Updated: 2026-06-10T09:38:08.485Z
<!-- /CLOUDFLARE_PREVIEW -->