### PR TITLE
[codex] Share stream explorer shell

### DIFF
--- a/apps/os/src/components/stream-explorer.tsx
+++ b/apps/os/src/components/stream-explorer.tsx
@@ -1,0 +1,49 @@
+import type { ComponentProps, ReactNode } from "react";
+import type { StreamPath as StreamPathType } from "@iterate-com/shared/streams/types";
+import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
+import {
+  StreamTreeBrowser,
+  type StreamTreeBrowserSource,
+} from "~/components/stream-tree-browser.tsx";
+
+type ProjectStreamViewProps = ComponentProps<typeof ProjectStreamView>;
+
+export function StreamExplorerTreePage({
+  currentPath,
+  header,
+  onOpenPath,
+  source,
+}: {
+  currentPath?: StreamPathType;
+  header?: ReactNode;
+  onOpenPath: (streamPath: StreamPathType) => void;
+  source: StreamTreeBrowserSource;
+}) {
+  return (
+    <section className="flex min-h-0 flex-1 flex-col gap-3 p-4">
+      {header == null ? null : <div className="min-w-0">{header}</div>}
+      <StreamTreeBrowser source={source} currentPath={currentPath} onOpenPath={onOpenPath} />
+    </section>
+  );
+}
+
+export function StreamExplorerDetail({
+  currentPath,
+  onOpenPath,
+  source,
+  streamView,
+}: {
+  currentPath: StreamPathType;
+  onOpenPath: (streamPath: StreamPathType) => void;
+  source: StreamTreeBrowserSource;
+  streamView: Omit<ProjectStreamViewProps, "streamPath">;
+}) {
+  return (
+    <section className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden lg:grid-cols-[20rem_minmax(0,1fr)]">
+      <aside className="hidden min-h-0 border-r p-3 lg:flex">
+        <StreamTreeBrowser source={source} currentPath={currentPath} onOpenPath={onOpenPath} />
+      </aside>
+      <ProjectStreamView {...streamView} streamPath={currentPath} />
+    </section>
+  );
+}

--- a/apps/os/src/routes/_app/projects/$projectSlug/streams/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/streams/$.tsx
@@ -1,8 +1,12 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { createBrowserOpenApiClient } from "~/orpc/client.ts";
-import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
+import { useMemo } from "react";
+import type { StreamPath as StreamPathType } from "@iterate-com/shared/streams/types";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { StreamExplorerDetail } from "~/components/stream-explorer.tsx";
+import { useItxClient } from "~/itx/react/index.ts";
 import { breadcrumbLoaderData } from "~/lib/route-breadcrumbs.ts";
+import { StreamNavigationState } from "~/lib/stream-navigation-state.ts";
 import { streamPathFromSplat, streamPathToSplat } from "~/lib/stream-links.ts";
+import { createBrowserOpenApiClient } from "~/orpc/client.ts";
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/streams/$")({
   params: {
@@ -34,7 +38,19 @@ export const Route = createFileRoute("/_app/projects/$projectSlug/streams/$")({
 
 function ProjectStreamDetailPage() {
   const params = Route.useParams();
+  const navigate = useNavigate();
+  const itxClient = useItxClient();
   const { project, streamPath } = Route.useLoaderData();
+  const source = useMemo(
+    () => ({
+      key: ["project", project.id, "streams"] as const,
+      getState: async (path: StreamPathType) =>
+        StreamNavigationState.parse(
+          await (await itxClient.project(project.id)).streams.get(path).getState(),
+        ),
+    }),
+    [itxClient, project.id],
+  );
 
   async function submitMessage(message: string) {
     await createBrowserOpenApiClient().project.streams.appendBatch({
@@ -49,16 +65,30 @@ function ProjectStreamDetailPage() {
     });
   }
 
+  function openStream(path: StreamPathType) {
+    void navigate({
+      to: "/projects/$projectSlug/streams/$",
+      params: {
+        projectSlug: params.projectSlug,
+        _splat: path,
+      },
+    });
+  }
+
   return (
-    <ProjectStreamView
-      defaultComposerMode="raw"
-      messageComposer={{
-        onSubmit: submitMessage,
-        placeholder: "Message this stream",
+    <StreamExplorerDetail
+      currentPath={streamPath}
+      onOpenPath={openStream}
+      source={source}
+      streamView={{
+        defaultComposerMode: "raw",
+        messageComposer: {
+          onSubmit: submitMessage,
+          placeholder: "Message this stream",
+        },
+        projectSlug: params.projectSlug,
+        projectSlugOrId: project.id,
       }}
-      projectSlug={params.projectSlug}
-      projectSlugOrId={project.id}
-      streamPath={streamPath}
     />
   );
 }

--- a/apps/os/src/routes/_app/projects/$projectSlug/streams/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/streams/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import type { StreamPath as StreamPathType } from "@iterate-com/shared/streams/types";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { StreamTreeBrowser } from "~/components/stream-tree-browser.tsx";
+import { StreamExplorerTreePage } from "~/components/stream-explorer.tsx";
 import { useItxClient } from "~/itx/react/index.ts";
 import { StreamNavigationState } from "~/lib/stream-navigation-state.ts";
 
@@ -39,9 +39,5 @@ function ProjectStreamsIndexPage() {
     });
   }
 
-  return (
-    <section className="flex min-h-0 flex-1 flex-col p-4">
-      <StreamTreeBrowser source={source} onOpenPath={openStream} />
-    </section>
-  );
+  return <StreamExplorerTreePage source={source} onOpenPath={openStream} />;
 }

--- a/apps/os/src/routes/admin/streams/$namespace/$.tsx
+++ b/apps/os/src/routes/admin/streams/$namespace/$.tsx
@@ -1,8 +1,7 @@
 import { useMemo } from "react";
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
 import type { StreamPath as StreamPathType } from "@iterate-com/shared/streams/types";
-import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
-import { StreamTreeBrowser } from "~/components/stream-tree-browser.tsx";
+import { StreamExplorerDetail } from "~/components/stream-explorer.tsx";
 import { useAdminItx } from "~/lib/admin-itx.ts";
 import { StreamNavigationState } from "~/lib/stream-navigation-state.ts";
 import { adminStreamRpcPath } from "~/lib/stream-rpc-paths.ts";
@@ -42,15 +41,15 @@ function AdminStreamDetailPage() {
   }
 
   return (
-    <section className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden lg:grid-cols-[20rem_minmax(0,1fr)]">
-      <aside className="hidden min-h-0 border-r p-3 lg:flex">
-        <StreamTreeBrowser source={source} currentPath={streamPath} onOpenPath={openStream} />
-      </aside>
-      <ProjectStreamView
-        emptyLabel="No events in this stream yet."
-        projectSlug={namespace}
-        projectSlugOrId={namespace}
-        renderStreamPathLink={({ path, children, className }) => (
+    <StreamExplorerDetail
+      currentPath={streamPath}
+      onOpenPath={openStream}
+      source={source}
+      streamView={{
+        emptyLabel: "No events in this stream yet.",
+        projectSlug: namespace,
+        projectSlugOrId: namespace,
+        renderStreamPathLink: ({ path, children, className }) => (
           <Link
             to="/admin/streams/$namespace/$"
             params={{ namespace, _splat: path }}
@@ -58,10 +57,9 @@ function AdminStreamDetailPage() {
           >
             {children}
           </Link>
-        )}
-        streamPath={streamPath}
-        streamUrl={adminStreamRpcPath(namespace, streamPath)}
-      />
-    </section>
+        ),
+        streamUrl: adminStreamRpcPath(namespace, streamPath),
+      }}
+    />
   );
 }

--- a/apps/os/src/routes/admin/streams/$namespace/index.tsx
+++ b/apps/os/src/routes/admin/streams/$namespace/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import type { StreamPath as StreamPathType } from "@iterate-com/shared/streams/types";
-import { StreamTreeBrowser } from "~/components/stream-tree-browser.tsx";
+import { StreamExplorerTreePage } from "~/components/stream-explorer.tsx";
 import { useAdminItx } from "~/lib/admin-itx.ts";
 import { StreamNavigationState } from "~/lib/stream-navigation-state.ts";
 
@@ -32,14 +32,15 @@ function AdminStreamNamespacePage() {
   }
 
   return (
-    <section className="flex min-h-0 flex-1 flex-col gap-3 p-4">
-      <div className="min-w-0">
+    <StreamExplorerTreePage
+      header={
         <h1 className="truncate text-lg font-semibold">
           Namespace{" "}
           <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">{namespace}</code>
         </h1>
-      </div>
-      <StreamTreeBrowser source={source} onOpenPath={openStream} />
-    </section>
+      }
+      source={source}
+      onOpenPath={openStream}
+    />
   );
 }


### PR DESCRIPTION
## Summary

- Add a shared stream explorer shell around the existing stream tree and project stream view components.
- Update the project stream routes to use that shared shell.
- Update the admin stream namespace and detail routes to use the same explorer components while keeping admin-specific RPC paths and links.

## Validation

- `pnpm --dir apps/os typecheck`
- `pnpm exec oxfmt --check apps/os/src/components/stream-explorer.tsx 'apps/os/src/routes/_app/projects/$projectSlug/streams/$.tsx' 'apps/os/src/routes/_app/projects/$projectSlug/streams/index.tsx' 'apps/os/src/routes/admin/streams/$namespace/$.tsx' 'apps/os/src/routes/admin/streams/$namespace/index.tsx'`
- `pnpm exec oxlint apps/os/src/components/stream-explorer.tsx 'apps/os/src/routes/_app/projects/$projectSlug/streams/$.tsx' 'apps/os/src/routes/_app/projects/$projectSlug/streams/index.tsx' 'apps/os/src/routes/admin/streams/$namespace/$.tsx' 'apps/os/src/routes/admin/streams/$namespace/index.tsx'`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": {
    "dopplerConfig": "preview_4",
    "leasedUntil": 1781109493731,
    "leaseId": "3f144561-9e82-4b1c-8d97-22fff3996222",
    "slug": "preview-4",
    "type": "environment-config-lease"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
Lease: `preview-4`
Doppler config: `preview_4`
Type: `environment-config-lease`
Leased until: 2026-06-10T16:38:13.731Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI layout refactor with behavior preserved via the same tree and stream view components; project detail adds a sidebar tree that was previously admin-only.
> 
> **Overview**
> Introduces **`stream-explorer.tsx`** with two shared layouts: **`StreamExplorerTreePage`** (tree-only) and **`StreamExplorerDetail`** (sidebar tree + **`ProjectStreamView`** on large screens).
> 
> Project and admin stream routes stop inlining **`StreamTreeBrowser`** / grid markup and instead compose these shells, passing route-specific **`source`**, **`onOpenPath`**, and **`streamView`** props (composer, links, RPC URLs).
> 
> The **project stream detail** route gains the same split explorer UX as admin: an ITX-backed tree beside the stream view, with navigation when opening paths from the tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94f3d51e6aa12e62a62d2d3af26010d2b87df409. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->