### PR TITLE
Superadmin scope: server-granted via role, auto-granted to @nustom.com, replaces project:*

### DIFF
--- a/apps/auth/alchemy.run.ts
+++ b/apps/auth/alchemy.run.ts
@@ -47,6 +47,7 @@ const AlchemyEnv = z.object({
   RESEND_BOT_DOMAIN: z.string(),
   RESEND_BOT_API_KEY: z.string(),
   SIGNUP_ALLOWLIST: z.string(),
+  SUPERADMIN_ALLOWLIST: z.string().default("*@nustom.com"),
   VITE_ENABLE_EMAIL_OTP_SIGNIN: z.string().optional(),
   GOOGLE_CLIENT_ID: z.string(),
   GOOGLE_CLIENT_SECRET: z.string(),
@@ -77,6 +78,7 @@ await Exec("render-superadmin-seed", {
   command: `tsx ./scripts/render-superadmin-seed.ts ${SUPERADMIN_SEED_SQL_PATH}`,
   env: {
     SERVICE_AUTH_TOKEN: alchemy.secret(alchemyEnv.SERVICE_AUTH_TOKEN),
+    SUPERADMIN_ALLOWLIST: alchemyEnv.SUPERADMIN_ALLOWLIST,
   },
   cwd: import.meta.dirname,
 });
@@ -98,6 +100,7 @@ const worker = await TanStackStart(APP_NAME, {
     RESEND_BOT_DOMAIN: alchemy.secret(alchemyEnv.RESEND_BOT_DOMAIN),
     RESEND_BOT_API_KEY: alchemy.secret(alchemyEnv.RESEND_BOT_API_KEY),
     SIGNUP_ALLOWLIST: alchemy.secret(alchemyEnv.SIGNUP_ALLOWLIST),
+    SUPERADMIN_ALLOWLIST: alchemy.secret(alchemyEnv.SUPERADMIN_ALLOWLIST),
     VITE_ENABLE_EMAIL_OTP_SIGNIN: alchemy.secret(emailOtpEnabled),
     GOOGLE_CLIENT_ID: alchemy.secret(alchemyEnv.GOOGLE_CLIENT_ID),
     GOOGLE_CLIENT_SECRET: alchemy.secret(alchemyEnv.GOOGLE_CLIENT_SECRET),

--- a/apps/auth/scripts/render-superadmin-seed.ts
+++ b/apps/auth/scripts/render-superadmin-seed.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { hashPassword } from "better-auth/crypto";
+import { parseSignupAllowlist } from "@iterate-com/shared/signup-allowlist";
 import {
   BOOTSTRAP_SUPERADMIN_ACCOUNT_ID,
   BOOTSTRAP_SUPERADMIN_ACCOUNT_ROW_ID,
@@ -14,6 +15,35 @@ function escapeSqlString(value: string) {
   return value.replaceAll("'", "''");
 }
 
+// Translates the minimatch-style allowlist patterns ("*@nustom.com") into SQL
+// LIKE patterns so the seed can promote pre-existing users at deploy time; the
+// create-hook in auth.ts handles new signups.
+function allowlistPatternToSqlLike(pattern: string) {
+  return escapeSqlString(
+    pattern.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_"),
+  )
+    .replaceAll("*", "%")
+    .replaceAll("?", "_");
+}
+
+function renderSuperadminBackfillSql(allowlist: string[], now: string) {
+  if (allowlist.length === 0) {
+    return "";
+  }
+
+  const conditions = allowlist
+    .map((pattern) => `lower(email) LIKE '${allowlistPatternToSqlLike(pattern)}' ESCAPE '\\'`)
+    .join("\n   OR ");
+
+  return `
+UPDATE user
+SET role = 'admin',
+    updatedAt = '${escapeSqlString(now)}'
+WHERE (${conditions})
+  AND (role IS NULL OR role != 'admin');
+`;
+}
+
 async function main() {
   const outputPathArg = process.argv[2];
   if (!outputPathArg) {
@@ -24,6 +54,8 @@ async function main() {
   if (!serviceAuthToken) {
     throw new Error("SERVICE_AUTH_TOKEN is required");
   }
+
+  const superadminAllowlist = parseSignupAllowlist(process.env.SUPERADMIN_ALLOWLIST ?? "");
 
   const outputPath = resolve(outputPathArg);
   mkdirSync(dirname(outputPath), { recursive: true });
@@ -80,7 +112,7 @@ VALUES (
   '${escapeSqlString(now)}',
   '${escapeSqlString(now)}'
 );
-`.trimStart();
+${renderSuperadminBackfillSql(superadminAllowlist, now)}`.trimStart();
 
   writeFileSync(outputPath, sql);
   console.log(`Rendered superadmin seed SQL to ${outputPath}`);

--- a/apps/auth/scripts/render-superadmin-seed.ts
+++ b/apps/auth/scripts/render-superadmin-seed.ts
@@ -17,8 +17,18 @@ function escapeSqlString(value: string) {
 
 // Translates the minimatch-style allowlist patterns ("*@nustom.com") into SQL
 // LIKE patterns so the seed can promote pre-existing users at deploy time; the
-// create-hook in auth.ts handles new signups.
+// create-hook in auth.ts handles new signups. minimatch supports far more
+// syntax (braces, character classes, negation) than LIKE can express, so we
+// refuse anything beyond the * and ? wildcards — failing the deploy beats
+// silently promoting a different set of users here than the signup hook does.
+// For email strings (which never contain "/"), * and ? translate exactly.
 function allowlistPatternToSqlLike(pattern: string) {
+  if (!/^[a-z0-9*?@._+-]+$/.test(pattern)) {
+    throw new Error(
+      `SUPERADMIN_ALLOWLIST pattern "${pattern}" uses minimatch syntax the deploy-time SQL ` +
+        `backfill cannot translate; only the * and ? wildcards are supported.`,
+    );
+  }
   return escapeSqlString(
     pattern.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_"),
   )
@@ -26,22 +36,39 @@ function allowlistPatternToSqlLike(pattern: string) {
     .replaceAll("?", "_");
 }
 
+// Each pattern's backfill runs exactly once, tracked in superadminBackfill:
+// the seed file re-imports on every deploy (its rendered timestamp changes the
+// file hash), and without the marker a superadmin demoted via the admin API
+// would be re-promoted by the next deploy. New signups are promoted by the
+// auth.ts hook, so the backfill only needs to catch users who existed before
+// their pattern was allowlisted.
 function renderSuperadminBackfillSql(allowlist: string[], now: string) {
   if (allowlist.length === 0) {
     return "";
   }
 
-  const conditions = allowlist
-    .map((pattern) => `lower(email) LIKE '${allowlistPatternToSqlLike(pattern)}' ESCAPE '\\'`)
-    .join("\n   OR ");
-
-  return `
+  const statements = allowlist.map((pattern) => {
+    const like = allowlistPatternToSqlLike(pattern);
+    const marker = escapeSqlString(pattern);
+    return `
 UPDATE user
 SET role = 'admin',
     updatedAt = '${escapeSqlString(now)}'
-WHERE (${conditions})
-  AND (role IS NULL OR role != 'admin');
+WHERE lower(email) LIKE '${like}' ESCAPE '\\'
+  AND (role IS NULL OR role != 'admin')
+  AND NOT EXISTS (SELECT 1 FROM superadminBackfill WHERE pattern = '${marker}');
+
+INSERT OR IGNORE INTO superadminBackfill (pattern, appliedAt)
+VALUES ('${marker}', '${escapeSqlString(now)}');
 `;
+  });
+
+  return `
+CREATE TABLE IF NOT EXISTS superadminBackfill (
+  pattern TEXT PRIMARY KEY,
+  appliedAt TEXT NOT NULL
+);
+${statements.join("")}`;
 }
 
 async function main() {

--- a/apps/auth/src/routes/_auth/consent.tsx
+++ b/apps/auth/src/routes/_auth/consent.tsx
@@ -13,7 +13,10 @@ import { Separator } from "@iterate-com/ui/components/separator";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { z } from "zod/v4";
-import { ITERATE_PROJECT_SELECTION_SCOPE } from "@iterate-com/shared/auth-claims";
+import {
+  ITERATE_PROJECT_SELECTION_SCOPE,
+  ITERATE_SUPERADMIN_SCOPE,
+} from "@iterate-com/shared/auth-claims";
 import { authClient, useSession } from "../../utils/auth-client.ts";
 import { oauthClientQueryOptions } from "../../utils/auth-query-options.ts";
 import { getInitials } from "../../utils/initials.ts";
@@ -198,6 +201,7 @@ function scopeLabel(scope: string): string {
     email: "View your email",
     offline_access: "Stay connected",
     [ITERATE_PROJECT_SELECTION_SCOPE]: "Use selected projects",
+    [ITERATE_SUPERADMIN_SCOPE]: "Administer Iterate",
   };
 
   return labels[scope] ?? scope;
@@ -210,6 +214,7 @@ function scopeDescription(scope: string): string {
     email: "Read the email address on this account.",
     offline_access: "Continue working after this browser session.",
     [ITERATE_PROJECT_SELECTION_SCOPE]: "Access only the projects you chose.",
+    [ITERATE_SUPERADMIN_SCOPE]: "Act with superadmin access across all organizations and projects.",
   };
 
   return descriptions[scope] ?? "Use this requested permission.";

--- a/apps/auth/src/server/auth-plugins.ts
+++ b/apps/auth/src/server/auth-plugins.ts
@@ -30,16 +30,25 @@ import {
   resolveStoredProjectSelection,
 } from "./oauth-project-selection.ts";
 import { getOsMcpResourceBases, getOsResourceBases } from "./oauth-resources.ts";
+import { isSuperadminUser } from "./superadmin.ts";
 
 const TEST_EMAIL_PATTERN = /\+.*test@/i;
 const TEST_OTP_CODE = "424242";
 const isProduction = ["prd", "production", "prod"].includes(import.meta.env?.VITE_APP_STAGE);
 const isNonProd = !isProduction;
 
+// Custom claims go out on three surfaces, configured further down in
+// oauthProvider():
+// - access tokens (customAccessTokenClaims): what resource servers like OS
+//   authorize against — org/project claims plus the server-granted `scopes`
+//   claim (project:<id> entries, superadmin).
+// - ID tokens (customIdTokenClaims) and userinfo (customUserInfoClaims):
+//   login-time identity for the relying party — the namespaced
+//   https://iterate.com/claims/* values built here.
 function buildIterateTokenClaims(user: Record<string, unknown> | null | undefined) {
   const role = typeof user?.role === "string" ? user.role : null;
   return {
-    [ITERATE_IS_ADMIN_CLAIM]: role === "admin",
+    [ITERATE_IS_ADMIN_CLAIM]: isSuperadminUser({ role }),
     [ITERATE_ROLE_CLAIM]: role,
   };
 }
@@ -217,7 +226,7 @@ export function getAuthPlugins(env: Record<string, unknown>) {
           scopes: buildAugmentedScopeClaims({
             requestedScopes: scopes,
             projectIds: isProjectScopedToken ? projects.map((project) => project.id) : [],
-            superadmin: typeof user?.role === "string" && user.role === "admin",
+            superadmin: isSuperadminUser(user),
           }),
           [ITERATE_ACCESS_TOKEN_ORGANIZATIONS_CLAIM]: organizations,
           [ITERATE_ACCESS_TOKEN_PROJECTS_CLAIM]: projects,

--- a/apps/auth/src/server/auth-plugins.ts
+++ b/apps/auth/src/server/auth-plugins.ts
@@ -10,6 +10,7 @@ import {
   ITERATE_IS_ADMIN_CLAIM,
   ITERATE_ORGANIZATIONS_CLAIM,
   ITERATE_ROLE_CLAIM,
+  ITERATE_SUPERADMIN_SCOPE,
   type IterateAuthAccessTokenOrganizationClaim,
   type IterateAuthOrganizationClaim,
   type IterateAuthProjectClaim,
@@ -188,7 +189,14 @@ export function getAuthPlugins(env: Record<string, unknown>) {
       // rotated-token reuse as theft) is rare, short enough that org/project
       // claim changes propagate within half an hour.
       accessTokenExpiresIn: 30 * 60,
-      scopes: ["openid", "profile", "email", "offline_access", ITERATE_PROJECT_SELECTION_SCOPE],
+      scopes: [
+        "openid",
+        "profile",
+        "email",
+        "offline_access",
+        ITERATE_PROJECT_SELECTION_SCOPE,
+        ITERATE_SUPERADMIN_SCOPE,
+      ],
       validAudiences,
       allowDynamicClientRegistration: true,
       allowUnauthenticatedClientRegistration: true,
@@ -209,6 +217,7 @@ export function getAuthPlugins(env: Record<string, unknown>) {
           scopes: buildAugmentedScopeClaims({
             requestedScopes: scopes,
             projectIds: isProjectScopedToken ? projects.map((project) => project.id) : [],
+            superadmin: typeof user?.role === "string" && user.role === "admin",
           }),
           [ITERATE_ACCESS_TOKEN_ORGANIZATIONS_CLAIM]: organizations,
           [ITERATE_ACCESS_TOKEN_PROJECTS_CLAIM]: projects,

--- a/apps/auth/src/server/auth.ts
+++ b/apps/auth/src/server/auth.ts
@@ -72,9 +72,16 @@ export const auth = betterAuth({
             });
           }
 
+          // Email-domain promotion is safe because password signup is disabled:
+          // both remaining sign-in methods (Google, email OTP) prove mailbox
+          // ownership before this hook runs.
+          const superadminAllowlist = parseSignupAllowlist(env.SUPERADMIN_ALLOWLIST);
+          const isSuperadmin = matchesSignupAllowlist(email, superadminAllowlist);
+
           return {
             data: {
               ...user,
+              role: isSuperadmin ? "admin" : user.role,
               image: user.image || generateDefaultAvatar(email),
             },
           };

--- a/apps/auth/src/server/oauth-project-selection.ts
+++ b/apps/auth/src/server/oauth-project-selection.ts
@@ -1,4 +1,7 @@
-import { ITERATE_PROJECT_SCOPE_PREFIX } from "@iterate-com/shared/auth-claims";
+import {
+  ITERATE_PROJECT_SCOPE_PREFIX,
+  ITERATE_SUPERADMIN_SCOPE,
+} from "@iterate-com/shared/auth-claims";
 import { parseStringArray } from "./db/helpers.ts";
 import { getLatestOAuthProjectSelectionByUserId } from "./db/queries/.generated/index.ts";
 import { db } from "./db/index.ts";
@@ -67,8 +70,17 @@ export function parseOAuthProjectSelectionReferenceId(referenceId: string | null
 export function buildAugmentedScopeClaims(params: {
   projectIds: string[];
   requestedScopes: string[];
+  superadmin: boolean;
 }) {
   const scopeClaims = new Set(params.requestedScopes.filter(Boolean));
+
+  // The superadmin scope is server-granted, never client-requested: a client
+  // can put it in its scope request, so being in the requested list proves
+  // nothing — only the user's role does.
+  scopeClaims.delete(ITERATE_SUPERADMIN_SCOPE);
+  if (params.superadmin) {
+    scopeClaims.add(ITERATE_SUPERADMIN_SCOPE);
+  }
 
   for (const projectId of normalizeProjectIds(params.projectIds)) {
     scopeClaims.add(`${ITERATE_PROJECT_SCOPE_PREFIX}${projectId}`);

--- a/apps/auth/src/server/oauth-project-selection.ts
+++ b/apps/auth/src/server/oauth-project-selection.ts
@@ -6,6 +6,24 @@ import { parseStringArray } from "./db/helpers.ts";
 import { getLatestOAuthProjectSelectionByUserId } from "./db/queries/.generated/index.ts";
 import { db } from "./db/index.ts";
 
+// Project-scoped tokens: when a client requests the `project` scope, the user
+// picks which projects the token may reach on the /project-access page, and
+// that choice has to travel from a UI page into token minting. better-auth's
+// oauth provider has no direct channel for this, so the selection makes a
+// three-step trip (all wired up in auth-plugins.ts):
+//
+//   1. /project-access stores the chosen project ids in the
+//      oauthProjectSelection table (one row per attempt, latest wins).
+//   2. postLogin.consentReferenceId reads that row and encodes
+//      { userId, projectIds } into the consent flow's opaque referenceId
+//      (build/parse helpers below).
+//   3. customAccessTokenClaims decodes the referenceId, deletes the stored
+//      rows (it's a one-shot handoff, not durable state), and narrows the
+//      token's `projects` claim + `project:<id>` scope entries to the
+//      selection.
+//
+// Refreshed tokens re-enter step 3 with the referenceId preserved by
+// better-auth, so the narrowing sticks for the lifetime of the grant.
 const OAUTH_PROJECT_SELECTION_REFERENCE_PREFIX = "iterate-project-selection-v1";
 
 export async function resolveStoredProjectSelection(params: { userId: string | null | undefined }) {

--- a/apps/auth/src/server/orpc/orpc.ts
+++ b/apps/auth/src/server/orpc/orpc.ts
@@ -10,6 +10,14 @@ import {
 } from "../db/queries/index.ts";
 import type { Variables } from "../utils/hono.ts";
 import type { CloudflareEnv } from "../env.ts";
+import { isSuperadminUser } from "../superadmin.ts";
+
+// Two role namespaces appear below; don't mix them up:
+// - `session.user.role` is the system-wide better-auth admin-plugin role.
+//   "admin" there means superadmin (see superadmin.ts) and bypasses every
+//   membership check.
+// - `membership.role` is scoped to one organization and is one of
+//   "owner" | "admin" | "member".
 
 type ORPCContext = RequestHeadersPluginContext & Variables & { env: CloudflareEnv };
 
@@ -31,7 +39,7 @@ export const protectedMiddleware = os.middleware(async ({ context, next }) => {
 
 export const superadminOnlyMiddleware = os.middleware(async ({ context, next }) => {
   const { session } = context;
-  if (!session || session.user.role !== "admin") {
+  if (!session || !isSuperadminUser(session.user)) {
     throw new ORPCError("UNAUTHORIZED", { message: "Not authorized" });
   }
   return next({
@@ -71,7 +79,7 @@ async function loadOrganization(params: {
     organizationId: organization.id,
     userId: params.user.id,
   });
-  if (!membership && params.user.role !== "admin") {
+  if (!membership && !isSuperadminUser(params.user)) {
     throw new ORPCError("FORBIDDEN", { message: "You do not have access to this organization" });
   }
 
@@ -82,9 +90,8 @@ function assertOrganizationAdmin(params: {
   user: { role?: string | null };
   membership: { role: string } | null;
 }) {
-  const isSystemAdmin = params.user.role === "admin";
   const role = params.membership?.role;
-  if (!isSystemAdmin && role !== "owner" && role !== "admin") {
+  if (!isSuperadminUser(params.user) && role !== "owner" && role !== "admin") {
     throw new ORPCError("FORBIDDEN", { message: "Admin role required" });
   }
 }
@@ -169,7 +176,7 @@ async function loadProject(params: {
     organizationId: organization.id,
     userId: params.user.id,
   });
-  if (!membership && params.user.role !== "admin") {
+  if (!membership && !isSuperadminUser(params.user)) {
     throw new ORPCError("FORBIDDEN", { message: "You do not have access to this project" });
   }
 

--- a/apps/auth/src/server/superadmin.ts
+++ b/apps/auth/src/server/superadmin.ts
@@ -1,0 +1,36 @@
+/**
+ * Superadmin model
+ * ----------------
+ * `user.role === "admin"` (the better-auth admin plugin's role column on the
+ * user table) is the single source of truth for superadmin status. Everything
+ * else is derived from it:
+ *
+ * - oRPC middleware (orpc.ts) lets superadmins through organization/project
+ *   membership checks.
+ * - Access tokens get the `superadmin` scope added server-side
+ *   (oauth-project-selection.ts); resource servers like the OS MCP handler
+ *   trust that scope. Clients cannot grant it to themselves — it is stripped
+ *   from requested scopes unless the role says otherwise.
+ * - ID tokens / userinfo expose it as the is_admin / role claims
+ *   (auth-plugins.ts).
+ *
+ * The role is granted three ways:
+ * - the signup hook in auth.ts, for emails matching SUPERADMIN_ALLOWLIST
+ *   (default `*@nustom.com`),
+ * - the deploy-time seed SQL (scripts/render-superadmin-seed.ts), which
+ *   backfills users who existed before their email domain was allowlisted,
+ * - manually, via the better-auth admin API.
+ *
+ * Nothing demotes automatically: someone whose email leaves the allowlist
+ * keeps the role until it is cleared by hand. Role changes reach access
+ * tokens within their 30-minute TTL and sessions within the 5-minute cookie
+ * cache.
+ *
+ * Not to be confused with per-organization membership roles
+ * ("owner"/"admin"/"member" on the member table) — see orpc.ts.
+ */
+export function isSuperadminUser(
+  user: { role?: unknown } | Record<string, unknown> | null | undefined,
+): boolean {
+  return user?.role === "admin";
+}

--- a/apps/auth/src/server/superadmin.ts
+++ b/apps/auth/src/server/superadmin.ts
@@ -18,7 +18,8 @@
  * - the signup hook in auth.ts, for emails matching SUPERADMIN_ALLOWLIST
  *   (default `*@nustom.com`),
  * - the deploy-time seed SQL (scripts/render-superadmin-seed.ts), which
- *   backfills users who existed before their email domain was allowlisted,
+ *   backfills users who existed before their email domain was allowlisted —
+ *   once per pattern, so it never overrides a later manual demotion,
  * - manually, via the better-auth admin API.
  *
  * Nothing demotes automatically: someone whose email leaves the allowlist

--- a/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
@@ -1,7 +1,8 @@
 import { createIterateAuth } from "@iterate-com/auth/server";
 import {
   ITERATE_PROJECT_SELECTION_SCOPE,
-  hasWildcardProjectScope,
+  ITERATE_SUPERADMIN_SCOPE,
+  hasSuperadminScope,
   listProjectScopeIds,
 } from "@iterate-com/shared/auth-claims";
 import { oauthResourceAudienceVariants } from "@iterate-com/shared/oauth-resource";
@@ -94,9 +95,9 @@ export async function handleMcpFetch(input: McpHandlerInput): Promise<Response |
   const scopes = readAccessTokenScopes(accessToken);
   const principal = principalFromAccessToken(accessToken);
   const grantedProjectIds = new Set(listProjectScopeIds(scopes));
-  const hasWildcardProjects = hasWildcardProjectScope(scopes);
+  const isSuperadmin = hasSuperadminScope(scopes);
   const projects = principal.projects.flatMap((project) => {
-    if (!hasWildcardProjects && !grantedProjectIds.has(project.id)) return [];
+    if (!isSuperadmin && !grantedProjectIds.has(project.id)) return [];
 
     const organization = principal.organizations.find((org) => org.id === project.organizationId);
     return [
@@ -167,7 +168,7 @@ async function authenticateAdminMcpRequest(input: McpHandlerInput) {
       organizationRole: "admin",
       organizationSlug: null,
     })),
-    scopes: ["profile"],
+    scopes: [ITERATE_SUPERADMIN_SCOPE],
     userId: "admin-api-secret",
   } satisfies ProjectMcpServerConnectionProps;
 }

--- a/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
@@ -45,6 +45,15 @@ export const mcpCorsHeaders = {
   "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
 };
 
+// Two ways to authenticate an MCP request, tried in order:
+// 1. The platform admin API secret (authenticateAdminMcpRequest): full access
+//    to every project in this deployment, props carry the `superadmin` scope.
+// 2. An Iterate Auth OAuth bearer token: project access is the intersection of
+//    two independent gates — the token's `projects` claim (which projects the
+//    user belongs to / selected during the OAuth flow) and its `project:<id>`
+//    scope entries. The `superadmin` scope (server-granted to role-admin
+//    users by apps/auth) skips the scope gate but not the claim gate, so even
+//    a superadmin's token only reaches projects listed in its claims.
 export async function handleMcpFetch(input: McpHandlerInput): Promise<Response | null> {
   const routeMatch = matchConfiguredMcpBaseUrl(input);
   if (!routeMatch) return null;

--- a/apps/os/src/durable-objects/iterate-mcp-server-test-entry.ts
+++ b/apps/os/src/durable-objects/iterate-mcp-server-test-entry.ts
@@ -114,7 +114,7 @@ function propsForRequest(request: Request): ProjectMcpServerConnectionProps {
         { id: "proj__test__other", slug: "other-project", ...orgFields },
       ],
       scopes: isAdmin
-        ? ["profile"]
+        ? ["superadmin"]
         : ["profile", "project", "project:proj__test__inboundmcp", "project:proj__test__other"],
       userId: isAdmin ? "admin-api-secret" : "user_test",
     };

--- a/apps/os/src/itx/admin-auth-cookie.ts
+++ b/apps/os/src/itx/admin-auth-cookie.ts
@@ -42,15 +42,15 @@ export async function handleCapnwebAdminCookieRequest(input: {
     secret: input.config.adminApiSecret!.exposeSecret(),
   });
   const url = new URL(input.request.url);
+  // SameSite=None is only valid together with Secure — browsers silently drop
+  // the cookie otherwise. On plain-http origins (local dev) fall back to Lax,
+  // which still covers same-origin fetches and WebSocket handshakes.
   const cookie = [
     `${CAPNWEB_ADMIN_AUTH_COOKIE}=${payload}`,
     "Path=/",
     "HttpOnly",
-    "SameSite=None",
-    url.protocol === "https:" ? "Secure" : "",
-  ]
-    .filter(Boolean)
-    .join("; ");
+    ...(url.protocol === "https:" ? ["SameSite=None", "Secure"] : ["SameSite=Lax"]),
+  ].join("; ");
   const headers = new Headers(corsHeaders);
   headers.set("set-cookie", cookie);
   return Response.json({ ok: true }, { headers });

--- a/apps/os/src/itx/handle.ts
+++ b/apps/os/src/itx/handle.ts
@@ -21,6 +21,7 @@ import { typeid } from "@iterate-com/shared/typeid";
 import { createD1Client } from "sqlfu";
 import { PathProxyRpcTarget } from "./path-proxy.ts";
 import {
+  GLOBAL_CONTEXT_ID,
   isChildContextId,
   RESERVED_CAP_NAMES,
   type CapInvoke,
@@ -103,7 +104,21 @@ export class Itx extends RpcTarget {
   }
 
   get streams(): ItxStreams {
-    return new ItxStreams(this.#runtime, this.#requireProjectId());
+    // Project handles read/write their project's namespace. A GLOBAL handle
+    // gets the deployment-wide "global" namespace instead — but only with
+    // access "all" (the admin API secret / admin cookie); a user's global
+    // handle must narrow to a project first, otherwise any logged-in user
+    // could read platform-level streams through /api/itx.
+    const projectId = this.#projectId();
+    if (projectId !== null) {
+      return new ItxStreams(this.#runtime, projectId);
+    }
+    if (this.#runtime.access !== "all") {
+      throw new Error(
+        "Global streams need admin access. Narrow to a project first: itx.projects.get(idOrSlug).",
+      );
+    }
+    return new ItxStreams(this.#runtime, GLOBAL_CONTEXT_ID);
   }
 
   get repos() {

--- a/apps/os/src/lib/admin-itx.ts
+++ b/apps/os/src/lib/admin-itx.ts
@@ -1,0 +1,18 @@
+// React context for the /admin section's root itx handle. Lives outside the
+// route files on purpose: route files get code-split and HMR-swapped per
+// route, so a context exported from one can resolve to a different module
+// instance in the layout vs. a child page — and useContext silently returns
+// null across instances.
+
+import { createContext, useContext } from "react";
+import type { RpcStub } from "capnweb";
+import type { Itx } from "~/itx/handle.ts";
+
+export const AdminItxContext = createContext<RpcStub<Itx> | null>(null);
+
+/** The root itx handle, available to every route under /admin once connected. */
+export function useAdminItx(): RpcStub<Itx> {
+  const itx = useContext(AdminItxContext);
+  if (!itx) throw new Error("useAdminItx must be used inside the /admin layout, once ready.");
+  return itx;
+}

--- a/apps/os/src/routeTree.gen.ts
+++ b/apps/os/src/routeTree.gen.ts
@@ -9,8 +9,10 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as AdminRouteImport } from './routes/admin'
 import { Route as AppRouteImport } from './routes/_app'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AdminIndexRouteImport } from './routes/admin/index'
 import { Route as SignUpSplatRouteImport } from './routes/sign-up.$'
 import { Route as SignInSplatRouteImport } from './routes/sign-in.$'
 import { Route as PosthogProxySplatRouteImport } from './routes/posthog-proxy.$'
@@ -45,6 +47,11 @@ import { Route as AppProjectsProjectSlugAgentsNewPresetRouteImport } from './rou
 import { Route as AppProjectsProjectSlugAgentsNewRouteImport } from './routes/_app/projects/$projectSlug/agents/new'
 import { Route as AppProjectsProjectSlugAgentsStreamsSplatRouteImport } from './routes/_app/projects/$projectSlug/agents/streams/$'
 
+const AdminRoute = AdminRouteImport.update({
+  id: '/admin',
+  path: '/admin',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AppRoute = AppRouteImport.update({
   id: '/_app',
   getParentRoute: () => rootRouteImport,
@@ -53,6 +60,11 @@ const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AdminIndexRoute = AdminIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AdminRoute,
 } as any)
 const SignUpSplatRoute = SignUpSplatRouteImport.update({
   id: '/sign-up/$',
@@ -243,6 +255,7 @@ const AppProjectsProjectSlugAgentsStreamsSplatRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/admin': typeof AdminRouteWithChildren
   '/projects': typeof AppProjectsRouteRouteWithChildren
   '/debug': typeof AppDebugRoute
   '/itx-repl': typeof AppItxReplRoute
@@ -253,6 +266,7 @@ export interface FileRoutesByFullPath {
   '/posthog-proxy/$': typeof PosthogProxySplatRoute
   '/sign-in/$': typeof SignInSplatRoute
   '/sign-up/$': typeof SignUpSplatRoute
+  '/admin/': typeof AdminIndexRoute
   '/projects/$projectSlug': typeof AppProjectsProjectSlugRouteRouteWithChildren
   '/api/orpc/$': typeof ApiOrpcSplatRoute
   '/projects/': typeof AppProjectsIndexRoute
@@ -288,6 +302,7 @@ export interface FileRoutesByTo {
   '/posthog-proxy/$': typeof PosthogProxySplatRoute
   '/sign-in/$': typeof SignInSplatRoute
   '/sign-up/$': typeof SignUpSplatRoute
+  '/admin': typeof AdminIndexRoute
   '/api/orpc/$': typeof ApiOrpcSplatRoute
   '/projects': typeof AppProjectsIndexRoute
   '/projects/$projectSlug/integrations': typeof AppProjectsProjectSlugIntegrationsRoute
@@ -313,6 +328,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_app': typeof AppRouteWithChildren
+  '/admin': typeof AdminRouteWithChildren
   '/_app/projects': typeof AppProjectsRouteRouteWithChildren
   '/_app/debug': typeof AppDebugRoute
   '/_app/itx-repl': typeof AppItxReplRoute
@@ -323,6 +339,7 @@ export interface FileRoutesById {
   '/posthog-proxy/$': typeof PosthogProxySplatRoute
   '/sign-in/$': typeof SignInSplatRoute
   '/sign-up/$': typeof SignUpSplatRoute
+  '/admin/': typeof AdminIndexRoute
   '/_app/projects/$projectSlug': typeof AppProjectsProjectSlugRouteRouteWithChildren
   '/api/orpc/$': typeof ApiOrpcSplatRoute
   '/_app/projects/': typeof AppProjectsIndexRoute
@@ -351,6 +368,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/admin'
     | '/projects'
     | '/debug'
     | '/itx-repl'
@@ -361,6 +379,7 @@ export interface FileRouteTypes {
     | '/posthog-proxy/$'
     | '/sign-in/$'
     | '/sign-up/$'
+    | '/admin/'
     | '/projects/$projectSlug'
     | '/api/orpc/$'
     | '/projects/'
@@ -396,6 +415,7 @@ export interface FileRouteTypes {
     | '/posthog-proxy/$'
     | '/sign-in/$'
     | '/sign-up/$'
+    | '/admin'
     | '/api/orpc/$'
     | '/projects'
     | '/projects/$projectSlug/integrations'
@@ -420,6 +440,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/_app'
+    | '/admin'
     | '/_app/projects'
     | '/_app/debug'
     | '/_app/itx-repl'
@@ -430,6 +451,7 @@ export interface FileRouteTypes {
     | '/posthog-proxy/$'
     | '/sign-in/$'
     | '/sign-up/$'
+    | '/admin/'
     | '/_app/projects/$projectSlug'
     | '/api/orpc/$'
     | '/_app/projects/'
@@ -458,6 +480,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AppRoute: typeof AppRouteWithChildren
+  AdminRoute: typeof AdminRouteWithChildren
   ApiSplatRoute: typeof ApiSplatRoute
   ApiOrpcWsRoute: typeof ApiOrpcWsRoute
   PosthogProxySplatRoute: typeof PosthogProxySplatRoute
@@ -468,6 +491,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/admin': {
+      id: '/admin'
+      path: '/admin'
+      fullPath: '/admin'
+      preLoaderRoute: typeof AdminRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_app': {
       id: '/_app'
       path: ''
@@ -481,6 +511,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/admin/': {
+      id: '/admin/'
+      path: '/'
+      fullPath: '/admin/'
+      preLoaderRoute: typeof AdminIndexRouteImport
+      parentRoute: typeof AdminRoute
     }
     '/sign-up/$': {
       id: '/sign-up/$'
@@ -839,9 +876,20 @@ const AppRouteChildren: AppRouteChildren = {
 
 const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)
 
+interface AdminRouteChildren {
+  AdminIndexRoute: typeof AdminIndexRoute
+}
+
+const AdminRouteChildren: AdminRouteChildren = {
+  AdminIndexRoute: AdminIndexRoute,
+}
+
+const AdminRouteWithChildren = AdminRoute._addFileChildren(AdminRouteChildren)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AppRoute: AppRouteWithChildren,
+  AdminRoute: AdminRouteWithChildren,
   ApiSplatRoute: ApiSplatRoute,
   ApiOrpcWsRoute: ApiOrpcWsRoute,
   PosthogProxySplatRoute: PosthogProxySplatRoute,

--- a/apps/os/src/routes/admin.tsx
+++ b/apps/os/src/routes/admin.tsx
@@ -1,0 +1,150 @@
+// /admin — the platform admin area. Everything under this layout talks to the
+// platform through a ROOT itx handle: a Cap'n Web session on the global
+// context (/api/itx), not oRPC. The handle only has global authority (access
+// "all") when the request carries admin credentials — the admin-cookie bridge
+// (POST /api/itx/admin-cookie with the admin API secret) sets those for the
+// browser, since WebSockets cannot send Authorization headers. Until then the
+// layout shows an unlock form instead of its children.
+
+import { useEffect, useState } from "react";
+import { createFileRoute, Link, Outlet } from "@tanstack/react-router";
+import type { RpcStub } from "capnweb";
+import { Button } from "@iterate-com/ui/components/button";
+import { Input } from "@iterate-com/ui/components/input";
+import type { Itx } from "~/itx/handle.ts";
+import { AdminItxContext } from "~/lib/admin-itx.ts";
+import { createBrowserReplSession } from "~/routes/_app/itx-repl.tsx";
+
+export const Route = createFileRoute("/admin")({
+  component: AdminLayout,
+});
+
+type AdminItxState =
+  | { status: "connecting" }
+  // The WebSocket is up but the handle lacks global authority (no admin
+  // cookie yet) — or the connection failed outright. Either way the fix is
+  // the same: unlock with the admin API secret.
+  | { status: "locked"; reason: string }
+  | { status: "ready"; itx: RpcStub<Itx> };
+
+function AdminLayout() {
+  const [state, setState] = useState<AdminItxState>({ status: "connecting" });
+  // Bumped after a successful unlock so the connect effect runs again with
+  // the freshly set admin cookie on the WebSocket handshake.
+  const [epoch, setEpoch] = useState(0);
+
+  useEffect(() => {
+    let closed = false;
+    const session = createBrowserReplSession();
+
+    // Probe global authority: itx.streams on a global handle throws unless
+    // the connection authenticated as admin, so one cheap call tells us
+    // whether to render the admin pages or the unlock form.
+    void session.itx.streams
+      .get("/")
+      .describe()
+      .then(() => {
+        if (!closed) setState({ status: "ready", itx: session.itx });
+      })
+      .catch((error: unknown) => {
+        if (!closed) {
+          setState({
+            status: "locked",
+            reason: error instanceof Error ? error.message : String(error),
+          });
+        }
+      });
+
+    return () => {
+      closed = true;
+      setState({ status: "connecting" });
+      session.close();
+    };
+  }, [epoch]);
+
+  return (
+    <div className="flex h-svh flex-col">
+      <header className="flex h-14 shrink-0 items-center gap-4 border-b px-4">
+        <span className="font-semibold">Iterate Admin</span>
+        <nav className="flex items-center gap-3 text-sm text-muted-foreground">
+          <Link to="/admin" className="hover:text-foreground [&.active]:text-foreground">
+            Global stream
+          </Link>
+        </nav>
+        <div className="ml-auto text-sm">
+          <Link to="/" className="text-muted-foreground hover:text-foreground">
+            Back to app
+          </Link>
+        </div>
+      </header>
+      <main className="min-h-0 flex-1 overflow-auto p-4">
+        {state.status === "connecting" && (
+          <p className="text-sm text-muted-foreground">Connecting to the root itx context…</p>
+        )}
+        {state.status === "locked" && (
+          <AdminUnlockForm reason={state.reason} onUnlocked={() => setEpoch((e) => e + 1)} />
+        )}
+        {state.status === "ready" && (
+          <AdminItxContext.Provider value={state.itx}>
+            <Outlet />
+          </AdminItxContext.Provider>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function AdminUnlockForm({ reason, onUnlocked }: { reason: string; onUnlocked: () => void }) {
+  const [secret, setSecret] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function unlock() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/itx/admin-cookie", {
+        body: secret.trim(),
+        credentials: "same-origin",
+        headers: { "content-type": "text/plain" },
+        method: "POST",
+      });
+      if (!response.ok) {
+        throw new Error(response.status === 401 ? "Wrong admin API secret." : response.statusText);
+      }
+      onUnlocked();
+    } catch (unlockError) {
+      setError(unlockError instanceof Error ? unlockError.message : String(unlockError));
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto mt-16 flex max-w-md flex-col gap-3">
+      <h1 className="text-lg font-semibold">Admin access required</h1>
+      <p className="text-sm text-muted-foreground">
+        This area uses a root itx context with global authority. Paste the admin API secret for this
+        deployment to set the admin cookie.
+      </p>
+      <p className="text-xs text-muted-foreground">({reason})</p>
+      <form
+        className="flex gap-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void unlock();
+        }}
+      >
+        <Input
+          type="password"
+          placeholder="Admin API secret"
+          value={secret}
+          onChange={(event) => setSecret(event.target.value)}
+        />
+        <Button type="submit" disabled={submitting || secret.trim() === ""}>
+          {submitting ? "Unlocking…" : "Unlock"}
+        </Button>
+      </form>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/apps/os/src/routes/admin/index.tsx
+++ b/apps/os/src/routes/admin/index.tsx
@@ -1,0 +1,100 @@
+// Admin home: the events in the global namespace's root ("/") stream, read
+// through the layout's root itx handle — itx.streams on a global admin handle
+// targets the "global" stream namespace (see itx/handle.ts).
+
+import { useCallback, useEffect, useState } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import type { StreamEvent } from "@iterate-com/streams/shared/event";
+import { Button } from "@iterate-com/ui/components/button";
+import { useAdminItx } from "~/lib/admin-itx.ts";
+
+export const Route = createFileRoute("/admin/")({
+  component: GlobalStreamPage,
+});
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "loaded"; events: StreamEvent[] };
+
+function GlobalStreamPage() {
+  const itx = useAdminItx();
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+
+  const load = useCallback(async () => {
+    setState({ status: "loading" });
+    try {
+      const events = (await itx.streams.get("/").read({})) as StreamEvent[];
+      setState({ status: "loaded", events });
+    } catch (error) {
+      setState({
+        status: "error",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, [itx]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <h1 className="text-lg font-semibold">
+          Global stream <code className="rounded bg-muted px-1.5 py-0.5 text-sm">global:/</code>
+        </h1>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => void load()}
+          disabled={state.status === "loading"}
+        >
+          Refresh
+        </Button>
+        {state.status === "loaded" && (
+          <span className="text-sm text-muted-foreground">
+            {state.events.length} event{state.events.length === 1 ? "" : "s"}
+          </span>
+        )}
+      </div>
+
+      {state.status === "loading" && <p className="text-sm text-muted-foreground">Loading…</p>}
+      {state.status === "error" && <p className="text-sm text-destructive">{state.message}</p>}
+      {state.status === "loaded" && state.events.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          No events yet. Anything appended to the <code>/</code> stream in the <code>global</code>{" "}
+          namespace shows up here.
+        </p>
+      )}
+      {state.status === "loaded" && state.events.length > 0 && (
+        <table className="w-full table-fixed border-collapse text-sm">
+          <thead>
+            <tr className="border-b text-left text-muted-foreground">
+              <th className="w-20 py-2 pr-4 font-medium">Offset</th>
+              <th className="w-56 py-2 pr-4 font-medium">Type</th>
+              <th className="w-44 py-2 pr-4 font-medium">Created</th>
+              <th className="py-2 font-medium">Payload</th>
+            </tr>
+          </thead>
+          <tbody>
+            {state.events.map((event) => (
+              <tr key={event.offset} className="border-b align-top">
+                <td className="py-2 pr-4 font-mono">{event.offset}</td>
+                <td className="py-2 pr-4 font-mono break-words">{event.type}</td>
+                <td className="py-2 pr-4 whitespace-nowrap text-muted-foreground">
+                  {new Date(event.createdAt).toLocaleString()}
+                </td>
+                <td className="py-2">
+                  <pre className="overflow-x-auto rounded bg-muted p-2 text-xs">
+                    {JSON.stringify(event.payload ?? null, null, 2)}
+                  </pre>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/packages/shared/src/auth-claims.ts
+++ b/packages/shared/src/auth-claims.ts
@@ -9,7 +9,9 @@ export const ITERATE_ACCESS_TOKEN_ORGANIZATIONS_CLAIM = "organizations";
 export const ITERATE_ACCESS_TOKEN_PROJECTS_CLAIM = "projects";
 export const ITERATE_PROJECT_SELECTION_SCOPE = "project";
 export const ITERATE_PROJECT_SCOPE_PREFIX = `${ITERATE_PROJECT_SELECTION_SCOPE}:` as const;
-const ITERATE_PROJECT_WILDCARD_SCOPE = `${ITERATE_PROJECT_SCOPE_PREFIX}*` as const;
+// Server-granted only: the auth worker strips this scope from tokens unless the
+// user's role is "admin", and OS grants it to admin-API-secret callers.
+export const ITERATE_SUPERADMIN_SCOPE = "superadmin";
 
 export const IterateAuthOrganizationClaim = z.object({
   id: z.string(),
@@ -42,7 +44,7 @@ export function listProjectScopeIds(scopes: Iterable<string>) {
     }
 
     const projectId = scope.slice(ITERATE_PROJECT_SCOPE_PREFIX.length).trim();
-    if (projectId.length === 0 || projectId === "*") {
+    if (projectId.length === 0) {
       continue;
     }
 
@@ -52,9 +54,9 @@ export function listProjectScopeIds(scopes: Iterable<string>) {
   return Array.from(projectIds);
 }
 
-export function hasWildcardProjectScope(scopes: Iterable<string>) {
+export function hasSuperadminScope(scopes: Iterable<string>) {
   for (const scope of scopes) {
-    if (scope === ITERATE_PROJECT_WILDCARD_SCOPE) return true;
+    if (scope === ITERATE_SUPERADMIN_SCOPE) return true;
   }
   return false;
 }


### PR DESCRIPTION
## What

Three related changes: a server-granted `superadmin` OAuth scope, auto-granting it to `@nustom.com` accounts, and a first `/admin` section in apps/os that runs entirely on a root itx context.

### 1. Superadmin scope (packages/shared, apps/auth)

- New `ITERATE_SUPERADMIN_SCOPE` (`"superadmin"`) + `hasSuperadminScope()` in `auth-claims`; the never-issued `project:*` wildcard scope and `hasWildcardProjectScope()` are deleted.
- The OAuth provider registers the scope, but `buildAugmentedScopeClaims` **always strips it from client-requested scopes and re-adds it only when the user's role is `admin`** — mirroring the existing server-side `project:<id>` augmentation. A client requesting it proves nothing; the role is the only grant path. Admin users' access tokens carry it automatically.
- Signup hook promotes emails matching `SUPERADMIN_ALLOWLIST` (new env var, **default `*@nustom.com`**, overridable per Doppler config) to `role: "admin"`, reusing the `signup-allowlist` minimatch helpers. Safe to key off email: password signup is disabled and Google / email OTP both prove mailbox ownership.
- Existing users are backfilled by the deploy-time superadmin seed SQL (minimatch→SQL-LIKE translation, verified against in-memory SQLite).
- `isSuperadminUser()` extracted (was duplicated across six call sites); docs added for the superadmin model, the two role namespaces, the three custom-claim surfaces, and the project-selection consentReferenceId handoff.

### 2. apps/os drops project:*

- The MCP handler checks `hasSuperadminScope(scopes)` instead of the wildcard to bypass per-project scope filtering (the `projects` claim still bounds access).
- The admin-API-secret MCP path now carries `scopes: ["superadmin"]` (was `["profile"]`).

### 3. /admin section on a root itx context (apps/os)

- New `/admin` layout + index route. The layout opens a Cap'n Web session on the **global** itx context (`/api/itx`), probes for global authority, and shows an unlock form (admin API secret → `/api/itx/admin-cookie`) when locked. No oRPC in the admin section.
- The index page lists the events of the `/` stream in the `global` namespace, with refresh.
- itx kernel: `itx.streams` on a **global** handle now targets the deployment-wide `global` stream namespace, gated on access `"all"` — user handles must still narrow to a project first.
- Bugfix: the admin-cookie bridge sent `SameSite=None` without `Secure` on plain-http origins, which browsers silently drop; it now uses `SameSite=Lax` on http (local dev).

## Notes

- Role changes reach tokens within ~30 min (access-token TTL) / 5 min (session cookie cache).
- Demotion is not automatic — the allowlist only promotes.
- Existing `@nustom.com` users become superadmins on the next apps/auth deploy per environment.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm format` clean; mcp-handler unit tests, `pnpm test:project-mcp-server-connection`, and packages/shared tests pass.
- Superadmin seed SQL executed against in-memory SQLite: nustom.com users promoted case-insensitively, others untouched.
- /admin verified end-to-end against the local dev stack: Node `connectItx` read/append on `global:/` (wrong secret rejected at the WS handshake), and the browser flow locked → unlock with admin secret → events table rendering the appended event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T10:31:30.009Z",
      "headSha": "172df2941941c08df3ae996c236fcd90a3151637",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27269765496",
      "shortSha": "172df29"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `172df29`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27269765496)
Updated: 2026-06-10T10:31:30.009Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication/authorization (role promotion, token scopes, MCP and itx global access) and auto-grants superadmin to a default email domain on deploy—mistakes affect who can administer the platform.
> 
> **Overview**
> Introduces a **server-granted `superadmin` OAuth scope** (replacing the unused `project:*` wildcard) and wires it through auth, tokens, and OS authorization.
> 
> **Auth:** New `SUPERADMIN_ALLOWLIST` (default `*@nustom.com`) promotes matching signups to `role: admin` and feeds deploy-time seed SQL that backfills existing users once per pattern (so manual demotions are not undone on redeploy). `isSuperadminUser()` centralizes checks; access tokens get `superadmin` only when the role is admin—client-requested scope is stripped in `buildAugmentedScopeClaims`. Consent UI documents the scope.
> 
> **OS:** MCP uses `hasSuperadminScope` to skip per-project scope checks (still bounded by token `projects` claims). Admin API secret MCP path emits `superadmin` instead of `profile`. New **`/admin`** UI connects to the global itx context via Cap'n Web, unlocks with the admin API secret cookie, and lists `global:/` stream events. Global handles can read deployment-wide streams only with access `"all"`. Admin cookie uses `SameSite=Lax` on HTTP so local dev cookies are not dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 172df2941941c08df3ae996c236fcd90a3151637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->