### PR TITLE
Split preview lifecycle workflow helpers

### DIFF
--- a/.github/ts-workflows/workflows/cloudflare-previews.ts
+++ b/.github/ts-workflows/workflows/cloudflare-previews.ts
@@ -72,7 +72,7 @@ function createCommonPreviewArguments(input: {
   ];
 }
 
-function createDopplerStep(input: { command: string; name: string }): Step {
+function createDopplerPreviewStep(input: { name: string; run: string }): Step {
   return {
     if: "github.event.pull_request.head.repo.fork != true",
     name: input.name,
@@ -82,33 +82,14 @@ function createDopplerStep(input: { command: string; name: string }): Step {
       WORKFLOW_RUN_URL:
         "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
     },
-    run: createPreviewCommand({
-      command: input.command,
-      includePullRequestBaseSha: input.command === "deploy",
-      includePullRequestHeadRefName: input.command === "deploy",
-      includePullRequestHeadSha: input.command !== "cleanup",
-      includePullRequestIsFork: input.command === "deploy",
-      includeWorkflowRunUrl: input.command !== "cleanup",
-      prefix: "doppler run --project _shared --config prd -- ",
-    }),
+    run: input.run,
   };
 }
 
-function createPreviewLifecycleJob(input: {
-  command: string;
-  /** Step name for the main command; defaults to the job name. */
-  commandStepName?: string;
-  /** Doppler-only commands run in the same job after the main command, sharing its runner and setup. */
-  dopplerFollowUps?: Array<{ command: string; name: string }>;
-  if: string;
-  name: string;
-  runsOnDoppler?: boolean;
-  runsOnForks?: boolean;
-}) {
-  const commandStepName = input.commandStepName ?? input.name;
-  const forkStep: Step = {
+function createForkPreviewDeployStep(): Step {
+  return {
     if: "github.event.pull_request.head.repo.fork == true",
-    name: `${commandStepName} for forks`,
+    name: "Preview / deploy for forks",
     env: {
       GITHUB_TOKEN: "${{ secrets.ITERATE_BOT_GITHUB_TOKEN || github.token }}",
       SEMAPHORE_BASE_URL: "https://semaphore.iterate.com",
@@ -116,16 +97,55 @@ function createPreviewLifecycleJob(input: {
         "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
     },
     run: createPreviewCommand({
-      command: input.command,
-      includePullRequestBaseSha: input.command === "deploy",
-      includePullRequestHeadRefName: input.command === "deploy",
-      includePullRequestHeadSha: input.command !== "cleanup",
-      includePullRequestIsFork: input.command === "deploy",
+      command: "deploy",
+      includePullRequestBaseSha: true,
+      includePullRequestHeadRefName: true,
+      includePullRequestHeadSha: true,
+      includePullRequestIsFork: true,
       includeSemaphoreBaseUrl: true,
       includeWorkflowRunUrl: true,
     }),
   };
+}
 
+function createDopplerPreviewDeployStep(): Step {
+  return createDopplerPreviewStep({
+    name: "Preview / deploy",
+    run: createPreviewCommand({
+      command: "deploy",
+      includePullRequestBaseSha: true,
+      includePullRequestHeadRefName: true,
+      includePullRequestHeadSha: true,
+      includePullRequestIsFork: true,
+      includeWorkflowRunUrl: true,
+      prefix: "doppler run --project _shared --config prd -- ",
+    }),
+  });
+}
+
+function createDopplerPreviewTestStep(): Step {
+  return createDopplerPreviewStep({
+    name: "Preview / e2e",
+    run: createPreviewCommand({
+      command: "test",
+      includePullRequestHeadSha: true,
+      includeWorkflowRunUrl: true,
+      prefix: "doppler run --project _shared --config prd -- ",
+    }),
+  });
+}
+
+function createDopplerPreviewCleanupStep(): Step {
+  return createDopplerPreviewStep({
+    name: "Preview / cleanup",
+    run: createPreviewCommand({
+      command: "cleanup",
+      prefix: "doppler run --project _shared --config prd -- ",
+    }),
+  });
+}
+
+function createPreviewLifecycleJob(input: { if: string; name: string; steps: Step[] }) {
   return {
     if: input.if,
     name: input.name,
@@ -142,16 +162,30 @@ function createPreviewLifecycleJob(input: {
         ...utils.installDopplerCli,
         if: "github.event.pull_request.head.repo.fork != true",
       },
-      ...(input.runsOnForks ? [forkStep] : []),
-      ...(input.runsOnDoppler
-        ? [createDopplerStep({ command: input.command, name: commandStepName })]
-        : []),
-      ...(input.dopplerFollowUps ?? []).map((followUp) => createDopplerStep(followUp)),
-      // TODO: Split deploy/test and cleanup lifecycle helpers so test-only
-      // behavior does not need to branch on the lifecycle command.
-      ...(input.command === "deploy" ? createPreviewTestArtifactSteps() : []),
+      ...input.steps,
     ],
   } satisfies Workflow["jobs"][string];
+}
+
+function createPreviewDeployAndTestJob() {
+  return createPreviewLifecycleJob({
+    if: "github.event.action != 'closed'",
+    name: "Preview / deploy + e2e",
+    steps: [
+      createForkPreviewDeployStep(),
+      createDopplerPreviewDeployStep(),
+      createDopplerPreviewTestStep(),
+      ...createPreviewTestArtifactSteps(),
+    ],
+  });
+}
+
+function createPreviewCleanupJob() {
+  return createPreviewLifecycleJob({
+    if: "github.event.action == 'closed' && github.event.pull_request.head.repo.fork != true",
+    name: "Preview / cleanup",
+    steps: [createDopplerPreviewCleanupStep()],
+  });
 }
 
 function createPreviewTestArtifactSteps(): Step[] {
@@ -190,20 +224,7 @@ export default {
     // Deploy and e2e share one job: a separate e2e job paid ~80s of runner
     // pickup plus checkout/install before running a single test. The e2e step
     // is doppler-only, so forks still deploy and simply skip it.
-    preview: createPreviewLifecycleJob({
-      command: "deploy",
-      commandStepName: "Preview / deploy",
-      dopplerFollowUps: [{ command: "test", name: "Preview / e2e" }],
-      if: "github.event.action != 'closed'",
-      name: "Preview / deploy + e2e",
-      runsOnDoppler: true,
-      runsOnForks: true,
-    }),
-    cleanup: createPreviewLifecycleJob({
-      command: "cleanup",
-      if: "github.event.action == 'closed' && github.event.pull_request.head.repo.fork != true",
-      name: "Preview / cleanup",
-      runsOnDoppler: true,
-    }),
+    preview: createPreviewDeployAndTestJob(),
+    cleanup: createPreviewCleanupJob(),
   },
 } satisfies Workflow;


### PR DESCRIPTION
## Summary

- Splits the Cloudflare preview workflow helper into explicit deploy+e2e and cleanup job builders.
- Replaces command-derived branches with named step factories for fork deploy, Doppler deploy, Doppler e2e, and Doppler cleanup.
- Removes the temporary TODO from #1564; generated workflow YAML is unchanged.

## Verification

- `pnpm workflows`
- `pnpm exec oxlint .github/ts-workflows/workflows/cloudflare-previews.ts --deny-warnings`
- `pnpm --dir .github/ts-workflows build`
- `git diff --check`

Stacked on #1564.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generator-only refactor with no intended change to emitted GitHub Actions behavior; risk is limited to accidental YAML drift if step ordering or flags were mis-copied.
> 
> **Overview**
> Refactors **`cloudflare-previews.ts`** so preview jobs are built from explicit step factories instead of a single `createPreviewLifecycleJob` that branched on `command`, `runsOnDoppler`, `runsOnForks`, and `dopplerFollowUps`.
> 
> **`createDopplerPreviewStep`** now takes a pre-built `run` string; fork deploy, Doppler deploy, e2e, and cleanup each have their own named helpers. **`createPreviewLifecycleJob`** only wires shared setup (checkout, Doppler CLI) plus a `steps` array. **`createPreviewDeployAndTestJob`** and **`createPreviewCleanupJob`** replace the old parameterized job definitions at the export site.
> 
> The TODO about splitting deploy/test vs cleanup helpers is removed. Per the PR description, generated workflow YAML is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acf8c6ca3de727eca88759adcca8b68c55bbebba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-06-18T16:56:02.174Z",
      "headSha": "acf8c6ca3de727eca88759adcca8b68c55bbebba",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27773467452",
      "shortSha": "acf8c6c",
      "cleanupDurationMs": 12907,
      "deployDurationMs": 38507,
      "testDurationMs": 5690
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-18T16:56:01.901Z",
      "headSha": "acf8c6ca3de727eca88759adcca8b68c55bbebba",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27773467452",
      "shortSha": "acf8c6c",
      "cleanupDurationMs": 12631,
      "deployDurationMs": 45338,
      "testDurationMs": 529
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-06-18T16:55:57.120Z",
      "headSha": "acf8c6ca3de727eca88759adcca8b68c55bbebba",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-2.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27773467452",
      "shortSha": "acf8c6c",
      "cleanupDurationMs": 7848,
      "deployDurationMs": 21836,
      "testDurationMs": 21808
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-18T16:55:47.961Z",
      "headSha": "acf8c6ca3de727eca88759adcca8b68c55bbebba",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27773467452",
      "shortSha": "acf8c6c",
      "cleanupDurationMs": 50151,
      "deployDurationMs": 94726,
      "testDurationMs": 125841
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `acf8c6c` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 45.3s | 529ms | 12.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/27773467452) | 2026-06-18T16:56:01.901Z | Preview app released. |
| OS | released | `acf8c6c` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 94.7s | 125.8s | 50.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/27773467452) | 2026-06-18T16:55:47.961Z | Preview app released. |
| Semaphore | released | `acf8c6c` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 38.5s | 5.7s | 12.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/27773467452) | 2026-06-18T16:56:02.174Z | Preview app released. |
| Streams Example App | released | `acf8c6c` | [https://streams-example-app-preview-2.iterate-dev-preview.workers.dev](https://streams-example-app-preview-2.iterate-dev-preview.workers.dev) | 21.8s | 21.8s | 7.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/27773467452) | 2026-06-18T16:55:57.120Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->