### PR TITLE
Fix Slack agent reaction wakeups

### DIFF
--- a/apps/os/alchemy.run.ts
+++ b/apps/os/alchemy.run.ts
@@ -445,6 +445,7 @@ const [
     entrypoint: "./src/workers/slack-agent.ts",
     bindings: {
       AGENT: agent,
+      DB: db,
       DO_CATALOG: db,
       SLACK_AGENT: slackAgent,
       STREAM: stream,

--- a/apps/os/src/domains/slack/stream-processors/slack-agent/implementation.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack-agent/implementation.ts
@@ -83,7 +83,11 @@ export class SlackAgentProcessor extends StreamProcessor<
         // is nothing to announce here.
         return;
       case "events.iterate.com/slack/webhook-received": {
-        const appendAgentInput = async () => {
+        const appendAgentInput = async (
+          input: {
+            llmRequestPolicy?: { behaviour: "dont-trigger-request" };
+          } = {},
+        ) => {
           await this.ctx.stream.append({
             event: {
               type: "events.iterate.com/agent/input-added",
@@ -94,6 +98,9 @@ export class SlackAgentProcessor extends StreamProcessor<
               }),
               payload: {
                 content: slackWebhookAgentInput(event.payload),
+                ...(input.llmRequestPolicy == null
+                  ? {}
+                  : { llmRequestPolicy: input.llmRequestPolicy }),
               },
             },
           });
@@ -116,7 +123,15 @@ export class SlackAgentProcessor extends StreamProcessor<
         const botBotId = state.botBotId ?? botBotIdFromPayload(event.payload);
         if (isOwnBotMessage(slackEvent, botBotId)) return;
         if (isBotAction(slackEvent, state.botUserId)) return;
-        if (readStringField(slackEvent, "type") !== "message") return;
+        if (readStringField(slackEvent, "type") !== "message") {
+          args.blockProcessorWhile(async () => {
+            await appendAgentInput({
+              llmRequestPolicy: { behaviour: "dont-trigger-request" },
+            });
+            await this.#addEyesReactionForMessageTarget(target);
+          });
+          return;
+        }
 
         const channel = target?.channel ?? state.channel ?? readStringField(slackEvent, "channel");
         const threadTs =

--- a/apps/os/src/domains/slack/stream-processors/slack-agent/implementation.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack-agent/implementation.ts
@@ -116,6 +116,7 @@ export class SlackAgentProcessor extends StreamProcessor<
         const botBotId = state.botBotId ?? botBotIdFromPayload(event.payload);
         if (isOwnBotMessage(slackEvent, botBotId)) return;
         if (isBotAction(slackEvent, state.botUserId)) return;
+        if (readStringField(slackEvent, "type") !== "message") return;
 
         const channel = target?.channel ?? state.channel ?? readStringField(slackEvent, "channel");
         const threadTs =

--- a/apps/os/src/domains/slack/stream-processors/slack-agent/slack-agent.test.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack-agent/slack-agent.test.ts
@@ -355,6 +355,39 @@ describe("SlackAgentProcessor", () => {
     expect(appended).toEqual([]);
   });
 
+  it("ignores human reaction events instead of treating them as agent input", async () => {
+    const { appended, processor } = createProcessor();
+
+    await processor.ingest({
+      events: [
+        committedEvent({
+          offset: 50,
+          type: "events.iterate.com/slack/webhook-received",
+          payload: {
+            body: {
+              type: "event_callback",
+              event: {
+                type: "reaction_added",
+                user: "U_USER",
+                reaction: "eyes",
+                item: { type: "message", channel: "C123", ts: "1772136259.000000" },
+                item_user: "U_OTHER_USER",
+                event_ts: "1772136260.000000",
+              },
+              authorizations: [
+                { team_id: "T123", user_id: "U_BOT", is_bot: true, is_enterprise_install: false },
+              ],
+            },
+          },
+        }),
+      ],
+      streamMaxOffset: 50,
+    });
+    await flushBackgroundWork();
+
+    expect(appended).toEqual([]);
+  });
+
   it("ignores messages posted by our own bot", async () => {
     const { appended, processor } = createProcessor();
 

--- a/apps/os/src/domains/slack/stream-processors/slack-agent/slack-agent.test.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack-agent/slack-agent.test.ts
@@ -355,7 +355,7 @@ describe("SlackAgentProcessor", () => {
     expect(appended).toEqual([]);
   });
 
-  it("ignores human reaction events instead of treating them as agent input", async () => {
+  it("renders human reaction events as non-triggering agent input", async () => {
     const { appended, processor } = createProcessor();
 
     await processor.ingest({
@@ -385,7 +385,15 @@ describe("SlackAgentProcessor", () => {
     });
     await flushBackgroundWork();
 
-    expect(appended).toEqual([]);
+    expect(appended).toHaveLength(1);
+    expect(appended[0]!.event).toMatchObject({
+      type: "events.iterate.com/agent/input-added",
+      idempotencyKey: "slack-agent/slack-webhook-to-agent-input@50",
+      payload: {
+        content: expect.stringContaining("type: reaction_added"),
+        llmRequestPolicy: { behaviour: "dont-trigger-request" },
+      },
+    });
   });
 
   it("ignores messages posted by our own bot", async () => {


### PR DESCRIPTION
## What
- Bind `DB` into the `slackAgent` worker so Slack agent status/reaction side effects can read `slack.access_token` instead of retrying and failing.
- Ignore Slack Events API callbacks whose inner event is not `message`, so `reaction_added` events do not become duplicate agent inputs.
- Add a regression test for human reaction events.

## Why
Debugging slow production thread `C096Q1M4Y86 / 1781681097.741929` showed about 22.3s from user message to bot reply. The largest chunk was OpenAI (`gpt-5.5`) at ~12.9s, but there was also avoidable pre-LLM noise: the routed Slack agent hit `Cannot read properties of undefined (reading prepare)` while reading the Slack token, and the subsequent `reaction_added` callback generated a second `agent/input-added` event.

## Local checks
- `pnpm --dir apps/os exec vitest run src/domains/slack/stream-processors/slack-agent/slack-agent.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm format:check`
- `pnpm lint`
- `pnpm --dir apps/os test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Slack→agent ingestion and worker bindings; wrong policy could suppress legitimate triggers or leave token reads broken on deploy.
> 
> **Overview**
> Fixes slow/noisy Slack thread handling by wiring **D1 `DB`** into the `slackAgent` worker so status/reaction side effects can load `slack.access_token` instead of failing on an undefined database client.
> 
> For Slack webhooks whose inner event is **not** `message` (e.g. `reaction_added`), the slack-agent processor now appends **`agent/input-added`** with **`llmRequestPolicy: dont-trigger-request`** so the event is visible in the thread without starting another LLM run. Human `reaction_added` callbacks are covered by a regression test; bot-authored reaction webhooks remain ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66bf930f5dcc2f7aefc8b0f011c068dd93055e6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-17T10:47:43.406Z",
      "headSha": "66bf930f5dcc2f7aefc8b0f011c068dd93055e6d",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27682415999",
      "shortSha": "66bf930",
      "cleanupDurationMs": 12041,
      "deployDurationMs": 23693,
      "testDurationMs": 446
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-17T10:47:28.967Z",
      "headSha": "66bf930f5dcc2f7aefc8b0f011c068dd93055e6d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27682415999",
      "shortSha": "66bf930",
      "cleanupDurationMs": 48142,
      "deployDurationMs": 41485,
      "testDurationMs": 92015
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `66bf930`
Preview: https://auth.iterate-preview-2.com
Deploy duration: 23.7s
Test duration: 446ms
Cleanup duration: 12.0s
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27682415999)
Updated: 2026-06-17T10:47:43.406Z

### OS
Status: released
Commit: `66bf930`
Preview: https://os.iterate-preview-2.com
Deploy duration: 41.5s
Test duration: 92.0s
Cleanup duration: 48.1s
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27682415999)
Updated: 2026-06-17T10:47:28.967Z
<!-- /CLOUDFLARE_PREVIEW -->