### PR TITLE
Fix cold-slot create latency: heal zombie worker routes, batch saga appends, restore test budgets

### DIFF
--- a/apps/auth/src/lib/server.ts
+++ b/apps/auth/src/lib/server.ts
@@ -546,7 +546,17 @@ export function createAuthHandler(config: IterateAuthConfig, infra: OAuthInfra) 
   });
 
   app.get("/callback", async (c) => {
-    const as = await getAuthorizationServer();
+    // Structured per-step timing for cold-deploy diagnosis (see
+    // tasks/os-cold-create-latency.md): one greppable line per remote hop.
+    const timeStep = async <T>(step: string, fn: () => Promise<T>): Promise<T> => {
+      const start = Date.now();
+      try {
+        return await fn();
+      } finally {
+        console.log("[callback-timing]", JSON.stringify({ step, ms: Date.now() - start }));
+      }
+    };
+    const as = await timeStep("discovery", () => getAuthorizationServer());
     const requestURL = new URL(c.req.url);
 
     let oauthState: OAuthState;
@@ -570,21 +580,25 @@ export function createAuthHandler(config: IterateAuthConfig, infra: OAuthInfra) 
 
     let tokenResponse: oauth.TokenEndpointResponse;
     try {
-      const response = await oauth.authorizationCodeGrantRequest(
-        as,
-        oauthClient,
-        clientAuth,
-        validatedParams,
-        config.redirectURI,
-        oauthState.verifier,
-        {
-          ...httpOptions(),
-          additionalParameters: { resource: infra.resource() },
-        },
+      const response = await timeStep("token-exchange", () =>
+        oauth.authorizationCodeGrantRequest(
+          as,
+          oauthClient,
+          clientAuth,
+          validatedParams,
+          config.redirectURI,
+          oauthState.verifier,
+          {
+            ...httpOptions(),
+            additionalParameters: { resource: infra.resource() },
+          },
+        ),
       );
-      tokenResponse = await oauth.processAuthorizationCodeResponse(as, oauthClient, response, {
-        expectedNonce: oauthState.nonce,
-      });
+      tokenResponse = await timeStep("token-exchange-process", () =>
+        oauth.processAuthorizationCodeResponse(as, oauthClient, response, {
+          expectedNonce: oauthState.nonce,
+        }),
+      );
     } catch (error) {
       console.error("OAuth callback error:", error);
       const message = error instanceof Error ? error.message : String(error);

--- a/apps/os/e2e/vitest.config.ts
+++ b/apps/os/e2e/vitest.config.ts
@@ -36,10 +36,11 @@ export default defineConfig({
     // at once is what pushes cold creates past the (deliberately tight)
     // saga timeout. See tasks/os-cold-create-latency.md.
     maxWorkers: 4,
-    // Generous: e2e runs against live deployments, concurrently with the
-    // Playwright specs in preview CI — cold slots under combined load need
-    // headroom, and slow-but-passing beats flaky.
-    hookTimeout: 240_000,
+    // e2e runs against live deployments, concurrently with the Playwright
+    // specs in preview CI. Cold-slot creates measure 3-5s per saga on a fresh
+    // stage under 4-way suite load (tasks/os-cold-create-latency.md); 120s is
+    // ample headroom without letting a wedged saga eat the whole job.
+    hookTimeout: 120_000,
     include: ["./e2e/vitest/**/*.test.ts"],
     passWithNoTests: true,
     setupFiles: ["./e2e/vitest/setup.ts"],
@@ -49,7 +50,7 @@ export default defineConfig({
       [E2E_RUN_SLUG_KEY]: vitestRunSlug,
       [E2E_REPO_ROOT_KEY]: repoRoot,
     },
-    testTimeout: 240_000,
+    testTimeout: 120_000,
     onConsoleLog(log, type, entity) {
       if (entity?.type !== "test") return;
 

--- a/apps/os/src/domains/projects/project-processor-implementation.ts
+++ b/apps/os/src/domains/projects/project-processor-implementation.ts
@@ -1,4 +1,5 @@
 import { StreamProcessor } from "../streams/stream-processor.ts";
+import { timedStep } from "../../lib/step-timing.ts";
 import { buildDurableObjectProcessorSubscriptionConfiguredEvent } from "../streams/utils.ts";
 import { PROJECT_REPO_PATH } from "../repos/utils.ts";
 import { PROJECT_REPO_ONBOARDING_MD } from "../repos/project-repo-template.ts";
@@ -113,38 +114,51 @@ export class ProjectProcessor extends StreamProcessor<
           );
         }
         blockProcessorWhile(async () => {
-          await append(
-            buildDurableObjectProcessorSubscriptionConfiguredEvent({
-              durableObjectName: DurableObjectNameCodec.stringify({
-                projectId: this.deps.itx.projectId,
-                path: "/",
-              }),
-              processorSlug: ItxProcessorContract.slug,
-              subscriberType: "itx",
-            }),
-          );
-          // Arm the Slack webhook router on `/integrations/slack` from birth,
-          // so a claimed workspace's first webhook routes even if the connect
-          // flow's own belt-and-braces subscription append raced.
-          await this.deps.itx.streams.get(SLACK_INTEGRATION_STREAM_PATH).append(
-            buildDurableObjectProcessorSubscriptionConfiguredEvent({
-              durableObjectName: DurableObjectNameCodec.stringify({
-                projectId: this.deps.itx.projectId,
-                path: SLACK_INTEGRATION_STREAM_PATH,
-              }),
-              idempotencyKey: `slack-router-subscription:${this.deps.itx.projectId}`,
-              processorSlug: SlackProcessorContract.slug,
-              subscriberType: "project",
-            }),
-          );
-          await append({
-            type: "events.iterate.com/repo/create-requested",
-            idempotencyKey: `repo-create-requested:${this.deps.itx.projectId}:${PROJECT_REPO_PATH}`,
-            payload: {
-              path: PROJECT_REPO_PATH,
-              projectId: this.deps.itx.projectId,
-            },
-          });
+          const timing = { projectId: this.deps.itx.projectId };
+          // One atomic root append (itx subscription + repo kickoff, original
+          // relative order preserved) in parallel with the independent Slack
+          // stream append. The previous three sequential awaits were the
+          // slowest lane of the create saga (~1.2-2.6s measured on preview-7;
+          // tasks/os-cold-create-latency.md) — batching cuts it to one
+          // round-trip apiece.
+          await Promise.all([
+            timedStep("create-timing", timing, "root-saga-append", () =>
+              append(
+                buildDurableObjectProcessorSubscriptionConfiguredEvent({
+                  durableObjectName: DurableObjectNameCodec.stringify({
+                    projectId: this.deps.itx.projectId,
+                    path: "/",
+                  }),
+                  processorSlug: ItxProcessorContract.slug,
+                  subscriberType: "itx",
+                }),
+                {
+                  type: "events.iterate.com/repo/create-requested",
+                  idempotencyKey: `repo-create-requested:${this.deps.itx.projectId}:${PROJECT_REPO_PATH}`,
+                  payload: {
+                    path: PROJECT_REPO_PATH,
+                    projectId: this.deps.itx.projectId,
+                  },
+                },
+              ),
+            ),
+            // Arm the Slack webhook router on `/integrations/slack` from birth,
+            // so a claimed workspace's first webhook routes even if the connect
+            // flow's own belt-and-braces subscription append raced.
+            timedStep("create-timing", timing, "slack-router-append", () =>
+              this.deps.itx.streams.get(SLACK_INTEGRATION_STREAM_PATH).append(
+                buildDurableObjectProcessorSubscriptionConfiguredEvent({
+                  durableObjectName: DurableObjectNameCodec.stringify({
+                    projectId: this.deps.itx.projectId,
+                    path: SLACK_INTEGRATION_STREAM_PATH,
+                  }),
+                  idempotencyKey: `slack-router-subscription:${this.deps.itx.projectId}`,
+                  processorSlug: SlackProcessorContract.slug,
+                  subscriberType: "project",
+                }),
+              ),
+            ),
+          ]);
         });
         break;
       }
@@ -195,32 +209,39 @@ export class ProjectProcessor extends StreamProcessor<
           return;
         }
         blockProcessorWhile(async () => {
-          await waitForDefaultProjectWorker(this.deps.itx);
-          await append({
-            type: "events.iterate.com/project/created",
-            idempotencyKey: `project-created:${this.deps.itx.projectId}`,
-            payload: state.createRequest!,
-          });
+          const timing = { projectId: this.deps.itx.projectId };
+          await timedStep("create-timing", timing, "worker-probe", () =>
+            waitForDefaultProjectWorker(this.deps.itx),
+          );
+          await timedStep("create-timing", timing, "project-created-append", () =>
+            append({
+              type: "events.iterate.com/project/created",
+              idempotencyKey: `project-created:${this.deps.itx.projectId}`,
+              payload: state.createRequest!,
+            }),
+          );
           // Seed the onboarding agent: full birth certificate (the generic
           // child-stream-created lane later double-appends with the same
           // idempotency keys and dedupes) plus the kickoff input that makes the
           // agent greet the user without waiting for a first message.
-          await this.deps.itx.streams.get(ONBOARDING_AGENT_PATH).append(
-            ...agentBirthCertificateEvents({
-              childPath: ONBOARDING_AGENT_PATH,
-              llmProvider: this.deps.defaultLlmProvider,
-              projectId: this.deps.itx.projectId,
-              systemPrompt: ONBOARDING_AGENT_SYSTEM_PROMPT,
-            }),
-            {
-              type: "events.iterate.com/agent/input-added",
-              idempotencyKey: `project-onboarding-start:${this.deps.itx.projectId}`,
-              payload: {
-                content:
-                  "Start onboarding now. The project owner just created this project and is looking at the chat.",
-                llmRequestPolicy: { behaviour: "after-current-request" as const },
+          await timedStep("create-timing", timing, "onboarding-agent-birth", () =>
+            this.deps.itx.streams.get(ONBOARDING_AGENT_PATH).append(
+              ...agentBirthCertificateEvents({
+                childPath: ONBOARDING_AGENT_PATH,
+                llmProvider: this.deps.defaultLlmProvider,
+                projectId: this.deps.itx.projectId,
+                systemPrompt: ONBOARDING_AGENT_SYSTEM_PROMPT,
+              }),
+              {
+                type: "events.iterate.com/agent/input-added",
+                idempotencyKey: `project-onboarding-start:${this.deps.itx.projectId}`,
+                payload: {
+                  content:
+                    "Start onboarding now. The project owner just created this project and is looking at the chat.",
+                  llmRequestPolicy: { behaviour: "after-current-request" as const },
+                },
               },
-            },
+            ),
           );
         });
         return;

--- a/apps/os/src/domains/repos/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/repo-durable-object.ts
@@ -9,6 +9,7 @@ import { StreamProcessorRpcTarget } from "../../rpc-targets.ts";
 import { StreamRpcTarget } from "../../rpc-targets.ts";
 import type { Env } from "../../env.ts";
 import { trustedInternalAuthContext } from "../../auth.ts";
+import { timedStep } from "../../lib/step-timing.ts";
 import { stableSha256 } from "../workers/utils.ts";
 import type { ResolvedWorkerSource } from "../workers/worker-loader.ts";
 import { DurableObjectNameCodec } from "../durable-object-names.ts";
@@ -235,18 +236,25 @@ export class RepoDurableObject extends DurableObject<Env> {
   }
 
   private async createArtifactRepo(_input: { path: string; projectId: string | null }) {
+    const timing = { projectId: this.#name.projectId, path: this.#name.path };
     const artifactName = this.artifactName();
-    await this.getOrCreateArtifact(artifactName);
+    await timedStep("create-timing", timing, "artifact-get-or-create", () =>
+      this.getOrCreateArtifact(artifactName),
+    );
     const defaultBranch = REPO_DEFAULT_BRANCH;
     const remote = this.artifactRemote(artifactName);
-    const token = await artifactToken(this.requireArtifacts(), artifactName);
+    const token = await timedStep("create-timing", timing, "artifact-token", () =>
+      artifactToken(this.requireArtifacts(), artifactName),
+    );
 
-    await seedArtifactRepo({
-      branch: defaultBranch,
-      files: PROJECT_REPO_INITIAL_FILES,
-      remote,
-      token,
-    });
+    await timedStep("create-timing", timing, "artifact-seed", () =>
+      seedArtifactRepo({
+        branch: defaultBranch,
+        files: PROJECT_REPO_INITIAL_FILES,
+        remote,
+        token,
+      }),
+    );
 
     return {
       artifactName,

--- a/apps/os/src/lib/step-timing.ts
+++ b/apps/os/src/lib/step-timing.ts
@@ -1,0 +1,25 @@
+/**
+ * Log a single structured timing line for one awaited saga step.
+ *
+ * Emits `[<label>] {"...fields, step, ms}` on completion (success or failure),
+ * so `wrangler tail --format json | grep create-timing` reconstructs per-step
+ * saga cost on any deployment. Deliberately console.log-only: creates are rare
+ * and the lines are the cheapest instrument that survives production.
+ */
+export async function timedStep<T>(
+  label: string,
+  fields: Record<string, string | null | undefined>,
+  step: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const start = Date.now();
+  let ok = true;
+  try {
+    return await fn();
+  } catch (error) {
+    ok = false;
+    throw error;
+  } finally {
+    console.log(`[${label}]`, JSON.stringify({ ...fields, step, ms: Date.now() - start, ok }));
+  }
+}

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -17,6 +17,7 @@ import {
   readProjectById,
 } from "./project-directory.ts";
 import { deploymentStatusesFromProbes } from "./project-deployment-status.ts";
+import { timedStep } from "./lib/step-timing.ts";
 import type { Env } from "./env.ts";
 import { DurableObjectNameCodec, normalizePath } from "./domains/durable-object-names.ts";
 import { normalizeAgentPath } from "./domains/agents/utils.ts";
@@ -221,28 +222,33 @@ async function requestRepoCreate(input: {
     path,
     projectId: input.projectId,
   });
-  const [, createRequested] = await stream.append(
-    buildDurableObjectProcessorSubscriptionConfiguredEvent({
-      durableObjectName: streamDurableObjectName({ projectId: input.projectId, path }),
-      processorSlug: RepoProcessorContract.slug,
-      subscriberType: "repo",
-    }),
-    {
-      type: "events.iterate.com/repo/create-requested",
-      idempotencyKey: `repo-create-requested:${input.projectId}:${path}`,
-      payload: { projectId: input.projectId, path },
-    },
+  const timing = { projectId: input.projectId, path };
+  const [, createRequested] = await timedStep("create-timing", timing, "repo-append", () =>
+    stream.append(
+      buildDurableObjectProcessorSubscriptionConfiguredEvent({
+        durableObjectName: streamDurableObjectName({ projectId: input.projectId, path }),
+        processorSlug: RepoProcessorContract.slug,
+        subscriberType: "repo",
+      }),
+      {
+        type: "events.iterate.com/repo/create-requested",
+        idempotencyKey: `repo-create-requested:${input.projectId}:${path}`,
+        payload: { projectId: input.projectId, path },
+      },
+    ),
   );
 
-  await stream.waitForEvent({
-    afterOffset: createRequested.offset - 1,
-    eventTypes: ["events.iterate.com/repo/created"],
-    predicate: (event) =>
-      event.payload?.projectId === input.projectId && event.payload?.path === path,
-    // Tight on purpose: creates should be fast (see tasks/os-cold-create-latency.md
-    // for the cold-slot outliers). Preview CI warms slots before the suites.
-    timeoutMs: 60_000,
-  });
+  await timedStep("create-timing", timing, "wait-repo-created", () =>
+    stream.waitForEvent({
+      afterOffset: createRequested.offset - 1,
+      eventTypes: ["events.iterate.com/repo/created"],
+      predicate: (event) =>
+        event.payload?.projectId === input.projectId && event.payload?.path === path,
+      // Tight on purpose: creates should be fast (see tasks/os-cold-create-latency.md
+      // for the cold-slot outliers). Preview CI warms slots before the suites.
+      timeoutMs: 60_000,
+    }),
+  );
 
   return new RepoRpcTarget({ auth: input.auth, path, projectId: input.projectId });
 }
@@ -791,7 +797,10 @@ export class ProjectCollectionRpcTarget extends RpcTarget implements ProjectColl
   }
 
   async create(args: Parameters<ProjectCollection["create"]>[0]) {
-    const registered = await this.#registerProject(args);
+    const registered = await timedStep("create-timing", { slug: args.slug }, "auth-register", () =>
+      this.#registerProject(args),
+    );
+    const timing = { projectId: registered.projectId };
     args.projectId = registered.projectId;
     // The auth worker may normalize the slug (slugify); adopt its canonical
     // form so stream events agree with the directory and ingress hostnames.
@@ -802,47 +811,61 @@ export class ProjectCollectionRpcTarget extends RpcTarget implements ProjectColl
     widenProjectAccess(this.props.auth, registered.projectId);
     // Prime the slug->id directory cache so the post-create navigation (and
     // the first project-host request) never miss into the auth worker.
-    await primeProjectDirectory(env.PROJECT_DIRECTORY, {
-      id: registered.projectId,
-      slug: registered.slug,
-      organizationId: registered.organizationId,
-      name: registered.slug,
-    });
+    await timedStep("create-timing", timing, "prime-directory", () =>
+      primeProjectDirectory(env.PROJECT_DIRECTORY, {
+        id: registered.projectId,
+        slug: registered.slug,
+        organizationId: registered.organizationId,
+        name: registered.slug,
+      }),
+    );
 
     const stream = rootStream({
       auth: this.props.auth,
       projectId: args.projectId,
     });
 
-    const [, , createRequested] = await stream.append(
-      buildDurableObjectProcessorSubscriptionConfiguredEvent({
-        durableObjectName: streamDurableObjectName({ projectId: args.projectId, path: "/" }),
-        processorSlug: ProjectProcessorContract.slug,
-        subscriberType: "project",
-      }),
-      buildDurableObjectProcessorSubscriptionConfiguredEvent({
-        durableObjectName: streamDurableObjectName({
-          projectId: args.projectId,
-          path: PROJECT_REPO_PATH,
+    const appendRootEvents = () =>
+      stream.append(
+        buildDurableObjectProcessorSubscriptionConfiguredEvent({
+          durableObjectName: streamDurableObjectName({
+            projectId: registered.projectId,
+            path: "/",
+          }),
+          processorSlug: ProjectProcessorContract.slug,
+          subscriberType: "project",
         }),
-        processorSlug: RepoProcessorContract.slug,
-        subscriberType: "repo",
-      }),
-      {
-        type: "events.iterate.com/project/create-requested",
-        idempotencyKey: `project-create-requested:${args.projectId}`,
-        payload: { projectId: args.projectId, slug: args.slug },
-      },
+        buildDurableObjectProcessorSubscriptionConfiguredEvent({
+          durableObjectName: streamDurableObjectName({
+            projectId: registered.projectId,
+            path: PROJECT_REPO_PATH,
+          }),
+          processorSlug: RepoProcessorContract.slug,
+          subscriberType: "repo",
+        }),
+        {
+          type: "events.iterate.com/project/create-requested",
+          idempotencyKey: `project-create-requested:${registered.projectId}`,
+          payload: { projectId: registered.projectId, slug: registered.slug },
+        },
+      );
+    const [, , createRequested] = await timedStep(
+      "create-timing",
+      timing,
+      "root-append",
+      appendRootEvents,
     );
-    await stream.waitForEvent({
-      afterOffset: createRequested.offset - 1,
-      eventTypes: ["events.iterate.com/project/created"],
-      predicate: (event) => event.payload?.projectId === args.projectId,
-      // Tight on purpose: the saga should complete in seconds (see
-      // tasks/os-cold-create-latency.md for the cold-slot outliers that must
-      // be fixed, not waited out). Preview CI warms slots before the suites.
-      timeoutMs: 60_000,
-    });
+    await timedStep("create-timing", timing, "wait-project-created", () =>
+      stream.waitForEvent({
+        afterOffset: createRequested.offset - 1,
+        eventTypes: ["events.iterate.com/project/created"],
+        predicate: (event) => event.payload?.projectId === args.projectId,
+        // Tight on purpose: the saga should complete in seconds (see
+        // tasks/os-cold-create-latency.md for the cold-slot outliers that must
+        // be fixed, not waited out). Preview CI warms slots before the suites.
+        timeoutMs: 60_000,
+      }),
+    );
 
     return new ItxRpcTarget({
       auth: this.props.auth,

--- a/packages/shared/src/alchemy/iterate-app.ts
+++ b/packages/shared/src/alchemy/iterate-app.ts
@@ -205,26 +205,24 @@ export async function IterateRoutes(
     });
 
     const routeZoneIds = new Map<string, string>();
-    await Promise.all(
-      routeHosts.map(async (hostname) => {
-        const { zoneId } = findActiveZoneForHostname({
-          accountId: cloudflareApi.accountId,
-          hostname,
-          zones,
-        });
-        routeZoneIds.set(hostname, zoneId);
+    for (const hostname of routeHosts) {
+      const { zoneId } = findActiveZoneForHostname({
+        accountId: cloudflareApi.accountId,
+        hostname,
+        zones,
+      });
+      routeZoneIds.set(hostname, zoneId);
+    }
 
-        await retryCloudflareWorkerRouteCreation(() =>
-          Route(routeResourceIdForHostname(hostname), {
-            pattern: `${hostname}/*`,
-            script: worker.name,
-            adopt: true,
-            zoneId,
-          }),
-        );
-      }),
-    );
-
+    // DNS records BEFORE routes. A Worker route only fires for hostnames with
+    // a proxied DNS record on the zone. Creating the route while the record
+    // does not exist yet has produced zombie routes on fresh preview slots:
+    // the route is visible in the API but never fires at the edge, so every
+    // request falls through to the (originless) placeholder record and dies
+    // with a 522 after ~20s — the "fresh slot" 522/parked-browser failure
+    // family (tasks/os-cold-create-latency.md). Deleting and recreating the
+    // identical route heals it instantly, which is what the verification pass
+    // below automates for any zombie that slips through regardless of order.
     const dnsRouteHosts = routeHosts.filter(shouldCreateDnsRecordForRouteHostname);
     await Promise.all(
       dnsRouteHosts.flatMap((hostname) =>
@@ -246,6 +244,143 @@ export async function IterateRoutes(
           });
         }),
       ),
+    );
+
+    await Promise.all(
+      routeHosts.map((hostname) =>
+        retryCloudflareWorkerRouteCreation(() =>
+          Route(routeResourceIdForHostname(hostname), {
+            pattern: `${hostname}/*`,
+            script: worker.name,
+            adopt: true,
+            zoneId: routeZoneIds.get(hostname)!,
+          }),
+        ),
+      ),
+    );
+
+    // Verify each exact hostname actually fires at the edge and heal zombies.
+    // Wildcard patterns are skipped: they have no single probeable hostname.
+    await Promise.all(
+      routeHosts
+        .filter((hostname) => !hostname.startsWith("*"))
+        .map((hostname) =>
+          verifyWorkerRouteFires({
+            cloudflareApi,
+            hostname,
+            script: worker.name,
+            zoneId: routeZoneIds.get(hostname)!,
+          }),
+        ),
+    );
+  }
+}
+
+/**
+ * HTTP statuses the Cloudflare edge returns when a request to a proxied
+ * hostname falls through to the origin instead of a Worker route. Our route
+ * hostnames sit on originless placeholder records (192.0.2.1 / 100::), so any
+ * of these means the route exists in the API but is NOT firing at the edge.
+ */
+const ORIGIN_FALLTHROUGH_STATUSES = new Set([521, 522, 523, 530]);
+
+/**
+ * Probe a route hostname and, when the edge answers with an origin-error
+ * status (route not firing — the zombie-route failure mode), heal it by
+ * deleting and recreating the identical route via the raw API. Recreation has
+ * been observed to activate a zombie route instantly; `Route(adopt: true)`
+ * re-adopts the pattern on the next deploy, so the id drift is harmless.
+ */
+async function verifyWorkerRouteFires(input: {
+  cloudflareApi: Awaited<ReturnType<typeof createCloudflareApi>>;
+  hostname: string;
+  script: string;
+  zoneId: string;
+}) {
+  const maxAttempts = 3;
+  let healed = false;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    let status = await probeEdgeStatus(input.hostname);
+    // Any worker/app response (including app-level 4xx/5xx) proves the route
+    // fires. A network-level probe failure is inconclusive (local DNS lag,
+    // egress hiccup) — do not fail the deploy over it.
+    if (status === null || !ORIGIN_FALLTHROUGH_STATUSES.has(status)) {
+      if (!healed) return;
+      // A heal propagates across the edge over a few seconds; one good probe
+      // can race it. Require a second good probe so the deploy only reports
+      // success once the hostname is consistently served.
+      await sleep(5_000);
+      status = await probeEdgeStatus(input.hostname);
+      if (status === null || !ORIGIN_FALLTHROUGH_STATUSES.has(status)) return;
+      // Fell back to origin again — keep healing.
+    }
+
+    console.warn(
+      `[iterate-routes] ${input.hostname} answered ${status} — route exists but is not firing at the edge; recreating it (attempt ${attempt}/${maxAttempts})`,
+    );
+    await recreateWorkerRoute(input);
+    healed = true;
+    await sleep(2_000);
+  }
+
+  const status = await probeEdgeStatus(input.hostname);
+  if (status !== null && ORIGIN_FALLTHROUGH_STATUSES.has(status)) {
+    throw new Error(
+      `Worker route for ${input.hostname} never became active: the edge keeps answering ${status} (origin fallthrough) after ${maxAttempts} recreations.`,
+    );
+  }
+}
+
+/** GET the hostname root; returns the HTTP status, or null when the probe itself failed. */
+async function probeEdgeStatus(hostname: string): Promise<number | null> {
+  try {
+    const response = await fetch(`https://${hostname}/`, {
+      redirect: "manual",
+      // A non-firing route 522s after ~20s of origin connect timeout; give the
+      // probe enough headroom to observe that instead of aborting into null.
+      signal: AbortSignal.timeout(30_000),
+    });
+    await response.body?.cancel();
+    return response.status;
+  } catch {
+    return null;
+  }
+}
+
+async function recreateWorkerRoute(input: {
+  cloudflareApi: Awaited<ReturnType<typeof createCloudflareApi>>;
+  hostname: string;
+  script: string;
+  zoneId: string;
+}) {
+  const pattern = `${input.hostname}/*`;
+  const listResponse = await input.cloudflareApi.get(`/zones/${input.zoneId}/workers/routes`);
+  if (!listResponse.ok) {
+    throw new Error(
+      `Failed to list worker routes while healing ${pattern}: ${listResponse.status} ${await listResponse.text()}`,
+    );
+  }
+  const listResult = (await listResponse.json()) as {
+    result?: Array<{ id: string; pattern?: string }>;
+  };
+  const existing = (listResult.result ?? []).find((route) => route.pattern === pattern);
+  if (existing) {
+    const deleteResponse = await input.cloudflareApi.delete(
+      `/zones/${input.zoneId}/workers/routes/${existing.id}`,
+    );
+    if (!deleteResponse.ok) {
+      throw new Error(
+        `Failed to delete zombie route ${pattern}: ${deleteResponse.status} ${await deleteResponse.text()}`,
+      );
+    }
+  }
+  const createResponse = await input.cloudflareApi.post(`/zones/${input.zoneId}/workers/routes`, {
+    pattern,
+    script: input.script,
+  });
+  if (!createResponse.ok) {
+    throw new Error(
+      `Failed to recreate route ${pattern}: ${createResponse.status} ${await createResponse.text()}`,
     );
   }
 }

--- a/specs/create-project.spec.ts
+++ b/specs/create-project.spec.ts
@@ -22,9 +22,10 @@ test("a new user can create a project through the UI form", async ({ page }) => 
   // the agent page's loading state both render two spinner-matching elements
   // at once, tripping its strict-mode isVisible.
   await spinnerWaiter.settings.run({ disabled: true }, async () => {
-    // 90s: the auth OAuth callback takes 30-90s on cold slots (see
-    // tasks/os-cold-create-latency.md) — the page cannot render before it.
-    await page.getByRole("button", { name: "Create new project" }).click({ timeout: 90_000 });
+    // The cold-slot 30-90s OAuth-callback parks traced back to zombie worker
+    // routes (deploy now verifies + heals them; tasks/os-cold-create-latency.md).
+    // On a healthy slot this renders in ~1s.
+    await page.getByRole("button", { name: "Create new project" }).click({ timeout: 30_000 });
 
     await page.getByLabel("Slug").fill(slug, { timeout: 15_000 });
     // Create walks auth + the project durable object bootstrap, then lands in

--- a/specs/signup.spec.ts
+++ b/specs/signup.spec.ts
@@ -20,11 +20,9 @@ test("can sign up with an email one-time passcode", async ({ page }) => {
   // Back on OS, signed in: a fresh user has no projects yet. The /projects
   // pending state renders its data-spinner section twice during the redirect,
   // which trips spinner-waiter's strict-mode isVisible — sit it out. The
-  // OAuth callback straggles on cold slots, so give this test extra budget
-  // (the waitFor must stay under the test timeout or Playwright kills the
-  // test before the locator resolves).
-  test.setTimeout(180_000);
+  // cold-slot OAuth-callback straggle traced back to zombie worker routes,
+  // which the deploy now verifies + heals (tasks/os-cold-create-latency.md).
   await spinnerWaiter.settings.run({ disabled: true }, () =>
-    page.getByText("No projects yet").waitFor({ timeout: 90_000 }),
+    page.getByText("No projects yet").waitFor({ timeout: 30_000 }),
   );
 });

--- a/tasks/os-cold-create-latency.md
+++ b/tasks/os-cold-create-latency.md
@@ -1,5 +1,5 @@
 ---
-state: todo
+state: done
 priority: high
 size: medium
 tags: [os, itx, performance, projects]
@@ -15,25 +15,42 @@ runs on 2026-07-02: rotating "Timed out waiting for stream event … saw 0
 events" failures across admin-project / stream-security / agent-tools, each
 a create stuck in the saga).
 
-The saga timeout is deliberately tight (60s in rpc-targets.ts) so this
-surfaces as failure signal instead of being waited out; preview CI warms
-slots with one sequential onboarding-smoke create before the suites.
+## Findings (2026-07-02, measured on preview-7)
 
-Suspects to measure (per-step timing events on the create saga would settle
-this quickly):
+Ruled out first: worker bundle bloat. Deployed engine workers are 1.3–5.5MB
+each (api 4.0MB, app 5.0MB, repo 5.5MB) — nowhere near the historical 89MB
+sourcemap incident.
 
-- CF Artifacts repo creation + seed commit on first touch
-- sequential cold DO chain (project → stream → repo → worker → agent), each
-  paying isolate spin-up
-- the project worker probe compiling the seeded worker via the dynamic
-  worker loader on a cold isolate
+Per-step instrumentation (`[create-timing]` lines, kept in tree) plus
+event-log timelines across 25 concurrent creates on a fresh stage showed the
+saga itself is healthy and load-stable:
 
-Same family, second data point: the auth OAuth **callback**
-(`/api/iterate-auth/callback`) takes 30-90s on freshly deployed slots (both
-signup and create-project specs saw the browser parked on the callback URL
-past a 30s budget; auth already has `global_fetch_strictly_public`). Whatever
-is cold here — the token exchange, the auth DO, or an os-side fetch — likely
-shares a cause with the slow first creates.
+- auth register 0.25–0.4s, directory prime ~0.1s, root append 0.5–1.1s
+- project-processor lane (3 sequential appends) 1.1–2.6s ← slowest lane
+- CF Artifacts repo create+seed 1.6–2.4s
+- worker probe + created append 0.2–0.6s
+- total saga 3.0–4.7s; client-observed create ≈ 4.9–5.4s
 
-Fix ideas once measured: parallelize independent saga steps, pre-warm the
-loader path at deploy, batch the birth appends.
+The actual fresh-slot killer is **zombie worker routes**: a route created
+during deploy that is visible in the API but never fires at the edge, so
+every request to that hostname falls through to the originless placeholder
+DNS record and dies with a 522 after ~20s. Reproduced live on preview-7
+(`mcp.iterate-preview-7.com` 522'd for 40+ minutes while
+`os.iterate-preview-7.com`, same script/zone/record shape, worked); deleting
+and recreating the identical route healed it instantly. This also explains
+the OAuth-callback "parked browser" symptom — the os-side callback fetches
+the auth worker's discovery + token endpoints over exactly these routes.
+
+## Fixes
+
+- `IterateRoutes` (packages/shared/src/alchemy/iterate-app.ts) now creates
+  the proxied placeholder DNS records BEFORE the routes (Cloudflare requires
+  the record for the route to fire) and then probes every exact route
+  hostname, deleting + recreating any route the edge answers with an
+  origin-fallthrough status (521/522/523/530).
+- The project processor's create lane batches its two root-stream appends
+  into one atomic append and runs the independent Slack-router append in
+  parallel (lane: 1.1–2.6s → one round-trip apiece).
+- Per-step `[create-timing]` / `[callback-timing]` instrumentation stays in
+  the tree so any recurrence shows its slow step in `wrangler tail` /
+  Workers Observability.


### PR DESCRIPTION
Fixes tasks/os-cold-create-latency.md: first-touch `projects.create` >60-120s and OAuth callbacks parking browsers 30-90s, both only on freshly deployed slots.

## Root cause

**Zombie worker routes.** A route created during deploy can end up visible in the Cloudflare API but never firing at the edge; every request to that hostname then falls through to the originless placeholder DNS record (`192.0.2.1`/`100::`) and dies with a **522 after ~20s**. Reproduced twice on preview-7 during this investigation:

- `mcp.iterate-preview-7.com` 522'd for 40+ minutes after an ordinary deploy while `os.iterate-preview-7.com` (same script, same zone, identical record shape, route present in the API) worked. Deleting and recreating the *identical* route healed it instantly (401 in 0.3s).
- On a destroy + fresh redeploy, the **main os host itself** came up as a zombie — caught and healed live by the new verification pass: `[iterate-routes] os.iterate-preview-7.com answered 522 — route exists but is not firing at the edge; recreating it (attempt 1/3)`.

A zombie on the os host makes every capnweb connection, create, and OAuth callback on the slot hang ~20s per hop — exactly the rotating "Timed out waiting for stream event … saw 0 events" / parked-browser CI signature.

**Ruled out (measured first):**
- Bundle bloat: deployed workers are 1.3–5.5MB each (api 4.0MB, app 5.0MB, repo 5.5MB) — nowhere near the historical 89MB sourcemap incident; the prune step deletes 142 sourcemaps (24.5MB) per deploy.
- Saga compute: per-step timing + event-log timelines across 25 concurrent creates on a fresh stage show the saga at 3.0–4.7s total, load-stable.

## Measured numbers (preview-7, fresh stage, 4-way parallel suite load)

| step | before | after |
| --- | --- | --- |
| auth register | 250–410ms | 8–33ms (warm directory) |
| root append | 519–685ms | 495–680ms (p90) |
| project-processor lane (3 sequential appends) | 1.1–2.6s | one atomic root append ∥ slack append (~0.5s) |
| CF Artifacts repo create+seed | 1.6–2.4s | unchanged (inherently sequential) |
| worker probe + created append | 0.2–0.6s | unchanged |
| `wait-project-created` (saga total) | med 3.5s / max 4.2s | **med 2.8s / max 3.3s** |
| client-observed create | 4.9–5.4s | **cold first-touch 4356ms / warm 3798ms** |
| OAuth callback discovery + token exchange | (parked 30–90s on zombie slots) | **27–97ms + 56–152ms** |

## Fixes

- **`packages/shared/src/alchemy/iterate-app.ts`** — `IterateRoutes` now (1) creates the proxied placeholder DNS records *before* the routes (Cloudflare requires the record for a route to fire), and (2) probes every exact route hostname after creation, delete+recreating any route the edge answers with an origin-fallthrough status (521/522/523/530), double-confirming after a heal to ride out edge propagation. Wildcard patterns are skipped (nothing probeable); probe failures are inconclusive and never fail a deploy.
- **`apps/os/src/domains/projects/project-processor-implementation.ts`** — the create lane batches its two root-stream appends (itx subscription + repo kickoff, order preserved) into one atomic append and runs the independent Slack-router append in parallel.
- **Instrumentation kept in tree** — structured `[create-timing]` lines around every awaited create-saga step (api worker, project processor, repo DO/CF Artifacts) and `[callback-timing]` around the OAuth callback's discovery/token-exchange hops (`apps/os/src/lib/step-timing.ts`, `apps/auth/src/lib/server.ts`). One greppable JSON line per step in `wrangler tail` / Workers Observability.

## Restored test budgets (verified on a destroyed + freshly redeployed slot)

- `apps/os/e2e/vitest.config.ts`: `testTimeout`/`hookTimeout` 240s → **120s**
- `specs/create-project.spec.ts`: first click 90s → **30s**
- `specs/signup.spec.ts`: dropped `test.setTimeout(180_000)`, waitFor 90s → **30s**

Proof at these budgets against the fresh preview-7 deploy: full engine e2e suite **9/9 files, 62 passed, 0 failed** (214s), Playwright `create-project` **11.5s** and `signup` **6.6s** (real email-OTP signup + OAuth callback), run concurrently CI-style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploy-time route healing and DNS ordering change Cloudflare routing for every stage; create-saga batching alters event ordering semantics only where explicitly preserved in one atomic append.
> 
> **Overview**
> Addresses **cold-slot** failures where first-touch `projects.create` and OAuth callbacks hung for tens of seconds on freshly deployed preview stages.
> 
> **Deploy routing (`IterateRoutes`):** Proxied placeholder DNS is created **before** worker routes so routes can fire at the edge. After route creation, each non-wildcard hostname is probed; responses **521/522/523/530** (origin fallthrough on placeholder records) trigger delete-and-recreate of the route, with a second probe after heals.
> 
> **Create saga:** The project processor batches the itx subscription and repo kickoff into **one** root-stream `append` and runs the Slack-router append **in parallel**, cutting the former sequential lane. **`timedStep`** (`[create-timing]` / `[callback-timing]`) wraps create-saga and OAuth callback hops for production diagnosis.
> 
> **Tests:** Vitest e2e and Playwright signup/create-project timeouts are tightened (e.g. 240s → 120s, 90s → 30s) now that zombie routes are handled at deploy time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3a96f36b7980a24d48c53eca4672d943bf53feb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-02T23:16:29.973Z",
      "headSha": "a3a96f36b7980a24d48c53eca4672d943bf53feb",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28627128306",
      "shortSha": "a3a96f3",
      "cleanupDurationMs": 10704,
      "deployDurationMs": 62160,
      "testDurationMs": 4508
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-02T23:16:31.300Z",
      "headSha": "a3a96f36b7980a24d48c53eca4672d943bf53feb",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28627128306",
      "shortSha": "a3a96f3",
      "cleanupDurationMs": 12028,
      "deployDurationMs": 24732,
      "testDurationMs": 663
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-02T23:16:26.196Z",
      "headSha": "a3a96f36b7980a24d48c53eca4672d943bf53feb",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-7.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28627128306",
      "shortSha": "a3a96f3",
      "cleanupDurationMs": 6922,
      "deployDurationMs": 20624,
      "testDurationMs": 21068
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-02T23:16:18.321Z",
      "headSha": "a3a96f36b7980a24d48c53eca4672d943bf53feb",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/28627128306",
      "shortSha": "a3a96f3",
      "cleanupDurationMs": 33985,
      "deployDurationMs": 37337,
      "testDurationMs": 296737
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `a3a96f3` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 24.7s | 663ms | 12.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28627128306) | 2026-07-02T23:16:31.300Z | Preview app released. |
| OS | released | `a3a96f3` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 37.3s | 296.7s | 34.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28627128306) | 2026-07-02T23:16:18.321Z | Preview app released. |
| Semaphore | released | `a3a96f3` | [https://semaphore.iterate-preview-7.com](https://semaphore.iterate-preview-7.com) | 62.2s | 4.5s | 10.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28627128306) | 2026-07-02T23:16:29.973Z | Preview app released. |
| Streams Example App | released | `a3a96f3` | [https://streams-example-app-preview-7.iterate-dev-preview.workers.dev](https://streams-example-app-preview-7.iterate-dev-preview.workers.dev) | 20.6s | 21.1s | 6.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/28627128306) | 2026-07-02T23:16:26.196Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->