### PR TITLE
[codex] fix sidebar account menu label

### DIFF
--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -235,7 +235,7 @@ function AppSidebarUser() {
               align="end"
               sideOffset={4}
             >
-              <DropdownMenuLabel className="p-0 font-normal">
+              <div className="p-0 font-normal">
                 <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
                   <Avatar className="size-8 rounded-lg">
                     <AvatarFallback className="rounded-lg">{initials}</AvatarFallback>
@@ -245,7 +245,7 @@ function AppSidebarUser() {
                     {email ? <span className="truncate text-xs">{email}</span> : null}
                   </div>
                 </div>
-              </DropdownMenuLabel>
+              </div>
               <DropdownMenuSeparator />
               <DropdownMenuGroup>
                 <DropdownMenuItem


### PR DESCRIPTION
## Summary

- replace the static account header in the OS sidebar user dropdown with plain markup instead of `DropdownMenuLabel`
- keep actionable dropdown entries inside `DropdownMenuGroup`

## Root Cause

This repo uses shadcn `base-nova`, where `DropdownMenuLabel` wraps Base UI `Menu.GroupLabel`. Base UI requires group labels to be rendered inside `Menu.Group`; the account header was static content directly under `DropdownMenuContent`, which triggered production error #31 when opening the user menu.

## Validation

- `pnpm --dir apps/os typecheck`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T13:40:28.478Z",
      "headSha": "d49c73e2b1865e4087019566c26728dc3318c1fd",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27279919926",
      "shortSha": "d49c73e"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `d49c73e`
Preview: https://os.iterate-preview-6.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27279919926)
Updated: 2026-06-10T13:40:28.478Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentational change in the sidebar user dropdown with no auth or data-path changes.
> 
> **Overview**
> Fixes a **production crash** when opening the OS sidebar account menu by rendering the static user header (avatar, name, email) as a plain `div` instead of `DropdownMenuLabel`.
> 
> With shadcn **base-nova**, `DropdownMenuLabel` maps to Base UI `Menu.GroupLabel`, which must live inside `Menu.Group`. That header sat directly under `DropdownMenuContent`, which violated the menu structure and triggered React error #31. Menu actions remain in `DropdownMenuGroup` as before; only the non-interactive header markup changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d49c73e2b1865e4087019566c26728dc3318c1fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->