### PR TITLE
Add lint rule for single-use type colocation

### DIFF
--- a/.github/ts-workflows/utils/index.ts
+++ b/.github/ts-workflows/utils/index.ts
@@ -47,6 +47,14 @@ export const getSetupRepo = ({ ref }: { ref?: string } = {}) =>
 /** checkout, setup pnpm, setup node, install dependencies */
 export const setupRepo = getSetupRepo();
 
+export const installDopplerCli = {
+  name: "Install Doppler CLI",
+  run: [
+    'for i in 1 2 3; do curl -sfLS https://cli.doppler.com/install.sh | sh -s -- --no-package-manager && break; echo "Attempt $i failed, retrying in 5s..."; sleep 5; done',
+    "doppler --version || { echo 'Failed to install Doppler CLI after 3 attempts'; exit 1; }",
+  ].join("\n"),
+} as const satisfies Step;
+
 type DopplerConfigName =
   | `dev_${string}`
   | `preview_${string}`
@@ -55,14 +63,6 @@ type DopplerConfigName =
   | "prd"
   | `\${{ ${string} }}`;
 type DopplerProjectName = string;
-
-export const installDopplerCli = {
-  name: "Install Doppler CLI",
-  run: [
-    'for i in 1 2 3; do curl -sfLS https://cli.doppler.com/install.sh | sh -s -- --no-package-manager && break; echo "Attempt $i failed, retrying in 5s..."; sleep 5; done',
-    "doppler --version || { echo 'Failed to install Doppler CLI after 3 attempts'; exit 1; }",
-  ].join("\n"),
-} as const satisfies Step;
 
 export const setupDoppler = ({
   config,

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -120,6 +120,7 @@
     "iterate/no-implied-eval": "error",
     "iterate/stream-processor-override-args": "error",
     "iterate/no-single-use-helpers": "error",
+    "iterate/colocate-single-use-types": "error",
     "prefer-const": "off",
     "iterate/prefer-const": "error",
     "iterate/isolated-codemode": [

--- a/apps/auth/src/lib/client.ts
+++ b/apps/auth/src/lib/client.ts
@@ -20,21 +20,6 @@ export type PublicSessionResponse =
   | { authenticated: false }
   | Pick<Extract<SessionResponse, { authenticated: true }>, "authenticated" | "session" | "user">;
 
-type IterateAuthClientConfig = {
-  /** Base path where the auth handler is mounted, e.g. "/api/iterate-auth" (Default) */
-  authHandlerBasePath?: string;
-};
-
-type LogoutOptions = {
-  /**
-   * Also sign out of the upstream auth server. This must use browser navigation
-   * so the auth server can clear its own HttpOnly cookies.
-   */
-  global?: boolean;
-  /** Destination after logout. Defaults to the current origin. */
-  returnTo?: string;
-};
-
 type LoginOptions = {
   /** Destination after OAuth callback. Defaults to the current origin. */
   returnTo?: string;
@@ -65,7 +50,20 @@ export type AuthClientProviderProps = {
   signOutReturnTo?: string | (() => string);
 };
 
-const AuthClientContext = createContext<AuthClientContextValue | null>(null);
+type IterateAuthClientConfig = {
+  /** Base path where the auth handler is mounted, e.g. "/api/iterate-auth" (Default) */
+  authHandlerBasePath?: string;
+};
+
+type LogoutOptions = {
+  /**
+   * Also sign out of the upstream auth server. This must use browser navigation
+   * so the auth server can clear its own HttpOnly cookies.
+   */
+  global?: boolean;
+  /** Destination after logout. Defaults to the current origin. */
+  returnTo?: string;
+};
 
 export function createIterateAuthClient(config: IterateAuthClientConfig = {}) {
   const base = (config.authHandlerBasePath ?? "/api/iterate-auth").replace(/\/$/, "");
@@ -106,6 +104,8 @@ export function createIterateAuthClient(config: IterateAuthClientConfig = {}) {
     },
   };
 }
+
+const AuthClientContext = createContext<AuthClientContextValue | null>(null);
 
 const defaultAuthClient = createIterateAuthClient();
 

--- a/apps/os/e2e/vitest/agents.itx.e2e.test.ts
+++ b/apps/os/e2e/vitest/agents.itx.e2e.test.ts
@@ -33,17 +33,6 @@ type SlackChannel = {
   name: string;
 };
 
-type SlackConversationsListResponse =
-  | {
-      channels: SlackChannel[];
-      ok: true;
-      response_metadata?: { next_cursor?: string };
-    }
-  | {
-      error?: string;
-      ok: false;
-    };
-
 const itIfSlackBotToken = process.env.APP_CONFIG_SLACK_BOT_TOKEN?.trim() ? test : test.skip;
 
 test("can configure Cloudflare AI Gateway as the provider for an agent stream", async () => {
@@ -1083,6 +1072,17 @@ async function postSlackMessage(input: { channel: string; text: string; token: s
   }
   return result;
 }
+
+type SlackConversationsListResponse =
+  | {
+      channels: SlackChannel[];
+      ok: true;
+      response_metadata?: { next_cursor?: string };
+    }
+  | {
+      error?: string;
+      ok: false;
+    };
 
 async function listSlackChannels(token: string) {
   const channels: SlackChannel[] = [];

--- a/apps/os/scripts/dev.ts
+++ b/apps/os/scripts/dev.ts
@@ -40,13 +40,6 @@ export type StartOptions = {
   timeoutMs?: number;
 };
 
-type LoadOsDopplerSecretsOptions = {
-  /** Doppler config to load. Defaults to the local apps/os Doppler setup. */
-  config?: string;
-  /** Environment used for the Doppler CLI process. Defaults to process.env. */
-  env?: NodeJS.ProcessEnv;
-};
-
 const APP_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const ALCHEMY_DIR = resolve(APP_ROOT, ".alchemy");
 const LOG_PATH = localDevServerLogPath(APP_ROOT);
@@ -450,6 +443,13 @@ function loadDevServerEnv(options: Pick<StartOptions, "config" | "skipDoppler">)
 
   return { ...process.env, ...dopplerEnv.secrets };
 }
+
+type LoadOsDopplerSecretsOptions = {
+  /** Doppler config to load. Defaults to the local apps/os Doppler setup. */
+  config?: string;
+  /** Environment used for the Doppler CLI process. Defaults to process.env. */
+  env?: NodeJS.ProcessEnv;
+};
 
 function loadOsSecrets(options: LoadOsDopplerSecretsOptions = {}) {
   try {

--- a/apps/os/scripts/do-duration-probe.ts
+++ b/apps/os/scripts/do-duration-probe.ts
@@ -16,11 +16,6 @@
 //   --threshold-hours N   wallTimeP99 ceiling per invocation, in hours (default 1)
 //   --prefix STR          only scripts whose name starts with STR (default "os-")
 
-interface CfGraphqlResponse<T> {
-  data?: T;
-  errors?: Array<{ message: string }>;
-}
-
 function requireEnv(name: string): string {
   const value = process.env[name];
   if (value === undefined || value === "") throw new Error(`Missing required env var ${name}`);
@@ -38,6 +33,11 @@ function flagStr(name: string, fallback: string): string {
   const fromCli = process.argv.indexOf(`--${name}`);
   if (fromCli !== -1 && process.argv[fromCli + 1] !== undefined) return process.argv[fromCli + 1]!;
   return fallback;
+}
+
+interface CfGraphqlResponse<T> {
+  data?: T;
+  errors?: Array<{ message: string }>;
 }
 
 async function main(): Promise<void> {

--- a/apps/os/scripts/itx.ts
+++ b/apps/os/scripts/itx.ts
@@ -38,19 +38,6 @@ type RunOptions = {
   baseUrl?: string;
 };
 
-type AgentSmokeOptions = {
-  /** Agent stream path, e.g. /agents/smoke. */
-  agentPath: string;
-  /** OS base URL. Defaults to APP_CONFIG_BASE_URL. */
-  baseUrl?: string;
-  /** Single user message to send to the agent. */
-  message: string;
-  /** Project id or slug to connect into over ITX. */
-  project: string;
-  /** Maximum time to wait for an assistant response. */
-  timeoutMs?: number;
-};
-
 /** Run an itx script body against a deployed OS worker over Cap'n Web. */
 export async function run(options: RunOptions) {
   const code = options.eval ?? (options.file ? await readFile(options.file, "utf8") : undefined);
@@ -80,6 +67,19 @@ export async function run(options: RunOptions) {
   // The Cap'n Web WebSocket would otherwise keep the process alive.
   process.exit(0);
 }
+
+type AgentSmokeOptions = {
+  /** Agent stream path, e.g. /agents/smoke. */
+  agentPath: string;
+  /** OS base URL. Defaults to APP_CONFIG_BASE_URL. */
+  baseUrl?: string;
+  /** Single user message to send to the agent. */
+  message: string;
+  /** Project id or slug to connect into over ITX. */
+  project: string;
+  /** Maximum time to wait for an assistant response. */
+  timeoutMs?: number;
+};
 
 /** Send one user message to an agent over ITX and wait for the assistant response. */
 export async function agentSmoke(options: AgentSmokeOptions) {

--- a/apps/os/src/components/project-settings-panel.tsx
+++ b/apps/os/src/components/project-settings-panel.tsx
@@ -12,8 +12,6 @@ import type { PublicRouteConfig } from "~/lib/public-route-config.ts";
 import { useItx } from "~/itx/itx-react.tsx";
 import type { ItxProjects } from "~/itx/handle.ts";
 
-type CustomHostnameStatus = Awaited<ReturnType<ItxProjects["customHostnameStatus"]>>;
-
 export function ProjectSettingsPanel({
   project,
   routeConfig,
@@ -217,6 +215,8 @@ function CustomHostnameDnsInstructions({
     </div>
   );
 }
+
+type CustomHostnameStatus = Awaited<ReturnType<ItxProjects["customHostnameStatus"]>>;
 
 function CustomHostnameCloudflareStatus({
   isPending,

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -80,6 +80,11 @@ import { presenceLabel, sparklinePoints, useSimulatedRttMetrics } from "~/lib/st
 import { useStreamViewSearch } from "~/lib/stream-view-search.ts";
 import { useVirtualizedTailScroll } from "~/lib/use-virtualized-tail-scroll.ts";
 
+const DEFAULT_RAW_EVENT_YAML =
+  "type: events.iterate.com/os/manual-event\npayload:\n  message: Hello from OS\n";
+
+const MAX_PRESENCE_AVATARS = 4;
+
 type ProjectStreamMessageComposer = {
   placeholder?: string;
   onInterrupt?: (llmRequestId: number) => Promise<void>;
@@ -93,11 +98,6 @@ type StreamPathLinkRenderer = (input: {
   path: StreamPath;
 }) => ReactNode;
 type ItxStreamSource = (streamPath: StreamPath) => StreamRpc | Promise<StreamRpc>;
-
-const DEFAULT_RAW_EVENT_YAML =
-  "type: events.iterate.com/os/manual-event\npayload:\n  message: Hello from OS\n";
-
-const MAX_PRESENCE_AVATARS = 4;
 
 export function ProjectStreamView({
   autoFocusMessageComposer = false,

--- a/apps/os/src/components/stream-explorer.tsx
+++ b/apps/os/src/components/stream-explorer.tsx
@@ -3,8 +3,6 @@ import type { StreamPath as StreamPathType } from "@iterate-com/shared/streams/t
 import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import { StreamTreeBrowser, type StreamTreeSource } from "~/components/stream-tree-browser.tsx";
 
-type ProjectStreamViewProps = ComponentProps<typeof ProjectStreamView>;
-
 export function StreamExplorerTreePage({
   currentPath,
   header,
@@ -36,6 +34,8 @@ export function StreamExplorerTreePage({
  * header's path pill, not a tree sidebar — the source feeds the switcher's
  * lazy child loading.
  */
+type ProjectStreamViewProps = ComponentProps<typeof ProjectStreamView>;
+
 export function StreamExplorerDetail({
   currentPath,
   showCommandPaletteTrigger = false,

--- a/apps/os/src/components/stream-processors-panel.tsx
+++ b/apps/os/src/components/stream-processors-panel.tsx
@@ -56,6 +56,11 @@ export function PresenceAvatar({
  * a facet of "the stream's consumers". Overview lists every consumer with
  * (simulated) RTT/lag; clicking one drills into its announced contract.
  */
+type ProcessorRuntimeStateResult = {
+  runtimeState: ProcessorRuntimeState | null;
+  streamMaxOffset: number;
+};
+
 export function StreamProcessorsPanel({
   presence,
   metrics,
@@ -180,11 +185,6 @@ type ProcessorRuntimeStateLoad =
       streamMaxOffset: number | null;
     }
   | { status: "error"; subscriptionKey: string; message: string };
-
-type ProcessorRuntimeStateResult = {
-  runtimeState: ProcessorRuntimeState | null;
-  streamMaxOffset: number;
-};
 
 function ProcessorsOverview({
   presence,

--- a/apps/os/src/domains/projects/egress-secret-substitution.ts
+++ b/apps/os/src/domains/projects/egress-secret-substitution.ts
@@ -11,8 +11,6 @@ type SecretReference = {
 
 const SECRET_REFERENCE_NAME = "getSecret(";
 
-type SecretReferenceParseResult = [errorResponse: Response | null, references: SecretReference[]];
-
 type SecretReferenceResolutionResult = [errorResponse: Response | null, value: string];
 
 export type SubstituteProjectEgressSecretHeadersResult = [
@@ -46,6 +44,8 @@ export async function substituteProjectEgressSecretHeaders(input: {
 
   return [null, substitutedHeaders];
 }
+
+type SecretReferenceParseResult = [errorResponse: Response | null, references: SecretReference[]];
 
 export function parseSecretReferences(input: {
   header: string;

--- a/apps/os/src/domains/streams/engine/stream-processor.ts
+++ b/apps/os/src/domains/streams/engine/stream-processor.ts
@@ -109,10 +109,6 @@ export type StreamProcessorRuntimeState<State> = {
 type MaybePromise<T> = T | Promise<T>;
 type StateChangeCallback<State> = (state: State) => unknown;
 type RetainedStateChangeCallback<State> = StateChangeCallback<State> & Disposable;
-type RetainableStateChangeCallback<State> = StateChangeCallback<State> &
-  Partial<Disposable> & {
-    dup?(): RetainedStateChangeCallback<State>;
-  };
 export type StreamProcessorStateUnsubscribe = (() => void) & Disposable;
 
 /**
@@ -457,6 +453,11 @@ export abstract class StreamProcessor<
     return this.#state;
   }
 }
+
+type RetainableStateChangeCallback<State> = StateChangeCallback<State> &
+  Partial<Disposable> & {
+    dup?(): RetainedStateChangeCallback<State>;
+  };
 
 function retainStateChangeCallback<State>(
   cb: StateChangeCallback<State>,

--- a/apps/os/src/domains/streams/engine/workers/rpc-lifecycle.ts
+++ b/apps/os/src/domains/streams/engine/workers/rpc-lifecycle.ts
@@ -11,13 +11,6 @@ type RetainableProcessEventBatch = ProcessEventBatch &
     onRpcBroken?(callback: (error: unknown) => void): void;
   };
 
-type RetainedGetProcessorRuntimeState = GetProcessorRuntimeState & Disposable;
-
-type RetainableGetProcessorRuntimeState = GetProcessorRuntimeState &
-  Partial<Disposable> & {
-    dup?(): RetainedGetProcessorRuntimeState;
-  };
-
 export function retainProcessEventBatch(
   processEventBatch: ProcessEventBatch,
   opts: {
@@ -93,6 +86,13 @@ export function retainProcessEventBatch(
   }
   return callback;
 }
+
+type RetainedGetProcessorRuntimeState = GetProcessorRuntimeState & Disposable;
+
+type RetainableGetProcessorRuntimeState = GetProcessorRuntimeState &
+  Partial<Disposable> & {
+    dup?(): RetainedGetProcessorRuntimeState;
+  };
 
 export function retainGetProcessorRuntimeState(
   getRuntimeState: GetProcessorRuntimeState | undefined,

--- a/apps/os/src/domains/streams/engine/workers/stream-processor-host.ts
+++ b/apps/os/src/domains/streams/engine/workers/stream-processor-host.ts
@@ -224,6 +224,12 @@ export function createStreamProcessorHost(ctx: DurableObjectState): StreamProces
   // (Re)opens the outbound subscription from the processor's durable checkpoint.
   // Called for the initial handshake and again by `recoverFromIngestFailure`, so
   // a failed batch replays from the last good offset instead of being skipped.
+  type OutboundStreamRpc = RetainedStreamRpc & {
+    subscribeOutbound(
+      args: Parameters<StreamRpc["subscribe"]>[0],
+    ): ReturnType<StreamRpc["subscribe"]>;
+  };
+
   async function openSubscription(name: string): Promise<void> {
     const entry = requireEntry(name);
     const stream = entry.stream;
@@ -440,12 +446,6 @@ type RetainedStreamRpc = StreamRpc &
   Disposable & {
     onRpcBroken?(callback: (error: unknown) => void): void;
   };
-
-type OutboundStreamRpc = RetainedStreamRpc & {
-  subscribeOutbound(
-    args: Parameters<StreamRpc["subscribe"]>[0],
-  ): ReturnType<StreamRpc["subscribe"]>;
-};
 
 type RetainableStreamRpc = StreamRpc &
   Partial<Disposable> & {

--- a/apps/os/src/routes/_app/projects/$projectSlug/reactivity.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/reactivity.tsx
@@ -37,10 +37,6 @@ type LiveProjectProcessorState = {
   status: LiveStatus;
 };
 
-type LiveProjectProcessorSnapshot = LiveProjectProcessorState & {
-  refreshSnapshot: () => Promise<void>;
-};
-
 const REACTIVITY_TEST_STREAM_PATH = "/reactivity-test";
 const REACTIVITY_TEST_EVENT_TYPE = "events.iterate.com/reactivity-test/appended";
 
@@ -65,6 +61,10 @@ type ReactivityTestStreamState = {
   events: ReactivityTestEvent[];
   lastBatchAt?: number;
   status: LiveStatus;
+};
+
+type LiveProjectProcessorSnapshot = LiveProjectProcessorState & {
+  refreshSnapshot: () => Promise<void>;
 };
 
 function useLiveProjectProcessorSnapshot(): LiveProjectProcessorSnapshot {

--- a/apps/semaphore/src/lib/resource-store.ts
+++ b/apps/semaphore/src/lib/resource-store.ts
@@ -17,18 +17,6 @@ import {
   type SemaphoreResourceRecord,
 } from "~/contract.ts";
 
-type ResourceRow = {
-  type: string;
-  slug: string;
-  data: string;
-  lease_state: string;
-  leased_until?: number | null;
-  last_acquired_at?: number | null;
-  last_released_at?: number | null;
-  created_at: string;
-  updated_at: string;
-};
-
 export class ResourceInputError extends Error {}
 
 export function parseType(input: string): string {
@@ -46,6 +34,18 @@ function parseData(value: string): SemaphoreJsonObject {
     throw error;
   }
 }
+
+type ResourceRow = {
+  type: string;
+  slug: string;
+  data: string;
+  lease_state: string;
+  leased_until?: number | null;
+  last_acquired_at?: number | null;
+  last_released_at?: number | null;
+  created_at: string;
+  updated_at: string;
+};
 
 function rowToResourceRecord(row: ResourceRow): SemaphoreResourceRecord {
   return {

--- a/apps/semaphore/src/routes/_app/resources.$type.$slug.tsx
+++ b/apps/semaphore/src/routes/_app/resources.$type.$slug.tsx
@@ -22,10 +22,6 @@ type SerializableJsonValue =
   | SerializableJsonValue[]
   | { [key: string]: SerializableJsonValue };
 
-type SerializableSemaphoreResource = Omit<SemaphoreResourceRecord, "data"> & {
-  data: Record<string, SerializableJsonValue>;
-};
-
 function toSerializableJsonValue(value: unknown): SerializableJsonValue {
   if (
     value === null ||
@@ -48,6 +44,10 @@ function toSerializableJsonValue(value: unknown): SerializableJsonValue {
 
   throw new Error("Semaphore resource data must be JSON-serializable");
 }
+
+type SerializableSemaphoreResource = Omit<SemaphoreResourceRecord, "data"> & {
+  data: Record<string, SerializableJsonValue>;
+};
 
 function serializeResource(resource: SemaphoreResourceRecord): SerializableSemaphoreResource {
   return {

--- a/oxlint-plugin-iterate.js
+++ b/oxlint-plugin-iterate.js
@@ -217,7 +217,17 @@ function isImmediatelyBeside(typeDeclaration, functionStatement) {
 
   const typeIndex = body.indexOf(typeDeclaration);
   const functionIndex = body.indexOf(functionStatement);
-  return typeIndex !== -1 && functionIndex !== -1 && Math.abs(typeIndex - functionIndex) === 1;
+  if (typeIndex === -1 || functionIndex === -1) return false;
+
+  const start = Math.min(typeIndex, functionIndex) + 1;
+  const end = Math.max(typeIndex, functionIndex);
+  const between = body.slice(start, end);
+  return between.every((statement) => isTypeDeclarationStatement(statement));
+}
+
+/** @param {import("estree").Node} statement */
+function isTypeDeclarationStatement(statement) {
+  return statement.type === "TSTypeAliasDeclaration" || statement.type === "TSInterfaceDeclaration";
 }
 
 /**

--- a/oxlint-plugin-iterate.js
+++ b/oxlint-plugin-iterate.js
@@ -145,6 +145,81 @@ function isFunctionLikeDeclaration(node) {
   });
 }
 
+/** @param {import("estree").Node} node */
+function isFunctionExpressionNode(node) {
+  return node.type === "FunctionExpression" || node.type === "ArrowFunctionExpression";
+}
+
+/**
+ * @param {import("estree").Node | undefined} node
+ * @returns {import("estree").Node | undefined}
+ */
+function getExportWrapper(node) {
+  if (
+    node?.type === "ExportNamedDeclaration" ||
+    node?.type === "ExportDefaultDeclaration" ||
+    node?.type === "ExportAllDeclaration"
+  ) {
+    return node;
+  }
+  return undefined;
+}
+
+/**
+ * @param {import("estree").Node} node
+ * @returns {import("estree").Node | undefined}
+ */
+function getFunctionColocationStatement(node) {
+  if (node.type === "FunctionDeclaration") {
+    return getExportWrapper(node.parent) || node;
+  }
+
+  if (!isFunctionExpressionNode(node)) return undefined;
+
+  const declarator = node.parent;
+  if (declarator?.type !== "VariableDeclarator" || declarator.init !== node) return undefined;
+  const declaration = declarator.parent;
+  if (declaration?.type !== "VariableDeclaration") return undefined;
+  return getExportWrapper(declaration.parent) || declaration;
+}
+
+/**
+ * @param {import("estree").Node} node
+ * @returns {import("estree").Node | undefined}
+ */
+function getTypeReferenceFunctionStatement(node) {
+  for (let current = node.parent; current; current = current.parent) {
+    if (current.type === "FunctionDeclaration") {
+      return getFunctionColocationStatement(current);
+    }
+    if (isFunctionExpressionNode(current)) {
+      const statement = getFunctionColocationStatement(current);
+      if (statement) return statement;
+    }
+    if (
+      current.type === "VariableDeclarator" &&
+      current.init &&
+      isFunctionExpressionNode(current.init)
+    ) {
+      return getFunctionColocationStatement(current.init);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * @param {import("estree").Node} typeDeclaration
+ * @param {import("estree").Node} functionStatement
+ */
+function isImmediatelyBeside(typeDeclaration, functionStatement) {
+  const body = typeDeclaration.parent?.body;
+  if (!Array.isArray(body) || body !== functionStatement.parent?.body) return false;
+
+  const typeIndex = body.indexOf(typeDeclaration);
+  const functionIndex = body.indexOf(functionStatement);
+  return typeIndex !== -1 && functionIndex !== -1 && Math.abs(typeIndex - functionIndex) === 1;
+}
+
 /**
  * Counts the source lines spanned by a function's body content: the statements between the
  * braces, or the expression of a concise arrow. Brace-only lines don't count, so
@@ -750,6 +825,53 @@ const plugin = {
             }
             checkHelper(node.id, node.init, node.parent);
           },
+        };
+      },
+    },
+    "colocate-single-use-types": {
+      meta: {
+        type: "suggestion",
+        docs: {
+          description:
+            "Require non-exported single-use type aliases and interfaces to sit immediately beside the function they serve.",
+        },
+      },
+      create(context) {
+        /**
+         * @param {import("estree").Node} node
+         */
+        function checkTypeDeclaration(node) {
+          const typeName = node.id?.name;
+          if (!typeName) return;
+          if (node.declare) return;
+          if (getExportWrapper(node.parent)) return;
+
+          const scope = context.sourceCode.getScope(node);
+          const variable = findVariableInScopeChain(scope, typeName);
+          if (!variable) return;
+
+          const reads = variable.references.filter((ref) => ref.isRead());
+          const isExportedReference = reads.some((ref) => {
+            const parentType = ref.identifier.parent?.type;
+            return parentType === "ExportSpecifier" || parentType === "ExportDefaultDeclaration";
+          });
+          if (isExportedReference) return;
+          if (reads.length !== 1) return;
+
+          const functionStatement = getTypeReferenceFunctionStatement(reads[0].identifier);
+          if (!functionStatement) return;
+          if (isImmediatelyBeside(node, functionStatement)) return;
+
+          context.report({
+            node: node.id,
+            message:
+              `${typeName} is a non-exported type used by one function. ` +
+              `Move it immediately before or immediately after that function.`,
+          });
+        }
+
+        return {
+          "TSTypeAliasDeclaration, TSInterfaceDeclaration": checkTypeDeclaration,
         };
       },
     },

--- a/packages/mock-http-proxy/src/server/mock-http-server-fixture.ts
+++ b/packages/mock-http-proxy/src/server/mock-http-server-fixture.ts
@@ -58,21 +58,6 @@ export type MockHttpServerFixture = AsyncDisposable &
   };
 export type MockHttpServer = MockHttpServerFixture;
 
-type TemporaryDirectoryFixture = Disposable & {
-  path: string;
-};
-
-type UseMitmProxyOptions = {
-  proxyTargetUrl: string;
-  port?: number;
-};
-
-type MitmProxyFixture = AsyncDisposable & {
-  url: string;
-  port: number;
-  envForNode(): Record<string, string>;
-};
-
 function resolveOnUnhandledRequest(
   explicit: msw.SharedOptions["onUnhandledRequest"] | undefined,
 ): msw.SharedOptions["onUnhandledRequest"] {
@@ -329,6 +314,10 @@ function toOriginalUrl(
   return new URL(rawUrl, `https://${host}`);
 }
 
+type TemporaryDirectoryFixture = Disposable & {
+  path: string;
+};
+
 export function useTemporaryDirectory(prefix = "mock-http-proxy-api-"): TemporaryDirectoryFixture {
   const path = mkdtempSync(join(tmpdir(), prefix));
   return {
@@ -338,6 +327,17 @@ export function useTemporaryDirectory(prefix = "mock-http-proxy-api-"): Temporar
     },
   };
 }
+
+type UseMitmProxyOptions = {
+  proxyTargetUrl: string;
+  port?: number;
+};
+
+type MitmProxyFixture = AsyncDisposable & {
+  url: string;
+  port: number;
+  envForNode(): Record<string, string>;
+};
 
 export async function useMitmProxy(options: UseMitmProxyOptions): Promise<MitmProxyFixture> {
   const ca = await mockttp.generateCACertificate();

--- a/packages/mock-http-proxy/src/server/msw-server-adapter.ts
+++ b/packages/mock-http-proxy/src/server/msw-server-adapter.ts
@@ -16,7 +16,6 @@ import {
 
 type AnyHandler = msw.RequestHandler | msw.WebSocketHandler;
 type UnhandledAction = "bypass" | "error";
-type LifecycleEmitter = Pick<EventEmitter, "on" | "emit" | "removeListener" | "removeAllListeners">;
 
 type NativeMswServerApi = Pick<
   mswNode.SetupServerApi,
@@ -420,7 +419,10 @@ export function createNativeMswServer(
   ) as AnyHandler[];
 
   const msw = setupServer(...handlers);
-  const lifecycleEmitter: LifecycleEmitter = new EventEmitter();
+  const lifecycleEmitter: Pick<
+    EventEmitter,
+    "on" | "emit" | "removeListener" | "removeAllListeners"
+  > = new EventEmitter();
   const onUnhandledRequest = options.onUnhandledRequest ?? "warn";
   const resolutionContextBaseUrl = options.resolutionContextBaseUrl;
   const transformRequest = options.transformRequest;

--- a/packages/shared/src/callable/runtime.ts
+++ b/packages/shared/src/callable/runtime.ts
@@ -15,25 +15,6 @@ type DynamicWorkerVia = Extract<
   FetchCallable["via"],
   { type: "env-binding"; bindingType: "dynamic-worker" }
 >;
-type EnvDurableObjectVia = Extract<
-  FetchCallable["via"],
-  { type: "env-binding"; bindingType: "durable-object-namespace" }
->;
-type LoopbackDurableObjectVia = Extract<
-  FetchCallable["via"],
-  { type: "loopback-binding"; bindingType: "durable-object-namespace" }
->;
-type DynamicWorkerCode = DynamicWorkerVia["workerCode"];
-type DynamicWorkerStub = {
-  getEntrypoint: (name?: string, options?: { props?: unknown }) => unknown;
-};
-type DynamicWorkerLoader = {
-  load: (code: DynamicWorkerCode) => DynamicWorkerStub;
-  get: (
-    id: string,
-    getCode: () => DynamicWorkerCode | Promise<DynamicWorkerCode>,
-  ) => DynamicWorkerStub;
-};
 
 /**
  * Parses untrusted JSON into the v1 Callable shape.
@@ -934,6 +915,15 @@ function resolveLoopbackServiceBinding(options: {
   return binding({ props: options.via.props });
 }
 
+type EnvDurableObjectVia = Extract<
+  FetchCallable["via"],
+  { type: "env-binding"; bindingType: "durable-object-namespace" }
+>;
+type LoopbackDurableObjectVia = Extract<
+  FetchCallable["via"],
+  { type: "loopback-binding"; bindingType: "durable-object-namespace" }
+>;
+
 function resolveDurableObjectFetchStub(
   options:
     | {
@@ -1116,6 +1106,18 @@ function isFetchableBinding(
     typeof value.fetch === "function"
   );
 }
+
+type DynamicWorkerCode = DynamicWorkerVia["workerCode"];
+type DynamicWorkerStub = {
+  getEntrypoint: (name?: string, options?: { props?: unknown }) => unknown;
+};
+type DynamicWorkerLoader = {
+  load: (code: DynamicWorkerCode) => DynamicWorkerStub;
+  get: (
+    id: string,
+    getCode: () => DynamicWorkerCode | Promise<DynamicWorkerCode>,
+  ) => DynamicWorkerStub;
+};
 
 function isDynamicWorkerLoader(value: unknown): value is DynamicWorkerLoader {
   return (

--- a/packages/shared/src/durable-object-utils/e2e/run-test-deployment.ts
+++ b/packages/shared/src/durable-object-utils/e2e/run-test-deployment.ts
@@ -4,16 +4,6 @@ import { env, platform, stderr, stdout } from "node:process";
 import { fileURLToPath } from "node:url";
 import { slugify } from "../../slugify.ts";
 
-type CommandOptions = {
-  readonly env?: Record<string, string>;
-  readonly allowFailure?: boolean;
-};
-
-type DeploymentOutput = {
-  readonly url?: string;
-  readonly routes?: readonly string[];
-};
-
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 const stage = env.ALCHEMY_STAGE ?? slugify(`do-utils-e2e-${Date.now().toString(36)}`);
 const alchemyEntrypoint = "./src/durable-object-utils/e2e/alchemy.run.ts";
@@ -67,6 +57,11 @@ if (failed) {
   process.exitCode = 1;
 }
 
+type CommandOptions = {
+  readonly env?: Record<string, string>;
+  readonly allowFailure?: boolean;
+};
+
 function run(command: string, args: readonly string[], options: CommandOptions = {}): string {
   stdout.write(`$ ${command} ${args.join(" ")}\n`);
 
@@ -111,6 +106,11 @@ function getBaseUrl(output: string): string {
     "Alchemy deployment did not report a worker URL. Set DURABLE_OBJECT_UTILS_E2E_WORKER_ROUTES to a hostname route or enable workers.dev for the account.",
   );
 }
+
+type DeploymentOutput = {
+  readonly url?: string;
+  readonly routes?: readonly string[];
+};
 
 function parseDeploymentOutput(output: string): DeploymentOutput {
   const jsonLine = output

--- a/packages/shared/src/durable-object-utils/mixins/fetch-mixin-utils.ts
+++ b/packages/shared/src/durable-object-utils/mixins/fetch-mixin-utils.ts
@@ -17,10 +17,6 @@ export type FetchBase = {
   fetch(request: Request): Response | Promise<Response>;
 };
 
-type OptionalFetchBase = {
-  fetch?(request: Request): Response | Promise<Response>;
-};
-
 /**
  * Public result type for mixins that add or wrap fetch().
  *
@@ -44,6 +40,10 @@ export type WithFetchMixinResult<TBase extends DurableObjectClass> = DurableObje
  * base class. If no lower layer handles fetch(), return a plain 404. This keeps
  * each inspector focused on its own route instead of duplicating fallback logic.
  */
+type OptionalFetchBase = {
+  fetch?(request: Request): Response | Promise<Response>;
+};
+
 export async function delegateToBaseFetch(
   Base: DurableObjectClass,
   instance: object,

--- a/packages/shared/src/durable-object-utils/mixins/with-lifecycle-hooks.ts
+++ b/packages/shared/src/durable-object-utils/mixins/with-lifecycle-hooks.ts
@@ -59,17 +59,6 @@ type LifecycleHook<StructuredName extends LifecycleStructuredName> = (
   structuredName: StructuredName,
 ) => void | Promise<void>;
 
-type DurableObjectBranded = {
-  /**
-   * `DurableObjectNamespace<T>` is meant to contain real Durable Object
-   * instances, not arbitrary objects that happen to implement `initialize()`.
-   * Cloudflare's DurableObject instance type includes this brand, so requiring
-   * it keeps `getInitializedDoStub({ namespace, ... })` tied to actual DO
-   * namespaces.
-   */
-  __DURABLE_OBJECT_BRAND: never;
-};
-
 type StructuredNameOf<TInstance> =
   TInstance extends LifecycleHooksMembers<infer StructuredName> ? StructuredName : never;
 
@@ -97,10 +86,6 @@ export type D1ObjectCatalogOptions<StructuredName extends LifecycleStructuredNam
   getDatabase(env: Env): D1Database;
   indexes?: D1ObjectCatalogIndexDefinitions<StructuredName>;
 };
-
-type D1ObjectCatalogSetting<StructuredName extends LifecycleStructuredName, Env> =
-  | "none"
-  | D1ObjectCatalogOptions<StructuredName, Env>;
 
 /**
  * Type-only protected surface.
@@ -233,6 +218,10 @@ export class InitializeInitialStateMismatchError extends Error {
  * `registerOnInstanceWake()`, and call `ensureStarted()` before public methods
  * touch initialized state.
  */
+type D1ObjectCatalogSetting<StructuredName extends LifecycleStructuredName, Env> =
+  | "none"
+  | D1ObjectCatalogOptions<StructuredName, Env>;
+
 export function withLifecycleHooks<
   StructuredName extends LifecycleStructuredName = string,
   InitialState = undefined,
@@ -615,6 +604,17 @@ export function withLifecycleHooks<
  * miss. A future helper shape should move the D1 preflight outside the stub
  * wake, then call `ensureStarted()` on catalog hits so drift is surfaced.
  */
+type DurableObjectBranded = {
+  /**
+   * `DurableObjectNamespace<T>` is meant to contain real Durable Object
+   * instances, not arbitrary objects that happen to implement `initialize()`.
+   * Cloudflare's DurableObject instance type includes this brand, so requiring
+   * it keeps `getInitializedDoStub({ namespace, ... })` tied to actual DO
+   * namespaces.
+   */
+  __DURABLE_OBJECT_BRAND: never;
+};
+
 export async function getInitializedDoStub<
   TInstance extends DurableObjectBranded,
   const AllowCreate extends boolean,

--- a/packages/shared/src/test-helpers/use-semaphore-lease.ts
+++ b/packages/shared/src/test-helpers/use-semaphore-lease.ts
@@ -19,17 +19,6 @@ export interface SemaphoreLeaseHandle<TData> extends AsyncDisposable {
   release(): Promise<void>;
 }
 
-// Deliberately a hand-rolled HTTP client rather than `createSemaphoreClient`
-// from apps/semaphore/src/contract.ts: packages/shared must not depend on an
-// app workspace, and this helper only touches two stable endpoints
-// (POST /api/resources/acquire and /api/resources/release).
-type SemaphoreLeaseResponse = {
-  slug: string;
-  leaseId: string;
-  expiresAt: number;
-  data: unknown;
-};
-
 async function semaphoreRequest<TResponse>(options: {
   apiToken: string;
   baseUrl: string;
@@ -58,6 +47,17 @@ async function semaphoreRequest<TResponse>(options: {
 /**
  * Acquire a Semaphore resource lease and release it on dispose.
  */
+// Deliberately a hand-rolled HTTP client rather than `createSemaphoreClient`
+// from apps/semaphore/src/contract.ts: packages/shared must not depend on an
+// app workspace, and this helper only touches two stable endpoints
+// (POST /api/resources/acquire and /api/resources/release).
+type SemaphoreLeaseResponse = {
+  slug: string;
+  leaseId: string;
+  expiresAt: number;
+  data: unknown;
+};
+
 export async function useSemaphoreLease<TData>(
   options: UseSemaphoreLeaseOptions<TData>,
 ): Promise<SemaphoreLeaseHandle<TData>> {

--- a/packages/ui/src/components/chart.tsx
+++ b/packages/ui/src/components/chart.tsx
@@ -10,7 +10,6 @@ import { cn } from "@iterate-com/ui/lib/utils";
 const THEMES = { light: "", dark: ".dark" } as const;
 
 const INITIAL_DIMENSION = { width: 320, height: 200 } as const;
-type TooltipNameType = number | string;
 
 export type ChartConfig = Record<
   string,
@@ -107,6 +106,8 @@ ${colorConfig
 };
 
 const ChartTooltip = RechartsPrimitive.Tooltip;
+
+type TooltipNameType = number | string;
 
 function ChartTooltipContent({
   active,

--- a/packages/ui/src/components/mobile-keyboard-toolbar.tsx
+++ b/packages/ui/src/components/mobile-keyboard-toolbar.tsx
@@ -1,18 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { cn } from "../lib/utils.ts";
 
-interface MobileKeyboardToolbarProps {
-  onKeyPress: (key: string) => void;
-  ctrlActive?: boolean;
-  keyboardVisible?: boolean;
-  onCtrlToggle?: () => void;
-  onToggleKeyboard?: () => void;
-  onSearch?: (query: string) => void;
-  onSearchNext?: (query: string) => void;
-  onSearchPrev?: (query: string) => void;
-  onSearchClose?: () => void;
-}
-
 interface KeyDef {
   label: string;
   key?: string;
@@ -118,6 +106,18 @@ const REPEAT_INTERVAL_MS = 80;
 
 function haptic() {
   navigator.vibrate?.(10);
+}
+
+interface MobileKeyboardToolbarProps {
+  onKeyPress: (key: string) => void;
+  ctrlActive?: boolean;
+  keyboardVisible?: boolean;
+  onCtrlToggle?: () => void;
+  onToggleKeyboard?: () => void;
+  onSearch?: (query: string) => void;
+  onSearchNext?: (query: string) => void;
+  onSearchPrev?: (query: string) => void;
+  onSearchClose?: () => void;
 }
 
 export function MobileKeyboardToolbar({

--- a/packages/ui/src/components/posthog.tsx
+++ b/packages/ui/src/components/posthog.tsx
@@ -1,6 +1,3 @@
-type PostHog = import("posthog-js").PostHog;
-type PostHogInterface = import("posthog-js").PostHogInterface;
-
 // posthog-js only ever runs in the browser; the SSR branch keeps it out of the
 // server bundle.
 const loadPosthog = import.meta.env.SSR ? null : () => import("posthog-js");
@@ -48,6 +45,8 @@ function getBootstrapConfig() {
   };
 }
 
+type PostHogInterface = import("posthog-js").PostHogInterface;
+
 function buildPosthogInitOptions(options: SetupPosthogOptions) {
   return {
     api_host: resolveBrowserUrl(options.proxyUrl ?? "/api/integrations/posthog/proxy"),
@@ -73,6 +72,8 @@ function buildPosthogInitOptions(options: SetupPosthogOptions) {
       : undefined,
   };
 }
+
+type PostHog = import("posthog-js").PostHog;
 
 function setupPosthog(client: PostHog, options: SetupPosthogOptions) {
   if (!shouldEnablePosthog(options.apiKey) || typeof window === "undefined") return;

--- a/packages/ui/src/components/route-defaults.tsx
+++ b/packages/ui/src/components/route-defaults.tsx
@@ -2,17 +2,6 @@ import type { ReactNode } from "react";
 import { Button } from "./button.tsx";
 import { Spinner } from "./spinner.tsx";
 
-type ErrorFallbackProps = {
-  error: unknown;
-  reset: () => void;
-  secondaryAction?: ReactNode;
-};
-
-type NotFoundFallbackProps = {
-  action?: ReactNode;
-  [key: string]: unknown;
-};
-
 export function DefaultPendingComponent() {
   return (
     <div className="flex min-h-screen items-center justify-center">
@@ -20,6 +9,11 @@ export function DefaultPendingComponent() {
     </div>
   );
 }
+
+type NotFoundFallbackProps = {
+  action?: ReactNode;
+  [key: string]: unknown;
+};
 
 export function DefaultNotFoundComponent({ action }: NotFoundFallbackProps = {}) {
   return (
@@ -34,6 +28,12 @@ export function DefaultNotFoundComponent({ action }: NotFoundFallbackProps = {})
     </div>
   );
 }
+
+type ErrorFallbackProps = {
+  error: unknown;
+  reset: () => void;
+  secondaryAction?: ReactNode;
+};
 
 export function DefaultErrorComponent({ error, reset, secondaryAction }: ErrorFallbackProps) {
   const message = error instanceof Error ? error.message : "An unexpected error occurred";

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -290,6 +290,13 @@ export async function status() {
 /**
  * Lease a specific preview slot for manual deploys so PR cleanup cannot destroy it.
  */
+type AcquireOptions = {
+  /** Preview slot: a number (9) or slug (preview-9 / preview_9). */
+  slot: string;
+  /** Manual lease length in hours. */
+  hours?: number;
+};
+
 export async function acquire(options: AcquireOptions) {
   const runtime = createPreviewRuntime();
   const semaphore = runtime.createPreviewSemaphoreResourceClient();
@@ -313,6 +320,13 @@ export async function acquire(options: AcquireOptions) {
 /**
  * Release a preview slot lease acquired with `preview acquire`.
  */
+type ReleaseOptions = {
+  /** Preview slot: a number (9) or slug (preview-9 / preview_9). */
+  slot: string;
+  /** Lease id returned by `pnpm preview acquire`. */
+  leaseId: string;
+};
+
 export async function release(options: ReleaseOptions) {
   const runtime = createPreviewRuntime();
   const semaphore = runtime.createPreviewSemaphoreResourceClient();
@@ -345,6 +359,11 @@ export async function reconcile() {
 /**
  * Ensure preview auth, OS, and streams-example Doppler configs contain per-slot constants.
  */
+type ProvisionAuthPreviewConfigsOptions = {
+  /** Regenerate OAuth client secrets and app auth tokens instead of keeping existing values. */
+  rotate?: boolean;
+};
+
 export async function provisionAuthPreviewConfigs(
   options: ProvisionAuthPreviewConfigsOptions = {},
 ) {
@@ -623,14 +642,6 @@ export const environmentConfigLeaseInventory = previewEnvironmentSlotNumbers.map
   };
 }) satisfies EnvironmentConfigLeaseInventoryItem[];
 
-type PreviewInventoryClient = {
-  add: (input: EnvironmentConfigLeaseInventoryItem) => Promise<unknown>;
-  delete: (input: { slug: string; type: string }) => Promise<unknown>;
-  list: (input: {
-    type: string;
-  }) => Promise<Array<{ slug: string; data: Record<string, unknown> }>>;
-};
-
 export type PreviewSemaphoreResourceClient = {
   acquire: (input: { leaseMs: number; type: string; waitMs?: number }) => Promise<{
     data: Record<string, unknown>;
@@ -670,25 +681,6 @@ export type PreviewSemaphoreResourceClient = {
 
 export type PreviewAppRuntime = (typeof cloudflarePreviewApps)[CloudflarePreviewAppSlugType];
 
-type AcquireOptions = {
-  /** Preview slot: a number (9) or slug (preview-9 / preview_9). */
-  slot: string;
-  /** Manual lease length in hours. */
-  hours?: number;
-};
-
-type ReleaseOptions = {
-  /** Preview slot: a number (9) or slug (preview-9 / preview_9). */
-  slot: string;
-  /** Lease id returned by `pnpm preview acquire`. */
-  leaseId: string;
-};
-
-type ProvisionAuthPreviewConfigsOptions = {
-  /** Regenerate OAuth client secrets and app auth tokens instead of keeping existing values. */
-  rotate?: boolean;
-};
-
 type PreviewRuntime = {
   commandEnvironment: NodeJS.ProcessEnv;
   createPreviewSemaphoreResourceClient: () => PreviewSemaphoreResourceClient;
@@ -710,10 +702,6 @@ type EnvironmentConfigLeaseResourceRecord = {
   data: Record<string, unknown>;
   leaseState: "available" | "leased";
   leasedUntil: number | null;
-};
-
-type PreviewReconcileClient = {
-  list: (input: { type: string }) => Promise<EnvironmentConfigLeaseResourceRecord[]>;
 };
 
 type CheckResult = {
@@ -738,25 +726,6 @@ type EnvironmentConfigLeaseReconcileIssue = {
   check: "resource-data" | "doppler-config" | "cloudflare-credentials" | "cloudflare-zone";
   message: string;
   resourceSlug: string;
-};
-
-type EnvironmentConfigLeaseReconcileResult = {
-  checkedAt: string;
-  ok: boolean;
-  semaphoreBaseUrl: string;
-  type: typeof ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE;
-  resources: Array<{
-    dopplerConfig: string | null;
-    domains: string[];
-    issues: EnvironmentConfigLeaseReconcileIssue[];
-    leaseState: "available" | "leased";
-    leasedUntil: string | null;
-    slug: string;
-  }>;
-  summary: {
-    resourceCount: number;
-    issueCount: number;
-  };
 };
 
 const previewManagedDopplerProjects = [
@@ -798,6 +767,14 @@ function createPreviewSemaphoreResourceClient(
     list: ({ type }) => semaphore.resources.list({ type }),
   };
 }
+
+type PreviewInventoryClient = {
+  add: (input: EnvironmentConfigLeaseInventoryItem) => Promise<unknown>;
+  delete: (input: { slug: string; type: string }) => Promise<unknown>;
+  list: (input: {
+    type: string;
+  }) => Promise<Array<{ slug: string; data: Record<string, unknown> }>>;
+};
 
 async function syncPreviewInventory(input: {
   client: PreviewInventoryClient;
@@ -1128,6 +1105,29 @@ async function writePullRequestBody(params: {
     pull_number: params.pullRequestNumber,
   });
 }
+
+type PreviewReconcileClient = {
+  list: (input: { type: string }) => Promise<EnvironmentConfigLeaseResourceRecord[]>;
+};
+
+type EnvironmentConfigLeaseReconcileResult = {
+  checkedAt: string;
+  ok: boolean;
+  semaphoreBaseUrl: string;
+  type: typeof ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE;
+  resources: Array<{
+    dopplerConfig: string | null;
+    domains: string[];
+    issues: EnvironmentConfigLeaseReconcileIssue[];
+    leaseState: "available" | "leased";
+    leasedUntil: string | null;
+    slug: string;
+  }>;
+  summary: {
+    resourceCount: number;
+    issueCount: number;
+  };
+};
 
 async function reconcileEnvironmentConfigLeaseResources(input: {
   checkCloudflareZone?: (input: {

--- a/tasks/colocate-single-use-types-lint-rule.md
+++ b/tasks/colocate-single-use-types-lint-rule.md
@@ -1,0 +1,33 @@
+---
+status: in-progress
+size: small
+---
+
+# Colocate Single-Use Types Lint Rule
+
+Status summary: Spec captured. Implementation has not started yet. The intended first PR should add only the rule, leaving existing violations unfixed so CI shows the blast radius.
+
+## Goal
+
+Add an internal lint rule that requires non-exported TypeScript types used in service of a single function to be colocated with that function.
+
+## Decisions
+
+- The rule should live in the existing internal oxlint plugin.
+- The rule should be enabled in the root oxlint config so CI reports existing violations.
+- For the initial PR, do not fix violations.
+- Exported type declarations are exempt.
+- Type declarations with two or more read references are exempt.
+- The first implementation should target `type` aliases and `interface` declarations.
+- A single-use type is compliant when its declaration is the sibling statement immediately before or immediately after the function declaration/variable declaration that uses it.
+
+## Checklist
+
+- [ ] Add an internal lint rule for single-use type colocation.
+- [ ] Enable the rule in `.oxlintrc.json`.
+- [ ] Run a focused lint command to confirm the rule reports existing violations.
+- [ ] Push the worktree branch and open a draft PR.
+
+## Implementation Log
+
+- Created worktree `/Users/mmkal/src/worktrees/iterate/colocate-single-use-types` on branch `lint/colocate-single-use-types` from `origin/main`.

--- a/tasks/colocate-single-use-types-lint-rule.md
+++ b/tasks/colocate-single-use-types-lint-rule.md
@@ -1,11 +1,11 @@
 ---
-status: in-progress
+status: waiting-on-decision
 size: small
 ---
 
 # Colocate Single-Use Types Lint Rule
 
-Status summary: Rule implementation is done and intentionally leaves 49 current lint violations unfixed. Remaining work is to push the branch and open the draft PR for CI/review.
+Status summary: Draft PR is open with the rule only and intentionally leaves 49 current lint violations unfixed. Waiting for the keep-and-fix-vs-scrap decision after CI/review.
 
 ## Goal
 
@@ -26,10 +26,11 @@ Add an internal lint rule that requires non-exported TypeScript types used in se
 - [x] Add an internal lint rule for single-use type colocation. _Implemented as `iterate/colocate-single-use-types` in `oxlint-plugin-iterate.js`._
 - [x] Enable the rule in `.oxlintrc.json`. _Registered globally as an error so CI shows existing violations._
 - [x] Run a focused lint command to confirm the rule reports existing violations. _`pnpm lint` reports 49 errors from the new rule and exits 1._
-- [ ] Push the worktree branch and open a draft PR.
+- [x] Push the worktree branch and open a draft PR. _Opened draft PR #1572 against `main`: https://github.com/iterate/iterate/pull/1572._
 
 ## Implementation Log
 
 - Created worktree `/Users/mmkal/src/worktrees/iterate/colocate-single-use-types` on branch `lint/colocate-single-use-types` from `origin/main`.
 - Added `iterate/colocate-single-use-types`, targeting non-exported `type` aliases and `interface` declarations with exactly one read reference.
 - Confirmed the first lint run fails with existing colocation violations and no plugin crash.
+- Opened draft PR #1572 so CI can show the full current violation set before cleanup work.

--- a/tasks/colocate-single-use-types-lint-rule.md
+++ b/tasks/colocate-single-use-types-lint-rule.md
@@ -5,7 +5,7 @@ size: small
 
 # Colocate Single-Use Types Lint Rule
 
-Status summary: Spec captured. Implementation has not started yet. The intended first PR should add only the rule, leaving existing violations unfixed so CI shows the blast radius.
+Status summary: Rule implementation is done and intentionally leaves 49 current lint violations unfixed. Remaining work is to push the branch and open the draft PR for CI/review.
 
 ## Goal
 
@@ -23,11 +23,13 @@ Add an internal lint rule that requires non-exported TypeScript types used in se
 
 ## Checklist
 
-- [ ] Add an internal lint rule for single-use type colocation.
-- [ ] Enable the rule in `.oxlintrc.json`.
-- [ ] Run a focused lint command to confirm the rule reports existing violations.
+- [x] Add an internal lint rule for single-use type colocation. _Implemented as `iterate/colocate-single-use-types` in `oxlint-plugin-iterate.js`._
+- [x] Enable the rule in `.oxlintrc.json`. _Registered globally as an error so CI shows existing violations._
+- [x] Run a focused lint command to confirm the rule reports existing violations. _`pnpm lint` reports 49 errors from the new rule and exits 1._
 - [ ] Push the worktree branch and open a draft PR.
 
 ## Implementation Log
 
 - Created worktree `/Users/mmkal/src/worktrees/iterate/colocate-single-use-types` on branch `lint/colocate-single-use-types` from `origin/main`.
+- Added `iterate/colocate-single-use-types`, targeting non-exported `type` aliases and `interface` declarations with exactly one read reference.
+- Confirmed the first lint run fails with existing colocation violations and no plugin crash.

--- a/tasks/complete/2026-06-23-colocate-single-use-types-lint-rule.md
+++ b/tasks/complete/2026-06-23-colocate-single-use-types-lint-rule.md
@@ -1,11 +1,11 @@
 ---
-status: waiting-on-decision
+status: complete
 size: small
 ---
 
 # Colocate Single-Use Types Lint Rule
 
-Status summary: Draft PR is open with the rule only and intentionally leaves 49 current lint violations unfixed. Waiting for the keep-and-fix-vs-scrap decision after CI/review.
+Status summary: Done. The branch adds the lint rule, enables it globally, and moves the existing single-use type declarations next to their only consumer functions so lint/typecheck/tests pass.
 
 ## Goal
 
@@ -15,11 +15,11 @@ Add an internal lint rule that requires non-exported TypeScript types used in se
 
 - The rule should live in the existing internal oxlint plugin.
 - The rule should be enabled in the root oxlint config so CI reports existing violations.
-- For the initial PR, do not fix violations.
+- The initial PR was opened with the rule only so CI showed the violation set; cleanup was added after the keep-and-fix decision.
 - Exported type declarations are exempt.
 - Type declarations with two or more read references are exempt.
 - The first implementation should target `type` aliases and `interface` declarations.
-- A single-use type is compliant when its declaration is the sibling statement immediately before or immediately after the function declaration/variable declaration that uses it.
+- A single-use type is compliant when its declaration is part of a contiguous type block immediately before or immediately after the function declaration/variable declaration that uses it.
 
 ## Checklist
 
@@ -27,6 +27,8 @@ Add an internal lint rule that requires non-exported TypeScript types used in se
 - [x] Enable the rule in `.oxlintrc.json`. _Registered globally as an error so CI shows existing violations._
 - [x] Run a focused lint command to confirm the rule reports existing violations. _`pnpm lint` reports 49 errors from the new rule and exits 1._
 - [x] Push the worktree branch and open a draft PR. _Opened draft PR #1572 against `main`: https://github.com/iterate/iterate/pull/1572._
+- [x] Fix the existing violations. _Moved reported single-use type aliases/interfaces beside their only consumer functions; the rule now permits contiguous adjacent type blocks._
+- [x] Verify the cleanup. _`pnpm format`, `pnpm lint`, `pnpm typecheck`, and `pnpm test` pass._
 
 ## Implementation Log
 
@@ -34,3 +36,6 @@ Add an internal lint rule that requires non-exported TypeScript types used in se
 - Added `iterate/colocate-single-use-types`, targeting non-exported `type` aliases and `interface` declarations with exactly one read reference.
 - Confirmed the first lint run fails with existing colocation violations and no plugin crash.
 - Opened draft PR #1572 so CI can show the full current violation set before cleanup work.
+- Refined adjacency to allow contiguous type-only blocks beside the consumer function; this handles functions with multiple local supporting types without requiring unnecessary inlining.
+- Moved the existing reported types across scripts, OS components/domains, shared helpers, UI, Semaphore, mock-http-proxy, and e2e helpers.
+- Verified cleanup with `pnpm format`, `pnpm lint`, `pnpm typecheck`, and `pnpm test`.


### PR DESCRIPTION
## Summary

Adds `iterate/colocate-single-use-types` to the internal oxlint plugin, enables it as an error, and colocates the existing single-use type aliases/interfaces that the rule reports.

The rule reports non-exported `type` aliases and `interface` declarations with exactly one read reference unless the declaration is part of a contiguous type-only block immediately before or immediately after the function declaration or function-valued variable declaration that uses it. Exported types and types with two or more read references are exempt.

## Example

```ts
// reported
type RunOptions = { dryRun: boolean };

const DEFAULT_DRY_RUN = false;

function run(options: RunOptions) {
  return options.dryRun || DEFAULT_DRY_RUN;
}

// allowed
type RunOptions = { dryRun: boolean };
function run(options: RunOptions) {
  return options.dryRun;
}

// also allowed: one adjacent local type block for one function
type RunOptions = { dryRun: boolean };
type RunResult = { ok: boolean };
function run(options: RunOptions): RunResult {
  return { ok: options.dryRun };
}
```

## Cleanup

The follow-up cleanup commit moves the current violations next to their only consumer functions across scripts, OS UI/domain code, shared helpers, UI components, Semaphore, mock-http-proxy, and e2e helpers. The task file is now complete under `tasks/complete/`.

## Validation

- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-06-23T11:36:53.070Z",
      "headSha": "c92e9e44b0f9639f745e78b27ca4972578cc48ad",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28021191345",
      "shortSha": "c92e9e4",
      "cleanupDurationMs": 10913,
      "deployDurationMs": 26322,
      "testDurationMs": 5500
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-06-23T11:36:53.186Z",
      "headSha": "c92e9e44b0f9639f745e78b27ca4972578cc48ad",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28021191345",
      "shortSha": "c92e9e4",
      "cleanupDurationMs": 11026,
      "deployDurationMs": 25295,
      "testDurationMs": 584
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-06-23T11:36:49.276Z",
      "headSha": "c92e9e44b0f9639f745e78b27ca4972578cc48ad",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-2.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28021191345",
      "shortSha": "c92e9e4",
      "cleanupDurationMs": 7113,
      "deployDurationMs": 18500,
      "testDurationMs": 23690
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-06-23T11:36:41.059Z",
      "headSha": "c92e9e44b0f9639f745e78b27ca4972578cc48ad",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28021191345",
      "shortSha": "c92e9e4",
      "cleanupDurationMs": 38774,
      "deployDurationMs": 55665,
      "testDurationMs": 256365
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `c92e9e4` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 25.3s | 584ms | 11.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28021191345) | 2026-06-23T11:36:53.186Z | Preview app released. |
| OS | released | `c92e9e4` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 55.7s | 256.4s | 38.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28021191345) | 2026-06-23T11:36:41.059Z | Preview app released. |
| Semaphore | released | `c92e9e4` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 26.3s | 5.5s | 10.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28021191345) | 2026-06-23T11:36:53.070Z | Preview app released. |
| Streams Example App | released | `c92e9e4` | [https://streams-example-app-preview-2.iterate-dev-preview.workers.dev](https://streams-example-app-preview-2.iterate-dev-preview.workers.dev) | 18.5s | 23.7s | 7.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28021191345) | 2026-06-23T11:36:49.276Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint and type-placement refactors only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Introduces **`iterate/colocate-single-use-types`** in the internal oxlint plugin and turns it on as an **error** in `.oxlintrc.json`. The rule flags non-exported `type` aliases and `interface` declarations with exactly one read reference unless they sit in a contiguous type-only block immediately before or after the function that uses them; exported types and types referenced more than once are exempt.
> 
> A follow-up pass **moves** the reported declarations next to their consumers across auth, OS (UI, domains, scripts, e2e), shared packages, UI, Semaphore, mock-http-proxy, and preview scripts—behavior is unchanged, only declaration order. **`installDopplerCli`** is reordered earlier in `.github/ts-workflows/utils/index.ts` (same export, no workflow behavior change). The work is documented in **`tasks/complete/2026-06-23-colocate-single-use-types-lint-rule.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c92e9e44b0f9639f745e78b27ca4972578cc48ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->