### PR TITLE
[codex] Use admin role for platform admin access

### DIFF
--- a/apps/auth-contract/src/index.ts
+++ b/apps/auth-contract/src/index.ts
@@ -385,23 +385,23 @@ export const authContract = oc.router({
       .input(ProjectInput)
       .output(z.object({ success: z.literal(true) })),
   },
-  superadmin: {
+  admin: {
     oauth: {
       createClient: oc
         .route({
           method: "POST",
-          path: "/superadmin/oauth/create-client",
+          path: "/admin/oauth/create-client",
           summary: "Create a new OAuth client",
-          tags: ["superadmin", "oauth"],
+          tags: ["admin", "oauth"],
         })
         .input(CreateClientInput)
         .output(OAuthClientRecord),
       listClients: oc
         .route({
           method: "GET",
-          path: "/superadmin/oauth/list-clients",
+          path: "/admin/oauth/list-clients",
           summary: "List all OAuth clients",
-          tags: ["superadmin", "oauth"],
+          tags: ["admin", "oauth"],
         })
         .output(z.array(OAuthClientRecord.omit({ clientSecret: true }))),
     },
@@ -517,7 +517,10 @@ export function createAuthContractClient(options: AuthContractClientOptions): Au
   ) as AuthContractClient;
 }
 
-function mergeRequestHeaders(request: URL | Request, initHeaders: HeadersInit | undefined) {
+function mergeRequestHeaders(
+  request: URL | Request,
+  initHeaders: ConstructorParameters<typeof Headers>[0] | undefined,
+) {
   const headers = new Headers(request instanceof Request ? request.headers : undefined);
   if (initHeaders) {
     for (const [key, value] of new Headers(initHeaders)) {

--- a/apps/auth-example/.env.example
+++ b/apps/auth-example/.env.example
@@ -1,5 +1,5 @@
 # Copy to .dev.vars and fill in values
-# Make an oauth client in the auth app at /superadmin/clients
+# Make an oauth client in the auth app at /admin/clients
 ITERATE_OAUTH_ISSUER=http://localhost:7101/api/auth
 ITERATE_OAUTH_CLIENT_ID=
 ITERATE_OAUTH_CLIENT_SECRET=

--- a/apps/auth/alchemy.run.ts
+++ b/apps/auth/alchemy.run.ts
@@ -6,7 +6,7 @@ import { slugify } from "@iterate-com/shared/slugify";
 import { z } from "zod/v4";
 
 const APP_NAME = "auth";
-const SUPERADMIN_SEED_SQL_PATH = "./.alchemy/generated/auth-superadmin-seed.sql";
+const ADMIN_SEED_SQL_PATH = "./.alchemy/generated/auth-admin-seed.sql";
 
 const AlchemyEnv = z.object({
   ALCHEMY_PASSWORD: z.string().trim().min(1, "ALCHEMY_PASSWORD is required"),
@@ -47,7 +47,7 @@ const AlchemyEnv = z.object({
   RESEND_BOT_DOMAIN: z.string(),
   RESEND_BOT_API_KEY: z.string(),
   SIGNUP_ALLOWLIST: z.string(),
-  SUPERADMIN_ALLOWLIST: z.string().default("*@nustom.com"),
+  ADMIN_ALLOWLIST: z.string().default("*@nustom.com"),
   VITE_ENABLE_EMAIL_OTP_SIGNIN: z.string().optional(),
   GOOGLE_CLIENT_ID: z.string(),
   GOOGLE_CLIENT_SECRET: z.string(),
@@ -74,11 +74,11 @@ const workerName = slugify(`${APP_NAME}-${app.stage}`);
 const emailOtpEnabled =
   alchemyEnv.VITE_ENABLE_EMAIL_OTP_SIGNIN?.trim() || (app.stage.startsWith("dev") ? "true" : "");
 
-await Exec("render-superadmin-seed", {
-  command: `tsx ./scripts/render-superadmin-seed.ts ${SUPERADMIN_SEED_SQL_PATH}`,
+await Exec("render-admin-seed", {
+  command: `tsx ./scripts/render-admin-seed.ts ${ADMIN_SEED_SQL_PATH}`,
   env: {
     SERVICE_AUTH_TOKEN: alchemy.secret(alchemyEnv.SERVICE_AUTH_TOKEN),
-    SUPERADMIN_ALLOWLIST: alchemyEnv.SUPERADMIN_ALLOWLIST,
+    ADMIN_ALLOWLIST: alchemyEnv.ADMIN_ALLOWLIST,
   },
   cwd: import.meta.dirname,
 });
@@ -86,7 +86,7 @@ await Exec("render-superadmin-seed", {
 const DB = await D1Database("auth-db", {
   name: `${workerName}-auth-db`,
   migrationsDir: "./src/server/db/migrations",
-  importFiles: [SUPERADMIN_SEED_SQL_PATH],
+  importFiles: [ADMIN_SEED_SQL_PATH],
 });
 
 const worker = await TanStackStart(APP_NAME, {
@@ -100,7 +100,7 @@ const worker = await TanStackStart(APP_NAME, {
     RESEND_BOT_DOMAIN: alchemy.secret(alchemyEnv.RESEND_BOT_DOMAIN),
     RESEND_BOT_API_KEY: alchemy.secret(alchemyEnv.RESEND_BOT_API_KEY),
     SIGNUP_ALLOWLIST: alchemy.secret(alchemyEnv.SIGNUP_ALLOWLIST),
-    SUPERADMIN_ALLOWLIST: alchemy.secret(alchemyEnv.SUPERADMIN_ALLOWLIST),
+    ADMIN_ALLOWLIST: alchemy.secret(alchemyEnv.ADMIN_ALLOWLIST),
     VITE_ENABLE_EMAIL_OTP_SIGNIN: alchemy.secret(emailOtpEnabled),
     GOOGLE_CLIENT_ID: alchemy.secret(alchemyEnv.GOOGLE_CLIENT_ID),
     GOOGLE_CLIENT_SECRET: alchemy.secret(alchemyEnv.GOOGLE_CLIENT_SECRET),

--- a/apps/auth/scripts/render-admin-seed.ts
+++ b/apps/auth/scripts/render-admin-seed.ts
@@ -3,13 +3,13 @@ import { dirname, resolve } from "node:path";
 import { hashPassword } from "better-auth/crypto";
 import { parseSignupAllowlist } from "@iterate-com/shared/signup-allowlist";
 import {
-  BOOTSTRAP_SUPERADMIN_ACCOUNT_ID,
-  BOOTSTRAP_SUPERADMIN_ACCOUNT_ROW_ID,
-  BOOTSTRAP_SUPERADMIN_EMAIL,
-  BOOTSTRAP_SUPERADMIN_NAME,
-  BOOTSTRAP_SUPERADMIN_ROLE,
-  BOOTSTRAP_SUPERADMIN_USER_ID,
-} from "../src/server/bootstrap-superadmin.ts";
+  BOOTSTRAP_ADMIN_ACCOUNT_ID,
+  BOOTSTRAP_ADMIN_ACCOUNT_ROW_ID,
+  BOOTSTRAP_ADMIN_EMAIL,
+  BOOTSTRAP_ADMIN_NAME,
+  BOOTSTRAP_ADMIN_ROLE,
+  BOOTSTRAP_ADMIN_USER_ID,
+} from "../src/server/bootstrap-admin.ts";
 
 function escapeSqlString(value: string) {
   return value.replaceAll("'", "''");
@@ -25,7 +25,7 @@ function escapeSqlString(value: string) {
 function allowlistPatternToSqlLike(pattern: string) {
   if (!/^[a-z0-9*?@._+-]+$/.test(pattern)) {
     throw new Error(
-      `SUPERADMIN_ALLOWLIST pattern "${pattern}" uses minimatch syntax the deploy-time SQL ` +
+      `ADMIN_ALLOWLIST pattern "${pattern}" uses minimatch syntax the deploy-time SQL ` +
         `backfill cannot translate; only the * and ? wildcards are supported.`,
     );
   }
@@ -36,13 +36,13 @@ function allowlistPatternToSqlLike(pattern: string) {
     .replaceAll("?", "_");
 }
 
-// Each pattern's backfill runs exactly once, tracked in superadminBackfill:
+// Each pattern's backfill runs exactly once, tracked in platformAdminBackfill:
 // the seed file re-imports on every deploy (its rendered timestamp changes the
-// file hash), and without the marker a superadmin demoted via the admin API
+// file hash), and without the marker a platform admin demoted via the admin API
 // would be re-promoted by the next deploy. New signups are promoted by the
 // auth.ts hook, so the backfill only needs to catch users who existed before
 // their pattern was allowlisted.
-function renderSuperadminBackfillSql(allowlist: string[], now: string) {
+function renderPlatformAdminBackfillSql(allowlist: string[], now: string) {
   if (allowlist.length === 0) {
     return "";
   }
@@ -56,18 +56,19 @@ SET role = 'admin',
     updatedAt = '${escapeSqlString(now)}'
 WHERE lower(email) LIKE '${like}' ESCAPE '\\'
   AND (role IS NULL OR role != 'admin')
-  AND NOT EXISTS (SELECT 1 FROM superadminBackfill WHERE pattern = '${marker}');
+  AND NOT EXISTS (SELECT 1 FROM platformAdminBackfill WHERE pattern = '${marker}');
 
-INSERT OR IGNORE INTO superadminBackfill (pattern, appliedAt)
+INSERT OR IGNORE INTO platformAdminBackfill (pattern, appliedAt)
 VALUES ('${marker}', '${escapeSqlString(now)}');
 `;
   });
 
   return `
-CREATE TABLE IF NOT EXISTS superadminBackfill (
+CREATE TABLE IF NOT EXISTS platformAdminBackfill (
   pattern TEXT PRIMARY KEY,
   appliedAt TEXT NOT NULL
 );
+
 ${statements.join("")}`;
 }
 
@@ -82,7 +83,7 @@ async function main() {
     throw new Error("SERVICE_AUTH_TOKEN is required");
   }
 
-  const superadminAllowlist = parseSignupAllowlist(process.env.SUPERADMIN_ALLOWLIST ?? "");
+  const platformAdminAllowlist = parseSignupAllowlist(process.env.ADMIN_ALLOWLIST ?? "");
 
   const outputPath = resolve(outputPathArg);
   mkdirSync(dirname(outputPath), { recursive: true });
@@ -102,12 +103,12 @@ INSERT INTO user (
   updatedAt
 )
 VALUES (
-  '${escapeSqlString(BOOTSTRAP_SUPERADMIN_USER_ID)}',
-  '${escapeSqlString(BOOTSTRAP_SUPERADMIN_NAME)}',
-  '${escapeSqlString(BOOTSTRAP_SUPERADMIN_EMAIL)}',
+  '${escapeSqlString(BOOTSTRAP_ADMIN_USER_ID)}',
+  '${escapeSqlString(BOOTSTRAP_ADMIN_NAME)}',
+  '${escapeSqlString(BOOTSTRAP_ADMIN_EMAIL)}',
   1,
   NULL,
-  '${escapeSqlString(BOOTSTRAP_SUPERADMIN_ROLE)}',
+  '${escapeSqlString(BOOTSTRAP_ADMIN_ROLE)}',
   '${escapeSqlString(now)}',
   '${escapeSqlString(now)}'
 )
@@ -118,7 +119,7 @@ ON CONFLICT(email) DO UPDATE SET
   updatedAt = excluded.updatedAt;
 
 DELETE FROM account
-WHERE accountId = '${escapeSqlString(BOOTSTRAP_SUPERADMIN_ACCOUNT_ID)}'
+WHERE accountId = '${escapeSqlString(BOOTSTRAP_ADMIN_ACCOUNT_ID)}'
   AND providerId = 'credential';
 
 INSERT INTO account (
@@ -131,18 +132,18 @@ INSERT INTO account (
   updatedAt
 )
 VALUES (
-  '${escapeSqlString(BOOTSTRAP_SUPERADMIN_ACCOUNT_ROW_ID)}',
-  '${escapeSqlString(BOOTSTRAP_SUPERADMIN_ACCOUNT_ID)}',
+  '${escapeSqlString(BOOTSTRAP_ADMIN_ACCOUNT_ROW_ID)}',
+  '${escapeSqlString(BOOTSTRAP_ADMIN_ACCOUNT_ID)}',
   'credential',
-  (SELECT id FROM user WHERE email = '${escapeSqlString(BOOTSTRAP_SUPERADMIN_EMAIL)}'),
+  (SELECT id FROM user WHERE email = '${escapeSqlString(BOOTSTRAP_ADMIN_EMAIL)}'),
   '${escapeSqlString(passwordHash)}',
   '${escapeSqlString(now)}',
   '${escapeSqlString(now)}'
 );
-${renderSuperadminBackfillSql(superadminAllowlist, now)}`.trimStart();
+${renderPlatformAdminBackfillSql(platformAdminAllowlist, now)}`.trimStart();
 
   writeFileSync(outputPath, sql);
-  console.log(`Rendered superadmin seed SQL to ${outputPath}`);
+  console.log(`Rendered admin seed SQL to ${outputPath}`);
 }
 
 await main();

--- a/apps/auth/src/routeTree.gen.ts
+++ b/apps/auth/src/routeTree.gen.ts
@@ -13,11 +13,11 @@ import { Route as LoginRouteImport } from "./routes/login.tsx";
 import { Route as DeviceRouteImport } from "./routes/device.tsx";
 import { Route as AuthRouteImport } from "./routes/_auth.tsx";
 import { Route as AuthIndexRouteImport } from "./routes/_auth/index.tsx";
-import { Route as AuthSuperadminRouteImport } from "./routes/_auth/superadmin.tsx";
 import { Route as AuthProjectsRouteImport } from "./routes/_auth/projects.tsx";
 import { Route as AuthProjectAccessRouteImport } from "./routes/_auth/project-access.tsx";
 import { Route as AuthConsentRouteImport } from "./routes/_auth/consent.tsx";
-import { Route as AuthSuperadminClientsRouteImport } from "./routes/_auth/superadmin/clients.tsx";
+import { Route as AuthAdminRouteImport } from "./routes/_auth/admin.tsx";
+import { Route as AuthAdminClientsRouteImport } from "./routes/_auth/admin/clients.tsx";
 
 const LoginRoute = LoginRouteImport.update({
   id: "/login",
@@ -38,11 +38,6 @@ const AuthIndexRoute = AuthIndexRouteImport.update({
   path: "/",
   getParentRoute: () => AuthRoute,
 } as any);
-const AuthSuperadminRoute = AuthSuperadminRouteImport.update({
-  id: "/superadmin",
-  path: "/superadmin",
-  getParentRoute: () => AuthRoute,
-} as any);
 const AuthProjectsRoute = AuthProjectsRouteImport.update({
   id: "/projects",
   path: "/projects",
@@ -58,43 +53,48 @@ const AuthConsentRoute = AuthConsentRouteImport.update({
   path: "/consent",
   getParentRoute: () => AuthRoute,
 } as any);
-const AuthSuperadminClientsRoute = AuthSuperadminClientsRouteImport.update({
+const AuthAdminRoute = AuthAdminRouteImport.update({
+  id: "/admin",
+  path: "/admin",
+  getParentRoute: () => AuthRoute,
+} as any);
+const AuthAdminClientsRoute = AuthAdminClientsRouteImport.update({
   id: "/clients",
   path: "/clients",
-  getParentRoute: () => AuthSuperadminRoute,
+  getParentRoute: () => AuthAdminRoute,
 } as any);
 
 export interface FileRoutesByFullPath {
   "/": typeof AuthIndexRoute;
   "/device": typeof DeviceRoute;
   "/login": typeof LoginRoute;
+  "/admin": typeof AuthAdminRouteWithChildren;
   "/consent": typeof AuthConsentRoute;
   "/project-access": typeof AuthProjectAccessRoute;
   "/projects": typeof AuthProjectsRoute;
-  "/superadmin": typeof AuthSuperadminRouteWithChildren;
-  "/superadmin/clients": typeof AuthSuperadminClientsRoute;
+  "/admin/clients": typeof AuthAdminClientsRoute;
 }
 export interface FileRoutesByTo {
   "/device": typeof DeviceRoute;
   "/login": typeof LoginRoute;
+  "/admin": typeof AuthAdminRouteWithChildren;
   "/consent": typeof AuthConsentRoute;
   "/project-access": typeof AuthProjectAccessRoute;
   "/projects": typeof AuthProjectsRoute;
-  "/superadmin": typeof AuthSuperadminRouteWithChildren;
   "/": typeof AuthIndexRoute;
-  "/superadmin/clients": typeof AuthSuperadminClientsRoute;
+  "/admin/clients": typeof AuthAdminClientsRoute;
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport;
   "/_auth": typeof AuthRouteWithChildren;
   "/device": typeof DeviceRoute;
   "/login": typeof LoginRoute;
+  "/_auth/admin": typeof AuthAdminRouteWithChildren;
   "/_auth/consent": typeof AuthConsentRoute;
   "/_auth/project-access": typeof AuthProjectAccessRoute;
   "/_auth/projects": typeof AuthProjectsRoute;
-  "/_auth/superadmin": typeof AuthSuperadminRouteWithChildren;
   "/_auth/": typeof AuthIndexRoute;
-  "/_auth/superadmin/clients": typeof AuthSuperadminClientsRoute;
+  "/_auth/admin/clients": typeof AuthAdminClientsRoute;
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath;
@@ -102,32 +102,32 @@ export interface FileRouteTypes {
     | "/"
     | "/device"
     | "/login"
+    | "/admin"
     | "/consent"
     | "/project-access"
     | "/projects"
-    | "/superadmin"
-    | "/superadmin/clients";
+    | "/admin/clients";
   fileRoutesByTo: FileRoutesByTo;
   to:
     | "/device"
     | "/login"
+    | "/admin"
     | "/consent"
     | "/project-access"
     | "/projects"
-    | "/superadmin"
     | "/"
-    | "/superadmin/clients";
+    | "/admin/clients";
   id:
     | "__root__"
     | "/_auth"
     | "/device"
     | "/login"
+    | "/_auth/admin"
     | "/_auth/consent"
     | "/_auth/project-access"
     | "/_auth/projects"
-    | "/_auth/superadmin"
     | "/_auth/"
-    | "/_auth/superadmin/clients";
+    | "/_auth/admin/clients";
   fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
@@ -166,13 +166,6 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof AuthIndexRouteImport;
       parentRoute: typeof AuthRoute;
     };
-    "/_auth/superadmin": {
-      id: "/_auth/superadmin";
-      path: "/superadmin";
-      fullPath: "/superadmin";
-      preLoaderRoute: typeof AuthSuperadminRouteImport;
-      parentRoute: typeof AuthRoute;
-    };
     "/_auth/projects": {
       id: "/_auth/projects";
       path: "/projects";
@@ -194,41 +187,48 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof AuthConsentRouteImport;
       parentRoute: typeof AuthRoute;
     };
-    "/_auth/superadmin/clients": {
-      id: "/_auth/superadmin/clients";
+    "/_auth/admin": {
+      id: "/_auth/admin";
+      path: "/admin";
+      fullPath: "/admin";
+      preLoaderRoute: typeof AuthAdminRouteImport;
+      parentRoute: typeof AuthRoute;
+    };
+    "/_auth/admin/clients": {
+      id: "/_auth/admin/clients";
       path: "/clients";
-      fullPath: "/superadmin/clients";
-      preLoaderRoute: typeof AuthSuperadminClientsRouteImport;
-      parentRoute: typeof AuthSuperadminRoute;
+      fullPath: "/admin/clients";
+      preLoaderRoute: typeof AuthAdminClientsRouteImport;
+      parentRoute: typeof AuthAdminRoute;
     };
   }
 }
 
-interface AuthSuperadminRouteChildren {
-  AuthSuperadminClientsRoute: typeof AuthSuperadminClientsRoute;
+interface AuthAdminRouteChildren {
+  AuthAdminClientsRoute: typeof AuthAdminClientsRoute;
 }
 
-const AuthSuperadminRouteChildren: AuthSuperadminRouteChildren = {
-  AuthSuperadminClientsRoute: AuthSuperadminClientsRoute,
+const AuthAdminRouteChildren: AuthAdminRouteChildren = {
+  AuthAdminClientsRoute: AuthAdminClientsRoute,
 };
 
-const AuthSuperadminRouteWithChildren = AuthSuperadminRoute._addFileChildren(
-  AuthSuperadminRouteChildren,
+const AuthAdminRouteWithChildren = AuthAdminRoute._addFileChildren(
+  AuthAdminRouteChildren,
 );
 
 interface AuthRouteChildren {
+  AuthAdminRoute: typeof AuthAdminRouteWithChildren;
   AuthConsentRoute: typeof AuthConsentRoute;
   AuthProjectAccessRoute: typeof AuthProjectAccessRoute;
   AuthProjectsRoute: typeof AuthProjectsRoute;
-  AuthSuperadminRoute: typeof AuthSuperadminRouteWithChildren;
   AuthIndexRoute: typeof AuthIndexRoute;
 }
 
 const AuthRouteChildren: AuthRouteChildren = {
+  AuthAdminRoute: AuthAdminRouteWithChildren,
   AuthConsentRoute: AuthConsentRoute,
   AuthProjectAccessRoute: AuthProjectAccessRoute,
   AuthProjectsRoute: AuthProjectsRoute,
-  AuthSuperadminRoute: AuthSuperadminRouteWithChildren,
   AuthIndexRoute: AuthIndexRoute,
 };
 
@@ -242,12 +242,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>();
-
-import type { getRouter } from "./router.tsx";
-import type { createStart } from "@tanstack/react-start";
-declare module "@tanstack/react-start" {
-  interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
-  }
-}

--- a/apps/auth/src/routes/_auth/admin.tsx
+++ b/apps/auth/src/routes/_auth/admin.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
 
-export const Route = createFileRoute("/_auth/superadmin")({
+export const Route = createFileRoute("/_auth/admin")({
   beforeLoad: ({ context }) => {
     if (context.session.user.role !== "admin")
       throw notFound({ data: { message: "Not authorized" } });

--- a/apps/auth/src/routes/_auth/admin/clients.tsx
+++ b/apps/auth/src/routes/_auth/admin/clients.tsx
@@ -11,12 +11,12 @@ import type { OAuthClientRecord } from "@iterate-com/auth-contract";
 import { orpc } from "../../../utils/query.tsx";
 import { InfoRow } from "../../../utils/info-row.tsx";
 
-export const Route = createFileRoute("/_auth/superadmin/clients")({
+export const Route = createFileRoute("/_auth/admin/clients")({
   component: ClientsPage,
 });
 
 function ClientsPage() {
-  const listClientsQuery = useQuery(orpc.superadmin.oauth.listClients.queryOptions());
+  const listClientsQuery = useQuery(orpc.admin.oauth.listClients.queryOptions());
 
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
@@ -53,12 +53,12 @@ function CreateClientForm() {
   const [redirectURIs, setRedirectURIs] = useState("");
 
   const createClientMutation = useMutation(
-    orpc.superadmin.oauth.createClient.mutationOptions({
+    orpc.admin.oauth.createClient.mutationOptions({
       onSuccess: () => {
         toast.success("OAuth client created");
         setClientName("");
         setRedirectURIs("");
-        queryClient.invalidateQueries({ queryKey: orpc.superadmin.oauth.listClients.key() });
+        queryClient.invalidateQueries({ queryKey: orpc.admin.oauth.listClients.key() });
       },
     }),
   );

--- a/apps/auth/src/routes/_auth/consent.tsx
+++ b/apps/auth/src/routes/_auth/consent.tsx
@@ -13,10 +13,7 @@ import { Separator } from "@iterate-com/ui/components/separator";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { z } from "zod/v4";
-import {
-  ITERATE_PROJECT_SELECTION_SCOPE,
-  ITERATE_SUPERADMIN_SCOPE,
-} from "@iterate-com/shared/auth-claims";
+import { ITERATE_PROJECT_SELECTION_SCOPE } from "@iterate-com/shared/auth-claims";
 import { authClient, useSession } from "../../utils/auth-client.ts";
 import { oauthClientQueryOptions } from "../../utils/auth-query-options.ts";
 import { getInitials } from "../../utils/initials.ts";
@@ -201,7 +198,6 @@ function scopeLabel(scope: string): string {
     email: "View your email",
     offline_access: "Stay connected",
     [ITERATE_PROJECT_SELECTION_SCOPE]: "Use selected projects",
-    [ITERATE_SUPERADMIN_SCOPE]: "Administer Iterate",
   };
 
   return labels[scope] ?? scope;
@@ -214,7 +210,6 @@ function scopeDescription(scope: string): string {
     email: "Read the email address on this account.",
     offline_access: "Continue working after this browser session.",
     [ITERATE_PROJECT_SELECTION_SCOPE]: "Access only the projects you chose.",
-    [ITERATE_SUPERADMIN_SCOPE]: "Act with superadmin access across all organizations and projects.",
   };
 
   return descriptions[scope] ?? "Use this requested permission.";

--- a/apps/auth/src/server/auth-plugins.ts
+++ b/apps/auth/src/server/auth-plugins.ts
@@ -10,7 +10,6 @@ import {
   ITERATE_IS_ADMIN_CLAIM,
   ITERATE_ORGANIZATIONS_CLAIM,
   ITERATE_ROLE_CLAIM,
-  ITERATE_SUPERADMIN_SCOPE,
   type IterateAuthAccessTokenOrganizationClaim,
   type IterateAuthOrganizationClaim,
   type IterateAuthProjectClaim,
@@ -30,7 +29,7 @@ import {
   resolveStoredProjectSelection,
 } from "./oauth-project-selection.ts";
 import { getOsMcpResourceBases, getOsResourceBases } from "./oauth-resources.ts";
-import { isSuperadminUser } from "./superadmin.ts";
+import { isPlatformAdminUser } from "./platform-admin.ts";
 
 const TEST_EMAIL_PATTERN = /\+.*test@/i;
 const TEST_OTP_CODE = "424242";
@@ -40,15 +39,15 @@ const isNonProd = !isProduction;
 // Custom claims go out on three surfaces, configured further down in
 // oauthProvider():
 // - access tokens (customAccessTokenClaims): what resource servers like OS
-//   authorize against — org/project claims plus the server-granted `scopes`
-//   claim (project:<id> entries, superadmin).
+//   authorize against — org/project claims, project:<id> scope entries, and
+//   the Better Auth admin-plugin role claim.
 // - ID tokens (customIdTokenClaims) and userinfo (customUserInfoClaims):
 //   login-time identity for the relying party — the namespaced
 //   https://iterate.com/claims/* values built here.
 function buildIterateTokenClaims(user: Record<string, unknown> | null | undefined) {
   const role = typeof user?.role === "string" ? user.role : null;
   return {
-    [ITERATE_IS_ADMIN_CLAIM]: isSuperadminUser({ role }),
+    [ITERATE_IS_ADMIN_CLAIM]: isPlatformAdminUser({ role }),
     [ITERATE_ROLE_CLAIM]: role,
   };
 }
@@ -198,14 +197,7 @@ export function getAuthPlugins(env: Record<string, unknown>) {
       // rotated-token reuse as theft) is rare, short enough that org/project
       // claim changes propagate within half an hour.
       accessTokenExpiresIn: 30 * 60,
-      scopes: [
-        "openid",
-        "profile",
-        "email",
-        "offline_access",
-        ITERATE_PROJECT_SELECTION_SCOPE,
-        ITERATE_SUPERADMIN_SCOPE,
-      ],
+      scopes: ["openid", "profile", "email", "offline_access", ITERATE_PROJECT_SELECTION_SCOPE],
       validAudiences,
       allowDynamicClientRegistration: true,
       allowUnauthenticatedClientRegistration: true,
@@ -223,10 +215,10 @@ export function getAuthPlugins(env: Record<string, unknown>) {
         ]);
 
         return {
+          ...buildIterateTokenClaims(user),
           scopes: buildAugmentedScopeClaims({
             requestedScopes: scopes,
             projectIds: isProjectScopedToken ? projects.map((project) => project.id) : [],
-            superadmin: isSuperadminUser(user),
           }),
           [ITERATE_ACCESS_TOKEN_ORGANIZATIONS_CLAIM]: organizations,
           [ITERATE_ACCESS_TOKEN_PROJECTS_CLAIM]: projects,

--- a/apps/auth/src/server/auth.ts
+++ b/apps/auth/src/server/auth.ts
@@ -75,13 +75,13 @@ export const auth = betterAuth({
           // Email-domain promotion is safe because password signup is disabled:
           // both remaining sign-in methods (Google, email OTP) prove mailbox
           // ownership before this hook runs.
-          const superadminAllowlist = parseSignupAllowlist(env.SUPERADMIN_ALLOWLIST);
-          const isSuperadmin = matchesSignupAllowlist(email, superadminAllowlist);
+          const platformAdminAllowlist = parseSignupAllowlist(env.ADMIN_ALLOWLIST);
+          const isPlatformAdmin = matchesSignupAllowlist(email, platformAdminAllowlist);
 
           return {
             data: {
               ...user,
-              role: isSuperadmin ? "admin" : user.role,
+              role: isPlatformAdmin ? "admin" : user.role,
               image: user.image || generateDefaultAvatar(email),
             },
           };

--- a/apps/auth/src/server/bootstrap-admin.ts
+++ b/apps/auth/src/server/bootstrap-admin.ts
@@ -1,0 +1,6 @@
+export const BOOTSTRAP_ADMIN_EMAIL = "admin@nustom.com";
+export const BOOTSTRAP_ADMIN_NAME = "Platform Admin";
+export const BOOTSTRAP_ADMIN_ROLE = "admin";
+export const BOOTSTRAP_ADMIN_ACCOUNT_ID = "admin";
+export const BOOTSTRAP_ADMIN_ACCOUNT_ROW_ID = "acc_bootstrap_admin";
+export const BOOTSTRAP_ADMIN_USER_ID = "usr_bootstrap_admin";

--- a/apps/auth/src/server/bootstrap-superadmin.ts
+++ b/apps/auth/src/server/bootstrap-superadmin.ts
@@ -1,6 +1,0 @@
-export const BOOTSTRAP_SUPERADMIN_EMAIL = "superadmin@nustom.com";
-export const BOOTSTRAP_SUPERADMIN_NAME = "Super Admin";
-export const BOOTSTRAP_SUPERADMIN_ROLE = "admin";
-export const BOOTSTRAP_SUPERADMIN_ACCOUNT_ID = "superadmin";
-export const BOOTSTRAP_SUPERADMIN_ACCOUNT_ROW_ID = "acc_bootstrap_superadmin";
-export const BOOTSTRAP_SUPERADMIN_USER_ID = "usr_bootstrap_superadmin";

--- a/apps/auth/src/server/oauth-project-selection.ts
+++ b/apps/auth/src/server/oauth-project-selection.ts
@@ -1,7 +1,4 @@
-import {
-  ITERATE_PROJECT_SCOPE_PREFIX,
-  ITERATE_SUPERADMIN_SCOPE,
-} from "@iterate-com/shared/auth-claims";
+import { ITERATE_PROJECT_SCOPE_PREFIX } from "@iterate-com/shared/auth-claims";
 import { parseStringArray } from "./db/helpers.ts";
 import { getLatestOAuthProjectSelectionByUserId } from "./db/queries/.generated/index.ts";
 import { db } from "./db/index.ts";
@@ -88,17 +85,8 @@ export function parseOAuthProjectSelectionReferenceId(referenceId: string | null
 export function buildAugmentedScopeClaims(params: {
   projectIds: string[];
   requestedScopes: string[];
-  superadmin: boolean;
 }) {
   const scopeClaims = new Set(params.requestedScopes.filter(Boolean));
-
-  // The superadmin scope is server-granted, never client-requested: a client
-  // can put it in its scope request, so being in the requested list proves
-  // nothing — only the user's role does.
-  scopeClaims.delete(ITERATE_SUPERADMIN_SCOPE);
-  if (params.superadmin) {
-    scopeClaims.add(ITERATE_SUPERADMIN_SCOPE);
-  }
 
   for (const projectId of normalizeProjectIds(params.projectIds)) {
     scopeClaims.add(`${ITERATE_PROJECT_SCOPE_PREFIX}${projectId}`);

--- a/apps/auth/src/server/orpc/index.ts
+++ b/apps/auth/src/server/orpc/index.ts
@@ -1,15 +1,15 @@
 import { os } from "./orpc.ts";
+import { admin } from "./routers/admin.ts";
 import { internal } from "./routers/internal.ts";
 import { organization } from "./routers/organization.ts";
 import { project } from "./routers/project.ts";
-import { superadmin } from "./routers/superadmin.ts";
 import { user } from "./routers/user.ts";
 
 export const appRouter = os.router({
   user,
   organization,
   project,
-  superadmin,
+  admin,
   internal,
 });
 

--- a/apps/auth/src/server/orpc/orpc.ts
+++ b/apps/auth/src/server/orpc/orpc.ts
@@ -10,11 +10,11 @@ import {
 } from "../db/queries/index.ts";
 import type { Variables } from "../utils/hono.ts";
 import type { CloudflareEnv } from "../env.ts";
-import { isSuperadminUser } from "../superadmin.ts";
+import { isPlatformAdminUser } from "../platform-admin.ts";
 
 // Two role namespaces appear below; don't mix them up:
 // - `session.user.role` is the system-wide better-auth admin-plugin role.
-//   "admin" there means superadmin (see superadmin.ts) and bypasses every
+//   "admin" there means platform admin and bypasses every
 //   membership check.
 // - `membership.role` is scoped to one organization and is one of
 //   "owner" | "admin" | "member".
@@ -37,9 +37,9 @@ export const protectedMiddleware = os.middleware(async ({ context, next }) => {
   });
 });
 
-export const superadminOnlyMiddleware = os.middleware(async ({ context, next }) => {
+export const platformAdminOnlyMiddleware = os.middleware(async ({ context, next }) => {
   const { session } = context;
-  if (!session || !isSuperadminUser(session.user)) {
+  if (!session || !isPlatformAdminUser(session.user)) {
     throw new ORPCError("UNAUTHORIZED", { message: "Not authorized" });
   }
   return next({
@@ -79,7 +79,7 @@ async function loadOrganization(params: {
     organizationId: organization.id,
     userId: params.user.id,
   });
-  if (!membership && !isSuperadminUser(params.user)) {
+  if (!membership && !isPlatformAdminUser(params.user)) {
     throw new ORPCError("FORBIDDEN", { message: "You do not have access to this organization" });
   }
 
@@ -91,7 +91,7 @@ function assertOrganizationAdmin(params: {
   membership: { role: string } | null;
 }) {
   const role = params.membership?.role;
-  if (!isSuperadminUser(params.user) && role !== "owner" && role !== "admin") {
+  if (!isPlatformAdminUser(params.user) && role !== "owner" && role !== "admin") {
     throw new ORPCError("FORBIDDEN", { message: "Admin role required" });
   }
 }
@@ -176,7 +176,7 @@ async function loadProject(params: {
     organizationId: organization.id,
     userId: params.user.id,
   });
-  if (!membership && !isSuperadminUser(params.user)) {
+  if (!membership && !isPlatformAdminUser(params.user)) {
     throw new ORPCError("FORBIDDEN", { message: "You do not have access to this project" });
   }
 

--- a/apps/auth/src/server/orpc/routers/admin.ts
+++ b/apps/auth/src/server/orpc/routers/admin.ts
@@ -1,11 +1,11 @@
 import { ORPCError } from "@orpc/server";
-import { os, superadminOnlyMiddleware } from "../orpc.ts";
+import { os, platformAdminOnlyMiddleware } from "../orpc.ts";
 import { parseStringArray } from "../../db/helpers.ts";
 import { listSystemOAuthClients } from "../../db/queries/index.ts";
 import { auth } from "../../auth.ts";
 
-const superadminCreateOAuthClient = os.superadmin.oauth.createClient
-  .use(superadminOnlyMiddleware)
+const adminCreateOAuthClient = os.admin.oauth.createClient
+  .use(platformAdminOnlyMiddleware)
   .handler(async ({ input }) => {
     const client = await auth.api.adminCreateOAuthClient({
       body: {
@@ -27,8 +27,8 @@ const superadminCreateOAuthClient = os.superadmin.oauth.createClient
     };
   });
 
-const superadminListOAuthClients = os.superadmin.oauth.listClients
-  .use(superadminOnlyMiddleware)
+const adminListOAuthClients = os.admin.oauth.listClients
+  .use(platformAdminOnlyMiddleware)
   .handler(async ({ context }) => {
     const clients = await listSystemOAuthClients(context.db);
 
@@ -39,9 +39,9 @@ const superadminListOAuthClients = os.superadmin.oauth.listClients
     }));
   });
 
-export const superadmin = os.superadmin.router({
+export const admin = os.admin.router({
   oauth: {
-    createClient: superadminCreateOAuthClient,
-    listClients: superadminListOAuthClients,
+    createClient: adminCreateOAuthClient,
+    listClients: adminListOAuthClients,
   },
 });

--- a/apps/auth/src/server/orpc/routers/internal.ts
+++ b/apps/auth/src/server/orpc/routers/internal.ts
@@ -21,7 +21,7 @@ import {
   updateOAuthClientReferenceByClientId,
   updateVerifiedUserById,
 } from "../../db/queries/index.ts";
-import { BOOTSTRAP_SUPERADMIN_EMAIL } from "../../bootstrap-superadmin.ts";
+import { BOOTSTRAP_ADMIN_EMAIL } from "../../bootstrap-admin.ts";
 import {
   generateId,
   toMembershipRole,
@@ -37,13 +37,13 @@ function extractCookieHeader(setCookieHeader: string | null): string | null {
   return firstCookie.split(";")[0] ?? null;
 }
 
-async function getBootstrapSuperadminAuthHeaders(params: {
+async function getBootstrapAdminAuthHeaders(params: {
   serviceAuthToken: string;
 }): Promise<Headers> {
   const signInResult = await auth.api.signInEmail({
     returnHeaders: true,
     body: {
-      email: BOOTSTRAP_SUPERADMIN_EMAIL,
+      email: BOOTSTRAP_ADMIN_EMAIL,
       password: params.serviceAuthToken,
     },
   });
@@ -51,7 +51,7 @@ async function getBootstrapSuperadminAuthHeaders(params: {
   const cookie = extractCookieHeader(signInResult.headers.get("set-cookie"));
   if (!cookie) {
     throw new ORPCError("INTERNAL_SERVER_ERROR", {
-      message: "Failed to establish bootstrap superadmin auth session",
+      message: "Failed to establish bootstrap admin auth session",
     });
   }
 
@@ -371,7 +371,7 @@ const ensureOAuthClient = os.internal.oauth.ensureClient
       });
     }
 
-    const headers = await getBootstrapSuperadminAuthHeaders({
+    const headers = await getBootstrapAdminAuthHeaders({
       serviceAuthToken,
     });
     const created = await auth.api.adminCreateOAuthClient({

--- a/apps/auth/src/server/platform-admin.ts
+++ b/apps/auth/src/server/platform-admin.ts
@@ -1,23 +1,18 @@
 /**
- * Superadmin model
- * ----------------
+ * Platform admin model
+ * --------------------
  * `user.role === "admin"` (the better-auth admin plugin's role column on the
- * user table) is the single source of truth for superadmin status. Everything
- * else is derived from it:
+ * user table) is the single source of truth for platform-admin status.
  *
- * - oRPC middleware (orpc.ts) lets superadmins through organization/project
+ * - oRPC middleware (orpc.ts) lets platform admins through organization/project
  *   membership checks.
- * - Access tokens get the `superadmin` scope added server-side
- *   (oauth-project-selection.ts); resource servers like the OS MCP handler
- *   trust that scope. Clients cannot grant it to themselves — it is stripped
- *   from requested scopes unless the role says otherwise.
- * - ID tokens / userinfo expose it as the is_admin / role claims
+ * - Access tokens, ID tokens, and userinfo expose it as the is_admin / role claims
  *   (auth-plugins.ts).
  *
  * The role is granted three ways:
- * - the signup hook in auth.ts, for emails matching SUPERADMIN_ALLOWLIST
+ * - the signup hook in auth.ts, for emails matching ADMIN_ALLOWLIST
  *   (default `*@nustom.com`),
- * - the deploy-time seed SQL (scripts/render-superadmin-seed.ts), which
+ * - the deploy-time seed SQL, which
  *   backfills users who existed before their email domain was allowlisted —
  *   once per pattern, so it never overrides a later manual demotion,
  * - manually, via the better-auth admin API.
@@ -30,7 +25,7 @@
  * Not to be confused with per-organization membership roles
  * ("owner"/"admin"/"member" on the member table) — see orpc.ts.
  */
-export function isSuperadminUser(
+export function isPlatformAdminUser(
   user: { role?: unknown } | Record<string, unknown> | null | undefined,
 ): boolean {
   return user?.role === "admin";

--- a/apps/os/docs/architecture-and-operations.md
+++ b/apps/os/docs/architecture-and-operations.md
@@ -162,7 +162,7 @@ it is not itself a codemode Tool Provider.
 Inbound MCP requests authenticate two ways, tried in order:
 
 1. The platform admin API secret — full access to every project in the
-   deployment (`superadmin` scope).
+   deployment (`authType: "admin_api_secret"`).
 2. An Iterate Auth OAuth bearer token — project access is the intersection of
    the token's `projects` claim and its `project:<id>` scope entries.
 

--- a/apps/os/docs/itx-next.md
+++ b/apps/os/docs/itx-next.md
@@ -311,15 +311,15 @@ by crippling the node. Naming: keep `global`, not `root` — it's already the
 literal namespace name in the streams domain.
 
 **The access model is deliberately two-tier, and it shipped (PR #1418):**
-the only scopes that exist are `superadmin` (server-granted via the `admin`
-role only — client-requested scope is always stripped; auto-granted to
-`@nustom.com` accounts) and `project:<id>` strings. Superadmin resolves to
-access `"all"`; everyone else may do project-scoped things iff the project
-id is literally in their scopes. There is no separate "global namespace
-grant" — global authority IS superadmin. The code keeps ONE seam where
-finer-grained permissions would slot in later; we deliberately build none
-of it now. #1418 also already ships the first slice of this section: the
-`/admin` UI connects to the global itx over Cap'n Web, and `itx.streams`
+admin is the Better Auth admin-plugin role (`user.role === "admin"`,
+surfaced to OS as `role` / `is_admin` token claims), while OAuth project
+selection remains `project:<id>` scope strings. Admin resolves to access
+`"all"`; everyone else may do project-scoped things iff the project id is
+literally in their scopes. There is no separate "global namespace grant" —
+global authority IS admin. The code keeps ONE seam where finer-grained
+permissions would slot in later; we deliberately build none of it now.
+#1418 also already ships the first slice of this section: the `/admin` UI
+connects to the global itx over Cap'n Web, and `itx.streams`
 on a global handle targets the deployment-wide `global` namespace, gated
 on access `"all"`.
 
@@ -508,10 +508,9 @@ second step, taken only after the shared layer proves itself.
   Not a `source` worker either — its code lives in the project's build
   artifact (the registry points, never pins). Kept as a spelling so
   `entrypoint` always names the export you call (§1).
-- ~~Access model granularity?~~ → Shipped in #1418: `superadmin`
-  (role-granted) + `project:<id>` scopes, nothing else. One seam in the
-  code for finer-grained later; no implementation now. Global authority =
-  superadmin (§3).
+- ~~Access model granularity?~~ → Shipped in #1418: Better Auth admin role +
+  `project:<id>` scopes, nothing else. One seam in the code for finer-grained
+  later; no implementation now. Global authority = admin (§3).
 - ~~`global` vs `root`?~~ → `global` (leaning; it's the existing literal
   namespace name, e.g. Slack webhook receiving streams).
 

--- a/apps/os/docs/preview-agent-browser-smoke.md
+++ b/apps/os/docs/preview-agent-browser-smoke.md
@@ -78,7 +78,7 @@ AB() { AGENT_BROWSER_AUTO_CONNECT=0 agent-browser --cdp 9444 "$@"; }
 The hosted login UI (`auth.iterate.com/login`) **only offers "Continue with
 Google"** — there is no email/password form to fill, and sign-up is disabled
 (`apps/auth/src/server/auth.ts`). So you cannot log in by filling a form. Instead
-authenticate the bootstrap superadmin against better-auth's **API**, inject the
+authenticate the bootstrap admin against better-auth's **API**, inject the
 resulting session cookies, then let the OAuth flow complete:
 
 1. **Sign in via the better-auth API** (email/password IS enabled at the API
@@ -89,10 +89,10 @@ resulting session cookies, then let the OAuth flow complete:
    export SECRET=$(doppler secrets get SERVICE_AUTH_TOKEN --project auth --config prd --plain)
    curl -s -c /tmp/auth.txt -X POST https://auth.iterate.com/api/auth/sign-in/email \
      -H 'content-type: application/json' \
-     --data "$(python3 -c 'import json,os;print(json.dumps({"email":"superadmin@nustom.com","password":os.environ["SECRET"]}))')"
+     --data "$(python3 -c 'import json,os;print(json.dumps({"email":"admin@nustom.com","password":os.environ["SECRET"]}))')"
    ```
 
-   - email: `superadmin@nustom.com` (`BOOTSTRAP_SUPERADMIN_EMAIL`)
+   - email: `admin@nustom.com` (`BOOTSTRAP_ADMIN_EMAIL`)
    - password: the auth worker's `SERVICE_AUTH_TOKEN` (Doppler `auth/prd`)
 
 2. **Inject the `__Secure-better-auth.session_{token,data}` cookies** into the
@@ -111,7 +111,7 @@ resulting session cookies, then let the OAuth flow complete:
 5. `AB state save /tmp/os-auth.json` immediately.
 
 Previews authenticate against **production** auth (`auth.iterate.com`), so this
-works against preview hosts too. For a fresh non-superadmin user, provision it
+works against preview hosts too. For a fresh non-admin user, provision it
 via the auth worker's service-token-gated internal oRPC API
 (`internal.user.upsertVerifiedEmail` + `internal.organization.createForUser`).
 

--- a/apps/os/docs/simplification-decisions.md
+++ b/apps/os/docs/simplification-decisions.md
@@ -141,7 +141,7 @@ semaphore now implements the same static debug response in its local router.
 Verified the deployed PR preview (`os.iterate-preview-3.com`) with a fully
 headless browser, no human in the loop (procedure: `preview-agent-browser-smoke.md`):
 
-- Signed in as the bootstrap superadmin, created a project via **`/new-project`**
+- Signed in as the bootstrap admin, created a project via **`/new-project`**
   (the renamed route — the original bug), and drove an agent conversation
   through the browser UI: typed a question into the agent's message box, and the
   agent (DO + OpenAI) replied correctly. Confirmed both via the UI send and via

--- a/apps/os/src/auth/principal.test.ts
+++ b/apps/os/src/auth/principal.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { AccessTokenClaims, AuthenticatedSession } from "@iterate-com/auth/server";
+import { ITERATE_IS_ADMIN_CLAIM, ITERATE_ROLE_CLAIM } from "@iterate-com/shared/auth-claims";
+import {
+  createUserPrincipal,
+  principalFromAccessToken,
+  principalFromSession,
+  principalIsAdmin,
+} from "./principal.ts";
+
+describe("auth principal admin access", () => {
+  it("identifies Better Auth admin browser sessions as admin", () => {
+    const principal = principalFromSession({
+      session: {
+        activeOrganizationId: null,
+        expiresAt: 4_102_444_800,
+        organizations: [],
+        projects: [],
+        scope: "openid profile",
+        sessionId: "sess_1",
+      },
+      tokenClaims: {} as AuthenticatedSession["tokenClaims"],
+      user: {
+        email: "jonas@nustom.com",
+        id: "usr_jonas",
+        isAdmin: true,
+        role: "admin",
+      },
+    });
+
+    expect(principal.isAdmin).toBe(true);
+    expect(principalIsAdmin(principal)).toBe(true);
+  });
+
+  it("identifies Better Auth admin bearer access tokens as admin", () => {
+    const principal = principalFromAccessToken({
+      aud: "https://os.iterate.com",
+      exp: 4_102_444_800,
+      iat: 1_700_000_000,
+      iss: "https://auth.iterate.com",
+      scope: "project",
+      sub: "usr_jonas",
+      [ITERATE_IS_ADMIN_CLAIM]: true,
+      [ITERATE_ROLE_CLAIM]: "admin",
+    } as AccessTokenClaims);
+
+    expect(principal.isAdmin).toBe(true);
+    expect(principalIsAdmin(principal)).toBe(true);
+  });
+
+  it("does not identify ordinary users as admin", () => {
+    const principal = createUserPrincipal({
+      organizations: [],
+      projects: [],
+      userId: "usr_member",
+    });
+
+    expect(principalIsAdmin(principal)).toBe(false);
+  });
+});

--- a/apps/os/src/auth/principal.ts
+++ b/apps/os/src/auth/principal.ts
@@ -2,6 +2,8 @@ import type { AccessTokenClaims, AuthenticatedSession } from "@iterate-com/auth/
 import {
   ITERATE_ACCESS_TOKEN_ORGANIZATIONS_CLAIM,
   ITERATE_ACCESS_TOKEN_PROJECTS_CLAIM,
+  ITERATE_IS_ADMIN_CLAIM,
+  ITERATE_ROLE_CLAIM,
   type IterateAuthAccessTokenOrganizationClaim,
   type IterateAuthProjectClaim,
 } from "@iterate-com/shared/auth-claims";
@@ -15,6 +17,7 @@ export type UserPrincipal = {
   type: "user";
   userId: string;
   sessionId?: string;
+  isAdmin: boolean;
   organizations: IterateAuthAccessTokenOrganizationClaim[];
   projects: IterateAuthProjectClaim[];
   can(action: string, resource?: PrincipalResource): boolean;
@@ -39,6 +42,7 @@ export function getUserPrincipal(principal: Principal | null | undefined): UserP
 export function createUserPrincipal(input: {
   userId: string;
   sessionId?: string;
+  isAdmin?: boolean;
   organizations: IterateAuthAccessTokenOrganizationClaim[];
   projects: IterateAuthProjectClaim[];
 }): UserPrincipal {
@@ -46,6 +50,7 @@ export function createUserPrincipal(input: {
     type: "user",
     userId: input.userId,
     sessionId: input.sessionId,
+    isAdmin: input.isAdmin ?? false,
     organizations: input.organizations,
     projects: input.projects,
     can: (_action, resource) => canAccessResource(input, resource),
@@ -56,6 +61,7 @@ export function principalFromSession(session: AuthenticatedSession): UserPrincip
   return createUserPrincipal({
     userId: session.user.id,
     sessionId: session.session.sessionId,
+    isAdmin: isAdminRole(session.user),
     organizations: session.session.organizations.map((organization) => ({
       id: organization.id,
       slug: organization.slug,
@@ -69,9 +75,21 @@ export function principalFromAccessToken(accessToken: AccessTokenClaims): UserPr
   return createUserPrincipal({
     userId: accessToken.sub,
     sessionId: accessToken.sid,
+    isAdmin: isAdminRole({
+      isAdmin: accessToken[ITERATE_IS_ADMIN_CLAIM],
+      role: accessToken[ITERATE_ROLE_CLAIM],
+    }),
     organizations: accessToken[ITERATE_ACCESS_TOKEN_ORGANIZATIONS_CLAIM] ?? [],
     projects: accessToken[ITERATE_ACCESS_TOKEN_PROJECTS_CLAIM] ?? [],
   });
+}
+
+export function principalIsAdmin(principal: Principal): boolean {
+  return principal.type === "admin" || principal.isAdmin;
+}
+
+function isAdminRole(input: { isAdmin?: unknown; role?: unknown } | null | undefined): boolean {
+  return input?.isAdmin === true || input?.role === "admin";
 }
 
 function canAccessResource(

--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -182,7 +182,7 @@ function AppSidebarUser() {
   const accountManagementUrl = authWorkerUrl(config, "/");
   const [debugOpen, setDebugOpen] = useState(false);
   const user = session?.authenticated ? session.user : null;
-  const isSuperadmin = user?.isAdmin ?? false;
+  const isAdmin = user?.isAdmin ?? false;
   const label = nonEmptyLabel(user?.name, user?.email, "Account");
   const email = user?.email?.trim() ?? "";
   const initials = userInitials(label);
@@ -257,7 +257,7 @@ function AppSidebarUser() {
                     </a>
                   }
                 />
-                {isSuperadmin && (
+                {isAdmin && (
                   <DropdownMenuItem render={<Link to="/admin" />}>
                     <Shield />
                     <span>Admin</span>

--- a/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
@@ -1,8 +1,6 @@
 import { createIterateAuth } from "@iterate-com/auth/server";
 import {
   ITERATE_PROJECT_SELECTION_SCOPE,
-  ITERATE_SUPERADMIN_SCOPE,
-  hasSuperadminScope,
   listProjectScopeIds,
 } from "@iterate-com/shared/auth-claims";
 import { oauthResourceAudienceVariants } from "@iterate-com/shared/oauth-resource";
@@ -47,13 +45,13 @@ export const mcpCorsHeaders = {
 
 // Two ways to authenticate an MCP request, tried in order:
 // 1. The platform admin API secret (authenticateAdminMcpRequest): full access
-//    to every project in this deployment, props carry the `superadmin` scope.
+//    to every project in this deployment.
 // 2. An Iterate Auth OAuth bearer token: project access is the intersection of
 //    two independent gates — the token's `projects` claim (which projects the
 //    user belongs to / selected during the OAuth flow) and its `project:<id>`
-//    scope entries. The `superadmin` scope (server-granted to role-admin
-//    users by apps/auth) skips the scope gate but not the claim gate, so even
-//    a superadmin's token only reaches projects listed in its claims.
+//    scope entries. A Better Auth admin-role token skips the scope gate but not
+//    the claim gate, so even a platform admin's token only reaches projects
+//    listed in its claims.
 export async function handleMcpFetch(input: McpHandlerInput): Promise<Response | null> {
   const routeMatch = matchConfiguredMcpBaseUrl(input);
   if (!routeMatch) return null;
@@ -104,9 +102,8 @@ export async function handleMcpFetch(input: McpHandlerInput): Promise<Response |
   const scopes = readAccessTokenScopes(accessToken);
   const principal = principalFromAccessToken(accessToken);
   const grantedProjectIds = new Set(listProjectScopeIds(scopes));
-  const isSuperadmin = hasSuperadminScope(scopes);
   const projects = principal.projects.flatMap((project) => {
-    if (!isSuperadmin && !grantedProjectIds.has(project.id)) return [];
+    if (!principal.isAdmin && !grantedProjectIds.has(project.id)) return [];
 
     const organization = principal.organizations.find((org) => org.id === project.organizationId);
     return [
@@ -177,7 +174,7 @@ async function authenticateAdminMcpRequest(input: McpHandlerInput) {
       organizationRole: "admin",
       organizationSlug: null,
     })),
-    scopes: [ITERATE_SUPERADMIN_SCOPE],
+    scopes: [],
     userId: "admin-api-secret",
   } satisfies ProjectMcpServerConnectionProps;
 }

--- a/apps/os/src/durable-objects/iterate-mcp-server-test-entry.ts
+++ b/apps/os/src/durable-objects/iterate-mcp-server-test-entry.ts
@@ -114,7 +114,7 @@ function propsForRequest(request: Request): ProjectMcpServerConnectionProps {
         { id: "proj__test__other", slug: "other-project", ...orgFields },
       ],
       scopes: isAdmin
-        ? ["superadmin"]
+        ? []
         : ["profile", "project", "project:proj__test__inboundmcp", "project:proj__test__other"],
       userId: isAdmin ? "admin-api-secret" : "user_test",
     };

--- a/apps/os/src/itx/fetch.ts
+++ b/apps/os/src/itx/fetch.ts
@@ -136,7 +136,8 @@ async function authenticateItxRequest(input: {
 
 /** The simplified access model: admin sees all, users see their projects. */
 function accessForPrincipal(principal: Principal): ProjectAccess {
-  return principal.type === "admin" ? "all" : principal.projects.map((project) => project.id);
+  if (principal.type === "admin" || principal.isAdmin) return "all";
+  return principal.projects.map((project) => project.id);
 }
 
 /**

--- a/apps/os/src/itx/types.ts
+++ b/apps/os/src/itx/types.ts
@@ -574,9 +574,8 @@ export type ContextRef = "global" | `prj_${string}` | `proj_${string}` | `ctx_${
  * seam rather than an invented parallel access model. Only fields itx
  * actually uses appear here.
  *
- * - `admin`: the admin API secret, or a token carrying the server-granted
- *   `superadmin` scope (granted via the `admin` role only; client-requested
- *   scope is always stripped). Sees everything.
+ * - `admin`: the admin API secret, or a user token carrying Better Auth's
+ *   admin-plugin role claim. Sees everything.
  * - `user`: organization memberships and project grants exactly as the auth
  *   worker issued them. May do project-scoped things iff the project is in
  *   `projects`. Nothing finer-grained exists (the seam does; the

--- a/apps/os/src/lib/auth.ts
+++ b/apps/os/src/lib/auth.ts
@@ -45,6 +45,7 @@ function getUserPrincipalFromSession(
   return createUserPrincipal({
     userId: session.user.id,
     sessionId: session.session.sessionId,
+    isAdmin: session.user.isAdmin === true || session.user.role === "admin",
     organizations: session.session.organizations,
     projects: session.session.projects,
   });

--- a/docs/plan-replace-clerk-with-auth-worker.md
+++ b/docs/plan-replace-clerk-with-auth-worker.md
@@ -543,7 +543,7 @@ Phase F is last.
   `https://os.iterate-dev-jonas.com` as an OAuth `resource`.
 - Re-ran real OAuth login/callback/session flows against both
   `https://os.iterate-dev-jonas.com` and `https://os.iterate-preview-2.com`
-  using the production auth worker, bootstrap superadmin credentials from auth
+  using the production auth worker, bootstrap admin credentials from auth
   Doppler, and in-memory cookies. Both flows completed and returned
   authenticated OS sessions without printing tokens, codes, cookies, or secrets.
 - Fixed the post-login empty-organization path on OS. `/organization` now shows

--- a/packages/iterate/README.md
+++ b/packages/iterate/README.md
@@ -99,7 +99,7 @@ Config shape:
       "authBaseUrl": "https://auth-dev-yourname.iterate.com",
       "daemonBaseUrl": "http://localhost:3001",
       "auth": {
-        "strategy": "superadmin",
+        "strategy": "admin",
         "adminPasswordEnvVarName": "SERVICE_AUTH_TOKEN",
         "userEmail": "dev-yourname@iterate.com"
       }
@@ -117,7 +117,7 @@ Config resolution priority: `--config` flag > workspace match (walk up from cwd)
 Auth strategies:
 
 - `device` — interactive browser-based login (RFC 8628 device flow). Run `iterate login`.
-- `superadmin` — CI/automation impersonation via admin password env var.
+- `admin` — CI/automation impersonation via admin password env var.
 
 ## Local iterate dev
 

--- a/packages/iterate/src/cli.ts
+++ b/packages/iterate/src/cli.ts
@@ -24,9 +24,9 @@ const XDG_CONFIG_PARENT = join(
 
 const CONFIG_PATH = join(XDG_CONFIG_PARENT, "config.json");
 
-/** Superadmin impersonation strategy — for CI/automation. Requires admin password env var. */
-const SuperadminStrategy = z.object({
-  strategy: z.literal("superadmin"),
+/** Admin impersonation strategy — for CI/automation. Requires admin password env var. */
+const AdminStrategy = z.object({
+  strategy: z.literal("admin"),
   adminPasswordEnvVarName: z.string().describe("Env var name containing admin password"),
   userEmail: z.string().describe("User email to impersonate for OS calls"),
 });
@@ -36,7 +36,7 @@ const DeviceStrategy = z.object({
   strategy: z.literal("device"),
 });
 
-const AuthStrategy = z.discriminatedUnion("strategy", [SuperadminStrategy, DeviceStrategy]);
+const AuthStrategy = z.discriminatedUnion("strategy", [AdminStrategy, DeviceStrategy]);
 
 /** Stored session (lives inside a config entry) */
 const Session = z.object({
@@ -277,11 +277,11 @@ const setCookiesToCookieHeader = (setCookies: string[] | undefined): string => {
 const impersonationUserIdCache = new Map<string, string>();
 
 const resolveImpersonationUserId = async ({
-  superadminAuthClient,
+  adminAuthClient,
   userEmail,
   baseUrl,
 }: {
-  superadminAuthClient: any;
+  adminAuthClient: any;
   userEmail: string;
   baseUrl: string;
 }): Promise<string> => {
@@ -295,7 +295,7 @@ const resolveImpersonationUserId = async ({
   let users: any[] = [];
 
   try {
-    const result = await superadminAuthClient.admin.listUsers({
+    const result = await adminAuthClient.admin.listUsers({
       query: {
         filterField: "email",
         filterOperator: "eq",
@@ -308,7 +308,7 @@ const resolveImpersonationUserId = async ({
     });
     users = Array.isArray(result?.users) ? result.users : [];
   } catch {
-    const result = await superadminAuthClient.admin.listUsers({
+    const result = await adminAuthClient.admin.listUsers({
       query: {
         searchField: "email",
         searchOperator: "contains",
@@ -345,8 +345,8 @@ const resolveImpersonationUserId = async ({
   return resolvedUserId;
 };
 
-const superadminAuthDance = async (config: Config & { auth: { strategy: "superadmin" } }) => {
-  let superadminSetCookie: string[] | undefined;
+const adminAuthDance = async (config: Config & { auth: { strategy: "admin" } }) => {
+  let adminSetCookie: string[] | undefined;
   const authClient = createAuthClient({
     baseURL: config.osBaseUrl,
     fetchOptions: {
@@ -359,36 +359,36 @@ const superadminAuthDance = async (config: Config & { auth: { strategy: "superad
   }
 
   await authClient.signIn.email({
-    email: "superadmin@nustom.com",
+    email: "admin@nustom.com",
     password,
     fetchOptions: {
       throw: true,
       onResponse: (ctx: { response: Response }) => {
-        superadminSetCookie = ctx.response.headers.getSetCookie();
+        adminSetCookie = ctx.response.headers.getSetCookie();
       },
     },
   });
 
-  const superadminAuthClient = createAuthClient({
+  const adminAuthClient = createAuthClient({
     baseURL: config.osBaseUrl,
     fetchOptions: {
       throw: true,
       onRequest: (ctx: { headers: Headers }) => {
         ctx.headers.set("origin", config.osBaseUrl);
-        ctx.headers.set("cookie", setCookiesToCookieHeader(superadminSetCookie));
+        ctx.headers.set("cookie", setCookiesToCookieHeader(adminSetCookie));
       },
     },
     plugins: [adminClient()],
   });
 
   const userId = await resolveImpersonationUserId({
-    superadminAuthClient,
+    adminAuthClient,
     userEmail: config.auth.userEmail,
     baseUrl: config.osBaseUrl,
   });
 
   let impersonateSetCookie: string[] | undefined;
-  await superadminAuthClient.admin.impersonateUser({
+  await adminAuthClient.admin.impersonateUser({
     userId,
     fetchOptions: {
       throw: true,
@@ -416,14 +416,14 @@ const superadminAuthDance = async (config: Config & { auth: { strategy: "superad
 
 /**
  * Get auth headers for OS API calls based on the resolved config's auth strategy.
- * Returns either a cookie header (superadmin) or Authorization: Bearer header (device flow).
+ * Returns either a cookie header (admin) or Authorization: Bearer header (device flow).
  */
 const getOsAuthHeaders = async (
   config: Config,
 ): Promise<{ cookie?: string; authorization?: string }> => {
-  if (config.auth.strategy === "superadmin") {
-    const { userCookies } = await superadminAuthDance(
-      config as Config & { auth: { strategy: "superadmin" } },
+  if (config.auth.strategy === "admin") {
+    const { userCookies } = await adminAuthDance(
+      config as Config & { auth: { strategy: "admin" } },
     );
     return { cookie: userCookies };
   }
@@ -778,10 +778,10 @@ const launcherProcedures = {
     .input(
       z
         .object({
-          superadmin: z
+          admin: z
             .boolean()
             .optional()
-            .describe("Use superadmin impersonation instead of device flow (for CI/automation)"),
+            .describe("Use admin impersonation instead of device flow (for CI/automation)"),
         })
         .partial(),
     )
@@ -793,20 +793,20 @@ const launcherProcedures = {
       if (resolved instanceof Error) throw resolved;
       const { config } = resolved;
 
-      if (input.superadmin || config.auth.strategy === "superadmin") {
-        if (config.auth.strategy !== "superadmin") {
+      if (input.admin || config.auth.strategy === "admin") {
+        if (config.auth.strategy !== "admin") {
           throw new Error(
-            "Config is not using superadmin strategy. Remove --superadmin or change config.",
+            "Config is not using admin strategy. Remove --admin or change config.",
           );
         }
         const typedConfig = config as Config & {
-          auth: { strategy: "superadmin" };
+          auth: { strategy: "admin" };
         };
-        const { userCookies, userClient } = await superadminAuthDance(typedConfig);
+        const { userCookies, userClient } = await adminAuthDance(typedConfig);
         storeSession(resolved.name, { cookie: userCookies });
         const session = await userClient.getSession();
         return {
-          message: "Logged in via superadmin impersonation",
+          message: "Logged in via admin impersonation",
           user: (session as any)?.data?.user ?? (session as any)?.user,
         };
       }
@@ -888,15 +888,15 @@ const launcherProcedures = {
             .string()
             .optional()
             .describe("Base URL for daemon API (e.g. http://localhost:3001)"),
-          strategy: z.enum(["device", "superadmin"]).default("device").describe("Auth strategy"),
+          strategy: z.enum(["device", "admin"]).default("device").describe("Auth strategy"),
           adminPasswordEnvVarName: z
             .string()
             .optional()
-            .describe("Env var name for admin password (superadmin strategy only)"),
+            .describe("Env var name for admin password (admin strategy only)"),
           userEmail: z
             .string()
             .optional()
-            .describe("User email to impersonate (superadmin strategy only)"),
+            .describe("User email to impersonate (admin strategy only)"),
           setDefault: z.boolean().optional().describe("Set as the default config"),
           setWorkspace: z.boolean().optional().describe("Map current directory to this config"),
         }),
@@ -907,9 +907,9 @@ const launcherProcedures = {
         configFile.configs ||= {};
 
         const auth: z.infer<typeof AuthStrategy> =
-          input.strategy === "superadmin"
+          input.strategy === "admin"
             ? {
-                strategy: "superadmin" as const,
+                strategy: "admin" as const,
                 adminPasswordEnvVarName: input.adminPasswordEnvVarName || "",
                 userEmail: input.userEmail || "",
               }

--- a/packages/shared/src/auth-claims.ts
+++ b/packages/shared/src/auth-claims.ts
@@ -9,9 +9,6 @@ export const ITERATE_ACCESS_TOKEN_ORGANIZATIONS_CLAIM = "organizations";
 export const ITERATE_ACCESS_TOKEN_PROJECTS_CLAIM = "projects";
 export const ITERATE_PROJECT_SELECTION_SCOPE = "project";
 export const ITERATE_PROJECT_SCOPE_PREFIX = `${ITERATE_PROJECT_SELECTION_SCOPE}:` as const;
-// Server-granted only: the auth worker strips this scope from tokens unless the
-// user's role is "admin", and OS grants it to admin-API-secret callers.
-export const ITERATE_SUPERADMIN_SCOPE = "superadmin";
 
 export const IterateAuthOrganizationClaim = z.object({
   id: z.string(),
@@ -52,11 +49,4 @@ export function listProjectScopeIds(scopes: Iterable<string>) {
   }
 
   return Array.from(projectIds);
-}
-
-export function hasSuperadminScope(scopes: Iterable<string>) {
-  for (const scope of scopes) {
-    if (scope === ITERATE_SUPERADMIN_SCOPE) return true;
-  }
-  return false;
 }


### PR DESCRIPTION
## Summary

Replaces the custom `superadmin` OAuth scope model with the Better Auth admin-plugin role as the platform-admin source of truth. Auth access tokens now carry the existing `role` / `is_admin` claims, and OS derives global itx access from those claims or from the admin API secret.

Also renames the auth admin oRPC/router/UI namespace from `superadmin` to `admin`, updates the CLI admin impersonation strategy, renames the bootstrap admin seed path/account, and refreshes docs around the access model.

## Impact

- Browser/OAuth users with Better Auth `user.role === "admin"` are clearly identifiable as admin in OS principals.
- HTTP clients using the OS admin API secret remain clearly identifiable via `Principal.type === "admin"` / `authType: "admin_api_secret"`.
- The custom `superadmin` OAuth scope is removed from shared auth claims and auth-provider advertised scopes.
- The admin allowlist env binding is now `ADMIN_ALLOWLIST`; no legacy `SUPERADMIN_*` compatibility path is retained.

## Validation

- `pnpm exec oxlint . --threads 1 --deny-warnings`
- `pnpm --dir apps/auth typecheck`
- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/auth-contract typecheck`
- `pnpm --dir packages/iterate typecheck`
- `pnpm --dir apps/os exec vitest run src/auth/principal.test.ts src/domains/inbound-mcp-server/mcp-handler.test.ts`
- `pnpm --dir apps/os test`
- `pnpm exec oxfmt --check apps/auth-contract/src/index.ts apps/auth/src apps/auth/scripts apps/auth/alchemy.run.ts apps/os/src apps/os/docs packages/iterate/src/cli.ts packages/iterate/README.md packages/shared/src/auth-claims.ts apps/auth-example/.env.example docs/plan-replace-clerk-with-auth-worker.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how platform-wide authorization is derived (tokens, MCP, itx global access) and renames admin API routes/env; misconfiguration could block operators or widen access until tokens refresh.
> 
> **Overview**
> Replaces the custom **`superadmin` OAuth scope** with **Better Auth’s platform admin role** (`user.role === "admin"`) as the source of truth for deployment-wide access. Auth no longer advertises or server-grants that scope; access tokens carry **`is_admin` / `role` claims** instead, and project scoping stays on **`project:<id>`** entries.
> 
> **Auth** renames the operator surface from `superadmin` to **`admin`**: oRPC contract paths (`/admin/oauth/*`), TanStack routes (`/admin/clients`), env (`ADMIN_ALLOWLIST`, admin seed SQL), bootstrap user (`admin@nustom.com`), and helpers (`isPlatformAdminUser`, `platformAdminOnlyMiddleware`). Deploy-time allowlist backfill now uses a **`platformAdminBackfill`** marker table (replacing `superadminBackfill` naming in seed generation).
> 
> **OS** threads admin through principals: **`UserPrincipal.isAdmin`**, **`principalIsAdmin`**, and **`accessForPrincipal`** treat admin API secret **or** admin-role users as **`"all"`** project access. Inbound MCP skips the project-scope gate when **`principal.isAdmin`** instead of checking a `superadmin` scope. Consent UI and shared **`ITERATE_SUPERADMIN_SCOPE`** / **`hasSuperadminScope`** are removed.
> 
> **CLI/docs** rename the CI impersonation strategy from **`superadmin`** to **`admin`** and update smoke/bootstrap references to the new bootstrap admin email.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2785777e110815d97f3e210c9b1bbfdf4974d647. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T14:47:57.444Z",
      "headSha": "2785777e110815d97f3e210c9b1bbfdf4974d647",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27282743138",
      "shortSha": "2785777"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-06-10T14:47:44.656Z",
      "headSha": "2785777e110815d97f3e210c9b1bbfdf4974d647",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27282743138",
      "shortSha": "2785777"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `2785777`
Preview: https://os.iterate-preview-1.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27282743138)
Updated: 2026-06-10T14:47:57.444Z

### Semaphore
Status: released
Commit: `2785777`
Preview: https://semaphore.iterate-preview-1.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27282743138)
Updated: 2026-06-10T14:47:44.656Z
<!-- /CLOUDFLARE_PREVIEW -->