### PR TITLE
itx: repos/workspace/worker become platform defaults; origin-carrying delegation; durable-object refs

### DIFF
--- a/apps/os/docs/itx-next.md
+++ b/apps/os/docs/itx-next.md
@@ -80,6 +80,17 @@ worker", and collapsed into `rpc` × `WorkerRef`. The full per-kind
 docstrings live in `apps/os/src/itx/types.ts`, which is the design of
 record.)
 
+`durable-object` refs SHIPPED, config-gated: the registry resolves
+`{ type: "durable-object", binding, name }` via `env[binding].getByName(name)`
+with members/path-call dispatch like any rpc target. The namespace
+allowlist (`DIALABLE_DURABLE_OBJECTS`) is EMPTY by default — every
+platform namespace is keyed across all projects, so allowlisting one
+would let any project handle dial any other project's objects by name.
+Deployments opt namespaces in via `APP_CONFIG_ITX.dialableDurableObjects`
+once they have a namespace whose instances are safe to reach by name;
+per-project name scoping is the open design before any platform
+namespace can join the defaults.
+
 `url` refs SHIPPED: the registry hands the call as data to the `UrlDial`
 loopback entrypoint (`src/itx/caps/url-dial.ts`), which opens ONE
 WebSocket Cap'n Web session per call in the stateless worker (Law 7 —
@@ -621,10 +632,24 @@ as the first hardwired built-in to become an ordinary definition; child
 contexts inherit it through the existing per-call parent delegation, no
 extra wiring.
 
-Sequencing: repos/workspace/streams are movable today (loopback refs
-shipped); worker/project wait on the durable-object ref (worker could go
-through the ProjectWorker forwarder now); fork-with-ancestry rides with
-the codemode drop.
+The migration SHIPPED: `repos`, `workspace`, and `worker` are now
+ordinary `platform:project` definitions (ReposCapability /
+WorkspaceCapability loopbacks; the ProjectWorker forwarder with a
+members inner replay) — their handle getters, the reserved names, and
+`callWorkerFunction` are deleted. The enabling change: **chain
+delegation carries the ORIGINATING context** (`itxInvoke` gains
+`origin`; the registry injects it as the `context` attribution prop), so
+the context-SCOPED workspace still resolves per caller — a forked child
+gets `itx:ctx_…`, the project gets `itx` — even though the definition
+lives two links up. One behavioral change: `itx.worker.fetch` no longer
+special-cases to project ingress (it replays `fetch` on the worker's
+default export like any other member); use the ingress URL for the
+homepage.
+
+Still kernel, deliberately: `streams` (the access model and global-
+namespace gating live there — resolution checks access, which a cap
+definition cannot express), `caps`, `fetch` (Law 5), `fork`, `project`,
+`projects`, `describe`.
 
 Open: the splice API shape on fork; ref naming for code contexts
 (`platform:` prefix?); can a context _revoke_ (not just shadow) a code
@@ -709,6 +734,13 @@ on the hot path?
   the SecretsCapability loopback inside UrlDial, not by routing the
   handshake through the Project DO (which would put the DO in the socket's
   data path for the session's lifetime — Law 7 in spirit).
+- ~~How can a context-scoped cap (workspace) live on a parent context?~~ →
+  Chain delegation carries the ORIGINATING context: `itxInvoke({ …,
+origin })`, set by the first delegating hop, preserved upward; the
+  registry's dial-time `context` injection uses it. Without this, a
+  workspace cap inherited from platform:project would bind every child
+  context to the project's shared workspace — agent-session isolation
+  requires the origin (no-backcompat protocol change, 2026-06-10).
 - ~~Where do §8 defaults hook in?~~ → `ContextRegistryHost.defaults`: a
   `CodeContext` (name + validated cap map from `defineCodeContext`) the
   registry falls through to on lookup miss. Own rows shadow; describe()
@@ -786,7 +818,14 @@ on the hot path?
   delete once nothing dials them; `packages/shared/src/codemode/*` rename.
 - The egress intercept tunnel never sees UrlDial's WebSocket handshakes
   (it cannot carry upgrades); url-cap traffic is invisible to a connected
-  intercept session.
+  intercept session. The capnweb fork (#1474) makes WS-bearing Responses
+  cross CAPNWEB hops (the captun tunnel itself), but the UrlDial → Project
+  DO hop is Workers jsrpc, which still cannot carry one — routing url dials
+  through `egressFetch` stays blocked on that, not on the tunnel.
+- §5's REPL-consumes-types.ts is still open: the editor's ambient typings
+  (`itx-repl-types.ts`) are maintained by hand next to a "keep in sync"
+  note; deriving them from `src/itx/types.ts` is a tooling exercise nobody
+  has needed badly enough yet.
 
 ## Open questions (rolled up)
 

--- a/apps/os/src/components/itx-repl-types.ts
+++ b/apps/os/src/components/itx-repl-types.ts
@@ -239,8 +239,6 @@ interface ItxWorkspace {
 
 /** The Project Durable Object surface exposed as cap #0. */
 interface ItxProjectAdmin {
-  /** Call a public function exported by the project's worker. */
-  callWorkerFunction(input: { args?: unknown[]; path: string[] }): Promise<unknown>;
   /** Return the project summary and ingress URL. */
   describe(): Promise<ProjectSummary & { ingressUrl: string }>;
   /** Fetch through the project's egress path. */
@@ -292,11 +290,11 @@ interface ItxBuiltins {
    * there is no separate project object.
    */
   readonly projects: ItxProjects;
-  /** The project's git repos capability. */
+  /** Platform default cap (platform:project, shadowable): the project's git repos. */
   readonly repos: CapSurface;
-  /** The project's workspace: file reads/writes and git operations. */
+  /** Platform default cap (shadowable): workspace file reads/writes + flat git methods. */
   readonly workspace: ItxWorkspace;
-  /** The project worker. Public methods/getters are reachable at any depth. */
+  /** Platform default cap (shadowable): the project's iterate-config worker. */
   readonly worker: CapSurface;
   /** The Project Durable Object stub, whole surface, exposed as cap #0. */
   readonly project: ItxProjectAdmin;

--- a/apps/os/src/config.ts
+++ b/apps/os/src/config.ts
@@ -108,6 +108,7 @@ export const AppConfig = z.object({
   itx: z
     .object({
       dialableBindings: publicValue(z.array(z.string().trim().min(1)).default([])),
+      dialableDurableObjects: publicValue(z.array(z.string().trim().min(1)).default([])),
       dialableLoopbacks: publicValue(z.array(z.string().trim().min(1)).default([])),
     })
     .optional(),

--- a/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
@@ -319,8 +319,12 @@ export class ProjectDurableObject extends DurableObject<ProjectEnv> {
     return this.itxRegistry().describe();
   }
 
-  async itxInvoke(input: PathCall & { name: string }) {
-    return await this.itxRegistry().invoke(input.name, { args: input.args, path: input.path });
+  async itxInvoke(input: PathCall & { name: string; origin?: string }) {
+    return await this.itxRegistry().invoke(
+      input.name,
+      { args: input.args, path: input.path },
+      input.origin,
+    );
   }
 
   private itxRegistry(): ContextRegistry {
@@ -402,20 +406,6 @@ export class ProjectDurableObject extends DurableObject<ProjectEnv> {
     return (
       (await this.workerHost.getCachedCheckout()) ?? (await this.workerHost.buildFresh(summary))
     );
-  }
-
-  /**
-   * `itx.worker.foo(...)`: replay a path call against the worker entrypoint.
-   * The entrypoint itself can never cross an RPC boundary (workerd forbids
-   * transferring loader entrypoints), so the call replays HERE — every public
-   * method/getter on the worker's default export is reachable with no wiring.
-   * Builds fresh so tool calls always see the latest pushed config.
-   */
-  async callWorkerFunction(input: { args?: unknown[]; path: string[] }): Promise<unknown> {
-    const summary = await this.requireSummary();
-    const checkout = await this.workerHost.buildFresh(summary);
-    const entrypoint = this.workerHost.load({ checkout, projectId: summary.id });
-    return await replayPathCall(entrypoint, { args: input.args ?? [], path: input.path });
   }
 
   /**

--- a/apps/os/src/domains/projects/durable-objects/worker.ts
+++ b/apps/os/src/domains/projects/durable-objects/worker.ts
@@ -225,7 +225,7 @@ export class WorkerHost {
   /**
    * Clone, build, validate-load, and persist a fresh checkout. Builds are
    * SERIALIZED: every caller (background rebuilds, the creation step,
-   * callWorkerFunction) shares one checkout directory in the workspace, so
+   * itxProjectWorkerCall) shares one checkout directory in the workspace, so
    * overlapping clone/read cycles would corrupt each other.
    */
   buildFresh(project: WorkerProject): Promise<WorkerCheckout> {

--- a/apps/os/src/domains/workspaces/entrypoints/workspace-capability.ts
+++ b/apps/os/src/domains/workspaces/entrypoints/workspace-capability.ts
@@ -5,6 +5,7 @@ import {
   type WorkspaceDurableObject,
   type WorkspaceStructuredName,
 } from "~/domains/workspaces/durable-objects/workspace-durable-object.ts";
+import { isChildContextId } from "~/itx/protocol.ts";
 
 type WorkspaceCapabilityEnv = {
   WORKSPACE?: DurableObjectNamespace<WorkspaceDurableObject>;
@@ -12,8 +13,22 @@ type WorkspaceCapabilityEnv = {
 
 export type WorkspaceCapabilityProps = {
   projectId: string;
-  workspaceId: string;
+  /** Explicit workspace; absent means derive from `context` (see below). */
+  workspaceId?: string;
+  /** Attribution, injected by the registry at dial time — and the workspace
+   * scope: project contexts share one workspace ("itx"), child contexts each
+   * get their own (`itx:ctx_…`), so an agent session's repo clones and files
+   * are isolated per context. Chain delegation carries the ORIGINATING
+   * context, which is what makes this derivation correct for caps inherited
+   * from platform:project. */
+  context?: string;
+  cap?: string;
 };
+
+/** Project contexts share one workspace; child contexts are isolated. */
+export function itxWorkspaceId(contextId: string): string {
+  return isChildContextId(contextId) ? `itx:${contextId}` : "itx";
+}
 
 type WorkspaceRpcStub = {
   cloudflareShellGit(): Promise<Record<string, (...args: unknown[]) => Promise<unknown>>>;
@@ -75,9 +90,14 @@ export class WorkspaceCapability extends WorkerEntrypoint<
   }
 
   private workspaceName(): WorkspaceStructuredName {
+    const props = this.ctx.props;
+    const workspaceId = props.workspaceId ?? (props.context ? itxWorkspaceId(props.context) : null);
+    if (!workspaceId) {
+      throw new Error("WorkspaceCapability needs props.workspaceId or props.context.");
+    }
     return {
-      projectId: this.ctx.props.projectId,
-      workspaceId: this.ctx.props.workspaceId,
+      projectId: props.projectId,
+      workspaceId,
     };
   }
 

--- a/apps/os/src/itx/code-contexts.ts
+++ b/apps/os/src/itx/code-contexts.ts
@@ -67,10 +67,12 @@ export function defineCodeContext(
 }
 
 /**
- * The defaults every project context delegates to. Deliberately small to
- * start: `ai` is the first hardwired built-in to become an ordinary
- * capability definition (§8's "cap #0 disappears" direction — repos,
- * workspace, and streams follow as their handle accessors migrate).
+ * The defaults every project context delegates to (§8's "cap #0 disappears"
+ * direction). What was hardwired into the handle is now ordinary capability
+ * definitions: ai, repos, workspace, and the project worker. The remaining
+ * kernel — caps, streams, fetch, fork, project, projects, describe — is
+ * composition the registry cannot express (access checks, narrowing, the
+ * registry itself).
  */
 export const platformProjectContext = defineCodeContext("platform:project", (caps) => {
   caps.define({
@@ -84,6 +86,50 @@ export const platformProjectContext = defineCodeContext("platform:project", (cap
     target: {
       entrypoint: "BindingCapability",
       props: { binding: "AI" },
+      type: "rpc",
+      worker: { type: "loopback" },
+    },
+  });
+  caps.define({
+    meta: {
+      instructions:
+        "The project's git repos: itx.repos.ensureIterateConfigInfo({ projectSlug }), " +
+        "list(), create({ slug }), get({ slug }) — repo handles expose commitFiles/readFiles/readLog.",
+    },
+    name: "repos",
+    target: {
+      entrypoint: "ReposCapability",
+      type: "rpc",
+      worker: { type: "loopback" },
+    },
+  });
+  caps.define({
+    meta: {
+      instructions:
+        "A persistent workspace filesystem: itx.workspace.readFile/writeFile plus the flat " +
+        "git methods gitClone/gitAdd/gitCommit/gitPush/gitStatus. Project contexts share " +
+        "one workspace; forked child contexts each get their own.",
+    },
+    name: "workspace",
+    target: {
+      entrypoint: "WorkspaceCapability",
+      type: "rpc",
+      worker: { type: "loopback" },
+    },
+  });
+  caps.define({
+    // path-call: the cap's own invoke describes the forwarder hop; the
+    // members replay against the user's default export rides in props.
+    invoke: "path-call",
+    meta: {
+      instructions:
+        "The project's own iterate-config worker, rebuilt from the repo on every call: " +
+        "itx.worker.someExportedFunction(args) reaches any public method of its default export.",
+    },
+    name: "worker",
+    target: {
+      entrypoint: "ProjectWorker",
+      props: { invoke: "members" },
       type: "rpc",
       worker: { type: "loopback" },
     },

--- a/apps/os/src/itx/context-do.ts
+++ b/apps/os/src/itx/context-do.ts
@@ -40,7 +40,7 @@ export type ContextDescriptor = {
 /** The registry surface a context host exposes; chain calls use this shape. */
 type RegistryHostStub = {
   itxDescribe(): Promise<CapDescription[]>;
-  itxInvoke(input: PathCall & { name: string }): Promise<unknown>;
+  itxInvoke(input: PathCall & { name: string; origin?: string }): Promise<unknown>;
 };
 
 export class ContextDO extends DurableObject<Env> {
@@ -112,13 +112,22 @@ export class ContextDO extends DurableObject<Env> {
     return [...own, ...parentCaps.filter((cap) => !ownNames.has(cap.name))];
   }
 
-  async itxInvoke(input: PathCall & { name: string }): Promise<unknown> {
+  async itxInvoke(input: PathCall & { name: string; origin?: string }): Promise<unknown> {
     const registry = this.registry();
     if (registry.has(input.name)) {
-      return await registry.invoke(input.name, { args: input.args, path: input.path });
+      return await registry.invoke(
+        input.name,
+        { args: input.args, path: input.path },
+        input.origin,
+      );
     }
-    // Chain delegation: one extra hop per parent level, no cache to invalidate.
-    return await this.parentStub().itxInvoke(input);
+    // Chain delegation: one extra hop per parent level, no cache to
+    // invalidate. The ORIGIN context rides along so context-scoped caps
+    // resolved at an ancestor still bind to the caller's context.
+    return await this.parentStub().itxInvoke({
+      ...input,
+      origin: input.origin ?? this.descriptor().id,
+    });
   }
 
   private parentStub(): RegistryHostStub {

--- a/apps/os/src/itx/e2e/itx-fork.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx-fork.e2e.test.ts
@@ -74,6 +74,34 @@ test("fork: child caps shadow the parent, misses delegate up the chain", async (
   expect(reconnectedShadow.marker).toBe("child-level");
 });
 
+test("fork: the inherited workspace default is isolated per child context", async () => {
+  using itx = connectGlobal();
+  const project = (await itx.projects.create({ slug: `itx-fork-ws-${suffix()}` })) as {
+    id: string;
+  };
+  createdProjectIds.push(project.id);
+  using projectItx = await itx.projects.get(project.id);
+
+  // `workspace` is a platform:project default, but it is CONTEXT-scoped:
+  // chain delegation carries the originating context, so a child resolves
+  // its own workspace (itx:ctx_…), not the project's shared one.
+  using child = await projectItx.fork({ name: "e2e-ws" });
+  const handle = (target: unknown) => target as never as Record<string, any>;
+
+  const marker = suffix();
+  await handle(child).workspace.writeFile(`/isolation-${marker}.txt`, "child only");
+  await expect(handle(child).workspace.readFile(`/isolation-${marker}.txt`)).resolves.toBe(
+    "child only",
+  );
+
+  // The project context's workspace must NOT see the child's file…
+  await expect(handle(projectItx).workspace.readFile(`/isolation-${marker}.txt`)).rejects.toThrow();
+
+  // …and a sibling fork gets its own empty workspace too.
+  using sibling = await projectItx.fork({ name: "e2e-ws-sibling" });
+  await expect(handle(sibling).workspace.readFile(`/isolation-${marker}.txt`)).rejects.toThrow();
+});
+
 test("fork narrows access: a session cannot reach sibling projects", async () => {
   using itx = connectGlobal();
   // Two projects under an admin (access "all") handle.

--- a/apps/os/src/itx/e2e/itx.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx.e2e.test.ts
@@ -177,10 +177,22 @@ test("platform bindings are dialable capabilities (raw + wrapped)", async () => 
       target: { entrypoint: "ItxEntrypoint", type: "rpc", worker: { type: "loopback" } },
     }),
   ).rejects.toThrow(/not dialable/);
+  // Durable Object refs name arbitrary instances across ALL projects, so the
+  // namespace allowlist defaults to empty — config has to opt in.
+  await expect(
+    projectItx.caps.define({
+      name: "sneakyDo",
+      target: {
+        type: "rpc",
+        worker: { binding: "PROJECT", name: "someone-elses-project", type: "durable-object" },
+      },
+    }),
+  ).rejects.toThrow(/not dialable/);
 
-  // describe() reports the new kinds and lifts instructions.
-  const caps = await projectItx.caps.describe();
-  expect(caps).toMatchObject([
+  // describe() reports the new kinds and lifts instructions (own rows only —
+  // inherited platform defaults carry their code context as owner).
+  const caps = (await projectItx.caps.describe()) as Array<{ owner: string }>;
+  expect(caps.filter((cap) => cap.owner === project.id)).toMatchObject([
     { instructions: "Workers AI. Use like the env.AI binding.", kind: "rpc", name: "ai" },
     { invoke: "path-call", kind: "rpc", name: "aiWrapped" },
   ]);
@@ -410,6 +422,12 @@ test("platform defaults arrive from the platform:project code context, and own r
     kind: "rpc",
     owner: "platform:project",
   });
+  // The whole migrated kernel arrives the same way (§8: cap #0 disappears).
+  for (const name of ["repos", "workspace", "worker"]) {
+    expect(before.caps.find((cap) => cap.name === name)).toMatchObject({
+      owner: "platform:project",
+    });
+  }
 
   // Defaults cannot be revoked — succeeding would lie (the default keeps
   // serving). Shadowing is the override mechanism.

--- a/apps/os/src/itx/e2e/itx.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx.e2e.test.ts
@@ -743,33 +743,23 @@ test("revoked and offline caps fail with instructive errors", async () => {
     }),
   ).rejects.toThrow(/reserved/);
 
-  // itx.project IS the full Project DO surface (D17): any public method is
-  // callable, so a method added to the DO is instantly reachable here. But a
-  // hand-built reserved path through itxInvoke is still gated server-side, so
-  // the full surface can never be abused to reach prototype internals.
-  await projectItx.caps.define({
-    name: "probe",
-    target: {
-      type: "rpc",
-      worker: {
-        type: "source",
-        source: {
-          cacheKey: crypto.randomUUID(),
-          mainModule: "cap.js",
-          modules: {
-            "cap.js":
-              "import { WorkerEntrypoint } from 'cloudflare:workers'; export default class extends WorkerEntrypoint { ok() { return 1; } }",
-          },
-        },
-      },
-    },
-  });
+  // itx.project IS the full Project DO surface (D17) — except the itx*
+  // registry verbs, which are node-to-node plumbing: itxInvoke carries the
+  // trusted chain-delegation `origin`, so exposing it would let any handle
+  // holder spoof another context's identity (a sibling fork's workspace).
+  // The proxy masks them; the registry's reserved-segment gate stays as
+  // defense in depth for paths arriving over the real chain.
   const projectDo = (projectItx as { project: unknown }).project as {
-    itxInvoke(input: { args: unknown[]; name: string; path: string[] }): Promise<unknown>;
+    itxInvoke(input: {
+      args: unknown[];
+      name: string;
+      origin?: string;
+      path: string[];
+    }): Promise<unknown>;
   };
   await expect(
-    projectDo.itxInvoke({ args: [], name: "probe", path: ["constructor"] }),
-  ).rejects.toThrow(/reserved/);
+    projectDo.itxInvoke({ args: [], name: "workspace", origin: "ctx_spoofed", path: ["readFile"] }),
+  ).rejects.toThrow(/internal registry plumbing/);
 });
 
 // ---- execution modes --------------------------------------------------------

--- a/apps/os/src/itx/handle.ts
+++ b/apps/os/src/itx/handle.ts
@@ -54,7 +54,6 @@ import {
 } from "~/domains/projects/durable-objects/project-durable-object.ts";
 import { isProjectId, mintProjectId } from "~/domains/projects/project-id.ts";
 import { getStreamsCapability } from "~/domains/streams/entrypoints/streams-capability.ts";
-import { getReposCapability } from "~/domains/repos/entrypoints/repo-capability.ts";
 
 /**
  * Everything a handle needs, resolved once by the restorer
@@ -84,15 +83,6 @@ function isAccessor(target: object, prop: PropertyKey): boolean {
     if (descriptor) return descriptor.get !== undefined;
   }
   return false;
-}
-
-/**
- * Project contexts share one workspace ("itx"); child contexts each get
- * their own, derived from the context id — an agent session's repo clones
- * and files are isolated per context.
- */
-function itxWorkspaceId(contextId: string): string {
-  return isChildContextId(contextId) ? `itx:${contextId}` : "itx";
 }
 
 export class Itx extends RpcTarget {
@@ -151,57 +141,6 @@ export class Itx extends RpcTarget {
       });
     }
     return new ItxStreams(this.#runtime, GLOBAL_CONTEXT_ID);
-  }
-
-  get repos() {
-    // The repos domain entrypoint is already a clean project-scoped
-    // capability; hand it out directly rather than wrapping it.
-    return getReposCapability({
-      exports: this.#runtime.exports as unknown as Parameters<
-        typeof getReposCapability
-      >[0]["exports"],
-      props: { projectId: this.#requireProjectId() },
-    });
-  }
-
-  get workspace() {
-    // Like itx.repos: the workspace domain entrypoint already exposes the
-    // exact surface we want (readFile/writeFile and the flat
-    // gitClone/gitAdd/gitCommit/gitPush/gitStatus methods), so hand it out
-    // directly rather than re-wrapping it. workspaceId is fixed to "itx" —
-    // one workspace per project context.
-    const factory = this.#runtime.exports.WorkspaceCapability;
-    if (typeof factory !== "function") {
-      throw new Error("WorkspaceCapability export is not available.");
-    }
-    return factory({
-      props: {
-        projectId: this.#requireProjectId(),
-        workspaceId: itxWorkspaceId(this.#runtime.contextId),
-      },
-    });
-  }
-
-  /**
-   * The project's worker. The loaded worker entrypoint itself can never cross
-   * an RPC boundary (workerd forbids transferring loader entrypoints), so the
-   * path is replayed against it INSIDE the Project DO — every public
-   * method/getter is proxied automatically, at any depth:
-   * itx.worker.someTool(args), itx.worker.group.tool(args). `fetch` is the
-   * one special case: the worker's fetch is the project's homepage, served by
-   * the stateless ingress entrypoint (fetch on the PROJECT is egress).
-   */
-  get worker(): unknown {
-    const project = this.#projectStub();
-    return new PathProxyRpcTarget(async ({ path, args }) => {
-      if (path.length === 1 && path[0] === "fetch") {
-        const ingress = this.#runtime.exports.ProjectIngressEntrypoint({
-          props: { projectId: this.#requireProjectId() },
-        }) as { fetch(request: Request): Promise<Response> };
-        return await ingress.fetch(args[0] as Request);
-      }
-      return await project.callWorkerFunction({ args, path });
-    });
   }
 
   /**

--- a/apps/os/src/itx/handle.ts
+++ b/apps/os/src/itx/handle.ts
@@ -158,7 +158,22 @@ export class Itx extends RpcTarget {
    */
   get project(): ProjectStub {
     const stub = this.#projectStub();
-    return new PathProxyRpcTarget((call) => replayPathCall(stub, call)) as unknown as ProjectStub;
+    return new PathProxyRpcTarget((call) => {
+      // The itx* verbs (itxInvoke, itxDefine, itxProjectWorkerCall, …) are
+      // node-to-node plumbing: chain delegation passes a TRUSTED `origin`
+      // and the forwarder passes registry-merged props. Reachable here,
+      // they would let any handle holder spoof another context's identity
+      // (e.g. read a sibling fork's workspace by faking origin). The proper
+      // doors are itx.caps and the caps themselves.
+      const head = call.path[0] ?? "";
+      if (/^itx[A-Z]/.test(head)) {
+        throw new ItxError({
+          code: "FORBIDDEN",
+          message: `${head} is internal registry plumbing, not part of the project surface — use itx.caps / itx.<cap> instead.`,
+        });
+      }
+      return replayPathCall(stub, call);
+    }) as unknown as ProjectStub;
   }
 
   get projects(): ItxProjects {

--- a/apps/os/src/itx/protocol.ts
+++ b/apps/os/src/itx/protocol.ts
@@ -137,17 +137,31 @@ export const DIALABLE_LOOPBACKS: ReadonlySet<string> = new Set([
   "McpClient",
   "OrpcCapability",
   "ProjectWorker",
+  "ReposCapability",
   "SlackCapability",
+  "WorkspaceCapability",
 ]);
+
+/**
+ * Durable Object namespace bindings dialable via `{ type: "durable-object" }`
+ * refs. Empty on purpose: a DO ref names an arbitrary instance
+ * (`binding` + `name`), and every platform namespace (PROJECT, STREAM, …) is
+ * keyed across ALL projects — allowlisting one would let any project handle
+ * dial any other project's objects. Deployments opt namespaces in via config
+ * once they have a namespace whose instances are safe to reach by name.
+ */
+export const DIALABLE_DURABLE_OBJECTS: ReadonlySet<string> = new Set();
 
 /** The dial allowlists a host resolves once (defaults ∪ deployment config). */
 export type DialableTargets = {
   bindings: ReadonlySet<string>;
+  durableObjects: ReadonlySet<string>;
   loopbacks: ReadonlySet<string>;
 };
 
 export const DEFAULT_DIALABLE_TARGETS: DialableTargets = {
   bindings: DIALABLE_BINDINGS,
+  durableObjects: DIALABLE_DURABLE_OBJECTS,
   loopbacks: DIALABLE_LOOPBACKS,
 };
 
@@ -158,13 +172,22 @@ export const DEFAULT_DIALABLE_TARGETS: DialableTargets = {
  */
 export function resolveDialableTargets(config?: {
   dialableBindings?: readonly string[];
+  dialableDurableObjects?: readonly string[];
   dialableLoopbacks?: readonly string[];
 }): DialableTargets {
-  if (!config?.dialableBindings?.length && !config?.dialableLoopbacks?.length) {
+  if (
+    !config?.dialableBindings?.length &&
+    !config?.dialableDurableObjects?.length &&
+    !config?.dialableLoopbacks?.length
+  ) {
     return DEFAULT_DIALABLE_TARGETS;
   }
   return {
     bindings: new Set([...DIALABLE_BINDINGS, ...(config.dialableBindings ?? [])]),
+    durableObjects: new Set([
+      ...DIALABLE_DURABLE_OBJECTS,
+      ...(config.dialableDurableObjects ?? []),
+    ]),
     loopbacks: new Set([...DIALABLE_LOOPBACKS, ...(config.dialableLoopbacks ?? [])]),
   };
 }
@@ -233,9 +256,16 @@ export function assertDefinableCapTarget(
       capSourceCacheKey(worker.source);
       return;
     case "durable-object":
-      throw new Error(
-        `Capability "${name}": ${worker.type} refs are not implemented yet (itx-next.md §1).`,
-      );
+      if (!dialable.durableObjects.has(worker.binding)) {
+        throw new Error(
+          `Capability "${name}": Durable Object namespace "${worker.binding}" is not dialable. ` +
+            `Dialable namespaces: ${[...dialable.durableObjects].join(", ") || "(none — opt in via APP_CONFIG_ITX)"}.`,
+        );
+      }
+      if (!worker.name) {
+        throw new Error(`Capability "${name}": durable-object refs need a non-empty name.`);
+      }
+      return;
   }
 }
 
@@ -284,10 +314,7 @@ const ITX_BUILTIN_NAMES = [
   "fork",
   "project",
   "projects",
-  "repos",
   "streams",
-  "worker",
-  "workspace",
 ] as const;
 
 /**

--- a/apps/os/src/itx/registry.ts
+++ b/apps/os/src/itx/registry.ts
@@ -333,8 +333,14 @@ export class ContextRegistry {
     return this.row(name) !== null || (this.host.defaults?.caps.has(name) ?? false);
   }
 
-  /** The only dispatch in the system (spec §4.4). */
-  async invoke(name: string, call: PathCall): Promise<unknown> {
+  /**
+   * The only dispatch in the system (spec §4.4). `origin` is the context the
+   * call STARTED at when it arrived via chain delegation (child → parent
+   * lookup misses) — context-scoped caps like the workspace must resolve
+   * against the caller's context, not the node the definition lives on.
+   * Absent means the call originated here.
+   */
+  async invoke(name: string, call: PathCall, origin?: string): Promise<unknown> {
     const row = this.row(name) ?? this.defaultRow(name);
     if (!row) {
       throw new Error(`No capability named "${name}" in context ${this.host.contextId}.`);
@@ -349,7 +355,7 @@ export class ContextRegistry {
     //  - facet  → the per-call facet stub.
     // project-worker refs return a custom dispatch instead of a target: the
     // call crosses to the Project DO as data and is replayed there.
-    const { dispatch, target, dispose } = this.borrowTarget(row);
+    const { dispatch, target, dispose } = this.borrowTarget(row, origin ?? this.host.contextId);
     try {
       if (dispatch) return await dispatch(call);
       if (row.invoke === "path-call") {
@@ -377,7 +383,10 @@ export class ContextRegistry {
    * The two-case shape (types.ts): a capability is either held up by a live
    * connection, or its serializable target is resolved at invoke time.
    */
-  private borrowTarget(row: CapRow): {
+  private borrowTarget(
+    row: CapRow,
+    originContext: string,
+  ): {
     target?: unknown;
     dispose: () => void;
     dispatch?: (call: PathCall) => Promise<unknown>;
@@ -392,13 +401,14 @@ export class ContextRegistry {
       const target = connection.target.dup ? connection.target.dup() : connection.target;
       return { target, dispose: () => disposeIfPossible(target) };
     }
-    return this.resolveTarget(row.name, targetOf(row), row.invoke);
+    return this.resolveTarget(row.name, targetOf(row), row.invoke, originContext);
   }
 
   private resolveTarget(
     name: string,
     target: SerializableCapTarget,
     invoke: CapInvoke,
+    originContext: string,
   ): {
     target?: unknown;
     dispose: () => void;
@@ -417,7 +427,7 @@ export class ContextRegistry {
           url: target.url,
           // Attribution + secret scope; same spoof-proofing as loopback refs.
           cap: name,
-          context: this.host.contextId,
+          context: originContext,
           projectId: this.host.projectId,
         },
       }) as { call(call: PathCall): Promise<unknown> };
@@ -453,8 +463,11 @@ export class ContextRegistry {
           props: {
             ...target.props,
             // Attribution wins over definer-supplied props, by spread order.
+            // `context` is the ORIGINATING context (chain delegation carries
+            // it), so context-scoped first-party caps — the workspace — bind
+            // to the caller's context even when the definition is inherited.
             cap: name,
-            context: this.host.contextId,
+            context: originContext,
             // Spoof-proofing: first-party entrypoints that scope by project
             // read props.projectId; the registry forces it to the owning
             // project so a definer can never point a dialable loopback at
@@ -491,10 +504,24 @@ export class ContextRegistry {
         const entrypoint = this.loadWorker(name, source).getEntrypoint(source.entrypoint);
         return { target: entrypoint, dispose: () => disposeIfPossible(entrypoint) };
       }
-      case "durable-object":
-        throw new Error(
-          `Capability "${name}": ${worker.type} refs are not implemented yet (itx-next.md §1).`,
-        );
+      case "durable-object": {
+        // Authoritative allowlist gate (define-time check is fail-fast only).
+        if (!this.dialable().durableObjects.has(worker.binding)) {
+          throw new Error(
+            `Capability "${name}": Durable Object namespace "${worker.binding}" is not dialable.`,
+          );
+        }
+        const namespace = this.host.binding?.(worker.binding) as
+          | { getByName(name: string): unknown }
+          | undefined;
+        if (typeof namespace?.getByName !== "function") {
+          throw new Error(
+            `Capability "${name}": "${worker.binding}" is not a Durable Object namespace on this host.`,
+          );
+        }
+        const stub = namespace.getByName(worker.name);
+        return { target: stub, dispose: () => disposeIfPossible(stub) };
+      }
     }
   }
 

--- a/apps/os/src/itx/types.ts
+++ b/apps/os/src/itx/types.ts
@@ -112,17 +112,22 @@ export interface ItxBuiltins {
    * is no separate "project object"; a narrowed itx IS the project. */
   readonly projects: ItxProjects;
 
-  /** The project's git repos. (Direction: becomes a defined capability
-   * rather than a hardwired built-in; surface unchanged.) */
+  /** PLATFORM DEFAULT, not kernel (§8 shipped): the project's git repos —
+   * an ordinary `platform:project` cap definition (ReposCapability
+   * loopback), shadowable like any inherited cap. Surface unchanged. */
   readonly repos: unknown;
 
-  /** The project's workspace: readFile/writeFile and the flat git methods
-   * (gitClone/gitAdd/gitCommit/gitPush/gitStatus — nested RpcTargets do not
-   * survive RPC boundaries). (Same direction as `repos`.) */
+  /** PLATFORM DEFAULT, not kernel: workspace readFile/writeFile and the
+   * flat git methods (gitClone/gitAdd/gitCommit/gitPush/gitStatus — nested
+   * RpcTargets do not survive RPC boundaries). Context-scoped: chain
+   * delegation carries the ORIGINATING context, so a forked child context
+   * gets its own isolated workspace even though the definition lives on
+   * `platform:project`. */
   readonly workspace: unknown;
 
-  /** The project worker. Every public method/getter is reachable at any
-   * depth: `itx.worker.someTool(args)`. */
+  /** PLATFORM DEFAULT, not kernel: the project's iterate-config worker via
+   * the ProjectWorker forwarder — `itx.worker.someTool(args)` reaches any
+   * public method of the default export, rebuilt from the repo per call. */
   readonly worker: unknown;
 
   /** The Project Durable Object stub, whole surface ("cap #0"). If your


### PR DESCRIPTION
The remaining itx roadmap on latest main, no backcompat (prd is redeployable): §8's endgame — the hardwired kernel becomes ordinary capability definitions — plus the last unimplemented WorkerRef kind.

## repos / workspace / worker are platform defaults now

All three move into the `platform:project` code context (`src/itx/code-contexts.ts`): `repos` and `workspace` as ReposCapability/WorkspaceCapability loopbacks, `worker` through the ProjectWorker forwarder (path-call hop, members inner replay against the default export). Their handle getters are deleted, their names leave the reserved list (shadowable — the point), and `callWorkerFunction` on the Project DO dies (the forwarder path covers it). What remains hardwired is exactly the composition a cap definition cannot express: `caps`, `streams` (the access model and global-namespace gating live there), `fetch` (Law 5), `fork`, `project`, `projects`, `describe`.

## Chain delegation carries the originating context

The enabling protocol change (allowed by no-backcompat): `itxInvoke` gains `origin`, set by the first delegating hop and preserved up the chain; the registry's dial-time `context` attribution prop uses it. This is what makes a context-SCOPED cap correct as an inherited definition — `workspace` resolves to `itx:ctx_…` for a forked child and `itx` for the project even though the definition lives two links up. WorkspaceCapability now derives its workspace id from the injected context (explicit `workspaceId` still wins; the agent DO's pre-clone wiring is unchanged and uses the same derivation).

New e2e: a child fork writes to its workspace; neither the project context nor a sibling fork can read the file.

## durable-object WorkerRef refs ship, config-gated

`{ type: "durable-object", binding, name }` resolves via `env[binding].getByName(name)` with the normal members/path-call dispatch. The namespace allowlist (`DIALABLE_DURABLE_OBJECTS`) is **empty by default**: every platform namespace (PROJECT, STREAM, …) is keyed across all projects, so allowlisting one would let any project handle dial any other project's objects by name. Deployments opt in via `APP_CONFIG_ITX.dialableDurableObjects`; per-project name scoping is the documented open design before any namespace can join the defaults. e2e asserts the define-time refusal.

## Behavioral changes

- `itx.worker.fetch` no longer special-cases to project ingress — it replays `fetch` on the worker's default export like any other member. The project homepage is the ingress URL.
- `describe()` on a fresh project now lists four inherited caps (`ai`, `repos`, `workspace`, `worker`) with `owner: "platform:project"`.

## Deferred, with reasons (in itx-next.md)

- `streams` stays kernel: resolution checks access, which a cap definition cannot express.
- REPL-consumes-types.ts (§5): the hand-maintained editor typings stay, comments updated.
- UrlDial through the egress intercept tunnel: the capnweb fork (#1474) only helps capnweb hops; the UrlDial → Project DO hop is Workers jsrpc, which still cannot carry a WebSocket-bearing Response.

## Verification

`pnpm typecheck` / `lint` / `knip` / `format` green; apps/os unit tests green (210); itx e2e (itx, fork incl. the new isolation test, http, subscribe — 21 tests) green against a local dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Protocol and dispatch changes (`origin`, workspace scoping, removed `callWorkerFunction`) affect fork isolation and worker routing; empty-default DO allowlist is security-critical if misconfigured.
> 
> **Overview**
> Continues **§8 “cap #0 disappears”**: **`repos`**, **`workspace`**, and **`worker`** move from hardwired `Itx` getters into the **`platform:project`** code context as ordinary loopback caps (`ReposCapability`, `WorkspaceCapability`, `ProjectWorker`). Those names leave the reserved list (shadowable); **`callWorkerFunction`** on the Project DO is removed in favor of the existing forwarder path.
> 
> **Chain delegation now carries the originating context**: **`itxInvoke`** accepts optional **`origin`**, set on the first delegating hop and forwarded up the chain; the registry uses it for dial-time **`context`** attribution so inherited caps stay **context-scoped**—notably **`workspace`** (`itx` vs `itx:ctx_…` per fork). **`WorkspaceCapability`** derives **`workspaceId`** from injected **`context`** when not explicit.
> 
> **`durable-object`** WorkerRefs are implemented behind an **empty-by-default** **`DIALABLE_DURABLE_OBJECTS`** allowlist, widened only via **`APP_CONFIG_ITX.dialableDurableObjects`**.
> 
> **Security / behavior**: **`itx.project`** blocks **`itx*`** registry methods (spoofing **`origin`**); **`itx.worker.fetch`** no longer routes to ingress—it replays the worker default export like any member. Docs, REPL typings, and e2e (workspace isolation, DO define refusal) updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3e0f0af06e6e51ae95a5c2c316eaf6271f9dc3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T22:06:09.374Z",
      "headSha": "e3e0f0af06e6e51ae95a5c2c316eaf6271f9dc3d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27309107590",
      "shortSha": "e3e0f0a"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `e3e0f0a`
Preview: https://os.iterate-preview-5.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27309107590)
Updated: 2026-06-10T22:06:09.374Z
<!-- /CLOUDFLARE_PREVIEW -->