### PR TITLE
refactor: agents are just streams — explorer-based listing, drop catalog

### DIFF
--- a/apps/os-contract/src/index.ts
+++ b/apps/os-contract/src/index.ts
@@ -115,15 +115,6 @@ export const ProjectSecretSummary = z.object({
 });
 export type ProjectSecretSummary = z.output<typeof ProjectSecretSummary>;
 
-export const AgentRecord = z.object({
-  agentPath: StreamPath,
-  name: z.string(),
-  projectId: z.string(),
-  createdAt: z.string(),
-  lastWokenAt: z.string(),
-});
-export type AgentRecord = z.output<typeof AgentRecord>;
-
 export const RepoRecord = z.object({
   createdAt: z.string(),
   lastWokenAt: z.string(),
@@ -277,15 +268,6 @@ export const osContract = oc.router({
       .input(ProjectScopedInput)
       .output(z.unknown()),
     agents: {
-      list: oc
-        .route({
-          method: "GET",
-          path: "/projects/{projectSlugOrId}/agents",
-          description: "List agents for a project",
-          tags: ["/project", "/agents"],
-        })
-        .input(ProjectScopedInput)
-        .output(z.object({ agents: z.array(AgentRecord) })),
       listPresets: oc
         .route({
           method: "GET",

--- a/apps/os/src/components/stream-explorer.tsx
+++ b/apps/os/src/components/stream-explorer.tsx
@@ -9,17 +9,24 @@ export function StreamExplorerTreePage({
   currentPath,
   header,
   onOpenPath,
+  rootPath,
   source,
 }: {
   currentPath?: StreamPathType;
   header?: ReactNode;
   onOpenPath: (streamPath: StreamPathType) => void;
+  rootPath?: StreamPathType;
   source: StreamTreeSource;
 }) {
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-3 p-4">
       {header == null ? null : <div className="min-w-0">{header}</div>}
-      <StreamTreeBrowser source={source} currentPath={currentPath} onOpenPath={onOpenPath} />
+      <StreamTreeBrowser
+        source={source}
+        currentPath={currentPath}
+        onOpenPath={onOpenPath}
+        rootPath={rootPath}
+      />
     </section>
   );
 }

--- a/apps/os/src/components/stream-tree-browser.tsx
+++ b/apps/os/src/components/stream-tree-browser.tsx
@@ -83,16 +83,20 @@ function useLiveStreamState(input: {
 export function StreamTreeBrowser({
   currentPath,
   onOpenPath,
+  rootPath = StreamPath.parse("/"),
   source,
 }: {
   currentPath?: StreamPathType;
   onOpenPath: (streamPath: StreamPathType) => void;
+  /** The stream the tree is rooted at — defaults to the project root. Pass a
+   * subtree (e.g. `/agents`) to scope the browser to it. */
+  rootPath?: StreamPathType;
   source: StreamTreeSource;
 }) {
   const [expandedPaths, setExpandedPaths] = useState<ReadonlySet<StreamPathType>>(
-    () => new Set<StreamPathType>(["/"]),
+    () => new Set<StreamPathType>([rootPath]),
   );
-  const root = useLiveStreamState({ enabled: true, source, streamPath: StreamPath.parse("/") });
+  const root = useLiveStreamState({ enabled: true, source, streamPath: rootPath });
 
   function toggleExpanded(path: StreamPathType) {
     setExpandedPaths((previous) => {
@@ -148,7 +152,7 @@ export function StreamTreeBrowser({
           onToggleExpanded={toggleExpanded}
           source={source}
           state={root.node.state}
-          streamPath={StreamPath.parse("/")}
+          streamPath={rootPath}
         />
       </div>
     </div>

--- a/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
+++ b/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
@@ -91,10 +91,9 @@ export type AgentDurableObjectEnv = {
   AI: CloudflareAiBinding;
   APP_CONFIG: string;
   ITX_CONTEXT: DurableObjectNamespace<ItxDurableObject>;
-  // The DO object-catalog D1 — the project→agents enumeration index behind
-  // `project.agents.list`, plus the incidental `itx.debug()` project-slug read.
-  // It indexes agents by their stream coordinate; it has no bearing on how an
-  // agent is addressed (that derives from the self-describing name).
+  // Shared app D1 — read-only here, for the `itx.debug()` project-slug lookup.
+  // The agent writes NO object-catalog projection: it is listed by walking the
+  // /agents stream tree and addressed by its self-describing name.
   DO_CATALOG: D1Database;
   REPO: DurableObjectNamespace<RepoDurableObject>;
   STREAM: DurableObjectNamespace<StreamDurableObject>;
@@ -129,21 +128,15 @@ type AgentStreamApi = Omit<
 
 // An agent IS a context, and its identity IS its stream coordinate:
 // `{projectId}:{agentPath}` (no opaque JSON name). The lifecycle base parses
-// that directly via the AgentDurableObjectName codec. The D1 object catalog is
-// retained ONLY as the project→agents enumeration index that
-// `project.agents.list` reads (the stream tree has no cheap createdAt/
-// lastWokenAt projection); it no longer has any bearing on how an agent is
-// addressed — that is fully derived from the self-describing name.
+// that directly via the AgentDurableObjectName codec. No D1 object catalog —
+// agents are listed by walking the `/agents` stream tree (the UI is just the
+// stream explorer scoped to /agents), and addressed by their self-describing
+// coordinate; nothing enumerates them through a catalog.
 const AgentLifecycleBase = createIterateDurableObjectBase<
   typeof AgentDurableObjectName,
-  Pick<AgentDurableObjectEnv, "DO_CATALOG">
+  AgentDurableObjectEnv
 >({
   className: "AgentDurableObject",
-  getDatabase: (env) => env.DO_CATALOG,
-  indexes: {
-    agentPath: (params) => params.agentPath,
-    projectId: (params) => params.projectId,
-  },
   nameSchema: AgentDurableObjectName,
 });
 

--- a/apps/os/src/lib/project-route-query.ts
+++ b/apps/os/src/lib/project-route-query.ts
@@ -31,13 +31,6 @@ export function projectLifecycleStateQueryOptions(projectId: string) {
   };
 }
 
-export function projectAgentsListQueryOptions(projectId: string) {
-  return {
-    ...orpc.project.agents.list.queryOptions({ input: { projectSlugOrId: projectId } }),
-    staleTime: PROJECT_CHILD_ROUTE_STALE_TIME,
-  };
-}
-
 export function projectAgentPresetsQueryOptions(projectId: string) {
   return {
     ...orpc.project.agents.listPresets.queryOptions({ input: { projectSlugOrId: projectId } }),

--- a/apps/os/src/orpc/routers/agents.ts
+++ b/apps/os/src/orpc/routers/agents.ts
@@ -1,5 +1,4 @@
 import { env } from "cloudflare:workers";
-import { listD1ObjectCatalogRecordsByIndex } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
 import { getInitializedDoStub } from "@iterate-com/shared/durable-object-utils/mixins/with-lifecycle-hooks";
 import type { Event, EventInput, StreamPath } from "@iterate-com/shared/streams/types";
 import {
@@ -14,7 +13,6 @@ import {
   type AgentLlmProvider,
 } from "~/domains/agents/agent-presets.ts";
 import {
-  type AgentDurableObjectStructuredName,
   AGENTS_STREAM_PATH,
   getAgentDurableObjectName,
 } from "~/domains/agents/durable-objects/agent-durable-object.ts";
@@ -22,30 +20,6 @@ import { os, projectScopeMiddleware } from "~/orpc/orpc.ts";
 import { requireProjectScope } from "~/orpc/project-access.ts";
 
 export const projectAgentsRouter = {
-  list: os.project.agents.list.use(projectScopeMiddleware).handler(async ({ context }) => {
-    const project = requireProjectScope(context);
-    const records = await listD1ObjectCatalogRecordsByIndex<AgentDurableObjectStructuredName>(
-      env.DB,
-      {
-        className: "AgentDurableObject",
-        indexName: "projectId",
-        indexValue: project.id,
-      },
-    );
-
-    return {
-      agents: records
-        .filter((record) => record.structuredName.agentPath.startsWith("/agents/"))
-        .map((record) => ({
-          agentPath: record.structuredName.agentPath,
-          createdAt: record.createdAt,
-          lastWokenAt: record.lastWokenAt,
-          name: record.name,
-          projectId: record.structuredName.projectId,
-        })),
-    };
-  }),
-
   listPresets: os.project.agents.listPresets
     .use(projectScopeMiddleware)
     .handler(async ({ context }) => {

--- a/apps/os/src/routes/_app/projects/$projectSlug/agents/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/agents/index.tsx
@@ -1,284 +1,50 @@
-import { useMemo, useState } from "react";
-import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
-import { Button } from "@iterate-com/ui/components/button";
-import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@iterate-com/ui/components/empty";
-import { EventsStreamPathLabel } from "@iterate-com/ui/components/events/stream-path-label";
-import { Input } from "@iterate-com/ui/components/input";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@iterate-com/ui/components/table";
-import { StreamDebugLink } from "~/components/stream-debug-link.tsx";
-import {
-  projectAgentPresetsQueryOptions,
-  projectAgentsListQueryOptions,
-} from "~/lib/project-route-query.ts";
+import { Suspense, useMemo } from "react";
+import type { StreamPath as StreamPathType } from "@iterate-com/shared/streams/types";
+import { StreamPath } from "@iterate-com/shared/streams/types";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { StreamExplorerTreePage } from "~/components/stream-explorer.tsx";
+import { useItx } from "~/itx/use-itx.ts";
+
+const AGENTS_ROOT = StreamPath.parse("/agents");
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/agents/")({
-  loader: async ({ context }) => {
-    const { project } = context;
-    await context.queryClient.ensureQueryData(projectAgentsListQueryOptions(project.id));
-    await context.queryClient.ensureQueryData(projectAgentPresetsQueryOptions(project.id));
-
-    return {
-      breadcrumb: "All",
-      project,
-    };
-  },
+  // Agents ARE streams: the listing is just the stream explorer scoped to
+  // /agents. useItx never SSRs (it throws on the server), and the tree paints
+  // from its own live subscriptions once the socket connects.
+  ssr: false,
+  loader: ({ context }) => ({
+    breadcrumb: "All",
+    project: context.project,
+  }),
   component: ProjectAgentsIndexPage,
 });
 
-type SortKey = "agentPath" | "createdAt" | "lastWokenAt";
-type SortDirection = "asc" | "desc";
-
 function ProjectAgentsIndexPage() {
+  return (
+    <Suspense
+      fallback={<div className="p-4 text-sm text-muted-foreground">Connecting to itx...</div>}
+    >
+      <ProjectAgentsIndexContent />
+    </Suspense>
+  );
+}
+
+function ProjectAgentsIndexContent() {
   const params = Route.useParams();
   const navigate = useNavigate();
   const { project } = Route.useLoaderData();
-  const [filter, setFilter] = useState("");
-  const [sort, setSort] = useState<{ key: SortKey; direction: SortDirection }>({
-    key: "lastWokenAt",
-    direction: "desc",
-  });
-  const agentsQueryOptions = projectAgentsListQueryOptions(project.id);
-  const { data } = useQuery({
-    ...agentsQueryOptions,
-    refetchInterval: 5_000,
-  });
-  const presetsQueryOptions = projectAgentPresetsQueryOptions(project.id);
-  const { data: presetsData } = useQuery(presetsQueryOptions);
-  const agents = useMemo(() => data?.agents ?? [], [data?.agents]);
-  const presets = useMemo(() => presetsData?.presets ?? [], [presetsData?.presets]);
-  const visibleAgents = useMemo(() => {
-    const query = filter.trim().toLowerCase();
-    return agents
-      .filter((agent) => {
-        if (!query) return true;
-        return (
-          agent.agentPath.toLowerCase().includes(query) || agent.name.toLowerCase().includes(query)
-        );
-      })
-      .toSorted((left, right) => {
-        const direction = sort.direction === "asc" ? 1 : -1;
-        return direction * compareAgentRows(left, right, sort.key);
-      });
-  }, [agents, filter, sort]);
+  const itx = useItx(project.id);
+  const source = useMemo(() => (streamPath: StreamPathType) => itx.streams.get(streamPath), [itx]);
 
-  return (
-    <section className="w-full space-y-4 p-4">
-      <div className="flex justify-end">
-        <div className="flex gap-2">
-          <Button
-            type="button"
-            onClick={() =>
-              void navigate({
-                to: "/projects/$projectSlug/agents/new",
-                params,
-              })
-            }
-          >
-            New agent
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() =>
-              void navigate({
-                to: "/projects/$projectSlug/agents/new-preset",
-                params,
-              })
-            }
-          >
-            New preset
-          </Button>
-          <StreamDebugLink label="Open root stream" projectSlug={project.slug} streamPath="/" />
-        </div>
-      </div>
-      <div className="flex w-full flex-col gap-2 md:flex-row">
-        <Input
-          className="h-9 flex-1"
-          placeholder="Filter agent paths..."
-          value={filter}
-          onChange={(event) => setFilter(event.currentTarget.value)}
-        />
-        <div className="flex gap-2 md:shrink-0">
-          <Button
-            type="button"
-            variant="outline"
-            className="flex-1 md:flex-none"
-            onClick={() => setFilter("")}
-          >
-            Reset
-          </Button>
-        </div>
-      </div>
+  function openAgent(streamPath: StreamPathType) {
+    void navigate({
+      to: "/projects/$projectSlug/agents/streams/$",
+      params: {
+        projectSlug: params.projectSlug,
+        _splat: streamPath,
+      },
+    });
+  }
 
-      <div className="space-y-3">
-        <div className="flex items-center justify-between gap-3">
-          <h2 className="text-sm font-semibold">Presets</h2>
-          <span className="text-xs text-muted-foreground">
-            {presets.length === 0
-              ? "No presets configured."
-              : `${presets.length} preset${presets.length === 1 ? "" : "s"} configured.`}
-          </span>
-        </div>
-        {presets.length > 0 ? (
-          <div className="space-y-2">
-            {presets.map((preset) => (
-              <div
-                key={preset.basePath}
-                className="flex items-center justify-between gap-4 rounded-md border bg-card px-3 py-2 text-sm"
-              >
-                <EventsStreamPathLabel path={preset.basePath} className="min-w-0" />
-                <span className="shrink-0 text-xs text-muted-foreground">
-                  {preset.events.length} events
-                </span>
-              </div>
-            ))}
-          </div>
-        ) : null}
-      </div>
-
-      {agents.length === 0 ? (
-        <Empty className="rounded-lg border">
-          <EmptyHeader>
-            <EmptyTitle>No agents</EmptyTitle>
-            <EmptyDescription>
-              Project agents will appear here after they are created.
-            </EmptyDescription>
-          </EmptyHeader>
-        </Empty>
-      ) : (
-        <div className="rounded-lg border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <SortableHead
-                  active={sort.key === "agentPath"}
-                  direction={sort.direction}
-                  label="Agent path"
-                  onClick={() => setSort(nextSort(sort, "agentPath"))}
-                />
-                <SortableHead
-                  active={sort.key === "createdAt"}
-                  direction={sort.direction}
-                  label="Created"
-                  onClick={() => setSort(nextSort(sort, "createdAt"))}
-                />
-                <SortableHead
-                  active={sort.key === "lastWokenAt"}
-                  direction={sort.direction}
-                  label="Woke"
-                  onClick={() => setSort(nextSort(sort, "lastWokenAt"))}
-                />
-                <TableHead className="w-28 text-right">Events</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {visibleAgents.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={4} className="h-24 text-center text-muted-foreground">
-                    No agents match.
-                  </TableCell>
-                </TableRow>
-              ) : (
-                visibleAgents.map((agent) => (
-                  <TableRow key={agent.name}>
-                    <TableCell className="py-3">
-                      <Link
-                        className="block min-w-0 rounded-sm text-sm font-medium hover:underline"
-                        to="/projects/$projectSlug/agents/streams/$"
-                        params={{
-                          projectSlug: params.projectSlug,
-                          // params.stringify on the route converts StreamPath ->
-                          // splat; passing a pre-splatted string would double-encode.
-                          _splat: agent.agentPath,
-                        }}
-                      >
-                        <EventsStreamPathLabel path={agent.agentPath} className="min-w-0" />
-                      </Link>
-                    </TableCell>
-                    <TableCell className="w-40 text-muted-foreground">
-                      {formatRelativeTime(agent.createdAt)}
-                    </TableCell>
-                    <TableCell className="w-40 text-muted-foreground">
-                      {formatRelativeTime(agent.lastWokenAt)}
-                    </TableCell>
-                    <TableCell className="w-28 text-right">
-                      <StreamDebugLink
-                        label="Open"
-                        projectSlug={project.slug}
-                        streamPath={agent.agentPath}
-                      />
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </div>
-      )}
-    </section>
-  );
-}
-
-function SortableHead(input: {
-  active: boolean;
-  direction: SortDirection;
-  label: string;
-  onClick: () => void;
-}) {
-  return (
-    <TableHead>
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="-ml-2 h-8 px-2"
-        onClick={input.onClick}
-      >
-        {input.label}
-        <span className="text-[10px] text-muted-foreground">
-          {input.active ? input.direction : "sort"}
-        </span>
-      </Button>
-    </TableHead>
-  );
-}
-
-function nextSort(current: { key: SortKey; direction: SortDirection }, key: SortKey) {
-  if (current.key !== key) return { key, direction: "asc" as const };
-  return { key, direction: current.direction === "asc" ? ("desc" as const) : ("asc" as const) };
-}
-
-function compareAgentRows(
-  left: { agentPath: string; createdAt: string; lastWokenAt: string },
-  right: { agentPath: string; createdAt: string; lastWokenAt: string },
-  key: SortKey,
-) {
-  if (key === "agentPath") return left.agentPath.localeCompare(right.agentPath);
-  return new Date(left[key]).getTime() - new Date(right[key]).getTime();
-}
-
-function formatRelativeTime(value: string) {
-  const seconds = Math.round((Date.now() - new Date(value).getTime()) / 1000);
-  const absoluteSeconds = Math.abs(seconds);
-  const units = [
-    { label: "year", seconds: 31_536_000 },
-    { label: "month", seconds: 2_592_000 },
-    { label: "day", seconds: 86_400 },
-    { label: "hour", seconds: 3_600 },
-    { label: "minute", seconds: 60 },
-  ] as const;
-  const unit = units.find((unit) => absoluteSeconds >= unit.seconds);
-  if (!unit) return seconds < 0 ? "in a few seconds" : "just now";
-
-  const count = Math.round(absoluteSeconds / unit.seconds);
-  const suffix = count === 1 ? unit.label : `${unit.label}s`;
-  return seconds < 0 ? `in ${count} ${suffix}` : `${count} ${suffix} ago`;
+  return <StreamExplorerTreePage source={source} rootPath={AGENTS_ROOT} onOpenPath={openAgent} />;
 }

--- a/apps/os/src/routes/_app/projects/$projectSlug/agents/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/agents/index.tsx
@@ -1,7 +1,8 @@
 import { Suspense, useMemo } from "react";
 import type { StreamPath as StreamPathType } from "@iterate-com/shared/streams/types";
 import { StreamPath } from "@iterate-com/shared/streams/types";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { buttonVariants } from "@iterate-com/ui/components/button";
 import { StreamExplorerTreePage } from "~/components/stream-explorer.tsx";
 import { useItx } from "~/itx/use-itx.ts";
 
@@ -36,15 +37,47 @@ function ProjectAgentsIndexContent() {
   const itx = useItx(project.id);
   const source = useMemo(() => (streamPath: StreamPathType) => itx.streams.get(streamPath), [itx]);
 
-  function openAgent(streamPath: StreamPathType) {
+  function openPath(streamPath: StreamPathType) {
+    // /agents itself is not an agent — open its raw stream. Anything under it
+    // is an agent: open the chat view.
+    if (streamPath === AGENTS_ROOT) {
+      void navigate({
+        to: "/projects/$projectSlug/streams/$",
+        params: { projectSlug: params.projectSlug, _splat: streamPath },
+      });
+      return;
+    }
     void navigate({
       to: "/projects/$projectSlug/agents/streams/$",
-      params: {
-        projectSlug: params.projectSlug,
-        _splat: streamPath,
-      },
+      params: { projectSlug: params.projectSlug, _splat: streamPath },
     });
   }
 
-  return <StreamExplorerTreePage source={source} rootPath={AGENTS_ROOT} onOpenPath={openAgent} />;
+  const header = (
+    <div className="flex items-center gap-2">
+      <Link
+        to="/projects/$projectSlug/agents/new"
+        params={{ projectSlug: params.projectSlug }}
+        className={buttonVariants({ size: "sm" })}
+      >
+        New agent
+      </Link>
+      <Link
+        to="/projects/$projectSlug/agents/new-preset"
+        params={{ projectSlug: params.projectSlug }}
+        className={buttonVariants({ size: "sm", variant: "outline" })}
+      >
+        New preset
+      </Link>
+    </div>
+  );
+
+  return (
+    <StreamExplorerTreePage
+      header={header}
+      source={source}
+      rootPath={AGENTS_ROOT}
+      onOpenPath={openPath}
+    />
+  );
 }

--- a/apps/os/src/routes/_app/projects/$projectSlug/agents/streams/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/agents/streams/$.tsx
@@ -1,11 +1,8 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { buttonVariants } from "@iterate-com/ui/components/button";
 import { AgentChatView } from "~/components/agent-chat-view.tsx";
-import {
-  projectAgentRuntimeStateQueryOptions,
-  projectAgentsListQueryOptions,
-} from "~/lib/project-route-query.ts";
+import { projectAgentRuntimeStateQueryOptions } from "~/lib/project-route-query.ts";
 import { breadcrumbLoaderData } from "~/lib/route-breadcrumbs.ts";
 import { streamPathFromSplat, streamPathToSplat } from "~/lib/stream-links.ts";
 import { orpc } from "~/orpc/client.ts";
@@ -43,16 +40,10 @@ export const Route = createFileRoute("/_app/projects/$projectSlug/agents/streams
 
 function ProjectAgentDetailPage() {
   const params = Route.useParams();
-  const queryClient = useQueryClient();
   const { project, streamPath } = Route.useLoaderData();
-  const agentsQueryOptions = projectAgentsListQueryOptions(project.id);
-  const sendMessage = useMutation(
-    orpc.project.agents.sendMessage.mutationOptions({
-      onSuccess: async () => {
-        await queryClient.invalidateQueries({ queryKey: agentsQueryOptions.queryKey });
-      },
-    }),
-  );
+  // The agent chat view subscribes to the stream live, so a send needs no
+  // cache invalidation — the new events arrive over the socket.
+  const sendMessage = useMutation(orpc.project.agents.sendMessage.mutationOptions());
 
   async function submitAgentMessage(message: string) {
     await sendMessage.mutateAsync({

--- a/packages/shared/src/durable-object-utils/iterate-durable-object.ts
+++ b/packages/shared/src/durable-object-utils/iterate-durable-object.ts
@@ -21,7 +21,13 @@ export type IterateDurableObjectBaseOptions<
   Env,
 > = {
   className: string;
-  getDatabase(env: Env): D1Database;
+  /**
+   * D1 object-catalog database. Omit to disable the catalog entirely
+   * (`d1ObjectCatalog: "none"`) — for objects whose name fully describes them
+   * and that are never enumerated through a catalog (e.g. agents, named
+   * `{projectId}:{agentPath}` and listed by walking their stream tree).
+   */
+  getDatabase?(env: Env): D1Database;
   indexes?: D1ObjectCatalogIndexDefinitions<StructuredNameFromSchema<NameSchema>>;
   nameSchema: NameSchema;
 };
@@ -51,12 +57,15 @@ export function withIterateDurableObjectStack<
   Env,
 >(options: IterateDurableObjectBaseOptions<NameSchema, Env>) {
   return function <TBase extends DurableObjectClass>(Base: TBase) {
+    const getDatabase = options.getDatabase;
     const CatalogBase = withLifecycleHooks<StructuredNameFromSchema<NameSchema>, undefined, Env>({
-      d1ObjectCatalog: {
-        className: options.className,
-        getDatabase: options.getDatabase,
-        indexes: options.indexes,
-      },
+      d1ObjectCatalog: getDatabase
+        ? {
+            className: options.className,
+            getDatabase,
+            indexes: options.indexes,
+          }
+        : "none",
       nameSchema: options.nameSchema as unknown as z.ZodType<StructuredNameFromSchema<NameSchema>>,
     })(withDurableObjectCore(Base));
     const CatalogBaseWithCore = CatalogBase as typeof CatalogBase &


### PR DESCRIPTION
Follow-up to #1513. Agents are streams under `/agents`, so stop treating them specially in the UI and stop projecting them into a D1 object catalog.

- **Agents index page = the stream explorer scoped to `/agents`.** Reuses `StreamExplorerTreePage`; `StreamTreeBrowser` gains an optional `rootPath` (default `/`, so the project streams page is unchanged). The custom agents table + sort + filter are gone.
- **Removed `project.agents.list`** — oRPC route, contract procedure, `AgentRecord`, the query-options helper, and the post-send cache invalidation in the agent detail page. The explorer paints from live stream subscriptions; nothing polls a list.
- **Dropped the agent D1 object catalog** (`d1ObjectCatalog: "none"`, via an optional `getDatabase` on the shared base). Agents are addressed by their self-describing `{projectId}:{agentPath}` name and listed by walking the stream tree — nothing left to enumerate. (`DO_CATALOG` stays bound only for the incidental `itx.debug()` project-slug read.)

The agent chat detail view (`AgentChatView`) is unchanged — clicking an agent in the explorer still opens it.

## Verification
- `pnpm typecheck` + `pnpm lint` + `pnpm format`: green.
- Agent backend (chat/slack with catalog-off + colon-name) verified earlier this session on local dev.
- Preview/prod smoke to follow on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes a public list API and D1 catalog indexing for agents, which may affect external consumers and operator enumeration; core agent chat/send paths are unchanged but discovery UX and data sources shift to live stream walks.
> 
> **Overview**
> Agents are treated as ordinary streams under `/agents`: the custom agents table, D1 catalog projection, and **`project.agents.list`** API are removed in favor of the shared stream explorer and live itx subscriptions.
> 
> **UI:** The agents index is **`StreamExplorerTreePage`** with **`rootPath`** `/agents` (`StreamTreeBrowser` gains optional **`rootPath`**, default `/`). The page disables SSR, uses **`useItx`** for the tree, and routes `/agents` to the raw stream view vs child paths to agent chat. Presets UI and list polling/invalidation on the detail page are gone.
> 
> **API & contract:** **`AgentRecord`** and **`GET …/agents`** list are deleted from the OS contract and oRPC router; **`projectAgentsListQueryOptions`** is removed.
> 
> **Agent DO:** **`AgentDurableObject`** no longer registers D1 catalog indexes; **`createIterateDurableObjectBase`** allows omitting **`getDatabase`** to set **`d1ObjectCatalog: "none"`**. Agents are discovered by walking the `/agents` stream tree and addressed by **`{projectId}:{agentPath}`**; D1 stays only for incidental debug project-slug reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d69dff9d1ef97dbe32c1d3ec8600c1c1c76d0bb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-06-12T16:13:56.515Z",
      "headSha": "7ce63e620df5796b4b21cdb33425c98f2f83bd4f",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27427593938",
      "shortSha": "7ce63e6"
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-12T16:14:00.029Z",
      "headSha": "d69dff9d1ef97dbe32c1d3ec8600c1c1c76d0bb9",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27427795328",
      "shortSha": "d69dff9"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `d69dff9`
Preview: https://auth.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27427795328)
Updated: 2026-06-12T16:14:00.029Z

### Semaphore
Status: released
Commit: `7ce63e6`
Preview: https://semaphore.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27427593938)
Updated: 2026-06-12T16:13:56.515Z
<!-- /CLOUDFLARE_PREVIEW -->