### PR TITLE
Faster CI: raise e2e concurrency, all workflows on Depot, fail-fast

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ from your machine, and when you need a public callback URL. Doppler/Cloudflare/d
 
 - [Dev environments](docs/dev-environments.md) — local dev, minting identities/admin sessions, browsers for agents, preview-from-local
 - [Coding style](docs/coding-style.md)
+- [Depot CI](docs/depot-ci.md) — how our Depot CI works, how to interact with it, the commands (run/status/logs/dispatch/metrics/secrets), gotchas, and links
 - [CI workflows](docs/ci-workflows.md) — generated GitHub Actions, Depot runners, Depot CI, and the image-bake workflow
 - [Preview CI performance](docs/ci-preview-performance.md) — how the preview deploy+e2e check stays ~2-3 min, the budget guardrail, and how to keep it fast without raising cost
 - [TypeScript conventions](docs/typescript-conventions.md)

--- a/apps/os/e2e/vitest.config.ts
+++ b/apps/os/e2e/vitest.config.ts
@@ -56,11 +56,13 @@ export default defineConfig({
     // and overloaded the slot ("Durable Object storage operation exceeded
     // timeout") at peak 8-24; with fast creates the slot tolerates the
     // fan-out. peak ≈ maxWorkers × maxConcurrency, so 4×4 = ~16 concurrent
-    // creates against the slot. Watch preview e2e for DO-storage-timeout /
-    // timing-teardown flakes if you push this higher — see
-    // tasks/raise-e2e-maxconcurrency.md.
+    // creates against the slot. 4 (peak ~16) still overloaded on a very cold
+    // slot (161s deploy) — 4 DO-storage-timeout fails that survived retry — so
+    // 3 (peak ~12) is the current ceiling. The robust fix for going higher is
+    // splitting the itx monolith into files (file parallelism at safe
+    // per-file concurrency) — see tasks/raise-e2e-maxconcurrency.md.
     sequence: { concurrent: ci },
-    maxConcurrency: 4,
+    maxConcurrency: 3,
     // One retry in CI: tests are self-contained (fresh project per test), so a
     // rare load-induced flake re-runs in seconds instead of failing the suite.
     retry: ci ? 1 : 0,

--- a/apps/os/e2e/vitest.config.ts
+++ b/apps/os/e2e/vitest.config.ts
@@ -50,16 +50,17 @@ export default defineConfig({
     // its own project against a deployed slot, so FILES are independent.
     // Sequential locally so a single dev server isn't hammered.
     fileParallelism: ci,
-    // File-level parallelism only (this matches main): the deployed preview
-    // slot — not the runner — is the bottleneck. Every e2e test creates a
-    // project (a whole cold DO chain), so ~4 concurrent creates is the ceiling
-    // the slot tolerates. Adding intra-file concurrency (`sequence.concurrent`
-    // + maxConcurrency) on top pushed it over — "Durable Object storage
-    // operation exceeded timeout" and rotating timing-teardown flakes at peak
-    // 8-24. The real speedup for the itx monolith is splitting it into files
-    // so THIS knob parallelizes it safely — see
-    // tasks/raise-e2e-maxconcurrency.md.
     maxWorkers: 4,
+    // Intra-file concurrency, back on now that #1601 fixed cold-slot create
+    // latency (~3-5s per saga). Before #1601 the slow cold creates piled up
+    // and overloaded the slot ("Durable Object storage operation exceeded
+    // timeout") at peak 8-24; with fast creates the slot tolerates the
+    // fan-out. peak ≈ maxWorkers × maxConcurrency, so 4×4 = ~16 concurrent
+    // creates against the slot. Watch preview e2e for DO-storage-timeout /
+    // timing-teardown flakes if you push this higher — see
+    // tasks/raise-e2e-maxconcurrency.md.
+    sequence: { concurrent: ci },
+    maxConcurrency: 4,
     // One retry in CI: tests are self-contained (fresh project per test), so a
     // rare load-induced flake re-runs in seconds instead of failing the suite.
     retry: ci ? 1 : 0,

--- a/apps/os/src/itx-client.ts
+++ b/apps/os/src/itx-client.ts
@@ -58,10 +58,10 @@ function connect<T extends CapnRpcCompatible<T>>(
   url: string,
   onWebSocketMessage?: (message: ItxWebSocketMessage) => void,
 ): CapnRpcStub<T> {
-  // 30s: cold deployments answer the upgrade only after the worker chain has
-  // loaded; concurrent e2e against a fresh slot saw >10s handshakes (499s at
-  // the edge). Slow-but-connected beats flaky.
-  const socket = new WebSocket(url, { handshakeTimeout: 30_000 });
+  // 15s: cold deployments answer the upgrade only after the worker chain has
+  // loaded, but #1601's route-healing + the preview slot warmup mean the first
+  // upgrade lands in a few seconds — 15s is headroom, not a hang budget.
+  const socket = new WebSocket(url, { handshakeTimeout: 15_000 });
 
   if (onWebSocketMessage) {
     const start = Date.now();

--- a/docs/depot-ci.md
+++ b/docs/depot-ci.md
@@ -1,0 +1,81 @@
+# Depot CI
+
+We run CI on [Depot CI](https://depot.dev/docs/ci) — Depot's own CI control
+plane — not just GitHub Actions. Depot CI assigns a runner in ~7s where GitHub
+Actions runner assignment measured 20s–3m39s (and once ~40min during a webhook
+incident), so the latency-sensitive checks live there.
+
+This doc is the practical guide: how it works, how to interact with it, and the
+commands you'll actually use. For the preview pipeline specifically, see
+[Preview CI performance](ci-preview-performance.md); for the GitHub-Actions side
+and the workflow generator, see [CI workflows](ci-workflows.md).
+
+## How it works
+
+- **Workflows live in `.depot/workflows/*.yml`** and use GitHub Actions YAML
+  syntax (Depot runs it largely unmodified). Depot's GitHub App reports each
+  job back to the PR as a normal check (the "Cloudflare Previews (Depot CI) /
+  …" checks you see on a PR come from Depot).
+- **Triggers register on the default branch.** When a workflow file lands on
+  `main`, Depot registers its `on:` triggers. Branch-only changes to the `on:`
+  block don't take effect until merged — test a branch with `depot ci dispatch`
+  (below).
+- **Supported triggers:** `push`, `pull_request`, `pull_request_target`,
+  `pull_request_review`, `schedule`, `workflow_call`, `workflow_dispatch`,
+  `workflow_run`, `merge_group`. **Not supported:** `issue_comment`, `issues`,
+  `pull_request_review_comment` (this is why `claude-assistant` stays on GitHub
+  Actions).
+- **Secrets** come from `depot ci secrets` (org-scoped), not GitHub secrets.
+- **Org / dashboard:** org id `0p91s0lz49`,
+  [dashboard](https://depot.dev/orgs/0p91s0lz49/workflows).
+
+## Commands you'll use
+
+```bash
+# --- watch runs ---
+depot ci run list      --org 0p91s0lz49 --repo iterate/iterate          # queued/active runs
+depot ci workflow list --org 0p91s0lz49 --repo iterate/iterate          # per-workflow rows incl. sha + run id
+depot ci status <run-id>     --org 0p91s0lz49 [--output json]           # run/job/attempt tree
+depot ci logs   <attempt-id> --org 0p91s0lz49 [--timestamps] [--output-file f.log]
+
+# --- run something ---
+# Trigger a workflow on a branch WITHOUT merging (uses the branch's version of the file):
+depot ci dispatch --org 0p91s0lz49 --repo iterate/iterate \
+  --workflow cloudflare-previews.yml --ref <branch> --input pull-request-number=<pr>
+
+# Run a workflow from your local checkout (uploads uncommitted changes as a patch):
+depot ci run --workflow .depot/workflows/<file>.yml --org 0p91s0lz49 --job <job>
+
+# --- diagnostics ---
+depot ci metrics --run <run-id> --org 0p91s0lz49 --output json          # CPU/mem utilization (runner sizing)
+depot ci diagnose <run-id> --org 0p91s0lz49                             # failure triage
+depot ci rerun    <run-id> --org 0p91s0lz49                             # re-run a workflow
+depot ci cancel   <run-id> --org 0p91s0lz49
+
+# --- secrets ---
+depot ci secrets list --org 0p91s0lz49
+printf '%s' "$VALUE" | depot ci secrets add NAME --org 0p91s0lz49
+depot ci secrets remove NAME --org 0p91s0lz49
+```
+
+## Gotchas
+
+- **`workflow_dispatch` and `pull_request` runs share a concurrency group** (the
+  preview workflow's `cloudflare-previews-<pr>` with `cancel-in-progress: true`),
+  so a manual `dispatch` and the automatic PR run **cancel each other**. When
+  validating, either rely on the PR run or the dispatch — not both at once.
+- **`depot ci logs --output-file` lags a live run** — the export can trail the
+  actual progress by a chunk; re-fetch until the line you expect appears.
+- **Run id vs workflow id vs attempt id** — `depot ci run list` shows _run_
+  ids; `depot ci workflow list` shows _workflow_ ids (with the run id in the
+  last column); `logs` wants the _attempt_ id (from `status … --output json`).
+- **The preview e2e check is not a required check** — a red preview
+  (e.g. a cold-slot signup flake) does not block merge if the required checks
+  (lint-typecheck, test, generate) are green.
+
+## Docs
+
+- [Depot CI overview](https://depot.dev/docs/ci) ·
+  [quickstart](https://depot.dev/docs/ci/quickstart) ·
+  [GitHub Actions compatibility](https://depot.dev/docs/ci/compatibility) ·
+  [CLI reference](https://depot.dev/docs/cli/reference/depot-ci)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   // dev server isn't hammered.
   fullyParallel: !!process.env.CI,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 6 : 1,
   outputDir: "test-results/playwright-output",
   reporter: [

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -493,6 +493,14 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
         // -L: /api/iterate-auth/login redirects to the slot's auth worker,
         // warming it for the login-flow specs.
         'for path in /api/health / /api/itx /sign-in /api/iterate-auth/login; do curl -sL -o /dev/null --max-time 20 "$OS_BASE_URL$path" || true; done',
+        // Warm the OAuth handshake path — the signup/create-project specs park
+        // 30-90s on a cold callback (token exchange + first-org onboarding).
+        // Boot both sides' isolates: the OS callback handler, and the auth
+        // worker (origin derived from the /login redirect) incl. its OTP and
+        // onboarding routes. Best-effort — see
+        // tasks/fix-cold-auth-oauth-callback-latency.md for the real fix.
+        'curl -sL -o /dev/null --max-time 20 "$OS_BASE_URL/api/iterate-auth/callback" || true',
+        'AUTH_BASE=$(curl -s -o /dev/null -w "%{redirect_url}" --max-time 20 "$OS_BASE_URL/api/iterate-auth/login?login_hint=email" | sed -E "s#(https?://[^/]+).*#\\1#") || true; if [ -n "$AUTH_BASE" ]; then for p in / /api/auth/ok /sign-in /onboarding; do curl -sL -o /dev/null --max-time 20 "$AUTH_BASE$p" || true; done; fi',
         // Subshell so the bare `wait` reaps only these curls, not the
         // background chromium install / create-smoke started above.
         '( for i in 1 2 3 4 5 6 7 8; do (curl -s -o /dev/null --max-time 20 "$OS_BASE_URL/api/health" && curl -s -o /dev/null --max-time 20 "$OS_BASE_URL/") & done; wait )',

--- a/tasks/move-all-ci-to-depot.md
+++ b/tasks/move-all-ci-to-depot.md
@@ -5,62 +5,68 @@ size: large
 tags: [ci, depot, infra, docs]
 ---
 
-# Move all Depot-compatible CI workflows to Depot CI (+ document it)
+# Move all Depot-compatible CI workflows to Depot CI (needs Doppler-in-image)
 
-Preview deploy/e2e/cleanup already runs on Depot CI
-(`.depot/workflows/cloudflare-previews.yml`). Move the rest of the generated
-GitHub Actions workflows onto Depot CI too, for the same ~7s pickup (vs GitHub's
-20s-3m39s runner assignment).
+Preview deploy/e2e/cleanup already runs on Depot CI. Move the rest of the
+generated workflows too, for the same ~7s pickup vs GitHub's 20s-3m39s. The
+mechanism + the one-secret design are worked out below; the blocker is
+operational (Doppler baked into the Depot image + validating prod deploys),
+which is why it wasn't rushed into the faster-ci PR.
 
-## Scope
+## One secret: DOPPLER_TOKEN (design is proven)
 
-Movable (Depot-supported triggers — push / pull_request / schedule /
-workflow_dispatch / workflow_call / workflow_run / pull_request_review):
+Depot needs exactly one secret, `DOPPLER_TOKEN`, because everything else is in
+Doppler (`_shared/prd`) and the code already sources it from there:
 
-- lint-typecheck, test, autofix, ci, nag, pr-dashboard (per-PR checks — the
-  speed win)
-- deploy-os / deploy-auth / deploy-semaphore / deploy-streams-example-app /
-  deploy-tunnels, deploy, release, pullfrog (prod deploys — validate carefully)
+- deploy-\*/deploy/test run under `doppler run` → Cloudflare/Alchemy/etc. injected.
+- `utils/slack.ts` `getSlackBotToken()` already falls back to
+  `doppler secrets --config prd get SLACK_CI_BOT_TOKEN` when the GitHub secret
+  is absent (which it is on Depot).
+- The only direct `${{ secrets.ITERATE_BOT_GITHUB_TOKEN }}` users (nag,
+  pr-dashboard, release, preview) can source it from Doppler the same way —
+  it resolves via `doppler secrets --project _shared --config prd get --plain
+ITERATE_BOT_GITHUB_TOKEN`.
 
-**Stays on GitHub Actions:** `claude-assistant` — it triggers on
-`issue_comment`, `issues`, and `pull_request_review_comment`, none of which
-Depot CI supports. (Depot DOES support `pull_request_review` — review
-submitted — just not the comment/issue events.) So "all" is really
-"all except claude-assistant".
+Verified 2026-07-02: both SLACK_CI_BOT_TOKEN and ITERATE_BOT_GITHUB_TOKEN
+resolve from Doppler `_shared/prd`.
 
-## How
+## Doppler belongs in the image, not a per-run install
 
-- The workflows are generated from `.github/ts-workflows/workflows/*.ts` into
-  `.github/workflows/*.yml` by `.github/ts-workflows/cli.ts`. Retarget the
-  generator to emit `.depot/workflows/*.yml` for the moved workflows (or emit
-  both and delete the GitHub copies) and update the drift check.
-- Secrets: ensure everything each workflow needs is in `depot ci secrets`
-  (currently only DOPPLER_TOKEN + ITERATE_BOT_GITHUB_TOKEN, and those are
-  interim personal tokens — swap for the iterate-bot PAT + a Doppler service
-  token).
-- Watch: branch-protection required-check names stay the same (Depot GitHub
-  App reports the same check names), but confirm before flipping. Depot
-  registers pull_request/etc. triggers only when the file is on the DEFAULT
-  branch.
+Do NOT `curl | sh` the Doppler CLI in each workflow. Bake Doppler into the
+Depot CI runner image (extend the existing `build-preview-ci-image.yml` bake,
+which already installs Doppler + pnpm + node_modules, and wire the Depot CI
+workflows to use that snapshot as their base — see
+depot.dev/docs/ci/how-to-guides/custom-images), then drop the per-workflow
+`installDopplerCli` steps. This is the operational prerequisite for the move.
 
-## Documentation (rolled into this PR — asked for explicitly)
+## The generator routing (implement then)
 
-Add a doc **discoverable directly from the repo root `README.md` in one hop**
-that explains how Depot CI works here and how to interact with it:
+`.github/ts-workflows/cli.ts` generates ts → `.github/workflows/`. Add a
+`DEPOT_WORKFLOW_NAMES` set and route those names' yaml to `.depot/workflows/`
+(read/write/clean-up the right dir per workflow; delete the stale `.github`
+copy on move). Everything Depot-trigger-compatible moves; the exceptions stay
+on GitHub Actions:
 
-- what Depot CI is and why we use it (pickup latency vs GitHub Actions)
-- where the workflows live (`.depot/workflows/`) and how they're
-  triggered/registered (default-branch registration caveat)
-- the important CLI commands: `depot ci run list` / `workflow list` /
-  `status <run>` / `logs <attempt> [--timestamps] [--output-file]` /
-  `metrics --run <id>` / `dispatch --workflow <name> --ref <branch> --input k=v`
-  / `secrets` (add/list/remove) / `run --workflow <file>` (local, uploads
-  uncommitted patch)
-- gotchas: workflow_dispatch vs pull_request runs share the concurrency group
-  and cancel each other; `logs --output-file` lags a live run; `status`
-  run-id vs workflow-id confusion
-- links: depot.dev/docs/ci (quickstart, compatibility, CLI reference), the org
-  dashboard (https://depot.dev/orgs/0p91s0lz49/workflows)
+- `claude-assistant` — `issue_comment`/`issues`/`pull_request_review_comment`
+  triggers are unsupported by Depot CI. (`pull_request_review` IS supported.)
+- `generate-workflows` — the self-referential generator guardian.
 
-Extend/point to the existing "Depot CI" section in `docs/ci-workflows.md`
-rather than duplicating.
+(A working draft of this routing was prototyped in the faster-ci branch and
+reverted pending the Doppler-in-image work.)
+
+## Cutover checklist
+
+1. Bake Doppler into the Depot CI image; wire workflows to it; drop per-run
+   Doppler installs.
+2. Refactor nag/pr-dashboard/release/preview to source ITERATE_BOT_GITHUB_TOKEN
+   from Doppler.
+3. Flip the workflows into `DEPOT_WORKFLOW_NAMES`, regenerate.
+4. Set Depot's `DOPPLER_TOKEN` to the real CI Doppler service token (scoped
+   `_shared/prd`) — replaces the interim personal token — then
+   `depot ci secrets remove ITERATE_BOT_GITHUB_TOKEN`.
+5. **Validate prod deploys on Depot deliberately** (high blast radius) before
+   relying on them — dispatch each deploy-\* on a branch first.
+6. Confirm branch-protection required-check names still match (Depot GitHub
+   App reports the same names).
+
+See docs/depot-ci.md for the usage/command reference.


### PR DESCRIPTION
Follow-up to #1589 — CI speed/reliability wins, plus the Depot CI usage doc.

## What's in this PR

- **Warm the OAuth path** (validated ✅) — the preview warms the cold OAuth callback (OS callback handler + the auth worker, origin derived from the `/login` redirect) before the specs. `signup.spec` went from **3 cold-callback timeouts (~33s each) to passing in ~4s**; `create-project` passes too.
- **Fail-fast** — Playwright `retries` 2→1 (one retry is enough); itx-client WS `handshakeTimeout` 30s→15s (post-#1601 connects are fast).
- **Raise e2e concurrency** — restore `sequence.concurrent` + `maxConcurrency: 3` (up from the reliability-pinned 2), now that #1601 fixed the cold-create latency. `4` (peak ~16) still overloaded a *very* cold slot (161s deploy → DO-storage-timeout fails that survived retry), so 3 (peak ~12) is the reliable ceiling. Going higher wants the itx-monolith split (`tasks/raise-e2e-maxconcurrency.md`).
- **`docs/depot-ci.md`** — README-discoverable (one hop): how our Depot CI works, the commands (run/status/logs/dispatch/metrics/secrets), gotchas, and links.

## "Move all CI to Depot" — designed, not landed here (on purpose)

I prototyped the full migration (generator routing `.github/workflows/` → `.depot/workflows/` for everything except `claude-assistant`) and **reverted it**, because doing it *right* is an infra task that shouldn't be rushed:

- **One secret is real** — Depot only needs `DOPPLER_TOKEN`: deploys/test already `doppler run`, `slack.ts` already falls back to Doppler for the Slack token, and `ITERATE_BOT_GITHUB_TOKEN` resolves from Doppler too. Verified both tokens resolve from `_shared/prd`.
- **But Doppler must be baked into the Depot image** (not `curl | sh`'d per run, per review), and **moving the prod-deploy workflows needs deliberate validation** (high blast radius).

The full runbook (Doppler-in-image → generator routing → one-secret → validate deploys) is in `tasks/move-all-ci-to-depot.md`.

> Note: `depot ci secrets` currently holds an interim *personal* `DOPPLER_TOKEN`; swap it for the CI Doppler service token before relying on the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-03T06:17:52.896Z",
      "headSha": "ea692fec99af00907805f276f2f4d14044bf08ca",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/316465335715900",
      "shortSha": "ea692fe",
      "cleanupDurationMs": 39616,
      "deployDurationMs": 48136,
      "testDurationMs": 120801
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-03T06:17:32.623Z",
      "headSha": "ea692fec99af00907805f276f2f4d14044bf08ca",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/316465335715900",
      "shortSha": "ea692fe",
      "cleanupDurationMs": 19339,
      "deployDurationMs": 27171,
      "testDurationMs": 631
    }
  },
  "environmentConfigLease": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `ea692fe` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 27.2s | 631ms | 19.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/316465335715900) | 2026-07-03T06:17:32.623Z | Preview app released. |
| OS | released | `ea692fe` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 48.1s | 120.8s | 39.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/316465335715900) | 2026-07-03T06:17:52.896Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes target preview CI warmup, test timeouts/retries, and documentation; no production app logic or auth behavior changes for deployed users.
> 
> **Overview**
> Speeds up and stabilizes **preview CI** by warming the OAuth callback path (OS + auth worker) before the concurrent e2e burst, cutting cold signup/create-project waits.
> 
> **Fail-fast:** Playwright CI retries **2→1**; itx WebSocket `handshakeTimeout` **30s→15s** (post-#1601 fast connects).
> 
> **Higher e2e parallelism:** Vitest CI turns **`sequence.concurrent`** back on with **`maxConcurrency: 3`** (~12 peak concurrent creates vs file-only parallelism), with comments documenting why 4 was too hot on very cold slots.
> 
> Adds **`docs/depot-ci.md`** (linked from the README) for Depot CI commands and gotchas. Updates **`tasks/move-all-ci-to-depot.md`** to record that full workflow migration stays blocked on Doppler-in-image and prod-deploy validation—not shipped in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea692fec99af00907805f276f2f4d14044bf08ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->