### PR TITLE
Upload preview test artifacts

### DIFF
--- a/.github/ts-workflows/workflows/cloudflare-previews.ts
+++ b/.github/ts-workflows/workflows/cloudflare-previews.ts
@@ -1,4 +1,4 @@
-import type { Step, Workflow } from "@jlarky/gha-ts/workflow-types";
+import { uses, type Step, type Workflow } from "@jlarky/gha-ts/workflow-types";
 import {
   cloudflarePreviewApps,
   cloudflarePreviewAdditionalTriggerPaths,
@@ -147,8 +147,25 @@ function createPreviewLifecycleJob(input: {
         ? [createDopplerStep({ command: input.command, name: commandStepName })]
         : []),
       ...(input.dopplerFollowUps ?? []).map((followUp) => createDopplerStep(followUp)),
+      ...(input.command === "deploy" ? createPreviewTestArtifactSteps() : []),
     ],
   } satisfies Workflow["jobs"][string];
+}
+
+function createPreviewTestArtifactSteps(): Step[] {
+  return Object.values(cloudflarePreviewApps).flatMap((app) => {
+    if (!app.previewTestArtifacts) return [];
+
+    return {
+      name: `Upload ${app.displayName} preview test artifacts`,
+      if: "always() && github.event.pull_request.head.repo.fork != true",
+      ...uses("actions/upload-artifact@v4", {
+        name: `preview-${app.slug}-test-artifacts`,
+        path: app.previewTestArtifacts.join("\n"),
+        "if-no-files-found": "ignore",
+      }),
+    };
+  });
 }
 
 export default {

--- a/.github/workflows/cloudflare-previews.yml
+++ b/.github/workflows/cloudflare-previews.yml
@@ -105,6 +105,13 @@ jobs:
             --pull-request-number "${{ github.event.pull_request.number }}" \
             --repository-full-name "${{ github.repository }}" \
             --workflow-run-url "$WORKFLOW_RUN_URL"
+      - name: Upload OS preview test artifacts
+        if: always() && github.event.pull_request.head.repo.fork != true
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-os-test-artifacts
+          path: test-results
+          if-no-files-found: ignore
   cleanup:
     if: github.event.action == 'closed' && github.event.pull_request.head.repo.fork != true
     name: Preview / cleanup

--- a/scripts/preview/apps.ts
+++ b/scripts/preview/apps.ts
@@ -16,6 +16,7 @@ export type CloudflarePreviewApp = {
   /** Readiness probe path on the app's public URL (default /api/__internal/health). */
   previewReadyUrlPath?: string;
   previewTestBaseUrlEnvVar: string;
+  previewTestArtifacts?: readonly [string, ...string[]];
   previewTestCommandArgs: readonly [string, ...string[]];
 };
 
@@ -63,6 +64,7 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     // OS bakes auth JWKS during deployment, so the slot's auth deployment must
     // finish before OS deploy starts.
     previewDependencies: ["auth"],
+    previewTestArtifacts: ["test-results"],
     previewTestBaseUrlEnvVar: "OS_BASE_URL",
     // The itx e2e (node project only — the browser project needs a Playwright
     // chromium install the preview e2e job doesn't have) reads


### PR DESCRIPTION
## Summary

- Adds `previewTestArtifacts` to Cloudflare preview app config.
- Configures the OS preview app to upload `test-results` after preview e2e runs.
- Regenerates the Cloudflare Previews workflow with an `actions/upload-artifact@v4` step so flaky Playwright screenshots, videos, and error contexts are visible from Actions.

## Verification

- `pnpm workflows`
- `pnpm exec oxlint .github/ts-workflows/workflows/cloudflare-previews.ts scripts/preview/apps.ts --deny-warnings`
- `pnpm --dir .github/ts-workflows build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow and preview config only; no runtime app or auth changes.
> 
> **Overview**
> Preview deploy jobs can now **upload Playwright/e2e output** to GitHub Actions artifacts when tests fail or flake, instead of losing screenshots and traces on the runner.
> 
> A new optional **`previewTestArtifacts`** field on each Cloudflare preview app drives this: the workflow generator emits an **`actions/upload-artifact@v4`** step per app that defines paths, only on the **deploy** lifecycle job (after preview e2e), with **`always()`** so uploads still run on test failure, **`if-no-files-found: ignore`**, and the same **non-fork** guard as other Doppler steps. **OS** is configured to upload **`test-results`** as **`preview-os-test-artifacts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d29cde8209d9f854fcd60dbf3808ff62e8ef0515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-06-18T16:14:47.420Z",
      "headSha": "d29cde8209d9f854fcd60dbf3808ff62e8ef0515",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27772411723",
      "shortSha": "d29cde8",
      "cleanupDurationMs": 10823,
      "deployDurationMs": 39481
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-18T16:14:49.573Z",
      "headSha": "d29cde8209d9f854fcd60dbf3808ff62e8ef0515",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27772411723",
      "shortSha": "d29cde8",
      "cleanupDurationMs": 12973,
      "deployDurationMs": 32294
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-06-18T16:14:44.364Z",
      "headSha": "d29cde8209d9f854fcd60dbf3808ff62e8ef0515",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-2.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27772411723",
      "shortSha": "d29cde8",
      "cleanupDurationMs": 7761,
      "deployDurationMs": 35227
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-18T16:14:35.053Z",
      "headSha": "d29cde8209d9f854fcd60dbf3808ff62e8ef0515",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27772411723",
      "shortSha": "d29cde8",
      "cleanupDurationMs": 42216,
      "deployDurationMs": 105861
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `d29cde8` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 32.3s |  | 13.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/27772411723) | 2026-06-18T16:14:49.573Z | Preview app released. |
| OS | released | `d29cde8` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 105.9s |  | 42.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/27772411723) | 2026-06-18T16:14:35.053Z | Preview app released. |
| Semaphore | released | `d29cde8` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 39.5s |  | 10.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/27772411723) | 2026-06-18T16:14:47.420Z | Preview app released. |
| Streams Example App | released | `d29cde8` | [https://streams-example-app-preview-2.iterate-dev-preview.workers.dev](https://streams-example-app-preview-2.iterate-dev-preview.workers.dev) | 35.2s |  | 7.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/27772411723) | 2026-06-18T16:14:44.364Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->