### PR TITLE
Fix local dev dynamic-worker failures: parent-worker-unique loader cache keys

### DIFF
--- a/apps/os/alchemy.run.ts
+++ b/apps/os/alchemy.run.ts
@@ -361,6 +361,10 @@ async function osWorker<B extends Bindings>(
       APP_CONFIG: ctx.app.local
         ? JSON.stringify(ctx.rawRuntimeConfig, null, 2)
         : alchemy.secret(JSON.stringify(ctx.rawRuntimeConfig, null, 2)),
+      // The worker's own name, for worker-loader cache keys (src/env.ts
+      // WORKER_SELF): local dev runs every itx worker inside one workerd whose
+      // loader cache is shared, so keys must be parent-worker-unique.
+      WORKER_SELF: name,
     },
     observability: ITERATE_WORKER_OBSERVABILITY,
     url: false,

--- a/apps/os/src/domains/workers/worker-loader.ts
+++ b/apps/os/src/domains/workers/worker-loader.ts
@@ -81,6 +81,10 @@ export function loadResolvedWorker({
       : `durable-object:${ref.className}`;
   const cacheKey = [
     "worker-loader",
+    // The hosting worker's own name. Loader caches are shared across parent
+    // workers when they run in one workerd (local dev), and a cached isolate
+    // only works for the parent whose loopback stubs it was created with.
+    env.WORKER_SELF,
     projectId,
     ref.path,
     workerScopeKey,

--- a/apps/os/src/env.ts
+++ b/apps/os/src/env.ts
@@ -11,6 +11,16 @@ import { env as workerEnv } from "cloudflare:workers";
  */
 export interface Env {
   AI: Ai;
+  /**
+   * This worker's own deployed name (e.g. "os-prd-api"). Exists so
+   * worker-loader cache keys are unique per hosting worker: local dev runs
+   * every itx worker inside ONE workerd whose loader cache is shared across
+   * them, and a dynamic worker isolate created by one parent carries that
+   * parent's loopback binding stubs — invoking it from another parent fails
+   * with a redacted internal error. In production each worker has its own
+   * loader, so this is just a stable constant in the key.
+   */
+  WORKER_SELF: string;
   ARTIFACTS: Artifacts;
   ARTIFACTS_ACCOUNT_ID: string;
   ARTIFACTS_NAMESPACE: string;


### PR DESCRIPTION
Fixes the permanently-failing local itx e2e tests ("Project repos, workers, runScript, and dynamic worker refs compose" and "repo worker source projection is cleared when the main worker file is deleted") plus project-host ingress against `pnpm dev` — all of which failed with the opaque `Error: internal error; reference = …`.

## Root cause

Local dev runs all eight itx workers inside **one workerd** (vite auxiliaryWorkers — one process so cross-script DO names stay intact), and workerd's worker-loader isolate cache is **shared across parent workers within that process**. Our loader cache keys (`worker-loader:{projectId}:{path}:{scope}:{type}:{entrypoint}:{sourceHash}`) were identical regardless of which worker called `loader.get`, so:

1. During project creation, the **stream/project workers** load the default repo-backed project worker first (stream-subscriber wake, worker readiness probe). The dynamic isolate is created with *their* `ctx.exports` loopback stubs (`ITX`, `globalOutbound` → `ProjectEgressEntrypoint`) baked into its env.
2. The **api worker** (project-host ingress, capnweb `project.worker.fetch`) later asks its own LOADER binding for the same cache key and receives the *cached foreign isolate* — env stubs bound to another worker's context.
3. Every invocation of that isolate fails inside workerd and comes back redacted as `internal error; reference = …`.

In production each deployed worker gets its own loader namespace, so the collision cannot happen — which is why these tests always passed on preview/prd and the failures had been written off for weeks as "known local-dev capnweb flake".

For the record, the diagnosis chain that pinned it (each step eliminated a hypothesis): not the capnweb client (plain HTTP ingress fails identically), not `Request` serialization (URL-string args fail too), not compat dates, not binding config (all eight generated configs are identical), not the vite-optimized capnweb copy (the working workers have one too, and it takes `RpcTarget` from `cloudflare:workers` correctly), not the runtime version (reproduces on miniflare 4.20260424.0 and 4.20260617.0). The discriminator: an **inline** worker (unique source hash → unique cache key) works perfectly through the api worker, and a **fresh repo-backed** worker (`apps/hello/worker.js`, not yet loaded by any other parent) works too — only sources *already loaded by a different parent worker* fail, and whichever parent loads a source first "wins" it.

## The fix

Every itx worker now carries a `WORKER_SELF` binding (its own deployed name, set once in `alchemy.run.ts`), and `loadResolvedWorker` includes it in the loader cache key. Parents can no longer share loader entries. In production this is a stable constant per worker, so cache behavior within a worker is unchanged — no key churn, no extra isolates relative to today (prod loaders were already per-worker; this makes the key say so).

## Devil's advocate: is the real smell that many workers use the loader at all?

Honest answer: **partly, yes.** This fix makes an implicit assumption explicit ("a dynamic-worker isolate belongs to the parent that created it"), but the deeper observation is that we have **four runtime call sites constructing `DynamicWorkerRunner`, spread across at least five workers**:

| Call site | Runs in | Why it loads workers |
| --- | --- | --- |
| `rpc-targets.ts` (`DynamicWorkerRpcTarget`) | api worker (and any worker hosting itx RpcTargets) | `project.worker.fetch`, `project.workers.get(ref)`, ingress |
| `stream-durable-object.ts` | stream worker | waking configured **worker** stream subscribers |
| `itx-durable-object.ts` | itx worker | itx-expression capabilities / codemode |
| `stateful-worker-durable-object.ts` | worker worker | hosting stateful (DO-class) dynamic workers |

Consequences of this spread, independent of the local-dev bug:

- **Isolate multiplication.** The same project worker source gets a separate isolate per parent worker that touches it (prod loaders are per-worker). A busy project can hold N warm copies of the same worker, each with its own cold start — and we've already hit Cloudflare's concurrent-dynamic-worker cap once (stable-cache-key incident). This PR makes local dev match that reality rather than reduce it.
- **Authority is minted in N places.** Each caller builds the loaded worker's `ITX`/`globalOutbound` bindings from *its own* `ctx.exports`, so every itx worker must re-export `ItxEntrypoint` + `ProjectEgressEntrypoint`, and the project-confinement scope is re-derived at each site. That's N places to get a security-relevant derivation right.
- **This bug class stays possible.** Any future cache keyed below the parent-worker level (or an upstream workerd change to loader scoping) re-opens it.

### What centralising into one loader worker would take

The natural shape already half-exists: the `worker` worker (`src/workers/worker.ts`, `StatefulWorkerDurableObject`) is *already* the single home for stateful dynamic workers. Centralising would extend that to stateless invocation:

1. **A `DynamicWorkerEntrypoint` (WorkerEntrypoint) on the worker worker** with the existing runner surface: `invokeCapability({ref, path, args, flattenNestedPath, projectId, scopePath})` plus a fetch passthrough. `Request`/`Response` and returned live RpcTargets cross service-binding RPC fine (the "stateless worker proxy" e2e tests pin exactly this kind of flow today).
2. **Callers swap `new DynamicWorkerRunner(...)` for a service-binding call.** The four call sites above become `env.WORKER_LOADER_SVC.invoke(...)`-shaped; `DynamicWorkerRunner` itself and `worker-loader.ts` move to (or are only imported by) the worker worker.
3. **Loopback bindings get minted in exactly one place.** The loader worker derives `ITX`/`globalOutbound` from *its own* `ctx.exports` and the passed `{projectId, scopePath}` — scope authority becomes data validated at one boundary instead of ambient context at four. The other workers could stop re-exporting the loopback entrypoints entirely. This also makes the bug fixed here *structurally impossible* (one parent, one cache, one stub owner).
4. **Wins:** one warm isolate per source per colo instead of per-parent copies (fewer cold starts, further from the isolate cap), one security boundary, simpler mental model ("dynamic workers live in the worker worker").
5. **Costs/risks:** +1 same-colo RPC hop per dynamic invocation (typically sub-ms, but it's on the agent codemode hot path); live stubs returned by dynamic workers now pipeline through an extra seam (the class of thing that has bitten us with capnweb/workers-rpc interop before); the stream DO's wake path and itx expression path both need re-pointing; worker-topology docs, `Env` contracts, and the deploy story all change. It's a real topology refactor, not an afternoon.

### Why this PR ships the small fix anyway

The 18-line change is behavior-preserving in production, unblocks local dev today, and is the correct key even in the centralised world (the key should *always* state whose stubs an isolate carries — centralising just makes the component constant). If we do the consolidation, it subsumes this fix rather than fights it. Proposed follow-up: a task file for "centralise dynamic worker loading in the worker worker" so the trade-offs above get decided deliberately rather than by accretion.

An upstream note is also warranted: workerd's loader cache being shared across workers in one process while production scopes it per-worker is a fidelity gap in local dev (miniflare/vite-plugin) — worth an issue even with our key fix in place.

## Verification

- Local repro matrix before → after: default project worker via api worker `internal error` → **200**; hello app 200 → 200; inline worker ok → ok; project-host ingress 500 → 200.
- Both previously-failing itx e2e tests pass locally with the fix; they still fail on clean `origin/main` (baselined in a separate worktree).
- Full node e2e suite passed against the preview deploy (attempt 2 of the preview workflow).
- `pnpm typecheck` / `pnpm lint` / unit tests clean.
- Preview check flake note: the preview job failed on a *different, rotating* single test across attempts (egress-intercept secret timing, admin-project stream list, signup-OTP hydration, egress-secrets timing) while 76-77/78 pass each run — the same rotating-cast preview instability #1611 documented fleet-wide, which this 3-file change (loader cache keys only) cannot influence. Retried until green rather than merged red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "deployed",
      "updatedAt": "2026-07-03T08:30:51.026Z",
      "headSha": "55a3733f4589c8fc2cd35e9ed7cee5c988c9bfc9",
      "message": null,
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/50909249406409",
      "shortSha": "55a3733",
      "deployDurationMs": 41414,
      "testDurationMs": 81865
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "deployed",
      "updatedAt": "2026-07-03T08:29:29.853Z",
      "headSha": "55a3733f4589c8fc2cd35e9ed7cee5c988c9bfc9",
      "message": null,
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/50909249406409",
      "shortSha": "55a3733",
      "deployDurationMs": 26786,
      "testDurationMs": 688
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "deployed",
      "updatedAt": "2026-07-03T08:29:45.030Z",
      "headSha": "55a3733f4589c8fc2cd35e9ed7cee5c988c9bfc9",
      "message": null,
      "publicUrl": "https://streams-example-app-preview-8.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/50909249406409",
      "shortSha": "55a3733",
      "deployDurationMs": 21428,
      "testDurationMs": 15862
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | deployed | `55a3733` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 26.8s | 688ms |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/50909249406409) | 2026-07-03T08:29:29.853Z |  |
| OS | deployed | `55a3733` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 41.4s | 81.9s |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/50909249406409) | 2026-07-03T08:30:51.026Z |  |
| Streams Example App | deployed | `55a3733` | [https://streams-example-app-preview-8.iterate-dev-preview.workers.dev](https://streams-example-app-preview-8.iterate-dev-preview.workers.dev) | 21.4s | 15.9s |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/50909249406409) | 2026-07-03T08:29:45.030Z |  |

</details>
<!-- /CLOUDFLARE_PREVIEW -->