### PR TITLE
Fix project worker package authoring types

### DIFF
--- a/apps/os/src/domains/repos/iterate-config-base-seed.ts
+++ b/apps/os/src/domains/repos/iterate-config-base-seed.ts
@@ -24,7 +24,7 @@ const ITERATE_CONFIG_PACKAGE_JSON = `{
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260426.1",
-    "iterate": "^0.2.5",
+    "iterate": "^0.2.6",
     "typescript": "^5.9.3"
   }
 }

--- a/apps/os/src/itx/source-build.ts
+++ b/apps/os/src/itx/source-build.ts
@@ -273,8 +273,12 @@ export type IterateProjectStreams = {
   append: (input: IterateStreamAppendInput) => Promise<unknown>;
 };
 
-export type IterateProjectEnv = {
-  ITERATE: unknown;
+export type IterateProjectItx<Context = unknown> = {
+  context: Promise<Context>;
+};
+
+export type IterateProjectEnv<Context = unknown> = {
+  ITERATE: IterateProjectItx<Context>;
   STREAMS: IterateProjectStreams;
 };
 
@@ -283,8 +287,10 @@ export type IterateProjectEventInput = {
   streamPath: string;
 };
 
-export class IterateProjectEntrypoint extends WorkerEntrypoint<IterateProjectEnv> {
-  get itx(): IterateProjectEnv["ITERATE"] {
+export class IterateProjectEntrypoint<Context = unknown> extends WorkerEntrypoint<
+  IterateProjectEnv<Context>
+> {
+  get itx(): IterateProjectItx<Context> {
     return this.env.ITERATE;
   }
 

--- a/packages/iterate/package.json
+++ b/packages/iterate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iterate",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "CLI for iterate",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/iterate/src/worker.d.mts
+++ b/packages/iterate/src/worker.d.mts
@@ -9,8 +9,12 @@ export type IterateProjectStreams = {
   append(input: IterateStreamAppendInput): Promise<unknown>;
 };
 
-export type IterateProjectEnv = {
-  ITERATE: unknown;
+export type IterateProjectItx<Context = unknown> = {
+  context: Promise<Context>;
+};
+
+export type IterateProjectEnv<Context = unknown> = {
+  ITERATE: IterateProjectItx<Context>;
   STREAMS: IterateProjectStreams;
 };
 
@@ -19,8 +23,10 @@ export type IterateProjectEventInput = {
   streamPath: string;
 };
 
-export declare class IterateProjectEntrypoint extends WorkerEntrypoint<IterateProjectEnv> {
-  get itx(): IterateProjectEnv["ITERATE"];
+export declare class IterateProjectEntrypoint<Context = unknown> extends WorkerEntrypoint<
+  IterateProjectEnv<Context>
+> {
+  get itx(): IterateProjectItx<Context>;
   get streams(): IterateProjectStreams;
   processEvent(input: IterateProjectEventInput): Promise<void>;
   protected onProjectEvent(input: IterateProjectEventInput): Promise<void>;

--- a/packages/iterate/src/worker.ts
+++ b/packages/iterate/src/worker.ts
@@ -9,8 +9,12 @@ export type IterateProjectStreams = {
   append: (input: IterateStreamAppendInput) => Promise<unknown>;
 };
 
-export type IterateProjectEnv = {
-  ITERATE: unknown;
+export type IterateProjectItx<Context = unknown> = {
+  context: Promise<Context>;
+};
+
+export type IterateProjectEnv<Context = unknown> = {
+  ITERATE: IterateProjectItx<Context>;
   STREAMS: IterateProjectStreams;
 };
 
@@ -19,8 +23,10 @@ export type IterateProjectEventInput = {
   streamPath: string;
 };
 
-export class IterateProjectEntrypoint extends WorkerEntrypoint<IterateProjectEnv> {
-  get itx(): IterateProjectEnv["ITERATE"] {
+export class IterateProjectEntrypoint<Context = unknown> extends WorkerEntrypoint<
+  IterateProjectEnv<Context>
+> {
+  get itx(): IterateProjectItx<Context> {
     return this.env.ITERATE;
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #1554 after reviewing the post-merge project-worker authoring path.

- bump the `iterate` package to `0.2.6` and seed new project repos with `iterate@^0.2.6`, the first package version intended to include the `./worker` subpath
- expose `IterateProjectItx<Context>` so strict TypeScript project workers can call `await this.itx.context` without casting
- keep the generated platform shim type shape aligned with the published `iterate/worker` surface

Example:

```ts
import { IterateProjectEntrypoint } from "iterate/worker";

type ProjectItx = {
  describe(): Promise<{ ok: true }>;
};

export default class Worker extends IterateProjectEntrypoint<ProjectItx> {
  async fetch() {
    const itx = await this.itx.context;
    return Response.json(await itx.describe());
  }
}
```

## Verification

- `pnpm --dir apps/os typecheck`
- `pnpm --dir packages/iterate build`
- `pnpm lint`
- `pnpm format:check`
- packed `packages/iterate` and typechecked a throwaway strict external project importing `iterate/worker` from the tarball

## Follow-up

After this lands, `iterate@0.2.6` still needs to be published to npm before seeded external project repos can install it.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-17T22:42:30.620Z",
      "headSha": "46560f48190b36de1d90eadeebc7a8b0c8f2191a",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27713245970",
      "shortSha": "46560f4",
      "cleanupDurationMs": 12900,
      "deployDurationMs": 30538,
      "testDurationMs": 590
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-17T22:42:16.845Z",
      "headSha": "46560f48190b36de1d90eadeebc7a8b0c8f2191a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27713245970",
      "shortSha": "46560f4",
      "cleanupDurationMs": 50545,
      "deployDurationMs": 51712,
      "testDurationMs": 114147
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `46560f4` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 30.5s | 590ms | 12.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/27713245970) | 2026-06-17T22:42:30.620Z | Preview app released. |
| OS | released | `46560f4` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 51.7s | 114.1s | 50.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/27713245970) | 2026-06-17T22:42:16.845Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only and version-bump changes to the project-worker authoring API; no runtime auth, data, or payment logic touched.
> 
> **Overview**
> **Typed project-worker authoring** for `iterate/worker`: `ITERATE` is no longer `unknown` — it’s `IterateProjectItx<Context>` with **`context: Promise<Context>`**, and **`IterateProjectEntrypoint`** is generic so strict TS workers can use `await this.itx.context` without casts.
> 
> **Version alignment**: `iterate` is bumped to **0.2.6** and new seeded project repos pin **`iterate@^0.2.6`**. The in-repo build shim in `source-build.ts` mirrors the same types as the published `packages/iterate` worker surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46560f48190b36de1d90eadeebc7a8b0c8f2191a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->