### PR TITLE
Add auth account chooser

### DIFF
--- a/apps/auth/src/routes/-login-account-chooser.tsx
+++ b/apps/auth/src/routes/-login-account-chooser.tsx
@@ -1,0 +1,235 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Avatar, AvatarFallback, AvatarImage } from "@iterate-com/ui/components/avatar";
+import { Button } from "@iterate-com/ui/components/button";
+import { toast } from "@iterate-com/ui/components/sonner";
+import { authClient } from "../utils/auth-client.ts";
+import { getInitials } from "../utils/initials.ts";
+
+export type LoginUser = {
+  id: string;
+  name: string | null;
+  email: string;
+  image: string | null;
+};
+
+type DeviceSession = Awaited<ReturnType<typeof authClient.multiSession.listDeviceSessions>>[number];
+
+const DEVICE_SESSIONS_QUERY_KEY = ["better-auth", "multi-session", "device-sessions"] as const;
+
+export function AccountChooser({
+  children,
+  currentUser,
+  continueWithAccount,
+  refreshCurrentPage,
+}: {
+  children: ReactNode;
+  currentUser: LoginUser;
+  continueWithAccount: () => void;
+  refreshCurrentPage: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [showLoginActions, setShowLoginActions] = useState(false);
+
+  const deviceSessionsQuery = useQuery({
+    queryKey: DEVICE_SESSIONS_QUERY_KEY,
+    queryFn: () => authClient.multiSession.listDeviceSessions(),
+  });
+
+  const setActiveSession = useMutation({
+    mutationFn: (sessionToken: string) => authClient.multiSession.setActive({ sessionToken }),
+    onSuccess: continueWithAccount,
+    onError: (error: Error) => {
+      toast.error(error.message || "Failed to switch account");
+    },
+  });
+
+  const revokeSession = useMutation({
+    mutationFn: (sessionToken: string) => authClient.multiSession.revoke({ sessionToken }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: DEVICE_SESSIONS_QUERY_KEY });
+      refreshCurrentPage();
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Failed to sign out account");
+    },
+  });
+
+  const signOutCurrentSession = useMutation({
+    mutationFn: () => authClient.signOut(),
+    onSuccess: refreshCurrentPage,
+    onError: (error: Error) => {
+      toast.error(error.message || "Failed to sign out account");
+    },
+  });
+
+  const isAccountActionPending =
+    revokeSession.isPending || signOutCurrentSession.isPending || setActiveSession.isPending;
+  const accounts = deviceSessionsQuery.isPending
+    ? []
+    : getAccountRows({ currentUser, sessions: deviceSessionsQuery.data ?? [] });
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        {deviceSessionsQuery.isPending ? (
+          <AccountStateMessage>Loading accounts...</AccountStateMessage>
+        ) : (
+          accounts.map((account) => {
+            const isCurrent = account.user.id === currentUser.id;
+            const token = account.token;
+            return (
+              <AccountRow
+                key={token ?? account.user.id}
+                user={account.user}
+                isCurrent={isCurrent}
+                isDisabled={isAccountActionPending}
+                isBusy={
+                  token !== null &&
+                  setActiveSession.isPending &&
+                  setActiveSession.variables === token
+                }
+                isRevoking={
+                  token === null
+                    ? signOutCurrentSession.isPending
+                    : revokeSession.isPending && revokeSession.variables === token
+                }
+                onContinue={() => {
+                  if (isCurrent || token === null) {
+                    continueWithAccount();
+                  } else {
+                    setActiveSession.mutate(token);
+                  }
+                }}
+                onSignOut={() => {
+                  if (token === null) {
+                    signOutCurrentSession.mutate();
+                  } else {
+                    revokeSession.mutate(token);
+                  }
+                }}
+              />
+            );
+          })
+        )}
+      </div>
+
+      {showLoginActions ? (
+        <div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+          {children}
+          <Button
+            className="w-full"
+            variant="ghost"
+            disabled={isAccountActionPending}
+            onClick={() => setShowLoginActions(false)}
+          >
+            Back to accounts
+          </Button>
+        </div>
+      ) : (
+        <Button
+          className="w-full"
+          variant="outline"
+          disabled={isAccountActionPending}
+          onClick={() => setShowLoginActions(true)}
+        >
+          Log in as someone else
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function getAccountRows({
+  currentUser,
+  sessions,
+}: {
+  currentUser: LoginUser;
+  sessions: DeviceSession[];
+}): Array<{ token: string | null; user: LoginUser }> {
+  const accounts = sessions.map((session) => ({
+    token: session.session.token,
+    user: toLoginUser(session.user),
+  }));
+
+  return accounts.some((account) => account.user.id === currentUser.id)
+    ? accounts
+    : [{ token: null, user: currentUser }, ...accounts];
+}
+
+function toLoginUser(user: DeviceSession["user"]): LoginUser {
+  return {
+    id: user.id,
+    name: user.name ?? null,
+    email: user.email,
+    image: user.image ?? null,
+  };
+}
+
+function AccountStateMessage({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-lg border bg-muted/30 p-4 text-sm text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+function AccountRow({
+  user,
+  isCurrent,
+  isDisabled,
+  isBusy,
+  isRevoking,
+  onContinue,
+  onSignOut,
+}: {
+  user: LoginUser;
+  isCurrent: boolean;
+  isDisabled: boolean;
+  isBusy: boolean;
+  isRevoking: boolean;
+  onContinue: () => void;
+  onSignOut: () => void;
+}) {
+  const initials = getInitials(user.name ?? user.email);
+
+  return (
+    <div className="rounded-lg border bg-muted/30 p-3 sm:flex sm:items-center sm:gap-3">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <Avatar>
+          {user.image && <AvatarImage src={user.image} alt={user.name ?? user.email} />}
+          <AvatarFallback>{initials}</AvatarFallback>
+        </Avatar>
+        <button
+          type="button"
+          className="min-w-0 flex-1 text-left"
+          disabled={isDisabled}
+          onClick={onContinue}
+        >
+          <span className="block truncate text-sm font-medium">{user.name ?? "User"}</span>
+          <span className="block truncate text-xs text-muted-foreground">{user.email}</span>
+        </button>
+        {isCurrent ? (
+          <span className="shrink-0 rounded-md bg-foreground px-2 py-1 text-xs font-medium text-background">
+            Current
+          </span>
+        ) : null}
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-2 sm:mt-0 sm:flex sm:shrink-0 sm:items-center">
+        <Button size="sm" className="w-full" disabled={isDisabled} onClick={onContinue}>
+          {isBusy ? "Switching..." : "Continue"}
+        </Button>
+        <Button
+          className="w-full"
+          variant="ghost"
+          size="sm"
+          disabled={isDisabled}
+          onClick={onSignOut}
+        >
+          {isRevoking ? "Signing out..." : "Sign out"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/auth/src/routes/login.tsx
+++ b/apps/auth/src/routes/login.tsx
@@ -3,7 +3,6 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import { useMutation } from "@tanstack/react-query";
 import { z } from "zod/v4";
-import { Avatar, AvatarFallback, AvatarImage } from "@iterate-com/ui/components/avatar";
 import { Button } from "@iterate-com/ui/components/button";
 import {
   Card,
@@ -19,7 +18,7 @@ import { Separator } from "@iterate-com/ui/components/separator";
 import { toast } from "@iterate-com/ui/components/sonner";
 import { parseConfig } from "../config.ts";
 import { authClient } from "../utils/auth-client.ts";
-import { getInitials } from "../utils/initials.ts";
+import { AccountChooser } from "./-login-account-chooser.tsx";
 
 // Runs on the server for both SSR and client navigations; the session comes
 // from the request cookie (utils/hono.ts). Only display fields are returned —
@@ -29,7 +28,9 @@ const getLoginState = createServerFn({ method: "GET" }).handler(({ context }) =>
   const user = context.variables.session?.user;
   return {
     emailOtpEnabled: parseConfig(context.cloudflare.env).emailOtpEnabled,
-    user: user ? { name: user.name ?? null, email: user.email, image: user.image ?? null } : null,
+    user: user
+      ? { id: user.id, name: user.name ?? null, email: user.email, image: user.image ?? null }
+      : null,
   };
 });
 
@@ -79,21 +80,31 @@ function RouteComponent() {
 
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
-      <Card className="w-full max-w-sm">
+      <Card className={signedInUser ? "w-full max-w-md" : "w-full max-w-sm"}>
         <CardHeader className="text-center">
           <CardTitle className="text-xl">
-            {signedInUser ? "Continue as this account" : "Sign in"}
+            {signedInUser ? "Choose an account" : "Sign in"}
           </CardTitle>
           <CardDescription>
             {signedInUser
-              ? "You're already signed in. Continue with this account or switch before authorizing the app."
+              ? "Continue with an Iterate account or sign in as someone else."
               : "Sign in to your Iterate account"}
           </CardDescription>
         </CardHeader>
         <Separator />
         <CardContent className="pt-6">
           {signedInUser ? (
-            <SignedInAccountCard redirectTo={redirectTo} user={signedInUser} />
+            <AccountChooser
+              currentUser={signedInUser}
+              continueWithAccount={() =>
+                window.location.assign(getPostLoginRedirectUrl(redirectTo))
+              }
+              refreshCurrentPage={() => {
+                window.location.assign(window.location.pathname + window.location.search);
+              }}
+            >
+              <LoginActions redirectTo={redirectTo} emailOtpEnabled={emailOtpEnabled} />
+            </AccountChooser>
           ) : (
             <LoginActions
               redirectTo={redirectTo}
@@ -103,59 +114,6 @@ function RouteComponent() {
           )}
         </CardContent>
       </Card>
-    </div>
-  );
-}
-
-function SignedInAccountCard({
-  redirectTo,
-  user,
-}: {
-  redirectTo: string;
-  user: { name: string | null; email: string; image: string | null };
-}) {
-  const initials = getInitials(user.name ?? user.email);
-  const switchAccount = useMutation({
-    mutationFn: () => authClient.signOut(),
-    onSuccess: () => {
-      window.location.assign(window.location.pathname + window.location.search);
-    },
-    onError: (error: Error) => {
-      toast.error(error.message || "Failed to switch account");
-    },
-  });
-
-  return (
-    <div className="space-y-4">
-      <div className="flex items-center gap-3 rounded-xl border bg-muted/30 p-4">
-        <Avatar>
-          {user.image && <AvatarImage src={user.image} alt={user.name ?? user.email} />}
-          <AvatarFallback>{initials}</AvatarFallback>
-        </Avatar>
-        <div className="min-w-0">
-          <p className="truncate text-sm font-medium">{user.name ?? "User"}</p>
-          <p className="truncate text-xs text-muted-foreground">{user.email}</p>
-        </div>
-      </div>
-
-      <div className="space-y-2">
-        <Button
-          className="w-full"
-          size="lg"
-          disabled={switchAccount.isPending}
-          onClick={() => window.location.assign(getPostLoginRedirectUrl(redirectTo))}
-        >
-          Continue with this account
-        </Button>
-        <Button
-          className="w-full"
-          variant="outline"
-          disabled={switchAccount.isPending}
-          onClick={() => switchAccount.mutate()}
-        >
-          {switchAccount.isPending ? "Switching..." : "Use another account"}
-        </Button>
-      </div>
     </div>
   );
 }

--- a/apps/auth/src/server/auth-plugins.ts
+++ b/apps/auth/src/server/auth-plugins.ts
@@ -1,5 +1,12 @@
 import { admin } from "better-auth/plugins/admin";
-import { bearer, deviceAuthorization, emailOTP, jwt, oneTimeToken } from "better-auth/plugins";
+import {
+  bearer,
+  deviceAuthorization,
+  emailOTP,
+  jwt,
+  multiSession,
+  oneTimeToken,
+} from "better-auth/plugins";
 import { oauthProvider } from "@better-auth/oauth-provider";
 import { organization } from "better-auth/plugins/organization";
 import {
@@ -79,6 +86,7 @@ export function getAuthPlugins(options: AuthPluginOptions) {
     bearer(),
     admin(),
     organization(),
+    multiSession({ maximumSessions: 10 }),
     deviceAuthorization({
       verificationUri: "/device",
       expiresIn: "15m",

--- a/apps/auth/src/server/auth.ts
+++ b/apps/auth/src/server/auth.ts
@@ -106,6 +106,7 @@ export const auth = betterAuth({
     google: {
       clientId: config.googleClientId,
       clientSecret: config.googleClientSecret.exposeSecret(),
+      prompt: "select_account",
     },
   },
   disabledPaths: ["/token"],

--- a/apps/auth/src/utils/auth-client.ts
+++ b/apps/auth/src/utils/auth-client.ts
@@ -1,15 +1,25 @@
 import { createAuthClient } from "better-auth/react";
 import { oauthProviderClient } from "@better-auth/oauth-provider/client";
-import { deviceAuthorizationClient, emailOTPClient } from "better-auth/client/plugins";
+import {
+  deviceAuthorizationClient,
+  emailOTPClient,
+  multiSessionClient,
+} from "better-auth/client/plugins";
 import { useRouteContext } from "@tanstack/react-router";
 
 // Only the client plugins the UI actually calls: oauth2.* (consent flows),
-// device.* (CLI authorization), emailOtp.* (sign-in). Organization/project
-// management goes through the typed oRPC client (utils/query.tsx), not
-// better-auth's organization client plugin.
+// device.* (CLI authorization), emailOtp.* (sign-in), and multiSession.* (the
+// OAuth account chooser). Organization/project management goes through the
+// typed oRPC client (utils/query.tsx), not better-auth's organization client
+// plugin.
 export const authClient = createAuthClient({
   baseURL: import.meta.env.VITE_AUTH_APP_ORIGIN,
-  plugins: [oauthProviderClient(), deviceAuthorizationClient(), emailOTPClient()],
+  plugins: [
+    oauthProviderClient(),
+    deviceAuthorizationClient(),
+    emailOTPClient(),
+    multiSessionClient(),
+  ],
   fetchOptions: { throw: true },
 });
 


### PR DESCRIPTION
## Summary
- add an OAuth interstitial account chooser for signed-in auth users
- enable better-auth multi-session server/client plugins so saved Iterate accounts can be listed, activated, or revoked
- prompt Google OAuth account selection when signing in as someone else

## Validation
- pnpm exec oxfmt apps/auth/src/routes/login.tsx apps/auth/src/routes/-login-account-chooser.tsx apps/auth/src/server/auth-plugins.ts apps/auth/src/server/auth.ts apps/auth/src/utils/auth-client.ts && pnpm --dir apps/auth typecheck
- pnpm exec oxlint apps/auth/src/routes/login.tsx apps/auth/src/routes/-login-account-chooser.tsx apps/auth/src/server/auth.ts apps/auth/src/server/auth-plugins.ts apps/auth/src/utils/auth-client.ts --deny-warnings
- pre-commit lint-staged oxfmt

## Notes
- Manual browser smoke was not completed because the auth dev server did not finish local Alchemy worker startup before I stopped it.
- I ran an extra strict quality pass inspired by the requested thermo-nuclear review and split the chooser out of login.tsx to keep route concerns smaller.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-03T21:18:13.763Z",
      "headSha": "2b669d4c2472124603f9d321a27b69b0b1c8a274",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/334103780381728",
      "shortSha": "2b669d4",
      "cleanupDurationMs": 87793,
      "deployDurationMs": 57999
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "cleanup-failed",
      "updatedAt": "2026-07-03T21:16:49.075Z",
      "headSha": "2b669d4c2472124603f9d321a27b69b0b1c8a274",
      "message": "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\nWARNING: UNKNOWN APP CONFIG OVERRIDE\nUnknown config key \"integrations\" from env var \"APP_CONFIG_INTEGRATIONS\". This env var is not consumed by the config schema.\nDeployment will continue, but this config value is being ignored by the typed runtime config.\nAdd the key to the app config schema or remove the env var from Doppler.\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\nWARNING: UNKNOWN APP CONFIG OVERRIDE\nUnknown config key \"baseUrl\" from env var \"APP_CONFIG_BASE_URL\". This env var is not consumed by the config schema.\nDeployment will continue, but this config value is being ignored by the typed runtime config.\nAdd the key to the app config schema or remove the env var from Doppler.\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\nWARNING: UNKNOWN APP CONFIG OVERRIDE\nUnknown config key \"logs\" from env var \"APP_CONFIG_LOGS\". This env var is not consumed by the config schema.\nDeployment will continue, but this config value is being ignored by the typed runtime config.\nAdd the key to the app config schema or remove the env var from Doppler.\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\nWARNING: UNKNOWN APP CONFIG OVERRIDE\nUnknown config key \"posthog\" from env var \"APP_CONFIG_POSTHOG\". This env var is not consumed by the config schema.\nDeployment will continue, but this config value is being ignored by the typed runtime config.\nAdd the key to the app config schema or remove the env var from Doppler.\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n/home/runner/work/iterate/iterate/packages/shared/src/config.ts:494\n  configSchema.parse(rawConfig);\n               ^\n\nZodError: [\n  {\n    \"expected\": \"string\",\n    \"code\": \"invalid_type\",\n    \"path\": [\n      \"authAppOrigin\"\n    ],\n    \"message\": \"Invalid input: expected string, received undefined\"\n  },\n  {\n    \"expected\": \"string\",\n    \"code\": \"invalid_type\",\n    \"path\": [\n      \"betterAuthSecret\"\n    ],\n    \"message\": \"Invalid input: expected string, received undefined\"\n  },\n  {\n    \"expected\": \"string\",\n    \"code\": \"invalid_type\",\n    \"path\": [\n      \"serviceAuthToken\"\n    ],\n    \"message\": \"Invalid input: expected string, received undefined\"\n  },\n  {\n    \"expected\": \"string\",\n    \"code\": \"invalid_type\",\n    \"path\": [\n      \"googleClientId\"\n    ],\n    \"message\": \"Invalid input: expected string, received undefined\"\n  },\n  {\n    \"expected\": \"string\",\n    \"code\": \"invalid_type\",\n    \"path\": [\n      \"googleClientSecret\"\n    ],\n    \"message\": \"Invalid input: expected string, received undefined\"\n  }\n]\n    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/config.ts:494:16)\n    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:48:28)\n    at <anonymous> (/home/runner/work/iterate/iterate/apps/auth/alchemy.run.ts:120:19)\n\nNode.js v24.18.0\n\n\n> @iterate-com/auth@0.0.0-dev alchemy:down /home/runner/work/iterate/iterate/apps/auth\n> tsx ./alchemy.run.ts --destroy && tsx ./alchemy.run.ts --park\n\n ELIFECYCLE  Command failed with exit code 1.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/334103780381728",
      "shortSha": "2b669d4",
      "cleanupDurationMs": 3101,
      "deployDurationMs": 2126
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_7",
    "leasedUntil": 1783199526011,
    "leaseId": "e9090805-c9ab-4b59-a3e3-cc96af621922",
    "slug": "preview-7",
    "type": "environment-config-lease"
  },
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>Lease: preview-7 | Doppler config: preview_7 | Type: environment-config-lease | Leased until: 2026-07-04T21:12:06.011Z</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | cleanup failed | `2b669d4` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 2.1s |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/334103780381728) | 2026-07-03T21:16:49.075Z | ZodError: [ |
| OS | released | `2b669d4` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 58.0s |  | 87.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/334103780381728) | 2026-07-03T21:18:13.763Z | Preview app released. |

</details>

<details>
<summary>Auth failure details</summary>

<pre>!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING: UNKNOWN APP CONFIG OVERRIDE
Unknown config key "integrations" from env var "APP_CONFIG_INTEGRATIONS". This env var is not consumed by the config schema.
Deployment will continue, but this config value is being ignored by the typed runtime config.
Add the key to the app config schema or remove the env var from Doppler.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING: UNKNOWN APP CONFIG OVERRIDE
Unknown config key "baseUrl" from env var "APP_CONFIG_BASE_URL". This env var is not consumed by the config schema.
Deployment will continue, but this config value is being ignored by the typed runtime config.
Add the key to the app config schema or remove the env var from Doppler.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING: UNKNOWN APP CONFIG OVERRIDE
Unknown config key "logs" from env var "APP_CONFIG_LOGS". This env var is not consumed by the config schema.
Deployment will continue, but this config value is being ignored by the typed runtime config.
Add the key to the app config schema or remove the env var from Doppler.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING: UNKNOWN APP CONFIG OVERRIDE
Unknown config key "posthog" from env var "APP_CONFIG_POSTHOG". This env var is not consumed by the config schema.
Deployment will continue, but this config value is being ignored by the typed runtime config.
Add the key to the app config schema or remove the env var from Doppler.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
/home/runner/work/iterate/iterate/packages/shared/src/config.ts:494
  configSchema.parse(rawConfig);
               ^

ZodError: [
  {
    "expected": "string",
    "code": "invalid_type",
    "path": [
      "authAppOrigin"
    ],
    "message": "Invalid input: expected string, received undefined"
  },
  {
    "expected": "string",
    "code": "invalid_type",
    "path": [
      "betterAuthSecret"
    ],
    "message": "Invalid input: expected string, received undefined"
  },
  {
    "expected": "string",
    "code": "invalid_type",
    "path": [
      "serviceAuthToken"
    ],
    "message": "Invalid input: expected string, received undefined"
  },
  {
    "expected": "string",
    "code": "invalid_type",
    "path": [
      "googleClientId"
    ],
    "message": "Invalid input: expected string, received undefined"
  },
  {
    "expected": "string",
    "code": "invalid_type",
    "path": [
      "googleClientSecret"
    ],
    "message": "Invalid input: expected string, received undefined"
  }
]
    at compileRawAppConfigFromEnv (/home/runner/work/iterate/iterate/packages/shared/src/config.ts:494:16)
    at initAlchemy (/home/runner/work/iterate/iterate/packages/shared/src/alchemy/init.ts:48:28)
    at &lt;anonymous&gt; (/home/runner/work/iterate/iterate/apps/auth/alchemy.run.ts:120:19)

Node.js v24.18.0


&gt; @iterate-com/auth@0.0.0-dev alchemy:down /home/runner/work/iterate/iterate/apps/auth
&gt; tsx ./alchemy.run.ts --destroy &amp;&amp; tsx ./alchemy.run.ts --park

 ELIFECYCLE  Command failed with exit code 1.</pre>

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session listing, activation, and revocation on the auth login/OAuth path; changes are localized but affect which account continues authorization.
> 
> **Overview**
> Replaces the OAuth signed-in **“continue as this account”** card with a **multi-account chooser** on the login page when the user is already signed in during an OAuth authorization flow (`sig` param).
> 
> A new **`AccountChooser`** component lists device sessions via **`multiSession.listDeviceSessions`**, lets users **continue**, **switch active session**, **revoke** other accounts, or **sign out** the current one, and exposes **“Log in as someone else”** by nesting the existing **`LoginActions`** (email/Google) UI.
> 
> **Server and client** wire up better-auth **`multiSession`** (cap **10** sessions) and **`multiSessionClient`**. Login loader now includes **`user.id`** for matching accounts. Google sign-in uses **`prompt: "select_account"`** so adding another account prompts account picker at Google.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b669d4c2472124603f9d321a27b69b0b1c8a274. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->