### PR TITLE
perf(os): scope the pretty-JSON interceptor to curl/CLI traffic instead of the browser transport

### DIFF
--- a/apps/os/src/orpc/handler.ts
+++ b/apps/os/src/orpc/handler.ts
@@ -2,36 +2,18 @@ import { EvlogHandlerPlugin } from "@iterate-com/shared/evlog/orpc-plugin";
 import { OpenAPIHandler } from "@orpc/openapi/fetch";
 import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
 import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
-import { onError, type Context } from "@orpc/server";
+import { onError } from "@orpc/server";
 import { RPCHandler } from "@orpc/server/fetch";
-import type { FetchHandleResult, FetchHandlerInterceptorOptions } from "@orpc/server/fetch";
 import { experimental_RPCHandler as WebSocketRPCHandler } from "@orpc/server/crossws";
 import { CORSPlugin } from "@orpc/server/plugins";
 import packageJson from "../../package.json" with { type: "json" };
 import type { RequestContext } from "~/request-context.ts";
 import { appRouter } from "~/orpc/root.ts";
+import { prettyJsonInterceptor } from "~/orpc/pretty-json-interceptor.ts";
 import { prettifyStandardSchemaError } from "~/standard-schema/errors.ts";
 import { looksLikeStandardSchemaFailure } from "~/standard-schema/utils.ts";
 
 const plugins = [new CORSPlugin({ origin: "*" }), new EvlogHandlerPlugin<RequestContext>()];
-
-/**
- * Pretty-print JSON responses for curl ergonomics. Leaves SSE
- * (`text/event-stream`) and non-JSON responses untouched.
- */
-async function prettyJsonInterceptor(
-  options: FetchHandlerInterceptorOptions<Context> & {
-    next(): Promise<FetchHandleResult>;
-  },
-) {
-  const result = await options.next();
-  const type = result.response?.headers.get("content-type");
-  if (!result.matched || result.response.body === null || !type?.includes("json")) return result;
-  return {
-    ...result,
-    response: new Response(JSON.stringify(await result.response.json(), null, 2), result.response),
-  };
-}
 
 export const orpcOpenApiHandler = new OpenAPIHandler(appRouter, {
   adapterInterceptors: [prettyJsonInterceptor],

--- a/apps/os/src/orpc/pretty-json-interceptor.test.ts
+++ b/apps/os/src/orpc/pretty-json-interceptor.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest";
+import type { FetchHandleResult, FetchHandlerInterceptorOptions } from "@orpc/server/fetch";
+import type { Context } from "@orpc/server";
+import { prettyJsonInterceptor } from "./pretty-json-interceptor.ts";
+
+function makeOptions(params: { userAgent?: string; result: FetchHandleResult }) {
+  const headers = new Headers();
+  if (params.userAgent) headers.set("user-agent", params.userAgent);
+  return {
+    request: new Request("https://os.example.com/api/projects", { headers }),
+    context: {},
+    next: () => Promise.resolve(params.result),
+  } as unknown as FetchHandlerInterceptorOptions<Context> & {
+    next(): Promise<FetchHandleResult>;
+  };
+}
+
+function jsonResult(body: unknown): FetchHandleResult {
+  return {
+    matched: true,
+    response: Response.json(body),
+  };
+}
+
+describe("prettyJsonInterceptor", () => {
+  test.for(["curl/8.7.1", "HTTPie/3.2.2", "Wget/1.24.5"])(
+    "pretty-prints JSON for %s",
+    async (userAgent) => {
+      const result = await prettyJsonInterceptor(
+        makeOptions({ userAgent, result: jsonResult({ a: 1, b: [2] }) }),
+      );
+      expect(result.matched).toBe(true);
+      expect(await result.response?.text()).toMatchInlineSnapshot(`
+        "{
+          "a": 1,
+          "b": [
+            2
+          ]
+        }"
+      `);
+    },
+  );
+
+  test("passes browser responses through without buffering", async () => {
+    const original = jsonResult({ a: 1 });
+    const result = await prettyJsonInterceptor(
+      makeOptions({
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+        result: original,
+      }),
+    );
+    // Same result object, same Response instance: the body was never consumed.
+    expect(result).toBe(original);
+    expect(original.response?.bodyUsed).toBe(false);
+    expect(await result.response?.text()).toBe(`{"a":1}`);
+  });
+
+  test("passes requests without a user-agent through untouched", async () => {
+    const original = jsonResult({ a: 1 });
+    const result = await prettyJsonInterceptor(makeOptions({ result: original }));
+    expect(result).toBe(original);
+  });
+
+  test("leaves SSE responses untouched even for curl", async () => {
+    const original: FetchHandleResult = {
+      matched: true,
+      response: new Response("data: hello\n\n", {
+        headers: { "content-type": "text/event-stream" },
+      }),
+    };
+    const result = await prettyJsonInterceptor(
+      makeOptions({ userAgent: "curl/8.7.1", result: original }),
+    );
+    expect(result).toBe(original);
+    expect(original.response?.bodyUsed).toBe(false);
+  });
+
+  test("leaves unmatched results untouched", async () => {
+    const original: FetchHandleResult = { matched: false, response: undefined };
+    const result = await prettyJsonInterceptor(
+      makeOptions({ userAgent: "curl/8.7.1", result: original }),
+    );
+    expect(result).toBe(original);
+  });
+});

--- a/apps/os/src/orpc/pretty-json-interceptor.ts
+++ b/apps/os/src/orpc/pretty-json-interceptor.ts
@@ -1,0 +1,33 @@
+import type { Context } from "@orpc/server";
+import type { FetchHandleResult, FetchHandlerInterceptorOptions } from "@orpc/server/fetch";
+
+/**
+ * Command-line HTTP clients whose terminal output benefits from indentation,
+ * e.g. `curl/8.7.1`, `HTTPie/3.2.2`, `Wget/1.24.5`.
+ */
+const CLI_CLIENT_USER_AGENT = /\b(curl|httpie|wget)\b/i;
+
+/**
+ * Pretty-print JSON responses for curl ergonomics, but only when the request
+ * actually comes from a command-line client. The OpenAPI handler at `/api` is
+ * also the browser dashboard's transport (`~/orpc/client.ts` points
+ * `OpenAPILink` at it), and those responses should stream through untouched
+ * instead of being buffered, re-serialized, and inflated with whitespace.
+ * Leaves SSE (`text/event-stream`) and non-JSON responses untouched.
+ */
+export async function prettyJsonInterceptor(
+  options: FetchHandlerInterceptorOptions<Context> & {
+    next(): Promise<FetchHandleResult>;
+  },
+): Promise<FetchHandleResult> {
+  const userAgent = options.request.headers.get("user-agent") ?? "";
+  if (!CLI_CLIENT_USER_AGENT.test(userAgent)) return options.next();
+
+  const result = await options.next();
+  const type = result.response?.headers.get("content-type");
+  if (!result.matched || result.response.body === null || !type?.includes("json")) return result;
+  return {
+    ...result,
+    response: new Response(JSON.stringify(await result.response.json(), null, 2), result.response),
+  };
+}


### PR DESCRIPTION
## Summary

`prettyJsonInterceptor` in `apps/os/src/orpc/handler.ts` re-stringified every JSON response from the OpenAPI handler with 2-space indentation for curl ergonomics. But that handler at `/api` is also the production browser transport — `src/orpc/client.ts` points `OpenAPILink` at `window.location.origin + /api` — so every dashboard API response was buffered, re-serialized, and inflated with whitespace.

Changes:

- Gate the prettification on the request's `User-Agent` matching a command-line HTTP client (`curl`, `HTTPie`, `wget`). Browser traffic (and anything else) now returns the upstream result untouched — the body is never consumed, so streaming responses pass through.
- Extract the interceptor into `apps/os/src/orpc/pretty-json-interceptor.ts` so it can be unit-tested without importing the full `appRouter`.
- Add `pretty-json-interceptor.test.ts` (7 tests): pretty-printing for curl/HTTPie/wget, pass-through for browser UAs and missing UA (asserting the original `Response` instance is returned with `bodyUsed === false`), SSE untouched, unmatched results untouched.

Curl ergonomics are preserved: `curl https://os.iterate.com/api/...` still gets indented JSON.

Note: the `iterate-app-cli` (`pnpm cli rpc ...`) uses `RPCLink` against `orpcRpcHandler` at `/api/orpc/`, which never had this interceptor, so CLI behavior is unchanged.

## Skipped items

None — the single finding was verified accurate and fixed.

## Flags for reviewers

- The UA allowlist is `curl`/`httpie`/`wget` (case-insensitive, word-boundary match). If other terminal tools are used against `/api` (e.g. `xh`), they'll now get compact JSON — easy to add to the regex if desired.
- An `Accept`-based check was considered, but curl sends `Accept: */*` by default, so User-Agent is the only signal that works without extra flags.

## Checks

- `pnpm typecheck` — pass
- `pnpm lint` — pass
- `pnpm exec vitest run src/orpc/pretty-json-interceptor.test.ts` (apps/os) — 7/7 pass
- oxfmt on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Response-shaping change on the OpenAPI adapter only; behavior for browsers improves (pass-through), with curl ergonomics preserved via UA allowlist.
> 
> **Overview**
> Limits **pretty-printed JSON** on the OpenAPI `/api` handler to requests whose `User-Agent` looks like **curl, HTTPie, or wget**. Browser dashboard traffic (and anything else) now skips the interceptor entirely so responses are not buffered or re-serialized.
> 
> The interceptor moves from `handler.ts` into **`pretty-json-interceptor.ts`**, with **Vitest** coverage for CLI pretty-printing, browser/missing-UA pass-through (same `Response`, `bodyUsed` unchanged), SSE, and unmatched routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c7745d6dfa8209ea5e6597ee160c90b6e619ac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.
<!-- /CLOUDFLARE_PREVIEW -->