### PR TITLE
[codex] Add itx MCP and OpenAPI examples

### DIFF
--- a/apps/os/e2e/examples/example-cases.ts
+++ b/apps/os/e2e/examples/example-cases.ts
@@ -24,6 +24,9 @@
 //   connect-openapi-petstore
 //                   calls Swagger's public Petstore OpenAPI deployment;
 //                   external service, so keep it interactive.
+//   secret-postman-echo
+//                   calls Postman Echo to prove egress secret substitution;
+//                   external service, so keep it interactive.
 
 export type ExampleRunContext = {
   /** Unique per example × runtime, for stream/event payload assertions. */
@@ -44,6 +47,7 @@ export const EXAMPLE_IDS_WITHOUT_CASES = new Set([
   "exa-web-search",
   "connect-public-mcp",
   "connect-openapi-petstore",
+  "secret-postman-echo",
 ]);
 
 export const EXAMPLE_CASES: Record<string, ExampleCase> = {

--- a/apps/os/e2e/examples/example-cases.ts
+++ b/apps/os/e2e/examples/example-cases.ts
@@ -18,6 +18,12 @@
 //   exa-web-search  calls Exa's public MCP server (external service, rate
 //                   limited); interactive reading material, same rationale as
 //                   ai-models.
+//   connect-public-mcp
+//                   explicitly connects to Exa's public MCP server; external
+//                   service and rate limited, so keep it interactive.
+//   connect-openapi-petstore
+//                   calls Swagger's public Petstore OpenAPI deployment;
+//                   external service, so keep it interactive.
 
 export type ExampleRunContext = {
   /** Unique per example × runtime, for stream/event payload assertions. */
@@ -36,6 +42,8 @@ export const EXAMPLE_IDS_WITHOUT_CASES = new Set([
   "list-projects",
   "ai-models",
   "exa-web-search",
+  "connect-public-mcp",
+  "connect-openapi-petstore",
 ]);
 
 export const EXAMPLE_CASES: Record<string, ExampleCase> = {

--- a/apps/os/src/itx/examples.ts
+++ b/apps/os/src/itx/examples.ts
@@ -464,6 +464,89 @@ return { pages, search };
 `.trim(),
   },
   {
+    id: "connect-public-mcp",
+    title: "Connect a public MCP server, then mount it",
+    description:
+      "itx.mcp.connect({ url }) opens any reachable MCP server as an ad-hoc capability target. Tool names become flat method calls on the returned client. Mount the same connection recipe as an itx-expression when you want agents and future sessions to discover it through describe() and call it as itx.publicMcp.<tool>(). External service, so run it interactively.",
+    context: "project",
+    runtimes: ALL_RUNTIMES,
+    code: `
+const mcpUrl = vars.mcpUrl ?? "https://mcp.exa.ai/mcp";
+
+// Ad-hoc client: no mount, no project event. You can call MCP tools directly
+// by their tool name on the returned client.
+const mcp = await itx.mcp.connect({ url: mcpUrl });
+const search = await mcp.web_search_exa({
+  query: vars.query ?? "Cloudflare Workers RPC capabilities",
+  numResults: 2,
+});
+
+// Durable mount: this records a capability recipe on the project scope so
+// describe() can teach agents that itx.publicMcp.web_search_exa(...) exists.
+await itx.provideCapability({
+  expression: ["mcp", ["connect", { url: mcpUrl }]],
+  instructions:
+    "Public MCP search client. Call itx.publicMcp.web_search_exa({ query, numResults }) or itx.publicMcp.web_fetch_exa({ urls, maxCharacters }).",
+  path: ["publicMcp"],
+  type: "itx-expression",
+});
+
+const mountedSearch = await itx.publicMcp.web_search_exa({
+  query: vars.query ?? "OpenAPI operationId example",
+  numResults: 1,
+});
+const mount = (await itx.describe()).capabilities.find(
+  (capability) => capability.path.join(".") === "publicMcp",
+);
+
+return {
+  adHocCalled: Boolean(search),
+  mountType: mount?.type,
+  mountedCalled: Boolean(mountedSearch),
+};
+`.trim(),
+  },
+  {
+    id: "connect-openapi-petstore",
+    title: "Connect OpenAPI Petstore, then mount it",
+    description:
+      "itx.openapi.connect({ specUrl }) fetches an OpenAPI document through project egress and returns a client whose methods are the spec's flat operationIds. This calls Swagger Petstore's findPetsByStatus operation, then registers the same OpenAPI connection as a durable capability at itx.petstore. External service, so run it interactively.",
+    context: "project",
+    runtimes: ALL_RUNTIMES,
+    code: `
+const petstoreSpecUrl =
+  vars.specUrl ?? "https://petstore3.swagger.io/api/v3/openapi.json";
+
+// Await the OpenAPI client, then call operationIds as methods. This is the
+// same operation as:
+//   await (await itx.openapi.connect({ specUrl: petstoreSpecUrl }))
+//     .findPetsByStatus({ status: "available" })
+const petstore = await itx.openapi.connect({ specUrl: petstoreSpecUrl });
+const availablePets = await petstore.findPetsByStatus({ status: "available" });
+
+// Mount the recipe when the client should become a named project capability.
+await itx.provideCapability({
+  expression: ["openapi", ["connect", { specUrl: petstoreSpecUrl }]],
+  instructions:
+    "Swagger Petstore OpenAPI client. Call itx.petstore.findPetsByStatus({ status: 'available' }) or any other operationId from the spec.",
+  path: ["petstore"],
+  type: "itx-expression",
+});
+
+const soldPets = await itx.petstore.findPetsByStatus({ status: "sold" });
+const mount = (await itx.describe()).capabilities.find(
+  (capability) => capability.path.join(".") === "petstore",
+);
+
+return {
+  availableCount: Array.isArray(availablePets) ? availablePets.length : null,
+  firstAvailableName: Array.isArray(availablePets) ? availablePets[0]?.name : undefined,
+  mountType: mount?.type,
+  soldCount: Array.isArray(soldPets) ? soldPets.length : null,
+};
+`.trim(),
+  },
+  {
     id: "ai-models",
     title: "Workers AI is a built-in capability",
     description:

--- a/apps/os/src/itx/examples.ts
+++ b/apps/os/src/itx/examples.ts
@@ -384,6 +384,55 @@ return described;
 `.trim(),
   },
   {
+    id: "secret-postman-echo",
+    title: "Use a stored secret in a Postman Echo request",
+    description:
+      "Stores a secret with Postman Echo on its egress allowlist, sends a request through itx.egress.fetch with a getSecret({ path }) header placeholder, and verifies that Postman Echo saw the substituted value while describe() still never exposes the material. External service, so run it interactively.",
+    context: "project",
+    runtimes: ALL_RUNTIMES,
+    code: `
+const secretPath = vars.secretPath ?? "/secrets/postman-echo";
+const material = "demo-" + (vars.note ?? "postman-echo-secret");
+const secret = itx.secrets.get(secretPath);
+
+await secret.update({
+  // Egress checks origins, so this allows any path on postman-echo.com.
+  egress: { urls: ["https://postman-echo.com/"] },
+  material,
+});
+
+// update() is durable immediately, but the secret processor folds the stream
+// asynchronously. Wait until the request path can see the new material.
+let before = await secret.describe();
+for (let attempt = 0; attempt < 50 && !before.hasMaterial; attempt += 1) {
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  before = await secret.describe();
+}
+
+const response = await itx.egress.fetch(
+  new Request("https://postman-echo.com/get?source=itx-secret-example", {
+    headers: {
+      "x-itx-secret": \`Bearer getSecret({ path: "\${secretPath}" })\`,
+    },
+  }),
+);
+if (!response.ok) {
+  throw new Error(\`Postman Echo returned \${response.status}: \${await response.text()}\`);
+}
+
+const body = await response.json();
+const after = await secret.describe();
+const echoedSecret = body?.headers?.["x-itx-secret"];
+
+return {
+  echoedSecretMatches: echoedSecret === \`Bearer \${material}\`,
+  hasMaterial: after.hasMaterial,
+  materialLeakedInDescription: JSON.stringify(after).includes(material),
+  usedCount: after.audit.usedCount,
+};
+`.trim(),
+  },
+  {
     id: "journal-is-the-record",
     title: "The stream IS the record: provide, revoke, read it back",
     description:


### PR DESCRIPTION
## What changed

Adds three project-context itx catalogue examples in `apps/os`:

- `connect-public-mcp`: uses `itx.mcp.connect({ url })` against Exa's public MCP server, calls MCP tool methods, then mounts the same connection as `itx.publicMcp` with an `itx-expression` capability.
- `connect-openapi-petstore`: uses `itx.openapi.connect({ specUrl: "https://petstore3.swagger.io/api/v3/openapi.json" })`, calls `findPetsByStatus`, then mounts the same OpenAPI connection as `itx.petstore`.
- `secret-postman-echo`: stores a project secret, calls Postman Echo through `itx.egress.fetch` with a `getSecret({ path })` header placeholder, and verifies the echoed substituted value while `describe()` still omits the material.

The e2e catalogue metadata explicitly excludes these examples from the unattended matrix because they depend on public external services.

## Validation

- `pnpm exec oxfmt --check apps/os/src/itx/examples.ts apps/os/e2e/examples/example-cases.ts`
- `pnpm --dir apps/os exec vitest run e2e/examples/examples-matrix.e2e.test.ts --config e2e/vitest.config.ts -t "every catalogue example is either matrix-tested or explicitly excluded"`
- `pnpm --dir apps/os typecheck`
- Direct Postman Echo shape check with `curl -H "x-itx-secret: Bearer probe" https://postman-echo.com/get?...` confirmed `headers["x-itx-secret"]` is echoed.

Note: an initial Prettier check was attempted before noticing this repo uses `oxfmt`; it failed because `prettier` is not installed.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-03T14:36:37.915Z",
      "headSha": "e4ce8bf35a467bc654330b721d39962418e4ee21",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/500567288187015",
      "shortSha": "e4ce8bf",
      "cleanupDurationMs": 45591,
      "deployDurationMs": 51040,
      "testDurationMs": 87076
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-03T14:36:13.294Z",
      "headSha": "e4ce8bf35a467bc654330b721d39962418e4ee21",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/500567288187015",
      "shortSha": "e4ce8bf",
      "cleanupDurationMs": 20965,
      "deployDurationMs": 29442,
      "testDurationMs": 604
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `e4ce8bf` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 29.4s | 604ms | 21.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/500567288187015) | 2026-07-03T14:36:13.294Z | Preview app released. |
| OS | released | `e4ce8bf` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 51.0s | 87.1s | 45.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/500567288187015) | 2026-07-03T14:36:37.915Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and interactive example catalogue changes only; no production runtime or auth logic is modified.
> 
> **Overview**
> Adds **three project-context catalogue snippets** in `apps/os/src/itx/examples.ts` for interactive REPL/docs use: **`connect-public-mcp`** (ad-hoc `itx.mcp.connect` + durable `itx-expression` mount at `publicMcp`), **`connect-openapi-petstore`** (`itx.openapi.connect` + mount at `petstore`), and **`secret-postman-echo`** (secret + `itx.egress.fetch` with `getSecret({ path })` and checks that Postman Echo echoes the substituted value without leaking material in `describe()`).
> 
> **E2E metadata** in `example-cases.ts` documents why each is external-dependent and adds their ids to `EXAMPLE_IDS_WITHOUT_CASES` so the unattended examples matrix still passes without matrix assertions for them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4ce8bf35a467bc654330b721d39962418e4ee21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->