### PR TITLE
[codex] Route merge announcements to ci

### DIFF
--- a/.github/ts-workflows/workflows/merge-to-main-slack.ts
+++ b/.github/ts-workflows/workflows/merge-to-main-slack.ts
@@ -36,7 +36,7 @@ export default {
           ].filter(Boolean);
 
           await slack.chat.postMessage({
-            channel: slackChannelIds["#building"],
+            channel: slackChannelIds["#ci"],
             text: pieces.join(" "),
           });
         }),

--- a/.github/workflows/merge-to-main-slack.yml
+++ b/.github/workflows/merge-to-main-slack.yml
@@ -59,7 +59,7 @@ jobs:
               ].filter(Boolean);
 
               await slack.chat.postMessage({
-                channel: slackChannelIds["#building"],
+                channel: slackChannelIds["#ci"],
                 text: pieces.join(" "),
               });
             };


### PR DESCRIPTION
## Summary

- Route the "merged to main" Slack announcement workflow to `#ci` instead of `#building`.
- Regenerate the checked-in workflow YAML from the TypeScript workflow source.

## Impact

- Future PR merge announcements for `main` will land in the CI Slack channel.

## Validation

- `pnpm --dir .github/ts-workflows generate`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Notification routing only; no auth, deploy, or application logic changes.
> 
> **Overview**
> **Merge-to-main Slack notifications** now post to **`#ci`** instead of **`#building`**.
> 
> The change is in the TypeScript workflow source (`merge-to-main-slack.ts`) and the **regenerated** checked-in GitHub Actions YAML so both stay in sync. Message content and triggers are unchanged—only the destination channel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea7f32fc0ead670dd8f3e7ed949914405a1e5763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->