### PR TITLE
[codex] Add minimal ITX web chat agent

### DIFF
--- a/apps/minimal-itx-v4/README.md
+++ b/apps/minimal-itx-v4/README.md
@@ -56,6 +56,23 @@ internal project/path scope. Inside loaded code:
 const itx = await env.ITX.get();
 ```
 
+Project and agent-scoped ITX also expose Workers AI through `itx.ai`. The
+minimal app implements this as an `AiRpcTarget` around the platform `env.AI`
+binding:
+
+```ts
+const reply = await itx.ai.run("@cf/moonshotai/kimi-k2.7-code", {
+  messages: [{ role: "user", content: "Say hello" }],
+});
+```
+
+The wrapper is intentionally binding-shaped: `run(model, body)` forwards to the
+home binding, and `models()` forwards when the binding exposes it. The agent
+runtime should treat model names as opaque. Cloudflare's AI binding can run
+Workers AI `@cf/...` models and AI Gateway third-party model names through the
+same `run(...)` entry point, so the agent core should not bake in a provider
+catalog.
+
 External clients still connect to `/api/itx` and call `authenticate(...)`.
 `connectItx` overloads are only client-side convenience:
 
@@ -87,6 +104,92 @@ ITX_BASE=https://your-worker.workers.dev pnpm repl
 The REPL exposes `itx`, `root`, `RpcTarget`, `baseUrl`, `projectId`, and `token`.
 Defaults are `http://127.0.0.1:8791`, project `prj_ref`, and the demo tokens
 from `src/auth.ts`.
+
+## Web Chat LLM Agent
+
+The minimal LLM agent should mirror the real `apps/os` agent shape, but keep
+only the web-chat channel. Slack-specific paths, prompts, and `itx.slack` tools
+do not belong here.
+
+The public entry is still an agent capability:
+
+```ts
+using agent = project.agents.get("/agents/demo");
+await agent.sendMessage("What changed today?");
+const reply = await agent.ask({ message: "Summarize the stream." });
+```
+
+`sendMessage` appends one channel event to the agent stream:
+
+```ts
+{
+  type: "events.iterate.com/agents/user-message-received",
+  payload: { origin: "web", content: message },
+}
+```
+
+The agent core processor owns model-visible history and request scheduling. It
+does not call a model directly:
+
+1. Render web input into `events.iterate.com/agent/input-added`.
+2. Apply the input policy: `after-current-request`, `interrupt-current-request`,
+   or `dont-trigger-request`.
+3. Debounce and append `events.iterate.com/agent/llm-request-requested` with
+   `{ provider, model }`.
+4. Re-render tool responses from `events.iterate.com/agents/web-message-sent`
+   back into history with `dont-trigger-request`.
+5. Extract the fenced JavaScript async arrow function from
+   `events.iterate.com/agent/output-added` and enqueue ITX script execution.
+
+The default web-chat prompt follows the OS agent contract: respond with exactly
+one fenced JavaScript code block and no surrounding prose. The code block must
+contain a single async arrow function:
+
+```js
+async (itx) => {
+  await itx.chat.sendMessage({ message: "Done." });
+};
+```
+
+LLM requests are request-by-reference. The `llm-request-requested` event carries
+no prompt body; its offset is the `llmRequestId`. A subscribed provider
+processor rebuilds the chat request by reducing committed agent history up to
+that offset, then executes the provider call and appends:
+
+```ts
+{ type: "events.iterate.com/<provider>/llm-request-started", payload: { llmRequestId, model } }
+{ type: "events.iterate.com/<provider>/llm-response-chunk", payload: { llmRequestId, sequence, chunk } }
+{ type: "events.iterate.com/agent/output-added", payload: { llmRequestId, content } }
+{ type: "events.iterate.com/agent/llm-request-completed", payload: { llmRequestId, provider, result } }
+```
+
+Provider support should stay behind one small binding boundary:
+
+```ts
+type AiLike = {
+  run(model: string, body: unknown): Promise<unknown>;
+};
+```
+
+The Cloudflare AI provider receives `env.AI` behind this `AiLike` boundary and
+calls `ai.run(model, { ...body, stream: true })`. The public `project.ai`
+capability is an `AiRpcTarget` over the same binding for direct scripts.
+Response parsing should accept the shapes OS already supports: Workers AI
+`{ response }`, OpenAI-compatible chat completions `{ choices }`, Anthropic
+message blocks `{ content: [...] }`, and streaming SSE chunks from those
+families. Other AI bindings can be mounted by providing the same `run(model,
+body)` capability shape, while the agent protocol and history reduction stay
+unchanged.
+
+The only agent-local channel tool is web chat:
+
+```ts
+await itx.chat.sendMessage({ message: "Done." });
+```
+
+That tool appends `events.iterate.com/agents/web-message-sent`. The agent core
+then records it as model-visible assistant context without triggering another
+LLM request.
 
 ## Stream Processor Hosting
 

--- a/apps/minimal-itx-v4/README.md
+++ b/apps/minimal-itx-v4/README.md
@@ -57,8 +57,8 @@ const itx = await env.ITX.get();
 ```
 
 Project and agent-scoped ITX also expose Workers AI through `itx.ai`. The
-minimal app implements this as an `AiRpcTarget` around the platform `env.AI`
-binding:
+minimal app implements this as an `AiRpcTarget` that proxies the platform
+`env.AI` binding directly:
 
 ```ts
 const reply = await itx.ai.run("@cf/moonshotai/kimi-k2.7-code", {
@@ -66,12 +66,13 @@ const reply = await itx.ai.run("@cf/moonshotai/kimi-k2.7-code", {
 });
 ```
 
-The wrapper is intentionally binding-shaped: `run(model, body)` forwards to the
-home binding, and `models()` forwards when the binding exposes it. The agent
-runtime should treat model names as opaque. Cloudflare's AI binding can run
-Workers AI `@cf/...` models and AI Gateway third-party model names through the
-same `run(...)` entry point, so the agent core should not bake in a provider
-catalog.
+The wrapper keeps the Cloudflare binding shape visible: `run(model, body)`
+forwards to `env.AI.run(...)`, `models()` forwards to `env.AI.models()`, and the
+constructor can carry AI Gateway options that are passed as the third
+`env.AI.run(...)` argument. The agent runtime should treat model names as
+opaque. Cloudflare's AI binding can run Workers AI `@cf/...` models and AI
+Gateway third-party model names through the same `run(...)` entry point, so the
+agent core should not bake in a provider catalog.
 
 External clients still connect to `/api/itx` and call `authenticate(...)`.
 `connectItx` overloads are only client-side convenience:
@@ -171,11 +172,11 @@ type AiLike = {
 };
 ```
 
-The Cloudflare AI provider receives `env.AI` behind this `AiLike` boundary and
-calls `ai.run(model, { ...body, stream: true })`. The public `project.ai`
-capability is an `AiRpcTarget` over the same binding for direct scripts.
-Response parsing should accept the shapes OS already supports: Workers AI
-`{ response }`, OpenAI-compatible chat completions `{ choices }`, Anthropic
+The Cloudflare AI provider receives only this minimal `run(...)` shape and calls
+`ai.run(model, { ...body, stream: true })`. The public `project.ai` capability
+uses `AiRpcTarget` to proxy the Worker-global `env.AI` binding for direct
+scripts. Response parsing should accept the shapes OS already supports: Workers
+AI `{ response }`, OpenAI-compatible chat completions `{ choices }`, Anthropic
 message blocks `{ content: [...] }`, and streaming SSE chunks from those
 families. Other AI bindings can be mounted by providing the same `run(model,
 body)` capability shape, while the agent protocol and history reduction stay

--- a/apps/minimal-itx-v4/itx.e2e.test.ts
+++ b/apps/minimal-itx-v4/itx.e2e.test.ts
@@ -18,7 +18,7 @@ import {
 } from "./src/domains/streams/stream-processor.ts";
 
 const PROJECT_WORKER_FORWARDED_EVENT_TYPE = "events.iterate.test/project-worker-forwarded";
-const AGENT_WEB_MESSAGE_SENT_TYPE = "events.iterate.com/agent/web-message-sent";
+const AGENT_WEB_MESSAGE_SENT_TYPE = "events.iterate.com/agents/web-message-sent";
 const AGENT_OUTPUT_ADDED_TYPE = "events.iterate.com/agent/output-added";
 const EGRESS_PROOF_HEADER = "x-itx-egress-proof";
 
@@ -362,6 +362,19 @@ describe("minimal itx v4", () => {
     ).rejects.toThrow(/no capability "someMethodInTestRunner.getSecret"/);
   });
 
+  test("Project describe exposes Workers AI as a builtin capability", async () => {
+    using session = withItxSession();
+    using itx = session.authenticate({
+      type: "trusted-internal",
+      token: TRUSTED_INTERNAL_ITX_TOKEN,
+    });
+
+    using project = itx.projects.create({ slug: "ai-builtin" });
+    const description = await project.describe();
+
+    expect(description.capabilities).toContainEqual({ path: ["ai"], type: "builtin" });
+  });
+
   test("Trusted internal root can access global streams and repos", async () => {
     using session = withItxSession();
     using itx = session.authenticate({
@@ -482,7 +495,7 @@ describe("minimal itx v4", () => {
       expect((await project.repos.list()).some((item) => item.path.startsWith("/repos/"))).toBe(
         true,
       );
-      expect((await project.agents.get(agentPath).processor.snapshot()).state.inputs).toEqual([]);
+      expect((await project.agents.get(agentPath).processor.snapshot()).state.history).toEqual([]);
       expect((await project.repo.processor.snapshot()).state.created).toBe(true);
       expect((await secret.processor.snapshot()).state.egress).toEqual({ urls: [echo.url] });
     } finally {
@@ -1305,7 +1318,7 @@ describe("minimal itx v4", () => {
     });
   });
 
-  test("Agent ask runs the faux web-chat loop and agent scripts can call project tools", async () => {
+  test("Agent scripts can send web-chat messages and call project tools", async () => {
     using session = withItxSession();
     using itx = session.authenticate({
       type: "trusted-internal",
@@ -1326,28 +1339,7 @@ describe("minimal itx v4", () => {
       },
     });
 
-    const reply = await agent.ask({ message: "hello agent" });
-    expect(reply).toMatchObject({
-      type: AGENT_WEB_MESSAGE_SENT_TYPE,
-      payload: { message: "This is the response to 'hello agent'" },
-    });
-
-    const askEvents = await agent.stream.getEvents();
-    expect(askEvents.map((event) => event.type)).toEqual(
-      expect.arrayContaining([
-        "events.iterate.com/agent/user-message-received",
-        "events.iterate.com/agent/input-added",
-        "events.iterate.com/agent/llm-request-scheduled",
-        "events.iterate.com/agent/llm-request-requested",
-        AGENT_OUTPUT_ADDED_TYPE,
-        "events.iterate.com/itx/script-execution-requested",
-        "events.iterate.com/itx/script-execution-completed",
-        AGENT_WEB_MESSAGE_SENT_TYPE,
-      ]),
-    );
-
     const projectToolReply = agent.stream.waitForEvent({
-      afterOffset: reply.offset,
       eventTypes: [AGENT_WEB_MESSAGE_SENT_TYPE],
       predicate: (event) => event.payload?.message === "project tool saw project-capability",
       timeoutMs: 30_000,
@@ -1359,10 +1351,7 @@ describe("minimal itx v4", () => {
         content: fencedAgentScript(`
           async (itx) => {
             const message = await itx.projectTool.format({ text: "project-capability" });
-            await itx.agent.stream.append({
-              type: ${JSON.stringify(AGENT_WEB_MESSAGE_SENT_TYPE)},
-              payload: { message },
-            });
+            await itx.chat.sendMessage({ message });
           }
         `),
       },
@@ -1372,6 +1361,17 @@ describe("minimal itx v4", () => {
       type: AGENT_WEB_MESSAGE_SENT_TYPE,
       payload: { message: "project tool saw project-capability" },
     });
+
+    const events = await agent.stream.getEvents();
+    expect(events.map((event) => event.type)).toEqual(
+      expect.arrayContaining([
+        AGENT_OUTPUT_ADDED_TYPE,
+        "events.iterate.com/itx/script-execution-requested",
+        "events.iterate.com/itx/script-execution-completed",
+        AGENT_WEB_MESSAGE_SENT_TYPE,
+        "events.iterate.com/agent/input-added",
+      ]),
+    );
   });
 
   test("New agent streams install processors and replay existing child events", async () => {
@@ -1388,10 +1388,7 @@ describe("minimal itx v4", () => {
 
     const content = fencedAgentScript(`
       async (itx) => {
-        await itx.agent.stream.append({
-          type: ${JSON.stringify(AGENT_WEB_MESSAGE_SENT_TYPE)},
-          payload: { message: ${JSON.stringify(marker)} },
-        });
+        await itx.chat.sendMessage({ message: ${JSON.stringify(marker)} });
       }
     `);
     const [historicalOutput] = await agent.stream.append({
@@ -1418,7 +1415,18 @@ describe("minimal itx v4", () => {
     const agentSubscriptionOffset = events.find(
       (event) =>
         event.type === "events.iterate.com/stream/subscription-configured" &&
-        (event.payload as { subscriber?: { type?: string } }).subscriber?.type === "agent",
+        (event.payload as { subscriptionKey?: string; subscriber?: { type?: string } }).subscriber
+          ?.type === "agent" &&
+        String((event.payload as { subscriptionKey?: string }).subscriptionKey).endsWith("#agent"),
+    )?.offset;
+    const cloudflareAiSubscriptionOffset = events.find(
+      (event) =>
+        event.type === "events.iterate.com/stream/subscription-configured" &&
+        (event.payload as { subscriptionKey?: string; subscriber?: { type?: string } }).subscriber
+          ?.type === "agent" &&
+        String((event.payload as { subscriptionKey?: string }).subscriptionKey).endsWith(
+          "#cloudflare-ai",
+        ),
     )?.offset;
     const itxSubscriptionOffset = events.find(
       (event) =>
@@ -1428,10 +1436,15 @@ describe("minimal itx v4", () => {
     const scriptRequestedOffset = events.find(
       (event) => event.type === "events.iterate.com/itx/script-execution-requested",
     )?.offset;
+    const modelSelectionOffset = events.find(
+      (event) => event.type === "events.iterate.com/agent/llm-provider-selected",
+    )?.offset;
 
     expect(outputOffset).toBe(historicalOutput.offset);
     expect(agentSubscriptionOffset).toBeGreaterThan(historicalOutput.offset);
+    expect(cloudflareAiSubscriptionOffset).toBeGreaterThan(historicalOutput.offset);
     expect(itxSubscriptionOffset).toBeGreaterThan(historicalOutput.offset);
+    expect(modelSelectionOffset).toBeGreaterThan(historicalOutput.offset);
     expect(scriptRequestedOffset).toBeGreaterThan(agentSubscriptionOffset!);
   });
 
@@ -1514,16 +1527,13 @@ describe("minimal itx v4", () => {
             const probe = await itx.agent.agentProbe.inspect("agent-only");
             const first = await itx.agent.agentCounter.increment();
             const current = await itx.agent.agentCounter.current();
-            await itx.agent.stream.append({
-              type: ${JSON.stringify(AGENT_WEB_MESSAGE_SENT_TYPE)},
-              payload: {
-                message: JSON.stringify({
-                  durableWorkerKey: ${JSON.stringify(durableWorkerKey)},
-                  current,
-                  first,
-                  probe,
-                }),
-              },
+            await itx.chat.sendMessage({
+              message: JSON.stringify({
+                durableWorkerKey: ${JSON.stringify(durableWorkerKey)},
+                current,
+                first,
+                probe,
+              }),
             });
           }
         `),

--- a/apps/minimal-itx-v4/src/domains/agents/agent-durable-object.ts
+++ b/apps/minimal-itx-v4/src/domains/agents/agent-durable-object.ts
@@ -8,20 +8,32 @@ import {
 import { StreamRpcTarget } from "../../rpc-targets.ts";
 import { AgentProcessorContract } from "./agent-processor-contract.ts";
 import { AgentProcessor } from "./agent-processor-implementation.ts";
+import { CloudflareAiProcessorContract } from "./cloudflare-ai-processor-contract.ts";
+import { CloudflareAiProcessor } from "./cloudflare-ai-processor-implementation.ts";
 import { parseAgentDurableObjectName } from "./utils.ts";
 
 export class AgentDurableObject extends DurableObject<Env> {
   readonly #name = parseAgentDurableObjectName(this.ctx.id.name!);
+  readonly #stream = new StreamRpcTarget({
+    auth: trustedInternalAuthContext(),
+    path: this.#name.path,
+    projectId: this.#name.projectId,
+  });
   readonly #processorHost = createStreamProcessorHost(this.ctx, {
-    stream: new StreamRpcTarget({
-      auth: trustedInternalAuthContext(),
-      path: this.#name.path,
-      projectId: this.#name.projectId,
-    }),
+    stream: this.#stream,
   });
   readonly #agentProcessor = this.#processorHost.add(
     AgentProcessorContract.slug,
     (deps) => new AgentProcessor(deps),
+  );
+  readonly cloudflareAiProcessor = this.#processorHost.add(
+    CloudflareAiProcessorContract.slug,
+    (deps) =>
+      new CloudflareAiProcessor({
+        ...deps,
+        ai: this.env.AI,
+        readStreamEvents: () => this.#stream.getEvents(),
+      }),
   );
 
   wakeStreamSubscriber(args: StreamSubscriberWakeRequest): Promise<void> {

--- a/apps/minimal-itx-v4/src/domains/agents/agent-processor-contract.ts
+++ b/apps/minimal-itx-v4/src/domains/agents/agent-processor-contract.ts
@@ -39,6 +39,7 @@ export const AgentProcessorContract = defineProcessorContract({
       })
       .default({ model: DEFAULT_AGENT_MODEL }),
     llmProvider: z.literal("cloudflare-ai").default("cloudflare-ai"),
+    llmProviderConfigured: z.boolean().default(false),
     currentRequest: z
       .discriminatedUnion("phase", [
         z.object({
@@ -119,6 +120,7 @@ export const AgentProcessorContract = defineProcessorContract({
       payloadSchema: z.object({
         model: z.string().min(1),
         provider: z.literal("cloudflare-ai"),
+        requestId: z.string(),
       }),
     },
     "events.iterate.com/agent/llm-request-completed": {

--- a/apps/minimal-itx-v4/src/domains/agents/agent-processor-contract.ts
+++ b/apps/minimal-itx-v4/src/domains/agents/agent-processor-contract.ts
@@ -2,92 +2,183 @@ import { z } from "zod";
 import { defineProcessorContract } from "../streams/stream-processor.ts";
 import { ItxProcessorContract } from "../itx/itx-processor-contract.ts";
 
+export const DEFAULT_AGENT_MODEL = "@cf/moonshotai/kimi-k2.7-code";
+export const DEFAULT_AGENT_LLM_REQUEST_DEBOUNCE_MS = 250;
+export const DEFAULT_AGENT_SYSTEM_PROMPT = [
+  "You are the minimal ITX web chat agent.",
+  "Respond with exactly one fenced JavaScript code block and no surrounding prose.",
+  "The code block must contain a single async arrow function: async (itx) => { ... }.",
+  "For web chat, reply with await itx.chat.sendMessage({ message }). Do not return side-effect-only call results unless you need to inspect them on your next turn.",
+  "Use project capabilities on itx when they are relevant.",
+].join("\n");
+
+const ChatMessage = z.object({
+  role: z.enum(["user", "assistant"]),
+  content: z.string(),
+});
+
+const LlmRequestPolicy = z
+  .discriminatedUnion("behaviour", [
+    z.object({ behaviour: z.literal("dont-trigger-request") }),
+    z.object({ behaviour: z.literal("interrupt-current-request") }),
+    z.object({ behaviour: z.literal("after-current-request") }),
+  ])
+  .default({ behaviour: "after-current-request" });
+
 export const AgentProcessorContract = defineProcessorContract({
   slug: "agent",
-  version: "0.1.0",
-  description: "Tiny faux-agent loop for minimal ITX v4.",
+  version: "0.2.0",
+  description:
+    "Maintains model-visible web-chat history and requests LLM work from a provider processor.",
   stateSchema: z.object({
-    inputs: z
-      .array(
+    systemPrompt: z.string().default(DEFAULT_AGENT_SYSTEM_PROMPT),
+    history: z.array(ChatMessage).default([]),
+    llmConfig: z
+      .object({
+        model: z.string().min(1),
+      })
+      .default({ model: DEFAULT_AGENT_MODEL }),
+    llmProvider: z.literal("cloudflare-ai").default("cloudflare-ai"),
+    currentRequest: z
+      .discriminatedUnion("phase", [
         z.object({
-          content: z.string(),
-          offset: z.number(),
+          phase: z.literal("scheduled"),
+          requestId: z.string(),
+          scheduledOffset: z.number().int().positive(),
         }),
-      )
-      .default([]),
-    outputs: z
-      .array(
         z.object({
-          content: z.string(),
-          offset: z.number(),
+          phase: z.literal("requested"),
+          llmRequestId: z.number().int().positive(),
         }),
-      )
-      .default([]),
-    scheduledRequests: z.record(z.string(), z.number()).default({}),
+      ])
+      .nullable()
+      .default(null),
+    pendingTriggerOffset: z.number().int().positive().nullable().default(null),
     scriptExecutionsCompleted: z.array(z.string()).default([]),
   }),
   events: {
-    "events.iterate.com/agent/user-message-received": {
-      description: "The web UI sent a user message to the agent.",
-      payloadSchema: z.looseObject({
-        content: z.string(),
-        origin: z.string(),
+    "events.iterate.com/agent/config-updated": {
+      description: "Project-authored agent setup/configuration.",
+      payloadSchema: z.object({
+        systemPrompt: z.string().optional(),
+      }),
+    },
+    "events.iterate.com/agent/system-prompt-updated": {
+      description: "Updates the system prompt used for future LLM requests.",
+      payloadSchema: z.object({
+        systemPrompt: z.string(),
       }),
     },
     "events.iterate.com/agent/input-added": {
       description: "A normalized model-visible input was added.",
-      payloadSchema: z.looseObject({
+      payloadSchema: z.object({
         content: z.string(),
-        origin: z.string().optional(),
-        sourceOffset: z.number().optional(),
+        llmRequestPolicy: LlmRequestPolicy,
+      }),
+    },
+    "events.iterate.com/agents/user-message-received": {
+      description: "The web UI sent a user message to the agent.",
+      payloadSchema: z.object({
+        content: z.string(),
+        origin: z.literal("web"),
+      }),
+    },
+    "events.iterate.com/agents/web-message-sent": {
+      description: "A visible agent message was sent to the web UI.",
+      payloadSchema: z.object({
+        message: z.string(),
+      }),
+    },
+    "events.iterate.com/agent/output-added": {
+      description: "The LLM provider produced assistant output.",
+      payloadSchema: z.object({
+        content: z.string(),
+        llmRequestId: z.number().int().positive().optional(),
+      }),
+    },
+    "events.iterate.com/agent/llm-provider-selected": {
+      description: "Selects the model for future LLM requests.",
+      payloadSchema: z.object({
+        ifUnset: z.boolean().optional(),
+        model: z.string().min(1),
+        provider: z.literal("cloudflare-ai"),
       }),
     },
     "events.iterate.com/agent/llm-request-scheduled": {
-      description: "A faux LLM request should be requested after a short debounce.",
-      payloadSchema: z.looseObject({
-        debounceMs: z.number(),
-        inputOffset: z.number(),
+      description: "An LLM request was scheduled after a trigger.",
+      payloadSchema: z.object({
+        debounceMs: z.number().int().nonnegative(),
+        model: z.string().min(1),
+        provider: z.literal("cloudflare-ai"),
         requestId: z.string(),
       }),
     },
     "events.iterate.com/agent/llm-request-requested": {
-      description: "The faux LLM request is ready to run.",
-      payloadSchema: z.looseObject({
-        inputOffset: z.number(),
-        requestId: z.string(),
+      description:
+        "The agent has prepared an LLM request. The event offset is the llmRequestId; providers rebuild the prompt from history.",
+      payloadSchema: z.object({
+        model: z.string().min(1),
+        provider: z.literal("cloudflare-ai"),
       }),
     },
-    "events.iterate.com/agent/output-added": {
-      description: "The faux LLM produced assistant output, usually codemode.",
-      payloadSchema: z.looseObject({
-        content: z.string(),
-        inputOffset: z.number().optional(),
-        requestId: z.string().optional(),
+    "events.iterate.com/agent/llm-request-completed": {
+      description: "A provider processor finished an LLM request.",
+      payloadSchema: z.object({
+        durationMs: z.number().int().nonnegative(),
+        llmRequestId: z.number().int().positive(),
+        provider: z.literal("cloudflare-ai"),
+        result: z.discriminatedUnion("status", [
+          z.object({
+            rawResponse: z.unknown().optional(),
+            status: z.literal("success"),
+            usage: z.unknown().optional(),
+          }),
+          z.object({
+            error: z.object({ message: z.string() }),
+            rawResponse: z.unknown().optional(),
+            status: z.literal("failure"),
+          }),
+        ]),
       }),
     },
-    "events.iterate.com/agent/web-message-sent": {
-      description: "A visible agent message was sent to the web UI.",
-      payloadSchema: z.looseObject({
-        message: z.string(),
-      }),
+    "events.iterate.com/agent/llm-request-cancelled": {
+      description: "The current scheduled or requested LLM request was cancelled.",
+      payloadSchema: z.discriminatedUnion("phase", [
+        z.object({
+          phase: z.literal("scheduled"),
+          reason: z.literal("interrupted-by-user-input"),
+          requestId: z.string(),
+        }),
+        z.object({
+          phase: z.literal("requested"),
+          reason: z.literal("interrupted-by-user-input"),
+          llmRequestId: z.number().int().positive(),
+        }),
+      ]),
     },
   },
   processorDeps: [ItxProcessorContract],
   consumes: [
-    "events.iterate.com/agent/user-message-received",
+    "events.iterate.com/agent/config-updated",
+    "events.iterate.com/agent/system-prompt-updated",
     "events.iterate.com/agent/input-added",
+    "events.iterate.com/agents/user-message-received",
+    "events.iterate.com/agents/web-message-sent",
+    "events.iterate.com/agent/output-added",
+    "events.iterate.com/agent/llm-provider-selected",
     "events.iterate.com/agent/llm-request-scheduled",
     "events.iterate.com/agent/llm-request-requested",
-    "events.iterate.com/agent/output-added",
-    "events.iterate.com/agent/web-message-sent",
+    "events.iterate.com/agent/llm-request-completed",
+    "events.iterate.com/agent/llm-request-cancelled",
     "events.iterate.com/itx/script-execution-requested",
     "events.iterate.com/itx/script-execution-completed",
   ],
   emits: [
+    "events.iterate.com/agent/system-prompt-updated",
     "events.iterate.com/agent/input-added",
     "events.iterate.com/agent/llm-request-scheduled",
     "events.iterate.com/agent/llm-request-requested",
-    "events.iterate.com/agent/output-added",
+    "events.iterate.com/agent/llm-request-cancelled",
     "events.iterate.com/itx/script-execution-requested",
   ],
 });

--- a/apps/minimal-itx-v4/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/minimal-itx-v4/src/domains/agents/agent-processor-implementation.ts
@@ -32,7 +32,7 @@ export class AgentProcessor extends StreamProcessor<typeof AgentProcessorContrac
     state,
   }: Parameters<StreamProcessor<typeof AgentProcessorContract>["processEvent"]>[0]): undefined {
     switch (event.type) {
-      case "events.iterate.com/agent/config-updated":
+      case "events.iterate.com/agent/config-updated": {
         if (event.payload.systemPrompt === undefined) return;
         const { systemPrompt } = event.payload;
         blockProcessorWhile(() =>
@@ -43,6 +43,7 @@ export class AgentProcessor extends StreamProcessor<typeof AgentProcessorContrac
           }),
         );
         return;
+      }
       case "events.iterate.com/agents/user-message-received":
         blockProcessorWhile(() =>
           append({

--- a/apps/minimal-itx-v4/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/minimal-itx-v4/src/domains/agents/agent-processor-implementation.ts
@@ -15,6 +15,7 @@ type LlmRequestPolicy = Extract<
 
 export class AgentProcessor extends StreamProcessor<typeof AgentProcessorContract> {
   readonly contract = AgentProcessorContract;
+  readonly #scheduledRequestsWithActiveTimers = new Set<string>();
 
   protected override reduce({
     event,
@@ -80,17 +81,22 @@ export class AgentProcessor extends StreamProcessor<typeof AgentProcessorContrac
         });
         return;
       case "events.iterate.com/agent/llm-request-scheduled":
+        this.#scheduledRequestsWithActiveTimers.add(event.payload.requestId);
         runInBackground(async () => {
           await new Promise<void>((resolve) => setTimeout(resolve, event.payload.debounceMs));
-          await append({
-            type: "events.iterate.com/agent/llm-request-requested",
-            idempotencyKey: `agent/llm-request-requested@${event.offset}`,
-            payload: {
-              model: event.payload.model,
-              provider: event.payload.provider,
-              requestId: event.payload.requestId,
-            },
-          });
+          try {
+            await append({
+              type: "events.iterate.com/agent/llm-request-requested",
+              idempotencyKey: `agent/llm-request-requested@${event.offset}`,
+              payload: {
+                model: event.payload.model,
+                provider: event.payload.provider,
+                requestId: event.payload.requestId,
+              },
+            });
+          } finally {
+            this.#scheduledRequestsWithActiveTimers.delete(event.payload.requestId);
+          }
         });
         return;
       case "events.iterate.com/agent/output-added":
@@ -121,6 +127,27 @@ export class AgentProcessor extends StreamProcessor<typeof AgentProcessorContrac
       default:
         return;
     }
+  }
+
+  protected override async processEventBatch(
+    args: Parameters<StreamProcessor<typeof AgentProcessorContract>["processEventBatch"]>[0],
+  ): Promise<void> {
+    await super.processEventBatch(args);
+    const scheduled = args.state.currentRequest;
+    if (scheduled?.phase !== "scheduled") return;
+    if (this.#scheduledRequestsWithActiveTimers.has(scheduled.requestId)) return;
+    // No active timer for this scheduled request: the DO restarted and lost the
+    // debounce. Fire llm-request-requested immediately. The idempotency key
+    // makes this safe if the timer also fires concurrently.
+    await args.append({
+      type: "events.iterate.com/agent/llm-request-requested",
+      idempotencyKey: `agent/llm-request-requested@${scheduled.scheduledOffset}`,
+      payload: {
+        model: args.state.llmConfig.model,
+        provider: args.state.llmProvider,
+        requestId: scheduled.requestId,
+      },
+    });
   }
 
   async #handleInputAdded(input: {

--- a/apps/minimal-itx-v4/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/minimal-itx-v4/src/domains/agents/agent-processor-implementation.ts
@@ -1,7 +1,17 @@
+import { z } from "zod";
+import type { StreamEvent } from "../../types.ts";
 import { StreamProcessor } from "../streams/stream-processor.ts";
-import { AgentProcessorContract } from "./agent-processor-contract.ts";
+import {
+  AgentProcessorContract,
+  DEFAULT_AGENT_LLM_REQUEST_DEBOUNCE_MS,
+} from "./agent-processor-contract.ts";
 
-const FAUX_LLM_DEBOUNCE_MS = 1_000;
+type AgentState = z.infer<typeof AgentProcessorContract.stateSchema>;
+type AgentConsumedEvent = ReturnType<typeof AgentProcessorContract.parseEvent>;
+type LlmRequestPolicy = Extract<
+  AgentConsumedEvent,
+  { type: "events.iterate.com/agent/input-added" }
+>["payload"]["llmRequestPolicy"];
 
 export class AgentProcessor extends StreamProcessor<typeof AgentProcessorContract> {
   readonly contract = AgentProcessorContract;
@@ -10,89 +20,74 @@ export class AgentProcessor extends StreamProcessor<typeof AgentProcessorContrac
     event,
     state,
   }: Parameters<StreamProcessor<typeof AgentProcessorContract>["reduce"]>[0]) {
-    switch (event.type) {
-      case "events.iterate.com/agent/input-added":
-        return {
-          ...state,
-          inputs: [
-            ...state.inputs,
-            {
-              content: event.payload.content,
-              offset: event.offset,
-            },
-          ],
-        };
-      case "events.iterate.com/agent/llm-request-scheduled":
-        return {
-          ...state,
-          scheduledRequests: {
-            ...state.scheduledRequests,
-            [event.payload.requestId]: event.payload.inputOffset,
-          },
-        };
-      case "events.iterate.com/agent/llm-request-requested": {
-        const scheduledRequests = { ...state.scheduledRequests };
-        delete scheduledRequests[event.payload.requestId];
-        return { ...state, scheduledRequests };
-      }
-      case "events.iterate.com/agent/output-added":
-        return {
-          ...state,
-          outputs: [...state.outputs, { content: event.payload.content, offset: event.offset }],
-        };
-      case "events.iterate.com/itx/script-execution-completed":
-        return {
-          ...state,
-          scriptExecutionsCompleted: [
-            ...state.scriptExecutionsCompleted,
-            event.payload.executionId,
-          ],
-        };
-      default:
-        return state;
-    }
+    return reduceAgentEvent({ event, state });
   }
 
   protected override processEvent({
     append,
     blockProcessorWhile,
     event,
+    previousState,
     runInBackground,
+    state,
   }: Parameters<StreamProcessor<typeof AgentProcessorContract>["processEvent"]>[0]): undefined {
     switch (event.type) {
-      case "events.iterate.com/agent/user-message-received":
-        blockProcessorWhile(async () => {
-          await append({
+      case "events.iterate.com/agent/config-updated":
+        if (event.payload.systemPrompt === undefined) return;
+        const { systemPrompt } = event.payload;
+        blockProcessorWhile(() =>
+          append({
+            type: "events.iterate.com/agent/system-prompt-updated",
+            idempotencyKey: `agent/system-prompt-updated@${event.offset}`,
+            payload: { systemPrompt },
+          }),
+        );
+        return;
+      case "events.iterate.com/agents/user-message-received":
+        blockProcessorWhile(() =>
+          append({
             type: "events.iterate.com/agent/input-added",
-            idempotencyKey: `agent/input-added@${event.offset}`,
+            idempotencyKey: `agent/render-web-message@${event.offset}`,
             payload: {
               content: event.payload.content,
-              origin: event.payload.origin,
-              sourceOffset: event.offset,
+              llmRequestPolicy: { behaviour: "after-current-request" },
             },
-          });
-        });
+          }),
+        );
+        return;
+      case "events.iterate.com/agents/web-message-sent":
+        blockProcessorWhile(() =>
+          append({
+            type: "events.iterate.com/agent/input-added",
+            idempotencyKey: `agent/render-web-response@${event.offset}`,
+            payload: {
+              content: `The assistant sent this visible web-chat message: ${event.payload.message}`,
+              llmRequestPolicy: { behaviour: "dont-trigger-request" },
+            },
+          }),
+        );
         return;
       case "events.iterate.com/agent/input-added":
         blockProcessorWhile(async () => {
-          await append({
-            type: "events.iterate.com/agent/llm-request-scheduled",
-            idempotencyKey: `agent/llm-request-scheduled@${event.offset}`,
-            payload: {
-              debounceMs: FAUX_LLM_DEBOUNCE_MS,
-              inputOffset: event.offset,
-              requestId: `faux-llm-request:${event.offset}`,
-            },
+          await this.#handleInputAdded({
+            append,
+            event,
+            policy: event.payload.llmRequestPolicy,
+            previousState,
+            state,
           });
         });
         return;
       case "events.iterate.com/agent/llm-request-scheduled":
         runInBackground(async () => {
           await new Promise<void>((resolve) => setTimeout(resolve, event.payload.debounceMs));
-          await this.#appendFauxLlmOutput({
-            append,
-            inputOffset: event.payload.inputOffset,
-            requestId: event.payload.requestId,
+          await append({
+            type: "events.iterate.com/agent/llm-request-requested",
+            idempotencyKey: `agent/llm-request-requested@${event.offset}`,
+            payload: {
+              model: event.payload.model,
+              provider: event.payload.provider,
+            },
           });
         });
         return;
@@ -110,52 +105,198 @@ export class AgentProcessor extends StreamProcessor<typeof AgentProcessorContrac
           });
         });
         return;
+      case "events.iterate.com/agent/llm-request-completed":
+      case "events.iterate.com/agent/llm-request-cancelled":
+        if (state.currentRequest !== null || state.pendingTriggerOffset === null) return;
+        blockProcessorWhile(() =>
+          this.#appendLlmRequestScheduled({
+            append,
+            sourceOffset: state.pendingTriggerOffset!,
+            state,
+          }),
+        );
+        return;
       default:
         return;
     }
   }
 
-  async #appendFauxLlmOutput(input: {
+  async #handleInputAdded(input: {
     append: Parameters<StreamProcessor<typeof AgentProcessorContract>["processEvent"]>[0]["append"];
-    inputOffset: number;
-    requestId: string;
+    event: Extract<AgentConsumedEvent, { type: "events.iterate.com/agent/input-added" }>;
+    policy: LlmRequestPolicy;
+    previousState: AgentState;
+    state: AgentState;
   }) {
-    const inputEvent = await this.stream.getEvent({ offset: input.inputOffset });
-    const userInput =
-      inputEvent?.type === "events.iterate.com/agent/input-added" &&
-      typeof inputEvent.payload?.content === "string"
-        ? inputEvent.payload.content
-        : "";
-    const code = fauxResponseScript(userInput);
-    await input.append(
-      {
-        type: "events.iterate.com/agent/llm-request-requested",
-        idempotencyKey: `agent/llm-request-requested@${input.inputOffset}`,
-        payload: input,
+    if (input.policy.behaviour === "dont-trigger-request") return;
+
+    if (
+      input.policy.behaviour === "interrupt-current-request" &&
+      input.previousState.currentRequest !== null
+    ) {
+      await input.append(cancelEventForCurrentRequest(input.previousState.currentRequest));
+      await this.#appendLlmRequestScheduled({
+        append: input.append,
+        sourceOffset: input.event.offset,
+        state: input.state,
+      });
+      return;
+    }
+
+    if (input.previousState.currentRequest !== null) return;
+    await this.#appendLlmRequestScheduled({
+      append: input.append,
+      sourceOffset: input.event.offset,
+      state: input.state,
+    });
+  }
+
+  async #appendLlmRequestScheduled(input: {
+    append: Parameters<StreamProcessor<typeof AgentProcessorContract>["processEvent"]>[0]["append"];
+    sourceOffset: number;
+    state: AgentState;
+  }) {
+    const requestId = `llm-request:${input.sourceOffset}`;
+    await input.append({
+      type: "events.iterate.com/agent/llm-request-scheduled",
+      idempotencyKey: `agent/llm-request-scheduled@${input.sourceOffset}`,
+      payload: {
+        debounceMs: DEFAULT_AGENT_LLM_REQUEST_DEBOUNCE_MS,
+        model: input.state.llmConfig.model,
+        provider: input.state.llmProvider,
+        requestId,
       },
-      {
-        type: "events.iterate.com/agent/output-added",
-        idempotencyKey: `agent/output-added@${input.inputOffset}`,
-        payload: {
-          content: ["```js", code, "```"].join("\n"),
-          inputOffset: input.inputOffset,
-          requestId: input.requestId,
-        },
-      },
-    );
+    });
   }
 }
 
-function fauxResponseScript(input: string): string {
-  const response = `This is the response to '${input}'`;
-  return `
-    async (itx) => {
-      await itx.agent.stream.append({
-        type: "events.iterate.com/agent/web-message-sent",
-        payload: { message: ${JSON.stringify(response)} },
+export function reduceAgentEvents(events: readonly StreamEvent[]): AgentState {
+  let state = AgentProcessorContract.stateSchema.parse({});
+  for (const event of events) {
+    try {
+      state = reduceAgentEvent({
+        event: AgentProcessorContract.parseEvent(event) as AgentConsumedEvent,
+        state,
       });
+    } catch {
+      continue;
     }
-  `.trim();
+  }
+  return state;
+}
+
+export function buildLlmChatRequest(state: AgentState) {
+  return {
+    messages: [{ role: "system" as const, content: state.systemPrompt }, ...state.history],
+  };
+}
+
+export function buildAgentLlmRequestBody(input: {
+  events: readonly StreamEvent[];
+  llmRequestId: number;
+}) {
+  return buildLlmChatRequest(
+    reduceAgentEvents(input.events.filter((event) => event.offset <= input.llmRequestId)),
+  );
+}
+
+function reduceAgentEvent(input: { event: AgentConsumedEvent; state: AgentState }): AgentState {
+  const { event, state } = input;
+  switch (event.type) {
+    case "events.iterate.com/agent/config-updated":
+      return state;
+    case "events.iterate.com/agent/system-prompt-updated":
+      return { ...state, systemPrompt: event.payload.systemPrompt };
+    case "events.iterate.com/agent/input-added": {
+      const shouldTrigger = event.payload.llmRequestPolicy.behaviour !== "dont-trigger-request";
+      return {
+        ...state,
+        history: [...state.history, { role: "user", content: event.payload.content }],
+        pendingTriggerOffset: shouldTrigger ? event.offset : state.pendingTriggerOffset,
+      };
+    }
+    case "events.iterate.com/agent/output-added":
+      return {
+        ...state,
+        history: [...state.history, { role: "assistant", content: event.payload.content }],
+      };
+    case "events.iterate.com/agent/llm-provider-selected":
+      return {
+        ...state,
+        llmConfig: { model: event.payload.model },
+        llmProvider: event.payload.provider,
+      };
+    case "events.iterate.com/agent/llm-request-scheduled":
+      return {
+        ...state,
+        currentRequest: {
+          phase: "scheduled",
+          requestId: event.payload.requestId,
+          scheduledOffset: event.offset,
+        },
+        pendingTriggerOffset: null,
+      };
+    case "events.iterate.com/agent/llm-request-requested":
+      return {
+        ...state,
+        currentRequest: { phase: "requested", llmRequestId: event.offset },
+      };
+    case "events.iterate.com/agent/llm-request-completed":
+      if (
+        state.currentRequest?.phase !== "requested" ||
+        state.currentRequest.llmRequestId !== event.payload.llmRequestId
+      ) {
+        return state;
+      }
+      return { ...state, currentRequest: null };
+    case "events.iterate.com/agent/llm-request-cancelled":
+      if (
+        event.payload.phase === "scheduled" &&
+        state.currentRequest?.phase === "scheduled" &&
+        state.currentRequest.requestId === event.payload.requestId
+      ) {
+        return { ...state, currentRequest: null };
+      }
+      if (
+        event.payload.phase === "requested" &&
+        state.currentRequest?.phase === "requested" &&
+        state.currentRequest.llmRequestId === event.payload.llmRequestId
+      ) {
+        return { ...state, currentRequest: null };
+      }
+      return state;
+    case "events.iterate.com/itx/script-execution-completed":
+      return {
+        ...state,
+        scriptExecutionsCompleted: [...state.scriptExecutionsCompleted, event.payload.executionId],
+      };
+    default:
+      return state;
+  }
+}
+
+function cancelEventForCurrentRequest(request: NonNullable<AgentState["currentRequest"]>) {
+  if (request.phase === "scheduled") {
+    return {
+      type: "events.iterate.com/agent/llm-request-cancelled" as const,
+      idempotencyKey: `agent/llm-request-cancelled@scheduled:${request.scheduledOffset}`,
+      payload: {
+        phase: "scheduled" as const,
+        reason: "interrupted-by-user-input" as const,
+        requestId: request.requestId,
+      },
+    };
+  }
+
+  return {
+    type: "events.iterate.com/agent/llm-request-cancelled" as const,
+    idempotencyKey: `agent/llm-request-cancelled@requested:${request.llmRequestId}`,
+    payload: {
+      phase: "requested" as const,
+      reason: "interrupted-by-user-input" as const,
+      llmRequestId: request.llmRequestId,
+    },
+  };
 }
 
 function extractAsyncJsSnippet(content: string): string | null {

--- a/apps/minimal-itx-v4/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/minimal-itx-v4/src/domains/agents/agent-processor-implementation.ts
@@ -88,6 +88,7 @@ export class AgentProcessor extends StreamProcessor<typeof AgentProcessorContrac
             payload: {
               model: event.payload.model,
               provider: event.payload.provider,
+              requestId: event.payload.requestId,
             },
           });
         });
@@ -222,10 +223,12 @@ function reduceAgentEvent(input: { event: AgentConsumedEvent; state: AgentState 
         history: [...state.history, { role: "assistant", content: event.payload.content }],
       };
     case "events.iterate.com/agent/llm-provider-selected":
+      if (event.payload.ifUnset && state.llmProviderConfigured) return state;
       return {
         ...state,
         llmConfig: { model: event.payload.model },
         llmProvider: event.payload.provider,
+        llmProviderConfigured: true,
       };
     case "events.iterate.com/agent/llm-request-scheduled":
       return {
@@ -238,9 +241,15 @@ function reduceAgentEvent(input: { event: AgentConsumedEvent; state: AgentState 
         pendingTriggerOffset: null,
       };
     case "events.iterate.com/agent/llm-request-requested":
+      if (
+        state.currentRequest?.phase !== "scheduled" ||
+        state.currentRequest.requestId !== event.payload.requestId
+      )
+        return state;
       return {
         ...state,
         currentRequest: { phase: "requested", llmRequestId: event.offset },
+        pendingTriggerOffset: null,
       };
     case "events.iterate.com/agent/llm-request-completed":
       if (

--- a/apps/minimal-itx-v4/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/minimal-itx-v4/src/domains/agents/agent-processor-implementation.ts
@@ -186,7 +186,7 @@ export function reduceAgentEvents(events: readonly StreamEvent[]): AgentState {
   return state;
 }
 
-export function buildLlmChatRequest(state: AgentState) {
+function buildLlmChatRequest(state: AgentState) {
   return {
     messages: [{ role: "system" as const, content: state.systemPrompt }, ...state.history],
   };

--- a/apps/minimal-itx-v4/src/domains/agents/agent-processors.test.ts
+++ b/apps/minimal-itx-v4/src/domains/agents/agent-processors.test.ts
@@ -174,6 +174,69 @@ describe("minimal web-chat agent processors", () => {
     });
   });
 
+  it("does not fire a second LLM call when a second message arrives during the first request", async () => {
+    const stream = new MemoryStream();
+    const aiCalls: unknown[] = [];
+    let resolveFirstCall!: () => void;
+    const firstCallInFlight = new Promise<void>((resolve) => {
+      resolveFirstCall = resolve;
+    });
+    const agent = new AgentProcessor({ stream });
+    const cloudflareAi = new CloudflareAiProcessor({
+      stream,
+      ai: {
+        async run(_model, body) {
+          aiCalls.push(body);
+          resolveFirstCall();
+          return { response: "```js\nasync (itx) => {}\n```" };
+        },
+      },
+      readStreamEvents: () => stream.getEvents(),
+    });
+    const cursors = new Map<object, number>();
+    const deliver = (processor: ProcessorLike) => deliverNewEvents({ processor, stream, cursors });
+
+    // First user message — triggers llm-request-scheduled (with debounce)
+    await stream.append({
+      type: "events.iterate.com/agents/user-message-received",
+      payload: { origin: "web", content: "message one" },
+    });
+    await deliver(agent);
+    await deliver(agent);
+    await deliver(agent);
+
+    // Second user message arrives before debounce fires — queued as pending
+    await stream.append({
+      type: "events.iterate.com/agents/user-message-received",
+      payload: { origin: "web", content: "message two" },
+    });
+    await deliver(agent);
+
+    // Wait for the LLM call to complete (both messages included in it)
+    await stream.waitForEvent({
+      eventTypes: ["events.iterate.com/agent/llm-request-requested"],
+      timeoutMs: 2_000,
+    });
+    await deliver(agent);
+    await deliver(cloudflareAi);
+    await firstCallInFlight;
+    await stream.waitForEvent({
+      eventTypes: ["events.iterate.com/agent/llm-request-completed"],
+      timeoutMs: 2_000,
+    });
+    await deliver(agent);
+
+    // Give the processor time to fire a spurious second request if the bug is present
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await deliver(agent);
+
+    expect(aiCalls).toHaveLength(1);
+    const firstCall = aiCalls[0] as { messages: Array<{ role: string; content: string }> };
+    expect(firstCall.messages.map((m) => m.content)).toEqual(
+      expect.arrayContaining(["message one", "message two"]),
+    );
+  });
+
   it("treats Workers AI terminal stream chunks without choices as successful completion", async () => {
     const stream = new MemoryStream();
     const cloudflareAi = new CloudflareAiProcessor({
@@ -224,6 +287,7 @@ describe("minimal web-chat agent processors", () => {
         payload: {
           model: "@cf/moonshotai/kimi-k2.7-code",
           provider: "cloudflare-ai",
+          requestId: "llm-request:1",
         },
       },
     );

--- a/apps/minimal-itx-v4/src/domains/agents/agent-processors.test.ts
+++ b/apps/minimal-itx-v4/src/domains/agents/agent-processors.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from "vitest";
+import type { Stream, StreamEvent, StreamEventInput } from "../../types.ts";
+import { AgentProcessor } from "./agent-processor-implementation.ts";
+import { DEFAULT_AGENT_SYSTEM_PROMPT } from "./agent-processor-contract.ts";
+import { CloudflareAiProcessor } from "./cloudflare-ai-processor-implementation.ts";
+
+class MemoryStream implements Stream {
+  events: StreamEvent[] = [];
+
+  async append(...inputs: StreamEventInput[]): Promise<StreamEvent[]> {
+    const appended = inputs.map((input) => {
+      const existing =
+        input.idempotencyKey === undefined
+          ? undefined
+          : this.events.find((event) => event.idempotencyKey === input.idempotencyKey);
+      if (existing !== undefined) return existing;
+      const event: StreamEvent = {
+        ...input,
+        createdAt: new Date(this.events.length + 1).toISOString(),
+        offset: this.events.length + 1,
+      };
+      this.events.push(event);
+      return event;
+    });
+    return appended;
+  }
+
+  at(): Stream {
+    return this;
+  }
+
+  async getEvent(
+    input: { offset: number } | { idempotencyKey: string },
+  ): Promise<StreamEvent | undefined> {
+    if ("offset" in input) return this.events.find((event) => event.offset === input.offset);
+    return this.events.find((event) => event.idempotencyKey === input.idempotencyKey);
+  }
+
+  async getEvents(): Promise<StreamEvent[]> {
+    return [...this.events];
+  }
+
+  async waitForEvent(input: {
+    afterOffset?: number;
+    eventTypes?: readonly string[];
+    predicate?: (event: StreamEvent) => boolean | Promise<boolean>;
+    timeoutMs: number;
+  }): Promise<StreamEvent> {
+    const deadline = Date.now() + input.timeoutMs;
+    while (Date.now() < deadline) {
+      for (const event of this.events) {
+        if (input.afterOffset !== undefined && event.offset <= input.afterOffset) continue;
+        if (input.eventTypes !== undefined && !input.eventTypes.includes(event.type)) continue;
+        if (input.predicate !== undefined && !(await input.predicate(event))) continue;
+        return event;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error("Timed out waiting for event");
+  }
+
+  async getProcessorRuntimeState(): Promise<null> {
+    return null;
+  }
+
+  async runtimeState() {
+    return { coreProcessorState: null, runtime: { connections: {} } };
+  }
+
+  async subscribe(): Promise<never> {
+    throw new Error("MemoryStream does not implement subscribe().");
+  }
+}
+
+type ProcessorLike = {
+  ingest(input: { events: StreamEvent[]; streamMaxOffset: number }): Promise<void>;
+};
+
+async function deliverNewEvents(input: {
+  processor: ProcessorLike;
+  stream: MemoryStream;
+  cursors: Map<object, number>;
+}) {
+  const cursor = input.cursors.get(input.processor) ?? 0;
+  const events = input.stream.events.slice(cursor);
+  input.cursors.set(input.processor, input.stream.events.length);
+  if (events.length === 0) return;
+  await input.processor.ingest({ events, streamMaxOffset: input.stream.events.length });
+}
+
+function sseStream(...chunks: unknown[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+      }
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+}
+
+describe("minimal web-chat agent processors", () => {
+  it("explains the exact codemode shape expected by the ITX script runner", () => {
+    expect(DEFAULT_AGENT_SYSTEM_PROMPT).toContain(
+      "The code block must contain a single async arrow function: async (itx) => { ... }.",
+    );
+    expect(DEFAULT_AGENT_SYSTEM_PROMPT).toContain("await itx.chat.sendMessage({ message })");
+    expect(DEFAULT_AGENT_SYSTEM_PROMPT).not.toContain("containing an async function");
+  });
+
+  it("normalizes web input, requests AI by reference, and turns output into script execution", async () => {
+    const stream = new MemoryStream();
+    const aiCalls: unknown[] = [];
+    const agent = new AgentProcessor({ stream });
+    const cloudflareAi = new CloudflareAiProcessor({
+      stream,
+      ai: {
+        async run(_model, body) {
+          aiCalls.push(body);
+          return {
+            response: [
+              "```js",
+              "async (itx) => {",
+              "  await itx.chat.sendMessage({ message: 'hello from ai' });",
+              "}",
+              "```",
+            ].join("\n"),
+          };
+        },
+      },
+      readStreamEvents: () => stream.getEvents(),
+    });
+    const cursors = new Map<object, number>();
+    const deliver = (processor: ProcessorLike) => deliverNewEvents({ processor, stream, cursors });
+
+    await stream.append({
+      type: "events.iterate.com/agents/user-message-received",
+      payload: { origin: "web", content: "hello" },
+    });
+    await deliver(agent);
+    await deliver(agent);
+    await deliver(agent);
+    await stream.waitForEvent({
+      eventTypes: ["events.iterate.com/agent/llm-request-requested"],
+      timeoutMs: 2_000,
+    });
+    await deliver(agent);
+    await deliver(cloudflareAi);
+    await stream.waitForEvent({
+      eventTypes: ["events.iterate.com/agent/llm-request-completed"],
+      timeoutMs: 2_000,
+    });
+    await deliver(agent);
+
+    expect(stream.events.map((event) => event.type)).toEqual(
+      expect.arrayContaining([
+        "events.iterate.com/agents/user-message-received",
+        "events.iterate.com/agent/input-added",
+        "events.iterate.com/agent/llm-request-scheduled",
+        "events.iterate.com/agent/llm-request-requested",
+        "events.iterate.com/cloudflare-ai/llm-request-started",
+        "events.iterate.com/agent/output-added",
+        "events.iterate.com/cloudflare-ai/llm-request-completed",
+        "events.iterate.com/agent/llm-request-completed",
+        "events.iterate.com/itx/script-execution-requested",
+      ]),
+    );
+    expect(aiCalls).toHaveLength(1);
+    expect(aiCalls[0]).toMatchObject({
+      stream: true,
+      messages: [expect.objectContaining({ role: "system" }), { role: "user", content: "hello" }],
+    });
+  });
+
+  it("treats Workers AI terminal stream chunks without choices as successful completion", async () => {
+    const stream = new MemoryStream();
+    const cloudflareAi = new CloudflareAiProcessor({
+      stream,
+      ai: {
+        async run() {
+          return sseStream(
+            { choices: [{ delta: { content: "```js\n" } }] },
+            {
+              choices: [
+                {
+                  delta: {
+                    content:
+                      "async (itx) => {\n  await itx.chat.sendMessage({ message: 'real-ai-agent-ok' });\n}\n```",
+                  },
+                },
+              ],
+            },
+            {
+              choices: [],
+              usage: { completion_tokens: 12, prompt_tokens: 34, total_tokens: 46 },
+            },
+          );
+        },
+      },
+      readStreamEvents: () => stream.getEvents(),
+    });
+
+    await stream.append(
+      {
+        type: "events.iterate.com/agent/input-added",
+        payload: {
+          content: "send real-ai-agent-ok",
+          llmRequestPolicy: { behaviour: "after-current-request" },
+        },
+      },
+      {
+        type: "events.iterate.com/agent/llm-request-scheduled",
+        payload: {
+          debounceMs: 0,
+          model: "@cf/moonshotai/kimi-k2.7-code",
+          provider: "cloudflare-ai",
+          requestId: "llm-request:1",
+        },
+      },
+      {
+        type: "events.iterate.com/agent/llm-request-requested",
+        payload: {
+          model: "@cf/moonshotai/kimi-k2.7-code",
+          provider: "cloudflare-ai",
+        },
+      },
+    );
+
+    await deliverNewEvents({
+      processor: cloudflareAi,
+      stream,
+      cursors: new Map<object, number>(),
+    });
+    const completed = await stream.waitForEvent({
+      eventTypes: ["events.iterate.com/agent/llm-request-completed"],
+      timeoutMs: 2_000,
+    });
+    const output = await stream.waitForEvent({
+      eventTypes: ["events.iterate.com/agent/output-added"],
+      timeoutMs: 2_000,
+    });
+
+    expect(completed.payload).toMatchObject({
+      result: { status: "success" },
+    });
+    expect(output.payload).toMatchObject({
+      content: expect.stringContaining("real-ai-agent-ok"),
+    });
+  });
+});

--- a/apps/minimal-itx-v4/src/domains/agents/agent-processors.test.ts
+++ b/apps/minimal-itx-v4/src/domains/agents/agent-processors.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Stream, StreamEvent, StreamEventInput } from "../../types.ts";
 import { AgentProcessor } from "./agent-processor-implementation.ts";
-import { DEFAULT_AGENT_SYSTEM_PROMPT } from "./agent-processor-contract.ts";
+import { AgentProcessorContract, DEFAULT_AGENT_SYSTEM_PROMPT } from "./agent-processor-contract.ts";
 import { CloudflareAiProcessor } from "./cloudflare-ai-processor-implementation.ts";
 
 class MemoryStream implements Stream {
@@ -235,6 +235,47 @@ describe("minimal web-chat agent processors", () => {
     expect(firstCall.messages.map((m) => m.content)).toEqual(
       expect.arrayContaining(["message one", "message two"]),
     );
+  });
+
+  it("recovers a stuck scheduled request after DO restart (lost debounce timer)", async () => {
+    const stream = new MemoryStream();
+    // Simulate events already committed before restart
+    await stream.append(
+      {
+        type: "events.iterate.com/agent/input-added",
+        payload: { content: "hello", llmRequestPolicy: { behaviour: "after-current-request" } },
+      },
+      {
+        type: "events.iterate.com/agent/llm-request-scheduled",
+        payload: {
+          debounceMs: 250,
+          model: "@cf/moonshotai/kimi-k2.7-code",
+          provider: "cloudflare-ai",
+          requestId: "llm-request:1",
+        },
+      },
+    );
+    // Simulate a checkpoint written after the scheduled event but before the timer fired
+    const stuckState = AgentProcessorContract.stateSchema.parse({
+      history: [{ role: "user", content: "hello" }],
+      currentRequest: { phase: "scheduled", requestId: "llm-request:1", scheduledOffset: 2 },
+      llmProviderConfigured: true,
+    });
+    const agent = new AgentProcessor({
+      stream,
+      readState: async () => ({ offset: 2, state: stuckState }),
+    });
+    // New event arrives after restart — triggers recovery
+    await stream.append({
+      type: "events.iterate.com/agents/user-message-received",
+      payload: { origin: "web", content: "second message" },
+    });
+    await deliverNewEvents({ processor: agent, stream, cursors: new Map() });
+    // Recovery should fire llm-request-requested without waiting for a debounce
+    await stream.waitForEvent({
+      eventTypes: ["events.iterate.com/agent/llm-request-requested"],
+      timeoutMs: 500,
+    });
   });
 
   it("treats Workers AI terminal stream chunks without choices as successful completion", async () => {

--- a/apps/minimal-itx-v4/src/domains/agents/cloudflare-ai-processor-contract.ts
+++ b/apps/minimal-itx-v4/src/domains/agents/cloudflare-ai-processor-contract.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+import { defineProcessorContract } from "../streams/stream-processor.ts";
+import { AgentProcessorContract } from "./agent-processor-contract.ts";
+
+export const CloudflareAiProcessorContract = defineProcessorContract({
+  slug: "cloudflare-ai",
+  version: "0.1.0",
+  description: "Runs agent LLM requests through an AI binding shaped like env.AI.",
+  stateSchema: z.object({
+    requests: z
+      .record(z.string(), z.object({ status: z.enum(["started", "completed"]) }))
+      .default({}),
+  }),
+  events: {
+    "events.iterate.com/cloudflare-ai/llm-request-started": {
+      description: "The Cloudflare AI processor started an agent LLM request.",
+      payloadSchema: z.object({
+        llmRequestId: z.number().int().positive(),
+        model: z.string().min(1),
+      }),
+    },
+    "events.iterate.com/cloudflare-ai/llm-response-chunk": {
+      description: "One streamed provider chunk received from the AI binding.",
+      payloadSchema: z.object({
+        chunk: z.unknown(),
+        llmRequestId: z.number().int().positive(),
+        sequence: z.number().int().nonnegative(),
+      }),
+    },
+    "events.iterate.com/cloudflare-ai/llm-request-completed": {
+      description: "The Cloudflare AI processor finished an agent LLM request.",
+      payloadSchema: z.object({
+        durationMs: z.number().int().nonnegative(),
+        llmRequestId: z.number().int().positive(),
+        result: z.discriminatedUnion("status", [
+          z.object({
+            rawResponse: z.unknown().optional(),
+            status: z.literal("success"),
+            usage: z.unknown().optional(),
+          }),
+          z.object({
+            error: z.object({ message: z.string() }),
+            rawResponse: z.unknown().optional(),
+            status: z.literal("failure"),
+          }),
+        ]),
+      }),
+    },
+  },
+  processorDeps: [AgentProcessorContract],
+  consumes: [
+    "events.iterate.com/agent/llm-request-requested",
+    "events.iterate.com/cloudflare-ai/llm-request-started",
+    "events.iterate.com/cloudflare-ai/llm-request-completed",
+  ],
+  emits: [
+    "events.iterate.com/cloudflare-ai/llm-request-started",
+    "events.iterate.com/cloudflare-ai/llm-response-chunk",
+    "events.iterate.com/cloudflare-ai/llm-request-completed",
+    "events.iterate.com/agent/output-added",
+    "events.iterate.com/agent/llm-request-completed",
+  ],
+});

--- a/apps/minimal-itx-v4/src/domains/agents/cloudflare-ai-processor-implementation.ts
+++ b/apps/minimal-itx-v4/src/domains/agents/cloudflare-ai-processor-implementation.ts
@@ -4,10 +4,6 @@ import { StreamProcessor } from "../streams/stream-processor.ts";
 import { buildAgentLlmRequestBody, reduceAgentEvents } from "./agent-processor-implementation.ts";
 import { CloudflareAiProcessorContract } from "./cloudflare-ai-processor-contract.ts";
 
-export type AiLike = {
-  run(model: string, body: unknown): Promise<unknown>;
-};
-
 type LlmRequestRequestedEvent = Extract<
   ReturnType<typeof CloudflareAiProcessorContract.parseEvent>,
   { type: "events.iterate.com/agent/llm-request-requested" }
@@ -16,7 +12,7 @@ type LlmRequestRequestedEvent = Extract<
 export class CloudflareAiProcessor extends StreamProcessor<
   typeof CloudflareAiProcessorContract,
   {
-    ai: AiLike;
+    ai: { run(model: string, body: unknown): Promise<unknown> };
     readStreamEvents(): Promise<StreamEvent[]>;
   }
 > {

--- a/apps/minimal-itx-v4/src/domains/agents/cloudflare-ai-processor-implementation.ts
+++ b/apps/minimal-itx-v4/src/domains/agents/cloudflare-ai-processor-implementation.ts
@@ -1,0 +1,307 @@
+import { z } from "zod";
+import type { StreamEvent } from "../../types.ts";
+import { StreamProcessor } from "../streams/stream-processor.ts";
+import { buildAgentLlmRequestBody, reduceAgentEvents } from "./agent-processor-implementation.ts";
+import { CloudflareAiProcessorContract } from "./cloudflare-ai-processor-contract.ts";
+
+export type AiLike = {
+  run(model: string, body: unknown): Promise<unknown>;
+};
+
+type CloudflareAiState = z.infer<typeof CloudflareAiProcessorContract.stateSchema>;
+type LlmRequestRequestedEvent = Extract<
+  ReturnType<typeof CloudflareAiProcessorContract.parseEvent>,
+  { type: "events.iterate.com/agent/llm-request-requested" }
+>;
+
+export class CloudflareAiProcessor extends StreamProcessor<
+  typeof CloudflareAiProcessorContract,
+  {
+    ai: AiLike;
+    readStreamEvents(): Promise<StreamEvent[]>;
+  }
+> {
+  readonly contract = CloudflareAiProcessorContract;
+
+  protected override reduce({
+    event,
+    state,
+  }: Parameters<StreamProcessor<typeof CloudflareAiProcessorContract>["reduce"]>[0]) {
+    switch (event.type) {
+      case "events.iterate.com/cloudflare-ai/llm-request-started":
+        return {
+          ...state,
+          requests: {
+            ...state.requests,
+            [String(event.payload.llmRequestId)]: { status: "started" as const },
+          },
+        };
+      case "events.iterate.com/cloudflare-ai/llm-request-completed":
+        return {
+          ...state,
+          requests: {
+            ...state.requests,
+            [String(event.payload.llmRequestId)]: { status: "completed" as const },
+          },
+        };
+      default:
+        return state;
+    }
+  }
+
+  protected override processEvent({
+    event,
+    runInBackground,
+    state,
+  }: Parameters<
+    StreamProcessor<typeof CloudflareAiProcessorContract>["processEvent"]
+  >[0]): undefined {
+    if (event.type !== "events.iterate.com/agent/llm-request-requested") return;
+    if (event.payload.provider !== CloudflareAiProcessorContract.slug) return;
+    const llmRequestId = event.offset;
+    if (state.requests[String(llmRequestId)]?.status === "completed") return;
+    runInBackground(() => this.#executeRequest({ event, state }));
+  }
+
+  async #executeRequest(input: {
+    event: LlmRequestRequestedEvent;
+    state: CloudflareAiState;
+  }): Promise<void> {
+    const llmRequestId = input.event.offset;
+    const startedAt = Date.now();
+    await this.stream.append({
+      type: "events.iterate.com/cloudflare-ai/llm-request-started",
+      idempotencyKey: `cloudflare-ai/llm-request-started@${llmRequestId}`,
+      payload: {
+        llmRequestId,
+        model: input.event.payload.model,
+      },
+    });
+
+    try {
+      const body = buildAgentLlmRequestBody({
+        events: await this.deps.readStreamEvents(),
+        llmRequestId,
+      });
+      const raw = await this.deps.ai.run(input.event.payload.model, { ...body, stream: true });
+      const completion =
+        raw instanceof ReadableStream
+          ? await this.#consumeStream({ body: raw, sourceEvent: input.event })
+          : {
+              text: extractAssistantText(raw),
+              rawResponse: jsonCompatible(raw),
+              usage: extractUsage(raw),
+            };
+
+      const durationMs = Date.now() - startedAt;
+      const providerResult = {
+        status: "success" as const,
+        rawResponse: completion.rawResponse,
+        ...(completion.usage === undefined ? {} : { usage: completion.usage }),
+      };
+
+      if (await this.#isRequestStillCurrent({ llmRequestId })) {
+        await this.stream.append({
+          type: "events.iterate.com/agent/output-added",
+          idempotencyKey: `cloudflare-ai/agent-output-added@${llmRequestId}`,
+          payload: { content: completion.text, llmRequestId },
+        });
+      }
+
+      await this.stream.append(
+        {
+          type: "events.iterate.com/cloudflare-ai/llm-request-completed",
+          idempotencyKey: `cloudflare-ai/provider-completed@${llmRequestId}`,
+          payload: {
+            durationMs,
+            llmRequestId,
+            result: providerResult,
+          },
+        },
+        {
+          type: "events.iterate.com/agent/llm-request-completed",
+          idempotencyKey: `cloudflare-ai/agent-completed@${llmRequestId}`,
+          payload: {
+            durationMs,
+            llmRequestId,
+            provider: "cloudflare-ai",
+            result: providerResult,
+          },
+        },
+      );
+    } catch (error) {
+      const durationMs = Date.now() - startedAt;
+      const failure = {
+        status: "failure" as const,
+        error: { message: stringifyError(error) },
+      };
+      await this.stream.append(
+        {
+          type: "events.iterate.com/cloudflare-ai/llm-request-completed",
+          idempotencyKey: `cloudflare-ai/provider-completed@${llmRequestId}`,
+          payload: {
+            durationMs,
+            llmRequestId,
+            result: failure,
+          },
+        },
+        {
+          type: "events.iterate.com/agent/llm-request-completed",
+          idempotencyKey: `cloudflare-ai/agent-completed@${llmRequestId}`,
+          payload: {
+            durationMs,
+            llmRequestId,
+            provider: "cloudflare-ai",
+            result: failure,
+          },
+        },
+      );
+    }
+  }
+
+  async #consumeStream(input: {
+    body: ReadableStream;
+    sourceEvent: LlmRequestRequestedEvent;
+  }): Promise<{ rawResponse: unknown; text: string; usage?: unknown }> {
+    const reader = input.body.getReader();
+    const decoder = new TextDecoder();
+    let buffered = "";
+    let sequence = 0;
+    let text = "";
+    let usage: unknown;
+
+    const handleChunk = async (chunk: unknown) => {
+      text += extractChunkText(chunk);
+      usage = extractUsage(chunk) ?? usage;
+      await this.stream.append({
+        type: "events.iterate.com/cloudflare-ai/llm-response-chunk",
+        idempotencyKey: `cloudflare-ai/llm-response-chunk@${input.sourceEvent.offset}:${sequence}`,
+        payload: {
+          chunk: jsonCompatible(chunk),
+          llmRequestId: input.sourceEvent.offset,
+          sequence,
+        },
+      });
+      sequence += 1;
+    };
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffered += typeof value === "string" ? value : decoder.decode(value, { stream: true });
+      const frames = buffered.split(/\r?\n\r?\n/);
+      buffered = frames.pop() ?? "";
+      for (const frame of frames) {
+        const chunk = parseSseFrame(frame);
+        if (chunk !== undefined) await handleChunk(chunk);
+      }
+    }
+    buffered += decoder.decode();
+    const finalChunk = parseSseFrame(buffered);
+    if (finalChunk !== undefined) await handleChunk(finalChunk);
+
+    return {
+      rawResponse: {
+        streamed: true,
+        chunkCount: sequence,
+        response: text,
+        ...(usage === undefined ? {} : { usage }),
+      },
+      text,
+      ...(usage === undefined ? {} : { usage }),
+    };
+  }
+
+  async #isRequestStillCurrent(input: { llmRequestId: number }) {
+    const state = reduceAgentEvents(await this.deps.readStreamEvents());
+    return (
+      state.currentRequest?.phase === "requested" &&
+      state.currentRequest.llmRequestId === input.llmRequestId
+    );
+  }
+}
+
+function parseSseFrame(frame: string): unknown | undefined {
+  const data = frame
+    .split("\n")
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice("data:".length).trim())
+    .join("\n");
+  if (data === "" || data === "[DONE]") return undefined;
+  try {
+    return JSON.parse(data) as unknown;
+  } catch {
+    return data;
+  }
+}
+
+function extractAssistantText(raw: unknown): string {
+  if (typeof raw === "string") return raw;
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("AI response did not contain assistant text.");
+  }
+  if ("response" in raw && typeof raw.response === "string") return raw.response;
+
+  const choices = (raw as { choices?: unknown }).choices;
+  if (Array.isArray(choices) && choices.length > 0) {
+    const first = choices[0] as
+      | { message?: { content?: unknown }; delta?: { content?: unknown } }
+      | undefined;
+    const content = first?.message?.content ?? first?.delta?.content;
+    if (typeof content === "string") return content;
+  }
+
+  const content = (raw as { content?: unknown }).content;
+  if (Array.isArray(content)) {
+    return content
+      .map((block) =>
+        typeof block === "object" &&
+        block !== null &&
+        "type" in block &&
+        block.type === "text" &&
+        "text" in block &&
+        typeof block.text === "string"
+          ? block.text
+          : "",
+      )
+      .join("");
+  }
+
+  throw new Error("AI response did not contain assistant text.");
+}
+
+function extractChunkText(chunk: unknown): string {
+  if (typeof chunk === "string") return chunk;
+  if (typeof chunk !== "object" || chunk === null) return "";
+  if ("response" in chunk && typeof chunk.response === "string") return chunk.response;
+
+  const choices = (chunk as { choices?: unknown }).choices;
+  if (Array.isArray(choices) && choices.length > 0) {
+    const first = choices[0] as { delta?: { content?: unknown } } | undefined;
+    if (typeof first?.delta?.content === "string") return first.delta.content;
+  }
+
+  const delta = (chunk as { delta?: { text?: unknown } }).delta;
+  return typeof delta?.text === "string" ? delta.text : "";
+}
+
+function extractUsage(raw: unknown): unknown | undefined {
+  return typeof raw === "object" && raw !== null && "usage" in raw ? raw.usage : undefined;
+}
+
+function jsonCompatible(value: unknown): unknown {
+  try {
+    return JSON.parse(JSON.stringify(value)) as unknown;
+  } catch {
+    return String(value);
+  }
+}
+
+function stringifyError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}

--- a/apps/minimal-itx-v4/src/domains/agents/cloudflare-ai-processor-implementation.ts
+++ b/apps/minimal-itx-v4/src/domains/agents/cloudflare-ai-processor-implementation.ts
@@ -8,7 +8,6 @@ export type AiLike = {
   run(model: string, body: unknown): Promise<unknown>;
 };
 
-type CloudflareAiState = z.infer<typeof CloudflareAiProcessorContract.stateSchema>;
 type LlmRequestRequestedEvent = Extract<
   ReturnType<typeof CloudflareAiProcessorContract.parseEvent>,
   { type: "events.iterate.com/agent/llm-request-requested" }
@@ -65,7 +64,7 @@ export class CloudflareAiProcessor extends StreamProcessor<
 
   async #executeRequest(input: {
     event: LlmRequestRequestedEvent;
-    state: CloudflareAiState;
+    state: z.infer<typeof CloudflareAiProcessorContract.stateSchema>;
   }): Promise<void> {
     const llmRequestId = input.event.offset;
     const startedAt = Date.now();

--- a/apps/minimal-itx-v4/src/domains/projects/project-processor-contract.ts
+++ b/apps/minimal-itx-v4/src/domains/projects/project-processor-contract.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { defineProcessorContract } from "../streams/stream-processor.ts";
 import { CoreProcessorContract } from "../streams/core-processor-contract.ts";
 import { RepoProcessorContract } from "../repos/repo-processor-contract.ts";
+import { AgentProcessorContract } from "../agents/agent-processor-contract.ts";
 
 const StreamListItem = z.object({
   createdAt: z.string(),
@@ -50,8 +51,10 @@ export const ProjectProcessorContract = defineProcessorContract({
     "events.iterate.com/stream/created",
     "events.iterate.com/stream/child-stream-created",
   ],
-  processorDeps: [CoreProcessorContract, RepoProcessorContract],
+  processorDeps: [CoreProcessorContract, RepoProcessorContract, AgentProcessorContract],
   emits: [
+    "events.iterate.com/agent/config-updated",
+    "events.iterate.com/agent/llm-provider-selected",
     "events.iterate.com/project/created",
     "events.iterate.com/repo/create-requested",
     "events.iterate.com/stream/subscription-configured",

--- a/apps/minimal-itx-v4/src/domains/projects/project-processor-implementation.ts
+++ b/apps/minimal-itx-v4/src/domains/projects/project-processor-implementation.ts
@@ -4,7 +4,12 @@ import { PROJECT_REPO_PATH } from "../repos/utils.ts";
 import type { StreamEvent, StreamListItem } from "../../types.ts";
 import type { ProjectRpcTarget } from "../../rpc-targets.ts";
 import { DurableObjectNameCodec } from "../durable-object-names.ts";
-import { AgentProcessorContract } from "../agents/agent-processor-contract.ts";
+import {
+  AgentProcessorContract,
+  DEFAULT_AGENT_MODEL,
+  DEFAULT_AGENT_SYSTEM_PROMPT,
+} from "../agents/agent-processor-contract.ts";
+import { CloudflareAiProcessorContract } from "../agents/cloudflare-ai-processor-contract.ts";
 import { ItxProcessorContract } from "../itx/itx-processor-contract.ts";
 import { SecretProcessorContract } from "../secrets/secret-processor-contract.ts";
 import { ProjectProcessorContract } from "./project-processor-contract.ts";
@@ -106,9 +111,28 @@ export class ProjectProcessor extends StreamProcessor<
               }),
               buildDurableObjectProcessorSubscriptionConfiguredEvent({
                 durableObjectName,
+                processorSlug: CloudflareAiProcessorContract.slug,
+                subscriberType: "agent",
+              }),
+              buildDurableObjectProcessorSubscriptionConfiguredEvent({
+                durableObjectName,
                 processorSlug: ItxProcessorContract.slug,
                 subscriberType: "itx",
               }),
+              {
+                type: "events.iterate.com/agent/config-updated",
+                idempotencyKey: `agent/config-updated:${this.deps.itx.projectId}:${childPath}`,
+                payload: { systemPrompt: DEFAULT_AGENT_SYSTEM_PROMPT },
+              },
+              {
+                type: "events.iterate.com/agent/llm-provider-selected",
+                idempotencyKey: `agent/llm-provider-selected:${this.deps.itx.projectId}:${childPath}`,
+                payload: {
+                  ifUnset: true,
+                  model: DEFAULT_AGENT_MODEL,
+                  provider: "cloudflare-ai",
+                },
+              },
             );
             return;
           }

--- a/apps/minimal-itx-v4/src/domains/streams/stream-processor-host.ts
+++ b/apps/minimal-itx-v4/src/domains/streams/stream-processor-host.ts
@@ -155,10 +155,12 @@ export function createStreamProcessorHost(
     return entry;
   }
 
-  function resolveProcessorName(): string {
+  function resolveProcessorName(subscriptionKey: string): string {
     if (entries.size === 1) return [...entries.keys()][0]!;
+    const suffix = subscriptionKey.split("#").at(-1);
+    if (suffix !== undefined && entries.has(suffix)) return suffix;
     throw new Error(
-      `wakeStreamSubscriber requires exactly one processor on this host (registered: ${[...entries.keys()].join(", ")})`,
+      `wakeStreamSubscriber could not resolve processor for subscription "${subscriptionKey}" (registered: ${[...entries.keys()].join(", ")})`,
     );
   }
 
@@ -336,7 +338,7 @@ export function createStreamProcessorHost(
     },
 
     async wakeStreamSubscriber(args) {
-      const name = resolveProcessorName();
+      const name = resolveProcessorName(args.subscriptionKey);
       const entry = requireEntry(name);
 
       ctx.storage.kv.put(subscriptionKeyKey(name), args.subscriptionKey);

--- a/apps/minimal-itx-v4/src/rpc-targets.ts
+++ b/apps/minimal-itx-v4/src/rpc-targets.ts
@@ -32,8 +32,10 @@ import { DynamicWorkerRef as WorkerRefSchema } from "./domains/workers/schemas.t
 import { DynamicWorkerRunner } from "./domains/workers/worker-runner.ts";
 import type {
   Agent,
+  AgentChat,
   AgentCollection,
   AgentItx,
+  Ai,
   CfExecutionContext,
   ItxAuth,
   ItxRoot,
@@ -57,6 +59,11 @@ import type {
   DynamicWorkerCollection,
   DynamicWorkerRef,
 } from "./types.ts";
+
+type AiBinding = {
+  models?: () => unknown;
+  run(model: string, body: unknown): Promise<unknown>;
+};
 
 export class StreamRpcTarget extends RpcTarget implements Stream {
   constructor(readonly props: { auth: ItxAuth; projectId: string | null; path: string }) {
@@ -347,6 +354,48 @@ class SecretRpcTarget extends RpcTarget implements Secret {
   }
 }
 
+class AiRpcTarget extends RpcTarget implements Ai {
+  constructor(readonly binding: AiBinding) {
+    super();
+  }
+
+  models() {
+    if (typeof this.binding.models !== "function") {
+      throw new Error("AI binding does not expose models().");
+    }
+    return Promise.resolve(this.binding.models());
+  }
+
+  run(...[model, body]: Parameters<Ai["run"]>) {
+    return this.binding.run(model, body);
+  }
+}
+
+class AgentChatRpcTarget extends RpcTarget implements AgentChat {
+  constructor(readonly props: { auth: ItxAuth; path: string; projectId: string }) {
+    super();
+    props.auth.assertCanAccessProject(props.projectId);
+  }
+
+  get stream() {
+    return new StreamRpcTarget({
+      auth: this.props.auth,
+      projectId: this.props.projectId,
+      path: this.props.path,
+    });
+  }
+
+  async sendMessage(input: Parameters<AgentChat["sendMessage"]>[0]) {
+    const message = input.message.trim();
+    if (message === "") throw new Error("itx.chat.sendMessage requires a non-empty message.");
+    const [event] = await this.stream.append({
+      type: "events.iterate.com/agents/web-message-sent",
+      payload: { message },
+    });
+    return event;
+  }
+}
+
 class AgentRpcTarget extends RpcTarget implements Agent {
   constructor(
     readonly props: { auth: ItxAuth; ctx: CfExecutionContext; path: string; projectId: string },
@@ -389,7 +438,7 @@ class AgentRpcTarget extends RpcTarget implements Agent {
 
   async sendMessage(message: string) {
     const [event] = await this.stream.append({
-      type: "events.iterate.com/agent/user-message-received",
+      type: "events.iterate.com/agents/user-message-received",
       payload: { content: message, origin: "web" },
     });
     return event;
@@ -399,7 +448,7 @@ class AgentRpcTarget extends RpcTarget implements Agent {
     const sent = await this.sendMessage(input.message);
     return await this.stream.waitForEvent({
       afterOffset: sent.offset,
-      eventTypes: ["events.iterate.com/agent/web-message-sent"],
+      eventTypes: ["events.iterate.com/agents/web-message-sent"],
       timeoutMs: 45_000,
     });
   }
@@ -590,6 +639,7 @@ export class ProjectCollectionRpcTarget extends RpcTarget implements ProjectColl
 
 type ProjectRpcTargetProps = { auth: ItxAuth; ctx: CfExecutionContext; projectId: string };
 const PROJECT_BUILTIN_CAPABILITY_PATHS = [
+  "ai",
   "agents",
   "egress",
   "mcp",
@@ -639,6 +689,10 @@ export class ProjectRpcTarget extends RpcTarget implements Project {
 
   get processor() {
     return this.durableObjectStub.processor;
+  }
+
+  get ai() {
+    return new AiRpcTarget(env.AI);
   }
 
   get #itx() {
@@ -762,6 +816,15 @@ export class AgentItxRpcTarget extends ProjectRpcTarget implements AgentItx {
     // capabilities stay at the root; agent-only capabilities and message APIs
     // live behind this explicit property instead of relying on fallback magic.
     return this.agents.get((this.props as ProjectRpcTargetProps & { agentPath: string }).agentPath);
+  }
+
+  get chat() {
+    const props = this.props as ProjectRpcTargetProps & { agentPath: string };
+    return new AgentChatRpcTarget({
+      auth: props.auth,
+      path: props.agentPath,
+      projectId: props.projectId,
+    });
   }
 }
 

--- a/apps/minimal-itx-v4/src/rpc-targets.ts
+++ b/apps/minimal-itx-v4/src/rpc-targets.ts
@@ -60,11 +60,6 @@ import type {
   DynamicWorkerRef,
 } from "./types.ts";
 
-type AiBinding = {
-  models?: () => unknown;
-  run(model: string, body: unknown): Promise<unknown>;
-};
-
 export class StreamRpcTarget extends RpcTarget implements Stream {
   constructor(readonly props: { auth: ItxAuth; projectId: string | null; path: string }) {
     super();
@@ -354,20 +349,21 @@ class SecretRpcTarget extends RpcTarget implements Secret {
   }
 }
 
+type AiRunOptions = NonNullable<Parameters<Cloudflare.Env["AI"]["run"]>[2]>;
+
 class AiRpcTarget extends RpcTarget implements Ai {
-  constructor(readonly binding: AiBinding) {
+  constructor(readonly props: { gateway?: AiRunOptions["gateway"] } = {}) {
     super();
   }
 
   models() {
-    if (typeof this.binding.models !== "function") {
-      throw new Error("AI binding does not expose models().");
-    }
-    return Promise.resolve(this.binding.models());
+    return Promise.resolve(env.AI.models());
   }
 
   run(...[model, body]: Parameters<Ai["run"]>) {
-    return this.binding.run(model, body);
+    const options: AiRunOptions | undefined =
+      this.props.gateway === undefined ? undefined : { gateway: this.props.gateway };
+    return env.AI.run(model, body as Record<string, unknown>, options);
   }
 }
 
@@ -692,7 +688,7 @@ export class ProjectRpcTarget extends RpcTarget implements Project {
   }
 
   get ai() {
-    return new AiRpcTarget(env.AI);
+    return new AiRpcTarget();
   }
 
   get #itx() {

--- a/apps/minimal-itx-v4/src/types.ts
+++ b/apps/minimal-itx-v4/src/types.ts
@@ -44,6 +44,7 @@ export interface ProjectCollection {
  * capabilities cannot shadow core project operations.
  */
 export interface Project extends ItxCapabilityHost {
+  ai: Ai;
   agents: AgentCollection;
   describe(): Promise<ProjectDescription>;
   egress: ProjectEgress;
@@ -66,6 +67,18 @@ export interface Project extends ItxCapabilityHost {
  */
 export interface AgentItx extends Project {
   agent: Agent;
+  chat: AgentChat;
+}
+
+/** Agent-local web chat response tool exposed inside agent script execution. */
+export interface AgentChat {
+  sendMessage(input: { message: string }): Promise<StreamEvent>;
+}
+
+/** Workers AI binding exposed through ITX as a project/agent capability. */
+export interface Ai {
+  models(): Promise<unknown>;
+  run(model: string, body: unknown): Promise<unknown>;
 }
 
 /** Agent catalog within one project. */
@@ -200,10 +213,16 @@ export type ProjectProcessorState = {
 };
 
 export type AgentProcessorState = {
-  inputs: Array<{ content: string; offset: number }>;
-  outputs: Array<{ content: string; offset: number }>;
-  scheduledRequests: Record<string, number>;
+  currentRequest:
+    | { phase: "scheduled"; requestId: string; scheduledOffset: number }
+    | { phase: "requested"; llmRequestId: number }
+    | null;
+  history: Array<{ role: "user" | "assistant"; content: string }>;
+  llmConfig: { model: string };
+  llmProvider: "cloudflare-ai";
+  pendingTriggerOffset: number | null;
   scriptExecutionsCompleted: string[];
+  systemPrompt: string;
 };
 
 export type RepoProcessorState = {

--- a/apps/minimal-itx-v4/wrangler.jsonc
+++ b/apps/minimal-itx-v4/wrangler.jsonc
@@ -12,6 +12,9 @@
       "enabled": true,
     },
   },
+  "ai": {
+    "binding": "AI",
+  },
   "durable_objects": {
     "bindings": [
       // Domain objects own their domain workflows. ITX owns the dynamic capability host.


### PR DESCRIPTION
## What changed

- Ports the minimal ITX v4 agent shape to the OS-style web-chat agent flow: the core agent processor owns history and scheduling, while provider processors execute LLM requests by reference.
- Adds a Cloudflare AI provider processor behind an `AiLike` binding boundary, plus `project.ai` as an `AiRpcTarget` wrapper over `env.AI`.
- Boots new `/agents/...` streams with agent, Cloudflare AI, and ITX processors, defaulting to `@cf/moonshotai/kimi-k2.7-code`.
- Keeps the agent prompt web-chat only and aligned with OS: one fenced JS block containing a single `async (itx) => { ... }` arrow function.
- Adds focused processor tests, including the real Workers AI terminal stream chunk shape with empty `choices`.

## Why

The previous minimal agent was a simplified/faux shape. This brings back the actual OS-style request-by-reference LLM agent model without Slack, while still supporting swappable AI bindings via the provider boundary.

## Validation

- `pnpm --dir apps/minimal-itx-v4 exec vitest run src/domains/agents/agent-processors.test.ts`
- `pnpm --dir apps/minimal-itx-v4 typecheck`
- `pnpm --dir apps/minimal-itx-v4 verify:miniflare` — 14 files passed, 88 tests passed, 2 skipped
- Deployed proof against `https://minimal-itx-v4.iterate-dev-preview.workers.dev`, version `ad7b8329-13b2-4348-a6e1-9558b16abe81`:
  - direct `project.ai.run("@cf/moonshotai/kimi-k2.7-code", ...)` returned `real-ai-direct-ok`
  - fresh default-prompt agent selected Kimi, streamed 84 Cloudflare AI chunks, emitted `async (itx) => { ... }`, executed the script, and appended the expected `events.iterate.com/agents/web-message-sent`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent event protocol, LLM scheduling/cancellation, and live Workers AI calls on agent streams; mistakes could cause duplicate requests, stuck debounces, or wrong model output handling, though idempotency and focused tests mitigate this.
> 
> **Overview**
> Replaces the minimal ITX v4 **faux** agent loop with an **OS-aligned web-chat agent**: the core agent processor owns **chat history**, **input policies**, debounced **request-by-reference** LLM scheduling, cancellation/recovery, and **codemode** script execution from model output; a separate **Cloudflare AI** processor rebuilds prompts from stream history and runs `env.AI` (streaming + multi-format parsing).
> 
> **Capabilities and bootstrap:** Adds **`project.ai`** / **`itx.ai`** via `AiRpcTarget`, **`itx.chat.sendMessage`** for web replies, renames channel events to `events.iterate.com/agents/*`, and on new `/agents/...` streams wires **agent + cloudflare-ai + ITX** subscriptions, default system prompt, and default model (`@cf/moonshotai/kimi-k2.7-code`). **Multi-processor** agent DOs resolve wake targets by `subscriptionKey#processor` suffix.
> 
> Docs, **wrangler** `AI` binding, processor unit tests, and e2e updates (no longer relying on faux `ask` replies) accompany the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4c5d897370fcd28f90dc9ea917c28d3e7aaa975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->