### PR TITLE
Fix preview auth seeding and itx discovery calls

### DIFF
--- a/apps/auth/alchemy.run.ts
+++ b/apps/auth/alchemy.run.ts
@@ -186,7 +186,22 @@ await IterateRoutes({ app, slug: APP_NAME }, { worker, hostnames: alchemyEnv.WOR
 // Local dev (`alchemy dev`) skips this: the server isn't up until later — run
 // `pnpm seed-oauth-clients` against it manually if needed.
 if (!app.local && process.env.AUTH_SEED_OAUTH_CLIENTS) {
-  await seedOAuthClients(process.env, { baseUrl: primaryUrl ?? worker.url });
+  const seedBaseUrls = Array.from(
+    new Set([primaryUrl, worker.url].filter((url): url is string => url != null && url !== "")),
+  );
+
+  for (const [index, baseUrl] of seedBaseUrls.entries()) {
+    try {
+      await seedOAuthClients(process.env, { baseUrl });
+      break;
+    } catch (error) {
+      if (index === seedBaseUrls.length - 1) throw error;
+      console.warn(
+        `OAuth client seed through ${baseUrl} failed; trying ${seedBaseUrls[index + 1]}`,
+        error,
+      );
+    }
+  }
 }
 
 export { worker };

--- a/apps/auth/alchemy.run.ts
+++ b/apps/auth/alchemy.run.ts
@@ -186,10 +186,7 @@ await IterateRoutes({ app, slug: APP_NAME }, { worker, hostnames: alchemyEnv.WOR
 // Local dev (`alchemy dev`) skips this: the server isn't up until later — run
 // `pnpm seed-oauth-clients` against it manually if needed.
 if (!app.local && process.env.AUTH_SEED_OAUTH_CLIENTS) {
-  // Seed through the workers.dev URL, which is live immediately — a fresh
-  // custom hostname (auth.iterate-preview-N.com on its first deploy) can take
-  // minutes to get an edge cert, which would time out the readiness probe.
-  await seedOAuthClients(process.env, { baseUrl: worker.url });
+  await seedOAuthClients(process.env, { baseUrl: primaryUrl ?? worker.url });
 }
 
 export { worker };

--- a/apps/auth/scripts/seed-oauth-clients.ts
+++ b/apps/auth/scripts/seed-oauth-clients.ts
@@ -103,10 +103,8 @@ async function waitForAuthDeployment(baseUrl: string, timeoutMs = 120_000) {
 export async function seedOAuthClients(
   env: Record<string, string | undefined>,
   // The reachable URL to seed *through* (API calls + readiness probe). Defaults
-  // to the custom-domain origin, but a fresh deploy passes the worker's
-  // workers.dev URL — it's live instantly, whereas a brand-new custom hostname
-  // can take minutes to issue an edge cert (which previously timed out the
-  // preview deploy). The seeded data (redirect URIs) is unaffected.
+  // to the configured auth app origin. The seeded data (redirect URIs) is
+  // unaffected by which deployed origin handles the admin request.
   opts: { baseUrl?: string } = {},
 ) {
   const parsed = SeedOAuthClientsEnv.safeParse(env);

--- a/apps/os/CONTEXT.md
+++ b/apps/os/CONTEXT.md
@@ -651,7 +651,7 @@ _Avoid_: Project MCP route, inbound MCP
 - Individual itx capability calls do not create durable function-call-requested/completed events. The dotted path is captured by the path proxy and dispatched once through the itx supervisor.
 - A provided capability may be a live object/function, a Worker RPC address, or a path-call target implementing `call({ path, args })`.
 - A returned live handle, such as a Repo handle from `itx.repos.get({ path })`, exposes its own Workers RPC methods after the original path call returns.
-- `itx.describe()` is the capability discovery surface. Providers attach instructions and optional types to each capability entry.
+- `itx.__describe()` is the capability discovery surface. Providers attach instructions and optional types to each capability entry.
 - Dynamic MCP and OpenAPI tools should be exposed as itx capabilities whose exact external tool names or operation IDs remain path segments; use bracket syntax when a segment contains dots.
 - Project default capabilities include `fetch`, `streams`, `secrets`, `integrations`, `repos`, `agents`, `workspace`, `worker`, and `ai` as defined by `PLATFORM_PROJECT_CAPABILITIES`.
 - Agent hosts add channel and agent-local capabilities such as `itx.slack` or `itx.chat`, `itx.debug`, `itx.gmail`, `itx.agents`, and an agent-private `itx.workspace`.
@@ -659,7 +659,7 @@ _Avoid_: Project MCP route, inbound MCP
 ## Target itx Blocks
 
 ```ts
-await itx.describe();
+await itx.__describe();
 ```
 
 `describe()` is the runtime truth for a handle: it returns the context ref,
@@ -742,7 +742,7 @@ context while the provider remains connected.
 > **Domain expert:** "The `repos.get` path call returns a repo handle; `getInfo` is a Workers RPC method on that returned handle."
 
 > **Dev:** "How does a script learn what is available?"
-> **Domain expert:** "Call `itx.describe()`. Providers attach instructions and optional types to each capability."
+> **Domain expert:** "Call `itx.__describe()`. Providers attach instructions and optional types to each capability."
 
 > **Dev:** "Should `docs.search` from an MCP server become `itx.docs.search(...)`?"
 > **Domain expert:** "No. External tool names and OpenAPI operation IDs are exact path segments, so use bracket syntax such as `itx.mcp.cloudflareDocs["docs.search"](...)` when needed."

--- a/apps/os/README.md
+++ b/apps/os/README.md
@@ -162,7 +162,7 @@ doppler run --project os --config dev -- sh -lc '
     --method tools/call \
     --tool-name exec_js \
     --tool-arg project=<project-slug> \
-    --tool-arg "code=async (itx) => { return await itx.describe(); }" \
+    --tool-arg "code=async (itx) => { return await itx.__describe(); }" \
     --header "Authorization: Bearer $APP_CONFIG_ADMIN_API_SECRET"
 '
 ```

--- a/apps/os/docs/agent-smoke-testing.md
+++ b/apps/os/docs/agent-smoke-testing.md
@@ -25,7 +25,7 @@ pass `--base-url http://localhost:<port>` using the port in
 
 ```bash
 doppler run --project os --config prd -- pnpm cli itx run \
-  --eval 'const project = await itx.projects.create({ slug: `agent-smoke-${Date.now()}` }); return await project.describe()'
+  --eval 'const project = await itx.projects.create({ slug: `agent-smoke-${Date.now()}` }); return await project.__describe()'
 ```
 
 `create` returns the project itx handle; `describe()` prints the `projectId`

--- a/apps/os/docs/architecture-and-operations.md
+++ b/apps/os/docs/architecture-and-operations.md
@@ -136,7 +136,7 @@ script shape: a body that runs with `itx` (and `vars`) in scope and ends with
 an explicit `return` (see `src/itx/examples.ts`, the catalogue that doubles
 as the REPL Examples panel and the cross-runtime e2e matrix).
 
-Capabilities are visible through `itx.describe()`. The built-ins
+Capabilities are visible through `itx.__describe()`. The built-ins
 (`itx.streams`, `itx.repos`, `itx.secrets`, `itx.agents`, `itx.workers`,
 `itx.worker`, `itx.egress`, `itx.mcp`, `itx.openapi`, `itx.ai`; `itx.agent` /
 `itx.chat` on agent scopes) plus mounted capabilities are catalogued in

--- a/apps/os/docs/debugging-deployed-os-workers.md
+++ b/apps/os/docs/debugging-deployed-os-workers.md
@@ -115,7 +115,7 @@ doppler run --config preview_3 -- pnpm cli itx run \
 ```bash
 # Confirm the project resolves and list its capabilities.
 doppler run --config prd -- pnpm cli itx run \
-  --eval 'const project = await itx.projects.get("<prj_id>"); return await project.describe()'
+  --eval 'const project = await itx.projects.get("<prj_id>"); return await project.__describe()'
 
 # List the project's streams.
 doppler run --config prd -- pnpm cli itx run \

--- a/apps/os/docs/itx-design.md
+++ b/apps/os/docs/itx-design.md
@@ -874,9 +874,9 @@ are read-only" (an earlier framing in this doc) was the wrong frame.
 
 The `caps` namespace exists to dodge name collisions, but reserved names
 already exist as a mechanism. Kernel flattens to root:
-`itx.provideCapability() / itx.revokeCapability() / itx.describe() /
+`itx.provideCapability() / itx.revokeCapability() / itx.__describe() /
 itx.fork() / itx.invoke()` — the `ItxCaps` class dies, and the
-`itx.describe()` vs `caps.describe()` duplication resolves to one merged
+`itx.__describe()` vs `caps.__describe()` duplication resolves to one merged
 view. A handle is **an address, an access set, and five verbs**.
 
 ### 4. Definitions live at PATHS — longest-prefix dispatch — SHIPPED

--- a/apps/os/scripts/itx.ts
+++ b/apps/os/scripts/itx.ts
@@ -83,7 +83,7 @@ export async function startRepl(options: ReplOptions) {
     [
       `Connected to ${connection.baseUrl}`,
       options.context
-        ? `Context: project ${options.context} — try: await itx.describe()`
+        ? `Context: project ${options.context} — try: await itx.__describe()`
         : "Context: session — try: await itx.projects.list()",
       "",
     ].join("\n"),

--- a/apps/os/src/README.md
+++ b/apps/os/src/README.md
@@ -237,7 +237,7 @@ accepts two recipes (`ProvideCapabilityInput`):
   disconnects without holding a live stub.
 
 Every mount carries optional `instructions` (prose) and `types` (a TypeScript
-source string exporting `type Capability`). `itx.describe()` returns project
+source string exporting `type Capability`). `itx.__describe()` returns project
 identity plus the full capability inventory — built-ins and mounts, from
 declared metadata only, never by probing live targets. Agents are a first-class
 audience and `describe()` is their only sense organ; write instructions for the

--- a/apps/os/src/domains/integrations/slack-processors.test.ts
+++ b/apps/os/src/domains/integrations/slack-processors.test.ts
@@ -860,8 +860,8 @@ describe("compileBangCommand", () => {
       compileBangCommand({ channel: "C1", message: "!whoami", threadTs: "1.2" })?.code,
     ).toContain("await itx.whoami()");
     expect(
-      compileBangCommand({ channel: "C1", message: "<@U1> !describe", threadTs: "1.2" })?.code,
-    ).toContain("await itx.describe()");
+      compileBangCommand({ channel: "C1", message: "<@U1> !__describe", threadTs: "1.2" })?.code,
+    ).toContain("await itx.__describe()");
   });
 
   it("returns null for ordinary messages", () => {

--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -100,7 +100,7 @@ pnpm dev          # fully-local OS dev server on http://localhost:<port>
       --method tools/call \
       --tool-name exec_js \
       --tool-arg project=<project-slug> \
-      --tool-arg "code=async (itx) => { return await itx.describe(); }" \
+      --tool-arg "code=async (itx) => { return await itx.__describe(); }" \
       --header "Authorization: Bearer $APP_CONFIG_ADMIN_API_SECRET"
   '
   ```
@@ -172,7 +172,7 @@ The working recipe to browse OS as a minted identity:
 # 1. create a project via the operator path (admin API secret)
 (cd apps/os && doppler run --project os --config dev -- pnpm cli itx run \
   --base-url http://localhost:<port> \
-  --eval 'const p = await itx.projects.create({ slug: "my-proj" }); return await p.describe()' # note the returned projectId
+  --eval 'const p = await itx.projects.create({ slug: "my-proj" }); return await p.__describe()' # note the returned projectId
 )
 
 # 2. mint with BOTH org and project claims (the org can be any made-up id —

--- a/specs/forged-session-repl.spec.ts
+++ b/specs/forged-session-repl.spec.ts
@@ -4,7 +4,19 @@ test("project REPL accepts a forged session", async ({ helpers, page }) => {
   await using fixture = await helpers.createFixture("basic-repl");
   await page.goto(`/projects/${fixture.project.slug}/repl`);
   // exact: the project slug can contain "run", which substring-matches sidebar buttons
+  await page.getByRole("button", { name: "Run", exact: true }).waitFor();
+  await page.getByTestId("itx-repl-editor").locator(".cm-content").waitFor();
+
+  const entries = page.getByTestId("itx-repl-entry");
+  const entryIndex = await entries.count();
   await page.getByRole("button", { name: "Run", exact: true }).click();
 
-  await page.getByTestId("itx-repl-visible-result").getByText(`"capabilities"`).waitFor();
+  const entry = page.locator(`[data-entry-index="${entryIndex}"][data-status="success"]`);
+  await entry.waitFor();
+
+  const resultJson = await entry.getByTestId("itx-repl-result-json").textContent();
+  const result = JSON.parse(resultJson!);
+  if (!Array.isArray(result.capabilities)) {
+    throw new Error("Project REPL result did not include capabilities.");
+  }
 });

--- a/specs/test-support/forged-session.ts
+++ b/specs/test-support/forged-session.ts
@@ -151,7 +151,7 @@ export async function createAdminProject(input: { baseUrl: string; slug: string 
     baseUrl: input.baseUrl,
   });
   using created = session.projects.create({ slug: input.slug });
-  const description = await created.describe();
+  const description = await created.__describe();
   const project = { id: description.projectId, slug: input.slug };
 
   return {

--- a/tasks/os-orpc-teardown.md
+++ b/tasks/os-orpc-teardown.md
@@ -74,7 +74,7 @@ rollback plan.
       / `ItxStream.subscribe`; migrate the e2e files
 - [ ] CLI: `pnpm cli itx run <file|--eval>` wrapping `POST /api/itx/run`
       (identical from curl), `pnpm cli itx call <path...>` sugar; discovery =
-      `itx.describe()`
+      `itx.__describe()`
 - [ ] MCP: `run_itx_code` tool on the project MCP server (depends on the itx
       processor task)
 


### PR DESCRIPTION
## Summary
- Seed auth preview OAuth clients through the route-verified preview origin after routes are installed.
- Use the current `__describe()` project discovery surface in forged preview session setup.
- Update local docs/help examples for the current project discovery call shape.

## Validation
- `pnpm --dir apps/auth test`
- `pnpm --dir apps/auth typecheck`
- `pnpm --dir apps/os exec vitest run src/domains/integrations/slack-processors.test.ts`
- `pnpm --dir apps/os exec vitest run src/itx/browser-repl.test.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly documentation and test alignment plus a defensive auth deploy seed retry; the auth seed path affects preview sign-in but fails over safely to workers.dev.
> 
> **Overview**
> **Auth preview deploys** now seed OAuth clients through the route-verified custom hostname first (`primaryUrl` after `IterateRoutes`), then fall back to `workers.dev` if readiness fails—replacing seeding only via `workers.dev`.
> 
> **itx discovery** is aligned across docs, CLI hints, MCP/`exec_js` examples, forged-session helpers, Slack bang-command tests, and tasks: callers use **`itx.__describe()`** instead of `itx.describe()`.
> 
> **Playwright** forged-session REPL smoke waits for the editor and asserts a successful REPL entry whose JSON result includes a **`capabilities`** array, instead of matching visible `"capabilities"` text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b01974425674c79b8f445517c156cc33124aeb28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-03T22:47:36.901Z",
      "headSha": "73e16d4fe980280d36930514c0fb8a6d12e4a8ef",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/490294466430205",
      "shortSha": "73e16d4",
      "cleanupDurationMs": 102095,
      "deployDurationMs": 78419,
      "testDurationMs": 70223
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-03T22:46:43.989Z",
      "headSha": "73e16d4fe980280d36930514c0fb8a6d12e4a8ef",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/490294466430205",
      "shortSha": "73e16d4",
      "cleanupDurationMs": 49178,
      "deployDurationMs": 24750,
      "testDurationMs": 489
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `73e16d4` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 24.8s | 489ms | 49.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/490294466430205) | 2026-07-03T22:46:43.989Z | Preview app released. |
| OS | released | `73e16d4` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 78.4s | 70.2s | 102.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/490294466430205) | 2026-07-03T22:47:36.901Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->