### PR TITLE
agents: request-by-reference LLM handoff + sibling-tidied providers

### DIFF
--- a/apps/os/src/domains/agents/stream-processors/agent/contract.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/contract.ts
@@ -153,22 +153,9 @@ export const AgentProcessorContract = defineProcessorContract({
     },
     "events.iterate.com/agent/llm-request-requested": {
       description:
-        "The agent has prepared an LLM request. A subscribed LLM request processor must execute it and respond with agent output and a terminal llm-request-completed event. The llmRequestId used by response events is this event's stream offset.",
+        "The agent has prepared an LLM request. A subscribed LLM request processor must execute it and respond with agent output and a terminal llm-request-completed event. The llmRequestId used by response events is this event's stream offset. REQUEST-BY-REFERENCE: the event carries no conversation body — embedding it would store a full copy of the growing history in every request (O(N²) stream growth). Providers rebuild the chat request by reducing committed history up to this event's offset (buildLlmChatRequest), which reproduces the exact model-visible context from the stream forever.",
       payloadSchema: z.object({
         model: z.string().min(1),
-        body: z.object({
-          messages: z
-            .array(
-              z.object({
-                role: z.enum(["system", "user", "assistant"]),
-                content: z.string(),
-              }),
-            )
-            .min(1),
-          max_tokens: z.number().int().positive().optional(),
-          temperature: z.number().optional(),
-          top_p: z.number().optional(),
-        }),
         runOpts: z.json().default({}),
       }),
     },

--- a/apps/os/src/domains/agents/stream-processors/agent/implementation.test.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/implementation.test.ts
@@ -539,7 +539,7 @@ describe("AgentProcessor", () => {
     ]);
   });
 
-  it("re-reads stream history before handing a scheduled LLM request to providers", async () => {
+  it("hands a scheduled LLM request to providers by reference, without a body", async () => {
     vi.useFakeTimers();
     const { stream, appended } = memoryStream();
     const triggeringInput = agentEvent({
@@ -575,18 +575,14 @@ describe("AgentProcessor", () => {
     await vi.advanceTimersByTimeAsync(1000);
 
     expect(appended).toHaveLength(2);
+    // Request-by-reference: the handoff records which model to run and how,
+    // but never embeds the conversation — providers rebuild it from history
+    // up to this event's own offset (see llm-request-helpers.ts).
     expect(appended[1]).toMatchObject({
       type: "events.iterate.com/agent/llm-request-requested",
-      payload: {
-        body: {
-          messages: [
-            { role: "system", content: "You are a helpful assistant. You can trust your user." },
-            { role: "user", content: "codemode primer" },
-            { role: "user", content: "hi" },
-          ],
-        },
-      },
+      payload: { model: expect.any(String), runOpts: {} },
     });
+    expect(appended[1]!.payload).not.toHaveProperty("body");
   });
 });
 

--- a/apps/os/src/domains/agents/stream-processors/agent/implementation.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/implementation.ts
@@ -17,7 +17,6 @@ import {
 import { StreamProcessor } from "@iterate-com/streams/stream-processor";
 import {
   AgentProcessorContract,
-  buildLlmChatRequest,
   reduceAgentEvent,
   reduceAgentEvents,
   type AgentConsumedEvent,
@@ -462,6 +461,8 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
     }
 
     try {
+      // Request-by-reference: no body. Providers rebuild the chat request from
+      // committed history up to this event's offset.
       await this.ctx.stream.append({
         event: {
           type: "events.iterate.com/agent/llm-request-requested",
@@ -472,7 +473,6 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
           }),
           payload: {
             model: stateAtRequest.llmConfig.model,
-            body: buildLlmChatRequest(stateAtRequest),
             runOpts: stateAtRequest.llmConfig.runOpts,
           },
         },

--- a/apps/os/src/domains/agents/stream-processors/cloudflare-ai/contract.ts
+++ b/apps/os/src/domains/agents/stream-processors/cloudflare-ai/contract.ts
@@ -39,11 +39,10 @@ export const CloudflareAiProcessorContract = defineProcessorContract({
     },
     "events.iterate.com/cloudflare-ai/llm-request-started": {
       description:
-        "The Cloudflare AI processor started executing an agent LLM request. The llmRequestId is the offset of the source agent/llm-request-requested event.",
+        "The Cloudflare AI processor started executing an agent LLM request. The llmRequestId is the offset of the source agent/llm-request-requested event; the chat request is rebuilt from stream history up to that offset, never embedded.",
       payloadSchema: z.object({
         llmRequestId: LlmRequestId,
         model: z.string().min(1),
-        body: z.json(),
         runOpts: z.json().default({}),
       }),
     },

--- a/apps/os/src/domains/agents/stream-processors/cloudflare-ai/implementation.test.ts
+++ b/apps/os/src/domains/agents/stream-processors/cloudflare-ai/implementation.test.ts
@@ -36,6 +36,42 @@ describe("CloudflareAiProcessor", () => {
     expect(eventTypes(appended)).toContain("events.iterate.com/cloudflare-ai/llm-request-started");
   });
 
+  it("rebuilds the chat request from history up to the request's offset", async () => {
+    const { stream, appended } = memoryStream();
+    const runs: string[] = [];
+    const bodies: unknown[] = [];
+    const processor = newProcessor({
+      stream,
+      runs,
+      bodies,
+      // Request-by-reference: the requested event carries no body, so what
+      // the model sees is exactly the reduction of committed history up to
+      // the request's own offset — rows that landed after it are excluded.
+      readStreamEvents: async () => [
+        inputAddedEvent({ offset: 2, content: "hello" }),
+        llmRequestRequestedEvent({ offset: 11 }),
+        inputAddedEvent({ offset: 15, content: "landed after the request" }),
+      ],
+    });
+
+    await processor.ingest({
+      events: [llmRequestRequestedEvent({ offset: 11 })],
+      streamMaxOffset: 11,
+    });
+
+    await waitFor(() =>
+      eventTypes(appended).includes("events.iterate.com/cloudflare-ai/llm-request-completed"),
+    );
+    expect(bodies).toEqual([
+      {
+        messages: [
+          { role: "system", content: "You are a helpful assistant. You can trust your user." },
+          { role: "user", content: "hello" },
+        ],
+      },
+    ]);
+  });
+
   it("retries a request a previous incarnation left in started", async () => {
     const { stream, appended } = memoryStream();
     const runs: string[] = [];
@@ -176,6 +212,7 @@ function stateWithRequest(
 function newProcessor(args: {
   stream: StreamProcessorIterateContext["stream"];
   runs: string[];
+  bodies?: unknown[];
   snapshot?: StreamProcessorSnapshot<CloudflareAiState>;
   readStreamEvents?: () => Promise<StreamEvent[]>;
 }) {
@@ -183,8 +220,9 @@ function newProcessor(args: {
     iterateContext: { stream: args.stream },
     readState: () => args.snapshot,
     ai: {
-      run: async (model: string) => {
+      run: async (model: string, body: unknown) => {
         args.runs.push(model);
+        args.bodies?.push(body);
         return { response: "ok" };
       },
     },
@@ -197,11 +235,16 @@ function newProcessor(args: {
 function llmRequestRequestedEvent(args: { offset: number }): StreamEvent {
   return {
     type: "events.iterate.com/agent/llm-request-requested",
-    payload: {
-      model: "test-model",
-      body: { messages: [{ role: "user" as const, content: "hi" }] },
-      runOpts: {},
-    },
+    payload: { model: "test-model", runOpts: {} },
+    offset: args.offset,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function inputAddedEvent(args: { offset: number; content: string }): StreamEvent {
+  return {
+    type: "events.iterate.com/agent/input-added",
+    payload: { content: args.content, llmRequestPolicy: { behaviour: "dont-trigger-request" } },
     offset: args.offset,
     createdAt: "2026-01-01T00:00:00.000Z",
   };

--- a/apps/os/src/domains/agents/stream-processors/cloudflare-ai/implementation.ts
+++ b/apps/os/src/domains/agents/stream-processors/cloudflare-ai/implementation.ts
@@ -1,8 +1,10 @@
-// Implements the "cloudflare-ai" processor as a class-based StreamProcessor.
+// Implements the "cloudflare-ai" processor.
 //
-// Migrated from packages/shared/src/stream-processors/cloudflare-ai/implementation.ts.
-// All appended events keep their legacy types, payload shapes, and
-// idempotency-key derivations (`cloudflare-ai/<key>@<sourceOffset>`).
+// This file is a deliberate SIBLING of ../openai-ws/implementation.ts: same
+// method names, same control flow, same comments where the logic matches —
+// the two differ only in transport (one AI.run call vs a Responses WebSocket).
+// Stateless logic they share lives in ../llm-request-helpers.ts. When you fix
+// something here, check whether the sibling needs the same fix.
 //
 // The LLM request runs as keep-alive-backed background work
 // (`runInBackground`): the serialized batch queue stays free while the
@@ -21,7 +23,12 @@ import {
   type StreamEvent,
 } from "@iterate-com/streams/shared/stream-processors";
 import { StreamProcessor } from "@iterate-com/streams/stream-processor";
-import { reduceAgentEvents } from "../agent/contract.ts";
+import {
+  buildAgentLlmRequestBody,
+  findDanglingLlmRequestIds,
+  isAgentLlmRequestStillCurrent,
+  parseLlmRequestRequestedEventAt,
+} from "../llm-request-helpers.ts";
 import { CloudflareAiProcessorContract, type CloudflareAiState } from "./contract.ts";
 
 export { CloudflareAiProcessorContract } from "./contract.ts";
@@ -81,11 +88,11 @@ export class CloudflareAiProcessor extends StreamProcessor<
    * Requests this instance has taken responsibility for executing. The DO
    * instance is the execution scope: a fresh instance after a crash/wake
    * starts empty, which is what lets `#reconcileDanglingStartedRequests`
-   * recognize requests a previous incarnation abandoned. Ids stay in the set
-   * after a request reaches its terminal appends (re-execution is never
-   * needed then, even while the completed event is still being delivered
-   * back); they are removed only when execution fails before the terminal
-   * appends landed, so a later batch's reconciliation can retry.
+   * recognize requests a previous incarnation abandoned. Entries are removed
+   * when execution fails before the terminal appends landed (so a later
+   * connected event can retry) and once the request's completed fact has been
+   * reduced back (re-execution is impossible then — the completed-skip is
+   * durable), which keeps the set bounded on long-lived instances.
    */
   #executedLlmRequestIds = new Set<number>();
 
@@ -124,7 +131,12 @@ export class CloudflareAiProcessor extends StreamProcessor<
     const { event, state } = args;
     switch (event.type) {
       case "events.iterate.com/cloudflare-ai/llm-request-started":
+        return;
       case "events.iterate.com/cloudflare-ai/llm-request-completed":
+        // The completed fact is durable; this instance can never need to
+        // (re-)execute this request again, so drop the claim — this is what
+        // keeps the executed set bounded.
+        this.#executedLlmRequestIds.delete(event.payload.llmRequestId);
         return;
       case "events.iterate.com/agent/llm-request-requested":
         this.#startLlmRequest({ event, state, runInBackground: args.runInBackground });
@@ -190,12 +202,10 @@ export class CloudflareAiProcessor extends StreamProcessor<
     sourceEvent: { offset: number };
     runInBackground: (work: () => Promise<unknown>) => void;
   }) {
-    const danglingIds = Object.entries(args.state.requests)
-      .filter(
-        ([id, request]) =>
-          request.status === "started" && !this.#executedLlmRequestIds.has(Number(id)),
-      )
-      .map(([id]) => Number(id));
+    const danglingIds = findDanglingLlmRequestIds({
+      requests: args.state.requests,
+      executedLlmRequestIds: this.#executedLlmRequestIds,
+    });
     if (danglingIds.length === 0) return;
 
     // Claim synchronously, before the first await: one batch routinely
@@ -211,16 +221,8 @@ export class CloudflareAiProcessor extends StreamProcessor<
     try {
       const events = await this.deps.readStreamEvents();
       for (const llmRequestId of danglingIds) {
-        const requestedEvent = events.find(
-          (event) =>
-            event.offset === llmRequestId &&
-            event.type === "events.iterate.com/agent/llm-request-requested",
-        );
-        const reduction =
-          requestedEvent === undefined
-            ? undefined
-            : this.reduceRawEvent({ event: requestedEvent, state: args.state });
-        if (reduction?.event.type !== "events.iterate.com/agent/llm-request-requested") {
+        const requestedEvent = parseLlmRequestRequestedEventAt({ events, llmRequestId });
+        if (requestedEvent === null) {
           // The entry cannot be tied back to a requested event, so it is
           // unrecoverable; the claim stays so it stops triggering history reads.
           heldClaims.delete(llmRequestId);
@@ -239,7 +241,7 @@ export class CloudflareAiProcessor extends StreamProcessor<
         // Handed to the executor: its own failure handling owns the claim now.
         heldClaims.delete(llmRequestId);
         this.#startLlmRequest({
-          event: reduction.event,
+          event: requestedEvent,
           state: args.state,
           runInBackground: args.runInBackground,
         });
@@ -301,18 +303,20 @@ export class CloudflareAiProcessor extends StreamProcessor<
       payload: {
         llmRequestId,
         model: args.event.payload.model,
-        body: args.event.payload.body,
         runOpts: args.event.payload.runOpts,
       },
     });
 
+    // Request-by-reference: the requested event carries no body; rebuild the
+    // chat request from committed history up to the request's own offset.
+    const body = buildAgentLlmRequestBody({
+      events: await this.deps.readStreamEvents(),
+      llmRequestId,
+    });
+
     let raw: unknown;
     try {
-      raw = await ai.run(
-        args.event.payload.model,
-        args.event.payload.body,
-        args.event.payload.runOpts,
-      );
+      raw = await ai.run(args.event.payload.model, body, args.event.payload.runOpts);
     } catch (error) {
       const durationMs = Date.now() - startedAt;
       const failure = {
@@ -485,12 +489,10 @@ export class CloudflareAiProcessor extends StreamProcessor<
   }
 
   async #isAgentLlmRequestStillCurrent(args: { llmRequestId: number }) {
-    const events = await this.deps.readStreamEvents();
-    const state = reduceAgentEvents({ events });
-    return (
-      state.currentRequest?.phase === "requested" &&
-      state.currentRequest.llmRequestId === args.llmRequestId
-    );
+    return isAgentLlmRequestStillCurrent({
+      events: await this.deps.readStreamEvents(),
+      llmRequestId: args.llmRequestId,
+    });
   }
 
   async #append(event: { type: string; idempotencyKey: string; payload: unknown }) {

--- a/apps/os/src/domains/agents/stream-processors/llm-request-helpers.ts
+++ b/apps/os/src/domains/agents/stream-processors/llm-request-helpers.ts
@@ -1,0 +1,102 @@
+// Pure helpers shared by the LLM request processors (cloudflare-ai,
+// openai-ws). The two processors are deliberate siblings: each owns its event
+// types, its control flow, and its transport; what they share are these
+// stateless functions over agent stream history and reduced request state.
+
+import type { StreamEvent } from "@iterate-com/streams/shared/stream-processors";
+import {
+  getConsumedEventDefinition,
+  getEventSchema,
+} from "@iterate-com/streams/shared/stream-processors";
+import {
+  AgentProcessorContract,
+  buildLlmChatRequest,
+  reduceAgentEvents,
+  type AgentConsumedEvent,
+} from "./agent/contract.ts";
+
+export type LlmRequestRequestedEvent = Extract<
+  AgentConsumedEvent,
+  { type: "events.iterate.com/agent/llm-request-requested" }
+>;
+
+/**
+ * REQUEST-BY-REFERENCE: `agent/llm-request-requested` carries no conversation
+ * body (embedding it would store a full copy of the growing history in every
+ * request — O(N²) stream growth). The llmRequestId IS the requested event's
+ * offset, so the chat request is rebuilt here from committed history up to
+ * that offset — reproducible from the stream forever.
+ */
+export function buildAgentLlmRequestBody(args: {
+  events: readonly StreamEvent[];
+  llmRequestId: number;
+}) {
+  return buildLlmChatRequest(
+    reduceAgentEvents({
+      events: args.events.filter((event) => event.offset <= args.llmRequestId),
+    }),
+  );
+}
+
+/**
+ * Whether the agent is still waiting on this request. Checked against
+ * committed history right before agent-visible appends: a request the agent
+ * has moved past (interrupted, superseded) completes quietly — provider
+ * completion only, no output row, no agent-level terminal (the cancellation
+ * already was one).
+ */
+export function isAgentLlmRequestStillCurrent(args: {
+  events: readonly StreamEvent[];
+  llmRequestId: number;
+}) {
+  const state = reduceAgentEvents({ events: [...args.events] });
+  return (
+    state.currentRequest?.phase === "requested" &&
+    state.currentRequest.llmRequestId === args.llmRequestId
+  );
+}
+
+/**
+ * Requests whose durable status says "started" but that this instance never
+ * executed — they can only come from a previous incarnation that died
+ * mid-request. The execution-claims set is instance-scoped on purpose; see
+ * the processors' `#executedLlmRequestIds` field docs.
+ */
+export function findDanglingLlmRequestIds(args: {
+  requests: Record<string, { status: "started" | "completed" }>;
+  executedLlmRequestIds: ReadonlySet<number>;
+}): number[] {
+  return Object.entries(args.requests)
+    .filter(
+      ([id, request]) =>
+        request.status === "started" && !args.executedLlmRequestIds.has(Number(id)),
+    )
+    .map(([id]) => Number(id));
+}
+
+/**
+ * Finds and schema-parses the `agent/llm-request-requested` event at the given
+ * offset, for recovery paths that must re-derive a typed requested event from
+ * raw history. Returns null when the offset holds no such event.
+ */
+export function parseLlmRequestRequestedEventAt(args: {
+  events: readonly StreamEvent[];
+  llmRequestId: number;
+}): LlmRequestRequestedEvent | null {
+  const requestedEvent = args.events.find(
+    (event) =>
+      event.offset === args.llmRequestId &&
+      event.type === "events.iterate.com/agent/llm-request-requested",
+  );
+  if (requestedEvent === undefined) return null;
+  const definition = getConsumedEventDefinition({
+    contract: AgentProcessorContract,
+    eventType: requestedEvent.type,
+  });
+  if (definition === undefined) return null;
+  const result = getEventSchema({
+    type: requestedEvent.type,
+    payloadSchema: definition.payloadSchema,
+  }).safeParse(requestedEvent);
+  return result.success ? (result.data as LlmRequestRequestedEvent) : null;
+}

--- a/apps/os/src/domains/agents/stream-processors/openai-ws/implementation.test.ts
+++ b/apps/os/src/domains/agents/stream-processors/openai-ws/implementation.test.ts
@@ -33,7 +33,7 @@ describe("OpenAiWsProcessor", () => {
     });
 
     const firstRequest = processor.ingest({
-      events: [llmRequestRequestedEvent({ content: "first", offset: 11 })],
+      events: [llmRequestRequestedEvent({ offset: 11 })],
       streamMaxOffset: 11,
     });
     await waitFor(() => sockets.length === 1);
@@ -43,7 +43,7 @@ describe("OpenAiWsProcessor", () => {
     await firstRequest;
 
     const secondRequest = processor.ingest({
-      events: [llmRequestRequestedEvent({ content: "second", offset: 22 })],
+      events: [llmRequestRequestedEvent({ offset: 22 })],
       streamMaxOffset: 22,
     });
     await waitFor(() => sockets[0]?.sent.length === 2);
@@ -76,6 +76,50 @@ describe("OpenAiWsProcessor", () => {
     expect(eventTypes(appended)).toContain("events.iterate.com/agent/llm-request-completed");
   });
 
+  it("rebuilds the request input from history up to the request's offset", async () => {
+    const { stream, appended } = memoryStream();
+    const sockets: FakeOpenAiResponsesWebSocket[] = [];
+    const processor = newProcessor({
+      stream,
+      appended,
+      sockets,
+      snapshot: { offset: 0, state: testState() },
+      // Request-by-reference: the requested event carries no body, so the
+      // frame's input is exactly the reduction of committed history up to the
+      // request's own offset — rows that landed after it are excluded.
+      readStreamEvents: async () => [
+        inputAddedEvent({ offset: 2, content: "hello" }),
+        llmRequestRequestedEvent({ offset: 11 }),
+        inputAddedEvent({ offset: 15, content: "landed after the request" }),
+      ],
+    });
+
+    const request = processor.ingest({
+      events: [llmRequestRequestedEvent({ offset: 11 })],
+      streamMaxOffset: 11,
+    });
+    await waitFor(() => sockets.length === 1);
+    sockets[0]?.open();
+    await waitFor(() => sockets[0]?.sent.length === 1);
+    completeResponse(sockets[0], { delta: "OK", responseId: "resp_rebuilt" });
+    await request;
+    await waitFor(() =>
+      eventTypes(appended).includes("events.iterate.com/agent/llm-request-completed"),
+    );
+
+    expect(sockets[0]?.sent[0]).toMatchObject({
+      type: "response.create",
+      instructions: "You are a helpful assistant. You can trust your user.",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "hello" }],
+        },
+      ],
+    });
+  });
+
   it("does not append agent output for a cancelled request", async () => {
     const { stream, appended } = memoryStream();
     const sockets: FakeOpenAiResponsesWebSocket[] = [];
@@ -86,13 +130,11 @@ describe("OpenAiWsProcessor", () => {
       snapshot: { offset: 0, state: testState() },
       // The stream's reduced agent state points at a NEWER request (offset 18),
       // so request 17's output must be dropped.
-      readStreamEvents: async () => [
-        llmRequestRequestedEvent({ content: "replacement", offset: 18 }),
-      ],
+      readStreamEvents: async () => [llmRequestRequestedEvent({ offset: 18 })],
     });
 
     const request = processor.ingest({
-      events: [llmRequestRequestedEvent({ content: "cancelled", offset: 17 })],
+      events: [llmRequestRequestedEvent({ offset: 17 })],
       streamMaxOffset: 17,
     });
     await waitFor(() => sockets.length === 1);
@@ -121,7 +163,7 @@ describe("OpenAiWsProcessor", () => {
     });
 
     const firstBatch = processor.ingest({
-      events: [llmRequestRequestedEvent({ content: "slow", offset: 11 })],
+      events: [llmRequestRequestedEvent({ offset: 11 })],
       streamMaxOffset: 11,
     });
     // The batch resolves (reduce + checkpoint) while the LLM request is still
@@ -161,7 +203,7 @@ describe("OpenAiWsProcessor", () => {
       snapshot: { offset: 0, state: testState() },
     });
     const firstRequest = firstProcessor.ingest({
-      events: [llmRequestRequestedEvent({ content: "first", offset: 11 })],
+      events: [llmRequestRequestedEvent({ offset: 11 })],
       streamMaxOffset: 11,
     });
     await waitFor(() => sockets.length === 1);
@@ -180,7 +222,7 @@ describe("OpenAiWsProcessor", () => {
       },
     });
     const secondRequest = processorAfterWake.ingest({
-      events: [llmRequestRequestedEvent({ content: "second", offset: 22 })],
+      events: [llmRequestRequestedEvent({ offset: 22 })],
       streamMaxOffset: 22,
     });
     await waitFor(() => sockets.length === 2);
@@ -211,7 +253,7 @@ describe("OpenAiWsProcessor", () => {
     });
 
     const request = processorAfterWake.ingest({
-      events: [llmRequestRequestedEvent({ content: "retry me", offset: 33 })],
+      events: [llmRequestRequestedEvent({ offset: 33 })],
       streamMaxOffset: 33,
     });
     await waitFor(() => sockets.length === 1);
@@ -243,9 +285,7 @@ describe("OpenAiWsProcessor", () => {
       },
       // History holds the original requested event at offset === llmRequestId
       // and the agent's reduced phase still points at it (current request).
-      readStreamEvents: async () => [
-        llmRequestRequestedEvent({ content: "recover me", offset: 33 }),
-      ],
+      readStreamEvents: async () => [llmRequestRequestedEvent({ offset: 33 })],
     });
 
     // The host re-handshakes after the crash; the only thing the stream
@@ -284,9 +324,7 @@ describe("OpenAiWsProcessor", () => {
         offset: 34,
         state: { ...testState(), requests: { "33": { status: "started" } } },
       },
-      readStreamEvents: async () => [
-        llmRequestRequestedEvent({ content: "recover me", offset: 33 }),
-      ],
+      readStreamEvents: async () => [llmRequestRequestedEvent({ offset: 33 })],
     });
 
     // An agent host re-handshake appends one connected event per co-hosted
@@ -326,9 +364,7 @@ describe("OpenAiWsProcessor", () => {
         offset: 34,
         state: { ...testState(), requests: { "33": { status: "started" } } },
       },
-      readStreamEvents: async () => [
-        llmRequestRequestedEvent({ content: "recover me", offset: 33 }),
-      ],
+      readStreamEvents: async () => [llmRequestRequestedEvent({ offset: 33 })],
     });
 
     // Recovery is connect-driven: a connected event is guaranteed on every
@@ -357,7 +393,7 @@ describe("OpenAiWsProcessor", () => {
     });
 
     await processor.ingest({
-      events: [llmRequestRequestedEvent({ content: "already done", offset: 17 })],
+      events: [llmRequestRequestedEvent({ offset: 17 })],
       streamMaxOffset: 17,
     });
 
@@ -399,22 +435,22 @@ function currentAgentRequestEvents(appended: readonly StreamEventInput[]): Strea
     .map((event) => (event.payload as { llmRequestId?: unknown }).llmRequestId)
     .findLast((value): value is number => typeof value === "number");
   if (llmRequestId == null) return [];
-  return [llmRequestRequestedEvent({ content: "current", offset: llmRequestId })];
+  return [llmRequestRequestedEvent({ offset: llmRequestId })];
 }
 
-function llmRequestRequestedEvent(args: { content: string; offset: number }): StreamEvent {
+function llmRequestRequestedEvent(args: { offset: number }): StreamEvent {
   return {
     type: "events.iterate.com/agent/llm-request-requested",
-    payload: {
-      model: "ignored-provider-owned-model",
-      body: {
-        messages: [
-          { role: "system" as const, content: "You are terse." },
-          { role: "user" as const, content: args.content },
-        ],
-      },
-      runOpts: {},
-    },
+    payload: { model: "ignored-provider-owned-model", runOpts: {} },
+    offset: args.offset,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function inputAddedEvent(args: { offset: number; content: string }): StreamEvent {
+  return {
+    type: "events.iterate.com/agent/input-added",
+    payload: { content: args.content, llmRequestPolicy: { behaviour: "dont-trigger-request" } },
     offset: args.offset,
     createdAt: "2026-01-01T00:00:00.000Z",
   };

--- a/apps/os/src/domains/agents/stream-processors/openai-ws/implementation.ts
+++ b/apps/os/src/domains/agents/stream-processors/openai-ws/implementation.ts
@@ -1,8 +1,10 @@
-// Implements the "openai-ws" processor as a class-based StreamProcessor.
+// Implements the "openai-ws" processor.
 //
-// Migrated from packages/shared/src/stream-processors/openai-ws/implementation.ts.
-// All appended events keep their legacy types, payload shapes, and
-// idempotency-key derivations (`openai-ws/<key>@<sourceOffset>`).
+// This file is a deliberate SIBLING of ../cloudflare-ai/implementation.ts:
+// same method names, same control flow, same comments where the logic matches
+// — the two differ only in transport (a Responses WebSocket vs one AI.run
+// call). Stateless logic they share lives in ../llm-request-helpers.ts. When
+// you fix something here, check whether the sibling needs the same fix.
 //
 // Connection lifecycle: the WebSocket connection is a lazy instance field on
 // the class. The hosting Durable Object instance is the connection scope —
@@ -28,7 +30,12 @@ import {
   type StreamEvent,
 } from "@iterate-com/streams/shared/stream-processors";
 import { StreamProcessor } from "@iterate-com/streams/stream-processor";
-import { reduceAgentEvents } from "../agent/contract.ts";
+import {
+  buildAgentLlmRequestBody,
+  findDanglingLlmRequestIds,
+  isAgentLlmRequestStillCurrent,
+  parseLlmRequestRequestedEventAt,
+} from "../llm-request-helpers.ts";
 import { OpenAiWsProcessorContract, type OpenAiWsState } from "./contract.ts";
 
 export { OpenAiWsProcessorContract } from "./contract.ts";
@@ -114,11 +121,11 @@ export class OpenAiWsProcessor extends StreamProcessor<
    * Requests this instance has taken responsibility for executing. The DO
    * instance is the execution scope: a fresh instance after a crash/wake
    * starts empty, which is what lets `#reconcileDanglingStartedRequests`
-   * recognize requests a previous incarnation abandoned. Ids stay in the set
-   * after a request reaches its terminal appends (re-execution is never
-   * needed then, even while the completed event is still being delivered
-   * back); they are removed only when execution fails before the terminal
-   * appends landed, so a later batch's reconciliation can retry.
+   * recognize requests a previous incarnation abandoned. Entries are removed
+   * when execution fails before the terminal appends landed (so a later
+   * connected event can retry) and once the request's completed fact has been
+   * reduced back (re-execution is impossible then — the completed-skip is
+   * durable), which keeps the set bounded on long-lived instances.
    */
   #executedLlmRequestIds = new Set<number>();
 
@@ -167,7 +174,12 @@ export class OpenAiWsProcessor extends StreamProcessor<
     switch (event.type) {
       case "events.iterate.com/openai-ws/config-updated":
       case "events.iterate.com/openai-ws/llm-request-started":
+        return;
       case "events.iterate.com/openai-ws/llm-request-completed":
+        // The completed fact is durable; this instance can never need to
+        // (re-)execute this request again, so drop the claim — this is what
+        // keeps the executed set bounded.
+        this.#executedLlmRequestIds.delete(event.payload.llmRequestId);
         return;
       case "events.iterate.com/agent/llm-request-requested":
         this.#startLlmRequest({ event, state, runInBackground: args.runInBackground });
@@ -238,12 +250,10 @@ export class OpenAiWsProcessor extends StreamProcessor<
     sourceEvent: { offset: number };
     runInBackground: (work: () => Promise<unknown>) => void;
   }) {
-    const danglingIds = Object.entries(args.state.requests)
-      .filter(
-        ([id, request]) =>
-          request.status === "started" && !this.#executedLlmRequestIds.has(Number(id)),
-      )
-      .map(([id]) => Number(id));
+    const danglingIds = findDanglingLlmRequestIds({
+      requests: args.state.requests,
+      executedLlmRequestIds: this.#executedLlmRequestIds,
+    });
     if (danglingIds.length === 0) return;
 
     // Claim synchronously, before the first await: one batch routinely
@@ -259,16 +269,8 @@ export class OpenAiWsProcessor extends StreamProcessor<
     try {
       const events = await this.deps.readStreamEvents();
       for (const llmRequestId of danglingIds) {
-        const requestedEvent = events.find(
-          (event) =>
-            event.offset === llmRequestId &&
-            event.type === "events.iterate.com/agent/llm-request-requested",
-        );
-        const reduction =
-          requestedEvent === undefined
-            ? undefined
-            : this.reduceRawEvent({ event: requestedEvent, state: args.state });
-        if (reduction?.event.type !== "events.iterate.com/agent/llm-request-requested") {
+        const requestedEvent = parseLlmRequestRequestedEventAt({ events, llmRequestId });
+        if (requestedEvent === null) {
           // The entry cannot be tied back to a requested event, so it is
           // unrecoverable; the claim stays so it stops triggering history reads.
           heldClaims.delete(llmRequestId);
@@ -287,7 +289,7 @@ export class OpenAiWsProcessor extends StreamProcessor<
         // Handed to the executor: its own failure handling owns the claim now.
         heldClaims.delete(llmRequestId);
         this.#startLlmRequest({
-          event: reduction.event,
+          event: requestedEvent,
           state: args.state,
           runInBackground: args.runInBackground,
         });
@@ -421,18 +423,20 @@ export class OpenAiWsProcessor extends StreamProcessor<
       },
     });
 
-    const systemMessages = args.event.payload.body.messages.filter(
-      (message) => message.role === "system",
-    );
-    const inputMessages = args.event.payload.body.messages.filter(
-      (message) => message.role !== "system",
-    );
+    // Request-by-reference: the requested event carries no body; rebuild the
+    // chat request from committed history up to the request's own offset.
+    const body = buildAgentLlmRequestBody({
+      events: await this.deps.readStreamEvents(),
+      llmRequestId,
+    });
+    const systemMessages = body.messages.filter((message) => message.role === "system");
+    const inputMessages = body.messages.filter((message) => message.role !== "system");
     const previousResponseId = this.#previousResponseId;
     /**
      * `store: false` keeps this out of OpenAI's stored response retention, but
      * WebSocket mode can still chain the immediate conversation by carrying
-     * `previous_response_id` from the prior completed response. The agent
-     * request body remains the source of truth for what we explicitly send.
+     * `previous_response_id` from the prior completed response. The rebuilt
+     * chat request remains the source of truth for what we explicitly send.
      */
     const requestMessage = toJsonValue({
       type: "response.create",
@@ -692,12 +696,10 @@ export class OpenAiWsProcessor extends StreamProcessor<
   }
 
   async #isAgentLlmRequestStillCurrent(args: { llmRequestId: number }) {
-    const events = await this.deps.readStreamEvents();
-    const state = reduceAgentEvents({ events });
-    return (
-      state.currentRequest?.phase === "requested" &&
-      state.currentRequest.llmRequestId === args.llmRequestId
-    );
+    return isAgentLlmRequestStillCurrent({
+      events: await this.deps.readStreamEvents(),
+      llmRequestId: args.llmRequestId,
+    });
   }
 
   async #append(event: { type: string; idempotencyKey: string; payload: unknown }) {


### PR DESCRIPTION
Steps B and C of the agents roadmap (after #1460 and #1475): the LLM request handoff stops embedding the conversation, and the two LLM request processors become deliberate, tidy siblings sharing pure helpers.

## Request-by-reference (no more embedded body)

`agent/llm-request-requested` used to carry the full chat request. Since the conversation grows with the stream, every request stored a complete copy of it — O(N²) stream growth. The `llmRequestId` already IS the requested event's offset, so the body is redundant: providers can rebuild it from committed history.

Before:

```ts
// agent processor, on handoff
payload: {
  model,
  runOpts,
  body: buildLlmChatRequest(stateAtRequest), // full conversation, every time
}
```

After:

```ts
// agent processor: just the reference + how to run it
payload: { model: stateAtRequest.llmConfig.model, runOpts: stateAtRequest.llmConfig.runOpts }

// provider, at execution time (both cloudflare-ai and openai-ws):
// Request-by-reference: the requested event carries no body; rebuild the
// chat request from committed history up to the request's own offset.
const body = buildAgentLlmRequestBody({
  events: await this.deps.readStreamEvents(),
  llmRequestId, // === the requested event's offset
});
```

The rebuild reduces history `events.filter((e) => e.offset <= llmRequestId)` through the same `reduceAgentEvents` + `buildLlmChatRequest` pair the agent itself uses, so the model-visible context is reproducible from the stream forever — including for crash-recovery retries, which re-derive exactly what the dead incarnation would have sent.

**Breaking change** to the `agent/llm-request-requested` payload (and `cloudflare-ai/llm-request-started`, which also embedded the body). No backcompat bridge; prd gets redeployed.

## Providers as siblings, not an abstraction

`cloudflare-ai` and `openai-ws` were ~500/790-line copy-pasted state machines. Rather than an abstract base class, they're now deliberate siblings: same method names, same control flow, same comments where the logic matches — each keeps its own event types (which scales better as providers diverge) and its own transport (one `AI.run()` call vs a shared Responses WebSocket). What they share are four stateless functions in `llm-request-helpers.ts`:

```ts
buildAgentLlmRequestBody({ events, llmRequestId });     // the request-by-reference rebuild
isAgentLlmRequestStillCurrent({ events, llmRequestId }); // stale-output guard before agent-visible appends
findDanglingLlmRequestIds({ requests, executedLlmRequestIds }); // crash-recovery candidates
parseLlmRequestRequestedEventAt({ events, llmRequestId });      // typed re-derivation for recovery
```

Both implementation files open with the same note: *"When you fix something here, check whether the sibling needs the same fix."*

## Bounded execution-claims set

`#executedLlmRequestIds` (the instance-scoped set distinguishing "this incarnation is executing it" from "a dead one was") previously only grew. Both siblings now drop a claim when the request's own completed fact reduces back:

```ts
case "events.iterate.com/cloudflare-ai/llm-request-completed":
  // The completed fact is durable; this instance can never need to
  // (re-)execute this request again, so drop the claim — this is what
  // keeps the executed set bounded.
  this.#executedLlmRequestIds.delete(event.payload.llmRequestId);
  return;
```

## Tests

- New in both provider suites: *rebuilds the chat request from history up to the request's offset* — history rows after the requested event's offset are excluded from what the model sees.
- The agent handoff test now asserts the requested payload is `{ model, runOpts }` with no `body`.
- Provider fixtures lost their embedded bodies; conversation content now flows through `readStreamEvents` history, matching production.

`pnpm typecheck && pnpm lint && pnpm format && pnpm test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking event payload shapes for `llm-request-requested` and provider started events; correctness now depends on history reads and offset-bounded rebuild at execution time, including crash recovery paths.
> 
> **Overview**
> **Request-by-reference LLM handoff** stops embedding the full conversation on `agent/llm-request-requested` (and drops `body` from `cloudflare-ai/llm-request-started`). Handoffs are now `{ model, runOpts }` only; `llmRequestId` stays the requested event’s offset, and **cloudflare-ai** / **openai-ws** rebuild model input at execution via shared `llm-request-helpers.ts` (`buildAgentLlmRequestBody` reduces history with `offset <= llmRequestId`).
> 
> The two provider processors are aligned as **siblings** (shared helpers for rebuild, still-current checks, dangling recovery, typed re-parse) instead of duplicated logic. **`#executedLlmRequestIds`** now drops entries when each request’s provider **completed** event reduces, so long-lived instances don’t grow the claim set forever.
> 
> Tests assert handoff payloads have no `body` and that providers exclude stream rows after the request offset when building chat input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83ed55497ec2f4d04aeb172f36d2dddd34b8dcfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T22:09:52.345Z",
      "headSha": "83ed55497ec2f4d04aeb172f36d2dddd34b8dcfc",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27309177659",
      "shortSha": "83ed554"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `83ed554`
Preview: https://os.iterate-preview-7.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27309177659)
Updated: 2026-06-10T22:09:52.345Z
<!-- /CLOUDFLARE_PREVIEW -->