### PR TITLE
Expose Workers AI through minimal ITX

### DIFF
--- a/apps/minimal-itx-v4/README.md
+++ b/apps/minimal-itx-v4/README.md
@@ -56,6 +56,23 @@ internal project/path scope. Inside loaded code:
 const itx = await env.ITX.get();
 ```
 
+Project and agent-scoped ITX also expose Workers AI through `itx.ai`. The
+minimal app implements this as an `AiRpcTarget` around the platform `env.AI`
+binding:
+
+```ts
+const reply = await itx.ai.run("@cf/meta/llama-3.1-8b-instruct", {
+  messages: [{ role: "user", content: "Say hello" }],
+});
+```
+
+The wrapper is intentionally binding-shaped: `run(model, body)` forwards to the
+home binding, and `models()` forwards when the binding exposes it. The agent
+runtime should treat model names as opaque. Cloudflare's AI binding can run
+Workers AI `@cf/...` models and AI Gateway third-party model names through the
+same `run(...)` entry point, so the agent core should not bake in a provider
+catalog.
+
 External clients still connect to `/api/itx` and call `authenticate(...)`.
 `connectItx` overloads are only client-side convenience:
 
@@ -87,6 +104,80 @@ ITX_BASE=https://your-worker.workers.dev pnpm repl
 The REPL exposes `itx`, `root`, `RpcTarget`, `baseUrl`, `projectId`, and `token`.
 Defaults are `http://127.0.0.1:8791`, project `prj_ref`, and the demo tokens
 from `src/auth.ts`.
+
+## Web Chat LLM Agent
+
+The minimal LLM agent should mirror the real `apps/os` agent shape, but keep
+only the web-chat channel. Slack-specific paths, prompts, and `itx.slack` tools
+do not belong here.
+
+The public entry is still an agent capability:
+
+```ts
+using agent = project.agents.get("/agents/demo");
+await agent.sendMessage("What changed today?");
+const reply = await agent.ask({ message: "Summarize the stream." });
+```
+
+`sendMessage` appends one channel event to the agent stream:
+
+```ts
+{
+  type: "events.iterate.com/agents/user-message-received",
+  payload: { origin: "web", content: message },
+}
+```
+
+The agent core processor owns model-visible history and request scheduling. It
+does not call a model directly:
+
+1. Render web input into `events.iterate.com/agent/input-added`.
+2. Apply the input policy: `after-current-request`, `interrupt-current-request`,
+   or `dont-trigger-request`.
+3. Debounce and append `events.iterate.com/agent/llm-request-requested` with
+   `{ provider, model }`.
+4. Re-render tool responses from `events.iterate.com/agents/web-message-sent`
+   back into history with `dont-trigger-request`.
+5. Extract fenced async JavaScript from `events.iterate.com/agent/output-added`
+   and enqueue ITX script execution.
+
+LLM requests are request-by-reference. The `llm-request-requested` event carries
+no prompt body; its offset is the `llmRequestId`. A subscribed provider
+processor rebuilds the chat request by reducing committed agent history up to
+that offset, then executes the provider call and appends:
+
+```ts
+{ type: "events.iterate.com/<provider>/llm-request-started", payload: { llmRequestId, model } }
+{ type: "events.iterate.com/<provider>/llm-response-chunk", payload: { llmRequestId, sequence, chunk } }
+{ type: "events.iterate.com/agent/output-added", payload: { llmRequestId, content } }
+{ type: "events.iterate.com/agent/llm-request-completed", payload: { llmRequestId, provider, result } }
+```
+
+Provider support should stay behind one small binding boundary:
+
+```ts
+type AiLike = {
+  run(model: string, body: unknown): Promise<unknown>;
+};
+```
+
+The Cloudflare AI provider uses `itx.ai.run(model, { ...body, stream: true })`.
+Response parsing should accept the shapes OS already supports: Workers AI
+`{ response }`, OpenAI-compatible chat completions `{ choices }`, Anthropic
+message blocks `{ content: [...] }`, and streaming SSE chunks from those
+families. Other AI bindings can be mounted by providing the same `run(model,
+body)` capability shape, while the agent protocol and history reduction stay
+unchanged.
+
+The only agent-local channel tool is web chat:
+
+```ts
+await itx.chat.sendMessage({ message: "Done." });
+```
+
+That tool appends `events.iterate.com/agents/web-message-sent`. The agent core
+then records it as model-visible assistant context without triggering another
+LLM request.
 
 ## Stream Processor Hosting
 

--- a/apps/minimal-itx-v4/itx.e2e.test.ts
+++ b/apps/minimal-itx-v4/itx.e2e.test.ts
@@ -362,6 +362,19 @@ describe("minimal itx v4", () => {
     ).rejects.toThrow(/no capability "someMethodInTestRunner.getSecret"/);
   });
 
+  test("Project describe exposes Workers AI as a builtin capability", async () => {
+    using session = withItxSession();
+    using itx = session.authenticate({
+      type: "trusted-internal",
+      token: TRUSTED_INTERNAL_ITX_TOKEN,
+    });
+
+    using project = itx.projects.create({ slug: "ai-builtin" });
+    const description = await project.describe();
+
+    expect(description.capabilities).toContainEqual({ path: ["ai"], type: "builtin" });
+  });
+
   test("Trusted internal root can access global streams and repos", async () => {
     using session = withItxSession();
     using itx = session.authenticate({

--- a/apps/minimal-itx-v4/src/rpc-targets.ts
+++ b/apps/minimal-itx-v4/src/rpc-targets.ts
@@ -34,6 +34,7 @@ import type {
   Agent,
   AgentCollection,
   AgentItx,
+  Ai,
   CfExecutionContext,
   ItxAuth,
   ItxRoot,
@@ -57,6 +58,11 @@ import type {
   DynamicWorkerCollection,
   DynamicWorkerRef,
 } from "./types.ts";
+
+type AiBinding = {
+  models?: () => unknown;
+  run(model: string, body: unknown): Promise<unknown>;
+};
 
 export class StreamRpcTarget extends RpcTarget implements Stream {
   constructor(readonly props: { auth: ItxAuth; projectId: string | null; path: string }) {
@@ -347,6 +353,23 @@ class SecretRpcTarget extends RpcTarget implements Secret {
   }
 }
 
+class AiRpcTarget extends RpcTarget implements Ai {
+  constructor(readonly binding: AiBinding) {
+    super();
+  }
+
+  models() {
+    if (typeof this.binding.models !== "function") {
+      throw new Error("AI binding does not expose models().");
+    }
+    return Promise.resolve(this.binding.models());
+  }
+
+  run(...[model, body]: Parameters<Ai["run"]>) {
+    return this.binding.run(model, body);
+  }
+}
+
 class AgentRpcTarget extends RpcTarget implements Agent {
   constructor(
     readonly props: { auth: ItxAuth; ctx: CfExecutionContext; path: string; projectId: string },
@@ -590,6 +613,7 @@ export class ProjectCollectionRpcTarget extends RpcTarget implements ProjectColl
 
 type ProjectRpcTargetProps = { auth: ItxAuth; ctx: CfExecutionContext; projectId: string };
 const PROJECT_BUILTIN_CAPABILITY_PATHS = [
+  "ai",
   "agents",
   "egress",
   "mcp",
@@ -639,6 +663,10 @@ export class ProjectRpcTarget extends RpcTarget implements Project {
 
   get processor() {
     return this.durableObjectStub.processor;
+  }
+
+  get ai() {
+    return new AiRpcTarget(env.AI);
   }
 
   get #itx() {

--- a/apps/minimal-itx-v4/src/types.ts
+++ b/apps/minimal-itx-v4/src/types.ts
@@ -44,6 +44,7 @@ export interface ProjectCollection {
  * capabilities cannot shadow core project operations.
  */
 export interface Project extends ItxCapabilityHost {
+  ai: Ai;
   agents: AgentCollection;
   describe(): Promise<ProjectDescription>;
   egress: ProjectEgress;
@@ -66,6 +67,12 @@ export interface Project extends ItxCapabilityHost {
  */
 export interface AgentItx extends Project {
   agent: Agent;
+}
+
+/** Workers AI binding exposed through ITX as a project/agent capability. */
+export interface Ai {
+  models(): Promise<unknown>;
+  run(model: string, body: unknown): Promise<unknown>;
 }
 
 /** Agent catalog within one project. */

--- a/apps/minimal-itx-v4/wrangler.jsonc
+++ b/apps/minimal-itx-v4/wrangler.jsonc
@@ -12,6 +12,9 @@
       "enabled": true,
     },
   },
+  "ai": {
+    "binding": "AI",
+  },
   "durable_objects": {
     "bindings": [
       // Domain objects own their domain workflows. ITX owns the dynamic capability host.


### PR DESCRIPTION
## Summary

- expose the Workers AI binding as project/agent ITX capability `ai`
- include `ai` in project descriptions as a built-in capability
- document the minimal web-chat LLM agent shape and AI provider boundary

## Validation

- `pnpm exec oxlint . --threads 1 --deny-warnings`
- `pnpm typecheck`
- `pnpm knip`
- `pnpm --dir apps/minimal-itx-v4 e2e itx.e2e.test.ts -t "Project describe exposes Workers AI"`
