### PR TITLE
itx kernel: CapTarget — capabilities are a name plus a typed target

### DIFF
--- a/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
@@ -61,7 +61,13 @@ import {
 import { ContextRegistry, durableObjectFacetsHook, type LiveCapTarget } from "~/itx/registry.ts";
 import { replayPathCall } from "~/itx/path-proxy.ts";
 import { ITX_AUDIT_STREAM_PATH } from "~/itx/protocol.ts";
-import type { CapInvoke, CapMeta, CapSource, PathCall } from "~/itx/protocol.ts";
+import type {
+  CapInvoke,
+  CapMeta,
+  CapSource,
+  PathCall,
+  SerializableCapTarget,
+} from "~/itx/protocol.ts";
 
 type CaptunServerTunnel = Fetcher & Disposable;
 export type ProjectStructuredName = {
@@ -405,7 +411,8 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
 
   async itxDefine(input: {
     name: string;
-    source: CapSource;
+    target?: SerializableCapTarget;
+    source?: CapSource;
     kind?: "worker" | "facet";
     invoke?: CapInvoke;
     meta?: CapMeta;
@@ -449,6 +456,8 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
           }),
         );
       },
+      // Gated on DIALABLE_BINDINGS inside the registry before this is called.
+      binding: (name) => (this.env as unknown as Record<string, unknown>)[name],
       contextId: projectId,
       facets: durableObjectFacetsHook(this.ctx),
       loader: projectRuntimeEnv(this.env).LOADER as unknown as ConstructorParameters<

--- a/apps/os/src/itx/context-do.ts
+++ b/apps/os/src/itx/context-do.ts
@@ -14,7 +14,14 @@ import { DurableObject } from "cloudflare:workers";
 import { StreamPath } from "@iterate-com/shared/streams/types";
 import { ContextRegistry, durableObjectFacetsHook, type LiveCapTarget } from "./registry.ts";
 import { ITX_AUDIT_STREAM_PATH, ITX_EVENT_TYPES } from "./protocol.ts";
-import type { CapDescription, CapInvoke, CapMeta, CapSource, PathCall } from "./protocol.ts";
+import type {
+  CapDescription,
+  CapInvoke,
+  CapMeta,
+  CapSource,
+  PathCall,
+  SerializableCapTarget,
+} from "./protocol.ts";
 import {
   getInitializedStreamStub,
   type StreamDurableObjectNamespace,
@@ -86,7 +93,8 @@ export class ContextDO extends DurableObject<Env> {
 
   itxDefine(input: {
     name: string;
-    source: CapSource;
+    target?: SerializableCapTarget;
+    source?: CapSource;
     kind?: "worker" | "facet";
     invoke?: CapInvoke;
     meta?: CapMeta;
@@ -130,6 +138,8 @@ export class ContextDO extends DurableObject<Env> {
     const descriptor = this.descriptor();
     this.#registry = new ContextRegistry({
       audit: (event) => this.audit(event.type, event.payload),
+      // Gated on DIALABLE_BINDINGS inside the registry before this is called.
+      binding: (name) => (this.env as unknown as Record<string, unknown>)[name],
       contextId: descriptor.id,
       facets: durableObjectFacetsHook(this.ctx),
       loader: this.env.LOADER as unknown as ConstructorParameters<

--- a/apps/os/src/itx/e2e/itx.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx.e2e.test.ts
@@ -105,7 +105,64 @@ test("the five-step capability flow: provide live, call, promote durable, call f
   const description = await projectItx.caps.describe();
   expect(description).toMatchObject([
     { connected: true, invoke: "path-call", kind: "live", name: "slack" },
-    { invoke: "path-call", kind: "worker", name: "slackDurable" },
+    // Legacy `source:` input normalizes to an rpc/source target.
+    { invoke: "path-call", kind: "rpc", name: "slackDurable" },
+  ]);
+});
+
+test("platform bindings are dialable capabilities (raw + wrapped)", async () => {
+  using itx = connectGlobal();
+  const project = (await itx.projects.create({ slug: `${PROJECT_SLUG}-ai` })) as { id: string };
+  using projectItx = await itx.projects.get(project.id);
+
+  // (1) Raw binding ref: env.AI itself is the target; members replay applies
+  // the dotted path straight onto it. models() is a free catalog read.
+  await projectItx.caps.define({
+    meta: { instructions: "Workers AI. Use like the env.AI binding." },
+    name: "ai",
+    target: { type: "rpc", worker: { binding: "AI", type: "binding" } },
+  });
+  const models = (await (projectItx as never as Record<string, any>).ai.models()) as unknown[];
+  expect(Array.isArray(models)).toBe(true);
+  expect(models.length).toBeGreaterThan(0);
+
+  // (2) Wrapped via the BindingCapability loopback (path-call): same binding,
+  // reached through the thin policy entrypoint — the §2 pattern.
+  await projectItx.caps.define({
+    invoke: "path-call",
+    name: "aiWrapped",
+    target: {
+      entrypoint: "BindingCapability",
+      props: { binding: "AI" },
+      type: "rpc",
+      worker: { type: "loopback" },
+    },
+  });
+  const wrapped = (await (
+    projectItx as never as Record<string, any>
+  ).aiWrapped.models()) as unknown[];
+  expect(Array.isArray(wrapped)).toBe(true);
+
+  // (3) Allowlist: a non-dialable binding refuses at define time, and a
+  // loopback export outside DIALABLE_LOOPBACKS refuses too.
+  await expect(
+    projectItx.caps.define({
+      name: "db",
+      target: { type: "rpc", worker: { binding: "DB", type: "binding" } },
+    }),
+  ).rejects.toThrow(/not dialable/);
+  await expect(
+    projectItx.caps.define({
+      name: "sneaky",
+      target: { entrypoint: "ItxEntrypoint", type: "rpc", worker: { type: "loopback" } },
+    }),
+  ).rejects.toThrow(/not dialable/);
+
+  // describe() reports the new kinds and lifts instructions.
+  const caps = await projectItx.caps.describe();
+  expect(caps).toMatchObject([
+    { instructions: "Workers AI. Use like the env.AI binding.", kind: "rpc", name: "ai" },
+    { invoke: "path-call", kind: "rpc", name: "aiWrapped" },
   ]);
 });
 

--- a/apps/os/src/itx/entrypoint.ts
+++ b/apps/os/src/itx/entrypoint.ts
@@ -10,7 +10,14 @@
 
 import { WorkerEntrypoint } from "cloudflare:workers";
 import { Itx, type ItxRuntime } from "./handle.ts";
-import { GLOBAL_CONTEXT_ID, isChildContextId, type ItxProps } from "./protocol.ts";
+import {
+  DIALABLE_BINDINGS,
+  GLOBAL_CONTEXT_ID,
+  isChildContextId,
+  type ItxProps,
+  type PathCall,
+} from "./protocol.ts";
+import { replayPathCall } from "./path-proxy.ts";
 import type { ContextDO } from "./context-do.ts";
 import { parseConfig } from "~/config.ts";
 import { getProjectDurableObjectName } from "~/domains/projects/durable-objects/project-durable-object.ts";
@@ -90,5 +97,39 @@ export class ProjectEgress extends WorkerEntrypoint<Env, ProjectEgressProps> {
     return await this.env.PROJECT.getByName(getProjectDurableObjectName(props.project)).egressFetch(
       request,
     );
+  }
+}
+
+export type BindingCapabilityProps = {
+  /** Which env binding this instance wraps. Definer-supplied. */
+  binding: string;
+  /** Attribution, injected by the registry at dial time. */
+  cap?: string;
+  context?: string;
+};
+
+/**
+ * The thin policy wrapper for platform bindings (itx-next.md §2): a
+ * loopback-dialable, path-call capability that applies the dotted path to
+ * `env[props.binding]`, receiver-preserving. Today the only policy is the
+ * DIALABLE_BINDINGS allowlist — props.binding is definer-controlled, so the
+ * check HERE is the authoritative gate for which binding gets wrapped.
+ * Gateway selection / attribution headers / quotas slot in here later.
+ *
+ * Registered via:
+ *   target: { type: "rpc", worker: { type: "loopback" },
+ *             entrypoint: "BindingCapability", props: { binding: "AI" } }
+ */
+export class BindingCapability extends WorkerEntrypoint<Env, BindingCapabilityProps> {
+  async call(input: PathCall): Promise<unknown> {
+    const props = (Reflect.get(this, "ctx") as ExecutionContext<BindingCapabilityProps>).props;
+    if (!DIALABLE_BINDINGS.has(props.binding)) {
+      throw new Error(`Binding "${props.binding}" is not dialable as a capability.`);
+    }
+    const binding = (this.env as unknown as Record<string, unknown>)[props.binding];
+    if (binding == null) {
+      throw new Error(`Binding "${props.binding}" is not available in this environment.`);
+    }
+    return await replayPathCall(binding, input);
   }
 }

--- a/apps/os/src/itx/handle.ts
+++ b/apps/os/src/itx/handle.ts
@@ -28,6 +28,7 @@ import {
   type CapMeta,
   type CapSource,
   type ProjectAccess,
+  type SerializableCapTarget,
 } from "./protocol.ts";
 import type { ContextDO } from "./context-do.ts";
 import { createShareToken, SHARE_TOKEN_PARAM } from "./http.ts";
@@ -343,7 +344,12 @@ export class ItxCaps extends RpcTarget {
 
   async define(input: {
     name: string;
-    source: CapSource;
+    /** The capability's target (types.ts). Serializable kinds only — for a
+     * live stub use provide(). */
+    target?: SerializableCapTarget;
+    /** Legacy: sugar for target { type: "rpc", worker: { type: "source" } }. */
+    source?: CapSource;
+    /** Legacy: "facet" maps to source.exportType "durable-object". */
     kind?: "worker" | "facet";
     invoke?: CapInvoke;
     meta?: CapMeta;

--- a/apps/os/src/itx/protocol.ts
+++ b/apps/os/src/itx/protocol.ts
@@ -45,26 +45,179 @@ export type PathCall = { path: string[]; args: unknown[] };
 /** The full shape a "path-call" capability provider implements. */
 export type PathCallTarget = { call(input: PathCall): unknown };
 
-export type CapKind = "live" | "worker" | "facet";
+/**
+ * A capability's kind is its target's type (design of record: types.ts).
+ * Stored rows may still carry the legacy kinds "worker"/"facet"; they
+ * normalize to "rpc" on read.
+ */
+export type CapKind = "live" | "rpc" | "url";
 
 /**
- * Source for durable (worker/facet) caps. `codeId` MUST change whenever the
- * module contents change — the Worker Loader caches by id (same discipline
- * as the AppRunner example in Cloudflare's Facets announcement).
+ * Source for a `{ type: "source" }` worker ref. `cacheKey` MUST change
+ * whenever the module contents change — the Worker Loader caches the
+ * materialized isolate by it (a content hash is the ideal value). `codeId`
+ * is the legacy spelling, still accepted.
  */
 export type CapSource = {
-  codeId: string;
+  cacheKey?: string;
+  /** @deprecated legacy spelling of `cacheKey`. */
+  codeId?: string;
   mainModule: string;
   modules: Record<string, string>;
   /** Named export to use; defaults to the default export. */
   entrypoint?: string;
+  /**
+   * What the entrypoint export IS: "worker-entrypoint" (default; stateless,
+   * fresh isolate per call) or "durable-object" (stateful; a NAMED export
+   * extending DurableObject, instantiated as a facet of the hosting context
+   * node with its own private SQLite).
+   */
+  exportType?: "worker-entrypoint" | "durable-object";
   compatibilityDate?: string;
 };
 
+export function capSourceCacheKey(source: CapSource): string {
+  const key = source.cacheKey ?? source.codeId;
+  if (!key) {
+    throw new Error(
+      "CapSource needs a cacheKey (rotate it whenever modules change; a content hash is ideal).",
+    );
+  }
+  return key;
+}
+
+/** Where an rpc target's worker lives (design of record: types.ts). */
+export type WorkerRef =
+  | { type: "binding"; binding: string }
+  | { type: "loopback" }
+  | { type: "project-worker" }
+  | { type: "durable-object"; binding: string; name: string }
+  | { type: "source"; source: CapSource };
+
+/**
+ * The serializable capability targets — this realm's sturdy refs. The
+ * non-serializable `live` kind never appears here: live stubs exist only in
+ * the registry's in-memory connection table.
+ */
+export type SerializableCapTarget =
+  | {
+      type: "rpc";
+      worker: WorkerRef;
+      /** Named export to instantiate (loopback refs require it). For
+       * `source` refs the export is named by `source.entrypoint` instead. */
+      entrypoint?: string;
+      /** Instantiation props (the ProjectEgress pattern). The registry adds
+       * `{ cap, context }` attribution at dial time. */
+      props?: Record<string, unknown>;
+    }
+  | { type: "url"; url: string; headers?: Record<string, string> };
+
+/**
+ * Which env bindings / loopback exports an rpc target may dial. Deliberately
+ * hardcoded constants for now (config-driven later — itx-next.md §2):
+ * binding and loopback refs reach PLATFORM resources, so an open list would
+ * let any project handle reach e.g. the deployment D1, or mint itx handles
+ * on arbitrary projects via ItxEntrypoint props. Checked at define time
+ * (fail fast) and again at dial time (authoritative).
+ */
+export const DIALABLE_BINDINGS: ReadonlySet<string> = new Set(["AI"]);
+export const DIALABLE_LOOPBACKS: ReadonlySet<string> = new Set(["BindingCapability"]);
+
+/**
+ * Normalize a define() input to a serializable target. Legacy callers pass
+ * `source` (+ optional `kind: "worker" | "facet"`); they normalize to an
+ * rpc/source target, with "facet" becoming `exportType: "durable-object"`.
+ */
+export function normalizeCapTarget(input: {
+  target?: SerializableCapTarget;
+  source?: CapSource;
+  kind?: "worker" | "facet";
+}): SerializableCapTarget {
+  if (input.target) {
+    if (input.source || input.kind) {
+      throw new Error("caps.define takes either target or legacy source/kind, not both.");
+    }
+    return input.target;
+  }
+  if (!input.source) throw new Error("caps.define needs a target.");
+  const source: CapSource = {
+    ...input.source,
+    exportType:
+      input.source.exportType ?? (input.kind === "facet" ? "durable-object" : "worker-entrypoint"),
+  };
+  return { type: "rpc", worker: { source, type: "source" } };
+}
+
+/**
+ * Define-time validation of a serializable target. The same checks run
+ * again at dial time inside the registry; this exists so misconfigured
+ * targets fail at define() with a useful error instead of at first call.
+ */
+export function assertDefinableCapTarget(name: string, target: SerializableCapTarget): void {
+  if (target.type === "url") {
+    throw new Error(
+      `Capability "${name}": url targets are not implemented yet (Law 7: Cap'n Web must terminate ` +
+        `in a stateless worker, never a DO — the dial path for url refs is a follow-up).`,
+    );
+  }
+  const worker = target.worker;
+  switch (worker.type) {
+    case "binding":
+      if (!DIALABLE_BINDINGS.has(worker.binding)) {
+        throw new Error(
+          `Capability "${name}": binding "${worker.binding}" is not dialable. ` +
+            `Dialable bindings: ${[...DIALABLE_BINDINGS].join(", ") || "(none)"}.`,
+        );
+      }
+      if (target.entrypoint) {
+        throw new Error(
+          `Capability "${name}": binding refs take no entrypoint — the binding object itself is the target.`,
+        );
+      }
+      return;
+    case "loopback":
+      if (!target.entrypoint) {
+        throw new Error(
+          `Capability "${name}": loopback refs need an entrypoint (the export name).`,
+        );
+      }
+      if (!DIALABLE_LOOPBACKS.has(target.entrypoint)) {
+        throw new Error(
+          `Capability "${name}": loopback export "${target.entrypoint}" is not dialable. ` +
+            `Dialable exports: ${[...DIALABLE_LOOPBACKS].join(", ") || "(none)"}.`,
+        );
+      }
+      return;
+    case "source":
+      if (worker.source.exportType === "durable-object" && !worker.source.entrypoint) {
+        // Default-export DO classes make workerd's facet instantiation fail
+        // with an opaque internal error; a NAMED export works (DECISIONS D12).
+        throw new Error(
+          `Capability "${name}" needs source.entrypoint naming an exported ` +
+            `"class X extends DurableObject" (default exports do not work as facet classes).`,
+        );
+      }
+      capSourceCacheKey(worker.source);
+      return;
+    case "durable-object":
+    case "project-worker":
+      throw new Error(
+        `Capability "${name}": ${worker.type} refs are not implemented yet (itx-next.md §1).`,
+      );
+  }
+}
+
+/**
+ * Arbitrary metadata, stored verbatim and surfaced by describe(). There is
+ * no schema — the named fields below are conventions:
+ * - `instructions`: a sentence for the human/agent who finds this cap.
+ * - `http`: HTTP routing flags (spec §8).
+ */
 export type CapMeta = {
+  instructions?: string;
   definedBy?: { type: "user" | "agent" | "system"; id: string };
-  /** HTTP routing flags (spec §8); consumed when cap routing lands. */
   http?: { expose: boolean; public?: boolean };
+  [key: string]: unknown;
 };
 
 /** A registry entry as reported by describe(); never contains live stubs. */
@@ -76,6 +229,8 @@ export type CapDescription = {
   owner: string;
   /** Live caps only: is the provider currently connected? */
   connected?: boolean;
+  /** Lifted from meta for convenience: the one thing to read first. */
+  instructions?: string;
   meta: CapMeta;
   updatedAtMs: number;
 };

--- a/apps/os/src/itx/registry.ts
+++ b/apps/os/src/itx/registry.ts
@@ -16,8 +16,13 @@
 // caller already held a handle on this context.
 
 import {
+  assertDefinableCapTarget,
   assertValidCapName,
+  capSourceCacheKey,
+  DIALABLE_BINDINGS,
+  DIALABLE_LOOPBACKS,
   ITX_EVENT_TYPES,
+  normalizeCapTarget,
   type CapDescription,
   type CapInvoke,
   type CapKind,
@@ -25,6 +30,7 @@ import {
   type CapSource,
   type PathCall,
   type PathCallTarget,
+  type SerializableCapTarget,
 } from "./protocol.ts";
 import { replayPathCall } from "./path-proxy.ts";
 
@@ -65,8 +71,13 @@ export type ContextRegistryHost = {
   /** The owning project (egress + worker-cap itx scoping). */
   projectId: string;
   sql: SqlStorage;
-  /** Worker Loader for worker-kind caps; absent in environments without it. */
+  /** Worker Loader for source-ref caps; absent in environments without it. */
   loader?: WorkerLoaderLike;
+  /**
+   * Resolve an env binding by name for `{ type: "binding" }` worker refs.
+   * The registry gates lookups on DIALABLE_BINDINGS before calling this.
+   */
+  binding?: (name: string) => unknown;
   /**
    * Create a loopback service-binding stub for a named export of the parent
    * worker, parameterized by props. Used to hand worker caps their
@@ -91,11 +102,17 @@ export type ContextRegistryHost = {
   ) => unknown;
 };
 
+/**
+ * `kind` is stored raw: new rows carry a CapKind ("live" | "rpc" | "url"),
+ * rows written before CapTarget landed carry the legacy "worker"/"facet".
+ * `targetOf()` is the single place legacy rows normalize.
+ */
 type CapRow = {
   name: string;
-  kind: CapKind;
+  kind: CapKind | "worker" | "facet";
   invoke: CapInvoke;
   source_json: string | null;
+  target_json: string | null;
   meta_json: string;
   updated_at_ms: number;
 };
@@ -164,6 +181,12 @@ export class ContextRegistry {
       meta_json TEXT NOT NULL,
       updated_at_ms INTEGER NOT NULL
     )`);
+    // CapTarget storage; rows from before this column exist with NULL and
+    // normalize from kind + source_json on read (targetOf).
+    const columns = host.sql.exec(`PRAGMA table_info(itx_caps)`).toArray() as { name: string }[];
+    if (!columns.some((column) => column.name === "target_json")) {
+      host.sql.exec(`ALTER TABLE itx_caps ADD COLUMN target_json TEXT`);
+    }
   }
 
   /**
@@ -205,7 +228,7 @@ export class ContextRegistry {
       kind: "live",
       meta: input.meta ?? {},
       name: input.name,
-      source: null,
+      target: null,
     });
     this.host.audit({
       type: ITX_EVENT_TYPES.capProvided,
@@ -215,41 +238,43 @@ export class ContextRegistry {
   }
 
   /**
-   * Register a durable capability from source. Loaded on demand via the
-   * Worker Loader; `source.codeId` must rotate with content (loader caches
-   * by id).
+   * Register a durable capability: a name plus a serializable target
+   * (types.ts is the design of record). Legacy callers pass `source`
+   * (+ optional kind "worker"/"facet"); both normalize to an rpc/source
+   * target. Targets are validated here so misconfiguration fails at
+   * define(), and again at dial time (the authoritative gate).
    */
   define(input: {
     name: string;
-    source: CapSource;
-    kind?: Exclude<CapKind, "live">;
+    target?: SerializableCapTarget;
+    source?: CapSource;
+    kind?: "worker" | "facet";
     invoke?: CapInvoke;
     meta?: CapMeta;
   }): { name: string; ok: true } {
     assertValidCapName(input.name);
-    const kind = input.kind ?? "worker";
-    if (kind === "facet" && !input.source.entrypoint) {
-      // Default-export DO classes make workerd's facet instantiation fail
-      // with an opaque internal error; a NAMED export works. Fail loudly at
-      // definition time instead (observed against workerd 2026-04, see
-      // DECISIONS.md D12).
-      throw new Error(
-        `Facet capability "${input.name}" needs source.entrypoint naming an exported ` +
-          `"class X extends DurableObject" (default exports do not work as facet classes).`,
-      );
-    }
+    const target = normalizeCapTarget(input);
+    assertDefinableCapTarget(input.name, target);
     const invoke = input.invoke ?? "members";
 
     this.upsertRow({
       invoke,
-      kind,
+      kind: target.type,
       meta: input.meta ?? {},
       name: input.name,
-      source: input.source,
+      target,
     });
     this.host.audit({
       type: ITX_EVENT_TYPES.capDefined,
-      payload: { codeId: input.source.codeId, invoke, kind, name: input.name },
+      payload: {
+        invoke,
+        kind: target.type,
+        name: input.name,
+        ...(target.type === "rpc" ? { worker: target.worker.type } : {}),
+        ...(target.type === "rpc" && target.worker.type === "source"
+          ? { cacheKey: capSourceCacheKey(target.worker.source) }
+          : {}),
+      },
     });
     return { name: input.name, ok: true };
   }
@@ -262,15 +287,19 @@ export class ContextRegistry {
   }
 
   describe(): CapDescription[] {
-    return this.rows().map((row) => ({
-      connected: row.kind === "live" ? this.#live.has(row.name) : undefined,
-      invoke: row.invoke,
-      kind: row.kind,
-      meta: JSON.parse(row.meta_json) as CapMeta,
-      name: row.name,
-      owner: this.host.contextId,
-      updatedAtMs: row.updated_at_ms,
-    }));
+    return this.rows().map((row) => {
+      const meta = JSON.parse(row.meta_json) as CapMeta;
+      return {
+        connected: row.kind === "live" ? this.#live.has(row.name) : undefined,
+        instructions: typeof meta.instructions === "string" ? meta.instructions : undefined,
+        invoke: row.invoke,
+        kind: normalizeKind(row.kind),
+        meta,
+        name: row.name,
+        owner: this.host.contextId,
+        updatedAtMs: row.updated_at_ms,
+      };
+    });
   }
 
   has(name: string): boolean {
@@ -314,98 +343,156 @@ export class ContextRegistry {
     }
   }
 
+  /**
+   * The two-case shape (types.ts): a capability is either held up by a live
+   * connection, or its serializable target is resolved at invoke time.
+   */
   private borrowTarget(row: CapRow): { target: unknown; dispose: () => void } {
-    switch (row.kind) {
-      case "live": {
-        const connection = this.#live.get(row.name);
-        if (!connection) throw new CapOfflineError(row.name);
-        // Borrow a duplicate, not the stored stub itself. Disposing the borrow
-        // releases only this call's reference; the registered target stays
-        // callable for the next caller (matches the original getConnection
-        // dup-on-borrow behaviour).
-        const target = connection.target.dup ? connection.target.dup() : connection.target;
-        return { target, dispose: () => disposeIfPossible(target) };
-      }
-      case "worker": {
-        const target = this.loadWorker(row).getEntrypoint(this.sourceFor(row).entrypoint);
-        return { target, dispose: () => disposeIfPossible(target) };
-      }
-      case "facet": {
-        const facets = this.host.facets;
-        if (!facets) {
-          throw new Error("Facet capabilities need a Durable-Object host with ctx.facets.");
+    if (row.kind === "live") {
+      const connection = this.#live.get(row.name);
+      if (!connection) throw new CapOfflineError(row.name);
+      // Borrow a duplicate, not the stored stub itself. Disposing the borrow
+      // releases only this call's reference; the registered target stays
+      // callable for the next caller (matches the original getConnection
+      // dup-on-borrow behaviour).
+      const target = connection.target.dup ? connection.target.dup() : connection.target;
+      return { target, dispose: () => disposeIfPossible(target) };
+    }
+    return this.resolveTarget(row.name, targetOf(row));
+  }
+
+  private resolveTarget(
+    name: string,
+    target: SerializableCapTarget,
+  ): { target: unknown; dispose: () => void } {
+    if (target.type === "url") {
+      throw new Error(
+        `Capability "${name}": url targets are not implemented yet (Law 7 — the dial must ` +
+          `terminate in a stateless worker, never this DO).`,
+      );
+    }
+    const worker = target.worker;
+    switch (worker.type) {
+      case "binding": {
+        // Authoritative allowlist gate (define-time check is fail-fast only).
+        if (!DIALABLE_BINDINGS.has(worker.binding)) {
+          throw new Error(`Capability "${name}": binding "${worker.binding}" is not dialable.`);
         }
-        // Facet name deliberately excludes codeId: the facet's private SQLite
-        // database survives code upgrades (new source, same data) — the same
-        // property Cloudflare's AppRunner example relies on.
-        const target = facets(`cap:${row.name}`, () => {
-          const source = this.sourceFor(row);
-          const facetClass = this.loadWorker(row).getDurableObjectClass?.(source.entrypoint);
-          if (!facetClass) {
-            throw new Error(
-              `Capability "${row.name}" did not yield a DurableObject class ` +
-                `(facet caps must export one, and the runtime must support getDurableObjectClass).`,
-            );
-          }
-          return { class: facetClass };
-        });
-        return { target, dispose: () => disposeIfPossible(target) };
+        const binding = this.host.binding?.(worker.binding);
+        if (binding == null) {
+          throw new Error(
+            `Capability "${name}": binding "${worker.binding}" is not available on this host.`,
+          );
+        }
+        // Env bindings are long-lived host objects, never per-call borrows —
+        // do NOT dispose them.
+        return { target: binding, dispose: () => {} };
       }
+      case "loopback": {
+        if (!target.entrypoint || !DIALABLE_LOOPBACKS.has(target.entrypoint)) {
+          throw new Error(
+            `Capability "${name}": loopback export "${target.entrypoint}" is not dialable.`,
+          );
+        }
+        const stub = this.host.loopback(target.entrypoint, {
+          props: {
+            ...target.props,
+            // Attribution wins over definer-supplied props, by spread order.
+            cap: name,
+            context: this.host.contextId,
+          },
+        });
+        return { target: stub, dispose: () => disposeIfPossible(stub) };
+      }
+      case "source": {
+        const source = worker.source;
+        if (source.exportType === "durable-object") {
+          const facets = this.host.facets;
+          if (!facets) {
+            throw new Error("Durable-object caps need a Durable-Object host with ctx.facets.");
+          }
+          // Facet name deliberately excludes the cache key: the facet's
+          // private SQLite survives code upgrades (new source, same data) —
+          // the same property Cloudflare's AppRunner example relies on.
+          const facetTarget = facets(`cap:${name}`, () => {
+            const facetClass = this.loadWorker(name, source).getDurableObjectClass?.(
+              source.entrypoint,
+            );
+            if (!facetClass) {
+              throw new Error(
+                `Capability "${name}" did not yield a DurableObject class ` +
+                  `(durable-object caps must export one, and the runtime must support getDurableObjectClass).`,
+              );
+            }
+            return { class: facetClass };
+          });
+          return { target: facetTarget, dispose: () => disposeIfPossible(facetTarget) };
+        }
+        const entrypoint = this.loadWorker(name, source).getEntrypoint(source.entrypoint);
+        return { target: entrypoint, dispose: () => disposeIfPossible(entrypoint) };
+      }
+      case "durable-object":
+      case "project-worker":
+        throw new Error(
+          `Capability "${name}": ${worker.type} refs are not implemented yet (itx-next.md §1).`,
+        );
     }
   }
 
-  private sourceFor(row: CapRow): CapSource {
-    const source = JSON.parse(row.source_json ?? "null") as CapSource | null;
-    if (!source) throw new Error(`Capability "${row.name}" has no stored source.`);
-    return source;
-  }
-
-  private loadWorker(row: CapRow): ReturnType<WorkerLoaderLike["get"]> {
+  private loadWorker(name: string, source: CapSource): ReturnType<WorkerLoaderLike["get"]> {
     const loader = this.host.loader;
-    if (!loader) throw new Error("Worker capabilities need a LOADER binding.");
-    const source = this.sourceFor(row);
+    if (!loader) throw new Error("Source capabilities need a LOADER binding.");
 
-    return loader.get(`itx-cap:${this.host.contextId}:${row.name}:${source.codeId}`, () => ({
-      compatibilityDate: source.compatibilityDate ?? DEFAULT_CAP_COMPATIBILITY_DATE,
-      compatibilityFlags: DEFAULT_CAP_COMPATIBILITY_FLAGS,
-      env: {
-        // The cap's own itx is scoped to its home context — a cap can never
-        // reach wider than where it is defined (Law 4). `cap` is attribution.
-        ITERATE: this.host.loopback("ItxEntrypoint", {
-          props: { cap: row.name, context: this.host.contextId },
+    return loader.get(
+      `itx-cap:${this.host.contextId}:${name}:${capSourceCacheKey(source)}`,
+      () => ({
+        compatibilityDate: source.compatibilityDate ?? DEFAULT_CAP_COMPATIBILITY_DATE,
+        compatibilityFlags: DEFAULT_CAP_COMPATIBILITY_FLAGS,
+        env: {
+          // The cap's own itx is scoped to its home context — a cap can never
+          // reach wider than where it is defined (Law 4). `cap` is attribution.
+          ITERATE: this.host.loopback("ItxEntrypoint", {
+            props: { cap: name, context: this.host.contextId },
+          }),
+        },
+        // Bare fetch() inside the cap IS project egress: secret substitution
+        // and (future) policy live in the Project DO, and the cap's isolate
+        // never sees secret material (Law 5).
+        globalOutbound: this.host.loopback("ProjectEgress", {
+          props: { cap: name, context: this.host.contextId, project: this.host.projectId },
         }),
-      },
-      // Bare fetch() inside the cap IS project egress: secret substitution
-      // and (future) policy live in the Project DO, and the cap's isolate
-      // never sees secret material (Law 5).
-      globalOutbound: this.host.loopback("ProjectEgress", {
-        props: { cap: row.name, context: this.host.contextId, project: this.host.projectId },
+        mainModule: source.mainModule,
+        modules: source.modules,
       }),
-      mainModule: source.mainModule,
-      modules: source.modules,
-    }));
+    );
   }
 
   private upsertRow(input: {
     name: string;
     kind: CapKind;
     invoke: CapInvoke;
-    source: CapSource | null;
+    target: SerializableCapTarget | null;
     meta: CapMeta;
   }) {
     this.host.sql.exec(
-      `INSERT INTO itx_caps (name, kind, invoke, source_json, meta_json, updated_at_ms)
-       VALUES (?, ?, ?, ?, ?, ?)
+      `INSERT INTO itx_caps (name, kind, invoke, source_json, target_json, meta_json, updated_at_ms)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(name) DO UPDATE SET
          kind = excluded.kind,
          invoke = excluded.invoke,
          source_json = excluded.source_json,
+         target_json = excluded.target_json,
          meta_json = excluded.meta_json,
          updated_at_ms = excluded.updated_at_ms`,
       input.name,
       input.kind,
       input.invoke,
-      input.source ? JSON.stringify(input.source) : null,
+      // source_json kept in sync for source targets so a rollback to the
+      // pre-CapTarget code can still read rows written by this version.
+      input.target?.type === "rpc" && input.target.worker.type === "source"
+        ? JSON.stringify(input.target.worker.source)
+        : null,
+      input.target ? JSON.stringify(input.target) : null,
       JSON.stringify(input.meta),
       Date.now(),
     );
@@ -414,7 +501,7 @@ export class ContextRegistry {
   private rows(): CapRow[] {
     return this.host.sql
       .exec<CapRow>(
-        `SELECT name, kind, invoke, source_json, meta_json, updated_at_ms FROM itx_caps ORDER BY name`,
+        `SELECT name, kind, invoke, source_json, target_json, meta_json, updated_at_ms FROM itx_caps ORDER BY name`,
       )
       .toArray();
   }
@@ -423,10 +510,38 @@ export class ContextRegistry {
     return (
       this.host.sql
         .exec<CapRow>(
-          `SELECT name, kind, invoke, source_json, meta_json, updated_at_ms FROM itx_caps WHERE name = ?`,
+          `SELECT name, kind, invoke, source_json, target_json, meta_json, updated_at_ms FROM itx_caps WHERE name = ?`,
           name,
         )
         .toArray()[0] ?? null
     );
   }
+}
+
+/** Legacy stored kinds ("worker"/"facet") report as "rpc" — their targets
+ * normalize to rpc/source refs in targetOf(). */
+function normalizeKind(kind: CapRow["kind"]): CapKind {
+  return kind === "worker" || kind === "facet" ? "rpc" : kind;
+}
+
+/**
+ * The single place a stored row becomes a serializable target. Rows written
+ * before target_json existed (kind "worker"/"facet" + source_json) normalize
+ * here; "facet" becomes exportType "durable-object".
+ */
+function targetOf(row: CapRow): SerializableCapTarget {
+  if (row.target_json) return JSON.parse(row.target_json) as SerializableCapTarget;
+  const source = JSON.parse(row.source_json ?? "null") as CapSource | null;
+  if (!source) throw new Error(`Capability "${row.name}" has no stored target.`);
+  return {
+    type: "rpc",
+    worker: {
+      source: {
+        ...source,
+        exportType:
+          source.exportType ?? (row.kind === "facet" ? "durable-object" : "worker-entrypoint"),
+      },
+      type: "source",
+    },
+  };
 }

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -50,7 +50,7 @@ export { AgentCapability } from "~/domains/agents/entrypoints/agent-capability.t
 export { AiCapability, OrpcCapability } from "~/domains/codemode/example-capabilities.ts";
 export { FetchCapability } from "~/domains/codemode/fetch-capability.ts";
 export { GmailCapability } from "~/domains/google/entrypoints/gmail-capability.ts";
-export { ItxEntrypoint, ProjectEgress } from "~/itx/entrypoint.ts";
+export { BindingCapability, ItxEntrypoint, ProjectEgress } from "~/itx/entrypoint.ts";
 export { ContextDO } from "~/itx/context-do.ts";
 export { ItxCapIngress } from "~/itx/http.ts";
 export { OpenApiBridge } from "~/rpc-targets/openapi-bridge.ts";


### PR DESCRIPTION
Supersedes #1433, which GitHub auto-closed when its base branch (`medieval-fibre`, merged as #1428) was deleted. Same commit, now based on main.

## What

First implementation slice of the CapTarget design from #1428 (design of record: `src/itx/types.ts`).

**A capability is now a name plus a typed target.** `caps.define` accepts:

```ts
// raw platform binding — members replay applies the path onto env.AI
await itx.caps.define({
  name: "ai",
  target: { type: "rpc", worker: { type: "binding", binding: "AI" } },
});
await itx.ai.models();

// the same binding through the thin policy wrapper (itx-next §2 pattern)
await itx.caps.define({
  invoke: "path-call",
  name: "aiWrapped",
  target: { type: "rpc", worker: { type: "loopback" }, entrypoint: "BindingCapability", props: { binding: "AI" } },
});
```

- `registry.borrowTarget()` is the two-case switch the design promised: live table, or resolve the stored target.
- Implemented worker refs: `binding`, `loopback`, `source` (the old worker/facet paths, unchanged underneath). `url` / `durable-object` / `project-worker` fail with informative not-implemented errors **at define time**.
- `BindingCapability`: new loopback entrypoint, the thin policy wrapper for bindings — gateway/quota policy slots in there later.
- `kind: "facet"` is gone from the API (legacy input still accepted): statefulness is `source.exportType: "worker-entrypoint" | "durable-object"`. `cacheKey` replaces `codeId` (deprecated alias kept).
- `CapMeta` is open metadata with the `instructions` convention, lifted into `describe()` output.

## Security

`binding` and `loopback` refs reach **platform** resources (an open list would let any project handle reach the deployment D1, or mint itx handles on arbitrary projects via ItxEntrypoint props). They are gated on hardcoded allowlists — `DIALABLE_BINDINGS = {AI}`, `DIALABLE_LOOPBACKS = {BindingCapability}` — checked at define time (fail fast) and again at dial time (authoritative). `BindingCapability` re-checks the binding allowlist itself since its props are definer-controlled. Config-driven lists are a follow-up.

## Compatibility

- `caps.define({ source, kind: "worker" | "facet" })` still works — normalizes to an rpc/source target.
- Stored rows from before this PR (kind worker/facet + source_json) normalize on read; new rows also write `source_json` for source targets so a rollback can still read them. New `target_json` column added via guarded ALTER.
- `describe()` now reports `kind: "rpc"` for stored-source caps (e2e assertion updated).

## Testing

- `pnpm typecheck` / `lint` / `format` / `test` (190 unit tests) all green.
- **Full `pnpm e2e:itx` suite ran green against a live deployment** (19 tests, 5 files, via the dev_jonas tunnel serving this branch): `itx.ai.models()` through the real AI binding raw + wrapped, allowlist refusals, and all pre-existing egress/facet/fork/HTTP tests — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces platform binding and loopback dialing gated only on small hardcoded allowlists; misconfiguration or future allowlist expansion could expose env bindings like D1 or arbitrary loopback exports to project handles.
> 
> **Overview**
> **Capabilities are now a name plus a typed `SerializableCapTarget`**, not legacy `source` + `kind: worker | facet`. `caps.define` accepts `target` (e.g. `rpc` with `binding`, `loopback`, or `source` worker refs); old `source`/`kind` input still normalizes to `rpc`/`source`.
> 
> **Registry dispatch** is refactored to the two-case model: live in-memory connections, or `resolveTarget()` at invoke time for stored targets. SQLite gains `target_json` (with legacy row normalization via `targetOf()`); `describe()` reports `kind: "rpc"` and lifts `meta.instructions`.
> 
> **Platform binding exposure** adds `BindingCapability` (loopback path-call wrapper), host `binding` resolvers on Project/Context DOs, and **allowlists** `DIALABLE_BINDINGS` / `DIALABLE_LOOPBACKS` enforced at define and dial time.
> 
> **Protocol updates**: `CapKind` becomes `live | rpc | url`; `cacheKey` replaces `codeId`; `exportType` replaces facet kind; `url` / `project-worker` / `durable-object` refs fail at define time until implemented.
> 
> **E2E** covers raw `AI` binding caps, wrapped `BindingCapability`, and allowlist rejections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13ab9e5ccc39a1348d29b74fd55086747b727bd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T12:13:49.919Z",
      "headSha": "13ab9e5ccc39a1348d29b74fd55086747b727bd6",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27275038072",
      "shortSha": "13ab9e5"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `13ab9e5`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27275038072)
Updated: 2026-06-10T12:13:49.919Z
<!-- /CLOUDFLARE_PREVIEW -->