### PR TITLE
Teach agents where project repo is cloned

### DIFF
--- a/apps/os/src/domains/agents/agent-prompt-guidance.ts
+++ b/apps/os/src/domains/agents/agent-prompt-guidance.ts
@@ -3,3 +3,12 @@ export const SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE =
 
 export const AGENT_CHAT_CAPABILITY_INSTRUCTIONS =
   "Use await itx.chat.sendMessage({ message }) inside the fenced JavaScript async function you output to send a visible reply to the user in the web chat. Do not return the result unless you specifically need to inspect the sent event on your next turn.";
+
+export const AGENT_WORKSPACE_CAPABILITY_INSTRUCTIONS =
+  "This agent's private workspace filesystem: itx.workspace.readFile/writeFile plus the " +
+  "flat git methods gitClone/gitAdd/gitCommit/gitPush/gitStatus. The project repo is " +
+  "already cloned at /project; read project files with paths like /project/AGENTS.md or " +
+  '/project/ONBOARDING.md by calling await itx.workspace.readFile({ path: "/project/ONBOARDING.md" }); ' +
+  "commit repo changes with git dir /project. Do not use unannounced APIs such as itx.repo, " +
+  "itx.fs, require('fs'), or process.cwd(); probing missing itx capabilities can throw before " +
+  "fallback code runs.";

--- a/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
+++ b/apps/os/src/domains/agents/durable-objects/agent-durable-object.ts
@@ -48,7 +48,10 @@ import {
   type AgentDurableObjectName,
   agentLlmProcessorSlug,
 } from "~/domains/agents/agent-stream-subscriptions.ts";
-import { AGENT_CHAT_CAPABILITY_INSTRUCTIONS } from "~/domains/agents/agent-prompt-guidance.ts";
+import {
+  AGENT_CHAT_CAPABILITY_INSTRUCTIONS,
+  AGENT_WORKSPACE_CAPABILITY_INSTRUCTIONS,
+} from "~/domains/agents/agent-prompt-guidance.ts";
 import { buildProjectStreamViewerUrl } from "~/lib/stream-viewer-url.ts";
 import { formatDurableObjectName, parseDurableObjectName } from "~/domains/durable-object-names.ts";
 
@@ -84,7 +87,7 @@ export type CloneProjectRepoInput = {
 /** Bump when agentContextCapabilities changes — re-provides the agent's tools
  * onto its own context (each provide appends an itx/capability-provided event
  * that both folds into the capability table and renders into the LLM's view). */
-const AGENT_CONTEXT_CAPABILITIES_VERSION = "8";
+const AGENT_CONTEXT_CAPABILITIES_VERSION = "10";
 
 export class AgentDurableObject extends DurableObject<AgentDurableObjectEnv> {
   readonly name = parseDurableObjectName(this.ctx.id.name!);
@@ -666,9 +669,7 @@ export class AgentDurableObject extends DurableObject<AgentDurableObjectEnv> {
           type: "rpc",
           worker: { type: "loopback" },
         },
-        instructions:
-          "This agent's private workspace filesystem: itx.workspace.readFile/writeFile plus the " +
-          "flat git methods gitClone/gitAdd/gitCommit/gitPush/gitStatus.",
+        instructions: AGENT_WORKSPACE_CAPABILITY_INSTRUCTIONS,
         name: "workspace",
       },
     ];

--- a/apps/os/src/domains/agents/stream-processors/agent/implementation.test.ts
+++ b/apps/os/src/domains/agents/stream-processors/agent/implementation.test.ts
@@ -11,7 +11,10 @@ import type {
   StreamProcessorIterateContext,
   StreamProcessorSnapshot,
 } from "~/domains/streams/engine/stream-processor.ts";
-import { AGENT_CHAT_CAPABILITY_INSTRUCTIONS } from "~/domains/agents/agent-prompt-guidance.ts";
+import {
+  AGENT_CHAT_CAPABILITY_INSTRUCTIONS,
+  AGENT_WORKSPACE_CAPABILITY_INSTRUCTIONS,
+} from "~/domains/agents/agent-prompt-guidance.ts";
 
 describe("AgentProcessor", () => {
   afterEach(() => {
@@ -534,6 +537,34 @@ describe("AgentProcessor", () => {
     expect(payload.content).toContain("itx.chat.sendMessage({ message })");
     expect(payload.content).toContain("Do not return the result");
     expect(payload.content).toContain("offset 44");
+  });
+
+  it("renders workspace capability instructions with the prepared project repo path", async () => {
+    const { stream, appended } = memoryStream();
+    const processor = newAgentProcessor({ stream });
+
+    await processor.ingest({
+      events: [
+        agentEvent({
+          type: "events.iterate.com/itx/capability-provided",
+          payload: {
+            path: ["workspace"],
+            meta: { instructions: AGENT_WORKSPACE_CAPABILITY_INSTRUCTIONS },
+          },
+          offset: 45,
+        }),
+      ],
+      streamMaxOffset: 45,
+    });
+
+    const payload = appended[1]?.payload as { content: string };
+    expect(payload.content).toContain("itx.workspace.readFile");
+    expect(payload.content).toContain("project repo is already cloned at /project");
+    expect(payload.content).toContain("/project/ONBOARDING.md");
+    expect(payload.content).toContain("git dir /project");
+    expect(payload.content).toContain("Do not use unannounced APIs");
+    expect(payload.content).toContain("itx.repo");
+    expect(payload.content).toContain("probing missing itx capabilities can throw");
   });
 
   it("recovers a scheduled request whose debounce timer died with a previous incarnation", async () => {

--- a/apps/os/src/domains/projects/stream-processors/project/implementation.test.ts
+++ b/apps/os/src/domains/projects/stream-processors/project/implementation.test.ts
@@ -14,7 +14,10 @@ vi.mock("~/domains/slack/durable-objects/slack-agent-durable-object.ts", () => (
 }));
 
 import { ProjectProcessor, defaultAgentSystemPrompt } from "./implementation.ts";
-import { SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE } from "~/domains/agents/agent-prompt-guidance.ts";
+import {
+  AGENT_WORKSPACE_CAPABILITY_INSTRUCTIONS,
+  SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE,
+} from "~/domains/agents/agent-prompt-guidance.ts";
 import { DEFAULT_WORKERS_AI_AGENT_MODEL } from "~/domains/agents/stream-processors/agent/contract.ts";
 
 describe("project agent prompts", () => {
@@ -23,8 +26,9 @@ describe("project agent prompts", () => {
 
     expect(prompt).toContain("await itx.chat.sendMessage({ message })");
     expect(prompt).toContain(SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE);
+    expect(prompt).toContain(AGENT_WORKSPACE_CAPABILITY_INSTRUCTIONS);
     expect(prompt).not.toContain("return await itx.chat.sendMessage");
-    expect(prompt).not.toContain("ONBOARDING.md");
+    expect(prompt).toContain("/project/ONBOARDING.md");
   });
 
   it("includes onboarding markdown instructions for the onboarding agent", () => {
@@ -40,6 +44,8 @@ describe("project agent prompts", () => {
 
     expect(prompt).toContain("await itx.slack.chat.postMessage");
     expect(prompt).toContain(SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE);
+    expect(prompt).toContain("itx.workspace.readFile");
+    expect(prompt).toContain("require('fs')");
     expect(prompt).not.toContain("return await itx.slack.chat.postMessage");
   });
 });

--- a/apps/os/src/domains/projects/stream-processors/project/implementation.ts
+++ b/apps/os/src/domains/projects/stream-processors/project/implementation.ts
@@ -39,7 +39,10 @@ import {
 } from "~/domains/streams/stream-runtime.ts";
 import type { AgentDurableObject } from "~/domains/agents/durable-objects/agent-durable-object.ts";
 import { agentProcessorSubscriptionConfiguredEvents } from "~/domains/agents/agent-stream-subscriptions.ts";
-import { SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE } from "~/domains/agents/agent-prompt-guidance.ts";
+import {
+  AGENT_WORKSPACE_CAPABILITY_INSTRUCTIONS,
+  SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE,
+} from "~/domains/agents/agent-prompt-guidance.ts";
 import { DEFAULT_WORKERS_AI_AGENT_MODEL } from "~/domains/agents/stream-processors/agent/contract.ts";
 import {
   getSlackAgentDurableObjectName,
@@ -406,6 +409,7 @@ export function defaultAgentSystemPrompt(agentPath: string) {
       : `For web chat, reply with await itx.chat.sendMessage({ message }). ${SIDE_EFFECT_ONLY_CALL_RESULT_GUIDANCE}`,
     "Use itx.streams.get(path) to read and append project stream events.",
     "Use the project repo as durable memory for stable project knowledge.",
+    AGENT_WORKSPACE_CAPABILITY_INSTRUCTIONS,
   ].join("\n\n");
 }
 


### PR DESCRIPTION
## Summary
- tell agents that their project repo clone is prepared at /project
- include examples for reading /project/AGENTS.md and /project/ONBOARDING.md
- bump agent context capability version so existing agents re-render the corrected workspace instructions

## Verification
- pnpm --dir apps/os exec vitest run src/domains/agents/stream-processors/agent/implementation.test.ts
- pnpm --dir apps/os typecheck
- pnpm --dir apps/os exec oxfmt --check src/domains/agents/agent-prompt-guidance.ts src/domains/agents/durable-objects/agent-durable-object.ts src/domains/agents/stream-processors/agent/implementation.test.ts
- deployed to prd from this branch
- prd natural-language proof: /agents/web/read-file-natural-after-guidance-1781677679314 read /project/ONBOARDING.md and replied with # Onboarding Agent plus the exact opening sentence

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and documentation-only changes to agent instructions; no auth, data, or execution-path logic is modified.
> 
> **Overview**
> Agents get **shared workspace capability copy** that states the project repo is already cloned at **`/project`**, with concrete `itx.workspace.readFile` examples (e.g. `/project/ONBOARDING.md`) and git workflows using **`git dir /project`**. The text also tells models **not** to use unannounced APIs (`itx.repo`, `require('fs')`, etc.) because probing missing capabilities can throw.
> 
> That guidance is wired into **agent context capability provisioning** (replacing the shorter inline workspace string) and into **`defaultAgentSystemPrompt`** for all project agents. **`AGENT_CONTEXT_CAPABILITIES_VERSION`** is bumped so existing agents **re-provide** capabilities and pick up the updated LLM-visible instructions.
> 
> Tests assert the new strings appear in capability rendering and default prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e80f10a3afad70c7cb970873e96cc9fb4bd04128. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-17T07:13:09.117Z",
      "headSha": "e80f10a3afad70c7cb970873e96cc9fb4bd04128",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27671292451",
      "shortSha": "e80f10a",
      "cleanupDurationMs": 11678,
      "deployDurationMs": 24162,
      "testDurationMs": 560
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-17T07:12:56.343Z",
      "headSha": "e80f10a3afad70c7cb970873e96cc9fb4bd04128",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27671292451",
      "shortSha": "e80f10a",
      "cleanupDurationMs": 45467,
      "deployDurationMs": 42104,
      "testDurationMs": 88199
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `e80f10a`
Preview: https://auth.iterate-preview-2.com
Deploy duration: 24.2s
Test duration: 560ms
Cleanup duration: 11.7s
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27671292451)
Updated: 2026-06-17T07:13:09.117Z

### OS
Status: released
Commit: `e80f10a`
Preview: https://os.iterate-preview-2.com
Deploy duration: 42.1s
Test duration: 88.2s
Cleanup duration: 45.5s
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27671292451)
Updated: 2026-06-17T07:12:56.343Z
<!-- /CLOUDFLARE_PREVIEW -->