### PR TITLE
[codex] fix project create session refresh

### DIFF
--- a/apps/auth/src/lib/client.ts
+++ b/apps/auth/src/lib/client.ts
@@ -40,6 +40,11 @@ type LoginOptions = {
   returnTo?: string;
 };
 
+type RefreshOptions = {
+  /** Reissue the OAuth access token even when it is not near expiry. */
+  force?: boolean;
+};
+
 export type AuthClient = ReturnType<typeof createIterateAuthClient>;
 
 export type AuthClientContextValue = {
@@ -47,7 +52,7 @@ export type AuthClientContextValue = {
   loading: boolean;
   signIn: (options?: LoginOptions) => void;
   signOut: () => Promise<void>;
-  refresh: () => Promise<void>;
+  refresh: (options?: RefreshOptions) => Promise<void>;
 };
 
 export type AuthClientProviderProps = {
@@ -63,8 +68,10 @@ const AuthClientContext = createContext<AuthClientContextValue | null>(null);
 export function createIterateAuthClient(config: IterateAuthClientConfig = {}) {
   const base = (config.authHandlerBasePath ?? "/api/iterate-auth").replace(/\/$/, "");
 
-  async function fetchSession(): Promise<SessionResponse> {
-    const response = await fetch(`${base}/session`, {
+  async function fetchSession(options: RefreshOptions = {}): Promise<SessionResponse> {
+    const url = options.force ? `${base}/session?refresh=force` : `${base}/session`;
+
+    const response = await fetch(url, {
       credentials: "include",
       headers: { Accept: "application/json" },
     });
@@ -107,14 +114,17 @@ export function AuthClientProvider({
   const [session, setSession] = useState<PublicSessionResponse | null>(initialSession);
   const [loading, setLoading] = useState(false);
 
-  const refresh = useCallback(async () => {
-    setLoading(true);
-    try {
-      setSession(toPublicSessionResponse(await client.fetchSession()));
-    } finally {
-      setLoading(false);
-    }
-  }, [client]);
+  const refresh = useCallback(
+    async (options: RefreshOptions = {}) => {
+      setLoading(true);
+      try {
+        setSession(toPublicSessionResponse(await client.fetchSession(options)));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [client],
+  );
 
   const signIn = useCallback(
     (options: LoginOptions = {}) => {

--- a/apps/auth/src/lib/server.ts
+++ b/apps/auth/src/lib/server.ts
@@ -592,15 +592,22 @@ export function createAuthHandler(config: IterateAuthConfig, infra: OAuthInfra) 
   });
 
   app.get("/session", async (c) => {
-    let tokenSet: TokenSet | null;
-    try {
-      tokenSet = getTokenSet(c);
-      if (tokenSet && tokenSet.accessTokenExpiresAt <= Date.now() + REFRESH_SKEW_MS) {
-        tokenSet = await doRefresh(tokenSet);
+    let tokenSet = getTokenSet(c);
+    const forceRefresh = c.req.query("refresh") === "force";
+    if (
+      tokenSet &&
+      tokenSet.refreshToken &&
+      (forceRefresh || tokenSet.accessTokenExpiresAt <= Date.now() + REFRESH_SKEW_MS)
+    ) {
+      const accessTokenExpired = tokenSet.accessTokenExpiresAt <= Date.now();
+      try {
+        tokenSet = (await doRefresh(tokenSet)) ?? tokenSet;
+      } catch {
+        if (accessTokenExpired) {
+          deleteCookie(c, SESSION_COOKIE, cookieOpts());
+          return c.json({ authenticated: false } satisfies SessionResponse, 401);
+        }
       }
-    } catch {
-      deleteCookie(c, SESSION_COOKIE, cookieOpts());
-      return c.json({ authenticated: false } satisfies SessionResponse, 401);
     }
 
     if (!tokenSet || !tokenSet.idToken) {

--- a/apps/os/docs/headless-local-debugging.md
+++ b/apps/os/docs/headless-local-debugging.md
@@ -133,9 +133,11 @@ cat <<'EOF' | ab eval --stdin
 EOF
 ```
 
-Project claims only land in the JWT on the next token refresh (or a fresh
-sign-in), so a just-created project is visible to the creating session via its
-seeded query cache but not to a cold reload until the access token reissues.
+Project claims only land in the JWT on token refresh (or a fresh sign-in), so
+the OS create-project UI forces an auth session refresh after creation before it
+navigates to the project. If you create directly through `fetch`, call
+`/api/iterate-auth/session?refresh=force` afterward before testing cold reloads
+or WebSocket-backed project routes.
 
 ## Read local server state directly
 

--- a/apps/os/src/auth/iterate-auth-login.test.ts
+++ b/apps/os/src/auth/iterate-auth-login.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { createAuthHandler, type IterateAuthConfig } from "@iterate-com/auth/server";
+import { describe, expect, it, vi } from "vitest";
+import { createAuthHandler, type IterateAuthConfig, type TokenSet } from "@iterate-com/auth/server";
 
 const config = {
   issuer: "https://auth.iterate-dev.com/api/auth",
@@ -40,9 +40,72 @@ describe("iterate auth login", () => {
     );
     expect(location.searchParams.get("state")).toBeTruthy();
   });
+
+  it("force refreshes session cookies before reading claims", async () => {
+    const tokenSet = testTokenSet({ accessTokenExpiresAt: Date.now() + 60 * 60 * 1000 });
+    const doRefresh = vi.fn(async (current: TokenSet) => current);
+    const handler = testAuthHandler(config, { doRefresh });
+
+    await handler(
+      new Request("http://os.localhost:65455/api/iterate-auth/session?refresh=force", {
+        headers: { cookie: sessionCookie(tokenSet) },
+      }),
+    );
+
+    expect(doRefresh).toHaveBeenCalledTimes(1);
+    expect(doRefresh).toHaveBeenCalledWith(tokenSet);
+  });
+
+  it("does not refresh non-expiring session cookies by default", async () => {
+    const doRefresh = vi.fn(async (current: TokenSet) => current);
+    const handler = testAuthHandler(config, { doRefresh });
+
+    await handler(
+      new Request("http://os.localhost:65455/api/iterate-auth/session", {
+        headers: {
+          cookie: sessionCookie(
+            testTokenSet({ accessTokenExpiresAt: Date.now() + 60 * 60 * 1000 }),
+          ),
+        },
+      }),
+    );
+
+    expect(doRefresh).not.toHaveBeenCalled();
+  });
+
+  it("keeps a still-valid session when forced refresh fails", async () => {
+    const signed = await signedTokenSet({
+      accessTokenExpiresAt: Date.now() + 60 * 60 * 1000,
+    });
+    const doRefresh = vi.fn(async () => {
+      throw new Error("temporary token endpoint failure");
+    });
+    const handler = testAuthHandler(config, {
+      doRefresh,
+      jwks: signed.jwks as never,
+    });
+
+    const response = await handler(
+      new Request("http://os.localhost:65455/api/iterate-auth/session?refresh=force", {
+        headers: { cookie: sessionCookie(signed.tokenSet) },
+      }),
+    );
+
+    expect(doRefresh).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      authenticated: true,
+      user: {
+        id: "usr_session",
+      },
+    });
+  });
 });
 
-function testAuthHandler(authConfig: IterateAuthConfig) {
+function testAuthHandler(
+  authConfig: IterateAuthConfig,
+  overrides: Partial<Parameters<typeof createAuthHandler>[1]> = {},
+) {
   const infra = {
     issuerURL: new URL(authConfig.issuer ?? "https://auth.iterate-dev.com/api/auth"),
     jwks: {},
@@ -63,7 +126,85 @@ function testAuthHandler(authConfig: IterateAuthConfig) {
     cookieOpts: () => ({ httpOnly: true, path: "/", sameSite: "Lax", secure: false }) as const,
     resource: () => "http://os.localhost",
     audiences: () => ["http://os.localhost"],
+    ...overrides,
   } as unknown as Parameters<typeof createAuthHandler>[1];
 
   return createAuthHandler(authConfig, infra).handler;
+}
+
+function testTokenSet(overrides: Partial<TokenSet> = {}): TokenSet {
+  return {
+    accessToken: "not-a-real-access-token",
+    accessTokenExpiresAt: Date.now() + 60 * 60 * 1000,
+    idToken: "not-a-real-id-token",
+    refreshToken: "refresh-token-1",
+    tokenType: "bearer",
+    ...overrides,
+  };
+}
+
+function sessionCookie(tokenSet: TokenSet) {
+  return `iterate_session=${encodeURIComponent(JSON.stringify(tokenSet))}`;
+}
+
+async function signedTokenSet(overrides: Partial<TokenSet> = {}) {
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  );
+  const now = Math.floor(Date.now() / 1000);
+  const expiresAt = Math.floor(
+    (overrides.accessTokenExpiresAt ?? Date.now() + 60 * 60 * 1000) / 1000,
+  );
+  const accessToken = await signJwt(keyPair.privateKey, {
+    aud: config.resource,
+    exp: expiresAt,
+    iat: now,
+    iss: config.issuer,
+    scope: "openid profile email offline_access",
+    sub: "usr_session",
+  });
+  const idToken = await signJwt(keyPair.privateKey, {
+    aud: config.clientId,
+    email: "session@example.com",
+    exp: expiresAt,
+    iat: now,
+    iss: config.issuer,
+    sub: "usr_session",
+  });
+
+  return {
+    jwks: keyPair.publicKey,
+    tokenSet: testTokenSet({
+      accessToken,
+      accessTokenExpiresAt: expiresAt * 1000,
+      idToken,
+      ...overrides,
+    }),
+  };
+}
+
+async function signJwt(privateKey: CryptoKey, payload: Record<string, unknown>) {
+  const encodedHeader = base64UrlEncode(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const input = `${encodedHeader}.${encodedPayload}`;
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    privateKey,
+    new TextEncoder().encode(input),
+  );
+  return `${input}.${base64UrlEncode(signature)}`;
+}
+
+function base64UrlEncode(value: string | ArrayBuffer) {
+  const bytes = typeof value === "string" ? new TextEncoder().encode(value) : new Uint8Array(value);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/u, "");
 }

--- a/apps/os/src/components/create-project-form.tsx
+++ b/apps/os/src/components/create-project-form.tsx
@@ -37,13 +37,14 @@ const CreateProjectInput = z.object({
 export function CreateProjectForm() {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { session } = useAuthClient();
+  const { refresh, session } = useAuthClient();
   const organizations = session?.authenticated ? session.session.organizations : [];
   const createProject = useMutation(
     orpc.projects.create.mutationOptions({
       onSuccess: async (project) => {
         cacheCreatedProjectQueries({ project, queryClient });
         void queryClient.invalidateQueries({ queryKey: orpc.projects.list.key() });
+        await refresh({ force: true });
         await router.invalidate({ sync: true });
         await router.navigate({
           to: "/projects/$projectSlug",

--- a/apps/os/src/routes/_app/projects/index.tsx
+++ b/apps/os/src/routes/_app/projects/index.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, createFileRoute, useRouter } from "@tanstack/react-router";
 import { FolderPlus } from "lucide-react";
 import type { Project } from "@iterate-com/os-contract";
+import { useAuthClient } from "@iterate-com/auth/client";
 import { Button } from "@iterate-com/ui/components/button";
 import { Identifier } from "@iterate-com/ui/components/identifier";
 import { toast } from "@iterate-com/ui/components/sonner";
@@ -36,6 +37,7 @@ function buildProjectHostname(input: {
 function ProjectsIndexPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
+  const { refresh } = useAuthClient();
   const { routeConfig } = Route.useLoaderData();
   const { data: projectsData } = useQuery(projectsListQueryOptions({ limit: 20, offset: 0 }));
 
@@ -44,6 +46,7 @@ function ProjectsIndexPage() {
       onSuccess: async (project) => {
         cacheCreatedProjectQueries({ project, queryClient });
         void queryClient.invalidateQueries({ queryKey: orpc.projects.list.key() });
+        await refresh({ force: true });
         await router.invalidate({ sync: true });
         await router.navigate({
           to: "/projects/$projectSlug",


### PR DESCRIPTION
## Summary

- add a forced auth session refresh path for `/api/iterate-auth/session`
- refresh the browser auth session after OS project creation before navigating to project-scoped routes
- cover forced refresh behavior with auth handler tests
- update local debugging docs for direct project creation

## Root Cause

OS created the project in Auth and D1, but the browser session kept using an access token whose project claims were minted before the new project existed. Project-scoped routes and WebSocket handshakes authorize from those claims, so the new project looked inaccessible until a later token refresh or sign-in.

## Validation

- `pnpm --dir apps/auth typecheck`
- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/os exec vitest run src/auth/iterate-auth-login.test.ts src/auth/iterate-auth-single-flight.test.ts src/auth/principal.test.ts`
- `pnpm --dir apps/os test`
- `git diff --check`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-13T13:24:14.525Z",
      "headSha": "cca6c14c6b50a4c9cb0095960a322985182d6932",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27467546742",
      "shortSha": "cca6c14"
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-13T13:24:01.820Z",
      "headSha": "cca6c14c6b50a4c9cb0095960a322985182d6932",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27467546742",
      "shortSha": "cca6c14"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `cca6c14`
Preview: https://auth.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27467546742)
Updated: 2026-06-13T13:24:14.525Z

### OS
Status: released
Commit: `cca6c14`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27467546742)
Updated: 2026-06-13T13:24:01.820Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth session refresh and token cookie handling on a security-sensitive path; behavior is narrowed with tests and only forces refresh when explicitly requested or near expiry.
> 
> **Overview**
> Fixes newly created projects appearing inaccessible on project-scoped routes until a later token refresh, by **forcing an OAuth token reissue** when the session is fetched with `refresh=force`.
> 
> The auth client and `/api/iterate-auth/session` now support optional forced refresh (`?refresh=force` / `refresh({ force: true })`). The session handler refreshes when forced or near expiry; if refresh fails but the access token is still valid, it keeps the session instead of logging the user out. **OS project creation** (`CreateProjectForm` and projects index) calls `refresh({ force: true })` after a successful create, before router invalidation and navigation, so JWT project claims include the new project.
> 
> Adds auth handler tests for forced refresh, skip refresh when not needed, and resilience when forced refresh fails. Local debugging docs note the forced refresh for direct `fetch` project creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cca6c14c6b50a4c9cb0095960a322985182d6932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->