### PR TITLE
Voice agents on the class-based stream processor stack

### DIFF
--- a/apps/os/public/voice-agent/input-worklet.js
+++ b/apps/os/public/voice-agent/input-worklet.js
@@ -1,0 +1,108 @@
+// Captures mic audio, downsamples it to the target rate with a box low-pass
+// filter, and posts fixed-size PCM16 chunks to the main thread.
+//
+// The audio thread must stay allocation-free in steady state: samples live in a
+// fixed Float32Array ring buffer addressed by absolute sample counters, and the
+// only per-chunk allocation is the transferable Int16Array that leaves the
+// worklet.
+class PcmInputProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.enabled = false;
+    this.targetSampleRate = 16000;
+    this.chunkSamples = 1600;
+    this.capacity = 32768;
+    this.ring = new Float32Array(this.capacity);
+    this.writeCount = 0; // total samples written, ever
+    this.readPos = 0; // fractional absolute read position
+    this.chunk = new Int16Array(this.chunkSamples);
+    this.chunkLength = 0;
+
+    this.port.onmessage = (event) => {
+      const message = event.data || {};
+      if (message.type === "configure") {
+        this.targetSampleRate = message.targetSampleRate || 16000;
+        const chunkMs = message.chunkMs || 100;
+        this.chunkSamples = Math.max(1, Math.round((this.targetSampleRate * chunkMs) / 1000));
+        this.chunk = new Int16Array(this.chunkSamples);
+        this.chunkLength = 0;
+      } else if (message.type === "set-enabled") {
+        this.enabled = Boolean(message.enabled);
+        if (!this.enabled) {
+          this.writeCount = 0;
+          this.readPos = 0;
+          this.chunkLength = 0;
+        }
+      }
+    };
+  }
+
+  process(inputs) {
+    if (!this.enabled) return true;
+
+    const input = inputs[0];
+    const channel = input && input[0];
+    if (!channel || channel.length === 0) return true;
+
+    for (let index = 0; index < channel.length; index++) {
+      this.ring[this.writeCount % this.capacity] = channel[index] || 0;
+      this.writeCount++;
+    }
+    if (this.writeCount - this.readPos > this.capacity) {
+      this.readPos = this.writeCount - this.capacity;
+    }
+
+    const ratio = sampleRate / this.targetSampleRate;
+    while (this.readPos + ratio <= this.writeCount) {
+      this.chunk[this.chunkLength++] = floatToInt16(
+        this.boxAverage(this.readPos, this.readPos + ratio),
+      );
+      this.readPos += ratio;
+      if (this.chunkLength >= this.chunkSamples) {
+        this.flushChunk();
+      }
+    }
+
+    return true;
+  }
+
+  // Average every source sample covered by [from, to), weighting partial
+  // samples by coverage. Acts as a low-pass at the target Nyquist, so
+  // downsampling doesn't fold high frequencies into the speech band the way
+  // take-every-Nth decimation does.
+  boxAverage(from, to) {
+    let sum = 0;
+    let weight = 0;
+    let pos = from;
+    while (pos < to) {
+      const index = Math.floor(pos);
+      const next = Math.min(index + 1, to);
+      const sliceWeight = next - pos;
+      sum += this.ring[index % this.capacity] * sliceWeight;
+      weight += sliceWeight;
+      pos = next;
+    }
+    return weight > 0 ? sum / weight : 0;
+  }
+
+  flushChunk() {
+    const pcm = this.chunk.slice(0, this.chunkLength);
+    this.chunkLength = 0;
+    this.port.postMessage(
+      {
+        type: "pcm",
+        sampleRate: this.targetSampleRate,
+        samples: pcm.length,
+        buffer: pcm.buffer,
+      },
+      [pcm.buffer],
+    );
+  }
+}
+
+function floatToInt16(value) {
+  const clamped = Math.max(-1, Math.min(1, value));
+  return clamped < 0 ? Math.round(clamped * 32768) : Math.round(clamped * 32767);
+}
+
+registerProcessor("pcm-input-processor", PcmInputProcessor);

--- a/apps/os/public/voice-agent/output-worklet.js
+++ b/apps/os/public/voice-agent/output-worklet.js
@@ -1,0 +1,106 @@
+// Plays queued PCM16 frames through the speaker, resampling from the source
+// rate to the device rate with linear interpolation.
+//
+// Audio lives in a fixed Float32Array ring buffer addressed by absolute sample
+// counters, so steady-state playback performs no allocation and no array
+// shifting on the audio thread.
+class PcmOutputProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.sourceSampleRate = 24000;
+    this.minBufferMs = 80;
+    this.capacity = 24000 * 30; // 30 seconds of queued audio
+    this.ring = new Float32Array(this.capacity);
+    this.writeCount = 0; // total samples enqueued, ever
+    this.readPos = 0; // fractional absolute read position
+    this.started = false;
+    this.underruns = 0;
+    this.drainedAt = null;
+    this.reportCounter = 0;
+
+    this.port.onmessage = (event) => {
+      const message = event.data || {};
+      if (message.type === "configure") {
+        this.sourceSampleRate = message.sourceSampleRate || 24000;
+        this.minBufferMs = message.minBufferMs || 80;
+      } else if (message.type === "enqueue") {
+        this.enqueue(new Int16Array(message.buffer));
+      } else if (message.type === "clear") {
+        this.readPos = this.writeCount;
+        this.started = false;
+        this.drainedAt = null;
+      }
+    };
+  }
+
+  enqueue(pcm) {
+    for (let index = 0; index < pcm.length; index++) {
+      this.ring[this.writeCount % this.capacity] = pcm[index] / 32768;
+      this.writeCount++;
+    }
+    if (this.writeCount - this.readPos > this.capacity) {
+      this.readPos = this.writeCount - this.capacity;
+    }
+
+    // Audio arriving shortly after the buffer drained means the drain was a
+    // genuine underrun (the provider was mid-utterance), not the natural end
+    // of an utterance.
+    if (!this.started && this.drainedAt != null && currentTime - this.drainedAt < 0.25) {
+      this.underruns++;
+      this.drainedAt = null;
+    }
+    if (!this.started && this.queuedMs() >= this.minBufferMs) {
+      this.started = true;
+      this.drainedAt = null;
+    }
+  }
+
+  process(_inputs, outputs) {
+    const output = outputs[0];
+    const channelCount = output ? output.length : 0;
+    if (!output || channelCount === 0) return true;
+
+    const frameCount = output[0].length;
+    const ratio = this.sourceSampleRate / sampleRate;
+
+    for (let frame = 0; frame < frameCount; frame++) {
+      let value = 0;
+      if (this.started && this.readPos < this.writeCount) {
+        const leftIndex = Math.floor(this.readPos);
+        const fraction = this.readPos - leftIndex;
+        const left = this.ring[leftIndex % this.capacity] || 0;
+        const right =
+          leftIndex + 1 < this.writeCount ? this.ring[(leftIndex + 1) % this.capacity] : left;
+        value = left + (right - left) * fraction;
+        this.readPos += ratio;
+      }
+      for (let channel = 0; channel < channelCount; channel++) {
+        output[channel][frame] = value;
+      }
+    }
+
+    if (this.started && this.readPos >= this.writeCount) {
+      this.readPos = this.writeCount;
+      this.started = false;
+      this.drainedAt = currentTime;
+    }
+
+    this.reportCounter++;
+    if (this.reportCounter >= 30) {
+      this.reportCounter = 0;
+      this.port.postMessage({
+        type: "status",
+        queuedMs: Math.round(this.queuedMs()),
+        underruns: this.underruns,
+      });
+    }
+
+    return true;
+  }
+
+  queuedMs() {
+    return (Math.max(0, this.writeCount - this.readPos) / this.sourceSampleRate) * 1000;
+  }
+}
+
+registerProcessor("pcm-output-processor", PcmOutputProcessor);

--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   GitBranch,
   KeyRound,
   LogOut,
+  Mic,
   Plug,
   Plus,
   Radio,
@@ -582,6 +583,7 @@ type ProjectStreamNavItemConfig = {
   streamPath: StreamPathType;
   to:
     | "/projects/$projectSlug/agents"
+    | "/projects/$projectSlug/voice-agents"
     | "/projects/$projectSlug/integrations"
     | "/projects/$projectSlug/secrets"
     | "/projects/$projectSlug/repos"
@@ -595,6 +597,13 @@ const PROJECT_STREAM_NAV_ITEMS: readonly ProjectStreamNavItemConfig[] = [
     label: "/agents",
     streamPath: StreamPath.parse("/agents"),
     to: "/projects/$projectSlug/agents",
+  },
+  {
+    fuzzy: true,
+    icon: Mic,
+    label: "/agents/voice",
+    streamPath: StreamPath.parse("/agents/voice"),
+    to: "/projects/$projectSlug/voice-agents",
   },
   {
     fuzzy: false,

--- a/apps/os/src/components/voice-agent-console.tsx
+++ b/apps/os/src/components/voice-agent-console.tsx
@@ -74,6 +74,9 @@ export function VoiceAgentConsole({
   const outputSequenceRef = useRef(0);
   // Stream offsets are monotonic, so one number replaces an ever-growing Set.
   const lastPlayedOffsetRef = useRef(0);
+  // Serializes speaker enqueues so bursts of provider deltas can never reorder
+  // while the output AudioContext is still being created.
+  const playbackChainRef = useRef<Promise<void>>(Promise.resolve());
   const inputAudioContextRef = useRef<AudioContext | null>(null);
   const inputNodeRef = useRef<AudioWorkletNode | null>(null);
   const inputMonitorRef = useRef<GainNode | null>(null);
@@ -141,9 +144,12 @@ export function VoiceAgentConsole({
     if (event.type === VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE) {
       // Playback must never block the subscription loop: a suspended
       // AudioContext can keep resume() pending until a user gesture arrives.
-      void playOutputEvent(event).catch((error) => {
-        setLastError(error instanceof Error ? error.message : String(error));
-      });
+      // One failed frame must not reject the chain and stall later frames.
+      playbackChainRef.current = playbackChainRef.current
+        .then(() => playOutputEvent(event))
+        .catch((error) => {
+          setLastError(error instanceof Error ? error.message : String(error));
+        });
       return;
     }
     if (event.type === VOICE_AGENT_PROVIDER_CONNECTED_EVENT_TYPE) {
@@ -265,7 +271,6 @@ export function VoiceAgentConsole({
 
   async function playOutputEvent(event: StreamEvent) {
     if (event.offset <= lastPlayedOffsetRef.current) return;
-    lastPlayedOffsetRef.current = event.offset;
 
     const payload = parseAudioPayload(event.payload);
     if (!payload || payload.sampleRate !== VOICE_AGENT_OUTPUT_SAMPLE_RATE) return;
@@ -273,6 +278,9 @@ export function VoiceAgentConsole({
     const node = await ensureOutputAudio();
     const buffer = base64ToArrayBuffer(payload.dataBase64);
     node.port.postMessage({ type: "enqueue", buffer }, [buffer]);
+    // Marked only after a successful enqueue: a transient audio-context
+    // failure leaves the offset unplayed instead of silently skipped.
+    lastPlayedOffsetRef.current = event.offset;
     setOutputStats((stats) => ({
       frames: stats.frames + 1,
       bytes: stats.bytes + buffer.byteLength,
@@ -370,7 +378,10 @@ export function VoiceAgentConsole({
   }
 
   // Single in-flight uploader: whatever accumulated while the previous request
-  // was on the wire goes out as one batch, so latency stays bounded.
+  // was on the wire goes out as one batch, so latency stays bounded. A failed
+  // batch is dropped rather than retried — replaying stale mic audio would add
+  // latency and confuse the provider's turn detection — but the drop is
+  // counted so it shows in the metrics.
   async function flushInputFrames() {
     if (inputFlushInFlightRef.current) return;
     inputFlushInFlightRef.current = true;
@@ -380,11 +391,15 @@ export function VoiceAgentConsole({
           0,
           pendingInputEventsRef.current.length,
         );
-        const itx = await connectItxBrowser({ projectId });
-        await itx.streams.get(streamPath).append(...events);
+        try {
+          const itx = await connectItxBrowser({ projectId });
+          await itx.streams.get(streamPath).append(...events);
+        } catch (error) {
+          setDroppedInputFrames((count) => count + events.length);
+          setLastError(error instanceof Error ? error.message : String(error));
+          return;
+        }
       }
-    } catch (error) {
-      setLastError(error instanceof Error ? error.message : String(error));
     } finally {
       inputFlushInFlightRef.current = false;
     }

--- a/apps/os/src/components/voice-agent-console.tsx
+++ b/apps/os/src/components/voice-agent-console.tsx
@@ -1,0 +1,738 @@
+import { useEffect, useRef, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { Activity, Mic, Play, Square, Volume2, Waves } from "lucide-react";
+import { Button } from "@iterate-com/ui/components/button";
+import { Input } from "@iterate-com/ui/components/input";
+import { Switch } from "@iterate-com/ui/components/switch";
+import type { StreamEvent, StreamEventInput } from "~/types.ts";
+import {
+  VOICE_AGENT_ERROR_OCCURRED_EVENT_TYPE,
+  VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_INPUT_SAMPLE_RATE,
+  VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_OUTPUT_SAMPLE_RATE,
+  VOICE_AGENT_PROVIDER_CONNECTED_EVENT_TYPE,
+  VOICE_AGENT_PROVIDER_SESSION_READY_EVENT_TYPE,
+  VOICE_AGENT_PROVIDER_STATUS_CHANGED_EVENT_TYPE,
+  VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
+} from "~/domains/agents/voice-agent-processor-contract.ts";
+import { connectItxBrowser, useItxEffect } from "~/itx/itx-react.tsx";
+import { streamPathToSplat } from "~/lib/stream-links.ts";
+
+const CHANNELS = 1;
+const INPUT_CHUNK_MS = 100;
+const OUTPUT_MIN_BUFFER_MS = 80;
+const OUTPUT_TONE_CHUNK_MS = 40;
+// Bounded mic upload queue: if append round trips fall behind realtime, drop the
+// oldest frames instead of growing voice latency for the rest of the session.
+const MAX_PENDING_INPUT_FRAMES = 20;
+
+type VoiceAudioFramePayload = {
+  streamId: string;
+  sequence: number;
+  encoding: "pcm_s16le";
+  sampleRate: number;
+  channels: number;
+  durationMs: number;
+  dataBase64: string;
+};
+
+type AudioStats = {
+  frames: number;
+  bytes: number;
+};
+
+function providerLabel(provider: unknown): string {
+  if (provider === "gemini-live") return "Gemini";
+  if (provider === "openai-realtime") return "OpenAI";
+  if (provider === "grok-realtime") return "Grok";
+  return "Provider";
+}
+
+type TranscriptLine = {
+  id: number;
+  direction: "input" | "output";
+  text: string;
+};
+
+export function VoiceAgentConsole({
+  projectId,
+  projectSlug,
+  streamPath,
+  title,
+}: {
+  projectId: string;
+  projectSlug: string;
+  streamPath: string;
+  title: string;
+}) {
+  const streamIdRef = useRef(crypto.randomUUID());
+  const pendingInputEventsRef = useRef<StreamEventInput[]>([]);
+  const inputFlushInFlightRef = useRef(false);
+  const inputSequenceRef = useRef(0);
+  const outputSequenceRef = useRef(0);
+  // Stream offsets are monotonic, so one number replaces an ever-growing Set.
+  const lastPlayedOffsetRef = useRef(0);
+  const inputAudioContextRef = useRef<AudioContext | null>(null);
+  const inputNodeRef = useRef<AudioWorkletNode | null>(null);
+  const inputMonitorRef = useRef<GainNode | null>(null);
+  const micStreamRef = useRef<MediaStream | null>(null);
+  const outputAudioContextRef = useRef<AudioContext | null>(null);
+  const outputNodeRef = useRef<AudioWorkletNode | null>(null);
+  const outputNodePromiseRef = useRef<Promise<AudioWorkletNode> | null>(null);
+
+  const [streamStatus, setStreamStatus] = useState<"connecting" | "live" | "error">("connecting");
+  const [captureStatus, setCaptureStatus] = useState<"idle" | "starting" | "capturing">("idle");
+  const [playbackReady, setPlaybackReady] = useState(false);
+  const [echoCancellation, setEchoCancellation] = useState(true);
+  const [noiseSuppression, setNoiseSuppression] = useState(true);
+  const [autoGainControl, setAutoGainControl] = useState(true);
+  const [toneSeconds, setToneSeconds] = useState(1);
+  const [inputStats, setInputStats] = useState<AudioStats>({ frames: 0, bytes: 0 });
+  const [droppedInputFrames, setDroppedInputFrames] = useState(0);
+  const [outputStats, setOutputStats] = useState<AudioStats>({ frames: 0, bytes: 0 });
+  const [outputQueueMs, setOutputQueueMs] = useState(0);
+  const [outputUnderruns, setOutputUnderruns] = useState(0);
+  const [lastError, setLastError] = useState<string | null>(null);
+  const [providerStatus, setProviderStatus] = useState("Waiting for audio");
+  const [transcriptLines, setTranscriptLines] = useState<TranscriptLine[]>([]);
+
+  // Live subscription from "now": voice sessions never replay stored audio.
+  // useItxEffect re-runs after a socket reconnect, re-subscribing live.
+  useItxEffect(
+    async (itx) => {
+      setStreamStatus("connecting");
+      try {
+        const subscription = await itx.streams.get(streamPath).subscribe({
+          processEventBatch: (batch) => {
+            for (const event of batch.events) {
+              // One malformed or unplayable event must not kill the subscription.
+              try {
+                handleStreamEvent(event);
+              } catch (error) {
+                setLastError(error instanceof Error ? error.message : String(error));
+              }
+            }
+          },
+        });
+        setStreamStatus("live");
+        return () => {
+          setStreamStatus("connecting");
+          subscription.unsubscribe();
+        };
+      } catch (error) {
+        setStreamStatus("error");
+        setLastError(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [streamPath],
+  );
+
+  useEffect(() => {
+    return () => {
+      stopCapture();
+      closeOutputAudio();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- unmount-only audio teardown
+  }, []);
+
+  function handleStreamEvent(event: StreamEvent) {
+    if (event.type === VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE) {
+      // Playback must never block the subscription loop: a suspended
+      // AudioContext can keep resume() pending until a user gesture arrives.
+      void playOutputEvent(event).catch((error) => {
+        setLastError(error instanceof Error ? error.message : String(error));
+      });
+      return;
+    }
+    if (event.type === VOICE_AGENT_PROVIDER_CONNECTED_EVENT_TYPE) {
+      const payload = event.payload as { provider?: unknown };
+      setProviderStatus(`${providerLabel(payload.provider)} connected`);
+      return;
+    }
+    if (event.type === VOICE_AGENT_PROVIDER_SESSION_READY_EVENT_TYPE) {
+      const payload = event.payload as { provider?: unknown };
+      setProviderStatus(`${providerLabel(payload.provider)} ready`);
+      return;
+    }
+    if (event.type === VOICE_AGENT_PROVIDER_STATUS_CHANGED_EVENT_TYPE) {
+      const payload = event.payload as { provider?: unknown; status?: unknown };
+      const label = providerLabel(payload.provider);
+      if (payload.status === "output-interrupted") setProviderStatus(`${label} interrupted`);
+      else if (payload.status === "turn-completed" || payload.status === "response-done") {
+        setProviderStatus("Turn complete");
+      } else if (payload.status === "going-away") {
+        setProviderStatus(`${label} session ending soon`);
+      } else if (payload.status === "speech-started") setProviderStatus("Listening…");
+      else if (payload.status === "speech-stopped") setProviderStatus("Thinking…");
+      return;
+    }
+    if (event.type === VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE) {
+      clearPlayback();
+      setProviderStatus("Speaker buffer cleared");
+      return;
+    }
+    if (event.type === VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE) {
+      const payload = event.payload as { source?: unknown; text?: unknown };
+      if (typeof payload.text === "string") {
+        appendTranscriptLine({
+          direction: payload.source === "input-transcription" ? "input" : "output",
+          eventOffset: event.offset,
+          text: payload.text,
+        });
+      }
+      return;
+    }
+    if (event.type === VOICE_AGENT_ERROR_OCCURRED_EVENT_TYPE) {
+      const payload = event.payload as { message?: unknown };
+      setLastError(typeof payload.message === "string" ? payload.message : "Voice agent error");
+    }
+  }
+
+  function appendTranscriptLine(input: {
+    direction: TranscriptLine["direction"];
+    eventOffset: number;
+    text: string;
+  }) {
+    setTranscriptLines((current) => {
+      const lastLine = current.at(-1);
+      if (lastLine?.direction === input.direction) {
+        return [
+          ...current.slice(0, -1),
+          {
+            ...lastLine,
+            text: `${lastLine.text}${input.text}`,
+          },
+        ];
+      }
+
+      return [
+        ...current,
+        {
+          id: input.eventOffset,
+          direction: input.direction,
+          text: input.text,
+        },
+      ];
+    });
+  }
+
+  async function ensureOutputAudio() {
+    if (outputAudioContextRef.current && outputNodeRef.current) {
+      if (outputAudioContextRef.current.state !== "running") {
+        // Never await resume(): without a user gesture the promise can stay
+        // pending forever under autoplay policy. The worklet buffers messages
+        // posted to a suspended context, so playback starts once it resumes.
+        void outputAudioContextRef.current.resume().catch(() => {});
+      }
+      return outputNodeRef.current;
+    }
+
+    // Concurrent callers (output frames arrive in bursts) must share one context.
+    outputNodePromiseRef.current ??= (async () => {
+      const context = new AudioContext();
+      await context.audioWorklet.addModule("/voice-agent/output-worklet.js");
+      const node = new AudioWorkletNode(context, "pcm-output-processor", {
+        numberOfInputs: 0,
+        numberOfOutputs: 1,
+        outputChannelCount: [1],
+      });
+      node.port.postMessage({
+        type: "configure",
+        minBufferMs: OUTPUT_MIN_BUFFER_MS,
+        sourceSampleRate: VOICE_AGENT_OUTPUT_SAMPLE_RATE,
+      });
+      node.port.onmessage = (event) => {
+        if (event.data?.type === "status") {
+          setOutputQueueMs(event.data.queuedMs ?? 0);
+          setOutputUnderruns(event.data.underruns ?? 0);
+        }
+      };
+      node.connect(context.destination);
+      outputAudioContextRef.current = context;
+      outputNodeRef.current = node;
+      setPlaybackReady(true);
+      return node;
+    })();
+    try {
+      return await outputNodePromiseRef.current;
+    } catch (error) {
+      outputNodePromiseRef.current = null;
+      throw error;
+    }
+  }
+
+  async function playOutputEvent(event: StreamEvent) {
+    if (event.offset <= lastPlayedOffsetRef.current) return;
+    lastPlayedOffsetRef.current = event.offset;
+
+    const payload = parseAudioPayload(event.payload);
+    if (!payload || payload.sampleRate !== VOICE_AGENT_OUTPUT_SAMPLE_RATE) return;
+
+    const node = await ensureOutputAudio();
+    const buffer = base64ToArrayBuffer(payload.dataBase64);
+    node.port.postMessage({ type: "enqueue", buffer }, [buffer]);
+    setOutputStats((stats) => ({
+      frames: stats.frames + 1,
+      bytes: stats.bytes + buffer.byteLength,
+    }));
+  }
+
+  async function startCapture() {
+    if (captureStatus !== "idle") return;
+    setCaptureStatus("starting");
+    setLastError(null);
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          echoCancellation,
+          noiseSuppression,
+          autoGainControl,
+        },
+      });
+      const context = new AudioContext();
+      await context.audioWorklet.addModule("/voice-agent/input-worklet.js");
+      const source = context.createMediaStreamSource(stream);
+      const node = new AudioWorkletNode(context, "pcm-input-processor", {
+        numberOfInputs: 1,
+        numberOfOutputs: 1,
+        outputChannelCount: [1],
+      });
+      const monitor = context.createGain();
+      monitor.gain.value = 0;
+      node.port.postMessage({
+        type: "configure",
+        targetSampleRate: VOICE_AGENT_INPUT_SAMPLE_RATE,
+        chunkMs: INPUT_CHUNK_MS,
+      });
+      node.port.onmessage = (event) => {
+        if (event.data?.type !== "pcm" || !(event.data.buffer instanceof ArrayBuffer)) {
+          return;
+        }
+        appendInputFrame(event.data.buffer, event.data.samples ?? 0);
+      };
+      source.connect(node);
+      node.connect(monitor);
+      monitor.connect(context.destination);
+      node.port.postMessage({ type: "set-enabled", enabled: true });
+
+      micStreamRef.current = stream;
+      inputAudioContextRef.current = context;
+      inputNodeRef.current = node;
+      inputMonitorRef.current = monitor;
+      setCaptureStatus("capturing");
+    } catch (error) {
+      setCaptureStatus("idle");
+      setLastError(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  function stopCapture() {
+    inputNodeRef.current?.port.postMessage({ type: "set-enabled", enabled: false });
+    inputNodeRef.current?.disconnect();
+    inputNodeRef.current = null;
+    inputMonitorRef.current?.disconnect();
+    inputMonitorRef.current = null;
+    void inputAudioContextRef.current?.close();
+    inputAudioContextRef.current = null;
+    micStreamRef.current?.getTracks().forEach((track) => track.stop());
+    micStreamRef.current = null;
+    setCaptureStatus("idle");
+  }
+
+  function appendInputFrame(buffer: ArrayBuffer, sampleCount: number) {
+    const sequence = inputSequenceRef.current++;
+    const event = audioFrameEvent({
+      type: VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+      streamId: streamIdRef.current,
+      sequence,
+      sampleRate: VOICE_AGENT_INPUT_SAMPLE_RATE,
+      durationMs: Math.round((sampleCount / VOICE_AGENT_INPUT_SAMPLE_RATE) * 1000),
+      buffer,
+    });
+
+    setInputStats((stats) => ({
+      frames: stats.frames + 1,
+      bytes: stats.bytes + buffer.byteLength,
+    }));
+
+    const pending = pendingInputEventsRef.current;
+    pending.push(event);
+    if (pending.length > MAX_PENDING_INPUT_FRAMES) {
+      const dropped = pending.length - MAX_PENDING_INPUT_FRAMES;
+      pending.splice(0, dropped);
+      setDroppedInputFrames((count) => count + dropped);
+    }
+    void flushInputFrames();
+  }
+
+  // Single in-flight uploader: whatever accumulated while the previous request
+  // was on the wire goes out as one batch, so latency stays bounded.
+  async function flushInputFrames() {
+    if (inputFlushInFlightRef.current) return;
+    inputFlushInFlightRef.current = true;
+    try {
+      while (pendingInputEventsRef.current.length > 0) {
+        const events = pendingInputEventsRef.current.splice(
+          0,
+          pendingInputEventsRef.current.length,
+        );
+        const itx = await connectItxBrowser({ projectId });
+        await itx.streams.get(streamPath).append(...events);
+      }
+    } catch (error) {
+      setLastError(error instanceof Error ? error.message : String(error));
+    } finally {
+      inputFlushInFlightRef.current = false;
+    }
+  }
+
+  async function appendTone() {
+    setLastError(null);
+    await ensureOutputAudio();
+    const events = createToneEvents({
+      seconds: toneSeconds,
+      streamId: streamIdRef.current,
+      startSequence: outputSequenceRef.current,
+    });
+    outputSequenceRef.current += events.length;
+
+    try {
+      const itx = await connectItxBrowser({ projectId });
+      await itx.streams.get(streamPath).append(...events);
+    } catch (error) {
+      setLastError(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  function clearPlayback() {
+    outputNodeRef.current?.port.postMessage({ type: "clear" });
+    setOutputQueueMs(0);
+    setOutputUnderruns(0);
+  }
+
+  function closeOutputAudio() {
+    outputNodeRef.current?.disconnect();
+    outputNodeRef.current = null;
+    void outputAudioContextRef.current?.close();
+    outputAudioContextRef.current = null;
+    outputNodePromiseRef.current = null;
+    setPlaybackReady(false);
+  }
+
+  const canCapture = typeof navigator !== "undefined" && !!navigator.mediaDevices?.getUserMedia;
+
+  return (
+    <section className="flex min-h-0 flex-1 flex-col overflow-auto">
+      <div className="border-b px-4 py-3">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="min-w-0">
+            <h1 className="text-base font-semibold">{title}</h1>
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+              <span>{providerStatus}</span>
+              <Link
+                className="font-medium text-foreground underline-offset-4 hover:underline"
+                to="/projects/$projectSlug/streams/$"
+                params={{ projectSlug, _splat: streamPathToSplat(streamPath) }}
+              >
+                {streamPath}
+              </Link>
+              <span>{streamStatusLabel(streamStatus)}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 p-4 xl:grid-cols-[minmax(0,1fr)_minmax(24rem,34rem)]">
+        <main className="space-y-4">
+          <section className="rounded-lg border bg-background">
+            <div className="flex flex-col gap-3 border-b p-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-sm font-semibold">Output playback</h2>
+                <p className="text-sm text-muted-foreground">
+                  Plays 24 kHz PCM output only after the stream delivers frame events.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button type="button" variant="outline" onClick={() => void ensureOutputAudio()}>
+                  <Volume2 />
+                  Enable speaker
+                </Button>
+                <Button type="button" variant="outline" onClick={() => void appendTone()}>
+                  <Play />
+                  Inject tone
+                </Button>
+                <Button type="button" variant="outline" onClick={clearPlayback}>
+                  <Square />
+                  Clear buffer
+                </Button>
+              </div>
+            </div>
+            <div className="grid gap-3 p-4 md:grid-cols-5">
+              <Metric label="Playback" value={playbackReady ? "Ready" : "Idle"} />
+              <Metric label="Output frames" value={String(outputStats.frames)} />
+              <Metric label="Output bytes" value={formatBytes(outputStats.bytes)} />
+              <Metric label="Queued" value={`${outputQueueMs} ms`} />
+              <Metric label="Underruns" value={String(outputUnderruns)} />
+            </div>
+            <div className="flex items-center gap-3 border-t p-4">
+              <label className="text-sm font-medium" htmlFor="tone-seconds">
+                Tone seconds
+              </label>
+              <Input
+                id="tone-seconds"
+                className="h-9 w-24"
+                type="number"
+                min={0.2}
+                max={5}
+                step={0.1}
+                value={toneSeconds}
+                onChange={(event) => setToneSeconds(Number(event.currentTarget.value))}
+              />
+            </div>
+          </section>
+
+          <section className="rounded-lg border bg-background">
+            <div className="flex flex-col gap-3 border-b p-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-sm font-semibold">Microphone input</h2>
+                <p className="text-sm text-muted-foreground">
+                  Captures browser mic audio as 16 kHz PCM and appends each chunk to the stream.
+                </p>
+              </div>
+              <div className="flex gap-2">
+                {captureStatus === "capturing" ? (
+                  <Button type="button" variant="outline" onClick={stopCapture}>
+                    <Square />
+                    Stop mic
+                  </Button>
+                ) : (
+                  <Button
+                    type="button"
+                    disabled={!canCapture || captureStatus === "starting"}
+                    onClick={() => void startCapture()}
+                  >
+                    <Mic />
+                    {captureStatus === "starting" ? "Starting..." : "Start mic"}
+                  </Button>
+                )}
+              </div>
+            </div>
+            <div className="grid gap-3 p-4 md:grid-cols-4">
+              <Metric label="Capture" value={captureStatusLabel(captureStatus)} />
+              <Metric label="Input frames" value={String(inputStats.frames)} />
+              <Metric label="Input bytes" value={formatBytes(inputStats.bytes)} />
+              <Metric label="Dropped" value={String(droppedInputFrames)} />
+            </div>
+            <div className="grid gap-3 border-t p-4 md:grid-cols-3">
+              <ToggleRow
+                checked={echoCancellation}
+                label="Echo cancellation"
+                onCheckedChange={setEchoCancellation}
+              />
+              <ToggleRow
+                checked={noiseSuppression}
+                label="Noise suppression"
+                onCheckedChange={setNoiseSuppression}
+              />
+              <ToggleRow
+                checked={autoGainControl}
+                label="Auto gain"
+                onCheckedChange={setAutoGainControl}
+              />
+            </div>
+          </section>
+        </main>
+
+        <aside className="space-y-4">
+          <section className="min-h-[24rem] rounded-lg border bg-background p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Activity className="size-4" />
+              <h2 className="text-sm font-semibold">Status</h2>
+            </div>
+            <div className="space-y-4 text-sm">
+              <p className="text-muted-foreground">{providerStatus}</p>
+              {transcriptLines.length > 0 ? (
+                <div className="space-y-3">
+                  {transcriptLines.map((line) => (
+                    <div key={line.id} className="rounded-md border bg-muted/30 p-3">
+                      <div className="mb-1 text-xs font-medium text-muted-foreground">
+                        {line.direction === "input" ? "You" : "Agent"}
+                      </div>
+                      <p className="whitespace-pre-wrap text-foreground">{line.text}</p>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+              {lastError ? <p className="text-destructive">{lastError}</p> : null}
+            </div>
+          </section>
+
+          <section className="rounded-lg border bg-background p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Waves className="size-4" />
+              <h2 className="text-sm font-semibold">Frame contract</h2>
+            </div>
+            <dl className="space-y-3 text-sm">
+              <KeyValue label="Input" value="pcm_s16le mono, 16 kHz" />
+              <KeyValue label="Output" value="pcm_s16le mono, 24 kHz" />
+              <KeyValue label="Chunking" value="100 ms input, provider-sized output" />
+              <KeyValue label="Stream ID" value={streamIdRef.current} />
+            </dl>
+          </section>
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border bg-muted/30 px-3 py-2">
+      <div className="text-xs font-medium text-muted-foreground">{label}</div>
+      <div className="mt-1 font-mono text-sm">{value}</div>
+    </div>
+  );
+}
+
+function KeyValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
+      <dd className="mt-1 break-all font-mono text-xs text-foreground">{value}</dd>
+    </div>
+  );
+}
+
+function ToggleRow({
+  checked,
+  label,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  label: string;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className="flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-sm">
+      <span>{label}</span>
+      <Switch checked={checked} onCheckedChange={onCheckedChange} />
+    </label>
+  );
+}
+
+function audioFrameEvent(input: {
+  buffer: ArrayBuffer;
+  durationMs: number;
+  sampleRate: number;
+  sequence: number;
+  streamId: string;
+  type:
+    | typeof VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE
+    | typeof VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE;
+}): StreamEventInput {
+  const payload: VoiceAudioFramePayload = {
+    channels: CHANNELS,
+    dataBase64: arrayBufferToBase64(input.buffer),
+    durationMs: input.durationMs,
+    encoding: "pcm_s16le",
+    sampleRate: input.sampleRate,
+    sequence: input.sequence,
+    streamId: input.streamId,
+  };
+
+  return {
+    type: input.type,
+    payload,
+  };
+}
+
+function createToneEvents(input: {
+  seconds: number;
+  startSequence: number;
+  streamId: string;
+}): StreamEventInput[] {
+  const seconds = Math.min(5, Math.max(0.2, input.seconds || 1));
+  const frameSamples = Math.round((VOICE_AGENT_OUTPUT_SAMPLE_RATE * OUTPUT_TONE_CHUNK_MS) / 1000);
+  const totalSamples = Math.round(VOICE_AGENT_OUTPUT_SAMPLE_RATE * seconds);
+  const events: StreamEventInput[] = [];
+  let sequence = input.startSequence;
+
+  for (let start = 0; start < totalSamples; start += frameSamples) {
+    const sampleCount = Math.min(frameSamples, totalSamples - start);
+    const pcm = new Int16Array(sampleCount);
+    for (let index = 0; index < sampleCount; index++) {
+      const sampleIndex = start + index;
+      const envelope = Math.min(1, sampleIndex / 480, (totalSamples - sampleIndex) / 480);
+      const value = Math.sin((2 * Math.PI * 440 * sampleIndex) / VOICE_AGENT_OUTPUT_SAMPLE_RATE);
+      pcm[index] = Math.round(value * envelope * 12000);
+    }
+    events.push(
+      audioFrameEvent({
+        buffer: pcm.buffer.slice(0),
+        durationMs: Math.round((sampleCount / VOICE_AGENT_OUTPUT_SAMPLE_RATE) * 1000),
+        sampleRate: VOICE_AGENT_OUTPUT_SAMPLE_RATE,
+        sequence,
+        streamId: input.streamId,
+        type: VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+      }),
+    );
+    sequence++;
+  }
+
+  return events;
+}
+
+function parseAudioPayload(payload: unknown): VoiceAudioFramePayload | null {
+  if (payload == null || typeof payload !== "object") return null;
+  const value = payload as Partial<VoiceAudioFramePayload>;
+  if (
+    value.encoding !== "pcm_s16le" ||
+    typeof value.dataBase64 !== "string" ||
+    typeof value.sampleRate !== "number" ||
+    typeof value.sequence !== "number"
+  ) {
+    return null;
+  }
+  return value as VoiceAudioFramePayload;
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize));
+  }
+  return btoa(binary);
+}
+
+function base64ToArrayBuffer(value: string) {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index++) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes.buffer;
+}
+
+function formatBytes(value: number) {
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`;
+  return `${(value / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function streamStatusLabel(status: "connecting" | "live" | "error") {
+  if (status === "connecting") return "Connecting";
+  if (status === "live") return "Live";
+  return "Stream error";
+}
+
+function captureStatusLabel(status: "idle" | "starting" | "capturing") {
+  if (status === "starting") return "Starting";
+  if (status === "capturing") return "Capturing";
+  return "Idle";
+}

--- a/apps/os/src/config.ts
+++ b/apps/os/src/config.ts
@@ -79,6 +79,10 @@ export const AppConfig = z.object({
     })
     .optional(),
   openAiApiKey: redacted(z.string().trim().min(1)),
+  /** Gemini API key for the voice-agent processor's Gemini Live provider. */
+  geminiApiKey: redacted(z.string().trim().min(1)).optional(),
+  /** xAI API key for the voice-agent processor's Grok Realtime provider. */
+  xAiApiKey: redacted(z.string().trim().min(1)).optional(),
   cloudflare: z
     .object({
       apiToken: redacted(z.string().trim().min(1)).optional(),

--- a/apps/os/src/domains/agents/agent-durable-object.ts
+++ b/apps/os/src/domains/agents/agent-durable-object.ts
@@ -16,7 +16,14 @@ import { CloudflareAiProcessorContract } from "./cloudflare-ai-processor-contrac
 import { CloudflareAiProcessor } from "./cloudflare-ai-processor-implementation.ts";
 import { OpenAiWsProcessorContract } from "./openai-ws-processor-contract.ts";
 import { OpenAiWsProcessor } from "./openai-ws-processor-implementation.ts";
-import { parseAgentDurableObjectName, readOpenAiApiKeyFromAppConfig } from "./utils.ts";
+import { VoiceAgentProcessorContract } from "./voice-agent-processor-contract.ts";
+import { VoiceAgentProcessor } from "./voice-agent-processor-implementation.ts";
+import {
+  parseAgentDurableObjectName,
+  readGeminiApiKeyFromAppConfig,
+  readOpenAiApiKeyFromAppConfig,
+  readXAiApiKeyFromAppConfig,
+} from "./utils.ts";
 
 export class AgentDurableObject extends DurableObject<Env> {
   readonly #name = parseAgentDurableObjectName(this.ctx.id.name!);
@@ -50,6 +57,21 @@ export class AgentDurableObject extends DurableObject<Env> {
         ...deps,
         apiKey: readOpenAiApiKeyFromAppConfig(this.env),
         readStreamEvents: () => this.#stream.getEvents(),
+      }),
+  );
+
+  // Registered on every agent host; it only wakes on voice agent streams
+  // (`/agents/voice/**`) where the project processor configured its
+  // subscription. Registered without keys too: the processor then answers
+  // inputs with a clear error-occurred event instead of crashing the host.
+  readonly voiceAgentProcessor = this.#processorHost.add(
+    VoiceAgentProcessorContract.slug,
+    (deps) =>
+      new VoiceAgentProcessor({
+        ...deps,
+        geminiApiKey: readGeminiApiKeyFromAppConfig(this.env),
+        openAiApiKey: readOpenAiApiKeyFromAppConfig(this.env),
+        xAiApiKey: readXAiApiKeyFromAppConfig(this.env),
       }),
   );
 

--- a/apps/os/src/domains/agents/utils.ts
+++ b/apps/os/src/domains/agents/utils.ts
@@ -34,3 +34,22 @@ export function readOpenAiApiKeyFromAppConfig(env: unknown): string | null {
     return null;
   }
 }
+
+/** Same non-throwing contract as the OpenAI reader, for the voice-agent providers. */
+export function readGeminiApiKeyFromAppConfig(env: unknown): string | null {
+  try {
+    const apiKey = parseConfig(env).geminiApiKey?.exposeSecret() ?? "";
+    return apiKey.trim() === "" ? null : apiKey;
+  } catch {
+    return null;
+  }
+}
+
+export function readXAiApiKeyFromAppConfig(env: unknown): string | null {
+  try {
+    const apiKey = parseConfig(env).xAiApiKey?.exposeSecret() ?? "";
+    return apiKey.trim() === "" ? null : apiKey;
+  } catch {
+    return null;
+  }
+}

--- a/apps/os/src/domains/agents/voice-agent-code-agent.ts
+++ b/apps/os/src/domains/agents/voice-agent-code-agent.ts
@@ -1,0 +1,34 @@
+// The code-agent half of the voice bridge. Agents under `/agents/voice/**`
+// share their stream with the voice-agent processor: the voice model's
+// messageAgent tool calls arrive as `agent/input-added` events, and the code
+// agent answers by appending `voice-agent/input-text-appended` facts that the
+// voice processor relays into the live call.
+
+import { DEFAULT_AGENT_SYSTEM_PROMPT } from "./agent-processor-contract.ts";
+import { VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE } from "./voice-agent-processor-contract.ts";
+
+export const VOICE_AGENT_PATH_PREFIX = "/agents/voice";
+
+export function isVoiceAgentPath(agentPath: string): boolean {
+  return (
+    agentPath === VOICE_AGENT_PATH_PREFIX || agentPath.startsWith(`${VOICE_AGENT_PATH_PREFIX}/`)
+  );
+}
+
+export const VOICE_AGENT_CODE_AGENT_SYSTEM_PROMPT = [
+  DEFAULT_AGENT_SYSTEM_PROMPT,
+  "",
+  "## Realtime voice operator support",
+  "You are supporting a realtime voice operator who is speaking with a human. The voice operator may ask you to investigate, calculate, fetch, edit files, or run code on behalf of that human.",
+  "The voice operator is busy speaking and listening. Do not ask the voice operator to run code. Only you can run code.",
+  "When you need to respond to the voice operator, append an authoritative voice-agent text input event on your own agent stream from a script:",
+  "```js",
+  "async (itx) => {",
+  `  await itx.agent.stream.append({ type: "${VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE}", payload: { text: "Concise speakable response for the voice operator.", source: "code-agent" } });`,
+  "}",
+  "```",
+  "The text you append should be the exact human-facing thing the voice operator should say next, not private commentary about what you are doing.",
+  "If you need more information before you can do the work, append a concise clarifying question for the voice operator to ask the human using that same event shape. For example: 'What occupation should I put on your profile?'",
+  "Do not use itx.chat.sendMessage for voice-agent responses. The realtime voice model cannot consume chat responses. It consumes the voice-agent text input events you append to the stream.",
+  "Keep voice-facing responses concise, directly speakable, and useful while the human is waiting.",
+].join("\n");

--- a/apps/os/src/domains/agents/voice-agent-processor-contract.ts
+++ b/apps/os/src/domains/agents/voice-agent-processor-contract.ts
@@ -51,7 +51,7 @@ export const VoiceAgentProvider = z.enum([
   VOICE_AGENT_PROVIDER_GROK_REALTIME,
 ]);
 
-export const VOICE_AGENT_PROVIDER_STATUSES = [
+const VOICE_AGENT_PROVIDER_STATUSES = [
   "speech-started",
   "speech-stopped",
   "output-audio-done",
@@ -235,7 +235,6 @@ export const VoiceAgentProcessorContract = defineProcessorContract({
   ],
 });
 
-export type VoiceAgentState = z.infer<typeof VoiceAgentProcessorContract.stateSchema>;
 export type VoiceAgentProvider = z.infer<typeof VoiceAgentProvider>;
 export type VoiceAgentSetup = z.infer<typeof VoiceAgentSetup>;
 export type VoiceAgentProviderStatus = z.infer<typeof VoiceAgentProviderStatus>;

--- a/apps/os/src/domains/agents/voice-agent-processor-contract.ts
+++ b/apps/os/src/domains/agents/voice-agent-processor-contract.ts
@@ -1,0 +1,241 @@
+import { z } from "zod";
+import { defineProcessorContract } from "../streams/stream-processor.ts";
+import { AgentProcessorContract } from "./agent-processor-contract.ts";
+
+export const VOICE_AGENT_PROVIDER_GEMINI_LIVE = "gemini-live" as const;
+export const VOICE_AGENT_PROVIDER_OPENAI_REALTIME = "openai-realtime" as const;
+export const VOICE_AGENT_PROVIDER_GROK_REALTIME = "grok-realtime" as const;
+
+export const DEFAULT_GEMINI_LIVE_MODEL = "gemini-3.1-flash-live-preview";
+export const DEFAULT_GEMINI_LIVE_VOICE = "Zephyr";
+export const DEFAULT_OPENAI_REALTIME_MODEL = "gpt-realtime-mini";
+export const DEFAULT_OPENAI_REALTIME_VOICE = "marin";
+export const DEFAULT_GROK_REALTIME_MODEL = "grok-voice-latest";
+export const DEFAULT_GROK_REALTIME_VOICE = "eve";
+export const DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION =
+  "You are a helpful realtime voice agent. Keep responses concise.";
+export const VOICE_AGENT_INPUT_SAMPLE_RATE = 16_000;
+export const VOICE_AGENT_OUTPUT_SAMPLE_RATE = 24_000;
+
+export const VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/setup-configured";
+export const VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/input-audio-frame-appended";
+export const VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/input-text-appended";
+export const VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/output-audio-frame-appended";
+export const VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/output-text-appended";
+export const VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/speaker-buffer-clear-requested";
+export const VOICE_AGENT_ERROR_OCCURRED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/error-occurred";
+export const VOICE_AGENT_PROVIDER_CONNECTED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/provider-connected";
+export const VOICE_AGENT_PROVIDER_DISCONNECTED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/provider-disconnected";
+export const VOICE_AGENT_PROVIDER_SESSION_READY_EVENT_TYPE =
+  "events.iterate.com/voice-agent/provider-session-ready";
+export const VOICE_AGENT_PROVIDER_MESSAGE_SENT_EVENT_TYPE =
+  "events.iterate.com/voice-agent/provider-message-sent";
+export const VOICE_AGENT_PROVIDER_MESSAGE_RECEIVED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/provider-message-received";
+export const VOICE_AGENT_PROVIDER_STATUS_CHANGED_EVENT_TYPE =
+  "events.iterate.com/voice-agent/provider-status-changed";
+export const AGENT_INPUT_ADDED_EVENT_TYPE = "events.iterate.com/agent/input-added";
+
+export const VoiceAgentProvider = z.enum([
+  VOICE_AGENT_PROVIDER_GEMINI_LIVE,
+  VOICE_AGENT_PROVIDER_OPENAI_REALTIME,
+  VOICE_AGENT_PROVIDER_GROK_REALTIME,
+]);
+
+export const VOICE_AGENT_PROVIDER_STATUSES = [
+  "speech-started",
+  "speech-stopped",
+  "output-audio-done",
+  "response-done",
+  "output-interrupted",
+  "turn-completed",
+  "going-away",
+] as const;
+
+const VoiceAgentProviderStatus = z.enum(VOICE_AGENT_PROVIDER_STATUSES);
+
+const VoiceAgentAudioFramePayload = z.object({
+  streamId: z.string().trim().min(1),
+  sequence: z.number().int().nonnegative(),
+  encoding: z.literal("pcm_s16le"),
+  sampleRate: z.number().int().positive(),
+  channels: z.literal(1),
+  durationMs: z.number().int().nonnegative(),
+  dataBase64: z.string().trim().min(1),
+});
+
+const VoiceAgentInputTextPayload = z.object({
+  text: z.string().trim().min(1),
+  source: z.string().trim().min(1).optional(),
+});
+
+const VoiceAgentOutputTextPayload = z.object({
+  connectionId: z.string().min(1).optional(),
+  text: z.string().trim().min(1),
+  source: z.enum(["input-transcription", "output-transcription", "provider-text"]).optional(),
+});
+
+const MessageAgentToolChoice = z.enum(["auto", "required"]).default("auto");
+
+function providerSetupSchema<const Provider extends string>(
+  provider: Provider,
+  defaults: { model: string; voiceName: string },
+) {
+  return z.object({
+    provider: z.literal(provider),
+    model: z.string().trim().min(1).default(defaults.model),
+    voiceName: z.string().trim().min(1).default(defaults.voiceName),
+    systemInstruction: z.string().default(DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION),
+    messageAgentToolChoice: MessageAgentToolChoice,
+  });
+}
+
+const VoiceAgentSetup = z.discriminatedUnion("provider", [
+  providerSetupSchema(VOICE_AGENT_PROVIDER_GEMINI_LIVE, {
+    model: DEFAULT_GEMINI_LIVE_MODEL,
+    voiceName: DEFAULT_GEMINI_LIVE_VOICE,
+  }),
+  providerSetupSchema(VOICE_AGENT_PROVIDER_OPENAI_REALTIME, {
+    model: DEFAULT_OPENAI_REALTIME_MODEL,
+    voiceName: DEFAULT_OPENAI_REALTIME_VOICE,
+  }),
+  providerSetupSchema(VOICE_AGENT_PROVIDER_GROK_REALTIME, {
+    model: DEFAULT_GROK_REALTIME_MODEL,
+    voiceName: DEFAULT_GROK_REALTIME_VOICE,
+  }),
+]);
+
+const ProviderConnectionPayload = z.object({
+  provider: VoiceAgentProvider,
+  connectionId: z.string().min(1),
+});
+
+export const VoiceAgentProcessorContract = defineProcessorContract({
+  slug: "voice-agent",
+  version: "0.3.0",
+  description:
+    "Forwards appended input PCM frames and text to the realtime voice provider selected by setup-configured (Gemini Live, OpenAI Realtime, or Grok Realtime) and appends returned output PCM frames back into the same stream. Bridges messageAgent tool calls to the colocated code agent.",
+  stateSchema: z.object({
+    setup: VoiceAgentSetup.nullable().default(null),
+  }),
+  processorDeps: [AgentProcessorContract],
+  events: {
+    [VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE]: {
+      description:
+        "Required voice-agent setup. Selects the realtime voice provider and provider-specific model/voice configuration before audio starts.",
+      payloadSchema: VoiceAgentSetup,
+    },
+    [VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE]: {
+      description: "One raw little-endian PCM16 mono microphone frame appended by a client.",
+      payloadSchema: VoiceAgentAudioFramePayload.extend({
+        sampleRate: z.literal(VOICE_AGENT_INPUT_SAMPLE_RATE),
+      }),
+    },
+    [VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE]: {
+      description:
+        "Authoritative text input/context to send to the selected realtime voice model. Voice clients should not speak this text directly.",
+      payloadSchema: VoiceAgentInputTextPayload,
+    },
+    [VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE]: {
+      description:
+        "One raw little-endian PCM16 mono speaker frame returned by the selected realtime voice provider.",
+      payloadSchema: VoiceAgentAudioFramePayload.extend({
+        sampleRate: z.literal(VOICE_AGENT_OUTPUT_SAMPLE_RATE),
+      }),
+    },
+    [VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE]: {
+      description:
+        "Text produced by the selected realtime voice provider, usually a transcript or diagnostic text.",
+      payloadSchema: VoiceAgentOutputTextPayload,
+    },
+    [VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE]: {
+      description:
+        "Provider-neutral command for subscribed voice clients to drop locally queued speaker audio.",
+      payloadSchema: ProviderConnectionPayload.extend({
+        reason: z.enum(["output-interrupted", "input-speech-started"]),
+      }),
+    },
+    [VOICE_AGENT_ERROR_OCCURRED_EVENT_TYPE]: {
+      description: "The voice-agent processor could not process or forward an input event.",
+      payloadSchema: z.object({
+        message: z.string().min(1),
+        sourceEventOffset: z.number().int().positive().optional(),
+      }),
+    },
+    [VOICE_AGENT_PROVIDER_CONNECTED_EVENT_TYPE]: {
+      description: "The processor opened a WebSocket to the selected realtime voice provider.",
+      payloadSchema: ProviderConnectionPayload.extend({
+        model: z.string().min(1),
+        url: z.url(),
+      }),
+    },
+    [VOICE_AGENT_PROVIDER_DISCONNECTED_EVENT_TYPE]: {
+      description: "The realtime voice provider WebSocket closed.",
+      payloadSchema: ProviderConnectionPayload.extend({
+        code: z.number().int().optional(),
+        reason: z.string().optional(),
+        wasClean: z.boolean().optional(),
+      }),
+    },
+    [VOICE_AGENT_PROVIDER_SESSION_READY_EVENT_TYPE]: {
+      description: "The realtime voice provider acknowledged session setup and is ready for audio.",
+      payloadSchema: ProviderConnectionPayload,
+    },
+    [VOICE_AGENT_PROVIDER_MESSAGE_SENT_EVENT_TYPE]: {
+      description:
+        "Audit copy of a JSON message sent to the provider. Large strings (audio payloads) are redacted.",
+      payloadSchema: ProviderConnectionPayload.extend({
+        sequence: z.number().int().nonnegative(),
+        sourceEventOffset: z.number().int().positive().optional(),
+        message: z.json(),
+      }),
+    },
+    [VOICE_AGENT_PROVIDER_MESSAGE_RECEIVED_EVENT_TYPE]: {
+      description:
+        "Audit copy of a JSON message received from the provider. Large strings (audio payloads) are redacted.",
+      payloadSchema: ProviderConnectionPayload.extend({
+        sequence: z.number().int().nonnegative(),
+        message: z.json(),
+      }),
+    },
+    [VOICE_AGENT_PROVIDER_STATUS_CHANGED_EVENT_TYPE]: {
+      description:
+        "Provider-neutral session status signal (speech start/stop, turn completion, interruption, imminent provider shutdown).",
+      payloadSchema: ProviderConnectionPayload.extend({
+        status: VoiceAgentProviderStatus,
+      }),
+    },
+  },
+  consumes: [
+    VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE,
+    VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+    VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
+  ],
+  emits: [
+    VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+    VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE,
+    VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
+    VOICE_AGENT_ERROR_OCCURRED_EVENT_TYPE,
+    VOICE_AGENT_PROVIDER_CONNECTED_EVENT_TYPE,
+    VOICE_AGENT_PROVIDER_DISCONNECTED_EVENT_TYPE,
+    VOICE_AGENT_PROVIDER_SESSION_READY_EVENT_TYPE,
+    VOICE_AGENT_PROVIDER_MESSAGE_SENT_EVENT_TYPE,
+    VOICE_AGENT_PROVIDER_MESSAGE_RECEIVED_EVENT_TYPE,
+    VOICE_AGENT_PROVIDER_STATUS_CHANGED_EVENT_TYPE,
+    AGENT_INPUT_ADDED_EVENT_TYPE,
+  ],
+});
+
+export type VoiceAgentState = z.infer<typeof VoiceAgentProcessorContract.stateSchema>;
+export type VoiceAgentProvider = z.infer<typeof VoiceAgentProvider>;
+export type VoiceAgentSetup = z.infer<typeof VoiceAgentSetup>;
+export type VoiceAgentProviderStatus = z.infer<typeof VoiceAgentProviderStatus>;

--- a/apps/os/src/domains/agents/voice-agent-processor-implementation.ts
+++ b/apps/os/src/domains/agents/voice-agent-processor-implementation.ts
@@ -71,6 +71,8 @@ type VoiceAgentProcessorDeps = {
 type ProviderConnection = {
   id: string;
   provider: VoiceAgentProvider;
+  /** JSON fingerprint of the setup this connection's session was configured with. */
+  setupKey: string;
   socket: WebSocket;
   urlForLog: string;
   ready: Promise<void>;
@@ -141,10 +143,13 @@ export class VoiceAgentProcessor extends StreamProcessor<
         // Frames must reach the provider socket in stream order, so forwarding
         // is serialized. Forwarding runs in the background: provider latency
         // must not hold up the processor checkpoint, and failures land on the
-        // stream as error events instead of failing the batch.
-        const task = (this.#sendChain = this.#sendChain.then(() =>
+        // stream as error events instead of failing the batch. The stored
+        // chain swallows rejections so one failed forward (e.g. a send on a
+        // just-closed socket) never wedges later inputs.
+        const task = this.#sendChain.then(() =>
           this.#forwardInputEvent({ event, setup: state.setup }),
-        ));
+        );
+        this.#sendChain = task.catch(() => undefined);
         runInBackground(() => task);
         return;
       }
@@ -191,33 +196,48 @@ export class VoiceAgentProcessor extends StreamProcessor<
       return;
     }
 
-    for (const message of buildInputMessages({ event, provider: connection.provider })) {
-      this.#sendProviderMessage({
-        connection,
-        message,
-        sourceEventOffset: event.offset,
-      });
+    try {
+      for (const message of buildInputMessages({ event, provider: connection.provider })) {
+        this.#sendProviderMessage({
+          connection,
+          message,
+          sourceEventOffset: event.offset,
+        });
+      }
+    } catch (error) {
+      await this.#appendInputError({ error, event });
     }
   }
 
   async #getConnection(setup: VoiceAgentSetup): Promise<ProviderConnection> {
+    // The fingerprint covers model/voice/system instruction, not just the
+    // provider: a setup change that keeps the provider must still re-dial so
+    // the session setup message reflects the new configuration.
+    const setupKey = JSON.stringify(setup);
     if (
-      this.#connection?.provider === setup.provider &&
+      this.#connection?.setupKey === setupKey &&
       this.#connection.socket.readyState === WEBSOCKET_OPEN
     ) {
       return this.#connection;
     }
     if (this.#openingConnection != null) {
-      return await this.#openingConnection;
+      // An in-flight dial may belong to an older setup (setup-configured can
+      // land while a forward is dialing); only adopt a fingerprint match.
+      const opening = await this.#openingConnection.catch(() => null);
+      if (opening?.setupKey === setupKey && opening.socket.readyState === WEBSOCKET_OPEN) {
+        return opening;
+      }
+      opening?.socket.close(1000, "Voice-agent setup changed during dial.");
     }
 
     this.#connection?.socket.close(1000, "Replacing stale voice-agent provider connection.");
-    this.#openingConnection = this.#openProviderConnection(setup);
+    const dial = this.#openProviderConnection(setup);
+    this.#openingConnection = dial;
     try {
-      this.#connection = await this.#openingConnection;
+      this.#connection = await dial;
       return this.#connection;
     } finally {
-      this.#openingConnection = null;
+      if (this.#openingConnection === dial) this.#openingConnection = null;
     }
   }
 
@@ -243,6 +263,7 @@ export class VoiceAgentProcessor extends StreamProcessor<
     const connection: ProviderConnection = {
       id: crypto.randomUUID(),
       provider: setup.provider,
+      setupKey: JSON.stringify(setup),
       socket,
       urlForLog: endpoint.urlForLog(setup),
       ready,

--- a/apps/os/src/domains/agents/voice-agent-processor-implementation.ts
+++ b/apps/os/src/domains/agents/voice-agent-processor-implementation.ts
@@ -1,0 +1,1121 @@
+// Implements the "voice-agent" stream processor.
+//
+// The processor bridges an agent stream to a realtime voice provider over an
+// outbound WebSocket: appended input PCM frames and text events are forwarded
+// to the provider selected by setup-configured, and provider output (audio
+// frames, transcripts, status signals) is appended back onto the same stream.
+//
+// The colocated agent processor is the "code agent" half of the bridge: when
+// the voice model calls the messageAgent tool, this processor appends
+// `agent/input-added` (waking the agent processor on the same stream), and the
+// agent responds by appending `voice-agent/input-text-appended` with
+// `source: "code-agent"`, which this processor relays to the voice model.
+//
+// Connection lifecycle mirrors openai-ws-processor-implementation.ts: the
+// WebSocket is a lazy instance field scoped to the hosting Durable Object;
+// input forwarding is serialized (`#sendChain`) so frames reach the provider
+// socket in stream order, and every append made on behalf of a connection goes
+// through that connection's append chain so events land in emission order.
+
+import { z } from "zod";
+import { StreamProcessor } from "../streams/stream-processor.ts";
+import type { StreamEventInput } from "../../types.ts";
+import {
+  AGENT_INPUT_ADDED_EVENT_TYPE,
+  VOICE_AGENT_ERROR_OCCURRED_EVENT_TYPE,
+  VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_OUTPUT_SAMPLE_RATE,
+  VOICE_AGENT_PROVIDER_CONNECTED_EVENT_TYPE,
+  VOICE_AGENT_PROVIDER_DISCONNECTED_EVENT_TYPE,
+  VOICE_AGENT_PROVIDER_GEMINI_LIVE,
+  VOICE_AGENT_PROVIDER_GROK_REALTIME,
+  VOICE_AGENT_PROVIDER_MESSAGE_RECEIVED_EVENT_TYPE,
+  VOICE_AGENT_PROVIDER_MESSAGE_SENT_EVENT_TYPE,
+  VOICE_AGENT_PROVIDER_OPENAI_REALTIME,
+  VOICE_AGENT_PROVIDER_SESSION_READY_EVENT_TYPE,
+  VOICE_AGENT_PROVIDER_STATUS_CHANGED_EVENT_TYPE,
+  VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
+  VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE,
+  type VoiceAgentProvider,
+  type VoiceAgentProviderStatus,
+  VoiceAgentProcessorContract,
+  type VoiceAgentSetup,
+} from "./voice-agent-processor-contract.ts";
+
+type VoiceAgentInputEvent = Extract<
+  ReturnType<typeof VoiceAgentProcessorContract.parseEvent>,
+  {
+    type:
+      | typeof VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE
+      | typeof VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE;
+  }
+>;
+type JsonValue = z.infer<ReturnType<typeof z.json>>;
+
+export type VoiceAgentProcessorDeps = {
+  /** Null when the deployment has no key; inputs then fail with a stream error event. */
+  geminiApiKey: string | null;
+  openAiApiKey: string | null;
+  xAiApiKey: string | null;
+  /** Test seam: replaces the outbound fetch-upgrade WebSocket. */
+  openProviderWebSocket?: (input: {
+    provider: VoiceAgentProvider;
+    url: URL;
+    headers: Record<string, string>;
+  }) => Promise<WebSocket>;
+};
+
+type ProviderConnection = {
+  id: string;
+  provider: VoiceAgentProvider;
+  socket: WebSocket;
+  urlForLog: string;
+  ready: Promise<void>;
+  resolveReady: () => void;
+  sendSequence: number;
+  receiveSequence: number;
+  handledToolCallIds: Set<string>;
+  /** Serializes incoming provider message handling so appends keep provider order. */
+  handlerChain: Promise<void>;
+  /** Serializes every stream append from this connection so output frames land in order. */
+  appendChain: Promise<unknown>;
+};
+
+type ProviderContext = {
+  connection: ProviderConnection;
+  append: (event: StreamEventInput) => Promise<unknown>;
+  createOutputSequence: () => number;
+  getLastInputStreamId: () => string;
+};
+
+const WEBSOCKET_OPEN = 1;
+const PROVIDER_READY_TIMEOUT_MS = 30_000;
+/** Strings longer than this are truncated in provider message audit events. */
+export const AUDIT_MAX_STRING_LENGTH = 256;
+
+export class VoiceAgentProcessor extends StreamProcessor<
+  typeof VoiceAgentProcessorContract,
+  VoiceAgentProcessorDeps
+> {
+  readonly contract = VoiceAgentProcessorContract;
+
+  /**
+   * Warm-instance transport state, not replay state: a live provider WebSocket
+   * plus the counters that keep its frames ordered. Lost on DO restart; the
+   * next input event re-dials.
+   */
+  #connection: ProviderConnection | null = null;
+  #openingConnection: Promise<ProviderConnection> | null = null;
+  #outputSequence = 0;
+  #lastInputStreamId = "voice-agent";
+  #sendChain: Promise<void> = Promise.resolve();
+
+  protected override reduce({
+    event,
+    state,
+  }: Parameters<StreamProcessor<typeof VoiceAgentProcessorContract>["reduce"]>[0]) {
+    if (event.type === VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE) {
+      return { ...state, setup: event.payload };
+    }
+    return state;
+  }
+
+  protected override processEvent({
+    event,
+    runInBackground,
+    state,
+  }: Parameters<
+    StreamProcessor<typeof VoiceAgentProcessorContract>["processEvent"]
+  >[0]): undefined {
+    switch (event.type) {
+      case VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE:
+        this.#connection?.socket.close(1000, "Voice-agent setup changed.");
+        this.#connection = null;
+        this.#openingConnection = null;
+        return;
+      case VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE:
+      case VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE: {
+        // Frames must reach the provider socket in stream order, so forwarding
+        // is serialized. Forwarding runs in the background: provider latency
+        // must not hold up the processor checkpoint, and failures land on the
+        // stream as error events instead of failing the batch.
+        const task = (this.#sendChain = this.#sendChain.then(() =>
+          this.#forwardInputEvent({ event, setup: state.setup }),
+        ));
+        runInBackground(() => task);
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  async #forwardInputEvent(args: {
+    event: VoiceAgentInputEvent;
+    setup: VoiceAgentSetup | null;
+  }): Promise<void> {
+    const { event, setup } = args;
+    if (setup == null) {
+      await this.#appendInputError({
+        error: new Error(
+          "Voice-agent setup-configured event is required before appending input events.",
+        ),
+        event,
+      });
+      return;
+    }
+
+    const endpoint = providerEndpoints[setup.provider];
+    if ((endpoint.apiKey(this.deps) ?? "").trim() === "") {
+      await this.#appendInputError({ error: new Error(endpoint.missingKeyMessage), event });
+      return;
+    }
+
+    if (event.type === VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE) {
+      this.#lastInputStreamId = event.payload.streamId;
+    }
+
+    let connection: ProviderConnection;
+    try {
+      connection = await this.#getConnection(setup);
+      await withTimeout(
+        connection.ready,
+        PROVIDER_READY_TIMEOUT_MS,
+        `Timed out waiting for ${endpoint.label} setup.`,
+      );
+    } catch (error) {
+      await this.#appendInputError({ error, event });
+      return;
+    }
+
+    for (const message of buildInputMessages({ event, provider: connection.provider })) {
+      this.#sendProviderMessage({
+        connection,
+        message,
+        sourceEventOffset: event.offset,
+      });
+    }
+  }
+
+  async #getConnection(setup: VoiceAgentSetup): Promise<ProviderConnection> {
+    if (
+      this.#connection?.provider === setup.provider &&
+      this.#connection.socket.readyState === WEBSOCKET_OPEN
+    ) {
+      return this.#connection;
+    }
+    if (this.#openingConnection != null) {
+      return await this.#openingConnection;
+    }
+
+    this.#connection?.socket.close(1000, "Replacing stale voice-agent provider connection.");
+    this.#openingConnection = this.#openProviderConnection(setup);
+    try {
+      this.#connection = await this.#openingConnection;
+      return this.#connection;
+    } finally {
+      this.#openingConnection = null;
+    }
+  }
+
+  async #openProviderConnection(setup: VoiceAgentSetup): Promise<ProviderConnection> {
+    const endpoint = providerEndpoints[setup.provider];
+    let resolveReady: () => void = () => {};
+    let rejectReady: (error: Error) => void = () => {};
+    const ready = new Promise<void>((resolve, reject) => {
+      resolveReady = resolve;
+      rejectReady = reject;
+    });
+    // Settling `ready` is how open/close/error report; an already-ready
+    // connection that later closes must not surface an unhandled rejection.
+    ready.catch(() => {});
+
+    const openSocket = this.deps.openProviderWebSocket ?? openFetchWebSocket;
+    const socket = await openSocket({
+      provider: setup.provider,
+      url: endpoint.url(this.deps, setup),
+      headers: endpoint.headers(this.deps),
+    });
+
+    const connection: ProviderConnection = {
+      id: crypto.randomUUID(),
+      provider: setup.provider,
+      socket,
+      urlForLog: endpoint.urlForLog(setup),
+      ready,
+      resolveReady,
+      sendSequence: 0,
+      receiveSequence: 0,
+      handledToolCallIds: new Set(),
+      handlerChain: Promise.resolve(),
+      appendChain: Promise.resolve(),
+    };
+    const ctx: ProviderContext = {
+      connection,
+      append: (event) => this.stream.append(event),
+      createOutputSequence: () => this.#outputSequence++,
+      getLastInputStreamId: () => this.#lastInputStreamId,
+    };
+
+    socket.addEventListener("message", (event) => {
+      connection.handlerChain = connection.handlerChain
+        .then(() => endpoint.handleMessage(ctx, event.data))
+        .catch((error) => {
+          enqueueAppend(ctx, {
+            type: VOICE_AGENT_ERROR_OCCURRED_EVENT_TYPE,
+            idempotencyKey: `voice-agent:${connection.id}:message-handler-error:${connection.receiveSequence}`,
+            payload: { message: stringifyError(error) },
+          });
+        });
+    });
+    socket.addEventListener("close", (event) => {
+      this.#markConnectionClosed(connection);
+      rejectReady(
+        new Error(event.reason || `${endpoint.label} WebSocket closed before setup completed.`),
+      );
+      enqueueAppend(ctx, {
+        type: VOICE_AGENT_PROVIDER_DISCONNECTED_EVENT_TYPE,
+        idempotencyKey: `voice-agent:${connection.id}:provider-disconnected`,
+        payload: {
+          provider: connection.provider,
+          connectionId: connection.id,
+          code: event.code,
+          reason: event.reason || undefined,
+          wasClean: event.wasClean,
+        },
+      });
+    });
+    socket.addEventListener("error", () => {
+      this.#markConnectionClosed(connection);
+      rejectReady(new Error(`${endpoint.label} WebSocket errored before setup completed.`));
+    });
+
+    enqueueAppend(ctx, {
+      type: VOICE_AGENT_PROVIDER_CONNECTED_EVENT_TYPE,
+      idempotencyKey: `voice-agent:${connection.id}:provider-connected`,
+      payload: {
+        provider: connection.provider,
+        connectionId: connection.id,
+        model: setup.model,
+        url: connection.urlForLog,
+      },
+    });
+
+    this.#sendProviderMessage({
+      connection,
+      message: endpoint.buildSessionSetupMessage(setup),
+    });
+
+    return connection;
+  }
+
+  #markConnectionClosed(closedConnection: ProviderConnection) {
+    if (this.#connection?.id === closedConnection.id) this.#connection = null;
+  }
+
+  #sendProviderMessage(args: {
+    connection: ProviderConnection;
+    message: JsonValue;
+    sourceEventOffset?: number;
+  }) {
+    sendProviderMessage({
+      ctx: {
+        connection: args.connection,
+        append: (event) => this.stream.append(event),
+        createOutputSequence: () => this.#outputSequence++,
+        getLastInputStreamId: () => this.#lastInputStreamId,
+      },
+      message: args.message,
+      sourceEventOffset: args.sourceEventOffset,
+    });
+  }
+
+  async #appendInputError(args: { error: unknown; event: VoiceAgentInputEvent }) {
+    await this.stream.append({
+      type: VOICE_AGENT_ERROR_OCCURRED_EVENT_TYPE,
+      idempotencyKey: `voice-agent:input-forwarding-failed@${args.event.offset}`,
+      payload: {
+        message: stringifyError(args.error),
+        sourceEventOffset: args.event.offset,
+      },
+    });
+  }
+}
+
+function buildInputMessages(args: {
+  event: VoiceAgentInputEvent;
+  provider: VoiceAgentProvider;
+}): JsonValue[] {
+  const { event, provider } = args;
+
+  if (event.type === VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE) {
+    switch (provider) {
+      case VOICE_AGENT_PROVIDER_GEMINI_LIVE:
+        return [
+          {
+            realtimeInput: {
+              audio: {
+                data: event.payload.dataBase64,
+                mimeType: `audio/pcm;rate=${event.payload.sampleRate}`,
+              },
+            },
+          },
+        ];
+      case VOICE_AGENT_PROVIDER_OPENAI_REALTIME:
+        // OpenAI Realtime only accepts 24 kHz PCM16.
+        return [
+          {
+            type: "input_audio_buffer.append",
+            audio: resamplePcm16Base64({
+              dataBase64: event.payload.dataBase64,
+              fromSampleRate: event.payload.sampleRate,
+              toSampleRate: 24_000,
+            }),
+          },
+        ];
+      case VOICE_AGENT_PROVIDER_GROK_REALTIME:
+        return [{ type: "input_audio_buffer.append", audio: event.payload.dataBase64 }];
+    }
+  }
+
+  const text = providerInputText(event.payload);
+  switch (provider) {
+    case VOICE_AGENT_PROVIDER_GEMINI_LIVE:
+      return [
+        {
+          clientContent: {
+            turns: [{ role: "user", parts: [{ text }] }],
+            turnComplete: true,
+          },
+        },
+      ];
+    case VOICE_AGENT_PROVIDER_OPENAI_REALTIME:
+    case VOICE_AGENT_PROVIDER_GROK_REALTIME:
+      return [
+        {
+          type: "conversation.item.create",
+          item: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text }],
+          },
+        },
+        { type: "response.create" },
+      ];
+  }
+}
+
+function providerInputText(payload: { text: string; source?: string }) {
+  if (payload.source !== "code-agent") return payload.text;
+  return [
+    "BACKGROUND AGENT MESSAGE TO RELAY TO THE HUMAN YOU ARE SPEAKING TO:",
+    payload.text,
+    "",
+    "This message is not from the caller. It is from the background code-capable agent you asked for help.",
+    "Your job is to relay this message to the human you are speaking to in natural speech.",
+    "If the background agent's message is a question, ask that question to the human you are speaking to. Do not answer the question yourself.",
+    "If the background agent's message is an answer or update, tell the human you are speaking to that answer or update directly.",
+    "Do not say thanks, thank you, thanks for the update, or any other gratitude/acknowledgement phrase.",
+    "Do not say the caller told you this. Do not describe the background agent as if it is another participant in the call.",
+  ].join("\n");
+}
+
+// Provider endpoints.
+
+type ProviderEndpoint = {
+  label: string;
+  apiKey: (deps: VoiceAgentProcessorDeps) => string | null;
+  missingKeyMessage: string;
+  url: (deps: VoiceAgentProcessorDeps, setup: VoiceAgentSetup) => URL;
+  urlForLog: (setup: VoiceAgentSetup) => string;
+  headers: (deps: VoiceAgentProcessorDeps) => Record<string, string>;
+  buildSessionSetupMessage: (setup: VoiceAgentSetup) => JsonValue;
+  handleMessage: (ctx: ProviderContext, data: unknown) => Promise<void>;
+};
+
+const providerEndpoints: Record<VoiceAgentProvider, ProviderEndpoint> = {
+  [VOICE_AGENT_PROVIDER_GEMINI_LIVE]: {
+    label: "Gemini Live",
+    apiKey: (deps) => deps.geminiApiKey,
+    missingKeyMessage:
+      "Gemini API key is not configured on this deployment (AppConfig geminiApiKey).",
+    url: (deps) => geminiLiveUrl(deps.geminiApiKey ?? ""),
+    urlForLog: () => geminiLiveUrl("").toString(),
+    headers: () => ({}),
+    buildSessionSetupMessage: (setup) => ({
+      setup: {
+        model: setup.model.startsWith("models/") ? setup.model : `models/${setup.model}`,
+        generationConfig: {
+          responseModalities: ["AUDIO"],
+          speechConfig: {
+            voiceConfig: {
+              prebuiltVoiceConfig: { voiceName: setup.voiceName },
+            },
+          },
+        },
+        inputAudioTranscription: {},
+        outputAudioTranscription: {},
+        // Gemini Live v1beta rejects toolConfig/functionCallingConfig anywhere in
+        // BidiGenerateContentSetup (close code 1007), so "required" tool choice
+        // can only be enforced through the system instruction.
+        systemInstruction: {
+          parts: [
+            {
+              text: [
+                systemInstructionWithMessageAgent(setup.systemInstruction),
+                ...(setup.messageAgentToolChoice === "required"
+                  ? [
+                      "You MUST call the messageAgent tool for every caller request before responding. Never answer a substantive request without calling it first.",
+                    ]
+                  : []),
+              ].join("\n\n"),
+            },
+          ],
+        },
+        tools: [
+          {
+            functionDeclarations: [
+              {
+                name: "messageAgent",
+                description: MESSAGE_AGENT_TOOL_DESCRIPTION,
+                parameters: messageAgentParameters(),
+              },
+            ],
+          },
+        ],
+      },
+    }),
+    handleMessage: handleGeminiMessage,
+  },
+  [VOICE_AGENT_PROVIDER_OPENAI_REALTIME]: {
+    label: "OpenAI Realtime",
+    apiKey: (deps) => deps.openAiApiKey,
+    missingKeyMessage:
+      "OpenAI API key is not configured on this deployment (AppConfig openAiApiKey).",
+    url: (_deps, setup) => realtimeUrl("https://api.openai.com/v1/realtime", setup.model),
+    urlForLog: (setup) => realtimeUrl("https://api.openai.com/v1/realtime", setup.model).toString(),
+    headers: (deps) => ({ Authorization: `Bearer ${deps.openAiApiKey}` }),
+    buildSessionSetupMessage: (setup) => ({
+      type: "session.update",
+      session: {
+        type: "realtime",
+        instructions: systemInstructionWithMessageAgent(setup.systemInstruction),
+        audio: {
+          input: {
+            format: { type: "audio/pcm", rate: 24_000 },
+            turn_detection: {
+              type: "server_vad",
+              create_response: true,
+              interrupt_response: true,
+            },
+            transcription: { model: "gpt-4o-mini-transcribe" },
+          },
+          output: {
+            format: { type: "audio/pcm", rate: VOICE_AGENT_OUTPUT_SAMPLE_RATE },
+            voice: setup.voiceName,
+          },
+        },
+        tools: [openAiCompatibleMessageAgentTool()],
+        tool_choice: setup.messageAgentToolChoice === "required" ? "required" : "auto",
+      },
+    }),
+    handleMessage: handleOpenAiCompatibleMessage,
+  },
+  [VOICE_AGENT_PROVIDER_GROK_REALTIME]: {
+    label: "Grok Realtime",
+    apiKey: (deps) => deps.xAiApiKey,
+    missingKeyMessage: "xAI API key is not configured on this deployment (AppConfig xAiApiKey).",
+    url: (_deps, setup) => realtimeUrl("https://api.x.ai/v1/realtime", setup.model),
+    urlForLog: (setup) => realtimeUrl("https://api.x.ai/v1/realtime", setup.model).toString(),
+    headers: (deps) => ({ Authorization: `Bearer ${deps.xAiApiKey}` }),
+    buildSessionSetupMessage: (setup) => ({
+      type: "session.update",
+      session: {
+        instructions: systemInstructionWithMessageAgent(setup.systemInstruction),
+        voice: setup.voiceName,
+        turn_detection: { type: "server_vad" },
+        audio: {
+          input: { format: { type: "audio/pcm", rate: 16_000 } },
+          output: { format: { type: "audio/pcm", rate: VOICE_AGENT_OUTPUT_SAMPLE_RATE } },
+        },
+        tools: [openAiCompatibleMessageAgentTool()],
+        tool_choice: setup.messageAgentToolChoice === "required" ? "required" : "auto",
+      },
+    }),
+    handleMessage: handleOpenAiCompatibleMessage,
+  },
+};
+
+// Gemini Live message handling.
+
+type GeminiServerMessage = {
+  setupComplete?: Record<string, unknown>;
+  serverContent?: {
+    modelTurn?: {
+      parts?: Array<{
+        inlineData?: { data?: string; mimeType?: string };
+        text?: string;
+      }>;
+    };
+    interrupted?: boolean;
+    turnComplete?: boolean;
+    inputTranscription?: { text?: string };
+    outputTranscription?: { text?: string };
+  };
+  toolCall?: {
+    functionCalls?: Array<{ id?: string; name?: string; args?: unknown }>;
+  };
+  goAway?: { timeLeft?: string };
+};
+
+async function handleGeminiMessage(ctx: ProviderContext, data: unknown) {
+  const message = JSON.parse(await websocketMessageToText(data)) as GeminiServerMessage;
+  const sequence = ctx.connection.receiveSequence++;
+  enqueueProviderMessageAudit({ ctx, message: message as JsonValue, sequence });
+
+  if (message.setupComplete != null) {
+    ctx.connection.resolveReady();
+    enqueueAppend(ctx, {
+      type: VOICE_AGENT_PROVIDER_SESSION_READY_EVENT_TYPE,
+      idempotencyKey: `voice-agent:${ctx.connection.id}:provider-session-ready`,
+      payload: { provider: ctx.connection.provider, connectionId: ctx.connection.id },
+    });
+  }
+
+  for (const functionCall of message.toolCall?.functionCalls ?? []) {
+    await handleToolCall({
+      ctx,
+      callId: functionCall.id,
+      name: functionCall.name,
+      argumentsValue: functionCall.args,
+      respond: (callId, output) => ({
+        toolResponse: {
+          functionResponses: [
+            { id: callId, name: functionCall.name ?? "unknown_tool", response: output },
+          ],
+        },
+      }),
+    });
+  }
+
+  // Gemini terminates Live sessions after a fixed duration; surface the warning
+  // instead of silently reconnecting into a fresh session with no context.
+  if (message.goAway != null) {
+    enqueueProviderStatus(ctx, "going-away", sequence);
+  }
+
+  const serverContent = message.serverContent;
+  if (serverContent == null) return;
+
+  for (const part of serverContent.modelTurn?.parts ?? []) {
+    if (part.inlineData?.data) {
+      enqueueOutputAudioFrame(ctx, part.inlineData.data);
+    }
+  }
+
+  if (serverContent.interrupted) {
+    enqueueProviderStatus(ctx, "output-interrupted", sequence);
+    enqueueSpeakerBufferClear(ctx, "output-interrupted", sequence);
+  }
+  if (serverContent.turnComplete) {
+    enqueueProviderStatus(ctx, "turn-completed", sequence);
+  }
+
+  enqueueTranscription(
+    ctx,
+    "input-transcription",
+    serverContent.inputTranscription?.text,
+    sequence,
+  );
+  enqueueTranscription(
+    ctx,
+    "output-transcription",
+    serverContent.outputTranscription?.text,
+    sequence,
+  );
+}
+
+// OpenAI-compatible (OpenAI Realtime / Grok Realtime) message handling.
+
+type RealtimeServerMessage = {
+  type?: string;
+  delta?: string;
+  transcript?: string;
+  error?: { message?: string };
+  item?: RealtimeFunctionCallItem;
+  response?: { output?: RealtimeFunctionCallItem[] };
+};
+
+type RealtimeFunctionCallItem = {
+  type?: string;
+  name?: string;
+  call_id?: string;
+  arguments?: string;
+};
+
+async function handleOpenAiCompatibleMessage(ctx: ProviderContext, data: unknown) {
+  const message = JSON.parse(await websocketMessageToText(data)) as RealtimeServerMessage;
+  const sequence = ctx.connection.receiveSequence++;
+  enqueueProviderMessageAudit({ ctx, message: message as JsonValue, sequence });
+
+  switch (message.type) {
+    case "session.updated":
+      ctx.connection.resolveReady();
+      enqueueAppend(ctx, {
+        type: VOICE_AGENT_PROVIDER_SESSION_READY_EVENT_TYPE,
+        idempotencyKey: `voice-agent:${ctx.connection.id}:provider-session-ready`,
+        payload: { provider: ctx.connection.provider, connectionId: ctx.connection.id },
+      });
+      return;
+    case "response.output_audio.delta":
+    case "response.audio.delta":
+      if (typeof message.delta === "string") {
+        enqueueOutputAudioFrame(ctx, message.delta);
+      }
+      return;
+    case "conversation.item.input_audio_transcription.completed":
+      enqueueTranscription(ctx, "input-transcription", message.transcript, sequence);
+      return;
+    case "response.output_audio_transcript.delta":
+    case "response.audio_transcript.delta":
+      enqueueTranscription(ctx, "output-transcription", message.delta, sequence);
+      return;
+    case "input_audio_buffer.speech_started":
+      enqueueProviderStatus(ctx, "speech-started", sequence);
+      enqueueSpeakerBufferClear(ctx, "input-speech-started", sequence);
+      return;
+    case "input_audio_buffer.speech_stopped":
+      enqueueProviderStatus(ctx, "speech-stopped", sequence);
+      return;
+    case "response.output_audio.done":
+    case "response.audio.done":
+      enqueueProviderStatus(ctx, "output-audio-done", sequence);
+      return;
+    case "response.output_item.done":
+      await handleOpenAiCompatibleFunctionCallItem(ctx, message.item);
+      return;
+    case "response.done":
+      enqueueProviderStatus(ctx, "response-done", sequence);
+      for (const item of message.response?.output ?? []) {
+        await handleOpenAiCompatibleFunctionCallItem(ctx, item);
+      }
+      return;
+    case "error":
+      // Providers send recoverable errors (e.g. rejected client events) on a live
+      // session; record them without tearing the connection down.
+      enqueueAppend(ctx, {
+        type: VOICE_AGENT_ERROR_OCCURRED_EVENT_TYPE,
+        idempotencyKey: `voice-agent:${ctx.connection.id}:provider-error:${sequence}`,
+        payload: {
+          message:
+            message.error?.message ??
+            `${providerEndpoints[ctx.connection.provider].label} returned an error.`,
+        },
+      });
+      return;
+    default:
+      return;
+  }
+}
+
+async function handleOpenAiCompatibleFunctionCallItem(
+  ctx: ProviderContext,
+  item: RealtimeFunctionCallItem | undefined,
+) {
+  if (item?.type !== "function_call") return;
+  await handleToolCall({
+    ctx,
+    callId: item.call_id,
+    name: item.name,
+    argumentsValue: item.arguments,
+    respond: (callId, output) => ({
+      type: "conversation.item.create",
+      item: {
+        type: "function_call_output",
+        call_id: callId,
+        output: JSON.stringify(output),
+      },
+    }),
+    followUp: { type: "response.create", response: { tool_choice: "none" } },
+  });
+}
+
+// messageAgent tool plumbing.
+
+const MESSAGE_AGENT_TOOL_DESCRIPTION =
+  "Ask the code-capable background agent to do work or answer a question. Use for actions, investigation, code, data lookup, or anything requiring tools.";
+
+async function handleToolCall(args: {
+  ctx: ProviderContext;
+  callId: string | undefined;
+  name: string | undefined;
+  argumentsValue: unknown;
+  respond: (callId: string, output: JsonValue) => JsonValue;
+  followUp?: JsonValue;
+}) {
+  const { ctx } = args;
+  const callId = args.callId;
+  if (callId == null || callId.trim() === "") return;
+  if (ctx.connection.handledToolCallIds.has(callId)) return;
+  ctx.connection.handledToolCallIds.add(callId);
+
+  const toolResult =
+    args.name === "messageAgent"
+      ? await appendMessageAgentInput({ ctx, callId, argumentsValue: args.argumentsValue })
+      : { ok: false, message: `Unknown tool: ${args.name ?? "<missing>"}` };
+
+  sendProviderMessage({ ctx, message: args.respond(callId, toolResult) });
+  if (args.followUp != null) {
+    sendProviderMessage({ ctx, message: args.followUp });
+  }
+}
+
+async function appendMessageAgentInput(args: {
+  ctx: ProviderContext;
+  callId: string;
+  argumentsValue: unknown;
+}) {
+  const parsed = parseMessageAgentArguments(args.argumentsValue);
+  if (!parsed.ok) return parsed;
+
+  await enqueueAppend(args.ctx, {
+    type: AGENT_INPUT_ADDED_EVENT_TYPE,
+    idempotencyKey: `voice-agent:${args.ctx.connection.id}:${args.ctx.connection.provider}:message-agent:${args.callId}:agent-input`,
+    payload: {
+      content: parsed.message,
+      llmRequestPolicy: { behaviour: "after-current-request" },
+    },
+  });
+
+  return {
+    ok: true,
+    message:
+      "Asked the code-capable background agent. Continue the call while it works; it will respond back into the voice stream when ready.",
+  };
+}
+
+function parseMessageAgentArguments(
+  argumentsValue: unknown,
+): { ok: true; message: string } | { ok: false; message: string } {
+  if (argumentsValue == null) {
+    return { ok: false, message: "messageAgent requires a JSON arguments object." };
+  }
+
+  let parsed = argumentsValue;
+  if (typeof argumentsValue === "string") {
+    if (argumentsValue.trim() === "") {
+      return { ok: false, message: "messageAgent requires a JSON arguments object." };
+    }
+    try {
+      parsed = JSON.parse(argumentsValue);
+    } catch {
+      return { ok: false, message: "messageAgent arguments must be valid JSON." };
+    }
+  }
+
+  const message = (parsed as { message?: unknown }).message;
+  if (typeof message !== "string" || message.trim() === "") {
+    return { ok: false, message: "messageAgent requires a non-empty message string." };
+  }
+  return { ok: true, message: message.trim() };
+}
+
+function systemInstructionWithMessageAgent(systemInstruction: string) {
+  return [
+    systemInstruction,
+    "You are speaking directly with a human. In these instructions, 'the caller' means the human you are speaking to. You have a tool named Message Agent. Use it when the caller asks for actions, investigation, code, data lookup, or anything requiring tools. Message Agent sends the request to a code-capable background agent. After calling it, tell the caller you asked the agent and continue the conversation while it works. When the background agent replies, relay its message to the caller; if it replies with a question, ask that question to the caller rather than answering it yourself.",
+  ].join("\n\n");
+}
+
+function messageAgentParameters(input: { additionalProperties?: boolean } = {}) {
+  return {
+    type: "object",
+    ...(input.additionalProperties == null
+      ? {}
+      : { additionalProperties: input.additionalProperties }),
+    properties: {
+      message: {
+        type: "string",
+        description:
+          "The plain-language request for the background code agent. Include relevant context from the call.",
+      },
+    },
+    required: ["message"],
+  } satisfies JsonValue;
+}
+
+function openAiCompatibleMessageAgentTool() {
+  return {
+    type: "function",
+    name: "messageAgent",
+    description: MESSAGE_AGENT_TOOL_DESCRIPTION,
+    parameters: messageAgentParameters({ additionalProperties: false }),
+  } satisfies JsonValue;
+}
+
+// Append helpers. Everything appended on behalf of a connection goes through
+// the connection's append chain so events land on the stream in emission order.
+
+function enqueueAppend(ctx: ProviderContext, event: StreamEventInput): Promise<unknown> {
+  const next = ctx.connection.appendChain.then(() => ctx.append(event));
+  ctx.connection.appendChain = next.catch((error) => {
+    console.error("voice-agent stream append failed", { error, type: event.type });
+  });
+  return next;
+}
+
+function sendProviderMessage(args: {
+  ctx: ProviderContext;
+  message: JsonValue;
+  sourceEventOffset?: number;
+}) {
+  const { ctx } = args;
+  const sequence = ctx.connection.sendSequence++;
+  ctx.connection.socket.send(JSON.stringify(args.message));
+  enqueueAppend(ctx, {
+    type: VOICE_AGENT_PROVIDER_MESSAGE_SENT_EVENT_TYPE,
+    idempotencyKey: `voice-agent:${ctx.connection.id}:provider-message-sent:${sequence}`,
+    payload: {
+      provider: ctx.connection.provider,
+      connectionId: ctx.connection.id,
+      sequence,
+      ...(args.sourceEventOffset == null ? {} : { sourceEventOffset: args.sourceEventOffset }),
+      message: redactLargeStringsForAudit(args.message) as Record<string, unknown>,
+    },
+  });
+}
+
+function enqueueProviderMessageAudit(args: {
+  ctx: ProviderContext;
+  message: JsonValue;
+  sequence: number;
+}) {
+  enqueueAppend(args.ctx, {
+    type: VOICE_AGENT_PROVIDER_MESSAGE_RECEIVED_EVENT_TYPE,
+    idempotencyKey: `voice-agent:${args.ctx.connection.id}:provider-message-received:${args.sequence}`,
+    payload: {
+      provider: args.ctx.connection.provider,
+      connectionId: args.ctx.connection.id,
+      sequence: args.sequence,
+      message: redactLargeStringsForAudit(args.message) as Record<string, unknown>,
+    },
+  });
+}
+
+function enqueueProviderStatus(
+  ctx: ProviderContext,
+  status: VoiceAgentProviderStatus,
+  sequence: number,
+) {
+  enqueueAppend(ctx, {
+    type: VOICE_AGENT_PROVIDER_STATUS_CHANGED_EVENT_TYPE,
+    idempotencyKey: `voice-agent:${ctx.connection.id}:provider-status:${status}:${sequence}`,
+    payload: {
+      provider: ctx.connection.provider,
+      connectionId: ctx.connection.id,
+      status,
+    },
+  });
+}
+
+function enqueueSpeakerBufferClear(
+  ctx: ProviderContext,
+  reason: "output-interrupted" | "input-speech-started",
+  sequence: number,
+) {
+  enqueueAppend(ctx, {
+    type: VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
+    idempotencyKey: `voice-agent:${ctx.connection.id}:speaker-buffer-clear:${sequence}`,
+    payload: {
+      provider: ctx.connection.provider,
+      connectionId: ctx.connection.id,
+      reason,
+    },
+  });
+}
+
+function enqueueOutputAudioFrame(ctx: ProviderContext, dataBase64: string) {
+  const bytes = base64ByteLength(dataBase64);
+  const sequence = ctx.createOutputSequence();
+  enqueueAppend(ctx, {
+    type: VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+    idempotencyKey: `voice-agent:${ctx.connection.id}:output-audio:${sequence}`,
+    payload: {
+      channels: 1,
+      dataBase64,
+      durationMs: Math.round((bytes / 2 / VOICE_AGENT_OUTPUT_SAMPLE_RATE) * 1000),
+      encoding: "pcm_s16le",
+      sampleRate: VOICE_AGENT_OUTPUT_SAMPLE_RATE,
+      sequence,
+      streamId: ctx.getLastInputStreamId(),
+    },
+  });
+}
+
+function enqueueTranscription(
+  ctx: ProviderContext,
+  source: "input-transcription" | "output-transcription",
+  text: string | undefined,
+  sequence: number,
+) {
+  if (!text) return;
+  enqueueAppend(ctx, {
+    type: VOICE_AGENT_OUTPUT_TEXT_APPENDED_EVENT_TYPE,
+    idempotencyKey: `voice-agent:${ctx.connection.id}:${source}:${sequence}`,
+    payload: {
+      connectionId: ctx.connection.id,
+      source,
+      text,
+    },
+  });
+}
+
+/**
+ * Provider messages embed base64 PCM that would otherwise double the stream's
+ * audio storage. Audit copies keep structure but truncate long strings; the
+ * canonical audio lives exactly once in input/output frame events.
+ */
+export function redactLargeStringsForAudit(value: JsonValue): JsonValue {
+  if (typeof value === "string") {
+    if (value.length <= AUDIT_MAX_STRING_LENGTH) return value;
+    return `${value.slice(0, 64)}… [${value.length - 64} more chars redacted]`;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactLargeStringsForAudit(item));
+  }
+  if (value != null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, redactLargeStringsForAudit(item)]),
+    );
+  }
+  return value;
+}
+
+// Transport helpers.
+
+async function openFetchWebSocket(input: {
+  provider: VoiceAgentProvider;
+  url: URL;
+  headers: Record<string, string>;
+}): Promise<WebSocket> {
+  const response = (await fetch(input.url, {
+    headers: {
+      ...input.headers,
+      Upgrade: "websocket",
+    },
+  })) as Response & { webSocket?: (WebSocket & { accept(): void }) | null };
+  if (!response.webSocket) {
+    throw new Error(
+      `${providerEndpoints[input.provider].label} WebSocket upgrade failed with HTTP ${response.status}.`,
+    );
+  }
+  response.webSocket.accept();
+  return response.webSocket;
+}
+
+function geminiLiveUrl(apiKey: string) {
+  const url = new URL(
+    "https://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent",
+  );
+  if (apiKey) {
+    url.searchParams.set("key", apiKey);
+  }
+  return url;
+}
+
+function realtimeUrl(base: string, model: string) {
+  const url = new URL(base);
+  url.searchParams.set("model", model);
+  return url;
+}
+
+async function websocketMessageToText(message: unknown): Promise<string> {
+  if (typeof message === "string") return message;
+  if (message instanceof ArrayBuffer) return new TextDecoder().decode(message);
+  if (message instanceof Uint8Array) return new TextDecoder().decode(message);
+  if (message instanceof Blob) return await message.text();
+  throw new Error(`Unsupported WebSocket message type: ${typeof message}`);
+}
+
+function base64ByteLength(base64: string) {
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+  return Math.max(0, Math.floor((base64.length * 3) / 4) - padding);
+}
+
+export function resamplePcm16Base64(input: {
+  dataBase64: string;
+  fromSampleRate: number;
+  toSampleRate: number;
+}) {
+  if (input.fromSampleRate === input.toSampleRate) return input.dataBase64;
+
+  const bytes = base64ToUint8Array(input.dataBase64);
+  const sourceSampleCount = Math.floor(bytes.byteLength / 2);
+  const source = new Int16Array(sourceSampleCount);
+  const sourceView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  for (let index = 0; index < source.length; index += 1) {
+    source[index] = sourceView.getInt16(index * 2, true);
+  }
+
+  const targetSampleCount = Math.max(
+    1,
+    Math.round(source.length * (input.toSampleRate / input.fromSampleRate)),
+  );
+  const target = new Int16Array(targetSampleCount);
+  for (let index = 0; index < target.length; index += 1) {
+    const sourcePosition = index * (input.fromSampleRate / input.toSampleRate);
+    const leftIndex = Math.min(source.length - 1, Math.floor(sourcePosition));
+    const rightIndex = Math.min(source.length - 1, leftIndex + 1);
+    const fraction = sourcePosition - leftIndex;
+    const left = source[leftIndex] ?? 0;
+    const right = source[rightIndex] ?? left;
+    target[index] = Math.round(left + (right - left) * fraction);
+  }
+
+  const outputBytes = new Uint8Array(target.byteLength);
+  const outputView = new DataView(outputBytes.buffer);
+  for (let index = 0; index < target.length; index += 1) {
+    outputView.setInt16(index * 2, target[index] ?? 0, true);
+  }
+  return uint8ArrayToBase64(outputBytes);
+}
+
+function base64ToUint8Array(base64: string) {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function uint8ArrayToBase64(bytes: Uint8Array) {
+  const chunkSize = 0x8000;
+  let binary = "";
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    const chunk = bytes.subarray(index, index + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout != null) clearTimeout(timeout);
+  }
+}
+
+function stringifyError(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/os/src/domains/agents/voice-agent-processor-implementation.ts
+++ b/apps/os/src/domains/agents/voice-agent-processor-implementation.ts
@@ -55,7 +55,7 @@ type VoiceAgentInputEvent = Extract<
 >;
 type JsonValue = z.infer<ReturnType<typeof z.json>>;
 
-export type VoiceAgentProcessorDeps = {
+type VoiceAgentProcessorDeps = {
   /** Null when the deployment has no key; inputs then fail with a stream error event. */
   geminiApiKey: string | null;
   openAiApiKey: string | null;
@@ -94,7 +94,7 @@ type ProviderContext = {
 const WEBSOCKET_OPEN = 1;
 const PROVIDER_READY_TIMEOUT_MS = 30_000;
 /** Strings longer than this are truncated in provider message audit events. */
-export const AUDIT_MAX_STRING_LENGTH = 256;
+const AUDIT_MAX_STRING_LENGTH = 256;
 
 export class VoiceAgentProcessor extends StreamProcessor<
   typeof VoiceAgentProcessorContract,

--- a/apps/os/src/domains/agents/voice-agent-processors.test.ts
+++ b/apps/os/src/domains/agents/voice-agent-processors.test.ts
@@ -433,6 +433,82 @@ describe("VoiceAgentProcessor", () => {
     );
   });
 
+  it("keeps forwarding later inputs after a provider send failure", async () => {
+    const harness = createHarness(VOICE_AGENT_PROVIDER_GEMINI_LIVE);
+
+    await harness.ingestText("First.");
+    await waitFor(() => harness.socket.sent.length === 1);
+    harness.socket.receive({ setupComplete: {} });
+    await waitFor(() => harness.socket.sent.length >= 2);
+
+    harness.socket.failNextSend = true;
+    await harness.ingestText("Dropped by a failing socket.");
+    await harness.ingestText("Second.");
+
+    await waitFor(() =>
+      harness.socket.sent.some((message) => JSON.stringify(message).includes("Second.")),
+    );
+  });
+
+  it("re-dials when the setup changes even within the same provider", async () => {
+    // Sockets whose close() does not flip readyState simulate the in-flight
+    // window where a connection configured for an older setup is still open;
+    // only the setup fingerprint check forces the re-dial then.
+    const sockets: FakeWebSocket[] = [];
+    const stream = new MemoryStream();
+    const processor = new VoiceAgentProcessor({
+      stream,
+      geminiApiKey: "gemini_test",
+      openAiApiKey: "openai_test",
+      xAiApiKey: "xai_test",
+      openProviderWebSocket: async () => {
+        const socket = new FakeWebSocket();
+        socket.closeChangesReadyState = false;
+        sockets.push(socket);
+        return socket as unknown as WebSocket;
+      },
+    });
+
+    let offset = 1000;
+    const ingest = async (event: Omit<StreamEventInput, "offset">) => {
+      offset += 1;
+      await processor.ingest({
+        events: [committedEvent(event as StreamEventInput, offset)],
+        streamMaxOffset: offset,
+      });
+    };
+    const setup = (voiceName: string) =>
+      ingest({
+        type: VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE,
+        payload: { provider: VOICE_AGENT_PROVIDER_GEMINI_LIVE, voiceName },
+      });
+    const text = (value: string) =>
+      ingest({ type: VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE, payload: { text: value } });
+
+    await setup("Zephyr");
+    await text("First.");
+    await waitFor(() => sockets.length === 1 && sockets[0]!.sent.length === 1);
+    sockets[0]!.receive({ setupComplete: {} });
+    await waitFor(() => sockets[0]!.sent.length >= 2);
+
+    await setup("Puck");
+    await text("Second.");
+    await waitFor(() => sockets.length === 2);
+    sockets[1]!.receive({ setupComplete: {} });
+    await waitFor(() => sockets[1]!.sent.length >= 2);
+
+    const secondSetup = sockets[1]!.sent[0] as {
+      setup: {
+        generationConfig: {
+          speechConfig: { voiceConfig: { prebuiltVoiceConfig: { voiceName: string } } };
+        };
+      };
+    };
+    expect(
+      secondSetup.setup.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName,
+    ).toBe("Puck");
+  });
+
   it("appends an error event when input arrives before setup", async () => {
     const stream = new MemoryStream();
     const processor = new VoiceAgentProcessor({
@@ -637,14 +713,20 @@ async function waitFor(predicate: () => boolean) {
 class FakeWebSocket {
   readonly sent: unknown[] = [];
   readyState = 1;
+  failNextSend = false;
+  closeChangesReadyState = true;
   #listeners = new Map<string, EventListener[]>();
 
   send(data: string) {
+    if (this.failNextSend) {
+      this.failNextSend = false;
+      throw new Error("send failed: socket closing");
+    }
     this.sent.push(JSON.parse(data));
   }
 
   close() {
-    this.readyState = 3;
+    if (this.closeChangesReadyState) this.readyState = 3;
   }
 
   addEventListener(type: string, listener: EventListener) {

--- a/apps/os/src/domains/agents/voice-agent-processors.test.ts
+++ b/apps/os/src/domains/agents/voice-agent-processors.test.ts
@@ -1,0 +1,661 @@
+import { describe, expect, it } from "vitest";
+import type { Stream, StreamEvent, StreamEventInput } from "../../types.ts";
+import {
+  AGENT_INPUT_ADDED_EVENT_TYPE,
+  VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+  VOICE_AGENT_PROVIDER_GEMINI_LIVE,
+  VOICE_AGENT_PROVIDER_GROK_REALTIME,
+  VOICE_AGENT_PROVIDER_OPENAI_REALTIME,
+  VOICE_AGENT_PROVIDER_STATUS_CHANGED_EVENT_TYPE,
+  VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE,
+  VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
+  type VoiceAgentProvider,
+  type VoiceAgentSetup,
+} from "./voice-agent-processor-contract.ts";
+import {
+  redactLargeStringsForAudit,
+  resamplePcm16Base64,
+  VoiceAgentProcessor,
+} from "./voice-agent-processor-implementation.ts";
+
+class MemoryStream implements Stream {
+  events: StreamEvent[] = [];
+
+  async append(...inputs: StreamEventInput[]): Promise<StreamEvent[]> {
+    const appended = inputs.map((input) => {
+      const existing =
+        input.idempotencyKey === undefined
+          ? undefined
+          : this.events.find((event) => event.idempotencyKey === input.idempotencyKey);
+      if (existing !== undefined) return existing;
+      const event: StreamEvent = {
+        ...input,
+        createdAt: new Date(this.events.length + 1).toISOString(),
+        offset: this.events.length + 1,
+      };
+      this.events.push(event);
+      return event;
+    });
+    return appended;
+  }
+
+  at(): Stream {
+    return this;
+  }
+
+  async getEvent(
+    input: { offset: number } | { idempotencyKey: string },
+  ): Promise<StreamEvent | undefined> {
+    if ("offset" in input) return this.events.find((event) => event.offset === input.offset);
+    return this.events.find((event) => event.idempotencyKey === input.idempotencyKey);
+  }
+
+  async getEvents(): Promise<StreamEvent[]> {
+    return [...this.events];
+  }
+
+  async waitForEvent(): Promise<StreamEvent> {
+    throw new Error("MemoryStream does not implement waitForEvent().");
+  }
+
+  async getProcessorRuntimeState(): Promise<null> {
+    return null;
+  }
+
+  async runtimeState() {
+    return { coreProcessorState: null, runtime: { connections: {} } };
+  }
+
+  async subscribe(): Promise<never> {
+    throw new Error("MemoryStream does not implement subscribe().");
+  }
+}
+
+describe("VoiceAgentProcessor", () => {
+  it("lets Gemini ask the colocated code agent through a Live API tool call", async () => {
+    const harness = createHarness(VOICE_AGENT_PROVIDER_GEMINI_LIVE);
+
+    await harness.ingestText("Ask the agent to check the repo.");
+
+    await waitFor(() => harness.socket.sent.length === 1);
+    expect(harness.socket.sent[0]).toMatchObject({
+      setup: {
+        tools: [
+          {
+            functionDeclarations: [
+              {
+                name: "messageAgent",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    harness.socket.receive({ setupComplete: {} });
+
+    await waitFor(() => harness.socket.sent.length >= 2);
+    harness.socket.receive({
+      toolCall: {
+        functionCalls: [
+          {
+            name: "messageAgent",
+            id: "call_123",
+            args: { message: "Please inspect the failing tests." },
+          },
+        ],
+      },
+    });
+
+    await waitFor(() =>
+      harness.stream.events.some((event) => event.type === AGENT_INPUT_ADDED_EVENT_TYPE),
+    );
+    expect(harness.stream.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: AGENT_INPUT_ADDED_EVENT_TYPE,
+          idempotencyKey: expect.stringContaining("gemini-live:message-agent:call_123:agent-input"),
+          payload: {
+            content: "Please inspect the failing tests.",
+            llmRequestPolicy: { behaviour: "after-current-request" },
+          },
+        }),
+      ]),
+    );
+    await waitFor(() =>
+      harness.socket.sent.some(
+        (message) => (message as { toolResponse?: unknown }).toolResponse != null,
+      ),
+    );
+    expect(harness.socket.sent).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          toolResponse: {
+            functionResponses: [
+              expect.objectContaining({
+                id: "call_123",
+                name: "messageAgent",
+              }),
+            ],
+          },
+        }),
+      ]),
+    );
+  });
+
+  it("forces Gemini to call messageAgent through the system instruction when required", async () => {
+    const harness = createHarness(VOICE_AGENT_PROVIDER_GEMINI_LIVE, {
+      messageAgentToolChoice: "required",
+    });
+
+    await harness.ingestText("Ask the agent to check the repo.");
+
+    await waitFor(() => harness.socket.sent.length === 1);
+    // Gemini Live v1beta rejects toolConfig in setup, so "required" rides on the
+    // system instruction instead.
+    const setup = harness.socket.sent[0] as {
+      setup: { systemInstruction: { parts: Array<{ text: string }> }; toolConfig?: unknown };
+    };
+    expect(setup.setup.toolConfig).toBeUndefined();
+    expect(setup.setup.systemInstruction.parts[0]?.text).toContain(
+      "MUST call the messageAgent tool",
+    );
+  });
+
+  it.each([
+    { label: "OpenAI", provider: VOICE_AGENT_PROVIDER_OPENAI_REALTIME },
+    { label: "Grok", provider: VOICE_AGENT_PROVIDER_GROK_REALTIME },
+  ] satisfies Array<{ label: string; provider: VoiceAgentProvider }>)(
+    "lets $label ask the colocated code agent through a realtime function call",
+    async ({ provider }) => {
+      const harness = createHarness(provider);
+
+      await harness.ingestText("Ask the agent to check the repo.");
+
+      await waitFor(() => harness.socket.sent.length === 1);
+      expect(harness.socket.sent[0]).toMatchObject({
+        type: "session.update",
+        session: {
+          tools: [
+            {
+              type: "function",
+              name: "messageAgent",
+            },
+          ],
+        },
+      });
+
+      harness.socket.receive({ type: "session.updated" });
+      await waitFor(() => harness.socket.sent.length >= 2);
+
+      harness.socket.receive({
+        type: "response.done",
+        response: {
+          status: "completed",
+          output: [
+            {
+              type: "function_call",
+              name: "messageAgent",
+              call_id: "call_123",
+              arguments: JSON.stringify({ message: "Please inspect the failing tests." }),
+            },
+          ],
+        },
+      });
+
+      await waitFor(() =>
+        harness.stream.events.some((event) => event.type === AGENT_INPUT_ADDED_EVENT_TYPE),
+      );
+      expect(harness.stream.events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: AGENT_INPUT_ADDED_EVENT_TYPE,
+            idempotencyKey: expect.stringContaining(
+              `${provider}:message-agent:call_123:agent-input`,
+            ),
+            payload: {
+              content: "Please inspect the failing tests.",
+              llmRequestPolicy: { behaviour: "after-current-request" },
+            },
+          }),
+        ]),
+      );
+      await waitFor(() =>
+        harness.socket.sent.some(
+          (message) => (message as { type?: unknown }).type === "response.create",
+        ),
+      );
+      expect(harness.socket.sent).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "conversation.item.create",
+            item: expect.objectContaining({
+              type: "function_call_output",
+              call_id: "call_123",
+            }),
+          }),
+          expect.objectContaining({ type: "response.create" }),
+        ]),
+      );
+    },
+  );
+
+  it.each([
+    { label: "Gemini", provider: VOICE_AGENT_PROVIDER_GEMINI_LIVE },
+    { label: "OpenAI", provider: VOICE_AGENT_PROVIDER_OPENAI_REALTIME },
+    { label: "Grok", provider: VOICE_AGENT_PROVIDER_GROK_REALTIME },
+  ] satisfies Array<{ label: string; provider: VoiceAgentProvider }>)(
+    "wraps $label code-agent text so the voice model relays it to the caller",
+    async ({ provider }) => {
+      const harness = createHarness(provider);
+
+      await harness.ingestText("What occupation should I put on your profile?", {
+        source: "code-agent",
+      });
+
+      await waitFor(() => harness.socket.sent.length === 1);
+      harness.socket.receive(
+        provider === VOICE_AGENT_PROVIDER_GEMINI_LIVE
+          ? { setupComplete: {} }
+          : { type: "session.updated" },
+      );
+      await waitFor(() => harness.socket.sent.length >= 2);
+
+      const providerText = providerSentText(harness.socket.sent, provider);
+      expect(providerText).toContain(
+        "BACKGROUND AGENT MESSAGE TO RELAY TO THE HUMAN YOU ARE SPEAKING TO:",
+      );
+      expect(providerText).toContain("What occupation should I put on your profile?");
+      expect(providerText).toContain("This message is not from the caller.");
+      expect(providerText).toContain("ask that question to the human you are speaking to");
+      expect(providerText).toContain("Do not say thanks, thank you");
+    },
+  );
+
+  it("forwards Gemini input audio verbatim and redacts it in the audit event", async () => {
+    const harness = createHarness(VOICE_AGENT_PROVIDER_GEMINI_LIVE);
+    const dataBase64 = pcm16ToBase64(Array.from({ length: 400 }, (_, index) => index));
+
+    await harness.ingestAudio(dataBase64);
+    await waitFor(() => harness.socket.sent.length === 1);
+    harness.socket.receive({ setupComplete: {} });
+    await waitFor(() => harness.socket.sent.length >= 2);
+
+    expect(harness.socket.sent[1]).toMatchObject({
+      realtimeInput: {
+        audio: {
+          data: dataBase64,
+          mimeType: "audio/pcm;rate=16000",
+        },
+      },
+    });
+
+    await waitFor(() =>
+      harness.stream.events.some((event) => {
+        if (event.type !== "events.iterate.com/voice-agent/provider-message-sent") return false;
+        const message = (event.payload as { message?: { realtimeInput?: unknown } }).message;
+        return message?.realtimeInput != null;
+      }),
+    );
+    const audit = harness.stream.events.find((event) => {
+      if (event.type !== "events.iterate.com/voice-agent/provider-message-sent") return false;
+      const message = (event.payload as { message?: { realtimeInput?: unknown } }).message;
+      return message?.realtimeInput != null;
+    });
+    if (audit == null) throw new Error("Expected a provider-message-sent audit event.");
+    const auditedData = (
+      audit.payload as {
+        message: { realtimeInput: { audio: { data: string } } };
+      }
+    ).message.realtimeInput.audio.data;
+    expect(auditedData).toContain("more chars redacted");
+    expect(auditedData.length).toBeLessThan(dataBase64.length);
+  });
+
+  it("resamples input audio to 24 kHz for OpenAI and passes Grok audio through", async () => {
+    const samples = Array.from({ length: 160 }, (_, index) => index * 10);
+    const dataBase64 = pcm16ToBase64(samples);
+
+    const openAi = createHarness(VOICE_AGENT_PROVIDER_OPENAI_REALTIME);
+    await openAi.ingestAudio(dataBase64);
+    await waitFor(() => openAi.socket.sent.length === 1);
+    openAi.socket.receive({ type: "session.updated" });
+    await waitFor(() => openAi.socket.sent.length >= 2);
+    const openAiAudio = (openAi.socket.sent[1] as { audio: string }).audio;
+    expect(base64ToPcm16(openAiAudio).length).toBe(Math.round(samples.length * 1.5));
+
+    const grok = createHarness(VOICE_AGENT_PROVIDER_GROK_REALTIME);
+    await grok.ingestAudio(dataBase64);
+    await waitFor(() => grok.socket.sent.length === 1);
+    grok.socket.receive({ type: "session.updated" });
+    await waitFor(() => grok.socket.sent.length >= 2);
+    expect((grok.socket.sent[1] as { audio: string }).audio).toBe(dataBase64);
+  });
+
+  it("appends provider output audio frames in provider order", async () => {
+    const harness = createHarness(VOICE_AGENT_PROVIDER_GEMINI_LIVE);
+    await harness.ingestText("Say something.");
+    await waitFor(() => harness.socket.sent.length === 1);
+    harness.socket.receive({ setupComplete: {} });
+    await waitFor(() => harness.socket.sent.length >= 2);
+
+    const first = pcm16ToBase64([1, 2, 3, 4]);
+    const second = pcm16ToBase64([5, 6, 7, 8]);
+    harness.socket.receive({
+      serverContent: { modelTurn: { parts: [{ inlineData: { data: first } }] } },
+    });
+    harness.socket.receive({
+      serverContent: { modelTurn: { parts: [{ inlineData: { data: second } }] } },
+    });
+
+    await waitFor(
+      () =>
+        harness.stream.events.filter(
+          (event) => event.type === VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+        ).length === 2,
+    );
+    const frames = harness.stream.events
+      .filter((event) => event.type === VOICE_AGENT_OUTPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE)
+      .map((event) => event.payload as { dataBase64: string; sequence: number });
+    expect(frames[0]).toMatchObject({ dataBase64: first, sequence: 0 });
+    expect(frames[1]).toMatchObject({ dataBase64: second, sequence: 1 });
+  });
+
+  it("requests a speaker buffer clear when Gemini output is interrupted", async () => {
+    const harness = createHarness(VOICE_AGENT_PROVIDER_GEMINI_LIVE);
+    await harness.ingestText("Say something.");
+    await waitFor(() => harness.socket.sent.length === 1);
+    harness.socket.receive({ setupComplete: {} });
+    await waitFor(() => harness.socket.sent.length >= 2);
+
+    harness.socket.receive({ serverContent: { interrupted: true } });
+
+    await waitFor(() =>
+      harness.stream.events.some(
+        (event) => event.type === VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
+      ),
+    );
+    expect(harness.stream.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
+          payload: expect.objectContaining({ reason: "output-interrupted" }),
+        }),
+        expect.objectContaining({
+          type: VOICE_AGENT_PROVIDER_STATUS_CHANGED_EVENT_TYPE,
+          payload: expect.objectContaining({ status: "output-interrupted" }),
+        }),
+      ]),
+    );
+  });
+
+  it("requests a speaker buffer clear when OpenAI-compatible speech starts", async () => {
+    const harness = createHarness(VOICE_AGENT_PROVIDER_OPENAI_REALTIME);
+    await harness.ingestText("Say something.");
+    await waitFor(() => harness.socket.sent.length === 1);
+    harness.socket.receive({ type: "session.updated" });
+    await waitFor(() => harness.socket.sent.length >= 2);
+
+    harness.socket.receive({ type: "input_audio_buffer.speech_started" });
+
+    await waitFor(() =>
+      harness.stream.events.some(
+        (event) => event.type === VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
+      ),
+    );
+    expect(harness.stream.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: VOICE_AGENT_SPEAKER_BUFFER_CLEAR_REQUESTED_EVENT_TYPE,
+          payload: expect.objectContaining({ reason: "input-speech-started" }),
+        }),
+      ]),
+    );
+  });
+
+  it("surfaces Gemini goAway as a going-away status event", async () => {
+    const harness = createHarness(VOICE_AGENT_PROVIDER_GEMINI_LIVE);
+    await harness.ingestText("Say something.");
+    await waitFor(() => harness.socket.sent.length === 1);
+    harness.socket.receive({ setupComplete: {} });
+    await waitFor(() => harness.socket.sent.length >= 2);
+
+    harness.socket.receive({ goAway: { timeLeft: "10s" } });
+
+    await waitFor(() =>
+      harness.stream.events.some(
+        (event) =>
+          event.type === VOICE_AGENT_PROVIDER_STATUS_CHANGED_EVENT_TYPE &&
+          (event.payload as { status?: unknown }).status === "going-away",
+      ),
+    );
+  });
+
+  it("appends an error event when input arrives before setup", async () => {
+    const stream = new MemoryStream();
+    const processor = new VoiceAgentProcessor({
+      stream,
+      geminiApiKey: "gemini_test",
+      openAiApiKey: "openai_test",
+      xAiApiKey: "xai_test",
+      openProviderWebSocket: async () => {
+        throw new Error("must not dial without setup");
+      },
+    });
+
+    await processor.ingest({
+      events: [
+        committedEvent(
+          {
+            type: VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
+            payload: { text: "Hello?" },
+          },
+          1001,
+        ),
+      ],
+      streamMaxOffset: 1001,
+    });
+
+    await waitFor(() =>
+      stream.events.some((event) => event.type === "events.iterate.com/voice-agent/error-occurred"),
+    );
+    expect(stream.events[0]?.payload).toMatchObject({
+      message: expect.stringContaining("setup-configured"),
+    });
+  });
+
+  it("stores parsed setup from setup-configured in reduced state", async () => {
+    const harness = createHarness(VOICE_AGENT_PROVIDER_OPENAI_REALTIME);
+    await harness.setupIngested;
+    const snapshot = await harness.processor.snapshot();
+    expect(snapshot.state.setup?.provider).toBe(VOICE_AGENT_PROVIDER_OPENAI_REALTIME);
+    expect(snapshot.state.setup?.model.length).toBeGreaterThan(0);
+  });
+});
+
+describe("resamplePcm16Base64", () => {
+  it("returns the input untouched when rates match", () => {
+    const dataBase64 = pcm16ToBase64([1, 2, 3]);
+    expect(resamplePcm16Base64({ dataBase64, fromSampleRate: 16_000, toSampleRate: 16_000 })).toBe(
+      dataBase64,
+    );
+  });
+
+  it("linearly interpolates when upsampling 16 kHz to 24 kHz", () => {
+    const dataBase64 = pcm16ToBase64([0, 300, 600]);
+    const result = base64ToPcm16(
+      resamplePcm16Base64({ dataBase64, fromSampleRate: 16_000, toSampleRate: 24_000 }),
+    );
+    expect(result).toEqual([0, 200, 400, 600, 600]);
+  });
+});
+
+describe("redactLargeStringsForAudit", () => {
+  it("truncates long strings anywhere in the structure and keeps short ones", () => {
+    const long = "x".repeat(5_000);
+    const redacted = redactLargeStringsForAudit({
+      keep: "short string",
+      audio: long,
+      nested: [{ delta: long }],
+    }) as { keep: string; audio: string; nested: [{ delta: string }] };
+
+    expect(redacted.keep).toBe("short string");
+    expect(redacted.audio).toContain("more chars redacted");
+    expect(redacted.audio.length).toBeLessThan(200);
+    expect(redacted.nested[0].delta).toContain("more chars redacted");
+  });
+});
+
+type Harness = {
+  processor: VoiceAgentProcessor;
+  socket: FakeWebSocket;
+  stream: MemoryStream;
+  setupIngested: Promise<void>;
+  ingestText: (text: string, options?: { source?: string }) => Promise<void>;
+  ingestAudio: (dataBase64: string) => Promise<void>;
+};
+
+function createHarness(
+  provider: VoiceAgentProvider,
+  setupOverrides: Partial<VoiceAgentSetup> = {},
+): Harness {
+  const socket = new FakeWebSocket();
+  const stream = new MemoryStream();
+  const processor = new VoiceAgentProcessor({
+    stream,
+    geminiApiKey: "gemini_test",
+    openAiApiKey: "openai_test",
+    xAiApiKey: "xai_test",
+    openProviderWebSocket: async () => socket as unknown as WebSocket,
+  });
+
+  // Ingested events use high offsets so appended events (offsets from 1) never
+  // collide with the ingest cursor.
+  let nextOffset = 1000;
+  const ingest = async (event: Omit<StreamEventInput, "offset">) => {
+    nextOffset += 1;
+    await processor.ingest({
+      events: [committedEvent(event as StreamEventInput, nextOffset)],
+      streamMaxOffset: nextOffset,
+    });
+  };
+
+  const setupIngested = ingest({
+    type: VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE,
+    payload: {
+      provider,
+      systemInstruction: "You are concise.",
+      ...setupOverrides,
+    },
+  });
+
+  return {
+    processor,
+    socket,
+    stream,
+    setupIngested,
+    ingestText: async (text, options = {}) => {
+      await setupIngested;
+      await ingest({
+        type: VOICE_AGENT_INPUT_TEXT_APPENDED_EVENT_TYPE,
+        payload: { text, ...(options.source == null ? {} : { source: options.source }) },
+      });
+    },
+    ingestAudio: async (dataBase64) => {
+      await setupIngested;
+      await ingest({
+        type: VOICE_AGENT_INPUT_AUDIO_FRAME_APPENDED_EVENT_TYPE,
+        payload: {
+          streamId: "client-1",
+          sequence: 0,
+          encoding: "pcm_s16le",
+          sampleRate: 16_000,
+          channels: 1,
+          durationMs: 100,
+          dataBase64,
+        },
+      });
+    },
+  };
+}
+
+function providerSentText(sent: unknown[], provider: VoiceAgentProvider) {
+  if (provider === VOICE_AGENT_PROVIDER_GEMINI_LIVE) {
+    const message = sent.find(
+      (candidate) => (candidate as { clientContent?: unknown }).clientContent != null,
+    ) as { clientContent?: { turns?: Array<{ parts?: Array<{ text?: string }> }> } } | undefined;
+    return message?.clientContent?.turns?.[0]?.parts?.[0]?.text ?? "";
+  }
+
+  const message = sent.find(
+    (candidate) => (candidate as { type?: unknown }).type === "conversation.item.create",
+  ) as { item?: { content?: Array<{ type?: string; text?: string }> } } | undefined;
+  return message?.item?.content?.find((part) => part.type === "input_text")?.text ?? "";
+}
+
+function committedEvent(input: StreamEventInput, offset: number): StreamEvent {
+  return {
+    ...input,
+    createdAt: "2026-07-03T00:00:00.000Z",
+    offset,
+  };
+}
+
+function pcm16ToBase64(samples: number[]) {
+  const bytes = new Uint8Array(samples.length * 2);
+  const view = new DataView(bytes.buffer);
+  samples.forEach((sample, index) => view.setInt16(index * 2, sample, true));
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+function base64ToPcm16(base64: string) {
+  const binary = atob(base64);
+  const samples: number[] = [];
+  for (let index = 0; index + 1 < binary.length; index += 2) {
+    const low = binary.charCodeAt(index);
+    const high = binary.charCodeAt(index + 1);
+    const value = (high << 8) | low;
+    samples.push(value >= 0x8000 ? value - 0x10000 : value);
+  }
+  return samples;
+}
+
+async function waitFor(predicate: () => boolean) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error("Timed out waiting for condition.");
+}
+
+class FakeWebSocket {
+  readonly sent: unknown[] = [];
+  readyState = 1;
+  #listeners = new Map<string, EventListener[]>();
+
+  send(data: string) {
+    this.sent.push(JSON.parse(data));
+  }
+
+  close() {
+    this.readyState = 3;
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.#listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.#listeners.set(type, listeners);
+  }
+
+  receive(message: unknown) {
+    for (const listener of this.#listeners.get("message") ?? []) {
+      listener({ data: JSON.stringify(message) } as MessageEvent);
+    }
+  }
+}

--- a/apps/os/src/domains/projects/project-processor-implementation.ts
+++ b/apps/os/src/domains/projects/project-processor-implementation.ts
@@ -26,6 +26,7 @@ import { VoiceAgentProcessorContract } from "../agents/voice-agent-processor-con
 import {
   isVoiceAgentPath,
   VOICE_AGENT_CODE_AGENT_SYSTEM_PROMPT,
+  VOICE_AGENT_PATH_PREFIX,
 } from "../agents/voice-agent-code-agent.ts";
 import { ProjectProcessorContract } from "./project-processor-contract.ts";
 
@@ -172,6 +173,9 @@ export class ProjectProcessor extends StreamProcessor<
       case "events.iterate.com/stream/child-stream-created": {
         const childPath = event.payload.childPath;
         if (!childPath.startsWith("/agents/") && !childPath.startsWith("/secrets/")) return;
+        // The bare /agents/voice container is a listing root (the voice-agents
+        // page's stream explorer creates it by subscribing), not an agent.
+        if (childPath === VOICE_AGENT_PATH_PREFIX) return;
         blockProcessorWhile(async () => {
           const durableObjectName = DurableObjectNameCodec.stringify({
             projectId: this.deps.itx.projectId,

--- a/apps/os/src/domains/projects/project-processor-implementation.ts
+++ b/apps/os/src/domains/projects/project-processor-implementation.ts
@@ -22,6 +22,11 @@ import { SecretProcessorContract } from "../secrets/secret-processor-contract.ts
 import { SlackAgentProcessorContract } from "../integrations/slack-agent-processor-contract.ts";
 import { SlackProcessorContract } from "../integrations/slack-processor-contract.ts";
 import { isSlackAgentPath, SLACK_INTEGRATION_STREAM_PATH } from "../integrations/utils.ts";
+import { VoiceAgentProcessorContract } from "../agents/voice-agent-processor-contract.ts";
+import {
+  isVoiceAgentPath,
+  VOICE_AGENT_CODE_AGENT_SYSTEM_PROMPT,
+} from "../agents/voice-agent-code-agent.ts";
 import { ProjectProcessorContract } from "./project-processor-contract.ts";
 
 const ONBOARDING_AGENT_PATH = "/agents/onboarding";
@@ -176,7 +181,10 @@ export class ProjectProcessor extends StreamProcessor<
             // Agents under /agents/slack/** additionally get the slack-agent
             // processor subscription and the Slack reply prompt — this is THE
             // place the "slack thread streams are slack agents" rule lives.
+            // Agents under /agents/voice/** likewise get the voice-agent
+            // processor subscription and the voice-operator-support prompt.
             const isSlack = isSlackAgentPath(childPath);
+            const isVoice = isVoiceAgentPath(childPath);
             await this.deps.itx.streams.get(childPath).append(
               // Identical idempotency keys to the create-time onboarding birth
               // certificate, so whichever lane runs second dedupes cleanly.
@@ -185,7 +193,12 @@ export class ProjectProcessor extends StreamProcessor<
                 llmProvider: this.deps.defaultLlmProvider,
                 projectId: this.deps.itx.projectId,
                 slack: isSlack,
-                systemPrompt: isSlack ? SLACK_AGENT_SYSTEM_PROMPT : DEFAULT_AGENT_SYSTEM_PROMPT,
+                voice: isVoice,
+                systemPrompt: isSlack
+                  ? SLACK_AGENT_SYSTEM_PROMPT
+                  : isVoice
+                    ? VOICE_AGENT_CODE_AGENT_SYSTEM_PROMPT
+                    : DEFAULT_AGENT_SYSTEM_PROMPT,
               }),
             );
             return;
@@ -265,6 +278,7 @@ function agentBirthCertificateEvents(input: {
   llmProvider: AgentLlmProvider;
   projectId: string;
   slack?: boolean;
+  voice?: boolean;
   systemPrompt: string;
 }) {
   const durableObjectName = DurableObjectNameCodec.stringify({
@@ -286,6 +300,7 @@ function agentBirthCertificateEvents(input: {
     subscription(OpenAiWsProcessorContract.slug, "agent"),
     subscription(ItxProcessorContract.slug, "itx"),
     ...(input.slack ? [subscription(SlackAgentProcessorContract.slug, "agent")] : []),
+    ...(input.voice ? [subscription(VoiceAgentProcessorContract.slug, "agent")] : []),
     {
       type: "events.iterate.com/agent/config-updated" as const,
       idempotencyKey: `agent/config-updated:${input.projectId}:${input.childPath}`,

--- a/apps/os/src/routeTree.gen.ts
+++ b/apps/os/src/routeTree.gen.ts
@@ -38,10 +38,12 @@ import { Route as AppProjectsProjectSlugReactivityRouteImport } from './routes/_
 import { Route as AppProjectsProjectSlugIntegrationsRouteImport } from './routes/_app/projects/$projectSlug/integrations'
 import { Route as AppProjectsProjectSlugStreamsRouteRouteImport } from './routes/_app/projects/$projectSlug/streams/route'
 import { Route as AppProjectsProjectSlugAgentsRouteRouteImport } from './routes/_app/projects/$projectSlug/agents/route'
+import { Route as AppProjectsProjectSlugVoiceAgentsIndexRouteImport } from './routes/_app/projects/$projectSlug/voice-agents/index'
 import { Route as AppProjectsProjectSlugStreamsIndexRouteImport } from './routes/_app/projects/$projectSlug/streams/index'
 import { Route as AppProjectsProjectSlugSecretsIndexRouteImport } from './routes/_app/projects/$projectSlug/secrets/index'
 import { Route as AppProjectsProjectSlugReposIndexRouteImport } from './routes/_app/projects/$projectSlug/repos/index'
 import { Route as AppProjectsProjectSlugAgentsIndexRouteImport } from './routes/_app/projects/$projectSlug/agents/index'
+import { Route as AppProjectsProjectSlugVoiceAgentsSplatRouteImport } from './routes/_app/projects/$projectSlug/voice-agents/$'
 import { Route as AppProjectsProjectSlugStreamsSplatRouteImport } from './routes/_app/projects/$projectSlug/streams/$'
 import { Route as AppProjectsProjectSlugSecretsSecretIdRouteImport } from './routes/_app/projects/$projectSlug/secrets/$secretId'
 import { Route as AppProjectsProjectSlugReposSplatRouteImport } from './routes/_app/projects/$projectSlug/repos/$'
@@ -203,6 +205,12 @@ const AppProjectsProjectSlugAgentsRouteRoute =
     path: '/agents',
     getParentRoute: () => AppProjectsProjectSlugRouteRoute,
   } as any)
+const AppProjectsProjectSlugVoiceAgentsIndexRoute =
+  AppProjectsProjectSlugVoiceAgentsIndexRouteImport.update({
+    id: '/voice-agents/',
+    path: '/voice-agents/',
+    getParentRoute: () => AppProjectsProjectSlugRouteRoute,
+  } as any)
 const AppProjectsProjectSlugStreamsIndexRoute =
   AppProjectsProjectSlugStreamsIndexRouteImport.update({
     id: '/',
@@ -226,6 +234,12 @@ const AppProjectsProjectSlugAgentsIndexRoute =
     id: '/',
     path: '/',
     getParentRoute: () => AppProjectsProjectSlugAgentsRouteRoute,
+  } as any)
+const AppProjectsProjectSlugVoiceAgentsSplatRoute =
+  AppProjectsProjectSlugVoiceAgentsSplatRouteImport.update({
+    id: '/voice-agents/$',
+    path: '/voice-agents/$',
+    getParentRoute: () => AppProjectsProjectSlugRouteRoute,
   } as any)
 const AppProjectsProjectSlugStreamsSplatRoute =
   AppProjectsProjectSlugStreamsSplatRouteImport.update({
@@ -291,10 +305,12 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/repos/$': typeof AppProjectsProjectSlugReposSplatRoute
   '/projects/$projectSlug/secrets/$secretId': typeof AppProjectsProjectSlugSecretsSecretIdRoute
   '/projects/$projectSlug/streams/$': typeof AppProjectsProjectSlugStreamsSplatRoute
+  '/projects/$projectSlug/voice-agents/$': typeof AppProjectsProjectSlugVoiceAgentsSplatRoute
   '/projects/$projectSlug/agents/': typeof AppProjectsProjectSlugAgentsIndexRoute
   '/projects/$projectSlug/repos/': typeof AppProjectsProjectSlugReposIndexRoute
   '/projects/$projectSlug/secrets/': typeof AppProjectsProjectSlugSecretsIndexRoute
   '/projects/$projectSlug/streams/': typeof AppProjectsProjectSlugStreamsIndexRoute
+  '/projects/$projectSlug/voice-agents/': typeof AppProjectsProjectSlugVoiceAgentsIndexRoute
   '/projects/$projectSlug/agents/streams/$': typeof AppProjectsProjectSlugAgentsStreamsSplatRoute
 }
 export interface FileRoutesByTo {
@@ -323,10 +339,12 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/repos/$': typeof AppProjectsProjectSlugReposSplatRoute
   '/projects/$projectSlug/secrets/$secretId': typeof AppProjectsProjectSlugSecretsSecretIdRoute
   '/projects/$projectSlug/streams/$': typeof AppProjectsProjectSlugStreamsSplatRoute
+  '/projects/$projectSlug/voice-agents/$': typeof AppProjectsProjectSlugVoiceAgentsSplatRoute
   '/projects/$projectSlug/agents': typeof AppProjectsProjectSlugAgentsIndexRoute
   '/projects/$projectSlug/repos': typeof AppProjectsProjectSlugReposIndexRoute
   '/projects/$projectSlug/secrets': typeof AppProjectsProjectSlugSecretsIndexRoute
   '/projects/$projectSlug/streams': typeof AppProjectsProjectSlugStreamsIndexRoute
+  '/projects/$projectSlug/voice-agents': typeof AppProjectsProjectSlugVoiceAgentsIndexRoute
   '/projects/$projectSlug/agents/streams/$': typeof AppProjectsProjectSlugAgentsStreamsSplatRoute
 }
 export interface FileRoutesById {
@@ -364,10 +382,12 @@ export interface FileRoutesById {
   '/_app/projects/$projectSlug/repos/$': typeof AppProjectsProjectSlugReposSplatRoute
   '/_app/projects/$projectSlug/secrets/$secretId': typeof AppProjectsProjectSlugSecretsSecretIdRoute
   '/_app/projects/$projectSlug/streams/$': typeof AppProjectsProjectSlugStreamsSplatRoute
+  '/_app/projects/$projectSlug/voice-agents/$': typeof AppProjectsProjectSlugVoiceAgentsSplatRoute
   '/_app/projects/$projectSlug/agents/': typeof AppProjectsProjectSlugAgentsIndexRoute
   '/_app/projects/$projectSlug/repos/': typeof AppProjectsProjectSlugReposIndexRoute
   '/_app/projects/$projectSlug/secrets/': typeof AppProjectsProjectSlugSecretsIndexRoute
   '/_app/projects/$projectSlug/streams/': typeof AppProjectsProjectSlugStreamsIndexRoute
+  '/_app/projects/$projectSlug/voice-agents/': typeof AppProjectsProjectSlugVoiceAgentsIndexRoute
   '/_app/projects/$projectSlug/agents/streams/$': typeof AppProjectsProjectSlugAgentsStreamsSplatRoute
 }
 export interface FileRouteTypes {
@@ -405,10 +425,12 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/repos/$'
     | '/projects/$projectSlug/secrets/$secretId'
     | '/projects/$projectSlug/streams/$'
+    | '/projects/$projectSlug/voice-agents/$'
     | '/projects/$projectSlug/agents/'
     | '/projects/$projectSlug/repos/'
     | '/projects/$projectSlug/secrets/'
     | '/projects/$projectSlug/streams/'
+    | '/projects/$projectSlug/voice-agents/'
     | '/projects/$projectSlug/agents/streams/$'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -437,10 +459,12 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/repos/$'
     | '/projects/$projectSlug/secrets/$secretId'
     | '/projects/$projectSlug/streams/$'
+    | '/projects/$projectSlug/voice-agents/$'
     | '/projects/$projectSlug/agents'
     | '/projects/$projectSlug/repos'
     | '/projects/$projectSlug/secrets'
     | '/projects/$projectSlug/streams'
+    | '/projects/$projectSlug/voice-agents'
     | '/projects/$projectSlug/agents/streams/$'
   id:
     | '__root__'
@@ -477,10 +501,12 @@ export interface FileRouteTypes {
     | '/_app/projects/$projectSlug/repos/$'
     | '/_app/projects/$projectSlug/secrets/$secretId'
     | '/_app/projects/$projectSlug/streams/$'
+    | '/_app/projects/$projectSlug/voice-agents/$'
     | '/_app/projects/$projectSlug/agents/'
     | '/_app/projects/$projectSlug/repos/'
     | '/_app/projects/$projectSlug/secrets/'
     | '/_app/projects/$projectSlug/streams/'
+    | '/_app/projects/$projectSlug/voice-agents/'
     | '/_app/projects/$projectSlug/agents/streams/$'
   fileRoutesById: FileRoutesById
 }
@@ -701,6 +727,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppProjectsProjectSlugAgentsRouteRouteImport
       parentRoute: typeof AppProjectsProjectSlugRouteRoute
     }
+    '/_app/projects/$projectSlug/voice-agents/': {
+      id: '/_app/projects/$projectSlug/voice-agents/'
+      path: '/voice-agents'
+      fullPath: '/projects/$projectSlug/voice-agents/'
+      preLoaderRoute: typeof AppProjectsProjectSlugVoiceAgentsIndexRouteImport
+      parentRoute: typeof AppProjectsProjectSlugRouteRoute
+    }
     '/_app/projects/$projectSlug/streams/': {
       id: '/_app/projects/$projectSlug/streams/'
       path: '/'
@@ -728,6 +761,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/projects/$projectSlug/agents/'
       preLoaderRoute: typeof AppProjectsProjectSlugAgentsIndexRouteImport
       parentRoute: typeof AppProjectsProjectSlugAgentsRouteRoute
+    }
+    '/_app/projects/$projectSlug/voice-agents/$': {
+      id: '/_app/projects/$projectSlug/voice-agents/$'
+      path: '/voice-agents/$'
+      fullPath: '/projects/$projectSlug/voice-agents/$'
+      preLoaderRoute: typeof AppProjectsProjectSlugVoiceAgentsSplatRouteImport
+      parentRoute: typeof AppProjectsProjectSlugRouteRoute
     }
     '/_app/projects/$projectSlug/streams/$': {
       id: '/_app/projects/$projectSlug/streams/$'
@@ -815,8 +855,10 @@ interface AppProjectsProjectSlugRouteRouteChildren {
   AppProjectsProjectSlugIndexRoute: typeof AppProjectsProjectSlugIndexRoute
   AppProjectsProjectSlugReposSplatRoute: typeof AppProjectsProjectSlugReposSplatRoute
   AppProjectsProjectSlugSecretsSecretIdRoute: typeof AppProjectsProjectSlugSecretsSecretIdRoute
+  AppProjectsProjectSlugVoiceAgentsSplatRoute: typeof AppProjectsProjectSlugVoiceAgentsSplatRoute
   AppProjectsProjectSlugReposIndexRoute: typeof AppProjectsProjectSlugReposIndexRoute
   AppProjectsProjectSlugSecretsIndexRoute: typeof AppProjectsProjectSlugSecretsIndexRoute
+  AppProjectsProjectSlugVoiceAgentsIndexRoute: typeof AppProjectsProjectSlugVoiceAgentsIndexRoute
 }
 
 const AppProjectsProjectSlugRouteRouteChildren: AppProjectsProjectSlugRouteRouteChildren =
@@ -836,10 +878,14 @@ const AppProjectsProjectSlugRouteRouteChildren: AppProjectsProjectSlugRouteRoute
       AppProjectsProjectSlugReposSplatRoute,
     AppProjectsProjectSlugSecretsSecretIdRoute:
       AppProjectsProjectSlugSecretsSecretIdRoute,
+    AppProjectsProjectSlugVoiceAgentsSplatRoute:
+      AppProjectsProjectSlugVoiceAgentsSplatRoute,
     AppProjectsProjectSlugReposIndexRoute:
       AppProjectsProjectSlugReposIndexRoute,
     AppProjectsProjectSlugSecretsIndexRoute:
       AppProjectsProjectSlugSecretsIndexRoute,
+    AppProjectsProjectSlugVoiceAgentsIndexRoute:
+      AppProjectsProjectSlugVoiceAgentsIndexRoute,
   }
 
 const AppProjectsProjectSlugRouteRouteWithChildren =

--- a/apps/os/src/routes/_app/projects/$projectSlug/voice-agents/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/voice-agents/$.tsx
@@ -1,0 +1,49 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { VoiceAgentConsole } from "~/components/voice-agent-console.tsx";
+import { ItxBoundary } from "~/components/itx-boundary.tsx";
+import { breadcrumbLoaderData } from "~/lib/route-breadcrumbs.ts";
+import { streamPathFromSplat, streamPathToSplat } from "~/lib/stream-links.ts";
+
+export const Route = createFileRoute("/_app/projects/$projectSlug/voice-agents/$")({
+  params: {
+    parse: (raw) => ({
+      _splat: streamPathFromSplat(raw._splat),
+    }),
+    stringify: (parsed) => ({
+      _splat: streamPathToSplat(parsed._splat),
+    }),
+  },
+  ssr: false,
+  loader: ({ context, params }) => {
+    const streamPath = params._splat;
+    const { project } = context;
+
+    return breadcrumbLoaderData({
+      breadcrumb: streamPath,
+      project,
+      streamPath,
+      streamBreadcrumb: {
+        projectId: project.id,
+        projectSlug: params.projectSlug,
+        streamPath,
+      },
+    });
+  },
+  component: VoiceAgentConversationPage,
+});
+
+function VoiceAgentConversationPage() {
+  const params = Route.useParams();
+  const { project, streamPath } = Route.useLoaderData();
+
+  return (
+    <ItxBoundary>
+      <VoiceAgentConsole
+        projectId={project.id}
+        projectSlug={params.projectSlug}
+        streamPath={streamPath}
+        title="Voice agent"
+      />
+    </ItxBoundary>
+  );
+}

--- a/apps/os/src/routes/_app/projects/$projectSlug/voice-agents/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/voice-agents/index.tsx
@@ -1,0 +1,265 @@
+import { useMemo, useState } from "react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Button } from "@iterate-com/ui/components/button";
+import { Input } from "@iterate-com/ui/components/input";
+import { Textarea } from "@iterate-com/ui/components/textarea";
+import { toast } from "@iterate-com/ui/components/sonner";
+import { cn } from "@iterate-com/ui/lib/utils";
+import { ItxBoundary } from "~/components/itx-boundary.tsx";
+import { StreamExplorerTreePage } from "~/components/stream-explorer.tsx";
+import {
+  DEFAULT_GROK_REALTIME_MODEL,
+  DEFAULT_GROK_REALTIME_VOICE,
+  DEFAULT_GEMINI_LIVE_MODEL,
+  DEFAULT_GEMINI_LIVE_VOICE,
+  DEFAULT_OPENAI_REALTIME_MODEL,
+  DEFAULT_OPENAI_REALTIME_VOICE,
+  DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION,
+  VOICE_AGENT_PROVIDER_GROK_REALTIME,
+  VOICE_AGENT_PROVIDER_GEMINI_LIVE,
+  VOICE_AGENT_PROVIDER_OPENAI_REALTIME,
+  VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE,
+  type VoiceAgentProvider,
+} from "~/domains/agents/voice-agent-processor-contract.ts";
+import { VOICE_AGENT_PATH_PREFIX } from "~/domains/agents/voice-agent-code-agent.ts";
+import { connectItxBrowser, useItx } from "~/itx/itx-react.tsx";
+import { StreamPath } from "~/lib/stream-links.ts";
+
+type ProviderOption = {
+  provider: VoiceAgentProvider;
+  label: string;
+  model: string;
+  voiceName: string;
+};
+
+const PROVIDER_OPTIONS: ProviderOption[] = [
+  {
+    provider: VOICE_AGENT_PROVIDER_GEMINI_LIVE,
+    label: "Gemini Live",
+    model: DEFAULT_GEMINI_LIVE_MODEL,
+    voiceName: DEFAULT_GEMINI_LIVE_VOICE,
+  },
+  {
+    provider: VOICE_AGENT_PROVIDER_OPENAI_REALTIME,
+    label: "OpenAI Realtime",
+    model: DEFAULT_OPENAI_REALTIME_MODEL,
+    voiceName: DEFAULT_OPENAI_REALTIME_VOICE,
+  },
+  {
+    provider: VOICE_AGENT_PROVIDER_GROK_REALTIME,
+    label: "Grok Realtime",
+    model: DEFAULT_GROK_REALTIME_MODEL,
+    voiceName: DEFAULT_GROK_REALTIME_VOICE,
+  },
+];
+
+const DEFAULT_MODELS = Object.fromEntries(
+  PROVIDER_OPTIONS.map((option) => [option.provider, option.model]),
+) as Record<VoiceAgentProvider, string>;
+
+const DEFAULT_VOICES = Object.fromEntries(
+  PROVIDER_OPTIONS.map((option) => [option.provider, option.voiceName]),
+) as Record<VoiceAgentProvider, string>;
+
+export const Route = createFileRoute("/_app/projects/$projectSlug/voice-agents/")({
+  // Voice agents ARE agent streams under /agents/voice: the listing is the
+  // stream explorer scoped there, plus a "start conversation" form that
+  // appends the setup-configured birth fact.
+  ssr: false,
+  loader: ({ context }) => ({
+    breadcrumb: "Voice agents",
+    project: context.project,
+  }),
+  component: VoiceAgentsIndexPage,
+});
+
+function VoiceAgentsIndexPage() {
+  return (
+    <ItxBoundary>
+      <VoiceAgentsIndexContent />
+    </ItxBoundary>
+  );
+}
+
+function VoiceAgentsIndexContent() {
+  const params = Route.useParams();
+  const { project } = Route.useLoaderData();
+  const navigate = useNavigate();
+  const itx = useItx();
+  const source = useMemo(() => (streamPath: string) => itx.streams.get(streamPath), [itx]);
+  const [isCreating, setIsCreating] = useState(false);
+  const [selectedProvider, setSelectedProvider] = useState<VoiceAgentProvider>(
+    VOICE_AGENT_PROVIDER_GEMINI_LIVE,
+  );
+  const [models, setModels] = useState<Record<VoiceAgentProvider, string>>(DEFAULT_MODELS);
+  const [voices, setVoices] = useState<Record<VoiceAgentProvider, string>>(DEFAULT_VOICES);
+  const [systemInstruction, setSystemInstruction] = useState(
+    DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION,
+  );
+
+  function openPath(streamPath: string) {
+    // /agents/voice itself is not a conversation — open its raw stream.
+    if (streamPath === VOICE_AGENT_PATH_PREFIX) {
+      void navigate({
+        to: "/projects/$projectSlug/streams/$",
+        params: { projectSlug: params.projectSlug, _splat: streamPath },
+      });
+      return;
+    }
+    void navigate({
+      to: "/projects/$projectSlug/voice-agents/$",
+      params: { projectSlug: params.projectSlug, _splat: streamPath },
+    });
+  }
+
+  async function startConversation() {
+    const model = models[selectedProvider].trim();
+    const voiceName = voices[selectedProvider].trim();
+    if (!model || !voiceName) {
+      toast.error("Model and voice are required.");
+      return;
+    }
+
+    setIsCreating(true);
+    const streamPath = StreamPath.parse(
+      `${VOICE_AGENT_PATH_PREFIX}/voice-${Date.now().toString(36)}`,
+    );
+    try {
+      // The first append creates the stream; the project processor reacts to
+      // the child-stream-created fact by appending the voice agent's birth
+      // certificate (processor subscriptions + code-agent prompt).
+      const itxHandle = await connectItxBrowser({ projectId: project.id });
+      await itxHandle.streams.get(streamPath).append({
+        type: VOICE_AGENT_SETUP_CONFIGURED_EVENT_TYPE,
+        idempotencyKey: `voice-agent-setup:${project.id}:${streamPath}`,
+        payload: {
+          provider: selectedProvider,
+          model,
+          voiceName,
+          systemInstruction: systemInstruction.trim() || DEFAULT_VOICE_AGENT_SYSTEM_INSTRUCTION,
+        },
+      });
+      void navigate({
+        to: "/projects/$projectSlug/voice-agents/$",
+        params: {
+          projectSlug: params.projectSlug,
+          _splat: streamPath,
+        },
+      });
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not start voice agent.");
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  const header = (
+    <section className="rounded-lg border bg-background p-4">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 flex-1 space-y-4">
+          <div>
+            <h2 className="text-sm font-semibold">New conversation</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Pick the backend before the stream starts.
+            </p>
+          </div>
+
+          <div className="grid gap-3 xl:grid-cols-[minmax(14rem,18rem)_minmax(0,1fr)_minmax(0,1fr)]">
+            <div>
+              <div className="text-xs font-medium text-muted-foreground">Backend</div>
+              <div className="mt-2 grid grid-cols-1 gap-1 rounded-lg border bg-muted/30 p-1">
+                {PROVIDER_OPTIONS.map((option) => (
+                  <button
+                    key={option.provider}
+                    type="button"
+                    aria-pressed={selectedProvider === option.provider}
+                    className={cn(
+                      "rounded-md px-3 py-2 text-left text-sm font-medium transition-colors",
+                      selectedProvider === option.provider
+                        ? "bg-background text-foreground shadow-sm"
+                        : "text-muted-foreground hover:bg-background/70 hover:text-foreground",
+                    )}
+                    onClick={() => setSelectedProvider(option.provider)}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <label
+                className="text-xs font-medium text-muted-foreground"
+                htmlFor="voice-agent-model"
+              >
+                Model
+              </label>
+              <Input
+                id="voice-agent-model"
+                value={models[selectedProvider]}
+                onChange={(event) =>
+                  setModels((current) => ({
+                    ...current,
+                    [selectedProvider]: event.currentTarget.value,
+                  }))
+                }
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label
+                className="text-xs font-medium text-muted-foreground"
+                htmlFor="voice-agent-voice"
+              >
+                Voice
+              </label>
+              <Input
+                id="voice-agent-voice"
+                value={voices[selectedProvider]}
+                onChange={(event) =>
+                  setVoices((current) => ({
+                    ...current,
+                    [selectedProvider]: event.currentTarget.value,
+                  }))
+                }
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label
+              className="text-xs font-medium text-muted-foreground"
+              htmlFor="voice-agent-system-instruction"
+            >
+              System instruction
+            </label>
+            <Textarea
+              id="voice-agent-system-instruction"
+              className="min-h-20"
+              value={systemInstruction}
+              onChange={(event) => setSystemInstruction(event.currentTarget.value)}
+            />
+          </div>
+        </div>
+
+        <Button
+          type="button"
+          className="w-full lg:w-auto"
+          disabled={isCreating}
+          onClick={() => void startConversation()}
+        >
+          {isCreating ? "Starting..." : "Start conversation"}
+        </Button>
+      </div>
+    </section>
+  );
+
+  return (
+    <StreamExplorerTreePage
+      header={header}
+      source={source}
+      rootPath={VOICE_AGENT_PATH_PREFIX}
+      onOpenPath={openPath}
+    />
+  );
+}


### PR DESCRIPTION
Re-implementation of the voice agent work from `voice-agent-processor-split` (PR #1351) on the current architecture — the class-based stream processors, agent Durable Object hosting, and the itx browser socket.

## What this adds

**Voice conversations are agent streams under `/agents/voice/**`.** The project processor's birth certificate gives them the standard agent processor set plus a `voice-agent` processor subscription and a voice-operator-support system prompt for the code agent — the same lane the slack-agent rule lives in.

**The `voice-agent` processor** (`apps/os/src/domains/agents/voice-agent-processor-{contract,implementation}.ts`) is hosted by `AgentDurableObject` alongside the agent/LLM processors. It forwards appended input PCM frames and text to the realtime voice provider selected by `voice-agent/setup-configured` — Gemini Live, OpenAI Realtime, or Grok Realtime — over an outbound fetch-upgrade WebSocket, and appends provider output (24 kHz PCM frames, transcripts, status signals, audited provider messages with audio redacted) back onto the same stream.

**The messageAgent tool bridge.** The voice model gets one tool: `messageAgent`, which appends `agent/input-added` on the shared stream. The colocated agent processor picks it up like any other input, runs its codemode loop, and replies by appending `voice-agent/input-text-appended` with `source: "code-agent"` via `itx.agent.stream` — which the voice processor wraps with relay instructions and speaks to the caller.

**Browser console + routes.** `/projects/$slug/voice-agents/` (start a conversation: provider/model/voice/system instruction) and `/projects/$slug/voice-agents/$` (the audio console). Mic capture and speaker playback run through PCM16 audio worklets (`public/voice-agent/`); transport is the itx socket — `stream.append` for 100 ms mic frames (bounded queue, single-flight batching), live `stream.subscribe` for playback/transcripts.

**Config.** `geminiApiKey` and `xAiApiKey` join AppConfig (`openAiApiKey` already existed). Doppler dev/preview/prd already carry `APP_CONFIG_GEMINI_API_KEY` / `APP_CONFIG_X_AI_API_KEY`, so no alchemy changes.

## Dropped from the old branch

Legacy `voice-agent/config-updated`, retired per-provider processor slugs, stream circuit-breaker events, the dedicated `StreamProcessorDurableObject`, and the `ensureCodeAgent` wake seam — the shared-stream subscription model makes the explicit wake unnecessary, and the rest have no counterpart on the new stack.

## Testing

- 18 unit tests ported to the MemoryStream + `ingest` harness (`voice-agent-processors.test.ts`): tool bridging for all three providers, required tool choice via Gemini system instruction, code-agent relay wrapping, audio resampling (16→24 kHz for OpenAI), audit redaction, output frame ordering, interruption/speaker-clear, goAway.
- `pnpm typecheck && pnpm lint && pnpm format && pnpm test` green.

**Verified live against a local dev server** (real Gemini Live over the dev API key):

- CLI smoke of the whole loop on a fresh project: append `setup-configured` + text input → real Gemini WebSocket (`provider-connected` → `session-ready`) → 15 output audio frames (2.5 s @ 24 kHz) + transcript, zero errors.
- messageAgent bridge round trip: Gemini tool call → `agent/input-added` ("What is 17 * 23?") → agent processor → openai-ws LLM → codemode script appending `voice-agent/input-text-appended` with `source: "code-agent"` via `itx.agent.stream` → voice processor relay → Gemini spoke *"I have the answer for you: 17 times 23 is 391. Anything else?"* (29 audio frames).
- Browser UI (headless Chrome, fake mic): `/voice-agents` index renders, Start conversation creates the stream + birth certificate and navigates to the console; console subscription goes Live; Start mic captured and uploaded 217 PCM frames over the itx socket (0 dropped), all forwarded to the live Gemini session, zero errors.

Notes: local `pnpm dev` on pristine main needs the alchemy→miniflare symlink workaround (compat date 2026-06-17 vs pinned workerd ≤2026-05-01); preview `deploy + e2e` is currently flaky across PRs on a `pkg.pr.new/captun` 404 during `pnpm install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new surface (outbound provider WebSockets, mic/audio in the browser, API keys) on the agent DO path; failures are mostly stream-level errors and unit-tested, but live behavior depends on third-party realtime APIs.
> 
> **Overview**
> Adds **realtime voice conversations** as agent streams under `/agents/voice/**`, wired into the existing agent Durable Object and project birth-certificate flow (mirroring the slack-agent pattern).
> 
> A new **`voice-agent` stream processor** bridges the shared stream to **Gemini Live, OpenAI Realtime, or Grok Realtime** over outbound WebSockets: mic PCM/text in, 24 kHz PCM/transcripts/status out, with ordered forwarding, provider audit events (audio redacted), and missing-key errors on the stream instead of host crashes. **`geminiApiKey`** and **`xAiApiKey`** join AppConfig; keys are read non-throwing like OpenAI.
> 
> The voice model gets a **`messageAgent` tool** that appends `agent/input-added` for the colocated code agent; replies via `voice-agent/input-text-appended` (`source: "code-agent"`) are wrapped with relay instructions before going back to the provider.
> 
> **UI:** sidebar entry for `/agents/voice`, routes to list/start conversations and an in-browser **`VoiceAgentConsole`** (live subscribe, bounded batched mic uploads, PCM16 **AudioWorklet** capture/playback). **18 unit tests** cover tool bridging, resampling, ordering, interruption/clear, and audit redaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aed05a6a198efed141960e825aafcf5e986de38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "tests-failed",
      "updatedAt": "2026-07-03T06:46:03.479Z",
      "headSha": "7aed05a6a198efed141960e825aafcf5e986de38",
      "message": "...(truncated)\node_modules/ws/lib/websocket.js:1046:13%0A%0A\n\n::error file=/home/runner/work/iterate/iterate/apps/os/e2e/examples/examples-matrix.e2e.test.ts,title=[node] e2e/examples/examples-matrix.e2e.test.ts > catalogue example \"journal-is-the-record\" runs identically across runtimes,line=101,column=17::Error: example \"journal-is-the-record\" failed in the node runtime: WebSocket connection failed.%0A ❯ e2e/examples/examples-matrix.e2e.test.ts:101:17%0A%0ACaused by: Caused by: Error: WebSocket connection failed.%0A ❯ WebSocket.<anonymous> ../../node_modules/.pnpm/capnweb@https+++github.com+iterate+capnweb+releases+download+v0.8.0-websocket.1+capnweb_2491d7b2aab66aad69cd458e61ff1183/node_modules/capnweb/dist/index.js:2387:40%0A ❯ callListener ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/event-target.js:290:14%0A ❯ WebSocket.onError ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/event-target.js:230:9%0A ❯ emitErrorAndClose ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/websocket.js:1046:13%0A%0A\n\n::error file=/home/runner/work/iterate/iterate/apps/os/e2e/examples/examples-matrix.e2e.test.ts,title=[node] e2e/examples/examples-matrix.e2e.test.ts > catalogue example \"agent-send-message\" runs identically across runtimes,line=101,column=17::Error: example \"agent-send-message\" failed in the node runtime: WebSocket connection failed.%0A ❯ e2e/examples/examples-matrix.e2e.test.ts:101:17%0A%0ACaused by: Caused by: Error: WebSocket connection failed.%0A ❯ WebSocket.<anonymous> ../../node_modules/.pnpm/capnweb@https+++github.com+iterate+capnweb+releases+download+v0.8.0-websocket.1+capnweb_2491d7b2aab66aad69cd458e61ff1183/node_modules/capnweb/dist/index.js:2387:40%0A ❯ callListener ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/event-target.js:290:14%0A ❯ WebSocket.onError ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/event-target.js:230:9%0A ❯ emitErrorAndClose ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/websocket.js:1046:13%0A%0A\n\n::error file=/home/runner/work/iterate/iterate/apps/os/e2e/examples/examples-matrix.e2e.test.ts,title=[node] e2e/examples/examples-matrix.e2e.test.ts > catalogue example \"browse-examples\" runs identically across runtimes,line=101,column=17::Error: example \"browse-examples\" failed in the node runtime: WebSocket connection failed.%0A ❯ e2e/examples/examples-matrix.e2e.test.ts:101:17%0A%0ACaused by: Caused by: Error: WebSocket connection failed.%0A ❯ WebSocket.<anonymous> ../../node_modules/.pnpm/capnweb@https+++github.com+iterate+capnweb+releases+download+v0.8.0-websocket.1+capnweb_2491d7b2aab66aad69cd458e61ff1183/node_modules/capnweb/dist/index.js:2387:40%0A ❯ callListener ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/event-target.js:290:14%0A ❯ WebSocket.onError ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/event-target.js:230:9%0A ❯ emitErrorAndClose ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/websocket.js:1046:13%0A%0A\n\n::error file=/home/runner/work/iterate/iterate/apps/os/e2e/vitest/admin-project.itx.e2e.test.ts,title=[node] e2e/vitest/admin-project.itx.e2e.test.ts > creates a disposable project and uses project streams through itx,line=56,column=6::AssertionError: expected false to be true // Object.is equality%0A%0A- Expected%0A+ Received%0A%0A- true%0A+ false%0A%0A ❯ e2e/vitest/admin-project.itx.e2e.test.ts:56:6%0A%0ACaused by: Caused by: Error: Matcher did not succeed in time.%0A ❯ e2e/vitest/admin-project.itx.e2e.test.ts:51:3%0A%0A\n\n::error file=/home/runner/work/iterate/iterate/apps/os/e2e/vitest/itx.e2e.test.ts,title=[node] e2e/vitest/itx.e2e.test.ts > itx > Live capabilities reject the removed target spelling,line=2488,column=6::AssertionError: expected [Function] to throw error matching /require \"capability\"/ but got 'WebSocket connection failed.'%0A%0A- Expected:%0A/require \"capability\"/%0A%0A+ Received:%0A\"WebSocket connection failed.\"%0A%0A ❯ e2e/vitest/itx.e2e.test.ts:2488:6%0A%0A\n ELIFECYCLE  Command failed with exit code 1.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/291189302542010",
      "shortSha": "7aed05a",
      "deployDurationMs": 42802,
      "testDurationMs": 753973
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "deployed",
      "updatedAt": "2026-07-03T06:33:30.120Z",
      "headSha": "7aed05a6a198efed141960e825aafcf5e986de38",
      "message": null,
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/291189302542010",
      "shortSha": "7aed05a",
      "deployDurationMs": 25461,
      "testDurationMs": 611
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_5",
    "leasedUntil": 1783063962743,
    "leaseId": "de321f34-65cf-42bb-be72-2aa25e82edd3",
    "slug": "preview-5",
    "type": "environment-config-lease"
  }
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>Lease: preview-5 | Doppler config: preview_5 | Type: environment-config-lease | Leased until: 2026-07-03T07:32:42.743Z</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | deployed | `7aed05a` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 25.5s | 611ms |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/291189302542010) | 2026-07-03T06:33:30.120Z |  |
| OS | tests failed | `7aed05a` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 42.8s | 754.0s |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/291189302542010) | 2026-07-03T06:46:03.479Z | ::error file=/home/runner/work/iterate/iterate/apps/os/e2e/examples/examples-matrix.e2e.test.ts,title=[node] e2e/examples/examples-matrix.e2e.test.ts > catalogue example "journal-... |

</details>

<details>
<summary>OS failure details</summary>

<pre>...(truncated)
ode_modules/ws/lib/websocket.js:1046:13%0A%0A

::error file=/home/runner/work/iterate/iterate/apps/os/e2e/examples/examples-matrix.e2e.test.ts,title=[node] e2e/examples/examples-matrix.e2e.test.ts &gt; catalogue example "journal-is-the-record" runs identically across runtimes,line=101,column=17::Error: example "journal-is-the-record" failed in the node runtime: WebSocket connection failed.%0A ❯ e2e/examples/examples-matrix.e2e.test.ts:101:17%0A%0ACaused by: Caused by: Error: WebSocket connection failed.%0A ❯ WebSocket.&lt;anonymous&gt; ../../node_modules/.pnpm/capnweb@https+++github.com+iterate+capnweb+releases+download+v0.8.0-websocket.1+capnweb_2491d7b2aab66aad69cd458e61ff1183/node_modules/capnweb/dist/index.js:2387:40%0A ❯ callListener ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/event-target.js:290:14%0A ❯ WebSocket.onError ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/event-target.js:230:9%0A ❯ emitErrorAndClose ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/websocket.js:1046:13%0A%0A

::error file=/home/runner/work/iterate/iterate/apps/os/e2e/examples/examples-matrix.e2e.test.ts,title=[node] e2e/examples/examples-matrix.e2e.test.ts &gt; catalogue example "agent-send-message" runs identically across runtimes,line=101,column=17::Error: example "agent-send-message" failed in the node runtime: WebSocket connection failed.%0A ❯ e2e/examples/examples-matrix.e2e.test.ts:101:17%0A%0ACaused by: Caused by: Error: WebSocket connection failed.%0A ❯ WebSocket.&lt;anonymous&gt; ../../node_modules/.pnpm/capnweb@https+++github.com+iterate+capnweb+releases+download+v0.8.0-websocket.1+capnweb_2491d7b2aab66aad69cd458e61ff1183/node_modules/capnweb/dist/index.js:2387:40%0A ❯ callListener ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/event-target.js:290:14%0A ❯ WebSocket.onError ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/event-target.js:230:9%0A ❯ emitErrorAndClose ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/websocket.js:1046:13%0A%0A

::error file=/home/runner/work/iterate/iterate/apps/os/e2e/examples/examples-matrix.e2e.test.ts,title=[node] e2e/examples/examples-matrix.e2e.test.ts &gt; catalogue example "browse-examples" runs identically across runtimes,line=101,column=17::Error: example "browse-examples" failed in the node runtime: WebSocket connection failed.%0A ❯ e2e/examples/examples-matrix.e2e.test.ts:101:17%0A%0ACaused by: Caused by: Error: WebSocket connection failed.%0A ❯ WebSocket.&lt;anonymous&gt; ../../node_modules/.pnpm/capnweb@https+++github.com+iterate+capnweb+releases+download+v0.8.0-websocket.1+capnweb_2491d7b2aab66aad69cd458e61ff1183/node_modules/capnweb/dist/index.js:2387:40%0A ❯ callListener ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/event-target.js:290:14%0A ❯ WebSocket.onError ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/event-target.js:230:9%0A ❯ emitErrorAndClose ../../node_modules/.pnpm/ws@8.19.0/node_modules/ws/lib/websocket.js:1046:13%0A%0A

::error file=/home/runner/work/iterate/iterate/apps/os/e2e/vitest/admin-project.itx.e2e.test.ts,title=[node] e2e/vitest/admin-project.itx.e2e.test.ts &gt; creates a disposable project and uses project streams through itx,line=56,column=6::AssertionError: expected false to be true // Object.is equality%0A%0A- Expected%0A+ Received%0A%0A- true%0A+ false%0A%0A ❯ e2e/vitest/admin-project.itx.e2e.test.ts:56:6%0A%0ACaused by: Caused by: Error: Matcher did not succeed in time.%0A ❯ e2e/vitest/admin-project.itx.e2e.test.ts:51:3%0A%0A

::error file=/home/runner/work/iterate/iterate/apps/os/e2e/vitest/itx.e2e.test.ts,title=[node] e2e/vitest/itx.e2e.test.ts &gt; itx &gt; Live capabilities reject the removed target spelling,line=2488,column=6::AssertionError: expected [Function] to throw error matching /require "capability"/ but got 'WebSocket connection failed.'%0A%0A- Expected:%0A/require "capability"/%0A%0A+ Received:%0A"WebSocket connection failed."%0A%0A ❯ e2e/vitest/itx.e2e.test.ts:2488:6%0A%0A
 ELIFECYCLE  Command failed with exit code 1.</pre>

</details>
<!-- /CLOUDFLARE_PREVIEW -->
