### PR TITLE
test(streams): regression tests for review bugs + Stream DO test harness

### DIFF
--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -32,7 +32,9 @@
     "build": "pnpm --dir example-app build",
     "preview": "pnpm --dir example-app preview",
     "deploy": "pnpm --dir example-app run deploy",
-    "test": "vitest run",
+    "test": "vitest run && vitest run --config vitest.workers.config.ts",
+    "test:node": "vitest run",
+    "test:workers": "vitest run --config vitest.workers.config.ts",
     "test:e2e": "pnpm --dir example-app test:e2e",
     "typecheck": "tsc --noEmit"
   },
@@ -44,6 +46,7 @@
     "zod": "~4.3.6"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "catalog:cloudflare",
     "@cloudflare/workers-types": "catalog:cloudflare",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",

--- a/packages/streams/src/stream-review-regressions.test.ts
+++ b/packages/streams/src/stream-review-regressions.test.ts
@@ -1,0 +1,247 @@
+// Regression tests from the June 2026 packages/streams review.
+// See tasks/streams-review-fixes.md — each test is tagged with its finding id.
+//
+// Tests for bugs that are not yet fixed use `it.fails`: they PASS today because
+// the asserted (correct) behavior currently throws/mismatches, and they will
+// START FAILING the moment the bug is fixed — at which point flip `it.fails`
+// back to `it`. This keeps `pnpm test` green while pinning the bug precisely.
+//
+// T3/T4/T7/T8 from the plan exercise the Stream Durable Object (SQL storage) and
+// need a vitest-pool-workers harness that this package does not have yet; they
+// are tracked in Stage 0 of the task and land with that harness.
+
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { defineProcessorContract } from "./shared/stream-processors.ts";
+import type { StreamEvent } from "./shared/event.ts";
+import type { StreamEventBatch } from "./types.ts";
+import { StreamProcessor, type StreamProcessorSnapshot } from "./stream-processor.ts";
+import { createStreamProcessorHost } from "./workers/stream-processor-host.ts";
+import {
+  CircuitBreakerProcessor,
+  CircuitBreakerContract,
+} from "./processors/circuit-breaker/implementation.ts";
+import { spendCircuitBreakerToken } from "./processors/circuit-breaker/contract.ts";
+
+const iso = (ms = 0) => new Date(ms).toISOString();
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+const iterateContext = () => ({ stream: { append() {}, appendBatch() {} } });
+
+// A minimal counting processor whose batch hook can be made to throw once.
+const CounterContract = defineProcessorContract({
+  slug: "test.regression-counter",
+  version: "0.1.0",
+  description: "Counts amounts for review regression tests.",
+  stateSchema: z.object({ total: z.number().default(0) }),
+  initialState: {},
+  events: { "test/add": { payloadSchema: z.object({ amount: z.number() }) } },
+  consumes: ["test/add"],
+  emits: [],
+});
+type CounterContract = typeof CounterContract;
+type CounterDeps = { onBatch?: () => void };
+
+class CounterProcessor extends StreamProcessor<CounterContract, CounterDeps> {
+  readonly contract = CounterContract;
+  protected override reduce(args: Parameters<StreamProcessor<CounterContract>["reduce"]>[0]) {
+    return { total: args.state.total + args.event.payload.amount };
+  }
+  protected override async processEventBatch(
+    args: Parameters<StreamProcessor<CounterContract>["processEventBatch"]>[0],
+  ): Promise<void> {
+    this.deps.onBatch?.();
+    await super.processEventBatch(args);
+  }
+}
+
+function add(offset: number, amount: number): StreamEvent {
+  return { type: "test/add", payload: { amount }, offset, createdAt: iso() };
+}
+
+// An in-memory DurableObjectState stub: just the kv + waitUntil surface the host
+// touches. waitUntil work is collected so tests can await it.
+function fakeDurableObjectCtx() {
+  const map = new Map<string, unknown>();
+  const pending: Promise<unknown>[] = [];
+  const ctx = {
+    storage: {
+      kv: {
+        get: <T>(key: string): T | undefined => map.get(key) as T | undefined,
+        put: (key: string, value: unknown) => void map.set(key, value),
+      },
+    },
+    waitUntil: (work: Promise<unknown>) => void pending.push(work),
+  };
+  return { ctx: ctx as unknown as DurableObjectState, settle: () => Promise.allSettled(pending) };
+}
+
+// A fake stream stub + pump that faithfully mimics the Stream DO delivery path
+// (stream.ts #openConnection): the cursor advances to the last offset BEFORE
+// delivery, and the batch result is fire-and-forget — a failed batch is never
+// re-delivered on a live connection.
+function fakeStreamWithPump() {
+  let processEventBatch: ((batch: StreamEventBatch) => unknown) | undefined;
+  const delivered: Promise<unknown>[] = [];
+  const stream = {
+    subscribeOutbound(args: { processEventBatch: (batch: StreamEventBatch) => unknown }) {
+      processEventBatch = args.processEventBatch;
+      return { subscriptionKey: "k", streamMaxOffset: 0, unsubscribe() {} };
+    },
+    append: (input: unknown) => input,
+    appendBatch: (input: unknown) => input,
+  };
+  function pump(events: StreamEvent[]) {
+    if (processEventBatch === undefined) throw new Error("not subscribed");
+    // cursor would advance here; we just hand the batch over and never await it.
+    const result = processEventBatch({
+      namespace: "stream",
+      path: "/r",
+      events,
+      streamMaxOffset: 0,
+    });
+    if (result instanceof Promise) delivered.push(result.catch(() => undefined));
+  }
+  return { stream, pump, settle: () => Promise.allSettled(delivered) };
+}
+
+describe("T1 — a swallowed ingest failure permanently drops events (C1)", () => {
+  // FAILS until C1 is fixed (host must resubscribe from the checkpoint on
+  // ingest failure). Flip `it.fails` -> `it` once Stage 1 lands.
+  it.fails("redelivers a failed batch instead of skipping past it", async () => {
+    const { ctx, settle: settleCtx } = fakeDurableObjectCtx();
+    const { stream, pump, settle: settlePump } = fakeStreamWithPump();
+    const host = createStreamProcessorHost(ctx);
+
+    let failNextBatch = true;
+    host.add(
+      "counter",
+      (deps) =>
+        new CounterProcessor({
+          ...deps,
+          onBatch: () => {
+            if (failNextBatch) {
+              failNextBatch = false;
+              throw new Error("transient ingest failure");
+            }
+          },
+        }),
+    );
+
+    await host.requestStreamSubscription({
+      stream: stream as never,
+      subscriptionKey: "k",
+      streamMaxOffset: 0,
+      subscriptionConfiguredEvent: { offset: 0 } as never,
+      streamRuntimeState: { coreProcessorState: { namespace: "stream", path: "/r" } as never },
+    });
+
+    pump([add(1, 5)]); // fails, swallowed; cursor advances past offset 1
+    await tick();
+    pump([add(2, 7)]); // succeeds
+    await settlePump();
+    await settleCtx();
+
+    // Both events must end up in reduced state. Today event 1 is lost forever.
+    expect(host.runtimeState("counter").snapshot?.state).toEqual({ total: 12 });
+  });
+});
+
+describe("T2 — writeState failure advances the in-memory checkpoint (C2)", () => {
+  // FAILS until C2 is fixed (assign #state/#checkpointOffset only after
+  // #saveSnapshot succeeds). Flip `it.fails` -> `it` once Stage 1 lands.
+  it.fails("persists a snapshot when a writeState failure is retried", async () => {
+    const writes: StreamProcessorSnapshot<{ total: number }>[] = [];
+    let failNextWrite = true;
+    const processor = new CounterProcessor({
+      iterateContext: iterateContext(),
+      writeState: (snapshot) => {
+        if (failNextWrite) {
+          failNextWrite = false;
+          throw new Error("storage write failed");
+        }
+        writes.push(snapshot);
+      },
+    });
+
+    await expect(processor.ingest({ events: [add(1, 5)], streamMaxOffset: 1 })).rejects.toThrow(
+      "storage write failed",
+    );
+
+    // The host trusts "failed => retries"; redeliver the same batch.
+    await processor.ingest({ events: [add(1, 5)], streamMaxOffset: 1 });
+
+    // A durable snapshot must eventually exist. Today the retry no-ops because
+    // the in-memory checkpoint already advanced past offset 1.
+    expect(writes).toEqual([{ offset: 1, state: { total: 5 } }]);
+  });
+});
+
+describe("T5 — circuit-breaker token bucket on a backwards clock (M3)", () => {
+  // FAILS until M3 is fixed (clamp the refill delta with Math.max(0, ...)).
+  // Flip `it.fails` -> `it` once Stage 1 lands.
+  it.fails("does not drain the bucket when createdAt regresses", () => {
+    const next = spendCircuitBreakerToken({
+      state: {
+        availableTokens: 5,
+        lastRefillAtMs: 10_000,
+        burstCapacity: 100_000,
+        refillRatePerMinute: 6_000_000,
+      },
+      event: { createdAt: iso(9_000) }, // 1s earlier than lastRefillAtMs
+    });
+
+    // Spending one token from 5 should leave 4, not collapse to a huge negative.
+    expect(next.availableTokens).toBe(4);
+  });
+});
+
+describe("T6 — circuit-breaker misses a flood after tripping during replay (M4)", () => {
+  // FAILS until M4 is fixed (fire the trip when tripped && offset > anchor &&
+  // !pausedYet, not only on the not-tripped->tripped edge). Flip once fixed.
+  it.fails("pauses on live events even when it tripped at/below the anchor", async () => {
+    const committed: StreamEvent[] = [];
+    const processor = new CircuitBreakerProcessor({
+      iterateContext: {
+        stream: {
+          append: (args) => {
+            const e = { ...args.event, offset: 100, createdAt: iso(1) } as StreamEvent;
+            committed.push(e);
+            return e;
+          },
+          appendBatch: () => [],
+        },
+      },
+      // anchor = 4: offsets <= 4 reduce but run no side effects (replay).
+      sideEffectsAfterOffset: () => 4,
+    });
+
+    await processor.ingest({
+      events: [
+        event("events.iterate.com/circuit-breaker/configured", 1, 1_000, {
+          burstCapacity: 1,
+          refillRatePerMinute: 1,
+        }),
+        event("test.widget", 2, 2_000),
+        event("test.widget", 3, 3_000), // trips here (offset 3 <= anchor 4)
+        event("test.widget", 4, 4_000),
+        event("test.widget", 5, 5_000), // LIVE: should pause
+        event("test.widget", 6, 6_000),
+      ],
+      streamMaxOffset: 6,
+    });
+    await tick();
+
+    expect(committed.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+void CircuitBreakerContract;
+
+function event(
+  type: string,
+  offset: number,
+  createdAtMs: number,
+  payload: unknown = {},
+): StreamEvent {
+  return { type, payload, offset, createdAt: iso(createdAtMs) };
+}

--- a/packages/streams/src/workers/durable-objects/stream.workers.test.ts
+++ b/packages/streams/src/workers/durable-objects/stream.workers.test.ts
@@ -1,0 +1,177 @@
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+// Stream Durable Object tests, run inside workerd via vitest.workers.config.ts.
+// See tasks/streams-review-fixes.md (Stage 0). These exercise the real SQL
+// storage path that node tests can't reach.
+//
+// Pattern (borrowed from cloudflare/agents + the workers-sdk rpc fixture): most
+// tests use `runInDurableObject` to call the DO instance directly and read its
+// `state.storage`, instead of going over an RPC stub. That keeps thrown errors
+// as ordinary local throws (so `expect().toThrow()` works without RPC
+// unhandled-rejection noise) and lets storage be inspected directly. One test
+// still goes over the RPC stub to cover the production boundary.
+//
+// T3 (C3) and T4 (M2) assert not-yet-true behavior with `it.fails` ratchets:
+// they pass today because the correct behavior is currently violated, and flip
+// to failing the moment the bug is fixed (then change `it.fails` -> `it`).
+// T7 and T8 are coverage for behavior that is already correct, so they pass now.
+
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { StreamEvent } from "../../shared/event.ts";
+import { PublicStreamRpcTarget, type Stream } from "./stream.ts";
+
+const STREAM = (env as unknown as { STREAM: DurableObjectNamespace<Stream> }).STREAM;
+
+// Each test uses a fresh DO name. The DO constructor seeds `created` (offset 1)
+// and `woken` (offset 2) on first touch, so user appends start at offset 3.
+let counter = 0;
+function freshStream() {
+  counter += 1;
+  return STREAM.getByName(`stream:/review/t${counter}`);
+}
+
+describe("T3 — PublicStreamRpcTarget must not expose protected DO methods (C3)", () => {
+  // FAILS until C3 is fixed (makeRpcTargetClass should allowlist the StreamRpc
+  // API instead of copying every prototype method). Flip `it.fails` -> `it`.
+  it.fails("does not proxy readCoreProcessorState / writeCoreProcessorState", () => {
+    const exposed = Object.getOwnPropertyNames(PublicStreamRpcTarget.prototype);
+    expect(exposed).not.toContain("writeCoreProcessorState");
+    expect(exposed).not.toContain("readCoreProcessorState");
+  });
+});
+
+describe("T4 — events carrying a `source` field must commit (M2)", () => {
+  // FAILS until M2 is fixed (getEventSchema is strict and omits `source`, so the
+  // inline core reduce throws "Unrecognized key: source"). Flip once fixed.
+  it.fails("appends and reads back an event with a source", async () => {
+    await runInDurableObject(freshStream(), async (stream) => {
+      const committed = await stream.append({
+        event: {
+          type: "events.iterate.com/review/with-source",
+          payload: { ok: true },
+          source: { processor: { slug: "reviewer", version: "0.1.0" } },
+        },
+      });
+      const read = await stream.getEvent({ offset: committed.offset });
+      expect(read?.source).toEqual({ processor: { slug: "reviewer", version: "0.1.0" } });
+    });
+  });
+});
+
+describe("T7 — idempotency keys (coverage)", () => {
+  it("dedups a repeated idempotencyKey and returns the existing event", async () => {
+    await runInDurableObject(freshStream(), async (stream) => {
+      const first = await stream.append({
+        event: { type: "test.idem", payload: { n: 1 }, idempotencyKey: "dup-key" },
+      });
+      const second = await stream.append({
+        event: { type: "test.idem", payload: { n: 2 }, idempotencyKey: "dup-key" },
+      });
+
+      expect(second.offset).toBe(first.offset);
+      expect(second.payload).toEqual({ n: 1 }); // the original wins; the new payload is ignored
+    });
+  });
+
+  it("rejects an offset precondition that disagrees with the idempotency hit", async () => {
+    await runInDurableObject(freshStream(), async (stream) => {
+      const first = await stream.append({
+        event: { type: "test.idem", payload: {}, idempotencyKey: "precondition" },
+      });
+
+      // A plain local throw via runInDurableObject — no RPC boundary, so
+      // expect().toThrow() works directly.
+      expect(() =>
+        stream.append({
+          event: {
+            type: "test.idem",
+            payload: {},
+            idempotencyKey: "precondition",
+            offset: first.offset + 10,
+          },
+        }),
+      ).toThrow(/idempotency hit/);
+    });
+  });
+});
+
+describe("T8 — Stream DO smoke (coverage)", () => {
+  it("assigns consecutive offsets over the RPC stub and round-trips via getEvent", async () => {
+    // This one goes over the real DurableObjectStub RPC boundary on purpose.
+    // The stub promisifies the method's `MaybePromise` return into an awkward
+    // type, hence the casts (the in-instance calls below need none).
+    const stream = freshStream();
+    const first = (await stream.append({
+      event: { type: "test.smoke", payload: { i: 1 } },
+    })) as StreamEvent;
+    const second = (await stream.append({
+      event: { type: "test.smoke", payload: { i: 2 } },
+    })) as StreamEvent;
+
+    expect(second.offset).toBe(first.offset + 1);
+    const read = (await stream.getEvent({ offset: second.offset })) as StreamEvent | undefined;
+    expect(read?.payload).toEqual({ i: 2 });
+  });
+
+  it("honors getEvents afterOffset + limit", async () => {
+    await runInDurableObject(freshStream(), async (stream) => {
+      const appended: StreamEvent[] = [];
+      for (let i = 0; i < 5; i += 1) {
+        appended.push(await stream.append({ event: { type: "test.range", payload: { i } } }));
+      }
+      const startOffset = appended[0]!.offset;
+      const page = await stream.getEvents({ afterOffset: startOffset, limit: 2 });
+
+      expect(page.map((e) => e.offset)).toEqual([startOffset + 1, startOffset + 2]);
+    });
+  });
+
+  it("round-trips a >512KB event and splits it across multiple chunk rows", async () => {
+    await runInDurableObject(freshStream(), async (stream, state) => {
+      const big = "x".repeat(700 * 1024); // > EVENT_CHUNK_SIZE (512KB) → multiple chunks
+      const committed = await stream.append({ event: { type: "test.big", payload: { big } } });
+
+      const read = await stream.getEvent({ offset: committed.offset });
+      expect(read).toBeDefined();
+      expect((read!.payload as { big: string }).big).toBe(big);
+
+      // Direct storage inspection (the cloudflare/agents pattern): the event JSON
+      // really is chunked, not stored in one oversized cell.
+      const chunkCount =
+        state.storage.sql
+          .exec<{ n: number }>(
+            "select count(*) as n from event_chunks where offset = ?",
+            committed.offset,
+          )
+          .toArray()[0]?.n ?? 0;
+      expect(chunkCount).toBeGreaterThan(1);
+    });
+  });
+
+  it("delivers replay from replayAfterOffset to a subscriber", async () => {
+    await runInDurableObject(freshStream(), async (stream) => {
+      const target = await stream.append({ event: { type: "test.replay", payload: {} } });
+
+      const seen: number[] = [];
+      const subscription = await stream.subscribe({
+        replayAfterOffset: 0,
+        processEventBatch: (batch) => {
+          for (const event of batch.events) seen.push(event.offset);
+        },
+      });
+
+      try {
+        // Same isolate + synchronous storage reads, so the pump drains in a few
+        // microtasks — no cross-isolate RPC and no long polling.
+        for (let i = 0; i < 20 && !seen.includes(target.offset); i += 1) {
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+        // Replay from 0 includes the seeded created/woken events plus our append.
+        expect(seen).toContain(target.offset);
+        expect(Math.min(...seen)).toBe(1);
+      } finally {
+        subscription.unsubscribe();
+      }
+    });
+  });
+});

--- a/packages/streams/src/workers/test-entry.ts
+++ b/packages/streams/src/workers/test-entry.ts
@@ -1,0 +1,13 @@
+// Worker entry used only by the vitest-pool-workers harness
+// (vitest.workers.config.ts). It exports the Stream + StreamProcessorRunner
+// Durable Objects so miniflare can bind them, and a default fetch so the worker
+// is valid. Tests reach the DOs through `env.STREAM` from `cloudflare:test`.
+
+export { Stream } from "./durable-objects/stream.ts";
+export { StreamProcessorRunner } from "./durable-objects/stream-processor-runner.ts";
+
+export default {
+  fetch(): Response {
+    return new Response("stream test worker", { status: 200 });
+  },
+};

--- a/packages/streams/vitest.config.ts
+++ b/packages/streams/vitest.config.ts
@@ -3,7 +3,14 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    exclude: ["e2e/**", "example-app/e2e/**", "scripts/**/*.test.ts", "**/node_modules/**"],
+    exclude: [
+      "e2e/**",
+      "example-app/e2e/**",
+      "scripts/**/*.test.ts",
+      "**/node_modules/**",
+      // Stream DO tests run in workerd via vitest.workers.config.ts.
+      "**/*.workers.test.ts",
+    ],
     testTimeout: 30_000,
   },
 });

--- a/packages/streams/vitest.workers.config.ts
+++ b/packages/streams/vitest.workers.config.ts
@@ -1,0 +1,25 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defaultExclude, defineConfig } from "vitest/config";
+
+// Runs the Stream Durable Object tests inside workerd via vitest-pool-workers.
+// Node-runtime tests stay in vitest.config.ts; these are split out by the
+// `*.workers.test.ts` suffix because they import `cloudflare:workers` /
+// `cloudflare:test` and cannot run in the node pool.
+const root = fileURLToPath(new URL(".", import.meta.url));
+
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      main: resolve(root, "src/workers/test-entry.ts"),
+      wrangler: { configPath: resolve(root, "vitest.workers.jsonc") },
+    }),
+  ],
+  test: {
+    include: ["src/**/*.workers.test.ts"],
+    exclude: [...defaultExclude],
+    hookTimeout: 60_000,
+    testTimeout: 30_000,
+  },
+});

--- a/packages/streams/vitest.workers.jsonc
+++ b/packages/streams/vitest.workers.jsonc
@@ -1,0 +1,17 @@
+{
+  // Wrangler config for the vitest-pool-workers harness (vitest.workers.config.ts).
+  // Mirrors example-app/wrangler.jsonc: the Stream DO needs the STREAM binding
+  // (it resolves sibling streams via env.STREAM.getByName), and the runner needs
+  // its own namespace for outbound subscription handshakes.
+  "name": "streams-vitest",
+  "main": "src/workers/test-entry.ts",
+  "compatibility_date": "2026-04-28",
+  "compatibility_flags": ["nodejs_compat"],
+  "durable_objects": {
+    "bindings": [
+      { "name": "STREAM", "class_name": "Stream" },
+      { "name": "STREAM_PROCESSOR_RUNNER", "class_name": "StreamProcessorRunner" },
+    ],
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["Stream", "StreamProcessorRunner"] }],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,6 +1014,9 @@ importers:
         specifier: ~4.3.6
         version: 4.3.6
     devDependencies:
+      '@cloudflare/vitest-pool-workers':
+        specifier: catalog:cloudflare
+        version: 0.14.9(@cloudflare/workers-types@4.20260426.1)(@vitest/runner@4.1.8)(@vitest/snapshot@4.1.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.12.4)(jsdom@27.4.0(@noble/hashes@2.0.1))(msw@2.13.3(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)))
       '@cloudflare/workers-types':
         specifier: catalog:cloudflare
         version: 4.20260426.1
@@ -14901,6 +14904,21 @@ snapshots:
       esbuild: 0.27.3
       miniflare: 4.20260421.0
       vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(jsdom@27.4.0(@noble/hashes@2.0.1))(msw@2.13.3(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      wrangler: 4.85.0(@cloudflare/workers-types@4.20260426.1)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - bufferutil
+      - utf-8-validate
+
+  '@cloudflare/vitest-pool-workers@0.14.9(@cloudflare/workers-types@4.20260426.1)(@vitest/runner@4.1.8)(@vitest/snapshot@4.1.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.12.4)(jsdom@27.4.0(@noble/hashes@2.0.1))(msw@2.13.3(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)))':
+    dependencies:
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      cjs-module-lexer: 1.4.3
+      esbuild: 0.27.3
+      miniflare: 4.20260421.0
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.12.4)(jsdom@27.4.0(@noble/hashes@2.0.1))(msw@2.13.3(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       wrangler: 4.85.0(@cloudflare/workers-types@4.20260426.1)
       zod: 3.25.76
     transitivePeerDependencies:

--- a/tasks/streams-review-fixes.md
+++ b/tasks/streams-review-fixes.md
@@ -1,0 +1,533 @@
+---
+state: todo
+priority: high
+size: large
+dependsOn: []
+---
+
+# packages/streams review: fixes & cleanup
+
+In-depth adversarial review of `packages/streams` (June 2026). Findings were
+produced by four parallel reviewers (browser runtime, workers/RPC, processors,
+docs) and the load-bearing ones independently re-verified against source. Three
+of the four reviewers converged on the same top bug (the failed-batch desync),
+which is why it leads.
+
+This task is organized into **stages** ordered so that safety nets land before
+behavioural changes, and structural changes land before cleanup. Each finding
+has a stable id (`Cn` / `Mn` / `Pn` / `En` / `Dn`) so PRs can reference them.
+
+Severity legend: **CRITICAL** = data loss / security; **MAJOR** = wrong
+behaviour under realistic conditions; **MINOR** = edge-case or quality;
+**NIT** = cosmetic.
+
+Owner intent driving this work (from the review request):
+
+- The whole package should be **as short and concise as possible**.
+- Storage and the initial `created` event should **not** be initialized until
+  the first `append` (lazy init). See Stage 2.
+- `stream.ts` specifically should get **cleaner and shorter**.
+
+---
+
+## Stage 0 — Regression tests first (safety net)
+
+The ~1000-line Stream DO has **zero always-on tests**: append, idempotency
+keys, the pause gate, >512 KB chunking, and subscription replay/cursor live only
+in `example-app/e2e/*`, which is `it.skip` unless `STREAM_STAGING_E2E=true`
+(`example-app/e2e/vitest/stream-capnweb.test.ts:9`). Land tests that pin current
+intended behaviour and fail on the bugs below, so the Stage 1–2 changes have a
+net.
+
+Write these first (all unit-testable with stubs, no deployed worker needed).
+
+**Status (2026-06-10): Stage 0 COMPLETE.** All 8 tests landed and proven red
+against current code (the four bug-pins are `it.fails` ratchets — flip to `it`
+when the matching fix lands; T7/T8 are coverage and pass now). `pnpm test` stays
+green: 58 passed + 4 expected-fail (node) and 6 passed + 2 expected-fail
+(workers).
+
+Files added:
+
+- `src/stream-review-regressions.test.ts` — node tests T1, T2, T5, T6. Proven red:
+  T1 `{total:7}` vs `12`; T2 nothing persisted on retry; T5 `-99996` tokens; T6
+  `0` pauses.
+- **vitest-pool-workers harness** (the structural gap): `vitest.workers.config.ts`
+  - `vitest.workers.jsonc` (wrangler, compat date `2026-04-28` — the bundled
+    workerd's newest supported date) + `src/workers/test-entry.ts` (exports the
+    Stream + StreamProcessorRunner DOs). Node config now excludes
+    `**/*.workers.test.ts`; `package.json` `test` runs both pools (`test:node`,
+    `test:workers` split out). `@cloudflare/vitest-pool-workers` added as a devDep.
+- `src/workers/durable-objects/stream.workers.test.ts` — DO tests T3, T4, T7, T8.
+  Proven red: T3 `PublicStreamRpcTarget.prototype` includes
+  `writeCoreProcessorState`; T4 append with `source` throws `Unrecognized key:
+"source"`.
+
+Harness notes for whoever picks up Stage 1+ (informed by how cloudflare/agents +
+the workers-sdk rpc fixture test DOs):
+
+- **Prefer `runInDurableObject(stub, (instance, state) => …)`** over RPC-stub
+  calls. It calls the DO instance directly (no RPC boundary), so thrown errors
+  are ordinary local throws — `expect(() => instance.append(...)).toThrow()`
+  works with no unhandled-rejection noise — and `state.storage.sql` can be
+  inspected directly (the >512KB test asserts the event really spans multiple
+  `event_chunks` rows this way). Subscribing with a _local_ callback under
+  `runInDurableObject` also makes replay deterministic (the pump drains in a few
+  microtasks; no cross-isolate RPC, no long polling). One test deliberately
+  stays on the stub to cover the production RPC boundary — note the stub
+  promisifies the method's `MaybePromise` return into an awkward type, so those
+  calls need `as StreamEvent` casts that the in-instance calls do not.
+- For alarm-driven code, use `runDurableObjectAlarm(stub)` to fire alarms
+  deterministically instead of advancing time. (The Stream DO's delivery pump is
+  microtask-driven, not alarm-driven, so no alarm tests yet — relevant if the
+  reconnect/backoff work in Stage 3/4 adds alarms.)
+- The DO seeds `created` (offset 1) + `woken` (offset 2) on first touch, so user
+  appends start at offset 3 (tests assert relative offsets). `cloudflare:test`
+  types come from `/// <reference types="@cloudflare/vitest-pool-workers/types" />`.
+
+- [x] **T1 — failed-batch redelivery / desync** (pins C1). Drives the real
+      `createStreamProcessorHost` with a fake pump that mimics `stream.ts`
+      (advance cursor before delivery, fire-and-forget the result); a batch fails
+      once, the next succeeds, and the first batch's events must survive in
+      reduced state. _Done — red._
+- [x] **T2 — `writeState` failure persistence** (pins C2). `writeState` throws
+      once; re-ingest the same batch; assert a snapshot is eventually persisted.
+      _Done — red._ (`stream-processor-class.test.ts:380` covers the
+      `readState`-failure half only.)
+- [x] **T3 — `PublicStreamRpcTarget` surface** (pins C3). Asserts the generated
+      target prototype does not expose `writeCoreProcessorState` /
+      `readCoreProcessorState`. Today it does. _Done — red._
+- [x] **T4 — append with `source` field** (pins M2). Appends an event with a
+      valid `source` and reads it back. Today it throws `Unrecognized key:
+    "source"`. _Done — red._
+- [x] **T5 — circuit-breaker clock regression** (pins M3). Spend a token with
+      `createdAt` 1 s earlier than `lastRefillAtMs`; assert tokens decrement by
+      ~1, not by 100k. _Done — red._
+- [x] **T6 — circuit-breaker post-anchor flood** (pins M4). Trips at/below the
+      anchor during replay, then feeds live events past the anchor; assert ≥1
+      `paused` append. Today: 0. _Done — red._
+- [x] **T7 — idempotency keys** (was untested anywhere). DO-level test: a
+      repeated `idempotencyKey` is a no-op that returns the existing event, and
+      an `offset` precondition that disagrees with the hit throws. _Done —
+      passes (behavior is already correct; this is the coverage that was
+      missing)._
+- [x] **T8 — DO smoke suite, always-on.** Covers append + consecutive offset
+      assignment, `getEvents` afterOffset/limit paging, a >512 KB chunked event
+      round-trip, and subscribe replay from `replayAfterOffset: 0`. _Done —
+      passes._ (`subscribeOutbound` handshake deferred — it needs the runner DO
+      wired in; left for the M1/M3 outbound-reconnect work which exercises that
+      path anyway.)
+
+---
+
+## Stage 1 — Critical correctness & security
+
+### C1 — A single failed batch permanently desyncs a subscriber (CRITICAL)
+
+_Found independently by the browser, workers, and processor reviewers._
+
+The delivery pump advances its cursor **before** delivering, then
+fire-and-forgets:
+
+- `stream.ts:646` — `cursor = lastOffset` (before delivery).
+- `stream.ts:660-666` — `disposeIgnoredRpcResult(pendingBatch)`, never awaited.
+
+Every consumer swallows its own failure with no redelivery:
+
+- Hosted processors: `stream-processor-host.ts:201-203` —
+  `ingest(batch).catch(err => console.error(...))`. Checkpoint isn't written,
+  but the _next_ successful batch advances `checkpointOffset` past the hole
+  (`stream-processor.ts:338-341`), so the gap is unrecoverable even across DO
+  restart (replay starts from the advanced checkpoint).
+- Browser mirror: `stream-browser-store.ts:380-391` — same shape, but the
+  SQLite continuity trigger (`RAISE(ABORT, 'offsets must append
+continuously')`, see ADR 0002 / `browser-raw-events/implementation.ts:106-125`)
+  then makes **every subsequent batch fail too**. The mirror freezes,
+  `connectionStatus` stays `"subscribed"`, and nothing resubscribes until the
+  user reloads.
+
+The comment at `stream-processor.ts:369` ("The checkpoint is not written; the
+batch retries") is the false claim: the base class is retry-_safe_ but nothing
+retries. The test at `stream-processor-class.test.ts:235` only passes because
+the test redelivers by hand.
+
+- [ ] **Fix:** on delivery/ingest failure, `unsubscribe()` and resubscribe from
+      the durable checkpoint (`snapshot().offset`). Replay is already idempotent
+      (offset filter + trigger `RAISE(IGNORE)`). Apply on both the hosted-host
+      path and the browser store path. Consider centralizing the "redeliver from
+      checkpoint on failure" policy rather than duplicating it per consumer.
+- [ ] Update the `stream-processor.ts:369` comment to describe the real policy.
+
+### C2 — `writeState` failure advances in-memory checkpoint, persists nothing (CRITICAL)
+
+`stream-processor.ts:374-376`:
+
+```ts
+this.#state = state;
+this.#checkpointOffset = checkpointOffset;
+await this.#saveSnapshot(); // throws AFTER the two lines above
+```
+
+A `writeState` throw rejects `ingest` _after_ the in-memory checkpoint advanced.
+The redelivered batch then filters out entirely at `stream-processor.ts:339` and
+returns at line 349 (`if (events.length === 0) return;`) without reaching
+`#saveSnapshot` again — a host trusting "failed ⇒ retries" gets a silent success
+that persisted nothing. (Verified with a runtime repro.)
+
+- [ ] **Fix:** assign `#state` / `#checkpointOffset` only **after**
+      `#saveSnapshot()` succeeds.
+
+### C3 — `PublicStreamRpcTarget` leaks `protected` methods → state injection → arbitrary callable dispatch (CRITICAL, security)
+
+`makeRpcTargetClass` (`shared/rpc-target.ts:49-66`) copies **every** own
+prototype method except those in `exclude`. The exclude lists at
+`stream.ts:789` / `stream.ts:794` only remove `subscribe` / `subscribeOutbound`.
+TypeScript `protected` is compile-time only, so these `Stream` methods are
+proxied and callable:
+
+- `readCoreProcessorState` (`stream.ts:119`), **`writeCoreProcessorState`**
+  (`stream.ts:135`), `reduce`, `reset`, `kill`.
+
+`PublicStreamRpcTarget` is served unauthenticated in the example app
+(`example-app/src/worker.ts`) and to any project member in prod OS
+(`apps/os/src/domains/streams/project-stream-rpc.ts`). `writeCoreProcessorState`
+accepts schema-valid state: an attacker can inject a `subscriptionsByKey` entry
+whose `latestConfiguredEvent.payload.subscriber.callable` is attacker-chosen, and
+on the next `#reconcile` → `#connectOutboundConnection` (`stream.ts:769`) the DO
+`dispatchCallable`s it with the worker's full `env` as context — turning a
+client-reachable RPC into arbitrary same-account binding/DO dispatch. Rolling
+back `maxOffset` also bricks future appends (PK conflicts).
+
+- [ ] **Fix:** make `makeRpcTargetClass` an **allowlist** (explicit set of API
+      methods) instead of a denylist, or pass an `exclude` covering every
+      non-API prototype method. Allowlist is the only safe default for a class
+      with this many internal methods. Re-derive the allowlist from the
+      `StreamRpc` type so it can't drift.
+- [ ] This likely lets `installSubscribeRpcTargetOverride` fold into the
+      allowlisted generator (see E-stream conciseness).
+
+---
+
+## Stage 2 — Lazy initialization (owner-requested) + the `woken` event
+
+Currently the constructor (`stream.ts:49-82`), on **every** incarnation:
+
+1. `#ensureStorageSchema()` — two `CREATE TABLE` execs.
+2. reads/recovers core state.
+3. appends `created` on first boot **and `woken` on every wake** (`stream.ts:72-77`).
+4. `#reconcile()`.
+
+So merely _reading_ a stream (a `getEvents`, an RPC probe, a reconcile dial)
+instantiates the DO and writes a `woken` event. Consequences:
+
+- The log grows one `woken` per restart forever — unbounded; each triggers a
+  full reduce + KV write + connection fan-out.
+- A pure reader can never be side-effect-free; any touch mutates durable state.
+
+- [ ] **Defer schema + `created` to the first `append`.** Move
+      `#ensureStorageSchema()` and the `created` append into the append path
+      (`#appendBatchHere`), guarded so it runs once.
+- [ ] **Reconsider `woken` entirely.** Almost nothing consumes it (only the
+      circuit-breaker's pass-through list and the paused-gate exception). Prefer
+      making incarnation id a piece of runtime/core state rather than a logged
+      event, or drop it. If kept, it must not be what initializes a stream.
+- [ ] **Couplings to handle when init goes lazy:**
+  - `getEvents` / `runtimeState` / `getEvent` on a never-appended stream must
+    return empty / initial state rather than throw.
+  - `#reconcile()` on boot (`stream.ts:81`) currently assumes state was read in
+    the constructor; rework so boot reconcile works from recovered-or-empty
+    state.
+  - The `created`-must-be-offset-1 special case
+    (`processors/core/implementation.ts:108-113`) gets simpler once `created` is
+    the deterministic first append.
+- [ ] This is also the single biggest length win in `stream.ts`: it collapses
+      the constructor and the offset-1 branch.
+
+---
+
+## Stage 3 — Major correctness bugs
+
+### M1 — `onRpcBroken` is (almost certainly) never wired → broken connections never detected (MAJOR)
+
+_Confirm with a quick test before acting — rests on capnweb/Workers-RPC stub internals._
+
+`rpc-lifecycle.ts:31` guards with `Object.hasOwn(retained, "onRpcBroken")`.
+capnweb proxy stubs expose no own descriptors (so `Object.hasOwn` is always
+false even though `typeof stub.onRpcBroken === "function"`), and native Workers
+RPC stubs have no `onRpcBroken` at all. If confirmed:
+
+- Outbound (hosted processors): when a runner DO is evicted/redeployed/aborted,
+  the broken connection stays in `#connections`; the pump keeps advancing
+  `cursor` into a dead stub with rejections discarded; `#reconcile` skips keys
+  already in `#connections` (`stream.ts:742`) so it never re-dials. Delivery
+  stalls silently until the Stream DO incarnation itself restarts. The docstring
+  "Triggered … on outbound connection loss" (`stream.ts:720`) is then false.
+- Inbound (capnweb clients): a client that drops without `unsubscribe` leaks the
+  DO connection for the incarnation lifetime and shows phantom connections in
+  `runtimeState()`.
+
+- [ ] **Verify:** test whether `onRpcBroken` fires for (a) a capnweb stub and
+      (b) a native RPC stub. Drop the `Object.hasOwn` guard and use
+      `typeof retained.onRpcBroken === "function"`.
+- [ ] **For the native outbound path** (no `onRpcBroken`): add liveness — observe
+      the delivery result and `connection.close()` + `#reconcile()` on rejection.
+      Note this overlaps with the C1 fix; design them together.
+
+### M2 — Any event with a `source` field crashes the whole `appendBatch` (MAJOR)
+
+_Verified with a runtime repro: ZodError `Unrecognized key: "source"`._
+
+`StreamEventInput` advertises `source?: StreamEventSource` (`event.ts:18-26,
+43-62`) and the DO accepts it (`stream.ts:375`, `.strict()` includes it). But
+`getEventSchema` (`stream-processors.ts:582-589`) is a `strictObject` **without**
+`source`, so the committed event hits the inline core reduce
+(`consumes: ["*"]`) → `reduceRawEvent` → strict parse → throws, rejecting the
+whole batch. Latent only because nothing currently sets `source`
+(`apps/os/tasks/migration-notes/project-repo.md:26` records this as a known
+trap). Same family: `idempotencyKey` is `z.string()` at input (`event.ts:59`)
+but `.trim().min(1)` in `getEventSchema` — a whitespace key passes input
+validation then explodes in reduce.
+
+- [ ] **Fix (decide):** either add `source` to `getEventSchema` /
+      `getEventInputSchema`, **or** delete `StreamEventSource` + `source`
+      entirely (zero callers — favours conciseness). Pick one and make input
+      and reduce schemas agree.
+- [ ] Align `idempotencyKey` validation between input and event schemas.
+
+### M3 — Circuit-breaker token bucket subtracts on a backwards clock (MAJOR)
+
+_Verified: `availableTokens === -99901` after a 1 s regression._
+
+`circuit-breaker/contract.ts:78-82` computes refill as
+`(createdAtMs - lastRefillAtMs) * (refillRatePerMinute / 60_000)`; a negative
+delta drains tokens. `createdAt` is per-event wall clock
+(`stream.ts: new Date().toISOString()`); DO migration / clock skew can regress
+it. At the default refill, −1 s = −100,000 tokens → instant false trip → stream
+paused for no reason.
+
+- [ ] **Fix:** clamp with `Math.max(0, createdAtMs - lastRefillAtMs)`.
+
+### M4 — Circuit-breaker edge-trigger misses sustained floods after replay (MAJOR)
+
+_Verified: 0 paused appends for live post-anchor events._
+
+`circuit-breaker/implementation.ts:54-56` is edge-triggered:
+`if (shouldTripCircuitBreaker(args.previousState)) return;`. If the
+not-tripped→tripped transition lands at an offset `<= sideEffectsAfterOffset`
+(skipped on replay by `stream-processor.ts:282`), every later live event sees
+`previousState` already tripped and returns — so during sustained overload the
+breaker is silently disabled. Also no retry if the background `stream/paused`
+append fails (`stream-processor.ts:324-327` only logs).
+
+- [ ] **Fix:** fire the trip side effect when
+      `tripped(state) && event.offset > anchor && !pausedYet`, not only on the
+      transition edge.
+
+### M5 — `eventTypes` is silently dropped by the subscribe override (MAJOR / decision)
+
+`installSubscribeRpcTargetOverride` (`stream.ts:822-826`) forwards only
+`subscriptionKey` / `replayAfterOffset` / `processEventBatch`. Yet
+`StreamRpc.subscribe` advertises `eventTypes` with the doc "Only deliver these
+event types" (`types.ts:49-55`), while `types.ts:46-48` _simultaneously_ says
+filtering "is planned, but not part of this shape". Every remote inbound
+subscriber therefore receives the full firehose and filters client-side, after
+the data crosses the socket. The only remote caller that passes `eventTypes`
+(`example-app/e2e/.../stream-processor-node.test.ts:41`) is masked because the
+echo processor re-filters in `ingest`. The hosted **outbound** path uses
+`subscribeOutbound` directly, so its filter _does_ work.
+
+- [ ] **Decide and do one:** (a) thread `eventTypes` through the override (one
+      line at `stream.ts:825`) — also fixes the firehose bandwidth waste (P3); or
+      (b) delete `eventTypes` from the public `subscribe` signature. Either way,
+      reconcile the contradictory `types.ts:46-48` comment.
+
+---
+
+## Stage 4 — Browser-runtime correctness (lower blast radius than C1, but real)
+
+### B1 — Stale `close` event tears down the replacement connection (MAJOR)
+
+`stream-browser-store.ts:314-321`: each `connect()` installs a status callback
+that mutates the **shared** `stream` / `subscriptionHandle` / `writerRole`
+without checking the event belongs to the current connection (contrast the
+election path, which guards with `stream !== election.connection` at lines
+369/386). A late `close` from a disposed connection A can land after connection
+B is live — most reachable via `clearLocalDatabase()` (line 487): dispose A →
+`discardLocalMirror()` → `reconnectNow()` assigns B → A's close arrives → B's
+writer lock released, subscription unsubscribed, `stream = undefined`, B's socket
+leaked. Plus a spurious reconnect 1 s later.
+
+- [ ] **Fix:** capture the connection in the callback closure (or a per-connection
+      `disposed` flag) and early-return for non-current connections.
+
+### B2 — `appendBatch` / `runtimeState` / `kill` / `reset` throw during reconnect (MAJOR)
+
+`stream-browser-store.ts:477-486`: `reconnectNow()` only assigns `stream` in a
+later microtask, so synchronously after a drop (and through the whole 1 s
+backoff window) `stream === undefined` and every call throws
+`"stream connection is disposed"` — wrong message, healthy runtime.
+
+- [ ] **Fix:** await the in-flight connection (return a promise that resolves
+      once `stream` is set), or at minimum throw a "reconnecting, retry" error.
+
+### B3 — Worker `ROLLBACK` masks the original error, defeating `withBusyRetry` (MAJOR)
+
+`stream-db.worker.ts:125-140`: on a statement/commit failure the catch block does
+`await sqlite3.exec(db, "ROLLBACK;")`; if that rollback itself rejects (e.g.
+"cannot rollback - no transaction is active"), the rollback error **replaces**
+the original, so `isBusyError` never sees `SQLITE_BUSY` and `withBusyRetry`
+gives up. Combined with C1 this wedges the mirror on one transient busy error.
+
+- [ ] **Fix:** wrap the rollback in its own try/catch; always rethrow the
+      original error.
+
+### B4 — Server reset-then-regrow silently splices two stream incarnations (MAJOR)
+
+`stream-browser-store.ts:290-306`: reconcile only checks
+`coreProcessorState.maxOffset >= localMaxOffset` and keeps the local suffix. If
+the stream was `reset()` out-of-band and regrown past the old max while this tab
+was offline, the check passes and `subscribe({replayAfterOffset: oldCheckpoint})`
+splices new-incarnation events onto stale rows. Offsets stay continuous so the
+trigger never fires — permanent, undetectable desync.
+
+- [ ] **Fix:** add an incarnation/epoch marker, or verify the event at
+      `localMaxOffset` matches the server's before trusting the suffix.
+
+### B5 — Web Locks request can't be cancelled; rejection swallowed (MINOR)
+
+`stream-leader.ts:24-39`: `release()` resolves `held` but the queued
+`navigator.locks.request` (no `AbortSignal`) stays queued and later transiently
+grabs/releases the lock; `void navigator.locks.request(...)` also swallows
+rejections, so `whenWriter` never resolves and the tab becomes a silent
+permanent follower.
+
+- [ ] **Fix:** pass an `AbortSignal` aborted by `release()`.
+
+### B6 — Query registry leaks orphans and re-runs every query on every change (MINOR, perf)
+
+`stream-browser-db.ts:216-261, 312-316`: `query()` inserts into `#queries`
+immediately but the GC timer is only armed in `unsubscribe`, so a query created
+but never subscribed (e.g. a discarded React render — `useStreamQuery`'s
+`useMemo` calls `db.query` during render) stays forever, and `#onChange` runs
+`#runQuery` for **every** entry on every change (a worker round-trip per orphan).
+A GC'd-then-resubscribed handle goes permanently stale (m2 in the review).
+
+- [ ] **Fix:** arm GC on create-without-subscribe; re-validate the entry on
+      resubscribe; add a result-equality check before swapping the snapshot
+      (avoids re-render storms at ~60/s during replay).
+
+---
+
+## Stage 5 — Performance
+
+- [ ] **P1 — `browser-event-feed` O(n²) write amplification.**
+      `grouping.ts:112-128` pushes a _cumulative_ `update` op per event extending
+      an open group (copying the whole accumulated array), and
+      `implementation.ts:50` executes all of them, each `JSON.stringify`ing the
+      full list. A 1,000-event same-type batch serializes ~500k events.
+      **Fix:** coalesce to the last op per `localIndex` before SQL.
+- [ ] **P2 — `browser-event-feed` unbounded group rows.** Groups only close on
+      event-type change (`grouping.ts:112-119`), so one dominant event type grows
+      a single `feed_items.data` blob forever. **Fix:** add a max-group-size
+      boundary.
+- [ ] **P3 — Core `reduce` exit-parses the whole `stateSchema` per event.**
+      `core/implementation.ts:226` re-runs the `SubscriptionsByKey` transform
+      (`contract.ts:63-84`, a `safeParse` per subscription) in the synchronous
+      append hot path — O(subscriptions) zod work per appended event. **Fix:**
+      validate only the changed slice, or skip the transform on the hot path.
+- [ ] **P4 — Inbound firehose** — see M5; threading `eventTypes` server-side
+      removes the bandwidth waste.
+
+---
+
+## Stage 6 — Elegance / conciseness (owner wants the package as short as possible)
+
+- [ ] **E1 — Delete ~130 lines of verified-dead exports** in
+      `shared/stream-processors.ts` (zero usages repo-wide): `createEvent`
+      (506-526; its comment falsely claims test usage), `getEventInputSchema`
+      (536-556), `validateProcessorContract` (700-746) + now-orphaned privates
+      `addResolvedEvent` / `assertResolvedEventTypes` /
+      `isProcessorContractDependency` (889-930), `getProcessorStateSchema`
+      (748-753), `ProcessorStreamApiProps` (466-474). Run `pnpm knip` to confirm.
+- [ ] **E2 — Delete `waitForOpen`** (`connection.ts:51`) — zero callers; the node
+      connect comment explains why awaiting open is unnecessary.
+- [ ] **E3 — Delete unreachable branch** `circuit-breaker/implementation.ts:56`
+      (`if (event.type === ".../stream/paused") return;`) — the line-54 guard
+      already returned because reducing `paused` resets `availableTokens` > 0.
+- [ ] **E4 — Collapse schema duplication:**
+  - `core/contract.ts` declares the `processor-registered` payload twice
+    (110-123 vs 190-204) — extract one const.
+  - `SupportedSubscriptionConfiguredEvent` / `HistoricalSubscriptionConfiguredEvent`
+    (43-61) differ only in subscriber schema.
+  - `packages/shared/src/streams/circuit-breaker-types.ts` re-declares the
+    breaker payloads verbatim from the contract (cross-package drift hazard).
+- [ ] **E5 — `messageInbox.error()`** (`subscription.ts:114-117`) is never called;
+      disposal looks like normal completion to consumers. Either wire it on
+      abnormal teardown or delete it (and the `waiters` machinery if `waitForEvent`
+      stays unused — confirm with owner whether it's a public surface).
+- [ ] **E6 — Trim circuit-breaker `consumes`** (`contract.ts:49-62`): names all
+      10 core events plus `"*"`; reduce only branches on
+      configured/paused/resumed/woken. The 7 extra named entries buy nothing.
+- [ ] **E7 — `stream.ts` conciseness** (the owner's specific target). Biggest wins:
+      Stage 2 lazy-init (collapses constructor + offset-1 branch); the C3
+      allowlist letting `installSubscribeRpcTargetOverride` fold into
+      `makeRpcTargetClass`; and the M5 `eventTypes` decision. The chunking
+      helpers (`chunkBytes` / `decodeChunks`) are the other dense spot but are
+      load-bearing — leave them.
+- [ ] **E8 — Note:** `echo` + `stream-processor-runner.ts` are e2e fixtures
+      shipped in `src/`. `circuit-breaker` is real (configured by
+      `apps/os/.../new-stream-runtime.ts` and hosted in the runner) — keep it.
+      Decide whether echo/runner belong under a fixtures path.
+
+---
+
+## Stage 7 — Documentation
+
+- [ ] **D1 — `design.md` is ~half fossil.** Rewrite or clearly mark
+      design-of-record vs abandoned. Concrete divergences from code:
+  - offsets are **1-based** (`stream.ts:398`, `core/implementation.ts:109-112`),
+    design.md claims 0-based.
+  - omitted `replayAfterOffset` **live-tails** (`stream.ts:624`); design.md
+    claims it replays from the start.
+  - the only supported subscriber is `{type:"callable"}`
+    (`core/contract.ts:19-23`); design.md documents the dropped `built-in` /
+    `external-url` shapes.
+  - storage is **SQL + JS chunking** (`stream.ts:92-117, 25-28`); design.md
+    claims async KV with `allowUnconfirmed`.
+  - the processor model is the `StreamProcessor` **class**; design.md's "Resolved
+    decisions" section describes a never-built `implementProcessor` /
+    `afterAppend` split.
+  - tech is `@journeyapps/wa-sqlite` + OPFS + `BroadcastChannel`, not "SQLocal".
+- [ ] **D2 — `README.md` code snippet is broken:** imports `connectStream`
+      (doesn't exist) — the real export is `withStreamConnectionFromBrowser`
+      (`browser/connect.ts:10`), and the connection is sync-`Disposable`, not
+      `AsyncDisposable`. Fix the snippet and the stale route map (`/streams` uses
+      a `?path=` search param; there is no `/streams/$splat`).
+- [ ] **D3 — ADR 0001 contradicts the code** (claims per-view runtimes; code uses
+      module-level per-(path,slug) singletons in `stream-browser-store.ts:94-139`).
+      Supersede or update. _(ADR 0002 is accurate — leave it.)_
+- [ ] **D4 — Comment drift:** `stream-processor.ts:369` ("batch retries" — see
+      C1/C2); `circuit-breaker/contract.ts:5` says `beforeAppend` (it's
+      `validateAppend`); `grouping.ts:9,86` say `afterAppendBatch` (it's
+      `processEventBatch`); `types.ts:46-48` denies the `eventTypes` filter that
+      exists; `event.ts:17-26` documents `source` as supported (see M2).
+- [ ] **D5 — Document currently-undocumented behaviour:** idempotency-key
+      semantics + `offset` precondition, the auto-appended `created`/`woken`
+      events (post-Stage-2), the `eventTypes` filter (if kept), relative
+      `streamPath` resolution + child-stream announcements, `reset()`, the
+      512 KB chunking. `CONTEXT.md` is the most accurate doc — fix only its two
+      errors: the Web Lock name is keyed on **slug**
+      (`stream-leader.ts:46-53`) not subscription key (H4), and view query-param
+      values are full slugs not "stems" (H5).
+
+---
+
+## Suggested PR sequencing
+
+1. **Stage 0** (tests) — merge first; they fail, documenting the bugs.
+2. **Stage 1** (C1/C2/C3) — the data-loss + security trio; tests go green.
+3. **Stage 2** (lazy init) — owner-requested, biggest `stream.ts` simplification.
+4. **Stage 3 + Stage 4** — remaining correctness, can split by reviewer area.
+5. **Stage 5/6/7** — perf, cleanup, docs; each independently shippable.
+
+Stages 1–2 are the ones that change durable behaviour; review them hardest.

--- a/tasks/streams-review-fixes.md
+++ b/tasks/streams-review-fixes.md
@@ -99,7 +99,7 @@ the workers-sdk rpc fixture test DOs):
       `readCoreProcessorState`. Today it does. _Done — red._
 - [x] **T4 — append with `source` field** (pins M2). Appends an event with a
       valid `source` and reads it back. Today it throws `Unrecognized key:
-    "source"`. _Done — red._
+  "source"`. _Done — red._
 - [x] **T5 — circuit-breaker clock regression** (pins M3). Spend a token with
       `createdAt` 1 s earlier than `lastRefillAtMs`; assert tokens decrement by
       ~1, not by 100k. _Done — red._

--- a/tasks/streams-review-fixes.md
+++ b/tasks/streams-review-fixes.md
@@ -99,7 +99,7 @@ the workers-sdk rpc fixture test DOs):
       `readCoreProcessorState`. Today it does. _Done — red._
 - [x] **T4 — append with `source` field** (pins M2). Appends an event with a
       valid `source` and reads it back. Today it throws `Unrecognized key:
-  "source"`. _Done — red._
+"source"`. _Done — red._
 - [x] **T5 — circuit-breaker clock regression** (pins M3). Spend a token with
       `createdAt` 1 s earlier than `lastRefillAtMs`; assert tokens decrement by
       ~1, not by 100k. _Done — red._


### PR DESCRIPTION
## What

**Stage 0** of an in-depth adversarial review of `packages/streams` (full plan + all findings in `tasks/streams-review-fixes.md`). This PR is **tests only — no behavior changes.** It pins the bugs the review found and gives the package its first always-on Durable Object tests, so the follow-up fix PRs land on a safety net.

## Why first

The ~1000-line Stream DO had **zero always-on tests** (append, idempotency, the pause gate, >512KB chunking, replay all lived only in `example-app/e2e/*`, skipped unless `STREAM_STAGING_E2E=true`). The review surfaced two CRITICAL data-loss/security bugs and several MAJORs; this PR documents them as failing tests before any fix touches the code.

## The bug-pins (committed as `it.fails` ratchets)

The six tests below assert the **correct** behavior, which is currently violated — so they register as "expected fail" and keep `pnpm test` green. Each was proven to fail for the right reason (output in the table). When a fix lands, flip `it.fails` → `it`.

| Test | Finding | Proven failure today |
|------|---------|----------------------|
| T1 | **C1** swallowed-ingest desync (CRITICAL) | `{total: 7}` — event lost, expected `12` |
| T2 | **C2** writeState checkpoint ordering (CRITICAL) | nothing persisted on retry |
| T3 | **C3** `PublicStreamRpcTarget` leaks `protected` methods (CRITICAL, security) | prototype exposes `writeCoreProcessorState` |
| T4 | **M2** `source` field crashes append | `Unrecognized key: "source"` |
| T5 | **M3** breaker token bucket on backwards clock | `-99996` tokens |
| T6 | **M4** breaker silent after replay trip | `0` pauses |

T7 (idempotency) and T8 (DO smoke: offsets, `getEvents` paging, >512KB chunk round-trip, subscribe replay) are coverage for already-correct behavior and pass now.

## The Stream DO test harness (structural)

Adds `vitest-pool-workers` to `packages/streams` (mirroring `packages/shared`):
- `vitest.workers.config.ts` + `vitest.workers.jsonc` (binds the `Stream` + `StreamProcessorRunner` DOs)
- `src/workers/test-entry.ts` (minimal worker exporting the DOs)
- node config excludes `**/*.workers.test.ts`; `pnpm test` runs both pools (`test:node` / `test:workers`)

Following **cloudflare/agents** and the workers-sdk rpc fixture, the DO tests use `runInDurableObject(stub, (instance, state) => …)` to call the instance directly and inspect `state.storage` — clean local throws (no RPC unhandled-rejection workaround), deterministic replay, and the chunking test asserts the event really spans multiple `event_chunks` rows. One test stays on the RPC stub to cover the production boundary.

## Verification

```
node pool:    58 passed | 4 expected-fail
workers pool:  6 passed | 2 expected-fail
typecheck: clean   lint: clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes and CI script updates; no production paths modified. Bug-pin tests document known failures without changing runtime behavior.
> 
> **Overview**
> **Stage 0 (tests only)** for the `packages/streams` review: no runtime behavior changes. It adds the first always-on coverage for the Stream Durable Object and pins six known bugs as **`it.fails` ratchets** so `pnpm test` stays green until fixes land.
> 
> A **vitest-pool-workers** harness is introduced (`vitest.workers.config.ts`, `vitest.workers.jsonc`, `src/workers/test-entry.ts`), with `@cloudflare/vitest-pool-workers` as a dev dependency. Node Vitest excludes `**/*.workers.test.ts`; **`pnpm test`** runs both pools (`test:node` / `test:workers`).
> 
> **Node** (`stream-review-regressions.test.ts`): T1–T2 (ingest desync, checkpoint after `writeState` failure) and T5–T6 (circuit-breaker clock regression and post-replay flood) assert correct behavior via stubs/fakes.
> 
> **Workerd** (`stream.workers.test.ts`): T3–T4 are failing ratchets for RPC surface leak and `source` on append; T7–T8 pass now (idempotency, offsets, paging, >512KB chunking, subscribe replay), mostly via `runInDurableObject` with one RPC-stub smoke test.
> 
> `tasks/streams-review-fixes.md` marks Stage 0 complete and documents the harness pattern for later fix PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c94b0eb141c3499e4580301719000b6d7235327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->