### PR TITLE
[codex] Remove legacy auth env fallbacks

### DIFF
--- a/apps/auth-example/.env.example
+++ b/apps/auth-example/.env.example
@@ -1,6 +1,6 @@
 # Copy to .dev.vars and fill in values
 # Make an oauth client in the auth app at /admin/clients
-ITERATE_OAUTH_ISSUER=http://localhost:7101/api/auth
-ITERATE_OAUTH_CLIENT_ID=
-ITERATE_OAUTH_CLIENT_SECRET=
-ITERATE_OAUTH_REDIRECT_URI=http://localhost:7201/api/iterate-auth/callback
+APP_CONFIG_ITERATE_AUTH__ISSUER=http://localhost:7101/api/auth
+APP_CONFIG_ITERATE_AUTH__CLIENT_ID=
+APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET=
+APP_CONFIG_ITERATE_AUTH__REDIRECT_URI=http://localhost:7201/api/iterate-auth/callback

--- a/apps/auth-example/src/worker.ts
+++ b/apps/auth-example/src/worker.ts
@@ -3,10 +3,10 @@ import { createIterateAuth } from "@iterate-com/auth/server";
 
 function authFromEnv(env: Cloudflare.Env) {
   return createIterateAuth({
-    clientId: env.ITERATE_OAUTH_CLIENT_ID,
-    clientSecret: env.ITERATE_OAUTH_CLIENT_SECRET,
-    redirectURI: env.ITERATE_OAUTH_REDIRECT_URI,
-    issuer: env.ITERATE_OAUTH_ISSUER,
+    clientId: env.APP_CONFIG_ITERATE_AUTH__CLIENT_ID,
+    clientSecret: env.APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET,
+    redirectURI: env.APP_CONFIG_ITERATE_AUTH__REDIRECT_URI,
+    issuer: env.APP_CONFIG_ITERATE_AUTH__ISSUER,
   });
 }
 

--- a/apps/auth-example/worker-configuration.d.ts
+++ b/apps/auth-example/worker-configuration.d.ts
@@ -6,10 +6,10 @@ declare namespace Cloudflare {
 	}
 	interface Env {
 		ASSETS: Fetcher;
-		ITERATE_OAUTH_ISSUER: string;
-		ITERATE_OAUTH_CLIENT_ID: string;
-		ITERATE_OAUTH_CLIENT_SECRET: string;
-		ITERATE_OAUTH_REDIRECT_URI: string;
+		APP_CONFIG_ITERATE_AUTH__ISSUER: string;
+		APP_CONFIG_ITERATE_AUTH__CLIENT_ID: string;
+		APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET: string;
+		APP_CONFIG_ITERATE_AUTH__REDIRECT_URI: string;
 	}
 }
 interface Env extends Cloudflare.Env {}

--- a/apps/auth/README.md
+++ b/apps/auth/README.md
@@ -152,18 +152,20 @@ move to a Workers RPC binding — see the note under "The three surfaces".)
 
 - A **session cookie** identifies a human; oRPC middlewares layer org/project
   membership checks on top.
-- The **service token** (`SERVICE_AUTH_TOKEN`) is a shared secret trusted by the
-  `internal.*` oRPC procedures — OS's runtime directory calls and deploy-time
-  scripts both present it. It also doubles as the seeded bootstrap admin's
-  password (`scripts/render-admin-seed.ts` writes that credential row), which is
-  how deploy scripts reach better-auth admin APIs that insist on a session.
+- The **service token** (`APP_CONFIG_SERVICE_AUTH_TOKEN` in Doppler) is a shared
+  secret trusted by the `internal.*` oRPC procedures — OS's runtime directory
+  calls and deploy-time scripts both present it. It also doubles as the seeded
+  bootstrap admin's password (`scripts/render-admin-seed.ts` writes that
+  credential row), which is how deploy scripts reach better-auth admin APIs that
+  insist on a session.
 
 ## Identity model
 
 - **Users** sign in with Google or email OTP (dev/preview always; prod behind
-  `VITE_ENABLE_EMAIL_OTP_SIGNIN`); password signup is disabled. `SIGNUP_ALLOWLIST`
-  gates who may sign up; `ADMIN_ALLOWLIST` (default `*@nustom.com`) promotes
-  matching emails to platform admin. The full model is documented in
+  `APP_CONFIG_EMAIL_OTP_ENABLED`); password signup is disabled.
+  `APP_CONFIG_SIGNUP_ALLOWLIST` gates who may sign up;
+  `APP_CONFIG_ADMIN_ALLOWLIST` (default `*@nustom.com`) promotes matching emails
+  to platform admin. The full model is documented in
   `src/server/platform-admin.ts`.
 - **Organizations & projects** live in auth's D1 and are the durable source of
   truth. OS keeps per-environment rows and re-adopts from auth after a reset;
@@ -219,11 +221,8 @@ fields); `alchemy.run.ts` calls the shared `initAlchemy()` which compiles
 `APP_CONFIG_*` Doppler vars (e.g. `APP_CONFIG_BETTER_AUTH_SECRET`,
 `APP_CONFIG_AUTH_APP_ORIGIN`) into a single `APP_CONFIG` worker binding. Server
 code reads `config.*` (from `server/env.ts`'s `parseConfig(env)`), never raw
-`env.*` — `env` now only carries the `DB` binding. `alchemy.run.ts` still
-accepts the legacy flat names (`BETTER_AUTH_SECRET`, `VITE_AUTH_APP_ORIGIN`, …)
-as a `?? <legacy>` fallback, and the browser bundle's own origin stays a
-build-time `import.meta.env.VITE_AUTH_APP_ORIGIN` (a Vite-inlined client
-concern, like os's `VITE_APP_STAGE`) — so both names live in Doppler.
+`env.*` — `env` now only carries the `DB` binding. The browser bundle's own
+origin is inlined from `APP_CONFIG_AUTH_APP_ORIGIN` at build time.
 
 ## Deployment
 

--- a/apps/auth/alchemy.run.ts
+++ b/apps/auth/alchemy.run.ts
@@ -82,39 +82,33 @@ process.env.VITE_APP_STAGE ||= alchemyEnv.ALCHEMY_STAGE;
 // Email OTP is on for dev stages by default; an explicit Doppler value wins.
 const emailOtpEnabled =
   process.env.APP_CONFIG_EMAIL_OTP_ENABLED ??
-  process.env.VITE_ENABLE_EMAIL_OTP_SIGNIN?.trim() ??
   (alchemyEnv.ALCHEMY_STAGE.startsWith("dev") ? "true" : "false");
 
-// Map the auth config into `APP_CONFIG_*` env vars for initAlchemy. New Doppler
-// configs set these directly; the `?? <legacy>` fallbacks let existing configs
-// (and the client's build-time `VITE_AUTH_APP_ORIGIN`) keep working through the
-// transition — the same pattern apps/os uses. See src/config.ts for the schema.
+const deployEnvWithoutAppConfig = Object.fromEntries(
+  Object.entries(process.env).filter(
+    ([key]) => key !== "APP_CONFIG" && !key.startsWith("APP_CONFIG_"),
+  ),
+);
+
+// Map the auth config into `APP_CONFIG_*` env vars for initAlchemy. Doppler
+// configs are expected to set the typed AppConfig names directly.
 const configEnv: Record<string, string | undefined> = {
-  ...process.env,
+  ...deployEnvWithoutAppConfig,
   // initAlchemy requires ALCHEMY_LOCAL; the old auth schema defaulted it to
   // non-local when unset (only `alchemy dev` sets it true).
   ALCHEMY_LOCAL: process.env.ALCHEMY_LOCAL ?? "false",
-  APP_CONFIG_AUTH_APP_ORIGIN:
-    process.env.APP_CONFIG_AUTH_APP_ORIGIN ?? process.env.VITE_AUTH_APP_ORIGIN,
-  APP_CONFIG_PUBLIC_URL:
-    process.env.APP_CONFIG_PUBLIC_URL ??
-    process.env.VITE_PUBLIC_URL ??
-    process.env.VITE_AUTH_APP_ORIGIN,
-  APP_CONFIG_BETTER_AUTH_SECRET:
-    process.env.APP_CONFIG_BETTER_AUTH_SECRET ?? process.env.BETTER_AUTH_SECRET,
-  APP_CONFIG_SERVICE_AUTH_TOKEN:
-    process.env.APP_CONFIG_SERVICE_AUTH_TOKEN ?? process.env.SERVICE_AUTH_TOKEN,
-  APP_CONFIG_GOOGLE_CLIENT_ID:
-    process.env.APP_CONFIG_GOOGLE_CLIENT_ID ?? process.env.GOOGLE_CLIENT_ID,
-  APP_CONFIG_GOOGLE_CLIENT_SECRET:
-    process.env.APP_CONFIG_GOOGLE_CLIENT_SECRET ?? process.env.GOOGLE_CLIENT_SECRET,
-  APP_CONFIG_RESEND_DOMAIN: process.env.APP_CONFIG_RESEND_DOMAIN ?? process.env.RESEND_BOT_DOMAIN,
-  APP_CONFIG_RESEND_API_KEY:
-    process.env.APP_CONFIG_RESEND_API_KEY ?? process.env.RESEND_BOT_API_KEY,
-  APP_CONFIG_SIGNUP_ALLOWLIST:
-    process.env.APP_CONFIG_SIGNUP_ALLOWLIST ?? process.env.SIGNUP_ALLOWLIST,
-  APP_CONFIG_ADMIN_ALLOWLIST: process.env.APP_CONFIG_ADMIN_ALLOWLIST ?? process.env.ADMIN_ALLOWLIST,
+  APP_CONFIG_AUTH_APP_ORIGIN: process.env.APP_CONFIG_AUTH_APP_ORIGIN,
+  APP_CONFIG_PUBLIC_URL: process.env.APP_CONFIG_PUBLIC_URL,
+  APP_CONFIG_BETTER_AUTH_SECRET: process.env.APP_CONFIG_BETTER_AUTH_SECRET,
+  APP_CONFIG_SERVICE_AUTH_TOKEN: process.env.APP_CONFIG_SERVICE_AUTH_TOKEN,
+  APP_CONFIG_GOOGLE_CLIENT_ID: process.env.APP_CONFIG_GOOGLE_CLIENT_ID,
+  APP_CONFIG_GOOGLE_CLIENT_SECRET: process.env.APP_CONFIG_GOOGLE_CLIENT_SECRET,
+  APP_CONFIG_RESEND_DOMAIN: process.env.APP_CONFIG_RESEND_DOMAIN,
+  APP_CONFIG_RESEND_API_KEY: process.env.APP_CONFIG_RESEND_API_KEY,
+  APP_CONFIG_SIGNUP_ALLOWLIST: process.env.APP_CONFIG_SIGNUP_ALLOWLIST,
+  APP_CONFIG_ADMIN_ALLOWLIST: process.env.APP_CONFIG_ADMIN_ALLOWLIST,
   APP_CONFIG_EMAIL_OTP_ENABLED: emailOtpEnabled,
+  APP_CONFIG_PROJECT_HOSTNAME_BASE: process.env.APP_CONFIG_PROJECT_HOSTNAME_BASE,
 };
 
 const ctx = await initAlchemy(APP_NAME, AppConfig, configEnv);
@@ -127,8 +121,8 @@ const primaryUrl = alchemyEnv.WORKER_ROUTES[0]
 await Exec("render-admin-seed", {
   command: `tsx ./scripts/render-admin-seed.ts ${ADMIN_SEED_SQL_PATH}`,
   env: {
-    SERVICE_AUTH_TOKEN: alchemy.secret(runtimeConfig.serviceAuthToken.exposeSecret()),
-    ADMIN_ALLOWLIST: runtimeConfig.adminAllowlist,
+    APP_CONFIG_SERVICE_AUTH_TOKEN: alchemy.secret(runtimeConfig.serviceAuthToken.exposeSecret()),
+    APP_CONFIG_ADMIN_ALLOWLIST: runtimeConfig.adminAllowlist,
   },
   cwd: import.meta.dirname,
 });

--- a/apps/auth/scripts/render-admin-seed.ts
+++ b/apps/auth/scripts/render-admin-seed.ts
@@ -25,7 +25,7 @@ function escapeSqlString(value: string) {
 function allowlistPatternToSqlLike(pattern: string) {
   if (!/^[a-z0-9*?@._+-]+$/.test(pattern)) {
     throw new Error(
-      `ADMIN_ALLOWLIST pattern "${pattern}" uses minimatch syntax the deploy-time SQL ` +
+      `APP_CONFIG_ADMIN_ALLOWLIST pattern "${pattern}" uses minimatch syntax the deploy-time SQL ` +
         `backfill cannot translate; only the * and ? wildcards are supported.`,
     );
   }
@@ -78,12 +78,12 @@ async function main() {
     throw new Error("Output path is required");
   }
 
-  const serviceAuthToken = process.env.SERVICE_AUTH_TOKEN?.trim();
+  const serviceAuthToken = process.env.APP_CONFIG_SERVICE_AUTH_TOKEN?.trim();
   if (!serviceAuthToken) {
-    throw new Error("SERVICE_AUTH_TOKEN is required");
+    throw new Error("APP_CONFIG_SERVICE_AUTH_TOKEN is required");
   }
 
-  const platformAdminAllowlist = parseSignupAllowlist(process.env.ADMIN_ALLOWLIST ?? "");
+  const platformAdminAllowlist = parseSignupAllowlist(process.env.APP_CONFIG_ADMIN_ALLOWLIST ?? "");
 
   const outputPath = resolve(outputPathArg);
   mkdirSync(dirname(outputPath), { recursive: true });

--- a/apps/auth/scripts/seed-oauth-clients.test.ts
+++ b/apps/auth/scripts/seed-oauth-clients.test.ts
@@ -12,38 +12,25 @@ const clientsJson = JSON.stringify([
 ]);
 
 describe("SeedOAuthClientsEnv", () => {
-  it("prefers AppConfig service token and auth origin over legacy env vars", () => {
+  it("reads the AppConfig service token and auth origin", () => {
     const env = SeedOAuthClientsEnv.parse({
       AUTH_SEED_OAUTH_CLIENTS: clientsJson,
       APP_CONFIG_SERVICE_AUTH_TOKEN: "app-config-token",
-      SERVICE_AUTH_TOKEN: "legacy-token",
       APP_CONFIG_AUTH_APP_ORIGIN: "https://auth.example.com",
-      VITE_AUTH_APP_ORIGIN: "https://legacy-auth.example.com",
     });
 
-    assert.equal(env.SERVICE_AUTH_TOKEN, "app-config-token");
-    assert.equal(env.VITE_AUTH_APP_ORIGIN, "https://auth.example.com");
+    assert.equal(env.serviceAuthToken, "app-config-token");
+    assert.equal(env.authAppOrigin, "https://auth.example.com");
   });
 
-  it("falls back to legacy service token and auth origin", () => {
-    const env = SeedOAuthClientsEnv.parse({
-      AUTH_SEED_OAUTH_CLIENTS: clientsJson,
-      SERVICE_AUTH_TOKEN: "legacy-token",
-      VITE_AUTH_APP_ORIGIN: "https://legacy-auth.example.com",
-    });
-
-    assert.equal(env.SERVICE_AUTH_TOKEN, "legacy-token");
-    assert.equal(env.VITE_AUTH_APP_ORIGIN, "https://legacy-auth.example.com");
-  });
-
-  it("requires a service token from AppConfig or legacy env vars", () => {
+  it("requires an AppConfig service token", () => {
     assert.throws(
       () =>
         SeedOAuthClientsEnv.parse({
           AUTH_SEED_OAUTH_CLIENTS: clientsJson,
-          VITE_AUTH_APP_ORIGIN: "https://legacy-auth.example.com",
+          APP_CONFIG_AUTH_APP_ORIGIN: "https://auth.example.com",
         }),
-      /APP_CONFIG_SERVICE_AUTH_TOKEN or SERVICE_AUTH_TOKEN is required/,
+      /APP_CONFIG_SERVICE_AUTH_TOKEN is required/,
     );
   });
 });

--- a/apps/auth/scripts/seed-oauth-clients.ts
+++ b/apps/auth/scripts/seed-oauth-clients.ts
@@ -52,36 +52,34 @@ export const SeedOAuthClientsEnv = z
       })
       .pipe(z.array(SeedOAuthClientSpec)),
     APP_CONFIG_SERVICE_AUTH_TOKEN: OptionalNonEmptyString,
-    SERVICE_AUTH_TOKEN: OptionalNonEmptyString,
     // The deployed auth origin to seed, e.g. https://auth.iterate-dev.com.
     APP_CONFIG_AUTH_APP_ORIGIN: OptionalUrl,
-    VITE_AUTH_APP_ORIGIN: OptionalUrl,
   })
   .transform((env, ctx) => {
-    const serviceAuthToken = env.APP_CONFIG_SERVICE_AUTH_TOKEN ?? env.SERVICE_AUTH_TOKEN;
+    const serviceAuthToken = env.APP_CONFIG_SERVICE_AUTH_TOKEN;
     if (!serviceAuthToken) {
       ctx.addIssue({
         code: "custom",
         path: ["APP_CONFIG_SERVICE_AUTH_TOKEN"],
-        message: "APP_CONFIG_SERVICE_AUTH_TOKEN or SERVICE_AUTH_TOKEN is required",
+        message: "APP_CONFIG_SERVICE_AUTH_TOKEN is required",
       });
       return z.NEVER;
     }
 
-    const authAppOrigin = env.APP_CONFIG_AUTH_APP_ORIGIN ?? env.VITE_AUTH_APP_ORIGIN;
+    const authAppOrigin = env.APP_CONFIG_AUTH_APP_ORIGIN;
     if (!authAppOrigin) {
       ctx.addIssue({
         code: "custom",
         path: ["APP_CONFIG_AUTH_APP_ORIGIN"],
-        message: "APP_CONFIG_AUTH_APP_ORIGIN or VITE_AUTH_APP_ORIGIN is required",
+        message: "APP_CONFIG_AUTH_APP_ORIGIN is required",
       });
       return z.NEVER;
     }
 
     return {
-      AUTH_SEED_OAUTH_CLIENTS: env.AUTH_SEED_OAUTH_CLIENTS,
-      SERVICE_AUTH_TOKEN: serviceAuthToken,
-      VITE_AUTH_APP_ORIGIN: authAppOrigin,
+      authAppOrigin,
+      clients: env.AUTH_SEED_OAUTH_CLIENTS,
+      serviceAuthToken,
     };
   });
 
@@ -115,18 +113,14 @@ export async function seedOAuthClients(
   if (!parsed.success) {
     throw new Error(`seed-oauth-clients env invalid: ${z.prettifyError(parsed.error)}`);
   }
-  const {
-    AUTH_SEED_OAUTH_CLIENTS: clients,
-    SERVICE_AUTH_TOKEN,
-    VITE_AUTH_APP_ORIGIN,
-  } = parsed.data;
-  const seedThroughUrl = opts.baseUrl?.trim() || VITE_AUTH_APP_ORIGIN;
+  const { authAppOrigin, clients, serviceAuthToken } = parsed.data;
+  const seedThroughUrl = opts.baseUrl?.trim() || authAppOrigin;
 
   await waitForAuthDeployment(seedThroughUrl);
 
   const authClient = createAuthContractClient({
     baseUrl: seedThroughUrl,
-    serviceToken: SERVICE_AUTH_TOKEN,
+    serviceToken: serviceAuthToken,
   });
 
   for (const spec of clients) {

--- a/apps/auth/src/config.ts
+++ b/apps/auth/src/config.ts
@@ -12,10 +12,8 @@ import { z } from "zod/v4";
  * be unwrapped with `.exposeSecret()` and never serialize their value. Plain
  * fields (allowlists) are server-only but not secret.
  *
- * Note: the browser bundle's own origin still comes from the build-time
- * `import.meta.env.VITE_AUTH_APP_ORIGIN` (utils/auth-client.ts, utils/query.tsx)
- * — that is a Vite-inlined client concern, separate from this runtime config,
- * the same way apps/os keeps `VITE_APP_STAGE` as a build var.
+ * Note: the browser bundle's own origin is inlined from
+ * `APP_CONFIG_AUTH_APP_ORIGIN` by vite.config.ts.
  */
 export const AppConfig = z.object({
   /** Public origin the auth worker is served from — better-auth `baseURL`, CORS

--- a/apps/auth/src/server/orpc/routers/internal.ts
+++ b/apps/auth/src/server/orpc/routers/internal.ts
@@ -408,7 +408,7 @@ const ensureOAuthClient = os.internal.oauth.ensureClient
     const serviceAuthToken = config.serviceAuthToken.exposeSecret().trim();
     if (!serviceAuthToken) {
       throw new ORPCError("INTERNAL_SERVER_ERROR", {
-        message: "SERVICE_AUTH_TOKEN is required for bootstrap OAuth client provisioning",
+        message: "config.serviceAuthToken is required for bootstrap OAuth client provisioning",
       });
     }
 
@@ -495,7 +495,7 @@ const setOAuthClient = os.internal.oauth.setClient
       const serviceAuthToken = config.serviceAuthToken.exposeSecret().trim();
       if (!serviceAuthToken) {
         throw new ORPCError("INTERNAL_SERVER_ERROR", {
-          message: "SERVICE_AUTH_TOKEN is required for OAuth client provisioning",
+          message: "config.serviceAuthToken is required for OAuth client provisioning",
         });
       }
       const headers = await getBootstrapAdminAuthHeaders({ serviceAuthToken });

--- a/apps/auth/src/server/platform-admin.ts
+++ b/apps/auth/src/server/platform-admin.ts
@@ -10,7 +10,7 @@
  *   (auth-plugins.ts).
  *
  * The role is granted three ways:
- * - the signup hook in auth.ts, for emails matching ADMIN_ALLOWLIST
+ * - the signup hook in auth.ts, for emails matching `config.adminAllowlist`
  *   (default `*@nustom.com`),
  * - the deploy-time seed SQL, which
  *   backfills users who existed before their email domain was allowlisted —

--- a/apps/auth/src/utils/auth-app-origin.ts
+++ b/apps/auth/src/utils/auth-app-origin.ts
@@ -1,0 +1,13 @@
+declare const __AUTH_APP_ORIGIN__: string | undefined;
+
+export function getAuthAppOrigin() {
+  if (typeof __AUTH_APP_ORIGIN__ === "string" && __AUTH_APP_ORIGIN__.trim()) {
+    return __AUTH_APP_ORIGIN__.trim();
+  }
+
+  if (typeof window !== "undefined") {
+    return window.location.origin;
+  }
+
+  throw new Error("APP_CONFIG_AUTH_APP_ORIGIN is required for server-side auth requests.");
+}

--- a/apps/auth/src/utils/auth-client.ts
+++ b/apps/auth/src/utils/auth-client.ts
@@ -6,6 +6,7 @@ import {
   multiSessionClient,
 } from "better-auth/client/plugins";
 import { useRouteContext } from "@tanstack/react-router";
+import { getAuthAppOrigin } from "./auth-app-origin.ts";
 
 // Only the client plugins the UI actually calls: oauth2.* (consent flows),
 // device.* (CLI authorization), emailOtp.* (sign-in), and multiSession.* (the
@@ -13,7 +14,7 @@ import { useRouteContext } from "@tanstack/react-router";
 // typed oRPC client (utils/query.tsx), not better-auth's organization client
 // plugin.
 export const authClient = createAuthClient({
-  baseURL: import.meta.env.VITE_AUTH_APP_ORIGIN,
+  baseURL: getAuthAppOrigin(),
   plugins: [
     oauthProviderClient(),
     deviceAuthorizationClient(),

--- a/apps/auth/src/utils/query.tsx
+++ b/apps/auth/src/utils/query.tsx
@@ -5,6 +5,7 @@ import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { RPCLink } from "@orpc/client/fetch";
 import type { RouterClient } from "@orpc/server";
 import type { AppRouter } from "../server/orpc/index.ts";
+import { getAuthAppOrigin } from "./auth-app-origin.ts";
 
 const queryClientOptions: QueryClientConfig = {
   defaultOptions: {
@@ -23,7 +24,7 @@ export const makeQueryClient = createIsomorphicFn()
 const link = new RPCLink({
   url: new URL(
     "/api/orpc",
-    import.meta.env.SSR ? import.meta.env.VITE_AUTH_APP_ORIGIN : window.location.origin,
+    typeof window === "undefined" ? getAuthAppOrigin() : window.location.origin,
   ).toString(),
 });
 

--- a/apps/auth/vite.config.ts
+++ b/apps/auth/vite.config.ts
@@ -4,7 +4,12 @@ import alchemy from "alchemy/cloudflare/vite";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 
+const authAppOrigin = process.env.APP_CONFIG_AUTH_APP_ORIGIN?.trim() ?? "";
+
 export default defineConfig({
+  define: {
+    __AUTH_APP_ORIGIN__: JSON.stringify(authAppOrigin),
+  },
   server: {
     cors: {
       origin: (origin, cb) => cb(null as unknown as Error, origin ?? true),

--- a/apps/os/alchemy.run.ts
+++ b/apps/os/alchemy.run.ts
@@ -70,8 +70,7 @@ if (process.argv.includes("--park")) {
   process.exit(0);
 }
 
-const resolvedAuthIssuer =
-  process.env.APP_CONFIG_ITERATE_AUTH__ISSUER ?? process.env.ITERATE_OAUTH_ISSUER;
+const resolvedAuthIssuer = process.env.APP_CONFIG_ITERATE_AUTH__ISSUER;
 
 // A static JWKS lets the worker verify auth JWTs without any runtime
 // roundtrip to the auth worker, including on cold isolate starts. Fetch it
@@ -117,7 +116,7 @@ async function resolveStaticAuthJwks(issuer: string | undefined) {
   }
   const issuerIsLoopback = ["localhost", "127.0.0.1", "::1"].includes(issuerUrl.hostname);
 
-  const explicit = process.env.APP_CONFIG_ITERATE_AUTH__JWKS ?? process.env.ITERATE_AUTH_JWKS;
+  const explicit = process.env.APP_CONFIG_ITERATE_AUTH__JWKS;
   if (explicit && !issuerIsLoopback) return withForgePublicKey(explicit);
 
   try {
@@ -203,17 +202,13 @@ function withForgePublicKey(jwksJson: string) {
 const env: Record<string, string | undefined> = {
   ...process.env,
   APP_CONFIG_ITERATE_AUTH__ISSUER: resolvedAuthIssuer,
-  APP_CONFIG_ITERATE_AUTH__CLIENT_ID:
-    process.env.APP_CONFIG_ITERATE_AUTH__CLIENT_ID ?? process.env.ITERATE_OAUTH_CLIENT_ID,
-  APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET:
-    process.env.APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET ?? process.env.ITERATE_OAUTH_CLIENT_SECRET,
+  APP_CONFIG_ITERATE_AUTH__CLIENT_ID: process.env.APP_CONFIG_ITERATE_AUTH__CLIENT_ID,
+  APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET: process.env.APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET,
   APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED:
     process.env.APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED ??
-    process.env.VITE_ENABLE_EMAIL_OTP_SIGNIN ??
     (process.env.ALCHEMY_STAGE?.startsWith("dev") ? "true" : undefined),
   APP_CONFIG_ITERATE_AUTH__JWKS: await resolveStaticAuthJwks(resolvedAuthIssuer),
-  APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN:
-    process.env.APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN ?? process.env.ITERATE_AUTH_SERVICE_TOKEN,
+  APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN: process.env.APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN,
 };
 
 // Fully-local dev: no Cloudflare resources. Picks a free port and writes

--- a/apps/os/docs/architecture-and-operations.md
+++ b/apps/os/docs/architecture-and-operations.md
@@ -177,12 +177,12 @@ managed by `scripts/sync-auth-clients.ts` (`pnpm auth:sync-clients`). For each
 target Doppler config (`dev_<name>`, `preview_1`–`preview_9`, `prd`) it
 ensures two OAuth clients (web + MCP/CLI) via the auth contract's
 `internal.oauth.ensureClient`, then writes `APP_CONFIG_BASE_URL`,
-`APP_CONFIG_MCP__BASE_URL`, `APP_CONFIG_PROJECT_HOSTNAME_BASES`, and the
-`ITERATE_OAUTH_*` / `ITERATE_MCP_OAUTH_*` values back to Doppler. It also
-copies the live auth worker JWKS into `ITERATE_AUTH_JWKS` so the next OS deploy
+`APP_CONFIG_MCP__BASE_URL`, `APP_CONFIG_PROJECT_HOSTNAME_BASES`, and
+`APP_CONFIG_ITERATE_AUTH__*` values back to Doppler. It also copies the live
+auth worker JWKS into `APP_CONFIG_ITERATE_AUTH__JWKS` so the next OS deploy
 bakes keys that can verify tokens issued by the current auth worker.
 
-It requires `SERVICE_AUTH_TOKEN` (run through Doppler for the auth project).
+It requires `APP_CONFIG_SERVICE_AUTH_TOKEN` (run through Doppler for the auth project).
 `AUTH_CLIENT_SYNC_TARGETS` filters targets;
 `ROTATE_AUTH_CLIENT_SECRETS=1` rotates client secrets.
 

--- a/apps/os/docs/headless-local-debugging.md
+++ b/apps/os/docs/headless-local-debugging.md
@@ -24,8 +24,8 @@ a _deployed_ preview against _production_ auth.
 pnpm dev-all   # monorepo root: starts apps/auth (localhost:7101) AND apps/os (localhost)
 ```
 
-`pnpm dev-all` exports `ITERATE_OAUTH_ISSUER=http://localhost:7101/api/auth` and
-points OS at it. OS writes its chosen base URL to
+`pnpm dev-all` points OS at the local auth issuer through
+`APP_CONFIG_ITERATE_AUTH__ISSUER`. OS writes its chosen base URL to
 `apps/os/.alchemy/dev-server.json`; drive the browser against that localhost
 URL.
 
@@ -70,7 +70,7 @@ Local/non-prod auth enables email OTP and a deterministic code:
 
 - Any email matching `/\+.*test@/i` skips email send and accepts OTP **`424242`**
   (see `apps/auth/src/server/auth-plugins.ts`).
-- Sign-_up_ is gated by `SIGNUP_ALLOWLIST` (auth Doppler). The local list allows
+- Sign-_up_ is gated by `APP_CONFIG_SIGNUP_ALLOWLIST` (auth Doppler). The local list allows
   `*@nustom.com`, `testuser+*@gmail.com`, etc. A brand-new email outside the
   allowlist returns `403 "Sign up is not available for this email address"`, so
   use e.g. `testuser+<scenario>@gmail.com`.

--- a/apps/os/docs/preview-agent-browser-smoke.md
+++ b/apps/os/docs/preview-agent-browser-smoke.md
@@ -84,14 +84,14 @@ resulting session cookies, then let the OAuth flow complete:
    echo it:
 
    ```bash
-   export SECRET=$(doppler secrets get SERVICE_AUTH_TOKEN --project auth --config prd --plain)
+   export SECRET=$(doppler secrets get APP_CONFIG_SERVICE_AUTH_TOKEN --project auth --config prd --plain)
    curl -s -c /tmp/auth.txt -X POST https://auth.iterate.com/api/auth/sign-in/email \
      -H 'content-type: application/json' \
      --data "$(python3 -c 'import json,os;print(json.dumps({"email":"admin@nustom.com","password":os.environ["SECRET"]}))')"
    ```
 
    - email: `admin@nustom.com` (`BOOTSTRAP_ADMIN_EMAIL`)
-   - password: the auth worker's `SERVICE_AUTH_TOKEN` (Doppler `auth/prd`)
+   - password: the auth worker's `APP_CONFIG_SERVICE_AUTH_TOKEN` (Doppler `auth/prd`)
 
 2. **Inject the `__Secure-better-auth.session_{token,data}` cookies** into the
    browser (`AB cookies set --curl <json>`; the jar uses `#HttpOnly_` lines —

--- a/apps/os/e2e/vitest/mcp-oauth.e2e.test.ts
+++ b/apps/os/e2e/vitest/mcp-oauth.e2e.test.ts
@@ -20,7 +20,7 @@ import { requireBaseUrl as requireOsBaseUrl } from "../test-support/os-client.ts
 //     project, and `exec_js` shows up)
 //
 // It needs a Better Auth browser session, which without a browser means the
-// bootstrap-admin email/password (the auth worker's SERVICE_AUTH_TOKEN). That
+// bootstrap-admin email/password (the auth worker's AppConfig service token). That
 // secret lives in the auth Doppler config, not the OS one, so the test skips
 // cleanly when it is absent (mirroring the preview smoke's admin-secret gate).
 // To run it against a preview slot:
@@ -106,9 +106,11 @@ function authClient(authOrigin: string) {
 }
 
 test("project MCP OAuth opaque-token flow", async () => {
-  const password = process.env.SERVICE_AUTH_TOKEN?.trim() || null;
+  const password = process.env.APP_CONFIG_SERVICE_AUTH_TOKEN?.trim() || null;
   if (!password) {
-    console.log("Skipping MCP OAuth e2e: SERVICE_AUTH_TOKEN not present in this environment.");
+    console.log(
+      "Skipping MCP OAuth e2e: APP_CONFIG_SERVICE_AUTH_TOKEN not present in this environment.",
+    );
     return;
   }
 

--- a/apps/os/scripts/sync-auth-clients.ts
+++ b/apps/os/scripts/sync-auth-clients.ts
@@ -38,12 +38,15 @@ const targets: Target[] = [
   },
 ];
 
-const authIssuer = process.env.ITERATE_OAUTH_ISSUER?.trim() || "https://auth.iterate.com/api/auth";
+const configuredAuthOrigin = process.env.APP_CONFIG_AUTH_APP_ORIGIN?.trim();
+const authIssuer = configuredAuthOrigin
+  ? `${configuredAuthOrigin.replace(/\/+$/, "")}/api/auth`
+  : "https://auth.iterate.com/api/auth";
 const authBaseUrl =
   process.env.AUTH_BASE_URL?.trim() ||
-  process.env.VITE_AUTH_APP_ORIGIN?.trim() ||
+  process.env.APP_CONFIG_AUTH_APP_ORIGIN?.trim() ||
   new URL(authIssuer).origin;
-const serviceToken = process.env.SERVICE_AUTH_TOKEN?.trim();
+const serviceToken = process.env.APP_CONFIG_SERVICE_AUTH_TOKEN?.trim();
 const authDopplerProject = process.env.DOPPLER_PROJECT?.trim() || "auth";
 const authDopplerConfig = process.env.DOPPLER_CONFIG?.trim() || "prd";
 const targetFilter = new Set(
@@ -56,7 +59,7 @@ const rotateClientSecrets = process.env.ROTATE_AUTH_CLIENT_SECRETS === "1";
 
 if (!serviceToken) {
   throw new Error(
-    "SERVICE_AUTH_TOKEN is required. Run through Doppler for auth prd, for example: doppler run --project auth --config prd -- pnpm --dir apps/os tsx scripts/sync-auth-clients.ts",
+    "APP_CONFIG_SERVICE_AUTH_TOKEN is required. Run through Doppler for auth prd, for example: doppler run --project auth --config prd -- pnpm --dir apps/os tsx scripts/sync-auth-clients.ts",
   );
 }
 
@@ -72,8 +75,11 @@ for (const target of targets) {
   const webRedirectUri = `${target.baseUrl}/api/iterate-auth/callback`;
   const webReferenceId = `os:${target.dopplerConfig}:web`;
   const webClientName = `OS ${target.dopplerConfig} web`;
-  const existingWebClientId = getDopplerSecret(target, "ITERATE_OAUTH_CLIENT_ID");
-  const existingWebClientSecret = getDopplerSecret(target, "ITERATE_OAUTH_CLIENT_SECRET");
+  const existingWebClientId = getDopplerSecret(target, "APP_CONFIG_ITERATE_AUTH__CLIENT_ID");
+  const existingWebClientSecret = getDopplerSecret(
+    target,
+    "APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET",
+  );
   const webClient = await authClient.internal.oauth.ensureClient({
     referenceId: webReferenceId,
     clientName: webClientName,
@@ -91,14 +97,15 @@ for (const target of targets) {
     "http://127.0.0.1:3334/callback",
     "http://localhost:3334/callback",
   ];
-  const existingMcpClientId = getDopplerSecret(target, "ITERATE_MCP_OAUTH_CLIENT_ID");
-  const existingMcpClientSecret = getDopplerSecret(target, "ITERATE_MCP_OAUTH_CLIENT_SECRET");
+  const existingMcpSeed = seedOAuthClients.find(
+    (candidate) => candidate.referenceId === mcpReferenceId,
+  );
   const mcpClient = await authClient.internal.oauth.ensureClient({
     referenceId: mcpReferenceId,
     clientName: mcpClientName,
     redirectURIs: mcpRedirectURIs,
-    existingClientId: existingMcpClientId,
-    existingClientSecret: existingMcpClientSecret,
+    existingClientId: existingMcpSeed?.clientId,
+    existingClientSecret: existingMcpSeed?.clientSecret,
     rotateClientSecret: rotateClientSecrets,
   });
 
@@ -106,14 +113,11 @@ for (const target of targets) {
     APP_CONFIG_BASE_URL: target.baseUrl,
     APP_CONFIG_MCP__BASE_URL: target.mcpBaseUrl,
     APP_CONFIG_PROJECT_HOSTNAME_BASES: JSON.stringify([target.projectHostnameBase]),
-    ITERATE_OAUTH_ISSUER: authIssuer,
-    ITERATE_OAUTH_CLIENT_ID: webClient.clientId,
-    ITERATE_OAUTH_CLIENT_SECRET: webClient.clientSecret,
-    ITERATE_OAUTH_REDIRECT_URI: webRedirectUri,
-    ITERATE_MCP_OAUTH_CLIENT_ID: mcpClient.clientId,
-    ITERATE_MCP_OAUTH_CLIENT_SECRET: mcpClient.clientSecret,
-    ITERATE_AUTH_SERVICE_TOKEN: serviceToken,
-    ITERATE_AUTH_JWKS: JSON.stringify(authJwks),
+    APP_CONFIG_ITERATE_AUTH__ISSUER: authIssuer,
+    APP_CONFIG_ITERATE_AUTH__CLIENT_ID: webClient.clientId,
+    APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET: webClient.clientSecret,
+    APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN: serviceToken,
+    APP_CONFIG_ITERATE_AUTH__JWKS: JSON.stringify(authJwks),
   });
 
   upsertSeedOAuthClient(seedOAuthClients, {

--- a/apps/os/src/auth/dev-oauth-client-bootstrap.ts
+++ b/apps/os/src/auth/dev-oauth-client-bootstrap.ts
@@ -30,9 +30,9 @@ export function resolveLocalDevOAuthClientBootstrap(
   const target = resolveDevAuthClientSyncTarget(env);
   if (!target) return null;
 
-  const authIssuer = env.APP_CONFIG_ITERATE_AUTH__ISSUER ?? env.ITERATE_OAUTH_ISSUER;
+  const authIssuer = env.APP_CONFIG_ITERATE_AUTH__ISSUER;
   const baseUrl = env.APP_CONFIG_BASE_URL;
-  const serviceToken = env.APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN ?? env.ITERATE_AUTH_SERVICE_TOKEN;
+  const serviceToken = env.APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN;
 
   if (
     !authIssuer ||
@@ -49,10 +49,8 @@ export function resolveLocalDevOAuthClientBootstrap(
 
   return {
     authOrigin,
-    existingClientId:
-      env.APP_CONFIG_ITERATE_AUTH__CLIENT_ID ?? env.ITERATE_OAUTH_CLIENT_ID ?? undefined,
-    existingClientSecret:
-      env.APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET ?? env.ITERATE_OAUTH_CLIENT_SECRET ?? undefined,
+    existingClientId: env.APP_CONFIG_ITERATE_AUTH__CLIENT_ID ?? undefined,
+    existingClientSecret: env.APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET ?? undefined,
     redirectURI: `${baseUrl.replace(/\/+$/, "")}/api/iterate-auth/callback`,
     serviceToken,
     target,
@@ -82,8 +80,6 @@ export async function ensureLocalDevOAuthClient(env: Record<string, string | und
 
       env.APP_CONFIG_ITERATE_AUTH__CLIENT_ID = client.clientId;
       env.APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET = client.clientSecret;
-      env.ITERATE_OAUTH_CLIENT_ID = client.clientId;
-      env.ITERATE_OAUTH_CLIENT_SECRET = client.clientSecret;
       return;
     } catch (error) {
       lastError = error;

--- a/apps/os/src/config.test.ts
+++ b/apps/os/src/config.test.ts
@@ -34,19 +34,6 @@ describe("AppConfig", () => {
     ).toEqual("admin-api-secret-example");
   });
 
-  it("accepts the legacy top-level Slack bot token during migration", () => {
-    expect(
-      parseAppConfigFromEnv({
-        configSchema: AppConfig,
-        prefix: "APP_CONFIG_",
-        env: {
-          APP_CONFIG: JSON.stringify(baseConfig),
-          APP_CONFIG_SLACK_BOT_TOKEN: "xoxb-example",
-        },
-      }).slackBotToken?.exposeSecret(),
-    ).toEqual("xoxb-example");
-  });
-
   it("accepts structured Slack and Google integration runtime config", () => {
     const parsed = parseAppConfigFromEnv({
       configSchema: AppConfig,

--- a/apps/os/src/config.ts
+++ b/apps/os/src/config.ts
@@ -105,9 +105,6 @@ export const AppConfig = z.object({
         .optional(),
     })
     .default({}),
-  /** Legacy deployment-wide Slack bot token fallback. New configs should set
-   * `integrations.slack.botToken` so each Slack app owns its own token. */
-  slackBotToken: redacted(z.string().trim().min(1)).optional(),
   typeIdPrefix: z
     .string()
     .trim()

--- a/apps/os/src/domains/integrations/slack-api.ts
+++ b/apps/os/src/domains/integrations/slack-api.ts
@@ -6,8 +6,7 @@
 // authorization header, so token material never leaves the secret DO's
 // substitution pipeline and every outbound attempt lands on the secret's
 // audit trail. When the project has no connected workspace, the deployment's
-// Slack integration `botToken` config is the fallback. The legacy top-level
-// `slackBotToken` is still accepted during the migration.
+// Slack integration `botToken` config is the fallback.
 
 import { itxEnv } from "../../env.ts";
 import { projectStub } from "../projects/egress.ts";
@@ -82,8 +81,7 @@ export async function callProjectSlackWebApi(input: {
 function readFallbackSlackBotToken(): string | null {
   try {
     const config = parseConfig(itxEnv);
-    const token =
-      config.integrations.slack?.botToken?.exposeSecret() ?? config.slackBotToken?.exposeSecret();
+    const token = config.integrations.slack?.botToken?.exposeSecret();
     return token && token.trim() !== "" ? token : null;
   } catch {
     return null;

--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -47,12 +47,11 @@ pnpm dev          # fully-local OS dev server on http://localhost:<port>
   Personal `dev_<you>` configs may still carry personal integration secrets,
   but they should not carry app/MCP/project-host URL overrides.
 
-  Don't (re)introduce legacy `ITERATE_OAUTH_*` / `ITERATE_AUTH_JWKS` vars in
-  these configs: an explicit JWKS in Doppler overrides the deploy-time fetch
-  from the auth worker, and a stale one makes OS silently reject every
-  session — login just bounces back to `/sign-in` with no error. (This broke
-  all `dev_<user>` and preview logins once; cleaned out of `dev_*` and the
-  `preview` root on 2026-06-12.)
+  Don't add old flat auth OAuth/JWKS vars in these configs: an explicit JWKS in
+  Doppler overrides the deploy-time fetch from the auth worker, and a stale one
+  makes OS silently reject every session — login just bounces back to
+  `/sign-in` with no error. This broke all `dev_<user>` and preview logins
+  once; the stale keys were cleaned out on 2026-06-12.
 
 - The chosen port is recorded in **`apps/os/.alchemy/dev-server.json`**
   (`{pid, port, baseUrl, logPath, stoppedAt?}`).

--- a/docs/slack-bot-token-migration.md
+++ b/docs/slack-bot-token-migration.md
@@ -1,4 +1,4 @@
-# Slack bot token migration
+# Slack bot token config
 
 Use this when collecting or rotating the per-app Slack Bot User OAuth Token for
 OS Slack smoke testing.
@@ -19,8 +19,7 @@ Each Slack app should own its complete runtime config in
 
 OS Slack Web API calls use the connected project workspace bot token first. If
 a project has no connected Slack token, OS falls back to this environment's
-`APP_CONFIG_INTEGRATIONS__SLACK.botToken`. The old top-level
-`APP_CONFIG_SLACK_BOT_TOKEN` is a temporary legacy fallback only.
+`APP_CONFIG_INTEGRATIONS__SLACK.botToken`.
 
 `Niterate (CI bot)` is not the production Slack app. The production Slack app
 is `iterate`; `Niterate (CI bot)` is the visible identity associated with the

--- a/docs/slack-smoke-testing.md
+++ b/docs/slack-smoke-testing.md
@@ -35,8 +35,7 @@ latency.
 The OS Slack bot must not wake itself. A message sent with the environment's
 Slack fallback token is useful for creating a real Slack thread, but it should
 not be treated as the inbound trigger. Current configs keep that fallback at
-`APP_CONFIG_INTEGRATIONS__SLACK.botToken`; `APP_CONFIG_SLACK_BOT_TOKEN` is only
-the legacy top-level fallback during migration.
+`APP_CONFIG_INTEGRATIONS__SLACK.botToken`.
 
 To test bot-originated wakeups, use either:
 
@@ -52,8 +51,7 @@ Run commands from `apps/os`.
 
 - `doppler` access to the target OS config.
 - `APP_CONFIG_ADMIN_API_SECRET` in that config.
-- `APP_CONFIG_INTEGRATIONS__SLACK.botToken` in that config, or the legacy
-  `APP_CONFIG_SLACK_BOT_TOKEN` during migration.
+- `APP_CONFIG_INTEGRATIONS__SLACK.botToken` in that config.
 - The OS Slack bot is a member of `#slack-agent-e2e-test`.
 - The target app is deployed and reachable through `APP_CONFIG_BASE_URL`.
 

--- a/docs/slack-testing.md
+++ b/docs/slack-testing.md
@@ -37,10 +37,7 @@ The Doppler secrets are split by purpose:
   deployment's `/integrations/slack-team-directory` stream.
 - Slack Web API calls use the project workspace token first. If the project has
   no connected Slack token, OS falls back to
-  `APP_CONFIG_INTEGRATIONS__SLACK.botToken`, then temporarily to the legacy
-  top-level `APP_CONFIG_SLACK_BOT_TOKEN` while the migration is being finished.
-- `APP_CONFIG_SLACK_BOT_TOKEN` is legacy. When diagnosing duplicate replies,
-  check whether it exists in the environment without printing the token.
+  `APP_CONFIG_INTEGRATIONS__SLACK.botToken`.
 
 ## Trigger actor for smoke tests
 
@@ -101,9 +98,9 @@ otherwise:
 - The app scope `chat:write.public` lets a Slack app post into public channels,
   so a bot user not appearing as a channel member does not rule out its app
   posting a reply.
-- If production has either `APP_CONFIG_INTEGRATIONS__SLACK.botToken` or the
-  legacy `APP_CONFIG_SLACK_BOT_TOKEN`, it can use that fallback token for
-  outbound Slack Web API calls when no project token is available.
+- If production has `APP_CONFIG_INTEGRATIONS__SLACK.botToken`, it can use that
+  fallback token for outbound Slack Web API calls when no project token is
+  available.
 
 For a precise diagnosis, inspect the Slack event wrapper and traces:
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {
-    "dev-all": "sh -c 'export VITE_AUTH_APP_ORIGIN=http://localhost:7101; export VITE_PUBLIC_URL=http://localhost:7101; export ITERATE_OAUTH_ISSUER=http://localhost:7101/api/auth; (cd apps/auth && doppler run --preserve-env=VITE_AUTH_APP_ORIGIN,VITE_PUBLIC_URL -- pnpm dev:local) & (cd apps/os && doppler run --preserve-env=ITERATE_OAUTH_ISSUER -- pnpm dev); wait'",
+    "dev-all": "sh -c 'export APP_CONFIG_AUTH_APP_ORIGIN=http://localhost:7101; export APP_CONFIG_PUBLIC_URL=http://localhost:7101; export APP_CONFIG_ITERATE_AUTH__ISSUER=http://localhost:7101/api/auth; (cd apps/auth && doppler run --preserve-env=APP_CONFIG_AUTH_APP_ORIGIN,APP_CONFIG_PUBLIC_URL -- pnpm dev:local) & (cd apps/os && doppler run --preserve-env=APP_CONFIG_ITERATE_AUTH__ISSUER -- pnpm dev); wait'",
     "dev": "pnpm os dev",
     "build": "pnpm -r --parallel --filter '!iterate' build",
     "typecheck": "pnpm -r --parallel --filter '!iterate' typecheck",

--- a/packages/iterate/README.md
+++ b/packages/iterate/README.md
@@ -32,7 +32,7 @@ npx iterate setup \
   --os-base-url https://dev-yourname-os.dev.iterate.com \
   --auth-base-url https://auth.iterate.com \
   --daemon-base-url http://localhost:3001 \
-  --admin-password-env-var-name SERVICE_AUTH_TOKEN \
+  --admin-password-env-var-name APP_CONFIG_SERVICE_AUTH_TOKEN \
   --user-email dev-yourname@iterate.com \
   --scope global
 ```
@@ -100,7 +100,7 @@ Config shape:
       "daemonBaseUrl": "http://localhost:3001",
       "auth": {
         "strategy": "admin",
-        "adminPasswordEnvVarName": "SERVICE_AUTH_TOKEN",
+        "adminPasswordEnvVarName": "APP_CONFIG_SERVICE_AUTH_TOKEN",
         "userEmail": "dev-yourname@iterate.com"
       }
     }
@@ -129,7 +129,7 @@ You can pin explicitly:
 npx iterate setup \
   --os-base-url https://dev-yourname-os.dev.iterate.com \
   --daemon-base-url http://localhost:3001 \
-  --admin-password-env-var-name SERVICE_AUTH_TOKEN \
+  --admin-password-env-var-name APP_CONFIG_SERVICE_AUTH_TOKEN \
   --user-email dev-yourname@iterate.com \
   --scope workspace
 ```

--- a/scripts/auth/mint-session.ts
+++ b/scripts/auth/mint-session.ts
@@ -127,12 +127,8 @@ if (!forgePrivateJwkJson) {
   );
 }
 
-const issuer = (
-  process.env.APP_CONFIG_ITERATE_AUTH__ISSUER ?? process.env.ITERATE_OAUTH_ISSUER
-)?.trim();
-const clientId = (
-  process.env.APP_CONFIG_ITERATE_AUTH__CLIENT_ID ?? process.env.ITERATE_OAUTH_CLIENT_ID
-)?.trim();
+const issuer = process.env.APP_CONFIG_ITERATE_AUTH__ISSUER?.trim();
+const clientId = process.env.APP_CONFIG_ITERATE_AUTH__CLIENT_ID?.trim();
 if (!issuer || !clientId) {
   throw new Error(
     "APP_CONFIG_ITERATE_AUTH__ISSUER and APP_CONFIG_ITERATE_AUTH__CLIENT_ID are required in the environment.",

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -982,11 +982,11 @@ const defaultPreviewDeployConcurrency = 5;
 const ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE = "environment-config-lease";
 const previewEnvironmentSlotNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
 const sharedAuthPreviewSecretsCopiedFromDev = [
-  "GOOGLE_CLIENT_ID",
-  "GOOGLE_CLIENT_SECRET",
-  "RESEND_BOT_DOMAIN",
-  "RESEND_BOT_API_KEY",
-  "SIGNUP_ALLOWLIST",
+  "APP_CONFIG_GOOGLE_CLIENT_ID",
+  "APP_CONFIG_GOOGLE_CLIENT_SECRET",
+  "APP_CONFIG_RESEND_DOMAIN",
+  "APP_CONFIG_RESEND_API_KEY",
+  "APP_CONFIG_SIGNUP_ALLOWLIST",
 ] as const;
 
 export const EnvironmentConfigLease = z.object({
@@ -1939,24 +1939,8 @@ function commandFailureSummary(result: { stderr: string; stdout: string }) {
   return output || "command failed";
 }
 
-// Flat secret -> its APP_CONFIG_* name (apps/auth reads these at runtime via
-// parseConfig; see apps/auth/src/config.ts). We write both: the flat names feed
-// the client's build-time VITE vars + the alchemy.run legacy fallback, the
-// APP_CONFIG_* names are what the worker config actually consumes.
-const authAppConfigNameByFlat: Record<string, string> = {
-  VITE_AUTH_APP_ORIGIN: "APP_CONFIG_AUTH_APP_ORIGIN",
-  BETTER_AUTH_SECRET: "APP_CONFIG_BETTER_AUTH_SECRET",
-  SERVICE_AUTH_TOKEN: "APP_CONFIG_SERVICE_AUTH_TOKEN",
-  GOOGLE_CLIENT_ID: "APP_CONFIG_GOOGLE_CLIENT_ID",
-  GOOGLE_CLIENT_SECRET: "APP_CONFIG_GOOGLE_CLIENT_SECRET",
-  RESEND_BOT_DOMAIN: "APP_CONFIG_RESEND_DOMAIN",
-  RESEND_BOT_API_KEY: "APP_CONFIG_RESEND_API_KEY",
-  SIGNUP_ALLOWLIST: "APP_CONFIG_SIGNUP_ALLOWLIST",
-};
-
 async function ensureAuthPreviewConfigs(input: { rotate: boolean }) {
   const rootValues: Record<string, string> = {
-    VITE_ENABLE_EMAIL_OTP_SIGNIN: "true",
     APP_CONFIG_EMAIL_OTP_ENABLED: "true",
   };
   for (const name of sharedAuthPreviewSecretsCopiedFromDev) {
@@ -1965,7 +1949,6 @@ async function ensureAuthPreviewConfigs(input: { rotate: boolean }) {
       getDopplerSecret("auth", "preview", name) || getDopplerSecret("auth", "dev", name);
     if (!value) throw new Error(`auth/dev is missing ${name}`);
     rootValues[name] = value;
-    rootValues[authAppConfigNameByFlat[name]] = value;
   }
   setDopplerSecrets("auth", "preview", rootValues);
   console.log("auth/preview root config ensured");
@@ -1991,11 +1974,11 @@ async function ensureAuthPreviewConfigs(input: { rotate: boolean }) {
 
     const existingServiceToken = input.rotate
       ? null
-      : getDopplerSecret("auth", config, "SERVICE_AUTH_TOKEN");
+      : getDopplerSecret("auth", config, "APP_CONFIG_SERVICE_AUTH_TOKEN");
     const serviceToken = existingServiceToken || freshSecret();
     const existingBetterAuthSecret = input.rotate
       ? null
-      : getDopplerSecret("auth", config, "BETTER_AUTH_SECRET");
+      : getDopplerSecret("auth", config, "APP_CONFIG_BETTER_AUTH_SECRET");
     const betterAuthSecret = existingBetterAuthSecret || freshSecret();
 
     const seed = JSON.stringify([
@@ -2010,14 +1993,10 @@ async function ensureAuthPreviewConfigs(input: { rotate: boolean }) {
     ]);
 
     setDopplerSecrets("auth", config, {
-      VITE_AUTH_APP_ORIGIN: authOrigin,
       // readPreviewAppConfig reads APP_CONFIG_BASE_URL to learn the app's public URL.
       APP_CONFIG_BASE_URL: authOrigin,
       WORKER_ROUTES: `auth.iterate-preview-${slot}.com`,
-      BETTER_AUTH_SECRET: betterAuthSecret,
-      SERVICE_AUTH_TOKEN: serviceToken,
       AUTH_SEED_OAUTH_CLIENTS: seed,
-      // The APP_CONFIG_* names apps/auth's runtime config actually reads.
       APP_CONFIG_AUTH_APP_ORIGIN: authOrigin,
       APP_CONFIG_BETTER_AUTH_SECRET: betterAuthSecret,
       APP_CONFIG_SERVICE_AUTH_TOKEN: serviceToken,

--- a/specs/create-project.spec.ts
+++ b/specs/create-project.spec.ts
@@ -13,7 +13,7 @@ import { test, uniqueSlug } from "./test-support/test.ts";
 test("a new user can create a project through the UI form", async ({ page }) => {
   test.skip(
     !(await startEmailOtpSignIn(page)),
-    "Email OTP sign-in is disabled for this deployment (VITE_ENABLE_EMAIL_OTP_SIGNIN on auth / APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED on OS).",
+    "Email OTP sign-in is disabled for this deployment (APP_CONFIG_EMAIL_OTP_ENABLED on auth / APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED on OS).",
   );
   const firstSlug = uniqueSlug("first-project");
   await signUpWithEmailOtp(page, {

--- a/specs/signup.spec.ts
+++ b/specs/signup.spec.ts
@@ -12,7 +12,7 @@ import { test, uniqueSlug } from "./test-support/test.ts";
 test("can sign up with an email one-time passcode", async ({ page }) => {
   test.skip(
     !(await startEmailOtpSignIn(page)),
-    "Email OTP sign-in is disabled for this deployment (VITE_ENABLE_EMAIL_OTP_SIGNIN on auth / APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED on OS).",
+    "Email OTP sign-in is disabled for this deployment (APP_CONFIG_EMAIL_OTP_ENABLED on auth / APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED on OS).",
   );
 
   const slug = uniqueSlug("signup");

--- a/specs/test-support/email-otp-signup.ts
+++ b/specs/test-support/email-otp-signup.ts
@@ -9,7 +9,7 @@ import { spinnerWaiter } from "middlewright";
  * (organization + first project in one form) → back to OS signed in.
  *
  * The lane only exists where the auth deployment enables it
- * (VITE_ENABLE_EMAIL_OTP_SIGNIN, default on for dev stages; OS mirrors it as
+ * (APP_CONFIG_EMAIL_OTP_ENABLED, default on for dev stages; OS mirrors it as
  * APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED) — check with
  * {@link startEmailOtpSignIn} and skip otherwise.
  *

--- a/tasks/os-auth-service-binding.md
+++ b/tasks/os-auth-service-binding.md
@@ -12,7 +12,8 @@ internet**: `apps/os/src/auth/auth-worker-service.ts` builds an HTTP oRPC client
 (`@iterate-com/auth-contract`) and calls `internal.project.bySlug`,
 `internal.project.createForOrganization`, `internal.project.mintProjectId`, and
 `internal.oauth.introspectAccessToken`, authenticating with a shared
-`x-iterate-service-token` (`SERVICE_AUTH_TOKEN` / `config.iterateAuth.serviceToken`).
+`x-iterate-service-token`
+(`APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN` / `config.iterateAuth.serviceToken`).
 
 Both workers live in the same Cloudflare account, so this hop can instead be a
 **[Workers RPC service binding](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/rpc/)** —

--- a/tasks/os-deploy-time-jwks-fetch.md
+++ b/tasks/os-deploy-time-jwks-fetch.md
@@ -8,18 +8,17 @@ size: small
 
 OS verifies auth JWTs locally using a static JWKS so authenticated page loads
 (including cold isolate starts) make no network roundtrips to the auth worker.
-Today the JWKS is copied by hand into Doppler (`ITERATE_AUTH_JWKS` in the `os`
-project's `prd`/`preview` root configs and personal dev configs). That works
-but has a rotation problem: if auth rotates its signing key, every OS env
-breaks until someone updates the secrets and redeploys.
+Today the JWKS can be overridden through Doppler
+(`APP_CONFIG_ITERATE_AUTH__JWKS` in the `os` project configs). That works but
+has a rotation problem: if auth rotates its signing key, every OS env with a
+stale override breaks until someone updates the secret and redeploys.
 
 ## Proposed shape
 
 - In `apps/os/alchemy.run.ts`, fetch `<issuer>/jwks` at deploy time and feed it
   into `APP_CONFIG_ITERATE_AUTH__JWKS` so it stays typesafe via the `AppConfig`
   zod schema (`iterateAuth.jwks`, already defined in `apps/os/src/config.ts`).
-- Keep the `ITERATE_AUTH_JWKS` / `APP_CONFIG_ITERATE_AUTH__JWKS` env vars as an
-  explicit override.
+- Keep `APP_CONFIG_ITERATE_AUTH__JWKS` as an explicit override.
 - Fall back gracefully (no static JWKS → runtime `createRemoteJWKSet`) when the
   fetch fails or when the issuer is a loopback origin that may not be running
   yet (local dev — see `ensureLocalDevOAuthClient`).


### PR DESCRIPTION
## What changed

- Removed legacy auth/OS env fallbacks and runtime reads for the old flat Doppler keys.
- Made auth deploy parse only the auth-owned `APP_CONFIG_*` keys so inherited shared AppConfig keys no longer produce auth deploy warnings.
- Updated preview provisioning, auth client sync, local dev helpers, tests, tasks, and docs to use the typed AppConfig names only.
- Removed OS top-level Slack bot token handling; Slack bot tokens now live only under `APP_CONFIG_INTEGRATIONS__SLACK.botToken`.
- Cleaned Doppler `auth` and `os` configs by deleting the old legacy keys, and synced `os/prd` auth client AppConfig keys.

## Why

The main deploy failure was caused around the auth deploy wrapper path after a successful Alchemy update. The unknown AppConfig warnings were non-fatal, but auth was inheriting shared OS-shaped AppConfig keys it does not own. This PR removes the legacy transition layer and makes the deploy/config boundary explicit.

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --dir apps/auth typecheck`
- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/os exec vitest run src/auth/dev-oauth-client-bootstrap.test.ts src/config.test.ts`
- `pnpm --dir apps/auth test`
- `pnpm --dir apps/auth-example typecheck`
- `doppler run --project auth --config dev_global -- pnpm --dir apps/auth alchemy:up`

## Operational notes

- Deleted legacy Doppler keys from `auth` and `os` dev, preview, and production configs.
- Ran `AUTH_CLIENT_SYNC_TARGETS=prd pnpm --dir apps/os auth:sync-clients` through `auth/prd` to populate the new `os/prd` `APP_CONFIG_ITERATE_AUTH__*` keys.
- Verified exact legacy-token searches are empty across the repo after the cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a breaking config migration: deploys and local dev fail if Doppler or `.env` still rely on removed legacy keys, and auth/OS login, OAuth client sync, and Slack fallback behavior all depend on the new variable names being set correctly.
> 
> **Overview**
> This PR **drops the transitional dual-name config layer** so auth, OS, deploy scripts, preview provisioning, and docs read **only** typed `APP_CONFIG_*` Doppler keys (e.g. `APP_CONFIG_ITERATE_AUTH__*`, `APP_CONFIG_SERVICE_AUTH_TOKEN`, `APP_CONFIG_EMAIL_OTP_ENABLED`) instead of legacy flat names like `ITERATE_OAUTH_*`, `SERVICE_AUTH_TOKEN`, or `VITE_AUTH_APP_ORIGIN`.
> 
> **Auth deploy** now builds `configEnv` from a filtered deploy env (no inherited `APP_CONFIG_*` from OS-shaped configs) and maps secrets/origins **without** `?? legacy` fallbacks. The auth UI gets its public origin from **`APP_CONFIG_AUTH_APP_ORIGIN` inlined at Vite build time** via `getAuthAppOrigin()` / `__AUTH_APP_ORIGIN__`, replacing `import.meta.env.VITE_AUTH_APP_ORIGIN`.
> 
> **OS** drops the same legacy fallbacks for iterate-auth issuer, client credentials, JWKS, service token, and email OTP; **local dev OAuth bootstrap** no longer mirrors credentials into old `ITERATE_OAUTH_*` env vars. **`sync-auth-clients`** writes `APP_CONFIG_ITERATE_AUTH__*` to Doppler and resolves MCP client IDs from auth seed data instead of `ITERATE_MCP_OAUTH_*`.
> 
> **Slack**: OS removes the top-level `slackBotToken` / `APP_CONFIG_SLACK_BOT_TOKEN` path; outbound fallback uses **`APP_CONFIG_INTEGRATIONS__SLACK.botToken` only**.
> 
> **auth-example**, root **`dev-all`**, preview **`ensureAuthPreviewConfigs`**, e2e/smoke docs, and iterate CLI setup docs are updated to the new names. Operational expectation: Doppler must already carry the typed keys; missing legacy fallbacks will fail deploy or local bootstrap until configs are migrated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73d78f9f3d59d49c3a494b12be00732819b52b85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-03T21:24:06.622Z",
      "headSha": "73d78f9f3d59d49c3a494b12be00732819b52b85",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/138515275490520",
      "shortSha": "73d78f9",
      "cleanupDurationMs": 79464,
      "deployDurationMs": 59008,
      "testDurationMs": 64308
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-03T21:23:00.239Z",
      "headSha": "73d78f9f3d59d49c3a494b12be00732819b52b85",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/138515275490520",
      "shortSha": "73d78f9",
      "cleanupDurationMs": 13077,
      "deployDurationMs": 21735,
      "testDurationMs": 5951
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-03T21:23:37.279Z",
      "headSha": "73d78f9f3d59d49c3a494b12be00732819b52b85",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/138515275490520",
      "shortSha": "73d78f9",
      "cleanupDurationMs": 50114,
      "deployDurationMs": 24764,
      "testDurationMs": 662
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-03T21:22:58.739Z",
      "headSha": "73d78f9f3d59d49c3a494b12be00732819b52b85",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-6.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/138515275490520",
      "shortSha": "73d78f9",
      "cleanupDurationMs": 11570,
      "deployDurationMs": 17286,
      "testDurationMs": 15031
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `73d78f9` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 24.8s | 662ms | 50.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/138515275490520) | 2026-07-03T21:23:37.279Z | Preview app released. |
| OS | released | `73d78f9` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 59.0s | 64.3s | 79.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/138515275490520) | 2026-07-03T21:24:06.622Z | Preview app released. |
| Semaphore | released | `73d78f9` | [https://semaphore.iterate-preview-6.com](https://semaphore.iterate-preview-6.com) | 21.7s | 6.0s | 13.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/138515275490520) | 2026-07-03T21:23:00.239Z | Preview app released. |
| Streams Example App | released | `73d78f9` | [https://streams-example-app-preview-6.iterate-dev-preview.workers.dev](https://streams-example-app-preview-6.iterate-dev-preview.workers.dev) | 17.3s | 15.0s | 11.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/138515275490520) | 2026-07-03T21:22:58.739Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->