### PR TITLE
Keep auth OAuth seed clients in sync

### DIFF
--- a/apps/os/scripts/sync-auth-clients.ts
+++ b/apps/os/scripts/sync-auth-clients.ts
@@ -8,6 +8,14 @@ type Target = {
   projectHostnameBase: string;
 };
 
+type SeedOAuthClientSpec = {
+  clientId: string;
+  clientSecret: string;
+  clientName: string;
+  redirectURIs: string[];
+  referenceId?: string;
+};
+
 const targets: Target[] = [
   ...[1, 2, 3, 4, 5, 6, 7, 8, 9].map(
     (previewNumber) =>
@@ -32,6 +40,8 @@ const authBaseUrl =
   process.env.VITE_AUTH_APP_ORIGIN?.trim() ||
   new URL(authIssuer).origin;
 const serviceToken = process.env.SERVICE_AUTH_TOKEN?.trim();
+const authDopplerProject = process.env.DOPPLER_PROJECT?.trim() || "auth";
+const authDopplerConfig = process.env.DOPPLER_CONFIG?.trim() || "prd";
 const targetFilter = new Set(
   (process.env.AUTH_CLIENT_SYNC_TARGETS ?? "")
     .split(",")
@@ -47,6 +57,7 @@ if (!serviceToken) {
 }
 
 const authClient = createAuthContractClient({ baseUrl: authBaseUrl, serviceToken });
+const seedOAuthClients = readSeedOAuthClients();
 
 for (const target of targets) {
   if (targetFilter.size > 0 && !targetFilter.has(target.dopplerConfig)) {
@@ -54,28 +65,33 @@ for (const target of targets) {
   }
 
   const webRedirectUri = `${target.baseUrl}/api/iterate-auth/callback`;
+  const webReferenceId = `os:${target.dopplerConfig}:web`;
+  const webClientName = `OS ${target.dopplerConfig} web`;
   const existingWebClientId = getDopplerSecret(target, "ITERATE_OAUTH_CLIENT_ID");
   const existingWebClientSecret = getDopplerSecret(target, "ITERATE_OAUTH_CLIENT_SECRET");
   const webClient = await authClient.internal.oauth.ensureClient({
-    referenceId: `os:${target.dopplerConfig}:web`,
-    clientName: `OS ${target.dopplerConfig} web`,
+    referenceId: webReferenceId,
+    clientName: webClientName,
     redirectURIs: [webRedirectUri],
     existingClientId: existingWebClientId,
     existingClientSecret: existingWebClientSecret,
     rotateClientSecret: rotateClientSecrets,
   });
 
+  const mcpReferenceId = `os:${target.dopplerConfig}:mcp`;
+  const mcpClientName = `OS ${target.dopplerConfig} MCP`;
+  const mcpRedirectURIs = [
+    "http://127.0.0.1/callback",
+    "http://localhost/callback",
+    "http://127.0.0.1:3334/callback",
+    "http://localhost:3334/callback",
+  ];
   const existingMcpClientId = getDopplerSecret(target, "ITERATE_MCP_OAUTH_CLIENT_ID");
   const existingMcpClientSecret = getDopplerSecret(target, "ITERATE_MCP_OAUTH_CLIENT_SECRET");
   const mcpClient = await authClient.internal.oauth.ensureClient({
-    referenceId: `os:${target.dopplerConfig}:mcp`,
-    clientName: `OS ${target.dopplerConfig} MCP`,
-    redirectURIs: [
-      "http://127.0.0.1/callback",
-      "http://localhost/callback",
-      "http://127.0.0.1:3334/callback",
-      "http://localhost:3334/callback",
-    ],
+    referenceId: mcpReferenceId,
+    clientName: mcpClientName,
+    redirectURIs: mcpRedirectURIs,
     existingClientId: existingMcpClientId,
     existingClientSecret: existingMcpClientSecret,
     rotateClientSecret: rotateClientSecrets,
@@ -94,8 +110,25 @@ for (const target of targets) {
     ITERATE_AUTH_SERVICE_TOKEN: serviceToken,
   });
 
+  upsertSeedOAuthClient(seedOAuthClients, {
+    clientId: webClient.clientId,
+    clientSecret: webClient.clientSecret,
+    clientName: webClientName,
+    redirectURIs: [webRedirectUri],
+    referenceId: webReferenceId,
+  });
+  upsertSeedOAuthClient(seedOAuthClients, {
+    clientId: mcpClient.clientId,
+    clientSecret: mcpClient.clientSecret,
+    clientName: mcpClientName,
+    redirectURIs: mcpRedirectURIs,
+    referenceId: mcpReferenceId,
+  });
+
   console.log(`synced auth clients for ${target.dopplerConfig}`);
 }
+
+setAuthSeedOAuthClients(seedOAuthClients);
 
 function getDopplerSecret(target: Target, key: string) {
   try {
@@ -108,6 +141,95 @@ function getDopplerSecret(target: Target, key: string) {
   } catch {
     return undefined;
   }
+}
+
+function readSeedOAuthClients() {
+  const result = spawnSync(
+    "doppler",
+    [
+      "secrets",
+      "get",
+      "AUTH_SEED_OAUTH_CLIENTS",
+      "--plain",
+      "--project",
+      authDopplerProject,
+      "--config",
+      authDopplerConfig,
+    ],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+
+  if (result.status !== 0) {
+    const output = `${result.stderr}\n${result.stdout}`;
+    if (
+      /not found|does not exist|not exist|not set|could not find requested secret/i.test(output)
+    ) {
+      return [];
+    }
+    throw new Error(
+      `Failed to read AUTH_SEED_OAUTH_CLIENTS for ${authDopplerProject}/${authDopplerConfig}: ${output}`,
+    );
+  }
+
+  const value = result.stdout.trim();
+  if (!value) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed as SeedOAuthClientSpec[];
+    }
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(`AUTH_SEED_OAUTH_CLIENTS is not valid JSON: ${error.message}`);
+    }
+    throw error;
+  }
+  throw new Error("AUTH_SEED_OAUTH_CLIENTS must be a JSON array");
+}
+
+function upsertSeedOAuthClient(clients: SeedOAuthClientSpec[], client: SeedOAuthClientSpec) {
+  const index = clients.findIndex(
+    (candidate) =>
+      candidate.referenceId === client.referenceId || candidate.clientId === client.clientId,
+  );
+  if (index === -1) {
+    clients.push(client);
+  } else {
+    clients[index] = client;
+  }
+  clients.sort((a, b) => (a.referenceId ?? a.clientId).localeCompare(b.referenceId ?? b.clientId));
+}
+
+function setAuthSeedOAuthClients(clients: SeedOAuthClientSpec[]) {
+  const result = spawnSync(
+    "doppler",
+    [
+      "secrets",
+      "set",
+      "AUTH_SEED_OAUTH_CLIENTS",
+      "--project",
+      authDopplerProject,
+      "--config",
+      authDopplerConfig,
+      "--no-interactive",
+    ],
+    {
+      input: JSON.stringify(clients),
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to set AUTH_SEED_OAUTH_CLIENTS for ${authDopplerProject}/${authDopplerConfig}: ${
+        result.stderr || result.stdout
+      }`,
+    );
+  }
+  console.log(`updated AUTH_SEED_OAUTH_CLIENTS for ${authDopplerProject}/${authDopplerConfig}`);
 }
 
 function setDopplerSecrets(target: Target, secrets: Record<string, string>) {


### PR DESCRIPTION
## Summary
- update the OS auth client sync script to also maintain auth AUTH_SEED_OAUTH_CLIENTS
- preserve existing seeded clients and upsert by reference id/client id
- fail on malformed seed JSON or unexpected Doppler read/write failures

## Production repair already applied
- synced auth clients for prd
- redeployed OS prd so os.iterate.com uses the current auth client id
- reran the updated script so auth/prd now has AUTH_SEED_OAUTH_CLIENTS populated

## Checks
- pnpm --dir apps/os typecheck
- pnpm exec oxfmt --check apps/os/scripts/sync-auth-clients.ts
- pnpm exec oxlint apps/os/scripts/sync-auth-clients.ts --deny-warnings
- curl login path now reaches auth login page with HTTP 200, not invalid_client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The script now writes OAuth client secrets into auth Doppler and can overwrite seed entries on each sync; misconfiguration or a bad run could break login until repaired.
> 
> **Overview**
> Extends **`sync-auth-clients.ts`** so each run keeps auth’s **`AUTH_SEED_OAUTH_CLIENTS`** Doppler secret aligned with the web and MCP OAuth clients it already provisions for every OS target (previews + prd).
> 
> At startup the script reads the existing seed JSON from the **auth** Doppler project/config (defaults **`auth`/`prd`**, overridable via **`DOPPLER_PROJECT`** / **`DOPPLER_CONFIG`**). After **`ensureClient`** and OS secret updates per target, it **upserts** entries by **`referenceId`** or **`clientId`**, preserves other seeded clients, sorts the list, and writes the full array back once at the end. Missing or empty seed secret starts from an empty array; invalid JSON or non-array values and unexpected Doppler failures **throw** instead of silently continuing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41023e6cb4e7092ed92e01b19f44ebde92af6816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->