### PR TITLE
Document local-dev-only itx e2e failure modes in e2e/AGENTS.md

### DIFF
--- a/apps/os/e2e/AGENTS.md
+++ b/apps/os/e2e/AGENTS.md
@@ -26,6 +26,16 @@ How to target local dev / previews / prd and the canonical env vars
 (`APP_CONFIG_BASE_URL`, `APP_CONFIG_ADMIN_API_SECRET`, the `OS_E2E_*` harness knobs) are documented
 in [docs/testing.md](../../../docs/testing.md).
 
+**Local-dev caveat:** a handful of itx e2e failures reproduce ONLY against local `pnpm dev`,
+never on a deployed preview or prd — verify against a preview before treating a local-only red
+as a regression. One class (redacted `Error: internal error; reference = …` from dynamic
+workers) was a shared worker-loader isolate cache across the parent workers that share local
+dev's single workerd (fix: PR #1614). A residual class (`The RPC receiver does not implement
+the method "…"`) is suspected to be capnweb classifying `RpcTarget`s at module-eval time: in
+the vite dev module graph a capnweb copy can evaluate before `cloudflare:workers` publishes the
+real class, so RpcTarget instances serialize as plain objects and their prototype methods
+vanish over RPC. Deployed single-bundle builds evaluate in the right order and are unaffected.
+
 - Live deployment tests: `pnpm e2e` (one config, `e2e/vitest.config.ts`, two projects). The
   `node` project runs the engine suites in `e2e/vitest/` (agents, admin-project, preview
   smoke) and the cross-runtime example matrix in `e2e/examples/`; the `browser` project runs


### PR DESCRIPTION
Doc-only follow-up from the #1610 session. The "itx e2e fails only against local pnpm dev" classes have bitten several sessions and were documented nowhere in the repo:

- The redacted `Error: internal error; reference = …` dynamic-worker class — shared worker-loader isolate cache across local dev's co-hosted parent workers, fixed by #1614.
- The residual `The RPC receiver does not implement the method "…"` class — suspected capnweb `RpcTarget` classification captured at module-eval time racing `cloudflare:workers` in the vite dev module graph; deployed single-bundle builds are unaffected.

The note tells agents/humans to verify local-only reds against a deployed preview before treating them as regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to e2e agent guidance with no runtime or test behavior changes.
> 
> **Overview**
> Adds a **local-dev caveat** to `e2e/AGENTS.md` so agents and humans do not treat preview/prd-green but local-red itx e2e runs as regressions without checking a deployed preview first.
> 
> The note documents two failure classes that only reproduce under local `pnpm dev`: redacted dynamic-worker `internal error; reference = …` (shared worker-loader isolate cache across co-hosted parent workers in one workerd; addressed in PR #1614), and `The RPC receiver does not implement the method "…"` (suspected capnweb `RpcTarget` classification at module-eval time racing the vite dev module graph vs `cloudflare:workers`; single-bundle deploys are unaffected).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10357f2b86d76bbb7fd7e958f6d6da75965588e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-03T14:28:12.596Z",
      "headSha": "10357f2b86d76bbb7fd7e958f6d6da75965588e8",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/582694370588115",
      "shortSha": "10357f2",
      "cleanupDurationMs": 43957,
      "deployDurationMs": 164093,
      "testDurationMs": 112730
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-03T14:27:47.927Z",
      "headSha": "10357f2b86d76bbb7fd7e958f6d6da75965588e8",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/582694370588115",
      "shortSha": "10357f2",
      "cleanupDurationMs": 19283,
      "deployDurationMs": 37071,
      "testDurationMs": 298
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `10357f2` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 37.1s | 298ms | 19.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/582694370588115) | 2026-07-03T14:27:47.927Z | Preview app released. |
| OS | released | `10357f2` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 164.1s | 112.7s | 44.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/582694370588115) | 2026-07-03T14:28:12.596Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->