### PR TITLE
skills: remove dead daemon/Fly instructions, fix wrong commands, repair skills-registry generator

### DIFF
--- a/.agents/skills/cloudflare-traces/EXAMPLES.md
+++ b/.agents/skills/cloudflare-traces/EXAMPLES.md
@@ -8,7 +8,7 @@ the underlying span events and counts them by span name.
 
 ```ts
 mcp__cloudflare_api__.execute({
-  account_id: "cc7f6f461fbe823c199da2b27f9e0ff3",
+  account_id: "376ef7ed81b0573f93524de763666c15",
   code: `async () => {
     const traceId = "250178b64271952ffb1ed1711133cf78";
     const timeframe = {

--- a/.opencode/skills/AGENTS.md
+++ b/.opencode/skills/AGENTS.md
@@ -1,10 +1,10 @@
 # Skills
 
-- Skills live in `skills/<skill-name>/SKILL.md`.
+- Skills live in `.opencode/skills/<skill-name>/SKILL.md` (this folder).
 - Public registry only includes skills with frontmatter `publish: true`.
 - Website well-known endpoint is served by `apps/iterate-com/backend/worker.ts`.
-- Registry data is generated from this folder by `apps/iterate-com/scripts/generate-skills-registry.mjs`.
-- Generated file: `apps/iterate-com/backend/generated/skills-registry.ts`.
+- Registry data is generated from this folder by `apps/iterate-com/scripts/generate-skills-registry.mjs` (run via `pnpm --dir apps/iterate-com skills:generate`; the iterate-com build and deploy scripts run it automatically). The generator fails loudly if this folder is missing.
+- Generated file: `apps/iterate-com/backend/generated/skills-registry.ts` (checked in; regenerate and commit when publishable skills change).
 - To use repo skills globally in local agents, run sync from repo root:
   - `pnpm skills:sync`
 - To inspect globally installed synced skills:

--- a/.opencode/skills/architect-diagnose-performance/SKILL.md
+++ b/.opencode/skills/architect-diagnose-performance/SKILL.md
@@ -11,7 +11,6 @@ Use when there are latency spikes, timeout increases, throughput drops, or capac
 
 - Cloudflare Observability MCP (latency/error distributions)
 - PostHog MCP (user-facing impact/error trends)
-- Fly signals (machine health/usage)
 - Recent git commits/PRs for regression correlation
 
 ## Workflow

--- a/.opencode/skills/architect/SKILL.md
+++ b/.opencode/skills/architect/SKILL.md
@@ -33,7 +33,7 @@ Rules:
 
 You need these MCP servers connected before starting:
 
-- **Cloudflare Workers Observability** (`https://observability.mcp.cloudflare.com/mcp`) - worker logs, errors, analytics, invocation timing
+- **Cloudflare API** (`https://mcp.cloudflare.com/mcp`) - worker logs, errors, analytics, invocation timing. Use the general API MCP server; do not configure a separate product-specific observability endpoint (see `.agents/skills/cloudflare-traces/SKILL.md`).
 - **PostHog** (`https://mcp.posthog.com/mcp`) - error tracking, exception investigation, event queries
 
 If either is unavailable, note it in your PR description and work with what you have.
@@ -63,7 +63,6 @@ Diagnosis tool access:
 
 - Cloudflare logs/observability via MCP
 - PostHog events/exceptions via MCP
-- Fly machine status via `fly` CLI (with credentials from env or Doppler)
 
 Anomaly triggers (use these to decide when to switch into diagnosis skills):
 
@@ -80,9 +79,9 @@ If there are anomalies, use one or more of the following skills:
 - `skills/architect-diagnose-test-flakes/SKILL.md`
 - `skills/debug-os-worker/SKILL.md`
 
-## Fly machine monitoring mode
+## Monitoring mode
 
-When the task is Fly machine health/usage monitoring, use:
+When the task is OS / Cloudflare app health monitoring, use:
 
 - `skills/architect-monitoring/SKILL.md`
 
@@ -138,13 +137,6 @@ gh pr create \
 
 For architect monitoring runs, follow `skills/architect-monitoring/SKILL.md` for Slack behavior and reporting.
 
-For all other architect runs, after opening a PR, post a summary to `#monitoring` (`C0AH6P1D1MJ`) with the PR link:
-
-```bash
-iterate tool exec-ts 'await slack.chat.postMessage({
-  channel: "C0AH6P1D1MJ",
-  text: "architect: <summary>\n<PR URL>\n\n<1-3 line summary of findings and fixes>",
-})'
-```
+For all other architect runs, after opening a PR, post a summary to `#monitoring` (`C0AH6P1D1MJ`) with the PR link and a 1-3 line summary of findings and fixes. The old `iterate tool exec-ts` daemon tooling is gone; use whatever Slack access your environment provides, and if you have none, note in the PR description that the Slack summary still needs to be posted.
 
 If a Slack thread already exists for this task (e.g. someone triggered the sweep from a thread), reply there instead of starting a new message. Always include the PR link.

--- a/.opencode/skills/debug-os-worker/SKILL.md
+++ b/.opencode/skills/debug-os-worker/SKILL.md
@@ -40,7 +40,7 @@ Filter on error level or distinctive message fragments from the alert.
 
 Map failures to handlers under:
 
-- `apps/os/src/entry.workerd.ts`
+- `apps/os/src/worker.ts`
 - `apps/os/src/orpc/`
 - `apps/os/src/domains/`
 

--- a/.opencode/skills/error-pulse/SKILL.md
+++ b/.opencode/skills/error-pulse/SKILL.md
@@ -37,17 +37,11 @@ If blocked, uncertain, or impact is broad, post in `#error-pulse` (`C09K1CTN4M7`
 - Use `@channel` for urgent incidents requiring immediate attention.
 - Use `@here` for important but not time-critical issues.
 
-When you open or continue a Slack thread, subscribe it to your current agent session so replies route back to you:
-
-```bash
-iterate tool subscribe-slack-thread --channel C09K1CTN4M7 --thread-ts <thread_ts> --session-id <session_id>
-```
-
-Use `get-current-session-id` tool to get `<session_id>`.
+There is no automated mechanism to route Slack thread replies back to your agent session (the old `iterate tool subscribe-slack-thread` daemon tooling was removed in PR #1341). Follow-up on escalation threads is manual: check threads you started while your run is still active, and assume a human picks up the thread after your run ends.
 
 ## Slack thread behavior
 
-When you are subscribed to a thread, reply to questions and direct asks even if you are not @mentioned. The `#error-pulse` channel is an active incident channel - any questions which seem directed at you should be answered, excluding questions where someone else is @tagged.
+While you are active in a thread, reply to questions and direct asks even if you are not @mentioned. The `#error-pulse` channel is an active incident channel - any questions which seem directed at you should be answered, excluding questions where someone else is @tagged.
 
 ## Slack message requirements
 

--- a/.opencode/skills/example-skill/SKILL.md
+++ b/.opencode/skills/example-skill/SKILL.md
@@ -1,19 +1,11 @@
 ---
 name: example-skill
-description: Example skill published from iterate's root skills directory
+description: Minimal smoke-test skill that verifies iterate's skills-registry publishing pipeline end to end.
 publish: true
 ---
 
 # Example Skill
 
-Use this as a template for publishing real skills from this repository.
+This skill is intentionally minimal. It exists to verify the publishing pipeline: it has `publish: true`, so its presence in the generated registry (`apps/iterate-com/backend/generated/skills-registry.ts`, served at `/.well-known/skills` by the iterate.com worker) confirms the generator and endpoint work.
 
-## When To Use
-
-Use when you want a minimal, installable skill that confirms the registry works.
-
-## Steps
-
-1. Read the task request.
-2. Apply concise, practical instructions.
-3. Return concrete output.
+It also serves as the template for a publishable skill: a directory under `.opencode/skills/` containing a `SKILL.md` whose frontmatter has `name` (matching the directory name), `description`, and `publish: true`.

--- a/.opencode/skills/playwriter-spec/SKILL.md
+++ b/.opencode/skills/playwriter-spec/SKILL.md
@@ -28,7 +28,7 @@ Tests live under each app, e.g. `apps/os/e2e/`, not a root `spec/` directory.
 ## Running tests
 
 ```bash
-OS_BASE_URL=https://… pnpm --dir apps/os test:e2e
+APP_CONFIG_BASE_URL=https://… pnpm --dir apps/os e2e
 ```
 
 See each app's `package.json` for required env vars.

--- a/apps/iterate-com/backend/generated/skills-registry.ts
+++ b/apps/iterate-com/backend/generated/skills-registry.ts
@@ -13,6 +13,24 @@ export interface WellKnownSkillsRegistry {
 }
 
 export const wellKnownSkillsRegistry: WellKnownSkillsRegistry = {
-  skills: [],
-  fileContents: {},
+  skills: [
+    {
+      name: "example-skill",
+      description:
+        "Minimal smoke-test skill that verifies iterate's skills-registry publishing pipeline end to end.",
+      files: ["SKILL.md"],
+    },
+    {
+      name: "playwriter-spec",
+      description:
+        "Run a Playwright e2e test manually in the browser via Playwriter while debugging and adapting in-flight.",
+      files: ["SKILL.md"],
+    },
+  ],
+  fileContents: {
+    "example-skill/SKILL.md":
+      "---\nname: example-skill\ndescription: Minimal smoke-test skill that verifies iterate's skills-registry publishing pipeline end to end.\npublish: true\n---\n\n# Example Skill\n\nThis skill is intentionally minimal. It exists to verify the publishing pipeline: it has `publish: true`, so its presence in the generated registry (`apps/iterate-com/backend/generated/skills-registry.ts`, served at `/.well-known/skills` by the iterate.com worker) confirms the generator and endpoint work.\n\nIt also serves as the template for a publishable skill: a directory under `.opencode/skills/` containing a `SKILL.md` whose frontmatter has `name` (matching the directory name), `description`, and `publish: true`.\n",
+    "playwriter-spec/SKILL.md":
+      "---\nname: playwriter-spec\ndescription: Run a Playwright e2e test manually in the browser via Playwriter while debugging and adapting in-flight.\npublish: true\n---\n\n# Manual E2E via Playwriter\n\nUse when an app e2e test is flaky or in flux and you want to execute the same flow manually with live debugging.\n\nTests live under each app, e.g. `apps/os/e2e/`, not a root `spec/` directory.\n\n## Workflow\n\n1. Read the target test file fully.\n2. Extract user journey, setup, and assertions.\n3. Reproduce steps in Playwriter (observe → act → observe).\n4. Debug in-place if behavior diverges.\n5. Record timings, blockers, and recovery actions.\n6. If asked, patch the test or product to match reliable behavior.\n\n## Rules\n\n- Stay faithful to test intent; explain deviations.\n- Prefer product signals over sleeps (loading UI, toasts, status text).\n- Summarize: pass/fail, evidence, concrete fixes.\n\n## Running tests\n\n```bash\nAPP_CONFIG_BASE_URL=https://… pnpm --dir apps/os e2e\n```\n\nSee each app's `package.json` for required env vars.\n",
+  },
 };

--- a/apps/iterate-com/scripts/generate-skills-registry.mjs
+++ b/apps/iterate-com/scripts/generate-skills-registry.mjs
@@ -6,7 +6,7 @@ import matter from "gray-matter";
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const appDir = resolve(scriptDir, "..");
 const repoRoot = resolve(appDir, "..", "..");
-const sourceSkillsDir = resolve(repoRoot, "skills");
+const sourceSkillsDir = resolve(repoRoot, ".opencode", "skills");
 const outputFile = resolve(appDir, "backend/generated/skills-registry.ts");
 
 function toPosixPath(pathname) {
@@ -33,7 +33,9 @@ async function listFilesRecursively(dirPath) {
 async function readSkillsFromRepo() {
   const rootEntries = await readdir(sourceSkillsDir, { withFileTypes: true }).catch((error) => {
     if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
-      return [];
+      throw new Error(
+        `Skills directory not found: ${sourceSkillsDir}. Repo skills live in .opencode/skills; refusing to emit an empty registry.`,
+      );
     }
     throw error;
   });

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -20,7 +20,7 @@ const baseConfig = {
     () => "pnpm -C apps/semaphore run db:types:stale",
     "git add apps/semaphore/sql/queries.ts",
   ],
-  "skills/**": [
+  ".opencode/skills/**": [
     () => "pnpm -C apps/iterate-com skills:generate",
     "git add apps/iterate-com/backend/generated/skills-registry.ts",
   ],


### PR DESCRIPTION
Sweep over agent skills plus a repair of the skills-publishing pipeline, which has been silently emitting an empty registry since the skills directory moved.

## Skill doc fixes

- **error-pulse**: removed the `iterate tool subscribe-slack-thread` / `get-current-session-id` instructions — those tools were deleted with the daemon stack in #1341 and no equivalent thread-subscription mechanism exists today. The skill now states that escalation-thread follow-up is manual.
- **architect**:
  - Required MCP access now points at the general Cloudflare API MCP server (`https://mcp.cloudflare.com/mcp`) instead of the product-specific observability endpoint that `.agents/skills/cloudflare-traces/SKILL.md` and `.agents/skills/debug-mcp-server/SKILL.md` explicitly forbid.
  - Dropped the `fly` CLI from diagnosis tool access and de-Fly'd the monitoring-mode section (kept as a pointer to `architect-monitoring`, which now covers OS/Cloudflare health monitoring; the Fly stack is removed).
  - Replaced the dead `iterate tool exec-ts 'await slack.chat.postMessage(...)'` snippet with a plain instruction to post the summary to `#monitoring`, noting the daemon tooling is gone. There is no documented programmatic Slack-posting CLI in the repo today, so the instruction stays mechanism-agnostic.
- **architect-diagnose-performance**: removed the "Fly signals (machine health/usage)" input.
- **playwriter-spec**: fixed the run command — `apps/os` has an `e2e` script (no `test:e2e`) and the suite reads `APP_CONFIG_BASE_URL` (not `OS_BASE_URL`).
- **cloudflare-traces EXAMPLES.md**: the `os-preview-2` example now uses the dev/preview account id `376ef7ed81b0573f93524de763666c15` instead of the garple account.
- **debug-os-worker**: `apps/os/src/entry.workerd.ts` no longer exists; replaced with `apps/os/src/worker.ts`.

## Registry pipeline repair

- `apps/iterate-com/scripts/generate-skills-registry.mjs` still read `<repoRoot>/skills`, which was moved to `.opencode/skills` in #1097, and swallowed the ENOENT — so the published `.well-known/skills` registry has been empty ever since. The generator now reads `.opencode/skills` and fails loudly if the directory is missing.
- Regenerated `apps/iterate-com/backend/generated/skills-registry.ts`; it now contains the two `publish: true` skills (`example-skill`, `playwriter-spec`).
- `lint-staged.config.cjs` had the same stale `skills/**` glob, so the auto-regeneration hook never fired on skill changes; updated to `.opencode/skills/**`.
- `.opencode/skills/AGENTS.md` updated to describe the fixed pipeline.
- **example-skill** kept `publish: true` and got an honest description/body as a minimal registry smoke-test skill (see flags below).

## Checks

- `pnpm install`, `pnpm format` (oxfmt), `pnpm lint`, `pnpm typecheck` — all green.
- `node apps/iterate-com/scripts/generate-skills-registry.mjs` and `pnpm --dir apps/iterate-com skills:generate` — output contains both publish:true skills.
- `pnpm --dir apps/iterate-com build` — builds successfully with the regenerated registry.

## Skipped

- Nothing skipped; all nine items re-verified against the code and applied. Did not touch `.agents/skills/adding-a-new-durable-object-mixin/` or `.agents/skills/drizzle-migrations/` (owned by other PRs).

## Flags for reviewers

- **example-skill judgment call**: I kept `publish: true` and rewrote it as an explicit registry smoke-test skill rather than unpublishing it — having one always-published skill gives the `.well-known/skills` endpoint a guaranteed non-empty payload to check against. Flip to `publish: false` if you'd rather not ship it.
- **Architect Slack reporting is now mechanism-agnostic**: with the daemon tooling gone I found no replacement programmatic Slack-posting path in the repo, so the skill just says to post to `#monitoring` with whatever access the runtime has. If a real mechanism exists (or gets added), the skill should name it.
- Merging this changes what `iterate.com/.well-known/skills` serves on next iterate-com deploy: from an empty list to `example-skill` + `playwriter-spec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and generated registry only; no runtime app logic, though iterate-com deploy will change the public skills list from empty to two published skills.
> 
> **Overview**
> Repairs the **skills publishing pipeline** after skills moved to `.opencode/skills`: the generator and `lint-staged` no longer point at the old `skills/` path or silently emit an empty registry—it reads `.opencode/skills`, errors if that folder is missing, and the checked-in `skills-registry.ts` now lists **`example-skill`** and **`playwriter-spec`**. **`.well-known/skills`** will serve real content on the next iterate-com deploy.
> 
> Agent skill docs are updated to match the current stack: removed **Fly** / **daemon** references (`iterate tool exec-ts`, `subscribe-slack-thread`), **architect** now requires the general **Cloudflare API MCP** and mechanism-agnostic Slack posting, **error-pulse** documents manual thread follow-up, and small fixes cover **playwriter-spec** e2e command/env, **debug-os-worker** entry at `worker.ts`, **cloudflare-traces** example account id, and **example-skill** as an explicit registry smoke test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf507477dc8148f9d7713bde741ef4f151e0b60e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->