### PR TITLE
[codex] scope projects page to auth claims

### DIFF
--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -527,6 +527,18 @@ function ProjectSidebarGroup({
                 }),
               )}
             />
+            <ProjectSidebarMenuItem
+              icon={SquareTerminal}
+              label="Repl"
+              render={<Link to="/projects/$projectSlug/repl" params={{ projectSlug }} />}
+              isActive={Boolean(
+                matchRoute({
+                  to: "/projects/$projectSlug/repl",
+                  params: { projectSlug },
+                  fuzzy: false,
+                }),
+              )}
+            />
             {customWorkerUrl ? (
               <ProjectSidebarMenuItem
                 icon={ExternalLink}

--- a/apps/os/src/components/create-project-form.tsx
+++ b/apps/os/src/components/create-project-form.tsx
@@ -1,5 +1,5 @@
 import { useForm } from "@tanstack/react-form";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import { useAuthClient } from "@iterate-com/auth/client";
 import { Button } from "@iterate-com/ui/components/button";
@@ -20,7 +20,8 @@ import {
 } from "@iterate-com/ui/components/select";
 import { toast } from "@iterate-com/ui/components/sonner";
 import { z } from "zod";
-import { connectItx, reconnectItx } from "~/itx/itx-react.tsx";
+import { createProjectServerFn, myProjectsQueryOptions } from "~/lib/project-server-fns.ts";
+import { reconnectItx } from "~/itx/itx-react.tsx";
 
 const PROJECT_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
@@ -35,14 +36,22 @@ const CreateProjectInput = z.object({
 
 export function CreateProjectForm() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { refresh, session } = useAuthClient();
   const organizations = session?.authenticated ? session.session.organizations : [];
   const createProject = useMutation({
     mutationFn: async (input: { slug: string; organizationSlug: string }) => {
-      const itx = await connectItx();
-      return await itx.projects.create({
-        slug: input.slug,
-        organizationSlug: input.organizationSlug || undefined,
+      // Product project creation must use the request/session-aware project
+      // directory, not the global itx handle. Admin users hold an "all" itx
+      // handle, and itx.projects.create intentionally uses that as an operator
+      // path with no auth organization ownership. The dashboard create form is
+      // different: it should create/adopt through auth for the selected org so
+      // the refreshed session contains the new project and `/projects` lists it.
+      return await createProjectServerFn({
+        data: {
+          slug: input.slug,
+          organizationSlug: input.organizationSlug || undefined,
+        },
       });
     },
     onSuccess: async (project) => {
@@ -50,6 +59,7 @@ export function CreateProjectForm() {
       // claim BEFORE navigating to the project-scoped route (#1516); without
       // this the project route loads before the session knows the project.
       await refresh({ force: true });
+      await queryClient.invalidateQueries({ queryKey: myProjectsQueryOptions().queryKey });
       // Drop the global itx socket so it re-dials with the refreshed claims —
       // otherwise itx.projects.list (connect-time principal) omits this project.
       reconnectItx();

--- a/apps/os/src/domains/projects/project-directory.ts
+++ b/apps/os/src/domains/projects/project-directory.ts
@@ -9,12 +9,10 @@ import { ORPCError } from "@orpc/server";
 import { createAuthWorkerServiceClient } from "~/auth/auth-worker-service.ts";
 import type { RequestContext } from "~/request-context.ts";
 import {
-  countAllProjects,
   deleteProject,
   getProjectById,
   getProjectBySlug,
   insertProject,
-  listAllProjects,
 } from "~/db/queries/.generated/index.ts";
 import { getProjectDurableObjectStub } from "~/domains/projects/durable-objects/project-durable-object-ref.ts";
 import { isProjectId } from "~/domains/projects/project-id.ts";
@@ -31,6 +29,7 @@ type ProjectRow = {
 type ProjectListItem = {
   id: string;
   slug: string;
+  organizationId: string | null;
   customHostname: string | null;
   createdAt: string | null;
   updatedAt: string | null;
@@ -59,21 +58,15 @@ export class ProjectsCapability extends RpcTarget {
     const context = this.props.context;
     const limit = input.limit ?? 100;
     const offset = input.offset ?? 0;
-    if (context.principal != null && principalIsAdmin(context.principal)) {
-      const [totalRow, rows] = await Promise.all([
-        countAllProjects(context.db),
-        listAllProjects(context.db, { limit, offset }),
-      ]);
-
-      return { projects: rows.map(toProject), total: totalRow?.total ?? 0 };
-    }
 
     const authProjects = listSignedProjectClaims(context);
     const page = authProjects.slice(offset, offset + limit);
     const projects = await Promise.all(
       page.map(async (authProject) => {
         const row = await getProjectById(context.db, { id: authProject.id });
-        return row ? toProject(row) : toOrphanedProjectFromAuthService(authProject);
+        return row
+          ? toProject(row, { organizationId: authProject.organizationId })
+          : toOrphanedProjectFromAuthService(authProject);
       }),
     );
 
@@ -218,10 +211,14 @@ export class ProjectsCapability extends RpcTarget {
   }
 }
 
-export function toProject(row: ProjectRow): ProjectListItem {
+export function toProject(
+  row: ProjectRow,
+  input: { organizationId?: string | null } = {},
+): ProjectListItem {
   return {
     id: row.id,
     slug: row.slug,
+    organizationId: input.organizationId ?? null,
     customHostname: row.custom_hostname ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -307,6 +304,7 @@ function toOrphanedProjectFromAuthService(project: AuthProject): ProjectListItem
   return {
     id: project.id,
     slug: project.slug,
+    organizationId: project.organizationId,
     customHostname: null,
     createdAt: null,
     updatedAt: null,

--- a/apps/os/src/lib/project-server-fns.ts
+++ b/apps/os/src/lib/project-server-fns.ts
@@ -18,6 +18,7 @@ import { requireRequestContext } from "~/request-context.ts";
 export type Project = {
   id: string;
   slug: string;
+  organizationId: string | null;
   customHostname: string | null;
   createdAt: string | null;
   updatedAt: string | null;
@@ -27,6 +28,14 @@ export type Project = {
 export type ProjectWithIngressUrl = Project & { ingressUrl: string };
 
 export type ProjectListResult = { projects: Project[]; total: number };
+
+export const createProjectServerFn: (input: {
+  data: { id?: string; slug: string; organizationSlug?: string };
+}) => Promise<ProjectWithIngressUrl> = createServerFn({ method: "POST" })
+  .inputValidator((input: { id?: string; slug: string; organizationSlug?: string }) => input)
+  .handler(async ({ data }) => {
+    return await new ProjectsCapability({ context: requireRequestContext() }).create(data);
+  });
 
 /** The session principal's accessible projects (mirrors the former `projects.list`). */
 export const listMyProjectsServerFn: (input: {

--- a/apps/os/src/routeTree.gen.ts
+++ b/apps/os/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as SignInSplatRouteImport } from './routes/sign-in.$'
 import { Route as PosthogProxySplatRouteImport } from './routes/posthog-proxy.$'
 import { Route as ApiHealthRouteImport } from './routes/api.health'
 import { Route as ApiSplatRouteImport } from './routes/api.$'
+import { Route as AdminReplRouteImport } from './routes/admin/repl'
 import { Route as AdminProjectsRouteImport } from './routes/admin/projects'
 import { Route as AppNewProjectRouteImport } from './routes/_app/new-project'
 import { Route as AppItxReplRouteImport } from './routes/_app/itx-repl'
@@ -111,6 +112,11 @@ const ApiSplatRoute = ApiSplatRouteImport.update({
   id: '/api/$',
   path: '/api/$',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AdminReplRoute = AdminReplRouteImport.update({
+  id: '/repl',
+  path: '/repl',
+  getParentRoute: () => AdminRoute,
 } as any)
 const AdminProjectsRoute = AdminProjectsRouteImport.update({
   id: '/projects',
@@ -303,6 +309,7 @@ export interface FileRoutesByFullPath {
   '/itx-repl': typeof AppItxReplRoute
   '/new-project': typeof AppNewProjectRoute
   '/admin/projects': typeof AdminProjectsRoute
+  '/admin/repl': typeof AdminReplRoute
   '/api/$': typeof ApiSplatRoute
   '/api/health': typeof ApiHealthRoute
   '/posthog-proxy/$': typeof PosthogProxySplatRoute
@@ -343,6 +350,7 @@ export interface FileRoutesByTo {
   '/itx-repl': typeof AppItxReplRoute
   '/new-project': typeof AppNewProjectRoute
   '/admin/projects': typeof AdminProjectsRoute
+  '/admin/repl': typeof AdminReplRoute
   '/api/$': typeof ApiSplatRoute
   '/api/health': typeof ApiHealthRoute
   '/posthog-proxy/$': typeof PosthogProxySplatRoute
@@ -385,6 +393,7 @@ export interface FileRoutesById {
   '/_app/itx-repl': typeof AppItxReplRoute
   '/_app/new-project': typeof AppNewProjectRoute
   '/admin/projects': typeof AdminProjectsRoute
+  '/admin/repl': typeof AdminReplRoute
   '/api/$': typeof ApiSplatRoute
   '/api/health': typeof ApiHealthRoute
   '/posthog-proxy/$': typeof PosthogProxySplatRoute
@@ -431,6 +440,7 @@ export interface FileRouteTypes {
     | '/itx-repl'
     | '/new-project'
     | '/admin/projects'
+    | '/admin/repl'
     | '/api/$'
     | '/api/health'
     | '/posthog-proxy/$'
@@ -471,6 +481,7 @@ export interface FileRouteTypes {
     | '/itx-repl'
     | '/new-project'
     | '/admin/projects'
+    | '/admin/repl'
     | '/api/$'
     | '/api/health'
     | '/posthog-proxy/$'
@@ -512,6 +523,7 @@ export interface FileRouteTypes {
     | '/_app/itx-repl'
     | '/_app/new-project'
     | '/admin/projects'
+    | '/admin/repl'
     | '/api/$'
     | '/api/health'
     | '/posthog-proxy/$'
@@ -644,6 +656,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/$'
       preLoaderRoute: typeof ApiSplatRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/admin/repl': {
+      id: '/admin/repl'
+      path: '/repl'
+      fullPath: '/admin/repl'
+      preLoaderRoute: typeof AdminReplRouteImport
+      parentRoute: typeof AdminRoute
     }
     '/admin/projects': {
       id: '/admin/projects'
@@ -1018,12 +1037,14 @@ const AdminStreamsRouteRouteWithChildren =
 interface AdminRouteChildren {
   AdminStreamsRouteRoute: typeof AdminStreamsRouteRouteWithChildren
   AdminProjectsRoute: typeof AdminProjectsRoute
+  AdminReplRoute: typeof AdminReplRoute
   AdminIndexRoute: typeof AdminIndexRoute
 }
 
 const AdminRouteChildren: AdminRouteChildren = {
   AdminStreamsRouteRoute: AdminStreamsRouteRouteWithChildren,
   AdminProjectsRoute: AdminProjectsRoute,
+  AdminReplRoute: AdminReplRoute,
   AdminIndexRoute: AdminIndexRoute,
 }
 

--- a/apps/os/src/routes/_app/projects/index.tsx
+++ b/apps/os/src/routes/_app/projects/index.tsx
@@ -1,16 +1,27 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { FolderPlus } from "lucide-react";
+import { useAuthClient } from "@iterate-com/auth/client";
 import { Button } from "@iterate-com/ui/components/button";
 import { Identifier } from "@iterate-com/ui/components/identifier";
 import { toast } from "@iterate-com/ui/components/sonner";
+import type { ReactNode } from "react";
 import { ItxBoundary } from "~/components/itx-boundary.tsx";
 import { normalizeProjectHostnameBase } from "~/lib/project-host-routing.ts";
 import { getPublicRouteConfig } from "~/lib/public-route-config.ts";
-import { useItx, useItxQuery } from "~/itx/itx-react.tsx";
-import type { ItxProjects } from "~/itx/handle.ts";
+import { myProjectsQueryOptions, type Project } from "~/lib/project-server-fns.ts";
+import { reconnectItx, useItx } from "~/itx/itx-react.tsx";
 
-type ProjectSummary = Awaited<ReturnType<ItxProjects["list"]>>["projects"][number];
+type OrganizationSummary = {
+  id: string;
+  name?: string | null;
+  slug: string;
+};
 
 export const Route = createFileRoute("/_app/projects/")({
   ssr: false,
@@ -41,41 +52,81 @@ function ProjectsIndexPage() {
 
 function ProjectsIndexContent() {
   const { routeConfig } = Route.useLoaderData();
+  const { session } = useAuthClient();
+  const organizations = session?.authenticated ? session.session.organizations : [];
+  const isAdmin = session?.authenticated ? session.user.isAdmin === true : false;
   const itx = useItx();
   const queryClient = useQueryClient();
-  // Orphan recovery deferred — itx.projects.list returns OS-DB projects only and
-  // intentionally does NOT merge auth-service orphans yet; see follow-up.
-  const projectsKey = ["projects"];
-  const list = useItxQuery({
-    key: projectsKey,
-    query: (itx) => itx.projects.list({ limit: 20, offset: 0 }),
-  });
-  const projects: ProjectSummary[] = list.projects ?? [];
+  const listQueryOptions = myProjectsQueryOptions();
+  const list = useQuery(listQueryOptions);
+  const projects = list.data?.projects ?? [];
+
+  // The scoped oRPC list intentionally merges two sources:
+  // - OS D1 rows for projects that exist in this deployment.
+  // - Auth-session project claims when auth still knows about a project but this
+  //   OS worker database does not. That happens in preview/dev when we delete or
+  //   recreate the OS database but leave the auth worker database intact. Showing
+  //   those auth-only rows separately lets us recover the exact auth-owned
+  //   project IDs and slugs without inventing random fallback slugs.
+  const osProjects = projects.filter((project) => !project.isOrphanedProjectFromAuthService);
+  const recoveredProjects = projects.filter((project) => project.isOrphanedProjectFromAuthService);
+  const hasProjects = osProjects.length > 0 || recoveredProjects.length > 0;
 
   const deleteProject = useMutation({
     mutationFn: async (input: { id: string }) => {
       return await itx.projects.remove(input);
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["itx", ...projectsKey] });
+      await queryClient.invalidateQueries({ queryKey: listQueryOptions.queryKey });
     },
     onError: (error) => toast.error(error instanceof Error ? error.message : String(error)),
   });
 
-  const hasProjects = projects.length > 0;
+  const recoverProject = useMutation({
+    mutationFn: async (project: Project) => {
+      const organizationSlug = project.organizationId
+        ? organizations.find((organization) => organization.id === project.organizationId)?.slug
+        : undefined;
+      return await itx.projects.create({
+        id: project.id,
+        slug: project.slug,
+        organizationSlug,
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: listQueryOptions.queryKey });
+      reconnectItx();
+      toast.success("Project recovered");
+    },
+    onError: (error) => toast.error(error instanceof Error ? error.message : String(error)),
+  });
 
   return (
-    <section className="space-y-4 p-4">
-      <div className="flex items-start justify-between gap-4">
+    <section className="space-y-5 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-4">
         <div className="space-y-1">
           <h2 className="text-sm font-semibold">Projects</h2>
-          <p className="text-sm text-muted-foreground">Create and manage projects.</p>
+          <p className="text-sm text-muted-foreground">
+            Create and manage projects in this OS deployment.
+          </p>
         </div>
-        {hasProjects ? (
-          <Button type="button" size="sm" render={<Link to="/new-project" />}>
-            New project
-          </Button>
-        ) : null}
+        <div className="flex flex-wrap items-center gap-2">
+          {isAdmin ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              render={<Link to="/admin/projects" />}
+            >
+              Go to admin project list
+            </Button>
+          ) : null}
+          {hasProjects ? (
+            <Button type="button" size="sm" render={<Link to="/new-project" />}>
+              New project
+            </Button>
+          ) : null}
+        </div>
       </div>
 
       {!hasProjects ? (
@@ -96,67 +147,212 @@ function ProjectsIndexContent() {
           </div>
         </div>
       ) : (
-        <div className="overflow-x-auto rounded-lg border">
-          <div className="grid min-w-[900px] grid-cols-[220px_160px_220px_minmax(220px,1fr)_190px_96px] border-b bg-muted/40 px-3 py-2 text-xs font-medium text-muted-foreground">
-            <div>ID</div>
-            <div>Slug</div>
-            <div>Custom hostname</div>
-            <div>Hostname</div>
-            <div>Created</div>
-            <div />
-          </div>
-          {projects.map((project) => {
-            const hostname = buildProjectHostname({
-              slug: project.slug,
-              customHostname: project.customHostname,
-              projectHostnameBases: routeConfig.projectHostnameBases,
-            });
+        <>
+          <ProjectTableSection
+            title="Projects in this OS deployment"
+            description="These projects exist in this OS worker database and are present in your auth session."
+          >
+            {osProjects.length === 0 ? (
+              <EmptyTableMessage>
+                No OS-backed projects are available in this deployment.
+              </EmptyTableMessage>
+            ) : (
+              <OsProjectsTable
+                projects={osProjects}
+                organizations={organizations}
+                projectHostnameBases={routeConfig.projectHostnameBases}
+                deleteProject={deleteProject}
+              />
+            )}
+          </ProjectTableSection>
 
-            return (
-              <div
-                key={project.id}
-                className="grid min-w-[900px] grid-cols-[220px_160px_220px_minmax(220px,1fr)_190px_96px] items-start gap-3 border-b px-3 py-3 text-sm last:border-b-0"
-              >
-                <Identifier value={project.id} textClassName="text-xs text-muted-foreground" />
-                <ProjectSlugCell project={project} />
-                <div className="truncate text-xs text-muted-foreground">
-                  {project.customHostname ?? "None"}
-                </div>
-                <div className="truncate text-xs">
-                  {hostname ? (
-                    <a
-                      href={`https://${hostname}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-500 hover:underline"
-                    >
-                      {hostname}
-                    </a>
-                  ) : (
-                    <span className="text-muted-foreground">-</span>
-                  )}
-                </div>
-                <div className="text-xs text-muted-foreground">{project.createdAt ?? "-"}</div>
-                <Button
-                  size="sm"
-                  variant="destructive"
-                  onClick={() => deleteProject.mutate({ id: project.id })}
-                  disabled={deleteProject.isPending && deleteProject.variables?.id === project.id}
-                >
-                  {deleteProject.isPending && deleteProject.variables?.id === project.id
-                    ? "Deleting..."
-                    : "Delete"}
-                </Button>
-              </div>
-            );
-          })}
-        </div>
+          <ProjectTableSection
+            title="Recovered from auth session"
+            description="These projects are present in your auth session but do not exist in this OS worker deployment."
+          >
+            {recoveredProjects.length === 0 ? (
+              <EmptyTableMessage>No auth-only projects need recovery.</EmptyTableMessage>
+            ) : (
+              <RecoveredProjectsTable
+                projects={recoveredProjects}
+                organizations={organizations}
+                recoverProject={recoverProject}
+              />
+            )}
+          </ProjectTableSection>
+        </>
       )}
     </section>
   );
 }
 
-function ProjectSlugCell({ project }: { project: ProjectSummary }) {
+function ProjectTableSection({
+  children,
+  description,
+  title,
+}: {
+  children: ReactNode;
+  description: string;
+  title: string;
+}) {
+  return (
+    <section className="space-y-2">
+      <div className="space-y-1">
+        <h3 className="text-sm font-medium">{title}</h3>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function EmptyTableMessage({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-lg border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+function OsProjectsTable({
+  deleteProject,
+  organizations,
+  projectHostnameBases,
+  projects,
+}: {
+  deleteProject: UseMutationResult<unknown, Error, { id: string }>;
+  organizations: OrganizationSummary[];
+  projectHostnameBases: readonly string[];
+  projects: Project[];
+}) {
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <div className="grid min-w-[1040px] grid-cols-[220px_160px_220px_180px_minmax(220px,1fr)_190px_96px] border-b bg-muted/40 px-3 py-2 text-xs font-medium text-muted-foreground">
+        <div>ID</div>
+        <div>Slug</div>
+        <div>Organization</div>
+        <div>Custom hostname</div>
+        <div>Hostname</div>
+        <div>Created</div>
+        <div />
+      </div>
+      {projects.map((project) => {
+        const hostname = buildProjectHostname({
+          slug: project.slug,
+          customHostname: project.customHostname,
+          projectHostnameBases,
+        });
+
+        return (
+          <div
+            key={project.id}
+            className="grid min-w-[1040px] grid-cols-[220px_160px_220px_180px_minmax(220px,1fr)_190px_96px] items-start gap-3 border-b px-3 py-3 text-sm last:border-b-0"
+          >
+            <Identifier value={project.id} textClassName="text-xs text-muted-foreground" />
+            <ProjectSlugCell project={project} />
+            <ProjectOrganizationCell project={project} organizations={organizations} />
+            <div className="truncate text-xs text-muted-foreground">
+              {project.customHostname ?? "None"}
+            </div>
+            <div className="truncate text-xs">
+              {hostname ? (
+                <a
+                  href={`https://${hostname}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-500 hover:underline"
+                >
+                  {hostname}
+                </a>
+              ) : (
+                <span className="text-muted-foreground">-</span>
+              )}
+            </div>
+            <div className="text-xs text-muted-foreground">{project.createdAt ?? "-"}</div>
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() => deleteProject.mutate({ id: project.id })}
+              disabled={deleteProject.isPending && deleteProject.variables?.id === project.id}
+            >
+              {deleteProject.isPending && deleteProject.variables?.id === project.id
+                ? "Deleting..."
+                : "Delete"}
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function RecoveredProjectsTable({
+  organizations,
+  projects,
+  recoverProject,
+}: {
+  organizations: OrganizationSummary[];
+  projects: Project[];
+  recoverProject: UseMutationResult<unknown, Error, Project>;
+}) {
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <div className="grid min-w-[820px] grid-cols-[220px_180px_240px_minmax(160px,1fr)_120px] border-b bg-muted/40 px-3 py-2 text-xs font-medium text-muted-foreground">
+        <div>ID</div>
+        <div>Slug</div>
+        <div>Organization</div>
+        <div>Status</div>
+        <div />
+      </div>
+      {projects.map((project) => (
+        <div
+          key={project.id}
+          className="grid min-w-[820px] grid-cols-[220px_180px_240px_minmax(160px,1fr)_120px] items-start gap-3 border-b px-3 py-3 text-sm last:border-b-0"
+        >
+          <Identifier value={project.id} textClassName="text-xs text-muted-foreground" />
+          <div className="truncate font-medium">{project.slug}</div>
+          <ProjectOrganizationCell project={project} organizations={organizations} />
+          <div className="text-xs text-muted-foreground">
+            Auth session only; missing from this OS worker database.
+          </div>
+          <Button
+            size="sm"
+            onClick={() => recoverProject.mutate(project)}
+            disabled={recoverProject.isPending && recoverProject.variables?.id === project.id}
+          >
+            {recoverProject.isPending && recoverProject.variables?.id === project.id
+              ? "Recovering..."
+              : "Recover"}
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ProjectOrganizationCell({
+  project,
+  organizations,
+}: {
+  project: Project;
+  organizations: OrganizationSummary[];
+}) {
+  if (!project.organizationId) {
+    return <div className="truncate text-xs text-muted-foreground">-</div>;
+  }
+
+  const organization = organizations.find((candidate) => candidate.id === project.organizationId);
+  return (
+    <div className="min-w-0">
+      <div className="truncate text-xs">
+        {organization?.name ?? organization?.slug ?? project.organizationId}
+      </div>
+      <div className="truncate text-xs text-muted-foreground">{project.organizationId}</div>
+    </div>
+  );
+}
+
+function ProjectSlugCell({ project }: { project: Project }) {
   return (
     <Link
       to="/projects/$projectSlug/agents/new"

--- a/apps/os/src/routes/admin.tsx
+++ b/apps/os/src/routes/admin.tsx
@@ -8,7 +8,13 @@
 
 import { Suspense, useEffect, useState, type CSSProperties } from "react";
 import { ClientOnly, createFileRoute, Link, Outlet, useRouterState } from "@tanstack/react-router";
-import { FolderKanbanIcon, RadioTowerIcon, ShieldIcon, WaypointsIcon } from "lucide-react";
+import {
+  FolderKanbanIcon,
+  RadioTowerIcon,
+  ShieldIcon,
+  SquareTerminalIcon,
+  WaypointsIcon,
+} from "lucide-react";
 import { Button } from "@iterate-com/ui/components/button";
 import {
   Field,
@@ -244,6 +250,16 @@ function AdminSidebar() {
                 >
                   <FolderKanbanIcon aria-hidden="true" />
                   <span>Projects</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  tooltip="Repl"
+                  isActive={pathname.startsWith("/admin/repl")}
+                  render={<Link to="/admin/repl" />}
+                >
+                  <SquareTerminalIcon aria-hidden="true" />
+                  <span>Repl</span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
             </SidebarMenu>

--- a/apps/os/src/routes/admin/repl.tsx
+++ b/apps/os/src/routes/admin/repl.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ConnectedItxRepl } from "~/routes/_app/itx-repl.tsx";
+
+export const Route = createFileRoute("/admin/repl")({
+  component: AdminReplPage,
+});
+
+function AdminReplPage() {
+  return <ConnectedItxRepl context="global" />;
+}


### PR DESCRIPTION
## Summary
- make the regular `/projects` list use auth project claims for all users, including admins
- keep global all-project listing on `/admin/projects` via the existing admin ITX page
- add nullable `organizationId` to project list records and show an Organization column for debugging

## Why
The product projects page should show the projects a user ostensibly owns or can adopt from auth, not every OS project just because the user is an admin. Global project inspection already belongs on the admin projects page.

## Validation
- pnpm exec oxlint apps/os/src/domains/projects/project-directory.ts apps/os/src/orpc/routers/projects.ts apps/os/src/routes/_app/projects/index.tsx apps/os/src/lib/cache-created-project-queries.ts apps/os-contract/src/index.ts --threads 1 --deny-warnings
- pnpm --dir apps/os typecheck
- pnpm --dir apps/os-contract typecheck
- pnpm format:check -- apps/os-contract/src/index.ts apps/os/src/domains/projects/project-directory.ts apps/os/src/lib/cache-created-project-queries.ts apps/os/src/orpc/routers/projects.ts apps/os/src/routes/_app/projects/index.tsx
- git diff --check

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-15T15:54:36.483Z",
      "headSha": "d0a46900e2e57f61a4b02b6dccf331ce60352f72",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27558271954",
      "shortSha": "d0a4690"
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-15T15:54:21.294Z",
      "headSha": "d0a46900e2e57f61a4b02b6dccf331ce60352f72",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27558271954",
      "shortSha": "d0a4690"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-06-15T15:54:33.883Z",
      "headSha": "332f355676f30fba4a15776b50a489b3d19430a8",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27556260569",
      "shortSha": "332f355"
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-06-15T15:54:29.898Z",
      "headSha": "332f355676f30fba4a15776b50a489b3d19430a8",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-6.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27556260569",
      "shortSha": "332f355"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `d0a4690`
Preview: https://auth.iterate-preview-6.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27558271954)
Updated: 2026-06-15T15:54:36.483Z

### OS
Status: released
Commit: `d0a4690`
Preview: https://os.iterate-preview-6.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27558271954)
Updated: 2026-06-15T15:54:21.294Z

### Semaphore
Status: released
Commit: `332f355`
Preview: https://semaphore.iterate-preview-6.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27556260569)
Updated: 2026-06-15T15:54:33.883Z

### Streams Example App
Status: released
Commit: `332f355`
Preview: https://streams-example-app-preview-6.iterate-dev-preview.workers.dev
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27556260569)
Updated: 2026-06-15T15:54:29.898Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who sees which projects (including admin behavior), project creation path, and recovery flows on a core dashboard surface; global listing remains on admin ITX.
> 
> **Overview**
> The product **`/projects`** list no longer returns every OS project for admins; **`ProjectsCapability.list`** always derives from the user’s signed auth project claims (with optional auth-only “orphan” rows when D1 is missing a row). List items now include nullable **`organizationId`**, surfaced on the projects page.
> 
> The projects index switches from **ITX** listing to **`myProjectsQueryOptions`** / server functions, splits **OS-backed** vs **auth-only recovery** tables (with a **Recover** action), and links admins to **`/admin/projects`**. **Create project** uses **`createProjectServerFn`** so creation goes through the session-aware directory (org ownership) instead of the global ITX operator path, and invalidates the my-projects cache after create.
> 
> Navigation adds **Repl** entry points: project sidebar → **`/projects/$projectSlug/repl`**, admin sidebar + new **`/admin/repl`** route (global ITX repl).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0a46900e2e57f61a4b02b6dccf331ce60352f72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->