### PR TITLE
Migrate captun to published 0.0.3

### DIFF
--- a/apps/os/e2e/test-support/create-test-project.ts
+++ b/apps/os/e2e/test-support/create-test-project.ts
@@ -143,8 +143,8 @@ export async function createProjectEgressInterceptTunnel(input: {
   fetch: Fetch;
 }) {
   return createCaptunTunnel({
-    url: `${input.project.ingressUrl}/__iterate/intercept-project-egress`,
-    headers: { Authorization: `Bearer ${requireAdminBearerToken()}` },
+    gateway: `${input.project.ingressUrl}/__iterate/intercept-project-egress`,
+    token: requireAdminBearerToken(),
     fetch: input.fetch,
   });
 }
@@ -154,8 +154,9 @@ export async function createPublicTunnel(input: { fetch: Fetch; tunnelName?: str
   const tunnelName = input.tunnelName || `e2e-${uniqueSuffix()}`;
   const url = `${requireBaseUrl()}/__iterate/captun/${encodeURIComponent(tunnelName)}`;
   const tunnel = await createCaptunTunnel({
-    url: `${url}/__captun-connect`,
-    headers: { Authorization: `Bearer ${requireAdminBearerToken()}` },
+    gateway: `${requireBaseUrl()}/__iterate/captun`,
+    name: tunnelName,
+    token: requireAdminBearerToken(),
     fetch: input.fetch,
   });
 

--- a/apps/os/package.json
+++ b/apps/os/package.json
@@ -82,7 +82,7 @@
     "@valtown/codemirror-ts": "2.3.1",
     "agents": "^0.11.0",
     "capnweb": "^0.8.0",
-    "captun": "https://pkg.pr.new/captun@14",
+    "captun": "^0.0.3",
     "comlink": "^4.4.2",
     "crossws": "^0.4.4",
     "dedent": "^1.7.2",

--- a/apps/os/package.json
+++ b/apps/os/package.json
@@ -82,7 +82,7 @@
     "@valtown/codemirror-ts": "2.3.1",
     "agents": "^0.11.0",
     "capnweb": "^0.8.0",
-    "captun": "^0.0.3",
+    "captun": "https://pkg.pr.new/captun@26",
     "comlink": "^4.4.2",
     "crossws": "^0.4.4",
     "dedent": "^1.7.2",

--- a/apps/os/package.json
+++ b/apps/os/package.json
@@ -82,7 +82,7 @@
     "@valtown/codemirror-ts": "2.3.1",
     "agents": "^0.11.0",
     "capnweb": "^0.8.0",
-    "captun": "https://pkg.pr.new/captun@26",
+    "captun": "https://pkg.pr.new/captun@f1778c8",
     "comlink": "^4.4.2",
     "crossws": "^0.4.4",
     "dedent": "^1.7.2",

--- a/apps/os/scripts/benchmark-project-egress-intercept-tunnel.ts
+++ b/apps/os/scripts/benchmark-project-egress-intercept-tunnel.ts
@@ -146,8 +146,8 @@ async function runOneTunnel(input: { interceptUrl: URL; options: Options }): Pro
   let tunnel: Disposable;
   try {
     tunnel = await createCaptunTunnel({
-      url: input.interceptUrl,
-      headers: { Authorization: `Bearer ${adminToken}` },
+      gateway: input.interceptUrl,
+      token: adminToken,
       fetch: globalThis.fetch,
     });
   } catch (error) {

--- a/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
@@ -1,7 +1,7 @@
 import { env } from "cloudflare:workers";
 import { createD1Client } from "sqlfu";
 import { z } from "zod";
-import { acceptCaptunTunnel, type Fetcher } from "captun";
+import { acceptFetcherCapability, type Fetcher } from "captun";
 import type { FetchCallable } from "@iterate-com/shared/callable/types.ts";
 import { createIterateDurableObjectBase } from "@iterate-com/shared/durable-object-utils/iterate-durable-object";
 import { deriveDurableObjectNameFromStructuredName } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
@@ -657,9 +657,14 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
       );
     }
 
+    // WebSocket clients can't set headers, so the captun client sends the
+    // admin token via its connect-token query param instead.
+    // captun's CONNECT_TOKEN_QUERY_PARAM; not re-exported from the package root in 0.0.3.
+    const connectToken = new URL(request.url).searchParams.get("captun-token");
     if (
       !authenticateAdminBearer({
-        authorizationHeader: request.headers.get("authorization"),
+        authorizationHeader:
+          request.headers.get("authorization") || (connectToken ? `Bearer ${connectToken}` : null),
         config: this.getAppConfig(),
       })
     ) {
@@ -673,7 +678,7 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
       );
     }
 
-    const { response, tunnel } = acceptCaptunTunnel({
+    const { response, fetcher: tunnel } = acceptFetcherCapability({
       onDisconnect: () => {
         if (this.#projectEgressInterceptTunnel === tunnel) {
           this.#projectEgressInterceptTunnel = null;
@@ -682,6 +687,10 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
     });
 
     this.replaceProjectEgressInterceptTunnel(tunnel);
+    // createCaptunTunnel waits for this before resolving on the client side.
+    const tunnelUrl = new URL(request.url);
+    tunnelUrl.search = "";
+    void tunnel.ready({ url: tunnelUrl.toString() });
     return response;
   }
 

--- a/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
@@ -1,7 +1,7 @@
 import { env } from "cloudflare:workers";
 import { createD1Client } from "sqlfu";
 import { z } from "zod";
-import { acceptFetcherCapability, type Fetcher } from "captun";
+import { acceptFetcherCapability, connectTokenFromRequest, type Fetcher } from "captun";
 import type { FetchCallable } from "@iterate-com/shared/callable/types.ts";
 import { createIterateDurableObjectBase } from "@iterate-com/shared/durable-object-utils/iterate-durable-object";
 import { deriveDurableObjectNameFromStructuredName } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
@@ -657,10 +657,11 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
       );
     }
 
-    // WebSocket clients can't set headers, so the captun client sends the
-    // admin token via its connect-token query param instead.
-    // captun's CONNECT_TOKEN_QUERY_PARAM; not re-exported from the package root in 0.0.3.
-    const connectToken = new URL(request.url).searchParams.get("captun-token");
+    // The captun client sends the token via the Sec-WebSocket-Protocol header
+    // (WebSocket clients can't set arbitrary headers, and URLs get logged);
+    // connectTokenFromRequest also reads captun's probe header and legacy
+    // query param.
+    const connectToken = connectTokenFromRequest(request);
     if (
       !authenticateAdminBearer({
         authorizationHeader:
@@ -678,7 +679,10 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
       );
     }
 
+    // Passing the request lets captun echo the negotiated subprotocol on the
+    // 101 response — strict WebSocket clients abort the handshake without it.
     const { response, fetcher: tunnel } = acceptFetcherCapability({
+      request,
       onDisconnect: () => {
         if (this.#projectEgressInterceptTunnel === tunnel) {
           this.#projectEgressInterceptTunnel = null;

--- a/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
@@ -659,8 +659,7 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
 
     // The captun client sends the token via the Sec-WebSocket-Protocol header
     // (WebSocket clients can't set arbitrary headers, and URLs get logged);
-    // connectTokenFromRequest also reads captun's probe header and legacy
-    // query param.
+    // connectTokenFromRequest also reads captun's diagnostic-probe header.
     const connectToken = connectTokenFromRequest(request);
     if (
       !authenticateAdminBearer({

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -197,7 +197,7 @@ async function handleCaptunTunnelFetch(request: Request, env: Env, config: AppCo
   url.pathname = url.pathname.slice(CAPTUN_TUNNEL_ROUTE_PREFIX.length) || "/";
 
   return await captunWorker.fetch(new Request(url, request), {
-    CAPTUN_SECRET: config.adminApiSecret?.exposeSecret(),
+    CAPTUN_TOKEN: config.adminApiSecret?.exposeSecret(),
     CaptunServerShard: env.CaptunServerShard,
     SHARD_COUNT: "1",
   });

--- a/oxlint-plugin-iterate.js
+++ b/oxlint-plugin-iterate.js
@@ -145,6 +145,44 @@ function isFunctionLikeDeclaration(node) {
   });
 }
 
+/**
+ * Counts the source lines spanned by a function's body content: the statements between the
+ * braces, or the expression of a concise arrow. Brace-only lines don't count, so
+ * `function f() {\n  return x;\n}` is 1 line.
+ *
+ * @param {import("eslint").SourceCode} sourceCode
+ * @param {import("estree").Function} fn
+ */
+function getFunctionBodyLineCount(sourceCode, fn) {
+  const body = fn.body;
+  if (!body) return Infinity; // overload signatures / declare function
+  let start;
+  let end;
+  if (body.type === "BlockStatement") {
+    const statements = body.body;
+    if (statements.length === 0) return 0;
+    start = statements[0].range?.[0];
+    end = statements[statements.length - 1].range?.[1];
+  } else {
+    start = body.range?.[0];
+    end = body.range?.[1];
+  }
+  if (start === undefined || end === undefined) return Infinity;
+  return sourceCode.getText().slice(start, end).split("\n").length;
+}
+
+/**
+ * @param {import("eslint").Scope.Scope | null} scope
+ * @param {string} name
+ */
+function findVariableInScopeChain(scope, name) {
+  for (let current = scope; current; current = current.upper) {
+    const variable = current.variables.find((v) => v.name === name);
+    if (variable) return variable;
+  }
+  return undefined;
+}
+
 /** @param {string} text */
 function compactTypeText(text) {
   return text.replace(/\s+/g, "");
@@ -559,6 +597,83 @@ const plugin = {
               message:
                 "Avoid vi.mock/vi.doMock in tests. Prefer dependency injection or a controllable fake dependency.",
             });
+          },
+        };
+      },
+    },
+    "no-single-use-helpers": {
+      meta: {
+        type: "suggestion",
+        docs: {
+          description:
+            "Flag tiny non-exported helper functions that are only used once. Inline them so the reader can see what's actually happening instead of chasing an indirection.",
+        },
+      },
+      create(context) {
+        const MAX_BODY_LINES = 1;
+
+        /**
+         * @param {import("estree").Identifier} id the helper's name binding
+         * @param {import("estree").Function} fn the function node
+         * @param {import("estree").Node} statement the enclosing declaration statement
+         */
+        function checkHelper(id, fn, statement) {
+          const exportParent = statement.parent?.type;
+          if (
+            exportParent === "ExportNamedDeclaration" ||
+            exportParent === "ExportDefaultDeclaration"
+          ) {
+            return;
+          }
+
+          const bodyLines = getFunctionBodyLineCount(context.sourceCode, fn);
+          if (bodyLines > MAX_BODY_LINES) return;
+
+          const variable = findVariableInScopeChain(
+            context.sourceCode.getScope(statement),
+            id.name,
+          );
+          if (!variable) return;
+
+          const reads = variable.references.filter((ref) => ref.isRead());
+          // `export { helper }` / `export default helper` make it part of the module's surface
+          const isExportedReference = reads.some((ref) => {
+            const parentType = ref.identifier.parent?.type;
+            return parentType === "ExportSpecifier" || parentType === "ExportDefaultDeclaration";
+          });
+          if (isExportedReference) return;
+
+          // a recursive helper can't be inlined, so any self-reference disqualifies it
+          const hasSelfReference = reads.some((ref) => {
+            const referenceStart = ref.identifier.range?.[0];
+            if (referenceStart === undefined || !fn.range) return false;
+            return referenceStart >= fn.range[0] && referenceStart < fn.range[1];
+          });
+          if (hasSelfReference) return;
+          if (reads.length !== 1) return;
+
+          context.report({
+            node: id,
+            message:
+              `${id.name} is a single-use helper with a ${bodyLines}-line body. ` +
+              `Inline it at the call site so the reader can see what's actually happening.`,
+          });
+        }
+
+        return {
+          FunctionDeclaration(node) {
+            if (!node.id) return;
+            checkHelper(node.id, node, node);
+          },
+          VariableDeclarator(node) {
+            if (node.id.type !== "Identifier" || !node.init) return;
+            if (
+              node.init.type !== "ArrowFunctionExpression" &&
+              node.init.type !== "FunctionExpression"
+            ) {
+              return;
+            }
+            checkHelper(node.id, node.init, node.parent);
           },
         };
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -564,8 +564,8 @@ importers:
         specifier: ^0.8.0
         version: 0.8.0
       captun:
-        specifier: https://pkg.pr.new/captun@26
-        version: https://pkg.pr.new/captun@26(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0)
+        specifier: https://pkg.pr.new/captun@f1778c8
+        version: https://pkg.pr.new/captun@f1778c8(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0)
       comlink:
         specifier: ^4.4.2
         version: 4.4.2
@@ -7872,8 +7872,8 @@ packages:
   capnweb@0.8.0:
     resolution: {integrity: sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==}
 
-  captun@https://pkg.pr.new/captun@26:
-    resolution: {tarball: https://pkg.pr.new/captun@26}
+  captun@https://pkg.pr.new/captun@f1778c8:
+    resolution: {tarball: https://pkg.pr.new/captun@f1778c8}
     version: 0.0.3
     hasBin: true
 
@@ -21530,7 +21530,7 @@ snapshots:
 
   capnweb@0.8.0: {}
 
-  captun@https://pkg.pr.new/captun@26(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0):
+  captun@https://pkg.pr.new/captun@f1778c8(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0):
     dependencies:
       '@inquirer/prompts': 8.4.3(@types/node@25.6.0)
       '@orpc/server': 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -564,8 +564,8 @@ importers:
         specifier: ^0.8.0
         version: 0.8.0
       captun:
-        specifier: ^0.0.3
-        version: 0.0.3(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0)
+        specifier: https://pkg.pr.new/captun@26
+        version: https://pkg.pr.new/captun@26(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0)
       comlink:
         specifier: ^4.4.2
         version: 4.4.2
@@ -7872,8 +7872,9 @@ packages:
   capnweb@0.8.0:
     resolution: {integrity: sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==}
 
-  captun@0.0.3:
-    resolution: {integrity: sha512-78s5QvKMbjxXIgEDxOQnUc0de5URKkFUD/O54qGY6hUIvYIcQhZhNmYhQQnz2ZAS7i8Hv25xtfGfmFXe2yi+5w==}
+  captun@https://pkg.pr.new/captun@26:
+    resolution: {tarball: https://pkg.pr.new/captun@26}
+    version: 0.0.3
     hasBin: true
 
   ccount@2.0.1:
@@ -21529,7 +21530,7 @@ snapshots:
 
   capnweb@0.8.0: {}
 
-  captun@0.0.3(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0):
+  captun@https://pkg.pr.new/captun@26(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0):
     dependencies:
       '@inquirer/prompts': 8.4.3(@types/node@25.6.0)
       '@orpc/server': 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -564,8 +564,8 @@ importers:
         specifier: ^0.8.0
         version: 0.8.0
       captun:
-        specifier: https://pkg.pr.new/captun@14
-        version: https://pkg.pr.new/captun@14(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0)
+        specifier: ^0.0.3
+        version: 0.0.3(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0)
       comlink:
         specifier: ^4.4.2
         version: 4.4.2
@@ -7872,9 +7872,8 @@ packages:
   capnweb@0.8.0:
     resolution: {integrity: sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==}
 
-  captun@https://pkg.pr.new/captun@14:
-    resolution: {tarball: https://pkg.pr.new/captun@14}
-    version: 0.0.2
+  captun@0.0.3:
+    resolution: {integrity: sha512-78s5QvKMbjxXIgEDxOQnUc0de5URKkFUD/O54qGY6hUIvYIcQhZhNmYhQQnz2ZAS7i8Hv25xtfGfmFXe2yi+5w==}
     hasBin: true
 
   ccount@2.0.1:
@@ -21530,7 +21529,7 @@ snapshots:
 
   capnweb@0.8.0: {}
 
-  captun@https://pkg.pr.new/captun@14(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0):
+  captun@0.0.3(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0):
     dependencies:
       '@inquirer/prompts': 8.4.3(@types/node@25.6.0)
       '@orpc/server': 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)

--- a/scripts/preview/preview-inventory.test.ts
+++ b/scripts/preview/preview-inventory.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
 import {
   ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE,
   environmentConfigLeaseInventory,
   parseEnvironmentConfigLeaseData,
   syncPreviewInventory,
 } from "./preview-inventory.ts";
+import { describe, expect, it, vi } from "vitest";
 
 describe("environmentConfigLeaseInventory", () => {
   it("matches the currently provisioned preview slot range", () => {

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "vitest";
 import {
   cloudflarePreviewApps,
   cloudflarePreviewAdditionalTriggerPaths,
@@ -11,6 +10,7 @@ import {
   resolvePreviewCompareBaseSha,
   selectPreviewAppsNeedingRetry,
 } from "./preview.ts";
+import { describe, expect, it } from "vitest";
 
 describe("preview app dependency expansion", () => {
   it("keeps independent apps as-is", () => {

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -3,7 +3,6 @@ import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
 import { resolve } from "node:path";
 import { Octokit } from "@octokit/rest";
-import { z } from "zod";
 import { stripAnsi } from "../../packages/shared/src/dev/strip-ansi.ts";
 import { runCommand } from "../../packages/shared/src/node/run-command.ts";
 import {
@@ -24,6 +23,7 @@ import {
   ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE,
   parseEnvironmentConfigLeaseData,
 } from "./preview-inventory.ts";
+import { z } from "zod";
 
 const defaultSemaphoreBaseUrl = "https://semaphore.iterate.com";
 const defaultPreviewLeaseMs = 60 * 60 * 1000;

--- a/scripts/preview/reconcile-environment-config-leases.test.ts
+++ b/scripts/preview/reconcile-environment-config-leases.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from "vitest";
 import {
   evaluateCloudflareZoneCheck,
   reconcileEnvironmentConfigLeaseResources,
 } from "./reconcile-environment-config-leases.ts";
 import { ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE } from "./preview-inventory.ts";
+import { describe, expect, it } from "vitest";
 
 describe("reconcileEnvironmentConfigLeaseResources", () => {
   it("checks live Semaphore leases against Doppler projects and Cloudflare zones", async () => {

--- a/scripts/preview/reconcile-environment-config-leases.ts
+++ b/scripts/preview/reconcile-environment-config-leases.ts
@@ -1,10 +1,10 @@
-import { z } from "zod";
 import { runCommand } from "../../packages/shared/src/node/run-command.ts";
 import { cloudflarePreviewApps } from "./apps.ts";
 import {
   ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE,
   parseEnvironmentConfigLeaseData,
 } from "./preview-inventory.ts";
+import { z } from "zod";
 
 type EnvironmentConfigLeaseResourceRecord = {
   slug: string;

--- a/scripts/preview/repository-full-name.test.ts
+++ b/scripts/preview/repository-full-name.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import { splitRepositoryFullName } from "./repository-full-name.ts";
+import { describe, expect, it } from "vitest";
 
 describe("splitRepositoryFullName", () => {
   it("parses owner/repo", () => {

--- a/scripts/preview/router.ts
+++ b/scripts/preview/router.ts
@@ -1,5 +1,4 @@
 import { os } from "@orpc/server";
-import { z } from "zod";
 import { createSemaphoreClient } from "../../apps/semaphore/src/contract.ts";
 import { ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE } from "./preview-inventory.ts";
 import {
@@ -12,6 +11,7 @@ import {
   testCloudflarePreviewForPullRequest,
 } from "./preview.ts";
 import { reconcileEnvironmentConfigLeaseResources } from "./reconcile-environment-config-leases.ts";
+import { z } from "zod";
 
 const env = process.env;
 const previewBoundaryEnv = createPreviewBoundaryEnv(env);

--- a/scripts/preview/state.test.ts
+++ b/scripts/preview/state.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "vitest";
 import {
   CloudflarePreviewAppEntry,
   EnvironmentConfigLease,
   parseCloudflarePreviewState,
   renderCloudflarePreviewPullRequestBody,
 } from "./state.ts";
+import { describe, expect, it } from "vitest";
 
 describe("cloudflare preview state helpers", () => {
   it("round-trips rendered preview state from the managed PR body section", () => {

--- a/scripts/preview/state.ts
+++ b/scripts/preview/state.ts
@@ -1,7 +1,7 @@
 import { Octokit } from "@octokit/rest";
-import { z } from "zod";
 import { markdownAnnotator } from "../../packages/shared/src/dev/markdown-annotator.ts";
 import { splitRepositoryFullName } from "./repository-full-name.ts";
+import { z } from "zod";
 
 const cloudflarePreviewSectionLabel = "CLOUDFLARE_PREVIEW";
 const cloudflarePreviewStateLabel = "CLOUDFLARE_PREVIEW_STATE";

--- a/tasks/complete/2026-06-10-migrate-captun-to-npm.md
+++ b/tasks/complete/2026-06-10-migrate-captun-to-npm.md
@@ -1,0 +1,21 @@
+---
+status: done
+size: small
+---
+
+# Migrate captun to the published npm package
+
+apps/os pinned `captun` to `https://pkg.pr.new/captun@14` — a pre-merge snapshot of iterate/captun#14 from May 22. That PR merged and captun 0.0.3 was published to npm, with API renames in between. Move to the published package so future captun work (reconnect-on-drop, WebSocket passthrough for the dev-tunnel plan in `tasks/switch-dev-tunnels-to-captun.md`) diffs against a real release instead of a stale PR build.
+
+- [x] Replace `pkg.pr.new/captun@14` with `captun@^0.0.3` _in apps/os/package.json_
+- [x] `acceptCaptunTunnel` → `acceptFetcherCapability`, returns `{response, fetcher}` instead of `{response, tunnel}` _one callsite in project-durable-object.ts_
+- [x] `CAPTUN_SECRET` → `CAPTUN_TOKEN` worker env key _in worker.ts handleCaptunTunnelFetch; 0.0.3 throws a descriptive error on the old key_
+- [x] Client options: `url`/`headers` → `gateway`/`name`/`token` (browser WebSockets can't set headers, so captun moved auth to a `captun-token` query param) _e2e create-test-project.ts helpers + benchmark script_
+- [x] Project DO egress-intercept endpoint accepts the `captun-token` query param as a bearer fallback _project-durable-object.ts acceptProjectEgressInterceptTunnel_
+- [x] Send the `ready({url})` RPC after accepting a tunnel — 0.0.3 clients block on it with a 5s timeout _project-durable-object.ts; the captun gateway worker does this itself, but our custom DO accept path didn't_
+
+## Implementation notes
+
+- Verified: apps/os typecheck, repo lint, and `pnpm test:project-ingress` (6/6, covers the egress-intercept tunnel including the 401 auth case).
+- Not verified locally: the e2e helpers (`createPublicTunnel`, `createProjectEgressInterceptTunnel`) need a deployed environment — CI e2e or a benchmark-script run against a dev/preview env is the remaining check.
+- `CONNECT_TOKEN_QUERY_PARAM` exists in 0.0.3 internals but isn't re-exported from the package root (current captun main exports it), so `"captun-token"` is inlined with a comment — a 0.0.4 release would let us import the constant.

--- a/tasks/complete/2026-06-10-migrate-captun-to-npm.md
+++ b/tasks/complete/2026-06-10-migrate-captun-to-npm.md
@@ -10,12 +10,14 @@ apps/os pinned `captun` to `https://pkg.pr.new/captun@14` — a pre-merge snapsh
 - [x] Replace `pkg.pr.new/captun@14` with `captun@^0.0.3` _in apps/os/package.json_
 - [x] `acceptCaptunTunnel` → `acceptFetcherCapability`, returns `{response, fetcher}` instead of `{response, tunnel}` _one callsite in project-durable-object.ts_
 - [x] `CAPTUN_SECRET` → `CAPTUN_TOKEN` worker env key _in worker.ts handleCaptunTunnelFetch; 0.0.3 throws a descriptive error on the old key_
-- [x] Client options: `url`/`headers` → `gateway`/`name`/`token` (browser WebSockets can't set headers, so captun moved auth to a `captun-token` query param) _e2e create-test-project.ts helpers + benchmark script_
-- [x] Project DO egress-intercept endpoint accepts the `captun-token` query param as a bearer fallback _project-durable-object.ts acceptProjectEgressInterceptTunnel_
+- [x] Client options: `url`/`headers` → `gateway`/`name`/`token` (browser WebSockets can't set headers, so captun moved auth out of headers) _e2e create-test-project.ts helpers + benchmark script_
+- [x] ~~Project DO egress-intercept endpoint accepts the `captun-token` query param as a bearer fallback~~ _superseded: the query param leaked the admin secret into URL logs (flagged by Jonas on the PR); iterate/captun#26 moved the token into `Sec-WebSocket-Protocol`, and the DO now reads it via captun's `connectTokenFromRequest`_
 - [x] Send the `ready({url})` RPC after accepting a tunnel — 0.0.3 clients block on it with a 5s timeout _project-durable-object.ts; the captun gateway worker does this itself, but our custom DO accept path didn't_
+- [x] Adopt the `Sec-WebSocket-Protocol` Connect Token transport from iterate/captun#26 _pin `pkg.pr.new/captun@26`; DO passes `request` to `acceptFetcherCapability` so the 101 echoes the negotiated subprotocol (strict clients abort the handshake otherwise), and auths via `connectTokenFromRequest` (subprotocol → probe header → legacy query param)_
 
 ## Implementation notes
 
-- Verified: apps/os typecheck, repo lint, and `pnpm test:project-ingress` (6/6, covers the egress-intercept tunnel including the 401 auth case).
+- Verified: apps/os typecheck, repo lint, and `pnpm test:project-ingress` (6/6, covers the egress-intercept tunnel including the 401 auth case). captun#26's own suite covers the real WebSocket handshake (subprotocol echo, wrong-token 401 diagnostics, query-param back-compat).
 - Not verified locally: the e2e helpers (`createPublicTunnel`, `createProjectEgressInterceptTunnel`) need a deployed environment — CI e2e or a benchmark-script run against a dev/preview env is the remaining check.
-- `CONNECT_TOKEN_QUERY_PARAM` exists in 0.0.3 internals but isn't re-exported from the package root (current captun main exports it), so `"captun-token"` is inlined with a comment — a 0.0.4 release would let us import the constant.
+- The `pkg.pr.new/captun@26` pin is temporary: once iterate/captun#26 merges and 0.0.4 ships, swap to `captun@^0.0.4`.
+- Follow-up worth its own task: stop using `adminApiSecret` as the tunnel-admission token entirely — mint a scoped tunnel secret so a leak grants "can connect tunnels", not "can administer iterate".


### PR DESCRIPTION
apps/os was pinned to `captun@https://pkg.pr.new/captun@14` — a frozen pre-merge snapshot of iterate/captun#14 from May 22. That PR merged long ago and `captun@0.0.3` is now on npm, so this migrates to the published API. Future captun features (reconnect-on-drop, WebSocket passthrough for the dev-tunnel plan in `tasks/switch-dev-tunnels-to-captun.md`) can now be diffed against a real release instead of a stale PR build.

## API migration

The client lost its `headers` option because browser WebSockets can't set headers — auth moved into the `token` option:

```ts
// before (@14)
await createCaptunTunnel({
  url: `${ingressUrl}/__iterate/intercept-project-egress`,
  headers: { Authorization: `Bearer ${adminToken}` },
  fetch,
});

// after
await createCaptunTunnel({
  gateway: `${ingressUrl}/__iterate/intercept-project-egress`,
  token: adminToken,
  fetch,
});
```

In captun 0.0.3 that token travelled as a `?captun-token=` query param — which would have put the iterate admin secret into Cloudflare request logs (caught by @jonastemplestein below). iterate/captun#26 fixes the transport upstream: the token now rides in the `Sec-WebSocket-Protocol` header as `captun-token.<base64url>`, and the gateway echoes the `captun` marker subprotocol on the 101 response (strict WebSocket clients abort the handshake otherwise). This PR pins `pkg.pr.new/captun@26` until that merges and 0.0.4 ships.

Server side:

- `acceptCaptunTunnel()` → `acceptFetcherCapability()`, returning `{response, fetcher}` instead of `{response, tunnel}`. The project DO passes the upgrade `request` in so the 101 echoes the negotiated subprotocol.
- `CAPTUN_SECRET` env key → `CAPTUN_TOKEN` (captun throws a descriptive error if you pass the old key).
- The project DO's egress-intercept endpoint authenticates via captun's `connectTokenFromRequest` (subprotocol → probe header → legacy query param), falling back to the `Authorization` header for non-captun callers.
- The DO now sends the `ready({url})` RPC after accepting a tunnel — captun clients block on it with a 5s timeout. The captun gateway worker does this itself, but our custom DO accept path didn't, so without it every e2e egress-intercept connect would hang and fail.

## Verification

- apps/os typecheck, repo lint, and `pnpm test:project-ingress` (6/6, includes the 401 unauthenticated-connect case) all pass.
- captun#26's own suite covers the real WebSocket handshake: subprotocol echo, wrong-token 401 diagnostics, query-param back-compat, and a URL-hygiene test asserting the token never appears in the connect URL.
- Not verifiable locally: the e2e tunnel helpers need a deployed environment — CI e2e covers them.

## Follow-up (own task)

We still use `adminApiSecret` as the tunnel-admission token. With the transport fixed, the remaining improvement is scoping: mint a dedicated tunnel secret so a leak grants "can connect tunnels", not "can administer iterate".

## History note

This change was originally committed onto `stream-tui-iterate-cli` (1a0401fc4) and has been reverted there (22d53e2c5); this PR is the same work cherry-picked onto main so it can be reviewed and merged independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes admin-gated WebSocket tunnel admission and connect handshake for project egress intercept; regressions could break e2e egress capture or leak/block tunnel connects, though scope is limited to captun integration paths.
> 
> **Overview**
> Moves **apps/os** off the stale `pkg.pr.new/captun@14` pin to a newer captun build (`f1778c8`, toward 0.0.3/0.0.4) and updates every integration to the renamed client/server APIs.
> 
> **Tunnel clients** (e2e helpers and the egress-intercept benchmark) now call `createCaptunTunnel` with `gateway` / `name` / `token` instead of `url` plus `Authorization` headers. **OS worker** passes `CAPTUN_TOKEN` into the captun gateway worker (replacing `CAPTUN_SECRET`).
> 
> **Project egress intercept** on the project DO switches from `acceptCaptunTunnel` to `acceptFetcherCapability` with the upgrade `request` so the 101 echoes the negotiated WebSocket subprotocol. Auth accepts captun’s connect token via `connectTokenFromRequest` (e.g. `Sec-WebSocket-Protocol`) as well as `Authorization`. After accept, the DO calls `tunnel.ready({ url })` so clients no longer hang on connect.
> 
> Also adds an oxlint **`no-single-use-helpers`** rule, reorders imports in several `scripts/preview/*` tests, and records the migration in a completed task note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b377dd27a8690efc6a31dc23b10dba8bd7f6937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "deployed",
      "updatedAt": "2026-06-10T16:56:56.660Z",
      "headSha": "7790b42ebe43fc5bda471940c717140a42a53fd5",
      "message": null,
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27289817017",
      "shortSha": "7790b42"
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_2",
    "leasedUntil": 1781114086236,
    "leaseId": "83bf6242-0cf8-464d-94fe-b0f7623121f8",
    "slug": "preview-2",
    "type": "environment-config-lease"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
Lease: `preview-2`
Doppler config: `preview_2`
Type: `environment-config-lease`
Leased until: 2026-06-10T17:54:46.236Z

### OS
Status: deployed
Commit: `7790b42`
Preview: https://os.iterate-preview-2.com
[Workflow run](https://github.com/iterate/iterate/actions/runs/27289817017)
Updated: 2026-06-10T16:56:56.660Z
<!-- /CLOUDFLARE_PREVIEW -->
