### PR TITLE
[codex] Reinstate Slack debug bang command

### DIFF
--- a/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
+++ b/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
@@ -306,11 +306,11 @@ export function compileBangCommand(input: {
     return {
       code: [
         "async (itx) => {",
-        "  const debug = await itx.describe();",
+        "  const debug = await itx.debug();",
         "  await itx.slack.chat.postMessage({",
         `    channel: ${JSON.stringify(input.channel)},`,
         `    thread_ts: ${JSON.stringify(input.threadTs)},`,
-        "    text: `Debug info:\\n${JSON.stringify(debug, null, 2)}`,",
+        "    text: `Debug info:\\n${debug}`,",
         "  });",
         "}",
       ].join("\n"),

--- a/apps/os/src/domains/integrations/slack-processors.test.ts
+++ b/apps/os/src/domains/integrations/slack-processors.test.ts
@@ -576,7 +576,7 @@ describe("SlackAgentProcessor", () => {
     expect(slackCalls).toHaveLength(0);
   });
 
-  it("compiles the !debug bang command into a Slack-posting describe script", async () => {
+  it("compiles the !debug bang command into a Slack-posting debug script", async () => {
     const { cursors, processor, slackCalls, stream } = setup();
 
     await stream.append({
@@ -593,15 +593,12 @@ describe("SlackAgentProcessor", () => {
       idempotencyKey: "slack-agent:bang-command:1",
       payload: { executionId: "slack-bang-command-1" },
     });
-    // Legacy called `itx.debug()` and carried an `enqueued` payload flag; on
-    // itx the debug dump is `itx.describe()` and the payload is just
-    // { code, executionId }.
     const code = (scripts[0]!.payload as { code: string }).code;
-    expect(code).toContain("const debug = await itx.describe();");
+    expect(code).toContain("const debug = await itx.debug();");
     expect(code).toContain("await itx.slack.chat.postMessage({");
     expect(code).toContain('channel: "C123"');
     expect(code).toContain('thread_ts: "111.222"');
-    expect(code).toContain("text: `Debug info:");
+    expect(code).toContain("text: `Debug info:\\n${debug}`");
     expect(
       stream.events.filter((event) => event.type === "events.iterate.com/agent/input-added"),
     ).toHaveLength(0);
@@ -742,7 +739,7 @@ describe("SlackAgentProcessor", () => {
     );
     expect(scripts).toHaveLength(1);
     expect((scripts[0]!.payload as { code: string }).code).toContain(
-      "const debug = await itx.describe();",
+      "const debug = await itx.debug();",
     );
     expect(slackCalls.filter((call) => call.method === "reactions.add")).toHaveLength(0);
   });

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -16,6 +16,7 @@ import {
 } from "./project-directory.ts";
 import { deploymentStatusesFromProbes } from "./project-deployment-status.ts";
 import { timedStep } from "./lib/step-timing.ts";
+import { buildProjectStreamViewerUrl } from "./lib/stream-viewer-url.ts";
 import type { Env } from "./env.ts";
 import { DurableObjectNameCodec, normalizePath } from "./domains/durable-object-names.ts";
 import { normalizeAgentPath } from "./domains/agents/utils.ts";
@@ -1048,6 +1049,7 @@ type ItxRpcTargetProps = {
 const PROJECT_BUILTIN_CAPABILITY_PATHS = [
   "ai",
   "agents",
+  "debug",
   "egress",
   "examples",
   "gmail",
@@ -1090,6 +1092,14 @@ const PROJECT_BUILTIN_CAPABILITY_DESCRIPTIONS: readonly CapabilityDescription[] 
       return {
         instructions:
           'Project integration management. Use itx.integrations.getConnection({ provider: "google" }) before Gmail work and { provider: "slack" } before Slack API work.',
+        path: [path],
+        type: "builtin" as const,
+      };
+    }
+    if (path === "debug") {
+      return {
+        instructions:
+          "Returns formatted OS debug info for this itx scope, including a dashboard stream link.",
         path: [path],
         type: "builtin" as const,
       };
@@ -1146,6 +1156,28 @@ export class ItxRpcTarget extends RpcTarget implements Itx {
       ...project,
       capabilities: [...PROJECT_BUILTIN_CAPABILITY_DESCRIPTIONS, ...mountedCapabilities],
     };
+  }
+
+  async debug() {
+    const [project, config] = await Promise.all([
+      readProjectById(env.PROJECT_DIRECTORY, this.props.projectId).catch(() => null),
+      Promise.resolve(parseConfig(env)),
+    ]);
+    const streamPath = this.props.itxPath ?? "/";
+    const streamUrl =
+      project?.slug == null
+        ? (config.baseUrl ?? "https://os.iterate.com")
+        : buildProjectStreamViewerUrl({
+            baseUrl: config.baseUrl,
+            projectSlug: project.slug,
+            streamPath,
+          });
+
+    return [
+      `*Debug:* <${streamUrl}|open stream>`,
+      `Path: \`${streamPath}\``,
+      `Project: \`${project?.slug ?? this.props.projectId}\``,
+    ].join("\n");
   }
 
   get processor() {

--- a/apps/os/src/types-source.generated.ts
+++ b/apps/os/src/types-source.generated.ts
@@ -119,6 +119,8 @@ export type ProjectListEntry = {
 export interface Itx extends ItxCapabilityHost {
   ai: Ai;
   agents: AgentCollection;
+  /** Formatted dashboard/debug info for this itx scope, suitable for Slack messages. */
+  debug(): Promise<string>;
   describe(): Promise<ProjectDescription>;
   egress: ProjectEgress;
   /** Read-only catalogue of known-good itx script snippets (\`list()\`, \`get({ id })\`). */

--- a/apps/os/src/types.ts
+++ b/apps/os/src/types.ts
@@ -114,6 +114,8 @@ export type ProjectListEntry = {
 export interface Itx extends ItxCapabilityHost {
   ai: Ai;
   agents: AgentCollection;
+  /** Formatted dashboard/debug info for this itx scope, suitable for Slack messages. */
+  debug(): Promise<string>;
   describe(): Promise<ProjectDescription>;
   egress: ProjectEgress;
   /** Read-only catalogue of known-good itx script snippets (`list()`, `get({ id })`). */


### PR DESCRIPTION
## Summary

- restore Slack `!debug` to inject the short `itx.debug()` snippet
- add `itx.debug()` back as a built-in formatter for the current itx surface
- include a dashboard stream link, stream path, and project in the Slack debug reply
- update the public itx type source and Slack processor regression tests

## Root Cause

The itx migration changed `!debug` to post a raw `itx.describe()` JSON dump. The previous behavior used a short injected script calling `itx.debug()`, which returned Slack-friendly formatted debug text with a stream link.

## Validation

- `pnpm -C apps/os exec vitest run src/domains/integrations/slack-processors.test.ts`
- `pnpm -C apps/os typecheck`
- `pnpm lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized integration and debug-formatting changes; no auth, secrets, or data-model changes.
> 
> **Overview**
> Restores **Slack-friendly debug output** after the itx migration had pointed `!debug` at a raw `itx.describe()` JSON dump.
> 
> Adds **`itx.debug()`** as a project built-in on `ItxRpcTarget`: it returns a short formatted string (dashboard stream link via `buildProjectStreamViewerUrl`, current **itx scope path**, and project slug/id) instead of the full capability catalogue from `describe()`. The public **`Itx`** contract and generated types source are updated accordingly.
> 
> **`compileBangCommand`** for `!debug` / `!debug()` now injects a script that calls `itx.debug()` and posts `Debug info:\n${debug}` to the thread. Slack processor tests assert the new snippet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e1699a9d2190d38e0aba73d36100634d32dbe10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> Teardown skipped: Slot preview-6 no longer belongs to pr-1618: it is now leased by pr-1594 (https://github.com/iterate/iterate/pull/1594). Their deployment has replaced this PR's apps on preview_6.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-03T09:58:20.153Z",
      "headSha": "4e1699a9d2190d38e0aba73d36100634d32dbe10",
      "message": "Teardown skipped: Slot preview-6 no longer belongs to pr-1618: it is now leased by pr-1594 (https://github.com/iterate/iterate/pull/1594). Their deployment has replaced this PR's apps on preview_6.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/93527565937402",
      "shortSha": "4e1699a",
      "deployDurationMs": 43169,
      "testDurationMs": 63560
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-03T09:58:20.153Z",
      "headSha": "4e1699a9d2190d38e0aba73d36100634d32dbe10",
      "message": "Teardown skipped: Slot preview-6 no longer belongs to pr-1618: it is now leased by pr-1594 (https://github.com/iterate/iterate/pull/1594). Their deployment has replaced this PR's apps on preview_6.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/93527565937402",
      "shortSha": "4e1699a",
      "deployDurationMs": 28018,
      "testDurationMs": 689
    }
  },
  "environmentConfigLease": null,
  "notice": "Teardown skipped: Slot preview-6 no longer belongs to pr-1618: it is now leased by pr-1594 (https://github.com/iterate/iterate/pull/1594). Their deployment has replaced this PR's apps on preview_6."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `4e1699a` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 28.0s | 689ms |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/93527565937402) | 2026-07-03T09:58:20.153Z | Teardown skipped: Slot preview-6 no longer belongs to pr-1618: it is now leased by pr-1594 (https://github.com/iterate/iterate/pull/1594). Their deployment has replaced this PR's ... |
| OS | released | `4e1699a` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 43.2s | 63.6s |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/93527565937402) | 2026-07-03T09:58:20.153Z | Teardown skipped: Slot preview-6 no longer belongs to pr-1618: it is now leased by pr-1594 (https://github.com/iterate/iterate/pull/1594). Their deployment has replaced this PR's ... |

</details>
<!-- /CLOUDFLARE_PREVIEW -->