### PR TITLE
Fix preview secrets e2e stalls: pull-through processor reads + configured-wake retry

### DIFF
--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -96,7 +96,12 @@ export class ProjectDurableObject extends DurableObject<Env> {
   }
 
   get processor() {
-    return new StreamProcessorRpcTarget(this.#projectProcessor);
+    return new StreamProcessorRpcTarget(this.#projectProcessor, {
+      // Lists served from this snapshot (child streams, secrets) must reflect
+      // a child stream created moments ago even when the root stream's push
+      // delivery is lagging or a wake was dropped.
+      catchUpBeforeSnapshot: () => this.#processorHost.catchUp(ProjectProcessorContract.slug),
+    });
   }
 
   async fetch(request: Request): Promise<Response> {

--- a/apps/os/src/domains/secrets/secret-durable-object.ts
+++ b/apps/os/src/domains/secrets/secret-durable-object.ts
@@ -37,7 +37,9 @@ export class SecretDurableObject extends DurableObject<Env> {
   }
 
   get processor() {
-    return new StreamProcessorRpcTarget(this.#secretProcessor);
+    return new StreamProcessorRpcTarget(this.#secretProcessor, {
+      catchUpBeforeSnapshot: () => this.#processorHost.catchUp(SecretProcessorContract.slug),
+    });
   }
 
   async update(input: SecretUpdateInput) {
@@ -72,6 +74,11 @@ export class SecretDurableObject extends DurableObject<Env> {
   }
 
   async describe(): Promise<SecretDescription> {
+    // update() appends to the stream and the processor folds it in
+    // asynchronously; pull-through makes update() -> describe()
+    // read-your-writes even when the configured subscription's wake is slow
+    // or was dropped.
+    await this.#processorHost.catchUp(SecretProcessorContract.slug);
     const { state } = await this.#secretProcessor.snapshot();
     return {
       audit: state.audit,
@@ -91,6 +98,9 @@ export class SecretDurableObject extends DurableObject<Env> {
       return secretErrorResponse("secret_reference_required", 400);
     }
 
+    // Same pull-through as describe(): egress substitution right after
+    // update() must see the just-stored material.
+    await this.#processorHost.catchUp(SecretProcessorContract.slug);
     const { state } = await this.#secretProcessor.snapshot();
     if (state.encryptedMaterial === null) {
       return secretErrorResponse("secret_not_found", 404);

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -124,6 +124,15 @@ export class StreamDurableObject extends DurableObject<Env> {
   // subscriptionKeys with a configured subscriber wakeup in flight, so concurrent
   // reconciliation runs never wake the same subscriber twice.
   #connecting = new Set<string>();
+  // Retry bookkeeping for failed configured-subscriber wakes. Without a retry,
+  // one transient RPC failure (subscriber cold start, cross-script hiccup)
+  // silences the subscription until the NEXT qualifying append — which for
+  // write-once streams like secrets may never come
+  // (tasks/stream-subscriber-deliveries-stall-mid-turn.md). In-memory is
+  // deliberate: an eviction drops the timers, but the durable subscription
+  // config survives and the next append or subscriber read re-wakes.
+  #wakeRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  #wakeRetryAttempts = new Map<string, number>();
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
@@ -1095,11 +1104,37 @@ export class StreamDurableObject extends DurableObject<Env> {
           await this.wakeConfiguredSubscriber({ configured, subscriptionKey });
         } catch (error) {
           console.error("Stream configured subscriber wakeup failed", { error, subscriptionKey });
+          this.#scheduleConfiguredWakeRetry(subscriptionKey);
         } finally {
           this.#connecting.delete(subscriptionKey);
         }
       });
     }
+  }
+
+  // Backoff retry for a failed configured-subscriber wake. Gives up after a
+  // bounded number of attempts (the subscriber is then genuinely broken, and
+  // every later append still re-triggers reconciliation).
+  #scheduleConfiguredWakeRetry(subscriptionKey: string): void {
+    const MAX_WAKE_RETRY_ATTEMPTS = 6;
+    if (this.#wakeRetryTimers.has(subscriptionKey)) return;
+    const attempt = (this.#wakeRetryAttempts.get(subscriptionKey) ?? 0) + 1;
+    this.#wakeRetryAttempts.set(subscriptionKey, attempt);
+    if (attempt > MAX_WAKE_RETRY_ATTEMPTS) {
+      console.error("Stream configured subscriber wakeup retries exhausted", {
+        subscriptionKey,
+        attempts: attempt - 1,
+      });
+      return;
+    }
+
+    const delayMs = Math.min(30_000, 500 * 2 ** (attempt - 1));
+    const timer = setTimeout(() => {
+      this.#wakeRetryTimers.delete(subscriptionKey);
+      if (!this.#needsConfiguredReconcile()) return;
+      this.#reconcileConnections();
+    }, delayMs);
+    this.#wakeRetryTimers.set(subscriptionKey, timer);
   }
 
   #startSubscription(
@@ -1240,6 +1275,13 @@ export class StreamDurableObject extends DurableObject<Env> {
     };
 
     this.#connections.set(subscriptionKey, connection);
+    // A live connection resets the wake-retry ledger for its key.
+    this.#wakeRetryAttempts.delete(subscriptionKey);
+    const pendingRetry = this.#wakeRetryTimers.get(subscriptionKey);
+    if (pendingRetry !== undefined) {
+      clearTimeout(pendingRetry);
+      this.#wakeRetryTimers.delete(subscriptionKey);
+    }
     // The presence fact lands after the connection is registered and after the
     // replay cursor is fixed, so connected is the tail of any first batch it
     // shares with replayed events.

--- a/apps/os/src/domains/streams/stream-processor-host.ts
+++ b/apps/os/src/domains/streams/stream-processor-host.ts
@@ -122,6 +122,17 @@ type StreamProcessorHost = {
   add<P extends AnyHostedProcessor>(name: string, build: (deps: HostedProcessorDeps) => P): P;
   /** Wire this to the host DO's wakeStreamSubscriber RPC method. */
   wakeStreamSubscriber(args: StreamSubscriberWakeRequest): Promise<void>;
+  /**
+   * Pull any events the push delivery has not (yet) brought this processor and
+   * ingest them now. Call before serving a read that must reflect a write the
+   * caller just made (read-your-writes): push delivery is asynchronous and can
+   * stall when a configured-subscriber wake is lost mid-chain (see
+   * tasks/stream-subscriber-deliveries-stall-mid-turn.md). Ingest is
+   * checkpoint-filtered and serialized, so racing a live subscription is safe.
+   * Failures are logged and swallowed — the read then serves the last
+   * successfully ingested state, exactly as it would have without the pull.
+   */
+  catchUp(name: string): Promise<void>;
 };
 
 export function createStreamProcessorHost(
@@ -344,6 +355,26 @@ export function createStreamProcessorHost(
         ingestChain: Promise.resolve(),
       });
       return processor;
+    },
+
+    async catchUp(name) {
+      const entry = requireEntry(name);
+      try {
+        const { offset } = await entry.processor.snapshot();
+        const events = await options.stream.getEvents({ afterOffset: offset });
+        if (events.length === 0) return;
+        // Non-consumed event types reduce to no-ops but still advance the
+        // checkpoint, mirroring what a filtered subscription's cursor does.
+        await entry.processor.ingest({
+          events,
+          streamMaxOffset: events[events.length - 1]!.offset,
+        });
+      } catch (error) {
+        console.error(
+          `stream processor "${name}" catch-up failed; serving last ingested state`,
+          error,
+        );
+      }
     },
 
     async wakeStreamSubscriber(args) {

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -1545,13 +1545,26 @@ export class StreamProcessorRpcTarget<Contract extends StreamProcessorContract>
   implements StreamProcessorRpc<ProcessorState<Contract>>
 {
   readonly #processor: StreamProcessor<Contract, object>;
+  readonly #catchUpBeforeSnapshot: (() => Promise<void>) | undefined;
 
-  constructor(processor: StreamProcessor<Contract, object>) {
+  constructor(
+    processor: StreamProcessor<Contract, object>,
+    options: {
+      /**
+       * Host-provided pull-through (`StreamProcessorHost.catchUp`): snapshots
+       * served over this target reflect events the push delivery has not
+       * brought yet, giving remote readers read-your-writes.
+       */
+      catchUpBeforeSnapshot?: () => Promise<void>;
+    } = {},
+  ) {
     super();
     this.#processor = processor;
+    this.#catchUpBeforeSnapshot = options.catchUpBeforeSnapshot;
   }
 
-  snapshot() {
+  async snapshot() {
+    await this.#catchUpBeforeSnapshot?.();
     return this.#processor.snapshot();
   }
 


### PR DESCRIPTION
## The regression

Since 2026-07-02's merges, every PR's preview e2e has been failing on a rotating cast of secrets-path tests: `itx.e2e > Project egress substitutes path-addressed secrets`, `examples-matrix > secrets-lifecycle`, `MCP built-in … Timed out waiting for MCP secret`. Unrelated branches fail identically (#1599 documented the fleet evidence before merging over it).

## Repro

Leased `preview-9` (`pnpm preview acquire --slot 9`), deployed clean **main**, and ran the three affected test groups **concurrently** (mimicking #1589's all-suites-at-once CI load), 4 rounds:

- **main: 4/12 failed** — `hasMaterial: false` after the poll window; `Timed out waiting for secret stream to appear in project processor list`.
- **with this fix: 12/12 passed** (same slot, same rounds; P ≈ 0.008 of that under the baseline failure rate).

## Root cause

This is the known, pre-existing delivery stall (`tasks/stream-subscriber-deliveries-stall-mid-turn.md`) — not caused by yesterday's merges, but unmasked by them:

- A secret's `hasMaterial` needs a multi-hop push relay: root-stream `child-stream-created` → ProjectProcessor ingest → `subscription-configured` append on the secret stream → **wake RPC to the Secret DO** → subscribe-back → replay/ingest. Same for `secrets.list()` via the root stream.
- In the Stream DO, **a failed configured-subscriber wake was `console.error`'d and never retried**. The next attempt only comes with the next qualifying append — which a write-once secret stream never sends. One cold-start RPC failure (the same class as the Slack-router incident) = stalled forever.
- #1589 made every suite run concurrently (cold-start wake failures became common exactly while secrets tests run); #1601 restored tight test budgets; `waitForCondition` allows 5s, the lifecycle example 10s. The slack that used to hide the stall vanished.

Browsers got a self-heal for this in #1501; DO processors had none — until now.

## The fix (three layers)

1. **`StreamProcessorHost.catchUp(name)`** — pull-through: read `getEvents(afterOffset: checkpoint)` and ingest on demand. Safe by construction: `ingest` is serialized in-processor and checkpoint-filtered, so racing live push delivery is a no-op; failures are logged and the read serves the last ingested state, exactly as before.
2. **Read-your-writes at the read paths.** `SecretDurableObject.describe()` and `fetch()` (egress substitution) catch up before serving, so `update() → describe()` can never be stale. `StreamProcessorRpcTarget` takes an optional `catchUpBeforeSnapshot` hook, wired into the Secret and Project DO `processor` getters — `secrets.list()` / child-stream lists now reflect a stream created moments ago even if root-stream push delivery is lagging.
3. **Wake retry in the Stream DO.** Failed configured-subscriber wakes now schedule bounded exponential-backoff retries (0.5s → 30s cap, 6 attempts) instead of being dropped; the ledger clears when the connection lands. In-memory by design — eviction drops the timers, but the durable subscription config survives and any later append or read re-wakes.

This fixes push delivery itself (helping every subscriber, including agent streams), while the pull-through makes the specific read-after-write surfaces immune to push health entirely. The broader delivery-contract redesign (registry durability across incarnations, subscribe-vs-create races) stays tracked in `tasks/stream-subscriber-deliveries-stall-mid-turn.md`.

## Testing

- Repro protocol above: 4/12 fail on main → 12/12 pass with the fix, same slot, same concurrency.
- Full OS node e2e suite run against the fixed preview-9 deploy (result posted in comments).
- `apps/os` unit tests (221) and typecheck green; repo lint/format green.

## Not in this PR (follow-up)

`captun` is pinned to an expired `pkg.pr.new` snapshot (`apps/os`, `apps/tunnels`), which 404s any cache-cold `pnpm install` — it killed #1599's post-merge preview cleanup. Needs a durable pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core stream delivery, secret egress reads, and processor snapshot RPC paths; behavior is additive (catch-up on read, wake retries) but changes timing/consistency guarantees under load.
> 
> **Overview**
> Addresses **stalled async stream push delivery** (especially secrets and project processor lists) when a configured-subscriber wake fails once and never retries.
> 
> **Pull-through ingest:** `StreamProcessorHost.catchUp(name)` reads committed events after the processor checkpoint and ingests them on demand (serialized, checkpoint-safe; errors are logged and reads fall back to last good state).
> 
> **Read-your-writes:** `SecretDurableObject.describe()` and `fetch()` call catch-up before serving state. `StreamProcessorRpcTarget.snapshot()` accepts an optional `catchUpBeforeSnapshot` hook, wired on Project and Secret DO `processor` getters so remote `secrets.list()` and similar snapshots are not stale when push lags.
> 
> **Wake recovery:** `StreamDurableObject` schedules **bounded exponential backoff** (6 attempts, 0.5s–30s) after a failed configured-subscriber wake and re-runs reconciliation; retry state clears when a live connection lands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 650190fddddc392dd15261f174cc475de5214304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-03T06:46:11.754Z",
      "headSha": "650190fddddc392dd15261f174cc475de5214304",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/44791512819307",
      "shortSha": "650190f",
      "cleanupDurationMs": 44523,
      "deployDurationMs": 42059
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-03T06:45:49.631Z",
      "headSha": "650190fddddc392dd15261f174cc475de5214304",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/44791512819307",
      "shortSha": "650190f",
      "cleanupDurationMs": 22395,
      "deployDurationMs": 25290
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-03T06:45:40.312Z",
      "headSha": "650190fddddc392dd15261f174cc475de5214304",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-1.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/44791512819307",
      "shortSha": "650190f",
      "cleanupDurationMs": 13073,
      "deployDurationMs": 29879
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `650190f` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 25.3s |  | 22.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/44791512819307) | 2026-07-03T06:45:49.631Z | Preview app released. |
| OS | released | `650190f` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 42.1s |  | 44.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/44791512819307) | 2026-07-03T06:46:11.754Z | Preview app released. |
| Streams Example App | released | `650190f` | [https://streams-example-app-preview-1.iterate-dev-preview.workers.dev](https://streams-example-app-preview-1.iterate-dev-preview.workers.dev) | 29.9s |  | 13.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/44791512819307) | 2026-07-03T06:45:40.312Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->