### PR TITLE
agent: recover triggering inputs skipped by the side-effect anchor

### DIFF
--- a/apps/os/e2e/vitest/agents.e2e.test.ts
+++ b/apps/os/e2e/vitest/agents.e2e.test.ts
@@ -898,6 +898,97 @@ itIfSlackBotToken(
   180_000,
 );
 
+itIfSlackBotToken(
+  "schedules and completes an LLM request for a plain routed Slack message",
+  async () => {
+    // Regression test for the 2026-06-10 prod outage: on a freshly
+    // bootstrapped Slack thread stream, the slack-agent processor rendered
+    // the webhook into a triggering agent input before the agent processor's
+    // subscription was configured. The host anchored side effects at the
+    // subscription-configured offset, so the trigger was replayed as
+    // historical and no LLM request was ever scheduled — the agent never
+    // replied. The subscriber-connected reconciliation must recover the
+    // skipped trigger, so the LLM turn completes no matter which side wins
+    // the bootstrap race.
+    await using fixture = await createTestProjectFixture({ slugPrefix: "slack-agent-llm" });
+    const { client, project } = fixture;
+    const suffix = uniqueSuffix();
+    const slackChannelId = await requireSlackChannelId();
+    const rootText = `OS slack-agent llm trigger proof ${suffix}`;
+    const rootMessage = await postSlackMessage({
+      channel: slackChannelId,
+      text: rootText,
+      token: requireSlackToken(),
+    });
+    const routedAgentPath = slackAgentPath({
+      channel: slackChannelId,
+      threadTs: rootMessage.ts,
+    });
+
+    await client.project.streams.append({
+      projectSlugOrId: project.id,
+      streamPath: "/integrations/slack",
+      event: slackProcessorSubscriptionEvent({ projectId: project.id, suffix }),
+    });
+
+    await client.project.streams.append({
+      projectSlugOrId: project.id,
+      streamPath: "/integrations/slack",
+      event: {
+        type: "events.iterate.com/slack/webhook-received",
+        idempotencyKey: `slack-agent-e2e-llm-webhook:${suffix}`,
+        payload: {
+          slackTeamId: "T_E2E",
+          body: {
+            type: "event_callback",
+            team_id: "T_E2E",
+            event_id: `EvLlm${suffix}`,
+            event: {
+              type: "message",
+              channel: slackChannelId,
+              channel_type: "channel",
+              user: "U_E2E",
+              ts: rootMessage.ts,
+              event_ts: rootMessage.ts,
+              text: `please acknowledge: ${rootText}`,
+            },
+          },
+        },
+      },
+    });
+
+    const events = await readUntil({
+      agentPath: routedAgentPath,
+      client,
+      projectId: project.id,
+      afterOffset: "start",
+      predicate: (event) =>
+        event.type === "events.iterate.com/agent/llm-request-completed" &&
+        (event.payload as { result?: { status?: unknown } }).result?.status === "success",
+      timeoutMs: 150_000,
+    });
+
+    // The durable handoff chain the regression silently dropped: trigger →
+    // scheduled (keyed off the triggering input, so live path and recovery
+    // converge) → requested → completed.
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "events.iterate.com/agent/llm-request-scheduled",
+        idempotencyKey: expect.stringMatching(/^agent\/llm-request-scheduled@\d+$/),
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "events.iterate.com/agent/llm-request-requested",
+      }),
+    );
+    expect(
+      events.filter((event) => event.type === "events.iterate.com/stream/error-occurred"),
+    ).toEqual([]);
+  },
+  180_000,
+);
+
 async function requireSlackChannelId() {
   const channels = await listSlackChannels(requireSlackToken());
   const channel = channels.find(

--- a/apps/os/src/domains/agents/stream-processors/agent/contract.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/contract.ts
@@ -69,6 +69,19 @@ export const AgentProcessorContract = defineProcessorContract({
       .nullable()
       .default(null),
     pendingTriggerCount: z.number().int().nonnegative().default(0),
+    /**
+     * Offset of the latest model-visible input that asked for an LLM request
+     * but is not yet covered by a durable request fact. Set by a triggering
+     * `input-added`, cleared by `llm-request-scheduled` / `llm-request-requested`
+     * / `llm-request-queued`. In live operation the window between set and
+     * clear is brief; if it survives in reduced state it means the input's
+     * scheduling side effect never ran — e.g. the input landed at or below the
+     * host's side-effect anchor because it was appended before this processor's
+     * subscription was configured — and the `subscriber-connected`
+     * reconciliation owes the stream a schedule for it. Optional so checkpoints
+     * written before this field existed still parse.
+     */
+    pendingTriggerOffset: z.number().int().positive().nullable().default(null),
   }),
   initialState: {},
   // The core contract owns `stream/subscriber-connected`, the scheduler's
@@ -273,6 +286,9 @@ export function reduceAgentEvent(args: { state: AgentState; event: AgentConsumed
       return {
         ...state,
         history: [...state.history, { role: "user" as const, content: event.payload.content }],
+        ...(event.payload.llmRequestPolicy.behaviour === "dont-trigger-request"
+          ? {}
+          : { pendingTriggerOffset: event.offset }),
       };
     case "events.iterate.com/agent/output-added":
       if (
@@ -297,11 +313,13 @@ export function reduceAgentEvent(args: { state: AgentState; event: AgentConsumed
           scheduledOffset: event.offset,
         },
         pendingTriggerCount: 0,
+        pendingTriggerOffset: null,
       };
     case "events.iterate.com/agent/llm-request-requested":
       return {
         ...state,
         currentRequest: { phase: "requested" as const, llmRequestId: event.offset },
+        pendingTriggerOffset: null,
       };
     case "events.iterate.com/agent/llm-request-completed":
       return state.currentRequest?.phase === "requested" &&
@@ -328,6 +346,7 @@ export function reduceAgentEvent(args: { state: AgentState; event: AgentConsumed
       return {
         ...state,
         pendingTriggerCount: state.pendingTriggerCount + 1,
+        pendingTriggerOffset: null,
       };
     // Consumed for side effects only; no state change.
     case "events.iterate.com/agent/status-updated":

--- a/apps/os/src/domains/agents/stream-processors/agent/implementation.test.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/implementation.test.ts
@@ -369,6 +369,116 @@ describe("AgentProcessor", () => {
     expect(appended).toEqual([]);
   });
 
+  it("recovers a triggering input whose scheduling side effect was skipped by the side-effect anchor", async () => {
+    // Production regression (2026-06-10): on a freshly bootstrapped Slack
+    // thread stream, the slack-agent processor rendered the webhook into a
+    // triggering input-added before this processor's subscription was
+    // configured. The host anchored side effects at the subscription-configured
+    // offset, so the input was reduced as historical and no llm-request was
+    // ever scheduled — the agent never replied. The subscriber-connected fact
+    // (always above the anchor) must recover the skipped trigger.
+    const { stream, appended } = memoryStream();
+    const processor = newAgentProcessor({ stream, sideEffectsAfterOffset: 15 });
+
+    await processor.ingest({
+      events: [
+        agentEvent({
+          type: "events.iterate.com/agent/input-added",
+          payload: { content: "<@bot> yo" },
+          offset: 9,
+        }),
+        subscriberConnectedEvent({ offset: 25 }),
+      ],
+      streamMaxOffset: 25,
+    });
+
+    expect(appended).toEqual([
+      expect.objectContaining({
+        type: "events.iterate.com/agent/llm-request-scheduled",
+        // Keyed off the trigger input, identical to the live path's key, so a
+        // raced live append dedups in the stream instead of double-scheduling.
+        idempotencyKey: "agent/llm-request-scheduled@9",
+      }),
+    ]);
+  });
+
+  it("does not recover a non-triggering input below the side-effect anchor", async () => {
+    const { stream, appended } = memoryStream();
+    const processor = newAgentProcessor({ stream, sideEffectsAfterOffset: 15 });
+
+    await processor.ingest({
+      events: [
+        agentEvent({
+          type: "events.iterate.com/agent/input-added",
+          payload: {
+            content: "context row",
+            llmRequestPolicy: { behaviour: "dont-trigger-request" },
+          },
+          offset: 9,
+        }),
+        subscriberConnectedEvent({ offset: 25 }),
+      ],
+      streamMaxOffset: 25,
+    });
+
+    expect(appended).toEqual([]);
+  });
+
+  it("queues an anchor-skipped trigger when a request is already in flight", async () => {
+    const { stream, appended } = memoryStream();
+    const processor = newAgentProcessor({
+      stream,
+      sideEffectsAfterOffset: 20,
+      snapshot: {
+        offset: 12,
+        state: {
+          ...initialState(),
+          currentRequest: { phase: "requested", llmRequestId: 12 },
+        },
+      },
+    });
+
+    await processor.ingest({
+      events: [
+        agentEvent({
+          type: "events.iterate.com/agent/input-added",
+          payload: { content: "follow up" },
+          offset: 18,
+        }),
+        subscriberConnectedEvent({ offset: 25 }),
+      ],
+      streamMaxOffset: 25,
+    });
+
+    expect(appended).toEqual([
+      expect.objectContaining({
+        type: "events.iterate.com/agent/llm-request-queued",
+        idempotencyKey: "agent/llm-request-queued@18",
+      }),
+    ]);
+  });
+
+  it("leaves live triggers to the input-added handler instead of double-scheduling on subscriber-connected", async () => {
+    const { stream, appended } = memoryStream();
+    const processor = newAgentProcessor({ stream });
+
+    await processor.ingest({
+      events: [
+        agentEvent({
+          type: "events.iterate.com/agent/input-added",
+          payload: { content: "hello" },
+          offset: 42,
+        }),
+        subscriberConnectedEvent({ offset: 43 }),
+      ],
+      streamMaxOffset: 43,
+    });
+
+    expect(
+      appended.filter((event) => event.type === "events.iterate.com/agent/llm-request-scheduled"),
+    ).toHaveLength(1);
+  });
+
   it("re-arms the debounce from durable state when input arrives after a restart", async () => {
     vi.useFakeTimers();
     const { stream, appended } = memoryStream();
@@ -598,11 +708,15 @@ function newAgentProcessor(args: {
   stream: StreamProcessorIterateContext["stream"];
   snapshot?: StreamProcessorSnapshot<AgentState>;
   readStreamEvents?: () => Promise<StreamEvent[]>;
+  sideEffectsAfterOffset?: number;
 }) {
   return new AgentProcessor({
     iterateContext: { stream: args.stream },
     readState: () => args.snapshot,
     readStreamEvents: args.readStreamEvents ?? (async () => []),
+    ...(args.sideEffectsAfterOffset === undefined
+      ? {}
+      : { sideEffectsAfterOffset: () => args.sideEffectsAfterOffset! }),
   });
 }
 

--- a/apps/os/src/domains/agents/stream-processors/agent/implementation.test.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/implementation.test.ts
@@ -387,19 +387,77 @@ describe("AgentProcessor", () => {
           payload: { content: "<@bot> yo" },
           offset: 9,
         }),
+        // The host announces every co-hosted processor, so several
+        // subscriber-connected facts land in quick succession (offsets 24-27
+        // in the prod stream). Each may race a recovery append; the shared
+        // idempotency key is what collapses them to one durable schedule.
+        subscriberConnectedEvent({ offset: 24 }),
         subscriberConnectedEvent({ offset: 25 }),
       ],
       streamMaxOffset: 25,
     });
 
-    expect(appended).toEqual([
+    const scheduled = appended.filter(
+      (event) => event.type === "events.iterate.com/agent/llm-request-scheduled",
+    );
+    expect(scheduled.length).toBeGreaterThanOrEqual(1);
+    for (const event of scheduled) {
+      // Keyed off the trigger input, identical to the live path's key, so
+      // raced duplicates dedup in the stream instead of double-scheduling.
+      expect(event.idempotencyKey).toBe("agent/llm-request-scheduled@9");
+    }
+    expect(appended.filter((event) => !scheduled.includes(event))).toEqual([]);
+  });
+
+  it("arms the recovery debounce with the committed requestId when the scheduled append dedups", async () => {
+    vi.useFakeTimers();
+    // A raced duplicate (another recovery or the live path) already committed
+    // the schedule under the shared idempotency key, so this append returns
+    // the existing event with a requestId this instance did not generate. The
+    // timer must adopt the committed requestId — the handoff re-reads durable
+    // history and bails on a mismatch, which would wedge the turn.
+    const triggerInput = agentEvent({
+      type: "events.iterate.com/agent/input-added",
+      payload: { content: "<@bot> yo", llmRequestPolicy: { behaviour: "after-current-request" } },
+      offset: 9,
+    });
+    const committedScheduled = agentEvent({
+      type: "events.iterate.com/agent/llm-request-scheduled",
+      payload: { requestId: "req_committed_elsewhere", debounceMs: 1000, model: "test-model" },
+      offset: 30,
+      idempotencyKey: "agent/llm-request-scheduled@9",
+    });
+    const appended: StreamEventInput[] = [];
+    const stream: StreamProcessorIterateContext["stream"] = {
+      append: (args) => {
+        appended.push(args.event);
+        if (args.event.idempotencyKey === "agent/llm-request-scheduled@9") {
+          return committedScheduled;
+        }
+        return { ...args.event, offset: 99, createdAt: new Date(0).toISOString() };
+      },
+      appendBatch: () => {
+        throw new Error("unused");
+      },
+    };
+    const processor = newAgentProcessor({
+      stream,
+      sideEffectsAfterOffset: 15,
+      readStreamEvents: async () => [triggerInput, committedScheduled],
+    });
+
+    await processor.ingest({
+      events: [triggerInput, subscriberConnectedEvent({ offset: 31 })],
+      streamMaxOffset: 31,
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(appended).toContainEqual(
       expect.objectContaining({
-        type: "events.iterate.com/agent/llm-request-scheduled",
-        // Keyed off the trigger input, identical to the live path's key, so a
-        // raced live append dedups in the stream instead of double-scheduling.
-        idempotencyKey: "agent/llm-request-scheduled@9",
+        type: "events.iterate.com/agent/llm-request-requested",
+        idempotencyKey: "agent/llm-request-requested@30",
       }),
-    ]);
+    );
   });
 
   it("does not recover a non-triggering input below the side-effect anchor", async () => {

--- a/apps/os/src/domains/agents/stream-processors/agent/implementation.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/implementation.ts
@@ -344,8 +344,16 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
         },
       },
     })) as StreamEvent;
+    // The append dedups on the idempotency key, so the committed payload may
+    // carry a different requestId than this call generated (a raced duplicate
+    // schedule, or a batch retry re-running this side effect). The timer must
+    // track the durable requestId — the handoff re-reads committed history and
+    // bails on a mismatch, which would wedge the schedule until the next
+    // subscriber-connected recovery.
+    const committedRequestId =
+      (scheduledEvent.payload as { requestId?: string }).requestId ?? requestId;
     this.#armLlmRequestDebounceTimer({
-      requestId,
+      requestId: committedRequestId,
       debounceMs,
       scheduledEvent,
     });

--- a/apps/os/src/domains/agents/stream-processors/agent/implementation.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/implementation.ts
@@ -95,18 +95,53 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
         // fire it — convert the schedule into a request now. The handoff is
         // keyed off the original scheduled event, so if the dead timer's
         // append did land, this dedups instead of double-requesting.
-        if (state.currentRequest?.phase !== "scheduled" || this.#scheduledLlmRequest !== null) {
+        if (state.currentRequest?.phase === "scheduled" && this.#scheduledLlmRequest === null) {
+          const scheduled = state.currentRequest;
+          args.blockProcessorWhile(() =>
+            this.#requestLlmWorkForSchedule({
+              requestId: scheduled.requestId,
+              ...(scheduled.scheduledOffset === undefined
+                ? {}
+                : { scheduledEvent: { offset: scheduled.scheduledOffset } }),
+            }),
+          );
           return;
         }
-        const scheduled = state.currentRequest;
-        args.blockProcessorWhile(() =>
-          this.#requestLlmWorkForSchedule({
-            requestId: scheduled.requestId,
-            ...(scheduled.scheduledOffset === undefined
-              ? {}
-              : { scheduledEvent: { offset: scheduled.scheduledOffset } }),
-          }),
-        );
+        // Anchor-skip recovery. A triggering input below the side-effect
+        // anchor was reduced into state but its scheduling side effect never
+        // ran — this happens when the input is appended before this
+        // processor's subscription is configured (e.g. a Slack webhook racing
+        // the agent's bootstrap on a freshly created thread stream). The
+        // anchor gate keeps this recovery off the live path: triggers above
+        // the anchor are owned by the `input-added` handler, and a request
+        // fact that already covers the trigger clears `pendingTriggerOffset`
+        // in the reducer before this event is processed. Appends are keyed
+        // off the trigger event, exactly like the live path, so a raced
+        // duplicate dedups in the stream.
+        if (
+          state.pendingTriggerOffset === null ||
+          state.pendingTriggerOffset > args.sideEffectsAfterOffset
+        ) {
+          return;
+        }
+        const triggerEvent = { offset: state.pendingTriggerOffset };
+        if (state.currentRequest === null) {
+          if (this.#scheduledLlmRequest !== null) return;
+          args.blockProcessorWhile(() =>
+            this.#appendLlmRequestScheduled({ sourceEvent: triggerEvent, state }),
+          );
+          return;
+        }
+        // A request is in flight: record the skipped trigger as a durable
+        // queued fact, the same shape the live path appends, so the terminal
+        // request event schedules the follow-up turn. Recovery never
+        // interrupts in-flight work — even an interrupt-policy input degrades
+        // to after-current-request here. The scheduled phase needs no queued
+        // fact: its handoff rebuilds the request body from full committed
+        // history, which already includes the skipped trigger.
+        if (state.currentRequest.phase === "requested") {
+          args.blockProcessorWhile(() => this.#emitQueued({ sourceEvent: triggerEvent }));
+        }
         return;
       }
       case "events.iterate.com/agent/capability-noted":

--- a/packages/streams/src/processors/core/implementation.ts
+++ b/packages/streams/src/processors/core/implementation.ts
@@ -119,6 +119,8 @@ export class CoreStreamProcessor extends StreamProcessor<CoreProcessorContract, 
       state: args.state,
       checkpointOffset: args.event.offset,
       streamMaxOffset: args.event.offset,
+      // Inline appends are always live, never historical replay.
+      sideEffectsAfterOffset: 0,
       blockProcessorWhile: () => {
         throw new Error(
           "blockProcessorWhile is unavailable when processing a reduced event inline",

--- a/packages/streams/src/stream-processor.ts
+++ b/packages/streams/src/stream-processor.ts
@@ -88,6 +88,15 @@ type ProcessEventArgs<Contract> = ReducedEvent<Contract> &
      * completes — the last event offset in the batch, not this event's offset.
      */
     checkpointOffset: number;
+    /**
+     * The side-effect anchor (see `StreamProcessorBaseDeps`). The default
+     * `processEventBatch` already skips `processEvent` for events at or below
+     * it; it is surfaced here so live handlers (e.g. reconciliation on
+     * `subscriber-connected`) can tell whether an earlier event's side effects
+     * were skipped as historical and recover the ones that are durable
+     * obligations.
+     */
+    sideEffectsAfterOffset: number;
   };
 
 type ProcessEventBatchArgs<Contract> = SideEffectHelpers & {
@@ -284,6 +293,7 @@ export abstract class StreamProcessor<
         ...reducedEvent,
         streamMaxOffset: args.streamMaxOffset,
         checkpointOffset: args.checkpointOffset,
+        sideEffectsAfterOffset: args.sideEffectsAfterOffset,
         blockProcessorWhile: args.blockProcessorWhile,
         runInBackground: args.runInBackground,
       });


### PR DESCRIPTION
## What was broken

Slack agents in prd receive messages but never reply — no LLM request is ever made. Observed live on 2026-06-10 in `iterate` project stream `/agents/slack/c08r1smtzgd/ts-1781124999-011519`:

- the slack-agent processor rendered the webhook into a triggering `agent/input-added` at **offset 9** (20:56:46.2)
- the agent processor's `subscription-configured` event landed at **offset 15** (20:56:46.7) — the AGENT DO wake hook appends it after D1 reads and workspace setup, so slack-agent reliably wins this race on a cold thread
- the host anchors side effects at the subscription-configured offset (`stream-processor-host.ts`), so the input at offset 9 was reduced as historical replay and its scheduling side effect was skipped: no `llm-request-scheduled`, no `llm-request-requested`, no `openai-ws` activity, no reply — and nothing ever retriggers it
- visible fingerprint in the stream: capability-noted renders exist only for offsets above the anchor (18–23), none for 8–9

The anchor mechanism is correct for re-attach (don't re-fire historical LLM requests), but it shipped in #1402 without anything making the *first* message of a new thread durable. Regression from #1402, same symptom as #1372 but a different mechanism. **Every first message of every new prod Slack thread is dropped.**

## The fix

Make the trigger a durable obligation in reduced state instead of a fire-and-forget side effect:

- **`AgentState.pendingTriggerOffset`** — set by a triggering `input-added`, cleared by `llm-request-scheduled` / `llm-request-requested` / `llm-request-queued`. If it survives in reduced state, the scheduling side effect never ran.
- **`subscriber-connected` reconciliation recovers it** (the presence fact always lands above the anchor, so this handler always runs live): schedule a request when idle, append the queued fact when a request is in flight (never interrupts in-flight work). Appends are keyed off the trigger event exactly like the live path (`agent/llm-request-scheduled@<offset>`), so raced duplicates dedup in the stream.
- **Gated on `pendingTriggerOffset <= sideEffectsAfterOffset`** so recovery fires only for anchor-skipped triggers and never races the live `input-added` handler. Crash/restart cases above the anchor remain owned by the existing scheduled-phase reconciliation.
- `StreamProcessor.processEvent` args now expose `sideEffectsAfterOffset` (the batch-level hook already had it); the core processor's inline path passes 0 (inline appends are always live).

The scheduled phase needs no queued fact on recovery: its handoff rebuilds the request body from full committed history, which already includes the skipped trigger.

## Verification

- Unit tests replay the prod stream shape: trigger below anchor + subscriber-connected above → exactly one `llm-request-scheduled@9`; non-triggering inputs don't recover; in-flight requests get a queued fact; live triggers aren't double-scheduled.
- New token-gated e2e (`schedules and completes an LLM request for a plain routed Slack message`) drives a real Slack root message + routed webhook through webhook → input → scheduled → requested → completed(success) against a live deployment.
- `pnpm typecheck && pnpm lint && pnpm format && pnpm test` all green.
- E2E run against the preview deployment with the real Slack bot token: results to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core agent LLM scheduling and subscriber-connected reconciliation on a production outage path; incorrect gating could double-schedule or miss triggers on every new Slack thread.
> 
> **Overview**
> Fixes **first-message silence** on new Slack thread streams when a triggering `input-added` lands **before** the agent subscription is configured: the host’s side-effect anchor replays that input into state but skips scheduling, so no LLM turn ever starts.
> 
> **Agent processor** now records **`pendingTriggerOffset`** in reduced state for triggering inputs and clears it when a durable schedule/request/queue fact exists. On **`subscriber-connected`**, when that offset is at or below the anchor, it **recovers** the missed obligation—`llm-request-scheduled` when idle (same idempotency key as the live path) or **`llm-request-queued`** when a request is already in flight—without double-scheduling live triggers above the anchor. **`#appendLlmRequestScheduled`** arms the debounce timer with the **committed** `requestId` after idempotent dedup so raced recovery paths don’t wedge the handoff.
> 
> **Streams**: `processEvent` receives **`sideEffectsAfterOffset`** so reconcilers can detect anchor-skipped side effects; the core inline path passes **`0`** (always live).
> 
> **Verification**: new unit coverage for anchor-skip recovery, deduped schedule, queue-when-busy, and no recovery for non-triggering inputs; token-gated e2e asserts routed Slack webhook → scheduled → requested → completed(success).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb3a7ac0bb17f468c1d5490f0b6951bfe612374e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T22:04:58.830Z",
      "headSha": "eb3a7ac0bb17f468c1d5490f0b6951bfe612374e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27308869802",
      "shortSha": "eb3a7ac"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `eb3a7ac`
Preview: https://os.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27308869802)
Updated: 2026-06-10T22:04:58.830Z
<!-- /CLOUDFLARE_PREVIEW -->