### PR TITLE
docs(iterate-com): fix fabricated public docs (getting started, context rules, your iterate repo)

### DIFF
--- a/apps/iterate-com/backend/content/docs/01_getting-started.md
+++ b/apps/iterate-com/backend/content/docs/01_getting-started.md
@@ -4,22 +4,29 @@ title: Getting Started
 
 These docs are a work in progress.
 
-![Sample Image](/backend/assets/nick.png)
+iterate runs in your browser — there is nothing to install. Sign in at
+[os.iterate.com](https://os.iterate.com) to get started.
 
-## Installation
+## 1. Create a project
 
-To get started, install the package:
+A project is the home for everything iterate does for you: its git repository,
+integrations, agents, and event streams. Pick a slug (lowercase letters,
+numbers, and hyphens) and create the project from the dashboard.
 
-```bash
-npm install iterate
-```
+## 2. Connect your tools
 
-## Basic Usage
+From the project's Integrations page you can connect:
 
-Here's a simple example:
+- **Slack** — so iterate can take part in your Slack workspace
+- **Google** — for Gmail, Calendar, Docs, Sheets, and Drive
 
-```javascript
-import { iterate } from "iterate";
+## 3. Talk to iterate in Slack
 
-const result = iterate.run();
-```
+Once Slack is connected, mention the iterate bot in a channel or thread and it
+will respond there. That conversation is the main way to work with iterate
+day to day.
+
+## What about the `iterate` package on npm?
+
+It's a command-line client for the platform, not a library — you don't need it
+to get started.

--- a/apps/iterate-com/backend/content/docs/03_context-rules.md
+++ b/apps/iterate-com/backend/content/docs/03_context-rules.md
@@ -5,15 +5,13 @@ category: Core concepts
 
 # Context Rules
 
-Context rules define how iterate should behave for your company. They live in your iterate repository and are loaded at runtime to guide agents.
+> **Coming soon.** Context rules are not available yet — this page describes
+> where we're headed.
 
-## What to include
+Context rules will let you define how iterate should behave for your company:
+tone of voice, coding standards, security constraints, and decision-making
+principles. The plan is for them to live in your iterate repository, so
+changes are versioned and reviewed like any other code.
 
-- Company tone of voice and writing preferences
-- Coding standards and architectural conventions
-- Security and data handling constraints
-- Decision-making principles and trade-offs
-
-## How it works
-
-Agents read these rules on startup and during tasks to align responses and actions with your preferences. Update them in git to roll out changes safely via PRs.
+Until then, the way to steer iterate is to tell it what you want directly in
+Slack.

--- a/apps/iterate-com/backend/content/docs/04_your-iterate-repo.md
+++ b/apps/iterate-com/backend/content/docs/04_your-iterate-repo.md
@@ -5,16 +5,26 @@ category: Core concepts
 
 # Your iterate repository
 
-Your iterate repo is where you store configuration, rules, and any custom tools. Treat it like code: versioned, reviewed, and deployed.
+Every project comes with a git repository called `iterate-config`. It holds
+your project's configuration and the code iterate runs on your behalf. Treat
+it like code: versioned, reviewed, and rolled out by pushing.
 
 ## Structure
 
-- rules/: context rules for agents
-- tools/: optional MCP clients or scripts
-- iterate.config.ts: global configuration
+A fresh repository looks like this:
+
+- `iterate.config.jsonc` — project configuration
+- `package.json`
+- `worker.js` — the project's root worker; it routes incoming requests to your
+  apps
+- `apps/<name>/worker.js` — one worker per app. New projects are seeded with
+  two example apps and a `webhooks` app that records incoming webhooks to your
+  project's event stream
 
 ## Workflow
 
-1. Create a branch and make changes
-2. Open a PR and gather review
-3. Merge to main to roll out to agents
+1. Clone the repository — your project's Repos page in the dashboard shows the
+   clone command and credentials
+2. Edit, commit, and push to the default branch
+3. iterate picks up new commits shortly after you push, rebuilds your
+   project's worker, and serves the new version

--- a/apps/iterate-com/backend/content/docs/97_faq.md
+++ b/apps/iterate-com/backend/content/docs/97_faq.md
@@ -6,7 +6,8 @@ title: FAQ
 
 ## Is iterate open source?
 
-Yes, core components are open source in this repo.
+Yes, core components are developed in the open at
+[github.com/iterate/iterate](https://github.com/iterate/iterate).
 
 ## Where do I configure my agent?
 


### PR DESCRIPTION
These are live, publicly served docs at iterate.com, and three pages described things that don't exist. This PR makes them match the product. **Please get a marketing/brand review before merging** — copy is intentionally short and conservative.

## Changes

- **01_getting-started.md** — removed `npm install iterate` + `import { iterate } from "iterate"; iterate.run()`. The npm `iterate` package is a CLI (a `bin` that talks to the OS oRPC API), not a library; that API never existed. Rewrote the page around the real flow verified in `apps/os`: sign in at os.iterate.com, create a project (`new-project` route + `create-project-form.tsx`), connect Slack/Google from the project Integrations page (`integrations.tsx`), then mention the bot in Slack (slack-agent processor responds in-thread). Added one line clarifying the npm package is a CLI.
- **04_your-iterate-repo.md** — the claimed `rules/`, `tools/`, `iterate.config.ts` layout doesn't exist. Rewrote to the actual seeded `iterate-config` repo per `apps/os/src/domains/repos/iterate-config-base-seed.ts`: `iterate.config.jsonc`, `package.json`, root `worker.js`, and `apps/<name>/worker.js` (two example apps + a webhooks app). Workflow now matches the dashboard Repos page (clone command/credentials shown there) and the project DO's behavior of re-cloning the default branch and rebuilding the worker (10s refresh interval, so "shortly after you push").
- **03_context-rules.md** — grepped `apps/os` for any context-rules/rules-loading mechanism: none exists (the only "rules" are internal JSONata reactor stream-processor rules, unrelated). **Choice made: kept the page but clearly marked it "Coming soon"** and cut all false mechanics ("loaded at runtime", "agents read these rules on startup"). Alternative was deleting the page — kept it since the FAQ and nav reference Core concepts, but happy to cut it instead.
- **97_faq.md** — "open source in this repo" made no sense on the marketing site; now links to github.com/iterate/iterate (verified public). Left the rest, including the "configure my agent in your iterate repository" answer, which is consistent with the rewritten repo page.
- **98_getting-help.md and changelog** — checked, no contradictions with the above; untouched.

## Skipped / not done

- Did not rewrite the placeholder changelog entries or 98_getting-help.md (out of scope; no contradictions).
- Did not run `pnpm build` for iterate-com (requires Doppler); ran app typecheck instead.

## Flags for human judgment

- **Marketing review requested for the whole PR** — tone, and whether we want a public docs page that says "Coming soon" (03_context-rules.md) at all.
- 98_getting-help.md mentions "the public Slack" — I could not verify a public Slack community exists. Not touched because it doesn't contradict these fixes, but worth a check.
- The getting-started page now implies open self-serve sign-up at os.iterate.com; if access is actually invite/sales-gated, the first paragraph should say so.

## Checks

- `pnpm install`, `pnpm format` (oxfmt), and `pnpm typecheck` in `apps/iterate-com` — all clean. Content-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only copy changes on the marketing site; no runtime or API behavior is modified.
> 
> **Overview**
> Public marketing docs under `apps/iterate-com/backend/content/docs` are updated so they describe the real product instead of placeholder or incorrect flows.
> 
> **Getting started** drops the fictional `npm install iterate` / `import { iterate }` library usage and walks through browser sign-in at os.iterate.com, creating a project, connecting Slack and Google from Integrations, and using the bot in Slack. It clarifies the npm `iterate` package is a CLI, not required to start.
> 
> **Your iterate repo** replaces the invented `rules/`, `tools/`, and `iterate.config.ts` layout with the actual `iterate-config` seed (`iterate.config.jsonc`, `package.json`, root and per-app `worker.js`, including example apps and webhooks) and a push-based rollout workflow via the dashboard Repos page.
> 
> **Context rules** is reframed as **coming soon**, removing claims that rules load at runtime or on agent startup; steering users to Slack until the feature exists.
> 
> **FAQ** open-source wording now points at [github.com/iterate/iterate](https://github.com/iterate/iterate) instead of an ambiguous “this repo.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77abfc8a2d5a766cb50af0497ae151ff62c80ef4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->