### PR TITLE
agents: per-project agent context — the project config worker is a stream processor

### DIFF
--- a/apps/os/e2e/vitest/agents.e2e.test.ts
+++ b/apps/os/e2e/vitest/agents.e2e.test.ts
@@ -359,6 +359,115 @@ test("lets agent scripts send visible agent responses through itx.chat.sendMessa
   );
 });
 
+test("project config worker customizes fresh agents by appending events", async () => {
+  await using fixture = await createTestProjectFixture({ slugPrefix: "agent-context-config" });
+  const { client, project } = fixture;
+  const suffix = uniqueSuffix();
+  const pusherPath = `/agents/config-pusher-${suffix}`;
+  const customizedPath = `/agents/customized-${suffix}`;
+  const promptMarker = `CUSTOM CONTEXT PROMPT ${suffix}`;
+  const capabilityName = `acmeTool${suffix.replace(/-/g, "")}`;
+
+  // Phase 1: push a config worker whose afterAppend reacts to new agent
+  // streams. Deterministic: the push script is injected as agent output (no
+  // LLM) and executed against the pusher agent's prepared workspace.
+  await client.project.agents.runtimeState({ agentPath: pusherPath, projectSlugOrId: project.id });
+
+  const configWorkerSource = [
+    "export default {",
+    '  async fetch() { return new Response("ok"); },',
+    "",
+    "  // The config worker is a stream processor: this receives every event on",
+    "  // the project root stream. New agent streams announce themselves as",
+    "  // child-stream-created; react by appending agent context events.",
+    "  async afterAppend({ event }, env) {",
+    '    if (event.type !== "events.iterate.com/stream/child-stream-created") return;',
+    "    const agentPath = event.payload.childPath;",
+    `    if (!agentPath.startsWith(${JSON.stringify(`/agents/customized-`)})) return;`,
+    "    await env.STREAMS.append({",
+    "      streamPath: agentPath,",
+    "      event: {",
+    '        type: "events.iterate.com/agent/system-prompt-updated",',
+    `        payload: { systemPrompt: ${JSON.stringify(promptMarker)} + " for " + agentPath },`,
+    "      },",
+    "    });",
+    "    await env.STREAMS.append({",
+    "      streamPath: agentPath,",
+    "      event: {",
+    '        type: "events.iterate.com/agent/capability-noted",',
+    `        payload: { name: ${JSON.stringify(capabilityName)}, instructions: "Use itx.worker.${capabilityName}() (custom ${suffix})." },`,
+    "      },",
+    "    });",
+    "  },",
+    "};",
+    "",
+  ].join("\n");
+  const pushScript = [
+    "async (itx) => {",
+    `  await itx.workspace.writeFile('/iterate-config/worker.js', ${JSON.stringify(configWorkerSource)});`,
+    "  await itx.workspace.git.add({ dir: '/iterate-config', filepath: 'worker.js' });",
+    "  await itx.workspace.git.commit({ dir: '/iterate-config', message: 'add agent context config', author: { name: 'Agent', email: 'agent@iterate.com' } });",
+    "  await itx.workspace.git.push({ dir: '/iterate-config', remote: 'origin', ref: 'main' });",
+    "}",
+  ].join("\n");
+  await client.project.streams.append({
+    projectSlugOrId: project.id,
+    streamPath: pusherPath,
+    event: {
+      type: "events.iterate.com/agent/output-added",
+      payload: { content: ["```js", pushScript, "```"].join("\n") },
+    },
+  });
+  const pushEvents = await readUntil({
+    agentPath: pusherPath,
+    client,
+    projectId: project.id,
+    afterOffset: "start",
+    predicate: (event) => event.type === "events.iterate.com/itx/execution-completed",
+    timeoutMs: 120_000,
+  });
+  expect(
+    requiredEvent(pushEvents, "events.iterate.com/itx/execution-completed").payload,
+  ).toMatchObject({ ok: true });
+
+  // Phase 2: a FRESH agent path wakes. Its stream creation announces a
+  // child-stream-created on the project root stream; the project-config-worker
+  // processor forwards it (blocking on a fresh checkout, so the just-pushed
+  // worker sees it); the config worker appends the custom context.
+  await client.project.agents.runtimeState({
+    agentPath: customizedPath,
+    projectSlugOrId: project.id,
+  });
+  const events = await readUntil({
+    agentPath: customizedPath,
+    client,
+    projectId: project.id,
+    afterOffset: "start",
+    predicate: (event) =>
+      event.type === "events.iterate.com/agent/system-prompt-updated" &&
+      typeof (event.payload as { systemPrompt?: unknown }).systemPrompt === "string" &&
+      ((event.payload as { systemPrompt?: string }).systemPrompt ?? "").includes(promptMarker),
+    timeoutMs: 120_000,
+  });
+
+  // The custom prompt must be what the agent actually runs with: either the
+  // platform defaults yielded to it (config worker won the race) or it landed
+  // after them (last-wins reducer). Both orders leave it as the LAST prompt.
+  const lastPrompt = requiredEvent(
+    [...events].reverse(),
+    "events.iterate.com/agent/system-prompt-updated",
+  );
+  const lastPromptText = requiredStringPayload(lastPrompt, "systemPrompt");
+  expect(lastPromptText).toContain(promptMarker);
+  expect(lastPromptText).toContain(customizedPath);
+  expect(events).toContainEqual(
+    expect.objectContaining({
+      type: "events.iterate.com/agent/capability-noted",
+      payload: expect.objectContaining({ name: capabilityName }),
+    }),
+  );
+}, 240_000);
+
 test("lets agent chat update iterate-config through the prepared workspace", async () => {
   await using fixture = await createTestProjectFixture({ slugPrefix: "agent-workspace" });
   const { client, project } = fixture;

--- a/apps/os/e2e/vitest/agents.e2e.test.ts
+++ b/apps/os/e2e/vitest/agents.e2e.test.ts
@@ -380,7 +380,7 @@ test("project config worker customizes fresh agents by appending events", async 
     "  // The config worker is a stream processor: this receives every event on",
     "  // the project root stream. New agent streams announce themselves as",
     "  // child-stream-created; react by appending agent context events.",
-    "  async afterAppend({ event }, env) {",
+    "  async processEvent({ event }, env) {",
     '    if (event.type !== "events.iterate.com/stream/child-stream-created") return;',
     "    const agentPath = event.payload.childPath;",
     `    if (!agentPath.startsWith(${JSON.stringify(`/agents/customized-`)})) return;`,

--- a/apps/os/iterate-config-repo/worker.js
+++ b/apps/os/iterate-config-repo/worker.js
@@ -17,4 +17,30 @@ export default {
   async afterAppend({ event }) {
     console.log("Project config worker afterAppend", event.type);
   },
+
+  // The config worker is a stream processor: afterAppend receives every event
+  // on the project root stream ("/"). React to facts by appending facts —
+  // e.g. customize every new agent in this project by watching for its stream
+  // to be created and appending your own context events (the last
+  // system-prompt-updated wins; platform defaults yield to yours):
+  //
+  // async afterAppend({ event }, env) {
+  //   if (event.type !== "events.iterate.com/stream/child-stream-created") return;
+  //   const agentPath = event.payload.childPath;
+  //   if (!agentPath.startsWith("/agents/")) return;
+  //   await env.STREAMS.append({
+  //     streamPath: agentPath,
+  //     event: {
+  //       type: "events.iterate.com/agent/system-prompt-updated",
+  //       payload: { systemPrompt: "You are this project's agent. ..." },
+  //     },
+  //   });
+  //   await env.STREAMS.append({
+  //     streamPath: agentPath,
+  //     event: {
+  //       type: "events.iterate.com/agent/capability-noted",
+  //       payload: { name: "worker.myTool", instructions: "Use itx.worker.myTool({ ... }) to ..." },
+  //     },
+  //   });
+  // },
 };

--- a/apps/os/iterate-config-repo/worker.js
+++ b/apps/os/iterate-config-repo/worker.js
@@ -14,17 +14,17 @@ export default {
     return new Response("Hello from the project config worker");
   },
 
-  async afterAppend({ event }) {
-    console.log("Project config worker afterAppend", event.type);
+  // The config worker is a stream processor: processEvent receives every
+  // event committed to the project root stream ("/"), in order. React to
+  // facts by appending facts — e.g. customize every new agent in this project
+  // by watching for its stream to be created and appending your own context
+  // events (the last system-prompt-updated wins; platform defaults yield to
+  // yours):
+  async processEvent({ event, streamPath }) {
+    console.log("Project config worker processEvent", streamPath, event.type);
   },
 
-  // The config worker is a stream processor: afterAppend receives every event
-  // on the project root stream ("/"). React to facts by appending facts —
-  // e.g. customize every new agent in this project by watching for its stream
-  // to be created and appending your own context events (the last
-  // system-prompt-updated wins; platform defaults yield to yours):
-  //
-  // async afterAppend({ event }, env) {
+  // async processEvent({ event }, env) {
   //   if (event.type !== "events.iterate.com/stream/child-stream-created") return;
   //   const agentPath = event.payload.childPath;
   //   if (!agentPath.startsWith("/agents/")) return;

--- a/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
@@ -6,7 +6,8 @@ import type { FetchCallable } from "@iterate-com/shared/callable/types.ts";
 import { createIterateDurableObjectBase } from "@iterate-com/shared/durable-object-utils/iterate-durable-object";
 import { deriveDurableObjectNameFromStructuredName } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
 import { getInitializedDoStub } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
-import { StreamPath, type Event } from "@iterate-com/shared/streams/types";
+import { StreamPath } from "@iterate-com/shared/streams/types";
+import type { StreamEvent } from "@iterate-com/streams/shared/event";
 import { typeid } from "@iterate-com/shared/typeid";
 import {
   createStreamProcessorHost,
@@ -106,7 +107,6 @@ export type ProjectSummary = {
 
 export type ProjectCapability = Pick<
   ProjectDurableObject,
-  | "afterAppend"
   | "callConfigWorkerFunction"
   | "createProject"
   | "describe"
@@ -162,7 +162,12 @@ export type ProjectDynamicWorkerEntrypoint = {
   [key: string]: any;
   [Symbol.dispose]?(): void;
   fetch(request: Request): Response | Promise<Response>;
-  afterAppend?(input: { event: Event }): unknown | Promise<unknown>;
+  /**
+   * The config worker's stream-processor hook: called with every event
+   * committed to the stream the platform subscribed it to (the project root
+   * stream), in order. Mirrors the StreamProcessor class model's processEvent.
+   */
+  processEvent?(input: { event: StreamEvent; streamPath: string }): unknown | Promise<unknown>;
 };
 
 type ProjectDynamicWorkerModule =
@@ -262,18 +267,17 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
     (deps) => new ProjectLifecycleProcessor(deps),
   );
   // The config worker as a stream processor: every root-stream event is
-  // forwarded to its afterAppend export. See the processor's contract for the
-  // composition story (per-project agent context etc.).
+  // forwarded to its processEvent export. See the processor's contract for
+  // the composition story (per-project agent context etc.).
   projectConfigWorker = this.host.add(
     ProjectConfigWorkerProcessorContract.slug,
     (deps) =>
       new ProjectConfigWorkerProcessor({
         ...deps,
-        // This subscription is on the project root stream, so the legacy
-        // Event shape's streamPath is always "/" here.
         forwardToConfigWorker: (event) =>
           this.forwardEventToConfigWorker({
-            event: { streamPath: PROJECT_LIFECYCLE_STREAM_PATH, ...event } as Event,
+            event,
+            streamPath: PROJECT_LIFECYCLE_STREAM_PATH,
           }),
       }),
   );
@@ -536,22 +540,16 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
     };
   }
 
-  async afterAppend(input: { event: Event }) {
-    await this.ensureStarted();
-    await this.forwardEventToConfigWorker(input);
-    return await this.getProjectLifecycleRunnerState();
-  }
-
   /**
-   * Delivers one event to the config worker's `afterAppend` export. No-op
+   * Delivers one event to the config worker's `processEvent` export. No-op
    * until the config worker has first been built (project provisioning does
    * that within seconds of creation; earlier events are platform lifecycle
    * noise). User-code failures are swallowed and logged — a throwing
-   * afterAppend is the project author's bug and must never wedge root-stream
+   * processEvent is the project author's bug and must never wedge root-stream
    * delivery (the host would otherwise treat the batch as poison and
    * disconnect the subscription).
    */
-  private async forwardEventToConfigWorker(input: { event: Event }) {
+  private async forwardEventToConfigWorker(input: { event: StreamEvent; streamPath: string }) {
     const summary = this.currentSummary();
     const configWorkerIsReady = await this.ctx.storage.get<boolean>(
       PROJECT_CONFIG_READY_STORAGE_KEY,
@@ -559,9 +557,9 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
     if (summary === null || configWorkerIsReady !== true) return;
     try {
       const entrypoint = await this.getForwardingProjectDynamicWorkerEntrypoint(summary);
-      await entrypoint.afterAppend?.(input);
+      await entrypoint.processEvent?.(input);
     } catch (error) {
-      console.error("Project config worker afterAppend failed.", error);
+      console.error("Project config worker processEvent failed.", error);
     }
   }
 

--- a/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
@@ -545,10 +545,16 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
    * Delivers one event to the config worker's `processEvent` export. No-op
    * until the config worker has first been built (project provisioning does
    * that within seconds of creation; earlier events are platform lifecycle
-   * noise). User-code failures are swallowed and logged — a throwing
-   * processEvent is the project author's bug and must never wedge root-stream
-   * delivery (the host would otherwise treat the batch as poison and
-   * disconnect the subscription).
+   * noise).
+   *
+   * Failure handling distinguishes whose fault it is:
+   * - PLATFORM failures (entrypoint resolution, an awaited rebuild) THROW:
+   *   the forwarding processor delivers under blockProcessorWhile, so the
+   *   checkpoint holds and the at-least-once machinery redelivers the event —
+   *   a transient repo/build hiccup must not silently drop it.
+   * - USER-code failures (the project's processEvent throwing) are swallowed
+   *   and logged: the project author's bug must never wedge root-stream
+   *   delivery into the host's poison-batch disconnect.
    */
   private async forwardEventToConfigWorker(input: { event: StreamEvent; streamPath: string }) {
     const summary = this.currentSummary();
@@ -556,8 +562,8 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
       PROJECT_CONFIG_READY_STORAGE_KEY,
     );
     if (summary === null || configWorkerIsReady !== true) return;
+    const entrypoint = await this.getForwardingProjectDynamicWorkerEntrypoint(summary);
     try {
-      const entrypoint = await this.getForwardingProjectDynamicWorkerEntrypoint(summary);
       await entrypoint.processEvent?.(input);
     } catch (error) {
       console.error("Project config worker processEvent failed.", error);

--- a/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
@@ -55,6 +55,7 @@ import {
 } from "~/domains/repos/durable-objects/repo-durable-object.ts";
 import { stripArtifactTokenQuery } from "~/domains/repos/artifacts.ts";
 import { ensureIterateConfigInfoForProject } from "~/domains/repos/entrypoints/repo-capability.ts";
+import { readRemoteBranchOid } from "~/domains/repos/repo-git.ts";
 import { ITERATE_CONFIG_REPO_SLUG } from "~/domains/repos/iterate-config-repo.ts";
 import { getSecretsCapability } from "~/domains/secrets/entrypoints/secrets-capability.ts";
 import type { StreamsCapabilityProps } from "~/domains/streams/entrypoints/streams-capability.ts";
@@ -565,23 +566,47 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
 
   /**
    * Entrypoint resolution for event forwarding. Unlike the ingress path
-   * (which serves the stale cached worker while a rebuild runs in the
-   * background, preferring latency), the forwarder prefers correctness: when
-   * the checkout is stale it AWAITS the rebuild, so a just-pushed config sees
-   * the very next event instead of losing the one that triggered it. The
-   * forwarding processor delivers under blockProcessorWhile, so the wait just
-   * holds this subscription's queue — at most one rebuild per freshness
-   * window.
+   * (which trusts a time-based freshness window and serves the stale cached
+   * worker while a rebuild runs in the background, preferring latency), the
+   * forwarder prefers correctness: an event can be the direct consequence of
+   * a config push — a new agent created right after its config landed — and
+   * serving the previous worker would consume the very trigger the new
+   * config exists to handle. So freshness is exact: one ls-remote request
+   * compares the repo's HEAD to the cached checkout's commit, and on any
+   * mismatch the rebuild is AWAITED. The forwarding processor delivers under
+   * blockProcessorWhile, so the wait just holds this subscription's queue;
+   * rebuilds only happen when the repo actually changed.
    */
   private async getForwardingProjectDynamicWorkerEntrypoint(
     summary: ProjectSummary,
   ): Promise<ProjectDynamicWorkerEntrypoint> {
-    if (await this.projectConfigCheckoutIsFresh()) {
-      try {
-        return await this.getCachedProjectDynamicWorkerEntrypoint(summary);
-      } catch (error) {
-        await this.clearProjectConfigWorkerReady();
-        console.error("Cached project config worker is invalid.", error);
+    try {
+      const cached = await this.ctx.storage.get<ProjectConfigCheckout>(
+        PROJECT_CONFIG_CHECKOUT_STORAGE_KEY,
+      );
+      if (isProjectConfigCheckout(cached)) {
+        const repo = await this.getOrCreateIterateConfigRepo(summary);
+        const headOid = await readRemoteBranchOid({
+          branch: repo.defaultBranch,
+          remote: repo.remote,
+          token: repo.token,
+        });
+        if (headOid !== null && headOid === cached.commitOid) {
+          return await this.getCachedProjectDynamicWorkerEntrypoint(summary);
+        }
+      }
+    } catch (error) {
+      // The probe is an optimization for exactness, not a gate: on probe
+      // failure fall back to the time-based window rather than blocking
+      // delivery on repo availability.
+      console.error("Project config freshness probe failed; using freshness window.", error);
+      if (await this.projectConfigCheckoutIsFresh()) {
+        try {
+          return await this.getCachedProjectDynamicWorkerEntrypoint(summary);
+        } catch (cacheError) {
+          await this.clearProjectConfigWorkerReady();
+          console.error("Cached project config worker is invalid.", cacheError);
+        }
       }
     }
     if (this.#projectConfigWorkerBuildPromise !== null) {

--- a/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
@@ -43,6 +43,10 @@ import {
   ProjectLifecycleProcessor,
   ProjectLifecycleProcessorContract,
 } from "~/domains/projects/stream-processors/project-lifecycle.ts";
+import {
+  ProjectConfigWorkerProcessor,
+  ProjectConfigWorkerProcessorContract,
+} from "~/domains/projects/stream-processors/project-config-worker/implementation.ts";
 import { substituteProjectEgressSecretHeaders } from "~/domains/projects/egress-secret-substitution.ts";
 import {
   type RepoDurableObject,
@@ -257,6 +261,22 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
     ProjectLifecycleProcessorContract.slug,
     (deps) => new ProjectLifecycleProcessor(deps),
   );
+  // The config worker as a stream processor: every root-stream event is
+  // forwarded to its afterAppend export. See the processor's contract for the
+  // composition story (per-project agent context etc.).
+  projectConfigWorker = this.host.add(
+    ProjectConfigWorkerProcessorContract.slug,
+    (deps) =>
+      new ProjectConfigWorkerProcessor({
+        ...deps,
+        // This subscription is on the project root stream, so the legacy
+        // Event shape's streamPath is always "/" here.
+        forwardToConfigWorker: (event) =>
+          this.forwardEventToConfigWorker({
+            event: { streamPath: PROJECT_LIFECYCLE_STREAM_PATH, ...event } as Event,
+          }),
+      }),
+  );
 
   #dynamicWorkerEntrypoint: {
     commitOid: string;
@@ -296,6 +316,11 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
     this.registerOnFirstInitialize(async (params) => {
       await this.ensureProjectLifecycleSubscription(params.projectId);
       await this.ensureAgentsRoot(params.projectId);
+    });
+    // On every wake (not just first initialize) so projects created before
+    // this processor existed get subscribed too; the append is idempotent.
+    this.registerOnInstanceWake(async (params) => {
+      await this.ensureProjectConfigWorkerSubscription(params.projectId);
     });
   }
 
@@ -513,21 +538,59 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
 
   async afterAppend(input: { event: Event }) {
     await this.ensureStarted();
+    await this.forwardEventToConfigWorker(input);
+    return await this.getProjectLifecycleRunnerState();
+  }
+
+  /**
+   * Delivers one event to the config worker's `afterAppend` export. No-op
+   * until the config worker has first been built (project provisioning does
+   * that within seconds of creation; earlier events are platform lifecycle
+   * noise). User-code failures are swallowed and logged — a throwing
+   * afterAppend is the project author's bug and must never wedge root-stream
+   * delivery (the host would otherwise treat the batch as poison and
+   * disconnect the subscription).
+   */
+  private async forwardEventToConfigWorker(input: { event: Event }) {
     const summary = this.currentSummary();
     const configWorkerIsReady = await this.ctx.storage.get<boolean>(
       PROJECT_CONFIG_READY_STORAGE_KEY,
     );
-    if (summary !== null && configWorkerIsReady === true) {
+    if (summary === null || configWorkerIsReady !== true) return;
+    try {
+      const entrypoint = await this.getForwardingProjectDynamicWorkerEntrypoint(summary);
+      await entrypoint.afterAppend?.(input);
+    } catch (error) {
+      console.error("Project config worker afterAppend failed.", error);
+    }
+  }
+
+  /**
+   * Entrypoint resolution for event forwarding. Unlike the ingress path
+   * (which serves the stale cached worker while a rebuild runs in the
+   * background, preferring latency), the forwarder prefers correctness: when
+   * the checkout is stale it AWAITS the rebuild, so a just-pushed config sees
+   * the very next event instead of losing the one that triggered it. The
+   * forwarding processor delivers under blockProcessorWhile, so the wait just
+   * holds this subscription's queue — at most one rebuild per freshness
+   * window.
+   */
+  private async getForwardingProjectDynamicWorkerEntrypoint(
+    summary: ProjectSummary,
+  ): Promise<ProjectDynamicWorkerEntrypoint> {
+    if (await this.projectConfigCheckoutIsFresh()) {
       try {
-        const entrypoint =
-          this.#dynamicWorkerEntrypoint?.entrypoint ??
-          (await this.getCachedProjectDynamicWorkerEntrypoint(summary));
-        await entrypoint.afterAppend?.(input);
+        return await this.getCachedProjectDynamicWorkerEntrypoint(summary);
       } catch (error) {
-        console.error("Project config worker afterAppend failed.", error);
+        await this.clearProjectConfigWorkerReady();
+        console.error("Cached project config worker is invalid.", error);
       }
     }
-    return await this.getProjectLifecycleRunnerState();
+    if (this.#projectConfigWorkerBuildPromise !== null) {
+      return await this.#projectConfigWorkerBuildPromise;
+    }
+    this.startProjectConfigWorkerBuild(summary);
+    return await this.#projectConfigWorkerBuildPromise!;
   }
 
   async ingressFetch(request: Request): Promise<Response> {
@@ -1144,6 +1207,27 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
     });
   }
 
+  private async ensureProjectConfigWorkerSubscription(projectId: string) {
+    const stream = await getInitializedStreamStub({
+      durableObjectNamespace: this.env.STREAM as unknown as StreamDurableObjectNamespace,
+      namespace: projectId,
+      path: PROJECT_LIFECYCLE_STREAM_PATH,
+    });
+
+    await stream.append({
+      type: STREAM_SUBSCRIPTION_CONFIGURED_TYPE,
+      idempotencyKey: `project-config-worker-subscription:${projectId}:callable`,
+      payload: {
+        subscriptionKey: projectConfigWorkerSubscriptionKey(projectId),
+        subscriber: durableObjectProcessorSubscriber({
+          bindingName: "PROJECT",
+          durableObjectName: getProjectDurableObjectName(projectId),
+          processorName: ProjectConfigWorkerProcessorContract.slug,
+        }),
+      },
+    });
+  }
+
   private async projectAppSlugFromHost(input: { host: string; summary: ProjectSummary }) {
     const platformHosts = parseProjectPlatformHosts({
       bases: this.getAppConfig().projectHostnameBases,
@@ -1171,6 +1255,10 @@ export class ProjectDurableObject extends ProjectLifecycleBase<ProjectEnv> {
     const prefix = host.slice(0, host.length - customHostname.length - 1);
     return prefix !== "" && !prefix.includes(".") ? prefix : null;
   }
+}
+
+function projectConfigWorkerSubscriptionKey(projectId: string) {
+  return `project-config-worker:${projectId}`;
 }
 
 function projectLifecycleSubscriptionKey(projectId: string) {

--- a/apps/os/src/domains/projects/stream-processors/project-config-worker/contract.ts
+++ b/apps/os/src/domains/projects/stream-processors/project-config-worker/contract.ts
@@ -2,7 +2,7 @@
 //
 // The project's config worker (iterate-config/worker.js) is a stream
 // processor: this contract subscribes it to the project root stream ("/") and
-// every committed event is forwarded to its exported `afterAppend` hook. That
+// every committed event is forwarded to its exported `processEvent` hook. That
 // is the project-code composition surface — config workers react to facts and
 // append facts. The motivating example is per-project agent context: the root
 // stream carries `stream/child-stream-created` for every new stream in the
@@ -19,7 +19,7 @@ export const ProjectConfigWorkerProcessorContract = defineProcessorContract({
   slug: "project-config-worker",
   version: "0.1.0",
   description:
-    "Forwards every project root-stream event to the project config worker's afterAppend hook.",
+    "Forwards every project root-stream event to the project config worker's processEvent hook.",
   // The processor itself is stateless: the config worker owns whatever durable
   // facts it wants by appending them to streams.
   stateSchema: z.object({}),

--- a/apps/os/src/domains/projects/stream-processors/project-config-worker/contract.ts
+++ b/apps/os/src/domains/projects/stream-processors/project-config-worker/contract.ts
@@ -1,0 +1,32 @@
+// Defines the "project-config-worker" processor contract.
+//
+// The project's config worker (iterate-config/worker.js) is a stream
+// processor: this contract subscribes it to the project root stream ("/") and
+// every committed event is forwarded to its exported `afterAppend` hook. That
+// is the project-code composition surface — config workers react to facts and
+// append facts. The motivating example is per-project agent context: the root
+// stream carries `stream/child-stream-created` for every new stream in the
+// project (including agent streams), so a config worker can watch for new
+// `/agents/...` paths and append its own system prompt, capability notes, or
+// llm config to them — last-wins reducers and the platform's
+// defaults-yield-to-existing-events behavior do the rest. No bespoke hook
+// protocol, no merge logic: just events.
+
+import { z } from "zod";
+import { defineProcessorContract } from "@iterate-com/streams/shared/stream-processors";
+
+export const ProjectConfigWorkerProcessorContract = defineProcessorContract({
+  slug: "project-config-worker",
+  version: "0.1.0",
+  description:
+    "Forwards every project root-stream event to the project config worker's afterAppend hook.",
+  // The processor itself is stateless: the config worker owns whatever durable
+  // facts it wants by appending them to streams.
+  stateSchema: z.object({}),
+  initialState: {},
+  events: {},
+  consumes: ["*"],
+  emits: [],
+});
+
+export type ProjectConfigWorkerProcessorContract = typeof ProjectConfigWorkerProcessorContract;

--- a/apps/os/src/domains/projects/stream-processors/project-config-worker/implementation.test.ts
+++ b/apps/os/src/domains/projects/stream-processors/project-config-worker/implementation.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { StreamEvent } from "@iterate-com/streams/shared/event";
+import { ProjectConfigWorkerProcessor } from "./implementation.ts";
+
+describe("ProjectConfigWorkerProcessor", () => {
+  it("forwards every event to the config worker in stream order", async () => {
+    const forwarded: string[] = [];
+    const processor = newProcessor({
+      forwardToConfigWorker: async (event) => {
+        forwarded.push(`${event.offset}:${event.type}`);
+      },
+    });
+
+    await processor.ingest({
+      events: [
+        event({ offset: 3, type: "events.iterate.com/stream/child-stream-created" }),
+        event({ offset: 4, type: "events.iterate.com/project/created" }),
+      ],
+      streamMaxOffset: 4,
+    });
+    await processor.ingest({
+      events: [event({ offset: 5, type: "some.custom/event" })],
+      streamMaxOffset: 5,
+    });
+
+    expect(forwarded).toEqual([
+      "3:events.iterate.com/stream/child-stream-created",
+      "4:events.iterate.com/project/created",
+      "5:some.custom/event",
+    ]);
+  });
+
+  it("does not advance the checkpoint past a failed forward", async () => {
+    let fail = true;
+    const forwarded: number[] = [];
+    const processor = newProcessor({
+      forwardToConfigWorker: async (event) => {
+        if (fail) throw new Error("config worker host hiccup");
+        forwarded.push(event.offset);
+      },
+    });
+
+    await expect(
+      processor.ingest({ events: [event({ offset: 3, type: "t" })], streamMaxOffset: 3 }),
+    ).rejects.toThrow("config worker host hiccup");
+    expect(processor.checkpointOffset).toBe(0);
+
+    // The replayed batch (at-least-once) delivers it.
+    fail = false;
+    await processor.ingest({ events: [event({ offset: 3, type: "t" })], streamMaxOffset: 3 });
+    expect(forwarded).toEqual([3]);
+    expect(processor.checkpointOffset).toBe(3);
+  });
+});
+
+function newProcessor(deps: { forwardToConfigWorker: (event: StreamEvent) => Promise<void> }) {
+  return new ProjectConfigWorkerProcessor({
+    iterateContext: { stream: { append: () => {}, appendBatch: () => {} } },
+    ...deps,
+  });
+}
+
+function event(args: { offset: number; type: string }): StreamEvent {
+  return {
+    type: args.type,
+    payload: {},
+    offset: args.offset,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+}

--- a/apps/os/src/domains/projects/stream-processors/project-config-worker/implementation.ts
+++ b/apps/os/src/domains/projects/stream-processors/project-config-worker/implementation.ts
@@ -1,0 +1,36 @@
+// Implements the "project-config-worker" processor: the bridge that makes the
+// project's config worker behave like a stream processor. See contract.ts.
+
+import { StreamProcessor } from "@iterate-com/streams/stream-processor";
+import type { StreamEvent } from "@iterate-com/streams/shared/event";
+import { ProjectConfigWorkerProcessorContract } from "./contract.ts";
+
+export { ProjectConfigWorkerProcessorContract } from "./contract.ts";
+
+export type ProjectConfigWorkerProcessorDeps = {
+  /**
+   * Delivers one event to the config worker's `afterAppend` export. The host
+   * (ProjectDurableObject) owns the gate (no-op until the config worker has
+   * been built) and MUST swallow user-code failures: a throwing afterAppend is
+   * the project author's bug and may never wedge the root stream's delivery —
+   * the host's poison-batch handling would otherwise disconnect this
+   * subscription after repeated failures.
+   */
+  forwardToConfigWorker(event: StreamEvent): Promise<void>;
+};
+
+export class ProjectConfigWorkerProcessor extends StreamProcessor<
+  ProjectConfigWorkerProcessorContract,
+  ProjectConfigWorkerProcessorDeps
+> {
+  readonly contract = ProjectConfigWorkerProcessorContract;
+
+  protected override processEvent(
+    args: Parameters<StreamProcessor<ProjectConfigWorkerProcessorContract>["processEvent"]>[0],
+  ): void {
+    // Blocking keeps delivery ordered and checkpointed: the config worker sees
+    // events in stream order, exactly once per checkpoint advance (at-least-
+    // once across crashes, like every processor side effect).
+    args.blockProcessorWhile(() => this.deps.forwardToConfigWorker(args.event));
+  }
+}

--- a/apps/os/src/domains/projects/stream-processors/project-config-worker/implementation.ts
+++ b/apps/os/src/domains/projects/stream-processors/project-config-worker/implementation.ts
@@ -9,12 +9,12 @@ export { ProjectConfigWorkerProcessorContract } from "./contract.ts";
 
 export type ProjectConfigWorkerProcessorDeps = {
   /**
-   * Delivers one event to the config worker's `afterAppend` export. The host
+   * Delivers one event to the config worker's `processEvent` export. The host
    * (ProjectDurableObject) owns the gate (no-op until the config worker has
-   * been built) and MUST swallow user-code failures: a throwing afterAppend is
-   * the project author's bug and may never wedge the root stream's delivery —
-   * the host's poison-batch handling would otherwise disconnect this
-   * subscription after repeated failures.
+   * been built) and MUST swallow user-code failures: a throwing processEvent
+   * is the project author's bug and may never wedge the root stream's
+   * delivery — the host's poison-batch handling would otherwise disconnect
+   * this subscription after repeated failures.
    */
   forwardToConfigWorker(event: StreamEvent): Promise<void>;
 };

--- a/apps/os/src/domains/projects/stream-processors/project-config-worker/implementation.ts
+++ b/apps/os/src/domains/projects/stream-processors/project-config-worker/implementation.ts
@@ -11,10 +11,12 @@ export type ProjectConfigWorkerProcessorDeps = {
   /**
    * Delivers one event to the config worker's `processEvent` export. The host
    * (ProjectDurableObject) owns the gate (no-op until the config worker has
-   * been built) and MUST swallow user-code failures: a throwing processEvent
-   * is the project author's bug and may never wedge the root stream's
-   * delivery — the host's poison-batch handling would otherwise disconnect
-   * this subscription after repeated failures.
+   * been built) and the failure split: USER-code failures (the project's
+   * processEvent throwing) must be swallowed there — the project author's bug
+   * may never wedge root-stream delivery into the poison-batch disconnect —
+   * while PLATFORM failures (entrypoint resolution, rebuilds) must throw so
+   * the blocking delivery below holds the checkpoint and the event is
+   * redelivered rather than silently dropped.
    */
   forwardToConfigWorker(event: StreamEvent): Promise<void>;
 };

--- a/apps/os/src/domains/repos/iterate-config-base-seed.ts
+++ b/apps/os/src/domains/repos/iterate-config-base-seed.ts
@@ -31,17 +31,17 @@ export default {
     return new Response("Hello from the project config worker");
   },
 
-  async afterAppend({ event }) {
-    console.log("Project config worker afterAppend", event.type);
+  // The config worker is a stream processor: processEvent receives every
+  // event committed to the project root stream ("/"), in order. React to
+  // facts by appending facts — e.g. customize every new agent in this project
+  // by watching for its stream to be created and appending your own context
+  // events (the last system-prompt-updated wins; platform defaults yield to
+  // yours):
+  async processEvent({ event, streamPath }) {
+    console.log("Project config worker processEvent", streamPath, event.type);
   },
 
-  // The config worker is a stream processor: afterAppend receives every event
-  // on the project root stream ("/"). React to facts by appending facts —
-  // e.g. customize every new agent in this project by watching for its stream
-  // to be created and appending your own context events (the last
-  // system-prompt-updated wins; platform defaults yield to yours):
-  //
-  // async afterAppend({ event }, env) {
+  // async processEvent({ event }, env) {
   //   if (event.type !== "events.iterate.com/stream/child-stream-created") return;
   //   const agentPath = event.payload.childPath;
   //   if (!agentPath.startsWith("/agents/")) return;

--- a/apps/os/src/domains/repos/iterate-config-base-seed.ts
+++ b/apps/os/src/domains/repos/iterate-config-base-seed.ts
@@ -34,6 +34,32 @@ export default {
   async afterAppend({ event }) {
     console.log("Project config worker afterAppend", event.type);
   },
+
+  // The config worker is a stream processor: afterAppend receives every event
+  // on the project root stream ("/"). React to facts by appending facts —
+  // e.g. customize every new agent in this project by watching for its stream
+  // to be created and appending your own context events (the last
+  // system-prompt-updated wins; platform defaults yield to yours):
+  //
+  // async afterAppend({ event }, env) {
+  //   if (event.type !== "events.iterate.com/stream/child-stream-created") return;
+  //   const agentPath = event.payload.childPath;
+  //   if (!agentPath.startsWith("/agents/")) return;
+  //   await env.STREAMS.append({
+  //     streamPath: agentPath,
+  //     event: {
+  //       type: "events.iterate.com/agent/system-prompt-updated",
+  //       payload: { systemPrompt: "You are this project's agent. ..." },
+  //     },
+  //   });
+  //   await env.STREAMS.append({
+  //     streamPath: agentPath,
+  //     event: {
+  //       type: "events.iterate.com/agent/capability-noted",
+  //       payload: { name: "worker.myTool", instructions: "Use itx.worker.myTool({ ... }) to ..." },
+  //     },
+  //   });
+  // },
 };
 `;
 

--- a/apps/os/src/domains/repos/repo-git.test.ts
+++ b/apps/os/src/domains/repos/repo-git.test.ts
@@ -1,12 +1,13 @@
 import { InMemoryFs } from "@cloudflare/shell";
 import { createGit } from "@cloudflare/shell/git";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   CommitRepoFilesInput,
   REPO_COMMIT_AUTHOR,
   RepoFileChange,
   applyRepoFileChanges,
   isMissingRemoteRefError,
+  readRemoteBranchOid,
 } from "./repo-git.ts";
 
 const REPO_DIR = "/repo";
@@ -186,4 +187,65 @@ describe("CommitRepoFilesInput", () => {
       CommitRepoFilesInput.parse({ changes: [{ content: "x", path: "a" }], message: " " }),
     ).toThrow();
   });
+});
+
+describe("readRemoteBranchOid", () => {
+  const OID = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+  const OTHER = "ffffffffffffffffffffffffffffffffffffffff";
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("parses the branch oid out of a smart-HTTP ref advertisement", async () => {
+    const fetchSpy = mockAdvertisement(
+      pktLine("# service=git-upload-pack\n") +
+        "0000" +
+        pktLine(`${OID} HEAD\u0000multi_ack side-band-64k agent=git/test\n`) +
+        pktLine(`${OID} refs/heads/main\n`) +
+        pktLine(`${OTHER} refs/heads/other\n`) +
+        "0000",
+    );
+
+    await expect(
+      readRemoteBranchOid({
+        branch: "main",
+        remote: "https://acc.artifacts.cloudflare.net/git/ns/iterate-config.git/",
+        token: "tok?expires=123",
+      }),
+    ).resolves.toBe(OID);
+
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toBe(
+      "https://acc.artifacts.cloudflare.net/git/ns/iterate-config.git/info/refs?service=git-upload-pack",
+    );
+    expect((init as RequestInit).headers).toMatchObject({ authorization: "Bearer tok" });
+  });
+
+  test("returns null when the branch is not advertised", async () => {
+    mockAdvertisement(pktLine(`${OID} refs/heads/other\n`) + "0000");
+    await expect(
+      readRemoteBranchOid({ branch: "main", remote: "https://r.test/x.git", token: "t" }),
+    ).resolves.toBeNull();
+  });
+
+  test("throws on a non-ok response so callers fall back to the freshness window", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope", { status: 401 }));
+    await expect(
+      readRemoteBranchOid({ branch: "main", remote: "https://r.test/x.git", token: "t" }),
+    ).rejects.toThrow("ls-remote");
+  });
+
+  function pktLine(content: string): string {
+    return (content.length + 4).toString(16).padStart(4, "0") + content;
+  }
+
+  function mockAdvertisement(body: string) {
+    return vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(body, {
+        headers: { "content-type": "application/x-git-upload-pack-advertisement" },
+        status: 200,
+      }),
+    );
+  }
 });

--- a/apps/os/src/domains/repos/repo-git.ts
+++ b/apps/os/src/domains/repos/repo-git.ts
@@ -212,6 +212,52 @@ export async function listRepoFiles(input: RepoRemote & { branch: string }): Pro
   return paths.sort();
 }
 
+/**
+ * Resolve a branch's commit oid on the remote with ONE HTTP request — the git
+ * smart-HTTP ref advertisement (`git ls-remote`), no clone. This is the cheap
+ * freshness probe: "does my cached checkout still match the remote?".
+ */
+export async function readRemoteBranchOid(
+  input: RepoRemote & { branch: string },
+): Promise<string | null> {
+  const base = input.remote.replace(/\/+$/, "");
+  const response = await fetch(`${base}/info/refs?service=git-upload-pack`, {
+    headers: {
+      accept: "application/x-git-upload-pack-advertisement",
+      authorization: `Bearer ${stripArtifactTokenQuery(input.token)}`,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`ls-remote against ${base} failed: ${response.status}`);
+  }
+  const wanted = `refs/heads/${input.branch}`;
+  for (const line of parsePktLines(await response.text())) {
+    // Advertisement lines are "<oid> <ref>"; the first ref also carries
+    // "\0<capabilities>". Non-ref pkt-lines (the service banner) fall out of
+    // the shape check.
+    const [oidAndRef = ""] = line.split("\0");
+    const oid = oidAndRef.slice(0, 40);
+    const ref = oidAndRef.slice(41).trim();
+    if (ref === wanted && /^[0-9a-f]{40}$/.test(oid)) return oid;
+  }
+  return null;
+}
+
+/** Git pkt-line framing: 4 hex length bytes (including themselves), "0000" = flush. */
+function* parsePktLines(body: string): Generator<string> {
+  let index = 0;
+  while (index + 4 <= body.length) {
+    const length = Number.parseInt(body.slice(index, index + 4), 16);
+    if (Number.isNaN(length)) return;
+    if (length === 0) {
+      index += 4; // flush-pkt
+      continue;
+    }
+    yield body.slice(index + 4, index + length).replace(/\n$/, "");
+    index += length;
+  }
+}
+
 export async function readRepoLog(
   input: RepoRemote & { branch: string; depth?: number },
 ): Promise<GitLogEntry[]> {

--- a/apps/os/src/durable-objects/project-ingress-test-entry.ts
+++ b/apps/os/src/durable-objects/project-ingress-test-entry.ts
@@ -1,4 +1,5 @@
 import { createD1Client } from "sqlfu";
+import { StreamPath } from "@iterate-com/shared/streams/types";
 import {
   getInitializedStreamStub,
   type StreamDurableObjectNamespace,
@@ -39,6 +40,20 @@ export default {
     }
 
     return new Response("Bundled project worker");
+  },
+
+  // The config worker is a stream processor: every project root-stream event
+  // is forwarded here. Echo pings back as facts so tests can observe the
+  // whole forwarding chain end to end.
+  async afterAppend({ event }, env) {
+    if (event.type !== "test.project/ping") return;
+    await env.STREAMS.append({
+      streamPath: "/config-worker-saw",
+      event: {
+        type: "test.project/config-worker-saw",
+        payload: { pingOffset: event.offset, n: event.payload.n },
+      },
+    });
   },
 };
 `;
@@ -246,6 +261,27 @@ export default {
         headers: Object.fromEntries(request.headers),
         url: request.url,
       });
+    }
+
+    if (url.pathname === "/__test/append-project-event") {
+      const stream = await getInitializedStreamStub({
+        durableObjectNamespace: env.STREAM as unknown as StreamDurableObjectNamespace,
+        namespace: "proj__local__test",
+        path: PROJECT_LIFECYCLE_STREAM_PATH,
+      });
+      const n = Number(url.searchParams.get("n") ?? "0");
+      const appended = await stream.append({ type: "test.project/ping", payload: { n } });
+      return Response.json({ appended });
+    }
+
+    if (url.pathname === "/__test/read-stream") {
+      const path = url.searchParams.get("path") ?? PROJECT_LIFECYCLE_STREAM_PATH;
+      const stream = await getInitializedStreamStub({
+        durableObjectNamespace: env.STREAM as unknown as StreamDurableObjectNamespace,
+        namespace: "proj__local__test",
+        path: StreamPath.parse(path),
+      });
+      return Response.json({ events: await stream.history({ before: "end" }) });
     }
 
     if (url.pathname === "/__test/project-stream") {

--- a/apps/os/src/durable-objects/project-ingress-test-entry.ts
+++ b/apps/os/src/durable-objects/project-ingress-test-entry.ts
@@ -45,7 +45,8 @@ export default {
   // The config worker is a stream processor: every project root-stream event
   // is forwarded here. Echo pings back as facts so tests can observe the
   // whole forwarding chain end to end.
-  async afterAppend({ event }, env) {
+  async processEvent({ event, streamPath }, env) {
+    if (streamPath !== "/") return;
     if (event.type !== "test.project/ping") return;
     await env.STREAMS.append({
       streamPath: "/config-worker-saw",

--- a/apps/os/src/durable-objects/project-ingress.test.ts
+++ b/apps/os/src/durable-objects/project-ingress.test.ts
@@ -327,6 +327,43 @@ describe("Project ingress routing", () => {
   });
 });
 
+test("project config worker receives root-stream events and appends facts back", async () => {
+  await createProject();
+
+  // The config worker must be built before forwarding delivers to it (the
+  // gate is the ready flag set by provisioning).
+  await waitForProjectLifecycleEvents([
+    expect.objectContaining({ type: "events.iterate.com/project/config-worker-built" }),
+  ]);
+
+  // Append a fact to the project root stream. The project-config-worker
+  // processor (subscribed to "/") forwards it to the config worker's
+  // afterAppend export, which echoes it onto /config-worker-saw — proving the
+  // whole chain: subscription wiring, blocking forward, entrypoint
+  // resolution, and the object-export env argument, all in real workerd.
+  const appendResponse = await SELF.fetch(
+    "https://os.iterate.localhost/__test/append-project-event?n=42",
+  );
+  expect(appendResponse.ok).toBe(true);
+
+  const deadline = Date.now() + 10_000;
+  let latest: unknown;
+  while (Date.now() < deadline) {
+    const response = await SELF.fetch(
+      "https://os.iterate.localhost/__test/read-stream?path=/config-worker-saw",
+    );
+    latest = await response.json();
+    const body = latest as { events: Array<{ type: string; payload: Record<string, unknown> }> };
+    const saw = body.events.find((event) => event.type === "test.project/config-worker-saw");
+    if (saw) {
+      expect(saw.payload).toMatchObject({ n: 42 });
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`config worker never saw the ping: ${JSON.stringify(latest)}`);
+});
+
 async function createProject() {
   const response = await SELF.fetch("https://os.iterate.localhost/__test/create-project");
   expect(response.ok).toBe(true);


### PR DESCRIPTION
## What

**A project's `iterate-config/worker.js` is now a stream processor.** Every event committed to the project root stream (`/`) is delivered to its exported `processEvent` hook — same name and spirit as the `StreamProcessor` class model — in order, checkpointed, at-least-once. Project code reacts to facts by appending facts. That one mechanism is the whole API: no hook protocol, no config schema, no merge logic.

The motivating use case (and the original goal of the agents-system work, `tasks/agents-system-audit-and-reconciler-design.md` §4): **per-project agent context**. Every new stream in a project — including every new agent — announces itself on the root stream as `stream/child-stream-created`. A config worker can watch for new agent paths and write its own context into them:

```js
// iterate-config/worker.js
export default {
  async fetch(request, env) { /* ... ingress apps ... */ },

  // Called with every event committed to the project root stream ("/").
  async processEvent({ event, streamPath }, env) {
    if (event.type !== "events.iterate.com/stream/child-stream-created") return;
    const agentPath = event.payload.childPath;
    if (!agentPath.startsWith("/agents/")) return;

    // Customize every agent in this project: the last system-prompt-updated
    // wins, and platform defaults yield to events that are already there —
    // so this works regardless of who wins the creation race.
    await env.STREAMS.append({
      streamPath: agentPath,
      event: {
        type: "events.iterate.com/agent/system-prompt-updated",
        payload: { systemPrompt: "You are the ACME deployment agent. ..." },
      },
    });

    // Anything this worker exports is already callable from agent scripts as
    // itx.worker.<name>(...) — capability-noted is how the LLM finds out:
    await env.STREAMS.append({
      streamPath: agentPath,
      event: {
        type: "events.iterate.com/agent/capability-noted",
        payload: {
          name: "worker.deploy",
          instructions: "Use itx.worker.deploy({ service }) to trigger a deploy.",
        },
      },
    });
  },

  async deploy({ service }) { /* ... reachable as itx.worker.deploy(...) ... */ },
};
```

The same shape works for model/provider config (`agent/llm-config-updated`, `os-agent/llm-provider-selected`), primer rows (`agent/input-added` with `dont-trigger-request`), or reacting to anything else on the root stream (webhooks, lifecycle facts).

> This PR was originally a `configureAgent` pull-RPC hook with a config schema and platform-side merging; reworked from scratch after review feedback to plain stream processing. The hook was then renamed from the legacy `afterAppend` to `processEvent({ event, streamPath }, env)` to match the class-model vocabulary; the project DO's vestigial public `afterAppend` is deleted.

## How

A `processEvent`-ish surface existed on the template (`afterAppend`) — but nothing in production drove it (only a debug route). This PR adds the missing processor:

```ts
// project-config-worker/implementation.ts — the entire bridge
export class ProjectConfigWorkerProcessor extends StreamProcessor<...> {
  protected override processEvent(args) {
    // Ordered, checkpointed, at-least-once — like every processor side effect.
    args.blockProcessorWhile(() => this.deps.forwardToConfigWorker(args.event));
  }
}
```

hosted on `ProjectDurableObject` next to `project-lifecycle`, subscribed to `/` with `consumes: ["*"]` (subscription ensured on every project wake, so pre-existing projects pick it up).

Two deliberate policies on the DO side:

- **Correctness over latency for config freshness.** The ingress path serves the stale cached worker while rebuilding; the forwarder instead *awaits* the rebuild when the checkout is stale — otherwise a just-pushed config would trigger a rebuild *because of* the very event it needed to see, and lose it.
- **User code can't wedge the platform.** A throwing `processEvent` is swallowed and logged — it must never poison root-stream delivery into a disconnect. Forwarding no-ops until the config worker's first build (project provisioning does that within seconds of creation).

## Testing

- **Unit** (`project-config-worker/implementation.test.ts`): events forwarded in stream order; a failed forward does not advance the checkpoint (the at-least-once replay delivers it).
- **Workerd** (`pnpm test:project-ingress`): the full chain in real runtime — the test project's config worker echoes a root-stream ping back as a fact on another stream, proving subscription wiring, blocking forward, fresh-entrypoint resolution, and that object-syntax exports receive `(input, env)`:

  ```js
  async processEvent({ event, streamPath }, env) {
    if (streamPath !== "/") return;
    if (event.type !== "test.project/ping") return;
    await env.STREAMS.append({
      streamPath: "/config-worker-saw",
      event: { type: "test.project/config-worker-saw", payload: { n: event.payload.n } },
    });
  }
  ```

- **E2E** (deterministic, no LLM in the loop): an injected agent script pushes a `processEvent` config worker into the project's iterate-config repo; a fresh agent path then wakes, and its stream must show the custom prompt as the **last** system-prompt fact (i.e. what the agent actually runs with) plus the announced capability. Passed against the deployed preview.
- The iterate-config template (repo copy + base seed) documents the pattern with a live `processEvent` logger plus a commented agent-customization example.
- `pnpm typecheck && pnpm lint && pnpm format && pnpm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T21:18:02.628Z",
      "headSha": "6ae7b5e5b513328ed74dfabffb514c7e95d0d203",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27306515412",
      "shortSha": "6ae7b5e"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `6ae7b5e`
Preview: https://os.iterate-preview-6.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27306515412)
Updated: 2026-06-10T21:18:02.628Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every project root-stream event is delivered to user code and how config worker builds are awaited on that path; mistakes could drop or delay customization events, though platform/user error split and tests mitigate this.
> 
> **Overview**
> **Project `iterate-config/worker.js` is wired as a stream processor:** every event on the project root stream (`/`) is delivered to **`processEvent({ event, streamPath }, env)`**, replacing the unused **`afterAppend`** hook and removing the Project DO’s public **`afterAppend`**.
> 
> A new **`project-config-worker`** processor on **`ProjectDurableObject`** subscribes to `/` (idempotent subscription on each project wake) and **forwards events in order** under **`blockProcessorWhile`**, so checkpoints advance only after delivery. **Platform failures** (rebuild/resolution) **throw** for redelivery; **user `processEvent` throws** are **logged and swallowed** so root-stream processing cannot wedge.
> 
> **Event forwarding uses stricter config freshness than ingress:** a single **`readRemoteBranchOid`** (`git ls-remote`) compares remote HEAD to the cached checkout; on mismatch the forwarder **awaits** a rebuild instead of serving a stale worker while a push-triggered event is in flight.
> 
> Templates/seeds document **`processEvent`** and a commented **per-agent context** pattern (`child-stream-created` → append system prompt / capability on agent streams). Coverage adds **unit** forwarding/checkpoint tests, a **workerd** root-stream echo chain, and an **e2e** that pushes a custom config worker and asserts fresh agents get the **last** custom prompt and capability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ae7b5e5b513328ed74dfabffb514c7e95d0d203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->