### PR TITLE
fix(streams): Stage 3 — source-field crash + circuit-breaker bugs (M2/M3/M4)

### DIFF
--- a/packages/streams/src/processors/circuit-breaker/contract.ts
+++ b/packages/streams/src/processors/circuit-breaker/contract.ts
@@ -72,13 +72,16 @@ export function spendCircuitBreakerToken(args: {
   event: { createdAt: string };
 }): CircuitBreakerProcessorState {
   const createdAtMs = Date.parse(args.event.createdAt);
+  // Clamp the elapsed time to >= 0. createdAt is per-event wall clock, so DO
+  // migration or clock skew can make it regress; without the clamp a negative
+  // delta would *subtract* refill and instantly drain the bucket into a false trip.
+  const elapsedMs = Math.max(0, createdAtMs - (args.state.lastRefillAtMs ?? createdAtMs));
   const refilled =
     args.state.lastRefillAtMs === null
       ? args.state.burstCapacity
       : Math.min(
           args.state.burstCapacity,
-          args.state.availableTokens +
-            (createdAtMs - args.state.lastRefillAtMs) * (args.state.refillRatePerMinute / 60_000),
+          args.state.availableTokens + elapsedMs * (args.state.refillRatePerMinute / 60_000),
         );
 
   return {

--- a/packages/streams/src/processors/circuit-breaker/implementation.ts
+++ b/packages/streams/src/processors/circuit-breaker/implementation.ts
@@ -51,8 +51,14 @@ export class CircuitBreakerProcessor extends StreamProcessor<CircuitBreakerContr
   protected override processEvent(
     args: Parameters<StreamProcessor<CircuitBreakerContract>["processEvent"]>[0],
   ): void {
+    // Level-triggered, not edge-triggered: fire whenever the bucket is in deficit
+    // on a live event. An edge guard (`!tripped(previousState)`) would miss the
+    // common case where the not-tripped->tripped transition happened at or below
+    // the side-effect anchor during replay — processEvent isn't called there, so
+    // the live flood that follows would never pause. The pause append is
+    // idempotency-keyed per offset and self-limits: once the stream is paused,
+    // ordinary appends are rejected, so the breaker stops being fed.
     if (!shouldTripCircuitBreaker(args.state)) return;
-    if (shouldTripCircuitBreaker(args.previousState)) return;
     if (args.event.type === "events.iterate.com/stream/paused") return;
     args.runInBackground(async () => {
       await this.ctx.stream.append({

--- a/packages/streams/src/shared/event.ts
+++ b/packages/streams/src/shared/event.ts
@@ -39,24 +39,24 @@ export const streamEventOffsetSchema = z.number().int().nonnegative();
 export const StreamEventCreatedAt = z.string();
 export const streamEventCreatedAtIsoSchema = z.iso.datetime({ offset: true });
 export const streamEventPathSchema = z.string().trim().min(1);
+// Shared so the runner-side parsers (getEventSchema / getEventInputSchema) accept
+// the same `source` shape the DO append accepts; otherwise an event carrying a
+// `source` commits but then throws "Unrecognized key" in the inline reduce.
+export const StreamEventSourceSchema = z
+  .object({
+    processor: z.object({ slug: z.string(), version: z.string() }).strict().optional(),
+  })
+  .strict();
+// Trim/min(1) here matches getEventSchema so a blank key can't pass append input
+// and then fail validation in reduce.
+export const streamEventIdempotencyKeySchema = z.string().trim().min(1);
 
 export const StreamEventInput = z.object({
   type: z.string(),
   payload: z.unknown().optional(),
   metadata: StreamEventMetadata.optional(),
-  source: z
-    .object({
-      processor: z
-        .object({
-          slug: z.string(),
-          version: z.string(),
-        })
-        .strict()
-        .optional(),
-    })
-    .strict()
-    .optional(),
-  idempotencyKey: z.string().optional(),
+  source: StreamEventSourceSchema.optional(),
+  idempotencyKey: streamEventIdempotencyKeySchema.optional(),
   /** Precondition: must equal the next offset when set. */
   offset: streamEventOffsetSchema.optional(),
 });

--- a/packages/streams/src/shared/rpc-target.ts
+++ b/packages/streams/src/shared/rpc-target.ts
@@ -26,19 +26,24 @@ export function makeRpcTargetClass<
   const TExcluded extends keyof TSource = never,
 >(
   sourceClass: { prototype: TSource },
-  options?: { exclude?: readonly TExcluded[] },
+  options?: { exclude?: readonly TExcluded[]; include?: readonly PropertyKey[] },
 ): RpcTargetClass<RpcMethods<TSource, TExcluded>, TSource>;
 
 export function makeRpcTargetClass<TApi extends object, TSource extends object = TApi>(
   sourceClass: { prototype: TSource },
-  options?: { exclude?: readonly PropertyKey[] },
+  options?: { exclude?: readonly PropertyKey[]; include?: readonly PropertyKey[] },
 ): RpcTargetClass<TApi, TSource>;
 
 export function makeRpcTargetClass<TSource extends object>(
   sourceClass: { prototype: TSource },
-  options: { exclude?: readonly PropertyKey[] } = {},
+  options: { exclude?: readonly PropertyKey[]; include?: readonly PropertyKey[] } = {},
 ): RpcTargetClass<object, TSource> {
   const exclude = new Set<PropertyKey>(["constructor", ...(options.exclude ?? [])]);
+  // When `include` is given it is an allowlist: only those methods are proxied.
+  // Prefer it for classes with internal (e.g. `protected`) methods — `protected`
+  // does not exist at runtime, so a denylist silently leaks any method not
+  // explicitly excluded.
+  const include = options.include === undefined ? undefined : new Set<PropertyKey>(options.include);
 
   class GeneratedRpcTarget extends RpcTarget {
     constructor(readonly source: TSource) {
@@ -50,6 +55,9 @@ export function makeRpcTargetClass<TSource extends object>(
     Object.getOwnPropertyDescriptors(sourceClass.prototype),
   )) {
     if (exclude.has(key)) {
+      continue;
+    }
+    if (include !== undefined && !include.has(key)) {
       continue;
     }
 

--- a/packages/streams/src/shared/stream-processors.ts
+++ b/packages/streams/src/shared/stream-processors.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
 import {
   streamEventCreatedAtIsoSchema,
+  streamEventIdempotencyKeySchema,
   StreamEventMetadata,
   streamEventOffsetSchema,
+  StreamEventSourceSchema,
   type StreamEvent,
   type StreamEventInput,
 } from "./event.ts";
@@ -547,7 +549,8 @@ export function getEventInputSchema<
     type: z.literal(args.type),
     payload: args.payloadSchema,
     metadata: StreamEventMetadata.optional(),
-    idempotencyKey: z.string().trim().min(1).optional(),
+    source: StreamEventSourceSchema.optional(),
+    idempotencyKey: streamEventIdempotencyKeySchema.optional(),
     offset: streamEventOffsetSchema.optional(),
   }) as unknown as z.ZodType<
     StreamEventInput<Type, z.output<PayloadSchema>>,
@@ -583,7 +586,8 @@ export function getEventSchema<
     type: z.literal(args.type),
     payload: args.payloadSchema,
     metadata: StreamEventMetadata.optional(),
-    idempotencyKey: z.string().trim().min(1).optional(),
+    source: StreamEventSourceSchema.optional(),
+    idempotencyKey: streamEventIdempotencyKeySchema.optional(),
     offset: streamEventOffsetSchema,
     createdAt: streamEventCreatedAtIsoSchema,
   }) as unknown as z.ZodType<

--- a/packages/streams/src/stream-processor.ts
+++ b/packages/streams/src/stream-processor.ts
@@ -366,14 +366,21 @@ export abstract class StreamProcessor<
       await Promise.all(blockingWork);
     } catch (error) {
       // A failed batch must still settle work it already registered so nothing
-      // rejects unobserved. The checkpoint is not written; the batch retries.
+      // rejects unobserved. The checkpoint is not written, so the batch stays
+      // retryable — the host re-handshakes from the checkpoint on failure and
+      // the stream replays it (see createStreamProcessorHost).
       await Promise.allSettled(blockingWork);
       throw error;
     }
 
+    // Persist before advancing in-memory state. If the durable write fails, the
+    // batch must stay retryable: the redelivered batch re-reduces from the old
+    // state and tries the write again. Advancing #state/#checkpointOffset first
+    // would make the retry a silent no-op (every event filtered out, nothing
+    // re-saved), so a transient write failure would lose the batch durably.
+    await this.#writeState({ offset: checkpointOffset, state });
     this.#state = state;
     this.#checkpointOffset = checkpointOffset;
-    await this.#saveSnapshot();
   }
 
   // keepAliveWhile is fire-and-forget from the host's point of view (it only
@@ -418,12 +425,5 @@ export abstract class StreamProcessor<
   #getState(): ProcessorState<Contract> {
     this.#state ??= getInitialProcessorState(this.contract);
     return this.#state;
-  }
-
-  async #saveSnapshot(): Promise<void> {
-    await this.#writeState({
-      offset: this.#checkpointOffset,
-      state: this.#getState(),
-    });
   }
 }

--- a/packages/streams/src/stream-review-regressions.test.ts
+++ b/packages/streams/src/stream-review-regressions.test.ts
@@ -99,6 +99,7 @@ function fakeStream() {
   const hostAppends: StreamEventInput[] = [];
   let deliver: ((batch: StreamEventBatch) => unknown) | undefined;
   let cursor = 0;
+  let subscribeFailures = 0; // make the next N subscribeOutbound calls throw
 
   const pump = () => {
     if (deliver === undefined) return;
@@ -132,6 +133,10 @@ function fakeStream() {
       replayAfterOffset?: number;
       processEventBatch: (batch: StreamEventBatch) => unknown;
     }) {
+      if (subscribeFailures > 0) {
+        subscribeFailures -= 1;
+        throw new Error("subscribeOutbound boom");
+      }
       deliver = args.processEventBatch;
       cursor = args.replayAfterOffset ?? 0;
       queueMicrotask(pump);
@@ -154,7 +159,14 @@ function fakeStream() {
 
   // External producer: append a user event to the stream (drives delivery).
   const produce = (input: StreamEventInput) => push(input);
-  return { stream, produce, hostAppends };
+  return {
+    stream,
+    produce,
+    hostAppends,
+    failNextSubscribes: (count: number) => {
+      subscribeFailures = count;
+    },
+  };
 }
 
 const subscribeArgs = (stream: ReturnType<typeof fakeStream>["stream"]) => ({
@@ -237,6 +249,48 @@ describe("T1b — a poison batch records an error and disconnects (C1 poison pol
       (event) => event.type === "events.iterate.com/stream/error-occurred",
     );
     expect(errorEvents).toHaveLength(1);
+  });
+});
+
+describe("T1c — a failed recovery must not permanently wedge the ingest chain (C1)", () => {
+  // The ingest chain is extended with `.then(...)`; if recovery throws (the
+  // re-handshake or poison append fails) the chain must not stay rejected, or
+  // every later batch's handler would be skipped. A subsequent re-handshake must
+  // still be able to make progress.
+  it("keeps processing after a re-handshake when the first recovery threw", async () => {
+    const { ctx, settle } = fakeDurableObjectCtx();
+    const fake = fakeStream();
+    const host = createStreamProcessorHost(ctx);
+
+    let failOnAdd = true;
+    host.add(
+      "counter",
+      (deps) =>
+        new CounterProcessor({
+          ...deps,
+          onBatch: ({ events }) => {
+            if (failOnAdd && events.some((event) => event.type === "test/add")) {
+              failOnAdd = false;
+              throw new Error("transient ingest failure");
+            }
+          },
+        }),
+    );
+
+    await host.requestStreamSubscription(subscribeArgs(fake.stream));
+    await settle();
+
+    // The add fails, recovery re-handshakes — and that resubscribe throws.
+    fake.failNextSubscribes(1);
+    fake.produce({ type: "test/add", payload: { amount: 5 } });
+    await settle();
+
+    // A fresh handshake (as the stream's reconcile would do) must still recover
+    // the add. If the chain were left rejected, this would never be processed.
+    await host.requestStreamSubscription(subscribeArgs(fake.stream));
+    await settle();
+
+    expect(host.runtimeState("counter").snapshot?.state).toEqual({ total: 5 });
   });
 });
 

--- a/packages/streams/src/stream-review-regressions.test.ts
+++ b/packages/streams/src/stream-review-regressions.test.ts
@@ -325,9 +325,8 @@ describe("T2 — writeState failure advances the in-memory checkpoint (C2)", () 
 });
 
 describe("T5 — circuit-breaker token bucket on a backwards clock (M3)", () => {
-  // FAILS until M3 is fixed (clamp the refill delta with Math.max(0, ...)).
-  // Flip `it.fails` -> `it` once Stage 1 lands.
-  it.fails("does not drain the bucket when createdAt regresses", () => {
+  // Fixed in Stage 3: the refill delta is clamped with Math.max(0, ...).
+  it("does not drain the bucket when createdAt regresses", () => {
     const next = spendCircuitBreakerToken({
       state: {
         availableTokens: 5,
@@ -344,9 +343,9 @@ describe("T5 — circuit-breaker token bucket on a backwards clock (M3)", () => 
 });
 
 describe("T6 — circuit-breaker misses a flood after tripping during replay (M4)", () => {
-  // FAILS until M4 is fixed (fire the trip when tripped && offset > anchor &&
-  // !pausedYet, not only on the not-tripped->tripped edge). Flip once fixed.
-  it.fails("pauses on live events even when it tripped at/below the anchor", async () => {
+  // Fixed in Stage 3: the trip is level-triggered (fires whenever the bucket is
+  // in deficit on a live event), not edge-triggered on the previous state.
+  it("pauses on live events even when it tripped at/below the anchor", async () => {
     const committed: StreamEvent[] = [];
     const processor = new CircuitBreakerProcessor({
       iterateContext: {

--- a/packages/streams/src/stream-review-regressions.test.ts
+++ b/packages/streams/src/stream-review-regressions.test.ts
@@ -1,19 +1,19 @@
 // Regression tests from the June 2026 packages/streams review.
 // See tasks/streams-review-fixes.md — each test is tagged with its finding id.
 //
-// Tests for bugs that are not yet fixed use `it.fails`: they PASS today because
-// the asserted (correct) behavior currently throws/mismatches, and they will
-// START FAILING the moment the bug is fixed — at which point flip `it.fails`
-// back to `it`. This keeps `pnpm test` green while pinning the bug precisely.
+// Tests for bugs that are still unfixed use `it.fails`: they PASS today because
+// the asserted (correct) behavior currently throws/mismatches, and they START
+// FAILING the moment the bug is fixed — at which point flip `it.fails` back to
+// `it`. This keeps `pnpm test` green while pinning the bug precisely.
 //
-// T3/T4/T7/T8 from the plan exercise the Stream Durable Object (SQL storage) and
-// need a vitest-pool-workers harness that this package does not have yet; they
-// are tracked in Stage 0 of the task and land with that harness.
+// Status: C1 (T1/T1b) and C2 (T2) are fixed in Stage 1 and now pass as `it`.
+// M3 (T5) and M4 (T6) remain `it.fails` until Stage 3. The Stream DO tests
+// (T3/T4/T7/T8) live in workers/durable-objects/stream.workers.test.ts.
 
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { defineProcessorContract } from "./shared/stream-processors.ts";
-import type { StreamEvent } from "./shared/event.ts";
+import type { StreamEvent, StreamEventInput } from "./shared/event.ts";
 import type { StreamEventBatch } from "./types.ts";
 import { StreamProcessor, type StreamProcessorSnapshot } from "./stream-processor.ts";
 import { createStreamProcessorHost } from "./workers/stream-processor-host.ts";
@@ -39,7 +39,7 @@ const CounterContract = defineProcessorContract({
   emits: [],
 });
 type CounterContract = typeof CounterContract;
-type CounterDeps = { onBatch?: () => void };
+type CounterDeps = { onBatch?: (args: { events: readonly StreamEvent[] }) => void };
 
 class CounterProcessor extends StreamProcessor<CounterContract, CounterDeps> {
   readonly contract = CounterContract;
@@ -49,7 +49,7 @@ class CounterProcessor extends StreamProcessor<CounterContract, CounterDeps> {
   protected override async processEventBatch(
     args: Parameters<StreamProcessor<CounterContract>["processEventBatch"]>[0],
   ): Promise<void> {
-    this.deps.onBatch?.();
+    this.deps.onBatch?.({ events: args.events });
     await super.processEventBatch(args);
   }
 }
@@ -59,7 +59,8 @@ function add(offset: number, amount: number): StreamEvent {
 }
 
 // An in-memory DurableObjectState stub: just the kv + waitUntil surface the host
-// touches. waitUntil work is collected so tests can await it.
+// touches. `settle()` drains the collected waitUntil work, including the chains
+// spawned by recovery, until it goes quiet.
 function fakeDurableObjectCtx() {
   const map = new Map<string, unknown>();
   const pending: Promise<unknown>[] = [];
@@ -72,84 +73,177 @@ function fakeDurableObjectCtx() {
     },
     waitUntil: (work: Promise<unknown>) => void pending.push(work),
   };
-  return { ctx: ctx as unknown as DurableObjectState, settle: () => Promise.allSettled(pending) };
-}
-
-// A fake stream stub + pump that faithfully mimics the Stream DO delivery path
-// (stream.ts #openConnection): the cursor advances to the last offset BEFORE
-// delivery, and the batch result is fire-and-forget — a failed batch is never
-// re-delivered on a live connection.
-function fakeStreamWithPump() {
-  let processEventBatch: ((batch: StreamEventBatch) => unknown) | undefined;
-  const delivered: Promise<unknown>[] = [];
-  const stream = {
-    subscribeOutbound(args: { processEventBatch: (batch: StreamEventBatch) => unknown }) {
-      processEventBatch = args.processEventBatch;
-      return { subscriptionKey: "k", streamMaxOffset: 0, unsubscribe() {} };
-    },
-    append: (input: unknown) => input,
-    appendBatch: (input: unknown) => input,
-  };
-  function pump(events: StreamEvent[]) {
-    if (processEventBatch === undefined) throw new Error("not subscribed");
-    // cursor would advance here; we just hand the batch over and never await it.
-    const result = processEventBatch({
-      namespace: "stream",
-      path: "/r",
-      events,
-      streamMaxOffset: 0,
-    });
-    if (result instanceof Promise) delivered.push(result.catch(() => undefined));
+  async function settle() {
+    let idleFlushes = 0;
+    for (let i = 0; i < 500 && idleFlushes < 3; i += 1) {
+      await tick(); // flush microtasks + queued pumps
+      if (pending.length === 0) {
+        idleFlushes += 1;
+        continue;
+      }
+      idleFlushes = 0;
+      await Promise.allSettled(pending.splice(0));
+    }
   }
-  return { stream, pump, settle: () => Promise.allSettled(delivered) };
+  return { ctx: ctx as unknown as DurableObjectState, settle };
 }
 
-describe("T1 — a swallowed ingest failure permanently drops events (C1)", () => {
-  // FAILS until C1 is fixed (host must resubscribe from the checkpoint on
-  // ingest failure). Flip `it.fails` -> `it` once Stage 1 lands.
-  it.fails("redelivers a failed batch instead of skipping past it", async () => {
-    const { ctx, settle: settleCtx } = fakeDurableObjectCtx();
-    const { stream, pump, settle: settlePump } = fakeStreamWithPump();
+// A faithful in-memory stream: an append log plus one live subscriber whose pump
+// mirrors stream.ts #openConnection — it advances the cursor and fire-and-forgets
+// each batch, and `subscribeOutbound({ replayAfterOffset })` replays everything
+// past that offset. This is what makes the host's resubscribe-from-checkpoint
+// recovery actually redeliver. `append` (used by the host for processor-registered
+// / error-occurred events) is recorded so tests can assert on it.
+function fakeStream() {
+  const log: StreamEvent[] = [];
+  const hostAppends: StreamEventInput[] = [];
+  let deliver: ((batch: StreamEventBatch) => unknown) | undefined;
+  let cursor = 0;
+
+  const pump = () => {
+    if (deliver === undefined) return;
+    const batch = log.filter((event) => event.offset > cursor);
+    if (batch.length === 0) return;
+    cursor = batch.at(-1)!.offset;
+    void Promise.resolve(
+      deliver({
+        namespace: "stream",
+        path: "/r",
+        events: batch,
+        streamMaxOffset: log.at(-1)?.offset ?? 0,
+      }),
+    ).catch(() => undefined);
+  };
+
+  const push = (input: StreamEventInput): StreamEvent => {
+    const event: StreamEvent = {
+      ...input,
+      offset: (log.at(-1)?.offset ?? 0) + 1,
+      createdAt: iso(),
+    };
+    log.push(event);
+    pump();
+    return event;
+  };
+
+  const stream = {
+    subscribeOutbound(args: {
+      subscriptionKey?: string;
+      replayAfterOffset?: number;
+      processEventBatch: (batch: StreamEventBatch) => unknown;
+    }) {
+      deliver = args.processEventBatch;
+      cursor = args.replayAfterOffset ?? 0;
+      queueMicrotask(pump);
+      return {
+        subscriptionKey: args.subscriptionKey ?? "k",
+        streamMaxOffset: log.at(-1)?.offset ?? 0,
+        unsubscribe() {
+          if (deliver === args.processEventBatch) deliver = undefined;
+        },
+      };
+    },
+    append(args: { event: StreamEventInput }) {
+      hostAppends.push(args.event);
+      return push(args.event);
+    },
+    appendBatch(args: { events: StreamEventInput[] }) {
+      return args.events.map(push);
+    },
+  };
+
+  // External producer: append a user event to the stream (drives delivery).
+  const produce = (input: StreamEventInput) => push(input);
+  return { stream, produce, hostAppends };
+}
+
+const subscribeArgs = (stream: ReturnType<typeof fakeStream>["stream"]) => ({
+  stream: stream as never,
+  subscriptionKey: "k",
+  streamMaxOffset: 0,
+  subscriptionConfiguredEvent: { offset: 0 } as never,
+  streamRuntimeState: { coreProcessorState: { namespace: "stream", path: "/r" } as never },
+});
+
+describe("T1 — a failed batch must not drop events under continued delivery (C1)", () => {
+  // Fixed in Stage 1: on ingest failure the host re-handshakes from the durable
+  // checkpoint and the stream replays the batch; batches delivered on the
+  // superseded connection are dropped so a later one can't advance the
+  // checkpoint past the gap.
+  it("recovers a transient failure even while later events keep arriving", async () => {
+    const { ctx, settle } = fakeDurableObjectCtx();
+    const { stream, produce } = fakeStream();
     const host = createStreamProcessorHost(ctx);
 
-    let failNextBatch = true;
+    let failOnAdd = true;
     host.add(
       "counter",
       (deps) =>
         new CounterProcessor({
           ...deps,
-          onBatch: () => {
-            if (failNextBatch) {
-              failNextBatch = false;
+          onBatch: ({ events }) => {
+            // Fail the first delivery that carries a user add, once.
+            if (failOnAdd && events.some((event) => event.type === "test/add")) {
+              failOnAdd = false;
               throw new Error("transient ingest failure");
             }
           },
         }),
     );
 
-    await host.requestStreamSubscription({
-      stream: stream as never,
-      subscriptionKey: "k",
-      streamMaxOffset: 0,
-      subscriptionConfiguredEvent: { offset: 0 } as never,
-      streamRuntimeState: { coreProcessorState: { namespace: "stream", path: "/r" } as never },
-    });
+    await host.requestStreamSubscription(subscribeArgs(stream));
+    await settle(); // process the auto-appended processor-registered event
 
-    pump([add(1, 5)]); // fails, swallowed; cursor advances past offset 1
-    await tick();
-    pump([add(2, 7)]); // succeeds
-    await settlePump();
-    await settleCtx();
+    // Two adds arrive close together: the first fails, the second is delivered
+    // on the same (now superseded) connection before recovery completes.
+    produce({ type: "test/add", payload: { amount: 5 } });
+    produce({ type: "test/add", payload: { amount: 7 } });
+    await settle();
 
-    // Both events must end up in reduced state. Today event 1 is lost forever.
+    // Neither add may be lost: 5 + 7.
     expect(host.runtimeState("counter").snapshot?.state).toEqual({ total: 12 });
   });
 });
 
+describe("T1b — a poison batch records an error and disconnects (C1 poison policy)", () => {
+  it("appends stream/error-occurred and stops after repeated failures", async () => {
+    const { ctx, settle } = fakeDurableObjectCtx();
+    const { stream, produce, hostAppends } = fakeStream();
+    const host = createStreamProcessorHost(ctx);
+
+    host.add(
+      "counter",
+      (deps) =>
+        new CounterProcessor({
+          ...deps,
+          onBatch: ({ events }) => {
+            if (events.some((event) => event.type === "test/add")) {
+              throw new Error("poison batch");
+            }
+          },
+        }),
+    );
+
+    await host.requestStreamSubscription(subscribeArgs(stream));
+    await settle();
+
+    produce({ type: "test/add", payload: { amount: 5 } });
+    await settle();
+
+    // The processor never advanced (the add never ingested) ...
+    expect(host.runtimeState("counter").snapshot?.state).toEqual({ total: 0 });
+    // ... and the host recorded the failure on the stream then disconnected.
+    const errorEvents = hostAppends.filter(
+      (event) => event.type === "events.iterate.com/stream/error-occurred",
+    );
+    expect(errorEvents).toHaveLength(1);
+  });
+});
+
 describe("T2 — writeState failure advances the in-memory checkpoint (C2)", () => {
-  // FAILS until C2 is fixed (assign #state/#checkpointOffset only after
-  // #saveSnapshot succeeds). Flip `it.fails` -> `it` once Stage 1 lands.
-  it.fails("persists a snapshot when a writeState failure is retried", async () => {
+  // Fixed in Stage 1: the snapshot is written before #state/#checkpointOffset
+  // advance, so a failed write leaves the batch retryable.
+  it("persists a snapshot when a writeState failure is retried", async () => {
     const writes: StreamProcessorSnapshot<{ total: number }>[] = [];
     let failNextWrite = true;
     const processor = new CounterProcessor({

--- a/packages/streams/src/workers/durable-objects/stream.ts
+++ b/packages/streams/src/workers/durable-objects/stream.ts
@@ -800,15 +800,32 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
   }
 }
 
+// Allowlist the RPC surface explicitly. The Stream DO has `protected` helpers
+// (readCoreProcessorState/writeCoreProcessorState) that are public at runtime;
+// a denylist would leak them onto the unauthenticated PublicStreamRpcTarget,
+// where writeCoreProcessorState could inject an attacker-chosen subscription
+// callable. `subscribe` is intentionally absent: installSubscribeRpcTargetOverride
+// adds its own forwarding implementation below.
+const STREAM_RPC_METHODS = [
+  "append",
+  "appendBatch",
+  "getEvent",
+  "getEvents",
+  "runtimeState",
+  "reduce",
+  "kill",
+  "reset",
+] as const satisfies readonly (keyof StreamRpc)[];
+
 export const StreamRpcTarget = makeRpcTargetClass<StreamRpc, StreamRpc>(
   Stream as { prototype: StreamRpc },
-  { exclude: ["subscribe"] },
+  { include: [...STREAM_RPC_METHODS, "subscribeOutbound"] },
 );
 installSubscribeRpcTargetOverride(StreamRpcTarget);
 
 export const PublicStreamRpcTarget = makeRpcTargetClass<StreamRpc, StreamRpc>(
   Stream as { prototype: StreamRpc },
-  { exclude: ["subscribe", "subscribeOutbound"] },
+  { include: STREAM_RPC_METHODS },
 );
 installSubscribeRpcTargetOverride(PublicStreamRpcTarget);
 

--- a/packages/streams/src/workers/durable-objects/stream.workers.test.ts
+++ b/packages/streams/src/workers/durable-objects/stream.workers.test.ts
@@ -31,9 +31,9 @@ function freshStream() {
 }
 
 describe("T3 — PublicStreamRpcTarget must not expose protected DO methods (C3)", () => {
-  // FAILS until C3 is fixed (makeRpcTargetClass should allowlist the StreamRpc
-  // API instead of copying every prototype method). Flip `it.fails` -> `it`.
-  it.fails("does not proxy readCoreProcessorState / writeCoreProcessorState", () => {
+  // Fixed in Stage 1: makeRpcTargetClass now allowlists the StreamRpc API, so
+  // the protected core-state helpers are no longer proxied.
+  it("does not proxy readCoreProcessorState / writeCoreProcessorState", () => {
     const exposed = Object.getOwnPropertyNames(PublicStreamRpcTarget.prototype);
     expect(exposed).not.toContain("writeCoreProcessorState");
     expect(exposed).not.toContain("readCoreProcessorState");

--- a/packages/streams/src/workers/durable-objects/stream.workers.test.ts
+++ b/packages/streams/src/workers/durable-objects/stream.workers.test.ts
@@ -41,9 +41,9 @@ describe("T3 — PublicStreamRpcTarget must not expose protected DO methods (C3)
 });
 
 describe("T4 — events carrying a `source` field must commit (M2)", () => {
-  // FAILS until M2 is fixed (getEventSchema is strict and omits `source`, so the
-  // inline core reduce throws "Unrecognized key: source"). Flip once fixed.
-  it.fails("appends and reads back an event with a source", async () => {
+  // Fixed in Stage 3: getEventSchema / getEventInputSchema now accept `source`
+  // (shared StreamEventSourceSchema), matching the DO append.
+  it("appends and reads back an event with a source", async () => {
     await runInDurableObject(freshStream(), async (stream) => {
       const committed = await stream.append({
         event: {

--- a/packages/streams/src/workers/stream-processor-host.ts
+++ b/packages/streams/src/workers/stream-processor-host.ts
@@ -87,7 +87,24 @@ type HostedEntry = {
   handle: StreamSubscriptionHandle | undefined;
   namespace: string | undefined;
   path: string | undefined;
+  /** Consecutive ingest failures since the last successful batch. */
+  consecutiveIngestFailures: number;
+  /**
+   * Bumped on every (re)subscription. Batches delivered on a superseded
+   * generation are dropped instead of ingested — see the gate in
+   * `openSubscription`.
+   */
+  generation: number;
+  /** Serializes ingest per processor so the generation gate is re-checked between batches. */
+  ingestChain: Promise<void>;
 };
+
+// A failed batch does not advance the checkpoint, so we re-handshake from it and
+// the stream replays the batch — this recovers transient failures. A batch that
+// keeps failing is poison: after this many consecutive failures we stop retrying,
+// record a stream/error-occurred event, and disconnect, leaving it to the
+// subscriber/processor (or a later re-dial) to decide whether to re-establish.
+const MAX_CONSECUTIVE_INGEST_FAILURES = 3;
 
 export type StreamProcessorHost = {
   /**
@@ -138,6 +155,100 @@ export function createStreamProcessorHost(ctx: DurableObjectState): StreamProces
     );
   }
 
+  // (Re)opens the outbound subscription from the processor's durable checkpoint.
+  // Called for the initial handshake and again by `recoverFromIngestFailure`, so
+  // a failed batch replays from the last good offset instead of being skipped.
+  async function openSubscription(name: string): Promise<void> {
+    const entry = requireEntry(name);
+    const stream = entry.stream;
+    if (stream === undefined) {
+      throw new Error(`Stream processor "${name}" cannot subscribe before its stream is retained`);
+    }
+    const subscriptionKey = ctx.storage.kv.get<string>(subscriptionKeyKey(name));
+    if (subscriptionKey === undefined) {
+      throw new Error(`Stream processor "${name}" has no stored subscription key`);
+    }
+    // Each (re)subscription is a generation. The pump is fire-and-forget, so
+    // while a failed batch recovers the stream keeps delivering later batches;
+    // ingesting one of those would advance the checkpoint past the failed offset
+    // and lose it. Capturing the generation and dropping batches from a
+    // superseded connection makes the post-recovery replay the single source of
+    // truth.
+    const generation = entry.generation;
+    const snapshot = await entry.processor.snapshot();
+    entry.handle = await (stream as OutboundStreamRpc).subscribeOutbound({
+      subscriptionKey,
+      replayAfterOffset: snapshot.offset,
+      // The contract is the filter: the stream only delivers event types the
+      // processor consumes. A `"*"` in consumes means unfiltered delivery.
+      eventTypes: entry.processor.contract.consumes,
+      processEventBatch: (batch) => {
+        // Serialize ingest per processor so the generation gate is re-checked
+        // *between* batches: a batch queued on a now-dead connection must be
+        // dropped, not ingested. ingest serializes internally too, but that
+        // can't drop a batch that was already accepted.
+        entry.ingestChain = entry.ingestChain.then(async () => {
+          if (generation !== entry.generation) return; // superseded connection; replay covers it
+          try {
+            await entry.processor.ingest(batch);
+            entry.consecutiveIngestFailures = 0;
+          } catch (error) {
+            await recoverFromIngestFailure(name, error);
+          }
+        });
+        // waitUntil keeps the DO alive through ingest + recovery after the RPC
+        // callback returns.
+        ctx.waitUntil(entry.ingestChain);
+        return entry.ingestChain;
+      },
+    });
+  }
+
+  // A failed batch never advances the checkpoint. Re-handshake from it (the
+  // stream replays the batch) to recover transient failures; give up and
+  // disconnect once a batch proves poison.
+  async function recoverFromIngestFailure(name: string, error: unknown): Promise<void> {
+    const entry = requireEntry(name);
+    entry.consecutiveIngestFailures += 1;
+    console.error(
+      `stream processor "${name}" failed to ingest batch (attempt ${entry.consecutiveIngestFailures})`,
+      error,
+    );
+
+    // Invalidate the current connection so its already-delivered batches are
+    // dropped by the generation gate, then tear it down.
+    entry.generation += 1;
+    entry.handle?.unsubscribe();
+    entry.handle = undefined;
+
+    if (entry.consecutiveIngestFailures <= MAX_CONSECUTIVE_INGEST_FAILURES) {
+      // Transient: re-handshake from the durable checkpoint; the stream replays
+      // the failed batch (replay is idempotent — events <= checkpoint filter out).
+      await openSubscription(name);
+      return;
+    }
+
+    // Poison batch: stop retrying, record the failure on the stream, and stay
+    // disconnected. It is up to the subscriber/processor (or a later re-dial) to
+    // decide whether to re-establish the subscription.
+    const offset = (await entry.processor.snapshot()).offset;
+    const message = (error instanceof Error ? error.message : String(error)) || "unknown error";
+    await entry.stream?.append({
+      event: {
+        type: "events.iterate.com/stream/error-occurred",
+        idempotencyKey: `processor-ingest-failed:${name}:${offset}`,
+        payload: {
+          message: `stream processor "${name}" gave up after ${entry.consecutiveIngestFailures} failed ingest attempts at offset ${offset}`,
+          error: {
+            message,
+            ...(error instanceof Error && error.name ? { name: error.name } : {}),
+            ...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
+          },
+        },
+      },
+    });
+  }
+
   return {
     add(name, build) {
       if (entries.has(name)) {
@@ -162,6 +273,9 @@ export function createStreamProcessorHost(ctx: DurableObjectState): StreamProces
         handle: undefined,
         namespace: undefined,
         path: undefined,
+        consecutiveIngestFailures: 0,
+        generation: 0,
+        ingestChain: Promise.resolve(),
       });
       return processor;
     },
@@ -187,24 +301,9 @@ export function createStreamProcessorHost(ctx: DurableObjectState): StreamProces
       entry.stream = retainStreamRpc(args.stream);
       entry.namespace = args.streamRuntimeState.coreProcessorState.namespace;
       entry.path = args.streamRuntimeState.coreProcessorState.path;
+      entry.consecutiveIngestFailures = 0;
 
-      const snapshot = await entry.processor.snapshot();
-      entry.handle = await (entry.stream as OutboundStreamRpc).subscribeOutbound({
-        subscriptionKey: args.subscriptionKey,
-        replayAfterOffset: snapshot.offset,
-        // The contract is the filter: the stream only delivers event types the
-        // processor consumes. A `"*"` in consumes means unfiltered delivery.
-        eventTypes: entry.processor.contract.consumes,
-        processEventBatch: (batch) => {
-          // ingest serializes batches internally; waitUntil keeps the DO alive
-          // through blocking side effects after the RPC callback returns.
-          const processed = entry.processor.ingest(batch).catch((error: unknown) => {
-            console.error(`stream processor "${name}" failed to ingest batch`, error);
-          });
-          ctx.waitUntil(processed);
-          return processed;
-        },
-      });
+      await openSubscription(name);
 
       // Announce the processor's contract on the stream (idempotent per
       // slug+version). This replaces the old per-processor

--- a/packages/streams/src/workers/stream-processor-host.ts
+++ b/packages/streams/src/workers/stream-processor-host.ts
@@ -187,15 +187,23 @@ export function createStreamProcessorHost(ctx: DurableObjectState): StreamProces
         // *between* batches: a batch queued on a now-dead connection must be
         // dropped, not ingested. ingest serializes internally too, but that
         // can't drop a batch that was already accepted.
-        entry.ingestChain = entry.ingestChain.then(async () => {
-          if (generation !== entry.generation) return; // superseded connection; replay covers it
-          try {
-            await entry.processor.ingest(batch);
-            entry.consecutiveIngestFailures = 0;
-          } catch (error) {
-            await recoverFromIngestFailure(name, error);
-          }
-        });
+        entry.ingestChain = entry.ingestChain
+          .then(async () => {
+            if (generation !== entry.generation) return; // superseded connection; replay covers it
+            try {
+              await entry.processor.ingest(batch);
+              entry.consecutiveIngestFailures = 0;
+            } catch (error) {
+              await recoverFromIngestFailure(name, error);
+            }
+          })
+          // Recovery itself can throw (e.g. the re-handshake or the poison-path
+          // error append fails). Never let that leave the chain rejected, or every
+          // later batch's `.then` would be skipped and delivery would wedge. A
+          // future re-handshake (stream-side reconcile) is the way back.
+          .catch((error: unknown) => {
+            console.error(`stream processor "${name}" ingest recovery failed`, error);
+          });
         // waitUntil keeps the DO alive through ingest + recovery after the RPC
         // callback returns.
         ctx.waitUntil(entry.ingestChain);

--- a/packages/streams/src/workers/stream-processor-host.ts
+++ b/packages/streams/src/workers/stream-processor-host.ts
@@ -302,6 +302,11 @@ export function createStreamProcessorHost(ctx: DurableObjectState): StreamProces
 
       entry.handle?.unsubscribe();
       entry.stream?.[Symbol.dispose]();
+      // Invalidate the previous connection (same as recoverFromIngestFailure):
+      // this handshake replaces it, so any batch still queued on it must be
+      // dropped by the generation gate — the new connection's replay from the
+      // checkpoint is authoritative.
+      entry.generation += 1;
       // Workers RPC parameter stubs are disposed when the call returns unless
       // duplicated. Processor side effects may append later, so retain the
       // stream capability until the next handshake replaces it.

--- a/tasks/streams-review-fixes.md
+++ b/tasks/streams-review-fixes.md
@@ -99,7 +99,7 @@ the workers-sdk rpc fixture test DOs):
       `readCoreProcessorState`. Today it does. _Done — red._
 - [x] **T4 — append with `source` field** (pins M2). Appends an event with a
       valid `source` and reads it back. Today it throws `Unrecognized key:
-"source"`. _Done — red._
+  "source"`. _Done — red._
 - [x] **T5 — circuit-breaker clock regression** (pins M3). Spend a token with
       `createdAt` 1 s earlier than `lastRefillAtMs`; assert tokens decrement by
       ~1, not by 100k. _Done — red._
@@ -151,12 +151,29 @@ batch retries") is the false claim: the base class is retry-_safe_ but nothing
 retries. The test at `stream-processor-class.test.ts:235` only passes because
 the test redelivers by hand.
 
-- [ ] **Fix:** on delivery/ingest failure, `unsubscribe()` and resubscribe from
-      the durable checkpoint (`snapshot().offset`). Replay is already idempotent
-      (offset filter + trigger `RAISE(IGNORE)`). Apply on both the hosted-host
-      path and the browser store path. Consider centralizing the "redeliver from
-      checkpoint on failure" policy rather than duplicating it per consumer.
-- [ ] Update the `stream-processor.ts:369` comment to describe the real policy.
+- [x] **Fixed (Stage 1) — hosted-processor path.** On ingest failure the host
+      (`createStreamProcessorHost`) re-handshakes from the durable checkpoint and
+      the stream replays the batch. Two subtleties the fix had to handle:
+  - **Continued delivery race:** the pump is fire-and-forget, so while a failed
+    batch recovers the stream keeps delivering _later_ batches; ingesting one
+    would advance the checkpoint past the gap. The host now tags each
+    subscription with a `generation` and runs ingest through a per-processor
+    serial chain that re-checks the generation **between** batches — batches from
+    the superseded connection are dropped, and the post-recovery replay is the
+    single source of truth.
+  - **Poison policy (your call):** after `MAX_CONSECUTIVE_INGEST_FAILURES` (3)
+    consecutive failures the host appends a `stream/error-occurred` event
+    (idempotency-keyed by checkpoint offset) and disconnects, leaving it to the
+    subscriber/processor (or a later re-dial) to decide — no hot loop.
+  - Covered by T1 (transient recovery under continued delivery) + T1b (poison),
+    both passing.
+- [x] Updated the `stream-processor.ts` "batch retries" comment to describe the
+      real host-driven recovery.
+- [ ] **Still TODO — browser-store path** (`stream-browser-store.ts:380-391`).
+      The browser mirror swallows ingest failures the same way and wedges on the
+      SQLite continuity trigger. Apply the same resubscribe-from-checkpoint
+      recovery there (separate consumer; tracked under Stage 4 alongside the
+      other browser-runtime fixes).
 
 ### C2 — `writeState` failure advances in-memory checkpoint, persists nothing (CRITICAL)
 
@@ -174,8 +191,10 @@ returns at line 349 (`if (events.length === 0) return;`) without reaching
 `#saveSnapshot` again — a host trusting "failed ⇒ retries" gets a silent success
 that persisted nothing. (Verified with a runtime repro.)
 
-- [ ] **Fix:** assign `#state` / `#checkpointOffset` only **after**
-      `#saveSnapshot()` succeeds.
+- [x] **Fixed (Stage 1):** `#ingest` now `await this.#writeState({ offset, state })`
+      **before** assigning `#state` / `#checkpointOffset`; the single-use
+      `#saveSnapshot` helper was inlined and removed. T2 flipped to `it` and
+      passes.
 
 ### C3 — `PublicStreamRpcTarget` leaks `protected` methods → state injection → arbitrary callable dispatch (CRITICAL, security)
 
@@ -198,13 +217,14 @@ on the next `#reconcile` → `#connectOutboundConnection` (`stream.ts:769`) the 
 client-reachable RPC into arbitrary same-account binding/DO dispatch. Rolling
 back `maxOffset` also bricks future appends (PK conflicts).
 
-- [ ] **Fix:** make `makeRpcTargetClass` an **allowlist** (explicit set of API
-      methods) instead of a denylist, or pass an `exclude` covering every
-      non-API prototype method. Allowlist is the only safe default for a class
-      with this many internal methods. Re-derive the allowlist from the
-      `StreamRpc` type so it can't drift.
-- [ ] This likely lets `installSubscribeRpcTargetOverride` fold into the
-      allowlisted generator (see E-stream conciseness).
+- [x] **Fixed (Stage 1):** `makeRpcTargetClass` gained an `include` allowlist
+      option; both `StreamRpcTarget` and `PublicStreamRpcTarget` now pass an
+      explicit `STREAM_RPC_METHODS` list (`satisfies readonly (keyof StreamRpc)[]`
+      so it can't drift), plus `subscribeOutbound` on the internal target only.
+      `readCoreProcessorState` / `writeCoreProcessorState` are no longer proxied.
+      T3 flipped to `it` and passes.
+- [ ] Follow-up (Stage 6 E7): fold `installSubscribeRpcTargetOverride` into the
+      allowlisted generator now that the surface is explicit.
 
 ---
 

--- a/tasks/streams-review-fixes.md
+++ b/tasks/streams-review-fixes.md
@@ -99,7 +99,7 @@ the workers-sdk rpc fixture test DOs):
       `readCoreProcessorState`. Today it does. _Done — red._
 - [x] **T4 — append with `source` field** (pins M2). Appends an event with a
       valid `source` and reads it back. Today it throws `Unrecognized key:
-  "source"`. _Done — red._
+"source"`. _Done — red._
 - [x] **T5 — circuit-breaker clock regression** (pins M3). Spend a token with
       `createdAt` 1 s earlier than `lastRefillAtMs`; assert tokens decrement by
       ~1, not by 100k. _Done — red._

--- a/tasks/streams-review-fixes.md
+++ b/tasks/streams-review-fixes.md
@@ -308,11 +308,12 @@ trap). Same family: `idempotencyKey` is `z.string()` at input (`event.ts:59`)
 but `.trim().min(1)` in `getEventSchema` — a whitespace key passes input
 validation then explodes in reduce.
 
-- [ ] **Fix (decide):** either add `source` to `getEventSchema` /
-      `getEventInputSchema`, **or** delete `StreamEventSource` + `source`
-      entirely (zero callers — favours conciseness). Pick one and make input
-      and reduce schemas agree.
-- [ ] Align `idempotencyKey` validation between input and event schemas.
+- [x] **Fixed (Stage 3):** kept `source` (the migration note shows OS wants it).
+      Extracted a shared `StreamEventSourceSchema` + `streamEventIdempotencyKeySchema`
+      in `event.ts` and used them in both `getEventSchema` and
+      `getEventInputSchema`, so input and reduce schemas agree. `idempotencyKey`
+      is now `trim().min(1)` on input too (a blank key can no longer pass append
+      and then fail in reduce). T4 flipped to `it` and passes.
 
 ### M3 — Circuit-breaker token bucket subtracts on a backwards clock (MAJOR)
 
@@ -325,7 +326,8 @@ delta drains tokens. `createdAt` is per-event wall clock
 it. At the default refill, −1 s = −100,000 tokens → instant false trip → stream
 paused for no reason.
 
-- [ ] **Fix:** clamp with `Math.max(0, createdAtMs - lastRefillAtMs)`.
+- [x] **Fixed (Stage 3):** `spendCircuitBreakerToken` clamps the elapsed time with
+      `Math.max(0, …)`. T5 flipped to `it` and passes.
 
 ### M4 — Circuit-breaker edge-trigger misses sustained floods after replay (MAJOR)
 
@@ -339,9 +341,14 @@ not-tripped→tripped transition lands at an offset `<= sideEffectsAfterOffset`
 breaker is silently disabled. Also no retry if the background `stream/paused`
 append fails (`stream-processor.ts:324-327` only logs).
 
-- [ ] **Fix:** fire the trip side effect when
-      `tripped(state) && event.offset > anchor && !pausedYet`, not only on the
-      transition edge.
+- [x] **Fixed (Stage 3):** the trip is now level-triggered — `processEvent` fires
+      whenever `shouldTripCircuitBreaker(state)` on a live event (the base class
+      only calls `processEvent` for events past the anchor), dropping the
+      `previousState` edge guard. The pause append is idempotency-keyed per offset
+      and self-limits (once paused, ordinary appends are rejected). T6 flipped to
+      `it` and passes. _(The "failed pause append never retried" sub-point is
+      subsumed by the C1 ingest-failure recovery and is not separately handled
+      here — noted for Stage 3 follow-up if it proves necessary.)_
 
 ### M5 — `eventTypes` is silently dropped by the subscribe override (MAJOR / decision)
 


### PR DESCRIPTION
## What

**Stage 3** of the `packages/streams` review. Clears the last three regression ratchets (**T4, T5, T6** → `it`). The entire streams suite is now green with **no `it.fails` left**.

**Stacked on #1458** (Stage 1) — base `streams-review-stage1-fixes`; retarget up the chain as the lower PRs merge.

## M2 — a `source` field no longer crashes `appendBatch`

The DO append accepts `source`, but the runner-side parsers (`getEventSchema` / `getEventInputSchema`) were strict objects that omitted it, so the inline core reduce (`consumes: ["*"]`) threw `Unrecognized key: "source"` and rejected the whole batch. Extracted a shared `StreamEventSourceSchema` (+ `streamEventIdempotencyKeySchema`) in `event.ts` and used them in both parsers so input and reduce schemas agree. Kept `source` (the migration note shows OS wants it). `idempotencyKey` is now `trim().min(1)` on input too, closing the same crash class for blank keys. Covered by **T4**.

## M3 — circuit-breaker no longer drains on a backwards clock

`spendCircuitBreakerToken` now clamps elapsed time with `Math.max(0, …)`. A regressed `createdAt` (DO migration / clock skew) previously *subtracted* refill — at the default rate a 1 s regression drained ~100k tokens and instantly tripped the breaker. Covered by **T5**.

## M4 — circuit-breaker now pauses a live flood that began tripping during replay

The trip was edge-triggered on `previousState`, but `processEvent` isn't called for replay events (≤ the side-effect anchor), so when the not-tripped→tripped transition happened during replay, every live event afterward saw an already-tripped `previousState` and the breaker stayed silent. Now level-triggered: fires whenever the bucket is in deficit on a live event. Idempotency-keyed per offset and self-limiting (once the stream pauses, ordinary appends are rejected). Covered by **T6**.

## Verification

```
node pool:    63 passed (63)   — no it.fails remaining
workers pool:  8 passed (8)
typecheck: clean   lint: clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches append/reduce validation on the hot path and changes when streams auto-pause under rate limits; behavior is pinned by T4–T6 but mis-tuned limits could still pause production streams.
> 
> **Overview**
> **Stage 3** closes three streams review findings (M2/M3/M4) and turns regression ratchets **T4, T5, T6** from `it.fails` into passing `it` tests.
> 
> **Event schema alignment (M2):** Shared `StreamEventSourceSchema` and `streamEventIdempotencyKeySchema` in `event.ts` are wired into base input, `getEventInputSchema`, and `getEventSchema` so append and inline reduce agree. Events with `source` no longer fail core reduce with `Unrecognized key`; `idempotencyKey` is `trim().min(1)` at append time so blank keys cannot commit and then fail in reduce.
> 
> **Circuit breaker (M3/M4):** `spendCircuitBreakerToken` clamps refill elapsed time with `Math.max(0, …)` so regressed `createdAt` (migration/clock skew) cannot subtract tokens and false-trip. Trip handling is **level-triggered**: `processEvent` appends `stream/paused` whenever the bucket is in deficit on a live event, without requiring a fresh not-tripped→tripped edge—so overload that tripped during replay still pauses the live flood. Pause appends stay idempotency-keyed per offset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 625f8754ecab6bb943a1be8a7bc1aa35be1b404c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.
<!-- /CLOUDFLARE_PREVIEW -->