### PR TITLE
fix(iterate): repair broken procedure discovery, rewrite README, align license

### DIFF
--- a/packages/iterate/README.md
+++ b/packages/iterate/README.md
@@ -2,78 +2,47 @@
 
 ⚠️⚠️⚠️ Coming soon! `npx iterate` is a work-in-progress CLI for managing [iterate.com](https://iterate.com) agents ⚠️⚠️⚠️
 
-CLI for Iterate.
+CLI for Iterate. It discovers the OS server's oRPC procedures at runtime and
+mounts them as commands under `iterate os ...`, alongside built-in commands for
+auth and config management.
 
-Runs as a thin bootstrapper that:
-
-1. Resolves an `iterate/iterate` checkout.
-2. Clones/install deps when needed.
-3. Loads `apps/os/src/orpc/root.ts` from that checkout.
-4. Exposes commands like `iterate os ...` and `iterate whoami`.
+When run inside an `iterate/iterate` checkout (or a project with a local
+`node_modules` install of `iterate`), the bin delegates to that local copy
+instead of the published one.
 
 ## Requirements
 
 - Node `>=22`
-- `git`
-- `pnpm` or `corepack`
 
 ## Quick start
-
-Run without installing globally:
 
 ```bash
 npx iterate --help
 ```
 
-Initial setup (writes auth + launcher config):
+Create a config pointing at a server, then log in:
 
 ```bash
-npx iterate setup \
-  --os-base-url https://dev-yourname-os.dev.iterate.com \
-  --auth-base-url https://auth.iterate.com \
-  --daemon-base-url http://localhost:3001 \
-  --admin-password-env-var-name SERVICE_AUTH_TOKEN \
-  --user-email dev-yourname@iterate.com \
-  --scope global
-```
-
-Then run commands:
-
-```bash
-npx iterate config local
+npx iterate config set --name prod --os-base-url https://os.iterate.com --set-default
 npx iterate login
 npx iterate whoami
-npx iterate orgs list
-npx iterate os project list
+npx iterate os --help
 ```
 
 ## Commands
 
-- `iterate setup` - configure auth + launcher defaults
-- `iterate doctor` - print resolved config/runtime info
-- `iterate install` - force clone/install for resolved checkout
-- `iterate whoami`
-- `iterate orgs list`
-- `iterate os ...`
-- `iterate daemon ...`
+- `iterate doctor` — show config file, resolved target, and session status
+- `iterate login [--superadmin]` — authenticate (browser device flow, or superadmin impersonation for CI)
+- `iterate logout` — remove the stored session for the current config
+- `iterate whoami` — show the current authenticated user
+- `iterate orgs list` — list organizations from the auth worker
+- `iterate config list | set | use | current | local` — manage named configs
+- `iterate os ...` — procedures discovered from the configured OS server
 
-`setup --scope global` writes auth + launcher values into `global`; `setup --scope workspace` writes them into `workspaces[process.cwd()]`.
+Global flags (consumed before command parsing):
 
-For local auth development, set `authBaseUrl` to `http://localhost:7101`. If you omit it and
-your `osBaseUrl` is `http://localhost:*` or `*.iterate-dev.com`, the CLI defaults to
-`http://localhost:7101`.
-
-To bootstrap a local repo config quickly, run:
-
-```bash
-npx iterate config local
-```
-
-That creates a `local` config with:
-
-- `osBaseUrl = https://<your-username>.iterate-dev.com`
-- `authBaseUrl = http://localhost:7101`
-- `daemonBaseUrl = http://localhost:3001`
+- `--config <name>` — use a specific named config
+- `--local-router <path>` — mount a local module exporting a named `router` under `local-router`
 
 ## Config file
 
@@ -86,28 +55,22 @@ Config shape:
 ```json
 {
   "configs": {
-    "default": {
+    "prod": {
       "osBaseUrl": "https://os.iterate.com",
-      "authBaseUrl": "https://auth.iterate.com",
-      "daemonBaseUrl": "http://localhost:3000",
-      "auth": {
-        "strategy": "device"
-      }
+      "auth": { "strategy": "device" }
     },
-    "dev": {
-      "osBaseUrl": "https://dev-yourname-os.dev.iterate.com",
-      "authBaseUrl": "https://auth-dev-yourname.iterate.com",
-      "daemonBaseUrl": "http://localhost:3001",
+    "ci": {
+      "osBaseUrl": "https://os.iterate.com",
       "auth": {
         "strategy": "superadmin",
         "adminPasswordEnvVarName": "SERVICE_AUTH_TOKEN",
-        "userEmail": "dev-yourname@iterate.com"
+        "userEmail": "someone@example.com"
       }
     }
   },
-  "default": "default",
+  "default": "prod",
   "workspaces": {
-    "/absolute/workspace/path": "dev"
+    "/absolute/workspace/path": "ci"
   }
 }
 ```
@@ -119,28 +82,32 @@ Auth strategies:
 - `device` — interactive browser-based login (RFC 8628 device flow). Run `iterate login`.
 - `superadmin` — CI/automation impersonation via admin password env var.
 
+`authBaseUrl` is optional. If omitted, the CLI derives it from `osBaseUrl`:
+
+- `os.iterate.com` → `https://auth.iterate.com`
+- `localhost` / `127.0.0.1` / `*.iterate-dev.com` → `http://localhost:7101`
+
 ## Local iterate dev
 
-If you run inside an `iterate/iterate` clone, the CLI auto-detects it. In that mode, default `autoInstall` is `false`.
-
-You can pin explicitly:
+To bootstrap a config for local development, run:
 
 ```bash
-npx iterate setup \
-  --os-base-url https://dev-yourname-os.dev.iterate.com \
-  --daemon-base-url http://localhost:3001 \
-  --admin-password-env-var-name SERVICE_AUTH_TOKEN \
-  --user-email dev-yourname@iterate.com \
-  --scope workspace
+npx iterate config local
 ```
+
+That creates a `local` config (and sets it as the default and the workspace
+config for the current directory) with:
+
+- `osBaseUrl = https://<your-username>.iterate-dev.com`
+- `authBaseUrl = http://localhost:7101`
 
 ## Publishing (maintainers)
 
-From repo root:
+From `packages/iterate`:
 
 ```bash
-pnpm --filter ./packages/iterate typecheck
-pnpm oxlint packages/iterate/bin/iterate.js
-pnpm oxfmt --check packages/iterate
-pnpm --filter ./packages/iterate publish --access public
+node pubme.js publish --version <version>
 ```
+
+This bumps the version, checks for a clean git status, and runs `npm publish`
+(prompts for your npm OTP).

--- a/packages/iterate/package.json
+++ b/packages/iterate/package.json
@@ -2,7 +2,7 @@
   "name": "iterate",
   "version": "0.2.5",
   "description": "CLI for iterate",
-  "license": "Apache-2.0",
+  "license": "AGPL-3.0-only",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/iterate/src/cli.ts
+++ b/packages/iterate/src/cli.ts
@@ -612,7 +612,8 @@ const deviceFlowLogin = async (
 const loadRemoteProcedures = async (params: {
   baseUrl: string;
 }): Promise<{ procedures: ParsedRouter }> => {
-  const url = `${params.baseUrl}/api/trpc-cli-procedures`;
+  // Matches the shared internal router contract (packages/shared/src/apps/internal-router-contract.ts)
+  const url = `${params.baseUrl}/api/__internal/trpc-cli-procedures`;
   const response = await fetch(url);
   if (!response.ok) {
     let text = await response.text();


### PR DESCRIPTION
## ⚠️ Deliberate-decision item: license change Apache-2.0 → AGPL-3.0-only

`packages/iterate/package.json` declared `Apache-2.0` while the repo (root `LICENSE`, root `package.json`, `CONTRIBUTING.md`) is `AGPL-3.0-only`. This PR aligns the published package to AGPL-3.0-only — **but the permissive license may have been intentional for the published CLI**. Maintainer must confirm this is the desired license before merging. If Apache-2.0 was deliberate, drop that commit hunk and instead add an Apache LICENSE file to the package.

## Changes

### 1. Fix broken procedure discovery (published CLI was unusable against current OS)

`packages/iterate/src/cli.ts` fetched `${osBaseUrl}/api/trpc-cli-procedures`, which 404s against current OS deployments — so every `iterate os ...` command failed. OS serves the discovery endpoint at `/api/__internal/trpc-cli-procedures` per the shared internal router contract (`packages/shared/src/apps/internal-router-contract.ts`, mounted in `apps/os/src/orpc/root.ts` / `handler.ts`).

Verified live (read-only):
- `GET https://os.iterate.com/api/trpc-cli-procedures` → 404
- `GET https://os.iterate.com/api/__internal/trpc-cli-procedures` → 200 with procedures (unauthenticated)
- Ran the CLI from this branch with a temp config pointing at prod: `iterate os --help` now lists all remote procedures (`projects`, `project`, `ping`, …).

No fallback to the old path was added — the old path has not existed on any current deployment, so a fallback would only mask misconfiguration.

### 2. Rewrite `packages/iterate/README.md` to match the code

Removed content that does not match the actual CLI:
- Clone-and-bootstrap architecture claims ("Resolves an iterate/iterate checkout", "Clones/install deps", "Loads apps/os/src/orpc/root.ts") — the bin only delegates to an already-present local copy (repo checkout or `node_modules`); it never clones or installs anything.
- Nonexistent `iterate setup` and `iterate install` commands.
- All daemon content (`iterate daemon`, `daemonBaseUrl` flags/examples) — the daemon was deleted. (The `daemonBaseUrl` config field still exists in the code as a dead optional; left undocumented.)
- Wrong example hostnames (`dev-yourname-os.dev.iterate.com` etc.) — replaced with the CLI's actual defaults (`os.iterate.com`/`auth.iterate.com`, `<username>.iterate-dev.com`, `localhost:7101`).
- Stale publishing instructions — replaced with the actual `pubme.js publish` flow.

Everything now documented was verified against `src/cli.ts` and `bin/iterate.js`.

### 3. License alignment

`packages/iterate/package.json` license: `Apache-2.0` → `AGPL-3.0-only`. See flag at top.

## Not done / notes

- **Version not bumped** (per instructions). The published npm package (0.2.5) still has the broken discovery path — a republish is needed after merge.
- `pnpm --filter ./packages/iterate typecheck` fails on main and on this branch with a pre-existing error in `apps/auth-contract/src/index.ts(520,67): Cannot find name 'HeadersInit'`. Root `pnpm typecheck` deliberately filters out the `iterate` package (`--filter '!iterate'`), so CI doesn't catch it. Not caused or fixed by this PR.
- The package has no tests (no test script; root `pnpm test` also filters out `iterate`), so "the package's tests" is vacuous; verified behavior with the live discovery run instead.

## Checks run

- `pnpm typecheck` — pass
- `pnpm lint` — pass (oxlint, 0 warnings/errors)
- `pnpm format` / lint-staged oxfmt on commit — no diffs
- Live CLI smoke test against https://os.iterate.com — remote procedures discovered and listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The discovery URL fix is required for CLI usability but changes runtime behavior for all `iterate os` users; the AGPL license change affects npm consumers and needs explicit maintainer sign-off.
> 
> **Overview**
> Fixes **`iterate os ...`** by pointing remote procedure discovery at **`/api/__internal/trpc-cli-procedures`** instead of the old **`/api/trpc-cli-procedures`** path (aligned with the shared internal router contract), so the published CLI can mount OS commands against current deployments again.
> 
> **`packages/iterate/README.md`** is rewritten to match the real CLI: runtime oRPC discovery, config/auth commands, optional **`authBaseUrl`** derivation, and **`iterate config local`** / **`pubme.js publish`** — and it drops docs for removed or nonexistent flows (**`setup`**, **`install`**, daemon, clone/bootstrap).
> 
> **`packages/iterate/package.json`** license changes from **Apache-2.0** to **AGPL-3.0-only** (maintainers should confirm that matches intent for the npm package).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf58d133f71c0a129c1b976ba4d4000949572b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->