### PR TITLE
Slack latency: 3× smaller worker script, append-only webhook ack, eyes at the routing hop, pre-warmed hosts

### DIFF
--- a/apps/os/src/domains/secrets/integration-api.ts
+++ b/apps/os/src/domains/secrets/integration-api.ts
@@ -318,7 +318,6 @@ async function handleVerifiedSlackWebhook(input: {
     ensureReady(): Promise<unknown>;
     initialize(input: { name: string }): Promise<unknown>;
   };
-  await slackIntegration.initialize({ name: slackIntegrationName });
 
   const stream = await getInitializedStreamStub({
     durableObjectNamespace: env.STREAM as never,
@@ -342,8 +341,18 @@ async function handleVerifiedSlackWebhook(input: {
       body: payload,
     },
   });
+  // Only the durable append gates the 200: Slack retries webhooks that take
+  // longer than ~3s, and awaiting the integration DO's initialize here used to
+  // serialize a cold DO chain ahead of the ack (observed at 8s in prd, with
+  // the retry queueing behind the same cold gate). Initialization is
+  // order-independent: an existing integration already has its
+  // subscription-configured event on the stream, and a brand-new one picks the
+  // webhook up via replay once the background initialize lands it.
   input.context.waitUntil?.(
-    slackIntegration.ensureReady().catch((error) => {
+    (async () => {
+      await slackIntegration.initialize({ name: slackIntegrationName });
+      await slackIntegration.ensureReady();
+    })().catch((error) => {
       console.error("[slack-integration-webhook] background catch-up failed", error);
     }),
   );

--- a/apps/os/src/domains/slack/durable-objects/slack-integration-durable-object.ts
+++ b/apps/os/src/domains/slack/durable-objects/slack-integration-durable-object.ts
@@ -18,10 +18,12 @@ import { type AgentDurableObject } from "~/domains/agents/durable-objects/agent-
 import {
   AGENT_HOST_PROCESSOR_SLUG,
   agentProcessorSubscriptionConfiguredEvent,
+  getAgentDurableObjectName,
 } from "~/domains/agents/agent-stream-subscriptions.ts";
 import { SLACK_INTEGRATION_STREAM_PATH } from "~/domains/secrets/integration-streams.ts";
 import {
   getSlackAgentDurableObjectName,
+  readSlackToken,
   type SlackAgentDurableObject,
 } from "~/domains/slack/durable-objects/slack-agent-durable-object.ts";
 import {
@@ -29,6 +31,8 @@ import {
   SlackProcessorContract,
 } from "~/domains/slack/stream-processors/slack/implementation.ts";
 import { SlackAgentProcessorContract } from "~/domains/slack/stream-processors/slack-agent/contract.ts";
+import { eyesReactionTargetFromWebhookPayload } from "~/domains/slack/stream-processors/slack-agent/implementation.ts";
+import { callSlackWebApi } from "~/domains/slack/entrypoints/slack-capability.ts";
 import { resolveStreamPath } from "~/domains/streams/entrypoints/streams-capability.ts";
 
 export { getSlackIntegrationDurableObjectName };
@@ -48,8 +52,10 @@ export function getSlackIntegrationStub(projectId: string) {
 
 type SlackIntegrationEnv = {
   AGENT: DurableObjectNamespace<AgentDurableObject>;
+  APP_CONFIG_SLACK_BOT_TOKEN?: string;
   DO_CATALOG: D1Database;
   SLACK_AGENT: DurableObjectNamespace<SlackAgentDurableObject>;
+  SLACK_BOT_TOKEN?: string;
   STREAM: DurableObjectNamespace<StreamDurableObject>;
 };
 
@@ -80,6 +86,49 @@ export class SlackIntegrationDurableObject extends SlackIntegrationLifecycleBase
           slackAgentDurableObjectName: "",
           streamPath,
         });
+      },
+      acknowledgeRoutedWebhook: async ({ payload }) => {
+        const ack = eyesReactionTargetFromWebhookPayload(payload);
+        if (ack == null) return;
+        const { projectId } = await this.ensureStartedOrInitializeFromRuntimeName();
+        const token = await readSlackToken({ db: this.env.DO_CATALOG, env: this.env, projectId });
+        if (!token) return;
+        try {
+          await callSlackWebApi({
+            body: { channel: ack.channel, name: "eyes", timestamp: ack.timestamp },
+            method: "reactions.add",
+            token,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          // The slack-agent processor adds the same reaction once the routed
+          // stream catches up; whichever lands second dedups here.
+          if (message.includes("already_reacted") || message.includes("not_reactable")) return;
+          console.error("[slack-integration] routed-webhook acknowledgement failed", {
+            error,
+            projectId,
+          });
+        }
+      },
+      prewarmRoutedStreamHosts: async ({ streamPath }) => {
+        const { projectId } = await this.ensureStartedOrInitializeFromRuntimeName();
+        const resolvedStreamPath = resolveStreamPath(streamPath);
+        const slackAgentName = getSlackAgentDurableObjectName({
+          projectId,
+          streamPath: resolvedStreamPath,
+        });
+        const agentName = getAgentDurableObjectName({
+          agentPath: resolvedStreamPath,
+          projectId,
+        });
+        // initialize() runs each host's full wake hook (agent setup events,
+        // subscriptions, itx context) concurrently with the thread stream's
+        // bootstrap append. Everything either side appends is idempotency-
+        // keyed and order-independent, so whichever wins the race dedups.
+        await Promise.all([
+          this.env.SLACK_AGENT.getByName(slackAgentName).initialize({ name: slackAgentName }),
+          this.env.AGENT.getByName(agentName).initialize({ name: agentName }),
+        ]);
       },
     });
   });

--- a/apps/os/src/domains/slack/stream-processors/slack-agent/implementation.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack-agent/implementation.ts
@@ -416,6 +416,30 @@ function slackAgentTargetFromWebhookPayload(payload: unknown): SlackAgentTarget 
   };
 }
 
+/**
+ * Payload-only gate for the integration-level fast acknowledgement: the 👀
+ * reaction added at the routing hop, before the routed thread stream and its
+ * slack-agent host even exist. Mirrors `#addEyesReactionForMessageTarget`'s
+ * gating using only what the webhook itself carries — bot-authored messages,
+ * reaction events, and actions performed by the authorized bot user are
+ * skipped. The slack-agent processor still adds the same reaction once the
+ * routed stream catches up; Slack's `already_reacted` makes the pair
+ * idempotent.
+ */
+export function eyesReactionTargetFromWebhookPayload(
+  payload: unknown,
+): { channel: string; timestamp: string } | null {
+  const target = slackAgentTargetFromWebhookPayload(payload);
+  if (target == null || target.isBotMessage || target.isReactionEvent) return null;
+  if (target.messageTs == null) return null;
+  const body = readRecord(readRecord(payload)?.body);
+  const slackEvent = readRecord(body?.event);
+  const eventUserId = readString(slackEvent?.user);
+  const botUserId = botUserIdFromPayload(payload);
+  if (eventUserId != null && botUserId != null && eventUserId === botUserId) return null;
+  return { channel: target.channel, timestamp: target.messageTs };
+}
+
 function slackAgentStatusForEvent(event: { payload: unknown; type: string }): {
   clear: boolean;
   status: { loading_messages?: string[]; status: string };

--- a/apps/os/src/domains/slack/stream-processors/slack-agent/slack-agent.test.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack-agent/slack-agent.test.ts
@@ -3,7 +3,71 @@
 
 import { describe, expect, it } from "vitest";
 import type { StreamEvent, StreamEventInput } from "@iterate-com/streams/shared/event";
-import { SlackAgentProcessor, type SlackAgentProcessorDeps } from "./implementation.ts";
+import {
+  SlackAgentProcessor,
+  eyesReactionTargetFromWebhookPayload,
+  type SlackAgentProcessorDeps,
+} from "./implementation.ts";
+
+describe("eyesReactionTargetFromWebhookPayload", () => {
+  const humanMessagePayload = (event: Record<string, unknown> = {}) => ({
+    slackTeamId: "T1",
+    body: {
+      type: "event_callback",
+      authorizations: [{ is_bot: true, user_id: "U_BOT", bot_id: "B_BOT" }],
+      event: {
+        type: "message",
+        channel: "C123",
+        channel_type: "channel",
+        user: "U_HUMAN",
+        ts: "1772136259.000000",
+        text: "hello",
+        ...event,
+      },
+    },
+  });
+
+  it("targets human messages", () => {
+    expect(eyesReactionTargetFromWebhookPayload(humanMessagePayload())).toEqual({
+      channel: "C123",
+      timestamp: "1772136259.000000",
+    });
+  });
+
+  it("skips bot-authored messages", () => {
+    expect(
+      eyesReactionTargetFromWebhookPayload(humanMessagePayload({ bot_id: "B_OTHER" })),
+    ).toBeNull();
+    expect(
+      eyesReactionTargetFromWebhookPayload(humanMessagePayload({ subtype: "bot_message" })),
+    ).toBeNull();
+  });
+
+  it("skips actions performed by the authorized bot user", () => {
+    expect(eyesReactionTargetFromWebhookPayload(humanMessagePayload({ user: "U_BOT" }))).toBeNull();
+  });
+
+  it("skips reaction events", () => {
+    expect(
+      eyesReactionTargetFromWebhookPayload({
+        slackTeamId: "T1",
+        body: {
+          type: "event_callback",
+          event: {
+            type: "reaction_added",
+            user: "U_HUMAN",
+            reaction: "eyes",
+            item: { type: "message", channel: "C123", ts: "1772136259.000000" },
+          },
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("skips payloads without a message timestamp", () => {
+    expect(eyesReactionTargetFromWebhookPayload({ body: { event: {} } })).toBeNull();
+  });
+});
 
 describe("SlackAgentProcessor", () => {
   it("reduces Slack route context", async () => {

--- a/apps/os/src/domains/slack/stream-processors/slack/implementation.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack/implementation.ts
@@ -26,6 +26,24 @@ export type SlackProcessorDeps = {
     streamPath: string;
     threadTs: string;
   }): Promise<StreamEventInput[]> | StreamEventInput[];
+  /**
+   * Acknowledge a routed webhook to the source platform (e.g. the 👀
+   * reaction) as soon as the router has decided where it goes, instead of
+   * waiting for the routed stream's own processors to wake — several Durable
+   * Object cold starts later on a fresh thread. The host owns filtering
+   * (which webhooks deserve an ack) and delivery; the router only reports
+   * "this webhook is being forwarded". Best-effort: failures must not affect
+   * routing.
+   */
+  acknowledgeRoutedWebhook?(input: { payload: unknown }): Promise<void> | void;
+  /**
+   * Pre-warm the Durable Objects that will subscribe to a newly routed
+   * stream, concurrently with the bootstrap append that creates it. Without
+   * this the chain is serial: thread stream cold start, then its dial wakes
+   * the slack-agent host, then the agent host — each a fresh isolate.
+   * Best-effort: the subscription dial remains the source of truth.
+   */
+  prewarmRoutedStreamHosts?(input: { streamPath: string }): Promise<void> | void;
 };
 
 export class SlackProcessor extends StreamProcessor<SlackProcessorContract, SlackProcessorDeps> {
@@ -93,6 +111,12 @@ export class SlackProcessor extends StreamProcessor<SlackProcessorContract, Slac
     const streamPath = state.routes[route.key] ?? route.streamPath;
     if (streamPath == null) return;
 
+    // Independent of the forwarding appends below so the user-visible ack
+    // races ahead of (possibly cold) stream creation rather than behind it.
+    args.runInBackground(async () => {
+      await this.deps.acknowledgeRoutedWebhook?.({ payload: event.payload });
+    });
+
     const forwardedWebhookEvent: StreamEventInput = {
       type: "events.iterate.com/slack/webhook-received",
       idempotencyKey: buildProcessorIdempotencyKey({
@@ -118,6 +142,11 @@ export class SlackProcessor extends StreamProcessor<SlackProcessorContract, Slac
           streamPath,
         },
       };
+      // The hosts that will subscribe to the new stream cold-start in
+      // parallel with its creation instead of serially after its first dial.
+      args.runInBackground(async () => {
+        await this.deps.prewarmRoutedStreamHosts?.({ streamPath });
+      });
       // Every append carries an idempotency key derived from the source event,
       // so replays after a re-handshake dedupe instead of double-forwarding.
       args.runInBackground(async () => {

--- a/apps/os/src/domains/slack/stream-processors/slack/slack.test.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack/slack.test.ts
@@ -186,6 +186,85 @@ describe("SlackProcessor", () => {
     expect(appended).toEqual([]);
   });
 
+  it("acknowledges routed webhooks and pre-warms hosts for new routes", async () => {
+    const acknowledged: unknown[] = [];
+    const prewarmed: string[] = [];
+    const { processor } = createProcessor({
+      createRoutedStreamBootstrapEvents: () => [],
+      acknowledgeRoutedWebhook: ({ payload }) => {
+        acknowledged.push(payload);
+      },
+      prewarmRoutedStreamHosts: ({ streamPath }) => {
+        prewarmed.push(streamPath);
+      },
+    });
+
+    await processor.ingest({
+      events: [webhookEvent({ offset: 7, text: "hello" })],
+      streamMaxOffset: 7,
+    });
+    await flushBackgroundWork();
+
+    expect(acknowledged).toEqual([webhookEvent({ offset: 7, text: "hello" }).payload]);
+    expect(prewarmed).toEqual(["/agents/slack/c123/ts-1772136258-963519"]);
+  });
+
+  it("acknowledges webhooks on existing routes without pre-warming again", async () => {
+    const acknowledged: unknown[] = [];
+    const prewarmed: string[] = [];
+    const { processor } = createProcessor({
+      acknowledgeRoutedWebhook: ({ payload }) => {
+        acknowledged.push(payload);
+      },
+      prewarmRoutedStreamHosts: ({ streamPath }) => {
+        prewarmed.push(streamPath);
+      },
+    });
+
+    await processor.ingest({
+      events: [
+        committedEvent({
+          offset: 3,
+          type: "events.iterate.com/slack/thread-route-configured",
+          payload: {
+            channel: "C123",
+            threadTs: "1772136258.963519",
+            streamPath: "/agents/slack/custom-path",
+          },
+        }),
+        webhookEvent({ offset: 4, text: "again" }),
+      ],
+      streamMaxOffset: 4,
+    });
+    await flushBackgroundWork();
+
+    expect(acknowledged).toHaveLength(1);
+    expect(prewarmed).toEqual([]);
+  });
+
+  it("does not acknowledge unroutable webhooks", async () => {
+    const acknowledged: unknown[] = [];
+    const { processor } = createProcessor({
+      acknowledgeRoutedWebhook: ({ payload }) => {
+        acknowledged.push(payload);
+      },
+    });
+
+    await processor.ingest({
+      events: [
+        committedEvent({
+          offset: 5,
+          type: "events.iterate.com/slack/webhook-received",
+          payload: { body: { type: "url_verification", challenge: "x" } },
+        }),
+      ],
+      streamMaxOffset: 5,
+    });
+    await flushBackgroundWork();
+
+    expect(acknowledged).toEqual([]);
+  });
+
   it("skips side effects for events at or below the side-effect anchor", async () => {
     const { appended, processor } = createProcessor({ sideEffectsAfterOffset: () => 10 });
 

--- a/packages/shared/src/alchemy/iterate-app.ts
+++ b/packages/shared/src/alchemy/iterate-app.ts
@@ -466,7 +466,15 @@ function withSequentialCloudflareAssetPreupload(input: { command: string; worker
   const preuploadScriptPath = fileURLToPath(
     new URL("./preupload-worker-assets.ts", import.meta.url),
   );
+  const pruneScriptPath = fileURLToPath(new URL("./prune-server-bundle.ts", import.meta.url));
 
+  // The prune step keeps the uploaded worker script small: alchemy's noBundle
+  // upload globs everything under dist/server, but the Vite SSR build also
+  // emits browser-only modules (web workers, wasm) the server graph never
+  // imports. Script size is what every cold Durable Object isolate pays to
+  // start, and our request paths chain several DOs — see
+  // prune-server-bundle.ts for the measured impact.
+  //
   // Alchemy's Cloudflare Assets helper currently uploads multiple asset buckets
   // concurrently. The Cloudflare Assets API returns the final completion JWT only
   // from the bucket that completes the upload session, so concurrent buckets can
@@ -476,7 +484,11 @@ function withSequentialCloudflareAssetPreupload(input: { command: string; worker
   // sequentially before Alchemy creates the Worker. Alchemy then opens its own
   // session, sees no remaining buckets, and attaches a stable completion token.
   // https://developers.cloudflare.com/workers/static-assets/direct-upload/
-  return `${input.command} && pnpm exec tsx ${JSON.stringify(preuploadScriptPath)} --worker-name ${JSON.stringify(input.workerName)} --assets ${JSON.stringify("dist/client")}`;
+  return [
+    input.command,
+    `pnpm exec tsx ${JSON.stringify(pruneScriptPath)} --server-dir ${JSON.stringify("dist/server")} --entrypoint ${JSON.stringify("index.js")}`,
+    `pnpm exec tsx ${JSON.stringify(preuploadScriptPath)} --worker-name ${JSON.stringify(input.workerName)} --assets ${JSON.stringify("dist/client")}`,
+  ].join(" && ");
 }
 
 /**

--- a/packages/shared/src/alchemy/prune-server-bundle.test.ts
+++ b/packages/shared/src/alchemy/prune-server-bundle.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, mkdir, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { pruneServerBundle } from "./prune-server-bundle.ts";
+
+describe("pruneServerBundle", () => {
+  it("deletes sourcemaps and modules unreachable from the entrypoint", async () => {
+    const serverDir = await mkdtemp(path.join(tmpdir(), "prune-server-bundle-"));
+    await mkdir(path.join(serverDir, "assets"), { recursive: true });
+
+    await write(serverDir, "index.js", [
+      `import { a } from "./assets/static-chunk.js";`,
+      `const lazy = () => import("./assets/dynamic-chunk.js");`,
+      `export * from "./assets/reexported-chunk.js";`,
+    ]);
+    await write(serverDir, "assets/static-chunk.js", [
+      `import wasmUrl from "./referenced.wasm";`,
+      `export const a = new URL("./url-referenced-chunk.js", import.meta.url);`,
+    ]);
+    await write(serverDir, "assets/dynamic-chunk.js", [`export const d = 1;`]);
+    await write(serverDir, "assets/reexported-chunk.js", [`export const r = 1;`]);
+    await write(serverDir, "assets/url-referenced-chunk.js", [`export const u = 1;`]);
+    await write(serverDir, "assets/referenced.wasm", ["wasm"]);
+    // Browser-only emissions the server graph never imports.
+    await write(serverDir, "assets/browser-worker.js", [`postMessage("hi");`]);
+    await write(serverDir, "assets/browser-only.wasm", ["wasm"]);
+    // Sourcemaps go regardless of reachability.
+    await write(serverDir, "index.js.map", ["{}"]);
+    await write(serverDir, "assets/static-chunk.js.map", ["{}"]);
+    // Non-module files are not the prune's business (the upload ignores them).
+    await write(serverDir, "manifest.json", ["{}"]);
+
+    const result = await pruneServerBundle({ entrypoint: "index.js", serverDir });
+
+    expect(result.deletedModules.sort()).toEqual([
+      "assets/browser-only.wasm",
+      "assets/browser-worker.js",
+    ]);
+    // The entrypoint's own map survives for worker stack-trace symbolication.
+    expect(result.deletedSourcemaps.sort()).toEqual(["assets/static-chunk.js.map"]);
+    expect(result.keptModules).toEqual([
+      "assets/dynamic-chunk.js",
+      "assets/reexported-chunk.js",
+      "assets/referenced.wasm",
+      "assets/static-chunk.js",
+      "assets/url-referenced-chunk.js",
+      "index.js",
+    ]);
+
+    const remaining = (await readdir(serverDir, { recursive: true })).sort();
+    expect(remaining).toContain("manifest.json");
+    expect(remaining).toContain("index.js.map");
+    expect(remaining).not.toContain(path.join("assets", "static-chunk.js.map"));
+    expect(remaining).not.toContain(path.join("assets", "browser-worker.js"));
+  });
+
+  it("throws when the entrypoint is missing instead of deleting everything", async () => {
+    const serverDir = await mkdtemp(path.join(tmpdir(), "prune-server-bundle-"));
+    await write(serverDir, "other.js", [`export const x = 1;`]);
+
+    await expect(pruneServerBundle({ entrypoint: "index.js", serverDir })).rejects.toThrow(
+      /Entrypoint index\.js not found/,
+    );
+  });
+});
+
+async function write(root: string, relativePath: string, lines: string[]) {
+  await writeFile(path.join(root, relativePath), lines.join("\n"));
+}

--- a/packages/shared/src/alchemy/prune-server-bundle.ts
+++ b/packages/shared/src/alchemy/prune-server-bundle.ts
@@ -1,0 +1,123 @@
+import { readFile, readdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Deployed worker size is a latency problem, not just a storage one: every
+// cold Durable Object instantiation loads the full script into a fresh
+// isolate, and our request paths chain several DOs. Alchemy's noBundle upload
+// globs every `.js`/`.mjs`/`.wasm` (and `.js.map`) under the server dist, but
+// the Vite SSR build also emits modules only the BROWSER ever uses (web
+// workers, their wasm) plus sourcemaps for everything. Measured on os prd
+// before pruning: 89 MB uploaded, of which 50 MB sourcemaps and ~5 MB modules
+// unreachable from the entrypoint — against a 34 MB live server graph.
+
+const MODULE_EXTENSIONS = new Set([".js", ".mjs", ".cjs", ".wasm"]);
+
+// Matches the relative specifiers Vite emits: static imports, re-exports,
+// dynamic `import("./…")` literals, and `new URL("./…", import.meta.url)`
+// asset references. Conservative by design — an unmatched dynamic pattern
+// keeps a module only if nothing else references it either.
+const RELATIVE_SPECIFIER_PATTERN =
+  /(?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s+|\bnew\s+URL\s*\(\s*)["'](\.{1,2}\/[^"']+)["']/g;
+
+export type PruneServerBundleResult = {
+  deletedModules: string[];
+  deletedSourcemaps: string[];
+  deletedBytes: number;
+  keptModules: string[];
+};
+
+/**
+ * Deletes from `serverDir` everything the worker upload would include but the
+ * deployed module graph can never load: sourcemaps (uploaded as modules, paid
+ * for on every isolate cold start) and `.js`/`.wasm` files unreachable from
+ * the entrypoint via import/`new URL` literals (browser-only web workers and
+ * their wasm that the SSR build emits alongside the server chunks).
+ *
+ * The entrypoint's own sourcemap survives: it is small, and Cloudflare can use
+ * an uploaded sourcemap module to symbolicate worker stack traces. Chunk maps
+ * are the bulk of the weight and mostly describe browser code, so they go.
+ */
+export async function pruneServerBundle(input: {
+  entrypoint: string;
+  serverDir: string;
+}): Promise<PruneServerBundleResult> {
+  const serverDir = path.resolve(input.serverDir);
+  const entrypointSourcemap = `${normalize(input.entrypoint)}.map`;
+  const files = await listFilesRecursively(serverDir);
+  const modules = files.filter((file) => MODULE_EXTENSIONS.has(path.extname(file)));
+  const sourcemaps = files.filter((file) => file.endsWith(".map") && file !== entrypointSourcemap);
+
+  if (!modules.includes(normalize(input.entrypoint))) {
+    throw new Error(
+      `Entrypoint ${input.entrypoint} not found in ${serverDir} (saw ${String(modules.length)} modules).`,
+    );
+  }
+
+  const moduleSet = new Set(modules);
+  const reachable = new Set<string>();
+  const queue = [normalize(input.entrypoint)];
+  while (queue.length > 0) {
+    const current = queue.pop()!;
+    if (reachable.has(current) || !moduleSet.has(current)) continue;
+    reachable.add(current);
+    if (current.endsWith(".wasm")) continue;
+    const source = await readFile(path.join(serverDir, current), "utf-8");
+    for (const match of source.matchAll(RELATIVE_SPECIFIER_PATTERN)) {
+      queue.push(normalize(path.posix.join(path.posix.dirname(current), match[1]!)));
+    }
+  }
+
+  const deletedModules = modules.filter((file) => !reachable.has(file));
+  let deletedBytes = 0;
+  for (const file of [...deletedModules, ...sourcemaps]) {
+    const filePath = path.join(serverDir, file);
+    deletedBytes += (await readFile(filePath)).byteLength;
+    await rm(filePath);
+  }
+
+  return {
+    deletedModules,
+    deletedSourcemaps: sourcemaps,
+    deletedBytes,
+    keptModules: [...reachable].sort(),
+  };
+}
+
+async function listFilesRecursively(root: string): Promise<string[]> {
+  const entries = await readdir(root, { recursive: true, withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => normalize(path.relative(root, path.join(entry.parentPath, entry.name))));
+}
+
+function normalize(relativePath: string): string {
+  return path.posix.normalize(relativePath.split(path.sep).join("/"));
+}
+
+const isCliInvocation =
+  process.argv[1] != null && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isCliInvocation) {
+  const args = process.argv.slice(2);
+  const readArg = (flag: string) => {
+    const index = args.indexOf(flag);
+    const value = index === -1 ? undefined : args[index + 1];
+    if (!value) throw new Error(`${flag} <value> is required`);
+    return value;
+  };
+  const serverDir = readArg("--server-dir");
+  const result = await pruneServerBundle({
+    entrypoint: readArg("--entrypoint"),
+    serverDir,
+  });
+  console.log(
+    `[prune-server-bundle] ${serverDir}: kept ${String(result.keptModules.length)} modules, ` +
+      `deleted ${String(result.deletedModules.length)} unreachable modules + ` +
+      `${String(result.deletedSourcemaps.length)} sourcemaps ` +
+      `(${(result.deletedBytes / 1e6).toFixed(1)} MB)`,
+  );
+  if (result.deletedModules.length > 0) {
+    console.log(`[prune-server-bundle] unreachable: ${result.deletedModules.join(", ")}`);
+  }
+}


### PR DESCRIPTION
## The problem

A Slack message in prd took **~14s to get the 👀 reaction** and ~20s to get a reply (example: `iterate` project, thread `ts-1781170058-112929`). Hop-by-hop, from the message's Slack `ts`:

| Δ | what happened |
|---|---|
| +0.9s | Slack delivered the webhook — Slack was fast |
| **+6.5s** | nothing of ours executed anywhere: cold instantiation of SlackIntegrationDO + the integration StreamDO (handler: 8.1s wall, **5ms CPU**). Slack's 3s retry queued behind the same gate and doubled the work |
| +2.1s | integration DO init + subscription + append + routing |
| **+3.0s** | cold instantiation of the new thread StreamDO |
| **+1.4s** | cold dial of the SLACK_AGENT host DO → input rendered → eyes at ~14s |
| +6s | LLM leg (openai-ws connect 1.1s, gpt-5.5 ~2s, itx exec) → reply at ~20s |

Two multiplying causes: **the deployed script was 89.1 MB** (50 MB sourcemaps + browser-only modules uploaded as worker modules by alchemy's noBundle glob over `dist/server`; the live server graph is ~34 MB, the entrypoint 1.75 MB) — and every cold DO isolate loads all of it — times **3–4 distinct DOs chained serially** on the webhook path. The warm path was always fine (webhook 1–6ms, appends 20–100ms): this is cold-start tax, not stream-architecture tax.

## The fixes (no change to the streams/processors idea)

1. **`prune-server-bundle.ts`** (runs between build and asset preupload): deletes every `dist/server` module unreachable from the entrypoint via import/`new URL` literals (browser web workers + their wasm that the SSR build emits), plus all sourcemaps **except the entrypoint's own** (small; the one Cloudflare can symbolicate worker stack traces with — chunk maps are browser code and pure ballast inside a worker script). Validated against the extracted prd bundle: keeps exactly the 186-module live graph, deletes the 3 browser-only modules + chunk maps.
2. **Append-only webhook ack**: the handler no longer awaits `SlackIntegrationDO.initialize()` before responding — only the durable append gates the 200; initialize + catch-up moved to `waitUntil`. Order-independent (existing integrations have their subscription on the stream; new ones pick the webhook up via replay). Stops the >3s Slack retry storm.
3. **👀 at the routing hop**: the slack router reports routed webhooks to its host (`acknowledgeRoutedWebhook`) and SlackIntegrationDO adds the reaction immediately — one hop from ingress instead of three cold DO hops downstream — gated by the same payload-only rules the slack-agent applies (no bot messages, no reaction events, no bot-user actions). slack-agent still adds it on catch-up; `already_reacted` makes the pair idempotent.
4. **Pre-warmed hosts** (`prewarmRoutedStreamHosts`): for a newly routed thread, the SLACK_AGENT and AGENT host DOs `initialize()` concurrently with the bootstrap append instead of serially after each dial. Everything either side appends is idempotency-keyed and order-independent (the anchor-skip recovery from #1481 covers trigger ordering).

## Measured

Dev-stage deploys of this branch (`os-dev-jonas`):

- prd today: **89.1 MB**
- this branch pre-#1486 baseline: **34.1 MB**
- this branch on latest main (includes #1486's SSR-graph shrink, 186→178 live modules): **28.3 MB** — 3.1× smaller; app smoke-tested (sign-in 200)
- prune log on the real prd bundle: `kept 186 modules, deleted 3 unreachable modules + 180 sourcemaps (55.0 MB)`

Expected effect: each cold DO instantiation drops from multi-second to sub-second, and the eyes ack stops depending on the deepest part of the chain. Worth re-measuring the full message→eyes timing in prd after this deploys.

## Trade-offs / notes

- Chunk-level deployed stack traces lose symbolication (entrypoint map kept). Symbolicate locally against the build output if needed.
- The prune is conservative: anything referenced by a quoted relative specifier (`from`, `import()`, `export from`, `new URL`) stays. The unreachable set on the real bundle is exactly the browser-only web workers + wasm.
- Follow-up idea (not this PR): split app-vs-platform workers so UI deploys stop evicting agent/stream DOs (the 2026-06-10 deploy-race incident), and consider per-DO-class workers for deploy isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production Slack webhook timing, adds best-effort Slack API calls on the routing path, and alters deploy artifacts via bundle pruning; behavior is designed to be idempotent but affects a critical user-visible path.
> 
> **Overview**
> Cuts Slack cold-path latency by shrinking the deployed worker and parallelizing work on the webhook path.
> 
> **Deploy:** Adds `prune-server-bundle` to the Alchemy build (after Vite, before asset preupload). It strips unreachable `dist/server` modules and most sourcemaps so each cold Durable Object isolate loads a much smaller script.
> 
> **Webhook ingress:** The Slack webhook handler now returns `{ ok: true }` after the durable stream append only; `SlackIntegrationDO.initialize()` / `ensureReady()` run in `waitUntil`, avoiding >3s acks and Slack retries.
> 
> **Routing hop:** `SlackProcessor` gains optional `acknowledgeRoutedWebhook` and `prewarmRoutedStreamHosts`. The integration DO adds the 👀 reaction at route time (via `eyesReactionTargetFromWebhookPayload` + `reactions.add`) and pre-initializes `SLACK_AGENT` and `AGENT` DOs in parallel with new-thread bootstrap. Downstream slack-agent behavior stays idempotent (`already_reacted`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cf05b16d08e47333866be25d49508ddcf145a9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-11T12:53:44.296Z",
      "headSha": "8cf05b16d08e47333866be25d49508ddcf145a9b",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27342005408",
      "shortSha": "8cf05b1"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-06-11T12:53:35.576Z",
      "headSha": "8cf05b16d08e47333866be25d49508ddcf145a9b",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27342005408",
      "shortSha": "8cf05b1"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### OS
Status: released
Commit: `8cf05b1`
Preview: https://os.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27342005408)
Updated: 2026-06-11T12:53:44.296Z

### Semaphore
Status: released
Commit: `8cf05b1`
Preview: https://semaphore.iterate-preview-3.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27342005408)
Updated: 2026-06-11T12:53:35.576Z
<!-- /CLOUDFLARE_PREVIEW -->