### PR TITLE
Right-size Depot CI runners

### DIFF
--- a/.depot/workflows/build-preview-ci-image.yml
+++ b/.depot/workflows/build-preview-ci-image.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build-image:
     name: Build preview CI image
-    runs-on: depot-ubuntu-24.04-64
+    runs-on: depot-ubuntu-24.04-16
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/ts-workflows/utils/index.ts
+++ b/.github/ts-workflows/utils/index.ts
@@ -5,14 +5,14 @@ export * from "./github-script.ts";
 export const prTriggerable = {
   on: {} satisfies Workflow["on"],
 };
-/** Use this for GitHub Actions jobs that should run on Depot's larger Linux runner. */
+/** Use this for ordinary GitHub Actions jobs that should run on Depot's small Linux runner. */
 export const runsOnDepotUbuntu = {
-  "runs-on": "depot-ubuntu-24.04-32",
+  "runs-on": "depot-ubuntu-24.04",
 };
 
-/** Use this for high-parallelism preview lifecycle jobs. */
-export const runsOnDepotUbuntu64 = {
-  "runs-on": "depot-ubuntu-24.04-64",
+/** Use this for preview lifecycle jobs that need more headroom than ordinary CI. */
+export const runsOnDepotUbuntuPreview = {
+  "runs-on": "depot-ubuntu-24.04-16",
 };
 
 /** checkout, setup pnpm, setup node, install dependencies. Accepts an optional ref override (e.g. for workflow_dispatch inputs). */

--- a/.github/ts-workflows/workflows/cloudflare-previews.ts
+++ b/.github/ts-workflows/workflows/cloudflare-previews.ts
@@ -36,7 +36,7 @@ export default {
     preview: {
       if: "github.event.action != 'closed'",
       name: "Preview / deploy + e2e",
-      ...utils.runsOnDepotUbuntu64,
+      ...utils.runsOnDepotUbuntuPreview,
       concurrency: {
         group: `cloudflare-preview-lifecycle-\${{ github.event.pull_request.number }}`,
         "cancel-in-progress": false,
@@ -96,7 +96,7 @@ export default {
     cleanup: {
       if: "github.event.action == 'closed'",
       name: "Preview / cleanup",
-      ...utils.runsOnDepotUbuntu64,
+      ...utils.runsOnDepotUbuntuPreview,
       concurrency: {
         group: `cloudflare-preview-lifecycle-\${{ github.event.pull_request.number }}`,
         "cancel-in-progress": false,

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -10,7 +10,7 @@ on:
       - "*autofix*"
 jobs:
   autofix:
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch: {}
 jobs:
   variables:
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Document rollout strategy
         run: |-
@@ -30,7 +30,7 @@ jobs:
       - variables
       - deploy
     if: always() && contains(needs.*.result, 'failure')
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     env:
       NEEDS: ${{ toJson(needs) }}
     steps:

--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -18,7 +18,7 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/cloudflare-previews.yml
+++ b/.github/workflows/cloudflare-previews.yml
@@ -33,7 +33,7 @@ jobs:
   preview:
     if: github.event.action != 'closed'
     name: Preview / deploy + e2e
-    runs-on: depot-ubuntu-24.04-64
+    runs-on: depot-ubuntu-24.04-16
     concurrency:
       group: cloudflare-preview-lifecycle-${{ github.event.pull_request.number }}
       cancel-in-progress: false
@@ -89,7 +89,7 @@ jobs:
   cleanup:
     if: github.event.action == 'closed'
     name: Preview / cleanup
-    runs-on: depot-ubuntu-24.04-64
+    runs-on: depot-ubuntu-24.04-16
     concurrency:
       group: cloudflare-preview-lifecycle-${{ github.event.pull_request.number }}
       cancel-in-progress: false

--- a/.github/workflows/deploy-auth.yml
+++ b/.github/workflows/deploy-auth.yml
@@ -26,7 +26,7 @@ on:
         default: ""
 jobs:
   deploy:
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: doppler run -- pnpm alchemy:up
   deploy-dev-global:
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-os.yml
+++ b/.github/workflows/deploy-os.yml
@@ -30,7 +30,7 @@ on:
         default: ""
 jobs:
   variables:
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     outputs:
       run_url: ${{ steps.vars.outputs.run_url }}
       short_sha: ${{ steps.vars.outputs.short_sha }}
@@ -46,7 +46,7 @@ jobs:
     needs:
       - variables
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     outputs:
       public_url: ${{ steps.metadata.outputs.public_url }}
     steps:
@@ -91,7 +91,7 @@ jobs:
       - variables
       - deploy
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.deploy.result == 'success'
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -146,7 +146,7 @@ jobs:
       - variables
       - deploy
     if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.deploy.result == 'failure'
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-semaphore.yml
+++ b/.github/workflows/deploy-semaphore.yml
@@ -27,7 +27,7 @@ on:
         default: ""
 jobs:
   variables:
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     outputs:
       run_url: ${{ steps.vars.outputs.run_url }}
       short_sha: ${{ steps.vars.outputs.short_sha }}
@@ -43,7 +43,7 @@ jobs:
     needs:
       - variables
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     outputs:
       public_url: ${{ steps.metadata.outputs.public_url }}
     steps:
@@ -88,7 +88,7 @@ jobs:
       - variables
       - deploy
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.deploy.result == 'success'
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -143,7 +143,7 @@ jobs:
       - variables
       - deploy
     if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.deploy.result == 'failure'
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-streams-example-app.yml
+++ b/.github/workflows/deploy-streams-example-app.yml
@@ -28,7 +28,7 @@ on:
         default: ""
 jobs:
   variables:
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     outputs:
       run_url: ${{ steps.vars.outputs.run_url }}
       short_sha: ${{ steps.vars.outputs.short_sha }}
@@ -44,7 +44,7 @@ jobs:
     needs:
       - variables
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     outputs:
       public_url: ${{ steps.metadata.outputs.public_url }}
     steps:
@@ -89,7 +89,7 @@ jobs:
       - variables
       - deploy
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.deploy.result == 'success'
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -144,7 +144,7 @@ jobs:
       - variables
       - deploy
     if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.deploy.result == 'failure'
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-tunnels.yml
+++ b/.github/workflows/deploy-tunnels.yml
@@ -25,7 +25,7 @@ on:
         default: ""
 jobs:
   deploy:
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ permissions:
   deployments: write
 jobs:
   deploy-iterate-com:
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     if: inputs.deploy_iterate_com
     steps:
       - name: Checkout code

--- a/.github/workflows/generate-workflows.yml
+++ b/.github/workflows/generate-workflows.yml
@@ -5,7 +5,7 @@ on:
   push: {}
 jobs:
   generate:
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/lint-typecheck.yml
+++ b/.github/workflows/lint-typecheck.yml
@@ -8,7 +8,7 @@ on:
   pull_request: {}
 jobs:
   lint-typecheck:
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/nag.yml
+++ b/.github/workflows/nag.yml
@@ -18,7 +18,7 @@ jobs:
     concurrency:
       group: global-nag-concurrency-group
       cancel-in-progress: false
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pr-dashboard.yml
+++ b/.github/workflows/pr-dashboard.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: false
 jobs:
   update_dashboard:
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -20,7 +20,7 @@ permissions:
   checks: read
 jobs:
   pullfrog:
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ on:
         type: string
 jobs:
   release:
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   pull_request: {}
 jobs:
   test:
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -70,7 +70,7 @@ Most workflows still run on GitHub Actions. Depot is used there as a runner
 provider by setting `runs-on` to a Depot runner label, for example:
 
 ```yaml
-runs-on: depot-ubuntu-24.04-64
+runs-on: depot-ubuntu-24.04
 ```
 
 This is still GitHub Actions. It uses GitHub workflow triggers, GitHub secrets,


### PR DESCRIPTION
## Summary
- move ordinary generated GitHub workflows from `depot-ubuntu-24.04-32` to `depot-ubuntu-24.04`
- move preview deploy/e2e/cleanup and the daily preview image bake from 64 CPU runners to `depot-ubuntu-24.04-16`
- regenerate checked-in GitHub workflow YAML and update the CI workflow docs example

## Verification
- `pnpm workflows`
- `pnpm --dir .github/ts-workflows build`
- `git diff --check`
- checked no `depot-ubuntu-24.04-8`, `-32`, or `-64` runner labels remain under `.github`, `.depot`, `docs`, or `scripts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Preview deploy/e2e and production deploy jobs run on smaller runners, which could cause timeouts or OOM until workloads are re-measured; workflow logic is unchanged.
> 
> **Overview**
> **Right-sizes Depot runner labels** across CI so ordinary jobs use the default small runner and heavier preview work uses a mid-tier size instead of 32- or 64-CPU labels.
> 
> Shared helpers in `.github/ts-workflows/utils/index.ts` now map **`runsOnDepotUbuntu`** to `depot-ubuntu-24.04` (was `-32`) and replace **`runsOnDepotUbuntu64`** with **`runsOnDepotUbuntuPreview`** on `depot-ubuntu-24.04-16`. Cloudflare preview deploy/e2e/cleanup and the daily preview CI image bake follow that preview helper. Regenerated `.github/workflows/*.yml` picks up the same labels, and `docs/ci-workflows.md` documents the default example runner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3a83bd6a9f8df37e0f00392661acf17f0008e3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-01T18:11:09.498Z",
      "headSha": "d3a83bd6a9f8df37e0f00392661acf17f0008e3e",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28526134198",
      "shortSha": "d3a83bd",
      "cleanupDurationMs": 14610,
      "deployDurationMs": 32851,
      "testDurationMs": 6450
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-01T18:11:11.348Z",
      "headSha": "d3a83bd6a9f8df37e0f00392661acf17f0008e3e",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28526134198",
      "shortSha": "d3a83bd",
      "cleanupDurationMs": 16457,
      "deployDurationMs": 30590,
      "testDurationMs": 638
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-01T18:11:03.765Z",
      "headSha": "d3a83bd6a9f8df37e0f00392661acf17f0008e3e",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-2.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28526134198",
      "shortSha": "d3a83bd",
      "cleanupDurationMs": 8872,
      "deployDurationMs": 16463,
      "testDurationMs": 24588
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-01T18:10:53.882Z",
      "headSha": "d3a83bd6a9f8df37e0f00392661acf17f0008e3e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28526134198",
      "shortSha": "d3a83bd",
      "cleanupDurationMs": 71026,
      "deployDurationMs": 57420,
      "testDurationMs": 587477
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `d3a83bd` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 30.6s | 638ms | 16.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28526134198) | 2026-07-01T18:11:11.348Z | Preview app released. |
| OS | released | `d3a83bd` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 57.4s | 587.5s | 71.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28526134198) | 2026-07-01T18:10:53.882Z | Preview app released. |
| Semaphore | released | `d3a83bd` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 32.9s | 6.5s | 14.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28526134198) | 2026-07-01T18:11:09.498Z | Preview app released. |
| Streams Example App | released | `d3a83bd` | [https://streams-example-app-preview-2.iterate-dev-preview.workers.dev](https://streams-example-app-preview-2.iterate-dev-preview.workers.dev) | 16.5s | 24.6s | 8.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28526134198) | 2026-07-01T18:11:03.765Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->