### PR TITLE
docs: clarify dev vs dev_<user> config choice and Google sign-in portability

### DIFF
--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -40,14 +40,31 @@ pnpm dev          # fully-local OS dev server on http://os.localhost:<port>
   `DOPPLER_CONFIG` env var → `doppler setup` scope for the worktree → shared
   `dev`. The scope (via the repo's `doppler.yaml`) is the intended mechanism;
   the env var is a one-off override.
-- **Which config?** `dev` is the shared fully-local config — works for
-  everyone, any number of parallel worktrees. `dev_<you>` is your personal
-  _tunnel-backed_ config: fixed port 5173 plus a cloudflared tunnel claiming
-  `os.iterate-dev-<you>.com` — only one worktree can usefully hold that
-  tunnel at a time, so use it in the worktree where you need webhooks and
-  scope everything else (especially agent worktrees) to `dev`. The startup
-  banner prints `Stage: <config>` — if it doesn't say `dev`, you're not
-  fully local.
+- **Which config?** Scope every worktree to `dev` by default — the shared
+  fully-local config works for everyone, any number of parallel worktrees,
+  with full sign-in (Google and email OTP) via `auth.iterate-dev.com`. Reach
+  for `dev_<you>` in exactly **one** worktree, and only when you need inbound
+  webhooks (practically: Slack — see
+  [Tunnels and webhooks](#tunnels-and-webhooks)).
+
+  `dev_<you>` is not a different kind of environment; it is `dev` plus
+  precisely two things: a _tunnel identity_ (`APP_CONFIG_BASE_URL =
+  https://os.iterate-dev-<you>.com`, fixed port 5173, a cloudflared tunnel
+  claiming that hostname, `iterate-dev-<you>.app` project hostnames) and your
+  _personal Slack app credentials_ (`APP_CONFIG_INTEGRATIONS__SLACK`, whose
+  delivery URL on Slack's side points at that tunnel hostname). Auth is
+  identical to `dev`: same `os-local-dev` client, same
+  `auth.iterate-dev.com`. Only one worktree can usefully hold the tunnel at a
+  time, so scope everything else (especially agent worktrees) to `dev`. The
+  startup banner prints `Stage: <config>` — if it doesn't say `dev`, you're
+  not fully local.
+
+  Don't (re)introduce legacy `ITERATE_OAUTH_*` / `ITERATE_AUTH_JWKS` vars in
+  these configs: an explicit JWKS in Doppler overrides the deploy-time fetch
+  from the auth worker, and a stale one makes OS silently reject every
+  session — login just bounces back to `/sign-in` with no error. (This broke
+  all `dev_<user>` and preview logins once; cleaned out of `dev_*` and the
+  `preview` root on 2026-06-12.)
 - The chosen port is baked into the env (`APP_CONFIG_BASE_URL`) at startup and
   recorded in **`apps/os/.alchemy/dev-server.json`** (`{pid, port, baseUrl}`).
   Scripts and CLIs that need "the local dev server" read that file — no
@@ -61,6 +78,10 @@ pnpm dev          # fully-local OS dev server on http://os.localhost:<port>
 - Sign in as a human with Google or email OTP via `auth.iterate-dev.com` — the
   shared `os-local-dev` OAuth client accepts any localhost port. Your identity
   there persists across every worktree and environment on your machine.
+  Google sign-in needs no per-port (or per-worktree) setup because Google
+  never sees your dev server: the only redirect URI it checks is
+  `auth.iterate-dev.com`'s own callback, and the OS↔auth hop uses the
+  port-agnostic loopback client above.
 - Sign in as an agent/test: mint it (next section). Never script the OAuth
   dance.
 - Test emails: any address matching `+...test@` (e.g. `alice+test@nustom.com`)

--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -49,7 +49,7 @@ pnpm dev          # fully-local OS dev server on http://os.localhost:<port>
 
   `dev_<you>` is not a different kind of environment; it is `dev` plus
   precisely two things: a _tunnel identity_ (`APP_CONFIG_BASE_URL =
-  https://os.iterate-dev-<you>.com`, fixed port 5173, a cloudflared tunnel
+https://os.iterate-dev-<you>.com`, fixed port 5173, a cloudflared tunnel
   claiming that hostname, `iterate-dev-<you>.app` project hostnames) and your
   _personal Slack app credentials_ (`APP_CONFIG_INTEGRATIONS__SLACK`, whose
   delivery URL on Slack's side points at that tunnel hostname). Auth is
@@ -65,6 +65,7 @@ pnpm dev          # fully-local OS dev server on http://os.localhost:<port>
   session — login just bounces back to `/sign-in` with no error. (This broke
   all `dev_<user>` and preview logins once; cleaned out of `dev_*` and the
   `preview` root on 2026-06-12.)
+
 - The chosen port is baked into the env (`APP_CONFIG_BASE_URL`) at startup and
   recorded in **`apps/os/.alchemy/dev-server.json`** (`{pid, port, baseUrl}`).
   Scripts and CLIs that need "the local dev server" read that file — no


### PR DESCRIPTION
Follow-up to #1503 and today's dev/preview login debugging. Doc-only.

- **Which config?** now leads with the rule of thumb: scope every worktree to `dev`; use `dev_<you>` in exactly one worktree, only for inbound webhooks (Slack).
- Enumerates what `dev_<you>` actually is — `dev` + tunnel identity (`os.iterate-dev-<you>.com`, port 5173, `.app` hostnames) + personal Slack credentials — and that auth is identical to `dev`.
- Warns against reintroducing legacy `ITERATE_OAUTH_*` / `ITERATE_AUTH_JWKS` Doppler vars: a stale explicit JWKS overrides the deploy-time fetch and silently bounces every login (this had broken all `dev_<user>` and preview slot logins; the vars were purged from `dev_*` and the `preview` root today).
- Notes why Google sign-in works on any random dev port with zero setup (Google only ever sees `auth.iterate-dev.com`'s callback; the OS↔auth hop is the port-agnostic loopback client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no code, config, or deploy behavior changes.
> 
> **Overview**
> Expands **`docs/dev-environments.md`** so engineers pick Doppler configs correctly and avoid a known login footgun—no runtime changes.
> 
> **Which config?** now states the default: scope every worktree to shared **`dev`**; use **`dev_<you>`** in exactly one worktree when inbound webhooks matter (mainly Slack). It clarifies that **`dev_<you>`** is **`dev` plus** a tunnel identity (`os.iterate-dev-<you>.com`, port 5173, `.app` hostnames) and personal Slack credentials—not a separate auth stack (same `os-local-dev` / `auth.iterate-dev.com`).
> 
> Adds a **do not reintroduce** warning for legacy **`ITERATE_OAUTH_*`** / **`ITERATE_AUTH_JWKS`** in Doppler: a stale explicit JWKS overrides deploy-time fetch from the auth worker and can silently reject sessions (login loops to `/sign-in`).
> 
> Documents **why Google sign-in works on any dev port**: Google only validates `auth.iterate-dev.com`’s callback; the OS↔auth hop uses the port-agnostic loopback OAuth client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b0d77701717c83b31cef3a3b40aa058ebdc4319. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->