### PR TITLE
Fix playwright forged-session fixture: describe() -> __describe()

### DIFF
--- a/specs/test-support/forged-session.ts
+++ b/specs/test-support/forged-session.ts
@@ -151,7 +151,7 @@ export async function createAdminProject(input: { baseUrl: string; slug: string 
     baseUrl: input.baseUrl,
   });
   using created = session.projects.create({ slug: input.slug });
-  const description = await created.describe();
+  const description = await created.__describe();
   const project = { id: description.projectId, slug: input.slug };
 
   return {


### PR DESCRIPTION
#1624 renamed `describe()`/`whoami()` to `__describe()` on every itx node, but its preview e2e run was skipped, and #1641 only fixed the **vitest** e2e lane. The **playwright** lane has its own stale call: `createAdminProject` in `specs/test-support/forged-session.ts` still calls `created.describe()`, which now dispatches to the capability host and throws `no capability "describe"`.

That fixture underpins most playwright specs (agent-chat, dashboard, forged-session-repl, reactivity, repl-examples), so **every PR's preview e2e is currently red** with the same error — verified identical on three independent PRs' Depot runs.

One-line fix: `created.describe()` → `created.__describe()` (`ProjectDescription` still carries `projectId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line test-support change with no production auth or data-path impact.
> 
> **Overview**
> Updates **`createAdminProject`** in `forged-session.ts` so the itx project handle calls **`__describe()`** instead of **`describe()`**, matching the renamed itx node API.
> 
> That fixture backs most Playwright preview specs; the old call hit the capability host and failed with **no capability "describe"**, so preview e2e stayed red after the vitest lane was fixed elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27a1d2718bc6dabd6912eb30d001c789a87a81f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->