### PR TITLE
Add login hints to direct users into email or Google sign-in

### DIFF
--- a/apps/auth/src/lib/client.ts
+++ b/apps/auth/src/lib/client.ts
@@ -38,6 +38,8 @@ type LogoutOptions = {
 type LoginOptions = {
   /** Destination after OAuth callback. Defaults to the current origin. */
   returnTo?: string;
+  /** Preferred sign-in method for the auth server login page. */
+  loginHint?: "email" | "google";
 };
 
 type RefreshOptions = {
@@ -86,6 +88,9 @@ export function createIterateAuthClient(config: IterateAuthClientConfig = {}) {
       const url = new URL(`${base}/login`, window.location.origin);
       if (options.returnTo) {
         url.searchParams.set("return_to", options.returnTo);
+      }
+      if (options.loginHint) {
+        url.searchParams.set("login_hint", options.loginHint);
       }
       window.location.href = url.toString();
     },

--- a/apps/auth/src/lib/server.ts
+++ b/apps/auth/src/lib/server.ts
@@ -527,6 +527,10 @@ export function createAuthHandler(config: IterateAuthConfig, infra: OAuthInfra) 
     url.searchParams.set("nonce", nonce);
     url.searchParams.set("code_challenge", challenge);
     url.searchParams.set("code_challenge_method", "S256");
+    const loginHint = normalizeLoginHint(requestURL.searchParams.get("login_hint"));
+    if (loginHint) {
+      url.searchParams.set("login_hint", loginHint);
+    }
 
     setCookie(
       c,
@@ -809,6 +813,10 @@ function localLoopbackCanonicalLoginURL(requestURL: URL, redirectURI: string) {
   if (!isLocalLoopbackHostname(redirectURL.hostname)) return null;
 
   return new URL(`${requestURL.pathname}${requestURL.search}`, redirectURL.origin);
+}
+
+function normalizeLoginHint(value: string | null) {
+  return value === "email" || value === "google" ? value : null;
 }
 
 function isLocalLoopbackHostname(hostname: string) {

--- a/apps/auth/src/lib/server.ts
+++ b/apps/auth/src/lib/server.ts
@@ -527,8 +527,8 @@ export function createAuthHandler(config: IterateAuthConfig, infra: OAuthInfra) 
     url.searchParams.set("nonce", nonce);
     url.searchParams.set("code_challenge", challenge);
     url.searchParams.set("code_challenge_method", "S256");
-    const loginHint = normalizeLoginHint(requestURL.searchParams.get("login_hint"));
-    if (loginHint) {
+    const loginHint = requestURL.searchParams.get("login_hint");
+    if (loginHint === "email" || loginHint === "google") {
       url.searchParams.set("login_hint", loginHint);
     }
 
@@ -813,10 +813,6 @@ function localLoopbackCanonicalLoginURL(requestURL: URL, redirectURI: string) {
   if (!isLocalLoopbackHostname(redirectURL.hostname)) return null;
 
   return new URL(`${requestURL.pathname}${requestURL.search}`, redirectURL.origin);
-}
-
-function normalizeLoginHint(value: string | null) {
-  return value === "email" || value === "google" ? value : null;
 }
 
 function isLocalLoopbackHostname(hostname: string) {

--- a/apps/auth/src/routes/login.tsx
+++ b/apps/auth/src/routes/login.tsx
@@ -177,13 +177,27 @@ function LoginActions({
   }, []);
 
   useEffect(() => {
+    let googleHintAlreadyConsumed = false;
+    try {
+      googleHintAlreadyConsumed =
+        sessionStorage.getItem("iterate-auth-google-login-hint") === window.location.href;
+    } catch {
+      googleHintAlreadyConsumed = false;
+    }
+
     if (
       isHydrated &&
       loginHint === "google" &&
       !consumedGoogleHint.current &&
+      !googleHintAlreadyConsumed &&
       !googleSignInPending
     ) {
       consumedGoogleHint.current = true;
+      try {
+        sessionStorage.setItem("iterate-auth-google-login-hint", window.location.href);
+      } catch {
+        // Ignore storage failures; the in-memory ref still prevents same-mount retries.
+      }
       signInWithGoogle();
     }
   }, [googleSignInPending, isHydrated, loginHint, signInWithGoogle]);

--- a/apps/auth/src/routes/login.tsx
+++ b/apps/auth/src/routes/login.tsx
@@ -47,9 +47,11 @@ function RouteComponent() {
   const { emailOtpEnabled, session } = Route.useLoaderData();
   const signedInSession = session && isOAuthProviderFlowSearch(search) ? session : null;
   const loginHint =
-    !signedInSession && (search.login_hint === "email" || search.login_hint === "google")
+    !signedInSession && search.login_hint === "email" && emailOtpEnabled
       ? search.login_hint
-      : undefined;
+      : !signedInSession && search.login_hint === "google"
+        ? search.login_hint
+        : undefined;
 
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
@@ -163,10 +165,10 @@ function LoginActions({
   const [isHydrated, setIsHydrated] = useState(false);
   const consumedGoogleHint = useRef(false);
   const { isPending: googleSignInPending, mutate: signInWithGoogle } = useMutation({
-    mutationFn: () =>
+    mutationFn: async () =>
       authClient.signIn.social({
         provider: "google",
-        callbackURL: redirectTo,
+        callbackURL: await getPostLoginRedirectUrl(redirectTo),
       }),
   });
 

--- a/apps/auth/src/routes/login.tsx
+++ b/apps/auth/src/routes/login.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ChangeEvent } from "react";
+import { useEffect, useRef, useState, type ChangeEvent } from "react";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import { useMutation } from "@tanstack/react-query";
@@ -28,6 +28,7 @@ const getLoginState = createServerFn({ method: "GET" }).handler(({ context }) =>
 export const Route = createFileRoute("/login")({
   validateSearch: z.looseObject({
     redirect: z.string().optional(),
+    login_hint: z.enum(["email", "google"]).optional().catch(undefined),
     sig: z.string().optional(),
   }),
   beforeLoad: async ({ search }) => {
@@ -45,6 +46,10 @@ function RouteComponent() {
   const redirectTo = safeRedirectPath(search.redirect);
   const { emailOtpEnabled, session } = Route.useLoaderData();
   const signedInSession = session && isOAuthProviderFlowSearch(search) ? session : null;
+  const loginHint =
+    !signedInSession && (search.login_hint === "email" || search.login_hint === "google")
+      ? search.login_hint
+      : undefined;
 
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
@@ -64,7 +69,11 @@ function RouteComponent() {
           {signedInSession ? (
             <SignedInAccountCard redirectTo={redirectTo} session={signedInSession} />
           ) : (
-            <LoginActions redirectTo={redirectTo} emailOtpEnabled={emailOtpEnabled} />
+            <LoginActions
+              redirectTo={redirectTo}
+              emailOtpEnabled={emailOtpEnabled}
+              loginHint={loginHint}
+            />
           )}
         </CardContent>
       </Card>
@@ -144,13 +153,16 @@ function SignedInAccountCard({
 function LoginActions({
   redirectTo,
   emailOtpEnabled,
+  loginHint,
 }: {
   redirectTo: string;
   emailOtpEnabled: boolean;
+  loginHint?: "email" | "google";
 }) {
-  const [emailMode, setEmailMode] = useState(false);
+  const [emailMode, setEmailMode] = useState(loginHint === "email" && emailOtpEnabled);
   const [isHydrated, setIsHydrated] = useState(false);
-  const googleSignIn = useMutation({
+  const consumedGoogleHint = useRef(false);
+  const { isPending: googleSignInPending, mutate: signInWithGoogle } = useMutation({
     mutationFn: () =>
       authClient.signIn.social({
         provider: "google",
@@ -161,6 +173,18 @@ function LoginActions({
   useEffect(() => {
     setIsHydrated(true);
   }, []);
+
+  useEffect(() => {
+    if (
+      isHydrated &&
+      loginHint === "google" &&
+      !consumedGoogleHint.current &&
+      !googleSignInPending
+    ) {
+      consumedGoogleHint.current = true;
+      signInWithGoogle();
+    }
+  }, [googleSignInPending, isHydrated, loginHint, signInWithGoogle]);
 
   return (
     <div className="space-y-4" data-hydrated={isHydrated}>
@@ -187,12 +211,12 @@ function LoginActions({
             className="w-full"
             variant="outline"
             size="lg"
-            disabled={googleSignIn.isPending || !isHydrated}
+            disabled={googleSignInPending || !isHydrated}
             data-testid="google-login-button"
-            onClick={() => googleSignIn.mutate()}
+            onClick={() => signInWithGoogle()}
           >
             <GoogleIcon />
-            {googleSignIn.isPending ? "Redirecting..." : "Continue with Google"}
+            {googleSignInPending ? "Redirecting..." : "Continue with Google"}
           </Button>
         </>
       ) : null}

--- a/apps/auth/src/server/worker.ts
+++ b/apps/auth/src/server/worker.ts
@@ -125,7 +125,8 @@ app.all("*", (c) =>
 export function preserveOAuthResourceRedirect(request: Request, response: Response) {
   const requestUrl = new URL(request.url);
   const paramNames = [OAUTH_RESOURCE_PARAMETER];
-  if (isLoginHint(requestUrl.searchParams.get("login_hint"))) {
+  const loginHint = requestUrl.searchParams.get("login_hint");
+  if (loginHint === "email" || loginHint === "google") {
     paramNames.push("login_hint");
   }
   return preserveRedirectSearchParams(request, response, paramNames);
@@ -162,10 +163,6 @@ function preserveRedirectSearchParams(
     statusText: response.statusText,
     headers,
   });
-}
-
-function isLoginHint(value: string | null) {
-  return value === "email" || value === "google";
 }
 
 export default app;

--- a/apps/auth/src/server/worker.ts
+++ b/apps/auth/src/server/worker.ts
@@ -123,7 +123,12 @@ app.all("*", (c) =>
 );
 
 export function preserveOAuthResourceRedirect(request: Request, response: Response) {
-  return preserveRedirectSearchParams(request, response, [OAUTH_RESOURCE_PARAMETER]);
+  const requestUrl = new URL(request.url);
+  const paramNames = [OAUTH_RESOURCE_PARAMETER];
+  if (isLoginHint(requestUrl.searchParams.get("login_hint"))) {
+    paramNames.push("login_hint");
+  }
+  return preserveRedirectSearchParams(request, response, paramNames);
 }
 
 function preserveRedirectSearchParams(
@@ -157,6 +162,10 @@ function preserveRedirectSearchParams(
     statusText: response.statusText,
     headers,
   });
+}
+
+function isLoginHint(value: string | null) {
+  return value === "email" || value === "google";
 }
 
 export default app;

--- a/apps/os/alchemy.run.ts
+++ b/apps/os/alchemy.run.ts
@@ -167,6 +167,10 @@ const env: Record<string, string | undefined> = {
     process.env.APP_CONFIG_ITERATE_AUTH__CLIENT_ID ?? process.env.ITERATE_OAUTH_CLIENT_ID,
   APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET:
     process.env.APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET ?? process.env.ITERATE_OAUTH_CLIENT_SECRET,
+  APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED:
+    process.env.APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED ??
+    process.env.VITE_ENABLE_EMAIL_OTP_SIGNIN ??
+    (process.env.ALCHEMY_STAGE?.startsWith("dev") ? "true" : undefined),
   APP_CONFIG_ITERATE_AUTH__JWKS: await resolveStaticAuthJwks(resolvedAuthIssuer),
   APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN:
     process.env.APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN ?? process.env.ITERATE_AUTH_SERVICE_TOKEN,

--- a/apps/os/src/auth/iterate-auth-login.test.ts
+++ b/apps/os/src/auth/iterate-auth-login.test.ts
@@ -41,6 +41,30 @@ describe("iterate auth login", () => {
     expect(location.searchParams.get("state")).toBeTruthy();
   });
 
+  it("forwards valid login hints to the auth worker authorization request", async () => {
+    const handler = testAuthHandler(config);
+
+    const response = await handler(
+      new Request("http://localhost:65455/api/iterate-auth/login?login_hint=google"),
+    );
+
+    expect(response.status).toBe(302);
+    const location = new URL(response.headers.get("location") ?? "");
+    expect(location.searchParams.get("login_hint")).toBe("google");
+  });
+
+  it("drops unknown login hints from the auth worker authorization request", async () => {
+    const handler = testAuthHandler(config);
+
+    const response = await handler(
+      new Request("http://localhost:65455/api/iterate-auth/login?login_hint=github"),
+    );
+
+    expect(response.status).toBe(302);
+    const location = new URL(response.headers.get("location") ?? "");
+    expect(location.searchParams.get("login_hint")).toBeNull();
+  });
+
   it("resolves relative return paths against the configured public return origin", async () => {
     const handler = testAuthHandler({
       ...config,

--- a/apps/os/src/config.ts
+++ b/apps/os/src/config.ts
@@ -74,6 +74,7 @@ export const AppConfig = z.object({
       jwks: JSONWebKeySet.optional(),
       serviceToken: redacted(z.string().trim().min(1)).optional(),
       resource: publicValue(z.url()).optional(),
+      emailOtpEnabled: publicValue(z.boolean().default(false)),
     })
     .optional(),
   openAiApiKey: redacted(z.string().trim().min(1)),

--- a/apps/os/src/routes/sign-in.$.tsx
+++ b/apps/os/src/routes/sign-in.$.tsx
@@ -26,9 +26,14 @@ function SignInRoute() {
   const returnTo = safeRedirectPath(redirectUrl);
   const [redirectingTo, setRedirectingTo] = useState<"email" | "google" | null>(null);
 
-  function startSignIn(loginHint: "email" | "google") {
-    setRedirectingTo(loginHint);
-    signIn({ returnTo, loginHint });
+  function startEmailSignIn() {
+    setRedirectingTo("email");
+    signIn({ returnTo });
+  }
+
+  function startGoogleSignIn() {
+    setRedirectingTo("google");
+    signIn({ returnTo, loginHint: "google" });
   }
 
   return (
@@ -45,7 +50,7 @@ function SignInRoute() {
             variant="outline"
             size="lg"
             disabled={redirectingTo !== null}
-            onClick={() => startSignIn("email")}
+            onClick={startEmailSignIn}
           >
             <MailIcon className="size-4" />
             {redirectingTo === "email" ? "Redirecting..." : "Sign in with email"}
@@ -55,7 +60,7 @@ function SignInRoute() {
             variant="outline"
             size="lg"
             disabled={redirectingTo !== null}
-            onClick={() => startSignIn("google")}
+            onClick={startGoogleSignIn}
           >
             <GoogleIcon />
             {redirectingTo === "google" ? "Redirecting..." : "Sign in with Google"}

--- a/apps/os/src/routes/sign-in.$.tsx
+++ b/apps/os/src/routes/sign-in.$.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
+import { extractPublicConfigSchema } from "@iterate-com/shared/config";
 import { z } from "zod";
 import { MailIcon } from "lucide-react";
 import { useAuthClient } from "@iterate-com/auth/client";
@@ -12,18 +13,27 @@ import {
   CardTitle,
 } from "@iterate-com/ui/components/card";
 import { Separator } from "@iterate-com/ui/components/separator";
+import { AppConfig } from "../config.ts";
+import { getPublicConfigServerFn } from "~/lib/public-route-config.ts";
+
+const PublicConfigSchema = extractPublicConfigSchema(AppConfig);
 
 export const Route = createFileRoute("/sign-in/$")({
   validateSearch: z.looseObject({
     redirect_url: z.string().optional(),
+  }),
+  loader: async () => ({
+    config: PublicConfigSchema.parse(JSON.parse(await getPublicConfigServerFn())),
   }),
   component: SignInRoute,
 });
 
 function SignInRoute() {
   const { signIn } = useAuthClient();
+  const { config } = Route.useLoaderData();
   const { redirect_url: redirectUrl } = Route.useSearch();
   const returnTo = safeRedirectPath(redirectUrl);
+  const emailOtpEnabled = config.iterateAuth?.emailOtpEnabled ?? false;
   const [redirectingTo, setRedirectingTo] = useState<"email" | "google" | null>(null);
 
   function startEmailSignIn() {
@@ -45,16 +55,18 @@ function SignInRoute() {
         </CardHeader>
         <Separator />
         <CardContent className="space-y-3 pt-6">
-          <Button
-            className="w-full border-border bg-background text-foreground shadow-sm transition-colors hover:bg-muted"
-            variant="outline"
-            size="lg"
-            disabled={redirectingTo !== null}
-            onClick={startEmailSignIn}
-          >
-            <MailIcon className="size-4" />
-            {redirectingTo === "email" ? "Redirecting..." : "Sign in with email"}
-          </Button>
+          {emailOtpEnabled ? (
+            <Button
+              className="w-full border-border bg-background text-foreground shadow-sm transition-colors hover:bg-muted"
+              variant="outline"
+              size="lg"
+              disabled={redirectingTo !== null}
+              onClick={startEmailSignIn}
+            >
+              <MailIcon className="size-4" />
+              {redirectingTo === "email" ? "Redirecting..." : "Sign in with email"}
+            </Button>
+          ) : null}
           <Button
             className="w-full"
             variant="outline"

--- a/apps/os/src/routes/sign-in.$.tsx
+++ b/apps/os/src/routes/sign-in.$.tsx
@@ -28,7 +28,7 @@ function SignInRoute() {
 
   function startEmailSignIn() {
     setRedirectingTo("email");
-    signIn({ returnTo });
+    signIn({ returnTo, loginHint: "email" });
   }
 
   function startGoogleSignIn() {

--- a/apps/os/src/routes/sign-in.$.tsx
+++ b/apps/os/src/routes/sign-in.$.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
+import { MailIcon } from "lucide-react";
 import { useAuthClient } from "@iterate-com/auth/client";
 import { Button } from "@iterate-com/ui/components/button";
 import {
@@ -10,6 +11,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@iterate-com/ui/components/card";
+import { Separator } from "@iterate-com/ui/components/separator";
 
 export const Route = createFileRoute("/sign-in/$")({
   validateSearch: z.looseObject({
@@ -22,30 +24,68 @@ function SignInRoute() {
   const { signIn } = useAuthClient();
   const { redirect_url: redirectUrl } = Route.useSearch();
   const returnTo = safeRedirectPath(redirectUrl);
-  const [redirecting, setRedirecting] = useState(false);
+  const [redirectingTo, setRedirectingTo] = useState<"email" | "google" | null>(null);
+
+  function startSignIn(loginHint: "email" | "google") {
+    setRedirectingTo(loginHint);
+    signIn({ returnTo, loginHint });
+  }
 
   return (
-    <main className="grid min-h-svh place-items-center bg-background p-4">
+    <main className="flex min-h-screen items-center justify-center p-4">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
-          <CardTitle className="text-xl">Sign in to OS</CardTitle>
-          <CardDescription>Continue with Iterate to open your projects.</CardDescription>
+          <CardTitle className="text-xl">Sign in</CardTitle>
+          <CardDescription>Sign in to your Iterate account</CardDescription>
         </CardHeader>
-        <CardContent>
+        <Separator />
+        <CardContent className="space-y-3 pt-6">
+          <Button
+            className="w-full border-border bg-background text-foreground shadow-sm transition-colors hover:bg-muted"
+            variant="outline"
+            size="lg"
+            disabled={redirectingTo !== null}
+            onClick={() => startSignIn("email")}
+          >
+            <MailIcon className="size-4" />
+            {redirectingTo === "email" ? "Redirecting..." : "Sign in with email"}
+          </Button>
           <Button
             className="w-full"
+            variant="outline"
             size="lg"
-            disabled={redirecting}
-            onClick={() => {
-              setRedirecting(true);
-              signIn({ returnTo });
-            }}
+            disabled={redirectingTo !== null}
+            onClick={() => startSignIn("google")}
           >
-            {redirecting ? "Redirecting…" : "Continue with Iterate"}
+            <GoogleIcon />
+            {redirectingTo === "google" ? "Redirecting..." : "Sign in with Google"}
           </Button>
         </CardContent>
       </Card>
     </main>
+  );
+}
+
+function GoogleIcon() {
+  return (
+    <svg className="size-4" viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </svg>
   );
 }
 


### PR DESCRIPTION
## Summary
- Add a `login_hint` flow through auth client, worker, and login UI so callers can preselect email or Google sign-in.
- Preserve valid hints across redirects and normalize them before forwarding to the auth authorization request.
- Update the OS sign-in page to surface separate email and Google buttons and pass the selected hint through.
- Add tests covering forwarding and rejection of invalid login hints.

## Testing
- Added unit coverage for login-hint forwarding and validation in the auth worker flow.
- UI behavior updated in the sign-in route to reflect the selected provider and redirect state.
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes login and OAuth redirect behavior across auth and OS, but hints are whitelisted and invalid values are dropped rather than passed through.
> 
> **Overview**
> Adds an optional **`login_hint`** (`email` | `google`) so apps can send users straight to the right sign-in path instead of a generic login screen.
> 
> The auth client passes **`login_hint`** on `/api/iterate-auth/login`; the iterate-auth handler only forwards allowed values to the authorization URL. The auth app login route reads the hint: **email** opens the OTP flow by default (when OTP is enabled), and **google** auto-starts Google sign-in with **sessionStorage** guards to avoid redirect loops. OAuth authorize redirects now **preserve** `login_hint` alongside the existing resource parameter.
> 
> OS exposes **`iterateAuth.emailOtpEnabled`** in public config (wired in alchemy for local dev), and the sign-in page shows separate **email** and **Google** buttons that call `signIn` with the matching hint. Unit tests cover valid hint forwarding and rejection of unknown hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c1a83f26e0586502fb0a1d50026901dac4c4e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-19T11:58:43.298Z",
      "headSha": "6c1a83f26e0586502fb0a1d50026901dac4c4e74",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27823016220",
      "shortSha": "6c1a83f",
      "cleanupDurationMs": 14250,
      "deployDurationMs": 26904,
      "testDurationMs": 341
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-19T11:58:28.094Z",
      "headSha": "6c1a83f26e0586502fb0a1d50026901dac4c4e74",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/27823016220",
      "shortSha": "6c1a83f",
      "cleanupDurationMs": 44991,
      "deployDurationMs": 62101,
      "testDurationMs": 254646
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `6c1a83f` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 26.9s | 341ms | 14.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/27823016220) | 2026-06-19T11:58:43.298Z | Preview app released. |
| OS | released | `6c1a83f` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 62.1s | 254.6s | 45.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/27823016220) | 2026-06-19T11:58:28.094Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->