### PR TITLE
Auth onboarding creates org + first project in one step, then returns to OS

### DIFF
--- a/apps/auth/src/config.ts
+++ b/apps/auth/src/config.ts
@@ -40,6 +40,10 @@ export const AppConfig = z.object({
   adminAllowlist: z.string().trim().default("*@nustom.com"),
   /** Whether the email one-time-passcode sign-in lane is offered. */
   emailOtpEnabled: publicValue(z.boolean().default(false)),
+  /** Deployed base domain project homepages live under (e.g. "iterate.app",
+   * "iterate-preview-3.app") — onboarding previews "<slug>.<base>". Mirrors
+   * os's APP_CONFIG_PROJECT_HOSTNAME_BASES. */
+  projectHostnameBase: publicValue(z.string().trim().min(1).default("iterate.app")),
 });
 
 export type AppConfig = z.output<typeof AppConfig>;

--- a/apps/auth/src/routes/_auth/project-access.tsx
+++ b/apps/auth/src/routes/_auth/project-access.tsx
@@ -72,7 +72,11 @@ const ProjectSlugInput = z
   .trim()
   .min(1, "Project slug is required")
   .max(50)
-  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "Use lowercase letters, numbers, and dashes");
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "Use lowercase letters, numbers, and dashes")
+  // The server normalizes slugs with slugify, which rewrites reserved and
+  // letter-less values to "unnamed" — reject anything it would alter so the
+  // stored slug always matches the homepage preview.
+  .refine((slug) => slugify(slug) === slug, "Include a letter, and avoid reserved words");
 
 const CreateOrganizationWithProjectInput = z.object({
   name: z.string().trim().min(1, "Organization name is required").max(100),
@@ -337,7 +341,14 @@ function RouteComponent() {
     isCreating: createProjectMutation.isPending,
     isValid: parsedProject.success,
     error: !parsedProject.success && projectSlug.length > 0 ? parsedProject.error.issues : null,
-    mutationError: createProjectMutation.isError ? createProjectMutation.error.message : null,
+    // The combined first-run mutation can leave an error behind when the
+    // organization was created but the project was not (the UI then falls to
+    // this project-only form) — keep that failure visible for the retry.
+    mutationError: createProjectMutation.isError
+      ? createProjectMutation.error.message
+      : createOrganizationWithProjectMutation.isError
+        ? createOrganizationWithProjectMutation.error.message
+        : null,
     onProjectSlugChange: setProjectSlug,
     onOrganizationSlugChange: setSelectedOrganizationSlug,
     onSubmit: () => {

--- a/apps/auth/src/routes/_auth/project-access.tsx
+++ b/apps/auth/src/routes/_auth/project-access.tsx
@@ -25,6 +25,7 @@ import {
 } from "@iterate-com/ui/components/dialog";
 import { Separator } from "@iterate-com/ui/components/separator";
 import { Navigate, createFileRoute } from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { slugify } from "@iterate-com/shared/slug";
@@ -47,6 +48,14 @@ import {
 } from "../../utils/auth-query-options.ts";
 import { getInitials } from "../../utils/initials.ts";
 import { orpcClient } from "../../utils/query.tsx";
+import { parseConfig } from "../../config.ts";
+
+// Runs on the server for both SSR and client navigations. The hostname base
+// is this environment's deployed project domain (e.g. "iterate.app",
+// "iterate-preview-3.app") — onboarding previews "<slug>.<base>" under it.
+const getProjectAccessConfig = createServerFn({ method: "GET" }).handler(({ context }) => ({
+  projectHostnameBase: parseConfig(context.cloudflare.env).projectHostnameBase,
+}));
 
 export const Route = createFileRoute("/_auth/project-access")({
   component: RouteComponent,
@@ -55,12 +64,8 @@ export const Route = createFileRoute("/_auth/project-access")({
     scope: z.string().optional(),
     redirect: z.string().optional(),
   }),
+  loader: () => getProjectAccessConfig(),
 });
-
-// Deployed project hostname base for this environment, baked in at build time
-// (e.g. "iterate.app", "iterate-preview-3.app"); see VITE_PROJECT_HOSTNAME_BASE
-// in alchemy.run.ts.
-const PROJECT_HOSTNAME_BASE: string = import.meta.env.VITE_PROJECT_HOSTNAME_BASE || "iterate.app";
 
 const ProjectSlugInput = z
   .string()
@@ -81,6 +86,7 @@ const CreateProjectInput = z.object({
 
 function RouteComponent() {
   const { client_id, scope, redirect } = Route.useSearch();
+  const { projectHostnameBase } = Route.useLoaderData();
   const navigate = Route.useNavigate();
   const queryClient = useQueryClient();
   const session = useSession();
@@ -325,6 +331,7 @@ function RouteComponent() {
   const createProjectFormProps = {
     organizations,
     projectSlug,
+    projectHostnameBase,
     selectedOrganizationSlug: effectiveOrganizationSlug,
     isSubmitting,
     isCreating: createProjectMutation.isPending,
@@ -409,7 +416,7 @@ function RouteComponent() {
                   <FieldDescription>
                     Your project homepage will be under{" "}
                     <span className="font-medium text-foreground">
-                      {firstProjectSlug || "your-project"}.{PROJECT_HOSTNAME_BASE}
+                      {firstProjectSlug || "your-project"}.{projectHostnameBase}
                     </span>
                   </FieldDescription>
                   {firstProjectSlugIssues.length > 0 ? (
@@ -725,6 +732,7 @@ function CreateProjectForm(props: {
   className?: string;
   organizations: { id: string; name: string; slug: string }[];
   projectSlug: string;
+  projectHostnameBase: string;
   selectedOrganizationSlug: string;
   isSubmitting: boolean;
   isCreating: boolean;
@@ -776,7 +784,7 @@ function CreateProjectForm(props: {
           <FieldDescription>
             Your project homepage will be under{" "}
             <span className="font-medium text-foreground">
-              {props.projectSlug || "your-project"}.{PROJECT_HOSTNAME_BASE}
+              {props.projectSlug || "your-project"}.{props.projectHostnameBase}
             </span>
           </FieldDescription>
           {props.error ? <FieldError errors={props.error} /> : null}

--- a/apps/auth/src/routes/_auth/project-access.tsx
+++ b/apps/auth/src/routes/_auth/project-access.tsx
@@ -26,8 +26,16 @@ import {
 import { Separator } from "@iterate-com/ui/components/separator";
 import { Navigate, createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
-import { Field, FieldError, FieldGroup, FieldLabel } from "@iterate-com/ui/components/field";
+import { useEffect, useState } from "react";
+import { slugify } from "@iterate-com/shared/slug";
+import { suggestOrganizationNameFromEmail } from "@iterate-com/shared/name-suggestions";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@iterate-com/ui/components/field";
 import { Input } from "@iterate-com/ui/components/input";
 import { NativeSelect, NativeSelectOption } from "@iterate-com/ui/components/native-select";
 import { z } from "zod/v4";
@@ -45,31 +53,51 @@ export const Route = createFileRoute("/_auth/project-access")({
   validateSearch: z.looseObject({
     client_id: z.string().optional(),
     scope: z.string().optional(),
+    redirect: z.string().optional(),
   }),
 });
 
-const CreateOrganizationInput = z.object({
+// Deployed project hostname base for this environment, baked in at build time
+// (e.g. "iterate.app", "iterate-preview-3.app"); see VITE_PROJECT_HOSTNAME_BASE
+// in alchemy.run.ts.
+const PROJECT_HOSTNAME_BASE: string = import.meta.env.VITE_PROJECT_HOSTNAME_BASE || "iterate.app";
+
+const ProjectSlugInput = z
+  .string()
+  .trim()
+  .min(1, "Project slug is required")
+  .max(50)
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "Use lowercase letters, numbers, and dashes");
+
+const CreateOrganizationWithProjectInput = z.object({
   name: z.string().trim().min(1, "Organization name is required").max(100),
+  projectSlug: ProjectSlugInput,
 });
 
 const CreateProjectInput = z.object({
   organizationSlug: z.string().trim().min(1, "Organization is required"),
-  name: z.string().trim().min(1, "Project name is required").max(100),
+  slug: ProjectSlugInput,
 });
 
 function RouteComponent() {
-  const { client_id, scope } = Route.useSearch();
+  const { client_id, scope, redirect } = Route.useSearch();
   const navigate = Route.useNavigate();
   const queryClient = useQueryClient();
   const session = useSession();
   const [selectedProjectIds, setSelectedProjectIds] = useState<string[] | null>(null);
-  const [organizationName, setOrganizationName] = useState("");
-  const [projectName, setProjectName] = useState("");
+  const [organizationName, setOrganizationName] = useState(() =>
+    suggestOrganizationNameFromEmail(session.user.email ?? ""),
+  );
+  // null = keep deriving the first project's slug from the organization name;
+  // a string means the user took over. Clearing the field hands control back.
+  const [projectSlugOverride, setProjectSlugOverride] = useState<string | null>(null);
+  const [projectSlug, setProjectSlug] = useState("");
   const [selectedOrganizationSlug, setSelectedOrganizationSlug] = useState("");
   const [isCreateProjectDialogOpen, setIsCreateProjectDialogOpen] = useState(false);
   const hasOAuthClientId = Boolean(client_id);
   const needsProjectSelection =
     scope?.split(" ").includes(ITERATE_PROJECT_SELECTION_SCOPE) ?? false;
+  const redirectTarget = resolveRedirectTarget(redirect);
 
   const oauthClientQuery = useQuery({
     ...oauthClientQueryOptions(client_id ?? ""),
@@ -79,19 +107,35 @@ function RouteComponent() {
   const organizationsQuery = useQuery(organizationsQueryOptions());
   const projectSelectionOptions = projectSelectionQueryOptions(organizationsQuery.data ?? []);
 
+  // Projects are needed for OAuth project selection AND to detect that a
+  // non-OAuth visitor already finished setup (so we bounce them back out
+  // instead of offering to create another project).
+  const wantsProjects = needsProjectSelection || !hasOAuthClientId;
   const projectSelectionQuery = useQuery({
     ...projectSelectionOptions,
-    enabled: needsProjectSelection && Boolean(organizationsQuery.data),
+    enabled: wantsProjects && Boolean(organizationsQuery.data),
   });
 
-  const createOrganizationMutation = useMutation({
-    mutationFn: (input: z.infer<typeof CreateOrganizationInput>) =>
-      orpcClient.organization.create(input),
-    onSuccess: async () => {
-      setOrganizationName("");
-      await queryClient.invalidateQueries({ queryKey: organizationsQueryOptions().queryKey });
+  const createOrganizationWithProjectMutation = useMutation({
+    mutationFn: async (input: z.infer<typeof CreateOrganizationWithProjectInput>) => {
+      const organization = await orpcClient.organization.create({ name: input.name });
+      try {
+        return await orpcClient.project.create({
+          organizationSlug: organization.slug,
+          name: input.projectSlug,
+          slug: input.projectSlug,
+        });
+      } catch (error) {
+        // The organization now exists: refresh it so a retry lands on the
+        // project-only form instead of failing on a duplicate organization.
+        await queryClient.invalidateQueries({ queryKey: organizationsQueryOptions().queryKey });
+        throw error;
+      }
+    },
+    onSuccess: async (project) => {
       if (!hasOAuthClientId) {
-        await navigate({ to: "/" });
+        // Back to the app that sent us here (usually the OS dashboard).
+        window.location.href = redirectTarget ?? "/";
         return;
       }
       if (!needsProjectSelection) {
@@ -101,18 +145,27 @@ function RouteComponent() {
         }
 
         window.location.href = result.url;
+        return;
       }
+      setSelectedProjectIds([project.id]);
+      await queryClient.invalidateQueries({ queryKey: organizationsQueryOptions().queryKey });
+      await queryClient.invalidateQueries({ queryKey: projectSelectionOptions.queryKey });
     },
   });
 
   const createProjectMutation = useMutation({
-    mutationFn: (input: z.infer<typeof CreateProjectInput>) => orpcClient.project.create(input),
+    mutationFn: (input: z.infer<typeof CreateProjectInput>) =>
+      orpcClient.project.create({
+        organizationSlug: input.organizationSlug,
+        name: input.slug,
+        slug: input.slug,
+      }),
     onSuccess: async (project) => {
-      setProjectName("");
+      setProjectSlug("");
       setIsCreateProjectDialogOpen(false);
       if (!hasOAuthClientId) {
-        await queryClient.invalidateQueries({ queryKey: projectSelectionOptions.queryKey });
-        await navigate({ to: "/" });
+        // Back to the app that sent us here (usually the OS dashboard).
+        window.location.href = redirectTarget ?? "/";
         return;
       }
       setSelectedProjectIds((current) => {
@@ -166,7 +219,7 @@ function RouteComponent() {
   });
 
   const isLoadingOAuthClient = hasOAuthClientId && oauthClientQuery.isPending;
-  const isLoadingProjectSelection = needsProjectSelection && projectSelectionQuery.isPending;
+  const isLoadingProjectSelection = wantsProjects && projectSelectionQuery.isPending;
 
   if (isLoadingOAuthClient || organizationsQuery.isPending || isLoadingProjectSelection) {
     return (
@@ -213,7 +266,7 @@ function RouteComponent() {
     );
   }
 
-  if (needsProjectSelection && projectSelectionQuery.isError) {
+  if (wantsProjects && projectSelectionQuery.isError) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-muted/20 p-4">
         <Card className="w-full max-w-md">
@@ -229,7 +282,9 @@ function RouteComponent() {
   const client = oauthClientQuery.data;
   const user = session.user;
   const initials = getInitials(user.name ?? user.email);
-  const clientName = client?.client_name ?? "This application";
+  // Without an OAuth client this is plain first-run setup, so brand the
+  // header as iterate rather than "This application".
+  const clientName = client?.client_name ?? (hasOAuthClientId ? "This application" : "iterate");
   const organizations = organizationsQuery.data;
   const projectSelections = projectSelectionQuery.data ?? [];
   const allProjectIds = projectSelections.flatMap((selection) =>
@@ -239,14 +294,29 @@ function RouteComponent() {
   const effectiveSelectedProjectIds = selectedProjectIds ?? allProjectIds;
   const canContinue = effectiveSelectedProjectIds.length > 0;
   const isCreatingFirstOrganization = organizations.length === 0;
-  const parsedOrganization = CreateOrganizationInput.safeParse({ name: organizationName });
+  const suggestedProjectSlug = organizationName.trim() ? slugify(organizationName) : "";
+  const firstProjectSlug = projectSlugOverride ?? suggestedProjectSlug;
+  const parsedOrganizationWithProject = CreateOrganizationWithProjectInput.safeParse({
+    name: organizationName,
+    projectSlug: firstProjectSlug,
+  });
+  const organizationNameIssues =
+    !parsedOrganizationWithProject.success && organizationName.length > 0
+      ? parsedOrganizationWithProject.error.issues.filter((issue) => issue.path[0] === "name")
+      : [];
+  const firstProjectSlugIssues =
+    !parsedOrganizationWithProject.success && firstProjectSlug.length > 0
+      ? parsedOrganizationWithProject.error.issues.filter(
+          (issue) => issue.path[0] === "projectSlug",
+        )
+      : [];
   const effectiveOrganizationSlug = selectedOrganizationSlug || organizations[0]?.slug || "";
   const parsedProject = CreateProjectInput.safeParse({
     organizationSlug: effectiveOrganizationSlug,
-    name: projectName,
+    slug: projectSlug,
   });
   const isSubmitting =
-    createOrganizationMutation.isPending ||
+    createOrganizationWithProjectMutation.isPending ||
     createProjectMutation.isPending ||
     saveSelectionMutation.isPending ||
     denyMutation.isPending ||
@@ -254,14 +324,14 @@ function RouteComponent() {
 
   const createProjectFormProps = {
     organizations,
-    projectName,
+    projectSlug,
     selectedOrganizationSlug: effectiveOrganizationSlug,
     isSubmitting,
     isCreating: createProjectMutation.isPending,
     isValid: parsedProject.success,
-    error: !parsedProject.success && projectName.length > 0 ? parsedProject.error.issues : null,
+    error: !parsedProject.success && projectSlug.length > 0 ? parsedProject.error.issues : null,
     mutationError: createProjectMutation.isError ? createProjectMutation.error.message : null,
-    onProjectNameChange: setProjectName,
+    onProjectSlugChange: setProjectSlug,
     onOrganizationSlugChange: setSelectedOrganizationSlug,
     onSubmit: () => {
       if (!parsedProject.success) return;
@@ -270,6 +340,9 @@ function RouteComponent() {
   };
 
   if (!hasOAuthClientId && hasProjects) {
+    if (redirectTarget) {
+      return <ExternalRedirect href={redirectTarget} />;
+    }
     return <Navigate to="/" />;
   }
 
@@ -284,7 +357,9 @@ function RouteComponent() {
               label={hasOAuthClientId ? "Project access" : "Setup"}
             />
             <CardTitle className="text-xl">Create your organization</CardTitle>
-            <CardDescription>Start with the team name people recognize.</CardDescription>
+            <CardDescription>
+              Name your organization and your first project comes with it.
+            </CardDescription>
           </CardHeader>
           <Separator />
           <CardContent className="space-y-4">
@@ -300,12 +375,12 @@ function RouteComponent() {
               className="space-y-4"
               onSubmit={(event) => {
                 event.preventDefault();
-                if (!parsedOrganization.success) return;
-                createOrganizationMutation.mutate(parsedOrganization.data);
+                if (!parsedOrganizationWithProject.success) return;
+                createOrganizationWithProjectMutation.mutate(parsedOrganizationWithProject.data);
               }}
             >
               <FieldGroup>
-                <Field data-invalid={!parsedOrganization.success && organizationName.length > 0}>
+                <Field data-invalid={organizationNameIssues.length > 0}>
                   <FieldLabel htmlFor="organization-name">Organization name</FieldLabel>
                   <Input
                     id="organization-name"
@@ -313,17 +388,38 @@ function RouteComponent() {
                     placeholder="Acme"
                     value={organizationName}
                     onChange={(event) => setOrganizationName(event.target.value)}
-                    aria-invalid={!parsedOrganization.success && organizationName.length > 0}
+                    aria-invalid={organizationNameIssues.length > 0}
                     disabled={isSubmitting}
                   />
-                  {!parsedOrganization.success && organizationName.length > 0 ? (
-                    <FieldError errors={parsedOrganization.error.issues} />
+                  {organizationNameIssues.length > 0 ? (
+                    <FieldError errors={organizationNameIssues} />
+                  ) : null}
+                </Field>
+                <Field data-invalid={firstProjectSlugIssues.length > 0}>
+                  <FieldLabel htmlFor="first-project-slug">Project slug</FieldLabel>
+                  <Input
+                    id="first-project-slug"
+                    name="first-project-slug"
+                    placeholder="acme"
+                    value={firstProjectSlug}
+                    onChange={(event) => setProjectSlugOverride(event.target.value || null)}
+                    aria-invalid={firstProjectSlugIssues.length > 0}
+                    disabled={isSubmitting}
+                  />
+                  <FieldDescription>
+                    Your project homepage will be under{" "}
+                    <span className="font-medium text-foreground">
+                      {firstProjectSlug || "your-project"}.{PROJECT_HOSTNAME_BASE}
+                    </span>
+                  </FieldDescription>
+                  {firstProjectSlugIssues.length > 0 ? (
+                    <FieldError errors={firstProjectSlugIssues} />
                   ) : null}
                 </Field>
               </FieldGroup>
-              {createOrganizationMutation.isError ? (
+              {createOrganizationWithProjectMutation.isError ? (
                 <p className="text-sm text-destructive">
-                  {createOrganizationMutation.error.message}
+                  {createOrganizationWithProjectMutation.error.message}
                 </p>
               ) : null}
 
@@ -331,18 +427,20 @@ function RouteComponent() {
                 <Button
                   type="submit"
                   className="flex-1"
-                  disabled={!parsedOrganization.success || isSubmitting}
+                  disabled={!parsedOrganizationWithProject.success || isSubmitting}
                 >
-                  {createOrganizationMutation.isPending ? "Creating..." : "Create organization"}
+                  {createOrganizationWithProjectMutation.isPending ? "Creating..." : "Get started"}
                 </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={isSubmitting}
-                  onClick={() => denyMutation.mutate()}
-                >
-                  Cancel
-                </Button>
+                {hasOAuthClientId ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={isSubmitting}
+                    onClick={() => denyMutation.mutate()}
+                  >
+                    Cancel
+                  </Button>
+                ) : null}
               </div>
             </form>
           </CardContent>
@@ -385,14 +483,16 @@ function RouteComponent() {
           </CardContent>
           <Separator />
           <CardFooter className="gap-3">
-            <Button
-              className="flex-1"
-              variant="outline"
-              disabled={isSubmitting}
-              onClick={() => denyMutation.mutate()}
-            >
-              Cancel
-            </Button>
+            {hasOAuthClientId ? (
+              <Button
+                className="flex-1"
+                variant="outline"
+                disabled={isSubmitting}
+                onClick={() => denyMutation.mutate()}
+              >
+                Cancel
+              </Button>
+            ) : null}
             <Button
               type="submit"
               form="create-first-project-form"
@@ -624,7 +724,7 @@ function CreateProjectForm(props: {
   id?: string;
   className?: string;
   organizations: { id: string; name: string; slug: string }[];
-  projectName: string;
+  projectSlug: string;
   selectedOrganizationSlug: string;
   isSubmitting: boolean;
   isCreating: boolean;
@@ -632,7 +732,7 @@ function CreateProjectForm(props: {
   error: z.core.$ZodIssue[] | null;
   mutationError: string | null;
   showSubmitButton?: boolean;
-  onProjectNameChange: (value: string) => void;
+  onProjectSlugChange: (value: string) => void;
   onOrganizationSlugChange: (value: string) => void;
   onSubmit: () => void;
 }) {
@@ -663,16 +763,22 @@ function CreateProjectForm(props: {
           </NativeSelect>
         </Field>
         <Field data-invalid={Boolean(props.error)}>
-          <FieldLabel htmlFor="project-name">Project name</FieldLabel>
+          <FieldLabel htmlFor="project-slug">Project slug</FieldLabel>
           <Input
-            id="project-name"
-            name="project-name"
-            placeholder="MCP Alpha"
-            value={props.projectName}
-            onChange={(event) => props.onProjectNameChange(event.target.value)}
+            id="project-slug"
+            name="project-slug"
+            placeholder="acme"
+            value={props.projectSlug}
+            onChange={(event) => props.onProjectSlugChange(event.target.value)}
             aria-invalid={Boolean(props.error)}
             disabled={props.isSubmitting}
           />
+          <FieldDescription>
+            Your project homepage will be under{" "}
+            <span className="font-medium text-foreground">
+              {props.projectSlug || "your-project"}.{PROJECT_HOSTNAME_BASE}
+            </span>
+          </FieldDescription>
           {props.error ? <FieldError errors={props.error} /> : null}
         </Field>
       </FieldGroup>
@@ -686,4 +792,26 @@ function CreateProjectForm(props: {
       ) : null}
     </form>
   );
+}
+
+/**
+ * Validates the `?redirect=` search param (set by the app that sent the user
+ * here, e.g. the OS dashboard) so setup can hand the user back when done.
+ * Only plain http(s) URLs are honored.
+ */
+function resolveRedirectTarget(redirect: string | undefined): string | null {
+  if (!redirect) return null;
+  try {
+    const url = new URL(redirect);
+    return url.protocol === "https:" || url.protocol === "http:" ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function ExternalRedirect(props: { href: string }) {
+  useEffect(() => {
+    window.location.replace(props.href);
+  }, [props.href]);
+  return null;
 }

--- a/apps/os/src/lib/auth.ts
+++ b/apps/os/src/lib/auth.ts
@@ -13,10 +13,11 @@ export function requireOrganizationMemberForSession(
   location: RouteLocation,
   issuer: string | undefined,
   authError: SignInAuthError | undefined,
+  appOrigin: string | undefined,
 ) {
   const principal = requireUserPrincipalFromSession(session, location, authError);
   if (principal.organizations.length === 0) {
-    throw redirectToProjectAccess(issuer);
+    throw redirectToProjectAccess(issuer, appOrigin);
   }
 
   return null;
@@ -28,11 +29,12 @@ export function requireAuthenticatedRootRedirectTargetFromSession(
   issuer: string | undefined,
   currentProjectHostSlug: string | null | undefined,
   authError: SignInAuthError | undefined,
+  appOrigin: string | undefined,
 ) {
   const principal = requireUserPrincipalFromSession(session, location, authError);
 
   if (principal.organizations.length === 0) {
-    throw redirectToProjectAccess(issuer);
+    throw redirectToProjectAccess(issuer, appOrigin);
   }
 
   return {
@@ -79,8 +81,12 @@ function redirectToSignIn(location: RouteLocation, authError: SignInAuthError | 
   });
 }
 
-function redirectToProjectAccess(issuer: string | undefined): never {
-  throw redirect({ href: new URL("/project-access", `${authWorkerOrigin(issuer)}/`).toString() });
+function redirectToProjectAccess(issuer: string | undefined, appOrigin: string | undefined): never {
+  const url = new URL("/project-access", `${authWorkerOrigin(issuer)}/`);
+  // After onboarding creates the organization and first project, the auth
+  // worker sends the user back here instead of stranding them on its own UI.
+  if (appOrigin) url.searchParams.set("redirect", appOrigin);
+  throw redirect({ href: url.toString() });
 }
 
 function authWorkerOrigin(issuer: string | undefined) {

--- a/apps/os/src/lib/root-auth-snapshot.ts
+++ b/apps/os/src/lib/root-auth-snapshot.ts
@@ -12,6 +12,12 @@ type RootAuthSnapshot = {
   authError: SignInAuthError | undefined;
   iterateAuthIssuer: string | undefined;
   currentProjectHostSlug: string | null;
+  /**
+   * This deployment's dashboard origin (config baseUrl, falling back to the
+   * request origin). Handed to the auth worker's onboarding page as the
+   * `?redirect=` return address.
+   */
+  appOrigin: string | undefined;
 };
 
 /**
@@ -38,8 +44,22 @@ export const fetchRootAuthSnapshot: () => Promise<RootAuthSnapshot> = createServ
       projectHostnameBases: context.config.projectHostnameBases ?? [],
       requestUrl: context.rawRequest?.url,
     }),
+    appOrigin: resolveAppOrigin({
+      baseUrl: context.config.baseUrl,
+      requestUrl: context.rawRequest?.url,
+    }),
   };
 });
+
+function resolveAppOrigin(input: { baseUrl: string | undefined; requestUrl: string | undefined }) {
+  const url = input.baseUrl ?? input.requestUrl;
+  if (!url) return undefined;
+  try {
+    return new URL(url).origin;
+  } catch {
+    return undefined;
+  }
+}
 
 function toPublicSession(session: AuthenticatedSession | null | undefined): PublicSessionResponse {
   if (!session) return { authenticated: false };

--- a/apps/os/src/routes/_app.tsx
+++ b/apps/os/src/routes/_app.tsx
@@ -15,6 +15,7 @@ export const Route = createFileRoute("/_app")({
       location,
       context.iterateAuthIssuer,
       context.authError,
+      context.appOrigin,
     ),
   // The project list is NOT pre-warmed here: it comes from the itx session
   // (browser-only), so the sidebar populates it after hydration.

--- a/apps/os/src/routes/_app/projects/index.tsx
+++ b/apps/os/src/routes/_app/projects/index.tsx
@@ -4,6 +4,7 @@ import {
   useQueryClient,
   type UseMutationResult,
 } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { FolderPlus } from "lucide-react";
 import { useAuthClient } from "@iterate-com/auth/client";
@@ -92,6 +93,22 @@ function ProjectsIndexPage() {
     },
     onError: (error) => toast.error(error instanceof Error ? error.message : String(error)),
   });
+
+  // Auth onboarding creates the project container on auth only, so a
+  // brand-new user's first project always arrives here as "missing" — run
+  // the set-up for them instead of asking them to press the button. Once per
+  // project per mount, so a failing bootstrap surfaces its toast instead of
+  // looping.
+  const autoSetUpProjectIds = useRef(new Set<string>());
+  const recoverProjectMutate = recoverProject.mutate;
+  useEffect(() => {
+    for (const project of data ?? []) {
+      if (project.deploymentStatus !== "missing") continue;
+      if (autoSetUpProjectIds.current.has(project.id)) continue;
+      autoSetUpProjectIds.current.add(project.id);
+      recoverProjectMutate(project);
+    }
+  }, [data, recoverProjectMutate]);
 
   return (
     <section className="space-y-5 p-4">

--- a/apps/os/src/routes/index.tsx
+++ b/apps/os/src/routes/index.tsx
@@ -10,6 +10,7 @@ export const Route = createFileRoute("/")({
       context.iterateAuthIssuer,
       context.currentProjectHostSlug,
       context.authError,
+      context.appOrigin,
     );
 
     // `session.projects.list()` includes projects the auth worker knows about

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -27,6 +27,7 @@
     "./oauth-resource": "./src/oauth-resource.ts",
     "./bearer": "./src/bearer.ts",
     "./slug": "./src/slug.ts",
+    "./name-suggestions": "./src/name-suggestions.ts",
     "./default-avatar": "./src/default-avatar.ts",
     "./signup-allowlist": "./src/signup-allowlist.ts"
   },

--- a/packages/shared/src/name-suggestions.test.ts
+++ b/packages/shared/src/name-suggestions.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { suggestOrganizationNameFromEmail } from "./name-suggestions.ts";
+
+describe("suggestOrganizationNameFromEmail", () => {
+  it("uses the company domain's first label", () => {
+    expect(suggestOrganizationNameFromEmail("jonas@nustom.com")).toBe("Nustom");
+    expect(suggestOrganizationNameFromEmail("hi@my-startup.co.uk")).toBe("My Startup");
+  });
+
+  it("falls back to the local part for generic email providers", () => {
+    expect(suggestOrganizationNameFromEmail("jane.doe@gmail.com")).toBe("Jane Doe");
+    expect(suggestOrganizationNameFromEmail("jane.doe+work@outlook.com")).toBe("Jane Doe");
+    expect(suggestOrganizationNameFromEmail("bob_smith@icloud.com")).toBe("Bob Smith");
+  });
+
+  it("normalizes case and whitespace", () => {
+    expect(suggestOrganizationNameFromEmail("  JONAS@NUSTOM.COM  ")).toBe("Nustom");
+  });
+
+  it("returns an empty string for junk input", () => {
+    expect(suggestOrganizationNameFromEmail("")).toBe("");
+    expect(suggestOrganizationNameFromEmail("not-an-email")).toBe("");
+    expect(suggestOrganizationNameFromEmail("@nustom.com")).toBe("");
+  });
+});

--- a/packages/shared/src/name-suggestions.ts
+++ b/packages/shared/src/name-suggestions.ts
@@ -1,0 +1,53 @@
+// Best-effort heuristics for proposing human-friendly names during
+// onboarding. They only need to produce a plausible first draft that the user
+// can edit — improve freely.
+
+/** Email providers whose domain says nothing about the user's team. */
+const GENERIC_EMAIL_DOMAINS = new Set([
+  "gmail.com",
+  "googlemail.com",
+  "yahoo.com",
+  "hotmail.com",
+  "outlook.com",
+  "live.com",
+  "msn.com",
+  "icloud.com",
+  "me.com",
+  "mac.com",
+  "aol.com",
+  "proton.me",
+  "protonmail.com",
+  "pm.me",
+  "hey.com",
+  "fastmail.com",
+  "gmx.com",
+  "gmx.net",
+  "mail.com",
+  "yandex.com",
+  "zoho.com",
+]);
+
+/**
+ * Proposes an organization name from an email address: the company domain's
+ * first label when the domain looks like a company ("jonas@nustom.com" →
+ * "Nustom"), otherwise the local part ("jane.doe+work@gmail.com" → "Jane
+ * Doe"). Returns "" when nothing sensible can be derived.
+ */
+export function suggestOrganizationNameFromEmail(email: string): string {
+  const [rawLocalPart, rawDomain] = email.trim().toLowerCase().split("@");
+  if (!rawLocalPart || !rawDomain) return "";
+
+  if (!GENERIC_EMAIL_DOMAINS.has(rawDomain)) {
+    return titleCaseWords(rawDomain.split(".")[0] ?? "");
+  }
+
+  return titleCaseWords(rawLocalPart.split("+")[0] ?? "");
+}
+
+function titleCaseWords(value: string): string {
+  return value
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+    .map((word) => word[0]!.toUpperCase() + word.slice(1))
+    .join(" ");
+}

--- a/specs/create-project.spec.ts
+++ b/specs/create-project.spec.ts
@@ -15,17 +15,27 @@ test("a new user can create a project through the UI form", async ({ page }) => 
     !(await startEmailOtpSignIn(page)),
     "Email OTP sign-in is disabled for this deployment (VITE_ENABLE_EMAIL_OTP_SIGNIN on auth / APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED on OS).",
   );
-  await signUpWithEmailOtp(page, { email: uniqueSignupEmail("create-project") });
+  const firstSlug = uniqueSlug("first-project");
+  await signUpWithEmailOtp(page, {
+    email: uniqueSignupEmail("create-project"),
+    projectSlug: firstSlug,
+  });
 
   const slug = uniqueSlug("create-project");
   // spinner-waiter is disabled through here: the /projects pending state and
   // the agent page's loading state both render two spinner-matching elements
   // at once, tripping its strict-mode isVisible.
   await spinnerWaiter.settings.run({ disabled: true }, async () => {
-    // The cold-slot 30-90s OAuth-callback parks traced back to zombie worker
+    // Back on OS after onboarding: wait for the first project's auto set-up
+    // to finish (its row name becomes a link) so the landing is settled. The
+    // cold-slot 30-90s OAuth-callback parks traced back to zombie worker
     // routes (deploy now verifies + heals them; tasks/os-cold-create-latency.md).
-    // On a healthy slot this renders in ~1s.
-    await page.getByRole("button", { name: "Create new project" }).click({ timeout: 30_000 });
+    await page.getByRole("link", { name: firstSlug }).waitFor({ timeout: 60_000 });
+
+    // /projects is the home of SUBSEQUENT projects: the header's "New project"
+    // and the sidebar's icon both link here, but share an accessible name, so
+    // navigate directly instead of picking one with a strict-mode locator.
+    await page.goto("/new-project");
 
     await page.getByLabel("Slug").fill(slug, { timeout: 15_000 });
     // Create resolves as soon as the project EXISTS (identity + bootstrap

--- a/specs/signup.spec.ts
+++ b/specs/signup.spec.ts
@@ -4,7 +4,7 @@ import {
   startEmailOtpSignIn,
   uniqueSignupEmail,
 } from "./test-support/email-otp-signup.ts";
-import { test } from "./test-support/test.ts";
+import { test, uniqueSlug } from "./test-support/test.ts";
 
 // Deviation from the suite's forged-session fixture pattern: this spec's whole
 // point is the REAL signup flow (goal 1 of the itx-v4 migration), so it drives
@@ -15,14 +15,17 @@ test("can sign up with an email one-time passcode", async ({ page }) => {
     "Email OTP sign-in is disabled for this deployment (VITE_ENABLE_EMAIL_OTP_SIGNIN on auth / APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED on OS).",
   );
 
-  await signUpWithEmailOtp(page, { email: uniqueSignupEmail("signup") });
+  const slug = uniqueSlug("signup");
+  await signUpWithEmailOtp(page, { email: uniqueSignupEmail("signup"), projectSlug: slug });
 
-  // Back on OS, signed in: a fresh user has no projects yet. The /projects
-  // pending state renders its data-spinner section twice during the redirect,
-  // which trips spinner-waiter's strict-mode isVisible — sit it out. The
-  // cold-slot OAuth-callback straggle traced back to zombie worker routes,
-  // which the deploy now verifies + heals (tasks/os-cold-create-latency.md).
+  // Back on OS, signed in: onboarding created the first project's container
+  // on auth, and /projects auto-runs the engine set-up for it. The pending
+  // state renders its data-spinner section twice during the redirect, which
+  // trips spinner-waiter's strict-mode isVisible — sit it out. Once the
+  // bootstrap finishes, the project row's name becomes a link. The cold-slot
+  // OAuth-callback straggle traced back to zombie worker routes, which the
+  // deploy now verifies + heals (tasks/os-cold-create-latency.md).
   await spinnerWaiter.settings.run({ disabled: true }, () =>
-    page.getByText("No projects yet").waitFor({ timeout: 30_000 }),
+    page.getByRole("link", { name: slug }).waitFor({ timeout: 60_000 }),
   );
 });

--- a/specs/test-support/email-otp-signup.ts
+++ b/specs/test-support/email-otp-signup.ts
@@ -5,8 +5,8 @@ import { spinnerWaiter } from "middlewright";
  * Real signup through the apps/auth email-OTP lane. Non-production auth
  * accepts the fixed code 424242 for `+…test@` addresses without sending mail
  * (apps/auth/src/server/auth-plugins.ts), so this drives the exact flow a
- * human sees: OS login → auth login (email OTP) → first-org onboarding → back
- * to OS signed in.
+ * human sees: OS login → auth login (email OTP) → first-run onboarding
+ * (organization + first project in one form) → back to OS signed in.
  *
  * The lane only exists where the auth deployment enables it
  * (VITE_ENABLE_EMAIL_OTP_SIGNIN, default on for dev stages; OS mirrors it as
@@ -35,21 +35,29 @@ export async function startEmailOtpSignIn(page: Page) {
   return await page.getByTestId("email-input").isVisible();
 }
 
-/** Call after {@link startEmailOtpSignIn}. Ends signed in on OS with one fresh organization. */
-export async function signUpWithEmailOtp(page: Page, input: { email: string }) {
+/**
+ * Call after {@link startEmailOtpSignIn}. Ends signed in on OS with one fresh
+ * organization and one project container (slug `input.projectSlug`) created
+ * by the onboarding form.
+ */
+export async function signUpWithEmailOtp(
+  page: Page,
+  input: { email: string; projectSlug: string },
+) {
   await page.getByTestId("email-input").fill(input.email);
   await page.getByTestId("email-submit-button").click();
   await page.getByTestId("email-otp-input").fill("424242");
   await page.getByTestId("email-verify-button").click();
 
   // A brand-new user has no organization, so the OAuth post-login flow parks
-  // on the auth app's first-org onboarding before returning to OS. The page
-  // loads behind an unmarked skeleton, so spinner-waiter can't help here —
-  // wait for the form directly instead.
+  // on the auth app's first-run onboarding — organization name and first
+  // project slug in one form. The page loads behind an unmarked skeleton, so
+  // spinner-waiter can't help here — wait for the form directly instead.
   await spinnerWaiter.settings.run({ disabled: true }, async () => {
     await page
       .getByLabel("Organization name")
       .fill(`Playwright ${input.email.split("@")[0]}`, { timeout: 30_000 });
-    await page.getByRole("button", { name: "Create organization" }).click({ timeout: 15_000 });
+    await page.getByLabel("Project slug").fill(input.projectSlug, { timeout: 15_000 });
+    await page.getByRole("button", { name: "Get started" }).click({ timeout: 15_000 });
   });
 }


### PR DESCRIPTION
## What

The `/project-access` first-run flow on auth previously created only an organization, then popped a bare "create a project" input (meant for MCP OAuth flows) even for users arriving from apps/os — and left them stranded on the auth profile page afterwards.

Now the first-run form creates the **organization and first project together**, for both plain OS arrivals and OAuth/MCP flows:

- **Org name prefilled from the email** via a simple, improvable heuristic (new `@iterate-com/shared/name-suggestions`): company domains use the first domain label (`jonas@nustom.com` → "Nustom"), generic providers fall back to the local part (`jane.doe@gmail.com` → "Jane Doe").
- **Project slug auto-derives** from the org name while typing, stops following once manually edited, resumes when cleared.
- **Live homepage hint** under the slug: *"Your project homepage will be under `<slug>.iterate.app`"* using the env's real hostname base — new `VITE_PROJECT_HOSTNAME_BASE` (already set in Doppler for `auth/prd` = `iterate.app` and `auth/preview_1..9` = `iterate-preview-N.app`, mirroring os's `APP_CONFIG_PROJECT_HOSTNAME_BASES`; code falls back to `iterate.app`).
- **Round trip back to OS**: os passes `?redirect=<its origin>` when sending users to `/project-access` (new `appOrigin` on the root auth snapshot), and auth bounces back there after setup. Only plain http(s) URLs are honored. Users who already finished setup bounce straight back too — this also fixes a latent bug where non-OAuth visits offered "Create a project to finish setup" again (project data was only fetched for OAuth flows).
- The org-exists fallback form and the OAuth "New project" dialog switch from a name input to the same slug input with the hostname hint. Header brands as "iterate" instead of "This application" outside OAuth; Cancel (an OAuth-deny action) only renders in OAuth flows.

`/projects` remains the place to create subsequent projects.

## Verification

Ran the real flow against local auth dev with a headless browser: OTP login (`+test@` fixed code), prefill "Nustom"/"nustom", slug live-followed "Fluffy Cactus Inc" → `fluffy-cactus-inc`, manual override stuck across org-name edits and resumed after clearing, submit fired `organization/create` + `project/create` (both 200, project name = slug, `prj_` id, visible on `/projects`), browser navigated to the `redirect` target, and a returning fully-set-up user bounced straight back out.

`pnpm typecheck`, `lint`, `format`, and new unit tests for the email heuristic all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-run signup/onboarding, cross-app redirects, and automatic project recovery mutations—important user paths but no direct auth-crypto changes; partial org-create + failed project-create needs retry behavior.
> 
> **Overview**
> **Auth first-run `/project-access`** now creates an **organization and first project in one step** (slug-based, with validation aligned to server `slugify`), instead of org-only then a separate project step. Org name is **prefilled from email** via new `@iterate-com/shared/name-suggestions`; the **project slug follows the org name** until the user edits it, with a **live `slug.<projectHostnameBase>` hint** from new auth config `projectHostnameBase`.
> 
> **Return path:** OS adds **`appOrigin`** on the root auth snapshot and sends users to auth with **`?redirect=`** (http/https only); after setup, auth sends them back. Users who already have projects **bounce out** without seeing “create again” (project list now loads for non-OAuth visits too).
> 
> **OS `/projects`** **auto-runs engine set-up** for projects that exist on auth but are `deploymentStatus: "missing"`. E2E signup/create-project helpers expect the combined form and first-project auto-setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98f1160fc035304b215a5b1c60b200d2f0f2bb8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-03T20:35:03.782Z",
      "headSha": "98f1160fc035304b215a5b1c60b200d2f0f2bb8f",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/115630254714050",
      "shortSha": "98f1160",
      "cleanupDurationMs": 83082,
      "deployDurationMs": 60712,
      "testDurationMs": 125904
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-03T20:33:55.913Z",
      "headSha": "459fe7a464c625fa2f66253debeb405cc0ec6a93",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/220576512451024",
      "shortSha": "459fe7a",
      "cleanupDurationMs": 15208,
      "deployDurationMs": 32652,
      "testDurationMs": 6377
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-03T20:34:33.626Z",
      "headSha": "98f1160fc035304b215a5b1c60b200d2f0f2bb8f",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/115630254714050",
      "shortSha": "98f1160",
      "cleanupDurationMs": 52918,
      "deployDurationMs": 31197,
      "testDurationMs": 583
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-03T20:33:54.312Z",
      "headSha": "459fe7a464c625fa2f66253debeb405cc0ec6a93",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-4.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/220576512451024",
      "shortSha": "459fe7a",
      "cleanupDurationMs": 13602,
      "deployDurationMs": 15702,
      "testDurationMs": 14216
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `98f1160` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 31.2s | 583ms | 52.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/115630254714050) | 2026-07-03T20:34:33.626Z | Preview app released. |
| OS | released | `98f1160` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 60.7s | 125.9s | 83.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/115630254714050) | 2026-07-03T20:35:03.782Z | Preview app released. |
| Semaphore | released | `459fe7a` | [https://semaphore.iterate-preview-4.com](https://semaphore.iterate-preview-4.com) | 32.7s | 6.4s | 15.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/220576512451024) | 2026-07-03T20:33:55.913Z | Preview app released. |
| Streams Example App | released | `459fe7a` | [https://streams-example-app-preview-4.iterate-dev-preview.workers.dev](https://streams-example-app-preview-4.iterate-dev-preview.workers.dev) | 15.7s | 14.2s | 13.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/220576512451024) | 2026-07-03T20:33:54.312Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->