### PR TITLE
itx: McpClient — first-party MCP client capability (loopback ref)

### DIFF
--- a/apps/os/src/itx/caps/mcp-client.ts
+++ b/apps/os/src/itx/caps/mcp-client.ts
@@ -55,8 +55,7 @@ export type McpClientProps = {
 
 export class McpClient extends WorkerEntrypoint<Env, McpClientProps> {
   async call(input: PathCall): Promise<unknown> {
-    const workerCtx = Reflect.get(this, "ctx") as ExecutionContext<McpClientProps>;
-    const props = workerCtx.props;
+    const props = this.ctx.props;
     if (!props.serverUrl) {
       throw new Error("McpClient needs props.serverUrl (the remote MCP server).");
     }
@@ -68,7 +67,7 @@ export class McpClient extends WorkerEntrypoint<Env, McpClientProps> {
 
     const itx = await resolveItx({
       env: this.env,
-      exports: workerCtx.exports as unknown as ItxRuntime["exports"],
+      exports: this.ctx.exports as unknown as ItxRuntime["exports"],
       props: { cap: props.cap, context: props.context },
     });
 

--- a/apps/os/src/itx/caps/mcp-client.ts
+++ b/apps/os/src/itx/caps/mcp-client.ts
@@ -74,15 +74,24 @@ export class McpClient extends WorkerEntrypoint<Env, McpClientProps> {
 
     const transport = new StreamableHTTPClientTransport(new URL(props.serverUrl), {
       // ALL transport HTTP rides the project egress pipe — this is where
-      // getSecret() placeholders in headers become real credentials.
+      // getSecret() placeholders in headers become real credentials. Build a
+      // real Request first: the SDK may pass a URL (which itx.fetch would not
+      // stringify) or a Request plus separate init (whose headers must merge
+      // before egress sees them).
       fetch: (fetchInput: Request | string | URL, init?: RequestInit) =>
-        itx.fetch(fetchInput as Request | string, init),
+        itx.fetch(
+          fetchInput instanceof Request
+            ? new Request(fetchInput, init)
+            : new Request(String(fetchInput), init),
+        ),
       requestInit: props.headers ? { headers: props.headers } : undefined,
     });
     const client = new Client({ name: "itx-mcp-client", version: "1.0.0" });
-    await client.connect(transport);
 
     try {
+      // Inside the try so a failed connect still runs close() — a partial
+      // handshake can otherwise leave server-side session state dangling.
+      await client.connect(transport);
       if (input.path.join(".") === "listTools") {
         const listed = await client.listTools();
         return describeOutboundMcpFromOurClientTools(

--- a/apps/os/src/itx/caps/mcp-client.ts
+++ b/apps/os/src/itx/caps/mcp-client.ts
@@ -1,0 +1,105 @@
+// McpClient: the first-party MCP client capability (itx-next.md §1).
+//
+// MCP is not a transport in the capability model — it is a client
+// IMPLEMENTATION, i.e. an ordinary RPC target. This entrypoint is the
+// first-party half of the litmus test: registered via a loopback ref and
+// parameterized per server by props, it must have NO powers a user-space
+// equivalent (the same class exported from a project worker) couldn't have.
+//
+//   await itx.caps.define({
+//     invoke: "path-call",
+//     name: "docs",
+//     target: {
+//       type: "rpc",
+//       worker: { type: "loopback" },
+//       entrypoint: "McpClient",
+//       props: {
+//         serverUrl: "https://docs.example.com/mcp",
+//         headers: { authorization: 'Bearer getSecret({ key: "DOCS_TOKEN" })' },
+//       },
+//     },
+//   });
+//
+//   await itx.docs.listTools();
+//   await itx.docs.someToolName({ ...args });
+//
+// Every HTTP request to the MCP server goes through PROJECT EGRESS via this
+// cap's own itx handle (Law 5): secret placeholders in `headers` are
+// substituted inside the Project DO and never exist in this isolate.
+//
+// Deliberately stateless: connect → call → close, per invocation. The old
+// OutboundMcpFromOurClientCapability cached the connection in a Durable
+// Object; when per-call handshake latency matters, the same class becomes a
+// `durable-object` ref (or a stored-source DO cap) without changing callers.
+
+import { WorkerEntrypoint } from "cloudflare:workers";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { resolveItx } from "../entrypoint.ts";
+import type { ItxRuntime } from "../handle.ts";
+import type { PathCall } from "../protocol.ts";
+import {
+  describeOutboundMcpFromOurClientTools,
+  executeOutboundMcpFromOurClientToolFunction,
+} from "~/domains/outbound-mcp-client/utils/outbound-mcp-from-our-client-capability-core.ts";
+
+export type McpClientProps = {
+  /** The remote MCP server (streamable HTTP). Definer-supplied. */
+  serverUrl: string;
+  /** Sent on every request; values pass through egress secret substitution. */
+  headers?: Record<string, string>;
+  /** Attribution, injected by the registry at dial time. */
+  cap?: string;
+  context?: string;
+};
+
+export class McpClient extends WorkerEntrypoint<Env, McpClientProps> {
+  async call(input: PathCall): Promise<unknown> {
+    const workerCtx = Reflect.get(this, "ctx") as ExecutionContext<McpClientProps>;
+    const props = workerCtx.props;
+    if (!props.serverUrl) {
+      throw new Error("McpClient needs props.serverUrl (the remote MCP server).");
+    }
+    if (!props.context) {
+      // The registry always injects context; refusing without it means this
+      // client can never fetch outside the egress pipe.
+      throw new Error("McpClient needs context attribution to route egress.");
+    }
+
+    const itx = await resolveItx({
+      env: this.env,
+      exports: workerCtx.exports as unknown as ItxRuntime["exports"],
+      props: { cap: props.cap, context: props.context },
+    });
+
+    const transport = new StreamableHTTPClientTransport(new URL(props.serverUrl), {
+      // ALL transport HTTP rides the project egress pipe — this is where
+      // getSecret() placeholders in headers become real credentials.
+      fetch: (fetchInput: Request | string | URL, init?: RequestInit) =>
+        itx.fetch(fetchInput as Request | string, init),
+      requestInit: props.headers ? { headers: props.headers } : undefined,
+    });
+    const client = new Client({ name: "itx-mcp-client", version: "1.0.0" });
+    await client.connect(transport);
+
+    try {
+      if (input.path.join(".") === "listTools") {
+        const listed = await client.listTools();
+        return describeOutboundMcpFromOurClientTools(
+          listed.tools.map((tool) => ({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.inputSchema as Record<string, unknown> | undefined,
+          })),
+        );
+      }
+      return await executeOutboundMcpFromOurClientToolFunction({
+        args: input.args,
+        client,
+        path: input.path,
+      });
+    } finally {
+      await client.close().catch(() => {});
+    }
+  }
+}

--- a/apps/os/src/itx/e2e/itx.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx.e2e.test.ts
@@ -123,6 +123,7 @@ test("the five-step capability flow: provide live, call, promote durable, call f
 test("platform bindings are dialable capabilities (raw + wrapped)", async () => {
   using itx = connectGlobal();
   const project = (await itx.projects.create({ slug: `${PROJECT_SLUG}-ai` })) as { id: string };
+  createdProjectIds.push(project.id);
   using projectItx = await itx.projects.get(project.id);
 
   // (1) Raw binding ref: env.AI itself is the target; members replay applies
@@ -189,6 +190,7 @@ test.skipIf(!MCP_TEST_SERVER_URL)(
   async () => {
     using itx = connectGlobal();
     const project = (await itx.projects.create({ slug: `${PROJECT_SLUG}-mcp` })) as { id: string };
+    createdProjectIds.push(project.id);
     using projectItx = await itx.projects.get(project.id);
 
     await projectItx.caps.define({

--- a/apps/os/src/itx/e2e/itx.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx.e2e.test.ts
@@ -176,6 +176,46 @@ test("platform bindings are dialable capabilities (raw + wrapped)", async () => 
   ]);
 });
 
+// A remote MCP server to test against: explicit env wins; otherwise the mock
+// provider worker (same source the inbound-MCP e2e suite uses), if deployed.
+const MCP_TEST_SERVER_URL =
+  process.env.OS_E2E_MCP_SERVER_URL?.trim() ||
+  (process.env.MOCK_PROVIDER_BASE_URL
+    ? `${process.env.MOCK_PROVIDER_BASE_URL.replace(/\/+$/, "")}/mcp`
+    : "");
+
+test.skipIf(!MCP_TEST_SERVER_URL)(
+  "the first-party McpClient cap bridges a remote MCP server",
+  async () => {
+    using itx = connectGlobal();
+    const project = (await itx.projects.create({ slug: `${PROJECT_SLUG}-mcp` })) as { id: string };
+    using projectItx = await itx.projects.get(project.id);
+
+    await projectItx.caps.define({
+      invoke: "path-call",
+      meta: { instructions: "Test MCP server. Call listTools() first." },
+      name: "mcptest",
+      target: {
+        entrypoint: "McpClient",
+        props: { serverUrl: MCP_TEST_SERVER_URL },
+        type: "rpc",
+        worker: { type: "loopback" },
+      },
+    });
+
+    const handle = projectItx as never as Record<string, any>;
+    const listed = (await handle.mcptest.listTools()) as { tools: { name: string }[] };
+    expect(Array.isArray(listed.tools)).toBe(true);
+    expect(listed.tools.length).toBeGreaterThan(0);
+
+    // Call the first listed tool with empty args — the mock provider's tools
+    // are unary echoes; any structured result proves the bridge end to end.
+    const firstTool = listed.tools[0]!.name;
+    const result = await handle.mcptest[firstTool]({});
+    expect(result).toBeDefined();
+  },
+);
+
 test("worker caps hold a correctly scoped itx of their own", async () => {
   using itx = connectGlobal();
   const project = (await itx.projects.create({ slug: `${PROJECT_SLUG}-todo` })) as { id: string };

--- a/apps/os/src/itx/entrypoint.ts
+++ b/apps/os/src/itx/entrypoint.ts
@@ -67,11 +67,10 @@ export async function resolveItx(input: {
  */
 export class ItxEntrypoint extends WorkerEntrypoint<Env, ItxProps> {
   get context(): Promise<Itx> {
-    const workerCtx = Reflect.get(this, "ctx") as ExecutionContext<ItxProps>;
     return resolveItx({
       env: this.env,
-      exports: workerCtx.exports as unknown as ItxRuntime["exports"],
-      props: workerCtx.props,
+      exports: this.ctx.exports as unknown as ItxRuntime["exports"],
+      props: this.ctx.props,
     });
   }
 }
@@ -93,7 +92,7 @@ export type ProjectEgressProps = {
  */
 export class ProjectEgress extends WorkerEntrypoint<Env, ProjectEgressProps> {
   async fetch(request: Request): Promise<Response> {
-    const props = (Reflect.get(this, "ctx") as ExecutionContext<ProjectEgressProps>).props;
+    const props = this.ctx.props;
     return await this.env.PROJECT.getByName(getProjectDurableObjectName(props.project)).egressFetch(
       request,
     );
@@ -122,7 +121,7 @@ export type BindingCapabilityProps = {
  */
 export class BindingCapability extends WorkerEntrypoint<Env, BindingCapabilityProps> {
   async call(input: PathCall): Promise<unknown> {
-    const props = (Reflect.get(this, "ctx") as ExecutionContext<BindingCapabilityProps>).props;
+    const props = this.ctx.props;
     if (!DIALABLE_BINDINGS.has(props.binding)) {
       throw new Error(`Binding "${props.binding}" is not dialable as a capability.`);
     }

--- a/apps/os/src/itx/http.ts
+++ b/apps/os/src/itx/http.ts
@@ -94,7 +94,7 @@ export type ItxCapIngressProps = {
  */
 export class ItxCapIngress extends WorkerEntrypoint<Env, ItxCapIngressProps> {
   async fetch(request: Request): Promise<Response> {
-    const props = (Reflect.get(this, "ctx") as ExecutionContext<ItxCapIngressProps>).props;
+    const props = this.ctx.props;
     const config = parseConfig(this.env);
     const project = this.env.PROJECT.getByName(getProjectDurableObjectName(props.projectId));
 

--- a/apps/os/src/itx/protocol.ts
+++ b/apps/os/src/itx/protocol.ts
@@ -121,7 +121,7 @@ export type SerializableCapTarget =
  * (fail fast) and again at dial time (authoritative).
  */
 export const DIALABLE_BINDINGS: ReadonlySet<string> = new Set(["AI"]);
-export const DIALABLE_LOOPBACKS: ReadonlySet<string> = new Set(["BindingCapability"]);
+export const DIALABLE_LOOPBACKS: ReadonlySet<string> = new Set(["BindingCapability", "McpClient"]);
 
 /**
  * Normalize a define() input to a serializable target. Legacy callers pass

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -52,6 +52,7 @@ export { AiCapability, OrpcCapability } from "~/domains/codemode/example-capabil
 export { FetchCapability } from "~/domains/codemode/fetch-capability.ts";
 export { GmailCapability } from "~/domains/google/entrypoints/gmail-capability.ts";
 export { BindingCapability, ItxEntrypoint, ProjectEgress } from "~/itx/entrypoint.ts";
+export { McpClient } from "~/itx/caps/mcp-client.ts";
 export { ContextDO } from "~/itx/context-do.ts";
 export { ItxCapIngress } from "~/itx/http.ts";
 export { OpenApiBridge } from "~/rpc-targets/openapi-bridge.ts";


### PR DESCRIPTION
Stacks on the merged CapTarget kernel (#1436). Part of the codemode rip-out sequence (itx-next.md §4).

## What

The first-party half of the §1 litmus test: **MCP is a client implementation, not a transport** — so it's an ordinary loopback-dialable RPC target, parameterized per server:

```ts
await itx.caps.define({
  invoke: "path-call",
  name: "docs",
  target: {
    type: "rpc",
    worker: { type: "loopback" },
    entrypoint: "McpClient",
    props: {
      serverUrl: "https://docs.example.com/mcp",
      headers: { authorization: 'Bearer getSecret({ key: "DOCS_TOKEN" })' },
    },
  },
});

await itx.docs.listTools();
await itx.docs.someToolName({ ... });
```

- **All transport HTTP rides project egress** via the cap's own itx handle (the MCP SDK's custom-`fetch` option), so header values may carry `getSecret()` placeholders — substitution happens in the Project DO, the credential never exists in the isolate (Law 5).
- **Stateless by design**: connect → call → close per invocation. When handshake latency matters, the same class becomes a `durable-object` ref without changing callers (the connection-caching pattern of the old `OutboundMcpFromOurClientCapability` DO).
- `listTools()` is an ordinary call, not a special discovery protocol — same convention the codemode provider used.
- Added to `DIALABLE_LOOPBACKS`; result shaping reuses the existing `outbound-mcp-from-our-client-capability-core` helpers.

In the upcoming codemode-drop PR this replaces `connectToMcpServer` and `createOutboundMcpFromOurClientToolProviderRegistration`.

## Testing

typecheck / lint / format / unit green. New e2e test (`itx.e2e.test.ts`) defines an McpClient cap, lists tools, and calls the first one — gated on `OS_E2E_MCP_SERVER_URL` or `MOCK_PROVIDER_BASE_URL` (skips when no MCP server is reachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands dialable loopback surface and routes all MCP HTTP through project egress; behavior is gated by existing allowlists and attribution checks but affects outbound networking for defined caps.
> 
> **Overview**
> Adds a first-party **`McpClient`** loopback RPC capability so projects can define remote MCP servers as ordinary `path-call` caps (`listTools()` plus dotted tool calls). Each invocation is **connect → call → close**; transport HTTP is forced through **`itx.fetch`** (project egress) so header secrets resolve in the Project DO, and tool listing/execution reuse the existing outbound MCP core helpers.
> 
> **`McpClient`** is allowlisted in **`DIALABLE_LOOPBACKS`** and exported from the main worker. Several itx entrypoints switch from **`Reflect.get(this, "ctx")`** to **`this.ctx.props`**. E2E gains a skipped-when-no-server test that defines an **`McpClient`** cap and exercises list/call, plus **`createdProjectIds`** cleanup for the AI bindings test project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 236953da701399b35300d23cc79c0a728f536743. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T13:56:08.912Z",
      "headSha": "236953da701399b35300d23cc79c0a728f536743",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27280672268",
      "shortSha": "236953d"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `236953d`
Preview: https://os.iterate-preview-5.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27280672268)
Updated: 2026-06-10T13:56:08.912Z
<!-- /CLOUDFLARE_PREVIEW -->