### PR TITLE
Fix #1624's unexercised e2e tests (its preview run was skipped)

### DIFF
--- a/apps/os/e2e/vitest/agent-tools.itx.e2e.test.ts
+++ b/apps/os/e2e/vitest/agent-tools.itx.e2e.test.ts
@@ -2,7 +2,7 @@
  * Goal coverage: an agent uses itx tools. Deterministic version of the
  * Playwright chat spec — drive an agent over itx, instruct it to run a script
  * that appends a proof event, and assert the full codemode loop on the stream:
- * llm request → output → itx/script-execution-requested/completed → proof
+ * llm request → output → capability-host/script-execution-requested/completed → proof
  * event on the target stream → visible web reply.
  */
 import { test } from "vitest";
@@ -45,8 +45,8 @@ test(
 
     const agentEvents = await agent.stream.getEvents({ limit: 500 });
     const types = agentEvents.map((event) => event.type.replace("events.iterate.com/", ""));
-    expect(types).toContain("itx/script-execution-requested");
-    expect(types).toContain("itx/script-execution-completed");
+    expect(types).toContain("capability-host/script-execution-requested");
+    expect(types).toContain("capability-host/script-execution-completed");
     expect(types).toContain("agents/web-message-sent");
   },
 );

--- a/apps/os/e2e/vitest/itx.e2e.test.ts
+++ b/apps/os/e2e/vitest/itx.e2e.test.ts
@@ -360,13 +360,17 @@ describe("itx", () => {
     expect(description.capabilities).toContainEqual(
       expect.objectContaining({ path: ["ai"], type: "builtin" }),
     );
+    // Gmail lives under the integrations built-in since the capability-host
+    // refactor; the connection-scoped proxy self-describes there.
     expect(description.capabilities).toContainEqual(
       expect.objectContaining({
-        instructions: expect.stringContaining("Gmail REST proxy"),
-        path: ["gmail"],
+        instructions: expect.stringContaining("itx.integrations.gmail"),
+        path: ["integrations"],
         type: "builtin",
       }),
     );
+    const gmail = await project.integrations.gmail.__describe();
+    expect(gmail.instructions).toContain("Gmail REST proxy");
   });
 
   test("Trusted internal root can access global streams and repos", async () => {
@@ -2133,16 +2137,19 @@ describe("itx", () => {
     // agent's own capability host and mounts on the project root by addressing
     // it through `capabilityHosts.get("/")`.
     const execution = await agent.capabilityHost.runScript(`async (itx) => {
-      const provision = await itx.capabilityHosts.get("/").provideCapability({
+      // Workers RPC: await the capability before calling through it.
+      const host = await itx.capabilityHosts.get("/");
+      const provision = await host.provideCapability({
         type: "live",
         path: ["crossScopeProbe"],
         capability: { ping: () => "pong-from-agent-mount" },
       });
       // Visible on the root host itself, and through the agent scope's own
       // inheritance chain (local miss -> parent -> root).
-      const viaRoot = await itx.capabilityHosts
-        .get("/")
-        .invokeCapability({ path: ["crossScopeProbe", "ping"], args: [] });
+      const viaRoot = await host.invokeCapability({
+        path: ["crossScopeProbe", "ping"],
+        args: [],
+      });
       const viaChain = await itx.crossScopeProbe.ping();
       const describedScopes = (await itx.capabilityHost.__describe()).capabilities
         .filter((capability) => capability.path.join(".") === "crossScopeProbe")


### PR DESCRIPTION
#1624 merged with its **preview deploy+e2e check skipped**, so its new e2e tests never executed anywhere. Three of them fail against main's own code — every PR's preview e2e is currently red on them. All three fixes are test-only; the underlying features work.

1. **`agent-tools.itx.e2e.test.ts`** — asserted the old `itx/script-execution-requested|completed` event names; #1624 renamed them to `capability-host/…`. Assertions and doc comment updated.
2. **"Project describe exposes self-describing builtin capabilities"** — expected a top-level `["gmail"]` builtin, but #1624 itself moved gmail under `integrations`. Now asserts the real surface: the `integrations` builtin names `itx.integrations.gmail`, and the gmail node's own `__describe()` carries the "Gmail REST proxy" instructions.
3. **`capabilityHosts.get("/")` cross-scope provide** — the script pipelined method calls through an un-awaited `get("/")`. Script `itx` crosses Workers RPC, which does not pipeline through unresolved returns (the documented "await the capability before calling through it" rule). Awaiting the host once fixes it — the headline cross-scope-provide feature itself works correctly.

All three verified green against a live local dev server on pure main (agent-tools: 2/2; describe: 1/1; cross-scope: 1/1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to e2e assertions and an inline script; no production paths modified.
> 
> **Overview**
> Updates **preview e2e** expectations so tests match post–#1624 behavior without changing product code.
> 
> In **`agent-tools.itx.e2e.test.ts`**, stream event assertions and the file comment now use **`capability-host/script-execution-requested`** and **`capability-host/script-execution-completed`** instead of the old **`itx/script-execution-*`** names.
> 
> The **“Project describe exposes self-describing builtin capabilities”** case no longer expects a top-level **`gmail`** builtin. It checks the **`integrations`** builtin references **`itx.integrations.gmail`**, then asserts **`project.integrations.gmail.__describe()`** still includes **“Gmail REST proxy”**.
> 
> The **cross-scope provide** script **`await`s** **`itx.capabilityHosts.get("/")`** once before **`provideCapability`** / **`invokeCapability`**, matching Workers RPC (no pipelining on unresolved handles).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2a6e5b2471dac552e5af0f71aea04ed8b3d2a25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> All preview slots are leased — this PR is waiting in line for one (since 2026-07-03T22:09:25.943Z).
>   preview-2  leased by pr-1634 until 2026-07-04T21:11:08.248Z (23h2m left) | https://github.com/iterate/iterate/pull/1634
>   preview-3  leased by pr-1640 until 2026-07-04T22:08:52.509Z (23h59m left) | https://github.com/iterate/iterate/pull/1640
>   preview-4  leased by pr-1639 until 2026-07-04T21:56:05.995Z (23h47m left) | https://github.com/iterate/iterate/pull/1639
>   preview-5  leased by pr-1634 until 2026-07-04T22:01:13.734Z (23h52m left) | https://github.com/iterate/iterate/pull/1634
>   preview-6  leased by pr-1636 until 2026-07-04T21:52:54.389Z (23h43m left) | https://github.com/iterate/iterate/pull/1636
>   preview-7  leased by pr-1638 until 2026-07-04T22:09:16.921Z (23h60m left) | https://github.com/iterate/iterate/pull/1638
>   preview-8  leased by pr-1612 until 2026-07-04T17:30:06.093Z (19h21m left) | https://github.com/iterate/iterate/pull/1612
>   preview-9  leased by pr-1612 until 2026-07-04T22:05:58.809Z (23h57m left) | https://github.com/iterate/iterate/pull/1612
>   preview-1  leased by pr-1508 until 2026-07-04T21:38:30.309Z (23h29m left) | https://github.com/iterate/iterate/pull/1508

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": "All preview slots are leased — this PR is waiting in line for one (since 2026-07-03T22:09:25.943Z).\n  preview-2  leased by pr-1634 until 2026-07-04T21:11:08.248Z (23h2m left) | https://github.com/iterate/iterate/pull/1634\n  preview-3  leased by pr-1640 until 2026-07-04T22:08:52.509Z (23h59m left) | https://github.com/iterate/iterate/pull/1640\n  preview-4  leased by pr-1639 until 2026-07-04T21:56:05.995Z (23h47m left) | https://github.com/iterate/iterate/pull/1639\n  preview-5  leased by pr-1634 until 2026-07-04T22:01:13.734Z (23h52m left) | https://github.com/iterate/iterate/pull/1634\n  preview-6  leased by pr-1636 until 2026-07-04T21:52:54.389Z (23h43m left) | https://github.com/iterate/iterate/pull/1636\n  preview-7  leased by pr-1638 until 2026-07-04T22:09:16.921Z (23h60m left) | https://github.com/iterate/iterate/pull/1638\n  preview-8  leased by pr-1612 until 2026-07-04T17:30:06.093Z (19h21m left) | https://github.com/iterate/iterate/pull/1612\n  preview-9  leased by pr-1612 until 2026-07-04T22:05:58.809Z (23h57m left) | https://github.com/iterate/iterate/pull/1612\n  preview-1  leased by pr-1508 until 2026-07-04T21:38:30.309Z (23h29m left) | https://github.com/iterate/iterate/pull/1508"
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->