### PR TITLE
Keep OS auth JWKS in sync

### DIFF
--- a/apps/auth/src/lib/server.ts
+++ b/apps/auth/src/lib/server.ts
@@ -346,6 +346,18 @@ export type AuthenticateResult = {
   responseHeaders: Headers;
 };
 
+export type AuthenticateErrorReason =
+  | "session_cookie_parse_failed"
+  | "session_refresh_failed"
+  | "access_token_verify_failed"
+  | "id_token_verify_failed"
+  | "session_claims_parse_failed";
+
+export type AuthenticateErrorEvent = {
+  reason: AuthenticateErrorReason;
+  error: unknown;
+};
+
 export type AuthenticateOptions = {
   /**
    * Fetch fresh userinfo claims from the issuer while authenticating a cookie
@@ -353,6 +365,8 @@ export type AuthenticateOptions = {
    * validation stays local to the worker isolate.
    */
   includeUserInfo?: boolean;
+  /** Reports why a present session cookie could not become an authenticated session. */
+  onError?: (event: AuthenticateErrorEvent) => void;
 };
 
 export function createAuthMiddleware(config: IterateAuthConfig, infra: OAuthInfra) {
@@ -372,6 +386,7 @@ export function createAuthMiddleware(config: IterateAuthConfig, infra: OAuthInfr
     async authenticate({
       headers,
       includeUserInfo = true,
+      onError,
     }: { headers: Headers } & AuthenticateOptions): Promise<AuthenticateResult> {
       const cookieJar = parse(headers.get("Cookie") ?? "");
       if (!cookieJar) return { session: null, responseHeaders: new Headers() };
@@ -379,7 +394,8 @@ export function createAuthMiddleware(config: IterateAuthConfig, infra: OAuthInfr
       let tokenSet: TokenSet;
       try {
         tokenSet = TokenSet.parse(JSON.parse(cookieJar[SESSION_COOKIE]));
-      } catch {
+      } catch (error) {
+        onError?.({ reason: "session_cookie_parse_failed", error });
         return { session: null, responseHeaders: new Headers() };
       }
 
@@ -404,7 +420,8 @@ export function createAuthMiddleware(config: IterateAuthConfig, infra: OAuthInfr
           } else if (accessTokenExpired) {
             return { session: null, responseHeaders: new Headers() };
           }
-        } catch {
+        } catch (error) {
+          onError?.({ reason: "session_refresh_failed", error });
           // A failed refresh while the current access token is still valid is
           // not fatal: serve this request with the existing token and let a
           // later request retry the refresh.
@@ -416,16 +433,31 @@ export function createAuthMiddleware(config: IterateAuthConfig, infra: OAuthInfr
         return { session: null, responseHeaders: new Headers() };
       }
 
+      let rawAccessToken: unknown;
       try {
-        const { payload: rawAccessToken } = await jwtVerify(tokenSet.accessToken, jwks, {
+        const { payload } = await jwtVerify(tokenSet.accessToken, jwks, {
           issuer,
           audience: audiences(),
         });
-        const { payload: rawIdToken } = await jwtVerify(tokenSet.idToken, jwks, {
+        rawAccessToken = payload;
+      } catch (error) {
+        onError?.({ reason: "access_token_verify_failed", error });
+        return { session: null, responseHeaders: new Headers() };
+      }
+
+      let rawIdToken: unknown;
+      try {
+        const { payload } = await jwtVerify(tokenSet.idToken, jwks, {
           issuer,
           audience: config.clientId,
         });
+        rawIdToken = payload;
+      } catch (error) {
+        onError?.({ reason: "id_token_verify_failed", error });
+        return { session: null, responseHeaders: new Headers() };
+      }
 
+      try {
         const accessToken = AccessTokenClaims.parse(rawAccessToken);
         const idToken = IdTokenClaims.parse(rawIdToken);
         const userInfo = includeUserInfo ? await getUserInfo(tokenSet.accessToken) : null;
@@ -439,7 +471,8 @@ export function createAuthMiddleware(config: IterateAuthConfig, infra: OAuthInfr
           session: buildAuthenticatedSession(accessToken, idToken, userInfo),
           responseHeaders,
         };
-      } catch {
+      } catch (error) {
+        onError?.({ reason: "session_claims_parse_failed", error });
         return { session: null, responseHeaders: new Headers() };
       }
     },

--- a/apps/os/docs/architecture-and-operations.md
+++ b/apps/os/docs/architecture-and-operations.md
@@ -178,7 +178,9 @@ target Doppler config (`dev_<name>`, `preview_1`–`preview_9`, `prd`) it
 ensures two OAuth clients (web + MCP/CLI) via the auth contract's
 `internal.oauth.ensureClient`, then writes `APP_CONFIG_BASE_URL`,
 `APP_CONFIG_MCP__BASE_URL`, `APP_CONFIG_PROJECT_HOSTNAME_BASES`, and the
-`ITERATE_OAUTH_*` / `ITERATE_MCP_OAUTH_*` values back to Doppler.
+`ITERATE_OAUTH_*` / `ITERATE_MCP_OAUTH_*` values back to Doppler. It also
+copies the live auth worker JWKS into `ITERATE_AUTH_JWKS` so the next OS deploy
+bakes keys that can verify tokens issued by the current auth worker.
 
 It requires `SERVICE_AUTH_TOKEN` (run through Doppler for the auth project).
 `AUTH_CLIENT_SYNC_TARGETS` filters targets;

--- a/apps/os/scripts/sync-auth-clients.ts
+++ b/apps/os/scripts/sync-auth-clients.ts
@@ -16,6 +16,10 @@ type SeedOAuthClientSpec = {
   referenceId?: string;
 };
 
+type JsonWebKeySet = {
+  keys: unknown[];
+};
+
 const targets: Target[] = [
   ...[1, 2, 3, 4, 5, 6, 7, 8, 9].map(
     (previewNumber) =>
@@ -58,6 +62,7 @@ if (!serviceToken) {
 
 const authClient = createAuthContractClient({ baseUrl: authBaseUrl, serviceToken });
 const seedOAuthClients = readSeedOAuthClients();
+const authJwks = await fetchAuthJwks();
 
 for (const target of targets) {
   if (targetFilter.size > 0 && !targetFilter.has(target.dopplerConfig)) {
@@ -108,6 +113,7 @@ for (const target of targets) {
     ITERATE_MCP_OAUTH_CLIENT_ID: mcpClient.clientId,
     ITERATE_MCP_OAUTH_CLIENT_SECRET: mcpClient.clientSecret,
     ITERATE_AUTH_SERVICE_TOKEN: serviceToken,
+    ITERATE_AUTH_JWKS: JSON.stringify(authJwks),
   });
 
   upsertSeedOAuthClient(seedOAuthClients, {
@@ -129,6 +135,37 @@ for (const target of targets) {
 }
 
 setAuthSeedOAuthClients(seedOAuthClients);
+
+async function fetchAuthJwks(): Promise<JsonWebKeySet> {
+  const jwksUrl = `${authIssuer.replace(/\/+$/, "")}/jwks`;
+  let response: Response;
+  try {
+    response = await fetch(jwksUrl, { headers: { accept: "application/json" } });
+  } catch (cause) {
+    throw new Error(`Failed to fetch auth JWKS from ${jwksUrl}`, { cause });
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch auth JWKS from ${jwksUrl}: HTTP ${response.status}`);
+  }
+
+  const parsed = (await response.json()) as unknown;
+  if (!isJsonWebKeySet(parsed)) {
+    throw new Error(`Auth JWKS from ${jwksUrl} must be a JSON object with a non-empty keys array`);
+  }
+
+  return parsed;
+}
+
+function isJsonWebKeySet(value: unknown): value is JsonWebKeySet {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "keys" in value &&
+    Array.isArray(value.keys) &&
+    value.keys.length > 0
+  );
+}
 
 function getDopplerSecret(target: Target, key: string) {
   try {

--- a/apps/os/src/auth/errors.ts
+++ b/apps/os/src/auth/errors.ts
@@ -1,0 +1,3 @@
+export const SIGN_IN_AUTH_ERRORS = ["session_verification_failed"] as const;
+
+export type SignInAuthError = (typeof SIGN_IN_AUTH_ERRORS)[number];

--- a/apps/os/src/auth/iterate-auth-login.test.ts
+++ b/apps/os/src/auth/iterate-auth-login.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { createAuthHandler, type IterateAuthConfig, type TokenSet } from "@iterate-com/auth/server";
+import {
+  createAuthHandler,
+  createAuthMiddleware,
+  type IterateAuthConfig,
+  type TokenSet,
+} from "@iterate-com/auth/server";
 
 const config = {
   issuer: "https://auth.iterate-dev.com/api/auth",
@@ -145,6 +150,25 @@ describe("iterate auth login", () => {
       },
     });
   });
+
+  it("reports session verification failures to the auth caller", async () => {
+    const auth = testAuthMiddleware(config);
+    const onError = vi.fn();
+
+    const result = await auth.authenticate({
+      headers: new Headers({
+        cookie: sessionCookie(testTokenSet()),
+      }),
+      includeUserInfo: false,
+      onError,
+    });
+
+    expect(result.session).toBeNull();
+    expect(onError).toHaveBeenCalledWith({
+      reason: "access_token_verify_failed",
+      error: expect.any(Error),
+    });
+  });
 });
 
 function testAuthHandler(
@@ -175,6 +199,35 @@ function testAuthHandler(
   } as unknown as Parameters<typeof createAuthHandler>[1];
 
   return createAuthHandler(authConfig, infra).handler;
+}
+
+function testAuthMiddleware(
+  authConfig: IterateAuthConfig,
+  overrides: Partial<Parameters<typeof createAuthMiddleware>[1]> = {},
+) {
+  const infra = {
+    issuerURL: new URL(authConfig.issuer ?? "https://auth.iterate-dev.com/api/auth"),
+    jwks: {},
+    oauthClient: { client_id: authConfig.clientId },
+    clientAuth: {},
+    insecure: false,
+    secureCookies: false,
+    getAuthorizationServer: async () => {
+      throw new Error("not used by middleware tests");
+    },
+    httpOptions: () => undefined,
+    toTokenSet: () => {
+      throw new Error("not used by middleware tests");
+    },
+    doRefresh: async () => null,
+    getUserInfo: async () => null,
+    cookieOpts: () => ({ httpOnly: true, path: "/", sameSite: "Lax", secure: false }) as const,
+    resource: () => "http://localhost",
+    audiences: () => ["http://localhost"],
+    ...overrides,
+  } as unknown as Parameters<typeof createAuthMiddleware>[1];
+
+  return createAuthMiddleware(authConfig, infra);
 }
 
 function testTokenSet(overrides: Partial<TokenSet> = {}): TokenSet {

--- a/apps/os/src/auth/iterate-auth-login.test.ts
+++ b/apps/os/src/auth/iterate-auth-login.test.ts
@@ -151,6 +151,35 @@ describe("iterate auth login", () => {
     });
   });
 
+  it("reports non-fatal refresh failures while returning a valid session", async () => {
+    const signed = await signedTokenSet({
+      accessTokenExpiresAt: Date.now() + 15 * 1000,
+    });
+    const doRefresh = vi.fn(async () => {
+      throw new Error("temporary token endpoint failure");
+    });
+    const auth = testAuthMiddleware(config, {
+      doRefresh,
+      jwks: signed.jwks as never,
+    });
+    const onError = vi.fn();
+
+    const result = await auth.authenticate({
+      headers: new Headers({
+        cookie: sessionCookie(signed.tokenSet),
+      }),
+      includeUserInfo: false,
+      onError,
+    });
+
+    expect(doRefresh).toHaveBeenCalledTimes(1);
+    expect(result.session?.user.id).toBe("usr_session");
+    expect(onError).toHaveBeenCalledWith({
+      reason: "session_refresh_failed",
+      error: expect.any(Error),
+    });
+  });
+
   it("reports session verification failures to the auth caller", async () => {
     const auth = testAuthMiddleware(config);
     const onError = vi.fn();

--- a/apps/os/src/auth/middleware.ts
+++ b/apps/os/src/auth/middleware.ts
@@ -1,7 +1,12 @@
-import { isAuthHandlerRequest, type AuthenticatedSession } from "@iterate-com/auth/server";
+import {
+  isAuthHandlerRequest,
+  type AuthenticatedSession,
+  type AuthenticateErrorEvent,
+} from "@iterate-com/auth/server";
 import { createMiddleware } from "@tanstack/react-start";
 import type { RequestContext } from "~/request-context.ts";
 import { authenticateAdminApiSecret } from "~/auth/admin.ts";
+import type { SignInAuthError } from "~/auth/errors.ts";
 import { createOsIterateAuth } from "~/auth/iterate-auth-client.ts";
 import type { OsIterateAuth } from "~/auth/iterate-auth-client.ts";
 import {
@@ -31,6 +36,7 @@ export const iterateAuthMiddleware = createMiddleware({ type: "request" }).serve
       context: {
         principal: resolvedAuth.principal,
         iterateAuthSession: resolvedAuth.session,
+        iterateAuthError: resolvedAuth.error,
         rawRequest: request,
       },
     });
@@ -46,11 +52,12 @@ export const iterateAuthMiddleware = createMiddleware({ type: "request" }).serve
 
 async function resolveRequestAuth(input: {
   auth: OsIterateAuth | null;
-  context: Pick<RequestContext, "config">;
+  context: Pick<RequestContext, "config" | "log">;
   request: Request;
 }): Promise<{
   principal: Principal | null;
   session: AuthenticatedSession | null;
+  error?: SignInAuthError;
   responseHeaders: Headers;
 }> {
   const adminApiPrincipal = authenticateAdminApiSecret(input.context, input.request);
@@ -58,13 +65,16 @@ async function resolveRequestAuth(input: {
     return {
       principal: adminApiPrincipal,
       session: null,
+      error: undefined,
       responseHeaders: new Headers(),
     };
   }
 
   const sessionAuth = await authenticateSession({
     auth: input.auth,
+    context: input.context,
     headers: input.request.headers,
+    request: input.request,
   });
   if (sessionAuth.principal) {
     return sessionAuth;
@@ -77,33 +87,53 @@ async function resolveRequestAuth(input: {
   return {
     principal: bearerPrincipal,
     session: sessionAuth.session,
+    error: sessionAuth.error,
     responseHeaders: sessionAuth.responseHeaders,
   };
 }
 
 async function authenticateSession(input: {
   auth: OsIterateAuth | null;
+  context: Pick<RequestContext, "config" | "log">;
   headers: Headers;
+  request: Request;
 }): Promise<{
   principal: Principal | null;
   session: AuthenticatedSession | null;
+  error?: SignInAuthError;
   responseHeaders: Headers;
 }> {
   if (!input.auth) {
     return {
       principal: null,
       session: null,
+      error: undefined,
       responseHeaders: new Headers(),
     };
   }
 
+  let authError: AuthenticateErrorEvent | null = null;
   const result = await input.auth.authenticate({
     headers: input.headers,
     includeUserInfo: false,
+    onError: (event) => {
+      authError = event;
+    },
   });
+  const hasSessionCookie = /(?:^|;\s*)iterate_session=/u.test(input.headers.get("cookie") ?? "");
+  const error = authError && hasSessionCookie ? "session_verification_failed" : undefined;
+  if (!result.session && authError && error) {
+    logAuthSessionVerificationFailure({
+      context: input.context,
+      error: authError,
+      request: input.request,
+    });
+  }
+
   return {
     principal: result.session ? principalFromSession(result.session) : null,
     session: result.session,
+    error,
     responseHeaders: result.responseHeaders,
   };
 }
@@ -116,4 +146,79 @@ async function authenticateBearerPrincipal(input: {
 
   const accessToken = await input.auth.authenticateBearer({ headers: input.headers });
   return accessToken ? principalFromAccessToken(accessToken) : null;
+}
+
+function logAuthSessionVerificationFailure(input: {
+  context: Pick<RequestContext, "config" | "log">;
+  error: AuthenticateErrorEvent;
+  request: Request;
+}) {
+  const url = new URL(input.request.url);
+  const details = {
+    reason: input.error.reason,
+    error: toLogError(input.error.error),
+    issuer: input.context.config.iterateAuth?.issuer,
+    clientId: input.context.config.iterateAuth?.clientId,
+    jwksKeyIds: input.context.config.iterateAuth?.jwks?.keys
+      ?.map((key) => (typeof key.kid === "string" ? key.kid : null))
+      .filter((kid) => kid !== null),
+    sessionCookie: summarizeSessionCookie(input.request.headers),
+    path: `${url.pathname}${url.search}`,
+  };
+
+  input.context.log.warn("os.auth.session_verification_failed");
+  input.context.log.set({ auth: { sessionVerificationFailure: details } });
+}
+
+function toLogError(error: unknown) {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message };
+  }
+  return { message: String(error) };
+}
+
+function summarizeSessionCookie(headers: Headers) {
+  const cookieValue = extractCookie(headers.get("cookie") ?? "", "iterate_session");
+  if (!cookieValue) return { present: false };
+
+  try {
+    const tokenSet = JSON.parse(decodeURIComponent(cookieValue)) as {
+      accessToken?: unknown;
+      idToken?: unknown;
+    };
+    return {
+      present: true,
+      parseable: true,
+      accessTokenKid: jwtHeaderKid(tokenSet.accessToken),
+      idTokenKid: jwtHeaderKid(tokenSet.idToken),
+    };
+  } catch {
+    return { present: true, parseable: false };
+  }
+}
+
+function extractCookie(cookieHeader: string, name: string) {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  const match = new RegExp(`(?:^|;\\s*)${escapedName}=([^;]*)`, "u").exec(cookieHeader);
+  return match?.[1] ?? null;
+}
+
+function jwtHeaderKid(token: unknown) {
+  if (typeof token !== "string") return null;
+  const encodedHeader = token.split(".", 1)[0];
+  if (!encodedHeader) return null;
+
+  try {
+    const header = JSON.parse(base64UrlDecode(encodedHeader)) as { kid?: unknown };
+    return typeof header.kid === "string" ? header.kid : null;
+  } catch {
+    return null;
+  }
+}
+
+function base64UrlDecode(value: string) {
+  const padded = `${value.replace(/-/gu, "+").replace(/_/gu, "/")}${"=".repeat(
+    (4 - (value.length % 4)) % 4,
+  )}`;
+  return atob(padded);
 }

--- a/apps/os/src/auth/middleware.ts
+++ b/apps/os/src/auth/middleware.ts
@@ -121,8 +121,9 @@ async function authenticateSession(input: {
     },
   });
   const hasSessionCookie = /(?:^|;\s*)iterate_session=/u.test(input.headers.get("cookie") ?? "");
-  const error = authError && hasSessionCookie ? "session_verification_failed" : undefined;
-  if (!result.session && authError && error) {
+  const error =
+    !result.session && authError && hasSessionCookie ? "session_verification_failed" : undefined;
+  if (authError && error) {
     logAuthSessionVerificationFailure({
       context: input.context,
       error: authError,

--- a/apps/os/src/lib/auth.ts
+++ b/apps/os/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import { redirect } from "@tanstack/react-router";
 import type { PublicSessionResponse } from "@iterate-com/auth/client";
+import type { SignInAuthError } from "~/auth/errors.ts";
 import { createUserPrincipal, type UserPrincipal } from "~/auth/principal.ts";
 
 type RouteLocation = {
@@ -11,8 +12,9 @@ export function requireOrganizationMemberForSession(
   session: PublicSessionResponse | null | undefined,
   location: RouteLocation,
   issuer: string | undefined,
+  authError: SignInAuthError | undefined,
 ) {
-  const principal = requireUserPrincipalFromSession(session, location);
+  const principal = requireUserPrincipalFromSession(session, location, authError);
   if (principal.organizations.length === 0) {
     throw redirectToProjectAccess(issuer);
   }
@@ -25,8 +27,9 @@ export function requireAuthenticatedRootRedirectTargetFromSession(
   location: RouteLocation,
   issuer: string | undefined,
   currentProjectHostSlug: string | null | undefined,
+  authError: SignInAuthError | undefined,
 ) {
-  const principal = requireUserPrincipalFromSession(session, location);
+  const principal = requireUserPrincipalFromSession(session, location, authError);
 
   if (principal.organizations.length === 0) {
     throw redirectToProjectAccess(issuer);
@@ -54,15 +57,16 @@ function getUserPrincipalFromSession(
 function requireUserPrincipalFromSession(
   session: PublicSessionResponse | null | undefined,
   location: RouteLocation,
+  authError: SignInAuthError | undefined,
 ): UserPrincipal {
   const principal = getUserPrincipalFromSession(session);
   if (!principal) {
-    throw redirectToSignIn(location);
+    throw redirectToSignIn(location, authError);
   }
   return principal;
 }
 
-function redirectToSignIn(location: RouteLocation): never {
+function redirectToSignIn(location: RouteLocation, authError: SignInAuthError | undefined): never {
   throw redirect({
     to: "/sign-in/$",
     params: { _splat: "" },
@@ -70,6 +74,7 @@ function redirectToSignIn(location: RouteLocation): never {
       // The sign-in page only accepts same-origin relative paths, so pass
       // pathname + search rather than a full href.
       redirect_url: `${location.pathname}${location.searchStr ?? ""}`,
+      auth_error: authError,
     },
   });
 }

--- a/apps/os/src/lib/root-auth-snapshot.ts
+++ b/apps/os/src/lib/root-auth-snapshot.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import type { PublicSessionResponse } from "@iterate-com/auth/client";
 import type { AuthenticatedSession } from "@iterate-com/auth/server";
+import type { SignInAuthError } from "~/auth/errors.ts";
 import {
   normalizeRequestHostname,
   resolveProjectSlugFromHostname,
@@ -8,6 +9,7 @@ import {
 
 type RootAuthSnapshot = {
   authSession: PublicSessionResponse;
+  authError: SignInAuthError | undefined;
   iterateAuthIssuer: string | undefined;
   currentProjectHostSlug: string | null;
 };
@@ -29,6 +31,7 @@ export const fetchRootAuthSnapshot: () => Promise<RootAuthSnapshot> = createServ
 }).handler(async ({ context }): Promise<RootAuthSnapshot> => {
   return {
     authSession: toPublicSession(context.iterateAuthSession),
+    authError: context.iterateAuthError,
     iterateAuthIssuer: context.config.iterateAuth?.issuer,
     currentProjectHostSlug: resolveCurrentProjectHostSlug({
       baseUrl: context.config.baseUrl,

--- a/apps/os/src/request-context.ts
+++ b/apps/os/src/request-context.ts
@@ -1,5 +1,6 @@
 import type { SharedRequestLogger } from "@iterate-com/shared/request-logging";
 import type { AuthenticatedSession } from "@iterate-com/auth/server";
+import type { SignInAuthError } from "~/auth/errors.ts";
 import type { AppConfig } from "~/config.ts";
 import type { Principal } from "~/auth/principal.ts";
 
@@ -23,6 +24,7 @@ export interface RequestContext {
   // Set by the iterate auth request middleware (src/auth/middleware.ts).
   principal?: Principal | null;
   iterateAuthSession?: AuthenticatedSession | null;
+  iterateAuthError?: SignInAuthError;
 }
 
 // Register the request context for both public module surfaces used by Start:

--- a/apps/os/src/router-context.ts
+++ b/apps/os/src/router-context.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 import type { PublicSessionResponse } from "@iterate-com/auth/client";
+import type { SignInAuthError } from "~/auth/errors.ts";
 
 /**
  * The router context provided to createRouter and augmented by the root
@@ -13,6 +14,7 @@ import type { PublicSessionResponse } from "@iterate-com/auth/client";
 export type RouterContext = {
   queryClient: QueryClient;
   authSession?: PublicSessionResponse;
+  authError?: SignInAuthError;
   currentProjectHostSlug?: string | null;
   iterateAuthIssuer?: string;
 };

--- a/apps/os/src/routes/_app.tsx
+++ b/apps/os/src/routes/_app.tsx
@@ -10,7 +10,12 @@ import { getSidebarDefaultOpen } from "~/lib/sidebar-state.ts";
 
 export const Route = createFileRoute("/_app")({
   beforeLoad: ({ context, location }) =>
-    requireOrganizationMemberForSession(context.authSession, location, context.iterateAuthIssuer),
+    requireOrganizationMemberForSession(
+      context.authSession,
+      location,
+      context.iterateAuthIssuer,
+      context.authError,
+    ),
   // The project list is NOT pre-warmed here: it comes from the itx session
   // (browser-only), so the sidebar populates it after hydration.
   loader: async () => ({

--- a/apps/os/src/routes/index.tsx
+++ b/apps/os/src/routes/index.tsx
@@ -9,6 +9,7 @@ export const Route = createFileRoute("/")({
       location,
       context.iterateAuthIssuer,
       context.currentProjectHostSlug,
+      context.authError,
     );
 
     // `session.projects.list()` includes projects the auth worker knows about

--- a/apps/os/src/routes/sign-in.$.tsx
+++ b/apps/os/src/routes/sign-in.$.tsx
@@ -2,8 +2,9 @@ import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { extractPublicConfigSchema } from "@iterate-com/shared/config";
 import { z } from "zod";
-import { MailIcon } from "lucide-react";
+import { AlertCircleIcon, MailIcon } from "lucide-react";
 import { useAuthClient } from "@iterate-com/auth/client";
+import { Alert, AlertDescription, AlertTitle } from "@iterate-com/ui/components/alert";
 import { Button } from "@iterate-com/ui/components/button";
 import {
   Card,
@@ -14,6 +15,7 @@ import {
 } from "@iterate-com/ui/components/card";
 import { Separator } from "@iterate-com/ui/components/separator";
 import { AppConfig } from "../config.ts";
+import { SIGN_IN_AUTH_ERRORS } from "~/auth/errors.ts";
 import { getPublicConfigServerFn } from "~/lib/public-route-config.ts";
 
 const PublicConfigSchema = extractPublicConfigSchema(AppConfig);
@@ -21,6 +23,7 @@ const PublicConfigSchema = extractPublicConfigSchema(AppConfig);
 export const Route = createFileRoute("/sign-in/$")({
   validateSearch: z.looseObject({
     redirect_url: z.string().optional(),
+    auth_error: z.enum(SIGN_IN_AUTH_ERRORS).optional(),
   }),
   loader: async () => ({
     config: PublicConfigSchema.parse(JSON.parse(await getPublicConfigServerFn())),
@@ -31,10 +34,11 @@ export const Route = createFileRoute("/sign-in/$")({
 function SignInRoute() {
   const { signIn } = useAuthClient();
   const { config } = Route.useLoaderData();
-  const { redirect_url: redirectUrl } = Route.useSearch();
+  const { auth_error: authError, redirect_url: redirectUrl } = Route.useSearch();
   const returnTo = safeRedirectPath(redirectUrl);
   const emailOtpEnabled = config.iterateAuth?.emailOtpEnabled ?? false;
   const [redirectingTo, setRedirectingTo] = useState<"email" | "google" | null>(null);
+  const signInError = authError ? signInErrorCopy[authError] : null;
 
   function startEmailSignIn() {
     setRedirectingTo("email");
@@ -55,6 +59,13 @@ function SignInRoute() {
         </CardHeader>
         <Separator />
         <CardContent className="space-y-3 pt-6">
+          {signInError ? (
+            <Alert variant="destructive">
+              <AlertCircleIcon className="size-4" />
+              <AlertTitle>{signInError.title}</AlertTitle>
+              <AlertDescription>{signInError.description}</AlertDescription>
+            </Alert>
+          ) : null}
           {emailOtpEnabled ? (
             <Button
               className="w-full border-border bg-background text-foreground shadow-sm transition-colors hover:bg-muted"
@@ -82,6 +93,14 @@ function SignInRoute() {
     </main>
   );
 }
+
+const signInErrorCopy = {
+  session_verification_failed: {
+    title: "Sign-in could not be verified",
+    description:
+      "Auth returned a session, but OS could not verify it. Try signing in again; if this keeps happening, contact Iterate support.",
+  },
+} satisfies Record<(typeof SIGN_IN_AUTH_ERRORS)[number], { title: string; description: string }>;
 
 function GoogleIcon() {
   return (


### PR DESCRIPTION
## Summary
- sync the live auth JWKS into each OS deploy config when running `apps/os` auth client sync
- surface session verification failures on the sign-in page instead of silently bouncing back to login
- add structured OS request logs for failed session verification, including configured JWKS key ids and session cookie JWT header key ids without logging token material

## Root cause
Production OS had OAuth client config fixed, but `ITERATE_AUTH_JWKS` was stale, so OS could reject auth-issued session tokens after callback and redirect back to `/sign-in`.

## Validation
- `AUTH_CLIENT_SYNC_TARGETS=prd doppler run --project auth --config prd -- pnpm --dir apps/os auth:sync-clients`
- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/os test src/auth/iterate-auth-login.test.ts`
- `pnpm exec oxlint apps/auth/src/lib/server.ts apps/os/src/auth/middleware.ts apps/os/src/routes/sign-in.$.tsx apps/os/src/auth/iterate-auth-login.test.ts --deny-warnings`
- verified OS prd JWKS key id matches live auth JWKS key id

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the authentication verification path and deploy-time JWKS sourcing; mis-synced or incorrect JWKS would break all session logins until the next sync/deploy.
> 
> **Overview**
> Keeps OS deploy config aligned with the live auth worker by having **`auth:sync-clients`** fetch the issuer **`/jwks`** endpoint and write **`ITERATE_AUTH_JWKS`** into each target Doppler config (addressing production cases where OAuth clients were correct but baked JWKS could not verify newly issued tokens).
> 
> **`createAuthMiddleware.authenticate`** now accepts an optional **`onError`** callback with structured reasons (cookie parse, refresh, access/id JWT verify, claims parse). OS middleware uses that to set **`iterateAuthError`** when a session cookie is present but verification fails, emit **`os.auth.session_verification_failed`** logs (reason, configured JWKS **`kid`**s, cookie JWT header **`kid`**s—no token bodies), and pass **`auth_error=session_verification_failed`** on redirects to sign-in. The sign-in route shows a destructive alert instead of a silent login loop.
> 
> Docs updated for JWKS sync; unit tests cover **`onError`** for refresh and verify failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d18221c44129015e98f91cddd38ff0e4e9af3eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> Teardown skipped: Slot preview-8 no longer belongs to pr-1609: it is now leased by pr-1614 (https://github.com/iterate/iterate/pull/1614). Their deployment has replaced this PR's apps on preview_8.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-03T06:41:53.413Z",
      "headSha": "8d695153fa2f7168d94aee787763b4e481b1fc4a",
      "message": "Teardown skipped: Slot preview-8 no longer belongs to pr-1609: it is now leased by pr-1614 (https://github.com/iterate/iterate/pull/1614). Their deployment has replaced this PR's apps on preview_8.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/153441859010380",
      "shortSha": "8d69515",
      "deployDurationMs": 39479,
      "testDurationMs": 115505
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-03T06:41:53.413Z",
      "headSha": "8d695153fa2f7168d94aee787763b4e481b1fc4a",
      "message": "Teardown skipped: Slot preview-8 no longer belongs to pr-1609: it is now leased by pr-1614 (https://github.com/iterate/iterate/pull/1614). Their deployment has replaced this PR's apps on preview_8.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/153441859010380",
      "shortSha": "8d69515",
      "deployDurationMs": 24161,
      "testDurationMs": 459
    }
  },
  "environmentConfigLease": null,
  "notice": "Teardown skipped: Slot preview-8 no longer belongs to pr-1609: it is now leased by pr-1614 (https://github.com/iterate/iterate/pull/1614). Their deployment has replaced this PR's apps on preview_8."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `8d69515` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 24.2s | 459ms |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/153441859010380) | 2026-07-03T06:41:53.413Z | Teardown skipped: Slot preview-8 no longer belongs to pr-1609: it is now leased by pr-1614 (https://github.com/iterate/iterate/pull/1614). Their deployment has replaced this PR's ... |
| OS | released | `8d69515` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 39.5s | 115.5s |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/153441859010380) | 2026-07-03T06:41:53.413Z | Teardown skipped: Slot preview-8 no longer belongs to pr-1609: it is now leased by pr-1614 (https://github.com/iterate/iterate/pull/1614). Their deployment has replaced this PR's ... |

</details>
<!-- /CLOUDFLARE_PREVIEW -->