### PR TITLE
preview: retry GitHub PR-body reads/writes through transient API failures

### DIFF
--- a/scripts/preview/state.ts
+++ b/scripts/preview/state.ts
@@ -229,6 +229,31 @@ function unwrapHiddenStateBlock(contents: string) {
   return contents;
 }
 
+/**
+ * Retry GitHub API calls unconditionally, status codes included: during the
+ * 2026-06-10 GitHub auth outage, valid tokens drew transient 401s and a
+ * single failed PATCH killed whole deploy jobs. A genuinely bad token just
+ * fails again a few seconds later.
+ */
+async function withGithubRetries<T>(operation: () => Promise<T>): Promise<T> {
+  const delaysMs = [2_000, 5_000];
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      const delayMs = delaysMs[attempt];
+      if (delayMs === undefined) {
+        throw error;
+      }
+      console.warn(
+        `GitHub API call failed (attempt ${attempt + 1}/${delaysMs.length + 1}), retrying in ${delayMs}ms...`,
+        error instanceof Error ? error.message : error,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+}
+
 async function readPullRequestBody(params: {
   githubToken: string;
   repositoryFullName: string;
@@ -238,11 +263,13 @@ async function readPullRequestBody(params: {
     auth: params.githubToken,
   });
   const [owner, repo] = splitRepositoryFullName(params.repositoryFullName);
-  const pullRequest = await octokit.rest.pulls.get({
-    owner,
-    repo,
-    pull_number: params.pullRequestNumber,
-  });
+  const pullRequest = await withGithubRetries(() =>
+    octokit.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: params.pullRequestNumber,
+    }),
+  );
 
   return pullRequest.data.body ?? "";
 }
@@ -257,10 +284,12 @@ async function writePullRequestBody(params: {
     auth: params.githubToken,
   });
   const [owner, repo] = splitRepositoryFullName(params.repositoryFullName);
-  await octokit.rest.pulls.update({
-    body: params.body,
-    owner,
-    repo,
-    pull_number: params.pullRequestNumber,
-  });
+  await withGithubRetries(() =>
+    octokit.rest.pulls.update({
+      body: params.body,
+      owner,
+      repo,
+      pull_number: params.pullRequestNumber,
+    }),
+  );
 }


### PR DESCRIPTION
During today's GitHub outage ("Authentication issues related to API requests", impact critical), valid tokens drew intermittent 401s and a single failed `PATCH /pulls/N` killed whole preview deploy jobs — it happened twice on #1462 and once on #1447's deploy, while a manual re-run in a lucky window sailed through.

`readPullRequestBody`/`writePullRequestBody` now retry up to 3 attempts with 2s/5s backoff, unconditionally (status codes included): today proved even "non-retryable" codes can be transient at GitHub's edge, and a genuinely bad token just fails again a few seconds later.

Scripts suite (30 tests), typecheck, lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to preview deploy state I/O with bounded retries; no auth or production path changes beyond tolerating GitHub API flakiness.
> 
> **Overview**
> Adds **unconditional retry with backoff** around GitHub PR body **GET** and **PATCH** calls in `scripts/preview/state.ts`, so transient API failures (including intermittent 401s during outages) no longer abort whole Cloudflare preview deploy jobs on the first error.
> 
> A new `withGithubRetries` helper runs up to **3 attempts** with **2s** then **5s** delays between failures, logs warnings on retry, and rethrows after the last attempt. Both `readPullRequestBody` and `writePullRequestBody` wrap their Octokit `pulls.get` / `pulls.update` calls through this helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b9693b8e2714a8c4a8f3c5cb8fb643ec1ebcc72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T17:54:28.062Z",
      "headSha": "4b9693b8e2714a8c4a8f3c5cb8fb643ec1ebcc72",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27288965194",
      "shortSha": "4b9693b"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-06-10T17:54:18.615Z",
      "headSha": "4b9693b8e2714a8c4a8f3c5cb8fb643ec1ebcc72",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27288965194",
      "shortSha": "4b9693b"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `4b9693b`
Preview: https://os.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27288965194)
Updated: 2026-06-10T17:54:28.062Z

### Semaphore
Status: released
Commit: `4b9693b`
Preview: https://semaphore.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27288965194)
Updated: 2026-06-10T17:54:18.615Z
<!-- /CLOUDFLARE_PREVIEW -->