### PR TITLE
auth: internal mint-project-id endpoint (prerequisite for #1485)

### DIFF
--- a/apps/auth-contract/src/index.ts
+++ b/apps/auth-contract/src/index.ts
@@ -459,6 +459,15 @@ export const authContract = oc.router({
         })
         .input(InternalCreateProjectForOrganizationInput)
         .output(ProjectRecord),
+      mintProjectId: oc
+        .route({
+          method: "POST",
+          path: "/internal/project/mint-project-id",
+          summary:
+            "Mint a canonical project id (prj_) without creating an auth-side project — for OS operator/recovery creates with no owning organization",
+          tags: ["internal", "project"],
+        })
+        .output(z.object({ id: z.string() })),
     },
     session: {
       createProjectIngressToken: oc

--- a/apps/auth/src/server/orpc/routers/internal.ts
+++ b/apps/auth/src/server/orpc/routers/internal.ts
@@ -177,6 +177,13 @@ const members = os.internal.organization.members
     }));
   });
 
+// Auth is the canonical minter of the prj_ id space. OS calls this for the
+// operator/recovery create path (no owning organization), so even org-less
+// projects get auth-minted ids and OS never mints locally.
+const mintProjectId = os.internal.project.mintProjectId
+  .use(serviceMiddleware)
+  .handler(async () => ({ id: generateId("prj") }));
+
 const createForOrganization = os.internal.project.createForOrganization
   .use(serviceMiddleware)
   .handler(async ({ context, input }) => {
@@ -458,6 +465,7 @@ export const internal = os.internal.router({
   },
   project: {
     createForOrganization,
+    mintProjectId,
   },
   session: {
     createProjectIngressToken,


### PR DESCRIPTION
## What

Adds `POST /internal/project/mint-project-id` (service middleware) to the auth worker + contract: mints a canonical `prj_` id without creating an auth-side project record.

## Why

#1485 makes auth the ONLY minter of the `prj_` id space — OS's operator/recovery create path round-trips through this endpoint instead of minting locally. Previews point at production auth, so this must deploy from main BEFORE #1485 can pass preview e2e (its preview run currently 404s on this route).

Purely additive — extracted verbatim from #1485; nothing calls it until that PR lands.

## Testing

- `apps/auth` + `apps/auth-contract` typecheck green.
- Exercised end-to-end by #1485's preview e2e once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive internal route behind existing service auth; no DB writes and no production callers until a dependent PR lands.
> 
> **Overview**
> Adds a **service-only** internal API so auth can hand out canonical `prj_*` ids **without** creating an auth project row—intended for OS operator/recovery creates that have no owning organization.
> 
> The **auth-contract** defines `POST /internal/project/mint-project-id` (no input; `{ id: string }` output). The **auth worker** implements it behind `serviceMiddleware`, returning `generateId("prj")` and registers `mintProjectId` on the internal project router. Nothing in this PR calls the route yet; follow-up work will route OS minting through auth instead of local id generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 211c08a5d8212f4ae82f5999318ad76f9dfe1a59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-11T06:33:02.060Z",
      "headSha": "211c08a5d8212f4ae82f5999318ad76f9dfe1a59",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27328011383",
      "shortSha": "211c08a"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `211c08a`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27328011383)
Updated: 2026-06-11T06:33:02.060Z
<!-- /CLOUDFLARE_PREVIEW -->