### PR TITLE
[codex] Show initial new-agent message in chat

### DIFF
--- a/apps/os/src/routes/_app/projects/$projectSlug/agents/new.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/agents/new.tsx
@@ -39,12 +39,7 @@ function NewAgentPage() {
       const itx = await connectItx({ projectId: params.projectSlug });
       await itx.streams.create({ streamPath: agentPath });
       await waitForProjectAgentSetup(itx, agentPath);
-      await itx.streams.get(agentPath).append({
-        event: {
-          type: "events.iterate.com/agent/input-added",
-          payload: { content },
-        },
-      });
+      await itx.agents.sendMessage({ agentPath, message: content, channel: "web" });
       return agentPath;
     },
     onSuccess: (agentPath) => {


### PR DESCRIPTION
## Summary

Fixes new agent chat creation so the first prompt is sent through the same visible user-message path as follow-up chat messages.

## Root cause

The new-agent route created the stream and appended `events.iterate.com/agent/input-added` directly. That event reaches the LLM context, but the Agent tab renders user rows from `events.iterate.com/agents/user-message-received`, so the initial prompt was invisible in the chat feed.

## Change

After creating the stream and waiting for project agent setup, call `itx.agents.sendMessage({ agentPath, message, channel: "web" })` instead of appending `agent/input-added` directly. The agent processor then renders the model input from the user-visible event.

## Validation

- Reproduced locally on `http://localhost:53322` with an agent stream containing only `agent/input-added`; the Agent tab showed “Nothing here yet” while raw events contained the prompt.
- Ran `pnpm --dir apps/os typecheck`.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-17T11:31:34.720Z",
      "headSha": "9f7597e30673687ddbfbfe0548ddeba443abcd0f",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27683426301",
      "shortSha": "9f7597e",
      "cleanupDurationMs": 11123,
      "deployDurationMs": 37260,
      "testDurationMs": 590
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-17T11:31:22.531Z",
      "headSha": "9f7597e30673687ddbfbfe0548ddeba443abcd0f",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27683426301",
      "shortSha": "9f7597e",
      "cleanupDurationMs": 45852,
      "deployDurationMs": 136316,
      "testDurationMs": 96985
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `9f7597e`
Preview: https://auth.iterate-preview-3.com
Deploy duration: 37.3s
Test duration: 590ms
Cleanup duration: 11.1s
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27683426301)
Updated: 2026-06-17T11:31:34.720Z

### OS
Status: released
Commit: `9f7597e`
Preview: https://os.iterate-preview-3.com
Deploy duration: 136.3s
Test duration: 97.0s
Cleanup duration: 45.9s
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27683426301)
Updated: 2026-06-17T11:31:22.531Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI mutation-path change on agent creation; behavior aligns with existing `sendMessage` usage elsewhere.
> 
> **Overview**
> Fixes the **new agent** flow so the first prompt appears in the Agent tab like later messages.
> 
> After stream creation and project agent setup, **`new.tsx`** now calls **`itx.agents.sendMessage`** with `channel: "web"` instead of appending **`events.iterate.com/agent/input-added`** on the stream. That routes the prompt through the same path as follow-up chat, producing **`user-message-received`** events the UI renders instead of only feeding the LLM context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f7597e30673687ddbfbfe0548ddeba443abcd0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->