### PR TITLE
Fix production onboarding agent startup

### DIFF
--- a/apps/os/iterate-config-repo/ONBOARDING.md
+++ b/apps/os/iterate-config-repo/ONBOARDING.md
@@ -1,18 +1,4 @@
-export const PROJECT_REPO_AGENTS_MD = `# Project Agent Notes
-
-This private repo is the durable brain for the project's agents.
-
-Agents should keep useful, stable project knowledge here: user preferences,
-working agreements, product decisions, research summaries, unresolved questions,
-and implementation notes that future agents should inherit. Prefer concise
-markdown files that are easy to scan and update.
-
-The project worker entrypoint is \`worker.js\`. The root project stream can call
-\`processEvent({ event, streamPath }, env)\` on that worker for committed
-project events.
-`;
-
-export const PROJECT_REPO_ONBOARDING_MD = `# Onboarding Agent
+# Onboarding Agent
 
 The onboarding agent helps a new project owner turn a blank Iterate project into
 a useful working space.
@@ -36,4 +22,3 @@ During onboarding:
   stream with payload { agentPath: "/agents/onboarding" }.
 
 Do not mark onboarding complete just because the first message was answered.
-`;

--- a/apps/os/src/domains/agents/stream-processors/agent/contract.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/contract.ts
@@ -327,7 +327,9 @@ export function reduceAgentEvent(args: { state: AgentState; event: AgentConsumed
     case "events.iterate.com/agents/tui-message-sent":
       return state;
     case "events.iterate.com/agent/config-updated":
-      return state;
+      return event.payload.systemPrompt === undefined
+        ? state
+        : { ...state, systemPrompt: event.payload.systemPrompt };
     case "events.iterate.com/agent/system-prompt-updated":
       return { ...state, systemPrompt: event.payload.systemPrompt };
     case "events.iterate.com/agent/input-added":

--- a/apps/os/src/domains/agents/stream-processors/agent/implementation.test.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/implementation.test.ts
@@ -119,6 +119,43 @@ describe("AgentProcessor", () => {
     ]);
   });
 
+  it("uses config-updated system prompts for inputs delivered in the same batch", async () => {
+    const { stream, appended } = memoryStream();
+    const processor = newAgentProcessor({ stream });
+
+    await processor.ingest({
+      events: [
+        agentEvent({
+          type: "events.iterate.com/agent/config-updated",
+          payload: { systemPrompt: "Onboard the project from ONBOARDING.md." },
+          offset: 10,
+        }),
+        providerSelectedEvent({ offset: 11 }),
+        agentEvent({
+          type: "events.iterate.com/agent/input-added",
+          payload: {
+            content: "Start onboarding now.",
+            llmRequestPolicy: { behaviour: "after-current-request" },
+          },
+          offset: 12,
+        }),
+      ],
+      streamMaxOffset: 12,
+    });
+
+    await expect(processor.snapshot()).resolves.toMatchObject({
+      state: { systemPrompt: "Onboard the project from ONBOARDING.md." },
+    });
+    expect(appended).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "events.iterate.com/agent/llm-request-scheduled",
+          idempotencyKey: "agent/llm-request-scheduled@12",
+        }),
+      ]),
+    );
+  });
+
   it("does not render received chat messages on the agents root stream", async () => {
     const { stream, appended } = memoryStream();
     const processor = newAgentProcessor({

--- a/apps/os/src/domains/projects/stream-processors/project/implementation.test.ts
+++ b/apps/os/src/domains/projects/stream-processors/project/implementation.test.ts
@@ -19,11 +19,20 @@ import { DEFAULT_WORKERS_AI_AGENT_MODEL } from "~/domains/agents/stream-processo
 
 describe("project agent prompts", () => {
   it("tells web agents to await chat sends without returning side-effect results", () => {
-    const prompt = defaultAgentSystemPrompt("/agents/onboarding");
+    const prompt = defaultAgentSystemPrompt("/agents/web/demo");
 
     expect(prompt).toContain("await itx.chat.sendMessage({ message })");
     expect(prompt).toContain(SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE);
     expect(prompt).not.toContain("return await itx.chat.sendMessage");
+    expect(prompt).not.toContain("ONBOARDING.md");
+  });
+
+  it("includes onboarding markdown instructions for the onboarding agent", () => {
+    const prompt = defaultAgentSystemPrompt("/agents/onboarding");
+
+    expect(prompt).toContain("ONBOARDING.md");
+    expect(prompt).toContain("Ask one focused question");
+    expect(prompt).toContain("events.iterate.com/project/onboarding-completed");
   });
 
   it("tells slack agents to await replies without returning side-effect results", () => {
@@ -169,8 +178,47 @@ describe("ProjectProcessor worker forwarding", () => {
             subscriptionKey: "agent:project_1:/agents/onboarding:openai-ws",
           }),
         }),
+        expect.objectContaining({
+          type: "events.iterate.com/agent/input-added",
+          idempotencyKey: "project-onboarding:start",
+          payload: expect.objectContaining({
+            content: expect.stringContaining("Start onboarding now"),
+          }),
+        }),
       ],
     });
+  });
+
+  it("does not proactively trigger ordinary fresh agent streams", async () => {
+    const appendedBatches: Array<{ events: unknown[]; streamPath?: string }> = [];
+    const processor = newProcessor({
+      forwardToProjectWorker: async () => undefined,
+      stream: {
+        append: async () => undefined,
+        appendBatch: async (batch) => {
+          appendedBatches.push(batch);
+        },
+      },
+    });
+
+    await processor.ingest({
+      events: [
+        childStreamCreated({
+          childPath: "/agents/web/demo",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          offset: 4,
+        }),
+      ],
+      streamMaxOffset: 4,
+    });
+
+    expect(appendedBatches).toHaveLength(1);
+    expect(appendedBatches[0]?.events).not.toContainEqual(
+      expect.objectContaining({
+        type: "events.iterate.com/agent/input-added",
+        idempotencyKey: "project-onboarding:start",
+      }),
+    );
   });
 
   it("does not advance the checkpoint past a failed project worker forward", async () => {

--- a/apps/os/src/domains/projects/stream-processors/project/implementation.ts
+++ b/apps/os/src/domains/projects/stream-processors/project/implementation.ts
@@ -50,6 +50,7 @@ import { SlackAgentProcessorContract } from "~/domains/slack/stream-processors/s
 import { SlackProcessorContract } from "~/domains/slack/stream-processors/slack/contract.ts";
 import { ensureProjectRepoInfoForProject } from "~/domains/repos/entrypoints/repo-capability.ts";
 import type { RepoDurableObject } from "~/domains/repos/durable-objects/repo-durable-object.ts";
+import { PROJECT_REPO_ONBOARDING_MD } from "~/domains/repos/project-repo-template.ts";
 import type { AppConfig } from "~/config.ts";
 import { SLACK_INTEGRATION_STREAM_PATH } from "~/domains/secrets/integration-stream-constants.ts";
 
@@ -345,6 +346,19 @@ export class ProjectProcessor extends StreamProcessor<
         ...(isSlackAgentPath(input.agentPath)
           ? [slackAgentProcessorSubscriptionConfiguredEvent(input)]
           : []),
+        ...(input.agentPath === ONBOARDING_AGENT_PATH
+          ? [
+              {
+                type: "events.iterate.com/agent/input-added",
+                idempotencyKey: "project-onboarding:start",
+                payload: {
+                  content:
+                    "Start onboarding now. Send the first onboarding message for this new project. " +
+                    "Follow ONBOARDING.md and ask exactly one focused question.",
+                },
+              },
+            ]
+          : []),
       ],
     });
   }
@@ -375,8 +389,15 @@ function isSlackAgentPath(agentPath: string) {
 
 export function defaultAgentSystemPrompt(agentPath: string) {
   const isSlack = isSlackAgentPath(agentPath);
+  const isOnboarding = agentPath === ONBOARDING_AGENT_PATH;
   return [
     `You are the iterate AI agent running on stream ${agentPath}.`,
+    ...(isOnboarding
+      ? [
+          "You are this project's onboarding agent. Follow the project repo file ONBOARDING.md exactly:",
+          PROJECT_REPO_ONBOARDING_MD,
+        ]
+      : []),
     "Respond with exactly one fenced JavaScript code block and no surrounding prose.",
     "The code block must contain a single async arrow function: async (itx) => { ... }.",
     "Use capabilities announced as itx/capability-provided events.",

--- a/apps/os/src/domains/repos/iterate-config-base-seed.ts
+++ b/apps/os/src/domains/repos/iterate-config-base-seed.ts
@@ -10,7 +10,10 @@ import {
   stripArtifactTokenQuery,
 } from "~/domains/repos/artifacts.ts";
 import { ITERATE_CONFIG_BASE_REPO_ARTIFACT_NAME } from "~/domains/repos/project-repo.ts";
-import { PROJECT_REPO_AGENTS_MD } from "~/domains/repos/project-repo-template.ts";
+import {
+  PROJECT_REPO_AGENTS_MD,
+  PROJECT_REPO_ONBOARDING_MD,
+} from "~/domains/repos/project-repo-template.ts";
 
 const ITERATE_CONFIG_REPO_DIR = "/repo";
 const ITERATE_CONFIG_JSONC = '{\n  "version": 1\n}\n';
@@ -152,6 +155,10 @@ export async function seedIterateConfigBaseRepo(input: {
     ITERATE_CONFIG_PACKAGE_JSON,
   );
   await filesystem.writeFile(`${ITERATE_CONFIG_REPO_DIR}/AGENTS.md`, PROJECT_REPO_AGENTS_MD);
+  await filesystem.writeFile(
+    `${ITERATE_CONFIG_REPO_DIR}/ONBOARDING.md`,
+    PROJECT_REPO_ONBOARDING_MD,
+  );
   await filesystem.mkdir(`${ITERATE_CONFIG_REPO_DIR}/apps/app1`, { recursive: true });
   await filesystem.mkdir(`${ITERATE_CONFIG_REPO_DIR}/apps/app2`, { recursive: true });
   await filesystem.mkdir(`${ITERATE_CONFIG_REPO_DIR}/apps/webhooks`, { recursive: true });
@@ -171,6 +178,7 @@ export async function seedIterateConfigBaseRepo(input: {
   await git.add({ dir: ITERATE_CONFIG_REPO_DIR, filepath: "iterate.config.jsonc" });
   await git.add({ dir: ITERATE_CONFIG_REPO_DIR, filepath: "package.json" });
   await git.add({ dir: ITERATE_CONFIG_REPO_DIR, filepath: "AGENTS.md" });
+  await git.add({ dir: ITERATE_CONFIG_REPO_DIR, filepath: "ONBOARDING.md" });
   await git.add({ dir: ITERATE_CONFIG_REPO_DIR, filepath: "worker.js" });
   await git.add({ dir: ITERATE_CONFIG_REPO_DIR, filepath: "apps/app1/worker.js" });
   await git.add({ dir: ITERATE_CONFIG_REPO_DIR, filepath: "apps/app2/worker.js" });


### PR DESCRIPTION
## Summary
- seed ONBOARDING.md into project/config repos
- make /agents/onboarding proactively send the first onboarding prompt
- apply agent config-updated systemPrompt during same-batch reduction before first LLM scheduling

## Verification
- pnpm --dir apps/os exec vitest run src/domains/agents/stream-processors/agent/implementation.test.ts src/domains/projects/stream-processors/project/implementation.test.ts
- pnpm --dir apps/os typecheck
- pnpm --dir apps/os exec oxfmt --check src/domains/agents/stream-processors/agent/contract.ts src/domains/agents/stream-processors/agent/implementation.test.ts src/domains/projects/stream-processors/project/implementation.ts src/domains/projects/stream-processors/project/implementation.test.ts src/domains/repos/iterate-config-base-seed.ts src/domains/repos/project-repo-template.ts iterate-config-repo/ONBOARDING.md
- deployed apps/os to prd from this branch
- prd fresh project codex-onboarding-1781648066791 produced agents/web-message-sent from /agents/onboarding and repo has ONBOARDING.md
- prd existing project iterate new agent /agents/web/codex-existing-1781648093 replied exactly: existing project new agent ok
- prd Slack proof against iterate posted real Slack thread reply: iterate prd Slack agent reply proof 1781648186650-41ac619a
- agent-browser loaded https://os.iterate.com/projects/codex-onboarding-1781648066791/agents/streams/agents/onboarding and saw: What do you want this project to help you accomplish?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent state reduction and project agent birth certificates; behavior is narrowed to onboarding and covered by new tests, but affects first-turn LLM scheduling for all agents when config-updated includes systemPrompt in the same batch.
> 
> **Overview**
> Fixes **onboarding agent startup** so new projects get a first message without user action and the model sees the right prompt when config and input land in one batch.
> 
> **ONBOARDING.md** is added to the iterate config repo template and seeded into the base config artifact (`PROJECT_REPO_ONBOARDING_MD`). The **onboarding agent** system prompt now inlines those instructions; other agents are unchanged.
> 
> When `/agents/onboarding` is birth-certified, the project processor appends a one-time **`agent/input-added`** (`project-onboarding:start`) that tells the agent to follow ONBOARDING.md and ask one question. Ordinary new agent streams do not get this kickoff.
> 
> **Agent reduction** now applies `systemPrompt` from **`agent/config-updated`** during the same ingest batch (previously ignored in `reduceAgentEvent`), so the first scheduled LLM request after setup uses the onboarding prompt instead of the default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dee66b69b7bfc8a41190a42f593bfe2782202ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-16T22:33:33.079Z",
      "headSha": "5dee66b69b7bfc8a41190a42f593bfe2782202ee",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27651966580",
      "shortSha": "5dee66b",
      "cleanupDurationMs": 13640,
      "deployDurationMs": 23622,
      "testDurationMs": 500
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-16T22:33:18.561Z",
      "headSha": "5dee66b69b7bfc8a41190a42f593bfe2782202ee",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27651966580",
      "shortSha": "5dee66b",
      "cleanupDurationMs": 43635,
      "deployDurationMs": 45635,
      "testDurationMs": 96026
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `5dee66b`
Preview: https://auth.iterate-preview-2.com
Deploy duration: 23.6s
Test duration: 500ms
Cleanup duration: 13.6s
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27651966580)
Updated: 2026-06-16T22:33:33.079Z

### OS
Status: released
Commit: `5dee66b`
Preview: https://os.iterate-preview-2.com
Deploy duration: 45.6s
Test duration: 96.0s
Cleanup duration: 43.6s
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27651966580)
Updated: 2026-06-16T22:33:18.561Z
<!-- /CLOUDFLARE_PREVIEW -->