### PR TITLE
[codex] clarify agent codemode return guidance

### DIFF
--- a/apps/os/src/domains/agents/agent-prompt-guidance.ts
+++ b/apps/os/src/domains/agents/agent-prompt-guidance.ts
@@ -1,0 +1,5 @@
+export const SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE =
+  "Do not return side-effect-only call results unless you need to inspect them on your next turn.";
+
+export const AGENT_CHAT_CAPABILITY_INSTRUCTIONS =
+  "Use await itx.chat.sendMessage({ message }) to send a visible reply to the user in the web chat. Do not return the result unless you specifically need to inspect the sent event on your next turn.";

--- a/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
+++ b/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
@@ -68,6 +68,7 @@ import {
   agentProcessorSubscriptionConfiguredEvents,
   getAgentDurableObjectName,
 } from "~/domains/agents/agent-stream-subscriptions.ts";
+import { AGENT_CHAT_CAPABILITY_INSTRUCTIONS } from "~/domains/agents/agent-prompt-guidance.ts";
 import { buildProjectStreamViewerUrl } from "~/lib/stream-viewer-url.ts";
 
 export {
@@ -704,8 +705,7 @@ export class AgentDurableObject extends AgentLifecycleBase<AgentDurableObjectEnv
             type: "rpc",
             worker: { type: "loopback" },
           } satisfies CapabilityAddress,
-          instructions:
-            "itx.chat.sendMessage({ message }) sends a visible reply to the user in the web chat.",
+          instructions: AGENT_CHAT_CAPABILITY_INSTRUCTIONS,
           name: "chat",
         };
 

--- a/apps/os/src/domains/agents/stream-processors/agent/implementation.test.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/implementation.test.ts
@@ -11,6 +11,7 @@ import type {
   StreamProcessorIterateContext,
   StreamProcessorSnapshot,
 } from "~/domains/streams/engine/stream-processor.ts";
+import { AGENT_CHAT_CAPABILITY_INSTRUCTIONS } from "~/domains/agents/agent-prompt-guidance.ts";
 
 describe("AgentProcessor", () => {
   afterEach(() => {
@@ -464,7 +465,7 @@ describe("AgentProcessor", () => {
           type: "events.iterate.com/itx/capability-provided",
           payload: {
             path: ["chat"],
-            meta: { instructions: "Use itx.chat.sendMessage({ message }) for chat output." },
+            meta: { instructions: AGENT_CHAT_CAPABILITY_INSTRUCTIONS },
           },
           offset: 44,
         }),
@@ -480,9 +481,12 @@ describe("AgentProcessor", () => {
         llmRequestPolicy: { behaviour: "dont-trigger-request" },
       },
     });
+    const explainerPayload = appended[0]?.payload as { content: string };
+    expect(explainerPayload.content).toContain("await the call but do not return it");
     const payload = appended[1]?.payload as { content: string };
     expect(payload.content).toContain("itx.chat");
     expect(payload.content).toContain("itx.chat.sendMessage({ message })");
+    expect(payload.content).toContain("Do not return the result");
     expect(payload.content).toContain("offset 44");
   });
 

--- a/apps/os/src/domains/agents/stream-processors/agent/implementation.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/implementation.ts
@@ -715,7 +715,7 @@ function eventTypeExplanation(eventType: string): string | null {
     return eventTypeExplanationBlock({
       type: eventType,
       meaning:
-        "A capability is now available to your scripts. Call it as `itx.<name>.<method>(args)` in a code block. If you're not sure about the shape of a result, just return it and you'll be shown it on your next turn. The event below shows the capability's name and usage instructions.",
+        "A capability is now available to your scripts. Call it as `itx.<name>.<method>(args)` in a code block. Return a value only when you need to inspect it on your next turn. For side-effect-only calls such as `itx.chat.sendMessage(...)`, await the call but do not return it. The event below shows the capability's name and usage instructions.",
     });
   }
   return null;

--- a/apps/os/src/domains/inbound-mcp-server/durable-objects/project-mcp-server-connection.ts
+++ b/apps/os/src/domains/inbound-mcp-server/durable-objects/project-mcp-server-connection.ts
@@ -207,7 +207,7 @@ export class ProjectMcpServerConnection extends McpAgent<
           "Execute JavaScript in an isolated sandbox. The code MUST be a single async arrow function: `async (itx) => { ... }`.",
           "",
           "The function receives `itx`, a handle on this session's iterate context. Use `Promise.all([...])` for concurrent operations. Use `fetch` for HTTP (project egress, secret substitution). The return value (or thrown error) is sent back as the tool result.",
-          "If you're not sure about the shape of the result of a call, just return it and you'll be shown it on your next turn.",
+          "Return a value only when you need to inspect it in the tool result. For side-effect-only calls, await the call but do not return its result.",
           "",
           "Available capabilities on itx:",
           providerDocs,
@@ -527,7 +527,7 @@ export class ProjectMcpServerConnection extends McpAgent<
       code: z
         .string()
         .describe(
-          "JavaScript async arrow function to execute, e.g. `async (itx) => { return await itx.describe(); }`",
+          "JavaScript async arrow function to execute. Return a value only when you need to inspect it, e.g. `async (itx) => { return await itx.describe(); }`",
         ),
       ...(options.requireProjectInput
         ? {

--- a/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/durable-objects/project-durable-object.ts
@@ -44,8 +44,9 @@ import {
 import { ProjectProcessor } from "~/domains/projects/stream-processors/project/implementation.ts";
 import {
   isMissingProjectWorkerError,
-  loadProjectWorker,
-} from "~/domains/projects/project-worker-runtime.ts";
+  isMissingProjectWorkerProcessEventError,
+} from "~/domains/projects/project-worker-errors.ts";
+import { loadProjectWorker } from "~/domains/projects/project-worker-runtime.ts";
 import { type RepoDurableObject } from "~/domains/repos/durable-objects/repo-durable-object.ts";
 import type { SlackAgentDurableObject } from "~/domains/slack/durable-objects/slack-agent-durable-object.ts";
 import { createContext } from "~/itx/coordinates.ts";
@@ -233,6 +234,7 @@ export class ProjectDurableObject extends DurableObject<ProjectEnv> {
         streamPath: PROJECT_STREAM_PATH,
       });
     } catch (error) {
+      if (isMissingProjectWorkerProcessEventError(error)) return;
       console.error("Project worker processEvent failed.", error);
     }
   }

--- a/apps/os/src/domains/projects/project-worker-errors.ts
+++ b/apps/os/src/domains/projects/project-worker-errors.ts
@@ -1,0 +1,21 @@
+/**
+ * "There is no worker to load" is a normal state: the repo or worker.js may not
+ * exist yet. Other load failures should still retry through the processor
+ * checkpoint.
+ */
+const MISSING_PROJECT_WORKER_ERROR_NAMES: ReadonlySet<string> = new Set([
+  "MissingProjectWorkerError",
+  "RepoNotCreatedError",
+  "RepoEmptyError",
+]);
+
+export function isMissingProjectWorkerError(error: unknown): boolean {
+  return error instanceof Error && MISSING_PROJECT_WORKER_ERROR_NAMES.has(error.name);
+}
+
+export function isMissingProjectWorkerProcessEventError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes('RPC receiver does not implement the method "processEvent"')
+  );
+}

--- a/apps/os/src/domains/projects/project-worker-runtime.test.ts
+++ b/apps/os/src/domains/projects/project-worker-runtime.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isMissingProjectWorkerProcessEventError } from "./project-worker-errors.ts";
+
+describe("project worker runtime", () => {
+  it("classifies absent optional processEvent hooks", () => {
+    expect(
+      isMissingProjectWorkerProcessEventError(
+        new TypeError('The RPC receiver does not implement the method "processEvent".'),
+      ),
+    ).toBe(true);
+
+    expect(
+      isMissingProjectWorkerProcessEventError(
+        new TypeError('The RPC receiver does not implement the method "fetch".'),
+      ),
+    ).toBe(false);
+    expect(isMissingProjectWorkerProcessEventError(new Error("user hook failed"))).toBe(false);
+  });
+});

--- a/apps/os/src/domains/projects/project-worker-runtime.ts
+++ b/apps/os/src/domains/projects/project-worker-runtime.ts
@@ -86,24 +86,3 @@ export function isProjectWorkerEntrypoint(value: unknown): value is ProjectWorke
     typeof value.fetch === "function"
   );
 }
-
-/**
- * "There is no worker to load" — a NORMAL state (the repo or its worker.js
- * does not exist yet), as opposed to a transient build/git failure. Event
- * forwarding skips on the former and rethrows the latter so checkpointed
- * delivery retries.
- *
- * Classified by `error.name`: every throw site is ours and typed
- * (MissingProjectWorkerError in ~/itx/source-build.ts; RepoNotCreatedError /
- * RepoEmptyError in ~/domains/repos), and Workers RPC preserves the name
- * across the repo-DO hop.
- */
-const MISSING_PROJECT_WORKER_ERROR_NAMES: ReadonlySet<string> = new Set([
-  "MissingProjectWorkerError",
-  "RepoNotCreatedError",
-  "RepoEmptyError",
-]);
-
-export function isMissingProjectWorkerError(error: unknown): boolean {
-  return error instanceof Error && MISSING_PROJECT_WORKER_ERROR_NAMES.has(error.name);
-}

--- a/apps/os/src/domains/projects/stream-processors/project/implementation.test.ts
+++ b/apps/os/src/domains/projects/stream-processors/project/implementation.test.ts
@@ -20,9 +20,9 @@ vi.mock("~/domains/slack/durable-objects/slack-agent-durable-object.ts", () => (
     `${input.projectId}:${input.streamPath}`,
 }));
 
+import { ProjectProcessor, defaultAgentSystemPrompt } from "./implementation.ts";
 import { SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE } from "~/domains/agents/agent-prompt-guidance.ts";
 import { projectOnboardingBootstrapMarkdown } from "~/domains/repos/project-repo-template.ts";
-import { ProjectProcessor, defaultAgentSystemPrompt } from "./implementation.ts";
 
 describe("project agent prompts", () => {
   it("tells web agents to await chat sends without returning side-effect results", () => {

--- a/apps/os/src/domains/projects/stream-processors/project/implementation.test.ts
+++ b/apps/os/src/domains/projects/stream-processors/project/implementation.test.ts
@@ -20,7 +20,38 @@ vi.mock("~/domains/slack/durable-objects/slack-agent-durable-object.ts", () => (
     `${input.projectId}:${input.streamPath}`,
 }));
 
-import { ProjectProcessor } from "./implementation.ts";
+import { SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE } from "~/domains/agents/agent-prompt-guidance.ts";
+import { projectOnboardingBootstrapMarkdown } from "~/domains/repos/project-repo-template.ts";
+import { ProjectProcessor, defaultAgentSystemPrompt } from "./implementation.ts";
+
+describe("project agent prompts", () => {
+  it("tells web agents to await chat sends without returning side-effect results", () => {
+    const prompt = defaultAgentSystemPrompt("/agents/onboarding");
+
+    expect(prompt).toContain("await itx.chat.sendMessage({ message })");
+    expect(prompt).toContain(SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE);
+    expect(prompt).not.toContain("return await itx.chat.sendMessage");
+  });
+
+  it("tells slack agents to await replies without returning side-effect results", () => {
+    const prompt = defaultAgentSystemPrompt("/agents/slack/C123/ts-456");
+
+    expect(prompt).toContain("await itx.slack.chat.postMessage");
+    expect(prompt).toContain(SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE);
+    expect(prompt).not.toContain("return await itx.slack.chat.postMessage");
+  });
+
+  it("onboarding bootstrap tells agents not to return chat-send results by default", () => {
+    const markdown = projectOnboardingBootstrapMarkdown({
+      projectId: "prj_test",
+      slug: "test-project",
+    });
+
+    expect(markdown).toContain("awaiting `itx.chat.sendMessage({ message })`");
+    expect(markdown).toContain("Do not\n  return the result");
+    expect(markdown).not.toContain("return await itx.chat.sendMessage");
+  });
+});
 
 describe("ProjectProcessor worker forwarding", () => {
   it("forwards project worker-visible root-stream events after project identity exists", async () => {

--- a/apps/os/src/domains/projects/stream-processors/project/implementation.ts
+++ b/apps/os/src/domains/projects/stream-processors/project/implementation.ts
@@ -36,6 +36,7 @@ import {
   OS_AGENT_LLM_PROVIDER_SELECTED_EVENT_TYPE,
   getAgentDurableObjectName,
 } from "~/domains/agents/agent-stream-subscriptions.ts";
+import { SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE } from "~/domains/agents/agent-prompt-guidance.ts";
 import {
   getSlackAgentDurableObjectName,
   type SlackAgentDurableObject,
@@ -387,7 +388,7 @@ function isSlackAgentPath(agentPath: string) {
   return normalized === "/agents/slack" || normalized.startsWith("/agents/slack/");
 }
 
-function defaultAgentSystemPrompt(agentPath: string) {
+export function defaultAgentSystemPrompt(agentPath: string) {
   const isSlack = isSlackAgentPath(agentPath);
   return [
     `You are the iterate AI agent running on stream ${agentPath}.`,
@@ -395,8 +396,8 @@ function defaultAgentSystemPrompt(agentPath: string) {
     "The code block must contain a single async arrow function: async (itx) => { ... }.",
     "Use capabilities announced as itx/capability-provided events.",
     isSlack
-      ? "For Slack, reply only when mentioned, directly asked, or clearly needed. Use itx.slack.chat.postMessage({ channel, thread_ts, text }) on the same thread."
-      : "For web chat, reply with itx.chat.sendMessage({ message }).",
+      ? `For Slack, reply only when mentioned, directly asked, or clearly needed. Use await itx.slack.chat.postMessage({ channel, thread_ts, text }) on the same thread. ${SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE}`
+      : `For web chat, reply with await itx.chat.sendMessage({ message }). ${SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE}`,
     "Use itx.streams.get(path) to read and append project stream events.",
     "Use the project repo as durable memory for stable project knowledge.",
   ].join("\n\n");

--- a/apps/os/src/domains/repos/project-repo-template.ts
+++ b/apps/os/src/domains/repos/project-repo-template.ts
@@ -31,7 +31,9 @@ is private to this project and is the right place for this knowledge.
 - Read any existing repo files before overwriting them.
 - Make commits whenever you discover useful durable information.
 - Use code comments inside your executable JavaScript block to plan your work.
-- Talk to the user by calling \`itx.chat.sendMessage({ message })\`.
+- Talk to the user by awaiting \`itx.chat.sendMessage({ message })\`. Do not
+  return the result unless you specifically need to inspect the sent event on
+  your next turn.
 
 ## Reading repo files
 


### PR DESCRIPTION
## What changed

- Clarified agent codemode guidance so return values are for inspection only.
- Updated chat/onboarding/Slack/MCP-facing prompts to tell agents to await side-effect-only calls, especially `itx.chat.sendMessage(...)`, without returning their results by default.
- Added prompt regression tests for web agent, Slack agent, onboarding bootstrap, and capability-provided instructions.
- Treated a missing optional project-worker `processEvent` hook as non-fatal to remove local project-create log spam.

## Why

The agent runtime intentionally feeds script return values back into model-visible context. The regression came from our prompts encouraging returns too broadly, which made side-effect-only chat sends easy for the model to return and then inspect again. This keeps the runtime rule intact and teaches the model the intended convention instead.

## Validation

- `pnpm exec vitest run src/domains/agents/stream-processors/agent/implementation.test.ts src/domains/projects/stream-processors/project/implementation.test.ts src/domains/projects/project-worker-runtime.test.ts`
- `pnpm exec tsc --noEmit --pretty false`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-16T14:47:14.847Z",
      "headSha": "6264c5aab456339d3dea2aeb2958ad96c8637e40",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27623293914",
      "shortSha": "6264c5a",
      "cleanupDurationMs": 3212,
      "deployDurationMs": 5068
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "cleanup-failed",
      "updatedAt": "2026-06-16T14:47:03.062Z",
      "headSha": "6264c5aab456339d3dea2aeb2958ad96c8637e40",
      "message": "[alchemy.run] JWKS fetch attempt 1 failed, retrying: [DOMException [TimeoutError]: The operation was aborted due to timeout]\n[alchemy.run] JWKS fetch attempt 2 failed, retrying: [DOMException [TimeoutError]: The operation was aborted due to timeout]\n/home/runner/work/iterate/iterate/apps/os/alchemy.run.ts:100\n      throw new Error(\n            ^\n\nError: [alchemy.run] Forge key is set but the deploy-time JWKS fetch from https://auth.iterate-preview-3.com/api/auth failed (The operation was aborted due to timeout). The forge pubkey can only be trusted via a baked static JWKS, so this would deploy a worker where minted tokens fail to verify. Aborting — retry the deploy.\n    at resolveStaticAuthJwks (/home/runner/work/iterate/iterate/apps/os/alchemy.run.ts:100:13)\n    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)\n    at async <anonymous> (/home/runner/work/iterate/iterate/apps/os/alchemy.run.ts:173:34)\n\nNode.js v24.15.0",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27623293914",
      "shortSha": "6264c5a",
      "cleanupDurationMs": 38563,
      "deployDurationMs": 37828
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_3",
    "leasedUntil": 1781622335474,
    "leaseId": "d1d9ac13-ede2-4149-a5cd-14f5bce067aa",
    "slug": "preview-3",
    "type": "environment-config-lease"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
Lease: `preview-3`
Doppler config: `preview_3`
Type: `environment-config-lease`
Leased until: 2026-06-16T15:05:35.474Z

### Auth
Status: released
Commit: `6264c5a`
Preview: https://auth.iterate-preview-3.com
Deploy duration: 5.1s
Cleanup duration: 3.2s
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27623293914)
Updated: 2026-06-16T14:47:14.847Z

### OS
Status: cleanup failed
Commit: `6264c5a`
Preview: https://os.iterate-preview-3.com
Deploy duration: 37.8s
Cleanup duration: 38.6s
Summary: [alchemy.run] JWKS fetch attempt 1 failed, retrying: [DOMException [TimeoutError]: The operation was aborted due to timeout]
[Workflow run](https://github.com/iterate/iterate/actions/runs/27623293914)
Updated: 2026-06-16T14:47:03.062Z

<details>
<summary>Failure details</summary>

<pre>[alchemy.run] JWKS fetch attempt 1 failed, retrying: [DOMException [TimeoutError]: The operation was aborted due to timeout]
[alchemy.run] JWKS fetch attempt 2 failed, retrying: [DOMException [TimeoutError]: The operation was aborted due to timeout]
/home/runner/work/iterate/iterate/apps/os/alchemy.run.ts:100
      throw new Error(
            ^

Error: [alchemy.run] Forge key is set but the deploy-time JWKS fetch from https://auth.iterate-preview-3.com/api/auth failed (The operation was aborted due to timeout). The forge pubkey can only be trusted via a baked static JWKS, so this would deploy a worker where minted tokens fail to verify. Aborting — retry the deploy.
    at resolveStaticAuthJwks (/home/runner/work/iterate/iterate/apps/os/alchemy.run.ts:100:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async &lt;anonymous&gt; (/home/runner/work/iterate/iterate/apps/os/alchemy.run.ts:173:34)

Node.js v24.15.0</pre>

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly prompt and documentation strings plus a narrow error-handling skip for optional worker hooks; no auth or data-path changes.
> 
> **Overview**
> Aligns agent and MCP prompts with the runtime rule that **script return values become model-visible context**, so models should **not return** side-effect-only calls (especially `itx.chat.sendMessage`) unless they need to inspect the result.
> 
> Shared guidance lives in `agent-prompt-guidance.ts` and is wired through web/Slack system prompts, chat capability instructions, onboarding `BOOTSTRAP.md`, the agent processor’s first-time `itx/capability-provided` explainer, and MCP `exec_js` tool copy. Regression tests cover web/Slack/onboarding prompts and capability-provided rendering.
> 
> Separately, missing optional project-worker `processEvent` is classified in `project-worker-errors.ts` and ignored when forwarding root-stream events, avoiding log noise when workers only export `fetch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6264c5aab456339d3dea2aeb2958ad96c8637e40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->