### PR TITLE
[codex] Add runtime stream tree explorer

### DIFF
--- a/apps/os/src/components/path-breadcrumbs.tsx
+++ b/apps/os/src/components/path-breadcrumbs.tsx
@@ -15,7 +15,7 @@ import { EventsStreamPathLabel } from "@iterate-com/ui/components/events/stream-
 import { Input } from "@iterate-com/ui/components/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@iterate-com/ui/components/popover";
 import { toast } from "@iterate-com/ui/components/sonner";
-import { useProjectStreamsList } from "~/lib/itx-queries.ts";
+import { useProjectStreamState } from "~/lib/itx-queries.ts";
 import type {
   RouteBreadcrumbLoaderData,
   RouteBreadcrumbStaticData,
@@ -179,15 +179,16 @@ function StreamSegmentNavigator({
 }) {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
-  const streamsQuery = useProjectStreamsList(streamBreadcrumb.projectId);
+  const parentPath = streamPathParent(segmentPath);
+  const parentStateQuery = useProjectStreamState({
+    projectId: streamBreadcrumb.projectId,
+    streamPath: parentPath,
+  });
   const siblingPaths = useMemo(() => {
-    const parentPath = streamPathParent(segmentPath);
-    const paths = (streamsQuery.data ?? [])
-      .map((stream) => stream.streamPath)
-      .filter((path) => isImmediateChild({ childPath: path, parentPath }));
+    const paths = [...(parentStateQuery.data?.childPaths ?? [])];
     if (!paths.includes(segmentPath)) paths.push(segmentPath);
     return paths.toSorted((left, right) => left.localeCompare(right));
-  }, [segmentPath, streamsQuery.data]);
+  }, [parentStateQuery.data?.childPaths, segmentPath]);
 
   function navigateToSibling(path: StreamPathType) {
     setOpen(false);
@@ -240,16 +241,16 @@ function StreamChildrenBreadcrumb({
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
   const [newChildSegment, setNewChildSegment] = useState("");
-  const streamsQuery = useProjectStreamsList(streamBreadcrumb.projectId);
+  const streamStateQuery = useProjectStreamState({
+    projectId: streamBreadcrumb.projectId,
+    streamPath: streamBreadcrumb.streamPath,
+  });
   const children = useMemo(
     () =>
-      (streamsQuery.data ?? []).filter((stream) =>
-        isImmediateChild({
-          childPath: stream.streamPath,
-          parentPath: streamBreadcrumb.streamPath,
-        }),
+      [...(streamStateQuery.data?.childPaths ?? [])].toSorted((left, right) =>
+        left.localeCompare(right),
       ),
-    [streamsQuery.data, streamBreadcrumb.streamPath],
+    [streamStateQuery.data?.childPaths],
   );
 
   function navigateToChild(childPath: StreamPathType) {
@@ -315,14 +316,14 @@ function StreamChildrenBreadcrumb({
                   No children yet
                 </p>
               ) : (
-                children.map((child) => (
+                children.map((childPath) => (
                   <button
-                    key={child.name}
+                    key={childPath}
                     type="button"
                     className="flex w-full items-center rounded-md px-2 py-1.5 text-left font-mono text-xs outline-hidden select-none hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground"
-                    onClick={() => navigateToChild(child.streamPath)}
+                    onClick={() => navigateToChild(childPath)}
                   >
-                    /{getStreamSegmentLabel(child.streamPath)}
+                    /{getStreamSegmentLabel(childPath)}
                   </button>
                 ))
               )}
@@ -336,15 +337,4 @@ function StreamChildrenBreadcrumb({
 
 function getStreamSegmentLabel(path: StreamPathType) {
   return path === "/" ? "/" : (path.split("/").at(-1) ?? path);
-}
-
-function isImmediateChild(input: { parentPath: StreamPathType; childPath: StreamPathType }) {
-  if (input.childPath === input.parentPath) return false;
-  if (input.parentPath === "/") {
-    return input.childPath.split("/").filter(Boolean).length === 1;
-  }
-
-  const prefix = `${input.parentPath}/`;
-  if (!input.childPath.startsWith(prefix)) return false;
-  return input.childPath.slice(prefix.length).split("/").filter(Boolean).length === 1;
 }

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -65,6 +65,11 @@ type ProjectStreamMessageComposer = {
 };
 
 type ProjectStreamViewTab = "feed" | "raw" | "state";
+type StreamPathLinkRenderer = (input: {
+  children: ReactNode;
+  className?: string;
+  path: StreamPath;
+}) => ReactNode;
 
 const DEFAULT_RAW_EVENT_YAML =
   "type: events.iterate.com/os/manual-event\npayload:\n  message: Hello from OS\n";
@@ -76,6 +81,8 @@ export function ProjectStreamView({
   messageComposer,
   projectSlug,
   projectSlugOrId,
+  renderStreamPathLink,
+  streamUrl,
   streamPath,
 }: {
   defaultComposerMode?: "message" | "raw";
@@ -84,6 +91,8 @@ export function ProjectStreamView({
   messageComposer?: ProjectStreamMessageComposer;
   projectSlug: string;
   projectSlugOrId: string;
+  renderStreamPathLink?: StreamPathLinkRenderer;
+  streamUrl?: string;
   streamPath: StreamPath;
 }) {
   const streamPathText = streamPath.toString();
@@ -92,7 +101,7 @@ export function ProjectStreamView({
       acquireStreamRuntime({
         namespace: projectSlugOrId,
         streamPath: streamPathText,
-        streamUrl: projectStreamRpcPath(projectSlugOrId, streamPathText),
+        streamUrl: streamUrl ?? projectStreamRpcPath(projectSlugOrId, streamPathText),
         slug: BrowserRawEventsContract.slug,
         schemaVersion: BROWSER_RAW_EVENTS_SCHEMA_VERSION,
         tables: ["events"],
@@ -110,7 +119,7 @@ export function ProjectStreamView({
           });
         },
       }),
-    [projectSlugOrId, streamPathText],
+    [projectSlugOrId, streamPathText, streamUrl],
   );
   const snapshot = useSyncExternalStore(
     store.subscribe,
@@ -204,7 +213,18 @@ export function ProjectStreamView({
         <ProjectStreamFeedView
           database={store.streamDatabase}
           emptyLabel={connectionLabel}
-          projectSlug={projectSlug}
+          renderStreamPathLink={
+            renderStreamPathLink ??
+            (({ path, children, className }) => (
+              <Link
+                to="/projects/$projectSlug/streams/$"
+                params={{ projectSlug, _splat: path }}
+                {...(className == null ? {} : { className })}
+              >
+                {children}
+              </Link>
+            ))
+          }
           reductionKey={`${projectSlugOrId}:${streamPathText}`}
         />
       ) : activeTab === "raw" ? (
@@ -258,12 +278,12 @@ export function ProjectStreamView({
 function ProjectStreamFeedView({
   database,
   emptyLabel,
-  projectSlug,
+  renderStreamPathLink,
   reductionKey,
 }: {
   database: StreamBrowserDatabase;
   emptyLabel: string;
-  projectSlug: string;
+  renderStreamPathLink: StreamPathLinkRenderer;
   reductionKey: string;
 }) {
   const feed = useStreamFeedState({ database, reductionKey });
@@ -290,15 +310,7 @@ function ProjectStreamFeedView({
       onHiddenElementTypesChange={setHiddenElementTypes}
       rendererMode={rendererMode}
       onRendererModeChange={setRendererMode}
-      renderStreamPathLink={({ path, children, className }) => (
-        <Link
-          to="/projects/$projectSlug/streams/$"
-          params={{ projectSlug, _splat: path }}
-          {...(className == null ? {} : { className })}
-        >
-          {children}
-        </Link>
-      )}
+      renderStreamPathLink={renderStreamPathLink}
     />
   );
 }

--- a/apps/os/src/components/stream-tree-browser.tsx
+++ b/apps/os/src/components/stream-tree-browser.tsx
@@ -1,0 +1,293 @@
+import { useMemo, useState } from "react";
+import { useQuery, useQueryClient, type QueryKey } from "@tanstack/react-query";
+import { ChevronDownIcon, ChevronRightIcon, RefreshCwIcon } from "lucide-react";
+import {
+  StreamPath,
+  type StreamState,
+  type StreamPath as StreamPathType,
+} from "@iterate-com/shared/streams/types";
+import { Badge } from "@iterate-com/ui/components/badge";
+import { Button } from "@iterate-com/ui/components/button";
+import { EventsStreamPathLabel } from "@iterate-com/ui/components/events/stream-path-label";
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@iterate-com/ui/components/empty";
+import { cn } from "@iterate-com/ui/lib/utils";
+
+export type StreamTreeBrowserSource = {
+  getState: (streamPath: StreamPathType) => Promise<StreamState>;
+  key: QueryKey;
+};
+
+export function StreamTreeBrowser({
+  currentPath,
+  onOpenPath,
+  source,
+}: {
+  currentPath?: StreamPathType;
+  onOpenPath: (streamPath: StreamPathType) => void;
+  source: StreamTreeBrowserSource;
+}) {
+  const queryClient = useQueryClient();
+  const [expandedPaths, setExpandedPaths] = useState<ReadonlySet<StreamPathType>>(
+    () => new Set<StreamPathType>(["/"]),
+  );
+  const rootStateQuery = useStreamStateQuery({ source, streamPath: StreamPath.parse("/") });
+
+  function toggleExpanded(path: StreamPathType) {
+    setExpandedPaths((previous) => {
+      const next = new Set(previous);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  }
+
+  async function refreshPath(path: StreamPathType) {
+    await queryClient.invalidateQueries({ queryKey: streamStateQueryKey(source.key, path) });
+  }
+
+  if (rootStateQuery.isPending) {
+    return <div className="p-4 text-sm text-muted-foreground">Loading stream tree...</div>;
+  }
+
+  if (rootStateQuery.isError) {
+    return (
+      <Empty className="border">
+        <EmptyHeader>
+          <EmptyTitle>Could not load stream tree</EmptyTitle>
+          <EmptyDescription>
+            {rootStateQuery.error instanceof Error
+              ? rootStateQuery.error.message
+              : "The root stream state could not be read."}
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border bg-background">
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b px-3 py-2">
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold">Streams</h2>
+          <p className="text-xs text-muted-foreground">Runtime child paths</p>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Refresh root stream"
+          onClick={() => void refreshPath(StreamPath.parse("/"))}
+        >
+          <RefreshCwIcon aria-hidden="true" data-icon="icon" />
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto p-1.5">
+        <StreamTreeNode
+          currentPath={currentPath}
+          depth={0}
+          expandedPaths={expandedPaths}
+          onOpenPath={onOpenPath}
+          onRefreshPath={refreshPath}
+          onToggleExpanded={toggleExpanded}
+          source={source}
+          state={rootStateQuery.data}
+          streamPath={StreamPath.parse("/")}
+        />
+      </div>
+    </div>
+  );
+}
+
+function StreamTreeNode({
+  currentPath,
+  depth,
+  expandedPaths,
+  onOpenPath,
+  onRefreshPath,
+  onToggleExpanded,
+  source,
+  state,
+  streamPath,
+}: {
+  currentPath?: StreamPathType;
+  depth: number;
+  expandedPaths: ReadonlySet<StreamPathType>;
+  onOpenPath: (streamPath: StreamPathType) => void;
+  onRefreshPath: (streamPath: StreamPathType) => Promise<void>;
+  onToggleExpanded: (streamPath: StreamPathType) => void;
+  source: StreamTreeBrowserSource;
+  state: StreamState;
+  streamPath: StreamPathType;
+}) {
+  const childPaths = useMemo(
+    () => [...state.childPaths].sort((left, right) => left.localeCompare(right)),
+    [state.childPaths],
+  );
+  const expanded = expandedPaths.has(streamPath);
+  const selected = currentPath === streamPath;
+
+  return (
+    <div>
+      <div
+        className={cn(
+          "group flex h-8 min-w-0 items-center gap-1 rounded-md pr-1 text-sm",
+          selected ? "bg-accent text-accent-foreground" : "hover:bg-accent/70",
+        )}
+        style={{ paddingLeft: depth * 14 + 4 }}
+      >
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="shrink-0"
+          aria-label={expanded ? `Collapse ${streamPath}` : `Expand ${streamPath}`}
+          disabled={childPaths.length === 0}
+          onClick={() => onToggleExpanded(streamPath)}
+        >
+          {childPaths.length === 0 ? (
+            <span className="size-4" aria-hidden="true" />
+          ) : expanded ? (
+            <ChevronDownIcon aria-hidden="true" data-icon="icon" />
+          ) : (
+            <ChevronRightIcon aria-hidden="true" data-icon="icon" />
+          )}
+        </Button>
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+          onClick={() => onOpenPath(streamPath)}
+        >
+          <EventsStreamPathLabel
+            path={streamPath}
+            label={streamPathSegment(streamPath)}
+            className="min-w-0"
+          />
+          <Badge variant="secondary" className="ml-auto shrink-0 font-mono text-[10px]">
+            {state.eventCount}
+          </Badge>
+        </button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="shrink-0 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+          aria-label={`Refresh ${streamPath}`}
+          onClick={() => void onRefreshPath(streamPath)}
+        >
+          <RefreshCwIcon aria-hidden="true" data-icon="icon" />
+        </Button>
+      </div>
+      {expanded ? (
+        <div>
+          {childPaths.map((childPath) => (
+            <StreamTreeChild
+              key={childPath}
+              currentPath={currentPath}
+              depth={depth + 1}
+              expandedPaths={expandedPaths}
+              onOpenPath={onOpenPath}
+              onRefreshPath={onRefreshPath}
+              onToggleExpanded={onToggleExpanded}
+              source={source}
+              streamPath={childPath}
+            />
+          ))}
+          {childPaths.length === 0 && depth === 0 ? (
+            <p className="px-9 py-2 text-xs text-muted-foreground">No child streams yet.</p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function StreamTreeChild(props: {
+  currentPath?: StreamPathType;
+  depth: number;
+  expandedPaths: ReadonlySet<StreamPathType>;
+  onOpenPath: (streamPath: StreamPathType) => void;
+  onRefreshPath: (streamPath: StreamPathType) => Promise<void>;
+  onToggleExpanded: (streamPath: StreamPathType) => void;
+  source: StreamTreeBrowserSource;
+  streamPath: StreamPathType;
+}) {
+  const shouldLoad =
+    props.expandedPaths.has(props.streamPath) || props.currentPath === props.streamPath;
+  const stateQuery = useStreamStateQuery({
+    enabled: shouldLoad,
+    source: props.source,
+    streamPath: props.streamPath,
+  });
+
+  if (stateQuery.isError) {
+    return (
+      <div
+        className="flex h-8 min-w-0 items-center gap-2 rounded-md pr-2 text-sm text-destructive"
+        style={{ paddingLeft: props.depth * 14 + 32 }}
+      >
+        <span className="truncate font-mono">{props.streamPath}</span>
+      </div>
+    );
+  }
+
+  if (stateQuery.data == null) {
+    const selected = props.currentPath === props.streamPath;
+    return (
+      <div
+        className={cn(
+          "flex h-8 min-w-0 items-center gap-1 rounded-md pr-1 text-sm",
+          selected ? "bg-accent text-accent-foreground" : "hover:bg-accent/70",
+        )}
+        style={{ paddingLeft: props.depth * 14 + 4 }}
+      >
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="shrink-0"
+          aria-label={`Load ${props.streamPath}`}
+          onClick={() => props.onToggleExpanded(props.streamPath)}
+        >
+          <ChevronRightIcon aria-hidden="true" data-icon="icon" />
+        </Button>
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+          onClick={() => props.onOpenPath(props.streamPath)}
+        >
+          <EventsStreamPathLabel
+            path={props.streamPath}
+            label={streamPathSegment(props.streamPath)}
+            className="min-w-0"
+          />
+        </button>
+      </div>
+    );
+  }
+
+  return <StreamTreeNode {...props} state={stateQuery.data} />;
+}
+
+function useStreamStateQuery(input: {
+  enabled?: boolean;
+  source: StreamTreeBrowserSource;
+  streamPath: StreamPathType;
+}) {
+  return useQuery({
+    enabled: input.enabled ?? true,
+    queryKey: streamStateQueryKey(input.source.key, input.streamPath),
+    queryFn: () => input.source.getState(input.streamPath),
+    staleTime: 10_000,
+  });
+}
+
+function streamStateQueryKey(sourceKey: QueryKey, streamPath: StreamPathType) {
+  return [...sourceKey, "state", streamPath] as const;
+}
+
+function streamPathSegment(path: StreamPathType) {
+  return path === "/" ? "/" : (path.split("/").at(-1) ?? path);
+}

--- a/apps/os/src/domains/streams/admin-stream-rpc.ts
+++ b/apps/os/src/domains/streams/admin-stream-rpc.ts
@@ -1,0 +1,67 @@
+import { newWorkersRpcResponse } from "capnweb";
+import { PublicStreamRpcTarget } from "@iterate-com/streams/workers/durable-objects/stream";
+import { StreamNamespace } from "@iterate-com/shared/streams/types";
+import { authenticateCapnwebAdmin } from "~/itx/admin-auth-cookie.ts";
+import { getStreamDurableObjectName } from "~/domains/streams/new-stream-runtime.ts";
+import { resolveStreamPath } from "~/domains/streams/entrypoints/streams-capability.ts";
+import type { AppConfig } from "~/config.ts";
+import type { RequestContext } from "~/request-context.ts";
+
+const ADMIN_STREAM_RPC_PREFIX = "/api/admin-streams";
+
+/**
+ * Admin-only Cap'n Web sessions for arbitrary stream namespaces.
+ *
+ * This powers the admin stream explorer without minting project-scoped auth.
+ * The namespace is explicit in the URL because admin is intentionally not
+ * limited to project namespaces.
+ */
+export async function handleAdminStreamRpcFetch(input: {
+  config: AppConfig;
+  context: RequestContext;
+  env: Env;
+  request: Request;
+}): Promise<Response | null> {
+  const route = parseAdminStreamRpcRoute(input.request);
+  if (!route) return null;
+
+  const principal = authenticateCapnwebAdmin({ config: input.config, request: input.request });
+  if (!principal) return new Response("Unauthorized", { status: 401 });
+
+  const namespace = StreamNamespace.parse(route.namespace);
+  const streamPath = resolveStreamPath(route.streamPath);
+  const stream = input.env.STREAM.getByName(
+    getStreamDurableObjectName({
+      namespace,
+      path: streamPath,
+    }),
+  );
+  return await newWorkersRpcResponse(input.request, new PublicStreamRpcTarget(stream));
+}
+
+function parseAdminStreamRpcRoute(request: Request): {
+  namespace: string;
+  streamPath: string;
+} | null {
+  const url = new URL(request.url);
+  if (
+    url.pathname !== ADMIN_STREAM_RPC_PREFIX &&
+    !url.pathname.startsWith(`${ADMIN_STREAM_RPC_PREFIX}/`)
+  ) {
+    return null;
+  }
+
+  const remainder = url.pathname.slice(ADMIN_STREAM_RPC_PREFIX.length);
+  const match = /^\/([^/]+)(?:\/(.*))?$/.exec(remainder);
+  if (!match) return null;
+  const namespace = decodeURIComponent(match[1] ?? "").trim();
+  if (!namespace) return null;
+  const encodedStreamPath = match[2];
+  return {
+    namespace,
+    streamPath:
+      encodedStreamPath == null || encodedStreamPath === ""
+        ? "/"
+        : decodeURIComponent(encodedStreamPath),
+  };
+}

--- a/apps/os/src/itx/handle.ts
+++ b/apps/os/src/itx/handle.ts
@@ -20,6 +20,7 @@ import { RpcTarget } from "cloudflare:workers";
 import { typeid } from "@iterate-com/shared/typeid";
 import type { StreamCursor, Event as StreamLegacyEvent } from "@iterate-com/shared/streams/types";
 import { createD1Client } from "sqlfu";
+import { StreamNamespace } from "@iterate-com/shared/streams/types";
 import { PathProxyRpcTarget } from "./path-proxy.ts";
 import {
   GLOBAL_CONTEXT_ID,
@@ -410,6 +411,13 @@ export class ItxStreams extends RpcTarget {
 
   get(path: string): ItxStream {
     return new ItxStream(this.runtime, this.projectId, path);
+  }
+
+  namespace(namespace: string): ItxStreams {
+    if (this.runtime.access !== "all") {
+      throw new Error("Selecting an arbitrary stream namespace requires admin access.");
+    }
+    return new ItxStreams(this.runtime, StreamNamespace.parse(namespace));
   }
 
   async list() {

--- a/apps/os/src/itx/react/index.ts
+++ b/apps/os/src/itx/react/index.ts
@@ -3,6 +3,7 @@
 //   import { ItxProvider, useItxQuery, useItxMutation, itxKey } from "~/itx/react";
 
 export { ItxProvider } from "./provider.tsx";
+export { useItxClient } from "./context.ts";
 export { itxKey, useItxQuery, useItxMutation } from "./hooks.ts";
 export { useStreamEvents } from "./use-stream-events.ts";
 export { isItxAccessError } from "./errors.ts";

--- a/apps/os/src/lib/itx-queries.ts
+++ b/apps/os/src/lib/itx-queries.ts
@@ -2,11 +2,16 @@
 // consumer of the same data on the same TanStack cache entry, so one
 // invalidation reaches all of them.
 
+import { StreamState, type StreamPath as StreamPathType } from "@iterate-com/shared/streams/types";
 import { itxKey, useItxQuery } from "~/itx/react/index.ts";
 import { PROJECT_CHILD_ROUTE_STALE_TIME } from "~/lib/project-route-query.ts";
 
 export function projectStreamsListKey(projectId: string) {
   return itxKey.project(projectId, "streams", "list");
+}
+
+export function projectStreamStateKey(projectId: string, streamPath: StreamPathType) {
+  return itxKey.project(projectId, "streams", "state", streamPath);
 }
 
 /** The project's stream list — shared by the streams index and breadcrumbs. */
@@ -15,6 +20,15 @@ export function useProjectStreamsList(projectId: string) {
     project: projectId,
     queryKey: projectStreamsListKey(projectId),
     queryFn: (itx) => itx.streams.list(),
+    staleTime: PROJECT_CHILD_ROUTE_STALE_TIME,
+  });
+}
+
+export function useProjectStreamState(input: { projectId: string; streamPath: StreamPathType }) {
+  return useItxQuery({
+    project: input.projectId,
+    queryKey: projectStreamStateKey(input.projectId, input.streamPath),
+    queryFn: async (itx) => StreamState.parse(await itx.streams.get(input.streamPath).getState()),
     staleTime: PROJECT_CHILD_ROUTE_STALE_TIME,
   });
 }

--- a/apps/os/src/lib/stream-rpc-paths.ts
+++ b/apps/os/src/lib/stream-rpc-paths.ts
@@ -1,0 +1,9 @@
+const ADMIN_STREAM_RPC_PREFIX = "/api/admin-streams";
+
+export function adminStreamRpcPath(namespace: string, streamPath: string) {
+  const normalized =
+    streamPath === "" ? "/" : streamPath.startsWith("/") ? streamPath : `/${streamPath}`;
+  return normalized === "/"
+    ? `${ADMIN_STREAM_RPC_PREFIX}/${encodeURIComponent(namespace)}`
+    : `${ADMIN_STREAM_RPC_PREFIX}/${encodeURIComponent(namespace)}/${encodeURIComponent(normalized)}`;
+}

--- a/apps/os/src/routeTree.gen.ts
+++ b/apps/os/src/routeTree.gen.ts
@@ -24,13 +24,18 @@ import { Route as ApiSplatRouteImport } from './routes/api.$'
 import { Route as AppNewProjectRouteImport } from './routes/_app/new-project'
 import { Route as AppItxReplRouteImport } from './routes/_app/itx-repl'
 import { Route as EventDocsProcessorSlugSplatRouteImport } from './routes/$eventDocsProcessorSlug.$'
+import { Route as AdminStreamsRouteRouteImport } from './routes/admin/streams/route'
 import { Route as AppProjectsRouteRouteImport } from './routes/_app/projects/route'
+import { Route as AdminStreamsIndexRouteImport } from './routes/admin/streams/index'
 import { Route as AppProjectsIndexRouteImport } from './routes/_app/projects/index'
 import { Route as ApiOrpcSplatRouteImport } from './routes/api.orpc.$'
+import { Route as AdminStreamsNamespaceRouteRouteImport } from './routes/admin/streams/$namespace/route'
 import { Route as AppProjectsProjectSlugRouteRouteImport } from './routes/_app/projects/$projectSlug/route'
 import { Route as DocsStreamsProcessorsIndexRouteImport } from './routes/docs.streams.processors.index'
+import { Route as AdminStreamsNamespaceIndexRouteImport } from './routes/admin/streams/$namespace/index'
 import { Route as AppProjectsProjectSlugIndexRouteImport } from './routes/_app/projects/$projectSlug/index'
 import { Route as DocsStreamsProcessorsProcessorSlugRouteImport } from './routes/docs.streams.processors.$processorSlug'
+import { Route as AdminStreamsNamespaceSplatRouteImport } from './routes/admin/streams/$namespace/$'
 import { Route as AppProjectsProjectSlugSettingsRouteImport } from './routes/_app/projects/$projectSlug/settings'
 import { Route as AppProjectsProjectSlugReplRouteImport } from './routes/_app/projects/$projectSlug/repl'
 import { Route as AppProjectsProjectSlugMcpRouteImport } from './routes/_app/projects/$projectSlug/mcp'
@@ -127,10 +132,20 @@ const EventDocsProcessorSlugSplatRoute =
     path: '/$',
     getParentRoute: () => EventDocsProcessorSlugRoute,
   } as any)
+const AdminStreamsRouteRoute = AdminStreamsRouteRouteImport.update({
+  id: '/streams',
+  path: '/streams',
+  getParentRoute: () => AdminRoute,
+} as any)
 const AppProjectsRouteRoute = AppProjectsRouteRouteImport.update({
   id: '/projects',
   path: '/projects',
   getParentRoute: () => AppRoute,
+} as any)
+const AdminStreamsIndexRoute = AdminStreamsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AdminStreamsRouteRoute,
 } as any)
 const AppProjectsIndexRoute = AppProjectsIndexRouteImport.update({
   id: '/',
@@ -142,6 +157,12 @@ const ApiOrpcSplatRoute = ApiOrpcSplatRouteImport.update({
   path: '/api/orpc/$',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AdminStreamsNamespaceRouteRoute =
+  AdminStreamsNamespaceRouteRouteImport.update({
+    id: '/$namespace',
+    path: '/$namespace',
+    getParentRoute: () => AdminStreamsRouteRoute,
+  } as any)
 const AppProjectsProjectSlugRouteRoute =
   AppProjectsProjectSlugRouteRouteImport.update({
     id: '/$projectSlug',
@@ -154,6 +175,12 @@ const DocsStreamsProcessorsIndexRoute =
     path: '/streams/processors/',
     getParentRoute: () => DocsRoute,
   } as any)
+const AdminStreamsNamespaceIndexRoute =
+  AdminStreamsNamespaceIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AdminStreamsNamespaceRouteRoute,
+  } as any)
 const AppProjectsProjectSlugIndexRoute =
   AppProjectsProjectSlugIndexRouteImport.update({
     id: '/',
@@ -165,6 +192,12 @@ const DocsStreamsProcessorsProcessorSlugRoute =
     id: '/streams/processors/$processorSlug',
     path: '/streams/processors/$processorSlug',
     getParentRoute: () => DocsRoute,
+  } as any)
+const AdminStreamsNamespaceSplatRoute =
+  AdminStreamsNamespaceSplatRouteImport.update({
+    id: '/$',
+    path: '/$',
+    getParentRoute: () => AdminStreamsNamespaceRouteRoute,
   } as any)
 const AppProjectsProjectSlugSettingsRoute =
   AppProjectsProjectSlugSettingsRouteImport.update({
@@ -293,6 +326,7 @@ export interface FileRoutesByFullPath {
   '/admin': typeof AdminRouteWithChildren
   '/docs': typeof DocsRouteWithChildren
   '/projects': typeof AppProjectsRouteRouteWithChildren
+  '/admin/streams': typeof AdminStreamsRouteRouteWithChildren
   '/$eventDocsProcessorSlug/$': typeof EventDocsProcessorSlugSplatRoute
   '/itx-repl': typeof AppItxReplRoute
   '/new-project': typeof AppNewProjectRoute
@@ -304,16 +338,20 @@ export interface FileRoutesByFullPath {
   '/admin/': typeof AdminIndexRoute
   '/docs/': typeof DocsIndexRoute
   '/projects/$projectSlug': typeof AppProjectsProjectSlugRouteRouteWithChildren
+  '/admin/streams/$namespace': typeof AdminStreamsNamespaceRouteRouteWithChildren
   '/api/orpc/$': typeof ApiOrpcSplatRoute
   '/projects/': typeof AppProjectsIndexRoute
+  '/admin/streams/': typeof AdminStreamsIndexRoute
   '/projects/$projectSlug/agents': typeof AppProjectsProjectSlugAgentsRouteRouteWithChildren
   '/projects/$projectSlug/streams': typeof AppProjectsProjectSlugStreamsRouteRouteWithChildren
   '/projects/$projectSlug/integrations': typeof AppProjectsProjectSlugIntegrationsRoute
   '/projects/$projectSlug/mcp': typeof AppProjectsProjectSlugMcpRoute
   '/projects/$projectSlug/repl': typeof AppProjectsProjectSlugReplRoute
   '/projects/$projectSlug/settings': typeof AppProjectsProjectSlugSettingsRoute
+  '/admin/streams/$namespace/$': typeof AdminStreamsNamespaceSplatRoute
   '/docs/streams/processors/$processorSlug': typeof DocsStreamsProcessorsProcessorSlugRouteWithChildren
   '/projects/$projectSlug/': typeof AppProjectsProjectSlugIndexRoute
+  '/admin/streams/$namespace/': typeof AdminStreamsNamespaceIndexRoute
   '/docs/streams/processors/': typeof DocsStreamsProcessorsIndexRoute
   '/projects/$projectSlug/agents/new': typeof AppProjectsProjectSlugAgentsNewRoute
   '/projects/$projectSlug/agents/new-preset': typeof AppProjectsProjectSlugAgentsNewPresetRoute
@@ -345,12 +383,15 @@ export interface FileRoutesByTo {
   '/docs': typeof DocsIndexRoute
   '/api/orpc/$': typeof ApiOrpcSplatRoute
   '/projects': typeof AppProjectsIndexRoute
+  '/admin/streams': typeof AdminStreamsIndexRoute
   '/projects/$projectSlug/integrations': typeof AppProjectsProjectSlugIntegrationsRoute
   '/projects/$projectSlug/mcp': typeof AppProjectsProjectSlugMcpRoute
   '/projects/$projectSlug/repl': typeof AppProjectsProjectSlugReplRoute
   '/projects/$projectSlug/settings': typeof AppProjectsProjectSlugSettingsRoute
+  '/admin/streams/$namespace/$': typeof AdminStreamsNamespaceSplatRoute
   '/docs/streams/processors/$processorSlug': typeof DocsStreamsProcessorsProcessorSlugRouteWithChildren
   '/projects/$projectSlug': typeof AppProjectsProjectSlugIndexRoute
+  '/admin/streams/$namespace': typeof AdminStreamsNamespaceIndexRoute
   '/docs/streams/processors': typeof DocsStreamsProcessorsIndexRoute
   '/projects/$projectSlug/agents/new': typeof AppProjectsProjectSlugAgentsNewRoute
   '/projects/$projectSlug/agents/new-preset': typeof AppProjectsProjectSlugAgentsNewPresetRoute
@@ -375,6 +416,7 @@ export interface FileRoutesById {
   '/admin': typeof AdminRouteWithChildren
   '/docs': typeof DocsRouteWithChildren
   '/_app/projects': typeof AppProjectsRouteRouteWithChildren
+  '/admin/streams': typeof AdminStreamsRouteRouteWithChildren
   '/$eventDocsProcessorSlug/$': typeof EventDocsProcessorSlugSplatRoute
   '/_app/itx-repl': typeof AppItxReplRoute
   '/_app/new-project': typeof AppNewProjectRoute
@@ -386,16 +428,20 @@ export interface FileRoutesById {
   '/admin/': typeof AdminIndexRoute
   '/docs/': typeof DocsIndexRoute
   '/_app/projects/$projectSlug': typeof AppProjectsProjectSlugRouteRouteWithChildren
+  '/admin/streams/$namespace': typeof AdminStreamsNamespaceRouteRouteWithChildren
   '/api/orpc/$': typeof ApiOrpcSplatRoute
   '/_app/projects/': typeof AppProjectsIndexRoute
+  '/admin/streams/': typeof AdminStreamsIndexRoute
   '/_app/projects/$projectSlug/agents': typeof AppProjectsProjectSlugAgentsRouteRouteWithChildren
   '/_app/projects/$projectSlug/streams': typeof AppProjectsProjectSlugStreamsRouteRouteWithChildren
   '/_app/projects/$projectSlug/integrations': typeof AppProjectsProjectSlugIntegrationsRoute
   '/_app/projects/$projectSlug/mcp': typeof AppProjectsProjectSlugMcpRoute
   '/_app/projects/$projectSlug/repl': typeof AppProjectsProjectSlugReplRoute
   '/_app/projects/$projectSlug/settings': typeof AppProjectsProjectSlugSettingsRoute
+  '/admin/streams/$namespace/$': typeof AdminStreamsNamespaceSplatRoute
   '/docs/streams/processors/$processorSlug': typeof DocsStreamsProcessorsProcessorSlugRouteWithChildren
   '/_app/projects/$projectSlug/': typeof AppProjectsProjectSlugIndexRoute
+  '/admin/streams/$namespace/': typeof AdminStreamsNamespaceIndexRoute
   '/docs/streams/processors/': typeof DocsStreamsProcessorsIndexRoute
   '/_app/projects/$projectSlug/agents/new': typeof AppProjectsProjectSlugAgentsNewRoute
   '/_app/projects/$projectSlug/agents/new-preset': typeof AppProjectsProjectSlugAgentsNewPresetRoute
@@ -420,6 +466,7 @@ export interface FileRouteTypes {
     | '/admin'
     | '/docs'
     | '/projects'
+    | '/admin/streams'
     | '/$eventDocsProcessorSlug/$'
     | '/itx-repl'
     | '/new-project'
@@ -431,16 +478,20 @@ export interface FileRouteTypes {
     | '/admin/'
     | '/docs/'
     | '/projects/$projectSlug'
+    | '/admin/streams/$namespace'
     | '/api/orpc/$'
     | '/projects/'
+    | '/admin/streams/'
     | '/projects/$projectSlug/agents'
     | '/projects/$projectSlug/streams'
     | '/projects/$projectSlug/integrations'
     | '/projects/$projectSlug/mcp'
     | '/projects/$projectSlug/repl'
     | '/projects/$projectSlug/settings'
+    | '/admin/streams/$namespace/$'
     | '/docs/streams/processors/$processorSlug'
     | '/projects/$projectSlug/'
+    | '/admin/streams/$namespace/'
     | '/docs/streams/processors/'
     | '/projects/$projectSlug/agents/new'
     | '/projects/$projectSlug/agents/new-preset'
@@ -472,12 +523,15 @@ export interface FileRouteTypes {
     | '/docs'
     | '/api/orpc/$'
     | '/projects'
+    | '/admin/streams'
     | '/projects/$projectSlug/integrations'
     | '/projects/$projectSlug/mcp'
     | '/projects/$projectSlug/repl'
     | '/projects/$projectSlug/settings'
+    | '/admin/streams/$namespace/$'
     | '/docs/streams/processors/$processorSlug'
     | '/projects/$projectSlug'
+    | '/admin/streams/$namespace'
     | '/docs/streams/processors'
     | '/projects/$projectSlug/agents/new'
     | '/projects/$projectSlug/agents/new-preset'
@@ -501,6 +555,7 @@ export interface FileRouteTypes {
     | '/admin'
     | '/docs'
     | '/_app/projects'
+    | '/admin/streams'
     | '/$eventDocsProcessorSlug/$'
     | '/_app/itx-repl'
     | '/_app/new-project'
@@ -512,16 +567,20 @@ export interface FileRouteTypes {
     | '/admin/'
     | '/docs/'
     | '/_app/projects/$projectSlug'
+    | '/admin/streams/$namespace'
     | '/api/orpc/$'
     | '/_app/projects/'
+    | '/admin/streams/'
     | '/_app/projects/$projectSlug/agents'
     | '/_app/projects/$projectSlug/streams'
     | '/_app/projects/$projectSlug/integrations'
     | '/_app/projects/$projectSlug/mcp'
     | '/_app/projects/$projectSlug/repl'
     | '/_app/projects/$projectSlug/settings'
+    | '/admin/streams/$namespace/$'
     | '/docs/streams/processors/$processorSlug'
     | '/_app/projects/$projectSlug/'
+    | '/admin/streams/$namespace/'
     | '/docs/streams/processors/'
     | '/_app/projects/$projectSlug/agents/new'
     | '/_app/projects/$projectSlug/agents/new-preset'
@@ -660,12 +719,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventDocsProcessorSlugSplatRouteImport
       parentRoute: typeof EventDocsProcessorSlugRoute
     }
+    '/admin/streams': {
+      id: '/admin/streams'
+      path: '/streams'
+      fullPath: '/admin/streams'
+      preLoaderRoute: typeof AdminStreamsRouteRouteImport
+      parentRoute: typeof AdminRoute
+    }
     '/_app/projects': {
       id: '/_app/projects'
       path: '/projects'
       fullPath: '/projects'
       preLoaderRoute: typeof AppProjectsRouteRouteImport
       parentRoute: typeof AppRoute
+    }
+    '/admin/streams/': {
+      id: '/admin/streams/'
+      path: '/'
+      fullPath: '/admin/streams/'
+      preLoaderRoute: typeof AdminStreamsIndexRouteImport
+      parentRoute: typeof AdminStreamsRouteRoute
     }
     '/_app/projects/': {
       id: '/_app/projects/'
@@ -681,6 +754,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiOrpcSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/admin/streams/$namespace': {
+      id: '/admin/streams/$namespace'
+      path: '/$namespace'
+      fullPath: '/admin/streams/$namespace'
+      preLoaderRoute: typeof AdminStreamsNamespaceRouteRouteImport
+      parentRoute: typeof AdminStreamsRouteRoute
+    }
     '/_app/projects/$projectSlug': {
       id: '/_app/projects/$projectSlug'
       path: '/$projectSlug'
@@ -695,6 +775,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsStreamsProcessorsIndexRouteImport
       parentRoute: typeof DocsRoute
     }
+    '/admin/streams/$namespace/': {
+      id: '/admin/streams/$namespace/'
+      path: '/'
+      fullPath: '/admin/streams/$namespace/'
+      preLoaderRoute: typeof AdminStreamsNamespaceIndexRouteImport
+      parentRoute: typeof AdminStreamsNamespaceRouteRoute
+    }
     '/_app/projects/$projectSlug/': {
       id: '/_app/projects/$projectSlug/'
       path: '/'
@@ -708,6 +795,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/docs/streams/processors/$processorSlug'
       preLoaderRoute: typeof DocsStreamsProcessorsProcessorSlugRouteImport
       parentRoute: typeof DocsRoute
+    }
+    '/admin/streams/$namespace/$': {
+      id: '/admin/streams/$namespace/$'
+      path: '/$'
+      fullPath: '/admin/streams/$namespace/$'
+      preLoaderRoute: typeof AdminStreamsNamespaceSplatRouteImport
+      parentRoute: typeof AdminStreamsNamespaceRouteRoute
     }
     '/_app/projects/$projectSlug/settings': {
       id: '/_app/projects/$projectSlug/settings'
@@ -985,11 +1079,42 @@ const AppRouteChildren: AppRouteChildren = {
 
 const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)
 
+interface AdminStreamsNamespaceRouteRouteChildren {
+  AdminStreamsNamespaceSplatRoute: typeof AdminStreamsNamespaceSplatRoute
+  AdminStreamsNamespaceIndexRoute: typeof AdminStreamsNamespaceIndexRoute
+}
+
+const AdminStreamsNamespaceRouteRouteChildren: AdminStreamsNamespaceRouteRouteChildren =
+  {
+    AdminStreamsNamespaceSplatRoute: AdminStreamsNamespaceSplatRoute,
+    AdminStreamsNamespaceIndexRoute: AdminStreamsNamespaceIndexRoute,
+  }
+
+const AdminStreamsNamespaceRouteRouteWithChildren =
+  AdminStreamsNamespaceRouteRoute._addFileChildren(
+    AdminStreamsNamespaceRouteRouteChildren,
+  )
+
+interface AdminStreamsRouteRouteChildren {
+  AdminStreamsNamespaceRouteRoute: typeof AdminStreamsNamespaceRouteRouteWithChildren
+  AdminStreamsIndexRoute: typeof AdminStreamsIndexRoute
+}
+
+const AdminStreamsRouteRouteChildren: AdminStreamsRouteRouteChildren = {
+  AdminStreamsNamespaceRouteRoute: AdminStreamsNamespaceRouteRouteWithChildren,
+  AdminStreamsIndexRoute: AdminStreamsIndexRoute,
+}
+
+const AdminStreamsRouteRouteWithChildren =
+  AdminStreamsRouteRoute._addFileChildren(AdminStreamsRouteRouteChildren)
+
 interface AdminRouteChildren {
+  AdminStreamsRouteRoute: typeof AdminStreamsRouteRouteWithChildren
   AdminIndexRoute: typeof AdminIndexRoute
 }
 
 const AdminRouteChildren: AdminRouteChildren = {
+  AdminStreamsRouteRoute: AdminStreamsRouteRouteWithChildren,
   AdminIndexRoute: AdminIndexRoute,
 }
 

--- a/apps/os/src/routes/_app/projects/$projectSlug/streams/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/streams/index.tsx
@@ -1,310 +1,46 @@
-import { useMemo, useState } from "react";
-import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useQueryClient } from "@tanstack/react-query";
-import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@iterate-com/ui/components/empty";
-import { EventsStreamPathLabel } from "@iterate-com/ui/components/events/stream-path-label";
-import { Button } from "@iterate-com/ui/components/button";
-import {
-  Combobox,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxList,
-} from "@iterate-com/ui/components/combobox";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@iterate-com/ui/components/table";
-import { toast } from "@iterate-com/ui/components/sonner";
-import { Spinner } from "@iterate-com/ui/components/spinner";
-import { StreamDebugLink } from "~/components/stream-debug-link.tsx";
-import { projectStreamsListKey, useProjectStreamsList } from "~/lib/itx-queries.ts";
-import { streamPathFromInput } from "~/lib/stream-links.ts";
-import { isItxAccessError, useItxMutation } from "~/itx/react/index.ts";
+import { useMemo } from "react";
+import { StreamState, type StreamPath as StreamPathType } from "@iterate-com/shared/streams/types";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { StreamTreeBrowser } from "~/components/stream-tree-browser.tsx";
+import { useItxClient } from "~/itx/react/index.ts";
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/streams/")({
   loader: ({ context }) => ({
-    breadcrumb: "All",
+    breadcrumb: "Tree",
     project: context.project,
   }),
   component: ProjectStreamsIndexPage,
 });
 
-type SortKey = "streamPath" | "createdAt" | "lastWokenAt";
-type SortDirection = "asc" | "desc";
-
 function ProjectStreamsIndexPage() {
   const params = Route.useParams();
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
+  const itxClient = useItxClient();
   const { project } = Route.useLoaderData();
-  const [filter, setFilter] = useState("");
-  const [sort, setSort] = useState<{ key: SortKey; direction: SortDirection }>({
-    key: "lastWokenAt",
-    direction: "desc",
-  });
-  const { data, isPending, error, refetch } = useProjectStreamsList(project.id);
-  const createStream = useItxMutation({
-    project: project.id,
-    mutationFn: (itx, input: { streamPath: string }) => itx.streams.create(input),
-    onSuccess: async (_state, input) => {
-      // Breadcrumbs share this cache entry, so one invalidation reaches both.
-      await queryClient.invalidateQueries({ queryKey: projectStreamsListKey(project.id) });
-      setFilter("");
-      void navigate({
-        to: "/projects/$projectSlug/streams/$",
-        params: {
-          projectSlug: params.projectSlug,
-          // The route's params.stringify converts StreamPath -> splat; passing
-          // a pre-splatted string here would get sliced a second time.
-          _splat: input.streamPath,
-        },
-      });
-    },
-    onError: (error) => {
-      toast.error(error instanceof Error ? error.message : "Could not create stream.");
-    },
-  });
-  const streams = useMemo(() => data ?? [], [data]);
-  const streamPaths = useMemo(() => streams.map((stream) => stream.streamPath), [streams]);
-  const visibleStreams = useMemo(() => {
-    const query = filter.trim().toLowerCase();
-    return streams
-      .filter((stream) => {
-        if (!query) return true;
-        return (
-          stream.streamPath.toLowerCase().includes(query) ||
-          stream.name.toLowerCase().includes(query)
-        );
-      })
-      .toSorted((left, right) => {
-        const direction = sort.direction === "asc" ? 1 : -1;
-        return direction * compareStreamRows(left, right, sort.key);
-      });
-  }, [filter, sort, streams]);
+  const source = useMemo(
+    () => ({
+      key: ["project", project.id, "streams"] as const,
+      getState: async (streamPath: StreamPathType) =>
+        StreamState.parse(
+          await (await itxClient.project(project.id)).streams.get(streamPath).getState(),
+        ),
+    }),
+    [itxClient, project.id],
+  );
 
-  function submitCreateStream() {
-    try {
-      createStream.mutate({
-        streamPath: streamPathFromInput(filter),
-      });
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Stream path is invalid.");
-    }
+  function openStream(streamPath: StreamPathType) {
+    void navigate({
+      to: "/projects/$projectSlug/streams/$",
+      params: {
+        projectSlug: params.projectSlug,
+        _splat: streamPath,
+      },
+    });
   }
 
   return (
-    <section className="w-full space-y-4 p-4">
-      <div className="flex justify-end">
-        <StreamDebugLink label="Open root stream" projectSlug={project.slug} streamPath="/" />
-      </div>
-      <form
-        className="flex w-full flex-col gap-2 md:flex-row"
-        onSubmit={(event) => {
-          event.preventDefault();
-          submitCreateStream();
-        }}
-      >
-        <Combobox<string>
-          items={streamPaths}
-          inputValue={filter}
-          onInputValueChange={(value) => setFilter(value)}
-          onValueChange={(value) => {
-            if (value) setFilter(value);
-          }}
-        >
-          <ComboboxInput
-            className="h-9 flex-1"
-            placeholder="Filter or create stream path..."
-            showClear
-            showTrigger={streamPaths.length > 0}
-          />
-          <ComboboxContent>
-            <ComboboxEmpty>No streams match.</ComboboxEmpty>
-            <ComboboxList>
-              {streamPaths.map((path) => (
-                <ComboboxItem key={path} value={path}>
-                  <EventsStreamPathLabel path={path} className="min-w-0" />
-                </ComboboxItem>
-              ))}
-            </ComboboxList>
-          </ComboboxContent>
-        </Combobox>
-        <div className="flex gap-2 md:shrink-0">
-          <Button
-            type="button"
-            variant="outline"
-            className="flex-1 md:flex-none"
-            onClick={() => setFilter("")}
-          >
-            Reset
-          </Button>
-          <Button type="submit" className="flex-1 md:flex-none" disabled={createStream.isPending}>
-            {createStream.isPending ? "Creating..." : "Create stream"}
-          </Button>
-        </div>
-      </form>
-
-      {error && isItxAccessError(error) ? (
-        <Empty className="rounded-lg border">
-          <EmptyHeader>
-            <EmptyTitle>No access to this project's streams</EmptyTitle>
-            <EmptyDescription>
-              Your session can't read this project. Sign in with an account that has access — the
-              account menu shows who you're signed in as.
-            </EmptyDescription>
-          </EmptyHeader>
-        </Empty>
-      ) : error ? (
-        <Empty className="rounded-lg border">
-          <EmptyHeader>
-            <EmptyTitle>Could not load streams</EmptyTitle>
-            <EmptyDescription>{error.message}</EmptyDescription>
-          </EmptyHeader>
-          <Button type="button" variant="outline" onClick={() => void refetch()}>
-            Retry
-          </Button>
-        </Empty>
-      ) : isPending ? (
-        <div className="flex h-24 items-center justify-center rounded-lg border">
-          <Spinner />
-        </div>
-      ) : streams.length === 0 ? (
-        <Empty className="rounded-lg border">
-          <EmptyHeader>
-            <EmptyTitle>No streams</EmptyTitle>
-            <EmptyDescription>Initialized project streams will appear here.</EmptyDescription>
-          </EmptyHeader>
-        </Empty>
-      ) : (
-        <div className="rounded-lg border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <SortableHead
-                  active={sort.key === "streamPath"}
-                  direction={sort.direction}
-                  label="Stream path"
-                  onClick={() => setSort(nextSort(sort, "streamPath"))}
-                />
-                <SortableHead
-                  active={sort.key === "createdAt"}
-                  direction={sort.direction}
-                  label="Created"
-                  onClick={() => setSort(nextSort(sort, "createdAt"))}
-                />
-                <SortableHead
-                  active={sort.key === "lastWokenAt"}
-                  direction={sort.direction}
-                  label="Woke"
-                  onClick={() => setSort(nextSort(sort, "lastWokenAt"))}
-                />
-                <TableHead className="w-28 text-right">Events</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {visibleStreams.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={4} className="h-24 text-center text-muted-foreground">
-                    No streams match.
-                  </TableCell>
-                </TableRow>
-              ) : (
-                visibleStreams.map((stream) => (
-                  <TableRow key={stream.name}>
-                    <TableCell className="py-3">
-                      <Link
-                        className="block min-w-0 rounded-sm text-sm font-medium hover:underline"
-                        to="/projects/$projectSlug/streams/$"
-                        params={{
-                          projectSlug: params.projectSlug,
-                          _splat: stream.streamPath,
-                        }}
-                      >
-                        <EventsStreamPathLabel path={stream.streamPath} className="min-w-0" />
-                      </Link>
-                    </TableCell>
-                    <TableCell className="w-40 text-muted-foreground">
-                      {formatRelativeTime(stream.createdAt)}
-                    </TableCell>
-                    <TableCell className="w-40 text-muted-foreground">
-                      {formatRelativeTime(stream.lastWokenAt)}
-                    </TableCell>
-                    <TableCell className="w-28 text-right">
-                      <StreamDebugLink
-                        label="Open"
-                        projectSlug={project.slug}
-                        streamPath={stream.streamPath}
-                      />
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </div>
-      )}
+    <section className="flex min-h-0 flex-1 flex-col p-4">
+      <StreamTreeBrowser source={source} onOpenPath={openStream} />
     </section>
   );
-}
-
-function SortableHead(input: {
-  active: boolean;
-  direction: SortDirection;
-  label: string;
-  onClick: () => void;
-}) {
-  return (
-    <TableHead>
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="-ml-2 h-8 px-2"
-        onClick={input.onClick}
-      >
-        {input.label}
-        <span className="text-[10px] text-muted-foreground">
-          {input.active ? input.direction : "sort"}
-        </span>
-      </Button>
-    </TableHead>
-  );
-}
-
-function nextSort(current: { key: SortKey; direction: SortDirection }, key: SortKey) {
-  if (current.key !== key) return { key, direction: "asc" as const };
-  return { key, direction: current.direction === "asc" ? ("desc" as const) : ("asc" as const) };
-}
-
-function compareStreamRows(
-  left: { streamPath: string; createdAt: string; lastWokenAt: string },
-  right: { streamPath: string; createdAt: string; lastWokenAt: string },
-  key: SortKey,
-) {
-  if (key === "streamPath") return left.streamPath.localeCompare(right.streamPath);
-  return new Date(left[key]).getTime() - new Date(right[key]).getTime();
-}
-
-function formatRelativeTime(value: string) {
-  const seconds = Math.round((Date.now() - new Date(value).getTime()) / 1000);
-  const absoluteSeconds = Math.abs(seconds);
-  const units = [
-    { label: "year", seconds: 31_536_000 },
-    { label: "month", seconds: 2_592_000 },
-    { label: "day", seconds: 86_400 },
-    { label: "hour", seconds: 3_600 },
-    { label: "minute", seconds: 60 },
-  ] as const;
-  const unit = units.find((unit) => absoluteSeconds >= unit.seconds);
-  if (!unit) return seconds < 0 ? "in a few seconds" : "just now";
-
-  const count = Math.round(absoluteSeconds / unit.seconds);
-  const suffix = count === 1 ? unit.label : `${unit.label}s`;
-  return seconds < 0 ? `in ${count} ${suffix}` : `${count} ${suffix} ago`;
 }

--- a/apps/os/src/routes/admin.tsx
+++ b/apps/os/src/routes/admin.tsx
@@ -70,6 +70,9 @@ function AdminLayout() {
           <Link to="/admin" className="hover:text-foreground [&.active]:text-foreground">
             Global stream
           </Link>
+          <Link to="/admin/streams" className="hover:text-foreground [&.active]:text-foreground">
+            Stream explorer
+          </Link>
         </nav>
         <div className="ml-auto text-sm">
           <Link to="/" className="text-muted-foreground hover:text-foreground">

--- a/apps/os/src/routes/admin/streams/$namespace/$.tsx
+++ b/apps/os/src/routes/admin/streams/$namespace/$.tsx
@@ -1,0 +1,66 @@
+import { useMemo } from "react";
+import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
+import { StreamState, type StreamPath as StreamPathType } from "@iterate-com/shared/streams/types";
+import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
+import { StreamTreeBrowser } from "~/components/stream-tree-browser.tsx";
+import { useAdminItx } from "~/lib/admin-itx.ts";
+import { adminStreamRpcPath } from "~/lib/stream-rpc-paths.ts";
+import { streamPathFromSplat, streamPathToSplat } from "~/lib/stream-links.ts";
+
+export const Route = createFileRoute("/admin/streams/$namespace/$")({
+  params: {
+    parse: (raw) => ({
+      _splat: streamPathFromSplat(raw._splat),
+    }),
+    stringify: (parsed) => ({
+      _splat: streamPathToSplat(parsed._splat),
+    }),
+  },
+  ssr: false,
+  component: AdminStreamDetailPage,
+});
+
+function AdminStreamDetailPage() {
+  const { namespace, _splat: streamPath } = Route.useParams();
+  const itx = useAdminItx();
+  const navigate = useNavigate();
+  const source = useMemo(
+    () => ({
+      key: ["admin", "streams", namespace] as const,
+      getState: async (path: StreamPathType) =>
+        StreamState.parse(await itx.streams.namespace(namespace).get(path).getState()),
+    }),
+    [itx, namespace],
+  );
+
+  function openStream(path: StreamPathType) {
+    void navigate({
+      to: "/admin/streams/$namespace/$",
+      params: { namespace, _splat: path },
+    });
+  }
+
+  return (
+    <section className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden lg:grid-cols-[20rem_minmax(0,1fr)]">
+      <aside className="hidden min-h-0 border-r p-3 lg:flex">
+        <StreamTreeBrowser source={source} currentPath={streamPath} onOpenPath={openStream} />
+      </aside>
+      <ProjectStreamView
+        emptyLabel="No events in this stream yet."
+        projectSlug={namespace}
+        projectSlugOrId={namespace}
+        renderStreamPathLink={({ path, children, className }) => (
+          <Link
+            to="/admin/streams/$namespace/$"
+            params={{ namespace, _splat: path }}
+            {...(className == null ? {} : { className })}
+          >
+            {children}
+          </Link>
+        )}
+        streamPath={streamPath}
+        streamUrl={adminStreamRpcPath(namespace, streamPath)}
+      />
+    </section>
+  );
+}

--- a/apps/os/src/routes/admin/streams/$namespace/index.tsx
+++ b/apps/os/src/routes/admin/streams/$namespace/index.tsx
@@ -1,0 +1,42 @@
+import { useMemo } from "react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { StreamState, type StreamPath as StreamPathType } from "@iterate-com/shared/streams/types";
+import { StreamTreeBrowser } from "~/components/stream-tree-browser.tsx";
+import { useAdminItx } from "~/lib/admin-itx.ts";
+
+export const Route = createFileRoute("/admin/streams/$namespace/")({
+  component: AdminStreamNamespacePage,
+});
+
+function AdminStreamNamespacePage() {
+  const { namespace } = Route.useParams();
+  const itx = useAdminItx();
+  const navigate = useNavigate();
+  const source = useMemo(
+    () => ({
+      key: ["admin", "streams", namespace] as const,
+      getState: async (streamPath: StreamPathType) =>
+        StreamState.parse(await itx.streams.namespace(namespace).get(streamPath).getState()),
+    }),
+    [itx, namespace],
+  );
+
+  function openStream(streamPath: StreamPathType) {
+    void navigate({
+      to: "/admin/streams/$namespace/$",
+      params: { namespace, _splat: streamPath },
+    });
+  }
+
+  return (
+    <section className="flex min-h-0 flex-1 flex-col gap-3 p-4">
+      <div className="min-w-0">
+        <h1 className="truncate text-lg font-semibold">
+          Namespace{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">{namespace}</code>
+        </h1>
+      </div>
+      <StreamTreeBrowser source={source} onOpenPath={openStream} />
+    </section>
+  );
+}

--- a/apps/os/src/routes/admin/streams/$namespace/route.tsx
+++ b/apps/os/src/routes/admin/streams/$namespace/route.tsx
@@ -1,0 +1,13 @@
+import { Outlet, createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/admin/streams/$namespace")({
+  component: AdminStreamNamespaceLayout,
+});
+
+function AdminStreamNamespaceLayout() {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <Outlet />
+    </div>
+  );
+}

--- a/apps/os/src/routes/admin/streams/index.tsx
+++ b/apps/os/src/routes/admin/streams/index.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Button } from "@iterate-com/ui/components/button";
+import { Input } from "@iterate-com/ui/components/input";
+import { toast } from "@iterate-com/ui/components/sonner";
+import { StreamNamespace } from "@iterate-com/shared/streams/types";
+
+export const Route = createFileRoute("/admin/streams/")({
+  component: AdminStreamsNamespacePicker,
+});
+
+function AdminStreamsNamespacePicker() {
+  const navigate = useNavigate();
+  const [namespace, setNamespace] = useState("global");
+
+  function submit() {
+    const parsed = StreamNamespace.safeParse(namespace);
+    if (!parsed.success) {
+      toast.error("Namespace must be a non-empty stream namespace.");
+      return;
+    }
+
+    void navigate({
+      to: "/admin/streams/$namespace",
+      params: { namespace: parsed.data },
+    });
+  }
+
+  return (
+    <section className="flex min-h-0 flex-1 flex-col gap-4 p-4">
+      <form
+        className="flex max-w-xl flex-col gap-2 sm:flex-row"
+        onSubmit={(event) => {
+          event.preventDefault();
+          submit();
+        }}
+      >
+        <Input
+          value={namespace}
+          onChange={(event) => setNamespace(event.currentTarget.value)}
+          placeholder="global or project id"
+          aria-label="Stream namespace"
+          className="font-mono"
+        />
+        <Button type="submit">Open namespace</Button>
+      </form>
+    </section>
+  );
+}

--- a/apps/os/src/routes/admin/streams/route.tsx
+++ b/apps/os/src/routes/admin/streams/route.tsx
@@ -1,0 +1,13 @@
+import { Outlet, createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/admin/streams")({
+  component: AdminStreamsLayout,
+});
+
+function AdminStreamsLayout() {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <Outlet />
+    </div>
+  );
+}

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -29,6 +29,7 @@ import { lookupIngressRule } from "~/ingress/lookup.ts";
 import { handleMcpFetch } from "~/domains/inbound-mcp-server/mcp-handler.ts";
 import { handleArtifactEventsBatch } from "~/domains/repos/artifact-events-queue-handler.ts";
 import { handleItxFetch, handleProjectHostItxFetch } from "~/itx/fetch.ts";
+import { handleAdminStreamRpcFetch } from "~/domains/streams/admin-stream-rpc.ts";
 import { handleProjectStreamRpcFetch } from "~/domains/streams/project-stream-rpc.ts";
 import { handleDocsMarkdownFetch } from "~/lib/docs-markdown.ts";
 
@@ -149,6 +150,14 @@ export default {
 
         const streamRpcResponse = await handleProjectStreamRpcFetch({ context, env, request });
         if (streamRpcResponse) return streamRpcResponse;
+
+        const adminStreamRpcResponse = await handleAdminStreamRpcFetch({
+          config: requestConfig,
+          context,
+          env,
+          request,
+        });
+        if (adminStreamRpcResponse) return adminStreamRpcResponse;
 
         const itxResponse = await handleItxFetch({ config, context, env, request });
         if (itxResponse) return itxResponse;


### PR DESCRIPTION
## What changed

- Replaced the project streams table with a lazy runtime-state stream tree rooted at `/`.
- Added reusable stream tree browsing UI backed by `StreamState.childPaths`.
- Switched stream breadcrumbs children/sibling navigation to read from stream reduced state instead of `streams.list`.
- Added admin stream explorer routes under `/admin/streams` with a namespace selector and detail views.
- Added an admin-only stream RPC endpoint for arbitrary namespaces so admin stream detail pages can reuse the existing stream viewer.

## Why

Stream navigation should reflect the runtime stream model directly. Child streams already live in core reduced state, so the UI no longer needs a project-wide stream list or fake D1-style stream timestamps.

## Validation

- `pnpm --dir apps/os typecheck`
- `pnpm lint`
- `pnpm --dir apps/os test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds admin-only cross-namespace stream RPC and itx `streams.namespace`; misconfiguration could expose arbitrary namespaces, though both paths require admin credentials.
> 
> **Overview**
> Stream navigation now follows **runtime reduced state** (`StreamState.childPaths`) instead of a project-wide `streams.list()` inventory.
> 
> The project **streams index** drops the sortable table, filter/create flow, and D1-style metadata in favor of a lazy **`StreamTreeBrowser`** rooted at `/`. **Breadcrumbs** use the same model: sibling and child pickers read `childPaths` from parent/current stream state via new **`useProjectStreamState`**, and client-side `isImmediateChild` filtering is removed.
> 
> **`ProjectStreamView`** gains optional **`streamUrl`** and **`renderStreamPathLink`** so admin pages can reuse the feed viewer with non-project RPC URLs and links.
> 
> For operators, **`/admin/streams`** adds a namespace picker, per-namespace tree views, and a split tree + stream detail layout. Backend support includes **`itx.streams.namespace(...)`** (admin access only), **`/api/admin-streams/<namespace>/…`** Cap'n Web RPC gated by the admin cookie, and worker dispatch for that route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae6e4cc3796369a5faa8ee0cddec7b256884f41a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T13:42:03.663Z",
      "headSha": "ae6e4cc3796369a5faa8ee0cddec7b256884f41a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27279695602",
      "shortSha": "ae6e4cc"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-06-10T13:41:50.532Z",
      "headSha": "ee0579d59e549673b1e1d8a4838a7081f4d7f4fa",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27278638401",
      "shortSha": "ee0579d"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `ae6e4cc`
Preview: https://os.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27279695602)
Updated: 2026-06-10T13:42:03.663Z

### Semaphore
Status: released
Commit: `ee0579d`
Preview: https://semaphore.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27278638401)
Updated: 2026-06-10T13:41:50.532Z
<!-- /CLOUDFLARE_PREVIEW -->