### PR TITLE
itx design notes + handwritten types.ts (design of record)

### DIFF
--- a/apps/os/docs/itx-next.md
+++ b/apps/os/docs/itx-next.md
@@ -1,0 +1,527 @@
+# itx: what's next (working notes)
+
+Status: NOODLING. This is the running list of things we want to fix or build in
+the itx layer, with positions and open questions. Nothing here is committed;
+when an item graduates it gets its own task/PR and the spec
+(`itx-spec.md`) gets amended. Companion docs: `apps/os/src/itx/README.md`
+(what exists), `apps/os/src/itx/DECISIONS.md` (what changed on contact with
+reality).
+
+## 0. The frame (recap, so this doc stands alone)
+
+A **context** is a durable, network-attached JS object: capabilities are its
+properties, the parent context is its prototype, and an **itx** is a remote
+reference to it. Lookup walks child → parent with shadowing (one DO hop per
+miss); writes always land on the node your handle points at; `fork()` is
+`Object.create(parent)`.
+
+A handle carries two separate things that must never be conflated (§3):
+its **access set** (which refs it may resolve — the authority, checked at
+every resolution) and its **default ref components** (which parts of a ref
+you may elide — pure ergonomics). "Project context" is not a structural
+concept: a project is a domain object with an ID that _happens_ to be
+usable as the namespace certain collections (streams, repos, workspaces)
+are keyed by. The 99% case, never a kernel assumption.
+
+The dimensions a capability can vary along (these are orthogonal; the current
+`live | worker | facet` kinds are three _points_ in this space, not the axes):
+
+1. **Who authored the code** — first-party trusted vs. AI/user-written.
+2. **Where it executes** — platform (static worker / dynamic isolate / DO
+   facet) vs. outside (Node on a laptop, agent sandbox, browser, phone,
+   third-party server).
+3. **Stateful vs. stateless.**
+4. **Wiring direction**, from the context's perspective — _inbound_
+   (something holds a live connection to me; the cap exists because the
+   connection exists) vs. _outbound_ (I hold an address and reach out at
+   invoke time — a binding, an entrypoint, a URL, or stored source the
+   platform materializes into an isolate).
+5. **Registration lifetime** — session-bound vs. durable.
+
+`kind` in the registry is really just "how the supervisor obtains a target
+stub at invoke time": `live` = take from memory, `worker` =
+`loader.getEntrypoint()`, `facet` = `ctx.facets.get()`. Everything below
+follows from generalizing that.
+
+## 1. CapTarget: a name and a target, the target comes in kinds
+
+Every gap we keep hitting is the same gap. A capability is a **name plus a
+target**, and the target is ONE discriminated union covering every way the
+supervisor obtains a callable at invoke time:
+
+```ts
+type CapTarget =
+  | { type: "live"; stub: LiveStub } // inbound: a connected provider's stub, session-bound. The ONE non-serializable kind.
+  | { type: "rpc"; worker: WorkerRef; entrypoint?: string; props?: Record<string, unknown> }
+  | { type: "url"; url: string; headers?: Record<string, string> }; // a Cap'n Web server across the internet; headers pass through egress secret substitution
+
+type WorkerRef = // where an rpc target's worker lives — ONE shape for everything Workers-RPC-reachable
+  | { type: "binding"; binding: string } // anything on env: a service binding, env.AI, a queue
+  | { type: "loopback" } // the platform worker's own exports (first-party code)
+  | { type: "project-worker" } // the project worker (user space) — sugar, see below
+  | { type: "durable-object"; binding: string; name: string }
+  | { type: "source"; source: CapSource }; // a dynamic worker materialized from stored source
+```
+
+`project-worker` is NOT a primitive: it normalizes at define time to
+reaching the first-party `ProjectWorker` loopback forwarder with this
+project's id (the registry already injects context attribution). It is not
+a `source` worker either — its code lives in the project's build artifact
+and changes on deploy, so the registry can only point at it, never pin it.
+The dedicated spelling exists purely so `entrypoint` always names the
+export YOU call (not the forwarder) and `describe()` stays informative.
+
+(Revised on review from a flat nine-kind union: the Workers-RPC-reachable
+kinds — binding, loopback, entrypoint, durable-object, config-worker,
+dynamic-worker — were all secretly the same thing, "an RPC target in some
+worker", and collapsed into `rpc` × `WorkerRef`. The full per-kind
+docstrings live in `apps/os/src/itx/types.ts`, which is the design of
+record.)
+
+**Inbound vs. outbound is a derived direction, not API surface.** `live` is
+inbound (something holds a connection to me; the cap exists because the
+connection exists); `rpc` and `url` are outbound (I reach out at invoke
+time). The caller never spells the direction. Storing source and loading it
+ourselves is not a third category, just another `WorkerRef` — which is
+exactly the two-case shape `borrowTarget` already has (live table, or
+resolve-the-target).
+
+**MCP and OpenAPI are deliberately NOT in the union.** They are not
+transports — they are client _implementations_, i.e. ordinary RPC targets.
+The litmus test for the whole design: a user must be able to implement an
+OpenAPI (or MCP) client as a WorkerEntrypoint exported from their own
+project worker and register it as a first-class cap — and the
+first-party `McpClient` must be the SAME shape, just reached via
+`{ type: "loopback" }` instead of `{ type: "project-worker" }`:
+
+```ts
+// First-party MCP client, parameterized per server. Headers carry
+// getSecret() placeholders — they travel through project egress.
+await itx.caps.define({
+  name: "docs",
+  invoke: "path-call",
+  target: {
+    type: "rpc",
+    worker: { type: "loopback" },
+    entrypoint: "McpClient",
+    props: { serverUrl: "https://docs.example.com/mcp", headers: { … } },
+  },
+});
+
+// User-space OpenAPI client: a class YOU export from your project worker.
+await itx.caps.define({
+  name: "petstore",
+  target: {
+    type: "rpc",
+    worker: { type: "project-worker" },
+    entrypoint: "OpenApiClient",
+    props: { specUrl: "https://petstore.example.com/openapi.json" },
+  },
+});
+```
+
+If the first-party client needs anything the user-space one can't have, the
+design has failed. Build both as the acceptance test (§4).
+
+Prior art in our own codebase: codemode's `ToolProviderRegistration` carries a
+`Callable` (`@iterate-com/shared/callable`) with
+`via: env-binding | loopback-binding` + `rpcMethod`. That IS this concept,
+buried inside codemode. Decision: take inspiration, don't necessarily reuse —
+the Callable shape carries codemode-specific baggage (`rpcMethod`,
+`argsMode`); CapTarget should stay a pure target description and let the existing
+`invoke: "members" | "path-call"` modes describe the calling convention.
+
+### Are these sturdy refs? (yes — here's the receipts)
+
+Kenton's Cap'n Proto defines this exactly, in
+[`persistent.capnp`](https://github.com/capnproto/capnproto/blob/master/c%2B%2B/src/capnp/persistent.capnp):
+a live capability can `save()` to a **SturdyRef**, a serializable token that
+can be stored and later **restored** to a live capability on a future
+connection. Crucially:
+
+- "The exact format of SturdyRef depends on the **realm**" — a realm is "an
+  abstract space in which all SturdyRefs have the same format and refer to
+  the same set of resources." The format is deliberately NOT defined by
+  Cap'n Proto; each application defines its own.
+- Restoring is itself a capability: per Kenton on the
+  [mailing list](https://groups.google.com/g/capnproto/c/d6uPbXf9e4E),
+  SturdyRefs are "sort of a design pattern… you can call save() on a
+  capability and receive back some sort of token that you can use to get
+  that capability again in the future," and the restorer may sit behind
+  authentication.
+- Refs can be **sealed** to an owner ("so that it can only be restored by
+  the specified Owner… meant to mitigate damage when a SturdyRef is
+  leaked").
+- Cap'n Web itself has none of this today (the README doesn't mention
+  persistence at all) — which is fine; it's a realm-level concern.
+
+So: **the iterate platform is a realm; the serializable `CapTarget` kinds
+(everything except `live`) are our realm's SturdyRef format; `resolveItx`
+is — and is already named — the restorer.** The
+vocabulary is already half-adopted: `protocol.ts` calls context ids "sturdy
+refs" and `entrypoint.ts` calls `resolveItx` "the restorer." CapTarget
+completes the picture by making capability _targets_ sturdy, not just
+contexts.
+
+One deliberate divergence to write down: classic SturdyRefs are often bearer
+tokens (possession = authority). Ours are **names within a trusted realm** —
+they carry zero authority by content (Law 2/3); authority is which context
+your handle points at, checked at connect. The one place we DO mint
+bearer-style sealed refs is the HTTP share token
+(`createShareToken`: HMAC over `project:cap:expiry`) — that is literally a
+sealed, expiring SturdyRef for one cap's fetch surface, and we should
+document it as such. Position: keep it that way — bearer form exists only at
+the HTTP edge, never inside the realm.
+
+### One verb, not three
+
+Earlier draft had `provide` / `dial` / `define` as sibling verbs. Preference:
+they're all "register a capability"; make ONE function whose argument shape
+is self-documenting:
+
+```ts
+itx.caps.define({ name: "mac",   target: { type: "live", stub } });                                        // inbound, session-bound
+itx.caps.define({ name: "slack", target: { type: "rpc", worker: { type: "source", source: { … } } } });    // outbound, durable
+itx.caps.define({ name: "ai",    target: { type: "rpc", worker: { type: "binding", binding: "AI" } } });   // outbound, durable
+```
+
+RESOLVED (supersedes an earlier `target | source | address` triple, which
+was confusing): one field, **`target`**, in different kinds — the
+discriminated union above. No separate `source`/`address` arms; direction
+is derived from the kind, never spelled by the caller. (Possible authoring
+sugar: a bare stub/function means `{ type: "live" }`.) `caps.provide` can
+stay as an alias during migration.
+
+RESOLVED: `kind: "facet"` dies as user-facing vocabulary (it names the
+platform _mechanism_, not the concept, and hides that this is a Durable
+Object). A dynamic worker's statefulness is a property of its source — the
+entrypoint export is either a `WorkerEntrypoint` (stateless, fresh per
+call) or a `DurableObject` class (stateful, own private SQLite; the
+platform instantiates it as a DO facet under the hood):
+
+```ts
+source: {
+  cacheKey, mainModule, modules,
+  entrypoint: "Todo",
+  exportType: "worker-entrypoint" | "durable-object",
+}
+```
+
+## 2. Platform bindings as capabilities (env.AI, env.BROWSER, queues, …)
+
+It must be **trivially easy** to hand a Cloudflare binding to a context —
+but raw pass-through is the _degenerate_ case, not the common one. Look at
+what the codemode AI provider actually does: it doesn't expose `env.AI`
+raw — it wraps it a tiny bit (picks a gateway, appends user/attribution
+info). That will usually be the case: a binding cap is _almost_
+pass-through, plus a thin policy layer (gateway selection, attribution,
+later allowlists/quotas).
+
+The pattern is the one we already have — ProjectEgress / Law 5, applied to
+a different resource. The platform ships ONE generic first-party loopback
+entrypoint (say `BindingCapability`) that receives identity props, applies
+policy, and replays the call onto `env[props.binding]`:
+
+```ts
+itx.caps.define({
+  name: "ai",
+  invoke: "members",
+  target: {
+    type: "rpc",
+    worker: { type: "loopback" },
+    entrypoint: "BindingCapability",
+    props: { binding: "AI", gateway: "project-default" },
+    // the registry adds { context, cap } attribution props at dial time,
+    // exactly as it does for ProjectEgress today
+  },
+});
+```
+
+Composition stays in code (the one entrypoint), parameterization stays in
+props (identity + attribution — Law 2 holds). Raw `{ type: "binding" }`
+remains in CapTarget for genuinely pass-through cases, but expect bindings
+to arrive wrapped. The supervisor's per-call hook (one line in
+`ContextRegistry.invoke`) gives usage/billing events for every cap
+uniformly.
+
+Authorization: defining a binding-backed cap requires a handle whose access
+covers the resource (global/admin for account-wide bindings like AI and
+browser rendering); once defined on a context, any handle on that context
+may call it. Open: do wrappers stay one generic `BindingCapability`
+entrypoint in practice, or do AI/browser/queues each want a small bespoke
+wrapper (gateway logic differs per binding)?
+
+## 3. A real global context (and the addressing model)
+
+Today `global` is fake: `resolveItx("global")` builds a handle with
+`projectId: null`, no registry, no node. Make it real. And the right frame
+for _what_ an itx is fell out of discussing it:
+
+**An itx is the realm's restorer, partially applied and bounded.** It is
+the function `ref → live object`, with some ref components pre-bound (the
+handle's _defaults_) and resolution limited to its _access set_. Every
+accessor is that one function in different sugar — `projects.get(ref)`,
+`streams.get(ref)`, `itx.slack` (a cap name is a context-relative ref),
+`fork()` (mint a ref, restore it). Connect is the same function with the
+authority supplied differently: `connectItx({ context: "global" },
+credential)` is `restore("global")` where the credential determines the
+bounds; thereafter the handle's own access set plays that role for every
+resolution. `resolveItx` already is this function — it just doesn't know
+it's the whole story.
+
+Refs are **unauthenticated** — pure names, zero authority by content.
+`"global"` is a ref anyone can write down; what restoring it yields depends
+entirely on who is restoring (Kenton: "restoring is itself a capability").
+The sealed HTTP share token stays the one deliberate bearer-form exception,
+at the edge only.
+
+**Namespaces belong to collections, not to contexts.** Streams, repos, and
+workspaces happen to be keyed by `(namespace, id)`; a project's ID happens
+to be usable as a namespace; `global` is another namespace value — and it
+really exists in production (Slack webhook receiving streams, global repos,
+the base iterate-config artifact / base repo). All of these address the
+same stream, and all must work:
+
+```ts
+// on a global handle:
+itx.streams.get("proj_123:/path"); // absolute, string ref
+itx.streams.get({ namespace: "proj_123", path: "/path" }); // absolute, structured ref
+itx.projects.get("proj_123").streams.get("/path"); // narrow, then relative
+itx.projects.get("proj_123").streams.get({ path: "/path" });
+// likewise itx.repos.get({ namespace, slug }), namespace may be "global"
+```
+
+Three rules keep this honest:
+
+1. **Sugar rule** — absolute forms internally construct the narrowed handle
+   and call through (Law 4). ONE code path; the access check never forks.
+2. **Resolution checks access** — every restore is checked against the
+   handle's access set, with the same error as not-found (no existence
+   probing). `projects.get` already behaves this way; this extends the same
+   rule to fully-qualified collection refs. A project handle cannot
+   fully-qualify its way out: `proj_456:/x` fails against access
+   `[proj_123]`.
+3. **Defaults ≠ authority** — narrowing produces a handle with a smaller
+   access set AND tighter defaults; only the access set is security.
+
+It follows that the global context is NOT a special node: same anatomy as
+every other context (registry, audit stream, live table). The spec's old
+worry ("ambient authority creep starts here") is handled by _access_, not
+by crippling the node. Naming: keep `global`, not `root` — it's already the
+literal namespace name in the streams domain.
+
+**The access model is deliberately two-tier, and it shipped (PR #1418):**
+the only scopes that exist are `superadmin` (server-granted via the `admin`
+role only — client-requested scope is always stripped; auto-granted to
+`@nustom.com` accounts) and `project:<id>` strings. Superadmin resolves to
+access `"all"`; everyone else may do project-scoped things iff the project
+id is literally in their scopes. There is no separate "global namespace
+grant" — global authority IS superadmin. The code keeps ONE seam where
+finer-grained permissions would slot in later; we deliberately build none
+of it now. #1418 also already ships the first slice of this section: the
+`/admin` UI connects to the global itx over Cap'n Web, and `itx.streams`
+on a global handle targets the deployment-wide `global` namespace, gated
+on access `"all"`.
+
+Direction, not commitment: if every accessor is restore-with-sugar, the
+logical endgame is one literal `itx.restore(ref)` taking a self-describing
+ref (`"stream:proj_123:/path"`). Today each collection parses its own ref
+format and that's fine; write the direction down so the dotted API is
+understood as sugar, and build the universal form only when something needs
+it.
+
+Remaining questions:
+
+- Is the global context's stream the audit surface for project lifecycle
+  (created/deleted), the way project `/itx` streams audit cap lifecycle?
+  (Symmetry says yes.)
+- Confirm the uncurried `{ namespace, … }` accessor pattern uniformly
+  across repos/streams/workspaces.
+
+## 4. Drop codemode (the proving use case for all of the above)
+
+A codemode session is a child context that doesn't know it yet. The
+`CodemodeProcessor` reduces `tool-provider-registered` events into a provider
+map — that map IS a capability registry maintained in parallel via streams.
+The executor's `ctx` proxy IS the itx path-proxy. `callFunction`'s
+longest-prefix provider resolution IS registry dispatch.
+
+The plan:
+
+- A session = `itx.fork()` → a `ctx_…` context.
+- Tool providers = caps on that context. The three codemode provider families
+  map exactly onto §1:
+  - `ctx.ai` → `{ type: "rpc", worker: { type: "binding" | "loopback" } }` (§2),
+  - `ctx.mcp.*` / `connectToMcpServer` → first-party `McpClient` entrypoint
+    via `{ type: "rpc", worker: { type: "loopback" }, props: { serverUrl, headers } }`,
+  - OpenAPI providers → user-space `OpenApiClient` exported from the
+    project worker, via `{ type: "rpc", worker: { type: "project-worker" } }`.
+    Making those three work — one first-party, one user-space, same shape —
+    is the acceptance test for CapTarget (the litmus test in §1).
+- Execution = two events on the context's stream:
+  - `events.iterate.com/itx/execution-requested` `{ executionId, code, vars }`
+  - `events.iterate.com/itx/execution-completed` `{ executionId, result | error, durationMs }`
+- **Record-only mode first**: the caller appends `execution-requested`, runs
+  the existing `/api/itx/run` loader harness inline (env.ITERATE scoped to
+  the context), appends `execution-completed`. Events are the durable
+  record, not the transport. No processor.
+- **Processor mode later** (additive): a subscriber on the context's stream
+  picks up `execution-requested` and runs it — durable/disconnected runs
+  (Slack-agent style). This is also the streams-convergence proof (§6): the
+  processor is just a dialed subscriber.
+- Per-function-call events (`function-call-requested/completed`) die. If we
+  want call-level audit later it's one hook in `ContextRegistry.invoke` —
+  the single supervisor dispatch — covering every cap uniformly.
+- `ProjectMcpServerConnection` shrinks to: authenticate → fork-or-reuse a
+  child context per MCP session → append/run/await → format (~750 lines →
+  ~150).
+- Needed along the way: per-context execution streams. Child-context audit
+  currently lands on the project's `/itx` stream (D9); execution events want
+  the session's history self-contained (e.g. `/itx/ctx_…`). Decide path
+  scheme.
+
+### Providing capabilities via events?
+
+The question that came up: "if I wanted to use an execution-requested event
+to provide a new capability, I'd have to run a one-off script that calls
+`caps.define` with source code in string form — should there be a dedicated
+event that lets me write the code unescaped?"
+
+Untangling it:
+
+- Cap definitions are ALREADY durable without any event: `define` writes the
+  registry SQLite row; the stream gets an audit event (D1: table
+  authoritative, stream is history). You never _need_ an event to provide.
+- A script execution that calls `itx.caps.define(...)` works today and is
+  the honest general mechanism (code holds composition, Law 1).
+- The string-escaping pain is real but it's an _authoring_ problem, not a
+  protocol problem. A dedicated `cap-define-requested` event with unescaped
+  source in the payload would create a SECOND way to mutate the registry,
+  with ordering/authority questions (who may append it? does replaying a
+  stream re-define caps?) — that's composition-as-data creeping back in.
+- Position: don't add the event. Fix the authoring ergonomics instead:
+  the REPL/SDK gets a helper that takes a real function/module, stringifies
+  - bundles it, and calls `define` (this is also what "promotion from the
+    REPL" already needs). Revisit only if a concrete replay/declarative-setup
+    use case shows up.
+- Open question to confirm: was the underlying want auditability/replay
+  ("rebuild a context from its stream") or just ergonomics? If replay, that
+  is a different feature (registry snapshots/event-sourcing) and should be
+  argued on its own.
+
+## 5. The handwritten types file
+
+SHIPPED (first cut): `apps/os/src/itx/types.ts` — handwritten, import-free,
+narrative-first (the three concepts, a thirty-second worked example, then
+the handle, capabilities, streams, projects, wire types). It is
+simultaneously: the source of truth the implementation conforms to, the
+string fed to the REPL editor for completion, and the document handed to an
+agent as "this is what you have."
+
+Decisions made in it on first review:
+
+- `KnownCaps` (not `ProjectCaps`) is the declaration-merge point for typed
+  caps — and it is documented as a compile-time convenience GLOBAL to the
+  codebase; the runtime truth is always `describe()`.
+- No invented access type: `ItxPrincipal` is typed out by hand from
+  `~/auth/principal.ts` + `auth-claims` (admin | user with organizations +
+  projects), so drift becomes a type error. `ItxProps` carries the
+  principal, not a precomputed access list.
+- `ContextRef` is a template-literal union
+  (`"global" | prj_… | proj_… | ctx_…`), not a bare string.
+- `CapMeta` is arbitrary metadata with ONE convention: `instructions`, a
+  sentence for the agent who finds the cap, surfaced by `describe()`.
+- `describe()` is specified as the always-works, maximum-breadcrumbs
+  exploration entry point.
+- A context is defined as an _addressable_ node — durability is optional
+  (needed only when others must re-address it; the global handle today is a
+  context with no node behind it).
+- Open: split `GlobalItx` / `ProjectItx` at the type level? Today one `Itx`
+  type; project-needing members throw on global handles.
+- `codeId` is RENAMED to `cacheKey` — it was never an id ("id" in this
+  codebase means typeid); it's the loader's cache key, content hash ideal.
+  Implementation migrates when CapSource moves into the kernel.
+
+## 6. Streams convergence (after CapTarget exists)
+
+A stream subscriber registration is — literally, in the code — a `Callable`
+the Stream DO dials to deliver events. With CapTarget in place: contexts
+and streams share the address/dial/reconnect machinery (one module:
+addresses, dialing, dup-discipline, offline semantics); the stream keeps its
+delivery semantics (offsets, checkpoints, at-least-once). A subscriber
+becomes "a cap this stream dials with a delivery loop."
+
+Whether to merge node types entirely ("every context has a stream; a stream
+is a context whose primary fact is its log") is a real possibility but a
+second step, taken only after the shared layer proves itself.
+
+## 7. Smaller items
+
+- **Rename "iterate-config worker" → "project worker" codebase-wide**
+  (`callConfigWorkerFunction`, the base iterate-config artifact naming,
+  docs, UI copy). Design docs and `types.ts` already use the new name.
+- `handle.ts` sheds its direct domain imports (repos/workspace/streams) —
+  becomes addresses or injected stubs; kernel approaches the ~500-line goal.
+- Document the share token as a sealed SturdyRef (§1).
+- Per-cap/per-call usage events at the supervisor (billing + audit hook,
+  feeds §2 and §4).
+- Global-context implementation: make the node real, wire namespace
+  currying through the built-ins. (Polishing its shape beyond that is
+  explicitly LATER.)
+
+## Resolved (was open, now decided)
+
+- ~~Root registry from day one?~~ → Global context gets the same anatomy as
+  every context; no special-casing. Authority lives in access, not in node
+  shape.
+- ~~Is `namespace` always a project?~~ → No. Namespaces are the unit;
+  `global` is one; repos/streams/workspaces are namespace-curried
+  collections (§3). Don't build around project-ness.
+- ~~Binding-cap authorization granularity?~~ → Finer than pass-through:
+  bindings arrive wrapped in a thin policy entrypoint with attribution
+  props (§2).
+- ~~`kind: "facet"`?~~ → Dies. Stored-source caps are
+  `{ type: "rpc", worker: { type: "source" } }` targets discriminating on
+  `source.exportType: "worker-entrypoint" | "durable-object"` (§1). The
+  facet is instantiated by the DO hosting the context (Project DO or
+  ContextDO); its private SQLite lives inside that host.
+- ~~Verb/kind taxonomy (pushed/dialed/hosted)?~~ → Rejected as unclear.
+  From the context's perspective there are exactly two directions:
+  **inbound** (live connection) and **outbound** (everything else) — but
+  direction is _derived_, not API. The API is a name + a `target` whose
+  kind is the CapTarget union (§1); the `target | source | address` triple
+  is also rejected.
+- ~~Flat nine-kind CapTarget?~~ → Rejected on review ("too much stuff,
+  all very suspicious"). Collapsed to three: `live | rpc | url`, with
+  `WorkerRef` naming where an rpc target's worker lives. MCP/OpenAPI are
+  client implementations (ordinary RPC targets, first-party or user-space),
+  not protocol values on `url`; `url` takes `headers` that pass through
+  egress secret substitution (§1).
+- ~~`ItxAccess`?~~ → Rejected ("don't invent something else"). The handle
+  carries the auth system's principal verbatim — `ItxPrincipal`, hand-typed
+  from `~/auth/principal.ts` so drift is a type error (§5).
+- ~~`CapMeta` with an `http` schema?~~ → Too leaky. Arbitrary metadata with
+  one convention: `instructions`, surfaced by `describe()` (§5).
+- ~~Is `config-worker` a primitive WorkerRef kind?~~ → No. Renamed
+  `project-worker` and documented as strict sugar: it normalizes to the
+  first-party `ProjectWorker` loopback forwarder with this project's id.
+  Not a `source` worker either — its code lives in the project's build
+  artifact (the registry points, never pins). Kept as a spelling so
+  `entrypoint` always names the export you call (§1).
+- ~~Access model granularity?~~ → Shipped in #1418: `superadmin`
+  (role-granted) + `project:<id>` scopes, nothing else. One seam in the
+  code for finer-grained later; no implementation now. Global authority =
+  superadmin (§3).
+- ~~`global` vs `root`?~~ → `global` (leaning; it's the existing literal
+  namespace name, e.g. Slack webhook receiving streams).
+
+## Open questions (rolled up)
+
+1. Event-provided caps: was the want replay/auditability or authoring
+   ergonomics? (Position assumes ergonomics → SDK helper, no new event.)
+2. Per-context stream path scheme for execution events (`/itx/ctx_…`?).
+3. One generic `BindingCapability` wrapper entrypoint, or bespoke thin
+   wrappers per binding (AI gateway logic vs browser vs queues)?
+4. Global context's stream as the project-lifecycle audit surface — confirm.
+5. Uncurried `{ namespace, … }` accessor pattern uniformly across
+   repos/streams/workspaces — confirm shape.

--- a/apps/os/src/itx/types.ts
+++ b/apps/os/src/itx/types.ts
@@ -1,0 +1,616 @@
+/**
+ * # itx — the iterate context surface
+ *
+ * This file is handwritten, import-free, and is the design of record: the
+ * implementation in this directory conforms to THIS file, not the other way
+ * around. It is also the completion source for the REPL editor and the
+ * document you hand an agent ("you have an `itx`; this is what it is").
+ * Roadmap: `apps/os/docs/itx-next.md`. History: `DECISIONS.md`.
+ *
+ * ## The three concepts
+ *
+ * **A context** is an addressable node that holds named capabilities.
+ * Contexts form a prototype chain: capability lookup walks child → parent
+ * with shadowing, writes land on the node your handle points at, and
+ * `fork()` is `Object.create(parent)`. A context MAY be durable (a project's
+ * context lives in its Durable Object; a forked child gets its own node so
+ * others can address it later) — but durability is not part of the concept:
+ * a context that nothing else needs to re-address can live entirely in a
+ * connection, like the global handle does today.
+ *
+ * **A capability** is a name plus a {@link CapTarget}: either a live stub
+ * someone connected and handed us (inbound, lives as long as their
+ * connection), or a serializable description of where to find the
+ * implementation (outbound — an RPC target in some worker, or a URL across
+ * the internet). The serializable kinds are this realm's sturdy refs: pure
+ * names that grant nothing by possession and are restored to live objects
+ * on demand.
+ *
+ * **An itx** is a live handle on one context — the only thing user code
+ * ever touches, identical in the browser, Node, the REPL, the project
+ * worker (the worker built from the project's own repo — formerly the
+ * "iterate-config worker"), itx scripts, and capabilities themselves. Built-in
+ * members (`caps`, `streams`, `fetch`, `fork`, …) are the trust kernel;
+ * every other property falls through to the context's capability registry.
+ * Authority is the handle itself: auth happens once at connect, and which
+ * context you hold — plus the principal it was minted for — is the whole
+ * permission model. Narrowing is construction: a weaker handle is a new
+ * handle on a narrower context, never a flag on a wider one.
+ *
+ * ## Thirty seconds of itx
+ *
+ * ```ts
+ * // You are handed an `itx` — in the REPL, from connectItx(), or inside
+ * // any platform-loaded isolate via `await env.ITERATE.context`.
+ *
+ * await itx.describe();                    // what am I holding? what can I call?
+ *
+ * await itx.slack.chat.postMessage({       // call a capability someone defined —
+ *   channel: "C123", text: "hi",           // works because "slack" is in the
+ * });                                      // registry, not because itx knows Slack
+ *
+ * await itx.fetch("https://api.stripe.com/v1/charges", {
+ *   headers: { authorization: 'Bearer getSecret({ key: "STRIPE_KEY" })' },
+ * });                                      // egress: the secret is substituted
+ *                                          // server-side; this code never sees it
+ *
+ * await itx.caps.define({                  // teach this context a new trick:
+ *   name: "ai",                            // itx.ai.run(model, input)
+ *   target: { type: "rpc", worker: { type: "binding", binding: "AI" } },
+ * });
+ *
+ * const session = await itx.fork({ name: "agent-run-42" });
+ * // a cheap, disposable child context: its caps shadow the project's,
+ * // misses delegate up the chain. (This is what a "codemode session" is.)
+ * ```
+ *
+ * One honest caveat on typing: there is ONE `Itx` type, but a live handle is
+ * bound to something — a project, a child context, or nothing (a global
+ * handle). Members that need a project (`repos`, `workspace`, `worker`,
+ * `project`, `fetch`) throw on a global handle until you narrow via
+ * `itx.projects.get(...)`. The type system does not yet encode that split;
+ * `describe()` is the runtime truth. (Splitting `GlobalItx` / `ProjectItx`
+ * is an open design question — see itx-next.md.)
+ */
+
+// ---------------------------------------------------------------------------
+// The handle
+// ---------------------------------------------------------------------------
+
+/**
+ * A live handle on a context.
+ *
+ * Unknown property names fall through to the context's capability registry
+ * at runtime: `itx.slack.chat.postMessage(...)` works because someone
+ * defined `slack`. Property access accumulates a path locally (zero round
+ * trips); the terminal call dispatches once. Type known caps via
+ * {@link KnownCaps} merging, or reach anything untyped via `itx.cap(name)`.
+ */
+export type Itx = ItxBuiltins & KnownCaps;
+
+/**
+ * The built-in surface of every handle — the trust kernel. Everything else
+ * you see on an `itx` is a capability that fell through to the registry.
+ *
+ * Child contexts inherit all of this: a forked session's `repos`,
+ * `workspace`, and `streams` resolve through its owning project — the child
+ * adds a capability registry of its own, not a different kernel.
+ */
+export interface ItxBuiltins {
+  /** Register, revoke, inspect, and share capabilities on this context. */
+  readonly caps: ItxCaps;
+
+  /**
+   * Event streams. Streams are keyed by `(namespace, path)`; this handle's
+   * binding picks the default namespace (the project id on a project
+   * handle; `"global"` on a global handle). See {@link StreamRef} for the
+   * relative/absolute addressing forms.
+   */
+  readonly streams: ItxStreams;
+
+  /** Narrow to a project — the access check, returning a NEW handle. There
+   * is no separate "project object"; a narrowed itx IS the project. */
+  readonly projects: ItxProjects;
+
+  /** The project's git repos. (Direction: becomes a defined capability
+   * rather than a hardwired built-in; surface unchanged.) */
+  readonly repos: unknown;
+
+  /** The project's workspace: readFile/writeFile and a nested git surface.
+   * (Same direction as `repos`.) */
+  readonly workspace: unknown;
+
+  /** The project worker. Every public method/getter is reachable at any
+   * depth: `itx.worker.someTool(args)`. */
+  readonly worker: unknown;
+
+  /** The Project Durable Object stub, whole surface ("cap #0"). If your
+   * handle is on this project's context at all, you get all of it. */
+  readonly project: unknown;
+
+  /**
+   * Explicit project egress. Secret placeholders are substituted inside the
+   * project's egress hop — `'Bearer getSecret({ key: "X_TOKEN" })'` in a
+   * header never sees the material. Isolates the platform loads get this
+   * same pipe bound as their global `fetch`, so inside a capability or itx
+   * script, bare `fetch()` and `itx.fetch()` are the same door.
+   */
+  fetch(input: Request | string, init?: RequestInit): Promise<Response>;
+
+  /**
+   * Who/what am I holding? `describe()` always works, on every handle, and
+   * endeavors to return every breadcrumb you need to explore from here:
+   * the context, the principal, and the merged capability chain — each cap
+   * with its provenance and its provider-supplied `instructions`. When in
+   * doubt, describe.
+   */
+  describe(): Promise<ItxDescription>;
+
+  /** Explicit form of the fallthrough: `itx.cap("slack")` ≡ `itx.slack`.
+   * Useful when the name is computed or shadowed by a built-in. */
+  cap(name: string): unknown;
+
+  /**
+   * Create a child context under this one: same anatomy, cheaper,
+   * disposable — an agent session, a REPL scratchpad. The child's caps
+   * shadow this context's; misses delegate up the chain. The child's
+   * authority is exactly its owning project, even if this handle was wider.
+   */
+  fork(opts?: { name?: string }): Promise<Itx>;
+}
+
+/**
+ * Declaration-merge point for caps you expect to exist, so they complete
+ * and type-check. This is a compile-time convenience that is GLOBAL to the
+ * codebase compiling against it — it cannot vary per project or per
+ * context, and the runtime neither reads nor enforces it. The runtime truth
+ * is always `describe()`.
+ *
+ * ```ts
+ * declare module "~/itx/types.ts" {
+ *   interface KnownCaps {
+ *     slack: Stubify<import("@slack/web-api").WebClient>;
+ *   }
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- empty on purpose: this is the declaration-merge point
+export interface KnownCaps {}
+
+/** What `describe()` returns. Aspirational contract: as many breadcrumbs as
+ * we can possibly give you — this should always be the best starting point
+ * for exploring what exists. */
+export type ItxDescription = {
+  /** "global", a project id, or a ctx_… child context id. */
+  context: ContextRef;
+  /** Who this handle was minted for. */
+  principal: ItxPrincipal;
+  /** Attribution: which capability's isolate holds this handle, if any. */
+  cap?: string;
+  /** The merged capability chain (own caps first, ancestors' after,
+   * shadowed names carry `owner` provenance), including each cap's
+   * `instructions`. */
+  caps: CapDescription[];
+  /** The bound project's own description, if this handle has one. */
+  project: unknown | null;
+};
+
+// ---------------------------------------------------------------------------
+// Capabilities
+// ---------------------------------------------------------------------------
+
+/** Registry verbs. All registration is `define`; the target kind carries
+ * everything else (direction, durability, statefulness). */
+export interface ItxCaps {
+  /**
+   * Register a capability on this handle's context: a flat-identifier name
+   * plus a target. Live targets are session-bound (re-define on reconnect);
+   * rpc/url targets are durable. Nested names are not a thing — nesting
+   * belongs to the provided object, not the registry.
+   *
+   * ```ts
+   * // From a laptop/sandbox (inbound, lives while connected):
+   * await itx.caps.define({
+   *   name: "runSwiftOnMyMac",
+   *   target: { type: "live", stub: async (src) => runSwift(src) },
+   *   meta: { instructions: "Compile-and-run Swift on Jonas's Mac." },
+   * });
+   *
+   * // A raw platform binding (outbound, durable):
+   * await itx.caps.define({
+   *   name: "ai",
+   *   target: { type: "rpc", worker: { type: "binding", binding: "AI" } },
+   * });
+   *
+   * // First-party MCP client, parameterized per server (see CapTarget):
+   * await itx.caps.define({
+   *   name: "docs",
+   *   invoke: "path-call",
+   *   target: {
+   *     type: "rpc",
+   *     worker: { type: "loopback" },
+   *     entrypoint: "McpClient",
+   *     props: {
+   *       serverUrl: "https://docs.example.com/mcp",
+   *       headers: { authorization: 'Bearer getSecret({ key: "DOCS_TOKEN" })' },
+   *     },
+   *   },
+   * });
+   *
+   * // User-space: a class YOU export from your project worker:
+   * await itx.caps.define({
+   *   name: "petstore",
+   *   target: {
+   *     type: "rpc",
+   *     worker: { type: "project-worker" },
+   *     entrypoint: "OpenApiClient",
+   *     props: { specUrl: "https://petstore.example.com/openapi.json" },
+   *   },
+   * });
+   * ```
+   */
+  define(input: {
+    name: string;
+    target: CapTarget;
+    invoke?: CapInvoke;
+    meta?: CapMeta;
+  }): Promise<{ name: string; ok: true }>;
+
+  /** Legacy alias: `provide({ name, target: stub })` ≡
+   * `define({ name, target: { type: "live", stub } })`. */
+  provide(input: {
+    name: string;
+    target: LiveStub;
+    invoke?: CapInvoke;
+    meta?: CapMeta;
+  }): Promise<{ name: string; ok: true }>;
+
+  revoke(input: { name: string }): Promise<{ name: string; ok: true }>;
+
+  /** The merged chain view — same data `itx.describe()` embeds. */
+  describe(): Promise<CapDescription[]>;
+
+  /**
+   * "Let me show you something real quick": a signed, expiring URL for one
+   * HTTP-exposed cap. Possession grants exactly that cap's fetch surface
+   * until expiry — the realm's one deliberate bearer-token edge case.
+   */
+  shareUrl(input: { name: string; path?: string; ttlSeconds?: number }): Promise<string>;
+}
+
+/**
+ * THE capability target. Three kinds:
+ *
+ * - `live` — inbound. Something connected to this context and handed us a
+ *   stub; the cap exists exactly as long as that connection does. The one
+ *   non-serializable kind.
+ * - `rpc` — outbound, inside the Workers RPC universe. "There is an RPC
+ *   target in some worker; here is how to reach it." The worker may be a
+ *   platform binding, the platform worker's own exports, the project
+ *   worker, a Durable Object, or a dynamic worker materialized from stored
+ *   source — see {@link WorkerRef}.
+ * - `url` — outbound, across the internet: a Cap'n Web server somewhere.
+ *   Headers travel through project egress, so they may carry
+ *   `getSecret(...)` placeholders.
+ *
+ * Deliberately NOT here: MCP and OpenAPI. Those are not transports — they
+ * are client implementations, i.e. ordinary RPC targets. The platform ships
+ * `McpClient` / `OpenApiClient` entrypoints (reach them via
+ * `worker: { type: "loopback" }`, parameterized by `props`), and nothing
+ * stops you from shipping your own version as an export of your project
+ * worker (`worker: { type: "project-worker" }`). If a first-party client
+ * needs to be special, the design has failed.
+ *
+ * (Possible later kind, deliberately absent until needed: a re-export of a
+ * cap registered on another context.)
+ */
+export type CapTarget =
+  | { type: "live"; stub: LiveStub }
+  | {
+      type: "rpc";
+      worker: WorkerRef;
+      /** Named export to use; defaults to the worker's default export (or,
+       * for `binding` workers, the binding object itself). */
+      entrypoint?: string;
+      /** Instantiation props for the entrypoint (the ProjectEgress
+       * pattern): serializable parameterization like a server URL or a
+       * gateway choice. The registry adds `{ context, cap }` attribution at
+       * dial time. */
+      props?: Record<string, unknown>;
+    }
+  | {
+      type: "url";
+      url: string;
+      /** Sent on connect; values pass through project egress secret
+       * substitution (`'Bearer getSecret({ key: "X" })'`). */
+      headers?: Record<string, string>;
+    };
+
+/**
+ * Where an `rpc` target's worker lives. One shape for every way code is
+ * reachable over Workers RPC — first-party and user-space are deliberately
+ * symmetric (same shape, different `type`).
+ */
+export type WorkerRef =
+  /** Anything on the platform worker's `env`: a service binding, env.AI,
+   * env.BROWSER, a queue. With no `entrypoint`, the binding object itself
+   * is the target (`itx.ai.run(...)` replays straight onto `env.AI`). */
+  | { type: "binding"; binding: string }
+  /** The platform worker's own exports (ctx.exports) — first-party code:
+   * `McpClient`, `OpenApiClient`, thin policy wrappers around bindings. */
+  | { type: "loopback" }
+  /** The project worker — user space: export a class from your repo's
+   * worker entry and point a cap at it. Already runs behind the egress
+   * pipe; no new trust surface. NOT a primitive: this is strict sugar for
+   * reaching the first-party `ProjectWorker` loopback forwarder with this
+   * project's id, normalized at define time — the spelling exists so
+   * `entrypoint` always names the export YOU call and `describe()` stays
+   * informative. */
+  | { type: "project-worker" }
+  /** A Durable Object, addressed by namespace binding + instance name. */
+  | { type: "durable-object"; binding: string; name: string }
+  /** A dynamic worker materialized on demand from stored source — code that
+   * lives in the registry itself rather than in any deployed artifact. */
+  | { type: "source"; source: CapSource };
+
+/**
+ * Stored source for a `{ type: "source" }` worker. The platform materializes
+ * it into an isolate on demand. Inside it: bare `fetch()` IS project egress
+ * (secrets substituted server-side, never visible to this code), and
+ * `env.ITERATE` is an itx scoped to the cap's home context — a capability
+ * can never reach wider than where it is defined.
+ */
+export type CapSource = {
+  /**
+   * The loader caches the materialized isolate by this string, so it MUST
+   * change whenever `modules` change; a content hash is the ideal value.
+   * (Replaces the old `codeId` field — it was never an id, and "id" in this
+   * codebase means typeid.)
+   */
+  cacheKey: string;
+  mainModule: string;
+  modules: Record<string, string>;
+  /** Named export to load; defaults to the default export. */
+  entrypoint?: string;
+  /**
+   * What the entrypoint export IS — this is where statefulness lives:
+   *
+   * - `"worker-entrypoint"` (default): stateless; a fresh isolate per call.
+   * - `"durable-object"`: stateful; a NAMED export extending
+   *   `DurableObject`, instantiated as a facet OF the Durable Object
+   *   hosting this context (the Project DO, or the child context's DO). It
+   *   gets its own private SQLite, physically stored inside that host, and
+   *   the database survives code upgrades.
+   */
+  exportType?: "worker-entrypoint" | "durable-object";
+  compatibilityDate?: string;
+};
+
+/**
+ * How a capability is called once the supervisor holds its target.
+ *
+ * `"members"` (default) — replay the property path on the target and call
+ * the terminal method on its parent, receiver-preserving. Use when the
+ * target is a real object whose methods exist:
+ *
+ * ```ts
+ * // target: { todos: { add(item) {…} } }
+ * itx.myCap.todos.add({ text: "x" })  // → replays ["todos","add"] on the target
+ * ```
+ *
+ * `"path-call"` — the target implements ONE method, `call({ path, args })`,
+ * and owns its own method-tree semantics. Use for SDK-shaped surfaces whose
+ * tree you don't predeclare; the public SDK docs become the tool docs:
+ *
+ * ```ts
+ * // provider: class { call({ path, args }) { return slackApi(path.join("."), args[0]); } }
+ * itx.slack.chat.postMessage({ … })   // → ONE call: call({ path: ["chat","postMessage"], … })
+ * ```
+ */
+export type CapInvoke = "members" | "path-call";
+
+/** The wire shape of one dynamic-surface invocation. */
+export type PathCall = { path: string[]; args: unknown[] };
+
+/** What a `"path-call"` capability provider implements. */
+export type PathCallTarget = { call(input: PathCall): unknown };
+
+/**
+ * A live provider's stub: a function, an object of functions, or an
+ * RpcTarget. Structural and opaque — it may arrive over Cap'n Web (a
+ * browser tab, a Node process, an agent's sandbox) or Workers RPC; the
+ * registry relies only on protocol-level controls (`dup`, `onRpcBroken`,
+ * `Symbol.dispose`) when present.
+ */
+export type LiveStub = object;
+
+/**
+ * Arbitrary metadata on a registration. The registry stores it verbatim and
+ * surfaces it in `describe()` — there is no schema. One convention worth
+ * following: `instructions`, a human/agent-readable sentence on what the
+ * cap does and how to call it, shown by `describe()`.
+ */
+export type CapMeta = {
+  /** Shown in describe(); write it for the agent who finds this cap. */
+  instructions?: string;
+  [key: string]: unknown;
+};
+
+/** A registry entry as reported by `describe()`. Never contains live stubs. */
+export type CapDescription = {
+  name: string;
+  /** The target's kind: "live" | "rpc" | "url". */
+  kind: CapTarget["type"];
+  invoke: CapInvoke;
+  /** Which context owns the entry — provenance for shadowing visibility. */
+  owner: string;
+  /** Live caps only: is the provider currently connected? */
+  connected?: boolean;
+  /** Lifted from meta for convenience: the one thing to read first. */
+  instructions?: string;
+  meta: CapMeta;
+  updatedAtMs: number;
+};
+
+// ---------------------------------------------------------------------------
+// Streams
+// ---------------------------------------------------------------------------
+
+/**
+ * How a stream is addressed. Streams are keyed by `(namespace, path)`; a
+ * project's id happens to be usable as a namespace, and `"global"` is the
+ * deployment-wide namespace. All of these reach the same stream:
+ *
+ * ```ts
+ * itx.streams.get("proj_123:/chat")                         // absolute, string
+ * itx.streams.get({ namespace: "proj_123", path: "/chat" }) // absolute, structured
+ * itx.projects.get("proj_123").streams.get("/chat")         // narrow, then relative
+ * itx.projects.get("proj_123").streams.get({ path: "/chat" })
+ * ```
+ *
+ * Absolute forms are sugar: they internally construct the narrowed handle
+ * and call through — one code path, and resolution is always checked
+ * against the handle's authority (a project handle cannot fully-qualify its
+ * way out).
+ */
+export type StreamRef = string | { namespace?: string; path: string };
+
+/** An event as read back from a stream. */
+export type StreamEvent = {
+  type: string;
+  payload?: unknown;
+  /** 1-based durable offset — the resume cursor. */
+  offset: number;
+};
+
+/** An event as appended. */
+export type StreamEventInput = {
+  type: string;
+  payload?: unknown;
+  /** Appends with the same key are dropped instead of duplicated. */
+  idempotencyKey?: string;
+};
+
+/** A handle pinned to one stream. */
+export interface ItxStream {
+  describe(): { namespace: string; path: string };
+  append(event: StreamEventInput): Promise<StreamEvent>;
+  appendBatch(events: StreamEventInput[]): Promise<StreamEvent[]>;
+  read(input?: {
+    afterOffset?: number | "start" | "end";
+    beforeOffset?: number | "start" | "end";
+  }): Promise<StreamEvent[]>;
+  getState(): Promise<unknown>;
+  listChildren(): Promise<unknown>;
+}
+
+/** The streams collection, namespace-bound by the handle. */
+export interface ItxStreams {
+  /** Resolve a stream ref — relative or absolute, see {@link StreamRef}. */
+  get(ref: StreamRef): ItxStream;
+  list(): Promise<unknown>;
+  create(input: { streamPath: string }): Promise<unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Projects
+// ---------------------------------------------------------------------------
+
+/** Narrowing lives here: `get()` checks the principal's grants and returns
+ * a NEW project-scoped handle. */
+export interface ItxProjects {
+  get(projectIdOrSlug: string): Promise<Itx>;
+  list(input?: {
+    limit?: number;
+    offset?: number;
+  }): Promise<{ projects: { id: string; slug: string }[]; total: number }>;
+  /** Admin principals only. */
+  create(input: { id?: string; slug: string }): Promise<{ id: string; slug: string }>;
+  /** Admin principals only. */
+  remove(input: { id: string }): Promise<{ deleted: boolean; id: string; ok: true }>;
+}
+
+// ---------------------------------------------------------------------------
+// Scripts
+// ---------------------------------------------------------------------------
+
+/**
+ * An itx script: a plain function of `({ itx, vars })`, runnable identically
+ * from every execution mode — the browser REPL, a Node process,
+ * `POST /api/itx/run`, the project worker, and capabilities themselves.
+ */
+export type ItxFn<V = Record<string, unknown>, R = unknown> = (input: {
+  itx: Itx;
+  vars: V;
+}) => Promise<R> | R;
+
+/**
+ * Map an SDK's type surface onto its itx stub: every function becomes
+ * async, everything else recurses. With this, {@link KnownCaps} merging
+ * gives `itx.slack` the real @slack/web-api types while the runtime stays a
+ * ten-line path-call forwarder.
+ */
+export type Stubify<T> = T extends (...args: infer A) => infer R
+  ? (...args: A) => Promise<Awaited<R>>
+  : T extends object
+    ? { [K in keyof T]: Stubify<T[K]> }
+    : never;
+
+// ---------------------------------------------------------------------------
+// Wire types: refs, principals, props
+// ---------------------------------------------------------------------------
+
+/**
+ * A context's sturdy ref: `"global"`, a project id, or a child context id.
+ * (Type-safe-ish via prefixes; `proj_` is the legacy project prefix, `prj_`
+ * the canonical one minted by the auth worker.)
+ */
+export type ContextRef = "global" | `prj_${string}` | `proj_${string}` | `ctx_${string}`;
+
+/**
+ * Who a handle was minted for — typed out BY HAND from the auth system
+ * (`~/auth/principal.ts` + `@iterate-com/shared/auth-claims`), minus the
+ * `can()` helper, so that drift becomes a type error at the conformance
+ * seam rather than an invented parallel access model. Only fields itx
+ * actually uses appear here.
+ *
+ * - `admin`: the admin API secret, or a token carrying the server-granted
+ *   `superadmin` scope (granted via the `admin` role only; client-requested
+ *   scope is always stripped). Sees everything.
+ * - `user`: organization memberships and project grants exactly as the auth
+ *   worker issued them. May do project-scoped things iff the project is in
+ *   `projects`. Nothing finer-grained exists (the seam does; the
+ *   implementation deliberately does not).
+ */
+export type ItxPrincipal =
+  | { type: "admin" }
+  | {
+      type: "user";
+      userId: string;
+      sessionId?: string;
+      organizations: {
+        id: string;
+        slug: string;
+        role: "member" | "admin" | "owner";
+        name?: string;
+      }[];
+      projects: { id: string; slug: string; organizationId: string }[];
+    };
+
+/**
+ * The ONE serializable parameterization in the system — what crosses a
+ * boundary when the platform wires a handle into an isolate. Props carry
+ * identity, never composition or authority-by-content:
+ *
+ * - `context`: which context. The restorer turns it into a live handle.
+ * - `principal`: honored on global handles only; a project-context handle
+ *   is always bound to exactly its own project regardless of what props
+ *   claim.
+ * - `cap`: pure attribution — which capability's isolate holds this handle.
+ *   It grants nothing; it labels egress and audit records.
+ */
+export type ItxProps = {
+  context: ContextRef;
+  principal?: ItxPrincipal;
+  cap?: string;
+};


### PR DESCRIPTION
## What

Two design artifacts from the post-#1407 itx review sessions — docs/types only, **no runtime changes**.

### `apps/os/docs/itx-next.md` — the working roadmap

The running list of what we want to fix or build in the itx layer, with positions, a decisions log, and open questions. Highlights:

- **CapTarget**: a capability is a name + a target; the target is one discriminated union of three kinds — `live` (inbound: a connected provider's stub, the one non-serializable kind), `rpc` (outbound: an RPC target in some worker, with `WorkerRef` naming where that worker lives — binding / loopback / project-worker / durable-object / stored source), and `url` (a Cap'n Web server across the internet, headers pass through egress secret substitution). Inbound/outbound is derived, never spelled.
- **MCP/OpenAPI are not transports** — they're client implementations, i.e. ordinary RPC targets. Litmus test: the first-party `McpClient` (loopback) and a user-space `OpenApiClient` (exported from your own project worker) must be the same shape.
- **One `caps.define` verb**; `kind: "facet"` dies (statefulness is `source.exportType`).
- **Platform bindings as caps**: thin policy wrappers (gateway selection, attribution) via loopback entrypoints — the ProjectEgress pattern applied to bindings.
- **A real global context** + the ref-addressing model (refs are unauthenticated sturdy refs; resolution checks the principal; absolute forms are sugar over narrowing).
- **Codemode drop plan**: a session = a forked child context; tool providers = caps; execution = two events (`itx/execution-requested|completed`), record-only first.
- Streams convergence direction, sturdy-refs receipts (Cap'n Proto `persistent.capnp`), resolved-decisions log, open questions.

### `apps/os/src/itx/types.ts` — the design of record

Handwritten, import-free. Narrative header (the three concepts + a thirty-second worked example), then `Itx`/`ItxBuiltins`, the `KnownCaps` declaration-merge point, `CapTarget`/`WorkerRef`, `CapSource` (with `cacheKey`, formerly `codeId`), `ItxPrincipal` hand-mirrored from `~/auth/principal.ts` (no invented access model), `StreamRef` addressing forms, and `CapMeta` as arbitrary metadata with the `instructions` convention. The implementation conforms to this file in follow-up PRs; it also doubles as the REPL completion source.

## Why

We want the design pinned down and reviewable before the kernel (`protocol.ts`/`registry.ts`) migrates to it. Next slices build on this: CapTarget in the registry (`itx.ai` via a binding ref as the proof), then the MCP/OpenAPI litmus pair, then the codemode drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and type sketches only; no production code paths, auth, or data handling change in this PR.
> 
> **Overview**
> Adds **documentation-only** design artifacts for the itx layer—no runtime or kernel changes.
> 
> **`apps/os/docs/itx-next.md`** is a working roadmap: **CapTarget** as `live | rpc | url` with **WorkerRef** (replacing today’s `live | worker | facet`); a single **`caps.define`** verb; MCP/OpenAPI as ordinary RPC clients, not protocol kinds; platform bindings as thin policy caps; a real **global** context and namespace-based stream addressing; a **codemode → fork + caps + execution events** migration plan; and a resolved/open-questions log.
> 
> **`apps/os/src/itx/types.ts`** is the import-free **design of record**: narrative plus types for `Itx`, `CapTarget`/`WorkerRef`/`CapSource` (`cacheKey` vs `codeId`), `ItxPrincipal` mirrored from auth, `StreamRef`, `KnownCaps`, and related wire types—intended for future implementation conformance, REPL completion, and agent-facing docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee52a30ecdead15fca064e1fac18765ced96a790. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T12:06:49.270Z",
      "headSha": "ee52a30ecdead15fca064e1fac18765ced96a790",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27273577632",
      "shortSha": "ee52a30"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `ee52a30`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27273577632)
Updated: 2026-06-10T12:06:49.270Z
<!-- /CLOUDFLARE_PREVIEW -->