### PR TITLE
[codex] Add itx REPL autocomplete docs

### DIFF
--- a/apps/os/src/components/itx-repl-autocomplete-worker.ts
+++ b/apps/os/src/components/itx-repl-autocomplete-worker.ts
@@ -1,0 +1,35 @@
+import type { CompletionContext, CompletionResult } from "@codemirror/autocomplete";
+import type { VirtualTypeScriptEnvironment } from "@typescript/vfs";
+import { getAutocompletion } from "@valtown/codemirror-ts/worker";
+import ts from "typescript";
+
+export async function getAutocompletionWithDocs(input: {
+  context: Pick<CompletionContext, "explicit" | "pos">;
+  env: VirtualTypeScriptEnvironment;
+  path: string;
+}): Promise<CompletionResult | null> {
+  const result = await getAutocompletion({
+    env: input.env,
+    path: input.path,
+    context: input.context,
+  });
+
+  if (!result) return null;
+
+  return {
+    ...result,
+    options: result.options.map((option) => {
+      const details = input.env.languageService.getCompletionEntryDetails(
+        input.path,
+        input.context.pos,
+        option.label,
+        {},
+        undefined,
+        {},
+        undefined,
+      );
+      const documentation = ts.displayPartsToString(details?.documentation ?? []).trim();
+      return documentation ? { ...option, info: documentation } : option;
+    }),
+  };
+}

--- a/apps/os/src/components/itx-repl-autocomplete.ts
+++ b/apps/os/src/components/itx-repl-autocomplete.ts
@@ -1,0 +1,25 @@
+import type { CompletionResult, CompletionSource } from "@codemirror/autocomplete";
+import type { Facet } from "@codemirror/state";
+import type { WorkerShape } from "@valtown/codemirror-ts/worker";
+import type { ItxReplTypeScriptWorker } from "./itx-repl-types.ts";
+
+type TypeScriptWorkerFacet = Facet<
+  { path: string; worker: WorkerShape },
+  { path: string; worker: WorkerShape } | null
+>;
+
+export function itxReplAutocompleteWorker(tsFacetWorker: TypeScriptWorkerFacet): CompletionSource {
+  return async (context): Promise<CompletionResult | null> => {
+    const config = context.state.facet(tsFacetWorker);
+    if (!config) return null;
+
+    const worker = config.worker as unknown as ItxReplTypeScriptWorker;
+    return worker.getAutocompletionWithDocs({
+      path: config.path,
+      context: {
+        explicit: context.explicit,
+        pos: context.pos,
+      },
+    });
+  };
+}

--- a/apps/os/src/components/itx-repl-types.test.ts
+++ b/apps/os/src/components/itx-repl-types.test.ts
@@ -1,0 +1,114 @@
+import { CompletionContext } from "@codemirror/autocomplete";
+import { EditorState } from "@codemirror/state";
+import { tsFacetWorker } from "@valtown/codemirror-ts";
+import type { VirtualTypeScriptEnvironment } from "@typescript/vfs";
+import ts from "typescript";
+import { describe, expect, test, vi } from "vitest";
+import { itxReplAutocompleteWorker } from "./itx-repl-autocomplete.ts";
+import { getAutocompletionWithDocs } from "./itx-repl-autocomplete-worker.ts";
+import { itxReplDeclaration, type ItxReplTypeScriptWorker } from "./itx-repl-types.ts";
+
+const REPL_SOURCE_PATH = "/repl.ts";
+const REPL_TYPES_PATH = "/iterate-repl-globals.d.ts";
+
+const compilerOptions: ts.CompilerOptions = {
+  allowSyntheticDefaultImports: true,
+  lib: ["es2022", "dom"],
+  module: ts.ModuleKind.ESNext,
+  moduleDetection: ts.ModuleDetectionKind.Force,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  noEmit: true,
+  strict: true,
+  target: ts.ScriptTarget.ES2022,
+};
+
+describe("itx REPL TypeScript declarations", () => {
+  test("autocomplete options include itx JSDoc as CodeMirror completion info", async () => {
+    const env = createReplTypeScriptEnv("itx.");
+    const result = await getAutocompletionWithDocs({
+      env,
+      path: REPL_SOURCE_PATH,
+      context: { explicit: true, pos: "itx.".length },
+    });
+
+    expect(result?.options.find((option) => option.label === "caps")?.info).toContain(
+      "Register, revoke, inspect, and share capabilities",
+    );
+    expect(result?.options.find((option) => option.label === "describe")?.info).toContain(
+      "Who/what am I holding?",
+    );
+    expect(result?.options.find((option) => option.label === "fetch")?.info).toContain(
+      "Explicit project egress",
+    );
+  });
+
+  test("nested autocomplete options include itx JSDoc as CodeMirror completion info", async () => {
+    const env = createReplTypeScriptEnv("itx.caps.");
+    const result = await getAutocompletionWithDocs({
+      env,
+      path: REPL_SOURCE_PATH,
+      context: { explicit: true, pos: "itx.caps.".length },
+    });
+
+    expect(result?.options.find((option) => option.label === "define")?.info).toContain(
+      "Register a capability",
+    );
+    expect(result?.options.find((option) => option.label === "shareUrl")?.info).toContain(
+      "signed, expiring URL",
+    );
+  });
+
+  test("CodeMirror completion source delegates to the REPL TypeScript worker", async () => {
+    const result = {
+      from: 4,
+      options: [{ label: "caps", info: "Register, revoke, inspect, and share capabilities." }],
+    };
+    const worker = {
+      getAutocompletionWithDocs: vi.fn().mockResolvedValue(result),
+    } as unknown as ItxReplTypeScriptWorker;
+    const state = EditorState.create({
+      doc: "itx.",
+      extensions: [tsFacetWorker.of({ path: REPL_SOURCE_PATH, worker })],
+    });
+
+    await expect(
+      itxReplAutocompleteWorker(tsFacetWorker)(new CompletionContext(state, 4, true)),
+    ).resolves.toBe(result);
+    expect(worker.getAutocompletionWithDocs).toHaveBeenCalledWith({
+      path: REPL_SOURCE_PATH,
+      context: { explicit: true, pos: 4 },
+    });
+  });
+});
+
+function createReplTypeScriptEnv(code: string): VirtualTypeScriptEnvironment {
+  const service = createReplLanguageService(code);
+  return {
+    getSourceFile: (path: string) => service.getProgram()?.getSourceFile(path),
+    languageService: service,
+  } as VirtualTypeScriptEnvironment;
+}
+
+function createReplLanguageService(code: string): ts.LanguageService {
+  const files = new Map<string, string>([
+    [REPL_TYPES_PATH, itxReplDeclaration],
+    [REPL_SOURCE_PATH, code],
+  ]);
+  const host: ts.LanguageServiceHost = {
+    directoryExists: ts.sys.directoryExists,
+    fileExists: (fileName) => files.has(fileName) || ts.sys.fileExists(fileName),
+    getCompilationSettings: () => compilerOptions,
+    getCurrentDirectory: () => process.cwd(),
+    getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+    getDirectories: ts.sys.getDirectories,
+    getScriptFileNames: () => [...files.keys()],
+    getScriptSnapshot: (fileName) => {
+      const content = files.get(fileName) ?? ts.sys.readFile(fileName);
+      return content === undefined ? undefined : ts.ScriptSnapshot.fromString(content);
+    },
+    getScriptVersion: () => "0",
+    readDirectory: ts.sys.readDirectory,
+    readFile: (fileName) => files.get(fileName) ?? ts.sys.readFile(fileName),
+  };
+  return ts.createLanguageService(host);
+}

--- a/apps/os/src/components/itx-repl-types.ts
+++ b/apps/os/src/components/itx-repl-types.ts
@@ -1,0 +1,336 @@
+import type { CompletionContext, CompletionResult } from "@codemirror/autocomplete";
+import type { WorkerShape } from "@valtown/codemirror-ts/worker";
+
+export type ItxReplTypeScriptWorker = WorkerShape & {
+  getAutocompletionWithDocs(input: {
+    context: Pick<CompletionContext, "explicit" | "pos">;
+    path: string;
+  }): Promise<CompletionResult | null>;
+};
+
+// Ambient declarations for REPL autocomplete. This is the itx surface as the
+// editor sees it; TypeScript uses these JSDoc comments for autocomplete detail
+// and hover text in the browser REPL.
+export const itxReplDeclaration = `
+declare class RpcTarget {}
+
+type JsonRecord = Record<string, unknown>;
+
+/**
+ * Anything not declared here resolves through the capability fallthrough.
+ *
+ * Capability property access accumulates a path locally, then the terminal
+ * call dispatches once: \`itx.slack.chat.postMessage(...)\`.
+ */
+type CapSurface = {
+  (...args: any[]): Promise<unknown>;
+  [segment: string]: CapSurface;
+};
+
+interface ProjectSummary {
+  id: string;
+  slug: string;
+  customHostname?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+}
+
+/**
+ * Narrowing lives here: \`get()\` checks the principal's grants and returns a
+ * new project-scoped handle.
+ */
+interface ItxProjects {
+  /** Admin principals only: create a project and return its summary. */
+  create(input: { id?: string; slug: string }): Promise<ProjectSummary>;
+  /**
+   * Narrow to a project. There is no separate "project object"; the returned
+   * handle is an itx scoped to that project.
+   */
+  get(projectIdOrSlug: string): Promise<Itx>;
+  /** List the projects this handle may see. */
+  list(input?: { limit?: number; offset?: number }): Promise<{ projects: ProjectSummary[]; total: number }>;
+  /** Admin principals only: remove a project by id. */
+  remove(input: { id: string }): Promise<{ ok: true; id: string; deleted: boolean }>;
+}
+
+/** A registry entry as reported by \`describe()\`. Never contains live stubs. */
+interface CapDescription {
+  name: string;
+  /** The target's kind: "live" | "rpc" | "url". */
+  kind: "live" | "rpc" | "url";
+  /** How the target is invoked once resolved. */
+  invoke: "members" | "path-call";
+  /** Which context owns the entry; provenance for shadowing visibility. */
+  owner: string;
+  /** Live caps only: is the provider currently connected? */
+  connected?: boolean;
+  /** Lifted from meta for convenience: the one thing to read first. */
+  instructions?: string;
+  meta?: JsonRecord;
+  updatedAtMs?: number;
+}
+
+/**
+ * Stored source for a dynamic worker capability. The platform materializes it
+ * into an isolate on demand.
+ */
+interface CapSource {
+  /** Cache key for the materialized isolate; change it whenever modules change. */
+  cacheKey: string;
+  mainModule: string;
+  modules: Record<string, string>;
+  /** Named export to load; defaults to the default export. */
+  entrypoint?: string;
+  /** Whether the entrypoint is stateless or a stateful Durable Object export. */
+  exportType?: "worker-entrypoint" | "durable-object";
+  compatibilityDate?: string;
+}
+
+/**
+ * Where an rpc target's worker lives. First-party and user-space code use the
+ * same shape; only the ref type differs.
+ */
+type WorkerRef =
+  /** A service/env binding such as AI; without an entrypoint, the binding itself is the target. */
+  | { type: "binding"; binding: string }
+  /** The platform worker's own exports, such as McpClient, ProjectWorker, or policy wrappers. */
+  | { type: "loopback" }
+  /** A Durable Object addressed by namespace binding and instance name. */
+  | { type: "durable-object"; binding: string; name: string }
+  /** A dynamic worker materialized from stored source. */
+  | { type: "source"; source: CapSource };
+
+/**
+ * The capability target. Live targets are session-bound; rpc/url targets are
+ * durable refs that the registry restores to live objects on demand.
+ */
+type CapTarget =
+  | { type: "live"; stub: object }
+  | {
+      type: "rpc";
+      worker: WorkerRef;
+      /** Named export to use; defaults to the worker's default export or binding object. */
+      entrypoint?: string;
+      /** Serializable entrypoint parameterization; the registry adds context/cap attribution. */
+      props?: JsonRecord;
+    }
+  | {
+      type: "url";
+      url: string;
+      /** Sent on connect; values pass through project egress secret substitution. */
+      headers?: Record<string, string>;
+    };
+
+type CapInvoke = "members" | "path-call";
+
+type CapMeta = {
+  /** Shown in describe(); write it for the agent who finds this cap. */
+  instructions?: string;
+  [key: string]: unknown;
+};
+
+/** Registry verbs. All registration is \`define\`; the target kind carries direction and durability. */
+interface ItxCaps {
+  /**
+   * Register a capability on this handle's context: a flat-identifier name
+   * plus a target. Live targets are session-bound; rpc/url targets are durable.
+   * Nested names belong to the provided object, not the registry.
+   */
+  define(input: { name: string; target: CapTarget; invoke?: CapInvoke; meta?: CapMeta }): Promise<{ name: string; ok: true }>;
+  /**
+   * Legacy alias: \`provide({ name, target: stub })\` is equivalent to defining
+   * a live capability target.
+   */
+  provide(input: { name: string; target: RpcTarget | Function | JsonRecord; invoke?: CapInvoke; meta?: CapMeta }): Promise<{ name: string; ok: true }>;
+  /** Remove a capability registration from this context. */
+  revoke(input: { name: string }): Promise<{ name: string; ok: true }>;
+  /** The merged chain view; same data \`itx.describe()\` embeds. */
+  describe(): Promise<CapDescription[]>;
+  /**
+   * A signed, expiring URL for one HTTP-exposed cap. Possession grants exactly
+   * that cap's fetch surface until expiry.
+   */
+  shareUrl(input: { name: string; path?: string; ttlSeconds?: number }): Promise<string>;
+}
+
+/** An event as read back from a stream. */
+interface StreamEvent {
+  type: string;
+  payload?: unknown;
+  /** 1-based durable offset; the resume cursor. */
+  offset: number;
+}
+
+/** An event as appended. */
+interface StreamEventInput {
+  type: string;
+  payload?: unknown;
+  /** Appends with the same key are dropped instead of duplicated. */
+  idempotencyKey?: string;
+}
+
+/** The public state of one stream. */
+interface StreamState {
+  namespace: string;
+  path: string;
+  eventCount: number;
+  childPaths: string[];
+  metadata: Record<string, unknown>;
+}
+
+/** How a stream is addressed: relative to this handle or as \`namespace:/path\`. */
+type StreamRef = string | { namespace?: string; path: string };
+
+/** A handle pinned to one stream. */
+interface ItxStream {
+  /** Return the stream namespace and path this handle is pinned to. */
+  describe(): { namespace: string; path: string };
+  /** Append one event and return the stored event, including its durable offset. */
+  append(event: StreamEventInput): Promise<StreamEvent>;
+  /** Append multiple events in one batch. */
+  appendBatch(events: StreamEventInput[]): Promise<StreamEvent[]>;
+  /** Read events from a durable offset window. */
+  read(input?: { afterOffset?: number | "start" | "end"; beforeOffset?: number | "start" | "end" }): Promise<StreamEvent[]>;
+  /** Read the stream's current state. */
+  getState(): Promise<StreamState>;
+  /** List child stream paths under this stream. */
+  listChildren(): Promise<unknown>;
+  /**
+   * The reactive primitive: catch up from \`afterOffset\`, then receive every
+   * committed batch until unsubscribed. Each batch carries current state.
+   */
+  subscribe(
+    onEventBatch: (batch: { events: StreamEvent[]; state: StreamState; streamMaxOffset: number }) => unknown,
+    opts: { afterOffset: number | "start" | "end"; events?: boolean },
+  ): Promise<{ unsubscribe(): void }>;
+  /** Sugar for state-only subscription from the end of the stream. */
+  onStateChange(onState: (state: StreamState) => unknown): Promise<{ unsubscribe(): void }>;
+}
+
+/** The streams collection, namespace-bound by the handle. */
+interface ItxStreams {
+  /** Resolve a stream ref, either relative to this handle or absolute. */
+  get(ref: StreamRef): ItxStream;
+  /** Create a stream path in this handle's namespace. */
+  create(input: { streamPath: string }): Promise<unknown>;
+}
+
+interface ItxWorkspaceGit {
+  /** Stage files in the project workspace. */
+  add(input: JsonRecord): Promise<unknown>;
+  /** Clone a repository into the project workspace. */
+  clone(input: JsonRecord): Promise<unknown>;
+  /** Commit staged workspace changes. */
+  commit(input: JsonRecord): Promise<unknown>;
+  /** Push workspace commits to the remote repository. */
+  push(input: JsonRecord): Promise<unknown>;
+  /** Read git status for the project workspace. */
+  status(input: JsonRecord): Promise<unknown>;
+}
+
+/** The project's workspace filesystem and git surface. */
+interface ItxWorkspace {
+  readonly git: ItxWorkspaceGit;
+  /** Read a file from the project workspace. */
+  readFile(path: string): Promise<string>;
+  /** Write a file in the project workspace. */
+  writeFile(path: string, content: string): Promise<unknown>;
+}
+
+/** The Project Durable Object surface exposed as cap #0. */
+interface ItxProjectAdmin {
+  /** Call a public function exported by the project's config worker. */
+  callConfigWorkerFunction(input: { args?: unknown[]; path: string[] }): Promise<unknown>;
+  /** Return the project summary and ingress URL. */
+  describe(): Promise<ProjectSummary & { ingressUrl: string }>;
+  /** Fetch through the project's egress path. */
+  egressFetch(request: Request): Promise<Response>;
+  /** Fetch through the project's ingress handler. */
+  fetch(request: Request): Promise<Response>;
+  /** Return the project's public ingress URL. */
+  ingressUrl(): Promise<string>;
+}
+
+/** What \`itx.describe()\` returns: context, principal, caps, and project breadcrumbs. */
+interface ItxDescription {
+  /** "global", a project id, or a ctx_* child context id. */
+  context: string;
+  /** Who this handle was minted for. */
+  principal?: unknown;
+  /** Attribution: which capability's isolate holds this handle, if any. */
+  cap?: string;
+  /** The merged capability chain, including provider-supplied instructions. */
+  caps: CapDescription[];
+  /** The bound project's own description, if this handle has one. */
+  project: unknown | null;
+}
+
+/**
+ * Declaration-merge point for caps you expect to exist, so they complete and
+ * type-check. Runtime truth is always \`itx.describe()\`.
+ */
+interface KnownCaps {}
+
+/**
+ * The built-in surface of every handle. Everything else you see on an \`itx\`
+ * is a capability that fell through to the registry.
+ */
+interface ItxBuiltins {
+  /** Register, revoke, inspect, and share capabilities on this context. */
+  readonly caps: ItxCaps;
+  /**
+   * Event streams. The handle picks the default namespace: the project id on
+   * a project handle, or "global" on an admin global handle.
+   */
+  readonly streams: ItxStreams;
+  /**
+   * Narrow to a project. The access check returns a new project-scoped handle;
+   * there is no separate project object.
+   */
+  readonly projects: ItxProjects;
+  /** The project's git repos capability. */
+  readonly repos: CapSurface;
+  /** The project's workspace: file reads/writes and git operations. */
+  readonly workspace: ItxWorkspace;
+  /** The project worker. Public methods/getters are reachable at any depth. */
+  readonly worker: CapSurface;
+  /** The Project Durable Object stub, whole surface, exposed as cap #0. */
+  readonly project: ItxProjectAdmin;
+  /**
+   * Explicit project egress. Secret placeholders are substituted inside the
+   * project's egress hop, so browser and capability code never sees secrets.
+   */
+  fetch(input: Request | string, init?: RequestInit): Promise<Response>;
+  /**
+   * Who/what am I holding? Returns the context, principal, and merged
+   * capability chain with provider-supplied instructions. When in doubt,
+   * describe.
+   */
+  describe(): Promise<ItxDescription>;
+  /**
+   * Explicit form of the fallthrough: \`itx.cap("slack")\` is equivalent to
+   * \`itx.slack\`. Useful when the name is computed or shadowed by a built-in.
+   */
+  cap(name: string): CapSurface;
+  /**
+   * Create a child context under this one: a disposable agent session or REPL
+   * scratchpad. Child caps shadow this context's; misses delegate upward.
+   */
+  fork(opts?: { name?: string }): Promise<Itx>;
+}
+
+/**
+ * A live handle on a context. Unknown property names fall through to the
+ * capability registry at runtime.
+ */
+type Itx = ItxBuiltins & KnownCaps & Record<string, CapSurface>;
+
+/** The connected Iterate context handle for this REPL session. */
+declare const itx: Itx;
+/** Environment-style values injected into this REPL session. */
+declare const env: JsonRecord;
+/** The last successful REPL result. */
+declare let $_: unknown;
+/** Alias for the last successful REPL result. */
+declare let _: unknown;
+`;

--- a/apps/os/src/components/itx-repl-typescript.worker.ts
+++ b/apps/os/src/components/itx-repl-typescript.worker.ts
@@ -6,6 +6,8 @@ import {
 import { createWorker } from "@valtown/codemirror-ts/worker";
 import * as Comlink from "comlink";
 import ts from "typescript";
+import { getAutocompletionWithDocs } from "./itx-repl-autocomplete-worker.ts";
+import { itxReplDeclaration } from "./itx-repl-types.ts";
 
 const REPL_SOURCE_PATH = "/repl.ts";
 const REPL_TYPES_PATH = "/iterate-repl-globals.d.ts";
@@ -21,133 +23,24 @@ const compilerOptions: ts.CompilerOptions = {
   target: ts.ScriptTarget.ES2022,
 };
 
-// Ambient declarations for REPL autocomplete. This is the itx surface as the
-// editor sees it — keep in sync with src/itx/handle.ts (the runtime truth).
-const itxDeclaration = `
-declare class RpcTarget {}
+const worker = createWorker(async () => {
+  const fsMap = await createDefaultMapFromCDN(compilerOptions, ts.version, false, ts);
+  fsMap.set(REPL_TYPES_PATH, itxReplDeclaration);
+  fsMap.set(REPL_SOURCE_PATH, "\n");
+  const system = createSystem(fsMap);
+  return createVirtualTypeScriptEnvironment(
+    system,
+    [REPL_TYPES_PATH, REPL_SOURCE_PATH],
+    ts,
+    compilerOptions,
+  );
+});
 
-type JsonRecord = Record<string, unknown>;
-
-/** Anything not declared here resolves through the capability fallthrough. */
-type CapSurface = {
-  (...args: any[]): Promise<unknown>;
-  [segment: string]: CapSurface;
-};
-
-interface ProjectSummary {
-  id: string;
-  slug: string;
-}
-
-interface ItxProjects {
-  create(input: { id?: string; slug: string }): Promise<ProjectSummary>;
-  get(projectIdOrSlug: string): Promise<Itx>;
-  list(input?: { limit?: number; offset?: number }): Promise<{ projects: ProjectSummary[]; total: number }>;
-  remove(input: { id: string }): Promise<{ ok: true; id: string; deleted: boolean }>;
-}
-
-interface CapDescription {
-  name: string;
-  kind: "live" | "rpc" | "url";
-  invoke: "members" | "path-call";
-  owner: string;
-  connected?: boolean;
-}
-
-interface CapSource {
-  cacheKey: string;
-  mainModule: string;
-  modules: Record<string, string>;
-  entrypoint?: string;
-  exportType?: "worker-entrypoint" | "durable-object";
-}
-
-type CapTarget =
-  | {
-      type: "rpc";
-      worker:
-        | { type: "binding"; binding: string }
-        | { type: "loopback" }
-        | { type: "source"; source: CapSource };
-      entrypoint?: string;
-      props?: JsonRecord;
-    }
-  | { type: "url"; url: string; headers?: Record<string, string> };
-
-interface ItxCaps {
-  provide(input: { name: string; target: RpcTarget | Function | JsonRecord; invoke?: "members" | "path-call" }): Promise<{ name: string; ok: true }>;
-  define(input: { name: string; target: CapTarget; invoke?: "members" | "path-call"; meta?: JsonRecord }): Promise<{ name: string; ok: true }>;
-  revoke(input: { name: string }): Promise<{ name: string; ok: true }>;
-  describe(): Promise<CapDescription[]>;
-}
-
-interface ItxStream {
-  append(event: JsonRecord): Promise<{ offset: number } & JsonRecord>;
-  appendBatch(events: JsonRecord[]): Promise<unknown>;
-  describe(): { namespace: string; path: string };
-  getState(): Promise<unknown>;
-  listChildren(): Promise<unknown>;
-  read(input?: JsonRecord): Promise<Array<{ type: string; payload: JsonRecord } & JsonRecord>>;
-}
-
-interface ItxStreams {
-  create(input: { streamPath: string }): Promise<unknown>;
-  get(path: string): ItxStream;
-}
-
-interface ItxWorkspaceGit {
-  add(input: JsonRecord): Promise<unknown>;
-  clone(input: JsonRecord): Promise<unknown>;
-  commit(input: JsonRecord): Promise<unknown>;
-  push(input: JsonRecord): Promise<unknown>;
-  status(input: JsonRecord): Promise<unknown>;
-}
-
-interface ItxWorkspace {
-  readonly git: ItxWorkspaceGit;
-  readFile(path: string): Promise<string>;
-  writeFile(path: string, content: string): Promise<unknown>;
-}
-
-interface ItxProjectAdmin {
-  callConfigWorkerFunction(input: { args?: unknown[]; path: string[] }): Promise<unknown>;
-  describe(): Promise<ProjectSummary & { ingressUrl: string }>;
-  egressFetch(request: Request): Promise<Response>;
-  fetch(request: Request): Promise<Response>;
-  ingressUrl(): Promise<string>;
-}
-
-interface Itx {
-  readonly caps: ItxCaps;
-  readonly project: ItxProjectAdmin;
-  readonly projects: ItxProjects;
-  readonly repos: CapSurface;
-  readonly streams: ItxStreams;
-  readonly worker: CapSurface;
-  readonly workspace: ItxWorkspace;
-  describe(): Promise<JsonRecord>;
-  fetch(input: string | Request, init?: RequestInit): Promise<Response>;
-  /** Capabilities by name: itx.slack.chat.postMessage(...), itx.todo.add(...) */
-  [capName: string]: CapSurface;
-}
-
-declare const itx: Itx;
-declare const env: JsonRecord;
-declare let $_: unknown;
-declare let _: unknown;
-`;
-
-Comlink.expose(
-  createWorker(async () => {
-    const fsMap = await createDefaultMapFromCDN(compilerOptions, ts.version, false, ts);
-    fsMap.set(REPL_TYPES_PATH, itxDeclaration);
-    fsMap.set(REPL_SOURCE_PATH, "\n");
-    const system = createSystem(fsMap);
-    return createVirtualTypeScriptEnvironment(
-      system,
-      [REPL_TYPES_PATH, REPL_SOURCE_PATH],
-      ts,
-      compilerOptions,
-    );
-  }),
-);
+Comlink.expose({
+  ...worker,
+  getAutocompletionWithDocs(input: Omit<Parameters<typeof getAutocompletionWithDocs>[0], "env">) {
+    const env = worker.getEnv();
+    if (!env) return null;
+    return getAutocompletionWithDocs({ ...input, env });
+  },
+});

--- a/apps/os/src/components/itx-repl.tsx
+++ b/apps/os/src/components/itx-repl.tsx
@@ -21,6 +21,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@iterate-com/ui/components/sheet";
+import { itxReplAutocompleteWorker } from "./itx-repl-autocomplete.ts";
 import type { BrowserReplEntry, BrowserReplExample } from "~/itx/browser-repl.ts";
 
 const REPL_SOURCE_PATH = "/repl.ts";
@@ -224,7 +225,7 @@ function useReplTypeScriptExtensions(input: { code: string; path: string }) {
         return;
       }
 
-      const { tsAutocompleteWorker, tsFacetWorker, tsHoverWorker, tsLinterWorker, tsSyncWorker } =
+      const { tsFacetWorker, tsHoverWorker, tsLinterWorker, tsSyncWorker } =
         typeScriptExtensionsModule;
 
       setExtensions([
@@ -234,7 +235,7 @@ function useReplTypeScriptExtensions(input: { code: string; path: string }) {
         autocompleteModule.autocompletion({
           activateOnTyping: true,
           activateOnTypingDelay: 0,
-          override: [tsAutocompleteWorker()],
+          override: [itxReplAutocompleteWorker(tsFacetWorker)],
         }),
         tsHoverWorker(),
       ]);


### PR DESCRIPTION
## What changed

- Moved the REPL ambient itx declaration into a shared module with JSDoc on the built-in itx surface and common nested types.
- Kept the existing @valtown/codemirror-ts extension stack, but replaced only the autocomplete source with a thin CodeMirror CompletionSource that asks the worker for TypeScript completion details and returns native Completion.info docstrings.
- Added tests that exercise CodeMirror completion info and the worker-backed completion source.

## Why

The REPL previously had TypeScript types for itx completions, but the autocomplete list did not surface the docstrings. The stock @valtown/codemirror-ts autocomplete source maps TypeScript entries down to label/type/boost, so this adds the missing CodeMirror-native info field without a custom renderer.

## Validation

- pnpm --dir apps/os exec vitest run src/components/itx-repl-types.test.ts src/itx/browser-repl.test.ts
- pnpm --dir apps/os exec tsc --noEmit --pretty false
- pnpm exec oxlint apps/os/src/components/itx-repl.tsx apps/os/src/components/itx-repl-types.ts apps/os/src/components/itx-repl-types.test.ts apps/os/src/components/itx-repl-typescript.worker.ts apps/os/src/components/itx-repl-autocomplete.ts apps/os/src/components/itx-repl-autocomplete-worker.ts --deny-warnings

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T21:08:38.216Z",
      "headSha": "3167ee8339ff47abff7c5e8e850f55d1bde7093d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27305966910",
      "shortSha": "3167ee8"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `3167ee8`
Preview: https://os.iterate-preview-7.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27305966910)
Updated: 2026-06-10T21:08:38.216Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor-only REPL autocomplete and ambient typings; no runtime itx behavior, auth, or data paths change.
> 
> **Overview**
> The itx browser REPL now shows **JSDoc in autocomplete** (CodeMirror `info`), not just labels and types. The stock `@valtown/codemirror-ts` autocomplete path drops documentation, so this PR adds a thin replacement.
> 
> **Shared `itx` ambient types** live in `itx-repl-types.ts` (`itxReplDeclaration`), with richer JSDoc and a broader declared surface than the old inline worker string. The TypeScript worker loads that module instead of embedding declarations.
> 
> **Worker-backed completions with docs:** `getAutocompletionWithDocs` runs the usual worker autocomplete, then calls `getCompletionEntryDetails` per option and maps TypeScript documentation into `option.info`. The worker exposes this via Comlink as `getAutocompletionWithDocs`; `itxReplAutocompleteWorker` is the CodeMirror `CompletionSource` that calls it. `itx-repl.tsx` swaps `tsAutocompleteWorker()` for that source while keeping sync, lint, and hover on the valtown stack.
> 
> **Tests** assert JSDoc appears on `itx.` / `itx.caps.` completions and that the completion source delegates to the worker with the right path and position.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3167ee8339ff47abff7c5e8e850f55d1bde7093d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->