### PR TITLE
[codex] fix stream example browser RPC URLs

### DIFF
--- a/apps/streams-example-app/src/lib/stream-rpc.ts
+++ b/apps/streams-example-app/src/lib/stream-rpc.ts
@@ -14,7 +14,8 @@ export async function withStreamConnectionFromBrowser(args: {
     error: string | undefined,
   ) => void;
 }): Promise<StreamConnection> {
-  const webSocket = new WebSocket(toWebSocketUrl(args.url));
+  const browserUrl = new URL(args.url, window.location.href);
+  const webSocket = new WebSocket(toWebSocketUrl(browserUrl));
   args.onConnectionStatusChange?.("connecting", undefined);
   webSocket.addEventListener("open", () => args.onConnectionStatusChange?.("connected", undefined));
   webSocket.addEventListener("close", (event) =>


### PR DESCRIPTION
## What changed

Fix the streams example app browser Cap'n Web helper so relative stream RPC paths are resolved against the current page URL before converting them to WebSocket URLs.

## Why

After the stream-specific Cap'n Web helpers moved into the example app, the browser helper passed relative `/api/streams?...` paths directly into `new URL()`. In the browser stream page this produced `Failed to construct 'URL': Invalid URL`, so the raw-events mirror never connected and preview Playwright tests could not see the initial `events.iterate.com/stream/created` event.

## Validation

- `pnpm --dir apps/streams-example-app typecheck`
- `pnpm --dir apps/streams-example-app exec vitest run e2e/vitest/stream-rpc.test.ts`
- `pnpm exec oxlint . --threads 1 --deny-warnings`

I also reproduced the browser test locally before the fix: it moved from the invalid URL error to the local Vite server's expected missing Worker WebSocket endpoint state. The deployed preview e2e is the authoritative check for this helper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line URL resolution change in the example app's browser helper; no auth, data, or shared production infrastructure.
> 
> **Overview**
> **Fixes browser stream Cap'n Web connections** when callers pass relative paths such as `/api/streams?...` (the default from `streamRpcPath`).
> 
> `withStreamConnectionFromBrowser` now resolves `args.url` with `new URL(args.url, window.location.href)` before `toWebSocketUrl`, instead of constructing a URL from the string alone. That avoids `Invalid URL` in the page and lets the raw-events mirror and preview e2e see the initial stream events again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc95bdf10330a14626b02d595f690ffb594da2a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.
<!-- /CLOUDFLARE_PREVIEW -->