### PR TITLE
fix(slack): ACK unclaimed-workspace webhooks with 200 to stop Slack auto-disable

### DIFF
--- a/apps/os/src/domains/secrets/integration-api.ts
+++ b/apps/os/src/domains/secrets/integration-api.ts
@@ -280,6 +280,56 @@ async function handleSlackInteractivityWebhook(input: {
   });
 }
 
+/**
+ * Handle one inbound Slack webhook (Events API callback or interactivity POST).
+ *
+ * ## The cardinal rule: ACK every *validly-signed* event with an HTTP 2xx
+ *
+ * Our Slack app is **distributed** — a single app (one signing secret, one
+ * Request URL) installed across many workspaces. Slack does not give each
+ * workspace its own endpoint: every install POSTs the same
+ * `/api/integrations/slack/webhook` URL. But only a handful of those workspaces
+ * are ever "claimed" by an OS project, so the *majority* of events we receive
+ * are for teams we have nowhere to route to.
+ *
+ * Slack treats ANY non-2xx response as a failed delivery, and it auto-disables
+ * an app's event subscriptions — for ALL workspaces, not just the failing one —
+ * when failures exceed 95% of attempts over a rolling 60-minute window:
+ *
+ *   https://docs.slack.dev/apis/events-api/  ("Failure limits")
+ *   > When your application enters any combination of these failure conditions
+ *   > for more than 95% of delivery attempts within 60 minutes, your
+ *   > application's event subscriptions will be temporarily disabled.
+ *   > ...We receive any other response than an HTTP 200-series response.
+ *
+ * So if we answer "team not claimed" with a 404 (as this handler used to), a
+ * distributed app whose traffic is mostly unclaimed workspaces sits permanently
+ * above the 95% failure line. Slack disables delivery for the entire app and
+ * even the *claimed* workspaces go silent. This is exactly the prd outage of
+ * 2026-06-15: ~99% of webhook responses were 404s and the one claimed workspace
+ * stopped receiving events. See `incident_slack_webhook_404_autodisable`.
+ *
+ * The fix is to ACK-and-drop: any request that is validly signed but that we
+ * can't route (unparseable body, no team id, unclaimed team) returns a **200**.
+ * The body of a 200 is ignored by Slack, so we include an `ignored` reason
+ * purely for our own debuggability. Dropping at 200 keeps our success rate at
+ * ~100% no matter how many unclaimed workspaces hammer the endpoint.
+ *
+ * Why a 200 rather than a non-2xx carrying `X-Slack-No-Retry: 1`? That header
+ * only suppresses *retries of a single event*; the original delivery still
+ * counts as a failure against the 95% auto-disable rule. Only a 2xx both
+ * suppresses the retry AND counts as a success. So 200 is strictly the right
+ * tool here — the no-retry header would not have prevented this outage.
+ *
+ * The ONE non-2xx we deliberately keep is the signature-verification failure
+ * (401). A request that fails signature verification is not proven to come from
+ * Slack at all — ACKing it 200 would let any unauthenticated caller flood us
+ * with "successful" writes, and the signature check is our entire trust
+ * boundary. The trade-off: if our OWN signing secret is ever misconfigured,
+ * *every* genuine Slack event 401s and Slack disables the app — but that is a
+ * loud, correct failure mode for "we can no longer authenticate Slack at all,"
+ * not the silent self-inflicted outage that unclaimed-team 404s caused.
+ */
 async function handleVerifiedSlackWebhook(input: {
   context: RequestContext;
   parsePayload(body: string): Record<string, unknown> | null;
@@ -293,25 +343,44 @@ async function handleVerifiedSlackWebhook(input: {
     signingSecret: config.webhookSigningSecret.exposeSecret(),
     timestamp: input.request.headers.get("x-slack-request-timestamp"),
   });
+  // Trust boundary — the only response we let stay non-2xx. See the doc comment
+  // above for why an unauthenticated request must NOT be ACKed with a 200.
   if (!valid) return Response.json({ error: "Invalid Slack signature." }, { status: 401 });
 
+  // From here down the request is provably from Slack (signature verified), so
+  // every "we can't use this" branch must ACK with a 200 and drop, never a 4xx.
   const payload = input.parsePayload(body);
-  if (!payload)
-    return Response.json({ error: "Slack webhook payload is invalid." }, { status: 400 });
+  if (!payload) {
+    // Signed but unparseable. Should be ~never; a non-2xx here would feed the
+    // auto-disable counter, so we still ACK and just note the reason.
+    return Response.json({ ok: true, ignored: "unparseable-payload" });
+  }
   if (payload.type === "url_verification") {
     return Response.json({ challenge: payload.challenge });
   }
 
   const teamId = readSlackTeamId(payload);
-  if (!teamId)
-    return Response.json({ error: "Slack webhook is missing team_id." }, { status: 400 });
+  if (!teamId) {
+    // Signed Slack event with no team id we can route on (e.g. some app-level
+    // events). Nothing to do, but it MUST be a 200 — see the doc comment.
+    return Response.json({ ok: true, ignored: "no-team-id" });
+  }
 
   const connection = await getProjectConnectionByWebhookIdentifier(input.context.db, {
     provider: "slack",
     webhookProviderIdentifier: teamId,
   });
   if (!connection) {
-    return Response.json({ error: "Slack team is not claimed by a project." }, { status: 404 });
+    // The common case for a distributed app: a workspace where our app is
+    // installed but which no OS project has claimed. This is the branch whose
+    // old 404 caused the 2026-06-15 outage — it is the *expected steady state*
+    // (most of our inbound traffic), so it MUST ACK with a 200 and drop.
+    //
+    // Intentionally not logged per-event: at hundreds of unclaimed events/hour
+    // this is normal background traffic, not an error. To measure the
+    // claimed/unclaimed split, group Slack webhook requests by response in
+    // Workers observability rather than scraping logs.
+    return Response.json({ ok: true, ignored: "team-not-claimed" });
   }
   const slackIntegrationName = getSlackIntegrationDurableObjectName(connection.projectId);
   const slackIntegration = getSlackIntegrationStub(connection.projectId) as unknown as {


### PR DESCRIPTION
## Problem

prd Slack went silent for project `iterate-v3dt0e` (workspace `T0675PSN873`). The connection was healthy — the failure was Slack-side **event-delivery auto-disable**.

Our Slack app (`A08NDMDC2JV`) is **distributed**: one signing secret + one Request URL across many workspaces. Only a handful are ever claimed by an OS project, so most inbound events are for workspaces we can't route. The webhook handler returned **404** ("team not claimed") for those.

Slack counts every non-2xx as a failed delivery and [temporarily disables an app's event subscriptions — for *all* workspaces — once failures exceed 95% over 60 min](https://docs.slack.dev/apis/events-api/). prd was at ~99% non-2xx (last 60 min: **592× 404, 8× 401, 4× 200**), so Slack disabled delivery and even the claimed workspace stopped receiving events.

Evidence the endpoint itself was fine: a correctly-signed synthetic webhook for `T0675PSN873` returned `200` and appended to the stream; the DB claim row is correct. The 404s pass signature verification, proving they're real events from *other* installed-but-unclaimed workspaces of the same app.

## Fix

Any **validly-signed** event we can't route (unparseable body, missing team id, unclaimed team) now ACKs with a **200** and drops, keeping the success rate ~100% regardless of how many unclaimed workspaces hit the endpoint.

- Kept the signature-failure path as **401** — it's the trust boundary; we must not ACK unauthenticated traffic.
- Chose 200 over a non-2xx + `X-Slack-No-Retry: 1`: that header only suppresses a single event's retry, the delivery still counts against the 95% rule. Only a 2xx both suppresses the retry and counts as success.
- Extensive comments on `handleVerifiedSlackWebhook` document the mechanism and both judgment calls.

| branch | before | after |
|--------|--------|-------|
| bad signature | 401 | **401** (unchanged) |
| unparseable body | 400 | **200** `{ok,ignored:"unparseable-payload"}` |
| no team id | 400 | **200** `{ok,ignored:"no-team-id"}` |
| **team not claimed** | **404** | **200** `{ok,ignored:"team-not-claimed"}` |

## Deploy / remediation

Slack has very likely already auto-disabled the subscription. **After deploying**, re-enable it at `api.slack.com/apps/A08NDMDC2JV` → Event Subscriptions. Re-enabling *before* the fix is live will just re-trip it within the hour.

## Notes
- Previews have no Slack config; dev uses a separate app — neither is involved.
- No existing test asserted the old 404/400 codes. Happy to add a unit test for the four branches of `handleVerifiedSlackWebhook` if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes webhook HTTP semantics for integration ingress (security boundary unchanged at 401); mis-handling could either drop legitimate events or reintroduce Slack-wide delivery disable.
> 
> **Overview**
> **Fixes Slack event delivery being auto-disabled** when most webhook traffic comes from installed-but-unclaimed workspaces on the distributed app.
> 
> `handleVerifiedSlackWebhook` now **ACKs with HTTP 200** (and an `ignored` reason) for any **validly signed** request that cannot be processed—unparseable body, missing team id, or **team not claimed**—instead of **400/404**. That keeps Slack’s delivery success rate high so subscriptions stay enabled for claimed workspaces. **Invalid signatures still return 401** as the trust boundary.
> 
> Adds a long doc comment on the handler explaining Slack’s 95%/60‑minute failure rule, why `X-Slack-No-Retry` is insufficient, and why unclaimed-team 404s caused the prd outage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18673cff95547a782f86514f817d12fb9a906d0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-15T10:16:42.576Z",
      "headSha": "18673cff95547a782f86514f817d12fb9a906d0a",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27538083001",
      "shortSha": "18673cf"
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-15T10:16:30.208Z",
      "headSha": "18673cff95547a782f86514f817d12fb9a906d0a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27538083001",
      "shortSha": "18673cf"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `18673cf`
Preview: https://auth.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27538083001)
Updated: 2026-06-15T10:16:42.576Z

### OS
Status: released
Commit: `18673cf`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27538083001)
Updated: 2026-06-15T10:16:30.208Z
<!-- /CLOUDFLARE_PREVIEW -->