### PR TITLE
[codex] Update stream path navigation API

### DIFF
--- a/apps/os/src/domains/projects/stream-processors/project/implementation.test.ts
+++ b/apps/os/src/domains/projects/stream-processors/project/implementation.test.ts
@@ -285,20 +285,32 @@ function newProcessor(deps: {
     exports: {},
     forwardToProjectWorker,
     stream:
-      stream ?? ({ append: () => {}, appendBatch: () => {} } as unknown as StreamProcessorStream),
+      stream ??
+      (() => {
+        const noop = {
+          append: () => {},
+          appendBatch: () => {},
+          at: () => noop,
+        } as unknown as StreamProcessorStream;
+        return noop;
+      })(),
     projectId: () => "project_1",
   });
 }
 
 function recordingStream(appendedBatches: Array<{ events: unknown[]; streamPath?: string }>) {
   let offset = 0;
-  return {
-    append: async (args: { event: StreamEventInput }) => event({ ...args.event, offset: ++offset }),
-    appendBatch: async (batch: { events: StreamEventInput[]; streamPath?: string }) => {
-      appendedBatches.push(batch);
-      return batch.events.map((input) => event({ ...input, offset: ++offset }));
-    },
-  } as unknown as StreamProcessorStream;
+  const streamFor = (streamPath: string | undefined): StreamProcessorStream =>
+    ({
+      append: async (args: { event: StreamEventInput }) =>
+        event({ ...args.event, offset: ++offset }),
+      appendBatch: async (batch: { events: StreamEventInput[] }) => {
+        appendedBatches.push({ ...batch, streamPath });
+        return batch.events.map((input) => event({ ...input, offset: ++offset }));
+      },
+      at: (nextPath: string) => streamFor(nextPath),
+    }) as unknown as StreamProcessorStream;
+  return streamFor(undefined);
 }
 
 function event(args: {

--- a/apps/os/src/domains/projects/stream-processors/project/implementation.ts
+++ b/apps/os/src/domains/projects/stream-processors/project/implementation.ts
@@ -331,8 +331,7 @@ export class ProjectProcessor extends StreamProcessor<
    * processors can safely ignore requests addressed to another provider.
    */
   async #appendAgentStreamBirthCertificate(input: { agentPath: StreamPath; projectId: string }) {
-    await this.deps.stream.appendBatch({
-      streamPath: input.agentPath,
+    await this.deps.stream.at(input.agentPath).appendBatch({
       events: [
         {
           type: "events.iterate.com/agent/config-updated",
@@ -376,8 +375,7 @@ export class ProjectProcessor extends StreamProcessor<
   }
 
   async #appendSlackIntegrationBirthCertificate(input: { projectId: string }) {
-    await this.deps.stream.append({
-      streamPath: SLACK_INTEGRATION_STREAM_PATH,
+    await this.deps.stream.at(SLACK_INTEGRATION_STREAM_PATH).append({
       event: {
         type: "events.iterate.com/stream/subscription-configured",
         idempotencyKey: `slack-subscription:${input.projectId}:workers-rpc:callable`,

--- a/apps/os/src/domains/slack/stream-processors/slack/implementation.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack/implementation.ts
@@ -145,8 +145,7 @@ export class SlackProcessor extends StreamProcessor<SlackProcessorContract, Slac
       // so the replay dedupes instead of double-forwarding.
       args.blockProcessorWhile(async () => {
         await this.deps.stream.append({ event: routeEvent });
-        await this.deps.stream.appendBatch({
-          streamPath,
+        await this.deps.stream.at(streamPath).appendBatch({
           events: [routeEvent, forwardedWebhookEvent],
         });
       });
@@ -164,7 +163,7 @@ export class SlackProcessor extends StreamProcessor<SlackProcessorContract, Slac
     // Block the checkpoint so a failed append replays the webhook instead of
     // dropping it; the idempotency key makes the replay a no-op if it landed.
     args.blockProcessorWhile(async () => {
-      await this.deps.stream.append({ streamPath, event: forwardedWebhookEvent });
+      await this.deps.stream.at(streamPath).append({ event: forwardedWebhookEvent });
     });
   }
 }

--- a/apps/os/src/domains/slack/stream-processors/slack/slack.test.ts
+++ b/apps/os/src/domains/slack/stream-processors/slack/slack.test.ts
@@ -129,10 +129,10 @@ describe("SlackProcessor", () => {
     // lost) and passes under `blockProcessorWhile`.
     const appended: Array<{ streamPath?: string; event: StreamEventInput }> = [];
     let failNextAppend = true;
-    const processor = new SlackProcessor({
-      stream: {
-        append: async (args: { event: StreamEventInput; streamPath?: string }) => {
-          const { event, streamPath } = args;
+    const streamFor = (streamPath: string | undefined): StreamProcessorStream =>
+      ({
+        append: async (args: { event: StreamEventInput }) => {
+          const { event } = args;
           if (failNextAppend) {
             failNextAppend = false;
             throw new Error("cold StreamsCapability RPC failed");
@@ -140,13 +140,15 @@ describe("SlackProcessor", () => {
           appended.push({ event, streamPath });
           return committedEvent({ ...event, offset: appended.length });
         },
-        appendBatch: async (args: { events: StreamEventInput[]; streamPath?: string }) =>
+        appendBatch: async (args: { events: StreamEventInput[] }) =>
           args.events.map((event) => {
-            const streamPath = args.streamPath;
             appended.push({ event, streamPath });
             return committedEvent({ ...event, offset: appended.length });
           }),
-      } as unknown as StreamProcessorStream,
+        at: (nextPath: string) => streamFor(nextPath),
+      }) as unknown as StreamProcessorStream;
+    const processor = new SlackProcessor({
+      stream: streamFor(undefined),
     });
 
     // First delivery: the append throws. ingest MUST reject and the checkpoint
@@ -297,21 +299,23 @@ function createProcessor(
   } = {},
 ) {
   const appended: Array<{ streamPath?: string; event: StreamEventInput }> = [];
-  const processor = new SlackProcessor({
-    stream: {
-      append: async (args: { event: StreamEventInput; streamPath?: string }) => {
-        const { event, streamPath } = args;
+  const streamFor = (streamPath: string | undefined): StreamProcessorStream =>
+    ({
+      append: async (args: { event: StreamEventInput }) => {
+        const { event } = args;
         appended.push({ event, streamPath });
         return committedEvent({ ...event, offset: appended.length });
       },
-      appendBatch: async (args: { events: StreamEventInput[]; streamPath?: string }) => {
+      appendBatch: async (args: { events: StreamEventInput[] }) => {
         return args.events.map((event) => {
-          const streamPath = args.streamPath;
           appended.push({ event, streamPath });
           return committedEvent({ ...event, offset: appended.length });
         });
       },
-    } as unknown as StreamProcessorStream,
+      at: (nextPath: string) => streamFor(nextPath),
+    }) as unknown as StreamProcessorStream;
+  const processor = new SlackProcessor({
+    stream: streamFor(undefined),
     ...deps,
   });
   return { appended, processor };

--- a/apps/os/src/domains/streams/engine/README.md
+++ b/apps/os/src/domains/streams/engine/README.md
@@ -133,8 +133,9 @@ Non-obvious behaviors worth knowing:
   to replay from the first event. Delivery starts at `replayAfterOffset + 1`.
 - **512KB event chunking.** Each event's JSON is split into 512KB rows in `event_chunks`, so a
   single event can exceed the Durable Object per-row size limit.
-- **Relative `streamPath`.** `append`/`appendBatch` accept a `streamPath` resolved relative to the
-  current stream's path; appends to another stream are dispatched to that Durable Object.
+- **Relative stream navigation.** `at(streamPath)` returns the stream RPC target resolved relative
+  to the current stream's path (`child`, `./child`, `../sibling`) or from the root for absolute
+  paths. Appends stay pinned to their target: use `stream.at("../sibling").append({ event })`.
 - **`reset()` vs `kill()`.** `reset()` clears all durable storage for the stream then aborts the
   current incarnation; `kill()` only aborts the incarnation.
 

--- a/apps/os/src/domains/streams/engine/processors/core/implementation.ts
+++ b/apps/os/src/domains/streams/engine/processors/core/implementation.ts
@@ -357,8 +357,7 @@ export class CoreStreamProcessor extends StreamProcessor<CoreProcessorContract, 
     args.runInBackground(async () => {
       await Promise.all(
         ancestorPaths.map((ancestorPath) =>
-          this.deps.stream.append({
-            streamPath: ancestorPath,
+          this.deps.stream.at(ancestorPath).append({
             event: {
               type: "events.iterate.com/stream/child-stream-created",
               idempotencyKey: `child-stream-created:${ancestorPath}:${path}`,

--- a/apps/os/src/domains/streams/engine/shared/rpc-target.ts
+++ b/apps/os/src/domains/streams/engine/shared/rpc-target.ts
@@ -46,8 +46,14 @@ export function makeRpcTargetClass<TSource extends object>(
   const include = options.include === undefined ? undefined : new Set<PropertyKey>(options.include);
 
   class GeneratedRpcTarget extends RpcTarget {
-    constructor(readonly source: TSource) {
+    declare readonly source: TSource;
+
+    constructor(source: TSource) {
       super();
+      // RpcTarget instances can cross Workers RPC boundaries. Keep the local
+      // source reference off the structured-clone surface; only methods below
+      // should be exposed remotely.
+      Object.defineProperty(this, "source", { value: source, enumerable: false });
     }
   }
 

--- a/apps/os/src/domains/streams/engine/stream-processor.test.ts
+++ b/apps/os/src/domains/streams/engine/stream-processor.test.ts
@@ -37,6 +37,20 @@ function event(args: {
   };
 }
 
+function resolveTestStreamPath(basePath: string, streamPath: string): string {
+  const segments = streamPath.startsWith("/") ? [] : basePath.split("/").filter(Boolean);
+  for (const segment of streamPath.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      if (segments.length === 0) throw new Error(`stream path escapes root: ${streamPath}`);
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  return `/${segments.join("/")}`;
+}
+
 // A stream stub that records appends in memory. These tests only exercise the
 // append surface, so the fake is cast to the full RPC stub type.
 function memoryStream(options: { startOffset?: number } = {}) {
@@ -54,6 +68,7 @@ function memoryStream(options: { startOffset?: number } = {}) {
         committed.push(e);
         return e;
       }),
+    at: () => stream,
   } as unknown as StreamProcessorStream;
   return { stream, committed };
 }
@@ -145,13 +160,16 @@ class CoreStreamSim {
 
   append(path: string, input: StreamEventInput, createdAtMs = 0): StreamEvent {
     const entry = this.#entry(path);
+    const streamFor = (streamPath: string): StreamProcessorStream =>
+      ({
+        append: (args: { event: StreamEventInput }) =>
+          this.append(streamPath, args.event, createdAtMs),
+        appendBatch: (args: { events: StreamEventInput[] }) =>
+          args.events.map((event) => this.append(streamPath, event, createdAtMs)),
+        at: (nextPath: string) => streamFor(resolveTestStreamPath(streamPath, nextPath)),
+      }) as unknown as StreamProcessorStream;
     const coreInline = new CoreStreamProcessor({
-      stream: {
-        append: (args: { streamPath?: string; event: StreamEventInput }) =>
-          this.append(args.streamPath ?? path, args.event, createdAtMs),
-        appendBatch: (args: { streamPath?: string; events: StreamEventInput[] }) =>
-          args.events.map((event) => this.append(args.streamPath ?? path, event, createdAtMs)),
-      } as unknown as StreamProcessorStream,
+      stream: streamFor(path),
     });
 
     coreInline.validateAppend({
@@ -237,13 +255,15 @@ describe("core stream state and subscription processors", () => {
     const batch = [...entry.events];
 
     const writes: StreamProcessorSnapshot<unknown>[] = [];
+    const streamFor = (streamPath: string): StreamProcessorStream =>
+      ({
+        append: (args: { event: StreamEventInput }) => sim.append(streamPath, args.event),
+        appendBatch: (args: { events: StreamEventInput[] }) =>
+          args.events.map((event) => sim.append(streamPath, event)),
+        at: (nextPath: string) => streamFor(resolveTestStreamPath(streamPath, nextPath)),
+      }) as unknown as StreamProcessorStream;
     const processor = new CircuitBreakerProcessor({
-      stream: {
-        append: (args: { streamPath?: string; event: StreamEventInput }) =>
-          sim.append(args.streamPath ?? "/cb", args.event),
-        appendBatch: (args: { streamPath?: string; events: StreamEventInput[] }) =>
-          args.events.map((event) => sim.append(args.streamPath ?? "/cb", event)),
-      } as unknown as StreamProcessorStream,
+      stream: streamFor("/cb"),
       writeState: (snapshot) => void writes.push(snapshot),
     });
 

--- a/apps/os/src/domains/streams/engine/types.ts
+++ b/apps/os/src/domains/streams/engine/types.ts
@@ -58,16 +58,20 @@ export type LiveStreamSubscriberDescriptor = Omit<StreamSubscriberDescriptor, "p
 
 /** The minimal append surface a processor's iterate context exposes. */
 export type ProcessorStream = {
-  append(args: { streamPath?: string; event: StreamEventInput }): unknown;
-  appendBatch(args: { streamPath?: string; events: StreamEventInput[] }): unknown;
+  append(args: { event: StreamEventInput }): unknown;
+  appendBatch(args: { events: StreamEventInput[] }): unknown;
+  at(streamPath: string): ProcessorStream;
 };
 
 export type StreamRpc = {
-  append(args: { streamPath?: string; event: StreamEventInput }): MaybePromise<StreamEvent>;
-  appendBatch(args: {
-    streamPath?: string;
-    events: StreamEventInput[];
-  }): MaybePromise<StreamEvent[]>;
+  append(args: { event: StreamEventInput }): MaybePromise<StreamEvent>;
+  appendBatch(args: { events: StreamEventInput[] }): MaybePromise<StreamEvent[]>;
+  /**
+   * Returns a stream target resolved from this stream's path. Absolute paths
+   * start at the project root; relative paths (`child`, `./child`, `../peer`)
+   * resolve from the current stream.
+   */
+  at(streamPath: string): StreamRpc;
   getEvent(
     args: { offset: number; idempotencyKey?: never } | { idempotencyKey: string; offset?: never },
   ): MaybePromise<StreamEvent | undefined>;

--- a/apps/os/src/domains/streams/engine/workers/durable-objects/stream.ts
+++ b/apps/os/src/domains/streams/engine/workers/durable-objects/stream.ts
@@ -344,15 +344,19 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
     return state;
   }
 
-  #resolveStream(streamPath: string): Pick<StreamRpc, "append" | "appendBatch"> {
+  at(streamPath: string): StreamRpc {
     const resolvedPath = resolveStreamPath(this.#coreProcessorState.path, streamPath);
-    if (resolvedPath === resolveStreamPath(this.#coreProcessorState.path, ".")) return this;
-    return this.env.STREAM.getByName(
-      formatDurableObjectName({
-        path: resolvedPath,
-        projectId: this.name.projectId,
-      }),
-    ) as unknown as Pick<StreamRpc, "append" | "appendBatch">;
+    if (resolvedPath === resolveStreamPath(this.#coreProcessorState.path, ".")) {
+      return new StreamRpcTarget(this) as unknown as StreamRpc;
+    }
+    return new StreamRpcTarget(
+      this.env.STREAM.getByName(
+        formatDurableObjectName({
+          path: resolvedPath,
+          projectId: this.name.projectId,
+        }),
+      ) as unknown as StreamRpc,
+    ) as unknown as StreamRpc;
   }
 
   /**
@@ -360,13 +364,7 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
    *
    * Uses `appendBatch()`, so all append ordering and persistence stays in one place.
    */
-  append(args: {
-    streamPath?: string;
-    event: StreamEventInput;
-  }): StreamEvent | Promise<StreamEvent> {
-    if (args.streamPath !== undefined) {
-      return this.#resolveStream(args.streamPath).append({ event: args.event });
-    }
+  append(args: { event: StreamEventInput }): StreamEvent | Promise<StreamEvent> {
     return this.#appendBatchHere({ events: [args.event] })[0]!;
   }
 
@@ -387,14 +385,7 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
    *
    * Returns the persisted events (including offsets + `createdAt`) in input order.
    */
-  appendBatch(args: {
-    streamPath?: string;
-    events: StreamEventInput[];
-  }): StreamEvent[] | Promise<StreamEvent[]> {
-    if (args.streamPath !== undefined) {
-      return this.#resolveStream(args.streamPath).appendBatch({ events: args.events });
-    }
-
+  appendBatch(args: { events: StreamEventInput[] }): StreamEvent[] | Promise<StreamEvent[]> {
     return this.#appendBatchHere({ events: args.events });
   }
 
@@ -780,6 +771,7 @@ export class Stream extends DurableObject<Env> implements StreamRpc {
 const STREAM_RPC_METHODS = [
   "append",
   "appendBatch",
+  "at",
   "getEvent",
   "getEvents",
   "waitForEvent",

--- a/apps/os/src/domains/streams/engine/workers/durable-objects/stream.workers.test.ts
+++ b/apps/os/src/domains/streams/engine/workers/durable-objects/stream.workers.test.ts
@@ -18,7 +18,7 @@
 import { env, runInDurableObject } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 import type { StreamEvent } from "../../shared/event.ts";
-import type { StreamEventBatch } from "../../types.ts";
+import type { StreamEventBatch, StreamRpc } from "../../types.ts";
 import { PublicStreamRpcTarget, type Stream } from "./stream.ts";
 
 const STREAM = (env as unknown as { STREAM: DurableObjectNamespace<Stream> }).STREAM;
@@ -112,6 +112,23 @@ describe("T8 — Stream DO smoke (coverage)", () => {
     expect(second.offset).toBe(first.offset + 1);
     const read = (await stream.getEvent({ offset: second.offset })) as StreamEvent | undefined;
     expect(read?.payload).toEqual({ i: 2 });
+  });
+
+  it("at returns a stream target resolved relative to the current stream", async () => {
+    const child = (await freshStream().at("child")) as StreamRpc;
+    const committed = (await child.append({
+      event: { type: "test.cd", payload: { target: "child" } },
+    })) as StreamEvent;
+
+    const state = (await child.runtimeState()) as Awaited<ReturnType<StreamRpc["runtimeState"]>>;
+    expect(committed.offset).toBe(3);
+    expect(state.coreProcessorState.path).toMatch(/^\/review\/t\d+\/child$/);
+
+    const sibling = (await child.at("../sibling")) as StreamRpc;
+    const siblingState = (await sibling.runtimeState()) as Awaited<
+      ReturnType<StreamRpc["runtimeState"]>
+    >;
+    expect(siblingState.coreProcessorState.path).toMatch(/^\/review\/t\d+\/sibling$/);
   });
 
   it("honors getEvents afterOffset + limit", async () => {

--- a/apps/os/src/domains/streams/engine/workers/stream-processor-host.ts
+++ b/apps/os/src/domains/streams/engine/workers/stream-processor-host.ts
@@ -430,6 +430,7 @@ export function createStreamProcessorHost(ctx: DurableObjectState): StreamProces
       append: (args: Parameters<StreamRpc["append"]>[0]) => requireStream(name).append(args),
       appendBatch: (args: Parameters<StreamRpc["appendBatch"]>[0]) =>
         requireStream(name).appendBatch(args),
+      at: (streamPath: string) => requireStream(name).at(streamPath),
       getEvent: (args: Parameters<StreamRpc["getEvent"]>[0]) => requireStream(name).getEvent(args),
       getEvents: (args?: Parameters<StreamRpc["getEvents"]>[0]) =>
         requireStream(name).getEvents(args),

--- a/apps/os/src/itx/README.md
+++ b/apps/os/src/itx/README.md
@@ -131,8 +131,8 @@ stub controls like `dup`/`then`/`constructor`).
 Note for the curious: there are TWO composing pipelining systems in play.
 This one flattens dotted NAMES into data before anything touches the network;
 the RPC transports (capnweb, Workers RPC) separately pipeline CALLS onto
-returned stubs. They compose — `itx.streams.get("/x").append(e)` is one
-PathCall producing a stub the transport then pipelines `append` onto.
+returned stubs. They compose — `itx.streams.get("/x").append({ event })` is
+one PathCall producing a stub the transport then pipelines `append` onto.
 
 ## ② Data becomes dots again: `replayPathCall`
 

--- a/apps/os/src/itx/capabilities/streams.ts
+++ b/apps/os/src/itx/capabilities/streams.ts
@@ -156,6 +156,25 @@ function parseStreamRef(ref: string | { projectId: string | null; path: string }
   });
 }
 
+function resolveRelativeStreamPath(basePath: string, streamPath: string): string {
+  const segments = streamPath.startsWith("/") ? [] : basePath.split("/").filter(Boolean);
+  for (const segment of streamPath.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      if (segments.length === 0) {
+        throw new ItxError({
+          code: "BAD_REQUEST",
+          message: `Stream path ${JSON.stringify(streamPath)} escapes the stream root.`,
+        });
+      }
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  return `/${segments.join("/")}`;
+}
+
 export class ItxStream extends RpcTarget {
   constructor(
     private readonly scope: StreamsScope,
@@ -171,6 +190,14 @@ export class ItxStream extends RpcTarget {
 
   async appendBatch(input: Parameters<StreamRpc["appendBatch"]>[0]) {
     return await this.client().appendBatch(input as never);
+  }
+
+  at(streamPath: string): ItxStream {
+    return new ItxStream(
+      this.scope,
+      this.projectId,
+      resolveRelativeStreamPath(this.path, streamPath),
+    );
   }
 
   async getEvent(input: Parameters<StreamRpc["getEvent"]>[0]) {

--- a/apps/os/src/itx/types.ts
+++ b/apps/os/src/itx/types.ts
@@ -648,8 +648,13 @@ export type StreamSubscriptionBatch = {
 
 /** A handle pinned to one stream. */
 export interface ItxStream {
-  append(args: { streamPath?: string; event: StreamEventInput }): Promise<StreamEvent>;
-  appendBatch(args: { streamPath?: string; events: StreamEventInput[] }): Promise<StreamEvent[]>;
+  append(args: { event: StreamEventInput }): Promise<StreamEvent>;
+  appendBatch(args: { events: StreamEventInput[] }): Promise<StreamEvent[]>;
+  /**
+   * Navigate from this stream to another stream in the same project. Absolute
+   * paths start at `/`; relative paths resolve from this stream.
+   */
+  at(streamPath: string): ItxStream;
   getEvent(
     args: { offset: number; idempotencyKey?: never } | { idempotencyKey: string; offset?: never },
   ): Promise<StreamEvent | undefined>;

--- a/apps/os/src/lib/itx-stream-browser-client.ts
+++ b/apps/os/src/lib/itx-stream-browser-client.ts
@@ -8,8 +8,9 @@ import type {
 type StreamSubscribeInput = Parameters<StreamRpc["subscribe"]>[0];
 
 export type ItxStreamForBrowserRuntime = {
-  append(args: { streamPath?: string; event: StreamEventInput }): Promise<StreamEvent>;
-  appendBatch(args: { streamPath?: string; events: StreamEventInput[] }): Promise<StreamEvent[]>;
+  append(args: { event: StreamEventInput }): Promise<StreamEvent>;
+  appendBatch(args: { events: StreamEventInput[] }): Promise<StreamEvent[]>;
+  at(streamPath: string): ItxStreamForBrowserRuntime;
   runtimeState(): Promise<StreamRuntimeState>;
   getProcessorRuntimeState(
     args: Parameters<StreamRpc["getProcessorRuntimeState"]>[0],
@@ -29,6 +30,7 @@ export function itxStreamBrowserClient(stream: ItxStreamForBrowserRuntime): Brow
   return {
     append: (args) => stream.append(args),
     appendBatch: (args) => stream.appendBatch(args),
+    at: (streamPath) => itxStreamBrowserClient(stream.at(streamPath)),
     runtimeState: () => stream.runtimeState(),
     getProcessorRuntimeState: (args) =>
       stream.getProcessorRuntimeState(args) as Promise<

--- a/apps/streams-example-app/e2e/vitest/stream-capnweb.test.ts
+++ b/apps/streams-example-app/e2e/vitest/stream-capnweb.test.ts
@@ -128,20 +128,18 @@ describe("stream capnweb protocol", () => {
     },
   );
 
-  // Cross-stream append must land on the same leading-slash DO name the rest of the
-  // system uses. The regressed `#resolveStream` stripped the leading slash, so an event
-  // appended via `streamPath` went to `default:e2e/.../child` while a reader connects to
-  // `default:/e2e/.../child` — a different, empty stream. These prove path resolution.
-  e2eIt('append resolves relative child paths ("child" and "./child")', async () => {
+  // Cross-stream navigation must land on the same leading-slash DO name the rest of the
+  // system uses. The regressed resolver stripped the leading slash, so an event
+  // appended via a relative path went to `default:e2e/.../child` while a reader connects
+  // to `default:/e2e/.../child` — a different, empty stream. These prove path resolution.
+  e2eIt('at resolves relative child paths ("child" and "./child")', async () => {
     const base = e2eStreamPathLabel("e2e/resolve-child");
     using parent = withStreamConnectionFromNode({ url: toStreamWebSocketUrl({ path: base }) });
 
-    const viaBare = await parent.stream.append({
-      streamPath: "child",
+    const viaBare = await parent.stream.at("child").append({
       event: { type: "test.stream.resolve", payload: { kind: "bare" } },
     });
-    const viaDot = await parent.stream.append({
-      streamPath: "./child",
+    const viaDot = await parent.stream.at("./child").append({
       event: { type: "test.stream.resolve", payload: { kind: "dot" } },
     });
 
@@ -159,14 +157,13 @@ describe("stream capnweb protocol", () => {
     expect(parentEvents.some((event) => event.type === "test.stream.resolve")).toBe(false);
   });
 
-  e2eIt("append resolves an absolute /root/path", async () => {
+  e2eIt("at resolves an absolute /root/path", async () => {
     const unique = crypto.randomUUID();
     const base = e2eStreamPath(`/e2e/resolve-abs-${unique}`);
     const target = e2eStreamPath(`/e2e/resolve-abs-target-${unique}`);
     using parent = withStreamConnectionFromNode({ url: toStreamWebSocketUrl({ path: base }) });
 
-    const appended = await parent.stream.append({
-      streamPath: target,
+    const appended = await parent.stream.at(target).append({
       event: { type: "test.stream.resolve", payload: { kind: "absolute" } },
     });
 
@@ -180,15 +177,14 @@ describe("stream capnweb protocol", () => {
     expect(parentEvents.some((event) => event.type === "test.stream.resolve")).toBe(false);
   });
 
-  e2eIt("append resolves ..-relative parent, grandparent and mixed paths", async () => {
+  e2eIt("at resolves ..-relative parent, grandparent and mixed paths", async () => {
     const root = e2eStreamPathLabel("e2e/resolve-up");
     using current = withStreamConnectionFromNode({
       url: toStreamWebSocketUrl({ path: `${root}/a/b/c` }),
     });
 
     // ../parent -> {root}/a/b/parent
-    const toParent = await current.stream.append({
-      streamPath: "../parent",
+    const toParent = await current.stream.at("../parent").append({
       event: { type: "test.stream.resolve", payload: { kind: "parent" } },
     });
     using parentStream = withStreamConnectionFromNode({
@@ -199,8 +195,7 @@ describe("stream capnweb protocol", () => {
     );
 
     // ../../grandparent -> {root}/a/grandparent
-    const toGrand = await current.stream.append({
-      streamPath: "../../grandparent",
+    const toGrand = await current.stream.at("../../grandparent").append({
       event: { type: "test.stream.resolve", payload: { kind: "grandparent" } },
     });
     using grandStream = withStreamConnectionFromNode({
@@ -209,8 +204,7 @@ describe("stream capnweb protocol", () => {
     await expect(grandStream.stream.getEvents({ afterOffset: 0 })).resolves.toContainEqual(toGrand);
 
     // ../../grandparent/.././bla normalizes to {root}/a/bla
-    const toMixed = await current.stream.append({
-      streamPath: "../../grandparent/.././bla",
+    const toMixed = await current.stream.at("../../grandparent/.././bla").append({
       event: { type: "test.stream.resolve", payload: { kind: "mixed" } },
     });
     using blaStream = withStreamConnectionFromNode({
@@ -219,14 +213,13 @@ describe("stream capnweb protocol", () => {
     await expect(blaStream.stream.getEvents({ afterOffset: 0 })).resolves.toContainEqual(toMixed);
   });
 
-  e2eIt("append rejects a streamPath that escapes the stream root", async () => {
+  e2eIt("at rejects a streamPath that escapes the stream root", async () => {
     // base has depth 2 ([e2e, resolve-escape-...]); three `..` pops past the root.
     const base = e2eStreamPathLabel("e2e/resolve-escape");
     using parent = withStreamConnectionFromNode({ url: toStreamWebSocketUrl({ path: base }) });
 
     await expect(
-      parent.stream.append({
-        streamPath: "../../../too-far",
+      parent.stream.at("../../../too-far").append({
         event: { type: "test.stream.resolve", payload: { kind: "escape" } },
       }),
     ).rejects.toThrow();

--- a/apps/streams-example-app/src/lib/capnweb-stream-browser-client.ts
+++ b/apps/streams-example-app/src/lib/capnweb-stream-browser-client.ts
@@ -24,6 +24,7 @@ export const createCapnwebStreamClient: BrowserStreamClientFactory = async (
   return {
     append: (appendArgs) => connection.stream.append(appendArgs),
     appendBatch: (appendArgs) => connection.stream.appendBatch(appendArgs),
+    at: (streamPath) => connection.stream.at(streamPath) as BrowserStreamClient,
     runtimeState: () => connection.stream.runtimeState(),
     getProcessorRuntimeState: (runtimeStateArgs) =>
       connection.stream.getProcessorRuntimeState(runtimeStateArgs),


### PR DESCRIPTION
## What changed

- Removed `streamPath` from `append` and `appendBatch` on stream targets.
- Added `at(streamPath)` to return the stream target at an absolute or relative path.
- Updated stream processors, itx wrappers, browser adapters, docs, and tests to use `stream.at(path).append({ event })`.
- Made generated stream `RpcTarget` source references non-enumerable so returned targets serialize correctly across Workers RPC.

## Why

Appending should be pinned to the stream target the caller holds. Cross-stream targeting now happens explicitly by resolving a target first, which makes the stream RPC surface smaller and less ambiguous.

## Validation

- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/streams-example-app typecheck`
- `pnpm --dir apps/os test:streams-workers`
- `pnpm --dir apps/os exec vitest run src/domains/streams/engine/stream-processor.test.ts src/domains/slack/stream-processors/slack/slack.test.ts src/domains/slack/stream-processors/slack-agent/slack-agent.test.ts src/domains/projects/stream-processors/project/implementation.test.ts`
- `pnpm exec oxlint apps/os/src/domains/streams/engine apps/os/src/domains/projects/stream-processors/project apps/os/src/domains/slack/stream-processors/slack apps/os/src/itx apps/os/src/lib/itx-stream-browser-client.ts apps/streams-example-app/src/lib/capnweb-stream-browser-client.ts apps/streams-example-app/e2e/vitest/stream-capnweb.test.ts --threads 1 --deny-warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking change to core stream append/navigation used by processors, ITX, and clients; incorrect path resolution would route events to the wrong Durable Object, though dedicated e2e coverage targets the prior leading-slash bug.
> 
> **Overview**
> Stream RPC **no longer accepts `streamPath` on `append` / `appendBatch`**. Cross-stream writes go through **`at(streamPath)`**, which returns a target pinned to an absolute or relative path (`child`, `./child`, `../sibling`); local appends stay on the handle you hold.
> 
> The **Stream Durable Object** exposes public **`at`**, resolves paths with the existing leading-slash rules, and returns **`StreamRpcTarget`** stubs (local or remote DO). **`at` is on the public RPC allowlist**. Processors (project birth certificates, Slack routing, core ancestor announcements), **ITX `ItxStream`**, **browser adapters**, docs, and **e2e path-resolution tests** are updated to the new shape.
> 
> **`makeRpcTargetClass`** stores the wrapped **`source` as non-enumerable** so RpcTarget instances serialize cleanly across Workers RPC without leaking the inner object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a426c8871ae809c9cfbe4fd7afd0c7a6ac773b77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "deployed",
      "updatedAt": "2026-06-18T12:17:56.122Z",
      "headSha": "a426c8871ae809c9cfbe4fd7afd0c7a6ac773b77",
      "message": null,
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27758726632",
      "shortSha": "a426c88",
      "deployDurationMs": 24918,
      "testDurationMs": 318
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "deployed",
      "updatedAt": "2026-06-18T12:18:16.556Z",
      "headSha": "a426c8871ae809c9cfbe4fd7afd0c7a6ac773b77",
      "message": null,
      "publicUrl": "https://streams-example-app-preview-3.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27758726632",
      "shortSha": "a426c88",
      "deployDurationMs": 19034,
      "testDurationMs": 20747
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "deployed",
      "updatedAt": "2026-06-18T12:19:41.472Z",
      "headSha": "a426c8871ae809c9cfbe4fd7afd0c7a6ac773b77",
      "message": null,
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27758726632",
      "shortSha": "a426c88",
      "deployDurationMs": 58705,
      "testDurationMs": 105660
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_3",
    "leasedUntil": 1781788586478,
    "leaseId": "941cd54d-d221-4c1e-928b-97b1b2cdbe99",
    "slug": "preview-3",
    "type": "environment-config-lease"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>Lease: preview-3 | Doppler config: preview_3 | Type: environment-config-lease | Leased until: 2026-06-18T13:16:26.478Z</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | deployed | `a426c88` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 24.9s | 318ms |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/27758726632) | 2026-06-18T12:17:56.122Z |  |
| OS | deployed | `a426c88` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 58.7s | 105.7s |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/27758726632) | 2026-06-18T12:19:41.472Z |  |
| Streams Example App | deployed | `a426c88` | [https://streams-example-app-preview-3.iterate-dev-preview.workers.dev](https://streams-example-app-preview-3.iterate-dev-preview.workers.dev) | 19.0s | 20.7s |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/27758726632) | 2026-06-18T12:18:16.556Z |  |

</details>
<!-- /CLOUDFLARE_PREVIEW -->