### PR TITLE
[codex] fix admin streams and projects view

### DIFF
--- a/apps/os/docs/doppler-backed-scripts.md
+++ b/apps/os/docs/doppler-backed-scripts.md
@@ -60,3 +60,43 @@ Use `APP_CONFIG_BASE_URL` for both configured deployments and ad hoc local
 overrides. When wrapping a local override with `doppler run`, pass
 `--preserve-env=APP_CONFIG_BASE_URL` so Doppler does not replace it with the
 configured deployment URL.
+
+## Local Admin Browser Cookie
+
+The `/admin` UI uses a root itx WebSocket. Browsers cannot add an
+`Authorization` header to WebSocket handshakes, so admin-token access must
+first be converted into the HttpOnly `iterate-admin-auth` cookie by posting the
+admin token to `/api/itx/admin-cookie`.
+
+For local dev, keep the token inside Doppler and use a one-shot localhost
+bridge. The bridge forwards only the `Set-Cookie` header to your browser and
+then redirects back to OS:
+
+```bash
+doppler run --project os --config dev_localhost -- node -e '
+const http = require("node:http");
+const target = "http://127.0.0.1:5177";
+const port = 5199;
+const server = http.createServer(async (_req, res) => {
+  const response = await fetch(`${target}/api/itx/admin-cookie`, {
+    method: "POST",
+    headers: { "content-type": "text/plain" },
+    body: process.env.APP_CONFIG_ADMIN_API_SECRET,
+  });
+  const setCookie = response.headers.get("set-cookie");
+  if (setCookie) res.setHeader("set-cookie", setCookie);
+  res.statusCode = response.ok ? 302 : 502;
+  res.setHeader("location", `${target}/admin/streams/global`);
+  res.end(response.ok ? "admin cookie set" : "admin cookie bridge failed");
+  server.close();
+});
+server.listen(port, "127.0.0.1", () => {
+  console.log(`Open http://127.0.0.1:${port}/ once in your browser.`);
+});
+setTimeout(() => server.close(), 60000).unref();
+'
+```
+
+Adjust `target`, `port`, and the Doppler config for the environment you are
+testing. The cookie is host-scoped, not port-scoped, so setting it from
+`127.0.0.1:5199` also makes it available to `127.0.0.1:5177`.

--- a/apps/os/src/domains/projects/project-directory.ts
+++ b/apps/os/src/domains/projects/project-directory.ts
@@ -18,6 +18,7 @@ import {
 } from "~/db/queries/.generated/index.ts";
 import { getProjectDurableObjectStub } from "~/domains/projects/durable-objects/project-durable-object.ts";
 import { isProjectId, mintProjectId } from "~/domains/projects/project-id.ts";
+import { principalIsAdmin } from "~/auth/principal.ts";
 
 type ProjectRow = {
   id: string;
@@ -58,7 +59,7 @@ export class ProjectsCapability extends RpcTarget {
     const context = this.props.context;
     const limit = input.limit ?? 100;
     const offset = input.offset ?? 0;
-    if (context.principal?.type === "admin") {
+    if (context.principal != null && principalIsAdmin(context.principal)) {
       const [totalRow, rows] = await Promise.all([
         countAllProjects(context.db),
         listAllProjects(context.db, { limit, offset }),
@@ -258,7 +259,7 @@ export async function requireProject(input: {
   }
 
   if (
-    input.context.principal?.type === "admin" ||
+    (input.context.principal != null && principalIsAdmin(input.context.principal)) ||
     input.context.principal?.can("read", { projectId: project.id })
   ) {
     return project;

--- a/apps/os/src/domains/streams/admin-stream-rpc.ts
+++ b/apps/os/src/domains/streams/admin-stream-rpc.ts
@@ -2,6 +2,8 @@ import { newWorkersRpcResponse } from "capnweb";
 import { PublicStreamRpcTarget } from "@iterate-com/streams/workers/durable-objects/stream";
 import { StreamNamespace } from "@iterate-com/shared/streams/types";
 import { authenticateCapnwebAdmin } from "~/itx/admin-auth-cookie.ts";
+import { createOsIterateAuth, resolveRequestAuth } from "~/auth/middleware.ts";
+import { principalIsAdmin } from "~/auth/principal.ts";
 import { getStreamDurableObjectName } from "~/domains/streams/stream-runtime.ts";
 import { resolveStreamPath } from "~/domains/streams/entrypoints/streams-capability.ts";
 import type { AppConfig } from "~/config.ts";
@@ -25,8 +27,8 @@ export async function handleAdminStreamRpcFetch(input: {
   const route = parseAdminStreamRpcRoute(input.request);
   if (!route) return null;
 
-  const principal = authenticateCapnwebAdmin({ config: input.config, request: input.request });
-  if (!principal) return new Response("Unauthorized", { status: 401 });
+  const auth = await authenticateAdminStreamRequest(input);
+  if (!auth.ok) return new Response("Unauthorized", { status: 401 });
 
   const namespace = StreamNamespace.parse(route.namespace);
   const streamPath = resolveStreamPath(route.streamPath);
@@ -64,4 +66,20 @@ function parseAdminStreamRpcRoute(request: Request): {
         ? "/"
         : decodeURIComponent(encodedStreamPath),
   };
+}
+
+async function authenticateAdminStreamRequest(input: {
+  config: AppConfig;
+  context: RequestContext;
+  request: Request;
+}) {
+  const capnwebAdmin = authenticateCapnwebAdmin({ config: input.config, request: input.request });
+  if (capnwebAdmin) return { ok: true };
+
+  const resolvedAuth = await resolveRequestAuth({
+    auth: createOsIterateAuth(input.context, input.request),
+    context: input.context,
+    request: input.request,
+  });
+  return { ok: resolvedAuth.principal ? principalIsAdmin(resolvedAuth.principal) : false };
 }

--- a/apps/os/src/itx/handle.ts
+++ b/apps/os/src/itx/handle.ts
@@ -677,5 +677,11 @@ export class ItxProjects extends RpcTarget {
 }
 
 function toProjectSummary(row: { id: string; slug: string; [key: string]: unknown }) {
-  return { id: row.id, slug: row.slug };
+  return {
+    id: row.id,
+    slug: row.slug,
+    customHostname: typeof row.custom_hostname === "string" ? row.custom_hostname : null,
+    createdAt: typeof row.created_at === "string" ? row.created_at : null,
+    updatedAt: typeof row.updated_at === "string" ? row.updated_at : null,
+  };
 }

--- a/apps/os/src/itx/types.ts
+++ b/apps/os/src/itx/types.ts
@@ -519,10 +519,16 @@ export interface ItxStreams {
  * a NEW project-scoped handle. */
 export interface ItxProjects {
   get(projectIdOrSlug: string): Promise<Itx>;
-  list(input?: {
-    limit?: number;
-    offset?: number;
-  }): Promise<{ projects: { id: string; slug: string }[]; total: number }>;
+  list(input?: { limit?: number; offset?: number }): Promise<{
+    projects: {
+      id: string;
+      slug: string;
+      customHostname: string | null;
+      createdAt: string | null;
+      updatedAt: string | null;
+    }[];
+    total: number;
+  }>;
   /** Admin principals only. */
   create(input: { id?: string; slug: string }): Promise<{ id: string; slug: string }>;
   /** Admin principals only. */

--- a/apps/os/src/orpc/project-access.ts
+++ b/apps/os/src/orpc/project-access.ts
@@ -2,6 +2,7 @@ import { ORPCError } from "@orpc/server";
 import type { RequestContext } from "~/request-context.ts";
 import { getProjectById, getProjectBySlug } from "~/db/queries/.generated/index.ts";
 import { isProjectId } from "~/domains/projects/project-id.ts";
+import { principalIsAdmin } from "~/auth/principal.ts";
 
 /**
  * Confirms a caller can access an ownerless project before exposing
@@ -64,7 +65,8 @@ export async function requireProjectScopedAccess(input: {
 
 export function canReadProject(context: Pick<RequestContext, "principal">, projectId: string) {
   return (
-    context.principal?.type === "admin" || context.principal?.can("read", { projectId }) === true
+    (context.principal != null && principalIsAdmin(context.principal)) ||
+    context.principal?.can("read", { projectId }) === true
   );
 }
 

--- a/apps/os/src/routeTree.gen.ts
+++ b/apps/os/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as SignInSplatRouteImport } from './routes/sign-in.$'
 import { Route as PosthogProxySplatRouteImport } from './routes/posthog-proxy.$'
 import { Route as ApiOrpcWsRouteImport } from './routes/api.orpc-ws'
 import { Route as ApiSplatRouteImport } from './routes/api.$'
+import { Route as AdminProjectsRouteImport } from './routes/admin/projects'
 import { Route as AppNewProjectRouteImport } from './routes/_app/new-project'
 import { Route as AppItxReplRouteImport } from './routes/_app/itx-repl'
 import { Route as EventDocsProcessorSlugSplatRouteImport } from './routes/$eventDocsProcessorSlug.$'
@@ -112,6 +113,11 @@ const ApiSplatRoute = ApiSplatRouteImport.update({
   id: '/api/$',
   path: '/api/$',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AdminProjectsRoute = AdminProjectsRouteImport.update({
+  id: '/projects',
+  path: '/projects',
+  getParentRoute: () => AdminRoute,
 } as any)
 const AppNewProjectRoute = AppNewProjectRouteImport.update({
   id: '/new-project',
@@ -309,6 +315,7 @@ export interface FileRoutesByFullPath {
   '/$eventDocsProcessorSlug/$': typeof EventDocsProcessorSlugSplatRoute
   '/itx-repl': typeof AppItxReplRoute
   '/new-project': typeof AppNewProjectRoute
+  '/admin/projects': typeof AdminProjectsRoute
   '/api/$': typeof ApiSplatRoute
   '/api/orpc-ws': typeof ApiOrpcWsRoute
   '/posthog-proxy/$': typeof PosthogProxySplatRoute
@@ -350,6 +357,7 @@ export interface FileRoutesByTo {
   '/$eventDocsProcessorSlug/$': typeof EventDocsProcessorSlugSplatRoute
   '/itx-repl': typeof AppItxReplRoute
   '/new-project': typeof AppNewProjectRoute
+  '/admin/projects': typeof AdminProjectsRoute
   '/api/$': typeof ApiSplatRoute
   '/api/orpc-ws': typeof ApiOrpcWsRoute
   '/posthog-proxy/$': typeof PosthogProxySplatRoute
@@ -393,6 +401,7 @@ export interface FileRoutesById {
   '/$eventDocsProcessorSlug/$': typeof EventDocsProcessorSlugSplatRoute
   '/_app/itx-repl': typeof AppItxReplRoute
   '/_app/new-project': typeof AppNewProjectRoute
+  '/admin/projects': typeof AdminProjectsRoute
   '/api/$': typeof ApiSplatRoute
   '/api/orpc-ws': typeof ApiOrpcWsRoute
   '/posthog-proxy/$': typeof PosthogProxySplatRoute
@@ -440,6 +449,7 @@ export interface FileRouteTypes {
     | '/$eventDocsProcessorSlug/$'
     | '/itx-repl'
     | '/new-project'
+    | '/admin/projects'
     | '/api/$'
     | '/api/orpc-ws'
     | '/posthog-proxy/$'
@@ -481,6 +491,7 @@ export interface FileRouteTypes {
     | '/$eventDocsProcessorSlug/$'
     | '/itx-repl'
     | '/new-project'
+    | '/admin/projects'
     | '/api/$'
     | '/api/orpc-ws'
     | '/posthog-proxy/$'
@@ -523,6 +534,7 @@ export interface FileRouteTypes {
     | '/$eventDocsProcessorSlug/$'
     | '/_app/itx-repl'
     | '/_app/new-project'
+    | '/admin/projects'
     | '/api/$'
     | '/api/orpc-ws'
     | '/posthog-proxy/$'
@@ -658,6 +670,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/$'
       preLoaderRoute: typeof ApiSplatRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/admin/projects': {
+      id: '/admin/projects'
+      path: '/projects'
+      fullPath: '/admin/projects'
+      preLoaderRoute: typeof AdminProjectsRouteImport
+      parentRoute: typeof AdminRoute
     }
     '/_app/new-project': {
       id: '/_app/new-project'
@@ -1041,11 +1060,13 @@ const AdminStreamsRouteRouteWithChildren =
 
 interface AdminRouteChildren {
   AdminStreamsRouteRoute: typeof AdminStreamsRouteRouteWithChildren
+  AdminProjectsRoute: typeof AdminProjectsRoute
   AdminIndexRoute: typeof AdminIndexRoute
 }
 
 const AdminRouteChildren: AdminRouteChildren = {
   AdminStreamsRouteRoute: AdminStreamsRouteRouteWithChildren,
+  AdminProjectsRoute: AdminProjectsRoute,
   AdminIndexRoute: AdminIndexRoute,
 }
 

--- a/apps/os/src/routes/admin.tsx
+++ b/apps/os/src/routes/admin.tsx
@@ -6,11 +6,35 @@
 // browser, since WebSockets cannot send Authorization headers. Until then the
 // layout shows an unlock form instead of its children.
 
-import { useEffect, useState } from "react";
-import { createFileRoute, Link, Outlet } from "@tanstack/react-router";
+import { useEffect, useState, type CSSProperties } from "react";
+import { createFileRoute, Link, Outlet, useRouterState } from "@tanstack/react-router";
 import type { RpcStub } from "capnweb";
+import { FolderKanbanIcon, RadioTowerIcon, ShieldIcon, WaypointsIcon } from "lucide-react";
 import { Button } from "@iterate-com/ui/components/button";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@iterate-com/ui/components/field";
 import { Input } from "@iterate-com/ui/components/input";
+import { Separator } from "@iterate-com/ui/components/separator";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarTrigger,
+} from "@iterate-com/ui/components/sidebar";
 import type { Itx } from "~/itx/handle.ts";
 import { AdminItxContext } from "~/lib/admin-itx.ts";
 import { createBrowserReplSession } from "~/routes/_app/itx-repl.tsx";
@@ -63,37 +87,43 @@ function AdminLayout() {
   }, [epoch]);
 
   return (
-    <div className="flex h-svh flex-col">
-      <header className="flex h-14 shrink-0 items-center gap-4 border-b px-4">
-        <span className="font-semibold">Iterate Admin</span>
-        <nav className="flex items-center gap-3 text-sm text-muted-foreground">
-          <Link to="/admin" className="hover:text-foreground [&.active]:text-foreground">
-            Global stream
-          </Link>
-          <Link to="/admin/streams" className="hover:text-foreground [&.active]:text-foreground">
-            Stream explorer
-          </Link>
-        </nav>
-        <div className="ml-auto text-sm">
-          <Link to="/" className="text-muted-foreground hover:text-foreground">
-            Back to app
-          </Link>
-        </div>
-      </header>
-      <main className="min-h-0 flex-1 overflow-auto p-4">
-        {state.status === "connecting" && (
-          <p className="text-sm text-muted-foreground">Connecting to the root itx context…</p>
-        )}
-        {state.status === "locked" && (
-          <AdminUnlockForm reason={state.reason} onUnlocked={() => setEpoch((e) => e + 1)} />
-        )}
-        {state.status === "ready" && (
-          <AdminItxContext.Provider value={state.itx}>
-            <Outlet />
-          </AdminItxContext.Provider>
-        )}
-      </main>
-    </div>
+    <SidebarProvider
+      className="h-svh"
+      style={
+        {
+          "--sidebar-width": "17rem",
+        } as CSSProperties
+      }
+    >
+      <AdminSidebar />
+      <SidebarInset className="min-w-0 overflow-hidden">
+        <header className="flex h-16 shrink-0 items-center gap-2 border-b">
+          <div className="flex items-center gap-2 px-4">
+            <SidebarTrigger className="-ml-1" />
+            <Separator
+              orientation="vertical"
+              className="mr-2 data-vertical:h-4 data-vertical:self-auto"
+            />
+            <span className="text-sm font-medium">Admin</span>
+          </div>
+        </header>
+        <main className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          {state.status === "connecting" && (
+            <div className="p-4 text-sm text-muted-foreground">
+              Connecting to the root itx context...
+            </div>
+          )}
+          {state.status === "locked" && (
+            <AdminUnlockForm reason={state.reason} onUnlocked={() => setEpoch((e) => e + 1)} />
+          )}
+          {state.status === "ready" && (
+            <AdminItxContext.Provider value={state.itx}>
+              <Outlet />
+            </AdminItxContext.Provider>
+          )}
+        </main>
+      </SidebarInset>
+    </SidebarProvider>
   );
 }
 
@@ -123,31 +153,109 @@ function AdminUnlockForm({ reason, onUnlocked }: { reason: string; onUnlocked: (
   }
 
   return (
-    <div className="mx-auto mt-16 flex max-w-md flex-col gap-3">
-      <h1 className="text-lg font-semibold">Admin access required</h1>
-      <p className="text-sm text-muted-foreground">
-        This area uses a root itx context with global authority. Paste the admin API secret for this
-        deployment to set the admin cookie.
-      </p>
-      <p className="text-xs text-muted-foreground">({reason})</p>
+    <div className="mx-auto mt-16 flex w-full max-w-md flex-col gap-5 px-4">
+      <div className="flex flex-col gap-1">
+        <h1 className="text-lg font-semibold">Admin access required</h1>
+        <p className="text-sm text-muted-foreground">
+          Paste the admin API secret for this deployment to set the admin cookie.
+        </p>
+      </div>
       <form
-        className="flex gap-2"
+        className="flex flex-col gap-3"
         onSubmit={(event) => {
           event.preventDefault();
           void unlock();
         }}
       >
-        <Input
-          type="password"
-          placeholder="Admin API secret"
-          value={secret}
-          onChange={(event) => setSecret(event.target.value)}
-        />
+        <FieldGroup>
+          <Field>
+            <FieldLabel htmlFor="admin-api-secret">Admin API secret</FieldLabel>
+            <Input
+              id="admin-api-secret"
+              type="password"
+              placeholder="Secret"
+              value={secret}
+              onChange={(event) => setSecret(event.target.value)}
+            />
+            <FieldDescription>{reason}</FieldDescription>
+          </Field>
+        </FieldGroup>
         <Button type="submit" disabled={submitting || secret.trim() === ""}>
-          {submitting ? "Unlocking…" : "Unlock"}
+          {submitting ? "Unlocking..." : "Unlock"}
         </Button>
       </form>
-      {error && <p className="text-sm text-destructive">{error}</p>}
+      <FieldError>{error}</FieldError>
     </div>
+  );
+}
+
+function AdminSidebar() {
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+
+  return (
+    <Sidebar collapsible="icon">
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="lg" tooltip="Iterate Admin" render={<Link to="/admin" />}>
+              <div className="flex aspect-square size-8 items-center justify-center rounded-md bg-sidebar-primary text-sidebar-primary-foreground">
+                <ShieldIcon aria-hidden="true" />
+              </div>
+              <div className="grid flex-1 text-left text-sm leading-tight">
+                <span className="truncate font-medium">Iterate Admin</span>
+                <span className="truncate text-xs text-sidebar-foreground/70">Platform tools</span>
+              </div>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Admin</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  tooltip="Streams explorer"
+                  isActive={pathname.startsWith("/admin/streams")}
+                  render={<Link to="/admin/streams" />}
+                >
+                  <WaypointsIcon aria-hidden="true" />
+                  <span>Streams explorer</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  tooltip="Projects"
+                  isActive={pathname.startsWith("/admin/projects")}
+                  render={<Link to="/admin/projects" />}
+                >
+                  <FolderKanbanIcon aria-hidden="true" />
+                  <span>Projects</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>Shortcuts</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  tooltip="Global streams"
+                  isActive={pathname.startsWith("/admin/streams/global")}
+                  render={<Link to="/admin/streams/$namespace" params={{ namespace: "global" }} />}
+                >
+                  <RadioTowerIcon aria-hidden="true" />
+                  <span>Global streams</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+      <SidebarRail />
+    </Sidebar>
   );
 }

--- a/apps/os/src/routes/admin/index.tsx
+++ b/apps/os/src/routes/admin/index.tsx
@@ -1,100 +1,10 @@
-// Admin home: the events in the global namespace's root ("/") stream, read
-// through the layout's root itx handle — itx.streams on a global admin handle
-// targets the "global" stream namespace (see itx/handle.ts).
-
-import { useCallback, useEffect, useState } from "react";
-import { createFileRoute } from "@tanstack/react-router";
-import type { StreamEvent } from "@iterate-com/streams/shared/event";
-import { Button } from "@iterate-com/ui/components/button";
-import { useAdminItx } from "~/lib/admin-itx.ts";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/admin/")({
-  component: GlobalStreamPage,
+  beforeLoad: () => {
+    throw redirect({
+      to: "/admin/streams/$namespace",
+      params: { namespace: "global" },
+    });
+  },
 });
-
-type LoadState =
-  | { status: "loading" }
-  | { status: "error"; message: string }
-  | { status: "loaded"; events: StreamEvent[] };
-
-function GlobalStreamPage() {
-  const itx = useAdminItx();
-  const [state, setState] = useState<LoadState>({ status: "loading" });
-
-  const load = useCallback(async () => {
-    setState({ status: "loading" });
-    try {
-      const events = (await itx.streams.get("/").read({})) as StreamEvent[];
-      setState({ status: "loaded", events });
-    } catch (error) {
-      setState({
-        status: "error",
-        message: error instanceof Error ? error.message : String(error),
-      });
-    }
-  }, [itx]);
-
-  useEffect(() => {
-    void load();
-  }, [load]);
-
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="flex items-center gap-3">
-        <h1 className="text-lg font-semibold">
-          Global stream <code className="rounded bg-muted px-1.5 py-0.5 text-sm">global:/</code>
-        </h1>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => void load()}
-          disabled={state.status === "loading"}
-        >
-          Refresh
-        </Button>
-        {state.status === "loaded" && (
-          <span className="text-sm text-muted-foreground">
-            {state.events.length} event{state.events.length === 1 ? "" : "s"}
-          </span>
-        )}
-      </div>
-
-      {state.status === "loading" && <p className="text-sm text-muted-foreground">Loading…</p>}
-      {state.status === "error" && <p className="text-sm text-destructive">{state.message}</p>}
-      {state.status === "loaded" && state.events.length === 0 && (
-        <p className="text-sm text-muted-foreground">
-          No events yet. Anything appended to the <code>/</code> stream in the <code>global</code>{" "}
-          namespace shows up here.
-        </p>
-      )}
-      {state.status === "loaded" && state.events.length > 0 && (
-        <table className="w-full table-fixed border-collapse text-sm">
-          <thead>
-            <tr className="border-b text-left text-muted-foreground">
-              <th className="w-20 py-2 pr-4 font-medium">Offset</th>
-              <th className="w-56 py-2 pr-4 font-medium">Type</th>
-              <th className="w-44 py-2 pr-4 font-medium">Created</th>
-              <th className="py-2 font-medium">Payload</th>
-            </tr>
-          </thead>
-          <tbody>
-            {state.events.map((event) => (
-              <tr key={event.offset} className="border-b align-top">
-                <td className="py-2 pr-4 font-mono">{event.offset}</td>
-                <td className="py-2 pr-4 font-mono break-words">{event.type}</td>
-                <td className="py-2 pr-4 whitespace-nowrap text-muted-foreground">
-                  {new Date(event.createdAt).toLocaleString()}
-                </td>
-                <td className="py-2">
-                  <pre className="overflow-x-auto rounded bg-muted p-2 text-xs">
-                    {JSON.stringify(event.payload ?? null, null, 2)}
-                  </pre>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
-    </div>
-  );
-}

--- a/apps/os/src/routes/admin/projects.tsx
+++ b/apps/os/src/routes/admin/projects.tsx
@@ -1,0 +1,189 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { ArrowLeftIcon, ArrowRightIcon, ExternalLinkIcon, WaypointsIcon } from "lucide-react";
+import { Badge } from "@iterate-com/ui/components/badge";
+import { Button } from "@iterate-com/ui/components/button";
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@iterate-com/ui/components/empty";
+import { Skeleton } from "@iterate-com/ui/components/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@iterate-com/ui/components/table";
+import { useAdminItx } from "~/lib/admin-itx.ts";
+
+const PAGE_SIZE = 100;
+
+export const Route = createFileRoute("/admin/projects")({
+  component: AdminProjectsPage,
+});
+
+type AdminProject = {
+  id: string;
+  slug: string;
+  customHostname: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
+function AdminProjectsPage() {
+  const itx = useAdminItx();
+  const [pageIndex, setPageIndex] = useState(0);
+  const offset = pageIndex * PAGE_SIZE;
+  const projectsQuery = useQuery({
+    queryKey: ["admin", "projects", { limit: PAGE_SIZE, offset }],
+    queryFn: async () => await itx.projects.list({ limit: PAGE_SIZE, offset }),
+  });
+  const projects = (projectsQuery.data?.projects ?? []) as AdminProject[];
+  const total = projectsQuery.data?.total ?? 0;
+  const hasPrevious = pageIndex > 0;
+  const hasNext = offset + projects.length < total;
+
+  return (
+    <section className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <header className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b px-4 py-3">
+        <div className="min-w-0">
+          <h1 className="text-base font-semibold">Projects</h1>
+          <p className="text-sm text-muted-foreground">
+            {projectsQuery.isPending ? "Loading projects..." : `${total.toLocaleString()} total`}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={!hasPrevious || projectsQuery.isFetching}
+            onClick={() => setPageIndex((current) => Math.max(0, current - 1))}
+          >
+            <ArrowLeftIcon data-icon="inline-start" aria-hidden="true" />
+            Previous
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={!hasNext || projectsQuery.isFetching}
+            onClick={() => setPageIndex((current) => current + 1)}
+          >
+            Next
+            <ArrowRightIcon data-icon="inline-end" aria-hidden="true" />
+          </Button>
+        </div>
+      </header>
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        {projectsQuery.isPending ? (
+          <ProjectsSkeleton />
+        ) : projectsQuery.isError ? (
+          <Empty className="border">
+            <EmptyHeader>
+              <EmptyTitle>Could not load projects</EmptyTitle>
+              <EmptyDescription>
+                {projectsQuery.error instanceof Error
+                  ? projectsQuery.error.message
+                  : "The project list could not be read."}
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : projects.length === 0 ? (
+          <Empty className="border">
+            <EmptyHeader>
+              <EmptyTitle>No projects</EmptyTitle>
+              <EmptyDescription>No projects exist in this environment.</EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Slug</TableHead>
+                <TableHead>ID</TableHead>
+                <TableHead>Custom hostname</TableHead>
+                <TableHead>Created</TableHead>
+                <TableHead>Updated</TableHead>
+                <TableHead className="text-right">Links</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {projects.map((project) => (
+                <TableRow key={project.id}>
+                  <TableCell className="font-medium">
+                    <Link
+                      to="/projects/$projectSlug"
+                      params={{ projectSlug: project.slug }}
+                      className="hover:underline"
+                    >
+                      {project.slug}
+                    </Link>
+                  </TableCell>
+                  <TableCell className="font-mono text-xs text-muted-foreground">
+                    {project.id}
+                  </TableCell>
+                  <TableCell>
+                    {project.customHostname ? (
+                      <Badge variant="secondary">{project.customHostname}</Badge>
+                    ) : (
+                      <span className="text-muted-foreground">None</span>
+                    )}
+                  </TableCell>
+                  <TableCell>{formatDate(project.createdAt)}</TableCell>
+                  <TableCell>{formatDate(project.updatedAt)}</TableCell>
+                  <TableCell>
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        nativeButton={false}
+                        render={
+                          <Link to="/admin/streams/$namespace" params={{ namespace: project.id }} />
+                        }
+                      >
+                        <WaypointsIcon data-icon="inline-start" aria-hidden="true" />
+                        Streams
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        nativeButton={false}
+                        aria-label={`Open ${project.slug}`}
+                        render={
+                          <Link
+                            to="/projects/$projectSlug"
+                            params={{ projectSlug: project.slug }}
+                          />
+                        }
+                      >
+                        <ExternalLinkIcon aria-hidden="true" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ProjectsSkeleton() {
+  return (
+    <div className="flex flex-col gap-2">
+      {Array.from({ length: 8 }, (_, index) => (
+        <Skeleton key={index} className="h-10 w-full" />
+      ))}
+    </div>
+  );
+}
+
+function formatDate(value: string | null) {
+  if (!value) return <span className="text-muted-foreground">-</span>;
+  return <span className="text-muted-foreground">{new Date(value).toLocaleString()}</span>;
+}

--- a/apps/os/src/routes/admin/streams/$namespace/index.tsx
+++ b/apps/os/src/routes/admin/streams/$namespace/index.tsx
@@ -1,5 +1,7 @@
 import { useMemo } from "react";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { ArrowLeftIcon, RadioTowerIcon } from "lucide-react";
+import { Button } from "@iterate-com/ui/components/button";
 import { StreamState, type StreamPath as StreamPathType } from "@iterate-com/shared/streams/types";
 import { StreamExplorerTreePage } from "~/components/stream-explorer.tsx";
 import { useAdminItx } from "~/lib/admin-itx.ts";
@@ -31,10 +33,36 @@ function AdminStreamNamespacePage() {
   return (
     <StreamExplorerTreePage
       header={
-        <h1 className="truncate text-lg font-semibold">
-          Namespace{" "}
-          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">{namespace}</code>
-        </h1>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h1 className="truncate text-base font-semibold">Streams explorer</h1>
+            <p className="truncate font-mono text-sm text-muted-foreground">{namespace}</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              nativeButton={false}
+              render={<Link to="/admin/streams" />}
+            >
+              <ArrowLeftIcon data-icon="inline-start" aria-hidden="true" />
+              Namespace
+            </Button>
+            {namespace === "global" ? null : (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                nativeButton={false}
+                render={<Link to="/admin/streams/$namespace" params={{ namespace: "global" }} />}
+              >
+                <RadioTowerIcon data-icon="inline-start" aria-hidden="true" />
+                Global
+              </Button>
+            )}
+          </div>
+        </div>
       }
       source={source}
       onOpenPath={openStream}

--- a/apps/os/src/routes/admin/streams/index.tsx
+++ b/apps/os/src/routes/admin/streams/index.tsx
@@ -1,6 +1,14 @@
 import { useState } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { ArrowRightIcon } from "lucide-react";
 import { Button } from "@iterate-com/ui/components/button";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@iterate-com/ui/components/field";
 import { Input } from "@iterate-com/ui/components/input";
 import { toast } from "@iterate-com/ui/components/sonner";
 import { StreamNamespace } from "@iterate-com/shared/streams/types";
@@ -12,13 +20,16 @@ export const Route = createFileRoute("/admin/streams/")({
 function AdminStreamsNamespacePicker() {
   const navigate = useNavigate();
   const [namespace, setNamespace] = useState("global");
+  const [error, setError] = useState<string | null>(null);
 
   function submit() {
     const parsed = StreamNamespace.safeParse(namespace);
     if (!parsed.success) {
+      setError("Namespace must be a non-empty stream namespace.");
       toast.error("Namespace must be a non-empty stream namespace.");
       return;
     }
+    setError(null);
 
     void navigate({
       to: "/admin/streams/$namespace",
@@ -27,22 +38,39 @@ function AdminStreamsNamespacePicker() {
   }
 
   return (
-    <section className="flex min-h-0 flex-1 flex-col gap-4 p-4">
+    <section className="flex min-h-0 flex-1 flex-col gap-5 p-4">
+      <div className="flex flex-col gap-1">
+        <h1 className="text-base font-semibold">Streams explorer</h1>
+        <p className="text-sm text-muted-foreground">
+          Open any stream namespace by namespace id, including project ids.
+        </p>
+      </div>
       <form
-        className="flex max-w-xl flex-col gap-2 sm:flex-row"
+        className="flex max-w-xl flex-col gap-3"
         onSubmit={(event) => {
           event.preventDefault();
           submit();
         }}
       >
-        <Input
-          value={namespace}
-          onChange={(event) => setNamespace(event.currentTarget.value)}
-          placeholder="global or project id"
-          aria-label="Stream namespace"
-          className="font-mono"
-        />
-        <Button type="submit">Open namespace</Button>
+        <FieldGroup>
+          <Field data-invalid={error != null}>
+            <FieldLabel htmlFor="admin-stream-namespace">Namespace</FieldLabel>
+            <Input
+              id="admin-stream-namespace"
+              value={namespace}
+              onChange={(event) => setNamespace(event.currentTarget.value)}
+              placeholder="global or prj_..."
+              aria-invalid={error != null}
+              className="font-mono"
+            />
+            <FieldDescription>Use a project id to inspect that project's streams.</FieldDescription>
+            <FieldError>{error}</FieldError>
+          </Field>
+        </FieldGroup>
+        <Button type="submit" className="self-start">
+          Open namespace
+          <ArrowRightIcon data-icon="inline-end" aria-hidden="true" />
+        </Button>
       </form>
     </section>
   );


### PR DESCRIPTION
## Summary

- Replace the admin top-nav with a shadcn sidebar shell and redirect `/admin` to the global streams explorer.
- Add an admin projects table with per-project deep links into the stream namespace explorer.
- Fix admin stream RPC auth so Better Auth admins and admin-token callers can open `/api/admin-streams/:namespace` WebSockets.
- Document a local admin-token-to-admin-cookie bridge for browser testing without exposing the token.

## Root Cause

The admin stream detail view used `/api/admin-streams/:namespace`, but that endpoint only accepted the admin API secret cookie/bearer path. A normal Better Auth admin browser session could unlock root itx, yet still received 401 on the stream WebSocket. Admin project listing had the same mismatch: it only treated the shared-secret principal as platform admin, not `isAdmin` user principals.

## Validation

- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/os exec oxlint src/routes/admin.tsx src/routes/admin/index.tsx src/routes/admin/projects.tsx src/routes/admin/streams/index.tsx src/routes/admin/streams/$namespace/index.tsx src/domains/streams/admin-stream-rpc.ts src/orpc/project-access.ts src/domains/projects/project-directory.ts src/itx/handle.ts src/itx/types.ts`
- `pnpm --dir apps/os test src/auth/principal.test.ts src/itx/react/connection.test.ts`
- Local admin-cookie bridge unlocked `/admin/streams/global`.
- Local `/api/admin-streams/global` WebSocket opened with admin credentials.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches admin authorization on admin-stream WebSockets and cross-project listing; changes are targeted but security-relevant for operator surfaces.
> 
> **Overview**
> Fixes **admin auth mismatches** so Better Auth `isAdmin` users and shared-secret admins are treated consistently: project listing, oRPC project access, and **`/api/admin-streams`** WebSockets now use `principalIsAdmin` instead of only `principal.type === "admin"`. Admin stream RPC still accepts the capnweb admin cookie first, then falls back to session auth.
> 
> **Admin UI** moves to a sidebar layout with **Projects** (`/admin/projects`)—paginated table via `itx.projects.list` with links into per-project stream namespaces—and **Streams explorer** polish. **`/admin`** redirects to global streams instead of the old inline global stream page.
> 
> **itx** `projects.list` responses now include `customHostname`, `createdAt`, and `updatedAt` (types updated to match).
> 
> Docs add a **local Doppler one-shot bridge** to set the `iterate-admin-auth` cookie for browser admin testing without exposing the token in the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c535074b2cb670de57eb31c427441ef685f1a31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T19:49:03.713Z",
      "headSha": "8c535074b2cb670de57eb31c427441ef685f1a31",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27301562251",
      "shortSha": "8c53507"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `8c53507`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27301562251)
Updated: 2026-06-10T19:49:03.713Z
<!-- /CLOUDFLARE_PREVIEW -->