### PR TITLE
[codex] Fix auth dev-global OAuth seed token precedence

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -24,7 +24,8 @@
     "db:migrate": "sqlfu migrate",
     "db:rebuild": "rm -f ./src/server/db/.local.db && pnpm db:migrate",
     "deploy:prd": "doppler run --project auth --config prd -- pnpm alchemy:up",
-    "seed-oauth-clients": "tsx ./scripts/seed-oauth-clients.ts"
+    "seed-oauth-clients": "tsx ./scripts/seed-oauth-clients.ts",
+    "test": "node --import tsx --test scripts/*.test.ts"
   },
   "dependencies": {
     "@better-auth/oauth-provider": "^1.6.9",

--- a/apps/auth/scripts/seed-oauth-clients.test.ts
+++ b/apps/auth/scripts/seed-oauth-clients.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { SeedOAuthClientsEnv } from "./seed-oauth-clients.ts";
+
+const clientsJson = JSON.stringify([
+  {
+    clientId: "client-id",
+    clientSecret: "client-secret-with-enough-length",
+    clientName: "Test client",
+    redirectURIs: ["https://example.com/callback"],
+  },
+]);
+
+describe("SeedOAuthClientsEnv", () => {
+  it("prefers AppConfig service token and auth origin over legacy env vars", () => {
+    const env = SeedOAuthClientsEnv.parse({
+      AUTH_SEED_OAUTH_CLIENTS: clientsJson,
+      APP_CONFIG_SERVICE_AUTH_TOKEN: "app-config-token",
+      SERVICE_AUTH_TOKEN: "legacy-token",
+      APP_CONFIG_AUTH_APP_ORIGIN: "https://auth.example.com",
+      VITE_AUTH_APP_ORIGIN: "https://legacy-auth.example.com",
+    });
+
+    assert.equal(env.SERVICE_AUTH_TOKEN, "app-config-token");
+    assert.equal(env.VITE_AUTH_APP_ORIGIN, "https://auth.example.com");
+  });
+
+  it("falls back to legacy service token and auth origin", () => {
+    const env = SeedOAuthClientsEnv.parse({
+      AUTH_SEED_OAUTH_CLIENTS: clientsJson,
+      SERVICE_AUTH_TOKEN: "legacy-token",
+      VITE_AUTH_APP_ORIGIN: "https://legacy-auth.example.com",
+    });
+
+    assert.equal(env.SERVICE_AUTH_TOKEN, "legacy-token");
+    assert.equal(env.VITE_AUTH_APP_ORIGIN, "https://legacy-auth.example.com");
+  });
+
+  it("requires a service token from AppConfig or legacy env vars", () => {
+    assert.throws(
+      () =>
+        SeedOAuthClientsEnv.parse({
+          AUTH_SEED_OAUTH_CLIENTS: clientsJson,
+          VITE_AUTH_APP_ORIGIN: "https://legacy-auth.example.com",
+        }),
+      /APP_CONFIG_SERVICE_AUTH_TOKEN or SERVICE_AUTH_TOKEN is required/,
+    );
+  });
+});

--- a/apps/auth/scripts/seed-oauth-clients.ts
+++ b/apps/auth/scripts/seed-oauth-clients.ts
@@ -28,22 +28,62 @@ export const SeedOAuthClientSpec = z.object({
 });
 export type SeedOAuthClientSpec = z.infer<typeof SeedOAuthClientSpec>;
 
-export const SeedOAuthClientsEnv = z.object({
-  AUTH_SEED_OAUTH_CLIENTS: z
-    .string()
-    .transform((value, ctx) => {
-      try {
-        return JSON.parse(value) as unknown;
-      } catch (error) {
-        ctx.addIssue({ code: "custom", message: `not valid JSON: ${error}` });
-        return z.NEVER;
-      }
-    })
-    .pipe(z.array(SeedOAuthClientSpec)),
-  SERVICE_AUTH_TOKEN: z.string().min(1),
-  // The deployed auth origin to seed, e.g. https://auth.iterate-dev.com.
-  VITE_AUTH_APP_ORIGIN: z.url(),
-});
+const OptionalNonEmptyString = z.preprocess(
+  (value) => (typeof value === "string" && value.trim() === "" ? undefined : value),
+  z.string().trim().min(1).optional(),
+);
+
+const OptionalUrl = z.preprocess(
+  (value) => (typeof value === "string" && value.trim() === "" ? undefined : value),
+  z.url().optional(),
+);
+
+export const SeedOAuthClientsEnv = z
+  .object({
+    AUTH_SEED_OAUTH_CLIENTS: z
+      .string()
+      .transform((value, ctx) => {
+        try {
+          return JSON.parse(value) as unknown;
+        } catch (error) {
+          ctx.addIssue({ code: "custom", message: `not valid JSON: ${error}` });
+          return z.NEVER;
+        }
+      })
+      .pipe(z.array(SeedOAuthClientSpec)),
+    APP_CONFIG_SERVICE_AUTH_TOKEN: OptionalNonEmptyString,
+    SERVICE_AUTH_TOKEN: OptionalNonEmptyString,
+    // The deployed auth origin to seed, e.g. https://auth.iterate-dev.com.
+    APP_CONFIG_AUTH_APP_ORIGIN: OptionalUrl,
+    VITE_AUTH_APP_ORIGIN: OptionalUrl,
+  })
+  .transform((env, ctx) => {
+    const serviceAuthToken = env.APP_CONFIG_SERVICE_AUTH_TOKEN ?? env.SERVICE_AUTH_TOKEN;
+    if (!serviceAuthToken) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["APP_CONFIG_SERVICE_AUTH_TOKEN"],
+        message: "APP_CONFIG_SERVICE_AUTH_TOKEN or SERVICE_AUTH_TOKEN is required",
+      });
+      return z.NEVER;
+    }
+
+    const authAppOrigin = env.APP_CONFIG_AUTH_APP_ORIGIN ?? env.VITE_AUTH_APP_ORIGIN;
+    if (!authAppOrigin) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["APP_CONFIG_AUTH_APP_ORIGIN"],
+        message: "APP_CONFIG_AUTH_APP_ORIGIN or VITE_AUTH_APP_ORIGIN is required",
+      });
+      return z.NEVER;
+    }
+
+    return {
+      AUTH_SEED_OAUTH_CLIENTS: env.AUTH_SEED_OAUTH_CLIENTS,
+      SERVICE_AUTH_TOKEN: serviceAuthToken,
+      VITE_AUTH_APP_ORIGIN: authAppOrigin,
+    };
+  });
 
 async function waitForAuthDeployment(baseUrl: string, timeoutMs = 120_000) {
   const discoveryUrl = `${baseUrl.replace(/\/+$/, "")}/api/auth/.well-known/openid-configuration`;


### PR DESCRIPTION
## What changed

- Make the auth OAuth seeding script prefer APP_CONFIG_SERVICE_AUTH_TOKEN over legacy SERVICE_AUTH_TOKEN, matching the worker runtime config precedence.
- Also prefer APP_CONFIG_AUTH_APP_ORIGIN over VITE_AUTH_APP_ORIGIN for the standalone seeding path.
- Add a small Node test lane for the auth seeding env parser.

## Root cause

The dev-global auth deploy completed successfully, then the post-deploy OAuth client seed failed with 401 Not authorized. The worker was deployed with APP_CONFIG_SERVICE_AUTH_TOKEN while the seed script still sent SERVICE_AUTH_TOKEN, so the internal oRPC service-token middleware rejected the request.

## Validation

- pnpm --dir apps/auth test
- pnpm --dir apps/auth typecheck
- pnpm exec oxfmt --check apps/auth/package.json apps/auth/scripts/seed-oauth-clients.ts apps/auth/scripts/seed-oauth-clients.test.ts
- pnpm lint
- pnpm workflows
- pnpm --dir .github/ts-workflows build
- pnpm typecheck
- pnpm test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the standalone seed script’s env parsing and tests; no runtime auth worker or middleware changes.
> 
> **Overview**
> Fixes post-deploy OAuth client seeding **401** failures when the worker is configured with AppConfig env vars but the seed script still read only legacy `SERVICE_AUTH_TOKEN` / `VITE_AUTH_APP_ORIGIN`.
> 
> **`SeedOAuthClientsEnv`** now accepts `APP_CONFIG_SERVICE_AUTH_TOKEN` and `APP_CONFIG_AUTH_APP_ORIGIN`, resolves them with the same **AppConfig-first, legacy-fallback** rules as `alchemy.run.ts`, and normalizes to the existing `SERVICE_AUTH_TOKEN` / `VITE_AUTH_APP_ORIGIN` shape the rest of the script uses. Empty strings are treated as unset.
> 
> Adds **`pnpm test`** in `apps/auth` (Node test runner) and **`seed-oauth-clients.test.ts`** covering precedence, fallback, and required-token validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfb7119f2f2b1ddc698a1ea5d8d9f7d36a8c0b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->