### PR TITLE
Run Playwright specs after OS preview deploy

### DIFF
--- a/.github/ts-workflows/workflows/cloudflare-previews.ts
+++ b/.github/ts-workflows/workflows/cloudflare-previews.ts
@@ -1,4 +1,4 @@
-import type { Step, Workflow } from "@jlarky/gha-ts/workflow-types";
+import { uses, type Step, type Workflow } from "@jlarky/gha-ts/workflow-types";
 import {
   cloudflarePreviewApps,
   cloudflarePreviewAdditionalTriggerPaths,
@@ -147,8 +147,25 @@ function createPreviewLifecycleJob(input: {
         ? [createDopplerStep({ command: input.command, name: commandStepName })]
         : []),
       ...(input.dopplerFollowUps ?? []).map((followUp) => createDopplerStep(followUp)),
+      ...(input.command === "deploy" ? createPreviewTestArtifactSteps() : []),
     ],
   } satisfies Workflow["jobs"][string];
+}
+
+function createPreviewTestArtifactSteps(): Step[] {
+  return Object.values(cloudflarePreviewApps).flatMap((app) => {
+    if (!app.previewTestArtifacts) return [];
+
+    return {
+      name: `Upload ${app.displayName} preview test artifacts`,
+      if: "always() && github.event.pull_request.head.repo.fork != true",
+      ...uses("actions/upload-artifact@v4", {
+        name: `preview-${app.slug}-test-artifacts`,
+        path: app.previewTestArtifacts.join("\n"),
+        "if-no-files-found": "ignore",
+      }),
+    };
+  });
 }
 
 export default {

--- a/.github/ts-workflows/workflows/cloudflare-previews.ts
+++ b/.github/ts-workflows/workflows/cloudflare-previews.ts
@@ -147,6 +147,8 @@ function createPreviewLifecycleJob(input: {
         ? [createDopplerStep({ command: input.command, name: commandStepName })]
         : []),
       ...(input.dopplerFollowUps ?? []).map((followUp) => createDopplerStep(followUp)),
+      // TODO: Split deploy/test and cleanup lifecycle helpers so test-only
+      // behavior does not need to branch on the lifecycle command.
       ...(input.command === "deploy" ? createPreviewTestArtifactSteps() : []),
     ],
   } satisfies Workflow["jobs"][string];

--- a/.github/workflows/cloudflare-previews.yml
+++ b/.github/workflows/cloudflare-previews.yml
@@ -105,6 +105,13 @@ jobs:
             --pull-request-number "${{ github.event.pull_request.number }}" \
             --repository-full-name "${{ github.repository }}" \
             --workflow-run-url "$WORKFLOW_RUN_URL"
+      - name: Upload OS preview test artifacts
+        if: always() && github.event.pull_request.head.repo.fork != true
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-os-test-artifacts
+          path: test-results
+          if-no-files-found: ignore
   cleanup:
     if: github.event.action == 'closed' && github.event.pull_request.head.repo.fork != true
     name: Preview / cleanup

--- a/.github/workflows/cloudflare-previews.yml
+++ b/.github/workflows/cloudflare-previews.yml
@@ -110,7 +110,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: preview-os-test-artifacts
-          path: test-results
+          path: |-
+            test-results
+            apps/os/test-results
+            /tmp/os-e2e-*
+            /tmp/os-itx-e2e-*
           if-no-files-found: ignore
   cleanup:
     if: github.event.action == 'closed' && github.event.pull_request.head.repo.fork != true

--- a/scripts/preview/apps.ts
+++ b/scripts/preview/apps.ts
@@ -64,7 +64,12 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     // OS bakes auth JWKS during deployment, so the slot's auth deployment must
     // finish before OS deploy starts.
     previewDependencies: ["auth"],
-    previewTestArtifacts: ["test-results"],
+    previewTestArtifacts: [
+      "test-results",
+      "apps/os/test-results",
+      "/tmp/os-e2e-*",
+      "/tmp/os-itx-e2e-*",
+    ],
     previewTestBaseUrlEnvVar: "OS_BASE_URL",
     // The itx e2e (node project only — the browser project needs a Playwright
     // chromium install the preview e2e job doesn't have) reads

--- a/scripts/preview/apps.ts
+++ b/scripts/preview/apps.ts
@@ -67,11 +67,14 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     // The itx e2e (node project only — the browser project needs a Playwright
     // chromium install the preview e2e job doesn't have) reads
     // APP_CONFIG_BASE_URL + APP_CONFIG_ADMIN_API_SECRET from the leased
-    // preview Doppler config, same as the preview smoke.
+    // preview Doppler config, same as the preview smoke. Root Playwright specs
+    // run after those Vitest lanes, using the same preview Doppler config.
     previewTestCommandArgs: [
       "bash",
       "-c",
       [
+        "set -euo pipefail",
+        "pnpm --dir ../.. exec playwright install chromium",
         'pnpm e2e -t "OS preview smoke" & smoke_pid=$!',
         // Keep the catalogue matrix out of the broad file-parallel run: mixing
         // both forms of parallelism in one Vitest process overloaded preview
@@ -86,6 +89,7 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
         'wait "$itx_pid" || itx_status=$?',
         'wait "$matrix_pid" || matrix_status=$?',
         'if [ "$smoke_status" -ne 0 ] || [ "$itx_status" -ne 0 ] || [ "$matrix_status" -ne 0 ]; then exit 1; fi',
+        "pnpm --dir ../.. spec",
       ].join("; "),
     ],
   },

--- a/scripts/preview/apps.ts
+++ b/scripts/preview/apps.ts
@@ -82,20 +82,9 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
       [
         "set -euo pipefail",
         "pnpm --dir ../.. exec playwright install chromium",
-        'pnpm e2e -t "OS preview smoke" & smoke_pid=$!',
-        // Keep the catalogue matrix out of the broad file-parallel run: mixing
-        // both forms of parallelism in one Vitest process overloaded preview
-        // workers in probes. Start it after a short delay so its setup overlaps
-        // the broad phase's tail without hitting the initial worker burst.
-        "OS_ITX_E2E_FILE_PARALLELISM=true OS_ITX_E2E_EGRESS_CONCURRENT=true OS_ITX_E2E_LIVE_CONCURRENT=true OS_ITX_E2E_SKIP_MATRIX=true pnpm e2e:itx --project node & itx_pid=$!",
-        "(sleep ${OS_ITX_E2E_MATRIX_DELAY_SECONDS:-20}; pnpm e2e:itx --project node src/itx/e2e/itx.e2e.test.ts -t 'catalogue example') & matrix_pid=$!",
-        "smoke_status=0",
-        "itx_status=0",
-        "matrix_status=0",
-        'wait "$smoke_pid" || smoke_status=$?',
-        'wait "$itx_pid" || itx_status=$?',
-        'wait "$matrix_pid" || matrix_status=$?',
-        'if [ "$smoke_status" -ne 0 ] || [ "$itx_status" -ne 0 ] || [ "$matrix_status" -ne 0 ]; then exit 1; fi',
+        'pnpm e2e -t "OS preview smoke"',
+        "OS_ITX_E2E_FILE_PARALLELISM=true OS_ITX_E2E_EGRESS_CONCURRENT=true OS_ITX_E2E_LIVE_CONCURRENT=true OS_ITX_E2E_SKIP_MATRIX=true pnpm e2e:itx --project node",
+        "pnpm e2e:itx --project node src/itx/e2e/itx.e2e.test.ts -t 'catalogue example'",
         "pnpm --dir ../.. spec",
       ].join("; "),
     ],

--- a/scripts/preview/apps.ts
+++ b/scripts/preview/apps.ts
@@ -16,6 +16,7 @@ export type CloudflarePreviewApp = {
   /** Readiness probe path on the app's public URL (default /api/__internal/health). */
   previewReadyUrlPath?: string;
   previewTestBaseUrlEnvVar: string;
+  previewTestArtifacts?: readonly [string, ...string[]];
   previewTestCommandArgs: readonly [string, ...string[]];
 };
 
@@ -63,6 +64,7 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     // OS bakes auth JWKS during deployment, so the slot's auth deployment must
     // finish before OS deploy starts.
     previewDependencies: ["auth"],
+    previewTestArtifacts: ["test-results"],
     previewTestBaseUrlEnvVar: "OS_BASE_URL",
     // The itx e2e (node project only — the browser project needs a Playwright
     // chromium install the preview e2e job doesn't have) reads

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -71,17 +71,21 @@ describe("preview test commands", () => {
   it("runs root Playwright specs after OS preview Vitest lanes", () => {
     const script = cloudflarePreviewApps.os.previewTestCommandArgs[2];
     const playwrightInstall = "pnpm --dir ../.. exec playwright install chromium";
+    const smoke = 'pnpm e2e -t "OS preview smoke"';
+    const broadItx =
+      "OS_ITX_E2E_FILE_PARALLELISM=true OS_ITX_E2E_EGRESS_CONCURRENT=true OS_ITX_E2E_LIVE_CONCURRENT=true OS_ITX_E2E_SKIP_MATRIX=true pnpm e2e:itx --project node";
+    const matrix = "pnpm e2e:itx --project node src/itx/e2e/itx.e2e.test.ts -t 'catalogue example'";
     const playwrightSpec = "pnpm --dir ../.. spec";
-    const vitestStatusGate =
-      'if [ "$smoke_status" -ne 0 ] || [ "$itx_status" -ne 0 ] || [ "$matrix_status" -ne 0 ]; then exit 1; fi';
 
     expect(script).toContain(playwrightInstall);
+    expect(script).toContain(smoke);
+    expect(script).toContain(broadItx);
+    expect(script).toContain(matrix);
     expect(script).toContain(playwrightSpec);
-    expect(script).toContain(vitestStatusGate);
-    expect(script.indexOf(playwrightInstall)).toBeLessThan(
-      script.indexOf('pnpm e2e -t "OS preview smoke" & smoke_pid=$!'),
-    );
-    expect(script.indexOf(playwrightSpec)).toBeGreaterThan(script.indexOf(vitestStatusGate));
+    expect(script.indexOf(playwrightInstall)).toBeLessThan(script.indexOf(smoke));
+    expect(script.indexOf(smoke)).toBeLessThan(script.indexOf(broadItx));
+    expect(script.indexOf(broadItx)).toBeLessThan(script.indexOf(matrix));
+    expect(script.indexOf(matrix)).toBeLessThan(script.indexOf(playwrightSpec));
   });
 });
 

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -57,6 +57,17 @@ describe("preview workflow scope", () => {
 });
 
 describe("preview test commands", () => {
+  it("uploads both Playwright and Vitest artifacts for OS preview failures", () => {
+    expect(cloudflarePreviewApps.os).toMatchObject({
+      previewTestArtifacts: [
+        "test-results",
+        "apps/os/test-results",
+        "/tmp/os-e2e-*",
+        "/tmp/os-itx-e2e-*",
+      ],
+    });
+  });
+
   it("runs root Playwright specs after OS preview Vitest lanes", () => {
     const script = cloudflarePreviewApps.os.previewTestCommandArgs[2];
     const playwrightInstall = "pnpm --dir ../.. exec playwright install chromium";

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -56,6 +56,24 @@ describe("preview workflow scope", () => {
   });
 });
 
+describe("preview test commands", () => {
+  it("runs root Playwright specs after OS preview Vitest lanes", () => {
+    const script = cloudflarePreviewApps.os.previewTestCommandArgs[2];
+    const playwrightInstall = "pnpm --dir ../.. exec playwright install chromium";
+    const playwrightSpec = "pnpm --dir ../.. spec";
+    const vitestStatusGate =
+      'if [ "$smoke_status" -ne 0 ] || [ "$itx_status" -ne 0 ] || [ "$matrix_status" -ne 0 ]; then exit 1; fi';
+
+    expect(script).toContain(playwrightInstall);
+    expect(script).toContain(playwrightSpec);
+    expect(script).toContain(vitestStatusGate);
+    expect(script.indexOf(playwrightInstall)).toBeLessThan(
+      script.indexOf('pnpm e2e -t "OS preview smoke" & smoke_pid=$!'),
+    );
+    expect(script.indexOf(playwrightSpec)).toBeGreaterThan(script.indexOf(vitestStatusGate));
+  });
+});
+
 describe("preview readiness URLs", () => {
   it("checks the deployed app URL without probing synthetic project hostnames", () => {
     expect(

--- a/tasks/complete/2026-06-18-os-preview-playwright-spec-ci.md
+++ b/tasks/complete/2026-06-18-os-preview-playwright-spec-ci.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 size: small
 ---
 
@@ -7,7 +7,7 @@ size: small
 
 ## Status Summary
 
-Implementation is complete and pushed to draft PR #1564. The OS preview test lane now runs root Playwright specs after the existing Vitest preview checks, workflow generation is clean, and focused validation passes; the remaining proof is the PR's actual preview CI run.
+Done in draft PR #1564. The OS preview test lane now runs root Playwright specs after the existing Vitest preview checks, workflow generation is clean, focused validation passes, and the PR's Cloudflare Previews check passed.
 
 ## Assumptions
 
@@ -24,6 +24,7 @@ Implementation is complete and pushed to draft PR #1564. The OS preview test lan
 - [x] Regenerate generated GitHub workflow YAML. _`pnpm workflows` completed; no generated YAML changed because the existing preview workflow already executes the preview runner._
 - [x] Run targeted validation for workflow generation and affected preview tests. _Passed `pnpm --dir .github/ts-workflows build`, `pnpm workflows`, formatter check, and `pnpm --dir apps/os exec vitest run --root ../.. scripts/preview/preview.test.ts`._
 - [x] Push branch and keep the draft PR updated. _Draft PR #1564 is open with the implementation commit pushed and the body updated with the CI shape plus local validation._
+- [x] Confirm preview CI. _Cloudflare Previews run 27769347493 passed; the OS preview test log showed the Playwright `Running 2 tests using 1 worker` / `2 passed` block before `[preview] test passed: os`._
 
 ## Implementation Notes
 
@@ -31,3 +32,4 @@ Implementation is complete and pushed to draft PR #1564. The OS preview test lan
 - Current `.github/workflows/cloudflare-previews.yml` is generated from `.github/ts-workflows/workflows/cloudflare-previews.ts`.
 - Preview configs use underscores (`preview_N`), not hyphenated names.
 - The first focused Vitest attempt from the repo root failed because `vitest` is not installed at root. The working command uses the OS workspace binary with `--root ../..`.
+- Full PR check rollup passed after the final push: Preview deploy/e2e, lint-typecheck, test, Generate Workflows, and autofix.

--- a/tasks/complete/2026-06-18-os-preview-playwright-spec-ci.md
+++ b/tasks/complete/2026-06-18-os-preview-playwright-spec-ci.md
@@ -33,3 +33,4 @@ Done in draft PR #1564. The OS preview test lane now runs root Playwright specs 
 - Preview configs use underscores (`preview_N`), not hyphenated names.
 - The first focused Vitest attempt from the repo root failed because `vitest` is not installed at root. The working command uses the OS workspace binary with `--root ../..`.
 - Full PR check rollup passed after the final push: Preview deploy/e2e, lint-typecheck, test, Generate Workflows, and autofix.
+- Follow-up after run 27773132640: the OS itx matrix failed before root Playwright ran, and the artifact upload step found no `test-results` directory. OS preview artifacts now include the Vitest `/tmp/os-e2e-*` and `/tmp/os-itx-e2e-*` run roots as well as Playwright result directories.

--- a/tasks/complete/2026-06-18-os-preview-playwright-spec-ci.md
+++ b/tasks/complete/2026-06-18-os-preview-playwright-spec-ci.md
@@ -34,3 +34,4 @@ Done in draft PR #1564. The OS preview test lane now runs root Playwright specs 
 - The first focused Vitest attempt from the repo root failed because `vitest` is not installed at root. The working command uses the OS workspace binary with `--root ../..`.
 - Full PR check rollup passed after the final push: Preview deploy/e2e, lint-typecheck, test, Generate Workflows, and autofix.
 - Follow-up after run 27773132640: the OS itx matrix failed before root Playwright ran, and the artifact upload step found no `test-results` directory. OS preview artifacts now include the Vitest `/tmp/os-e2e-*` and `/tmp/os-itx-e2e-*` run roots as well as Playwright result directories.
+- Follow-up after run 27775715377: artifacts uploaded correctly, but OS e2e still failed under concurrent smoke/broad-itx/matrix load. The OS preview command now runs those phases sequentially before root Playwright to reduce preview-slot pressure.

--- a/tasks/os-preview-playwright-spec-ci.md
+++ b/tasks/os-preview-playwright-spec-ci.md
@@ -7,7 +7,7 @@ size: small
 
 ## Status Summary
 
-Implementation is mostly complete. The OS preview test lane now runs root Playwright specs after the existing Vitest preview checks, workflow generation is clean, and focused validation passes; the branch still needs its implementation commit pushed.
+Implementation is complete and pushed to draft PR #1564. The OS preview test lane now runs root Playwright specs after the existing Vitest preview checks, workflow generation is clean, and focused validation passes; the remaining proof is the PR's actual preview CI run.
 
 ## Assumptions
 
@@ -23,7 +23,7 @@ Implementation is mostly complete. The OS preview test lane now runs root Playwr
 - [x] Add Playwright specs to the OS preview test lane after preview deployment. _`scripts/preview/apps.ts` now installs Chromium and runs root `pnpm spec` after the existing OS Vitest preview lanes._
 - [x] Regenerate generated GitHub workflow YAML. _`pnpm workflows` completed; no generated YAML changed because the existing preview workflow already executes the preview runner._
 - [x] Run targeted validation for workflow generation and affected preview tests. _Passed `pnpm --dir .github/ts-workflows build`, `pnpm workflows`, formatter check, and `pnpm --dir apps/os exec vitest run --root ../.. scripts/preview/preview.test.ts`._
-- [ ] Push branch and keep the draft PR updated.
+- [x] Push branch and keep the draft PR updated. _Draft PR #1564 is open with the implementation commit pushed and the body updated with the CI shape plus local validation._
 
 ## Implementation Notes
 

--- a/tasks/os-preview-playwright-spec-ci.md
+++ b/tasks/os-preview-playwright-spec-ci.md
@@ -7,7 +7,7 @@ size: small
 
 ## Status Summary
 
-Early task definition is complete. Implementation still needs to wire root Playwright specs into the OS preview test lane, regenerate the workflow, and verify the generated YAML/checks.
+Implementation is mostly complete. The OS preview test lane now runs root Playwright specs after the existing Vitest preview checks, workflow generation is clean, and focused validation passes; the branch still needs its implementation commit pushed.
 
 ## Assumptions
 
@@ -19,13 +19,15 @@ Early task definition is complete. Implementation still needs to wire root Playw
 
 ## Checklist
 
-- [ ] Inspect existing preview deployment/test workflow and command generation.
-- [ ] Add Playwright specs to the OS preview test lane after preview deployment.
-- [ ] Regenerate generated GitHub workflow YAML.
-- [ ] Run targeted validation for workflow generation and affected preview tests.
+- [x] Inspect existing preview deployment/test workflow and command generation. _The preview CLI stores the leased `preview_N` config in PR state and runs app tests under `doppler run --project <app> --config preview_N`._
+- [x] Add Playwright specs to the OS preview test lane after preview deployment. _`scripts/preview/apps.ts` now installs Chromium and runs root `pnpm spec` after the existing OS Vitest preview lanes._
+- [x] Regenerate generated GitHub workflow YAML. _`pnpm workflows` completed; no generated YAML changed because the existing preview workflow already executes the preview runner._
+- [x] Run targeted validation for workflow generation and affected preview tests. _Passed `pnpm --dir .github/ts-workflows build`, `pnpm workflows`, formatter check, and `pnpm --dir apps/os exec vitest run --root ../.. scripts/preview/preview.test.ts`._
 - [ ] Push branch and keep the draft PR updated.
 
 ## Implementation Notes
 
 - Root `playwright.config.ts` uses `APP_CONFIG_BASE_URL` when present, otherwise it tries to start local OS dev. Running under `doppler run --project os --config preview_N` should therefore target the deployed preview rather than local dev.
 - Current `.github/workflows/cloudflare-previews.yml` is generated from `.github/ts-workflows/workflows/cloudflare-previews.ts`.
+- Preview configs use underscores (`preview_N`), not hyphenated names.
+- The first focused Vitest attempt from the repo root failed because `vitest` is not installed at root. The working command uses the OS workspace binary with `--root ../..`.

--- a/tasks/os-preview-playwright-spec-ci.md
+++ b/tasks/os-preview-playwright-spec-ci.md
@@ -1,0 +1,31 @@
+---
+status: in-progress
+size: small
+---
+
+# Run OS Playwright Specs After Preview Deploy
+
+## Status Summary
+
+Early task definition is complete. Implementation still needs to wire root Playwright specs into the OS preview test lane, regenerate the workflow, and verify the generated YAML/checks.
+
+## Assumptions
+
+- The root `pnpm spec` command is the Playwright spec lane to add to preview CI.
+- Specs should run after the OS preview deployment has completed and the deployed URL is known.
+- The specs should run under the leased OS Doppler config, e.g. `doppler run --project os --config preview_N -- pnpm spec`, so `APP_CONFIG_BASE_URL`, auth, and admin secrets come from the deployed preview environment.
+- Existing preview Vitest e2e coverage should keep running; this change should add Playwright coverage, not replace the current `pnpm preview test` OS checks.
+- Fork PRs cannot access Doppler secrets, so Playwright specs should be skipped there just like the current Doppler-only preview e2e step.
+
+## Checklist
+
+- [ ] Inspect existing preview deployment/test workflow and command generation.
+- [ ] Add Playwright specs to the OS preview test lane after preview deployment.
+- [ ] Regenerate generated GitHub workflow YAML.
+- [ ] Run targeted validation for workflow generation and affected preview tests.
+- [ ] Push branch and keep the draft PR updated.
+
+## Implementation Notes
+
+- Root `playwright.config.ts` uses `APP_CONFIG_BASE_URL` when present, otherwise it tries to start local OS dev. Running under `doppler run --project os --config preview_N` should therefore target the deployed preview rather than local dev.
+- Current `.github/workflows/cloudflare-previews.yml` is generated from `.github/ts-workflows/workflows/cloudflare-previews.ts`.


### PR DESCRIPTION
## Summary

- Run root Playwright specs as part of the OS preview test lane after the preview deployment and existing Vitest preview checks.
- Execute the specs from the repo root under the leased `os/preview_N` Doppler config, so `APP_CONFIG_BASE_URL`, auth, and admin secrets target the deployed preview.
- Upload OS preview test artifacts from both Playwright result directories and Vitest `/tmp/os-*` run roots.
- Run OS preview smoke, broad itx, catalogue matrix, and Playwright sequentially to avoid overloading the preview slot.

## Expected CI shape

```bash
doppler run --project os --config preview_N -- pnpm --dir ../.. spec
```

The generated GitHub workflow YAML changed only for artifact upload paths. `cloudflare-previews.yml` already runs `pnpm preview test`; this PR changes the OS test command that runner executes.

## Diagnosis Notes

- Run 27773132640 failed in the existing OS itx catalogue matrix before root Playwright ran: `extend-child-context` hit a disconnected live capability. Artifact upload found no `test-results`, so there were no artifacts.
- Run 27775715377 confirmed the artifact fix: `preview-os-test-artifacts` uploaded, but concurrent OS smoke/broad-itx/matrix execution still overloaded the preview slot (`WebSocket connection failed`, project creation stuck in `onboarding: in-progress`).
- The final fix runs OS preview phases sequentially before root Playwright.

## Validation

- `pnpm workflows`
- `pnpm --dir .github/ts-workflows build`
- `pnpm --dir apps/os exec vitest run --root ../.. scripts/preview/preview.test.ts`
- `pnpm exec oxfmt --check scripts/preview/apps.ts scripts/preview/preview.test.ts tasks/complete/2026-06-18-os-preview-playwright-spec-ci.md .github/workflows/cloudflare-previews.yml`
- PR Cloudflare Previews run 27776100026 passed: `Preview / deploy + e2e` completed successfully, OS preview tests passed, and `preview-os-test-artifacts` uploaded as artifact ID 7730504968.