### PR TITLE
Stream DOs shed idle connections to stop the post-#1500 DO billable-duration leak

### DIFF
--- a/apps/os/package.json
+++ b/apps/os/package.json
@@ -14,6 +14,7 @@
     "dev:local": "tsx ./scripts/dev.ts --no-doppler",
     "build": "doppler run -- pnpm exec vite build",
     "rpc": "pnpm cli rpc",
+    "probe:do-duration": "tsx ./scripts/do-duration-probe.ts",
     "cf:deploy": "pnpm exec tsx ./alchemy.run.ts",
     "cf:destroy": "pnpm exec tsx ./alchemy.run.ts --destroy",
     "deploy": "doppler run --project os --config prd -- pnpm cf:deploy",

--- a/apps/os/scripts/do-duration-probe.ts
+++ b/apps/os/scripts/do-duration-probe.ts
@@ -1,0 +1,130 @@
+// Defense-in-depth probe for the Durable Objects billable-duration leak class of
+// bug (see apps/os/tasks/do-duration-leak/). It queries Cloudflare's GraphQL
+// analytics for the pinned-DO signature — a single DO invocation running for
+// HOURS of wall-clock at ~0 CPU — which is how a leaked cross-isolate RPC session
+// shows up in billing. If any Worker script crosses the threshold it prints a
+// report and exits non-zero, so a cron / CI step / monitoring job can alert.
+//
+// Run it under a Doppler config that carries CLOUDFLARE_API_TOKEN +
+// CLOUDFLARE_ACCOUNT_ID (the same creds the deploy uses):
+//
+//   doppler run --config prd        -- pnpm tsx apps/os/scripts/do-duration-probe.ts
+//   doppler run --config preview_3  -- pnpm tsx apps/os/scripts/do-duration-probe.ts --hours 6
+//
+// Flags (env or CLI):
+//   --hours N             lookback window in hours (default 24)
+//   --threshold-hours N   wallTimeP99 ceiling per invocation, in hours (default 1)
+//   --prefix STR          only scripts whose name starts with STR (default "os-")
+
+interface CfGraphqlResponse<T> {
+  data?: T;
+  errors?: Array<{ message: string }>;
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value === "") throw new Error(`Missing required env var ${name}`);
+  return value;
+}
+
+function flag(name: string, fallback: number): number {
+  const fromCli = process.argv.indexOf(`--${name}`);
+  if (fromCli !== -1 && process.argv[fromCli + 1] !== undefined)
+    return Number(process.argv[fromCli + 1]);
+  return fallback;
+}
+
+function flagStr(name: string, fallback: string): string {
+  const fromCli = process.argv.indexOf(`--${name}`);
+  if (fromCli !== -1 && process.argv[fromCli + 1] !== undefined) return process.argv[fromCli + 1]!;
+  return fallback;
+}
+
+async function main(): Promise<void> {
+  const accountTag = requireEnv("CLOUDFLARE_ACCOUNT_ID");
+  const apiToken = requireEnv("CLOUDFLARE_API_TOKEN");
+  const lookbackHours = flag("hours", 24);
+  const thresholdHours = flag("threshold-hours", 1);
+  const prefix = flagStr("prefix", "os-");
+  const thresholdMicros = thresholdHours * 3.6e9; // hours → microseconds
+
+  // Cloudflare keeps adaptive analytics for the trailing window; query by day so
+  // the schema accepts the filter, then keep only scripts over the ceiling.
+  const start = new Date(Date.now() - lookbackHours * 3600_000).toISOString().slice(0, 10);
+  const end = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+
+  const query = `
+    query DoDurationProbe($accountTag: string!, $start: Date!, $end: Date!) {
+      viewer {
+        accounts(filter: { accountTag: $accountTag }) {
+          durableObjectsInvocationsAdaptiveGroups(
+            limit: 500
+            filter: { date_geq: $start, date_leq: $end }
+            orderBy: [date_ASC]
+          ) {
+            dimensions { date scriptName }
+            sum { requests }
+            quantiles { wallTimeP99 }
+          }
+        }
+      }
+    }`;
+
+  const response = await fetch("https://api.cloudflare.com/client/v4/graphql", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ query, variables: { accountTag, start, end } }),
+  });
+  const body = (await response.json()) as CfGraphqlResponse<{
+    viewer: {
+      accounts: Array<{
+        durableObjectsInvocationsAdaptiveGroups: Array<{
+          dimensions: { date: string; scriptName: string };
+          sum: { requests: number };
+          quantiles: { wallTimeP99: number };
+        }>;
+      }>;
+    };
+  }>;
+
+  if (body.errors?.length) {
+    throw new Error(`Cloudflare GraphQL errors: ${body.errors.map((e) => e.message).join("; ")}`);
+  }
+
+  const rows = body.data?.viewer.accounts[0]?.durableObjectsInvocationsAdaptiveGroups ?? [];
+  const flagged = rows
+    .filter((r) => r.dimensions.scriptName.startsWith(prefix))
+    .filter((r) => r.quantiles.wallTimeP99 > thresholdMicros)
+    .map((r) => ({
+      date: r.dimensions.date,
+      script: r.dimensions.scriptName,
+      wallTimeP99Hours: +(r.quantiles.wallTimeP99 / 3.6e9).toFixed(2),
+      requests: r.sum.requests,
+    }))
+    .sort((a, b) => b.wallTimeP99Hours - a.wallTimeP99Hours);
+
+  if (flagged.length === 0) {
+    console.log(
+      `✅ DO duration probe clean: no ${prefix}* script in the last ${lookbackHours}h had a ` +
+        `single invocation over ${thresholdHours}h wall-clock (the pinned-DO signature).`,
+    );
+    return;
+  }
+
+  console.error(
+    `🚨 DO duration probe: ${flagged.length} ${prefix}* script-day(s) show a DO invocation running ` +
+      `longer than ${thresholdHours}h of wall-clock — the signature of a leaked cross-isolate RPC ` +
+      `session pinning a Durable Object resident (see apps/os/tasks/do-duration-leak/).`,
+  );
+  for (const row of flagged) {
+    console.error(
+      `  - ${row.date}  ${row.script}  wallTimeP99=${row.wallTimeP99Hours}h  reqs=${row.requests}`,
+    );
+  }
+  process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/apps/os/tasks/do-duration-leak/ALTERNATIVES.md
+++ b/apps/os/tasks/do-duration-leak/ALTERNATIVES.md
@@ -1,0 +1,104 @@
+# Fix alternatives — detailed menu
+
+Detailed write-up of every option we considered, so we can revisit a rejected one
+later. Chosen approach: **Option 1 (Idle teardown, Stream-DO-authoritative)**. See
+DECISION_LOG.md for why.
+
+Root cause recap: each subscription retains two cross-isolate RPC stubs over one
+session — Stream DO holds the `processEventBatch` callback (pins the subscriber);
+subscriber holds the stream handle (`entry.stream`, pins the Stream DO). An open
+session bills duration on both ends (no RPC hibernation; only WebSockets get it).
+No idle teardown exists today (`implementation.ts:615–652`).
+
+---
+
+## Option 1 — Idle teardown + re-dial on append ✅ CHOSEN
+
+Stream DO is the authority. Track last-activity; a DO alarm fires after an idle
+window; on fire (if still idle) the Stream DO **deletes all live connections** —
+disposes every callback stub (frees subscribers) AND calls each subscriber to
+release its retained stream handle (frees the Stream DO) — then hibernates. The
+durable `subscriptionsByKey` config persists; on the next append/wake the existing
+`woken → reconcileConnections → dial` path re-dials every subscriber, which
+re-handshakes from its durable checkpoint (replay covers the gap).
+
+- Touches: `stream.ts` (alarm schedule + `alarm()` handler; suppress the
+  constructor `woken` re-dial on the idle-alarm wake), `implementation.ts`
+  (`Connection` close-all + per-connection subscriber-release; new disconnect
+  reason `"idle"`), `core/contract.ts` (reason enum), a new
+  `releaseStreamSubscription` RPC on the subscriber host (`stream-processor-host.ts`).
+- Pros: stops idle billing on BOTH ends; reuses 100% of reconcile + generation
+  gate + checkpoint replay; no public subscription-contract change; latency
+  unaffected when active (alarm pushed forward on every append).
+- Cons: one alarm storage write per idle window; must suppress the constructor's
+  woken-reconcile on the alarm wake or it thrashes (re-dial→teardown loop); idle
+  window needs tuning.
+- Risk: MEDIUM. Race: append lands while alarm firing — guard with "re-check
+  idle at alarm fire; any wake cancels/reschedules the alarm".
+
+## Option 2 — Subscriber-driven pull via alarm ❌ rejected (for now)
+
+Invert to pull: subscriber wakes on its own alarm, pulls events since checkpoint,
+no retained callback on the Stream DO.
+
+- Pros: zero retained stubs; both DOs fully hibernate.
+- Cons: **breaks real-time push** — events wait up to the pull interval; exactly-once
+  becomes fragile (ingest/checkpoint must be atomic or idempotent); more RPC
+  traffic. Risk HIGH. Rejected: gives up the push latency guarantee the product
+  relies on.
+
+## Option 3 — Hibernatable WebSocket transport ❌ rejected (heavy)
+
+Move cross-DO delivery onto the WebSocket Hibernation API (doesn't bill idle).
+
+- Pros: true hibernation; durable buffer preserves delivery.
+- Cons: whole new transport layer + handshake; subscriber must expose a WS upgrade
+  endpoint; slight wake latency; incompatible with the existing callable-subscriber
+  infra without a rewrite. Risk MEDIUM-HIGH. Rejected: largest surface for the same
+  outcome Option 1 achieves with reconcile we already have. Revisit if we want
+  idle billing → 0 with no alarm churn at very high subscription counts.
+
+## Option 4 — Lease/heartbeat with expiry ❌ rejected (close 2nd)
+
+Subscriptions carry a TTL; subscriber renews on activity; Stream DO drops
+connections whose lease lapses.
+
+- Pros: surgical; compatible with reconcile + generation gate.
+- Cons: renewal RPC per ingest; clock-skew grace windows; expiry not atomic with
+  close. Risk MEDIUM. Rejected vs Option 1 because it adds steady-state renewal
+  traffic for always-on agents and still needs a sweep alarm — Option 1's
+  "push the alarm forward on activity" gets the same result without per-batch
+  renewals. **Best fallback if alarm-storage churn proves costly.**
+
+## Option 5 — Reference-count / dispose discipline ❌ rejected (breaking)
+
+Retain only a per-subscription factory; create+dispose a fresh per-batch callback
+each delivery.
+
+- Cons: changes the public subscription callable contract (callback → factory) —
+  breaking for all processors/agents; per-batch factory RPC overhead. Risk HIGH.
+  Rejected: breaking change for a problem the idle case already solves.
+
+## Option 6 — Co-location / topology (partial revert of #1500) ❌ rejected (defeats split)
+
+Keep a Stream DO and its hot subscribers in one script so the session is
+in-isolate (free) again.
+
+- Pros: zero billing for co-located hot subscribers; reuses all machinery.
+- Cons: only helps co-located subscribers (remote agents still leak); reintroduces
+  shared-isolate coupling the split deliberately removed; new callable type. Risk
+  LOW-MEDIUM. Rejected: narrows the blast radius but doesn't fix remote subscribers
+  and undoes the split's isolation. Keep in pocket as a perf optimization for the
+  hottest same-app streams.
+
+---
+
+## Defense-in-depth candidates (separate from the fix; see task #6)
+
+- CF budget alert on DO activeTime per script (catches recurrence in $).
+- An invariant/assert + test: "no Stream DO holds a live outbound connection after
+  N minutes of no appends" — runs in the workerd suite and as a periodic prod probe.
+- A periodic GraphQL probe (scheduled agent) that flags any script whose
+  wallTimeP99 exceeds e.g. 1h — the signature of a pinned DO.
+- Lint/review guard against retaining a cross-script stub without a registered
+  teardown path.

--- a/apps/os/tasks/do-duration-leak/DECISION_LOG.md
+++ b/apps/os/tasks/do-duration-leak/DECISION_LOG.md
@@ -197,4 +197,22 @@ heavy new transport / breaking contract change).
     itx-stream-subscribe. No regressions.
     Next: subscriber-side belt-and-braces (host idle disconnect) + failing test;
     public PR; preview repro + pressure test; defense-in-depth.
-    </content>
+
+- 2026-06-14 — Public PR opened: https://github.com/iterate/iterate/pull/1518 (draft).
+- 2026-06-14 — Narrowed the re-dial gate per Jonas: exclude EXACTLY the
+  `subscriber-disconnected` event (the one self-undoing trigger), not the whole
+  `stream/*` namespace. Documented inline in `stream.ts`.
+- 2026-06-14 — Subscriber-side belt-and-braces landed (host idle disconnect):
+  - `stream-processor-host.ts`: in-memory idle timer (`HOST_IDLE_TEARDOWN_MS`, 5m),
+    reset on each delivered batch + handshake, cleared when no entry holds a live
+    stream stub; `runIdleDisconnectNow()` unsubscribes (frees this DO) and disposes
+    `entry.stream` (frees the producer), keeping the durable checkpoint so the
+    producer's re-dial re-handshakes.
+  - `stream-processor-runner.ts`: exposes `runIdleDisconnectNow()`.
+  - Lives in `createStreamProcessorHost`, so it AUTOMATICALLY protects the real
+    Agent / repo / workspace host DOs (the pinned subscribers in the leak data).
+  - New `stream-host-idle-disconnect.workers.test.ts`: host drops its stub on idle
+    → producer's outbound connection closes too → re-handshakes on next append.
+    Green: 79 node + 17 workers streams; apps/os typecheck; oxlint clean.
+    Remaining: preview repro + adversarial pressure test (real billing signal);
+    defense-in-depth recurrence guard.

--- a/apps/os/tasks/do-duration-leak/DECISION_LOG.md
+++ b/apps/os/tasks/do-duration-leak/DECISION_LOG.md
@@ -216,3 +216,24 @@ heavy new transport / breaking contract change).
     Green: 79 node + 17 workers streams; apps/os typecheck; oxlint clean.
     Remaining: preview repro + adversarial pressure test (real billing signal);
     defense-in-depth recurrence guard.
+
+- 2026-06-14 — Adversarial pressure tests (workerd, deterministic — preview
+  analytics lag makes a tight loop there impossible). `stream-idle-teardown-adversarial.workers.test.ts`:
+  (1) sever the PRODUCER before EVERY append (forced cold re-dial each time) →
+  echo processor's durable `seen` advances exactly 1,2,3,4,5 (exactly-once, no
+  loss/dup across 5 teardowns); (2) BOTH timers fire between appends (subscriber
+  disconnect + producer sever, worst order) → next append still delivered;
+  (3) double-sever a quiet stream → harmless no-op, later delivery intact. All green.
+- 2026-06-14 — Defense-in-depth recurrence guard: `apps/os/scripts/do-duration-probe.ts`
+  (+ `pnpm --dir apps/os probe:do-duration`). Queries CF GraphQL for the pinned-DO
+  signature (a single DO invocation > 1h wall-clock) and exits non-zero so a cron
+  can alert. VALIDATED against prd: correctly flagged the known leak (16 os-prd-\*
+  script-days, os-prd-agent wallTimeP99 17.35h, etc.). Wire to a scheduled job
+  (cron / monitoring) post-merge. The two-sided idle timers remain the primary,
+  structural defense — any future subscription is auto-capped on both ends.
+- 2026-06-14 — Preview: PR #1518 CI auto-deploys the fix to a slot ("Preview /
+  deploy + e2e" + "streams-e2e"). Empirical activeTime confirmation depends on CF
+  analytics lag (minutes–~1h), so the authoritative proof of the mechanism is the
+  workerd suite (sever + re-dial + exactly-once over the REAL Stream DO + runner
+  DO via real Workers RPC); the probe will confirm prd activeTime falls once the
+  fix ships.

--- a/apps/os/tasks/do-duration-leak/DECISION_LOG.md
+++ b/apps/os/tasks/do-duration-leak/DECISION_LOG.md
@@ -1,0 +1,200 @@
+---
+title: DO billable-duration leak from cross-script stream subscriptions
+status: in-progress
+branch: fix/do-subscription-duration-leak
+opened: 2026-06-14
+owner: jonas + claude
+---
+
+# Durable Objects billable-duration leak — decision log
+
+Living document. Append-only narrative + a "rejected alternatives" section we can
+revisit. Newest dated entries at the bottom of each section.
+
+## Problem statement
+
+After PR #1500 ("Split os into per-DO workers", merged 2026-06-12 10:04 BST), the
+prd Cloudflare account's **Durable Objects billable compute duration** jumped
+100–1000×. dev/preview is worse (~13× prd). Signature: individual DO invocations
+with wallTime up to **17 hours**, **~0 CPU**, **0 WebSockets**. Cost is small in
+absolute terms (~$25 prd / ~$300 dev-preview per cycle) but it is a real
+architectural leak that scales with usage.
+
+## Confirmed mechanism (as of 2026-06-14)
+
+Stream subscriptions use a **push** model. A subscriber DO calls
+`subscribeOutbound(...)` on the Stream DO (cross-script Workers RPC) and passes a
+`processEventBatch` callback. The Stream DO **dup()s and retains that callback
+stub** so it can push later (`packages/streams/src/processors/core/implementation.ts:530`,
+comment at `:514–517`). A capability passed across an RPC keeps that **RPC session
+open until the stub is disposed**. Per CF docs, _"a Durable Object stays alive as
+long as requests are being processed"_ — so the still-open session keeps **both**
+DOs resident and billable, at ~0 CPU and no WebSocket, for the entire subscription
+lifetime.
+
+- NOT caused by `ctx.waitUntil` (it is a **no-op** inside DOs — corrected after an
+  initial wrong explanation that leaned on it). The misleading comment lives at
+  `packages/streams/src/workers/stream-processor-host.ts:232`.
+- NOT an alarm and NOT a busy loop. The pump parks (returns) when caught up and is
+  re-woken by `connection.wake()` on append (`implementation.ts:548–604`).
+- Before #1500 both ends were in one isolate, so the retained callback was an
+  in-process JS reference — no cross-isolate session, nothing extra billed. The
+  split turned it into a genuine cross-script open session.
+- No idle teardown: a connection only closes on `unsubscribed` / `replaced` /
+  `rpc-broken` / `delivery-failed` / `subscription-removed`
+  (`implementation.ts:615–652`). A subscription to a quiet stream stays pinned
+  forever.
+
+### Evidence (CF GraphQL analytics, account 04b3b57291ef2626c6a8daa9d47065a7)
+
+| date     | activeTime (µs) | note                                     |
+| -------- | --------------- | ---------------------------------------- |
+| Jun 7–11 | <2e9/day        | baseline                                 |
+| Jun 12   | 2.91e11         | split lands 10:04 BST                    |
+| Jun 13   | 1.23e12         | peak (~14 DO-equivalents pinned all day) |
+| Jun 14   | 3.34e11         | still accruing at query time             |
+
+Per-script wallTime p99 (Jun 12): os-prd-agent 62,457s (~17.3h), os-prd-itx
+61,404s, os-prd-repo 61,402s. dev/preview reproduced the same on os-preview-3-_
+and os-preview-5-_ (and a distinct pre-split os-dev-jonas hold on Jun 11).
+
+## Plan
+
+1. Reproduce reliably in ONE preview environment; capture the billing signal.
+2. Deeply understand (done at code level; confirm empirically).
+3. Write a FAILING test — fast workerd integration test for the mechanism +
+   slow preview e2e for the duration signal.
+4. Fix.
+5. Adversarially pressure-test in the preview env.
+6. Defense-in-depth to prevent recurrence.
+
+## Chosen approach — Option 1, Stream-DO-authoritative idle teardown
+
+Jonas's steer (2026-06-14): _"specific logic in the stream durable object that says
+'if nothing happens for a while, I'll deliberately go to sleep — delete all
+connections etc.'"_ Adopted.
+
+Design (revised — **in-memory timer, NOT a DO alarm**; see "alarm vs timer" below):
+
+1. Stream DO holds an **in-memory `setTimeout`**. It is (re)armed after each append
+   while there are live outbound connections, and cleared when the connection count
+   hits zero. No storage writes; no durable alarm.
+2. On fire: sever every live **outbound** connection — dispose each retained
+   callback stub. The freed subscriber DO hibernates (~10s), which wipes its
+   in-memory `entry.stream`, releasing the Stream DO too (cascade). New disconnect
+   reason `"idle"`. Scope = outbound only (the measured leak); inbound (browser)
+   connections are left alone — they belong to active viewers and want WS
+   Hibernation, a separate change. (Pending Jonas's call on outbound-only vs all.)
+3. The durable `subscriptionsByKey` config is untouched, so the existing
+   `woken → reconcileConnections → dial` path re-dials all subscribers on the next
+   real append; each re-handshakes from its durable checkpoint (replay covers the
+   gap). Verified: `implementation.ts:391–432` (reconcile from persisted config),
+   `stream.ts:75–100` (woken fact restores connections on every wake).
+
+### Alarm vs in-memory timer (Jonas, 2026-06-14) — TIMER wins
+
+Initial design used a DO alarm; Jonas pushed back: if the DO is already awake, why
+a durable alarm rather than an in-memory `setTimeout`? He's right. The retained
+stubs we tear down are in-memory and die on eviction — exactly the lifetime of a
+`setTimeout`. A durable alarm buys cross-eviction persistence we don't want: if the
+DO is evicted the stubs are already gone (nothing to tear down), and an alarm's only
+extra power — waking a _hibernated_ DO — is the very thing we must avoid. The alarm
+is also worse on the hot path (a `setAlarm()` storage write per append to push the
+deadline) and has more moving parts (deleteAlarm, persisted lastActivity). Since the
+DO is always resident while holding stubs, the in-memory timer is guaranteed to fire.
+Decision: in-memory `setTimeout`, reset on append, cleared at zero connections.
+(Testability note: in-memory timers are harder to fire deterministically than
+`runDurableObjectAlarm`; the regression test uses a short idle window + real-time
+`settle()`, or a directly-invoked sever method — TBD against the outbound harness.)
+
+### Two-sided teardown (Jonas, 2026-06-14): producer AND subscriber idle timers
+
+Belt-and-braces, both with failing tests:
+
+1. **Producer (Stream DO)**: in-memory idle timer severs outbound connections
+   (disposes the callback stub → frees the subscriber).
+2. **Subscriber (StreamProcessorHost / StreamProcessorRunner / Agent DO)**: its
+   OWN in-memory idle timer, reset on each delivered batch; on fire it disposes
+   `entry.stream` (+ unsubscribes) → frees the producer and goes dormant. Re-armed
+   when the producer re-dials it.
+   These are complementary (each frees the OTHER side directly; each frees itself via
+   the hibernation cascade), so either firing is sufficient and both firing is prompt
+
+- robust to one side's logic failing.
+
+Re-dial correctness for BOTH paths: appends don't reconcile by default
+(`stream.ts:476`). So after ANY idle sever (producer- or subscriber-initiated) the
+Stream DO must re-dial configured-but-disconnected subscriptions on the next
+append. Implemented generally via `coreProcessor.needsOutboundReconcile()` (cheap
+O(subscriptions) check; no-op in steady state) called from `#appendBatchHere`.
+
+### The symmetric-pin subtlety (must-get-right)
+
+A subscription holds TWO retained stubs over one session: Stream DO → subscriber
+(callback, pins the subscriber) and subscriber → Stream DO (`entry.stream`, pins
+the Stream DO). "Delete all connections" on the Stream DO frees subscribers but not
+the Stream DO itself — so the teardown must ALSO tell each subscriber to drop its
+handle (new `releaseStreamSubscription` RPC on the host). Confirmed by data: the
+subscriber scripts (os-prd-agent/itx/repo/workspace) were pinned too, not just
+os-prd-stream.
+
+### "Doesn't the idle alarm just WAKE the DO?" (Jonas, 2026-06-14)
+
+No — and the question tightened the design. The alarm only ever fires on a DO that
+is _already awake_: the retained stubs pin it resident (that IS the bug), so it
+cannot hibernate while connections are held. The alarm runs on the live, already-
+billing incarnation, disposes the stubs, then the DO sleeps. It does not wake a
+sleeping DO; it lets a stuck-awake one sleep. Two rules prevent a recurring alarm
+from waking a _hibernated_ DO:
+
+1. Arm the alarm ONLY when there are live connections (`hasLiveConnections()`
+   guard). No connections → no alarm → natural hibernation, nothing scheduled.
+2. `deleteAlarm()` after teardown → no pending alarm survives; the DO sleeps until
+   a real external append wakes it (when there's genuinely work).
+   A timer is unavoidable: "idle for a while" has no triggering event, so some
+   scheduled primitive must fire. A DO alarm is correct (a `setTimeout` is itself
+   in-flight work that keeps the DO up and doesn't survive eviction). Net: strictly
+   less resident time.
+
+### Known implementation gotcha
+
+`stream.ts` constructor appends a `woken` fact on EVERY wake — including the
+idle-alarm wake — which re-dials everyone. The teardown must suppress re-dial on
+the alarm path (e.g. flag the alarm wake; reconcile skips dialing) or it
+thrashes (re-dial → teardown loop). Covered by a regression test.
+
+## Rejected / deferred alternatives
+
+See `ALTERNATIVES.md`. Summary: Option 4 (lease/heartbeat) is the best fallback if
+alarm-storage churn is costly; Option 6 (co-location) kept as a perf optimization
+for the hottest same-app streams; Options 2/3/5 rejected (break push latency /
+heavy new transport / breaking contract change).
+
+## Timeline / log
+
+- 2026-06-14 — Diagnosis complete; branch + decision log opened; 3 investigation
+  sub-agents dispatched (repro runbook, test-harness observables, fix menu).
+- 2026-06-14 — Chosen Option 1 (Stream-DO-authoritative idle teardown) per Jonas.
+  Verified cold re-dial path works from durable `subscriptionsByKey`. Documented
+  the symmetric-pin subtlety + the woken-reconcile gotcha. Next: failing workerd
+  test, then implement.
+- 2026-06-14 — Switched alarm → in-memory `setTimeout` (Jonas: the DO is already
+  awake while pinned; durable alarm would only wake a hibernated DO + writes
+  storage per append). Producer-side fix landed:
+  - `contract.ts`: `"idle"` disconnect reason.
+  - `implementation.ts`: `hasLiveOutboundConnections()`, `closeIdleOutboundConnections()`,
+    `needsOutboundReconcile()`.
+  - `stream.ts`: in-memory `#idleTimer`, `#idleTeardownMs()` (env-overridable,
+    default 5m), `#armOrClearIdleTimer()` (arm only when outbound connections
+    exist), `runIdleTeardownNow()`; `#appendBatchHere` re-dials severed
+    subscriptions on the next DOMAIN append and re-arms/clears the timer.
+  - Bug caught by the test: the teardown's own `subscriber-disconnected` fact
+    re-triggered `needsOutboundReconcile` and instantly re-dialed — fixed by
+    gating re-dial to non-`stream/*` (domain) appends.
+  - Tests green: new `stream-idle-teardown.workers.test.ts` (sever → reason "idle"
+    → re-dial on next append, via the real echo-runner outbound path) +
+    79 streams node + 16 streams workers (incl. M1 re-dial) + 13 apps/os inbound
+    itx-stream-subscribe. No regressions.
+    Next: subscriber-side belt-and-braces (host idle disconnect) + failing test;
+    public PR; preview repro + pressure test; defense-in-depth.
+    </content>

--- a/apps/os/tasks/do-duration-leak/DECISION_LOG.md
+++ b/apps/os/tasks/do-duration-leak/DECISION_LOG.md
@@ -237,3 +237,20 @@ heavy new transport / breaking contract change).
   workerd suite (sever + re-dial + exactly-once over the REAL Stream DO + runner
   DO via real Workers RPC); the probe will confirm prd activeTime falls once the
   fix ships.
+
+- 2026-06-14 — PREVIEW VALIDATION (PR #1518 deployed to preview-2):
+  - `streams-e2e` + `Preview / deploy + e2e` PASS against the deployed fix — the
+    real subscription path delivers end-to-end with idle teardown active.
+  - `do-duration-probe` contrast on the dev/preview account (48h):
+    - os-preview-3-_ / os-preview-5-_ (OLD code): FLAGGED — 9 script-days, e.g.
+      os-preview-5-agent wallTimeP99 11h, os-preview-3-project 10.45h. Leak live.
+    - os-preview-2-\* (THIS FIX): CLEAN — no pinned-DO signature.
+  - Honest caveat: airtight same-slot before/after needs hours of analytics lag;
+    the evidence here (deployed e2e green + workerd adversarial exactly-once + the
+    fixed slot clean while leaking slots still flag + the probe correctly flagging
+    prd) is strong and convergent. Post-merge, the probe on prd should flip from
+    16 flagged script-days to clean as the fix runs and the window rolls forward.
+    STATUS: fix complete, tested (unit + adversarial + deployed e2e), validated in
+    preview, defense-in-depth in place, public PR #1518 green. Remaining: review +
+    merge; wire the probe to a scheduled monitoring job; decide outbound-only vs also
+    inbound (browser) teardown (currently outbound-only by design).

--- a/packages/streams/src/processors/core/contract.ts
+++ b/packages/streams/src/processors/core/contract.ts
@@ -87,6 +87,13 @@ export const StreamSubscriberDisconnectReason = z.enum([
   "delivery-failed",
   /** The outbound subscription's configuration was removed. */
   "subscription-removed",
+  /**
+   * The stream went quiet for longer than its idle window, so the Stream DO
+   * deliberately dropped every connection to let itself (and its subscribers)
+   * hibernate instead of accruing billable duration on idle cross-isolate RPC
+   * sessions. The durable subscription config is kept; the next append re-dials.
+   */
+  "idle",
 ]);
 
 export type StreamSubscriberDisconnectReason = z.infer<typeof StreamSubscriberDisconnectReason>;

--- a/packages/streams/src/processors/core/implementation.ts
+++ b/packages/streams/src/processors/core/implementation.ts
@@ -360,6 +360,51 @@ export class CoreStreamProcessor extends StreamProcessor<CoreProcessorContract, 
     for (const connection of this.#connections.values()) connection.wake();
   }
 
+  /** True if any live connection delivers outbound into a subscriber DO. */
+  hasLiveOutboundConnections(): boolean {
+    for (const connection of this.#connections.values()) {
+      if (connection.direction === "outbound") return true;
+    }
+    return false;
+  }
+
+  /**
+   * Deliberately drops every live OUTBOUND delivery connection so a quiet stream
+   * stops pinning subscriber DOs (and, via the hibernation cascade, itself) with
+   * idle cross-isolate RPC sessions. Disposes each retained callback stub
+   * (`connection.close` → `processEventBatch[Symbol.dispose]`) and appends a
+   * `subscriber-disconnected("idle")` fact. The durable `subscriptionsByKey`
+   * config is untouched, so the next append (`needsOutboundReconcile`) or a wake
+   * re-dials the subscriber, which re-handshakes from its durable checkpoint and
+   * replays anything the cursor advanced past. Returns the severed keys.
+   */
+  closeIdleOutboundConnections(): string[] {
+    const severed: string[] = [];
+    // Snapshot first: close() mutates #connections.
+    for (const [subscriptionKey, connection] of [...this.#connections]) {
+      if (connection.direction !== "outbound") continue;
+      severed.push(subscriptionKey);
+      connection.close("idle");
+    }
+    return severed;
+  }
+
+  /**
+   * True if a configured outbound subscription currently has no live or
+   * in-flight connection — i.e. one was severed (idle teardown here or on the
+   * subscriber, a clean unsubscribe, etc.) and needs re-dialing. Cheap
+   * O(subscriptions) scan; a no-op in steady state when everything is connected.
+   */
+  needsOutboundReconcile(): boolean {
+    const state = this.#currentState();
+    for (const subscriptionKey of Object.keys(state.subscriptionsByKey)) {
+      if (!this.#connections.has(subscriptionKey) && !this.#connecting.has(subscriptionKey)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /** Serializable debug view of the live connections, for runtimeState(). */
   connectionsRuntimeState(): Record<
     string,

--- a/packages/streams/src/workers/durable-objects/stream-host-idle-disconnect.workers.test.ts
+++ b/packages/streams/src/workers/durable-objects/stream-host-idle-disconnect.workers.test.ts
@@ -1,0 +1,128 @@
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+// Belt-and-braces companion to stream-idle-teardown.workers.test.ts. The leak is
+// symmetric: a subscriber DO that holds a subscription's retained stream stub
+// (`entry.stream`) pins the PRODUCER Stream DO resident just as the producer's
+// retained callback pins the subscriber. So the StreamProcessorHost has its OWN
+// in-memory idle timer: when no batch has arrived for a while it unsubscribes and
+// disposes its stream stubs, freeing both DOs to hibernate. The durable
+// checkpoint persists, so the producer re-dials and the host re-handshakes when
+// activity resumes.
+//
+// Either side's idle timer alone is sufficient (each frees the other); this test
+// proves the SUBSCRIBER side independently tears the session down.
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { durableObjectProcessorSubscriber } from "../../shared/callable-subscriber.ts";
+import type { StreamEvent } from "../../shared/event.ts";
+import type { StreamProcessorRunner } from "./stream-processor-runner.ts";
+import type { Stream } from "./stream.ts";
+
+const STREAM = (env as unknown as { STREAM: DurableObjectNamespace<Stream> }).STREAM;
+const RUNNER = (
+  env as unknown as { STREAM_PROCESSOR_RUNNER: DurableObjectNamespace<StreamProcessorRunner> }
+).STREAM_PROCESSOR_RUNNER;
+
+const INPUT_TYPE = "events.iterate.com/echo-example/input-received";
+const OUTPUT_TYPE = "events.iterate.com/echo-example/output-echoed";
+
+let counter = 0;
+function freshNames() {
+  counter += 1;
+  return { streamName: `hostidle:/hostidle/t${counter}`, runnerName: `hostidle-runner-${counter}` };
+}
+
+async function appendEvent(
+  stream: DurableObjectStub<Stream>,
+  event: { type: string; payload: unknown },
+) {
+  return await runInDurableObject(stream, (instance) => instance.append({ event }));
+}
+async function getEvents(stream: DurableObjectStub<Stream>): Promise<StreamEvent[]> {
+  return await runInDurableObject(stream, (instance) => instance.getEvents({ afterOffset: 0 }));
+}
+async function outboundConnectionCount(stream: DurableObjectStub<Stream>): Promise<number> {
+  return await runInDurableObject(
+    stream,
+    (instance) =>
+      Object.values(instance.runtimeState().runtime.connections).filter(
+        (c) => c.direction === "outbound",
+      ).length,
+  );
+}
+async function runnerSubscription(runner: DurableObjectStub<StreamProcessorRunner>) {
+  return await runInDurableObject(
+    runner,
+    (instance) => instance.runtimeState({ processorName: "echo-example" }).subscription,
+  );
+}
+async function waitFor<T>(
+  fn: () => Promise<T | undefined | false>,
+  description: string,
+  { attempts = 100, delay = 50 } = {},
+): Promise<T> {
+  for (let i = 0; i < attempts; i += 1) {
+    const value = await fn();
+    if (value) return value as T;
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+async function configureEchoSubscription(args: { streamName: string; runnerName: string }) {
+  const stream = STREAM.getByName(args.streamName);
+  await appendEvent(stream, {
+    type: "events.iterate.com/stream/subscription-configured",
+    payload: {
+      subscriptionKey: `echo:${args.runnerName}`,
+      subscriber: durableObjectProcessorSubscriber({
+        bindingName: "STREAM_PROCESSOR_RUNNER",
+        durableObjectName: args.runnerName,
+        processorName: "echo-example",
+      }),
+    },
+  });
+  return stream;
+}
+
+describe("subscriber-side idle disconnect frees the producer too (belt-and-braces)", () => {
+  it("the host drops its stream stub on idle, freeing the producer connection, then re-handshakes on the next append", async () => {
+    const { streamName, runnerName } = freshNames();
+    const stream = await configureEchoSubscription({ streamName, runnerName });
+    const runner = RUNNER.getByName(runnerName);
+
+    // Establish the session: producer holds an outbound connection, the host
+    // holds a retained stream stub (its subscription).
+    const first = await appendEvent(stream, { type: INPUT_TYPE, payload: { n: 1 } });
+    await waitFor(
+      async () =>
+        (await getEvents(stream)).some((e) => e.type === OUTPUT_TYPE && e.offset > first.offset),
+      "echo of the first input",
+    );
+    expect(await outboundConnectionCount(stream)).toBeGreaterThan(0);
+    expect(await runnerSubscription(runner)).toBeDefined();
+
+    // The SUBSCRIBER's idle timer fires (invoked directly for determinism).
+    // Before the fix this method does not exist -> red.
+    await runInDurableObject(runner, (instance) => instance.runIdleDisconnectNow());
+
+    // The host released its subscription (no retained stream stub pinning the
+    // producer) ...
+    expect(await runnerSubscription(runner)).toBeUndefined();
+    // ... and the producer's outbound connection is gone too (the host
+    // unsubscribed), so neither DO is pinned.
+    await waitFor(
+      async () => (await outboundConnectionCount(stream)) === 0,
+      "the producer's outbound connection to close after the host unsubscribed",
+    );
+
+    // Durable checkpoint survived: the next append re-dials the host, which
+    // re-handshakes and ingests — the echo continues from where it left off.
+    const second = await appendEvent(stream, { type: INPUT_TYPE, payload: { n: 2 } });
+    const echoed = await waitFor(
+      async () =>
+        (await getEvents(stream)).find((e) => e.type === OUTPUT_TYPE && e.offset > second.offset),
+      "echo after re-handshake",
+    );
+    expect((echoed.payload as { seen: number }).seen).toBe(2);
+  }, 30_000);
+});

--- a/packages/streams/src/workers/durable-objects/stream-idle-teardown-adversarial.workers.test.ts
+++ b/packages/streams/src/workers/durable-objects/stream-idle-teardown-adversarial.workers.test.ts
@@ -1,0 +1,125 @@
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+// Adversarial pressure tests for the idle-teardown fix: try to make the
+// sever / re-dial machinery lose, duplicate, or wedge delivery. The echo
+// processor counts inputs it has ingested (`seen`), advancing its DURABLE
+// checkpoint per input — so a monotonic 1,2,3,… across forced cold re-dials is
+// proof of exactly-once delivery, and any gap or repeat would surface as a wrong
+// count.
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { durableObjectProcessorSubscriber } from "../../shared/callable-subscriber.ts";
+import type { StreamEvent } from "../../shared/event.ts";
+import type { StreamProcessorRunner } from "./stream-processor-runner.ts";
+import type { Stream } from "./stream.ts";
+
+const STREAM = (env as unknown as { STREAM: DurableObjectNamespace<Stream> }).STREAM;
+const RUNNER = (
+  env as unknown as { STREAM_PROCESSOR_RUNNER: DurableObjectNamespace<StreamProcessorRunner> }
+).STREAM_PROCESSOR_RUNNER;
+
+const INPUT_TYPE = "events.iterate.com/echo-example/input-received";
+const OUTPUT_TYPE = "events.iterate.com/echo-example/output-echoed";
+
+let counter = 0;
+function freshNames() {
+  counter += 1;
+  return { streamName: `adv:/adv/t${counter}`, runnerName: `adv-runner-${counter}` };
+}
+
+async function appendEvent(
+  stream: DurableObjectStub<Stream>,
+  event: { type: string; payload: unknown },
+) {
+  return await runInDurableObject(stream, (instance) => instance.append({ event }));
+}
+async function getEvents(stream: DurableObjectStub<Stream>): Promise<StreamEvent[]> {
+  return await runInDurableObject(stream, (instance) => instance.getEvents({ afterOffset: 0 }));
+}
+async function severProducer(stream: DurableObjectStub<Stream>) {
+  await runInDurableObject(stream, (instance) => instance.runIdleTeardownNow());
+}
+async function severSubscriber(runner: DurableObjectStub<StreamProcessorRunner>) {
+  await runInDurableObject(runner, (instance) => instance.runIdleDisconnectNow());
+}
+async function waitFor<T>(
+  fn: () => Promise<T | undefined | false>,
+  description: string,
+): Promise<T> {
+  for (let i = 0; i < 200; i += 1) {
+    const value = await fn();
+    if (value) return value as T;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+async function expectEchoSeen(
+  stream: DurableObjectStub<Stream>,
+  afterOffset: number,
+  label: string,
+) {
+  const echoed = await waitFor(
+    async () =>
+      (await getEvents(stream)).find((e) => e.type === OUTPUT_TYPE && e.offset > afterOffset),
+    label,
+  );
+  return (echoed.payload as { seen: number }).seen;
+}
+async function configureEchoSubscription(args: { streamName: string; runnerName: string }) {
+  const stream = STREAM.getByName(args.streamName);
+  await appendEvent(stream, {
+    type: "events.iterate.com/stream/subscription-configured",
+    payload: {
+      subscriptionKey: `echo:${args.runnerName}`,
+      subscriber: durableObjectProcessorSubscriber({
+        bindingName: "STREAM_PROCESSOR_RUNNER",
+        durableObjectName: args.runnerName,
+        processorName: "echo-example",
+      }),
+    },
+  });
+  return stream;
+}
+
+describe("idle teardown — adversarial pressure", () => {
+  it("severs the PRODUCER before every append (forced cold re-dial each time) with no lost or duplicated echoes", async () => {
+    const { streamName, runnerName } = freshNames();
+    const stream = await configureEchoSubscription({ streamName, runnerName });
+
+    const seen: number[] = [];
+    for (let n = 1; n <= 5; n += 1) {
+      await severProducer(stream); // tear the session down right before the append
+      const input = await appendEvent(stream, { type: INPUT_TYPE, payload: { n } });
+      seen.push(await expectEchoSeen(stream, input.offset, `echo ${n} after cold re-dial`));
+    }
+    // Exactly-once across 5 forced re-dials: the durable checkpoint makes the
+    // processor's input count advance 1..5 with no gap (loss) or repeat (dup).
+    expect(seen).toEqual([1, 2, 3, 4, 5]);
+  }, 60_000);
+
+  it("survives BOTH timers firing between appends (producer sever + subscriber disconnect)", async () => {
+    const { streamName, runnerName } = freshNames();
+    const stream = await configureEchoSubscription({ streamName, runnerName });
+    const runner = RUNNER.getByName(runnerName);
+
+    const first = await appendEvent(stream, { type: INPUT_TYPE, payload: { n: 1 } });
+    expect(await expectEchoSeen(stream, first.offset, "echo 1")).toBe(1);
+
+    // Both sides independently tear the same session down, in the worst order.
+    await severSubscriber(runner);
+    await severProducer(stream);
+
+    const second = await appendEvent(stream, { type: INPUT_TYPE, payload: { n: 2 } });
+    expect(await expectEchoSeen(stream, second.offset, "echo 2 after both-sided teardown")).toBe(2);
+  }, 60_000);
+
+  it("severing a quiet stream with no live connection is a harmless no-op", async () => {
+    const { streamName, runnerName } = freshNames();
+    const stream = await configureEchoSubscription({ streamName, runnerName });
+    // Sever twice in a row with no append in between — the second sever has
+    // nothing to close and must not throw, re-dial, or wedge later delivery.
+    await severProducer(stream);
+    await severProducer(stream);
+    const input = await appendEvent(stream, { type: INPUT_TYPE, payload: { n: 1 } });
+    expect(await expectEchoSeen(stream, input.offset, "echo after double-sever")).toBe(1);
+  }, 60_000);
+});

--- a/packages/streams/src/workers/durable-objects/stream-idle-teardown.workers.test.ts
+++ b/packages/streams/src/workers/durable-objects/stream-idle-teardown.workers.test.ts
@@ -1,0 +1,119 @@
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+// Regression test for the Durable Objects billable-duration leak (#1500 fallout):
+// a Stream DO that holds an idle OUTBOUND delivery connection keeps a
+// cross-isolate RPC session open, pinning BOTH itself and the subscriber DO
+// resident — billing duration for hours at ~0 CPU. The fix gives the Stream DO
+// an in-memory idle timer that severs outbound connections once a stream goes
+// quiet, so both DOs can hibernate; the durable subscription config is kept, so
+// the next append re-dials and the subscriber re-handshakes from its checkpoint.
+//
+// Drives the real leak path: Stream DO -> Callable dial -> StreamProcessorRunner
+// (echo processor) -> subscribeOutbound -> retained callback stub.
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { durableObjectProcessorSubscriber } from "../../shared/callable-subscriber.ts";
+import type { StreamEvent } from "../../shared/event.ts";
+import type { Stream } from "./stream.ts";
+
+const STREAM = (env as unknown as { STREAM: DurableObjectNamespace<Stream> }).STREAM;
+
+const INPUT_TYPE = "events.iterate.com/echo-example/input-received";
+const OUTPUT_TYPE = "events.iterate.com/echo-example/output-echoed";
+const DISCONNECTED_TYPE = "events.iterate.com/stream/subscriber-disconnected";
+
+let counter = 0;
+function freshNames() {
+  counter += 1;
+  return { streamName: `idle:/idle/t${counter}`, runnerName: `idle-runner-${counter}` };
+}
+
+async function appendEvent(
+  stream: DurableObjectStub<Stream>,
+  event: { type: string; payload: unknown; idempotencyKey?: string },
+) {
+  return await runInDurableObject(stream, (instance) => instance.append({ event }));
+}
+
+async function getEvents(stream: DurableObjectStub<Stream>): Promise<StreamEvent[]> {
+  return await runInDurableObject(stream, (instance) => instance.getEvents({ afterOffset: 0 }));
+}
+
+async function outboundConnectionKeys(stream: DurableObjectStub<Stream>): Promise<string[]> {
+  return await runInDurableObject(stream, (instance) =>
+    Object.entries(instance.runtimeState().runtime.connections)
+      .filter(([, connection]) => connection.direction === "outbound")
+      .map(([key]) => key),
+  );
+}
+
+async function waitFor<T>(
+  fn: () => Promise<T | undefined | false>,
+  description: string,
+  { attempts = 100, delay = 50 } = {},
+): Promise<T> {
+  for (let i = 0; i < attempts; i += 1) {
+    const value = await fn();
+    if (value) return value as T;
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+async function configureEchoSubscription(args: { streamName: string; runnerName: string }) {
+  const stream = STREAM.getByName(args.streamName);
+  await appendEvent(stream, {
+    type: "events.iterate.com/stream/subscription-configured",
+    payload: {
+      subscriptionKey: `echo:${args.runnerName}`,
+      subscriber: durableObjectProcessorSubscriber({
+        bindingName: "STREAM_PROCESSOR_RUNNER",
+        durableObjectName: args.runnerName,
+        processorName: "echo-example",
+      }),
+    },
+  });
+  return stream;
+}
+
+describe("idle outbound teardown lets a quiet Stream DO hibernate", () => {
+  it("severs the idle outbound connection, records reason 'idle', then re-dials on the next append", async () => {
+    const { streamName, runnerName } = freshNames();
+    const stream = await configureEchoSubscription({ streamName, runnerName });
+
+    // The dial establishes a live outbound connection — the leak's pin.
+    const first = await appendEvent(stream, { type: INPUT_TYPE, payload: { n: 1 } });
+    await waitFor(
+      async () =>
+        (await getEvents(stream)).some((e) => e.type === OUTPUT_TYPE && e.offset > first.offset),
+      "echo of the first input",
+    );
+    await waitFor(
+      async () => (await outboundConnectionKeys(stream)).length > 0,
+      "a live outbound delivery connection",
+    );
+
+    // The stream goes quiet: the idle timer fires (invoked directly for
+    // determinism — the same action the in-memory timer takes).
+    await runInDurableObject(stream, (instance) => instance.runIdleTeardownNow());
+
+    // The outbound connection is gone, so nothing pins the DO any more ...
+    expect(await outboundConnectionKeys(stream)).toEqual([]);
+    // ... and the deliberate teardown is recorded with reason "idle".
+    const afterTeardown = await getEvents(stream);
+    expect(
+      afterTeardown.some(
+        (e) => e.type === DISCONNECTED_TYPE && (e.payload as { reason?: string }).reason === "idle",
+      ),
+    ).toBe(true);
+
+    // The durable subscription config survived: the next append re-dials the
+    // subscriber (it re-handshakes from its checkpoint) and the echo lands.
+    const second = await appendEvent(stream, { type: INPUT_TYPE, payload: { n: 2 } });
+    const echoed = await waitFor(
+      async () =>
+        (await getEvents(stream)).find((e) => e.type === OUTPUT_TYPE && e.offset > second.offset),
+      "echo after re-dial",
+    );
+    expect((echoed.payload as { seen: number }).seen).toBe(2);
+  }, 30_000);
+});

--- a/packages/streams/src/workers/durable-objects/stream-processor-runner.ts
+++ b/packages/streams/src/workers/durable-objects/stream-processor-runner.ts
@@ -32,6 +32,15 @@ export class StreamProcessorRunner extends DurableObject {
   runtimeState(args?: { processorName?: string }): HostedProcessorRuntimeState {
     return this.host.runtimeState(args?.processorName);
   }
+
+  /**
+   * Subscriber-side idle teardown (belt-and-braces companion to the Stream DO's):
+   * drop retained stream stubs so this DO and the producer can hibernate. The
+   * idle timer calls this automatically; exposed for tests/operators.
+   */
+  runIdleDisconnectNow(): void {
+    this.host.runIdleDisconnectNow();
+  }
 }
 
 export const StreamProcessorRunnerRpcTarget = makeRpcTargetClass<

--- a/packages/streams/src/workers/durable-objects/stream.ts
+++ b/packages/streams/src/workers/durable-objects/stream.ts
@@ -491,17 +491,27 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
     this.coreProcessor.wakeConnections();
 
     // Re-dial any configured subscription left without a live connection — e.g.
-    // an idle teardown (here or on the subscriber) severed it. The subscriber
-    // re-handshakes from its durable checkpoint, so replay covers this very
-    // event. Cheap (O(subscriptions)) and a no-op once everything is connected.
-    // Gated to DOMAIN appends: the teardown's own subscriber-disconnected fact
-    // (a `stream/*` system event) must NOT re-dial, or idle teardown would
-    // instantly undo itself. `woken`/`subscription-configured` already reconcile
-    // via the core's reduced-event side effect.
-    const hasDomainAppend = newEvents.some(
-      (event) => !event.type.startsWith("events.iterate.com/stream/"),
+    // an idle teardown (here or on the subscriber), a clean unsubscribe, etc.
+    // severed it. The subscriber re-handshakes from its durable checkpoint, so
+    // replay covers this very event. Cheap (O(subscriptions)) and a no-op once
+    // everything is connected.
+    //
+    // Exactly ONE event type is excluded as a re-dial trigger:
+    // `subscriber-disconnected`. `connection.close()` appends one as it removes
+    // the connection from the map, so at that instant `needsOutboundReconcile()`
+    // is transiently true for the just-closed key — reconciling on it would
+    // immediately re-dial and undo every teardown (idle / unsubscribed /
+    // replaced / …). Re-dial must wait for the next genuine append. Every OTHER
+    // event is safe to trigger on: `woken` and `subscription-configured` have
+    // already reconciled via the core's reduced-event side effect (so the check
+    // is a no-op), and `subscriber-connected` only lands while its key is
+    // connected/connecting (also a no-op). We deliberately do NOT exclude the
+    // whole `stream/*` namespace — only this single self-undoing event.
+    const SUBSCRIBER_DISCONNECTED_TYPE = "events.iterate.com/stream/subscriber-disconnected";
+    const hasRedialTriggeringAppend = newEvents.some(
+      (event) => event.type !== SUBSCRIBER_DISCONNECTED_TYPE,
     );
-    if (hasDomainAppend && this.coreProcessor.needsOutboundReconcile()) {
+    if (hasRedialTriggeringAppend && this.coreProcessor.needsOutboundReconcile()) {
       this.coreProcessor.reconcileConnections();
     }
 

--- a/packages/streams/src/workers/durable-objects/stream.ts
+++ b/packages/streams/src/workers/durable-objects/stream.ts
@@ -48,8 +48,20 @@ const textEncoder = new TextEncoder();
 //      events instead of the removed processor-registered event.
 const CORE_STATE_VERSION = 4;
 
+// How long a stream may hold idle OUTBOUND delivery connections before the
+// Stream DO severs them so it (and its subscribers) can hibernate instead of
+// accruing billable duration on cross-isolate RPC sessions that pin both DOs.
+// Tracked with an in-memory timer (NOT a DO alarm): the retained stubs we tear
+// down are in-memory and die on eviction anyway, the DO is always resident while
+// it holds them (so the timer is guaranteed to fire), and a durable alarm's only
+// extra power — waking a hibernated DO — is exactly what we must never do.
+// Overridable via the STREAM_IDLE_TEARDOWN_MS env var (used by tests).
+const DEFAULT_STREAM_IDLE_TEARDOWN_MS = 5 * 60_000;
+
 export class Stream extends DurableObject<Env> implements StreamRpc {
   #coreProcessorState: StreamCoreProcessorState;
+  /** In-memory idle teardown timer; armed only while outbound connections exist. */
+  #idleTimer: ReturnType<typeof setTimeout> | undefined;
   // The core processor owns the live delivery connections and reconciles them
   // against reduced state; this DO supplies the storage and RPC mechanics it
   // needs (committed-event reads, the live state, Callable dispatch).
@@ -478,6 +490,26 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
     // subscription-configured facts, which ran in the loop above.)
     this.coreProcessor.wakeConnections();
 
+    // Re-dial any configured subscription left without a live connection — e.g.
+    // an idle teardown (here or on the subscriber) severed it. The subscriber
+    // re-handshakes from its durable checkpoint, so replay covers this very
+    // event. Cheap (O(subscriptions)) and a no-op once everything is connected.
+    // Gated to DOMAIN appends: the teardown's own subscriber-disconnected fact
+    // (a `stream/*` system event) must NOT re-dial, or idle teardown would
+    // instantly undo itself. `woken`/`subscription-configured` already reconcile
+    // via the core's reduced-event side effect.
+    const hasDomainAppend = newEvents.some(
+      (event) => !event.type.startsWith("events.iterate.com/stream/"),
+    );
+    if (hasDomainAppend && this.coreProcessor.needsOutboundReconcile()) {
+      this.coreProcessor.reconcileConnections();
+    }
+
+    // Re-arm (or clear) the in-memory idle timer against the post-append
+    // connection set, so a stream that just went quiet sheds its outbound
+    // delivery sessions and lets both DOs hibernate.
+    this.#armOrClearIdleTimer();
+
     return events;
   }
 
@@ -580,6 +612,39 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
         connections: this.coreProcessor.connectionsRuntimeState(),
       },
     };
+  }
+
+  #idleTeardownMs(): number {
+    const raw = (this.env as { STREAM_IDLE_TEARDOWN_MS?: string | number }).STREAM_IDLE_TEARDOWN_MS;
+    const parsed = typeof raw === "string" ? Number(raw) : raw;
+    return typeof parsed === "number" && Number.isFinite(parsed) && parsed > 0
+      ? parsed
+      : DEFAULT_STREAM_IDLE_TEARDOWN_MS;
+  }
+
+  // Keep the in-memory idle timer armed only while the DO holds outbound
+  // delivery connections (the thing that pins it resident). Reset on every
+  // append; cleared once no outbound connection remains. No storage writes, and
+  // nothing scheduled against a hibernated DO.
+  #armOrClearIdleTimer(): void {
+    if (this.#idleTimer !== undefined) {
+      clearTimeout(this.#idleTimer);
+      this.#idleTimer = undefined;
+    }
+    if (!this.coreProcessor.hasLiveOutboundConnections()) return;
+    this.#idleTimer = setTimeout(() => this.runIdleTeardownNow(), this.#idleTeardownMs());
+  }
+
+  /**
+   * Sever every idle outbound connection now — the idle timer's action, also
+   * callable directly (tests / operator "put this quiet stream to sleep").
+   * Disposes the retained callback stubs so the freed subscriber DOs hibernate;
+   * the durable subscription config is kept, so the next append re-dials
+   * (`needsOutboundReconcile` in `#appendBatchHere`).
+   */
+  runIdleTeardownNow(): void {
+    this.#idleTimer = undefined;
+    this.coreProcessor.closeIdleOutboundConnections();
   }
 
   /**

--- a/packages/streams/src/workers/stream-processor-host.ts
+++ b/packages/streams/src/workers/stream-processor-host.ts
@@ -116,6 +116,17 @@ type HostedEntry = {
 // subscriber/processor (or a later re-dial) to decide whether to re-establish.
 const MAX_CONSECUTIVE_INGEST_FAILURES = 3;
 
+// Belt-and-braces companion to the Stream DO's idle teardown. A host that holds a
+// subscription's retained stream stub (`entry.stream`) pins the producer Stream
+// DO resident. If no batch arrives for this long, the host unsubscribes and
+// disposes its stream stubs so BOTH this subscriber DO and the producer can
+// hibernate; the durable checkpoint + subscription-key persist, so the producer
+// re-dials and the host re-handshakes when activity resumes. In-memory timer for
+// the same reason as the Stream DO side: the stubs are in-memory and the DO is
+// resident while it holds them, so the timer is guaranteed to fire — and a
+// durable alarm's only extra power, waking a hibernated DO, is exactly wrong.
+const HOST_IDLE_TEARDOWN_MS = 5 * 60_000;
+
 export type StreamProcessorHost = {
   /**
    * Register a named processor. The builder receives the host-provided base
@@ -128,6 +139,15 @@ export type StreamProcessorHost = {
   requestStreamSubscription(args: RequestStreamSubscriptionArgs): Promise<void>;
   /** Durable processor state for tests and operator inspection. */
   runtimeState(processorName?: string): HostedProcessorRuntimeState;
+  /**
+   * Drop every live subscription's retained stream stub now — the idle timer's
+   * action, also callable directly (tests / operator "let this idle subscriber
+   * sleep"). Unsubscribes from the producer (so the producer disposes its
+   * callback stub and frees this DO) and disposes the stream handle (freeing the
+   * producer Stream DO). The durable checkpoint + subscription-key persist, so
+   * the producer re-dials and this host re-handshakes on the next activity.
+   */
+  runIdleDisconnectNow(): void;
 };
 
 export function createStreamProcessorHost(ctx: DurableObjectState): StreamProcessorHost {
@@ -172,6 +192,54 @@ export function createStreamProcessorHost(ctx: DurableObjectState): StreamProces
     );
   }
 
+  // In-memory idle teardown: drop retained stream stubs after a quiet spell so
+  // this subscriber DO (and the producer it pins) can hibernate. See
+  // HOST_IDLE_TEARDOWN_MS.
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function hasLiveSubscription(): boolean {
+    for (const entry of entries.values()) if (entry.stream !== undefined) return true;
+    return false;
+  }
+
+  // (Re)armed on every handshake and every delivered batch; cleared once no
+  // entry holds a live stream stub. The DO is resident while it holds stubs, so
+  // the timer is guaranteed to fire.
+  function armIdleTimer(): void {
+    if (idleTimer !== undefined) {
+      clearTimeout(idleTimer);
+      idleTimer = undefined;
+    }
+    if (!hasLiveSubscription()) return;
+    idleTimer = setTimeout(runIdleDisconnectNow, HOST_IDLE_TEARDOWN_MS);
+  }
+
+  function runIdleDisconnectNow(): void {
+    idleTimer = undefined;
+    for (const entry of entries.values()) {
+      const stream = entry.stream;
+      if (stream === undefined) continue;
+      // Bump the generation so any batch still queued on this connection is
+      // dropped by the gate in openSubscription. Then unsubscribe — the producer
+      // closes the connection and disposes its callback stub, freeing THIS DO —
+      // and dispose our retained stream stub, freeing the producer Stream DO.
+      // The durable checkpoint + subscription-key persist (we only clear the
+      // in-memory handle/stream/namespace/path), so the producer's next re-dial
+      // re-handshakes us from where we left off.
+      entry.generation += 1;
+      try {
+        entry.handle?.unsubscribe();
+      } catch {
+        // The producer may already be gone; the stub is dead either way.
+      }
+      entry.handle = undefined;
+      stream[Symbol.dispose]();
+      entry.stream = undefined;
+      entry.namespace = undefined;
+      entry.path = undefined;
+    }
+  }
+
   // (Re)opens the outbound subscription from the processor's durable checkpoint.
   // Called for the initial handshake and again by `recoverFromIngestFailure`, so
   // a failed batch replays from the last good offset instead of being skipped.
@@ -208,6 +276,8 @@ export function createStreamProcessorHost(ctx: DurableObjectState): StreamProces
         processor: announceContract(entry.processor.contract),
       },
       processEventBatch: (batch) => {
+        // A batch arrived — this subscription is active; reset the idle countdown.
+        armIdleTimer();
         // Serialize ingest per processor so the generation gate is re-checked
         // *between* batches: a batch queued on a now-dead connection must be
         // dropped, not ingested. ingest serializes internally too, but that
@@ -235,6 +305,8 @@ export function createStreamProcessorHost(ctx: DurableObjectState): StreamProces
         return entry.ingestChain;
       },
     });
+    // A fresh handshake holds a live stream stub now; start the idle countdown.
+    armIdleTimer();
   }
 
   // A failed batch never advances the checkpoint. Re-handshake from it (the
@@ -362,6 +434,7 @@ export function createStreamProcessorHost(ctx: DurableObjectState): StreamProces
               },
       };
     },
+    runIdleDisconnectNow,
   };
 }
 


### PR DESCRIPTION
## Problem

After #1500 split os into per-DO workers, **Durable Objects billable compute duration** on prd jumped 100–1000× (dev/preview ~13× worse). Signature: individual DO invocations running **up to 17h wall-clock at ~0 CPU, 0 WebSockets**.

Root cause: a stream subscription's retained `processEventBatch` callback is a **cross-script RPC session**. An open session keeps a DO from hibernating (RPC has no hibernation API, only WebSockets do), so it bills duration the whole time. Pre-split these were same-isolate references (free); the split made them cross-isolate sessions that pin **both** the Stream DO and the subscriber DO. There is no idle teardown, so a subscription to a quiet stream stays pinned forever.

Full investigation + alternatives + design decisions: `apps/os/tasks/do-duration-leak/`.

## Fix (this PR — producer side; subscriber-side belt-and-braces incoming)

The Stream DO now holds an **in-memory idle timer** (deliberately not a durable alarm — the stubs are in-memory and the DO is always resident while it holds them, so the timer is guaranteed to fire; an alarm would only ever wake a *hibernated* DO and would write storage on every append). When a stream goes quiet it severs its outbound delivery connections, disposing the retained stubs so both DOs hibernate. The durable subscription config is kept; the next domain append re-dials and the subscriber re-handshakes from its checkpoint (replay covers the gap).

## Tests

- New `stream-idle-teardown.workers.test.ts` drives the real echo-runner outbound path: sever → records reason `"idle"` → re-dials and delivers on the next append.
- Green: 79 streams node + 16 streams workers (incl. M1 re-dial) + 13 apps/os inbound itx-stream-subscribe. No regressions.

## Still to come on this branch

- [ ] Subscriber-side (StreamProcessorHost) idle disconnect + failing test
- [ ] Preview-env reproduction + adversarial pressure test (real billing signal)
- [ ] Defense-in-depth recurrence guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-14T09:09:45.698Z",
      "headSha": "44b0c41371e24be79041e98333bf654ae031cf48",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27493860158",
      "shortSha": "44b0c41"
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-14T09:09:32.356Z",
      "headSha": "44b0c41371e24be79041e98333bf654ae031cf48",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27493860158",
      "shortSha": "44b0c41"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `44b0c41`
Preview: https://auth.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27493860158)
Updated: 2026-06-14T09:09:45.698Z

### OS
Status: released
Commit: `44b0c41`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27493860158)
Updated: 2026-06-14T09:09:32.356Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core stream subscription lifecycle and cross-DO RPC retention on the hot append path; delivery bugs could cause loss, duplication, or stuck subscriptions, though behavior is heavily covered by new workerd tests.
> 
> **Overview**
> Fixes **post-#1500 Durable Objects billable-duration blow-up** from idle **cross-isolate stream subscription RPC** sessions pinning both the Stream DO and subscriber DOs for hours at ~0 CPU.
> 
> **Stream DO (producer):** After ~5 minutes with no appends while **outbound** delivery connections exist, an in-memory timer severs those connections (`closeIdleOutboundConnections`), disposes retained `processEventBatch` stubs, and records disconnect reason **`idle`**. Durable `subscriptionsByKey` is unchanged. On the next real append, **`needsOutboundReconcile`** triggers re-dial unless the batch is only `subscriber-disconnected` (avoids instantly undoing teardown).
> 
> **StreamProcessorHost (subscriber):** Matching idle timer resets on handshake and each delivered batch; on fire **`runIdleDisconnectNow`** unsubscribes and disposes retained stream stubs so the producer side can hibernate too. Exposed on **`StreamProcessorRunner`** for tests.
> 
> **Defense-in-depth:** New **`apps/os/scripts/do-duration-probe.ts`** (`pnpm probe:do-duration`) queries CF GraphQL for pinned-DO signatures (very high wallTime p99) and exits non-zero for cron/CI. Task docs under **`apps/os/tasks/do-duration-leak/`**.
> 
> **Tests:** Worker regression + adversarial suites (forced re-dial, both-sided teardown, exactly-once across sever cycles).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44b0c41371e24be79041e98333bf654ae031cf48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->