### PR TITLE
[codex] fix mock proxy fetch-safe test ports

### DIFF
--- a/packages/mock-http-proxy/src/har/har-recorder.test.ts
+++ b/packages/mock-http-proxy/src/har/har-recorder.test.ts
@@ -1,12 +1,11 @@
 import { mkdtemp, readFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
-import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { once } from "node:events";
 import { brotliCompressSync, deflateSync, gzipSync } from "node:zlib";
 import { request } from "undici";
 import { describe, expect, test } from "vitest";
+import { listenOnFetchSafePort } from "../server/fetch-safe-listen.ts";
 import { HarRecorder } from "./har-recorder.ts";
 
 function harHeaderValue(
@@ -17,10 +16,8 @@ function harHeaderValue(
 }
 
 async function listen(server: Server): Promise<string> {
-  server.listen(0, "127.0.0.1");
-  await once(server, "listening");
-  const address = server.address() as AddressInfo;
-  return `http://127.0.0.1:${String(address.port)}`;
+  const { baseUrl } = await listenOnFetchSafePort(server);
+  return baseUrl;
 }
 
 async function close(server: Server): Promise<void> {

--- a/packages/mock-http-proxy/src/server/fetch-safe-listen.test.ts
+++ b/packages/mock-http-proxy/src/server/fetch-safe-listen.test.ts
@@ -1,0 +1,53 @@
+import { createServer, type Server } from "node:http";
+import { describe, expect, test } from "vitest";
+import { isFetchBlockedPort, listenOnFetchSafePort } from "./fetch-safe-listen.ts";
+
+describe("listenOnFetchSafePort", () => {
+  test("retries ephemeral ports that Fetch would block", async () => {
+    const server = createServer((_req, res) => {
+      res.end("ok");
+    });
+    const blockedPorts: number[] = [];
+    let calls = 0;
+
+    const result = await listenOnFetchSafePort(server, {
+      maxAttempts: 3,
+      isFetchBlockedPort(port) {
+        calls += 1;
+        if (calls === 1) {
+          blockedPorts.push(port);
+          return true;
+        }
+        return false;
+      },
+    });
+
+    try {
+      expect(calls).toBe(2);
+      expect(result.port).not.toBe(blockedPorts[0]);
+
+      const response = await fetch(result.baseUrl);
+      await expect(response.text()).resolves.toBe("ok");
+    } finally {
+      await close(server);
+    }
+  });
+
+  test("identifies ports blocked by Fetch", () => {
+    expect(isFetchBlockedPort(10080)).toBe(true);
+    expect(isFetchBlockedPort(6667)).toBe(true);
+    expect(isFetchBlockedPort(3000)).toBe(false);
+  });
+});
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}

--- a/packages/mock-http-proxy/src/server/fetch-safe-listen.ts
+++ b/packages/mock-http-proxy/src/server/fetch-safe-listen.ts
@@ -1,0 +1,104 @@
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+const FETCH_BLOCKED_PORTS = new Set([
+  1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77, 79, 87, 95, 101, 102,
+  103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 137, 139, 143, 161, 179, 389, 427, 465,
+  512, 513, 514, 515, 526, 530, 531, 532, 540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993,
+  995, 1719, 1720, 1723, 2049, 3659, 4045, 4190, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668,
+  6669, 6697, 10080,
+]);
+
+export type FetchSafeListenResult = {
+  baseUrl: string;
+  host: string;
+  port: number;
+};
+
+type FetchSafeListenOptions = {
+  host?: string;
+  port?: number;
+  maxAttempts?: number;
+  isFetchBlockedPort?: (port: number) => boolean;
+};
+
+export function isFetchBlockedPort(port: number): boolean {
+  return FETCH_BLOCKED_PORTS.has(port);
+}
+
+export async function listenOnFetchSafePort(
+  server: Server,
+  options: FetchSafeListenOptions = {},
+): Promise<FetchSafeListenResult> {
+  const host = options.host ?? "127.0.0.1";
+  const requestedPort = options.port ?? 0;
+  const maxAttempts = options.maxAttempts ?? 16;
+  const isBlocked = options.isFetchBlockedPort ?? isFetchBlockedPort;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    await listenOnce(server, requestedPort, host);
+    const address = server.address();
+    if (!isAddressInfo(address)) {
+      await closeServer(server);
+      throw new Error("Expected TCP server address after listening");
+    }
+
+    if (!isBlocked(address.port)) {
+      return {
+        baseUrl: `http://${formatUrlHost(host)}:${String(address.port)}`,
+        host,
+        port: address.port,
+      };
+    }
+
+    await closeServer(server);
+    if (requestedPort !== 0) {
+      throw new Error(`Port ${String(address.port)} is blocked by Fetch`);
+    }
+  }
+
+  throw new Error(
+    `Could not find a Fetch-safe ephemeral port after ${String(maxAttempts)} attempts`,
+  );
+}
+
+async function listenOnce(server: Server, port: number, host: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = (): void => {
+      server.off("error", onError);
+      server.off("listening", onListening);
+    };
+    const onError = (error: Error): void => {
+      cleanup();
+      reject(error);
+    };
+    const onListening = (): void => {
+      cleanup();
+      resolve();
+    };
+
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(port, host);
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function isAddressInfo(address: ReturnType<Server["address"]>): address is AddressInfo {
+  return typeof address === "object" && address !== null && "port" in address;
+}
+
+function formatUrlHost(host: string): string {
+  return host.includes(":") ? `[${host}]` : host;
+}

--- a/packages/mock-http-proxy/src/server/mock-http-server-fixture.ts
+++ b/packages/mock-http-proxy/src/server/mock-http-server-fixture.ts
@@ -1,9 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { once } from "node:events";
 import type * as msw from "msw";
 import type * as mswNode from "msw/node";
 import type { Har } from "har-format";
@@ -24,6 +22,7 @@ import {
   createProxyRequestTransform,
   createProxyWebSocketUrlTransform,
 } from "./proxy-request-transform.ts";
+import { listenOnFetchSafePort } from "./fetch-safe-listen.ts";
 
 export type UseMockHttpServerOptions = {
   recorder?: RecorderOpts;
@@ -260,12 +259,10 @@ export async function useMockHttpServer(
   });
 
   const host = options.host ?? "127.0.0.1";
-  server.listen(options.port ?? 0, host);
-  await once(server, "listening");
-
-  const address = server.address() as AddressInfo;
-  const port = address.port;
-  const url = `http://${host}:${String(port)}`;
+  const { baseUrl: url, port } = await listenOnFetchSafePort(server, {
+    host,
+    port: options.port,
+  });
   let disposed = false;
   const dispose = async (): Promise<void> => {
     if (disposed) return;

--- a/packages/mock-http-proxy/src/server/msw-server-adapter.api.test.ts
+++ b/packages/mock-http-proxy/src/server/msw-server-adapter.api.test.ts
@@ -1,17 +1,14 @@
-import { once } from "node:events";
-import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, test } from "vitest";
 import { HttpResponse, http } from "msw";
+import { listenOnFetchSafePort } from "./fetch-safe-listen.ts";
 import { createNativeMswServer, type NativeMswServer } from "./msw-server-adapter.ts";
 
 const activeServers = new Set<NativeMswServer>();
 
 async function listen(server: NativeMswServer): Promise<string> {
-  server.listen(0, "127.0.0.1");
-  await once(server, "listening");
+  const { baseUrl } = await listenOnFetchSafePort(server);
   activeServers.add(server);
-  const address = server.address() as AddressInfo;
-  return `http://127.0.0.1:${String(address.port)}`;
+  return baseUrl;
 }
 
 async function close(server: NativeMswServer): Promise<void> {

--- a/packages/mock-http-proxy/src/server/msw-server-adapter.http-parity.test.ts
+++ b/packages/mock-http-proxy/src/server/msw-server-adapter.http-parity.test.ts
@@ -1,8 +1,7 @@
-import { once } from "node:events";
 import { createServer, request as httpRequest, type Server } from "node:http";
-import type { AddressInfo } from "node:net";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { HttpResponse, http, passthrough } from "msw";
+import { listenOnFetchSafePort } from "./fetch-safe-listen.ts";
 import { createNativeMswServer, type NativeMswServer } from "./msw-server-adapter.ts";
 
 const activeServers = new Set<NativeMswServer>();
@@ -20,13 +19,11 @@ type LifecycleEventName = (typeof lifecycleEventNames)[number];
 type LifecycleEventCall = [LifecycleEventName, { request: Request; requestId: string }];
 
 async function listen(server: NativeMswServer): Promise<{ baseUrl: string; port: number }> {
-  server.listen(0, "127.0.0.1");
-  await once(server, "listening");
+  const { baseUrl, port } = await listenOnFetchSafePort(server);
   activeServers.add(server);
-  const address = server.address() as AddressInfo;
   return {
-    baseUrl: `http://127.0.0.1:${String(address.port)}`,
-    port: address.port,
+    baseUrl,
+    port,
   };
 }
 
@@ -44,13 +41,11 @@ async function close(server: NativeMswServer): Promise<void> {
 }
 
 async function listenUpstream(server: Server): Promise<{ baseUrl: string; port: number }> {
-  server.listen(0, "127.0.0.1");
-  await once(server, "listening");
+  const { baseUrl, port } = await listenOnFetchSafePort(server);
   activeUpstreamServers.add(server);
-  const address = server.address() as AddressInfo;
   return {
-    baseUrl: `http://127.0.0.1:${String(address.port)}`,
-    port: address.port,
+    baseUrl,
+    port,
   };
 }
 

--- a/packages/mock-http-proxy/src/server/msw-server-adapter.transport.test.ts
+++ b/packages/mock-http-proxy/src/server/msw-server-adapter.transport.test.ts
@@ -1,11 +1,11 @@
 import { once } from "node:events";
 import { Agent, createServer, request as httpRequest, type Server } from "node:http";
-import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, test } from "vitest";
 import { HttpResponse, http, ws } from "msw";
 import { WebSocket, WebSocketServer } from "ws";
 import type { RawData } from "ws";
 import { ws as exportedWs } from "../index.ts";
+import { listenOnFetchSafePort } from "./fetch-safe-listen.ts";
 import { createNativeMswServer, type NativeMswServer } from "./msw-server-adapter.ts";
 
 const activeServers = new Set<NativeMswServer>();
@@ -13,14 +13,12 @@ const activeWebSocketServers = new Set<WebSocketServer>();
 const activeUpstreamHttpServers = new Set<Server>();
 
 async function listen(server: NativeMswServer): Promise<{ baseUrl: string; port: number }> {
-  server.listen(0, "127.0.0.1");
-  await once(server, "listening");
+  const { baseUrl, port } = await listenOnFetchSafePort(server);
   activeServers.add(server);
-  const address = server.address() as AddressInfo;
 
   return {
-    baseUrl: `http://127.0.0.1:${String(address.port)}`,
-    port: address.port,
+    baseUrl,
+    port,
   };
 }
 
@@ -51,11 +49,9 @@ async function closeWebSocketServer(server: WebSocketServer): Promise<void> {
 }
 
 async function listenUpstreamHttpServer(server: Server): Promise<{ port: number }> {
-  server.listen(0, "127.0.0.1");
-  await once(server, "listening");
+  const { port } = await listenOnFetchSafePort(server);
   activeUpstreamHttpServers.add(server);
-  const address = server.address() as AddressInfo;
-  return { port: address.port };
+  return { port };
 }
 
 async function closeUpstreamHttpServer(server: Server): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes a mock-http-proxy test flake where `server.listen(0)` can receive an ephemeral port that Fetch refuses before the request reaches the local server.

Adds a shared `listenOnFetchSafePort` helper that retries ephemeral binds when the selected port is blocked by Fetch, then uses it in the mock proxy test helpers and reusable mock server fixture.

## Root Cause

The OS can assign ephemeral ports from Fetch's blocked-port table. Node can listen on those ports, but `fetch("http://127.0.0.1:<port>")` rejects the URL before contacting the server.

## Validation

- `pnpm --dir packages/mock-http-proxy typecheck`
- `pnpm --dir packages/mock-http-proxy test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and dev-fixture infrastructure only; no production runtime or auth/data paths change.
> 
> **Overview**
> Adds **`listenOnFetchSafePort`** (and **`isFetchBlockedPort`**) so test and fixture servers avoid ephemeral ports that Node can bind but **`fetch`** rejects before any traffic hits the server.
> 
> For port `0`, the helper closes and retries (up to 16 attempts) when the assigned port is on Fetch’s blocked list; a fixed blocked port fails fast with a clear error. **`useMockHttpServer`** and shared test **`listen`** helpers now use this instead of raw **`listen(0)`**.
> 
> New unit tests cover retry behavior (with injectable **`isFetchBlockedPort`**) and a few known blocked vs safe ports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 384d72337ef0693cd854c9dc552f51f42611d8a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->