### PR TITLE
Restore auth dependency for OS previews

### DIFF
--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -36,15 +36,14 @@ Useful entry points:
 The preview workflow is deliberately simple:
 
 - select the apps affected by the PR diff;
-- deploy the selected apps concurrently;
-- when auth and OS are both selected, deploy auth before OS because OS bakes
-  auth JWKS during deployment;
+- include declared preview dependencies, currently OS -> auth;
+- deploy the selected apps in dependency batches;
 - after deployment has finished, run tests for every deployed app concurrently.
 
 The preview script does not try to prove dependency freshness or start each app's
 tests as soon as it is individually ready. That lost little in the measured case
-and keeps the behavior easy to reason about. Ordinary OS-only changes probe the
-slot's existing auth worker and only redeploy auth first if that probe fails.
+and keeps the behavior easy to reason about. OS deploys only after the slot's
+auth deployment is ready because OS bakes auth JWKS during deployment.
 
 To run the same deploy-then-test lifecycle from your machine:
 

--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -253,11 +253,10 @@ Each preview slot N is a complete, isolated stack on the dev/preview
 Cloudflare account: `os.iterate-preview-N.com`, `auth.iterate-preview-N.com`,
 and `<proj-slug>.iterate-preview-N.app`. Slots are leased via semaphore
 (`environment-config-lease`, slugs `preview-1..9`). CI acquires a lease per PR,
-deploys the apps touched by the PR, runs e2e, and destroys the PR's deployed apps
-and releases the lease on PR close. Ordinary OS-only changes probe the existing
-slot auth worker and only redeploy auth first if that probe fails; when auth and
-OS are both selected, auth deploys before OS because OS bakes auth JWKS during
-deployment.
+deploys the apps touched by the PR, runs e2e, and destroys the PR's deployed
+apps and releases the lease on PR close. OS preview deploys include auth and
+wait for the slot's auth deployment before OS starts because OS bakes auth JWKS
+during deployment.
 
 The slot's OS↔auth OAuth client credentials are **constants in Doppler**
 (`auth/preview_N` carries `AUTH_SEED_OAUTH_CLIENTS`; `os/preview_N` carries
@@ -276,8 +275,7 @@ doppler run --project _shared --config prd -- pnpm preview status              #
 doppler run --project _shared --config prd -- pnpm preview acquire --slot 9    # lease it (3h default)
 # → prints leaseId + the matching release command
 
-# 2. Deploy (same primitive as everything else; deploy auth first when you
-#    changed auth or need to seed a fresh slot):
+# 2. Deploy (same primitive as everything else; auth first because OS bakes its JWKS):
 cd apps/auth && doppler run --project auth --config preview_9 -- pnpm alchemy:up
 cd ../os     && doppler run --project os   --config preview_9 -- pnpm alchemy:up
 

--- a/scripts/preview/apps.ts
+++ b/scripts/preview/apps.ts
@@ -10,6 +10,7 @@ export type CloudflarePreviewApp = {
   appPath: `apps/${string}`;
   dopplerProject: string;
   paths: string[];
+  previewDependencies?: CloudflarePreviewAppSlug[];
   /** Readiness probe path on the app's public URL (default /api/__internal/health). */
   previewReadyUrlPath?: string;
   previewTestBaseUrlEnvVar: string;
@@ -55,6 +56,9 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
       "apps/auth-contract/**",
       "apps/os/src/domains/streams/**",
     ],
+    // OS bakes auth JWKS during deployment, so the slot's auth deployment must
+    // finish before OS deploy starts.
+    previewDependencies: ["auth"],
     previewTestBaseUrlEnvVar: "OS_BASE_URL",
     // The itx e2e (node project only — the browser project needs a Playwright
     // chromium install the preview e2e job doesn't have) reads

--- a/scripts/preview/apps.ts
+++ b/scripts/preview/apps.ts
@@ -74,7 +74,7 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
         // workers in probes. Start it after a short delay so its setup overlaps
         // the broad phase's tail without hitting the initial worker burst.
         "OS_ITX_E2E_FILE_PARALLELISM=true OS_ITX_E2E_EGRESS_CONCURRENT=true OS_ITX_E2E_LIVE_CONCURRENT=true OS_ITX_E2E_SKIP_MATRIX=true pnpm e2e:itx --project node & itx_pid=$!",
-        "(sleep ${OS_ITX_E2E_MATRIX_DELAY_SECONDS:-20}; OS_ITX_E2E_MATRIX_CONCURRENT=true pnpm e2e:itx --project node src/itx/e2e/itx.e2e.test.ts -t 'catalogue example') & matrix_pid=$!",
+        "(sleep ${OS_ITX_E2E_MATRIX_DELAY_SECONDS:-20}; pnpm e2e:itx --project node src/itx/e2e/itx.e2e.test.ts -t 'catalogue example') & matrix_pid=$!",
         "smoke_status=0",
         "itx_status=0",
         "matrix_status=0",

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -5,19 +5,34 @@ import {
   cloudflarePreviewSharedPaths,
 } from "./apps.ts";
 import {
+  expandPreviewDependencies,
   orderPreviewDeployBatches,
   resolvePreviewReadinessUrls,
   resolvePreviewCompareBaseSha,
   selectPreviewAppsNeedingRetry,
 } from "./preview.ts";
 
+describe("preview app dependency expansion", () => {
+  it("expands os to include its auth dependency", () => {
+    expect(expandPreviewDependencies(["os"])).toEqual(["os", "auth"]);
+  });
+
+  it("keeps independent apps as-is", () => {
+    expect(expandPreviewDependencies(["semaphore"])).toEqual(["semaphore"]);
+  });
+
+  it("deduplicates dependencies", () => {
+    expect(expandPreviewDependencies(["os", "os", "auth"])).toEqual(["os", "auth"]);
+  });
+});
+
 describe("preview deploy ordering", () => {
-  it("keeps OS-only deploys in the first batch", () => {
+  it("keeps independent apps in the same batch", () => {
     expect(
-      orderPreviewDeployBatches([cloudflarePreviewApps.os]).map((batch) =>
+      orderPreviewDeployBatches([cloudflarePreviewApps.semaphore]).map((batch) =>
         batch.map((app) => app.slug),
       ),
-    ).toEqual([["os"]]);
+    ).toEqual([["semaphore"]]);
   });
 
   it("deploys auth before OS when both are selected", () => {
@@ -87,7 +102,7 @@ describe("preview compare base", () => {
 });
 
 describe("preview retry selection", () => {
-  it("retries current-head failed apps", () => {
+  it("retries current-head failed apps and their dependencies", () => {
     expect(
       selectPreviewAppsNeedingRetry({
         previousState: {
@@ -104,7 +119,7 @@ describe("preview retry selection", () => {
         },
         pullRequestHeadSha: "current-head",
       }).map((app) => app.slug),
-    ).toEqual(["os"]);
+    ).toEqual(["os", "auth"]);
   });
 
   it("does not retry previously failed apps from older commits", () => {

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -38,7 +38,6 @@ const defaultPreviewLeaseMs = 60 * 60 * 1000;
 // returning immediately once the health endpoint is reachable.
 const defaultPreviewReadyTimeoutMs = 600_000;
 const defaultPreviewReadyUrlPath = "/api/__internal/health";
-const defaultPreviewAuthProbeTimeoutMs = 5_000;
 const defaultPreviewTestMaxAttempts = 1;
 const defaultPreviewTestRetryDelayMs = 5_000;
 const defaultPreviewAppConcurrency = 5;
@@ -186,7 +185,7 @@ export async function deployCloudflarePreviewForPullRequest(
     repositoryFullName: params.repositoryFullName,
     pullRequestNumber: params.pullRequestNumber,
   });
-  let selectedApps = await selectPreviewAppsForPullRequest({
+  const selectedApps = await selectPreviewAppsForPullRequest({
     force: params.force ?? false,
     githubToken: params.githubToken,
     previousState: current.state,
@@ -214,13 +213,6 @@ export async function deployCloudflarePreviewForPullRequest(
     ),
     semaphoreBaseUrl: params.semaphoreBaseUrl ?? defaultSemaphoreBaseUrl,
     waitMs: params.waitMs,
-  });
-  selectedApps = await includeAuthPreviewIfOsNeedsIt({
-    commandEnvironment: params.commandEnvironment,
-    dopplerConfig: environmentConfigLease.dopplerConfig,
-    repositoryRoot: params.repositoryRoot,
-    selectedApps,
-    signal: params.signal,
   });
   const leaseUpdate = await updatePreviewState(params, (state) => ({
     ...state,
@@ -804,7 +796,7 @@ async function selectPreviewAppsForPullRequest(input: {
     }
   }
 
-  return Object.values(cloudflarePreviewApps).filter((app) => selectedSlugs.has(app.slug));
+  return expandPreviewDependencies([...selectedSlugs]).map((slug) => cloudflarePreviewApps[slug]);
 }
 
 export function selectPreviewAppsNeedingRetry(params: {
@@ -816,7 +808,30 @@ export function selectPreviewAppsNeedingRetry(params: {
     .filter((entry) => ["awaiting-tests", "deploy-failed", "tests-failed"].includes(entry.status))
     .map((entry) => CloudflarePreviewAppSlug.parse(entry.appSlug));
 
-  return Object.values(cloudflarePreviewApps).filter((app) => retrySlugs.includes(app.slug));
+  return expandPreviewDependencies(retrySlugs).map((slug) => cloudflarePreviewApps[slug]);
+}
+
+export function expandPreviewDependencies(appSlugs: readonly CloudflarePreviewAppSlugType[]) {
+  const selected = new Set(appSlugs);
+  const visit = (appSlug: CloudflarePreviewAppSlugType) => {
+    const app = cloudflarePreviewApps[appSlug];
+    for (const dependency of app.previewDependencies ?? []) {
+      if (selected.has(dependency)) {
+        continue;
+      }
+
+      selected.add(dependency);
+      visit(dependency);
+    }
+  };
+
+  for (const appSlug of appSlugs) {
+    visit(appSlug);
+  }
+
+  return Object.values(cloudflarePreviewApps)
+    .map((app) => app.slug)
+    .filter((appSlug) => selected.has(appSlug));
 }
 
 export function orderPreviewDeployBatches(apps: readonly PreviewAppRuntime[]) {
@@ -827,52 +842,6 @@ export function orderPreviewDeployBatches(apps: readonly PreviewAppRuntime[]) {
   }
 
   return [apps.filter((app) => app.slug !== "os"), [os]];
-}
-
-async function includeAuthPreviewIfOsNeedsIt(input: {
-  commandEnvironment: NodeJS.ProcessEnv;
-  dopplerConfig: string;
-  repositoryRoot: string;
-  selectedApps: readonly PreviewAppRuntime[];
-  signal?: AbortSignal;
-}) {
-  const selectedSlugs = new Set(input.selectedApps.map((app) => app.slug));
-  if (!selectedSlugs.has("os") || selectedSlugs.has("auth")) {
-    return [...input.selectedApps];
-  }
-
-  const auth = cloudflarePreviewApps.auth;
-  try {
-    const authConfig = await readPreviewAppConfig({
-      app: auth,
-      commandEnvironment: input.commandEnvironment,
-      dopplerConfig: input.dopplerConfig,
-      repositoryRoot: input.repositoryRoot,
-      signal: input.signal,
-    });
-    const readiness = await waitForPreviewAppReadiness({
-      publicUrl: authConfig.baseUrl,
-      readyUrlPath: auth.previewReadyUrlPath,
-      signal: input.signal,
-      timeoutMs: defaultPreviewAuthProbeTimeoutMs,
-    });
-    if (readiness.ok) {
-      console.error("[preview] existing auth preview is ready; deploying OS without auth");
-      return [...input.selectedApps];
-    }
-
-    console.error(
-      `[preview] auth preview is not ready; deploying auth before OS: ${readiness.message}`,
-    );
-  } catch (error) {
-    console.error(
-      `[preview] auth preview probe failed; deploying auth before OS: ${formatPreviewErrorMessage(error)}`,
-    );
-  }
-
-  return Object.values(cloudflarePreviewApps).filter(
-    (app) => app.slug === "auth" || selectedSlugs.has(app.slug),
-  );
 }
 
 async function mapWithConcurrency<T, Result>(


### PR DESCRIPTION
## Summary

Restore the conservative preview deploy ordering for OS:

- OS preview selection includes auth again via `previewDependencies: ["auth"]`.
- Auth deploys and passes readiness before OS deploy starts.
- The conditional "probe existing auth and skip auth deploy" path is removed.
- Docs/tests are updated back to the dependency-batch model.

## Why

PR #1541 exposed that relying on an existing auth preview worker is not robust enough. OS bakes auth JWKS during deployment, so the boring invariant is safer: when OS is selected, deploy auth first, then OS.

This intentionally gives back the conditional auth-skip optimization for now.

## Validation

- `pnpm --dir scripts test`
- `pnpm exec oxlint scripts/preview/apps.ts scripts/preview/preview.ts scripts/preview/preview.test.ts --threads 1 --deny-warnings`
- `pnpm typecheck`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-06-16T15:33:43.480Z",
      "headSha": "09b3ec9dc9b86e8c9a74bb7c0698758adfb23ce8",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27626400496",
      "shortSha": "09b3ec9",
      "cleanupDurationMs": 12931,
      "deployDurationMs": 24245,
      "testDurationMs": 6155
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-16T15:33:43.657Z",
      "headSha": "09b3ec9dc9b86e8c9a74bb7c0698758adfb23ce8",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27626400496",
      "shortSha": "09b3ec9",
      "cleanupDurationMs": 13105,
      "deployDurationMs": 26507,
      "testDurationMs": 212
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-06-16T15:33:39.748Z",
      "headSha": "09b3ec9dc9b86e8c9a74bb7c0698758adfb23ce8",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-4.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27626400496",
      "shortSha": "09b3ec9",
      "cleanupDurationMs": 9193,
      "deployDurationMs": 15688,
      "testDurationMs": 22511
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-16T15:33:27.585Z",
      "headSha": "09b3ec9dc9b86e8c9a74bb7c0698758adfb23ce8",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27626400496",
      "shortSha": "09b3ec9",
      "cleanupDurationMs": 57435,
      "deployDurationMs": 49423,
      "testDurationMs": 89185
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `09b3ec9`
Preview: https://auth.iterate-preview-4.com
Deploy duration: 26.5s
Test duration: 212ms
Cleanup duration: 13.1s
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27626400496)
Updated: 2026-06-16T15:33:43.657Z

### OS
Status: released
Commit: `09b3ec9`
Preview: https://os.iterate-preview-4.com
Deploy duration: 49.4s
Test duration: 89.2s
Cleanup duration: 57.4s
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27626400496)
Updated: 2026-06-16T15:33:27.585Z

### Semaphore
Status: released
Commit: `09b3ec9`
Preview: https://semaphore.iterate-preview-4.com
Deploy duration: 24.2s
Test duration: 6.2s
Cleanup duration: 12.9s
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27626400496)
Updated: 2026-06-16T15:33:43.480Z

### Streams Example App
Status: released
Commit: `09b3ec9`
Preview: https://streams-example-app-preview-4.iterate-dev-preview.workers.dev
Deploy duration: 15.7s
Test duration: 22.5s
Cleanup duration: 9.2s
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27626400496)
Updated: 2026-06-16T15:33:39.748Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI preview orchestration and deploy ordering for OS; misconfiguration could slow previews or break OS deploys if auth fails, but behavior is more conservative than the removed probe optimization.
> 
> **Overview**
> **Preview deploys** go back to a declared dependency model: selecting OS also selects **auth** via `previewDependencies`, deploys run in batches (auth ready before OS), and the runtime path that probed an existing auth worker and skipped auth deploy is removed.
> 
> **Retries** on failed OS preview runs now redeploy **auth** as well, since it is part of the expanded dependency set.
> 
> Docs (`ci-workflows`, `dev-environments`) describe dependency batches instead of conditional auth probing. OS preview e2e drops `OS_ITX_E2E_MATRIX_CONCURRENT` on the delayed catalogue matrix subprocess only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b3ec9dc9b86e8c9a74bb7c0698758adfb23ce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->