### PR TITLE
envs.ts: fix stale prd project-directory KV id

### DIFF
--- a/envs.ts
+++ b/envs.ts
@@ -109,7 +109,7 @@ export const envs = {
     authBaseUrl: "https://auth.iterate.com",
     projectHostnameBases: ["iterate.app"],
     resources: {
-      projectDirectoryKvId: "68a1bca8ba934ee9ba23c44c13a698f5",
+      projectDirectoryKvId: "79d78df2e83b46d2b9083533e9f189c4",
       authDbId: "f33fec8c-d5a3-44cf-b792-6a319ee1f729",
     },
   },


### PR DESCRIPTION
The prd `project-directory` KV was recreated during the 2026-07-03 prd reset; `envs.ts` (merged in #1636) carried the pre-reset id, so the first post-merge Deploy OS run fails with `KV namespace '68a1bca8…' not found`. Reconciled via `pnpm ensure-resources --env prd` — exactly the failure mode that flow was designed to surface.

After merge: re-run Deploy OS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single reviewed infrastructure ID swap in the env map; no application logic changes, but wrong IDs would break prd deploys until fixed.
> 
> **Overview**
> Updates the **prd** `resources.projectDirectoryKvId` in `envs.ts` to the current Cloudflare KV namespace after the production project-directory KV was recreated during the 2026-07-03 prd reset.
> 
> The previous id (`68a1bca8…`) no longer exists, which caused **Deploy OS** to fail with `KV namespace '…' not found` when generating/deploying wrangler config. The new id matches what `pnpm ensure-resources --env prd` reports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f8c16b9bad48d48cd3b61950553fe635488e854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->