### PR TITLE
itx: callsite purity — plain objects are capabilities, describe() drops the owner noise

### DIFF
--- a/apps/os/docs/itx-next.md
+++ b/apps/os/docs/itx-next.md
@@ -1048,8 +1048,8 @@ deep: { thought: (q) => … } } })` works directly, callable at any depth
   `call({ path, args })` owns the whole method tree — the SDK shape); a
   bare function still auto-wraps (empty remainder calls it).
 - **describe() dropped the owner noise.** Own entries carry NO provenance
-  field; inherited entries carry `from: <owner>`, and the platform context
-  renders as `"platform"` (PLATFORM_PROJECT_CONTEXT_ID stays internal).
+  field; inherited entries carry `from: <owner>`, and the defaults
+  render as `"defaults"` (PLATFORM_PROJECT_CONTEXT_ID stays internal).
   Journal records keep their `owner` field unchanged — this is a
   describe()-projection change only.
 

--- a/apps/os/docs/itx-next.md
+++ b/apps/os/docs/itx-next.md
@@ -1047,6 +1047,11 @@ deep: { thought: (q) => … } } })` works directly, callable at any depth
 - A CALL-implementing provider keeps its documented semantics (one
   `call({ path, args })` owns the whole method tree — the SDK shape); a
   bare function still auto-wraps (empty remainder calls it).
+- **describe() dropped the owner noise.** Own entries carry NO provenance
+  field; inherited entries carry `from: <owner>`, and the platform context
+  renders as `"platform"` (PLATFORM_PROJECT_CONTEXT_ID stays internal).
+  Journal records keep their `owner` field unchanged — this is a
+  describe()-projection change only.
 
 ## Resolved (was open, now decided)
 

--- a/apps/os/docs/itx-next.md
+++ b/apps/os/docs/itx-next.md
@@ -1031,6 +1031,23 @@ commit, entrypoint } }`) — source as a dimension separate from the
 - **The 500-line workshop** as a standalone teaching document; the build
   order now exists as `src/itx/README.md`.
 
+### SHIPPED (2026-06-12): callsite purity — plain objects are capabilities
+
+We're allergic to weird wrappers and helpers that aren't just a capnweb or
+Workers-RPC stub at the itx callsite, so the last one died:
+
+- **`asPathCallable` is DELETED** (the export, the re-exports, the REPL
+  global). Dispatch decides instead: in the core's live-cap borrow
+  (itx.ts), a target that does not implement `call` as a function has the
+  remaining path replayed onto its members via `replayPathCall` — so
+  `provideCapability({ name: "answer", capability: { ultimate: () => 42,
+deep: { thought: (q) => … } } })` works directly, callable at any depth
+  through the fallthrough. Earlier mentions of `asPathCallable` in the
+  dated entries above describe the superseded shape.
+- A CALL-implementing provider keeps its documented semantics (one
+  `call({ path, args })` owns the whole method tree — the SDK shape); a
+  bare function still auto-wraps (empty remainder calls it).
+
 ## Resolved (was open, now decided)
 
 - ~~Two invoke modes as registry data?~~ → ONE dispatch mode (2026-06-11):

--- a/apps/os/scripts/itx-run.ts
+++ b/apps/os/scripts/itx-run.ts
@@ -15,16 +15,11 @@ import { os } from "@orpc/server";
 import { RpcTarget } from "capnweb";
 import { z } from "zod";
 
-import { asPathCallable, withItx } from "../src/itx/client.ts";
+import { withItx } from "../src/itx/client.ts";
 
 const AsyncFunction = async function () {}.constructor as new (
   ...args: string[]
-) => (
-  itx: unknown,
-  vars: Record<string, unknown>,
-  rpcTarget: unknown,
-  pathCallable: unknown,
-) => Promise<unknown>;
+) => (itx: unknown, vars: Record<string, unknown>, rpcTarget: unknown) => Promise<unknown>;
 
 const ItxRunInput = z.object({
   eval: z
@@ -65,10 +60,10 @@ export const itxRunScript = os
 
     // The script body becomes an async function body, so `return` works and
     // `await` is available throughout — same wrapping as /api/itx/run.
-    const script = new AsyncFunction("itx", "vars", "RpcTarget", "asPathCallable", code);
+    const script = new AsyncFunction("itx", "vars", "RpcTarget", code);
 
     using itx = withItx({ baseUrl, context: input.context, token });
-    const result = await script(itx, vars, RpcTarget, asPathCallable);
+    const result = await script(itx, vars, RpcTarget);
 
     // Exactly one JSON document on stdout — scripts and the e2e suite parse it.
     process.stdout.write(`${JSON.stringify(result ?? null, null, 2)}\n`);

--- a/apps/os/src/components/itx-repl-types.ts
+++ b/apps/os/src/components/itx-repl-types.ts
@@ -51,14 +51,6 @@ declare global {
   class RpcTarget {}
 
   /**
-   * Wrap a plain object-of-methods (or a bare function) so it speaks the
-   * kernel's one calling convention and can be provided as a LIVE capability:
-   * the wrapper crosses the session as a stub and replays each
-   * call({ path, args }) back here, on your concrete object.
-   */
-  function asPathCallable(target: object): PathCallable;
-
-  /**
    * Anything not declared on the itx builtins resolves through the capability
    * fallthrough. Property access accumulates a path locally, then the
    * terminal call dispatches once: \`itx.slack.chat.postMessage(...)\`.

--- a/apps/os/src/debug-routes.ts
+++ b/apps/os/src/debug-routes.ts
@@ -10,6 +10,7 @@ import { DEBUG_APPEND_CHAIN_EVENT_TYPE } from "~/durable-objects/debug-append-ch
 import { authenticateAdminBearer } from "~/auth/admin.ts";
 
 const EGRESS_ECHO_PATH = "/api/itx/egress-echo";
+const OPENAPI_FIXTURE_BASE = "/api/itx/openapi-fixture";
 const STREAM_SUBSCRIPTION_CONFIGURED_TYPE = "events.iterate.com/stream/subscription-configured";
 
 /**
@@ -24,6 +25,7 @@ export async function handleDebugRoutes(input: {
 }): Promise<Response | null> {
   return (
     handleEgressEchoFetch(input) ??
+    (await handleOpenApiFixtureFetch(input)) ??
     (await handleDebugAppendChainFetch(input)) ??
     (await handleSeedIterateConfigBaseFetch(input))
   );
@@ -47,6 +49,131 @@ function handleEgressEchoFetch(input: { request: Request; config: AppConfig }) {
     method: input.request.method,
     url: url.toString(),
   });
+}
+
+/**
+ * A tiny, deterministic OpenAPI service — the spec document plus the API it
+ * describes — so the OpenApiClient e2e never depends on a live third-party
+ * demo server. Admin-token-gated like the egress echo: the e2e provides the
+ * capability with an admin bearer in props.headers, which also proves that
+ * headers ride every API call (nothing here answers without them).
+ */
+async function handleOpenApiFixtureFetch(input: {
+  request: Request;
+  config: AppConfig;
+}): Promise<Response | null> {
+  const url = new URL(input.request.url);
+  if (
+    url.pathname !== OPENAPI_FIXTURE_BASE &&
+    !url.pathname.startsWith(`${OPENAPI_FIXTURE_BASE}/`)
+  ) {
+    return null;
+  }
+
+  const expectedToken = input.config.adminApiSecret?.exposeSecret();
+  if (
+    expectedToken == null ||
+    input.request.headers.get("authorization") !== `Bearer ${expectedToken}`
+  ) {
+    return Response.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  const subpath = url.pathname.slice(OPENAPI_FIXTURE_BASE.length);
+  if (subpath === "/openapi.json" && input.request.method === "GET") {
+    return Response.json(openApiFixtureSpec());
+  }
+  if (subpath === "/pets" && input.request.method === "GET") {
+    const status = url.searchParams.get("status");
+    if (!status) return Response.json({ error: "status is required." }, { status: 400 });
+    const limit = Number(url.searchParams.get("limit") ?? "2");
+    const pets = [
+      { id: 1, name: `${status}-pet-1`, tag: status },
+      { id: 2, name: `${status}-pet-2`, tag: status },
+    ];
+    return Response.json(pets.slice(0, limit));
+  }
+  if (subpath === "/pets" && input.request.method === "POST") {
+    const body = (await input.request.json().catch(() => null)) as Record<string, unknown> | null;
+    if (body == null || typeof body.name !== "string") {
+      return Response.json({ error: "A pet needs a name." }, { status: 400 });
+    }
+    return Response.json({ ...body, id: 99 });
+  }
+  const petMatch = subpath.match(/^\/pets\/(\d+)$/);
+  if (petMatch && input.request.method === "GET") {
+    const id = Number(petMatch[1]);
+    return Response.json({ id, name: `pet-${id}` });
+  }
+  return Response.json({ error: "Not found." }, { status: 404 });
+}
+
+function openApiFixtureSpec() {
+  const petRef = { $ref: "#/components/schemas/Pet" };
+  return {
+    components: {
+      schemas: {
+        Pet: {
+          properties: {
+            id: { type: "integer" },
+            name: { type: "string" },
+            tag: { type: "string" },
+          },
+          required: ["id", "name"],
+          type: "object",
+        },
+      },
+    },
+    info: { title: "Itx OpenAPI Fixture", version: "1.0.0" },
+    openapi: "3.0.3",
+    paths: {
+      "/pets": {
+        get: {
+          operationId: "listPets",
+          parameters: [
+            {
+              in: "query",
+              name: "status",
+              required: true,
+              schema: { enum: ["available", "pending", "sold"], type: "string" },
+            },
+            { in: "query", name: "limit", schema: { type: "integer" } },
+          ],
+          responses: {
+            "200": {
+              content: { "application/json": { schema: { items: petRef, type: "array" } } },
+              description: "Pets with the given status.",
+            },
+          },
+          summary: "List pets by status.",
+        },
+        post: {
+          operationId: "createPet",
+          requestBody: { content: { "application/json": { schema: petRef } } },
+          responses: {
+            "200": {
+              content: { "application/json": { schema: petRef } },
+              description: "The created pet.",
+            },
+          },
+          summary: "Create a pet.",
+        },
+      },
+      "/pets/{petId}": {
+        get: {
+          operationId: "getPet",
+          parameters: [{ in: "path", name: "petId", required: true, schema: { type: "integer" } }],
+          responses: {
+            "200": {
+              content: { "application/json": { schema: petRef } },
+              description: "The pet.",
+            },
+          },
+          summary: "One pet by id.",
+        },
+      },
+    },
+    servers: [{ url: OPENAPI_FIXTURE_BASE }],
+  };
 }
 
 async function handleDebugAppendChainFetch(input: {

--- a/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
@@ -57,10 +57,10 @@ import {
   loadProjectWorker,
 } from "~/domains/projects/project-worker-runtime.ts";
 import { type RepoDurableObject } from "~/domains/repos/durable-objects/repo-durable-object.ts";
-import { Itx, type CapabilityAddress } from "~/itx/itx.ts";
+import { DEFAULTS_DESCRIBE_FROM, Itx, type CapabilityAddress } from "~/itx/itx.ts";
 import { durableObjectFacetsHook, makeDial, resolveDialableTargets } from "~/itx/dial.ts";
 import { journalStream, ownJournalPath, projectContextAddress } from "~/itx/journal.ts";
-import { getPlatformContext, PLATFORM_DESCRIBE_FROM } from "~/itx/platform-context.ts";
+import { getPlatformContext } from "~/itx/platform-context.ts";
 import { runItxScript } from "~/itx/run.ts";
 import type { ItxRuntime } from "~/itx/handle.ts";
 
@@ -224,8 +224,8 @@ export class ProjectDurableObject extends DurableObject<ProjectEnv> {
   // pipeline calls through property accesses, see `processor` above). The
   // context's journal is the project's /itx stream — the only authority;
   // this DO's storage holds the fold's disposable checkpoint. The parent
-  // link is the in-process platform context: the chain's code root, where
-  // the platform defaults live.
+  // link is the in-process defaults context: the chain's code root, where
+  // the defaults live.
 
   #itx: Itx | null = null;
 
@@ -255,9 +255,9 @@ export class ProjectDurableObject extends DurableObject<ProjectEnv> {
       iterateContext: { journal: journalStream(this.env as unknown as Env, journal) },
       keepAliveWhile: (work) => this.ctx.waitUntil(work()),
       parentItx: () => ({
-        // describe() labels entries inherited through this link "platform";
+        // describe() labels entries inherited through this link "defaults";
         // the internal platform:project chain id stays internal.
-        from: PLATFORM_DESCRIBE_FROM,
+        from: DEFAULTS_DESCRIBE_FROM,
         stub: getPlatformContext({
           exports: this.ctx.exports as unknown as Parameters<
             typeof getPlatformContext

--- a/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
@@ -60,7 +60,7 @@ import { type RepoDurableObject } from "~/domains/repos/durable-objects/repo-dur
 import { Itx, type CapabilityAddress } from "~/itx/itx.ts";
 import { durableObjectFacetsHook, makeDial, resolveDialableTargets } from "~/itx/dial.ts";
 import { journalStream, ownJournalPath, projectContextAddress } from "~/itx/journal.ts";
-import { getPlatformContext } from "~/itx/platform-context.ts";
+import { getPlatformContext, PLATFORM_DESCRIBE_FROM } from "~/itx/platform-context.ts";
 import { runItxScript } from "~/itx/run.ts";
 import type { ItxRuntime } from "~/itx/handle.ts";
 
@@ -254,13 +254,17 @@ export class ProjectDurableObject extends DurableObject<ProjectEnv> {
       }),
       iterateContext: { journal: journalStream(this.env as unknown as Env, journal) },
       keepAliveWhile: (work) => this.ctx.waitUntil(work()),
-      parentItx: () =>
-        getPlatformContext({
+      parentItx: () => ({
+        // describe() labels entries inherited through this link "platform";
+        // the internal platform:project chain id stays internal.
+        from: PLATFORM_DESCRIBE_FROM,
+        stub: getPlatformContext({
           exports: this.ctx.exports as unknown as Parameters<
             typeof getPlatformContext
           >[0]["exports"],
           projectId,
         }),
+      }),
       readState: async () =>
         await this.ctx.storage.get<{ offset: number; state: Itx["state"] }>("itx-checkpoint"),
       // Processor-mode execution: an enqueued script-execution-requested on

--- a/apps/os/src/domains/secrets/entrypoints/secrets-capability-call.test.ts
+++ b/apps/os/src/domains/secrets/entrypoints/secrets-capability-call.test.ts
@@ -1,0 +1,43 @@
+// The itx secrets allowlist: writes and redacted summaries dispatch; the
+// material-returning methods refuse with a self-describing error. This is
+// the unit-level proof behind the "secret material is never readable through
+// itx" property — the e2e (itx-egress.e2e.test.ts) proves the happy path
+// against a real deployment.
+
+import { describe, expect, test } from "vitest";
+import { ITX_SECRETS_METHODS, resolveItxSecretsMethod } from "./secrets-capability-call.ts";
+
+describe("resolveItxSecretsMethod", () => {
+  test("dispatches exactly the write-and-summary surface", () => {
+    expect([...ITX_SECRETS_METHODS]).toEqual([
+      "setSecret",
+      "listSecrets",
+      "deleteSecret",
+      "getSecretSummaryByKey",
+    ]);
+    for (const method of ITX_SECRETS_METHODS) {
+      expect(resolveItxSecretsMethod([method])).toBe(method);
+    }
+  });
+
+  test("material-returning methods are refused with the self-describing error", () => {
+    for (const method of ["getSecret", "getSecretOrNull", "getSecretSummary", "deleteSecretById"]) {
+      expect(() => resolveItxSecretsMethod([method])).toThrow(
+        /secret material is never readable through itx — placeholders are substituted on egress/,
+      );
+      expect(() => resolveItxSecretsMethod([method])).toThrow(
+        /setSecret\/listSecrets\/deleteSecret\/getSecretSummaryByKey/,
+      );
+    }
+  });
+
+  test("deeper paths, empty paths, and protocol names refuse too", () => {
+    expect(() => resolveItxSecretsMethod(["setSecret", "deeper"])).toThrow(
+      /got "setSecret\.deeper"/,
+    );
+    expect(() => resolveItxSecretsMethod([])).toThrow(/itx\.secrets exposes/);
+    // The provide-time describeItx probe is best-effort; a refusal here just
+    // leaves the provide unenriched (itx.ts #dialSelfDescription).
+    expect(() => resolveItxSecretsMethod(["describeItx"])).toThrow(/itx\.secrets exposes/);
+  });
+});

--- a/apps/os/src/domains/secrets/entrypoints/secrets-capability-call.ts
+++ b/apps/os/src/domains/secrets/entrypoints/secrets-capability-call.ts
@@ -1,0 +1,33 @@
+// The itx-reachable surface of the project secrets capability — pure and
+// import-free so the allowlist is provable without workerd (the entrypoint
+// itself needs cloudflare:workers).
+//
+// Owner decision (recorded): agent-writable setSecret/deleteSecret on the
+// itx surface is INTENDED. The material-returning methods (getSecret,
+// getSecretOrNull, getSecretSummary, deleteSecretById) are deliberately NOT
+// itx-reachable: secret material only exists in the egress substitution path
+// (entrypoint.ts EgressPipe); the oRPC/admin surface keeps the full method
+// set for platform code.
+
+export const ITX_SECRETS_METHODS = [
+  "setSecret",
+  "listSecrets",
+  "deleteSecret",
+  "getSecretSummaryByKey",
+] as const;
+
+export type ItxSecretsMethod = (typeof ITX_SECRETS_METHODS)[number];
+
+/** Resolve an itx path call to an allowlisted method, or refuse with a
+ * self-describing error. Only flat single-segment paths exist here. */
+export function resolveItxSecretsMethod(path: string[]): ItxSecretsMethod {
+  const method = path.length === 1 ? path[0] : undefined;
+  if (method && (ITX_SECRETS_METHODS as readonly string[]).includes(method)) {
+    return method as ItxSecretsMethod;
+  }
+  throw new Error(
+    `itx.secrets exposes ${ITX_SECRETS_METHODS.join("/")}; secret material is never ` +
+      `readable through itx — placeholders are substituted on egress` +
+      (path.length > 0 ? ` (got "${path.join(".")}").` : `.`),
+  );
+}

--- a/apps/os/src/domains/secrets/entrypoints/secrets-capability.ts
+++ b/apps/os/src/domains/secrets/entrypoints/secrets-capability.ts
@@ -1,6 +1,8 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import { createD1Client } from "sqlfu";
+import { resolveItxSecretsMethod } from "./secrets-capability-call.ts";
 import { parseConfig } from "~/config.ts";
+import type { PathCall } from "~/itx/itx.ts";
 import {
   deleteProjectSecretById,
   deleteProjectSecret,
@@ -37,6 +39,18 @@ export class SecretsCapability extends WorkerEntrypoint<
   SecretsCapabilityEnv,
   SecretsCapabilityProps
 > {
+  /**
+   * The itx calling convention (dial.ts dispatches loopback caps as
+   * `call({ path, args })`). Only the write-and-summary surface is reachable
+   * this way — see secrets-capability-call.ts for the allowlist and why the
+   * material-returning methods are not on it. The full method set below
+   * stays for platform code (egress substitution, the oRPC/admin surface).
+   */
+  async call(input: PathCall): Promise<unknown> {
+    const method = resolveItxSecretsMethod(input.path);
+    return await (this[method] as (arg?: unknown) => Promise<unknown>).call(this, input.args[0]);
+  }
+
   async getSecret(input: { key: string }) {
     const secret = await getProjectSecret(this.db(), {
       key: input.key,

--- a/apps/os/src/itx/README.md
+++ b/apps/os/src/itx/README.md
@@ -292,7 +292,7 @@ A context is a Durable Object with a stream. Two hosts, one anatomy:
   `itx()` returns its core (a method, not a property — workerd does not
   pipeline calls through property accesses, so `node.itx().invoke(…)` stays
   one round trip). Journal: `(projectId, "/itx")`. Its `parentItx` is the
-  platform context (⑧).
+  defaults (⑧).
 - **`ItxDurableObject`** (`itx-durable-object.ts`) is the GENERIC host — one
   instance per extension. It holds NO configuration: its DO **name IS the
   journal coordinate** (`<namespace>:<journalPath>`), so identity, journal
@@ -304,8 +304,8 @@ A context is a Durable Object with a stream. Two hosts, one anatomy:
   their own context instances today.)
 
 Workspaces are deliberately NOT the kernel's concern: `WorkspaceCapability`
-takes an explicit provider-chosen `workspaceId`. The platform context
-provides the shared project workspace; the AGENT host provides its own
+takes an explicit provider-chosen `workspaceId`. The defaults
+provide the shared project workspace; the AGENT host provides its own
 `workspace` capability bound to its context's identity, on its context's
 journal. Plain extensions share the project workspace through the chain.
 
@@ -342,7 +342,7 @@ Client plumbing: `client.ts` (`withItx` for Node, Scene 2), `use-itx.ts`
 (`ItxError` codes that survive capnweb's name-dropping reconstruction, plus
 existence-masking — missing and forbidden are byte-identical NOT_FOUND).
 
-## ⑧ The platform chain: defaults are a parent written in code (`platform-context.ts`)
+## ⑧ The defaults: a parent written in code (`platform-context.ts`)
 
 Every chain roots in code: **everything WRITABLE is durable; the root of
 every chain is code.**
@@ -363,7 +363,7 @@ repo (slug `project`). Shipping a new default is a deploy, not a migration:
 the chain sees it immediately; journaled rows shadow it; revoking a shadow
 resurfaces it. There is no defaults mechanism — only the chain.
 
-Egress, both doors — `fetch` is itself a shadowable platform default:
+Egress, both doors — `fetch` is itself a shadowable default:
 
 ```text
 bare fetch() in ANY loaded isolate ─► ProjectEgress.fetch (origin's node) ─┐

--- a/apps/os/src/itx/README.md
+++ b/apps/os/src/itx/README.md
@@ -132,19 +132,24 @@ the RPC transports (capnweb, Workers RPC) separately pipeline CALLS onto
 returned stubs. They compose — `itx.streams.get("/x").append(e)` is one
 PathCall producing a stub the transport then pipelines `append` onto.
 
-## ② Data becomes dots again: `replayPathCall` and `asPathCallable`
+## ② Data becomes dots again: `replayPathCall`
 
 **`replayPathCall(target, { path, args })`** is the receiver-preserving
 replay: walk the segments on a concrete object (re-filtering reserved names —
 this is the authoritative gate, since `invoke` is public and paths can be
 hand-built) and call the terminal method ON ITS PARENT. An empty path calls
-`target` itself as a function. **`asPathCallable(obj)`** wraps a plain
-object-of-methods (or bare function) so it speaks the one calling convention
-from ① — as a capnweb `RpcTarget`, so a live provider's replay runs back in
-the provider's own process.
+`target` itself as a function.
+
+There is deliberately NO callsite wrapper to pair with it: a plain object
+(or bare function) IS a live capability — the core's dispatch notices a
+target that doesn't implement `call` and replays the path onto its members
+itself (③). The replay still runs where the object lives (your functions
+cross the session as stubs), so providing `{ run(src) { … } }` means `run`
+executes in YOUR process.
 
 That is Law 6 in full: the core only ever says `target.call({ path, args })`;
-whoever holds the concrete object decides what a path means there.
+whoever holds the concrete object decides what a path means there — and "I'm
+just an object of methods" is the default, not a wrapper.
 
 ## ③ The core: `Itx` — one map, longest prefix, a chain (`itx.ts`)
 
@@ -168,10 +173,11 @@ Its state is ONE path-keyed capability table; its protocol is four verbs
   chain's trusted identity channel: attribution, and — crucially — dial-back
   (⑤).
 - **What can be provided** (`Capability`): a serializable
-  **`CapabilityAddress`** (durable), or anything live — a stub implementing
-  `call` itself, an `asPathCallable` wrap, or a **bare function** (live by
-  nature; auto-wrapped so calling the capability calls the function and any
-  deeper path errors). Discrimination is structural
+  **`CapabilityAddress`** (durable), or anything live — a **plain object of
+  methods** (dispatch replays the dotted path onto its members; nested
+  objects give depth for free), a **bare function** (calling the capability
+  calls the function), or a stub implementing `call` itself (own your whole
+  method tree). Discrimination is structural
   (`isCapabilityAddress`): an address is a PLAIN object carrying
   `type: "rpc" | "url"`; everything else is live. Live stubs sit in an
   in-memory instance table, dup-retained, torn down with the provider's
@@ -379,7 +385,7 @@ bearer-token edge) | `meta.http.public`; then one core dispatch with
 | ----------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `itx.ts`                | THE CORE              | `Itx` (the four verbs, journal write/consume seam, live table, longest-prefix dispatch, chain), capability data model, validation |
 | `contract.ts`           | the journal contract  | `ItxContract`, `ITX_EVENT_TYPES`, `ItxState` (zod schemas — deliberately loose so old journals never wedge the fold)              |
-| `path-proxy.ts`         | Law 6, client-safe    | `PathProxy`, `replayPathCall`, `asPathCallable`, `RESERVED_PATH_SEGMENTS`                                                         |
+| `path-proxy.ts`         | Law 6, client-safe    | `PathProxy`, `replayPathCall`, `RESERVED_PATH_SEGMENTS`                                                                           |
 | `journal.ts`            | the coordinate system | journal paths, context addresses, `dialContext`, `extendContext`, the D1 catalog, the reserved-segment guard                      |
 | `dial.ts`               | reach                 | `makeDial` (allowlists, loader/facet wiring, prop injection), `durableObjectFacetsHook`, `resolveDialableTargets`                 |
 | `platform-context.ts`   | the chain root        | `PlatformContext` (read-only code context), `PLATFORM_PROJECT_CAPABILITIES`, `getPlatformContext`                                 |
@@ -405,12 +411,12 @@ _on top of_ this layer or beside it — never underneath it.
 ## Writing capabilities
 
 **Live** (session-bound — your laptop, a browser tab, another service; Scene
-2). The capability IS the stub; `provideCapability` discriminates
+2). The capability IS the value you pass; `provideCapability` discriminates
 structurally. A bare function is the simplest provider (calling the
-capability calls it); an object either implements `call({ path, args })`
-itself — the SDK shape: own your whole method tree, the public SDK docs
-become the tool docs — or is wrapped with `asPathCallable` (the replay runs
-back in YOUR process):
+capability calls it); a plain object of methods is the next step up — dotted
+paths replay onto its members, in YOUR process, no wrapper anywhere; and an
+object that implements `call({ path, args })` itself owns its whole method
+tree (the SDK shape: the public SDK docs become the tool docs):
 
 ```ts
 import { withItx } from "~/itx/client.ts";

--- a/apps/os/src/itx/browser-repl.test.ts
+++ b/apps/os/src/itx/browser-repl.test.ts
@@ -11,7 +11,7 @@ import {
   runBrowserReplEntry,
 } from "./browser-repl.ts";
 import { ITX_EXAMPLES } from "./examples.ts";
-import { PathProxy } from "./path-proxy.ts";
+import { PathProxy, replayPathCall } from "./path-proxy.ts";
 
 describe("browser Cap'n Web REPL", () => {
   test("default snippet uses Cap'n Web promise pipelining", async () => {
@@ -480,14 +480,15 @@ const persisted = answer();
 
   test("live-capability example registers and calls a session-owned target", async () => {
     // Mirrors a PROJECT-scoped itx handle: provideCapability() with a live
-    // capability registers it, and unknown names on the handle fall through to
-    // a path proxy whose terminal call dispatches the kernel's one calling
-    // convention — provider.call({ path, args }) — exactly like the core.
-    const providedTargets = new Map<string, { call(input: unknown): unknown }>();
+    // capability registers it, and unknown names on the handle fall through
+    // to a path proxy whose terminal call dispatches exactly like the core:
+    // a call-implementing target receives the path as data; a plain object
+    // (no `call`) has the path replayed onto its members.
+    const providedTargets = new Map<string, Record<string, unknown>>();
     const alert = vi.fn();
     const itx = new Proxy(
       {
-        provideCapability(input: { name: string; capability: { call(input: unknown): unknown } }) {
+        provideCapability(input: { name: string; capability: Record<string, unknown> }) {
           providedTargets.set(input.name, input.capability);
         },
       },
@@ -495,7 +496,11 @@ const persisted = answer();
         get(target, prop: string | symbol) {
           if (typeof prop === "string" && providedTargets.has(prop)) {
             const provided = providedTargets.get(prop)!;
-            return new PathProxy((call) => provided.call(call));
+            return new PathProxy((call) =>
+              typeof provided.call === "function"
+                ? provided.call(call)
+                : replayPathCall(provided, call),
+            );
           }
           return Reflect.get(target, prop);
         },

--- a/apps/os/src/itx/browser-repl.test.ts
+++ b/apps/os/src/itx/browser-repl.test.ts
@@ -478,14 +478,13 @@ const persisted = answer();
     }
   });
 
-  test("live-capability example registers and calls a session-owned target", async () => {
+  test("plain-object example registers and calls a session-owned target", async () => {
     // Mirrors a PROJECT-scoped itx handle: provideCapability() with a live
     // capability registers it, and unknown names on the handle fall through
     // to a path proxy whose terminal call dispatches exactly like the core:
     // a call-implementing target receives the path as data; a plain object
     // (no `call`) has the path replayed onto its members.
     const providedTargets = new Map<string, Record<string, unknown>>();
-    const alert = vi.fn();
     const itx = new Proxy(
       {
         provideCapability(input: { name: string; capability: Record<string, unknown> }) {
@@ -508,18 +507,20 @@ const persisted = answer();
     );
 
     const example = ITX_EXAMPLES.find((candidate) => {
-      return candidate.id === "provide-live-capability";
+      return candidate.id === "provide-plain-object";
     });
-    if (!example) throw new Error("Missing provide-live-capability example.");
+    if (!example) throw new Error("Missing provide-plain-object example.");
 
     await expect(
       evalBrowserReplSessionCode({
         code: example.code,
         itx,
-        scope: { ...createBrowserReplScope(), alert },
+        scope: createBrowserReplScope(),
       }),
-    ).resolves.toBe("alerted");
-    expect(alert).toHaveBeenCalledWith("The answer is 42");
+    ).resolves.toEqual({
+      deep: { answer: 42, question: "life, the universe, everything" },
+      ultimate: 42,
+    });
   });
 
   test("snippets ending in a top-level return produce that value", async () => {

--- a/apps/os/src/itx/browser-repl.ts
+++ b/apps/os/src/itx/browser-repl.ts
@@ -1,5 +1,4 @@
 import { RpcTarget } from "capnweb";
-import { asPathCallable } from "./path-proxy.ts";
 
 export const DEFAULT_BROWSER_REPL_CODE = "await itx.projects.list({ limit: 5 })";
 
@@ -17,8 +16,7 @@ export function createBrowserReplScope(scope?: Record<string, unknown>): Record<
   // examples.ts) run unchanged in the REPL: scripts read parameters from
   // `vars` and every other runtime injects it the same way. Assign your own
   // (`const vars = { … }`) to parameterize a snippet by hand.
-  // `asPathCallable` makes a plain object-of-methods providable as a live cap.
-  return { asPathCallable, RpcTarget, vars: {}, ...scope };
+  return { RpcTarget, vars: {}, ...scope };
 }
 
 export function browserReplExternalScopesEqual(

--- a/apps/os/src/itx/capabilities/mcp-client-core.ts
+++ b/apps/os/src/itx/capabilities/mcp-client-core.ts
@@ -11,6 +11,8 @@ export async function connectMcp(input: {
   /** All transport HTTP goes through this (e.g. the project egress pipe). */
   fetch?: McpFetch;
   headers?: Record<string, string>;
+  /** Per-request deadline for the initialize handshake. */
+  requestOptions?: McpRequestOptions;
   serverUrl: string;
 }): Promise<Client> {
   const transport = new StreamableHTTPClientTransport(new URL(input.serverUrl), {
@@ -19,7 +21,7 @@ export async function connectMcp(input: {
   });
   const client = new Client({ name: "itx-mcp-client", version: "1.0.0" });
   try {
-    await client.connect(transport);
+    await client.connect(transport, input.requestOptions);
   } catch (error) {
     // A partial handshake can leave server-side session state dangling.
     await client.close().catch(() => {});
@@ -28,8 +30,10 @@ export async function connectMcp(input: {
   return client;
 }
 
-export async function listMcpTools(client: Client) {
-  const response = await client.listTools();
+export type McpRequestOptions = { timeout?: number };
+
+export async function listMcpTools(client: Client, options?: McpRequestOptions) {
+  const response = await client.listTools(undefined, options);
   return {
     tools: response.tools.map((tool) => ({
       name: tool.name,
@@ -42,6 +46,7 @@ export async function listMcpTools(client: Client) {
 export async function executeMcpToolCall(input: {
   args: unknown[];
   client: Client;
+  options?: McpRequestOptions;
   path: string[];
 }) {
   const toolName = input.path[0];
@@ -55,7 +60,11 @@ export async function executeMcpToolCall(input: {
       ? (firstArg as Record<string, unknown>)
       : {};
 
-  const result = await input.client.callTool({ name: toolName, arguments: args });
+  const result = await input.client.callTool(
+    { name: toolName, arguments: args },
+    undefined,
+    input.options,
+  );
 
   if (result.structuredContent != null) return result.structuredContent;
 

--- a/apps/os/src/itx/capabilities/mcp-client.ts
+++ b/apps/os/src/itx/capabilities/mcp-client.ts
@@ -57,6 +57,13 @@ export class McpClient extends WorkerEntrypoint<Env, McpClientProps> {
       // client can never fetch outside the egress pipe.
       throw new Error("McpClient needs context attribution to route egress.");
     }
+    if (input.path.join(".") === "describeItx") {
+      // The core's provide-time self-description probe (itx.ts). An MCP
+      // surface is dynamic — listTools is the discovery door — so there is
+      // nothing static to answer; returning empty keeps the probe from
+      // becoming a real network tool call.
+      return {};
+    }
 
     const itx = await resolveItx({
       env: this.env,

--- a/apps/os/src/itx/capabilities/mcp-client.ts
+++ b/apps/os/src/itx/capabilities/mcp-client.ts
@@ -76,13 +76,25 @@ export class McpClient extends WorkerEntrypoint<Env, McpClientProps> {
       // getSecret() placeholders in headers become real credentials. Build a
       // real Request first: the SDK may pass a URL (which itx.fetch would not
       // stringify) or a Request plus separate init (whose headers must merge
-      // before egress sees them).
-      fetch: (fetchInput: Request | string | URL, init?: RequestInit) =>
-        itx.fetch(
+      // before egress sees them). The SDK also attaches an AbortSignal to
+      // every request, and a signal cannot cross the RPC hop to the egress
+      // pipe (DataCloneError: AbortSignal serialization is not enabled) —
+      // rebuild WITHOUT it; per-request aborts don't survive egress, the
+      // pipe's own timeouts do the bounding.
+      fetch: (fetchInput: Request | string | URL, init?: RequestInit) => {
+        const request =
           fetchInput instanceof Request
             ? new Request(fetchInput, init)
-            : new Request(String(fetchInput), init),
-        ),
+            : new Request(String(fetchInput), init);
+        return itx.fetch(
+          new Request(request.url, {
+            body: request.body,
+            headers: request.headers,
+            method: request.method,
+            redirect: request.redirect,
+          }),
+        );
+      },
       headers: props.headers,
       serverUrl: props.serverUrl,
     });

--- a/apps/os/src/itx/capabilities/mcp-client.ts
+++ b/apps/os/src/itx/capabilities/mcp-client.ts
@@ -41,6 +41,9 @@ export type McpClientProps = {
   serverUrl: string;
   /** Sent on every request; values pass through egress secret substitution. */
   headers?: Record<string, string>;
+  /** Per-request deadline forwarded to the MCP SDK (its default is 60s);
+   * raise it for genuinely slow servers. Provider-supplied. */
+  timeoutMs?: number;
   /** Attribution, injected by the dial. */
   capabilityPath?: string;
   context?: string;
@@ -71,41 +74,43 @@ export class McpClient extends WorkerEntrypoint<Env, McpClientProps> {
       props: { capabilityPath: props.capabilityPath, context: props.context },
     });
 
+    const options = props.timeoutMs ? { timeout: props.timeoutMs } : undefined;
     const client = await connectMcp({
       // ALL transport HTTP rides the project egress pipe — this is where
       // getSecret() placeholders in headers become real credentials. Build a
       // real Request first: the SDK may pass a URL (which itx.fetch would not
       // stringify) or a Request plus separate init (whose headers must merge
-      // before egress sees them). The SDK also attaches an AbortSignal to
-      // every request, and a signal cannot cross the RPC hop to the egress
-      // pipe (DataCloneError: AbortSignal serialization is not enabled) —
-      // rebuild WITHOUT it; per-request aborts don't survive egress, the
-      // pipe's own timeouts do the bounding.
+      // before egress sees them). The handle's fetch — the one egress door —
+      // strips the SDK's per-request AbortSignal; nothing transport-specific
+      // is handled here.
       fetch: (fetchInput: Request | string | URL, init?: RequestInit) => {
         const request =
           fetchInput instanceof Request
             ? new Request(fetchInput, init)
             : new Request(String(fetchInput), init);
-        return itx.fetch(
-          new Request(request.url, {
-            body: request.body,
-            headers: request.headers,
-            method: request.method,
-            redirect: request.redirect,
-          }),
-        );
+        // The transport's standalone GET (the server-push SSE channel) is
+        // useless in this stateless connect → call → close client and would
+        // pin a long-lived stream through the egress chain for every call —
+        // answer it locally with the spec's "not offered" status, which the
+        // SDK handles as the expected no-stream case.
+        if (request.method === "GET") {
+          return Promise.resolve(new Response(null, { status: 405 }));
+        }
+        return itx.fetch(request);
       },
       headers: props.headers,
+      requestOptions: options,
       serverUrl: props.serverUrl,
     });
 
     try {
       if (input.path.join(".") === "listTools") {
-        return await listMcpTools(client);
+        return await listMcpTools(client, options);
       }
       return await executeMcpToolCall({
         args: input.args,
         client,
+        options,
         path: input.path,
       });
     } finally {

--- a/apps/os/src/itx/capabilities/openapi-client.ts
+++ b/apps/os/src/itx/capabilities/openapi-client.ts
@@ -1,0 +1,222 @@
+// OpenApiClient: any OpenAPI 3.x API as an ergonomic first-party capability.
+//
+// Like McpClient, this is an ordinary RPC target behind a loopback ref —
+// parameterized per API by props, with NO powers a user-space equivalent
+// couldn't have:
+//
+//   await itx.provideCapability({
+//     name: "petstore",
+//     capability: {
+//       type: "rpc", worker: { type: "loopback" }, entrypoint: "OpenApiClient",
+//       props: {
+//         specUrl: "https://petstore3.swagger.io/api/v3/openapi.json",
+//         headers: { authorization: 'Bearer getSecret({ key: "PETSTORE_TOKEN" })' },
+//       },
+//     },
+//   });
+//
+//   await itx.petstore.findPetsByStatus({ status: "available" });
+//   await itx.petstore.listOperations();
+//
+// Dispatch is by FLAT operationId (path = [operationId]) — see
+// listOpenApiOperations for why a nested tag.operationId convention loses.
+// args[0] is ONE object merging path params + query params + body properties
+// (a non-object body travels under the single `body` key) — exactly the
+// shape the derived `types` string declares.
+//
+// Every HTTP request — the spec fetch included — rides PROJECT EGRESS via
+// this cap's own itx handle (Law 5), so getSecret(...) placeholders in
+// `headers` are substituted inside the egress pipe and never exist here.
+//
+// Self-description: `describeItx` answers { types, instructions } derived
+// from the spec — the provide-time hook in the core (itx.ts) journals them
+// so describe() carries the full typed surface with zero callsite ceremony.
+
+import { WorkerEntrypoint } from "cloudflare:workers";
+import { resolveItx } from "../entrypoint.ts";
+import type { ItxRuntime } from "../handle.ts";
+import type { PathCall } from "../itx.ts";
+import {
+  deriveOpenApiTypes,
+  isObjectSchema,
+  listOpenApiOperations,
+  operationBodySchema,
+  type OpenApiOperation,
+} from "./openapi-types.ts";
+
+export type OpenApiClientProps = {
+  /** Where the OpenAPI 3.x document lives. Provider-supplied. */
+  specUrl: string;
+  /** Overrides the spec's first `servers` entry as the request base. */
+  baseUrl?: string;
+  /** Sent on every request (spec fetch included); values pass through egress
+   * secret substitution. */
+  headers?: Record<string, string>;
+  /** Attribution, injected by the dial. */
+  capabilityPath?: string;
+  context?: string;
+  projectId?: string;
+};
+
+/** Specs are immutable-enough documents: memoize per isolate with a TTL —
+ * the same discipline as the source-build memo (warm key, no fetch). Keyed
+ * by project too: the fetch rides a project's egress (its headers, its
+ * secrets), so two projects never share an entry. */
+const SPEC_CACHE_TTL_MS = 5 * 60_000;
+const specCache = new Map<string, { fetchedAtMs: number; spec: Record<string, unknown> }>();
+
+export class OpenApiClient extends WorkerEntrypoint<Env, OpenApiClientProps> {
+  async call(input: PathCall): Promise<unknown> {
+    const props = this.ctx.props;
+    if (!props.specUrl) {
+      throw new Error("OpenApiClient needs props.specUrl (the OpenAPI document).");
+    }
+    if (!props.context) {
+      // The dial always injects context; refusing without it means this
+      // client can never fetch outside the egress pipe.
+      throw new Error("OpenApiClient needs context attribution to route egress.");
+    }
+
+    const itx = await resolveItx({
+      env: this.env,
+      exports: this.ctx.exports as unknown as ItxRuntime["exports"],
+      props: { capabilityPath: props.capabilityPath, context: props.context },
+    });
+    const egressFetch = (request: Request) => itx.fetch(request);
+    const spec = await fetchSpec(props, egressFetch);
+
+    const method = input.path.join(".");
+    if (method === "describeItx") {
+      const info = (spec.info ?? {}) as { title?: string; version?: string };
+      const name = props.capabilityPath ?? "<cap>";
+      return {
+        instructions:
+          `${info.title ?? "An OpenAPI API"}${info.version ? ` v${info.version}` : ""}: ` +
+          `call itx.${name}.<operationId>({ ...pathParams, ...queryParams, ...body }); ` +
+          `itx.${name}.listOperations() lists every operation.`,
+        types: deriveOpenApiTypes(spec),
+      };
+    }
+    if (method === "listOperations") {
+      return listOpenApiOperations(spec).map((operation) => ({
+        method: operation.method,
+        operationId: operation.operationId,
+        path: operation.path,
+        summary: operation.summary ?? null,
+      }));
+    }
+
+    const operationId = input.path[0];
+    if (!operationId || input.path.length > 1) {
+      throw new Error(
+        `OpenApiClient dispatches flat operationIds (itx.<cap>.<operationId>(input)); ` +
+          `got path "${input.path.join(".")}". listOperations() lists what exists.`,
+      );
+    }
+    const operation = listOpenApiOperations(spec).find(
+      (candidate) => candidate.operationId === operationId,
+    );
+    if (!operation) {
+      throw new Error(
+        `Operation "${operationId}" is not in the OpenAPI spec at ${props.specUrl}. ` +
+          `listOperations() lists what exists.`,
+      );
+    }
+    return await executeOperation({ egressFetch, input: input.args[0], operation, props, spec });
+  }
+}
+
+async function fetchSpec(
+  props: OpenApiClientProps,
+  egressFetch: (request: Request) => Promise<Response>,
+): Promise<Record<string, unknown>> {
+  const cacheKey = `${props.projectId ?? ""}:${props.specUrl}`;
+  const cached = specCache.get(cacheKey);
+  if (cached && Date.now() - cached.fetchedAtMs < SPEC_CACHE_TTL_MS) return cached.spec;
+  const response = await egressFetch(new Request(props.specUrl, { headers: props.headers ?? {} }));
+  if (!response.ok) {
+    throw new Error(`Fetching the OpenAPI spec at ${props.specUrl} returned ${response.status}.`);
+  }
+  const spec = (await response.json()) as Record<string, unknown>;
+  specCache.set(cacheKey, { fetchedAtMs: Date.now(), spec });
+  return spec;
+}
+
+async function executeOperation(args: {
+  egressFetch: (request: Request) => Promise<Response>;
+  input: unknown;
+  operation: OpenApiOperation;
+  props: OpenApiClientProps;
+  spec: Record<string, unknown>;
+}): Promise<unknown> {
+  const { operation, props, spec } = args;
+  const input =
+    args.input != null && typeof args.input === "object" && !Array.isArray(args.input)
+      ? { ...(args.input as Record<string, unknown>) }
+      : {};
+
+  // Path + query parameters are consumed by name; whatever remains is the body.
+  let resolvedPath = operation.path;
+  const query: Array<[string, string]> = [];
+  for (const parameter of operation.parameters) {
+    const value = input[parameter.name];
+    if (parameter.in === "path") {
+      if (value == null) {
+        throw new Error(`Operation "${operation.operationId}" needs "${parameter.name}".`);
+      }
+      resolvedPath = resolvedPath.replaceAll(
+        `{${parameter.name}}`,
+        encodeURIComponent(String(value)),
+      );
+      delete input[parameter.name];
+    } else if (parameter.in === "query" && value != null) {
+      query.push([parameter.name, String(value)]);
+      delete input[parameter.name];
+    }
+  }
+  const url = new URL(resolvedPath.replace(/^\//, ""), requestBase(props, spec));
+  for (const [name, value] of query) url.searchParams.set(name, value);
+
+  let body: string | undefined;
+  if (operation.requestBody && Object.keys(input).length > 0) {
+    // The SPEC decides the convention (same split the derived types declare):
+    // a non-object body schema travels under the single `body` key; an
+    // object schema's properties arrive inline as the leftover object.
+    const single =
+      Object.keys(input).length === 1 &&
+      "body" in input &&
+      !isObjectSchema(operationBodySchema(operation, spec));
+    body = JSON.stringify(single ? input.body : input);
+  }
+  const headers = new Headers(props.headers ?? {});
+  if (body !== undefined && !headers.has("content-type")) {
+    headers.set("content-type", "application/json");
+  }
+
+  const response = await args.egressFetch(
+    new Request(url, { body, headers, method: operation.method.toUpperCase() }),
+  );
+  if (!response.ok) {
+    const snippet = (await response.text().catch(() => "")).slice(0, 300);
+    throw new Error(
+      `${operation.method.toUpperCase()} ${url.pathname} (${operation.operationId}) ` +
+        `returned ${response.status}${snippet ? `: ${snippet}` : ""}`,
+    );
+  }
+  const contentType = response.headers.get("content-type") ?? "";
+  return contentType.includes("json") ? await response.json() : await response.text();
+}
+
+/** props.baseUrl, else the spec's first server (relative servers resolve
+ * against the spec URL — petstore's "/api/v3" does this), else the spec origin. */
+function requestBase(props: OpenApiClientProps, spec: Record<string, unknown>): string {
+  if (props.baseUrl) return ensureTrailingSlash(props.baseUrl);
+  const servers = spec.servers as Array<{ url?: string }> | undefined;
+  const serverUrl = servers?.[0]?.url;
+  if (serverUrl) return ensureTrailingSlash(new URL(serverUrl, props.specUrl).toString());
+  return new URL("/", props.specUrl).toString();
+}
+
+function ensureTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url : `${url}/`;
+}

--- a/apps/os/src/itx/capabilities/openapi-client.ts
+++ b/apps/os/src/itx/capabilities/openapi-client.ts
@@ -188,8 +188,15 @@ async function executeOperation(args: {
       );
       delete input[parameter.name];
     } else if (parameter.in === "query") {
-      // Consumed by name even when absent/null — a null query param is
-      // simply not sent, never mistaken for a body property.
+      // Consumed by name even when absent/null — a null optional query param
+      // is simply not sent, never mistaken for a body property. A missing
+      // REQUIRED one fails here, locally and instructively, exactly like a
+      // missing path param — not as a remote API error.
+      if (value == null && parameter.required) {
+        throw new Error(
+          `Operation "${operation.operationId}" needs query parameter "${parameter.name}".`,
+        );
+      }
       if (value != null) query.push([parameter.name, String(value)]);
       delete input[parameter.name];
     }

--- a/apps/os/src/itx/capabilities/openapi-client.ts
+++ b/apps/os/src/itx/capabilities/openapi-client.ts
@@ -108,9 +108,10 @@ export class OpenApiClient extends WorkerEntrypoint<Env, OpenApiClientProps> {
 
     const operationId = input.path[0];
     if (!operationId || input.path.length > 1) {
+      const name = props.capabilityPath ?? "<cap>";
       throw new Error(
-        `OpenApiClient dispatches flat operationIds (itx.<cap>.<operationId>(input)); ` +
-          `got path "${input.path.join(".")}". listOperations() lists what exists.`,
+        `Call operations by operationId only: itx.${name}.<operationId>(input) — there are ` +
+          `no nested paths (got "${input.path.join(".")}"). listOperations() lists what exists.`,
       );
     }
     const operation = listOpenApiOperations(spec).find(
@@ -133,7 +134,14 @@ async function fetchSpec(
   const cacheKey = `${props.projectId ?? ""}:${props.specUrl}`;
   const cached = specCache.get(cacheKey);
   if (cached && Date.now() - cached.fetchedAtMs < SPEC_CACHE_TTL_MS) return cached.spec;
-  const response = await egressFetch(new Request(props.specUrl, { headers: props.headers ?? {} }));
+  // props.headers are API credentials (real material by the time egress has
+  // substituted them) — they ride the spec fetch ONLY when the spec lives on
+  // the API host itself, never to a third-party spec host.
+  const specHost = new URL(props.specUrl).host;
+  const apiHost = props.baseUrl ? new URL(props.baseUrl).host : specHost;
+  const response = await egressFetch(
+    new Request(props.specUrl, { headers: specHost === apiHost ? (props.headers ?? {}) : {} }),
+  );
   if (!response.ok) {
     throw new Error(`Fetching the OpenAPI spec at ${props.specUrl} returned ${response.status}.`);
   }
@@ -142,6 +150,17 @@ async function fetchSpec(
   return spec;
 }
 
+/**
+ * Execute one operation. The input convention (mirrored exactly by the
+ * derived `types` string): args[0] is ONE object whose keys are consumed by
+ * path/query parameter NAME first; whatever remains is the JSON body (a
+ * non-object body schema travels under the single `body` key). Collisions
+ * resolve to the PARAMETER — a body property sharing a name with a path or
+ * query parameter cannot be expressed inline. Query values stringify via
+ * String(): arrays comma-join (style=form, explode=false); repeated query
+ * keys are never emitted. An operation with no request body refuses leftover
+ * keys instead of silently dropping them.
+ */
 async function executeOperation(args: {
   egressFetch: (request: Request) => Promise<Response>;
   input: unknown;
@@ -155,7 +174,6 @@ async function executeOperation(args: {
       ? { ...(args.input as Record<string, unknown>) }
       : {};
 
-  // Path + query parameters are consumed by name; whatever remains is the body.
   let resolvedPath = operation.path;
   const query: Array<[string, string]> = [];
   for (const parameter of operation.parameters) {
@@ -169,9 +187,24 @@ async function executeOperation(args: {
         encodeURIComponent(String(value)),
       );
       delete input[parameter.name];
-    } else if (parameter.in === "query" && value != null) {
-      query.push([parameter.name, String(value)]);
+    } else if (parameter.in === "query") {
+      // Consumed by name even when absent/null — a null query param is
+      // simply not sent, never mistaken for a body property.
+      if (value != null) query.push([parameter.name, String(value)]);
       delete input[parameter.name];
+    }
+  }
+  if (!operation.requestBody) {
+    const leftover = Object.keys(input);
+    if (leftover.length > 0) {
+      const valid = operation.parameters
+        .filter((parameter) => parameter.in === "path" || parameter.in === "query")
+        .map((parameter) => parameter.name);
+      throw new Error(
+        `Operation "${operation.operationId}" has no request body and got unknown input ` +
+          `key${leftover.length > 1 ? "s" : ""} ${leftover.map((key) => JSON.stringify(key)).join(", ")} — ` +
+          (valid.length > 0 ? `valid params: ${valid.join(", ")}.` : `it takes no parameters.`),
+      );
     }
   }
   const url = new URL(resolvedPath.replace(/^\//, ""), requestBase(props, spec));

--- a/apps/os/src/itx/capabilities/openapi-types.test.ts
+++ b/apps/os/src/itx/capabilities/openapi-types.test.ts
@@ -1,0 +1,152 @@
+// Unit tests for the OpenAPI → TypeScript declaration derivation — plain
+// Node, one small inline spec, assertions on the exact signatures an agent
+// would read out of describe().types.
+
+import { describe, expect, test } from "vitest";
+import { deriveOpenApiTypes, listOpenApiOperations } from "./openapi-types.ts";
+
+const SPEC = {
+  openapi: "3.0.3",
+  info: { title: "Widget API", version: "1.0.0" },
+  paths: {
+    "/widgets/{widgetId}": {
+      parameters: [{ name: "widgetId", in: "path", required: true, schema: { type: "integer" } }],
+      get: {
+        operationId: "getWidget",
+        summary: "Fetch one widget",
+        parameters: [{ name: "verbose", in: "query", schema: { type: "boolean" } }],
+        responses: {
+          "200": {
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/Widget" } },
+            },
+          },
+        },
+      },
+      delete: { operationId: "deleteWidget", responses: { "204": { description: "gone" } } },
+    },
+    "/widgets": {
+      get: {
+        operationId: "listWidgets",
+        parameters: [
+          {
+            name: "status",
+            in: "query",
+            required: true,
+            schema: { type: "string", enum: ["draft", "live"] },
+          },
+        ],
+        responses: {
+          "200": {
+            content: {
+              "application/json": {
+                schema: { type: "array", items: { $ref: "#/components/schemas/Widget" } },
+              },
+            },
+          },
+        },
+      },
+      post: {
+        operationId: "createWidget",
+        requestBody: {
+          content: {
+            "application/json": { schema: { $ref: "#/components/schemas/NewWidget" } },
+          },
+        },
+        responses: {
+          "201": {
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/Widget" } },
+            },
+          },
+        },
+      },
+    },
+    "/raw": {
+      put: {
+        operationId: "putRaw",
+        requestBody: { content: { "application/json": { schema: { type: "string" } } } },
+        responses: { "200": { content: { "application/json": { schema: { type: "boolean" } } } } },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Widget: {
+        type: "object",
+        required: ["id", "name"],
+        properties: {
+          id: { type: "integer" },
+          name: { type: "string" },
+          status: { type: "string", enum: ["draft", "live"] },
+          tags: { type: "array", items: { type: "string" } },
+          owner: { oneOf: [{ $ref: "#/components/schemas/Owner" }, { type: "null" }] },
+        },
+      },
+      NewWidget: {
+        type: "object",
+        required: ["name"],
+        properties: { name: { type: "string" }, status: { type: "string" } },
+      },
+      Owner: { type: "object", properties: { email: { type: "string" } } },
+    },
+  },
+} as unknown as Record<string, unknown>;
+
+describe("listOpenApiOperations", () => {
+  test("flattens paths×methods to flat operationIds, merging path-item parameters", () => {
+    const operations = listOpenApiOperations(SPEC);
+    expect(operations.map((operation) => operation.operationId)).toEqual([
+      "getWidget",
+      "deleteWidget",
+      "listWidgets",
+      "createWidget",
+      "putRaw",
+    ]);
+    const getWidget = operations.find((operation) => operation.operationId === "getWidget")!;
+    expect(getWidget).toMatchObject({ method: "get", path: "/widgets/{widgetId}" });
+    // The path-item-level widgetId parameter merges into the operation's own.
+    expect(getWidget.parameters.map((parameter) => parameter.name)).toEqual([
+      "widgetId",
+      "verbose",
+    ]);
+  });
+});
+
+describe("deriveOpenApiTypes", () => {
+  const types = deriveOpenApiTypes(SPEC);
+
+  test("path + query params merge into ONE input object; path params are required", () => {
+    expect(types).toContain(
+      "declare function getWidget(input: { widgetId: number; verbose?: boolean }): Promise<",
+    );
+  });
+
+  test("$refs resolve against components.schemas; enums become literal unions", () => {
+    expect(types).toContain(
+      'Promise<{ id: number; name: string; status?: "draft" | "live"; tags?: string[]; owner?: { email?: string } | null }>',
+    );
+    expect(types).toContain('status: "draft" | "live"');
+  });
+
+  test("object request bodies inline their properties into the input object", () => {
+    expect(types).toContain(
+      "declare function createWidget(input: { name: string; status?: string }): Promise<",
+    );
+  });
+
+  test("non-object bodies travel under a `body` key; bare responses are unknown", () => {
+    expect(types).toContain("declare function putRaw(input: { body: string }): Promise<boolean>;");
+    // deleteWidget inherits the path-item-level widgetId; no response schema → unknown.
+    expect(types).toContain(
+      "declare function deleteWidget(input: { widgetId: number }): Promise<unknown>;",
+    );
+  });
+
+  test("summaries become JSDoc; arrays of $refs resolve", () => {
+    expect(types).toContain("/** Fetch one widget */");
+    expect(types).toContain(
+      'declare function listWidgets(input: { status: "draft" | "live" }): Promise<{ id: number; name: string;',
+    );
+  });
+});

--- a/apps/os/src/itx/capabilities/openapi-types.ts
+++ b/apps/os/src/itx/capabilities/openapi-types.ts
@@ -1,0 +1,215 @@
+// OpenAPI 3.x → TypeScript declaration STRING — the machine-facing half of a
+// capability's self-description (`types` in describe()). Dependency-free and
+// deliberately small: one `declare function <operationId>(input): Promise<…>`
+// per operation, with JSON Schema converted structurally (objects, arrays,
+// primitives, enums, unions, basic $ref against components.schemas) and
+// `unknown` wherever fidelity would cost complexity. Structure cribbed from
+// cloudflare/agents packages/codemode (json-schema-types.ts), reduced to what
+// an agent reading describe() actually needs.
+
+type SchemaNode = Record<string, unknown>;
+
+export type OpenApiOperation = {
+  operationId: string;
+  method: string;
+  path: string;
+  summary?: string;
+  /** path + query parameters, path-item-level ones merged in. */
+  parameters: Array<{ name: string; in: string; required?: boolean; schema?: SchemaNode }>;
+  requestBody?: { content?: Record<string, { schema?: SchemaNode }> };
+  responses?: Record<string, { content?: Record<string, { schema?: SchemaNode }> }>;
+};
+
+const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"] as const;
+const MAX_DEPTH = 6;
+
+/** Every operation carrying an operationId, flattened across paths×methods.
+ * Dispatch is by FLAT operationId: real-world specs (petstore, Stripe,
+ * GitHub) keep operationIds unique and camelCased, so a nested
+ * tag.operationId convention would only add ceremony. */
+export function listOpenApiOperations(spec: Record<string, unknown>): OpenApiOperation[] {
+  const paths = (spec.paths ?? {}) as Record<string, SchemaNode>;
+  const operations: OpenApiOperation[] = [];
+  for (const [path, pathItem] of Object.entries(paths)) {
+    if (pathItem == null || typeof pathItem !== "object") continue;
+    const shared = Array.isArray(pathItem.parameters) ? pathItem.parameters : [];
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method] as SchemaNode | undefined;
+      if (typeof operation?.operationId !== "string") continue;
+      const own = Array.isArray(operation.parameters) ? operation.parameters : [];
+      operations.push({
+        method,
+        operationId: operation.operationId,
+        parameters: [...shared, ...own] as OpenApiOperation["parameters"],
+        path,
+        requestBody: operation.requestBody as OpenApiOperation["requestBody"],
+        responses: operation.responses as OpenApiOperation["responses"],
+        summary: (operation.summary ?? operation.description) as string | undefined,
+      });
+    }
+  }
+  return operations;
+}
+
+/** The whole spec as one declaration string. Operations whose operationId is
+ * not a plain identifier are skipped here (dot-paths could never reach them)
+ * but stay visible through listOperations. */
+export function deriveOpenApiTypes(spec: Record<string, unknown>): string {
+  const declarations: string[] = [];
+  for (const operation of listOpenApiOperations(spec)) {
+    if (!/^[A-Za-z_$][\w$]*$/.test(operation.operationId)) continue;
+    if (operation.summary) {
+      declarations.push(`/** ${operation.summary.replaceAll("*/", "*\\/")} */`);
+    }
+    declarations.push(
+      `declare function ${operation.operationId}(` +
+        `input: ${operationInputType(operation, spec)}` +
+        `): Promise<${operationResponseType(operation, spec)}>;`,
+    );
+  }
+  return declarations.join("\n");
+}
+
+/** One input object merging path params + query params + body properties —
+ * mirroring exactly what OpenApiClient.call accepts as args[0]. */
+function operationInputType(operation: OpenApiOperation, spec: Record<string, unknown>): string {
+  const members: string[] = [];
+  for (const parameter of operation.parameters) {
+    if (parameter.in !== "path" && parameter.in !== "query") continue;
+    const required = parameter.in === "path" || parameter.required === true;
+    const type = schemaToTs(parameter.schema, spec, 1);
+    members.push(`${propertyKey(parameter.name)}${required ? "" : "?"}: ${type}`);
+  }
+  const bodySchema = operationBodySchema(operation, spec);
+  if (bodySchema) {
+    if (isObjectSchema(bodySchema)) {
+      const required = new Set(Array.isArray(bodySchema.required) ? bodySchema.required : []);
+      for (const [name, propSchema] of Object.entries(
+        (bodySchema.properties ?? {}) as Record<string, SchemaNode>,
+      )) {
+        members.push(
+          `${propertyKey(name)}${required.has(name) ? "" : "?"}: ${schemaToTs(propSchema, spec, 1)}`,
+        );
+      }
+    } else {
+      // Non-object bodies travel under the single `body` key (see
+      // OpenApiClient's dispatch).
+      members.push(`body: ${schemaToTs(bodySchema, spec, 1)}`);
+    }
+  }
+  return members.length === 0 ? "Record<string, never>" : `{ ${members.join("; ")} }`;
+}
+
+function operationResponseType(operation: OpenApiOperation, spec: Record<string, unknown>): string {
+  const responses = operation.responses ?? {};
+  const success = responses["200"] ?? responses["201"] ?? responses["default"];
+  const schema = jsonContentSchema(success);
+  return schema ? schemaToTs(schema, spec, 0) : "unknown";
+}
+
+/** The operation's request-body schema, $ref-resolved — the client's dispatch
+ * uses it to decide between the inline-properties and single-`body`-key
+ * conventions (the same split operationInputType declares). */
+export function operationBodySchema(
+  operation: OpenApiOperation,
+  spec: Record<string, unknown>,
+): SchemaNode | undefined {
+  return resolveRef(jsonContentSchema(operation.requestBody), spec);
+}
+
+function jsonContentSchema(
+  carrier: { content?: Record<string, { schema?: SchemaNode }> } | undefined,
+): SchemaNode | undefined {
+  const content = carrier?.content ?? {};
+  const media = content["application/json"] ?? Object.values(content)[0];
+  return media?.schema;
+}
+
+/** JSON Schema → TS type string: depth-capped, $ref-resolving, unknown-on-doubt. */
+function schemaToTs(
+  schema: SchemaNode | undefined,
+  spec: Record<string, unknown>,
+  depth: number,
+): string {
+  if (!schema || typeof schema !== "object") return "unknown";
+  if (depth > MAX_DEPTH) return "unknown";
+  const resolved = resolveRef(schema, spec);
+  if (!resolved) return "unknown";
+  schema = resolved;
+
+  const nullable = schema.nullable === true ? " | null" : "";
+  const union = (variants: unknown): string | null =>
+    Array.isArray(variants) && variants.length > 0
+      ? variants.map((variant) => schemaToTs(variant as SchemaNode, spec, depth + 1)).join(" | ")
+      : null;
+
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return schema.enum.map((value) => JSON.stringify(value) ?? "unknown").join(" | ") + nullable;
+  }
+  const oneOf = union(schema.oneOf) ?? union(schema.anyOf);
+  if (oneOf) return oneOf + nullable;
+  if (Array.isArray(schema.allOf) && schema.allOf.length > 0) {
+    return (
+      schema.allOf.map((part) => schemaToTs(part as SchemaNode, spec, depth + 1)).join(" & ") +
+      nullable
+    );
+  }
+
+  const type = Array.isArray(schema.type)
+    ? schema.type.map((entry) => scalarTs(String(entry))).join(" | ") // 3.1 type arrays
+    : typeof schema.type === "string"
+      ? schema.type
+      : undefined;
+  if (type === "array") {
+    return `${schemaToTs(schema.items as SchemaNode, spec, depth + 1)}[]` + nullable;
+  }
+  if (type === "object" || (type === undefined && isObjectSchema(schema))) {
+    const properties = (schema.properties ?? {}) as Record<string, SchemaNode>;
+    if (Object.keys(properties).length === 0) return "Record<string, unknown>" + nullable;
+    const required = new Set(Array.isArray(schema.required) ? schema.required : []);
+    const members = Object.entries(properties).map(
+      ([name, propSchema]) =>
+        `${propertyKey(name)}${required.has(name) ? "" : "?"}: ${schemaToTs(propSchema, spec, depth + 1)}`,
+    );
+    return `{ ${members.join("; ")} }` + nullable;
+  }
+  if (type !== undefined) return scalarTs(type) + nullable;
+  return "unknown";
+}
+
+function scalarTs(type: string): string {
+  if (type === "integer" || type === "number") return "number";
+  if (type === "string" || type === "boolean") return type;
+  if (type === "null") return "null";
+  return "unknown";
+}
+
+/** Internal #/… pointer resolution (components.schemas and friends). Returns
+ * the input untouched when it carries no $ref; null when the ref dangles. */
+function resolveRef(
+  schema: SchemaNode | undefined,
+  spec: Record<string, unknown>,
+): SchemaNode | undefined {
+  if (!schema || typeof schema.$ref !== "string") return schema;
+  if (!schema.$ref.startsWith("#/")) return undefined;
+  let current: unknown = spec;
+  for (const segment of schema.$ref.slice(2).split("/")) {
+    if (current == null || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[
+      segment.replaceAll("~1", "/").replaceAll("~0", "~")
+    ];
+  }
+  return current && typeof current === "object" ? (current as SchemaNode) : undefined;
+}
+
+export function isObjectSchema(schema: SchemaNode | undefined): schema is SchemaNode {
+  return (
+    schema != null &&
+    typeof schema === "object" &&
+    (schema.type === "object" || (schema.type === undefined && schema.properties != null))
+  );
+}
+
+function propertyKey(name: string): string {
+  return /^[A-Za-z_$][\w$]*$/.test(name) ? name : JSON.stringify(name);
+}

--- a/apps/os/src/itx/client.ts
+++ b/apps/os/src/itx/client.ts
@@ -12,12 +12,6 @@ import { newWebSocketRpcSession, type RpcStub } from "capnweb";
 import WebSocket from "ws";
 import type { ItxHandle } from "./handle.ts";
 
-// The client-side half of the one calling convention: wrap a plain
-// object-of-methods before provideCapability()ing it as a live provider.
-// (From path-proxy.ts, not itx.ts: this module runs in Node, and itx.ts —
-// the core — imports cloudflare:workers.)
-export { asPathCallable } from "./path-proxy.ts";
-
 export type WithItxInput = {
   /** OS base url, e.g. https://os.iterate-preview-3.com */
   baseUrl: string;

--- a/apps/os/src/itx/dial.ts
+++ b/apps/os/src/itx/dial.ts
@@ -306,6 +306,10 @@ const DIALABLE_LOOPBACKS: ReadonlySet<string> = new Set([
   // through their own project's pipe.
   "OpenApiClient",
   "ReposCapability",
+  // Scopes strictly by the dial-injected projectId (SecretsCapability reads
+  // ctx.props.projectId, which the injection spread always overwrites), so a
+  // provider can never point it at another project's secrets.
+  "SecretsCapability",
   "SlackCapability",
   "StreamsCapability",
   "WorkspaceCapability",

--- a/apps/os/src/itx/dial.ts
+++ b/apps/os/src/itx/dial.ts
@@ -300,6 +300,11 @@ const DIALABLE_LOOPBACKS: ReadonlySet<string> = new Set([
   "EgressPipe",
   "GmailCapability",
   "McpClient",
+  // Like McpClient: only provider props (specUrl/baseUrl/headers) + the
+  // dial-injected attribution — every fetch rides the originating project's
+  // egress, so a handle holder providing it grants nothing beyond HTTP
+  // through their own project's pipe.
+  "OpenApiClient",
   "ReposCapability",
   "SlackCapability",
   "StreamsCapability",

--- a/apps/os/src/itx/dial.ts
+++ b/apps/os/src/itx/dial.ts
@@ -134,7 +134,7 @@ export function makeDial(host: DialHost): CapabilityDial {
         // The binding is a concrete env object that doesn't speak the calling
         // convention — wrap it here, where it is real. Env bindings are
         // long-lived host objects, never per-call borrows: no dispose.
-        return inProcessPathCallable(binding);
+        return inProcessPathCallable(binding, { capability: name });
       }
       case "loopback": {
         // First-party loopback entrypoints all implement call({ path, args })
@@ -183,7 +183,10 @@ export function makeDial(host: DialHost): CapabilityDial {
             }
             return { class: facetClass };
           });
-          return inProcessPathCallable(facetTarget, () => disposeIfPossible(facetTarget));
+          return inProcessPathCallable(facetTarget, {
+            capability: name,
+            dispose: () => disposeIfPossible(facetTarget),
+          });
         }
         const entrypoint = loadWorker(name, attribution.origin, source).then((worker) =>
           worker.getEntrypoint(source.entrypoint),
@@ -193,7 +196,7 @@ export function makeDial(host: DialHost): CapabilityDial {
         // path still awaits the original promise and gets the real error).
         entrypoint.catch(() => {});
         const borrowed: PathCallable & Disposable = {
-          call: async (input) => replayPathCall(await entrypoint, input),
+          call: async (input) => replayPathCall(await entrypoint, input, { capability: name }),
           [Symbol.dispose]: () => void entrypoint.then(disposeIfPossible, () => {}),
         };
         return borrowed;
@@ -241,10 +244,13 @@ export function sourceIsolateKey(input: {
  * on the concrete object the dial just resolved, and (optionally) disposes
  * the inner borrow when the core finishes the call. Never crosses RPC — the
  * core consumes it in-process, so no RpcTarget wrapper is needed. */
-function inProcessPathCallable(target: unknown, dispose?: () => void): PathCallable {
+function inProcessPathCallable(
+  target: unknown,
+  opts?: { capability?: string; dispose?: () => void },
+): PathCallable {
   return {
-    call: (input) => replayPathCall(target, input),
-    ...(dispose ? { [Symbol.dispose]: dispose } : {}),
+    call: (input) => replayPathCall(target, input, { capability: opts?.capability }),
+    ...(opts?.dispose ? { [Symbol.dispose]: opts.dispose } : {}),
   };
 }
 

--- a/apps/os/src/itx/e2e/example-cases.ts
+++ b/apps/os/src/itx/e2e/example-cases.ts
@@ -5,8 +5,6 @@
 // a runnable example is missing one (so examples can't silently rot).
 //
 // Not here by design:
-//   provide-live-capability        browser-only alert flow, asserted by its
-//                                  dedicated browser test (alert capture)
 //   egress-with-secret-substitution depends on an external echo service;
 //                                  covered by itx-egress.e2e.test.ts
 //   fetch-middleware               depends on the same external echo service;
@@ -56,7 +54,6 @@ export const EXAMPLE_IDS_WITHOUT_CASES = new Set([
   "mcp-authenticated",
   "mcp-client",
   "openapi-client",
-  "provide-live-capability",
   "repo-sourced-capability",
   "secrets-and-egress",
 ]);
@@ -125,12 +122,12 @@ export const EXAMPLE_CASES: Record<string, ExampleCase> = {
       expect(result).toMatchObject({ fromChild: "child" });
       const capabilities = (result as { capabilities: Array<{ from?: string; name: string }> })
         .capabilities;
-      // The shadow is the child's OWN entry (no provenance field); platform
-      // defaults arrive through the chain labeled from: "platform".
+      // The shadow is the child's OWN entry (no provenance field); the
+      // defaults arrive through the chain labeled from: "defaults".
       const shared = capabilities.filter((entry) => entry.name === "shared");
       expect(shared).toHaveLength(1);
       expect(shared[0]!.from).toBeUndefined();
-      expect(capabilities.find((entry) => entry.name === "fetch")?.from).toBe("platform");
+      expect(capabilities.find((entry) => entry.name === "fetch")?.from).toBe("defaults");
     },
   },
   "journal-is-the-record": {

--- a/apps/os/src/itx/e2e/example-cases.ts
+++ b/apps/os/src/itx/e2e/example-cases.ts
@@ -23,6 +23,10 @@
 //                                  a project secret; proven end to end (incl.
 //                                  the placeholder-never-material negative
 //                                  controls) by itx-mcp-auth.e2e.test.ts
+//   openapi-client                 depends on the live petstore demo server
+//                                  (and the provide-time describeItx probe's
+//                                  cold-start retry); proven end to end by
+//                                  itx-openapi.e2e.test.ts
 
 import { expect } from "vitest";
 
@@ -42,6 +46,7 @@ export const EXAMPLE_IDS_WITHOUT_CASES = new Set([
   "egress-with-secret-substitution",
   "fetch-middleware",
   "mcp-authenticated",
+  "openapi-client",
   "provide-live-capability",
   "repo-sourced-capability",
 ]);

--- a/apps/os/src/itx/e2e/example-cases.ts
+++ b/apps/os/src/itx/e2e/example-cases.ts
@@ -19,10 +19,18 @@
 //                                  for the per-runtime matrix; proven end to
 //                                  end by the litmus e2e in itx.e2e.test.ts
 //                                  ("user-space caps: repo-sourced code …")
+//   mcp-client                     depends on Cloudflare's live public docs
+//                                  MCP server; the same flow is the
+//                                  always-running e2e in itx-mcp-auth.e2e.test.ts
+//                                  ("public MCP: …")
 //   mcp-authenticated              needs a real Cloudflare API token stored as
 //                                  a project secret; proven end to end (incl.
 //                                  the placeholder-never-material negative
 //                                  controls) by itx-mcp-auth.e2e.test.ts
+//   secrets-and-egress             depends on the same external echo service;
+//                                  the setSecret → placeholder-fetch flow is
+//                                  the "itx.secrets" e2e in
+//                                  itx-egress.e2e.test.ts
 //   openapi-client                 depends on the live petstore demo server
 //                                  (and the provide-time describeItx probe's
 //                                  cold-start retry); proven end to end by
@@ -46,9 +54,11 @@ export const EXAMPLE_IDS_WITHOUT_CASES = new Set([
   "egress-with-secret-substitution",
   "fetch-middleware",
   "mcp-authenticated",
+  "mcp-client",
   "openapi-client",
   "provide-live-capability",
   "repo-sourced-capability",
+  "secrets-and-egress",
 ]);
 
 export const EXAMPLE_CASES: Record<string, ExampleCase> = {

--- a/apps/os/src/itx/e2e/example-cases.ts
+++ b/apps/os/src/itx/e2e/example-cases.ts
@@ -31,10 +31,10 @@
 //                                  the setSecret → placeholder-fetch flow is
 //                                  the "itx.secrets" e2e in
 //                                  itx-egress.e2e.test.ts
-//   openapi-client                 depends on the live petstore demo server
-//                                  (and the provide-time describeItx probe's
-//                                  cold-start retry); proven end to end by
-//                                  itx-openapi.e2e.test.ts
+//   openapi-client                 the catalogue snippet points at the live
+//                                  petstore demo; the same flow is proven
+//                                  deterministically against the deployment's
+//                                  own fixture in itx-openapi.e2e.test.ts
 
 import { expect } from "vitest";
 

--- a/apps/os/src/itx/e2e/example-cases.ts
+++ b/apps/os/src/itx/e2e/example-cases.ts
@@ -9,6 +9,16 @@
 //                                  dedicated browser test (alert capture)
 //   egress-with-secret-substitution depends on an external echo service;
 //                                  covered by itx-egress.e2e.test.ts
+//   fetch-middleware               depends on the same external echo service;
+//                                  the middleware behavior itself (shadow +
+//                                  itx.super delegation, both egress doors) is
+//                                  the locked acceptance e2e in
+//                                  itx-extend.e2e.test.ts ("MIDDLEWARE — …")
+//   repo-sourced-capability        a real git push + per-commit build + the
+//                                  ~10s "latest" probe window — too slow/flaky
+//                                  for the per-runtime matrix; proven end to
+//                                  end by the litmus e2e in itx.e2e.test.ts
+//                                  ("user-space caps: repo-sourced code …")
 
 import { expect } from "vitest";
 
@@ -26,7 +36,9 @@ export type ExampleCase = {
 /** Example ids that intentionally have no matrix case (see header). */
 export const EXAMPLE_IDS_WITHOUT_CASES = new Set([
   "egress-with-secret-substitution",
+  "fetch-middleware",
   "provide-live-capability",
+  "repo-sourced-capability",
 ]);
 
 export const EXAMPLE_CASES: Record<string, ExampleCase> = {
@@ -41,6 +53,14 @@ export const EXAMPLE_CASES: Record<string, ExampleCase> = {
     assert: (result, { marker }) => {
       expect(result).toMatchObject({ appended: { payload: { note: marker } } });
       expect((result as { count: number }).count).toBeGreaterThan(0);
+    },
+  },
+  "provide-plain-object": {
+    assert: (result) => {
+      expect(result).toEqual({
+        deep: { answer: 42, question: "life, the universe, everything" },
+        ultimate: 42,
+      });
     },
   },
   "provide-path-call-sdk": {
@@ -82,7 +102,21 @@ export const EXAMPLE_CASES: Record<string, ExampleCase> = {
   },
   "extend-child-context": {
     assert: (result) => {
-      expect(result).toMatchObject({ fromChild: { from: "child", method: "ping" } });
+      expect(result).toMatchObject({ fromChild: "child" });
+      const capabilities = (result as { capabilities: Array<{ from?: string; name: string }> })
+        .capabilities;
+      // The shadow is the child's OWN entry (no provenance field); platform
+      // defaults arrive through the chain labeled from: "platform".
+      const shared = capabilities.filter((entry) => entry.name === "shared");
+      expect(shared).toHaveLength(1);
+      expect(shared[0]!.from).toBeUndefined();
+      expect(capabilities.find((entry) => entry.name === "fetch")?.from).toBe("platform");
+    },
+  },
+  "journal-is-the-record": {
+    vars: ({ marker }) => ({ capName: `journal_${marker.replace(/-/g, "_")}` }),
+    assert: (result) => {
+      expect(result).toEqual({ record: ["capability-provided", "capability-revoked"] });
     },
   },
   "http-cap-and-share-url": {

--- a/apps/os/src/itx/e2e/example-cases.ts
+++ b/apps/os/src/itx/e2e/example-cases.ts
@@ -19,6 +19,10 @@
 //                                  for the per-runtime matrix; proven end to
 //                                  end by the litmus e2e in itx.e2e.test.ts
 //                                  ("user-space caps: repo-sourced code …")
+//   mcp-authenticated              needs a real Cloudflare API token stored as
+//                                  a project secret; proven end to end (incl.
+//                                  the placeholder-never-material negative
+//                                  controls) by itx-mcp-auth.e2e.test.ts
 
 import { expect } from "vitest";
 
@@ -37,6 +41,7 @@ export type ExampleCase = {
 export const EXAMPLE_IDS_WITHOUT_CASES = new Set([
   "egress-with-secret-substitution",
   "fetch-middleware",
+  "mcp-authenticated",
   "provide-live-capability",
   "repo-sourced-capability",
 ]);

--- a/apps/os/src/itx/e2e/example-matrix.ts
+++ b/apps/os/src/itx/e2e/example-matrix.ts
@@ -14,7 +14,6 @@ import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 import { RpcTarget } from "capnweb";
-import { asPathCallable } from "../client.ts";
 import type { ItxExample, ItxExampleRuntime } from "../examples.ts";
 import { adminApiSecret, baseUrl, connectGlobal } from "./e2e-env.ts";
 
@@ -26,12 +25,7 @@ export type MatrixRuntime = (typeof MATRIX_RUNTIMES)[number] & ItxExampleRuntime
 
 const AsyncFunction = async function () {}.constructor as new (
   ...args: string[]
-) => (
-  itx: unknown,
-  vars: Record<string, unknown>,
-  rpcTarget: unknown,
-  pathCallable: unknown,
-) => Promise<unknown>;
+) => (itx: unknown, vars: Record<string, unknown>, rpcTarget: unknown) => Promise<unknown>;
 
 export async function runExampleCode(
   runtime: MatrixRuntime,
@@ -81,10 +75,10 @@ async function runInNode(input: {
   projectId: string;
   vars: Record<string, unknown>;
 }): Promise<unknown> {
-  const script = new AsyncFunction("itx", "vars", "RpcTarget", "asPathCallable", input.code);
+  const script = new AsyncFunction("itx", "vars", "RpcTarget", input.code);
   using itx = connectGlobal();
   using projectItx = await itx.projects.get(input.projectId);
-  return await script(projectItx, input.vars, RpcTarget, asPathCallable);
+  return await script(projectItx, input.vars, RpcTarget);
 }
 
 async function runInCli(input: {

--- a/apps/os/src/itx/e2e/itx-egress.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx-egress.e2e.test.ts
@@ -128,7 +128,7 @@ test("bare fetch() inside a worker cap goes through egress (implicit door)", asy
   expect(echoedHeader(probe.body)).toContain(SECRET_MATERIAL);
 });
 
-test("itx.secrets: set a secret through the platform default, then fetch with its placeholder", async () => {
+test("itx.secrets: set a secret through the default, then fetch with its placeholder", async () => {
   using itx = connectGlobal();
   const project = (await itx.projects.create({ slug: `itx-secrets-${suffix()}` })) as {
     id: string;
@@ -138,7 +138,7 @@ test("itx.secrets: set a secret through the platform default, then fetch with it
   await waitForProjectReady(projectItx);
 
   // The secrets-and-egress catalogue example's flow: store material once via
-  // the `secrets` platform default, reference it by KEY in an egress header,
+  // the `secrets` default, reference it by KEY in an egress header,
   // and the pipe substitutes server-side.
   const handle = projectItx as never as Record<string, any>;
   const material = `lifecycle-${crypto.randomUUID()}`;

--- a/apps/os/src/itx/e2e/itx-egress.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx-egress.e2e.test.ts
@@ -128,6 +128,41 @@ test("bare fetch() inside a worker cap goes through egress (implicit door)", asy
   expect(echoedHeader(probe.body)).toContain(SECRET_MATERIAL);
 });
 
+test("itx.secrets: set a secret through the platform default, then fetch with its placeholder", async () => {
+  using itx = connectGlobal();
+  const project = (await itx.projects.create({ slug: `itx-secrets-${suffix()}` })) as {
+    id: string;
+  };
+  createdProjectIds.push(project.id);
+  using projectItx = await itx.projects.get(project.id);
+  await waitForProjectReady(projectItx);
+
+  // The secrets-and-egress catalogue example's flow: store material once via
+  // the `secrets` platform default, reference it by KEY in an egress header,
+  // and the pipe substitutes server-side.
+  const handle = projectItx as never as Record<string, any>;
+  const material = `lifecycle-${crypto.randomUUID()}`;
+  await handle.secrets.setSecret({ key: "demo.api_key", material });
+
+  const listed = (await handle.secrets.listSecrets()) as Array<{ key: string }>;
+  expect(listed.map((secret) => secret.key)).toContain("demo.api_key");
+  // Summaries are redacted — material never rides the list surface.
+  expect(JSON.stringify(listed)).not.toContain(material);
+
+  const response = await projectItx.fetch(echoUrl(), {
+    headers: {
+      authorization: `Bearer ${adminApiSecret()}`,
+      [HEADER]: 'getSecret({ key: "demo.api_key" })',
+    },
+  });
+  expect(response.status).toBe(200);
+  expect(echoedHeader(await response.json())).toContain(material);
+
+  await handle.secrets.deleteSecret({ key: "demo.api_key" });
+  const afterDelete = (await handle.secrets.listSecrets()) as Array<{ key: string }>;
+  expect(afterDelete.map((secret) => secret.key)).not.toContain("demo.api_key");
+});
+
 // ---- helpers ----------------------------------------------------------------
 
 /**

--- a/apps/os/src/itx/e2e/itx-extend.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx-extend.e2e.test.ts
@@ -282,7 +282,7 @@ test(
     // genuine default pipe.
     const probeUrl = new URL("/api/itx", baseUrl()).toString();
 
-    // The shadow is a BARE FUNCTION — no RpcTarget, no asPathCallable. It
+    // The shadow is a BARE FUNCTION — no RpcTarget, no wrapper of any kind. It
     // crosses the provide input nested inside a plain object, which is the
     // bare-nested-function-over-capnweb serialization proof: capnweb stubs
     // the function, the platform probes the stub (a pure property pull) and

--- a/apps/os/src/itx/e2e/itx-extend.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx-extend.e2e.test.ts
@@ -49,7 +49,8 @@ test("extend: child caps shadow the parent, misses delegate up the chain", async
   expect(viaChain.marker).toBe("project-level");
 
   // (2) The child provides its own capability under the SAME name → shadows
-  // visibly (describe reports the owner).
+  // visibly: exactly one `shared` survives, and it is an OWN entry (no
+  // `from` — that field marks inherited entries only).
   await child.provideCapability({
     name: "shared",
     capability: chatPostTarget("child-level"),
@@ -59,10 +60,10 @@ test("extend: child caps shadow the parent, misses delegate up the chain", async
   })) as { marker: string };
   expect(viaShadow.marker).toBe("child-level");
 
-  const merged = (await child.describe()).capabilities as Array<{ name: string; owner: string }>;
+  const merged = (await child.describe()).capabilities as Array<{ from?: string; name: string }>;
   const shared = merged.filter((entry) => entry.name === "shared");
   expect(shared).toHaveLength(1);
-  expect(String(shared[0]!.owner)).toMatch(/^itx_/);
+  expect(shared[0]!.from).toBeUndefined();
 
   // (3) The parent is untouched — and a sibling extension sees the parent's cap.
   using sibling = await projectItx.extend();

--- a/apps/os/src/itx/e2e/itx-extend.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx-extend.e2e.test.ts
@@ -161,7 +161,7 @@ test("extend: workspaces are HOST-provided — plain extensions share the projec
   using projectItx = await itx.projects.get(project.id);
 
   // Workspaces are not itx's concern (no per-context derivation magic): the
-  // platform context provides the PROJECT workspace explicitly, so a plain
+  // defaults provide the PROJECT workspace explicitly, so a plain
   // extension inherits that same workspace through the chain…
   using child = await projectItx.extend({ name: "e2e-ws" });
   const handle = (target: unknown) => target as never as Record<string, any>;
@@ -295,7 +295,7 @@ test(
         seen.push(url);
         // Middleware: delegate to the UNSHADOWED pipe — itx.super is the
         // "call next()" of the chain (the parent context has no shadow, so
-        // its `fetch` resolves the platform default).
+        // its `fetch` resolves the default).
         const delegated = (await childHandle.super.fetch(url)) as Response;
         return new Response(JSON.stringify({ delegatedStatus: delegated.status, shadowed: true }), {
           headers: { "content-type": "application/json" },

--- a/apps/os/src/itx/e2e/itx-mcp-auth.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx-mcp-auth.e2e.test.ts
@@ -24,10 +24,45 @@ import {
 
 const CLOUDFLARE_API_TOKEN = process.env.CLOUDFLARE_API_TOKEN?.trim() ?? "";
 const MCP_SERVER_URL = "https://bindings.mcp.cloudflare.com/mcp";
+const PUBLIC_MCP_SERVER_URL = "https://docs.mcp.cloudflare.com/mcp";
 const SECRET_KEY = "CLOUDFLARE_API_TOKEN";
 const PLACEHOLDER = `Bearer getSecret({ key: "${SECRET_KEY}" })`;
 
 const createdProjectIds = registerCreatedProjectCleanup();
+
+test(
+  "public MCP: an unauthenticated server via McpClient (the mcp-client catalogue example)",
+  { timeout: 90_000 },
+  async () => {
+    using itx = connectGlobal();
+    const project = (await itx.projects.create({
+      slug: `itx-mcp-pub-${crypto.randomUUID().slice(0, 8)}`,
+    })) as { id: string };
+    createdProjectIds.push(project.id);
+    using projectItx = await itx.projects.get(project.id);
+
+    await projectItx.provideCapability({
+      name: "cfdocs",
+      instructions: "Cloudflare's documentation MCP server. Call listTools() first.",
+      capability: {
+        entrypoint: "McpClient",
+        props: { serverUrl: PUBLIC_MCP_SERVER_URL },
+        type: "rpc",
+        worker: { type: "loopback" },
+      },
+    });
+
+    const handle = projectItx as never as Record<string, any>;
+    const listed = (await handle.cfdocs.listTools()) as { tools: { name: string }[] };
+    expect(listed.tools.map((tool) => tool.name)).toContain("search_cloudflare_documentation");
+    const answer = await handle.cfdocs.search_cloudflare_documentation({
+      query: "durable objects",
+    });
+    expect(
+      String(typeof answer === "string" ? answer : JSON.stringify(answer)).length,
+    ).toBeGreaterThan(0);
+  },
+);
 
 test.skipIf(!CLOUDFLARE_API_TOKEN)(
   "authenticated MCP: the credential is a project secret, substituted on egress, invisible everywhere else",

--- a/apps/os/src/itx/e2e/itx-mcp-auth.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx-mcp-auth.e2e.test.ts
@@ -1,0 +1,115 @@
+// Authenticated MCP via secret-substituted egress, proven against a REAL
+// third-party server: Cloudflare's remote MCP server at
+// https://bindings.mcp.cloudflare.com/mcp (streamable HTTP; 401 without
+// `Authorization: Bearer <api token>`, full MCP with it).
+//
+// The shape under test is the McpClient docstring's promise end to end:
+//   - the credential lives as a PROJECT SECRET (a D1 row, written via the
+//     admin REST surface)
+//   - the capability ADDRESS carries only a getSecret(...) placeholder
+//   - substitution happens server-side in the EgressPipe on the egress path
+//   - neither describe() nor the journal ever contains the material
+//
+// Requires CLOUDFLARE_API_TOKEN in the environment — present under
+// `doppler run --config prd|preview_N --project os` (the same token alchemy
+// deploys with). Absent → the test skips, never fails.
+
+import { expect, test } from "vitest";
+import {
+  adminApiSecret,
+  baseUrl,
+  connectGlobal,
+  registerCreatedProjectCleanup,
+} from "./e2e-env.ts";
+
+const CLOUDFLARE_API_TOKEN = process.env.CLOUDFLARE_API_TOKEN?.trim() ?? "";
+const MCP_SERVER_URL = "https://bindings.mcp.cloudflare.com/mcp";
+const SECRET_KEY = "CLOUDFLARE_API_TOKEN";
+const PLACEHOLDER = `Bearer getSecret({ key: "${SECRET_KEY}" })`;
+
+const createdProjectIds = registerCreatedProjectCleanup();
+
+test.skipIf(!CLOUDFLARE_API_TOKEN)(
+  "authenticated MCP: the credential is a project secret, substituted on egress, invisible everywhere else",
+  { timeout: 90_000 },
+  async () => {
+    using itx = connectGlobal();
+    const project = (await itx.projects.create({
+      slug: `itx-mcp-auth-${crypto.randomUUID().slice(0, 8)}`,
+    })) as { id: string };
+    createdProjectIds.push(project.id);
+    using projectItx = await itx.projects.get(project.id);
+
+    // (1) The secret enters the platform exactly once, through the project
+    // secrets surface — from here on only the KEY travels.
+    const upsert = await fetch(new URL(`/api/projects/${project.id}/secrets`, baseUrl()), {
+      body: JSON.stringify({ key: SECRET_KEY, material: CLOUDFLARE_API_TOKEN }),
+      headers: {
+        authorization: `Bearer ${adminApiSecret()}`,
+        "content-type": "application/json",
+      },
+      method: "PUT",
+    });
+    expect(upsert.status, await upsert.clone().text()).toBe(200);
+
+    // (2) The capability address carries the PLACEHOLDER, never the material.
+    await projectItx.provideCapability({
+      path: ["mcp", "cloudflare"],
+      capability: {
+        entrypoint: "McpClient",
+        props: {
+          headers: { authorization: PLACEHOLDER },
+          serverUrl: MCP_SERVER_URL,
+        },
+        type: "rpc",
+        worker: { type: "loopback" },
+      },
+      instructions: "Cloudflare's MCP server, authenticated via a project secret.",
+    });
+
+    // (3) listTools succeeds — which can only happen if the EgressPipe
+    // substituted the real token (the server 401s without it; see the curl
+    // probes in this file's header).
+    const handle = projectItx as never as Record<string, any>;
+    const listed = (await handle.mcp.cloudflare.listTools()) as { tools: { name: string }[] };
+    expect(Array.isArray(listed.tools)).toBe(true);
+    expect(listed.tools.length).toBeGreaterThan(0);
+
+    // (4) One read-only tool call asserting a REAL result. The docs-search
+    // tool is account-independent and stable; any non-empty answer proves the
+    // authenticated round trip end to end.
+    expect(listed.tools.map((tool) => tool.name)).toContain("search_cloudflare_documentation");
+    const result = await handle.mcp.cloudflare.search_cloudflare_documentation({
+      query: "durable objects",
+    });
+    const resultText = typeof result === "string" ? result : JSON.stringify(result);
+    expect(resultText.length).toBeGreaterThan(0);
+    expect(resultText.toLowerCase()).toContain("durable");
+    expect(resultText).not.toContain(CLOUDFLARE_API_TOKEN);
+
+    // (5) Negative control: the secret material exists ONLY in the egress
+    // pipe. describe() (the agent-facing view) and the journal (the durable
+    // record, address included) both carry the placeholder, never the token.
+    const description = await projectItx.describe();
+    const describedJson = JSON.stringify(description);
+    expect(describedJson).toContain("mcp.cloudflare");
+    expect(describedJson).not.toContain(CLOUDFLARE_API_TOKEN);
+
+    const journal = (await projectItx.streams.get("/itx").read()) as Array<{
+      payload: Record<string, unknown>;
+      type: string;
+    }>;
+    const provided = journal.find(
+      (event) =>
+        event.type === "events.iterate.com/itx/capability-provided" &&
+        Array.isArray(event.payload.path) &&
+        (event.payload.path as string[]).join(".") === "mcp.cloudflare",
+    );
+    expect(provided).toBeDefined();
+    const journaledAddress = provided!.payload.address as {
+      props: { headers: Record<string, string> };
+    };
+    expect(journaledAddress.props.headers.authorization).toBe(PLACEHOLDER);
+    expect(JSON.stringify(journal)).not.toContain(CLOUDFLARE_API_TOKEN);
+  },
+);

--- a/apps/os/src/itx/e2e/itx-openapi.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx-openapi.e2e.test.ts
@@ -1,0 +1,106 @@
+// OpenApiClient e2e: any OpenAPI API as an ergonomic capability, proven
+// against the public Swagger petstore demo. Three claims:
+//
+//   1. itx.petstore.findPetsByStatus({ status }) — flat operationId
+//      dispatch, ONE merged input object, through project egress
+//   2. describe() carries spec-derived `types` with zero callsite ceremony —
+//      the core's provide-time describeItx hook journaled them
+//   3. listOperations() enumerates the surface
+//
+// petstore3.swagger.io is a live demo server: assertions stay tolerant
+// (shapes, not data), and the provide is retried because the very first
+// describeItx probe races a cold project DO chain against the hook's
+// few-second best-effort deadline.
+
+import { expect, test } from "vitest";
+import { connectGlobal, registerCreatedProjectCleanup } from "./e2e-env.ts";
+
+const SPEC_URL = "https://petstore3.swagger.io/api/v3/openapi.json";
+
+const createdProjectIds = registerCreatedProjectCleanup();
+
+test(
+  "OpenApiClient: ergonomic calls + spec-derived types in describe() + listOperations",
+  { timeout: 120_000 },
+  async () => {
+    using itx = connectGlobal();
+    const project = (await itx.projects.create({
+      slug: `itx-openapi-${crypto.randomUUID().slice(0, 8)}`,
+    })) as { id: string };
+    createdProjectIds.push(project.id);
+    using projectItx = await itx.projects.get(project.id);
+
+    const provide = async () => {
+      await projectItx.provideCapability({
+        name: "petstore",
+        capability: {
+          entrypoint: "OpenApiClient",
+          props: { specUrl: SPEC_URL },
+          type: "rpc",
+          worker: { type: "loopback" },
+        },
+      });
+      const description = await projectItx.describe();
+      return description.capabilities.find((entry) => entry.name === "petstore") as
+        | { instructions?: string; types?: string }
+        | undefined;
+    };
+
+    // (2) first: the provide-time hook fills types + instructions from the
+    // spec. Re-provide until the probe beats its deadline (cold start: spec
+    // fetch + isolate spin-up can exceed it once; the spec memo makes the
+    // next attempt instant).
+    await expect
+      .poll(async () => (await provide())?.types ?? "", { interval: 2_000, timeout: 90_000 })
+      .toContain("declare function findPetsByStatus");
+    const entry = (await projectItx.describe()).capabilities.find(
+      (candidate) => candidate.name === "petstore",
+    ) as { instructions?: string; types?: string };
+    // A plausible response type, not just the name: findPetsByStatus takes
+    // the status enum and returns Pet[] — an object array carrying `name`.
+    expect(entry.types).toContain(
+      'declare function findPetsByStatus(input: { status: "available" | "pending" | "sold" })',
+    );
+    expect(entry.types).toMatch(/findPetsByStatus.*Promise<\{ .*name: string.* \}\[\]>;/);
+    // The instructions default names the API (the spec's info.title).
+    expect(entry.instructions ?? "").toContain("Swagger Petstore");
+
+    const handle = projectItx as never as Record<string, any>;
+
+    // (1) the ergonomic call, through egress, against the live demo.
+    const pets = (await handle.petstore.findPetsByStatus({ status: "available" })) as unknown[];
+    expect(Array.isArray(pets)).toBe(true);
+
+    // (3) listOperations is the reserved discovery door.
+    const operations = (await handle.petstore.listOperations()) as Array<{
+      method: string;
+      operationId: string;
+      path: string;
+    }>;
+    expect(operations.length).toBeGreaterThan(5);
+    expect(operations).toContainEqual(
+      expect.objectContaining({
+        method: "get",
+        operationId: "findPetsByStatus",
+        path: "/pet/findByStatus",
+      }),
+    );
+
+    // Path-param dispatch: getPetById({ petId }) resolves /pet/{petId}. The
+    // demo dataset shifts constantly, so accept the data OR the API's own
+    // 404 — what matters is that the operation routed and the path resolved.
+    if (pets.length > 0) {
+      const petId = (pets[0] as { id?: number }).id;
+      if (petId != null) {
+        const pet = await handle.petstore
+          .getPetById({ petId })
+          .catch((error: Error) => error.message);
+        if (typeof pet === "string") {
+          expect(pet).toMatch(/getPetById|returned 404/);
+        } else {
+          expect(pet).toMatchObject({ id: petId });
+        }
+      }
+    }
+  },
+);

--- a/apps/os/src/itx/e2e/itx-openapi.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx-openapi.e2e.test.ts
@@ -37,31 +37,22 @@ test(
     createdProjectIds.push(project.id);
     using projectItx = await itx.projects.get(project.id);
 
-    const provide = async () => {
-      await projectItx.provideCapability({
-        name: "fixture",
-        capability: {
-          entrypoint: "OpenApiClient",
-          props: {
-            headers: { authorization: `Bearer ${adminApiSecret()}` },
-            specUrl: new URL("/api/itx/openapi-fixture/openapi.json", baseUrl()).toString(),
-          },
-          type: "rpc",
-          worker: { type: "loopback" },
+    await projectItx.provideCapability({
+      name: "fixture",
+      capability: {
+        entrypoint: "OpenApiClient",
+        props: {
+          headers: { authorization: `Bearer ${adminApiSecret()}` },
+          specUrl: new URL("/api/itx/openapi-fixture/openapi.json", baseUrl()).toString(),
         },
-      });
-      const description = await projectItx.describe();
-      return description.capabilities.find((entry) => entry.name === "fixture") as
-        | { instructions?: string; types?: string }
-        | undefined;
-    };
+        type: "rpc",
+        worker: { type: "loopback" },
+      },
+    });
 
-    // (2) the provide-time hook fills types + instructions from the spec.
-    // Re-provide until the probe beats its deadline on a cold project chain;
-    // the spec memo makes the next attempt instant.
-    await expect
-      .poll(async () => (await provide())?.types ?? "", { interval: 2_000, timeout: 90_000 })
-      .toContain("declare function getPet");
+    // (2) ONE provide is enough: the loopback probe deadline absorbs the
+    // cold project chain (itx.ts SELF_DESCRIPTION_LOOPBACK_TIMEOUT_MS), so
+    // the journaled meta carries the spec-derived surface immediately.
     const entry = (await projectItx.describe()).capabilities.find(
       (candidate) => candidate.name === "fixture",
     ) as { instructions?: string; types?: string };

--- a/apps/os/src/itx/e2e/itx-openapi.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx-openapi.e2e.test.ts
@@ -1,26 +1,33 @@
 // OpenApiClient e2e: any OpenAPI API as an ergonomic capability, proven
-// against the public Swagger petstore demo. Three claims:
+// against the deployment's OWN deterministic fixture (debug-routes.ts) — a
+// spec document plus the API it describes, admin-gated, so nothing here
+// depends on a live third-party demo server. Claims:
 //
-//   1. itx.petstore.findPetsByStatus({ status }) — flat operationId
-//      dispatch, ONE merged input object, through project egress
+//   1. flat operationId dispatch — path + query + body merge into ONE input
+//      object, through project egress (the fixture only answers with the
+//      admin bearer from props.headers, so headers riding every call is
+//      proven implicitly)
 //   2. describe() carries spec-derived `types` with zero callsite ceremony —
 //      the core's provide-time describeItx hook journaled them
 //   3. listOperations() enumerates the surface
+//   4. refusals are self-describing: unknown input keys on a body-less
+//      operation list the valid params; nested paths point at operationIds
 //
-// petstore3.swagger.io is a live demo server: assertions stay tolerant
-// (shapes, not data), and the provide is retried because the very first
-// describeItx probe races a cold project DO chain against the hook's
-// few-second best-effort deadline.
+// One OPTIONAL live petstore smoke stays at the end, tolerant by design — a
+// flaky public demo server must never fail CI.
 
 import { expect, test } from "vitest";
-import { connectGlobal, registerCreatedProjectCleanup } from "./e2e-env.ts";
-
-const SPEC_URL = "https://petstore3.swagger.io/api/v3/openapi.json";
+import {
+  adminApiSecret,
+  baseUrl,
+  connectGlobal,
+  registerCreatedProjectCleanup,
+} from "./e2e-env.ts";
 
 const createdProjectIds = registerCreatedProjectCleanup();
 
 test(
-  "OpenApiClient: ergonomic calls + spec-derived types in describe() + listOperations",
+  "OpenApiClient: deterministic fixture — typed dispatch, derived types, instructive refusals",
   { timeout: 120_000 },
   async () => {
     using itx = connectGlobal();
@@ -32,75 +39,114 @@ test(
 
     const provide = async () => {
       await projectItx.provideCapability({
-        name: "petstore",
+        name: "fixture",
         capability: {
           entrypoint: "OpenApiClient",
-          props: { specUrl: SPEC_URL },
+          props: {
+            headers: { authorization: `Bearer ${adminApiSecret()}` },
+            specUrl: new URL("/api/itx/openapi-fixture/openapi.json", baseUrl()).toString(),
+          },
           type: "rpc",
           worker: { type: "loopback" },
         },
       });
       const description = await projectItx.describe();
-      return description.capabilities.find((entry) => entry.name === "petstore") as
+      return description.capabilities.find((entry) => entry.name === "fixture") as
         | { instructions?: string; types?: string }
         | undefined;
     };
 
-    // (2) first: the provide-time hook fills types + instructions from the
-    // spec. Re-provide until the probe beats its deadline (cold start: spec
-    // fetch + isolate spin-up can exceed it once; the spec memo makes the
-    // next attempt instant).
+    // (2) the provide-time hook fills types + instructions from the spec.
+    // Re-provide until the probe beats its deadline on a cold project chain;
+    // the spec memo makes the next attempt instant.
     await expect
       .poll(async () => (await provide())?.types ?? "", { interval: 2_000, timeout: 90_000 })
-      .toContain("declare function findPetsByStatus");
+      .toContain("declare function getPet");
     const entry = (await projectItx.describe()).capabilities.find(
-      (candidate) => candidate.name === "petstore",
+      (candidate) => candidate.name === "fixture",
     ) as { instructions?: string; types?: string };
-    // A plausible response type, not just the name: findPetsByStatus takes
-    // the status enum and returns Pet[] — an object array carrying `name`.
     expect(entry.types).toContain(
-      'declare function findPetsByStatus(input: { status: "available" | "pending" | "sold" })',
+      "declare function getPet(input: { petId: number }): " +
+        "Promise<{ id: number; name: string; tag?: string }>;",
     );
-    expect(entry.types).toMatch(/findPetsByStatus.*Promise<\{ .*name: string.* \}\[\]>;/);
-    // The instructions default names the API (the spec's info.title).
-    expect(entry.instructions ?? "").toContain("Swagger Petstore");
+    expect(entry.types).toContain(
+      'declare function listPets(input: { status: "available" | "pending" | "sold"; limit?: number })',
+    );
+    expect(entry.instructions ?? "").toContain("Itx OpenAPI Fixture");
 
     const handle = projectItx as never as Record<string, any>;
 
-    // (1) the ergonomic call, through egress, against the live demo.
-    const pets = (await handle.petstore.findPetsByStatus({ status: "available" })) as unknown[];
-    expect(Array.isArray(pets)).toBe(true);
+    // (1) path params, query params, and a JSON body — all deterministic.
+    await expect(handle.fixture.getPet({ petId: 7 })).resolves.toEqual({
+      id: 7,
+      name: "pet-7",
+    });
+    await expect(handle.fixture.listPets({ limit: 1, status: "available" })).resolves.toEqual([
+      { id: 1, name: "available-pet-1", tag: "available" },
+    ]);
+    await expect(handle.fixture.createPet({ name: "rex", tag: "dog" })).resolves.toEqual({
+      id: 99,
+      name: "rex",
+      tag: "dog",
+    });
 
     // (3) listOperations is the reserved discovery door.
-    const operations = (await handle.petstore.listOperations()) as Array<{
+    const operations = (await handle.fixture.listOperations()) as Array<{
       method: string;
       operationId: string;
       path: string;
     }>;
-    expect(operations.length).toBeGreaterThan(5);
-    expect(operations).toContainEqual(
-      expect.objectContaining({
-        method: "get",
-        operationId: "findPetsByStatus",
-        path: "/pet/findByStatus",
-      }),
+    expect(operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ method: "get", operationId: "getPet", path: "/pets/{petId}" }),
+        expect.objectContaining({ method: "get", operationId: "listPets", path: "/pets" }),
+        expect.objectContaining({ method: "post", operationId: "createPet", path: "/pets" }),
+      ]),
     );
 
-    // Path-param dispatch: getPetById({ petId }) resolves /pet/{petId}. The
-    // demo dataset shifts constantly, so accept the data OR the API's own
-    // 404 — what matters is that the operation routed and the path resolved.
-    if (pets.length > 0) {
-      const petId = (pets[0] as { id?: number }).id;
-      if (petId != null) {
-        const pet = await handle.petstore
-          .getPetById({ petId })
-          .catch((error: Error) => error.message);
-        if (typeof pet === "string") {
-          expect(pet).toMatch(/getPetById|returned 404/);
-        } else {
-          expect(pet).toMatchObject({ id: petId });
-        }
-      }
+    // (4) self-describing refusals.
+    await expect(handle.fixture.getPet({ bogus: true, petId: 7 })).rejects.toThrow(
+      /unknown input key "bogus" — valid params: petId/,
+    );
+    await expect(handle.fixture.pets.getPet({ petId: 1 })).rejects.toThrow(
+      /Call operations by operationId only/,
+    );
+  },
+);
+
+const PETSTORE_SPEC_URL = "https://petstore3.swagger.io/api/v3/openapi.json";
+
+test(
+  "optional live petstore smoke (tolerant: a public demo server never fails CI)",
+  {
+    timeout: 60_000,
+  },
+  async () => {
+    using itx = connectGlobal();
+    const project = (await itx.projects.create({
+      slug: `itx-petstore-${crypto.randomUUID().slice(0, 8)}`,
+    })) as { id: string };
+    createdProjectIds.push(project.id);
+    using projectItx = await itx.projects.get(project.id);
+
+    try {
+      await projectItx.provideCapability({
+        name: "petstore",
+        capability: {
+          entrypoint: "OpenApiClient",
+          props: { specUrl: PETSTORE_SPEC_URL },
+          type: "rpc",
+          worker: { type: "loopback" },
+        },
+      });
+      const handle = projectItx as never as Record<string, any>;
+      const pets = (await handle.petstore.findPetsByStatus({ status: "available" })) as unknown[];
+      expect(Array.isArray(pets)).toBe(true);
+    } catch (error) {
+      console.warn(
+        "live petstore smoke skipped (demo server unavailable):",
+        error instanceof Error ? error.message : String(error),
+      );
     }
   },
 );

--- a/apps/os/src/itx/e2e/itx-scripts.ts
+++ b/apps/os/src/itx/e2e/itx-scripts.ts
@@ -5,9 +5,9 @@
 
 /**
  * Worker-cap source: a durable fake-Slack capability. Source caps are
- * member-shaped — the dial wraps the loader entrypoint with
- * asPathCallable and replays the dotted path on its real members (nested
- * RpcTargets included), so the worker just exports the surface.
+ * member-shaped — the dial replays the dotted path on the loader
+ * entrypoint's real members (nested RpcTargets included), so the worker
+ * just exports the surface.
  */
 export function slackShapedCapabilitySource(input: { marker: string }) {
   return `

--- a/apps/os/src/itx/e2e/itx.browser.test.ts
+++ b/apps/os/src/itx/e2e/itx.browser.test.ts
@@ -95,32 +95,10 @@ describe.skipIf(!httpsTarget)("itx browser execution mode", () => {
     }, 120_000);
   }
 
-  it("provides a live browser-owned capability and calls it via the fallthrough (alert example)", async () => {
-    const projectId = await ensureBrowserMatrixProject();
-    using itx = await connectFromBrowser(projectId);
-
-    const example = ITX_EXAMPLES.find((candidate) => candidate.id === "provide-live-capability");
-    if (!example) throw new Error("Missing provide-live-capability example.");
-
-    const alertMessages: string[] = [];
-    const originalAlert = globalThis.alert;
-    globalThis.alert = (message?: unknown) => {
-      alertMessages.push(String(message));
-    };
-    try {
-      await expect(
-        evalBrowserReplSessionCode({
-          code: example.code,
-          env: {},
-          itx,
-          scope: createBrowserReplScope({ projectId }),
-        }),
-      ).resolves.toBe("alerted");
-    } finally {
-      globalThis.alert = originalAlert;
-    }
-    expect(alertMessages).toEqual(["The answer is 42"]);
-  }, 45_000);
+  // The browser-as-provider story (a tab registering live, browser-owned
+  // objects) is covered by the matrix run of "provide-plain-object": its
+  // closures live in this tab, so the asserted values can only have been
+  // computed by calls travelling back over the open session.
 
   it("provides a browser path-call cap with an SDK-shaped surface", async () => {
     const projectId = await ensureBrowserMatrixProject();

--- a/apps/os/src/itx/e2e/itx.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx.e2e.test.ts
@@ -182,11 +182,11 @@ test("the five-step capability flow: provide live, call, promote durable, call f
     expect(viaDurable).toMatchObject({ marker, method: "chat.postMessage" });
   }
 
-  // Own rows only — platform defaults (e.g. `ai` from platform:project)
-  // also appear in describe() with their code context as owner. `types`
-  // is lifted from meta like instructions.
-  const description = (await projectItx.describe()).capabilities as Array<{ owner: string }>;
-  expect(description.filter((entry) => entry.owner === project.id)).toMatchObject([
+  // Own rows carry NO provenance field — `from` marks inherited entries
+  // only (platform defaults like `ai` appear with from: "platform").
+  // `types` is lifted from meta like instructions.
+  const description = (await projectItx.describe()).capabilities as Array<{ from?: string }>;
+  expect(description.filter((entry) => entry.from === undefined)).toMatchObject([
     { connected: true, kind: "live", name: "slack" },
     { kind: "rpc", name: "slackDurable", types: slackDurableTypes },
   ]);
@@ -279,10 +279,10 @@ test("platform bindings are dialable capabilities (raw + wrapped)", async () => 
   await expect(handle.sneakyDo.anything()).rejects.toThrow(/not dialable/);
 
   // describe() reports the new kinds and lifts instructions (own rows only —
-  // inherited platform defaults carry their code context as owner). The
-  // unreachable-but-provided rows from (3) appear too: provide is structural.
-  const caps = (await projectItx.describe()).capabilities as Array<{ owner: string }>;
-  expect(caps.filter((entry) => entry.owner === project.id)).toMatchObject([
+  // they carry no `from`; inherited platform defaults read from: "platform").
+  // The unreachable-but-provided rows from (3) appear too: provide is structural.
+  const caps = (await projectItx.describe()).capabilities as Array<{ from?: string }>;
+  expect(caps.filter((entry) => entry.from === undefined)).toMatchObject([
     { instructions: "Workers AI. Use like the env.AI binding.", kind: "rpc", name: "ai" },
     { kind: "rpc", name: "aiWrapped" },
     { kind: "rpc", name: "db" },
@@ -441,25 +441,25 @@ test("url caps dial a remote Cap'n Web server over a WebSocket session", async (
   expect(described.capabilities.map((entry) => entry.name)).toContain("remoteItx");
 });
 
-test("platform defaults arrive from the platform:project code context, and own rows shadow them", async () => {
+test("platform defaults arrive from the platform code context, and own rows shadow them", async () => {
   using itx = connectGlobal();
   const project = (await itx.projects.create({ slug: `${PROJECT_SLUG}-def` })) as { id: string };
   createdProjectIds.push(project.id);
   using projectItx = await itx.projects.get(project.id);
 
   // A fresh project has zero rows of its own, but `ai` is already there —
-  // inherited from the code-defined parent context, with that context's
-  // name as owner (itx-next.md §8).
-  type Described = { capabilities: Array<{ name: string; owner: string }> };
+  // inherited from the code-defined parent context, labeled from: "platform"
+  // (the internal chain id never leaves the chain).
+  type Described = { capabilities: Array<{ from?: string; name: string }> };
   const before = (await projectItx.describe()) as Described;
   expect(before.capabilities.find((entry) => entry.name === "ai")).toMatchObject({
+    from: "platform",
     kind: "rpc",
-    owner: "platform:project",
   });
   // The whole migrated kernel arrives the same way (§8: cap #0 disappears).
   for (const name of ["repos", "streams", "workspace", "worker"]) {
     expect(before.capabilities.find((entry) => entry.name === name)).toMatchObject({
-      owner: "platform:project",
+      from: "platform",
     });
   }
 
@@ -468,7 +468,7 @@ test("platform defaults arrive from the platform:project code context, and own r
   await expect(projectItx.revokeCapability({ name: "ai" })).rejects.toThrow(/platform default/);
 
   // Shadowing is prototype semantics: a row of this context's own wins, and
-  // describe() shows exactly one `ai` with the project as owner.
+  // describe() shows exactly one `ai` — an OWN entry, so no `from` field.
   class ShadowAi extends RpcTarget {
     async call({ path }: { path: string[]; args: unknown[] }) {
       return { method: path.join("."), provider: "shadow" };
@@ -481,7 +481,7 @@ test("platform defaults arrive from the platform:project code context, and own r
   const after = (await projectItx.describe()) as Described;
   const aiCaps = after.capabilities.filter((entry) => entry.name === "ai");
   expect(aiCaps).toHaveLength(1);
-  expect(aiCaps[0]!.owner).toBe(project.id);
+  expect(aiCaps[0]!.from).toBeUndefined();
 
   const handle = projectItx as never as Record<string, any>;
   expect(await handle.ai.run("model", { prompt: "hi" })).toEqual({
@@ -497,10 +497,10 @@ test("fetch is a shadowable capability: a live provider intercepts project egres
   using projectItx = await itx.projects.get(project.id);
 
   // (1) Fresh project: `fetch` is a platform default, not kernel.
-  type Described = { capabilities: Array<{ name: string; owner: string }> };
+  type Described = { capabilities: Array<{ from?: string; name: string }> };
   const before = (await projectItx.describe()) as Described;
   expect(before.capabilities.find((entry) => entry.name === "fetch")).toMatchObject({
-    owner: "platform:project",
+    from: "platform",
   });
 
   // (2) A Node-side shadow provider: the whole intercept is ONE call method.
@@ -555,7 +555,7 @@ test("fetch is a shadowable capability: a live provider intercepts project egres
   await projectItx.revokeCapability({ name: "fetch" });
   const after = (await projectItx.describe()) as Described;
   expect(after.capabilities.find((entry) => entry.name === "fetch")).toMatchObject({
-    owner: "platform:project",
+    from: "platform",
   });
   await expect(projectItx.fetch("https://intercept-probe.invalid/x")).rejects.toThrow();
 

--- a/apps/os/src/itx/e2e/itx.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx.e2e.test.ts
@@ -183,7 +183,7 @@ test("the five-step capability flow: provide live, call, promote durable, call f
   }
 
   // Own rows carry NO provenance field — `from` marks inherited entries
-  // only (platform defaults like `ai` appear with from: "platform").
+  // only (defaults like `ai` appear with from: "defaults").
   // `types` is lifted from meta like instructions.
   const description = (await projectItx.describe()).capabilities as Array<{ from?: string }>;
   expect(description.filter((entry) => entry.from === undefined)).toMatchObject([
@@ -279,7 +279,7 @@ test("platform bindings are dialable capabilities (raw + wrapped)", async () => 
   await expect(handle.sneakyDo.anything()).rejects.toThrow(/not dialable/);
 
   // describe() reports the new kinds and lifts instructions (own rows only —
-  // they carry no `from`; inherited platform defaults read from: "platform").
+  // they carry no `from`; the inherited defaults read from: "defaults").
   // The unreachable-but-provided rows from (3) appear too: provide is structural.
   const caps = (await projectItx.describe()).capabilities as Array<{ from?: string }>;
   expect(caps.filter((entry) => entry.from === undefined)).toMatchObject([
@@ -441,31 +441,33 @@ test("url caps dial a remote Cap'n Web server over a WebSocket session", async (
   expect(described.capabilities.map((entry) => entry.name)).toContain("remoteItx");
 });
 
-test("platform defaults arrive from the platform code context, and own rows shadow them", async () => {
+test("the defaults arrive from the code-rooted chain end, and own rows shadow them", async () => {
   using itx = connectGlobal();
   const project = (await itx.projects.create({ slug: `${PROJECT_SLUG}-def` })) as { id: string };
   createdProjectIds.push(project.id);
   using projectItx = await itx.projects.get(project.id);
 
   // A fresh project has zero rows of its own, but `ai` is already there —
-  // inherited from the code-defined parent context, labeled from: "platform"
+  // inherited from the code-defined parent context, labeled from: "defaults"
   // (the internal chain id never leaves the chain).
   type Described = { capabilities: Array<{ from?: string; name: string }> };
   const before = (await projectItx.describe()) as Described;
   expect(before.capabilities.find((entry) => entry.name === "ai")).toMatchObject({
-    from: "platform",
+    from: "defaults",
     kind: "rpc",
   });
   // The whole migrated kernel arrives the same way (§8: cap #0 disappears).
   for (const name of ["repos", "streams", "workspace", "worker"]) {
     expect(before.capabilities.find((entry) => entry.name === name)).toMatchObject({
-      from: "platform",
+      from: "defaults",
     });
   }
 
   // Defaults cannot be revoked — succeeding would lie (the default keeps
   // serving). Shadowing is the override mechanism.
-  await expect(projectItx.revokeCapability({ name: "ai" })).rejects.toThrow(/platform default/);
+  await expect(projectItx.revokeCapability({ name: "ai" })).rejects.toThrow(
+    /inherited from the defaults/,
+  );
 
   // Shadowing is prototype semantics: a row of this context's own wins, and
   // describe() shows exactly one `ai` — an OWN entry, so no `from` field.
@@ -496,11 +498,11 @@ test("fetch is a shadowable capability: a live provider intercepts project egres
   createdProjectIds.push(project.id);
   using projectItx = await itx.projects.get(project.id);
 
-  // (1) Fresh project: `fetch` is a platform default, not kernel.
+  // (1) Fresh project: `fetch` is a default, not kernel.
   type Described = { capabilities: Array<{ from?: string; name: string }> };
   const before = (await projectItx.describe()) as Described;
   expect(before.capabilities.find((entry) => entry.name === "fetch")).toMatchObject({
-    from: "platform",
+    from: "defaults",
   });
 
   // (2) A Node-side shadow provider: the whole intercept is ONE call method.
@@ -555,7 +557,7 @@ test("fetch is a shadowable capability: a live provider intercepts project egres
   await projectItx.revokeCapability({ name: "fetch" });
   const after = (await projectItx.describe()) as Described;
   expect(after.capabilities.find((entry) => entry.name === "fetch")).toMatchObject({
-    from: "platform",
+    from: "defaults",
   });
   await expect(projectItx.fetch("https://intercept-probe.invalid/x")).rejects.toThrow();
 

--- a/apps/os/src/itx/entrypoint.ts
+++ b/apps/os/src/itx/entrypoint.ts
@@ -127,7 +127,11 @@ export class ProjectEgress extends WorkerEntrypoint<Env, ProjectEgressProps> {
       (this.ctx.props.contextAddress as CapabilityAddress | null | undefined) ??
       projectContextAddress(this.ctx.props.projectId);
     const node = dialContext(this.env, address);
-    return (await node.itx().invoke({ args: [request], path: ["fetch"] })) as Response;
+    // The implicit door's signal strip — same reason as ItxHandle.fetch (the
+    // explicit door): an AbortSignal cannot cross the RPC hop to the node.
+    return (await node
+      .itx()
+      .invoke({ args: [new Request(request, { signal: null })], path: ["fetch"] })) as Response;
   }
 }
 

--- a/apps/os/src/itx/entrypoint.ts
+++ b/apps/os/src/itx/entrypoint.ts
@@ -120,7 +120,7 @@ export class ProjectEgress extends WorkerEntrypoint<Env, ProjectEgressProps> {
   async fetch(request: Request): Promise<Response> {
     // Dispatch at the ORIGINATING context node, not the project: a child
     // context's `fetch` shadow must catch its isolates' bare fetch() too —
-    // the chain (child → project → platform defaults) is what resolves the
+    // the chain (child → project → the defaults) is what resolves the
     // cap. The address rides in props so the hot path never needs the
     // context catalog.
     const address =

--- a/apps/os/src/itx/examples.ts
+++ b/apps/os/src/itx/examples.ts
@@ -96,44 +96,16 @@ return { appended, count: events.length };
 `.trim(),
   },
   {
-    id: "provide-live-capability",
-    title: "Provide a live, browser-owned capability",
-    description:
-      "Registers a browser-owned object as a LIVE capability on the project (session-bound — it lives only while this REPL tab is connected), then calls it straight back through the itx fallthrough as itx.answer.run().",
-    context: "project",
-    runtimes: ["browser"],
-    code: `
-// A live capability is just an object you own. Its methods run HERE, in
-// the browser tab — the project calls back to you over the open session.
-const answer = {
-  async run() {
-    alert("The answer is 42");
-    return "alerted";
-  },
-};
-
-// provideCapability() is THE verb, and you pass your object DIRECTLY —
-// there is no client library between you and the capability table. Dotted
-// calls replay onto its members, back here where they live. A live cap
-// disappears when this tab disconnects; reconnect and provideCapability()
-// again to restore it.
-await itx.provideCapability({ name: "answer", capability: answer });
-
-// Unknown names on the handle fall through to the capability table, so the cap is
-// callable as if it were built in.
-return await itx.answer.run();
-`.trim(),
-  },
-  {
     id: "provide-plain-object",
     title: "Provide a plain object — it IS the capability",
     description:
-      "You pass your object; there is no client library between you and the capability table. A plain object of functions (nested at any depth) is a live capability: dotted calls replay onto its members, back in the provider's process. Session-bound, like every live cap.",
+      "You pass your object; there is no client library between you and the capability table. A plain object of functions (nested at any depth) is a live capability: dotted calls replay onto its members, back in the provider's process — your browser tab or Node session. Live caps are session-bound: gone when the session disconnects, back when you reconnect and provide again.",
     context: "project",
     runtimes: ["browser", "node", "cli"],
     code: `
 // No wrapper, no base class, no registration ceremony — the object you
-// already have is the capability.
+// already have is the capability. Its methods run HERE, in your process;
+// the project calls back to you over the open session.
 const answer = {
   ultimate: () => 42,
   deep: {
@@ -148,8 +120,10 @@ await itx.provideCapability({
   capability: answer,
 });
 
-// Methods are reachable at ANY depth through the fallthrough; each call
-// runs back here, where the object lives.
+// Unknown names on the handle fall through to the capability table, so the
+// cap is callable as if it were built in — at any depth; each call runs
+// back here, where the object lives. (A live cap disappears when this
+// session disconnects; reconnect and provideCapability() again to restore it.)
 return {
   ultimate: await itx.answer.ultimate(),
   deep: await itx.answer.deep.thought("life, the universe, everything"),
@@ -232,7 +206,7 @@ return {
     id: "repo-sourced-capability",
     title: "Code in your repo as a capability, built per commit",
     description:
-      "The project's own git repo is a capability source: commit a module, then provide a { type: 'repo' } address pointing at the file. The platform builds it per COMMIT (memoized), never per call — 'latest' tracks pushes; a pinned sha makes the journal entry fully determine behavior. The platform `worker` default is exactly this pattern.",
+      "The project's own git repo is a capability source: commit a module, then provide a { type: 'repo' } address pointing at the file. The platform builds it per COMMIT (memoized), never per call — 'latest' tracks pushes; a pinned sha makes the journal entry fully determine behavior. The `worker` default is exactly this pattern.",
     context: "project",
     runtimes: ALL_RUNTIMES,
     code: `
@@ -507,7 +481,7 @@ await child.provideCapability({
 
 // ...so the child sees its own, while the project still sees its own.
 // In the merged describe(), the child's entries carry no provenance field;
-// inherited ones say from: <context> ("platform" for the defaults).
+// inherited ones say from: <context> ("defaults" for the defaults).
 return {
   fromChild: await child.shared.whoami(),
   capabilities: (await child.describe()).capabilities, // merged chain, child entries first
@@ -546,7 +520,7 @@ return { traceHeaderSeen: echoed.headers["x-trace-id"] };
     id: "journal-is-the-record",
     title: "The journal IS the record: provide, revoke, read it back",
     description:
-      "A context's capability table is a fold of an ordinary event stream — its journal at /itx. provideCapability and revokeCapability are appends; read the stream back and watch the record happen. There is no hidden registry to drift from it.",
+      "A context's capability table is replayed from an ordinary event stream — its journal at /itx. provideCapability and revokeCapability are appends; read the stream back and watch the record happen. There is no hidden registry to drift from it.",
     context: "project",
     runtimes: ALL_RUNTIMES,
     code: `

--- a/apps/os/src/itx/examples.ts
+++ b/apps/os/src/itx/examples.ts
@@ -568,6 +568,36 @@ return { record }; // ["capability-provided", "capability-revoked"]
 `.trim(),
   },
   {
+    id: "mcp-authenticated",
+    title: "An authenticated MCP server via a project secret",
+    description:
+      "Connect a remote MCP server that needs an Authorization header — without the credential ever leaving the platform. The token lives as a PROJECT SECRET; the capability address carries only a getSecret(...) placeholder; substitution happens server-side on the egress path. This session, describe(), and the journal never see the material.",
+    context: "project",
+    runtimes: ALL_RUNTIMES,
+    code: `
+// Store the credential ONCE as a project secret (Settings → Secrets), e.g.
+// key "CLOUDFLARE_API_TOKEN". From here on, only the key travels.
+await itx.provideCapability({
+  path: ["mcp", "cloudflare"],
+  instructions: "Cloudflare's MCP server, authenticated via a project secret.",
+  capability: {
+    type: "rpc",
+    worker: { type: "loopback" },
+    entrypoint: "McpClient",
+    props: {
+      serverUrl: "https://bindings.mcp.cloudflare.com/mcp",
+      headers: { authorization: 'Bearer getSecret({ key: "CLOUDFLARE_API_TOKEN" })' },
+    },
+  },
+});
+
+// Every MCP request rides the project egress pipe, where the placeholder
+// becomes the real token — the connected agent/isolate never sees it.
+const { tools } = await itx.mcp.cloudflare.listTools();
+return tools.map((tool) => tool.name);
+`.trim(),
+  },
+  {
     id: "egress-with-secret-substitution",
     title: "Egress with server-side secret substitution",
     description:

--- a/apps/os/src/itx/examples.ts
+++ b/apps/os/src/itx/examples.ts
@@ -125,6 +125,38 @@ return await itx.answer.run();
 `.trim(),
   },
   {
+    id: "provide-plain-object",
+    title: "Provide a plain object — it IS the capability",
+    description:
+      "You pass your object; there is no client library between you and the capability table. A plain object of functions (nested at any depth) is a live capability: dotted calls replay onto its members, back in the provider's process. Session-bound, like every live cap.",
+    context: "project",
+    runtimes: ["browser", "node", "cli"],
+    code: `
+// No wrapper, no base class, no registration ceremony — the object you
+// already have is the capability.
+const answer = {
+  ultimate: () => 42,
+  deep: {
+    thought: async (question) => ({ answer: 42, question }),
+  },
+};
+
+await itx.provideCapability({
+  name: "answer",
+  instructions:
+    "The answer to everything: itx.answer.ultimate(), or itx.answer.deep.thought(question).",
+  capability: answer,
+});
+
+// Methods are reachable at ANY depth through the fallthrough; each call
+// runs back here, where the object lives.
+return {
+  ultimate: await itx.answer.ultimate(),
+  deep: await itx.answer.deep.thought("life, the universe, everything"),
+};
+`.trim(),
+  },
+  {
     id: "provide-path-call-sdk",
     title: "Provide a live SDK-shaped capability (path-call)",
     description:
@@ -194,6 +226,63 @@ return {
   greeting: await itx.greeter.hello({ name: "world" }),
   sum: await itx.greeter.add({ a: 2, b: 3 }),
 };
+`.trim(),
+  },
+  {
+    id: "repo-sourced-capability",
+    title: "Code in your repo as a capability, built per commit",
+    description:
+      "The project's own git repo is a capability source: commit a module, then provide a { type: 'repo' } address pointing at the file. The platform builds it per COMMIT (memoized), never per call — 'latest' tracks pushes; a pinned sha makes the journal entry fully determine behavior. The platform `worker` default is exactly this pattern.",
+    context: "project",
+    runtimes: ALL_RUNTIMES,
+    code: `
+// (1) Commit a capability module into the project's own repo (the shared
+// workspace speaks git; repo.token authenticates the push).
+const { project } = await itx.describe();
+const repo = await itx.repos.ensureProjectRepoInfo({ projectSlug: project.slug });
+const url = new URL(repo.remote);
+url.username = "x";
+url.password = repo.token.split("?")[0];
+const dir = "/repo-cap-demo";
+await itx.workspace.gitClone({ branch: repo.defaultBranch, depth: 1, dir, url: url.toString() });
+await itx.workspace.writeFile(dir + "/caps/greeter.js", \`
+import { WorkerEntrypoint } from "cloudflare:workers";
+export class Greeter extends WorkerEntrypoint {
+  hello({ name }) { return "hello from the repo, " + name; }
+}
+\`);
+await itx.workspace.gitAdd({ dir, filepath: "caps/greeter.js" });
+await itx.workspace.gitCommit({
+  author: { email: "examples@iterate.com", name: "itx example" },
+  dir,
+  message: "add greeter capability",
+});
+await itx.workspace.gitPush({ dir, ref: repo.defaultBranch, remote: "origin" });
+
+// (2) The address points at the FILE; "latest" tracks pushes. (A fresh
+// push can take ~10s to be picked up by the "latest" probe.)
+await itx.provideCapability({
+  name: "repoGreeter",
+  instructions:
+    "Greeter built from caps/greeter.js in the project repo: itx.repoGreeter.hello({ name }).",
+  capability: {
+    type: "rpc",
+    worker: {
+      type: "source",
+      source: {
+        type: "repo",
+        repo: "project",
+        commit: "latest",
+        path: "caps/greeter.js",
+        entrypoint: "Greeter",
+        bundle: {},
+      },
+    },
+  },
+});
+
+// (3) Call it like any other capability.
+return await itx.repoGreeter.hello({ name: "world" });
 `.trim(),
   },
   {
@@ -396,34 +485,86 @@ return { current: await itx.counter.current() };   // 2, and it persists
     id: "extend-child-context",
     title: "Extend the context with its own caps",
     description:
-      "itx.extend() makes a cheap, disposable child context under the project — an agent session or scratchpad. Its caps SHADOW the parent's; names it doesn't provide delegate up the chain. describe() shows the merged view with provenance.",
+      "itx.extend() makes a cheap, disposable child context under the project — an agent session or scratchpad. Its caps SHADOW the parent's; names it doesn't provide delegate up the chain. describe() shows the merged view: own entries plain, inherited ones labeled from: <context>.",
     context: "project",
     runtimes: ["browser", "node", "cli"],
     code: `
-// A cap on the project — visible to every child through the chain.
+// A cap on the project — visible to every child through the chain. A plain
+// object is all a live capability takes.
 await itx.provideCapability({
   name: "shared",
-  capability: new (class extends RpcTarget {
-    async call({ path }) { return { from: "project", method: path.join(".") }; }
-  })(),
+  capability: { whoami: () => "project" },
 });
 
 // Extend a child. It's a full itx handle on a new itx_… context.
 const child = await itx.extend({ name: "repl-scratch" });
 
-// The child can shadow 'shared' with its own definition...
+// The child can shadow 'shared' with its own object...
 await child.provideCapability({
   name: "shared",
-  capability: new (class extends RpcTarget {
-    async call({ path }) { return { from: "child", method: path.join(".") }; }
-  })(),
+  capability: { whoami: () => "child" },
 });
 
 // ...so the child sees its own, while the project still sees its own.
+// In the merged describe(), the child's entries carry no provenance field;
+// inherited ones say from: <context> ("platform" for the defaults).
 return {
-  fromChild: await child.shared.ping(),
+  fromChild: await child.shared.whoami(),
   capabilities: (await child.describe()).capabilities, // merged chain, child entries first
 };
+`.trim(),
+  },
+  {
+    id: "fetch-middleware",
+    title: "Middleware: shadow fetch, delegate via itx.super",
+    description:
+      "The middleware story in five lines: shadow `fetch` on an extended child with a plain function that stamps a header, then delegates to the parent chain's unshadowed pipe via itx.super.fetch. Bare fetch() inside the child's isolates flows through the same shadow; the parent is untouched.",
+    context: "project",
+    runtimes: ["browser", "node", "cli"],
+    code: `
+const session = await itx.extend({ name: "traced" });
+
+// The shadow is a PLAIN FUNCTION; itx.super is "call next()" — the parent
+// chain, where fetch is still the real egress pipe.
+await session.provideCapability({
+  name: "fetch",
+  instructions: "Project egress with an x-trace-id header stamped on every request.",
+  capability: async (request) => {
+    const traced = new Request(request.url ?? String(request), request);
+    traced.headers.set("x-trace-id", "itx-example-trace");
+    return await session.super.fetch(traced);
+  },
+});
+
+// Every egress on the session now carries the header. Revoke the shadow
+// and the real pipe resurfaces — middleware is just shadowing plus super.
+const echoed = await (await session.fetch("https://postman-echo.com/get")).json();
+return { traceHeaderSeen: echoed.headers["x-trace-id"] };
+`.trim(),
+  },
+  {
+    id: "journal-is-the-record",
+    title: "The journal IS the record: provide, revoke, read it back",
+    description:
+      "A context's capability table is a fold of an ordinary event stream — its journal at /itx. provideCapability and revokeCapability are appends; read the stream back and watch the record happen. There is no hidden registry to drift from it.",
+    context: "project",
+    runtimes: ALL_RUNTIMES,
+    code: `
+// Use a unique name so the journal slice below is unambiguous.
+const name = vars.capName ?? "ephemeral";
+
+await itx.provideCapability({
+  name,
+  capability: { type: "rpc", worker: { type: "binding", binding: "AI" } },
+});
+await itx.revokeCapability({ name });
+
+// The context's journal is an ordinary stream — same read API as anything.
+const journal = await itx.streams.get("/itx").read();
+const record = journal
+  .filter((e) => Array.isArray(e.payload?.path) && e.payload.path.join(".") === name)
+  .map((e) => e.type.split("/").pop());
+return { record }; // ["capability-provided", "capability-revoked"]
 `.trim(),
   },
   {

--- a/apps/os/src/itx/examples.ts
+++ b/apps/os/src/itx/examples.ts
@@ -112,12 +112,12 @@ const answer = {
   },
 };
 
-// provideCapability() is THE verb: a live stub is just another capability.
-// asPathCallable() makes a plain object-of-methods speak the one calling
-// convention (call({ path, args }) replayed back here on your object). A
-// live cap disappears when this tab disconnects; reconnect and
-// provideCapability() again to restore it.
-await itx.provideCapability({ name: "answer", capability: asPathCallable(answer) });
+// provideCapability() is THE verb, and you pass your object DIRECTLY —
+// there is no client library between you and the capability table. Dotted
+// calls replay onto its members, back here where they live. A live cap
+// disappears when this tab disconnects; reconnect and provideCapability()
+// again to restore it.
+await itx.provideCapability({ name: "answer", capability: answer });
 
 // Unknown names on the handle fall through to the capability table, so the cap is
 // callable as if it were built in.

--- a/apps/os/src/itx/examples.ts
+++ b/apps/os/src/itx/examples.ts
@@ -568,6 +568,33 @@ return { record }; // ["capability-provided", "capability-revoked"]
 `.trim(),
   },
   {
+    id: "mcp-client",
+    title: "Connect a public MCP server",
+    description:
+      "Any remote MCP server (streamable HTTP) becomes a capability via the first-party McpClient: listTools() discovers the surface, and every tool is a dotted call. Cloudflare's docs server is public — no credentials needed. All transport HTTP rides the project egress pipe.",
+    context: "project",
+    runtimes: ALL_RUNTIMES,
+    code: `
+await itx.provideCapability({
+  name: "cfdocs",
+  instructions: "Cloudflare's documentation MCP server. Call listTools() first.",
+  capability: {
+    type: "rpc",
+    worker: { type: "loopback" },
+    entrypoint: "McpClient",
+    props: { serverUrl: "https://docs.mcp.cloudflare.com/mcp" },
+  },
+});
+
+// Tools are dotted calls; listTools() is the discovery door.
+const { tools } = await itx.cfdocs.listTools();
+const answer = await itx.cfdocs.search_cloudflare_documentation({
+  query: "durable objects",
+});
+return { tools: tools.map((tool) => tool.name), snippet: String(answer).slice(0, 200) };
+`.trim(),
+  },
+  {
     id: "mcp-authenticated",
     title: "An authenticated MCP server via a project secret",
     description:
@@ -645,6 +672,28 @@ const response = await itx.fetch("https://postman-echo.com/get", {
 });
 const body = await response.json();
 return { status: response.status, sawSubstitutedHeader: body.headers };
+`.trim(),
+  },
+  {
+    id: "secrets-and-egress",
+    title: "Store a secret, then fetch with it",
+    description:
+      "The full credential lifecycle in one script: itx.secrets.setSecret() stores material in the project's secret store, and from then on a getSecret(...) placeholder in any egress header becomes the real value server-side — the script itself never round-trips the material again. This is how authenticated MCP/OpenAPI capability addresses stay credential-free.",
+    context: "project",
+    runtimes: ALL_RUNTIMES,
+    code: `
+// (1) Store the credential once. listSecrets() shows redacted summaries.
+await itx.secrets.setSecret({ key: "demo.api_key", material: "demo-" + crypto.randomUUID() });
+
+// (2) Use it by KEY: the placeholder substitutes inside the egress pipe.
+const response = await itx.fetch("https://postman-echo.com/get", {
+  headers: { "x-api-key": 'getSecret({ key: "demo.api_key" })' },
+});
+const echoed = await response.json();
+
+// (3) Clean up. The echo saw the real material; this script only saw the key.
+await itx.secrets.deleteSecret({ key: "demo.api_key" });
+return { status: response.status, echoedKeyHeader: echoed.headers["x-api-key"] };
 `.trim(),
   },
   {

--- a/apps/os/src/itx/examples.ts
+++ b/apps/os/src/itx/examples.ts
@@ -598,6 +598,38 @@ return tools.map((tool) => tool.name);
 `.trim(),
   },
   {
+    id: "openapi-client",
+    title: "Any OpenAPI API as an ergonomic capability",
+    description:
+      "Point OpenApiClient at an OpenAPI 3.x spec and every operation becomes a dotted call: itx.petstore.findPetsByStatus({ status }). One input object merges path params, query params, and body. The provider self-describes at provide time — describe() carries TypeScript declarations derived from the spec, with zero callsite ceremony. Auth headers take getSecret(...) placeholders, substituted on egress like everything else.",
+    context: "project",
+    runtimes: ALL_RUNTIMES,
+    code: `
+await itx.provideCapability({
+  name: "petstore",
+  capability: {
+    type: "rpc",
+    worker: { type: "loopback" },
+    entrypoint: "OpenApiClient",
+    props: {
+      specUrl: "https://petstore3.swagger.io/api/v3/openapi.json",
+      // For authenticated APIs, add headers with a secret placeholder:
+      // headers: { authorization: 'Bearer getSecret({ key: "API_TOKEN" })' },
+    },
+  },
+});
+
+// Flat operationIds, one merged input object, through project egress.
+const pets = await itx.petstore.findPetsByStatus({ status: "available" });
+
+// describe() now carries spec-derived TypeScript — the provider answered
+// the platform's provide-time describeItx probe, no callsite ceremony.
+const { capabilities } = await itx.describe();
+const entry = capabilities.find((cap) => cap.name === "petstore");
+return { count: pets.length, types: entry.types.split("\\n").slice(0, 3) };
+`.trim(),
+  },
+  {
     id: "egress-with-secret-substitution",
     title: "Egress with server-side secret substitution",
     description:

--- a/apps/os/src/itx/handle.ts
+++ b/apps/os/src/itx/handle.ts
@@ -146,10 +146,10 @@ export class ItxHandle extends RpcTarget {
   async provideCapability(input: {
     name?: string;
     path?: string[];
-    /** The capability (types.ts): a serializable rpc/url address, a bare
-     * function (auto-wrapped: empty remainder calls it, deeper errors), or
-     * anything live — a stub implementing call({ path, args }) itself, or a
-     * plain object-of-methods wrapped client-side with asPathCallable. */
+    /** The capability (types.ts): a serializable rpc/url address, or
+     * anything live — a plain object of methods (dispatch replays the dotted
+     * path onto its members, no wrapper), a bare function (calling the cap
+     * calls it), or a target implementing call({ path, args }) itself. */
     capability: CapabilityTarget;
     /** A sentence for the human/agent who finds this cap (the
      * meta.instructions convention field, lifted by describe()). */
@@ -507,8 +507,10 @@ export class CapabilityProvision extends RpcTarget implements CapabilityProvisio
 
 /**
  * Normalize a live capability before it crosses to the context node. Bare
- * functions auto-wrap with asPathCallable semantics — an empty remainder
- * calls the function, a deeper remainder errors:
+ * functions auto-wrap — an empty remainder calls the function, a deeper
+ * remainder errors. Plain objects pass through UNTOUCHED: they cross every
+ * transport by value (with their functions as stubs), so the core's dispatch
+ * can replay paths onto their members directly — no wrapper exists.
  *
  * - A LOCAL function (prototype Function/AsyncFunction.prototype — never
  *   true of an RPC stub) wraps directly.

--- a/apps/os/src/itx/handle.ts
+++ b/apps/os/src/itx/handle.ts
@@ -19,14 +19,12 @@
 //     here knows about Slack.
 
 import { RpcTarget } from "cloudflare:workers";
-import { RpcStub } from "capnweb";
 import { createD1Client } from "sqlfu";
 import { PathProxy } from "./path-proxy.ts";
 import { ItxError } from "./errors.ts";
 import { ItxStreams } from "./capabilities/streams.ts";
 import {
   isCapabilityAddress,
-  isLocalBareFunction,
   replayPathCall,
   RESERVED_CAPABILITY_NAMES,
   type CapabilityAddress,
@@ -35,6 +33,7 @@ import {
   type ItxStub,
   type PathCall,
 } from "./itx.ts";
+import { resolveLiveCapability } from "./live-target.ts";
 import {
   dialContext,
   extendContext,
@@ -502,82 +501,6 @@ export class CapabilityProvision extends RpcTarget implements CapabilityProvisio
 
   [Symbol.dispose](): void {
     if (this.#live) void this.#revoke().catch(() => {});
-  }
-}
-
-/**
- * Normalize a live capability before it crosses to the context node. Bare
- * functions auto-wrap. Plain objects pass through UNTOUCHED: they cross
- * every transport by value (with their functions as stubs), the core
- * dup-retains those member stubs at registration (itx.ts), and dispatch
- * replays paths onto them directly — no wrapper exists.
- *
- * - A LOCAL function (prototype Function/AsyncFunction.prototype — never
- *   true of an RPC stub) wraps directly.
- * - A capnweb stub of a REMOTE function is indistinguishable from an object
- *   stub by type (every capnweb stub is a callable proxy), so it is probed:
- *   `await stub.call` is a pure property pull (no user code runs) that
- *   resolves `undefined` only when the remote target is a bare function —
- *   a call-implementing provider yields its method. Probe failures fall
- *   back to the historical call-convention dispatch.
- */
-async function resolveLiveCapability(capability: CapabilityTarget): Promise<CapabilityTarget> {
-  if (isCapabilityAddress(capability)) return capability;
-  if (isLocalBareFunction(capability)) {
-    return new BareFunctionCapability(capability) as unknown as CapabilityTarget;
-  }
-  if (typeof capability === "function" && (capability as object) instanceof RpcStub) {
-    const callMember = await Promise.resolve(
-      (capability as unknown as { call: unknown }).call,
-    ).then(
-      (value) => value,
-      () => "unprobeable" as const,
-    );
-    if (callMember === undefined) {
-      return new BareFunctionCapability(
-        capability as unknown as (...args: never[]) => unknown,
-      ) as unknown as CapabilityTarget;
-    }
-    (callMember as Partial<Disposable> | null | undefined)?.[Symbol.dispose]?.();
-  }
-  return capability;
-}
-
-/**
- * The wrap for a bare-function capability: speaks the one calling convention
- * (`call({ path, args })`) by invoking the function for an empty remainder
- * and refusing anything deeper. Extends RpcTarget so it crosses the
- * worker → context-node hop as a stub while the function (local or a capnweb
- * stub of the provider's process) stays callable right here.
- */
-class BareFunctionCapability extends RpcTarget {
-  readonly #fn: (...args: never[]) => unknown;
-
-  constructor(fn: (...args: never[]) => unknown) {
-    super();
-    // Retain a dup when the function is itself a session stub: RPC disposes
-    // argument stubs when the provide call returns.
-    const dup = (fn as { dup?: () => (...args: never[]) => unknown }).dup;
-    this.#fn = typeof dup === "function" ? dup.call(fn) : fn;
-  }
-
-  call(input: PathCall): unknown {
-    if (input.path.length > 0) {
-      throw new Error(
-        `This capability is a bare function — it has no member "${input.path.join(".")}"; call it directly.`,
-      );
-    }
-    return this.#fn(...(input.args as never[]));
-  }
-
-  onRpcBroken(callback: (error: unknown) => void): void {
-    (this.#fn as { onRpcBroken?: (callback: (error: unknown) => void) => void }).onRpcBroken?.(
-      callback,
-    );
-  }
-
-  [Symbol.dispose](): void {
-    (this.#fn as Partial<Disposable>)[Symbol.dispose]?.();
   }
 }
 

--- a/apps/os/src/itx/handle.ts
+++ b/apps/os/src/itx/handle.ts
@@ -12,7 +12,7 @@
 //   - typed built-ins (the trust kernel): the verbs provideCapability,
 //     revokeCapability, describe, extend, invoke — plus super, streams,
 //     project, projects, and `fetch`, which is sugar dispatching through the
-//     core's `fetch` capability (a shadowable platform default)
+//     core's `fetch` capability (a shadowable default)
 //   - a fallthrough Proxy: any unknown name becomes a PathProxy whose
 //     terminal call dispatches to the context node's core (node.itx()).
 //     itx.slack works because someone provided "slack", not because anything
@@ -346,8 +346,8 @@ export class ItxHandle extends RpcTarget {
    * `await itx.super` also works and yields the parent handle's surface.
    *
    * An extension's parent comes from its birth certificate; the project
-   * context's parent IS the platform context (the chain's code root); the
-   * platform context is the end of the line.
+   * context's parent IS the defaults (the chain's code root); the
+   * defaults are the end of the line.
    */
   get super(): ItxHandle {
     const parentHandle = async (): Promise<ItxHandle> => {
@@ -373,11 +373,11 @@ export class ItxHandle extends RpcTarget {
       if (this.#runtime.contextId === PLATFORM_PROJECT_CONTEXT_ID) {
         throw new ItxError({
           code: "BAD_REQUEST",
-          message: "The platform context is the chain root — it has no parent.",
+          message: "The defaults are the chain root — they have no parent.",
         });
       }
-      // The project context's parent IS the platform defaults link: a
-      // read-only code context, dialed in-process.
+      // The project context's parent IS the defaults link: a read-only code
+      // context, dialed in-process.
       return new ItxHandle({
         ...this.#runtime,
         capabilityPath: undefined,
@@ -436,7 +436,7 @@ export class ItxHandle extends RpcTarget {
    * project contexts, an ItxDurableObject for extended children — both
    * expose it via itx() (a method, so `node.itx().invoke(...)` pipelines in
    * ONE round trip; workerd does not pipeline calls through property
-   * accesses) — or the in-process platform context at the chain root. The
+   * accesses) — or the in-process defaults context at the chain root. The
    * runtime carries the ADDRESS; global handles get the narrow-first error.
    */
   #itx(): ItxStub {

--- a/apps/os/src/itx/handle.ts
+++ b/apps/os/src/itx/handle.ts
@@ -507,10 +507,10 @@ export class CapabilityProvision extends RpcTarget implements CapabilityProvisio
 
 /**
  * Normalize a live capability before it crosses to the context node. Bare
- * functions auto-wrap — an empty remainder calls the function, a deeper
- * remainder errors. Plain objects pass through UNTOUCHED: they cross every
- * transport by value (with their functions as stubs), so the core's dispatch
- * can replay paths onto their members directly — no wrapper exists.
+ * functions auto-wrap. Plain objects pass through UNTOUCHED: they cross
+ * every transport by value (with their functions as stubs), the core
+ * dup-retains those member stubs at registration (itx.ts), and dispatch
+ * replays paths onto them directly — no wrapper exists.
  *
  * - A LOCAL function (prototype Function/AsyncFunction.prototype — never
  *   true of an RPC stub) wraps directly.

--- a/apps/os/src/itx/handle.ts
+++ b/apps/os/src/itx/handle.ts
@@ -269,7 +269,13 @@ export class ItxHandle extends RpcTarget {
    * Isolates the platform loads get this same dispatch as global fetch.
    */
   async fetch(input: Request | string, init?: RequestInit): Promise<Response> {
-    const request = typeof input === "string" ? new Request(input, init) : input;
+    // The explicit egress door — and where any AbortSignal is detached: a
+    // signal cannot cross the RPC hop to the context node ("AbortSignal
+    // serialization is not enabled"), so the door strips it once for every
+    // caller (the MCP SDK attaches one to each request, for example).
+    // Per-request aborts don't survive egress; the pipe's bounds do.
+    const built = typeof input === "string" ? new Request(input, init) : input;
+    const request = new Request(built, { signal: null });
     return (await this.#itx().invoke({ args: [request], path: ["fetch"] })) as Response;
   }
 

--- a/apps/os/src/itx/itx-durable-object.ts
+++ b/apps/os/src/itx/itx-durable-object.ts
@@ -11,7 +11,8 @@
 // Capability resolution walks the chain child → parent (→ … → the
 // platform context): the core delegates a miss per call through the parent
 // address recorded in the birth certificate. Shadowing is allowed and
-// VISIBLE: describe() returns the merged chain with each entry's owner.
+// VISIBLE: describe() returns the merged chain — inherited entries carry
+// `from`, own entries carry no provenance field.
 
 import { DurableObject } from "cloudflare:workers";
 import { Itx, type CapabilityAddress, type ItxStub } from "./itx.ts";
@@ -75,15 +76,18 @@ export class ItxDurableObject extends DurableObject<Env> {
     const journal = this.#journal();
     const contextId = contextIdOfJournalPath(journal.path);
     const selfAddress = childContextAddress(journal);
-    const parentNode = (): ItxStub | null => {
+    const parentNode = (): { from: string; stub: ItxStub } | null => {
       const parent = this.#itx?.state.context?.parent;
       if (!parent) return null;
       const node = () => dialContext(this.env, parent.address as CapabilityAddress);
       return {
-        describe: () => node().itx().describe(),
-        invoke: (input) => node().itx().invoke(input),
-        provideCapability: (input) => node().itx().provideCapability(input),
-        revokeCapability: (input) => node().itx().revokeCapability(input),
+        from: parent.id,
+        stub: {
+          describe: () => node().itx().describe(),
+          invoke: (input) => node().itx().invoke(input),
+          provideCapability: (input) => node().itx().provideCapability(input),
+          revokeCapability: (input) => node().itx().revokeCapability(input),
+        },
       };
     };
     // Legacy pre-journal residue (the itx_capabilities/itx_context SQLite

--- a/apps/os/src/itx/itx-durable-object.ts
+++ b/apps/os/src/itx/itx-durable-object.ts
@@ -9,7 +9,7 @@
 // checkpoint — a disposable cache of the fold.
 //
 // Capability resolution walks the chain child → parent (→ … → the
-// platform context): the core delegates a miss per call through the parent
+// defaults): the core delegates a miss per call through the parent
 // address recorded in the birth certificate. Shadowing is allowed and
 // VISIBLE: describe() returns the merged chain — inherited entries carry
 // `from`, own entries carry no provenance field.

--- a/apps/os/src/itx/itx.test.ts
+++ b/apps/os/src/itx/itx.test.ts
@@ -114,8 +114,14 @@ describe("provide + longest-prefix invoke", () => {
     const result = await itx.invoke({ args: [{ text: "hi" }], path: ["slack", "chat", "post"] });
 
     expect(result).toMatchObject({ path: ["chat", "post"] });
-    expect(dialed).toHaveLength(1);
+    // Two dials: the provide-time describeItx probe (self-description hook;
+    // a typeless rpc provide always asks once), then the invoke itself.
+    expect(dialed).toHaveLength(2);
     expect(dialed[0]).toMatchObject({
+      call: { args: [], path: ["describeItx"] },
+      disposed: true,
+    });
+    expect(dialed.at(-1)).toMatchObject({
       address: AI_ADDRESS,
       attribution: { capabilityPath: "slack", origin: { address: SELF_ADDRESS, id: "prj_1" } },
       call: { args: [{ text: "hi" }], path: ["chat", "post"] },
@@ -158,7 +164,95 @@ describe("provide + longest-prefix invoke", () => {
       id: "itx_child",
     };
     await itx.invoke({ args: [], origin, path: ["workspace", "readFile"] });
-    expect(dialed[0]!.attribution).toEqual({ capabilityPath: "workspace", origin });
+    expect(dialed.at(-1)!.attribution).toEqual({ capabilityPath: "workspace", origin });
+  });
+});
+
+describe("provide-time self-description (describeItx)", () => {
+  /** A dial whose target answers the probe — and records every call. */
+  function selfDescribingDial(answer: unknown) {
+    const calls: Array<{ path: string[]; args: unknown[] }> = [];
+    const dial: CapabilityDial = () => ({
+      call: async (input: { path: string[]; args: unknown[] }) => {
+        calls.push(input);
+        if (input.path.join(".") === "describeItx") return answer;
+        return "called";
+      },
+    });
+    return { calls, dial };
+  }
+
+  test("a typeless rpc provide journals the target's own types + instructions", async () => {
+    const { calls, dial } = selfDescribingDial({
+      instructions: "Petstore. listOperations() first.",
+      types: "declare function findPetsByStatus(input: { status: string }): Promise<unknown>;",
+    });
+    const { events, journal } = fakeJournal();
+    const itx = makeItx({ dial, journal });
+
+    await itx.provideCapability({ capability: LOOPBACK_ADDRESS, name: "petstore" });
+    expect(calls).toEqual([{ args: [], path: ["describeItx"] }]);
+    // The enrichment is IN the journaled event — the record, not a patch.
+    expect(events[0]!.payload).toMatchObject({
+      meta: {
+        instructions: "Petstore. listOperations() first.",
+        types: expect.stringContaining("declare function findPetsByStatus"),
+      },
+    });
+    expect(await itx.describe()).toMatchObject([
+      { instructions: "Petstore. listOperations() first.", name: "petstore" },
+    ]);
+  });
+
+  test("explicit caller values win; caller-supplied types skip the probe entirely", async () => {
+    const { calls, dial } = selfDescribingDial({ instructions: "theirs", types: "their types" });
+    const itx = makeItx({ dial });
+
+    await itx.provideCapability({
+      capability: LOOPBACK_ADDRESS,
+      instructions: "mine",
+      name: "a",
+    });
+    expect(await itx.describe()).toMatchObject([
+      { instructions: "mine", name: "a", types: "their types" },
+    ]);
+
+    calls.length = 0;
+    await itx.provideCapability({ capability: LOOPBACK_ADDRESS, name: "b", types: "mine" });
+    expect(calls).toEqual([]); // no probe — nothing to fill
+    expect(await itx.describe()).toMatchObject([{ name: "a" }, { name: "b", types: "mine" }]);
+  });
+
+  test("a throwing or garbage-answering target never blocks or fails the provide", async () => {
+    const throwingDial: CapabilityDial = () => ({
+      call: async () => {
+        throw new Error("no such method");
+      },
+    });
+    const itx = makeItx({ dial: throwingDial });
+    await itx.provideCapability({ capability: AI_ADDRESS, name: "ai" });
+    expect(await itx.describe()).toMatchObject([{ name: "ai", types: undefined }]);
+
+    const garbage = makeItx({ dial: selfDescribingDial(42).dial });
+    await garbage.provideCapability({ capability: AI_ADDRESS, name: "ai" });
+    expect(await garbage.describe()).toMatchObject([{ name: "ai", types: undefined }]);
+  });
+
+  test("live provides are never probed", async () => {
+    const dial = vi.fn();
+    const itx = makeItx({ dial: dial as unknown as CapabilityDial });
+    await itx.provideCapability({ capability: { run: async () => 1 }, name: "live" });
+    expect(dial).not.toHaveBeenCalled();
+  });
+
+  test("describeItx is reserved: not as a capability path, not as a dispatch segment", async () => {
+    const itx = makeItx();
+    await expect(
+      itx.provideCapability({ capability: AI_ADDRESS, name: "describeItx" }),
+    ).rejects.toThrow(/reserved/);
+    await expect(
+      itx.provideCapability({ capability: AI_ADDRESS, path: ["x", "describeItx"] }),
+    ).rejects.toThrow(/reserved/);
   });
 });
 

--- a/apps/os/src/itx/itx.test.ts
+++ b/apps/os/src/itx/itx.test.ts
@@ -6,6 +6,7 @@
 // folds to the same state).
 
 import { describe, expect, test, vi } from "vitest";
+import { newMessagePortRpcSession, RpcTarget } from "capnweb";
 import type { StreamEvent } from "@iterate-com/streams/shared/event";
 import {
   ITX_EVENT_TYPES,
@@ -15,6 +16,7 @@ import {
   type CapabilityDial,
   type ItxOrigin,
   type ItxStub,
+  type ProvideCapabilityInput,
 } from "./itx.ts";
 
 const AI_ADDRESS: CapabilityAddress = {
@@ -544,6 +546,82 @@ describe("plain objects ARE capabilities", () => {
       /did not resolve to a function/,
     );
     expect(await itx.describe()).toMatchObject([{ connected: true, kind: "live", name: "answer" }]);
+  });
+
+  test("member stubs are dup-retained at registration; revoke releases exactly the dups", async () => {
+    // Plain objects cross RPC by value with their function members as
+    // session stubs, and RPC disposes argument stubs when the provide call
+    // returns — so the core must store DUPS of the members, never the
+    // originals. This fake mirrors a member stub's protocol surface.
+    const disposed: string[] = [];
+    const memberStub = (label: string) => {
+      const fn = (...args: unknown[]) => ({ args, from: label });
+      return Object.assign(fn, {
+        dup: () => memberStub(`${label}+dup`),
+        [Symbol.dispose]: () => disposed.push(label),
+      });
+    };
+    const ultimate = memberStub("ultimate");
+    const thought = memberStub("thought");
+    const itx = makeItx();
+    await itx.provideCapability({
+      capability: { deep: { thought }, ultimate },
+      name: "answer",
+    });
+
+    // Simulate the RPC layer disposing the provide call's argument stubs.
+    ultimate[Symbol.dispose]();
+    thought[Symbol.dispose]();
+    // Dispatch runs on the retained dups, at any depth.
+    await expect(itx.invoke({ args: [1], path: ["answer", "ultimate"] })).resolves.toEqual({
+      args: [1],
+      from: "ultimate+dup",
+    });
+    await expect(itx.invoke({ args: [], path: ["answer", "deep", "thought"] })).resolves.toEqual({
+      args: [],
+      from: "thought+dup",
+    });
+
+    // Revoke releases exactly what registration dup'd — nothing else.
+    await itx.revokeCapability({ name: "answer" });
+    expect(disposed).toEqual(["ultimate", "thought", "thought+dup", "ultimate+dup"]);
+  });
+
+  test("members survive a REAL capnweb session's provide (argument stubs die at call end)", async () => {
+    const itx = makeItx();
+    // The context node's protocol surface, exposed over a real Cap'n Web
+    // session pair (in-memory MessagePorts — same wire discipline as the
+    // WebSocket sessions production uses).
+    class CoreMain extends RpcTarget {
+      provideCapability(input: ProvideCapabilityInput) {
+        return itx.provideCapability(input);
+      }
+      invoke(input: { path: string[]; args: unknown[] }) {
+        return itx.invoke(input);
+      }
+    }
+    const channel = new MessageChannel();
+    try {
+      newMessagePortRpcSession(channel.port1 as never, new CoreMain());
+      const remote = newMessagePortRpcSession<CoreMain>(channel.port2 as never);
+      await remote.provideCapability({
+        capability: {
+          deep: { thought: async (question: string) => ({ answer: 42, question }) },
+          ultimate: () => 42,
+        },
+        name: "answer",
+      } as never);
+
+      // The provide RPC has RETURNED — capnweb disposed its argument stubs.
+      // Dispatch must run on the core's retained dups, back in the provider.
+      await expect(remote.invoke({ args: [], path: ["answer", "ultimate"] })).resolves.toBe(42);
+      await expect(
+        remote.invoke({ args: ["life"], path: ["answer", "deep", "thought"] }),
+      ).resolves.toEqual({ answer: 42, question: "life" });
+    } finally {
+      channel.port1.close();
+      channel.port2.close();
+    }
   });
 
   test("a call-implementing provider still receives ONE call({ path, args }) — members are never traversed", async () => {

--- a/apps/os/src/itx/itx.test.ts
+++ b/apps/os/src/itx/itx.test.ts
@@ -399,11 +399,61 @@ describe("bare-function capabilities", () => {
 
     await expect(itx.invoke({ args: [1, "two"], path: ["probe"] })).resolves.toEqual({ ok: true });
     expect(seen).toEqual([[1, "two"]]);
-    // asPathCallable semantics: a bare function has no member tree.
+    // A bare function has no member tree — a deeper path is a plain miss.
     await expect(itx.invoke({ args: [], path: ["probe", "deeper"] })).rejects.toThrow(
       /did not resolve to a function/,
     );
     expect(await itx.describe()).toMatchObject([{ connected: true, kind: "live", name: "probe" }]);
+  });
+});
+
+describe("plain objects ARE capabilities", () => {
+  test("a plain object-of-methods dispatches by member path, at any depth, with no wrapper", async () => {
+    const itx = makeItx();
+    await itx.provideCapability({
+      capability: {
+        deep: { thought: (question: string) => ({ answer: 42, question }) },
+        ultimate: () => 42,
+      },
+      name: "answer",
+    });
+
+    await expect(itx.invoke({ args: [], path: ["answer", "ultimate"] })).resolves.toBe(42);
+    // Depth: the fallthrough replays ["deep", "thought"] onto the object's
+    // members — itx.answer.deep.thought("…") with zero client-side wrapping.
+    await expect(
+      itx.invoke({
+        args: ["what do you get if you multiply six by nine"],
+        path: ["answer", "deep", "thought"],
+      }),
+    ).resolves.toEqual({ answer: 42, question: "what do you get if you multiply six by nine" });
+    // A member miss inside the object is an instructive path error.
+    await expect(itx.invoke({ args: [], path: ["answer", "nope"] })).rejects.toThrow(
+      /did not resolve to a function/,
+    );
+    expect(await itx.describe()).toMatchObject([{ connected: true, kind: "live", name: "answer" }]);
+  });
+
+  test("a call-implementing provider still receives ONE call({ path, args }) — members are never traversed", async () => {
+    const itx = makeItx();
+    const calls: unknown[] = [];
+    await itx.provideCapability({
+      capability: {
+        call: (input: { path: string[]; args: unknown[] }) => {
+          calls.push(input);
+          return "from-call";
+        },
+        // A decoy member tree: implementing `call` means the provider owns
+        // its whole method-tree semantics, so this must never run.
+        chat: { post: () => "member tree, must not run" },
+      },
+      name: "sdk",
+    });
+
+    await expect(
+      itx.invoke({ args: [{ text: "hi" }], path: ["sdk", "chat", "post"] }),
+    ).resolves.toBe("from-call");
+    expect(calls).toEqual([{ args: [{ text: "hi" }], path: ["chat", "post"] }]);
   });
 });
 

--- a/apps/os/src/itx/itx.test.ts
+++ b/apps/os/src/itx/itx.test.ts
@@ -89,6 +89,8 @@ function makeItx(
     dial?: CapabilityDial;
     journal?: ReturnType<typeof fakeJournal>["journal"];
     parent?: ItxStub | null;
+    /** describe()'s label for entries inherited through the parent link. */
+    parentFrom?: string;
     runScript?: (input: { code: string; executionId: string }) => Promise<unknown>;
   } = {},
 ) {
@@ -96,7 +98,8 @@ function makeItx(
     contextId: input.contextId ?? "prj_1",
     dial: input.dial ?? fakeDial().dial,
     iterateContext: { journal: input.journal ?? fakeJournal().journal },
-    parentItx: () => input.parent ?? null,
+    parentItx: () =>
+      input.parent ? { from: input.parentFrom ?? "prj_1", stub: input.parent } : null,
     runScript: input.runScript,
     selfAddress: SELF_ADDRESS,
   });
@@ -171,12 +174,15 @@ describe("the journal is the only authority", () => {
     });
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
+      // The JOURNAL record keeps its internal owner field (data) …
       payload: { address: AI_ADDRESS, kind: "rpc", owner: "prj_1", path: ["ai"] },
       type: ITX_EVENT_TYPES.capabilityProvided,
     });
-    expect(await itx.describe()).toMatchObject([
-      { instructions: "Workers AI.", kind: "rpc", name: "ai", owner: "prj_1" },
-    ]);
+    // … while describe() — the projection — shows an OWN entry with no
+    // provenance field at all (`from` is for inherited entries only).
+    const described = await itx.describe();
+    expect(described).toMatchObject([{ instructions: "Workers AI.", kind: "rpc", name: "ai" }]);
+    expect(described[0]).not.toHaveProperty("from");
   });
 
   test("a fresh instance over the same journal folds to the same state; live entries replay disconnected", async () => {
@@ -235,8 +241,11 @@ describe("chain delegation", () => {
   function parentStub() {
     return {
       describe: vi.fn(async () => [
-        { kind: "rpc" as const, meta: {}, name: "ai", owner: "platform:project", updatedAtMs: 0 },
-        { kind: "rpc" as const, meta: {}, name: "inherited", owner: "prj_1", updatedAtMs: 1 },
+        // The parent's own merged view: `ai` arrived from ITS parent (the
+        // platform link, already stamped); `inherited` is the parent's own
+        // entry, so it carries no provenance field yet.
+        { from: "platform", kind: "rpc" as const, meta: {}, name: "ai", updatedAtMs: 0 },
+        { kind: "rpc" as const, meta: {}, name: "inherited", updatedAtMs: 1 },
       ]),
       invoke: vi.fn(async () => "from-parent"),
       provideCapability: vi.fn(async () => {}),
@@ -280,16 +289,25 @@ describe("chain delegation", () => {
     );
   });
 
-  test("describe merges the parent chain with exact-match suppression", async () => {
+  test("describe merges the parent chain: own entries unstamped, inherited carry `from`", async () => {
     const parent = parentStub();
-    const itx = makeItx({ contextId: "itx_a", parent });
-    await itx.provideCapability({ capability: AI_ADDRESS, name: "ai" }); // shadows the parent's
+    const itx = makeItx({ contextId: "itx_a", parent, parentFrom: "prj_1" });
 
-    const described = await itx.describe();
-    expect(described.map(({ name, owner }) => ({ name, owner }))).toEqual([
-      { name: "ai", owner: "itx_a" },
-      { name: "inherited", owner: "prj_1" },
+    // Before any own provide: everything is inherited. A deeper ancestor's
+    // stamp ("platform") survives verbatim; the parent's own entry is
+    // stamped with this link's label, exactly one level below its owner.
+    expect((await itx.describe()).map(({ from, name }) => ({ from, name }))).toEqual([
+      { from: "platform", name: "ai" },
+      { from: "prj_1", name: "inherited" },
     ]);
+
+    await itx.provideCapability({ capability: AI_ADDRESS, name: "ai" }); // shadows the parent's
+    const described = await itx.describe();
+    expect(described.map(({ from, name }) => ({ from, name }))).toEqual([
+      { from: undefined, name: "ai" }, // own — no provenance field
+      { from: "prj_1", name: "inherited" },
+    ]);
+    expect(described[0]).not.toHaveProperty("from");
   });
 
   test("platform defaults shadow and resurface as chain consequences", async () => {

--- a/apps/os/src/itx/itx.test.ts
+++ b/apps/os/src/itx/itx.test.ts
@@ -240,6 +240,24 @@ describe("provide-time self-description (describeItx)", () => {
     expect(await garbage.describe()).toMatchObject([{ name: "ai", types: undefined }]);
   });
 
+  test("an oversized describeItx answer is truncated before it is journaled", async () => {
+    const { dial } = selfDescribingDial({ types: "x".repeat(80 * 1024) });
+    const { events, journal } = fakeJournal();
+    const itx = makeItx({ dial, journal });
+    await itx.provideCapability({ capability: LOOPBACK_ADDRESS, name: "huge" });
+
+    const journaled = (events[0]!.payload as { meta: { types: string } }).meta.types;
+    expect(journaled.length).toBeLessThan(65 * 1024);
+    expect(journaled).toContain("truncated by the platform");
+    // Caller-supplied values are the caller's business — never truncated.
+    await itx.provideCapability({
+      capability: LOOPBACK_ADDRESS,
+      name: "mine",
+      types: "y".repeat(80 * 1024),
+    });
+    expect((events[1]!.payload as { meta: { types: string } }).meta.types).toHaveLength(80 * 1024);
+  });
+
   test("live provides are never probed", async () => {
     const dial = vi.fn();
     const itx = makeItx({ dial: dial as unknown as CapabilityDial });

--- a/apps/os/src/itx/itx.test.ts
+++ b/apps/os/src/itx/itx.test.ts
@@ -356,9 +356,9 @@ describe("chain delegation", () => {
     return {
       describe: vi.fn(async () => [
         // The parent's own merged view: `ai` arrived from ITS parent (the
-        // platform link, already stamped); `inherited` is the parent's own
+        // defaults link, already stamped); `inherited` is the parent's own
         // entry, so it carries no provenance field yet.
-        { from: "platform", kind: "rpc" as const, meta: {}, name: "ai", updatedAtMs: 0 },
+        { from: "defaults", kind: "rpc" as const, meta: {}, name: "ai", updatedAtMs: 0 },
         { kind: "rpc" as const, meta: {}, name: "inherited", updatedAtMs: 1 },
       ]),
       invoke: vi.fn(async () => "from-parent"),
@@ -408,10 +408,10 @@ describe("chain delegation", () => {
     const itx = makeItx({ contextId: "itx_a", parent, parentFrom: "prj_1" });
 
     // Before any own provide: everything is inherited. A deeper ancestor's
-    // stamp ("platform") survives verbatim; the parent's own entry is
+    // stamp ("defaults") survives verbatim; the parent's own entry is
     // stamped with this link's label, exactly one level below its owner.
     expect((await itx.describe()).map(({ from, name }) => ({ from, name }))).toEqual([
-      { from: "platform", name: "ai" },
+      { from: "defaults", name: "ai" },
       { from: "prj_1", name: "inherited" },
     ]);
 
@@ -424,7 +424,7 @@ describe("chain delegation", () => {
     expect(described[0]).not.toHaveProperty("from");
   });
 
-  test("platform defaults shadow and resurface as chain consequences", async () => {
+  test("the defaults shadow and resurface as chain consequences", async () => {
     const parent = parentStub();
     const { dial, dialed } = fakeDial();
     const itx = makeItx({ dial, parent });
@@ -442,7 +442,9 @@ describe("chain delegation", () => {
     expect(parent.invoke).toHaveBeenCalledTimes(1);
 
     // Revoking the INHERITED entry itself refuses with the shadowing hint.
-    await expect(itx.revokeCapability({ name: "ai" })).rejects.toThrow(/platform default/);
+    await expect(itx.revokeCapability({ name: "ai" })).rejects.toThrow(
+      /inherited from the defaults/,
+    );
     // Revoking something that exists nowhere stays a no-op.
     await expect(itx.revokeCapability({ name: "neverExisted" })).resolves.toBeUndefined();
   });

--- a/apps/os/src/itx/itx.ts
+++ b/apps/os/src/itx/itx.ts
@@ -15,8 +15,8 @@
 // Everything effectful is injected: `dial` turns a CapabilityAddress into
 // something speaking `call({ path, args })` (dial.ts builds it; the core
 // never touches env or a project id), `parentItx` is a stub of the parent
-// context's core (chain delegation — the platform defaults are simply the
-// chain's code-rooted final link, platform-context.ts), and the journal
+// context's core (chain delegation — the defaults are simply the chain's
+// code-rooted final link, platform-context.ts), and the journal
 // append/read pair rides in as the processor's iterate context.
 //
 // Hosts: the Project DO and ItxDurableObject expose the core via an `itx()`
@@ -34,15 +34,16 @@ import {
   type PathCall,
   type PathCallable,
 } from "./path-proxy.ts";
-import type {
-  CapabilityAddress,
-  CapabilityDescription,
-  CapabilityKind,
-  CapabilityMeta,
-  CapabilityTarget,
-  ItxOrigin,
-  WorkerRef,
-  WorkerSource,
+import {
+  DEFAULTS_DESCRIBE_FROM,
+  type CapabilityAddress,
+  type CapabilityDescription,
+  type CapabilityKind,
+  type CapabilityMeta,
+  type CapabilityTarget,
+  type ItxOrigin,
+  type WorkerRef,
+  type WorkerSource,
 } from "./types.ts";
 
 // Server-side one-stop: the calling-convention pieces live in path-proxy.ts
@@ -57,6 +58,7 @@ export {
   type PathCallable,
 } from "./path-proxy.ts";
 export { ItxContract, ITX_EVENT_TYPES, type ItxState } from "./contract.ts";
+export { DEFAULTS_DESCRIBE_FROM } from "./types.ts";
 export type {
   CapabilityAddress,
   CapabilityDescription,
@@ -241,7 +243,7 @@ export type ItxDeps = {
    * because a generic context learns its parent from its own birth
    * certificate (state), which exists only after the journal is consumed.
    * `from` is how describe() labels entries inherited through this link —
-   * the parent's context id, or "platform" at the code root (the internal
+   * the parent's context id, or "defaults" at the code root (the internal
    * platform:project id never leaves the chain). */
   parentItx: () => { from: string; stub: ItxStub } | null;
   /** Processor-mode execution: run one enqueued script-execution-requested
@@ -312,7 +314,7 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
       }
       kind = "live";
       const live = isLocalBareFunction(input.capability)
-        ? localFunctionCapability(input.capability)
+        ? localFunctionCapability(input.capability, name)
         : (input.capability as LiveProvider);
       this.#registerLiveStub(name, live);
     }
@@ -360,7 +362,7 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
   /**
    * Remove an entry (exact path match, never prefix) by appending
    * `capability-revoked`. Only this context's OWN entries can be revoked:
-   * inherited entries (platform defaults, ancestors') resolve through the
+   * inherited entries (the defaults, ancestors') resolve through the
    * chain, so "revoking" one here would lie — shadow it instead. Revoking a
    * shadow resurfaces whatever the chain resolves, by construction.
    */
@@ -379,8 +381,9 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
         const from = inherited.from ?? parent!.from;
         throw new Error(
           `Capability "${name}" is not provided on this context — it is inherited from ` +
-            `${from === "platform" ? "the platform defaults" : `context ${from}`} and cannot ` +
-            `be revoked here; provide your own "${name}" to shadow it.`,
+            `${from === DEFAULTS_DESCRIBE_FROM ? "the defaults" : `context ${from}`} and cannot ` +
+            `be revoked here; provide your own "${name}" on this context to take its place; ` +
+            `the original stays on the parent.`,
         );
       }
       return;
@@ -392,7 +395,7 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
   /**
    * The merged chain view: own entries first (no provenance field — they are
    * yours), then the parent chain's, each carrying `from` (the context the
-   * entry actually lives on; the platform defaults read `from: "platform"`).
+   * entry actually lives on; the defaults read `from: "defaults"`).
    * Suppression is deliberately EXACT-match only: a path provide
    * ("sdk.chat.postMessage") shadows just its subtree — the parent's "sdk"
    * stays live for every other path, so hiding it here would lie about what
@@ -681,7 +684,7 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
       // materializes a callable proxy for any member name, `call` included.
       if (typeof borrowed.call === "function") return borrowed as unknown as PathCallable;
       return {
-        call: (input: PathCall) => replayPathCall(borrowed, input),
+        call: (input: PathCall) => replayPathCall(borrowed, input, { capability: entry.name }),
         [Symbol.dispose]: () => disposeIfPossible(borrowed),
       } as PathCallable;
     }
@@ -716,7 +719,7 @@ export function resolveLongestProvidedPrefix<Entry>(
  * Names that may never be FIRST path segments: a cap must not shadow the
  * trust kernel (it is reachable as `itx.<name>`, so it competes with the
  * handle's built-ins). `fetch` and `streams` are deliberately NOT here:
- * both are shadowable platform default capabilities (providing your own
+ * both are shadowable default capabilities (providing your own
  * `fetch` is how egress interception works) — the handle's real members
  * still win property lookup; they route through the core anyway.
  */
@@ -824,8 +827,10 @@ function truncateSelfDescription(value: string): string {
  * empty remainder calls the function, a deeper remainder errors (replayed
  * in-process). The wrap exists because a bare function would otherwise look
  * call-speaking to dispatch — `fn.call` IS a function (Function.prototype). */
-function localFunctionCapability(fn: (...args: never[]) => unknown): LiveProvider {
-  return { call: (input: PathCall) => replayPathCall(fn, input) } as LiveProvider;
+function localFunctionCapability(fn: (...args: never[]) => unknown, name: string): LiveProvider {
+  return {
+    call: (input: PathCall) => replayPathCall(fn, input, { capability: name }),
+  } as LiveProvider;
 }
 
 function isPlainObject(target: unknown): boolean {

--- a/apps/os/src/itx/itx.ts
+++ b/apps/os/src/itx/itx.ts
@@ -879,7 +879,10 @@ function retainLiveProvider(provider: LiveProvider): {
     const copy: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(node)) {
       const dup = (value as { dup?: () => LiveProvider } | null)?.dup;
-      if (typeof value === "function" && typeof dup === "function") {
+      if (value !== null && typeof dup === "function") {
+        // Any member exposing dup() is a session stub — a function OR an
+        // object-shaped stub (e.g. a nested RpcTarget). Both die with the
+        // provide RPC unless retained here.
         const duped = Reflect.apply(dup, value, []) as LiveProvider;
         memberDups.push(duped);
         copy[key] = duped;

--- a/apps/os/src/itx/itx.ts
+++ b/apps/os/src/itx/itx.ts
@@ -217,16 +217,19 @@ export type ItxIterateContext = {
 };
 
 export type ItxDeps = {
-  /** This context's identity — describe() owner label, origin id. */
+  /** This context's identity — the journal records' owner field, origin id. */
   contextId: string;
   /** This context's own address — stamped as origin when delegating. */
   selfAddress: CapabilityAddress;
   /** THE only dial effect: address → something speaking call({ path, args }). */
   dial: CapabilityDial;
-  /** The parent context's core, or null at the chain root. A function
+  /** The parent context's link, or null at the chain root. A function
    * because a generic context learns its parent from its own birth
-   * certificate (state), which exists only after the journal is consumed. */
-  parentItx: () => ItxStub | null;
+   * certificate (state), which exists only after the journal is consumed.
+   * `from` is how describe() labels entries inherited through this link —
+   * the parent's context id, or "platform" at the code root (the internal
+   * platform:project id never leaves the chain). */
+  parentItx: () => { from: string; stub: ItxStub } | null;
   /** Processor-mode execution: run one enqueued script-execution-requested
    * event (the runner appends the completed event to this journal). */
   runScript?: (input: { code: string; executionId: string }) => Promise<unknown>;
@@ -326,14 +329,15 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
     if (!(name in this.state.capabilities)) {
       // Distinguish "never existed" (a no-op, matching the old semantics)
       // from "inherited through the chain" (refuse with the shadowing hint).
-      const inherited = (await this.deps.parentItx()?.describe())?.find(
+      const parent = this.deps.parentItx();
+      const inherited = (await parent?.stub.describe())?.find(
         (description) => description.name === name,
       );
       if (inherited) {
         throw new Error(
           `Capability "${name}" is not provided on this context — it is inherited from ` +
-            `${inherited.owner} (e.g. a platform default) and cannot be revoked here; ` +
-            `provide your own "${name}" to shadow it.`,
+            `${inherited.from ?? parent!.from} (e.g. a platform default) and cannot be ` +
+            `revoked here; provide your own "${name}" to shadow it.`,
         );
       }
       return;
@@ -343,13 +347,13 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
   }
 
   /**
-   * The merged chain view: own entries (each with its `owner` provenance),
-   * then the parent chain's — the platform defaults arrive from the chain's
-   * code-rooted final link like any other ancestor's. Suppression is
-   * deliberately EXACT-match only: a path provide ("sdk.chat.postMessage")
-   * shadows just its subtree — the parent's "sdk" stays live for every other
-   * path, so hiding it here would lie about what longest-prefix dispatch
-   * actually resolves.
+   * The merged chain view: own entries first (no provenance field — they are
+   * yours), then the parent chain's, each carrying `from` (the context the
+   * entry actually lives on; the platform defaults read `from: "platform"`).
+   * Suppression is deliberately EXACT-match only: a path provide
+   * ("sdk.chat.postMessage") shadows just its subtree — the parent's "sdk"
+   * stays live for every other path, so hiding it here would lie about what
+   * longest-prefix dispatch actually resolves.
    */
   async describe(): Promise<CapabilityDescription[]> {
     await this.#materialize();
@@ -363,7 +367,6 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
           kind: entry.kind,
           meta,
           name: entry.name,
-          owner: entry.owner,
           types: typeof meta.types === "string" ? meta.types : undefined,
           updatedAtMs: entry.updatedAtMs,
         };
@@ -371,8 +374,18 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
     const parent = this.deps.parentItx();
     if (!parent) return own;
     const shadowed = new Set(own.map((description) => description.name));
-    const inherited = await parent.describe();
-    return [...own, ...inherited.filter((description) => !shadowed.has(description.name))];
+    const inherited = await parent.stub.describe();
+    return [
+      ...own,
+      ...inherited
+        .filter((description) => !shadowed.has(description.name))
+        // Stamp `from` exactly one level below the owner: the parent's OWN
+        // entries arrive unstamped (own entries carry no provenance) and get
+        // this link's label; deeper ancestors' already carry theirs.
+        .map((description) =>
+          description.from === undefined ? { ...description, from: parent.from } : description,
+        ),
+    ];
   }
 
   /**
@@ -391,7 +404,7 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
     if (!resolved) {
       const parent = this.deps.parentItx();
       if (parent) {
-        return await parent.invoke({ ...input, origin });
+        return await parent.stub.invoke({ ...input, origin });
       }
       throw new Error(
         `No capability named "${input.path[0] ?? ""}" in context ${this.deps.contextId}` +

--- a/apps/os/src/itx/itx.ts
+++ b/apps/os/src/itx/itx.ts
@@ -126,8 +126,16 @@ export type ItxStub = {
   invoke(input: { path: string[]; args: unknown[]; origin?: ItxOrigin }): Promise<unknown>;
 };
 
-/** How long a provide waits for a target's optional describeItx answer. */
+/** How long a provide waits for a target's optional describeItx answer.
+ * Loopback dials get longer: a first-party client's first probe may ride a
+ * cold project chain and fetch real data (OpenApiClient fetches its spec);
+ * everything else stays snappy — a miss just means an unenriched provide. */
 const SELF_DESCRIPTION_TIMEOUT_MS = 3_000;
+const SELF_DESCRIPTION_LOOPBACK_TIMEOUT_MS = 15_000;
+
+/** Probe-derived strings are journaled forever; cap them so a pathological
+ * spec cannot bloat the record. Caller-supplied values are never touched. */
+const SELF_DESCRIPTION_META_BUDGET = 64 * 1024;
 
 export class CapabilityOfflineError extends Error {
   constructor(name: string) {
@@ -314,19 +322,23 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
     // knows its own surface best at exactly that moment. An rpc provide
     // with no caller-supplied `types` is dialed ONCE and asked
     // (`describeItx` — a reserved protocol name, so user paths can never
-    // collide); explicit caller values always win. Strictly best-effort:
-    // any failure or the short timeout means the provide proceeds
-    // unenriched. Only call-implementing targets (OpenApiClient, …) can
-    // answer — member-shaped source caps hit replayPathCall's reserved
-    // gate, which is the collision protection doing its job.
+    // collide); explicit caller values always win. The probe is a
+    // best-effort, SIDE-EFFECTFUL call into provider code at provide time
+    // (an OpenApiClient probe fetches its spec). Strictly best-effort:
+    // any failure or the timeout means the provide proceeds unenriched.
+    // Only call-implementing targets (OpenApiClient, …) can answer —
+    // member-shaped source caps hit replayPathCall's reserved gate, which
+    // is the collision protection doing its job.
     if (kind === "rpc" && meta.types === undefined) {
       const described = await this.#dialSelfDescription(
         name,
         input.capability as CapabilityAddress,
       );
-      if (typeof described?.types === "string") meta.types = described.types;
+      if (typeof described?.types === "string") {
+        meta.types = truncateSelfDescription(described.types);
+      }
       if (typeof described?.instructions === "string" && meta.instructions === undefined) {
-        meta.instructions = described.instructions;
+        meta.instructions = truncateSelfDescription(described.instructions);
       }
     }
 
@@ -484,10 +496,14 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
       });
       const call = Promise.resolve(borrowed.call({ args: [], path: [SELF_DESCRIPTION_METHOD] }));
       call.catch(() => {});
+      const deadlineMs =
+        address.type === "rpc" && address.worker.type === "loopback"
+          ? SELF_DESCRIPTION_LOOPBACK_TIMEOUT_MS
+          : SELF_DESCRIPTION_TIMEOUT_MS;
       const result = await Promise.race([
         call,
         new Promise<null>((resolve) => {
-          timer = setTimeout(() => resolve(null), SELF_DESCRIPTION_TIMEOUT_MS);
+          timer = setTimeout(() => resolve(null), deadlineMs);
         }),
       ]);
       if (result == null || typeof result !== "object") return null;
@@ -792,6 +808,16 @@ export function isLocalBareFunction(
   if (typeof capability !== "function") return false;
   const proto = Object.getPrototypeOf(capability) as object | null;
   return proto === Function.prototype || proto === ASYNC_FUNCTION_PROTOTYPE;
+}
+
+/** Cap one probe-derived string against the journaled-meta budget, with an
+ * honest note where the cut happened. */
+function truncateSelfDescription(value: string): string {
+  if (value.length <= SELF_DESCRIPTION_META_BUDGET) return value;
+  return (
+    value.slice(0, SELF_DESCRIPTION_META_BUDGET) +
+    "\n// … truncated by the platform: the describeItx answer exceeded the 64KB journaled-meta budget."
+  );
 }
 
 /** Wrap a bare local function so it speaks the one calling convention:

--- a/apps/os/src/itx/itx.ts
+++ b/apps/os/src/itx/itx.ts
@@ -652,20 +652,17 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
       const stub = this.#liveStubs.get(entry.name);
       if (!stub) throw new CapabilityOfflineError(entry.name);
       const borrowed = (stub.dup ? stub.dup() : stub) as LiveProvider;
-      // Dispatch decides the live target's mode, right here. Probing at
-      // dispatch (not at provide time, and uncached) is deliberate: the
-      // check is a free local property lookup, never a round trip. A LOCAL
-      // target — a plain object, an RpcTarget instance, the bare-function
-      // wrap — answers truthfully; a session-crossed RPC stub materializes
-      // a callable proxy for ANY member name (including `call`), which is
-      // exactly right because the handle normalizes every session-provided
-      // live target to a call-speaking one (handle.ts resolveLiveCapability).
-      //
-      // A target that implements `call` owns its whole method-tree semantics
-      // (the SDK shape: one method receives { path, args } as data). NOT
-      // implementing `call` means the target IS its member tree — a plain
-      // object of methods is a capability with no wrapper at all; replay the
-      // remaining path onto its members, in the process where they live.
+      // Dispatch decides the live target's mode right here, by a free local
+      // property probe (never a round trip). A target implementing `call`
+      // owns its whole method-tree semantics (the SDK shape: one method
+      // receives { path, args } as data); anything else IS its member tree —
+      // replay the remaining path onto it. Plain objects always take the
+      // member branch: they cross sessions by value (the probe sees their
+      // real, absent `call`), and their retained member stubs are what the
+      // replay calls. Function-shaped targets always probe call-speaking —
+      // bare functions wrap at provide (localFunctionCapability / the
+      // handle's wrapper, live-target.ts), and a session-crossed stub
+      // materializes a callable proxy for any member name, `call` included.
       if (typeof borrowed.call === "function") return borrowed as unknown as PathCallable;
       return {
         call: (input: PathCall) => replayPathCall(borrowed, input),

--- a/apps/os/src/itx/itx.ts
+++ b/apps/os/src/itx/itx.ts
@@ -30,6 +30,7 @@ import { ItxContract, ITX_EVENT_TYPES, type ItxState } from "./contract.ts";
 import {
   replayPathCall,
   RESERVED_PATH_SEGMENTS,
+  SELF_DESCRIPTION_METHOD,
   type PathCall,
   type PathCallable,
 } from "./path-proxy.ts";
@@ -51,6 +52,7 @@ import type {
 export {
   replayPathCall,
   RESERVED_PATH_SEGMENTS,
+  SELF_DESCRIPTION_METHOD,
   type PathCall,
   type PathCallable,
 } from "./path-proxy.ts";
@@ -123,6 +125,9 @@ export type ItxStub = {
   describe(): Promise<CapabilityDescription[]>;
   invoke(input: { path: string[]; args: unknown[]; origin?: ItxOrigin }): Promise<unknown>;
 };
+
+/** How long a provide waits for a target's optional describeItx answer. */
+const SELF_DESCRIPTION_TIMEOUT_MS = 3_000;
 
 export class CapabilityOfflineError extends Error {
   constructor(name: string) {
@@ -301,6 +306,27 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
       this.#registerLiveStub(name, live);
     }
 
+    // The self-description doctrine's provide-time hook: instructions +
+    // types belong in the journaled meta AT PROVIDE TIME, and the target
+    // knows its own surface best at exactly that moment. An rpc provide
+    // with no caller-supplied `types` is dialed ONCE and asked
+    // (`describeItx` — a reserved protocol name, so user paths can never
+    // collide); explicit caller values always win. Strictly best-effort:
+    // any failure or the short timeout means the provide proceeds
+    // unenriched. Only call-implementing targets (OpenApiClient, …) can
+    // answer — member-shaped source caps hit replayPathCall's reserved
+    // gate, which is the collision protection doing its job.
+    if (kind === "rpc" && meta.types === undefined) {
+      const described = await this.#dialSelfDescription(
+        name,
+        input.capability as CapabilityAddress,
+      );
+      if (typeof described?.types === "string") meta.types = described.types;
+      if (typeof described?.instructions === "string" && meta.instructions === undefined) {
+        meta.instructions = described.instructions;
+      }
+    }
+
     try {
       await this.#append(ITX_EVENT_TYPES.capabilityProvided, {
         address: kind === "live" ? null : (input.capability as CapabilityAddress),
@@ -435,6 +461,43 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
       throw error;
     } finally {
       disposeIfPossible(borrowed);
+    }
+  }
+
+  /** Provide-time self-description (see provideCapability): one dial, one
+   * `describeItx` call, a short deadline, and null on ANY miss — never an
+   * error, never a hang. The losing in-flight call is observed so a late
+   * rejection cannot become unhandled. */
+  async #dialSelfDescription(
+    name: string,
+    address: CapabilityAddress,
+  ): Promise<{ instructions?: string; types?: string } | null> {
+    let borrowed: PathCallable | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      borrowed = this.deps.dial(address, {
+        capabilityPath: name,
+        origin: { address: this.deps.selfAddress, id: this.deps.contextId },
+      });
+      const call = Promise.resolve(borrowed.call({ args: [], path: [SELF_DESCRIPTION_METHOD] }));
+      call.catch(() => {});
+      const result = await Promise.race([
+        call,
+        new Promise<null>((resolve) => {
+          timer = setTimeout(() => resolve(null), SELF_DESCRIPTION_TIMEOUT_MS);
+        }),
+      ]);
+      if (result == null || typeof result !== "object") return null;
+      const { instructions, types } = result as { instructions?: unknown; types?: unknown };
+      return {
+        ...(typeof instructions === "string" ? { instructions } : {}),
+        ...(typeof types === "string" ? { types } : {}),
+      };
+    } catch {
+      return null;
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+      if (borrowed) disposeIfPossible(borrowed);
     }
   }
 

--- a/apps/os/src/itx/itx.ts
+++ b/apps/os/src/itx/itx.ts
@@ -248,6 +248,9 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
    * In-memory on purpose: a connection cannot be persisted (workerd#6087
    * may change this) — replay marks live entries disconnected. */
   #liveStubs = new Map<string, LiveProvider>();
+  /** Releases everything a live registration dup-retained (the provider's
+   * own dup, or every member dup of a plain-object provider). */
+  #liveStubReleases = new Map<string, () => void>();
   #materialized = false;
   /** Monotonic append counter; #catchUp compares it against the counter a
    * sync STARTED at to guarantee read-your-writes. */
@@ -602,10 +605,13 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
   #registerLiveStub(name: string, provider: LiveProvider): void {
     // RPC disposes argument stubs when the call returns; keep a duplicate
     // (and hand further dups to borrowers) — both directions of the dup()
-    // discipline from the original capnweb learnings.
-    const retained = provider.dup ? provider.dup() : provider;
+    // discipline from the original capnweb learnings. A PLAIN-object provider
+    // crosses RPC by value with its function members as stubs, so retention
+    // walks it and dups every member (retainLiveProvider).
+    const { onRpcBroken, release, retained } = retainLiveProvider(provider);
     this.#dropLiveStub(name, { record: false });
     this.#liveStubs.set(name, retained);
+    this.#liveStubReleases.set(name, release);
     // Best-effort teardown registration: capnweb stubs implement onRpcBroken
     // locally, but Workers-RPC stubs proxy EVERY property as a remote method,
     // so on a provider that doesn't implement it the call rejects with "does
@@ -614,7 +620,7 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
     const teardown = () => {
       if (this.#liveStubs.get(name) === retained) this.#dropLiveStub(name, { record: true });
     };
-    void Promise.resolve(retained.onRpcBroken?.(teardown) as unknown).catch(() => {});
+    void Promise.resolve(onRpcBroken?.(teardown) as unknown).catch(() => {});
   }
 
   /** Drop a live stub. `record: true` (session teardown) appends the
@@ -624,6 +630,8 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
     const stub = this.#liveStubs.get(name);
     if (!stub) return;
     this.#liveStubs.delete(name);
+    const release = this.#liveStubReleases.get(name);
+    this.#liveStubReleases.delete(name);
     if (opts.record) {
       void this.ctx.journal
         .append({
@@ -634,7 +642,7 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
           console.error(`[itx] capability-disconnected append failed for "${name}":`, error);
         });
     }
-    stub[Symbol.dispose]?.();
+    release?.();
   }
 
   /** The two-case shape: a capability is either held up by a live connection
@@ -801,6 +809,66 @@ function isPlainObject(target: unknown): boolean {
   if (typeof target !== "object" || target === null) return false;
   const proto = Object.getPrototypeOf(target);
   return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Retention for a live provider, beyond the provide call that delivered it:
+ * RPC disposes argument stubs when the call returns, so anything stored must
+ * be a dup. Three shapes:
+ *
+ * - a stub with `.dup` (RpcTarget/function providers) retains via one dup;
+ * - a PLAIN object crosses RPC by value with its function members as session
+ *   stubs — retention deep-walks it and dups every stub-valued member (the
+ *   members are the things that die at call end, not the carrier object);
+ * - anything else (a local object) needs no retention.
+ *
+ * `release` disposes exactly what was dup'd here (#dropLiveStub calls it);
+ * `onRpcBroken` is the best teardown hook the shape offers — the provider's
+ * own, or any member stub's (members share the provider's session).
+ */
+function retainLiveProvider(provider: LiveProvider): {
+  retained: LiveProvider;
+  release: () => void;
+  onRpcBroken?: (callback: (error: unknown) => void) => void;
+} {
+  if (typeof provider.dup === "function") {
+    const retained = provider.dup();
+    return {
+      onRpcBroken: (callback) => retained.onRpcBroken?.(callback),
+      release: () => disposeIfPossible(retained),
+      retained,
+    };
+  }
+  if (!isPlainObject(provider)) {
+    return {
+      onRpcBroken: (callback) => provider.onRpcBroken?.(callback),
+      release: () => disposeIfPossible(provider),
+      retained: provider,
+    };
+  }
+  const memberDups: LiveProvider[] = [];
+  const walk = (node: Record<string, unknown>): Record<string, unknown> => {
+    const copy: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(node)) {
+      const dup = (value as { dup?: () => LiveProvider } | null)?.dup;
+      if (typeof value === "function" && typeof dup === "function") {
+        const duped = Reflect.apply(dup, value, []) as LiveProvider;
+        memberDups.push(duped);
+        copy[key] = duped;
+      } else if (isPlainObject(value)) {
+        copy[key] = walk(value as Record<string, unknown>);
+      } else {
+        copy[key] = value;
+      }
+    }
+    return copy;
+  };
+  const retained = walk(provider as Record<string, unknown>) as LiveProvider;
+  return {
+    onRpcBroken: memberDups[0] ? (callback) => memberDups[0]!.onRpcBroken?.(callback) : undefined,
+    release: () => memberDups.forEach((duped) => disposeIfPossible(duped)),
+    retained,
+  };
 }
 
 /**

--- a/apps/os/src/itx/itx.ts
+++ b/apps/os/src/itx/itx.ts
@@ -128,7 +128,8 @@ export class CapabilityOfflineError extends Error {
   constructor(name: string) {
     super(
       `Capability "${name}" is registered but its provider is not connected. ` +
-        `Live capabilities last as long as the provider's session; the provider must reconnect and provide() again.`,
+        `Live capabilities last as long as the provider's session; the provider must ` +
+        `reconnect and call provideCapability() again.`,
     );
   }
 }
@@ -334,10 +335,11 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
         (description) => description.name === name,
       );
       if (inherited) {
+        const from = inherited.from ?? parent!.from;
         throw new Error(
           `Capability "${name}" is not provided on this context — it is inherited from ` +
-            `${inherited.from ?? parent!.from} (e.g. a platform default) and cannot be ` +
-            `revoked here; provide your own "${name}" to shadow it.`,
+            `${from === "platform" ? "the platform defaults" : `context ${from}`} and cannot ` +
+            `be revoked here; provide your own "${name}" to shadow it.`,
         );
       }
       return;
@@ -360,14 +362,17 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
     const own = Object.values(this.state.capabilities)
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((entry): CapabilityDescription => {
-        const meta = entry.meta as CapabilityMeta;
+        // `instructions`/`types` are LIFTED to the entry's top level and
+        // removed from the projected meta — one place to read each fact.
+        // (The journal keeps the full meta verbatim; this is projection.)
+        const { instructions, types, ...meta } = entry.meta as CapabilityMeta;
         return {
           connected: entry.kind === "live" ? this.#liveStubs.has(entry.name) : undefined,
-          instructions: typeof meta.instructions === "string" ? meta.instructions : undefined,
+          instructions: typeof instructions === "string" ? instructions : undefined,
           kind: entry.kind,
           meta,
           name: entry.name,
-          types: typeof meta.types === "string" ? meta.types : undefined,
+          types: typeof types === "string" ? types : undefined,
           updatedAtMs: entry.updatedAtMs,
         };
       });

--- a/apps/os/src/itx/itx.ts
+++ b/apps/os/src/itx/itx.ts
@@ -49,7 +49,6 @@ import type {
 // model lives in types.ts (the import-free design of record). Server code
 // imports all of it from here.
 export {
-  asPathCallable,
   replayPathCall,
   RESERVED_PATH_SEGMENTS,
   type PathCall,
@@ -254,9 +253,10 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
    * the checkpoint's offset bookkeeping makes any later delivery of the
    * same offsets a no-op). A CapabilityAddress registers durably-shaped;
    * anything else is LIVE — the EVENT is journaled (the record outlives the
-   * session) while the stub stays an instance field. A bare local FUNCTION
-   * is live by nature and auto-wraps with asPathCallable semantics (empty
-   * remainder calls the function; a deeper remainder errors).
+   * session) while the stub stays an instance field. A live target needs no
+   * wrapper: a plain object (or bare function) IS the capability — dispatch
+   * replays paths onto its members; a target that implements `call({ path,
+   * args })` itself owns its whole method-tree semantics instead (#borrow).
    *
    * Returns nothing: the HANDLE (handle.ts) builds the CapabilityProvision
    * its callers hold — the core's provide is just the journaled write.
@@ -562,7 +562,26 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
     if (entry.kind === "live") {
       const stub = this.#liveStubs.get(entry.name);
       if (!stub) throw new CapabilityOfflineError(entry.name);
-      return (stub.dup ? stub.dup() : stub) as unknown as PathCallable;
+      const borrowed = (stub.dup ? stub.dup() : stub) as LiveProvider;
+      // Dispatch decides the live target's mode, right here. Probing at
+      // dispatch (not at provide time, and uncached) is deliberate: the
+      // check is a free local property lookup, never a round trip. A LOCAL
+      // target — a plain object, an RpcTarget instance, the bare-function
+      // wrap — answers truthfully; a session-crossed RPC stub materializes
+      // a callable proxy for ANY member name (including `call`), which is
+      // exactly right because the handle normalizes every session-provided
+      // live target to a call-speaking one (handle.ts resolveLiveCapability).
+      //
+      // A target that implements `call` owns its whole method-tree semantics
+      // (the SDK shape: one method receives { path, args } as data). NOT
+      // implementing `call` means the target IS its member tree — a plain
+      // object of methods is a capability with no wrapper at all; replay the
+      // remaining path onto its members, in the process where they live.
+      if (typeof borrowed.call === "function") return borrowed as unknown as PathCallable;
+      return {
+        call: (input: PathCall) => replayPathCall(borrowed, input),
+        [Symbol.dispose]: () => disposeIfPossible(borrowed),
+      } as PathCallable;
     }
     return this.deps.dial(entry.address! as CapabilityAddress, {
       capabilityPath: entry.name,
@@ -690,8 +709,9 @@ export function isLocalBareFunction(
 }
 
 /** Wrap a bare local function so it speaks the one calling convention:
- * empty remainder calls the function, a deeper remainder errors (the
- * asPathCallable semantics, replayed in-process). */
+ * empty remainder calls the function, a deeper remainder errors (replayed
+ * in-process). The wrap exists because a bare function would otherwise look
+ * call-speaking to dispatch — `fn.call` IS a function (Function.prototype). */
 function localFunctionCapability(fn: (...args: never[]) => unknown): LiveProvider {
   return { call: (input: PathCall) => replayPathCall(fn, input) } as LiveProvider;
 }

--- a/apps/os/src/itx/live-target.test.ts
+++ b/apps/os/src/itx/live-target.test.ts
@@ -1,0 +1,69 @@
+// The one live wrapper (live-target.ts): functions call, classes
+// member-replay. Plain Node tests — the cloudflare:workers RpcTarget base is
+// shimmed (vitest.config.ts), and the wrapper itself is pure dispatch.
+
+import { describe, expect, test } from "vitest";
+import { LiveCallableCapability, resolveLiveCapability } from "./live-target.ts";
+
+describe("LiveCallableCapability", () => {
+  test("an empty path calls the function with the args", async () => {
+    const seen: unknown[][] = [];
+    const wrapper = new LiveCallableCapability((...args: unknown[]) => {
+      seen.push(args);
+      return "called";
+    });
+    await expect(wrapper.call({ args: [1, "two"], path: [] })).resolves.toBe("called");
+    expect(seen).toEqual([[1, "two"]]);
+  });
+
+  test("a member path replays onto the target's members (the call-less-class shape)", async () => {
+    // A capnweb stub of a call-less RpcTarget is a callable proxy whose
+    // property accesses materialize its members; this local stand-in has the
+    // same shape — a function carrying a member tree.
+    const target = Object.assign(() => "root", {
+      chat: { post: (input: { text: string }) => ({ posted: input.text }) },
+    });
+    const wrapper = new LiveCallableCapability(target as never);
+    await expect(wrapper.call({ args: [{ text: "hi" }], path: ["chat", "post"] })).resolves.toEqual(
+      { posted: "hi" },
+    );
+    // And the same wrapper still calls the function itself on an empty path.
+    await expect(wrapper.call({ args: [], path: [] })).resolves.toBe("root");
+  });
+
+  test("a member miss on a memberless function is a plain path error", async () => {
+    const wrapper = new LiveCallableCapability(() => 42);
+    await expect(wrapper.call({ args: [], path: ["nope"] })).rejects.toThrow(
+      /did not resolve to a function/,
+    );
+  });
+
+  test("retains a dup of stub-shaped functions; dispose releases it", () => {
+    const log: string[] = [];
+    const makeStub = (label: string) =>
+      Object.assign(() => label, {
+        dup: () => makeStub(`${label}+dup`),
+        [Symbol.dispose]: () => log.push(label),
+      });
+    const wrapper = new LiveCallableCapability(makeStub("fn") as never);
+    wrapper[Symbol.dispose]();
+    expect(log).toEqual(["fn+dup"]);
+  });
+});
+
+describe("resolveLiveCapability", () => {
+  test("local bare functions wrap; the wrapper speaks call()", async () => {
+    const resolved = (await resolveLiveCapability(
+      (async (a: number, b: number) => a + b) as never,
+    )) as LiveCallableCapability;
+    expect(resolved).toBeInstanceOf(LiveCallableCapability);
+    await expect(resolved.call({ args: [40, 2], path: [] })).resolves.toBe(42);
+  });
+
+  test("plain objects and addresses pass through untouched", async () => {
+    const plain = { deep: { thought: () => 42 } };
+    await expect(resolveLiveCapability(plain)).resolves.toBe(plain);
+    const address = { type: "rpc" as const, worker: { binding: "AI", type: "binding" as const } };
+    await expect(resolveLiveCapability(address)).resolves.toBe(address);
+  });
+});

--- a/apps/os/src/itx/live-target.ts
+++ b/apps/os/src/itx/live-target.ts
@@ -1,0 +1,91 @@
+// The handle-side normalization of LIVE capability targets — split from
+// handle.ts so the pure wrapper logic is unit-testable without the handle's
+// server dependencies (D1 queries, the Project DO).
+
+import { RpcTarget } from "cloudflare:workers";
+import { RpcStub } from "capnweb";
+import {
+  isCapabilityAddress,
+  isLocalBareFunction,
+  replayPathCall,
+  type CapabilityTarget,
+  type PathCall,
+} from "./itx.ts";
+
+/**
+ * Normalize a live capability before it crosses to the context node. Bare
+ * functions auto-wrap. Plain objects pass through UNTOUCHED: they cross
+ * every transport by value (with their functions as stubs), the core
+ * dup-retains those member stubs at registration (itx.ts), and dispatch
+ * replays paths onto them directly — no wrapper exists.
+ *
+ * - A LOCAL function (prototype Function/AsyncFunction.prototype — never
+ *   true of an RPC stub) wraps directly.
+ * - A capnweb stub is ALWAYS a callable proxy, so a remote bare function and
+ *   a remote call-less class are indistinguishable from a call-implementing
+ *   provider by type. It is probed: `await stub.call` is a pure property
+ *   pull (no user code runs) that resolves `undefined` exactly when the
+ *   remote target implements no `call` — those get the wrapper (which both
+ *   calls and member-replays); a call-implementing provider keeps its own
+ *   call semantics. Probe failures fall back to the historical
+ *   call-convention dispatch.
+ */
+export async function resolveLiveCapability(
+  capability: CapabilityTarget,
+): Promise<CapabilityTarget> {
+  if (isCapabilityAddress(capability)) return capability;
+  if (isLocalBareFunction(capability)) {
+    return new LiveCallableCapability(capability) as unknown as CapabilityTarget;
+  }
+  if (typeof capability === "function" && (capability as object) instanceof RpcStub) {
+    const callMember = await Promise.resolve(
+      (capability as unknown as { call: unknown }).call,
+    ).then(
+      (value) => value,
+      () => "unprobeable" as const,
+    );
+    if (callMember === undefined) {
+      return new LiveCallableCapability(
+        capability as unknown as (...args: never[]) => unknown,
+      ) as unknown as CapabilityTarget;
+    }
+    (callMember as Partial<Disposable> | null | undefined)?.[Symbol.dispose]?.();
+  }
+  return capability;
+}
+
+/**
+ * The ONE wrapper for callable live targets that don't speak `call({ path,
+ * args })` themselves: bare functions AND call-less classes behind a capnweb
+ * stub. It speaks the calling convention by replaying the path on the
+ * target — an empty path calls the function; a member path pipelines onto
+ * its members (a stub materializes them; a local bare function has none and
+ * misses with the path error). Extends RpcTarget so it crosses the
+ * worker → context-node hop as a stub while the function (local or a capnweb
+ * stub of the provider's process) stays callable right here.
+ */
+export class LiveCallableCapability extends RpcTarget {
+  readonly #fn: (...args: never[]) => unknown;
+
+  constructor(fn: (...args: never[]) => unknown) {
+    super();
+    // Retain a dup when the function is itself a session stub: RPC disposes
+    // argument stubs when the provide call returns.
+    const dup = (fn as { dup?: () => (...args: never[]) => unknown }).dup;
+    this.#fn = typeof dup === "function" ? dup.call(fn) : fn;
+  }
+
+  call(input: PathCall): unknown {
+    return replayPathCall(this.#fn, input);
+  }
+
+  onRpcBroken(callback: (error: unknown) => void): void {
+    (this.#fn as { onRpcBroken?: (callback: (error: unknown) => void) => void }).onRpcBroken?.(
+      callback,
+    );
+  }
+
+  [Symbol.dispose](): void {
+    (this.#fn as Partial<Disposable>)[Symbol.dispose]?.();
+  }
+}

--- a/apps/os/src/itx/path-proxy.ts
+++ b/apps/os/src/itx/path-proxy.ts
@@ -1,22 +1,25 @@
 // The client-safe half of the ONE calling convention (Law 6).
 //
 // The kernel (itx.ts) dispatches every capability as `target.call({ path,
-// args })`. This module owns the three pure pieces of that convention that
+// args })`. This module owns the two pure pieces of that convention that
 // must load OUTSIDE workerd — withItx providers in Node and the browser
 // REPL import them at runtime, so nothing here may touch cloudflare:workers
 // (itx.ts re-exports all of it for server-side imports):
 //
 //   - PathProxy        dots → data (consumer side, zero round trips)
 //   - replayPathCall   data → dots (receiver-preserving replay)
-//   - asPathCallable   wrap a concrete object so it speaks the convention
+//
+// There is deliberately NO callsite wrapper here: a plain object (or bare
+// function) IS a live capability — the core's dispatch replays paths onto
+// its members (itx.ts). The only things at an itx callsite are capnweb /
+// Workers RPC stubs and your own objects.
 //
 // This is the only place in the codebase that plays reserved-name games.
 // Capability *names* are validated at registration time instead (itx.ts), so
 // the proxy only needs to protect protocol-level names on intermediate path
 // segments.
 
-import { RpcTarget } from "capnweb";
-import type { PathCall, PathCallable } from "./types.ts";
+import type { PathCall } from "./types.ts";
 
 // The ONE calling convention's shapes (PathCall, PathCallable) are declared
 // in types.ts — the design of record — and re-exported here for runtime
@@ -154,34 +157,4 @@ export async function replayPathCall(target: unknown, call: PathCall): Promise<u
     throw new Error(`Capability path ${call.path.join(".")} did not resolve to a function.`);
   }
   return await holder[method](...call.args);
-}
-
-/**
- * Make a member-shaped object speak the kernel's ONE calling convention:
- * `asPathCallable(obj).call({ path, args })` replays the path on `obj` via
- * {@link replayPathCall} — in THIS process, where `obj` is concrete.
- *
- * This is the CLIENT-side wrapper: a live provider wraps a plain
- * object-of-methods (or a bare function) before provideCapability()ing it —
- * the wrapper extends capnweb's RpcTarget so it crosses the session as a
- * stub, and the replay then runs back in the provider's process. Providers
- * that implement `call` themselves (the SDK-shaped FakeSlackSdk pattern)
- * don't need it. (The dial wraps the concrete objects it resolves itself with
- * plain in-process wrappers — dial.ts.)
- */
-export function asPathCallable(target: unknown): PathCallable {
-  return new ClientPathCallable(target);
-}
-
-class ClientPathCallable extends RpcTarget {
-  readonly #target: unknown;
-
-  constructor(target: unknown) {
-    super();
-    this.#target = target;
-  }
-
-  call(input: PathCall): Promise<unknown> {
-    return replayPathCall(this.#target, input);
-  }
 }

--- a/apps/os/src/itx/path-proxy.ts
+++ b/apps/os/src/itx/path-proxy.ts
@@ -136,7 +136,11 @@ function pathNode(callPath: PathProxyCall, path: string[]): Function {
  * detaching them can make workerd try to transfer the entrypoint
  * (capnweb LEARNINGS, "Preserve Receivers").
  */
-export async function replayPathCall(target: unknown, call: PathCall): Promise<unknown> {
+export async function replayPathCall(
+  target: unknown,
+  call: PathCall,
+  context?: { capability?: string },
+): Promise<unknown> {
   // Filter the path here too, not just in the consumer proxy: `invoke` is a
   // public verb, so a caller can hand-build a `path` and reach this directly.
   // This is the authoritative reserved-name gate.
@@ -146,9 +150,18 @@ export async function replayPathCall(target: unknown, call: PathCall): Promise<u
     }
   }
 
+  // A replay MISS on a known capability points the caller back at discovery
+  // — the suffix is only honest when a name exists for describe() to show.
+  const miss = (message: string) =>
+    new Error(
+      context?.capability
+        ? `${message} (capability "${context.capability}") — describe() lists what exists.`
+        : message,
+    );
+
   if (call.path.length === 0) {
     if (typeof target !== "function") {
-      throw new Error("Capability invoked as a function but the target is not callable.");
+      throw miss("Capability invoked as a function but the target is not callable.");
     }
     return await target(...call.args);
   }
@@ -157,14 +170,14 @@ export async function replayPathCall(target: unknown, call: PathCall): Promise<u
   for (const segment of call.path.slice(0, -1)) {
     parent = await (parent as Record<string, unknown>)[segment];
     if (parent == null) {
-      throw new Error(`Capability path ${call.path.join(".")} hit ${String(parent)}.`);
+      throw miss(`Capability path ${call.path.join(".")} hit ${String(parent)}.`);
     }
   }
 
   const method = call.path.at(-1)!;
   const holder = parent as Record<string, (...args: unknown[]) => unknown>;
   if (typeof holder[method] !== "function") {
-    throw new Error(`Capability path ${call.path.join(".")} did not resolve to a function.`);
+    throw miss(`Capability path ${call.path.join(".")} did not resolve to a function.`);
   }
   return await holder[method](...call.args);
 }

--- a/apps/os/src/itx/path-proxy.ts
+++ b/apps/os/src/itx/path-proxy.ts
@@ -27,6 +27,15 @@ import type { PathCall } from "./types.ts";
 export type { PathCall, PathCallable } from "./types.ts";
 
 /**
+ * The optional self-description method the core probes at provide time
+ * (itx.ts): a call-implementing target answering `call({ path:
+ * ["describeItx"], args: [] })` with `{ types?, instructions? }` describes
+ * itself into the journaled meta. Reserved below so user capability paths
+ * can never collide with the protocol name.
+ */
+export const SELF_DESCRIPTION_METHOD = "describeItx";
+
+/**
  * Names that must never traverse a dynamic surface — prototype-pollution
  * vectors, capnweb stub controls, and thenable/`Function.prototype` traps.
  * The single source of truth for BOTH the consumer-side path proxy and the
@@ -34,6 +43,7 @@ export type { PathCall, PathCallable } from "./types.ts";
  * `invoke` directly is filtered identically.
  */
 export const RESERVED_PATH_SEGMENTS: ReadonlySet<string> = new Set([
+  SELF_DESCRIPTION_METHOD,
   "__defineGetter__",
   "__defineSetter__",
   "__lookupGetter__",

--- a/apps/os/src/itx/platform-context.ts
+++ b/apps/os/src/itx/platform-context.ts
@@ -166,7 +166,7 @@ export class PlatformContext extends WorkerEntrypoint<Env, PlatformContextProps>
     return PLATFORM_PROJECT_CAPABILITIES.map((capability) => ({
       instructions: capability.instructions,
       kind: capability.address.type,
-      meta: { instructions: capability.instructions },
+      meta: {},
       name: capability.name,
       updatedAtMs: 0,
     }));
@@ -180,9 +180,13 @@ export class PlatformContext extends WorkerEntrypoint<Env, PlatformContextProps>
     );
     const resolved = resolveLongestProvidedPrefix(byName, input.path);
     if (!resolved) {
+      // This is the error every FULL-chain miss surfaces to the caller (the
+      // chain root answers last), so it must read as "nothing anywhere",
+      // not name internal plumbing like the platform:project chain id.
       throw new Error(
-        `No capability named "${input.path[0] ?? ""}" in context ${PLATFORM_PROJECT_CONTEXT_ID}` +
-          (input.path.length > 1 ? ` (call path "${input.path.join(".")}").` : `.`),
+        `No capability named "${input.path[0] ?? ""}" on this context or anywhere up its chain` +
+          (input.path.length > 1 ? ` (call path "${input.path.join(".")}").` : `.`) +
+          ` describe() lists what exists.`,
       );
     }
     const origin = input.origin ?? {

--- a/apps/os/src/itx/platform-context.ts
+++ b/apps/os/src/itx/platform-context.ts
@@ -1,10 +1,10 @@
-// The platform context: the code-rooted FINAL LINK of every project's
+// The defaults: the code-rooted FINAL LINK of every project's
 // capability chain (itx-next.md, "LOCKED: the final shape" — "Defaults live
 // on the parent chain; the root of every chain is code").
 //
 //   itx_a1b2 → project → platform:project (THIS, code)
 //
-// There is exactly ONE capability map per context; the platform defaults are
+// There is exactly ONE capability map per context; the defaults are
 // not a layer inside any instance — they are this context's provides,
 // reached by ordinary chain delegation. Shadowing, revoke-resurfaces-
 // the-default, and deploy-updates are consequences of the chain, not rules:
@@ -33,11 +33,6 @@ import { parseConfig } from "~/config.ts";
 
 export const PLATFORM_PROJECT_CONTEXT_ID = "platform:project";
 
-/** How describe() labels entries inherited from the platform context. The
- * chain id above stays internal plumbing — handles, agents, and the REPL
- * see plain `from: "platform"`. */
-export const PLATFORM_DESCRIBE_FROM = "platform";
-
 /**
  * The project worker's source: the code in the project's own config repo,
  * addressed like ANY repo-sourced capability. "latest" tracks pushes; the
@@ -52,7 +47,7 @@ export const PROJECT_WORKER_SOURCE = {
   type: "repo",
 } as const satisfies import("./itx.ts").WorkerSource;
 
-/** The platform context's own address — pure code behind a loopback name. */
+/** The defaults context's own address — pure code behind a loopback name. */
 export const PLATFORM_PROJECT_CONTEXT_ADDRESS: CapabilityAddress = {
   entrypoint: "PlatformContext",
   type: "rpc",
@@ -176,8 +171,8 @@ export type PlatformContextProps = {
 export class PlatformContext extends WorkerEntrypoint<Env, PlatformContextProps> {
   async describe(): Promise<CapabilityDescription[]> {
     // These are this context's OWN entries, so no `from` here — the project
-    // core stamps `from: "platform"` when it merges them into a chain view
-    // (Itx.describe).
+    // core stamps `from: "defaults"` (DEFAULTS_DESCRIBE_FROM, types.ts) when
+    // it merges them into a chain view (Itx.describe).
     return PLATFORM_PROJECT_CAPABILITIES.map((capability) => ({
       instructions: capability.instructions,
       kind: capability.address.type,
@@ -216,7 +211,7 @@ export class PlatformContext extends WorkerEntrypoint<Env, PlatformContextProps>
       exports: this.ctx.exports as unknown as Parameters<typeof makeDial>[0]["exports"],
       // The `worker` default is a repo SOURCE, so the chain's code root must
       // be able to load isolates (no facets: this entrypoint is stateless,
-      // and no platform default is a durable-object source).
+      // and no default is a durable-object source).
       loader: (this.env as { LOADER?: unknown }).LOADER as Parameters<typeof makeDial>[0]["loader"],
       projectId,
     });
@@ -233,21 +228,21 @@ export class PlatformContext extends WorkerEntrypoint<Env, PlatformContextProps>
 
   async provideCapability(_input: ProvideCapabilityInput): Promise<never> {
     throw new Error(
-      "The platform context is read-only — its capabilities ship with the deploy. " +
+      "The defaults are read-only — they ship with the deploy. " +
         "Provide on your own context to shadow a default.",
     );
   }
 
   async revokeCapability(_input: { name?: string; path?: string[] }): Promise<never> {
     throw new Error(
-      "The platform context is read-only — its capabilities ship with the deploy " +
+      "The defaults are read-only — they ship with the deploy " +
         "and cannot be revoked; shadow them on your own context instead.",
     );
   }
 }
 
 /** The in-process parent link a project context's core delegates to: the
- * loopback dial of the platform context, parameterized by project. */
+ * loopback dial of the defaults context, parameterized by project. */
 export function getPlatformContext(input: {
   exports: Record<string, (options: { props: Record<string, unknown> }) => unknown>;
   projectId: string;

--- a/apps/os/src/itx/platform-context.ts
+++ b/apps/os/src/itx/platform-context.ts
@@ -33,6 +33,11 @@ import { parseConfig } from "~/config.ts";
 
 export const PLATFORM_PROJECT_CONTEXT_ID = "platform:project";
 
+/** How describe() labels entries inherited from the platform context. The
+ * chain id above stays internal plumbing — handles, agents, and the REPL
+ * see plain `from: "platform"`. */
+export const PLATFORM_DESCRIBE_FROM = "platform";
+
 /**
  * The project worker's source: the code in the project's own config repo,
  * addressed like ANY repo-sourced capability. "latest" tracks pushes; the
@@ -155,12 +160,14 @@ export type PlatformContextProps = {
  */
 export class PlatformContext extends WorkerEntrypoint<Env, PlatformContextProps> {
   async describe(): Promise<CapabilityDescription[]> {
+    // These are this context's OWN entries, so no `from` here — the project
+    // core stamps `from: "platform"` when it merges them into a chain view
+    // (Itx.describe).
     return PLATFORM_PROJECT_CAPABILITIES.map((capability) => ({
       instructions: capability.instructions,
       kind: capability.address.type,
       meta: { instructions: capability.instructions },
       name: capability.name,
-      owner: PLATFORM_PROJECT_CONTEXT_ID,
       updatedAtMs: 0,
     }));
   }

--- a/apps/os/src/itx/platform-context.ts
+++ b/apps/os/src/itx/platform-context.ts
@@ -113,14 +113,15 @@ const PLATFORM_PROJECT_CAPABILITIES: PlatformCapability[] = [
     // The project's secret store — the WRITE half of the placeholder design:
     // store material once (itx.secrets.setSecret), then reference it in any
     // egress header as getSecret({ key }) and the egress pipe substitutes it
-    // server-side. getSecret here returns material to project-authorized
-    // handle holders; prefer placeholders so connected sessions never hold it.
+    // server-side. The itx surface is writes + redacted summaries ONLY —
+    // material never crosses an itx boundary (secrets-capability-call.ts).
     address: { entrypoint: "SecretsCapability", type: "rpc", worker: { type: "loopback" } },
     instructions:
       "Project secrets: itx.secrets.setSecret({ key, material }), listSecrets() " +
-      "(redacted summaries), deleteSecret({ key }). Reference a stored secret in any " +
-      'egress header as getSecret({ key: "…" }) — substitution happens server-side ' +
-      "in the egress pipe, so scripts and connected sessions never handle the material.",
+      "(redacted summaries), getSecretSummaryByKey({ key }), deleteSecret({ key }). " +
+      'Reference a stored secret in any outbound-HTTP header as getSecret({ key: "…" }) ' +
+      "— the platform substitutes the real value inside its own outbound-HTTP layer; " +
+      "your code only ever sees the placeholder.",
     name: "secrets",
   },
   {

--- a/apps/os/src/itx/platform-context.ts
+++ b/apps/os/src/itx/platform-context.ts
@@ -110,6 +110,20 @@ const PLATFORM_PROJECT_CAPABILITIES: PlatformCapability[] = [
     name: "streams",
   },
   {
+    // The project's secret store — the WRITE half of the placeholder design:
+    // store material once (itx.secrets.setSecret), then reference it in any
+    // egress header as getSecret({ key }) and the egress pipe substitutes it
+    // server-side. getSecret here returns material to project-authorized
+    // handle holders; prefer placeholders so connected sessions never hold it.
+    address: { entrypoint: "SecretsCapability", type: "rpc", worker: { type: "loopback" } },
+    instructions:
+      "Project secrets: itx.secrets.setSecret({ key, material }), listSecrets() " +
+      "(redacted summaries), deleteSecret({ key }). Reference a stored secret in any " +
+      'egress header as getSecret({ key: "…" }) — substitution happens server-side ' +
+      "in the egress pipe, so scripts and connected sessions never handle the material.",
+    name: "secrets",
+  },
+  {
     address: { entrypoint: "ReposCapability", type: "rpc", worker: { type: "loopback" } },
     instructions:
       "The project's git repos: itx.repos.ensureProjectRepoInfo({ projectSlug }), " +

--- a/apps/os/src/itx/types.ts
+++ b/apps/os/src/itx/types.ts
@@ -354,9 +354,8 @@ export type ItxDescription = {
   /** Attribution: which capability's isolate holds this handle, if any
    * (the dotted route). */
   capabilityPath?: string;
-  /** The merged capability chain (own caps first, ancestors' after,
-   * shadowed names carry `owner` provenance), including each cap's
-   * `instructions`. */
+  /** The merged capability chain (own caps first, ancestors' after —
+   * inherited entries carry `from`), including each cap's `instructions`. */
   capabilities: CapabilityDescription[];
   /** The bound project's own description, if this handle has one. */
   project: unknown | null;
@@ -579,8 +578,10 @@ export type CapabilityDescription = {
   name: string;
   /** The target's kind: "live" | "rpc" | "url". */
   kind: CapabilityKind;
-  /** Which context owns the entry — provenance for shadowing visibility. */
-  owner: string;
+  /** INHERITED entries only: which chain link the entry comes from — a
+   * context id, or `"platform"` for the code-rooted defaults. The described
+   * context's own entries carry no provenance field at all. */
+  from?: string;
   /** Live caps only: is the provider currently connected? */
   connected?: boolean;
   /** Lifted from meta for convenience: the one thing to read first. */

--- a/apps/os/src/itx/types.ts
+++ b/apps/os/src/itx/types.ts
@@ -502,29 +502,36 @@ export type WorkerSource = (
  * The kernel knows exactly ONE calling convention: every capability is
  * dispatched as `target.call({ path, args })`. Whether a dotted path is
  * replayed onto a real member tree is decided at the EDGE where the
- * concrete object lives, never by core data:
+ * concrete object lives, never by core data — and the default is always
+ * "your object IS the capability":
  *
- * - The dial wraps the objects it resolves itself — env bindings, loader
- *   entrypoints, facets — with its own plain in-process wrapper (dial.ts),
- *   so a source cap just exports methods and its whole public surface is
- *   replayed:
+ * - A LIVE provider is just the value you pass: a plain object of methods
+ *   (nested as deep as you like) has the dotted path replayed onto its
+ *   members, back in the process where they live; a bare function is called
+ *   directly. No wrapper, no client library:
  *
  * ```ts
- * // source worker: class extends WorkerEntrypoint { add({a,b}) { … } }
- * itx.myCap.add({ a: 1, b: 2 })  // → wrap replays ["add"] on the entrypoint
+ * await itx.provideCapability({
+ *   name: "answer",
+ *   capability: { ultimate: () => 42, deep: { thought: (q) => think(q) } },
+ * });
+ * itx.answer.deep.thought("…")   // replays ["deep","thought"] on YOUR object
  * ```
  *
- * - A LIVE provider either implements `call` itself (the SDK shape — own
- *   your method-tree semantics; the public SDK docs become the tool docs)
- *   or wraps a plain object-of-methods with `asPathCallable` before
- *   providing (the replay then runs back in the provider's process):
+ * - A live provider that implements `call` itself owns its whole
+ *   method-tree semantics instead (the SDK shape — the public SDK docs
+ *   become the tool docs, with a ten-line forwarder):
  *
  * ```ts
  * // provider: class { call({ path, args }) { return slackApi(path.join("."), args[0]); } }
  * itx.slack.chat.postMessage({ … })   // → ONE call: call({ path: ["chat","postMessage"], … })
- *
- * await itx.provideCapability({ name: "mac", capability: asPathCallable({ run(src) { … } }) });
  * ```
+ *
+ * - The dial wraps the objects it resolves itself — env bindings, loader
+ *   entrypoints, facets — with its own plain in-process wrapper (dial.ts),
+ *   so a source cap just exports methods and its whole public surface is
+ *   replayed: `itx.myCap.add({ a: 1, b: 2 })` replays ["add"] on the
+ *   entrypoint.
  *
  * - Forwarders pick their INNER mode themselves: UrlDial always replays
  *   the path as capnweb member pipelining against the remote main.

--- a/apps/os/src/itx/types.ts
+++ b/apps/os/src/itx/types.ts
@@ -206,7 +206,7 @@ export interface ItxBuiltins {
   }): Promise<CapabilityProvision>;
 
   /** Remove an entry — exact path match, never prefix; `name`/`path` as in
-   * {@link provideCapability}. Platform defaults cannot be revoked, only
+   * {@link provideCapability}. The defaults cannot be revoked, only
    * shadowed (revoking a shadow resurfaces the default). */
   revokeCapability(input: { name?: string; path?: string[] }): Promise<void>;
 
@@ -227,7 +227,7 @@ export interface ItxBuiltins {
 
   /**
    * Event streams, keyed by `(namespace, path)`. On a PROJECT handle this
-   * is a platform default cap (StreamsCapability loopback, shadowable) pinned to
+   * is a default cap (StreamsCapability loopback, shadowable) pinned to
    * the project's namespace; on a GLOBAL handle it is kernel — the
    * deployment-wide `"global"` namespace gated on the connect-time access
    * set, which no cap definition can express. See {@link StreamRef} for
@@ -239,12 +239,12 @@ export interface ItxBuiltins {
    * is no separate "project object"; a narrowed itx IS the project. */
   readonly projects: ItxProjects;
 
-  /** PLATFORM DEFAULT, not kernel (§8 shipped): the project's git repos —
+  /** A DEFAULT, not kernel (§8 shipped): the project's git repos —
    * an ordinary `platform:project` cap definition (ReposCapability
    * loopback), shadowable like any inherited cap. Surface unchanged. */
   readonly repos: unknown;
 
-  /** PLATFORM DEFAULT, not kernel: workspace readFile/writeFile and the
+  /** A DEFAULT, not kernel: workspace readFile/writeFile and the
    * flat git methods (gitClone/gitAdd/gitCommit/gitPush/gitStatus — nested
    * RpcTargets do not survive RPC boundaries). Context-scoped: chain
    * delegation carries the ORIGINATING context, so an extended child context
@@ -252,7 +252,7 @@ export interface ItxBuiltins {
    * `platform:project`. */
   readonly workspace: unknown;
 
-  /** PLATFORM DEFAULT, not kernel: the project's own worker — an ordinary
+  /** A DEFAULT, not kernel: the project's own worker — an ordinary
    * `{ type: "repo" }` source provide pointed at the project repo, built
    * per commit. `itx.worker.someTool(args)` reaches any public method of
    * its default export. */
@@ -263,7 +263,7 @@ export interface ItxBuiltins {
   readonly project: unknown;
 
   /**
-   * PLATFORM DEFAULT, not kernel: explicit project egress, as sugar over the
+   * A DEFAULT, not kernel: explicit project egress, as sugar over the
    * context's `fetch` capability (`platform:project` defines the default).
    * The default pipe substitutes secret placeholders inside the project's
    * egress hop — `'Bearer getSecret({ key: "X_TOKEN" })'` in a header never
@@ -307,8 +307,8 @@ export interface ItxBuiltins {
    * A handle on the PARENT context — the "call next()" of middleware: a
    * `fetch` shadow delegates to the unshadowed pipe via
    * `itx.super.fetch(request)`. An extension's parent comes from its birth
-   * certificate; the project context's parent is the platform context (the
-   * chain's read-only code root).
+   * certificate; the project context's parent is the defaults (the chain's
+   * read-only code root).
    */
   readonly super: ItxHandle;
 }
@@ -574,14 +574,21 @@ export type CapabilityMeta = {
 /** A capability's kind is its provider's kind. */
 export type CapabilityKind = "live" | "rpc" | "url";
 
+/** How describe() labels entries inherited from the defaults — the
+ * code-rooted final link of every chain (platform-context.ts). The internal
+ * chain id stays internal plumbing; handles, agents, and the REPL see plain
+ * `from: "defaults"`: an inherited default you can shadow. */
+export const DEFAULTS_DESCRIBE_FROM = "defaults";
+
 /** A capability entry as reported by `describe()`. Never contains live stubs. */
 export type CapabilityDescription = {
   name: string;
   /** The target's kind: "live" | "rpc" | "url". */
   kind: CapabilityKind;
   /** INHERITED entries only: which chain link the entry comes from — a
-   * context id, or `"platform"` for the code-rooted defaults. The described
-   * context's own entries carry no provenance field at all. */
+   * context id, or `"defaults"` ({@link DEFAULTS_DESCRIBE_FROM}) for the
+   * code-rooted defaults. The described context's own entries carry no
+   * provenance field at all. */
   from?: string;
   /** Live caps only: is the provider currently connected? */
   connected?: boolean;

--- a/apps/os/src/itx/types.ts
+++ b/apps/os/src/itx/types.ts
@@ -554,8 +554,9 @@ export type LiveStub = object;
  * surfaces it in `describe()` — there is no schema. Two conventions worth
  * following, a pair: `instructions` for the human/agent (a sentence on what
  * the cap does and how to call it) and `types` for the machine/editor
- * (TypeScript declarations of the cap's surface). Both are lifted by
- * `describe()`.
+ * (TypeScript declarations of the cap's surface). Both are LIFTED to the
+ * entry's top level by `describe()` and removed from the projected meta —
+ * each fact appears once (the journal record keeps the full meta).
  */
 export type CapabilityMeta = {
   /** Shown in describe(); write it for the agent who finds this cap. */
@@ -584,10 +585,12 @@ export type CapabilityDescription = {
   from?: string;
   /** Live caps only: is the provider currently connected? */
   connected?: boolean;
-  /** Lifted from meta for convenience: the one thing to read first. */
+  /** Lifted from meta: the one thing to read first. */
   instructions?: string;
   /** Lifted from meta: TypeScript declarations for the cap's surface. */
   types?: string;
+  /** The provide's remaining meta (e.g. `http`); `instructions`/`types`
+   * live at the top level, not in here. */
   meta: CapabilityMeta;
   updatedAtMs: number;
 };

--- a/apps/os/src/lib/worker-env.d.ts
+++ b/apps/os/src/lib/worker-env.d.ts
@@ -11,6 +11,7 @@ type WorkerMainModule = Pick<
     | "GmailCapability"
     | "ItxEntrypoint"
     | "EgressPipe"
+    | "OpenApiClient"
     | "ProjectEgress"
     | "ProjectIngressEntrypoint"
     | "ProjectMcpServerEntrypoint"

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -50,6 +50,7 @@ export { AgentToolsCapability } from "~/domains/agents/entrypoints/agent-tools-c
 export { GmailCapability } from "~/domains/google/entrypoints/gmail-capability.ts";
 export { BindingCapability, EgressPipe, ItxEntrypoint, ProjectEgress } from "~/itx/entrypoint.ts";
 export { McpClient } from "~/itx/capabilities/mcp-client.ts";
+export { OpenApiClient } from "~/itx/capabilities/openapi-client.ts";
 export { UrlDial } from "~/itx/capabilities/url-dial.ts";
 export { StreamsCapability } from "~/itx/capabilities/streams.ts";
 export { ItxDurableObject } from "~/itx/itx-durable-object.ts";


### PR DESCRIPTION
Follow-up to the itx address unification (#1493).

## Motivation

> we're allergic to weird wrappers and helpers that aren't just a capnweb or workers rpc stub at the itx callsite

and

> what is this `owner: "platform:project"` everywhere when i do itx.describe()?

Two purity fixes: the last callsite wrapper (`asPathCallable`) is deleted, and `describe()` stops stamping internal provenance ids on every entry.

## 1. A plain object IS a capability — `asPathCallable` deleted

Dispatch decides now: in the core's live-cap borrow (`itx.ts#borrow`), a live target that does not implement `call({ path, args })` as a function gets the remaining path replayed onto its members via `replayPathCall` — in the process where the object lives (its functions cross the session as stubs). A `call`-implementing provider keeps its documented semantics (one `call` owns the whole method tree — the SDK shape); bare functions are unchanged.

**Before:**

```ts
await itx.provideCapability({
  name: "answer",
  capability: asPathCallable({ ultimate: () => 42, deep: { thought: (q) => think(q) } }),
});
```

**After:**

```ts
await itx.provideCapability({
  name: "answer",
  capability: { ultimate: () => 42, deep: { thought: (q) => think(q) } },
});
await itx.answer.deep.thought("…"); // replays ["deep","thought"] on YOUR object
```

`asPathCallable` is gone everywhere: the export (path-proxy.ts), the re-exports (itx.ts, client.ts), the REPL scope + editor global, the matrix/CLI runtime scopes, and the docs. `replayPathCall` stays — server-side machinery, not a callsite wrapper. New unit tests cover plain-object dispatch at depth, the one-`call` SDK contract (members never traversed), and the unchanged bare-function path.

## 2. `describe()` drops the owner noise

Own entries carry **no provenance field**; inherited entries carry `from: <owner>`, stamped exactly one level below the entry's owner as the chain merges. The platform context renders as plain `"platform"` — `PLATFORM_PROJECT_CONTEXT_ID` stays internal. Journal records keep their `owner` field unchanged (data); this is a `describe()`-projection change only.

**Before:**

```jsonc
[
  { "name": "slack", "kind": "live", "owner": "prj_abc123" },
  { "name": "fetch", "kind": "rpc", "owner": "platform:project" },
]
```

**After:**

```jsonc
[
  { "name": "slack", "kind": "live" }, // yours — nothing to say
  { "name": "fetch", "kind": "rpc", "from": "platform" },
]
```

## 3. The catalogue teaches the new model

Added:

- **provide-plain-object** — a nested plain object provided directly, called at depth via the fallthrough (matrix-tested in browser/node/cli).
- **journal-is-the-record** — provide + revoke, then read the context's own `/itx` journal showing the `capability-provided`/`capability-revoked` events (matrix-tested across all five runtimes).
- **fetch-middleware** — a plain-function `fetch` shadow on an extension delegating via `itx.super.fetch(request)`; excluded from the matrix (external echo dependency) with the locked middleware acceptance e2e covering the behavior.
- **repo-sourced-capability** — commit a module to the project's repo, provide `{ type: "repo", commit: "latest", … }` pointing at it; excluded from the matrix (real git push + per-commit build + the ~10s "latest" probe window) with the repo-source litmus e2e covering it.

Rewritten: **provide-live-capability** and **extend-child-context** now pass plain objects, and the extend example teaches the new `from` provenance.

## 4. Sharp edges filed down

- `describe()` entries no longer say everything twice: `instructions`/`types` are lifted to the top level and removed from the projected `meta` (`meta.http` etc. stay; journal keeps the full meta).
- The full-chain miss error stopped naming `platform:project`; it now ends with "describe() lists what exists."
- `CapabilityOfflineError` names the real verb (`provideCapability()`).
- The revoke-an-inherited-entry refusal says "the platform defaults" / "context <id>" instead of pasting a raw owner string.

Reported, not fixed (bigger than a papercut): a capnweb stub of an RpcTarget **object** without `call` is still normalized at the handle as a bare-function capability (deep member calls fail with the remote transport's error instead of member replay) — fixing it needs a handle-side member-replay wrapper with dup/teardown semantics.

## Testing

`pnpm typecheck && pnpm lint && pnpm format && pnpm test` plus the workerd suites (`test:project-ingress`, `test:itx-stream-subscribe`, `test:project-mcp-server-connection`) green on every commit. Live-provide paths through a served handle can't run against local vite dev (known capnweb-fork RpcTarget identity issue) — preview CI runs the e2e matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core itx live dispatch, describe merging, and project egress behavior, plus a narrowed itx secrets API—high blast radius but heavily covered by new unit and e2e tests.
> 
> **Overview**
> **Callsite purity:** `asPathCallable` is removed end-to-end (exports, REPL/CLI/matrix scopes, docs). Live capabilities can be **plain objects of methods**—the core replays dotted paths onto members via `replayPathCall`, with dup-retention for RPC member stubs; SDK-shaped targets that implement `call({ path, args })` are unchanged, and bare functions still auto-wrap.
> 
> **`describe()` projection:** Own capability rows no longer expose journal `owner`; inherited chain entries get **`from`** (defaults labeled **`"defaults"`**). `instructions` / `types` are lifted off projected `meta`; revoke errors and e2e assertions follow the new shape.
> 
> **New integration surfaces:** **`OpenApiClient`** loopback capability (spec fetch over egress, flat `operationId` dispatch, `describeItx` / `listOperations`, derived `types`) plus an admin-gated **`/api/itx/openapi-fixture`** and deterministic e2e. **`SecretsCapability`** gains an itx **`call`** path gated by **`resolveItxSecretsMethod`** (writes/summaries only; material reads refused). **MCP** client core gains timeouts, `describeItx`, and local handling of transport SSE GETs; egress **`fetch`** strips **`AbortSignal`** on implicit/explicit doors.
> 
> **Provide-time enrichment:** Rpc provides without caller `types` trigger a best-effort **`describeItx`** dial probe (budgeted/truncated) before journaling. Examples, browser tests, and e2e suites expand for plain-object provide, journal-as-record, MCP auth, secrets+egress, and OpenAPI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a134749b69c8bc08ea21d8135f32f7e79f897c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-12T06:40:18.241Z",
      "headSha": "23a134749b69c8bc08ea21d8135f32f7e79f897c",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27399043877",
      "shortSha": "23a1347"
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-12T06:40:02.754Z",
      "headSha": "23a134749b69c8bc08ea21d8135f32f7e79f897c",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27399043877",
      "shortSha": "23a1347"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `23a1347`
Preview: https://auth.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27399043877)
Updated: 2026-06-12T06:40:18.241Z

### OS
Status: released
Commit: `23a1347`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27399043877)
Updated: 2026-06-12T06:40:02.754Z
<!-- /CLOUDFLARE_PREVIEW -->