### PR TITLE
Ingress e2e: derive project hosts from the deployment config

### DIFF
--- a/apps/os/e2e/vitest/project-ingress.e2e.test.ts
+++ b/apps/os/e2e/vitest/project-ingress.e2e.test.ts
@@ -50,10 +50,21 @@ test("routes seeded apps by host: stateless hello and stateful counter", async (
       headers.set("x-forwarded-host", `${appHostPrefix}.localhost`);
       return fetch(base, { ...init, headers });
     }
-    // os.iterate-preview-N.com serves projects at *.iterate-preview-N.app —
-    // same derivation the preview smoke uses for the MCP host.
+    // The deployment's project hosts live on APP_CONFIG_PROJECT_HOSTNAME_BASES
+    // (e.g. iterate.app for prd, iterate-preview-N.app for previews) — fall
+    // back to the preview-derivation only when the env var is absent.
+    const configuredBase = (() => {
+      const raw = process.env.APP_CONFIG_PROJECT_HOSTNAME_BASES?.trim();
+      if (!raw) return undefined;
+      try {
+        const parsed: unknown = JSON.parse(raw);
+        return Array.isArray(parsed) ? String(parsed[0]) : String(parsed);
+      } catch {
+        return raw.split(",")[0]?.trim();
+      }
+    })();
     const previewMatch = /^os\.(iterate-preview-\d+)\.com$/.exec(base.hostname);
-    const projectBase = previewMatch ? `${previewMatch[1]}.app` : base.hostname;
+    const projectBase = configuredBase || (previewMatch ? `${previewMatch[1]}.app` : base.hostname);
     return fetch(`${base.protocol}//${appHostPrefix}.${projectBase}${path}`, init);
   };
 


### PR DESCRIPTION
Test-only. `fetchApp` built `hello--<slug>.os.iterate.com` on prd because it only knew the preview host pattern; the product was fine (`iterate.app` hosts answer 200). It now reads `APP_CONFIG_PROJECT_HOSTNAME_BASES` (JSON-array env) with the preview derivation as fallback. Verified 2/2 against prd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect e2e test URL construction; no production routing or config behavior is modified.
> 
> **Overview**
> **Test-only fix** for deployed ingress e2e: `fetchApp` in `project-ingress.e2e.test.ts` now builds app hostnames using the deployment’s **`APP_CONFIG_PROJECT_HOSTNAME_BASES`** (first entry from JSON array, or comma-separated fallback) instead of assuming preview-style `*.iterate-preview-N.app` derivation from the OS hostname.
> 
> On **prd**, requests were incorrectly aimed at hosts like `hello--<slug>.os.iterate.com` while real project ingress lives on **`iterate.app`**; local behavior is unchanged (`x-forwarded-host` on `*.localhost`). When the env var is missing, the previous preview hostname logic still applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 217ee07825284f5ccf26df6c9beae8d59ccfa1b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->