### PR TITLE
prefetchItxQuery: no errored residue after a failed first fetch

### DIFF
--- a/apps/os/src/itx/loader.test.ts
+++ b/apps/os/src/itx/loader.test.ts
@@ -65,10 +65,28 @@ describe("prefetchItxQuery", () => {
 
     await expect(prefetchItxQuery({ query, queryClient })).resolves.toBeUndefined();
 
-    // The cache holds no data; the component's own query re-runs the fetch
-    // and surfaces the failure in its inline error states.
+    // The cache holds NOTHING — not even the error: a data-less errored entry
+    // would make the consuming component flash its error state on mount
+    // before retryOnMount recovers. The component's own query fetches fresh
+    // and surfaces any failure in its inline error states.
     expect(queryClient.getQueryData(query.queryKey)).toBeUndefined();
-    expect(queryClient.getQueryState(query.queryKey)?.status).toBe("error");
+    expect(queryClient.getQueryState(query.queryKey)).toBeUndefined();
+  });
+
+  test("a failed revalidation keeps existing data (stale beats empty)", async () => {
+    serverItx.mockResolvedValue(fakeHandle);
+    const queryClient = makeQueryClient();
+    const query = streamsListQuery();
+    queryClient.setQueryData(query.queryKey, ["/", "/agents"]);
+    // Make the entry stale so ensureQueryData revalidates — and fail that.
+    queryClient.getQueryCache().find({ queryKey: query.queryKey })!.setState({
+      dataUpdatedAt: 0,
+    });
+    serverItx.mockRejectedValue(new Error("kaboom"));
+
+    await expect(prefetchItxQuery({ query, queryClient })).resolves.toBeUndefined();
+
+    expect(queryClient.getQueryData(query.queryKey)).toEqual(["/", "/agents"]);
   });
 
   test("swallows queryFn failures from the kernel", async () => {
@@ -83,5 +101,6 @@ describe("prefetchItxQuery", () => {
 
     await expect(prefetchItxQuery({ query, queryClient })).resolves.toBeUndefined();
     expect(queryClient.getQueryData(query.queryKey)).toBeUndefined();
+    expect(queryClient.getQueryState(query.queryKey)).toBeUndefined();
   });
 });

--- a/apps/os/src/itx/loader.ts
+++ b/apps/os/src/itx/loader.ts
@@ -74,6 +74,15 @@ export async function prefetchItxQuery<TData>(input: {
       staleTime: input.query.staleTime,
     });
   } catch {
-    // Swallowed by design — see the doc comment above.
+    // Swallowed by design — see the doc comment above. One bit of hygiene: a
+    // failed FIRST fetch leaves an errored, data-less cache entry behind, and
+    // a component mounting against it flashes its error state before
+    // retryOnMount refetches. Removing the empty entry means the component
+    // mounts pending instead. An entry that already HAS data is kept — stale
+    // data plus a background error beats no data.
+    const state = input.queryClient.getQueryState(input.query.queryKey);
+    if (state?.status === "error" && state.data === undefined) {
+      input.queryClient.removeQueries({ exact: true, queryKey: input.query.queryKey });
+    }
   }
 }


### PR DESCRIPTION
Follow-up to #1457, addressing bugbot's "failed prefetch poisons query cache" finding: a swallowed prefetch failure left an errored, data-less entry on the shared query key, so the consuming component (streams tree, breadcrumb navigators) flashed its error state on mount before `retryOnMount` refetched. The catch now removes the entry when it is errored **and** empty — components mount pending and fetch fresh. Entries that already hold data are kept (stale data + background error beats no data), covered by a new revalidation test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow loader/cache hygiene change with matching unit tests; no auth or API surface changes.
> 
> **Overview**
> Fixes a **prefetch cache poisoning** issue: when `prefetchItxQuery` swallowed a failure on a **first** fetch, React Query still left an **errored, data-less** entry on the shared key, so streams tree / breadcrumb UI briefly showed error on mount before `retryOnMount` refetched.
> 
> After the catch, the loader now **`removeQueries`** when state is `error` and `data` is undefined, so consumers mount **pending** and fetch fresh. **Stale entries with existing data are untouched** when revalidation fails—stale data is preferred over wiping the cache.
> 
> Tests now assert no cache residue on failed prefetch and add coverage for failed revalidation with seeded data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3219b1530a952cd1e70eaefb2d670358443f17cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T18:09:44.936Z",
      "headSha": "3219b1530a952cd1e70eaefb2d670358443f17cd",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27295793774",
      "shortSha": "3219b15"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `3219b15`
Preview: https://os.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27295793774)
Updated: 2026-06-10T18:09:44.936Z
<!-- /CLOUDFLARE_PREVIEW -->