### PR TITLE
Move Slack bot fallback into integration config

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ from your machine, and when you need a public callback URL. Doppler/Cloudflare/d
 - [Design system & React](docs/design-system.md)
 - [Slack testing](docs/slack-testing.md) — real Slack flows, preview app setup, and internal duplicate-bot caveats
 - [Slack preview OAuth clients](docs/slack-preview-oauth-clients.md) — bulk-create preview Slack apps and collect Doppler secrets
+- [Slack bot token migration](docs/slack-bot-token-migration.md) — per-app bot token fallback links and Doppler shape
 - [Testing](docs/testing.md) — test lanes, how to run them against any environment, and the canonical env vars
 - [Vitest patterns](docs/vitest-patterns.md)
 - [Domain objects & stream processors](docs/domain-objects-and-stream-processors.md)

--- a/apps/os/docs/slack-preview-app-manifest.md
+++ b/apps/os/docs/slack-preview-app-manifest.md
@@ -3,8 +3,8 @@
 Use this runbook when a browser-using agent needs to create or repair the Slack
 app for an OS preview slot.
 
-For the end-to-end testing flow and the `Niterate Bot` duplicate-reply caveat
-in the Iterate Slack workspace, see
+For the end-to-end testing flow and the `Niterate (CI bot)` duplicate-reply
+caveat in the Iterate Slack workspace, see
 [`docs/slack-testing.md`](../../../docs/slack-testing.md).
 For bulk creation of the remaining preview Slack apps and the secrets handoff
 form, see
@@ -14,8 +14,8 @@ Each preview slot gets its own Slack app:
 
 | OS config   | Slack label         | Dashboard URL                      | Slack app name        |
 | ----------- | ------------------- | ---------------------------------- | --------------------- |
-| `preview_N` | `preview-N`         | `https://os.iterate-preview-N.com` | `Iterate (preview-N)` |
-| `preview_1` | `preview-1` example | `https://os.iterate-preview-1.com` | `Iterate (preview-1)` |
+| `preview_N` | `preview-N`         | `https://os.iterate-preview-N.com` | `iterate (preview-N)` |
+| `preview_1` | `preview-1` example | `https://os.iterate-preview-1.com` | `iterate (preview-1)` |
 
 Do not reuse the production Slack app for previews, and do not point one Slack
 app at multiple preview slots. Slack has one active Events API Request URL per
@@ -44,8 +44,8 @@ Use hyphen form (`preview-N`) in Slack labels and hostnames, and underscore form
 
 ```yaml
 display_information:
-  name: Iterate (preview-N)
-  description: Iterate Slack agent for preview-N testing only
+  name: iterate (preview-N)
+  description: iterate Slack agent for preview-N testing only
   background_color: "#111827"
 features:
   app_home:
@@ -53,7 +53,7 @@ features:
     messages_tab_enabled: true
     messages_tab_read_only_enabled: false
   agent_view:
-    agent_description: Test Iterate's preview-N Slack agent against the preview OS deployment.
+    agent_description: Test iterate's preview-N Slack agent against the preview OS deployment.
     suggested_prompts:
       - title: Debug this thread
         message: "!debug"
@@ -126,16 +126,10 @@ verified yet, create the app with a bootstrap manifest first:
 
 ```yaml
 display_information:
-  name: Iterate (preview-N)
-  description: Iterate Slack agent for preview-N testing only
+  name: iterate (preview-N)
+  description: iterate Slack agent for preview-N testing only
   background_color: "#111827"
 features:
-  app_home:
-    home_tab_enabled: false
-    messages_tab_enabled: true
-    messages_tab_read_only_enabled: false
-  agent_view:
-    agent_description: Test Iterate's preview-N Slack agent against the preview OS deployment.
   bot_user:
     display_name: iterate-preview-N
     always_online: true
@@ -176,6 +170,12 @@ Then finish Doppler and deployment, return to **App Manifest**, paste the full
 manifest, and save it. Slack URL verification will succeed only after the
 preview worker has the matching signing secret and is deployed.
 
+The bootstrap manifest intentionally omits `features.agent_view`, app-home
+settings, Events API subscriptions, and interactivity. Slack validates Agent
+View against `message.im`, `app_home_opened`, and a verifiable request URL, so
+those fields belong in the full manifest only after the preview worker can
+answer Slack's URL verification challenge.
+
 ## Copy Slack credentials
 
 After Slack creates the app, open **Basic Information** and collect:
@@ -183,6 +183,8 @@ After Slack creates the app, open **Basic Information** and collect:
 - **Client ID**
 - **Client Secret**
 - **Signing Secret**
+- Optional fallback for smoke testing: **Bot User OAuth Token** from
+  **OAuth & Permissions**
 - Optional for inventory only: **App ID** and **Team ID**
 
 Do not use the Verification Token.
@@ -196,12 +198,15 @@ or an interactive prompt; do not paste them into this file.
 export SLACK_CLIENT_ID='...'
 export SLACK_CLIENT_SECRET='...'
 export SLACK_SIGNING_SECRET='...'
+export SLACK_BOT_TOKEN='' # optional xoxb- token from OAuth & Permissions
 
 jq -nc \
   --arg id "$SLACK_CLIENT_ID" \
   --arg secret "$SLACK_CLIENT_SECRET" \
   --arg signing "$SLACK_SIGNING_SECRET" \
-  '{oauthClientId:$id,oauthClientSecret:$secret,webhookSigningSecret:$signing}' |
+  --arg bot "$SLACK_BOT_TOKEN" \
+  '{oauthClientId:$id,oauthClientSecret:$secret,webhookSigningSecret:$signing}
+    + if $bot == "" then {} else {botToken:$bot} end' |
   doppler secrets set APP_CONFIG_INTEGRATIONS__SLACK \
     --project os \
     --config preview_N \
@@ -273,7 +278,7 @@ separate deployment.
 Use a private or dedicated Slack test channel; message events in channels where
 the bot is present are real triggers. In the Iterate Slack workspace, avoid
 shared public channels for preview testing unless duplicate replies from the
-production `Niterate Bot` app are acceptable.
+production `iterate` app or legacy `Niterate (CI bot)` actor are acceptable.
 
 1. Invite the preview bot to the channel:
 
@@ -313,11 +318,11 @@ Slack's Events API and OAuth.
 - **Events verify but no project reacts**: the Slack workspace may not be
   claimed through OS. Run the OS **Connect Slack** flow for the intended
   project.
-- **Preview and `Niterate Bot` both reply**: this is usually an internal
-  Iterate Slack workspace artifact. Production and preview apps can both be
-  installed there with broad `message.channels` subscriptions, and
-  `chat:write.public` means the production app can post into public channels
-  even when its bot user is not visibly in the channel. See
+- **Preview and another Iterate-owned bot both reply**: this is usually an
+  internal Iterate Slack workspace artifact. Production and preview apps can
+  both be installed there with broad `message.channels` subscriptions, and
+  `chat:write.public` means an app can post into public channels even when its
+  bot user is not visibly in the channel. See
   [`docs/slack-testing.md`](../../../docs/slack-testing.md).
 - **Channel messages do nothing**: invite the preview bot to the channel and
   verify the app has been reinstalled after any scope changes. Slack applies

--- a/apps/os/src/config.test.ts
+++ b/apps/os/src/config.test.ts
@@ -34,7 +34,7 @@ describe("AppConfig", () => {
     ).toEqual("admin-api-secret-example");
   });
 
-  it("accepts an optional Slack bot token for codemode Slack examples", () => {
+  it("accepts the legacy top-level Slack bot token during migration", () => {
     expect(
       parseAppConfigFromEnv({
         configSchema: AppConfig,
@@ -57,6 +57,7 @@ describe("AppConfig", () => {
           oauthClientId: "slack-client-id",
           oauthClientSecret: "slack-client-secret",
           webhookSigningSecret: "slack-signing-secret",
+          botToken: "slack-bot-token",
         }),
         APP_CONFIG_INTEGRATIONS__GOOGLE: JSON.stringify({
           oauthClientId: "google-client-id",
@@ -72,6 +73,7 @@ describe("AppConfig", () => {
     expect(parsed.integrations.slack?.webhookSigningSecret.exposeSecret()).toEqual(
       "slack-signing-secret",
     );
+    expect(parsed.integrations.slack?.botToken?.exposeSecret()).toEqual("slack-bot-token");
     expect(parsed.integrations.google?.oauthClientId).toEqual("google-client-id");
     expect(parsed.integrations.google?.oauthClientSecret.exposeSecret()).toEqual(
       "google-client-secret",

--- a/apps/os/src/config.ts
+++ b/apps/os/src/config.ts
@@ -92,6 +92,7 @@ export const AppConfig = z.object({
           oauthClientId: publicValue(z.string().trim().min(1)),
           oauthClientSecret: redacted(z.string().trim().min(1)),
           webhookSigningSecret: redacted(z.string().trim().min(1)),
+          botToken: redacted(z.string().trim().min(1)).optional(),
           scopes: publicValue(z.array(SlackScope).default(DEFAULT_SLACK_BOT_SCOPES)),
         })
         .optional(),
@@ -104,8 +105,8 @@ export const AppConfig = z.object({
         .optional(),
     })
     .default({}),
-  /** Deployment-wide Slack bot token fallback used when a project has no
-   * connected Slack workspace secret (codemode Slack examples, dev smokes). */
+  /** Legacy deployment-wide Slack bot token fallback. New configs should set
+   * `integrations.slack.botToken` so each Slack app owns its own token. */
   slackBotToken: redacted(z.string().trim().min(1)).optional(),
   typeIdPrefix: z
     .string()

--- a/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
+++ b/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
@@ -242,22 +242,30 @@ function isBotMessage(slackEvent: Record<string, unknown>): boolean {
 // Returns true only when the message came from our own bot. Slack's
 // `authorizations` payload often carries the authorized bot `user_id` without a
 // `bot_id`, so fall back to comparing the message's bot user identity before
-// considering other bot messages safe to forward.
+// considering other bot messages safe to forward. If Slack gives us no
+// comparable identity, treat the bot message as our own to avoid self-wake.
 function isOwnBotMessage(
   slackEvent: Record<string, unknown>,
   identity: { botBotId: string | undefined; botUserId: string | undefined },
 ): boolean {
   if (!isBotMessage(slackEvent)) return false;
 
+  let comparedIdentity = false;
   const msgBotId = readStringField(slackEvent, "bot_id");
-  if (identity.botBotId != null && msgBotId != null) return msgBotId === identity.botBotId;
+  if (identity.botBotId != null && msgBotId != null) {
+    comparedIdentity = true;
+    if (msgBotId === identity.botBotId) return true;
+  }
 
   const msgUserId =
     readStringField(slackEvent, "user") ??
     readStringField(readRecordField(slackEvent, "bot_profile"), "user_id");
-  if (identity.botUserId != null && msgUserId != null) return msgUserId === identity.botUserId;
+  if (identity.botUserId != null && msgUserId != null) {
+    comparedIdentity = true;
+    if (msgUserId === identity.botUserId) return true;
+  }
 
-  return identity.botBotId == null && identity.botUserId == null;
+  return !comparedIdentity;
 }
 
 /**

--- a/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
+++ b/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
@@ -112,9 +112,10 @@ export class SlackAgentProcessor extends StreamProcessor<
 
         const slackEvent = parsed.data.event;
         const target = slackAgentTargetFromWebhookPayload(event.payload);
+        const botUserId = state.botUserId ?? botUserIdFromPayload(event.payload);
         const botBotId = state.botBotId ?? botBotIdFromPayload(event.payload);
-        if (isOwnBotMessage(slackEvent, botBotId)) return;
-        if (isBotAction(slackEvent, state.botUserId)) return;
+        if (isOwnBotMessage(slackEvent, { botBotId, botUserId })) return;
+        if (isBotAction(slackEvent, botUserId)) return;
         if (readStringField(slackEvent, "type") !== "message") {
           blockProcessorWhile(async () => {
             await appendAgentInput({
@@ -238,16 +239,25 @@ function isBotMessage(slackEvent: Record<string, unknown>): boolean {
   return false;
 }
 
-// Returns true only when the message came from our own bot (same bot_id as the
-// authorized app). Falls back to blocking all bots when our bot_id is unknown.
+// Returns true only when the message came from our own bot. Slack's
+// `authorizations` payload often carries the authorized bot `user_id` without a
+// `bot_id`, so fall back to comparing the message's bot user identity before
+// considering other bot messages safe to forward.
 function isOwnBotMessage(
   slackEvent: Record<string, unknown>,
-  botBotId: string | undefined,
+  identity: { botBotId: string | undefined; botUserId: string | undefined },
 ): boolean {
-  if (botBotId == null) return isBotMessage(slackEvent);
+  if (!isBotMessage(slackEvent)) return false;
+
   const msgBotId = readStringField(slackEvent, "bot_id");
-  if (msgBotId == null) return false;
-  return msgBotId === botBotId;
+  if (identity.botBotId != null && msgBotId != null) return msgBotId === identity.botBotId;
+
+  const msgUserId =
+    readStringField(slackEvent, "user") ??
+    readStringField(readRecordField(slackEvent, "bot_profile"), "user_id");
+  if (identity.botUserId != null && msgUserId != null) return msgUserId === identity.botUserId;
+
+  return identity.botBotId == null && identity.botUserId == null;
 }
 
 /**

--- a/apps/os/src/domains/integrations/slack-api.ts
+++ b/apps/os/src/domains/integrations/slack-api.ts
@@ -5,8 +5,9 @@
 // egress door with a `getSecret({ path: ... })` placeholder in the
 // authorization header, so token material never leaves the secret DO's
 // substitution pipeline and every outbound attempt lands on the secret's
-// audit trail. When the project has no connected workspace, the deployment
-// `slackBotToken` config (if set) is the fallback, matching legacy behavior.
+// audit trail. When the project has no connected workspace, the deployment's
+// Slack integration `botToken` config is the fallback. The legacy top-level
+// `slackBotToken` is still accepted during the migration.
 
 import { itxEnv } from "../../env.ts";
 import { projectStub } from "../projects/egress.ts";
@@ -36,8 +37,8 @@ export async function callSlackWebApi(input: {
  * Slack Web API call authorized by the project's stored bot token, without
  * ever reading the token material: the request carries a secret reference
  * placeholder and traverses the project egress door, which substitutes it in
- * the secret Durable Object. Falls back to the deployment `slackBotToken`
- * config when the project has no stored token.
+ * the secret Durable Object. Falls back to the Slack integration bot token
+ * when the project has no stored token.
  */
 export async function callProjectSlackWebApi(input: {
   body: Record<string, unknown>;
@@ -65,7 +66,7 @@ export async function callProjectSlackWebApi(input: {
       const fallbackToken = readFallbackSlackBotToken();
       if (fallbackToken === null) {
         throw new Error(
-          `Slack Web API ${input.method} failed: no project Slack bot token secret and no slackBotToken config fallback (${errorBody.error}).`,
+          `Slack Web API ${input.method} failed: no project Slack bot token secret and no Slack integration botToken config fallback (${errorBody.error}).`,
         );
       }
       return await callSlackWebApi({
@@ -80,7 +81,9 @@ export async function callProjectSlackWebApi(input: {
 
 function readFallbackSlackBotToken(): string | null {
   try {
-    const token = parseConfig(itxEnv).slackBotToken?.exposeSecret();
+    const config = parseConfig(itxEnv);
+    const token =
+      config.integrations.slack?.botToken?.exposeSecret() ?? config.slackBotToken?.exposeSecret();
     return token && token.trim() !== "" ? token : null;
   } catch {
     return null;

--- a/apps/os/src/domains/integrations/slack-processors.test.ts
+++ b/apps/os/src/domains/integrations/slack-processors.test.ts
@@ -718,6 +718,63 @@ describe("SlackAgentProcessor", () => {
     // Bot-authored messages never get the eyes reaction, even when forwarded.
     expect(slackCalls.filter((call) => call.method === "reactions.add")).toHaveLength(0);
   });
+
+  it("forwards other bot messages when Slack authorizations omit bot_id", async () => {
+    const { cursors, processor, slackCalls, stream } = setup();
+
+    const payload = humanMessageWebhookPayload({ text: "<@UBOT> !debug" });
+    delete (payload.body.authorizations[0] as Record<string, unknown>).bot_id;
+    const event = payload.body.event as Record<string, unknown>;
+    event.subtype = "bot_message";
+    event.bot_id = "BOTHERBOT";
+    event.user = "UOTHERBOT";
+    event.bot_profile = { id: "BOTHERBOT", user_id: "UOTHERBOT" };
+
+    await stream.append({
+      type: "events.iterate.com/slack/webhook-received",
+      payload,
+    });
+    await deliverNewEvents({ cursors, processor, stream });
+
+    const scripts = stream.events.filter(
+      (streamEvent) => streamEvent.type === "events.iterate.com/itx/script-execution-requested",
+    );
+    expect(scripts).toHaveLength(1);
+    expect((scripts[0]!.payload as { code: string }).code).toContain(
+      "const debug = await itx.describe();",
+    );
+    expect(slackCalls.filter((call) => call.method === "reactions.add")).toHaveLength(0);
+  });
+
+  it("ignores our own bot messages when Slack authorizations omit bot_id", async () => {
+    const { cursors, processor, slackCalls, stream } = setup();
+
+    const payload = humanMessageWebhookPayload({ text: "<@UBOT> !debug" });
+    delete (payload.body.authorizations[0] as Record<string, unknown>).bot_id;
+    const event = payload.body.event as Record<string, unknown>;
+    event.subtype = "bot_message";
+    event.bot_id = "BBOT";
+    event.user = "UBOT";
+    event.bot_profile = { id: "BBOT", user_id: "UBOT" };
+
+    await stream.append({
+      type: "events.iterate.com/slack/webhook-received",
+      payload,
+    });
+    await deliverNewEvents({ cursors, processor, stream });
+
+    expect(
+      stream.events.filter((streamEvent) => {
+        return streamEvent.type === "events.iterate.com/itx/script-execution-requested";
+      }),
+    ).toHaveLength(0);
+    expect(
+      stream.events.filter(
+        (streamEvent) => streamEvent.type === "events.iterate.com/agent/input-added",
+      ),
+    ).toHaveLength(0);
+    expect(slackCalls).toHaveLength(0);
+  });
 });
 
 describe("eyesReactionTargetFromWebhookPayload", () => {

--- a/apps/os/src/domains/integrations/slack-processors.test.ts
+++ b/apps/os/src/domains/integrations/slack-processors.test.ts
@@ -775,6 +775,36 @@ describe("SlackAgentProcessor", () => {
     ).toHaveLength(0);
     expect(slackCalls).toHaveLength(0);
   });
+
+  it("ignores bot messages when Slack gives no comparable bot identity", async () => {
+    const { cursors, processor, slackCalls, stream } = setup();
+
+    const payload = humanMessageWebhookPayload({ text: "<@UBOT> !debug" });
+    delete (payload.body.authorizations[0] as Record<string, unknown>).bot_id;
+    const event = payload.body.event as Record<string, unknown>;
+    event.subtype = "bot_message";
+    event.bot_id = "BBOT";
+    delete event.user;
+    delete event.bot_profile;
+
+    await stream.append({
+      type: "events.iterate.com/slack/webhook-received",
+      payload,
+    });
+    await deliverNewEvents({ cursors, processor, stream });
+
+    expect(
+      stream.events.filter((streamEvent) => {
+        return streamEvent.type === "events.iterate.com/itx/script-execution-requested";
+      }),
+    ).toHaveLength(0);
+    expect(
+      stream.events.filter(
+        (streamEvent) => streamEvent.type === "events.iterate.com/agent/input-added",
+      ),
+    ).toHaveLength(0);
+    expect(slackCalls).toHaveLength(0);
+  });
 });
 
 describe("eyesReactionTargetFromWebhookPayload", () => {

--- a/docs/slack-bot-token-migration.md
+++ b/docs/slack-bot-token-migration.md
@@ -40,6 +40,7 @@ prd
 preview_1
 preview_2
 preview_3
+preview_4
 preview_5
 preview_6
 preview_7
@@ -47,52 +48,42 @@ preview_8
 preview_9
 ```
 
-Known gaps:
-
-- `preview_4` has a Slack app, but the paste-back form did not include a bot
-  token.
-- `preview_10` has a Slack app ID, but `os/preview_10` does not currently
-  exist in Doppler.
-- Affected workers still need to be redeployed before they can use newly
-  uploaded Doppler values.
+Affected workers still need to be redeployed before they can use newly
+uploaded Doppler values.
 
 ## OAuth pages
 
 Open the app's **OAuth & Permissions** page, then copy **Bot User OAuth
 Token**. It should start with `xoxb-`.
 
-| Config       | Slack app              | OAuth page                                     |
-| ------------ | ---------------------- | ---------------------------------------------- |
-| `prd`        | `iterate`              | <https://api.slack.com/apps/A08NDMDC2JV/oauth> |
-| `dev`        | shared dev app         | <https://api.slack.com/apps/A0BELTE7H6X/oauth> |
-| `dev_jonas`  | `iterate (dev-jonas)`  | <https://api.slack.com/apps/A08T45SFJF3/oauth> |
-| `dev_misha`  | `iterate (dev-misha)`  | <https://api.slack.com/apps/A09A308RAT0/oauth> |
-| `dev_rahul`  | `iterate (dev-rahul)`  | <https://api.slack.com/apps/A0A9CMH5DU4/oauth> |
-| `preview_1`  | `iterate (preview-1)`  | <https://api.slack.com/apps/A0BESK0LJ7L/oauth> |
-| `preview_2`  | `iterate (preview-2)`  | <https://api.slack.com/apps/A0BETEYFPCZ/oauth> |
-| `preview_3`  | `iterate (preview-3)`  | <https://api.slack.com/apps/A0BFM413EMN/oauth> |
-| `preview_4`  | `iterate (preview-4)`  | <https://api.slack.com/apps/A0BESQ2278S/oauth> |
-| `preview_5`  | `iterate (preview-5)`  | <https://api.slack.com/apps/A0BEBDGA1TR/oauth> |
-| `preview_6`  | `iterate (preview-6)`  | <https://api.slack.com/apps/A0BEPFZ8THT/oauth> |
-| `preview_7`  | `iterate (preview-7)`  | <https://api.slack.com/apps/A0BELK8UL3V/oauth> |
-| `preview_8`  | `iterate (preview-8)`  | <https://api.slack.com/apps/A0BEURK2AAV/oauth> |
-| `preview_9`  | `iterate (preview-9)`  | <https://api.slack.com/apps/A0BEQUQ51F0/oauth> |
-| `preview_10` | `iterate (preview-10)` | <https://api.slack.com/apps/A0BER06737Y/oauth> |
+| Config      | Slack app             | OAuth page                                     |
+| ----------- | --------------------- | ---------------------------------------------- |
+| `prd`       | `iterate`             | <https://api.slack.com/apps/A08NDMDC2JV/oauth> |
+| `dev`       | shared dev app        | <https://api.slack.com/apps/A0BELTE7H6X/oauth> |
+| `dev_jonas` | `iterate (dev-jonas)` | <https://api.slack.com/apps/A08T45SFJF3/oauth> |
+| `dev_misha` | `iterate (dev-misha)` | <https://api.slack.com/apps/A09A308RAT0/oauth> |
+| `dev_rahul` | `iterate (dev-rahul)` | <https://api.slack.com/apps/A0A9CMH5DU4/oauth> |
+| `preview_1` | `iterate (preview-1)` | <https://api.slack.com/apps/A0BESK0LJ7L/oauth> |
+| `preview_2` | `iterate (preview-2)` | <https://api.slack.com/apps/A0BETEYFPCZ/oauth> |
+| `preview_3` | `iterate (preview-3)` | <https://api.slack.com/apps/A0BFM413EMN/oauth> |
+| `preview_4` | `iterate (preview-4)` | <https://api.slack.com/apps/A0BESQ2278S/oauth> |
+| `preview_5` | `iterate (preview-5)` | <https://api.slack.com/apps/A0BEBDGA1TR/oauth> |
+| `preview_6` | `iterate (preview-6)` | <https://api.slack.com/apps/A0BEPFZ8THT/oauth> |
+| `preview_7` | `iterate (preview-7)` | <https://api.slack.com/apps/A0BELK8UL3V/oauth> |
+| `preview_8` | `iterate (preview-8)` | <https://api.slack.com/apps/A0BEURK2AAV/oauth> |
+| `preview_9` | `iterate (preview-9)` | <https://api.slack.com/apps/A0BEQUQ51F0/oauth> |
 
 ## Paste-back form
 
-Do not commit a filled copy of this file. Paste filled values back to the
-agent, or use a private temporary file outside the repo.
+Do not commit a filled copy of this file. Use this only for future rotations;
+paste filled values back to the agent, or use a private temporary file outside
+the repo.
 
 ```text
 SLACK_APP_BOT_TOKENS
 
-preview_4:
-  app_id: A0BESQ2278S
-  bot_token:
-
-preview_10:
-  app_id: A0BER06737Y
+config_name:
+  app_id:
   bot_token:
 ```
 

--- a/docs/slack-bot-token-migration.md
+++ b/docs/slack-bot-token-migration.md
@@ -1,0 +1,130 @@
+# Slack bot token migration
+
+Use this when collecting or rotating the per-app Slack Bot User OAuth Token for
+OS Slack smoke testing.
+
+## Goal
+
+Each Slack app should own its complete runtime config in
+`APP_CONFIG_INTEGRATIONS__SLACK`:
+
+```json
+{
+  "oauthClientId": "...",
+  "oauthClientSecret": "...",
+  "webhookSigningSecret": "...",
+  "botToken": "xoxb-..."
+}
+```
+
+OS Slack Web API calls use the connected project workspace bot token first. If
+a project has no connected Slack token, OS falls back to this environment's
+`APP_CONFIG_INTEGRATIONS__SLACK.botToken`. The old top-level
+`APP_CONFIG_SLACK_BOT_TOKEN` is a temporary legacy fallback only.
+
+`Niterate (CI bot)` is not the production Slack app. The production Slack app
+is `iterate`; `Niterate (CI bot)` is the visible identity associated with the
+legacy shared CI/smoke token.
+
+## Current status
+
+As of July 2, 2026, Doppler has `botToken` embedded in
+`APP_CONFIG_INTEGRATIONS__SLACK` for these `os` configs:
+
+```text
+dev
+dev_jonas
+dev_misha
+dev_rahul
+prd
+preview_1
+preview_2
+preview_3
+preview_5
+preview_6
+preview_7
+preview_8
+preview_9
+```
+
+Known gaps:
+
+- `preview_4` has a Slack app, but the paste-back form did not include a bot
+  token.
+- `preview_10` has a Slack app ID, but `os/preview_10` does not currently
+  exist in Doppler.
+- Affected workers still need to be redeployed before they can use newly
+  uploaded Doppler values.
+
+## OAuth pages
+
+Open the app's **OAuth & Permissions** page, then copy **Bot User OAuth
+Token**. It should start with `xoxb-`.
+
+| Config       | Slack app              | OAuth page                                     |
+| ------------ | ---------------------- | ---------------------------------------------- |
+| `prd`        | `iterate`              | <https://api.slack.com/apps/A08NDMDC2JV/oauth> |
+| `dev`        | shared dev app         | <https://api.slack.com/apps/A0BELTE7H6X/oauth> |
+| `dev_jonas`  | `iterate (dev-jonas)`  | <https://api.slack.com/apps/A08T45SFJF3/oauth> |
+| `dev_misha`  | `iterate (dev-misha)`  | <https://api.slack.com/apps/A09A308RAT0/oauth> |
+| `dev_rahul`  | `iterate (dev-rahul)`  | <https://api.slack.com/apps/A0A9CMH5DU4/oauth> |
+| `preview_1`  | `iterate (preview-1)`  | <https://api.slack.com/apps/A0BESK0LJ7L/oauth> |
+| `preview_2`  | `iterate (preview-2)`  | <https://api.slack.com/apps/A0BETEYFPCZ/oauth> |
+| `preview_3`  | `iterate (preview-3)`  | <https://api.slack.com/apps/A0BFM413EMN/oauth> |
+| `preview_4`  | `iterate (preview-4)`  | <https://api.slack.com/apps/A0BESQ2278S/oauth> |
+| `preview_5`  | `iterate (preview-5)`  | <https://api.slack.com/apps/A0BEBDGA1TR/oauth> |
+| `preview_6`  | `iterate (preview-6)`  | <https://api.slack.com/apps/A0BEPFZ8THT/oauth> |
+| `preview_7`  | `iterate (preview-7)`  | <https://api.slack.com/apps/A0BELK8UL3V/oauth> |
+| `preview_8`  | `iterate (preview-8)`  | <https://api.slack.com/apps/A0BEURK2AAV/oauth> |
+| `preview_9`  | `iterate (preview-9)`  | <https://api.slack.com/apps/A0BEQUQ51F0/oauth> |
+| `preview_10` | `iterate (preview-10)` | <https://api.slack.com/apps/A0BER06737Y/oauth> |
+
+## Paste-back form
+
+Do not commit a filled copy of this file. Paste filled values back to the
+agent, or use a private temporary file outside the repo.
+
+```text
+SLACK_APP_BOT_TOKENS
+
+preview_4:
+  app_id: A0BESQ2278S
+  bot_token:
+
+preview_10:
+  app_id: A0BER06737Y
+  bot_token:
+```
+
+## Doppler update shape
+
+Merge `botToken` into the existing JSON. Do not replace the OAuth client ID,
+OAuth client secret, or webhook signing secret.
+
+```bash
+existing="$(
+  doppler secrets get APP_CONFIG_INTEGRATIONS__SLACK \
+    --project os \
+    --config preview_N \
+    --plain
+)"
+
+updated="$(
+  jq -c --arg bot "$SLACK_BOT_TOKEN" '. + {botToken:$bot}' <<<"$existing"
+)"
+
+doppler secrets set APP_CONFIG_INTEGRATIONS__SLACK="$updated" \
+  --project os \
+  --config preview_N \
+  --silent
+```
+
+Verify shape without printing secret material:
+
+```bash
+doppler secrets get APP_CONFIG_INTEGRATIONS__SLACK \
+  --project os \
+  --config preview_N \
+  --plain |
+  jq -e '.oauthClientId and .oauthClientSecret and .webhookSigningSecret and .botToken' >/dev/null
+```

--- a/docs/slack-preview-oauth-clients.md
+++ b/docs/slack-preview-oauth-clients.md
@@ -29,8 +29,7 @@ Use the JSON under the preview heading first, then save the full manifest after
 the deployed worker can verify the request URL.
 
 `preview_2` already has a Slack app. The repo's preview deployment docs
-currently describe active preview slots `preview_1` through `preview_9`; create
-`preview_10` only after that platform slot exists.
+currently describe active preview slots `preview_1` through `preview_9`.
 
 ## preview_1
 
@@ -520,70 +519,6 @@ preview_8:
 
 ```text
 preview_9:
-  app_id:
-  client_id:
-  client_secret:
-  signing_secret:
-  team_id:
-  app_dashboard_url:
-```
-
-## preview_10
-
-Only create this app after `preview_10` exists as a real platform slot.
-
-```json
-{
-  "display_information": {
-    "name": "iterate (preview-10)",
-    "description": "iterate Slack agent for preview-10 testing only",
-    "background_color": "#111827"
-  },
-  "features": {
-    "bot_user": {
-      "display_name": "iterate-preview-10",
-      "always_online": true
-    }
-  },
-  "oauth_config": {
-    "redirect_urls": ["https://os.iterate-preview-10.com/api/integrations/slack/callback"],
-    "scopes": {
-      "bot": [
-        "channels:history",
-        "channels:join",
-        "channels:manage",
-        "channels:read",
-        "chat:write",
-        "chat:write.public",
-        "files:read",
-        "files:write",
-        "groups:history",
-        "groups:read",
-        "im:history",
-        "im:read",
-        "im:write",
-        "mpim:history",
-        "mpim:read",
-        "reactions:read",
-        "reactions:write",
-        "users.profile:read",
-        "users:read",
-        "users:read.email",
-        "assistant:write",
-        "conversations.connect:write"
-      ]
-    }
-  },
-  "settings": {
-    "org_deploy_enabled": false,
-    "socket_mode_enabled": false,
-    "token_rotation_enabled": false
-  }
-}
-```
-
-```text
-preview_10:
   app_id:
   client_id:
   client_secret:

--- a/docs/slack-preview-oauth-clients.md
+++ b/docs/slack-preview-oauth-clients.md
@@ -17,11 +17,16 @@ agent instead. After that, the agent can upload
 and redeploy the slots.
 
 These are bootstrap manifests. They intentionally omit Events API and
-interactivity request URLs so Slack does not need to verify the webhook before
-the preview worker has the app's signing secret. After Doppler upload and
-deploy, save the full manifest from
+interactivity request URLs, App Home, and Agent View so Slack does not need to
+verify the webhook before the preview worker has the app's signing secret.
+After Doppler upload and deploy, save the full manifest from
 [apps/os/docs/slack-preview-app-manifest.md](../apps/os/docs/slack-preview-app-manifest.md)
 to enable event subscriptions and interactivity.
+
+If Slack validation mentions Agent View requiring `message.im` or
+`app_home_opened`, the manifest being pasted is not the bootstrap manifest.
+Use the JSON under the preview heading first, then save the full manifest after
+the deployed worker can verify the request URL.
 
 `preview_2` already has a Slack app. The repo's preview deployment docs
 currently describe active preview slots `preview_1` through `preview_9`; create
@@ -37,20 +42,6 @@ currently describe active preview slots `preview_1` through `preview_9`; create
     "background_color": "#111827"
   },
   "features": {
-    "app_home": {
-      "home_tab_enabled": false,
-      "messages_tab_enabled": true,
-      "messages_tab_read_only_enabled": false
-    },
-    "agent_view": {
-      "agent_description": "Test iterate's preview-1 Slack agent against the preview OS deployment.",
-      "suggested_prompts": [
-        {
-          "title": "Debug this thread",
-          "message": "!debug"
-        }
-      ]
-    },
     "bot_user": {
       "display_name": "iterate-preview-1",
       "always_online": true
@@ -113,20 +104,6 @@ preview_1:
     "background_color": "#111827"
   },
   "features": {
-    "app_home": {
-      "home_tab_enabled": false,
-      "messages_tab_enabled": true,
-      "messages_tab_read_only_enabled": false
-    },
-    "agent_view": {
-      "agent_description": "Test iterate's preview-3 Slack agent against the preview OS deployment.",
-      "suggested_prompts": [
-        {
-          "title": "Debug this thread",
-          "message": "!debug"
-        }
-      ]
-    },
     "bot_user": {
       "display_name": "iterate-preview-3",
       "always_online": true
@@ -189,20 +166,6 @@ preview_3:
     "background_color": "#111827"
   },
   "features": {
-    "app_home": {
-      "home_tab_enabled": false,
-      "messages_tab_enabled": true,
-      "messages_tab_read_only_enabled": false
-    },
-    "agent_view": {
-      "agent_description": "Test iterate's preview-4 Slack agent against the preview OS deployment.",
-      "suggested_prompts": [
-        {
-          "title": "Debug this thread",
-          "message": "!debug"
-        }
-      ]
-    },
     "bot_user": {
       "display_name": "iterate-preview-4",
       "always_online": true
@@ -265,20 +228,6 @@ preview_4:
     "background_color": "#111827"
   },
   "features": {
-    "app_home": {
-      "home_tab_enabled": false,
-      "messages_tab_enabled": true,
-      "messages_tab_read_only_enabled": false
-    },
-    "agent_view": {
-      "agent_description": "Test iterate's preview-5 Slack agent against the preview OS deployment.",
-      "suggested_prompts": [
-        {
-          "title": "Debug this thread",
-          "message": "!debug"
-        }
-      ]
-    },
     "bot_user": {
       "display_name": "iterate-preview-5",
       "always_online": true
@@ -341,20 +290,6 @@ preview_5:
     "background_color": "#111827"
   },
   "features": {
-    "app_home": {
-      "home_tab_enabled": false,
-      "messages_tab_enabled": true,
-      "messages_tab_read_only_enabled": false
-    },
-    "agent_view": {
-      "agent_description": "Test iterate's preview-6 Slack agent against the preview OS deployment.",
-      "suggested_prompts": [
-        {
-          "title": "Debug this thread",
-          "message": "!debug"
-        }
-      ]
-    },
     "bot_user": {
       "display_name": "iterate-preview-6",
       "always_online": true
@@ -417,20 +352,6 @@ preview_6:
     "background_color": "#111827"
   },
   "features": {
-    "app_home": {
-      "home_tab_enabled": false,
-      "messages_tab_enabled": true,
-      "messages_tab_read_only_enabled": false
-    },
-    "agent_view": {
-      "agent_description": "Test iterate's preview-7 Slack agent against the preview OS deployment.",
-      "suggested_prompts": [
-        {
-          "title": "Debug this thread",
-          "message": "!debug"
-        }
-      ]
-    },
     "bot_user": {
       "display_name": "iterate-preview-7",
       "always_online": true
@@ -493,20 +414,6 @@ preview_7:
     "background_color": "#111827"
   },
   "features": {
-    "app_home": {
-      "home_tab_enabled": false,
-      "messages_tab_enabled": true,
-      "messages_tab_read_only_enabled": false
-    },
-    "agent_view": {
-      "agent_description": "Test iterate's preview-8 Slack agent against the preview OS deployment.",
-      "suggested_prompts": [
-        {
-          "title": "Debug this thread",
-          "message": "!debug"
-        }
-      ]
-    },
     "bot_user": {
       "display_name": "iterate-preview-8",
       "always_online": true
@@ -569,20 +476,6 @@ preview_8:
     "background_color": "#111827"
   },
   "features": {
-    "app_home": {
-      "home_tab_enabled": false,
-      "messages_tab_enabled": true,
-      "messages_tab_read_only_enabled": false
-    },
-    "agent_view": {
-      "agent_description": "Test iterate's preview-9 Slack agent against the preview OS deployment.",
-      "suggested_prompts": [
-        {
-          "title": "Debug this thread",
-          "message": "!debug"
-        }
-      ]
-    },
     "bot_user": {
       "display_name": "iterate-preview-9",
       "always_online": true
@@ -647,20 +540,6 @@ Only create this app after `preview_10` exists as a real platform slot.
     "background_color": "#111827"
   },
   "features": {
-    "app_home": {
-      "home_tab_enabled": false,
-      "messages_tab_enabled": true,
-      "messages_tab_read_only_enabled": false
-    },
-    "agent_view": {
-      "agent_description": "Test iterate's preview-10 Slack agent against the preview OS deployment.",
-      "suggested_prompts": [
-        {
-          "title": "Debug this thread",
-          "message": "!debug"
-        }
-      ]
-    },
     "bot_user": {
       "display_name": "iterate-preview-10",
       "always_online": true

--- a/docs/slack-smoke-testing.md
+++ b/docs/slack-smoke-testing.md
@@ -32,9 +32,11 @@ latency.
 
 ## Important Self-Wake Rule
 
-The OS Slack bot must not wake itself. A message sent with
-`APP_CONFIG_SLACK_BOT_TOKEN` is useful for creating a real Slack thread, but it
-should not be treated as the inbound trigger.
+The OS Slack bot must not wake itself. A message sent with the environment's
+Slack fallback token is useful for creating a real Slack thread, but it should
+not be treated as the inbound trigger. Current configs keep that fallback at
+`APP_CONFIG_INTEGRATIONS__SLACK.botToken`; `APP_CONFIG_SLACK_BOT_TOKEN` is only
+the legacy top-level fallback during migration.
 
 To test bot-originated wakeups, use either:
 
@@ -50,7 +52,8 @@ Run commands from `apps/os`.
 
 - `doppler` access to the target OS config.
 - `APP_CONFIG_ADMIN_API_SECRET` in that config.
-- `APP_CONFIG_SLACK_BOT_TOKEN` in that config.
+- `APP_CONFIG_INTEGRATIONS__SLACK.botToken` in that config, or the legacy
+  `APP_CONFIG_SLACK_BOT_TOKEN` during migration.
 - The OS Slack bot is a member of `#slack-agent-e2e-test`.
 - The target app is deployed and reachable through `APP_CONFIG_BASE_URL`.
 

--- a/docs/slack-testing.md
+++ b/docs/slack-testing.md
@@ -9,6 +9,8 @@ production environments.
   [apps/os/docs/slack-preview-app-manifest.md](../apps/os/docs/slack-preview-app-manifest.md)
 - Bulk-create remaining preview Slack OAuth clients:
   [slack-preview-oauth-clients.md](slack-preview-oauth-clients.md)
+- Slack bot token migration and portal links:
+  [slack-bot-token-migration.md](slack-bot-token-migration.md)
 - Public local URLs for Slack callbacks:
   [dev-environments.md#tunnels-and-webhooks](dev-environments.md#tunnels-and-webhooks)
 - Older manual production smoke notes:
@@ -20,7 +22,7 @@ Every public OS environment needs its own Slack app and callback URLs.
 
 | OS environment | Slack app                             | Request URL                                                         |
 | -------------- | ------------------------------------- | ------------------------------------------------------------------- |
-| `prd`          | `Niterate Bot`                        | `https://os.iterate.com/api/integrations/slack/webhook`             |
+| `prd`          | `iterate`                             | `https://os.iterate.com/api/integrations/slack/webhook`             |
 | `preview_N`    | `iterate-preview-N`                   | `https://os.iterate-preview-N.com/api/integrations/slack/webhook`   |
 | local dev      | personal/dev Slack app or preview app | `https://<name>.tunnels.iterate.com/api/integrations/slack/webhook` |
 
@@ -28,14 +30,34 @@ The Doppler secrets are split by purpose:
 
 - `APP_CONFIG_INTEGRATIONS__SLACK` contains the Slack app credentials for the
   OS deployment: OAuth client ID, OAuth client secret, and webhook signing
-  secret.
+  secret. It also contains `botToken`, the deployment-level outbound fallback
+  for that same Slack app.
 - The OS **Connect Slack** flow stores the workspace bot token for a project at
   `/secrets/integrations/slack/bot-token` and claims the Slack team in the
   deployment's `/integrations/slack-team-directory` stream.
-- `APP_CONFIG_SLACK_BOT_TOKEN` is a deployment-level outbound fallback for
-  Slack Web API calls when a project bot token is unavailable. When diagnosing
-  duplicate replies, check whether this exists in the environment without
-  printing the token.
+- Slack Web API calls use the project workspace token first. If the project has
+  no connected Slack token, OS falls back to
+  `APP_CONFIG_INTEGRATIONS__SLACK.botToken`, then temporarily to the legacy
+  top-level `APP_CONFIG_SLACK_BOT_TOKEN` while the migration is being finished.
+- `APP_CONFIG_SLACK_BOT_TOKEN` is legacy. When diagnosing duplicate replies,
+  check whether it exists in the environment without printing the token.
+
+## Trigger actor for smoke tests
+
+Use a real human Slack message for the cleanest end-to-end smoke test. If a
+script needs to create the inbound Slack message, use a second actor token that
+is not the Slack bot under test.
+
+For example, when testing `iterate-preview-2`, the bot under test replies with
+the connected project token or the `preview_2` fallback token from
+`APP_CONFIG_INTEGRATIONS__SLACK.botToken`. The inbound trigger should be a
+human user, a separate test bot, or a synthetic signed webhook whose Slack
+identity is not `iterate-preview-2`.
+
+Do not use the same app's Bot User OAuth Token to pretend to be the user that
+wakes that same app. That creates self-wake ambiguity and can be ignored by the
+processor. `Niterate (CI bot)` is only an internal legacy CI/smoke actor; it is
+not the production `iterate` app and should not be the normal preview trigger.
 
 ## Manual preview smoke test
 
@@ -59,13 +81,15 @@ The Doppler secrets are split by purpose:
 
 ## Duplicate replies in Iterate Slack
 
-The Iterate Slack workspace is a special case because it can have both the
-production `Niterate Bot` app and one or more preview Slack apps installed at
-the same time. Customer workspaces normally only install one Iterate app, so
-they should not see this specific preview-vs-production duplication.
+The Iterate Slack workspace is a special case because it can have the
+production `iterate` app, the legacy `Niterate (CI bot)` actor, and one or more
+preview Slack apps installed at the same time. Customer workspaces normally
+only install one Iterate app, so they should not see this specific
+preview-vs-production duplication.
 
-If a preview bot and `Niterate Bot` both reply to the same Slack message, treat
-it as an internal workspace isolation issue until proven otherwise:
+If a preview bot and another Iterate-owned bot both reply to the same Slack
+message, treat it as an internal workspace isolation issue until proven
+otherwise:
 
 - Our preview and production manifests subscribe to broad `message.channels`
   events. Slack's docs describe `message.channels` as the public-channel message
@@ -74,12 +98,12 @@ it as an internal workspace isolation issue until proven otherwise:
 - The current OS Slack processor routes normal Slack `message.*` events. It
   does not require the mentioned user ID to match the deployment's bot user
   before starting the agent.
-- The app scope `chat:write.public` lets a Slack app post into public channels.
-  So `Niterate Bot` not appearing as a channel member does not rule out
-  production posting a reply.
-- If `APP_CONFIG_SLACK_BOT_TOKEN` exists in `os/prd`, production can use that
-  fallback token for outbound Slack Web API calls when no project token is
-  available.
+- The app scope `chat:write.public` lets a Slack app post into public channels,
+  so a bot user not appearing as a channel member does not rule out its app
+  posting a reply.
+- If production has either `APP_CONFIG_INTEGRATIONS__SLACK.botToken` or the
+  legacy `APP_CONFIG_SLACK_BOT_TOKEN`, it can use that fallback token for
+  outbound Slack Web API calls when no project token is available.
 
 For a precise diagnosis, inspect the Slack event wrapper and traces:
 
@@ -92,6 +116,6 @@ For a precise diagnosis, inspect the Slack event wrapper and traces:
 
 Avoid duplicate internal replies by testing previews in a private channel that
 only contains the preview app, or in a Slack workspace that does not also have
-the production `Niterate Bot` installed. Public channels in the Iterate
+the production `iterate` app installed. Public channels in the Iterate
 workspace can still be visible to production while broad public-channel event
 subscriptions and `chat:write.public` are enabled.


### PR DESCRIPTION
## Summary

- Move the Slack fallback bot token into `APP_CONFIG_INTEGRATIONS__SLACK.botToken`, with the legacy top-level env var still supported as a fallback during rollout.
- Update Slack setup and smoke-testing docs so preview/dev/prod Slack apps use their own app-scoped bot tokens instead of the CI bot token.
- Add a discoverable migration guide linked from the repo README, including OAuth portal links and the paste-back form for future token rotations.
- Keep the preview OAuth manifest docs limited to active preview slots.
- Fix Slack-agent self-bot filtering for the real Events API shape where `authorizations[]` includes the authorized bot `user_id` but not `bot_id`; messages from a different bot app now route instead of being ignored.
- Preserve the self-wake guard for ambiguous bot webhooks where Slack gives only a message `bot_id` and no comparable bot-user identity.

## Doppler

Uploaded embedded Slack bot tokens for:

- `dev`, `dev_jonas`, `dev_misha`, `dev_rahul`
- `prd`
- `preview_1` through `preview_9`

The legacy `APP_CONFIG_SLACK_BOT_TOKEN` remains in place where it already existed, but runtime fallback now prefers `integrations.slack.botToken` when present.

## Verification

Direct fallback verification:

- `preview_9` has both an embedded preview-app token and the legacy CI fallback token configured.
- Direct Slack `auth.test` identified the embedded token as `iteratepreview9`.
- Direct Slack `auth.test` identified the legacy fallback as `iterate_ci_preview_bo`.
- An OS preview probe created a fresh project with no project Slack secret and called `project.slack.request({ method: "auth.test" })` through the deployed preview backend.
- The OS probe returned `user: "iteratepreview9"`, confirming the runtime prefers the embedded preview app token over the legacy CI fallback token.

Real Slack post/reply verification after deploying this branch to `preview_2`:

- OS fallback `auth.test` for a fresh project returned `iteratepreview2`, not the legacy CI bot.
- OS posted a setup message to `#test-blank` using `project.slack.chat.postMessage`; Slack recorded it as `iteratepreview2` (`B0BEKEPLMFD`).
- `Niterate (CI bot)` then posted `<@iteratepreview2> !debug` as the separate trigger actor (`B0964BNAJEM`).
- Slack delivered the trigger to the preview app (`api_app_id: A0BETEYFPCZ`).
- The preview agent executed the `!debug` script and replied in-thread as `iteratepreview2` after about 8.7s.
- The temporary preview team claim was removed after the test.

BugBot follow-up:

- Ambiguous bot-authored webhook events that expose only `bot_id`, while Slack authorizations only expose the app bot `user_id`, remain ignored so the bot cannot self-wake.

## Checks

- `pnpm --dir apps/os exec vitest run src/domains/integrations/slack-processors.test.ts src/config.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm exec oxfmt --check README.md apps/os/docs/slack-preview-app-manifest.md apps/os/src/config.test.ts apps/os/src/config.ts apps/os/src/domains/integrations/slack-api.ts docs/slack-preview-oauth-clients.md docs/slack-smoke-testing.md docs/slack-testing.md docs/slack-bot-token-migration.md`
- Parsed every JSON manifest block in `docs/slack-preview-oauth-clients.md`
- Deployed this branch to `preview_2` and completed the live Slack smoke above

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-02T18:13:51.613Z",
      "headSha": "4baf9942b01b3e524fbc914965b1faa1511b7568",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28610796518",
      "shortSha": "4baf994",
      "cleanupDurationMs": 13785,
      "deployDurationMs": 28621,
      "testDurationMs": 804
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-02T18:13:36.775Z",
      "headSha": "4baf9942b01b3e524fbc914965b1faa1511b7568",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28610796518",
      "shortSha": "4baf994",
      "cleanupDurationMs": 38412,
      "deployDurationMs": 40766,
      "testDurationMs": 369082
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `4baf994` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 28.6s | 804ms | 13.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28610796518) | 2026-07-02T18:13:51.613Z | Preview app released. |
| OS | released | `4baf994` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 40.8s | 369.1s | 38.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28610796518) | 2026-07-02T18:13:36.775Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Slack Web API token resolution and webhook routing/self-bot filtering in the agent processor; incorrect identity matching could drop legitimate bot triggers or reintroduce self-wake loops.
> 
> **Overview**
> Moves the deployment-wide Slack Web API fallback from legacy `APP_CONFIG_SLACK_BOT_TOKEN` into optional `integrations.slack.botToken`, while still accepting the old env var during rollout. `callProjectSlackWebApi` now prefers the integration-scoped token when a project has no connected workspace secret.
> 
> **Slack agent ingress:** `isOwnBotMessage` now matches on both `bot_id` and bot `user_id` from webhook `authorizations` (including when Slack omits `bot_id`). Other bots’ messages can route again; ambiguous bot messages without a comparable identity are treated as self to avoid self-wake.
> 
> **Docs:** Adds `docs/slack-bot-token-migration.md` (README link), updates Slack testing/smoke/preview runbooks for per-app tokens, `iterate` vs `Niterate (CI bot)` naming, bootstrap manifests without Agent View until URL verification, and optional `botToken` in Doppler `APP_CONFIG_INTEGRATIONS__SLACK`. Preview OAuth bulk manifests drop App Home/Agent View and `preview_10`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4baf9942b01b3e524fbc914965b1faa1511b7568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
