### PR TITLE
[codex] stop adding random chars to project slugs and fix project slug adoption 

### DIFF
--- a/apps/auth/src/server/orpc/routers/_shared.ts
+++ b/apps/auth/src/server/orpc/routers/_shared.ts
@@ -1,6 +1,10 @@
 import { OrganizationRole } from "@iterate-com/auth-contract";
 import { parseProjectMetadata, parseTimestampMs } from "../../db/helpers.ts";
-import type { insertProjectReturning, updateProjectReturning } from "../../db/queries/index.ts";
+import type {
+  getProjectBySlug,
+  insertProjectReturning,
+  updateProjectReturning,
+} from "../../db/queries/index.ts";
 
 export function generateId(prefix: string) {
   return `${prefix}_${crypto.randomUUID().replace(/-/g, "")}`;
@@ -52,14 +56,25 @@ export function toMembershipRole(role: string | null | undefined): OrganizationR
   return OrganizationRole.parse(role ?? "member");
 }
 
-type ReturnedProjectRow = (insertProjectReturning.Result | updateProjectReturning.Result) &
+type ReturnedProjectRow = (
+  | getProjectBySlug.Result
+  | insertProjectReturning.Result
+  | updateProjectReturning.Result
+) &
   Partial<{ organizationId: string; archivedAt?: number }>;
 
 export function toProjectRecordFromReturnedRow(project: ReturnedProjectRow) {
   const organizationId =
-    typeof project.organizationId === "string" ? project.organizationId : project.organization_id;
+    "organization_id" in project && typeof project.organization_id === "string"
+      ? project.organization_id
+      : project.organizationId;
   const archivedAt =
-    typeof project.archivedAt === "number" ? project.archivedAt : project.archived_at;
+    "archived_at" in project && typeof project.archived_at === "number"
+      ? project.archived_at
+      : project.archivedAt;
+  if (!organizationId) {
+    throw new Error(`Project ${project.id} is missing organization id`);
+  }
 
   return toProjectRecord({
     id: project.id,

--- a/apps/auth/src/server/orpc/routers/internal.ts
+++ b/apps/auth/src/server/orpc/routers/internal.ts
@@ -8,8 +8,6 @@ import {
   getOAuthClientByClientId,
   getOAuthClientByReferenceId,
   getOrganizationBySlug,
-  getProjectById,
-  getProjectBySlug,
   getUserByEmail,
   getUserById,
   insertMembership,
@@ -30,6 +28,7 @@ import {
   toProjectRecordFromReturnedRow,
   toUserRecord,
 } from "./_shared.ts";
+import { resolveProjectCreateTarget } from "./project-slugs.ts";
 
 function extractCookieHeader(setCookieHeader: string | null): string | null {
   if (!setCookieHeader) return null;
@@ -195,24 +194,25 @@ const createForOrganization = os.internal.project.createForOrganization
       throw new ORPCError("NOT_FOUND", { message: "Organization not found" });
     }
 
-    const slug = await resolveUniqueSlug({
+    const target = await resolveProjectCreateTarget({
+      db: context.db,
+      id: input.id,
       name: input.name,
+      organizationId: organization.id,
       slug: input.slug,
-      isTaken: async (candidate) =>
-        Boolean(await getProjectBySlug(context.db, { slug: candidate })),
     });
+    if (target.kind === "existing") {
+      return toProjectRecordFromReturnedRow(target.project);
+    }
 
     const projectId = input.id ?? generateId("prj");
-    if (input.id && (await getProjectById(context.db, { id: input.id }))) {
-      throw new ORPCError("CONFLICT", { message: "Project ID already exists" });
-    }
 
     const now = Date.now();
     const created = await insertProjectReturning(context.db, {
       id: projectId,
       organizationId: organization.id,
       name: input.name,
-      slug,
+      slug: target.slug,
       metadata: JSON.stringify(input.metadata ?? {}),
       archivedAt: null,
       createdAt: now,

--- a/apps/auth/src/server/orpc/routers/project-slugs.ts
+++ b/apps/auth/src/server/orpc/routers/project-slugs.ts
@@ -1,0 +1,70 @@
+import { ORPCError } from "@orpc/server";
+import { slugify } from "@iterate-com/shared/slug";
+import type { Client } from "sqlfu";
+import { getProjectById, getProjectBySlug } from "../../db/queries/index.ts";
+
+type ExistingProject = getProjectBySlug.Result;
+
+// Auth is the durable source for user-owned projects, while OS keeps its own
+// per-environment project row. In preview/dev we often delete the OS worker's
+// D1 database without deleting auth's database. OS then reads the auth session,
+// shows the user "orphaned" auth projects, and lets them quickly recreate the
+// missing OS rows.
+//
+// This resolver is the auth-side half of that adoption flow:
+// - same organization + same slug, optionally with the same id, means "use the
+//   project auth already knows about";
+// - same slug in another organization is a real conflict;
+// - we never append random suffixes, because OS must recreate the exact auth
+//   project slug so routes and project hostnames stay stable across DB resets.
+export type ProjectCreateTarget =
+  | { kind: "existing"; project: ExistingProject }
+  | { kind: "new"; slug: string };
+
+export async function resolveProjectCreateTarget(input: {
+  db: Client;
+  id?: string;
+  name: string;
+  organizationId: string;
+  slug?: string;
+}): Promise<ProjectCreateTarget> {
+  const slug = slugify(input.slug ?? input.name);
+
+  const existingById = input.id ? await getProjectById(input.db, { id: input.id }) : null;
+  if (existingById) {
+    // A caller-provided id is an adoption request only if it names the same
+    // slug in the same organization. Any drift means the caller is trying to
+    // bind one identity to a different project, so fail instead of guessing.
+    if (existingById.slug !== slug) {
+      throw new ORPCError("CONFLICT", {
+        message: `Project ${input.id} already exists with slug ${existingById.slug}.`,
+      });
+    }
+    if (existingById.organizationId !== input.organizationId) {
+      throw new ORPCError("CONFLICT", {
+        message: `Project slug ${slug} is already taken.`,
+      });
+    }
+    return { kind: "existing", project: existingById };
+  }
+
+  const existingBySlug = await getProjectBySlug(input.db, { slug });
+  if (!existingBySlug) return { kind: "new", slug };
+
+  // Slugs are globally unique in auth today. Returning an existing same-org
+  // row supports OS re-adoption; returning an other-org row would leak or steal
+  // a project identity, so treat it as taken.
+  if (existingBySlug.organizationId !== input.organizationId) {
+    throw new ORPCError("CONFLICT", {
+      message: `Project slug ${slug} is already taken.`,
+    });
+  }
+
+  if (input.id && existingBySlug.id !== input.id) {
+    throw new ORPCError("CONFLICT", {
+      message: `Project slug ${slug} already exists with id ${existingBySlug.id}.`,
+    });
+  }
+
+  return { kind: "existing", project: existingBySlug };
+}

--- a/apps/auth/src/server/orpc/routers/project.ts
+++ b/apps/auth/src/server/orpc/routers/project.ts
@@ -1,5 +1,5 @@
 import { ORPCError } from "@orpc/server";
-import { resolveUniqueSlug, slugify } from "@iterate-com/shared/slug";
+import { slugify } from "@iterate-com/shared/slug";
 import {
   organizationAdminMiddleware,
   organizationScopedMiddleware,
@@ -10,13 +10,12 @@ import {
 import { parseProjectMetadata, parseTimestampMs } from "../../db/helpers.ts";
 import {
   deleteProjectById,
-  getProjectById,
-  getProjectBySlug,
   insertProjectReturning,
   listProjectsByOrganizationId,
   updateProjectReturning,
 } from "../../db/queries/index.ts";
 import { generateId, toProjectRecord, toProjectRecordFromReturnedRow } from "./_shared.ts";
+import { resolveProjectCreateTarget } from "./project-slugs.ts";
 
 const list = os.project.list.use(organizationScopedMiddleware).handler(async ({ context }) => {
   const projects = await listProjectsByOrganizationId(context.db, {
@@ -42,23 +41,25 @@ const bySlug = os.project.bySlug.use(projectScopedMiddleware).handler(async ({ c
 const create = os.project.create
   .use(organizationAdminMiddleware)
   .handler(async ({ context, input }) => {
-    const slug = await resolveUniqueSlug({
+    const target = await resolveProjectCreateTarget({
+      db: context.db,
+      id: input.id,
       name: input.name,
+      organizationId: context.organization.id,
       slug: input.slug,
-      isTaken: async (candidate) =>
-        Boolean(await getProjectBySlug(context.db, { slug: candidate })),
     });
-    const projectId = input.id ?? generateId("prj");
-    if (input.id && (await getProjectById(context.db, { id: input.id }))) {
-      throw new ORPCError("CONFLICT", { message: "Project ID already exists" });
+    if (target.kind === "existing") {
+      return toProjectRecordFromReturnedRow(target.project);
     }
+
+    const projectId = input.id ?? generateId("prj");
 
     const now = Date.now();
     const created = await insertProjectReturning(context.db, {
       id: projectId,
       organizationId: context.organization.id,
       name: input.name,
-      slug,
+      slug: target.slug,
       metadata: JSON.stringify(input.metadata ?? {}),
       archivedAt: null,
       createdAt: now,

--- a/apps/os/src/routes/index.tsx
+++ b/apps/os/src/routes/index.tsx
@@ -14,25 +14,31 @@ export const Route = createFileRoute("/")({
       context.currentProjectHostSlug,
     );
 
-    if (target.projectSlug) {
-      throw redirect({
-        to: "/projects/$projectSlug",
-        params: { projectSlug: target.projectSlug },
-        replace: true,
-      });
-    }
-
     const projectsData = await context.queryClient.ensureQueryData(
       projectsListQueryOptions({ limit: 100, offset: 0 }),
     );
+    // `projects.list` is intentionally a merge of auth-session projects and
+    // OS D1 rows. During preview/dev testing we often reset only the OS worker
+    // database, leaving auth's database intact. Those auth-only projects are
+    // returned as `isOrphanedProjectFromAuthService` so the `/projects` page can
+    // offer a one-click OS re-adoption form.
+    //
+    // Root redirect must make a different decision: only projects that already
+    // exist in OS are valid redirect targets. If auth knows about ten projects
+    // but OS has recreated only one of them, `/` should go to that one OS
+    // project, not stay on the project picker because of auth-only claims.
     const projects = projectsData.projects.filter(
       (project) => !project.isOrphanedProjectFromAuthService,
     );
 
-    if (projects.length === 1) {
+    const project =
+      projects.find((candidate) => candidate.slug === target.projectSlug) ??
+      (projects.length === 1 ? projects[0] : null);
+
+    if (project) {
       throw redirect({
         to: "/projects/$projectSlug",
-        params: { projectSlug: projects[0]!.slug },
+        params: { projectSlug: project.slug },
         replace: true,
       });
     }


### PR DESCRIPTION
## Summary
- make auth project creation adopt an existing same-organization project when the supplied slug, or id plus slug pair, already exists in auth
- keep duplicate slugs in other organizations as conflicts, without random suffix generation
- make the OS root redirect count only OS-backed projects by ignoring auth-only orphan project claims

## Why
In dev and preview, OS D1 is often reset while the auth worker database remains intact. Auth project creation needs to be idempotent for projects the caller already owns there, so OS can re-adopt those projects without auth generating a random slug. The root redirect also needs to consider projects that actually exist in OS, not just everything present in the auth session.

## Validation
- pnpm --dir apps/auth typecheck
- pnpm --dir apps/os typecheck
- pnpm format:check -- apps/auth/src/server/orpc/routers/_shared.ts apps/auth/src/server/orpc/routers/project-slugs.ts apps/auth/src/server/orpc/routers/project.ts apps/auth/src/server/orpc/routers/internal.ts apps/os/src/domains/projects/project-directory.ts apps/os/src/routes/index.tsx
- git diff --check

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-15T14:19:34.598Z",
      "headSha": "1e6126ac251859e2ca87ba741d9e21d363b603dd",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27552232685",
      "shortSha": "1e6126a"
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-15T14:19:19.938Z",
      "headSha": "1e6126ac251859e2ca87ba741d9e21d363b603dd",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27552232685",
      "shortSha": "1e6126a"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `1e6126a`
Preview: https://auth.iterate-preview-6.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27552232685)
Updated: 2026-06-15T14:19:34.598Z

### OS
Status: released
Commit: `1e6126a`
Preview: https://os.iterate-preview-6.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27552232685)
Updated: 2026-06-15T14:19:19.938Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes project identity and create idempotency in auth (globally unique slugs, conflict rules) and root routing behavior when auth and OS DBs diverge; mistakes could mis-route users or return wrong project records on re-adoption.
> 
> **Overview**
> Replaces **random slug suffix generation** on auth project create with **`resolveProjectCreateTarget`**, which returns an existing same-org project when the slug (or id + slug) already exists in auth, and treats cross-org slug collisions as **CONFLICT** errors.
> 
> **`project.create`** and **`internal.project.createForOrganization`** now short-circuit on `existing` targets instead of always inserting; **`toProjectRecordFromReturnedRow`** accepts slug-lookup rows and normalizes snake_case vs camelCase org/archived fields, with a hard error if org id is missing.
> 
> On OS, the **`/`** loader no longer redirects from session `projectSlug` alone—it filters out **`isOrphanedProjectFromAuthService`** entries, then redirects to a matching OS-backed project or the sole OS project, otherwise **`/projects`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e6126ac251859e2ca87ba741d9e21d363b603dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->