### PR TITLE
Docs: ensure-only route lifecycle in worker topology (post-#1622 preview lifecycle test)

### DIFF
--- a/apps/os/docs/worker-topology.md
+++ b/apps/os/docs/worker-topology.md
@@ -72,9 +72,15 @@ mutual cross-script bindings as long as both scripts exist.
 ## Request routing
 
 The ingress worker is the only worker with routes (the app base URL, the MCP
-hostname, and each project hostname base + wildcards). It is the trust
-boundary: it strips the internal forwarding headers from inbound requests,
-then forwards whole requests over service bindings:
+hostname, and each project hostname base + wildcards). Routes and DNS are not
+alchemy resources: deploys idempotently ensure and edge-verify them after
+`finalize()`, destroys chain `--park` to keep them live against a placeholder
+script, and nothing ever deletes them — see
+`packages/shared/src/alchemy/iterate-app.ts` for the lifecycle rationale.
+
+The ingress worker is also the trust boundary: it strips the internal
+forwarding headers from inbound requests, then forwards whole requests over
+service bindings:
 
 ```
                     ┌────────────► <n>-app  (MCP hostname → /api/mcp)


### PR DESCRIPTION
One-paragraph doc addition to `apps/os/docs/worker-topology.md` documenting the route lifecycle that landed in #1622.

This PR doubles as the live end-to-end CI validation of #1622's preview lifecycle on merged main:
1. its preview deploy lands on a slot (possibly parked by a previous tenant's cleanup),
2. e2e runs against it,
3. closing the PR runs the new cleanup: destroy + `--park`, leaving the slot's routes live and verified.

Will be closed once the cycle is observed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-03T17:10:57.274Z",
      "headSha": "46de8adb47a7f591fee9140b00114fbe09437077",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/106461371627370",
      "shortSha": "46de8ad",
      "cleanupDurationMs": 87774,
      "deployDurationMs": 57272,
      "testDurationMs": 2431
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-03T17:10:24.266Z",
      "headSha": "46de8adb47a7f591fee9140b00114fbe09437077",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/106461371627370",
      "shortSha": "46de8ad",
      "cleanupDurationMs": 54762,
      "deployDurationMs": 27649,
      "testDurationMs": 667
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `46de8ad` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 27.6s | 667ms | 54.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/106461371627370) | 2026-07-03T17:10:24.266Z | Preview app released. |
| OS | released | `46de8ad` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 57.3s | 2.4s | 87.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/106461371627370) | 2026-07-03T17:10:57.274Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or deploy behavior impact.
> 
> **Overview**
> **Request routing** in `worker-topology.md` now spells out how **routes and DNS** are managed outside Alchemy: deploys idempotently ensure and edge-verify them after `finalize()`, teardown uses destroy plus `--park` so routes stay bound to a placeholder script, and routes are never deleted. It points readers to `packages/shared/src/alchemy/iterate-app.ts` for the rationale.
> 
> The ingress worker is still described as the sole routed worker and trust boundary; that sentence is split so route lifecycle is separate from header stripping and service-binding forwards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46de8adb47a7f591fee9140b00114fbe09437077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->