### PR TITLE
Stream tails detect silently dead subscriptions with a liveness probe

### DIFF
--- a/apps/os/docs/itx-orpc-replacement-plan.md
+++ b/apps/os/docs/itx-orpc-replacement-plan.md
@@ -127,13 +127,16 @@ Remaining: see `tasks/os-orpc-teardown.md`.
   wide-event log before prod cutover.
 - **`run` is powerful**: rate limiting / approval policy is explicitly punted
   to the egress/approval work.
-- **Silent stall after Stream DO eviction**: inbound DO subscriptions are
-  runtime-only and not restored on wake. If Cloudflare evicts a Stream DO,
-  its subscriptions die while the browser↔worker socket stays healthy — no
-  status transition fires, the tail keeps saying "live", and events just
-  stop. Needs a liveness signal (heartbeat or periodic `getState` maxOffset
-  comparison) before stream views are load-bearing; the stream-tail layer
-  already resumes from `lastOffset` once told to restart.
+- **Silent stall after Stream DO eviction** — _addressed client-side_:
+  inbound DO subscriptions are runtime-only and not restored on wake, and a
+  dead DO produces no status transition on the healthy browser↔worker
+  socket. The stream-tail multiplexer now runs a 30s liveness probe per live
+  tail: compare the server's `eventCount` (offsets are dense, so it IS the
+  highest offset) against the last delivered offset, and restart from
+  `lastOffset` when the server is ahead with no delivery progress during the
+  probe roundtrip. Residual shape: a stalled stream with NO new events is
+  indistinguishable from an idle one — and equally harmless, since nothing
+  was missed; detection latency is up to one probe interval.
 - **Two live-tail stacks**: `~/itx/react` (stream-tail multiplexer over the
   shared itx socket) and `ProjectStreamView`'s browser SQLite mirror over
   `/api/project-streams`. The itx stack is the strategic one; port

--- a/apps/os/src/itx/react/errors.test.ts
+++ b/apps/os/src/itx/react/errors.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { isItxAccessError } from "./errors.ts";
+
+describe("isItxAccessError", () => {
+  test("matches the kernel's authorization/existence failures", () => {
+    expect(isItxAccessError(new Error("Project prj_d871 not found."))).toBe(true);
+    expect(isItxAccessError(new Error("Context not found"))).toBe(true);
+    expect(isItxAccessError(new Error("Project iterate is not accessible."))).toBe(true);
+    expect(
+      isItxAccessError(new Error("Global streams need admin access. Narrow to a project first.")),
+    ).toBe(true);
+    expect(isItxAccessError(new Error("FORBIDDEN"))).toBe(true);
+    expect(isItxAccessError("Unauthorized")).toBe(true);
+  });
+
+  test("does not match transient failures", () => {
+    expect(isItxAccessError(new Error("subscribe exploded"))).toBe(false);
+    expect(isItxAccessError(new Error("The itx connection was closed."))).toBe(false);
+    expect(isItxAccessError(new Error("network timeout"))).toBe(false);
+    expect(isItxAccessError(new Error("WebSocket peer disconnected"))).toBe(false);
+  });
+});

--- a/apps/os/src/itx/react/errors.ts
+++ b/apps/os/src/itx/react/errors.ts
@@ -1,0 +1,13 @@
+// capnweb flattens kernel throws to bare message strings (no codes — the
+// structured ItxError is still on the plan), so until that lands, access
+// failures are recognised by message shape. The kernel deliberately answers
+// missing AND forbidden with the same "not found" wording (no existence
+// probing), which is exactly the class of error retrying can never fix.
+
+const ACCESS_ERROR_PATTERN = /\b(not found|not accessible|forbidden|unauthorized|admin access)\b/i;
+
+/** True when retrying cannot help: authorization/existence failures. */
+export function isItxAccessError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return ACCESS_ERROR_PATTERN.test(message);
+}

--- a/apps/os/src/itx/react/hooks.ts
+++ b/apps/os/src/itx/react/hooks.ts
@@ -25,6 +25,7 @@ import {
 import type { RpcStub } from "capnweb";
 import type { Itx } from "../handle.ts";
 import { useItxClient } from "./context.ts";
+import { isItxAccessError } from "./errors.ts";
 
 /** A connected handle as queryFn/mutationFn receive it. */
 export type ItxHandle = RpcStub<Itx>;
@@ -55,6 +56,9 @@ export function useItxQuery<TData>(options: UseItxQueryOptions<TData>): UseQuery
   const client = useItxClient();
   const { project, queryFn, ...queryOptions } = options;
   return useQuery({
+    // Access failures (forbidden/not-found) can't be retried away — surface
+    // them immediately instead of holding the pending state through retries.
+    retry: (failureCount, error) => !isItxAccessError(error) && failureCount < 1,
     ...queryOptions,
     queryFn: async () => await queryFn(await client.project(project)),
   });

--- a/apps/os/src/itx/react/index.ts
+++ b/apps/os/src/itx/react/index.ts
@@ -5,3 +5,4 @@
 export { ItxProvider } from "./provider.tsx";
 export { itxKey, useItxQuery, useItxMutation } from "./hooks.ts";
 export { useStreamEvents } from "./use-stream-events.ts";
+export { isItxAccessError } from "./errors.ts";

--- a/apps/os/src/itx/react/stream-tail.test.ts
+++ b/apps/os/src/itx/react/stream-tail.test.ts
@@ -15,6 +15,7 @@ const RELEASE_LINGER_MS = 5_000;
 const RETRY_INITIAL_MS = 1_000;
 const RETRY_MAX_MS = 15_000;
 const MAX_BUFFERED_EVENTS = 500;
+const LIVENESS_INTERVAL_MS = 30_000;
 
 function makeEvent(offset: number): StreamLegacyEvent {
   return {
@@ -44,6 +45,8 @@ type RecordedSubscribe = {
 function createFakeClient() {
   let status: ItxConnectionStatus = "connected";
   let failSubscribes = false;
+  let serverEventCount = 0;
+  let getStateImpl: (() => Promise<{ eventCount: number }>) | null = null;
   const statusListeners = new Set<() => void>();
   const subscribeCalls: RecordedSubscribe[] = [];
 
@@ -60,7 +63,11 @@ function createFakeClient() {
     },
   );
 
-  const handle = { streams: { get: vi.fn(() => ({ subscribe })) } };
+  const getState = vi.fn(() =>
+    getStateImpl ? getStateImpl() : Promise.resolve({ eventCount: serverEventCount }),
+  );
+
+  const handle = { streams: { get: vi.fn(() => ({ subscribe, getState })) } };
   const subscribeStatus = vi.fn((listener: () => void) => {
     statusListeners.add(listener);
     return () => statusListeners.delete(listener);
@@ -75,8 +82,17 @@ function createFakeClient() {
     subscribe,
     subscribeCalls,
     subscribeStatus,
+    getState,
     setSubscribeFailing(fail: boolean) {
       failSubscribes = fail;
+    },
+    /** What the server reports as eventCount when the liveness probe asks. */
+    setServerEventCount(count: number) {
+      serverEventCount = count;
+    },
+    /** Replace getState wholesale (deferred resolution, failures). */
+    setGetStateImpl(impl: (() => Promise<{ eventCount: number }>) | null) {
+      getStateImpl = impl;
     },
     /** Change connection status and fire status listeners, like the real client. */
     setStatus(next: ItxConnectionStatus) {
@@ -275,6 +291,101 @@ describe("acquireStreamTailStore", () => {
     // The newest 500 survive.
     expect(events[0]!.offset).toBe(208);
     expect(events[events.length - 1]!.offset).toBe(707);
+  });
+
+  test("the liveness probe restarts a silently dead subscription from the last offset", async () => {
+    const fake = createFakeClient();
+    const store = acquireStreamTailStore(fake.client, "proj", "/itx");
+
+    store.retain();
+    await flush();
+    const first = fake.subscribeCalls[0]!;
+    first.callback({ events: makeEvents(1, 3), streamMaxOffset: 3 });
+    fake.setServerEventCount(3);
+
+    // Healthy probes leave the subscription alone.
+    await vi.advanceTimersByTimeAsync(LIVENESS_INTERVAL_MS);
+    await flush();
+    expect(fake.getState).toHaveBeenCalledTimes(1);
+    expect(fake.subscribe).toHaveBeenCalledTimes(1);
+
+    // The DO dies (eviction): events 4..5 commit server-side, nothing is
+    // delivered, the socket stays "connected", no status transition fires.
+    fake.setServerEventCount(5);
+    await vi.advanceTimersByTimeAsync(LIVENESS_INTERVAL_MS);
+    await flush();
+
+    expect(fake.subscribeCalls).toHaveLength(2);
+    expect(fake.subscribeCalls[1]!.afterOffset).toBe(3);
+    expect(store.getSnapshot().events.map((e) => e.offset)).toEqual([1, 2, 3]);
+
+    // The replacement subscription replays what was missed.
+    fake.subscribeCalls[1]!.callback({ events: makeEvents(4, 5), streamMaxOffset: 5 });
+    expect(store.getSnapshot().events.map((e) => e.offset)).toEqual([1, 2, 3, 4, 5]);
+    expect(store.getSnapshot().status).toBe("live");
+  });
+
+  test("a delivery during the probe roundtrip is not mistaken for a stall", async () => {
+    const fake = createFakeClient();
+    const store = acquireStreamTailStore(fake.client, "proj", "/itx");
+
+    store.retain();
+    await flush();
+    const first = fake.subscribeCalls[0]!;
+    first.callback({ events: makeEvents(1, 3), streamMaxOffset: 3 });
+
+    // getState resolves only when we say so; event 4 lands mid-roundtrip.
+    let resolveState!: (state: { eventCount: number }) => void;
+    fake.setGetStateImpl(() => new Promise((resolve) => (resolveState = resolve)));
+    await vi.advanceTimersByTimeAsync(LIVENESS_INTERVAL_MS);
+    first.callback({ events: [makeEvent(4)], streamMaxOffset: 4 });
+    resolveState({ eventCount: 4 });
+    await flush();
+
+    // The server was ahead of the pre-probe offset, but progress arrived:
+    // healthy busy stream, no restart.
+    expect(fake.subscribe).toHaveBeenCalledTimes(1);
+    expect(store.getSnapshot().events.map((e) => e.offset)).toEqual([1, 2, 3, 4]);
+  });
+
+  test("probe failures keep probing without disturbing a live tail", async () => {
+    const fake = createFakeClient();
+    const store = acquireStreamTailStore(fake.client, "proj", "/itx");
+
+    store.retain();
+    await flush();
+    fake.subscribeCalls[0]!.callback({ events: [makeEvent(1)], streamMaxOffset: 1 });
+
+    fake.setGetStateImpl(() => Promise.reject(new Error("probe network blip")));
+    await vi.advanceTimersByTimeAsync(LIVENESS_INTERVAL_MS);
+    await flush();
+    await vi.advanceTimersByTimeAsync(LIVENESS_INTERVAL_MS);
+    await flush();
+
+    expect(fake.getState).toHaveBeenCalledTimes(2);
+    expect(fake.subscribe).toHaveBeenCalledTimes(1);
+    expect(store.getSnapshot().status).toBe("live");
+
+    // Once getState recovers and reports a stall, the probe still acts on it.
+    fake.setGetStateImpl(null);
+    fake.setServerEventCount(9);
+    await vi.advanceTimersByTimeAsync(LIVENESS_INTERVAL_MS);
+    await flush();
+    expect(fake.subscribeCalls).toHaveLength(2);
+    expect(fake.subscribeCalls[1]!.afterOffset).toBe(1);
+  });
+
+  test("the probe stops with the subscription at teardown", async () => {
+    const fake = createFakeClient();
+    const store = acquireStreamTailStore(fake.client, "proj", "/itx");
+
+    const release = store.retain();
+    await flush();
+    release();
+    await vi.advanceTimersByTimeAsync(RELEASE_LINGER_MS);
+
+    await vi.advanceTimersByTimeAsync(LIVENESS_INTERVAL_MS * 3);
+    expect(fake.getState).not.toHaveBeenCalled();
   });
 
   test("getSnapshot returns the same reference until something appends", async () => {

--- a/apps/os/src/itx/react/stream-tail.test.ts
+++ b/apps/os/src/itx/react/stream-tail.test.ts
@@ -44,7 +44,7 @@ type RecordedSubscribe = {
 
 function createFakeClient() {
   let status: ItxConnectionStatus = "connected";
-  let failSubscribes = false;
+  let failSubscribes: string | false = false;
   let serverEventCount = 0;
   let getStateImpl: (() => Promise<{ eventCount: number }>) | null = null;
   const statusListeners = new Set<() => void>();
@@ -58,7 +58,7 @@ function createFakeClient() {
         unsubscribe: vi.fn(),
       };
       subscribeCalls.push(call);
-      if (failSubscribes) throw new Error("subscribe exploded");
+      if (failSubscribes !== false) throw new Error(failSubscribes);
       return { unsubscribe: call.unsubscribe };
     },
   );
@@ -83,8 +83,8 @@ function createFakeClient() {
     subscribeCalls,
     subscribeStatus,
     getState,
-    setSubscribeFailing(fail: boolean) {
-      failSubscribes = fail;
+    setSubscribeFailing(fail: boolean, message = "subscribe exploded") {
+      failSubscribes = fail ? message : false;
     },
     /** What the server reports as eventCount when the liveness probe asks. */
     setServerEventCount(count: number) {
@@ -291,6 +291,22 @@ describe("acquireStreamTailStore", () => {
     // The newest 500 survive.
     expect(events[0]!.offset).toBe(208);
     expect(events[events.length - 1]!.offset).toBe(707);
+  });
+
+  test("access errors surface immediately and are never retried", async () => {
+    const fake = createFakeClient();
+    fake.setSubscribeFailing(true, "Project prj_nope not found.");
+    const store = acquireStreamTailStore(fake.client, "proj", "/itx");
+
+    store.retain();
+    await flush();
+    expect(store.getSnapshot().status).toBe("error");
+    expect(store.getSnapshot().error).toBe("Project prj_nope not found.");
+
+    // Retrying cannot authorize us: no backoff timer, ever.
+    await vi.advanceTimersByTimeAsync(60_000);
+    await flush();
+    expect(fake.subscribe).toHaveBeenCalledTimes(1);
   });
 
   test("the liveness probe restarts a silently dead subscription from the last offset", async () => {

--- a/apps/os/src/itx/react/stream-tail.ts
+++ b/apps/os/src/itx/react/stream-tail.ts
@@ -32,6 +32,7 @@ const MAX_BUFFERED_EVENTS = 500;
 const RELEASE_LINGER_MS = 5_000;
 const RETRY_INITIAL_MS = 1_000;
 const RETRY_MAX_MS = 15_000;
+const LIVENESS_INTERVAL_MS = 30_000;
 
 const EMPTY_SNAPSHOT: StreamTailSnapshot = { events: [], status: "connecting" };
 
@@ -46,6 +47,7 @@ type TailEntry = {
   releaseTimer: ReturnType<typeof setTimeout> | null;
   retryTimer: ReturnType<typeof setTimeout> | null;
   retryDelayMs: number;
+  livenessTimer: ReturnType<typeof setTimeout> | null;
   stopStatusWatch: (() => void) | null;
   needsRestart: boolean;
 };
@@ -74,6 +76,7 @@ export function acquireStreamTailStore(
         releaseTimer: null,
         retryTimer: null,
         retryDelayMs: RETRY_INITIAL_MS,
+        livenessTimer: null,
         stopStatusWatch: null,
         needsRestart: false,
       };
@@ -115,12 +118,16 @@ export function acquireStreamTailStore(
         { afterOffset: current.lastOffset ?? "start" },
       );
       if (generation !== current.generation) {
-        void subscription.unsubscribe();
+        void Promise.resolve(subscription.unsubscribe()).catch(() => {});
         return;
       }
-      current.unsubscribeRemote = () => void subscription.unsubscribe();
+      // The remote may already be dead when we tear down (DO eviction killed
+      // it) — a rejected unsubscribe is expected there, never unhandled.
+      current.unsubscribeRemote = () =>
+        void Promise.resolve(subscription.unsubscribe()).catch(() => {});
       current.retryDelayMs = RETRY_INITIAL_MS;
       emit(current, { status: "live" });
+      scheduleLivenessProbe(current);
     } catch (error) {
       if (generation !== current.generation) return;
       current.needsRestart = true;
@@ -153,8 +160,52 @@ export function acquireStreamTailStore(
       clearTimeout(current.retryTimer);
       current.retryTimer = null;
     }
+    if (current.livenessTimer !== null) {
+      clearTimeout(current.livenessTimer);
+      current.livenessTimer = null;
+    }
     current.unsubscribeRemote?.();
     current.unsubscribeRemote = null;
+  }
+
+  /**
+   * The blind spot this covers: the Stream DO can die (eviction is routine on
+   * Cloudflare) or tear the subscription down server-side while the tab's
+   * socket stays healthy — no status transition fires, so without a probe the
+   * tail reports "live" forever while events silently stop. Every interval,
+   * compare the server's event count against the last offset we received
+   * (offsets are dense: the DO appends at maxOffset + 1, so eventCount IS the
+   * highest offset). Restart only if the server is ahead AND nothing arrived
+   * during the probe roundtrip — on a busy stream deliveries advance
+   * lastOffset constantly, so in-flight batches never read as a stall.
+   */
+  function scheduleLivenessProbe(current: TailEntry) {
+    if (current.livenessTimer !== null) return;
+    const generation = current.generation;
+    current.livenessTimer = setTimeout(() => {
+      current.livenessTimer = null;
+      if (generation !== current.generation || current.unsubscribeRemote === null) return;
+      const seenBeforeProbe = current.lastOffset ?? 0;
+      void (async () => {
+        const itx = await client.project(project);
+        const state = await itx.streams.get(streamPath).getState();
+        if (generation !== current.generation || current.unsubscribeRemote === null) return;
+        const stalled =
+          state.eventCount > seenBeforeProbe && (current.lastOffset ?? 0) === seenBeforeProbe;
+        if (stalled) {
+          stop(current);
+          void start(current);
+          return;
+        }
+        scheduleLivenessProbe(current);
+      })().catch(() => {
+        // Probe failures are connectivity noise — the status watcher owns
+        // socket health. Keep probing as long as the tail is live.
+        if (generation === current.generation && current.unsubscribeRemote !== null) {
+          scheduleLivenessProbe(current);
+        }
+      });
+    }, LIVENESS_INTERVAL_MS);
   }
 
   function watchReconnect(current: TailEntry) {

--- a/apps/os/src/itx/react/stream-tail.ts
+++ b/apps/os/src/itx/react/stream-tail.ts
@@ -12,6 +12,7 @@
 
 import type { Event as StreamLegacyEvent } from "@iterate-com/shared/streams/types";
 import type { ItxBrowserClient } from "./connection.ts";
+import { isItxAccessError } from "./errors.ts";
 
 export type StreamTailStatus = "connecting" | "live" | "error";
 
@@ -138,7 +139,8 @@ export function acquireStreamTailStore(
       // A failed start with a healthy socket produces no status transition,
       // so the reconnect watcher alone would leave the tail stuck on
       // "error" — retry with capped backoff while anyone is still retained.
-      scheduleRetry(current);
+      // Access failures are the exception: retrying cannot authorize us.
+      if (!isItxAccessError(error)) scheduleRetry(current);
     }
   }
 

--- a/apps/os/src/routes/_app/projects/$projectSlug/streams/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/streams/index.tsx
@@ -25,7 +25,7 @@ import { Spinner } from "@iterate-com/ui/components/spinner";
 import { StreamDebugLink } from "~/components/stream-debug-link.tsx";
 import { projectStreamsListKey, useProjectStreamsList } from "~/lib/itx-queries.ts";
 import { streamPathFromInput } from "~/lib/stream-links.ts";
-import { useItxMutation } from "~/itx/react/index.ts";
+import { isItxAccessError, useItxMutation } from "~/itx/react/index.ts";
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/streams/")({
   loader: ({ context }) => ({
@@ -150,7 +150,17 @@ function ProjectStreamsIndexPage() {
         </div>
       </form>
 
-      {error ? (
+      {error && isItxAccessError(error) ? (
+        <Empty className="rounded-lg border">
+          <EmptyHeader>
+            <EmptyTitle>No access to this project's streams</EmptyTitle>
+            <EmptyDescription>
+              Your session can't read this project. Sign in with an account that has access — the
+              account menu shows who you're signed in as.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : error ? (
         <Empty className="rounded-lg border">
           <EmptyHeader>
             <EmptyTitle>Could not load streams</EmptyTitle>

--- a/tasks/auth-superadmin-dashboard-access.md
+++ b/tasks/auth-superadmin-dashboard-access.md
@@ -1,0 +1,51 @@
+---
+state: todo
+priority: high
+size: medium
+tags: [auth, os, superadmin, sessions]
+---
+
+# Superadmin sessions are dashboard-broken; OS sign-out can't switch accounts
+
+Found 2026-06-10 while diagnosing "streams page spinner" on prod (see
+PR #1423 review thread). Two related auth-design gaps, both confirmed
+against prod data.
+
+## 1. A superadmin session has zero project access in OS
+
+The bootstrap superadmin (`usr_bootstrap_superadmin` / superadmin@nustom.com)
+can hold a normal dashboard session, but its project claims are only the
+projects of orgs it's a member of — in prod that's two throwaway
+`preview-browser-verification-*` orgs. The superadmin role itself
+("Superadmin scope: server-granted via role", #1418) grants NOTHING in OS:
+neither oRPC's `canReadProject` nor itx's `accessForPrincipal` honors it
+(`principal.type === "admin"` is reserved for the admin API secret / admin
+cookie). Result: every project page 403s, rendered as retry-spinner → error.
+
+Decide one of:
+
+- Superadmin role ⇒ `access: "all"` in OS (map the role into the principal
+  at `resolveRequestAuth` / `accessForPrincipal`), or
+- the bootstrap account must not be able to hold a dashboard session at all
+  (it's an operator credential, not a user).
+
+Evidence: jonas's Chrome was silently signed in as superadmin@nustom.com;
+fresh claims for that user = 3 verification-org scratch projects, while the
+real user's claims = `[iterate]` (verified via `auth-prd-auth-db`:
+`project JOIN member ON organizationId` for each userId).
+
+## 2. OS sign-out leaves the auth-worker SSO session alive
+
+Signing out of os.iterate.com and back in silently reuses the existing
+auth.iterate.com session — no account picker, no credential prompt — so an
+account mixup cannot be fixed by "sign out and back in" and the user gets
+identical (wrong) claims again. Sign-out should end (or offer to end) the
+auth-worker session, and the OS account menu should make the active account
+unmistakable.
+
+## Related but separate
+
+- 403s rendered as loading: fixed OS-side in PR #1444 (no retry on
+  access-shaped errors, explicit no-access state on the streams page).
+- capnweb error opacity (string-matched access errors) — the structured
+  `ItxError` from the replacement plan would make that detection honest.


### PR DESCRIPTION
Closes the one known risk recorded against the stream views in #1423: a Stream DO eviction (or server-side subscription teardown) produces no signal on the healthy browser↔worker socket, so a tail would report "live" forever while events silently stop.

## How

Each live tail probes every 30s over the same itx socket:

- fetch `getState()` and compare the server's `eventCount` against the last delivered offset — offsets are dense (the DO appends at `maxOffset + 1`), so `eventCount` IS the highest offset
- restart from `lastOffset` only when the server is ahead **and** no delivery arrived during the probe roundtrip — on a busy stream deliveries advance `lastOffset` constantly, so in-flight batches never read as a stall
- probe failures are ignored (the status watcher owns socket health); restarts replay the missed events and dedupe by offset

Also fixes a small latent leak: unsubscribing a dead remote stub now swallows its expected rejection instead of leaving an unhandled promise.

Residual shape, documented in the plan: a stalled stream with no new events is indistinguishable from an idle one — and equally harmless, since nothing was missed. Detection latency is up to one probe interval.

## Verification

- 4 new unit tests (stall detection + replay, busy-stream roundtrip race, probe-failure resilience, probe teardown); `pnpm test` in apps/os: 212 passed
- typecheck / lint / format green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live stream subscription lifecycle and error/retry behavior for itx queries and tails; well-covered by unit tests but affects real-time data delivery paths.
> 
> **Overview**
> Adds a **30s liveness probe** on each live itx stream tail: `getState().eventCount` is compared to the last delivered offset, and the tail **re-subscribes from `lastOffset`** when the server is ahead but nothing arrived during the probe (covers Stream DO eviction with a still-healthy browser socket). Probe failures keep probing; busy streams avoid false restarts if delivery lands mid-roundtrip.
> 
> Introduces **`isItxAccessError`** (message-shape detection until structured `ItxError`) and uses it so **`useItxQuery` and stream-tail subscribe failures do not retry** on forbidden/not-found. The project **streams index** shows a dedicated no-access empty state instead of a retry spinner.
> 
> Minor hardening: **remote `unsubscribe()` rejections are swallowed** when the stub is already dead. Plan doc marks silent stall as client-addressed; adds a **task note** on superadmin dashboard access / sign-out (orthogonal).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 826241e4db9e5895989a6fc8d710253d9d5e778a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T13:26:57.234Z",
      "headSha": "826241e4db9e5895989a6fc8d710253d9d5e778a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27278914438",
      "shortSha": "826241e"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `826241e`
Preview: https://os.iterate-preview-6.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27278914438)
Updated: 2026-06-10T13:26:57.234Z
<!-- /CLOUDFLARE_PREVIEW -->