### PR TITLE
[codex] Route signup users into project onboarding

### DIFF
--- a/apps/os/src/lib/project-root-redirect.test.ts
+++ b/apps/os/src/lib/project-root-redirect.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "vitest";
+import { chooseRootProjectRedirect, type RootRedirectProject } from "./project-root-redirect.ts";
+
+const project = (
+  overrides: Partial<RootRedirectProject> & Pick<RootRedirectProject, "id" | "slug">,
+): RootRedirectProject => ({
+  organizationId: "org_1",
+  deploymentStatus: "ready",
+  ...overrides,
+});
+
+describe("chooseRootProjectRedirect", () => {
+  test("prefers the current project host when that project is ready", () => {
+    expect(
+      chooseRootProjectRedirect({
+        preferredProjectSlug: "beta",
+        projects: [project({ id: "prj_a", slug: "alpha" }), project({ id: "prj_b", slug: "beta" })],
+      }),
+    ).toMatchObject({
+      kind: "project",
+      project: { slug: "beta" },
+      welcome: false,
+    });
+  });
+
+  test("redirects to the only ready project without welcome mode", () => {
+    expect(
+      chooseRootProjectRedirect({
+        preferredProjectSlug: null,
+        projects: [project({ id: "prj_a", slug: "alpha" })],
+      }),
+    ).toMatchObject({
+      kind: "project",
+      project: { slug: "alpha" },
+      welcome: false,
+    });
+  });
+
+  test("sends a single auth-created missing project through welcome mode", () => {
+    expect(
+      chooseRootProjectRedirect({
+        preferredProjectSlug: null,
+        projects: [project({ id: "prj_a", slug: "alpha", deploymentStatus: "missing" })],
+      }),
+    ).toMatchObject({
+      kind: "project",
+      project: { slug: "alpha" },
+      welcome: true,
+    });
+  });
+
+  test("leaves ambiguous or unknown project sets on the projects page", () => {
+    expect(
+      chooseRootProjectRedirect({
+        preferredProjectSlug: null,
+        projects: [
+          project({ id: "prj_a", slug: "alpha", deploymentStatus: "missing" }),
+          project({ id: "prj_b", slug: "beta", deploymentStatus: "missing" }),
+        ],
+      }),
+    ).toEqual({ kind: "projects" });
+
+    expect(
+      chooseRootProjectRedirect({
+        preferredProjectSlug: null,
+        projects: [project({ id: "prj_a", slug: "alpha", deploymentStatus: "unknown" })],
+      }),
+    ).toEqual({ kind: "projects" });
+  });
+});

--- a/apps/os/src/lib/project-root-redirect.ts
+++ b/apps/os/src/lib/project-root-redirect.ts
@@ -1,0 +1,42 @@
+import type { ProjectDeploymentStatus } from "~/types.ts";
+
+export type RootRedirectProject = {
+  id: string;
+  slug: string;
+  organizationId: string | null;
+  deploymentStatus: ProjectDeploymentStatus;
+};
+
+export type RootProjectRedirectDecision =
+  | {
+      kind: "project";
+      project: RootRedirectProject;
+      welcome: boolean;
+    }
+  | {
+      kind: "projects";
+    };
+
+export function chooseRootProjectRedirect(input: {
+  preferredProjectSlug: string | null;
+  projects: RootRedirectProject[];
+}): RootProjectRedirectDecision {
+  const readyProjects = input.projects.filter((project) => project.deploymentStatus === "ready");
+  const preferredReadyProject = readyProjects.find(
+    (project) => project.slug === input.preferredProjectSlug,
+  );
+
+  if (preferredReadyProject) {
+    return { kind: "project", project: preferredReadyProject, welcome: false };
+  }
+
+  if (readyProjects.length === 1) {
+    return { kind: "project", project: readyProjects[0]!, welcome: false };
+  }
+
+  if (input.projects.length === 1 && input.projects[0]!.deploymentStatus === "missing") {
+    return { kind: "project", project: input.projects[0]!, welcome: true };
+  }
+
+  return { kind: "projects" };
+}

--- a/apps/os/src/lib/project-server-fns.ts
+++ b/apps/os/src/lib/project-server-fns.ts
@@ -5,6 +5,10 @@ import { env } from "cloudflare:workers";
 import { authenticateCapnwebAdmin } from "~/auth/admin-auth-cookie.ts";
 import { getUserPrincipal } from "~/auth/principal.ts";
 import { buildProjectWorkerUrl } from "~/lib/project-host-routing.ts";
+import {
+  chooseRootProjectRedirect,
+  type RootProjectRedirectDecision,
+} from "~/lib/project-root-redirect.ts";
 import { readProjectBySlug } from "~/project-directory.ts";
 import type { ProjectDeploymentStatus, UnauthenticatedItx } from "~/types.ts";
 import type { RequestContext } from "~/request-context.ts";
@@ -18,8 +22,10 @@ import type { RequestContext } from "~/request-context.ts";
  * ~/itx/itx-react.tsx consumers). What remains here is only what MUST run
  * server-side:
  * - `getProjectBySlugServerFn` — the project layout's `beforeLoad` (SSR).
- * - `listReadyProjectsServerFn` — the root `/` redirect decision (SSR); a thin
- *   proxy over the engine's `session.projects.list()`.
+ * - `getRootProjectRedirectServerFn` — the root `/` redirect decision (SSR);
+ *   a thin proxy over the engine's `session.projects.list()`, plus the
+ *   signup handoff for the one auth-created project that still needs its OS
+ *   bootstrap.
  *
  * Project deletion is deliberately absent rather than half-implemented:
  * the archival verb (auth-worker archive + engine teardown + UI) has not
@@ -45,16 +51,27 @@ export type Project = {
 type ProjectWithIngressUrl = Project & { ingressUrl: string };
 
 /**
- * The session's projects that actually exist in THIS deployment — the root
- * `/` redirect's input. It runs during SSR (itx is client-only), so it proxies
- * the engine's `session.projects.list()` through one pipelined capnweb HTTP
- * batch that forwards the caller's cookie. Failures degrade to an empty list:
- * the redirect then lands on `/projects`, which renders the real list.
+ * The root `/` redirect decision. It runs during SSR (itx is client-only), so
+ * it proxies the engine's `session.projects.list()` through one pipelined
+ * capnweb HTTP batch that forwards the caller's cookie.
+ *
+ * A brand-new auth signup creates the user/org/project records in auth before
+ * OS has a project stream. When that single auth-known project is the whole
+ * project set, this starts the OS bootstrap with `waitUntilCreated: false`,
+ * then redirects into the same `welcome=true` project home path used by the
+ * create form. The project home keeps showing creation progress and hands off
+ * to `/agents/onboarding` when `project/created` lands.
+ *
+ * Failures degrade to `/projects`, where the client-side recovery button and
+ * auto-recovery still render the real list.
  */
-export const listReadyProjectsServerFn: (input?: {
-  data?: undefined;
-}) => Promise<{ id: string; slug: string }[]> = createServerFn({ method: "GET" }).handler(
-  async ({ context }) => {
+export const getRootProjectRedirectServerFn: (input?: {
+  data?: { preferredProjectSlug: string | null };
+}) => Promise<RootProjectRedirectDecision> = createServerFn({ method: "GET" })
+  .validator((input?: { preferredProjectSlug: string | null }) => ({
+    preferredProjectSlug: input?.preferredProjectSlug ?? null,
+  }))
+  .handler(async ({ context, data }) => {
     try {
       const session = engineBatchSession(context);
       const root = session.authenticate({ type: "from-server-cookie" });
@@ -62,14 +79,29 @@ export const listReadyProjectsServerFn: (input?: {
       // root redirect must follow the signed-in user's claims, never the
       // deployment listing.
       const projects = await root.projects.list({ scope: "mine" });
-      return projects
-        .filter((project) => project.deploymentStatus === "ready")
-        .map((project) => ({ id: project.id, slug: project.slug }));
+      const decision = chooseRootProjectRedirect({
+        preferredProjectSlug: data.preferredProjectSlug,
+        projects,
+      });
+
+      if (decision.kind === "project" && decision.welcome) {
+        try {
+          await root.projects.create({
+            projectId: decision.project.id,
+            slug: decision.project.slug,
+            waitUntilCreated: false,
+            ...organizationSlugForProject(context, decision.project),
+          });
+        } catch {
+          return { kind: "projects" };
+        }
+      }
+
+      return decision;
     } catch {
-      return [];
+      return { kind: "projects" };
     }
-  },
-);
+  });
 
 /** A single project the session principal can read, by slug. */
 export const getProjectBySlugServerFn: (input: {
@@ -160,4 +192,16 @@ function engineBatchSession(context: RequestContext) {
       headers: { cookie },
     }),
   );
+}
+
+function organizationSlugForProject(
+  context: RequestContext,
+  project: { organizationId: string | null },
+) {
+  if (!project.organizationId) return {};
+
+  const organization = getUserPrincipal(context.principal)?.organizations.find(
+    (candidate) => candidate.id === project.organizationId,
+  );
+  return organization ? { organizationSlug: organization.slug } : {};
 }

--- a/apps/os/src/routes/index.tsx
+++ b/apps/os/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { requireAuthenticatedRootRedirectTargetFromSession } from "../lib/auth.ts";
-import { listReadyProjectsServerFn } from "~/lib/project-server-fns.ts";
+import { getRootProjectRedirectServerFn } from "~/lib/project-server-fns.ts";
 
 export const Route = createFileRoute("/")({
   loader: async ({ context, location }) => {
@@ -13,25 +13,15 @@ export const Route = createFileRoute("/")({
       context.appOrigin,
     );
 
-    // `session.projects.list()` includes projects the auth worker knows about
-    // but this deployment's engine does not (`deploymentStatus: "missing"` —
-    // e.g. after an engine-only reset; the `/projects` page offers a one-click
-    // set-up for those).
-    //
-    // Root redirect must make a different decision: only projects that
-    // actually exist in this deployment are valid redirect targets. If auth
-    // knows about ten projects but this engine has only one of them, `/`
-    // should go to that one project, not stay on the picker.
-    const projects = await listReadyProjectsServerFn();
+    const decision = await getRootProjectRedirectServerFn({
+      data: { preferredProjectSlug: target.projectSlug },
+    });
 
-    const project =
-      projects.find((candidate) => candidate.slug === target.projectSlug) ??
-      (projects.length === 1 ? projects[0] : null);
-
-    if (project) {
+    if (decision.kind === "project") {
       throw redirect({
         to: "/projects/$projectSlug",
-        params: { projectSlug: project.slug },
+        params: { projectSlug: decision.project.slug },
+        search: decision.welcome ? { welcome: true } : {},
         replace: true,
       });
     }


### PR DESCRIPTION
## Summary
- route the OS root redirect through a typed project redirect decision
- bootstrap the single auth-created missing project on first return from signup
- send that project through the existing `welcome=true` onboarding handoff

## Why
Auth signup creates the user, organization, and first project records before OS has project engine state. Returning to OS should not strand that user on the project list; the single-project signup path should continue straight into the onboarding agent once bootstrap lands.

## Validation
- `pnpm --dir apps/os exec vitest run src/lib/project-root-redirect.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm -w run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-login routing and triggers project creation during the root redirect; failures degrade to `/projects`, but a bad decision could affect onboarding for new signups.
> 
> **Overview**
> **Root `/` no longer only considers “ready” projects.** It uses a typed **`chooseRootProjectRedirect`** decision: prefer a ready project matching the current host slug, else the sole ready project, else a **single auth-known project with `deploymentStatus: "missing"`** (post-signup before the engine exists).
> 
> **`listReadyProjectsServerFn` is replaced by `getRootProjectRedirectServerFn`**, which lists the user’s projects via the engine, applies that decision, and on the welcome path kicks off **`projects.create`** with `waitUntilCreated: false` (org slug from the session when available). Errors fall back to **`/projects`**.
> 
> The index loader redirects to the project home with **`welcome: true`** when the decision says so, matching the create-form onboarding handoff instead of leaving new signups on the project picker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6f878f822199714ed6c501b804164ae247f3608. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-03T21:18:12.556Z",
      "headSha": "b6f878f822199714ed6c501b804164ae247f3608",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/561320537701278",
      "shortSha": "b6f878f",
      "cleanupDurationMs": 104287,
      "deployDurationMs": 79860
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "cleanup-failed",
      "updatedAt": "2026-07-03T21:16:31.320Z",
      "headSha": "b6f878f822199714ed6c501b804164ae247f3608",
      "message": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\nWARNING: UNKNOWN APP CONFIG OVERRIDE\nUnknown config key \"integrations\" from env var \"APP_CONFIG_INTEGRATIONS\". This env var is not consumed by the config schema.\nDeployment will continue, but this config value is being ignored by the typed runtime config.\nAdd the key to the app config schema or remove the env var from Doppler.\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\nWARNING: UNKNOWN APP CONFIG OVERRIDE\nUnknown config key \"baseUrl\" from env var \"APP_CONFIG_BASE_URL\". This env var is not consumed by the config schema.\nDeployment will continue, but this config value is being ignored by the typed runtime config.\nAdd the key to the app config schema or remove the env var from Doppler.\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\nWARNING: UNKNOWN APP CONFIG OVERRIDE\nUnknown config key \"logs\" from env var \"APP_CONFIG_LOGS\". This env var is not consumed by the config schema.\nDeployment will continue, but this config value is being ignored by the typed runtime config.\nAdd the key to the app config schema or remove the env var from Doppler.\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\nWARNING: UNKNOWN APP CONFIG OVERRIDE\nUnknown config key \"posthog\" from env var \"APP_CONFIG_POSTHOG\". This env var is not consumed by the config schema.\nDeployment will continue, but this config value is being ignored by the typed runtime config.\nAdd the key to the app config schema or remove the env var from Doppler.\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n/home/runner/work/iterate/iterate/packages/shared/src/config.ts:494\n  configSchema.parse(rawConfig);\n               ^\n\nZodError: [\n  {\n    \"expected\": \"string\",\n    \"code\": \"invalid_type\",\n    \"path\": [\n      \"authAppOrigin\"\n    ],\n    \"message\": \"Invalid input: expected string, received undefined\"\n  },\n  {\n    \"expected\": \"string\",\n    \"code\": \"invalid_type\",\n    \"path\": [\n      \"betterAuthSecret\"\n    ],\n    \"message\": \"Invalid input: expected string, received undefined\"\n  },\n  {\n    \"expected\": \"string\",\n    \"code\": \"invalid_type\",\n    \"path\": [\n      \"serviceAuthToken\"\n    ],\n    \"message\": \"Invalid input: expected string, received undefined\"\n  },\n  {\n    \"expected\": \"string\",\n    \"code\": \"invalid_type\",\n    \"path\": [\n      \"googleClientId\"\n    ],\n    \"message\": \"Invalid input: expected string, received undefined\"\n  },\n  {\n    \"expected\": \"string\",\n    \"code\": \"invalid_type\",\n    \"path\": [\n      \"googleClientSecret\"\n    ],\n    \"message\": \"Invalid input: expected string, received undefined\"\n  }\n]\n    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/config.ts:494:16)\n    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:48:28)\n    at <anonymous> (/home/runner/work/iterate/iterate/apps/auth/alchemy.run.ts:120:19)\n\nNode.js v24.18.0\n\n\n> @iterate-com/auth@0.0.0-dev alchemy:down /home/runner/work/iterate/iterate/apps/auth\n> tsx ./alchemy.run.ts --destroy && tsx ./alchemy.run.ts --park\n\n ELIFECYCLE  Command failed with exit code 1.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/561320537701278",
      "shortSha": "b6f878f",
      "cleanupDurationMs": 3047,
      "deployDurationMs": 1930
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_9",
    "leasedUntil": 1783198996436,
    "leaseId": "491aa9bf-59a5-42b4-83d3-60512ae294d5",
    "slug": "preview-9",
    "type": "environment-config-lease"
  },
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>Lease: preview-9 | Doppler config: preview_9 | Type: environment-config-lease | Leased until: 2026-07-04T21:03:16.436Z</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | cleanup failed | `b6f878f` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 1.9s |  | 3.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/561320537701278) | 2026-07-03T21:16:31.320Z | ZodError: [ |
| OS | released | `b6f878f` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 79.9s |  | 104.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/561320537701278) | 2026-07-03T21:18:12.556Z | Preview app released. |

</details>

<details>
<summary>Auth failure details</summary>

<pre>!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING: UNKNOWN APP CONFIG OVERRIDE
Unknown config key "integrations" from env var "APP_CONFIG_INTEGRATIONS". This env var is not consumed by the config schema.
Deployment will continue, but this config value is being ignored by the typed runtime config.
Add the key to the app config schema or remove the env var from Doppler.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING: UNKNOWN APP CONFIG OVERRIDE
Unknown config key "baseUrl" from env var "APP_CONFIG_BASE_URL". This env var is not consumed by the config schema.
Deployment will continue, but this config value is being ignored by the typed runtime config.
Add the key to the app config schema or remove the env var from Doppler.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING: UNKNOWN APP CONFIG OVERRIDE
Unknown config key "logs" from env var "APP_CONFIG_LOGS". This env var is not consumed by the config schema.
Deployment will continue, but this config value is being ignored by the typed runtime config.
Add the key to the app config schema or remove the env var from Doppler.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING: UNKNOWN APP CONFIG OVERRIDE
Unknown config key "posthog" from env var "APP_CONFIG_POSTHOG". This env var is not consumed by the config schema.
Deployment will continue, but this config value is being ignored by the typed runtime config.
Add the key to the app config schema or remove the env var from Doppler.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
/home/runner/work/iterate/iterate/packages/shared/src/config.ts:494
  configSchema.parse(rawConfig);
               ^

ZodError: [
  {
    "expected": "string",
    "code": "invalid_type",
    "path": [
      "authAppOrigin"
    ],
    "message": "Invalid input: expected string, received undefined"
  },
  {
    "expected": "string",
    "code": "invalid_type",
    "path": [
      "betterAuthSecret"
    ],
    "message": "Invalid input: expected string, received undefined"
  },
  {
    "expected": "string",
    "code": "invalid_type",
    "path": [
      "serviceAuthToken"
    ],
    "message": "Invalid input: expected string, received undefined"
  },
  {
    "expected": "string",
    "code": "invalid_type",
    "path": [
      "googleClientId"
    ],
    "message": "Invalid input: expected string, received undefined"
  },
  {
    "expected": "string",
    "code": "invalid_type",
    "path": [
      "googleClientSecret"
    ],
    "message": "Invalid input: expected string, received undefined"
  }
]
    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/config.ts:494:16)
    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:48:28)
    at &lt;anonymous&gt; (/home/runner/work/iterate/iterate/apps/auth/alchemy.run.ts:120:19)

Node.js v24.18.0


&gt; @iterate-com/auth@0.0.0-dev alchemy:down /home/runner/work/iterate/iterate/apps/auth
&gt; tsx ./alchemy.run.ts --destroy &amp;&amp; tsx ./alchemy.run.ts --park

 ELIFECYCLE  Command failed with exit code 1.</pre>

</details>
<!-- /CLOUDFLARE_PREVIEW -->