### PR TITLE
agents: dead-code sweep + shared agent setup form

### DIFF
--- a/apps/os/src/components/agent-setup-form.tsx
+++ b/apps/os/src/components/agent-setup-form.tsx
@@ -1,0 +1,193 @@
+// Shared form for the two agent-setup surfaces: "new agent" (appends setup
+// events to one agent stream) and "new preset" (saves setup events for a path
+// prefix). The pages own path normalization, preview building, and the submit
+// mutation; this component owns the field state and layout.
+
+import { useMemo, useState, type ReactNode } from "react";
+import type { EventInput } from "@iterate-com/shared/streams/types";
+import { Button } from "@iterate-com/ui/components/button";
+import { Field, FieldDescription, FieldGroup, FieldLabel } from "@iterate-com/ui/components/field";
+import { Input } from "@iterate-com/ui/components/input";
+import { NativeSelect, NativeSelectOption } from "@iterate-com/ui/components/native-select";
+import { SerializedObjectCodeBlock } from "@iterate-com/ui/components/serialized-object-code-block";
+import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
+import { Textarea } from "@iterate-com/ui/components/textarea";
+import {
+  type AgentLlmProvider,
+  DEFAULT_AGENT_LLM_PROVIDER,
+  DEFAULT_CLOUDFLARE_AGENT_MODEL,
+  DEFAULT_OPENAI_AGENT_MODEL,
+  defaultAgentSystemPrompt,
+} from "~/domains/agents/agent-presets.ts";
+
+const emptyEventsYaml = "[]\n";
+
+export type AgentSetupFormValues = {
+  customEventsYaml: string;
+  model: string;
+  pathInput: string;
+  provider: AgentLlmProvider;
+  runOpts: string;
+  systemPrompt: string;
+};
+
+export function AgentSetupFormPage<
+  Preview extends { error?: string; events: EventInput[] },
+>(props: {
+  buildPreview: (values: AgentSetupFormValues) => Preview;
+  customEventsDescription: string;
+  description: string;
+  idPrefix: string;
+  initialPathInput: string;
+  isPending: boolean;
+  onSubmit: (input: { preview: Preview; values: AgentSetupFormValues }) => void;
+  pathLabel: string;
+  pathPlaceholder: string;
+  previewDescription: (preview: Preview) => string;
+  previewTitle: string;
+  submitIcon: ReactNode;
+  submitIdleLabel: string;
+  submitPendingLabel: string;
+  title: string;
+}) {
+  const [pathInput, setPathInput] = useState(props.initialPathInput);
+  const [provider, setProvider] = useState<AgentLlmProvider>(DEFAULT_AGENT_LLM_PROVIDER);
+  const [model, setModel] = useState(DEFAULT_OPENAI_AGENT_MODEL);
+  const [runOpts, setRunOpts] = useState('{"gateway":{"id":"default"}}');
+  const [systemPrompt, setSystemPrompt] = useState(defaultAgentSystemPrompt());
+  const [customEventsYaml, setCustomEventsYaml] = useState(emptyEventsYaml);
+
+  const { buildPreview } = props;
+  const values = useMemo<AgentSetupFormValues>(
+    () => ({ customEventsYaml, model, pathInput, provider, runOpts, systemPrompt }),
+    [customEventsYaml, model, pathInput, provider, runOpts, systemPrompt],
+  );
+  const preview = useMemo(() => buildPreview(values), [buildPreview, values]);
+
+  function selectProvider(nextProvider: AgentLlmProvider) {
+    setProvider(nextProvider);
+    setModel((current) => {
+      if (nextProvider === "openai-ws" && current === DEFAULT_CLOUDFLARE_AGENT_MODEL) {
+        return DEFAULT_OPENAI_AGENT_MODEL;
+      }
+      if (nextProvider === "cloudflare-ai" && current === DEFAULT_OPENAI_AGENT_MODEL) {
+        return DEFAULT_CLOUDFLARE_AGENT_MODEL;
+      }
+      return current;
+    });
+  }
+
+  return (
+    <section className="w-full max-w-7xl space-y-4 p-4">
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold">{props.title}</h2>
+        <p className="text-sm text-muted-foreground">{props.description}</p>
+      </div>
+
+      <div className="grid min-h-0 gap-4 xl:grid-cols-[minmax(0,0.95fr)_minmax(440px,1.05fr)]">
+        <div className="space-y-4">
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor={`${props.idPrefix}-path`}>{props.pathLabel}</FieldLabel>
+              <Input
+                id={`${props.idPrefix}-path`}
+                value={pathInput}
+                onChange={(event) => setPathInput(event.currentTarget.value)}
+                placeholder={props.pathPlaceholder}
+              />
+            </Field>
+
+            <div className="grid gap-3 md:grid-cols-[14rem_minmax(0,1fr)]">
+              <Field>
+                <FieldLabel htmlFor={`${props.idPrefix}-provider`}>Provider</FieldLabel>
+                <NativeSelect
+                  id={`${props.idPrefix}-provider`}
+                  value={provider}
+                  onChange={(event) =>
+                    selectProvider(event.currentTarget.value as AgentLlmProvider)
+                  }
+                >
+                  <NativeSelectOption value="openai-ws">OpenAI WebSocket</NativeSelectOption>
+                  <NativeSelectOption value="cloudflare-ai">
+                    Cloudflare AI Gateway
+                  </NativeSelectOption>
+                </NativeSelect>
+              </Field>
+              <Field>
+                <FieldLabel htmlFor={`${props.idPrefix}-model`}>Model</FieldLabel>
+                <Input
+                  id={`${props.idPrefix}-model`}
+                  value={model}
+                  onChange={(event) => setModel(event.currentTarget.value)}
+                />
+              </Field>
+            </div>
+
+            {provider === "cloudflare-ai" ? (
+              <Field>
+                <FieldLabel htmlFor={`${props.idPrefix}-run-opts`}>Run options JSON</FieldLabel>
+                <Textarea
+                  id={`${props.idPrefix}-run-opts`}
+                  className="min-h-20 font-mono text-xs"
+                  value={runOpts}
+                  onChange={(event) => setRunOpts(event.currentTarget.value)}
+                />
+              </Field>
+            ) : null}
+
+            <Field>
+              <FieldLabel htmlFor={`${props.idPrefix}-system-prompt`}>System prompt</FieldLabel>
+              <Textarea
+                id={`${props.idPrefix}-system-prompt`}
+                className="min-h-32 font-mono text-xs"
+                value={systemPrompt}
+                onChange={(event) => setSystemPrompt(event.currentTarget.value)}
+              />
+            </Field>
+
+            <Field>
+              <FieldLabel htmlFor={`${props.idPrefix}-custom-events`}>Custom events</FieldLabel>
+              <SourceCodeBlock
+                code={customEventsYaml}
+                className="min-h-44"
+                editable
+                language="yaml"
+                onChange={setCustomEventsYaml}
+              />
+              <FieldDescription>{props.customEventsDescription}</FieldDescription>
+            </Field>
+          </FieldGroup>
+        </div>
+
+        <aside className="min-h-[42rem] space-y-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-1">
+              <p className="text-sm font-semibold">{props.previewTitle}</p>
+              <p className="text-sm text-muted-foreground">{props.previewDescription(preview)}</p>
+            </div>
+            <Button
+              onClick={() => props.onSubmit({ preview, values })}
+              disabled={props.isPending || preview.error != null}
+            >
+              {props.submitIcon}
+              {props.isPending ? props.submitPendingLabel : props.submitIdleLabel}
+            </Button>
+          </div>
+
+          {preview.error ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+              {preview.error}
+            </div>
+          ) : (
+            <SerializedObjectCodeBlock
+              data={preview.events}
+              className="h-[42rem]"
+              initialFormat="yaml"
+              showToggle
+            />
+          )}
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/apps/os/src/domains/agents/agent-presets.test.ts
+++ b/apps/os/src/domains/agents/agent-presets.test.ts
@@ -134,36 +134,6 @@ describe("agent presets", () => {
     ).toBe(slackOpenAiPreset);
   });
 
-  it("ignores the legacy generated Slack OpenAI preset so Slack agents fall back to the built-in default", () => {
-    const legacySlackOpenAiPreset = {
-      basePath: "/agents/slack",
-      events: [
-        {
-          type: "events.iterate.com/os-agent/llm-provider-selected",
-          payload: { provider: "openai-ws" },
-        },
-        {
-          type: "events.iterate.com/openai-ws/config-updated",
-          payload: { model: "gpt-5.5" },
-        },
-        {
-          type: "events.iterate.com/agent/system-prompt-updated",
-          payload: {
-            systemPrompt:
-              "You are an Iterate agent responding from Slack. Send Slack replies with itx.slack.chat.postMessage({ channel, thread_ts, text }).",
-          },
-        },
-      ],
-    };
-
-    expect(
-      selectAgentSetupPreset({
-        agentPath: "/agents/slack/c123/ts-1778565914-773159",
-        presets: [legacySlackOpenAiPreset],
-      }),
-    ).toBeNull();
-  });
-
   it("ignores invalid stored preset paths while selecting a prefix preset", () => {
     const validPreset = {
       basePath: "/agents/alice",

--- a/apps/os/src/domains/agents/agent-presets.ts
+++ b/apps/os/src/domains/agents/agent-presets.ts
@@ -11,8 +11,6 @@ export const DEFAULT_CLOUDFLARE_AGENT_MODEL = DEFAULT_WORKERS_AI_AGENT_MODEL;
 export const DEFAULT_OPENAI_AGENT_MODEL = "gpt-5.5";
 export const DEFAULT_AGENT_LLM_PROVIDER = "openai-ws";
 export const DEFAULT_AGENT_DEBOUNCE_MS = 200;
-const LEGACY_GENERATED_SLACK_OPENAI_PROMPT_MARKER =
-  "You are an Iterate agent responding from Slack.";
 
 export const AgentLlmProvider = z.enum(["openai-ws", "cloudflare-ai"]);
 export type AgentLlmProvider = z.infer<typeof AgentLlmProvider>;
@@ -222,9 +220,7 @@ export function selectAgentSetupPreset(input: {
 
   return selectAgentPathPrefixPreset({
     agentPath: input.agentPath,
-    presets: input.presets
-      .filter((preset) => isSlackAgentPath(preset.basePath))
-      .filter((preset) => !isLegacyGeneratedSlackOpenAiPreset(preset)),
+    presets: input.presets.filter((preset) => isSlackAgentPath(preset.basePath)),
   });
 }
 
@@ -253,23 +249,6 @@ function tryNormalizeAgentPresetBasePath(input: string): StreamPath | null {
 
 export function isSlackAgentPath(agentPath: string) {
   return agentPath === "/agents/slack" || agentPath.startsWith("/agents/slack/");
-}
-
-function isLegacyGeneratedSlackOpenAiPreset(preset: AgentPathPrefixPreset) {
-  if (preset.basePath !== "/agents/slack") return false;
-  const provider = preset.events
-    .map((event) => (event.payload as { provider?: unknown }).provider)
-    .find((value) => value === "openai-ws" || value === "cloudflare-ai");
-  if (provider !== "openai-ws") return false;
-
-  return preset.events.some((event) => {
-    if (event.type !== "events.iterate.com/agent/system-prompt-updated") return false;
-    const systemPrompt = (event.payload as { systemPrompt?: unknown }).systemPrompt;
-    return (
-      typeof systemPrompt === "string" &&
-      systemPrompt.includes(LEGACY_GENERATED_SLACK_OPENAI_PROMPT_MARKER)
-    );
-  });
 }
 
 function parseAgentEventsYaml(value: string) {

--- a/apps/os/src/domains/agents/stream-processors/agent-chat/contract.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent-chat/contract.ts
@@ -4,9 +4,6 @@
 // Web and terminal chat are channels of the same domain concept. The channel
 // stays in payload data; the processor owns rendering chat-domain events into
 // curated `agent/input-added` rows for the Agent processor.
-//
-// Migrated from packages/shared/src/stream-processors/agent-chat/contract.ts.
-// Wire formats (event types and payload schemas) are unchanged.
 
 import { z } from "zod";
 import { defineProcessorContract } from "@iterate-com/streams/shared/stream-processors";

--- a/apps/os/src/domains/agents/stream-processors/agent-chat/implementation.test.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent-chat/implementation.test.ts
@@ -1,6 +1,5 @@
-// Ported from packages/shared/src/stream-processors/agent-chat/implementation.test.ts
-// onto the class-based StreamProcessor model. Idempotency-key assertions are
-// wire-format regression checks — they must not change.
+// Idempotency-key assertions are wire-format regression checks — they must
+// not change.
 
 import { describe, expect, it } from "vitest";
 import type { StreamEvent, StreamEventInput } from "@iterate-com/streams/shared/event";

--- a/apps/os/src/domains/agents/stream-processors/agent-chat/implementation.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent-chat/implementation.ts
@@ -3,9 +3,9 @@
 // The chat surfaces append raw chat-domain events; this processor transcribes
 // them into Agent input rows.
 //
-// Migrated from packages/shared/src/stream-processors/agent-chat/implementation.ts.
-// All appended events keep their legacy types, payload shapes, and
-// idempotency-key derivations (`agent-chat/<key>@<sourceOffset>`).
+// Appended event types, payload shapes, and idempotency-key derivations
+// (`agent-chat/<key>@<sourceOffset>`) are stable wire formats — changing them
+// breaks dedup against events already committed to streams.
 
 import {
   assertNever,

--- a/apps/os/src/domains/agents/stream-processors/agent-host/contract.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent-host/contract.ts
@@ -1,7 +1,5 @@
-// Defines the "agent-host" processor contract on the class-based stream model.
+// Defines the "agent-host" processor contract.
 //
-// Recreated from the inline contract that used to live in the deleted legacy
-// stream-processor runner.
 // The processor observes every event on an agent stream (`consumes: ["*"]`)
 // and runs OS-owned host side effects: waking the stream's AgentDurableObject,
 // initializing child-agent DOs, and bridging codemode script execution.

--- a/apps/os/src/domains/agents/stream-processors/agent-host/implementation.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent-host/implementation.ts
@@ -1,10 +1,8 @@
-// Implements the "agent-host" processor as a class-based StreamProcessor.
+// Implements the "agent-host" processor.
 //
-// Recreated from the inline `createAgentHostProcessor` that used to live in
-// the deleted legacy stream-processor runner. The host-side-effect handlers
-// moved here from agent-durable-object.ts; keeping them out of the Durable
-// Object module avoids a runtime import cycle now that the DO constructs this
-// processor in a class field initializer.
+// Host-side-effect handlers live here rather than in agent-durable-object.ts:
+// keeping them out of the Durable Object module avoids a runtime import cycle,
+// since the DO constructs this processor in a class field initializer.
 
 import type { Event, EventInput, StreamPath } from "@iterate-com/shared/streams/types";
 import { StreamPath as StreamPathSchema } from "@iterate-com/shared/streams/types";

--- a/apps/os/src/domains/agents/stream-processors/agent/contract.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/contract.ts
@@ -6,11 +6,8 @@
 // module to project stream events into display state without constructing the
 // backend processor class.
 //
-// Migrated from packages/shared/src/stream-processors/agent/contract.ts.
-// Wire formats (event types and payload schemas) are unchanged. The
-// standardProcessorBehavior registration slice (`hasRegisteredCurrentVersion`
-// state + core stream-processor-registered consumption) is gone: contract
-// announcements now ride the host's `stream/subscriber-connected` fact.
+// Contract announcements ride the host's `stream/subscriber-connected` fact;
+// there is no per-processor registration slice.
 
 import { z } from "zod";
 import {

--- a/apps/os/src/domains/agents/stream-processors/agent/implementation.test.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/implementation.test.ts
@@ -1,7 +1,6 @@
-// Ported from packages/shared/src/stream-processors/agent/implementation.test.ts
-// onto the class-based StreamProcessor model: events are driven through
-// `ingest` and state is seeded through `readState` snapshots. Idempotency-key
-// assertions are wire-format regression checks — they must not change.
+// Events are driven through `ingest` and state is seeded through `readState`
+// snapshots. Idempotency-key assertions are wire-format regression checks —
+// they must not change.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getInitialProcessorState } from "@iterate-com/streams/shared/stream-processors";

--- a/apps/os/src/domains/agents/stream-processors/agent/implementation.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/implementation.ts
@@ -5,9 +5,9 @@
 // subscribed LLM request processor owes the stream `agent/output-added` plus a
 // terminal `agent/llm-request-completed`.
 //
-// Migrated from packages/shared/src/stream-processors/agent/implementation.ts.
-// All appended events keep their legacy types, payload shapes, and
-// idempotency-key derivations (`agent/<key>@<sourceOffset>`).
+// Appended event types, payload shapes, and idempotency-key derivations
+// (`agent/<key>@<sourceOffset>`) are stable wire formats — changing them
+// breaks dedup against events already committed to streams.
 
 import {
   assertNever,

--- a/apps/os/src/domains/agents/stream-processors/cloudflare-ai/contract.ts
+++ b/apps/os/src/domains/agents/stream-processors/cloudflare-ai/contract.ts
@@ -1,7 +1,4 @@
-// Defines the "cloudflare-ai" processor contract on the class-based stream model.
-//
-// Migrated from packages/shared/src/stream-processors/cloudflare-ai/contract.ts.
-// Wire formats (event types and payload schemas) are unchanged.
+// Defines the "cloudflare-ai" processor contract.
 
 import { z } from "zod";
 import { defineProcessorContract } from "@iterate-com/streams/shared/stream-processors";

--- a/apps/os/src/domains/agents/stream-processors/jsonata-reactor/contract.ts
+++ b/apps/os/src/domains/agents/stream-processors/jsonata-reactor/contract.ts
@@ -1,10 +1,7 @@
-// Defines the "jsonata-reactor" processor contract on the class-based stream model.
+// Defines the "jsonata-reactor" processor contract.
 //
-// Migrated from packages/shared/src/stream-processors/jsonata-reactor/contract.ts.
-// Wire formats (event types and payload schemas) are unchanged. The legacy
-// `consumesAllEvents: true` escape hatch becomes an explicit `"*"` entry in
-// `consumes`, which also drives the host's subscription event-type filter
-// (unfiltered delivery).
+// The `"*"` entry in `consumes` drives the host's subscription event-type
+// filter (unfiltered delivery).
 
 import { z } from "zod";
 import { defineProcessorContract } from "@iterate-com/streams/shared/stream-processors";

--- a/apps/os/src/domains/agents/stream-processors/jsonata-reactor/implementation.ts
+++ b/apps/os/src/domains/agents/stream-processors/jsonata-reactor/implementation.ts
@@ -1,6 +1,5 @@
-// Implements the "jsonata-reactor" processor as a class-based StreamProcessor.
+// Implements the "jsonata-reactor" processor.
 //
-// Migrated from packages/shared/src/stream-processors/jsonata-reactor/implementation.ts.
 // Reaction events are appended exactly as the rule's JSONata expression produces
 // them (including any rule-provided idempotency keys); reaction evaluation and
 // appends run under `blockProcessorWhile` because rules may produce reactions

--- a/apps/os/src/domains/agents/stream-processors/openai-ws/contract.ts
+++ b/apps/os/src/domains/agents/stream-processors/openai-ws/contract.ts
@@ -3,9 +3,6 @@
 // OpenAI Responses WebSocket mode uses `response.create` messages on a
 // WebSocket connection and emits the same streaming event family as ordinary
 // Responses streaming. https://developers.openai.com/api/docs/guides/websocket-mode
-//
-// Migrated from packages/shared/src/stream-processors/openai-ws/contract.ts.
-// Wire formats (event types and payload schemas) are unchanged.
 
 import { z } from "zod";
 import { defineProcessorContract } from "@iterate-com/streams/shared/stream-processors";

--- a/apps/os/src/domains/agents/stream-processors/openai-ws/implementation.test.ts
+++ b/apps/os/src/domains/agents/stream-processors/openai-ws/implementation.test.ts
@@ -1,8 +1,6 @@
-// Ported from packages/shared/src/stream-processors/openai-ws/implementation.test.ts
-// onto the class-based StreamProcessor model. The WebSocket connection is an
-// instance field on the processor class (the hosting DO is the connection
-// scope), so connection-reuse and wake semantics are exercised by reusing or
-// recreating processor instances.
+// The WebSocket connection is an instance field on the processor class (the
+// hosting DO is the connection scope), so connection-reuse and wake semantics
+// are exercised by reusing or recreating processor instances.
 
 import { describe, expect, it } from "vitest";
 import { z } from "zod";

--- a/apps/os/src/domains/slack/stream-processors/slack-agent/contract.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack-agent/contract.ts
@@ -1,12 +1,8 @@
 // Contract for the "slack-agent" processor that runs on one routed Slack
 // agent stream.
 //
-// Migrated from `packages/shared/src/stream-processors/slack-agent/contract.ts`
-// onto the class-based StreamProcessor model. Event wire formats (types +
-// payload schemas) are unchanged. The standardProcessorBehavior registration
-// slice is gone: the stream processor host announces contracts after each
-// subscription handshake instead (migration log D11), and the reducer now
-// lives on the `SlackAgentProcessor` class.
+// The stream processor host announces contracts after each subscription
+// handshake; the reducer lives on the `SlackAgentProcessor` class.
 
 import { z } from "zod";
 import { defineProcessorContract } from "@iterate-com/streams/shared/stream-processors";

--- a/apps/os/src/domains/slack/stream-processors/slack-agent/implementation.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack-agent/implementation.ts
@@ -1,9 +1,9 @@
-// Implements the "slack-agent" processor on the class-based StreamProcessor
-// model. Migrated from
-// `packages/shared/src/stream-processors/slack-agent/implementation.ts`;
-// emitted event types/payloads and idempotency keys are unchanged.
+// Implements the "slack-agent" processor.
 //
-// Side-effect policy (see migration log D5/D6):
+// Emitted event types, payloads, and idempotency keys are stable wire formats
+// — changing them breaks dedup against events already committed to streams.
+//
+// Side-effect policy:
 // - Slack Web API calls (status updates, reactions) run inside
 //   `blockProcessorWhile` so the checkpoint only advances once they finished;
 //   sequences like "commit agent input, then add the eyes reaction" keep their

--- a/apps/os/src/domains/slack/stream-processors/slack-agent/slack-agent.test.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack-agent/slack-agent.test.ts
@@ -1,7 +1,5 @@
-// Ported from packages/shared/src/stream-processors/slack-agent/slack-agent.test.ts
-// onto the class-based StreamProcessor model: state is built by ingesting
-// events instead of being passed into afterAppend, and the first-attach
-// lookback test became a sideEffectsAfterOffset anchor test.
+// State is built by ingesting events; first-attach lookback is covered by the
+// sideEffectsAfterOffset anchor test.
 
 import { describe, expect, it } from "vitest";
 import type { StreamEvent, StreamEventInput } from "@iterate-com/streams/shared/event";

--- a/apps/os/src/domains/slack/stream-processors/slack/contract.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack/contract.ts
@@ -1,11 +1,7 @@
 // Contract for the "slack" processor mounted on `/integrations/slack`.
 //
-// Migrated from `packages/shared/src/stream-processors/slack/contract.ts` onto
-// the class-based StreamProcessor model. Event wire formats (types + payload
-// schemas) are unchanged. The standardProcessorBehavior registration slice is
-// gone: the stream processor host announces contracts after each subscription
-// handshake instead (migration log D11), and the reducer now lives on the
-// `SlackProcessor` class.
+// The stream processor host announces contracts after each subscription
+// handshake; the reducer lives on the `SlackProcessor` class.
 
 import { z } from "zod";
 import { defineProcessorContract } from "@iterate-com/streams/shared/stream-processors";

--- a/apps/os/src/domains/slack/stream-processors/slack/implementation.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack/implementation.ts
@@ -1,7 +1,7 @@
-// Implements the "slack" webhook-router processor on the class-based
-// StreamProcessor model. Migrated from
-// `packages/shared/src/stream-processors/slack/implementation.ts`; routing
-// logic, emitted event types/payloads, and idempotency keys are unchanged.
+// Implements the "slack" webhook-router processor.
+//
+// Emitted event types, payloads, and idempotency keys are stable wire formats
+// — changing them breaks dedup against events already committed to streams.
 
 import { z } from "zod";
 import { StreamProcessor } from "@iterate-com/streams/stream-processor";

--- a/apps/os/src/routes/_app/projects/$projectSlug/agents/new-preset.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/agents/new-preset.tsx
@@ -1,32 +1,18 @@
-import { useCallback, useMemo, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Save } from "lucide-react";
 import { EventInput, StreamPath } from "@iterate-com/shared/streams/types";
-import { Button } from "@iterate-com/ui/components/button";
-import { Field, FieldDescription, FieldGroup, FieldLabel } from "@iterate-com/ui/components/field";
-import { Input } from "@iterate-com/ui/components/input";
-import { NativeSelect, NativeSelectOption } from "@iterate-com/ui/components/native-select";
-import { SerializedObjectCodeBlock } from "@iterate-com/ui/components/serialized-object-code-block";
 import { toast } from "@iterate-com/ui/components/sonner";
-import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
-import { Textarea } from "@iterate-com/ui/components/textarea";
+import { AgentSetupFormPage, type AgentSetupFormValues } from "~/components/agent-setup-form.tsx";
 import {
   AgentPresetEvent,
-  type AgentLlmProvider,
-  DEFAULT_AGENT_LLM_PROVIDER,
-  DEFAULT_CLOUDFLARE_AGENT_MODEL,
-  DEFAULT_OPENAI_AGENT_MODEL,
   configuredAgentSetupEvents,
-  defaultAgentSystemPrompt,
   normalizeAgentPresetBasePath,
   parseAgentPresetEventsYaml,
   parseAgentRunOptsJson,
 } from "~/domains/agents/agent-presets.ts";
 import { projectAgentPresetsQueryOptions } from "~/lib/project-route-query.ts";
 import { orpcClient } from "~/orpc/client.ts";
-
-const emptyEventsYaml = "[]\n";
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/agents/new-preset")({
   loader: async ({ context }) => {
@@ -40,43 +26,32 @@ export const Route = createFileRoute("/_app/projects/$projectSlug/agents/new-pre
   component: NewAgentPresetPage,
 });
 
+type PresetPreview = {
+  basePath: StreamPath;
+  customEvents: AgentPresetEvent[];
+  error?: string;
+  events: EventInput[];
+};
+
 function NewAgentPresetPage() {
   const params = Route.useParams();
   const { project } = Route.useLoaderData();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [basePathInput, setBasePathInput] = useState("/agents");
-  const [provider, setProvider] = useState<AgentLlmProvider>(DEFAULT_AGENT_LLM_PROVIDER);
-  const [model, setModel] = useState(DEFAULT_OPENAI_AGENT_MODEL);
-  const [runOpts, setRunOpts] = useState('{"gateway":{"id":"default"}}');
-  const [systemPrompt, setSystemPrompt] = useState(defaultAgentSystemPrompt());
-  const [customEventsYaml, setCustomEventsYaml] = useState(emptyEventsYaml);
-
-  const preview = useMemo(
-    () =>
-      buildPresetPreview({
-        basePathInput,
-        customEventsYaml,
-        model,
-        provider,
-        runOpts,
-        systemPrompt,
-      }),
-    [basePathInput, customEventsYaml, model, provider, runOpts, systemPrompt],
-  );
 
   const presetsQueryOptions = projectAgentPresetsQueryOptions(project.id);
   const savePreset = useMutation({
-    mutationFn: async () => {
+    mutationFn: async (input: { preview: PresetPreview; values: AgentSetupFormValues }) => {
+      const { preview, values } = input;
       if (preview.error) throw new Error(preview.error);
       return await orpcClient.project.agents.configurePreset({
         basePath: preview.basePath,
         events: preview.customEvents,
-        model: model.trim(),
+        model: values.model.trim(),
         projectSlugOrId: project.id,
-        provider,
-        runOpts: provider === "cloudflare-ai" ? parseAgentRunOptsJson(runOpts) : {},
-        systemPrompt: systemPrompt.trim(),
+        provider: values.provider,
+        runOpts: values.provider === "cloudflare-ai" ? parseAgentRunOptsJson(values.runOpts) : {},
+        systemPrompt: values.systemPrompt.trim(),
       });
     },
     onSuccess: async (result) => {
@@ -90,171 +65,46 @@ function NewAgentPresetPage() {
     onError: (error) => toast.error(error instanceof Error ? error.message : String(error)),
   });
 
-  const submit = useCallback(() => {
-    savePreset.mutate();
-  }, [savePreset]);
-
-  function selectProvider(nextProvider: AgentLlmProvider) {
-    setProvider(nextProvider);
-    setModel((current) => {
-      if (nextProvider === "openai-ws" && current === DEFAULT_CLOUDFLARE_AGENT_MODEL) {
-        return DEFAULT_OPENAI_AGENT_MODEL;
-      }
-      if (nextProvider === "cloudflare-ai" && current === DEFAULT_OPENAI_AGENT_MODEL) {
-        return DEFAULT_CLOUDFLARE_AGENT_MODEL;
-      }
-      return current;
-    });
-  }
-
   return (
-    <section className="w-full max-w-7xl space-y-4 p-4">
-      <div className="space-y-1">
-        <h2 className="text-sm font-semibold">New Agent Preset</h2>
-        <p className="text-sm text-muted-foreground">
-          Assemble the events that will seed matching agent streams.
-        </p>
-      </div>
-
-      <div className="grid min-h-0 gap-4 xl:grid-cols-[minmax(0,0.95fr)_minmax(440px,1.05fr)]">
-        <div className="space-y-4">
-          <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="agent-preset-base-path">Path prefix</FieldLabel>
-              <Input
-                id="agent-preset-base-path"
-                value={basePathInput}
-                onChange={(event) => setBasePathInput(event.currentTarget.value)}
-                placeholder="/agents"
-              />
-            </Field>
-
-            <div className="grid gap-3 md:grid-cols-[14rem_minmax(0,1fr)]">
-              <Field>
-                <FieldLabel htmlFor="agent-preset-provider">Provider</FieldLabel>
-                <NativeSelect
-                  id="agent-preset-provider"
-                  value={provider}
-                  onChange={(event) =>
-                    selectProvider(event.currentTarget.value as AgentLlmProvider)
-                  }
-                >
-                  <NativeSelectOption value="openai-ws">OpenAI WebSocket</NativeSelectOption>
-                  <NativeSelectOption value="cloudflare-ai">
-                    Cloudflare AI Gateway
-                  </NativeSelectOption>
-                </NativeSelect>
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="agent-preset-model">Model</FieldLabel>
-                <Input
-                  id="agent-preset-model"
-                  value={model}
-                  onChange={(event) => setModel(event.currentTarget.value)}
-                />
-              </Field>
-            </div>
-
-            {provider === "cloudflare-ai" ? (
-              <Field>
-                <FieldLabel htmlFor="agent-preset-run-opts">Run options JSON</FieldLabel>
-                <Textarea
-                  id="agent-preset-run-opts"
-                  className="min-h-20 font-mono text-xs"
-                  value={runOpts}
-                  onChange={(event) => setRunOpts(event.currentTarget.value)}
-                />
-              </Field>
-            ) : null}
-
-            <Field>
-              <FieldLabel htmlFor="agent-preset-system-prompt">System prompt</FieldLabel>
-              <Textarea
-                id="agent-preset-system-prompt"
-                className="min-h-32 font-mono text-xs"
-                value={systemPrompt}
-                onChange={(event) => setSystemPrompt(event.currentTarget.value)}
-              />
-            </Field>
-
-            <Field>
-              <FieldLabel htmlFor="agent-preset-custom-events">Custom events</FieldLabel>
-              <SourceCodeBlock
-                code={customEventsYaml}
-                className="min-h-44"
-                editable
-                language="yaml"
-                onChange={setCustomEventsYaml}
-              />
-              <FieldDescription>
-                YAML array of extra EventInput objects appended after provider setup.
-              </FieldDescription>
-            </Field>
-          </FieldGroup>
-        </div>
-
-        <aside className="min-h-[42rem] space-y-3">
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div className="space-y-1">
-              <p className="text-sm font-semibold">Preset event preview</p>
-              <p className="text-sm text-muted-foreground">
-                YAML preview of events saved for {preview.basePath}.
-              </p>
-            </div>
-            <Button onClick={submit} disabled={savePreset.isPending || preview.error != null}>
-              <Save className="size-4" />
-              {savePreset.isPending ? "Saving..." : "Save preset"}
-            </Button>
-          </div>
-
-          {preview.error ? (
-            <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
-              {preview.error}
-            </div>
-          ) : (
-            <SerializedObjectCodeBlock
-              data={preview.events}
-              className="h-[42rem]"
-              initialFormat="yaml"
-              showToggle
-            />
-          )}
-        </aside>
-      </div>
-    </section>
+    <AgentSetupFormPage
+      title="New Agent Preset"
+      description="Assemble the events that will seed matching agent streams."
+      idPrefix="agent-preset"
+      pathLabel="Path prefix"
+      pathPlaceholder="/agents"
+      initialPathInput="/agents"
+      customEventsDescription="YAML array of extra EventInput objects appended after provider setup."
+      buildPreview={buildPresetPreview}
+      previewTitle="Preset event preview"
+      previewDescription={(preview) => `YAML preview of events saved for ${preview.basePath}.`}
+      submitIcon={<Save className="size-4" />}
+      submitIdleLabel="Save preset"
+      submitPendingLabel="Saving..."
+      isPending={savePreset.isPending}
+      onSubmit={(input) => savePreset.mutate(input)}
+    />
   );
 }
 
-function buildPresetPreview(input: {
-  basePathInput: string;
-  customEventsYaml: string;
-  model: string;
-  provider: AgentLlmProvider;
-  runOpts: string;
-  systemPrompt: string;
-}): {
-  basePath: StreamPath;
-  customEvents: AgentPresetEvent[];
-  error?: string;
-  events: EventInput[];
-} {
+function buildPresetPreview(values: AgentSetupFormValues): PresetPreview {
   let basePath = StreamPath.parse("/agents");
   try {
-    basePath = normalizeAgentPresetBasePath(input.basePathInput);
-    if (input.model.trim() === "") throw new Error("Model is required.");
-    if (input.systemPrompt.trim() === "") throw new Error("System prompt is required.");
-    const customEvents = parseAgentPresetEventsYaml(input.customEventsYaml);
-    const runOpts = input.provider === "cloudflare-ai" ? parseAgentRunOptsJson(input.runOpts) : {};
+    basePath = normalizeAgentPresetBasePath(values.pathInput);
+    if (values.model.trim() === "") throw new Error("Model is required.");
+    if (values.systemPrompt.trim() === "") throw new Error("System prompt is required.");
+    const customEvents = parseAgentPresetEventsYaml(values.customEventsYaml);
+    const runOpts =
+      values.provider === "cloudflare-ai" ? parseAgentRunOptsJson(values.runOpts) : {};
 
     return {
       basePath,
       customEvents,
       events: [
         ...configuredAgentSetupEvents({
-          model: input.model.trim(),
-          provider: input.provider,
+          model: values.model.trim(),
+          provider: values.provider,
           runOpts,
-          systemPrompt: input.systemPrompt.trim(),
+          systemPrompt: values.systemPrompt.trim(),
         }),
         ...customEvents,
       ],

--- a/apps/os/src/routes/_app/projects/$projectSlug/agents/new.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/agents/new.tsx
@@ -1,23 +1,11 @@
-import { useCallback, useMemo, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Play } from "lucide-react";
 import { EventInput, StreamPath } from "@iterate-com/shared/streams/types";
-import { Button } from "@iterate-com/ui/components/button";
-import { Field, FieldDescription, FieldGroup, FieldLabel } from "@iterate-com/ui/components/field";
-import { Input } from "@iterate-com/ui/components/input";
-import { NativeSelect, NativeSelectOption } from "@iterate-com/ui/components/native-select";
-import { SerializedObjectCodeBlock } from "@iterate-com/ui/components/serialized-object-code-block";
 import { toast } from "@iterate-com/ui/components/sonner";
-import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
-import { Textarea } from "@iterate-com/ui/components/textarea";
+import { AgentSetupFormPage, type AgentSetupFormValues } from "~/components/agent-setup-form.tsx";
 import {
-  type AgentLlmProvider,
-  DEFAULT_AGENT_LLM_PROVIDER,
-  DEFAULT_CLOUDFLARE_AGENT_MODEL,
-  DEFAULT_OPENAI_AGENT_MODEL,
   configuredAgentSetupEvents,
-  defaultAgentSystemPrompt,
   parseAgentEventInputsYaml,
   parseAgentRunOptsJson,
 } from "~/domains/agents/agent-presets.ts";
@@ -27,8 +15,6 @@ import {
 } from "~/domains/agents/agent-stream-subscriptions.ts";
 import { agentPathFromInput } from "~/lib/agent-links.ts";
 import { orpcClient } from "~/orpc/client.ts";
-
-const emptyEventsYaml = "[]\n";
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/agents/new")({
   loader: async ({ context }) => {
@@ -42,41 +28,24 @@ export const Route = createFileRoute("/_app/projects/$projectSlug/agents/new")({
   component: NewAgentPage,
 });
 
+type NewAgentPreview = { agentPath: StreamPath; error?: string; events: EventInput[] };
+
 function NewAgentPage() {
   const params = Route.useParams();
   const { project } = Route.useLoaderData();
   const navigate = useNavigate();
-  const [agentPathInput, setAgentPathInput] = useState("/agents/assistant");
-  const [provider, setProvider] = useState<AgentLlmProvider>(DEFAULT_AGENT_LLM_PROVIDER);
-  const [model, setModel] = useState(DEFAULT_OPENAI_AGENT_MODEL);
-  const [runOpts, setRunOpts] = useState('{"gateway":{"id":"default"}}');
-  const [systemPrompt, setSystemPrompt] = useState(defaultAgentSystemPrompt());
-  const [customEventsYaml, setCustomEventsYaml] = useState(emptyEventsYaml);
-
-  const preview = useMemo(
-    () =>
-      buildPreviewEvents({
-        agentPathInput,
-        customEventsYaml,
-        model,
-        projectId: project.id,
-        provider,
-        runOpts,
-        systemPrompt,
-      }),
-    [agentPathInput, customEventsYaml, model, project.id, provider, runOpts, systemPrompt],
-  );
 
   const createAgent = useMutation({
-    mutationFn: async () => {
+    mutationFn: async (preview: NewAgentPreview) => {
       if (preview.error) throw new Error(preview.error);
-      return await orpcClient.project.streams.appendBatch({
+      await orpcClient.project.streams.appendBatch({
         events: preview.events,
         projectSlugOrId: project.id,
         streamPath: preview.agentPath,
       });
+      return preview;
     },
-    onSuccess: () => {
+    onSuccess: (preview) => {
       void navigate({
         to: "/projects/$projectSlug/agents/streams/$",
         params: {
@@ -88,157 +57,42 @@ function NewAgentPage() {
     onError: (error) => toast.error(error instanceof Error ? error.message : String(error)),
   });
 
-  const submit = useCallback(() => {
-    createAgent.mutate();
-  }, [createAgent]);
-
-  function selectProvider(nextProvider: AgentLlmProvider) {
-    setProvider(nextProvider);
-    setModel((current) => {
-      if (nextProvider === "openai-ws" && current === DEFAULT_CLOUDFLARE_AGENT_MODEL) {
-        return DEFAULT_OPENAI_AGENT_MODEL;
-      }
-      if (nextProvider === "cloudflare-ai" && current === DEFAULT_OPENAI_AGENT_MODEL) {
-        return DEFAULT_CLOUDFLARE_AGENT_MODEL;
-      }
-      return current;
-    });
-  }
-
   return (
-    <section className="w-full max-w-7xl space-y-4 p-4">
-      <div className="space-y-1">
-        <h2 className="text-sm font-semibold">New Agent</h2>
-        <p className="text-sm text-muted-foreground">
-          Assemble the events that will be appended to the agent stream.
-        </p>
-      </div>
-
-      <div className="grid min-h-0 gap-4 xl:grid-cols-[minmax(0,0.95fr)_minmax(440px,1.05fr)]">
-        <div className="space-y-4">
-          <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="agent-path">Agent path</FieldLabel>
-              <Input
-                id="agent-path"
-                value={agentPathInput}
-                onChange={(event) => setAgentPathInput(event.currentTarget.value)}
-                placeholder="/agents/assistant"
-              />
-            </Field>
-
-            <div className="grid gap-3 md:grid-cols-[14rem_minmax(0,1fr)]">
-              <Field>
-                <FieldLabel htmlFor="agent-provider">Provider</FieldLabel>
-                <NativeSelect
-                  id="agent-provider"
-                  value={provider}
-                  onChange={(event) =>
-                    selectProvider(event.currentTarget.value as AgentLlmProvider)
-                  }
-                >
-                  <NativeSelectOption value="openai-ws">OpenAI WebSocket</NativeSelectOption>
-                  <NativeSelectOption value="cloudflare-ai">
-                    Cloudflare AI Gateway
-                  </NativeSelectOption>
-                </NativeSelect>
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="agent-model">Model</FieldLabel>
-                <Input
-                  id="agent-model"
-                  value={model}
-                  onChange={(event) => setModel(event.currentTarget.value)}
-                />
-              </Field>
-            </div>
-
-            {provider === "cloudflare-ai" ? (
-              <Field>
-                <FieldLabel htmlFor="agent-run-opts">Run options JSON</FieldLabel>
-                <Textarea
-                  id="agent-run-opts"
-                  className="min-h-20 font-mono text-xs"
-                  value={runOpts}
-                  onChange={(event) => setRunOpts(event.currentTarget.value)}
-                />
-              </Field>
-            ) : null}
-
-            <Field>
-              <FieldLabel htmlFor="agent-system-prompt">System prompt</FieldLabel>
-              <Textarea
-                id="agent-system-prompt"
-                className="min-h-32 font-mono text-xs"
-                value={systemPrompt}
-                onChange={(event) => setSystemPrompt(event.currentTarget.value)}
-              />
-            </Field>
-
-            <Field>
-              <FieldLabel htmlFor="agent-custom-events">Custom events</FieldLabel>
-              <SourceCodeBlock
-                code={customEventsYaml}
-                className="min-h-44"
-                editable
-                language="yaml"
-                onChange={setCustomEventsYaml}
-              />
-              <FieldDescription>
-                YAML array of EventInput objects appended before tool-provider registrations.
-              </FieldDescription>
-            </Field>
-          </FieldGroup>
-        </div>
-
-        <aside className="min-h-[42rem] space-y-3">
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div className="space-y-1">
-              <p className="text-sm font-semibold">Event preview</p>
-              <p className="text-sm text-muted-foreground">
-                YAML preview of events appendBatch will append to {preview.agentPath}.
-              </p>
-            </div>
-            <Button onClick={submit} disabled={createAgent.isPending || preview.error != null}>
-              <Play className="size-4" />
-              {createAgent.isPending ? "Creating..." : "Create agent"}
-            </Button>
-          </div>
-
-          {preview.error ? (
-            <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
-              {preview.error}
-            </div>
-          ) : (
-            <SerializedObjectCodeBlock
-              data={preview.events}
-              className="h-[42rem]"
-              initialFormat="yaml"
-              showToggle
-            />
-          )}
-        </aside>
-      </div>
-    </section>
+    <AgentSetupFormPage
+      title="New Agent"
+      description="Assemble the events that will be appended to the agent stream."
+      idPrefix="agent"
+      pathLabel="Agent path"
+      pathPlaceholder="/agents/assistant"
+      initialPathInput="/agents/assistant"
+      customEventsDescription="YAML array of EventInput objects appended before tool-provider registrations."
+      buildPreview={(values) => buildPreviewEvents({ projectId: project.id, values })}
+      previewTitle="Event preview"
+      previewDescription={(preview) =>
+        `YAML preview of events appendBatch will append to ${preview.agentPath}.`
+      }
+      submitIcon={<Play className="size-4" />}
+      submitIdleLabel="Create agent"
+      submitPendingLabel="Creating..."
+      isPending={createAgent.isPending}
+      onSubmit={({ preview }) => createAgent.mutate(preview)}
+    />
   );
 }
 
 function buildPreviewEvents(input: {
-  agentPathInput: string;
-  customEventsYaml: string;
-  model: string;
   projectId: string;
-  provider: AgentLlmProvider;
-  runOpts: string;
-  systemPrompt: string;
-}): { agentPath: StreamPath; error?: string; events: EventInput[] } {
+  values: AgentSetupFormValues;
+}): NewAgentPreview {
+  const { values } = input;
   let agentPath = StreamPath.parse("/agents/assistant");
   try {
-    agentPath = agentPathFromInput(input.agentPathInput);
-    if (input.model.trim() === "") throw new Error("Model is required.");
-    if (input.systemPrompt.trim() === "") throw new Error("System prompt is required.");
-    const customEvents = parseAgentEventInputsYaml(input.customEventsYaml);
-    const runOpts = input.provider === "cloudflare-ai" ? parseAgentRunOptsJson(input.runOpts) : {};
+    agentPath = agentPathFromInput(values.pathInput);
+    if (values.model.trim() === "") throw new Error("Model is required.");
+    if (values.systemPrompt.trim() === "") throw new Error("System prompt is required.");
+    const customEvents = parseAgentEventInputsYaml(values.customEventsYaml);
+    const runOpts =
+      values.provider === "cloudflare-ai" ? parseAgentRunOptsJson(values.runOpts) : {};
 
     // Tool capabilities are no longer compiled into stream events here: the
     // Agent Durable Object seeds its itx context (and the matching
@@ -248,14 +102,14 @@ function buildPreviewEvents(input: {
       events: [
         ...configuredAgentSetupEvents({
           idempotencyKeyPrefix: "os-agent-new:setup",
-          model: input.model.trim(),
-          provider: input.provider,
+          model: values.model.trim(),
+          provider: values.provider,
           runOpts,
-          systemPrompt: input.systemPrompt.trim(),
+          systemPrompt: values.systemPrompt.trim(),
         }),
         ...agentProcessorSubscriptionConfiguredEvents({
           agentPath,
-          processorSlugs: defaultAgentProcessorSlugs(input.provider),
+          processorSlugs: defaultAgentProcessorSlugs(values.provider),
           projectId: input.projectId,
         }),
         ...customEvents,


### PR DESCRIPTION
The last batch of outstanding work from the agents audit (after #1460, #1475, #1483): the section-3 dead-code sweep and the UI shrink. Net **−188 lines** (−503/+315).

## One agent setup form

`agents/new.tsx` and `agents/new-preset.tsx` were ~270-line, ~90%-identical forms (provider/model/runOpts/system-prompt/custom-events fields plus the YAML preview pane). They now share one `AgentSetupFormPage` component; each route keeps only what genuinely differs — its path normalization, its preview builder, and its submit mutation:

```tsx
<AgentSetupFormPage
  title="New Agent"
  pathLabel="Agent path"
  buildPreview={(values) => buildPreviewEvents({ projectId: project.id, values })}
  submitIdleLabel="Create agent"
  isPending={createAgent.isPending}
  onSubmit={({ preview }) => createAgent.mutate(preview)}
  ...
/>
```

The routes drop from ~270 lines each to ~125, and the next form tweak happens once instead of twice.

## Legacy Slack preset filter deleted

`agent-presets.ts` carried `isLegacyGeneratedSlackOpenAiPreset` — a content-sniffing filter that suppressed an old auto-generated `/agents/slack` preset by matching its system-prompt text. Checked prd before deleting: the iterate project has **zero** stored presets, so the filter guards nothing. The intentional behavior next to it (Slack agents never inherit the generic `/agents` preset) stays, with its tests.

## Stale migration headers

Every processor under `apps/os/src/domains/{agents,slack}/stream-processors/` opened with "Migrated from `packages/shared/src/stream-processors/...`" — a directory that no longer exists. Those provenance paragraphs are gone. Where they carried a live constraint, the constraint survives in its own words:

```ts
// Appended event types, payload shapes, and idempotency-key derivations
// (`agent/<key>@<sourceOffset>`) are stable wire formats — changing them
// breaks dedup against events already committed to streams.
```

## Audit bug status (no code change needed)

- **2.4 zombie `pendingTriggerCount`** — fixed by construction since #1460: the reconcilers guarantee dangling requests reach a terminal event, and a queued count only ever represents real user inputs whose follow-up turn rebuilds from full history.
- **2.3 cancellation check-then-act race** — still a theoretical window; closing it needs conditional appends (append-if-still-current at the stream layer), which is its own design, not a cleanup.

`pnpm typecheck && pnpm lint && pnpm format && pnpm test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI deduplication and comment edits; Slack preset selection is slightly broader if old auto-generated presets exist in storage, which the PR assumes is empty.
> 
> **Overview**
> Introduces **`AgentSetupFormPage`** so **New Agent** and **New Agent Preset** share one form (provider, model, run options, system prompt, custom events YAML, live preview). Each route only keeps path handling, its preview builder, and submit logic—roughly halving page size.
> 
> **Removes** the legacy **`isLegacyGeneratedSlackOpenAiPreset`** filter and its test from `agent-presets.ts`. Slack agents still only match Slack-scoped presets; stored `/agents/slack` presets are no longer sniffed and ignored by prompt text.
> 
> **Trims** stale “migrated from `packages/shared`…” headers across agent and Slack stream-processor modules, leaving short notes where wire formats and idempotency keys must stay stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9cf738e2dad4877de8286cf370cf50cedd81eeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-10T22:27:04.770Z",
      "headSha": "c9cf738e2dad4877de8286cf370cf50cedd81eeb",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27310094398",
      "shortSha": "c9cf738"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `c9cf738`
Preview: https://os.iterate-preview-4.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27310094398)
Updated: 2026-06-10T22:27:04.770Z
<!-- /CLOUDFLARE_PREVIEW -->