### PR TITLE
[codex] add ITX agent smoke test and stream waitForEvent

### DIFF
--- a/apps/os/docs/agent-smoke-testing.md
+++ b/apps/os/docs/agent-smoke-testing.md
@@ -1,12 +1,14 @@
 # Smoke-testing a real agent in a deployed environment
 
-How to manually verify that an agent works **end-to-end** in a deployed OS
-environment (prd, a preview slot, or your dev tunnel) by creating a throwaway
-project, creating an agent stream, sending it a message over the oRPC API, and
-reading its reply. This exercises the full live path — Project DO → agent stream
-→ Agent Durable Object → cross-script stream subscription → LLM turn → streamed
-response — so it's the truest check that a deploy didn't break agents (CI unit
-tests don't drive a real LLM turn).
+How to verify that an agent works **end-to-end** in a deployed OS environment
+(prd, a preview slot, or your dev tunnel). The quick path uses the ITX
+single-turn smoke command; the manual oRPC steps below are useful when you need
+to inspect intermediate events.
+
+This exercises the full live path — Project DO → agent stream → Agent Durable
+Object → cross-script stream subscription → LLM turn → streamed response — so
+it's the truest check that a deploy didn't break agents (CI unit tests don't
+drive a real LLM turn).
 
 It's the same flow used to confirm PR #1518 (the DO-duration idle-teardown fix)
 didn't regress agents in prd.
@@ -24,7 +26,7 @@ didn't regress agents in prd.
   - **Use `--project os`** (not just `--config`) so the os `APP_CONFIG` —
     including the admin API secret the CLI authenticates with — is loaded.
   - Discover procedures/flags with `... cli rpc --help`, `... cli rpc project
-agents --help`, `... cli rpc project streams --help`.
+agents --help`, `... cli rpc project agents configure-preset --help`.
 
 See also [Doppler-backed scripts](./doppler-backed-scripts.md) and the
 [OS app README](../AGENTS.md).
@@ -42,27 +44,49 @@ doppler run --project os --config prd -- pnpm --dir apps/os cli rpc \
 
 Note the returned `id` (`prj_…`) and `slug`. Use a clearly disposable slug.
 
-### 2. Create an agent stream
+### 2. Configure an agent preset
 
 ```bash
 doppler run --project os --config prd -- pnpm --dir apps/os cli rpc \
-  project streams create \
+  project agents configure-preset \
   --project-slug-or-id <slug> \
-  --stream-path /agents/smoke
+  --base-path /agents/smoke \
+  --provider cloudflare-ai \
+  --model "@cf/meta/llama-3.1-8b-instruct" \
+  --system-prompt "You are a smoke-test agent. When the user says PING, reply with exactly the single word PONG and nothing else."
 ```
 
-Creating `/agents/smoke` emits `stream/child-stream-created` on `/agents`. The
-project processor reacts by appending the default provider/config/system prompt
-and processor subscriptions to the child stream. Before sending a message, read
-the stream until `project-agent-setup:system-prompt` appears:
+- **`--base-path` MUST be `/agents` or start with `/agents/`.** Anything else
+  (e.g. `/smoke`) is rejected server-side — see the gotcha below.
+- `--provider`: `cloudflare-ai` (keyless, uses Workers AI / the AI gateway) or
+  `openai-ws` (needs the env's OpenAI config). Start with `cloudflare-ai`.
+- Success returns `{ "basePath": "/agents/smoke", "eventCount": N }`.
+
+### 3. Run the quick ITX smoke command
 
 ```bash
-doppler run --project os --config prd -- pnpm --dir apps/os cli rpc \
-  project streams read --project-slug-or-id <slug> \
-  --stream-path /agents/smoke --before-offset end
+doppler run --project os --config prd -- pnpm --dir apps/os cli \
+  itx agent-smoke \
+  --project <slug> \
+  --agent-path /agents/smoke \
+  --message "PING"
 ```
 
-### 3. Send the agent a message
+The command connects to the project over ITX, appends a
+`events.iterate.com/agent-chat/user-message-added` event directly to the agent
+stream, then waits with `itx.streams.get(...).waitForEvent(...)` until an
+`events.iterate.com/agent-chat/assistant-response-added` event arrives. On
+success it prints one JSON object containing the appended user event and the
+assistant response event. On agent errors or timeout it exits non-zero.
+
+For a custom timeout:
+
+```bash
+... itx agent-smoke --project <slug> --agent-path /agents/smoke \
+  --message "PING" --timeout-ms 180000
+```
+
+### 4. Manual fallback: send the agent a message
 
 ```bash
 doppler run --project os --config prd -- pnpm --dir apps/os cli rpc \
@@ -72,11 +96,11 @@ doppler run --project os --config prd -- pnpm --dir apps/os cli rpc \
   --message "PING"
 ```
 
-Returns the appended `web-message-received` event with its `offset` — note it; the
+Returns the appended `user-message-added` event with its `offset` — note it; the
 reply lands at higher offsets. The LLM turn runs **asynchronously**; give it a few
 seconds.
 
-### 4. Read and verify the reply
+### 5. Manual fallback: read and verify the reply
 
 Read the agent stream (use `--after-offset <the user-message offset>` to skip past
 the setup events and the default read window):
@@ -94,7 +118,6 @@ A healthy turn shows this event sequence (no `error-occurred`):
 - `events.iterate.com/openai-ws/llm-request-completed`
 - many `response.output_text.delta` (the streamed reply)
 - `events.iterate.com/agent/output-added`
-- `events.iterate.com/agent-chat/assistant-response-added`
 
 OS agents run in **code-mode**: the reply is an itx JS script, not plain prose.
 For the PING prompt above a correct reply looks like:
@@ -115,7 +138,7 @@ d = sys.stdin.read()
 print("".join(json.loads("\""+x+"\"") for x in re.findall(r"\"delta\"\s*:\s*\"((?:[^\"\\\\]|\\\\.)*)\"', d)))'
 ```
 
-### 5. Clean up
+### 6. Clean up
 
 ```bash
 doppler run --project os --config prd -- pnpm --dir apps/os cli rpc \
@@ -138,18 +161,21 @@ This hides the real server-side error. To get it, query **Workers
 Observability** for the os workers around the time of the call (the RPC ingress
 is `os-prd`, the app logic is `os-prd-app`). See
 [Debugging deployed OS workers](./debugging-deployed-os-workers.md), or run a
-telemetry query filtered to your project id and the stream path you appended to.
+telemetry query filtered to your project id / `configurePreset`. For example, the
+"agent preset path" rule above surfaced only as a logged
+`Error: Agent preset path must be /agents or start with /agents/.` in
+`os-prd-app` — never in the terminal.
 
 Quick recipe (general Cloudflare MCP, prd account
 `04b3b57291ef2626c6a8daa9d47065a7`): `POST /accounts/{id}/workers/observability/telemetry/query`
 with `view: "events"`, a tight `timeframe`, and filters like
-`$metadata.message includes "<your stream path>"` or `… includes "<your prj_ id>"`.
+`$metadata.message includes "configurePreset"` or `… includes "<your prj_ id>"`.
 
-### Agent paths must live under `/agents`
+### `--base-path` / `--agent-path` must live under `/agents`
 
-Project-worker setup normally watches for child streams under `/agents/...`.
-Use the same absolute path when appending stream events and when calling
-`send-message --agent-path`.
+`configure-preset` rejects any base path that isn't `/agents` or under
+`/agents/…`. The agent's stream is then at `/agents/<name>` and `send-message`
+uses the same `--agent-path`.
 
 ### Use `--project os --config <cfg>`
 

--- a/apps/os/scripts/itx-agent-smoke.ts
+++ b/apps/os/scripts/itx-agent-smoke.ts
@@ -1,0 +1,89 @@
+import process from "node:process";
+
+import { os } from "@orpc/server";
+import { z } from "zod";
+
+import { withItx } from "../src/itx/client.ts";
+
+const ASSISTANT_RESPONSE_TYPE = "events.iterate.com/agents/web-message-sent";
+const USER_MESSAGE_TYPE = "events.iterate.com/agents/user-message-received";
+
+const ItxAgentSmokeInput = z.object({
+  agentPath: z
+    .string()
+    .trim()
+    .refine((value) => value.startsWith("/agents/"), {
+      message: "Agent path must start with /agents/.",
+    })
+    .describe("Agent stream path, e.g. /agents/smoke."),
+  baseUrl: z.string().optional().describe("OS base URL. Defaults to APP_CONFIG_BASE_URL."),
+  project: z.string().trim().min(1).describe("Project id or slug to connect into over ITX."),
+  message: z.string().trim().min(1).describe("Single user message to send to the agent."),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .default(180_000)
+    .describe("Maximum time to wait for an assistant response."),
+});
+
+export const itxAgentSmokeScript = os
+  .meta({
+    description: "Send one user message to an agent over ITX and wait for the assistant response.",
+  })
+  .input(ItxAgentSmokeInput)
+  .handler(async ({ input }) => {
+    const baseUrl = input.baseUrl ?? process.env.APP_CONFIG_BASE_URL?.trim();
+    if (!baseUrl) throw new Error("No base URL: pass --base-url or set APP_CONFIG_BASE_URL.");
+    const token =
+      process.env.OS_ADMIN_API_SECRET?.trim() ||
+      process.env.APP_CONFIG_ADMIN_API_SECRET?.trim() ||
+      "";
+    if (!token) {
+      throw new Error("APP_CONFIG_ADMIN_API_SECRET (or OS_ADMIN_API_SECRET) is required.");
+    }
+
+    const startedAt = Date.now();
+    using itx = withItx({ baseUrl, context: input.project, token });
+
+    const stream = await itx.streams.get(input.agentPath);
+    const userEvent = await stream.append({
+      type: USER_MESSAGE_TYPE,
+      payload: {
+        content: input.message,
+        origin: "web",
+      },
+    });
+
+    const responseEvent = await stream.waitForEvent(
+      (event) => {
+        if (event.type.endsWith("error-occurred")) {
+          throw new Error(`Agent stream reported an error: ${JSON.stringify(event)}`);
+        }
+        return event.type === ASSISTANT_RESPONSE_TYPE;
+      },
+      {
+        afterOffset: userEvent.offset,
+        timeoutMs: input.timeoutMs,
+      },
+    );
+    const assistantMessage = (responseEvent.payload as { message?: unknown }).message;
+
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          agentPath: input.agentPath,
+          assistantMessage: typeof assistantMessage === "string" ? assistantMessage : null,
+          elapsedMs: Date.now() - startedAt,
+          project: input.project,
+          responseEvent,
+          userEvent,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    // The Cap'n Web WebSocket would otherwise keep the process alive.
+    process.exit(0);
+  });

--- a/apps/os/src/domains/streams/engine/types.ts
+++ b/apps/os/src/domains/streams/engine/types.ts
@@ -60,6 +60,16 @@ export type StreamRpc = {
     limit?: number;
   }): MaybePromise<StreamEvent[]>;
   /**
+   * Waits for the first event after `afterOffset` whose predicate returns true.
+   * Omitting `afterOffset` waits from the live edge; pass 0 to include history.
+   */
+  waitForEvent(args: {
+    afterOffset?: number;
+    eventTypes?: readonly string[];
+    predicate: (event: StreamEvent) => MaybePromise<boolean>;
+    timeoutMs: number;
+  }): MaybePromise<StreamEvent>;
+  /**
    * Subscribes to catch-up then live event batches. Every subscription
    * immediately receives one batch carrying the current `state` and
    * `streamMaxOffset` (plus the replayed events when `replayAfterOffset`

--- a/apps/os/src/domains/streams/engine/workers/durable-objects/stream.ts
+++ b/apps/os/src/domains/streams/engine/workers/durable-objects/stream.ts
@@ -16,6 +16,7 @@ import {
   type StreamSubscriberDescriptor,
 } from "../../processors/core/contract.ts";
 import type { StreamRpc } from "../../types.ts";
+import { createStreamSubscription } from "../../subscription.ts";
 import { makeRpcTargetClass, type RpcTargetClass } from "../../shared/rpc-target.ts";
 import { disposeIgnoredRpcResult, retainProcessEventBatch } from "../rpc-lifecycle.ts";
 
@@ -555,6 +556,70 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
     });
   }
 
+  /**
+   * One-shot convenience over `subscribe()`: replay from the requested cursor,
+   * then live-tail until a caller predicate accepts an event.
+   *
+   * This is intentionally not a durable waiter. If the RPC caller or this DO
+   * incarnation dies, the wait dies too; callers that need retry semantics
+   * should call again with the same `afterOffset`.
+   */
+  async waitForEvent(args: {
+    afterOffset?: number;
+    eventTypes?: readonly string[];
+    predicate: (event: StreamEvent) => boolean | Promise<boolean>;
+    timeoutMs: number;
+  }): Promise<StreamEvent> {
+    if (!Number.isFinite(args.timeoutMs) || args.timeoutMs <= 0) {
+      throw new Error("waitForEvent timeoutMs must be a positive number.");
+    }
+    if (
+      args.afterOffset !== undefined &&
+      (!Number.isInteger(args.afterOffset) || args.afterOffset < 0)
+    ) {
+      throw new Error("waitForEvent afterOffset must be a non-negative integer.");
+    }
+
+    const seenEvents: StreamEvent[] = [];
+    const subscription = createStreamSubscription();
+    const timeout = Promise.withResolvers<never>();
+    const timer = setTimeout(() => {
+      timeout.reject(
+        new Error(`Timed out waiting for stream event. Saw: ${JSON.stringify(seenEvents)}`),
+      );
+    }, args.timeoutMs);
+    let handle: { unsubscribe(): void } | undefined;
+
+    try {
+      handle = this.subscribe({
+        eventTypes: args.eventTypes,
+        replayAfterOffset: args.afterOffset,
+        subscriber: { description: "waitForEvent" },
+        processEventBatch: subscription.processEventBatch,
+      });
+
+      const match = (async () => {
+        // Batches are queued synchronously; async predicate work happens here
+        // so stream delivery is never blocked on caller code.
+        for await (const batch of subscription) {
+          seenEvents.push(...batch.events);
+          for (const event of batch.events) {
+            if (await args.predicate(event)) return event;
+          }
+        }
+        throw new Error("Stream subscription closed before matching event.");
+      })();
+
+      // If timeout wins, cleanup closes the iterator; observe that loser too.
+      void match.catch(() => {});
+      return await Promise.race([match, timeout.promise]);
+    } finally {
+      clearTimeout(timer);
+      handle?.unsubscribe();
+      await subscription[Symbol.asyncDispose]();
+    }
+  }
+
   reduce(args: {
     event: StreamEvent;
     coreProcessorState?: StreamCoreProcessorState;
@@ -710,6 +775,7 @@ const STREAM_RPC_METHODS = [
   "appendBatch",
   "getEvent",
   "getEvents",
+  "waitForEvent",
   "runtimeState",
   "reduce",
   "kill",

--- a/apps/os/src/domains/streams/engine/workers/durable-objects/stream.workers.test.ts
+++ b/apps/os/src/domains/streams/engine/workers/durable-objects/stream.workers.test.ts
@@ -175,6 +175,33 @@ describe("T8 — Stream DO smoke (coverage)", () => {
       }
     });
   });
+
+  it("waitForEvent resolves with the first matching live event", async () => {
+    await runInDurableObject(freshStream(), async (stream) => {
+      const pending = stream.waitForEvent({
+        timeoutMs: 1_000,
+        predicate: (event) => event.type === "test.wait.match",
+      });
+
+      await stream.append({ event: { type: "test.wait.ignore", payload: { ok: false } } });
+      const match = await stream.append({
+        event: { type: "test.wait.match", payload: { ok: true } },
+      });
+
+      await expect(pending).resolves.toEqual(match);
+    });
+  });
+
+  it("waitForEvent times out when no event matches", async () => {
+    await runInDurableObject(freshStream(), async (stream) => {
+      await expect(
+        stream.waitForEvent({
+          timeoutMs: 1,
+          predicate: (event) => event.type === "test.wait.never",
+        }),
+      ).rejects.toThrow(/Timed out waiting for stream event/);
+    });
+  });
 });
 
 describe("subscription protocol — every batch carries state, every subscribe gets an initial push", () => {

--- a/apps/os/src/domains/streams/entrypoints/streams-backend.ts
+++ b/apps/os/src/domains/streams/entrypoints/streams-backend.ts
@@ -73,6 +73,12 @@ export type StreamSubscribeInput = StreamPathInput & {
   events?: boolean;
 };
 
+export type StreamWaitForEventInput = StreamPathInput & {
+  afterOffset?: StreamCursor;
+  eventTypes?: readonly string[];
+  timeoutMs: number;
+};
+
 /** What every subscription delivery carries; `state` is the same public
  * {@link StreamState} shape `getState()` returns. */
 export type StreamSubscribeBatch = {
@@ -92,6 +98,7 @@ type StreamsBackendClient = Pick<
   | "read"
   | "stream"
   | "subscribe"
+  | "waitForEvent"
 >;
 
 /**
@@ -270,6 +277,29 @@ export class StreamsBackend extends WorkerEntrypoint<StreamsBackendEnv, StreamsB
         releaseCallback();
       },
     };
+  }
+
+  async waitForEvent(
+    input: StreamWaitForEventInput,
+    predicate: (event: Event) => boolean | Promise<boolean>,
+  ): Promise<Event> {
+    const path = this.resolveNamespacePath(input);
+    const streamStub = (this.env.STREAM as unknown as StreamDurableObjectNamespace).getByName(
+      getStreamDurableObjectName({ namespace: this.ctx.props.projectId, path }),
+    ) as unknown as StreamRpc;
+
+    const afterOffset =
+      input.afterOffset === undefined || input.afterOffset === "end"
+        ? undefined
+        : toAfterOffset(input.afterOffset);
+
+    const event = await streamStub.waitForEvent({
+      afterOffset,
+      eventTypes: input.eventTypes,
+      timeoutMs: input.timeoutMs,
+      predicate: async (rawEvent) => await predicate(withStreamPath(rawEvent, path)),
+    });
+    return withStreamPath(event, path);
   }
 
   async getState(input: StreamPathInput = {}) {

--- a/apps/os/src/itx/capabilities/streams.ts
+++ b/apps/os/src/itx/capabilities/streams.ts
@@ -173,6 +173,13 @@ export class ItxStream extends RpcTarget {
     return await this.client().read(input as never);
   }
 
+  async waitForEvent(
+    predicate: (event: StreamEvent) => boolean | Promise<boolean>,
+    opts: { afterOffset?: StreamCursor; eventTypes?: string[]; timeoutMs: number },
+  ) {
+    return await this.client().waitForEvent(opts as never, predicate as never);
+  }
+
   async getState() {
     return await this.client().getState({} as never);
   }

--- a/knip.ts
+++ b/knip.ts
@@ -24,6 +24,7 @@ function makeOsCloudflareAppWorkspace(workerEnvShim: string): WorkspaceConfig {
       "e2e/tui-test/run.ts",
       // Mounted into the CLI by packages/iterate/src/os/router.ts, which knip
       // doesn't traverse (the iterate package isn't a knip workspace).
+      "scripts/itx-agent-smoke.ts",
       "scripts/itx-run.ts",
       "scripts/seed-iterate-config-base-repo.ts",
       "scripts/setup-artifact-event-subscriptions.ts",

--- a/packages/iterate/src/os/router.ts
+++ b/packages/iterate/src/os/router.ts
@@ -2,6 +2,7 @@ import { os } from "@orpc/server";
 
 // This router is only ever loaded from a repo checkout (via iterateAppCli.localRouterPaths),
 // so it can reach into apps/os for scripts that depend on OS domain internals.
+import { itxAgentSmokeScript } from "../../../../apps/os/scripts/itx-agent-smoke.ts";
 import { itxRunScript } from "../../../../apps/os/scripts/itx-run.ts";
 import { seedIterateConfigBaseRepoScript } from "../../../../apps/os/scripts/seed-iterate-config-base-repo.ts";
 import { setupArtifactEventSubscriptionsScript } from "../../../../apps/os/scripts/setup-artifact-event-subscriptions.ts";
@@ -14,6 +15,7 @@ export const router = os.router({
   },
   "claude-mcp": claudeMcpScript,
   itx: {
+    "agent-smoke": itxAgentSmokeScript,
     run: itxRunScript,
   },
 });


### PR DESCRIPTION
## What changed

- Added a stream-level `waitForEvent(...)` RPC on the OS stream Durable Object and exposed it through `StreamsBackend` and ITX stream handles.
- Added `pnpm cli itx agent-smoke`, a single-turn smoke test command that connects to a project over ITX, appends an agent chat user-message event directly to `/agents/...`, waits for the assistant-response event, and prints one JSON result.
- Registered the command under `pnpm --dir apps/os cli itx agent-smoke` with `--project`, `--agent-path`, `--message`, and `--timeout-ms` options.
- Updated the deployed agent smoke-test docs to use the quick ITX path, with the manual oRPC/read flow kept as a fallback.
- Added Stream DO tests covering `waitForEvent` success and timeout behavior.

## Why

Manual deployed-agent smoke testing was still a multi-step flow: send a message, then separately read or poll stream events until a response appeared. This PR makes the common check a single command while keeping the primitive in the stream layer where event waiting belongs.

## Impact

Developers can smoke a real deployed agent with:

```bash
doppler run --project os --config prd -- pnpm --dir apps/os cli \
  itx agent-smoke \
  --project <project-slug-or-id> \
  --agent-path /agents/smoke \
  --message "PING"
```

The stream API also gains a reusable `waitForEvent(predicate, { afterOffset, timeoutMs })` helper for other ITX/scripted workflows.

## Validation

- `pnpm --dir apps/os exec tsc --noEmit`
- `pnpm --dir apps/os test:streams-workers -- src/domains/streams/engine/workers/durable-objects/stream.workers.test.ts`
- `DOPPLER_CONFIG=dev pnpm --dir apps/os cli itx agent-smoke --help`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-15T15:42:40.484Z",
      "headSha": "fd187e2dd08c015fb283a00f94b8553c2def8861",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27555257338",
      "shortSha": "fd187e2"
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-06-15T15:42:35.120Z",
      "headSha": "fd187e2dd08c015fb283a00f94b8553c2def8861",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-7.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27555257338",
      "shortSha": "fd187e2"
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-15T15:42:26.060Z",
      "headSha": "fd187e2dd08c015fb283a00f94b8553c2def8861",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27555257338",
      "shortSha": "fd187e2"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `fd187e2`
Preview: https://auth.iterate-preview-7.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27555257338)
Updated: 2026-06-15T15:42:40.484Z

### OS
Status: released
Commit: `fd187e2`
Preview: https://os.iterate-preview-7.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27555257338)
Updated: 2026-06-15T15:42:26.060Z

### Streams Example App
Status: released
Commit: `fd187e2`
Preview: https://streams-example-app-preview-7.iterate-dev-preview.workers.dev
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27555257338)
Updated: 2026-06-15T15:42:35.120Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New long-lived subscribe RPC on the Stream DO affects core streaming infrastructure; behavior is bounded by timeouts and tests, but callers can hold DO connections during waits.
> 
> **Overview**
> Adds **`waitForEvent`** on the stream Durable Object: replay from an optional cursor, subscribe, and resolve when a predicate matches (with timeout and cleanup). The method is on the public Stream RPC allowlist and wired through **`StreamsBackend`** and **`ItxStream.waitForEvent`** for ITX/scripts.
> 
> Introduces **`pnpm cli itx agent-smoke`**, which connects to a project, appends a user message on an `/agents/...` stream, waits for the assistant **`web-message-sent`** event, prints JSON, and exits. Registered in the iterate OS router and knip entries.
> 
> **Agent smoke-testing** docs now lead with **`configure-preset`** plus the ITX one-liner; manual oRPC send/read steps remain as fallback. Stream DO worker tests cover match and timeout for **`waitForEvent`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd187e2dd08c015fb283a00f94b8553c2def8861. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

