### PR TITLE
Migrate captun to published npm 0.0.3

### DIFF
--- a/apps/os/e2e/test-support/create-test-project.ts
+++ b/apps/os/e2e/test-support/create-test-project.ts
@@ -143,8 +143,8 @@ export async function createProjectEgressInterceptTunnel(input: {
   fetch: Fetch;
 }) {
   return createCaptunTunnel({
-    url: `${input.project.ingressUrl}/__iterate/intercept-project-egress`,
-    headers: { Authorization: `Bearer ${requireAdminBearerToken()}` },
+    gateway: `${input.project.ingressUrl}/__iterate/intercept-project-egress`,
+    token: requireAdminBearerToken(),
     fetch: input.fetch,
   });
 }
@@ -154,8 +154,9 @@ export async function createPublicTunnel(input: { fetch: Fetch; tunnelName?: str
   const tunnelName = input.tunnelName || `e2e-${uniqueSuffix()}`;
   const url = `${requireBaseUrl()}/__iterate/captun/${encodeURIComponent(tunnelName)}`;
   const tunnel = await createCaptunTunnel({
-    url: `${url}/__captun-connect`,
-    headers: { Authorization: `Bearer ${requireAdminBearerToken()}` },
+    gateway: `${requireBaseUrl()}/__iterate/captun`,
+    name: tunnelName,
+    token: requireAdminBearerToken(),
     fetch: input.fetch,
   });
 

--- a/apps/os/package.json
+++ b/apps/os/package.json
@@ -82,7 +82,7 @@
     "@valtown/codemirror-ts": "2.3.1",
     "agents": "^0.11.0",
     "capnweb": "^0.8.0",
-    "captun": "https://pkg.pr.new/captun@14",
+    "captun": "^0.0.3",
     "comlink": "^4.4.2",
     "crossws": "^0.4.4",
     "dedent": "^1.7.2",

--- a/apps/os/scripts/benchmark-project-egress-intercept-tunnel.ts
+++ b/apps/os/scripts/benchmark-project-egress-intercept-tunnel.ts
@@ -146,8 +146,8 @@ async function runOneTunnel(input: { interceptUrl: URL; options: Options }): Pro
   let tunnel: Disposable;
   try {
     tunnel = await createCaptunTunnel({
-      url: input.interceptUrl,
-      headers: { Authorization: `Bearer ${adminToken}` },
+      gateway: input.interceptUrl,
+      token: adminToken,
       fetch: globalThis.fetch,
     });
   } catch (error) {

--- a/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
@@ -1,7 +1,7 @@
 import { env } from "cloudflare:workers";
 import { createD1Client } from "sqlfu";
 import { z } from "zod";
-import { acceptCaptunTunnel, type Fetcher } from "captun";
+import { acceptFetcherCapability, type Fetcher } from "captun";
 import type { FetchCallable } from "@iterate-com/shared/callable/types.ts";
 import { createIterateDurableObjectBase } from "@iterate-com/shared/durable-object-utils/iterate-durable-object";
 import { deriveDurableObjectNameFromStructuredName } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
@@ -657,9 +657,14 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
       );
     }
 
+    // WebSocket clients can't set headers, so the captun client sends the
+    // admin token via its connect-token query param instead.
+    // captun's CONNECT_TOKEN_QUERY_PARAM; not re-exported from the package root in 0.0.3.
+    const connectToken = new URL(request.url).searchParams.get("captun-token");
     if (
       !authenticateAdminBearer({
-        authorizationHeader: request.headers.get("authorization"),
+        authorizationHeader:
+          request.headers.get("authorization") || (connectToken ? `Bearer ${connectToken}` : null),
         config: this.getAppConfig(),
       })
     ) {
@@ -673,7 +678,7 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
       );
     }
 
-    const { response, tunnel } = acceptCaptunTunnel({
+    const { response, fetcher: tunnel } = acceptFetcherCapability({
       onDisconnect: () => {
         if (this.#projectEgressInterceptTunnel === tunnel) {
           this.#projectEgressInterceptTunnel = null;
@@ -682,6 +687,10 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
     });
 
     this.replaceProjectEgressInterceptTunnel(tunnel);
+    // createCaptunTunnel waits for this before resolving on the client side.
+    const tunnelUrl = new URL(request.url);
+    tunnelUrl.search = "";
+    void tunnel.ready({ url: tunnelUrl.toString() });
     return response;
   }
 

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -197,7 +197,7 @@ async function handleCaptunTunnelFetch(request: Request, env: Env, config: AppCo
   url.pathname = url.pathname.slice(CAPTUN_TUNNEL_ROUTE_PREFIX.length) || "/";
 
   return await captunWorker.fetch(new Request(url, request), {
-    CAPTUN_SECRET: config.adminApiSecret?.exposeSecret(),
+    CAPTUN_TOKEN: config.adminApiSecret?.exposeSecret(),
     CaptunServerShard: env.CaptunServerShard,
     SHARD_COUNT: "1",
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -564,8 +564,8 @@ importers:
         specifier: ^0.8.0
         version: 0.8.0
       captun:
-        specifier: https://pkg.pr.new/captun@14
-        version: https://pkg.pr.new/captun@14(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0)
+        specifier: ^0.0.3
+        version: 0.0.3(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0)
       comlink:
         specifier: ^4.4.2
         version: 4.4.2
@@ -7872,9 +7872,8 @@ packages:
   capnweb@0.8.0:
     resolution: {integrity: sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==}
 
-  captun@https://pkg.pr.new/captun@14:
-    resolution: {tarball: https://pkg.pr.new/captun@14}
-    version: 0.0.2
+  captun@0.0.3:
+    resolution: {integrity: sha512-78s5QvKMbjxXIgEDxOQnUc0de5URKkFUD/O54qGY6hUIvYIcQhZhNmYhQQnz2ZAS7i8Hv25xtfGfmFXe2yi+5w==}
     hasBin: true
 
   ccount@2.0.1:
@@ -21530,7 +21529,7 @@ snapshots:
 
   capnweb@0.8.0: {}
 
-  captun@https://pkg.pr.new/captun@14(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0):
+  captun@0.0.3(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(valibot@1.2.0(typescript@5.9.3))(ws@8.19.0):
     dependencies:
       '@inquirer/prompts': 8.4.3(@types/node@25.6.0)
       '@orpc/server': 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)

--- a/tasks/complete/2026-06-10-migrate-captun-to-npm.md
+++ b/tasks/complete/2026-06-10-migrate-captun-to-npm.md
@@ -1,0 +1,30 @@
+# Migrate captun dependency to published npm release
+
+Move apps/os off the stale `https://pkg.pr.new/captun@14` pin (a pre-merge snapshot of
+iterate/captun#14, merged 2026-05-23) onto the published `captun@^0.0.3` npm release,
+adapting to the API changes that landed between that snapshot and the release
+(captun PRs #16–#24: hosted captun.sh, safety controls, runtime adapters).
+
+Groundwork for [switching local dev tunnelling to captun](../switch-dev-tunnels-to-captun.md):
+any new captun features (client reconnect loop, WebSocket passthrough) will now diff
+against a real release instead of a stale PR build.
+
+- [x] Swap `captun` dependency to `^0.0.3` _(apps/os/package.json)_
+- [x] `acceptCaptunTunnel` → `acceptFetcherCapability`, return shape `{response, tunnel}` → `{response, fetcher}` _(project-durable-object.ts)_
+- [x] `CAPTUN_SECRET` → `CAPTUN_TOKEN` worker env key — 0.0.3 throws a descriptive error on the old key _(worker.ts `handleCaptunTunnelFetch`)_
+- [x] Client options `url`/`headers` → `gateway`/`name`/`token` — captun moved auth to a `captun-token` query param because browser WebSockets can't set headers _(e2e create-test-project.ts, benchmark script)_
+- [x] Accept the `captun-token` query param as admin auth on the egress-intercept endpoint, falling back from the `Authorization` header _(project-durable-object.ts `acceptProjectEgressInterceptTunnel`)_
+- [x] Send the `ready({url})` handshake after accepting an egress-intercept tunnel — 0.0.3 clients block on it with a 5s timeout _(project-durable-object.ts)_
+
+## Implementation notes
+
+- Verified with apps/os typecheck, repo lint, and `pnpm test:project-ingress` (6/6,
+  covers the egress-intercept tunnel accept path including the 401 case).
+- `CONNECT_TOKEN_QUERY_PARAM` exists in captun 0.0.3 internally but isn't re-exported
+  from the package root until later commits on captun main, so `"captun-token"` is
+  inlined with a comment; a captun 0.0.4 release would let us import the constant.
+- Not verified locally: the e2e helpers (`createPublicTunnel`,
+  `createProjectEgressInterceptTunnel`) need a deployed environment — worth one
+  e2e pass or a run of `benchmark:intercept-tunnel` against a dev/preview env.
+- History: this work originally landed as `1a0401fc4` on `stream-tui-iterate-cli`,
+  was reverted there (`22d53e2c5`), and cherry-picked here onto main.


### PR DESCRIPTION
Moves apps/os off the stale `https://pkg.pr.new/captun@14` pin — a pre-merge snapshot of [iterate/captun#14](https://github.com/iterate/captun/pull/14), merged 2026-05-23 — onto the published `captun@^0.0.3` npm release. This is groundwork for switching local dev tunnelling to captun (see `tasks/switch-dev-tunnels-to-captun.md` on `stream-tui-iterate-cli`): future captun features (client reconnect, WebSocket passthrough) will now diff against a real release instead of a frozen PR build.

The captun API changed between the snapshot and the release (captun PRs #16–#24), so this is more than a version bump:

```ts
// before (@14 snapshot)
const tunnel = await createCaptunTunnel({
  url: `${ingressUrl}/__iterate/intercept-project-egress`,
  headers: { Authorization: `Bearer ${adminToken}` },
  fetch,
});
const { response, tunnel } = acceptCaptunTunnel({ onDisconnect });

// after (0.0.3)
const tunnel = await createCaptunTunnel({
  gateway: `${ingressUrl}/__iterate/intercept-project-egress`,
  token: adminToken, // sent as a ?captun-token= query param — WebSocket clients can't set headers
  fetch,
});
const { response, fetcher } = acceptFetcherCapability({ onDisconnect });
```

Server-side changes that follow from that:

- `handleCaptunTunnelFetch` passes `CAPTUN_TOKEN` instead of `CAPTUN_SECRET` (0.0.3 throws a descriptive error on the old key).
- The project egress-intercept endpoint accepts the admin token via the `captun-token` query param, falling back from the `Authorization` header.
- After accepting an egress-intercept tunnel, the project DO now sends the `ready({url})` handshake — 0.0.3 clients block on it with a 5s timeout, so without this every e2e egress-intercept connect would hang.

Verified: apps/os typecheck, repo lint, and `pnpm test:project-ingress` (6/6, covers the tunnel accept path including the 401 case) on top of latest main. Not verified locally: the e2e helpers need a deployed environment — worth one e2e pass or a `benchmark:intercept-tunnel` run against a dev/preview env before merging.

History note: this originally landed as `1a0401fc4` on `stream-tui-iterate-cli`, was reverted there (`22d53e2c5`), and is cherry-picked here so it can ride to main independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches admin-authenticated tunnel paths and project egress intercept WebSocket handling; mis-wiring would break e2e tunnels or leave connects timing out without `ready`.
> 
> **Overview**
> Replaces the stale `pkg.pr.new/captun@14` pin with published **`captun@^0.0.3`** and updates all call sites for the post-release API.
> 
> **Client tunnels** (`createCaptunTunnel` in e2e helpers and the intercept benchmark) now use `gateway` / `name` / `token` instead of `url` plus `Authorization` headers; auth rides on the `captun-token` query param because WebSocket clients cannot set headers.
> 
> **Worker captun relay** passes `CAPTUN_TOKEN` instead of `CAPTUN_SECRET`. **Project egress intercept** switches to `acceptFetcherCapability` (returns `fetcher` not `tunnel`), accepts admin auth from `captun-token` or the bearer header, and calls **`ready({ url })`** so 0.0.3 clients do not hang on connect.
> 
> Adds a completed task note documenting verification and follow-ups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d172d682cf956249ee9787a90c8a4c731e34718. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->