### PR TITLE
ci: deploy-os path filter covers all compiled-in packages; run scripts/ tests and knip in CI

### DIFF
--- a/.github/ts-workflows/workflows/deploy-auth.ts
+++ b/.github/ts-workflows/workflows/deploy-auth.ts
@@ -1,4 +1,5 @@
 import { workflow } from "@jlarky/gha-ts/workflow-types";
+import { cloudflareAppSharedPaths } from "../../../scripts/preview/apps.ts";
 import * as utils from "../utils/index.ts";
 
 export default workflow({
@@ -14,7 +15,7 @@ export default workflow({
   on: {
     push: {
       branches: ["main"],
-      paths: ["apps/auth/**", "apps/auth-contract/**"],
+      paths: ["apps/auth/**", "apps/auth-contract/**", ...cloudflareAppSharedPaths],
     },
     workflow_dispatch: {
       inputs: {

--- a/.github/ts-workflows/workflows/lint-typecheck.ts
+++ b/.github/ts-workflows/workflows/lint-typecheck.ts
@@ -41,6 +41,10 @@ export default workflow({
           name: "Run Typecheck",
           run: "pnpm typecheck",
         },
+        {
+          name: "Run Knip",
+          run: "pnpm knip",
+        },
       ],
     },
   },

--- a/.github/workflows/cloudflare-previews.yml
+++ b/.github/workflows/cloudflare-previews.yml
@@ -31,10 +31,7 @@ jobs:
             const previewPaths = [
               ".github/workflows/cloudflare-previews.yml",
               ".github/ts-workflows/workflows/cloudflare-previews.ts",
-              "packages/shared/src/alchemy/**",
-              "packages/shared/src/config.ts",
-              "packages/shared/src/dev/**",
-              "packages/shared/src/evlog/**",
+              "packages/shared/**",
               "packages/ui/**",
               "packages/mock-http-proxy/**",
               "scripts/preview/**",
@@ -44,6 +41,7 @@ jobs:
               "apps/os-contract/**",
               "apps/auth/**",
               "apps/auth-contract/**",
+              "packages/streams/**",
               "apps/semaphore/**",
             ];
             const __handler = async function should_run_preview({ context, github }) {

--- a/.github/workflows/deploy-auth.yml
+++ b/.github/workflows/deploy-auth.yml
@@ -14,6 +14,9 @@ on:
     paths:
       - apps/auth/**
       - apps/auth-contract/**
+      - packages/shared/**
+      - packages/ui/**
+      - packages/mock-http-proxy/**
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/deploy-os.yml
+++ b/.github/workflows/deploy-os.yml
@@ -16,10 +16,8 @@ on:
       - apps/os-contract/**
       - apps/auth/**
       - apps/auth-contract/**
-      - packages/shared/src/alchemy/**
-      - packages/shared/src/config.ts
-      - packages/shared/src/dev/**
-      - packages/shared/src/evlog/**
+      - packages/streams/**
+      - packages/shared/**
       - packages/ui/**
       - packages/mock-http-proxy/**
   workflow_dispatch:

--- a/.github/workflows/deploy-semaphore.yml
+++ b/.github/workflows/deploy-semaphore.yml
@@ -13,10 +13,7 @@ on:
       - main
     paths:
       - apps/semaphore/**
-      - packages/shared/src/alchemy/**
-      - packages/shared/src/config.ts
-      - packages/shared/src/dev/**
-      - packages/shared/src/evlog/**
+      - packages/shared/**
       - packages/ui/**
       - packages/mock-http-proxy/**
   workflow_dispatch:

--- a/.github/workflows/lint-typecheck.yml
+++ b/.github/workflows/lint-typecheck.yml
@@ -25,3 +25,5 @@ jobs:
         run: pnpm exec oxlint . --threads 1 --deny-warnings
       - name: Run Typecheck
         run: pnpm typecheck
+      - name: Run Knip
+        run: pnpm knip

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1233,6 +1233,22 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  scripts:
+    dependencies:
+      '@octokit/rest':
+        specifier: ^22.0.0
+        version: 22.0.1
+      '@orpc/server':
+        specifier: 1.13.14
+        version: 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(jsdom@27.4.0(@noble/hashes@2.0.1))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+
 packages:
 
   '@acemir/cssom@0.9.31':
@@ -20381,6 +20397,15 @@ snapshots:
       vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     optional: true
 
+  '@vitest/mocker@4.1.8(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.13.3(@types/node@25.6.0)(typescript@6.0.3)
+      vite: 8.0.16(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+
   '@vitest/pretty-format@4.0.15':
     dependencies:
       tinyrainbow: 3.1.0
@@ -24915,6 +24940,32 @@ snapshots:
       - '@types/node'
     optional: true
 
+  msw@2.13.3(@types/node@25.6.0)(typescript@6.0.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@25.6.0)
+      '@mswjs/interceptors': 0.41.3
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.13.1
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.7
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 5.5.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   mute-stream@2.0.0: {}
 
   mute-stream@3.0.0: {}
@@ -27581,6 +27632,22 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
+  vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.6.0
+      esbuild: 0.27.4
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.46.0
+      tsx: 4.21.0
+      yaml: 2.8.3
+
   vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -27817,6 +27884,35 @@ snapshots:
     transitivePeerDependencies:
       - msw
     optional: true
+
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(jsdom@27.4.0(@noble/hashes@2.0.1))(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.6.0
+      jsdom: 27.4.0(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - msw
 
   vscode-jsonrpc@8.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
   - packages/*
   - packages/*/example-app
   - .github/ts-workflows
+  - scripts
 
 catalogs:
   cloudflare:

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@iterate-com/scripts",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@octokit/rest": "^22.0.0",
+    "@orpc/server": "1.13.14",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.7"
+  }
+}

--- a/scripts/preview/apps.ts
+++ b/scripts/preview/apps.ts
@@ -16,11 +16,12 @@ export type CloudflarePreviewApp = {
   previewTestCommandArgs: readonly [string, ...string[]];
 };
 
+// Deployed apps compile in @iterate-com/shared via many subpath exports (streams,
+// durable-object-utils, callable, codemode, config, evlog, ...), so trigger on the
+// whole package rather than chasing individual subdirectories. Deploys are idempotent,
+// so over-triggering is safe; under-triggering means prod silently misses deploys.
 export const cloudflareAppSharedPaths = [
-  "packages/shared/src/alchemy/**",
-  "packages/shared/src/config.ts",
-  "packages/shared/src/dev/**",
-  "packages/shared/src/evlog/**",
+  "packages/shared/**",
   "packages/ui/**",
   "packages/mock-http-proxy/**",
 ] as const;
@@ -44,7 +45,14 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     displayName: "OS",
     appPath: "apps/os",
     dopplerProject: "os",
-    paths: ["apps/os/**", "apps/os-contract/**", "apps/auth/**", "apps/auth-contract/**"],
+    paths: [
+      "apps/os/**",
+      "apps/os-contract/**",
+      "apps/auth/**",
+      "apps/auth-contract/**",
+      // apps/os compiles in @iterate-com/streams (see apps/os/src/worker.ts).
+      "packages/streams/**",
+    ],
     previewDependencies: [],
     previewTestBaseUrlEnvVar: "OS_BASE_URL",
     previewTestCommandArgs: ["pnpm", "e2e", "-t", "OS preview smoke"],

--- a/scripts/seed-cloudflare-tunnel-pool.test.ts
+++ b/scripts/seed-cloudflare-tunnel-pool.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   buildTunnelServiceUrl,
   buildDnsRecordBody,


### PR DESCRIPTION
> **Stacked PR:** based on #1429 (`review-sweep/dead-code`), which makes knip exit clean. Retarget to `main` after #1429 merges.

Fixes three CI coverage gaps. All `.github/workflows/*.yml` changes are regenerated from `.github/ts-workflows` (verified zero baseline diff before editing — never hand-edited).

## 1. Deploy path filters miss most of what the apps compile in

`deploy-os.yml` only triggered on `packages/shared/src/{alchemy,dev,evlog}/**` + `config.ts`, but `apps/os` imports `@iterate-com/shared/{streams,durable-object-utils,callable,codemode,typeid,posthog,...}` and `@iterate-com/streams` (via `src/worker.ts`). Changes there silently skipped prod deploys.

- `cloudflareAppSharedPaths` (in `scripts/preview/apps.ts`) broadened to `packages/shared/**` — this also feeds `deploy-semaphore.yml` and the preview workflow trigger; over-triggering is safe since deploys are idempotent.
- `packages/streams/**` added to the OS app's own `paths` (rather than the shared constant) so semaphore previews don't redeploy on streams changes, while OS prod deploys and previews do.
- `deploy-auth.yml` had the same gap (auth imports `@iterate-com/shared` and `@iterate-com/ui` but only watched `apps/auth*/**`) — it now includes `cloudflareAppSharedPaths` too.

## 2. scripts/ tests were run by no runner

`scripts/preview/*.test.ts` (5 vitest files) and `scripts/seed-cloudflare-tunnel-pool.test.ts` (node:test) were executed by nothing — root `pnpm test` is `pnpm -r`, and `scripts/` was not a workspace package.

- `scripts/` is now a private workspace package (`@iterate-com/scripts`, added to `pnpm-workspace.yaml` alongside the existing `.github/ts-workflows` precedent) with `"test": "vitest run"`, so root `pnpm test` (and the Test workflow) picks it up automatically.
- `seed-cloudflare-tunnel-pool.test.ts` converted from `node:test` to vitest (one-line import change; assertions stay `node:assert/strict`) so a single runner covers all 6 files.
- No rot found: **all 6 files / 30 tests pass** (verified under both node:test pre-conversion and vitest post-conversion).

## 3. knip in CI

Added a `Run Knip` step to the Lint and Typecheck workflow (`pnpm knip`). Verified `pnpm knip` exits 0 on this branch, before and after the other changes.

## Skipped

- `deploy-streams-example-app.yml` untouched (per carve-out: os-streams deploy is handled separately; it already triggers on `packages/streams/**`).

## Flags for reviewers

- The finding referenced `newStyleCloudflareAppSharedPaths` in `packages/shared/src/apps/new-style-cloudflare-apps.ts`; on this branch the constant is `cloudflareAppSharedPaths` in `scripts/preview/apps.ts`. Same constant, same gap — fixed there.
- `packages/shared/**` in the shared paths means semaphore (and auth) also redeploy on any shared change, including subpaths they don't import. Intentional trade-off: simple and safe over precise.
- `scripts/` still has no `typecheck` script / tsconfig (status quo — it was never typechecked); only its tests are newly wired in.

## Checks run

`pnpm install`, `pnpm workflows` (zero diff before change, expected diff after), `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` (full workspace, green), `pnpm knip` (exit 0), scripts tests directly (30/30 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and path-filter changes only; broader deploy triggers are intentional and idempotent, with no runtime or auth logic changes.
> 
> **Overview**
> Closes CI gaps so prod deploys, preview triggers, `scripts/` tests, and dead-code checks stay aligned with what apps actually compile in.
> 
> **Deploy and preview path filters** broaden `cloudflareAppSharedPaths` from a few `packages/shared` subpaths to **`packages/shared/**`**, and wire **auth** deploys to that shared list (not only `apps/auth*`). **OS** deploy/preview paths add **`packages/streams/**`** on the OS app config so streams changes trigger OS without pulling streams into every app’s shared constant. Generated workflows (`deploy-os`, `deploy-semaphore`, `deploy-auth`, `cloudflare-previews`) pick up the same rules from `scripts/preview/apps.ts` and ts-workflow sources.
> 
> **Lint workflow** gains a **`pnpm knip`** step alongside lint and typecheck.
> 
> **`scripts/`** becomes workspace package **`@iterate-com/scripts`** with Vitest (`pnpm test` / recursive test runs include it). **`seed-cloudflare-tunnel-pool.test.ts`** switches from `node:test` to Vitest; lockfile adds the new workspace deps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b178f41608ea6377c21474afb1c06bc1879a881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T12:37:13.907Z",
      "headSha": "0b178f41608ea6377c21474afb1c06bc1879a881",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27275931749",
      "shortSha": "0b178f4"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-06-10T12:37:03.254Z",
      "headSha": "0b178f41608ea6377c21474afb1c06bc1879a881",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27275931749",
      "shortSha": "0b178f4"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `0b178f4`
Preview: https://os.iterate-preview-6.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27275931749)
Updated: 2026-06-10T12:37:13.907Z

### Semaphore
Status: released
Commit: `0b178f4`
Preview: https://semaphore.iterate-preview-6.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27275931749)
Updated: 2026-06-10T12:37:03.254Z
<!-- /CLOUDFLARE_PREVIEW -->