### PR TITLE
ItxError: five-code structured kernel errors over capnweb

### DIFF
--- a/apps/os/docs/itx-orpc-replacement-plan.md
+++ b/apps/os/docs/itx-orpc-replacement-plan.md
@@ -107,6 +107,10 @@ Done (PR #1423):
   `useStreamEvents`, and `ItxActivityTail` (live `/itx` audit tail on the
   project repl page).
 - First route conversion: project streams index reads through the handle.
+- `ItxError { code, message, details? }` (`src/itx/errors.ts`): five codes
+  riding capnweb as own enumerable props, duck-typed client detection
+  (`getItxErrorCode`/`isItxAccessError`), and `onSendError` tagging every
+  other outbound error INTERNAL with its stack — see DECISIONS.md D18.
 
 Happening separately: codemode is deleted and replaced by the **itx
 processor** (`events.iterate.com/itx/execution-requested` /
@@ -116,9 +120,6 @@ Remaining: see `tasks/os-orpc-teardown.md`.
 
 ## Known risks
 
-- **Error opacity**: capnweb flattens server throws to strings. A structured
-  `ItxError { code, message }` rehydrated client-side must land before the
-  bulk of the UI converts.
 - **OAuth redirect-URI derivation** currently uses the incoming request URL;
   over itx the call arrives on a long-lived socket — derive from project/app
   config instead, verify on a preview.

--- a/apps/os/src/domains/streams/entrypoints/streams-capability.ts
+++ b/apps/os/src/domains/streams/entrypoints/streams-capability.ts
@@ -8,6 +8,7 @@ import {
   StreamPath,
 } from "@iterate-com/shared/streams/types";
 import type { ExecuteCodemodeFunctionCallInput } from "~/domains/codemode/stream-processors/codemode/implementation.ts";
+import { ItxError } from "~/itx/errors.ts";
 import {
   getStreamDurableObjectName,
   getInitializedStreamStub,
@@ -323,7 +324,13 @@ export class StreamsCapability extends WorkerEntrypoint<
       return;
     }
 
-    throw new Error(`Stream append policy rejected append to ${path}.`);
+    // FORBIDDEN, not NOT_FOUND: the caller already holds this capability, so
+    // the stream's existence is not a secret — only the append right is.
+    throw new ItxError({
+      code: "FORBIDDEN",
+      details: { path, policyMode: policy.mode },
+      message: `Stream append policy rejected append to ${path}.`,
+    });
   }
 }
 
@@ -352,7 +359,7 @@ export function getStreamsCapability(input: {
 export function resolveStreamPath(pathInput: string): StreamPath {
   const trimmedPath = pathInput.trim();
   if (!trimmedPath) {
-    throw new Error("Stream path is required.");
+    throw new ItxError({ code: "BAD_REQUEST", message: "Stream path is required." });
   }
 
   const path = trimmedPath.startsWith("/") ? trimmedPath : `/${trimmedPath}`;
@@ -362,7 +369,7 @@ export function resolveStreamPath(pathInput: string): StreamPath {
 function resolveCapabilityStreamPath(input: { basePath?: string; pathInput?: string }): StreamPath {
   if (input.pathInput == null) {
     if (input.basePath == null) {
-      throw new Error("Stream path is required.");
+      throw new ItxError({ code: "BAD_REQUEST", message: "Stream path is required." });
     }
 
     return resolveStreamPath(input.basePath);
@@ -370,7 +377,7 @@ function resolveCapabilityStreamPath(input: { basePath?: string; pathInput?: str
 
   const trimmedPath = input.pathInput.trim();
   if (!trimmedPath) {
-    throw new Error("Stream path is required.");
+    throw new ItxError({ code: "BAD_REQUEST", message: "Stream path is required." });
   }
 
   if (trimmedPath.startsWith("/")) {

--- a/apps/os/src/durable-objects/itx-stream-subscribe-test-entry.ts
+++ b/apps/os/src/durable-objects/itx-stream-subscribe-test-entry.ts
@@ -1,6 +1,7 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import type { StreamCursor, Event as StreamLegacyEvent } from "@iterate-com/shared/streams/types";
 import { ItxStream, ItxStreams, type ItxRuntime } from "~/itx/handle.ts";
+import { getStreamsCapability } from "~/domains/streams/entrypoints/streams-capability.ts";
 
 export { StreamsCapability } from "~/domains/streams/entrypoints/streams-capability.ts";
 export { Stream as StreamDurableObject } from "@iterate-com/streams/workers/durable-objects/stream";
@@ -38,6 +39,20 @@ export class ItxStreamHarness extends WorkerEntrypoint<Env> {
     return await this.#stream(input.path).subscribe(onEventBatch, {
       afterOffset: input.afterOffset,
     });
+  }
+
+  /**
+   * Trips the append-policy check inside StreamsCapability, so the resulting
+   * ItxError must cross the ctx.exports loopback (Workers RPC) back into this
+   * entrypoint, then the harness boundary into the test — proving that
+   * `code`/`details` survive Workers RPC hops, not just capnweb.
+   */
+  async appendOutsidePolicy(input: { path: string }) {
+    const capability = getStreamsCapability({
+      exports: this.ctx.exports as unknown as Parameters<typeof getStreamsCapability>[0]["exports"],
+      props: { appendPolicy: { mode: "none" }, projectId, streamPath: input.path },
+    });
+    await capability.append({ event: { type: "test.iterate.com/itx-subscribe/denied" } as never });
   }
 
   #stream(path: string): ItxStream {

--- a/apps/os/src/durable-objects/itx-stream-subscribe.test.ts
+++ b/apps/os/src/durable-objects/itx-stream-subscribe.test.ts
@@ -19,6 +19,7 @@ type HarnessStub = {
     path: string;
     event: { type: string; payload: Record<string, unknown> };
   }): Promise<StreamEvent>;
+  appendOutsidePolicy(input: { path: string }): Promise<void>;
   list(): Promise<{ streamPath: string }[]>;
   read(input: { path: string }): Promise<StreamEvent[]>;
   subscribe(
@@ -157,6 +158,24 @@ describe("itx stream subscribe against a real Stream Durable Object", () => {
     // The worker (and the stream) survived: both appends were committed.
     const events = await harness.read({ path });
     expect(markersOf(events)).toEqual(["boom", "after-boom"]);
+  });
+});
+
+describe("itx errors across real Workers RPC boundaries", () => {
+  test("an ItxError's code and details survive the loopback and harness hops", async () => {
+    const path = newStreamPath();
+    // The append-policy FORBIDDEN is thrown inside StreamsCapability, crosses
+    // the ctx.exports loopback into the harness entrypoint, then the harness
+    // RPC boundary into this test — two real Workers RPC serializations.
+    const error = await harness.appendOutsidePolicy({ path }).then(
+      () => null,
+      (thrown: unknown) => thrown as Error & { code?: unknown; details?: unknown },
+    );
+
+    expect(error).not.toBeNull();
+    expect(error!.name).toBe("ItxError");
+    expect(error!.code).toBe("FORBIDDEN");
+    expect(error!.details).toEqual({ path, policyMode: "none" });
   });
 });
 

--- a/apps/os/src/itx/DECISIONS.md
+++ b/apps/os/src/itx/DECISIONS.md
@@ -161,3 +161,32 @@ under the project-level access model ("you have the project or you don't").
 The genuinely dangerous direction — a hand-built `path` into
 reserved/prototype names via `itxInvoke` — stays gated in `replayPathCall`
 (D16), which is exactly why that server-side filter is load-bearing now.
+
+## D18: ItxError — five codes, duck-typed, tag-don't-redact
+
+Structured kernel errors live in `errors.ts`; full rationale in its doc
+comments. The compact version:
+
+- **Wire shape over class identity.** capnweb serializes an error's own
+  enumerable props and reconstructs a plain `Error` on the far side, so
+  `ItxError` is just `Error` + enumerable `code`/`details` and detection is
+  duck-typed (`getItxErrorCode`), never `instanceof`. No rehydration layer.
+- **Exactly five codes**: NOT_FOUND, FORBIDDEN, CONFLICT, BAD_REQUEST,
+  INTERNAL. No UNAUTHORIZED — auth happens at connect (Law 3), so auth
+  failures are transport-level 401s before a session exists.
+- **Existence masking**: resolution boundaries (`itx.projects.get`,
+  `/api/itx[/run]` context resolution) answer NOT_FOUND for missing AND
+  forbidden, byte-identical, so callers cannot probe which ids/slugs exist.
+  FORBIDDEN is reserved for cases where existence is established or not
+  secret (global streams, append policy, create/remove projects).
+- **Tag, don't redact**: the `/api/itx` sessions' `onSendError`
+  (`tagOutboundItxError`, wired in `fetch.ts`) rewrites every non-ItxError to
+  `ItxError { code: "INTERNAL" }` keeping the original message and stack — we
+  trust our callers; returning the error from the hook is also what makes
+  capnweb transmit the stack at all. `details` ships in v1 (maximum info).
+- **Retry semantics downstream**: `useItxQuery` retries only code-less
+  (socket) or INTERNAL errors, once; the stream-tail multiplexer skips
+  retry exactly for access errors (NOT_FOUND/FORBIDDEN).
+- Verified by the worker harness (`pnpm test:itx-stream-subscribe`) that
+  `code`/`details` also survive plain Workers RPC hops, so kernel throws
+  born inside `StreamsCapability` keep their codes on the way to capnweb.

--- a/apps/os/src/itx/e2e/itx.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx.e2e.test.ts
@@ -382,6 +382,23 @@ test("one dynamic worker cap calls another's methods through its own itx", async
   });
 });
 
+test("kernel errors cross capnweb as ItxError-shaped errors with codes", async () => {
+  using itx = connectGlobal();
+
+  // The REAL wire crossing: capnweb reconstructs a plain Error and reattaches
+  // the kernel ItxError's own enumerable props (code, details). NOT_FOUND
+  // also covers forbidden projects (existence masking), so this is the shape
+  // every access failure takes.
+  const error = await itx.projects.get("definitely-not-a-project").then(
+    () => null,
+    (thrown: unknown) => thrown as Error & { code?: unknown; details?: unknown },
+  );
+  expect(error).not.toBeNull();
+  expect(error!.name).toBe("ItxError");
+  expect(error!.code).toBe("NOT_FOUND");
+  expect(error!.details).toEqual({ projectIdOrSlug: "definitely-not-a-project" });
+});
+
 test("revoked and offline caps fail with instructive errors", async () => {
   using itx = connectGlobal();
   const project = (await itx.projects.create({ slug: `${PROJECT_SLUG}-err` })) as { id: string };

--- a/apps/os/src/itx/errors.ts
+++ b/apps/os/src/itx/errors.ts
@@ -1,0 +1,117 @@
+// ItxError: the structured error the itx kernel throws, and the duck-typed
+// helpers every consumer (browser, Node e2e, caps) uses to read it back.
+// This module is transport-agnostic and dependency-free on purpose — the
+// react client re-exports from here, kernel code imports it directly.
+
+/**
+ * The five itx error codes. Exactly five, deliberately:
+ *
+ * - `NOT_FOUND`    — the target does not exist *for you*. Existence masking:
+ *                    at resolution boundaries (`itx.projects.get`, connect
+ *                    paths) "missing" and "forbidden" both answer NOT_FOUND
+ *                    with the same message, so a caller can never probe which
+ *                    project ids/slugs exist by comparing error shapes.
+ * - `FORBIDDEN`    — you may not do this, and saying so reveals nothing:
+ *                    existence is already established or not secret (global
+ *                    streams need admin, append-policy rejections,
+ *                    create/remove projects on a named-access handle).
+ * - `CONFLICT`     — the request is valid but collides with existing state
+ *                    (duplicate slug, id already taken with another slug).
+ * - `BAD_REQUEST`  — caller misuse that no retry or permission fixes (global
+ *                    handle where a project handle is needed, malformed id).
+ * - `INTERNAL`     — everything else. Any non-ItxError crossing the /api/itx
+ *                    boundary is tagged INTERNAL by `tagOutboundItxError`.
+ *
+ * There is no UNAUTHORIZED: itx auth happens at connect time (Law 3), so an
+ * authentication failure is a transport-level 401 on the HTTP/WebSocket
+ * handshake — by the time a capnweb session exists and errors can flow over
+ * it, the principal is already established.
+ */
+export const ITX_ERROR_CODES = [
+  "NOT_FOUND",
+  "FORBIDDEN",
+  "CONFLICT",
+  "BAD_REQUEST",
+  "INTERNAL",
+] as const;
+
+export type ItxErrorCode = (typeof ITX_ERROR_CODES)[number];
+
+const ITX_ERROR_CODE_SET: ReadonlySet<string> = new Set(ITX_ERROR_CODES);
+
+/**
+ * The error the itx kernel throws. Designed around how capnweb (0.8.0) moves
+ * errors across the wire:
+ *
+ * - The serializer emits `["error", name, message, stack?, props?]` where
+ *   `props` is the error's OWN ENUMERABLE properties (everything except
+ *   name/message/stack). The receiver reconstructs a plain `Error` (builtin
+ *   names like TypeError map to their classes; anything else — including
+ *   "ItxError" — becomes `Error` with `name` reattached) and copies the props
+ *   back on. Class identity is lost in transit, so `code` and `details` are
+ *   own enumerable properties and detection is duck-typed via
+ *   {@link getItxErrorCode} — NEVER `instanceof ItxError` on the client.
+ * - The stack is only transmitted when the session's `onSendError` hook
+ *   returns a rewritten error; see {@link tagOutboundItxError}.
+ *
+ * Posture: no redaction. We trust our callers with messages, stacks, and
+ * `details` (maximum debugging info, v1 decision). The one thing we DO hide
+ * is existence at resolution boundaries — see the NOT_FOUND masking note on
+ * {@link ITX_ERROR_CODES}.
+ */
+export class ItxError extends Error {
+  override readonly name = "ItxError";
+  declare readonly code: ItxErrorCode;
+  declare readonly details?: Record<string, unknown>;
+
+  constructor(input: { code: ItxErrorCode; message: string; details?: Record<string, unknown> }) {
+    super(input.message);
+    this.code = input.code;
+    // Only attach when provided: own enumerable props are exactly what
+    // capnweb serializes, so an undefined `details` would be wire noise.
+    if (input.details !== undefined) {
+      this.details = input.details;
+    }
+  }
+}
+
+/**
+ * Duck-typed detection (works on both ends of any RPC boundary): an ItxError
+ * is anything named "ItxError" carrying one of the five codes. Returns the
+ * code, or undefined for everything else — including socket/connection
+ * failures, which is what makes "retry only when code-less or INTERNAL"
+ * predicates work.
+ */
+export function getItxErrorCode(error: unknown): ItxErrorCode | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const candidate = error as { code?: unknown; name?: unknown };
+  if (candidate.name !== "ItxError") return undefined;
+  if (typeof candidate.code !== "string" || !ITX_ERROR_CODE_SET.has(candidate.code)) {
+    return undefined;
+  }
+  return candidate.code as ItxErrorCode;
+}
+
+/** True when retrying cannot help: authorization/existence failures. */
+export function isItxAccessError(error: unknown): boolean {
+  const code = getItxErrorCode(error);
+  return code === "NOT_FOUND" || code === "FORBIDDEN";
+}
+
+/**
+ * The `onSendError` hook for every server-side itx capnweb session: tag,
+ * don't redact. Anything outbound that is not already an ItxError is
+ * rewritten to `ItxError { code: "INTERNAL" }` with the original message and
+ * stack preserved — so the client can always read a code, and nothing is
+ * hidden ("we trust our callers").
+ *
+ * Returning an error from this hook (the original ItxError included) is also
+ * what opts its stack into transmission: capnweb only serializes
+ * `rewritten.stack`, never the stack of an unrewritten error.
+ */
+export function tagOutboundItxError(error: Error): Error {
+  if (getItxErrorCode(error) !== undefined) return error;
+  const tagged = new ItxError({ code: "INTERNAL", message: error.message });
+  tagged.stack = error.stack;
+  return tagged;
+}

--- a/apps/os/src/itx/fetch.ts
+++ b/apps/os/src/itx/fetch.ts
@@ -9,8 +9,13 @@
 //   POST    /api/itx/admin-cookie     test-only browser auth bridge (browsers
 //                                     cannot set WebSocket Authorization headers)
 
-import { newWorkersRpcResponse } from "capnweb";
+import {
+  newHttpBatchRpcResponse,
+  newWorkersWebSocketRpcResponse,
+  type RpcSessionOptions,
+} from "capnweb";
 import { resolveItx } from "./entrypoint.ts";
+import { tagOutboundItxError } from "./errors.ts";
 import { runItxScript } from "./run.ts";
 import {
   GLOBAL_CONTEXT_ID,
@@ -72,11 +77,13 @@ export async function handleItxFetch(input: {
       env: input.env,
       idOrSlug: decodeURIComponent(subpath),
     });
-    if (!resolved) return new Response("Not Found", { status: 404 });
+    if (!resolved) {
+      return Response.json({ code: "NOT_FOUND", error: "Context not found" }, { status: 404 });
+    }
     props = { context: resolved.contextId };
   }
 
-  const response = await newWorkersRpcResponse(
+  const response = await newItxRpcResponse(
     input.request,
     await resolveItx({ env: input.env, exports: workerExports(input.context), props }),
   );
@@ -110,7 +117,7 @@ export async function handleProjectHostItxFetch(input: {
   const principal = authenticateCapnwebAdmin({ config: input.config, request: input.request });
   if (!principal) return new Response("Unauthorized", { status: 401 });
 
-  return await newWorkersRpcResponse(
+  return await newItxRpcResponse(
     input.request,
     await resolveItx({
       env: input.env,
@@ -118,6 +125,27 @@ export async function handleProjectHostItxFetch(input: {
       props: { context: input.projectId },
     }),
   );
+}
+
+/**
+ * capnweb's `newWorkersRpcResponse` convenience wrapper takes no
+ * RpcSessionOptions (0.8.0), so this re-implements its POST/WebSocket
+ * dispatch in order to pass `onSendError`: every error leaving an itx
+ * session is tagged with an ItxError code (non-ItxErrors become INTERNAL),
+ * and returning the error from the hook is what makes capnweb transmit its
+ * stack — tag-don't-redact, see `tagOutboundItxError` (errors.ts).
+ */
+async function newItxRpcResponse(request: Request, localMain: unknown): Promise<Response> {
+  const options: RpcSessionOptions = { onSendError: tagOutboundItxError };
+  if (request.method === "POST") {
+    const response = await newHttpBatchRpcResponse(request, localMain, options);
+    response.headers.set("Access-Control-Allow-Origin", "*");
+    return response;
+  }
+  if (request.headers.get("Upgrade")?.toLowerCase() === "websocket") {
+    return newWorkersWebSocketRpcResponse(request, localMain, options);
+  }
+  return new Response("This endpoint only accepts POST or WebSocket requests.", { status: 400 });
 }
 
 async function authenticateItxRequest(input: {
@@ -190,7 +218,12 @@ async function handleItxRun(input: {
   request: Request;
 }): Promise<Response> {
   if (!input.env.LOADER) {
-    return Response.json({ error: "LOADER binding not available" }, { status: 503 });
+    return Response.json(
+      { code: "INTERNAL", error: "LOADER binding not available" },
+      {
+        status: 503,
+      },
+    );
   }
 
   const body = (await input.request.json()) as {
@@ -199,7 +232,12 @@ async function handleItxRun(input: {
     vars?: Record<string, unknown>;
   };
   if (typeof body.functionSource !== "string" || body.functionSource.trim() === "") {
-    return Response.json({ error: "functionSource is required" }, { status: 400 });
+    return Response.json(
+      { code: "BAD_REQUEST", error: "functionSource is required" },
+      {
+        status: 400,
+      },
+    );
   }
 
   let props: ItxProps;
@@ -211,14 +249,20 @@ async function handleItxRun(input: {
       env: input.env,
       idOrSlug: body.context,
     });
-    if (!resolved) return Response.json({ error: "Context not found" }, { status: 404 });
+    // NOT_FOUND covers both missing and forbidden contexts (existence
+    // masking — same posture as ItxProjects.get, see errors.ts).
+    if (!resolved) {
+      return Response.json({ code: "NOT_FOUND", error: "Context not found" }, { status: 404 });
+    }
     props = { context: resolved.contextId };
     scriptProjectId = resolved.projectId;
   } else {
     // A global-context script inherits the platform's own egress (no
     // per-project globalOutbound), so it is admin-only — same rule as the
     // global connect handle.
-    if (input.access !== "all") return Response.json({ error: "Forbidden" }, { status: 403 });
+    if (input.access !== "all") {
+      return Response.json({ code: "FORBIDDEN", error: "Forbidden" }, { status: 403 });
+    }
     props = { access: input.access, context: GLOBAL_CONTEXT_ID };
   }
 
@@ -231,8 +275,16 @@ async function handleItxRun(input: {
     vars: body.vars,
   });
   if (!outcome.ok) {
+    // The script isolate flattens throws to JSON, so the ItxError code (when
+    // the kernel threw one) rides along as a plain field; anything code-less
+    // is INTERNAL, mirroring the capnweb sessions' tagging.
     return Response.json(
-      { error: outcome.error, executionId: outcome.executionId, stack: outcome.stack },
+      {
+        code: outcome.code ?? "INTERNAL",
+        error: outcome.error,
+        executionId: outcome.executionId,
+        stack: outcome.stack,
+      },
       { status: 500 },
     );
   }

--- a/apps/os/src/itx/handle.ts
+++ b/apps/os/src/itx/handle.ts
@@ -22,6 +22,7 @@ import type { StreamCursor, Event as StreamLegacyEvent } from "@iterate-com/shar
 import { createD1Client } from "sqlfu";
 import { StreamNamespace } from "@iterate-com/shared/streams/types";
 import { PathProxyRpcTarget } from "./path-proxy.ts";
+import { ItxError } from "./errors.ts";
 import {
   GLOBAL_CONTEXT_ID,
   isChildContextId,
@@ -117,9 +118,11 @@ export class Itx extends RpcTarget {
       return new ItxStreams(this.#runtime, projectId);
     }
     if (this.#runtime.access !== "all") {
-      throw new Error(
-        "Global streams need admin access. Narrow to a project first: itx.projects.get(idOrSlug).",
-      );
+      throw new ItxError({
+        code: "FORBIDDEN",
+        message:
+          "Global streams need admin access. Narrow to a project first: itx.projects.get(idOrSlug).",
+      });
     }
     return new ItxStreams(this.#runtime, GLOBAL_CONTEXT_ID);
   }
@@ -271,9 +274,11 @@ export class Itx extends RpcTarget {
   #requireProjectId(): string {
     const projectId = this.#projectId();
     if (projectId === null) {
-      throw new Error(
-        "This itx handle is on the global context. Narrow to a project first: itx.projects.get(idOrSlug).",
-      );
+      throw new ItxError({
+        code: "BAD_REQUEST",
+        message:
+          "This itx handle is on the global context. Narrow to a project first: itx.projects.get(idOrSlug).",
+      });
     }
     return projectId;
   }
@@ -377,7 +382,12 @@ export class ItxCaps extends RpcTarget {
     const secret = this.runtime.config.adminApiSecret?.exposeSecret();
     if (!secret) throw new Error("Share URLs need an admin API secret configured.");
     const projectId = this.runtime.projectId;
-    if (!projectId) throw new Error("Share URLs are project-scoped; narrow to a project first.");
+    if (!projectId) {
+      throw new ItxError({
+        code: "BAD_REQUEST",
+        message: "Share URLs are project-scoped; narrow to a project first.",
+      });
+    }
 
     const ingress = new URL(await this.project().ingressUrl());
     const expiresAtMs = Date.now() + (input.ttlSeconds ?? 3600) * 1000;
@@ -415,7 +425,10 @@ export class ItxStreams extends RpcTarget {
 
   namespace(namespace: string): ItxStreams {
     if (this.runtime.access !== "all") {
-      throw new Error("Selecting an arbitrary stream namespace requires admin access.");
+      throw new ItxError({
+        code: "FORBIDDEN",
+        message: "Selecting an arbitrary stream namespace requires admin access.",
+      });
     }
     return new ItxStreams(this.runtime, StreamNamespace.parse(namespace));
   }
@@ -575,19 +588,31 @@ export class ItxProjects extends RpcTarget {
     // auth org to own the project. A supplied id must already be a project id
     // (legacy "proj_" still accepted), never a slug.
     if (input.id !== undefined && !isProjectId(input.id)) {
-      throw new Error("Project ID must start with prj_ (or legacy proj_).");
+      throw new ItxError({
+        code: "BAD_REQUEST",
+        details: { id: input.id },
+        message: "Project ID must start with prj_ (or legacy proj_).",
+      });
     }
     const id = input.id ?? mintProjectId();
 
     const existingById = await getProjectById(db, { id });
     if (existingById) {
       if (existingById.slug !== input.slug) {
-        throw new Error(`Project ${id} already exists with slug ${existingById.slug}.`);
+        throw new ItxError({
+          code: "CONFLICT",
+          details: { existingSlug: existingById.slug, id },
+          message: `Project ${id} already exists with slug ${existingById.slug}.`,
+        });
       }
       return toProjectSummary(existingById);
     }
     if (await getProjectBySlug(db, { slug: input.slug })) {
-      throw new Error(`A project with slug ${input.slug} already exists.`);
+      throw new ItxError({
+        code: "CONFLICT",
+        details: { slug: input.slug },
+        message: `A project with slug ${input.slug} already exists.`,
+      });
     }
 
     await insertProject(db, { id, slug: input.slug });
@@ -617,17 +642,27 @@ export class ItxProjects extends RpcTarget {
     const row = isProjectId(projectIdOrSlug)
       ? await getProjectById(db, { id: projectIdOrSlug })
       : await getProjectBySlug(db, { slug: projectIdOrSlug });
-    if (!row) throw new Error(`Project ${projectIdOrSlug} not found.`);
+    // Existence masking (errors.ts): missing and forbidden are byte-identical
+    // NOT_FOUND errors, so access probing cannot reveal which ids/slugs exist.
+    const notFound = () =>
+      new ItxError({
+        code: "NOT_FOUND",
+        details: { projectIdOrSlug },
+        message: `Project ${projectIdOrSlug} not found.`,
+      });
+    if (!row) throw notFound();
     if (this.runtime.access !== "all" && !this.runtime.access.includes(row.id)) {
-      // Same message as not-found: access probing should not reveal existence.
-      throw new Error(`Project ${projectIdOrSlug} not found.`);
+      throw notFound();
     }
     return row;
   }
 
   private requireAllAccess(action: string) {
     if (this.runtime.access !== "all") {
-      throw new Error(`This itx handle may not ${action}; it has access to named projects only.`);
+      throw new ItxError({
+        code: "FORBIDDEN",
+        message: `This itx handle may not ${action}; it has access to named projects only.`,
+      });
     }
   }
 

--- a/apps/os/src/itx/react/errors.test.ts
+++ b/apps/os/src/itx/react/errors.test.ts
@@ -1,22 +1,105 @@
 import { describe, expect, test } from "vitest";
-import { isItxAccessError } from "./errors.ts";
+import { ItxError, tagOutboundItxError } from "../errors.ts";
+import { getItxErrorCode, isItxAccessError } from "./errors.ts";
 
-describe("isItxAccessError", () => {
-  test("matches the kernel's authorization/existence failures", () => {
-    expect(isItxAccessError(new Error("Project prj_d871 not found."))).toBe(true);
-    expect(isItxAccessError(new Error("Context not found"))).toBe(true);
-    expect(isItxAccessError(new Error("Project iterate is not accessible."))).toBe(true);
-    expect(
-      isItxAccessError(new Error("Global streams need admin access. Narrow to a project first.")),
-    ).toBe(true);
-    expect(isItxAccessError(new Error("FORBIDDEN"))).toBe(true);
-    expect(isItxAccessError("Unauthorized")).toBe(true);
+/**
+ * What the far side of a capnweb session holds after an ItxError crosses:
+ * a plain reconstructed Error with name and the thrown error's own
+ * enumerable props reattached — class identity gone. (capnweb 0.8.0
+ * serializes `["error", name, message, stack?, props?]` with props from
+ * `Object.keys(error)` minus name/message/stack.)
+ */
+function simulateCapnwebCrossing(error: Error): Error {
+  const received = new Error(error.message);
+  received.name = error.name;
+  for (const key of Object.keys(error)) {
+    if (key === "name" || key === "message" || key === "stack") continue;
+    (received as unknown as Record<string, unknown>)[key] = (
+      error as unknown as Record<string, unknown>
+    )[key];
+  }
+  return received;
+}
+
+describe("ItxError", () => {
+  test("code and details are own enumerable properties (the load-bearing wire property)", () => {
+    const error = new ItxError({
+      code: "NOT_FOUND",
+      details: { projectIdOrSlug: "nope" },
+      message: "Project nope not found.",
+    });
+    expect(Object.keys(error)).toContain("code");
+    expect(Object.keys(error)).toContain("details");
+    expect(error.name).toBe("ItxError");
   });
 
-  test("does not match transient failures", () => {
-    expect(isItxAccessError(new Error("subscribe exploded"))).toBe(false);
-    expect(isItxAccessError(new Error("The itx connection was closed."))).toBe(false);
-    expect(isItxAccessError(new Error("network timeout"))).toBe(false);
+  test("details stays off the instance (and the wire) when not provided", () => {
+    const error = new ItxError({ code: "FORBIDDEN", message: "no" });
+    expect(Object.keys(error)).not.toContain("details");
+  });
+
+  test("code and details survive a simulated capnweb round trip; instanceof does not", () => {
+    const thrown = new ItxError({
+      code: "NOT_FOUND",
+      details: { projectIdOrSlug: "ghost" },
+      message: "Project ghost not found.",
+    });
+    const received = simulateCapnwebCrossing(thrown);
+
+    expect(received).not.toBeInstanceOf(ItxError);
+    expect(getItxErrorCode(received)).toBe("NOT_FOUND");
+    expect((received as unknown as { details: unknown }).details).toEqual({
+      projectIdOrSlug: "ghost",
+    });
+  });
+});
+
+describe("getItxErrorCode", () => {
+  test("reads the code from anything ItxError-shaped", () => {
+    expect(getItxErrorCode(new ItxError({ code: "CONFLICT", message: "taken" }))).toBe("CONFLICT");
+    const duckTyped = Object.assign(new Error("rejected"), {
+      code: "FORBIDDEN",
+      name: "ItxError",
+    });
+    expect(getItxErrorCode(duckTyped)).toBe("FORBIDDEN");
+  });
+
+  test("returns undefined for everything else", () => {
+    expect(getItxErrorCode(new Error("The itx connection was closed."))).toBeUndefined();
+    expect(getItxErrorCode(new Error("network timeout"))).toBeUndefined();
+    expect(getItxErrorCode("Unauthorized")).toBeUndefined();
+    expect(getItxErrorCode(null)).toBeUndefined();
+    // Wrong name: a coded error that isn't ours.
+    expect(getItxErrorCode(Object.assign(new Error("x"), { code: "NOT_FOUND" }))).toBeUndefined();
+    // Right name, unknown code.
+    expect(
+      getItxErrorCode(Object.assign(new Error("x"), { code: "TEAPOT", name: "ItxError" })),
+    ).toBeUndefined();
+  });
+});
+
+describe("isItxAccessError", () => {
+  test("true exactly for NOT_FOUND and FORBIDDEN", () => {
+    expect(isItxAccessError(new ItxError({ code: "NOT_FOUND", message: "gone" }))).toBe(true);
+    expect(isItxAccessError(new ItxError({ code: "FORBIDDEN", message: "no" }))).toBe(true);
+    expect(isItxAccessError(new ItxError({ code: "CONFLICT", message: "taken" }))).toBe(false);
+    expect(isItxAccessError(new ItxError({ code: "BAD_REQUEST", message: "bad" }))).toBe(false);
+    expect(isItxAccessError(new ItxError({ code: "INTERNAL", message: "boom" }))).toBe(false);
     expect(isItxAccessError(new Error("WebSocket peer disconnected"))).toBe(false);
+  });
+});
+
+describe("tagOutboundItxError", () => {
+  test("returns ItxErrors unchanged (which opts their stack into transmission)", () => {
+    const error = new ItxError({ code: "NOT_FOUND", message: "gone" });
+    expect(tagOutboundItxError(error)).toBe(error);
+  });
+
+  test("rewrites everything else to INTERNAL, preserving message and stack", () => {
+    const original = new Error("kaboom");
+    const tagged = tagOutboundItxError(original);
+    expect(getItxErrorCode(tagged)).toBe("INTERNAL");
+    expect(tagged.message).toBe("kaboom");
+    expect(tagged.stack).toBe(original.stack);
   });
 });

--- a/apps/os/src/itx/react/errors.ts
+++ b/apps/os/src/itx/react/errors.ts
@@ -1,13 +1,6 @@
-// capnweb flattens kernel throws to bare message strings (no codes — the
-// structured ItxError is still on the plan), so until that lands, access
-// failures are recognised by message shape. The kernel deliberately answers
-// missing AND forbidden with the same "not found" wording (no existence
-// probing), which is exactly the class of error retrying can never fix.
+// The browser face of the kernel's error module. ItxError codes cross
+// capnweb as own enumerable props on a reconstructed Error (class identity
+// does not survive), so detection is duck-typed — see ~/itx/errors.ts for
+// the wire mechanics, code taxonomy, and masking policy.
 
-const ACCESS_ERROR_PATTERN = /\b(not found|not accessible|forbidden|unauthorized|admin access)\b/i;
-
-/** True when retrying cannot help: authorization/existence failures. */
-export function isItxAccessError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return ACCESS_ERROR_PATTERN.test(message);
-}
+export { getItxErrorCode, isItxAccessError, type ItxErrorCode } from "../errors.ts";

--- a/apps/os/src/itx/react/hooks.ts
+++ b/apps/os/src/itx/react/hooks.ts
@@ -25,7 +25,7 @@ import {
 import type { RpcStub } from "capnweb";
 import type { Itx } from "../handle.ts";
 import { useItxClient } from "./context.ts";
-import { isItxAccessError } from "./errors.ts";
+import { getItxErrorCode } from "./errors.ts";
 
 /** A connected handle as queryFn/mutationFn receive it. */
 export type ItxHandle = RpcStub<Itx>;
@@ -56,9 +56,14 @@ export function useItxQuery<TData>(options: UseItxQueryOptions<TData>): UseQuery
   const client = useItxClient();
   const { project, queryFn, ...queryOptions } = options;
   return useQuery({
-    // Access failures (forbidden/not-found) can't be retried away — surface
-    // them immediately instead of holding the pending state through retries.
-    retry: (failureCount, error) => !isItxAccessError(error) && failureCount < 1,
+    // Retry only what a retry could fix: code-less errors (socket/connection
+    // hiccups) and INTERNAL. Coded kernel failures (NOT_FOUND, FORBIDDEN,
+    // CONFLICT, BAD_REQUEST) are deterministic — surface them immediately
+    // instead of holding the pending state through retries.
+    retry: (failureCount, error) => {
+      const code = getItxErrorCode(error);
+      return (code === undefined || code === "INTERNAL") && failureCount < 1;
+    },
     ...queryOptions,
     queryFn: async () => await queryFn(await client.project(project)),
   });

--- a/apps/os/src/itx/react/index.ts
+++ b/apps/os/src/itx/react/index.ts
@@ -6,4 +6,4 @@ export { ItxProvider } from "./provider.tsx";
 export { useItxClient } from "./context.ts";
 export { itxKey, useItxQuery, useItxMutation } from "./hooks.ts";
 export { useStreamEvents } from "./use-stream-events.ts";
-export { isItxAccessError } from "./errors.ts";
+export { getItxErrorCode, isItxAccessError, type ItxErrorCode } from "./errors.ts";

--- a/apps/os/src/itx/react/stream-tail.test.ts
+++ b/apps/os/src/itx/react/stream-tail.test.ts
@@ -44,7 +44,7 @@ type RecordedSubscribe = {
 
 function createFakeClient() {
   let status: ItxConnectionStatus = "connected";
-  let failSubscribes: string | false = false;
+  let failSubscribes: Error | false = false;
   let serverEventCount = 0;
   let getStateImpl: (() => Promise<{ eventCount: number }>) | null = null;
   const statusListeners = new Set<() => void>();
@@ -58,7 +58,7 @@ function createFakeClient() {
         unsubscribe: vi.fn(),
       };
       subscribeCalls.push(call);
-      if (failSubscribes !== false) throw new Error(failSubscribes);
+      if (failSubscribes !== false) throw failSubscribes;
       return { unsubscribe: call.unsubscribe };
     },
   );
@@ -83,8 +83,8 @@ function createFakeClient() {
     subscribeCalls,
     subscribeStatus,
     getState,
-    setSubscribeFailing(fail: boolean, message = "subscribe exploded") {
-      failSubscribes = fail ? message : false;
+    setSubscribeFailing(fail: boolean, error?: Error) {
+      failSubscribes = fail ? (error ?? new Error("subscribe exploded")) : false;
     },
     /** What the server reports as eventCount when the liveness probe asks. */
     setServerEventCount(count: number) {
@@ -295,7 +295,15 @@ describe("acquireStreamTailStore", () => {
 
   test("access errors surface immediately and are never retried", async () => {
     const fake = createFakeClient();
-    fake.setSubscribeFailing(true, "Project prj_nope not found.");
+    // What an ItxError looks like after crossing capnweb: a plain Error with
+    // name and code reattached as own props (class identity is lost).
+    fake.setSubscribeFailing(
+      true,
+      Object.assign(new Error("Project prj_nope not found."), {
+        code: "NOT_FOUND",
+        name: "ItxError",
+      }),
+    );
     const store = acquireStreamTailStore(fake.client, "proj", "/itx");
 
     store.retain();

--- a/apps/os/src/itx/run.ts
+++ b/apps/os/src/itx/run.ts
@@ -29,7 +29,16 @@ export type ItxScriptOutcome = {
   durationMs: number;
   /** console.log/warn/error lines captured from the script's isolate. */
   logs: string[];
-} & ({ ok: true; result: unknown } | { ok: false; error: string; stack?: string });
+} & (
+  | { ok: true; result: unknown }
+  | {
+      ok: false;
+      error: string;
+      stack?: string;
+      /** The ItxError code when the script's throw carried one (errors.ts). */
+      code?: string;
+    }
+);
 
 /** Keep stream payloads bounded; the full value still returns to the caller. */
 const MAX_RECORDED_RESULT_CHARS = 64_000;
@@ -106,7 +115,7 @@ export async function runItxScript(input: {
 
     const raw = JSON.parse(await entrypoint.run(input.vars ?? {})) as { logs?: string[] } & (
       | { ok: true; result: unknown }
-      | { error: string; ok: false; stack?: string }
+      | { code?: string; error: string; ok: false; stack?: string }
     );
     outcome = {
       ...raw,
@@ -171,6 +180,7 @@ function itxRunWorkerSource(functionSource: string) {
           return JSON.stringify({ logs, ok: true, result });
         } catch (error) {
           return JSON.stringify({
+            code: typeof error?.code === "string" ? error.code : undefined,
             error: error instanceof Error ? error.message : String(error),
             logs,
             ok: false,

--- a/tasks/os-orpc-teardown.md
+++ b/tasks/os-orpc-teardown.md
@@ -26,9 +26,11 @@ rollback plan.
 
 ### Kernel hardening
 
-- [ ] `ItxError { code, message, details? }` serialized across capnweb and
-      rehydrated in the client core (codes: NOT_FOUND, FORBIDDEN, CONFLICT,
-      BAD_REQUEST). UI conversion of mutating pages waits on this.
+- [x] `ItxError { code, message, details? }` serialized across capnweb and
+      read back duck-typed in the client core (codes: NOT_FOUND, FORBIDDEN,
+      CONFLICT, BAD_REQUEST, INTERNAL; `onSendError` tags everything else
+      INTERNAL) — **PR #1456**, see `apps/os/src/itx/errors.ts` and
+      DECISIONS.md D18. UI conversion of mutating pages is unblocked.
 - [ ] `getServerItx(requestContext, target?)` — in-process handle for SSR
       loaders (resolveItx + accessForPrincipal); project-narrowed handle in
       route context under `$projectSlug`; seed QueryClient with the same


### PR DESCRIPTION
## What

Replaces the message-shape regex error detection in the itx react client with structured `ItxError`s thrown by the kernel and read back by code, end to end across capnweb. Immediate cutover: server and client deploy together; the regex is gone.

## Design

- **`apps/os/src/itx/errors.ts`** (new, transport-agnostic): `ItxError extends Error` with own **enumerable** `code` and optional `details` — exactly the properties capnweb (0.8.0) serializes (`["error", name, message, stack?, props?]`). The receiver reconstructs a plain `Error`, so detection is duck-typed via `getItxErrorCode(error)` — never `instanceof`. No rehydration layer.
- **Exactly five codes**: `NOT_FOUND`, `FORBIDDEN`, `CONFLICT`, `BAD_REQUEST`, `INTERNAL`. No UNAUTHORIZED — itx auth happens at connect (Law 3), so auth failures are transport-level 401s before a session exists.
- **Existence masking preserved**: `itx.projects.get` / context resolution answer byte-identical `NOT_FOUND` for missing AND forbidden, so error shapes can't be used to probe which project ids/slugs exist. `FORBIDDEN` only where existence is established or not secret (global streams, append policy, create/remove projects).
- **Tag, don't redact**: the `/api/itx` sessions get `onSendError: tagOutboundItxError` — every outbound non-ItxError becomes `ItxError { code: "INTERNAL" }` with the original message and stack preserved; returning the error from the hook is also what opts the stack into transmission (we trust our callers). capnweb's `newWorkersRpcResponse` wrapper takes no options, so `fetch.ts` re-implements its two-line dispatch as `newItxRpcResponse`.
- **`details` ships in v1**: throw sites attach what they have (`{ projectIdOrSlug }`, `{ path, policyMode }`, conflict slugs/ids).
- **`/api/itx/run`**: HTTP error bodies now carry `code` (400/403/404/500/503); the script isolate threads a thrown ItxError's `code` through its JSON outcome.
- **Client**: `useItxQuery` retries only code-less (socket) or `INTERNAL` errors, at most once; the stream-tail multiplexer keeps skipping retry exactly for access errors (`NOT_FOUND`/`FORBIDDEN`).

## Tests

- `react/errors.test.ts` rewritten: code-based detection, own-enumerability of `code`/`details` (the load-bearing wire property), simulated capnweb crossing (instanceof lost, code/details survive), `tagOutboundItxError`.
- `stream-tail.test.ts`: access-error case now throws the post-capnweb shape (plain Error + name/code).
- Worker harness (`pnpm test:itx-stream-subscribe`): new case proves `code`/`details` survive **real Workers RPC** hops (StreamsCapability → loopback → harness → test) — 9/9 pass, so kernel throws born behind the loopback keep their codes on the way to capnweb.
- e2e (`itx.e2e.test.ts`): `itx.projects.get("definitely-not-a-project")` rejects with name `ItxError`, code `NOT_FOUND`, details — runs against a deployment in preview CI.

## Docs

- Doc comments on `ItxError` (wire mechanics, taxonomy, masking, posture) and the `onSendError` wiring.
- `DECISIONS.md` D18; oRPC replacement plan: kernel-hardening item recorded as done, "Error opacity" risk removed; task checkbox ticked.

## Verification

`pnpm typecheck && pnpm lint && pnpm format && pnpm test` all green at repo root; `pnpm test:itx-stream-subscribe` 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth-sensitive error shapes (existence masking), all /api/itx RPC sessions, and client retry behavior; coordinated deploy required but well-tested across RPC boundaries.
> 
> **Overview**
> Introduces **`ItxError`** with five codes (`NOT_FOUND`, `FORBIDDEN`, `CONFLICT`, `BAD_REQUEST`, `INTERNAL`) as own enumerable props so capnweb can serialize them; clients detect errors via **`getItxErrorCode`** / **`isItxAccessError`**, not `instanceof` or message regexes.
> 
> Kernel throw sites in **`handle.ts`**, **`streams-capability.ts`**, and related paths now raise **`ItxError`** with masking preserved (`NOT_FOUND` for missing and forbidden projects). **`fetch.ts`** wires **`onSendError: tagOutboundItxError`** through a custom **`newItxRpcResponse`** (non-ItxErrors become `INTERNAL` with stack); HTTP **`/api/itx/run`** and connect failures return JSON **`code`** fields. Script runner threads **`code`** through isolate JSON outcomes.
> 
> React layer drops regex-based access-error detection; **`useItxQuery`** retries only code-less or **`INTERNAL`** errors; stream-tail tests use post-capnweb error shapes. Docs (**D18**, plan, teardown task) mark kernel error hardening done. New e2e and worker-harness tests assert **`code`/`details`** survive capnweb and Workers RPC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7661b13c50d05979bbaff9ad0791bfd9bfab1139. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T14:45:38.214Z",
      "headSha": "7661b13c50d05979bbaff9ad0791bfd9bfab1139",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27283560542",
      "shortSha": "7661b13"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `7661b13`
Preview: https://os.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27283560542)
Updated: 2026-06-10T14:45:38.214Z
<!-- /CLOUDFLARE_PREVIEW -->