### PR TITLE
itx-next: §8 — default capabilities are the context's prototype (flavors)

### DIFF
--- a/apps/os/docs/itx-next.md
+++ b/apps/os/docs/itx-next.md
@@ -461,13 +461,106 @@ second step, taken only after the shared layer proves itself.
   (`callConfigWorkerFunction`, the base iterate-config artifact naming,
   docs, UI copy). Design docs and `types.ts` already use the new name.
 - `handle.ts` sheds its direct domain imports (repos/workspace/streams) —
-  becomes addresses or injected stubs; kernel approaches the ~500-line goal.
+  they become default caps; mechanism in §8. Kernel approaches the
+  ~500-line goal.
 - Document the share token as a sealed SturdyRef (§1).
 - Per-cap/per-call usage events at the supervisor (billing + audit hook,
   feeds §2 and §4).
 - Global-context implementation: make the node real, wire namespace
   currying through the built-ins. (Polishing its shape beyond that is
   explicitly LATER.)
+
+## 8. Default capabilities are the context's prototype (flavors)
+
+The idea (born as "what if ProjectItx / GlobalItx / CodemodeSessionItx
+subclasses just called `this.caps.define()` a few times in their
+constructor, the way you would in a codemode snippet"): now that
+`caps.define` exists, the built-ins hardwired into the handle should be
+ordinary capability definitions. The instinct is right; the only question
+is **which lifecycle the "constructor" runs at**. There are three
+candidates and they are not equal:
+
+1. **Per-handle (the literal reading)** — wrong. Handles are ephemeral
+   views constructed on every connect/restore/narrowing; defines are writes
+   to the durable node. A handle constructor that defines would re-write
+   rows constantly.
+2. **Per-node, as stored rows** (the DO's init seeds the registry) — works
+   mechanically, but: every project duplicates identical rows, re-seeding
+   churns `updated_at` and spams the audit stream, and shipping a new
+   platform default means migrating thousands of stored rows.
+3. **Per-flavor, at module init** — right. A _flavor_ is a named, code-level
+   defaults set, and the resolution chain gets one more link at the root:
+   own caps → parent chain → **flavor defaults (code)**. No rows, no
+   migrations (a deploy updates every context instantly), no audit spam,
+   and shadowing falls out of the chain: a stored `repos` cap overrides the
+   default exactly like a child cap shadows a parent's. Law 1 said this all
+   along: _code holds composition_ — defaults are composition; only
+   overrides are data.
+
+The authoring surface keeps the snippet feel — a flavor is written with the
+SAME verbs a user types in the REPL, just executed against a code-level
+registry once per isolate instead of against a node:
+
+```ts
+export const projectFlavor = defineFlavor("project", (caps) => {
+  caps.define({
+    name: "repos",
+    target: { type: "rpc", worker: { type: "loopback" }, entrypoint: "ReposCapability" },
+  });
+  caps.define({
+    name: "workspace",
+    target: { type: "rpc", worker: { type: "loopback" }, entrypoint: "WorkspaceCapability" },
+  });
+  caps.define({
+    name: "ai",
+    target: {
+      type: "rpc",
+      worker: { type: "loopback" },
+      entrypoint: "BindingCapability",
+      props: { binding: "AI" },
+    },
+  });
+  // worker → { type: "project-worker" }; project → { type: "durable-object" } — once those refs land
+});
+```
+
+(The registry already injects `{ context, cap }` attribution at dial time,
+so flavor definitions stay fully static — entrypoints derive the project
+from context.)
+
+What this dissolves:
+
+- **"Cap #0" disappears.** Every hardwired built-in maps onto an
+  already-designed target kind — repos/workspace/streams → loopback,
+  ai → binding/loopback, worker → project-worker, project →
+  durable-object — which is strong validation of CapTarget. The
+  irreducible kernel shrinks to `caps`, `fork`, `describe`, `fetch`
+  (Law 5 infrastructure), plus `projects` on global handles.
+- **The reserved-name list shrinks to the true kernel** — defaults become
+  shadowable (prototype semantics), which is the point.
+- **The GlobalItx/ProjectItx typing question (§5) gets its answer**: the
+  class names live on as _types_, one per flavor — `ProjectItx =
+ItxBuiltins & ProjectFlavorCaps & KnownCaps` — derived from the same
+  flavor definition that drives runtime resolution.
+- **Forking takes a flavor**: `itx.fork({ flavor: "codemode" })`. The node
+  stores the flavor NAME (a sturdy ref to a code-defined set — Law 2
+  clean); resolution consults that flavor's map. The codemode-session
+  replacement (§4) becomes literally this.
+
+And the dynamic half of the user's instinct is ALSO right, as a separate
+thing: per-context setup that genuinely varies (e.g. seeding a session with
+request-specific MCP servers) is a real itx snippet run against the fresh
+context after fork — actual `caps.define` calls, actual stored rows, actual
+audit events. Static defaults = flavor (code); dynamic setup = snippet
+(data). Same verb, two lifecycles, and the platform uses the same public
+API users do.
+
+Sequencing: repos/workspace/streams are movable today (loopback refs
+shipped); worker/project wait on the project-worker and durable-object
+refs; the flavor-name-on-fork plumbing rides with the codemode drop.
+
+Open: can a context _revoke_ (not just shadow) a flavor default —
+tombstone rows? Defer until someone needs it.
 
 ## Resolved (was open, now decided)
 

--- a/apps/os/docs/itx-next.md
+++ b/apps/os/docs/itx-next.md
@@ -470,39 +470,45 @@ second step, taken only after the shared layer proves itself.
   currying through the built-ins. (Polishing its shape beyond that is
   explicitly LATER.)
 
-## 8. Default capabilities are the context's prototype (flavors)
+## 8. Default capabilities are parent contexts written in code
 
 The idea (born as "what if ProjectItx / GlobalItx / CodemodeSessionItx
 subclasses just called `this.caps.define()` a few times in their
 constructor, the way you would in a codemode snippet"): now that
 `caps.define` exists, the built-ins hardwired into the handle should be
-ordinary capability definitions. The instinct is right; the only question
-is **which lifecycle the "constructor" runs at**. There are three
-candidates and they are not equal:
+ordinary capability definitions. The instinct is right; the question is
+where those definitions live. Per-handle is wrong (handles are ephemeral
+views; defines are node writes). Per-node-as-rows works but churns: every
+project duplicates identical rows, and shipping a new platform default
+means migrating thousands of registries.
 
-1. **Per-handle (the literal reading)** — wrong. Handles are ephemeral
-   views constructed on every connect/restore/narrowing; defines are writes
-   to the durable node. A handle constructor that defines would re-write
-   rows constantly.
-2. **Per-node, as stored rows** (the DO's init seeds the registry) — works
-   mechanically, but: every project duplicates identical rows, re-seeding
-   churns `updated_at` and spams the audit stream, and shipping a new
-   platform default means migrating thousands of stored rows.
-3. **Per-flavor, at module init** — right. A _flavor_ is a named, code-level
-   defaults set, and the resolution chain gets one more link at the root:
-   own caps → parent chain → **flavor defaults (code)**. No rows, no
-   migrations (a deploy updates every context instantly), no audit spam,
-   and shadowing falls out of the chain: a stored `repos` cap overrides the
-   default exactly like a child cap shadows a parent's. Law 1 said this all
-   along: _code holds composition_ — defaults are composition; only
-   overrides are data.
+The answer needs NO new concept — not "flavors", and not an ItxProps
+builder either. A named, addressable, shadowable collection of caps that
+lookup falls through to **is what a context is**. The defaults are simply a
+parent context that happens to be implemented in code instead of SQLite
+rows:
 
-The authoring surface keeps the snippet feel — a flavor is written with the
-SAME verbs a user types in the REPL, just executed against a code-level
-registry once per isolate instead of against a node:
+```text
+ctx_session → prj_123 → platform:project (code) → global
+```
+
+Chain delegation already exists; a hop to a code-defined context resolves
+in-process (no DO hop). `describe()` merges it with
+`owner: "platform:project"` provenance like any ancestor. Shadowing works
+because shadowing already works. Law 1 said it all along: code holds
+composition — defaults are composition; only overrides are data.
+
+Why not props (the builder framing): Law 2 — props carry identity, never
+composition. "Here are the caps you have" riding in props is
+composition-as-data, the exact thing the mounts/scopes deletion killed. And
+defaults must resolve server-side at the node anyway: a worker cap calling
+`itx.ai` dispatches through its home context's chain regardless of how any
+handle was constructed. The builder intuition survives as the _authoring_
+surface: what you build is a code context, with the same verbs as a REPL
+snippet, executed once per isolate against an in-memory registry:
 
 ```ts
-export const projectFlavor = defineFlavor("project", (caps) => {
+export const projectContext = defineCodeContext("platform:project", (caps) => {
   caps.define({
     name: "repos",
     target: { type: "rpc", worker: { type: "loopback" }, entrypoint: "ReposCapability" },
@@ -524,43 +530,49 @@ export const projectFlavor = defineFlavor("project", (caps) => {
 });
 ```
 
-(The registry already injects `{ context, cap }` attribution at dial time,
-so flavor definitions stay fully static — entrypoints derive the project
-from context.)
+(The registry injects `{ context, cap }` attribution at dial time, so code
+contexts stay fully static — entrypoints derive the project from context.)
 
 What this dissolves:
 
 - **"Cap #0" disappears.** Every hardwired built-in maps onto an
   already-designed target kind — repos/workspace/streams → loopback,
   ai → binding/loopback, worker → project-worker, project →
-  durable-object — which is strong validation of CapTarget. The
-  irreducible kernel shrinks to `caps`, `fork`, `describe`, `fetch`
-  (Law 5 infrastructure), plus `projects` on global handles.
-- **The reserved-name list shrinks to the true kernel** — defaults become
-  shadowable (prototype semantics), which is the point.
-- **The GlobalItx/ProjectItx typing question (§5) gets its answer**: the
-  class names live on as _types_, one per flavor — `ProjectItx =
-ItxBuiltins & ProjectFlavorCaps & KnownCaps` — derived from the same
-  flavor definition that drives runtime resolution.
-- **Forking takes a flavor**: `itx.fork({ flavor: "codemode" })`. The node
-  stores the flavor NAME (a sturdy ref to a code-defined set — Law 2
-  clean); resolution consults that flavor's map. The codemode-session
-  replacement (§4) becomes literally this.
+  durable-object — strong validation of CapTarget. The irreducible kernel
+  shrinks to `caps`, `fork`, `describe`, `fetch` (Law 5 infrastructure),
+  plus `projects` on global handles. Reserved names shrink to match;
+  defaults become shadowable (prototype semantics — the point).
+- **The global context gets born for free.** The cheap first step to §3:
+  `global` starts as a code-defined context (its accessors are platform
+  composition anyway); a data node appears only when someone needs to
+  define on it at runtime.
+- **The GlobalItx/ProjectItx typing question (§5) gets its answer**: one
+  typed caps interface per code context, declared next to its definitions;
+  `ProjectItx` = builtins & the chain's caps. Types compose the way the
+  runtime resolves.
+- **Forking picks ancestry**: `itx.fork({ extend: "platform:codemode" })`
+  splices a code context above the project — the node stores parent NAMES
+  (sturdy refs into the code realm — Law 2 clean); resolution walks the
+  list. The codemode-session replacement (§4) becomes literally this.
+- **Versioning falls out**: code contexts version with deploys; describe()
+  can report which deploy's defaults you see, and stored overrides shadow
+  across deploys — exactly the semantics you want.
 
-And the dynamic half of the user's instinct is ALSO right, as a separate
-thing: per-context setup that genuinely varies (e.g. seeding a session with
+The dynamic half of the original instinct is ALSO right, as a separate
+thing: per-context setup that genuinely varies (seeding a session with
 request-specific MCP servers) is a real itx snippet run against the fresh
-context after fork — actual `caps.define` calls, actual stored rows, actual
-audit events. Static defaults = flavor (code); dynamic setup = snippet
-(data). Same verb, two lifecycles, and the platform uses the same public
-API users do.
+context after fork — actual `caps.define` calls, actual rows, actual audit
+events. Static defaults = code context; dynamic setup = snippet (data).
+Same verb, two lifecycles, and the platform uses the same public API users
+do.
 
 Sequencing: repos/workspace/streams are movable today (loopback refs
 shipped); worker/project wait on the project-worker and durable-object
-refs; the flavor-name-on-fork plumbing rides with the codemode drop.
+refs; fork-with-ancestry rides with the codemode drop.
 
-Open: can a context _revoke_ (not just shadow) a flavor default —
-tombstone rows? Defer until someone needs it.
+Open: the splice API shape on fork; ref naming for code contexts
+(`platform:` prefix?); can a context _revoke_ (not just shadow) a code
+default — tombstone rows? Defer until someone needs them.
 
 ## Resolved (was open, now decided)
 


### PR DESCRIPTION
Docs only. Adds §8 to the itx roadmap, capturing the "ProjectItx / GlobalItx / CodemodeSessionItx subclasses that caps.define() in their constructor" idea and resolving it into the flavors design:

- Three candidate lifecycles for the "constructor" — per-handle (wrong: handles are ephemeral views), per-node stored rows (works but churns/duplicates/migrates), **per-flavor at module init** (right: a code-level defaults map as the root link of the resolution chain).
- Flavors are authored with the same `caps.define` verbs a user types in a REPL snippet — the platform dogfoods the public API.
- Dissolves "cap #0": every hardwired built-in maps onto an existing CapTarget kind; the kernel shrinks to caps/fork/describe/fetch (+projects on global).
- Answers the GlobalItx/ProjectItx typing question: one handle type per flavor, derived from the flavor definition.
- `itx.fork({ flavor: "codemode" })` becomes the codemode-session mechanism; genuinely dynamic per-session setup stays a real itx snippet against the forked node (same verb, two lifecycles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only roadmap update with no runtime or security behavior changes.
> 
> **Overview**
> Adds **§8** to the itx-next roadmap and ties **§7**’s `handle.ts` slim-down to that mechanism (built-ins become **default caps** via §8, not ad hoc wiring).
> 
> **§8** records the design for platform defaults: hardwired handle built-ins should be ordinary `caps.define` targets, but stored as **code-defined parent contexts** on the existing prototype chain (e.g. `ctx_session → prj_123 → platform:project (code) → global`), not per-handle defines, per-node duplicate rows, a new **“flavors”** concept, or composition in **ItxProps**. Authoring uses something like `defineCodeContext("platform:project", …)` with the same verbs as user snippets.
> 
> The section spells out consequences: **“cap #0”** goes away (built-ins map to **CapTarget** kinds), the kernel shrinks toward **caps / fork / describe / fetch**, **GlobalItx / ProjectItx** typing follows one interface per code context, **`itx.fork({ extend: "platform:codemode" })`** replaces the codemode-session pattern, and **static defaults vs dynamic post-fork snippets** share one API with two lifecycles. Sequencing and open questions (fork splice API, `platform:` naming, revoke vs shadow) are noted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c28958a55478bae8772291fd9f57bcad93b2dfb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T13:58:40.477Z",
      "headSha": "c28958a55478bae8772291fd9f57bcad93b2dfb0",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27275803916",
      "shortSha": "c28958a"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `c28958a`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27275803916)
Updated: 2026-06-10T13:58:40.477Z
<!-- /CLOUDFLARE_PREVIEW -->