### PR TITLE
lint: add iterate/no-single-use-helpers rule (CI intentionally red)

### DIFF
--- a/.github/ts-workflows/workflows/cloudflare-previews.ts
+++ b/.github/ts-workflows/workflows/cloudflare-previews.ts
@@ -24,15 +24,16 @@ function createPreviewCommand(input: {
   includeWorkflowRunUrl?: boolean;
   prefix?: string;
 }) {
-  const argumentsWithLineContinuations = addLineContinuations(
-    createCommonPreviewArguments({
-      includePullRequestBaseSha: input.includePullRequestBaseSha ?? false,
-      includePullRequestHeadRefName: input.includePullRequestHeadRefName ?? false,
-      includePullRequestHeadSha: input.includePullRequestHeadSha ?? false,
-      includePullRequestIsFork: input.includePullRequestIsFork ?? false,
-      includeSemaphoreBaseUrl: input.includeSemaphoreBaseUrl ?? false,
-      includeWorkflowRunUrl: input.includeWorkflowRunUrl ?? false,
-    }),
+  const lines = createCommonPreviewArguments({
+    includePullRequestBaseSha: input.includePullRequestBaseSha ?? false,
+    includePullRequestHeadRefName: input.includePullRequestHeadRefName ?? false,
+    includePullRequestHeadSha: input.includePullRequestHeadSha ?? false,
+    includePullRequestIsFork: input.includePullRequestIsFork ?? false,
+    includeSemaphoreBaseUrl: input.includeSemaphoreBaseUrl ?? false,
+    includeWorkflowRunUrl: input.includeWorkflowRunUrl ?? false,
+  });
+  const argumentsWithLineContinuations = lines.map((line, index) =>
+    index === lines.length - 1 ? `  ${line}` : `  ${line} \\`,
   );
 
   return [
@@ -40,10 +41,6 @@ function createPreviewCommand(input: {
     `${input.prefix ?? ""}pnpm preview ${input.command} \\`,
     ...argumentsWithLineContinuations,
   ].join("\n");
-}
-
-function addLineContinuations(lines: string[]) {
-  return lines.map((line, index) => (index === lines.length - 1 ? `  ${line}` : `  ${line} \\`));
 }
 
 function createCommonPreviewArguments(input: {

--- a/.github/ts-workflows/workflows/nag.ts
+++ b/.github/ts-workflows/workflows/nag.ts
@@ -155,10 +155,11 @@ export default {
                 const [hour, day] = [now.getHours(), now.getDay()];
                 return hour >= 9 && hour < 18 && day !== 0 && day !== 6;
               };
-              const testWorkingHours: typeof realWorkingHours = () => {
-                return true;
-              };
-              const workingHours = isTest ? testWorkingHours : realWorkingHours;
+              const workingHours: typeof realWorkingHours = isTest
+                ? () => {
+                    return true;
+                  }
+                : realWorkingHours;
 
               const lastNagTime = state.read().nags?.at(-1)?.time;
 

--- a/.github/ts-workflows/workflows/pr-dashboard.ts
+++ b/.github/ts-workflows/workflows/pr-dashboard.ts
@@ -79,10 +79,8 @@ export default {
             );
             mergedToday.sort((a, b) => (a.pr.merged_at || "").localeCompare(b.pr.merged_at || ""));
 
-            const escape = (text: string) =>
-              text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
             const link = (item: { number: number; title: string; html_url: string }) =>
-              `<${item.html_url}|#${item.number} ${escape(item.title)}>`;
+              `<${item.html_url}|#${item.number} ${item.title.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")}>`;
             const by = (login: string | undefined) => {
               const slackUser = slackUsers.find(
                 (u) => u.github.toLowerCase() === (login || "").toLowerCase(),

--- a/.github/workflows/nag.yml
+++ b/.github/workflows/nag.yml
@@ -163,10 +163,11 @@ jobs:
                   const [hour, day] = [now.getHours(), now.getDay()];
                   return hour >= 9 && hour < 18 && day !== 0 && day !== 6;
                 };
-                const testWorkingHours = () => {
-                  return true;
-                };
-                const workingHours = isTest ? testWorkingHours : realWorkingHours;
+                const workingHours = isTest
+                  ? () => {
+                      return true;
+                    }
+                  : realWorkingHours;
 
                 const lastNagTime = state.read().nags?.at(-1)?.time;
 

--- a/.github/workflows/pr-dashboard.yml
+++ b/.github/workflows/pr-dashboard.yml
@@ -91,9 +91,8 @@ jobs:
               );
               mergedToday.sort((a, b) => (a.pr.merged_at || "").localeCompare(b.pr.merged_at || ""));
 
-              const escape = (text) =>
-                text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
-              const link = (item) => `<${item.html_url}|#${item.number} ${escape(item.title)}>`;
+              const link = (item) =>
+                `<${item.html_url}|#${item.number} ${item.title.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")}>`;
               const by = (login) => {
                 const slackUser = slackUsers.find(
                   (u) => u.github.toLowerCase() === (login || "").toLowerCase(),

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -119,6 +119,7 @@
     "iterate/no-raw-durable-object-binding-access": "error",
     "iterate/no-implied-eval": "error",
     "iterate/stream-processor-override-args": "error",
+    "iterate/no-single-use-helpers": "error",
     "prefer-const": "off",
     "iterate/prefer-const": "error",
     "iterate/isolated-codemode": [

--- a/apps/auth/alchemy.run.ts
+++ b/apps/auth/alchemy.run.ts
@@ -56,8 +56,6 @@ const AlchemyEnv = z.object({
 const alchemyEnv = AlchemyEnv.parse(process.env);
 const publicUrl = alchemyEnv.VITE_PUBLIC_URL ?? alchemyEnv.VITE_AUTH_APP_ORIGIN;
 
-const stateStore = (scope: Scope) =>
-  scope.local ? new SQLiteStateStore(scope, { engine: "libsql" }) : new CloudflareStateStore(scope);
 const primaryUrl = alchemyEnv.WORKER_ROUTES[0]
   ? `https://${alchemyEnv.WORKER_ROUTES[0]}`
   : undefined;
@@ -67,7 +65,10 @@ const app = await alchemy(APP_NAME, {
   stage: alchemyEnv.ALCHEMY_STAGE,
   ...(alchemyEnv.ALCHEMY_LOCAL ? { local: true } : {}),
   adopt: true,
-  stateStore,
+  stateStore: (scope: Scope) =>
+    scope.local
+      ? new SQLiteStateStore(scope, { engine: "libsql" })
+      : new CloudflareStateStore(scope),
 });
 
 const workerName = slugify(`${APP_NAME}-${app.stage}`);

--- a/apps/auth/src/lib/server.ts
+++ b/apps/auth/src/lib/server.ts
@@ -233,10 +233,6 @@ function createOAuthInfra(config: IterateAuthConfig, jwks: JWKS): OAuthInfra {
     return { [oauth.allowInsecureRequests]: true } as const;
   }
 
-  function cookieOpts() {
-    return { httpOnly: true, path: "/", sameSite: "Lax", secure: secureCookies } as const;
-  }
-
   function audiences() {
     const resources = Array.isArray(config.resource) ? config.resource : [config.resource];
     const configuredResources = resources.filter((resource): resource is string => !!resource);
@@ -338,7 +334,8 @@ function createOAuthInfra(config: IterateAuthConfig, jwks: JWKS): OAuthInfra {
     toTokenSet,
     doRefresh,
     getUserInfo,
-    cookieOpts,
+    cookieOpts: () =>
+      ({ httpOnly: true, path: "/", sameSite: "Lax", secure: secureCookies }) as const,
     resource,
     audiences,
   };

--- a/apps/auth/src/routes/_auth/projects.tsx
+++ b/apps/auth/src/routes/_auth/projects.tsx
@@ -173,7 +173,9 @@ function WorkspaceInventoryPage() {
             {selectedOrganization ? (
               <OrganizationDetail
                 organization={selectedOrganization}
-                canManage={canManageOrganization(selectedOrganization)}
+                canManage={
+                  selectedOrganization.role === "owner" || selectedOrganization.role === "admin"
+                }
                 onCreateProject={() =>
                   setProjectDialog({
                     organizationSlug: selectedOrganization.slug,
@@ -572,8 +574,4 @@ function DeleteProjectDialog(props: {
       </AlertDialogContent>
     </AlertDialog>
   );
-}
-
-function canManageOrganization(organization: Organization) {
-  return organization.role === "owner" || organization.role === "admin";
 }

--- a/apps/auth/src/server/auth-plugins.ts
+++ b/apps/auth/src/server/auth-plugins.ts
@@ -10,7 +10,6 @@ import {
   ITERATE_IS_ADMIN_CLAIM,
   ITERATE_ORGANIZATIONS_CLAIM,
   ITERATE_ROLE_CLAIM,
-  type IterateAuthAccessTokenOrganizationClaim,
   type IterateAuthOrganizationClaim,
   type IterateAuthProjectClaim,
 } from "@iterate-com/shared/auth-claims";
@@ -74,12 +73,6 @@ async function listOrganizationClaims(
     role:
       organization.role === "owner" || organization.role === "admin" ? organization.role : "member",
   }));
-}
-
-async function listAccessTokenOrganizationClaims(
-  user: Record<string, unknown> | null | undefined,
-): Promise<IterateAuthAccessTokenOrganizationClaim[]> {
-  return await listOrganizationClaims(user);
 }
 
 async function listProjectClaims(
@@ -210,7 +203,9 @@ export function getAuthPlugins(env: Record<string, unknown>) {
         const isProjectScopedToken = scopes.includes(ITERATE_PROJECT_SELECTION_SCOPE);
         const selectedProjectIds = isProjectScopedToken ? (selection?.projectIds ?? []) : null;
         const [organizations, projects] = await Promise.all([
-          listAccessTokenOrganizationClaims(user),
+          // the org claims double as the access-token organizations claim
+          // (IterateAuthAccessTokenOrganizationClaim, where name is optional)
+          listOrganizationClaims(user),
           listProjectClaims(user, selectedProjectIds),
         ]);
 

--- a/apps/auth/src/server/worker.ts
+++ b/apps/auth/src/server/worker.ts
@@ -131,7 +131,7 @@ function preserveRedirectSearchParams(
   response: Response,
   paramNames: Iterable<string>,
 ) {
-  if (!isRedirectStatus(response.status)) return response;
+  if (response.status < 300 || response.status >= 400) return response;
 
   const requestUrl = new URL(request.url);
   const location = response.headers.get("Location");
@@ -157,10 +157,6 @@ function preserveRedirectSearchParams(
     statusText: response.statusText,
     headers,
   });
-}
-
-function isRedirectStatus(status: number) {
-  return status >= 300 && status < 400;
 }
 
 export default app;

--- a/apps/os/alchemy.run.ts
+++ b/apps/os/alchemy.run.ts
@@ -193,7 +193,10 @@ const { worker, afterFinalize } = await IterateApp(ctx, {
   extraRouteHostnames: [
     ...(eventDocsRouteHostname ? [eventDocsRouteHostname] : []),
     ...(mcpRouteHostname ? [mcpRouteHostname] : []),
-    ...projectHostnameBases.flatMap(projectRouteHostnamesForBase),
+    // each project-host base routes both the bare base and its dotted project
+    // subdomains (`<slug>.<base>`); preview bases like iterate-preview-N.app
+    // are normal bases too
+    ...projectHostnameBases.flatMap((base) => [base, `*.${base}`]),
   ],
 });
 
@@ -203,16 +206,6 @@ await ctx.app.finalize();
 await afterFinalize();
 
 if (!ctx.app.local) process.exit(0);
-
-/**
- * Convert OS project-host bases into Cloudflare route host patterns.
- *
- * Normal bases use dotted project subdomains (`<slug>.<base>`). OS preview
- * project bases are normal bases too: `<slug>.iterate-preview-N.app`.
- */
-function projectRouteHostnamesForBase(base: string) {
-  return [base, `*.${base}`];
-}
 
 function routeHostnameForUrl(url: string | undefined) {
   if (!url) return undefined;

--- a/apps/os/docs/capability-global-hierarchy.sketch.ts
+++ b/apps/os/docs/capability-global-hierarchy.sketch.ts
@@ -109,12 +109,9 @@ export class ProjectsCapability extends RpcTarget {
       this.input.props.auth,
       input.organization,
     );
-    const projectId = input.id ?? allocateProjectId();
-    createProject({
-      organization,
-      projectId,
-      slug: input.slug,
-    });
+    const projectId = input.id ?? "proj_generated";
+    // sketch only: a real implementation would persist the project record here
+    void { organization, projectId, slug: input.slug };
     return new ProjectCapability({
       env: this.input.env,
       props: withAuth(this.input.props, { projectId }),
@@ -122,7 +119,9 @@ export class ProjectsCapability extends RpcTarget {
   }
 
   get(projectIdOrSlug: string) {
-    const projectId = resolveProjectId(projectIdOrSlug);
+    const projectId = projectIdOrSlug.startsWith("proj_")
+      ? projectIdOrSlug
+      : `proj_${projectIdOrSlug}`;
     assertCanAccessProject(this.input.props.auth, projectId);
     return new ProjectCapability({
       env: this.input.env,
@@ -683,22 +682,6 @@ type CapabilityEnv = {
   STREAM: DurableObjectNamespace<StreamDurableObject>;
   WORKSPACE: DurableObjectNamespace<WorkspaceDurableObject>;
 };
-
-function resolveProjectId(projectIdOrSlug: string) {
-  return projectIdOrSlug.startsWith("proj_") ? projectIdOrSlug : `proj_${projectIdOrSlug}`;
-}
-
-function allocateProjectId() {
-  return "proj_generated";
-}
-
-function createProject(input: {
-  organization?: ProjectCreateOrganization;
-  projectId: string;
-  slug: string;
-}) {
-  void input;
-}
 
 function resolveProjectCreationOrganization(
   auth: CapabilityAuth,

--- a/apps/os/e2e/test-support/os-client.ts
+++ b/apps/os/e2e/test-support/os-client.ts
@@ -139,7 +139,7 @@ export async function readProjectStreamUntil<T extends Event>(input: {
       streamPath: input.streamPath,
     });
     if (result.events.some(input.predicate)) return result.events;
-    await delay(1_000);
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
   }
 
   const result = await input.client.project.streams.read({
@@ -192,8 +192,4 @@ export async function streamProjectEventsUntil<T extends Event>(input: {
 
 export function uniqueSuffix() {
   return `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
-}
-
-async function delay(ms: number) {
-  await new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/apps/os/e2e/vitest/agents.e2e.test.ts
+++ b/apps/os/e2e/vitest/agents.e2e.test.ts
@@ -1076,7 +1076,7 @@ async function readUntil(input: {
       streamPath: input.agentPath,
     });
     if (result.events.some(input.predicate)) return result.events;
-    await delay(1_000);
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
   }
 
   const result = await input.client.project.streams.read({
@@ -1150,8 +1150,4 @@ function maxGapAfter(events: readonly Event[], afterOffset: number) {
 
 function uniqueSuffix() {
   return `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
-}
-
-async function delay(ms: number) {
-  await new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/apps/os/src/auth/dev-oauth-client-bootstrap.ts
+++ b/apps/os/src/auth/dev-oauth-client-bootstrap.ts
@@ -53,7 +53,7 @@ export async function ensureLocalDevOAuthClient(env: Record<string, string | und
     return;
   }
 
-  const authClient = createAuthClient(authOrigin, serviceToken);
+  const authClient = createAuthContractClient({ baseUrl: authOrigin, serviceToken });
   const redirectURI = `${baseUrl.replace(/\/+$/, "")}/api/iterate-auth/callback`;
   const existingClientId =
     env.APP_CONFIG_ITERATE_AUTH__CLIENT_ID ?? env.ITERATE_OAUTH_CLIENT_ID ?? undefined;
@@ -85,15 +85,11 @@ export async function ensureLocalDevOAuthClient(env: Record<string, string | und
           { cause: error },
         );
       }
-      await sleep(RETRY_DELAY_MS);
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
     }
   }
 
   throw new Error(`Failed to bootstrap local OAuth client for ${target}`, { cause: lastError });
-}
-
-function createAuthClient(authOrigin: string, serviceToken: string) {
-  return createAuthContractClient({ baseUrl: authOrigin, serviceToken });
 }
 
 function isLoopbackOrigin(origin: string) {
@@ -111,8 +107,4 @@ function isRetryableBootstrapError(error: unknown) {
     message.includes("socket") ||
     message.includes("timed out")
   );
-}
-
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -183,7 +183,7 @@ function AppSidebarUser() {
   const [debugOpen, setDebugOpen] = useState(false);
   const user = session?.authenticated ? session.user : null;
   const isAdmin = user?.isAdmin ?? false;
-  const label = nonEmptyLabel(user?.name, user?.email, "Account");
+  const label = [user?.name, user?.email, "Account"].find((value) => value?.trim())?.trim() ?? "";
   const email = user?.email?.trim() ?? "";
   const initials = userInitials(label);
   const debugInfo = useMemo(
@@ -315,10 +315,6 @@ function userInitials(label: string) {
     .join("")
     .toUpperCase();
   return initials || "I";
-}
-
-function nonEmptyLabel(...values: Array<string | null | undefined>) {
-  return values.find((value) => value?.trim())?.trim() ?? "";
 }
 
 function authWorkerUrl(config: PublicConfig, path: string) {

--- a/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
+++ b/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
@@ -594,9 +594,7 @@ export class AgentDurableObject extends AgentLifecycleBase<AgentDurableObjectEnv
     );
 
     for (const [index, event] of setupEvents.entries()) {
-      const idempotencyKey = `os-agent-setup:${normalizeIdempotencyKeyPart(
-        preset?.basePath ?? "default",
-      )}:${index}:${event.type}`;
+      const idempotencyKey = `os-agent-setup:${(preset?.basePath ?? "default").replace(/[^a-zA-Z0-9._/-]+/g, "-")}:${index}:${event.type}`;
       if (events.some((existingEvent) => existingEvent.idempotencyKey === idempotencyKey)) {
         continue;
       }
@@ -812,10 +810,6 @@ export class AgentDurableObject extends AgentLifecycleBase<AgentDurableObjectEnv
       streamPath,
     });
   }
-}
-
-function normalizeIdempotencyKeyPart(value: string) {
-  return value.replace(/[^a-zA-Z0-9._/-]+/g, "-");
 }
 
 function hasEquivalentDefaultSetupEvent(input: {

--- a/apps/os/src/domains/agents/stream-processors/agent-chat/implementation.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent-chat/implementation.ts
@@ -119,7 +119,8 @@ function eventBlock(args: {
     `  offset: ${args.offset}`,
     `  type: ${yamlScalar(args.type)}`,
     `  channel: ${yamlScalar(args.channel)}`,
-    ...yamlBlockScalar(args.bodyTag, args.body),
+    `  ${args.bodyTag}: |-`,
+    ...args.body.split("\n").map((line) => `    ${line}`),
   ];
   return ["```yaml", ...yamlLines, "```"].join("\n");
 }
@@ -127,8 +128,4 @@ function eventBlock(args: {
 function yamlScalar(value: string): string {
   if (/^[a-zA-Z0-9._/@:-]+$/.test(value)) return value;
   return JSON.stringify(value);
-}
-
-function yamlBlockScalar(key: string, value: string): string[] {
-  return [`  ${key}: |-`, ...value.split("\n").map((line) => `    ${line}`)];
 }

--- a/apps/os/src/domains/agents/stream-processors/agent/implementation.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/implementation.ts
@@ -151,12 +151,7 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
           await this.#appendRewrite({
             event,
             key: "render-agent-capability-noted",
-            content: capabilityNotedEventBlock({
-              instructions: event.payload.instructions,
-              name: event.payload.name,
-              offset: event.offset,
-              type: event.type,
-            }),
+            content: `Capability available as \`itx.${event.payload.name}\`. ${event.payload.instructions} (to debug further, see ${event.type} event at offset ${event.offset})`,
           });
         });
         return;
@@ -643,7 +638,9 @@ function eventBlock(args: {
     `  offset: ${args.offset}`,
     `  type: ${yamlScalar(args.type)}`,
     ...Object.entries(args.fields ?? {}).map(([key, value]) => `  ${key}: ${yamlScalar(value)}`),
-    ...(args.body == null ? [] : yamlBlockScalar(args.bodyTag ?? "body", args.body)),
+    ...(args.body == null
+      ? []
+      : [`  ${args.bodyTag ?? "body"}: |-`, ...args.body.split("\n").map((line) => `    ${line}`)]),
   ];
   return ["```yaml", ...yamlLines, "```"].join("\n");
 }
@@ -652,17 +649,4 @@ function yamlScalar(value: string | number): string {
   if (typeof value === "number") return String(value);
   if (/^[a-zA-Z0-9._/@:-]+$/.test(value)) return value;
   return JSON.stringify(value);
-}
-
-function yamlBlockScalar(key: string, value: string): string[] {
-  return [`  ${key}: |-`, ...value.split("\n").map((line) => `    ${line}`)];
-}
-
-function capabilityNotedEventBlock(args: {
-  instructions: string;
-  name: string;
-  offset: number;
-  type: string;
-}): string {
-  return `Capability available as \`itx.${args.name}\`. ${args.instructions} (to debug further, see ${args.type} event at offset ${args.offset})`;
 }

--- a/apps/os/src/domains/agents/stream-processors/openai-ws/implementation.ts
+++ b/apps/os/src/domains/agents/stream-processors/openai-ws/implementation.ts
@@ -326,7 +326,7 @@ export class OpenAiWsProcessor extends StreamProcessor<
       return this.#connection;
     }
 
-    const connectionId = createConnectionId({ llmRequestId: sourceEvent.offset });
+    const connectionId = `openai_ws_${sourceEvent.offset}_${crypto.randomUUID()}`;
     const client = await this.deps.openResponsesWebSocket();
     const iterator = client.stream();
     await waitForOpenAiResponsesSocketOpen(iterator);
@@ -705,10 +705,6 @@ export class OpenAiWsProcessor extends StreamProcessor<
   async #append(event: { type: string; idempotencyKey: string; payload: unknown }) {
     await this.ctx.stream.append({ event });
   }
-}
-
-function createConnectionId(args: { llmRequestId: number }) {
-  return `openai_ws_${args.llmRequestId}_${crypto.randomUUID()}`;
 }
 
 async function waitForOpenAiResponsesSocketOpen(

--- a/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
@@ -60,7 +60,7 @@ export async function handleMcpFetch(input: McpHandlerInput): Promise<Response |
     return new Response(null, { headers: mcpCorsHeaders });
   }
 
-  if (isMcpProtectedResourceMetadataPath(routeMatch.relativePathname)) {
+  if (routeMatch.relativePathname === "/.well-known/oauth-protected-resource") {
     return Response.json(buildProtectedResourceMetadata(input), { headers: mcpCorsHeaders });
   }
 
@@ -179,10 +179,6 @@ async function authenticateAdminMcpRequest(input: McpHandlerInput) {
   } satisfies ProjectMcpServerConnectionProps;
 }
 
-function isMcpProtectedResourceMetadataPath(pathname: string) {
-  return pathname === "/.well-known/oauth-protected-resource";
-}
-
 function matchConfiguredMcpBaseUrl(input: McpHandlerInput) {
   return matchMcpRequestUrl({
     appBaseUrl: input.config.baseUrl,
@@ -201,7 +197,7 @@ function createMcpIterateAuth(input: McpHandlerInput) {
   const config = input.config.iterateAuth;
   if (!config) return null;
 
-  const baseUrl = getRequestBaseUrl(input);
+  const baseUrl = (input.config.baseUrl ?? new URL(input.request.url).origin).replace(/\/+$/, "");
   return createIterateAuth({
     issuer: config.issuer,
     clientId: config.clientId,
@@ -264,10 +260,6 @@ function canonicalMcpResourceUrl(input: McpHandlerInput) {
   if (!rawUrl) throw new Error("APP_CONFIG_MCP__BASE_URL is required for MCP requests.");
   const baseUrl = normalizeMcpBaseUrl(rawUrl);
   return stripTrailingSlash(baseUrl.toString());
-}
-
-function getRequestBaseUrl(input: McpHandlerInput) {
-  return (input.config.baseUrl ?? new URL(input.request.url).origin).replace(/\/+$/, "");
 }
 
 function unauthorizedMcpResponse(input: McpHandlerInput, message: string) {

--- a/apps/os/src/domains/projects/project-directory.ts
+++ b/apps/os/src/domains/projects/project-directory.ts
@@ -150,7 +150,7 @@ export class ProjectsCapability extends RpcTarget {
         slug,
       });
     } catch (error) {
-      if (isUniqueConstraintError(error)) {
+      if (error instanceof Error && error.message.includes("UNIQUE constraint failed")) {
         throw new ORPCError("CONFLICT", {
           message: `A project with slug ${slug} already exists.`,
         });
@@ -293,10 +293,6 @@ function projectDurableObject(projectId: string) {
   return getProjectDurableObjectStub(projectId);
 }
 
-function isUniqueConstraintError(error: unknown) {
-  return error instanceof Error && error.message.includes("UNIQUE constraint failed");
-}
-
 export type AuthProject = {
   id: string;
   slug: string;
@@ -314,12 +310,10 @@ function toOrphanedProjectFromAuthService(project: AuthProject): ProjectListItem
   };
 }
 
-function sortAuthProjects<T extends Pick<AuthProject, "slug">>(projects: T[]) {
-  return [...projects].sort((a, b) => a.slug.localeCompare(b.slug));
-}
-
 function listSignedProjectClaims(context: Pick<RequestContext, "principal">): AuthProject[] {
-  return context.principal?.type === "user" ? sortAuthProjects(context.principal.projects) : [];
+  return context.principal?.type === "user"
+    ? [...context.principal.projects].sort((a, b) => a.slug.localeCompare(b.slug))
+    : [];
 }
 
 function getAccessibleSignedProject(input: { context: RequestContext; projectId: string }) {

--- a/apps/os/src/domains/repos/artifacts.ts
+++ b/apps/os/src/domains/repos/artifacts.ts
@@ -233,7 +233,12 @@ async function artifactsApi<T>(
   const response = await fetch(
     `https://api.cloudflare.com/client/v4/accounts/${input.accountId}/artifacts/namespaces/${input.namespace}${apiPath}`,
     {
-      body: body == null ? undefined : JSON.stringify(dropUndefinedValues(body)),
+      body:
+        body == null
+          ? undefined
+          : JSON.stringify(
+              Object.fromEntries(Object.entries(body).filter(([, value]) => value !== undefined)),
+            ),
       headers: {
         authorization: `Bearer ${input.apiToken}`,
         "content-type": "application/json",
@@ -286,8 +291,4 @@ function cloudflareErrorMessage(payload: CloudflareApiEnvelope<unknown>) {
     .map((entry) => entry.message)
     .filter((message) => typeof message === "string" && message.length > 0);
   return messages.length > 0 ? messages.join("; ") : JSON.stringify(payload);
-}
-
-function dropUndefinedValues(input: Record<string, unknown>) {
-  return Object.fromEntries(Object.entries(input).filter(([, value]) => value !== undefined));
 }

--- a/apps/os/src/domains/repos/durable-objects/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/durable-objects/repo-durable-object.ts
@@ -463,7 +463,7 @@ export class RepoDurableObject extends RepoLifecycleBase<RepoEnv> {
       type: STREAM_SUBSCRIPTION_CONFIGURED_TYPE,
       idempotencyKey: `repo-subscription:${params.projectId}:${params.repoSlug}:workers-rpc:callable`,
       payload: {
-        subscriptionKey: repoProcessorSubscriptionKey(params),
+        subscriptionKey: `repo:${params.projectId}:${params.repoSlug}`,
         subscriber: durableObjectProcessorSubscriber({
           bindingName: "REPO",
           durableObjectName: getRepoDurableObjectName(params),
@@ -485,10 +485,6 @@ type RepoProcessorRuntimeState = {
   state: { repo: RepoInfoSource | null } | null;
   reducedThroughOffset: number;
 };
-
-function repoProcessorSubscriptionKey(input: RepoStructuredName) {
-  return `repo:${input.projectId}:${input.repoSlug}`;
-}
 
 export function getRepoDurableObjectName(name: RepoStructuredName) {
   return deriveDurableObjectNameFromStructuredName({

--- a/apps/os/src/domains/repos/iterate-config-base-seed.ts
+++ b/apps/os/src/domains/repos/iterate-config-base-seed.ts
@@ -208,7 +208,9 @@ export async function seedIterateConfigBaseRepo(input: {
     });
     await ensureBranchRef({ branch: defaultBranch, git });
   } catch (error) {
-    if (!isNothingToCommitError(error)) throw error;
+    if (!(error instanceof Error && /nothing to commit|no changes/i.test(error.message))) {
+      throw error;
+    }
     committed = false;
   }
 
@@ -238,7 +240,7 @@ async function ensureBranchRef(input: { branch: string; git: ReturnType<typeof c
       name: input.branch,
     });
   } catch (error) {
-    if (!isBranchExistsError(error)) throw error;
+    if (!(error instanceof Error && /already exists/i.test(error.message))) throw error;
   }
 }
 
@@ -259,14 +261,6 @@ async function getOrCreateBaseArtifact(artifacts: CloudflareArtifactsBinding): P
       created: false,
     };
   }
-}
-
-function isNothingToCommitError(error: unknown) {
-  return error instanceof Error && /nothing to commit|no changes/i.test(error.message);
-}
-
-function isBranchExistsError(error: unknown) {
-  return error instanceof Error && /already exists/i.test(error.message);
 }
 
 async function readArtifactString(value: unknown): Promise<string | null> {

--- a/apps/os/src/domains/repos/stream-processors/repo-stream-processor.test.ts
+++ b/apps/os/src/domains/repos/stream-processors/repo-stream-processor.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "vitest";
 import { RepoStreamProcessor } from "./repo-stream-processor.ts";
 
-const iterateContext = () => ({ stream: { append() {}, appendBatch() {} } });
-
 describe("Repo stream processor", () => {
   test("derives Repo state from events.iterate.com/repo/created", async () => {
-    const processor = new RepoStreamProcessor({ iterateContext: iterateContext() });
+    const processor = new RepoStreamProcessor({
+      iterateContext: { stream: { append() {}, appendBatch() {} } },
+    });
 
     await processor.ingest({
       events: [

--- a/apps/os/src/domains/secrets/integration-api.ts
+++ b/apps/os/src/domains/secrets/integration-api.ts
@@ -422,12 +422,8 @@ async function verifySlackSignature(input: {
     key,
     new TextEncoder().encode(`v0:${input.timestamp}:${input.body}`),
   );
-  const expected = `v0=${hex(new Uint8Array(signature))}`;
+  const expected = `v0=${Array.from(new Uint8Array(signature), (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
   return constantTimeEqual(expected, input.signature);
-}
-
-function hex(bytes: Uint8Array) {
-  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 function constantTimeEqual(left: string, right: string) {

--- a/apps/os/src/domains/secrets/secrets-store.ts
+++ b/apps/os/src/domains/secrets/secrets-store.ts
@@ -56,10 +56,6 @@ export function projectSecretId(input: { typeIdPrefix: string }) {
   });
 }
 
-function legacyId(prefix: string) {
-  return `${prefix}_${crypto.randomUUID().replaceAll("-", "")}`;
-}
-
 function parseMetadata(value: string): Record<string, unknown> {
   const parsed = JSON.parse(value) as unknown;
   return parsed && typeof parsed === "object" && !Array.isArray(parsed)
@@ -281,7 +277,7 @@ export async function upsertProjectConnection(
     webhookProviderIdentifier?: string | null;
   },
 ): Promise<ProjectConnection> {
-  const connectionId = legacyId("conn");
+  const connectionId = `conn_${crypto.randomUUID().replaceAll("-", "")}`;
   const rows = await db.all<ProjectConnectionRow>({
     name: "upsertProjectConnection",
     sql: `

--- a/apps/os/src/domains/slack/durable-objects/slack-integration-durable-object.ts
+++ b/apps/os/src/domains/slack/durable-objects/slack-integration-durable-object.ts
@@ -151,7 +151,7 @@ export class SlackIntegrationDurableObject extends SlackIntegrationLifecycleBase
       // streams that already carry the legacy built-in subscription.
       idempotencyKey: `slack-subscription:${projectId}:workers-rpc:callable`,
       payload: {
-        subscriptionKey: slackIntegrationProcessorSubscriptionKey(projectId),
+        subscriptionKey: `slack:${projectId}`,
         subscriber: durableObjectProcessorSubscriber({
           bindingName: "SLACK_INTEGRATION",
           durableObjectName: getSlackIntegrationDurableObjectName(projectId),
@@ -176,10 +176,7 @@ export function routedStreamBootstrapEvents(input: {
       // streams that already carry the legacy built-in subscription.
       idempotencyKey: `slack-agent-subscription:${input.projectId}:${input.streamPath}:workers-rpc:callable`,
       payload: {
-        subscriptionKey: slackAgentProcessorSubscriptionKey({
-          projectId: input.projectId,
-          streamPath,
-        }),
+        subscriptionKey: `slack-agent:${input.projectId}:${streamPath}`,
         // The SLACK_AGENT host DO name is derived here rather than taken from
         // the input so legacy callers passing "" still produce a dialable
         // subscriber.
@@ -203,12 +200,4 @@ export function routedStreamBootstrapEvents(input: {
       projectId: input.projectId,
     }),
   ];
-}
-
-function slackIntegrationProcessorSubscriptionKey(projectId: string) {
-  return `slack:${projectId}`;
-}
-
-function slackAgentProcessorSubscriptionKey(input: { projectId: string; streamPath: string }) {
-  return `slack-agent:${input.projectId}:${input.streamPath}`;
 }

--- a/apps/os/src/durable-objects/project-ingress-test-entry.ts
+++ b/apps/os/src/durable-objects/project-ingress-test-entry.ts
@@ -245,7 +245,7 @@ export default {
         async call({ args }: { path: string[]; args: unknown[] }) {
           const request = args[0] as Request;
           return Response.json({
-            headers: headersToArrays(request.headers),
+            headers: Object.fromEntries([...request.headers].map(([key, value]) => [key, [value]])),
             url: request.url,
           });
         }
@@ -435,8 +435,4 @@ function readWorkspaceStateMethod(input: { method: string; state: Record<string,
     throw new Error(`Workspace state does not implement ${input.method}.`);
   }
   return method;
-}
-
-function headersToArrays(headers: Headers) {
-  return Object.fromEntries([...headers].map(([key, value]) => [key, [value]]));
 }

--- a/apps/os/src/durable-objects/project-ingress.test.ts
+++ b/apps/os/src/durable-objects/project-ingress.test.ts
@@ -413,14 +413,10 @@ function mockPublicEchoFetch() {
     }
 
     return Response.json({
-      headers: headersToArrays(request.headers),
+      headers: Object.fromEntries([...request.headers].map(([key, value]) => [key, [value]])),
       url: request.url,
     });
   });
-}
-
-function headersToArrays(headers: Headers) {
-  return Object.fromEntries([...headers].map(([key, value]) => [key, [value]]));
 }
 
 async function waitForProjectState() {

--- a/apps/os/src/itx/admin-auth-cookie.ts
+++ b/apps/os/src/itx/admin-auth-cookie.ts
@@ -37,10 +37,16 @@ export async function handleCapnwebAdminCookieRequest(input: {
     return new Response("Unauthorized", { headers: corsHeaders, status: 401 });
   }
 
-  const payload = encodeCookiePayload({
-    scopes: { projects: "all" },
-    secret: input.config.adminApiSecret!.exposeSecret(),
-  });
+  // base64url-encode (no padding) so the payload survives cookie syntax.
+  const payload = btoa(
+    JSON.stringify({
+      scopes: { projects: "all" },
+      secret: input.config.adminApiSecret!.exposeSecret(),
+    } satisfies CookiePayload),
+  )
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
   const url = new URL(input.request.url);
   // SameSite=None is only valid together with Secure — browsers silently drop
   // the cookie otherwise. On plain-http origins (local dev) fall back to Lax,
@@ -65,10 +71,6 @@ function capnwebCookieCorsHeaders(request: Request) {
     "access-control-allow-origin": origin ?? "*",
     vary: "origin",
   };
-}
-
-function encodeCookiePayload(payload: CookiePayload) {
-  return btoa(JSON.stringify(payload)).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
 }
 
 function decodeCookiePayload(value: string): CookiePayload | null {

--- a/apps/os/src/itx/browser-repl.test.ts
+++ b/apps/os/src/itx/browser-repl.test.ts
@@ -600,8 +600,7 @@ class BrowserPathTarget extends RpcTarget {
   }
 
   private callable(path: string[]): Function {
-    const fn = (...args: unknown[]) => this.callPath({ args, path });
-    return new Proxy(fn, {
+    return new Proxy((...args: unknown[]) => this.callPath({ args, path }), {
       apply: (_target, _thisArg, args) => this.callPath({ args, path }),
       get: (target, key, receiver) => {
         if (key === "then") return undefined;

--- a/apps/os/src/itx/browser-repl.ts
+++ b/apps/os/src/itx/browser-repl.ts
@@ -95,7 +95,9 @@ export async function runBrowserReplEntry(input: {
 
 export function compileBrowserReplFunction(rawCode: string) {
   const code = rewriteBrowserReplImports(rawCode);
-  if (startsWithTopLevelDeclaration(code)) {
+  // Snippets starting with a top-level declaration (function/class) go
+  // straight to statement mode — they can't be wrapped as an expression.
+  if (/^\s*(?:async\s+function|function|class)\s+[A-Za-z_$][\w$]*/.test(code)) {
     return compileBrowserReplStatements(code);
   }
 
@@ -129,10 +131,6 @@ function compileBrowserReplStatements(code: string) {
     "scope",
     `with (scope) { return (async () => { let __replLastValue;\n${statementSource}\n; return __replLastValue })() }`,
   ) as ReplFunction;
-}
-
-function startsWithTopLevelDeclaration(code: string) {
-  return /^\s*(?:async\s+function|function|class)\s+[A-Za-z_$][\w$]*/.test(code);
 }
 
 /**
@@ -554,7 +552,8 @@ function readTopLevelDeclarationReplacement(
 }
 
 function isTopLevelStatementBoundary(code: string, index: number) {
-  if (!isIdentifierStart(code[index] ?? "")) return false;
+  // A statement boundary must start with an identifier character.
+  if (!/^[A-Za-z_$]$/.test(code[index] ?? "")) return false;
 
   let previous = index - 1;
   let crossedLineBreak = false;
@@ -566,10 +565,6 @@ function isTopLevelStatementBoundary(code: string, index: number) {
   if (crossedLineBreak) return true;
 
   return [";", "}"].includes(code[previous] ?? "");
-}
-
-function isIdentifierStart(value: string) {
-  return /^[A-Za-z_$]$/.test(value);
 }
 
 function scopeAssignmentTarget(name: string) {
@@ -617,8 +612,11 @@ function createBrowserReplConsole(logs: BrowserReplConsoleLog[]) {
 
   return new Proxy(globalThis.console, {
     get(consoleTarget, key, receiver) {
-      if (typeof key === "string" && isBrowserReplConsoleMethod(key)) {
-        return capturedMethods.get(key);
+      if (
+        typeof key === "string" &&
+        BROWSER_REPL_CONSOLE_METHODS.includes(key as BrowserReplConsoleMethod)
+      ) {
+        return capturedMethods.get(key as BrowserReplConsoleMethod);
       }
 
       const value = Reflect.get(consoleTarget, key, receiver);
@@ -630,19 +628,11 @@ function createBrowserReplConsole(logs: BrowserReplConsoleLog[]) {
 
 const BROWSER_REPL_CONSOLE_METHODS = ["debug", "error", "info", "log", "table", "warn"] as const;
 
-function isBrowserReplConsoleMethod(value: string): value is BrowserReplConsoleMethod {
-  return BROWSER_REPL_CONSOLE_METHODS.includes(value as BrowserReplConsoleMethod);
-}
-
 function formatBrowserReplConsoleOutput(logs: BrowserReplConsoleLog[]) {
   return logs
     .map((log) => {
       const prefix = log.method === "log" ? "" : `${log.method}: `;
-      return `${prefix}${log.args.map(formatBrowserReplConsoleArg).join(" ")}`;
+      return `${prefix}${log.args.map((arg) => formatBrowserReplResult(arg).text).join(" ")}`;
     })
     .join("\n");
-}
-
-function formatBrowserReplConsoleArg(arg: unknown) {
-  return formatBrowserReplResult(arg).text;
 }

--- a/apps/os/src/itx/path-proxy.ts
+++ b/apps/os/src/itx/path-proxy.ts
@@ -29,9 +29,7 @@ export class PathProxyRpcTarget {
 }
 
 function pathNode(callPath: PathProxyCall, path: string[]): Function {
-  const fn = (...args: unknown[]) => callPath({ args, path });
-
-  return new Proxy(fn, {
+  return new Proxy((...args: unknown[]) => callPath({ args, path }), {
     apply(_target, _thisArg, args) {
       return callPath({ args, path });
     },

--- a/apps/os/src/itx/use-itx.ts
+++ b/apps/os/src/itx/use-itx.ts
@@ -140,11 +140,12 @@ export function useItx(context?: string): RpcStub<Itx> {
     (listener: () => void) => pool.subscribe(context, listener),
     [context],
   );
-  useSyncExternalStore(subscribe, () => pool.peek(context), neverOnTheServer);
+  // Server snapshot is never read: assertBrowser threw long before
+  // useSyncExternalStore could ask.
+  useSyncExternalStore(
+    subscribe,
+    () => pool.peek(context),
+    () => undefined,
+  );
   return use(pool.get(context).promise);
-}
-
-function neverOnTheServer(): undefined {
-  // assertBrowser threw long before useSyncExternalStore could ask.
-  return undefined;
 }

--- a/apps/os/src/lib/auth.ts
+++ b/apps/os/src/lib/auth.ts
@@ -75,11 +75,7 @@ function redirectToSignIn(location: RouteLocation): never {
 }
 
 function redirectToProjectAccess(issuer: string | undefined): never {
-  throw redirect({ href: authWorkerUrl("/project-access", issuer) });
-}
-
-function authWorkerUrl(path: string, issuer: string | undefined) {
-  return new URL(path, `${authWorkerOrigin(issuer)}/`).toString();
+  throw redirect({ href: new URL("/project-access", `${authWorkerOrigin(issuer)}/`).toString() });
 }
 
 function authWorkerOrigin(issuer: string | undefined) {

--- a/apps/os/src/lib/docs-markdown.ts
+++ b/apps/os/src/lib/docs-markdown.ts
@@ -36,7 +36,10 @@ export function handleDocsMarkdownFetch(input: {
       "content-signal": "ai-train=yes, search=yes, ai-input=yes",
       "content-type": "text/markdown; charset=utf-8",
       vary: "accept",
-      "x-markdown-tokens": estimateTokenCount(markdown).toString(),
+      // Estimated token count: ~1.35 tokens per whitespace-separated word.
+      "x-markdown-tokens": Math.ceil(
+        markdown.split(/\s+/).filter(Boolean).length * 1.35,
+      ).toString(),
     },
   });
 }
@@ -52,7 +55,7 @@ function resolveDocsMarkdownRequest(input: {
   isEventDocsHost: boolean;
   pathname: string;
 }): DocsMarkdownRequest | null {
-  const path = normalizePath(input.pathname);
+  const path = decodeURIComponent(input.pathname).replace(/^\/+|\/+$/g, "");
   const markdownPath = stripMarkdownIndexSuffix(path);
   const forceMarkdown = markdownPath !== path || path.endsWith(".md") || path.endsWith("llms.txt");
 
@@ -305,10 +308,6 @@ function stripMarkdownIndexSuffix(path: string) {
   return path;
 }
 
-function normalizePath(pathname: string) {
-  return decodeURIComponent(pathname).replace(/^\/+|\/+$/g, "");
-}
-
 function prefersMarkdown(accept: string | null) {
   const parsed = parseAccept(accept);
   if (parsed.length === 0) return false;
@@ -342,8 +341,4 @@ function bestQuality(parsed: readonly { mediaType: string; q: number }[], mediaT
   const matches = parsed.filter((item) => mediaTypes.includes(item.mediaType));
   if (matches.length === 0) return null;
   return Math.max(...matches.map((item) => item.q));
-}
-
-function estimateTokenCount(markdown: string) {
-  return Math.ceil(markdown.split(/\s+/).filter(Boolean).length * 1.35);
 }

--- a/apps/os/src/orpc/routers/projects.ts
+++ b/apps/os/src/orpc/routers/projects.ts
@@ -50,7 +50,7 @@ function toProject(row: ProjectRow) {
 async function toProjectWithIngressUrl(row: ProjectRow) {
   return {
     ...toProject(row),
-    ingressUrl: await projectDurableObject(row.id).ingressUrl(),
+    ingressUrl: await getProjectDurableObjectStub(row.id).ingressUrl(),
   };
 }
 
@@ -90,10 +90,6 @@ function normalizeConfigCustomHostname(
   }
 
   return customHostname;
-}
-
-function isUniqueConstraintError(error: unknown) {
-  return error instanceof Error && error.message.includes("UNIQUE constraint failed");
 }
 
 export const projectsRouter = {
@@ -147,7 +143,7 @@ export const projectsRouter = {
             { id: input.id },
           );
         } catch (error) {
-          if (isUniqueConstraintError(error)) {
+          if (error instanceof Error && error.message.includes("UNIQUE constraint failed")) {
             throw new ORPCError("CONFLICT", {
               message: `Custom hostname ${nextCustomHostname} is already assigned.`,
             });
@@ -234,7 +230,9 @@ export const projectsRouter = {
         const project = requireProjectScope(context);
         // Raw Workers stub: await the property before calling (workerd does
         // not pipeline through property accesses; itx handles wrap this).
-        const processor = await projectStateDurableObject(project.id).processor;
+        const processor = await (
+          getProjectDurableObjectStub(project.id) as unknown as ProjectStateRpc
+        ).processor;
         return await processor.snapshot();
       }),
     agents: projectAgentsRouter,
@@ -267,16 +265,8 @@ async function requireProject(input: { context: RequestContext; projectId: strin
   return await requireAuthorizedProject(input);
 }
 
-function projectDurableObject(projectId: string) {
-  return getProjectDurableObjectStub(projectId);
-}
-
 // Processors extend RpcTarget (capnweb's, which IS cloudflare:workers' inside
 // workerd), so the `processor` getter traverses the stub.
 type ProjectStateRpc = {
   processor: { snapshot(): Promise<unknown> };
 };
-
-function projectStateDurableObject(projectId: string): ProjectStateRpc {
-  return getProjectDurableObjectStub(projectId) as unknown as ProjectStateRpc;
-}

--- a/apps/os/src/routes/_app/projects/$projectSlug/integrations.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/integrations.tsx
@@ -52,7 +52,7 @@ function ProjectIntegrationsPage() {
   const googleQuery = projectGoogleConnectionQueryOptions(project.id);
   const { data: slackConnection } = useQuery(slackQuery);
   const { data: googleConnection } = useQuery(googleQuery);
-  const oauthErrorLabel = search.error ? formatOAuthError(search.error) : null;
+  const oauthErrorLabel = search.error ? search.error.replaceAll("_", " ") : null;
 
   const startSlack = useMutation(
     orpc.project.integrations.startSlackOAuthFlow.mutationOptions({
@@ -282,10 +282,6 @@ function formatTimestamp(value: string) {
     dateStyle: "medium",
     timeStyle: "short",
   }).format(new Date(timestamp));
-}
-
-function formatOAuthError(value: string) {
-  return value.replaceAll("_", " ");
 }
 
 function countScopes(scopes: string | null, separator: "," | " ") {

--- a/apps/os/src/routes/_app/projects/$projectSlug/route.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/route.tsx
@@ -13,9 +13,5 @@ export const Route = createFileRoute("/_app/projects/$projectSlug")({
       breadcrumb: context.project.slug,
     };
   },
-  component: ProjectLayout,
+  component: () => <Outlet />,
 });
-
-function ProjectLayout() {
-  return <Outlet />;
-}

--- a/apps/os/src/routes/_app/projects/route.tsx
+++ b/apps/os/src/routes/_app/projects/route.tsx
@@ -3,9 +3,5 @@ import { breadcrumbStaticData } from "~/lib/route-breadcrumbs.ts";
 
 export const Route = createFileRoute("/_app/projects")({
   staticData: breadcrumbStaticData("Projects"),
-  component: ProjectsLayout,
+  component: () => <Outlet />,
 });
-
-function ProjectsLayout() {
-  return <Outlet />;
-}

--- a/apps/os/src/routes/sign-up.$.tsx
+++ b/apps/os/src/routes/sign-up.$.tsx
@@ -4,9 +4,5 @@ export const Route = createFileRoute("/sign-up/$")({
   beforeLoad: () => {
     throw redirect({ href: "/api/iterate-auth/login" });
   },
-  component: SignUpRoute,
+  component: () => <main className="grid min-h-svh place-items-center bg-background p-4" />,
 });
-
-function SignUpRoute() {
-  return <main className="grid min-h-svh place-items-center bg-background p-4" />;
-}

--- a/apps/os/src/rpc-targets/openapi-bridge-core.ts
+++ b/apps/os/src/rpc-targets/openapi-bridge-core.ts
@@ -46,7 +46,7 @@ export async function executeOpenApiToolFunction(input: OpenApiBridgeInput) {
     }));
   }
 
-  const operation = findOpenApiOperation(spec, operationId);
+  const operation = listOpenApiOperations(spec).find((op) => op.operationId === operationId);
   if (!operation) throw new Error(`Operation "${operationId}" not found in spec`);
   const [payload] = input.args;
 
@@ -97,10 +97,6 @@ function listOpenApiOperations(spec: Record<string, unknown>): OpenApiOperation[
   }
 
   return operations;
-}
-
-function findOpenApiOperation(spec: Record<string, unknown>, operationId: string) {
-  return listOpenApiOperations(spec).find((op) => op.operationId === operationId);
 }
 
 function buildOpenApiRequestUrl(

--- a/apps/semaphore/src/routes/__root.tsx
+++ b/apps/semaphore/src/routes/__root.tsx
@@ -34,7 +34,9 @@ export const Route = createRootRouteWithContext<RouterContext>()({
   }),
   shellComponent: RootDocument,
   component: RootComponent,
-  errorComponent: RootErrorComponent,
+  errorComponent: (props: { error: unknown; reset: () => void }) => (
+    <DefaultErrorComponent {...props} />
+  ),
 });
 
 function RootDocument({ children }: { children: ReactNode }) {
@@ -76,8 +78,4 @@ function RootComponent() {
       <Outlet />
     </AppProviders>
   );
-}
-
-function RootErrorComponent(props: { error: unknown; reset: () => void }) {
-  return <DefaultErrorComponent {...props} />;
 }

--- a/oxlint-plugin-iterate.js
+++ b/oxlint-plugin-iterate.js
@@ -145,6 +145,44 @@ function isFunctionLikeDeclaration(node) {
   });
 }
 
+/**
+ * Counts the source lines spanned by a function's body content: the statements between the
+ * braces, or the expression of a concise arrow. Brace-only lines don't count, so
+ * `function f() {\n  return x;\n}` is 1 line.
+ *
+ * @param {import("eslint").SourceCode} sourceCode
+ * @param {import("estree").Function} fn
+ */
+function getFunctionBodyLineCount(sourceCode, fn) {
+  const body = fn.body;
+  if (!body) return Infinity; // overload signatures / declare function
+  let start;
+  let end;
+  if (body.type === "BlockStatement") {
+    const statements = body.body;
+    if (statements.length === 0) return 0;
+    start = statements[0].range?.[0];
+    end = statements[statements.length - 1].range?.[1];
+  } else {
+    start = body.range?.[0];
+    end = body.range?.[1];
+  }
+  if (start === undefined || end === undefined) return Infinity;
+  return sourceCode.getText().slice(start, end).split("\n").length;
+}
+
+/**
+ * @param {import("eslint").Scope.Scope | null} scope
+ * @param {string} name
+ */
+function findVariableInScopeChain(scope, name) {
+  for (let current = scope; current; current = current.upper) {
+    const variable = current.variables.find((v) => v.name === name);
+    if (variable) return variable;
+  }
+  return undefined;
+}
+
 /** @param {string} text */
 function compactTypeText(text) {
   return text.replace(/\s+/g, "");
@@ -581,6 +619,81 @@ const plugin = {
               message:
                 "Avoid vi.mock/vi.doMock in tests. Prefer dependency injection or a controllable fake dependency.",
             });
+          },
+        };
+      },
+    },
+    "no-single-use-helpers": {
+      meta: {
+        type: "suggestion",
+        docs: {
+          description:
+            "Flag tiny non-exported helper functions that are only used once. Inline them so the reader can see what's actually happening instead of chasing an indirection.",
+        },
+      },
+      create(context) {
+        const MAX_BODY_LINES = 1;
+
+        /**
+         * @param {import("estree").Identifier} id the helper's name binding
+         * @param {import("estree").Function} fn the function node
+         * @param {import("estree").Node} statement the enclosing declaration statement
+         */
+        function checkHelper(id, fn, statement) {
+          const exportParent = statement.parent?.type;
+          if (
+            exportParent === "ExportNamedDeclaration" ||
+            exportParent === "ExportDefaultDeclaration"
+          ) {
+            return;
+          }
+
+          const bodyLines = getFunctionBodyLineCount(context.sourceCode, fn);
+          if (bodyLines > MAX_BODY_LINES) return;
+
+          const scope = context.sourceCode.getScope(statement);
+          const variable = findVariableInScopeChain(scope, id.name);
+          if (!variable) return;
+
+          const reads = variable.references.filter((ref) => ref.isRead());
+          // `export { helper }` / `export default helper` make it part of the module's surface
+          const isExportedReference = reads.some((ref) => {
+            const parentType = ref.identifier.parent?.type;
+            return parentType === "ExportSpecifier" || parentType === "ExportDefaultDeclaration";
+          });
+          if (isExportedReference) return;
+
+          // a recursive helper can't be inlined, so any self-reference disqualifies it
+          const hasSelfReference = reads.some((ref) => {
+            const referenceStart = ref.identifier.range?.[0];
+            if (referenceStart === undefined || !fn.range) return false;
+            return referenceStart >= fn.range[0] && referenceStart < fn.range[1];
+          });
+          if (hasSelfReference) return;
+          if (reads.length !== 1) return;
+
+          context.report({
+            node: id,
+            message:
+              `${id.name} is a single-use helper with a ${bodyLines}-line body. ` +
+              `Inline it at the call site so the reader can see what's actually happening.`,
+          });
+        }
+
+        return {
+          FunctionDeclaration(node) {
+            if (!node.id) return;
+            checkHelper(node.id, node, node);
+          },
+          VariableDeclarator(node) {
+            if (node.id.type !== "Identifier" || !node.init) return;
+            if (
+              node.init.type !== "ArrowFunctionExpression" &&
+              node.init.type !== "FunctionExpression"
+            ) {
+              return;
+            }
+            checkHelper(node.id, node.init, node.parent);
           },
         };
       },

--- a/oxlint-plugin-iterate.js
+++ b/oxlint-plugin-iterate.js
@@ -42,13 +42,8 @@ function getPropertyName(node) {
 }
 
 /** @param {string} filename */
-function normalizePathForLint(filename) {
-  return filename.replaceAll("\\", "/");
-}
-
-/** @param {string} filename */
 function isAllowedRawDurableObjectBindingAccessFile(filename) {
-  const path = normalizePathForLint(filename);
+  const path = filename.replaceAll("\\", "/");
 
   if (!path.includes("/apps/os/src/")) return true;
   if (path.includes("/apps/os/docs/")) return true;
@@ -107,11 +102,6 @@ function getTestLintCallObjectName(node) {
 function isDescribeCall(callee) {
   const name = getTestLintCallName(callee);
   return name === "describe" || Boolean(name?.startsWith("describe."));
-}
-
-/** @param {import("estree").Node} callee */
-function isLifecycleHookCall(callee) {
-  return callee.type === "Identifier" && LIFECYCLE_HOOKS.has(callee.name);
 }
 
 /** @param {import("estree").Node} callee */
@@ -571,7 +561,7 @@ const plugin = {
       create(context) {
         return {
           CallExpression(node) {
-            if (!isLifecycleHookCall(node.callee)) return;
+            if (node.callee.type !== "Identifier" || !LIFECYCLE_HOOKS.has(node.callee.name)) return;
             context.report({
               node,
               message:

--- a/packages/iterate/src/cli.ts
+++ b/packages/iterate/src/cli.ts
@@ -307,9 +307,6 @@ const base64Url = (buffer: Buffer) => buffer.toString("base64url");
 
 const randomBase64Url = (byteLength = 32) => base64Url(randomBytes(byteLength));
 
-const pkceChallenge = (verifier: string) =>
-  base64Url(createHash("sha256").update(verifier).digest());
-
 const openUrlInBrowser = async (url: string) => {
   try {
     const { execFile } = await import("node:child_process");
@@ -447,12 +444,11 @@ const startOAuthCallbackServer = async (): Promise<{
 
   const address = server.address();
   const port = typeof address === "object" && address ? address.port : 0;
-  const close = () => new Promise<void>((resolve) => server.close(() => resolve()));
 
   return {
     redirectUri: `http://${LOOPBACK_HOST}:${port}${LOOPBACK_CALLBACK_PATH}`,
     wait: () => callbackPromise.finally(() => clearTimeout(timeout)),
-    close,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
   };
 };
 
@@ -565,7 +561,10 @@ const oauthLogin = async (config: Config): Promise<StoredSession> => {
   authorizeUrl.searchParams.set("scope", OAUTH_SCOPE);
   authorizeUrl.searchParams.set("resource", config.osBaseUrl);
   authorizeUrl.searchParams.set("state", state);
-  authorizeUrl.searchParams.set("code_challenge", pkceChallenge(codeVerifier));
+  authorizeUrl.searchParams.set(
+    "code_challenge",
+    base64Url(createHash("sha256").update(codeVerifier).digest()),
+  );
   authorizeUrl.searchParams.set("code_challenge_method", "S256");
 
   console.error(`\nOpening browser to authenticate with Iterate:\n`);

--- a/packages/iterate/src/os/claude-mcp.ts
+++ b/packages/iterate/src/os/claude-mcp.ts
@@ -39,7 +39,7 @@ export const claudeMcpScript = os
   })
   .handler(async ({ input }) => {
     const adminToken = requireEnv("APP_CONFIG_ADMIN_API_SECRET");
-    const mcpUrl = input.baseHost ? mcpUrlFromBaseHost(input.baseHost) : defaultMcpUrlFromEnv();
+    const mcpUrl = input.baseHost ? normalizeBaseUrl(input.baseHost) : defaultMcpUrlFromEnv();
     await assertMcpAdminBearerAccepted({ mcpUrl, token: adminToken });
     const command = buildClaudeShellCommand([
       "--mcp-config",
@@ -94,10 +94,6 @@ function requireEnv(name: string) {
     throw new Error(`claude-mcp requires ${name} in the current environment.`);
   }
   return value;
-}
-
-function mcpUrlFromBaseHost(value: string) {
-  return normalizeBaseUrl(value);
 }
 
 function normalizeBaseUrl(value: string) {

--- a/packages/iterate/src/stream-tui/command-discovery.ts
+++ b/packages/iterate/src/stream-tui/command-discovery.ts
@@ -100,7 +100,7 @@ export function suggestSlashCommands<TCommand extends SlashCommandRecord>(args: 
 }
 
 export function acceptedSlashInput(command: SlashCommandRecord) {
-  return `/${command.slash.name}${commandNeedsInput(command) ? " " : ""}`;
+  return `/${command.slash.name}${command.input?.positional?.required === true ? " " : ""}`;
 }
 
 export function formatSlashCommandLabel(command: SlashCommandRecord) {
@@ -145,10 +145,6 @@ function scoreSlashCommand(args: { command: SlashCommandRecord; query: string })
   if (fuzzyMatchRanges(slash, args.query).length > 0) return 18;
   if (fuzzyMatchRanges(title, args.query).length > 0) return 10;
   return 0;
-}
-
-function commandNeedsInput(command: SlashCommandRecord) {
-  return command.input?.positional?.required === true;
 }
 
 /**

--- a/packages/iterate/src/stream-tui/command-invocation.ts
+++ b/packages/iterate/src/stream-tui/command-invocation.ts
@@ -44,7 +44,7 @@ export function parseSlashCommandInput(args: {
   }
 
   for (const flag of args.input.flags ?? []) {
-    if (hasFlag(remainingArgs, flag.flag)) {
+    if (remainingArgs.split(/\s+/).includes(flag.flag)) {
       input[flag.name] = flag.value;
       remainingArgs = removeFlag(remainingArgs, flag.flag);
     }
@@ -81,8 +81,9 @@ export function removeStringOption(rawArgs: string, optionName: string) {
 }
 
 function matchStringOption(rawArgs: string, optionName: string) {
+  const escapedOptionName = optionName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const pattern = new RegExp(
-    `(?:^|\\s)${escapeRegExp(optionName)}(?:=|\\s+)(?:"([^"]+)"|'([^']+)'|(\\S+))`,
+    `(?:^|\\s)${escapedOptionName}(?:=|\\s+)(?:"([^"]+)"|'([^']+)'|(\\S+))`,
   );
   const match = pattern.exec(rawArgs);
   if (match == null || match.index == null) return undefined;
@@ -94,18 +95,10 @@ function matchStringOption(rawArgs: string, optionName: string) {
   };
 }
 
-function hasFlag(rawArgs: string, flagName: string) {
-  return rawArgs.split(/\s+/).includes(flagName);
-}
-
 function removeFlag(rawArgs: string, flagName: string) {
   return rawArgs
     .split(/\s+/)
     .filter((part) => part !== flagName)
     .join(" ")
     .trim();
-}
-
-function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/packages/iterate/src/stream-tui/command-router.ts
+++ b/packages/iterate/src/stream-tui/command-router.ts
@@ -418,8 +418,8 @@ function collectCommandEntries(
       continue;
     }
 
-    if (isRecord(value)) {
-      entries.push(...collectCommandEntries(value, pathSegments));
+    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+      entries.push(...collectCommandEntries(value as Record<string, unknown>, pathSegments));
     }
   }
 
@@ -433,8 +433,4 @@ function readCommandMeta(procedure: CommandProcedure) {
   }
 
   return meta.tui;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/iterate/src/stream-tui/event-stream-terminal.tsx
+++ b/packages/iterate/src/stream-tui/event-stream-terminal.tsx
@@ -1042,7 +1042,7 @@ function createOAuthAuthProvider(initialSession: OAuthRuntimeSession, cookie: st
   let lastForcedRefreshAt = 0;
 
   const refresh = async (force: boolean) => {
-    if (!canRefreshOAuthSession(session)) return false;
+    if (!(session.refreshToken && session.clientId && session.authBaseUrl)) return false;
     if (force) {
       const now = Date.now();
       if (now - lastForcedRefreshAt < OAUTH_FORCE_REFRESH_THROTTLE_MS) return false;
@@ -1078,10 +1078,6 @@ function authHeaders(input: { bearerToken: string | undefined; cookie: string | 
     ...(input.bearerToken ? { Authorization: `Bearer ${input.bearerToken}` } : {}),
     ...(input.cookie ? { Cookie: input.cookie } : {}),
   };
-}
-
-function canRefreshOAuthSession(session: OAuthRuntimeSession) {
-  return Boolean(session.refreshToken && session.clientId && session.authBaseUrl);
 }
 
 function sessionNeedsRefresh(session: OAuthRuntimeSession) {

--- a/packages/mock-http-proxy/src/har/har-format.ts
+++ b/packages/mock-http-proxy/src/har/har-format.ts
@@ -52,10 +52,6 @@ function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 
-function extractTimestamp(startedDateTime: string): string {
-  return startedDateTime.slice(11, 19);
-}
-
 function truncateDisplay(text: string, maxLen: number): string {
   if (text.length <= maxLen) return text;
   return `${text.slice(0, maxLen)}... (${formatSize(text.length)})`;
@@ -71,10 +67,6 @@ function tryPrettyJson(text: string, maxLen: number): string | null {
   } catch {
     return null;
   }
-}
-
-function isSSE(mimeType: string): boolean {
-  return mimeType.startsWith("text/event-stream");
 }
 
 function formatSSEBody(text: string, opts: FormatHarEntryOptions): string {
@@ -209,8 +201,9 @@ export function formatHarEntry(
   const meta = entry._iterateMetadata;
   const sanitizedHeaders = new Set(meta?.sanitizedHeaders ?? []);
 
+  // slice(11, 19) extracts HH:MM:SS from the ISO startedDateTime
   const prefix = opts.timestamp
-    ? `${c(DIM, extractTimestamp(entry.startedDateTime), opts.color)} `
+    ? `${c(DIM, entry.startedDateTime.slice(11, 19), opts.color)} `
     : "";
   lines.push(`${prefix}${formatHarEntryOneLine(entry, { color: opts.color })}`);
 
@@ -271,7 +264,7 @@ export function formatHarEntry(
             : "";
         lines.push(c(DIM, `  -- Response body (${sizeLabel}${truncLabel}) --`, opts.color));
 
-        if (isSSE(entry.response.content.mimeType)) {
+        if (entry.response.content.mimeType.startsWith("text/event-stream")) {
           const sseText = truncateDisplay(entry.response.content.text, opts.maxBodyLength);
           lines.push(indentBlock(formatSSEBody(sseText, opts), "    "));
         } else {

--- a/packages/mock-http-proxy/src/har/har-sanitizer.ts
+++ b/packages/mock-http-proxy/src/har/har-sanitizer.ts
@@ -311,13 +311,6 @@ function sanitizeWebSocketMessage(message: HarWebSocketMessage): HarWebSocketMes
   return { ...message, data: JSON.stringify(sanitized) };
 }
 
-function findHeader(
-  headers: Array<{ name: string; value: string }>,
-  name: string,
-): { name: string; value: string } | undefined {
-  return headers.find((h) => h.name.toLowerCase() === name.toLowerCase());
-}
-
 function setOrAddHeader(
   headers: Array<{ name: string; value: string }>,
   name: string,
@@ -396,7 +389,9 @@ export function createDefaultHarSanitizer(): HarEntrySanitizer {
       sanitized.response.content.size = newSize;
       sanitized.response.bodySize = newSize;
 
-      const existingCL = findHeader(sanitized.response.headers, "content-length");
+      const existingCL = sanitized.response.headers.find(
+        (h) => h.name.toLowerCase() === "content-length",
+      );
       if (existingCL) {
         sanitized.response.headers = setOrAddHeader(
           sanitized.response.headers,

--- a/packages/mock-http-proxy/src/server/msw-server-adapter.ts
+++ b/packages/mock-http-proxy/src/server/msw-server-adapter.ts
@@ -89,14 +89,6 @@ export type CreateNativeMswServerOptions = {
   }) => boolean;
 };
 
-function isRequestHandler(handler: AnyHandler): handler is msw.RequestHandler {
-  return handler instanceof RequestHandler;
-}
-
-function isWebSocketHandler(handler: AnyHandler): handler is msw.WebSocketHandler {
-  return handler instanceof WebSocketHandler;
-}
-
 function incomingToWebSocketUrl(req: http.IncomingMessage): URL {
   const protocol =
     "encrypted" in req.socket && Boolean((req.socket as tls.TLSSocket).encrypted) ? "wss:" : "ws:";
@@ -437,7 +429,9 @@ export function createNativeMswServer(
       const startedAt = Date.now();
       const rawRequest = incomingToWebRequest(req);
       const webRequest = transformRequest ? transformRequest(rawRequest) : rawRequest;
-      const activeHandlers = msw.listHandlers().filter(isRequestHandler);
+      const activeHandlers = msw
+        .listHandlers()
+        .filter((handler) => handler instanceof RequestHandler);
       const requestId = `native-${randomUUID()}`;
       const mockedResponse = await handleRequest(
         webRequest,
@@ -573,7 +567,9 @@ export function createNativeMswServer(
   };
 
   nodeServer.on("upgrade", (req, socket, head) => {
-    const webSocketHandlers = msw.listHandlers().filter(isWebSocketHandler);
+    const webSocketHandlers = msw
+      .listHandlers()
+      .filter((handler) => handler instanceof WebSocketHandler);
     const rawWsUrl = incomingToWebSocketUrl(req);
     const wsHeaders = incomingHeadersToHeaders(req.headers);
     const requestUrl = transformWebSocketUrl

--- a/packages/mock-http-proxy/src/server/proxy-request-transform.ts
+++ b/packages/mock-http-proxy/src/server/proxy-request-transform.ts
@@ -23,15 +23,14 @@ function isLoopbackHost(host: string): boolean {
   return name === "localhost" || name === "::1" || name === "127.0.0.1" || name.startsWith("127.");
 }
 
-function normalizeProto(value: string): string {
-  return value.trim().toLowerCase().replace(/:$/, "");
-}
-
 function resolveTargetUrl(requestUrl: URL, headers: Headers, scheme: "http" | "ws"): URL | null {
   const host = headers.get(X_FORWARDED_HOST_HEADER) ?? headers.get("host") ?? "";
   if (!host) return null;
 
-  const proto = normalizeProto(headers.get(X_FORWARDED_PROTO_HEADER) ?? "");
+  const proto = (headers.get(X_FORWARDED_PROTO_HEADER) ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/:$/, "");
 
   let targetScheme: string;
   if (scheme === "ws") {

--- a/packages/shared/src/alchemy/iterate-app.ts
+++ b/packages/shared/src/alchemy/iterate-app.ts
@@ -218,7 +218,13 @@ export async function IterateApp<B extends Bindings>(
       );
     }
 
-    const dnsRouteHosts = routeHosts.filter(shouldCreateDnsRecordForRouteHostname);
+    // Cloudflare accepts route patterns like `*-preview-1.iterate.app/*`, but
+    // DNS has no equivalent partial-label wildcard record. OS preview relies on
+    // the existing proxied `*.iterate.app` DNS record for those one-label project
+    // hosts, while ordinary exact and `*.` wildcard routes still get app-owned DNS.
+    const dnsRouteHosts = routeHosts.filter(
+      (hostname) => !hostname.startsWith("*") || hostname.startsWith("*."),
+    );
     await Promise.all(
       dnsRouteHosts.map(async (hostname) => {
         const zoneId =
@@ -268,14 +274,6 @@ function routeResourceIdForHostname(hostname: string) {
   return hostname.startsWith("*.")
     ? `route-wildcard-${slugify(hostname.slice(2))}`
     : `route-${slugify(hostname)}`;
-}
-
-function shouldCreateDnsRecordForRouteHostname(hostname: string) {
-  // Cloudflare accepts route patterns like `*-preview-1.iterate.app/*`, but
-  // DNS has no equivalent partial-label wildcard record. OS preview relies on
-  // the existing proxied `*.iterate.app` DNS record for those one-label project
-  // hosts, while ordinary exact and `*.` wildcard routes still get app-owned DNS.
-  return !hostname.startsWith("*") || hostname.startsWith("*.");
 }
 
 /**

--- a/packages/shared/src/apps/cli.ts
+++ b/packages/shared/src/apps/cli.ts
@@ -551,11 +551,9 @@ function getValidationIssues(error: unknown): ValidationIssue[] {
     return [];
   }
 
-  return rawIssues.filter(isValidationIssue);
-}
-
-function isValidationIssue(value: unknown): value is ValidationIssue {
-  return typeof value === "object" && value !== null;
+  return rawIssues.filter(
+    (value): value is ValidationIssue => typeof value === "object" && value !== null,
+  );
 }
 
 function formatIssue(issue: ValidationIssue) {

--- a/packages/shared/src/callable/runtime.ts
+++ b/packages/shared/src/callable/runtime.ts
@@ -419,13 +419,9 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return prototype === Object.prototype || prototype === null;
 }
 
-function isFetchCallable(callable: Callable): callable is FetchCallable {
-  return callable.type === "fetch";
-}
-
 function validateFetchCallable(options: { callable: unknown }): FetchCallable {
   const callable = validateCallable({ callable: options.callable });
-  if (!isFetchCallable(callable)) {
+  if (callable.type !== "fetch") {
     throw new CallableError("DESCRIPTOR_VALIDATION_FAILED", `Unsupported callable kind`);
   }
   return callable;

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -277,16 +277,14 @@ function getBaseConfigEnvKey(prefix: string) {
   return baseKey;
 }
 
-function formatEnvSegment(segment: string) {
-  return segment.replace(/([A-Z])/g, "_$1").toUpperCase();
-}
-
 function formatEnvOverrideKey(prefix: string, path: AppConfigPath) {
   if (path.length === 0) {
     return getBaseConfigEnvKey(prefix);
   }
 
-  return `${prefix}${path.map(formatEnvSegment).join(ENV_PATH_SEPARATOR)}`;
+  return `${prefix}${path
+    .map((segment) => segment.replace(/([A-Z])/g, "_$1").toUpperCase())
+    .join(ENV_PATH_SEPARATOR)}`;
 }
 
 function formatConfigPath(path: AppConfigPath) {

--- a/packages/shared/src/durable-object-utils/e2e/alchemy.run.ts
+++ b/packages/shared/src/durable-object-utils/e2e/alchemy.run.ts
@@ -46,8 +46,6 @@ const AlchemyEnv = z.object({
 });
 
 const env = AlchemyEnv.parse(process.env);
-const stateStore = (scope: Scope) =>
-  scope.local ? new SQLiteStateStore(scope, { engine: "libsql" }) : new CloudflareStateStore(scope);
 
 // Alchemy treats CI as non-interactive by default. Local Alchemy runs are a
 // developer workflow, so let Alchemy use its local behavior when requested.
@@ -57,7 +55,10 @@ const app = await alchemy(APP_NAME, {
   stage: env.ALCHEMY_STAGE,
   local: env.ALCHEMY_LOCAL,
   password: env.ALCHEMY_PASSWORD,
-  stateStore,
+  stateStore: (scope: Scope) =>
+    scope.local
+      ? new SQLiteStateStore(scope, { engine: "libsql" })
+      : new CloudflareStateStore(scope),
 });
 
 const workerName = makeWorkerName(APP_NAME, app.stage);

--- a/packages/shared/src/durable-object-utils/mixins/with-lifecycle-hooks.ts
+++ b/packages/shared/src/durable-object-utils/mixins/with-lifecycle-hooks.ts
@@ -951,11 +951,7 @@ export function serializeDurableObjectStructuredName(options: {
     return options.structuredName;
   }
 
-  return canonicalFlatNameJson(options.structuredName);
-}
-
-function canonicalFlatNameJson(value: Record<string, LifecycleStructuredNamePrimitive>): string {
-  return JSON.stringify(canonicalizeStructuredNameRecord(value));
+  return JSON.stringify(canonicalizeStructuredNameRecord(options.structuredName));
 }
 
 function canonicalizeStructuredNameRecord(

--- a/packages/shared/src/durable-object-utils/test-harness/initialize-fronting-worker.ts
+++ b/packages/shared/src/durable-object-utils/test-harness/initialize-fronting-worker.ts
@@ -370,7 +370,12 @@ export default {
         const stub = env.ROOMS.getByName(name);
         const result = await stub.trySendMessage(requireString(body.text, "text"));
 
-        if (isCaughtErrorResult(result)) {
+        if (
+          typeof result === "object" &&
+          result !== null &&
+          "kind" in result &&
+          result.kind === "error"
+        ) {
           return json(
             {
               error: result.name,
@@ -423,8 +428,4 @@ function serializeError(error: unknown): CaughtErrorResult {
     name: error instanceof Error ? error.name : "UnknownError",
     message: error instanceof Error ? error.message : String(error),
   };
-}
-
-function isCaughtErrorResult(value: unknown): value is CaughtErrorResult {
-  return typeof value === "object" && value !== null && "kind" in value && value.kind === "error";
 }

--- a/packages/shared/src/posthog/posthog.ts
+++ b/packages/shared/src/posthog/posthog.ts
@@ -5,10 +5,6 @@ export interface ProxyPosthogRequestOptions {
   assetHost?: string;
 }
 
-function isNullBodyStatus(status: number) {
-  return status === 101 || status === 103 || status === 204 || status === 205 || status === 304;
-}
-
 function upstreamRequestBody(request: Request): ReadableStream<Uint8Array> | undefined {
   if (request.method === "GET" || request.method === "HEAD") return undefined;
   // Stream the body through instead of buffering (same idea as forwarding `c.req.raw.body` in Workers).
@@ -53,9 +49,12 @@ export async function proxyPosthogRequest(options: ProxyPosthogRequestOptions): 
     responseHeaders.delete("content-length");
   }
 
-  const body = isNullBodyStatus(upstreamResponse.status)
-    ? null
-    : await upstreamResponse.arrayBuffer();
+  // Null-body statuses: `new Response()` throws if given a body for these.
+  const status = upstreamResponse.status;
+  const body =
+    status === 101 || status === 103 || status === 204 || status === 205 || status === 304
+      ? null
+      : await upstreamResponse.arrayBuffer();
 
   return new Response(body, {
     status: upstreamResponse.status,

--- a/packages/streams/example-app/e2e/playwright/stream-browser.spec.ts
+++ b/packages/streams/example-app/e2e/playwright/stream-browser.spec.ts
@@ -252,7 +252,7 @@ test("event feed view starts at the bottom on first visit while replay fills the
     timeout: 30_000,
   });
   await expect(page.getByTestId("stream-status")).toHaveText("subscribed", { timeout: 30_000 });
-  await expectAtFeedEnd(page);
+  await expect.poll(() => feedDistanceFromEnd(page)).toBeLessThanOrEqual(2);
   await expect(page.getByTestId("feed-scroll-to-bottom-affordance")).toHaveCount(0);
   await freshContext.close();
 });
@@ -985,10 +985,6 @@ async function feedDistanceFromEnd(page: Page) {
       throw new Error("event feed scroller must be an HTMLElement");
     return Math.round(element.scrollHeight - element.clientHeight - element.scrollTop);
   });
-}
-
-async function expectAtFeedEnd(page: Page) {
-  await expect.poll(() => feedDistanceFromEnd(page)).toBeLessThanOrEqual(2);
 }
 
 async function composerDistanceFromScrollerBottom(page: Page) {

--- a/packages/streams/example-app/e2e/vitest/stream-capnweb.test.ts
+++ b/packages/streams/example-app/e2e/vitest/stream-capnweb.test.ts
@@ -611,12 +611,17 @@ describe("stream capnweb protocol", () => {
     const inbound = parsedFrames(frames)
       .slice(afterSubscribe)
       .filter((frame) => frame.direction === "in");
-    expect(inbound.every((frame) => isPushOrReleaseFrame(frame.data))).toBe(true);
+    expect(
+      inbound.every(
+        (frame) =>
+          isPushFrame(frame.data) || (Array.isArray(frame.data) && frame.data[0] === "release"),
+      ),
+    ).toBe(true);
     // Earlier push frames race the `afterSubscribe` snapshot and each other:
     // the subscription's initial state push (events: []) and the
     // subscriber-connected fact's delivery. Assert the last frame (the
     // published event's) exactly; earlier ones are push frames by the
-    // `isPushOrReleaseFrame` check above.
+    // push-or-release check above.
     const pushFrames = inbound.filter((frame) => isPushFrame(frame.data));
     expect(pushFrames.length).toBeGreaterThanOrEqual(1);
     expect(pushFrames.at(-1)).toMatchObject({
@@ -659,10 +664,6 @@ function outboundFrames(messages: WebSocketFrame[], afterFrameIndex: number) {
     .slice(afterFrameIndex)
     .filter((frame) => frame.direction === "out")
     .map((frame) => frame.data);
-}
-
-function isPushOrReleaseFrame(value: unknown) {
-  return isPushFrame(value) || (Array.isArray(value) && value[0] === "release");
 }
 
 function isPushFrame(value: unknown) {

--- a/packages/streams/src/browser/processor-state-storage.test.ts
+++ b/packages/streams/src/browser/processor-state-storage.test.ts
@@ -47,8 +47,6 @@ function wrap(db: DatabaseSync): SqlClient {
   };
 }
 
-const iterateContext = () => ({ stream: { append() {}, appendBatch() {} } });
-
 function rawEvent(offset: number): StreamEvent {
   return { type: "test/raw", payload: { offset }, offset, createdAt: new Date(0).toISOString() };
 }
@@ -59,7 +57,7 @@ function createRawEventsProcessor(sql: SqlClient) {
     processorSlug: BrowserRawEventsContract.slug,
   });
   return new BrowserRawEventsProcessor({
-    iterateContext: iterateContext(),
+    iterateContext: { stream: { append() {}, appendBatch() {} } },
     sql,
     readState: storage.readState,
     writeState: storage.writeState,

--- a/packages/streams/src/browser/stream-browser-db.ts
+++ b/packages/streams/src/browser/stream-browser-db.ts
@@ -80,8 +80,8 @@ export class StreamBrowserDatabase implements Disposable {
     readonly namespace: string,
     readonly streamPath: string,
   ) {
-    this.databasePath = databasePathFor(namespace, streamPath);
-    this.downloadFilename = downloadFilenameFor(namespace, streamPath);
+    this.databasePath = `${encodeURIComponent(namespace)}/${DATABASE_CACHE_VERSION}/${databaseSlugForStreamPath(streamPath)}.sqlite3`;
+    this.downloadFilename = `${encodeURIComponent(namespace)}__${DATABASE_CACHE_VERSION}-${databaseSlugForStreamPath(streamPath)}.sqlite3`;
     this.#worker = new Worker(new URL("./stream-db.worker.ts", import.meta.url), {
       type: "module",
     });
@@ -310,10 +310,15 @@ export class StreamBrowserDatabase implements Disposable {
       const data = await this.exec(entry.sql, entry.params);
       next = { data, status: "ok", error: undefined };
     } catch (error) {
-      if (isMissingTableError(error)) {
+      if (error instanceof Error && error.message.includes("no such table")) {
         // A view's table may not exist until its processor's first write creates it. Treat
-        // that as an empty result (count 0 / no rows) rather than a surfaced error.
-        next = { data: emptyTableRows(entry.sql), status: "ok", error: undefined };
+        // that as an empty result rather than a surfaced error: a `SELECT COUNT(*) AS count
+        // ...` over a not-yet-created table reads as 0, anything else reads as no rows.
+        next = {
+          data: /^\s*SELECT\s+COUNT\(\*\)\s+AS\s+count\b/i.test(entry.sql) ? [{ count: 0 }] : [],
+          status: "ok",
+          error: undefined,
+        };
       } else {
         console.error(`[stream-browser-db ${this.streamPath}] SQLite query failed`, {
           error,
@@ -399,14 +404,6 @@ export class StreamBrowserDatabase implements Disposable {
 // the mirror is a cache and will be replayed from the durable stream.
 const DATABASE_CACHE_VERSION = "v3";
 
-function databasePathFor(namespace: string, streamPath: string) {
-  return `${encodeURIComponent(namespace)}/${DATABASE_CACHE_VERSION}/${databaseSlugForStreamPath(streamPath)}.sqlite3`;
-}
-
-function downloadFilenameFor(namespace: string, streamPath: string) {
-  return `${encodeURIComponent(namespace)}__${DATABASE_CACHE_VERSION}-${databaseSlugForStreamPath(streamPath)}.sqlite3`;
-}
-
 function databaseSlugForStreamPath(streamPath: string) {
   const segments = streamPath.split("/").filter(Boolean).map(encodeURIComponent);
   const hint = segments.at(-1) ?? "root";
@@ -438,10 +435,6 @@ function isSqlValue(value: unknown): value is SqlValue {
   );
 }
 
-function isMissingTableError(error: unknown) {
-  return error instanceof Error && error.message.includes("no such table");
-}
-
 /**
  * Structural equality for query snapshots, used to suppress redundant listener
  * notifications. Rows are plain `Record<string, SqlValue>` objects, so a stable JSON
@@ -464,10 +457,4 @@ function serializeRows(rows: Record<string, SqlValue>[]): string {
   return JSON.stringify(rows, (_key, value) =>
     typeof value === "bigint" ? `__bigint__${value.toString()}` : value,
   );
-}
-
-function emptyTableRows(sql: string): Record<string, SqlValue>[] {
-  // A `SELECT COUNT(*) AS count ...` over a not-yet-created table reads as 0; anything else
-  // reads as no rows.
-  return /^\s*SELECT\s+COUNT\(\*\)\s+AS\s+count\b/i.test(sql) ? [{ count: 0 }] : [];
 }

--- a/packages/streams/src/browser/stream-leader.ts
+++ b/packages/streams/src/browser/stream-leader.ts
@@ -27,11 +27,8 @@ export type WriterRole = {
 };
 
 export function acquireWriterRole(args: { lockName: string }): WriterRole {
-  let release = () => {};
   // The lock is held until this promise resolves; resolving it === resigning.
-  const held = new Promise<void>((resolve) => {
-    release = resolve;
-  });
+  const held = Promise.withResolvers<void>();
   let signalWriter = () => {};
   const whenWriter = new Promise<void>((resolve) => {
     signalWriter = resolve;
@@ -45,7 +42,7 @@ export function acquireWriterRole(args: { lockName: string }): WriterRole {
   navigator.locks
     .request(args.lockName, { mode: "exclusive", signal: abortController.signal }, async () => {
       signalWriter();
-      await held;
+      await held.promise;
     })
     .catch((error: unknown) => {
       // AbortError is the expected outcome of release()-before-grant; anything else is a
@@ -59,7 +56,7 @@ export function acquireWriterRole(args: { lockName: string }): WriterRole {
       // Abort a not-yet-granted request, free a held lock, and settle whenWriter so an election
       // awaiting it can't hang forever when it's released before the lock is ever granted.
       abortController.abort();
-      release();
+      held.resolve();
       signalWriter();
     },
   };

--- a/packages/streams/src/stream-processor-class.test.ts
+++ b/packages/streams/src/stream-processor-class.test.ts
@@ -91,10 +91,6 @@ function add(offset: number, amount: number): StreamEvent {
   return { type: "test/add", payload: { amount }, offset, createdAt: iso };
 }
 
-function ignored(offset: number): StreamEvent {
-  return { type: "test/ignored", payload: {}, offset, createdAt: iso };
-}
-
 describe("reduce and checkpoint", () => {
   it("reduces consumed events into state and checkpoints once per batch", async () => {
     const writes: CounterSnapshot[] = [];
@@ -153,7 +149,10 @@ describe("reduce and checkpoint", () => {
       onProcessEvent,
     });
 
-    await processor.ingest({ events: [ignored(1)], streamMaxOffset: 1 });
+    await processor.ingest({
+      events: [{ type: "test/ignored", payload: {}, offset: 1, createdAt: iso }],
+      streamMaxOffset: 1,
+    });
 
     expect(processor.state).toEqual({ total: 0 });
     expect(processor.checkpointOffset).toBe(1);

--- a/packages/streams/src/stream-review-regressions.test.ts
+++ b/packages/streams/src/stream-review-regressions.test.ts
@@ -25,7 +25,6 @@ import { spendCircuitBreakerToken } from "./processors/circuit-breaker/contract.
 
 const iso = (ms = 0) => new Date(ms).toISOString();
 const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
-const iterateContext = () => ({ stream: { append() {}, appendBatch() {} } });
 
 // A minimal counting processor whose batch hook can be made to throw once.
 const CounterContract = defineProcessorContract({
@@ -171,11 +170,10 @@ function fakeStream() {
     },
   };
 
-  // External producer: append a user event to the stream (drives delivery).
-  const produce = (input: StreamEventInput) => push(input);
   return {
     stream,
-    produce,
+    // External producer: append a user event to the stream (drives delivery).
+    produce: push,
     hostAppends,
     failNextSubscribes: (count: number) => {
       subscribeFailures = count;
@@ -315,7 +313,7 @@ describe("T2 — writeState failure advances the in-memory checkpoint (C2)", () 
     const writes: StreamProcessorSnapshot<{ total: number }>[] = [];
     let failNextWrite = true;
     const processor = new CounterProcessor({
-      iterateContext: iterateContext(),
+      iterateContext: { stream: { append() {}, appendBatch() {} } },
       writeState: (snapshot) => {
         if (failNextWrite) {
           failNextWrite = false;

--- a/packages/streams/src/workers/rpc-lifecycle.test.ts
+++ b/packages/streams/src/workers/rpc-lifecycle.test.ts
@@ -66,10 +66,9 @@ describe("retainProcessEventBatch onRpcBroken wiring (M1)", () => {
 describe("retainProcessEventBatch delivery rejection (M1)", () => {
   it("reports a rejected delivery through onDeliveryError", async () => {
     const failure = new Error("Durable Object reset because its code was updated");
-    const dead: ProcessEventBatch = () => Promise.reject(failure);
 
     const onDeliveryError = vi.fn();
-    const retained = retainProcessEventBatch(dead, { onDeliveryError });
+    const retained = retainProcessEventBatch(() => Promise.reject(failure), { onDeliveryError });
     retained(batch);
 
     await vi.waitFor(() => expect(onDeliveryError).toHaveBeenCalledWith(failure));
@@ -80,10 +79,11 @@ describe("retainProcessEventBatch delivery rejection (M1)", () => {
     const result = Object.assign(Promise.resolve(undefined), {
       [Symbol.dispose]: disposed,
     });
-    const alive: ProcessEventBatch = () => result as unknown as Promise<void>;
 
     const onDeliveryError = vi.fn();
-    const retained = retainProcessEventBatch(alive, { onDeliveryError });
+    const retained = retainProcessEventBatch(() => result as unknown as Promise<void>, {
+      onDeliveryError,
+    });
     retained(batch);
 
     await vi.waitFor(() => expect(disposed).toHaveBeenCalled());
@@ -98,9 +98,8 @@ describe("retainProcessEventBatch delivery rejection (M1)", () => {
     const disposed = vi.fn();
     const then = vi.fn();
     const result = { then, [Symbol.dispose]: disposed };
-    const alive: ProcessEventBatch = () => result as unknown as Promise<void>;
 
-    const retained = retainProcessEventBatch(alive);
+    const retained = retainProcessEventBatch(() => result as unknown as Promise<void>);
     retained(batch);
 
     expect(disposed).toHaveBeenCalledTimes(1);
@@ -109,9 +108,10 @@ describe("retainProcessEventBatch delivery rejection (M1)", () => {
 
   it("handles synchronous (non-thenable) callback results", () => {
     const calls: unknown[] = [];
-    const sync: ProcessEventBatch = (delivered) => void calls.push(delivered);
 
-    const retained = retainProcessEventBatch(sync, { onDeliveryError: vi.fn() });
+    const retained = retainProcessEventBatch((delivered) => void calls.push(delivered), {
+      onDeliveryError: vi.fn(),
+    });
     expect(() => retained(batch)).not.toThrow();
     expect(calls).toEqual([batch]);
   });

--- a/packages/ui/src/components/events/event-inspector-sheet.tsx
+++ b/packages/ui/src/components/events/event-inspector-sheet.tsx
@@ -236,7 +236,7 @@ function formatElapsedTime(durationMs: number) {
 
   if (normalizedDurationMs < 60_000) {
     const seconds = Math.floor(normalizedDurationMs / 100) / 10;
-    return `+${trimTrailingZero(seconds)}s`;
+    return `+${seconds.toFixed(1).replace(/\.0$/, "")}s`;
   }
 
   const totalSeconds = Math.floor(normalizedDurationMs / 1_000);
@@ -244,10 +244,6 @@ function formatElapsedTime(durationMs: number) {
   const seconds = totalSeconds % 60;
 
   return `+${totalMinutes}m${seconds}s`;
-}
-
-function trimTrailingZero(value: number) {
-  return value.toFixed(1).replace(/\.0$/, "");
 }
 
 const EVENT_YAML_DISPLAY_KEY_ORDER = [

--- a/packages/ui/src/components/events/feed-element-renderers/expandable-feed-text.tsx
+++ b/packages/ui/src/components/events/feed-element-renderers/expandable-feed-text.tsx
@@ -26,7 +26,8 @@ export function ExpandableFeedText({
   contentClassName?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const canExpand = shouldOfferExpansion(text);
+  const canExpand =
+    text.length > EXPAND_THRESHOLD_CHARS || text.split("\n").length > EXPAND_THRESHOLD_LINES;
 
   return (
     <div
@@ -66,8 +67,4 @@ export function ExpandableFeedText({
       ) : null}
     </div>
   );
-}
-
-function shouldOfferExpansion(text: string) {
-  return text.length > EXPAND_THRESHOLD_CHARS || text.split("\n").length > EXPAND_THRESHOLD_LINES;
 }

--- a/packages/ui/src/components/events/feed-element-renderers/prompt-context-card.tsx
+++ b/packages/ui/src/components/events/feed-element-renderers/prompt-context-card.tsx
@@ -15,7 +15,7 @@ import { cn } from "@iterate-com/ui/lib/utils";
 
 export function PromptContextCard({ element }: { element: EventsStreamPromptContextElement }) {
   const sourceLabel = element.props.source == null ? null : `from ${element.props.source}`;
-  const policyLabel = formatLlmRequestPolicy(element.props.llmRequestPolicy);
+  const policyLabel = element.props.llmRequestPolicy.behaviour;
   const policyDescription = describeLlmRequestPolicy(element.props.llmRequestPolicy);
   const canTriggerRequest = element.props.llmRequestPolicy.behaviour !== "dont-trigger-request";
 
@@ -56,12 +56,6 @@ export function PromptContextCard({ element }: { element: EventsStreamPromptCont
       </MessageContent>
     </Message>
   );
-}
-
-function formatLlmRequestPolicy(
-  policy: EventsStreamPromptContextElement["props"]["llmRequestPolicy"],
-) {
-  return policy.behaviour;
 }
 
 function describeLlmRequestPolicy(

--- a/packages/ui/src/components/events/stream-composer.tsx
+++ b/packages/ui/src/components/events/stream-composer.tsx
@@ -164,7 +164,7 @@ function RawPresetPicker({
 }) {
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState("");
-  const indexedPresets = useMemo(() => indexRawPresets(presets), [presets]);
+  const indexedPresets = useMemo(() => presets.map(indexRawPreset), [presets]);
   const filteredGroups = useMemo(
     () => groupRawPresetOptions(filterRawPresetOptions({ options: indexedPresets, filter })),
     [filter, indexedPresets],
@@ -301,12 +301,6 @@ type IndexedRawPresetOption = {
   payloadPreview: string;
   searchText: string;
 };
-
-function indexRawPresets(
-  presets: readonly EventsStreamComposerRawPreset[],
-): IndexedRawPresetOption[] {
-  return presets.map(indexRawPreset);
-}
 
 function indexRawPreset(preset: EventsStreamComposerRawPreset): IndexedRawPresetOption {
   const eventType = preset.eventType ?? readYamlScalarLine({ yaml: preset.value, key: "type" });

--- a/packages/ui/src/components/events/stream-feed.tsx
+++ b/packages/ui/src/components/events/stream-feed.tsx
@@ -119,7 +119,7 @@ export function EventsStreamView({
   errorLabel?: string;
   className?: string;
 }) {
-  const feedElementTypes = getElementTypes(viewState.slots.feed);
+  const feedElementTypes = [...new Set(viewState.slots.feed.map((element) => element.type))].sort();
   const visibleFeedElements = filterElementsByElementType({
     elements: viewState.slots.feed,
     hiddenElementTypes,
@@ -570,7 +570,7 @@ function ActivityHeaderElement({ element }: { element: EventsStreamActivityEleme
 
 function RawJsonDump({ element }: { element: EventsStreamRawJsonDumpElement }) {
   const events = useMemo(
-    () => orderRawJsonDumpEventsForDisplay(element.props.events),
+    () => element.props.events.map(orderRawJsonDumpEventForDisplay),
     [element.props.events],
   );
 
@@ -604,12 +604,6 @@ const RAW_JSON_DUMP_EVENT_ORDERED_KEYS = new Set<string>([
   ...RAW_JSON_DUMP_EVENT_PREFIX_KEY_ORDER,
   ...RAW_JSON_DUMP_EVENT_SUFFIX_KEY_ORDER,
 ]);
-
-function orderRawJsonDumpEventsForDisplay(
-  events: readonly Event[],
-): Array<Record<string, unknown>> {
-  return events.map(orderRawJsonDumpEventForDisplay);
-}
 
 function orderRawJsonDumpEventForDisplay(event: Event): Record<string, unknown> {
   const eventRecord = event as Record<string, unknown>;
@@ -973,12 +967,6 @@ function getRawEventSummaries(
   return elements
     .flatMap((element) => (element.type === "grouped-raw-event" ? element.props.events : []))
     .sort((a, b) => a.offset - b.offset);
-}
-
-function getElementTypes(
-  elements: readonly EventsStreamBuiltInElement[],
-): EventsStreamElementType[] {
-  return [...new Set(elements.map((element) => element.type))].sort();
 }
 
 function filterElementsByElementType({

--- a/packages/ui/src/components/events/stream-view-processor/contract.ts
+++ b/packages/ui/src/components/events/stream-view-processor/contract.ts
@@ -90,7 +90,10 @@ const StreamViewProcessorContractBase = defineProcessorContract({
 
     const feedItems = appendFeedItems({
       feedItems: state.slots.feed,
-      nextItems: reduceEventToRawPrettyFeedItems(event),
+      nextItems: [
+        createRawEventGroup([toRawEventSummary(event)]),
+        ...reduceEventToSemanticFeedItems(event),
+      ],
     });
 
     return deriveSlots({ feed: feedItems, activity });
@@ -267,10 +270,6 @@ function reduceActivityState(args: {
 // ---------------------------------------------------------------------------
 // Feed item production
 // ---------------------------------------------------------------------------
-
-function reduceEventToRawPrettyFeedItems(event: Event): EventsStreamBuiltInElement[] {
-  return [toRawEventFeedItem(event), ...reduceEventToSemanticFeedItems(event)];
-}
 
 function appendFeedItems(args: {
   feedItems: EventsStreamBuiltInElement[];
@@ -533,10 +532,6 @@ function reduceEventToSemanticFeedItems(event: Event): EventsStreamBuiltInElemen
 // ---------------------------------------------------------------------------
 // Raw event helpers
 // ---------------------------------------------------------------------------
-
-function toRawEventFeedItem(event: Event): EventsStreamGroupedRawEventElement {
-  return createRawEventGroup([toRawEventSummary(event)]);
-}
 
 function toRawEventSummary(event: Event): EventsStreamRawEventSummary {
   return {

--- a/scripts/preview/state.ts
+++ b/scripts/preview/state.ts
@@ -114,7 +114,9 @@ function renderCloudflarePreviewSection(state: CloudflarePreviewState) {
   return [
     "## Environment Config Lease",
     "",
-    markdownAnnotator("", cloudflarePreviewStateLabel).update(wrapHiddenStateBlock(state)),
+    markdownAnnotator("", cloudflarePreviewStateLabel).update(
+      ["<!--", JSON.stringify(state, null, 2), "-->"].join("\n"),
+    ),
     state.environmentConfigLease
       ? renderEnvironmentConfigLease(state.environmentConfigLease)
       : "No active environment config lease.",
@@ -153,7 +155,7 @@ function renderPreviewAppEntry(entry: CloudflarePreviewAppEntry) {
           "<details>",
           "<summary>Failure details</summary>",
           "",
-          `<pre>${escapeHtml(details)}</pre>`,
+          `<pre>${details.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")}</pre>`,
           "",
           "</details>",
         ].join("\n")
@@ -210,14 +212,6 @@ function renderStatusLabel(status: CloudflarePreviewAppEntry["status"]) {
     case "fork-unavailable":
       return "unavailable for forks";
   }
-}
-
-function escapeHtml(value: string) {
-  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
-}
-
-function wrapHiddenStateBlock(state: CloudflarePreviewState) {
-  return ["<!--", JSON.stringify(state, null, 2), "-->"].join("\n");
 }
 
 function unwrapHiddenStateBlock(contents: string) {


### PR DESCRIPTION
Adds a custom oxlint rule that flags tiny single-use helper functions — the kind of indirection where the reader has to jump to a definition just to find one line of code that could have been written at the call site.

```ts
// flagged:
function normalizePath(pathname: string) {
  return decodeURIComponent(pathname).replace(/^\/+|\/+$/g, "");
}
const docs = lookupDocs(normalizePath(request.url));

// preferred:
const docs = lookupDocs(decodeURIComponent(request.url).replace(/^\/+|\/+$/g, ""));
```

A helper is flagged when it is:

- **not exported** (neither `export function foo` nor a later `export { foo }` / `export default foo`)
- **referenced exactly once** anywhere (scope-analysis based; works at module level and nested)
- **has a ≤1-line body**, measured from first to last statement so brace-only lines don't count — a classic 3-line `function f() {\n  return x;\n}` block counts as 1

Recursive helpers (can't be inlined) and TS overload signatures are skipped. First cut is deliberately conservative at 1 body line; bumping to 2 roughly triples the catch (~165 at last count).

## ⚠️ CI is red on purpose

The rule is enabled as `error` with **no suppressions**, so lint fails with the **106 existing infractions across 77 files** standing as a mark of shame until they're inlined. Inlining them is deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "tests-failed",
      "updatedAt": "2026-06-11T15:01:04.994Z",
      "headSha": "6a495a8fdae2723b503e6f4aa67c9d8f253083fb",
      "message": "...(truncated)\nype\": \"text/plain; charset=UTF-8\",%0A      \"date\": \"Thu, 11 Jun 2026 15:00:46 GMT\",%0A      \"expires\": \"Thu, 01 Jan 1970 00:00:01 GMT\",%0A      \"referrer-policy\": \"same-origin\",%0A      \"server\": \"cloudflare\",%0A      \"x-frame-options\": \"SAMEORIGIN\"%0A    }%0A  }%0A}%0A ❯ seedProject e2e/vitest/preview-smoke.e2e.test.ts:127:11%0A ❯ seedProjectMcpUrl e2e/vitest/preview-smoke.e2e.test.ts:155:19%0A ❯ e2e/vitest/preview-smoke.e2e.test.ts:184:23%0A%0A\n ELIFECYCLE  Command failed with exit code 1.\n ❯  node  src/itx/e2e/itx-subscribe.e2e.test.ts (2 tests | 2 failed) 2152ms\n   × subscribe replays history, tails live appends, and unsubscribes 1070ms\n   × onStateChange pushes initial state immediately, then state after appends 1080ms\n ❯  node  src/itx/e2e/itx-http.e2e.test.ts (2 tests | 2 failed) 3657ms\n   × facet caps keep private durable state across invocations 1625ms\n   × HTTP-exposed caps serve their own hostname: admin, share URL, public 2031ms\n ❯  node  src/itx/e2e/itx-egress.e2e.test.ts (3 tests | 3 failed) 4631ms\n   × itx.fetch substitutes secrets through project egress (explicit door) 1135ms\n   × bare fetch() in a project itx script goes through egress (implicit door) 1874ms\n   × bare fetch() inside a worker cap goes through egress (implicit door) 1620ms\n ❯  node  src/itx/e2e/itx-fork.e2e.test.ts (4 tests | 4 failed) 6339ms\n   × fork: child caps shadow the parent, misses delegate up the chain 1142ms\n   × fork: the inherited workspace default is isolated per child context 2423ms\n   × fork narrows access: a session cannot reach sibling projects 1480ms\n   × fork: child worker caps run with the owning project's authority 1292ms\n ❯  node  src/itx/e2e/itx.e2e.test.ts (25 tests | 22 failed | 1 skipped) 20142ms\n   ✓ every catalogue example is either matrix-tested or explicitly excluded 1ms\n   × catalogue example \"list-and-describe-project\" runs identically across runtimes 1709ms\n   × catalogue example \"append-and-read-stream\" runs identically across runtimes 0ms\n   × catalogue example \"provide-path-call-sdk\" runs identically across runtimes 0ms\n   × catalogue example \"define-durable-worker-cap\" runs identically across runtimes 0ms\n   × catalogue example \"worker-cap-uses-its-own-itx\" runs identically across runtimes 0ms\n   × catalogue example \"deep-auto-proxy\" runs identically across runtimes 0ms\n   × catalogue example \"worker-to-worker\" runs identically across runtimes 0ms\n   × catalogue example \"stateful-facet-cap\" runs identically across runtimes 0ms\n   × catalogue example \"fork-child-context\" runs identically across runtimes 0ms\n   × catalogue example \"http-cap-and-share-url\" runs identically across runtimes 0ms\n   × the five-step capability flow: provide live, call, promote durable, call from a script 1899ms\n   × platform bindings are dialable capabilities (raw + wrapped) 1174ms\n   ↓ the first-party McpClient cap bridges a remote MCP server\n   × user-space caps: a named export of the project worker is a first-class capability 1915ms\n   × url caps dial a remote Cap'n Web server over a WebSocket session 1454ms\n   × platform defaults arrive from the platform:project code context, and own rows shadow them 1263ms\n   × fetch is a shadowable capability: a live provider intercepts project egress 1164ms\n   × absolute stream refs are sugar through the one access check 1445ms\n   × script executions leave a two-event record on the /itx stream 1157ms\n   × worker caps hold a correctly scoped itx of their own 1559ms\n   × members caps auto-proxy every public method/getter at any depth 1298ms\n   × one dynamic worker cap calls another's methods through its own itx 1347ms\n   ✓ kernel errors cross capnweb as ItxError-shaped errors with codes  1532ms\n   × revoked and offline caps fail with instructive errors 1223ms\n\n Test Files  5 failed (5)\n      Tests  33 failed | 2 passed | 1 skipped (36)\n   Start at  15:00:44\n   Duration  20.29s (transform 179ms, setup 0ms, import 311ms, tests 36.92s, environment 0ms)\n\n ELIFECYCLE  Command failed with exit code 1.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27355961146",
      "shortSha": "6a495a8"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "deployed",
      "updatedAt": "2026-06-11T15:00:24.210Z",
      "headSha": "6a495a8fdae2723b503e6f4aa67c9d8f253083fb",
      "message": null,
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27355961146",
      "shortSha": "6a495a8"
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_2",
    "leasedUntil": 1781193514767,
    "leaseId": "61f71837-31f8-4467-99bc-dcac308aac47",
    "slug": "preview-2",
    "type": "environment-config-lease"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
Lease: `preview-2`
Doppler config: `preview_2`
Type: `environment-config-lease`
Leased until: 2026-06-11T15:58:34.767Z

### OS
Status: tests failed
Commit: `6a495a8`
Preview: https://os.iterate-preview-2.com
Summary: ELIFECYCLE  Command failed with exit code 1.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27355961146)
Updated: 2026-06-11T15:01:04.994Z

<details>
<summary>Failure details</summary>

<pre>...(truncated)
ype": "text/plain; charset=UTF-8",%0A      "date": "Thu, 11 Jun 2026 15:00:46 GMT",%0A      "expires": "Thu, 01 Jan 1970 00:00:01 GMT",%0A      "referrer-policy": "same-origin",%0A      "server": "cloudflare",%0A      "x-frame-options": "SAMEORIGIN"%0A    }%0A  }%0A}%0A ❯ seedProject e2e/vitest/preview-smoke.e2e.test.ts:127:11%0A ❯ seedProjectMcpUrl e2e/vitest/preview-smoke.e2e.test.ts:155:19%0A ❯ e2e/vitest/preview-smoke.e2e.test.ts:184:23%0A%0A
 ELIFECYCLE  Command failed with exit code 1.
 ❯  node  src/itx/e2e/itx-subscribe.e2e.test.ts (2 tests | 2 failed) 2152ms
   × subscribe replays history, tails live appends, and unsubscribes 1070ms
   × onStateChange pushes initial state immediately, then state after appends 1080ms
 ❯  node  src/itx/e2e/itx-http.e2e.test.ts (2 tests | 2 failed) 3657ms
   × facet caps keep private durable state across invocations 1625ms
   × HTTP-exposed caps serve their own hostname: admin, share URL, public 2031ms
 ❯  node  src/itx/e2e/itx-egress.e2e.test.ts (3 tests | 3 failed) 4631ms
   × itx.fetch substitutes secrets through project egress (explicit door) 1135ms
   × bare fetch() in a project itx script goes through egress (implicit door) 1874ms
   × bare fetch() inside a worker cap goes through egress (implicit door) 1620ms
 ❯  node  src/itx/e2e/itx-fork.e2e.test.ts (4 tests | 4 failed) 6339ms
   × fork: child caps shadow the parent, misses delegate up the chain 1142ms
   × fork: the inherited workspace default is isolated per child context 2423ms
   × fork narrows access: a session cannot reach sibling projects 1480ms
   × fork: child worker caps run with the owning project's authority 1292ms
 ❯  node  src/itx/e2e/itx.e2e.test.ts (25 tests | 22 failed | 1 skipped) 20142ms
   ✓ every catalogue example is either matrix-tested or explicitly excluded 1ms
   × catalogue example "list-and-describe-project" runs identically across runtimes 1709ms
   × catalogue example "append-and-read-stream" runs identically across runtimes 0ms
   × catalogue example "provide-path-call-sdk" runs identically across runtimes 0ms
   × catalogue example "define-durable-worker-cap" runs identically across runtimes 0ms
   × catalogue example "worker-cap-uses-its-own-itx" runs identically across runtimes 0ms
   × catalogue example "deep-auto-proxy" runs identically across runtimes 0ms
   × catalogue example "worker-to-worker" runs identically across runtimes 0ms
   × catalogue example "stateful-facet-cap" runs identically across runtimes 0ms
   × catalogue example "fork-child-context" runs identically across runtimes 0ms
   × catalogue example "http-cap-and-share-url" runs identically across runtimes 0ms
   × the five-step capability flow: provide live, call, promote durable, call from a script 1899ms
   × platform bindings are dialable capabilities (raw + wrapped) 1174ms
   ↓ the first-party McpClient cap bridges a remote MCP server
   × user-space caps: a named export of the project worker is a first-class capability 1915ms
   × url caps dial a remote Cap'n Web server over a WebSocket session 1454ms
   × platform defaults arrive from the platform:project code context, and own rows shadow them 1263ms
   × fetch is a shadowable capability: a live provider intercepts project egress 1164ms
   × absolute stream refs are sugar through the one access check 1445ms
   × script executions leave a two-event record on the /itx stream 1157ms
   × worker caps hold a correctly scoped itx of their own 1559ms
   × members caps auto-proxy every public method/getter at any depth 1298ms
   × one dynamic worker cap calls another's methods through its own itx 1347ms
   ✓ kernel errors cross capnweb as ItxError-shaped errors with codes  1532ms
   × revoked and offline caps fail with instructive errors 1223ms

 Test Files  5 failed (5)
      Tests  33 failed | 2 passed | 1 skipped (36)
   Start at  15:00:44
   Duration  20.29s (transform 179ms, setup 0ms, import 311ms, tests 36.92s, environment 0ms)

 ELIFECYCLE  Command failed with exit code 1.</pre>

</details>

### Semaphore
Status: deployed
Commit: `6a495a8`
Preview: https://semaphore.iterate-preview-2.com
[Workflow run](https://github.com/iterate/iterate/actions/runs/27355961146)
Updated: 2026-06-11T15:00:24.210Z
<!-- /CLOUDFLARE_PREVIEW -->