### PR TITLE
Add root product Playwright specs

### DIFF
--- a/apps/auth/src/routes/login.tsx
+++ b/apps/auth/src/routes/login.tsx
@@ -163,7 +163,7 @@ function LoginActions({
   }, []);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4" data-hydrated={isHydrated}>
       {emailOtpEnabled ? (
         <EmailOtpSignIn
           redirectTo={redirectTo}
@@ -255,14 +255,22 @@ function EmailOtpSignIn({
 
   return (
     <div className="space-y-3">
-      {!showExpandedForm ? (
+      {!showExpandedForm && !isHydrated ? (
+        <Button
+          className="w-full border-border bg-background text-foreground shadow-sm transition-colors"
+          variant="outline"
+          size="lg"
+          data-spinner="true"
+          disabled
+        >
+          Loading...
+        </Button>
+      ) : !showExpandedForm ? (
         <Button
           className="w-full border-border bg-background text-foreground shadow-sm transition-colors hover:bg-muted"
           variant="outline"
           size="lg"
           data-testid="email-login-button"
-          aria-disabled={!isHydrated}
-          disabled={!isHydrated}
           onClick={() => onExpandedChange(true)}
         >
           Continue with email

--- a/apps/os/package.json
+++ b/apps/os/package.json
@@ -53,6 +53,7 @@
     "@iterate-com/auth-contract": "workspace:*",
     "@iterate-com/shared": "workspace:*",
     "@iterate-com/ui": "workspace:*",
+    "@journeyapps/wa-sqlite": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentui/core": "0.1.102",
     "@opentui/react": "0.1.102",
@@ -81,8 +82,7 @@
     "sqlfu": "0.0.3-14",
     "tailwindcss": "^4.1.18",
     "yaml": "^2.8.3",
-    "zod": "^4.3.6",
-    "@journeyapps/wa-sqlite": "^1.7.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "catalog:cloudflare",
@@ -104,7 +104,6 @@
     "iterate": "workspace:*",
     "jsdom": "27.4.0",
     "miniflare": "catalog:cloudflare",
-    "playwright": "1.57.0",
     "tinyexec": "^1.0.2",
     "tsx": "^4.20.3",
     "typescript": "^5.9.3",

--- a/apps/os/src/components/itx-boundary.tsx
+++ b/apps/os/src/components/itx-boundary.tsx
@@ -2,7 +2,11 @@ import { Suspense, type ReactNode } from "react";
 
 /** The one muted-text placeholder both the socket-connect and first-read waits render. */
 function ItxPending({ children }: { children: ReactNode }) {
-  return <div className="p-4 text-sm text-muted-foreground">{children}</div>;
+  return (
+    <div className="p-4 text-sm text-muted-foreground" data-spinner="true">
+      {children}
+    </div>
+  );
 }
 
 /** Suspense wrapper shared by every route that reads through itx. */

--- a/apps/os/src/components/itx-repl.tsx
+++ b/apps/os/src/components/itx-repl.tsx
@@ -71,6 +71,7 @@ export function ItxRepl({
     code,
     path: REPL_SOURCE_PATH,
   });
+  const runButtonLabel = typeScriptExtensions.loading ? "Loading..." : "Run";
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -141,16 +142,21 @@ export function ItxRepl({
               </div>
             ))}
             <div className="flex flex-col gap-2 border-l-2 border-primary/50 py-2 pr-3 pl-3">
-              <ReplPromptRow status={status}>
-                <Button disabled={!canRun} onClick={onRun} size="sm">
+              <ReplPromptRow status={typeScriptExtensions.loading ? null : status}>
+                <Button
+                  data-spinner={typeScriptExtensions.loading ? "true" : undefined}
+                  disabled={typeScriptExtensions.loading || !canRun}
+                  onClick={onRun}
+                  size="sm"
+                >
                   <Play data-icon="inline-start" />
-                  Run
+                  {runButtonLabel}
                 </Button>
               </ReplPromptRow>
               <SourceCodeBlock
                 code={code}
                 className={`${replCodeBlockClassName} min-h-24`}
-                codeMirrorExtensions={typeScriptExtensions}
+                codeMirrorExtensions={typeScriptExtensions.extensions}
                 editable
                 language="typescript"
                 onChange={onChangeCode}
@@ -223,6 +229,7 @@ function useReplTypeScriptExtensions(input: { code: string; path: string }) {
   const codeRef = useRef(input.code);
   codeRef.current = input.code;
   const [extensions, setExtensions] = useState<readonly SourceCodeBlockExtension[]>([]);
+  const [loading, setLoading] = useState(Boolean(loadTypeScriptExtensionModules));
 
   useEffect(() => {
     let innerWorker: Worker | null = null;
@@ -230,7 +237,10 @@ function useReplTypeScriptExtensions(input: { code: string; path: string }) {
     let disposed = false;
 
     async function initializeTypeScriptExtensions() {
-      if (!loadTypeScriptExtensionModules) return;
+      if (!loadTypeScriptExtensionModules) {
+        setLoading(false);
+        return;
+      }
       const [autocompleteModule, comlinkModule, typeScriptExtensionsModule] =
         await loadTypeScriptExtensionModules();
 
@@ -268,11 +278,13 @@ function useReplTypeScriptExtensions(input: { code: string; path: string }) {
         }),
         tsHoverWorker(),
       ]);
+      setLoading(false);
     }
 
     void initializeTypeScriptExtensions().catch((error: unknown) => {
       if (disposed) return;
       console.error("[itx-repl] Failed to initialize TypeScript worker", error);
+      setLoading(false);
     });
 
     return () => {
@@ -282,7 +294,7 @@ function useReplTypeScriptExtensions(input: { code: string; path: string }) {
     };
   }, [input.path]);
 
-  return useMemo(() => extensions, [extensions]);
+  return useMemo(() => ({ extensions, loading }), [extensions, loading]);
 }
 
 function ReplPromptRow(input: { children?: ReactNode; status: string | null }) {

--- a/apps/os/src/routes/__root.tsx
+++ b/apps/os/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import {
   Outlet,
   Scripts,
   createRootRouteWithContext,
+  useHydrated,
 } from "@tanstack/react-router";
 import { extractPublicConfigSchema } from "@iterate-com/shared/config";
 import { AuthClientProvider } from "@iterate-com/auth/client";
@@ -66,12 +67,14 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 });
 
 function RootDocument({ children }: { children: ReactNode }) {
+  const isHydrated = useHydrated();
+
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
         <HeadContent />
       </head>
-      <body>
+      <body data-hydrated={isHydrated}>
         {children}
         <Scripts />
       </body>

--- a/apps/os/src/routes/_app/itx-repl.tsx
+++ b/apps/os/src/routes/_app/itx-repl.tsx
@@ -33,7 +33,11 @@ export const Route = createFileRoute("/_app/itx-repl")({
 
 /** The shared "connecting to itx" fallback both repls suspend behind. */
 export function ItxReplConnecting() {
-  return <div className="p-4 text-sm text-muted-foreground">Connecting to itx...</div>;
+  return (
+    <div className="p-4 text-sm text-muted-foreground" data-spinner="true">
+      Connecting to itx...
+    </div>
+  );
 }
 
 /**

--- a/apps/os/src/routes/_app/projects/index.tsx
+++ b/apps/os/src/routes/_app/projects/index.tsx
@@ -35,8 +35,17 @@ export const Route = createFileRoute("/_app/projects/")({
   loader: async () => ({
     routeConfig: await getPublicRouteConfig(),
   }),
+  pendingComponent: ProjectsIndexPending,
   component: ProjectsIndexPage,
 });
+
+function ProjectsIndexPending() {
+  return (
+    <section className="p-4 text-sm text-muted-foreground" data-spinner="true">
+      Loading projects...
+    </section>
+  );
+}
 
 function buildProjectHostname(input: {
   slug: string;
@@ -116,6 +125,7 @@ function ProjectsIndexPage() {
         <div className="flex flex-wrap items-center gap-2">
           {isAdmin ? (
             <Button
+              nativeButton={false}
               type="button"
               variant="outline"
               size="sm"
@@ -125,7 +135,12 @@ function ProjectsIndexPage() {
             </Button>
           ) : null}
           {hasProjects ? (
-            <Button type="button" size="sm" render={<Link to="/new-project" />}>
+            <Button
+              nativeButton={false}
+              type="button"
+              size="sm"
+              render={<Link to="/new-project" />}
+            >
               New project
             </Button>
           ) : null}
@@ -144,7 +159,12 @@ function ProjectsIndexPage() {
                 Create your first project to start using OS.
               </p>
             </div>
-            <Button type="button" size="sm" render={<Link to="/new-project" />}>
+            <Button
+              nativeButton={false}
+              type="button"
+              size="sm"
+              render={<Link to="/new-project" />}
+            >
               Create new project
             </Button>
           </div>

--- a/knip.ts
+++ b/knip.ts
@@ -140,6 +140,13 @@ const config: KnipConfig = {
   // Keep the config honest in CI/local runs: if Knip thinks our patterns or
   // workspace setup drifted, fail instead of silently warning.
   treatConfigHintsAsErrors: true,
+  entry: [
+    "playwright.config.ts",
+    "specs/**/*.spec.ts",
+    "specs/seed-local-auth.ts",
+    "specs/start-local-dev.ts",
+  ],
+  project: ["playwright.config.ts", "specs/**/*.ts"],
   // Keep this root command intentionally scoped. When Knip includes dependent
   // workspaces for a selected package, we still do not want it wandering into
   // unrelated apps with heavyweight config loading.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint:fix": "oxlint . --fix",
     "knip": "knip --workspace apps/os --workspace apps/semaphore --workspace apps/streams-example-app --workspace packages/shared",
     "prepare": "is-ci || husky",
+    "spec": "playwright test --config playwright.config.ts",
     "vitest": "pnpm --dir apps/os test",
     "test": "pnpm -r --parallel --filter '!iterate' test",
     "test:onboarding": "pnpm -r --parallel --filter '!iterate' test:onboarding",
@@ -33,6 +34,9 @@
     "auth:mint": "tsx scripts/auth/mint-session.ts"
   },
   "devDependencies": {
+    "@iterate-com/auth-contract": "workspace:*",
+    "@iterate-com/shared": "workspace:*",
+    "@playwright/test": "1.60.0",
     "@tanstack/eslint-plugin-router": "^1.139.0",
     "@types/node": "^24.10.1",
     "@typescript/native-preview": "^7.0.0-dev.20260203.1",
@@ -46,8 +50,10 @@
     "is-ci": "4.1.0",
     "knip": "^6.0.5",
     "lint-staged": "^16.2.7",
+    "middlewright": "^0.1.0",
     "oxfmt": "^0.35.0",
     "oxlint": "^1.50.0",
+    "playwright": "1.60.0",
     "skills": "^1.4.5",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const videoMode = process.env.VIDEO_MODE === "1";
+const readyPort = Number(process.env.OS_PLAYWRIGHT_READY_PORT || 17604);
+
+export default defineConfig({
+  testDir: "specs",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  outputDir: "test-results/playwright-output",
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: "test-results/playwright-html", open: "never" }],
+    ["json", { outputFile: "test-results/playwright-results.json" }],
+  ],
+  timeout: videoMode ? 300_000 : 90_000,
+  expect: { timeout: 15_000 },
+  use: {
+    actionTimeout: videoMode ? 10_000 : 750,
+    screenshot: "only-on-failure",
+    trace: process.env.CI ? "on-first-retry" : "retain-on-failure",
+    video: videoMode ? "on" : "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"], viewport: { width: 1280, height: 900 } },
+    },
+  ],
+  webServer: process.env.OS_PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: `pnpm exec tsx ./specs/start-local-dev.ts --ready-port ${readyPort}`,
+        url: `http://127.0.0.1:${readyPort}/ready`,
+        reuseExistingServer: !process.env.CI,
+        timeout: 180_000,
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,15 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@iterate-com/auth-contract':
+        specifier: workspace:*
+        version: link:apps/auth-contract
+      '@iterate-com/shared':
+        specifier: workspace:*
+        version: link:packages/shared
+      '@playwright/test':
+        specifier: 1.60.0
+        version: 1.60.0
       '@tanstack/eslint-plugin-router':
         specifier: ^1.139.0
         version: 1.161.4(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3)
@@ -110,12 +119,18 @@ importers:
       lint-staged:
         specifier: ^16.2.7
         version: 16.3.2
+      middlewright:
+        specifier: ^0.1.0
+        version: 0.1.0(@playwright/test@1.60.0)
       oxfmt:
         specifier: ^0.35.0
         version: 0.35.0
       oxlint:
         specifier: ^1.50.0
         version: 1.51.0
+      playwright:
+        specifier: 1.60.0
+        version: 1.60.0
       skills:
         specifier: ^1.4.5
         version: 1.4.5
@@ -621,7 +636,7 @@ importers:
         version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.28.6)(rolldown@1.1.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/browser-playwright':
         specifier: ^4.1.7
-        version: 4.1.8(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(playwright@1.57.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)
+        version: 4.1.8(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(playwright@1.60.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)
       alchemy:
         specifier: ^0.83.3
         version: 0.83.3(patch_hash=c837ce6f9ef4f420a7d2360823f65ec7a6c649c756ae76f7c12baf906f13c5f5)(@aws-sdk/client-s3@3.1002.0)(@cloudflare/vite-plugin@1.33.2(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1)))(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.18.0)(better-sqlite3@12.6.2)(kysely@0.28.16)(mysql2@3.18.2(@types/node@25.6.0))(pg@8.19.0)(postgres@3.4.8)(sql.js@1.14.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260424.1)(wrangler@4.85.0(@cloudflare/workers-types@4.20260426.1))
@@ -637,9 +652,6 @@ importers:
       miniflare:
         specifier: catalog:cloudflare
         version: 4.20260424.0
-      playwright:
-        specifier: 1.57.0
-        version: 1.57.0
       tinyexec:
         specifier: ^1.0.2
         version: 1.1.1
@@ -8810,6 +8822,10 @@ packages:
   embla-carousel@8.6.0:
     resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
 
+  emittery@1.2.1:
+    resolution: {integrity: sha512-sFz64DCRjirhwHLxofFqxYQm6DCp6o0Ix7jwKQvuCHPn4GMRZNuBZyLPu9Ccmk/QSCAMZt6FOUqA8JZCQvA9fw==}
+    engines: {node: '>=14.16'}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -10699,6 +10715,12 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  middlewright@0.1.0:
+    resolution: {integrity: sha512-1xWxyVV/w+5Rvo/yjM8ukzdwmPwOTCi4Dr5x8xEHIuiGuP1LW/KcuTVgxRA0KIpTdl1QO63J+Y26+zyI2iEiDg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@playwright/test': '>=1.49.0'
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -11403,11 +11425,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright-core@1.57.0:
-    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
@@ -11415,11 +11432,6 @@ packages:
 
   playwright@1.56.1:
     resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.57.0:
-    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -20419,19 +20431,6 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser-playwright@4.1.8(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(playwright@1.57.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)':
-    dependencies:
-      '@vitest/browser': 4.1.8(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)
-      '@vitest/mocker': 4.1.8(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
-      playwright: 1.57.0
-      tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(jsdom@27.4.0(@noble/hashes@2.0.1))(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-
   '@vitest/browser-playwright@4.1.8(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(playwright@1.60.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)':
     dependencies:
       '@vitest/browser': 4.1.8(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)
@@ -20444,7 +20443,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-    optional: true
 
   '@vitest/browser-playwright@4.1.8(msw@2.13.3(@types/node@25.6.0)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)':
     dependencies:
@@ -22690,6 +22688,8 @@ snapshots:
       embla-carousel: 8.6.0
 
   embla-carousel@8.6.0: {}
+
+  emittery@1.2.1: {}
 
   emoji-regex@10.6.0: {}
 
@@ -25136,6 +25136,14 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  middlewright@0.1.0(@playwright/test@1.60.0):
+    dependencies:
+      '@playwright/test': 1.60.0
+      dedent: 1.7.2
+      emittery: 1.2.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+
   mime-db@1.52.0: {}
 
   mime-db@1.54.0: {}
@@ -26134,19 +26142,11 @@ snapshots:
 
   playwright-core@1.56.1: {}
 
-  playwright-core@1.57.0: {}
-
   playwright-core@1.60.0: {}
 
   playwright@1.56.1:
     dependencies:
       playwright-core: 1.56.1
-    optionalDependencies:
-      fsevents: 2.3.2
-
-  playwright@1.57.0:
-    dependencies:
-      playwright-core: 1.57.0
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/specs/AGENTS.md
+++ b/specs/AGENTS.md
@@ -1,0 +1,11 @@
+## Writing playwright tests
+
+Think of these as _specs_ as well as tests. The idea is that a human or agent can read a test and go "I see how this aspect of the product is supposed to work now".
+
+## Locators over `expect`
+
+Avoid using the expect-based API for asserting that UI is visible/in a particular state. For example, don't bother with `await expect(page.getByRole("button", { name: "Run" })).toBeEnabled()` before clicking a button. Just call `await page.getByRole("button", { name: "Run" }).click()` directly. The `.click` implementation already waits for the button to exist, be visible, and to be enabled. Similarly if you want to assert that something is present on the page you can just do `await page.getByText("Welcome").waitFor()`. No need for any `await expect(...).toBeVisible()` rubbish.
+
+Avoid using `timeout` for actions like `click`, `waitFor` etc. Read the [middlewright docs](https://github.com/iterate/middlewright) for why (TL;DR: we should have progress UI in our app rather than bumping test timeouts): `.waitFor({ timeout: 5_000 })`
+
+Avoid doing `await myButton.waitFor()` and then `await runButton.click()`. It's another code-smell. `.click()` should _already_ wait for the button to be clickable so the `.waitFor()` is doing nothing other than give you another chance to run the test and hope for the flake gods to smile on you this time.

--- a/specs/dashboard.spec.ts
+++ b/specs/dashboard.spec.ts
@@ -1,0 +1,14 @@
+import { createProject, signInWithLocalAuth, test, uniqueSlug } from "./test-support/test.ts";
+
+test("can enter the dashboard and create a project", async ({ page }) => {
+  await signInWithLocalAuth(page);
+
+  const projectSlug = uniqueSlug("playwright-project");
+  await createProject(page, projectSlug);
+
+  await page.waitForURL(new RegExp(`/projects/${projectSlug}/`));
+  await page.getByText(projectSlug).first().waitFor();
+
+  await page.goto("/projects");
+  await page.getByRole("link", { name: projectSlug }).waitFor();
+});

--- a/specs/forged-session-repl.spec.ts
+++ b/specs/forged-session-repl.spec.ts
@@ -1,0 +1,10 @@
+import { createProjectFixture } from "./test-support/forged-session.ts";
+import { test } from "./test-support/test.ts";
+
+test("project REPL accepts a directly minted JWT session cookie", async ({ baseURL, page }) => {
+  await using projectFixture = await createProjectFixture("basic-repl", { baseURL, page });
+  await page.goto(`/projects/${projectFixture.project.slug}/repl`);
+  await page.getByRole("button", { name: "Run" }).click();
+
+  await page.getByText(`"capabilities"`).waitFor();
+});

--- a/specs/seed-local-auth.ts
+++ b/specs/seed-local-auth.ts
@@ -1,0 +1,85 @@
+import { parseArgs } from "node:util";
+import { createAuthContractClient } from "@iterate-com/auth-contract";
+
+const { values } = parseArgs({
+  options: {
+    email: { type: "string" },
+    "organization-name": { type: "string" },
+    "organization-slug": { type: "string" },
+    "project-slug": { type: "string" },
+  },
+});
+
+const email = required(values.email, "--email");
+const organizationName = required(values["organization-name"], "--organization-name");
+const organizationSlug = required(values["organization-slug"], "--organization-slug");
+const projectSlug = required(values["project-slug"], "--project-slug");
+
+const authBaseUrl = resolveLocalAuthBaseUrl();
+const serviceToken =
+  process.env.APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN ||
+  process.env.ITERATE_AUTH_SERVICE_TOKEN ||
+  process.env.SERVICE_AUTH_TOKEN;
+if (!serviceToken) {
+  throw new Error(
+    "A local auth service token is required. Run through Doppler so SERVICE_AUTH_TOKEN or ITERATE_AUTH_SERVICE_TOKEN is available.",
+  );
+}
+
+const client = createAuthContractClient({ baseUrl: authBaseUrl, serviceToken });
+const seeded = await retry(async () => {
+  const user = await client.internal.user.upsertVerifiedEmail({
+    email,
+    image: null,
+    name: email.split("@")[0] || email,
+  });
+  const organization = await client.internal.organization.createForUser({
+    name: organizationName,
+    slug: organizationSlug,
+    userId: user.id,
+  });
+  const project = await client.internal.project.createForOrganization({
+    name: projectSlug,
+    organizationSlug: organization.slug,
+    slug: projectSlug,
+  });
+
+  return { email, organization, project, user };
+});
+
+console.log(JSON.stringify(seeded));
+
+function required(value: string | undefined, flag: string) {
+  if (value) return value;
+  throw new Error(`${flag} is required`);
+}
+
+function resolveLocalAuthBaseUrl() {
+  const issuer = (
+    process.env.APP_CONFIG_ITERATE_AUTH__ISSUER ||
+    process.env.ITERATE_OAUTH_ISSUER ||
+    "http://localhost:7101/api/auth"
+  ).trim();
+  const origin = new URL(issuer).origin;
+  const hostname = new URL(origin).hostname;
+  if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") {
+    return origin;
+  }
+  throw new Error(`OS Playwright auth seed is local-only; refusing auth origin ${origin}`);
+}
+
+async function retry<T>(fn: () => Promise<T>): Promise<T> {
+  const deadline = Date.now() + 120_000;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+
+  throw lastError;
+}

--- a/specs/start-local-dev.ts
+++ b/specs/start-local-dev.ts
@@ -1,0 +1,134 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { parseArgs } from "node:util";
+import { createAuthContractClient } from "@iterate-com/auth-contract";
+import { OS_APP_ROOT, REPO_ROOT, waitForLocalOsBaseUrl } from "./test-support/local-dev.ts";
+
+const { values } = parseArgs({
+  options: {
+    "ready-port": { type: "string", default: "17604" },
+  },
+});
+
+const readyPort = Number(values["ready-port"]);
+if (!Number.isInteger(readyPort) || readyPort <= 0) {
+  throw new Error(`Invalid --ready-port: ${String(values["ready-port"])}`);
+}
+
+const localAuthServiceToken =
+  process.env.OS_PLAYWRIGHT_LOCAL_AUTH_SERVICE_TOKEN || "os-playwright-local-auth-service-token";
+const localAlchemyStage = "dev_playwright";
+
+const children: ChildProcess[] = [];
+let server: Server | undefined;
+
+if (!process.env.OS_PLAYWRIGHT_BASE_URL) {
+  startDevProcess("auth", {
+    args: [
+      "run",
+      "--preserve-env=ALCHEMY_STAGE,APP_CONFIG_ITERATE_AUTH__ISSUER,SERVICE_AUTH_TOKEN,VITE_AUTH_APP_ORIGIN,VITE_PUBLIC_URL",
+      "--",
+      "pnpm",
+      "dev:local",
+    ],
+    cwd: `${REPO_ROOT}/apps/auth`,
+    env: {
+      ...process.env,
+      ALCHEMY_STAGE: localAlchemyStage,
+      APP_CONFIG_ITERATE_AUTH__ISSUER: "http://localhost:7101/api/auth",
+      SERVICE_AUTH_TOKEN: localAuthServiceToken,
+      VITE_AUTH_APP_ORIGIN: "http://localhost:7101",
+      VITE_PUBLIC_URL: "http://localhost:7101",
+    },
+  });
+  await waitForLocalAuthService(localAuthServiceToken);
+  startDevProcess("os", {
+    args: [
+      "run",
+      "--preserve-env=ALCHEMY_STAGE,APP_CONFIG_ITERATE_AUTH__ISSUER,APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN,DEV_TUNNEL,ITERATE_AUTH_SERVICE_TOKEN,ITERATE_OAUTH_ISSUER",
+      "--",
+      "pnpm",
+      "dev:local",
+    ],
+    cwd: OS_APP_ROOT,
+    env: {
+      ...process.env,
+      ALCHEMY_STAGE: localAlchemyStage,
+      APP_CONFIG_ITERATE_AUTH__ISSUER: "http://localhost:7101/api/auth",
+      APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN: localAuthServiceToken,
+      ITERATE_AUTH_SERVICE_TOKEN: localAuthServiceToken,
+      ITERATE_OAUTH_ISSUER: "http://localhost:7101/api/auth",
+    },
+  });
+}
+
+const baseUrl = await waitForLocalOsBaseUrl({ timeoutMs: 180_000 });
+server = createServer((request, response) => {
+  if (request.url !== "/ready") {
+    response.writeHead(404).end();
+    return;
+  }
+  response.setHeader("content-type", "application/json");
+  response.end(JSON.stringify({ ok: true, baseUrl }));
+});
+
+await new Promise<void>((resolve, reject) => {
+  server!.once("error", reject);
+  server!.listen(readyPort, "127.0.0.1", () => resolve());
+});
+
+console.log(`OS Playwright ready at http://127.0.0.1:${readyPort}/ready for ${baseUrl}`);
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.once(signal, () => {
+    server?.close();
+    for (const child of children) {
+      child.kill(signal);
+    }
+    if (children.length === 0) process.exit(exitCodeForSignal(signal) ?? 0);
+  });
+}
+
+function startDevProcess(
+  label: string,
+  input: { args: string[]; cwd: string; env: NodeJS.ProcessEnv },
+) {
+  const child = spawn("doppler", input.args, {
+    cwd: input.cwd,
+    env: input.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  children.push(child);
+  child.stdout?.on("data", (chunk) => process.stdout.write(`[${label}] ${chunk}`));
+  child.stderr?.on("data", (chunk) => process.stderr.write(`[${label}] ${chunk}`));
+  child.once("exit", (code, signal) => {
+    process.exit(code ?? exitCodeForSignal(signal) ?? 1);
+  });
+}
+
+async function waitForLocalAuthService(serviceToken: string) {
+  const authClient = createAuthContractClient({
+    baseUrl: "http://localhost:7101",
+    serviceToken,
+  });
+  const deadline = Date.now() + 120_000;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      await authClient.internal.project.mintProjectId();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+
+  throw new Error(`Timed out waiting for local auth service: ${String(lastError)}`);
+}
+
+function exitCodeForSignal(signal: NodeJS.Signals | null) {
+  if (signal === "SIGINT") return 130;
+  if (signal === "SIGTERM") return 143;
+  return undefined;
+}

--- a/specs/test-support/forged-session.ts
+++ b/specs/test-support/forged-session.ts
@@ -1,0 +1,376 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { Page } from "@playwright/test";
+import {
+  ITERATE_ACCESS_TOKEN_ORGANIZATIONS_CLAIM,
+  ITERATE_ACCESS_TOKEN_PROJECTS_CLAIM,
+  ITERATE_IS_ADMIN_CLAIM,
+  ITERATE_ROLE_CLAIM,
+  type IterateAuthAccessTokenOrganizationClaim,
+  type IterateAuthProjectClaim,
+} from "@iterate-com/shared/auth-claims";
+import { withItx } from "../../apps/os/src/itx/client.ts";
+
+const execFileAsync = promisify(execFile);
+
+type DopplerAuthEnv = {
+  APP_CONFIG_ADMIN_API_SECRET?: string;
+  APP_CONFIG_ITERATE_AUTH__CLIENT_ID?: string;
+  APP_CONFIG_ITERATE_AUTH__ISSUER?: string;
+  APP_CONFIG_ITERATE_AUTH__RESOURCE?: string;
+  AUTH_FORGE_PRIVATE_JWK?: string;
+  ITERATE_OAUTH_CLIENT_ID?: string;
+  ITERATE_OAUTH_ISSUER?: string;
+};
+
+type ForgePrivateJwk = JsonWebKey & {
+  alg?: string;
+  kid?: string;
+};
+
+type OsPlaywrightAuthConfig = {
+  adminApiSecret: string;
+  clientId: string;
+  forgePrivateJwk: ForgePrivateJwk;
+  issuer: string;
+  resource: string;
+};
+
+export type MintedIterateSession = {
+  accessToken: string;
+  expiresAtMs: number;
+  idToken: string;
+};
+
+let configPromise: Promise<OsPlaywrightAuthConfig> | undefined;
+let signingKeyPromise: Promise<CryptoKey> | undefined;
+
+export async function createProjectFixture(
+  slugPrefix: string,
+  input: { baseURL: string | undefined; page: Page },
+) {
+  if (!input.baseURL) throw new Error("Playwright baseURL fixture is required.");
+
+  const projectSlug = uniqueFixtureSlug(slugPrefix);
+  const projectFixture = await createAdminProject({ baseUrl: input.baseURL, slug: projectSlug });
+  try {
+    const organization = {
+      id: `org_${crypto.randomUUID().replaceAll("-", "").slice(0, 16)}`,
+      name: `Playwright ${projectSlug}`,
+      role: "admin" as const,
+      slug: uniqueFixtureSlug(`${slugPrefix}-org`),
+    };
+    const session = await mintIterateSession({
+      baseUrl: input.baseURL,
+      email: `forged-${projectSlug}+test@nustom.com`,
+      organizations: [organization],
+      projects: [
+        {
+          id: projectFixture.project.id,
+          organizationId: organization.id,
+          slug: projectFixture.project.slug,
+        },
+      ],
+    });
+
+    await input.page.context().addCookies([
+      {
+        expires: Math.floor(session.expiresAtMs / 1000),
+        httpOnly: true,
+        name: "iterate_session",
+        sameSite: "Lax",
+        secure: new URL(input.baseURL).protocol === "https:",
+        url: input.baseURL,
+        value: encodeURIComponent(
+          JSON.stringify({
+            accessToken: session.accessToken,
+            accessTokenExpiresAt: session.expiresAtMs,
+            idToken: session.idToken,
+            tokenType: "bearer",
+          }),
+        ),
+      },
+    ]);
+
+    return {
+      organization,
+      project: projectFixture.project,
+      session,
+      async [Symbol.asyncDispose]() {
+        await projectFixture[Symbol.asyncDispose]();
+      },
+    };
+  } catch (error) {
+    await projectFixture[Symbol.asyncDispose]();
+    throw error;
+  }
+}
+
+export async function createAdminProject(input: { baseUrl: string; slug: string }) {
+  const config = await resolveOsPlaywrightAuthConfig(input.baseUrl);
+  using itx = withItx({ baseUrl: input.baseUrl, token: config.adminApiSecret });
+  const project = (await itx.projects.create({ slug: input.slug })) as {
+    id: string;
+    slug: string;
+  };
+  let disposed = false;
+
+  return {
+    project,
+    async [Symbol.asyncDispose]() {
+      if (disposed) return;
+      disposed = true;
+      using cleanupItx = withItx({ baseUrl: input.baseUrl, token: config.adminApiSecret });
+      await cleanupItx.projects.remove({ id: project.id }).catch(() => undefined);
+    },
+  };
+}
+
+export async function mintIterateSession(input: {
+  baseUrl: string;
+  email: string;
+  organizations: IterateAuthAccessTokenOrganizationClaim[];
+  projects: IterateAuthProjectClaim[];
+}) {
+  const config = await resolveOsPlaywrightAuthConfig(input.baseUrl);
+  const subject = `usr_forged_${input.email.replace(/[^a-z0-9]+/gi, "_").toLowerCase()}`;
+  const now = Math.floor(Date.now() / 1000);
+  const ttlSeconds = 60 * 60;
+  const expiresAtSeconds = now + ttlSeconds;
+  const sessionId = `ses_forged_${crypto.randomUUID().slice(0, 8)}`;
+
+  const accessToken = await signJwt({
+    audience: config.resource,
+    issuer: config.issuer,
+    payload: {
+      email: input.email,
+      scope: "openid profile email",
+      scopes: ["openid", "profile", "email"],
+      sid: sessionId,
+      [ITERATE_IS_ADMIN_CLAIM]: false,
+      [ITERATE_ROLE_CLAIM]: null,
+      [ITERATE_ACCESS_TOKEN_ORGANIZATIONS_CLAIM]: input.organizations,
+      [ITERATE_ACCESS_TOKEN_PROJECTS_CLAIM]: input.projects,
+    },
+    subject,
+    now,
+    expiresAtSeconds,
+    privateJwk: config.forgePrivateJwk,
+  });
+  const idToken = await signJwt({
+    audience: config.clientId,
+    issuer: config.issuer,
+    payload: {
+      email: input.email,
+      email_verified: true,
+      name: input.email.split("@")[0] || input.email,
+      [ITERATE_IS_ADMIN_CLAIM]: false,
+      [ITERATE_ROLE_CLAIM]: null,
+    },
+    subject,
+    now,
+    expiresAtSeconds,
+    privateJwk: config.forgePrivateJwk,
+  });
+
+  return {
+    accessToken,
+    expiresAtMs: expiresAtSeconds * 1000,
+    idToken,
+  };
+}
+
+async function resolveOsPlaywrightAuthConfig(baseUrl: string): Promise<OsPlaywrightAuthConfig> {
+  configPromise = configPromise || loadOsPlaywrightAuthConfig(baseUrl);
+  return await configPromise;
+}
+
+async function loadOsPlaywrightAuthConfig(baseUrl: string): Promise<OsPlaywrightAuthConfig> {
+  const dopplerEnv = await readDopplerAuthEnv();
+  const authorizeConfig = await readOsAuthAuthorizeConfig(baseUrl);
+  const issuer =
+    process.env.OS_PLAYWRIGHT_AUTH_ISSUER ||
+    authorizeConfig.issuer ||
+    process.env.APP_CONFIG_ITERATE_AUTH__ISSUER ||
+    process.env.ITERATE_OAUTH_ISSUER ||
+    dopplerEnv.APP_CONFIG_ITERATE_AUTH__ISSUER ||
+    dopplerEnv.ITERATE_OAUTH_ISSUER ||
+    "";
+  const clientId =
+    authorizeConfig.clientId ||
+    process.env.APP_CONFIG_ITERATE_AUTH__CLIENT_ID ||
+    process.env.ITERATE_OAUTH_CLIENT_ID ||
+    dopplerEnv.APP_CONFIG_ITERATE_AUTH__CLIENT_ID ||
+    dopplerEnv.ITERATE_OAUTH_CLIENT_ID ||
+    "";
+  const resource =
+    process.env.OS_PLAYWRIGHT_AUTH_RESOURCE ||
+    authorizeConfig.resource ||
+    process.env.APP_CONFIG_ITERATE_AUTH__RESOURCE ||
+    dopplerEnv.APP_CONFIG_ITERATE_AUTH__RESOURCE ||
+    defaultAuthResource(baseUrl);
+  const adminApiSecret =
+    process.env.OS_E2E_ADMIN_API_SECRET ||
+    process.env.OS_ADMIN_API_SECRET ||
+    process.env.APP_CONFIG_ADMIN_API_SECRET ||
+    dopplerEnv.APP_CONFIG_ADMIN_API_SECRET ||
+    "";
+  const forgePrivateJwkJson =
+    process.env.AUTH_FORGE_PRIVATE_JWK || dopplerEnv.AUTH_FORGE_PRIVATE_JWK || "";
+
+  if (!issuer) throw new Error("Missing Iterate auth issuer for Playwright forged session.");
+  if (!clientId) throw new Error("Missing Iterate auth client id for Playwright forged session.");
+  if (!resource) throw new Error("Missing Iterate auth resource for Playwright forged session.");
+  if (!adminApiSecret) {
+    throw new Error("Missing OS admin API secret for Playwright admin project setup.");
+  }
+  if (!forgePrivateJwkJson) {
+    throw new Error("Missing AUTH_FORGE_PRIVATE_JWK for Playwright forged session.");
+  }
+
+  const forgePrivateJwk = JSON.parse(forgePrivateJwkJson) as ForgePrivateJwk;
+  if (forgePrivateJwk.kty !== "OKP" || forgePrivateJwk.crv !== "Ed25519") {
+    throw new Error("Playwright forged sessions currently require an Ed25519 forge JWK.");
+  }
+  if (!forgePrivateJwk.kid) {
+    throw new Error("AUTH_FORGE_PRIVATE_JWK must include a kid.");
+  }
+
+  return {
+    adminApiSecret,
+    clientId,
+    forgePrivateJwk,
+    issuer,
+    resource,
+  };
+}
+
+async function readDopplerAuthEnv(): Promise<DopplerAuthEnv> {
+  const direct: DopplerAuthEnv = {
+    APP_CONFIG_ADMIN_API_SECRET: process.env.APP_CONFIG_ADMIN_API_SECRET,
+    APP_CONFIG_ITERATE_AUTH__CLIENT_ID: process.env.APP_CONFIG_ITERATE_AUTH__CLIENT_ID,
+    APP_CONFIG_ITERATE_AUTH__ISSUER: process.env.APP_CONFIG_ITERATE_AUTH__ISSUER,
+    APP_CONFIG_ITERATE_AUTH__RESOURCE: process.env.APP_CONFIG_ITERATE_AUTH__RESOURCE,
+    AUTH_FORGE_PRIVATE_JWK: process.env.AUTH_FORGE_PRIVATE_JWK,
+    ITERATE_OAUTH_CLIENT_ID: process.env.ITERATE_OAUTH_CLIENT_ID,
+    ITERATE_OAUTH_ISSUER: process.env.ITERATE_OAUTH_ISSUER,
+  };
+  if (
+    direct.APP_CONFIG_ADMIN_API_SECRET &&
+    direct.AUTH_FORGE_PRIVATE_JWK &&
+    (direct.APP_CONFIG_ITERATE_AUTH__CLIENT_ID || direct.ITERATE_OAUTH_CLIENT_ID)
+  ) {
+    return direct;
+  }
+
+  const config = process.env.OS_PLAYWRIGHT_DOPPLER_CONFIG || process.env.DOPPLER_CONFIG || "dev";
+  const script = `
+const keys = [
+  "APP_CONFIG_ADMIN_API_SECRET",
+  "APP_CONFIG_ITERATE_AUTH__CLIENT_ID",
+  "APP_CONFIG_ITERATE_AUTH__ISSUER",
+  "APP_CONFIG_ITERATE_AUTH__RESOURCE",
+  "AUTH_FORGE_PRIVATE_JWK",
+  "ITERATE_OAUTH_CLIENT_ID",
+  "ITERATE_OAUTH_ISSUER"
+];
+process.stdout.write(JSON.stringify(Object.fromEntries(keys.map((key) => [key, process.env[key] || ""]))));
+`;
+
+  const { stdout } = await execFileAsync(
+    "doppler",
+    ["run", "--project", "os", "--config", config, "--", "node", "-e", script],
+    { maxBuffer: 1024 * 1024 },
+  );
+  return JSON.parse(stdout) as DopplerAuthEnv;
+}
+
+async function signJwt(input: {
+  audience: string;
+  expiresAtSeconds: number;
+  issuer: string;
+  now: number;
+  payload: Record<string, unknown>;
+  privateJwk: ForgePrivateJwk;
+  subject: string;
+}) {
+  const header = base64UrlEncode(
+    JSON.stringify({
+      alg: "EdDSA",
+      kid: input.privateJwk.kid,
+      typ: "JWT",
+    }),
+  );
+  const payload = base64UrlEncode(
+    JSON.stringify({
+      ...input.payload,
+      aud: input.audience,
+      exp: input.expiresAtSeconds,
+      iat: input.now,
+      iss: input.issuer,
+      sub: input.subject,
+    }),
+  );
+  const signingInput = `${header}.${payload}`;
+  const signature = await crypto.subtle.sign(
+    { name: "Ed25519" },
+    await signingKey(input.privateJwk),
+    new TextEncoder().encode(signingInput),
+  );
+  return `${signingInput}.${base64UrlEncode(signature)}`;
+}
+
+async function signingKey(privateJwk: ForgePrivateJwk) {
+  signingKeyPromise =
+    signingKeyPromise ||
+    crypto.subtle.importKey("jwk", privateJwk, { name: "Ed25519" }, false, ["sign"]);
+  return await signingKeyPromise;
+}
+
+function defaultAuthResource(baseUrl: string) {
+  const url = new URL(baseUrl);
+  const loopback =
+    url.hostname === "localhost" ||
+    url.hostname === "127.0.0.1" ||
+    url.hostname === "::1" ||
+    url.hostname.endsWith(".localhost");
+  return loopback ? `http://${url.hostname}` : baseUrl.replace(/\/+$/, "");
+}
+
+async function readOsAuthAuthorizeConfig(baseUrl: string) {
+  let url = new URL("/api/iterate-auth/login?return_to=/", baseUrl);
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const response = await fetch(url, { redirect: "manual" });
+    const location = response.headers.get("location");
+    if (!location) break;
+
+    const nextUrl = new URL(location, url);
+    if (nextUrl.origin === new URL(baseUrl).origin && nextUrl.pathname === url.pathname) {
+      url = nextUrl;
+      continue;
+    }
+
+    const issuerPath = nextUrl.pathname.replace(/\/oauth2\/authorize$/u, "");
+    return {
+      clientId: nextUrl.searchParams.get("client_id") || "",
+      issuer: `${nextUrl.origin}${issuerPath}`,
+      resource: nextUrl.searchParams.get("resource") || "",
+    };
+  }
+
+  return {
+    clientId: "",
+    issuer: "",
+    resource: "",
+  };
+}
+
+function base64UrlEncode(value: string | ArrayBuffer) {
+  const bytes = typeof value === "string" ? new TextEncoder().encode(value) : new Uint8Array(value);
+  return Buffer.from(bytes).toString("base64url");
+}
+
+function uniqueFixtureSlug(prefix: string) {
+  return `${prefix}-${Date.now().toString(36)}-${crypto.randomUUID().slice(0, 8)}`.toLowerCase();
+}

--- a/specs/test-support/local-dev.ts
+++ b/specs/test-support/local-dev.ts
@@ -1,0 +1,54 @@
+import { fileURLToPath } from "node:url";
+import { readLocalDevServerInfo } from "@iterate-com/shared/alchemy/local-dev-server";
+
+export const OS_APP_ROOT = fileURLToPath(new URL("../../apps/os", import.meta.url));
+export const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+export async function waitForLocalOsBaseUrl(input: { timeoutMs?: number } = {}) {
+  const deadline = Date.now() + (input.timeoutMs || 60_000);
+  let lastError = "local OS dev server has not written .alchemy/dev-server.json yet";
+
+  while (Date.now() < deadline) {
+    const baseUrl =
+      process.env.OS_PLAYWRIGHT_BASE_URL ||
+      readLocalDevServerInfo(OS_APP_ROOT, { requireLive: true })?.baseUrl.replace(/\/+$/, "");
+    if (baseUrl) {
+      assertLoopbackBaseUrl(baseUrl);
+      const health = await probeHealth(baseUrl);
+      if (health.ok) return baseUrl;
+      lastError = health.error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  }
+
+  throw new Error(`Timed out waiting for local OS dev server: ${lastError}`);
+}
+
+async function probeHealth(baseUrl: string): Promise<{ ok: true } | { ok: false; error: string }> {
+  const url = new URL("/api/health", baseUrl);
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(2_000) });
+    if (response.ok) return { ok: true };
+    return { ok: false, error: `GET ${url.toString()} returned ${response.status}` };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function assertLoopbackBaseUrl(baseUrl: string) {
+  const { hostname } = new URL(baseUrl);
+  if (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname.endsWith(".localhost")
+  ) {
+    return;
+  }
+  throw new Error(
+    `OS Playwright e2e is localhost-only; refusing to run against non-loopback base URL ${baseUrl}`,
+  );
+}

--- a/specs/test-support/test.ts
+++ b/specs/test-support/test.ts
@@ -1,0 +1,148 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { test as base, type Page } from "@playwright/test";
+import {
+  addPlugins,
+  hydrationWaiter,
+  spinnerWaiter,
+  uiErrorReporter,
+  videoMode,
+} from "middlewright";
+import { REPO_ROOT, waitForLocalOsBaseUrl } from "./local-dev.ts";
+
+const execFileAsync = promisify(execFile);
+
+export const test = base.extend({
+  baseURL: async ({ browserName: _browserName }, use) => {
+    await use(await waitForLocalOsBaseUrl());
+  },
+  page: async ({ page: basePage }, use, testInfo) => {
+    await using page = await addPlugins({
+      page: basePage,
+      testInfo,
+      plugins: [
+        hydrationWaiter({ timeout: 30_000 }),
+        uiErrorReporter(),
+        spinnerWaiter({ spinnerTimeout: 30_000 }),
+        process.env.VIDEO_MODE === "1" && videoMode({ skipStackFrames: ["test-support/test.ts"] }),
+      ],
+      boxedStackPrefixes: (defaults) => [...defaults, import.meta.dirname],
+    });
+
+    await use(page);
+  },
+});
+
+export function uniqueSlug(prefix: string) {
+  return `${prefix}-${Date.now().toString(36)}-${crypto.randomUUID().slice(0, 8)}`.toLowerCase();
+}
+
+export async function signInWithLocalAuth(page: Page) {
+  const suffix = uniqueSlug("pw");
+  const email = `testuser+${suffix}test@gmail.com`;
+  const seed = await seedLocalAuth({
+    bootstrapProjectSlug: uniqueSlug("playwright-bootstrap"),
+    email,
+    organizationName: `Playwright ${suffix}`,
+    organizationSlug: suffix,
+  });
+
+  await page.context().clearCookies();
+  await page.goto("/api/iterate-auth/login?return_to=/projects");
+  await page.getByRole("button", { name: "Continue with email" }).click();
+  await page.getByTestId("email-input").fill(email);
+  await page.getByTestId("email-submit-button").click();
+  await page.getByTestId("email-otp-input").fill("424242");
+  await page.getByTestId("email-verify-button").click();
+  await continueOAuthProjectAccess(page);
+  await page.getByRole("heading", { exact: true, name: "Projects" }).waitFor();
+  await page.getByText(email).waitFor();
+
+  return seed;
+}
+
+export async function createProject(page: Page, projectSlug: string) {
+  await page
+    .getByRole("button", { name: "Create new project" })
+    .or(page.getByRole("button", { name: "New project" }))
+    .first()
+    .click();
+  await page.getByLabel("Slug").fill(projectSlug);
+  await page.getByRole("button", { name: "Create project" }).click();
+  await page.waitForURL(
+    new RegExp(`/projects/${projectSlug.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?:/|$)`),
+  );
+}
+
+async function seedLocalAuth(input: {
+  bootstrapProjectSlug: string;
+  email: string;
+  organizationName: string;
+  organizationSlug: string;
+}) {
+  const seedArgs = [
+    "exec",
+    "tsx",
+    "./specs/seed-local-auth.ts",
+    "--email",
+    input.email,
+    "--organization-name",
+    input.organizationName,
+    "--organization-slug",
+    input.organizationSlug,
+    "--project-slug",
+    input.bootstrapProjectSlug,
+  ];
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    APP_CONFIG_ITERATE_AUTH__ISSUER: "http://localhost:7101/api/auth",
+    SERVICE_AUTH_TOKEN:
+      process.env.OS_PLAYWRIGHT_LOCAL_AUTH_SERVICE_TOKEN ||
+      "os-playwright-local-auth-service-token",
+    ITERATE_OAUTH_ISSUER: "http://localhost:7101/api/auth",
+  };
+  const direct =
+    env.APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN ||
+    env.ITERATE_AUTH_SERVICE_TOKEN ||
+    env.SERVICE_AUTH_TOKEN;
+  const command = direct ? "pnpm" : "doppler";
+  const args = direct
+    ? seedArgs
+    : [
+        "run",
+        "--preserve-env=APP_CONFIG_ITERATE_AUTH__ISSUER,ITERATE_OAUTH_ISSUER,SERVICE_AUTH_TOKEN",
+        "--",
+        "pnpm",
+        "--dir",
+        "../..",
+        ...seedArgs,
+      ];
+
+  const { stdout } = await execFileAsync(command, args, {
+    cwd: direct ? REPO_ROOT : `${REPO_ROOT}/apps/auth`,
+    env,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  const json = stdout
+    .trim()
+    .split("\n")
+    .findLast((line) => line.trim().startsWith("{"));
+  if (!json) {
+    throw new Error(`local auth seed did not return JSON: ${stdout.trim()}`);
+  }
+  return JSON.parse(json) as {
+    email: string;
+    organization: { id: string; name: string; slug: string };
+    project: { id: string; slug: string };
+    user: { id: string; email: string };
+  };
+}
+
+async function continueOAuthProjectAccess(page: Page) {
+  const projectAccessContinue = page.getByRole("button", { exact: true, name: "Continue" });
+  if (await projectAccessContinue.isVisible().catch(() => false)) {
+    await projectAccessContinue.click();
+  }
+
+  await page.getByRole("button", { name: "Allow access" }).click();
+}

--- a/tasks/complete/2026-06-16-os-local-playwright-e2e.md
+++ b/tasks/complete/2026-06-16-os-local-playwright-e2e.md
@@ -1,0 +1,48 @@
+---
+status: complete
+size: medium
+branch: codex/os-local-playwright-e2e-main
+base: main
+---
+
+# OS Local Playwright E2E
+
+Status summary: Complete, recreated against `main` after PR 1545 was accidentally based on `codex/project-worker-ts-entrypoint`. The repo now has root-level product specs in `specs/` with a localhost-only Playwright lane that starts local auth and OS through `webServer`, discovers the OS dev port from `.alchemy/dev-server.json`, signs in through local auth, and creates a project. Focused static/unit checks and the full local Playwright run are green.
+
+## Assumptions
+
+- This is recreated directly on `main`; the original PR 1545 branch was stacked on top of `codex/project-worker-ts-entrypoint`.
+- The lane is localhost-only and should use `pnpm dev:local` or equivalent local OS dev startup, not Doppler tunnel configs, webhooks, or deployed preview/prod URLs.
+- Playwright should discover the actual selected localhost port through the existing `.alchemy/dev-server.json` mechanism instead of hardcoding a Vite port or scraping logs.
+- Use the published npm package `middlewright` and keep `actionTimeout` aggressively low.
+- Follow q1’s helper balance: helpers for common actions like login and project creation; no helper wrappers for one-off assertions.
+
+## Checklist
+
+- [x] Add a root Playwright config with `webServer` startup and localhost base URL discovery. _Implemented in `playwright.config.ts`; `specs/start-local-dev.ts` starts local auth/OS and waits on a ready endpoint backed by `.alchemy/dev-server.json`._
+- [x] Add middlewright-backed Playwright fixture wiring with aggressive action timeouts. _Implemented in `specs/test-support/test.ts` using `middlewright` with a 750ms normal action timeout._
+- [x] Add a minimal dashboard flow spec that logs in and creates a project. _Implemented in `specs/dashboard.spec.ts`; the helper signs in through local auth OTP and the test creates a project._
+- [x] Add package scripts/dependencies needed to run the Playwright lane from the repo root. _Added `pnpm spec`, Playwright/middlewright, and root workspace support deps for auth/shared helpers in `package.json`/`pnpm-lock.yaml`._
+- [x] Run and document verification for the new Playwright lane plus relevant static checks. _Verified Playwright discovery, local auth bootstrap unit coverage, OS typecheck, root lint, and the full local Playwright run._
+
+## Implementation Notes
+
+- q1 reference checked before implementation: root `playwright.config.ts`, `spec/test-helpers.ts`, and the login/org/project specs.
+- Current OS dev startup writes `.alchemy/dev-server.json`; `specs/test-support/local-dev.ts` now uses the shared reader directly from root-level product specs.
+- The first implementation used forged auth URLs, but the final lane now starts `apps/auth` locally and drives the real local auth email OTP/OAuth flow with seeded local auth data.
+- The local `../middlewright` checkout was used to inspect the API, but the committed dependency is the published `middlewright@^0.1.0`; CI cannot install from a sibling checkout path.
+- `apps/os/src/auth/dev-oauth-client-bootstrap.ts` now treats underscore `dev_*` Alchemy stages as local OAuth sync targets, so `dev:local` can register the OS OAuth client correctly.
+- `apps/os/src/routes/_app/projects/index.tsx` uses `nativeButton={false}` for Base UI buttons rendered as TanStack links, removing the invalid nested-button warning surfaced by Playwright.
+- The recreated main-based branch runs local auth and OS under `dev_playwright`; plain shared `dev` does not give OS a concrete `dev_*` OAuth client bootstrap target.
+- `apps/auth/src/routes/login.tsx` exposes a hydration/loading marker for the email login button so middlewright waits for the real clickable button instead of racing a pre-hydration disabled control.
+- `apps/os/src/routes/_app/projects/index.tsx` exposes a small pending state so the dashboard route is not a blank outlet while server-function data loads.
+- Verification run:
+  - `pnpm install --frozen-lockfile`
+  - `OS_PLAYWRIGHT_BASE_URL=http://localhost:1 pnpm exec playwright test --config playwright.config.ts --list`
+  - `pnpm knip`
+  - `pnpm --dir apps/os exec vitest run src/auth/dev-oauth-client-bootstrap.test.ts`
+  - `pnpm --dir apps/os typecheck`
+  - `pnpm --dir apps/auth typecheck`
+  - `pnpm lint`
+  - `pnpm format:check`
+  - `pnpm spec`


### PR DESCRIPTION
## Summary

Recreates PR #1545 directly against `main` after the original PR was accidentally merged with base `codex/project-worker-ts-entrypoint`. This branch keeps the Playwright/local e2e work only and does not include the project-worker TypeScript entrypoint changes from PR #1544.

This adds a root product spec lane:

```bash
pnpm spec
```

The lane starts local Auth and OS through Playwright `webServer`, discovers the OS localhost URL from `.alchemy/dev-server.json`, signs in through local email OTP/OAuth, creates a project from the dashboard, and also covers a forged-session project REPL path.

## What changed

- Adds root `playwright.config.ts` and `specs/` product specs/support code using `middlewright`.
- Moves Playwright/middlewright dependencies and the `pnpm spec` script to the repo root.
- Starts local Auth and OS under a dedicated `dev_playwright` Alchemy stage so OS can bootstrap a local OAuth client deterministically.
- Adds focused loading/hydration hooks needed by the specs: auth email login hydration/loading state, OS root hydration marker, itx pending markers, REPL loading state, and a projects-index pending state.
- Marks project list link-rendered Base UI buttons with `nativeButton={false}` to avoid invalid nested button markup during browser flows.
- Carries forward the completed task file with updated `main` branch/base metadata.

## Verification

- `pnpm install --frozen-lockfile`
- `OS_PLAYWRIGHT_BASE_URL=http://localhost:1 pnpm exec playwright test --config playwright.config.ts --list`
- `pnpm knip`
- `pnpm --dir apps/os exec vitest run src/auth/dev-oauth-client-bootstrap.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/auth typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm spec`

`pnpm spec` passed locally with the expected current dev-server noise: unknown Doppler app config warnings, TanStack Start's existing CSRF middleware warning, and non-fatal repo artifact 404 retries while project stream processors initialize.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease
<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-17T17:07:32.655Z",
      "headSha": "12a120ac84472f7d37e8dbdb8d4014ff5d8df576",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27698011659",
      "shortSha": "12a120a",
      "cleanupDurationMs": 13280,
      "deployDurationMs": 40113,
      "testDurationMs": 844
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-17T17:07:18.054Z",
      "headSha": "12a120ac84472f7d37e8dbdb8d4014ff5d8df576",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27698011659",
      "shortSha": "12a120a",
      "cleanupDurationMs": 46504,
      "deployDurationMs": 132960,
      "testDurationMs": 116055
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->
No active environment config lease.

### Auth
Status: released
Commit: `12a120a`
Preview: https://auth.iterate-preview-7.com
Deploy duration: 40.1s
Test duration: 844ms
Cleanup duration: 13.3s
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27698011659)
Updated: 2026-06-17T17:07:32.655Z

### OS
Status: released
Commit: `12a120a`
Preview: https://os.iterate-preview-7.com
Deploy duration: 133.0s
Test duration: 116.1s
Cleanup duration: 46.5s
Summary: Preview app released.
[Workflow run](https://github.com/iterate/iterate/actions/runs/27698011659)
Updated: 2026-06-17T17:07:18.054Z
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth login UX and adds test-only forged JWT signing (dev secrets via Doppler); production auth paths are unchanged but UI loading behavior is slightly different.
> 
> **Overview**
> Introduces a **localhost-only product spec lane** at the repo root: `playwright.config.ts`, `pnpm spec`, and `specs/` with `webServer` startup (`specs/start-local-dev.ts` spins auth + OS under `dev_playwright`, ready probe, OS URL from `.alchemy/dev-server.json`). Tests use **middlewright** (`hydrationWaiter`, `spinnerWaiter`) with a 750ms action timeout; helpers cover real email OTP/OAuth sign-in, project creation, and optional **forged JWT** sessions for a faster REPL path.
> 
> **App changes** support stable automation: `data-hydrated` on auth login and OS root `body`; `data-spinner` on itx/projects pending states and REPL TypeScript worker loading; auth email button shows a loading stub until hydrated; projects index gets `pendingComponent` and `nativeButton={false}` on link buttons. **Tooling**: Playwright/middlewright move to root `package.json`; knip entries for `specs/`; `apps/os` drops duplicate Playwright devDependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a120ac84472f7d37e8dbdb8d4014ff5d8df576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->