### PR TITLE
itx hotfix: provide is a pure journal append (fixes agents broken on prd)

### DIFF
--- a/apps/os/docs/itx-explainer.html
+++ b/apps/os/docs/itx-explainer.html
@@ -1,2960 +1,4522 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>itx — the iterate context, from scratch</title>
-<style>
-:root {
-  --bg: #fcfcfb;
-  --ink: #1c1e21;
-  --muted: #6b7280;
-  --line: #e4e6ea;
-  --accent: #2456d6;
-  --accent-soft: #eef2fd;
-  --code-bg: #15181e;
-  --code-ink: #d7dce3;
-  --ok: #15803d;
-  --err: #b91c1c;
-}
-* { box-sizing: border-box; }
-html { scroll-behavior: smooth; }
-body {
-  margin: 0;
-  font: 16px/1.65 system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
-  color: var(--ink);
-  background: var(--bg);
-  -webkit-font-smoothing: antialiased;
-}
-nav#toc {
-  position: fixed; top: 0; left: 0; bottom: 0; width: 248px;
-  padding: 26px 18px; border-right: 1px solid var(--line);
-  overflow-y: auto; background: var(--bg); z-index: 10;
-}
-nav#toc .brand { font-weight: 700; font-size: 15px; margin-bottom: 2px; }
-nav#toc .brand code { background: none; padding: 0; font-size: 15px; }
-nav#toc .sub { font-size: 12px; color: var(--muted); margin-bottom: 18px; line-height: 1.4; }
-nav#toc a {
-  display: flex; gap: 8px; align-items: baseline;
-  padding: 5px 8px; margin: 1px 0; color: var(--muted); text-decoration: none;
-  border-radius: 6px; font-size: 13px; line-height: 1.35;
-}
-nav#toc a .n { font-size: 11px; font-variant-numeric: tabular-nums; opacity: .7; min-width: 16px; }
-nav#toc a:hover { color: var(--ink); background: #f1f2f4; }
-nav#toc a.active { color: var(--accent); background: var(--accent-soft); font-weight: 600; }
-main { margin-left: 248px; padding: 52px 44px 140px; max-width: 880px; }
-header.page h1 { font-size: 34px; line-height: 1.2; margin: 0 0 10px; letter-spacing: -0.02em; }
-header.page p.lede { font-size: 17.5px; color: #3a3f47; max-width: 46rem; }
-section { margin: 0 0 96px; scroll-margin-top: 28px; }
-.kicker {
-  font-size: 12px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase;
-  color: var(--accent); margin-bottom: 6px;
-}
-h2 { font-size: 26px; letter-spacing: -0.015em; margin: 0 0 14px; line-height: 1.25; }
-h3 { font-size: 18px; margin: 34px 0 10px; }
-p, li { max-width: 46rem; }
-li { margin: 4px 0; }
-hr { border: none; border-top: 1px solid var(--line); margin: 40px 0; }
-code {
-  background: #eef0f3; padding: 1px 5px; border-radius: 5px;
-  font: 0.86em ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-}
-strong code { font-weight: 600; }
-figure.code { margin: 18px 0; border-radius: 10px; overflow: hidden; background: var(--code-bg); }
-figure.code figcaption {
-  font: 11.5px ui-monospace, Menlo, monospace; color: #8b93a1;
-  padding: 8px 16px 0; display: flex; justify-content: space-between; gap: 12px;
-}
-figure.code pre {
-  margin: 0; padding: 13px 18px 15px; overflow-x: auto;
-  font: 12.5px/1.6 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  color: var(--code-ink);
-}
-.tok-k { color: #82aaff; }
-.tok-s { color: #c3e88d; }
-.tok-c { color: #697283; font-style: italic; }
-.tok-n { color: #f78c6c; }
-aside.note, aside.warn {
-  border-left: 3px solid var(--accent); background: var(--accent-soft);
-  padding: 12px 18px; border-radius: 0 8px 8px 0; margin: 22px 0;
-  font-size: 14.5px; max-width: 48rem;
-}
-aside.warn { border-left-color: #b45309; background: #fdf6ec; }
-aside.note p, aside.warn p { margin: 6px 0; }
-.demo {
-  border: 1px solid var(--line); border-radius: 12px; padding: 16px 18px 18px;
-  margin: 26px 0; background: #fff; box-shadow: 0 1px 2px rgba(20,24,33,.04);
-}
-.demo > .dtitle {
-  font-size: 11px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase;
-  color: var(--muted); margin-bottom: 12px;
-}
-.demo > .dtitle .live { color: var(--ok); }
-.toolbar { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 12px; align-items: center; }
-.toolbar .sep { width: 1px; align-self: stretch; background: var(--line); margin: 0 4px; }
-button {
-  font: 13px system-ui, sans-serif; padding: 6px 12px; cursor: pointer;
-  border: 1px solid #c9d0da; background: #f8fafc; border-radius: 7px; color: var(--ink);
-}
-button:hover { border-color: var(--accent); color: var(--accent); }
-button.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
-button.primary:hover { background: #1d47b4; color: #fff; }
-input[type=text], select {
-  font: 13px ui-monospace, Menlo, monospace; padding: 6px 9px;
-  border: 1px solid #c9d0da; border-radius: 7px; background: #fff; color: var(--ink);
-}
-.panes { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-top: 10px; }
-.panes.three { grid-template-columns: 1fr 1fr 1fr; }
-.pane { border: 1px solid var(--line); border-radius: 9px; background: #fbfbfa; min-width: 0; }
-.pane > h4 {
-  margin: 0; padding: 7px 11px; font-size: 10.5px; font-weight: 700;
-  text-transform: uppercase; letter-spacing: .07em; color: var(--muted);
-  border-bottom: 1px solid var(--line);
-}
-.pane > .body {
-  padding: 8px 11px; font: 12px/1.6 ui-monospace, Menlo, monospace;
-  max-height: 280px; overflow: auto; white-space: pre-wrap; word-break: break-word;
-}
-.pane .empty { color: #9aa1ac; font-style: italic; }
-.jev { padding: 2px 0; border-bottom: 1px dashed #ececea; }
-.jev:last-child { border-bottom: none; }
-.jev .off { color: var(--muted); margin-right: 6px; font-variant-numeric: tabular-nums; }
-.jev .jtype { color: var(--accent); font-weight: 600; margin-right: 6px; }
-.jev .jp { color: #4b5563; }
-.jev.hl { background: #fef6e0; }
-.capRow { padding: 3px 0; border-bottom: 1px dashed #ececea; }
-.capRow:last-child { border-bottom: none; }
-.capRow .cname { font-weight: 700; }
-.capRow .ckind { color: #7c3aed; margin-left: 6px; }
-.capRow .cfrom { color: var(--muted); margin-left: 6px; }
-.capRow .cconn { margin-left: 6px; }
-.capRow .cconn.on { color: var(--ok); }
-.capRow .cconn.off { color: var(--err); }
-.capRow .cinstr { color: #6b7280; display: block; }
-.log .line { padding: 2px 0; }
-.log .line.ok { color: var(--ok); }
-.log .line.err { color: var(--err); }
-.log .line .arrow { color: var(--muted); }
-.chain { display: grid; grid-template-columns: 1fr 1fr 1.1fr; gap: 12px; margin-top: 12px; }
-.chainNode { border: 1px solid var(--line); border-radius: 10px; background: #fbfbfa; min-width: 0; }
-.chainNode > header {
-  padding: 8px 11px; border-bottom: 1px solid var(--line);
-  font: 11px ui-monospace, Menlo, monospace;
-}
-.chainNode > header .cid { font-weight: 700; font-size: 12px; display: block; }
-.chainNode > header .role { color: var(--muted); }
-.chainNode > .caps { padding: 7px 8px; }
-.capEntry {
-  padding: 3px 8px; border-radius: 6px; margin: 2px 0;
-  font: 11.5px ui-monospace, Menlo, monospace;
-}
-.capEntry.win { outline: 2px solid var(--accent); background: var(--accent-soft); font-weight: 700; }
-.capEntry .k { color: #7c3aed; }
-.chainArrow { text-align: center; font-size: 11px; color: var(--muted); padding-top: 4px; }
-svg.diagram { width: 100%; height: auto; margin: 18px 0; }
-svg.diagram .box { fill: #fff; stroke: #c9d0da; stroke-width: 1.2; rx: 8; }
-svg.diagram .box.accent { stroke: var(--accent); fill: var(--accent-soft); }
-svg.diagram .box.dark { fill: var(--code-bg); stroke: var(--code-bg); }
-svg.diagram text { font: 12.5px system-ui, sans-serif; fill: var(--ink); }
-svg.diagram text.small { font-size: 10.5px; fill: var(--muted); }
-svg.diagram text.mono { font-family: ui-monospace, Menlo, monospace; font-size: 11px; }
-svg.diagram text.onDark { fill: #d7dce3; }
-svg.diagram line, svg.diagram path.arrow { stroke: #9aa1ac; stroke-width: 1.3; fill: none; }
-dl.gloss { max-width: 48rem; }
-dl.gloss dt { font-weight: 700; margin-top: 16px; }
-dl.gloss dt code { font-weight: 700; }
-dl.gloss dd { margin: 3px 0 0 0; color: #3a3f47; }
-table.plain { border-collapse: collapse; font-size: 14px; margin: 16px 0; }
-table.plain th, table.plain td { border: 1px solid var(--line); padding: 6px 12px; text-align: left; vertical-align: top; }
-table.plain th { background: #f5f6f8; font-size: 12.5px; }
-table.plain td code { white-space: nowrap; }
-footer.page { border-top: 1px solid var(--line); padding-top: 28px; color: var(--muted); font-size: 14px; }
-footer.page ul { padding-left: 20px; }
-@media (max-width: 1020px) {
-  nav#toc { position: static; width: auto; border-right: none; border-bottom: 1px solid var(--line); }
-  main { margin-left: 0; padding: 32px 20px 100px; }
-  .panes, .panes.three, .chain { grid-template-columns: 1fr; }
-}
-</style>
-</head>
-<body>
-
-<nav id="toc">
-  <div class="brand"><code>itx</code> — from scratch</div>
-  <div class="sub">the iterate context: every term, every mechanic, one page. Works offline; all demos run locally.</div>
-  <a href="#why"><span class="n">0</span> Why: authority is held, not configured</a>
-  <a href="#table"><span class="n">1</span> A table of capabilities</a>
-  <a href="#convention"><span class="n">2</span> One calling convention</a>
-  <a href="#journal"><span class="n">3</span> The journal is the only authority</a>
-  <a href="#stubs"><span class="n">4</span> Live vs durable: stubs &amp; addresses</a>
-  <a href="#chain"><span class="n">5</span> The chain: extend, shadow, super</a>
-  <a href="#dial"><span class="n">6</span> The dial</a>
-  <a href="#identity"><span class="n">7</span> Identity is a stream coordinate</a>
-  <a href="#source"><span class="n">8</span> Code is a capability</a>
-  <a href="#describe"><span class="n">9</span> Self-description</a>
-  <a href="#doctrine"><span class="n">10</span> Extending the platform</a>
-  <a href="#glossary"><span class="n">11</span> Glossary</a>
-</nav>
-
-<main>
-
-<header class="page">
-  <h1><code>itx</code> — the iterate context, built up from a Map</h1>
-  <p class="lede">
-    This page constructs the itx system one concept at a time, starting from ten lines of
-    JavaScript and ending at the real implementation in <code>apps/os/src/itx/</code>. A
-    miniature but faithful core — same fold, same dispatch, same chain — runs inside this page
-    and powers every demo. Where the page simplifies, it says so inline; everything stated as
-    the real API is checked against <code>types.ts</code> (the design of record),
-    <code>itx.ts</code> (the core), and <code>examples.ts</code> (the live recipe catalogue).
-  </p>
-</header>
-
-<!-- ============================================================ 0 WHY -->
-<section id="why">
-  <div class="kicker">Section 0</div>
-  <h2>Why: authority should be held, not configured</h2>
-  <p>
-    The platform is full of actors that need to offer each other abilities. An agent needs the
-    project's repos and an AI model. A script needs to read a stream. Your laptop wants to lend
-    its Swift toolchain to an agent for an afternoon. A browser tab wants to intercept every
-    outbound HTTP request of one session. Code committed to a project's repo wants to be
-    callable as a tool. A third-party server across the internet wants in too. Wiring these
-    pairwise — Slack-to-agent, laptop-to-REPL, repo-to-worker, each with its own registration
-    protocol, its own auth, its own discovery — grows quadratically and every edge invents its
-    own permission model. The classical fix is <em>configuration</em>: central registries,
-    scopes, API keys sprinkled through env vars. itx takes the capability-systems answer
-    instead: <strong>authority is held, not configured</strong>. There is one kind of node — a
-    <strong>context</strong>, an addressable object that holds named capabilities — and one
-    kind of reference to it — an <strong>itx handle</strong>. Whoever holds a handle can call
-    what the context holds; providing, calling, describing, and overriding are the same four
-    verbs for every actor in the picture. Auth happens once, at connect; after that,
-    <em>which context your handle points at</em> is the entire permission model.
-  </p>
-
-  <svg class="diagram" viewBox="0 0 760 330" role="img" aria-label="Actors around a context node">
-    <rect class="box accent" x="280" y="125" width="200" height="80" rx="10"/>
-    <text x="380" y="158" text-anchor="middle" font-weight="700">a context</text>
-    <text x="380" y="178" text-anchor="middle" class="mono">prj_demo · holds capabilities</text>
-
-    <rect class="box" x="40"  y="30"  width="170" height="52" rx="8"/>
-    <text x="125" y="52" text-anchor="middle">an agent</text>
-    <text x="125" y="69" text-anchor="middle" class="small">describe() is its only sense organ</text>
-
-    <rect class="box" x="300" y="22" width="160" height="52" rx="8"/>
-    <text x="380" y="44" text-anchor="middle">your laptop</text>
-    <text x="380" y="61" text-anchor="middle" class="small">withItx() over one WebSocket</text>
-
-    <rect class="box" x="550" y="30" width="170" height="52" rx="8"/>
-    <text x="635" y="52" text-anchor="middle">a browser tab / REPL</text>
-    <text x="635" y="69" text-anchor="middle" class="small">same handle, same verbs</text>
-
-    <rect class="box" x="40"  y="245" width="170" height="52" rx="8"/>
-    <text x="125" y="267" text-anchor="middle">the project's repo</text>
-    <text x="125" y="284" text-anchor="middle" class="small">code built per commit</text>
-
-    <rect class="box" x="300" y="252" width="160" height="52" rx="8"/>
-    <text x="380" y="274" text-anchor="middle">platform services</text>
-    <text x="380" y="291" text-anchor="middle" class="small">ai · streams · secrets · …</text>
-
-    <rect class="box" x="550" y="245" width="170" height="52" rx="8"/>
-    <text x="635" y="267" text-anchor="middle">a server on the internet</text>
-    <text x="635" y="284" text-anchor="middle" class="small">a Cap'n Web URL</text>
-
-    <line x1="160" y1="82"  x2="300" y2="135"/>
-    <line x1="380" y1="74"  x2="380" y2="125"/>
-    <line x1="600" y1="82"  x2="460" y2="135"/>
-    <line x1="160" y1="245" x2="300" y2="195"/>
-    <line x1="380" y1="252" x2="380" y2="205"/>
-    <line x1="600" y1="245" x2="460" y2="195"/>
-    <text x="220" y="105" class="small">provide / call</text>
-    <text x="500" y="105" class="small">provide / call</text>
-    <text x="220" y="235" class="small">provide / call</text>
-    <text x="500" y="235" class="small">provide / call</text>
-  </svg>
-
-  <p>
-    Each arrow above is the <em>same</em> mechanism. By the end of this page you will know it
-    completely: a path-keyed capability table (§1–2), replayed from an event journal (§3),
-    holding live stubs or serializable addresses (§4), arranged in a prototype chain whose root
-    is code (§5), dispatched through one effectful function (§6), identified by stream
-    coordinates (§7), with code itself as just another capability kind (§8), self-describing
-    throughout (§9) — and a doctrine for building the next thing the same way (§10).
-  </p>
-</section>
-
-<!-- ============================================================ 1 TABLE -->
-<section id="table">
-  <div class="kicker">Section 1</div>
-  <h2>A table of capabilities</h2>
-  <p>
-    Strip everything away and the seed of the whole system is ten lines: a <code>Map</code>
-    from a name to a thing, a verb to put things in, and a verb to call them.
-  </p>
-
-  <script type="text/plain" class="code" data-title="the seed — a capability table in 10 lines" data-lang="js">
-const capabilities = new Map();
-
-function provide(name, thing) {
-  capabilities.set(name, thing);
-}
-
-function invoke(name, ...args) {
-  const cap = capabilities.get(name);
-  if (!cap) throw new Error(`No capability named "${name}"`);
-  return cap(...args);
-}</script>
-
-  <p>
-    That is already recognizably itx: <code>provide</code> doesn't care what the thing is or
-    where it came from; <code>invoke</code> doesn't care who's asking; the table is the single
-    point of indirection between them. Everything that follows is this table acquiring the
-    properties production needs — a wire-safe calling convention, durability, inheritance,
-    reach, identity, and self-description — without ever stopping being a table.
-  </p>
-
-  <div class="demo" id="demo-seed">
-    <div class="dtitle"><span class="live">●</span> live demo — the ten-line table, running here</div>
-    <div class="toolbar">
-      <button data-act="provide-greet">provide("greet", who =&gt; `hello, ${who}`)</button>
-      <button data-act="provide-dice">provide("dice", () =&gt; 1–6)</button>
-      <button data-act="provide-now">provide("now", () =&gt; ISO time)</button>
-      <span class="sep"></span>
-      <button data-act="invoke-greet" class="primary">invoke("greet", "world")</button>
-      <button data-act="invoke-dice" class="primary">invoke("dice")</button>
-      <button data-act="invoke-missing">invoke("slack") — not provided</button>
-    </div>
-    <div class="panes">
-      <div class="pane"><h4>the table</h4><div class="body" id="seed-table"></div></div>
-      <div class="pane"><h4>calls</h4><div class="body log" id="seed-log"></div></div>
-    </div>
-  </div>
-
-  <p>
-    Two things are wrong with the seed, and fixing them produces the next two sections. First,
-    the value side is a bare function — real capabilities are whole API surfaces
-    (<code>slack.chat.postMessage</code>), so we need a calling convention that carries
-    <em>structure</em> (§2). Second, the table lives in memory — restart and it's gone, and
-    there is no record of who put what there. The fix is not "add a database"; it's that the
-    table stops being written at all and becomes a <em>fold over events</em> (§3).
-  </p>
-</section>
-
-<!-- ============================================================ 2 CONVENTION -->
-<section id="convention">
-  <div class="kicker">Section 2</div>
-  <h2>One calling convention: <code>call({ path, args })</code></h2>
-  <p>
-    The kernel knows exactly one way to call anything. Every dispatch in the system — every
-    capability, every transport, every host — bottoms out in:
-  </p>
-
-  <script type="text/plain" class="code" data-title="types.ts — the ONE wire shape" data-lang="ts">
-type PathCall = { path: string[]; args: unknown[] };
-
-/** What every dispatched capability target implements. */
-type PathCallable = { call(input: PathCall): unknown };</script>
-
-  <p>
-    Two pure functions convert between dots and data, and they are the only places paths are
-    interpreted:
-  </p>
-  <ul>
-    <li>
-      <strong>Dots become data — <code>PathProxy</code></strong> (consumer side,
-      <code>path-proxy.ts</code>). A callable JS <code>Proxy</code> where property access
-      accumulates a path <em>locally</em> — zero round trips — and the terminal call fires once
-      with the accumulated <code>PathCall</code>. <code>itx.slack.chat.postMessage(msg)</code>
-      becomes <code>{ path: ["slack","chat","postMessage"], args: [msg] }</code>. The proxy
-      reads <code>then</code> as <code>undefined</code> so <code>await</code> never mistakes a
-      mid-chain node for a thenable.
-    </li>
-    <li>
-      <strong>Data becomes dots — <code>replayPathCall(target, { path, args })</code></strong>
-      (receiver side). Walk the segments on a concrete object and call the terminal method
-      <em>on its parent</em> (receivers preserved — Workers RPC methods can depend on
-      <code>this</code>). An empty path calls the target itself as a function. A shared
-      <code>RESERVED_PATH_SEGMENTS</code> set (<code>__proto__</code>, <code>constructor</code>,
-      <code>then</code>, <code>call</code>, <code>dup</code>, <code>describeItx</code>, …) is
-      filtered on <em>both</em> sides; the replay is the authoritative gate, because
-      <code>invoke</code> is public and a path can be hand-built.
-    </li>
-  </ul>
-  <p>
-    Dispatch resolves the <strong>longest provided prefix</strong> of the call path and hands
-    the <em>remainder</em> to the target. Because the convention is universal, <em>any</em>
-    shape plugs in with zero client wrapper — the choice of how a path maps onto an object
-    lives at the edge where the concrete object is, never in stored data:
-  </p>
-
-  <script type="text/plain" class="code" data-title="three provider shapes, one convention (real API — types.ts / examples.ts)" data-lang="ts">
-// 1. A bare function — the simplest provider. Calling the cap calls it
-//    (auto-wrapped at provide; an empty remainder invokes the function).
-await itx.provideCapability({
-  name: "runSwiftOnMyMac",
-  instructions: "Compile-and-run Swift on Jonas's Mac.",
-  capability: async (src) => runSwift(src),
-});
-
-// 2. A plain object of methods — nested at any depth. Dispatch replays the
-//    dotted remainder onto its members, back in YOUR process. No wrapper.
-await itx.provideCapability({
-  name: "answer",
-  capability: { ultimate: () => 42, deep: { thought: (q) => think(q) } },
-});
-await itx.answer.deep.thought("…"); // replays ["deep","thought"] on YOUR object
-
-// 3. An SDK-style class that implements call() itself — it owns its whole
-//    method tree as data (the public SDK docs become the tool docs):
-class FakeSlackSdk extends RpcTarget {
-  async call({ path, args }) {
-    return slackApi(path.join("."), args[0]);
-  }
-}
-await itx.provideCapability({ name: "slack", capability: new FakeSlackSdk() });
-await itx.slack.chat.postMessage({ channel: "C123", text: "hi" });
-// → arrives as ONE call({ path: ["chat","postMessage"], args: [msg] })</script>
-
-  <p>
-    Here is the miniature that runs this page's demos — the toy's calling-convention half,
-    extracted verbatim from the script powering every demo below:
-  </p>
-  <div class="toy-src" data-region="convention" data-title="the toy, part 1 of 3 — dots ⇄ data (running on this page)"></div>
-
-  <div class="demo" id="demo-conv">
-    <div class="dtitle"><span class="live">●</span> live demo — provide a nested plain object, watch the dispatched PathCall</div>
-    <div class="toolbar">
-      <button data-act="provide" class="primary">provideCapability({ name: "answer", capability: {…} })</button>
-      <button data-act="ultimate">itx.answer.ultimate()</button>
-      <button data-act="thought">itx.answer.deep.thought(question)</button>
-      <input type="text" id="conv-q" value="life, the universe, everything" size="30">
-    </div>
-    <div class="toolbar">
-      <span style="font-size:12.5px;color:var(--muted)">or call an arbitrary dotted path:</span>
-      <input type="text" id="conv-path" value="answer.deep.thought" size="24">
-      <button data-act="custom">call it</button>
-    </div>
-    <div class="panes">
-      <div class="pane"><h4>dispatch — what the core saw</h4><div class="body log" id="conv-dispatch"></div></div>
-      <div class="pane"><h4>result</h4><div class="body log" id="conv-log"></div></div>
-    </div>
-  </div>
-
-  <aside class="note">
-    <p>
-      <strong>Two pipelining systems compose here, and they are different things.</strong> The
-      PathProxy flattens dotted <em>names</em> into data before anything touches the network.
-      The RPC transports (Cap'n&nbsp;Web, Workers RPC) separately pipeline <em>calls</em> onto
-      returned stubs. <code>itx.streams.get("/x").append(e)</code> is one PathCall producing a
-      stub that the transport then pipelines <code>append</code> onto — still one round trip.
-    </p>
-  </aside>
-</section>
-<!-- ============================================================ 3 JOURNAL -->
-<section id="journal">
-  <div class="kicker">Section 3</div>
-  <h2>The journal is the only authority</h2>
-  <p>
-    Now make the table durable — by never writing it. In itx, <code>provideCapability</code>
-    and <code>revokeCapability</code> do not mutate a table; they <strong>append events</strong>
-    to the context's <strong>journal</strong>, an ordinary event stream. The table you saw in
-    §1 is the <strong>fold</strong> (reduce) of that stream. The complete event vocabulary
-    (<code>contract.ts</code>):
-  </p>
-
-  <script type="text/plain" class="code" data-title="contract.ts — ITX_EVENT_TYPES, the journal's entire vocabulary" data-lang="ts">
-export const ITX_EVENT_TYPES = {
-  contextCreated:           "events.iterate.com/itx/context-created",            // the birth certificate (event #1)
-  capabilityProvided:       "events.iterate.com/itx/capability-provided",        // THE write
-  capabilityRevoked:        "events.iterate.com/itx/capability-revoked",         // exact path match, never prefix
-  capabilityDisconnected:   "events.iterate.com/itx/capability-disconnected",    // record-only: a live provider's session broke
-  scriptExecutionRequested: "events.iterate.com/itx/script-execution-requested", // with enqueued:true, appending IS requesting work
-  scriptExecutionCompleted: "events.iterate.com/itx/script-execution-completed", // the pair makes at-least-once reruns detectable
-} as const;</script>
-
-  <p>What "the journal is the only authority" buys, concretely:</p>
-  <ul>
-    <li>
-      <strong>State is a fold; the checkpoint is a disposable cache.</strong> The processor's
-      storage holds <code>{ offset, state }</code> — a memo of <code>reduce</code> over the
-      journal. Delete it and replay rebuilds it, bit for bit. The record and the state cannot
-      disagree, because events are the only writes.
-    </li>
-    <li>
-      <strong>Exactly-once is a property of the fold, not of delivery.</strong> The reducer
-      takes the first birth certificate and ignores any later one; duplicate deliveries are
-      inert by offset bookkeeping. No idempotency keys as a correctness mechanism, no
-      <code>ON CONFLICT DO NOTHING</code>.
-    </li>
-    <li>
-      <strong>No initialize RPC.</strong> Creating a context is one append: mint an
-      <code>itx_…</code> id, append <code>context-created { id, name, parent: { id, address } }</code>
-      — the <strong>birth certificate</strong>, the journal's first event — and return. Nothing
-      touches the new node; it materializes lazily by consuming its own journal on first
-      dispatch.
-    </li>
-    <li>
-      <strong>"Audit log" stops existing as a separate concept.</strong> Anything that needs to
-      be auditable is an event, because events are the only writes. The journal is an ordinary
-      readable stream — every stream viewer shows it.
-    </li>
-    <li>
-      <strong>Live provides journal the EVENT too.</strong> The record outlives the session
-      (the stub itself stays an in-memory instance field, §4); after a replay the entry shows
-      up as registered-but-disconnected.
-    </li>
-  </ul>
-
-  <p>
-    Here is the toy's journal half — the same event types, the same defensive fold (a malformed
-    payload keeps the current state, so replay can never wedge on an old event shape), the same
-    append-then-catch-up write seam:
-  </p>
-  <div class="toy-src" data-region="journal" data-title="the toy, part 2 of 3 — events and the fold (running on this page)"></div>
-
-  <p>And the core class that ties parts 1 and 2 together:</p>
-  <div class="toy-src" data-region="core" data-title="the toy, part 3 of 3 — the core: provide/revoke/describe/invoke/extend (running on this page)"></div>
-
-  <aside class="note">
-    <p>
-      <strong>This miniature is the whole shape, for real.</strong> The production core —
-      <code>src/itx/itx.ts</code>, one file of roughly a thousand lines, half of them
-      explanatory comments — is exactly this fold, this longest-prefix dispatch, and this
-      chain, plus what crossing real process boundaries demands: dup-retention of live RPC
-      stubs and their session-teardown hooks, the single-flight append/catch-up seam that keeps
-      read-your-writes under concurrent writers, structural address validation, the
-      <code>describeItx</code> probe with timeouts and a 64&nbsp;KB journaled-meta budget,
-      script-execution processing, and error masking. Every demo below runs the code you just
-      read.
-    </p>
-  </aside>
-
-  <div class="demo" id="demo-journal">
-    <div class="dtitle"><span class="live">●</span> live demo — the journal and the fold are the same data, rendered two ways</div>
-    <div class="toolbar">
-      <button data-act="provide-live" class="primary">provide "clock" (live object)</button>
-      <button data-act="provide-rpc" class="primary">provide "ai" (rpc address)</button>
-      <button data-act="call-clock">itx.clock.nowMs()</button>
-      <button data-act="revoke">revokeCapability({ name: "clock" })</button>
-      <span class="sep"></span>
-      <button data-act="wipe">wipe checkpoint &amp; replay journal</button>
-      <button data-act="extend">itx.extend({ name: "scratch" })</button>
-    </div>
-    <div class="panes">
-      <div class="pane"><h4>the journal — events, the only writes</h4><div class="body" id="j3-journal"></div></div>
-      <div class="pane"><h4>state.capabilities — the fold (own entries)</h4><div class="body" id="j3-caps"></div></div>
-    </div>
-    <div class="panes" id="j3-childwrap" style="display:none">
-      <div class="pane"><h4 id="j3-childtitle">the child's journal — event #1 is its birth certificate</h4><div class="body" id="j3-childjournal"></div></div>
-      <div class="pane"><h4>activity</h4><div class="body log" id="j3-log"></div></div>
-    </div>
-    <div class="panes" id="j3-logwrap">
-      <div class="pane" style="grid-column: 1 / -1"><h4>activity</h4><div class="body log" id="j3-log2"></div></div>
-    </div>
-  </div>
-
-  <p>
-    Try the order: provide twice, call, revoke, then <em>wipe checkpoint &amp; replay</em>. The
-    demo snapshots the folded state before wiping, replays the journal from offset 0, and
-    proves the rebuilt state is byte-identical. Then <em>extend</em>: the child gets its own
-    journal whose event #1 is the birth certificate — creation was one append. This is also a
-    real, runnable fact about production — the journal is an ordinary stream you can read back:
-  </p>
-
-  <script type="text/plain" class="code" data-title="examples.ts — “the journal IS the record” (runs in every execution mode)" data-lang="ts">
-await itx.provideCapability({
-  name,
-  capability: { type: "rpc", worker: { type: "binding", binding: "AI" } },
-});
-await itx.revokeCapability({ name });
-
-// The context's journal is an ordinary stream — same read API as anything.
-const journal = await itx.streams.get("/itx").read();
-const record = journal
-  .filter((e) => Array.isArray(e.payload?.path) && e.payload.path.join(".") === name)
-  .map((e) => e.type.split("/").pop());
-return { record }; // ["capability-provided", "capability-revoked"]</script>
-
-  <p>
-    One subtlety worth naming: the write seam is <em>append, then self-ingest through the one
-    consumption door</em> — read from the checkpoint forward, fold. A provide observes its own
-    event before returning (read-your-writes), and because consumption always reads from the
-    checkpoint, events written by <em>other</em> writers (the <code>/api/itx/run</code> record
-    door, a concurrent session) interleave correctly. There is exactly one way state changes,
-    and everything goes through it.
-  </p>
-</section>
-
-<!-- ============================================================ 4 STUBS & ADDRESSES -->
-<section id="stubs">
-  <div class="kicker">Section 4</div>
-  <h2>Live vs durable: stubs and addresses</h2>
-  <p>
-    What can sit in the table? The <code>CapabilityTarget</code> union has exactly two arms,
-    and the discrimination is <em>structural</em>:
-  </p>
-
-  <script type="text/plain" class="code" data-title="types.ts — THE capability target" data-lang="ts">
-type CapabilityTarget = LiveStub | CapabilityAddress;
-
-/** A live provider's stub: a function, an object of functions, or an
- * RpcTarget. Opaque; it may arrive over Cap'n Web or Workers RPC. */
-type LiveStub = object;
-
-type CapabilityAddress =
-  | { type: "rpc"; worker: WorkerRef; entrypoint?: string; props?: Record<string, unknown> }
-  | { type: "url"; url: string; headers?: Record<string, string> }; // a Cap'n Web server across the internet
-
-type WorkerRef =
-  | { type: "binding"; binding: string }                  // anything on env: env.AI, a service binding, a queue
-  | { type: "loopback" }                                  // this worker's own exports (first-party code)
-  | { type: "durable-object"; binding: string; name: string } // dialed as itx:<projectId>:<name>
-  | { type: "source"; source: WorkerSource };             // a dynamic worker from stored source (§8)</script>
-
-  <p>
-    An <strong>address</strong> is a <em>plain</em> object — prototype
-    <code>Object.prototype</code> or <code>null</code> — carrying
-    <code>type: "rpc" | "url"</code>. <em>Everything else is live.</em> The plainness check
-    must run before any <code>.type</code> probe: property access on a capnweb stub returns a
-    truthy pipelined stub, so reading <code>.type</code> first would misclassify every live
-    capability. (A plain object with a <em>string</em> <code>type</code> that isn't
-    <code>"rpc"</code>/<code>"url"</code> is rejected loudly as a malformed address — a typo
-    must not register as an offline live cap.)
-  </p>
-
-  <h3>Live: a stub you are holding</h3>
-  <ul>
-    <li>
-      Inbound: something connected to this context and handed it a stub. The capability exists
-      exactly as long as that connection does — <strong>live caps die with the session</strong>
-      and come back when the provider reconnects and provides again. There is no durable
-      delivery on live stubs: offline means offline.
-    </li>
-    <li>
-      The stub lives in the core's in-memory instance table (dup-retained), never in the
-      journal — but the provide <em>event</em> is journaled, so after replay the entry survives
-      as registered-but-offline. <code>describe()</code> reports live entries with
-      <code>connected: true | false</code>; calling an offline one throws
-      <code>CapabilityOfflineError</code> ("…the provider must reconnect and call
-      provideCapability() again").
-    </li>
-    <li>
-      Session teardown appends <code>capability-disconnected</code> — record only; the fold
-      ignores it (connectedness is computed from the live table, never from events).
-    </li>
-  </ul>
-
-  <h3>Durable: an address — this realm's sturdy refs</h3>
-  <p>
-    The serializable kinds are the realm's <strong>SturdyRef</strong> format (in Cap'n Proto's
-    sense): pure names that can be stored in a journal and restored to a live object on demand.
-    Crucially they <strong>grant nothing by possession</strong> — they are names within a
-    trusted realm, not bearer tokens; restoring is itself gated (authority is which context
-    your handle points at, checked at connect). The one deliberate bearer-form exception is the
-    HTTP share URL (§9), at the edge only. Real address JSON, as it sits in journals:
-  </p>
-
-  <script type="text/plain" class="code" data-title="every address kind, verbatim shapes from the codebase" data-lang="ts">
-// A raw platform binding (types.ts "Thirty seconds of itx"): itx.ai.run(...)
-{ "type": "rpc", "worker": { "type": "binding", "binding": "AI" } }
-
-// A first-party loopback entrypoint, parameterized per provide via props —
-// the McpClient shape (capabilities/mcp-client.ts). Note the secret
-// PLACEHOLDER: the journal never carries material (§9).
-{
-  "type": "rpc",
-  "worker": { "type": "loopback" },
-  "entrypoint": "McpClient",
-  "props": {
-    "serverUrl": "https://docs.example.com/mcp",
-    "headers": { "authorization": "Bearer getSecret({ key: \"DOCS_TOKEN\" })" }
-  }
-}
-
-// A Durable Object, by namespace binding + instance name. The dial scopes
-// the name under the owning project — getByName("itx:<projectId>:inbox") —
-// so a name can never reach a sibling project's instances.
-{ "type": "rpc", "worker": { "type": "durable-object", "binding": "TODO", "name": "inbox" } }
-
-// A dynamic worker from stored source — code as data (§8).
-{ "type": "rpc", "worker": { "type": "source", "source": {
-    "type": "inline", "cacheKey": "greeter-v1", "mainModule": "cap.js",
-    "modules": { "cap.js": "…WorkerEntrypoint source…" } } } }
-
-// A Cap'n Web server across the internet. ONE WebSocket session per call,
-// terminating in the stateless UrlDial worker (Law 7). Headers ride the
-// handshake and pass through egress secret substitution.
-{ "type": "url", "url": "wss://caps.example.com/api",
-  "headers": { "authorization": "Bearer getSecret({ key: \"REMOTE_TOKEN\" })" } }</script>
-
-  <p>
-    Context nodes themselves are addressed with the same data structure — an address whose
-    worker ref is a Durable Object <em>is</em> "how to dial the node that owns this identity"
-    (§7). One data structure; everything is a use of it.
-  </p>
-
-  <aside class="note">
-    <p>
-      <strong>What <code>provideCapability</code> returns:</strong> a provision handle
-      <code>{ revoke(), [Symbol.dispose] }</code>. Dispose auto-revokes <em>only live</em>
-      provides — a live cap dies with its session anyway, while a durable provide must outlive
-      the session that created it (session teardown disposes every returned handle, so a
-      revoking disposer would silently undo durable provides). Also: provide-time validation is
-      <em>structural only</em> (path shape, address well-formedness). Whether an address is
-      <em>reachable</em> is the dial's authority and surfaces at first call (§6).
-    </p>
-  </aside>
-
-  <div class="demo" id="demo-stubs">
-    <div class="dtitle"><span class="live">●</span> live demo — a live stub dies with its session; an address survives</div>
-    <div class="toolbar">
-      <button data-act="provide-mac" class="primary">provide "mac" (live: { runSwift })</button>
-      <button data-act="provide-ai" class="primary">provide "ai" (durable: binding address)</button>
-      <button data-act="call-mac">itx.mac.runSwift(src)</button>
-      <button data-act="call-ai">itx.ai.run("@cf/meta/llama", …)</button>
-      <span class="sep"></span>
-      <button data-act="drop">the provider's session drops</button>
-    </div>
-    <div class="panes">
-      <div class="pane"><h4>describe() — note <code>connected</code> on live entries</h4><div class="body" id="s4-caps"></div></div>
-      <div class="pane"><h4>journal + calls</h4><div class="body log" id="s4-log"></div></div>
-    </div>
-  </div>
-</section>
-
-<!-- ============================================================ 5 CHAIN -->
-<section id="chain">
-  <div class="kicker">Section 5</div>
-  <h2>The chain: extend, shadow, super</h2>
-  <p>
-    Contexts form a <strong>prototype chain</strong>. Behaviorally, a context is a
-    prototype-chain object whose properties are capabilities: lookup walks child → parent with
-    shadowing, writes land on the node your handle points at, and
-    <code>extend()</code> is <code>Object.create(parent)</code> — it mints a cheap child
-    context with its own journal (birth certificate first, §3), whose capabilities shadow the
-    parent's and whose misses delegate the <em>whole path</em> up the chain.
-  </p>
-
-  <script type="text/plain" class="code" data-title="README scene 3 — override one method (real API)" data-lang="ts">
-const session = await itx.extend({ name: "review-run" });
-
-await session.provideCapability({
-  path: ["workspace", "gitPush"],
-  instructions: "gitPush waits for human approval; everything else is the real workspace.",
-  capability: approvalGate, // async (input) => { await approve(input); return itx.workspace.gitPush(input); }
-});
-
-// session.workspace.gitPush(...)  → the gate (the child's table wins)
-// session.workspace.readFile(...) → misses the child, falls through the
-//                                    chain to the inherited workspace
-// Hand `session` to the thing you don't fully trust; keep `itx`.</script>
-
-  <p>The rules — all consequences of the chain, not separate mechanisms:</p>
-  <ul>
-    <li>
-      <strong>Shadowing is per path.</strong> Entries live at paths;
-      <code>provideCapability({ path: ["slack","chat","postMessage"], … })</code> shadows ONE
-      subtree of an inherited cap while every other <code>slack.*</code> call falls through.
-      Longest provided prefix wins <em>per context</em>; no prefix → delegate the whole path to
-      the parent.
-    </li>
-    <li>
-      <strong>Revoke resurfaces.</strong> Revoking a shadow makes lookup reach the chain again,
-      so the inherited entry comes back — by construction. Revoking an <em>inherited</em> entry
-      is refused with a hint ("provide your own on this context to take its place; the original
-      stays on the parent"): claiming to revoke something that lives on another node would lie.
-    </li>
-    <li>
-      <strong><code>itx.super</code> is middleware's "call next()".</strong> A handle on the
-      parent context: a <code>fetch</code> shadow delegates to the unshadowed pipe via
-      <code>itx.super.fetch(request)</code>. (One priced papercut: <code>super</code> is a
-      reserved word, so <code>itx.super</code> works but destructuring it does not.)
-    </li>
-    <li>
-      <strong>Delegation carries <code>origin</code></strong> — <code>{ id, address }</code> of
-      the context the call <em>started</em> at, set by delegating nodes, never by handles. It
-      is the chain's trusted identity channel: attribution, context-scoped capabilities (the
-      workspace), and origin dial-back (§6).
-    </li>
-    <li>
-      <strong><code>describe()</code> is the merged chain view.</strong> Own entries first (no
-      provenance field — they are yours), then ancestors' entries, each stamped
-      <code>from: &lt;context id&gt;</code>. Suppression is exact-match only: a path shadow
-      like <code>sdk.chat.postMessage</code> does not hide the parent's <code>sdk</code>,
-      because that entry is still live for every other path.
-    </li>
-  </ul>
-
-  <h3>The root of every chain is code</h3>
-  <p>
-    The chain does not end in data. Every project context's <code>parentItx</code> is the
-    <strong>defaults</strong> — <code>PlatformContext</code>
-    (<code>platform-context.ts</code>), a read-only loopback <code>WorkerEntrypoint</code> that
-    answers the same four-verb context protocol as every node: <code>describe</code> and
-    <code>invoke</code> from a literal list in code, <code>provideCapability</code> /
-    <code>revokeCapability</code> refused ("The defaults are read-only — they ship with the
-    deploy"). The defaults every project inherits: <strong>ai, fetch, streams, secrets, repos,
-    workspace, worker</strong> — each with its own <code>instructions</code>, so even the
-    code-rooted defaults self-describe. In <code>describe()</code> they appear as
-    <code>from: "defaults"</code> (<code>DEFAULTS_DESCRIBE_FROM</code>, types.ts — the internal
-    <code>platform:project</code> chain id never leaves the chain).
-  </p>
-  <p>
-    Shipping a new default is a <em>deploy, not a migration</em>: the chain sees it
-    immediately; journaled rows shadow it; revoking a shadow resurfaces it. There is no
-    defaults mechanism — only the chain. And because the parent link is dialed in-process
-    (loopback), default dispatch pays no Durable Object hop.
-  </p>
-
-  <div class="demo" id="demo-chain">
-    <div class="dtitle"><span class="live">●</span> live demo — the chain: child → project → defaults (code)</div>
-    <div class="toolbar">
-      <button data-act="shadow-gitpush" class="primary">shadow workspace.gitPush on child</button>
-      <button data-act="shadow-fetch" class="primary">shadow fetch on child</button>
-      <button data-act="provide-slack">provide slack on project</button>
-      <button data-act="revoke-gitpush">revoke child's gitPush shadow</button>
-      <button data-act="revoke-default">try revoking inherited "ai" on child</button>
-      <button data-act="provide-on-defaults">try providing on the defaults</button>
-    </div>
-    <div class="toolbar">
-      <span style="font-size:12.5px;color:var(--muted)">resolve a call path:</span>
-      <input type="text" id="chain-path" value="workspace.gitPush" size="26">
-      <button data-act="resolve" class="primary">child.invoke(…)</button>
-      <button data-act="super">child.super.fetch(…) — skip the child's table</button>
-    </div>
-    <div class="chain" id="chain-viz"></div>
-    <div class="panes" style="margin-top:12px">
-      <div class="pane" style="grid-column: 1 / -1"><h4>resolution trace</h4><div class="body log" id="chain-log"></div></div>
-    </div>
-  </div>
-
-  <p>
-    The middleware acceptance test, verbatim from the example catalogue — shadow
-    <code>fetch</code> with a plain function, delegate via <code>super</code>:
-  </p>
-
-  <script type="text/plain" class="code" data-title="examples.ts — middleware: shadow fetch, delegate via itx.super (real, e2e-proven)" data-lang="ts">
-const session = await itx.extend({ name: "traced" });
-
-// The shadow is a PLAIN FUNCTION; itx.super is "call next()" — the parent
-// chain, where fetch is still the real egress pipe.
-await session.provideCapability({
-  name: "fetch",
-  instructions: "Project egress with an x-trace-id header stamped on every request.",
-  capability: async (request) => {
-    const traced = new Request(request.url ?? String(request), request);
-    traced.headers.set("x-trace-id", "itx-example-trace");
-    return await session.super.fetch(traced);
-  },
-});
-
-// Every egress on the session now carries the header — including bare
-// fetch() inside the session's isolates. Revoke the shadow and the real
-// pipe resurfaces. Middleware is just shadowing plus super.</script>
-</section>
-<!-- ============================================================ 6 DIAL -->
-<section id="dial">
-  <div class="kicker">Section 6</div>
-  <h2>The dial: the one effectful function</h2>
-  <p>
-    The core is pure structure: entries, the fold, longest-prefix dispatch, chain delegation.
-    Everything effectful is injected as <strong>one function</strong> — the dial:
-  </p>
-
-  <script type="text/plain" class="code" data-title="itx.ts — the ONE effect injected into the core" data-lang="ts">
-/** The one effect injected into the core: turn an address into something
- * speaking call({ path, args }) for THIS call. */
-type CapabilityDial = (
-  address: CapabilityAddress,
-  attribution: { capabilityPath: string; origin: ItxOrigin },
-) => PathCallable;</script>
-
-  <p>
-    <strong>The core owns structure; the dial owns reach.</strong> Every invoke, whatever it
-    looks like at the callsite, ends in one <code>call({ path, args })</code> against something
-    the dial resolved:
-  </p>
-
-  <svg class="diagram" viewBox="0 0 760 360" role="img" aria-label="Dispatch flow">
-    <rect class="box" x="20" y="20" width="330" height="56" rx="8"/>
-    <text x="185" y="43" text-anchor="middle" class="mono">await itx.slack.chat.postMessage(msg)</text>
-    <text x="185" y="62" text-anchor="middle" class="small">your code, anywhere a handle exists</text>
-
-    <rect class="box" x="20" y="110" width="330" height="56" rx="8"/>
-    <text x="185" y="133" text-anchor="middle">the handle: PathProxy → one invoke</text>
-    <text x="185" y="152" text-anchor="middle" class="mono small">invoke({ path: ["slack","chat","postMessage"], args })</text>
-
-    <rect class="box accent" x="20" y="200" width="330" height="74" rx="8"/>
-    <text x="185" y="224" text-anchor="middle" font-weight="700">node.itx() — the core</text>
-    <text x="185" y="243" text-anchor="middle" class="small">fold lookup: longest provided prefix wins</text>
-    <text x="185" y="260" text-anchor="middle" class="mono small">entry "slack" · remainder ["chat","postMessage"]</text>
-
-    <rect class="box" x="430" y="110" width="310" height="56" rx="8"/>
-    <text x="585" y="133" text-anchor="middle">miss → delegate WHOLE path to parentItx</text>
-    <text x="585" y="152" text-anchor="middle" class="small">carrying origin { id, address } — set by nodes, never handles</text>
-
-    <rect class="box" x="430" y="200" width="310" height="74" rx="8"/>
-    <text x="585" y="224" text-anchor="middle" font-weight="700">the dial: address → PathCallable</text>
-    <text x="585" y="243" text-anchor="middle" class="small">allowlists checked HERE (first call, not provide)</text>
-    <text x="585" y="260" text-anchor="middle" class="small">injects { capabilityPath, context, projectId } props</text>
-
-    <rect class="box dark" x="230" y="300" width="310" height="44" rx="8"/>
-    <text x="385" y="327" text-anchor="middle" class="mono onDark">target.call({ path: remainder, args })</text>
-
-    <line x1="185" y1="76" x2="185" y2="110"/>
-    <line x1="185" y1="166" x2="185" y2="200"/>
-    <line x1="350" y1="237" x2="430" y2="237"/>
-    <text x="390" y="230" class="small">address?</text>
-    <line x1="350" y1="228" x2="430" y2="146"/>
-    <line x1="280" y1="274" x2="330" y2="300"/>
-    <text x="200" y="292" class="small">live stub (in-memory)</text>
-    <line x1="585" y1="274" x2="500" y2="300"/>
-  </svg>
-
-  <p>Per address kind, the dial (<code>dial.ts</code>) does:</p>
-  <ul>
-    <li>
-      <strong><code>binding</code></strong> — gate on the bindings allowlist, take the concrete
-      object off <code>env</code>, wrap it in-process with the §2 replay (a binding doesn't
-      speak the convention; wrap it where it is real).
-    </li>
-    <li>
-      <strong><code>loopback</code></strong> — gate on the loopbacks allowlist, instantiate the
-      named export with <code>{ ...address.props, ...injected }</code>. Injection wins by
-      spread order: the dial-injected <code>{ capabilityPath, context, projectId }</code>
-      overwrite anything provider-supplied, which is the spoof-proofing — a provider can never
-      point a dialable loopback at someone else's project. First-party loopbacks implement
-      <code>call</code> themselves.
-    </li>
-    <li>
-      <strong><code>source</code></strong> — materialize an isolate via the Worker Loader (§8),
-      wired by <code>wireIsolateEnv</code> with <code>env.ITERATE</code> (an itx scoped to the
-      <em>origin</em> context) and <code>globalOutbound = ProjectEgress</code> (Law 5).
-      <code>exportType: "durable-object"</code> sources become <strong>facets</strong> of the
-      hosting DO with their own private SQLite.
-    </li>
-    <li>
-      <strong><code>durable-object</code></strong> — gate on the (default-empty) namespace
-      allowlist, then <code>getByName("itx:" + projectId + ":" + name)</code> — instance names
-      are scoped under the owning project, so two projects naming the same instance get
-      disjoint objects.
-    </li>
-    <li>
-      <strong><code>url</code></strong> — cross to the stateless <code>UrlDial</code> loopback
-      entrypoint, which opens <em>one</em> Cap'n Web WebSocket session per call against the
-      remote main and disposes it. Law 7: Cap'n Web terminates in the stateless worker, never
-      in a DO.
-    </li>
-  </ul>
-
-  <script type="text/plain" class="code" data-title="dial.ts — the allowlists (hardcoded defaults; config can only WIDEN)" data-lang="ts">
-const DIALABLE_BINDINGS = new Set(["AI"]);
-
-// Loopbacks listed here MUST scope strictly by the dial-injected props
-// ({ capabilityPath, context, projectId }) — never by provider props —
-// because anyone with a handle can provide a cap dialing them.
-const DIALABLE_LOOPBACKS = new Set([
-  "AgentCapability", "AgentToolsCapability", "BindingCapability", "EgressPipe",
-  "GmailCapability", "McpClient", "OpenApiClient", "ReposCapability",
-  "SecretsCapability", "SlackCapability", "StreamsCapability", "WorkspaceCapability",
-]);
-
-// Deliberately EMPTY: namespaces whose EXISTING instances matter (PROJECT,
-// STREAM, …) must not be allowlisted — itx dials would only reach fresh,
-// empty objects under the project-scoped names, never the real ones.
-const DIALABLE_DURABLE_OBJECTS = new Set([]);
-
-// resolveDialableTargets(config): defaults ∪ APP_CONFIG_ITX additions —
-// config can only widen, so a misconfigured deployment never loses
-// first-party caps.</script>
-
-  <p>
-    Reachability errors surface <em>at the capability's first call</em>, never at provide time
-    (provide is structural only). That asymmetry is deliberate: a deployment that widens its
-    allowlists never strands rows that were provided before the widening.
-  </p>
-
-  <p>
-    <strong>Origin dial-back</strong>, the dial's subtlest consequence: a source capability's
-    isolate is wired to the <em>originating</em> context, not the definition's home. Invoke an
-    inherited source cap through your extension and its bare <code>fetch()</code> climbs
-    <em>your</em> chain — shadow <code>fetch</code> on the extension and the inherited
-    capability's outbound traffic lands in your shadow, while siblings and the parent are
-    untouched. (Context <em>addresses</em> are dialed by a separate kernel restore,
-    <code>dialContext</code> in <code>journal.ts</code> — deliberately not allowlist-gated,
-    because only kernel code writes context addresses.)
-  </p>
-
-  <div class="demo" id="demo-dial">
-    <div class="dtitle"><span class="live">●</span> live demo — hand the toy dial an address, watch reach being decided</div>
-    <div class="toolbar">
-      <select id="dial-pick"></select>
-      <button data-act="dial" class="primary">dial it, then call({ path, args })</button>
-    </div>
-    <div class="panes">
-      <div class="pane"><h4>the address</h4><div class="body" id="dial-addr"></div></div>
-      <div class="pane"><h4>what the dial did</h4><div class="body log" id="dial-log"></div></div>
-    </div>
-  </div>
-</section>
-
-<!-- ============================================================ 7 IDENTITY -->
-<section id="identity">
-  <div class="kicker">Section 7</div>
-  <h2>Identity is a stream coordinate</h2>
-  <p>
-    Where does a context <em>live</em>? Its journal is an ordinary event stream, and streams
-    are keyed by <code>(namespace, path)</code>. Journals live at
-    <code>&lt;host base&gt;/itx[/&lt;child-id&gt;]</code> in the owning project's namespace:
-  </p>
-
-  <script type="text/plain" class="code" data-title="journal.ts — the coordinate system" data-lang="ts">
-// project context              (prj_x, "/itx")           — own journal, base "/"
-// extend the project           (prj_x, "/itx/itx_a")     — child under the base
-// an agent's context           (prj_x, "<agentPath>/itx/itx_b")</script>
-
-  <ul>
-    <li>
-      <strong>The DO name IS the coordinate.</strong> The generic context host
-      (<code>ItxDurableObject</code>) holds <em>no configuration</em>: its Durable Object name
-      encodes the coordinate verbatim — <code>&lt;namespace&gt;:&lt;journalPath&gt;</code> —
-      so identity, journal ref, and self-address are <em>projections of the name</em>, derived
-      and never configured. Parentage folds from the birth certificate;
-      <code>descriptor()</code> derives from state. Address, journal, and identity are three
-      parses of one string.
-    </li>
-    <li>
-      <strong><code>itx</code> is a reserved stream path segment.</strong> Domain code and user
-      streams may not write under it — the user-facing append doors refuse with one clear
-      error (<code>assertStreamPathDoesNotClaimItxSegment</code>). Journals stay readable
-      everywhere: they are ordinary streams, and every stream viewer shows them.
-    </li>
-    <li>
-      <strong>The D1 row is a directory, never the authority.</strong> Bare
-      <code>itx_…</code> refs (reconnects, <code>/api/itx/run</code>, isolate props) resolve to
-      their coordinate through the <code>itx_contexts</code> D1 catalog — D1 in its sanctioned
-      role (a directory), while parentage and state fold from the journal.
-    </li>
-    <li>
-      <strong>The project context is code-born.</strong> It is hosted by the Project DO
-      (addressed by the project id, binding <code>PROJECT</code>), its journal is
-      <code>(projectId, "/itx")</code>, and it has <em>no</em> birth certificate — its identity
-      derives from its host's name; its <code>parentItx</code> is the defaults. Only extended
-      children carry <code>context-created</code> as event #1.
-    </li>
-    <li>
-      <strong>Chain depth ≠ path depth.</strong> Extending an extension still files the
-      grandchild's journal at <code>&lt;base&gt;/itx/&lt;id&gt;</code> — the base is the
-      journal path with its own <code>/itx[/&lt;id&gt;]</code> tail removed. Parentage lives in
-      the birth certificate, not in path nesting.
-    </li>
-  </ul>
-
-  <script type="text/plain" class="code" data-title="journal.ts — context addresses: the same data structure as every capability" data-lang="ts">
-/** The Project DO hosts the project context, addressed by the project id. */
-projectContextAddress(projectId) // →
-{ type: "rpc", worker: { type: "durable-object", binding: "PROJECT", name: projectId } }
-
-/** The generic host is addressed by the journal coordinate itself. */
-childContextAddress({ namespace, path }) // →
-{ type: "rpc", worker: { type: "durable-object", binding: "ITX_CONTEXT",
-                         name: `${namespace}:${path}` } }</script>
-
-  <div class="demo" id="demo-identity">
-    <div class="dtitle"><span class="live">●</span> live demo — one name, three parses</div>
-    <div class="toolbar">
-      <button data-name="prj_01hq3v:/itx">prj_01hq3v:/itx</button>
-      <button data-name="prj_01hq3v:/itx/itx_a1b2c3">prj_01hq3v:/itx/itx_a1b2c3</button>
-      <button data-name="prj_01hq3v:/agents/slack/T123/itx/itx_d4e5f6">an agent's context</button>
-      <input type="text" id="id-name" value="prj_01hq3v:/itx/itx_a1b2c3" size="40">
-      <button data-act="parse" class="primary">parse the DO name</button>
-    </div>
-    <div class="panes">
-      <div class="pane"><h4>projections of the name</h4><div class="body" id="id-out"></div></div>
-      <div class="pane"><h4>self-address (childContextAddress)</h4><div class="body" id="id-addr"></div></div>
-    </div>
-  </div>
-
-  <p>
-    Creation, end to end (<code>extendContext</code>, <code>journal.ts</code>): mint an
-    <code>itx_…</code> id → append <code>context-created { id, name, parent: { id, address } }</code>
-    to the new journal → insert the directory row in D1 → return
-    <code>{ contextId, journal, address }</code>. Nothing dials the new node; it materializes
-    lazily by consuming its journal on first dispatch. Creating a context is literally one
-    append.
-  </p>
-</section>
-
-<!-- ============================================================ 8 SOURCE -->
-<section id="source">
-  <div class="kicker">Section 8</div>
-  <h2>Code is a capability</h2>
-  <p>
-    A <code>{ type: "source" }</code> worker ref carries <em>code as data</em>: the platform
-    materializes it into an isolate on demand. Inside that isolate, bare <code>fetch()</code>
-    IS project egress (secrets substituted server-side, invisible to the code) and
-    <code>env.ITERATE</code> is an itx scoped to the capability's home context — a capability
-    can never reach wider than where it is provided. Two source kinds:
-  </p>
-
-  <script type="text/plain" class="code" data-title="types.ts — WorkerSource (the design of record, abridged comments)" data-lang="ts">
-type WorkerSource = (
-  | {
-      // The code travels in the capability record itself. The loader caches
-      // the materialized isolate by cacheKey, so it MUST change whenever
-      // modules change; a content hash is the ideal value.
-      type: "inline";
-      cacheKey: string;
-      mainModule: string;
-      modules: Record<string, string>;
-    }
-  | {
-      // The code lives in one of the project's repos. Built per COMMIT —
-      // never per call — through @cloudflare/worker-bundler, memoized in R2
-      // by hash(repo, sha, path, bundle). A pinned commit sha makes the
-      // journal entry fully determine behavior; "latest" tracks pushes.
-      // With no `bundle`, the file at `path` IS the worker, verbatim.
-      type: "repo";
-      repo: string;
-      commit: string | "latest";
-      path: string;
-      bundle?: { minify?: boolean; externals?: string[] };
-    }
-) & {
-  entrypoint?: string; // named export; defaults to the default export
-  // "worker-entrypoint" (default): stateless, fresh isolate per call.
-  // "durable-object": stateful — a NAMED export extending DurableObject,
-  // instantiated as a facet of the DO hosting this context, with its own
-  // private SQLite that survives code upgrades.
-  exportType?: "worker-entrypoint" | "durable-object";
-  compatibilityDate?: string;
-};</script>
-
-  <h3>Repo sources build per commit, never per call</h3>
-  <p>
-    <code>build(repo@sha, path, bundle) → modules</code> is a pure function, so its output is a
-    <strong>memo</strong>, never an address. Three tiers, one key: the repo (the authority) →
-    R2 (<code>ITX_BUILD_CACHE</code>, hash-keyed immutable bundles, evictable because every
-    entry is reproducible from its key) → the Worker Loader's isolate cache (ephemeral). The
-    memo key is the content address:
-    <code>build/&lt;sha256(projectId, repo, commitOid, path, bundle, compatibilityDate)&gt;</code>.
-    Bundling runs in-process on an in-memory vfs (repo&nbsp;DO <code>readTree</code> →
-    <code>@cloudflare/worker-bundler</code> / esbuild-wasm → R2) — no clone, no workspace, no
-    filesystem. A <code>"latest"</code> commit resolves to a sha at most once per 10-second
-    window per isolate; concurrent dials of a cold key share one build instead of stampeding;
-    a failed memo write never fails the dial that just built good code.
-  </p>
-
-  <div class="demo" id="demo-memo">
-    <div class="dtitle"><span class="live">●</span> live demo — the build memo: cold key builds, warm key never does</div>
-    <div class="toolbar">
-      <button data-act="dial" class="primary">dial itx.repoGreeter.hello({ name: "world" })</button>
-      <button data-act="push">git push (new commit lands)</button>
-      <span id="memo-sha" style="font:12px ui-monospace,monospace;color:var(--muted)"></span>
-    </div>
-    <div class="panes">
-      <div class="pane"><h4>dial trace</h4><div class="body log" id="memo-log"></div></div>
-      <div class="pane"><h4>R2 memo (ITX_BUILD_CACHE)</h4><div class="body" id="memo-r2"></div></div>
-    </div>
-  </div>
-
-  <h3>The project worker is not special</h3>
-  <p>
-    The platform's only guarantee is that every project has its config repo (slug
-    <code>project</code>) with a defined file structure. The <code>worker</code> default — the
-    project's own code as a capability,
-    <code>itx.worker.someExportedFunction(args)</code> — is just an ordinary repo source
-    pointed at it. The actual literal, from <code>platform-context.ts</code>:
-  </p>
-
-  <script type="text/plain" class="code" data-title="platform-context.ts — PROJECT_WORKER_SOURCE, verbatim" data-lang="ts">
-/**
- * The project worker's source: the code in the project's own config repo,
- * addressed like ANY repo-sourced capability. "latest" tracks pushes; the
- * build is memoized per commit (source-build.ts).
- */
-export const PROJECT_WORKER_SOURCE = {
-  bundle: {},
-  commit: "latest",
-  path: "worker.js",
-  repo: "project",
-  type: "repo",
-} as const satisfies WorkerSource;</script>
-
-  <p>And the two source recipes from the example catalogue, both e2e-proven:</p>
-
-  <script type="text/plain" class="code" data-title="examples.ts — a durable stateless cap from inline source" data-lang="ts">
-await itx.provideCapability({
-  name: "greeter",
-  capability: {
-    type: "rpc",
-    worker: {
-      type: "source",
-      source: {
-        type: "inline",
-        cacheKey: "itx-example-greeter-v1", // a content version: bump when modules change
-        mainModule: "cap.js",
-        modules: {
-          "cap.js": `
-            import { WorkerEntrypoint } from "cloudflare:workers";
-            export default class extends WorkerEntrypoint {
-              hello({ name }) { return "hello, " + name; }
-              add({ a, b }) { return a + b; }
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>itx — the iterate context, from scratch</title>
+    <style>
+      :root {
+        --bg: #fcfcfb;
+        --ink: #1c1e21;
+        --muted: #6b7280;
+        --line: #e4e6ea;
+        --accent: #2456d6;
+        --accent-soft: #eef2fd;
+        --code-bg: #15181e;
+        --code-ink: #d7dce3;
+        --ok: #15803d;
+        --err: #b91c1c;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html {
+        scroll-behavior: smooth;
+      }
+      body {
+        margin: 0;
+        font:
+          16px/1.65 system-ui,
+          -apple-system,
+          "Segoe UI",
+          Roboto,
+          "Helvetica Neue",
+          sans-serif;
+        color: var(--ink);
+        background: var(--bg);
+        -webkit-font-smoothing: antialiased;
+      }
+      nav#toc {
+        position: fixed;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        width: 248px;
+        padding: 26px 18px;
+        border-right: 1px solid var(--line);
+        overflow-y: auto;
+        background: var(--bg);
+        z-index: 10;
+      }
+      nav#toc .brand {
+        font-weight: 700;
+        font-size: 15px;
+        margin-bottom: 2px;
+      }
+      nav#toc .brand code {
+        background: none;
+        padding: 0;
+        font-size: 15px;
+      }
+      nav#toc .sub {
+        font-size: 12px;
+        color: var(--muted);
+        margin-bottom: 18px;
+        line-height: 1.4;
+      }
+      nav#toc a {
+        display: flex;
+        gap: 8px;
+        align-items: baseline;
+        padding: 5px 8px;
+        margin: 1px 0;
+        color: var(--muted);
+        text-decoration: none;
+        border-radius: 6px;
+        font-size: 13px;
+        line-height: 1.35;
+      }
+      nav#toc a .n {
+        font-size: 11px;
+        font-variant-numeric: tabular-nums;
+        opacity: 0.7;
+        min-width: 16px;
+      }
+      nav#toc a:hover {
+        color: var(--ink);
+        background: #f1f2f4;
+      }
+      nav#toc a.active {
+        color: var(--accent);
+        background: var(--accent-soft);
+        font-weight: 600;
+      }
+      main {
+        margin-left: 248px;
+        padding: 52px 44px 140px;
+        max-width: 880px;
+      }
+      header.page h1 {
+        font-size: 34px;
+        line-height: 1.2;
+        margin: 0 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p.lede {
+        font-size: 17.5px;
+        color: #3a3f47;
+        max-width: 46rem;
+      }
+      section {
+        margin: 0 0 96px;
+        scroll-margin-top: 28px;
+      }
+      .kicker {
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--accent);
+        margin-bottom: 6px;
+      }
+      h2 {
+        font-size: 26px;
+        letter-spacing: -0.015em;
+        margin: 0 0 14px;
+        line-height: 1.25;
+      }
+      h3 {
+        font-size: 18px;
+        margin: 34px 0 10px;
+      }
+      p,
+      li {
+        max-width: 46rem;
+      }
+      li {
+        margin: 4px 0;
+      }
+      hr {
+        border: none;
+        border-top: 1px solid var(--line);
+        margin: 40px 0;
+      }
+      code {
+        background: #eef0f3;
+        padding: 1px 5px;
+        border-radius: 5px;
+        font:
+          0.86em ui-monospace,
+          SFMono-Regular,
+          Menlo,
+          Consolas,
+          monospace;
+      }
+      strong code {
+        font-weight: 600;
+      }
+      figure.code {
+        margin: 18px 0;
+        border-radius: 10px;
+        overflow: hidden;
+        background: var(--code-bg);
+      }
+      figure.code figcaption {
+        font:
+          11.5px ui-monospace,
+          Menlo,
+          monospace;
+        color: #8b93a1;
+        padding: 8px 16px 0;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      figure.code pre {
+        margin: 0;
+        padding: 13px 18px 15px;
+        overflow-x: auto;
+        font:
+          12.5px/1.6 ui-monospace,
+          SFMono-Regular,
+          Menlo,
+          Consolas,
+          monospace;
+        color: var(--code-ink);
+      }
+      .tok-k {
+        color: #82aaff;
+      }
+      .tok-s {
+        color: #c3e88d;
+      }
+      .tok-c {
+        color: #697283;
+        font-style: italic;
+      }
+      .tok-n {
+        color: #f78c6c;
+      }
+      aside.note,
+      aside.warn {
+        border-left: 3px solid var(--accent);
+        background: var(--accent-soft);
+        padding: 12px 18px;
+        border-radius: 0 8px 8px 0;
+        margin: 22px 0;
+        font-size: 14.5px;
+        max-width: 48rem;
+      }
+      aside.warn {
+        border-left-color: #b45309;
+        background: #fdf6ec;
+      }
+      aside.note p,
+      aside.warn p {
+        margin: 6px 0;
+      }
+      .demo {
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 16px 18px 18px;
+        margin: 26px 0;
+        background: #fff;
+        box-shadow: 0 1px 2px rgba(20, 24, 33, 0.04);
+      }
+      .demo > .dtitle {
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--muted);
+        margin-bottom: 12px;
+      }
+      .demo > .dtitle .live {
+        color: var(--ok);
+      }
+      .toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: 0 0 12px;
+        align-items: center;
+      }
+      .toolbar .sep {
+        width: 1px;
+        align-self: stretch;
+        background: var(--line);
+        margin: 0 4px;
+      }
+      button {
+        font:
+          13px system-ui,
+          sans-serif;
+        padding: 6px 12px;
+        cursor: pointer;
+        border: 1px solid #c9d0da;
+        background: #f8fafc;
+        border-radius: 7px;
+        color: var(--ink);
+      }
+      button:hover {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+      button.primary {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: #fff;
+      }
+      button.primary:hover {
+        background: #1d47b4;
+        color: #fff;
+      }
+      input[type="text"],
+      select {
+        font:
+          13px ui-monospace,
+          Menlo,
+          monospace;
+        padding: 6px 9px;
+        border: 1px solid #c9d0da;
+        border-radius: 7px;
+        background: #fff;
+        color: var(--ink);
+      }
+      .panes {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 14px;
+        margin-top: 10px;
+      }
+      .panes.three {
+        grid-template-columns: 1fr 1fr 1fr;
+      }
+      .pane {
+        border: 1px solid var(--line);
+        border-radius: 9px;
+        background: #fbfbfa;
+        min-width: 0;
+      }
+      .pane > h4 {
+        margin: 0;
+        padding: 7px 11px;
+        font-size: 10.5px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        color: var(--muted);
+        border-bottom: 1px solid var(--line);
+      }
+      .pane > .body {
+        padding: 8px 11px;
+        font:
+          12px/1.6 ui-monospace,
+          Menlo,
+          monospace;
+        max-height: 280px;
+        overflow: auto;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      .pane .empty {
+        color: #9aa1ac;
+        font-style: italic;
+      }
+      .jev {
+        padding: 2px 0;
+        border-bottom: 1px dashed #ececea;
+      }
+      .jev:last-child {
+        border-bottom: none;
+      }
+      .jev .off {
+        color: var(--muted);
+        margin-right: 6px;
+        font-variant-numeric: tabular-nums;
+      }
+      .jev .jtype {
+        color: var(--accent);
+        font-weight: 600;
+        margin-right: 6px;
+      }
+      .jev .jp {
+        color: #4b5563;
+      }
+      .jev.hl {
+        background: #fef6e0;
+      }
+      .capRow {
+        padding: 3px 0;
+        border-bottom: 1px dashed #ececea;
+      }
+      .capRow:last-child {
+        border-bottom: none;
+      }
+      .capRow .cname {
+        font-weight: 700;
+      }
+      .capRow .ckind {
+        color: #7c3aed;
+        margin-left: 6px;
+      }
+      .capRow .cfrom {
+        color: var(--muted);
+        margin-left: 6px;
+      }
+      .capRow .cconn {
+        margin-left: 6px;
+      }
+      .capRow .cconn.on {
+        color: var(--ok);
+      }
+      .capRow .cconn.off {
+        color: var(--err);
+      }
+      .capRow .cinstr {
+        color: #6b7280;
+        display: block;
+      }
+      .log .line {
+        padding: 2px 0;
+      }
+      .log .line.ok {
+        color: var(--ok);
+      }
+      .log .line.err {
+        color: var(--err);
+      }
+      .log .line .arrow {
+        color: var(--muted);
+      }
+      .chain {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1.1fr;
+        gap: 12px;
+        margin-top: 12px;
+      }
+      .chainNode {
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        background: #fbfbfa;
+        min-width: 0;
+      }
+      .chainNode > header {
+        padding: 8px 11px;
+        border-bottom: 1px solid var(--line);
+        font:
+          11px ui-monospace,
+          Menlo,
+          monospace;
+      }
+      .chainNode > header .cid {
+        font-weight: 700;
+        font-size: 12px;
+        display: block;
+      }
+      .chainNode > header .role {
+        color: var(--muted);
+      }
+      .chainNode > .caps {
+        padding: 7px 8px;
+      }
+      .capEntry {
+        padding: 3px 8px;
+        border-radius: 6px;
+        margin: 2px 0;
+        font:
+          11.5px ui-monospace,
+          Menlo,
+          monospace;
+      }
+      .capEntry.win {
+        outline: 2px solid var(--accent);
+        background: var(--accent-soft);
+        font-weight: 700;
+      }
+      .capEntry .k {
+        color: #7c3aed;
+      }
+      .chainArrow {
+        text-align: center;
+        font-size: 11px;
+        color: var(--muted);
+        padding-top: 4px;
+      }
+      svg.diagram {
+        width: 100%;
+        height: auto;
+        margin: 18px 0;
+      }
+      svg.diagram .box {
+        fill: #fff;
+        stroke: #c9d0da;
+        stroke-width: 1.2;
+        rx: 8;
+      }
+      svg.diagram .box.accent {
+        stroke: var(--accent);
+        fill: var(--accent-soft);
+      }
+      svg.diagram .box.dark {
+        fill: var(--code-bg);
+        stroke: var(--code-bg);
+      }
+      svg.diagram text {
+        font:
+          12.5px system-ui,
+          sans-serif;
+        fill: var(--ink);
+      }
+      svg.diagram text.small {
+        font-size: 10.5px;
+        fill: var(--muted);
+      }
+      svg.diagram text.mono {
+        font-family: ui-monospace, Menlo, monospace;
+        font-size: 11px;
+      }
+      svg.diagram text.onDark {
+        fill: #d7dce3;
+      }
+      svg.diagram line,
+      svg.diagram path.arrow {
+        stroke: #9aa1ac;
+        stroke-width: 1.3;
+        fill: none;
+      }
+      dl.gloss {
+        max-width: 48rem;
+      }
+      dl.gloss dt {
+        font-weight: 700;
+        margin-top: 16px;
+      }
+      dl.gloss dt code {
+        font-weight: 700;
+      }
+      dl.gloss dd {
+        margin: 3px 0 0 0;
+        color: #3a3f47;
+      }
+      table.plain {
+        border-collapse: collapse;
+        font-size: 14px;
+        margin: 16px 0;
+      }
+      table.plain th,
+      table.plain td {
+        border: 1px solid var(--line);
+        padding: 6px 12px;
+        text-align: left;
+        vertical-align: top;
+      }
+      table.plain th {
+        background: #f5f6f8;
+        font-size: 12.5px;
+      }
+      table.plain td code {
+        white-space: nowrap;
+      }
+      footer.page {
+        border-top: 1px solid var(--line);
+        padding-top: 28px;
+        color: var(--muted);
+        font-size: 14px;
+      }
+      footer.page ul {
+        padding-left: 20px;
+      }
+      @media (max-width: 1020px) {
+        nav#toc {
+          position: static;
+          width: auto;
+          border-right: none;
+          border-bottom: 1px solid var(--line);
+        }
+        main {
+          margin-left: 0;
+          padding: 32px 20px 100px;
+        }
+        .panes,
+        .panes.three,
+        .chain {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav id="toc">
+      <div class="brand"><code>itx</code> — from scratch</div>
+      <div class="sub">
+        the iterate context: every term, every mechanic, one page. Works offline; all demos run
+        locally.
+      </div>
+      <a href="#why"><span class="n">0</span> Why: authority is held, not configured</a>
+      <a href="#table"><span class="n">1</span> A table of capabilities</a>
+      <a href="#convention"><span class="n">2</span> One calling convention</a>
+      <a href="#journal"><span class="n">3</span> The journal is the only authority</a>
+      <a href="#stubs"><span class="n">4</span> Live vs durable: stubs &amp; addresses</a>
+      <a href="#chain"><span class="n">5</span> The chain: extend, shadow, super</a>
+      <a href="#dial"><span class="n">6</span> The dial</a>
+      <a href="#identity"><span class="n">7</span> Identity is a stream coordinate</a>
+      <a href="#source"><span class="n">8</span> Code is a capability</a>
+      <a href="#describe"><span class="n">9</span> Self-description</a>
+      <a href="#doctrine"><span class="n">10</span> Extending the platform</a>
+      <a href="#glossary"><span class="n">11</span> Glossary</a>
+    </nav>
+
+    <main>
+      <header class="page">
+        <h1><code>itx</code> — the iterate context, built up from a Map</h1>
+        <p class="lede">
+          This page constructs the itx system one concept at a time, starting from ten lines of
+          JavaScript and ending at the real implementation in <code>apps/os/src/itx/</code>. A
+          miniature but faithful core — same fold, same dispatch, same chain — runs inside this page
+          and powers every demo. Where the page simplifies, it says so inline; everything stated as
+          the real API is checked against <code>types.ts</code> (the design of record),
+          <code>itx.ts</code> (the core), and <code>examples.ts</code> (the live recipe catalogue).
+        </p>
+      </header>
+
+      <!-- ============================================================ 0 WHY -->
+      <section id="why">
+        <div class="kicker">Section 0</div>
+        <h2>Why: authority should be held, not configured</h2>
+        <p>
+          The platform is full of actors that need to offer each other abilities. An agent needs the
+          project's repos and an AI model. A script needs to read a stream. Your laptop wants to
+          lend its Swift toolchain to an agent for an afternoon. A browser tab wants to intercept
+          every outbound HTTP request of one session. Code committed to a project's repo wants to be
+          callable as a tool. A third-party server across the internet wants in too. Wiring these
+          pairwise — Slack-to-agent, laptop-to-REPL, repo-to-worker, each with its own registration
+          protocol, its own auth, its own discovery — grows quadratically and every edge invents its
+          own permission model. The classical fix is <em>configuration</em>: central registries,
+          scopes, API keys sprinkled through env vars. itx takes the capability-systems answer
+          instead: <strong>authority is held, not configured</strong>. There is one kind of node — a
+          <strong>context</strong>, an addressable object that holds named capabilities — and one
+          kind of reference to it — an <strong>itx handle</strong>. Whoever holds a handle can call
+          what the context holds; providing, calling, describing, and overriding are the same four
+          verbs for every actor in the picture. Auth happens once, at connect; after that,
+          <em>which context your handle points at</em> is the entire permission model.
+        </p>
+
+        <svg
+          class="diagram"
+          viewBox="0 0 760 330"
+          role="img"
+          aria-label="Actors around a context node"
+        >
+          <rect class="box accent" x="280" y="125" width="200" height="80" rx="10" />
+          <text x="380" y="158" text-anchor="middle" font-weight="700">a context</text>
+          <text x="380" y="178" text-anchor="middle" class="mono">
+            prj_demo · holds capabilities
+          </text>
+
+          <rect class="box" x="40" y="30" width="170" height="52" rx="8" />
+          <text x="125" y="52" text-anchor="middle">an agent</text>
+          <text x="125" y="69" text-anchor="middle" class="small">
+            describe() is its only sense organ
+          </text>
+
+          <rect class="box" x="300" y="22" width="160" height="52" rx="8" />
+          <text x="380" y="44" text-anchor="middle">your laptop</text>
+          <text x="380" y="61" text-anchor="middle" class="small">
+            withItx() over one WebSocket
+          </text>
+
+          <rect class="box" x="550" y="30" width="170" height="52" rx="8" />
+          <text x="635" y="52" text-anchor="middle">a browser tab / REPL</text>
+          <text x="635" y="69" text-anchor="middle" class="small">same handle, same verbs</text>
+
+          <rect class="box" x="40" y="245" width="170" height="52" rx="8" />
+          <text x="125" y="267" text-anchor="middle">the project's repo</text>
+          <text x="125" y="284" text-anchor="middle" class="small">code built per commit</text>
+
+          <rect class="box" x="300" y="252" width="160" height="52" rx="8" />
+          <text x="380" y="274" text-anchor="middle">platform services</text>
+          <text x="380" y="291" text-anchor="middle" class="small">ai · streams · secrets · …</text>
+
+          <rect class="box" x="550" y="245" width="170" height="52" rx="8" />
+          <text x="635" y="267" text-anchor="middle">a server on the internet</text>
+          <text x="635" y="284" text-anchor="middle" class="small">a Cap'n Web URL</text>
+
+          <line x1="160" y1="82" x2="300" y2="135" />
+          <line x1="380" y1="74" x2="380" y2="125" />
+          <line x1="600" y1="82" x2="460" y2="135" />
+          <line x1="160" y1="245" x2="300" y2="195" />
+          <line x1="380" y1="252" x2="380" y2="205" />
+          <line x1="600" y1="245" x2="460" y2="195" />
+          <text x="220" y="105" class="small">provide / call</text>
+          <text x="500" y="105" class="small">provide / call</text>
+          <text x="220" y="235" class="small">provide / call</text>
+          <text x="500" y="235" class="small">provide / call</text>
+        </svg>
+
+        <p>
+          Each arrow above is the <em>same</em> mechanism. By the end of this page you will know it
+          completely: a path-keyed capability table (§1–2), replayed from an event journal (§3),
+          holding live stubs or serializable addresses (§4), arranged in a prototype chain whose
+          root is code (§5), dispatched through one effectful function (§6), identified by stream
+          coordinates (§7), with code itself as just another capability kind (§8), self-describing
+          throughout (§9) — and a doctrine for building the next thing the same way (§10).
+        </p>
+      </section>
+
+      <!-- ============================================================ 1 TABLE -->
+      <section id="table">
+        <div class="kicker">Section 1</div>
+        <h2>A table of capabilities</h2>
+        <p>
+          Strip everything away and the seed of the whole system is ten lines: a <code>Map</code>
+          from a name to a thing, a verb to put things in, and a verb to call them.
+        </p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="the seed — a capability table in 10 lines"
+          data-lang="js"
+        >
+          const capabilities = new Map();
+
+          function provide(name, thing) {
+            capabilities.set(name, thing);
+          }
+
+          function invoke(name, ...args) {
+            const cap = capabilities.get(name);
+            if (!cap) throw new Error(`No capability named "${name}"`);
+            return cap(...args);
+          }
+        </script>
+
+        <p>
+          That is already recognizably itx: <code>provide</code> doesn't care what the thing is or
+          where it came from; <code>invoke</code> doesn't care who's asking; the table is the single
+          point of indirection between them. Everything that follows is this table acquiring the
+          properties production needs — a wire-safe calling convention, durability, inheritance,
+          reach, identity, and self-description — without ever stopping being a table.
+        </p>
+
+        <div class="demo" id="demo-seed">
+          <div class="dtitle">
+            <span class="live">●</span> live demo — the ten-line table, running here
+          </div>
+          <div class="toolbar">
+            <button data-act="provide-greet">provide("greet", who =&gt; `hello, ${who}`)</button>
+            <button data-act="provide-dice">provide("dice", () =&gt; 1–6)</button>
+            <button data-act="provide-now">provide("now", () =&gt; ISO time)</button>
+            <span class="sep"></span>
+            <button data-act="invoke-greet" class="primary">invoke("greet", "world")</button>
+            <button data-act="invoke-dice" class="primary">invoke("dice")</button>
+            <button data-act="invoke-missing">invoke("slack") — not provided</button>
+          </div>
+          <div class="panes">
+            <div class="pane">
+              <h4>the table</h4>
+              <div class="body" id="seed-table"></div>
+            </div>
+            <div class="pane">
+              <h4>calls</h4>
+              <div class="body log" id="seed-log"></div>
+            </div>
+          </div>
+        </div>
+
+        <p>
+          Two things are wrong with the seed, and fixing them produces the next two sections. First,
+          the value side is a bare function — real capabilities are whole API surfaces
+          (<code>slack.chat.postMessage</code>), so we need a calling convention that carries
+          <em>structure</em> (§2). Second, the table lives in memory — restart and it's gone, and
+          there is no record of who put what there. The fix is not "add a database"; it's that the
+          table stops being written at all and becomes a <em>fold over events</em> (§3).
+        </p>
+      </section>
+
+      <!-- ============================================================ 2 CONVENTION -->
+      <section id="convention">
+        <div class="kicker">Section 2</div>
+        <h2>One calling convention: <code>call({ path, args })</code></h2>
+        <p>
+          The kernel knows exactly one way to call anything. Every dispatch in the system — every
+          capability, every transport, every host — bottoms out in:
+        </p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="types.ts — the ONE wire shape"
+          data-lang="ts"
+        >
+          type PathCall = { path: string[]; args: unknown[] };
+
+          /** What every dispatched capability target implements. */
+          type PathCallable = { call(input: PathCall): unknown };
+        </script>
+
+        <p>
+          Two pure functions convert between dots and data, and they are the only places paths are
+          interpreted:
+        </p>
+        <ul>
+          <li>
+            <strong>Dots become data — <code>PathProxy</code></strong> (consumer side,
+            <code>path-proxy.ts</code>). A callable JS <code>Proxy</code> where property access
+            accumulates a path <em>locally</em> — zero round trips — and the terminal call fires
+            once with the accumulated <code>PathCall</code>.
+            <code>itx.slack.chat.postMessage(msg)</code> becomes
+            <code>{ path: ["slack","chat","postMessage"], args: [msg] }</code>. The proxy reads
+            <code>then</code> as <code>undefined</code> so <code>await</code> never mistakes a
+            mid-chain node for a thenable.
+          </li>
+          <li>
+            <strong>Data becomes dots — <code>replayPathCall(target, { path, args })</code></strong>
+            (receiver side). Walk the segments on a concrete object and call the terminal method
+            <em>on its parent</em> (receivers preserved — Workers RPC methods can depend on
+            <code>this</code>). An empty path calls the target itself as a function. A shared
+            <code>RESERVED_PATH_SEGMENTS</code> set (<code>__proto__</code>,
+            <code>constructor</code>, <code>then</code>, <code>call</code>, <code>dup</code>,
+            <code>describeItx</code>, …) is filtered on <em>both</em> sides; the replay is the
+            authoritative gate, because <code>invoke</code> is public and a path can be hand-built.
+          </li>
+        </ul>
+        <p>
+          Dispatch resolves the <strong>longest provided prefix</strong> of the call path and hands
+          the <em>remainder</em> to the target. Because the convention is universal, <em>any</em>
+          shape plugs in with zero client wrapper — the choice of how a path maps onto an object
+          lives at the edge where the concrete object is, never in stored data:
+        </p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="three provider shapes, one convention (real API — types.ts / examples.ts)"
+          data-lang="ts"
+        >
+          // 1. A bare function — the simplest provider. Calling the cap calls it
+          //    (auto-wrapped at provide; an empty remainder invokes the function).
+          await itx.provideCapability({
+            name: "runSwiftOnMyMac",
+            instructions: "Compile-and-run Swift on Jonas's Mac.",
+            capability: async (src) => runSwift(src),
+          });
+
+          // 2. A plain object of methods — nested at any depth. Dispatch replays the
+          //    dotted remainder onto its members, back in YOUR process. No wrapper.
+          await itx.provideCapability({
+            name: "answer",
+            capability: { ultimate: () => 42, deep: { thought: (q) => think(q) } },
+          });
+          await itx.answer.deep.thought("…"); // replays ["deep","thought"] on YOUR object
+
+          // 3. An SDK-style class that implements call() itself — it owns its whole
+          //    method tree as data (the public SDK docs become the tool docs):
+          class FakeSlackSdk extends RpcTarget {
+            async call({ path, args }) {
+              return slackApi(path.join("."), args[0]);
             }
-          `,
-        },
-      },
-    },
-  },
-});
-// Every public method is auto-proxied — no method list anywhere:
-await itx.greeter.hello({ name: "world" });
-await itx.greeter.add({ a: 2, b: 3 });</script>
+          }
+          await itx.provideCapability({ name: "slack", capability: new FakeSlackSdk() });
+          await itx.slack.chat.postMessage({ channel: "C123", text: "hi" });
+          // → arrives as ONE call({ path: ["chat","postMessage"], args: [msg] })
+        </script>
 
-  <script type="text/plain" class="code" data-title="examples.ts — a stateful cap: exportType 'durable-object' (a facet)" data-lang="ts">
-await itx.provideCapability({
-  name: "counter",
-  capability: {
-    type: "rpc",
-    worker: {
-      type: "source",
-      source: {
-        type: "inline",
-        cacheKey: "itx-example-counter-v1",
-        entrypoint: "Counter",          // named export REQUIRED for facets
-        exportType: "durable-object",
-        mainModule: "cap.js",
-        modules: {
-          "cap.js": `
-            import { DurableObject } from "cloudflare:workers";
-            export class Counter extends DurableObject {
-              async increment() {
-                const n = ((await this.ctx.storage.get("n")) ?? 0) + 1;
-                await this.ctx.storage.put("n", n);  // this.ctx.storage is YOURS alone
-                return n;
+        <p>
+          Here is the miniature that runs this page's demos — the toy's calling-convention half,
+          extracted verbatim from the script powering every demo below:
+        </p>
+        <div
+          class="toy-src"
+          data-region="convention"
+          data-title="the toy, part 1 of 3 — dots ⇄ data (running on this page)"
+        ></div>
+
+        <div class="demo" id="demo-conv">
+          <div class="dtitle">
+            <span class="live">●</span> live demo — provide a nested plain object, watch the
+            dispatched PathCall
+          </div>
+          <div class="toolbar">
+            <button data-act="provide" class="primary">
+              provideCapability({ name: "answer", capability: {…} })
+            </button>
+            <button data-act="ultimate">itx.answer.ultimate()</button>
+            <button data-act="thought">itx.answer.deep.thought(question)</button>
+            <input type="text" id="conv-q" value="life, the universe, everything" size="30" />
+          </div>
+          <div class="toolbar">
+            <span style="font-size: 12.5px; color: var(--muted)"
+              >or call an arbitrary dotted path:</span
+            >
+            <input type="text" id="conv-path" value="answer.deep.thought" size="24" />
+            <button data-act="custom">call it</button>
+          </div>
+          <div class="panes">
+            <div class="pane">
+              <h4>dispatch — what the core saw</h4>
+              <div class="body log" id="conv-dispatch"></div>
+            </div>
+            <div class="pane">
+              <h4>result</h4>
+              <div class="body log" id="conv-log"></div>
+            </div>
+          </div>
+        </div>
+
+        <aside class="note">
+          <p>
+            <strong>Two pipelining systems compose here, and they are different things.</strong> The
+            PathProxy flattens dotted <em>names</em> into data before anything touches the network.
+            The RPC transports (Cap'n&nbsp;Web, Workers RPC) separately pipeline <em>calls</em> onto
+            returned stubs. <code>itx.streams.get("/x").append(e)</code> is one PathCall producing a
+            stub that the transport then pipelines <code>append</code> onto — still one round trip.
+          </p>
+        </aside>
+      </section>
+      <!-- ============================================================ 3 JOURNAL -->
+      <section id="journal">
+        <div class="kicker">Section 3</div>
+        <h2>The journal is the only authority</h2>
+        <p>
+          Now make the table durable — by never writing it. In itx,
+          <code>provideCapability</code> and <code>revokeCapability</code> do not mutate a table;
+          they <strong>append events</strong> to the context's <strong>journal</strong>, an ordinary
+          event stream. The table you saw in §1 is the <strong>fold</strong> (reduce) of that
+          stream. The complete event vocabulary (<code>contract.ts</code>):
+        </p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="contract.ts — ITX_EVENT_TYPES, the journal's entire vocabulary"
+          data-lang="ts"
+        >
+          export const ITX_EVENT_TYPES = {
+            contextCreated:           "events.iterate.com/itx/context-created",            // the birth certificate (event #1)
+            capabilityProvided:       "events.iterate.com/itx/capability-provided",        // THE write
+            capabilityRevoked:        "events.iterate.com/itx/capability-revoked",         // exact path match, never prefix
+            capabilityDisconnected:   "events.iterate.com/itx/capability-disconnected",    // record-only: a live provider's session broke
+            scriptExecutionRequested: "events.iterate.com/itx/script-execution-requested", // with enqueued:true, appending IS requesting work
+            scriptExecutionCompleted: "events.iterate.com/itx/script-execution-completed", // the pair makes at-least-once reruns detectable
+          } as const;
+        </script>
+
+        <p>What "the journal is the only authority" buys, concretely:</p>
+        <ul>
+          <li>
+            <strong>State is a fold; the checkpoint is a disposable cache.</strong> The processor's
+            storage holds <code>{ offset, state }</code> — a memo of <code>reduce</code> over the
+            journal. Delete it and replay rebuilds it, bit for bit. The record and the state cannot
+            disagree, because events are the only writes.
+          </li>
+          <li>
+            <strong>Exactly-once is a property of the fold, not of delivery.</strong> The reducer
+            takes the first birth certificate and ignores any later one; duplicate deliveries are
+            inert by offset bookkeeping. No idempotency keys as a correctness mechanism, no
+            <code>ON CONFLICT DO NOTHING</code>.
+          </li>
+          <li>
+            <strong>No initialize RPC.</strong> Creating a context is one append: mint an
+            <code>itx_…</code> id, append
+            <code>context-created { id, name, parent: { id, address } }</code> — the
+            <strong>birth certificate</strong>, the journal's first event — and return. Nothing
+            touches the new node; it materializes lazily by consuming its own journal on first
+            dispatch.
+          </li>
+          <li>
+            <strong>"Audit log" stops existing as a separate concept.</strong> Anything that needs
+            to be auditable is an event, because events are the only writes. The journal is an
+            ordinary readable stream — every stream viewer shows it.
+          </li>
+          <li>
+            <strong>Live provides journal the EVENT too.</strong> The record outlives the session
+            (the stub itself stays an in-memory instance field, §4); after a replay the entry shows
+            up as registered-but-disconnected.
+          </li>
+        </ul>
+
+        <p>
+          Here is the toy's journal half — the same event types, the same defensive fold (a
+          malformed payload keeps the current state, so replay can never wedge on an old event
+          shape), the same append-then-catch-up write seam:
+        </p>
+        <div
+          class="toy-src"
+          data-region="journal"
+          data-title="the toy, part 2 of 3 — events and the fold (running on this page)"
+        ></div>
+
+        <p>And the core class that ties parts 1 and 2 together:</p>
+        <div
+          class="toy-src"
+          data-region="core"
+          data-title="the toy, part 3 of 3 — the core: provide/revoke/describe/invoke/extend (running on this page)"
+        ></div>
+
+        <aside class="note">
+          <p>
+            <strong>This miniature is the whole shape, for real.</strong> The production core —
+            <code>src/itx/itx.ts</code>, one file of roughly a thousand lines, half of them
+            explanatory comments — is exactly this fold, this longest-prefix dispatch, and this
+            chain, plus what crossing real process boundaries demands: dup-retention of live RPC
+            stubs and their session-teardown hooks, the single-flight append/catch-up seam that
+            keeps read-your-writes under concurrent writers, structural address validation, the
+            <code>describeItx</code> probe with timeouts and a 64&nbsp;KB journaled-meta budget,
+            script-execution processing, and error masking. Every demo below runs the code you just
+            read.
+          </p>
+        </aside>
+
+        <div class="demo" id="demo-journal">
+          <div class="dtitle">
+            <span class="live">●</span> live demo — the journal and the fold are the same data,
+            rendered two ways
+          </div>
+          <div class="toolbar">
+            <button data-act="provide-live" class="primary">provide "clock" (live object)</button>
+            <button data-act="provide-rpc" class="primary">provide "ai" (rpc address)</button>
+            <button data-act="call-clock">itx.clock.nowMs()</button>
+            <button data-act="revoke">revokeCapability({ name: "clock" })</button>
+            <span class="sep"></span>
+            <button data-act="wipe">wipe checkpoint &amp; replay journal</button>
+            <button data-act="extend">itx.extend({ name: "scratch" })</button>
+          </div>
+          <div class="panes">
+            <div class="pane">
+              <h4>the journal — events, the only writes</h4>
+              <div class="body" id="j3-journal"></div>
+            </div>
+            <div class="pane">
+              <h4>state.capabilities — the fold (own entries)</h4>
+              <div class="body" id="j3-caps"></div>
+            </div>
+          </div>
+          <div class="panes" id="j3-childwrap" style="display: none">
+            <div class="pane">
+              <h4 id="j3-childtitle">the child's journal — event #1 is its birth certificate</h4>
+              <div class="body" id="j3-childjournal"></div>
+            </div>
+            <div class="pane">
+              <h4>activity</h4>
+              <div class="body log" id="j3-log"></div>
+            </div>
+          </div>
+          <div class="panes" id="j3-logwrap">
+            <div class="pane" style="grid-column: 1 / -1">
+              <h4>activity</h4>
+              <div class="body log" id="j3-log2"></div>
+            </div>
+          </div>
+        </div>
+
+        <p>
+          Try the order: provide twice, call, revoke, then <em>wipe checkpoint &amp; replay</em>.
+          The demo snapshots the folded state before wiping, replays the journal from offset 0, and
+          proves the rebuilt state is byte-identical. Then <em>extend</em>: the child gets its own
+          journal whose event #1 is the birth certificate — creation was one append. This is also a
+          real, runnable fact about production — the journal is an ordinary stream you can read
+          back:
+        </p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="examples.ts — “the journal IS the record” (runs in every execution mode)"
+          data-lang="ts"
+        >
+          await itx.provideCapability({
+            name,
+            capability: { type: "rpc", worker: { type: "binding", binding: "AI" } },
+          });
+          await itx.revokeCapability({ name });
+
+          // The context's journal is an ordinary stream — same read API as anything.
+          const journal = await itx.streams.get("/itx").read();
+          const record = journal
+            .filter((e) => Array.isArray(e.payload?.path) && e.payload.path.join(".") === name)
+            .map((e) => e.type.split("/").pop());
+          return { record }; // ["capability-provided", "capability-revoked"]
+        </script>
+
+        <p>
+          One subtlety worth naming: the write seam is
+          <em>append, then self-ingest through the one consumption door</em> — read from the
+          checkpoint forward, fold. A provide observes its own event before returning
+          (read-your-writes), and because consumption always reads from the checkpoint, events
+          written by <em>other</em> writers (the <code>/api/itx/run</code> record door, a concurrent
+          session) interleave correctly. There is exactly one way state changes, and everything goes
+          through it.
+        </p>
+      </section>
+
+      <!-- ============================================================ 4 STUBS & ADDRESSES -->
+      <section id="stubs">
+        <div class="kicker">Section 4</div>
+        <h2>Live vs durable: stubs and addresses</h2>
+        <p>
+          What can sit in the table? The <code>CapabilityTarget</code> union has exactly two arms,
+          and the discrimination is <em>structural</em>:
+        </p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="types.ts — THE capability target"
+          data-lang="ts"
+        >
+          type CapabilityTarget = LiveStub | CapabilityAddress;
+
+          /** A live provider's stub: a function, an object of functions, or an
+           * RpcTarget. Opaque; it may arrive over Cap'n Web or Workers RPC. */
+          type LiveStub = object;
+
+          type CapabilityAddress =
+            | { type: "rpc"; worker: WorkerRef; entrypoint?: string; props?: Record<string, unknown> }
+            | { type: "url"; url: string; headers?: Record<string, string> }; // a Cap'n Web server across the internet
+
+          type WorkerRef =
+            | { type: "binding"; binding: string }                  // anything on env: env.AI, a service binding, a queue
+            | { type: "loopback" }                                  // this worker's own exports (first-party code)
+            | { type: "durable-object"; binding: string; name: string } // dialed as itx:<projectId>:<name>
+            | { type: "source"; source: WorkerSource };             // a dynamic worker from stored source (§8)
+        </script>
+
+        <p>
+          An <strong>address</strong> is a <em>plain</em> object — prototype
+          <code>Object.prototype</code> or <code>null</code> — carrying
+          <code>type: "rpc" | "url"</code>. <em>Everything else is live.</em> The plainness check
+          must run before any <code>.type</code> probe: property access on a capnweb stub returns a
+          truthy pipelined stub, so reading <code>.type</code> first would misclassify every live
+          capability. (A plain object with a <em>string</em> <code>type</code> that isn't
+          <code>"rpc"</code>/<code>"url"</code> is rejected loudly as a malformed address — a typo
+          must not register as an offline live cap.)
+        </p>
+
+        <h3>Live: a stub you are holding</h3>
+        <ul>
+          <li>
+            Inbound: something connected to this context and handed it a stub. The capability exists
+            exactly as long as that connection does —
+            <strong>live caps die with the session</strong>
+            and come back when the provider reconnects and provides again. There is no durable
+            delivery on live stubs: offline means offline.
+          </li>
+          <li>
+            The stub lives in the core's in-memory instance table (dup-retained), never in the
+            journal — but the provide <em>event</em> is journaled, so after replay the entry
+            survives as registered-but-offline. <code>describe()</code> reports live entries with
+            <code>connected: true | false</code>; calling an offline one throws
+            <code>CapabilityOfflineError</code> ("…the provider must reconnect and call
+            provideCapability() again").
+          </li>
+          <li>
+            Session teardown appends <code>capability-disconnected</code> — record only; the fold
+            ignores it (connectedness is computed from the live table, never from events).
+          </li>
+        </ul>
+
+        <h3>Durable: an address — this realm's sturdy refs</h3>
+        <p>
+          The serializable kinds are the realm's <strong>SturdyRef</strong> format (in Cap'n Proto's
+          sense): pure names that can be stored in a journal and restored to a live object on
+          demand. Crucially they <strong>grant nothing by possession</strong> — they are names
+          within a trusted realm, not bearer tokens; restoring is itself gated (authority is which
+          context your handle points at, checked at connect). The one deliberate bearer-form
+          exception is the HTTP share URL (§9), at the edge only. Real address JSON, as it sits in
+          journals:
+        </p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="every address kind, verbatim shapes from the codebase"
+          data-lang="ts"
+        >
+          // A raw platform binding (types.ts "Thirty seconds of itx"): itx.ai.run(...)
+          { "type": "rpc", "worker": { "type": "binding", "binding": "AI" } }
+
+          // A first-party loopback entrypoint, parameterized per provide via props —
+          // the McpClient shape (capabilities/mcp-client.ts). Note the secret
+          // PLACEHOLDER: the journal never carries material (§9).
+          {
+            "type": "rpc",
+            "worker": { "type": "loopback" },
+            "entrypoint": "McpClient",
+            "props": {
+              "serverUrl": "https://docs.example.com/mcp",
+              "headers": { "authorization": "Bearer getSecret({ key: \"DOCS_TOKEN\" })" }
+            }
+          }
+
+          // A Durable Object, by namespace binding + instance name. The dial scopes
+          // the name under the owning project — getByName("itx:<projectId>:inbox") —
+          // so a name can never reach a sibling project's instances.
+          { "type": "rpc", "worker": { "type": "durable-object", "binding": "TODO", "name": "inbox" } }
+
+          // A dynamic worker from stored source — code as data (§8).
+          { "type": "rpc", "worker": { "type": "source", "source": {
+              "type": "inline", "cacheKey": "greeter-v1", "mainModule": "cap.js",
+              "modules": { "cap.js": "…WorkerEntrypoint source…" } } } }
+
+          // A Cap'n Web server across the internet. ONE WebSocket session per call,
+          // terminating in the stateless UrlDial worker (Law 7). Headers ride the
+          // handshake and pass through egress secret substitution.
+          { "type": "url", "url": "wss://caps.example.com/api",
+            "headers": { "authorization": "Bearer getSecret({ key: \"REMOTE_TOKEN\" })" } }
+        </script>
+
+        <p>
+          Context nodes themselves are addressed with the same data structure — an address whose
+          worker ref is a Durable Object <em>is</em> "how to dial the node that owns this identity"
+          (§7). One data structure; everything is a use of it.
+        </p>
+
+        <aside class="note">
+          <p>
+            <strong>What <code>provideCapability</code> returns:</strong> a provision handle
+            <code>{ revoke(), [Symbol.dispose] }</code>. Dispose auto-revokes <em>only live</em>
+            provides — a live cap dies with its session anyway, while a durable provide must outlive
+            the session that created it (session teardown disposes every returned handle, so a
+            revoking disposer would silently undo durable provides). Also: provide-time validation
+            is
+            <em>structural only</em> (path shape, address well-formedness). Whether an address is
+            <em>reachable</em> is the dial's authority and surfaces at first call (§6).
+          </p>
+        </aside>
+
+        <div class="demo" id="demo-stubs">
+          <div class="dtitle">
+            <span class="live">●</span> live demo — a live stub dies with its session; an address
+            survives
+          </div>
+          <div class="toolbar">
+            <button data-act="provide-mac" class="primary">
+              provide "mac" (live: { runSwift })
+            </button>
+            <button data-act="provide-ai" class="primary">
+              provide "ai" (durable: binding address)
+            </button>
+            <button data-act="call-mac">itx.mac.runSwift(src)</button>
+            <button data-act="call-ai">itx.ai.run("@cf/meta/llama", …)</button>
+            <span class="sep"></span>
+            <button data-act="drop">the provider's session drops</button>
+          </div>
+          <div class="panes">
+            <div class="pane">
+              <h4>describe() — note <code>connected</code> on live entries</h4>
+              <div class="body" id="s4-caps"></div>
+            </div>
+            <div class="pane">
+              <h4>journal + calls</h4>
+              <div class="body log" id="s4-log"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================ 5 CHAIN -->
+      <section id="chain">
+        <div class="kicker">Section 5</div>
+        <h2>The chain: extend, shadow, super</h2>
+        <p>
+          Contexts form a <strong>prototype chain</strong>. Behaviorally, a context is a
+          prototype-chain object whose properties are capabilities: lookup walks child → parent with
+          shadowing, writes land on the node your handle points at, and <code>extend()</code> is
+          <code>Object.create(parent)</code> — it mints a cheap child context with its own journal
+          (birth certificate first, §3), whose capabilities shadow the parent's and whose misses
+          delegate the <em>whole path</em> up the chain.
+        </p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="README scene 3 — override one method (real API)"
+          data-lang="ts"
+        >
+          const session = await itx.extend({ name: "review-run" });
+
+          await session.provideCapability({
+            path: ["workspace", "gitPush"],
+            instructions: "gitPush waits for human approval; everything else is the real workspace.",
+            capability: approvalGate, // async (input) => { await approve(input); return itx.workspace.gitPush(input); }
+          });
+
+          // session.workspace.gitPush(...)  → the gate (the child's table wins)
+          // session.workspace.readFile(...) → misses the child, falls through the
+          //                                    chain to the inherited workspace
+          // Hand `session` to the thing you don't fully trust; keep `itx`.
+        </script>
+
+        <p>The rules — all consequences of the chain, not separate mechanisms:</p>
+        <ul>
+          <li>
+            <strong>Shadowing is per path.</strong> Entries live at paths;
+            <code>provideCapability({ path: ["slack","chat","postMessage"], … })</code> shadows ONE
+            subtree of an inherited cap while every other <code>slack.*</code> call falls through.
+            Longest provided prefix wins <em>per context</em>; no prefix → delegate the whole path
+            to the parent.
+          </li>
+          <li>
+            <strong>Revoke resurfaces.</strong> Revoking a shadow makes lookup reach the chain
+            again, so the inherited entry comes back — by construction. Revoking an
+            <em>inherited</em> entry is refused with a hint ("provide your own on this context to
+            take its place; the original stays on the parent"): claiming to revoke something that
+            lives on another node would lie.
+          </li>
+          <li>
+            <strong><code>itx.super</code> is middleware's "call next()".</strong> A handle on the
+            parent context: a <code>fetch</code> shadow delegates to the unshadowed pipe via
+            <code>itx.super.fetch(request)</code>. (One priced papercut: <code>super</code> is a
+            reserved word, so <code>itx.super</code> works but destructuring it does not.)
+          </li>
+          <li>
+            <strong>Delegation carries <code>origin</code></strong> —
+            <code>{ id, address }</code> of the context the call <em>started</em> at, set by
+            delegating nodes, never by handles. It is the chain's trusted identity channel:
+            attribution, context-scoped capabilities (the workspace), and origin dial-back (§6).
+          </li>
+          <li>
+            <strong><code>describe()</code> is the merged chain view.</strong> Own entries first (no
+            provenance field — they are yours), then ancestors' entries, each stamped
+            <code>from: &lt;context id&gt;</code>. Suppression is exact-match only: a path shadow
+            like <code>sdk.chat.postMessage</code> does not hide the parent's <code>sdk</code>,
+            because that entry is still live for every other path.
+          </li>
+        </ul>
+
+        <h3>The root of every chain is code</h3>
+        <p>
+          The chain does not end in data. Every project context's <code>parentItx</code> is the
+          <strong>defaults</strong> —
+          <code>PlatformContext</code> (<code>platform-context.ts</code>), a read-only loopback
+          <code>WorkerEntrypoint</code> that answers the same four-verb context protocol as every
+          node: <code>describe</code> and <code>invoke</code> from a literal list in code,
+          <code>provideCapability</code> / <code>revokeCapability</code> refused ("The defaults are
+          read-only — they ship with the deploy"). The defaults every project inherits:
+          <strong>ai, fetch, streams, secrets, repos, workspace, worker</strong> — each with its own
+          <code>instructions</code>, so even the code-rooted defaults self-describe. In
+          <code>describe()</code> they appear as
+          <code>from: "defaults"</code> (<code>DEFAULTS_DESCRIBE_FROM</code>, types.ts — the
+          internal <code>platform:project</code> chain id never leaves the chain).
+        </p>
+        <p>
+          Shipping a new default is a <em>deploy, not a migration</em>: the chain sees it
+          immediately; journaled rows shadow it; revoking a shadow resurfaces it. There is no
+          defaults mechanism — only the chain. And because the parent link is dialed in-process
+          (loopback), default dispatch pays no Durable Object hop.
+        </p>
+
+        <div class="demo" id="demo-chain">
+          <div class="dtitle">
+            <span class="live">●</span> live demo — the chain: child → project → defaults (code)
+          </div>
+          <div class="toolbar">
+            <button data-act="shadow-gitpush" class="primary">
+              shadow workspace.gitPush on child
+            </button>
+            <button data-act="shadow-fetch" class="primary">shadow fetch on child</button>
+            <button data-act="provide-slack">provide slack on project</button>
+            <button data-act="revoke-gitpush">revoke child's gitPush shadow</button>
+            <button data-act="revoke-default">try revoking inherited "ai" on child</button>
+            <button data-act="provide-on-defaults">try providing on the defaults</button>
+          </div>
+          <div class="toolbar">
+            <span style="font-size: 12.5px; color: var(--muted)">resolve a call path:</span>
+            <input type="text" id="chain-path" value="workspace.gitPush" size="26" />
+            <button data-act="resolve" class="primary">child.invoke(…)</button>
+            <button data-act="super">child.super.fetch(…) — skip the child's table</button>
+          </div>
+          <div class="chain" id="chain-viz"></div>
+          <div class="panes" style="margin-top: 12px">
+            <div class="pane" style="grid-column: 1 / -1">
+              <h4>resolution trace</h4>
+              <div class="body log" id="chain-log"></div>
+            </div>
+          </div>
+        </div>
+
+        <p>
+          The middleware acceptance test, verbatim from the example catalogue — shadow
+          <code>fetch</code> with a plain function, delegate via <code>super</code>:
+        </p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="examples.ts — middleware: shadow fetch, delegate via itx.super (real, e2e-proven)"
+          data-lang="ts"
+        >
+          const session = await itx.extend({ name: "traced" });
+
+          // The shadow is a PLAIN FUNCTION; itx.super is "call next()" — the parent
+          // chain, where fetch is still the real egress pipe.
+          await session.provideCapability({
+            name: "fetch",
+            instructions: "Project egress with an x-trace-id header stamped on every request.",
+            capability: async (request) => {
+              const traced = new Request(request.url ?? String(request), request);
+              traced.headers.set("x-trace-id", "itx-example-trace");
+              return await session.super.fetch(traced);
+            },
+          });
+
+          // Every egress on the session now carries the header — including bare
+          // fetch() inside the session's isolates. Revoke the shadow and the real
+          // pipe resurfaces. Middleware is just shadowing plus super.
+        </script>
+      </section>
+      <!-- ============================================================ 6 DIAL -->
+      <section id="dial">
+        <div class="kicker">Section 6</div>
+        <h2>The dial: the one effectful function</h2>
+        <p>
+          The core is pure structure: entries, the fold, longest-prefix dispatch, chain delegation.
+          Everything effectful is injected as <strong>one function</strong> — the dial:
+        </p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="itx.ts — the ONE effect injected into the core"
+          data-lang="ts"
+        >
+          /** The one effect injected into the core: turn an address into something
+           * speaking call({ path, args }) for THIS call. */
+          type CapabilityDial = (
+            address: CapabilityAddress,
+            attribution: { capabilityPath: string; origin: ItxOrigin },
+          ) => PathCallable;
+        </script>
+
+        <p>
+          <strong>The core owns structure; the dial owns reach.</strong> Every invoke, whatever it
+          looks like at the callsite, ends in one <code>call({ path, args })</code> against
+          something the dial resolved:
+        </p>
+
+        <svg class="diagram" viewBox="0 0 760 360" role="img" aria-label="Dispatch flow">
+          <rect class="box" x="20" y="20" width="330" height="56" rx="8" />
+          <text x="185" y="43" text-anchor="middle" class="mono">
+            await itx.slack.chat.postMessage(msg)
+          </text>
+          <text x="185" y="62" text-anchor="middle" class="small">
+            your code, anywhere a handle exists
+          </text>
+
+          <rect class="box" x="20" y="110" width="330" height="56" rx="8" />
+          <text x="185" y="133" text-anchor="middle">the handle: PathProxy → one invoke</text>
+          <text x="185" y="152" text-anchor="middle" class="mono small">
+            invoke({ path: ["slack","chat","postMessage"], args })
+          </text>
+
+          <rect class="box accent" x="20" y="200" width="330" height="74" rx="8" />
+          <text x="185" y="224" text-anchor="middle" font-weight="700">node.itx() — the core</text>
+          <text x="185" y="243" text-anchor="middle" class="small">
+            fold lookup: longest provided prefix wins
+          </text>
+          <text x="185" y="260" text-anchor="middle" class="mono small">
+            entry "slack" · remainder ["chat","postMessage"]
+          </text>
+
+          <rect class="box" x="430" y="110" width="310" height="56" rx="8" />
+          <text x="585" y="133" text-anchor="middle">miss → delegate WHOLE path to parentItx</text>
+          <text x="585" y="152" text-anchor="middle" class="small">
+            carrying origin { id, address } — set by nodes, never handles
+          </text>
+
+          <rect class="box" x="430" y="200" width="310" height="74" rx="8" />
+          <text x="585" y="224" text-anchor="middle" font-weight="700">
+            the dial: address → PathCallable
+          </text>
+          <text x="585" y="243" text-anchor="middle" class="small">
+            allowlists checked HERE (first call, not provide)
+          </text>
+          <text x="585" y="260" text-anchor="middle" class="small">
+            injects { capabilityPath, context, projectId } props
+          </text>
+
+          <rect class="box dark" x="230" y="300" width="310" height="44" rx="8" />
+          <text x="385" y="327" text-anchor="middle" class="mono onDark">
+            target.call({ path: remainder, args })
+          </text>
+
+          <line x1="185" y1="76" x2="185" y2="110" />
+          <line x1="185" y1="166" x2="185" y2="200" />
+          <line x1="350" y1="237" x2="430" y2="237" />
+          <text x="390" y="230" class="small">address?</text>
+          <line x1="350" y1="228" x2="430" y2="146" />
+          <line x1="280" y1="274" x2="330" y2="300" />
+          <text x="200" y="292" class="small">live stub (in-memory)</text>
+          <line x1="585" y1="274" x2="500" y2="300" />
+        </svg>
+
+        <p>Per address kind, the dial (<code>dial.ts</code>) does:</p>
+        <ul>
+          <li>
+            <strong><code>binding</code></strong> — gate on the bindings allowlist, take the
+            concrete object off <code>env</code>, wrap it in-process with the §2 replay (a binding
+            doesn't speak the convention; wrap it where it is real).
+          </li>
+          <li>
+            <strong><code>loopback</code></strong> — gate on the loopbacks allowlist, instantiate
+            the named export with <code>{ ...address.props, ...injected }</code>. Injection wins by
+            spread order: the dial-injected <code>{ capabilityPath, context, projectId }</code>
+            overwrite anything provider-supplied, which is the spoof-proofing — a provider can never
+            point a dialable loopback at someone else's project. First-party loopbacks implement
+            <code>call</code> themselves.
+          </li>
+          <li>
+            <strong><code>source</code></strong> — materialize an isolate via the Worker Loader
+            (§8), wired by <code>wireIsolateEnv</code> with <code>env.ITERATE</code> (an itx scoped
+            to the <em>origin</em> context) and <code>globalOutbound = ProjectEgress</code> (Law 5).
+            <code>exportType: "durable-object"</code> sources become <strong>facets</strong> of the
+            hosting DO with their own private SQLite.
+          </li>
+          <li>
+            <strong><code>durable-object</code></strong> — gate on the (default-empty) namespace
+            allowlist, then <code>getByName("itx:" + projectId + ":" + name)</code> — instance names
+            are scoped under the owning project, so two projects naming the same instance get
+            disjoint objects.
+          </li>
+          <li>
+            <strong><code>url</code></strong> — cross to the stateless <code>UrlDial</code> loopback
+            entrypoint, which opens <em>one</em> Cap'n Web WebSocket session per call against the
+            remote main and disposes it. Law 7: Cap'n Web terminates in the stateless worker, never
+            in a DO.
+          </li>
+        </ul>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="dial.ts — the allowlists (hardcoded defaults; config can only WIDEN)"
+          data-lang="ts"
+        >
+          const DIALABLE_BINDINGS = new Set(["AI"]);
+
+          // Loopbacks listed here MUST scope strictly by the dial-injected props
+          // ({ capabilityPath, context, projectId }) — never by provider props —
+          // because anyone with a handle can provide a cap dialing them.
+          const DIALABLE_LOOPBACKS = new Set([
+            "AgentCapability", "AgentToolsCapability", "BindingCapability", "EgressPipe",
+            "GmailCapability", "McpClient", "OpenApiClient", "ReposCapability",
+            "SecretsCapability", "SlackCapability", "StreamsCapability", "WorkspaceCapability",
+          ]);
+
+          // Deliberately EMPTY: namespaces whose EXISTING instances matter (PROJECT,
+          // STREAM, …) must not be allowlisted — itx dials would only reach fresh,
+          // empty objects under the project-scoped names, never the real ones.
+          const DIALABLE_DURABLE_OBJECTS = new Set([]);
+
+          // resolveDialableTargets(config): defaults ∪ APP_CONFIG_ITX additions —
+          // config can only widen, so a misconfigured deployment never loses
+          // first-party caps.
+        </script>
+
+        <p>
+          Reachability errors surface <em>at the capability's first call</em>, never at provide time
+          (provide is structural only). That asymmetry is deliberate: a deployment that widens its
+          allowlists never strands rows that were provided before the widening.
+        </p>
+
+        <p>
+          <strong>Origin dial-back</strong>, the dial's subtlest consequence: a source capability's
+          isolate is wired to the <em>originating</em> context, not the definition's home. Invoke an
+          inherited source cap through your extension and its bare <code>fetch()</code> climbs
+          <em>your</em> chain — shadow <code>fetch</code> on the extension and the inherited
+          capability's outbound traffic lands in your shadow, while siblings and the parent are
+          untouched. (Context <em>addresses</em> are dialed by a separate kernel restore,
+          <code>dialContext</code> in <code>journal.ts</code> — deliberately not allowlist-gated,
+          because only kernel code writes context addresses.)
+        </p>
+
+        <div class="demo" id="demo-dial">
+          <div class="dtitle">
+            <span class="live">●</span> live demo — hand the toy dial an address, watch reach being
+            decided
+          </div>
+          <div class="toolbar">
+            <select id="dial-pick"></select>
+            <button data-act="dial" class="primary">dial it, then call({ path, args })</button>
+          </div>
+          <div class="panes">
+            <div class="pane">
+              <h4>the address</h4>
+              <div class="body" id="dial-addr"></div>
+            </div>
+            <div class="pane">
+              <h4>what the dial did</h4>
+              <div class="body log" id="dial-log"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================ 7 IDENTITY -->
+      <section id="identity">
+        <div class="kicker">Section 7</div>
+        <h2>Identity is a stream coordinate</h2>
+        <p>
+          Where does a context <em>live</em>? Its journal is an ordinary event stream, and streams
+          are keyed by <code>(namespace, path)</code>. Journals live at
+          <code>&lt;host base&gt;/itx[/&lt;child-id&gt;]</code> in the owning project's namespace:
+        </p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="journal.ts — the coordinate system"
+          data-lang="ts"
+        >
+          // project context              (prj_x, "/itx")           — own journal, base "/"
+          // extend the project           (prj_x, "/itx/itx_a")     — child under the base
+          // an agent's context           (prj_x, "<agentPath>/itx/itx_b")
+        </script>
+
+        <ul>
+          <li>
+            <strong>The DO name IS the coordinate.</strong> The generic context host
+            (<code>ItxDurableObject</code>) holds <em>no configuration</em>: its Durable Object name
+            encodes the coordinate verbatim — <code>&lt;namespace&gt;:&lt;journalPath&gt;</code> —
+            so identity, journal ref, and self-address are <em>projections of the name</em>, derived
+            and never configured. Parentage folds from the birth certificate;
+            <code>descriptor()</code> derives from state. Address, journal, and identity are three
+            parses of one string.
+          </li>
+          <li>
+            <strong><code>itx</code> is a reserved stream path segment.</strong> Domain code and
+            user streams may not write under it — the user-facing append doors refuse with one clear
+            error (<code>assertStreamPathDoesNotClaimItxSegment</code>). Journals stay readable
+            everywhere: they are ordinary streams, and every stream viewer shows them.
+          </li>
+          <li>
+            <strong>The D1 row is a directory, never the authority.</strong> Bare
+            <code>itx_…</code> refs (reconnects, <code>/api/itx/run</code>, isolate props) resolve
+            to their coordinate through the <code>itx_contexts</code> D1 catalog — D1 in its
+            sanctioned role (a directory), while parentage and state fold from the journal.
+          </li>
+          <li>
+            <strong>The project context is code-born.</strong> It is hosted by the Project DO
+            (addressed by the project id, binding <code>PROJECT</code>), its journal is
+            <code>(projectId, "/itx")</code>, and it has <em>no</em> birth certificate — its
+            identity derives from its host's name; its <code>parentItx</code> is the defaults. Only
+            extended children carry <code>context-created</code> as event #1.
+          </li>
+          <li>
+            <strong>Chain depth ≠ path depth.</strong> Extending an extension still files the
+            grandchild's journal at <code>&lt;base&gt;/itx/&lt;id&gt;</code> — the base is the
+            journal path with its own <code>/itx[/&lt;id&gt;]</code> tail removed. Parentage lives
+            in the birth certificate, not in path nesting.
+          </li>
+        </ul>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="journal.ts — context addresses: the same data structure as every capability"
+          data-lang="ts"
+        >
+          /** The Project DO hosts the project context, addressed by the project id. */
+          projectContextAddress(projectId) // →
+          { type: "rpc", worker: { type: "durable-object", binding: "PROJECT", name: projectId } }
+
+          /** The generic host is addressed by the journal coordinate itself. */
+          childContextAddress({ namespace, path }) // →
+          { type: "rpc", worker: { type: "durable-object", binding: "ITX_CONTEXT",
+                                   name: `${namespace}:${path}` } }
+        </script>
+
+        <div class="demo" id="demo-identity">
+          <div class="dtitle"><span class="live">●</span> live demo — one name, three parses</div>
+          <div class="toolbar">
+            <button data-name="prj_01hq3v:/itx">prj_01hq3v:/itx</button>
+            <button data-name="prj_01hq3v:/itx/itx_a1b2c3">prj_01hq3v:/itx/itx_a1b2c3</button>
+            <button data-name="prj_01hq3v:/agents/slack/T123/itx/itx_d4e5f6">
+              an agent's context
+            </button>
+            <input type="text" id="id-name" value="prj_01hq3v:/itx/itx_a1b2c3" size="40" />
+            <button data-act="parse" class="primary">parse the DO name</button>
+          </div>
+          <div class="panes">
+            <div class="pane">
+              <h4>projections of the name</h4>
+              <div class="body" id="id-out"></div>
+            </div>
+            <div class="pane">
+              <h4>self-address (childContextAddress)</h4>
+              <div class="body" id="id-addr"></div>
+            </div>
+          </div>
+        </div>
+
+        <p>
+          Creation, end to end (<code>extendContext</code>, <code>journal.ts</code>): mint an
+          <code>itx_…</code> id → append
+          <code>context-created { id, name, parent: { id, address } }</code>
+          to the new journal → insert the directory row in D1 → return
+          <code>{ contextId, journal, address }</code>. Nothing dials the new node; it materializes
+          lazily by consuming its journal on first dispatch. Creating a context is literally one
+          append.
+        </p>
+      </section>
+
+      <!-- ============================================================ 8 SOURCE -->
+      <section id="source">
+        <div class="kicker">Section 8</div>
+        <h2>Code is a capability</h2>
+        <p>
+          A <code>{ type: "source" }</code> worker ref carries <em>code as data</em>: the platform
+          materializes it into an isolate on demand. Inside that isolate, bare <code>fetch()</code>
+          IS project egress (secrets substituted server-side, invisible to the code) and
+          <code>env.ITERATE</code> is an itx scoped to the capability's home context — a capability
+          can never reach wider than where it is provided. Two source kinds:
+        </p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="types.ts — WorkerSource (the design of record, abridged comments)"
+          data-lang="ts"
+        >
+          type WorkerSource = (
+            | {
+                // The code travels in the capability record itself. The loader caches
+                // the materialized isolate by cacheKey, so it MUST change whenever
+                // modules change; a content hash is the ideal value.
+                type: "inline";
+                cacheKey: string;
+                mainModule: string;
+                modules: Record<string, string>;
               }
+            | {
+                // The code lives in one of the project's repos. Built per COMMIT —
+                // never per call — through @cloudflare/worker-bundler, memoized in R2
+                // by hash(repo, sha, path, bundle). A pinned commit sha makes the
+                // journal entry fully determine behavior; "latest" tracks pushes.
+                // With no `bundle`, the file at `path` IS the worker, verbatim.
+                type: "repo";
+                repo: string;
+                commit: string | "latest";
+                path: string;
+                bundle?: { minify?: boolean; externals?: string[] };
+              }
+          ) & {
+            entrypoint?: string; // named export; defaults to the default export
+            // "worker-entrypoint" (default): stateless, fresh isolate per call.
+            // "durable-object": stateful — a NAMED export extending DurableObject,
+            // instantiated as a facet of the DO hosting this context, with its own
+            // private SQLite that survives code upgrades.
+            exportType?: "worker-entrypoint" | "durable-object";
+            compatibilityDate?: string;
+          };
+        </script>
+
+        <h3>Repo sources build per commit, never per call</h3>
+        <p>
+          <code>build(repo@sha, path, bundle) → modules</code> is a pure function, so its output is
+          a <strong>memo</strong>, never an address. Three tiers, one key: the repo (the authority)
+          → R2 (<code>ITX_BUILD_CACHE</code>, hash-keyed immutable bundles, evictable because every
+          entry is reproducible from its key) → the Worker Loader's isolate cache (ephemeral). The
+          memo key is the content address:
+          <code
+            >build/&lt;sha256(projectId, repo, commitOid, path, bundle, compatibilityDate)&gt;</code
+          >. Bundling runs in-process on an in-memory vfs (repo&nbsp;DO <code>readTree</code> →
+          <code>@cloudflare/worker-bundler</code> / esbuild-wasm → R2) — no clone, no workspace, no
+          filesystem. A <code>"latest"</code> commit resolves to a sha at most once per 10-second
+          window per isolate; concurrent dials of a cold key share one build instead of stampeding;
+          a failed memo write never fails the dial that just built good code.
+        </p>
+
+        <div class="demo" id="demo-memo">
+          <div class="dtitle">
+            <span class="live">●</span> live demo — the build memo: cold key builds, warm key never
+            does
+          </div>
+          <div class="toolbar">
+            <button data-act="dial" class="primary">
+              dial itx.repoGreeter.hello({ name: "world" })
+            </button>
+            <button data-act="push">git push (new commit lands)</button>
+            <span
+              id="memo-sha"
+              style="
+                font:
+                  12px ui-monospace,
+                  monospace;
+                color: var(--muted);
+              "
+            ></span>
+          </div>
+          <div class="panes">
+            <div class="pane">
+              <h4>dial trace</h4>
+              <div class="body log" id="memo-log"></div>
+            </div>
+            <div class="pane">
+              <h4>R2 memo (ITX_BUILD_CACHE)</h4>
+              <div class="body" id="memo-r2"></div>
+            </div>
+          </div>
+        </div>
+
+        <h3>The project worker is not special</h3>
+        <p>
+          The platform's only guarantee is that every project has its config repo (slug
+          <code>project</code>) with a defined file structure. The <code>worker</code> default — the
+          project's own code as a capability, <code>itx.worker.someExportedFunction(args)</code> —
+          is just an ordinary repo source pointed at it. The actual literal, from
+          <code>platform-context.ts</code>:
+        </p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="platform-context.ts — PROJECT_WORKER_SOURCE, verbatim"
+          data-lang="ts"
+        >
+          /**
+           * The project worker's source: the code in the project's own config repo,
+           * addressed like ANY repo-sourced capability. "latest" tracks pushes; the
+           * build is memoized per commit (source-build.ts).
+           */
+          export const PROJECT_WORKER_SOURCE = {
+            bundle: {},
+            commit: "latest",
+            path: "worker.js",
+            repo: "project",
+            type: "repo",
+          } as const satisfies WorkerSource;
+        </script>
+
+        <p>And the two source recipes from the example catalogue, both e2e-proven:</p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="examples.ts — a durable stateless cap from inline source"
+          data-lang="ts"
+        >
+          await itx.provideCapability({
+            name: "greeter",
+            capability: {
+              type: "rpc",
+              worker: {
+                type: "source",
+                source: {
+                  type: "inline",
+                  cacheKey: "itx-example-greeter-v1", // a content version: bump when modules change
+                  mainModule: "cap.js",
+                  modules: {
+                    "cap.js": `
+                      import { WorkerEntrypoint } from "cloudflare:workers";
+                      export default class extends WorkerEntrypoint {
+                        hello({ name }) { return "hello, " + name; }
+                        add({ a, b }) { return a + b; }
+                      }
+                    `,
+                  },
+                },
+              },
+            },
+          });
+          // Every public method is auto-proxied — no method list anywhere:
+          await itx.greeter.hello({ name: "world" });
+          await itx.greeter.add({ a: 2, b: 3 });
+        </script>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="examples.ts — a stateful cap: exportType 'durable-object' (a facet)"
+          data-lang="ts"
+        >
+          await itx.provideCapability({
+            name: "counter",
+            capability: {
+              type: "rpc",
+              worker: {
+                type: "source",
+                source: {
+                  type: "inline",
+                  cacheKey: "itx-example-counter-v1",
+                  entrypoint: "Counter",          // named export REQUIRED for facets
+                  exportType: "durable-object",
+                  mainModule: "cap.js",
+                  modules: {
+                    "cap.js": `
+                      import { DurableObject } from "cloudflare:workers";
+                      export class Counter extends DurableObject {
+                        async increment() {
+                          const n = ((await this.ctx.storage.get("n")) ?? 0) + 1;
+                          await this.ctx.storage.put("n", n);  // this.ctx.storage is YOURS alone
+                          return n;
+                        }
+                      }
+                    `,
+                  },
+                },
+              },
+            },
+          });
+        </script>
+
+        <p>
+          Facet mechanics worth knowing: the facet is instantiated <em>inside</em> the Durable
+          Object hosting the context (the Project DO, or the child context's DO), keyed by the
+          <strong>host</strong> context — a stateful cap's data belongs to the context it was
+          provided on. The facet name deliberately excludes the cache key, so the private SQLite
+          survives code upgrades (new source, same data). One asymmetry vs the stateless path: a
+          <code>"latest"</code>-commit source resolves at facet <em>start</em> and stays on that
+          build until the DO is evicted, while the worker-entrypoint path re-resolves per dial
+          (≤10&nbsp;s staleness).
+        </p>
+      </section>
+      <!-- ============================================================ 9 DESCRIBE -->
+      <section id="describe">
+        <div class="kicker">Section 9</div>
+        <h2>Self-description: <code>describe()</code> is the agents' sense organ</h2>
+        <p>
+          Agents are a first-class audience, and their only sense organ is <code>describe()</code>.
+          It always works, on every handle, and returns every breadcrumb needed to explore from
+          here: the context, the access set, and the merged capability chain — each entry with its
+          provenance and its provider-supplied <code>instructions</code> (prose, for whoever finds
+          the cap) and <code>types</code> (TypeScript declarations, for machines and editors). Both
+          ride the provide, are journaled with it, and come back from <code>describe()</code> on
+          every handle down the chain. The review question for anything in this system is always the
+          same: <strong>what does <code>describe()</code> say?</strong>
+        </p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="README scene 1 — what am I holding?"
+          data-lang="ts"
+        >
+          await itx.describe();
+          // → { context: "prj_…", access: ["prj_…"],
+          //     capabilities: [{ name: "slack", kind: "rpc", instructions: "Use
+          //       itx.slack.<Slack Web API method path>(args), e.g.
+          //       itx.slack.chat.postMessage({ channel, thread_ts, text })…" }, …],
+          //     project: { … } }
+        </script>
+
+        <h3>The <code>describeItx</code> provide-time hook</h3>
+        <p>
+          Instructions and types belong in the journaled meta <em>at provide time</em> — and the
+          target knows its own surface best at exactly that moment. So: an <code>rpc</code> provide
+          with no caller-supplied <code>types</code> is dialed <em>once</em> and asked
+          <code>describeItx</code> (a reserved protocol path segment, so user capability paths can
+          never collide with it). Explicit caller values always win; the probe is best-effort and
+          side-effectful (an <code>OpenApiClient</code> probe fetches its spec) with a short
+          deadline (3&nbsp;s; 15&nbsp;s for loopbacks, whose first probe may ride a cold chain) —
+          any failure or timeout just means an unenriched provide. Probe-derived strings are capped
+          at 64&nbsp;KB (they are journaled forever). Only <code>call</code>-implementing targets
+          can answer; member-shaped source caps hit the replay's reserved-name gate, which is the
+          collision protection doing its job.
+        </p>
+
+        <h3>Recipe: an authenticated MCP server, credential-free addresses</h3>
+        <p>
+          The full secret story in one recipe. Material is stored once via the
+          <code>secrets</code> default; from then on only a <em>placeholder</em> travels —
+          <code>'Bearer getSecret({ key: "…" })'</code> — and substitution happens on egress, inside
+          the stateless terminal pipe. The session, <code>describe()</code>, and the journal never
+          see the material.
+        </p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="examples.ts — store a secret, then an authenticated MCP capability"
+          data-lang="ts"
+        >
+          // (1) Store the credential ONCE. listSecrets() shows redacted summaries;
+          //     material never crosses an itx boundary again.
+          await itx.secrets.setSecret({ key: "CLOUDFLARE_API_TOKEN", material: token });
+
+          // (2) The capability address carries only the PLACEHOLDER.
+          await itx.provideCapability({
+            path: ["mcp", "cloudflare"],
+            instructions: "Cloudflare's MCP server, authenticated via a project secret.",
+            capability: {
+              type: "rpc",
+              worker: { type: "loopback" },
+              entrypoint: "McpClient",
+              props: {
+                serverUrl: "https://bindings.mcp.cloudflare.com/mcp",
+                headers: { authorization: 'Bearer getSecret({ key: "CLOUDFLARE_API_TOKEN" })' },
+              },
+            },
+          });
+
+          // (3) Every MCP request rides the project egress pipe, where the placeholder
+          //     becomes the real token — the connected agent/isolate never sees it.
+          const { tools } = await itx.mcp.cloudflare.listTools();
+        </script>
+
+        <p>
+          Mechanics behind it: <code>McpClient</code> is an ordinary loopback RPC target (MCP is a
+          client <em>implementation</em>, not a transport — deliberately not a capability kind). Its
+          streamable-HTTP transport is stateless: connect → call → close per invocation, all HTTP
+          through the cap's own <code>itx.fetch</code>. Its <code>describeItx</code> answers
+          <code>{}</code> — an MCP surface is dynamic, <code>listTools()</code> is the discovery
+          door. And the placeholder design has a security property worth repeating from §5: a live
+          <code>fetch</code> <em>shadow</em> receives placeholders <strong>unsubstituted</strong> —
+          substitution exists only in the default pipe, so an interceptor never sees secret
+          material.
+        </p>
+
+        <h3>Recipe: any OpenAPI spec becomes a typed capability</h3>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="examples.ts — OpenApiClient: spec-derived types via describeItx"
+          data-lang="ts"
+        >
+          await itx.provideCapability({
+            name: "petstore",
+            capability: {
+              type: "rpc",
+              worker: { type: "loopback" },
+              entrypoint: "OpenApiClient",
+              props: {
+                specUrl: "https://petstore3.swagger.io/api/v3/openapi.json",
+                // For authenticated APIs, add headers with a secret placeholder:
+                // headers: { authorization: 'Bearer getSecret({ key: "API_TOKEN" })' },
+              },
+            },
+          });
+
+          // Flat operationIds, ONE merged input object (path params + query params +
+          // body properties), through project egress:
+          const pets = await itx.petstore.findPetsByStatus({ status: "available" });
+
+          // describe() now carries spec-derived TypeScript — the provider answered
+          // the platform's provide-time describeItx probe, no callsite ceremony.
+          const { capabilities } = await itx.describe();
+          capabilities.find((cap) => cap.name === "petstore").types;
+          // → "declare function findPetsByStatus(input: { status?: … }): Promise<…>; …"
+        </script>
+
+        <div class="demo" id="demo-describe">
+          <div class="dtitle">
+            <span class="live">●</span> live demo — the describeItx hook, in the toy
+          </div>
+          <div class="toolbar">
+            <button data-act="provide" class="primary">
+              provide "petstore" (OpenApiClient address, no types given)
+            </button>
+            <button data-act="call">itx.petstore.findPetsByStatus({ status: "available" })</button>
+            <button data-act="describe">describe()</button>
+          </div>
+          <div class="panes">
+            <div class="pane">
+              <h4>journal — note meta.types arrived AT PROVIDE TIME</h4>
+              <div class="body" id="d9-journal"></div>
+            </div>
+            <div class="pane">
+              <h4>describe() / calls</h4>
+              <div class="body log" id="d9-log"></div>
+            </div>
+          </div>
+        </div>
+
+        <h3>Recipe: your laptop as a capability</h3>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="README scene 2 — offer a capability from your laptop (real API)"
+          data-lang="ts"
+        >
+          import { withItx } from "~/itx/client.ts";
+
+          using itx = withItx({ baseUrl, token, context: "my-project" });
+
+          await itx.provideCapability({
+            name: "runSwiftOnMyMac",
+            instructions: "Compile-and-run Swift on Jonas's Mac. Pass the source string.",
+            capability: async (src) => runSwift(src),
+          });
+          // While your process stays connected, every agent, REPL, and script in the
+          // project can call itx.runSwiftOnMyMac(src) — the call travels back over
+          // YOUR connection and runs in YOUR process. The instructions you attach are
+          // what everyone else's describe() will say — write them for the stranger
+          // who finds your capability there.
+        </script>
+
+        <h3>Recipe: fetch middleware (extend + super)</h3>
+        <p>
+          Already shown in full in §5 — shadow <code>fetch</code> on an extension with a plain
+          function, delegate to the real pipe via <code>session.super.fetch(request)</code>. It
+          earns its place in this list because it is pure composition: no interception API exists;
+          the recipe is just the chain (§5) plus the one egress door (Law 5).
+        </p>
+
+        <h3>Two more describe-adjacent doors</h3>
+        <ul>
+          <li>
+            <strong>HTTP exposure</strong>: a cap provided with
+            <code>meta: { http: { expose: true } }</code> gets its own hostname —
+            <code>https://{cap}--{project}.{base}/…</code> → <code>ItxCapabilityIngress</code>: 404
+            unless exposed; the gate is admin bearer, a signed share URL, or
+            <code>meta.http.public</code>; then one core dispatch with
+            <code>[...capabilityPath, "fetch"]</code>.
+          </li>
+          <li>
+            <strong><code>itx.shareUrl({ name, path?, ttlSeconds? })</code></strong> — "let me show
+            you something real quick": a signed, expiring URL for one HTTP-exposed cap. Possession
+            grants exactly that cap's fetch surface until expiry — the realm's one deliberate
+            bearer-token edge.
+          </li>
+        </ul>
+
+        <aside class="note">
+          <p>
+            <strong
+              >The Laws — the invariants that ARE the architecture (README, condensed):</strong
+            >
+          </p>
+          <p>
+            1. The journal holds the facts; the node holds live refs; code holds composition.<br />
+            2. Props carry identity, never composition or authority-by-content.<br />
+            3. Auth happens at connect, nowhere else — which context your handle points at is the
+            authority.<br />
+            4. Narrowing is construction: <code>itx.projects.get()</code> and
+            <code>itx.extend()</code> return new handles on narrower contexts, never flags on wider
+            ones.<br />
+            5. All policy-governed egress flows through one pipe; secret placeholders are
+            substituted only in the stateless terminal pipe.<br />
+            6. One calling convention: <code>target.call({ path, args })</code> — the
+            members/path-call choice lives at the edges, never in stored data.<br />
+            7. Cap'n Web terminates in the stateless worker, never in a DO.
+          </p>
+        </aside>
+      </section>
+
+      <!-- ============================================================ 10 DOCTRINE -->
+      <section id="doctrine">
+        <div class="kicker">Section 10</div>
+        <h2>Extending the platform: how to build the next domain object</h2>
+        <p>
+          itx is the reference implementation of a standing doctrine
+          (<code>docs/domain-objects-and-stream-processors.md</code>) for designing
+          <em>any</em> durable domain object on this platform — agents, contexts, MCP sessions,
+          whatever comes next. A context is a domain object whose state is its capability table and
+          whose creation event is <code>context-created</code>. The rules:
+        </p>
+        <ul>
+          <li>
+            <strong>Creation is an event.</strong> A durable thing's existence is not configuration
+            — it is the FIRST event in its own stream: mint the id, append the birth certificate,
+            return a handle. No <code>initialize()</code> RPC, no idempotency keys as a correctness
+            mechanism; exactly-once is a property of the fold (first creation event wins, later ones
+            are inert). Lazy materialization: the object comes alive on first dispatch by reading
+            its own journal.
+          </li>
+          <li>
+            <strong>Derive what names carry; reduce everything else.</strong> DO names are
+            structured records (project id, path). Identity, journal ref, and self-address are
+            projections of the name — never configuration. Anything a name cannot carry arrives as
+            an event.
+          </li>
+          <li>
+            <strong>State is a fold; the checkpoint is disposable.</strong> Storage holds
+            <code>{ offset, state }</code> as a cache of <code>reduce</code> over the journal.
+            Delete it and replay rebuilds it. The stream is the only authority.
+          </li>
+          <li>
+            <strong
+              >Side effects live in <code>processEvent</code>, never in <code>reduce</code>.</strong
+            >
+            Replay rebuilds state without re-running effects (<code>sideEffectsAfterOffset</code>);
+            serialized batches give in-order execution; a requested/completed event pair makes
+            at-least-once reruns detectable.
+          </li>
+          <li>
+            <strong>Self-describing, always.</strong> Every domain object answers
+            <code>describe()</code>; every provided surface carries <code>instructions</code> and
+            <code>types</code> from the moment it exists. The acceptance test: an agent with no
+            prior knowledge, handed a stub, acts competently from <code>describe()</code> alone.
+          </li>
+        </ul>
+
+        <h3>Worked example: designing <code>CronSchedule</code></h3>
+        <p>
+          A hypothetical new domain object — recurring scheduled script runs for a project —
+          designed step by step under the rules. (Hypothetical: this does not exist in the codebase;
+          it is the doctrine applied.)
+        </p>
+
+        <p>
+          <strong>Step 1 — the structured name.</strong> One Durable Object per schedule, its name
+          the stream coordinate: <code>&lt;projectId&gt;:/cron/&lt;cron_…&gt;</code>. Identity
+          (<code>cron_…</code>, the last path segment), journal ref (<code
+            >(projectId, "/cron/&lt;id&gt;")</code
+          >), and self-address (<code
+            >{ type: "rpc", worker: { type: "durable-object", binding: "CRON", name } }</code
+          >) are all parses of the name. Note the path does <em>not</em> claim the reserved
+          <code>itx</code>
+          segment — that belongs to context journals. If the platform keeps a D1 row mapping bare
+          <code>cron_…</code> ids to coordinates, it is a directory, never the authority.
+        </p>
+
+        <p><strong>Step 2 — the journal events, birth certificate first.</strong></p>
+
+        <script
+          type="text/plain"
+          class="code"
+          data-title="hypothetical cron-contract.ts — the event vocabulary"
+          data-lang="ts"
+        >
+          export const CRON_EVENT_TYPES = {
+            // The birth certificate — event #1, carrying identity and creation facts.
+            scheduleCreated:  "events.iterate.com/cron/schedule-created",   // { id, spec, script, parent: { id, address } }
+            scheduleUpdated:  "events.iterate.com/cron/schedule-updated",   // { spec?, script? }
+            schedulePaused:   "events.iterate.com/cron/schedule-paused",    // {}
+            scheduleResumed:  "events.iterate.com/cron/schedule-resumed",   // {}
+            // The at-least-once pair: appending fire-requested IS requesting work.
+            fireRequested:    "events.iterate.com/cron/fire-requested",     // { fireId, scheduledForMs, enqueued: true }
+            fireCompleted:    "events.iterate.com/cron/fire-completed",     // { fireId, result | error }
+          } as const;
+        </script>
+
+        <p>
+          Creating a schedule is one append of <code>schedule-created</code> — no initialize RPC,
+          nothing touches the new DO; it materializes when the first dispatch (or its alarm) makes
+          it consume its journal. Payload schemas stay deliberately loose, so a journal carrying
+          events from before a deploy never wedges the fold.
+        </p>
+
+        <p><strong>Step 3 — the reduce (pure, module-level, defensive).</strong></p>
+
+        <script type="text/plain" class="code" data-title="hypothetical — the fold" data-lang="ts">
+          export function reduceCronJournalEvent(state, event) {
+            const p = event.payload ?? {};
+            switch (event.type) {
+              case CRON_EVENT_TYPES.scheduleCreated:
+                if (state.schedule !== null) return state;   // first birth certificate wins
+                if (typeof p.id !== "string") return state;  // malformed payloads never wedge replay
+                return { ...state, schedule: { id: p.id, spec: p.spec, script: p.script, paused: false } };
+              case CRON_EVENT_TYPES.scheduleUpdated:
+                if (state.schedule === null) return state;
+                return { ...state, schedule: { ...state.schedule, ...(p.spec ? { spec: p.spec } : {}), ...(p.script ? { script: p.script } : {}) } };
+              case CRON_EVENT_TYPES.schedulePaused:
+                return state.schedule ? { ...state, schedule: { ...state.schedule, paused: true } } : state;
+              case CRON_EVENT_TYPES.scheduleResumed:
+                return state.schedule ? { ...state, schedule: { ...state.schedule, paused: false } } : state;
+              case CRON_EVENT_TYPES.fireRequested:
+                if (p.enqueued !== true || typeof p.fireId !== "string") return state;
+                return { ...state, pendingFires: { ...state.pendingFires, [p.fireId]: true } };
+              case CRON_EVENT_TYPES.fireCompleted: {
+                if (!(p.fireId in state.pendingFires)) return state;  // unknown/duplicate completion: inert
+                const pendingFires = { ...state.pendingFires };
+                delete pendingFires[p.fireId];
+                return { ...state, pendingFires };
+              }
+              default:
+                return state;
             }
-          `,
-        },
-      },
-    },
-  },
-});</script>
+          }
+        </script>
 
-  <p>
-    Facet mechanics worth knowing: the facet is instantiated <em>inside</em> the Durable Object
-    hosting the context (the Project DO, or the child context's DO), keyed by the
-    <strong>host</strong> context — a stateful cap's data belongs to the context it was
-    provided on. The facet name deliberately excludes the cache key, so the private SQLite
-    survives code upgrades (new source, same data). One asymmetry vs the stateless path: a
-    <code>"latest"</code>-commit source resolves at facet <em>start</em> and stays on that
-    build until the DO is evicted, while the worker-entrypoint path re-resolves per dial
-    (≤10&nbsp;s staleness).
-  </p>
-</section>
-<!-- ============================================================ 9 DESCRIBE -->
-<section id="describe">
-  <div class="kicker">Section 9</div>
-  <h2>Self-description: <code>describe()</code> is the agents' sense organ</h2>
-  <p>
-    Agents are a first-class audience, and their only sense organ is <code>describe()</code>.
-    It always works, on every handle, and returns every breadcrumb needed to explore from here:
-    the context, the access set, and the merged capability chain — each entry with its
-    provenance and its provider-supplied <code>instructions</code> (prose, for whoever finds
-    the cap) and <code>types</code> (TypeScript declarations, for machines and editors). Both
-    ride the provide, are journaled with it, and come back from <code>describe()</code> on
-    every handle down the chain. The review question for anything in this system is always the
-    same: <strong>what does <code>describe()</code> say?</strong>
-  </p>
+        <p>
+          <strong>Step 4 — side effects in <code>processEventBatch</code>, never in reduce.</strong>
+          The alarm handler appends <code>fire-requested { enqueued: true }</code>;
+          <code>processEventBatch</code> sees it (past <code>sideEffectsAfterOffset</code>, still
+          pending in batch-final state), runs the script — the side effect — and appends
+          <code>fire-completed</code>. A replay rebuilds <code>pendingFires</code> without
+          re-running anything; a crash between the pair leaves a pending entry that the next wake
+          detects and re-runs (at-least-once, detectable). Setting the next alarm is also a
+          <code>processEvent</code> concern, derived from folded state.
+        </p>
 
-  <script type="text/plain" class="code" data-title="README scene 1 — what am I holding?" data-lang="ts">
-await itx.describe();
-// → { context: "prj_…", access: ["prj_…"],
-//     capabilities: [{ name: "slack", kind: "rpc", instructions: "Use
-//       itx.slack.<Slack Web API method path>(args), e.g.
-//       itx.slack.chat.postMessage({ channel, thread_ts, text })…" }, …],
-//     project: { … } }</script>
+        <p>
+          <strong>Step 5 — the capability surface.</strong> How does anyone reach it? Provide it —
+          with instructions and types, from the moment it exists:
+        </p>
 
-  <h3>The <code>describeItx</code> provide-time hook</h3>
-  <p>
-    Instructions and types belong in the journaled meta <em>at provide time</em> — and the
-    target knows its own surface best at exactly that moment. So: an <code>rpc</code> provide
-    with no caller-supplied <code>types</code> is dialed <em>once</em> and asked
-    <code>describeItx</code> (a reserved protocol path segment, so user capability paths can
-    never collide with it). Explicit caller values always win; the probe is best-effort and
-    side-effectful (an <code>OpenApiClient</code> probe fetches its spec) with a short deadline
-    (3&nbsp;s; 15&nbsp;s for loopbacks, whose first probe may ride a cold chain) — any failure
-    or timeout just means an unenriched provide. Probe-derived strings are capped at 64&nbsp;KB
-    (they are journaled forever). Only <code>call</code>-implementing targets can answer;
-    member-shaped source caps hit the replay's reserved-name gate, which is the collision
-    protection doing its job.
-  </p>
+        <script
+          type="text/plain"
+          class="code"
+          data-title="hypothetical — cron as a capability (a loopback, like SecretsCapability)"
+          data-lang="ts"
+        >
+          // First-party path: a CronCapability loopback entrypoint, added to
+          // DIALABLE_LOOPBACKS, scoping STRICTLY by the dial-injected projectId —
+          // the same discipline as SecretsCapability. Then, on the project context:
+          await itx.provideCapability({
+            name: "cron",
+            instructions:
+              "Recurring scheduled runs: itx.cron.create({ spec, script }) (spec is a " +
+              "cron expression; script is `async (itx) => …`), list(), pause({ id }), " +
+              "resume({ id }), history({ id }).",
+            types: `declare function create(input: { spec: string; script: string }): Promise<{ id: string }>;
+          declare function list(): Promise<{ id: string; spec: string; paused: boolean }[]>;
+          declare function pause(input: { id: string }): Promise<void>;
+          declare function resume(input: { id: string }): Promise<void>;`,
+            capability: { type: "rpc", worker: { type: "loopback" }, entrypoint: "CronCapability" },
+          });
+          // (Alternative: allowlist the CRON namespace via APP_CONFIG_ITX and dial
+          // { type: "durable-object", binding: "CRON", name } directly — remembering
+          // the dial scopes names as itx:<projectId>:<name>, so only namespaces
+          // DESIGNED to be reached that way belong on the allowlist.)
+        </script>
 
-  <h3>Recipe: an authenticated MCP server, credential-free addresses</h3>
-  <p>
-    The full secret story in one recipe. Material is stored once via the <code>secrets</code>
-    default; from then on only a <em>placeholder</em> travels —
-    <code>'Bearer getSecret({ key: "…" })'</code> — and substitution happens on egress, inside
-    the stateless terminal pipe. The session, <code>describe()</code>, and the journal never
-    see the material.
-  </p>
+        <p>
+          Promoting <code>cron</code> into the defaults later is a deploy, not a migration: add it
+          to <code>PLATFORM_PROJECT_CAPABILITIES</code> and every chain sees it immediately; any
+          project's own <code>cron</code> row shadows it.
+        </p>
 
-  <script type="text/plain" class="code" data-title="examples.ts — store a secret, then an authenticated MCP capability" data-lang="ts">
-// (1) Store the credential ONCE. listSecrets() shows redacted summaries;
-//     material never crosses an itx boundary again.
-await itx.secrets.setSecret({ key: "CLOUDFLARE_API_TOKEN", material: token });
+        <div class="demo" id="demo-cron">
+          <div class="dtitle">
+            <span class="live">●</span> live demo — the CronSchedule fold, under the doctrine
+          </div>
+          <div class="toolbar">
+            <button data-act="create" class="primary">append schedule-created</button>
+            <button data-act="create-dup">append schedule-created again (retried append)</button>
+            <button data-act="update">append schedule-updated</button>
+            <button data-act="request">append fire-requested</button>
+            <button data-act="complete">append fire-completed</button>
+            <button data-act="wipe">wipe checkpoint &amp; replay</button>
+          </div>
+          <div class="panes">
+            <div class="pane">
+              <h4>the journal</h4>
+              <div class="body" id="cron-journal"></div>
+            </div>
+            <div class="pane">
+              <h4>the fold: { schedule, pendingFires }</h4>
+              <div class="body" id="cron-state"></div>
+            </div>
+          </div>
+          <div class="panes">
+            <div class="pane" style="grid-column: 1 / -1">
+              <h4>notes</h4>
+              <div class="body log" id="cron-log"></div>
+            </div>
+          </div>
+        </div>
 
-// (2) The capability address carries only the PLACEHOLDER.
-await itx.provideCapability({
-  path: ["mcp", "cloudflare"],
-  instructions: "Cloudflare's MCP server, authenticated via a project secret.",
-  capability: {
-    type: "rpc",
-    worker: { type: "loopback" },
-    entrypoint: "McpClient",
-    props: {
-      serverUrl: "https://bindings.mcp.cloudflare.com/mcp",
-      headers: { authorization: 'Bearer getSecret({ key: "CLOUDFLARE_API_TOKEN" })' },
-    },
-  },
-});
+        <h3>The review checklist</h3>
+        <ul>
+          <li>
+            <strong>What does <code>describe()</code> say about it?</strong> Could an agent with no
+            prior knowledge act competently from that alone?
+          </li>
+          <li>
+            Is creation exactly one append, with the birth certificate as event #1? Is there any
+            initialize RPC, setup path, or "configured" residue replay cannot reproduce?
+          </li>
+          <li>Can you delete the checkpoint right now and lose nothing?</li>
+          <li>
+            Does anything write state outside the journal? (If it needs to be auditable, is it an
+            event — because events are the only writes?)
+          </li>
+          <li>
+            Do retried appends and duplicate deliveries reduce to no-ops in the fold, without
+            idempotency keys as a correctness mechanism?
+          </li>
+          <li>
+            Are all side effects in <code>processEvent</code>/<code>processEventBatch</code>,
+            guarded by a requested/completed pair — never in <code>reduce</code>?
+          </li>
+          <li>
+            Does the name carry exactly identity (and the journal coordinate), with everything else
+            reduced from events? Is any D1 row strictly a directory?
+          </li>
+          <li>
+            How does it become dialable — a loopback scoping by dial-injected props, or an
+            allowlisted DO namespace designed for
+            <code>itx:&lt;projectId&gt;:&lt;name&gt;</code> scoping?
+          </li>
+          <li>Does its stream path stay clear of the reserved <code>itx</code> segment?</li>
+        </ul>
+      </section>
 
-// (3) Every MCP request rides the project egress pipe, where the placeholder
-//     becomes the real token — the connected agent/isolate never sees it.
-const { tools } = await itx.mcp.cloudflare.listTools();</script>
+      <!-- ============================================================ 11 GLOSSARY -->
+      <section id="glossary">
+        <div class="kicker">Section 11</div>
+        <h2>Glossary</h2>
+        <dl class="gloss">
+          <dt>context</dt>
+          <dd>
+            An addressable node that holds named capabilities. Contexts form a prototype chain
+            (child → parent with shadowing); a context may be durable (a DO with a journal) but
+            durability is not part of the concept. <code>ContextRef</code>: <code>"global"</code>, a
+            project id (<code>prj_…</code>; <code>proj_…</code> legacy), or a child id
+            (<code>itx_…</code>).
+          </dd>
+          <dt>capability</dt>
+          <dd>
+            A name (a path, really) plus a <code>CapabilityTarget</code> — either a live stub
+            someone handed the context, or a serializable address of where the implementation lives.
+            Its kind is its provider's kind: <code>"live" | "rpc" | "url"</code>.
+          </dd>
+          <dt>handle (<code>ItxHandle</code>)</dt>
+          <dd>
+            The cheap, ephemeral view user code touches — identical in browser, Node, REPL, project
+            worker, scripts, and capabilities. The trust kernel (the four verbs plus
+            <code>extend</code>, <code>super</code>, <code>streams</code>, <code>projects</code>,
+            <code>project</code>, <code>fetch</code>, <code>capability()</code>,
+            <code>shareUrl</code>) plus a fallthrough proxy: any unknown name becomes a PathProxy
+            whose terminal call is one invoke on the node's core. Minted exactly three ways:
+            connect, narrowing, platform wiring.
+          </dd>
+          <dt>stub</dt>
+          <dd>
+            A live RPC reference to an object in another process (capnweb or Workers RPC). "An Itx
+            holds capabilities; everything else holds a stub of one." <code>ItxStub</code> is the
+            four-verb context protocol shape.
+          </dd>
+          <dt>core (<code>Itx</code>)</dt>
+          <dd>
+            The capability core a context node embeds (<code>itx.ts</code>): the path-keyed entry
+            table, the live-stub table, longest-prefix dispatch, chain delegation — four verbs:
+            <code>provideCapability</code>, <code>revokeCapability</code>, <code>describe</code>,
+            <code>invoke</code>. Exposed by hosts via an <code>itx()</code> <em>method</em> (workerd
+            doesn't pipeline through property accesses).
+          </dd>
+          <dt>journal</dt>
+          <dd>
+            The context's event stream — the only authority. Provides/revokes append events and
+            self-ingest; nothing else writes state.
+          </dd>
+          <dt>fold / reduce / replay</dt>
+          <dd>
+            The pure function from journal to state (<code>reduceItxJournalEvent</code>). Replay =
+            re-running the fold from offset 0; defensive by design so old event shapes never wedge
+            it.
+          </dd>
+          <dt>checkpoint</dt>
+          <dd>
+            <code>{ offset, state }</code> in the host DO's storage — a disposable cache of the
+            fold. Delete it; replay rebuilds it.
+          </dd>
+          <dt>dial</dt>
+          <dd>
+            The one effectful function injected into the core:
+            <code>CapabilityAddress → PathCallable</code>. Owns reach (allowlists), injects
+            attribution props, wires isolates and facets.
+          </dd>
+          <dt>chain</dt>
+          <dd>
+            The parent links contexts resolve through:
+            <code>itx_… → project → defaults (code)</code>. A lookup miss delegates the whole path
+            upward, carrying origin.
+          </dd>
+          <dt>defaults</dt>
+          <dd>
+            The code-rooted final link of every chain: <code>PlatformContext</code>, read-only,
+            answering the context protocol from <code>PLATFORM_PROJECT_CAPABILITIES</code> (ai,
+            fetch, streams, secrets, repos, workspace, worker). Labeled
+            <code>from: "defaults"</code> in describe. Shipping one is a deploy, not a migration.
+          </dd>
+          <dt>extend</dt>
+          <dd>
+            <code>itx.extend({ name? })</code>: mint a child context — an id, a journal with a birth
+            certificate, an address, a handle. <code>Object.create(parent)</code> for contexts.
+          </dd>
+          <dt>shadow</dt>
+          <dd>
+            Providing (at a name or deeper path) on a child what the chain already resolves — your
+            entry wins longest-prefix locally; revoke it and the inherited entry resurfaces.
+          </dd>
+          <dt><code>super</code></dt>
+          <dd>
+            The handle on the parent context — middleware's "call next()". A reserved word, so dot
+            it, don't destructure it.
+          </dd>
+          <dt>live vs durable</dt>
+          <dd>
+            Live: an inbound stub, session-bound, in-memory, journaled only as an event (describe
+            shows <code>connected</code>). Durable: a serializable address, restored at invoke time.
+            Everything writable is durable; the root of every chain is code.
+          </dd>
+          <dt>address (<code>CapabilityAddress</code>)</dt>
+          <dd>
+            <code>{ type: "rpc", worker, entrypoint?, props? }</code> or
+            <code>{ type: "url", url, headers? }</code> — the system's one serializable data
+            structure; context nodes are addressed with it too.
+          </dd>
+          <dt>sturdy ref</dt>
+          <dd>
+            Cap'n Proto's term for a serializable token restorable to a live capability. The
+            serializable address kinds are this realm's sturdy-ref format — pure names, zero
+            authority by content; <code>resolveItx</code> is the restorer. The HTTP share token is
+            the one deliberate sealed/bearer-form exception, at the edge only.
+          </dd>
+          <dt><code>WorkerSource</code></dt>
+          <dd>
+            Stored source for a <code>{ type: "source" }</code> worker: <code>inline</code> (code in
+            the record, cached by <code>cacheKey</code>) or <code>repo</code> (code in a project
+            repo, built per commit). Plus <code>entrypoint</code> and
+            <code>exportType</code> ("worker-entrypoint" stateless | "durable-object" facet).
+          </dd>
+          <dt>the memo</dt>
+          <dd>
+            The R2 build cache for repo sources:
+            <code>build/&lt;hash(projectId, repo, sha, path, bundle, compatibilityDate)&gt;</code> →
+            built modules. An optimization, never an authority — every entry is reproducible from
+            its key.
+          </dd>
+          <dt>birth certificate</dt>
+          <dd>
+            <code>context-created { id, name, parent: { id, address } }</code> — the first event in
+            a journal. The fold takes the first and ignores later ones; parentage and descriptor
+            derive from it. Code-born contexts (the project context, the defaults) have none.
+          </dd>
+          <dt>stream coordinate</dt>
+          <dd>
+            <code>(namespace, path)</code> — where a stream (hence a journal, hence a context's
+            identity) lives. The generic host's DO name is the coordinate verbatim:
+            <code>&lt;namespace&gt;:&lt;journalPath&gt;</code>.
+          </dd>
+          <dt>reserved segment</dt>
+          <dd>
+            Three reservations, by position: the stream path segment <code>itx</code> (context
+            journals only); <code>RESERVED_PATH_SEGMENTS</code> (protocol/prototype names like
+            <code>then</code>, <code>call</code>, <code>constructor</code>,
+            <code>describeItx</code> — never traversable anywhere in a path);
+            <code>RESERVED_CAPABILITY_NAMES</code> (the trust-kernel builtins — banned as a
+            <em>first</em> segment only; <code>fetch</code> and <code>streams</code> deliberately
+            not on it, because shadowing them is the point).
+          </dd>
+          <dt><code>describeItx</code></dt>
+          <dd>
+            The reserved provide-time self-description probe: an rpc provide with no caller
+            <code>types</code> is dialed once and asked; a call-implementing target may answer
+            <code>{ instructions?, types? }</code>, journaled into meta (64 KB cap, best-effort, 3
+            s/15 s deadline).
+          </dd>
+          <dt>placeholder / substitution</dt>
+          <dd>
+            <code>'Bearer getSecret({ key: "X" })'</code> in an outbound header. Material lives in
+            project secrets; substitution happens only in the stateless terminal egress pipe;
+            journals, describe(), isolates, and fetch shadows only ever see the placeholder.
+          </dd>
+          <dt>allowlist</dt>
+          <dd>
+            <code>DialableTargets</code> — which bindings/loopbacks/DO-namespaces an rpc address may
+            dial. Hardcoded defaults ∪ deployment config; config can only widen; checked at dial
+            time (first invoke), never at provide.
+          </dd>
+          <dt>facet</dt>
+          <dd>
+            A Durable Object instantiated <em>inside</em> the DO hosting a context
+            (<code>ctx.facets</code>), with its own private SQLite stored in the host. How
+            <code>exportType: "durable-object"</code> source caps get state with zero provisioning;
+            named <code>cap:&lt;name&gt;</code> (no cache key) so data survives code upgrades.
+          </dd>
+          <dt>origin (<code>ItxOrigin</code>)</dt>
+          <dd>
+            <code>{ id, address }</code> of the context a delegated call started at. Set by
+            delegating nodes, never by handles — the chain's trusted identity channel for
+            attribution, context-scoped caps, and origin dial-back.
+          </dd>
+          <dt>PathCall / longest-prefix / member replay</dt>
+          <dd>
+            The wire shape <code>{ path, args }</code>; resolution picks the longest provided prefix
+            and dispatches the remainder; targets that don't implement <code>call</code> get the
+            remainder replayed onto their members, receiver-preserved, in the process where they
+            live.
+          </dd>
+          <dt>narrowing / access set</dt>
+          <dd>
+            <code>itx.projects.get(id)</code> — the access check, returning a NEW handle bound to
+            the project. Access is <code>"all"</code> (admin) or a list of project ids; missing and
+            forbidden are byte-identical NOT_FOUND. Narrowing is construction, never a flag.
+          </dd>
+          <dt><code>ItxProps</code></dt>
+          <dd>
+            The one serializable parameterization crossing boundaries:
+            <code>{ context, contextAddress?, projectId?, access?, capabilityPath? }</code>.
+            Identity and attribution only — never composition, never authority-by-content.
+          </dd>
+          <dt>project worker</dt>
+          <dd>
+            The worker built from the project's own config repo (slug <code>project</code>) — the
+            <code>worker</code> default, an ordinary repo source
+            (<code>PROJECT_WORKER_SOURCE</code>). The platform's only guarantee is that the repo
+            exists.
+          </dd>
+        </dl>
+      </section>
 
-  <p>
-    Mechanics behind it: <code>McpClient</code> is an ordinary loopback RPC target (MCP is a
-    client <em>implementation</em>, not a transport — deliberately not a capability kind). Its
-    streamable-HTTP transport is stateless: connect → call → close per invocation, all HTTP
-    through the cap's own <code>itx.fetch</code>. Its <code>describeItx</code> answers
-    <code>{}</code> — an MCP surface is dynamic, <code>listTools()</code> is the discovery
-    door. And the placeholder design has a security property worth repeating from §5: a live
-    <code>fetch</code> <em>shadow</em> receives placeholders <strong>unsubstituted</strong> —
-    substitution exists only in the default pipe, so an interceptor never sees secret material.
-  </p>
-
-  <h3>Recipe: any OpenAPI spec becomes a typed capability</h3>
-
-  <script type="text/plain" class="code" data-title="examples.ts — OpenApiClient: spec-derived types via describeItx" data-lang="ts">
-await itx.provideCapability({
-  name: "petstore",
-  capability: {
-    type: "rpc",
-    worker: { type: "loopback" },
-    entrypoint: "OpenApiClient",
-    props: {
-      specUrl: "https://petstore3.swagger.io/api/v3/openapi.json",
-      // For authenticated APIs, add headers with a secret placeholder:
-      // headers: { authorization: 'Bearer getSecret({ key: "API_TOKEN" })' },
-    },
-  },
-});
-
-// Flat operationIds, ONE merged input object (path params + query params +
-// body properties), through project egress:
-const pets = await itx.petstore.findPetsByStatus({ status: "available" });
-
-// describe() now carries spec-derived TypeScript — the provider answered
-// the platform's provide-time describeItx probe, no callsite ceremony.
-const { capabilities } = await itx.describe();
-capabilities.find((cap) => cap.name === "petstore").types;
-// → "declare function findPetsByStatus(input: { status?: … }): Promise<…>; …"</script>
-
-  <div class="demo" id="demo-describe">
-    <div class="dtitle"><span class="live">●</span> live demo — the describeItx hook, in the toy</div>
-    <div class="toolbar">
-      <button data-act="provide" class="primary">provide "petstore" (OpenApiClient address, no types given)</button>
-      <button data-act="call">itx.petstore.findPetsByStatus({ status: "available" })</button>
-      <button data-act="describe">describe()</button>
-    </div>
-    <div class="panes">
-      <div class="pane"><h4>journal — note meta.types arrived AT PROVIDE TIME</h4><div class="body" id="d9-journal"></div></div>
-      <div class="pane"><h4>describe() / calls</h4><div class="body log" id="d9-log"></div></div>
-    </div>
-  </div>
-
-  <h3>Recipe: your laptop as a capability</h3>
-
-  <script type="text/plain" class="code" data-title="README scene 2 — offer a capability from your laptop (real API)" data-lang="ts">
-import { withItx } from "~/itx/client.ts";
-
-using itx = withItx({ baseUrl, token, context: "my-project" });
-
-await itx.provideCapability({
-  name: "runSwiftOnMyMac",
-  instructions: "Compile-and-run Swift on Jonas's Mac. Pass the source string.",
-  capability: async (src) => runSwift(src),
-});
-// While your process stays connected, every agent, REPL, and script in the
-// project can call itx.runSwiftOnMyMac(src) — the call travels back over
-// YOUR connection and runs in YOUR process. The instructions you attach are
-// what everyone else's describe() will say — write them for the stranger
-// who finds your capability there.</script>
-
-  <h3>Recipe: fetch middleware (extend + super)</h3>
-  <p>
-    Already shown in full in §5 — shadow <code>fetch</code> on an extension with a plain
-    function, delegate to the real pipe via <code>session.super.fetch(request)</code>. It earns
-    its place in this list because it is pure composition: no interception API exists; the
-    recipe is just the chain (§5) plus the one egress door (Law 5).
-  </p>
-
-  <h3>Two more describe-adjacent doors</h3>
-  <ul>
-    <li>
-      <strong>HTTP exposure</strong>: a cap provided with <code>meta: { http: { expose: true } }</code>
-      gets its own hostname — <code>https://{cap}--{project}.{base}/…</code> →
-      <code>ItxCapabilityIngress</code>: 404 unless exposed; the gate is admin bearer, a signed
-      share URL, or <code>meta.http.public</code>; then one core dispatch with
-      <code>[...capabilityPath, "fetch"]</code>.
-    </li>
-    <li>
-      <strong><code>itx.shareUrl({ name, path?, ttlSeconds? })</code></strong> — "let me show
-      you something real quick": a signed, expiring URL for one HTTP-exposed cap. Possession
-      grants exactly that cap's fetch surface until expiry — the realm's one deliberate
-      bearer-token edge.
-    </li>
-  </ul>
-
-  <aside class="note">
-    <p><strong>The Laws — the invariants that ARE the architecture (README, condensed):</strong></p>
-    <p>1. The journal holds the facts; the node holds live refs; code holds composition.<br>
-       2. Props carry identity, never composition or authority-by-content.<br>
-       3. Auth happens at connect, nowhere else — which context your handle points at is the authority.<br>
-       4. Narrowing is construction: <code>itx.projects.get()</code> and <code>itx.extend()</code> return new handles on narrower contexts, never flags on wider ones.<br>
-       5. All policy-governed egress flows through one pipe; secret placeholders are substituted only in the stateless terminal pipe.<br>
-       6. One calling convention: <code>target.call({ path, args })</code> — the members/path-call choice lives at the edges, never in stored data.<br>
-       7. Cap'n Web terminates in the stateless worker, never in a DO.</p>
-  </aside>
-</section>
-
-<!-- ============================================================ 10 DOCTRINE -->
-<section id="doctrine">
-  <div class="kicker">Section 10</div>
-  <h2>Extending the platform: how to build the next domain object</h2>
-  <p>
-    itx is the reference implementation of a standing doctrine
-    (<code>docs/domain-objects-and-stream-processors.md</code>) for designing <em>any</em>
-    durable domain object on this platform — agents, contexts, MCP sessions, whatever comes
-    next. A context is a domain object whose state is its capability table and whose creation
-    event is <code>context-created</code>. The rules:
-  </p>
-  <ul>
-    <li>
-      <strong>Creation is an event.</strong> A durable thing's existence is not configuration —
-      it is the FIRST event in its own stream: mint the id, append the birth certificate,
-      return a handle. No <code>initialize()</code> RPC, no idempotency keys as a correctness
-      mechanism; exactly-once is a property of the fold (first creation event wins, later ones
-      are inert). Lazy materialization: the object comes alive on first dispatch by reading its
-      own journal.
-    </li>
-    <li>
-      <strong>Derive what names carry; reduce everything else.</strong> DO names are structured
-      records (project id, path). Identity, journal ref, and self-address are projections of
-      the name — never configuration. Anything a name cannot carry arrives as an event.
-    </li>
-    <li>
-      <strong>State is a fold; the checkpoint is disposable.</strong> Storage holds
-      <code>{ offset, state }</code> as a cache of <code>reduce</code> over the journal. Delete
-      it and replay rebuilds it. The stream is the only authority.
-    </li>
-    <li>
-      <strong>Side effects live in <code>processEvent</code>, never in <code>reduce</code>.</strong>
-      Replay rebuilds state without re-running effects (<code>sideEffectsAfterOffset</code>);
-      serialized batches give in-order execution; a requested/completed event pair makes
-      at-least-once reruns detectable.
-    </li>
-    <li>
-      <strong>Self-describing, always.</strong> Every domain object answers
-      <code>describe()</code>; every provided surface carries <code>instructions</code> and
-      <code>types</code> from the moment it exists. The acceptance test: an agent with no prior
-      knowledge, handed a stub, acts competently from <code>describe()</code> alone.
-    </li>
-  </ul>
-
-  <h3>Worked example: designing <code>CronSchedule</code></h3>
-  <p>
-    A hypothetical new domain object — recurring scheduled script runs for a project — designed
-    step by step under the rules. (Hypothetical: this does not exist in the codebase; it is the
-    doctrine applied.)
-  </p>
-
-  <p><strong>Step 1 — the structured name.</strong> One Durable Object per schedule, its name
-  the stream coordinate: <code>&lt;projectId&gt;:/cron/&lt;cron_…&gt;</code>. Identity
-  (<code>cron_…</code>, the last path segment), journal ref
-  (<code>(projectId, "/cron/&lt;id&gt;")</code>), and self-address
-  (<code>{ type: "rpc", worker: { type: "durable-object", binding: "CRON", name } }</code>) are
-  all parses of the name. Note the path does <em>not</em> claim the reserved <code>itx</code>
-  segment — that belongs to context journals. If the platform keeps a D1 row mapping bare
-  <code>cron_…</code> ids to coordinates, it is a directory, never the authority.</p>
-
-  <p><strong>Step 2 — the journal events, birth certificate first.</strong></p>
-
-  <script type="text/plain" class="code" data-title="hypothetical cron-contract.ts — the event vocabulary" data-lang="ts">
-export const CRON_EVENT_TYPES = {
-  // The birth certificate — event #1, carrying identity and creation facts.
-  scheduleCreated:  "events.iterate.com/cron/schedule-created",   // { id, spec, script, parent: { id, address } }
-  scheduleUpdated:  "events.iterate.com/cron/schedule-updated",   // { spec?, script? }
-  schedulePaused:   "events.iterate.com/cron/schedule-paused",    // {}
-  scheduleResumed:  "events.iterate.com/cron/schedule-resumed",   // {}
-  // The at-least-once pair: appending fire-requested IS requesting work.
-  fireRequested:    "events.iterate.com/cron/fire-requested",     // { fireId, scheduledForMs, enqueued: true }
-  fireCompleted:    "events.iterate.com/cron/fire-completed",     // { fireId, result | error }
-} as const;</script>
-
-  <p>
-    Creating a schedule is one append of <code>schedule-created</code> — no initialize RPC,
-    nothing touches the new DO; it materializes when the first dispatch (or its alarm) makes it
-    consume its journal. Payload schemas stay deliberately loose, so a journal carrying events
-    from before a deploy never wedges the fold.
-  </p>
-
-  <p><strong>Step 3 — the reduce (pure, module-level, defensive).</strong></p>
-
-  <script type="text/plain" class="code" data-title="hypothetical — the fold" data-lang="ts">
-export function reduceCronJournalEvent(state, event) {
-  const p = event.payload ?? {};
-  switch (event.type) {
-    case CRON_EVENT_TYPES.scheduleCreated:
-      if (state.schedule !== null) return state;   // first birth certificate wins
-      if (typeof p.id !== "string") return state;  // malformed payloads never wedge replay
-      return { ...state, schedule: { id: p.id, spec: p.spec, script: p.script, paused: false } };
-    case CRON_EVENT_TYPES.scheduleUpdated:
-      if (state.schedule === null) return state;
-      return { ...state, schedule: { ...state.schedule, ...(p.spec ? { spec: p.spec } : {}), ...(p.script ? { script: p.script } : {}) } };
-    case CRON_EVENT_TYPES.schedulePaused:
-      return state.schedule ? { ...state, schedule: { ...state.schedule, paused: true } } : state;
-    case CRON_EVENT_TYPES.scheduleResumed:
-      return state.schedule ? { ...state, schedule: { ...state.schedule, paused: false } } : state;
-    case CRON_EVENT_TYPES.fireRequested:
-      if (p.enqueued !== true || typeof p.fireId !== "string") return state;
-      return { ...state, pendingFires: { ...state.pendingFires, [p.fireId]: true } };
-    case CRON_EVENT_TYPES.fireCompleted: {
-      if (!(p.fireId in state.pendingFires)) return state;  // unknown/duplicate completion: inert
-      const pendingFires = { ...state.pendingFires };
-      delete pendingFires[p.fireId];
-      return { ...state, pendingFires };
-    }
-    default:
-      return state;
-  }
-}</script>
-
-  <p>
-    <strong>Step 4 — side effects in <code>processEventBatch</code>, never in reduce.</strong>
-    The alarm handler appends <code>fire-requested { enqueued: true }</code>;
-    <code>processEventBatch</code> sees it (past <code>sideEffectsAfterOffset</code>, still
-    pending in batch-final state), runs the script — the side effect — and appends
-    <code>fire-completed</code>. A replay rebuilds <code>pendingFires</code> without re-running
-    anything; a crash between the pair leaves a pending entry that the next wake detects and
-    re-runs (at-least-once, detectable). Setting the next alarm is also a
-    <code>processEvent</code> concern, derived from folded state.
-  </p>
-
-  <p><strong>Step 5 — the capability surface.</strong> How does anyone reach it? Provide it —
-  with instructions and types, from the moment it exists:</p>
-
-  <script type="text/plain" class="code" data-title="hypothetical — cron as a capability (a loopback, like SecretsCapability)" data-lang="ts">
-// First-party path: a CronCapability loopback entrypoint, added to
-// DIALABLE_LOOPBACKS, scoping STRICTLY by the dial-injected projectId —
-// the same discipline as SecretsCapability. Then, on the project context:
-await itx.provideCapability({
-  name: "cron",
-  instructions:
-    "Recurring scheduled runs: itx.cron.create({ spec, script }) (spec is a " +
-    "cron expression; script is `async (itx) => …`), list(), pause({ id }), " +
-    "resume({ id }), history({ id }).",
-  types: `declare function create(input: { spec: string; script: string }): Promise<{ id: string }>;
-declare function list(): Promise<{ id: string; spec: string; paused: boolean }[]>;
-declare function pause(input: { id: string }): Promise<void>;
-declare function resume(input: { id: string }): Promise<void>;`,
-  capability: { type: "rpc", worker: { type: "loopback" }, entrypoint: "CronCapability" },
-});
-// (Alternative: allowlist the CRON namespace via APP_CONFIG_ITX and dial
-// { type: "durable-object", binding: "CRON", name } directly — remembering
-// the dial scopes names as itx:<projectId>:<name>, so only namespaces
-// DESIGNED to be reached that way belong on the allowlist.)</script>
-
-  <p>
-    Promoting <code>cron</code> into the defaults later is a deploy, not a migration: add it to
-    <code>PLATFORM_PROJECT_CAPABILITIES</code> and every chain sees it immediately; any
-    project's own <code>cron</code> row shadows it.
-  </p>
-
-  <div class="demo" id="demo-cron">
-    <div class="dtitle"><span class="live">●</span> live demo — the CronSchedule fold, under the doctrine</div>
-    <div class="toolbar">
-      <button data-act="create" class="primary">append schedule-created</button>
-      <button data-act="create-dup">append schedule-created again (retried append)</button>
-      <button data-act="update">append schedule-updated</button>
-      <button data-act="request">append fire-requested</button>
-      <button data-act="complete">append fire-completed</button>
-      <button data-act="wipe">wipe checkpoint &amp; replay</button>
-    </div>
-    <div class="panes">
-      <div class="pane"><h4>the journal</h4><div class="body" id="cron-journal"></div></div>
-      <div class="pane"><h4>the fold: { schedule, pendingFires }</h4><div class="body" id="cron-state"></div></div>
-    </div>
-    <div class="panes">
-      <div class="pane" style="grid-column: 1 / -1"><h4>notes</h4><div class="body log" id="cron-log"></div></div>
-    </div>
-  </div>
-
-  <h3>The review checklist</h3>
-  <ul>
-    <li><strong>What does <code>describe()</code> say about it?</strong> Could an agent with no prior knowledge act competently from that alone?</li>
-    <li>Is creation exactly one append, with the birth certificate as event #1? Is there any initialize RPC, setup path, or "configured" residue replay cannot reproduce?</li>
-    <li>Can you delete the checkpoint right now and lose nothing?</li>
-    <li>Does anything write state outside the journal? (If it needs to be auditable, is it an event — because events are the only writes?)</li>
-    <li>Do retried appends and duplicate deliveries reduce to no-ops in the fold, without idempotency keys as a correctness mechanism?</li>
-    <li>Are all side effects in <code>processEvent</code>/<code>processEventBatch</code>, guarded by a requested/completed pair — never in <code>reduce</code>?</li>
-    <li>Does the name carry exactly identity (and the journal coordinate), with everything else reduced from events? Is any D1 row strictly a directory?</li>
-    <li>How does it become dialable — a loopback scoping by dial-injected props, or an allowlisted DO namespace designed for <code>itx:&lt;projectId&gt;:&lt;name&gt;</code> scoping?</li>
-    <li>Does its stream path stay clear of the reserved <code>itx</code> segment?</li>
-  </ul>
-</section>
-
-<!-- ============================================================ 11 GLOSSARY -->
-<section id="glossary">
-  <div class="kicker">Section 11</div>
-  <h2>Glossary</h2>
-  <dl class="gloss">
-    <dt>context</dt>
-    <dd>An addressable node that holds named capabilities. Contexts form a prototype chain (child → parent with shadowing); a context may be durable (a DO with a journal) but durability is not part of the concept. <code>ContextRef</code>: <code>"global"</code>, a project id (<code>prj_…</code>; <code>proj_…</code> legacy), or a child id (<code>itx_…</code>).</dd>
-    <dt>capability</dt>
-    <dd>A name (a path, really) plus a <code>CapabilityTarget</code> — either a live stub someone handed the context, or a serializable address of where the implementation lives. Its kind is its provider's kind: <code>"live" | "rpc" | "url"</code>.</dd>
-    <dt>handle (<code>ItxHandle</code>)</dt>
-    <dd>The cheap, ephemeral view user code touches — identical in browser, Node, REPL, project worker, scripts, and capabilities. The trust kernel (the four verbs plus <code>extend</code>, <code>super</code>, <code>streams</code>, <code>projects</code>, <code>project</code>, <code>fetch</code>, <code>capability()</code>, <code>shareUrl</code>) plus a fallthrough proxy: any unknown name becomes a PathProxy whose terminal call is one invoke on the node's core. Minted exactly three ways: connect, narrowing, platform wiring.</dd>
-    <dt>stub</dt>
-    <dd>A live RPC reference to an object in another process (capnweb or Workers RPC). "An Itx holds capabilities; everything else holds a stub of one." <code>ItxStub</code> is the four-verb context protocol shape.</dd>
-    <dt>core (<code>Itx</code>)</dt>
-    <dd>The capability core a context node embeds (<code>itx.ts</code>): the path-keyed entry table, the live-stub table, longest-prefix dispatch, chain delegation — four verbs: <code>provideCapability</code>, <code>revokeCapability</code>, <code>describe</code>, <code>invoke</code>. Exposed by hosts via an <code>itx()</code> <em>method</em> (workerd doesn't pipeline through property accesses).</dd>
-    <dt>journal</dt>
-    <dd>The context's event stream — the only authority. Provides/revokes append events and self-ingest; nothing else writes state.</dd>
-    <dt>fold / reduce / replay</dt>
-    <dd>The pure function from journal to state (<code>reduceItxJournalEvent</code>). Replay = re-running the fold from offset 0; defensive by design so old event shapes never wedge it.</dd>
-    <dt>checkpoint</dt>
-    <dd><code>{ offset, state }</code> in the host DO's storage — a disposable cache of the fold. Delete it; replay rebuilds it.</dd>
-    <dt>dial</dt>
-    <dd>The one effectful function injected into the core: <code>CapabilityAddress → PathCallable</code>. Owns reach (allowlists), injects attribution props, wires isolates and facets.</dd>
-    <dt>chain</dt>
-    <dd>The parent links contexts resolve through: <code>itx_… → project → defaults (code)</code>. A lookup miss delegates the whole path upward, carrying origin.</dd>
-    <dt>defaults</dt>
-    <dd>The code-rooted final link of every chain: <code>PlatformContext</code>, read-only, answering the context protocol from <code>PLATFORM_PROJECT_CAPABILITIES</code> (ai, fetch, streams, secrets, repos, workspace, worker). Labeled <code>from: "defaults"</code> in describe. Shipping one is a deploy, not a migration.</dd>
-    <dt>extend</dt>
-    <dd><code>itx.extend({ name? })</code>: mint a child context — an id, a journal with a birth certificate, an address, a handle. <code>Object.create(parent)</code> for contexts.</dd>
-    <dt>shadow</dt>
-    <dd>Providing (at a name or deeper path) on a child what the chain already resolves — your entry wins longest-prefix locally; revoke it and the inherited entry resurfaces.</dd>
-    <dt><code>super</code></dt>
-    <dd>The handle on the parent context — middleware's "call next()". A reserved word, so dot it, don't destructure it.</dd>
-    <dt>live vs durable</dt>
-    <dd>Live: an inbound stub, session-bound, in-memory, journaled only as an event (describe shows <code>connected</code>). Durable: a serializable address, restored at invoke time. Everything writable is durable; the root of every chain is code.</dd>
-    <dt>address (<code>CapabilityAddress</code>)</dt>
-    <dd><code>{ type: "rpc", worker, entrypoint?, props? }</code> or <code>{ type: "url", url, headers? }</code> — the system's one serializable data structure; context nodes are addressed with it too.</dd>
-    <dt>sturdy ref</dt>
-    <dd>Cap'n Proto's term for a serializable token restorable to a live capability. The serializable address kinds are this realm's sturdy-ref format — pure names, zero authority by content; <code>resolveItx</code> is the restorer. The HTTP share token is the one deliberate sealed/bearer-form exception, at the edge only.</dd>
-    <dt><code>WorkerSource</code></dt>
-    <dd>Stored source for a <code>{ type: "source" }</code> worker: <code>inline</code> (code in the record, cached by <code>cacheKey</code>) or <code>repo</code> (code in a project repo, built per commit). Plus <code>entrypoint</code> and <code>exportType</code> ("worker-entrypoint" stateless | "durable-object" facet).</dd>
-    <dt>the memo</dt>
-    <dd>The R2 build cache for repo sources: <code>build/&lt;hash(projectId, repo, sha, path, bundle, compatibilityDate)&gt;</code> → built modules. An optimization, never an authority — every entry is reproducible from its key.</dd>
-    <dt>birth certificate</dt>
-    <dd><code>context-created { id, name, parent: { id, address } }</code> — the first event in a journal. The fold takes the first and ignores later ones; parentage and descriptor derive from it. Code-born contexts (the project context, the defaults) have none.</dd>
-    <dt>stream coordinate</dt>
-    <dd><code>(namespace, path)</code> — where a stream (hence a journal, hence a context's identity) lives. The generic host's DO name is the coordinate verbatim: <code>&lt;namespace&gt;:&lt;journalPath&gt;</code>.</dd>
-    <dt>reserved segment</dt>
-    <dd>Three reservations, by position: the stream path segment <code>itx</code> (context journals only); <code>RESERVED_PATH_SEGMENTS</code> (protocol/prototype names like <code>then</code>, <code>call</code>, <code>constructor</code>, <code>describeItx</code> — never traversable anywhere in a path); <code>RESERVED_CAPABILITY_NAMES</code> (the trust-kernel builtins — banned as a <em>first</em> segment only; <code>fetch</code> and <code>streams</code> deliberately not on it, because shadowing them is the point).</dd>
-    <dt><code>describeItx</code></dt>
-    <dd>The reserved provide-time self-description probe: an rpc provide with no caller <code>types</code> is dialed once and asked; a call-implementing target may answer <code>{ instructions?, types? }</code>, journaled into meta (64 KB cap, best-effort, 3 s/15 s deadline).</dd>
-    <dt>placeholder / substitution</dt>
-    <dd><code>'Bearer getSecret({ key: "X" })'</code> in an outbound header. Material lives in project secrets; substitution happens only in the stateless terminal egress pipe; journals, describe(), isolates, and fetch shadows only ever see the placeholder.</dd>
-    <dt>allowlist</dt>
-    <dd><code>DialableTargets</code> — which bindings/loopbacks/DO-namespaces an rpc address may dial. Hardcoded defaults ∪ deployment config; config can only widen; checked at dial time (first invoke), never at provide.</dd>
-    <dt>facet</dt>
-    <dd>A Durable Object instantiated <em>inside</em> the DO hosting a context (<code>ctx.facets</code>), with its own private SQLite stored in the host. How <code>exportType: "durable-object"</code> source caps get state with zero provisioning; named <code>cap:&lt;name&gt;</code> (no cache key) so data survives code upgrades.</dd>
-    <dt>origin (<code>ItxOrigin</code>)</dt>
-    <dd><code>{ id, address }</code> of the context a delegated call started at. Set by delegating nodes, never by handles — the chain's trusted identity channel for attribution, context-scoped caps, and origin dial-back.</dd>
-    <dt>PathCall / longest-prefix / member replay</dt>
-    <dd>The wire shape <code>{ path, args }</code>; resolution picks the longest provided prefix and dispatches the remainder; targets that don't implement <code>call</code> get the remainder replayed onto their members, receiver-preserved, in the process where they live.</dd>
-    <dt>narrowing / access set</dt>
-    <dd><code>itx.projects.get(id)</code> — the access check, returning a NEW handle bound to the project. Access is <code>"all"</code> (admin) or a list of project ids; missing and forbidden are byte-identical NOT_FOUND. Narrowing is construction, never a flag.</dd>
-    <dt><code>ItxProps</code></dt>
-    <dd>The one serializable parameterization crossing boundaries: <code>{ context, contextAddress?, projectId?, access?, capabilityPath? }</code>. Identity and attribution only — never composition, never authority-by-content.</dd>
-    <dt>project worker</dt>
-    <dd>The worker built from the project's own config repo (slug <code>project</code>) — the <code>worker</code> default, an ordinary repo source (<code>PROJECT_WORKER_SOURCE</code>). The platform's only guarantee is that the repo exists.</dd>
-  </dl>
-</section>
-
-<footer class="page">
-  <p><strong>Ground truth this page was written against</strong> (read them in this order and you should find zero contradictions):</p>
-  <ul>
-    <li><code>apps/os/src/itx/README.md</code> — the three scenes, the Laws, the build order</li>
-    <li><code>apps/os/src/itx/types.ts</code> — the design of record (handwritten, import-free)</li>
-    <li><code>apps/os/src/itx/itx.ts</code> — the core; <code>contract.ts</code> — the journal vocabulary</li>
-    <li><code>apps/os/src/itx/platform-context.ts</code>, <code>dial.ts</code>, <code>journal.ts</code>, <code>source-build.ts</code>, <code>path-proxy.ts</code></li>
-    <li><code>apps/os/src/itx/examples.ts</code> + <code>capabilities/mcp-client.ts</code> + <code>capabilities/openapi-client.ts</code> — the recipes</li>
-    <li><code>apps/os/docs/itx-next.md</code> — design history; <code>docs/domain-objects-and-stream-processors.md</code> — the doctrine</li>
-  </ul>
-  <p><strong>Where this page simplifies (the toy vs the real core):</strong></p>
-  <ul>
-    <li>The toy is synchronous and in-process; the real verbs are async and cross RPC boundaries (capnweb and Workers RPC), with dup-retention of live stubs, member-walking retention for plain-object providers, and <code>onRpcBroken</code> teardown.</li>
-    <li>The toy's append/catch-up is a simple loop; the real seam is single-flight with an append counter guaranteeing read-your-writes under concurrent writers.</li>
-    <li>The toy omits: script-execution events and processor-mode runs, structural address validation, the 64 KB describeItx budget and timeouts, error masking (NOT_FOUND), the access model, and <code>shareUrl</code>/HTTP ingress.</li>
-    <li>The toy's reserved-name sets are abbreviated; the real lists live in <code>path-proxy.ts</code> and <code>itx.ts</code>.</li>
-    <li>The demo "defaults" simulate their dispatch results in one line each; the real defaults dial real entrypoints (EgressPipe, StreamsCapability, …) in-process.</li>
-    <li>The toy handle is only the fallthrough proxy; the real handle adds the built-in members and is minted via connect/narrowing/wiring.</li>
-  </ul>
-  <p>Generated as a single self-contained file; no external dependencies; works from <code>file://</code>.</p>
-</footer>
-<script id="toy-itx">
-/* The toy itx: a faithful miniature of apps/os/src/itx/itx.ts. Every demo
+      <footer class="page">
+        <p>
+          <strong>Ground truth this page was written against</strong> (read them in this order and
+          you should find zero contradictions):
+        </p>
+        <ul>
+          <li>
+            <code>apps/os/src/itx/README.md</code> — the three scenes, the Laws, the build order
+          </li>
+          <li>
+            <code>apps/os/src/itx/types.ts</code> — the design of record (handwritten, import-free)
+          </li>
+          <li>
+            <code>apps/os/src/itx/itx.ts</code> — the core; <code>contract.ts</code> — the journal
+            vocabulary
+          </li>
+          <li>
+            <code>apps/os/src/itx/platform-context.ts</code>, <code>dial.ts</code>,
+            <code>journal.ts</code>, <code>source-build.ts</code>, <code>path-proxy.ts</code>
+          </li>
+          <li>
+            <code>apps/os/src/itx/examples.ts</code> + <code>capabilities/mcp-client.ts</code> +
+            <code>capabilities/openapi-client.ts</code> — the recipes
+          </li>
+          <li>
+            <code>apps/os/docs/itx-next.md</code> — design history;
+            <code>docs/domain-objects-and-stream-processors.md</code> — the doctrine
+          </li>
+        </ul>
+        <p><strong>Where this page simplifies (the toy vs the real core):</strong></p>
+        <ul>
+          <li>
+            The toy is synchronous and in-process; the real verbs are async and cross RPC boundaries
+            (capnweb and Workers RPC), with dup-retention of live stubs, member-walking retention
+            for plain-object providers, and <code>onRpcBroken</code> teardown.
+          </li>
+          <li>
+            The toy's append/catch-up is a simple loop; the real seam is single-flight with an
+            append counter guaranteeing read-your-writes under concurrent writers.
+          </li>
+          <li>
+            The toy omits: script-execution events and processor-mode runs, structural address
+            validation, the 64 KB describeItx budget and timeouts, error masking (NOT_FOUND), the
+            access model, and <code>shareUrl</code>/HTTP ingress.
+          </li>
+          <li>
+            The toy's reserved-name sets are abbreviated; the real lists live in
+            <code>path-proxy.ts</code> and <code>itx.ts</code>.
+          </li>
+          <li>
+            The demo "defaults" simulate their dispatch results in one line each; the real defaults
+            dial real entrypoints (EgressPipe, StreamsCapability, …) in-process.
+          </li>
+          <li>
+            The toy handle is only the fallthrough proxy; the real handle adds the built-in members
+            and is minted via connect/narrowing/wiring.
+          </li>
+        </ul>
+        <p>
+          Generated as a single self-contained file; no external dependencies; works from
+          <code>file://</code>.
+        </p>
+      </footer>
+      <script id="toy-itx">
+        /* The toy itx: a faithful miniature of apps/os/src/itx/itx.ts. Every demo
    on this page runs through this one implementation. The page renders the
    three regions below into sections 2 and 3 verbatim, so the code you read
    there is the code that is running. */
 
-//#region convention
-// ---- dots ⇄ data: the ONE calling convention ------------------------------
+        //#region convention
+        // ---- dots ⇄ data: the ONE calling convention ------------------------------
 
-// Names that may never traverse a dynamic surface (abbreviated — the real
-// list lives in path-proxy.ts). "describeItx" is the reserved provide-time
-// self-description probe (section 9).
-const RESERVED_PATH_SEGMENTS = new Set([
-  "then", "call", "constructor", "__proto__", "prototype",
-  "toString", "valueOf", "dup", "describeItx",
-]);
+        // Names that may never traverse a dynamic surface (abbreviated — the real
+        // list lives in path-proxy.ts). "describeItx" is the reserved provide-time
+        // self-description probe (section 9).
+        const RESERVED_PATH_SEGMENTS = new Set([
+          "then",
+          "call",
+          "constructor",
+          "__proto__",
+          "prototype",
+          "toString",
+          "valueOf",
+          "dup",
+          "describeItx",
+        ]);
 
-// Consumer side: property access accumulates a path LOCALLY (zero round
-// trips); the terminal call fires once with the accumulated PathCall.
-// `then` reads undefined so `await` never misfires mid-chain.
-function pathProxy(onCall, path = []) {
-  const fn = (...args) => onCall({ path, args });
-  return new Proxy(fn, {
-    apply: (_t, _this, args) => onCall({ path, args }),
-    get(_t, key) {
-      if (typeof key === "symbol") return undefined;
-      if (RESERVED_PATH_SEGMENTS.has(key)) return undefined;
-      return pathProxy(onCall, [...path, key]);
-    },
-  });
-}
-
-// Receiver side: walk the segments on a concrete object and call the
-// terminal method ON ITS PARENT (receivers preserved). An empty path calls
-// the target itself as a function. This is the authoritative reserved-name
-// gate: invoke is public, so a path can be hand-built.
-function replayPathCall(target, { path, args }) {
-  for (const seg of path) {
-    if (RESERVED_PATH_SEGMENTS.has(seg)) {
-      throw new Error(`Capability path segment "${seg}" is reserved.`);
-    }
-  }
-  if (path.length === 0) {
-    if (typeof target !== "function") {
-      throw new Error("Capability invoked as a function but the target is not callable.");
-    }
-    return target(...args);
-  }
-  let parent = target;
-  for (const seg of path.slice(0, -1)) {
-    parent = parent == null ? undefined : parent[seg];
-    if (parent == null) throw new Error(`Capability path ${path.join(".")} hit ${String(parent)}.`);
-  }
-  const method = path[path.length - 1];
-  if (typeof parent[method] !== "function") {
-    throw new Error(`Capability path ${path.join(".")} did not resolve to a function.`);
-  }
-  return parent[method](...args);
-}
-
-// Dispatch: among the provided entries (keyed by dot-joined path), the
-// LONGEST prefix of the call path wins; the REMAINDER becomes the call
-// path. One exact lookup per candidate depth — never traverses targets.
-function resolveLongestProvidedPrefix(capabilities, path) {
-  for (let depth = path.length; depth >= 1; depth--) {
-    const entry = capabilities[path.slice(0, depth).join(".")];
-    if (entry !== undefined) return { entry, remainder: path.slice(depth) };
-  }
-  return null;
-}
-//#endregion
-
-//#region journal
-// ---- the journal: events are the only writes -------------------------------
-
-const ITX_EVENT_TYPES = {
-  contextCreated: "events.iterate.com/itx/context-created",
-  capabilityProvided: "events.iterate.com/itx/capability-provided",
-  capabilityRevoked: "events.iterate.com/itx/capability-revoked",
-  capabilityDisconnected: "events.iterate.com/itx/capability-disconnected",
-};
-
-const initialState = () => ({ context: null, capabilities: {} });
-
-// The pure fold: one journal event into the next state. Defensive by
-// design — a malformed payload keeps the current state, so replay can
-// never wedge on a pre-deploy event shape.
-function reduceItxJournalEvent(state, event) {
-  const p = event.payload ?? {};
-  switch (event.type) {
-    case ITX_EVENT_TYPES.contextCreated:
-      // The FIRST birth certificate wins; later ones are inert (retried
-      // appends, replays) — exactly-once as a property of the fold.
-      if (state.context !== null) return state;
-      if (typeof p.id !== "string") return state;
-      return { ...state, context: { id: p.id, name: p.name ?? null, parent: p.parent ?? null } };
-    case ITX_EVENT_TYPES.capabilityProvided: {
-      if (!Array.isArray(p.path) || p.path.length === 0) return state;
-      const name = p.path.join(".");
-      const entry = { name, kind: p.kind, address: p.address ?? null, meta: p.meta ?? {}, owner: p.owner };
-      return { ...state, capabilities: { ...state.capabilities, [name]: entry } };
-    }
-    case ITX_EVENT_TYPES.capabilityRevoked: {
-      if (!Array.isArray(p.path)) return state;
-      const name = p.path.join(".");
-      if (!(name in state.capabilities)) return state;
-      const capabilities = { ...state.capabilities };
-      delete capabilities[name];
-      return { ...state, capabilities };
-    }
-    default:
-      // capability-disconnected is record-only: connectedness is computed
-      // from the live-stub table, never from events. Unknown types: inert.
-      return state;
-  }
-}
-
-// The live-vs-address discriminator: an ADDRESS is a PLAIN object (proto
-// Object.prototype or null) carrying type "rpc" | "url". Everything else
-// is live. Plainness MUST be checked first: property access on an RPC stub
-// returns a truthy pipelined stub, so probing .type first would
-// misclassify every live capability.
-function isCapabilityAddress(capability) {
-  if (typeof capability !== "object" || capability === null) return false;
-  const proto = Object.getPrototypeOf(capability);
-  if (proto !== Object.prototype && proto !== null) return false;
-  return capability.type === "rpc" || capability.type === "url";
-}
-//#endregion
-
-//#region core
-// ---- the core: one map, longest prefix, a chain ----------------------------
-
-// A cap name may not shadow the trust kernel — FIRST segment only; deeper
-// segments are fine. `fetch` and `streams` are deliberately NOT here:
-// shadowing them is how interception works.
-const RESERVED_CAPABILITY_NAMES = new Set([
-  "capability", "describe", "extend", "invoke", "project", "projects",
-  "provideCapability", "revokeCapability", "shareUrl", "super",
-]);
-
-class ToyItx {
-  constructor({ contextId, journalRef, journal, address, parentItx = null, dial = null }) {
-    this.contextId = contextId;   // identity — the journal records' owner
-    this.journalRef = journalRef; // { namespace, path } — the stream coordinate
-    this.journal = journal;       // the event stream (here: an array)
-    this.address = address;       // this node's own address — stamped as origin
-    this.parentItx = parentItx;   // () => ({ from, stub }) | null — the chain link
-    this.dial = dial;             // THE one effect: address → { call({ path, args }) }
-    this.liveStubs = new Map();   // session-bound; never journaled
-    this.state = initialState();  // the checkpoint: a disposable CACHE of the fold
-    this.offset = 0;
-  }
-
-  // ONE write path: append, then catch up through the one consumption door
-  // (read-your-writes; duplicate delivery is inert by offset bookkeeping).
-  append(type, payload) {
-    this.journal.push({ offset: this.journal.length + 1, type, payload });
-    this.catchUp();
-  }
-  catchUp() {
-    while (this.offset < this.journal.length) {
-      this.state = reduceItxJournalEvent(this.state, this.journal[this.offset]);
-      this.offset += 1;
-    }
-  }
-  wipeCheckpointAndReplay() { // the checkpoint is disposable: prove it
-    this.state = initialState();
-    this.offset = 0;
-    this.catchUp();
-  }
-
-  provideCapability({ name, path, capability, instructions, types, meta }) {
-    if ((name === undefined) === (path === undefined)) {
-      throw new Error("Provide exactly one of `name` or `path`.");
-    }
-    const segs = path ? [...path] : [name];
-    segs.forEach((seg, i) => {
-      if (!/^[A-Za-z_$][\w$]*$/.test(seg)) {
-        throw new Error(`Capability path segment ${JSON.stringify(seg)} must be a plain JavaScript identifier.`);
-      }
-      if ((i === 0 ? RESERVED_CAPABILITY_NAMES : RESERVED_PATH_SEGMENTS).has(seg)) {
-        throw new Error(`Capability ${i === 0 ? "name" : "path segment"} ${JSON.stringify(seg)} is reserved.`);
-      }
-    });
-    const capName = segs.join(".");
-    const fullMeta = {
-      ...meta,
-      ...(instructions !== undefined ? { instructions } : {}),
-      ...(types !== undefined ? { types } : {}),
-    };
-    let kind, address = null;
-    if (isCapabilityAddress(capability)) {
-      kind = capability.type;
-      address = capability;
-      this.liveStubs.delete(capName);
-      // The describeItx provide-time hook (section 9): an rpc provide with
-      // no caller-supplied types is dialed ONCE and asked. Best-effort:
-      // any miss just means an unenriched provide. Member-shaped targets
-      // hit the replay's reserved gate — collision protection working.
-      if (kind === "rpc" && fullMeta.types === undefined && this.dial) {
-        try {
-          const probe = this.dial(address, {
-            capabilityPath: capName,
-            origin: { id: this.contextId, address: this.address },
+        // Consumer side: property access accumulates a path LOCALLY (zero round
+        // trips); the terminal call fires once with the accumulated PathCall.
+        // `then` reads undefined so `await` never misfires mid-chain.
+        function pathProxy(onCall, path = []) {
+          const fn = (...args) => onCall({ path, args });
+          return new Proxy(fn, {
+            apply: (_t, _this, args) => onCall({ path, args }),
+            get(_t, key) {
+              if (typeof key === "symbol") return undefined;
+              if (RESERVED_PATH_SEGMENTS.has(key)) return undefined;
+              return pathProxy(onCall, [...path, key]);
+            },
           });
-          const answer = probe.call({ path: ["describeItx"], args: [] });
-          if (answer && typeof answer.types === "string") fullMeta.types = answer.types;
-          if (answer && typeof answer.instructions === "string" && fullMeta.instructions === undefined) {
-            fullMeta.instructions = answer.instructions;
+        }
+
+        // Receiver side: walk the segments on a concrete object and call the
+        // terminal method ON ITS PARENT (receivers preserved). An empty path calls
+        // the target itself as a function. This is the authoritative reserved-name
+        // gate: invoke is public, so a path can be hand-built.
+        function replayPathCall(target, { path, args }) {
+          for (const seg of path) {
+            if (RESERVED_PATH_SEGMENTS.has(seg)) {
+              throw new Error(`Capability path segment "${seg}" is reserved.`);
+            }
           }
-        } catch (_) { /* unenriched */ }
-      }
-    } else {
-      kind = "live";
-      // A bare function is wrapped so it speaks the one calling convention
-      // (empty remainder calls it); anything else IS the stub. The stub
-      // stays an instance field…
-      const live = typeof capability === "function"
-        ? { call: (input) => replayPathCall(capability, input) }
-        : capability;
-      this.liveStubs.set(capName, live);
-    }
-    // …but the EVENT is always journaled: the record outlives the session.
-    this.append(ITX_EVENT_TYPES.capabilityProvided, {
-      path: segs, kind, address, meta: fullMeta, owner: this.contextId, providedAtMs: Date.now(),
-    });
-  }
+          if (path.length === 0) {
+            if (typeof target !== "function") {
+              throw new Error("Capability invoked as a function but the target is not callable.");
+            }
+            return target(...args);
+          }
+          let parent = target;
+          for (const seg of path.slice(0, -1)) {
+            parent = parent == null ? undefined : parent[seg];
+            if (parent == null)
+              throw new Error(`Capability path ${path.join(".")} hit ${String(parent)}.`);
+          }
+          const method = path[path.length - 1];
+          if (typeof parent[method] !== "function") {
+            throw new Error(`Capability path ${path.join(".")} did not resolve to a function.`);
+          }
+          return parent[method](...args);
+        }
 
-  // Exact path match, never prefix. Only OWN entries can be revoked:
-  // claiming to revoke an inherited one would lie — shadow it instead.
-  revokeCapability({ name, path }) {
-    const segs = path ? [...path] : [name];
-    const capName = segs.join(".");
-    if (!(capName in this.state.capabilities)) {
-      const parent = this.parentItx && this.parentItx();
-      const inherited = parent && parent.stub.describe().find((d) => d.name === capName);
-      if (inherited) {
-        const from = inherited.from !== undefined ? inherited.from : parent.from;
-        throw new Error(
-          `Capability "${capName}" is not provided on this context — it is inherited from ` +
-          `${from === "defaults" ? "the defaults" : `context ${from}`} and cannot be revoked here; ` +
-          `provide your own "${capName}" on this context to take its place; the original stays on the parent.`,
-        );
-      }
-      return; // never existed: a no-op
-    }
-    this.append(ITX_EVENT_TYPES.capabilityRevoked, { path: segs });
-    this.liveStubs.delete(capName);
-  }
+        // Dispatch: among the provided entries (keyed by dot-joined path), the
+        // LONGEST prefix of the call path wins; the REMAINDER becomes the call
+        // path. One exact lookup per candidate depth — never traverses targets.
+        function resolveLongestProvidedPrefix(capabilities, path) {
+          for (let depth = path.length; depth >= 1; depth--) {
+            const entry = capabilities[path.slice(0, depth).join(".")];
+            if (entry !== undefined) return { entry, remainder: path.slice(depth) };
+          }
+          return null;
+        }
+        //#endregion
 
-  // The merged chain view: own entries first (no provenance field — they
-  // are yours), then ancestors', each stamped `from` one level below its
-  // owner. Suppression is exact-match only: a path shadow never hides the
-  // parent's broader entry.
-  describe() {
-    const own = Object.values(this.state.capabilities).map((entry) => ({
-      name: entry.name,
-      kind: entry.kind,
-      connected: entry.kind === "live" ? this.liveStubs.has(entry.name) : undefined,
-      instructions: entry.meta.instructions,
-      types: entry.meta.types,
-    }));
-    const parent = this.parentItx && this.parentItx();
-    if (!parent) return own;
-    const shadowed = new Set(own.map((d) => d.name));
-    return [
-      ...own,
-      ...parent.stub.describe()
-        .filter((d) => !shadowed.has(d.name))
-        .map((d) => (d.from === undefined ? { ...d, from: parent.from } : d)),
-    ];
-  }
+        //#region journal
+        // ---- the journal: events are the only writes -------------------------------
 
-  // The only dispatch in the system. The longest provided prefix wins and
-  // is called with the REMAINDER; a miss delegates the WHOLE path up the
-  // chain, carrying origin — the context the call STARTED at.
-  invoke({ path, args, origin }) {
-    this.catchUp();
-    const effectiveOrigin = origin ?? { id: this.contextId, address: this.address };
-    const resolved = resolveLongestProvidedPrefix(this.state.capabilities, path);
-    if (!resolved) {
-      const parent = this.parentItx && this.parentItx();
-      if (parent) return parent.stub.invoke({ path, args, origin: effectiveOrigin });
-      throw new Error(`No capability named "${path[0] ?? ""}" on this context or anywhere up its chain. describe() lists what exists.`);
-    }
-    const { entry, remainder } = resolved;
-    if (entry.kind === "live") {
-      const stub = this.liveStubs.get(entry.name);
-      if (!stub) {
-        throw new Error(
-          `Capability "${entry.name}" is registered but its provider is not connected. ` +
-          `Live capabilities last as long as the provider's session; the provider must ` +
-          `reconnect and call provideCapability() again.`,
-        );
-      }
-      // A target implementing `call` owns its whole method tree (the SDK
-      // shape); anything else IS its member tree — replay onto it, in the
-      // process where it lives.
-      if (typeof stub.call === "function") return stub.call({ path: remainder, args });
-      return replayPathCall(stub, { path: remainder, args });
-    }
-    return this.dial(entry.address, { capabilityPath: entry.name, origin: effectiveOrigin })
-      .call({ path: remainder, args });
-  }
+        const ITX_EVENT_TYPES = {
+          contextCreated: "events.iterate.com/itx/context-created",
+          capabilityProvided: "events.iterate.com/itx/capability-provided",
+          capabilityRevoked: "events.iterate.com/itx/capability-revoked",
+          capabilityDisconnected: "events.iterate.com/itx/capability-disconnected",
+        };
 
-  // extend(): creation is an event. Mint the id, give the child its own
-  // journal at <base>/itx/<id>, append the birth certificate (event #1),
-  // return. Nothing else touches the new node.
-  extend({ name } = {}) {
-    const id = "itx_" + Math.random().toString(36).slice(2, 8);
-    const base = journalBaseOf(this.journalRef.path);
-    const journalRef = {
-      namespace: this.journalRef.namespace,
-      path: (base === "/" ? "" : base) + "/itx/" + id,
-    };
-    const child = new ToyItx({
-      contextId: id,
-      journalRef,
-      journal: [],
-      address: childContextAddress(journalRef),
-      dial: this.dial,
-      parentItx: () => ({ from: this.contextId, stub: this }),
-    });
-    child.append(ITX_EVENT_TYPES.contextCreated, {
-      id, name: name ?? null,
-      parent: { id: this.contextId, address: this.address },
-    });
-    return child;
-  }
+        const initialState = () => ({ context: null, capabilities: {} });
 
-  // The handle's fallthrough: unknown names become a PathProxy whose
-  // terminal call is ONE invoke on this core.
-  handle() { return pathProxy((pathCall) => this.invoke(pathCall)); }
+        // The pure fold: one journal event into the next state. Defensive by
+        // design — a malformed payload keeps the current state, so replay can
+        // never wedge on a pre-deploy event shape.
+        function reduceItxJournalEvent(state, event) {
+          const p = event.payload ?? {};
+          switch (event.type) {
+            case ITX_EVENT_TYPES.contextCreated:
+              // The FIRST birth certificate wins; later ones are inert (retried
+              // appends, replays) — exactly-once as a property of the fold.
+              if (state.context !== null) return state;
+              if (typeof p.id !== "string") return state;
+              return {
+                ...state,
+                context: { id: p.id, name: p.name ?? null, parent: p.parent ?? null },
+              };
+            case ITX_EVENT_TYPES.capabilityProvided: {
+              if (!Array.isArray(p.path) || p.path.length === 0) return state;
+              const name = p.path.join(".");
+              const entry = {
+                name,
+                kind: p.kind,
+                address: p.address ?? null,
+                meta: p.meta ?? {},
+                owner: p.owner,
+              };
+              return { ...state, capabilities: { ...state.capabilities, [name]: entry } };
+            }
+            case ITX_EVENT_TYPES.capabilityRevoked: {
+              if (!Array.isArray(p.path)) return state;
+              const name = p.path.join(".");
+              if (!(name in state.capabilities)) return state;
+              const capabilities = { ...state.capabilities };
+              delete capabilities[name];
+              return { ...state, capabilities };
+            }
+            default:
+              // capability-disconnected is record-only: connectedness is computed
+              // from the live-stub table, never from events. Unknown types: inert.
+              return state;
+          }
+        }
 
-  // Simulate the provider's session dropping: stubs die, records survive.
-  disconnectSession() {
-    for (const capName of [...this.liveStubs.keys()]) {
-      this.liveStubs.delete(capName);
-      this.append(ITX_EVENT_TYPES.capabilityDisconnected, { path: capName.split(".") });
-    }
-  }
-}
+        // The live-vs-address discriminator: an ADDRESS is a PLAIN object (proto
+        // Object.prototype or null) carrying type "rpc" | "url". Everything else
+        // is live. Plainness MUST be checked first: property access on an RPC stub
+        // returns a truthy pipelined stub, so probing .type first would
+        // misclassify every live capability.
+        function isCapabilityAddress(capability) {
+          if (typeof capability !== "object" || capability === null) return false;
+          const proto = Object.getPrototypeOf(capability);
+          if (proto !== Object.prototype && proto !== null) return false;
+          return capability.type === "rpc" || capability.type === "url";
+        }
+        //#endregion
 
-// The journal base a child inherits: the path minus its /itx[/<id>] tail.
-// Chain depth ≠ path depth: every project-rooted extension files at
-// <base>/itx/<id>; parentage lives in the birth certificate.
-function journalBaseOf(journalPath) {
-  const segments = journalPath.split("/").filter(Boolean);
-  const index = segments.lastIndexOf("itx");
-  const base = segments.slice(0, index === -1 ? segments.length : index).join("/");
-  return base === "" ? "/" : "/" + base;
-}
+        //#region core
+        // ---- the core: one map, longest prefix, a chain ----------------------------
 
-// A context's address is the SAME data structure as every capability's:
-// "how to dial the node that owns this identity".
-function childContextAddress(journalRef) {
-  return {
-    type: "rpc",
-    worker: {
-      type: "durable-object",
-      binding: "ITX_CONTEXT",
-      name: journalRef.namespace + ":" + journalRef.path,
-    },
-  };
-}
-//#endregion
-</script>
+        // A cap name may not shadow the trust kernel — FIRST segment only; deeper
+        // segments are fine. `fetch` and `streams` are deliberately NOT here:
+        // shadowing them is how interception works.
+        const RESERVED_CAPABILITY_NAMES = new Set([
+          "capability",
+          "describe",
+          "extend",
+          "invoke",
+          "project",
+          "projects",
+          "provideCapability",
+          "revokeCapability",
+          "shareUrl",
+          "super",
+        ]);
 
-<script id="page">
-"use strict";
+        class ToyItx {
+          constructor({ contextId, journalRef, journal, address, parentItx = null, dial = null }) {
+            this.contextId = contextId; // identity — the journal records' owner
+            this.journalRef = journalRef; // { namespace, path } — the stream coordinate
+            this.journal = journal; // the event stream (here: an array)
+            this.address = address; // this node's own address — stamped as origin
+            this.parentItx = parentItx; // () => ({ from, stub }) | null — the chain link
+            this.dial = dial; // THE one effect: address → { call({ path, args }) }
+            this.liveStubs = new Map(); // session-bound; never journaled
+            this.state = initialState(); // the checkpoint: a disposable CACHE of the fold
+            this.offset = 0;
+          }
 
-/* ---------------- generic helpers ---------------- */
+          // ONE write path: append, then catch up through the one consumption door
+          // (read-your-writes; duplicate delivery is inert by offset bookkeeping).
+          append(type, payload) {
+            this.journal.push({ offset: this.journal.length + 1, type, payload });
+            this.catchUp();
+          }
+          catchUp() {
+            while (this.offset < this.journal.length) {
+              this.state = reduceItxJournalEvent(this.state, this.journal[this.offset]);
+              this.offset += 1;
+            }
+          }
+          wipeCheckpointAndReplay() {
+            // the checkpoint is disposable: prove it
+            this.state = initialState();
+            this.offset = 0;
+            this.catchUp();
+          }
 
-function escapeHtml(s) {
-  return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-function truncate(s, n) { return s.length > n ? s.slice(0, n - 1) + "…" : s; }
-function fmt(obj) { return escapeHtml(JSON.stringify(obj, null, 2)); }
-function logLine(el, html, cls) {
-  const d = document.createElement("div");
-  d.className = "line" + (cls ? " " + cls : "");
-  d.innerHTML = html;
-  el.appendChild(d);
-  el.scrollTop = el.scrollHeight;
-}
+          provideCapability({ name, path, capability, instructions, types, meta }) {
+            if ((name === undefined) === (path === undefined)) {
+              throw new Error("Provide exactly one of `name` or `path`.");
+            }
+            const segs = path ? [...path] : [name];
+            segs.forEach((seg, i) => {
+              if (!/^[A-Za-z_$][\w$]*$/.test(seg)) {
+                throw new Error(
+                  `Capability path segment ${JSON.stringify(seg)} must be a plain JavaScript identifier.`,
+                );
+              }
+              if ((i === 0 ? RESERVED_CAPABILITY_NAMES : RESERVED_PATH_SEGMENTS).has(seg)) {
+                throw new Error(
+                  `Capability ${i === 0 ? "name" : "path segment"} ${JSON.stringify(seg)} is reserved.`,
+                );
+              }
+            });
+            const capName = segs.join(".");
+            const fullMeta = {
+              ...meta,
+              ...(instructions !== undefined ? { instructions } : {}),
+              ...(types !== undefined ? { types } : {}),
+            };
+            let kind,
+              address = null;
+            if (isCapabilityAddress(capability)) {
+              kind = capability.type;
+              address = capability;
+              this.liveStubs.delete(capName);
+              // The describeItx provide-time hook (section 9): an rpc provide with
+              // no caller-supplied types is dialed ONCE and asked. Best-effort:
+              // any miss just means an unenriched provide. Member-shaped targets
+              // hit the replay's reserved gate — collision protection working.
+              if (kind === "rpc" && fullMeta.types === undefined && this.dial) {
+                try {
+                  const probe = this.dial(address, {
+                    capabilityPath: capName,
+                    origin: { id: this.contextId, address: this.address },
+                  });
+                  const answer = probe.call({ path: ["describeItx"], args: [] });
+                  if (answer && typeof answer.types === "string") fullMeta.types = answer.types;
+                  if (
+                    answer &&
+                    typeof answer.instructions === "string" &&
+                    fullMeta.instructions === undefined
+                  ) {
+                    fullMeta.instructions = answer.instructions;
+                  }
+                } catch (_) {
+                  /* unenriched */
+                }
+              }
+            } else {
+              kind = "live";
+              // A bare function is wrapped so it speaks the one calling convention
+              // (empty remainder calls it); anything else IS the stub. The stub
+              // stays an instance field…
+              const live =
+                typeof capability === "function"
+                  ? { call: (input) => replayPathCall(capability, input) }
+                  : capability;
+              this.liveStubs.set(capName, live);
+            }
+            // …but the EVENT is always journaled: the record outlives the session.
+            this.append(ITX_EVENT_TYPES.capabilityProvided, {
+              path: segs,
+              kind,
+              address,
+              meta: fullMeta,
+              owner: this.contextId,
+              providedAtMs: Date.now(),
+            });
+          }
 
-/* ---------------- the ~40-line highlighter ---------------- */
+          // Exact path match, never prefix. Only OWN entries can be revoked:
+          // claiming to revoke an inherited one would lie — shadow it instead.
+          revokeCapability({ name, path }) {
+            const segs = path ? [...path] : [name];
+            const capName = segs.join(".");
+            if (!(capName in this.state.capabilities)) {
+              const parent = this.parentItx && this.parentItx();
+              const inherited = parent && parent.stub.describe().find((d) => d.name === capName);
+              if (inherited) {
+                const from = inherited.from !== undefined ? inherited.from : parent.from;
+                throw new Error(
+                  `Capability "${capName}" is not provided on this context — it is inherited from ` +
+                    `${from === "defaults" ? "the defaults" : `context ${from}`} and cannot be revoked here; ` +
+                    `provide your own "${capName}" on this context to take its place; the original stays on the parent.`,
+                );
+              }
+              return; // never existed: a no-op
+            }
+            this.append(ITX_EVENT_TYPES.capabilityRevoked, { path: segs });
+            this.liveStubs.delete(capName);
+          }
 
-const HL_RE = new RegExp(
-  [
-    "(\\/\\/[^\\n]*|\\/\\*[\\s\\S]*?\\*\\/)",                              // 1 comment
-    "(\"(?:[^\"\\\\\\n]|\\\\.)*\"|'(?:[^'\\\\\\n]|\\\\.)*'|`(?:[^`\\\\]|\\\\.)*`)", // 2 string
-    "\\b(\\d+(?:\\.\\d+)?)\\b",                                            // 3 number
-    "\\b(const|let|var|function|class|extends|return|await|async|new|if|else|for|while|switch|case|default|throw|try|catch|finally|typeof|delete|in|of|import|export|from|null|undefined|true|false|this|using|type|interface|declare|readonly|satisfies|as|void)\\b", // 4 keyword
-  ].join("|"),
-  "g",
-);
-function highlight(code) {
-  let out = "", last = 0, m;
-  HL_RE.lastIndex = 0;
-  while ((m = HL_RE.exec(code))) {
-    out += escapeHtml(code.slice(last, m.index));
-    const cls = m[1] ? "tok-c" : m[2] ? "tok-s" : m[3] ? "tok-n" : "tok-k";
-    out += '<span class="' + cls + '">' + escapeHtml(m[0]) + "</span>";
-    last = m.index + m[0].length;
-  }
-  return out + escapeHtml(code.slice(last));
-}
-function codeFigure(title, code) {
-  const fig = document.createElement("figure");
-  fig.className = "code";
-  fig.innerHTML =
-    "<figcaption>" + escapeHtml(title) + "</figcaption>" +
-    "<pre><code>" + highlight(code) + "</code></pre>";
-  return fig;
-}
+          // The merged chain view: own entries first (no provenance field — they
+          // are yours), then ancestors', each stamped `from` one level below its
+          // owner. Suppression is exact-match only: a path shadow never hides the
+          // parent's broader entry.
+          describe() {
+            const own = Object.values(this.state.capabilities).map((entry) => ({
+              name: entry.name,
+              kind: entry.kind,
+              connected: entry.kind === "live" ? this.liveStubs.has(entry.name) : undefined,
+              instructions: entry.meta.instructions,
+              types: entry.meta.types,
+            }));
+            const parent = this.parentItx && this.parentItx();
+            if (!parent) return own;
+            const shadowed = new Set(own.map((d) => d.name));
+            return [
+              ...own,
+              ...parent.stub
+                .describe()
+                .filter((d) => !shadowed.has(d.name))
+                .map((d) => (d.from === undefined ? { ...d, from: parent.from } : d)),
+            ];
+          }
 
-// Render every text/plain code block as a highlighted figure.
-document.querySelectorAll('script[type="text/plain"].code').forEach((block) => {
-  const code = block.textContent.replace(/^\n/, "").replace(/\s+$/, "");
-  block.replaceWith(codeFigure(block.dataset.title || "", code));
-});
+          // The only dispatch in the system. The longest provided prefix wins and
+          // is called with the REMAINDER; a miss delegates the WHOLE path up the
+          // chain, carrying origin — the context the call STARTED at.
+          invoke({ path, args, origin }) {
+            this.catchUp();
+            const effectiveOrigin = origin ?? { id: this.contextId, address: this.address };
+            const resolved = resolveLongestProvidedPrefix(this.state.capabilities, path);
+            if (!resolved) {
+              const parent = this.parentItx && this.parentItx();
+              if (parent) return parent.stub.invoke({ path, args, origin: effectiveOrigin });
+              throw new Error(
+                `No capability named "${path[0] ?? ""}" on this context or anywhere up its chain. describe() lists what exists.`,
+              );
+            }
+            const { entry, remainder } = resolved;
+            if (entry.kind === "live") {
+              const stub = this.liveStubs.get(entry.name);
+              if (!stub) {
+                throw new Error(
+                  `Capability "${entry.name}" is registered but its provider is not connected. ` +
+                    `Live capabilities last as long as the provider's session; the provider must ` +
+                    `reconnect and call provideCapability() again.`,
+                );
+              }
+              // A target implementing `call` owns its whole method tree (the SDK
+              // shape); anything else IS its member tree — replay onto it, in the
+              // process where it lives.
+              if (typeof stub.call === "function") return stub.call({ path: remainder, args });
+              return replayPathCall(stub, { path: remainder, args });
+            }
+            return this.dial(entry.address, {
+              capabilityPath: entry.name,
+              origin: effectiveOrigin,
+            }).call({ path: remainder, args });
+          }
 
-// Render the toy's own regions — the displayed source IS the running source.
-const toySource = document.getElementById("toy-itx").textContent;
-document.querySelectorAll(".toy-src").forEach((div) => {
-  const re = new RegExp("//#region " + div.dataset.region + "\\n([\\s\\S]*?)//#endregion");
-  const m = toySource.match(re);
-  const code = m ? m[1].replace(/\s+$/, "") : "(region not found)";
-  div.replaceWith(codeFigure(div.dataset.title || div.dataset.region, code));
-});
+          // extend(): creation is an event. Mint the id, give the child its own
+          // journal at <base>/itx/<id>, append the birth certificate (event #1),
+          // return. Nothing else touches the new node.
+          extend({ name } = {}) {
+            const id = "itx_" + Math.random().toString(36).slice(2, 8);
+            const base = journalBaseOf(this.journalRef.path);
+            const journalRef = {
+              namespace: this.journalRef.namespace,
+              path: (base === "/" ? "" : base) + "/itx/" + id,
+            };
+            const child = new ToyItx({
+              contextId: id,
+              journalRef,
+              journal: [],
+              address: childContextAddress(journalRef),
+              dial: this.dial,
+              parentItx: () => ({ from: this.contextId, stub: this }),
+            });
+            child.append(ITX_EVENT_TYPES.contextCreated, {
+              id,
+              name: name ?? null,
+              parent: { id: this.contextId, address: this.address },
+            });
+            return child;
+          }
 
-/* ---------------- shared render helpers ---------------- */
+          // The handle's fallthrough: unknown names become a PathProxy whose
+          // terminal call is ONE invoke on this core.
+          handle() {
+            return pathProxy((pathCall) => this.invoke(pathCall));
+          }
 
-function renderJournal(el, journal, opts) {
-  el.innerHTML = "";
-  if (!journal.length) { el.innerHTML = '<div class="empty">(empty — no events yet)</div>'; return; }
-  for (const ev of journal) {
-    const row = document.createElement("div");
-    row.className = "jev" + (opts && opts.highlight === ev.offset ? " hl" : "");
-    row.innerHTML =
-      '<span class="off">#' + ev.offset + '</span>' +
-      '<span class="jtype">' + escapeHtml(ev.type.split("/").pop()) + '</span>' +
-      '<span class="jp">' + escapeHtml(truncate(JSON.stringify(ev.payload), 150)) + "</span>";
-    el.appendChild(row);
-  }
-  el.scrollTop = el.scrollHeight;
-}
+          // Simulate the provider's session dropping: stubs die, records survive.
+          disconnectSession() {
+            for (const capName of [...this.liveStubs.keys()]) {
+              this.liveStubs.delete(capName);
+              this.append(ITX_EVENT_TYPES.capabilityDisconnected, { path: capName.split(".") });
+            }
+          }
+        }
 
-function renderOwnFold(el, itx) {
-  const entries = Object.values(itx.state.capabilities);
-  el.innerHTML = "";
-  if (!entries.length) { el.innerHTML = '<div class="empty">(no own entries — the fold of an empty journal)</div>'; return; }
-  for (const entry of entries) {
-    const row = document.createElement("div");
-    row.className = "capRow";
-    row.innerHTML =
-      '<span class="cname">' + escapeHtml(entry.name) + '</span>' +
-      '<span class="ckind">' + entry.kind + '</span>' +
-      '<span class="cfrom">owner ' + escapeHtml(entry.owner) + "</span>" +
-      (entry.meta && entry.meta.types ? '<span class="cfrom">· meta.types ✓</span>' : "");
-    el.appendChild(row);
-  }
-}
+        // The journal base a child inherits: the path minus its /itx[/<id>] tail.
+        // Chain depth ≠ path depth: every project-rooted extension files at
+        // <base>/itx/<id>; parentage lives in the birth certificate.
+        function journalBaseOf(journalPath) {
+          const segments = journalPath.split("/").filter(Boolean);
+          const index = segments.lastIndexOf("itx");
+          const base = segments.slice(0, index === -1 ? segments.length : index).join("/");
+          return base === "" ? "/" : "/" + base;
+        }
 
-function renderDescribe(el, descriptions) {
-  el.innerHTML = "";
-  if (!descriptions.length) { el.innerHTML = '<div class="empty">(nothing — describe() is empty)</div>'; return; }
-  for (const d of descriptions) {
-    const row = document.createElement("div");
-    row.className = "capRow";
-    let html =
-      '<span class="cname">' + escapeHtml(d.name) + '</span>' +
-      '<span class="ckind">' + d.kind + "</span>";
-    if (d.connected !== undefined) {
-      html += '<span class="cconn ' + (d.connected ? "on" : "off") + '">' +
-        (d.connected ? "connected" : "offline") + "</span>";
-    }
-    if (d.from !== undefined) html += '<span class="cfrom">from: ' + escapeHtml(d.from) + "</span>";
-    if (d.instructions) html += '<span class="cinstr">' + escapeHtml(truncate(d.instructions, 110)) + "</span>";
-    row.innerHTML = html;
-    el.appendChild(row);
-  }
-}
-
-/* ---------------- the demo world: env, exports, allowlists, dial ---------------- */
-
-const PETSTORE_TYPES = [
-  '// derived from the OpenAPI spec by the provider, at provide time',
-  'declare function findPetsByStatus(input: { status?: "available" | "pending" | "sold" }): Promise<unknown>;',
-  'declare function getPetById(input: { petId: number }): Promise<unknown>;',
-  'declare function placeOrder(input: { petId?: number; quantity?: number }): Promise<unknown>;',
-  'declare function listOperations(): Promise<unknown>;',
-].join("\n");
-
-const TOY_DEFAULT_CAPS = [
-  { name: "ai", blurb: "BindingCapability → env.AI", instructions: "Workers AI. Use it like an env.AI binding: itx.ai.run(model, inputs). Shadow it with your own `ai` cap to swap providers." },
-  { name: "fetch", blurb: "EgressPipe — secret placeholders substituted here, in the stateless terminal pipe", instructions: "Project egress: itx.fetch(request) and bare fetch() inside platform-loaded isolates both flow through this cap. Shadow it to intercept ALL egress on your context; a shadow receives getSecret(...) placeholders UNSUBSTITUTED." },
-  { name: "streams", blurb: "StreamsCapability — the project's namespace", instructions: "Event streams in this project's namespace: itx.streams.get('/path') → append/read/getState/subscribe." },
-  { name: "secrets", blurb: "SecretsCapability — writes + redacted summaries only", instructions: "Project secrets: setSecret({ key, material }), listSecrets() (redacted). Reference stored secrets in egress headers as getSecret({ key }) placeholders." },
-  { name: "repos", blurb: "ReposCapability", instructions: "The project's git repos: ensureProjectRepoInfo, list, create, get." },
-  { name: "workspace", blurb: "WorkspaceCapability, context-scoped via origin", instructions: "The project's shared workspace: readFile/writeFile + flat git methods (gitClone/gitAdd/gitCommit/gitPush/gitStatus)." },
-  { name: "worker", blurb: "an ordinary repo source: { repo: 'project', commit: 'latest', path: 'worker.js' }", instructions: "The project's own worker, built per commit and tracking pushes: itx.worker.someExportedFunction(args)." },
-];
-
-function makeWorld() {
-  const world = {
-    projectId: "prj_demo",
-    env: {
-      AI: { run: (model) => "[env.AI] ran " + String(model) + " (wrapped in-process by the dial — Law 6)" },
-    },
-    allowlists: {
-      bindings: new Set(["AI"]),
-      loopbacks: new Set(["BindingCapability", "EgressPipe", "McpClient", "OpenApiClient",
-        "ReposCapability", "SecretsCapability", "StreamsCapability", "WorkspaceCapability"]),
-      durableObjects: new Set(),
-    },
-  };
-  world.exports = {
-    EgressPipe: () => ({
-      call: ({ args }) => "[EgressPipe] fetched " + String(args[0]) + " — getSecret(…) placeholders substituted here, never anywhere else",
-    }),
-    McpClient: (props) => ({
-      call: ({ path }) => {
-        const m = path.join(".");
-        if (m === "describeItx") return {}; // an MCP surface is dynamic; listTools is the discovery door
-        if (m === "listTools") return { tools: [{ name: "search_docs" }, { name: "get_page" }] };
-        return "[McpClient] tool " + m + " called against " + props.serverUrl + " — all transport HTTP rides the project egress pipe";
-      },
-    }),
-    OpenApiClient: (props) => ({
-      call: ({ path, args }) => {
-        const m = path.join(".");
-        if (m === "describeItx") {
+        // A context's address is the SAME data structure as every capability's:
+        // "how to dial the node that owns this identity".
+        function childContextAddress(journalRef) {
           return {
-            instructions: "Swagger Petstore v1.0: call itx." + (props.capabilityPath || "<cap>") +
-              ".<operationId>({ ...pathParams, ...queryParams, ...body }); listOperations() lists every operation.",
-            types: PETSTORE_TYPES,
+            type: "rpc",
+            worker: {
+              type: "durable-object",
+              binding: "ITX_CONTEXT",
+              name: journalRef.namespace + ":" + journalRef.path,
+            },
           };
         }
-        if (m === "listOperations") {
-          return [
-            { operationId: "findPetsByStatus", method: "get", path: "/pet/findByStatus" },
-            { operationId: "getPetById", method: "get", path: "/pet/{petId}" },
-            { operationId: "placeOrder", method: "post", path: "/store/order" },
-          ];
+        //#endregion
+      </script>
+
+      <script id="page">
+        "use strict";
+
+        /* ---------------- generic helpers ---------------- */
+
+        function escapeHtml(s) {
+          return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
         }
-        if (path.length !== 1) throw new Error("Call operations by operationId only — listOperations() lists what exists.");
-        return "[OpenApiClient] " + m + "(" + JSON.stringify(args[0] || {}) + ") → GET /pet/findByStatus via project egress (spec-derived param mapping)";
-      },
-    }),
-  };
-  world.loadIsolate = (address, attribution, input) => {
-    const source = address.worker.source;
-    const key = source.type === "inline" ? source.cacheKey : "build/…memo key…";
-    return "[loader] materialized isolate (cache key " + key + "); env.ITERATE scoped to ORIGIN " +
-      attribution.origin.id + "; globalOutbound = ProjectEgress → replayed ." +
-      input.path.join(".") + "(…) on the entrypoint's members";
-  };
-  world.dial = (address, attribution) => ({
-    call(input) {
-      if (address.type === "url") {
-        return "[UrlDial] stateless worker opened ONE Cap'n Web WebSocket session to " + address.url +
-          ", replayed ." + input.path.join(".") + "(…) as member pipelining against the remote main, disposed (Law 7)";
-      }
-      const worker = address.worker;
-      switch (worker.type) {
-        case "binding": {
-          if (!world.allowlists.bindings.has(worker.binding)) {
-            throw new Error('Capability "' + attribution.capabilityPath + '": binding "' + worker.binding + '" is not dialable.');
+        function truncate(s, n) {
+          return s.length > n ? s.slice(0, n - 1) + "…" : s;
+        }
+        function fmt(obj) {
+          return escapeHtml(JSON.stringify(obj, null, 2));
+        }
+        function logLine(el, html, cls) {
+          const d = document.createElement("div");
+          d.className = "line" + (cls ? " " + cls : "");
+          d.innerHTML = html;
+          el.appendChild(d);
+          el.scrollTop = el.scrollHeight;
+        }
+
+        /* ---------------- the ~40-line highlighter ---------------- */
+
+        const HL_RE = new RegExp(
+          [
+            "(\\/\\/[^\\n]*|\\/\\*[\\s\\S]*?\\*\\/)", // 1 comment
+            "(\"(?:[^\"\\\\\\n]|\\\\.)*\"|'(?:[^'\\\\\\n]|\\\\.)*'|`(?:[^`\\\\]|\\\\.)*`)", // 2 string
+            "\\b(\\d+(?:\\.\\d+)?)\\b", // 3 number
+            "\\b(const|let|var|function|class|extends|return|await|async|new|if|else|for|while|switch|case|default|throw|try|catch|finally|typeof|delete|in|of|import|export|from|null|undefined|true|false|this|using|type|interface|declare|readonly|satisfies|as|void)\\b", // 4 keyword
+          ].join("|"),
+          "g",
+        );
+        function highlight(code) {
+          let out = "",
+            last = 0,
+            m;
+          HL_RE.lastIndex = 0;
+          while ((m = HL_RE.exec(code))) {
+            out += escapeHtml(code.slice(last, m.index));
+            const cls = m[1] ? "tok-c" : m[2] ? "tok-s" : m[3] ? "tok-n" : "tok-k";
+            out += '<span class="' + cls + '">' + escapeHtml(m[0]) + "</span>";
+            last = m.index + m[0].length;
           }
-          const binding = world.env[worker.binding];
-          if (binding == null) throw new Error('binding "' + worker.binding + '" is not available on this host.');
-          return replayPathCall(binding, input);
+          return out + escapeHtml(code.slice(last));
         }
-        case "loopback": {
-          if (!address.entrypoint || !world.allowlists.loopbacks.has(address.entrypoint)) {
-            throw new Error('Capability "' + attribution.capabilityPath + '": loopback export "' + address.entrypoint + '" is not dialable.');
+        function codeFigure(title, code) {
+          const fig = document.createElement("figure");
+          fig.className = "code";
+          fig.innerHTML =
+            "<figcaption>" +
+            escapeHtml(title) +
+            "</figcaption>" +
+            "<pre><code>" +
+            highlight(code) +
+            "</code></pre>";
+          return fig;
+        }
+
+        // Render every text/plain code block as a highlighted figure.
+        document.querySelectorAll('script[type="text/plain"].code').forEach((block) => {
+          const code = block.textContent.replace(/^\n/, "").replace(/\s+$/, "");
+          block.replaceWith(codeFigure(block.dataset.title || "", code));
+        });
+
+        // Render the toy's own regions — the displayed source IS the running source.
+        const toySource = document.getElementById("toy-itx").textContent;
+        document.querySelectorAll(".toy-src").forEach((div) => {
+          const re = new RegExp("//#region " + div.dataset.region + "\\n([\\s\\S]*?)//#endregion");
+          const m = toySource.match(re);
+          const code = m ? m[1].replace(/\s+$/, "") : "(region not found)";
+          div.replaceWith(codeFigure(div.dataset.title || div.dataset.region, code));
+        });
+
+        /* ---------------- shared render helpers ---------------- */
+
+        function renderJournal(el, journal, opts) {
+          el.innerHTML = "";
+          if (!journal.length) {
+            el.innerHTML = '<div class="empty">(empty — no events yet)</div>';
+            return;
           }
-          // Injection wins by spread order — the spoof-proofing.
-          const stub = world.exports[address.entrypoint]({
-            ...(address.props || {}),
-            capabilityPath: attribution.capabilityPath,
-            context: attribution.origin && attribution.origin.id,
-            projectId: world.projectId,
-          });
-          return stub.call(input);
-        }
-        case "source":
-          return world.loadIsolate(address, attribution, input);
-        case "durable-object": {
-          if (!world.allowlists.durableObjects.has(worker.binding)) {
-            throw new Error('Capability "' + attribution.capabilityPath + '": Durable Object namespace "' + worker.binding +
-              '" is not dialable. (The default DO allowlist is EMPTY; deployments widen it via config — and the dial would scope the name as itx:' +
-              world.projectId + ":" + worker.name + ")");
+          for (const ev of journal) {
+            const row = document.createElement("div");
+            row.className = "jev" + (opts && opts.highlight === ev.offset ? " hl" : "");
+            row.innerHTML =
+              '<span class="off">#' +
+              ev.offset +
+              "</span>" +
+              '<span class="jtype">' +
+              escapeHtml(ev.type.split("/").pop()) +
+              "</span>" +
+              '<span class="jp">' +
+              escapeHtml(truncate(JSON.stringify(ev.payload), 150)) +
+              "</span>";
+            el.appendChild(row);
           }
-          return "[DO " + worker.binding + "] dialed itx:" + world.projectId + ":" + worker.name;
+          el.scrollTop = el.scrollHeight;
         }
-      }
-    },
-  });
-  const byName = Object.fromEntries(TOY_DEFAULT_CAPS.map((c) => [c.name, c]));
-  world.defaultsStub = {
-    describe: () => TOY_DEFAULT_CAPS.map((c) => ({ name: c.name, kind: "rpc", instructions: c.instructions })),
-    invoke({ path, args, origin }) {
-      const resolved = resolveLongestProvidedPrefix(byName, path);
-      if (!resolved) {
-        throw new Error('No capability named "' + (path[0] || "") + '" on this context or anywhere up its chain. describe() lists what exists.');
-      }
-      const tail = resolved.remainder.length ? "." + resolved.remainder.join(".") : "";
-      return "[defaults:" + resolved.entry.name + tail + "] → " + resolved.entry.blurb +
-        " · origin " + (origin ? origin.id : "?") + (args && args.length ? " · args " + truncate(JSON.stringify(args), 60) : "");
-    },
-    provideCapability() {
-      throw new Error("The defaults are read-only — they ship with the deploy. Provide on your own context to shadow a default.");
-    },
-    revokeCapability() {
-      throw new Error("The defaults are read-only — they ship with the deploy and cannot be revoked; shadow them on your own context instead.");
-    },
-  };
-  world.newProject = (id) => new ToyItx({
-    contextId: id,
-    journalRef: { namespace: id, path: "/itx" },
-    journal: [],
-    address: { type: "rpc", worker: { type: "durable-object", binding: "PROJECT", name: id } },
-    dial: world.dial,
-    parentItx: () => ({ from: "defaults", stub: world.defaultsStub }),
-  });
-  return world;
-}
 
-/* ---------------- demo 1: the seed ---------------- */
+        function renderOwnFold(el, itx) {
+          const entries = Object.values(itx.state.capabilities);
+          el.innerHTML = "";
+          if (!entries.length) {
+            el.innerHTML =
+              '<div class="empty">(no own entries — the fold of an empty journal)</div>';
+            return;
+          }
+          for (const entry of entries) {
+            const row = document.createElement("div");
+            row.className = "capRow";
+            row.innerHTML =
+              '<span class="cname">' +
+              escapeHtml(entry.name) +
+              "</span>" +
+              '<span class="ckind">' +
+              entry.kind +
+              "</span>" +
+              '<span class="cfrom">owner ' +
+              escapeHtml(entry.owner) +
+              "</span>" +
+              (entry.meta && entry.meta.types ? '<span class="cfrom">· meta.types ✓</span>' : "");
+            el.appendChild(row);
+          }
+        }
 
-(function demoSeed() {
-  const root = document.getElementById("demo-seed");
-  if (!root) return;
-  const tableEl = document.getElementById("seed-table");
-  const logEl = document.getElementById("seed-log");
-  const capabilities = new Map();
-  function provide(name, thing) { capabilities.set(name, thing); render(); logLine(logEl, 'provide("' + name + '", …)', "ok"); }
-  function invoke(name, ...args) {
-    const cap = capabilities.get(name);
-    if (!cap) throw new Error('No capability named "' + name + '"');
-    return cap(...args);
-  }
-  function render() {
-    tableEl.innerHTML = capabilities.size ? "" : '<div class="empty">(empty)</div>';
-    for (const [name, thing] of capabilities) {
-      const row = document.createElement("div");
-      row.className = "capRow";
-      row.innerHTML = '<span class="cname">' + escapeHtml(name) + '</span> <span class="cfrom">→ ' + escapeHtml(String(thing)) + "</span>";
-      tableEl.appendChild(row);
-    }
-  }
-  root.addEventListener("click", (e) => {
-    const act = e.target.dataset && e.target.dataset.act;
-    if (!act) return;
-    try {
-      if (act === "provide-greet") provide("greet", (who) => "hello, " + who);
-      else if (act === "provide-dice") provide("dice", () => 1 + Math.floor(Math.random() * 6));
-      else if (act === "provide-now") provide("now", () => new Date().toISOString());
-      else if (act === "invoke-greet") logLine(logEl, 'invoke("greet", "world") <span class="arrow">→</span> ' + escapeHtml(JSON.stringify(invoke("greet", "world"))), "ok");
-      else if (act === "invoke-dice") logLine(logEl, 'invoke("dice") <span class="arrow">→</span> ' + escapeHtml(JSON.stringify(invoke("dice"))), "ok");
-      else if (act === "invoke-missing") invoke("slack");
-    } catch (err) { logLine(logEl, escapeHtml(err.message || String(err)), "err"); }
-  });
-  render();
-})();
+        function renderDescribe(el, descriptions) {
+          el.innerHTML = "";
+          if (!descriptions.length) {
+            el.innerHTML = '<div class="empty">(nothing — describe() is empty)</div>';
+            return;
+          }
+          for (const d of descriptions) {
+            const row = document.createElement("div");
+            row.className = "capRow";
+            let html =
+              '<span class="cname">' +
+              escapeHtml(d.name) +
+              "</span>" +
+              '<span class="ckind">' +
+              d.kind +
+              "</span>";
+            if (d.connected !== undefined) {
+              html +=
+                '<span class="cconn ' +
+                (d.connected ? "on" : "off") +
+                '">' +
+                (d.connected ? "connected" : "offline") +
+                "</span>";
+            }
+            if (d.from !== undefined)
+              html += '<span class="cfrom">from: ' + escapeHtml(d.from) + "</span>";
+            if (d.instructions)
+              html +=
+                '<span class="cinstr">' + escapeHtml(truncate(d.instructions, 110)) + "</span>";
+            row.innerHTML = html;
+            el.appendChild(row);
+          }
+        }
 
-/* ---------------- demo 2: the calling convention ---------------- */
+        /* ---------------- the demo world: env, exports, allowlists, dial ---------------- */
 
-(function demoConvention() {
-  const root = document.getElementById("demo-conv");
-  if (!root) return;
-  const dispatchEl = document.getElementById("conv-dispatch");
-  const logEl = document.getElementById("conv-log");
-  const itx = new ToyItx({
-    contextId: "prj_demo",
-    journalRef: { namespace: "prj_demo", path: "/itx" },
-    journal: [],
-    address: { type: "rpc", worker: { type: "durable-object", binding: "PROJECT", name: "prj_demo" } },
-  });
-  const handle = pathProxy((pathCall) => {
-    logLine(dispatchEl, "PathCall " + escapeHtml(JSON.stringify(pathCall)));
-    const resolved = resolveLongestProvidedPrefix(itx.state.capabilities, pathCall.path);
-    if (resolved) {
-      logLine(dispatchEl,
-        '&nbsp;&nbsp;longest provided prefix: <b>"' + escapeHtml(resolved.entry.name) + '"</b> · remainder ' +
-        escapeHtml(JSON.stringify(resolved.remainder)) + " → member replay on the provider's object");
-    } else {
-      logLine(dispatchEl, "&nbsp;&nbsp;no provided prefix → would delegate up the chain (none here)");
-    }
-    return itx.invoke(pathCall);
-  });
-  root.addEventListener("click", (e) => {
-    const act = e.target.dataset && e.target.dataset.act;
-    if (!act) return;
-    try {
-      if (act === "provide") {
-        itx.provideCapability({
-          name: "answer",
-          instructions: "The answer to everything: itx.answer.ultimate(), or itx.answer.deep.thought(question).",
-          capability: { ultimate: () => 42, deep: { thought: (q) => ({ answer: 42, question: q }) } },
-        });
-        logLine(logEl, 'provided "answer" — a plain nested object IS the capability (kind: live)', "ok");
-      } else if (act === "ultimate") {
-        logLine(logEl, "itx.answer.ultimate() <span class=\"arrow\">→</span> " + escapeHtml(JSON.stringify(handle.answer.ultimate())), "ok");
-      } else if (act === "thought") {
-        const q = document.getElementById("conv-q").value;
-        logLine(logEl, "itx.answer.deep.thought(…) <span class=\"arrow\">→</span> " + escapeHtml(JSON.stringify(handle.answer.deep.thought(q))), "ok");
-      } else if (act === "custom") {
-        const segs = document.getElementById("conv-path").value.split(".").filter(Boolean);
-        const target = segs.reduce((acc, key) => acc[key], handle);
-        logLine(logEl, "itx." + escapeHtml(segs.join(".")) + "(…) <span class=\"arrow\">→</span> " + escapeHtml(JSON.stringify(target("…"))), "ok");
-      }
-    } catch (err) { logLine(logEl, escapeHtml(err.message || String(err)), "err"); }
-  });
-})();
+        const PETSTORE_TYPES = [
+          "// derived from the OpenAPI spec by the provider, at provide time",
+          'declare function findPetsByStatus(input: { status?: "available" | "pending" | "sold" }): Promise<unknown>;',
+          "declare function getPetById(input: { petId: number }): Promise<unknown>;",
+          "declare function placeOrder(input: { petId?: number; quantity?: number }): Promise<unknown>;",
+          "declare function listOperations(): Promise<unknown>;",
+        ].join("\n");
 
-/* ---------------- demo 3: the journal ---------------- */
-
-(function demoJournal() {
-  const root = document.getElementById("demo-journal");
-  if (!root) return;
-  const world = makeWorld();
-  const itx = world.newProject("prj_demo");
-  const handle = itx.handle();
-  let child = null;
-  const journalEl = document.getElementById("j3-journal");
-  const capsEl = document.getElementById("j3-caps");
-  const childWrap = document.getElementById("j3-childwrap");
-  const childJournalEl = document.getElementById("j3-childjournal");
-  const childSideEl = document.getElementById("j3-log");
-  const logEl = document.getElementById("j3-log2");
-  function refresh() {
-    renderJournal(journalEl, itx.journal);
-    renderOwnFold(capsEl, itx);
-    if (child) {
-      childWrap.style.display = "";
-      renderJournal(childJournalEl, child.journal, { highlight: 1 });
-      childSideEl.previousElementSibling.textContent = "child.describe() — merged chain view (own → parent → defaults)";
-      renderDescribe(childSideEl, child.describe());
-    }
-  }
-  root.addEventListener("click", (e) => {
-    const act = e.target.dataset && e.target.dataset.act;
-    if (!act) return;
-    try {
-      if (act === "provide-live") {
-        itx.provideCapability({
-          name: "clock",
-          instructions: "The provider's wall clock: itx.clock.nowMs().",
-          capability: { nowMs: () => Date.now() },
-        });
-        logLine(logEl, "appended capability-provided (kind: live — the EVENT is journaled, the stub stays in memory)", "ok");
-      } else if (act === "provide-rpc") {
-        itx.provideCapability({
-          name: "ai",
-          capability: { type: "rpc", worker: { type: "binding", binding: "AI" } },
-        });
-        logLine(logEl, "appended capability-provided (kind: rpc — the full address is in the journal)", "ok");
-      } else if (act === "call-clock") {
-        logLine(logEl, "itx.clock.nowMs() <span class=\"arrow\">→</span> " + escapeHtml(JSON.stringify(handle.clock.nowMs())), "ok");
-      } else if (act === "revoke") {
-        itx.revokeCapability({ name: "clock" });
-        logLine(logEl, "appended capability-revoked — the fold drops the entry", "ok");
-      } else if (act === "wipe") {
-        const before = JSON.stringify(itx.state);
-        itx.wipeCheckpointAndReplay();
-        const after = JSON.stringify(itx.state);
-        logLine(logEl, "checkpoint wiped; replayed " + itx.journal.length + " events from offset 0 — rebuilt state is " +
-          (before === after ? "<b>byte-identical ✓</b> (the checkpoint is a disposable cache)" : "DIFFERENT ✗ (bug!)"),
-          before === after ? "ok" : "err");
-      } else if (act === "extend") {
-        child = itx.extend({ name: "scratch" });
-        logLine(logEl, "extended → " + child.contextId + " · journal at (" + child.journalRef.namespace + ", " +
-          child.journalRef.path + ") · event #1 is its birth certificate — creation was ONE append", "ok");
-      }
-    } catch (err) { logLine(logEl, escapeHtml(err.message || String(err)), "err"); }
-    refresh();
-  });
-  refresh();
-})();
-
-/* ---------------- demo 4: live vs durable ---------------- */
-
-(function demoStubs() {
-  const root = document.getElementById("demo-stubs");
-  if (!root) return;
-  const world = makeWorld();
-  const itx = new ToyItx({
-    contextId: "prj_demo",
-    journalRef: { namespace: "prj_demo", path: "/itx" },
-    journal: [],
-    address: { type: "rpc", worker: { type: "durable-object", binding: "PROJECT", name: "prj_demo" } },
-    dial: world.dial,
-  });
-  const handle = itx.handle();
-  const capsEl = document.getElementById("s4-caps");
-  const logEl = document.getElementById("s4-log");
-  function refresh() { renderDescribe(capsEl, itx.describe()); }
-  root.addEventListener("click", (e) => {
-    const act = e.target.dataset && e.target.dataset.act;
-    if (!act) return;
-    try {
-      if (act === "provide-mac") {
-        itx.provideCapability({
-          name: "mac",
-          instructions: "Compile-and-run Swift on Jonas's Mac: itx.mac.runSwift(src).",
-          capability: { runSwift: (src) => "compiled & ran " + src.length + " chars of Swift, in the provider's process" },
-        });
-        logLine(logEl, 'provided "mac" — live: the stub is held over the provider\'s session', "ok");
-      } else if (act === "provide-ai") {
-        itx.provideCapability({ name: "ai", capability: { type: "rpc", worker: { type: "binding", binding: "AI" } } });
-        logLine(logEl, 'provided "ai" — durable: a serializable address, restored at invoke time', "ok");
-      } else if (act === "call-mac") {
-        logLine(logEl, 'itx.mac.runSwift("print(42)") <span class="arrow">→</span> ' + escapeHtml(JSON.stringify(handle.mac.runSwift("print(42)"))), "ok");
-      } else if (act === "call-ai") {
-        logLine(logEl, 'itx.ai.run("@cf/meta/llama-3") <span class="arrow">→</span> ' + escapeHtml(JSON.stringify(handle.ai.run("@cf/meta/llama-3"))), "ok");
-      } else if (act === "drop") {
-        itx.disconnectSession();
-        logLine(logEl, "session dropped → appended capability-disconnected (record only; the fold ignores it). " +
-          "The live entry survives as offline; the rpc address is untouched. Try calling mac again.", "ok");
-      }
-    } catch (err) { logLine(logEl, escapeHtml(err.message || String(err)), "err"); }
-    refresh();
-  });
-  refresh();
-})();
-
-/* ---------------- demo 5: the chain ---------------- */
-
-(function demoChain() {
-  const root = document.getElementById("demo-chain");
-  if (!root) return;
-  const world = makeWorld();
-  const project = world.newProject("prj_demo");
-  const child = project.extend({ name: "review-run" });
-  const viz = document.getElementById("chain-viz");
-  const logEl = document.getElementById("chain-log");
-  function renderChain(win) {
-    viz.innerHTML = "";
-    const nodes = [
-      { key: "child", title: child.contextId, role: 'extension "review-run" · journal ' + child.journalRef.path + " · delegates →", caps: Object.values(child.state.capabilities) },
-      { key: "project", title: "prj_demo", role: "the project context · journal /itx · delegates →", caps: Object.values(project.state.capabilities) },
-      { key: "defaults", title: "defaults", role: "PlatformContext — read-only code; ships with the deploy", caps: TOY_DEFAULT_CAPS.map((c) => ({ name: c.name, kind: "rpc" })) },
-    ];
-    for (const node of nodes) {
-      const div = document.createElement("div");
-      div.className = "chainNode";
-      let caps = node.caps.length
-        ? node.caps.map((c) =>
-            '<div class="capEntry' + (win && win.node === node.key && win.name === c.name ? " win" : "") + '" ' +
-            'data-node="' + node.key + '" data-name="' + escapeHtml(c.name) + '">' +
-            escapeHtml(c.name) + ' <span class="k">' + c.kind + "</span></div>").join("")
-        : '<div class="empty" style="font:11.5px ui-monospace,monospace;color:#9aa1ac;padding:3px 8px">(no own entries)</div>';
-      div.innerHTML = '<header><span class="cid">' + escapeHtml(node.title) + '</span><span class="role">' +
-        escapeHtml(node.role) + '</span></header><div class="caps">' + caps + "</div>";
-      viz.appendChild(div);
-    }
-  }
-  function traceAndCall(pathStr, startAtParent) {
-    const segs = pathStr.split(".").filter(Boolean);
-    if (!segs.length) return;
-    logLine(logEl, "<b>" + (startAtParent ? "child.super." : "child.") + escapeHtml(segs.join(".")) + "(…)</b>");
-    let win = null;
-    const hops = [
-      { key: "child", label: child.contextId, caps: child.state.capabilities },
-      { key: "project", label: "prj_demo", caps: project.state.capabilities },
-    ].slice(startAtParent ? 1 : 0);
-    if (startAtParent) {
-      logLine(logEl, "&nbsp;&nbsp;super: resolution starts ONE link up — the child's table is skipped; origin is still " + child.contextId);
-    }
-    let resolvedSomewhere = false;
-    for (const hop of hops) {
-      const r = resolveLongestProvidedPrefix(hop.caps, segs);
-      if (r) {
-        logLine(logEl, "&nbsp;&nbsp;" + escapeHtml(hop.label) + ': <b>"' + escapeHtml(r.entry.name) + '"</b> wins (longest provided prefix) · remainder ' +
-          escapeHtml(JSON.stringify(r.remainder)) + " → " + (r.entry.kind === "live" ? "live stub" : "dial the " + r.entry.kind + " address"));
-        win = { node: hop.key, name: r.entry.name };
-        resolvedSomewhere = true;
-        break;
-      }
-      logLine(logEl, "&nbsp;&nbsp;" + escapeHtml(hop.label) + ": no provided prefix → delegate the WHOLE path to the parent (origin stays " + child.contextId + ")");
-    }
-    if (!resolvedSomewhere) {
-      const d = TOY_DEFAULT_CAPS.find((c) => c.name === segs[0]);
-      if (d) {
-        logLine(logEl, '&nbsp;&nbsp;defaults: <b>"' + d.name + '"</b> wins · remainder ' + escapeHtml(JSON.stringify(segs.slice(1))) +
-          " → dialed in-process (loopback — default dispatch pays no DO hop)");
-        win = { node: "defaults", name: d.name };
-      }
-    }
-    try {
-      const args = segs[0] === "fetch" ? ["https://api.example.com/v1/thing"] : [{ demo: true }];
-      const result = startAtParent
-        ? project.invoke({ path: segs, args, origin: { id: child.contextId, address: child.address } })
-        : child.invoke({ path: segs, args });
-      logLine(logEl, "&nbsp;&nbsp;result <span class=\"arrow\">→</span> " + escapeHtml(typeof result === "string" ? result : JSON.stringify(result)), "ok");
-    } catch (err) {
-      logLine(logEl, "&nbsp;&nbsp;" + escapeHtml(err.message || String(err)), "err");
-    }
-    renderChain(win);
-  }
-  root.addEventListener("click", (e) => {
-    const act = e.target.dataset && e.target.dataset.act;
-    if (!act) return;
-    try {
-      if (act === "shadow-gitpush") {
-        child.provideCapability({
-          path: ["workspace", "gitPush"],
-          instructions: "gitPush waits for human approval; everything else is the real workspace.",
-          capability: (input) => "⏸ held for approval (the gate) — input " + JSON.stringify(input),
-        });
-        logLine(logEl, 'shadowed ONE method: path ["workspace","gitPush"] on ' + child.contextId +
-          " — workspace.readFile etc. still fall through the chain", "ok");
-      } else if (act === "shadow-fetch") {
-        child.provideCapability({
-          name: "fetch",
-          instructions: "Egress with an x-trace-id header; delegates to the real pipe via itx.super.fetch.",
-          capability: (request) => "[child's fetch shadow] stamped x-trace-id, placeholders UNsubstituted → super.fetch → " +
-            project.invoke({ path: ["fetch"], args: [request], origin: { id: child.contextId, address: child.address } }),
-        });
-        logLine(logEl, 'shadowed "fetch" on the child with a plain function that calls super — middleware in one provide', "ok");
-      } else if (act === "provide-slack") {
-        project.provideCapability({
-          name: "slack",
-          instructions: "Post to the team Slack: itx.slack.chat.postMessage({ channel, text }).",
-          capability: { chat: { postMessage: (m) => "[live slack provider] posted " + JSON.stringify(m) } },
-        });
-        logLine(logEl, 'provided "slack" on the PROJECT — the child inherits it through the chain', "ok");
-      } else if (act === "revoke-gitpush") {
-        child.revokeCapability({ path: ["workspace", "gitPush"] });
-        logLine(logEl, "revoked the child's gitPush shadow — the inherited workspace resurfaces, by construction", "ok");
-      } else if (act === "revoke-default") {
-        child.revokeCapability({ name: "ai" });
-      } else if (act === "provide-on-defaults") {
-        world.defaultsStub.provideCapability({ name: "evil", capability: {} });
-      } else if (act === "resolve") {
-        traceAndCall(document.getElementById("chain-path").value, false);
-        return; // traceAndCall renders
-      } else if (act === "super") {
-        traceAndCall("fetch", true);
-        return;
-      }
-    } catch (err) { logLine(logEl, escapeHtml(err.message || String(err)), "err"); }
-    renderChain(null);
-  });
-  renderChain(null);
-})();
-
-/* ---------------- demo 6: the dial ---------------- */
-
-(function demoDial() {
-  const root = document.getElementById("demo-dial");
-  if (!root) return;
-  const world = makeWorld();
-  const pick = document.getElementById("dial-pick");
-  const addrEl = document.getElementById("dial-addr");
-  const logEl = document.getElementById("dial-log");
-  const candidates = [
-    { label: 'binding "AI" — allowlisted', path: ["run"], args: ["@cf/meta/llama-3"],
-      address: { type: "rpc", worker: { type: "binding", binding: "AI" } } },
-    { label: 'binding "DB" — NOT allowlisted', path: ["query"], args: ["select 1"],
-      address: { type: "rpc", worker: { type: "binding", binding: "DB" } } },
-    { label: 'loopback "McpClient" — allowlisted, props ride the provide', path: ["listTools"], args: [],
-      address: { type: "rpc", worker: { type: "loopback" }, entrypoint: "McpClient", props: { serverUrl: "https://docs.mcp.cloudflare.com/mcp" } } },
-    { label: 'loopback "SecretLeaker" — NOT allowlisted', path: ["leak"], args: [],
-      address: { type: "rpc", worker: { type: "loopback" }, entrypoint: "SecretLeaker" } },
-    { label: 'durable-object "TODO":"inbox" — default allowlist is empty', path: ["add"], args: [{ text: "hi" }],
-      address: { type: "rpc", worker: { type: "durable-object", binding: "TODO", name: "inbox" } } },
-    { label: "source (inline greeter) — loader isolate, origin-scoped", path: ["hello"], args: [{ name: "world" }],
-      address: { type: "rpc", worker: { type: "source", source: { type: "inline", cacheKey: "greeter-v1", mainModule: "cap.js", modules: { "cap.js": "…" } } } } },
-    { label: "url — a Cap'n Web server across the internet", path: ["chat", "postMessage"], args: [{ text: "hi" }],
-      address: { type: "url", url: "wss://caps.example.com/api", headers: { authorization: 'Bearer getSecret({ key: "REMOTE_TOKEN" })' } } },
-  ];
-  candidates.forEach((c, i) => {
-    const opt = document.createElement("option");
-    opt.value = String(i);
-    opt.textContent = c.label;
-    pick.appendChild(opt);
-  });
-  function show() {
-    const c = candidates[Number(pick.value)];
-    addrEl.innerHTML = fmt(c.address);
-  }
-  pick.addEventListener("change", show);
-  root.addEventListener("click", (e) => {
-    if (!e.target.dataset || e.target.dataset.act !== "dial") return;
-    const c = candidates[Number(pick.value)];
-    show();
-    logLine(logEl, "<b>dial(address) → call({ path: " + escapeHtml(JSON.stringify(c.path)) + ", args })</b>");
-    try {
-      const result = world.dial(c.address, { capabilityPath: "demo", origin: { id: "prj_demo", address: null } })
-        .call({ path: c.path, args: c.args });
-      logLine(logEl, escapeHtml(typeof result === "string" ? result : JSON.stringify(result)), "ok");
-    } catch (err) {
-      logLine(logEl, escapeHtml(err.message || String(err)) + " <span class=\"arrow\">(surfaced at FIRST CALL — provide was structural only)</span>", "err");
-    }
-  });
-  show();
-})();
-
-/* ---------------- demo 7: identity ---------------- */
-
-(function demoIdentity() {
-  const root = document.getElementById("demo-identity");
-  if (!root) return;
-  const input = document.getElementById("id-name");
-  const outEl = document.getElementById("id-out");
-  const addrEl = document.getElementById("id-addr");
-  function parse() {
-    const name = input.value.trim();
-    try {
-      const colon = name.indexOf(":");
-      if (colon <= 0 || name[colon + 1] !== "/") {
-        throw new Error('ItxDurableObject must be addressed by its journal coordinate ("<namespace>:/<path>"), got ' + JSON.stringify(name) + ".");
-      }
-      const namespace = name.slice(0, colon);
-      const path = name.slice(colon + 1);
-      const segs = path.split("/").filter(Boolean);
-      const last = segs[segs.length - 1];
-      const contextId = last && last.indexOf("itx_") === 0
-        ? last
-        : "(the host's own context — identity derives from the host, no birth certificate)";
-      outEl.innerHTML =
-        "namespace (owning project):  <b>" + escapeHtml(namespace) + "</b>\n" +
-        "journal path:                <b>" + escapeHtml(path) + "</b>\n" +
-        "context id (last segment):   <b>" + escapeHtml(contextId) + "</b>\n" +
-        "journal base for children:   <b>" + escapeHtml(journalBaseOf(path)) + "</b>\n" +
-        'reserved segment in use:     <b>"itx"</b> — user streams may not claim it';
-      addrEl.innerHTML = fmt(childContextAddress({ namespace, path }));
-    } catch (err) {
-      outEl.innerHTML = '<span style="color:var(--err)">' + escapeHtml(err.message || String(err)) + "</span>";
-      addrEl.innerHTML = "";
-    }
-  }
-  root.addEventListener("click", (e) => {
-    const t = e.target;
-    if (t.dataset && t.dataset.name) { input.value = t.dataset.name; parse(); }
-    else if (t.dataset && t.dataset.act === "parse") parse();
-  });
-  parse();
-})();
-
-/* ---------------- demo 8: the build memo ---------------- */
-
-(function demoMemo() {
-  const root = document.getElementById("demo-memo");
-  if (!root) return;
-  const logEl = document.getElementById("memo-log");
-  const r2El = document.getElementById("memo-r2");
-  const shaEl = document.getElementById("memo-sha");
-  const r2 = new Map();
-  function newSha() {
-    let s = "";
-    for (let i = 0; i < 8; i++) s += "0123456789abcdef"[Math.floor(Math.random() * 16)];
-    return s;
-  }
-  let sha = newSha();
-  function fakeHash(s) {
-    let h = 5381;
-    for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) >>> 0;
-    return h.toString(16).padStart(8, "0") + (((h ^ 0xabcdef) >>> 0)).toString(16).slice(0, 4);
-  }
-  function refresh() {
-    shaEl.textContent = 'repo "project" HEAD = ' + sha;
-    r2El.innerHTML = r2.size ? "" : '<div class="empty">(empty)</div>';
-    for (const [key, value] of r2) {
-      const row = document.createElement("div");
-      row.className = "capRow";
-      row.innerHTML = '<span class="cname">' + escapeHtml(key) + '</span> <span class="cfrom">' + escapeHtml(value) + "</span>";
-      r2El.appendChild(row);
-    }
-  }
-  root.addEventListener("click", (e) => {
-    const act = e.target.dataset && e.target.dataset.act;
-    if (!act) return;
-    if (act === "push") {
-      sha = newSha();
-      logLine(logEl, "git push → new commit " + sha + ' — "latest" resolves to it (probe memoized ≤10 s per isolate)', "ok");
-    } else if (act === "dial") {
-      logLine(logEl, "<b>dial itx.repoGreeter.hello({ name: \"world\" })</b>");
-      logLine(logEl, '&nbsp;&nbsp;probe "latest" → ' + sha);
-      const memoKey = "build/" + fakeHash("prj_demo|project|" + sha + "|caps/greeter.js|{}|null");
-      logLine(logEl, "&nbsp;&nbsp;memo key = hash(projectId, repo, sha, path, bundle, compatDate) = " + memoKey);
-      if (r2.has(memoKey)) {
-        logLine(logEl, "&nbsp;&nbsp;R2 HIT — no build, no readTree. Warm dials never build.", "ok");
-      } else {
-        logLine(logEl, "&nbsp;&nbsp;cold key: repo DO readTree(" + sha + ") → worker-bundler (in-memory vfs, no clone) → R2 put " + memoKey);
-        r2.set(memoKey, "built modules for " + sha);
-      }
-      logLine(logEl, '&nbsp;&nbsp;loader isolate key itx-cap:prj_demo:repoGreeter:' + memoKey +
-        ' → replayed .hello(…) <span class="arrow">→</span> "hello from the repo, world"', "ok");
-    }
-    refresh();
-  });
-  refresh();
-})();
-
-/* ---------------- demo 9: describeItx ---------------- */
-
-(function demoDescribe() {
-  const root = document.getElementById("demo-describe");
-  if (!root) return;
-  const world = makeWorld();
-  const itx = world.newProject("prj_demo");
-  const handle = itx.handle();
-  const journalEl = document.getElementById("d9-journal");
-  const logEl = document.getElementById("d9-log");
-  function refresh() { renderJournal(journalEl, itx.journal); }
-  root.addEventListener("click", (e) => {
-    const act = e.target.dataset && e.target.dataset.act;
-    if (!act) return;
-    try {
-      if (act === "provide") {
-        itx.provideCapability({
-          name: "petstore",
-          capability: {
-            type: "rpc",
-            worker: { type: "loopback" },
-            entrypoint: "OpenApiClient",
-            props: { specUrl: "https://petstore3.swagger.io/api/v3/openapi.json" },
+        const TOY_DEFAULT_CAPS = [
+          {
+            name: "ai",
+            blurb: "BindingCapability → env.AI",
+            instructions:
+              "Workers AI. Use it like an env.AI binding: itx.ai.run(model, inputs). Shadow it with your own `ai` cap to swap providers.",
           },
-        });
-        logLine(logEl, "provided with NO types — the core dialed the address once and asked describeItx; " +
-          "the provider derived types from its spec, and they were JOURNALED with the provide", "ok");
-      } else if (act === "call") {
-        logLine(logEl, "itx.petstore.findPetsByStatus(…) <span class=\"arrow\">→</span> " +
-          escapeHtml(String(handle.petstore.findPetsByStatus({ status: "available" }))), "ok");
-      } else if (act === "describe") {
-        const descriptions = itx.describe();
-        for (const d of descriptions.slice(0, 3)) {
-          logLine(logEl, "<b>" + escapeHtml(d.name) + "</b> [" + d.kind + (d.from ? " · from: " + escapeHtml(d.from) : "") + "] " +
-            escapeHtml(truncate(d.instructions || "", 100)));
-          if (d.types) logLine(logEl, '&nbsp;&nbsp;types: <span style="color:#6b7280">' + escapeHtml(truncate(d.types.split("\n")[1] || d.types, 110)) + " …</span>");
+          {
+            name: "fetch",
+            blurb:
+              "EgressPipe — secret placeholders substituted here, in the stateless terminal pipe",
+            instructions:
+              "Project egress: itx.fetch(request) and bare fetch() inside platform-loaded isolates both flow through this cap. Shadow it to intercept ALL egress on your context; a shadow receives getSecret(...) placeholders UNSUBSTITUTED.",
+          },
+          {
+            name: "streams",
+            blurb: "StreamsCapability — the project's namespace",
+            instructions:
+              "Event streams in this project's namespace: itx.streams.get('/path') → append/read/getState/subscribe.",
+          },
+          {
+            name: "secrets",
+            blurb: "SecretsCapability — writes + redacted summaries only",
+            instructions:
+              "Project secrets: setSecret({ key, material }), listSecrets() (redacted). Reference stored secrets in egress headers as getSecret({ key }) placeholders.",
+          },
+          {
+            name: "repos",
+            blurb: "ReposCapability",
+            instructions: "The project's git repos: ensureProjectRepoInfo, list, create, get.",
+          },
+          {
+            name: "workspace",
+            blurb: "WorkspaceCapability, context-scoped via origin",
+            instructions:
+              "The project's shared workspace: readFile/writeFile + flat git methods (gitClone/gitAdd/gitCommit/gitPush/gitStatus).",
+          },
+          {
+            name: "worker",
+            blurb:
+              "an ordinary repo source: { repo: 'project', commit: 'latest', path: 'worker.js' }",
+            instructions:
+              "The project's own worker, built per commit and tracking pushes: itx.worker.someExportedFunction(args).",
+          },
+        ];
+
+        function makeWorld() {
+          const world = {
+            projectId: "prj_demo",
+            env: {
+              AI: {
+                run: (model) =>
+                  "[env.AI] ran " + String(model) + " (wrapped in-process by the dial — Law 6)",
+              },
+            },
+            allowlists: {
+              bindings: new Set(["AI"]),
+              loopbacks: new Set([
+                "BindingCapability",
+                "EgressPipe",
+                "McpClient",
+                "OpenApiClient",
+                "ReposCapability",
+                "SecretsCapability",
+                "StreamsCapability",
+                "WorkspaceCapability",
+              ]),
+              durableObjects: new Set(),
+            },
+          };
+          world.exports = {
+            EgressPipe: () => ({
+              call: ({ args }) =>
+                "[EgressPipe] fetched " +
+                String(args[0]) +
+                " — getSecret(…) placeholders substituted here, never anywhere else",
+            }),
+            McpClient: (props) => ({
+              call: ({ path }) => {
+                const m = path.join(".");
+                if (m === "describeItx") return {}; // an MCP surface is dynamic; listTools is the discovery door
+                if (m === "listTools")
+                  return { tools: [{ name: "search_docs" }, { name: "get_page" }] };
+                return (
+                  "[McpClient] tool " +
+                  m +
+                  " called against " +
+                  props.serverUrl +
+                  " — all transport HTTP rides the project egress pipe"
+                );
+              },
+            }),
+            OpenApiClient: (props) => ({
+              call: ({ path, args }) => {
+                const m = path.join(".");
+                if (m === "describeItx") {
+                  return {
+                    instructions:
+                      "Swagger Petstore v1.0: call itx." +
+                      (props.capabilityPath || "<cap>") +
+                      ".<operationId>({ ...pathParams, ...queryParams, ...body }); listOperations() lists every operation.",
+                    types: PETSTORE_TYPES,
+                  };
+                }
+                if (m === "listOperations") {
+                  return [
+                    { operationId: "findPetsByStatus", method: "get", path: "/pet/findByStatus" },
+                    { operationId: "getPetById", method: "get", path: "/pet/{petId}" },
+                    { operationId: "placeOrder", method: "post", path: "/store/order" },
+                  ];
+                }
+                if (path.length !== 1)
+                  throw new Error(
+                    "Call operations by operationId only — listOperations() lists what exists.",
+                  );
+                return (
+                  "[OpenApiClient] " +
+                  m +
+                  "(" +
+                  JSON.stringify(args[0] || {}) +
+                  ") → GET /pet/findByStatus via project egress (spec-derived param mapping)"
+                );
+              },
+            }),
+          };
+          world.loadIsolate = (address, attribution, input) => {
+            const source = address.worker.source;
+            const key = source.type === "inline" ? source.cacheKey : "build/…memo key…";
+            return (
+              "[loader] materialized isolate (cache key " +
+              key +
+              "); env.ITERATE scoped to ORIGIN " +
+              attribution.origin.id +
+              "; globalOutbound = ProjectEgress → replayed ." +
+              input.path.join(".") +
+              "(…) on the entrypoint's members"
+            );
+          };
+          world.dial = (address, attribution) => ({
+            call(input) {
+              if (address.type === "url") {
+                return (
+                  "[UrlDial] stateless worker opened ONE Cap'n Web WebSocket session to " +
+                  address.url +
+                  ", replayed ." +
+                  input.path.join(".") +
+                  "(…) as member pipelining against the remote main, disposed (Law 7)"
+                );
+              }
+              const worker = address.worker;
+              switch (worker.type) {
+                case "binding": {
+                  if (!world.allowlists.bindings.has(worker.binding)) {
+                    throw new Error(
+                      'Capability "' +
+                        attribution.capabilityPath +
+                        '": binding "' +
+                        worker.binding +
+                        '" is not dialable.',
+                    );
+                  }
+                  const binding = world.env[worker.binding];
+                  if (binding == null)
+                    throw new Error(
+                      'binding "' + worker.binding + '" is not available on this host.',
+                    );
+                  return replayPathCall(binding, input);
+                }
+                case "loopback": {
+                  if (!address.entrypoint || !world.allowlists.loopbacks.has(address.entrypoint)) {
+                    throw new Error(
+                      'Capability "' +
+                        attribution.capabilityPath +
+                        '": loopback export "' +
+                        address.entrypoint +
+                        '" is not dialable.',
+                    );
+                  }
+                  // Injection wins by spread order — the spoof-proofing.
+                  const stub = world.exports[address.entrypoint]({
+                    ...(address.props || {}),
+                    capabilityPath: attribution.capabilityPath,
+                    context: attribution.origin && attribution.origin.id,
+                    projectId: world.projectId,
+                  });
+                  return stub.call(input);
+                }
+                case "source":
+                  return world.loadIsolate(address, attribution, input);
+                case "durable-object": {
+                  if (!world.allowlists.durableObjects.has(worker.binding)) {
+                    throw new Error(
+                      'Capability "' +
+                        attribution.capabilityPath +
+                        '": Durable Object namespace "' +
+                        worker.binding +
+                        '" is not dialable. (The default DO allowlist is EMPTY; deployments widen it via config — and the dial would scope the name as itx:' +
+                        world.projectId +
+                        ":" +
+                        worker.name +
+                        ")",
+                    );
+                  }
+                  return (
+                    "[DO " + worker.binding + "] dialed itx:" + world.projectId + ":" + worker.name
+                  );
+                }
+              }
+            },
+          });
+          const byName = Object.fromEntries(TOY_DEFAULT_CAPS.map((c) => [c.name, c]));
+          world.defaultsStub = {
+            describe: () =>
+              TOY_DEFAULT_CAPS.map((c) => ({
+                name: c.name,
+                kind: "rpc",
+                instructions: c.instructions,
+              })),
+            invoke({ path, args, origin }) {
+              const resolved = resolveLongestProvidedPrefix(byName, path);
+              if (!resolved) {
+                throw new Error(
+                  'No capability named "' +
+                    (path[0] || "") +
+                    '" on this context or anywhere up its chain. describe() lists what exists.',
+                );
+              }
+              const tail = resolved.remainder.length ? "." + resolved.remainder.join(".") : "";
+              return (
+                "[defaults:" +
+                resolved.entry.name +
+                tail +
+                "] → " +
+                resolved.entry.blurb +
+                " · origin " +
+                (origin ? origin.id : "?") +
+                (args && args.length ? " · args " + truncate(JSON.stringify(args), 60) : "")
+              );
+            },
+            provideCapability() {
+              throw new Error(
+                "The defaults are read-only — they ship with the deploy. Provide on your own context to shadow a default.",
+              );
+            },
+            revokeCapability() {
+              throw new Error(
+                "The defaults are read-only — they ship with the deploy and cannot be revoked; shadow them on your own context instead.",
+              );
+            },
+          };
+          world.newProject = (id) =>
+            new ToyItx({
+              contextId: id,
+              journalRef: { namespace: id, path: "/itx" },
+              journal: [],
+              address: {
+                type: "rpc",
+                worker: { type: "durable-object", binding: "PROJECT", name: id },
+              },
+              dial: world.dial,
+              parentItx: () => ({ from: "defaults", stub: world.defaultsStub }),
+            });
+          return world;
         }
-        logLine(logEl, "… plus " + Math.max(0, descriptions.length - 3) + ' inherited entries (from: "defaults")');
-      }
-    } catch (err) { logLine(logEl, escapeHtml(err.message || String(err)), "err"); }
-    refresh();
-  });
-  refresh();
-})();
 
-/* ---------------- demo 10: the cron fold ---------------- */
+        /* ---------------- demo 1: the seed ---------------- */
 
-(function demoCron() {
-  const root = document.getElementById("demo-cron");
-  if (!root) return;
-  const journalEl = document.getElementById("cron-journal");
-  const stateEl = document.getElementById("cron-state");
-  const logEl = document.getElementById("cron-log");
-  const CRON = {
-    created: "events.iterate.com/cron/schedule-created",
-    updated: "events.iterate.com/cron/schedule-updated",
-    requested: "events.iterate.com/cron/fire-requested",
-    completed: "events.iterate.com/cron/fire-completed",
-  };
-  const initial = () => ({ schedule: null, pendingFires: {} });
-  function reduceCron(state, event) {
-    const p = event.payload || {};
-    switch (event.type) {
-      case CRON.created:
-        if (state.schedule !== null) return state;
-        if (typeof p.id !== "string") return state;
-        return { ...state, schedule: { id: p.id, spec: p.spec, paused: false } };
-      case CRON.updated:
-        if (state.schedule === null) return state;
-        return { ...state, schedule: { ...state.schedule, ...(p.spec ? { spec: p.spec } : {}) } };
-      case CRON.requested:
-        if (p.enqueued !== true || typeof p.fireId !== "string") return state;
-        return { ...state, pendingFires: { ...state.pendingFires, [p.fireId]: true } };
-      case CRON.completed: {
-        if (!(p.fireId in state.pendingFires)) return state;
-        const pendingFires = { ...state.pendingFires };
-        delete pendingFires[p.fireId];
-        return { ...state, pendingFires };
-      }
-      default:
-        return state;
-    }
-  }
-  const journal = [];
-  let state = initial();
-  let offset = 0;
-  let fireCount = 0;
-  function append(type, payload) {
-    journal.push({ offset: journal.length + 1, type, payload });
-    while (offset < journal.length) { state = reduceCron(state, journal[offset]); offset += 1; }
-  }
-  function refresh() {
-    renderJournal(journalEl, journal);
-    stateEl.innerHTML = fmt(state);
-  }
-  root.addEventListener("click", (e) => {
-    const act = e.target.dataset && e.target.dataset.act;
-    if (!act) return;
-    if (act === "create" || act === "create-dup") {
-      const had = state.schedule !== null;
-      append(CRON.created, { id: "cron_x9k2", spec: "0 9 * * 1", parent: { id: "prj_demo" } });
-      logLine(logEl, had
-        ? "appended a SECOND schedule-created — the fold ignored it: the first birth certificate wins, retried appends are inert"
-        : "appended the birth certificate (event #1) — creating the thing was ONE append; no initialize RPC", had ? "ok" : "ok");
-    } else if (act === "update") {
-      append(CRON.updated, { spec: "0 9 * * " + (1 + Math.floor(Math.random() * 5)) });
-      logLine(logEl, "appended schedule-updated — creation-time facts and later facts go through the SAME reducer", "ok");
-    } else if (act === "request") {
-      fireCount += 1;
-      append(CRON.requested, { fireId: "fire_" + fireCount, scheduledForMs: Date.now(), enqueued: true });
-      logLine(logEl, "appended fire-requested (enqueued: true) — appending IS requesting work; processEventBatch runs the side effect, never reduce", "ok");
-    } else if (act === "complete") {
-      const pending = Object.keys(state.pendingFires);
-      const fireId = pending[0] || "fire_unknown";
-      append(CRON.completed, { fireId });
-      logLine(logEl, pending.length
-        ? "appended fire-completed for " + fireId + " — the requested/completed pair makes at-least-once reruns detectable"
-        : "appended fire-completed for an UNKNOWN fireId — inert in the fold (look: state unchanged)", "ok");
-    } else if (act === "wipe") {
-      const before = JSON.stringify(state);
-      state = initial(); offset = 0;
-      while (offset < journal.length) { state = reduceCron(state, journal[offset]); offset += 1; }
-      logLine(logEl, "checkpoint wiped; replayed " + journal.length + " events — rebuilt state is " +
-        (before === JSON.stringify(state) ? "<b>byte-identical ✓</b>" : "DIFFERENT ✗"), "ok");
-    }
-    refresh();
-  });
-  refresh();
-})();
+        (function demoSeed() {
+          const root = document.getElementById("demo-seed");
+          if (!root) return;
+          const tableEl = document.getElementById("seed-table");
+          const logEl = document.getElementById("seed-log");
+          const capabilities = new Map();
+          function provide(name, thing) {
+            capabilities.set(name, thing);
+            render();
+            logLine(logEl, 'provide("' + name + '", …)', "ok");
+          }
+          function invoke(name, ...args) {
+            const cap = capabilities.get(name);
+            if (!cap) throw new Error('No capability named "' + name + '"');
+            return cap(...args);
+          }
+          function render() {
+            tableEl.innerHTML = capabilities.size ? "" : '<div class="empty">(empty)</div>';
+            for (const [name, thing] of capabilities) {
+              const row = document.createElement("div");
+              row.className = "capRow";
+              row.innerHTML =
+                '<span class="cname">' +
+                escapeHtml(name) +
+                '</span> <span class="cfrom">→ ' +
+                escapeHtml(String(thing)) +
+                "</span>";
+              tableEl.appendChild(row);
+            }
+          }
+          root.addEventListener("click", (e) => {
+            const act = e.target.dataset && e.target.dataset.act;
+            if (!act) return;
+            try {
+              if (act === "provide-greet") provide("greet", (who) => "hello, " + who);
+              else if (act === "provide-dice")
+                provide("dice", () => 1 + Math.floor(Math.random() * 6));
+              else if (act === "provide-now") provide("now", () => new Date().toISOString());
+              else if (act === "invoke-greet")
+                logLine(
+                  logEl,
+                  'invoke("greet", "world") <span class="arrow">→</span> ' +
+                    escapeHtml(JSON.stringify(invoke("greet", "world"))),
+                  "ok",
+                );
+              else if (act === "invoke-dice")
+                logLine(
+                  logEl,
+                  'invoke("dice") <span class="arrow">→</span> ' +
+                    escapeHtml(JSON.stringify(invoke("dice"))),
+                  "ok",
+                );
+              else if (act === "invoke-missing") invoke("slack");
+            } catch (err) {
+              logLine(logEl, escapeHtml(err.message || String(err)), "err");
+            }
+          });
+          render();
+        })();
 
-/* ---------------- nav: active-section highlighting ---------------- */
+        /* ---------------- demo 2: the calling convention ---------------- */
 
-(function nav() {
-  if (typeof IntersectionObserver === "undefined") return;
-  const links = Array.from(document.querySelectorAll("nav#toc a"));
-  const byId = new Map(links.map((a) => [a.getAttribute("href").slice(1), a]));
-  const observer = new IntersectionObserver((entries) => {
-    for (const entry of entries) {
-      if (!entry.isIntersecting) continue;
-      links.forEach((a) => a.classList.remove("active"));
-      const link = byId.get(entry.target.id);
-      if (link) link.classList.add("active");
-    }
-  }, { rootMargin: "-15% 0px -75% 0px" });
-  document.querySelectorAll("main section").forEach((section) => observer.observe(section));
-})();
-</script>
+        (function demoConvention() {
+          const root = document.getElementById("demo-conv");
+          if (!root) return;
+          const dispatchEl = document.getElementById("conv-dispatch");
+          const logEl = document.getElementById("conv-log");
+          const itx = new ToyItx({
+            contextId: "prj_demo",
+            journalRef: { namespace: "prj_demo", path: "/itx" },
+            journal: [],
+            address: {
+              type: "rpc",
+              worker: { type: "durable-object", binding: "PROJECT", name: "prj_demo" },
+            },
+          });
+          const handle = pathProxy((pathCall) => {
+            logLine(dispatchEl, "PathCall " + escapeHtml(JSON.stringify(pathCall)));
+            const resolved = resolveLongestProvidedPrefix(itx.state.capabilities, pathCall.path);
+            if (resolved) {
+              logLine(
+                dispatchEl,
+                '&nbsp;&nbsp;longest provided prefix: <b>"' +
+                  escapeHtml(resolved.entry.name) +
+                  '"</b> · remainder ' +
+                  escapeHtml(JSON.stringify(resolved.remainder)) +
+                  " → member replay on the provider's object",
+              );
+            } else {
+              logLine(
+                dispatchEl,
+                "&nbsp;&nbsp;no provided prefix → would delegate up the chain (none here)",
+              );
+            }
+            return itx.invoke(pathCall);
+          });
+          root.addEventListener("click", (e) => {
+            const act = e.target.dataset && e.target.dataset.act;
+            if (!act) return;
+            try {
+              if (act === "provide") {
+                itx.provideCapability({
+                  name: "answer",
+                  instructions:
+                    "The answer to everything: itx.answer.ultimate(), or itx.answer.deep.thought(question).",
+                  capability: {
+                    ultimate: () => 42,
+                    deep: { thought: (q) => ({ answer: 42, question: q }) },
+                  },
+                });
+                logLine(
+                  logEl,
+                  'provided "answer" — a plain nested object IS the capability (kind: live)',
+                  "ok",
+                );
+              } else if (act === "ultimate") {
+                logLine(
+                  logEl,
+                  'itx.answer.ultimate() <span class="arrow">→</span> ' +
+                    escapeHtml(JSON.stringify(handle.answer.ultimate())),
+                  "ok",
+                );
+              } else if (act === "thought") {
+                const q = document.getElementById("conv-q").value;
+                logLine(
+                  logEl,
+                  'itx.answer.deep.thought(…) <span class="arrow">→</span> ' +
+                    escapeHtml(JSON.stringify(handle.answer.deep.thought(q))),
+                  "ok",
+                );
+              } else if (act === "custom") {
+                const segs = document.getElementById("conv-path").value.split(".").filter(Boolean);
+                const target = segs.reduce((acc, key) => acc[key], handle);
+                logLine(
+                  logEl,
+                  "itx." +
+                    escapeHtml(segs.join(".")) +
+                    '(…) <span class="arrow">→</span> ' +
+                    escapeHtml(JSON.stringify(target("…"))),
+                  "ok",
+                );
+              }
+            } catch (err) {
+              logLine(logEl, escapeHtml(err.message || String(err)), "err");
+            }
+          });
+        })();
 
-</main>
-</body>
+        /* ---------------- demo 3: the journal ---------------- */
+
+        (function demoJournal() {
+          const root = document.getElementById("demo-journal");
+          if (!root) return;
+          const world = makeWorld();
+          const itx = world.newProject("prj_demo");
+          const handle = itx.handle();
+          let child = null;
+          const journalEl = document.getElementById("j3-journal");
+          const capsEl = document.getElementById("j3-caps");
+          const childWrap = document.getElementById("j3-childwrap");
+          const childJournalEl = document.getElementById("j3-childjournal");
+          const childSideEl = document.getElementById("j3-log");
+          const logEl = document.getElementById("j3-log2");
+          function refresh() {
+            renderJournal(journalEl, itx.journal);
+            renderOwnFold(capsEl, itx);
+            if (child) {
+              childWrap.style.display = "";
+              renderJournal(childJournalEl, child.journal, { highlight: 1 });
+              childSideEl.previousElementSibling.textContent =
+                "child.describe() — merged chain view (own → parent → defaults)";
+              renderDescribe(childSideEl, child.describe());
+            }
+          }
+          root.addEventListener("click", (e) => {
+            const act = e.target.dataset && e.target.dataset.act;
+            if (!act) return;
+            try {
+              if (act === "provide-live") {
+                itx.provideCapability({
+                  name: "clock",
+                  instructions: "The provider's wall clock: itx.clock.nowMs().",
+                  capability: { nowMs: () => Date.now() },
+                });
+                logLine(
+                  logEl,
+                  "appended capability-provided (kind: live — the EVENT is journaled, the stub stays in memory)",
+                  "ok",
+                );
+              } else if (act === "provide-rpc") {
+                itx.provideCapability({
+                  name: "ai",
+                  capability: { type: "rpc", worker: { type: "binding", binding: "AI" } },
+                });
+                logLine(
+                  logEl,
+                  "appended capability-provided (kind: rpc — the full address is in the journal)",
+                  "ok",
+                );
+              } else if (act === "call-clock") {
+                logLine(
+                  logEl,
+                  'itx.clock.nowMs() <span class="arrow">→</span> ' +
+                    escapeHtml(JSON.stringify(handle.clock.nowMs())),
+                  "ok",
+                );
+              } else if (act === "revoke") {
+                itx.revokeCapability({ name: "clock" });
+                logLine(logEl, "appended capability-revoked — the fold drops the entry", "ok");
+              } else if (act === "wipe") {
+                const before = JSON.stringify(itx.state);
+                itx.wipeCheckpointAndReplay();
+                const after = JSON.stringify(itx.state);
+                logLine(
+                  logEl,
+                  "checkpoint wiped; replayed " +
+                    itx.journal.length +
+                    " events from offset 0 — rebuilt state is " +
+                    (before === after
+                      ? "<b>byte-identical ✓</b> (the checkpoint is a disposable cache)"
+                      : "DIFFERENT ✗ (bug!)"),
+                  before === after ? "ok" : "err",
+                );
+              } else if (act === "extend") {
+                child = itx.extend({ name: "scratch" });
+                logLine(
+                  logEl,
+                  "extended → " +
+                    child.contextId +
+                    " · journal at (" +
+                    child.journalRef.namespace +
+                    ", " +
+                    child.journalRef.path +
+                    ") · event #1 is its birth certificate — creation was ONE append",
+                  "ok",
+                );
+              }
+            } catch (err) {
+              logLine(logEl, escapeHtml(err.message || String(err)), "err");
+            }
+            refresh();
+          });
+          refresh();
+        })();
+
+        /* ---------------- demo 4: live vs durable ---------------- */
+
+        (function demoStubs() {
+          const root = document.getElementById("demo-stubs");
+          if (!root) return;
+          const world = makeWorld();
+          const itx = new ToyItx({
+            contextId: "prj_demo",
+            journalRef: { namespace: "prj_demo", path: "/itx" },
+            journal: [],
+            address: {
+              type: "rpc",
+              worker: { type: "durable-object", binding: "PROJECT", name: "prj_demo" },
+            },
+            dial: world.dial,
+          });
+          const handle = itx.handle();
+          const capsEl = document.getElementById("s4-caps");
+          const logEl = document.getElementById("s4-log");
+          function refresh() {
+            renderDescribe(capsEl, itx.describe());
+          }
+          root.addEventListener("click", (e) => {
+            const act = e.target.dataset && e.target.dataset.act;
+            if (!act) return;
+            try {
+              if (act === "provide-mac") {
+                itx.provideCapability({
+                  name: "mac",
+                  instructions: "Compile-and-run Swift on Jonas's Mac: itx.mac.runSwift(src).",
+                  capability: {
+                    runSwift: (src) =>
+                      "compiled & ran " + src.length + " chars of Swift, in the provider's process",
+                  },
+                });
+                logLine(
+                  logEl,
+                  'provided "mac" — live: the stub is held over the provider\'s session',
+                  "ok",
+                );
+              } else if (act === "provide-ai") {
+                itx.provideCapability({
+                  name: "ai",
+                  capability: { type: "rpc", worker: { type: "binding", binding: "AI" } },
+                });
+                logLine(
+                  logEl,
+                  'provided "ai" — durable: a serializable address, restored at invoke time',
+                  "ok",
+                );
+              } else if (act === "call-mac") {
+                logLine(
+                  logEl,
+                  'itx.mac.runSwift("print(42)") <span class="arrow">→</span> ' +
+                    escapeHtml(JSON.stringify(handle.mac.runSwift("print(42)"))),
+                  "ok",
+                );
+              } else if (act === "call-ai") {
+                logLine(
+                  logEl,
+                  'itx.ai.run("@cf/meta/llama-3") <span class="arrow">→</span> ' +
+                    escapeHtml(JSON.stringify(handle.ai.run("@cf/meta/llama-3"))),
+                  "ok",
+                );
+              } else if (act === "drop") {
+                itx.disconnectSession();
+                logLine(
+                  logEl,
+                  "session dropped → appended capability-disconnected (record only; the fold ignores it). " +
+                    "The live entry survives as offline; the rpc address is untouched. Try calling mac again.",
+                  "ok",
+                );
+              }
+            } catch (err) {
+              logLine(logEl, escapeHtml(err.message || String(err)), "err");
+            }
+            refresh();
+          });
+          refresh();
+        })();
+
+        /* ---------------- demo 5: the chain ---------------- */
+
+        (function demoChain() {
+          const root = document.getElementById("demo-chain");
+          if (!root) return;
+          const world = makeWorld();
+          const project = world.newProject("prj_demo");
+          const child = project.extend({ name: "review-run" });
+          const viz = document.getElementById("chain-viz");
+          const logEl = document.getElementById("chain-log");
+          function renderChain(win) {
+            viz.innerHTML = "";
+            const nodes = [
+              {
+                key: "child",
+                title: child.contextId,
+                role:
+                  'extension "review-run" · journal ' + child.journalRef.path + " · delegates →",
+                caps: Object.values(child.state.capabilities),
+              },
+              {
+                key: "project",
+                title: "prj_demo",
+                role: "the project context · journal /itx · delegates →",
+                caps: Object.values(project.state.capabilities),
+              },
+              {
+                key: "defaults",
+                title: "defaults",
+                role: "PlatformContext — read-only code; ships with the deploy",
+                caps: TOY_DEFAULT_CAPS.map((c) => ({ name: c.name, kind: "rpc" })),
+              },
+            ];
+            for (const node of nodes) {
+              const div = document.createElement("div");
+              div.className = "chainNode";
+              let caps = node.caps.length
+                ? node.caps
+                    .map(
+                      (c) =>
+                        '<div class="capEntry' +
+                        (win && win.node === node.key && win.name === c.name ? " win" : "") +
+                        '" ' +
+                        'data-node="' +
+                        node.key +
+                        '" data-name="' +
+                        escapeHtml(c.name) +
+                        '">' +
+                        escapeHtml(c.name) +
+                        ' <span class="k">' +
+                        c.kind +
+                        "</span></div>",
+                    )
+                    .join("")
+                : '<div class="empty" style="font:11.5px ui-monospace,monospace;color:#9aa1ac;padding:3px 8px">(no own entries)</div>';
+              div.innerHTML =
+                '<header><span class="cid">' +
+                escapeHtml(node.title) +
+                '</span><span class="role">' +
+                escapeHtml(node.role) +
+                '</span></header><div class="caps">' +
+                caps +
+                "</div>";
+              viz.appendChild(div);
+            }
+          }
+          function traceAndCall(pathStr, startAtParent) {
+            const segs = pathStr.split(".").filter(Boolean);
+            if (!segs.length) return;
+            logLine(
+              logEl,
+              "<b>" +
+                (startAtParent ? "child.super." : "child.") +
+                escapeHtml(segs.join(".")) +
+                "(…)</b>",
+            );
+            let win = null;
+            const hops = [
+              { key: "child", label: child.contextId, caps: child.state.capabilities },
+              { key: "project", label: "prj_demo", caps: project.state.capabilities },
+            ].slice(startAtParent ? 1 : 0);
+            if (startAtParent) {
+              logLine(
+                logEl,
+                "&nbsp;&nbsp;super: resolution starts ONE link up — the child's table is skipped; origin is still " +
+                  child.contextId,
+              );
+            }
+            let resolvedSomewhere = false;
+            for (const hop of hops) {
+              const r = resolveLongestProvidedPrefix(hop.caps, segs);
+              if (r) {
+                logLine(
+                  logEl,
+                  "&nbsp;&nbsp;" +
+                    escapeHtml(hop.label) +
+                    ': <b>"' +
+                    escapeHtml(r.entry.name) +
+                    '"</b> wins (longest provided prefix) · remainder ' +
+                    escapeHtml(JSON.stringify(r.remainder)) +
+                    " → " +
+                    (r.entry.kind === "live"
+                      ? "live stub"
+                      : "dial the " + r.entry.kind + " address"),
+                );
+                win = { node: hop.key, name: r.entry.name };
+                resolvedSomewhere = true;
+                break;
+              }
+              logLine(
+                logEl,
+                "&nbsp;&nbsp;" +
+                  escapeHtml(hop.label) +
+                  ": no provided prefix → delegate the WHOLE path to the parent (origin stays " +
+                  child.contextId +
+                  ")",
+              );
+            }
+            if (!resolvedSomewhere) {
+              const d = TOY_DEFAULT_CAPS.find((c) => c.name === segs[0]);
+              if (d) {
+                logLine(
+                  logEl,
+                  '&nbsp;&nbsp;defaults: <b>"' +
+                    d.name +
+                    '"</b> wins · remainder ' +
+                    escapeHtml(JSON.stringify(segs.slice(1))) +
+                    " → dialed in-process (loopback — default dispatch pays no DO hop)",
+                );
+                win = { node: "defaults", name: d.name };
+              }
+            }
+            try {
+              const args =
+                segs[0] === "fetch" ? ["https://api.example.com/v1/thing"] : [{ demo: true }];
+              const result = startAtParent
+                ? project.invoke({
+                    path: segs,
+                    args,
+                    origin: { id: child.contextId, address: child.address },
+                  })
+                : child.invoke({ path: segs, args });
+              logLine(
+                logEl,
+                '&nbsp;&nbsp;result <span class="arrow">→</span> ' +
+                  escapeHtml(typeof result === "string" ? result : JSON.stringify(result)),
+                "ok",
+              );
+            } catch (err) {
+              logLine(logEl, "&nbsp;&nbsp;" + escapeHtml(err.message || String(err)), "err");
+            }
+            renderChain(win);
+          }
+          root.addEventListener("click", (e) => {
+            const act = e.target.dataset && e.target.dataset.act;
+            if (!act) return;
+            try {
+              if (act === "shadow-gitpush") {
+                child.provideCapability({
+                  path: ["workspace", "gitPush"],
+                  instructions:
+                    "gitPush waits for human approval; everything else is the real workspace.",
+                  capability: (input) =>
+                    "⏸ held for approval (the gate) — input " + JSON.stringify(input),
+                });
+                logLine(
+                  logEl,
+                  'shadowed ONE method: path ["workspace","gitPush"] on ' +
+                    child.contextId +
+                    " — workspace.readFile etc. still fall through the chain",
+                  "ok",
+                );
+              } else if (act === "shadow-fetch") {
+                child.provideCapability({
+                  name: "fetch",
+                  instructions:
+                    "Egress with an x-trace-id header; delegates to the real pipe via itx.super.fetch.",
+                  capability: (request) =>
+                    "[child's fetch shadow] stamped x-trace-id, placeholders UNsubstituted → super.fetch → " +
+                    project.invoke({
+                      path: ["fetch"],
+                      args: [request],
+                      origin: { id: child.contextId, address: child.address },
+                    }),
+                });
+                logLine(
+                  logEl,
+                  'shadowed "fetch" on the child with a plain function that calls super — middleware in one provide',
+                  "ok",
+                );
+              } else if (act === "provide-slack") {
+                project.provideCapability({
+                  name: "slack",
+                  instructions:
+                    "Post to the team Slack: itx.slack.chat.postMessage({ channel, text }).",
+                  capability: {
+                    chat: {
+                      postMessage: (m) => "[live slack provider] posted " + JSON.stringify(m),
+                    },
+                  },
+                });
+                logLine(
+                  logEl,
+                  'provided "slack" on the PROJECT — the child inherits it through the chain',
+                  "ok",
+                );
+              } else if (act === "revoke-gitpush") {
+                child.revokeCapability({ path: ["workspace", "gitPush"] });
+                logLine(
+                  logEl,
+                  "revoked the child's gitPush shadow — the inherited workspace resurfaces, by construction",
+                  "ok",
+                );
+              } else if (act === "revoke-default") {
+                child.revokeCapability({ name: "ai" });
+              } else if (act === "provide-on-defaults") {
+                world.defaultsStub.provideCapability({ name: "evil", capability: {} });
+              } else if (act === "resolve") {
+                traceAndCall(document.getElementById("chain-path").value, false);
+                return; // traceAndCall renders
+              } else if (act === "super") {
+                traceAndCall("fetch", true);
+                return;
+              }
+            } catch (err) {
+              logLine(logEl, escapeHtml(err.message || String(err)), "err");
+            }
+            renderChain(null);
+          });
+          renderChain(null);
+        })();
+
+        /* ---------------- demo 6: the dial ---------------- */
+
+        (function demoDial() {
+          const root = document.getElementById("demo-dial");
+          if (!root) return;
+          const world = makeWorld();
+          const pick = document.getElementById("dial-pick");
+          const addrEl = document.getElementById("dial-addr");
+          const logEl = document.getElementById("dial-log");
+          const candidates = [
+            {
+              label: 'binding "AI" — allowlisted',
+              path: ["run"],
+              args: ["@cf/meta/llama-3"],
+              address: { type: "rpc", worker: { type: "binding", binding: "AI" } },
+            },
+            {
+              label: 'binding "DB" — NOT allowlisted',
+              path: ["query"],
+              args: ["select 1"],
+              address: { type: "rpc", worker: { type: "binding", binding: "DB" } },
+            },
+            {
+              label: 'loopback "McpClient" — allowlisted, props ride the provide',
+              path: ["listTools"],
+              args: [],
+              address: {
+                type: "rpc",
+                worker: { type: "loopback" },
+                entrypoint: "McpClient",
+                props: { serverUrl: "https://docs.mcp.cloudflare.com/mcp" },
+              },
+            },
+            {
+              label: 'loopback "SecretLeaker" — NOT allowlisted',
+              path: ["leak"],
+              args: [],
+              address: { type: "rpc", worker: { type: "loopback" }, entrypoint: "SecretLeaker" },
+            },
+            {
+              label: 'durable-object "TODO":"inbox" — default allowlist is empty',
+              path: ["add"],
+              args: [{ text: "hi" }],
+              address: {
+                type: "rpc",
+                worker: { type: "durable-object", binding: "TODO", name: "inbox" },
+              },
+            },
+            {
+              label: "source (inline greeter) — loader isolate, origin-scoped",
+              path: ["hello"],
+              args: [{ name: "world" }],
+              address: {
+                type: "rpc",
+                worker: {
+                  type: "source",
+                  source: {
+                    type: "inline",
+                    cacheKey: "greeter-v1",
+                    mainModule: "cap.js",
+                    modules: { "cap.js": "…" },
+                  },
+                },
+              },
+            },
+            {
+              label: "url — a Cap'n Web server across the internet",
+              path: ["chat", "postMessage"],
+              args: [{ text: "hi" }],
+              address: {
+                type: "url",
+                url: "wss://caps.example.com/api",
+                headers: { authorization: 'Bearer getSecret({ key: "REMOTE_TOKEN" })' },
+              },
+            },
+          ];
+          candidates.forEach((c, i) => {
+            const opt = document.createElement("option");
+            opt.value = String(i);
+            opt.textContent = c.label;
+            pick.appendChild(opt);
+          });
+          function show() {
+            const c = candidates[Number(pick.value)];
+            addrEl.innerHTML = fmt(c.address);
+          }
+          pick.addEventListener("change", show);
+          root.addEventListener("click", (e) => {
+            if (!e.target.dataset || e.target.dataset.act !== "dial") return;
+            const c = candidates[Number(pick.value)];
+            show();
+            logLine(
+              logEl,
+              "<b>dial(address) → call({ path: " +
+                escapeHtml(JSON.stringify(c.path)) +
+                ", args })</b>",
+            );
+            try {
+              const result = world
+                .dial(c.address, {
+                  capabilityPath: "demo",
+                  origin: { id: "prj_demo", address: null },
+                })
+                .call({ path: c.path, args: c.args });
+              logLine(
+                logEl,
+                escapeHtml(typeof result === "string" ? result : JSON.stringify(result)),
+                "ok",
+              );
+            } catch (err) {
+              logLine(
+                logEl,
+                escapeHtml(err.message || String(err)) +
+                  ' <span class="arrow">(surfaced at FIRST CALL — provide was structural only)</span>',
+                "err",
+              );
+            }
+          });
+          show();
+        })();
+
+        /* ---------------- demo 7: identity ---------------- */
+
+        (function demoIdentity() {
+          const root = document.getElementById("demo-identity");
+          if (!root) return;
+          const input = document.getElementById("id-name");
+          const outEl = document.getElementById("id-out");
+          const addrEl = document.getElementById("id-addr");
+          function parse() {
+            const name = input.value.trim();
+            try {
+              const colon = name.indexOf(":");
+              if (colon <= 0 || name[colon + 1] !== "/") {
+                throw new Error(
+                  'ItxDurableObject must be addressed by its journal coordinate ("<namespace>:/<path>"), got ' +
+                    JSON.stringify(name) +
+                    ".",
+                );
+              }
+              const namespace = name.slice(0, colon);
+              const path = name.slice(colon + 1);
+              const segs = path.split("/").filter(Boolean);
+              const last = segs[segs.length - 1];
+              const contextId =
+                last && last.indexOf("itx_") === 0
+                  ? last
+                  : "(the host's own context — identity derives from the host, no birth certificate)";
+              outEl.innerHTML =
+                "namespace (owning project):  <b>" +
+                escapeHtml(namespace) +
+                "</b>\n" +
+                "journal path:                <b>" +
+                escapeHtml(path) +
+                "</b>\n" +
+                "context id (last segment):   <b>" +
+                escapeHtml(contextId) +
+                "</b>\n" +
+                "journal base for children:   <b>" +
+                escapeHtml(journalBaseOf(path)) +
+                "</b>\n" +
+                'reserved segment in use:     <b>"itx"</b> — user streams may not claim it';
+              addrEl.innerHTML = fmt(childContextAddress({ namespace, path }));
+            } catch (err) {
+              outEl.innerHTML =
+                '<span style="color:var(--err)">' +
+                escapeHtml(err.message || String(err)) +
+                "</span>";
+              addrEl.innerHTML = "";
+            }
+          }
+          root.addEventListener("click", (e) => {
+            const t = e.target;
+            if (t.dataset && t.dataset.name) {
+              input.value = t.dataset.name;
+              parse();
+            } else if (t.dataset && t.dataset.act === "parse") parse();
+          });
+          parse();
+        })();
+
+        /* ---------------- demo 8: the build memo ---------------- */
+
+        (function demoMemo() {
+          const root = document.getElementById("demo-memo");
+          if (!root) return;
+          const logEl = document.getElementById("memo-log");
+          const r2El = document.getElementById("memo-r2");
+          const shaEl = document.getElementById("memo-sha");
+          const r2 = new Map();
+          function newSha() {
+            let s = "";
+            for (let i = 0; i < 8; i++) s += "0123456789abcdef"[Math.floor(Math.random() * 16)];
+            return s;
+          }
+          let sha = newSha();
+          function fakeHash(s) {
+            let h = 5381;
+            for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) >>> 0;
+            return (
+              h.toString(16).padStart(8, "0") + ((h ^ 0xabcdef) >>> 0).toString(16).slice(0, 4)
+            );
+          }
+          function refresh() {
+            shaEl.textContent = 'repo "project" HEAD = ' + sha;
+            r2El.innerHTML = r2.size ? "" : '<div class="empty">(empty)</div>';
+            for (const [key, value] of r2) {
+              const row = document.createElement("div");
+              row.className = "capRow";
+              row.innerHTML =
+                '<span class="cname">' +
+                escapeHtml(key) +
+                '</span> <span class="cfrom">' +
+                escapeHtml(value) +
+                "</span>";
+              r2El.appendChild(row);
+            }
+          }
+          root.addEventListener("click", (e) => {
+            const act = e.target.dataset && e.target.dataset.act;
+            if (!act) return;
+            if (act === "push") {
+              sha = newSha();
+              logLine(
+                logEl,
+                "git push → new commit " +
+                  sha +
+                  ' — "latest" resolves to it (probe memoized ≤10 s per isolate)',
+                "ok",
+              );
+            } else if (act === "dial") {
+              logLine(logEl, '<b>dial itx.repoGreeter.hello({ name: "world" })</b>');
+              logLine(logEl, '&nbsp;&nbsp;probe "latest" → ' + sha);
+              const memoKey =
+                "build/" + fakeHash("prj_demo|project|" + sha + "|caps/greeter.js|{}|null");
+              logLine(
+                logEl,
+                "&nbsp;&nbsp;memo key = hash(projectId, repo, sha, path, bundle, compatDate) = " +
+                  memoKey,
+              );
+              if (r2.has(memoKey)) {
+                logLine(
+                  logEl,
+                  "&nbsp;&nbsp;R2 HIT — no build, no readTree. Warm dials never build.",
+                  "ok",
+                );
+              } else {
+                logLine(
+                  logEl,
+                  "&nbsp;&nbsp;cold key: repo DO readTree(" +
+                    sha +
+                    ") → worker-bundler (in-memory vfs, no clone) → R2 put " +
+                    memoKey,
+                );
+                r2.set(memoKey, "built modules for " + sha);
+              }
+              logLine(
+                logEl,
+                "&nbsp;&nbsp;loader isolate key itx-cap:prj_demo:repoGreeter:" +
+                  memoKey +
+                  ' → replayed .hello(…) <span class="arrow">→</span> "hello from the repo, world"',
+                "ok",
+              );
+            }
+            refresh();
+          });
+          refresh();
+        })();
+
+        /* ---------------- demo 9: describeItx ---------------- */
+
+        (function demoDescribe() {
+          const root = document.getElementById("demo-describe");
+          if (!root) return;
+          const world = makeWorld();
+          const itx = world.newProject("prj_demo");
+          const handle = itx.handle();
+          const journalEl = document.getElementById("d9-journal");
+          const logEl = document.getElementById("d9-log");
+          function refresh() {
+            renderJournal(journalEl, itx.journal);
+          }
+          root.addEventListener("click", (e) => {
+            const act = e.target.dataset && e.target.dataset.act;
+            if (!act) return;
+            try {
+              if (act === "provide") {
+                itx.provideCapability({
+                  name: "petstore",
+                  capability: {
+                    type: "rpc",
+                    worker: { type: "loopback" },
+                    entrypoint: "OpenApiClient",
+                    props: { specUrl: "https://petstore3.swagger.io/api/v3/openapi.json" },
+                  },
+                });
+                logLine(
+                  logEl,
+                  "provided with NO types — the core dialed the address once and asked describeItx; " +
+                    "the provider derived types from its spec, and they were JOURNALED with the provide",
+                  "ok",
+                );
+              } else if (act === "call") {
+                logLine(
+                  logEl,
+                  'itx.petstore.findPetsByStatus(…) <span class="arrow">→</span> ' +
+                    escapeHtml(String(handle.petstore.findPetsByStatus({ status: "available" }))),
+                  "ok",
+                );
+              } else if (act === "describe") {
+                const descriptions = itx.describe();
+                for (const d of descriptions.slice(0, 3)) {
+                  logLine(
+                    logEl,
+                    "<b>" +
+                      escapeHtml(d.name) +
+                      "</b> [" +
+                      d.kind +
+                      (d.from ? " · from: " + escapeHtml(d.from) : "") +
+                      "] " +
+                      escapeHtml(truncate(d.instructions || "", 100)),
+                  );
+                  if (d.types)
+                    logLine(
+                      logEl,
+                      '&nbsp;&nbsp;types: <span style="color:#6b7280">' +
+                        escapeHtml(truncate(d.types.split("\n")[1] || d.types, 110)) +
+                        " …</span>",
+                    );
+                }
+                logLine(
+                  logEl,
+                  "… plus " +
+                    Math.max(0, descriptions.length - 3) +
+                    ' inherited entries (from: "defaults")',
+                );
+              }
+            } catch (err) {
+              logLine(logEl, escapeHtml(err.message || String(err)), "err");
+            }
+            refresh();
+          });
+          refresh();
+        })();
+
+        /* ---------------- demo 10: the cron fold ---------------- */
+
+        (function demoCron() {
+          const root = document.getElementById("demo-cron");
+          if (!root) return;
+          const journalEl = document.getElementById("cron-journal");
+          const stateEl = document.getElementById("cron-state");
+          const logEl = document.getElementById("cron-log");
+          const CRON = {
+            created: "events.iterate.com/cron/schedule-created",
+            updated: "events.iterate.com/cron/schedule-updated",
+            requested: "events.iterate.com/cron/fire-requested",
+            completed: "events.iterate.com/cron/fire-completed",
+          };
+          const initial = () => ({ schedule: null, pendingFires: {} });
+          function reduceCron(state, event) {
+            const p = event.payload || {};
+            switch (event.type) {
+              case CRON.created:
+                if (state.schedule !== null) return state;
+                if (typeof p.id !== "string") return state;
+                return { ...state, schedule: { id: p.id, spec: p.spec, paused: false } };
+              case CRON.updated:
+                if (state.schedule === null) return state;
+                return {
+                  ...state,
+                  schedule: { ...state.schedule, ...(p.spec ? { spec: p.spec } : {}) },
+                };
+              case CRON.requested:
+                if (p.enqueued !== true || typeof p.fireId !== "string") return state;
+                return { ...state, pendingFires: { ...state.pendingFires, [p.fireId]: true } };
+              case CRON.completed: {
+                if (!(p.fireId in state.pendingFires)) return state;
+                const pendingFires = { ...state.pendingFires };
+                delete pendingFires[p.fireId];
+                return { ...state, pendingFires };
+              }
+              default:
+                return state;
+            }
+          }
+          const journal = [];
+          let state = initial();
+          let offset = 0;
+          let fireCount = 0;
+          function append(type, payload) {
+            journal.push({ offset: journal.length + 1, type, payload });
+            while (offset < journal.length) {
+              state = reduceCron(state, journal[offset]);
+              offset += 1;
+            }
+          }
+          function refresh() {
+            renderJournal(journalEl, journal);
+            stateEl.innerHTML = fmt(state);
+          }
+          root.addEventListener("click", (e) => {
+            const act = e.target.dataset && e.target.dataset.act;
+            if (!act) return;
+            if (act === "create" || act === "create-dup") {
+              const had = state.schedule !== null;
+              append(CRON.created, {
+                id: "cron_x9k2",
+                spec: "0 9 * * 1",
+                parent: { id: "prj_demo" },
+              });
+              logLine(
+                logEl,
+                had
+                  ? "appended a SECOND schedule-created — the fold ignored it: the first birth certificate wins, retried appends are inert"
+                  : "appended the birth certificate (event #1) — creating the thing was ONE append; no initialize RPC",
+                had ? "ok" : "ok",
+              );
+            } else if (act === "update") {
+              append(CRON.updated, { spec: "0 9 * * " + (1 + Math.floor(Math.random() * 5)) });
+              logLine(
+                logEl,
+                "appended schedule-updated — creation-time facts and later facts go through the SAME reducer",
+                "ok",
+              );
+            } else if (act === "request") {
+              fireCount += 1;
+              append(CRON.requested, {
+                fireId: "fire_" + fireCount,
+                scheduledForMs: Date.now(),
+                enqueued: true,
+              });
+              logLine(
+                logEl,
+                "appended fire-requested (enqueued: true) — appending IS requesting work; processEventBatch runs the side effect, never reduce",
+                "ok",
+              );
+            } else if (act === "complete") {
+              const pending = Object.keys(state.pendingFires);
+              const fireId = pending[0] || "fire_unknown";
+              append(CRON.completed, { fireId });
+              logLine(
+                logEl,
+                pending.length
+                  ? "appended fire-completed for " +
+                      fireId +
+                      " — the requested/completed pair makes at-least-once reruns detectable"
+                  : "appended fire-completed for an UNKNOWN fireId — inert in the fold (look: state unchanged)",
+                "ok",
+              );
+            } else if (act === "wipe") {
+              const before = JSON.stringify(state);
+              state = initial();
+              offset = 0;
+              while (offset < journal.length) {
+                state = reduceCron(state, journal[offset]);
+                offset += 1;
+              }
+              logLine(
+                logEl,
+                "checkpoint wiped; replayed " +
+                  journal.length +
+                  " events — rebuilt state is " +
+                  (before === JSON.stringify(state) ? "<b>byte-identical ✓</b>" : "DIFFERENT ✗"),
+                "ok",
+              );
+            }
+            refresh();
+          });
+          refresh();
+        })();
+
+        /* ---------------- nav: active-section highlighting ---------------- */
+
+        (function nav() {
+          if (typeof IntersectionObserver === "undefined") return;
+          const links = Array.from(document.querySelectorAll("nav#toc a"));
+          const byId = new Map(links.map((a) => [a.getAttribute("href").slice(1), a]));
+          const observer = new IntersectionObserver(
+            (entries) => {
+              for (const entry of entries) {
+                if (!entry.isIntersecting) continue;
+                links.forEach((a) => a.classList.remove("active"));
+                const link = byId.get(entry.target.id);
+                if (link) link.classList.add("active");
+              }
+            },
+            { rootMargin: "-15% 0px -75% 0px" },
+          );
+          document.querySelectorAll("main section").forEach((section) => observer.observe(section));
+        })();
+      </script>
+    </main>
+  </body>
 </html>

--- a/apps/os/docs/itx-explainer.html
+++ b/apps/os/docs/itx-explainer.html
@@ -1,0 +1,2960 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>itx — the iterate context, from scratch</title>
+<style>
+:root {
+  --bg: #fcfcfb;
+  --ink: #1c1e21;
+  --muted: #6b7280;
+  --line: #e4e6ea;
+  --accent: #2456d6;
+  --accent-soft: #eef2fd;
+  --code-bg: #15181e;
+  --code-ink: #d7dce3;
+  --ok: #15803d;
+  --err: #b91c1c;
+}
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  font: 16px/1.65 system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+nav#toc {
+  position: fixed; top: 0; left: 0; bottom: 0; width: 248px;
+  padding: 26px 18px; border-right: 1px solid var(--line);
+  overflow-y: auto; background: var(--bg); z-index: 10;
+}
+nav#toc .brand { font-weight: 700; font-size: 15px; margin-bottom: 2px; }
+nav#toc .brand code { background: none; padding: 0; font-size: 15px; }
+nav#toc .sub { font-size: 12px; color: var(--muted); margin-bottom: 18px; line-height: 1.4; }
+nav#toc a {
+  display: flex; gap: 8px; align-items: baseline;
+  padding: 5px 8px; margin: 1px 0; color: var(--muted); text-decoration: none;
+  border-radius: 6px; font-size: 13px; line-height: 1.35;
+}
+nav#toc a .n { font-size: 11px; font-variant-numeric: tabular-nums; opacity: .7; min-width: 16px; }
+nav#toc a:hover { color: var(--ink); background: #f1f2f4; }
+nav#toc a.active { color: var(--accent); background: var(--accent-soft); font-weight: 600; }
+main { margin-left: 248px; padding: 52px 44px 140px; max-width: 880px; }
+header.page h1 { font-size: 34px; line-height: 1.2; margin: 0 0 10px; letter-spacing: -0.02em; }
+header.page p.lede { font-size: 17.5px; color: #3a3f47; max-width: 46rem; }
+section { margin: 0 0 96px; scroll-margin-top: 28px; }
+.kicker {
+  font-size: 12px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase;
+  color: var(--accent); margin-bottom: 6px;
+}
+h2 { font-size: 26px; letter-spacing: -0.015em; margin: 0 0 14px; line-height: 1.25; }
+h3 { font-size: 18px; margin: 34px 0 10px; }
+p, li { max-width: 46rem; }
+li { margin: 4px 0; }
+hr { border: none; border-top: 1px solid var(--line); margin: 40px 0; }
+code {
+  background: #eef0f3; padding: 1px 5px; border-radius: 5px;
+  font: 0.86em ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+strong code { font-weight: 600; }
+figure.code { margin: 18px 0; border-radius: 10px; overflow: hidden; background: var(--code-bg); }
+figure.code figcaption {
+  font: 11.5px ui-monospace, Menlo, monospace; color: #8b93a1;
+  padding: 8px 16px 0; display: flex; justify-content: space-between; gap: 12px;
+}
+figure.code pre {
+  margin: 0; padding: 13px 18px 15px; overflow-x: auto;
+  font: 12.5px/1.6 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  color: var(--code-ink);
+}
+.tok-k { color: #82aaff; }
+.tok-s { color: #c3e88d; }
+.tok-c { color: #697283; font-style: italic; }
+.tok-n { color: #f78c6c; }
+aside.note, aside.warn {
+  border-left: 3px solid var(--accent); background: var(--accent-soft);
+  padding: 12px 18px; border-radius: 0 8px 8px 0; margin: 22px 0;
+  font-size: 14.5px; max-width: 48rem;
+}
+aside.warn { border-left-color: #b45309; background: #fdf6ec; }
+aside.note p, aside.warn p { margin: 6px 0; }
+.demo {
+  border: 1px solid var(--line); border-radius: 12px; padding: 16px 18px 18px;
+  margin: 26px 0; background: #fff; box-shadow: 0 1px 2px rgba(20,24,33,.04);
+}
+.demo > .dtitle {
+  font-size: 11px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase;
+  color: var(--muted); margin-bottom: 12px;
+}
+.demo > .dtitle .live { color: var(--ok); }
+.toolbar { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 12px; align-items: center; }
+.toolbar .sep { width: 1px; align-self: stretch; background: var(--line); margin: 0 4px; }
+button {
+  font: 13px system-ui, sans-serif; padding: 6px 12px; cursor: pointer;
+  border: 1px solid #c9d0da; background: #f8fafc; border-radius: 7px; color: var(--ink);
+}
+button:hover { border-color: var(--accent); color: var(--accent); }
+button.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+button.primary:hover { background: #1d47b4; color: #fff; }
+input[type=text], select {
+  font: 13px ui-monospace, Menlo, monospace; padding: 6px 9px;
+  border: 1px solid #c9d0da; border-radius: 7px; background: #fff; color: var(--ink);
+}
+.panes { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-top: 10px; }
+.panes.three { grid-template-columns: 1fr 1fr 1fr; }
+.pane { border: 1px solid var(--line); border-radius: 9px; background: #fbfbfa; min-width: 0; }
+.pane > h4 {
+  margin: 0; padding: 7px 11px; font-size: 10.5px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .07em; color: var(--muted);
+  border-bottom: 1px solid var(--line);
+}
+.pane > .body {
+  padding: 8px 11px; font: 12px/1.6 ui-monospace, Menlo, monospace;
+  max-height: 280px; overflow: auto; white-space: pre-wrap; word-break: break-word;
+}
+.pane .empty { color: #9aa1ac; font-style: italic; }
+.jev { padding: 2px 0; border-bottom: 1px dashed #ececea; }
+.jev:last-child { border-bottom: none; }
+.jev .off { color: var(--muted); margin-right: 6px; font-variant-numeric: tabular-nums; }
+.jev .jtype { color: var(--accent); font-weight: 600; margin-right: 6px; }
+.jev .jp { color: #4b5563; }
+.jev.hl { background: #fef6e0; }
+.capRow { padding: 3px 0; border-bottom: 1px dashed #ececea; }
+.capRow:last-child { border-bottom: none; }
+.capRow .cname { font-weight: 700; }
+.capRow .ckind { color: #7c3aed; margin-left: 6px; }
+.capRow .cfrom { color: var(--muted); margin-left: 6px; }
+.capRow .cconn { margin-left: 6px; }
+.capRow .cconn.on { color: var(--ok); }
+.capRow .cconn.off { color: var(--err); }
+.capRow .cinstr { color: #6b7280; display: block; }
+.log .line { padding: 2px 0; }
+.log .line.ok { color: var(--ok); }
+.log .line.err { color: var(--err); }
+.log .line .arrow { color: var(--muted); }
+.chain { display: grid; grid-template-columns: 1fr 1fr 1.1fr; gap: 12px; margin-top: 12px; }
+.chainNode { border: 1px solid var(--line); border-radius: 10px; background: #fbfbfa; min-width: 0; }
+.chainNode > header {
+  padding: 8px 11px; border-bottom: 1px solid var(--line);
+  font: 11px ui-monospace, Menlo, monospace;
+}
+.chainNode > header .cid { font-weight: 700; font-size: 12px; display: block; }
+.chainNode > header .role { color: var(--muted); }
+.chainNode > .caps { padding: 7px 8px; }
+.capEntry {
+  padding: 3px 8px; border-radius: 6px; margin: 2px 0;
+  font: 11.5px ui-monospace, Menlo, monospace;
+}
+.capEntry.win { outline: 2px solid var(--accent); background: var(--accent-soft); font-weight: 700; }
+.capEntry .k { color: #7c3aed; }
+.chainArrow { text-align: center; font-size: 11px; color: var(--muted); padding-top: 4px; }
+svg.diagram { width: 100%; height: auto; margin: 18px 0; }
+svg.diagram .box { fill: #fff; stroke: #c9d0da; stroke-width: 1.2; rx: 8; }
+svg.diagram .box.accent { stroke: var(--accent); fill: var(--accent-soft); }
+svg.diagram .box.dark { fill: var(--code-bg); stroke: var(--code-bg); }
+svg.diagram text { font: 12.5px system-ui, sans-serif; fill: var(--ink); }
+svg.diagram text.small { font-size: 10.5px; fill: var(--muted); }
+svg.diagram text.mono { font-family: ui-monospace, Menlo, monospace; font-size: 11px; }
+svg.diagram text.onDark { fill: #d7dce3; }
+svg.diagram line, svg.diagram path.arrow { stroke: #9aa1ac; stroke-width: 1.3; fill: none; }
+dl.gloss { max-width: 48rem; }
+dl.gloss dt { font-weight: 700; margin-top: 16px; }
+dl.gloss dt code { font-weight: 700; }
+dl.gloss dd { margin: 3px 0 0 0; color: #3a3f47; }
+table.plain { border-collapse: collapse; font-size: 14px; margin: 16px 0; }
+table.plain th, table.plain td { border: 1px solid var(--line); padding: 6px 12px; text-align: left; vertical-align: top; }
+table.plain th { background: #f5f6f8; font-size: 12.5px; }
+table.plain td code { white-space: nowrap; }
+footer.page { border-top: 1px solid var(--line); padding-top: 28px; color: var(--muted); font-size: 14px; }
+footer.page ul { padding-left: 20px; }
+@media (max-width: 1020px) {
+  nav#toc { position: static; width: auto; border-right: none; border-bottom: 1px solid var(--line); }
+  main { margin-left: 0; padding: 32px 20px 100px; }
+  .panes, .panes.three, .chain { grid-template-columns: 1fr; }
+}
+</style>
+</head>
+<body>
+
+<nav id="toc">
+  <div class="brand"><code>itx</code> — from scratch</div>
+  <div class="sub">the iterate context: every term, every mechanic, one page. Works offline; all demos run locally.</div>
+  <a href="#why"><span class="n">0</span> Why: authority is held, not configured</a>
+  <a href="#table"><span class="n">1</span> A table of capabilities</a>
+  <a href="#convention"><span class="n">2</span> One calling convention</a>
+  <a href="#journal"><span class="n">3</span> The journal is the only authority</a>
+  <a href="#stubs"><span class="n">4</span> Live vs durable: stubs &amp; addresses</a>
+  <a href="#chain"><span class="n">5</span> The chain: extend, shadow, super</a>
+  <a href="#dial"><span class="n">6</span> The dial</a>
+  <a href="#identity"><span class="n">7</span> Identity is a stream coordinate</a>
+  <a href="#source"><span class="n">8</span> Code is a capability</a>
+  <a href="#describe"><span class="n">9</span> Self-description</a>
+  <a href="#doctrine"><span class="n">10</span> Extending the platform</a>
+  <a href="#glossary"><span class="n">11</span> Glossary</a>
+</nav>
+
+<main>
+
+<header class="page">
+  <h1><code>itx</code> — the iterate context, built up from a Map</h1>
+  <p class="lede">
+    This page constructs the itx system one concept at a time, starting from ten lines of
+    JavaScript and ending at the real implementation in <code>apps/os/src/itx/</code>. A
+    miniature but faithful core — same fold, same dispatch, same chain — runs inside this page
+    and powers every demo. Where the page simplifies, it says so inline; everything stated as
+    the real API is checked against <code>types.ts</code> (the design of record),
+    <code>itx.ts</code> (the core), and <code>examples.ts</code> (the live recipe catalogue).
+  </p>
+</header>
+
+<!-- ============================================================ 0 WHY -->
+<section id="why">
+  <div class="kicker">Section 0</div>
+  <h2>Why: authority should be held, not configured</h2>
+  <p>
+    The platform is full of actors that need to offer each other abilities. An agent needs the
+    project's repos and an AI model. A script needs to read a stream. Your laptop wants to lend
+    its Swift toolchain to an agent for an afternoon. A browser tab wants to intercept every
+    outbound HTTP request of one session. Code committed to a project's repo wants to be
+    callable as a tool. A third-party server across the internet wants in too. Wiring these
+    pairwise — Slack-to-agent, laptop-to-REPL, repo-to-worker, each with its own registration
+    protocol, its own auth, its own discovery — grows quadratically and every edge invents its
+    own permission model. The classical fix is <em>configuration</em>: central registries,
+    scopes, API keys sprinkled through env vars. itx takes the capability-systems answer
+    instead: <strong>authority is held, not configured</strong>. There is one kind of node — a
+    <strong>context</strong>, an addressable object that holds named capabilities — and one
+    kind of reference to it — an <strong>itx handle</strong>. Whoever holds a handle can call
+    what the context holds; providing, calling, describing, and overriding are the same four
+    verbs for every actor in the picture. Auth happens once, at connect; after that,
+    <em>which context your handle points at</em> is the entire permission model.
+  </p>
+
+  <svg class="diagram" viewBox="0 0 760 330" role="img" aria-label="Actors around a context node">
+    <rect class="box accent" x="280" y="125" width="200" height="80" rx="10"/>
+    <text x="380" y="158" text-anchor="middle" font-weight="700">a context</text>
+    <text x="380" y="178" text-anchor="middle" class="mono">prj_demo · holds capabilities</text>
+
+    <rect class="box" x="40"  y="30"  width="170" height="52" rx="8"/>
+    <text x="125" y="52" text-anchor="middle">an agent</text>
+    <text x="125" y="69" text-anchor="middle" class="small">describe() is its only sense organ</text>
+
+    <rect class="box" x="300" y="22" width="160" height="52" rx="8"/>
+    <text x="380" y="44" text-anchor="middle">your laptop</text>
+    <text x="380" y="61" text-anchor="middle" class="small">withItx() over one WebSocket</text>
+
+    <rect class="box" x="550" y="30" width="170" height="52" rx="8"/>
+    <text x="635" y="52" text-anchor="middle">a browser tab / REPL</text>
+    <text x="635" y="69" text-anchor="middle" class="small">same handle, same verbs</text>
+
+    <rect class="box" x="40"  y="245" width="170" height="52" rx="8"/>
+    <text x="125" y="267" text-anchor="middle">the project's repo</text>
+    <text x="125" y="284" text-anchor="middle" class="small">code built per commit</text>
+
+    <rect class="box" x="300" y="252" width="160" height="52" rx="8"/>
+    <text x="380" y="274" text-anchor="middle">platform services</text>
+    <text x="380" y="291" text-anchor="middle" class="small">ai · streams · secrets · …</text>
+
+    <rect class="box" x="550" y="245" width="170" height="52" rx="8"/>
+    <text x="635" y="267" text-anchor="middle">a server on the internet</text>
+    <text x="635" y="284" text-anchor="middle" class="small">a Cap'n Web URL</text>
+
+    <line x1="160" y1="82"  x2="300" y2="135"/>
+    <line x1="380" y1="74"  x2="380" y2="125"/>
+    <line x1="600" y1="82"  x2="460" y2="135"/>
+    <line x1="160" y1="245" x2="300" y2="195"/>
+    <line x1="380" y1="252" x2="380" y2="205"/>
+    <line x1="600" y1="245" x2="460" y2="195"/>
+    <text x="220" y="105" class="small">provide / call</text>
+    <text x="500" y="105" class="small">provide / call</text>
+    <text x="220" y="235" class="small">provide / call</text>
+    <text x="500" y="235" class="small">provide / call</text>
+  </svg>
+
+  <p>
+    Each arrow above is the <em>same</em> mechanism. By the end of this page you will know it
+    completely: a path-keyed capability table (§1–2), replayed from an event journal (§3),
+    holding live stubs or serializable addresses (§4), arranged in a prototype chain whose root
+    is code (§5), dispatched through one effectful function (§6), identified by stream
+    coordinates (§7), with code itself as just another capability kind (§8), self-describing
+    throughout (§9) — and a doctrine for building the next thing the same way (§10).
+  </p>
+</section>
+
+<!-- ============================================================ 1 TABLE -->
+<section id="table">
+  <div class="kicker">Section 1</div>
+  <h2>A table of capabilities</h2>
+  <p>
+    Strip everything away and the seed of the whole system is ten lines: a <code>Map</code>
+    from a name to a thing, a verb to put things in, and a verb to call them.
+  </p>
+
+  <script type="text/plain" class="code" data-title="the seed — a capability table in 10 lines" data-lang="js">
+const capabilities = new Map();
+
+function provide(name, thing) {
+  capabilities.set(name, thing);
+}
+
+function invoke(name, ...args) {
+  const cap = capabilities.get(name);
+  if (!cap) throw new Error(`No capability named "${name}"`);
+  return cap(...args);
+}</script>
+
+  <p>
+    That is already recognizably itx: <code>provide</code> doesn't care what the thing is or
+    where it came from; <code>invoke</code> doesn't care who's asking; the table is the single
+    point of indirection between them. Everything that follows is this table acquiring the
+    properties production needs — a wire-safe calling convention, durability, inheritance,
+    reach, identity, and self-description — without ever stopping being a table.
+  </p>
+
+  <div class="demo" id="demo-seed">
+    <div class="dtitle"><span class="live">●</span> live demo — the ten-line table, running here</div>
+    <div class="toolbar">
+      <button data-act="provide-greet">provide("greet", who =&gt; `hello, ${who}`)</button>
+      <button data-act="provide-dice">provide("dice", () =&gt; 1–6)</button>
+      <button data-act="provide-now">provide("now", () =&gt; ISO time)</button>
+      <span class="sep"></span>
+      <button data-act="invoke-greet" class="primary">invoke("greet", "world")</button>
+      <button data-act="invoke-dice" class="primary">invoke("dice")</button>
+      <button data-act="invoke-missing">invoke("slack") — not provided</button>
+    </div>
+    <div class="panes">
+      <div class="pane"><h4>the table</h4><div class="body" id="seed-table"></div></div>
+      <div class="pane"><h4>calls</h4><div class="body log" id="seed-log"></div></div>
+    </div>
+  </div>
+
+  <p>
+    Two things are wrong with the seed, and fixing them produces the next two sections. First,
+    the value side is a bare function — real capabilities are whole API surfaces
+    (<code>slack.chat.postMessage</code>), so we need a calling convention that carries
+    <em>structure</em> (§2). Second, the table lives in memory — restart and it's gone, and
+    there is no record of who put what there. The fix is not "add a database"; it's that the
+    table stops being written at all and becomes a <em>fold over events</em> (§3).
+  </p>
+</section>
+
+<!-- ============================================================ 2 CONVENTION -->
+<section id="convention">
+  <div class="kicker">Section 2</div>
+  <h2>One calling convention: <code>call({ path, args })</code></h2>
+  <p>
+    The kernel knows exactly one way to call anything. Every dispatch in the system — every
+    capability, every transport, every host — bottoms out in:
+  </p>
+
+  <script type="text/plain" class="code" data-title="types.ts — the ONE wire shape" data-lang="ts">
+type PathCall = { path: string[]; args: unknown[] };
+
+/** What every dispatched capability target implements. */
+type PathCallable = { call(input: PathCall): unknown };</script>
+
+  <p>
+    Two pure functions convert between dots and data, and they are the only places paths are
+    interpreted:
+  </p>
+  <ul>
+    <li>
+      <strong>Dots become data — <code>PathProxy</code></strong> (consumer side,
+      <code>path-proxy.ts</code>). A callable JS <code>Proxy</code> where property access
+      accumulates a path <em>locally</em> — zero round trips — and the terminal call fires once
+      with the accumulated <code>PathCall</code>. <code>itx.slack.chat.postMessage(msg)</code>
+      becomes <code>{ path: ["slack","chat","postMessage"], args: [msg] }</code>. The proxy
+      reads <code>then</code> as <code>undefined</code> so <code>await</code> never mistakes a
+      mid-chain node for a thenable.
+    </li>
+    <li>
+      <strong>Data becomes dots — <code>replayPathCall(target, { path, args })</code></strong>
+      (receiver side). Walk the segments on a concrete object and call the terminal method
+      <em>on its parent</em> (receivers preserved — Workers RPC methods can depend on
+      <code>this</code>). An empty path calls the target itself as a function. A shared
+      <code>RESERVED_PATH_SEGMENTS</code> set (<code>__proto__</code>, <code>constructor</code>,
+      <code>then</code>, <code>call</code>, <code>dup</code>, <code>describeItx</code>, …) is
+      filtered on <em>both</em> sides; the replay is the authoritative gate, because
+      <code>invoke</code> is public and a path can be hand-built.
+    </li>
+  </ul>
+  <p>
+    Dispatch resolves the <strong>longest provided prefix</strong> of the call path and hands
+    the <em>remainder</em> to the target. Because the convention is universal, <em>any</em>
+    shape plugs in with zero client wrapper — the choice of how a path maps onto an object
+    lives at the edge where the concrete object is, never in stored data:
+  </p>
+
+  <script type="text/plain" class="code" data-title="three provider shapes, one convention (real API — types.ts / examples.ts)" data-lang="ts">
+// 1. A bare function — the simplest provider. Calling the cap calls it
+//    (auto-wrapped at provide; an empty remainder invokes the function).
+await itx.provideCapability({
+  name: "runSwiftOnMyMac",
+  instructions: "Compile-and-run Swift on Jonas's Mac.",
+  capability: async (src) => runSwift(src),
+});
+
+// 2. A plain object of methods — nested at any depth. Dispatch replays the
+//    dotted remainder onto its members, back in YOUR process. No wrapper.
+await itx.provideCapability({
+  name: "answer",
+  capability: { ultimate: () => 42, deep: { thought: (q) => think(q) } },
+});
+await itx.answer.deep.thought("…"); // replays ["deep","thought"] on YOUR object
+
+// 3. An SDK-style class that implements call() itself — it owns its whole
+//    method tree as data (the public SDK docs become the tool docs):
+class FakeSlackSdk extends RpcTarget {
+  async call({ path, args }) {
+    return slackApi(path.join("."), args[0]);
+  }
+}
+await itx.provideCapability({ name: "slack", capability: new FakeSlackSdk() });
+await itx.slack.chat.postMessage({ channel: "C123", text: "hi" });
+// → arrives as ONE call({ path: ["chat","postMessage"], args: [msg] })</script>
+
+  <p>
+    Here is the miniature that runs this page's demos — the toy's calling-convention half,
+    extracted verbatim from the script powering every demo below:
+  </p>
+  <div class="toy-src" data-region="convention" data-title="the toy, part 1 of 3 — dots ⇄ data (running on this page)"></div>
+
+  <div class="demo" id="demo-conv">
+    <div class="dtitle"><span class="live">●</span> live demo — provide a nested plain object, watch the dispatched PathCall</div>
+    <div class="toolbar">
+      <button data-act="provide" class="primary">provideCapability({ name: "answer", capability: {…} })</button>
+      <button data-act="ultimate">itx.answer.ultimate()</button>
+      <button data-act="thought">itx.answer.deep.thought(question)</button>
+      <input type="text" id="conv-q" value="life, the universe, everything" size="30">
+    </div>
+    <div class="toolbar">
+      <span style="font-size:12.5px;color:var(--muted)">or call an arbitrary dotted path:</span>
+      <input type="text" id="conv-path" value="answer.deep.thought" size="24">
+      <button data-act="custom">call it</button>
+    </div>
+    <div class="panes">
+      <div class="pane"><h4>dispatch — what the core saw</h4><div class="body log" id="conv-dispatch"></div></div>
+      <div class="pane"><h4>result</h4><div class="body log" id="conv-log"></div></div>
+    </div>
+  </div>
+
+  <aside class="note">
+    <p>
+      <strong>Two pipelining systems compose here, and they are different things.</strong> The
+      PathProxy flattens dotted <em>names</em> into data before anything touches the network.
+      The RPC transports (Cap'n&nbsp;Web, Workers RPC) separately pipeline <em>calls</em> onto
+      returned stubs. <code>itx.streams.get("/x").append(e)</code> is one PathCall producing a
+      stub that the transport then pipelines <code>append</code> onto — still one round trip.
+    </p>
+  </aside>
+</section>
+<!-- ============================================================ 3 JOURNAL -->
+<section id="journal">
+  <div class="kicker">Section 3</div>
+  <h2>The journal is the only authority</h2>
+  <p>
+    Now make the table durable — by never writing it. In itx, <code>provideCapability</code>
+    and <code>revokeCapability</code> do not mutate a table; they <strong>append events</strong>
+    to the context's <strong>journal</strong>, an ordinary event stream. The table you saw in
+    §1 is the <strong>fold</strong> (reduce) of that stream. The complete event vocabulary
+    (<code>contract.ts</code>):
+  </p>
+
+  <script type="text/plain" class="code" data-title="contract.ts — ITX_EVENT_TYPES, the journal's entire vocabulary" data-lang="ts">
+export const ITX_EVENT_TYPES = {
+  contextCreated:           "events.iterate.com/itx/context-created",            // the birth certificate (event #1)
+  capabilityProvided:       "events.iterate.com/itx/capability-provided",        // THE write
+  capabilityRevoked:        "events.iterate.com/itx/capability-revoked",         // exact path match, never prefix
+  capabilityDisconnected:   "events.iterate.com/itx/capability-disconnected",    // record-only: a live provider's session broke
+  scriptExecutionRequested: "events.iterate.com/itx/script-execution-requested", // with enqueued:true, appending IS requesting work
+  scriptExecutionCompleted: "events.iterate.com/itx/script-execution-completed", // the pair makes at-least-once reruns detectable
+} as const;</script>
+
+  <p>What "the journal is the only authority" buys, concretely:</p>
+  <ul>
+    <li>
+      <strong>State is a fold; the checkpoint is a disposable cache.</strong> The processor's
+      storage holds <code>{ offset, state }</code> — a memo of <code>reduce</code> over the
+      journal. Delete it and replay rebuilds it, bit for bit. The record and the state cannot
+      disagree, because events are the only writes.
+    </li>
+    <li>
+      <strong>Exactly-once is a property of the fold, not of delivery.</strong> The reducer
+      takes the first birth certificate and ignores any later one; duplicate deliveries are
+      inert by offset bookkeeping. No idempotency keys as a correctness mechanism, no
+      <code>ON CONFLICT DO NOTHING</code>.
+    </li>
+    <li>
+      <strong>No initialize RPC.</strong> Creating a context is one append: mint an
+      <code>itx_…</code> id, append <code>context-created { id, name, parent: { id, address } }</code>
+      — the <strong>birth certificate</strong>, the journal's first event — and return. Nothing
+      touches the new node; it materializes lazily by consuming its own journal on first
+      dispatch.
+    </li>
+    <li>
+      <strong>"Audit log" stops existing as a separate concept.</strong> Anything that needs to
+      be auditable is an event, because events are the only writes. The journal is an ordinary
+      readable stream — every stream viewer shows it.
+    </li>
+    <li>
+      <strong>Live provides journal the EVENT too.</strong> The record outlives the session
+      (the stub itself stays an in-memory instance field, §4); after a replay the entry shows
+      up as registered-but-disconnected.
+    </li>
+  </ul>
+
+  <p>
+    Here is the toy's journal half — the same event types, the same defensive fold (a malformed
+    payload keeps the current state, so replay can never wedge on an old event shape), the same
+    append-then-catch-up write seam:
+  </p>
+  <div class="toy-src" data-region="journal" data-title="the toy, part 2 of 3 — events and the fold (running on this page)"></div>
+
+  <p>And the core class that ties parts 1 and 2 together:</p>
+  <div class="toy-src" data-region="core" data-title="the toy, part 3 of 3 — the core: provide/revoke/describe/invoke/extend (running on this page)"></div>
+
+  <aside class="note">
+    <p>
+      <strong>This miniature is the whole shape, for real.</strong> The production core —
+      <code>src/itx/itx.ts</code>, one file of roughly a thousand lines, half of them
+      explanatory comments — is exactly this fold, this longest-prefix dispatch, and this
+      chain, plus what crossing real process boundaries demands: dup-retention of live RPC
+      stubs and their session-teardown hooks, the single-flight append/catch-up seam that keeps
+      read-your-writes under concurrent writers, structural address validation, the
+      <code>describeItx</code> probe with timeouts and a 64&nbsp;KB journaled-meta budget,
+      script-execution processing, and error masking. Every demo below runs the code you just
+      read.
+    </p>
+  </aside>
+
+  <div class="demo" id="demo-journal">
+    <div class="dtitle"><span class="live">●</span> live demo — the journal and the fold are the same data, rendered two ways</div>
+    <div class="toolbar">
+      <button data-act="provide-live" class="primary">provide "clock" (live object)</button>
+      <button data-act="provide-rpc" class="primary">provide "ai" (rpc address)</button>
+      <button data-act="call-clock">itx.clock.nowMs()</button>
+      <button data-act="revoke">revokeCapability({ name: "clock" })</button>
+      <span class="sep"></span>
+      <button data-act="wipe">wipe checkpoint &amp; replay journal</button>
+      <button data-act="extend">itx.extend({ name: "scratch" })</button>
+    </div>
+    <div class="panes">
+      <div class="pane"><h4>the journal — events, the only writes</h4><div class="body" id="j3-journal"></div></div>
+      <div class="pane"><h4>state.capabilities — the fold (own entries)</h4><div class="body" id="j3-caps"></div></div>
+    </div>
+    <div class="panes" id="j3-childwrap" style="display:none">
+      <div class="pane"><h4 id="j3-childtitle">the child's journal — event #1 is its birth certificate</h4><div class="body" id="j3-childjournal"></div></div>
+      <div class="pane"><h4>activity</h4><div class="body log" id="j3-log"></div></div>
+    </div>
+    <div class="panes" id="j3-logwrap">
+      <div class="pane" style="grid-column: 1 / -1"><h4>activity</h4><div class="body log" id="j3-log2"></div></div>
+    </div>
+  </div>
+
+  <p>
+    Try the order: provide twice, call, revoke, then <em>wipe checkpoint &amp; replay</em>. The
+    demo snapshots the folded state before wiping, replays the journal from offset 0, and
+    proves the rebuilt state is byte-identical. Then <em>extend</em>: the child gets its own
+    journal whose event #1 is the birth certificate — creation was one append. This is also a
+    real, runnable fact about production — the journal is an ordinary stream you can read back:
+  </p>
+
+  <script type="text/plain" class="code" data-title="examples.ts — “the journal IS the record” (runs in every execution mode)" data-lang="ts">
+await itx.provideCapability({
+  name,
+  capability: { type: "rpc", worker: { type: "binding", binding: "AI" } },
+});
+await itx.revokeCapability({ name });
+
+// The context's journal is an ordinary stream — same read API as anything.
+const journal = await itx.streams.get("/itx").read();
+const record = journal
+  .filter((e) => Array.isArray(e.payload?.path) && e.payload.path.join(".") === name)
+  .map((e) => e.type.split("/").pop());
+return { record }; // ["capability-provided", "capability-revoked"]</script>
+
+  <p>
+    One subtlety worth naming: the write seam is <em>append, then self-ingest through the one
+    consumption door</em> — read from the checkpoint forward, fold. A provide observes its own
+    event before returning (read-your-writes), and because consumption always reads from the
+    checkpoint, events written by <em>other</em> writers (the <code>/api/itx/run</code> record
+    door, a concurrent session) interleave correctly. There is exactly one way state changes,
+    and everything goes through it.
+  </p>
+</section>
+
+<!-- ============================================================ 4 STUBS & ADDRESSES -->
+<section id="stubs">
+  <div class="kicker">Section 4</div>
+  <h2>Live vs durable: stubs and addresses</h2>
+  <p>
+    What can sit in the table? The <code>CapabilityTarget</code> union has exactly two arms,
+    and the discrimination is <em>structural</em>:
+  </p>
+
+  <script type="text/plain" class="code" data-title="types.ts — THE capability target" data-lang="ts">
+type CapabilityTarget = LiveStub | CapabilityAddress;
+
+/** A live provider's stub: a function, an object of functions, or an
+ * RpcTarget. Opaque; it may arrive over Cap'n Web or Workers RPC. */
+type LiveStub = object;
+
+type CapabilityAddress =
+  | { type: "rpc"; worker: WorkerRef; entrypoint?: string; props?: Record<string, unknown> }
+  | { type: "url"; url: string; headers?: Record<string, string> }; // a Cap'n Web server across the internet
+
+type WorkerRef =
+  | { type: "binding"; binding: string }                  // anything on env: env.AI, a service binding, a queue
+  | { type: "loopback" }                                  // this worker's own exports (first-party code)
+  | { type: "durable-object"; binding: string; name: string } // dialed as itx:<projectId>:<name>
+  | { type: "source"; source: WorkerSource };             // a dynamic worker from stored source (§8)</script>
+
+  <p>
+    An <strong>address</strong> is a <em>plain</em> object — prototype
+    <code>Object.prototype</code> or <code>null</code> — carrying
+    <code>type: "rpc" | "url"</code>. <em>Everything else is live.</em> The plainness check
+    must run before any <code>.type</code> probe: property access on a capnweb stub returns a
+    truthy pipelined stub, so reading <code>.type</code> first would misclassify every live
+    capability. (A plain object with a <em>string</em> <code>type</code> that isn't
+    <code>"rpc"</code>/<code>"url"</code> is rejected loudly as a malformed address — a typo
+    must not register as an offline live cap.)
+  </p>
+
+  <h3>Live: a stub you are holding</h3>
+  <ul>
+    <li>
+      Inbound: something connected to this context and handed it a stub. The capability exists
+      exactly as long as that connection does — <strong>live caps die with the session</strong>
+      and come back when the provider reconnects and provides again. There is no durable
+      delivery on live stubs: offline means offline.
+    </li>
+    <li>
+      The stub lives in the core's in-memory instance table (dup-retained), never in the
+      journal — but the provide <em>event</em> is journaled, so after replay the entry survives
+      as registered-but-offline. <code>describe()</code> reports live entries with
+      <code>connected: true | false</code>; calling an offline one throws
+      <code>CapabilityOfflineError</code> ("…the provider must reconnect and call
+      provideCapability() again").
+    </li>
+    <li>
+      Session teardown appends <code>capability-disconnected</code> — record only; the fold
+      ignores it (connectedness is computed from the live table, never from events).
+    </li>
+  </ul>
+
+  <h3>Durable: an address — this realm's sturdy refs</h3>
+  <p>
+    The serializable kinds are the realm's <strong>SturdyRef</strong> format (in Cap'n Proto's
+    sense): pure names that can be stored in a journal and restored to a live object on demand.
+    Crucially they <strong>grant nothing by possession</strong> — they are names within a
+    trusted realm, not bearer tokens; restoring is itself gated (authority is which context
+    your handle points at, checked at connect). The one deliberate bearer-form exception is the
+    HTTP share URL (§9), at the edge only. Real address JSON, as it sits in journals:
+  </p>
+
+  <script type="text/plain" class="code" data-title="every address kind, verbatim shapes from the codebase" data-lang="ts">
+// A raw platform binding (types.ts "Thirty seconds of itx"): itx.ai.run(...)
+{ "type": "rpc", "worker": { "type": "binding", "binding": "AI" } }
+
+// A first-party loopback entrypoint, parameterized per provide via props —
+// the McpClient shape (capabilities/mcp-client.ts). Note the secret
+// PLACEHOLDER: the journal never carries material (§9).
+{
+  "type": "rpc",
+  "worker": { "type": "loopback" },
+  "entrypoint": "McpClient",
+  "props": {
+    "serverUrl": "https://docs.example.com/mcp",
+    "headers": { "authorization": "Bearer getSecret({ key: \"DOCS_TOKEN\" })" }
+  }
+}
+
+// A Durable Object, by namespace binding + instance name. The dial scopes
+// the name under the owning project — getByName("itx:<projectId>:inbox") —
+// so a name can never reach a sibling project's instances.
+{ "type": "rpc", "worker": { "type": "durable-object", "binding": "TODO", "name": "inbox" } }
+
+// A dynamic worker from stored source — code as data (§8).
+{ "type": "rpc", "worker": { "type": "source", "source": {
+    "type": "inline", "cacheKey": "greeter-v1", "mainModule": "cap.js",
+    "modules": { "cap.js": "…WorkerEntrypoint source…" } } } }
+
+// A Cap'n Web server across the internet. ONE WebSocket session per call,
+// terminating in the stateless UrlDial worker (Law 7). Headers ride the
+// handshake and pass through egress secret substitution.
+{ "type": "url", "url": "wss://caps.example.com/api",
+  "headers": { "authorization": "Bearer getSecret({ key: \"REMOTE_TOKEN\" })" } }</script>
+
+  <p>
+    Context nodes themselves are addressed with the same data structure — an address whose
+    worker ref is a Durable Object <em>is</em> "how to dial the node that owns this identity"
+    (§7). One data structure; everything is a use of it.
+  </p>
+
+  <aside class="note">
+    <p>
+      <strong>What <code>provideCapability</code> returns:</strong> a provision handle
+      <code>{ revoke(), [Symbol.dispose] }</code>. Dispose auto-revokes <em>only live</em>
+      provides — a live cap dies with its session anyway, while a durable provide must outlive
+      the session that created it (session teardown disposes every returned handle, so a
+      revoking disposer would silently undo durable provides). Also: provide-time validation is
+      <em>structural only</em> (path shape, address well-formedness). Whether an address is
+      <em>reachable</em> is the dial's authority and surfaces at first call (§6).
+    </p>
+  </aside>
+
+  <div class="demo" id="demo-stubs">
+    <div class="dtitle"><span class="live">●</span> live demo — a live stub dies with its session; an address survives</div>
+    <div class="toolbar">
+      <button data-act="provide-mac" class="primary">provide "mac" (live: { runSwift })</button>
+      <button data-act="provide-ai" class="primary">provide "ai" (durable: binding address)</button>
+      <button data-act="call-mac">itx.mac.runSwift(src)</button>
+      <button data-act="call-ai">itx.ai.run("@cf/meta/llama", …)</button>
+      <span class="sep"></span>
+      <button data-act="drop">the provider's session drops</button>
+    </div>
+    <div class="panes">
+      <div class="pane"><h4>describe() — note <code>connected</code> on live entries</h4><div class="body" id="s4-caps"></div></div>
+      <div class="pane"><h4>journal + calls</h4><div class="body log" id="s4-log"></div></div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ 5 CHAIN -->
+<section id="chain">
+  <div class="kicker">Section 5</div>
+  <h2>The chain: extend, shadow, super</h2>
+  <p>
+    Contexts form a <strong>prototype chain</strong>. Behaviorally, a context is a
+    prototype-chain object whose properties are capabilities: lookup walks child → parent with
+    shadowing, writes land on the node your handle points at, and
+    <code>extend()</code> is <code>Object.create(parent)</code> — it mints a cheap child
+    context with its own journal (birth certificate first, §3), whose capabilities shadow the
+    parent's and whose misses delegate the <em>whole path</em> up the chain.
+  </p>
+
+  <script type="text/plain" class="code" data-title="README scene 3 — override one method (real API)" data-lang="ts">
+const session = await itx.extend({ name: "review-run" });
+
+await session.provideCapability({
+  path: ["workspace", "gitPush"],
+  instructions: "gitPush waits for human approval; everything else is the real workspace.",
+  capability: approvalGate, // async (input) => { await approve(input); return itx.workspace.gitPush(input); }
+});
+
+// session.workspace.gitPush(...)  → the gate (the child's table wins)
+// session.workspace.readFile(...) → misses the child, falls through the
+//                                    chain to the inherited workspace
+// Hand `session` to the thing you don't fully trust; keep `itx`.</script>
+
+  <p>The rules — all consequences of the chain, not separate mechanisms:</p>
+  <ul>
+    <li>
+      <strong>Shadowing is per path.</strong> Entries live at paths;
+      <code>provideCapability({ path: ["slack","chat","postMessage"], … })</code> shadows ONE
+      subtree of an inherited cap while every other <code>slack.*</code> call falls through.
+      Longest provided prefix wins <em>per context</em>; no prefix → delegate the whole path to
+      the parent.
+    </li>
+    <li>
+      <strong>Revoke resurfaces.</strong> Revoking a shadow makes lookup reach the chain again,
+      so the inherited entry comes back — by construction. Revoking an <em>inherited</em> entry
+      is refused with a hint ("provide your own on this context to take its place; the original
+      stays on the parent"): claiming to revoke something that lives on another node would lie.
+    </li>
+    <li>
+      <strong><code>itx.super</code> is middleware's "call next()".</strong> A handle on the
+      parent context: a <code>fetch</code> shadow delegates to the unshadowed pipe via
+      <code>itx.super.fetch(request)</code>. (One priced papercut: <code>super</code> is a
+      reserved word, so <code>itx.super</code> works but destructuring it does not.)
+    </li>
+    <li>
+      <strong>Delegation carries <code>origin</code></strong> — <code>{ id, address }</code> of
+      the context the call <em>started</em> at, set by delegating nodes, never by handles. It
+      is the chain's trusted identity channel: attribution, context-scoped capabilities (the
+      workspace), and origin dial-back (§6).
+    </li>
+    <li>
+      <strong><code>describe()</code> is the merged chain view.</strong> Own entries first (no
+      provenance field — they are yours), then ancestors' entries, each stamped
+      <code>from: &lt;context id&gt;</code>. Suppression is exact-match only: a path shadow
+      like <code>sdk.chat.postMessage</code> does not hide the parent's <code>sdk</code>,
+      because that entry is still live for every other path.
+    </li>
+  </ul>
+
+  <h3>The root of every chain is code</h3>
+  <p>
+    The chain does not end in data. Every project context's <code>parentItx</code> is the
+    <strong>defaults</strong> — <code>PlatformContext</code>
+    (<code>platform-context.ts</code>), a read-only loopback <code>WorkerEntrypoint</code> that
+    answers the same four-verb context protocol as every node: <code>describe</code> and
+    <code>invoke</code> from a literal list in code, <code>provideCapability</code> /
+    <code>revokeCapability</code> refused ("The defaults are read-only — they ship with the
+    deploy"). The defaults every project inherits: <strong>ai, fetch, streams, secrets, repos,
+    workspace, worker</strong> — each with its own <code>instructions</code>, so even the
+    code-rooted defaults self-describe. In <code>describe()</code> they appear as
+    <code>from: "defaults"</code> (<code>DEFAULTS_DESCRIBE_FROM</code>, types.ts — the internal
+    <code>platform:project</code> chain id never leaves the chain).
+  </p>
+  <p>
+    Shipping a new default is a <em>deploy, not a migration</em>: the chain sees it
+    immediately; journaled rows shadow it; revoking a shadow resurfaces it. There is no
+    defaults mechanism — only the chain. And because the parent link is dialed in-process
+    (loopback), default dispatch pays no Durable Object hop.
+  </p>
+
+  <div class="demo" id="demo-chain">
+    <div class="dtitle"><span class="live">●</span> live demo — the chain: child → project → defaults (code)</div>
+    <div class="toolbar">
+      <button data-act="shadow-gitpush" class="primary">shadow workspace.gitPush on child</button>
+      <button data-act="shadow-fetch" class="primary">shadow fetch on child</button>
+      <button data-act="provide-slack">provide slack on project</button>
+      <button data-act="revoke-gitpush">revoke child's gitPush shadow</button>
+      <button data-act="revoke-default">try revoking inherited "ai" on child</button>
+      <button data-act="provide-on-defaults">try providing on the defaults</button>
+    </div>
+    <div class="toolbar">
+      <span style="font-size:12.5px;color:var(--muted)">resolve a call path:</span>
+      <input type="text" id="chain-path" value="workspace.gitPush" size="26">
+      <button data-act="resolve" class="primary">child.invoke(…)</button>
+      <button data-act="super">child.super.fetch(…) — skip the child's table</button>
+    </div>
+    <div class="chain" id="chain-viz"></div>
+    <div class="panes" style="margin-top:12px">
+      <div class="pane" style="grid-column: 1 / -1"><h4>resolution trace</h4><div class="body log" id="chain-log"></div></div>
+    </div>
+  </div>
+
+  <p>
+    The middleware acceptance test, verbatim from the example catalogue — shadow
+    <code>fetch</code> with a plain function, delegate via <code>super</code>:
+  </p>
+
+  <script type="text/plain" class="code" data-title="examples.ts — middleware: shadow fetch, delegate via itx.super (real, e2e-proven)" data-lang="ts">
+const session = await itx.extend({ name: "traced" });
+
+// The shadow is a PLAIN FUNCTION; itx.super is "call next()" — the parent
+// chain, where fetch is still the real egress pipe.
+await session.provideCapability({
+  name: "fetch",
+  instructions: "Project egress with an x-trace-id header stamped on every request.",
+  capability: async (request) => {
+    const traced = new Request(request.url ?? String(request), request);
+    traced.headers.set("x-trace-id", "itx-example-trace");
+    return await session.super.fetch(traced);
+  },
+});
+
+// Every egress on the session now carries the header — including bare
+// fetch() inside the session's isolates. Revoke the shadow and the real
+// pipe resurfaces. Middleware is just shadowing plus super.</script>
+</section>
+<!-- ============================================================ 6 DIAL -->
+<section id="dial">
+  <div class="kicker">Section 6</div>
+  <h2>The dial: the one effectful function</h2>
+  <p>
+    The core is pure structure: entries, the fold, longest-prefix dispatch, chain delegation.
+    Everything effectful is injected as <strong>one function</strong> — the dial:
+  </p>
+
+  <script type="text/plain" class="code" data-title="itx.ts — the ONE effect injected into the core" data-lang="ts">
+/** The one effect injected into the core: turn an address into something
+ * speaking call({ path, args }) for THIS call. */
+type CapabilityDial = (
+  address: CapabilityAddress,
+  attribution: { capabilityPath: string; origin: ItxOrigin },
+) => PathCallable;</script>
+
+  <p>
+    <strong>The core owns structure; the dial owns reach.</strong> Every invoke, whatever it
+    looks like at the callsite, ends in one <code>call({ path, args })</code> against something
+    the dial resolved:
+  </p>
+
+  <svg class="diagram" viewBox="0 0 760 360" role="img" aria-label="Dispatch flow">
+    <rect class="box" x="20" y="20" width="330" height="56" rx="8"/>
+    <text x="185" y="43" text-anchor="middle" class="mono">await itx.slack.chat.postMessage(msg)</text>
+    <text x="185" y="62" text-anchor="middle" class="small">your code, anywhere a handle exists</text>
+
+    <rect class="box" x="20" y="110" width="330" height="56" rx="8"/>
+    <text x="185" y="133" text-anchor="middle">the handle: PathProxy → one invoke</text>
+    <text x="185" y="152" text-anchor="middle" class="mono small">invoke({ path: ["slack","chat","postMessage"], args })</text>
+
+    <rect class="box accent" x="20" y="200" width="330" height="74" rx="8"/>
+    <text x="185" y="224" text-anchor="middle" font-weight="700">node.itx() — the core</text>
+    <text x="185" y="243" text-anchor="middle" class="small">fold lookup: longest provided prefix wins</text>
+    <text x="185" y="260" text-anchor="middle" class="mono small">entry "slack" · remainder ["chat","postMessage"]</text>
+
+    <rect class="box" x="430" y="110" width="310" height="56" rx="8"/>
+    <text x="585" y="133" text-anchor="middle">miss → delegate WHOLE path to parentItx</text>
+    <text x="585" y="152" text-anchor="middle" class="small">carrying origin { id, address } — set by nodes, never handles</text>
+
+    <rect class="box" x="430" y="200" width="310" height="74" rx="8"/>
+    <text x="585" y="224" text-anchor="middle" font-weight="700">the dial: address → PathCallable</text>
+    <text x="585" y="243" text-anchor="middle" class="small">allowlists checked HERE (first call, not provide)</text>
+    <text x="585" y="260" text-anchor="middle" class="small">injects { capabilityPath, context, projectId } props</text>
+
+    <rect class="box dark" x="230" y="300" width="310" height="44" rx="8"/>
+    <text x="385" y="327" text-anchor="middle" class="mono onDark">target.call({ path: remainder, args })</text>
+
+    <line x1="185" y1="76" x2="185" y2="110"/>
+    <line x1="185" y1="166" x2="185" y2="200"/>
+    <line x1="350" y1="237" x2="430" y2="237"/>
+    <text x="390" y="230" class="small">address?</text>
+    <line x1="350" y1="228" x2="430" y2="146"/>
+    <line x1="280" y1="274" x2="330" y2="300"/>
+    <text x="200" y="292" class="small">live stub (in-memory)</text>
+    <line x1="585" y1="274" x2="500" y2="300"/>
+  </svg>
+
+  <p>Per address kind, the dial (<code>dial.ts</code>) does:</p>
+  <ul>
+    <li>
+      <strong><code>binding</code></strong> — gate on the bindings allowlist, take the concrete
+      object off <code>env</code>, wrap it in-process with the §2 replay (a binding doesn't
+      speak the convention; wrap it where it is real).
+    </li>
+    <li>
+      <strong><code>loopback</code></strong> — gate on the loopbacks allowlist, instantiate the
+      named export with <code>{ ...address.props, ...injected }</code>. Injection wins by
+      spread order: the dial-injected <code>{ capabilityPath, context, projectId }</code>
+      overwrite anything provider-supplied, which is the spoof-proofing — a provider can never
+      point a dialable loopback at someone else's project. First-party loopbacks implement
+      <code>call</code> themselves.
+    </li>
+    <li>
+      <strong><code>source</code></strong> — materialize an isolate via the Worker Loader (§8),
+      wired by <code>wireIsolateEnv</code> with <code>env.ITERATE</code> (an itx scoped to the
+      <em>origin</em> context) and <code>globalOutbound = ProjectEgress</code> (Law 5).
+      <code>exportType: "durable-object"</code> sources become <strong>facets</strong> of the
+      hosting DO with their own private SQLite.
+    </li>
+    <li>
+      <strong><code>durable-object</code></strong> — gate on the (default-empty) namespace
+      allowlist, then <code>getByName("itx:" + projectId + ":" + name)</code> — instance names
+      are scoped under the owning project, so two projects naming the same instance get
+      disjoint objects.
+    </li>
+    <li>
+      <strong><code>url</code></strong> — cross to the stateless <code>UrlDial</code> loopback
+      entrypoint, which opens <em>one</em> Cap'n Web WebSocket session per call against the
+      remote main and disposes it. Law 7: Cap'n Web terminates in the stateless worker, never
+      in a DO.
+    </li>
+  </ul>
+
+  <script type="text/plain" class="code" data-title="dial.ts — the allowlists (hardcoded defaults; config can only WIDEN)" data-lang="ts">
+const DIALABLE_BINDINGS = new Set(["AI"]);
+
+// Loopbacks listed here MUST scope strictly by the dial-injected props
+// ({ capabilityPath, context, projectId }) — never by provider props —
+// because anyone with a handle can provide a cap dialing them.
+const DIALABLE_LOOPBACKS = new Set([
+  "AgentCapability", "AgentToolsCapability", "BindingCapability", "EgressPipe",
+  "GmailCapability", "McpClient", "OpenApiClient", "ReposCapability",
+  "SecretsCapability", "SlackCapability", "StreamsCapability", "WorkspaceCapability",
+]);
+
+// Deliberately EMPTY: namespaces whose EXISTING instances matter (PROJECT,
+// STREAM, …) must not be allowlisted — itx dials would only reach fresh,
+// empty objects under the project-scoped names, never the real ones.
+const DIALABLE_DURABLE_OBJECTS = new Set([]);
+
+// resolveDialableTargets(config): defaults ∪ APP_CONFIG_ITX additions —
+// config can only widen, so a misconfigured deployment never loses
+// first-party caps.</script>
+
+  <p>
+    Reachability errors surface <em>at the capability's first call</em>, never at provide time
+    (provide is structural only). That asymmetry is deliberate: a deployment that widens its
+    allowlists never strands rows that were provided before the widening.
+  </p>
+
+  <p>
+    <strong>Origin dial-back</strong>, the dial's subtlest consequence: a source capability's
+    isolate is wired to the <em>originating</em> context, not the definition's home. Invoke an
+    inherited source cap through your extension and its bare <code>fetch()</code> climbs
+    <em>your</em> chain — shadow <code>fetch</code> on the extension and the inherited
+    capability's outbound traffic lands in your shadow, while siblings and the parent are
+    untouched. (Context <em>addresses</em> are dialed by a separate kernel restore,
+    <code>dialContext</code> in <code>journal.ts</code> — deliberately not allowlist-gated,
+    because only kernel code writes context addresses.)
+  </p>
+
+  <div class="demo" id="demo-dial">
+    <div class="dtitle"><span class="live">●</span> live demo — hand the toy dial an address, watch reach being decided</div>
+    <div class="toolbar">
+      <select id="dial-pick"></select>
+      <button data-act="dial" class="primary">dial it, then call({ path, args })</button>
+    </div>
+    <div class="panes">
+      <div class="pane"><h4>the address</h4><div class="body" id="dial-addr"></div></div>
+      <div class="pane"><h4>what the dial did</h4><div class="body log" id="dial-log"></div></div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================ 7 IDENTITY -->
+<section id="identity">
+  <div class="kicker">Section 7</div>
+  <h2>Identity is a stream coordinate</h2>
+  <p>
+    Where does a context <em>live</em>? Its journal is an ordinary event stream, and streams
+    are keyed by <code>(namespace, path)</code>. Journals live at
+    <code>&lt;host base&gt;/itx[/&lt;child-id&gt;]</code> in the owning project's namespace:
+  </p>
+
+  <script type="text/plain" class="code" data-title="journal.ts — the coordinate system" data-lang="ts">
+// project context              (prj_x, "/itx")           — own journal, base "/"
+// extend the project           (prj_x, "/itx/itx_a")     — child under the base
+// an agent's context           (prj_x, "<agentPath>/itx/itx_b")</script>
+
+  <ul>
+    <li>
+      <strong>The DO name IS the coordinate.</strong> The generic context host
+      (<code>ItxDurableObject</code>) holds <em>no configuration</em>: its Durable Object name
+      encodes the coordinate verbatim — <code>&lt;namespace&gt;:&lt;journalPath&gt;</code> —
+      so identity, journal ref, and self-address are <em>projections of the name</em>, derived
+      and never configured. Parentage folds from the birth certificate;
+      <code>descriptor()</code> derives from state. Address, journal, and identity are three
+      parses of one string.
+    </li>
+    <li>
+      <strong><code>itx</code> is a reserved stream path segment.</strong> Domain code and user
+      streams may not write under it — the user-facing append doors refuse with one clear
+      error (<code>assertStreamPathDoesNotClaimItxSegment</code>). Journals stay readable
+      everywhere: they are ordinary streams, and every stream viewer shows them.
+    </li>
+    <li>
+      <strong>The D1 row is a directory, never the authority.</strong> Bare
+      <code>itx_…</code> refs (reconnects, <code>/api/itx/run</code>, isolate props) resolve to
+      their coordinate through the <code>itx_contexts</code> D1 catalog — D1 in its sanctioned
+      role (a directory), while parentage and state fold from the journal.
+    </li>
+    <li>
+      <strong>The project context is code-born.</strong> It is hosted by the Project DO
+      (addressed by the project id, binding <code>PROJECT</code>), its journal is
+      <code>(projectId, "/itx")</code>, and it has <em>no</em> birth certificate — its identity
+      derives from its host's name; its <code>parentItx</code> is the defaults. Only extended
+      children carry <code>context-created</code> as event #1.
+    </li>
+    <li>
+      <strong>Chain depth ≠ path depth.</strong> Extending an extension still files the
+      grandchild's journal at <code>&lt;base&gt;/itx/&lt;id&gt;</code> — the base is the
+      journal path with its own <code>/itx[/&lt;id&gt;]</code> tail removed. Parentage lives in
+      the birth certificate, not in path nesting.
+    </li>
+  </ul>
+
+  <script type="text/plain" class="code" data-title="journal.ts — context addresses: the same data structure as every capability" data-lang="ts">
+/** The Project DO hosts the project context, addressed by the project id. */
+projectContextAddress(projectId) // →
+{ type: "rpc", worker: { type: "durable-object", binding: "PROJECT", name: projectId } }
+
+/** The generic host is addressed by the journal coordinate itself. */
+childContextAddress({ namespace, path }) // →
+{ type: "rpc", worker: { type: "durable-object", binding: "ITX_CONTEXT",
+                         name: `${namespace}:${path}` } }</script>
+
+  <div class="demo" id="demo-identity">
+    <div class="dtitle"><span class="live">●</span> live demo — one name, three parses</div>
+    <div class="toolbar">
+      <button data-name="prj_01hq3v:/itx">prj_01hq3v:/itx</button>
+      <button data-name="prj_01hq3v:/itx/itx_a1b2c3">prj_01hq3v:/itx/itx_a1b2c3</button>
+      <button data-name="prj_01hq3v:/agents/slack/T123/itx/itx_d4e5f6">an agent's context</button>
+      <input type="text" id="id-name" value="prj_01hq3v:/itx/itx_a1b2c3" size="40">
+      <button data-act="parse" class="primary">parse the DO name</button>
+    </div>
+    <div class="panes">
+      <div class="pane"><h4>projections of the name</h4><div class="body" id="id-out"></div></div>
+      <div class="pane"><h4>self-address (childContextAddress)</h4><div class="body" id="id-addr"></div></div>
+    </div>
+  </div>
+
+  <p>
+    Creation, end to end (<code>extendContext</code>, <code>journal.ts</code>): mint an
+    <code>itx_…</code> id → append <code>context-created { id, name, parent: { id, address } }</code>
+    to the new journal → insert the directory row in D1 → return
+    <code>{ contextId, journal, address }</code>. Nothing dials the new node; it materializes
+    lazily by consuming its journal on first dispatch. Creating a context is literally one
+    append.
+  </p>
+</section>
+
+<!-- ============================================================ 8 SOURCE -->
+<section id="source">
+  <div class="kicker">Section 8</div>
+  <h2>Code is a capability</h2>
+  <p>
+    A <code>{ type: "source" }</code> worker ref carries <em>code as data</em>: the platform
+    materializes it into an isolate on demand. Inside that isolate, bare <code>fetch()</code>
+    IS project egress (secrets substituted server-side, invisible to the code) and
+    <code>env.ITERATE</code> is an itx scoped to the capability's home context — a capability
+    can never reach wider than where it is provided. Two source kinds:
+  </p>
+
+  <script type="text/plain" class="code" data-title="types.ts — WorkerSource (the design of record, abridged comments)" data-lang="ts">
+type WorkerSource = (
+  | {
+      // The code travels in the capability record itself. The loader caches
+      // the materialized isolate by cacheKey, so it MUST change whenever
+      // modules change; a content hash is the ideal value.
+      type: "inline";
+      cacheKey: string;
+      mainModule: string;
+      modules: Record<string, string>;
+    }
+  | {
+      // The code lives in one of the project's repos. Built per COMMIT —
+      // never per call — through @cloudflare/worker-bundler, memoized in R2
+      // by hash(repo, sha, path, bundle). A pinned commit sha makes the
+      // journal entry fully determine behavior; "latest" tracks pushes.
+      // With no `bundle`, the file at `path` IS the worker, verbatim.
+      type: "repo";
+      repo: string;
+      commit: string | "latest";
+      path: string;
+      bundle?: { minify?: boolean; externals?: string[] };
+    }
+) & {
+  entrypoint?: string; // named export; defaults to the default export
+  // "worker-entrypoint" (default): stateless, fresh isolate per call.
+  // "durable-object": stateful — a NAMED export extending DurableObject,
+  // instantiated as a facet of the DO hosting this context, with its own
+  // private SQLite that survives code upgrades.
+  exportType?: "worker-entrypoint" | "durable-object";
+  compatibilityDate?: string;
+};</script>
+
+  <h3>Repo sources build per commit, never per call</h3>
+  <p>
+    <code>build(repo@sha, path, bundle) → modules</code> is a pure function, so its output is a
+    <strong>memo</strong>, never an address. Three tiers, one key: the repo (the authority) →
+    R2 (<code>ITX_BUILD_CACHE</code>, hash-keyed immutable bundles, evictable because every
+    entry is reproducible from its key) → the Worker Loader's isolate cache (ephemeral). The
+    memo key is the content address:
+    <code>build/&lt;sha256(projectId, repo, commitOid, path, bundle, compatibilityDate)&gt;</code>.
+    Bundling runs in-process on an in-memory vfs (repo&nbsp;DO <code>readTree</code> →
+    <code>@cloudflare/worker-bundler</code> / esbuild-wasm → R2) — no clone, no workspace, no
+    filesystem. A <code>"latest"</code> commit resolves to a sha at most once per 10-second
+    window per isolate; concurrent dials of a cold key share one build instead of stampeding;
+    a failed memo write never fails the dial that just built good code.
+  </p>
+
+  <div class="demo" id="demo-memo">
+    <div class="dtitle"><span class="live">●</span> live demo — the build memo: cold key builds, warm key never does</div>
+    <div class="toolbar">
+      <button data-act="dial" class="primary">dial itx.repoGreeter.hello({ name: "world" })</button>
+      <button data-act="push">git push (new commit lands)</button>
+      <span id="memo-sha" style="font:12px ui-monospace,monospace;color:var(--muted)"></span>
+    </div>
+    <div class="panes">
+      <div class="pane"><h4>dial trace</h4><div class="body log" id="memo-log"></div></div>
+      <div class="pane"><h4>R2 memo (ITX_BUILD_CACHE)</h4><div class="body" id="memo-r2"></div></div>
+    </div>
+  </div>
+
+  <h3>The project worker is not special</h3>
+  <p>
+    The platform's only guarantee is that every project has its config repo (slug
+    <code>project</code>) with a defined file structure. The <code>worker</code> default — the
+    project's own code as a capability,
+    <code>itx.worker.someExportedFunction(args)</code> — is just an ordinary repo source
+    pointed at it. The actual literal, from <code>platform-context.ts</code>:
+  </p>
+
+  <script type="text/plain" class="code" data-title="platform-context.ts — PROJECT_WORKER_SOURCE, verbatim" data-lang="ts">
+/**
+ * The project worker's source: the code in the project's own config repo,
+ * addressed like ANY repo-sourced capability. "latest" tracks pushes; the
+ * build is memoized per commit (source-build.ts).
+ */
+export const PROJECT_WORKER_SOURCE = {
+  bundle: {},
+  commit: "latest",
+  path: "worker.js",
+  repo: "project",
+  type: "repo",
+} as const satisfies WorkerSource;</script>
+
+  <p>And the two source recipes from the example catalogue, both e2e-proven:</p>
+
+  <script type="text/plain" class="code" data-title="examples.ts — a durable stateless cap from inline source" data-lang="ts">
+await itx.provideCapability({
+  name: "greeter",
+  capability: {
+    type: "rpc",
+    worker: {
+      type: "source",
+      source: {
+        type: "inline",
+        cacheKey: "itx-example-greeter-v1", // a content version: bump when modules change
+        mainModule: "cap.js",
+        modules: {
+          "cap.js": `
+            import { WorkerEntrypoint } from "cloudflare:workers";
+            export default class extends WorkerEntrypoint {
+              hello({ name }) { return "hello, " + name; }
+              add({ a, b }) { return a + b; }
+            }
+          `,
+        },
+      },
+    },
+  },
+});
+// Every public method is auto-proxied — no method list anywhere:
+await itx.greeter.hello({ name: "world" });
+await itx.greeter.add({ a: 2, b: 3 });</script>
+
+  <script type="text/plain" class="code" data-title="examples.ts — a stateful cap: exportType 'durable-object' (a facet)" data-lang="ts">
+await itx.provideCapability({
+  name: "counter",
+  capability: {
+    type: "rpc",
+    worker: {
+      type: "source",
+      source: {
+        type: "inline",
+        cacheKey: "itx-example-counter-v1",
+        entrypoint: "Counter",          // named export REQUIRED for facets
+        exportType: "durable-object",
+        mainModule: "cap.js",
+        modules: {
+          "cap.js": `
+            import { DurableObject } from "cloudflare:workers";
+            export class Counter extends DurableObject {
+              async increment() {
+                const n = ((await this.ctx.storage.get("n")) ?? 0) + 1;
+                await this.ctx.storage.put("n", n);  // this.ctx.storage is YOURS alone
+                return n;
+              }
+            }
+          `,
+        },
+      },
+    },
+  },
+});</script>
+
+  <p>
+    Facet mechanics worth knowing: the facet is instantiated <em>inside</em> the Durable Object
+    hosting the context (the Project DO, or the child context's DO), keyed by the
+    <strong>host</strong> context — a stateful cap's data belongs to the context it was
+    provided on. The facet name deliberately excludes the cache key, so the private SQLite
+    survives code upgrades (new source, same data). One asymmetry vs the stateless path: a
+    <code>"latest"</code>-commit source resolves at facet <em>start</em> and stays on that
+    build until the DO is evicted, while the worker-entrypoint path re-resolves per dial
+    (≤10&nbsp;s staleness).
+  </p>
+</section>
+<!-- ============================================================ 9 DESCRIBE -->
+<section id="describe">
+  <div class="kicker">Section 9</div>
+  <h2>Self-description: <code>describe()</code> is the agents' sense organ</h2>
+  <p>
+    Agents are a first-class audience, and their only sense organ is <code>describe()</code>.
+    It always works, on every handle, and returns every breadcrumb needed to explore from here:
+    the context, the access set, and the merged capability chain — each entry with its
+    provenance and its provider-supplied <code>instructions</code> (prose, for whoever finds
+    the cap) and <code>types</code> (TypeScript declarations, for machines and editors). Both
+    ride the provide, are journaled with it, and come back from <code>describe()</code> on
+    every handle down the chain. The review question for anything in this system is always the
+    same: <strong>what does <code>describe()</code> say?</strong>
+  </p>
+
+  <script type="text/plain" class="code" data-title="README scene 1 — what am I holding?" data-lang="ts">
+await itx.describe();
+// → { context: "prj_…", access: ["prj_…"],
+//     capabilities: [{ name: "slack", kind: "rpc", instructions: "Use
+//       itx.slack.<Slack Web API method path>(args), e.g.
+//       itx.slack.chat.postMessage({ channel, thread_ts, text })…" }, …],
+//     project: { … } }</script>
+
+  <h3>The <code>describeItx</code> provide-time hook</h3>
+  <p>
+    Instructions and types belong in the journaled meta <em>at provide time</em> — and the
+    target knows its own surface best at exactly that moment. So: an <code>rpc</code> provide
+    with no caller-supplied <code>types</code> is dialed <em>once</em> and asked
+    <code>describeItx</code> (a reserved protocol path segment, so user capability paths can
+    never collide with it). Explicit caller values always win; the probe is best-effort and
+    side-effectful (an <code>OpenApiClient</code> probe fetches its spec) with a short deadline
+    (3&nbsp;s; 15&nbsp;s for loopbacks, whose first probe may ride a cold chain) — any failure
+    or timeout just means an unenriched provide. Probe-derived strings are capped at 64&nbsp;KB
+    (they are journaled forever). Only <code>call</code>-implementing targets can answer;
+    member-shaped source caps hit the replay's reserved-name gate, which is the collision
+    protection doing its job.
+  </p>
+
+  <h3>Recipe: an authenticated MCP server, credential-free addresses</h3>
+  <p>
+    The full secret story in one recipe. Material is stored once via the <code>secrets</code>
+    default; from then on only a <em>placeholder</em> travels —
+    <code>'Bearer getSecret({ key: "…" })'</code> — and substitution happens on egress, inside
+    the stateless terminal pipe. The session, <code>describe()</code>, and the journal never
+    see the material.
+  </p>
+
+  <script type="text/plain" class="code" data-title="examples.ts — store a secret, then an authenticated MCP capability" data-lang="ts">
+// (1) Store the credential ONCE. listSecrets() shows redacted summaries;
+//     material never crosses an itx boundary again.
+await itx.secrets.setSecret({ key: "CLOUDFLARE_API_TOKEN", material: token });
+
+// (2) The capability address carries only the PLACEHOLDER.
+await itx.provideCapability({
+  path: ["mcp", "cloudflare"],
+  instructions: "Cloudflare's MCP server, authenticated via a project secret.",
+  capability: {
+    type: "rpc",
+    worker: { type: "loopback" },
+    entrypoint: "McpClient",
+    props: {
+      serverUrl: "https://bindings.mcp.cloudflare.com/mcp",
+      headers: { authorization: 'Bearer getSecret({ key: "CLOUDFLARE_API_TOKEN" })' },
+    },
+  },
+});
+
+// (3) Every MCP request rides the project egress pipe, where the placeholder
+//     becomes the real token — the connected agent/isolate never sees it.
+const { tools } = await itx.mcp.cloudflare.listTools();</script>
+
+  <p>
+    Mechanics behind it: <code>McpClient</code> is an ordinary loopback RPC target (MCP is a
+    client <em>implementation</em>, not a transport — deliberately not a capability kind). Its
+    streamable-HTTP transport is stateless: connect → call → close per invocation, all HTTP
+    through the cap's own <code>itx.fetch</code>. Its <code>describeItx</code> answers
+    <code>{}</code> — an MCP surface is dynamic, <code>listTools()</code> is the discovery
+    door. And the placeholder design has a security property worth repeating from §5: a live
+    <code>fetch</code> <em>shadow</em> receives placeholders <strong>unsubstituted</strong> —
+    substitution exists only in the default pipe, so an interceptor never sees secret material.
+  </p>
+
+  <h3>Recipe: any OpenAPI spec becomes a typed capability</h3>
+
+  <script type="text/plain" class="code" data-title="examples.ts — OpenApiClient: spec-derived types via describeItx" data-lang="ts">
+await itx.provideCapability({
+  name: "petstore",
+  capability: {
+    type: "rpc",
+    worker: { type: "loopback" },
+    entrypoint: "OpenApiClient",
+    props: {
+      specUrl: "https://petstore3.swagger.io/api/v3/openapi.json",
+      // For authenticated APIs, add headers with a secret placeholder:
+      // headers: { authorization: 'Bearer getSecret({ key: "API_TOKEN" })' },
+    },
+  },
+});
+
+// Flat operationIds, ONE merged input object (path params + query params +
+// body properties), through project egress:
+const pets = await itx.petstore.findPetsByStatus({ status: "available" });
+
+// describe() now carries spec-derived TypeScript — the provider answered
+// the platform's provide-time describeItx probe, no callsite ceremony.
+const { capabilities } = await itx.describe();
+capabilities.find((cap) => cap.name === "petstore").types;
+// → "declare function findPetsByStatus(input: { status?: … }): Promise<…>; …"</script>
+
+  <div class="demo" id="demo-describe">
+    <div class="dtitle"><span class="live">●</span> live demo — the describeItx hook, in the toy</div>
+    <div class="toolbar">
+      <button data-act="provide" class="primary">provide "petstore" (OpenApiClient address, no types given)</button>
+      <button data-act="call">itx.petstore.findPetsByStatus({ status: "available" })</button>
+      <button data-act="describe">describe()</button>
+    </div>
+    <div class="panes">
+      <div class="pane"><h4>journal — note meta.types arrived AT PROVIDE TIME</h4><div class="body" id="d9-journal"></div></div>
+      <div class="pane"><h4>describe() / calls</h4><div class="body log" id="d9-log"></div></div>
+    </div>
+  </div>
+
+  <h3>Recipe: your laptop as a capability</h3>
+
+  <script type="text/plain" class="code" data-title="README scene 2 — offer a capability from your laptop (real API)" data-lang="ts">
+import { withItx } from "~/itx/client.ts";
+
+using itx = withItx({ baseUrl, token, context: "my-project" });
+
+await itx.provideCapability({
+  name: "runSwiftOnMyMac",
+  instructions: "Compile-and-run Swift on Jonas's Mac. Pass the source string.",
+  capability: async (src) => runSwift(src),
+});
+// While your process stays connected, every agent, REPL, and script in the
+// project can call itx.runSwiftOnMyMac(src) — the call travels back over
+// YOUR connection and runs in YOUR process. The instructions you attach are
+// what everyone else's describe() will say — write them for the stranger
+// who finds your capability there.</script>
+
+  <h3>Recipe: fetch middleware (extend + super)</h3>
+  <p>
+    Already shown in full in §5 — shadow <code>fetch</code> on an extension with a plain
+    function, delegate to the real pipe via <code>session.super.fetch(request)</code>. It earns
+    its place in this list because it is pure composition: no interception API exists; the
+    recipe is just the chain (§5) plus the one egress door (Law 5).
+  </p>
+
+  <h3>Two more describe-adjacent doors</h3>
+  <ul>
+    <li>
+      <strong>HTTP exposure</strong>: a cap provided with <code>meta: { http: { expose: true } }</code>
+      gets its own hostname — <code>https://{cap}--{project}.{base}/…</code> →
+      <code>ItxCapabilityIngress</code>: 404 unless exposed; the gate is admin bearer, a signed
+      share URL, or <code>meta.http.public</code>; then one core dispatch with
+      <code>[...capabilityPath, "fetch"]</code>.
+    </li>
+    <li>
+      <strong><code>itx.shareUrl({ name, path?, ttlSeconds? })</code></strong> — "let me show
+      you something real quick": a signed, expiring URL for one HTTP-exposed cap. Possession
+      grants exactly that cap's fetch surface until expiry — the realm's one deliberate
+      bearer-token edge.
+    </li>
+  </ul>
+
+  <aside class="note">
+    <p><strong>The Laws — the invariants that ARE the architecture (README, condensed):</strong></p>
+    <p>1. The journal holds the facts; the node holds live refs; code holds composition.<br>
+       2. Props carry identity, never composition or authority-by-content.<br>
+       3. Auth happens at connect, nowhere else — which context your handle points at is the authority.<br>
+       4. Narrowing is construction: <code>itx.projects.get()</code> and <code>itx.extend()</code> return new handles on narrower contexts, never flags on wider ones.<br>
+       5. All policy-governed egress flows through one pipe; secret placeholders are substituted only in the stateless terminal pipe.<br>
+       6. One calling convention: <code>target.call({ path, args })</code> — the members/path-call choice lives at the edges, never in stored data.<br>
+       7. Cap'n Web terminates in the stateless worker, never in a DO.</p>
+  </aside>
+</section>
+
+<!-- ============================================================ 10 DOCTRINE -->
+<section id="doctrine">
+  <div class="kicker">Section 10</div>
+  <h2>Extending the platform: how to build the next domain object</h2>
+  <p>
+    itx is the reference implementation of a standing doctrine
+    (<code>docs/domain-objects-and-stream-processors.md</code>) for designing <em>any</em>
+    durable domain object on this platform — agents, contexts, MCP sessions, whatever comes
+    next. A context is a domain object whose state is its capability table and whose creation
+    event is <code>context-created</code>. The rules:
+  </p>
+  <ul>
+    <li>
+      <strong>Creation is an event.</strong> A durable thing's existence is not configuration —
+      it is the FIRST event in its own stream: mint the id, append the birth certificate,
+      return a handle. No <code>initialize()</code> RPC, no idempotency keys as a correctness
+      mechanism; exactly-once is a property of the fold (first creation event wins, later ones
+      are inert). Lazy materialization: the object comes alive on first dispatch by reading its
+      own journal.
+    </li>
+    <li>
+      <strong>Derive what names carry; reduce everything else.</strong> DO names are structured
+      records (project id, path). Identity, journal ref, and self-address are projections of
+      the name — never configuration. Anything a name cannot carry arrives as an event.
+    </li>
+    <li>
+      <strong>State is a fold; the checkpoint is disposable.</strong> Storage holds
+      <code>{ offset, state }</code> as a cache of <code>reduce</code> over the journal. Delete
+      it and replay rebuilds it. The stream is the only authority.
+    </li>
+    <li>
+      <strong>Side effects live in <code>processEvent</code>, never in <code>reduce</code>.</strong>
+      Replay rebuilds state without re-running effects (<code>sideEffectsAfterOffset</code>);
+      serialized batches give in-order execution; a requested/completed event pair makes
+      at-least-once reruns detectable.
+    </li>
+    <li>
+      <strong>Self-describing, always.</strong> Every domain object answers
+      <code>describe()</code>; every provided surface carries <code>instructions</code> and
+      <code>types</code> from the moment it exists. The acceptance test: an agent with no prior
+      knowledge, handed a stub, acts competently from <code>describe()</code> alone.
+    </li>
+  </ul>
+
+  <h3>Worked example: designing <code>CronSchedule</code></h3>
+  <p>
+    A hypothetical new domain object — recurring scheduled script runs for a project — designed
+    step by step under the rules. (Hypothetical: this does not exist in the codebase; it is the
+    doctrine applied.)
+  </p>
+
+  <p><strong>Step 1 — the structured name.</strong> One Durable Object per schedule, its name
+  the stream coordinate: <code>&lt;projectId&gt;:/cron/&lt;cron_…&gt;</code>. Identity
+  (<code>cron_…</code>, the last path segment), journal ref
+  (<code>(projectId, "/cron/&lt;id&gt;")</code>), and self-address
+  (<code>{ type: "rpc", worker: { type: "durable-object", binding: "CRON", name } }</code>) are
+  all parses of the name. Note the path does <em>not</em> claim the reserved <code>itx</code>
+  segment — that belongs to context journals. If the platform keeps a D1 row mapping bare
+  <code>cron_…</code> ids to coordinates, it is a directory, never the authority.</p>
+
+  <p><strong>Step 2 — the journal events, birth certificate first.</strong></p>
+
+  <script type="text/plain" class="code" data-title="hypothetical cron-contract.ts — the event vocabulary" data-lang="ts">
+export const CRON_EVENT_TYPES = {
+  // The birth certificate — event #1, carrying identity and creation facts.
+  scheduleCreated:  "events.iterate.com/cron/schedule-created",   // { id, spec, script, parent: { id, address } }
+  scheduleUpdated:  "events.iterate.com/cron/schedule-updated",   // { spec?, script? }
+  schedulePaused:   "events.iterate.com/cron/schedule-paused",    // {}
+  scheduleResumed:  "events.iterate.com/cron/schedule-resumed",   // {}
+  // The at-least-once pair: appending fire-requested IS requesting work.
+  fireRequested:    "events.iterate.com/cron/fire-requested",     // { fireId, scheduledForMs, enqueued: true }
+  fireCompleted:    "events.iterate.com/cron/fire-completed",     // { fireId, result | error }
+} as const;</script>
+
+  <p>
+    Creating a schedule is one append of <code>schedule-created</code> — no initialize RPC,
+    nothing touches the new DO; it materializes when the first dispatch (or its alarm) makes it
+    consume its journal. Payload schemas stay deliberately loose, so a journal carrying events
+    from before a deploy never wedges the fold.
+  </p>
+
+  <p><strong>Step 3 — the reduce (pure, module-level, defensive).</strong></p>
+
+  <script type="text/plain" class="code" data-title="hypothetical — the fold" data-lang="ts">
+export function reduceCronJournalEvent(state, event) {
+  const p = event.payload ?? {};
+  switch (event.type) {
+    case CRON_EVENT_TYPES.scheduleCreated:
+      if (state.schedule !== null) return state;   // first birth certificate wins
+      if (typeof p.id !== "string") return state;  // malformed payloads never wedge replay
+      return { ...state, schedule: { id: p.id, spec: p.spec, script: p.script, paused: false } };
+    case CRON_EVENT_TYPES.scheduleUpdated:
+      if (state.schedule === null) return state;
+      return { ...state, schedule: { ...state.schedule, ...(p.spec ? { spec: p.spec } : {}), ...(p.script ? { script: p.script } : {}) } };
+    case CRON_EVENT_TYPES.schedulePaused:
+      return state.schedule ? { ...state, schedule: { ...state.schedule, paused: true } } : state;
+    case CRON_EVENT_TYPES.scheduleResumed:
+      return state.schedule ? { ...state, schedule: { ...state.schedule, paused: false } } : state;
+    case CRON_EVENT_TYPES.fireRequested:
+      if (p.enqueued !== true || typeof p.fireId !== "string") return state;
+      return { ...state, pendingFires: { ...state.pendingFires, [p.fireId]: true } };
+    case CRON_EVENT_TYPES.fireCompleted: {
+      if (!(p.fireId in state.pendingFires)) return state;  // unknown/duplicate completion: inert
+      const pendingFires = { ...state.pendingFires };
+      delete pendingFires[p.fireId];
+      return { ...state, pendingFires };
+    }
+    default:
+      return state;
+  }
+}</script>
+
+  <p>
+    <strong>Step 4 — side effects in <code>processEventBatch</code>, never in reduce.</strong>
+    The alarm handler appends <code>fire-requested { enqueued: true }</code>;
+    <code>processEventBatch</code> sees it (past <code>sideEffectsAfterOffset</code>, still
+    pending in batch-final state), runs the script — the side effect — and appends
+    <code>fire-completed</code>. A replay rebuilds <code>pendingFires</code> without re-running
+    anything; a crash between the pair leaves a pending entry that the next wake detects and
+    re-runs (at-least-once, detectable). Setting the next alarm is also a
+    <code>processEvent</code> concern, derived from folded state.
+  </p>
+
+  <p><strong>Step 5 — the capability surface.</strong> How does anyone reach it? Provide it —
+  with instructions and types, from the moment it exists:</p>
+
+  <script type="text/plain" class="code" data-title="hypothetical — cron as a capability (a loopback, like SecretsCapability)" data-lang="ts">
+// First-party path: a CronCapability loopback entrypoint, added to
+// DIALABLE_LOOPBACKS, scoping STRICTLY by the dial-injected projectId —
+// the same discipline as SecretsCapability. Then, on the project context:
+await itx.provideCapability({
+  name: "cron",
+  instructions:
+    "Recurring scheduled runs: itx.cron.create({ spec, script }) (spec is a " +
+    "cron expression; script is `async (itx) => …`), list(), pause({ id }), " +
+    "resume({ id }), history({ id }).",
+  types: `declare function create(input: { spec: string; script: string }): Promise<{ id: string }>;
+declare function list(): Promise<{ id: string; spec: string; paused: boolean }[]>;
+declare function pause(input: { id: string }): Promise<void>;
+declare function resume(input: { id: string }): Promise<void>;`,
+  capability: { type: "rpc", worker: { type: "loopback" }, entrypoint: "CronCapability" },
+});
+// (Alternative: allowlist the CRON namespace via APP_CONFIG_ITX and dial
+// { type: "durable-object", binding: "CRON", name } directly — remembering
+// the dial scopes names as itx:<projectId>:<name>, so only namespaces
+// DESIGNED to be reached that way belong on the allowlist.)</script>
+
+  <p>
+    Promoting <code>cron</code> into the defaults later is a deploy, not a migration: add it to
+    <code>PLATFORM_PROJECT_CAPABILITIES</code> and every chain sees it immediately; any
+    project's own <code>cron</code> row shadows it.
+  </p>
+
+  <div class="demo" id="demo-cron">
+    <div class="dtitle"><span class="live">●</span> live demo — the CronSchedule fold, under the doctrine</div>
+    <div class="toolbar">
+      <button data-act="create" class="primary">append schedule-created</button>
+      <button data-act="create-dup">append schedule-created again (retried append)</button>
+      <button data-act="update">append schedule-updated</button>
+      <button data-act="request">append fire-requested</button>
+      <button data-act="complete">append fire-completed</button>
+      <button data-act="wipe">wipe checkpoint &amp; replay</button>
+    </div>
+    <div class="panes">
+      <div class="pane"><h4>the journal</h4><div class="body" id="cron-journal"></div></div>
+      <div class="pane"><h4>the fold: { schedule, pendingFires }</h4><div class="body" id="cron-state"></div></div>
+    </div>
+    <div class="panes">
+      <div class="pane" style="grid-column: 1 / -1"><h4>notes</h4><div class="body log" id="cron-log"></div></div>
+    </div>
+  </div>
+
+  <h3>The review checklist</h3>
+  <ul>
+    <li><strong>What does <code>describe()</code> say about it?</strong> Could an agent with no prior knowledge act competently from that alone?</li>
+    <li>Is creation exactly one append, with the birth certificate as event #1? Is there any initialize RPC, setup path, or "configured" residue replay cannot reproduce?</li>
+    <li>Can you delete the checkpoint right now and lose nothing?</li>
+    <li>Does anything write state outside the journal? (If it needs to be auditable, is it an event — because events are the only writes?)</li>
+    <li>Do retried appends and duplicate deliveries reduce to no-ops in the fold, without idempotency keys as a correctness mechanism?</li>
+    <li>Are all side effects in <code>processEvent</code>/<code>processEventBatch</code>, guarded by a requested/completed pair — never in <code>reduce</code>?</li>
+    <li>Does the name carry exactly identity (and the journal coordinate), with everything else reduced from events? Is any D1 row strictly a directory?</li>
+    <li>How does it become dialable — a loopback scoping by dial-injected props, or an allowlisted DO namespace designed for <code>itx:&lt;projectId&gt;:&lt;name&gt;</code> scoping?</li>
+    <li>Does its stream path stay clear of the reserved <code>itx</code> segment?</li>
+  </ul>
+</section>
+
+<!-- ============================================================ 11 GLOSSARY -->
+<section id="glossary">
+  <div class="kicker">Section 11</div>
+  <h2>Glossary</h2>
+  <dl class="gloss">
+    <dt>context</dt>
+    <dd>An addressable node that holds named capabilities. Contexts form a prototype chain (child → parent with shadowing); a context may be durable (a DO with a journal) but durability is not part of the concept. <code>ContextRef</code>: <code>"global"</code>, a project id (<code>prj_…</code>; <code>proj_…</code> legacy), or a child id (<code>itx_…</code>).</dd>
+    <dt>capability</dt>
+    <dd>A name (a path, really) plus a <code>CapabilityTarget</code> — either a live stub someone handed the context, or a serializable address of where the implementation lives. Its kind is its provider's kind: <code>"live" | "rpc" | "url"</code>.</dd>
+    <dt>handle (<code>ItxHandle</code>)</dt>
+    <dd>The cheap, ephemeral view user code touches — identical in browser, Node, REPL, project worker, scripts, and capabilities. The trust kernel (the four verbs plus <code>extend</code>, <code>super</code>, <code>streams</code>, <code>projects</code>, <code>project</code>, <code>fetch</code>, <code>capability()</code>, <code>shareUrl</code>) plus a fallthrough proxy: any unknown name becomes a PathProxy whose terminal call is one invoke on the node's core. Minted exactly three ways: connect, narrowing, platform wiring.</dd>
+    <dt>stub</dt>
+    <dd>A live RPC reference to an object in another process (capnweb or Workers RPC). "An Itx holds capabilities; everything else holds a stub of one." <code>ItxStub</code> is the four-verb context protocol shape.</dd>
+    <dt>core (<code>Itx</code>)</dt>
+    <dd>The capability core a context node embeds (<code>itx.ts</code>): the path-keyed entry table, the live-stub table, longest-prefix dispatch, chain delegation — four verbs: <code>provideCapability</code>, <code>revokeCapability</code>, <code>describe</code>, <code>invoke</code>. Exposed by hosts via an <code>itx()</code> <em>method</em> (workerd doesn't pipeline through property accesses).</dd>
+    <dt>journal</dt>
+    <dd>The context's event stream — the only authority. Provides/revokes append events and self-ingest; nothing else writes state.</dd>
+    <dt>fold / reduce / replay</dt>
+    <dd>The pure function from journal to state (<code>reduceItxJournalEvent</code>). Replay = re-running the fold from offset 0; defensive by design so old event shapes never wedge it.</dd>
+    <dt>checkpoint</dt>
+    <dd><code>{ offset, state }</code> in the host DO's storage — a disposable cache of the fold. Delete it; replay rebuilds it.</dd>
+    <dt>dial</dt>
+    <dd>The one effectful function injected into the core: <code>CapabilityAddress → PathCallable</code>. Owns reach (allowlists), injects attribution props, wires isolates and facets.</dd>
+    <dt>chain</dt>
+    <dd>The parent links contexts resolve through: <code>itx_… → project → defaults (code)</code>. A lookup miss delegates the whole path upward, carrying origin.</dd>
+    <dt>defaults</dt>
+    <dd>The code-rooted final link of every chain: <code>PlatformContext</code>, read-only, answering the context protocol from <code>PLATFORM_PROJECT_CAPABILITIES</code> (ai, fetch, streams, secrets, repos, workspace, worker). Labeled <code>from: "defaults"</code> in describe. Shipping one is a deploy, not a migration.</dd>
+    <dt>extend</dt>
+    <dd><code>itx.extend({ name? })</code>: mint a child context — an id, a journal with a birth certificate, an address, a handle. <code>Object.create(parent)</code> for contexts.</dd>
+    <dt>shadow</dt>
+    <dd>Providing (at a name or deeper path) on a child what the chain already resolves — your entry wins longest-prefix locally; revoke it and the inherited entry resurfaces.</dd>
+    <dt><code>super</code></dt>
+    <dd>The handle on the parent context — middleware's "call next()". A reserved word, so dot it, don't destructure it.</dd>
+    <dt>live vs durable</dt>
+    <dd>Live: an inbound stub, session-bound, in-memory, journaled only as an event (describe shows <code>connected</code>). Durable: a serializable address, restored at invoke time. Everything writable is durable; the root of every chain is code.</dd>
+    <dt>address (<code>CapabilityAddress</code>)</dt>
+    <dd><code>{ type: "rpc", worker, entrypoint?, props? }</code> or <code>{ type: "url", url, headers? }</code> — the system's one serializable data structure; context nodes are addressed with it too.</dd>
+    <dt>sturdy ref</dt>
+    <dd>Cap'n Proto's term for a serializable token restorable to a live capability. The serializable address kinds are this realm's sturdy-ref format — pure names, zero authority by content; <code>resolveItx</code> is the restorer. The HTTP share token is the one deliberate sealed/bearer-form exception, at the edge only.</dd>
+    <dt><code>WorkerSource</code></dt>
+    <dd>Stored source for a <code>{ type: "source" }</code> worker: <code>inline</code> (code in the record, cached by <code>cacheKey</code>) or <code>repo</code> (code in a project repo, built per commit). Plus <code>entrypoint</code> and <code>exportType</code> ("worker-entrypoint" stateless | "durable-object" facet).</dd>
+    <dt>the memo</dt>
+    <dd>The R2 build cache for repo sources: <code>build/&lt;hash(projectId, repo, sha, path, bundle, compatibilityDate)&gt;</code> → built modules. An optimization, never an authority — every entry is reproducible from its key.</dd>
+    <dt>birth certificate</dt>
+    <dd><code>context-created { id, name, parent: { id, address } }</code> — the first event in a journal. The fold takes the first and ignores later ones; parentage and descriptor derive from it. Code-born contexts (the project context, the defaults) have none.</dd>
+    <dt>stream coordinate</dt>
+    <dd><code>(namespace, path)</code> — where a stream (hence a journal, hence a context's identity) lives. The generic host's DO name is the coordinate verbatim: <code>&lt;namespace&gt;:&lt;journalPath&gt;</code>.</dd>
+    <dt>reserved segment</dt>
+    <dd>Three reservations, by position: the stream path segment <code>itx</code> (context journals only); <code>RESERVED_PATH_SEGMENTS</code> (protocol/prototype names like <code>then</code>, <code>call</code>, <code>constructor</code>, <code>describeItx</code> — never traversable anywhere in a path); <code>RESERVED_CAPABILITY_NAMES</code> (the trust-kernel builtins — banned as a <em>first</em> segment only; <code>fetch</code> and <code>streams</code> deliberately not on it, because shadowing them is the point).</dd>
+    <dt><code>describeItx</code></dt>
+    <dd>The reserved provide-time self-description probe: an rpc provide with no caller <code>types</code> is dialed once and asked; a call-implementing target may answer <code>{ instructions?, types? }</code>, journaled into meta (64 KB cap, best-effort, 3 s/15 s deadline).</dd>
+    <dt>placeholder / substitution</dt>
+    <dd><code>'Bearer getSecret({ key: "X" })'</code> in an outbound header. Material lives in project secrets; substitution happens only in the stateless terminal egress pipe; journals, describe(), isolates, and fetch shadows only ever see the placeholder.</dd>
+    <dt>allowlist</dt>
+    <dd><code>DialableTargets</code> — which bindings/loopbacks/DO-namespaces an rpc address may dial. Hardcoded defaults ∪ deployment config; config can only widen; checked at dial time (first invoke), never at provide.</dd>
+    <dt>facet</dt>
+    <dd>A Durable Object instantiated <em>inside</em> the DO hosting a context (<code>ctx.facets</code>), with its own private SQLite stored in the host. How <code>exportType: "durable-object"</code> source caps get state with zero provisioning; named <code>cap:&lt;name&gt;</code> (no cache key) so data survives code upgrades.</dd>
+    <dt>origin (<code>ItxOrigin</code>)</dt>
+    <dd><code>{ id, address }</code> of the context a delegated call started at. Set by delegating nodes, never by handles — the chain's trusted identity channel for attribution, context-scoped caps, and origin dial-back.</dd>
+    <dt>PathCall / longest-prefix / member replay</dt>
+    <dd>The wire shape <code>{ path, args }</code>; resolution picks the longest provided prefix and dispatches the remainder; targets that don't implement <code>call</code> get the remainder replayed onto their members, receiver-preserved, in the process where they live.</dd>
+    <dt>narrowing / access set</dt>
+    <dd><code>itx.projects.get(id)</code> — the access check, returning a NEW handle bound to the project. Access is <code>"all"</code> (admin) or a list of project ids; missing and forbidden are byte-identical NOT_FOUND. Narrowing is construction, never a flag.</dd>
+    <dt><code>ItxProps</code></dt>
+    <dd>The one serializable parameterization crossing boundaries: <code>{ context, contextAddress?, projectId?, access?, capabilityPath? }</code>. Identity and attribution only — never composition, never authority-by-content.</dd>
+    <dt>project worker</dt>
+    <dd>The worker built from the project's own config repo (slug <code>project</code>) — the <code>worker</code> default, an ordinary repo source (<code>PROJECT_WORKER_SOURCE</code>). The platform's only guarantee is that the repo exists.</dd>
+  </dl>
+</section>
+
+<footer class="page">
+  <p><strong>Ground truth this page was written against</strong> (read them in this order and you should find zero contradictions):</p>
+  <ul>
+    <li><code>apps/os/src/itx/README.md</code> — the three scenes, the Laws, the build order</li>
+    <li><code>apps/os/src/itx/types.ts</code> — the design of record (handwritten, import-free)</li>
+    <li><code>apps/os/src/itx/itx.ts</code> — the core; <code>contract.ts</code> — the journal vocabulary</li>
+    <li><code>apps/os/src/itx/platform-context.ts</code>, <code>dial.ts</code>, <code>journal.ts</code>, <code>source-build.ts</code>, <code>path-proxy.ts</code></li>
+    <li><code>apps/os/src/itx/examples.ts</code> + <code>capabilities/mcp-client.ts</code> + <code>capabilities/openapi-client.ts</code> — the recipes</li>
+    <li><code>apps/os/docs/itx-next.md</code> — design history; <code>docs/domain-objects-and-stream-processors.md</code> — the doctrine</li>
+  </ul>
+  <p><strong>Where this page simplifies (the toy vs the real core):</strong></p>
+  <ul>
+    <li>The toy is synchronous and in-process; the real verbs are async and cross RPC boundaries (capnweb and Workers RPC), with dup-retention of live stubs, member-walking retention for plain-object providers, and <code>onRpcBroken</code> teardown.</li>
+    <li>The toy's append/catch-up is a simple loop; the real seam is single-flight with an append counter guaranteeing read-your-writes under concurrent writers.</li>
+    <li>The toy omits: script-execution events and processor-mode runs, structural address validation, the 64 KB describeItx budget and timeouts, error masking (NOT_FOUND), the access model, and <code>shareUrl</code>/HTTP ingress.</li>
+    <li>The toy's reserved-name sets are abbreviated; the real lists live in <code>path-proxy.ts</code> and <code>itx.ts</code>.</li>
+    <li>The demo "defaults" simulate their dispatch results in one line each; the real defaults dial real entrypoints (EgressPipe, StreamsCapability, …) in-process.</li>
+    <li>The toy handle is only the fallthrough proxy; the real handle adds the built-in members and is minted via connect/narrowing/wiring.</li>
+  </ul>
+  <p>Generated as a single self-contained file; no external dependencies; works from <code>file://</code>.</p>
+</footer>
+<script id="toy-itx">
+/* The toy itx: a faithful miniature of apps/os/src/itx/itx.ts. Every demo
+   on this page runs through this one implementation. The page renders the
+   three regions below into sections 2 and 3 verbatim, so the code you read
+   there is the code that is running. */
+
+//#region convention
+// ---- dots ⇄ data: the ONE calling convention ------------------------------
+
+// Names that may never traverse a dynamic surface (abbreviated — the real
+// list lives in path-proxy.ts). "describeItx" is the reserved provide-time
+// self-description probe (section 9).
+const RESERVED_PATH_SEGMENTS = new Set([
+  "then", "call", "constructor", "__proto__", "prototype",
+  "toString", "valueOf", "dup", "describeItx",
+]);
+
+// Consumer side: property access accumulates a path LOCALLY (zero round
+// trips); the terminal call fires once with the accumulated PathCall.
+// `then` reads undefined so `await` never misfires mid-chain.
+function pathProxy(onCall, path = []) {
+  const fn = (...args) => onCall({ path, args });
+  return new Proxy(fn, {
+    apply: (_t, _this, args) => onCall({ path, args }),
+    get(_t, key) {
+      if (typeof key === "symbol") return undefined;
+      if (RESERVED_PATH_SEGMENTS.has(key)) return undefined;
+      return pathProxy(onCall, [...path, key]);
+    },
+  });
+}
+
+// Receiver side: walk the segments on a concrete object and call the
+// terminal method ON ITS PARENT (receivers preserved). An empty path calls
+// the target itself as a function. This is the authoritative reserved-name
+// gate: invoke is public, so a path can be hand-built.
+function replayPathCall(target, { path, args }) {
+  for (const seg of path) {
+    if (RESERVED_PATH_SEGMENTS.has(seg)) {
+      throw new Error(`Capability path segment "${seg}" is reserved.`);
+    }
+  }
+  if (path.length === 0) {
+    if (typeof target !== "function") {
+      throw new Error("Capability invoked as a function but the target is not callable.");
+    }
+    return target(...args);
+  }
+  let parent = target;
+  for (const seg of path.slice(0, -1)) {
+    parent = parent == null ? undefined : parent[seg];
+    if (parent == null) throw new Error(`Capability path ${path.join(".")} hit ${String(parent)}.`);
+  }
+  const method = path[path.length - 1];
+  if (typeof parent[method] !== "function") {
+    throw new Error(`Capability path ${path.join(".")} did not resolve to a function.`);
+  }
+  return parent[method](...args);
+}
+
+// Dispatch: among the provided entries (keyed by dot-joined path), the
+// LONGEST prefix of the call path wins; the REMAINDER becomes the call
+// path. One exact lookup per candidate depth — never traverses targets.
+function resolveLongestProvidedPrefix(capabilities, path) {
+  for (let depth = path.length; depth >= 1; depth--) {
+    const entry = capabilities[path.slice(0, depth).join(".")];
+    if (entry !== undefined) return { entry, remainder: path.slice(depth) };
+  }
+  return null;
+}
+//#endregion
+
+//#region journal
+// ---- the journal: events are the only writes -------------------------------
+
+const ITX_EVENT_TYPES = {
+  contextCreated: "events.iterate.com/itx/context-created",
+  capabilityProvided: "events.iterate.com/itx/capability-provided",
+  capabilityRevoked: "events.iterate.com/itx/capability-revoked",
+  capabilityDisconnected: "events.iterate.com/itx/capability-disconnected",
+};
+
+const initialState = () => ({ context: null, capabilities: {} });
+
+// The pure fold: one journal event into the next state. Defensive by
+// design — a malformed payload keeps the current state, so replay can
+// never wedge on a pre-deploy event shape.
+function reduceItxJournalEvent(state, event) {
+  const p = event.payload ?? {};
+  switch (event.type) {
+    case ITX_EVENT_TYPES.contextCreated:
+      // The FIRST birth certificate wins; later ones are inert (retried
+      // appends, replays) — exactly-once as a property of the fold.
+      if (state.context !== null) return state;
+      if (typeof p.id !== "string") return state;
+      return { ...state, context: { id: p.id, name: p.name ?? null, parent: p.parent ?? null } };
+    case ITX_EVENT_TYPES.capabilityProvided: {
+      if (!Array.isArray(p.path) || p.path.length === 0) return state;
+      const name = p.path.join(".");
+      const entry = { name, kind: p.kind, address: p.address ?? null, meta: p.meta ?? {}, owner: p.owner };
+      return { ...state, capabilities: { ...state.capabilities, [name]: entry } };
+    }
+    case ITX_EVENT_TYPES.capabilityRevoked: {
+      if (!Array.isArray(p.path)) return state;
+      const name = p.path.join(".");
+      if (!(name in state.capabilities)) return state;
+      const capabilities = { ...state.capabilities };
+      delete capabilities[name];
+      return { ...state, capabilities };
+    }
+    default:
+      // capability-disconnected is record-only: connectedness is computed
+      // from the live-stub table, never from events. Unknown types: inert.
+      return state;
+  }
+}
+
+// The live-vs-address discriminator: an ADDRESS is a PLAIN object (proto
+// Object.prototype or null) carrying type "rpc" | "url". Everything else
+// is live. Plainness MUST be checked first: property access on an RPC stub
+// returns a truthy pipelined stub, so probing .type first would
+// misclassify every live capability.
+function isCapabilityAddress(capability) {
+  if (typeof capability !== "object" || capability === null) return false;
+  const proto = Object.getPrototypeOf(capability);
+  if (proto !== Object.prototype && proto !== null) return false;
+  return capability.type === "rpc" || capability.type === "url";
+}
+//#endregion
+
+//#region core
+// ---- the core: one map, longest prefix, a chain ----------------------------
+
+// A cap name may not shadow the trust kernel — FIRST segment only; deeper
+// segments are fine. `fetch` and `streams` are deliberately NOT here:
+// shadowing them is how interception works.
+const RESERVED_CAPABILITY_NAMES = new Set([
+  "capability", "describe", "extend", "invoke", "project", "projects",
+  "provideCapability", "revokeCapability", "shareUrl", "super",
+]);
+
+class ToyItx {
+  constructor({ contextId, journalRef, journal, address, parentItx = null, dial = null }) {
+    this.contextId = contextId;   // identity — the journal records' owner
+    this.journalRef = journalRef; // { namespace, path } — the stream coordinate
+    this.journal = journal;       // the event stream (here: an array)
+    this.address = address;       // this node's own address — stamped as origin
+    this.parentItx = parentItx;   // () => ({ from, stub }) | null — the chain link
+    this.dial = dial;             // THE one effect: address → { call({ path, args }) }
+    this.liveStubs = new Map();   // session-bound; never journaled
+    this.state = initialState();  // the checkpoint: a disposable CACHE of the fold
+    this.offset = 0;
+  }
+
+  // ONE write path: append, then catch up through the one consumption door
+  // (read-your-writes; duplicate delivery is inert by offset bookkeeping).
+  append(type, payload) {
+    this.journal.push({ offset: this.journal.length + 1, type, payload });
+    this.catchUp();
+  }
+  catchUp() {
+    while (this.offset < this.journal.length) {
+      this.state = reduceItxJournalEvent(this.state, this.journal[this.offset]);
+      this.offset += 1;
+    }
+  }
+  wipeCheckpointAndReplay() { // the checkpoint is disposable: prove it
+    this.state = initialState();
+    this.offset = 0;
+    this.catchUp();
+  }
+
+  provideCapability({ name, path, capability, instructions, types, meta }) {
+    if ((name === undefined) === (path === undefined)) {
+      throw new Error("Provide exactly one of `name` or `path`.");
+    }
+    const segs = path ? [...path] : [name];
+    segs.forEach((seg, i) => {
+      if (!/^[A-Za-z_$][\w$]*$/.test(seg)) {
+        throw new Error(`Capability path segment ${JSON.stringify(seg)} must be a plain JavaScript identifier.`);
+      }
+      if ((i === 0 ? RESERVED_CAPABILITY_NAMES : RESERVED_PATH_SEGMENTS).has(seg)) {
+        throw new Error(`Capability ${i === 0 ? "name" : "path segment"} ${JSON.stringify(seg)} is reserved.`);
+      }
+    });
+    const capName = segs.join(".");
+    const fullMeta = {
+      ...meta,
+      ...(instructions !== undefined ? { instructions } : {}),
+      ...(types !== undefined ? { types } : {}),
+    };
+    let kind, address = null;
+    if (isCapabilityAddress(capability)) {
+      kind = capability.type;
+      address = capability;
+      this.liveStubs.delete(capName);
+      // The describeItx provide-time hook (section 9): an rpc provide with
+      // no caller-supplied types is dialed ONCE and asked. Best-effort:
+      // any miss just means an unenriched provide. Member-shaped targets
+      // hit the replay's reserved gate — collision protection working.
+      if (kind === "rpc" && fullMeta.types === undefined && this.dial) {
+        try {
+          const probe = this.dial(address, {
+            capabilityPath: capName,
+            origin: { id: this.contextId, address: this.address },
+          });
+          const answer = probe.call({ path: ["describeItx"], args: [] });
+          if (answer && typeof answer.types === "string") fullMeta.types = answer.types;
+          if (answer && typeof answer.instructions === "string" && fullMeta.instructions === undefined) {
+            fullMeta.instructions = answer.instructions;
+          }
+        } catch (_) { /* unenriched */ }
+      }
+    } else {
+      kind = "live";
+      // A bare function is wrapped so it speaks the one calling convention
+      // (empty remainder calls it); anything else IS the stub. The stub
+      // stays an instance field…
+      const live = typeof capability === "function"
+        ? { call: (input) => replayPathCall(capability, input) }
+        : capability;
+      this.liveStubs.set(capName, live);
+    }
+    // …but the EVENT is always journaled: the record outlives the session.
+    this.append(ITX_EVENT_TYPES.capabilityProvided, {
+      path: segs, kind, address, meta: fullMeta, owner: this.contextId, providedAtMs: Date.now(),
+    });
+  }
+
+  // Exact path match, never prefix. Only OWN entries can be revoked:
+  // claiming to revoke an inherited one would lie — shadow it instead.
+  revokeCapability({ name, path }) {
+    const segs = path ? [...path] : [name];
+    const capName = segs.join(".");
+    if (!(capName in this.state.capabilities)) {
+      const parent = this.parentItx && this.parentItx();
+      const inherited = parent && parent.stub.describe().find((d) => d.name === capName);
+      if (inherited) {
+        const from = inherited.from !== undefined ? inherited.from : parent.from;
+        throw new Error(
+          `Capability "${capName}" is not provided on this context — it is inherited from ` +
+          `${from === "defaults" ? "the defaults" : `context ${from}`} and cannot be revoked here; ` +
+          `provide your own "${capName}" on this context to take its place; the original stays on the parent.`,
+        );
+      }
+      return; // never existed: a no-op
+    }
+    this.append(ITX_EVENT_TYPES.capabilityRevoked, { path: segs });
+    this.liveStubs.delete(capName);
+  }
+
+  // The merged chain view: own entries first (no provenance field — they
+  // are yours), then ancestors', each stamped `from` one level below its
+  // owner. Suppression is exact-match only: a path shadow never hides the
+  // parent's broader entry.
+  describe() {
+    const own = Object.values(this.state.capabilities).map((entry) => ({
+      name: entry.name,
+      kind: entry.kind,
+      connected: entry.kind === "live" ? this.liveStubs.has(entry.name) : undefined,
+      instructions: entry.meta.instructions,
+      types: entry.meta.types,
+    }));
+    const parent = this.parentItx && this.parentItx();
+    if (!parent) return own;
+    const shadowed = new Set(own.map((d) => d.name));
+    return [
+      ...own,
+      ...parent.stub.describe()
+        .filter((d) => !shadowed.has(d.name))
+        .map((d) => (d.from === undefined ? { ...d, from: parent.from } : d)),
+    ];
+  }
+
+  // The only dispatch in the system. The longest provided prefix wins and
+  // is called with the REMAINDER; a miss delegates the WHOLE path up the
+  // chain, carrying origin — the context the call STARTED at.
+  invoke({ path, args, origin }) {
+    this.catchUp();
+    const effectiveOrigin = origin ?? { id: this.contextId, address: this.address };
+    const resolved = resolveLongestProvidedPrefix(this.state.capabilities, path);
+    if (!resolved) {
+      const parent = this.parentItx && this.parentItx();
+      if (parent) return parent.stub.invoke({ path, args, origin: effectiveOrigin });
+      throw new Error(`No capability named "${path[0] ?? ""}" on this context or anywhere up its chain. describe() lists what exists.`);
+    }
+    const { entry, remainder } = resolved;
+    if (entry.kind === "live") {
+      const stub = this.liveStubs.get(entry.name);
+      if (!stub) {
+        throw new Error(
+          `Capability "${entry.name}" is registered but its provider is not connected. ` +
+          `Live capabilities last as long as the provider's session; the provider must ` +
+          `reconnect and call provideCapability() again.`,
+        );
+      }
+      // A target implementing `call` owns its whole method tree (the SDK
+      // shape); anything else IS its member tree — replay onto it, in the
+      // process where it lives.
+      if (typeof stub.call === "function") return stub.call({ path: remainder, args });
+      return replayPathCall(stub, { path: remainder, args });
+    }
+    return this.dial(entry.address, { capabilityPath: entry.name, origin: effectiveOrigin })
+      .call({ path: remainder, args });
+  }
+
+  // extend(): creation is an event. Mint the id, give the child its own
+  // journal at <base>/itx/<id>, append the birth certificate (event #1),
+  // return. Nothing else touches the new node.
+  extend({ name } = {}) {
+    const id = "itx_" + Math.random().toString(36).slice(2, 8);
+    const base = journalBaseOf(this.journalRef.path);
+    const journalRef = {
+      namespace: this.journalRef.namespace,
+      path: (base === "/" ? "" : base) + "/itx/" + id,
+    };
+    const child = new ToyItx({
+      contextId: id,
+      journalRef,
+      journal: [],
+      address: childContextAddress(journalRef),
+      dial: this.dial,
+      parentItx: () => ({ from: this.contextId, stub: this }),
+    });
+    child.append(ITX_EVENT_TYPES.contextCreated, {
+      id, name: name ?? null,
+      parent: { id: this.contextId, address: this.address },
+    });
+    return child;
+  }
+
+  // The handle's fallthrough: unknown names become a PathProxy whose
+  // terminal call is ONE invoke on this core.
+  handle() { return pathProxy((pathCall) => this.invoke(pathCall)); }
+
+  // Simulate the provider's session dropping: stubs die, records survive.
+  disconnectSession() {
+    for (const capName of [...this.liveStubs.keys()]) {
+      this.liveStubs.delete(capName);
+      this.append(ITX_EVENT_TYPES.capabilityDisconnected, { path: capName.split(".") });
+    }
+  }
+}
+
+// The journal base a child inherits: the path minus its /itx[/<id>] tail.
+// Chain depth ≠ path depth: every project-rooted extension files at
+// <base>/itx/<id>; parentage lives in the birth certificate.
+function journalBaseOf(journalPath) {
+  const segments = journalPath.split("/").filter(Boolean);
+  const index = segments.lastIndexOf("itx");
+  const base = segments.slice(0, index === -1 ? segments.length : index).join("/");
+  return base === "" ? "/" : "/" + base;
+}
+
+// A context's address is the SAME data structure as every capability's:
+// "how to dial the node that owns this identity".
+function childContextAddress(journalRef) {
+  return {
+    type: "rpc",
+    worker: {
+      type: "durable-object",
+      binding: "ITX_CONTEXT",
+      name: journalRef.namespace + ":" + journalRef.path,
+    },
+  };
+}
+//#endregion
+</script>
+
+<script id="page">
+"use strict";
+
+/* ---------------- generic helpers ---------------- */
+
+function escapeHtml(s) {
+  return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+function truncate(s, n) { return s.length > n ? s.slice(0, n - 1) + "…" : s; }
+function fmt(obj) { return escapeHtml(JSON.stringify(obj, null, 2)); }
+function logLine(el, html, cls) {
+  const d = document.createElement("div");
+  d.className = "line" + (cls ? " " + cls : "");
+  d.innerHTML = html;
+  el.appendChild(d);
+  el.scrollTop = el.scrollHeight;
+}
+
+/* ---------------- the ~40-line highlighter ---------------- */
+
+const HL_RE = new RegExp(
+  [
+    "(\\/\\/[^\\n]*|\\/\\*[\\s\\S]*?\\*\\/)",                              // 1 comment
+    "(\"(?:[^\"\\\\\\n]|\\\\.)*\"|'(?:[^'\\\\\\n]|\\\\.)*'|`(?:[^`\\\\]|\\\\.)*`)", // 2 string
+    "\\b(\\d+(?:\\.\\d+)?)\\b",                                            // 3 number
+    "\\b(const|let|var|function|class|extends|return|await|async|new|if|else|for|while|switch|case|default|throw|try|catch|finally|typeof|delete|in|of|import|export|from|null|undefined|true|false|this|using|type|interface|declare|readonly|satisfies|as|void)\\b", // 4 keyword
+  ].join("|"),
+  "g",
+);
+function highlight(code) {
+  let out = "", last = 0, m;
+  HL_RE.lastIndex = 0;
+  while ((m = HL_RE.exec(code))) {
+    out += escapeHtml(code.slice(last, m.index));
+    const cls = m[1] ? "tok-c" : m[2] ? "tok-s" : m[3] ? "tok-n" : "tok-k";
+    out += '<span class="' + cls + '">' + escapeHtml(m[0]) + "</span>";
+    last = m.index + m[0].length;
+  }
+  return out + escapeHtml(code.slice(last));
+}
+function codeFigure(title, code) {
+  const fig = document.createElement("figure");
+  fig.className = "code";
+  fig.innerHTML =
+    "<figcaption>" + escapeHtml(title) + "</figcaption>" +
+    "<pre><code>" + highlight(code) + "</code></pre>";
+  return fig;
+}
+
+// Render every text/plain code block as a highlighted figure.
+document.querySelectorAll('script[type="text/plain"].code').forEach((block) => {
+  const code = block.textContent.replace(/^\n/, "").replace(/\s+$/, "");
+  block.replaceWith(codeFigure(block.dataset.title || "", code));
+});
+
+// Render the toy's own regions — the displayed source IS the running source.
+const toySource = document.getElementById("toy-itx").textContent;
+document.querySelectorAll(".toy-src").forEach((div) => {
+  const re = new RegExp("//#region " + div.dataset.region + "\\n([\\s\\S]*?)//#endregion");
+  const m = toySource.match(re);
+  const code = m ? m[1].replace(/\s+$/, "") : "(region not found)";
+  div.replaceWith(codeFigure(div.dataset.title || div.dataset.region, code));
+});
+
+/* ---------------- shared render helpers ---------------- */
+
+function renderJournal(el, journal, opts) {
+  el.innerHTML = "";
+  if (!journal.length) { el.innerHTML = '<div class="empty">(empty — no events yet)</div>'; return; }
+  for (const ev of journal) {
+    const row = document.createElement("div");
+    row.className = "jev" + (opts && opts.highlight === ev.offset ? " hl" : "");
+    row.innerHTML =
+      '<span class="off">#' + ev.offset + '</span>' +
+      '<span class="jtype">' + escapeHtml(ev.type.split("/").pop()) + '</span>' +
+      '<span class="jp">' + escapeHtml(truncate(JSON.stringify(ev.payload), 150)) + "</span>";
+    el.appendChild(row);
+  }
+  el.scrollTop = el.scrollHeight;
+}
+
+function renderOwnFold(el, itx) {
+  const entries = Object.values(itx.state.capabilities);
+  el.innerHTML = "";
+  if (!entries.length) { el.innerHTML = '<div class="empty">(no own entries — the fold of an empty journal)</div>'; return; }
+  for (const entry of entries) {
+    const row = document.createElement("div");
+    row.className = "capRow";
+    row.innerHTML =
+      '<span class="cname">' + escapeHtml(entry.name) + '</span>' +
+      '<span class="ckind">' + entry.kind + '</span>' +
+      '<span class="cfrom">owner ' + escapeHtml(entry.owner) + "</span>" +
+      (entry.meta && entry.meta.types ? '<span class="cfrom">· meta.types ✓</span>' : "");
+    el.appendChild(row);
+  }
+}
+
+function renderDescribe(el, descriptions) {
+  el.innerHTML = "";
+  if (!descriptions.length) { el.innerHTML = '<div class="empty">(nothing — describe() is empty)</div>'; return; }
+  for (const d of descriptions) {
+    const row = document.createElement("div");
+    row.className = "capRow";
+    let html =
+      '<span class="cname">' + escapeHtml(d.name) + '</span>' +
+      '<span class="ckind">' + d.kind + "</span>";
+    if (d.connected !== undefined) {
+      html += '<span class="cconn ' + (d.connected ? "on" : "off") + '">' +
+        (d.connected ? "connected" : "offline") + "</span>";
+    }
+    if (d.from !== undefined) html += '<span class="cfrom">from: ' + escapeHtml(d.from) + "</span>";
+    if (d.instructions) html += '<span class="cinstr">' + escapeHtml(truncate(d.instructions, 110)) + "</span>";
+    row.innerHTML = html;
+    el.appendChild(row);
+  }
+}
+
+/* ---------------- the demo world: env, exports, allowlists, dial ---------------- */
+
+const PETSTORE_TYPES = [
+  '// derived from the OpenAPI spec by the provider, at provide time',
+  'declare function findPetsByStatus(input: { status?: "available" | "pending" | "sold" }): Promise<unknown>;',
+  'declare function getPetById(input: { petId: number }): Promise<unknown>;',
+  'declare function placeOrder(input: { petId?: number; quantity?: number }): Promise<unknown>;',
+  'declare function listOperations(): Promise<unknown>;',
+].join("\n");
+
+const TOY_DEFAULT_CAPS = [
+  { name: "ai", blurb: "BindingCapability → env.AI", instructions: "Workers AI. Use it like an env.AI binding: itx.ai.run(model, inputs). Shadow it with your own `ai` cap to swap providers." },
+  { name: "fetch", blurb: "EgressPipe — secret placeholders substituted here, in the stateless terminal pipe", instructions: "Project egress: itx.fetch(request) and bare fetch() inside platform-loaded isolates both flow through this cap. Shadow it to intercept ALL egress on your context; a shadow receives getSecret(...) placeholders UNSUBSTITUTED." },
+  { name: "streams", blurb: "StreamsCapability — the project's namespace", instructions: "Event streams in this project's namespace: itx.streams.get('/path') → append/read/getState/subscribe." },
+  { name: "secrets", blurb: "SecretsCapability — writes + redacted summaries only", instructions: "Project secrets: setSecret({ key, material }), listSecrets() (redacted). Reference stored secrets in egress headers as getSecret({ key }) placeholders." },
+  { name: "repos", blurb: "ReposCapability", instructions: "The project's git repos: ensureProjectRepoInfo, list, create, get." },
+  { name: "workspace", blurb: "WorkspaceCapability, context-scoped via origin", instructions: "The project's shared workspace: readFile/writeFile + flat git methods (gitClone/gitAdd/gitCommit/gitPush/gitStatus)." },
+  { name: "worker", blurb: "an ordinary repo source: { repo: 'project', commit: 'latest', path: 'worker.js' }", instructions: "The project's own worker, built per commit and tracking pushes: itx.worker.someExportedFunction(args)." },
+];
+
+function makeWorld() {
+  const world = {
+    projectId: "prj_demo",
+    env: {
+      AI: { run: (model) => "[env.AI] ran " + String(model) + " (wrapped in-process by the dial — Law 6)" },
+    },
+    allowlists: {
+      bindings: new Set(["AI"]),
+      loopbacks: new Set(["BindingCapability", "EgressPipe", "McpClient", "OpenApiClient",
+        "ReposCapability", "SecretsCapability", "StreamsCapability", "WorkspaceCapability"]),
+      durableObjects: new Set(),
+    },
+  };
+  world.exports = {
+    EgressPipe: () => ({
+      call: ({ args }) => "[EgressPipe] fetched " + String(args[0]) + " — getSecret(…) placeholders substituted here, never anywhere else",
+    }),
+    McpClient: (props) => ({
+      call: ({ path }) => {
+        const m = path.join(".");
+        if (m === "describeItx") return {}; // an MCP surface is dynamic; listTools is the discovery door
+        if (m === "listTools") return { tools: [{ name: "search_docs" }, { name: "get_page" }] };
+        return "[McpClient] tool " + m + " called against " + props.serverUrl + " — all transport HTTP rides the project egress pipe";
+      },
+    }),
+    OpenApiClient: (props) => ({
+      call: ({ path, args }) => {
+        const m = path.join(".");
+        if (m === "describeItx") {
+          return {
+            instructions: "Swagger Petstore v1.0: call itx." + (props.capabilityPath || "<cap>") +
+              ".<operationId>({ ...pathParams, ...queryParams, ...body }); listOperations() lists every operation.",
+            types: PETSTORE_TYPES,
+          };
+        }
+        if (m === "listOperations") {
+          return [
+            { operationId: "findPetsByStatus", method: "get", path: "/pet/findByStatus" },
+            { operationId: "getPetById", method: "get", path: "/pet/{petId}" },
+            { operationId: "placeOrder", method: "post", path: "/store/order" },
+          ];
+        }
+        if (path.length !== 1) throw new Error("Call operations by operationId only — listOperations() lists what exists.");
+        return "[OpenApiClient] " + m + "(" + JSON.stringify(args[0] || {}) + ") → GET /pet/findByStatus via project egress (spec-derived param mapping)";
+      },
+    }),
+  };
+  world.loadIsolate = (address, attribution, input) => {
+    const source = address.worker.source;
+    const key = source.type === "inline" ? source.cacheKey : "build/…memo key…";
+    return "[loader] materialized isolate (cache key " + key + "); env.ITERATE scoped to ORIGIN " +
+      attribution.origin.id + "; globalOutbound = ProjectEgress → replayed ." +
+      input.path.join(".") + "(…) on the entrypoint's members";
+  };
+  world.dial = (address, attribution) => ({
+    call(input) {
+      if (address.type === "url") {
+        return "[UrlDial] stateless worker opened ONE Cap'n Web WebSocket session to " + address.url +
+          ", replayed ." + input.path.join(".") + "(…) as member pipelining against the remote main, disposed (Law 7)";
+      }
+      const worker = address.worker;
+      switch (worker.type) {
+        case "binding": {
+          if (!world.allowlists.bindings.has(worker.binding)) {
+            throw new Error('Capability "' + attribution.capabilityPath + '": binding "' + worker.binding + '" is not dialable.');
+          }
+          const binding = world.env[worker.binding];
+          if (binding == null) throw new Error('binding "' + worker.binding + '" is not available on this host.');
+          return replayPathCall(binding, input);
+        }
+        case "loopback": {
+          if (!address.entrypoint || !world.allowlists.loopbacks.has(address.entrypoint)) {
+            throw new Error('Capability "' + attribution.capabilityPath + '": loopback export "' + address.entrypoint + '" is not dialable.');
+          }
+          // Injection wins by spread order — the spoof-proofing.
+          const stub = world.exports[address.entrypoint]({
+            ...(address.props || {}),
+            capabilityPath: attribution.capabilityPath,
+            context: attribution.origin && attribution.origin.id,
+            projectId: world.projectId,
+          });
+          return stub.call(input);
+        }
+        case "source":
+          return world.loadIsolate(address, attribution, input);
+        case "durable-object": {
+          if (!world.allowlists.durableObjects.has(worker.binding)) {
+            throw new Error('Capability "' + attribution.capabilityPath + '": Durable Object namespace "' + worker.binding +
+              '" is not dialable. (The default DO allowlist is EMPTY; deployments widen it via config — and the dial would scope the name as itx:' +
+              world.projectId + ":" + worker.name + ")");
+          }
+          return "[DO " + worker.binding + "] dialed itx:" + world.projectId + ":" + worker.name;
+        }
+      }
+    },
+  });
+  const byName = Object.fromEntries(TOY_DEFAULT_CAPS.map((c) => [c.name, c]));
+  world.defaultsStub = {
+    describe: () => TOY_DEFAULT_CAPS.map((c) => ({ name: c.name, kind: "rpc", instructions: c.instructions })),
+    invoke({ path, args, origin }) {
+      const resolved = resolveLongestProvidedPrefix(byName, path);
+      if (!resolved) {
+        throw new Error('No capability named "' + (path[0] || "") + '" on this context or anywhere up its chain. describe() lists what exists.');
+      }
+      const tail = resolved.remainder.length ? "." + resolved.remainder.join(".") : "";
+      return "[defaults:" + resolved.entry.name + tail + "] → " + resolved.entry.blurb +
+        " · origin " + (origin ? origin.id : "?") + (args && args.length ? " · args " + truncate(JSON.stringify(args), 60) : "");
+    },
+    provideCapability() {
+      throw new Error("The defaults are read-only — they ship with the deploy. Provide on your own context to shadow a default.");
+    },
+    revokeCapability() {
+      throw new Error("The defaults are read-only — they ship with the deploy and cannot be revoked; shadow them on your own context instead.");
+    },
+  };
+  world.newProject = (id) => new ToyItx({
+    contextId: id,
+    journalRef: { namespace: id, path: "/itx" },
+    journal: [],
+    address: { type: "rpc", worker: { type: "durable-object", binding: "PROJECT", name: id } },
+    dial: world.dial,
+    parentItx: () => ({ from: "defaults", stub: world.defaultsStub }),
+  });
+  return world;
+}
+
+/* ---------------- demo 1: the seed ---------------- */
+
+(function demoSeed() {
+  const root = document.getElementById("demo-seed");
+  if (!root) return;
+  const tableEl = document.getElementById("seed-table");
+  const logEl = document.getElementById("seed-log");
+  const capabilities = new Map();
+  function provide(name, thing) { capabilities.set(name, thing); render(); logLine(logEl, 'provide("' + name + '", …)', "ok"); }
+  function invoke(name, ...args) {
+    const cap = capabilities.get(name);
+    if (!cap) throw new Error('No capability named "' + name + '"');
+    return cap(...args);
+  }
+  function render() {
+    tableEl.innerHTML = capabilities.size ? "" : '<div class="empty">(empty)</div>';
+    for (const [name, thing] of capabilities) {
+      const row = document.createElement("div");
+      row.className = "capRow";
+      row.innerHTML = '<span class="cname">' + escapeHtml(name) + '</span> <span class="cfrom">→ ' + escapeHtml(String(thing)) + "</span>";
+      tableEl.appendChild(row);
+    }
+  }
+  root.addEventListener("click", (e) => {
+    const act = e.target.dataset && e.target.dataset.act;
+    if (!act) return;
+    try {
+      if (act === "provide-greet") provide("greet", (who) => "hello, " + who);
+      else if (act === "provide-dice") provide("dice", () => 1 + Math.floor(Math.random() * 6));
+      else if (act === "provide-now") provide("now", () => new Date().toISOString());
+      else if (act === "invoke-greet") logLine(logEl, 'invoke("greet", "world") <span class="arrow">→</span> ' + escapeHtml(JSON.stringify(invoke("greet", "world"))), "ok");
+      else if (act === "invoke-dice") logLine(logEl, 'invoke("dice") <span class="arrow">→</span> ' + escapeHtml(JSON.stringify(invoke("dice"))), "ok");
+      else if (act === "invoke-missing") invoke("slack");
+    } catch (err) { logLine(logEl, escapeHtml(err.message || String(err)), "err"); }
+  });
+  render();
+})();
+
+/* ---------------- demo 2: the calling convention ---------------- */
+
+(function demoConvention() {
+  const root = document.getElementById("demo-conv");
+  if (!root) return;
+  const dispatchEl = document.getElementById("conv-dispatch");
+  const logEl = document.getElementById("conv-log");
+  const itx = new ToyItx({
+    contextId: "prj_demo",
+    journalRef: { namespace: "prj_demo", path: "/itx" },
+    journal: [],
+    address: { type: "rpc", worker: { type: "durable-object", binding: "PROJECT", name: "prj_demo" } },
+  });
+  const handle = pathProxy((pathCall) => {
+    logLine(dispatchEl, "PathCall " + escapeHtml(JSON.stringify(pathCall)));
+    const resolved = resolveLongestProvidedPrefix(itx.state.capabilities, pathCall.path);
+    if (resolved) {
+      logLine(dispatchEl,
+        '&nbsp;&nbsp;longest provided prefix: <b>"' + escapeHtml(resolved.entry.name) + '"</b> · remainder ' +
+        escapeHtml(JSON.stringify(resolved.remainder)) + " → member replay on the provider's object");
+    } else {
+      logLine(dispatchEl, "&nbsp;&nbsp;no provided prefix → would delegate up the chain (none here)");
+    }
+    return itx.invoke(pathCall);
+  });
+  root.addEventListener("click", (e) => {
+    const act = e.target.dataset && e.target.dataset.act;
+    if (!act) return;
+    try {
+      if (act === "provide") {
+        itx.provideCapability({
+          name: "answer",
+          instructions: "The answer to everything: itx.answer.ultimate(), or itx.answer.deep.thought(question).",
+          capability: { ultimate: () => 42, deep: { thought: (q) => ({ answer: 42, question: q }) } },
+        });
+        logLine(logEl, 'provided "answer" — a plain nested object IS the capability (kind: live)', "ok");
+      } else if (act === "ultimate") {
+        logLine(logEl, "itx.answer.ultimate() <span class=\"arrow\">→</span> " + escapeHtml(JSON.stringify(handle.answer.ultimate())), "ok");
+      } else if (act === "thought") {
+        const q = document.getElementById("conv-q").value;
+        logLine(logEl, "itx.answer.deep.thought(…) <span class=\"arrow\">→</span> " + escapeHtml(JSON.stringify(handle.answer.deep.thought(q))), "ok");
+      } else if (act === "custom") {
+        const segs = document.getElementById("conv-path").value.split(".").filter(Boolean);
+        const target = segs.reduce((acc, key) => acc[key], handle);
+        logLine(logEl, "itx." + escapeHtml(segs.join(".")) + "(…) <span class=\"arrow\">→</span> " + escapeHtml(JSON.stringify(target("…"))), "ok");
+      }
+    } catch (err) { logLine(logEl, escapeHtml(err.message || String(err)), "err"); }
+  });
+})();
+
+/* ---------------- demo 3: the journal ---------------- */
+
+(function demoJournal() {
+  const root = document.getElementById("demo-journal");
+  if (!root) return;
+  const world = makeWorld();
+  const itx = world.newProject("prj_demo");
+  const handle = itx.handle();
+  let child = null;
+  const journalEl = document.getElementById("j3-journal");
+  const capsEl = document.getElementById("j3-caps");
+  const childWrap = document.getElementById("j3-childwrap");
+  const childJournalEl = document.getElementById("j3-childjournal");
+  const childSideEl = document.getElementById("j3-log");
+  const logEl = document.getElementById("j3-log2");
+  function refresh() {
+    renderJournal(journalEl, itx.journal);
+    renderOwnFold(capsEl, itx);
+    if (child) {
+      childWrap.style.display = "";
+      renderJournal(childJournalEl, child.journal, { highlight: 1 });
+      childSideEl.previousElementSibling.textContent = "child.describe() — merged chain view (own → parent → defaults)";
+      renderDescribe(childSideEl, child.describe());
+    }
+  }
+  root.addEventListener("click", (e) => {
+    const act = e.target.dataset && e.target.dataset.act;
+    if (!act) return;
+    try {
+      if (act === "provide-live") {
+        itx.provideCapability({
+          name: "clock",
+          instructions: "The provider's wall clock: itx.clock.nowMs().",
+          capability: { nowMs: () => Date.now() },
+        });
+        logLine(logEl, "appended capability-provided (kind: live — the EVENT is journaled, the stub stays in memory)", "ok");
+      } else if (act === "provide-rpc") {
+        itx.provideCapability({
+          name: "ai",
+          capability: { type: "rpc", worker: { type: "binding", binding: "AI" } },
+        });
+        logLine(logEl, "appended capability-provided (kind: rpc — the full address is in the journal)", "ok");
+      } else if (act === "call-clock") {
+        logLine(logEl, "itx.clock.nowMs() <span class=\"arrow\">→</span> " + escapeHtml(JSON.stringify(handle.clock.nowMs())), "ok");
+      } else if (act === "revoke") {
+        itx.revokeCapability({ name: "clock" });
+        logLine(logEl, "appended capability-revoked — the fold drops the entry", "ok");
+      } else if (act === "wipe") {
+        const before = JSON.stringify(itx.state);
+        itx.wipeCheckpointAndReplay();
+        const after = JSON.stringify(itx.state);
+        logLine(logEl, "checkpoint wiped; replayed " + itx.journal.length + " events from offset 0 — rebuilt state is " +
+          (before === after ? "<b>byte-identical ✓</b> (the checkpoint is a disposable cache)" : "DIFFERENT ✗ (bug!)"),
+          before === after ? "ok" : "err");
+      } else if (act === "extend") {
+        child = itx.extend({ name: "scratch" });
+        logLine(logEl, "extended → " + child.contextId + " · journal at (" + child.journalRef.namespace + ", " +
+          child.journalRef.path + ") · event #1 is its birth certificate — creation was ONE append", "ok");
+      }
+    } catch (err) { logLine(logEl, escapeHtml(err.message || String(err)), "err"); }
+    refresh();
+  });
+  refresh();
+})();
+
+/* ---------------- demo 4: live vs durable ---------------- */
+
+(function demoStubs() {
+  const root = document.getElementById("demo-stubs");
+  if (!root) return;
+  const world = makeWorld();
+  const itx = new ToyItx({
+    contextId: "prj_demo",
+    journalRef: { namespace: "prj_demo", path: "/itx" },
+    journal: [],
+    address: { type: "rpc", worker: { type: "durable-object", binding: "PROJECT", name: "prj_demo" } },
+    dial: world.dial,
+  });
+  const handle = itx.handle();
+  const capsEl = document.getElementById("s4-caps");
+  const logEl = document.getElementById("s4-log");
+  function refresh() { renderDescribe(capsEl, itx.describe()); }
+  root.addEventListener("click", (e) => {
+    const act = e.target.dataset && e.target.dataset.act;
+    if (!act) return;
+    try {
+      if (act === "provide-mac") {
+        itx.provideCapability({
+          name: "mac",
+          instructions: "Compile-and-run Swift on Jonas's Mac: itx.mac.runSwift(src).",
+          capability: { runSwift: (src) => "compiled & ran " + src.length + " chars of Swift, in the provider's process" },
+        });
+        logLine(logEl, 'provided "mac" — live: the stub is held over the provider\'s session', "ok");
+      } else if (act === "provide-ai") {
+        itx.provideCapability({ name: "ai", capability: { type: "rpc", worker: { type: "binding", binding: "AI" } } });
+        logLine(logEl, 'provided "ai" — durable: a serializable address, restored at invoke time', "ok");
+      } else if (act === "call-mac") {
+        logLine(logEl, 'itx.mac.runSwift("print(42)") <span class="arrow">→</span> ' + escapeHtml(JSON.stringify(handle.mac.runSwift("print(42)"))), "ok");
+      } else if (act === "call-ai") {
+        logLine(logEl, 'itx.ai.run("@cf/meta/llama-3") <span class="arrow">→</span> ' + escapeHtml(JSON.stringify(handle.ai.run("@cf/meta/llama-3"))), "ok");
+      } else if (act === "drop") {
+        itx.disconnectSession();
+        logLine(logEl, "session dropped → appended capability-disconnected (record only; the fold ignores it). " +
+          "The live entry survives as offline; the rpc address is untouched. Try calling mac again.", "ok");
+      }
+    } catch (err) { logLine(logEl, escapeHtml(err.message || String(err)), "err"); }
+    refresh();
+  });
+  refresh();
+})();
+
+/* ---------------- demo 5: the chain ---------------- */
+
+(function demoChain() {
+  const root = document.getElementById("demo-chain");
+  if (!root) return;
+  const world = makeWorld();
+  const project = world.newProject("prj_demo");
+  const child = project.extend({ name: "review-run" });
+  const viz = document.getElementById("chain-viz");
+  const logEl = document.getElementById("chain-log");
+  function renderChain(win) {
+    viz.innerHTML = "";
+    const nodes = [
+      { key: "child", title: child.contextId, role: 'extension "review-run" · journal ' + child.journalRef.path + " · delegates →", caps: Object.values(child.state.capabilities) },
+      { key: "project", title: "prj_demo", role: "the project context · journal /itx · delegates →", caps: Object.values(project.state.capabilities) },
+      { key: "defaults", title: "defaults", role: "PlatformContext — read-only code; ships with the deploy", caps: TOY_DEFAULT_CAPS.map((c) => ({ name: c.name, kind: "rpc" })) },
+    ];
+    for (const node of nodes) {
+      const div = document.createElement("div");
+      div.className = "chainNode";
+      let caps = node.caps.length
+        ? node.caps.map((c) =>
+            '<div class="capEntry' + (win && win.node === node.key && win.name === c.name ? " win" : "") + '" ' +
+            'data-node="' + node.key + '" data-name="' + escapeHtml(c.name) + '">' +
+            escapeHtml(c.name) + ' <span class="k">' + c.kind + "</span></div>").join("")
+        : '<div class="empty" style="font:11.5px ui-monospace,monospace;color:#9aa1ac;padding:3px 8px">(no own entries)</div>';
+      div.innerHTML = '<header><span class="cid">' + escapeHtml(node.title) + '</span><span class="role">' +
+        escapeHtml(node.role) + '</span></header><div class="caps">' + caps + "</div>";
+      viz.appendChild(div);
+    }
+  }
+  function traceAndCall(pathStr, startAtParent) {
+    const segs = pathStr.split(".").filter(Boolean);
+    if (!segs.length) return;
+    logLine(logEl, "<b>" + (startAtParent ? "child.super." : "child.") + escapeHtml(segs.join(".")) + "(…)</b>");
+    let win = null;
+    const hops = [
+      { key: "child", label: child.contextId, caps: child.state.capabilities },
+      { key: "project", label: "prj_demo", caps: project.state.capabilities },
+    ].slice(startAtParent ? 1 : 0);
+    if (startAtParent) {
+      logLine(logEl, "&nbsp;&nbsp;super: resolution starts ONE link up — the child's table is skipped; origin is still " + child.contextId);
+    }
+    let resolvedSomewhere = false;
+    for (const hop of hops) {
+      const r = resolveLongestProvidedPrefix(hop.caps, segs);
+      if (r) {
+        logLine(logEl, "&nbsp;&nbsp;" + escapeHtml(hop.label) + ': <b>"' + escapeHtml(r.entry.name) + '"</b> wins (longest provided prefix) · remainder ' +
+          escapeHtml(JSON.stringify(r.remainder)) + " → " + (r.entry.kind === "live" ? "live stub" : "dial the " + r.entry.kind + " address"));
+        win = { node: hop.key, name: r.entry.name };
+        resolvedSomewhere = true;
+        break;
+      }
+      logLine(logEl, "&nbsp;&nbsp;" + escapeHtml(hop.label) + ": no provided prefix → delegate the WHOLE path to the parent (origin stays " + child.contextId + ")");
+    }
+    if (!resolvedSomewhere) {
+      const d = TOY_DEFAULT_CAPS.find((c) => c.name === segs[0]);
+      if (d) {
+        logLine(logEl, '&nbsp;&nbsp;defaults: <b>"' + d.name + '"</b> wins · remainder ' + escapeHtml(JSON.stringify(segs.slice(1))) +
+          " → dialed in-process (loopback — default dispatch pays no DO hop)");
+        win = { node: "defaults", name: d.name };
+      }
+    }
+    try {
+      const args = segs[0] === "fetch" ? ["https://api.example.com/v1/thing"] : [{ demo: true }];
+      const result = startAtParent
+        ? project.invoke({ path: segs, args, origin: { id: child.contextId, address: child.address } })
+        : child.invoke({ path: segs, args });
+      logLine(logEl, "&nbsp;&nbsp;result <span class=\"arrow\">→</span> " + escapeHtml(typeof result === "string" ? result : JSON.stringify(result)), "ok");
+    } catch (err) {
+      logLine(logEl, "&nbsp;&nbsp;" + escapeHtml(err.message || String(err)), "err");
+    }
+    renderChain(win);
+  }
+  root.addEventListener("click", (e) => {
+    const act = e.target.dataset && e.target.dataset.act;
+    if (!act) return;
+    try {
+      if (act === "shadow-gitpush") {
+        child.provideCapability({
+          path: ["workspace", "gitPush"],
+          instructions: "gitPush waits for human approval; everything else is the real workspace.",
+          capability: (input) => "⏸ held for approval (the gate) — input " + JSON.stringify(input),
+        });
+        logLine(logEl, 'shadowed ONE method: path ["workspace","gitPush"] on ' + child.contextId +
+          " — workspace.readFile etc. still fall through the chain", "ok");
+      } else if (act === "shadow-fetch") {
+        child.provideCapability({
+          name: "fetch",
+          instructions: "Egress with an x-trace-id header; delegates to the real pipe via itx.super.fetch.",
+          capability: (request) => "[child's fetch shadow] stamped x-trace-id, placeholders UNsubstituted → super.fetch → " +
+            project.invoke({ path: ["fetch"], args: [request], origin: { id: child.contextId, address: child.address } }),
+        });
+        logLine(logEl, 'shadowed "fetch" on the child with a plain function that calls super — middleware in one provide', "ok");
+      } else if (act === "provide-slack") {
+        project.provideCapability({
+          name: "slack",
+          instructions: "Post to the team Slack: itx.slack.chat.postMessage({ channel, text }).",
+          capability: { chat: { postMessage: (m) => "[live slack provider] posted " + JSON.stringify(m) } },
+        });
+        logLine(logEl, 'provided "slack" on the PROJECT — the child inherits it through the chain', "ok");
+      } else if (act === "revoke-gitpush") {
+        child.revokeCapability({ path: ["workspace", "gitPush"] });
+        logLine(logEl, "revoked the child's gitPush shadow — the inherited workspace resurfaces, by construction", "ok");
+      } else if (act === "revoke-default") {
+        child.revokeCapability({ name: "ai" });
+      } else if (act === "provide-on-defaults") {
+        world.defaultsStub.provideCapability({ name: "evil", capability: {} });
+      } else if (act === "resolve") {
+        traceAndCall(document.getElementById("chain-path").value, false);
+        return; // traceAndCall renders
+      } else if (act === "super") {
+        traceAndCall("fetch", true);
+        return;
+      }
+    } catch (err) { logLine(logEl, escapeHtml(err.message || String(err)), "err"); }
+    renderChain(null);
+  });
+  renderChain(null);
+})();
+
+/* ---------------- demo 6: the dial ---------------- */
+
+(function demoDial() {
+  const root = document.getElementById("demo-dial");
+  if (!root) return;
+  const world = makeWorld();
+  const pick = document.getElementById("dial-pick");
+  const addrEl = document.getElementById("dial-addr");
+  const logEl = document.getElementById("dial-log");
+  const candidates = [
+    { label: 'binding "AI" — allowlisted', path: ["run"], args: ["@cf/meta/llama-3"],
+      address: { type: "rpc", worker: { type: "binding", binding: "AI" } } },
+    { label: 'binding "DB" — NOT allowlisted', path: ["query"], args: ["select 1"],
+      address: { type: "rpc", worker: { type: "binding", binding: "DB" } } },
+    { label: 'loopback "McpClient" — allowlisted, props ride the provide', path: ["listTools"], args: [],
+      address: { type: "rpc", worker: { type: "loopback" }, entrypoint: "McpClient", props: { serverUrl: "https://docs.mcp.cloudflare.com/mcp" } } },
+    { label: 'loopback "SecretLeaker" — NOT allowlisted', path: ["leak"], args: [],
+      address: { type: "rpc", worker: { type: "loopback" }, entrypoint: "SecretLeaker" } },
+    { label: 'durable-object "TODO":"inbox" — default allowlist is empty', path: ["add"], args: [{ text: "hi" }],
+      address: { type: "rpc", worker: { type: "durable-object", binding: "TODO", name: "inbox" } } },
+    { label: "source (inline greeter) — loader isolate, origin-scoped", path: ["hello"], args: [{ name: "world" }],
+      address: { type: "rpc", worker: { type: "source", source: { type: "inline", cacheKey: "greeter-v1", mainModule: "cap.js", modules: { "cap.js": "…" } } } } },
+    { label: "url — a Cap'n Web server across the internet", path: ["chat", "postMessage"], args: [{ text: "hi" }],
+      address: { type: "url", url: "wss://caps.example.com/api", headers: { authorization: 'Bearer getSecret({ key: "REMOTE_TOKEN" })' } } },
+  ];
+  candidates.forEach((c, i) => {
+    const opt = document.createElement("option");
+    opt.value = String(i);
+    opt.textContent = c.label;
+    pick.appendChild(opt);
+  });
+  function show() {
+    const c = candidates[Number(pick.value)];
+    addrEl.innerHTML = fmt(c.address);
+  }
+  pick.addEventListener("change", show);
+  root.addEventListener("click", (e) => {
+    if (!e.target.dataset || e.target.dataset.act !== "dial") return;
+    const c = candidates[Number(pick.value)];
+    show();
+    logLine(logEl, "<b>dial(address) → call({ path: " + escapeHtml(JSON.stringify(c.path)) + ", args })</b>");
+    try {
+      const result = world.dial(c.address, { capabilityPath: "demo", origin: { id: "prj_demo", address: null } })
+        .call({ path: c.path, args: c.args });
+      logLine(logEl, escapeHtml(typeof result === "string" ? result : JSON.stringify(result)), "ok");
+    } catch (err) {
+      logLine(logEl, escapeHtml(err.message || String(err)) + " <span class=\"arrow\">(surfaced at FIRST CALL — provide was structural only)</span>", "err");
+    }
+  });
+  show();
+})();
+
+/* ---------------- demo 7: identity ---------------- */
+
+(function demoIdentity() {
+  const root = document.getElementById("demo-identity");
+  if (!root) return;
+  const input = document.getElementById("id-name");
+  const outEl = document.getElementById("id-out");
+  const addrEl = document.getElementById("id-addr");
+  function parse() {
+    const name = input.value.trim();
+    try {
+      const colon = name.indexOf(":");
+      if (colon <= 0 || name[colon + 1] !== "/") {
+        throw new Error('ItxDurableObject must be addressed by its journal coordinate ("<namespace>:/<path>"), got ' + JSON.stringify(name) + ".");
+      }
+      const namespace = name.slice(0, colon);
+      const path = name.slice(colon + 1);
+      const segs = path.split("/").filter(Boolean);
+      const last = segs[segs.length - 1];
+      const contextId = last && last.indexOf("itx_") === 0
+        ? last
+        : "(the host's own context — identity derives from the host, no birth certificate)";
+      outEl.innerHTML =
+        "namespace (owning project):  <b>" + escapeHtml(namespace) + "</b>\n" +
+        "journal path:                <b>" + escapeHtml(path) + "</b>\n" +
+        "context id (last segment):   <b>" + escapeHtml(contextId) + "</b>\n" +
+        "journal base for children:   <b>" + escapeHtml(journalBaseOf(path)) + "</b>\n" +
+        'reserved segment in use:     <b>"itx"</b> — user streams may not claim it';
+      addrEl.innerHTML = fmt(childContextAddress({ namespace, path }));
+    } catch (err) {
+      outEl.innerHTML = '<span style="color:var(--err)">' + escapeHtml(err.message || String(err)) + "</span>";
+      addrEl.innerHTML = "";
+    }
+  }
+  root.addEventListener("click", (e) => {
+    const t = e.target;
+    if (t.dataset && t.dataset.name) { input.value = t.dataset.name; parse(); }
+    else if (t.dataset && t.dataset.act === "parse") parse();
+  });
+  parse();
+})();
+
+/* ---------------- demo 8: the build memo ---------------- */
+
+(function demoMemo() {
+  const root = document.getElementById("demo-memo");
+  if (!root) return;
+  const logEl = document.getElementById("memo-log");
+  const r2El = document.getElementById("memo-r2");
+  const shaEl = document.getElementById("memo-sha");
+  const r2 = new Map();
+  function newSha() {
+    let s = "";
+    for (let i = 0; i < 8; i++) s += "0123456789abcdef"[Math.floor(Math.random() * 16)];
+    return s;
+  }
+  let sha = newSha();
+  function fakeHash(s) {
+    let h = 5381;
+    for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) >>> 0;
+    return h.toString(16).padStart(8, "0") + (((h ^ 0xabcdef) >>> 0)).toString(16).slice(0, 4);
+  }
+  function refresh() {
+    shaEl.textContent = 'repo "project" HEAD = ' + sha;
+    r2El.innerHTML = r2.size ? "" : '<div class="empty">(empty)</div>';
+    for (const [key, value] of r2) {
+      const row = document.createElement("div");
+      row.className = "capRow";
+      row.innerHTML = '<span class="cname">' + escapeHtml(key) + '</span> <span class="cfrom">' + escapeHtml(value) + "</span>";
+      r2El.appendChild(row);
+    }
+  }
+  root.addEventListener("click", (e) => {
+    const act = e.target.dataset && e.target.dataset.act;
+    if (!act) return;
+    if (act === "push") {
+      sha = newSha();
+      logLine(logEl, "git push → new commit " + sha + ' — "latest" resolves to it (probe memoized ≤10 s per isolate)', "ok");
+    } else if (act === "dial") {
+      logLine(logEl, "<b>dial itx.repoGreeter.hello({ name: \"world\" })</b>");
+      logLine(logEl, '&nbsp;&nbsp;probe "latest" → ' + sha);
+      const memoKey = "build/" + fakeHash("prj_demo|project|" + sha + "|caps/greeter.js|{}|null");
+      logLine(logEl, "&nbsp;&nbsp;memo key = hash(projectId, repo, sha, path, bundle, compatDate) = " + memoKey);
+      if (r2.has(memoKey)) {
+        logLine(logEl, "&nbsp;&nbsp;R2 HIT — no build, no readTree. Warm dials never build.", "ok");
+      } else {
+        logLine(logEl, "&nbsp;&nbsp;cold key: repo DO readTree(" + sha + ") → worker-bundler (in-memory vfs, no clone) → R2 put " + memoKey);
+        r2.set(memoKey, "built modules for " + sha);
+      }
+      logLine(logEl, '&nbsp;&nbsp;loader isolate key itx-cap:prj_demo:repoGreeter:' + memoKey +
+        ' → replayed .hello(…) <span class="arrow">→</span> "hello from the repo, world"', "ok");
+    }
+    refresh();
+  });
+  refresh();
+})();
+
+/* ---------------- demo 9: describeItx ---------------- */
+
+(function demoDescribe() {
+  const root = document.getElementById("demo-describe");
+  if (!root) return;
+  const world = makeWorld();
+  const itx = world.newProject("prj_demo");
+  const handle = itx.handle();
+  const journalEl = document.getElementById("d9-journal");
+  const logEl = document.getElementById("d9-log");
+  function refresh() { renderJournal(journalEl, itx.journal); }
+  root.addEventListener("click", (e) => {
+    const act = e.target.dataset && e.target.dataset.act;
+    if (!act) return;
+    try {
+      if (act === "provide") {
+        itx.provideCapability({
+          name: "petstore",
+          capability: {
+            type: "rpc",
+            worker: { type: "loopback" },
+            entrypoint: "OpenApiClient",
+            props: { specUrl: "https://petstore3.swagger.io/api/v3/openapi.json" },
+          },
+        });
+        logLine(logEl, "provided with NO types — the core dialed the address once and asked describeItx; " +
+          "the provider derived types from its spec, and they were JOURNALED with the provide", "ok");
+      } else if (act === "call") {
+        logLine(logEl, "itx.petstore.findPetsByStatus(…) <span class=\"arrow\">→</span> " +
+          escapeHtml(String(handle.petstore.findPetsByStatus({ status: "available" }))), "ok");
+      } else if (act === "describe") {
+        const descriptions = itx.describe();
+        for (const d of descriptions.slice(0, 3)) {
+          logLine(logEl, "<b>" + escapeHtml(d.name) + "</b> [" + d.kind + (d.from ? " · from: " + escapeHtml(d.from) : "") + "] " +
+            escapeHtml(truncate(d.instructions || "", 100)));
+          if (d.types) logLine(logEl, '&nbsp;&nbsp;types: <span style="color:#6b7280">' + escapeHtml(truncate(d.types.split("\n")[1] || d.types, 110)) + " …</span>");
+        }
+        logLine(logEl, "… plus " + Math.max(0, descriptions.length - 3) + ' inherited entries (from: "defaults")');
+      }
+    } catch (err) { logLine(logEl, escapeHtml(err.message || String(err)), "err"); }
+    refresh();
+  });
+  refresh();
+})();
+
+/* ---------------- demo 10: the cron fold ---------------- */
+
+(function demoCron() {
+  const root = document.getElementById("demo-cron");
+  if (!root) return;
+  const journalEl = document.getElementById("cron-journal");
+  const stateEl = document.getElementById("cron-state");
+  const logEl = document.getElementById("cron-log");
+  const CRON = {
+    created: "events.iterate.com/cron/schedule-created",
+    updated: "events.iterate.com/cron/schedule-updated",
+    requested: "events.iterate.com/cron/fire-requested",
+    completed: "events.iterate.com/cron/fire-completed",
+  };
+  const initial = () => ({ schedule: null, pendingFires: {} });
+  function reduceCron(state, event) {
+    const p = event.payload || {};
+    switch (event.type) {
+      case CRON.created:
+        if (state.schedule !== null) return state;
+        if (typeof p.id !== "string") return state;
+        return { ...state, schedule: { id: p.id, spec: p.spec, paused: false } };
+      case CRON.updated:
+        if (state.schedule === null) return state;
+        return { ...state, schedule: { ...state.schedule, ...(p.spec ? { spec: p.spec } : {}) } };
+      case CRON.requested:
+        if (p.enqueued !== true || typeof p.fireId !== "string") return state;
+        return { ...state, pendingFires: { ...state.pendingFires, [p.fireId]: true } };
+      case CRON.completed: {
+        if (!(p.fireId in state.pendingFires)) return state;
+        const pendingFires = { ...state.pendingFires };
+        delete pendingFires[p.fireId];
+        return { ...state, pendingFires };
+      }
+      default:
+        return state;
+    }
+  }
+  const journal = [];
+  let state = initial();
+  let offset = 0;
+  let fireCount = 0;
+  function append(type, payload) {
+    journal.push({ offset: journal.length + 1, type, payload });
+    while (offset < journal.length) { state = reduceCron(state, journal[offset]); offset += 1; }
+  }
+  function refresh() {
+    renderJournal(journalEl, journal);
+    stateEl.innerHTML = fmt(state);
+  }
+  root.addEventListener("click", (e) => {
+    const act = e.target.dataset && e.target.dataset.act;
+    if (!act) return;
+    if (act === "create" || act === "create-dup") {
+      const had = state.schedule !== null;
+      append(CRON.created, { id: "cron_x9k2", spec: "0 9 * * 1", parent: { id: "prj_demo" } });
+      logLine(logEl, had
+        ? "appended a SECOND schedule-created — the fold ignored it: the first birth certificate wins, retried appends are inert"
+        : "appended the birth certificate (event #1) — creating the thing was ONE append; no initialize RPC", had ? "ok" : "ok");
+    } else if (act === "update") {
+      append(CRON.updated, { spec: "0 9 * * " + (1 + Math.floor(Math.random() * 5)) });
+      logLine(logEl, "appended schedule-updated — creation-time facts and later facts go through the SAME reducer", "ok");
+    } else if (act === "request") {
+      fireCount += 1;
+      append(CRON.requested, { fireId: "fire_" + fireCount, scheduledForMs: Date.now(), enqueued: true });
+      logLine(logEl, "appended fire-requested (enqueued: true) — appending IS requesting work; processEventBatch runs the side effect, never reduce", "ok");
+    } else if (act === "complete") {
+      const pending = Object.keys(state.pendingFires);
+      const fireId = pending[0] || "fire_unknown";
+      append(CRON.completed, { fireId });
+      logLine(logEl, pending.length
+        ? "appended fire-completed for " + fireId + " — the requested/completed pair makes at-least-once reruns detectable"
+        : "appended fire-completed for an UNKNOWN fireId — inert in the fold (look: state unchanged)", "ok");
+    } else if (act === "wipe") {
+      const before = JSON.stringify(state);
+      state = initial(); offset = 0;
+      while (offset < journal.length) { state = reduceCron(state, journal[offset]); offset += 1; }
+      logLine(logEl, "checkpoint wiped; replayed " + journal.length + " events — rebuilt state is " +
+        (before === JSON.stringify(state) ? "<b>byte-identical ✓</b>" : "DIFFERENT ✗"), "ok");
+    }
+    refresh();
+  });
+  refresh();
+})();
+
+/* ---------------- nav: active-section highlighting ---------------- */
+
+(function nav() {
+  if (typeof IntersectionObserver === "undefined") return;
+  const links = Array.from(document.querySelectorAll("nav#toc a"));
+  const byId = new Map(links.map((a) => [a.getAttribute("href").slice(1), a]));
+  const observer = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (!entry.isIntersecting) continue;
+      links.forEach((a) => a.classList.remove("active"));
+      const link = byId.get(entry.target.id);
+      if (link) link.classList.add("active");
+    }
+  }, { rootMargin: "-15% 0px -75% 0px" });
+  document.querySelectorAll("main section").forEach((section) => observer.observe(section));
+})();
+</script>
+
+</main>
+</body>
+</html>

--- a/apps/os/src/domains/secrets/entrypoints/secrets-capability-call.test.ts
+++ b/apps/os/src/domains/secrets/entrypoints/secrets-capability-call.test.ts
@@ -36,8 +36,8 @@ describe("resolveItxSecretsMethod", () => {
       /got "setSecret\.deeper"/,
     );
     expect(() => resolveItxSecretsMethod([])).toThrow(/itx\.secrets exposes/);
-    // The provide-time describeItx probe is best-effort; a refusal here just
-    // leaves the provide unenriched (itx.ts #dialSelfDescription).
+    // describeItx is a reserved protocol name, not an allowlisted method —
+    // itx.secrets refuses it like any other non-allowlisted path.
     expect(() => resolveItxSecretsMethod(["describeItx"])).toThrow(/itx\.secrets exposes/);
   });
 });

--- a/apps/os/src/itx/e2e/itx-openapi.e2e.test.ts
+++ b/apps/os/src/itx/e2e/itx-openapi.e2e.test.ts
@@ -7,10 +7,8 @@
 //      object, through project egress (the fixture only answers with the
 //      admin bearer from props.headers, so headers riding every call is
 //      proven implicitly)
-//   2. describe() carries spec-derived `types` with zero callsite ceremony —
-//      the core's provide-time describeItx hook journaled them
-//   3. listOperations() enumerates the surface
-//   4. refusals are self-describing: unknown input keys on a body-less
+//   2. listOperations() enumerates the surface
+//   3. refusals are self-describing: unknown input keys on a body-less
 //      operation list the valid params; nested paths point at operationIds
 //
 // One OPTIONAL live petstore smoke stays at the end, tolerant by design — a
@@ -49,21 +47,6 @@ test(
         worker: { type: "loopback" },
       },
     });
-
-    // (2) ONE provide is enough: the loopback probe deadline absorbs the
-    // cold project chain (itx.ts SELF_DESCRIPTION_LOOPBACK_TIMEOUT_MS), so
-    // the journaled meta carries the spec-derived surface immediately.
-    const entry = (await projectItx.describe()).capabilities.find(
-      (candidate) => candidate.name === "fixture",
-    ) as { instructions?: string; types?: string };
-    expect(entry.types).toContain(
-      "declare function getPet(input: { petId: number }): " +
-        "Promise<{ id: number; name: string; tag?: string }>;",
-    );
-    expect(entry.types).toContain(
-      'declare function listPets(input: { status: "available" | "pending" | "sold"; limit?: number })',
-    );
-    expect(entry.instructions ?? "").toContain("Itx OpenAPI Fixture");
 
     const handle = projectItx as never as Record<string, any>;
 

--- a/apps/os/src/itx/examples.ts
+++ b/apps/os/src/itx/examples.ts
@@ -623,11 +623,9 @@ await itx.provideCapability({
 // Flat operationIds, one merged input object, through project egress.
 const pets = await itx.petstore.findPetsByStatus({ status: "available" });
 
-// describe() now carries spec-derived TypeScript — the provider answered
-// the platform's provide-time describeItx probe, no callsite ceremony.
-const { capabilities } = await itx.describe();
-const entry = capabilities.find((cap) => cap.name === "petstore");
-return { count: pets.length, types: entry.types.split("\\n").slice(0, 3) };
+// listOperations() enumerates the surface the spec describes.
+const operations = await itx.petstore.listOperations();
+return { count: pets.length, operations: operations.slice(0, 3) };
 `.trim(),
   },
   {

--- a/apps/os/src/itx/itx.test.ts
+++ b/apps/os/src/itx/itx.test.ts
@@ -116,13 +116,9 @@ describe("provide + longest-prefix invoke", () => {
     const result = await itx.invoke({ args: [{ text: "hi" }], path: ["slack", "chat", "post"] });
 
     expect(result).toMatchObject({ path: ["chat", "post"] });
-    // Two dials: the provide-time describeItx probe (self-description hook;
-    // a typeless rpc provide always asks once), then the invoke itself.
-    expect(dialed).toHaveLength(2);
-    expect(dialed[0]).toMatchObject({
-      call: { args: [], path: ["describeItx"] },
-      disposed: true,
-    });
+    // ONE dial: provide is a pure append (it never dials), so the only dial
+    // is the invoke itself.
+    expect(dialed).toHaveLength(1);
     expect(dialed.at(-1)).toMatchObject({
       address: AI_ADDRESS,
       attribution: { capabilityPath: "slack", origin: { address: SELF_ADDRESS, id: "prj_1" } },
@@ -170,95 +166,41 @@ describe("provide + longest-prefix invoke", () => {
   });
 });
 
-describe("provide-time self-description (describeItx)", () => {
-  /** A dial whose target answers the probe — and records every call. */
-  function selfDescribingDial(answer: unknown) {
-    const calls: Array<{ path: string[]; args: unknown[] }> = [];
-    const dial: CapabilityDial = () => ({
-      call: async (input: { path: string[]; args: unknown[] }) => {
-        calls.push(input);
-        if (input.path.join(".") === "describeItx") return answer;
-        return "called";
-      },
-    });
-    return { calls, dial };
-  }
+describe("provide is a pure journal append (no provider-code calls)", () => {
+  test("a typeless rpc provide dials NOTHING — provide never calls the target", async () => {
+    // Regression: a provide-time describeItx probe re-entered an agent's own
+    // Durable Object mid-wake and broke agents in prod. provide must append
+    // and return; the target is only dialed on invoke. Self-description is
+    // caller-supplied (instructions/types at provide time).
+    const dial = vi.fn();
+    const itx = makeItx({ dial: dial as unknown as CapabilityDial });
+    await itx.provideCapability({ capability: AI_ADDRESS, name: "ai" });
+    await itx.provideCapability({ capability: LOOPBACK_ADDRESS, name: "petstore" });
+    expect(dial).not.toHaveBeenCalled();
+    expect(await itx.describe()).toMatchObject([
+      { name: "ai", types: undefined },
+      { name: "petstore", types: undefined },
+    ]);
+  });
 
-  test("a typeless rpc provide journals the target's own types + instructions", async () => {
-    const { calls, dial } = selfDescribingDial({
+  test("caller-supplied instructions + types are journaled verbatim", async () => {
+    const { events, journal } = fakeJournal();
+    const itx = makeItx({ journal });
+    await itx.provideCapability({
+      capability: LOOPBACK_ADDRESS,
       instructions: "Petstore. listOperations() first.",
+      name: "petstore",
       types: "declare function findPetsByStatus(input: { status: string }): Promise<unknown>;",
     });
-    const { events, journal } = fakeJournal();
-    const itx = makeItx({ dial, journal });
-
-    await itx.provideCapability({ capability: LOOPBACK_ADDRESS, name: "petstore" });
-    expect(calls).toEqual([{ args: [], path: ["describeItx"] }]);
-    // The enrichment is IN the journaled event — the record, not a patch.
     expect(events[0]!.payload).toMatchObject({
       meta: {
         instructions: "Petstore. listOperations() first.",
         types: expect.stringContaining("declare function findPetsByStatus"),
       },
     });
-    expect(await itx.describe()).toMatchObject([
-      { instructions: "Petstore. listOperations() first.", name: "petstore" },
-    ]);
   });
 
-  test("explicit caller values win; caller-supplied types skip the probe entirely", async () => {
-    const { calls, dial } = selfDescribingDial({ instructions: "theirs", types: "their types" });
-    const itx = makeItx({ dial });
-
-    await itx.provideCapability({
-      capability: LOOPBACK_ADDRESS,
-      instructions: "mine",
-      name: "a",
-    });
-    expect(await itx.describe()).toMatchObject([
-      { instructions: "mine", name: "a", types: "their types" },
-    ]);
-
-    calls.length = 0;
-    await itx.provideCapability({ capability: LOOPBACK_ADDRESS, name: "b", types: "mine" });
-    expect(calls).toEqual([]); // no probe — nothing to fill
-    expect(await itx.describe()).toMatchObject([{ name: "a" }, { name: "b", types: "mine" }]);
-  });
-
-  test("a throwing or garbage-answering target never blocks or fails the provide", async () => {
-    const throwingDial: CapabilityDial = () => ({
-      call: async () => {
-        throw new Error("no such method");
-      },
-    });
-    const itx = makeItx({ dial: throwingDial });
-    await itx.provideCapability({ capability: AI_ADDRESS, name: "ai" });
-    expect(await itx.describe()).toMatchObject([{ name: "ai", types: undefined }]);
-
-    const garbage = makeItx({ dial: selfDescribingDial(42).dial });
-    await garbage.provideCapability({ capability: AI_ADDRESS, name: "ai" });
-    expect(await garbage.describe()).toMatchObject([{ name: "ai", types: undefined }]);
-  });
-
-  test("an oversized describeItx answer is truncated before it is journaled", async () => {
-    const { dial } = selfDescribingDial({ types: "x".repeat(80 * 1024) });
-    const { events, journal } = fakeJournal();
-    const itx = makeItx({ dial, journal });
-    await itx.provideCapability({ capability: LOOPBACK_ADDRESS, name: "huge" });
-
-    const journaled = (events[0]!.payload as { meta: { types: string } }).meta.types;
-    expect(journaled.length).toBeLessThan(65 * 1024);
-    expect(journaled).toContain("truncated by the platform");
-    // Caller-supplied values are the caller's business — never truncated.
-    await itx.provideCapability({
-      capability: LOOPBACK_ADDRESS,
-      name: "mine",
-      types: "y".repeat(80 * 1024),
-    });
-    expect((events[1]!.payload as { meta: { types: string } }).meta.types).toHaveLength(80 * 1024);
-  });
-
-  test("live provides are never probed", async () => {
+  test("live provides are never dialed", async () => {
     const dial = vi.fn();
     const itx = makeItx({ dial: dial as unknown as CapabilityDial });
     await itx.provideCapability({ capability: { run: async () => 1 }, name: "live" });

--- a/apps/os/src/itx/itx.ts
+++ b/apps/os/src/itx/itx.ts
@@ -128,17 +128,6 @@ export type ItxStub = {
   invoke(input: { path: string[]; args: unknown[]; origin?: ItxOrigin }): Promise<unknown>;
 };
 
-/** How long a provide waits for a target's optional describeItx answer.
- * Loopback dials get longer: a first-party client's first probe may ride a
- * cold project chain and fetch real data (OpenApiClient fetches its spec);
- * everything else stays snappy — a miss just means an unenriched provide. */
-const SELF_DESCRIPTION_TIMEOUT_MS = 3_000;
-const SELF_DESCRIPTION_LOOPBACK_TIMEOUT_MS = 15_000;
-
-/** Probe-derived strings are journaled forever; cap them so a pathological
- * spec cannot bloat the record. Caller-supplied values are never touched. */
-const SELF_DESCRIPTION_META_BUDGET = 64 * 1024;
-
 export class CapabilityOfflineError extends Error {
   constructor(name: string) {
     super(
@@ -319,31 +308,13 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
       this.#registerLiveStub(name, live);
     }
 
-    // The self-description doctrine's provide-time hook: instructions +
-    // types belong in the journaled meta AT PROVIDE TIME, and the target
-    // knows its own surface best at exactly that moment. An rpc provide
-    // with no caller-supplied `types` is dialed ONCE and asked
-    // (`describeItx` — a reserved protocol name, so user paths can never
-    // collide); explicit caller values always win. The probe is a
-    // best-effort, SIDE-EFFECTFUL call into provider code at provide time
-    // (an OpenApiClient probe fetches its spec). Strictly best-effort:
-    // any failure or the timeout means the provide proceeds unenriched.
-    // Only call-implementing targets (OpenApiClient, …) can answer —
-    // member-shaped source caps hit replayPathCall's reserved gate, which
-    // is the collision protection doing its job.
-    if (kind === "rpc" && meta.types === undefined) {
-      const described = await this.#dialSelfDescription(
-        name,
-        input.capability as CapabilityAddress,
-      );
-      if (typeof described?.types === "string") {
-        meta.types = truncateSelfDescription(described.types);
-      }
-      if (typeof described?.instructions === "string" && meta.instructions === undefined) {
-        meta.instructions = truncateSelfDescription(described.instructions);
-      }
-    }
-
+    // provide is a PURE JOURNAL APPEND — it never calls into provider code.
+    // (An earlier provide-time `describeItx` probe dialed the target to
+    // auto-fill `types`; it was removed after it broke agents in prod: an
+    // agent re-providing its tool caps re-entered its own Durable Object
+    // mid-wake through the probe. Self-description stays caller-supplied:
+    // pass `instructions`/`types` at provide time. `describeItx` remains a
+    // reserved protocol name.)
     try {
       await this.#append(ITX_EVENT_TYPES.capabilityProvided, {
         address: kind === "live" ? null : (input.capability as CapabilityAddress),
@@ -479,47 +450,6 @@ export class Itx extends StreamProcessor<typeof ItxContract, ItxDeps, ItxIterate
       throw error;
     } finally {
       disposeIfPossible(borrowed);
-    }
-  }
-
-  /** Provide-time self-description (see provideCapability): one dial, one
-   * `describeItx` call, a short deadline, and null on ANY miss — never an
-   * error, never a hang. The losing in-flight call is observed so a late
-   * rejection cannot become unhandled. */
-  async #dialSelfDescription(
-    name: string,
-    address: CapabilityAddress,
-  ): Promise<{ instructions?: string; types?: string } | null> {
-    let borrowed: PathCallable | undefined;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    try {
-      borrowed = this.deps.dial(address, {
-        capabilityPath: name,
-        origin: { address: this.deps.selfAddress, id: this.deps.contextId },
-      });
-      const call = Promise.resolve(borrowed.call({ args: [], path: [SELF_DESCRIPTION_METHOD] }));
-      call.catch(() => {});
-      const deadlineMs =
-        address.type === "rpc" && address.worker.type === "loopback"
-          ? SELF_DESCRIPTION_LOOPBACK_TIMEOUT_MS
-          : SELF_DESCRIPTION_TIMEOUT_MS;
-      const result = await Promise.race([
-        call,
-        new Promise<null>((resolve) => {
-          timer = setTimeout(() => resolve(null), deadlineMs);
-        }),
-      ]);
-      if (result == null || typeof result !== "object") return null;
-      const { instructions, types } = result as { instructions?: unknown; types?: unknown };
-      return {
-        ...(typeof instructions === "string" ? { instructions } : {}),
-        ...(typeof types === "string" ? { types } : {}),
-      };
-    } catch {
-      return null;
-    } finally {
-      if (timer !== undefined) clearTimeout(timer);
-      if (borrowed) disposeIfPossible(borrowed);
     }
   }
 
@@ -811,16 +741,6 @@ export function isLocalBareFunction(
   if (typeof capability !== "function") return false;
   const proto = Object.getPrototypeOf(capability) as object | null;
   return proto === Function.prototype || proto === ASYNC_FUNCTION_PROTOTYPE;
-}
-
-/** Cap one probe-derived string against the journaled-meta budget, with an
- * honest note where the cut happened. */
-function truncateSelfDescription(value: string): string {
-  if (value.length <= SELF_DESCRIPTION_META_BUDGET) return value;
-  return (
-    value.slice(0, SELF_DESCRIPTION_META_BUDGET) +
-    "\n// … truncated by the platform: the describeItx answer exceeded the 64KB journaled-meta budget."
-  );
 }
 
 /** Wrap a bare local function so it speaks the one calling convention:


### PR DESCRIPTION
## Incident
Agents stopped responding on prd after the itx PRs (#1493, #1498) deployed.

## Root cause — a two-PR interaction
- **#1493** bumped the agent capability-set version `"2"` → `"3"`, so every existing agent **re-provides its tool capabilities** on its first wake after the deploy.
- **#1498** added a provide-time `describeItx` hook: `provideCapability` dialed every typeless `rpc` capability and called `describeItx` on it to auto-fill `types`.

For an agent's own tool caps (`chat`/`debug`), the target is `AgentToolsCapability`, whose `call()` does `env.AGENT.getByName(self).callAgentTool(...)` — **the AgentDurableObject RPC-calling itself by name while it is blocked mid-wake** (re-entrant self-dial). `gmail`/`slack` fired bogus `describeItx` calls at Google/Slack. Each stalled to the 15s self-description timeout, so the agent's first post-deploy turn never completed.

The structural defect: `provideCapability` — which must be a pure journal append — was calling into arbitrary, side-effectful provider code.

## Fix
`provideCapability` is a pure append again; it never calls into provider code. Self-description stays **caller-supplied** (`instructions`/`types` at provide time). `describeItx` remains a reserved protocol name. Removed the probe, `#dialSelfDescription`, the timeout/budget constants, and `truncateSelfDescription`. `OpenApiClient`/`McpClient` keep their `describeItx` handlers (harmless, reserved-gated) for a possible future *describe()-time* (read-only) enrichment.

**Existing agents recover on their next wake** — the re-provide is now a plain append.

## Verification
- Core unit tests updated to assert provide dials nothing; 269 apps/os unit tests + the three workerd suites (project-ingress, itx-stream-subscribe, project-mcp-server-connection) green; typecheck/lint/format/knip clean.
- Preview e2e will exercise the full agent + itx surface on real infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-12T08:26:01.359Z",
      "headSha": "013031639be2dd2afe07b2beaab1fb37ed01a913",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27403733273",
      "shortSha": "0130316"
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-12T08:25:48.872Z",
      "headSha": "013031639be2dd2afe07b2beaab1fb37ed01a913",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27403733273",
      "shortSha": "0130316"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `0130316`
Preview: https://auth.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27403733273)
Updated: 2026-06-12T08:26:01.359Z

### OS
Status: released
Commit: `0130316`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27403733273)
Updated: 2026-06-12T08:25:48.872Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core itx provide semantics on the hot path for agents and all capability registration; wrong behavior could break tool provisioning or self-description, though the change restores the pre-probe model and is heavily tested.
> 
> **Overview**
> **Hotfix for agents stuck on prod:** `provideCapability` is again a **pure journal append** — it no longer dials typeless `rpc` caps and calls **`describeItx`** at provide time. That probe could re-enter an agent DO during wake (after capability-set re-provide) and block turns for up to the self-description timeout. **Self-description is caller-supplied** via `instructions` / `types` on provide; targets are only dialed on **invoke**.
> 
> Tests and docs are aligned with the new contract: unit tests assert provide never calls the dial; OpenAPI e2e/examples drop expectations of auto-journaled `types` from the probe; secrets tests clarify `describeItx` stays a reserved protocol path.
> 
> The diff also adds **`apps/os/docs/itx-explainer.html`**, a large offline explainer with embedded “toy itx” demos (the toy still documents provide-time `describeItx` in places — worth reconciling with the hotfix if that page ships as ground truth).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 013031639be2dd2afe07b2beaab1fb37ed01a913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->