### PR TITLE
auth: fix 20s /login SSR hang (global_fetch_strictly_public) + sign-in pending state

### DIFF
--- a/apps/auth/alchemy.run.ts
+++ b/apps/auth/alchemy.run.ts
@@ -114,6 +114,10 @@ const worker = await TanStackStart(APP_NAME, {
   },
   routes: alchemyEnv.WORKER_ROUTES.map((pattern) => ({ pattern: `${pattern}/*`, adopt: true })),
   adopt: true,
+  // Without this flag, same-zone subrequests (e.g. SSR calling our own
+  // /api/auth/get-session via the public hostname) bypass Worker routes and
+  // hang against the originless zone for ~20s per page load.
+  compatibilityFlags: ["global_fetch_strictly_public"],
   assets: {
     not_found_handling: "single-page-application",
     run_worker_first: ["/api/*"],

--- a/apps/os/src/routes/sign-in.$.tsx
+++ b/apps/os/src/routes/sign-in.$.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 import { useAuthClient } from "@iterate-com/auth/client";
@@ -21,6 +22,7 @@ function SignInRoute() {
   const { signIn } = useAuthClient();
   const { redirect_url: redirectUrl } = Route.useSearch();
   const returnTo = safeRedirectPath(redirectUrl);
+  const [redirecting, setRedirecting] = useState(false);
 
   return (
     <main className="grid min-h-svh place-items-center bg-background p-4">
@@ -30,8 +32,16 @@ function SignInRoute() {
           <CardDescription>Continue with Iterate to open your projects.</CardDescription>
         </CardHeader>
         <CardContent>
-          <Button className="w-full" size="lg" onClick={() => signIn({ returnTo })}>
-            Continue with Iterate
+          <Button
+            className="w-full"
+            size="lg"
+            disabled={redirecting}
+            onClick={() => {
+              setRedirecting(true);
+              signIn({ returnTo });
+            }}
+          >
+            {redirecting ? "Redirecting…" : "Continue with Iterate"}
           </Button>
         </CardContent>
       </Card>


### PR DESCRIPTION
## What

- Add `compatibilityFlags: ["global_fetch_strictly_public"]` to the auth worker (`apps/auth/alchemy.run.ts`).
- Give the OS sign-in button a disabled "Redirecting…" pending state.

## Why

The auth worker's `/login` route SSRs a `beforeLoad` that calls `authClient.getSession()`, which fetches the worker's **own public hostname**. Without `global_fetch_strictly_public`, that same-zone subrequest bypasses Worker routes and hangs against the originless zone for ~20s per page load — the error is swallowed by `.catch(() => null)`, so the page eventually renders and nothing is logged. Every environment of the auth worker had `/login` TTFB of 20–34s (dev-global, previews, and almost certainly prd), which presented as the "stuck login button" / multi-click / super-slow sign-in flow.

The OS worker already carries this flag for exactly the same reason (#1368, see the comment in `apps/os/alchemy.run.ts`).

## Verified

- `auth.iterate-dev.com/login`: **20–34s → 0.1–0.4s** TTFB (deployed out-of-band from this branch).
- `auth.iterate-preview-9.com/login`: **20s → 0.4s**.
- Full email-OTP login flow (`+test` / 424242) verified end-to-end in a real browser against two parallel local dev worktrees and against preview slot 9.

⚠️ dev-global and preview_9 auth already run this code; **prd auth should be redeployed after merge** to pick up the fix.

## Related ops fixes (no code in this PR)

- The legacy `ITERATE_AUTH_JWKS` var in the **root `os/preview` Doppler config** (inherited by all `preview_N`) and in `os/dev_jonas` held **prd's** auth signing key and overrode the deploy-time JWKS fetch (`apps/os/alchemy.run.ts:49`), so every preview OS rejected valid sessions and bounced logins back to `/sign-in`. Deleted from both; `os/prd` still has it (matches live, harmless). Follow-up: drop the `?? process.env.ITERATE_AUTH_JWKS` legacy fallback and the prd var.
- Preview "Log in with Google" fails with `redirect_uri_mismatch`: `https://auth.iterate-preview-N.com/api/auth/callback/google` is not registered on the shared Google OAuth client — needs Google Cloud Console registration, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-12T08:39:27.986Z",
      "headSha": "d9af44b5d627656a544974281687124de0568a9d",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27404194672",
      "shortSha": "d9af44b"
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-12T08:39:16.222Z",
      "headSha": "d9af44b5d627656a544974281687124de0568a9d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27404194672",
      "shortSha": "d9af44b"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `d9af44b`
Preview: https://auth.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27404194672)
Updated: 2026-06-12T08:39:27.986Z

### OS
Status: released
Commit: `d9af44b`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27404194672)
Updated: 2026-06-12T08:39:16.222Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Infra compatibility flag aligned with existing OS config plus a small UI pending state; no auth logic or data model changes.
> 
> **Overview**
> Fixes **~20s SSR hangs** on auth `/login` by enabling Cloudflare `global_fetch_strictly_public` on the auth worker—the same flag the OS worker already uses. Same-zone fetches to the worker’s own public hostname (e.g. session checks during SSR) were bypassing Worker routes and stalling on the originless zone.
> 
> The OS **sign-in** page now disables the button and shows **“Redirecting…”** after click so users don’t double-submit while navigation to auth starts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9af44b5d627656a544974281687124de0568a9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->