### PR TITLE
[codex] migrate itx mcp client to beta sdk

### DIFF
--- a/apps/os/e2e/workspace-itx-preview-example.ts
+++ b/apps/os/e2e/workspace-itx-preview-example.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env npx tsx
 
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
 import { createAdminOsItx } from "./test-support/os-client.ts";
 
 const DEFAULT_BASE_URL = "https://os.iterate-preview-2.com";

--- a/apps/os/package.json
+++ b/apps/os/package.json
@@ -38,6 +38,7 @@
     "@iterate-com/shared": "workspace:*",
     "@iterate-com/ui": "workspace:*",
     "@journeyapps/wa-sqlite": "^1.7.0",
+    "@modelcontextprotocol/client": "2.0.0-beta.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentui/core": "0.1.102",
     "@opentui/react": "0.1.102",

--- a/apps/os/src/domains/itx/mcp-client.test.ts
+++ b/apps/os/src/domains/itx/mcp-client.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { callMcpToolPath } from "./mcp-client.ts";
+
+describe("itx MCP client", () => {
+  it("initializes, calls a tool through egress, and does not list tools first", async () => {
+    const methods: string[] = [];
+    const authHeaders: string[] = [];
+    const egress = {
+      fetch: vi.fn(async (request: Request) => {
+        authHeaders.push(request.headers.get("authorization") ?? "");
+
+        const payload = (await request.json()) as {
+          id?: string | number;
+          method?: string;
+          params?: { arguments?: { query?: string } };
+        };
+        methods.push(payload.method ?? "");
+
+        if (payload.method === "initialize") {
+          return Response.json({
+            id: payload.id,
+            jsonrpc: "2.0",
+            result: {
+              capabilities: { tools: {} },
+              protocolVersion: "2025-11-25",
+              serverInfo: { name: "mock-mcp", version: "1.0.0" },
+            },
+          });
+        }
+
+        if (payload.method === "notifications/initialized") {
+          return new Response(null, { status: 202 });
+        }
+
+        if (payload.method === "tools/call") {
+          const result = { answer: `docs:${payload.params?.arguments?.query}` };
+          return Response.json({
+            id: payload.id,
+            jsonrpc: "2.0",
+            result: {
+              content: [{ text: JSON.stringify(result), type: "text" }],
+              structuredContent: result,
+            },
+          });
+        }
+
+        return Response.json({
+          error: { code: -32601, message: "Method not found" },
+          id: payload.id,
+          jsonrpc: "2.0",
+        });
+      }),
+    } as unknown as Fetcher;
+
+    await expect(
+      callMcpToolPath({
+        args: [{ query: "Workers" }],
+        config: {
+          headers: { authorization: 'Bearer getSecret({ path: "/secrets/mcp" })' },
+          url: "https://example.com/mcp",
+        },
+        egress,
+        path: ["search_docs"],
+      }),
+    ).resolves.toEqual({ answer: "docs:Workers" });
+
+    expect(methods).toEqual(["initialize", "notifications/initialized", "tools/call"]);
+    expect(methods).not.toContain("tools/list");
+    expect(authHeaders).toEqual(
+      expect.arrayContaining(['Bearer getSecret({ path: "/secrets/mcp" })']),
+    );
+  });
+
+  it("rejects nested MCP tool paths before connecting", async () => {
+    const egress = { fetch: vi.fn() } as unknown as Fetcher;
+
+    await expect(
+      callMcpToolPath({
+        args: [],
+        config: { url: "https://example.com/mcp" },
+        egress,
+        path: ["search_docs", "nested"],
+      }),
+    ).rejects.toThrow('MCP tools are flat tool names, got "search_docs.nested".');
+
+    expect(egress.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/os/src/domains/itx/mcp-client.ts
+++ b/apps/os/src/domains/itx/mcp-client.ts
@@ -1,0 +1,151 @@
+import {
+  Client,
+  StreamableHTTPClientTransport,
+  type CallToolResult,
+  type FetchLike,
+  type RequestOptions,
+  type StreamableHTTPClientTransportOptions,
+} from "@modelcontextprotocol/client";
+import type { McpClientConnectInput } from "../../types.ts";
+
+const CLIENT_INFO = {
+  name: "itx-mcp-client",
+  version: "1.0.0",
+};
+
+type McpClientSessionInput = {
+  config: McpClientConnectInput;
+  egress: Fetcher;
+};
+
+export async function callMcpToolPath(
+  input: McpClientSessionInput & {
+    args: unknown[];
+    path: string[];
+  },
+) {
+  const toolCall = toolCallFromCapabilityPath(input.path, input.args);
+  const session = await ItxMcpClientSession.connect(input);
+  try {
+    return await session.callTool(toolCall);
+  } finally {
+    await session.close();
+  }
+}
+
+class ItxMcpClientSession {
+  static async connect(input: McpClientSessionInput) {
+    const requestOptions = input.config.timeoutMs ? { timeout: input.config.timeoutMs } : undefined;
+    const client = new Client(CLIENT_INFO);
+
+    try {
+      await client.connect(
+        new StreamableHTTPClientTransport(
+          new URL(input.config.url),
+          transportOptionsFor(input.config, input.egress),
+        ),
+        requestOptions,
+      );
+      return new ItxMcpClientSession(client, requestOptions);
+    } catch (error) {
+      await client.close().catch(() => {});
+      throw error;
+    }
+  }
+
+  private constructor(
+    private readonly client: Client,
+    private readonly requestOptions: RequestOptions | undefined,
+  ) {}
+
+  async callTool(input: McpToolCall) {
+    return mcpResultToItxValue(
+      await this.client.callTool(
+        {
+          arguments: input.arguments,
+          name: input.name,
+        },
+        this.requestOptions,
+      ),
+    );
+  }
+
+  async close() {
+    await this.client.close().catch(() => {});
+  }
+}
+
+type McpToolCall = {
+  arguments: Record<string, unknown>;
+  name: string;
+};
+
+function toolCallFromCapabilityPath(path: string[], args: unknown[]): McpToolCall {
+  const [name, ...extraPath] = path;
+  if (!name) throw new Error("MCP tool calls need a tool name path.");
+  if (extraPath.length > 0) {
+    throw new Error(`MCP tools are flat tool names, got "${path.join(".")}".`);
+  }
+
+  return {
+    arguments: toolArgumentsFromRpcArgs(args),
+    name,
+  };
+}
+
+function toolArgumentsFromRpcArgs(args: unknown[]) {
+  const [firstArg] = args;
+  return firstArg != null && typeof firstArg === "object" && !Array.isArray(firstArg)
+    ? (firstArg as Record<string, unknown>)
+    : {};
+}
+
+function transportOptionsFor(
+  input: McpClientConnectInput,
+  egress: Fetcher,
+): StreamableHTTPClientTransportOptions {
+  return {
+    fetch: statelessEgressFetch(egress),
+    requestInit: input.headers ? { headers: input.headers } : undefined,
+  };
+}
+
+function statelessEgressFetch(egress: Fetcher): FetchLike {
+  return (url, init) => {
+    const request = new Request(url, init);
+    // Streamable HTTP may probe a standalone GET SSE channel. This adapter is
+    // deliberately connect -> call -> close, so answering 405 keeps each
+    // invocation stateless and avoids pinning a stream through project egress.
+    if (request.method === "GET") {
+      return Promise.resolve(new Response(null, { status: 405 }));
+    }
+
+    // Headers may contain getSecret({ path }) placeholders. Egress owns
+    // substitution and origin checks, so this adapter forwards SDK-built
+    // requests unchanged.
+    return egress.fetch(request);
+  };
+}
+
+function mcpResultToItxValue(result: CallToolResult) {
+  if (result.isError) {
+    const message = textContent(result).join("\n") || "MCP tool call failed";
+    throw new Error(message);
+  }
+
+  if (result.structuredContent !== undefined) return result.structuredContent;
+
+  const textParts = textContent(result);
+  if (textParts.length === 0) return result;
+
+  const text = textParts.join("\n");
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function textContent(result: CallToolResult) {
+  return result.content.flatMap((part) => (part.type === "text" ? [part.text] : []));
+}

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -1,6 +1,4 @@
 import { RpcTarget } from "cloudflare:workers";
-import { Client as McpSdkClient } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { AppConfig } from "./config.ts";
 import { createAuthWorkerServiceClient } from "./auth/auth-worker-service.ts";
 import { parseConfig } from "./config.ts";
@@ -56,6 +54,7 @@ import {
   operationBodySchema,
   type OpenApiOperation,
 } from "./domains/itx/openapi-types.ts";
+import { callMcpToolPath } from "./domains/itx/mcp-client.ts";
 import type {
   ProcessorState,
   StreamProcessor,
@@ -1537,13 +1536,7 @@ export class StreamProcessorRpcTarget<Contract extends StreamProcessorContract>
   }
 }
 
-// MCP is common enough to expose as a built-in, but the built-in stays tiny:
-// it is an RpcTarget that gets a project egress Fetcher and otherwise uses the
-// public MCP SDK. A dynamic worker can implement the same shape by calling
-// env.ITX.get().egress.fetch through its single ITX binding.
 type McpClientDeps = { egress: Fetcher };
-
-type McpRequestOptions = { timeout?: number };
 
 class McpClientCollectionRpcTarget extends RpcTarget implements McpClientCollection {
   constructor(readonly props: McpClientDeps) {
@@ -1571,108 +1564,13 @@ class McpClientRpcTarget extends RpcTarget {
   }
 
   async invokeCapability({ args = [], path }: Parameters<SlackCapability["invokeCapability"]>[0]) {
-    const options = this.props.config.timeoutMs
-      ? { timeout: this.props.config.timeoutMs }
-      : undefined;
-    const client = await connectMcp(this.props.config, this.props.egress, options);
-    try {
-      return await executeMcpToolCall({ args, client, options, path });
-    } finally {
-      await client.close().catch(() => {});
-    }
+    return await callMcpToolPath({
+      args,
+      config: this.props.config,
+      egress: this.props.egress,
+      path,
+    });
   }
-}
-
-async function connectMcp(
-  input: McpClientConnectInput,
-  egress: Fetcher,
-  options?: McpRequestOptions,
-): Promise<McpSdkClient> {
-  const transport = new StreamableHTTPClientTransport(new URL(input.url), {
-    fetch: (fetchInput: Request | string | URL, init?: RequestInit) => {
-      const request =
-        fetchInput instanceof Request
-          ? new Request(fetchInput, init)
-          : new Request(String(fetchInput), init);
-      // Streamable HTTP may probe a standalone GET SSE channel. This reference
-      // client is deliberately connect -> call -> close, so answering 405 keeps
-      // every invocation stateless and avoids pinning a stream through egress.
-      if (request.method === "GET") {
-        return Promise.resolve(new Response(null, { status: 405 }));
-      }
-      // Headers may contain getSecret({ path }) placeholders. Egress owns
-      // substitution and origin checks, so the MCP adapter just forwards the
-      // SDK-built Request unchanged.
-      return egress.fetch(request);
-    },
-    requestInit: input.headers ? { headers: input.headers } : undefined,
-  });
-  const client = new McpSdkClient({ name: "iterate-os-mcp-client", version: "1.0.0" });
-  try {
-    await client.connect(transport, options);
-    return client;
-  } catch (error) {
-    await client.close().catch(() => {});
-    throw error;
-  }
-}
-
-async function executeMcpToolCall(input: {
-  args: unknown[];
-  client: McpSdkClient;
-  options?: McpRequestOptions;
-  path: string[];
-}) {
-  const [name, ...extraPath] = input.path;
-  if (!name) throw new Error("MCP tool calls need a tool name path.");
-  if (extraPath.length > 0) {
-    throw new Error(`MCP tools are flat tool names, got "${input.path.join(".")}".`);
-  }
-  const [firstArg] = input.args;
-  const toolArguments =
-    firstArg != null && typeof firstArg === "object" && !Array.isArray(firstArg)
-      ? (firstArg as Record<string, unknown>)
-      : {};
-
-  const result = await input.client.callTool(
-    { name, arguments: toolArguments },
-    undefined,
-    input.options,
-  );
-  // Prefer structured content when a server provides it; otherwise fall back to
-  // the text content convention used by many simple MCP servers.
-  if (result.structuredContent != null) return result.structuredContent;
-
-  if (result.isError) {
-    const message = extractTextContent(result.content).join("\n") || "MCP tool call failed";
-    throw new Error(message);
-  }
-
-  const textParts = extractTextContent(result.content);
-  if (textParts.length > 0) {
-    const text = textParts.join("\n");
-    try {
-      return JSON.parse(text);
-    } catch {
-      return text;
-    }
-  }
-
-  return result;
-}
-
-function extractTextContent(content: unknown) {
-  if (!Array.isArray(content)) return [];
-  return content.flatMap((item) =>
-    item != null &&
-    typeof item === "object" &&
-    "type" in item &&
-    item.type === "text" &&
-    "text" in item &&
-    typeof item.text === "string"
-      ? [item.text]
-      : [],
-  );
 }
 
 // First-party OpenAPI is just an RpcTarget hosted by Project. The only special

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,6 +512,9 @@ importers:
       '@journeyapps/wa-sqlite':
         specifier: ^1.7.0
         version: 1.7.0
+      '@modelcontextprotocol/client':
+        specifier: 2.0.0-beta.1
+        version: 2.0.0-beta.1
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
@@ -3585,6 +3588,10 @@ packages:
 
   '@mjackson/node-fetch-server@0.2.0':
     resolution: {integrity: sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==}
+
+  '@modelcontextprotocol/client@2.0.0-beta.1':
+    resolution: {integrity: sha512-1YbnguKN7OFGA/lmCtgIthyE5d+j7dvu7hJld+f0mKrM0YAV4Q8TG80RBto+qyupxhHjTMEWItHu7cQlAmVtyA==}
+    engines: {node: '>=20'}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -16335,6 +16342,15 @@ snapshots:
       - '@swc/helpers'
 
   '@mjackson/node-fetch-server@0.2.0': {}
+
+  '@modelcontextprotocol/client@2.0.0-beta.1':
+    dependencies:
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      jose: 6.2.2
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `@modelcontextprotocol/client@2.0.0-beta.1` for the outbound itx MCP client path.
- Moves the project MCP capability client out of `rpc-targets.ts` into a dedicated `domains/itx/mcp-client.ts` adapter.
- Keeps the existing stateless connect -> tool call -> close behavior, including egress-owned header/secret substitution and no pre-listing of tools.
- Updates the workspace itx preview example to import the beta client package too.

## Why The Diff Adds ~265 LOC

The LOC count is mostly a readability and coverage trade, not new product surface area:

- `rpc-targets.ts` loses the old inline MCP implementation, including v1 SDK transport setup and result coercion.
- `mcp-client.ts` adds the same outbound behavior back as a small dedicated adapter around the beta client package. That makes the itx capability tree bridge read as one delegation point instead of carrying MCP transport details in the large RPC target file.
- `mcp-client.test.ts` is 88 lines of focused coverage for the contract this path depends on: initialize, call `tools/call`, preserve egress/header handling, and avoid `tools/list`.
- The lockfile accounts for the new beta client package and its transitive metadata.

Net effect: the runtime behavior stays intentionally narrow, while the MCP-specific implementation becomes easier to review and test in isolation.

## Notes

`2.0.0-beta.2` exists, but the repo's pnpm minimum-release-age policy rejects it because it was published too recently. This uses `2.0.0-beta.1`, the newest beta allowed by the normal install policy.

## Validation

- `pnpm --dir apps/os exec vitest run src/domains/itx/mcp-client.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm lint`
- `pnpm --dir apps/os test:unit`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-02T22:36:41.160Z",
      "headSha": "4dd501eec88adff3616eb8b9bedd2a32523ef048",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28625075489",
      "shortSha": "4dd501e",
      "cleanupDurationMs": 12461,
      "deployDurationMs": 26772,
      "testDurationMs": 206
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-02T22:36:27.780Z",
      "headSha": "4dd501eec88adff3616eb8b9bedd2a32523ef048",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28625075489",
      "shortSha": "4dd501e",
      "cleanupDurationMs": 34062,
      "deployDurationMs": 58411,
      "testDurationMs": 343964
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-02T22:36:38.709Z",
      "headSha": "4dd501eec88adff3616eb8b9bedd2a32523ef048",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28625075489",
      "shortSha": "4dd501e",
      "cleanupDurationMs": 10008,
      "deployDurationMs": 54312,
      "testDurationMs": 5348
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-02T22:36:36.343Z",
      "headSha": "4dd501eec88adff3616eb8b9bedd2a32523ef048",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-9.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28625075489",
      "shortSha": "4dd501e",
      "cleanupDurationMs": 7641,
      "deployDurationMs": 38800,
      "testDurationMs": 6583
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `4dd501e` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 26.8s | 206ms | 12.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28625075489) | 2026-07-02T22:36:41.160Z | Preview app released. |
| OS | released | `4dd501e` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 58.4s | 344.0s | 34.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28625075489) | 2026-07-02T22:36:27.780Z | Preview app released. |
| Semaphore | released | `4dd501e` | [https://semaphore.iterate-preview-9.com](https://semaphore.iterate-preview-9.com) | 54.3s | 5.3s | 10.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28625075489) | 2026-07-02T22:36:38.709Z | Preview app released. |
| Streams Example App | released | `4dd501e` | [https://streams-example-app-preview-9.iterate-dev-preview.workers.dev](https://streams-example-app-preview-9.iterate-dev-preview.workers.dev) | 38.8s | 6.6s | 7.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28625075489) | 2026-07-02T22:36:36.343Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches project MCP egress and tool-call result handling on a beta SDK; behavior is mostly preserved but dependency and error-order semantics changed slightly.
> 
> **Overview**
> Migrates the outbound **itx** MCP capability path from `@modelcontextprotocol/sdk` to **`@modelcontextprotocol/client@2.0.0-beta.1`**, and pulls MCP wiring out of `rpc-targets.ts` into **`domains/itx/mcp-client.ts`**.
> 
> `McpClientRpcTarget.invokeCapability` now delegates to **`callMcpToolPath`**, which keeps the same narrow runtime contract: **connect → single `tools/call` → close**, route HTTP through **project egress** (including `getSecret` header placeholders), answer **405** on GET so streamable HTTP stays stateless, and **reject nested tool paths** without opening a session. Result coercion now treats **`isError` before `structuredContent`**.
> 
> Adds **`mcp-client.test.ts`** for initialize/call flow, egress auth forwarding, no `tools/list`, and flat tool names. The workspace itx preview example imports **`Client` and `StreamableHTTPClientTransport`** from the beta client package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dd501eec88adff3616eb8b9bedd2a32523ef048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->