### PR TITLE
Stream list reads the root's reduced state: one getState instead of a DO walk

### DIFF
--- a/apps/os/src/domains/streams/entrypoints/streams-capability.ts
+++ b/apps/os/src/domains/streams/entrypoints/streams-capability.ts
@@ -163,10 +163,17 @@ export class StreamsCapability extends WorkerEntrypoint<
   }
 
   async list() {
-    const paths = await listNamespaceStreamPaths({
+    // One Durable Object call: every stream/created is announced to all of its
+    // ancestor streams, and the root stream's reduced state accumulates the
+    // full announced paths in descendantPaths. Streams persisted before that
+    // field existed are rebuilt by CORE_STATE_VERSION replay on their next
+    // wake, so the root state is authoritative — no per-stream DO walk.
+    const rootState = await getNamespaceStreamState({
       durableObjectNamespace: this.env.STREAM,
       namespace: this.ctx.props.projectId,
+      path: StreamPath.parse("/"),
     });
+    const paths = ["/", ...rootState.descendantPaths];
     return paths.map((path) => ({
       name: `${this.ctx.props.projectId}:${path}`,
       namespace: this.ctx.props.projectId,
@@ -458,31 +465,6 @@ async function getNamespaceStreamState(args: {
 }) {
   const stub = await getInitializedNamespaceStreamStub(args);
   return await stub.getState();
-}
-
-async function listNamespaceStreamPaths(args: {
-  durableObjectNamespace: DurableObjectNamespace<StreamDurableObject>;
-  namespace: string;
-}) {
-  const visited = new Set<string>();
-  const paths: StreamPath[] = [];
-
-  async function visit(path: StreamPath) {
-    if (visited.has(path)) return;
-    visited.add(path);
-    paths.push(path);
-    const state = await getNamespaceStreamState({
-      durableObjectNamespace: args.durableObjectNamespace,
-      namespace: args.namespace,
-      path,
-    });
-    for (const childPath of state.childPaths) {
-      await visit(StreamPath.parse(childPath));
-    }
-  }
-
-  await visit(StreamPath.parse("/"));
-  return paths;
 }
 
 async function* streamNamespaceStreamEvents(args: {

--- a/apps/os/src/domains/streams/new-stream-runtime.ts
+++ b/apps/os/src/domains/streams/new-stream-runtime.ts
@@ -94,6 +94,9 @@ function toLegacyStreamState(
     path: StreamPath.parse(core.path),
     eventCount: core.eventCount,
     childPaths: core.childPaths.map((childPath: string) => StreamPath.parse(childPath)),
+    descendantPaths: core.descendantPaths.map((descendantPath: string) =>
+      StreamPath.parse(descendantPath),
+    ),
     metadata: core.metadata as StreamState["metadata"],
     processors: {
       "circuit-breaker": {

--- a/apps/os/src/durable-objects/itx-stream-subscribe-test-entry.ts
+++ b/apps/os/src/durable-objects/itx-stream-subscribe-test-entry.ts
@@ -1,6 +1,6 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import type { StreamCursor, Event as StreamLegacyEvent } from "@iterate-com/shared/streams/types";
-import { ItxStream, type ItxRuntime } from "~/itx/handle.ts";
+import { ItxStream, ItxStreams, type ItxRuntime } from "~/itx/handle.ts";
 
 export { StreamsCapability } from "~/domains/streams/entrypoints/streams-capability.ts";
 export { Stream as StreamDurableObject } from "@iterate-com/streams/workers/durable-objects/stream";
@@ -27,6 +27,10 @@ export class ItxStreamHarness extends WorkerEntrypoint<Env> {
     return (await this.#stream(input.path).read()) as StreamLegacyEvent[];
   }
 
+  async list(): Promise<{ streamPath: string }[]> {
+    return await new ItxStreams(this.#runtime(), projectId).list();
+  }
+
   async subscribe(
     input: { afterOffset: StreamCursor; path: string },
     onEventBatch: (batch: { events: StreamLegacyEvent[]; streamMaxOffset: number }) => unknown,
@@ -37,9 +41,13 @@ export class ItxStreamHarness extends WorkerEntrypoint<Env> {
   }
 
   #stream(path: string): ItxStream {
-    // ItxStream only touches `runtime.exports`; the rest of ItxRuntime is
-    // connect-time wiring this harness does not exercise.
-    const runtime: ItxRuntime = {
+    return new ItxStream(this.#runtime(), projectId, path);
+  }
+
+  #runtime(): ItxRuntime {
+    // ItxStream/ItxStreams only touch `runtime.exports`; the rest of
+    // ItxRuntime is connect-time wiring this harness does not exercise.
+    return {
       access: [projectId],
       config: null as never,
       contextId: projectId,
@@ -47,7 +55,6 @@ export class ItxStreamHarness extends WorkerEntrypoint<Env> {
       exports: this.ctx.exports as unknown as ItxRuntime["exports"],
       projectId,
     };
-    return new ItxStream(runtime, projectId, path);
   }
 }
 

--- a/apps/os/src/durable-objects/itx-stream-subscribe.test.ts
+++ b/apps/os/src/durable-objects/itx-stream-subscribe.test.ts
@@ -4,11 +4,13 @@
 // .subscribe → Stream DO holds the wrapper. The key risk under test is
 // lifetime: deliveries must keep arriving after every initiating RPC call has
 // returned, for as long as the returned subscription handle is held.
-import { env } from "cloudflare:test";
+import { env, runInDurableObject } from "cloudflare:test";
 import { describe, expect, test, vi } from "vitest";
 import type { StreamCursor, Event as StreamEvent } from "@iterate-com/shared/streams/types";
 
 const TEST_EVENT_TYPE = "test.iterate.com/itx-subscribe/marker";
+// Must match the harness entrypoint's project id (itx-stream-subscribe-test-entry.ts).
+const PROJECT_ID = "proj__test__itxsubscribe";
 
 type EventBatch = { events: StreamEvent[]; streamMaxOffset: number };
 
@@ -17,6 +19,7 @@ type HarnessStub = {
     path: string;
     event: { type: string; payload: Record<string, unknown> };
   }): Promise<StreamEvent>;
+  list(): Promise<{ streamPath: string }[]>;
   read(input: { path: string }): Promise<StreamEvent[]>;
   subscribe(
     input: { afterOffset: StreamCursor; path: string },
@@ -154,6 +157,62 @@ describe("itx stream subscribe against a real Stream Durable Object", () => {
     // The worker (and the stream) survived: both appends were committed.
     const events = await harness.read({ path });
     expect(markersOf(events)).toEqual(["boom", "after-boom"]);
+  });
+});
+
+describe("streams list against a real Stream Durable Object", () => {
+  test("list() enumerates every stream (nested included) from the root's reduced state", async () => {
+    const base = `/list-tests/${crypto.randomUUID()}`;
+    for (const path of [`${base}/a`, `${base}/a/b`, `${base}/c`]) {
+      await harness.append({ path, event: markerEvent("seed") });
+    }
+
+    // Ancestor announcements (and the intermediate streams they create) are
+    // fire-and-forget background appends, so poll until they all land.
+    await vi.waitFor(
+      async () => {
+        const paths = (await harness.list()).map((stream) => stream.streamPath);
+        expect(paths).toEqual(
+          expect.arrayContaining(["/", base, `${base}/a`, `${base}/a/b`, `${base}/c`]),
+        );
+      },
+      { timeout: 10_000 },
+    );
+  });
+
+  test("a root persisted before descendantPaths existed is rebuilt by replay on its next wake", async () => {
+    const base = `/migration-tests/${crypto.randomUUID()}`;
+    await harness.append({ path: `${base}/a/b`, event: markerEvent("seed") });
+    await vi.waitFor(
+      async () => {
+        const paths = (await harness.list()).map((stream) => stream.streamPath);
+        expect(paths).toEqual(expect.arrayContaining([base, `${base}/a`, `${base}/a/b`]));
+      },
+      { timeout: 10_000 },
+    );
+
+    // Rewrite the root stream's persisted state to the pre-descendantPaths
+    // shape (no descendantPaths field, no stateVersion key) — exactly what a
+    // stream last reduced before the schema change has on disk.
+    const streamNamespace = (env as unknown as { STREAM: DurableObjectNamespace }).STREAM;
+    const rootStub = streamNamespace.getByName(`${PROJECT_ID}:/`);
+    await runInDurableObject(rootStub, async (_instance, state) => {
+      const stored = state.storage.kv.get<Record<string, unknown>>("state");
+      if (stored === undefined) throw new Error("expected persisted root stream state");
+      expect(stored.descendantPaths).toEqual(expect.arrayContaining([`${base}/a/b`]));
+      const { descendantPaths: _dropped, ...preDescendantPathsShape } = stored;
+      state.storage.kv.put("state", preDescendantPathsShape);
+      state.storage.kv.delete("stateVersion");
+    });
+    // Abort the current incarnation so the next call re-runs the constructor's
+    // read-persisted-state path against the doctored storage. The abort makes
+    // the kill() RPC itself reject; that is expected.
+    await (rootStub as unknown as { kill(): Promise<void> }).kill().catch(() => {});
+
+    // The rewoken root sees the version mismatch, replays its event log and
+    // serves the full catalog again — list() never walks child streams.
+    const paths = (await harness.list()).map((stream) => stream.streamPath);
+    expect(paths).toEqual(expect.arrayContaining(["/", base, `${base}/a`, `${base}/a/b`]));
   });
 });
 

--- a/apps/os/src/durable-objects/test-stream-durable-object.ts
+++ b/apps/os/src/durable-objects/test-stream-durable-object.ts
@@ -25,6 +25,7 @@ export class StreamDurableObject extends DurableObject {
 
     await this.ctx.storage.put("state", {
       childPaths: [],
+      descendantPaths: [],
       eventCount: 0,
       metadata: {},
       namespace: structuredName.namespace,

--- a/packages/shared/src/streams/types.ts
+++ b/packages/shared/src/streams/types.ts
@@ -170,6 +170,11 @@ export const StreamState = z.object({
   path: StreamPath,
   eventCount: z.number().int().nonnegative(),
   childPaths: z.array(StreamPath),
+  /**
+   * Full paths of every stream strictly under this one, in announcement order.
+   * The root stream's copy lists every stream in the namespace.
+   */
+  descendantPaths: z.array(StreamPath),
   metadata: JSONObject,
   processors: ProcessorsState,
 });

--- a/packages/streams/src/processors/core/contract.test.ts
+++ b/packages/streams/src/processors/core/contract.test.ts
@@ -264,8 +264,54 @@ describe("core processor contract", () => {
     }
 
     expect(state.childPaths).toEqual(["/a/b"]);
+    expect(state.descendantPaths).toEqual(["/a/b/c"]);
     expect(state.metadata).toEqual({ title: "Demo stream" });
     expect(state.maxOffset).toBe(3);
+  });
+
+  it("accumulates full descendant paths from child-stream-created announcements", () => {
+    const announcement = (offset: number, childPath: string): StreamEvent => ({
+      offset,
+      createdAt: `2026-06-01T12:00:0${offset}.000Z`,
+      type: "events.iterate.com/stream/child-stream-created",
+      idempotencyKey: `child-stream-created:${offset}:${childPath}`,
+      payload: { childPath },
+    });
+
+    // The root hears every announcement in the namespace and keeps each full
+    // path once, in insertion order — this is what namespace listing reads.
+    const rootState = reduceEvents({
+      state: CoreProcessorContract.stateSchema.parse({
+        ...CoreProcessorContract.initialState,
+        path: "/",
+      }),
+      events: [
+        announcement(1, "/a"),
+        announcement(2, "/a/b"),
+        announcement(3, "/c"),
+        announcement(4, "/a/b"), // duplicate announcement is ignored
+      ],
+    });
+    expect(rootState.childPaths).toEqual(["/a", "/c"]);
+    expect(rootState.descendantPaths).toEqual(["/a", "/a/b", "/c"]);
+
+    // An intermediate ancestor keeps only paths strictly under its own path:
+    // not itself, not siblings, and not a path that merely shares a prefix.
+    const intermediateState = reduceEvents({
+      state: CoreProcessorContract.stateSchema.parse({
+        ...CoreProcessorContract.initialState,
+        path: "/a",
+      }),
+      events: [
+        announcement(1, "/a"),
+        announcement(2, "/a/b"),
+        announcement(3, "/a/b/c"),
+        announcement(4, "/c"),
+        announcement(5, "/ab"),
+      ],
+    });
+    expect(intermediateState.childPaths).toEqual(["/a/b"]);
+    expect(intermediateState.descendantPaths).toEqual(["/a/b", "/a/b/c"]);
   });
 
   it("rebuilds state by replaying committed events", () => {
@@ -300,6 +346,7 @@ describe("core processor contract", () => {
       eventCount: 3,
       maxOffset: 3,
       childPaths: ["/agents/debug"],
+      descendantPaths: ["/agents/debug"],
     });
   });
 

--- a/packages/streams/src/processors/core/contract.ts
+++ b/packages/streams/src/processors/core/contract.ts
@@ -99,6 +99,14 @@ export const CoreProcessorContract = defineProcessorContract({
     eventCount: z.number().int().min(0),
     maxOffset: z.number().int().min(0),
     childPaths: z.array(z.string().trim().min(1)),
+    // Full paths of every descendant stream announced to this stream (insertion
+    // order, deduped) — not just immediate children like `childPaths`. The root
+    // stream's copy is the namespace's stream catalog: one getState("/") call
+    // enumerates every stream without walking child DOs. The `.default([])`
+    // only keeps state persisted by an older reducer parseable; actually
+    // backfilling the field is the job of CORE_STATE_VERSION in the Stream
+    // Durable Object, which replays the event log when the version changes.
+    descendantPaths: z.array(z.string().trim().min(1)).default([]),
     paused: z.boolean(),
     pauseReason: z.string().nullable(),
     processorsBySlug: z.record(
@@ -139,6 +147,7 @@ export const CoreProcessorContract = defineProcessorContract({
     eventCount: 0,
     maxOffset: 0,
     childPaths: [],
+    descendantPaths: [],
     paused: false,
     pauseReason: null,
     processorsBySlug: {},
@@ -173,7 +182,8 @@ export const CoreProcessorContract = defineProcessorContract({
       }),
     },
     "events.iterate.com/stream/child-stream-created": {
-      description: "Records an immediate child stream under this stream.",
+      description:
+        "Records a descendant stream under this stream: the immediate child segment in childPaths and the full announced path in descendantPaths.",
       payloadSchema: z.object({
         childPath: z.string().trim().min(1),
       }),

--- a/packages/streams/src/processors/core/implementation.ts
+++ b/packages/streams/src/processors/core/implementation.ts
@@ -144,18 +144,19 @@ export class CoreStreamProcessor extends StreamProcessor<CoreProcessorContract> 
         break;
 
       case "events.iterate.com/stream/child-stream-created": {
+        const announcedPath = args.event.payload.childPath;
         let childPath: string | null;
-        if (args.event.payload.childPath === state.path) {
+        if (announcedPath === state.path) {
           childPath = null;
         } else if (state.path === "/") {
-          const [firstSegment] = args.event.payload.childPath.split("/").filter(Boolean);
+          const [firstSegment] = announcedPath.split("/").filter(Boolean);
           childPath = firstSegment === undefined ? null : `/${firstSegment}`;
         } else {
           const parentPrefix = `${state.path}/`;
-          if (!args.event.payload.childPath.startsWith(parentPrefix)) {
+          if (!announcedPath.startsWith(parentPrefix)) {
             childPath = null;
           } else {
-            const [firstSegment] = args.event.payload.childPath
+            const [firstSegment] = announcedPath
               .slice(parentPrefix.length)
               .split("/")
               .filter(Boolean);
@@ -163,10 +164,20 @@ export class CoreStreamProcessor extends StreamProcessor<CoreProcessorContract> 
           }
         }
 
-        next =
-          childPath === null || next.childPaths.includes(childPath)
-            ? next
-            : { ...next, childPaths: [...next.childPaths, childPath] };
+        if (childPath !== null && !next.childPaths.includes(childPath)) {
+          next = { ...next, childPaths: [...next.childPaths, childPath] };
+        }
+
+        // Besides the truncated immediate-child segment above, keep the FULL
+        // announced path when it is strictly under this stream. The root
+        // stream's descendantPaths is the namespace's stream catalog (this is
+        // what makes listing a namespace a single getState("/") call).
+        const isDescendant =
+          announcedPath !== state.path &&
+          (state.path === "/" || announcedPath.startsWith(`${state.path}/`));
+        if (isDescendant && !next.descendantPaths.includes(announcedPath)) {
+          next = { ...next, descendantPaths: [...next.descendantPaths, announcedPath] };
+        }
         break;
       }
 

--- a/packages/streams/src/stream-processor.test.ts
+++ b/packages/streams/src/stream-processor.test.ts
@@ -224,6 +224,11 @@ describe("core stream state and subscription processors", () => {
     expect(sim.streams.get("/")?.coreProcessorState.childPaths).toEqual(["/a"]);
     expect(sim.streams.get("/a")?.coreProcessorState.childPaths).toEqual(["/a/b"]);
     expect(sim.streams.get("/a/b")?.coreProcessorState.childPaths).toEqual(["/a/b/c"]);
+    // Every ancestor also keeps the FULL announced path (the root's copy is
+    // the namespace catalog that stream listing reads with one getState).
+    expect(sim.streams.get("/")?.coreProcessorState.descendantPaths).toEqual(["/a/b/c"]);
+    expect(sim.streams.get("/a")?.coreProcessorState.descendantPaths).toEqual(["/a/b/c"]);
+    expect(sim.streams.get("/a/b")?.coreProcessorState.descendantPaths).toEqual(["/a/b/c"]);
   });
 
   it("circuit breaker trips from an ordinary subscription processor", async () => {

--- a/packages/streams/src/workers/durable-objects/stream.ts
+++ b/packages/streams/src/workers/durable-objects/stream.ts
@@ -28,6 +28,18 @@ import { disposeIgnoredRpcResult, retainProcessEventBatch } from "../rpc-lifecyc
 const EVENT_CHUNK_SIZE = 512 * 1024;
 const textEncoder = new TextEncoder();
 
+// Version of the persisted core reduced state ("state" in KV). Bump this when
+// the core reducer starts deriving NEW state from already-reduced events
+// (already-committed events are never re-reduced on the incremental catch-up
+// path). On wake, a stored version that differs from this constant discards
+// the persisted state and rebuilds it by replaying the full event log from the
+// DO's own SQLite — the same path used when KV state is missing entirely.
+//
+// History:
+// - 1 (implicit; no "stateVersion" key in KV): pre-descendantPaths state.
+// - 2: childPaths gained a sibling descendantPaths (full announced paths).
+const CORE_STATE_VERSION = 2;
+
 export class Stream extends DurableObject<Env> implements StreamRpc {
   #coreProcessorState: StreamCoreProcessorState;
   coreProcessor = new CoreStreamProcessor({
@@ -118,15 +130,19 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
 
   protected readCoreProcessorState(): StreamCoreProcessorState {
     const stored = this.ctx.storage.kv.get<unknown>("state");
-    const storedState =
-      stored === undefined
-        ? this.#recoverCoreProcessorStateFromEventLog()
-        : CoreProcessorContract.stateSchema.parse(stored);
+    const storedVersion = this.ctx.storage.kv.get<unknown>("stateVersion") ?? 1;
+    // State persisted by a reducer of a different version is incomplete (it
+    // was reduced before newer derived fields existed), so it is discarded and
+    // rebuilt from the event log rather than trusted.
+    const storedStateIsCurrent = stored !== undefined && storedVersion === CORE_STATE_VERSION;
+    const storedState = storedStateIsCurrent
+      ? CoreProcessorContract.stateSchema.parse(stored)
+      : this.#recoverCoreProcessorStateFromEventLog();
     if (storedState === undefined) return getInitialProcessorState(CoreProcessorContract);
 
     const state = this.#catchUpCoreProcessorState(storedState);
 
-    if (state.maxOffset !== storedState.maxOffset) {
+    if (!storedStateIsCurrent || state.maxOffset !== storedState.maxOffset) {
       this.writeCoreProcessorState(state);
     }
     return state;
@@ -134,6 +150,7 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
 
   protected writeCoreProcessorState(state: StreamCoreProcessorState): void {
     this.ctx.storage.kv.put("state", state);
+    this.ctx.storage.kv.put("stateVersion", CORE_STATE_VERSION);
   }
 
   #catchUpCoreProcessorState(state: StreamCoreProcessorState): StreamCoreProcessorState {


### PR DESCRIPTION
## Problem

`StreamsCapability.list()` enumerated a namespace by recursively walking `getState("/")` → child → child, one **sequential** Durable Object call per stream. Measured on prod: ~3,985 ms cold for a 10-stream namespace (each cold DO wake ~400 ms, serialized). This backs the dashboard streams page, so the first view of a project took seconds.

## Change

Every `stream/created` is already announced to every ancestor stream (including `/`) via `child-stream-created`; the reducer just threw the full path away after truncating it to the immediate-child segment.

- **Core reducer** (`packages/streams/src/processors/core/{contract,implementation}.ts`): each stream's reduced state now also accumulates `descendantPaths` — the full announced paths strictly under its own path, deduped, insertion order. The root's copy is the namespace's stream catalog.
- **Capability** (`apps/os/src/domains/streams/entrypoints/streams-capability.ts`): `list()` is now a single `getState("/")` → `["/", ...descendantPaths]`. The recursive `listNamespaceStreamPaths` walk is deleted. `listChildren` still uses `childPaths`, unchanged.
- **Public surface**: `descendantPaths` added to the shared `StreamState` zod (orpc `streams.create` output), the legacy adapter (`toLegacyStreamState`), and the test stream DO.

## Migration

Core reduced state is persisted in KV and only incrementally caught up, so already-reduced events would never re-reduce and existing streams would be missing `descendantPaths` forever. There was **no existing version/replay mechanism** for the DO's persisted core state (the browser `schemaVersion` constants are for browser-side SQLite caches only), so this adds a minimal one:

- `CORE_STATE_VERSION` (now `2`) stored in KV next to the state.
- On wake, a missing/mismatched version discards the persisted state and rebuilds it by replaying the full event log from the DO's own SQLite — the same code path already used when KV state is lost. Version 1 is implicit (no `stateVersion` key), so every existing stream re-reduces on its next wake. No fallback walk in `list()`; the root state is authoritative.

## Tests

- `packages/streams` reducer coverage: root and intermediate ancestors accumulate full descendant paths; dedupe; self/sibling/shared-prefix announcements ignored; replay/catch-up tests extended.
- Real-DO worker harness (`pnpm test:itx-stream-subscribe`): `list()` returns `/`, intermediate and nested streams after creating `…/a`, `…/a/b`, `…/c`; and a root whose persisted state was rewritten to the pre-`descendantPaths` shape (via `runInDurableObject`) is rebuilt by the version replay on its next wake — this test was verified to go red with the version mechanism disabled.
- Green: `packages/streams` tests (59), `packages/shared` tests, `apps/os` `pnpm test` (226), `test:itx-stream-subscribe` (8), `test:project-ingress` (6), `test:codemode-session` (18), `test:project-mcp-server-connection` (4), `pnpm typecheck`, `pnpm lint`, `pnpm format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core stream reduced state, DO wake/replay, and a hot dashboard path; migration relies on event-log replay on next wake rather than a list-time fallback walk.
> 
> **Overview**
> **Namespace stream listing is now one root Durable Object read** instead of a recursive walk that called `getState` on every stream in sequence (a major latency win for dashboards).
> 
> The core reducer **adds `descendantPaths`**: on each `child-stream-created` announcement it keeps the full announced path (deduped), while **`childPaths` stays for immediate children** (`listChildren` unchanged). The root stream’s `descendantPaths` is the namespace catalog; **`StreamsCapability.list()`** returns `["/", ...rootState.descendantPaths]` and **removes `listNamespaceStreamPaths`**.
> 
> **Migration:** the Stream DO persists **`CORE_STATE_VERSION` (2)** beside KV state. On wake, a missing or stale version **replays the SQLite event log** to rebuild reduced state (including `descendantPaths`) instead of trusting old KV. **`descendantPaths`** is also exposed on shared **`StreamState`**, the legacy adapter, and tests (including real-DO list + replay-after-downgrade scenarios).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb7674488816e25479be66e185b7defa66e57f12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T13:38:20.608Z",
      "headSha": "bb7674488816e25479be66e185b7defa66e57f12",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27279525455",
      "shortSha": "bb76744"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-06-10T13:38:12.157Z",
      "headSha": "bb7674488816e25479be66e185b7defa66e57f12",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27279525455",
      "shortSha": "bb76744"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `bb76744`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27279525455)
Updated: 2026-06-10T13:38:20.608Z

### Semaphore
Status: released
Commit: `bb76744`
Preview: https://semaphore.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27279525455)
Updated: 2026-06-10T13:38:12.157Z
<!-- /CLOUDFLARE_PREVIEW -->