### PR TITLE
[codex] Use Start server functions for project lists

### DIFF
--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, type ReactElement } from "react";
 import { Link, useMatches, useMatchRoute } from "@tanstack/react-router";
+import { useServerFn } from "@tanstack/react-start";
 import {
   ArrowLeft,
   Bug,
@@ -69,7 +70,7 @@ import {
 } from "@iterate-com/ui/components/sidebar";
 import type { AppConfig } from "~/config.ts";
 import { buildProjectWorkerUrl } from "~/lib/project-host-routing.ts";
-import { myProjectsQueryOptions } from "~/lib/project-server-fns.ts";
+import { listMyProjectsServerFn, myProjectsQueryOptions } from "~/lib/project-server-fns.ts";
 import type { PublicRouteConfig } from "~/lib/public-route-config.ts";
 
 type PublicConfig = PublicAppConfig<AppConfig>;
@@ -106,7 +107,7 @@ export function AppSidebar({ routeConfig }: AppSidebarProps) {
 function AppSidebarHeader() {
   const matches = useMatches();
   const { isMobile } = useSidebar();
-  const { data } = useQuery(myProjectsQueryOptions());
+  const { data } = useMyProjectsQuery();
   const projects =
     data?.projects.filter((project) => !project.isOrphanedProjectFromAuthService) ?? [];
   const activeProjectSlug = getActiveProjectSlug(matches);
@@ -376,7 +377,7 @@ function authWorkerOrigin(config: PublicConfig) {
 function AppSidebarNav({ routeConfig }: { routeConfig: PublicRouteConfig }) {
   const matchRoute = useMatchRoute();
   const matches = useMatches();
-  const { data } = useQuery(myProjectsQueryOptions());
+  const { data } = useMyProjectsQuery();
   const projects =
     data?.projects.filter((project) => !project.isOrphanedProjectFromAuthService) ?? [];
   const activeProjectSlug = getActiveProjectSlug(matches);
@@ -460,6 +461,14 @@ function AppSidebarNav({ routeConfig }: { routeConfig: PublicRouteConfig }) {
       </SidebarGroup>
     </>
   );
+}
+
+function useMyProjectsQuery() {
+  const listMyProjectsFn = useServerFn(listMyProjectsServerFn);
+  return useQuery({
+    ...myProjectsQueryOptions(),
+    queryFn: () => listMyProjectsFn({ data: { limit: 100, offset: 0 } }),
+  });
 }
 
 function getActiveProjectSlug(matches: ReturnType<typeof useMatches>) {

--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -465,10 +465,9 @@ function AppSidebarNav({ routeConfig }: { routeConfig: PublicRouteConfig }) {
 
 function useMyProjectsQuery() {
   const listMyProjectsFn = useServerFn(listMyProjectsServerFn);
-  return useQuery({
-    ...myProjectsQueryOptions(),
-    queryFn: () => listMyProjectsFn({ data: { limit: 100, offset: 0 } }),
-  });
+  return useQuery(
+    myProjectsQueryOptions(() => listMyProjectsFn({ data: { limit: 100, offset: 0 } })),
+  );
 }
 
 function getActiveProjectSlug(matches: ReturnType<typeof useMatches>) {

--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState, type ReactElement } from "react";
 import { Link, useMatches, useMatchRoute } from "@tanstack/react-router";
-import { useServerFn } from "@tanstack/react-start";
 import {
   ArrowLeft,
   Bug,
@@ -70,7 +69,13 @@ import {
 } from "@iterate-com/ui/components/sidebar";
 import type { AppConfig } from "~/config.ts";
 import { buildProjectWorkerUrl } from "~/lib/project-host-routing.ts";
-import { listMyProjectsServerFn, myProjectsQueryOptions } from "~/lib/project-server-fns.ts";
+import {
+  listMyProjectsServerFn,
+  myProjectsListInput,
+  myProjectsQueryKey,
+  myProjectsStaleTime,
+  type Project,
+} from "~/lib/project-server-fns.ts";
 import type { PublicRouteConfig } from "~/lib/public-route-config.ts";
 
 type PublicConfig = PublicAppConfig<AppConfig>;
@@ -80,6 +85,14 @@ type AppSidebarProps = {
 };
 
 export function AppSidebar({ routeConfig }: AppSidebarProps) {
+  const { data } = useQuery({
+    queryKey: myProjectsQueryKey,
+    queryFn: () => listMyProjectsServerFn({ data: myProjectsListInput }),
+    staleTime: myProjectsStaleTime,
+  });
+  const projects =
+    data?.projects.filter((project) => !project.isOrphanedProjectFromAuthService) ?? [];
+
   // Sidebar composition follows shadcn sidebar blocks 07/08:
   // https://ui.shadcn.com/blocks/sidebar
   return (
@@ -90,10 +103,10 @@ export function AppSidebar({ routeConfig }: AppSidebarProps) {
           SidebarMenuButton uses for its width/height/padding — so the padding offset
           and the button's height change move the logo together instead of drifting. */}
       <SidebarHeader className="transition-[padding] group-data-[collapsible=icon]:pt-3">
-        <AppSidebarHeader />
+        <AppSidebarHeader projects={projects} />
       </SidebarHeader>
       <SidebarContent>
-        <AppSidebarNav routeConfig={routeConfig} />
+        <AppSidebarNav routeConfig={routeConfig} projects={projects} />
       </SidebarContent>
       <SidebarFooter>
         <AppSidebarCollapseButton />
@@ -104,12 +117,9 @@ export function AppSidebar({ routeConfig }: AppSidebarProps) {
   );
 }
 
-function AppSidebarHeader() {
+function AppSidebarHeader({ projects }: { projects: Project[] }) {
   const matches = useMatches();
   const { isMobile } = useSidebar();
-  const { data } = useMyProjectsQuery();
-  const projects =
-    data?.projects.filter((project) => !project.isOrphanedProjectFromAuthService) ?? [];
   const activeProjectSlug = getActiveProjectSlug(matches);
   const headerDescription = activeProjectSlug ?? "(select project)";
 
@@ -374,12 +384,15 @@ function authWorkerOrigin(config: PublicConfig) {
   return "https://auth.iterate.com";
 }
 
-function AppSidebarNav({ routeConfig }: { routeConfig: PublicRouteConfig }) {
+function AppSidebarNav({
+  projects,
+  routeConfig,
+}: {
+  projects: Project[];
+  routeConfig: PublicRouteConfig;
+}) {
   const matchRoute = useMatchRoute();
   const matches = useMatches();
-  const { data } = useMyProjectsQuery();
-  const projects =
-    data?.projects.filter((project) => !project.isOrphanedProjectFromAuthService) ?? [];
   const activeProjectSlug = getActiveProjectSlug(matches);
   const activeProject = projects.find((project) => project.slug === activeProjectSlug);
 
@@ -460,13 +473,6 @@ function AppSidebarNav({ routeConfig }: { routeConfig: PublicRouteConfig }) {
         </SidebarGroupContent>
       </SidebarGroup>
     </>
-  );
-}
-
-function useMyProjectsQuery() {
-  const listMyProjectsFn = useServerFn(listMyProjectsServerFn);
-  return useQuery(
-    myProjectsQueryOptions(() => listMyProjectsFn({ data: { limit: 100, offset: 0 } })),
   );
 }
 

--- a/apps/os/src/components/create-project-form.tsx
+++ b/apps/os/src/components/create-project-form.tsx
@@ -1,7 +1,6 @@
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
-import { useServerFn } from "@tanstack/react-start";
 import { useAuthClient } from "@iterate-com/auth/client";
 import { Button } from "@iterate-com/ui/components/button";
 import {
@@ -40,7 +39,6 @@ export function CreateProjectForm() {
   const queryClient = useQueryClient();
   const { refresh, session } = useAuthClient();
   const organizations = session?.authenticated ? session.session.organizations : [];
-  const createProjectFn = useServerFn(createProjectServerFn);
   const createProject = useMutation({
     mutationFn: async (input: { slug: string; organizationSlug: string }) => {
       // Product project creation must use the request/session-aware project
@@ -49,7 +47,7 @@ export function CreateProjectForm() {
       // path with no auth organization ownership. The dashboard create form is
       // different: it should create/adopt through auth for the selected org so
       // the refreshed session contains the new project and `/projects` lists it.
-      return await createProjectFn({
+      return await createProjectServerFn({
         data: {
           slug: input.slug,
           organizationSlug: input.organizationSlug || undefined,

--- a/apps/os/src/components/create-project-form.tsx
+++ b/apps/os/src/components/create-project-form.tsx
@@ -21,7 +21,7 @@ import {
 } from "@iterate-com/ui/components/select";
 import { toast } from "@iterate-com/ui/components/sonner";
 import { z } from "zod";
-import { createProjectServerFn, myProjectsQueryOptions } from "~/lib/project-server-fns.ts";
+import { createProjectServerFn, myProjectsQueryKey } from "~/lib/project-server-fns.ts";
 import { reconnectItx } from "~/itx/itx-react.tsx";
 
 const PROJECT_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
@@ -61,7 +61,7 @@ export function CreateProjectForm() {
       // claim BEFORE navigating to the project-scoped route (#1516); without
       // this the project route loads before the session knows the project.
       await refresh({ force: true });
-      await queryClient.invalidateQueries({ queryKey: myProjectsQueryOptions().queryKey });
+      await queryClient.invalidateQueries({ queryKey: myProjectsQueryKey });
       // Drop the global itx socket so it re-dials with the refreshed claims —
       // otherwise itx.projects.list (connect-time principal) omits this project.
       reconnectItx();

--- a/apps/os/src/components/create-project-form.tsx
+++ b/apps/os/src/components/create-project-form.tsx
@@ -20,7 +20,7 @@ import {
 } from "@iterate-com/ui/components/select";
 import { toast } from "@iterate-com/ui/components/sonner";
 import { z } from "zod";
-import { createProjectServerFn, myProjectsQueryKey } from "~/lib/project-server-fns.ts";
+import { createMyProjectServerFn, myProjectsQueryKey } from "~/lib/project-server-fns.ts";
 import { reconnectItx } from "~/itx/itx-react.tsx";
 
 const PROJECT_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
@@ -41,13 +41,7 @@ export function CreateProjectForm() {
   const organizations = session?.authenticated ? session.session.organizations : [];
   const createProject = useMutation({
     mutationFn: async (input: { slug: string; organizationSlug: string }) => {
-      // Product project creation must use the request/session-aware project
-      // directory, not the global itx handle. Admin users hold an "all" itx
-      // handle, and itx.projects.create intentionally uses that as an operator
-      // path with no auth organization ownership. The dashboard create form is
-      // different: it should create/adopt through auth for the selected org so
-      // the refreshed session contains the new project and `/projects` lists it.
-      return await createProjectServerFn({
+      return await createMyProjectServerFn({
         data: {
           slug: input.slug,
           organizationSlug: input.organizationSlug || undefined,

--- a/apps/os/src/components/create-project-form.tsx
+++ b/apps/os/src/components/create-project-form.tsx
@@ -1,6 +1,7 @@
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
+import { useServerFn } from "@tanstack/react-start";
 import { useAuthClient } from "@iterate-com/auth/client";
 import { Button } from "@iterate-com/ui/components/button";
 import {
@@ -39,6 +40,7 @@ export function CreateProjectForm() {
   const queryClient = useQueryClient();
   const { refresh, session } = useAuthClient();
   const organizations = session?.authenticated ? session.session.organizations : [];
+  const createProjectFn = useServerFn(createProjectServerFn);
   const createProject = useMutation({
     mutationFn: async (input: { slug: string; organizationSlug: string }) => {
       // Product project creation must use the request/session-aware project
@@ -47,7 +49,7 @@ export function CreateProjectForm() {
       // path with no auth organization ownership. The dashboard create form is
       // different: it should create/adopt through auth for the selected org so
       // the refreshed session contains the new project and `/projects` lists it.
-      return await createProjectServerFn({
+      return await createProjectFn({
         data: {
           slug: input.slug,
           organizationSlug: input.organizationSlug || undefined,

--- a/apps/os/src/domains/projects/project-directory.ts
+++ b/apps/os/src/domains/projects/project-directory.ts
@@ -9,10 +9,12 @@ import { ORPCError } from "@orpc/server";
 import { createAuthWorkerServiceClient } from "~/auth/auth-worker-service.ts";
 import type { RequestContext } from "~/request-context.ts";
 import {
+  countAllProjects,
   deleteProject,
   getProjectById,
   getProjectBySlug,
   insertProject,
+  listAllProjects,
 } from "~/db/queries/.generated/index.ts";
 import { getProjectDurableObjectStub } from "~/domains/projects/durable-objects/project-durable-object-ref.ts";
 import { isProjectId } from "~/domains/projects/project-id.ts";
@@ -71,6 +73,24 @@ export class ProjectsCapability extends RpcTarget {
     );
 
     return { projects, total: authProjects.length };
+  }
+
+  async listAllForAdmin(
+    input: { limit?: number; offset?: number } = {},
+  ): Promise<ProjectListResult> {
+    const context = this.props.context;
+    if (!context.principal || !principalIsAdmin(context.principal)) {
+      throw new ORPCError("FORBIDDEN", { message: "Admin access required." });
+    }
+
+    const limit = input.limit ?? 100;
+    const offset = input.offset ?? 0;
+    const [totalRow, rows] = await Promise.all([
+      countAllProjects(context.db),
+      listAllProjects(context.db, { limit, offset }),
+    ]);
+
+    return { projects: rows.map((row) => toProject(row)), total: totalRow?.total ?? 0 };
   }
 
   async create(input: {

--- a/apps/os/src/lib/project-server-fns.ts
+++ b/apps/os/src/lib/project-server-fns.ts
@@ -1,5 +1,8 @@
 import { createServerFn } from "@tanstack/react-start";
 import { ProjectsCapability } from "~/domains/projects/project-directory.ts";
+import { principalIsAdmin } from "~/auth/principal.ts";
+import { countAllProjects, listAllProjects } from "~/db/queries/.generated/index.ts";
+import { authenticateCapnwebAdmin } from "~/itx/admin-auth-cookie.ts";
 import { requireRequestContext } from "~/request-context.ts";
 
 /**
@@ -44,6 +47,44 @@ export const listMyProjectsServerFn: (input: {
   .inputValidator((input: { limit?: number; offset?: number }) => input)
   .handler(async ({ data }) => {
     return await new ProjectsCapability({ context: requireRequestContext() }).list(data);
+  });
+
+/** All OS projects, guarded for the admin page. */
+export const listAdminProjectsServerFn: (input: {
+  data: { limit?: number; offset?: number };
+}) => Promise<ProjectListResult> = createServerFn({ method: "GET" })
+  .inputValidator((input: { limit?: number; offset?: number }) => input)
+  .handler(async ({ data }) => {
+    const context = requireRequestContext();
+    const adminCookiePrincipal = context.rawRequest
+      ? authenticateCapnwebAdmin({ config: context.config, request: context.rawRequest })
+      : null;
+    const isAdmin =
+      (context.principal ? principalIsAdmin(context.principal) : false) ||
+      adminCookiePrincipal !== null;
+    if (!isAdmin) {
+      throw new Error("Admin access required.");
+    }
+
+    const limit = data.limit ?? 100;
+    const offset = data.offset ?? 0;
+    const [totalRow, rows] = await Promise.all([
+      countAllProjects(context.db),
+      listAllProjects(context.db, { limit, offset }),
+    ]);
+
+    return {
+      projects: rows.map((row) => ({
+        id: row.id,
+        slug: row.slug,
+        organizationId: null,
+        customHostname: row.custom_hostname ?? null,
+        createdAt: row.created_at ?? null,
+        updatedAt: row.updated_at ?? null,
+        isOrphanedProjectFromAuthService: false,
+      })),
+      total: totalRow?.total ?? 0,
+    };
   });
 
 /**

--- a/apps/os/src/lib/project-server-fns.ts
+++ b/apps/os/src/lib/project-server-fns.ts
@@ -34,12 +34,12 @@ export const myProjectsQueryKey = ["my-projects"] as const;
 export const myProjectsListInput = { limit: 100, offset: 0 } as const;
 export const myProjectsStaleTime = 30_000;
 
-export const createProjectServerFn: (input: {
+export const createMyProjectServerFn: (input: {
   data: { id?: string; slug: string; organizationSlug?: string };
 }) => Promise<ProjectWithIngressUrl> = createServerFn({ method: "POST" })
   .validator((input: { id?: string; slug: string; organizationSlug?: string }) => input)
   .handler(async ({ data }) => {
-    return await new ProjectsCapability({ context: requireRequestContext() }).create(data);
+    return await new ProjectsCapability({ context: requireUserRequestContext() }).create(data);
   });
 
 export const deleteProjectServerFn: (input: {
@@ -89,6 +89,14 @@ function adminProjectContext(): RequestContext {
     if (adminCookiePrincipal) {
       return { ...context, principal: adminCookiePrincipal };
     }
+  }
+  return context;
+}
+
+function requireUserRequestContext(): RequestContext {
+  const context = requireRequestContext();
+  if (context.principal?.type !== "user") {
+    throw new Error("Sign in to create projects.");
   }
   return context;
 }

--- a/apps/os/src/lib/project-server-fns.ts
+++ b/apps/os/src/lib/project-server-fns.ts
@@ -30,10 +30,14 @@ export type ProjectWithIngressUrl = Project & { ingressUrl: string };
 
 export type ProjectListResult = { projects: Project[]; total: number };
 
+export const myProjectsQueryKey = ["my-projects"] as const;
+export const myProjectsListInput = { limit: 100, offset: 0 } as const;
+export const myProjectsStaleTime = 30_000;
+
 export const createProjectServerFn: (input: {
   data: { id?: string; slug: string; organizationSlug?: string };
 }) => Promise<ProjectWithIngressUrl> = createServerFn({ method: "POST" })
-  .inputValidator((input: { id?: string; slug: string; organizationSlug?: string }) => input)
+  .validator((input: { id?: string; slug: string; organizationSlug?: string }) => input)
   .handler(async ({ data }) => {
     return await new ProjectsCapability({ context: requireRequestContext() }).create(data);
   });
@@ -41,7 +45,7 @@ export const createProjectServerFn: (input: {
 export const deleteProjectServerFn: (input: {
   data: { id: string };
 }) => Promise<{ ok: true; id: string; deleted: boolean }> = createServerFn({ method: "POST" })
-  .inputValidator((input: { id: string }) => input)
+  .validator((input: { id: string }) => input)
   .handler(async ({ data }) => {
     return await new ProjectsCapability({ context: requireRequestContext() }).remove(data);
   });
@@ -50,7 +54,7 @@ export const deleteProjectServerFn: (input: {
 export const listMyProjectsServerFn: (input: {
   data: { limit?: number; offset?: number };
 }) => Promise<ProjectListResult> = createServerFn({ method: "GET" })
-  .inputValidator((input: { limit?: number; offset?: number }) => input)
+  .validator((input: { limit?: number; offset?: number }) => input)
   .handler(async ({ data }) => {
     return await new ProjectsCapability({ context: requireRequestContext() }).list(data);
   });
@@ -59,34 +63,16 @@ export const listMyProjectsServerFn: (input: {
 export const listAdminProjectsServerFn: (input: {
   data: { limit?: number; offset?: number };
 }) => Promise<ProjectListResult> = createServerFn({ method: "GET" })
-  .inputValidator((input: { limit?: number; offset?: number }) => input)
+  .validator((input: { limit?: number; offset?: number }) => input)
   .handler(async ({ data }) => {
     return await new ProjectsCapability({ context: adminProjectContext() }).listAllForAdmin(data);
   });
-
-export const myProjectsQueryKey = ["my-projects"] as const;
-
-/**
- * Shared query options for the session's accessible projects: the `_app`
- * loader prefetches it (SSR), the sidebar reads it via `useQuery`, both off the
- * same key so hydration matches with no flash.
- */
-export function myProjectsQueryOptions(
-  queryFn: () => Promise<ProjectListResult> = () =>
-    listMyProjectsServerFn({ data: { limit: 100, offset: 0 } }),
-) {
-  return {
-    queryKey: myProjectsQueryKey,
-    queryFn,
-    staleTime: 30_000,
-  };
-}
 
 /** A single project the session principal can read, by slug (mirrors `projects.findBySlug`). */
 export const getProjectBySlugServerFn: (input: {
   data: { slug: string };
 }) => Promise<ProjectWithIngressUrl> = createServerFn({ method: "GET" })
-  .inputValidator((input: { slug: string }) => input)
+  .validator((input: { slug: string }) => input)
   .handler(async ({ data }) => {
     return await new ProjectsCapability({ context: requireRequestContext() }).findBySlug({
       slug: data.slug,

--- a/apps/os/src/lib/project-server-fns.ts
+++ b/apps/os/src/lib/project-server-fns.ts
@@ -1,9 +1,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import { ProjectsCapability } from "~/domains/projects/project-directory.ts";
-import { principalIsAdmin } from "~/auth/principal.ts";
-import { countAllProjects, listAllProjects } from "~/db/queries/.generated/index.ts";
 import { authenticateCapnwebAdmin } from "~/itx/admin-auth-cookie.ts";
-import { requireRequestContext } from "~/request-context.ts";
+import { requireRequestContext, type RequestContext } from "~/request-context.ts";
 
 /**
  * SSR-safe project reads as TanStack server functions. itx is client-only (it
@@ -40,6 +38,14 @@ export const createProjectServerFn: (input: {
     return await new ProjectsCapability({ context: requireRequestContext() }).create(data);
   });
 
+export const deleteProjectServerFn: (input: {
+  data: { id: string };
+}) => Promise<{ ok: true; id: string; deleted: boolean }> = createServerFn({ method: "POST" })
+  .inputValidator((input: { id: string }) => input)
+  .handler(async ({ data }) => {
+    return await new ProjectsCapability({ context: requireRequestContext() }).remove(data);
+  });
+
 /** The session principal's accessible projects (mirrors the former `projects.list`). */
 export const listMyProjectsServerFn: (input: {
   data: { limit?: number; offset?: number };
@@ -55,47 +61,23 @@ export const listAdminProjectsServerFn: (input: {
 }) => Promise<ProjectListResult> = createServerFn({ method: "GET" })
   .inputValidator((input: { limit?: number; offset?: number }) => input)
   .handler(async ({ data }) => {
-    const context = requireRequestContext();
-    const adminCookiePrincipal = context.rawRequest
-      ? authenticateCapnwebAdmin({ config: context.config, request: context.rawRequest })
-      : null;
-    const isAdmin =
-      (context.principal ? principalIsAdmin(context.principal) : false) ||
-      adminCookiePrincipal !== null;
-    if (!isAdmin) {
-      throw new Error("Admin access required.");
-    }
-
-    const limit = data.limit ?? 100;
-    const offset = data.offset ?? 0;
-    const [totalRow, rows] = await Promise.all([
-      countAllProjects(context.db),
-      listAllProjects(context.db, { limit, offset }),
-    ]);
-
-    return {
-      projects: rows.map((row) => ({
-        id: row.id,
-        slug: row.slug,
-        organizationId: null,
-        customHostname: row.custom_hostname ?? null,
-        createdAt: row.created_at ?? null,
-        updatedAt: row.updated_at ?? null,
-        isOrphanedProjectFromAuthService: false,
-      })),
-      total: totalRow?.total ?? 0,
-    };
+    return await new ProjectsCapability({ context: adminProjectContext() }).listAllForAdmin(data);
   });
+
+export const myProjectsQueryKey = ["my-projects"] as const;
 
 /**
  * Shared query options for the session's accessible projects: the `_app`
  * loader prefetches it (SSR), the sidebar reads it via `useQuery`, both off the
  * same key so hydration matches with no flash.
  */
-export function myProjectsQueryOptions() {
+export function myProjectsQueryOptions(
+  queryFn: () => Promise<ProjectListResult> = () =>
+    listMyProjectsServerFn({ data: { limit: 100, offset: 0 } }),
+) {
   return {
-    queryKey: ["my-projects"] as const,
-    queryFn: () => listMyProjectsServerFn({ data: { limit: 100, offset: 0 } }),
+    queryKey: myProjectsQueryKey,
+    queryFn,
     staleTime: 30_000,
   };
 }
@@ -110,3 +92,17 @@ export const getProjectBySlugServerFn: (input: {
       slug: data.slug,
     });
   });
+
+function adminProjectContext(): RequestContext {
+  const context = requireRequestContext();
+  if (context.rawRequest) {
+    const adminCookiePrincipal = authenticateCapnwebAdmin({
+      config: context.config,
+      request: context.rawRequest,
+    });
+    if (adminCookiePrincipal) {
+      return { ...context, principal: adminCookiePrincipal };
+    }
+  }
+  return context;
+}

--- a/apps/os/src/routes/_app.tsx
+++ b/apps/os/src/routes/_app.tsx
@@ -4,7 +4,12 @@ import { requireOrganizationMemberForSession } from "../lib/auth.ts";
 import { AppSidebar } from "~/components/app-sidebar.tsx";
 import { GlobalCommandPalette } from "~/components/global-command-palette.tsx";
 import { PathBreadcrumbs } from "~/components/path-breadcrumbs.tsx";
-import { myProjectsQueryOptions } from "~/lib/project-server-fns.ts";
+import {
+  listMyProjectsServerFn,
+  myProjectsListInput,
+  myProjectsQueryKey,
+  myProjectsStaleTime,
+} from "~/lib/project-server-fns.ts";
 import { getPublicRouteConfig } from "~/lib/public-route-config.ts";
 import type { AppRouteStaticData } from "~/lib/route-breadcrumbs.ts";
 import { getSidebarDefaultOpen } from "~/lib/sidebar-state.ts";
@@ -13,7 +18,11 @@ export const Route = createFileRoute("/_app")({
   beforeLoad: ({ context, location }) =>
     requireOrganizationMemberForSession(context.authSession, location, context.iterateAuthIssuer),
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(myProjectsQueryOptions());
+    await context.queryClient.ensureQueryData({
+      queryKey: myProjectsQueryKey,
+      queryFn: () => listMyProjectsServerFn({ data: myProjectsListInput }),
+      staleTime: myProjectsStaleTime,
+    });
 
     return {
       routeConfig: await getPublicRouteConfig(),

--- a/apps/os/src/routes/_app/projects/index.tsx
+++ b/apps/os/src/routes/_app/projects/index.tsx
@@ -14,7 +14,7 @@ import type { ReactNode } from "react";
 import { normalizeProjectHostnameBase } from "~/lib/project-host-routing.ts";
 import { getPublicRouteConfig } from "~/lib/public-route-config.ts";
 import {
-  createProjectServerFn,
+  createMyProjectServerFn,
   deleteProjectServerFn,
   listMyProjectsServerFn,
   myProjectsListInput,
@@ -88,7 +88,7 @@ function ProjectsIndexPage() {
       const organizationSlug = project.organizationId
         ? organizations.find((organization) => organization.id === project.organizationId)?.slug
         : undefined;
-      return await createProjectServerFn({
+      return await createMyProjectServerFn({
         data: {
           id: project.id,
           slug: project.slug,

--- a/apps/os/src/routes/_app/projects/index.tsx
+++ b/apps/os/src/routes/_app/projects/index.tsx
@@ -5,6 +5,7 @@ import {
   type UseMutationResult,
 } from "@tanstack/react-query";
 import { Link, createFileRoute } from "@tanstack/react-router";
+import { useServerFn } from "@tanstack/react-start";
 import { FolderPlus } from "lucide-react";
 import { useAuthClient } from "@iterate-com/auth/client";
 import { Button } from "@iterate-com/ui/components/button";
@@ -14,7 +15,12 @@ import type { ReactNode } from "react";
 import { ItxBoundary } from "~/components/itx-boundary.tsx";
 import { normalizeProjectHostnameBase } from "~/lib/project-host-routing.ts";
 import { getPublicRouteConfig } from "~/lib/public-route-config.ts";
-import { myProjectsQueryOptions, type Project } from "~/lib/project-server-fns.ts";
+import {
+  createProjectServerFn,
+  listMyProjectsServerFn,
+  myProjectsQueryOptions,
+  type Project,
+} from "~/lib/project-server-fns.ts";
 import { reconnectItx, useItx } from "~/itx/itx-react.tsx";
 
 type OrganizationSummary = {
@@ -57,8 +63,13 @@ function ProjectsIndexContent() {
   const isAdmin = session?.authenticated ? session.user.isAdmin === true : false;
   const itx = useItx();
   const queryClient = useQueryClient();
+  const listMyProjectsFn = useServerFn(listMyProjectsServerFn);
+  const createProjectFn = useServerFn(createProjectServerFn);
   const listQueryOptions = myProjectsQueryOptions();
-  const list = useQuery(listQueryOptions);
+  const list = useQuery({
+    ...listQueryOptions,
+    queryFn: () => listMyProjectsFn({ data: { limit: 100, offset: 0 } }),
+  });
   const projects = list.data?.projects ?? [];
 
   // The scoped oRPC list intentionally merges two sources:
@@ -87,10 +98,12 @@ function ProjectsIndexContent() {
       const organizationSlug = project.organizationId
         ? organizations.find((organization) => organization.id === project.organizationId)?.slug
         : undefined;
-      return await itx.projects.create({
-        id: project.id,
-        slug: project.slug,
-        organizationSlug,
+      return await createProjectFn({
+        data: {
+          id: project.id,
+          slug: project.slug,
+          organizationSlug,
+        },
       });
     },
     onSuccess: async () => {

--- a/apps/os/src/routes/_app/projects/index.tsx
+++ b/apps/os/src/routes/_app/projects/index.tsx
@@ -5,7 +5,6 @@ import {
   type UseMutationResult,
 } from "@tanstack/react-query";
 import { Link, createFileRoute } from "@tanstack/react-router";
-import { useServerFn } from "@tanstack/react-start";
 import { FolderPlus } from "lucide-react";
 import { useAuthClient } from "@iterate-com/auth/client";
 import { Button } from "@iterate-com/ui/components/button";
@@ -18,7 +17,9 @@ import {
   createProjectServerFn,
   deleteProjectServerFn,
   listMyProjectsServerFn,
-  myProjectsQueryOptions,
+  myProjectsListInput,
+  myProjectsQueryKey,
+  myProjectsStaleTime,
   type Project,
 } from "~/lib/project-server-fns.ts";
 import { reconnectItx } from "~/itx/itx-react.tsx";
@@ -54,13 +55,11 @@ function ProjectsIndexPage() {
   const organizations = session?.authenticated ? session.session.organizations : [];
   const isAdmin = session?.authenticated ? session.user.isAdmin === true : false;
   const queryClient = useQueryClient();
-  const listMyProjectsFn = useServerFn(listMyProjectsServerFn);
-  const createProjectFn = useServerFn(createProjectServerFn);
-  const deleteProjectFn = useServerFn(deleteProjectServerFn);
-  const listQueryOptions = myProjectsQueryOptions(() =>
-    listMyProjectsFn({ data: { limit: 100, offset: 0 } }),
-  );
-  const list = useQuery(listQueryOptions);
+  const list = useQuery({
+    queryKey: myProjectsQueryKey,
+    queryFn: () => listMyProjectsServerFn({ data: myProjectsListInput }),
+    staleTime: myProjectsStaleTime,
+  });
   const projects = list.data?.projects ?? [];
 
   // The scoped oRPC list intentionally merges two sources:
@@ -76,10 +75,10 @@ function ProjectsIndexPage() {
 
   const deleteProject = useMutation({
     mutationFn: async (input: { id: string }) => {
-      return await deleteProjectFn({ data: input });
+      return await deleteProjectServerFn({ data: input });
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: listQueryOptions.queryKey });
+      await queryClient.invalidateQueries({ queryKey: myProjectsQueryKey });
     },
     onError: (error) => toast.error(error instanceof Error ? error.message : String(error)),
   });
@@ -89,7 +88,7 @@ function ProjectsIndexPage() {
       const organizationSlug = project.organizationId
         ? organizations.find((organization) => organization.id === project.organizationId)?.slug
         : undefined;
-      return await createProjectFn({
+      return await createProjectServerFn({
         data: {
           id: project.id,
           slug: project.slug,
@@ -98,7 +97,7 @@ function ProjectsIndexPage() {
       });
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: listQueryOptions.queryKey });
+      await queryClient.invalidateQueries({ queryKey: myProjectsQueryKey });
       reconnectItx();
       toast.success("Project recovered");
     },

--- a/apps/os/src/routes/_app/projects/index.tsx
+++ b/apps/os/src/routes/_app/projects/index.tsx
@@ -12,16 +12,16 @@ import { Button } from "@iterate-com/ui/components/button";
 import { Identifier } from "@iterate-com/ui/components/identifier";
 import { toast } from "@iterate-com/ui/components/sonner";
 import type { ReactNode } from "react";
-import { ItxBoundary } from "~/components/itx-boundary.tsx";
 import { normalizeProjectHostnameBase } from "~/lib/project-host-routing.ts";
 import { getPublicRouteConfig } from "~/lib/public-route-config.ts";
 import {
   createProjectServerFn,
+  deleteProjectServerFn,
   listMyProjectsServerFn,
   myProjectsQueryOptions,
   type Project,
 } from "~/lib/project-server-fns.ts";
-import { reconnectItx, useItx } from "~/itx/itx-react.tsx";
+import { reconnectItx } from "~/itx/itx-react.tsx";
 
 type OrganizationSummary = {
   id: string;
@@ -49,27 +49,18 @@ function buildProjectHostname(input: {
 }
 
 function ProjectsIndexPage() {
-  return (
-    <ItxBoundary>
-      <ProjectsIndexContent />
-    </ItxBoundary>
-  );
-}
-
-function ProjectsIndexContent() {
   const { routeConfig } = Route.useLoaderData();
   const { session } = useAuthClient();
   const organizations = session?.authenticated ? session.session.organizations : [];
   const isAdmin = session?.authenticated ? session.user.isAdmin === true : false;
-  const itx = useItx();
   const queryClient = useQueryClient();
   const listMyProjectsFn = useServerFn(listMyProjectsServerFn);
   const createProjectFn = useServerFn(createProjectServerFn);
-  const listQueryOptions = myProjectsQueryOptions();
-  const list = useQuery({
-    ...listQueryOptions,
-    queryFn: () => listMyProjectsFn({ data: { limit: 100, offset: 0 } }),
-  });
+  const deleteProjectFn = useServerFn(deleteProjectServerFn);
+  const listQueryOptions = myProjectsQueryOptions(() =>
+    listMyProjectsFn({ data: { limit: 100, offset: 0 } }),
+  );
+  const list = useQuery(listQueryOptions);
   const projects = list.data?.projects ?? [];
 
   // The scoped oRPC list intentionally merges two sources:
@@ -85,7 +76,7 @@ function ProjectsIndexContent() {
 
   const deleteProject = useMutation({
     mutationFn: async (input: { id: string }) => {
-      return await itx.projects.remove(input);
+      return await deleteProjectFn({ data: input });
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: listQueryOptions.queryKey });

--- a/apps/os/src/routes/admin/projects.tsx
+++ b/apps/os/src/routes/admin/projects.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useServerFn } from "@tanstack/react-start";
 import { ArrowLeftIcon, ArrowRightIcon, ExternalLinkIcon, WaypointsIcon } from "lucide-react";
 import { Badge } from "@iterate-com/ui/components/badge";
 import { Button } from "@iterate-com/ui/components/button";
@@ -24,12 +23,11 @@ export const Route = createFileRoute("/admin/projects")({
 });
 
 function AdminProjectsPage() {
-  const listAdminProjectsFn = useServerFn(listAdminProjectsServerFn);
   const [pageIndex, setPageIndex] = useState(0);
   const offset = pageIndex * PAGE_SIZE;
   const projectsQuery = useQuery({
     queryKey: ["admin", "projects", { limit: PAGE_SIZE, offset }],
-    queryFn: async () => await listAdminProjectsFn({ data: { limit: PAGE_SIZE, offset } }),
+    queryFn: async () => await listAdminProjectsServerFn({ data: { limit: PAGE_SIZE, offset } }),
   });
   const projects = projectsQuery.data?.projects ?? [];
   const total = projectsQuery.data?.total ?? 0;

--- a/apps/os/src/routes/admin/projects.tsx
+++ b/apps/os/src/routes/admin/projects.tsx
@@ -23,14 +23,6 @@ export const Route = createFileRoute("/admin/projects")({
   component: AdminProjectsPage,
 });
 
-type AdminProject = {
-  id: string;
-  slug: string;
-  customHostname: string | null;
-  createdAt: string | null;
-  updatedAt: string | null;
-};
-
 function AdminProjectsPage() {
   const listAdminProjectsFn = useServerFn(listAdminProjectsServerFn);
   const [pageIndex, setPageIndex] = useState(0);
@@ -39,7 +31,7 @@ function AdminProjectsPage() {
     queryKey: ["admin", "projects", { limit: PAGE_SIZE, offset }],
     queryFn: async () => await listAdminProjectsFn({ data: { limit: PAGE_SIZE, offset } }),
   });
-  const projects = (projectsQuery.data?.projects ?? []) as AdminProject[];
+  const projects = projectsQuery.data?.projects ?? [];
   const total = projectsQuery.data?.total ?? 0;
   const hasPrevious = pageIndex > 0;
   const hasNext = offset + projects.length < total;

--- a/apps/os/src/routes/admin/projects.tsx
+++ b/apps/os/src/routes/admin/projects.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
+import { useServerFn } from "@tanstack/react-start";
 import { ArrowLeftIcon, ArrowRightIcon, ExternalLinkIcon, WaypointsIcon } from "lucide-react";
 import { Badge } from "@iterate-com/ui/components/badge";
 import { Button } from "@iterate-com/ui/components/button";
@@ -14,7 +15,7 @@ import {
   TableHeader,
   TableRow,
 } from "@iterate-com/ui/components/table";
-import { useItx } from "~/itx/itx-react.tsx";
+import { listAdminProjectsServerFn } from "~/lib/project-server-fns.ts";
 
 const PAGE_SIZE = 100;
 
@@ -31,12 +32,12 @@ type AdminProject = {
 };
 
 function AdminProjectsPage() {
-  const itx = useItx();
+  const listAdminProjectsFn = useServerFn(listAdminProjectsServerFn);
   const [pageIndex, setPageIndex] = useState(0);
   const offset = pageIndex * PAGE_SIZE;
   const projectsQuery = useQuery({
     queryKey: ["admin", "projects", { limit: PAGE_SIZE, offset }],
-    queryFn: async () => await itx.projects.list({ limit: PAGE_SIZE, offset }),
+    queryFn: async () => await listAdminProjectsFn({ data: { limit: PAGE_SIZE, offset } }),
   });
   const projects = (projectsQuery.data?.projects ?? []) as AdminProject[];
   const total = projectsQuery.data?.total ?? 0;


### PR DESCRIPTION
## Summary
- Route product project listing, project recovery, and project creation through TanStack Start server functions from React components via `useServerFn`.
- Add an admin-only Start server function for `/admin/projects` backed by the generated project SQL helpers.
- Keep existing query keys and hydration behavior while removing direct browser-side `itx.projects.list/create` calls from these project list/create surfaces.

## Validation
- `pnpm --dir apps/os typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches project create/delete authorization and admin listing (cookie-based admin principal override); behavior should match prior product flows but auth boundaries shifted off itx.
> 
> **Overview**
> Dashboard project flows no longer call **`itx.projects.list` / `create` / `remove`** from the browser. Listing, create, recovery, and delete go through **TanStack Start server functions** that reuse **`ProjectsCapability`** on the request principal (same session-aware directory as before).
> 
> **My projects** query setup is flattened to exported **`myProjectsQueryKey`**, **`myProjectsListInput`**, and **`myProjectsStaleTime`**; the **`_app` loader** and **`AppSidebar`** share one prefetch/fetch path, with the sidebar hoisting the query and passing **`projects`** into header/nav instead of fetching twice.
> 
> **Create** is renamed to **`createMyProjectServerFn`** and requires a **signed-in user** principal so product create cannot follow the admin “all projects” itx path. **Delete** adds **`deleteProjectServerFn`**. The projects index drops **`ItxBoundary`** / **`useItx`** for these operations.
> 
> **Admin `/admin/projects`** uses **`listAdminProjectsServerFn`**, which can elevate via **`authenticateCapnwebAdmin`** and calls new **`listAllForAdmin`** on **`ProjectsCapability`** (paginated **`listAllProjects`** / **`countAllProjects`** in D1, admin-gated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8490fb8a44a2f70bffcad3daf3977afa237fe800. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "deployed",
      "updatedAt": "2026-06-17T12:08:25.440Z",
      "headSha": "8490fb8a44a2f70bffcad3daf3977afa237fe800",
      "message": null,
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27687672076",
      "shortSha": "8490fb8",
      "deployDurationMs": 23579,
      "testDurationMs": 470
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-17T12:21:55.767Z",
      "headSha": "8490fb8a44a2f70bffcad3daf3977afa237fe800",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27687672076",
      "shortSha": "8490fb8",
      "cleanupDurationMs": 47103,
      "deployDurationMs": 53474,
      "testDurationMs": 97227
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_5",
    "leasedUntil": 1781701622004,
    "leaseId": "a1cb1b6f-c25c-44ea-9563-fa62d4cefa20",
    "slug": "preview-5",
    "type": "environment-config-lease"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
Lease: `preview-5`
Doppler config: `preview_5`
Type: `environment-config-lease`
Leased until: 2026-06-17T13:07:02.004Z

### Auth
Status: deployed
Commit: `8490fb8`
Preview: https://auth.iterate-preview-5.com
Deploy duration: 23.6s
Test duration: 470ms
[Workflow run](https://github.com/iterate/iterate/actions/runs/27687672076)
Updated: 2026-06-17T12:08:25.440Z

### OS
Status: released
Commit: `8490fb8`
Preview: https://os.iterate-preview-5.com
Deploy duration: 53.5s
Test duration: 97.2s
Cleanup duration: 47.1s
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27687672076)
Updated: 2026-06-17T12:21:55.767Z
<!-- /CLOUDFLARE_PREVIEW -->