### PR TITLE
Remove os.localhost from dev auth setup

### DIFF
--- a/apps/auth/docs/login-and-bundle-debugging.md
+++ b/apps/auth/docs/login-and-bundle-debugging.md
@@ -5,7 +5,7 @@ Date: 2026-06-12
 ## What I observed
 
 - `apps/os` dev sign-in can look like a no-op if the user clicks the SSR-rendered button before the client has hydrated.
-- In a Playwright repro against `http://os.localhost:61975/sign-in?redirect_url=%2F`, an immediate click produced no `/api/iterate-auth/login` request. Waiting longer before clicking produced the expected request:
+- In a Playwright repro against `http://localhost:61975/sign-in?redirect_url=%2F`, an immediate click produced no `/api/iterate-auth/login` request. Waiting longer before clicking produced the expected request:
   `GET /api/iterate-auth/login?return_to=%2F`.
 - The slow hydration is made worse because the OS dev client loads `src/start.ts`, then `src/auth/middleware.ts`, then `apps/auth/src/lib/server.ts`. That pulls server auth code into the dev client graph before the sign-in button handler is active.
 - The auth worker build also has a large startup surface. A synthetic esbuild bundle of `apps/auth/src/server/worker.ts` was about `3.75 MB` unminified without code splitting.

--- a/apps/auth/src/server/oauth-resources.ts
+++ b/apps/auth/src/server/oauth-resources.ts
@@ -7,10 +7,9 @@ export function getOsResourceBases() {
     "https://os.iterate-dev-misha.com",
     "https://os.iterate-dev-rahul.com",
     "http://localhost:5173",
-    // Fully-local dev runs on arbitrary ports (http://os.localhost:<port>), so
+    // Fully-local dev runs on arbitrary ports (http://localhost:<port>), so
     // the RFC 8707 resource/audience is the stable portless loopback origin —
     // OS sets APP_CONFIG_ITERATE_AUTH__RESOURCE to match.
-    "http://os.localhost",
     "http://localhost",
     "http://127.0.0.1",
     ...[1, 2, 3, 4, 5, 6, 7, 8, 9].map(

--- a/apps/os/src/auth/iterate-auth-login.test.ts
+++ b/apps/os/src/auth/iterate-auth-login.test.ts
@@ -5,8 +5,8 @@ const config = {
   issuer: "https://auth.iterate-dev.com/api/auth",
   clientId: "os-local-dev",
   clientSecret: "secret",
-  redirectURI: "http://os.localhost:65455/api/iterate-auth/callback",
-  resource: "http://os.localhost",
+  redirectURI: "http://localhost:65455/api/iterate-auth/callback",
+  resource: "http://localhost",
 } satisfies IterateAuthConfig;
 
 describe("iterate auth login", () => {
@@ -19,7 +19,7 @@ describe("iterate auth login", () => {
 
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe(
-      "http://os.localhost:65455/api/iterate-auth/login?return_to=%2Fprojects",
+      "http://localhost:65455/api/iterate-auth/login?return_to=%2Fprojects",
     );
     expect(response.headers.get("set-cookie")).toBeNull();
   });
@@ -27,7 +27,7 @@ describe("iterate auth login", () => {
   it("writes the OAuth state cookie on the configured callback origin", async () => {
     const handler = testAuthHandler(config);
 
-    const response = await handler(new Request("http://os.localhost:65455/api/iterate-auth/login"));
+    const response = await handler(new Request("http://localhost:65455/api/iterate-auth/login"));
 
     expect(response.status).toBe(302);
     expect(response.headers.get("set-cookie")).toContain("iterate_oauth_state=");
@@ -36,7 +36,7 @@ describe("iterate auth login", () => {
     expect(location.origin).toBe("https://auth.iterate-dev.com");
     expect(location.searchParams.get("client_id")).toBe("os-local-dev");
     expect(location.searchParams.get("redirect_uri")).toBe(
-      "http://os.localhost:65455/api/iterate-auth/callback",
+      "http://localhost:65455/api/iterate-auth/callback",
     );
     expect(location.searchParams.get("state")).toBeTruthy();
   });
@@ -47,7 +47,7 @@ describe("iterate auth login", () => {
     const handler = testAuthHandler(config, { doRefresh });
 
     await handler(
-      new Request("http://os.localhost:65455/api/iterate-auth/session?refresh=force", {
+      new Request("http://localhost:65455/api/iterate-auth/session?refresh=force", {
         headers: { cookie: sessionCookie(tokenSet) },
       }),
     );
@@ -61,7 +61,7 @@ describe("iterate auth login", () => {
     const handler = testAuthHandler(config, { doRefresh });
 
     await handler(
-      new Request("http://os.localhost:65455/api/iterate-auth/session", {
+      new Request("http://localhost:65455/api/iterate-auth/session", {
         headers: {
           cookie: sessionCookie(
             testTokenSet({ accessTokenExpiresAt: Date.now() + 60 * 60 * 1000 }),
@@ -86,7 +86,7 @@ describe("iterate auth login", () => {
     });
 
     const response = await handler(
-      new Request("http://os.localhost:65455/api/iterate-auth/session?refresh=force", {
+      new Request("http://localhost:65455/api/iterate-auth/session?refresh=force", {
         headers: { cookie: sessionCookie(signed.tokenSet) },
       }),
     );
@@ -124,8 +124,8 @@ function testAuthHandler(
     doRefresh: async () => null,
     getUserInfo: async () => null,
     cookieOpts: () => ({ httpOnly: true, path: "/", sameSite: "Lax", secure: false }) as const,
-    resource: () => "http://os.localhost",
-    audiences: () => ["http://os.localhost"],
+    resource: () => "http://localhost",
+    audiences: () => ["http://localhost"],
     ...overrides,
   } as unknown as Parameters<typeof createAuthHandler>[1];
 


### PR DESCRIPTION
## Summary
- remove `os.localhost` from OS/auth dev auth resource and login test coverage
- update auth debugging notes to use `localhost:<port>`
- keep the dev OAuth callback convention on portless `localhost` / `127.0.0.1`, which the auth worker accepts for arbitrary loopback ports

## Deployment
- updated `auth/dev_global` `AUTH_SEED_OAUTH_CLIENTS` to remove `http://os.localhost/api/iterate-auth/callback`
- reseeded deployed `https://auth.iterate-dev.com` so `os-local-dev` now has only `http://localhost/api/iterate-auth/callback` and `http://127.0.0.1/api/iterate-auth/callback`

## Verification
- `pnpm -C apps/os exec vitest run src/auth/iterate-auth-login.test.ts`
- `pnpm exec oxlint apps/auth/src/server/oauth-resources.ts apps/os/src/auth/iterate-auth-login.test.ts --deny-warnings`
- `pnpm exec oxfmt --check apps/auth/src/server/oauth-resources.ts apps/os/src/auth/iterate-auth-login.test.ts apps/auth/docs/login-and-bundle-debugging.md`
- direct authorize probes for `http://localhost:65455/api/iterate-auth/callback` and `http://127.0.0.1:61234/api/iterate-auth/callback` now redirect to `/login` instead of `invalid_redirect`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-15T20:34:56.768Z",
      "headSha": "e13e85e20d4f46600bc097facf727ebac113f032",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27558676666",
      "shortSha": "e13e85e"
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-15T20:34:44.204Z",
      "headSha": "e13e85e20d4f46600bc097facf727ebac113f032",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27558676666",
      "shortSha": "e13e85e"
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `e13e85e`
Preview: https://auth.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27558676666)
Updated: 2026-06-15T20:34:56.768Z

### OS
Status: released
Commit: `e13e85e`
Preview: https://os.iterate-preview-2.com
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27558676666)
Updated: 2026-06-15T20:34:44.204Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow dev-only URL and test/doc alignment; production resource bases are unchanged aside from removing an unused local hostname variant.
> 
> **Overview**
> Standardizes **fully-local OS dev auth** on plain **`localhost` / `127.0.0.1`** instead of **`os.localhost`**.
> 
> **`getOsResourceBases()`** no longer lists `http://os.localhost` as an OAuth resource/audience; comments now describe arbitrary ports as `http://localhost:<port>`. **`iterate-auth-login.test.ts`** updates redirect URI, resource, and request URLs to match, including loopback canonicalization expectations.
> 
> **Login debugging notes** swap the Playwright repro URL from `os.localhost` to `localhost` for the same hydration/sign-in behavior.
> 
> Deployed dev OAuth client seeding (outside this diff) is aligned so callbacks use portless loopback origins the worker already accepts for any loopback port.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e13e85e20d4f46600bc097facf727ebac113f032. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->