### PR TITLE
fix(streams+agent): re-dial dead outbound subscribers, resurrect scheduled LLM turns after DO eviction

### DIFF
--- a/apps/os/src/domains/agents/stream-processors/agent/contract.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/contract.ts
@@ -49,7 +49,16 @@ export const AgentProcessorContract = defineProcessorContract({
       .default({ model: DEFAULT_WORKERS_AI_AGENT_MODEL, runOpts: {}, debounceMs: 1000 }),
     currentRequest: z
       .discriminatedUnion("phase", [
-        z.object({ phase: z.literal("scheduled"), requestId: z.string() }),
+        z.object({
+          phase: z.literal("scheduled"),
+          requestId: z.string(),
+          // Offset of the llm-request-scheduled event. Lets a rehydrated
+          // processor instance re-arm the debounce timer (the timer dies with
+          // the Durable Object; this is the durable anchor it is rebuilt
+          // from). Optional so checkpoints written before this field existed
+          // still parse.
+          scheduledOffset: z.number().int().positive().optional(),
+        }),
         z.object({ phase: z.literal("requested"), llmRequestId: z.number().int().positive() }),
       ])
       .nullable()
@@ -270,7 +279,11 @@ export function reduceAgentEvent(args: { state: AgentState; event: AgentConsumed
     case "events.iterate.com/agent/llm-request-scheduled":
       return {
         ...state,
-        currentRequest: { phase: "scheduled" as const, requestId: event.payload.requestId },
+        currentRequest: {
+          phase: "scheduled" as const,
+          requestId: event.payload.requestId,
+          scheduledOffset: event.offset,
+        },
         pendingTriggerCount: 0,
       };
     case "events.iterate.com/agent/llm-request-requested":

--- a/apps/os/src/domains/agents/stream-processors/agent/implementation.test.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/implementation.test.ts
@@ -282,6 +282,191 @@ describe("AgentProcessor", () => {
     expect(payload.content).toContain("offset 44");
   });
 
+  // Regression tests for the 2026-06-10 prod incident: a deploy evicted the
+  // agent's Durable Object between `llm-request-scheduled` committing and the
+  // in-memory debounce timer firing. The rehydrated instance never re-armed
+  // the timer, so the turn never fired — and default-policy follow-up inputs
+  // only tried to reset the nonexistent timer, wedging the stream forever.
+  describe("scheduled request recovery after rehydration", () => {
+    it("re-arms the debounce timer from a rehydrated checkpoint on snapshot()", async () => {
+      vi.useFakeTimers();
+      const { stream, appended } = memoryStream();
+      const scheduled = agentEvent({
+        type: "events.iterate.com/agent/llm-request-scheduled",
+        payload: { requestId: "req_lost", debounceMs: 1000, model: "test-model" },
+        offset: 7,
+      });
+      const triggeringInput = agentEvent({
+        type: "events.iterate.com/agent/input-added",
+        payload: { content: "hello?", llmRequestPolicy: { behaviour: "after-current-request" } },
+        offset: 6,
+      });
+      // Simulates the post-eviction shape: the checkpoint says a request is
+      // scheduled, but this (fresh) instance has no timer for it.
+      const processor = newAgentProcessor({
+        stream,
+        snapshot: {
+          offset: 7,
+          state: {
+            ...initialState(),
+            history: [{ role: "user", content: "hello?" }],
+            currentRequest: { phase: "scheduled", requestId: "req_lost", scheduledOffset: 7 },
+          },
+        },
+        readStreamEvents: async () => [triggeringInput, scheduled],
+      });
+
+      // The host calls snapshot() on every subscription (re-)handshake — even
+      // when the stream has no new events to deliver.
+      await processor.snapshot();
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(appended).toEqual([
+        expect.objectContaining({
+          type: "events.iterate.com/agent/llm-request-requested",
+          idempotencyKey: "agent/llm-request-requested@7",
+        }),
+      ]);
+    });
+
+    it("re-arms the timer when a batch replays the scheduled state", async () => {
+      vi.useFakeTimers();
+      const { stream, appended } = memoryStream();
+      const scheduled = agentEvent({
+        type: "events.iterate.com/agent/llm-request-scheduled",
+        payload: { requestId: "req_replayed", debounceMs: 1000, model: "test-model" },
+        offset: 7,
+      });
+      const processor = newAgentProcessor({
+        stream,
+        readStreamEvents: async () => [scheduled],
+      });
+
+      // Replay path: the scheduled event arrives in a batch (e.g. after a
+      // re-handshake replays from an older checkpoint). processEvent treats it
+      // as a no-op; the batch-level recovery must still arm the timer.
+      await processor.ingest({ events: [scheduled], streamMaxOffset: 7 });
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(appended).toEqual([
+        expect.objectContaining({
+          type: "events.iterate.com/agent/llm-request-requested",
+          idempotencyKey: "agent/llm-request-requested@7",
+        }),
+      ]);
+    });
+
+    it("recovers the scheduled offset from history for checkpoints written before scheduledOffset existed", async () => {
+      vi.useFakeTimers();
+      const { stream, appended } = memoryStream();
+      const scheduled = agentEvent({
+        type: "events.iterate.com/agent/llm-request-scheduled",
+        payload: { requestId: "req_old", debounceMs: 1000, model: "test-model" },
+        offset: 9,
+      });
+      const processor = newAgentProcessor({
+        stream,
+        snapshot: {
+          offset: 9,
+          state: {
+            ...initialState(),
+            // Old checkpoint shape: no scheduledOffset.
+            currentRequest: { phase: "scheduled", requestId: "req_old" },
+          },
+        },
+        readStreamEvents: async () => [scheduled],
+      });
+
+      await processor.snapshot();
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(appended).toEqual([
+        expect.objectContaining({
+          type: "events.iterate.com/agent/llm-request-requested",
+          idempotencyKey: "agent/llm-request-requested@9",
+        }),
+      ]);
+    });
+
+    it("does not double-arm when the live instance already owns the scheduled request", async () => {
+      vi.useFakeTimers();
+      const { stream, appended } = memoryStream();
+      const triggeringInput = agentEvent({
+        type: "events.iterate.com/agent/input-added",
+        payload: { content: "hi", llmRequestPolicy: { behaviour: "after-current-request" } },
+        offset: 3,
+      });
+      const processor = newAgentProcessor({
+        stream,
+        readStreamEvents: async () => [triggeringInput],
+      });
+
+      // Live path: the input schedules the request (memoryStream commits the
+      // scheduled event at offset 100) and arms the timer in-instance.
+      await processor.ingest({ events: [triggeringInput], streamMaxOffset: 3 });
+      const scheduledInput = appended[0] as { payload: { requestId: string } };
+      // The stream then delivers the committed scheduled event back; recovery
+      // must recognize the live timer instead of re-arming.
+      await processor.ingest({
+        events: [
+          agentEvent({
+            type: "events.iterate.com/agent/llm-request-scheduled",
+            payload: {
+              requestId: scheduledInput.payload.requestId,
+              debounceMs: 1000,
+              model: "test-model",
+            },
+            offset: 100,
+          }),
+        ],
+        streamMaxOffset: 100,
+      });
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const requested = appended.filter(
+        (event) => event.type === "events.iterate.com/agent/llm-request-requested",
+      );
+      expect(requested).toHaveLength(1);
+    });
+
+    it("retries the handoff append instead of dropping the turn when it fails", async () => {
+      vi.useFakeTimers();
+      const { stream, appended } = memoryStream();
+      const originalAppend = stream.append.bind(stream);
+      let failNextRequestAppend = true;
+      stream.append = (args: Parameters<typeof stream.append>[0]) => {
+        if (
+          (args.event as { type: string }).type ===
+            "events.iterate.com/agent/llm-request-requested" &&
+          failNextRequestAppend
+        ) {
+          failNextRequestAppend = false;
+          throw new Error("Network connection lost.");
+        }
+        return originalAppend(args);
+      };
+      const triggeringInput = agentEvent({
+        type: "events.iterate.com/agent/input-added",
+        payload: { content: "hi", llmRequestPolicy: { behaviour: "after-current-request" } },
+        offset: 3,
+      });
+      const processor = newAgentProcessor({
+        stream,
+        readStreamEvents: async () => [triggeringInput],
+      });
+
+      await processor.ingest({ events: [triggeringInput], streamMaxOffset: 3 });
+      await vi.advanceTimersByTimeAsync(1000); // debounce fires; append fails
+      await vi.advanceTimersByTimeAsync(1000); // retry timer fires; append succeeds
+
+      expect(appended).toContainEqual(
+        expect.objectContaining({
+          type: "events.iterate.com/agent/llm-request-requested",
+        }),
+      );
+    });
+  });
+
   it("re-reads stream history before handing a scheduled LLM request to providers", async () => {
     vi.useFakeTimers();
     const { stream, appended } = memoryStream();

--- a/apps/os/src/domains/agents/stream-processors/agent/implementation.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/implementation.ts
@@ -49,6 +49,14 @@ type ScheduledLlmRequest = {
   scheduledEvent: { offset: number };
 };
 
+/**
+ * Retry delay when the `llm-request-requested` handoff append fails. The
+ * scheduled request is a durable promise (state stays `phase: "scheduled"`
+ * until the handoff commits), so a transient append failure must re-arm the
+ * timer instead of dropping the turn.
+ */
+const LLM_REQUEST_HANDOFF_RETRY_MS = 1000;
+
 export class AgentProcessor extends StreamProcessor<AgentProcessorContract, AgentProcessorDeps> {
   readonly contract = AgentProcessorContract;
 
@@ -64,6 +72,33 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
     args: Parameters<StreamProcessor<AgentProcessorContract>["reduce"]>[0],
   ) {
     return reduceAgentEvent(args);
+  }
+
+  /**
+   * The host calls `snapshot()` on every subscription (re-)handshake. A
+   * rehydrated instance whose durable state says a request is scheduled holds
+   * no timer for it — the timer died with the previous Durable Object
+   * incarnation — so this is where the pending turn is resurrected even when
+   * the stream has no new events to deliver. Without it the stream wedges
+   * permanently: the scheduled request never fires, and later default-policy
+   * inputs only try to reset the (nonexistent) timer.
+   */
+  override async snapshot(): Promise<
+    Awaited<ReturnType<StreamProcessor<AgentProcessorContract>["snapshot"]>>
+  > {
+    const snapshot = await super.snapshot();
+    this.#ensureScheduledLlmRequestTimer({ state: snapshot.state });
+    return snapshot;
+  }
+
+  protected override async processEventBatch(
+    args: Parameters<StreamProcessor<AgentProcessorContract>["processEventBatch"]>[0],
+  ): Promise<void> {
+    await super.processEventBatch(args);
+    // Covers the replay path: a batch can reduce `llm-request-scheduled` from
+    // history (at or below the side-effect anchor, so processEvent never runs
+    // for it) and still owe the stream a turn.
+    this.#ensureScheduledLlmRequestTimer({ state: args.state });
   }
 
   protected override processEvent(
@@ -340,6 +375,53 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
     this.#armLlmRequestDebounceTimer({ ...args, scheduledEvent });
   }
 
+  /**
+   * Re-arms the debounce timer when durable state says a request is scheduled
+   * but this instance holds no timer for it. The two ways to get there:
+   * rehydration after a Durable Object eviction, and an instance whose
+   * handoff attempt failed. The handoff append is idempotent (keyed off the
+   * scheduled event's offset), so re-arming can never double-request.
+   */
+  #ensureScheduledLlmRequestTimer(args: { state: AgentState }) {
+    const currentRequest = args.state.currentRequest;
+    if (currentRequest?.phase !== "scheduled") return;
+    if (this.#scheduledLlmRequest?.requestId === currentRequest.requestId) return;
+
+    const debounceMs = args.state.llmConfig.debounceMs;
+    if (currentRequest.scheduledOffset !== undefined) {
+      this.#armLlmRequestDebounceTimer({
+        requestId: currentRequest.requestId,
+        debounceMs,
+        scheduledEvent: { offset: currentRequest.scheduledOffset },
+      });
+      return;
+    }
+
+    // Checkpoint written before scheduledOffset existed: recover the offset
+    // from durable history (the scheduled event must be there — reduced state
+    // only says "scheduled" because it was committed).
+    this.runInBackground(async () => {
+      const events = await this.deps.readStreamEvents();
+      const scheduledEvent = events.find(
+        (event) =>
+          event.type === "events.iterate.com/agent/llm-request-scheduled" &&
+          (event.payload as { requestId?: string }).requestId === currentRequest.requestId,
+      );
+      if (scheduledEvent === undefined) {
+        console.error("[agent] scheduled llm request has no llm-request-scheduled event", {
+          requestId: currentRequest.requestId,
+        });
+        return;
+      }
+      if (this.#scheduledLlmRequest?.requestId === currentRequest.requestId) return;
+      this.#armLlmRequestDebounceTimer({
+        requestId: currentRequest.requestId,
+        debounceMs,
+        scheduledEvent: { offset: scheduledEvent.offset },
+      });
+    });
+  }
+
   #armLlmRequestDebounceTimer(args: {
     requestId: string;
     debounceMs: number;
@@ -360,34 +442,47 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
   async #requestScheduledLlmWork(args: { requestId: string }) {
     if (this.#scheduledLlmRequest?.requestId !== args.requestId) return;
 
-    /**
-     * Rebuild the LLM handoff from durable stream history at the last possible
-     * moment. The request debounce timer is independent from batch delivery, so
-     * it can fire after the user-triggering input has been reduced but before
-     * related non-triggering context rows (e.g. the codemode primer) have
-     * reached this processor. Reading and reducing the committed stream here
-     * makes the provider request reflect the stream, not a stale warm object.
-     */
-    const events = await this.deps.readStreamEvents();
-    const stateAtRequest = reduceAgentEvents({ events });
-
     const scheduledEvent = this.#scheduledLlmRequest.scheduledEvent;
     this.#scheduledLlmRequest = null;
-    await this.ctx.stream.append({
-      event: {
-        type: "events.iterate.com/agent/llm-request-requested",
-        idempotencyKey: buildProcessorIdempotencyKey({
-          processor: AgentProcessorContract,
-          key: "llm-request-requested",
-          sourceEvent: scheduledEvent,
-        }),
-        payload: {
-          model: stateAtRequest.llmConfig.model,
-          body: buildLlmChatRequest(stateAtRequest),
-          runOpts: stateAtRequest.llmConfig.runOpts,
+    try {
+      /**
+       * Rebuild the LLM handoff from durable stream history at the last possible
+       * moment. The request debounce timer is independent from batch delivery, so
+       * it can fire after the user-triggering input has been reduced but before
+       * related non-triggering context rows (e.g. the codemode primer) have
+       * reached this processor. Reading and reducing the committed stream here
+       * makes the provider request reflect the stream, not a stale warm object.
+       */
+      const events = await this.deps.readStreamEvents();
+      const stateAtRequest = reduceAgentEvents({ events });
+
+      await this.ctx.stream.append({
+        event: {
+          type: "events.iterate.com/agent/llm-request-requested",
+          idempotencyKey: buildProcessorIdempotencyKey({
+            processor: AgentProcessorContract,
+            key: "llm-request-requested",
+            sourceEvent: scheduledEvent,
+          }),
+          payload: {
+            model: stateAtRequest.llmConfig.model,
+            body: buildLlmChatRequest(stateAtRequest),
+            runOpts: stateAtRequest.llmConfig.runOpts,
+          },
         },
-      },
-    });
+      });
+    } catch (error) {
+      // The durable state still says "scheduled" (the handoff never
+      // committed), so dropping the timer here would wedge the stream until
+      // the next rehydration. Re-arm and retry; the idempotency key makes a
+      // raced duplicate harmless.
+      console.error("[agent] scheduled llm request handoff failed; retrying", error);
+      this.#armLlmRequestDebounceTimer({
+        requestId: args.requestId,
+        debounceMs: LLM_REQUEST_HANDOFF_RETRY_MS,
+        scheduledEvent,
+      });
+    }
   }
 
   async #emitQueued(args: { sourceEvent: { offset: number } }) {

--- a/packages/streams/src/workers/durable-objects/stream-redial.workers.test.ts
+++ b/packages/streams/src/workers/durable-objects/stream-redial.workers.test.ts
@@ -1,0 +1,144 @@
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+// Regression tests for tasks/streams-review-fixes.md M1: a subscriber DO that
+// dies (eviction, deploy, abort) leaves the Stream DO holding a dead outbound
+// connection. Before the fix, batch delivery rejections were swallowed, the
+// dead connection stayed in the stream's connection map, and reconcile skipped
+// its key — so the subscriber was never re-dialed and delivery stalled
+// silently for the rest of the stream incarnation. This is exactly the prod
+// 2026-06-10 Slack-agent shape: a deploy evicted the agent host DO and the
+// agent never received another event.
+//
+// The test drives the real path: Stream DO -> Callable dial ->
+// StreamProcessorRunner (echo processor) -> subscribeOutbound -> batch pump,
+// then aborts the runner to simulate a deploy and asserts the next append
+// still reaches a (fresh) runner instance.
+
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { durableObjectProcessorSubscriber } from "../../shared/callable-subscriber.ts";
+import type { StreamEvent } from "../../shared/event.ts";
+import type { StreamProcessorRunner } from "./stream-processor-runner.ts";
+import type { Stream } from "./stream.ts";
+
+const STREAM = (env as unknown as { STREAM: DurableObjectNamespace<Stream> }).STREAM;
+const RUNNER = (
+  env as unknown as { STREAM_PROCESSOR_RUNNER: DurableObjectNamespace<StreamProcessorRunner> }
+).STREAM_PROCESSOR_RUNNER;
+
+const INPUT_TYPE = "events.iterate.com/echo-example/input-received";
+const OUTPUT_TYPE = "events.iterate.com/echo-example/output-echoed";
+
+let counter = 0;
+function freshNames() {
+  counter += 1;
+  return {
+    streamName: `redial:/redial/t${counter}`,
+    runnerName: `redial-runner-${counter}`,
+  };
+}
+
+async function appendEvent(
+  stream: DurableObjectStub<Stream>,
+  event: { type: string; payload: unknown; idempotencyKey?: string },
+) {
+  return await runInDurableObject(stream, (instance) => instance.append({ event }));
+}
+
+async function waitForEvent(
+  stream: DurableObjectStub<Stream>,
+  predicate: (event: StreamEvent) => boolean,
+  description: string,
+): Promise<StreamEvent> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const events = await runInDurableObject(stream, (instance) =>
+      instance.getEvents({ afterOffset: 0 }),
+    );
+    const match = events.find(predicate);
+    if (match !== undefined) return match;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+async function configureEchoSubscription(args: { streamName: string; runnerName: string }) {
+  const stream = STREAM.getByName(args.streamName);
+  await appendEvent(stream, {
+    type: "events.iterate.com/stream/subscription-configured",
+    payload: {
+      subscriptionKey: `echo:${args.runnerName}`,
+      subscriber: durableObjectProcessorSubscriber({
+        bindingName: "STREAM_PROCESSOR_RUNNER",
+        durableObjectName: args.runnerName,
+        processorName: "echo-example",
+      }),
+    },
+  });
+  return stream;
+}
+
+describe("outbound re-dial after subscriber death (M1)", () => {
+  it("delivers an event appended after the subscriber DO is aborted", async () => {
+    const { streamName, runnerName } = freshNames();
+    const stream = await configureEchoSubscription({ streamName, runnerName });
+
+    // Sanity: the live path works before the simulated deploy.
+    const first = await appendEvent(stream, { type: INPUT_TYPE, payload: { n: 1 } });
+    await waitForEvent(
+      stream,
+      (event) => event.type === OUTPUT_TYPE && event.offset > first.offset,
+      "echo of the first input",
+    );
+
+    // Simulate a deploy: abort the runner DO. The stream's retained delivery
+    // stub now points at a dead incarnation.
+    await runInDurableObject(RUNNER.getByName(runnerName), (instance) =>
+      // `ctx` is protected on DurableObject; tests reach in to simulate the eviction.
+      (instance as unknown as { ctx: DurableObjectState }).ctx.abort("simulated deploy eviction"),
+    ).catch(() => {
+      // The abort kills the instance mid-call; the rejection is the point.
+    });
+
+    // The append after the abort must still reach a (fresh) runner: delivery
+    // into the dead stub rejects, the stream drops the connection and
+    // re-dials, and the runner re-handshakes from its durable checkpoint.
+    const second = await appendEvent(stream, { type: INPUT_TYPE, payload: { n: 2 } });
+    const echoed = await waitForEvent(
+      stream,
+      (event) => event.type === OUTPUT_TYPE && event.offset > second.offset,
+      "echo of the input appended after the subscriber died",
+    );
+    expect((echoed.payload as { seen: number }).seen).toBe(2);
+  }, 30_000);
+
+  it("advances the subscriber's durable checkpoint past events appended after the abort", async () => {
+    const { streamName, runnerName } = freshNames();
+    const stream = await configureEchoSubscription({ streamName, runnerName });
+
+    const first = await appendEvent(stream, { type: INPUT_TYPE, payload: { n: 1 } });
+    await waitForEvent(
+      stream,
+      (event) => event.type === OUTPUT_TYPE && event.offset > first.offset,
+      "echo of the first input",
+    );
+
+    await runInDurableObject(RUNNER.getByName(runnerName), (instance) =>
+      (instance as unknown as { ctx: DurableObjectState }).ctx.abort("simulated deploy eviction"),
+    ).catch(() => {});
+
+    const second = await appendEvent(stream, { type: INPUT_TYPE, payload: { n: 2 } });
+
+    // The Stream DO's connection cursor advances even into a dead stub (that
+    // is the bug), so the only honest signal is the subscriber side: the
+    // runner's durable processor checkpoint (DO KV, survives the abort) only
+    // moves past the second input if the stream actually re-dialed and a
+    // fresh runner incarnation ingested the batch.
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const snapshot = await runInDurableObject(RUNNER.getByName(runnerName), (instance) =>
+        instance.runtimeState({ processorName: "echo-example" }),
+      );
+      if ((snapshot.snapshot?.offset ?? 0) >= second.offset) return;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    throw new Error("subscriber checkpoint never advanced past the post-abort append");
+  }, 30_000);
+});

--- a/packages/streams/src/workers/durable-objects/stream.ts
+++ b/packages/streams/src/workers/durable-objects/stream.ts
@@ -634,14 +634,33 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
         ? undefined
         : new Set(args.eventTypes);
 
+    let cursor = args.replayAfterOffset ?? this.#coreProcessorState.maxOffset;
+    let draining = false;
+    let open = true;
+
     // Workers RPC disposes parameter stubs when an RPC method returns unless the
     // callee duplicates them. Keep a retained callback because this stream calls
     // it later from the pump, after subscribe() has returned:
     // https://developers.cloudflare.com/workers/runtime-apis/rpc/lifecycle/
-    const processEventBatch = retainProcessEventBatch(args.processEventBatch);
-    let cursor = args.replayAfterOffset ?? this.#coreProcessorState.maxOffset;
-    let draining = false;
-    let open = true;
+    const processEventBatch = retainProcessEventBatch(args.processEventBatch, {
+      // A rejected delivery means the subscriber stub is gone (callee DO
+      // evicted/redeployed/aborted) or the batch was refused. Either way the
+      // connection is not making progress: drop it so reconcile can re-dial,
+      // and the subscriber re-handshakes from its durable checkpoint — replay
+      // covers whatever this connection's cursor already advanced past.
+      // Without this, a dead stub stayed in #connections for the rest of the
+      // incarnation and #reconcile skipped its key, stalling delivery forever.
+      onDeliveryError: (error) => {
+        if (!open) return;
+        console.error("Stream event batch delivery failed; dropping connection for re-dial", {
+          subscriptionKey,
+          direction: args.direction,
+          error,
+        });
+        connection.close();
+        if (args.direction === "outbound") this.#reconcile();
+      },
+    });
 
     // The single delivery path: drain committed events to the callback, then park.
     //

--- a/packages/streams/src/workers/rpc-lifecycle.test.ts
+++ b/packages/streams/src/workers/rpc-lifecycle.test.ts
@@ -1,0 +1,94 @@
+// Regression tests for tasks/streams-review-fixes.md M1: broken delivery
+// connections were never detected. Two halves:
+//
+// 1. `onRpcBroken` was guarded by `Object.hasOwn`, which is always false for
+//    Cap'n Web proxy stubs (they intercept the property without exposing an own
+//    descriptor), so the break callback was never wired.
+// 2. The retained delivery callback disposed the remote call result without
+//    observing it, so a delivery rejection (the only break signal native
+//    Workers RPC stubs give us) was swallowed and the dead connection stayed
+//    in the stream's connection map forever.
+
+import { describe, expect, it, vi } from "vitest";
+import type { ProcessEventBatch } from "../types.ts";
+import { retainProcessEventBatch } from "./rpc-lifecycle.ts";
+
+const batch = { namespace: "test", path: "/p", events: [], streamMaxOffset: 0 };
+
+describe("retainProcessEventBatch onRpcBroken wiring (M1)", () => {
+  it("wires onRpcBroken exposed only through a proxy get trap (Cap'n Web stub shape)", () => {
+    const registered: ((error: unknown) => void)[] = [];
+    // Cap'n Web stubs are proxies: `typeof stub.onRpcBroken === "function"`
+    // but `Object.hasOwn(stub, "onRpcBroken")` is false.
+    const stub = new Proxy((() => undefined) as unknown as ProcessEventBatch as object, {
+      get(target, property, receiver) {
+        if (property === "onRpcBroken") {
+          return (callback: (error: unknown) => void) => void registered.push(callback);
+        }
+        return Reflect.get(target, property, receiver);
+      },
+      getOwnPropertyDescriptor() {
+        return undefined;
+      },
+    }) as ProcessEventBatch;
+    expect(Object.hasOwn(stub, "onRpcBroken")).toBe(false);
+
+    const retained = retainProcessEventBatch(stub);
+    const onBroken = vi.fn();
+    retained.onRpcBroken?.(onBroken);
+
+    expect(registered).toHaveLength(1);
+    registered[0]!(new Error("stub broken"));
+    expect(onBroken).toHaveBeenCalledWith(new Error("stub broken"));
+  });
+
+  it("survives a pipelined fake onRpcBroken that rejects at call time (native RPC stub shape)", async () => {
+    // Property access on a Workers RPC stub can fabricate a method that only
+    // fails asynchronously when called. Registration must not throw and must
+    // not produce an unhandled rejection.
+    const fake = Object.assign((() => undefined) as unknown as ProcessEventBatch as object, {
+      onRpcBroken: () => Promise.reject(new Error("no such method")),
+    }) as ProcessEventBatch;
+
+    const retained = retainProcessEventBatch(fake);
+    expect(() => retained.onRpcBroken?.(() => undefined)).not.toThrow();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+});
+
+describe("retainProcessEventBatch delivery rejection (M1)", () => {
+  it("reports a rejected delivery through onDeliveryError", async () => {
+    const failure = new Error("Durable Object reset because its code was updated");
+    const dead: ProcessEventBatch = () => Promise.reject(failure);
+
+    const onDeliveryError = vi.fn();
+    const retained = retainProcessEventBatch(dead, { onDeliveryError });
+    retained(batch);
+
+    await vi.waitFor(() => expect(onDeliveryError).toHaveBeenCalledWith(failure));
+  });
+
+  it("does not report successful deliveries and disposes the settled result", async () => {
+    const disposed = vi.fn();
+    const result = Object.assign(Promise.resolve(undefined), {
+      [Symbol.dispose]: disposed,
+    });
+    const alive: ProcessEventBatch = () => result as unknown as Promise<void>;
+
+    const onDeliveryError = vi.fn();
+    const retained = retainProcessEventBatch(alive, { onDeliveryError });
+    retained(batch);
+
+    await vi.waitFor(() => expect(disposed).toHaveBeenCalled());
+    expect(onDeliveryError).not.toHaveBeenCalled();
+  });
+
+  it("handles synchronous (non-thenable) callback results", () => {
+    const calls: unknown[] = [];
+    const sync: ProcessEventBatch = (delivered) => void calls.push(delivered);
+
+    const retained = retainProcessEventBatch(sync, { onDeliveryError: vi.fn() });
+    expect(() => retained(batch)).not.toThrow();
+    expect(calls).toEqual([batch]);
+  });
+});

--- a/packages/streams/src/workers/rpc-lifecycle.ts
+++ b/packages/streams/src/workers/rpc-lifecycle.ts
@@ -13,13 +13,41 @@ type RetainableProcessEventBatch = ProcessEventBatch &
 
 export function retainProcessEventBatch(
   processEventBatch: ProcessEventBatch,
+  opts: {
+    /**
+     * Observes a rejected batch delivery. Both Workers RPC and Cap'n Web reject
+     * the call promise when the remote stub is broken (callee DO evicted,
+     * redeployed, or aborted), so this is how a stream notices a dead
+     * connection even when `onRpcBroken` is unavailable — see the re-dial
+     * wiring in the Stream DO's `#openConnection`.
+     */
+    onDeliveryError?: (error: unknown) => void;
+  } = {},
 ): RetainedProcessEventBatch {
   const retainable = processEventBatch as RetainableProcessEventBatch;
   const retained = retainable.dup?.() ?? retainable;
   const dispose = retained[Symbol.dispose]?.bind(retained);
   const callback: RetainedProcessEventBatch = Object.assign(
     (batch: Parameters<ProcessEventBatch>[0]) => {
-      const result = retained(batch);
+      let result: unknown;
+      try {
+        result = retained(batch);
+      } catch (error) {
+        // A disposed/broken stub can throw synchronously at call time.
+        opts.onDeliveryError?.(error);
+        return;
+      }
+      if (isThenable(result)) {
+        // Delivery stays fire-and-forget (the pump never awaits the remote
+        // result), but the rejection must be observed: a dead stub rejects
+        // every call, and swallowing that left broken connections in place
+        // forever. Dispose only after settle — disposing a pending Cap'n Web
+        // promise cancels the call.
+        void Promise.resolve(result)
+          .then(undefined, (error: unknown) => opts.onDeliveryError?.(error))
+          .finally(() => disposeIgnoredRpcResult(result));
+        return;
+      }
       disposeIgnoredRpcResult(result);
     },
     {
@@ -28,10 +56,36 @@ export function retainProcessEventBatch(
       },
     },
   );
-  if (Object.hasOwn(retained, "onRpcBroken") && typeof retained.onRpcBroken === "function") {
-    callback.onRpcBroken = retained.onRpcBroken.bind(retained);
+  // Cap'n Web stubs intercept `onRpcBroken` locally but expose no own property
+  // descriptors, so an `Object.hasOwn` guard never wires it. `typeof` is also
+  // unreliable in the other direction: property access on a Workers RPC stub
+  // can fabricate a pipelined method that rejects at call time. Wire whatever
+  // the stub claims to have, defensively — a stub without a real onRpcBroken
+  // is still covered by the onDeliveryError path above.
+  const onRpcBroken = retained.onRpcBroken;
+  if (typeof onRpcBroken === "function") {
+    callback.onRpcBroken = (brokenCallback: (error: unknown) => void) => {
+      try {
+        const result = onRpcBroken.call(retained, brokenCallback) as unknown;
+        if (isThenable(result)) {
+          void Promise.resolve(result).catch(() => {
+            // Pipelined fake: the remote has no onRpcBroken method.
+          });
+        }
+      } catch {
+        // Same: registration is best-effort.
+      }
+    };
   }
   return callback;
+}
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return (
+    value !== null &&
+    (typeof value === "object" || typeof value === "function") &&
+    typeof (value as PromiseLike<unknown>).then === "function"
+  );
 }
 
 export function disposeIgnoredRpcResult(result: unknown): void {

--- a/tasks/streams-review-fixes.md
+++ b/tasks/streams-review-fixes.md
@@ -286,12 +286,20 @@ RPC stubs have no `onRpcBroken` at all. If confirmed:
   DO connection for the incarnation lifetime and shows phantom connections in
   `runtimeState()`.
 
-- [ ] **Verify:** test whether `onRpcBroken` fires for (a) a capnweb stub and
+- [x] **Verify:** test whether `onRpcBroken` fires for (a) a capnweb stub and
       (b) a native RPC stub. Drop the `Object.hasOwn` guard and use
-      `typeof retained.onRpcBroken === "function"`.
-- [ ] **For the native outbound path** (no `onRpcBroken`): add liveness — observe
+      `typeof retained.onRpcBroken === "function"`. _Fixed: `Object.hasOwn`
+      guard dropped; the wiring is defensive because property access on a
+      native RPC stub can fabricate a pipelined method (`rpc-lifecycle.ts`,
+      unit tests in `rpc-lifecycle.test.ts`)._
+- [x] **For the native outbound path** (no `onRpcBroken`): add liveness — observe
       the delivery result and `connection.close()` + `#reconcile()` on rejection.
-      Note this overlaps with the C1 fix; design them together.
+      Note this overlaps with the C1 fix; design them together. _Fixed:
+      `retainProcessEventBatch` takes `onDeliveryError`; the Stream DO drops the
+      connection and re-dials on a rejected delivery, and the subscriber
+      re-handshakes from its checkpoint (C1's generation gate drops stragglers).
+      End-to-end abort/re-dial regression tests in
+      `stream-redial.workers.test.ts`._
 
 ### M2 — Any event with a `source` field crashes the whole `appendBatch` (MAJOR)
 


### PR DESCRIPTION
## Context

Root-cause fixes from today's prd Slack agent outage (second incident of the day). A deploy landed at 16:02:09 UTC — three seconds after a Slack message in `#...C08R1SMTZGD` — evicted the agent host DO mid-run, and the agent never responded to that message or any later one. Diagnosis trail: thread stream `/agents/slack/c08r1smtzgd/ts-1781107326-880549` shows full agent setup then nothing (no LLM request, no error), and observability shows zero completed `SlackAgentDurableObject` invocations account-wide after the deploy.

Two independent bugs compose into "agent permanently silent":

## 1. Streams kernel: dead outbound connections never re-dialed (M1 from `tasks/streams-review-fixes.md`)

Batch delivery into a subscriber stub was fire-and-forget with the result disposed immediately and rejections discarded. When a subscriber DO dies (deploy eviction, abort), the broken connection stays in `#connections`, the pump keeps advancing its cursor into the dead stub, and `#reconcile` skips keys that already have a connection — so the subscriber is never re-dialed and delivery stalls silently for the rest of the stream incarnation.

- `retainProcessEventBatch` now takes `onDeliveryError` and observes the delivery result (rejections **and** synchronous stub throws), disposing only after settle (disposing a pending Cap'n Web promise cancels the call).
- The Stream DO drops the connection on a failed delivery and re-dials (outbound); the subscriber re-handshakes from its durable checkpoint, and the existing generation gate drops stragglers.
- Dropped the `Object.hasOwn` guard that prevented `onRpcBroken` from ever being wired for Cap'n Web proxy stubs (they expose no own descriptors). The wiring is defensive because property access on a native Workers RPC stub can fabricate a pipelined method that only fails at call time.

## 2. Agent processor: scheduled LLM turn dies with the DO and wedges the stream

`agent/llm-request-scheduled` is durable, but the debounce timer lived only in memory. After eviction+rehydration nothing re-armed it — and `#resetScheduledLlmRequestTimer` no-ops when there is no in-memory `scheduledEvent`, so **every later default-policy input was silently swallowed too**. Streams evicted between `llm-request-scheduled` and `llm-request-requested` were permanently wedged.

- The scheduled `currentRequest` state now records `scheduledOffset` (optional, so old checkpoints still parse).
- `snapshot()` — called by the host on every subscription (re-)handshake, even with no new events — and `processEventBatch` re-arm the lost timer; a history-read fallback covers checkpoints written before `scheduledOffset` existed, so already-wedged prod streams recover on their next re-handshake after this deploys.
- The handoff append retries instead of dropping the turn. All recovery is idempotent: `llm-request-requested` is keyed off the scheduled event's offset.

## Regression tests (all verified to fail on the unfixed code)

- `packages/streams/src/workers/durable-objects/stream-redial.workers.test.ts` — end-to-end in workerd: Stream DO → Callable dial → `StreamProcessorRunner` (echo), then `ctx.abort()` the runner to simulate a deploy and assert the next append still delivers and the subscriber's durable checkpoint advances. (The Stream-side cursor advances even into a dead stub — that *is* the bug — so the assertions are on actual delivery and the subscriber checkpoint.)
- `packages/streams/src/workers/rpc-lifecycle.test.ts` — proxy-shaped `onRpcBroken` wiring, pipelined-fake survival, delivery rejection reporting, settle-then-dispose.
- `apps/os/.../agent/implementation.test.ts` — four recovery tests: re-arm via `snapshot()` rehydration, re-arm via batch replay, history fallback for old checkpoints, handoff append retry.

`pnpm typecheck && pnpm lint && pnpm format && pnpm test` green, plus the streams workers suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core stream delivery and agent LLM scheduling paths that run on every deploy/eviction; mistakes could duplicate LLM requests or drop events, though idempotency keys and generation gates mitigate double-handoff.
> 
> **Overview**
> Fixes a production outage where deploy eviction left Slack agents permanently silent by addressing **two independent failure modes** that composed together.
> 
> **Streams (M1):** Outbound batch delivery into a dead subscriber DO no longer leaves a zombie connection in `#connections`. `retainProcessEventBatch` now accepts `onDeliveryError`, observes rejections/sync throws, and disposes RPC results only after settle; `onRpcBroken` wiring no longer uses the broken `Object.hasOwn` guard. The Stream DO closes the connection and calls `#reconcile()` on delivery failure so subscribers are re-dialed and re-handshake from durable checkpoints.
> 
> **Agent processor:** Scheduled LLM turns persist `scheduledOffset` on `currentRequest` so a rehydrated DO can rebuild the in-memory debounce timer. Recovery runs on `snapshot()` (subscription re-handshake) and after `processEventBatch` replay; old checkpoints without `scheduledOffset` fall back to stream history. Failed `llm-request-requested` appends re-arm the timer instead of wedging the stream.
> 
> Regression coverage: `stream-redial.workers.test.ts`, `rpc-lifecycle.test.ts`, and agent `implementation.test.ts` scheduled-recovery suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 714b21a3d9cc29ba49216e83038e581631e4403b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T19:11:51.700Z",
      "headSha": "714b21a3d9cc29ba49216e83038e581631e4403b",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27297848885",
      "shortSha": "714b21a"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `714b21a`
Preview: https://os.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27297848885)
Updated: 2026-06-10T19:11:51.700Z
<!-- /CLOUDFLARE_PREVIEW -->