### PR TITLE
[codex] Fix browser REPL result history

### DIFF
--- a/apps/os/src/components/itx-repl.tsx
+++ b/apps/os/src/components/itx-repl.tsx
@@ -13,6 +13,7 @@ import {
   SourceCodeBlock,
   type SourceCodeBlockExtension,
 } from "@iterate-com/ui/components/source-code-block";
+import { SerializedObjectCodeBlock } from "@iterate-com/ui/components/serialized-object-code-block";
 import {
   Sheet,
   SheetContent,
@@ -36,7 +37,6 @@ export interface ItxReplProps {
   onRun: () => void;
   onSelectExample: (code: string) => void;
   onSetExamplesOpen: (open: boolean) => void;
-  selectAllSignal: number;
   status: string;
 }
 
@@ -50,7 +50,6 @@ export function ItxRepl({
   onRun,
   onSelectExample,
   onSetExamplesOpen,
-  selectAllSignal,
   status,
 }: ItxReplProps) {
   const typeScriptExtensions = useReplTypeScriptExtensions({
@@ -114,12 +113,16 @@ export function ItxRepl({
                     title="Console"
                   />
                 ) : null}
-                <ReplCollapsibleCodeBlock
-                  code={entry.output}
-                  language={entry.outputLanguage}
-                  title={entry.status === "error" ? "Error" : "Result"}
-                  variant={entry.status === "error" ? "error" : "default"}
-                />
+                {entry.status === "success" ? (
+                  <ReplCollapsibleSerializedBlock data={entry.result} title="Result" />
+                ) : (
+                  <ReplCollapsibleCodeBlock
+                    code={entry.output}
+                    language={entry.outputLanguage}
+                    title="Error"
+                    variant="error"
+                  />
+                )}
               </div>
             ))}
             <div className="flex flex-col gap-2 border-l-2 border-primary/50 py-2 pr-3 pl-3">
@@ -138,7 +141,6 @@ export function ItxRepl({
                 onChange={onChangeCode}
                 onModEnter={onRun}
                 plainChrome
-                selectAllSignal={selectAllSignal}
                 showCopyButton={false}
                 showLineNumbers={false}
               />
@@ -276,7 +278,7 @@ function ReplCodeBlock(input: { code: string; language: "json" | "text" | "types
       }
       language={input.language}
       plainChrome
-      showCopyButton={false}
+      showCopyButton
       showLineNumbers={false}
     />
   );
@@ -306,6 +308,29 @@ function ReplCollapsibleCodeBlock(input: {
         <div className={input.variant === "error" ? "[&_.cm-content]:text-destructive" : ""}>
           <ReplCodeBlock code={input.code} language={input.language} />
         </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function ReplCollapsibleSerializedBlock(input: { data: unknown; title: string }) {
+  return (
+    <Collapsible defaultOpen>
+      <div className="flex items-center justify-between gap-2">
+        <CollapsibleTrigger className="group flex items-center gap-1 text-xs font-medium text-muted-foreground">
+          <ChevronDown className="size-3 -rotate-90 transition-transform [[data-panel-open]_&]:rotate-0" />
+          {input.title}
+        </CollapsibleTrigger>
+      </div>
+      <CollapsibleContent>
+        <SerializedObjectCodeBlock
+          className="max-h-96"
+          data={input.data}
+          initialFormat="json"
+          showCopyButton
+          showLineNumbers
+          showToggle
+        />
       </CollapsibleContent>
     </Collapsible>
   );

--- a/apps/os/src/itx/browser-repl.test.ts
+++ b/apps/os/src/itx/browser-repl.test.ts
@@ -1,8 +1,10 @@
 import { RpcStub, RpcTarget } from "capnweb";
 import { describe, expect, test, vi } from "vitest";
 import {
+  browserReplExternalScopesEqual,
   BROWSER_REPL_EXAMPLES,
   compileBrowserReplFunction,
+  createBrowserReplScope,
   DEFAULT_BROWSER_REPL_CODE,
   evalBrowserReplCode,
   evalBrowserReplSessionCode,
@@ -78,8 +80,25 @@ describe("browser Cap'n Web REPL", () => {
       code: DEFAULT_BROWSER_REPL_CODE,
       output: JSON.stringify({ projects: [{ id: "proj_123" }], total: 1, limit: 5 }, null, 2),
       outputLanguage: "json",
+      result: { projects: [{ id: "proj_123" }], total: 1, limit: 5 },
       status: "success",
     });
+  });
+
+  test("external scope comparison preserves REPL bindings across equivalent renders", () => {
+    const currentScope = createBrowserReplScope({ projectId: "proj_123" });
+    currentScope.$_ = 42;
+    currentScope._ = 42;
+
+    expect(
+      browserReplExternalScopesEqual({ projectId: "proj_123" }, { projectId: "proj_123" }),
+    ).toBe(true);
+    expect(currentScope.$_).toBe(42);
+    expect(currentScope._).toBe(42);
+
+    expect(
+      browserReplExternalScopesEqual({ projectId: "proj_123" }, { projectId: "proj_456" }),
+    ).toBe(false);
   });
 
   test("REPL supports SDK-shaped calls through a server-side path target", async () => {

--- a/apps/os/src/itx/browser-repl.ts
+++ b/apps/os/src/itx/browser-repl.ts
@@ -1,3 +1,5 @@
+import { RpcTarget } from "capnweb";
+
 export const DEFAULT_BROWSER_REPL_CODE = "await itx.projects.list({ limit: 5 })";
 
 export type BrowserReplExample = {
@@ -12,8 +14,29 @@ export type BrowserReplEntry = {
   consoleOutput: string;
   output: string;
   outputLanguage: "json" | "text";
+  result?: unknown;
   status: "error" | "success";
 };
+
+export function createBrowserReplScope(scope?: Record<string, unknown>): Record<string, unknown> {
+  return { RpcTarget, ...scope };
+}
+
+export function browserReplExternalScopesEqual(
+  first?: Record<string, unknown>,
+  second?: Record<string, unknown>,
+) {
+  const firstKeys = Object.keys(first ?? {});
+  const secondKeys = Object.keys(second ?? {});
+  if (firstKeys.length !== secondKeys.length) return false;
+
+  for (const key of firstKeys) {
+    if (!Object.prototype.hasOwnProperty.call(second ?? {}, key)) return false;
+    if (!Object.is(first?.[key], second?.[key])) return false;
+  }
+
+  return true;
+}
 
 // These are living examples: each one mirrors a scenario from the itx e2e
 // suite (apps/os/src/itx/e2e/*), rewritten as a self-contained REPL snippet.
@@ -450,6 +473,7 @@ export async function runBrowserReplEntry(input: {
       consoleOutput: formatBrowserReplConsoleOutput(consoleLogs),
       output: formattedResult.text,
       outputLanguage: formattedResult.language,
+      result,
       status: "success",
     };
   } catch (error) {

--- a/apps/os/src/routes/_app/itx-repl.tsx
+++ b/apps/os/src/routes/_app/itx-repl.tsx
@@ -5,9 +5,11 @@
 
 import { useEffect, useRef, useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import { newWebSocketRpcSession, RpcTarget, type RpcStub } from "capnweb";
+import { newWebSocketRpcSession, type RpcStub } from "capnweb";
 import {
+  browserReplExternalScopesEqual,
   BROWSER_REPL_EXAMPLES,
+  createBrowserReplScope,
   DEFAULT_BROWSER_REPL_CODE,
   runBrowserReplEntry,
   type BrowserReplEntry,
@@ -75,11 +77,16 @@ export function ItxReplPage({
   const [status, setStatus] = useState("Connecting...");
   const [entries, setEntries] = useState<BrowserReplEntry[]>([]);
   const [examplesOpen, setExamplesOpen] = useState(false);
-  const [selectAllSignal, setSelectAllSignal] = useState(0);
   const envRef = useRef<Record<string, unknown>>({});
-  const scopeRef = useRef<Record<string, unknown>>({ RpcTarget, ...scope });
-  // Keep the scope in sync when navigating between project repls (same route, new params).
-  scopeRef.current = { RpcTarget, ...scope };
+  const externalScopeRef = useRef(scope);
+  const scopeRef = useRef<Record<string, unknown>>(createBrowserReplScope(scope));
+
+  // Keep injected values in sync when navigating between project repls, without
+  // wiping REPL-created bindings on ordinary state updates.
+  if (!browserReplExternalScopesEqual(externalScopeRef.current, scope)) {
+    externalScopeRef.current = scope;
+    scopeRef.current = createBrowserReplScope(scope);
+  }
 
   useEffect(() => {
     const globals = globalThis as typeof globalThis & {
@@ -119,6 +126,7 @@ export function ItxReplPage({
     const trimmedCode = code.trim();
     if (!itx || trimmedCode === "") return;
     setStatus("Running...");
+    setCode("");
     const entry = await runBrowserReplEntry({
       code: trimmedCode,
       env: envRef.current,
@@ -126,7 +134,6 @@ export function ItxReplPage({
       scope: scopeRef.current,
     });
     setEntries((current) => [...current, entry]);
-    setSelectAllSignal((current) => current + 1);
     setStatus("Connected");
   }
 
@@ -146,7 +153,6 @@ export function ItxReplPage({
       onRun={() => void run()}
       onSelectExample={selectExample}
       onSetExamplesOpen={setExamplesOpen}
-      selectAllSignal={selectAllSignal}
       status={status}
     />
   );


### PR DESCRIPTION
## What changed

- Keeps the browser REPL scope stable across rerenders so `_` and `$_` continue to point at the previous successful result.
- Clears the editable prompt after submit instead of selecting all text.
- Renders submitted prompts and output with copy controls, and renders successful results through `SerializedObjectCodeBlock` so JSON can be folded/copied/toggled.
- Stores the raw successful result on REPL history entries for structured rendering.

## Why

A rerender after submitting an entry rebuilt the REPL scope from props, wiping REPL-created bindings such as `_` and `$_`. That made previous-result aliases disappear even though `runBrowserReplEntry` still assigned them.

## Validation

- `pnpm --dir apps/os exec vitest run src/itx/browser-repl.test.ts`
- `pnpm --dir apps/os exec tsc --noEmit`
- `pnpm --dir apps/os exec oxlint src/itx/browser-repl.ts src/itx/browser-repl.test.ts src/routes/_app/itx-repl.tsx src/components/itx-repl.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> REPL-only UX and client-side scope handling; no auth, API, or data-path changes.
> 
> **Overview**
> Fixes browser REPL **result history** so `_` / `$_` and other session bindings survive ordinary rerenders (e.g. after Run), and improves how past prompts and outputs are shown.
> 
> **Scope:** The route keeps a stable `scopeRef` and only rebuilds injected scope when external props (like `projectId`) actually change via `createBrowserReplScope` and `browserReplExternalScopesEqual`, instead of resetting `{ RpcTarget, ...scope }` every render. Successful runs still attach the raw value on history entries as `result` for structured UI.
> 
> **UX:** After submit, the input **clears** instead of select-all (`selectAllSignal` removed). History prompts and console/error blocks get **copy** controls; successful **results** render through **`SerializedObjectCodeBlock`** (fold/toggle/copy) rather than a plain JSON string block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f35e85e35bce597c6f6e34a65bfa4f50975eea88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T13:58:27.933Z",
      "headSha": "f35e85e35bce597c6f6e34a65bfa4f50975eea88",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27279935399",
      "shortSha": "f35e85e"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `f35e85e`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27279935399)
Updated: 2026-06-10T13:58:27.933Z
<!-- /CLOUDFLARE_PREVIEW -->