### PR TITLE
itx: execution events — two-event durable record for script runs

### DIFF
--- a/apps/os/src/itx/e2e/itx.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx.e2e.test.ts
@@ -218,6 +218,43 @@ test.skipIf(!MCP_TEST_SERVER_URL)(
   },
 );
 
+test("script executions leave a two-event record on the /itx stream", async () => {
+  using itx = connectGlobal();
+  const project = (await itx.projects.create({ slug: `${PROJECT_SLUG}-rec` })) as { id: string };
+
+  const response = await fetch(new URL("/api/itx/run", baseUrl()), {
+    body: JSON.stringify({
+      context: project.id,
+      functionSource: "async ({ vars }) => vars.a + vars.b",
+      vars: { a: 40, b: 2 },
+    }),
+    headers: authHeaders(),
+    method: "POST",
+  });
+  const body = (await response.json()) as { executionId: string; result: unknown };
+  expect(response.ok).toBe(true);
+  expect(body.result).toBe(42);
+  expect(typeof body.executionId).toBe("string");
+
+  using projectItx = await itx.projects.get(project.id);
+  const events = (await projectItx.streams.get("/itx").read()) as Array<{
+    payload: Record<string, unknown>;
+    type: string;
+  }>;
+  const requested = events.find(
+    (event) =>
+      event.type === "events.iterate.com/itx/execution-requested" &&
+      event.payload.executionId === body.executionId,
+  );
+  const completed = events.find(
+    (event) =>
+      event.type === "events.iterate.com/itx/execution-completed" &&
+      event.payload.executionId === body.executionId,
+  );
+  expect(requested?.payload).toMatchObject({ context: project.id });
+  expect(completed?.payload).toMatchObject({ ok: true, result: 42 });
+});
+
 test("worker caps hold a correctly scoped itx of their own", async () => {
   using itx = connectGlobal();
   const project = (await itx.projects.create({ slug: `${PROJECT_SLUG}-todo` })) as { id: string };

--- a/apps/os/src/itx/e2e/itx.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx.e2e.test.ts
@@ -221,6 +221,7 @@ test.skipIf(!MCP_TEST_SERVER_URL)(
 test("script executions leave a two-event record on the /itx stream", async () => {
   using itx = connectGlobal();
   const project = (await itx.projects.create({ slug: `${PROJECT_SLUG}-rec` })) as { id: string };
+  createdProjectIds.push(project.id);
 
   const response = await fetch(new URL("/api/itx/run", baseUrl()), {
     body: JSON.stringify({

--- a/apps/os/src/itx/fetch.ts
+++ b/apps/os/src/itx/fetch.ts
@@ -11,6 +11,7 @@
 
 import { newWorkersRpcResponse } from "capnweb";
 import { resolveItx } from "./entrypoint.ts";
+import { runItxScript } from "./run.ts";
 import {
   GLOBAL_CONTEXT_ID,
   isChildContextId,
@@ -177,34 +178,10 @@ async function resolveAccessibleContextId(input: {
 
 // ---- /api/itx/run ----------------------------------------------------------
 //
-// The dumb harness: load a one-off isolate whose env.ITERATE is an
-// ItxEntrypoint, call the provided function with { itx, vars }, JSON the
-// result. No fetch monkeypatching — when the script runs against a project
-// context, bare fetch() IS project egress via globalOutbound (Law 5).
-
-function itxRunWorkerSource(functionSource: string) {
-  return /* js */ `
-    import { WorkerEntrypoint } from "cloudflare:workers";
-
-    const script = (${functionSource});
-
-    export default class extends WorkerEntrypoint {
-      async run(vars) {
-        try {
-          const itx = await this.env.ITERATE.context;
-          const result = await script({ itx, vars });
-          return JSON.stringify({ ok: true, result });
-        } catch (error) {
-          return JSON.stringify({
-            error: error instanceof Error ? error.message : String(error),
-            ok: false,
-            stack: error instanceof Error ? error.stack : undefined,
-          });
-        }
-      }
-    }
-  `;
-}
+// Thin HTTP shim over the shared runner (run.ts): resolve + access-check the
+// target context here (Law 3 — this is the auth boundary), then delegate.
+// The runner leaves the two-event execution record on the project's /itx
+// stream; the HTTP response carries the executionId so callers can correlate.
 
 async function handleItxRun(input: {
   access: ProjectAccess;
@@ -239,57 +216,27 @@ async function handleItxRun(input: {
     scriptProjectId = resolved.projectId;
   } else {
     // A global-context script inherits the platform's own egress (no
-    // per-project globalOutbound below), so it is admin-only — same rule as
-    // the global connect handle.
+    // per-project globalOutbound), so it is admin-only — same rule as the
+    // global connect handle.
     if (input.access !== "all") return Response.json({ error: "Forbidden" }, { status: 403 });
     props = { access: input.access, context: GLOBAL_CONTEXT_ID };
   }
 
-  const exports = workerExports(input.context) as Record<
-    string,
-    (options: { props: Record<string, unknown> }) => unknown
-  >;
-  const worker = input.env.LOADER.load({
-    compatibilityDate: "2026-04-27",
-    env: {
-      ITERATE: exports.ItxEntrypoint!({ props }),
-    },
-    // Project scripts get the egress pipe as their global fetch; global
-    // scripts inherit the parent's network (they are admin-held by
-    // construction — only connect-time auth mints global handles).
-    ...(scriptProjectId !== null
-      ? {
-          globalOutbound: exports.ProjectEgress!({
-            props: { context: props.context, project: scriptProjectId },
-          }) as Fetcher,
-        }
-      : {}),
-    mainModule: "itx-script.js",
-    modules: { "itx-script.js": itxRunWorkerSource(body.functionSource) },
+  const outcome = await runItxScript({
+    env: input.env,
+    exports: workerExports(input.context),
+    functionSource: body.functionSource,
+    projectId: scriptProjectId,
+    props,
+    vars: body.vars,
   });
-
-  const entrypoint = worker.getEntrypoint() as unknown as {
-    run(vars: Record<string, unknown>): Promise<string>;
-  } & Partial<Disposable>;
-  try {
-    const outcome = JSON.parse(await entrypoint.run(body.vars ?? {})) as
-      | { ok: true; result: unknown }
-      | { error: string; ok: false; stack?: string };
-    if (!outcome.ok) {
-      return Response.json({ error: outcome.error, stack: outcome.stack }, { status: 500 });
-    }
-    return Response.json({ result: outcome.result ?? null });
-  } catch (error) {
+  if (!outcome.ok) {
     return Response.json(
-      {
-        error: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      },
+      { error: outcome.error, executionId: outcome.executionId, stack: outcome.stack },
       { status: 500 },
     );
-  } finally {
-    entrypoint[Symbol.dispose]?.();
   }
+  return Response.json({ executionId: outcome.executionId, result: outcome.result ?? null });
 }
 
 function workerExports(context: RequestContext): ItxRuntime["exports"] {

--- a/apps/os/src/itx/protocol.ts
+++ b/apps/os/src/itx/protocol.ts
@@ -323,6 +323,15 @@ export const ITX_EVENT_TYPES = {
   capRevoked: "events.iterate.com/itx/cap-revoked",
   capDisconnected: "events.iterate.com/itx/cap-disconnected",
   contextForked: "events.iterate.com/itx/context-forked",
+  /**
+   * Script execution record (itx-next.md §4, record-only mode): the runner
+   * appends `executionRequested` before the script starts and
+   * `executionCompleted` when it settles. The events are the durable record,
+   * not the transport — everything between them is invisible to the stream.
+   * These two events replace codemode's six-event execution protocol.
+   */
+  executionRequested: "events.iterate.com/itx/execution-requested",
+  executionCompleted: "events.iterate.com/itx/execution-completed",
 } as const;
 
 /** Child context ids: `ctx_…` TypeIDs; project contexts use the project id. */

--- a/apps/os/src/itx/run.ts
+++ b/apps/os/src/itx/run.ts
@@ -24,10 +24,12 @@ import {
   type StreamDurableObjectNamespace,
 } from "~/domains/streams/new-stream-runtime.ts";
 
-export type ItxScriptOutcome = { executionId: string; durationMs: number } & (
-  | { ok: true; result: unknown }
-  | { ok: false; error: string; stack?: string }
-);
+export type ItxScriptOutcome = {
+  executionId: string;
+  durationMs: number;
+  /** console.log/warn/error lines captured from the script's isolate. */
+  logs: string[];
+} & ({ ok: true; result: unknown } | { ok: false; error: string; stack?: string });
 
 /** Keep stream payloads bounded; the full value still returns to the caller. */
 const MAX_RECORDED_RESULT_CHARS = 64_000;
@@ -40,6 +42,10 @@ export async function runItxScript(input: {
   /** The owning project; null only for global-context scripts (no egress
    * pipe, no event record — admin-only by construction). */
   projectId: string | null;
+  /** Where the two-event record lands. Defaults to the owning project's
+   * /itx stream; callers whose loop lives on another stream (e.g. an agent
+   * reading completions off its own stream) point this there. */
+  record?: { namespace: string; path: string };
   functionSource: string;
   vars?: Record<string, unknown>;
 }): Promise<ItxScriptOutcome> {
@@ -48,8 +54,11 @@ export async function runItxScript(input: {
 
   const executionId = crypto.randomUUID();
   const startedAtMs = Date.now();
+  const record =
+    input.record ??
+    (input.projectId === null ? null : { namespace: input.projectId, path: ITX_AUDIT_STREAM_PATH });
 
-  await recordExecutionEvent(input, {
+  await recordExecutionEvent(input.env, record, {
     type: ITX_EVENT_TYPES.executionRequested,
     payload: {
       code: input.functionSource,
@@ -88,15 +97,22 @@ export async function runItxScript(input: {
 
   let outcome: ItxScriptOutcome;
   try {
-    const raw = JSON.parse(await entrypoint.run(input.vars ?? {})) as
+    const raw = JSON.parse(await entrypoint.run(input.vars ?? {})) as { logs?: string[] } & (
       | { ok: true; result: unknown }
-      | { error: string; ok: false; stack?: string };
-    outcome = { ...raw, durationMs: Date.now() - startedAtMs, executionId };
+      | { error: string; ok: false; stack?: string }
+    );
+    outcome = {
+      ...raw,
+      durationMs: Date.now() - startedAtMs,
+      executionId,
+      logs: raw.logs ?? [],
+    };
   } catch (error) {
     outcome = {
       durationMs: Date.now() - startedAtMs,
       error: error instanceof Error ? error.message : String(error),
       executionId,
+      logs: [],
       ok: false,
       stack: error instanceof Error ? error.stack : undefined,
     };
@@ -104,12 +120,13 @@ export async function runItxScript(input: {
     entrypoint[Symbol.dispose]?.();
   }
 
-  await recordExecutionEvent(input, {
+  await recordExecutionEvent(input.env, record, {
     type: ITX_EVENT_TYPES.executionCompleted,
     payload: {
       context: input.props.context,
       durationMs: outcome.durationMs,
       executionId,
+      ...(outcome.logs.length > 0 ? { logs: outcome.logs.slice(0, 200) } : {}),
       ok: outcome.ok,
       ...(outcome.ok
         ? { result: boundRecordedResult(outcome.result) }
@@ -126,15 +143,29 @@ function itxRunWorkerSource(functionSource: string) {
 
     const script = (${functionSource});
 
+    const logs = [];
+    const stringify = (value) => {
+      if (typeof value === "string") return value;
+      try { return JSON.stringify(value) ?? String(value); } catch { return String(value); }
+    };
+    for (const level of ["log", "warn", "error"]) {
+      const original = console[level].bind(console);
+      console[level] = (...args) => {
+        if (logs.length < 200) logs.push("[" + level + "] " + args.map(stringify).join(" "));
+        original(...args);
+      };
+    }
+
     export default class extends WorkerEntrypoint {
       async run(vars) {
         try {
           const itx = await this.env.ITERATE.context;
           const result = await script({ itx, vars });
-          return JSON.stringify({ ok: true, result });
+          return JSON.stringify({ logs, ok: true, result });
         } catch (error) {
           return JSON.stringify({
             error: error instanceof Error ? error.message : String(error),
+            logs,
             ok: false,
             stack: error instanceof Error ? error.stack : undefined,
           });
@@ -145,15 +176,16 @@ function itxRunWorkerSource(functionSource: string) {
 }
 
 async function recordExecutionEvent(
-  input: { env: Env; projectId: string | null },
+  env: Env,
+  record: { namespace: string; path: string } | null,
   event: { type: string; payload: Record<string, unknown> },
 ): Promise<void> {
-  if (input.projectId === null) return; // global scripts have no project stream
+  if (record === null) return; // global scripts have no project stream
   try {
     const stream = await getInitializedStreamStub({
-      durableObjectNamespace: input.env.STREAM as unknown as StreamDurableObjectNamespace,
-      namespace: input.projectId,
-      path: StreamPath.parse(ITX_AUDIT_STREAM_PATH),
+      durableObjectNamespace: env.STREAM as unknown as StreamDurableObjectNamespace,
+      namespace: record.namespace,
+      path: StreamPath.parse(record.path),
     });
     await stream.append(event);
   } catch (error) {

--- a/apps/os/src/itx/run.ts
+++ b/apps/os/src/itx/run.ts
@@ -1,0 +1,176 @@
+// The itx script runner (record-only mode, itx-next.md §4).
+//
+// One function runs a script in a loader isolate against a context and
+// leaves a durable two-event record on the owning project's /itx stream:
+//
+//   events.iterate.com/itx/execution-requested   { executionId, code, vars, context }
+//   events.iterate.com/itx/execution-completed   { executionId, ok, result|error, durationMs, context }
+//
+// The events are the RECORD, not the transport: callers get the outcome from
+// the return value; everything between the two events is invisible to the
+// stream. (This pair replaces codemode's six-event execution protocol.)
+// Appends are best-effort, matching the registry's audit posture (D1: the
+// caller-visible outcome is authoritative; the stream is history).
+//
+// No fetch monkeypatching — when the script runs against a project context,
+// bare fetch() IS project egress via globalOutbound (Law 5).
+
+import { StreamPath } from "@iterate-com/shared/streams/types";
+import type { ItxRuntime } from "./handle.ts";
+import { ITX_AUDIT_STREAM_PATH, ITX_EVENT_TYPES } from "./protocol.ts";
+import type { ItxProps } from "./protocol.ts";
+import {
+  getInitializedStreamStub,
+  type StreamDurableObjectNamespace,
+} from "~/domains/streams/new-stream-runtime.ts";
+
+export type ItxScriptOutcome = { executionId: string; durationMs: number } & (
+  | { ok: true; result: unknown }
+  | { ok: false; error: string; stack?: string }
+);
+
+/** Keep stream payloads bounded; the full value still returns to the caller. */
+const MAX_RECORDED_RESULT_CHARS = 64_000;
+
+export async function runItxScript(input: {
+  env: Env;
+  exports: ItxRuntime["exports"];
+  /** Already access-checked by the caller (connect-time auth, Law 3). */
+  props: ItxProps;
+  /** The owning project; null only for global-context scripts (no egress
+   * pipe, no event record — admin-only by construction). */
+  projectId: string | null;
+  functionSource: string;
+  vars?: Record<string, unknown>;
+}): Promise<ItxScriptOutcome> {
+  const loader = input.env.LOADER;
+  if (!loader) throw new Error("LOADER binding not available");
+
+  const executionId = crypto.randomUUID();
+  const startedAtMs = Date.now();
+
+  await recordExecutionEvent(input, {
+    type: ITX_EVENT_TYPES.executionRequested,
+    payload: {
+      code: input.functionSource,
+      context: input.props.context,
+      executionId,
+      vars: input.vars ?? {},
+    },
+  });
+
+  const exports = input.exports as unknown as Record<
+    string,
+    (options: { props: Record<string, unknown> }) => unknown
+  >;
+  const worker = loader.load({
+    compatibilityDate: "2026-04-27",
+    env: {
+      ITERATE: exports.ItxEntrypoint!({ props: input.props as Record<string, unknown> }),
+    },
+    // Project scripts get the egress pipe as their global fetch; global
+    // scripts inherit the parent's network (they are admin-held by
+    // construction — only connect-time auth mints global handles).
+    ...(input.projectId !== null
+      ? {
+          globalOutbound: exports.ProjectEgress!({
+            props: { context: input.props.context, project: input.projectId },
+          }) as Fetcher,
+        }
+      : {}),
+    mainModule: "itx-script.js",
+    modules: { "itx-script.js": itxRunWorkerSource(input.functionSource) },
+  });
+
+  const entrypoint = worker.getEntrypoint() as unknown as {
+    run(vars: Record<string, unknown>): Promise<string>;
+  } & Partial<Disposable>;
+
+  let outcome: ItxScriptOutcome;
+  try {
+    const raw = JSON.parse(await entrypoint.run(input.vars ?? {})) as
+      | { ok: true; result: unknown }
+      | { error: string; ok: false; stack?: string };
+    outcome = { ...raw, durationMs: Date.now() - startedAtMs, executionId };
+  } catch (error) {
+    outcome = {
+      durationMs: Date.now() - startedAtMs,
+      error: error instanceof Error ? error.message : String(error),
+      executionId,
+      ok: false,
+      stack: error instanceof Error ? error.stack : undefined,
+    };
+  } finally {
+    entrypoint[Symbol.dispose]?.();
+  }
+
+  await recordExecutionEvent(input, {
+    type: ITX_EVENT_TYPES.executionCompleted,
+    payload: {
+      context: input.props.context,
+      durationMs: outcome.durationMs,
+      executionId,
+      ok: outcome.ok,
+      ...(outcome.ok
+        ? { result: boundRecordedResult(outcome.result) }
+        : { error: outcome.error, stack: outcome.stack }),
+    },
+  });
+
+  return outcome;
+}
+
+function itxRunWorkerSource(functionSource: string) {
+  return /* js */ `
+    import { WorkerEntrypoint } from "cloudflare:workers";
+
+    const script = (${functionSource});
+
+    export default class extends WorkerEntrypoint {
+      async run(vars) {
+        try {
+          const itx = await this.env.ITERATE.context;
+          const result = await script({ itx, vars });
+          return JSON.stringify({ ok: true, result });
+        } catch (error) {
+          return JSON.stringify({
+            error: error instanceof Error ? error.message : String(error),
+            ok: false,
+            stack: error instanceof Error ? error.stack : undefined,
+          });
+        }
+      }
+    }
+  `;
+}
+
+async function recordExecutionEvent(
+  input: { env: Env; projectId: string | null },
+  event: { type: string; payload: Record<string, unknown> },
+): Promise<void> {
+  if (input.projectId === null) return; // global scripts have no project stream
+  try {
+    const stream = await getInitializedStreamStub({
+      durableObjectNamespace: input.env.STREAM as unknown as StreamDurableObjectNamespace,
+      namespace: input.projectId,
+      path: StreamPath.parse(ITX_AUDIT_STREAM_PATH),
+    });
+    await stream.append(event);
+  } catch (error) {
+    console.error(`[itx] execution event append failed (${event.type}):`, error);
+  }
+}
+
+function boundRecordedResult(result: unknown): unknown {
+  try {
+    const serialized = JSON.stringify(result);
+    if (serialized === undefined || serialized.length <= MAX_RECORDED_RESULT_CHARS) return result;
+    return {
+      __truncated: true,
+      chars: serialized.length,
+      preview: serialized.slice(0, MAX_RECORDED_RESULT_CHARS),
+    };
+  } catch {
+    return { __truncated: true, reason: "unserializable" };
+  }
+}

--- a/apps/os/src/itx/run.ts
+++ b/apps/os/src/itx/run.ts
@@ -72,31 +72,38 @@ export async function runItxScript(input: {
     string,
     (options: { props: Record<string, unknown> }) => unknown
   >;
-  const worker = loader.load({
-    compatibilityDate: "2026-04-27",
-    env: {
-      ITERATE: exports.ItxEntrypoint!({ props: input.props as Record<string, unknown> }),
-    },
-    // Project scripts get the egress pipe as their global fetch; global
-    // scripts inherit the parent's network (they are admin-held by
-    // construction — only connect-time auth mints global handles).
-    ...(input.projectId !== null
-      ? {
-          globalOutbound: exports.ProjectEgress!({
-            props: { context: input.props.context, project: input.projectId },
-          }) as Fetcher,
-        }
-      : {}),
-    mainModule: "itx-script.js",
-    modules: { "itx-script.js": itxRunWorkerSource(input.functionSource) },
-  });
-
-  const entrypoint = worker.getEntrypoint() as unknown as {
-    run(vars: Record<string, unknown>): Promise<string>;
-  } & Partial<Disposable>;
 
   let outcome: ItxScriptOutcome;
+  let entrypoint:
+    | ({ run(vars: Record<string, unknown>): Promise<string> } & Partial<Disposable>)
+    | undefined;
+  // One try/catch from loading through running: a loader failure must still
+  // produce an ok:false outcome (and the matching completed event) — never a
+  // throw that leaves a dangling execution-requested record.
   try {
+    const worker = loader.load({
+      compatibilityDate: "2026-04-27",
+      env: {
+        ITERATE: exports.ItxEntrypoint!({ props: input.props as Record<string, unknown> }),
+      },
+      // Project scripts get the egress pipe as their global fetch; global
+      // scripts inherit the parent's network (they are admin-held by
+      // construction — only connect-time auth mints global handles).
+      ...(input.projectId !== null
+        ? {
+            globalOutbound: exports.ProjectEgress!({
+              props: { context: input.props.context, project: input.projectId },
+            }) as Fetcher,
+          }
+        : {}),
+      mainModule: "itx-script.js",
+      modules: { "itx-script.js": itxRunWorkerSource(input.functionSource) },
+    });
+
+    entrypoint = worker.getEntrypoint() as unknown as {
+      run(vars: Record<string, unknown>): Promise<string>;
+    } & Partial<Disposable>;
+
     const raw = JSON.parse(await entrypoint.run(input.vars ?? {})) as { logs?: string[] } & (
       | { ok: true; result: unknown }
       | { error: string; ok: false; stack?: string }
@@ -117,7 +124,7 @@ export async function runItxScript(input: {
       stack: error instanceof Error ? error.stack : undefined,
     };
   } finally {
-    entrypoint[Symbol.dispose]?.();
+    entrypoint?.[Symbol.dispose]?.();
   }
 
   await recordExecutionEvent(input.env, record, {


### PR DESCRIPTION
Stacked on #1441 (McpClient). Part of the codemode rip-out sequence (itx-next.md §4).

## What

The two-event execution record that replaces codemode's six-event protocol:

- `events.iterate.com/itx/execution-requested` `{ executionId, code, vars, context }`
- `events.iterate.com/itx/execution-completed` `{ executionId, ok, result | error+stack, durationMs, context }`

Both land on the owning project's `/itx` stream (D9-consistent: context id in the payload).

**Record-only mode**: the events are the durable history, not the transport — callers get the outcome from the return value/HTTP response, and everything between the two events is invisible to the stream. Appends are best-effort, matching the registry's audit posture. Recorded results are bounded (64k chars, truncated with a preview beyond that); the full value still returns to the caller.

Mechanically: the loader harness moves out of `fetch.ts` into a shared `src/itx/run.ts` (`runItxScript()`), `/api/itx/run` becomes a thin resolve-and-delegate shim, and the response now includes the `executionId` for correlation. Global-context scripts record no events (no owning project stream).

The shared runner is the function the upcoming codemode-drop PR points the inbound-MCP `exec_js` and agent execution paths at.

## Testing

typecheck / lint / format green. New e2e test runs a script via `/api/itx/run` and asserts both events land on the `/itx` stream with the returned `executionId` and the correct outcome payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dynamic code execution and stream audit payloads; auth stays at the existing `/api/itx/run` boundary, but execution records and API response shape change for all script runs.
> 
> **Overview**
> Introduces **record-only** script execution auditing: each project-context run appends **`execution-requested`** then **`execution-completed`** on the project **`/itx`** stream (replacing codemode’s six-event protocol), while callers still get the outcome from the HTTP/return value.
> 
> The loader harness moves from **`fetch.ts`** into shared **`runItxScript()`** in **`run.ts`**; **`POST /api/itx/run`** only resolves access and delegates. Responses now include **`executionId`** (and on errors too) for correlation. The runner captures isolate **console** lines, **truncates** large results on the stream (64k), always emits **completed** even on loader failures, and skips stream writes for **global** (admin-only) scripts.
> 
> A new e2e test runs a script via **`/api/itx/run`** and asserts both events match the returned **`executionId`** and result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f43fee8b69ae70c6889cdd236fd568c1eab9b671. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T14:07:32.827Z",
      "headSha": "f43fee8b69ae70c6889cdd236fd568c1eab9b671",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27281391307",
      "shortSha": "f43fee8"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-06-10T14:07:20.109Z",
      "headSha": "f43fee8b69ae70c6889cdd236fd568c1eab9b671",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27281391307",
      "shortSha": "f43fee8"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `f43fee8`
Preview: https://os.iterate-preview-7.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27281391307)
Updated: 2026-06-10T14:07:32.827Z

### Semaphore
Status: released
Commit: `f43fee8`
Preview: https://semaphore.iterate-preview-7.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27281391307)
Updated: 2026-06-10T14:07:20.109Z
<!-- /CLOUDFLARE_PREVIEW -->