### PR TITLE
Agent processor: state-derived LLM scheduling; MCP session warmup barrier; openai-ws expired-response retry

### DIFF
--- a/apps/os/src/domains/agents/agent-processor-contract.ts
+++ b/apps/os/src/domains/agents/agent-processor-contract.ts
@@ -121,7 +121,7 @@ const LlmRequestPolicy = z
 
 export const AgentProcessorContract = defineProcessorContract({
   slug: "agent",
-  version: "0.2.0",
+  version: "0.3.0",
   description:
     "Maintains model-visible web-chat history and requests LLM work from a provider processor.",
   stateSchema: z.object({
@@ -149,6 +149,13 @@ export const AgentProcessorContract = defineProcessorContract({
       .nullable()
       .default(null),
     pendingTriggerOffset: z.number().int().positive().nullable().default(null),
+    /**
+     * Count of finished LLM request lifecycles (completed or cancelled).
+     * llm-request-scheduled idempotency is keyed on this, so every trigger
+     * derivation between two finishes — however delivery batches the inputs —
+     * collapses into one scheduled event at the stream's append dedup layer.
+     */
+    requestGeneration: z.number().int().nonnegative().default(0),
     scriptExecutionsCompleted: z.array(z.string()).default([]),
   }),
   events: {

--- a/apps/os/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/os/src/domains/agents/agent-processor-implementation.ts
@@ -8,10 +8,6 @@ import {
 
 type AgentState = z.infer<typeof AgentProcessorContract.stateSchema>;
 type AgentConsumedEvent = ReturnType<typeof AgentProcessorContract.parseEvent>;
-type LlmRequestPolicy = Extract<
-  AgentConsumedEvent,
-  { type: "events.iterate.com/agent/input-added" }
->["payload"]["llmRequestPolicy"];
 
 export class AgentProcessor extends StreamProcessor<typeof AgentProcessorContract> {
   readonly contract = AgentProcessorContract;
@@ -30,7 +26,6 @@ export class AgentProcessor extends StreamProcessor<typeof AgentProcessorContrac
     event,
     previousState,
     runInBackground,
-    state,
   }: Parameters<StreamProcessor<typeof AgentProcessorContract>["processEvent"]>[0]): undefined {
     switch (event.type) {
       case "events.iterate.com/agent/config-updated": {
@@ -69,17 +64,16 @@ export class AgentProcessor extends StreamProcessor<typeof AgentProcessorContrac
           }),
         );
         return;
-      case "events.iterate.com/agent/input-added":
-        blockProcessorWhile(async () => {
-          await this.#handleInputAdded({
-            append,
-            event,
-            policy: event.payload.llmRequestPolicy,
-            previousState,
-            state,
-          });
-        });
+      case "events.iterate.com/agent/input-added": {
+        // Scheduling the next LLM request is derived from reduced state at the
+        // end of the batch (see #settleLlmRequestScheduling); the only
+        // per-event side effect is interrupting a request already underway.
+        if (event.payload.llmRequestPolicy.behaviour !== "interrupt-current-request") return;
+        const interrupted = previousState.currentRequest;
+        if (interrupted === null) return;
+        blockProcessorWhile(() => append(cancelEventForCurrentRequest(interrupted)));
         return;
+      }
       case "events.iterate.com/agent/llm-request-scheduled":
         this.#scheduledRequestsWithActiveTimers.add(event.payload.requestId);
         runInBackground(async () => {
@@ -128,17 +122,6 @@ export class AgentProcessor extends StreamProcessor<typeof AgentProcessorContrac
         );
         return;
       }
-      case "events.iterate.com/agent/llm-request-completed":
-      case "events.iterate.com/agent/llm-request-cancelled":
-        if (state.currentRequest !== null || state.pendingTriggerOffset === null) return;
-        blockProcessorWhile(() =>
-          this.#appendLlmRequestScheduled({
-            append,
-            sourceOffset: state.pendingTriggerOffset!,
-            state,
-          }),
-        );
-        return;
       default:
         return;
     }
@@ -148,67 +131,48 @@ export class AgentProcessor extends StreamProcessor<typeof AgentProcessorContrac
     args: Parameters<StreamProcessor<typeof AgentProcessorContract>["processEventBatch"]>[0],
   ): Promise<void> {
     await super.processEventBatch(args);
-    const scheduled = args.state.currentRequest;
-    if (scheduled?.phase !== "scheduled") return;
-    if (this.#scheduledRequestsWithActiveTimers.has(scheduled.requestId)) return;
+    await this.#settleLlmRequestScheduling(args);
+  }
+
+  /**
+   * The LLM-request scheduling decision, derived from reduced state once per
+   * batch after the whole fold — never per event, where appends made earlier
+   * in the same batch are invisible. "A trigger is pending and no request is
+   * current" means exactly one llm-request-scheduled for the current request
+   * generation; the generation-keyed idempotency makes every re-derivation
+   * (many inputs in one batch, chunked delivery, crash replay) collapse into
+   * the same stream event.
+   */
+  async #settleLlmRequestScheduling(
+    args: Parameters<StreamProcessor<typeof AgentProcessorContract>["processEventBatch"]>[0],
+  ): Promise<void> {
+    const { state } = args;
+    if (state.currentRequest === null) {
+      if (state.pendingTriggerOffset === null) return;
+      await args.append({
+        type: "events.iterate.com/agent/llm-request-scheduled",
+        idempotencyKey: `agent/llm-request-scheduled@generation:${state.requestGeneration}`,
+        payload: {
+          debounceMs: DEFAULT_AGENT_LLM_REQUEST_DEBOUNCE_MS,
+          model: state.llmConfig.model,
+          provider: state.llmProvider,
+          requestId: `llm-request:gen-${state.requestGeneration}`,
+        },
+      });
+      return;
+    }
+    if (state.currentRequest.phase !== "scheduled") return;
+    if (this.#scheduledRequestsWithActiveTimers.has(state.currentRequest.requestId)) return;
     // No active timer for this scheduled request: the DO restarted and lost the
     // debounce. Fire llm-request-requested immediately. The idempotency key
     // makes this safe if the timer also fires concurrently.
     await args.append({
       type: "events.iterate.com/agent/llm-request-requested",
-      idempotencyKey: `agent/llm-request-requested@${scheduled.scheduledOffset}`,
+      idempotencyKey: `agent/llm-request-requested@${state.currentRequest.scheduledOffset}`,
       payload: {
-        model: args.state.llmConfig.model,
-        provider: args.state.llmProvider,
-        requestId: scheduled.requestId,
-      },
-    });
-  }
-
-  async #handleInputAdded(input: {
-    append: Parameters<StreamProcessor<typeof AgentProcessorContract>["processEvent"]>[0]["append"];
-    event: Extract<AgentConsumedEvent, { type: "events.iterate.com/agent/input-added" }>;
-    policy: LlmRequestPolicy;
-    previousState: AgentState;
-    state: AgentState;
-  }) {
-    if (input.policy.behaviour === "dont-trigger-request") return;
-
-    if (
-      input.policy.behaviour === "interrupt-current-request" &&
-      input.previousState.currentRequest !== null
-    ) {
-      await input.append(cancelEventForCurrentRequest(input.previousState.currentRequest));
-      await this.#appendLlmRequestScheduled({
-        append: input.append,
-        sourceOffset: input.event.offset,
-        state: input.state,
-      });
-      return;
-    }
-
-    if (input.previousState.currentRequest !== null) return;
-    await this.#appendLlmRequestScheduled({
-      append: input.append,
-      sourceOffset: input.event.offset,
-      state: input.state,
-    });
-  }
-
-  async #appendLlmRequestScheduled(input: {
-    append: Parameters<StreamProcessor<typeof AgentProcessorContract>["processEvent"]>[0]["append"];
-    sourceOffset: number;
-    state: AgentState;
-  }) {
-    const requestId = `llm-request:${input.sourceOffset}`;
-    await input.append({
-      type: "events.iterate.com/agent/llm-request-scheduled",
-      idempotencyKey: `agent/llm-request-scheduled@${input.sourceOffset}`,
-      payload: {
-        debounceMs: DEFAULT_AGENT_LLM_REQUEST_DEBOUNCE_MS,
-        model: input.state.llmConfig.model,
-        provider: input.state.llmProvider,
-        requestId,
+        model: state.llmConfig.model,
+        provider: state.llmProvider,
+        requestId: state.currentRequest.requestId,
       },
     });
   }
@@ -300,21 +264,21 @@ function reduceAgentEvent(input: { event: AgentConsumedEvent; state: AgentState 
       ) {
         return state;
       }
-      return { ...state, currentRequest: null };
+      return { ...state, currentRequest: null, requestGeneration: state.requestGeneration + 1 };
     case "events.iterate.com/agent/llm-request-cancelled":
       if (
         event.payload.phase === "scheduled" &&
         state.currentRequest?.phase === "scheduled" &&
         state.currentRequest.requestId === event.payload.requestId
       ) {
-        return { ...state, currentRequest: null };
+        return { ...state, currentRequest: null, requestGeneration: state.requestGeneration + 1 };
       }
       if (
         event.payload.phase === "requested" &&
         state.currentRequest?.phase === "requested" &&
         state.currentRequest.llmRequestId === event.payload.llmRequestId
       ) {
-        return { ...state, currentRequest: null };
+        return { ...state, currentRequest: null, requestGeneration: state.requestGeneration + 1 };
       }
       return state;
     case "events.iterate.com/itx/script-execution-completed":

--- a/apps/os/src/domains/agents/agent-processors.test.ts
+++ b/apps/os/src/domains/agents/agent-processors.test.ts
@@ -344,6 +344,101 @@ describe("minimal web-chat agent processors", () => {
     });
   });
 
+  it("coalesces multiple triggering inputs delivered in one batch into one LLM request", async () => {
+    const stream = new MemoryStream();
+    const agent = new AgentProcessor({ stream });
+
+    await stream.append(
+      {
+        type: "events.iterate.com/agent/input-added",
+        payload: {
+          content: "message one",
+          llmRequestPolicy: { behaviour: "after-current-request" },
+        },
+      },
+      {
+        type: "events.iterate.com/agent/input-added",
+        payload: {
+          content: "message two",
+          llmRequestPolicy: { behaviour: "after-current-request" },
+        },
+      },
+    );
+    await deliverNewEvents({ processor: agent, stream, cursors: new Map<object, number>() });
+
+    const scheduled = stream.events.filter(
+      (event) => event.type === "events.iterate.com/agent/llm-request-scheduled",
+    );
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]!.payload).toMatchObject({ requestId: "llm-request:gen-0" });
+  });
+
+  it("coalesces triggering inputs even when delivery chunks them across batches", async () => {
+    const stream = new MemoryStream();
+    const agent = new AgentProcessor({ stream });
+
+    await stream.append(
+      {
+        type: "events.iterate.com/agent/input-added",
+        payload: {
+          content: "message one",
+          llmRequestPolicy: { behaviour: "after-current-request" },
+        },
+      },
+      {
+        type: "events.iterate.com/agent/input-added",
+        payload: {
+          content: "message two",
+          llmRequestPolicy: { behaviour: "after-current-request" },
+        },
+      },
+    );
+
+    // First chunk delivers only input one; its batch appends the scheduled
+    // event at offset 3. The second chunk delivers only input two — a batch
+    // that predates the scheduled event, so state still shows no current
+    // request. The generation-keyed idempotency collapses the re-derived
+    // schedule into the event already on the stream.
+    await agent.ingest({ events: stream.events.slice(0, 1), streamMaxOffset: 2 });
+    await agent.ingest({ events: stream.events.slice(1, 2), streamMaxOffset: 3 });
+
+    const scheduled = stream.events.filter(
+      (event) => event.type === "events.iterate.com/agent/llm-request-scheduled",
+    );
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]!.payload).toMatchObject({ requestId: "llm-request:gen-0" });
+  });
+
+  it("coalesces multiple MCP-origin user messages replayed through the cold session backlog", async () => {
+    const stream = new MemoryStream();
+    const agent = new AgentProcessor({ stream });
+    const cursors = new Map<object, number>();
+
+    await stream.append(
+      {
+        type: "events.iterate.com/agents/user-message-received",
+        payload: { origin: "mcp", content: "first ask from MCP" },
+      },
+      {
+        type: "events.iterate.com/agents/user-message-received",
+        payload: { origin: "mcp", content: "second ask from MCP" },
+      },
+    );
+
+    await deliverNewEvents({ processor: agent, stream, cursors });
+    expect(
+      stream.events.filter((event) => event.type === "events.iterate.com/agent/input-added"),
+    ).toHaveLength(2);
+
+    await deliverNewEvents({ processor: agent, stream, cursors });
+
+    const scheduled = stream.events.filter(
+      (event) => event.type === "events.iterate.com/agent/llm-request-scheduled",
+    );
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]!.payload).toMatchObject({ requestId: "llm-request:gen-0" });
+  });
+
   it("does not fire a second LLM call when a second message arrives during the first request", async () => {
     const stream = new MemoryStream();
     const aiCalls: unknown[] = [];
@@ -576,6 +671,73 @@ describe("minimal web-chat agent processors", () => {
       result: { status: "success", usage: { total_tokens: 7 } },
     });
     expect(output.payload).toMatchObject({ content: "```js\nasync (itx) => {}\n```" });
+  });
+
+  it("retries openai-ws once with full input when a previous response id expires", async () => {
+    const stream = new MemoryStream();
+    const sockets: FakeResponsesWebSocket[] = [];
+    let responseCreateCount = 0;
+    const openAiWs = new OpenAiWsProcessor({
+      stream,
+      apiKey: "sk-test",
+      createResponsesWebSocketClient: async () => {
+        const socket = fakeResponsesWebSocket(() => {
+          responseCreateCount += 1;
+          if (responseCreateCount === 1) {
+            return [
+              { type: "response.output_text.delta", delta: "first answer" },
+              { type: "response.completed", response: { id: "resp_1" } },
+            ];
+          }
+          if (responseCreateCount === 2) {
+            return [
+              {
+                type: "response.failed",
+                error: { message: "Previous response with id 'resp_1' not found." },
+              },
+            ];
+          }
+          return [
+            { type: "response.output_text.delta", delta: "second answer" },
+            { type: "response.completed", response: { id: "resp_2" } },
+          ];
+        });
+        sockets.push(socket);
+        return socket;
+      },
+      readStreamEvents: () => stream.getEvents(),
+    });
+    const cursors = new Map<object, number>();
+
+    await stream.append(...openAiWsRequestEvents("first"));
+    await deliverNewEvents({ processor: openAiWs, stream, cursors });
+    const firstCompleted = await stream.waitForEvent({
+      eventTypes: ["events.iterate.com/agent/llm-request-completed"],
+      timeoutMs: 2_000,
+    });
+
+    await stream.append(...openAiWsRequestEvents("second"));
+    await deliverNewEvents({ processor: openAiWs, stream, cursors });
+    const secondCompleted = await stream.waitForEvent({
+      afterOffset: firstCompleted.offset,
+      eventTypes: ["events.iterate.com/agent/llm-request-completed"],
+      timeoutMs: 2_000,
+    });
+
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0]!.sent).toHaveLength(3);
+    expect(sockets[0]!.sent[1]).toMatchObject({ previous_response_id: "resp_1" });
+    expect(sockets[0]!.sent[2]).not.toHaveProperty("previous_response_id");
+    expect(sockets[0]!.sent[2]).toMatchObject({
+      input: expect.arrayContaining([
+        expect.objectContaining({ role: "user", content: "first" }),
+        expect.objectContaining({ role: "user", content: "second" }),
+      ]),
+    });
+    expect(secondCompleted.payload).toMatchObject({
+      provider: "openai-ws",
+      result: { status: "success" },
+    });
   });
 
   it("does not answer llm requests addressed to cloudflare-ai", async () => {

--- a/apps/os/src/domains/agents/openai-ws-processor-implementation.ts
+++ b/apps/os/src/domains/agents/openai-ws-processor-implementation.ts
@@ -139,21 +139,28 @@ export class OpenAiWsProcessor extends StreamProcessor<
         events: await this.deps.readStreamEvents(),
         llmRequestId,
       });
-      const connection = await this.#getConnection();
-      const requestMessage = buildResponsesClientEvent({
-        messages: body.messages,
-        model,
-        previousResponseId: this.#previousResponseId,
-      });
+      const attemptedPreviousResponseId = this.#previousResponseId;
+      let completion;
       try {
-        connection.client.sendResponseCreate(requestMessage);
+        completion = await this.#createAndConsumeResponse({
+          messages: body.messages,
+          model,
+          previousResponseId: attemptedPreviousResponseId,
+          sourceEvent: input.event,
+        });
       } catch (error) {
-        connection.client.close({ code: 1011, reason: "send-failed" });
-        this.#markConnectionClosed(connection);
-        throw error;
+        if (attemptedPreviousResponseId === null || !isPreviousResponseNotFoundError(error)) {
+          throw error;
+        }
+        this.#previousResponseId = null;
+        completion = await this.#createAndConsumeResponse({
+          idempotencyScope: `retry-without-previous-response:${attemptedPreviousResponseId}`,
+          messages: body.messages,
+          model,
+          previousResponseId: null,
+          sourceEvent: input.event,
+        });
       }
-
-      const completion = await this.#consumeResponse({ connection, sourceEvent: input.event });
       const durationMs = Date.now() - startedAt;
       const providerResult = {
         status: "success" as const,
@@ -221,6 +228,34 @@ export class OpenAiWsProcessor extends StreamProcessor<
     }
   }
 
+  async #createAndConsumeResponse(input: {
+    idempotencyScope?: string;
+    messages: ReturnType<typeof buildAgentLlmRequestBody>["messages"];
+    model: string;
+    previousResponseId: string | null;
+    sourceEvent: LlmRequestRequestedEvent;
+  }): Promise<{ rawResponse: unknown; responseId?: string; text: string; usage?: unknown }> {
+    const connection = await this.#getConnection();
+    const requestMessage = buildResponsesClientEvent({
+      messages: input.messages,
+      model: input.model,
+      previousResponseId: input.previousResponseId,
+    });
+    try {
+      connection.client.sendResponseCreate(requestMessage);
+    } catch (error) {
+      connection.client.close({ code: 1011, reason: "send-failed" });
+      this.#markConnectionClosed(connection);
+      throw error;
+    }
+
+    return await this.#consumeResponse({
+      connection,
+      idempotencyScope: input.idempotencyScope,
+      sourceEvent: input.sourceEvent,
+    });
+  }
+
   /**
    * Reads socket frames until the response terminates. Every frame lands on the
    * stream as an llm-response-chunk so subscribers (e.g. the browser agent UI)
@@ -228,6 +263,7 @@ export class OpenAiWsProcessor extends StreamProcessor<
    */
   async #consumeResponse(input: {
     connection: OpenAiWsConnection;
+    idempotencyScope?: string;
     sourceEvent: LlmRequestRequestedEvent;
   }): Promise<{ rawResponse: unknown; responseId?: string; text: string; usage?: unknown }> {
     const llmRequestId = input.sourceEvent.offset;
@@ -249,7 +285,10 @@ export class OpenAiWsProcessor extends StreamProcessor<
 
       await this.stream.append({
         type: "events.iterate.com/openai-ws/llm-response-chunk",
-        idempotencyKey: `openai-ws/llm-response-chunk@${llmRequestId}:${sequence}`,
+        idempotencyKey:
+          input.idempotencyScope === undefined
+            ? `openai-ws/llm-response-chunk@${llmRequestId}:${sequence}`
+            : `openai-ws/llm-response-chunk@${llmRequestId}:${input.idempotencyScope}:${sequence}`,
         payload: { chunk, llmRequestId, sequence },
       });
       sequence += 1;
@@ -379,6 +418,11 @@ function stringifyError(error: unknown): string {
   } catch {
     return String(error);
   }
+}
+
+function isPreviousResponseNotFoundError(error: unknown): boolean {
+  const message = stringifyError(error);
+  return message.includes("Previous response") && message.includes("not found");
 }
 
 // =============================================================================

--- a/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
@@ -15,6 +15,7 @@ import { z } from "zod";
 import { newHttpBatchRpcSession } from "capnweb";
 import { env } from "cloudflare:workers";
 import packageJson from "../../../package.json" with { type: "json" };
+import { ensureMcpSessionAgentReady } from "./mcp-session-agent-ready.ts";
 import { resolveMcpSessionAgentPath } from "./mcp-session-agent-path.ts";
 import { authenticateAdminApiSecret, readBearerToken } from "~/auth/admin.ts";
 import { createAuthWorkerServiceClient } from "~/auth/auth-worker-service.ts";
@@ -194,22 +195,24 @@ function createServer(input: {
       const project = await resolveProject(parsedInput.project);
       const agentPath = await resolveSessionAgentPath();
 
-      // One pipelined batch: agents.ask appends the message and waits for the
-      // agent's next chat reply server-side. Reply matching is by order on the
-      // session stream, not per-request correlation — the session belongs to
-      // this one MCP client, so interleaved replies are the client's own doing
-      // (same trust model as one person running exec_js mid-conversation).
+      // agents.ask appends the message and waits for the agent's next chat
+      // reply server-side. Reply matching is by order on the session stream,
+      // not per-request correlation — the session belongs to this one MCP
+      // client, so interleaved replies are the client's own doing (same trust
+      // model as one person running exec_js mid-conversation).
       let reply;
       try {
-        reply = await engineBatchSession(input.context)
-          .authenticate({ type: "admin-secret", secret: requireAdminSecret(input.context) })
-          .projects.get(project.id)
-          .agents.get(agentPath)
-          .ask({
-            message: parsedInput.message,
-            origin: "mcp",
-            timeoutMs: ASK_ASSISTANT_TIMEOUT_MS,
-          });
+        const root = engineBatchSession(input.context).authenticate({
+          type: "admin-secret",
+          secret: requireAdminSecret(input.context),
+        });
+        const projectItx = await root.projects.get(project.id);
+        await ensureMcpSessionAgentReady({ agentPath, projectItx });
+        reply = await projectItx.agents.get(agentPath).ask({
+          message: parsedInput.message,
+          origin: "mcp",
+          timeoutMs: ASK_ASSISTANT_TIMEOUT_MS,
+        });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         return {

--- a/apps/os/src/domains/inbound-mcp-server/mcp-session-agent-ready.test.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-session-agent-ready.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  ASK_ASSISTANT_SESSION_READY_TIMEOUT_MS,
+  ensureMcpSessionAgentReady,
+} from "./mcp-session-agent-ready.ts";
+import type { StreamEvent, StreamEventInput } from "~/types.ts";
+
+describe("ensureMcpSessionAgentReady", () => {
+  it("creates the session stream and waits for the agent system prompt before returning", async () => {
+    const promptReady = Promise.withResolvers<StreamEvent>();
+    const appended: StreamEventInput[] = [];
+    const waitCalls: Array<{
+      afterOffset?: number;
+      eventTypes?: readonly string[];
+      timeoutMs: number;
+    }> = [];
+    let requestedPath: string | undefined;
+
+    const ready = ensureMcpSessionAgentReady({
+      agentPath: "/agents/mcp/session-test",
+      projectItx: {
+        streams: {
+          get(path) {
+            requestedPath = path;
+            return {
+              async append(...events) {
+                appended.push(...events);
+                return events.map((event, index) => ({
+                  ...event,
+                  createdAt: new Date(index + 1).toISOString(),
+                  offset: index + 1,
+                }));
+              },
+              async waitForEvent(args) {
+                waitCalls.push(args);
+                return await promptReady.promise;
+              },
+            };
+          },
+        },
+      },
+    });
+
+    await Promise.resolve();
+
+    expect(requestedPath).toBe("/agents/mcp/session-test");
+    expect(appended).toEqual([
+      {
+        type: "events.iterate.com/mcp/session-agent-warmup",
+        idempotencyKey: "mcp/session-agent-warmup:/agents/mcp/session-test",
+        payload: { agentPath: "/agents/mcp/session-test" },
+      },
+    ]);
+    expect(waitCalls).toEqual([
+      {
+        afterOffset: 0,
+        eventTypes: ["events.iterate.com/agent/system-prompt-updated"],
+        timeoutMs: ASK_ASSISTANT_SESSION_READY_TIMEOUT_MS,
+      },
+    ]);
+
+    let returned = false;
+    void ready.then(() => {
+      returned = true;
+    });
+    await Promise.resolve();
+    expect(returned).toBe(false);
+
+    promptReady.resolve({
+      type: "events.iterate.com/agent/system-prompt-updated",
+      payload: { systemPrompt: "ready" },
+      createdAt: new Date().toISOString(),
+      offset: 2,
+    });
+    await ready;
+
+    expect(returned).toBe(true);
+  });
+});

--- a/apps/os/src/domains/inbound-mcp-server/mcp-session-agent-ready.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-session-agent-ready.ts
@@ -1,0 +1,24 @@
+import type { Stream } from "~/types.ts";
+
+export const ASK_ASSISTANT_SESSION_READY_TIMEOUT_MS = 90_000;
+
+export async function ensureMcpSessionAgentReady(input: {
+  agentPath: string;
+  projectItx: {
+    streams: {
+      get(path: string): Pick<Stream, "append" | "waitForEvent">;
+    };
+  };
+}): Promise<void> {
+  const stream = input.projectItx.streams.get(input.agentPath);
+  await stream.append({
+    type: "events.iterate.com/mcp/session-agent-warmup",
+    idempotencyKey: `mcp/session-agent-warmup:${input.agentPath}`,
+    payload: { agentPath: input.agentPath },
+  });
+  await stream.waitForEvent({
+    afterOffset: 0,
+    eventTypes: ["events.iterate.com/agent/system-prompt-updated"],
+    timeoutMs: ASK_ASSISTANT_SESSION_READY_TIMEOUT_MS,
+  });
+}


### PR DESCRIPTION
## Context

Production transcript showed an MCP `ask_assistant` against a cold session firing **two** LLM requests for one conversation: the session processor replayed both `user-message-received` events into `agent/input-added`, and a later cold delivery reduced both inputs in one batch — each one scheduled its own request. Separately, the first MCP message could land on a session stream before the agent was bootstrapped at all.

## Changes

### LLM-request scheduling derived from reduced state (the main refactor)

The agent processor was deciding "should I schedule an LLM request?" **per event** from `previousState`, which by design cannot see appends made earlier in the same batch — the root of the double-schedule. An in-memory batch flag would patch the same-batch case only; a chunked-delivery variant (input-2 delivered in a batch that predates input-1's `llm-request-scheduled`) slips past it, and offset-derived idempotency keys don't dedup because the source offsets differ.

Now scheduling is a pure function of reduced state, decided once per batch after the whole fold (`#settleLlmRequestScheduling`):

- State gains `requestGeneration`, bumped by the reducer whenever a request lifecycle finishes (completed or cancelled).
- At batch end: no current request + pending trigger → append `llm-request-scheduled` with idempotency key `@generation:{N}`. Every re-derivation of the same generation — many inputs in one batch, chunked delivery, crash replay — produces the same key, and the stream's append dedup collapses them into one event.
- The DO-restart debounce recovery (scheduled request with no live timer → fire `llm-request-requested` immediately) folds into the same batch-end derivation.
- All per-event scheduling is deleted: `#handleInputAdded`, the `llm-request-completed/cancelled` reschedule case, and the batch flag. The only per-event side effect left on `input-added` is the `interrupt-current-request` cancel; the reschedule happens next batch after the cancel folds.

Behavior notes: an interrupting input reschedules one delivery hop later (the debounce absorbs it); request ids change format from `llm-request:{offset}` to `llm-request:gen-{N}` (nothing outside the agent processor generates them — consumers treat them as opaque).

### MCP session warmup barrier

`ask_assistant` now calls `ensureMcpSessionAgentReady` before asking: appends `mcp/session-agent-warmup` and does not return until `agent/system-prompt-updated` exists on the session stream, so the user message never lands on an unbootstrapped session.

### openai-ws: retry once when previous_response_id expires

When the provider reports `Previous response with id '...' not found`, retry once with the full input (no `previous_response_id`) instead of failing the turn; response chunks from the retry get a distinct idempotency scope.

## Tests

- Same-batch coalescing (two triggering inputs in one delivered batch → one scheduled event)
- Chunked-delivery coalescing (one-event `ingest` slices → generation-keyed dedup collapses the re-derivation; fails under offset-keyed design)
- MCP cold-backlog replay (two `origin: "mcp"` user messages replayed through a cold session → one scheduled event)
- Warmup barrier unit tests; openai-ws expired-response retry test

`pnpm test` (apps/os domains: 20 files / 118 tests), `pnpm typecheck`, `pnpm lint`, `pnpm format` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent LLM scheduling and MCP ask path (behavior + timing); contract version bump and idempotency key changes affect stream replay semantics, though scoped to the agent processor.
> 
> **Overview**
> Fixes duplicate LLM turns on cold MCP sessions and related agent/provider edge cases.
> 
> The **agent processor** (v0.3.0) stops scheduling LLM work per `input-added` event. It adds **`requestGeneration`** (incremented when a request completes or is cancelled) and **`#settleLlmRequestScheduling`** at **batch end**: if there is a pending trigger and no active request, it appends a single **`llm-request-scheduled`** keyed by generation (`llm-request:gen-{N}`), so same-batch inputs, chunked delivery, and replay dedupe to one schedule. Per-event scheduling and post-complete reschedule paths are removed; **`interrupt-current-request`** still cancels in-flight work only. DO restart debounce recovery stays in the same batch-end path.
> 
> **MCP `ask_assistant`** calls **`ensureMcpSessionAgentReady`** first: append **`mcp/session-agent-warmup`**, then block until **`agent/system-prompt-updated`** on the session stream.
> 
> **openai-ws** retries once when **`previous_response_id`** is “not found”, resending full input without continuation; retry stream chunks use a separate idempotency scope.
> 
> Tests cover coalescing (batch, chunked ingest, MCP backlog), warmup, and expired-response retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39b088aa89abc4e1e452c67cecb632540f0de2fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-03T14:30:58.995Z",
      "headSha": "39b088aa89abc4e1e452c67cecb632540f0de2fb",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/250700688187007",
      "shortSha": "39b088a",
      "cleanupDurationMs": 48003,
      "deployDurationMs": 58141,
      "testDurationMs": 72001
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-03T14:30:34.025Z",
      "headSha": "39b088aa89abc4e1e452c67cecb632540f0de2fb",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/250700688187007",
      "shortSha": "39b088a",
      "cleanupDurationMs": 23029,
      "deployDurationMs": 27140,
      "testDurationMs": 971
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `39b088a` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 27.1s | 971ms | 23.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/250700688187007) | 2026-07-03T14:30:34.025Z | Preview app released. |
| OS | released | `39b088a` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 58.1s | 72.0s | 48.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/250700688187007) | 2026-07-03T14:30:58.995Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->