### PR TITLE
feat(streams): lazy stream initialization (Stage 2)

### DIFF
--- a/packages/streams/example-app/e2e/playwright/stream-browser.spec.ts
+++ b/packages/streams/example-app/e2e/playwright/stream-browser.spec.ts
@@ -34,8 +34,6 @@ test("stream page appends through the shared browser mirror", async ({ page }) =
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath }));
 
-  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
-
   const type = "events.iterate.com/debug/playwright-single";
   await appendComposerEvent(page, {
     type,
@@ -48,7 +46,6 @@ test("stream page appends through the shared browser mirror", async ({ page }) =
 test("sidebar circuit breaker config runs the hosted built-in processor", async ({ page }) => {
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath }));
-  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
 
   await page.getByTestId("circuit-breaker-burst-capacity").fill("1");
   await page.getByTestId("circuit-breaker-refill-rate").fill("1");
@@ -82,7 +79,6 @@ test("sidebar circuit breaker config runs the hosted built-in processor", async 
 test("event type filter uses the indexed SQLite type column", async ({ page }) => {
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath }));
-  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
 
   const primaryType = "events.iterate.com/debug/playwright-filter-primary";
   const secondaryType = "events.iterate.com/debug/playwright-filter-secondary";
@@ -164,7 +160,6 @@ test("random bulk insert creates multiple filterable event types and shows filte
 }) => {
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath }));
-  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
 
   await page.getByLabel("Count").fill("80");
   await page.getByLabel("Batch size").fill("80");
@@ -200,7 +195,6 @@ test("random bulk insert creates multiple filterable event types and shows filte
 test("stream page reload starts at the bottom of an existing local mirror", async ({ page }) => {
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath }));
-  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
 
   const insertedCount = 200;
   await page.getByLabel("Count").fill(String(insertedCount));
@@ -232,7 +226,6 @@ test("event feed view starts at the bottom on first visit while replay fills the
   const setupContext = await browser.newContext();
   const setupPage = await setupContext.newPage();
   await setupPage.goto(streamRoute({ path: streamPath }));
-  await expect(eventMeta(setupPage, "events.iterate.com/stream/created").first()).toBeVisible();
 
   const insertedCount = 200;
   await setupPage.getByLabel("Count").fill(String(insertedCount));
@@ -259,6 +252,14 @@ test("event feed view starts at the bottom on first visit while replay fills the
 test("first event row draws quickly", async ({ page }) => {
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath }));
+
+  // Lazy init: the stream is empty on open, so the first append initializes it and draws the
+  // first row (created@1, woken@2, then this event@3).
+  const type = "events.iterate.com/debug/playwright-first-row";
+  await appendComposerEvent(page, {
+    type,
+    payload: { streamPath, value: crypto.randomUUID() },
+  });
   await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
 
   const firstRowDrawMs = await page.evaluate(() => {
@@ -279,7 +280,6 @@ test("split view can mount the same stream twice and mirror appends", async ({ p
   );
 
   await expect(page.getByText(streamPath)).toHaveCount(2);
-  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
 
   const type = "events.iterate.com/debug/playwright-split";
   await appendComposerEvent(page, {
@@ -303,10 +303,6 @@ test("two browser tabs update and hand off leadership after the writer closes", 
   await Promise.all([
     page.goto(streamRoute({ path: streamPath })),
     otherPage.goto(streamRoute({ path: streamPath })),
-  ]);
-  await Promise.all([
-    expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible(),
-    expect(eventMeta(otherPage, "events.iterate.com/stream/created").first()).toBeVisible(),
   ]);
 
   const type = "events.iterate.com/debug/playwright-two-tabs";
@@ -350,8 +346,8 @@ test("fresh runtime takes over when a legacy writer lock is still held", async (
 
   await page.goto(streamRoute({ path: streamPath }));
   await expect(page.getByTestId("subscription-status")).toHaveText("leader");
-  await expect(page.getByTestId("event-count")).toHaveText("2");
-  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
+  // Lazy init: a stream that has never been appended to is empty on open (no created/woken seed).
+  await expect(page.getByTestId("event-count")).toHaveText("0");
 
   await legacyLockHolder.close();
 });
@@ -414,6 +410,13 @@ test("auto-growing composer stays in the stream scrollbar and preserves tail app
 }) => {
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath }));
+
+  // Lazy init: the stream is empty on open, so seed it with one event to materialise an event
+  // row (created@1, woken@2, this event@3) before measuring row/composer alignment below.
+  await appendComposerEvent(page, {
+    type: "events.iterate.com/debug/playwright-grown-composer-seed",
+    payload: { streamPath, value: crypto.randomUUID() },
+  });
   await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
 
   await expect
@@ -503,7 +506,6 @@ test("auto-growing composer stays in the stream scrollbar and preserves tail app
 test("scroll to bottom affordance counts new events while away from tail", async ({ page }) => {
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath }));
-  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
 
   await page.getByLabel("Count").fill("80");
   await page.getByLabel("Batch size").fill("80");
@@ -537,7 +539,6 @@ test("scroll to bottom affordance keeps counting while scrolling older rows duri
 }) => {
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath }));
-  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
 
   await page.getByLabel("Count").fill("100");
   await page.getByLabel("Batch size").fill("100");
@@ -584,7 +585,6 @@ test("expanding the tail event row at stream end stays above the composer", asyn
 
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath }));
-  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
 
   await page.getByLabel("Count").fill("120");
   await page.getByLabel("Batch size").fill("120");
@@ -624,7 +624,6 @@ test("expanding the tail event row at stream end stays above the composer", asyn
 test("event row open and closed state survives virtual row unmounts", async ({ page }) => {
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath }));
-  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
 
   await page.getByLabel("Count").fill("160");
   await page.getByLabel("Batch size").fill("160");
@@ -715,7 +714,6 @@ test("large streams stay virtualized and can scroll from tail to earliest rows",
 }) => {
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath }));
-  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
 
   const insertedCount = 1_500;
   await page.getByLabel("Count").fill(String(insertedCount));
@@ -756,7 +754,6 @@ test("large streams stay virtualized and can scroll from tail to earliest rows",
 test("downloaded SQLite file can be queried from disk", async ({ page }) => {
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath }));
-  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
 
   const type = "events.iterate.com/debug/playwright-download";
   await appendComposerEvent(page, {
@@ -784,11 +781,20 @@ test("downloaded SQLite file can be queried from disk", async ({ page }) => {
 test("kill reconnects and appends a new woken event", async ({ page }) => {
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath }));
-  await expect(page.getByTestId("event-count")).toHaveText("2");
+  // Lazy init: the stream is empty on open. The first append initializes it with
+  // created@1, woken@2, then the appended event@3 (count "3").
+  await expect(page.getByTestId("event-count")).toHaveText("0");
+  await appendComposerEvent(page, {
+    type: "events.iterate.com/debug/playwright-kill",
+    payload: { streamPath, value: crypto.randomUUID() },
+  });
+  await expect(page.getByTestId("event-count")).toHaveText("3");
 
   await page.getByRole("button", { name: "Kill" }).click();
   await expect(page.getByTestId("stream-status")).toHaveText("subscribed", { timeout: 30_000 });
-  await expect(page.getByTestId("event-count")).toHaveText("3", { timeout: 30_000 });
+  // The new DO incarnation appends its own woken on wake, so the stream grows to count "4" with
+  // two woken events (the init woken@2 and the reconnect woken).
+  await expect(page.getByTestId("event-count")).toHaveText("4", { timeout: 30_000 });
   await expect(eventMeta(page, "events.iterate.com/stream/woken")).toHaveCount(2);
 });
 
@@ -809,9 +815,13 @@ test("reset discards stale local rows and shows a fresh stream", async ({ page }
 
   await page.getByRole("button", { name: "Reset", exact: true }).click();
   await expect(page.getByTestId("stream-status")).toHaveText("subscribed", { timeout: 30_000 });
-  await expect(page.getByTestId("event-count")).toHaveText("2", { timeout: 30_000 });
+  // Lazy init: reset wipes storage, so the fresh stream is empty (maxOffset 0). The new
+  // incarnation only re-appends `woken` for an already-initialized stream, so nothing is
+  // re-created until the next append — count "0", no `created`/`woken`, and the stale local row
+  // is gone.
+  await expect(page.getByTestId("event-count")).toHaveText("0", { timeout: 30_000 });
   await expect(eventMeta(page, type)).toHaveCount(0);
-  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
+  await expect(eventMeta(page, "events.iterate.com/stream/created")).toHaveCount(0);
 });
 
 // The event-feed view hosts the browser-event-feed processor: specific-renderer events
@@ -822,6 +832,11 @@ test("event-feed view renders specific renderers as singletons and groups by typ
 }) => {
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath, view: "browser-event-feed" }));
+
+  // Lazy init: the stream is empty on open. The first append initializes it, so `created` (offset
+  // 1) and `woken` (offset 2) arrive in the same batch as this feed-a event and render as their
+  // own specific-renderer singleton rows.
+  await appendComposerEvent(page, { type: "events.iterate.com/debug/feed-a", payload: { v: 1 } });
 
   await expect(
     page.locator("[data-testid='feed-item'][data-component='stream.created']"),
@@ -836,7 +851,6 @@ test("event-feed view renders specific renderers as singletons and groups by typ
     page.locator("[data-testid='feed-lifecycle-marker'][data-kind='woken']"),
   ).toContainText("Durable object woke up");
 
-  await appendComposerEvent(page, { type: "events.iterate.com/debug/feed-a", payload: { v: 1 } });
   const groupA = page.locator(
     "[data-testid='feed-item'][data-event-type='events.iterate.com/debug/feed-a']",
   );
@@ -883,7 +897,6 @@ test("root stream route respects the selected view", async ({ page }) => {
 test("view switcher navigates between the three views", async ({ page }) => {
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath }));
-  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
 
   await page.getByTestId("view-link-browser-event-feed").click();
   await expect(page).toHaveURL(/view=browser-event-feed/);

--- a/packages/streams/example-app/e2e/playwright/stream-browser.spec.ts
+++ b/packages/streams/example-app/e2e/playwright/stream-browser.spec.ts
@@ -790,7 +790,8 @@ test("kill reconnects and appends a new woken event", async ({ page }) => {
   });
   await expect(page.getByTestId("event-count")).toHaveText("3");
 
-  await page.getByRole("button", { name: "Kill" }).click();
+  // `exact` so this doesn't also match the appended `…/playwright-kill` event row.
+  await page.getByRole("button", { name: "Kill", exact: true }).click();
   await expect(page.getByTestId("stream-status")).toHaveText("subscribed", { timeout: 30_000 });
   // The new DO incarnation appends its own woken on wake, so the stream grows to count "4" with
   // two woken events (the init woken@2 and the reconnect woken).

--- a/packages/streams/example-app/e2e/vitest/stream-capnweb.test.ts
+++ b/packages/streams/example-app/e2e/vitest/stream-capnweb.test.ts
@@ -412,6 +412,15 @@ describe("stream capnweb protocol", () => {
     const path = e2eStreamPathLabel("stream-capnweb-anon-sub");
     using stream = withStreamConnectionFromNode({ url: toStreamWebSocketUrl({ path }) });
 
+    // Lazy init: initialize the stream first (created@1, woken@2, this@3) so the subscriptions
+    // below start from maxOffset and observe only events appended after they subscribe.
+    await stream.stream.append({
+      event: {
+        type: "test.stream.capnweb-anon-sub-init",
+        payload: { path },
+      },
+    });
+
     const callbackA = new TestSubscriptionCallback();
     const callbackB = new TestSubscriptionCallback();
     const first = await stream.stream.subscribe({

--- a/packages/streams/example-app/src/routes/-stream-page.tsx
+++ b/packages/streams/example-app/src/routes/-stream-page.tsx
@@ -1145,7 +1145,11 @@ function StreamSidebar({
         streamStore={streamStore}
       />
       <InsertEventsTool streamStore={streamStore} streamPath={streamView.path} />
-      <StreamControlTool snapshot={snapshot} streamStore={streamStore} />
+      <StreamControlTool
+        snapshot={snapshot}
+        streamStore={streamStore}
+        streamPath={streamView.path}
+      />
     </aside>
   );
 }
@@ -1372,9 +1376,11 @@ function useStreamRuntimeState(streamStore: StreamBrowserStore, connectionStatus
 function StreamControlTool({
   snapshot,
   streamStore,
+  streamPath,
 }: {
   snapshot: StreamBrowserSnapshot;
   streamStore: StreamBrowserStore;
+  streamPath: string;
 }) {
   const { runtimeState, pollError } = useStreamRuntimeState(streamStore, snapshot.connectionStatus);
   const core = runtimeState?.coreProcessorState;
@@ -1427,7 +1433,10 @@ function StreamControlTool({
               subscriptionKey,
               subscriber: durableObjectProcessorSubscriber({
                 bindingName: "STREAM_PROCESSOR_RUNNER",
-                durableObjectName: `${core.path}:${subscriptionKey}`,
+                // Use the real stream path, not `core.path`: with lazy init the
+                // reduced state is the "uninitialized" placeholder until the
+                // first append, which would name every runner the same.
+                durableObjectName: `${streamPath}:${subscriptionKey}`,
                 processorName: "circuit-breaker",
               }),
             },

--- a/packages/streams/src/workers/durable-objects/stream.ts
+++ b/packages/streams/src/workers/durable-objects/stream.ts
@@ -43,6 +43,9 @@ const CORE_STATE_VERSION = 3;
 
 export class Stream extends DurableObject<Env> implements StreamRpc {
   #coreProcessorState: StreamCoreProcessorState;
+  // Whether the SQLite tables exist yet. A stream that has never been appended
+  // to has no storage and no events; both are created lazily by the first append.
+  #storageReady: boolean;
   coreProcessor = new CoreStreamProcessor({
     iterateContext: {
       stream: {
@@ -61,37 +64,35 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
-    this.#ensureStorageSchema();
-
+    // Lazy initialization: a never-appended stream has no tables. Don't create
+    // them here — only detect whether a prior incarnation already did.
+    this.#storageReady = this.#eventsTableExists();
     this.#coreProcessorState = this.readCoreProcessorState();
 
-    // When the durable object boots up the _first time_, we add a
-    // events.iterate.com/stream/created event to the stream.
-    //
-    // And every time it's woken up for any reason (inbound fetch, rpc or alarm),
-    // we append a "woken" event to the stream.
-    if (this.#coreProcessorState.eventCount === 0) {
-      // stream durable objects have names like "namespace:/some/stream/path"
-      if (!ctx.id.name) throw new Error("ctx.id.name is falsey - this should never happen");
-      const [namespace, path] = ctx.id.name.split(":");
+    // An uninitialized stream stays completely empty: no storage, no `created`,
+    // no `woken`, nothing to reconcile. The first append initializes it (see
+    // `#appendBatchHere`). An already-initialized stream waking up records the
+    // incarnation and restores any outbound subscriptions it should have —
+    // without this, a stream that wakes with configured subscriptions but no new
+    // appends never reconnects.
+    if (this.#coreProcessorState.maxOffset > 0) {
       this.append({
         event: {
-          type: "events.iterate.com/stream/created",
-          payload: { namespace, path },
+          type: "events.iterate.com/stream/woken",
+          payload: { incarnationId: crypto.randomUUID() },
         },
       });
+      this.#reconcile();
     }
-    // each time the durable object wakes up, we append this event
-    this.append({
-      event: {
-        type: "events.iterate.com/stream/woken",
-        payload: { incarnationId: crypto.randomUUID() },
-      },
-    });
+  }
 
-    // Restore outbound connections this stream should have. Without this, a stream
-    // that wakes with configured subscriptions but no new appends never reconnects.
-    this.#reconcile();
+  /** Cheap existence check that does not itself create the table. */
+  #eventsTableExists(): boolean {
+    return (
+      this.ctx.storage.sql
+        .exec("select 1 from sqlite_master where type = 'table' and name = 'events' limit 1")
+        .toArray().length > 0
+    );
   }
 
   #ensureStorageSchema(): void {
@@ -100,6 +101,20 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
     // - `event_chunks` stores the full event JSON as bounded UTF-8 byte rows.
     this.#createEventsTable();
     this.#createEventChunksTable();
+    this.#storageReady = true;
+  }
+
+  /**
+   * The `created` event input for this stream, derived from its DO name
+   * (`namespace:/some/stream/path`). Prepended by the first append.
+   */
+  #createdEventInput(): StreamEventInput {
+    if (!this.ctx.id.name) throw new Error("ctx.id.name is falsey - this should never happen");
+    const [namespace, path] = this.ctx.id.name.split(":");
+    return {
+      type: "events.iterate.com/stream/created",
+      payload: { namespace, path },
+    };
   }
 
   #createEventsTable(): void {
@@ -138,7 +153,11 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
     const storedStateIsCurrent = stored !== undefined && storedVersion === CORE_STATE_VERSION;
     const storedState = storedStateIsCurrent
       ? CoreProcessorContract.stateSchema.parse(stored)
-      : this.#recoverCoreProcessorStateFromEventLog();
+      : // No usable KV state. Replay the event log only if storage exists; a
+        // never-appended stream has no tables and is simply uninitialized.
+        this.#storageReady
+        ? this.#recoverCoreProcessorStateFromEventLog()
+        : undefined;
     if (storedState === undefined) return getInitialProcessorState(CoreProcessorContract);
 
     const state = this.#catchUpCoreProcessorState(storedState);
@@ -169,6 +188,7 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
   }
 
   #readHighestEventOffset(): number {
+    if (!this.#storageReady) return 0;
     return (
       this.ctx.storage.sql
         .exec<{ offset: number | null }>("select max(offset) as offset from events")
@@ -209,6 +229,7 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
   }
 
   #readEventByOffset(offset: number): StreamEvent | undefined {
+    if (!this.#storageReady) return undefined;
     const row = this.ctx.storage.sql
       .exec<{ offset: number }>(
         `
@@ -225,6 +246,7 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
   }
 
   #readEventByIdempotencyKey(idempotencyKey: string): StreamEvent | undefined {
+    if (!this.#storageReady) return undefined;
     const row = this.ctx.storage.sql
       .exec<{ offset: number }>(
         `
@@ -264,6 +286,7 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
     beforeOffset: number;
     limit: number;
   }): StreamEvent[] {
+    if (!this.#storageReady) return [];
     // One indexed metadata subquery picks the replay window; the join then streams each
     // event's chunks in primary-key order (offset, chunk_index).
     const chunks = this.ctx.storage.sql
@@ -379,6 +402,23 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
   }
 
   #appendBatchHere(args: { events: StreamEventInput[] }): StreamEvent[] {
+    // Lazy initialization: the first real append creates storage and prepends the
+    // `created` event (offset 1). A never-appended stream has no tables and no
+    // events; an empty append leaves it that way.
+    let inputEvents = args.events;
+    let prependedCreated = false;
+    if (
+      this.#coreProcessorState.maxOffset === 0 &&
+      inputEvents.length > 0 &&
+      inputEvents[0]?.type !== "events.iterate.com/stream/created"
+    ) {
+      inputEvents = [this.#createdEventInput(), ...inputEvents];
+      prependedCreated = true;
+    }
+    if (inputEvents.length > 0 && !this.#storageReady) {
+      this.#ensureStorageSchema();
+    }
+
     let workingCoreProcessorState = this.#coreProcessorState;
     const events: StreamEvent[] = [];
     const newEvents: StreamEvent[] = [];
@@ -389,7 +429,7 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
     }> = [];
     const idempotencyHitsInBatch = new Map<string, StreamEvent>();
     // 1. Prepare events and reduced state.
-    for (const eventInput of args.events) {
+    for (const eventInput of inputEvents) {
       const input = StreamEventInputSchema.strict().parse(eventInput);
 
       if (input.idempotencyKey !== undefined) {
@@ -475,7 +515,9 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
       this.#reconcile();
     }
 
-    return events;
+    // Return only the caller's events, input-aligned. A `created` event we
+    // prepended for lazy init is committed but is not part of the caller's batch.
+    return prependedCreated ? events.slice(1) : events;
   }
 
   getEvent(

--- a/packages/streams/src/workers/durable-objects/stream.ts
+++ b/packages/streams/src/workers/durable-objects/stream.ts
@@ -70,11 +70,12 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
     this.#coreProcessorState = this.readCoreProcessorState();
 
     // An uninitialized stream stays completely empty: no storage, no `created`,
-    // no `woken`, nothing to reconcile. The first append initializes it (see
-    // `#appendBatchHere`). An already-initialized stream waking up records the
-    // incarnation and restores any outbound subscriptions it should have —
-    // without this, a stream that wakes with configured subscriptions but no new
-    // appends never reconnects.
+    // no `woken`, nothing to reconcile — connecting to a stream you never append
+    // to leaves no trace. The first append initializes it with `created` +
+    // `woken` (see `#appendBatchHere`). An already-initialized stream waking up
+    // records this incarnation's `woken` and restores any outbound subscriptions
+    // it should have — without this, a stream that wakes with configured
+    // subscriptions but no new appends never reconnects.
     if (this.#coreProcessorState.maxOffset > 0) {
       this.append({
         event: {
@@ -105,16 +106,21 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
   }
 
   /**
-   * The `created` event input for this stream, derived from its DO name
-   * (`namespace:/some/stream/path`). Prepended by the first append.
+   * The events the first append prepends to lazily initialize a stream:
+   * `created` (offset 1, derived from the DO name `namespace:/some/stream/path`)
+   * then `woken` for the initializing incarnation. Later incarnations append
+   * their own `woken` from the constructor.
    */
-  #createdEventInput(): StreamEventInput {
+  #initEventInputs(): StreamEventInput[] {
     if (!this.ctx.id.name) throw new Error("ctx.id.name is falsey - this should never happen");
     const [namespace, path] = this.ctx.id.name.split(":");
-    return {
-      type: "events.iterate.com/stream/created",
-      payload: { namespace, path },
-    };
+    return [
+      { type: "events.iterate.com/stream/created", payload: { namespace, path } },
+      {
+        type: "events.iterate.com/stream/woken",
+        payload: { incarnationId: crypto.randomUUID() },
+      },
+    ];
   }
 
   #createEventsTable(): void {
@@ -402,18 +408,19 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
   }
 
   #appendBatchHere(args: { events: StreamEventInput[] }): StreamEvent[] {
-    // Lazy initialization: the first real append creates storage and prepends the
-    // `created` event (offset 1). A never-appended stream has no tables and no
-    // events; an empty append leaves it that way.
+    // Lazy initialization: the first real append creates storage and prepends
+    // `created` (offset 1) + `woken` (offset 2). A never-appended stream has no
+    // tables and no events; an empty append leaves it that way.
     let inputEvents = args.events;
-    let prependedCreated = false;
+    let prependedCount = 0;
     if (
       this.#coreProcessorState.maxOffset === 0 &&
       inputEvents.length > 0 &&
       inputEvents[0]?.type !== "events.iterate.com/stream/created"
     ) {
-      inputEvents = [this.#createdEventInput(), ...inputEvents];
-      prependedCreated = true;
+      const init = this.#initEventInputs();
+      inputEvents = [...init, ...inputEvents];
+      prependedCount = init.length;
     }
     if (inputEvents.length > 0 && !this.#storageReady) {
       this.#ensureStorageSchema();
@@ -515,9 +522,10 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
       this.#reconcile();
     }
 
-    // Return only the caller's events, input-aligned. A `created` event we
-    // prepended for lazy init is committed but is not part of the caller's batch.
-    return prependedCreated ? events.slice(1) : events;
+    // Return only the caller's events, input-aligned. The `created`/`woken`
+    // events we prepended for lazy init are committed but are not part of the
+    // caller's batch.
+    return prependedCount > 0 ? events.slice(prependedCount) : events;
   }
 
   getEvent(

--- a/packages/streams/src/workers/durable-objects/stream.ts
+++ b/packages/streams/src/workers/durable-objects/stream.ts
@@ -106,14 +106,24 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
   }
 
   /**
-   * The events the first append prepends to lazily initialize a stream:
-   * `created` (offset 1, derived from the DO name `namespace:/some/stream/path`)
-   * then `woken` for the initializing incarnation. Later incarnations append
-   * their own `woken` from the constructor.
+   * The stream's identity, from its DO name (`namespace:/some/stream/path`).
+   * This is the source of truth even before initialization — a lazily
+   * uninitialized stream's reduced state still holds the `"uninitialized"`
+   * placeholders, so path resolution and the `created` event must use the name.
    */
-  #initEventInputs(): StreamEventInput[] {
+  #streamIdentity(): { namespace: string; path: string } {
     if (!this.ctx.id.name) throw new Error("ctx.id.name is falsey - this should never happen");
     const [namespace, path] = this.ctx.id.name.split(":");
+    return { namespace, path };
+  }
+
+  /**
+   * The events the first append prepends to lazily initialize a stream:
+   * `created` (offset 1) then `woken` for the initializing incarnation. Later
+   * incarnations append their own `woken` from the constructor.
+   */
+  #initEventInputs(): StreamEventInput[] {
+    const { namespace, path } = this.#streamIdentity();
     return [
       { type: "events.iterate.com/stream/created", payload: { namespace, path } },
       {
@@ -359,9 +369,15 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
   }
 
   #resolveStream(streamPath: string): Pick<StreamRpc, "append" | "appendBatch"> {
-    const resolvedPath = resolveStreamPath(this.#coreProcessorState.path, streamPath);
-    if (resolvedPath === resolveStreamPath(this.#coreProcessorState.path, ".")) return this;
-    return this.env.STREAM.getByName(`${this.#coreProcessorState.namespace}:${resolvedPath}`);
+    // Resolve against the DO's own name, not reduced state: a lazily
+    // uninitialized stream has only `"uninitialized"` placeholders in state, but
+    // its real namespace/path are always known from its name. Without this,
+    // appending to a relative child of a not-yet-appended parent targets the
+    // wrong stream.
+    const { namespace, path } = this.#streamIdentity();
+    const resolvedPath = resolveStreamPath(path, streamPath);
+    if (resolvedPath === resolveStreamPath(path, ".")) return this;
+    return this.env.STREAM.getByName(`${namespace}:${resolvedPath}`);
   }
 
   /**

--- a/packages/streams/src/workers/durable-objects/stream.workers.test.ts
+++ b/packages/streams/src/workers/durable-objects/stream.workers.test.ts
@@ -23,9 +23,9 @@ import { PublicStreamRpcTarget, type Stream } from "./stream.ts";
 const STREAM = (env as unknown as { STREAM: DurableObjectNamespace<Stream> }).STREAM;
 
 // Each test uses a fresh DO name. Storage is lazy: a never-appended stream has
-// no events. The first append prepends `created` (offset 1), so the caller's
-// first event is offset 2. `woken` is only appended when an already-initialized
-// stream wakes on a new incarnation (see the lazy-initialization tests below).
+// no events. The first append prepends `created` (offset 1) + `woken` (offset
+// 2), so the caller's first event is offset 3. Each later incarnation appends
+// its own `woken` on wake (see the lazy-initialization tests below).
 let counter = 0;
 function freshStream() {
   counter += 1;
@@ -193,20 +193,19 @@ describe("Stage 2 — lazy initialization", () => {
     });
   });
 
-  it("the first append prepends `created` at offset 1 and returns only the caller's event", async () => {
+  it("the first append prepends `created` + `woken` and returns only the caller's event", async () => {
     await runInDurableObject(freshStream(), async (stream) => {
       const committed = await stream.append({ event: { type: "test.first", payload: { n: 1 } } });
-      // The caller gets back their own event at offset 2, not the prepended created.
+      // The caller gets back their own event at offset 3, after created + woken.
       expect(committed.type).toBe("test.first");
-      expect(committed.offset).toBe(2);
+      expect(committed.offset).toBe(3);
 
       const events = await stream.getEvents();
       expect(events.map((e) => [e.offset, e.type])).toEqual([
         [1, "events.iterate.com/stream/created"],
-        [2, "test.first"],
+        [2, "events.iterate.com/stream/woken"],
+        [3, "test.first"],
       ]);
-      // No `woken` was written on the first boot.
-      expect(events.some((e) => e.type === "events.iterate.com/stream/woken")).toBe(false);
     });
   });
 
@@ -216,15 +215,17 @@ describe("Stage 2 — lazy initialization", () => {
     const stub = STREAM.getByName(name);
     await stub.append({ event: { type: "test.init", payload: {} } });
 
+    // The initializing incarnation logged one woken (offset 2).
     const before = (await stub.getEvents()) as StreamEvent[];
-    expect(before.some((e) => e.type === "events.iterate.com/stream/woken")).toBe(false);
+    expect(before.filter((e) => e.type === "events.iterate.com/stream/woken")).toHaveLength(1);
 
     // Abort the incarnation; the aborted stub is poisoned, so reach the fresh
     // incarnation through a new stub for the same DO name.
     await stub.kill().catch(() => undefined);
 
+    // The new incarnation appended its own woken on wake.
     const after = (await STREAM.getByName(name).getEvents()) as StreamEvent[];
     const woken = after.filter((e) => e.type === "events.iterate.com/stream/woken");
-    expect(woken).toHaveLength(1);
+    expect(woken).toHaveLength(2);
   });
 });

--- a/packages/streams/src/workers/durable-objects/stream.workers.test.ts
+++ b/packages/streams/src/workers/durable-objects/stream.workers.test.ts
@@ -22,8 +22,10 @@ import { PublicStreamRpcTarget, type Stream } from "./stream.ts";
 
 const STREAM = (env as unknown as { STREAM: DurableObjectNamespace<Stream> }).STREAM;
 
-// Each test uses a fresh DO name. The DO constructor seeds `created` (offset 1)
-// and `woken` (offset 2) on first touch, so user appends start at offset 3.
+// Each test uses a fresh DO name. Storage is lazy: a never-appended stream has
+// no events. The first append prepends `created` (offset 1), so the caller's
+// first event is offset 2. `woken` is only appended when an already-initialized
+// stream wakes on a new incarnation (see the lazy-initialization tests below).
 let counter = 0;
 function freshStream() {
   counter += 1;
@@ -166,12 +168,63 @@ describe("T8 — Stream DO smoke (coverage)", () => {
         for (let i = 0; i < 20 && !seen.includes(target.offset); i += 1) {
           await new Promise((resolve) => setTimeout(resolve, 0));
         }
-        // Replay from 0 includes the seeded created/woken events plus our append.
+        // Replay from 0 includes the lazily-seeded `created` event plus our append.
         expect(seen).toContain(target.offset);
         expect(Math.min(...seen)).toBe(1);
       } finally {
         subscription.unsubscribe();
       }
     });
+  });
+});
+
+describe("Stage 2 — lazy initialization", () => {
+  it("a never-appended stream has no events and no storage", async () => {
+    await runInDurableObject(freshStream(), async (stream, state) => {
+      expect(await stream.getEvents()).toEqual([]);
+      // The runtime state is the uninitialized placeholder, max offset 0.
+      const runtime = await stream.runtimeState();
+      expect(runtime.coreProcessorState.maxOffset).toBe(0);
+      // And no SQLite tables were created just by instantiating + reading.
+      const tables = state.storage.sql
+        .exec("select name from sqlite_master where type = 'table' and name = 'events'")
+        .toArray();
+      expect(tables).toEqual([]);
+    });
+  });
+
+  it("the first append prepends `created` at offset 1 and returns only the caller's event", async () => {
+    await runInDurableObject(freshStream(), async (stream) => {
+      const committed = await stream.append({ event: { type: "test.first", payload: { n: 1 } } });
+      // The caller gets back their own event at offset 2, not the prepended created.
+      expect(committed.type).toBe("test.first");
+      expect(committed.offset).toBe(2);
+
+      const events = await stream.getEvents();
+      expect(events.map((e) => [e.offset, e.type])).toEqual([
+        [1, "events.iterate.com/stream/created"],
+        [2, "test.first"],
+      ]);
+      // No `woken` was written on the first boot.
+      expect(events.some((e) => e.type === "events.iterate.com/stream/woken")).toBe(false);
+    });
+  });
+
+  it("appends `woken` when an already-initialized stream wakes on a new incarnation", async () => {
+    counter += 1;
+    const name = `stream:/review/wake${counter}`;
+    const stub = STREAM.getByName(name);
+    await stub.append({ event: { type: "test.init", payload: {} } });
+
+    const before = (await stub.getEvents()) as StreamEvent[];
+    expect(before.some((e) => e.type === "events.iterate.com/stream/woken")).toBe(false);
+
+    // Abort the incarnation; the aborted stub is poisoned, so reach the fresh
+    // incarnation through a new stub for the same DO name.
+    await stub.kill().catch(() => undefined);
+
+    const after = (await STREAM.getByName(name).getEvents()) as StreamEvent[];
+    const woken = after.filter((e) => e.type === "events.iterate.com/stream/woken");
+    expect(woken).toHaveLength(1);
   });
 });

--- a/packages/streams/src/workers/durable-objects/stream.workers.test.ts
+++ b/packages/streams/src/workers/durable-objects/stream.workers.test.ts
@@ -228,4 +228,28 @@ describe("Stage 2 — lazy initialization", () => {
     const woken = after.filter((e) => e.type === "events.iterate.com/stream/woken");
     expect(woken).toHaveLength(2);
   });
+
+  it("resolves a relative child path against the DO name even when the parent was never initialized", async () => {
+    // Regression: relative resolution must use the DO's name, not reduced state
+    // (which is the "uninitialized" placeholder until the parent is appended to).
+    counter += 1;
+    const parentName = `stream:/review/resolve${counter}`;
+    const parent = STREAM.getByName(parentName);
+
+    // Never append directly to the parent — it stays lazy. Append to a child.
+    const committed = (await parent.append({
+      streamPath: "child",
+      event: { type: "test.resolve", payload: { k: 1 } },
+    })) as StreamEvent;
+    expect(committed.type).toBe("test.resolve");
+
+    // The intended `${parentPath}/child` stream received it...
+    const child = (await STREAM.getByName(`${parentName}/child`).getEvents()) as StreamEvent[];
+    expect(child.some((e) => e.type === "test.resolve")).toBe(true);
+
+    // ...and it did not leak into the parent (which would happen if resolution
+    // used the placeholder path).
+    const parentEvents = (await parent.getEvents()) as StreamEvent[];
+    expect(parentEvents.some((e) => e.type === "test.resolve")).toBe(false);
+  });
 });

--- a/tasks/streams-review-fixes.md
+++ b/tasks/streams-review-fixes.md
@@ -244,24 +244,44 @@ instantiates the DO and writes a `woken` event. Consequences:
   full reduce + KV write + connection fan-out.
 - A pure reader can never be side-effect-free; any touch mutates durable state.
 
-- [ ] **Defer schema + `created` to the first `append`.** Move
-      `#ensureStorageSchema()` and the `created` append into the append path
-      (`#appendBatchHere`), guarded so it runs once.
-- [ ] **Reconsider `woken` entirely.** Almost nothing consumes it (only the
-      circuit-breaker's pass-through list and the paused-gate exception). Prefer
-      making incarnation id a piece of runtime/core state rather than a logged
-      event, or drop it. If kept, it must not be what initializes a stream.
-- [ ] **Couplings to handle when init goes lazy:**
-  - `getEvents` / `runtimeState` / `getEvent` on a never-appended stream must
-    return empty / initial state rather than throw.
-  - `#reconcile()` on boot (`stream.ts:81`) currently assumes state was read in
-    the constructor; rework so boot reconcile works from recovered-or-empty
-    state.
-  - The `created`-must-be-offset-1 special case
-    (`processors/core/implementation.ts:108-113`) gets simpler once `created` is
-    the deterministic first append.
-- [ ] This is also the single biggest length win in `stream.ts`: it collapses
-      the constructor and the offset-1 branch.
+**Status (2026-06-10): IMPLEMENTED (branch `streams-review-stage2-lazy-init`, off main).**
+
+- [x] **Deferred schema + `created` to the first append.** The constructor no
+      longer creates tables or appends anything for an uninitialized stream; it
+      only detects existing storage (`#eventsTableExists()` → `#storageReady`).
+      `#appendBatchHere` ensures the schema and prepends the `created` event
+      (offset 1) on the first real append, and strips it from the input-aligned
+      return value so `append()` still returns the caller's event.
+- [x] **`woken` decision:** kept as a feature but appended **only when an
+      already-initialized stream wakes** (`maxOffset > 0`), preserving the
+      audit-trail/e2e behavior for active streams. A fresh stream's first boot no
+      longer logs a `woken` (it logs `created` via the first append). I did NOT
+      remove `woken` — it's product-observable (example-app UI, circuit-breaker
+      reset, incarnationId) and e2e-asserted; full removal can be a later call.
+- [x] **Couplings handled:** read helpers (`getEvents` / `getEvent` /
+      `#readHighestEventOffset` / range reads) short-circuit on `!#storageReady`;
+      `runtimeState`/`reduce` are memory-only; boot `#reconcile()` runs only when
+      `maxOffset > 0`. `readCoreProcessorState` only replays the event log when
+      storage exists. The `created`-must-be-offset-1 branch stays valid (created
+      is offset 1 as the first append).
+- [x] Covered by 3 new DO tests (Stage 2 — lazy initialization): empty fresh
+      stream (no tables), first append prepends `created`@1 / returns caller's
+      event@2 / no `woken`, and `woken` reappears when an initialized stream
+      wakes on a new incarnation (kill + fresh stub).
+
+**Behavior change / fallout (needs a human e2e pass):** visiting/subscribing to a
+stream no longer auto-creates it — a never-appended stream is empty until the
+first append. This changes the example-app UX (a freshly-opened stream shows 0
+events) and invalidates the gated browser/capnweb e2e assertions that expect
+`created`/`woken` on visit (`example-app/e2e/playwright/stream-browser.spec.ts`
+~15 `created`-visible checks + the `woken` count at :792; `stream-capnweb.test.ts`
+:302-303,:391-402). These are `STREAM_STAGING_E2E`/Playwright-gated (not in CI).
+**Left for a follow-up that can actually run e2e** — either embrace empty-on-visit
+and update the tests, or have the example app append a marker on load.
+
+- [ ] Follow-up: update example-app e2e for empty-on-visit (human-run).
+- [ ] Optional (not done): further shrink `stream.ts`; the constructor did get
+      smaller but the offset-1 branch in `core/implementation.ts` was left as-is.
 
 ---
 

--- a/tasks/streams-review-fixes.md
+++ b/tasks/streams-review-fixes.md
@@ -252,12 +252,11 @@ instantiates the DO and writes a `woken` event. Consequences:
       `#appendBatchHere` ensures the schema and prepends the `created` event
       (offset 1) on the first real append, and strips it from the input-aligned
       return value so `append()` still returns the caller's event.
-- [x] **`woken` decision:** kept as a feature but appended **only when an
-      already-initialized stream wakes** (`maxOffset > 0`), preserving the
-      audit-trail/e2e behavior for active streams. A fresh stream's first boot no
-      longer logs a `woken` (it logs `created` via the first append). I did NOT
-      remove `woken` — it's product-observable (example-app UI, circuit-breaker
-      reset, incarnationId) and e2e-asserted; full removal can be a later call.
+- [x] **`woken` decision (owner: keep both `created` and `woken`):** the first
+      append prepends **`created`@1 + `woken`@2** then the caller's event@3, and
+      every later incarnation still appends its own `woken` on wake. So the
+      post-first-append state is identical to the old eager behavior — only the
+      window between opening a stream and its first append differs (now empty).
 - [x] **Couplings handled:** read helpers (`getEvents` / `getEvent` /
       `#readHighestEventOffset` / range reads) short-circuit on `!#storageReady`;
       `runtimeState`/`reduce` are memory-only; boot `#reconcile()` runs only when
@@ -265,23 +264,26 @@ instantiates the DO and writes a `woken` event. Consequences:
       storage exists. The `created`-must-be-offset-1 branch stays valid (created
       is offset 1 as the first append).
 - [x] Covered by 3 new DO tests (Stage 2 — lazy initialization): empty fresh
-      stream (no tables), first append prepends `created`@1 / returns caller's
-      event@2 / no `woken`, and `woken` reappears when an initialized stream
-      wakes on a new incarnation (kill + fresh stub).
+      stream (no tables/events), first append prepends `created`@1 + `woken`@2 /
+      returns caller's event@3, and a second `woken` appears when an initialized
+      stream wakes on a new incarnation (kill + fresh stub).
 
-**Behavior change / fallout (needs a human e2e pass):** visiting/subscribing to a
-stream no longer auto-creates it — a never-appended stream is empty until the
-first append. This changes the example-app UX (a freshly-opened stream shows 0
-events) and invalidates the gated browser/capnweb e2e assertions that expect
-`created`/`woken` on visit (`example-app/e2e/playwright/stream-browser.spec.ts`
-~15 `created`-visible checks + the `woken` count at :792; `stream-capnweb.test.ts`
-:302-303,:391-402). These are `STREAM_STAGING_E2E`/Playwright-gated (not in CI).
-**Left for a follow-up that can actually run e2e** — either embrace empty-on-visit
-and update the tests, or have the example app append a marker on load.
+**Behavior change (intended):** connecting to / opening a stream no longer
+auto-creates it — a never-appended stream is empty and leaves no trace (no
+storage, not in any parent's children). It initializes only on the first append.
 
-- [ ] Follow-up: update example-app e2e for empty-on-visit (human-run).
-- [ ] Optional (not done): further shrink `stream.ts`; the constructor did get
-      smaller but the offset-1 branch in `core/implementation.ts` was left as-is.
+- [x] **Example-app e2e rewritten for empty-on-visit** (owner approved):
+      `example-app/e2e/playwright/stream-browser.spec.ts` +
+      `e2e/vitest/stream-capnweb.test.ts`. Only the bare-open / pre-first-append
+      assertions changed (open shows `event-count` "0"; created/woken/counts are
+      asserted after the first append, where the state is unchanged from before).
+      The kill test now appends to initialize then asserts the reconnect `woken`;
+      the reset test asserts the stream goes empty. example-app `tsc` passes.
+      **The Playwright + capnweb suites run in CI via `streams-e2e.yml` on any
+      `packages/streams/**` PR (deploys a per-PR worker) — that run is the
+      verification; they can't be run locally here.\*\*
+- [ ] Optional (not done): further shrink `stream.ts` / the offset-1 branch in
+      `core/implementation.ts`.
 
 ---
 


### PR DESCRIPTION
## What

**Stage 2** of the `packages/streams` review: a stream is no longer initialized eagerly on first touch — it initializes lazily on its first append.

- **Connect to a stream that doesn't exist → empty.** Subscribing/reading a never-appended stream creates no storage and leaves no trace (not in any parent's `childPaths`).
- **First append initializes it:** prepends `created`@1 + `woken`@2, then your event@3. Both lifecycle events are kept; each later DO incarnation still appends its own `woken` on wake. State *after* the first append is identical to the old eager behavior — only the open→first-append window is now empty.

## Implementation (Stream DO)

- Constructor does no writes for an uninitialized stream; only detects existing storage (`#eventsTableExists()` → `#storageReady`). An initialized stream still appends `woken` + reconciles on wake.
- `#appendBatchHere` ensures the schema and prepends `[created, woken]` on the first append, stripped from the input-aligned return.
- Read paths short-circuit when storage isn't ready; `readCoreProcessorState` only replays the log when it exists.
- **Path resolution** uses the DO's own name (`#streamIdentity()`), not reduced state (the `"uninitialized"` placeholder pre-init would misroute relative/child appends).

## Tests — verified locally

Always-on DO tests (vitest-pool-workers): empty fresh stream, first-append created@1/woken@2/event@3, woken-per-incarnation, relative-child resolution on a never-initialized parent. **node 67 + workers 12 green.**

example-app **e2e** rewritten for empty-on-visit and **run locally** against a `vite dev` worker (Playwright auto-starts the dev server; chromium only; no Doppler): **Playwright 26/26, capnweb 18 + 1 expected-fail.** Running it caught two real bugs (fixed here): relative-path misrouting on a lazy parent, and the example app naming the circuit-breaker runner DO from the lazy `core.path` (→ shared runner that never tripped) — now uses the real `streamView.path`.

## ⚠️ Needs rebase onto #1460

`#1460` (subscriber-presence facts + reconciler homogenization) landed on main after this branch and significantly reworked the Stream DO (CORE_STATE_VERSION→4, core processor owns reconciliation, `processor-registered` → `subscriber-connected`). This branch now conflicts and needs a deliberate rebase that re-applies lazy init on the new reconciler model — not a mechanical merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
