### PR TITLE
docs: fix wording in jonasland rules

### DIFF
--- a/docs/jonasland-rules.md
+++ b/docs/jonasland-rules.md
@@ -108,7 +108,7 @@ The good thing about orpc procedures is
 - you can call the script across the network
 - with our cli you can call them from the terminal
 
-For example, if a service has some database seeding logic, you can just stick in in an orpc procedure called "seedDatabase" and then call that from wherever you'd call your seed script.
+For example, if a service has some database seeding logic, you can just stick it in an orpc procedure called "seedDatabase" and then call that from wherever you'd call your seed script.
 
 ESPECIALLY code that runs inside a project deployment machine (e.g. fly or docker container) should be an orpc procedure.
 


### PR DESCRIPTION
Fixes a small wording issue in `docs/jonasland-rules.md`: `stick in in` → `stick it in`.

This is a documentation-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording fix with no runtime or behavioral impact.
> 
> **Overview**
> Corrects a typo in the oRPC procedures guidance: **`stick in in`** is now **`stick it in`** in the database seeding example sentence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1f38e7cced8b1eed9936f2ade4532d691f26235. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->