### PR TITLE
Preview 522 fix: ensure-only worker routes, parked slot teardowns

### DIFF
--- a/apps/auth/alchemy.run.ts
+++ b/apps/auth/alchemy.run.ts
@@ -3,7 +3,7 @@ import { D1Database, TanStackStart } from "alchemy/cloudflare";
 import { Exec } from "alchemy/os";
 import { CloudflareStateStore, SQLiteStateStore } from "alchemy/state";
 import { slugify } from "@iterate-com/shared/slugify";
-import { ensureProxiedDnsForHostnames } from "@iterate-com/shared/alchemy/iterate-app";
+import { IterateRoutes, parkWorkerRoutes } from "@iterate-com/shared/alchemy/iterate-app";
 import { z } from "zod/v4";
 import { seedOAuthClients } from "./scripts/seed-oauth-clients.ts";
 
@@ -54,6 +54,30 @@ const AlchemyEnv = z.object({
   GOOGLE_CLIENT_ID: z.string(),
   GOOGLE_CLIENT_SECRET: z.string(),
 });
+
+// `--park` re-parks the slot edge after `--destroy`: placeholder script plus
+// re-ensured, verified routes, so the next tenant's deploy finds live routes
+// instead of creating them on its critical path (see parkWorkerRoutes).
+// Chained as a separate invocation because alchemy exits the process inside
+// the destroy phase.
+if (process.argv.includes("--park")) {
+  const parkEnv = AlchemyEnv.pick({
+    ALCHEMY_LOCAL: true,
+    ALCHEMY_STAGE: true,
+    CLOUDFLARE_ACCOUNT_ID: true,
+    CLOUDFLARE_API_TOKEN: true,
+    WORKER_ROUTES: true,
+  }).parse(process.env);
+  if (!parkEnv.ALCHEMY_LOCAL) {
+    await parkWorkerRoutes({
+      hostnames: parkEnv.WORKER_ROUTES,
+      slug: APP_NAME,
+      stage: parkEnv.ALCHEMY_STAGE,
+      workerName: slugify(`${APP_NAME}-${parkEnv.ALCHEMY_STAGE}`),
+    });
+  }
+  process.exit(0);
+}
 
 const alchemyEnv = AlchemyEnv.parse(process.env);
 const publicUrl = alchemyEnv.VITE_PUBLIC_URL ?? alchemyEnv.VITE_AUTH_APP_ORIGIN;
@@ -113,7 +137,6 @@ const worker = await TanStackStart(APP_NAME, {
     GOOGLE_CLIENT_ID: alchemy.secret(alchemyEnv.GOOGLE_CLIENT_ID),
     GOOGLE_CLIENT_SECRET: alchemy.secret(alchemyEnv.GOOGLE_CLIENT_SECRET),
   },
-  routes: alchemyEnv.WORKER_ROUTES.map((pattern) => ({ pattern: `${pattern}/*`, adopt: true })),
   adopt: true,
   // Without this flag, same-zone subrequests (e.g. SSR calling our own
   // /api/auth/get-session via the public hostname) bypass Worker routes and
@@ -144,14 +167,12 @@ console.dir(
 
 await app.finalize();
 
-// Worker routes need proxied DNS on the zone to fire; ensure originless
-// records for every routed hostname (e.g. auth.iterate-preview-N.com).
-if (!app.local) {
-  await ensureProxiedDnsForHostnames({
-    hostnames: alchemyEnv.WORKER_ROUTES,
-    comment: `Managed by auth alchemy (${app.stage}).`,
-  });
-}
+// Routes + DNS ensured after finalize, DNS-before-routes, edge-verified
+// (see iterate-app.ts). Auth previously declared routes on the Worker
+// resource and only ensured DNS afterwards — exactly the ordering that
+// produces zombie routes (visible in the API, dead at the edge, every
+// sign-in 522s) on fresh slots.
+await IterateRoutes({ app, slug: APP_NAME }, { worker, hostnames: alchemyEnv.WORKER_ROUTES });
 
 // Seed declarative OAuth clients (Doppler → DB) after every deployed run, so
 // the database always matches AUTH_SEED_OAUTH_CLIENTS in the selected config.

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "alchemy:up": "tsx ./alchemy.run.ts",
-    "alchemy:down": "tsx ./alchemy.run.ts --destroy",
+    "alchemy:down": "tsx ./alchemy.run.ts --destroy && tsx ./alchemy.run.ts --park",
     "dev:local": "alchemy dev",
     "dev": "doppler run --project auth --config dev -- alchemy dev",
     "auth:generate": "auth generate --config ./src/server/auth.schema-only.ts --yes",

--- a/apps/os/alchemy.run.ts
+++ b/apps/os/alchemy.run.ts
@@ -18,8 +18,10 @@ import {
   ITERATE_WORKER_OBSERVABILITY,
   IterateAppWorker,
   IterateRoutes,
+  parkWorkerRoutes,
 } from "@iterate-com/shared/alchemy/iterate-app";
 import { prepareLocalDevServer } from "@iterate-com/shared/alchemy/local-dev-server";
+import { slugify } from "@iterate-com/shared/slugify";
 import { ensureLocalDevOAuthClient } from "./src/auth/dev-oauth-client-bootstrap.ts";
 import { AppConfig } from "./src/config.ts";
 import type { AgentDurableObject } from "./src/domains/agents/agent-durable-object.ts";
@@ -29,6 +31,42 @@ import type { RepoDurableObject } from "./src/domains/repos/repo-durable-object.
 import type { SecretDurableObject } from "./src/domains/secrets/secret-durable-object.ts";
 import type { StreamDurableObject } from "./src/domains/streams/stream-durable-object.ts";
 import type { StatefulWorkerDurableObject } from "./src/domains/workers/stateful-worker-durable-object.ts";
+
+// `--park` re-parks the slot edge after `--destroy` deleted every worker:
+// upload a placeholder ingress script and re-ensure + verify routes/DNS
+// against it, so the next tenant's deploy finds live routes instead of
+// paying the route-creation propagation lottery (see parkWorkerRoutes).
+// Alchemy exits the process inside the destroy phase, so this cannot run in
+// the same invocation — package.json "destroy" chains it. Hostnames are read
+// straight from the flat APP_CONFIG_* env vars (with the APP_CONFIG blob as
+// fallback, same precedence as scripts/preview readPreviewAppConfig) instead
+// of the full AppConfig parse, which would drag deploy-time JWKS fetching —
+// against the auth worker this very teardown just deleted — into the park.
+if (process.argv.includes("--park")) {
+  if (/^(1|true|yes)$/i.test(process.env.ALCHEMY_LOCAL ?? "")) process.exit(0);
+  const stage = process.env.ALCHEMY_STAGE?.trim();
+  if (!stage) throw new Error("ALCHEMY_STAGE is required to park a slot.");
+  const appConfigBlob = process.env.APP_CONFIG?.trim()
+    ? (JSON.parse(process.env.APP_CONFIG) as {
+        baseUrl?: string;
+        mcp?: { baseUrl?: string };
+        projectHostnameBases?: string[];
+      })
+    : {};
+  await parkWorkerRoutes({
+    hostnames: osRouteHostnames({
+      baseUrl: process.env.APP_CONFIG_BASE_URL || appConfigBlob.baseUrl,
+      mcp: { baseUrl: process.env.APP_CONFIG_MCP__BASE_URL || appConfigBlob.mcp?.baseUrl },
+      projectHostnameBases: process.env.APP_CONFIG_PROJECT_HOSTNAME_BASES?.trim()
+        ? (JSON.parse(process.env.APP_CONFIG_PROJECT_HOSTNAME_BASES) as string[])
+        : appConfigBlob.projectHostnameBases,
+    }),
+    slug: "os",
+    stage,
+    workerName: slugify(`os-${stage}`),
+  });
+  process.exit(0);
+}
 
 const resolvedAuthIssuer =
   process.env.APP_CONFIG_ITERATE_AUTH__ISSUER ?? process.env.ITERATE_OAUTH_ISSUER;
@@ -227,9 +265,8 @@ const workerNames = {
 // (local dev), and <slug>.iterate-preview-N.app (preview).
 // The preview app shell deliberately lives on the sibling
 // iterate-preview-N.com zone (`os.iterate-preview-N.com`) so project/MCP hosts
-// can own the iterate-preview-N.app zone cleanly.
-const projectHostnameBases = ctx.runtimeConfig.projectHostnameBases ?? [];
-const mcpRouteHostname = routeHostnameForUrl(ctx.runtimeConfig.mcp?.baseUrl);
+// can own the iterate-preview-N.app zone cleanly. Hostname derivation:
+// osRouteHostnames below.
 const artifactsAccountId = requireEnv("CLOUDFLARE_ACCOUNT_ID");
 const artifactsNamespace = `${ctx.workerName}-repos`;
 
@@ -498,22 +535,6 @@ const ingressWorker = await osWorker("ingress", {
   },
 });
 
-const baseUrlHostname = ctx.runtimeConfig.baseUrl
-  ? new URL(ctx.runtimeConfig.baseUrl).hostname
-  : undefined;
-await IterateRoutes(ctx, {
-  worker: ingressWorker,
-  hostnames: [
-    ...new Set(
-      [
-        ...(baseUrlHostname ? [baseUrlHostname] : []),
-        ...(mcpRouteHostname ? [mcpRouteHostname] : []),
-        ...projectHostnameBases.flatMap(projectRouteHostnamesForBase),
-      ].filter((hostname) => !hostname.endsWith(".workers.dev")),
-    ),
-  ],
-});
-
 /** Per-worker Env types for src/lib/worker-env.d.ts. */
 export const workers = {
   agent: agentWorker,
@@ -530,7 +551,40 @@ export const workers = {
 
 await ctx.app.finalize();
 
+// Routes + DNS are ensured AFTER finalize: they are not alchemy resources
+// (deploys and destroys never delete them — see iterate-app.ts), and running
+// the ensure earlier would let finalize's orphan cleanup delete a route the
+// ensure just verified.
+await IterateRoutes(ctx, {
+  worker: ingressWorker,
+  hostnames: osRouteHostnames(ctx.runtimeConfig),
+});
+
 if (!ctx.app.local) process.exit(0);
+
+/**
+ * Every hostname routed to the os ingress worker for a given config: the app
+ * base URL, the MCP host, and the project-host patterns. Shared between the
+ * deploy path (ctx.runtimeConfig) and `--park` (config parsed straight from
+ * env, no alchemy app).
+ */
+function osRouteHostnames(config: {
+  baseUrl?: string;
+  mcp?: { baseUrl?: string };
+  projectHostnameBases?: string[];
+}) {
+  const baseUrlHostname = config.baseUrl ? new URL(config.baseUrl).hostname : undefined;
+  const configMcpHostname = routeHostnameForUrl(config.mcp?.baseUrl);
+  return [
+    ...new Set(
+      [
+        ...(baseUrlHostname ? [baseUrlHostname] : []),
+        ...(configMcpHostname ? [configMcpHostname] : []),
+        ...(config.projectHostnameBases ?? []).flatMap(projectRouteHostnamesForBase),
+      ].filter((hostname) => !hostname.endsWith(".workers.dev")),
+    ),
+  ];
+}
 
 /**
  * Convert OS project-host bases into Cloudflare route host patterns.

--- a/apps/os/package.json
+++ b/apps/os/package.json
@@ -13,7 +13,7 @@
     "build": "doppler run -- pnpm exec vite build",
     "probe:do-duration": "tsx ./scripts/do-duration-probe.ts",
     "deploy": "doppler run -- tsx ./alchemy.run.ts",
-    "destroy": "doppler run -- tsx ./alchemy.run.ts --destroy",
+    "destroy": "doppler run -- tsx ./alchemy.run.ts --destroy && doppler run -- tsx ./alchemy.run.ts --park",
     "routes:generate": "tsx ./scripts/generate-route-tree.ts",
     "generate:itx-types-source": "tsx ./scripts/generate-itx-types-source.ts",
     "routes:check": "tsx ./scripts/generate-route-tree.ts --check",

--- a/apps/semaphore/alchemy.run.ts
+++ b/apps/semaphore/alchemy.run.ts
@@ -1,6 +1,10 @@
 import { D1Database, DurableObjectNamespace } from "alchemy/cloudflare";
 import { initAlchemy } from "@iterate-com/shared/alchemy/init";
-import { IterateApp } from "@iterate-com/shared/alchemy/iterate-app";
+import {
+  IterateAppWorker,
+  IterateRoutes,
+  deriveWorkerRouteHosts,
+} from "@iterate-com/shared/alchemy/iterate-app";
 import { AppConfig } from "./src/config.ts";
 import type { ResourceCoordinator } from "~/durable-objects/resource-coordinator.ts";
 
@@ -17,13 +21,22 @@ const coordinator = DurableObjectNamespace<ResourceCoordinator>("resource-coordi
   sqlite: true,
 });
 
-const worker = await IterateApp(ctx, {
+const worker = await IterateAppWorker(ctx, {
   main: "./src/worker.ts",
   bindings: { DB: db, RESOURCE_COORDINATOR: coordinator },
 });
 
+console.dir({ url: ctx.runtimeConfig.baseUrl ?? worker.url, workersDevUrl: worker.url });
+
 export { worker };
 
 await ctx.app.finalize();
+
+// Routes are ensured after finalize — they are not alchemy resources (see
+// iterate-app.ts for the lifecycle rationale).
+await IterateRoutes(ctx, {
+  worker,
+  hostnames: deriveWorkerRouteHosts(ctx.runtimeConfig.baseUrl),
+});
 
 if (!ctx.app.local) process.exit(0);

--- a/apps/streams-example-app/alchemy.run.ts
+++ b/apps/streams-example-app/alchemy.run.ts
@@ -1,6 +1,10 @@
 import { DurableObjectNamespace } from "alchemy/cloudflare";
 import { initAlchemy } from "@iterate-com/shared/alchemy/init";
-import { IterateApp } from "@iterate-com/shared/alchemy/iterate-app";
+import {
+  IterateAppWorker,
+  IterateRoutes,
+  deriveWorkerRouteHosts,
+} from "@iterate-com/shared/alchemy/iterate-app";
 import { AppConfig } from "./src/config.ts";
 import type { StreamDurableObject } from "~/domains/streams/stream-durable-object.ts";
 
@@ -19,15 +23,24 @@ const stream = DurableObjectNamespace<StreamDurableObject>("stream", {
   sqlite: true,
 });
 
-const worker = await IterateApp(ctx, {
+const worker = await IterateAppWorker(ctx, {
   main: "./src/worker.ts",
   bindings: {
     STREAM: stream,
   },
 });
 
+console.dir({ url: ctx.runtimeConfig.baseUrl ?? worker.url, workersDevUrl: worker.url });
+
 export { worker };
 
 await ctx.app.finalize();
+
+// Routes are ensured after finalize — they are not alchemy resources (see
+// iterate-app.ts for the lifecycle rationale).
+await IterateRoutes(ctx, {
+  worker,
+  hostnames: deriveWorkerRouteHosts(ctx.runtimeConfig.baseUrl),
+});
 
 if (!ctx.app.local) process.exit(0);

--- a/docs/ci-preview-performance.md
+++ b/docs/ci-preview-performance.md
@@ -50,13 +50,18 @@ seconds and run alongside OS.
   suites run concurrently too (`scripts/preview/preview.ts`).
 - **Playwright runs 6 workers, `fullyParallel`, in CI** (`playwright.config.ts`)
   — every spec creates its own fixture project.
-- **The slot is warmed before the burst.** A cold deployment answers its first
-  requests only after loading each worker; ~40 concurrent WebSocket handshakes
-  against zero warm isolates returned edge 499/522s. The test command curls
-  each worker (health, app, itx, auth) before starting the lanes, and the
-  WebSocket handshake timeout is 30s (`apps/os/src/itx-client.ts`).
-- **The chromium install overlaps the warmup.** `playwright install chromium`
-  hits no slot, so it runs in the background while the slot warms and the
+- **One sequential create-saga smoke runs before the burst.** The first real
+  project create pays the genuine cold-start costs (cold DO chain, repo seed,
+  worker probe) once, sequentially, instead of surfacing as rotating timeout
+  flakes across the concurrent suites — and fails loudly if the slot is
+  broken. The curl-round HTTP warmups that used to accompany it existed to
+  absorb post-deploy edge 499/522s; those were zombie worker routes (routes
+  visible in the API but dead at the edge), which deploys now verify and heal
+  directly (`ensureWorkerRoutesAndDns` in
+  `packages/shared/src/alchemy/iterate-app.ts`) and slot teardowns keep parked
+  (`parkWorkerRoutes`), so the curls are gone.
+- **The chromium install overlaps the smoke.** `playwright install chromium`
+  hits no slot, so it runs in the background while the smoke runs and the
   vitest lanes start, instead of blocking the specs.
 - **GitHub API calls retry transient 5xx.** The preview script fetches PR
   context from GitHub's REST API at the start of each step; that API
@@ -91,8 +96,9 @@ creep visible. If you see one:
   you must add coverage, fold it into an existing concurrent lane.
 - **Never serialize what can self-provision.** The apps' suites and the vitest
   lanes run concurrently on purpose; keep it that way.
-- **Keep the warmup.** Removing it brings back the cold-start stampede
-  (edge 499/522s), which fails or retries and makes runs _slower_, not faster.
+- **Keep the create-saga smoke.** Removing it brings back the rotating
+  "saw 0 events" cold-start flakes across the concurrent suites, which fail or
+  retry and make runs _slower_, not faster.
 - **Mind slot load, not just runner load.** More Playwright workers or higher
   `maxConcurrency` increases concurrent pressure on the _deployed slot_, which
   is where the known stream-delivery race lives

--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -397,7 +397,9 @@ doppler run --project _shared --config prd -- pnpm preview acquire --slot 9    #
 # "Acting as users" above; bare --admin lands on the auth login page):
 doppler run --project os --config preview_9 -- pnpm auth:mint --admin --browser-url
 
-# Tear down and release when done:
+# Tear down and release when done (destroy chains --park: the slot's routes
+# and DNS stay live against a placeholder script, so the next deploy never
+# creates routes on its critical path — see iterate-app.ts):
 (cd apps/os   && doppler run --project os   --config preview_9 -- pnpm run destroy)
 (cd apps/auth && doppler run --project auth --config preview_9 -- pnpm alchemy:down)
 doppler run --project _shared --config prd -- pnpm preview release --slot 9 --lease-id <leaseId>

--- a/packages/shared/src/alchemy/iterate-app.ts
+++ b/packages/shared/src/alchemy/iterate-app.ts
@@ -1,38 +1,29 @@
 import { fileURLToPath } from "node:url";
 import alchemy from "alchemy";
-import { Route, TanStackStart, createCloudflareApi } from "alchemy/cloudflare";
+import { TanStackStart, createCloudflareApi } from "alchemy/cloudflare";
 import type { Bindings, WorkerProps } from "alchemy/cloudflare";
-import type { BaseAppConfig } from "../config.ts";
-import { slugify } from "../slugify.ts";
 import type { initAlchemy } from "./init.ts";
 
 /**
- * Create a standard Iterate app worker with automatic route derivation, DNS,
- * and observability.
+ * Iterate's Cloudflare worker + edge-routing conventions.
  *
- * This is the standard way to deploy an Iterate app to Cloudflare Workers. It
- * wraps alchemy's TanStackStart (https://alchemy.run/providers/cloudflare/tanstack-start/)
- * and adds our conventions on top:
+ * Two layers with deliberately different lifecycles:
  *
- * **Route + DNS derivation from `baseUrl`:**
- * Each environment (dev, preview, prod) sets `APP_CONFIG_BASE_URL` in Doppler.
- * This function extracts the hostname and creates both a Cloudflare worker route
- * and a proxied CNAME DNS record pointing to the worker. Worker routes alone are
- * not enough — Cloudflare requires a DNS record on the zone for the proxied
- * hostname to resolve. See https://developers.cloudflare.com/workers/configuration/routing/routes/
+ * **Workers** ({@link IterateAppWorker}) are alchemy resources: created,
+ * updated, and destroyed with the app's stage.
  *
- * **Observability:**
- * All Iterate workers use the same observability config: full sampling with
- * persistent logs and traces. See https://developers.cloudflare.com/workers/observability/
- *
- * ```ts
- * const ctx = await initAlchemy("my-app", AppConfig, process.env);
- * const db = await D1Database("db", { name: `${ctx.workerName}-db` });
- * const worker = await IterateApp(ctx, {
- *   bindings: { DB: db },
- * });
- * await ctx.app.finalize();
- * ```
+ * **Routes + DNS** ({@link IterateRoutes}) are NOT alchemy resources. They are
+ * idempotently ENSURED against the Cloudflare API and never deleted by any
+ * deploy or destroy. Rationale: creating a zone route is the only edge
+ * operation we have that can silently fail — the route is visible in the API
+ * but never fires at the edge ("zombie route"), so every request falls through
+ * to the originless placeholder DNS record and dies with a 522 after ~20s
+ * (tasks/os-cold-create-latency.md). Script uploads, by contrast, are the
+ * battle-tested steady-state path. So route creation is pushed to the rarest
+ * possible moment (a genuinely fresh hostname, or re-parking after a slot
+ * teardown — see {@link parkWorkerRoutes}), always ordered after DNS, and
+ * always verified with a live edge probe that heals zombies by recreation.
+ * Steady-state deploys mutate no route or DNS state at all.
  */
 /**
  * The observability config every Iterate worker uses: full sampling with
@@ -46,7 +37,15 @@ export const ITERATE_WORKER_OBSERVABILITY = {
   traces: { enabled: true, persist: true, headSamplingRate: 1 },
 } as const;
 
-type IterateCtx = Awaited<ReturnType<typeof initAlchemy>>;
+/**
+ * The subset of an initAlchemy context the route helpers need. Structural on
+ * purpose: apps that hand-roll their alchemy app (apps/auth) can construct it
+ * directly.
+ */
+export type IterateRoutesCtx = {
+  app: { local?: boolean; stage: string };
+  slug: string;
+};
 
 export type IterateAppProps<B extends Bindings> = {
   /** App-specific worker bindings (D1, DOs, etc). APP_CONFIG is added automatically. */
@@ -60,13 +59,6 @@ export type IterateAppProps<B extends Bindings> = {
   compatibilityFlags?: string[];
   /** Worker compatibility date. Defaults to Alchemy's current Workers runtime date. */
   compatibilityDate?: string;
-  /**
-   * Additional hostnames to route to this worker beyond `baseUrl`.
-   * Each hostname gets a worker route and (for non-local deploys) a DNS CNAME.
-   * For example, os passes `["iterate.app", "*.iterate.app"]` for project
-   * subdomain routing.
-   */
-  extraRouteHostnames?: string[];
   /** Worker entry module (default: `./src/entry.workerd.ts`). */
   main?: string;
   /**
@@ -97,35 +89,30 @@ export type IterateAppProps<B extends Bindings> = {
   url?: boolean;
 };
 
-export async function IterateApp<B extends Bindings>(ctx: IterateCtx, props: IterateAppProps<B>) {
-  const runtimeConfig = ctx.runtimeConfig as BaseAppConfig;
-  const routeHosts = deriveWorkerRouteHosts(runtimeConfig.baseUrl, props.extraRouteHostnames);
-
-  const worker = await IterateAppWorker(ctx, props);
-  await IterateRoutes(ctx, { hostnames: routeHosts, worker });
-
-  console.dir(
-    {
-      config: runtimeConfig,
-      url: runtimeConfig.baseUrl ?? worker.url,
-      workersDevUrl: worker.url,
-    },
-    { depth: null },
-  );
-
-  return worker;
-}
+/** The context initAlchemy returns — the full ctx IterateAppWorker consumes. */
+type IterateCtx = Awaited<ReturnType<typeof initAlchemy>>;
 
 /**
  * The app worker with Iterate conventions — TanStack Start build via Vite,
  * APP_CONFIG injection, standard observability, asset preupload + server
- * bundle pruning — but no routes or DNS. Apps that put a router
- * worker in front (apps/os) call this directly and give the routes to the
- * router via {@link IterateRoutes}.
+ * bundle pruning — but no routes or DNS. Callers ensure routes with
+ * {@link IterateRoutes} AFTER `ctx.app.finalize()`: the ensure is not an
+ * alchemy resource, so running it before finalize would let a stale Route
+ * resource in state orphan-delete the very route it just verified.
+ *
+ * ```ts
+ * const ctx = await initAlchemy("my-app", AppConfig, process.env);
+ * const worker = await IterateAppWorker(ctx, { bindings: { DB: db } });
+ * await ctx.app.finalize();
+ * await IterateRoutes(ctx, {
+ *   worker,
+ *   hostnames: deriveWorkerRouteHosts(ctx.runtimeConfig.baseUrl),
+ * });
+ * ```
  */
 export async function IterateAppWorker<B extends Bindings>(
   ctx: IterateCtx,
-  props: Omit<IterateAppProps<B>, "extraRouteHostnames">,
+  props: IterateAppProps<B>,
 ) {
   const { app, rawRuntimeConfig, slug } = ctx;
   const workerName = props.name ?? ctx.workerName;
@@ -171,109 +158,235 @@ export async function IterateAppWorker<B extends Bindings>(
 }
 
 /**
- * Routes + DNS for a deployed worker.
+ * Ensure routes + DNS for a deployed worker. Idempotent and create-only:
+ * routes are never deleted here or anywhere else (see the module docstring
+ * for why), so on a slot that has been deployed before this is a read + probe
+ * pass with zero mutations. Call AFTER `app.finalize()`. No-op in local mode.
  *
  * Worker routes tell Cloudflare "send requests matching this pattern to this
- * worker", but the hostname still needs a proxied DNS record. We create
- * routes only after the worker script is uploaded and visible; Cloudflare
- * rejects route creation for scripts that do not exist yet. We then create
- * originless dummy A records so Cloudflare can terminate DNS/TLS and invoke
- * the route without trying to resolve the worker's workers.dev hostname as
- * an origin. No-op in local mode.
+ * worker", but the hostname still needs a proxied DNS record — originless
+ * dummy A/AAAA records so Cloudflare terminates DNS/TLS and invokes the route
+ * without trying to reach an origin. Routes are created only after the script
+ * is visible to the API (Cloudflare rejects routes for unknown scripts), and
+ * every hostname — including `*.` wildcards, via a synthetic probe host — is
+ * verified to actually fire at the edge, healing zombies by recreation.
  * https://developers.cloudflare.com/workers/configuration/routing/routes/#subdomains-must-have-a-dns-record
- * https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/get-started/hostname-routing/
  */
 export async function IterateRoutes(
-  ctx: IterateCtx,
+  ctx: IterateRoutesCtx,
   props: {
     hostnames: string[];
-    /** The worker the routes point at (an alchemy Worker resource). */
-    worker: { name: string; url?: string };
+    /** The worker the routes point at — only the deployed script name is used. */
+    worker: { name: string };
   },
 ) {
-  const { app, slug } = ctx;
-  const { worker } = props;
-  const routeHosts = props.hostnames;
+  if (ctx.app.local || props.hostnames.length === 0) return;
+  await ensureWorkerRoutesAndDns({
+    comment: `Managed by ${ctx.slug} alchemy (${ctx.app.stage}).`,
+    hostnames: props.hostnames,
+    scriptName: props.worker.name,
+  });
+}
 
-  if (!app.local && routeHosts.length > 0) {
-    const cloudflareApi = await createCloudflareApi({});
-    const zones = await listCloudflareZones(cloudflareApi);
-
-    await waitForCloudflareWorkerScript({
-      cloudflareApi,
-      workerName: worker.name,
-    });
-
-    const routeZoneIds = new Map<string, string>();
-    for (const hostname of routeHosts) {
-      const { zoneId } = findActiveZoneForHostname({
-        accountId: cloudflareApi.accountId,
-        hostname,
-        zones,
-      });
-      routeZoneIds.set(hostname, zoneId);
+/**
+ * Re-park a slot's edge after its stage was destroyed: upload a placeholder
+ * script under the routed worker's name (only when no script exists — a live
+ * deployment is never clobbered) and re-ensure DNS + routes against it.
+ *
+ * This exists because routes cannot outlive their script: force-deleting a
+ * worker CASCADES and deletes its zone routes, and re-uploading a same-named
+ * script does not bring them back (verified empirically against
+ * iterate-preview-9.com, 2026-07-03 — the hostname 522s indefinitely). So a
+ * teardown that stopped at `alchemy --destroy` would push route re-creation
+ * onto the next tenant's deploy, which is exactly the edge-propagation
+ * lottery behind the post-deploy 522s. Parking instead recreates and VERIFIES
+ * the routes at teardown time, when nobody is waiting; the next PR's deploy
+ * then finds live routes and only re-uploads script code.
+ *
+ * Wired as `alchemy.run.ts --park`, chained after `--destroy` (alchemy exits
+ * the process inside the destroy phase, so this must be a separate run).
+ */
+export async function parkWorkerRoutes(input: {
+  hostnames: string[];
+  /** App slug + stage, for DNS/route comments and the placeholder body. */
+  slug: string;
+  stage: string;
+  workerName: string;
+}) {
+  const cloudflareApi = await createCloudflareApi({});
+  const settingsResponse = await cloudflareApi.get(
+    `/accounts/${cloudflareApi.accountId}/workers/scripts/${encodeURIComponent(input.workerName)}/settings`,
+  );
+  if (settingsResponse.status === 404) {
+    const metadata = new Blob(
+      [JSON.stringify({ main_module: "index.mjs", compatibility_date: "2025-05-01" })],
+      { type: "application/json" },
+    );
+    const script = new Blob(
+      [
+        `export default { fetch() { return new Response(` +
+          `${JSON.stringify(`${input.slug} (${input.stage}) is parked between deployments.\n`)}, ` +
+          `{ status: 503, headers: { "content-type": "text/plain" } }); } };`,
+      ],
+      { type: "application/javascript+module" },
+    );
+    const form = new FormData();
+    form.append("metadata", metadata);
+    form.append("index.mjs", script, "index.mjs");
+    const uploadResponse = await cloudflareApi.put(
+      `/accounts/${cloudflareApi.accountId}/workers/scripts/${encodeURIComponent(input.workerName)}`,
+      form,
+    );
+    if (!uploadResponse.ok) {
+      throw new Error(
+        `Failed to upload parked placeholder for ${input.workerName}: ${uploadResponse.status} ${await uploadResponse.text()}`,
+      );
     }
-
-    // DNS records BEFORE routes. A Worker route only fires for hostnames with
-    // a proxied DNS record on the zone. Creating the route while the record
-    // does not exist yet has produced zombie routes on fresh preview slots:
-    // the route is visible in the API but never fires at the edge, so every
-    // request falls through to the (originless) placeholder record and dies
-    // with a 522 after ~20s — the "fresh slot" 522/parked-browser failure
-    // family (tasks/os-cold-create-latency.md). Deleting and recreating the
-    // identical route heals it instantly, which is what the verification pass
-    // below automates for any zombie that slips through regardless of order.
-    const dnsRouteHosts = routeHosts.filter(shouldCreateDnsRecordForRouteHostname);
-    await Promise.all(
-      dnsRouteHosts.flatMap((hostname) =>
-        placeholderDnsRecordsForHostname({
-          comment: `Managed by ${slug} alchemy (${app.stage}).`,
-          hostname,
-        }).map(async (record) => {
-          const zoneId =
-            routeZoneIds.get(record.name) ??
-            findActiveZoneForHostname({
-              accountId: cloudflareApi.accountId,
-              hostname: record.name,
-              zones,
-            }).zoneId;
-          await ensureCloudflareDnsRecord({
-            cloudflareApi,
-            record,
-            zoneId,
-          });
-        }),
-      ),
+    console.log(`[iterate-routes] parked ${input.workerName} with a placeholder script`);
+  } else if (!settingsResponse.ok) {
+    throw new Error(
+      `Failed to check worker script ${input.workerName} before parking: ${settingsResponse.status} ${await settingsResponse.text()}`,
     );
-
-    await Promise.all(
-      routeHosts.map((hostname) =>
-        retryCloudflareWorkerRouteCreation(() =>
-          Route(routeResourceIdForHostname(hostname), {
-            pattern: `${hostname}/*`,
-            script: worker.name,
-            adopt: true,
-            zoneId: routeZoneIds.get(hostname)!,
-          }),
-        ),
-      ),
-    );
-
-    // Verify each exact hostname actually fires at the edge and heal zombies.
-    // Wildcard patterns are skipped: they have no single probeable hostname.
-    await Promise.all(
-      routeHosts
-        .filter((hostname) => !hostname.startsWith("*"))
-        .map((hostname) =>
-          verifyWorkerRouteFires({
-            cloudflareApi,
-            hostname,
-            script: worker.name,
-            zoneId: routeZoneIds.get(hostname)!,
-          }),
-        ),
+  } else {
+    console.log(
+      `[iterate-routes] ${input.workerName} still has a deployed script — keeping it, only ensuring routes`,
     );
   }
+
+  await ensureWorkerRoutesAndDns({
+    comment: `Managed by ${input.slug} alchemy (${input.stage}).`,
+    hostnames: input.hostnames,
+    scriptName: input.workerName,
+  });
+}
+
+async function ensureWorkerRoutesAndDns(input: {
+  comment: string;
+  hostnames: string[];
+  scriptName: string;
+}) {
+  const cloudflareApi = await createCloudflareApi({});
+  const zones = await listCloudflareZones(cloudflareApi);
+
+  const routeZoneIds = new Map<string, string>();
+  for (const hostname of input.hostnames) {
+    const { zoneId } = findActiveZoneForHostname({
+      accountId: cloudflareApi.accountId,
+      hostname,
+      zones,
+    });
+    routeZoneIds.set(hostname, zoneId);
+  }
+
+  // DNS records BEFORE routes. A Worker route only fires for hostnames with
+  // a proxied DNS record on the zone. Creating the route while the record
+  // does not exist yet has produced zombie routes on fresh preview slots:
+  // the route is visible in the API but never fires at the edge, so every
+  // request falls through to the (originless) placeholder record and dies
+  // with a 522 after ~20s (tasks/os-cold-create-latency.md). The verification
+  // pass below heals any zombie that slips through regardless of order.
+  const dnsRouteHosts = input.hostnames.filter(shouldCreateDnsRecordForRouteHostname);
+  await Promise.all(
+    dnsRouteHosts.flatMap((hostname) =>
+      placeholderDnsRecordsForHostname({
+        comment: input.comment,
+        hostname,
+      }).map(async (record) => {
+        const zoneId =
+          routeZoneIds.get(record.name) ??
+          findActiveZoneForHostname({
+            accountId: cloudflareApi.accountId,
+            hostname: record.name,
+            zones,
+          }).zoneId;
+        await ensureCloudflareDnsRecord({
+          cloudflareApi,
+          record,
+          zoneId,
+        });
+      }),
+    ),
+  );
+
+  const routesByZone = new Map<string, ExistingCloudflareWorkerRoute[]>();
+  for (const zoneId of new Set(routeZoneIds.values())) {
+    routesByZone.set(zoneId, await listCloudflareWorkerRoutes({ cloudflareApi, zoneId }));
+  }
+
+  // Create-if-missing / repoint-if-wrong-script. The script-visibility wait
+  // and the 10019 retry only run when a route is actually being created —
+  // the ordinary deploy finds every route already present and skips both.
+  let waitedForScript = false;
+  for (const hostname of input.hostnames) {
+    const zoneId = routeZoneIds.get(hostname)!;
+    const pattern = `${hostname}/*`;
+    const existing = routesByZone.get(zoneId)!.find((route) => route.pattern === pattern);
+    if (existing?.script === input.scriptName) continue;
+
+    if (existing) {
+      console.warn(
+        `[iterate-routes] ${pattern} pointed at ${existing.script ?? "<none>"} — repointing to ${input.scriptName}`,
+      );
+      const response = await cloudflareApi.put(`/zones/${zoneId}/workers/routes/${existing.id}`, {
+        pattern,
+        script: input.scriptName,
+      });
+      if (!response.ok) {
+        throw new Error(
+          `Failed to repoint route ${pattern}: ${response.status} ${await response.text()}`,
+        );
+      }
+      continue;
+    }
+
+    if (!waitedForScript) {
+      await waitForCloudflareWorkerScript({
+        cloudflareApi,
+        workerName: input.scriptName,
+      });
+      waitedForScript = true;
+    }
+    console.log(`[iterate-routes] creating route ${pattern} -> ${input.scriptName}`);
+    await createWorkerRouteWithRetry({
+      cloudflareApi,
+      pattern,
+      script: input.scriptName,
+      zoneId,
+    });
+  }
+
+  // Verify every hostname actually fires at the edge and heal zombies.
+  // Wildcards are probed through a synthetic child host resolved by the
+  // wildcard DNS record ensured above — previously the biggest verification
+  // gap: a zombie `*.<base>` project-host route sailed through deploys and
+  // 522'd the first real project request.
+  await Promise.all(
+    input.hostnames.map((hostname) => {
+      const probeHostname = probeHostnameForRoutePattern(hostname);
+      if (!probeHostname) return undefined;
+      return verifyWorkerRouteFires({
+        cloudflareApi,
+        probeHostname,
+        routeHostname: hostname,
+        script: input.scriptName,
+        zoneId: routeZoneIds.get(hostname)!,
+      });
+    }),
+  );
+}
+
+/**
+ * The hostname to probe to prove a route pattern fires at the edge.
+ *
+ * Exact hostnames probe themselves. `*.base` wildcards probe a synthetic
+ * child host (resolvable via the wildcard DNS record the ensure pass
+ * creates). `*base` catch-alls have no probeable hostname of their own — the
+ * exact `base` route ensured alongside them covers the apex.
+ */
+function probeHostnameForRoutePattern(hostname: string): string | null {
+  if (hostname.startsWith("*.")) return `iterate-route-probe.${hostname.slice(2)}`;
+  if (hostname.startsWith("*")) return null;
+  return hostname;
 }
 
 /**
@@ -288,19 +401,21 @@ const ORIGIN_FALLTHROUGH_STATUSES = new Set([521, 522, 523, 530]);
  * Probe a route hostname and, when the edge answers with an origin-error
  * status (route not firing — the zombie-route failure mode), heal it by
  * deleting and recreating the identical route via the raw API. Recreation has
- * been observed to activate a zombie route instantly; `Route(adopt: true)`
- * re-adopts the pattern on the next deploy, so the id drift is harmless.
+ * been observed to activate a zombie route instantly.
  */
 async function verifyWorkerRouteFires(input: {
   cloudflareApi: Awaited<ReturnType<typeof createCloudflareApi>>;
-  hostname: string;
+  /** The hostname to fetch — differs from routeHostname for wildcards. */
+  probeHostname: string;
+  /** The hostname of the route pattern, used when healing. */
+  routeHostname: string;
   script: string;
   zoneId: string;
 }) {
   const maxAttempts = 3;
   let healed = false;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    let status = await probeEdgeStatus(input.hostname);
+    let status = await probeEdgeStatus(input.probeHostname);
     // Any worker/app response (including app-level 4xx/5xx) proves the route
     // fires. A network-level probe failure is inconclusive (local DNS lag,
     // egress hiccup) — do not fail the deploy over it.
@@ -310,23 +425,23 @@ async function verifyWorkerRouteFires(input: {
       // can race it. Require a second good probe so the deploy only reports
       // success once the hostname is consistently served.
       await sleep(5_000);
-      status = await probeEdgeStatus(input.hostname);
+      status = await probeEdgeStatus(input.probeHostname);
       if (status === null || !ORIGIN_FALLTHROUGH_STATUSES.has(status)) return;
       // Fell back to origin again — keep healing.
     }
 
     console.warn(
-      `[iterate-routes] ${input.hostname} answered ${status} — route exists but is not firing at the edge; recreating it (attempt ${attempt}/${maxAttempts})`,
+      `[iterate-routes] ${input.probeHostname} answered ${status} — route ${input.routeHostname}/* exists but is not firing at the edge; recreating it (attempt ${attempt}/${maxAttempts})`,
     );
     await recreateWorkerRoute(input);
     healed = true;
     await sleep(2_000);
   }
 
-  const status = await probeEdgeStatus(input.hostname);
+  const status = await probeEdgeStatus(input.probeHostname);
   if (status !== null && ORIGIN_FALLTHROUGH_STATUSES.has(status)) {
     throw new Error(
-      `Worker route for ${input.hostname} never became active: the edge keeps answering ${status} (origin fallthrough) after ${maxAttempts} recreations.`,
+      `Worker route for ${input.routeHostname} never became active: the edge keeps answering ${status} (origin fallthrough) after ${maxAttempts} recreations.`,
     );
   }
 }
@@ -349,21 +464,16 @@ async function probeEdgeStatus(hostname: string): Promise<number | null> {
 
 async function recreateWorkerRoute(input: {
   cloudflareApi: Awaited<ReturnType<typeof createCloudflareApi>>;
-  hostname: string;
+  routeHostname: string;
   script: string;
   zoneId: string;
 }) {
-  const pattern = `${input.hostname}/*`;
-  const listResponse = await input.cloudflareApi.get(`/zones/${input.zoneId}/workers/routes`);
-  if (!listResponse.ok) {
-    throw new Error(
-      `Failed to list worker routes while healing ${pattern}: ${listResponse.status} ${await listResponse.text()}`,
-    );
-  }
-  const listResult = (await listResponse.json()) as {
-    result?: Array<{ id: string; pattern?: string }>;
-  };
-  const existing = (listResult.result ?? []).find((route) => route.pattern === pattern);
+  const pattern = `${input.routeHostname}/*`;
+  const existingRoutes = await listCloudflareWorkerRoutes({
+    cloudflareApi: input.cloudflareApi,
+    zoneId: input.zoneId,
+  });
+  const existing = existingRoutes.find((route) => route.pattern === pattern);
   if (existing) {
     const deleteResponse = await input.cloudflareApi.delete(
       `/zones/${input.zoneId}/workers/routes/${existing.id}`,
@@ -383,6 +493,27 @@ async function recreateWorkerRoute(input: {
       `Failed to recreate route ${pattern}: ${createResponse.status} ${await createResponse.text()}`,
     );
   }
+}
+
+/** A zone worker route as the Cloudflare API returns it. */
+type ExistingCloudflareWorkerRoute = {
+  id: string;
+  pattern?: string;
+  script?: string;
+};
+
+async function listCloudflareWorkerRoutes(input: {
+  cloudflareApi: Awaited<ReturnType<typeof createCloudflareApi>>;
+  zoneId: string;
+}): Promise<ExistingCloudflareWorkerRoute[]> {
+  const response = await input.cloudflareApi.get(`/zones/${input.zoneId}/workers/routes`);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to list worker routes for zone ${input.zoneId}: ${response.status} ${await response.text()}`,
+    );
+  }
+  const result = (await response.json()) as { result?: ExistingCloudflareWorkerRoute[] };
+  return result.result ?? [];
 }
 
 function placeholderDnsRecordsForHostname(input: {
@@ -410,12 +541,10 @@ function placeholderDnsRecordsForHostname(input: {
 }
 
 /**
- * Ensure proxied originless DNS records exist for worker-route hostnames.
- *
- * Worker routes only fire when the hostname has a proxied DNS record on the
- * zone. IterateApp does this automatically from `baseUrl`; apps that declare
- * routes directly (apps/auth via WORKER_ROUTES) call this after deploy so new
- * hostnames like auth.iterate-preview-N.com resolve without manual DNS work.
+ * Ensure proxied originless DNS records exist for hostnames served by
+ * something other than an app worker route (apps/tunnels points wildcard
+ * tunnel hosts at its own worker routes declared inline). Apps deployed via
+ * {@link IterateRoutes} get this automatically.
  */
 export async function ensureProxiedDnsForHostnames(input: {
   hostnames: readonly string[];
@@ -440,12 +569,6 @@ export async function ensureProxiedDnsForHostnames(input: {
       }),
     ),
   );
-}
-
-function routeResourceIdForHostname(hostname: string) {
-  if (hostname.startsWith("*.")) return `route-wildcard-${slugify(hostname.slice(2))}`;
-  if (hostname.startsWith("*")) return `route-catchall-${slugify(hostname.slice(1))}`;
-  return `route-${slugify(hostname)}`;
 }
 
 function shouldCreateDnsRecordForRouteHostname(hostname: string) {
@@ -681,9 +804,11 @@ function withSequentialCloudflareAssetPreupload(input: { command: string; worker
 
 /**
  * Wait until Cloudflare's Workers Scripts API can read the just-uploaded
- * script before creating zone routes for it.
+ * script before creating zone routes for it. Only runs when a route is
+ * actually about to be created — on the first deploy of a fresh hostname or
+ * when re-parking a torn-down slot.
  *
- * Alchemy's `TanStackStart` returns after the upload step, but in CI we have
+ * Alchemy's worker resources return after the upload step, but in CI we have
  * seen the immediately-following Routes API call fail with Cloudflare error
  * 10019 ("Worker does not exist"). Polling the first-party script-read endpoint
  * catches the ordinary upload lag. Requiring a second successful read after a
@@ -734,31 +859,29 @@ async function waitForCloudflareWorkerScript(params: {
   );
 }
 
-async function retryCloudflareWorkerRouteCreation(createRoute: () => Promise<unknown>) {
+async function createWorkerRouteWithRetry(input: {
+  cloudflareApi: Awaited<ReturnType<typeof createCloudflareApi>>;
+  pattern: string;
+  script: string;
+  zoneId: string;
+}) {
   const maxAttempts = 12;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    try {
-      await createRoute();
-      return;
-    } catch (error) {
-      if (attempt === maxAttempts || !isCloudflareWorkerRouteMissingError(error)) {
-        throw error;
-      }
-
-      await sleep(2_000);
+    const response = await input.cloudflareApi.post(`/zones/${input.zoneId}/workers/routes`, {
+      pattern: input.pattern,
+      script: input.script,
+    });
+    if (response.ok) return;
+    const body = await response.text();
+    // 10019 "Worker which does not exist": the Routes API can lag the Scripts
+    // API by a few seconds right after an upload — retry, everything else is
+    // a real error.
+    const scriptNotVisibleYet = body.includes("10019") && attempt < maxAttempts;
+    if (!scriptNotVisibleYet) {
+      throw new Error(`Failed to create route ${input.pattern}: ${response.status} ${body}`);
     }
+    await sleep(2_000);
   }
-}
-
-function isCloudflareWorkerRouteMissingError(error: unknown) {
-  const maybeError = error as {
-    errorData?: unknown;
-    message?: unknown;
-    status?: unknown;
-  };
-  const details = `${String(maybeError.message ?? "")}\n${JSON.stringify(maybeError.errorData ?? "")}`;
-
-  return details.includes("10019") && details.includes("Worker which does not exist");
 }
 
 async function sleep(ms: number) {
@@ -787,7 +910,10 @@ async function sleep(ms: number) {
  * @see https://developers.cloudflare.com/workers/configuration/routing/routes/
  * @see https://developers.cloudflare.com/workers/configuration/routing/workers-dev/
  */
-function deriveWorkerRouteHosts(baseUrl: string | undefined, extraRouteHostnames: string[] = []) {
+export function deriveWorkerRouteHosts(
+  baseUrl: string | undefined,
+  extraRouteHostnames: string[] = [],
+) {
   const baseUrlHostname = baseUrl ? new URL(baseUrl).hostname : undefined;
   return [
     ...new Set([...(baseUrlHostname ? [baseUrlHostname] : []), ...extraRouteHostnames]),

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -869,37 +869,19 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
       [
         "set -euo pipefail",
         // The chromium download hits no deployed slot, so start it first and
-        // let it overlap the warmup and the vitest lane; it's ready by the
+        // let it overlap the smoke and the vitest lane; it's ready by the
         // time we reach the specs instead of adding ~4s in front of them.
         "pnpm --dir ../.. exec playwright install chromium > /tmp/os-preview-pw-install.log 2>&1 & PW_INSTALL_PID=$!",
-        // Create-saga warmup: one sequential real project create pays the
+        // Create-saga smoke: one sequential real project create pays the
         // cold-start costs (cold DO chain, repo seed, worker probe) that
         // otherwise surface as rotating "saw 0 events" timeout flakes across
-        // the concurrent e2e suites (see tasks/os-cold-create-latency.md).
-        // Runs in the background, concurrently with the HTTP-route warmup
-        // below; we wait for it before starting the suites.
+        // the concurrent e2e suites (see tasks/os-cold-create-latency.md),
+        // and fails loudly if the slot is broken before the suites start.
+        // The curl-round HTTP warmups that used to run alongside it were
+        // treating symptoms of zombie routes (routes dead at the edge →
+        // 522s), which deploys now verify and heal directly — see
+        // ensureWorkerRoutesAndDns in packages/shared/src/alchemy/iterate-app.ts.
         "pnpm exec tsx e2e/vitest/onboarding-smoke.ts > /tmp/os-preview-smoke.log 2>&1 & SMOKE_PID=$!",
-        // Warm the freshly-deployed slot before the concurrent burst: a cold
-        // deployment answers its first requests only after loading each
-        // worker, and a 40-connection stampede against zero warm isolates
-        // ends in edge 499/522s. One round boots each worker, a parallel
-        // round fans isolates out.
-        // -L: /api/iterate-auth/login redirects to the slot's auth worker,
-        // warming it for the login-flow specs.
-        'for path in /api/health / /api/itx /sign-in /api/iterate-auth/login; do curl -sL -o /dev/null --max-time 20 "$OS_BASE_URL$path" || true; done',
-        // Warm the OAuth handshake path — the signup/create-project specs park
-        // 30-90s on a cold callback (token exchange + first-org onboarding).
-        // Boot both sides' isolates: the OS callback handler, and the auth
-        // worker (origin derived from the /login redirect) incl. its OTP and
-        // onboarding routes. Best-effort — see
-        // tasks/fix-cold-auth-oauth-callback-latency.md for the real fix.
-        'curl -sL -o /dev/null --max-time 20 "$OS_BASE_URL/api/iterate-auth/callback" || true',
-        'AUTH_BASE=$(curl -s -o /dev/null -w "%{redirect_url}" --max-time 20 "$OS_BASE_URL/api/iterate-auth/login?login_hint=email" | sed -E "s#(https?://[^/]+).*#\\1#") || true; if [ -n "$AUTH_BASE" ]; then for p in / /api/auth/ok /sign-in /onboarding; do curl -sL -o /dev/null --max-time 20 "$AUTH_BASE$p" || true; done; fi',
-        // Subshell so the bare `wait` reaps only these curls, not the
-        // background chromium install / create-smoke started above.
-        '( for i in 1 2 3 4 5 6 7 8; do (curl -s -o /dev/null --max-time 20 "$OS_BASE_URL/api/health" && curl -s -o /dev/null --max-time 20 "$OS_BASE_URL/") & done; wait )',
-        // Block on the create-saga warmup before the suites — a failed warmup
-        // means the slot is broken, so fail loudly rather than flake.
         'wait "$SMOKE_PID" || { cat /tmp/os-preview-smoke.log; exit 1; }',
         // The e2e vitest lane and the Playwright specs hit the same slot but
         // provision independent projects, so they run concurrently: the vitest
@@ -935,6 +917,10 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     slug: "auth",
     displayName: "Auth",
     appPath: "apps/auth",
+    // alchemy:down chains `--park` so the slot's routes stay live (and
+    // verified) across teardown instead of being recreated on the next
+    // tenant's critical path (see parkWorkerRoutes in iterate-app.ts).
+    destroyCommandArgs: ["pnpm", "run-script", "alchemy:down"],
     dopplerProject: "auth",
     paths: ["apps/auth/**", "apps/auth-contract/**"],
     // better-auth's liveness endpoint; auth has no /api/__internal/health.


### PR DESCRIPTION
## Problem

PRs over the last 24h kept hitting 522s on preview hosts right after deployment. The root cause family is known ("zombie" worker routes — visible in the API, never firing at the edge, so requests fall through to the originless placeholder DNS record and die with 522 after ~20s, see `tasks/os-cold-create-latency.md`), and #1601 mitigated it with a post-deploy probe-and-heal pass. But the *reason we kept rolling those dice* remained: every preview teardown destroyed the slot's routes, and every next PR recreated them from scratch on its critical path. Route creation is the one edge operation Cloudflare propagates unreliably; we were doing it on every slot handoff.

## What changed

**1. Routes + DNS are no longer alchemy resources — they're ensure-only edge state** (`packages/shared/src/alchemy/iterate-app.ts`).

`IterateRoutes` now runs raw-API reconciliation: list the zone's routes, create only what's missing (repoint if a route targets the wrong script), then verify every hostname actually fires at the edge, healing zombies by delete+recreate. Nothing ever deletes a route — not deploys, not `--destroy`. On a slot that's been deployed before, the whole thing is a read + probe pass with **zero mutations**. The `waitForCloudflareWorkerScript` poll and the 10019 retry only run on the rare create path instead of every deploy.

It runs **after** `app.finalize()`: since routes are no longer declared as resources, finalize's orphan cleanup deletes the legacy `Route` resources from state on the first deploy per stage — the ensure then recreates and edge-verifies them immediately (see migration notes below).

**2. Slot teardown parks the edge instead of orphaning it** (`parkWorkerRoutes`).

A spike against `iterate-preview-9.com` (2026-07-03) confirmed the constraint that shapes this design: **force-deleting a worker script cascades and deletes its zone routes, and re-uploading a same-named script does not bring them back** — the hostname 522s indefinitely until the route is recreated. So routes can't simply "survive" a stage destroy; something has to put them back.

That something is now `--park`, chained after `--destroy` (`apps/os` `pnpm destroy`, `apps/auth` `pnpm alchemy:down`): it uploads a tiny 503 "parked" placeholder script under the routed worker's name (only when no script exists — it never clobbers a live deployment) and re-runs the same ensure + edge-verify. Route creation therefore happens at teardown time, **when nobody is waiting**, and the next tenant's deploy finds live, verified routes and only replaces script code — the battle-tested steady-state path. A parked slot answers 503 with a clear message instead of a 20-second 522.

If a park ever fails or is skipped, nothing is lost: the next deploy's ensure creates and verifies the routes itself, exactly like before — just back on the critical path for that one deploy.

**3. Auth gets the fix it never got.** `apps/auth` previously declared routes inline on the Worker resource and only ensured DNS *after* finalize — precisely the routes-before-DNS ordering that mints zombies, with no verification at all. A zombie `auth.iterate-preview-N.com` 522s every sign-in and OAuth callback, which lines up with the recent flakes. Auth now uses the same shared `IterateRoutes` (DNS first, verified, healed).

**4. Wildcard routes are now verified.** The old verifier skipped `*.` patterns entirely — a zombie `*.iterate-preview-N.app` project-host route sailed through deploy verification and 522'd the first real project request in e2e. Wildcards are now probed through a synthetic child host (`iterate-route-probe.<base>`), which the wildcard DNS record resolves.

**5. The preview warmup curls are gone** (`scripts/preview/preview.ts`). The rounds of `curl`s against health/app/itx/auth/OAuth paths existed to absorb post-deploy edge 499/522s — symptoms of the zombie-route class this PR removes structurally (routes are verified live before the deploy step reports success). The one *sequential create-saga smoke* stays: it pays genuine DO-chain cold-start costs once and fails loudly if the slot is broken. If cold-OAuth-callback flakes resurface, the real fix is `tasks/fix-cold-auth-oauth-callback-latency.md`, not curls.

**6. `semaphore` / `streams-example-app`** move from the deleted `IterateApp` wrapper to the explicit two-step (`IterateAppWorker` → finalize → `IterateRoutes`), same as os. `tunnels` keeps its inline routes + `ensureProxiedDnsForHostnames` (prod-only, never torn down).

## Live validation (preview-9, manual lease, 2026-07-03)

The full lifecycle was exercised against a real slot, and it caught **six live zombie routes across four deploy/park operations** — direct evidence of how often this fires on fresh route creation:

- [x] **Fresh deploy of auth + os**: all 6 routes created; verifier caught + healed zombies on `auth.iterate-preview-9.com` (×2 heals), `os.iterate-preview-9.com`, `mcp.iterate-preview-9.com` (×2 heals), and — via the new synthetic probe host — the `*.iterate-preview-9.app` wildcard, which the old verifier never checked. All hosts then answered in 0.05–0.5s.
- [x] **`destroy && --park` (both apps)**: full stage destroy (workers, D1, KV, DOs), placeholder uploaded, routes recreated + verified (one more zombie healed on mcp). All hostnames answer `503 "… is parked between deployments"` in ~50–200ms — where a torn-down slot used to answer 522 after a 20s hang.
- [x] **Redeploy over the parked slot** (the path every future PR deploy takes): zero route mutations — no `creating route`, no heals, just verification probes passing against already-live routes.

## Migration notes

- **First deploy per existing stage after this merges** (including prd): finalize orphan-deletes the legacy `Route` resources from alchemy state, and the post-finalize ensure immediately recreates + edge-verifies them. That's a brief (seconds) route-recreation window per hostname, verified before the deploy reports success. For prd, deploy at a quiet moment.
- Preview slots that were torn down by the *old* cleanup (no park) start with no routes; the first new-style deploy creates + verifies them, and every teardown after that parks.
- No Doppler/config changes required.

## Cruft removed

- The per-deploy `Route(adopt: true)` resources and their creation-retry wrapper
- `waitForCloudflareWorkerScript` on the steady-state path (create-path only now)
- The warmup curl rounds + their doc sections (`docs/ci-preview-performance.md` rewritten accordingly)
- `IterateApp` (the routes-coupled worker wrapper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core Cloudflare deploy/teardown and routing for auth, os, and preview slots; first deploy per stage recreates legacy Route resources, and a failed park pushes route creation back onto the next deploy’s critical path.
> 
> **Overview**
> Fixes preview **522s** from zombie Cloudflare worker routes by changing how routes and DNS are managed across deploy and teardown.
> 
> **Routes are ensure-only edge state, not Alchemy resources.** `IterateRoutes` now reconciles via the Cloudflare API (DNS first, then create/repoint routes, then live edge probes that heal zombies). Nothing deletes routes on deploy or destroy; steady-state deploys are mostly read + verify. It runs **after** `app.finalize()` so orphan cleanup does not drop routes that were just verified. The old `IterateApp` wrapper is removed; apps use `IterateAppWorker` → finalize → `IterateRoutes`.
> 
> **Slot teardown parks the edge.** `parkWorkerRoutes` uploads a 503 placeholder script when the worker is gone and re-ensures verified routes. `destroy` / `alchemy:down` chain a separate `--park` run (auth, os, preview cleanup). The next deploy only replaces script code instead of recreating routes on the critical path.
> 
> **Auth aligns with the shared path** — inline worker routes and post-finalize DNS-only are replaced by shared `IterateRoutes` (DNS-before-routes + verification).
> 
> **Wildcard routes are probed** via synthetic hosts (e.g. `iterate-route-probe.<base>` for `*.base`).
> 
> **Preview CI** drops the post-deploy curl warmups; the sequential create-saga smoke stays. Docs note parking and the new routing lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c7efda62c7f0ebebdf50b00107f0b5749742fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-03T15:33:04.074Z",
      "headSha": "14c7efda62c7f0ebebdf50b00107f0b5749742fe",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/127383892540103",
      "shortSha": "14c7efd",
      "cleanupDurationMs": 79450,
      "deployDurationMs": 155219,
      "testDurationMs": 78757
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-03T15:32:01.946Z",
      "headSha": "14c7efda62c7f0ebebdf50b00107f0b5749742fe",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/127383892540103",
      "shortSha": "14c7efd",
      "cleanupDurationMs": 17318,
      "deployDurationMs": 74147,
      "testDurationMs": 7831
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-03T15:32:15.102Z",
      "headSha": "14c7efda62c7f0ebebdf50b00107f0b5749742fe",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/127383892540103",
      "shortSha": "14c7efd",
      "cleanupDurationMs": 30470,
      "deployDurationMs": 66907,
      "testDurationMs": 726
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-03T15:31:58.545Z",
      "headSha": "14c7efda62c7f0ebebdf50b00107f0b5749742fe",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-1.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/127383892540103",
      "shortSha": "14c7efd",
      "cleanupDurationMs": 13907,
      "deployDurationMs": 28605,
      "testDurationMs": 16002
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `14c7efd` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 66.9s | 726ms | 30.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/127383892540103) | 2026-07-03T15:32:15.102Z | Preview app released. |
| OS | released | `14c7efd` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 155.2s | 78.8s | 79.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/127383892540103) | 2026-07-03T15:33:04.074Z | Preview app released. |
| Semaphore | released | `14c7efd` | [https://semaphore.iterate-preview-1.com](https://semaphore.iterate-preview-1.com) | 74.1s | 7.8s | 17.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/127383892540103) | 2026-07-03T15:32:01.946Z | Preview app released. |
| Streams Example App | released | `14c7efd` | [https://streams-example-app-preview-1.iterate-dev-preview.workers.dev](https://streams-example-app-preview-1.iterate-dev-preview.workers.dev) | 28.6s | 16.0s | 13.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/127383892540103) | 2026-07-03T15:31:58.545Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->