### PR TITLE
Export readBearerToken: fix red main typecheck and blocked OS deploys

### DIFF
--- a/apps/os/src/auth/admin.ts
+++ b/apps/os/src/auth/admin.ts
@@ -1,7 +1,7 @@
 import type { AppConfig } from "~/config.ts";
 import { adminPrincipal, type AdminPrincipal } from "~/auth/principal.ts";
 
-function readBearerToken(headerValue: string | null): string | null {
+export function readBearerToken(headerValue: string | null): string | null {
   if (!headerValue) return null;
   const match = /^bearer\s+(.+)$/i.exec(headerValue);
   const token = match?.[1]?.trim() ?? "";


### PR DESCRIPTION
Main's Lint and Typecheck (and consequently Deploy OS) have been red since #1596 landed: it imports `readBearerToken` from `~/auth/admin.ts`, but #1588 had introduced that function as a local, non-exported helper. The two PRs merged around each other without a combined CI run — the standard conflicting-PR race (`iterate_pr_ci_race_gotchas`).

One-line fix: export the helper. Verified `apps/os` `tsc --noEmit` green on this branch.

Every open PR currently inherits this failure through the merge commit, so this should land ASAP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single export keyword change with no logic changes; restores CI only.
> 
> **Overview**
> **Exports** `readBearerToken` from `apps/os/src/auth/admin.ts` so `inbound-mcp-server/mcp-handler.ts` can import it for OAuth bearer parsing in `resolveOAuthAccessToken`.
> 
> No behavior change—the helper was already used inside `authenticateAdminBearer`; this only fixes the missing export that broke `apps/os` typecheck and blocked OS deploys after conflicting merges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcf47b7fc97b1c65ed0b0f52a4b641c80af2c601. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->