### PR TITLE
fix(slack): make the router's webhook forward durable (don't drop on transient append failure)

### DIFF
--- a/apps/os/src/domains/slack/stream-processors/slack/implementation.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack/implementation.ts
@@ -147,9 +147,21 @@ export class SlackProcessor extends StreamProcessor<SlackProcessorContract, Slac
       args.runInBackground(async () => {
         await this.deps.prewarmRoutedStreamHosts?.({ streamPath });
       });
+      // Durable obligation, NOT best-effort: this forward is the only copy of
+      // the Slack message on its way to the agent. Run it under
+      // `blockProcessorWhile` so a failed append holds the checkpoint and the
+      // host replays this webhook until it lands. `runInBackground` would
+      // swallow the error, advance the checkpoint, and silently drop the
+      // message — which is exactly the prd outage of 2026-06-15: the first
+      // message on a freshly-created project hit a cold cross-worker
+      // StreamsCapability RPC that threw after ~4s, the forward was dropped, and
+      // the agent never saw it (the thread stream was created by the prewarm
+      // below but never received the webhook). The ack/prewarm above stay
+      // best-effort and remain on `runInBackground`.
+      //
       // Every append carries an idempotency key derived from the source event,
-      // so replays after a re-handshake dedupe instead of double-forwarding.
-      args.runInBackground(async () => {
+      // so the replay dedupes instead of double-forwarding.
+      args.blockProcessorWhile(async () => {
         await this.ctx.stream.append({ event: routeEvent });
         await this.ctx.stream.appendBatch({
           streamPath,
@@ -174,7 +186,10 @@ export class SlackProcessor extends StreamProcessor<SlackProcessorContract, Slac
      * shapes into agent input without this router needing to understand
      * agent semantics.
      */
-    args.runInBackground(async () => {
+    // Durable obligation — same reasoning as the route-creation forward above.
+    // Block the checkpoint so a failed append replays the webhook instead of
+    // dropping it; the idempotency key makes the replay a no-op if it landed.
+    args.blockProcessorWhile(async () => {
       await this.ctx.stream.append({ streamPath, event: forwardedWebhookEvent });
     });
   }

--- a/apps/os/src/domains/slack/stream-processors/slack/slack.test.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack/slack.test.ts
@@ -140,6 +140,67 @@ describe("SlackProcessor", () => {
     ]);
   });
 
+  it("replays the webhook when the forward append fails instead of dropping it", async () => {
+    // Regression for the prd 2026-06-15 loss: the first message on a fresh
+    // project reached the project stream but the agent never saw it. The router
+    // forwarded it with fire-and-forget `runInBackground`, so when the (cold,
+    // cross-worker) append threw, the error was swallowed, the checkpoint
+    // advanced, and the only copy of the message was dropped.
+    //
+    // The forward must be a durable obligation: a failed append rejects the
+    // batch and HOLDS the checkpoint so the host replays the webhook. This test
+    // fails against the old `runInBackground` wiring (ingest resolves, message
+    // lost) and passes under `blockProcessorWhile`.
+    const appended: Array<{ streamPath?: string; event: StreamEventInput }> = [];
+    let failNextAppend = true;
+    const processor = new SlackProcessor({
+      iterateContext: {
+        stream: {
+          append: async ({ event, streamPath }) => {
+            if (failNextAppend) {
+              failNextAppend = false;
+              throw new Error("cold StreamsCapability RPC failed");
+            }
+            appended.push({ event, streamPath });
+            return committedEvent({ ...event, offset: appended.length });
+          },
+          appendBatch: async ({ events, streamPath }) =>
+            events.map((event) => {
+              appended.push({ event, streamPath });
+              return committedEvent({ ...event, offset: appended.length });
+            }),
+        },
+      },
+      createRoutedStreamBootstrapEvents: () => [],
+    });
+
+    // First delivery: the append throws. ingest MUST reject and the checkpoint
+    // MUST stay at 0 — otherwise the webhook is gone for good.
+    await expect(
+      processor.ingest({
+        events: [webhookEvent({ offset: 7, text: "hello" })],
+        streamMaxOffset: 7,
+      }),
+    ).rejects.toThrow(/StreamsCapability/);
+    expect(processor.checkpointOffset).toBe(0);
+    expect(appended).toEqual([]);
+
+    // The host replays the same webhook from the un-advanced checkpoint; the
+    // append now succeeds, the forward lands, and the checkpoint advances.
+    await processor.ingest({
+      events: [webhookEvent({ offset: 7, text: "hello" })],
+      streamMaxOffset: 7,
+    });
+    expect(processor.checkpointOffset).toBe(7);
+    expect(
+      appended.some(
+        (entry) =>
+          entry.streamPath === "/agents/slack/c123/ts-1772136258-963519" &&
+          entry.event.type === "events.iterate.com/slack/webhook-received",
+      ),
+    ).toBe(true);
+  });
+
   it("ignores webhooks that cannot be keyed as channel:thread_ts", async () => {
     const { appended, processor } = createProcessor();
 


### PR DESCRIPTION
## Why

Follow-up to #1521, addressing the bug that actually silenced the agent in the 2026-06-15 prd incident.

A Slack message **did** reach the project's `/integrations/slack` stream, but the agent never replied. The `slack` router forwards each webhook to the agent's thread stream (`/agents/slack/<channel>/ts-<ts>`) using fire-and-forget `runInBackground`. Per the processor framework, only `blockProcessorWhile` work holds the checkpoint — `runInBackground` failures are caught, logged, and **the checkpoint advances anyway**. So when the forwarding append threw, the message was silently dropped and never retried.

In the incident: the first message on a freshly-created project hit a cold cross-worker `StreamsCapability` RPC that threw after ~4s (the only `os-prd-itx` error in 6h, `wallTimeMs: 4125`, `outcome: exception`). The `prewarm` had already created the thread stream, so it existed but contained only `stream/created` + `stream/woken` — the webhook, route event, and agent input never landed. No input → no agent run → no reply.

## Fix

Move both forwarding appends (route-creation path and known-route path) from `runInBackground` to `blockProcessorWhile`. A failed append now fails the batch and holds the checkpoint, so the host replays the webhook from the un-advanced checkpoint until it lands. The forwarded events already carry idempotency keys (`slack-route:<key>`, `slack/forward-slack-webhook@<offset>`), so the replay dedupes instead of double-forwarding.

The 👀 ack (`acknowledgeRoutedWebhook`) and host `prewarm` are genuinely best-effort and **stay** on `runInBackground`.

No Slack-facing latency change: the router runs as an async subscriber *after* the webhook ingress already returned 200 to Slack.

## Regression test

Added `replays the webhook when the forward append fails instead of dropping it`: the mock `stream.append` throws once, then the test asserts `ingest()` **rejects** and `checkpointOffset` stays `0`, then that a replay recovers the forward and advances the checkpoint. Verified it **fails against the old `runInBackground` wiring** (ingest resolves, message lost) and passes under the fix.

```
Test Files  1 passed (1)
     Tests  10 passed (10)
```

## Notes
- This is the durability defect; #1521 is the separate webhook-ACK fix. Independent files, independent PRs.
- The specific lost message won't self-heal (the router checkpointed past it); this prevents the class of loss going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delivery semantics for critical message-forwarding paths; mitigated by existing idempotency keys and a targeted regression test, but affects production Slack routing behavior.
> 
> **Overview**
> Fixes silent loss of Slack messages when forwarding webhooks from the integration router to agent thread streams: **both** forwarding paths (new-route bootstrap + known-route forward) now run under **`blockProcessorWhile`** instead of **`runInBackground`**, so a failed stream append rejects ingest and **keeps the processor checkpoint**, allowing the host to replay the webhook until the forward succeeds. Existing idempotency keys on forwarded events prevent double-delivery on replay.
> 
> **Ack** (`acknowledgeRoutedWebhook`) and **prewarm** stay on **`runInBackground`** as best-effort work that must not block routing durability.
> 
> Adds a regression test that simulates a cold append failure: first `ingest` rejects and checkpoint stays at 0; replay succeeds and the webhook lands on the routed stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b44e5a1f4d345552a5e37b5e7c2ae66dd0925585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-15T10:48:07.471Z",
      "headSha": "b44e5a1f4d345552a5e37b5e7c2ae66dd0925585",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27540174544",
      "shortSha": "b44e5a1"
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-15T10:47:54.838Z",
      "headSha": "b44e5a1f4d345552a5e37b5e7c2ae66dd0925585",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27540174544",
      "shortSha": "b44e5a1"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `b44e5a1`
Preview: https://auth.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27540174544)
Updated: 2026-06-15T10:48:07.471Z

### OS
Status: released
Commit: `b44e5a1`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27540174544)
Updated: 2026-06-15T10:47:54.838Z
<!-- /CLOUDFLARE_PREVIEW -->