### PR TITLE
Document autofix diff-correlation failure in Depot CI gotchas

### DIFF
--- a/docs/depot-ci.md
+++ b/docs/depot-ci.md
@@ -221,3 +221,12 @@ cancel each other. When validating previews, use one path at a time.
 `depot ci logs` accepts a run id, job id, or attempt id. When a run has multiple
 jobs, pass `--job <job-key>` or use `depot ci status <run-id> --output json` to
 find the exact job/attempt id.
+
+When the autofix job fails with `pull request parse error: cannot find workflow
+run named "autofix.ci"`, the real signal is that autofix found a diff to apply
+(the apply step only contacts GitHub when there is one) and could not correlate
+the Depot run with a GitHub Actions run. Look at the `git diff` output in the
+job logs, apply the same fix locally (usually `pnpm format`), and push. A common
+cause is committing a locally regenerated file (for example
+`apps/iterate-com/backend/generated/skills-registry.ts`) whose generator output
+is not format-stable.


### PR DESCRIPTION
## Summary

- add a Trigger Gotchas note to `docs/depot-ci.md` explaining the misleading `cannot find workflow run named "autofix.ci"` failure: it means autofix found a diff to apply and could not correlate the Depot run with a GitHub Actions run; the fix is in the job's `git diff` output

Learned while landing #1637, where a locally regenerated `skills-registry.ts` triggered exactly this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or CI behavior impact.
> 
> **Overview**
> Adds a **Trigger Gotchas** note in `docs/depot-ci.md` for when the autofix job fails with `pull request parse error: cannot find workflow run named "autofix.ci"`.
> 
> The doc explains that message is misleading: autofix already found a diff to apply but could not tie the Depot run to a GitHub Actions run. Reviewers should use the job’s **`git diff`**, fix locally (often **`pnpm format`**), and push. It also calls out a frequent cause—committing locally regenerated, non–format-stable generated files such as `skills-registry.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ead03254b410e6748354020deb5dd5c5fcada89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->