### PR TITLE
[codex] add OS docs portal for event types

### DIFF
--- a/apps/os/alchemy.run.ts
+++ b/apps/os/alchemy.run.ts
@@ -18,6 +18,7 @@ import type { SlackAgentDurableObject } from "./src/domains/slack/durable-object
 import type { SlackIntegrationDurableObject } from "./src/domains/slack/durable-objects/slack-integration-durable-object.ts";
 import type { WorkspaceDurableObject } from "./src/domains/workspaces/durable-objects/workspace-durable-object.ts";
 import type { OutboundMcpFromOurClientCapability } from "./src/domains/outbound-mcp-client/entrypoints/outbound-mcp-from-our-client-capability.ts";
+import { eventDocsHostnameForAppBaseUrl } from "./src/lib/event-docs-host.ts";
 
 const resolvedAuthIssuer =
   process.env.APP_CONFIG_ITERATE_AUTH__ISSUER ?? process.env.ITERATE_OAUTH_ISSUER;
@@ -93,6 +94,7 @@ const db = await D1Database("os-db", {
 // can own the iterate-preview-N.app zone cleanly.
 const projectHostnameBases = ctx.runtimeConfig.projectHostnameBases ?? [];
 const mcpRouteHostname = routeHostnameForUrl(ctx.runtimeConfig.mcp?.baseUrl);
+const eventDocsRouteHostname = eventDocsHostnameForAppBaseUrl(ctx.runtimeConfig.baseUrl);
 const artifactsAccountId = requireEnv("CLOUDFLARE_ACCOUNT_ID");
 const artifactsNamespace = `${ctx.workerName}-repos`;
 const outboundMcpFromOurClientCapability =
@@ -194,6 +196,7 @@ const { worker, afterFinalize } = await IterateApp(ctx, {
   // hostnames.
   compatibilityFlags: ["global_fetch_strictly_public"],
   extraRouteHostnames: [
+    ...(eventDocsRouteHostname ? [eventDocsRouteHostname] : []),
     ...(mcpRouteHostname ? [mcpRouteHostname] : []),
     ...projectHostnameBases.flatMap(projectRouteHostnamesForBase),
   ],

--- a/apps/os/src/components/docs-portal.tsx
+++ b/apps/os/src/components/docs-portal.tsx
@@ -1,0 +1,474 @@
+import { Link } from "@tanstack/react-router";
+import { useMemo, useState, type CSSProperties, type ReactNode } from "react";
+import { Search } from "lucide-react";
+import { Badge } from "@iterate-com/ui/components/badge";
+import { Input } from "@iterate-com/ui/components/input";
+import { Separator } from "@iterate-com/ui/components/separator";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarTrigger,
+} from "@iterate-com/ui/components/sidebar";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@iterate-com/ui/components/tooltip";
+import { StreamEventType } from "@iterate-com/ui/components/events/stream-event-type";
+import { cn } from "@iterate-com/ui/lib/utils";
+import {
+  eventDocs,
+  getEventDocByType,
+  processorDocs,
+  type EventDoc,
+  type EventReferenceDoc,
+  type ProcessorDoc,
+} from "~/lib/event-docs.ts";
+
+export function DocsHomePage() {
+  return (
+    <DocsPortalChrome>
+      <section className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-4 md:p-6">
+        <div className="space-y-2">
+          <p className="text-xs font-medium uppercase text-muted-foreground">Docs</p>
+          <h1 className="text-2xl font-semibold">Iterate OS docs</h1>
+          <p className="max-w-2xl text-sm text-muted-foreground">
+            Static server-rendered documentation for OS runtime concepts.
+          </p>
+        </div>
+        <Link
+          to="/docs/streams/processors"
+          className="block max-w-xl rounded-md border bg-card p-4 transition-colors hover:bg-accent/50"
+        >
+          <div className="space-y-1">
+            <h2 className="font-medium">Stream Processors</h2>
+            <p className="text-sm text-muted-foreground">
+              Processor contracts, event type URLs, payload schemas, and examples.
+            </p>
+          </div>
+        </Link>
+      </section>
+    </DocsPortalChrome>
+  );
+}
+
+export function StreamProcessorsIndexPage() {
+  const [query, setQuery] = useState("");
+  const normalizedQuery = query.trim().toLowerCase();
+  const visibleProcessors = useMemo(() => {
+    if (!normalizedQuery) return processorDocs;
+    return processorDocs.filter(
+      (processor) =>
+        processor.slug.toLowerCase().includes(normalizedQuery) ||
+        processor.contract.description?.toLowerCase().includes(normalizedQuery),
+    );
+  }, [normalizedQuery]);
+
+  return (
+    <DocsPortalChrome>
+      <section className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-4 md:p-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div className="space-y-2">
+            <p className="text-xs font-medium uppercase text-muted-foreground">Stream Processors</p>
+            <h1 className="text-2xl font-semibold">Processor contracts</h1>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              The contract catalog behind the resolvable `events.iterate.com` event type URLs.
+            </p>
+          </div>
+          <div className="relative w-full md:w-80">
+            <Search className="pointer-events-none absolute left-2.5 top-2.5 size-4 text-muted-foreground" />
+            <Input
+              aria-label="Search stream processors"
+              className="pl-8"
+              value={query}
+              onChange={(event) => setQuery(event.currentTarget.value)}
+              placeholder="Search processors"
+            />
+          </div>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <Metric label="Processors" value={processorDocs.length} />
+          <Metric label="Event types" value={eventDocs.length} />
+          <Metric
+            label="Side-effect processors"
+            value={processorDocs.filter((processor) => processor.events.length === 0).length}
+          />
+          <Metric
+            label="Wildcard consumers"
+            value={
+              processorDocs.filter((processor) => processor.contract.consumes.includes("*")).length
+            }
+          />
+        </div>
+        <div className="grid gap-3 md:grid-cols-2">
+          {visibleProcessors.map((processor) => (
+            <ProcessorSummary key={processor.slug} processor={processor} />
+          ))}
+        </div>
+      </section>
+    </DocsPortalChrome>
+  );
+}
+
+export function ProcessorOverviewPage({ processor }: { processor: ProcessorDoc }) {
+  return (
+    <DocsPortalChrome processor={processor}>
+      <section className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-4 md:p-6">
+        <div className="space-y-2">
+          <p className="text-xs font-medium uppercase text-muted-foreground">Stream Processor</p>
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-2xl font-semibold">{processor.slug}</h1>
+            {processor.contract.version ? (
+              <Badge variant="secondary">{processor.contract.version}</Badge>
+            ) : null}
+          </div>
+          {processor.contract.slug !== processor.slug ? (
+            <p className="text-xs text-muted-foreground">
+              Contract slug: {processor.contract.slug}
+            </p>
+          ) : null}
+          {processor.contract.description ? (
+            <p className="text-sm text-muted-foreground">{processor.contract.description}</p>
+          ) : null}
+        </div>
+
+        {processor.processorDeps.length > 0 ? (
+          <ProcessorLinks title="Processor deps" processors={processor.processorDeps} />
+        ) : null}
+
+        <EventReferenceLinks title="Consumes" events={processor.consumes} />
+        <UnresolvedEventReferences title="External consumes" types={processor.unresolvedConsumes} />
+        <EventReferenceLinks
+          title="Emits"
+          events={(processor.contract.emits ?? [])
+            .map((type) => getEventDocByType(type))
+            .filter((event): event is EventDoc => event != null)}
+        />
+        <UnresolvedEventReferences title="External emits" types={processor.unresolvedEmits} />
+        <EventLinks title="Owned events" events={processor.events} />
+      </section>
+    </DocsPortalChrome>
+  );
+}
+
+export function EventDocPage({ event }: { event: EventDoc }) {
+  const eventExamples =
+    event.examples.length > 0
+      ? event.examples.map((example) => ({
+          description: example.description,
+          event: { type: event.type, payload: example.payload },
+        }))
+      : [{ description: "Minimal event input", event: { type: event.type, payload: {} } }];
+
+  return (
+    <DocsPortalChrome event={event} processor={event.processor}>
+      <section className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-4 md:p-6">
+        <div className="space-y-2">
+          <p className="text-xs font-medium uppercase text-muted-foreground">Event Type</p>
+          <h1 className="text-xl font-semibold">
+            <EventType type={event.type} link={false} />
+          </h1>
+          {event.description ? (
+            <p className="text-sm text-muted-foreground">{event.description}</p>
+          ) : null}
+        </div>
+        <section className="space-y-2">
+          <h2 className="text-sm font-medium">Payload JSON schema</h2>
+          <CodeBlock value={event.payloadJsonSchema} className="max-h-[32rem]" />
+        </section>
+        <section className="space-y-2">
+          <h2 className="text-sm font-medium">
+            {eventExamples.length === 1 ? "Example event input" : "Example event inputs"}
+          </h2>
+          <div className="space-y-3">
+            {eventExamples.map((example) => (
+              <div key={example.description} className="space-y-2">
+                <p className="text-sm text-muted-foreground">{example.description}</p>
+                <CodeBlock value={example.event} />
+              </div>
+            ))}
+          </div>
+        </section>
+      </section>
+    </DocsPortalChrome>
+  );
+}
+
+function DocsPortalChrome({
+  children,
+  event,
+  processor,
+}: {
+  children: ReactNode;
+  event?: EventDoc;
+  processor?: ProcessorDoc;
+}) {
+  return (
+    <SidebarProvider
+      defaultOpen
+      className="h-svh"
+      style={{ "--sidebar-width": "22rem" } as CSSProperties}
+    >
+      <DocsSidebar />
+      <SidebarInset className="min-w-0 overflow-hidden">
+        <header className="flex h-12 shrink-0 items-center gap-2 border-b px-3">
+          <SidebarTrigger className="-ml-1" />
+          <Separator orientation="vertical" className="mr-1 h-4" />
+          <DocsBreadcrumbs event={event} processor={processor} />
+        </header>
+        <main className="flex min-h-0 flex-1 flex-col overflow-auto">{children}</main>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}
+
+function DocsSidebar() {
+  return (
+    <Sidebar collapsible="icon">
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="lg" render={<Link to="/docs" />}>
+              <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-md font-semibold">
+                OS
+              </div>
+              <div className="grid flex-1 text-left text-sm leading-tight">
+                <span className="truncate font-semibold">Docs</span>
+                <span className="truncate text-xs text-sidebar-foreground/70">OS reference</span>
+              </div>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Stream Processors</SidebarGroupLabel>
+          <SidebarGroupContent className="overflow-x-auto">
+            <SidebarMenu className="min-w-max">
+              {processorDocs.map((processor) => (
+                <DocsProcessorNavItem key={processor.slug} processor={processor} />
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+      <SidebarRail />
+    </Sidebar>
+  );
+}
+
+function DocsProcessorNavItem({ processor }: { processor: ProcessorDoc }) {
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton render={<Link to={processor.href} />}>
+        <span>{processor.slug}</span>
+      </SidebarMenuButton>
+      {processor.events.length > 0 ? (
+        <SidebarMenuSub className="mx-0 min-w-max border-l pl-3 pr-0">
+          {processor.events.map((event) => (
+            <SidebarMenuSubItem key={event.type}>
+              <SidebarMenuSubButton
+                render={<Link to={event.href} title={event.type} />}
+                className="h-6 font-mono text-[11px]"
+              >
+                <span className="truncate">{event.eventSlug}</span>
+              </SidebarMenuSubButton>
+            </SidebarMenuSubItem>
+          ))}
+        </SidebarMenuSub>
+      ) : null}
+    </SidebarMenuItem>
+  );
+}
+
+function DocsBreadcrumbs({ event, processor }: { event?: EventDoc; processor?: ProcessorDoc }) {
+  return (
+    <nav aria-label="Breadcrumbs" className="flex min-w-0 items-center gap-2 text-sm">
+      <Link to="/docs" className="shrink-0 text-muted-foreground hover:text-foreground">
+        Docs
+      </Link>
+      <span className="shrink-0 text-muted-foreground">/</span>
+      <Link
+        to="/docs/streams/processors"
+        className="shrink-0 text-muted-foreground hover:text-foreground"
+      >
+        Stream Processors
+      </Link>
+      {processor ? (
+        <>
+          <span className="shrink-0 text-muted-foreground">/</span>
+          <Link to={processor.href} className="min-w-0 truncate hover:underline">
+            {processor.slug}
+          </Link>
+        </>
+      ) : null}
+      {event ? (
+        <>
+          <span className="shrink-0 text-muted-foreground">/</span>
+          <span className="min-w-0 truncate font-mono text-xs">{event.eventSlug}</span>
+        </>
+      ) : null}
+    </nav>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md border bg-card p-3">
+      <p className="text-2xl font-semibold">{value}</p>
+      <p className="text-sm text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+function ProcessorSummary({ processor }: { processor: ProcessorDoc }) {
+  return (
+    <Link to={processor.href} className="block rounded-md border bg-card p-4 hover:bg-accent/50">
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-2">
+          <p className="truncate font-medium">{processor.slug}</p>
+          <Badge variant="outline">{processor.events.length} events</Badge>
+        </div>
+        {processor.contract.description ? (
+          <p className="line-clamp-2 text-sm text-muted-foreground">
+            {processor.contract.description}
+          </p>
+        ) : null}
+      </div>
+    </Link>
+  );
+}
+
+function ProcessorLinks({ processors, title }: { processors: ProcessorDoc[]; title: string }) {
+  return (
+    <DocPanel title={title}>
+      <div className="flex flex-col gap-2">
+        {processors.map((processor) => (
+          <Link
+            key={processor.slug}
+            to={processor.href}
+            className="text-sm text-primary hover:underline"
+          >
+            {processor.slug}
+          </Link>
+        ))}
+      </div>
+    </DocPanel>
+  );
+}
+
+function EventLinks({ events, title }: { events: EventDoc[]; title: string }) {
+  return (
+    <DocPanel title={title}>
+      {events.length === 0 ? (
+        <p className="text-sm text-muted-foreground">None.</p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {events.map((event) => (
+            <div key={event.type} className="min-w-0 space-y-1">
+              <EventType type={event.type} className="text-sm" />
+              {event.description ? (
+                <p className="text-sm text-muted-foreground">{event.description}</p>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      )}
+    </DocPanel>
+  );
+}
+
+function EventReferenceLinks({ events, title }: { events: EventReferenceDoc[]; title: string }) {
+  return (
+    <DocPanel title={title}>
+      {events.length === 0 ? (
+        <p className="text-sm text-muted-foreground">None.</p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {events.map((event) => (
+            <EventType key={event.type} type={event.type} className="text-sm" />
+          ))}
+        </div>
+      )}
+    </DocPanel>
+  );
+}
+
+function UnresolvedEventReferences({ title, types }: { title: string; types: readonly string[] }) {
+  if (types.length === 0) return null;
+
+  return (
+    <DocPanel title={title}>
+      <div className="flex flex-col gap-2">
+        {types.map((type) => (
+          <EventType key={type} type={type} className="text-sm" link={false} />
+        ))}
+      </div>
+    </DocPanel>
+  );
+}
+
+function DocPanel({ children, title }: { children: ReactNode; title: string }) {
+  return (
+    <section className="space-y-2 rounded-md border bg-card p-4">
+      <h2 className="text-xs font-medium uppercase text-muted-foreground">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function EventType({
+  type,
+  className,
+  link = true,
+}: {
+  type: string;
+  className?: string;
+  link?: boolean;
+}) {
+  const label = (
+    <StreamEventType
+      type={type}
+      getHref={link ? (eventType) => getEventDocByType(eventType)?.href : undefined}
+      renderLink={({ href, className: linkClassName, children }) => (
+        <Link to={href} className={linkClassName}>
+          {children}
+        </Link>
+      )}
+      className={cn("max-w-full", className)}
+    />
+  );
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={<span className="inline-flex min-w-0 max-w-full" />}>
+        {label}
+      </TooltipTrigger>
+      <TooltipContent className="max-w-sm">
+        <p className="font-mono text-xs wrap-break-word">{type}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function CodeBlock({ className, value }: { className?: string; value: unknown }) {
+  return (
+    <pre
+      className={cn(
+        "overflow-auto whitespace-pre-wrap wrap-break-word rounded-md border bg-muted p-3 font-mono text-xs",
+        className,
+      )}
+    >
+      {JSON.stringify(value, null, 2)}
+    </pre>
+  );
+}

--- a/apps/os/src/lib/docs-markdown.test.ts
+++ b/apps/os/src/lib/docs-markdown.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { handleDocsMarkdownFetch } from "~/lib/docs-markdown.ts";
+
+describe("docs markdown responses", () => {
+  it("serves Markdown for docs pages when requested by Accept header", async () => {
+    const response = handleDocsMarkdownFetch({
+      appBaseUrl: "https://os.iterate.com",
+      request: new Request("https://os.iterate.com/docs/streams/processors/stream", {
+        headers: { accept: "text/markdown, text/html;q=0.9" },
+      }),
+    });
+
+    expect(response?.headers.get("content-type")).toContain("text/markdown");
+    expect(response?.headers.get("vary")).toBe("accept");
+    await expect(response?.text()).resolves.toContain("# stream");
+  });
+
+  it("keeps ordinary browser accepts on HTML", () => {
+    const response = handleDocsMarkdownFetch({
+      appBaseUrl: "https://os.iterate.com",
+      request: new Request("https://os.iterate.com/docs/streams/processors/stream", {
+        headers: { accept: "text/html,application/xhtml+xml,*/*;q=0.8" },
+      }),
+    });
+
+    expect(response).toBeNull();
+  });
+
+  it("serves Markdown from index.md URLs without needing Accept negotiation", async () => {
+    const response = handleDocsMarkdownFetch({
+      appBaseUrl: "https://os.iterate.com",
+      request: new Request("https://os.iterate.com/docs/streams/processors/stream/index.md"),
+    });
+
+    expect(response?.headers.get("content-type")).toContain("text/markdown");
+    await expect(response?.text()).resolves.toContain("Maintains the stream's own reduced state.");
+  });
+
+  it("serves root llms.txt for OS discovery", async () => {
+    const response = handleDocsMarkdownFetch({
+      appBaseUrl: "https://os.iterate.com",
+      request: new Request("https://os.iterate.com/llms.txt"),
+    });
+
+    await expect(response?.text()).resolves.toContain("## Stream Processors");
+  });
+
+  it("keeps docs llms.txt as a discovery alias", async () => {
+    const response = handleDocsMarkdownFetch({
+      appBaseUrl: "https://os.iterate.com",
+      request: new Request("https://os.iterate.com/docs/llms.txt"),
+    });
+
+    await expect(response?.text()).resolves.toContain("## Stream Processors");
+  });
+
+  it("serves root llms.txt for the events host", async () => {
+    const response = handleDocsMarkdownFetch({
+      appBaseUrl: "https://os.iterate.com",
+      request: new Request("https://events.iterate.com/llms.txt"),
+    });
+
+    await expect(response?.text()).resolves.toContain("## Stream Processors");
+  });
+
+  it("maps event-host aliases to the same Markdown content", async () => {
+    const response = handleDocsMarkdownFetch({
+      appBaseUrl: "https://os.iterate.com",
+      request: new Request("https://events.iterate.com/stream/created", {
+        headers: { accept: "text/markdown" },
+      }),
+    });
+
+    await expect(response?.text()).resolves.toContain("# events.iterate.com/stream/created");
+  });
+
+  it("serves canonical docs paths on the events host with Accept negotiation", async () => {
+    const response = handleDocsMarkdownFetch({
+      appBaseUrl: "https://os.iterate.com",
+      request: new Request("https://events.iterate.com/docs/streams/processors/stream", {
+        headers: { accept: "text/markdown" },
+      }),
+    });
+
+    await expect(response?.text()).resolves.toContain("# stream");
+  });
+
+  it("serves canonical docs index.md paths on the events host", async () => {
+    const response = handleDocsMarkdownFetch({
+      appBaseUrl: "https://os.iterate.com",
+      request: new Request("https://events.iterate.com/docs/streams/processors/stream/index.md"),
+    });
+
+    await expect(response?.text()).resolves.toContain("Maintains the stream's own reduced state.");
+  });
+});

--- a/apps/os/src/lib/docs-markdown.ts
+++ b/apps/os/src/lib/docs-markdown.ts
@@ -1,0 +1,349 @@
+import {
+  eventDocs,
+  getEventDocByPath,
+  getProcessorDocByPath,
+  processorDocs,
+  type EventDoc,
+  type EventReferenceDoc,
+  type ProcessorDoc,
+} from "~/lib/event-docs.ts";
+import { isEventDocsHostname } from "~/lib/event-docs-host.ts";
+
+export function handleDocsMarkdownFetch(input: {
+  appBaseUrl: string | undefined;
+  request: Request;
+}) {
+  const url = new URL(input.request.url);
+  const isEventDocsHost = isEventDocsHostname({
+    appBaseUrl: input.appBaseUrl,
+    requestUrl: input.request.url,
+  });
+  const markdownRequest = resolveDocsMarkdownRequest({
+    isEventDocsHost,
+    pathname: url.pathname,
+  });
+  if (!markdownRequest) return null;
+
+  if (!markdownRequest.forceMarkdown && !prefersMarkdown(input.request.headers.get("accept"))) {
+    return null;
+  }
+
+  const markdown = renderDocsMarkdown(markdownRequest);
+  if (!markdown) return null;
+
+  return new Response(markdown, {
+    headers: {
+      "content-signal": "ai-train=yes, search=yes, ai-input=yes",
+      "content-type": "text/markdown; charset=utf-8",
+      vary: "accept",
+      "x-markdown-tokens": estimateTokenCount(markdown).toString(),
+    },
+  });
+}
+
+type DocsMarkdownRequest =
+  | { kind: "llms"; forceMarkdown: boolean }
+  | { kind: "home"; forceMarkdown: boolean }
+  | { kind: "stream-processors"; forceMarkdown: boolean }
+  | { kind: "processor"; forceMarkdown: boolean; processor: ProcessorDoc }
+  | { kind: "event"; forceMarkdown: boolean; event: EventDoc };
+
+function resolveDocsMarkdownRequest(input: {
+  isEventDocsHost: boolean;
+  pathname: string;
+}): DocsMarkdownRequest | null {
+  const path = normalizePath(input.pathname);
+  const markdownPath = stripMarkdownIndexSuffix(path);
+  const forceMarkdown = markdownPath !== path || path.endsWith(".md") || path.endsWith("llms.txt");
+
+  if (input.isEventDocsHost) {
+    if (markdownPath === "" || markdownPath === "docs") return { kind: "home", forceMarkdown };
+    if (markdownPath === "llms.txt" || markdownPath === "docs/llms.txt") {
+      return { kind: "llms", forceMarkdown: true };
+    }
+    if (markdownPath.startsWith("docs/")) {
+      return resolveCanonicalDocsMarkdownPath({ forceMarkdown, markdownPath });
+    }
+
+    const [processorSlug, ...eventSlugParts] = markdownPath.split("/");
+    if (!processorSlug) return null;
+    if (eventSlugParts.length === 0) {
+      const processor = getProcessorDocByPath(processorSlug);
+      return processor ? { kind: "processor", processor, forceMarkdown } : null;
+    }
+
+    const event = getEventDocByPath(`${processorSlug}/${eventSlugParts.join("/")}`);
+    return event ? { kind: "event", event, forceMarkdown } : null;
+  }
+
+  return resolveCanonicalDocsMarkdownPath({ forceMarkdown, markdownPath });
+}
+
+function resolveCanonicalDocsMarkdownPath(input: {
+  forceMarkdown: boolean;
+  markdownPath: string;
+}): DocsMarkdownRequest | null {
+  const { forceMarkdown, markdownPath } = input;
+  if (markdownPath === "docs" || markdownPath === "docs/") return { kind: "home", forceMarkdown };
+  if (markdownPath === "llms.txt" || markdownPath === "docs/llms.txt") {
+    return { kind: "llms", forceMarkdown: true };
+  }
+  if (markdownPath === "docs/streams/processors") {
+    return { kind: "stream-processors", forceMarkdown };
+  }
+
+  const processorMatch = markdownPath.match(/^docs\/streams\/processors\/([^/]+)$/);
+  if (processorMatch?.[1]) {
+    const processor = getProcessorDocByPath(processorMatch[1]);
+    return processor ? { kind: "processor", processor, forceMarkdown } : null;
+  }
+
+  const eventMatch = markdownPath.match(/^docs\/streams\/processors\/([^/]+)\/events\/(.+)$/);
+  if (eventMatch?.[1] && eventMatch[2]) {
+    const event =
+      getEventDocByPath(`${eventMatch[1]}/${eventMatch[2]}`) ?? getEventDocByPath(eventMatch[2]);
+    return event ? { kind: "event", event, forceMarkdown } : null;
+  }
+
+  return null;
+}
+
+function renderDocsMarkdown(request: DocsMarkdownRequest) {
+  switch (request.kind) {
+    case "llms":
+      return renderLlmsTxt();
+    case "home":
+      return (
+        frontmatter({
+          title: "Iterate OS docs",
+          description: "Static documentation for Iterate OS runtime concepts.",
+        }) +
+        [
+          "# Iterate OS docs",
+          "",
+          "Static documentation for Iterate OS runtime concepts.",
+          "",
+          "## Sections",
+          "",
+          `- [Stream Processors](/docs/streams/processors) - Processor contracts, event type URLs, payload schemas, and examples.`,
+        ].join("\n")
+      );
+    case "stream-processors":
+      return renderStreamProcessorsMarkdown();
+    case "processor":
+      return renderProcessorMarkdown(request.processor);
+    case "event":
+      return renderEventMarkdown(request.event);
+  }
+}
+
+function renderLlmsTxt() {
+  return [
+    "# Iterate OS docs",
+    "",
+    "> Documentation index for agents. Request any page with `Accept: text/markdown` or append `/index.md` for Markdown.",
+    "",
+    "## Docs",
+    "",
+    "- [Docs home](/docs)",
+    "- [Stream Processors](/docs/streams/processors)",
+    "",
+    "## Stream Processors",
+    "",
+    ...processorDocs.map(
+      (processor) =>
+        `- [${processor.slug}](${processor.href}) - ${processor.contract.description ?? "No description."}`,
+    ),
+  ].join("\n");
+}
+
+function renderStreamProcessorsMarkdown() {
+  return (
+    frontmatter({
+      title: "Stream Processors",
+      description: "Processor contracts, event type URLs, payload schemas, and examples.",
+    }) +
+    [
+      "# Stream Processors",
+      "",
+      `Processor contracts: ${processorDocs.length}`,
+      `Event types: ${eventDocs.length}`,
+      "",
+      "## Processors",
+      "",
+      ...processorDocs.flatMap((processor) => [
+        `### [${processor.slug}](${processor.href})`,
+        "",
+        processor.contract.description ?? "No description.",
+        "",
+        `Owned events: ${processor.events.length}`,
+        "",
+      ]),
+    ].join("\n")
+  );
+}
+
+function renderProcessorMarkdown(processor: ProcessorDoc) {
+  return (
+    frontmatter({
+      title: `${processor.slug} stream processor`,
+      description: processor.contract.description ?? "Stream processor contract documentation.",
+    }) +
+    [
+      `# ${processor.slug}`,
+      "",
+      processor.contract.description ?? "No description.",
+      "",
+      `- Canonical docs path: \`${processor.href}\``,
+      `- Contract slug: \`${processor.contract.slug}\``,
+      processor.contract.version ? `- Version: \`${processor.contract.version}\`` : undefined,
+      "",
+      ...sectionList(
+        "Processor deps",
+        processor.processorDeps.map((dep) => `- [${dep.slug}](${dep.href})`),
+      ),
+      ...eventReferenceSection("Consumes", processor.consumes),
+      ...stringSection("External consumes", processor.unresolvedConsumes),
+      ...eventReferenceSection(
+        "Emits",
+        (processor.contract.emits ?? [])
+          .map((type) => eventDocs.find((event) => event.type === type))
+          .filter((event): event is EventDoc => event != null),
+      ),
+      ...stringSection("External emits", processor.unresolvedEmits),
+      ...sectionList(
+        "Owned events",
+        processor.events.map((event) =>
+          [`- [${event.type}](${event.href})`, event.description ? `  ${event.description}` : ""]
+            .filter(Boolean)
+            .join("\n"),
+        ),
+      ),
+    ]
+      .filter((line): line is string => line != null)
+      .join("\n")
+  );
+}
+
+function renderEventMarkdown(event: EventDoc) {
+  const examples =
+    event.examples.length > 0
+      ? event.examples
+      : [{ description: "Minimal event input", payload: {} }];
+
+  return (
+    frontmatter({
+      title: event.type,
+      description: event.description ?? "Event type documentation.",
+    }) +
+    [
+      `# ${event.type}`,
+      "",
+      event.description ?? "No description.",
+      "",
+      `- Canonical event URL: \`https://${event.type}\``,
+      `- Canonical docs path: \`${event.href}\``,
+      `- Owning processor: [${event.processor.slug}](${event.processor.href})`,
+      "",
+      "## Payload JSON schema",
+      "",
+      "```json",
+      JSON.stringify(event.payloadJsonSchema, null, 2),
+      "```",
+      "",
+      examples.length === 1 ? "## Example event input" : "## Example event inputs",
+      "",
+      ...examples.flatMap((example) => [
+        `### ${example.description}`,
+        "",
+        "```json",
+        JSON.stringify({ type: event.type, payload: example.payload }, null, 2),
+        "```",
+        "",
+      ]),
+    ].join("\n")
+  );
+}
+
+function eventReferenceSection(title: string, events: readonly EventReferenceDoc[]) {
+  return sectionList(
+    title,
+    events.map((event) => `- ${event.href ? `[${event.type}](${event.href})` : event.type}`),
+  );
+}
+
+function stringSection(title: string, values: readonly string[]) {
+  return sectionList(
+    title,
+    values.map((value) => `- ${value}`),
+  );
+}
+
+function sectionList(title: string, items: readonly string[]) {
+  if (items.length === 0) return [] as string[];
+  return [`## ${title}`, "", ...items, ""];
+}
+
+function frontmatter(input: { description: string; title: string }) {
+  return [
+    "---",
+    `title: ${yamlString(input.title)}`,
+    `description: ${yamlString(input.description)}`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+function yamlString(value: string) {
+  return JSON.stringify(value);
+}
+
+function stripMarkdownIndexSuffix(path: string) {
+  if (path === "index.md") return "";
+  if (path.endsWith("/index.md")) return path.slice(0, -"/index.md".length);
+  if (path.endsWith(".md")) return path.slice(0, -".md".length);
+  return path;
+}
+
+function normalizePath(pathname: string) {
+  return decodeURIComponent(pathname).replace(/^\/+|\/+$/g, "");
+}
+
+function prefersMarkdown(accept: string | null) {
+  const parsed = parseAccept(accept);
+  if (parsed.length === 0) return false;
+
+  const markdown = bestQuality(parsed, ["text/markdown", "text/*"]);
+  const html = bestQuality(parsed, ["text/html", "application/xhtml+xml"]);
+  const all = bestQuality(parsed, ["*/*"]);
+
+  if (markdown == null) return false;
+  if (html == null && all == null) return true;
+  return markdown > Math.max(html ?? 0, all ?? 0);
+}
+
+function parseAccept(accept: string | null) {
+  if (!accept) return [] as Array<{ mediaType: string; q: number }>;
+
+  return accept
+    .split(",")
+    .map((part) => {
+      const [mediaType, ...params] = part.trim().split(";");
+      const qParam = params.find((param) => param.trim().startsWith("q="));
+      const q = qParam ? Number(qParam.trim().slice(2)) : 1;
+      return mediaType
+        ? { mediaType: mediaType.toLowerCase(), q: Number.isFinite(q) ? q : 0 }
+        : null;
+    })
+    .filter((item): item is { mediaType: string; q: number } => item != null && item.q > 0);
+}
+
+function bestQuality(parsed: readonly { mediaType: string; q: number }[], mediaTypes: string[]) {
+  const matches = parsed.filter((item) => mediaTypes.includes(item.mediaType));
+  if (matches.length === 0) return null;
+  return Math.max(...matches.map((item) => item.q));
+}
+
+function estimateTokenCount(markdown: string) {
+  return Math.ceil(markdown.split(/\s+/).filter(Boolean).length * 1.35);
+}

--- a/apps/os/src/lib/event-docs-host.test.ts
+++ b/apps/os/src/lib/event-docs-host.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { eventDocsHostnameForAppBaseUrl, isEventDocsHostname } from "~/lib/event-docs-host.ts";
+
+describe("event docs host", () => {
+  it("derives the production event docs host from the OS production host", () => {
+    expect(eventDocsHostnameForAppBaseUrl("https://os.iterate.com")).toBe("events.iterate.com");
+  });
+
+  it("derives sibling event docs hosts for preview and dev OS hosts", () => {
+    expect(eventDocsHostnameForAppBaseUrl("https://os.iterate-preview-3.com")).toBe(
+      "events.iterate-preview-3.com",
+    );
+    expect(eventDocsHostnameForAppBaseUrl("https://os.iterate-dev-jonas.com")).toBe(
+      "events.iterate-dev-jonas.com",
+    );
+  });
+
+  it("does not derive a routed event docs host for localhost", () => {
+    expect(eventDocsHostnameForAppBaseUrl("http://localhost:5173")).toBeNull();
+  });
+
+  it("recognizes the configured event docs request host", () => {
+    expect(
+      isEventDocsHostname({
+        appBaseUrl: "https://os.iterate-preview-3.com",
+        requestUrl: "https://events.iterate-preview-3.com/stream",
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/os/src/lib/event-docs-host.ts
+++ b/apps/os/src/lib/event-docs-host.ts
@@ -1,0 +1,29 @@
+import { normalizeRequestHostname } from "~/lib/project-host-routing.ts";
+
+export const PRODUCTION_EVENT_DOCS_HOSTNAME = "events.iterate.com";
+
+export function eventDocsHostnameForAppBaseUrl(baseUrl: string | undefined) {
+  if (!baseUrl) return null;
+
+  const hostname = normalizeRequestHostname(new URL(baseUrl).hostname);
+  if (hostname.startsWith("localhost") || hostname === "127.0.0.1" || hostname === "::1") {
+    return null;
+  }
+
+  if (hostname === "os.iterate.com") return PRODUCTION_EVENT_DOCS_HOSTNAME;
+  if (hostname.startsWith("os.")) return `events.${hostname.slice("os.".length)}`;
+  return null;
+}
+
+export function isEventDocsHostname(input: {
+  appBaseUrl: string | undefined;
+  requestUrl: string | undefined;
+}) {
+  if (!input.requestUrl) return false;
+
+  const requestHostname = normalizeRequestHostname(new URL(input.requestUrl).hostname);
+  return (
+    requestHostname === PRODUCTION_EVENT_DOCS_HOSTNAME ||
+    requestHostname === eventDocsHostnameForAppBaseUrl(input.appBaseUrl)
+  );
+}

--- a/apps/os/src/lib/event-docs.test.ts
+++ b/apps/os/src/lib/event-docs.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  eventDocs,
+  getEventDocByPath,
+  getProcessorDocByPath,
+  processorDocs,
+} from "~/lib/event-docs.ts";
+
+describe("event docs catalog", () => {
+  it("documents the stream processor at the public stream slug", () => {
+    const processor = getProcessorDocByPath("stream");
+
+    expect(processor?.slug).toBe("stream");
+    expect(processor?.contract.slug).toBe("core");
+    expect(processor?.href).toBe("/docs/streams/processors/stream");
+  });
+
+  it("maps event URL paths to docs pages under the owning processor", () => {
+    const event = getEventDocByPath("stream/created");
+
+    expect(event?.type).toBe("events.iterate.com/stream/created");
+    expect(event?.href).toBe("/docs/streams/processors/stream/events/created");
+  });
+
+  it("keeps the stream/create alias navigable", () => {
+    expect(getEventDocByPath("stream/create")).toBe(getEventDocByPath("stream/created"));
+  });
+
+  it("keeps full event paths in docs links when the event namespace differs from the page slug", () => {
+    const event = getEventDocByPath("os/project-created");
+
+    expect(event?.href).toBe("/docs/streams/processors/project/events/os/project-created");
+  });
+
+  it("builds a non-empty processor and event catalog", () => {
+    expect(processorDocs.length).toBeGreaterThan(5);
+    expect(eventDocs.length).toBeGreaterThan(10);
+  });
+});

--- a/apps/os/src/lib/event-docs.ts
+++ b/apps/os/src/lib/event-docs.ts
@@ -1,0 +1,280 @@
+import { z } from "zod";
+import { CircuitBreakerContract } from "@iterate-com/streams/processors/circuit-breaker/contract";
+import { CoreProcessorContract } from "@iterate-com/streams/processors/core/contract";
+import { AgentChatProcessorContract } from "~/domains/agents/stream-processors/agent-chat/contract.ts";
+import { AgentHostProcessorContract } from "~/domains/agents/stream-processors/agent-host/contract.ts";
+import { AgentProcessorContract } from "~/domains/agents/stream-processors/agent/contract.ts";
+import { CloudflareAiProcessorContract } from "~/domains/agents/stream-processors/cloudflare-ai/contract.ts";
+import { JsonataReactorProcessorContract } from "~/domains/agents/stream-processors/jsonata-reactor/contract.ts";
+import { OpenAiWsProcessorContract } from "~/domains/agents/stream-processors/openai-ws/contract.ts";
+import { CodemodeProcessorContract } from "~/domains/codemode/stream-processors/codemode/contract.ts";
+import { ProjectLifecycleProcessorContract } from "~/domains/projects/stream-processors/project-lifecycle.ts";
+import { RepoStreamProcessorContract } from "~/domains/repos/stream-processors/repo-stream-processor.ts";
+import { SlackAgentProcessorContract } from "~/domains/slack/stream-processors/slack-agent/contract.ts";
+import { SlackProcessorContract } from "~/domains/slack/stream-processors/slack/contract.ts";
+
+const EVENT_TYPE_PREFIX = "events.iterate.com/";
+const EVENT_TYPE_URL_PREFIX = "https://events.iterate.com/";
+
+type EventDefinitionForDocs = {
+  description?: string;
+  examples?: unknown;
+  payloadSchema?: z.ZodType;
+};
+
+type ProcessorContractForDocs = {
+  consumes: readonly string[];
+  description?: string;
+  emits?: readonly string[];
+  events: Record<string, EventDefinitionForDocs>;
+  processorDeps?: readonly unknown[];
+  slug: string;
+  version?: string;
+};
+
+const processorContracts = [
+  CoreProcessorContract,
+  CircuitBreakerContract,
+  ProjectLifecycleProcessorContract,
+  RepoStreamProcessorContract,
+  AgentProcessorContract,
+  AgentChatProcessorContract,
+  AgentHostProcessorContract,
+  CloudflareAiProcessorContract,
+  JsonataReactorProcessorContract,
+  OpenAiWsProcessorContract,
+  CodemodeProcessorContract,
+  SlackProcessorContract,
+  SlackAgentProcessorContract,
+] as const satisfies readonly ProcessorContractForDocs[];
+
+export type EventDoc = {
+  description?: string;
+  eventPath: string;
+  eventSlug: string;
+  examples: EventExampleDoc[];
+  href: string;
+  payloadJsonSchema: unknown;
+  processor: ProcessorDoc;
+  type: string;
+};
+
+export type EventExampleDoc = {
+  description: string;
+  payload: unknown;
+};
+
+export type ProcessorDoc = {
+  consumes: EventReferenceDoc[];
+  contract: ProcessorContractForDocs;
+  docsPath: string;
+  events: EventDoc[];
+  href: string;
+  processorDeps: ProcessorDoc[];
+  slug: string;
+  unresolvedConsumes: string[];
+  unresolvedEmits: string[];
+};
+
+export type EventReferenceDoc = {
+  description?: string;
+  href?: string;
+  type: string;
+};
+
+export const processorDocs = buildProcessorDocs();
+export const eventDocs = processorDocs.flatMap((processor) => processor.events);
+
+const eventsByPath = new Map(eventDocs.map((event) => [event.eventPath, event]));
+const eventsByType = new Map(eventDocs.map((event) => [event.type, event]));
+const processorsByPath = new Map(processorDocs.map((processor) => [processor.docsPath, processor]));
+const processorsBySlug = new Map(
+  processorDocs.map((processor) => [processor.contract.slug, processor]),
+);
+
+const streamCreatedEvent = eventsByPath.get("stream/created");
+if (streamCreatedEvent) eventsByPath.set("stream/create", streamCreatedEvent);
+
+export function getProcessorDocByPath(path: string) {
+  const cleanPath = cleanEventPath(path);
+  return processorsByPath.get(cleanPath) ?? processorsBySlug.get(cleanPath);
+}
+
+export function getEventDocByPath(path: string) {
+  return eventsByPath.get(cleanEventPath(path));
+}
+
+export function getEventDocByType(type: string) {
+  return eventsByType.get(type);
+}
+
+export function processorDocsPathForSlug(processorSlug: string) {
+  return `/docs/streams/processors/${processorSlug}`;
+}
+
+export function processorEventDocsPath(event: EventDoc) {
+  const eventPath =
+    event.eventPath === `${event.processor.slug}/${event.eventSlug}`
+      ? event.eventSlug
+      : event.eventPath;
+  return `/docs/streams/processors/${event.processor.slug}/events/${eventPath}`;
+}
+
+function buildProcessorDocs(): ProcessorDoc[] {
+  const baseDocs = processorContracts.map((contract) => buildBaseProcessorDoc(contract));
+  const docsBySlug = new Map(baseDocs.map((processor) => [processor.contract.slug, processor]));
+  const eventReferencesByType = new Map(
+    baseDocs.flatMap((processor) =>
+      processor.events.map((event) => [
+        event.type,
+        {
+          type: event.type,
+          href: event.href,
+          description: event.description,
+        } satisfies EventReferenceDoc,
+      ]),
+    ),
+  );
+
+  return baseDocs.map((processor) => ({
+    ...processor,
+    consumes: resolveEventReferences({
+      eventReferencesByType,
+      types: processor.contract.consumes.filter((type) => type !== "*"),
+    }),
+    processorDeps: (processor.contract.processorDeps ?? [])
+      .map((dep) => (hasProcessorSlug(dep) ? docsBySlug.get(dep.slug) : undefined))
+      .filter((dep): dep is ProcessorDoc => dep != null),
+    unresolvedConsumes: processor.contract.consumes.filter(
+      (type) => type !== "*" && !eventReferencesByType.has(type),
+    ),
+    unresolvedEmits: (processor.contract.emits ?? []).filter(
+      (type) => !eventReferencesByType.has(type),
+    ),
+  }));
+}
+
+function buildBaseProcessorDoc(contract: ProcessorContractForDocs): ProcessorDoc {
+  const docsPath = processorDocsPath(contract);
+  const processor: ProcessorDoc = {
+    contract,
+    docsPath,
+    href: processorDocsPathForSlug(docsPath),
+    slug: docsPath,
+    events: [],
+    consumes: [],
+    processorDeps: [],
+    unresolvedConsumes: [],
+    unresolvedEmits: [],
+  } satisfies ProcessorDoc;
+
+  processor.events = Object.entries(contract.events)
+    .map(([type, definition]) => buildEventDoc({ definition, processor, type }))
+    .sort((a, b) => a.eventPath.localeCompare(b.eventPath));
+
+  return processor;
+}
+
+function buildEventDoc(args: {
+  definition: EventDefinitionForDocs;
+  processor: ProcessorDoc;
+  type: string;
+}): EventDoc {
+  const eventPath = eventPathFromType(args.type);
+  const examples = eventExamples(args.definition.examples);
+  const [, ...eventSlugParts] = eventPath.split("/");
+  const event = {
+    ...(args.definition.description == null ? {} : { description: args.definition.description }),
+    eventPath,
+    eventSlug: eventSlugParts.join("/"),
+    examples,
+    href: "",
+    payloadJsonSchema: eventPayloadJsonSchema({
+      examples,
+      payloadSchema: args.definition.payloadSchema,
+    }),
+    processor: args.processor,
+    type: args.type,
+  } satisfies EventDoc;
+  event.href = processorEventDocsPath(event);
+  return event;
+}
+
+function resolveEventReferences(args: {
+  eventReferencesByType: ReadonlyMap<string, EventReferenceDoc>;
+  types: readonly string[];
+}) {
+  return args.types
+    .map((type) => args.eventReferencesByType.get(type))
+    .filter((event): event is EventReferenceDoc => event != null);
+}
+
+function eventPayloadJsonSchema(args: {
+  examples: readonly { payload: unknown }[];
+  payloadSchema: z.ZodType | undefined;
+}) {
+  if (!args.payloadSchema) return { description: "No payload schema defined." };
+
+  const jsonSchema = z.toJSONSchema(args.payloadSchema, {
+    io: "input",
+    unrepresentable: "any",
+  });
+
+  if (args.examples.length === 0) return jsonSchema;
+  if (typeof jsonSchema !== "object" || jsonSchema === null || Array.isArray(jsonSchema)) {
+    return jsonSchema;
+  }
+
+  return {
+    ...jsonSchema,
+    examples: args.examples.map((example) => example.payload),
+  };
+}
+
+function eventExamples(examples: unknown): EventExampleDoc[] {
+  if (!Array.isArray(examples)) return [];
+
+  return examples
+    .map((example) => {
+      if (
+        typeof example === "object" &&
+        example !== null &&
+        "description" in example &&
+        "payload" in example &&
+        typeof example.description === "string"
+      ) {
+        return {
+          description: example.description,
+          payload: example.payload,
+        };
+      }
+
+      return null;
+    })
+    .filter((example): example is EventExampleDoc => example != null);
+}
+
+function processorDocsPath(contract: ProcessorContractForDocs) {
+  const firstEventType = Object.keys(contract.events)[0];
+  if (!firstEventType) return contract.slug;
+  return eventPathFromType(firstEventType).split("/")[0] ?? contract.slug;
+}
+
+function eventPathFromType(type: string) {
+  if (type.startsWith(EVENT_TYPE_PREFIX))
+    return cleanEventPath(type.slice(EVENT_TYPE_PREFIX.length));
+  if (type.startsWith(EVENT_TYPE_URL_PREFIX)) {
+    return cleanEventPath(type.slice(EVENT_TYPE_URL_PREFIX.length));
+  }
+  return cleanEventPath(type);
+}
+
+function cleanEventPath(path: string) {
+  return path.replace(/^\/+|\/+$/g, "");
+}
+
+function hasProcessorSlug(value: unknown): value is { slug: string } {
+  return (
+    typeof value === "object" && value !== null && "slug" in value && typeof value.slug === "string"
+  );
+}

--- a/apps/os/src/lib/root-auth-snapshot.ts
+++ b/apps/os/src/lib/root-auth-snapshot.ts
@@ -5,12 +5,14 @@ import {
   normalizeRequestHostname,
   resolveProjectSlugFromHostname,
 } from "~/lib/project-host-routing.ts";
+import { isEventDocsHostname } from "~/lib/event-docs-host.ts";
 import { requireRequestContext } from "~/request-context.ts";
 
 export type RootAuthSnapshot = {
   authSession: PublicSessionResponse;
   iterateAuthIssuer: string | undefined;
   currentProjectHostSlug: string | null;
+  isEventDocsHost: boolean;
 };
 
 /**
@@ -35,6 +37,10 @@ export const fetchRootAuthSnapshot: () => Promise<RootAuthSnapshot> = createServ
     currentProjectHostSlug: resolveCurrentProjectHostSlug({
       baseUrl: startContext.config.baseUrl,
       projectHostnameBases: startContext.config.projectHostnameBases ?? [],
+      requestUrl: startContext.rawRequest?.url,
+    }),
+    isEventDocsHost: isEventDocsHostname({
+      appBaseUrl: startContext.config.baseUrl,
       requestUrl: startContext.rawRequest?.url,
     }),
   };

--- a/apps/os/src/routeTree.gen.ts
+++ b/apps/os/src/routeTree.gen.ts
@@ -9,9 +9,12 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as DocsRouteImport } from './routes/docs'
 import { Route as AdminRouteImport } from './routes/admin'
 import { Route as AppRouteImport } from './routes/_app'
+import { Route as EventDocsProcessorSlugRouteImport } from './routes/$eventDocsProcessorSlug'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as DocsIndexRouteImport } from './routes/docs.index'
 import { Route as AdminIndexRouteImport } from './routes/admin/index'
 import { Route as SignUpSplatRouteImport } from './routes/sign-up.$'
 import { Route as SignInSplatRouteImport } from './routes/sign-in.$'
@@ -22,11 +25,14 @@ import { Route as AppNewProjectRouteImport } from './routes/_app/new-project'
 import { Route as AppLogStreamRouteImport } from './routes/_app/log-stream'
 import { Route as AppItxReplRouteImport } from './routes/_app/itx-repl'
 import { Route as AppDebugRouteImport } from './routes/_app/debug'
+import { Route as EventDocsProcessorSlugSplatRouteImport } from './routes/$eventDocsProcessorSlug.$'
 import { Route as AppProjectsRouteRouteImport } from './routes/_app/projects/route'
 import { Route as AppProjectsIndexRouteImport } from './routes/_app/projects/index'
 import { Route as ApiOrpcSplatRouteImport } from './routes/api.orpc.$'
 import { Route as AppProjectsProjectSlugRouteRouteImport } from './routes/_app/projects/$projectSlug/route'
+import { Route as DocsStreamsProcessorsIndexRouteImport } from './routes/docs.streams.processors.index'
 import { Route as AppProjectsProjectSlugIndexRouteImport } from './routes/_app/projects/$projectSlug/index'
+import { Route as DocsStreamsProcessorsProcessorSlugRouteImport } from './routes/docs.streams.processors.$processorSlug'
 import { Route as AppProjectsProjectSlugSettingsRouteImport } from './routes/_app/projects/$projectSlug/settings'
 import { Route as AppProjectsProjectSlugReplRouteImport } from './routes/_app/projects/$projectSlug/repl'
 import { Route as AppProjectsProjectSlugMcpRouteImport } from './routes/_app/projects/$projectSlug/mcp'
@@ -45,8 +51,14 @@ import { Route as AppProjectsProjectSlugCodemodeSessionsNewRouteImport } from '.
 import { Route as AppProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRouteImport } from './routes/_app/projects/$projectSlug/codemode-sessions/$codemodeSessionName'
 import { Route as AppProjectsProjectSlugAgentsNewPresetRouteImport } from './routes/_app/projects/$projectSlug/agents/new-preset'
 import { Route as AppProjectsProjectSlugAgentsNewRouteImport } from './routes/_app/projects/$projectSlug/agents/new'
+import { Route as DocsStreamsProcessorsProcessorSlugEventsSplatRouteImport } from './routes/docs.streams.processors.$processorSlug.events.$'
 import { Route as AppProjectsProjectSlugAgentsStreamsSplatRouteImport } from './routes/_app/projects/$projectSlug/agents/streams/$'
 
+const DocsRoute = DocsRouteImport.update({
+  id: '/docs',
+  path: '/docs',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AdminRoute = AdminRouteImport.update({
   id: '/admin',
   path: '/admin',
@@ -56,10 +68,20 @@ const AppRoute = AppRouteImport.update({
   id: '/_app',
   getParentRoute: () => rootRouteImport,
 } as any)
+const EventDocsProcessorSlugRoute = EventDocsProcessorSlugRouteImport.update({
+  id: '/$eventDocsProcessorSlug',
+  path: '/$eventDocsProcessorSlug',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const DocsIndexRoute = DocsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => DocsRoute,
 } as any)
 const AdminIndexRoute = AdminIndexRouteImport.update({
   id: '/',
@@ -111,6 +133,12 @@ const AppDebugRoute = AppDebugRouteImport.update({
   path: '/debug',
   getParentRoute: () => AppRoute,
 } as any)
+const EventDocsProcessorSlugSplatRoute =
+  EventDocsProcessorSlugSplatRouteImport.update({
+    id: '/$',
+    path: '/$',
+    getParentRoute: () => EventDocsProcessorSlugRoute,
+  } as any)
 const AppProjectsRouteRoute = AppProjectsRouteRouteImport.update({
   id: '/projects',
   path: '/projects',
@@ -132,11 +160,23 @@ const AppProjectsProjectSlugRouteRoute =
     path: '/$projectSlug',
     getParentRoute: () => AppProjectsRouteRoute,
   } as any)
+const DocsStreamsProcessorsIndexRoute =
+  DocsStreamsProcessorsIndexRouteImport.update({
+    id: '/streams/processors/',
+    path: '/streams/processors/',
+    getParentRoute: () => DocsRoute,
+  } as any)
 const AppProjectsProjectSlugIndexRoute =
   AppProjectsProjectSlugIndexRouteImport.update({
     id: '/',
     path: '/',
     getParentRoute: () => AppProjectsProjectSlugRouteRoute,
+  } as any)
+const DocsStreamsProcessorsProcessorSlugRoute =
+  DocsStreamsProcessorsProcessorSlugRouteImport.update({
+    id: '/streams/processors/$processorSlug',
+    path: '/streams/processors/$processorSlug',
+    getParentRoute: () => DocsRoute,
   } as any)
 const AppProjectsProjectSlugSettingsRoute =
   AppProjectsProjectSlugSettingsRouteImport.update({
@@ -246,6 +286,12 @@ const AppProjectsProjectSlugAgentsNewRoute =
     path: '/new',
     getParentRoute: () => AppProjectsProjectSlugAgentsRouteRoute,
   } as any)
+const DocsStreamsProcessorsProcessorSlugEventsSplatRoute =
+  DocsStreamsProcessorsProcessorSlugEventsSplatRouteImport.update({
+    id: '/events/$',
+    path: '/events/$',
+    getParentRoute: () => DocsStreamsProcessorsProcessorSlugRoute,
+  } as any)
 const AppProjectsProjectSlugAgentsStreamsSplatRoute =
   AppProjectsProjectSlugAgentsStreamsSplatRouteImport.update({
     id: '/streams/$',
@@ -255,8 +301,11 @@ const AppProjectsProjectSlugAgentsStreamsSplatRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/$eventDocsProcessorSlug': typeof EventDocsProcessorSlugRouteWithChildren
   '/admin': typeof AdminRouteWithChildren
+  '/docs': typeof DocsRouteWithChildren
   '/projects': typeof AppProjectsRouteRouteWithChildren
+  '/$eventDocsProcessorSlug/$': typeof EventDocsProcessorSlugSplatRoute
   '/debug': typeof AppDebugRoute
   '/itx-repl': typeof AppItxReplRoute
   '/log-stream': typeof AppLogStreamRoute
@@ -267,6 +316,7 @@ export interface FileRoutesByFullPath {
   '/sign-in/$': typeof SignInSplatRoute
   '/sign-up/$': typeof SignUpSplatRoute
   '/admin/': typeof AdminIndexRoute
+  '/docs/': typeof DocsIndexRoute
   '/projects/$projectSlug': typeof AppProjectsProjectSlugRouteRouteWithChildren
   '/api/orpc/$': typeof ApiOrpcSplatRoute
   '/projects/': typeof AppProjectsIndexRoute
@@ -276,7 +326,9 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/mcp': typeof AppProjectsProjectSlugMcpRoute
   '/projects/$projectSlug/repl': typeof AppProjectsProjectSlugReplRoute
   '/projects/$projectSlug/settings': typeof AppProjectsProjectSlugSettingsRoute
+  '/docs/streams/processors/$processorSlug': typeof DocsStreamsProcessorsProcessorSlugRouteWithChildren
   '/projects/$projectSlug/': typeof AppProjectsProjectSlugIndexRoute
+  '/docs/streams/processors/': typeof DocsStreamsProcessorsIndexRoute
   '/projects/$projectSlug/agents/new': typeof AppProjectsProjectSlugAgentsNewRoute
   '/projects/$projectSlug/agents/new-preset': typeof AppProjectsProjectSlugAgentsNewPresetRoute
   '/projects/$projectSlug/codemode-sessions/$codemodeSessionName': typeof AppProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRoute
@@ -290,9 +342,12 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/secrets/': typeof AppProjectsProjectSlugSecretsIndexRoute
   '/projects/$projectSlug/streams/': typeof AppProjectsProjectSlugStreamsIndexRoute
   '/projects/$projectSlug/agents/streams/$': typeof AppProjectsProjectSlugAgentsStreamsSplatRoute
+  '/docs/streams/processors/$processorSlug/events/$': typeof DocsStreamsProcessorsProcessorSlugEventsSplatRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/$eventDocsProcessorSlug': typeof EventDocsProcessorSlugRouteWithChildren
+  '/$eventDocsProcessorSlug/$': typeof EventDocsProcessorSlugSplatRoute
   '/debug': typeof AppDebugRoute
   '/itx-repl': typeof AppItxReplRoute
   '/log-stream': typeof AppLogStreamRoute
@@ -303,13 +358,16 @@ export interface FileRoutesByTo {
   '/sign-in/$': typeof SignInSplatRoute
   '/sign-up/$': typeof SignUpSplatRoute
   '/admin': typeof AdminIndexRoute
+  '/docs': typeof DocsIndexRoute
   '/api/orpc/$': typeof ApiOrpcSplatRoute
   '/projects': typeof AppProjectsIndexRoute
   '/projects/$projectSlug/integrations': typeof AppProjectsProjectSlugIntegrationsRoute
   '/projects/$projectSlug/mcp': typeof AppProjectsProjectSlugMcpRoute
   '/projects/$projectSlug/repl': typeof AppProjectsProjectSlugReplRoute
   '/projects/$projectSlug/settings': typeof AppProjectsProjectSlugSettingsRoute
+  '/docs/streams/processors/$processorSlug': typeof DocsStreamsProcessorsProcessorSlugRouteWithChildren
   '/projects/$projectSlug': typeof AppProjectsProjectSlugIndexRoute
+  '/docs/streams/processors': typeof DocsStreamsProcessorsIndexRoute
   '/projects/$projectSlug/agents/new': typeof AppProjectsProjectSlugAgentsNewRoute
   '/projects/$projectSlug/agents/new-preset': typeof AppProjectsProjectSlugAgentsNewPresetRoute
   '/projects/$projectSlug/codemode-sessions/$codemodeSessionName': typeof AppProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRoute
@@ -323,13 +381,17 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/secrets': typeof AppProjectsProjectSlugSecretsIndexRoute
   '/projects/$projectSlug/streams': typeof AppProjectsProjectSlugStreamsIndexRoute
   '/projects/$projectSlug/agents/streams/$': typeof AppProjectsProjectSlugAgentsStreamsSplatRoute
+  '/docs/streams/processors/$processorSlug/events/$': typeof DocsStreamsProcessorsProcessorSlugEventsSplatRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/$eventDocsProcessorSlug': typeof EventDocsProcessorSlugRouteWithChildren
   '/_app': typeof AppRouteWithChildren
   '/admin': typeof AdminRouteWithChildren
+  '/docs': typeof DocsRouteWithChildren
   '/_app/projects': typeof AppProjectsRouteRouteWithChildren
+  '/$eventDocsProcessorSlug/$': typeof EventDocsProcessorSlugSplatRoute
   '/_app/debug': typeof AppDebugRoute
   '/_app/itx-repl': typeof AppItxReplRoute
   '/_app/log-stream': typeof AppLogStreamRoute
@@ -340,6 +402,7 @@ export interface FileRoutesById {
   '/sign-in/$': typeof SignInSplatRoute
   '/sign-up/$': typeof SignUpSplatRoute
   '/admin/': typeof AdminIndexRoute
+  '/docs/': typeof DocsIndexRoute
   '/_app/projects/$projectSlug': typeof AppProjectsProjectSlugRouteRouteWithChildren
   '/api/orpc/$': typeof ApiOrpcSplatRoute
   '/_app/projects/': typeof AppProjectsIndexRoute
@@ -349,7 +412,9 @@ export interface FileRoutesById {
   '/_app/projects/$projectSlug/mcp': typeof AppProjectsProjectSlugMcpRoute
   '/_app/projects/$projectSlug/repl': typeof AppProjectsProjectSlugReplRoute
   '/_app/projects/$projectSlug/settings': typeof AppProjectsProjectSlugSettingsRoute
+  '/docs/streams/processors/$processorSlug': typeof DocsStreamsProcessorsProcessorSlugRouteWithChildren
   '/_app/projects/$projectSlug/': typeof AppProjectsProjectSlugIndexRoute
+  '/docs/streams/processors/': typeof DocsStreamsProcessorsIndexRoute
   '/_app/projects/$projectSlug/agents/new': typeof AppProjectsProjectSlugAgentsNewRoute
   '/_app/projects/$projectSlug/agents/new-preset': typeof AppProjectsProjectSlugAgentsNewPresetRoute
   '/_app/projects/$projectSlug/codemode-sessions/$codemodeSessionName': typeof AppProjectsProjectSlugCodemodeSessionsCodemodeSessionNameRoute
@@ -363,13 +428,17 @@ export interface FileRoutesById {
   '/_app/projects/$projectSlug/secrets/': typeof AppProjectsProjectSlugSecretsIndexRoute
   '/_app/projects/$projectSlug/streams/': typeof AppProjectsProjectSlugStreamsIndexRoute
   '/_app/projects/$projectSlug/agents/streams/$': typeof AppProjectsProjectSlugAgentsStreamsSplatRoute
+  '/docs/streams/processors/$processorSlug/events/$': typeof DocsStreamsProcessorsProcessorSlugEventsSplatRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/$eventDocsProcessorSlug'
     | '/admin'
+    | '/docs'
     | '/projects'
+    | '/$eventDocsProcessorSlug/$'
     | '/debug'
     | '/itx-repl'
     | '/log-stream'
@@ -380,6 +449,7 @@ export interface FileRouteTypes {
     | '/sign-in/$'
     | '/sign-up/$'
     | '/admin/'
+    | '/docs/'
     | '/projects/$projectSlug'
     | '/api/orpc/$'
     | '/projects/'
@@ -389,7 +459,9 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/mcp'
     | '/projects/$projectSlug/repl'
     | '/projects/$projectSlug/settings'
+    | '/docs/streams/processors/$processorSlug'
     | '/projects/$projectSlug/'
+    | '/docs/streams/processors/'
     | '/projects/$projectSlug/agents/new'
     | '/projects/$projectSlug/agents/new-preset'
     | '/projects/$projectSlug/codemode-sessions/$codemodeSessionName'
@@ -403,9 +475,12 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/secrets/'
     | '/projects/$projectSlug/streams/'
     | '/projects/$projectSlug/agents/streams/$'
+    | '/docs/streams/processors/$processorSlug/events/$'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/$eventDocsProcessorSlug'
+    | '/$eventDocsProcessorSlug/$'
     | '/debug'
     | '/itx-repl'
     | '/log-stream'
@@ -416,13 +491,16 @@ export interface FileRouteTypes {
     | '/sign-in/$'
     | '/sign-up/$'
     | '/admin'
+    | '/docs'
     | '/api/orpc/$'
     | '/projects'
     | '/projects/$projectSlug/integrations'
     | '/projects/$projectSlug/mcp'
     | '/projects/$projectSlug/repl'
     | '/projects/$projectSlug/settings'
+    | '/docs/streams/processors/$processorSlug'
     | '/projects/$projectSlug'
+    | '/docs/streams/processors'
     | '/projects/$projectSlug/agents/new'
     | '/projects/$projectSlug/agents/new-preset'
     | '/projects/$projectSlug/codemode-sessions/$codemodeSessionName'
@@ -436,12 +514,16 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/secrets'
     | '/projects/$projectSlug/streams'
     | '/projects/$projectSlug/agents/streams/$'
+    | '/docs/streams/processors/$processorSlug/events/$'
   id:
     | '__root__'
     | '/'
+    | '/$eventDocsProcessorSlug'
     | '/_app'
     | '/admin'
+    | '/docs'
     | '/_app/projects'
+    | '/$eventDocsProcessorSlug/$'
     | '/_app/debug'
     | '/_app/itx-repl'
     | '/_app/log-stream'
@@ -452,6 +534,7 @@ export interface FileRouteTypes {
     | '/sign-in/$'
     | '/sign-up/$'
     | '/admin/'
+    | '/docs/'
     | '/_app/projects/$projectSlug'
     | '/api/orpc/$'
     | '/_app/projects/'
@@ -461,7 +544,9 @@ export interface FileRouteTypes {
     | '/_app/projects/$projectSlug/mcp'
     | '/_app/projects/$projectSlug/repl'
     | '/_app/projects/$projectSlug/settings'
+    | '/docs/streams/processors/$processorSlug'
     | '/_app/projects/$projectSlug/'
+    | '/docs/streams/processors/'
     | '/_app/projects/$projectSlug/agents/new'
     | '/_app/projects/$projectSlug/agents/new-preset'
     | '/_app/projects/$projectSlug/codemode-sessions/$codemodeSessionName'
@@ -475,12 +560,15 @@ export interface FileRouteTypes {
     | '/_app/projects/$projectSlug/secrets/'
     | '/_app/projects/$projectSlug/streams/'
     | '/_app/projects/$projectSlug/agents/streams/$'
+    | '/docs/streams/processors/$processorSlug/events/$'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  EventDocsProcessorSlugRoute: typeof EventDocsProcessorSlugRouteWithChildren
   AppRoute: typeof AppRouteWithChildren
   AdminRoute: typeof AdminRouteWithChildren
+  DocsRoute: typeof DocsRouteWithChildren
   ApiSplatRoute: typeof ApiSplatRoute
   ApiOrpcWsRoute: typeof ApiOrpcWsRoute
   PosthogProxySplatRoute: typeof PosthogProxySplatRoute
@@ -491,6 +579,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/docs': {
+      id: '/docs'
+      path: '/docs'
+      fullPath: '/docs'
+      preLoaderRoute: typeof DocsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/admin': {
       id: '/admin'
       path: '/admin'
@@ -505,12 +600,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/$eventDocsProcessorSlug': {
+      id: '/$eventDocsProcessorSlug'
+      path: '/$eventDocsProcessorSlug'
+      fullPath: '/$eventDocsProcessorSlug'
+      preLoaderRoute: typeof EventDocsProcessorSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/docs/': {
+      id: '/docs/'
+      path: '/'
+      fullPath: '/docs/'
+      preLoaderRoute: typeof DocsIndexRouteImport
+      parentRoute: typeof DocsRoute
     }
     '/admin/': {
       id: '/admin/'
@@ -582,6 +691,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppDebugRouteImport
       parentRoute: typeof AppRoute
     }
+    '/$eventDocsProcessorSlug/$': {
+      id: '/$eventDocsProcessorSlug/$'
+      path: '/$'
+      fullPath: '/$eventDocsProcessorSlug/$'
+      preLoaderRoute: typeof EventDocsProcessorSlugSplatRouteImport
+      parentRoute: typeof EventDocsProcessorSlugRoute
+    }
     '/_app/projects': {
       id: '/_app/projects'
       path: '/projects'
@@ -610,12 +726,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppProjectsProjectSlugRouteRouteImport
       parentRoute: typeof AppProjectsRouteRoute
     }
+    '/docs/streams/processors/': {
+      id: '/docs/streams/processors/'
+      path: '/streams/processors'
+      fullPath: '/docs/streams/processors/'
+      preLoaderRoute: typeof DocsStreamsProcessorsIndexRouteImport
+      parentRoute: typeof DocsRoute
+    }
     '/_app/projects/$projectSlug/': {
       id: '/_app/projects/$projectSlug/'
       path: '/'
       fullPath: '/projects/$projectSlug/'
       preLoaderRoute: typeof AppProjectsProjectSlugIndexRouteImport
       parentRoute: typeof AppProjectsProjectSlugRouteRoute
+    }
+    '/docs/streams/processors/$processorSlug': {
+      id: '/docs/streams/processors/$processorSlug'
+      path: '/streams/processors/$processorSlug'
+      fullPath: '/docs/streams/processors/$processorSlug'
+      preLoaderRoute: typeof DocsStreamsProcessorsProcessorSlugRouteImport
+      parentRoute: typeof DocsRoute
     }
     '/_app/projects/$projectSlug/settings': {
       id: '/_app/projects/$projectSlug/settings'
@@ -743,6 +873,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppProjectsProjectSlugAgentsNewRouteImport
       parentRoute: typeof AppProjectsProjectSlugAgentsRouteRoute
     }
+    '/docs/streams/processors/$processorSlug/events/$': {
+      id: '/docs/streams/processors/$processorSlug/events/$'
+      path: '/events/$'
+      fullPath: '/docs/streams/processors/$processorSlug/events/$'
+      preLoaderRoute: typeof DocsStreamsProcessorsProcessorSlugEventsSplatRouteImport
+      parentRoute: typeof DocsStreamsProcessorsProcessorSlugRoute
+    }
     '/_app/projects/$projectSlug/agents/streams/$': {
       id: '/_app/projects/$projectSlug/agents/streams/$'
       path: '/streams/$'
@@ -752,6 +889,20 @@ declare module '@tanstack/react-router' {
     }
   }
 }
+
+interface EventDocsProcessorSlugRouteChildren {
+  EventDocsProcessorSlugSplatRoute: typeof EventDocsProcessorSlugSplatRoute
+}
+
+const EventDocsProcessorSlugRouteChildren: EventDocsProcessorSlugRouteChildren =
+  {
+    EventDocsProcessorSlugSplatRoute: EventDocsProcessorSlugSplatRoute,
+  }
+
+const EventDocsProcessorSlugRouteWithChildren =
+  EventDocsProcessorSlugRoute._addFileChildren(
+    EventDocsProcessorSlugRouteChildren,
+  )
 
 interface AppProjectsProjectSlugAgentsRouteRouteChildren {
   AppProjectsProjectSlugAgentsNewRoute: typeof AppProjectsProjectSlugAgentsNewRoute
@@ -886,10 +1037,42 @@ const AdminRouteChildren: AdminRouteChildren = {
 
 const AdminRouteWithChildren = AdminRoute._addFileChildren(AdminRouteChildren)
 
+interface DocsStreamsProcessorsProcessorSlugRouteChildren {
+  DocsStreamsProcessorsProcessorSlugEventsSplatRoute: typeof DocsStreamsProcessorsProcessorSlugEventsSplatRoute
+}
+
+const DocsStreamsProcessorsProcessorSlugRouteChildren: DocsStreamsProcessorsProcessorSlugRouteChildren =
+  {
+    DocsStreamsProcessorsProcessorSlugEventsSplatRoute:
+      DocsStreamsProcessorsProcessorSlugEventsSplatRoute,
+  }
+
+const DocsStreamsProcessorsProcessorSlugRouteWithChildren =
+  DocsStreamsProcessorsProcessorSlugRoute._addFileChildren(
+    DocsStreamsProcessorsProcessorSlugRouteChildren,
+  )
+
+interface DocsRouteChildren {
+  DocsIndexRoute: typeof DocsIndexRoute
+  DocsStreamsProcessorsProcessorSlugRoute: typeof DocsStreamsProcessorsProcessorSlugRouteWithChildren
+  DocsStreamsProcessorsIndexRoute: typeof DocsStreamsProcessorsIndexRoute
+}
+
+const DocsRouteChildren: DocsRouteChildren = {
+  DocsIndexRoute: DocsIndexRoute,
+  DocsStreamsProcessorsProcessorSlugRoute:
+    DocsStreamsProcessorsProcessorSlugRouteWithChildren,
+  DocsStreamsProcessorsIndexRoute: DocsStreamsProcessorsIndexRoute,
+}
+
+const DocsRouteWithChildren = DocsRoute._addFileChildren(DocsRouteChildren)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  EventDocsProcessorSlugRoute: EventDocsProcessorSlugRouteWithChildren,
   AppRoute: AppRouteWithChildren,
   AdminRoute: AdminRouteWithChildren,
+  DocsRoute: DocsRouteWithChildren,
   ApiSplatRoute: ApiSplatRoute,
   ApiOrpcWsRoute: ApiOrpcWsRoute,
   PosthogProxySplatRoute: PosthogProxySplatRoute,

--- a/apps/os/src/router-context.ts
+++ b/apps/os/src/router-context.ts
@@ -14,5 +14,6 @@ export type RouterContext = {
   queryClient: QueryClient;
   authSession?: PublicSessionResponse;
   currentProjectHostSlug?: string | null;
+  isEventDocsHost?: boolean;
   iterateAuthIssuer?: string;
 };

--- a/apps/os/src/routes/$eventDocsProcessorSlug.$.tsx
+++ b/apps/os/src/routes/$eventDocsProcessorSlug.$.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { EventDocPage } from "~/components/docs-portal.tsx";
+import { getEventDocByPath } from "~/lib/event-docs.ts";
+
+export const Route = createFileRoute("/$eventDocsProcessorSlug/$")({
+  beforeLoad: ({ context }) => {
+    if (!context.isEventDocsHost) throw notFound();
+  },
+  component: EventDocsEventAliasRoute,
+});
+
+function EventDocsEventAliasRoute() {
+  const { _splat, eventDocsProcessorSlug } = Route.useParams();
+  if (!_splat) throw notFound();
+  const event = getEventDocByPath(`${eventDocsProcessorSlug}/${_splat}`);
+  if (!event) throw notFound();
+  return <EventDocPage event={event} />;
+}

--- a/apps/os/src/routes/$eventDocsProcessorSlug.tsx
+++ b/apps/os/src/routes/$eventDocsProcessorSlug.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { ProcessorOverviewPage } from "~/components/docs-portal.tsx";
+import { getProcessorDocByPath } from "~/lib/event-docs.ts";
+
+export const Route = createFileRoute("/$eventDocsProcessorSlug")({
+  beforeLoad: ({ context }) => {
+    if (!context.isEventDocsHost) throw notFound();
+  },
+  component: EventDocsProcessorAliasRoute,
+});
+
+function EventDocsProcessorAliasRoute() {
+  const { eventDocsProcessorSlug } = Route.useParams();
+  const processor = getProcessorDocByPath(eventDocsProcessorSlug);
+  if (!processor) throw notFound();
+  return <ProcessorOverviewPage processor={processor} />;
+}

--- a/apps/os/src/routes/docs.index.tsx
+++ b/apps/os/src/routes/docs.index.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { DocsHomePage } from "~/components/docs-portal.tsx";
+
+export const Route = createFileRoute("/docs/")({
+  component: DocsHomePage,
+});

--- a/apps/os/src/routes/docs.streams.processors.$processorSlug.events.$.tsx
+++ b/apps/os/src/routes/docs.streams.processors.$processorSlug.events.$.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { EventDocPage } from "~/components/docs-portal.tsx";
+import { getEventDocByPath } from "~/lib/event-docs.ts";
+
+export const Route = createFileRoute("/docs/streams/processors/$processorSlug/events/$")({
+  component: ProcessorEventRoute,
+});
+
+function ProcessorEventRoute() {
+  const { _splat, processorSlug } = Route.useParams();
+  if (!_splat) throw notFound();
+  const event = getEventDocByPath(`${processorSlug}/${_splat}`) ?? getEventDocByPath(_splat);
+  if (!event) throw notFound();
+  return <EventDocPage event={event} />;
+}

--- a/apps/os/src/routes/docs.streams.processors.$processorSlug.tsx
+++ b/apps/os/src/routes/docs.streams.processors.$processorSlug.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { ProcessorOverviewPage } from "~/components/docs-portal.tsx";
+import { getProcessorDocByPath } from "~/lib/event-docs.ts";
+
+export const Route = createFileRoute("/docs/streams/processors/$processorSlug")({
+  component: ProcessorRoute,
+});
+
+function ProcessorRoute() {
+  const { processorSlug } = Route.useParams();
+  const processor = getProcessorDocByPath(processorSlug);
+  if (!processor) throw notFound();
+  return <ProcessorOverviewPage processor={processor} />;
+}

--- a/apps/os/src/routes/docs.streams.processors.index.tsx
+++ b/apps/os/src/routes/docs.streams.processors.index.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { StreamProcessorsIndexPage } from "~/components/docs-portal.tsx";
+
+export const Route = createFileRoute("/docs/streams/processors/")({
+  component: StreamProcessorsIndexPage,
+});

--- a/apps/os/src/routes/docs.tsx
+++ b/apps/os/src/routes/docs.tsx
@@ -1,0 +1,5 @@
+import { Outlet, createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/docs")({
+  component: Outlet,
+});

--- a/apps/os/src/routes/index.tsx
+++ b/apps/os/src/routes/index.tsx
@@ -1,9 +1,12 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { requireAuthenticatedRootRedirectTargetFromSession } from "../lib/auth.ts";
+import { DocsHomePage } from "~/components/docs-portal.tsx";
 import { projectsListQueryOptions } from "~/lib/project-route-query.ts";
 
 export const Route = createFileRoute("/")({
   loader: async ({ context, location }) => {
+    if (context.isEventDocsHost) return;
+
     const target = requireAuthenticatedRootRedirectTargetFromSession(
       context.authSession,
       location,
@@ -39,4 +42,5 @@ export const Route = createFileRoute("/")({
       replace: true,
     });
   },
+  component: DocsHomePage,
 });

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -29,6 +29,7 @@ import { lookupIngressRule } from "~/ingress/lookup.ts";
 import { handleMcpFetch } from "~/domains/inbound-mcp-server/mcp-handler.ts";
 import { handleItxFetch, handleProjectHostItxFetch } from "~/itx/fetch.ts";
 import { handleProjectStreamRpcFetch } from "~/domains/streams/project-stream-rpc.ts";
+import { handleDocsMarkdownFetch } from "~/lib/docs-markdown.ts";
 
 // Durable objects and RPC entrypoints must be exported from the worker's main
 // module so the runtime can find the classes the bindings refer to:
@@ -129,6 +130,12 @@ export default {
             request,
           });
         }
+
+        const docsMarkdownResponse = handleDocsMarkdownFetch({
+          appBaseUrl: requestConfig.baseUrl,
+          request,
+        });
+        if (docsMarkdownResponse) return docsMarkdownResponse;
 
         const context: RequestContext = {
           config: requestConfig,


### PR DESCRIPTION
## What changed

- Adds an OS docs portal under `/docs` with a Stream Processors section backed by current processor contracts.
- Adds canonical processor and event routes such as `/docs/streams/processors/stream` and `/docs/streams/processors/stream/events/created`.
- Routes `events.iterate.com` to OS and serves host aliases such as `/stream` and `/stream/created`.
- Adds agent-friendly Markdown responses for docs pages via `Accept: text/markdown`, `/index.md`, and root `/llms.txt` on both `os.iterate.com` and `events.iterate.com`, following Markdown-for-agents content negotiation recommendations.

## Why

The deleted events app had made event type URLs resolvable. OS now owns that documentation surface directly while keeping the product app root behavior intact on `os.iterate.com`.

## Validation

- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/os exec vitest run src/lib/event-docs.test.ts src/lib/event-docs-host.test.ts src/lib/docs-markdown.test.ts`
- touched-file `pnpm lint`
- local curl checks for HTML docs routes, events-host aliases, `Accept: text/markdown`, `/index.md`, and root `/llms.txt`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public routes and a dedicated events hostname change request routing and deploy host configuration; root `/` behavior is host-dependent but existing OS dashboard redirects are preserved for non-events hosts.
> 
> **Overview**
> Adds an **OS docs portal** for stream processor and event-type reference, replacing the old events-app documentation surface on OS itself.
> 
> **Routing and hosting:** New `/docs` tree (home, stream processors index, per-processor and per-event pages) plus **short paths on the events host** (`events.iterate.com` / preview siblings) via `/$processor` and `/$processor/$event`, gated by `isEventDocsHost` in router context. Deploy wires the derived events hostname into `extraRouteHostnames` in `alchemy.run.ts`.
> 
> **Data layer:** `event-docs.ts` builds a catalog from existing processor contracts (Zod → JSON schema, consumes/emits, aliases like `stream/create` → `stream/created`).
> 
> **Agent-friendly Markdown:** `handleDocsMarkdownFetch` in the worker serves Markdown for `Accept: text/markdown`, `/index.md`, and `/llms.txt`, including events-host alias paths.
> 
> **Product root:** On `events.iterate.com`, `/` skips auth/project redirects and shows the docs home; on `os.iterate.com`, `/` still redirects signed-in users to projects as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 258558fce13216f904d963d2961790837e650ed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T10:40:22.458Z",
      "headSha": "258558fce13216f904d963d2961790837e650ed0",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27270210624",
      "shortSha": "258558f"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `258558f`
Preview: https://os.iterate-preview-6.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27270210624)
Updated: 2026-06-10T10:40:22.458Z
<!-- /CLOUDFLARE_PREVIEW -->