### PR TITLE
Deploy fixes: retag alchemy:vN migration tags; envs.ts triggers deploy workflows

### DIFF
--- a/.depot/workflows/deploy-auth.yml
+++ b/.depot/workflows/deploy-auth.yml
@@ -11,6 +11,8 @@ on:
       - main
     paths:
       - apps/auth/**
+      - envs.ts
+      - scripts/lib/**
       - apps/auth-contract/**
       - packages/shared/**
       - packages/ui/**

--- a/.depot/workflows/deploy-os.yml
+++ b/.depot/workflows/deploy-os.yml
@@ -11,6 +11,8 @@ on:
       - main
     paths:
       - .depot/workflows/deploy-os.yml
+      - envs.ts
+      - scripts/lib/**
       - apps/os/**
       - apps/auth/**
       - apps/auth-contract/**

--- a/.depot/workflows/deploy-semaphore.yml
+++ b/.depot/workflows/deploy-semaphore.yml
@@ -11,6 +11,8 @@ on:
       - main
     paths:
       - .depot/workflows/deploy-semaphore.yml
+      - envs.ts
+      - scripts/lib/**
       - apps/semaphore/**
       - packages/shared/**
       - packages/ui/**

--- a/.depot/workflows/deploy-streams-example-app.yml
+++ b/.depot/workflows/deploy-streams-example-app.yml
@@ -11,6 +11,8 @@ on:
       - main
     paths:
       - .depot/workflows/deploy-streams-example-app.yml
+      - envs.ts
+      - scripts/lib/**
       - apps/streams-example-app/**
       - apps/os/src/domains/streams/**
       - packages/shared/**

--- a/.depot/workflows/deploy-tunnels.yml
+++ b/.depot/workflows/deploy-tunnels.yml
@@ -11,6 +11,8 @@ on:
       - main
     paths:
       - apps/tunnels/**
+      - envs.ts
+      - scripts/lib/**
       - packages/shared/**
       - packages/ui/**
       - packages/mock-http-proxy/**

--- a/scripts/lib/deploy-helpers.ts
+++ b/scripts/lib/deploy-helpers.ts
@@ -82,13 +82,14 @@ export async function adoptDoMigrationTag(ctx: CfContext, workerName: string) {
     `/workers/scripts?per_page=1000`,
   );
   const script = scripts.find((candidate) => candidate.id === workerName);
-  // Loose != also catches the list endpoint omitting the field (undefined).
-  if (!script || script.migration_tag != null) return;
-  // Adoption is ONLY correct when the classes are already live: tagging a
-  // CLASSLESS worker makes wrangler treat the v1 migrations as already
-  // applied and skip creating the classes — wedging every future deploy on
-  // 10061 (observed live on os-preview-3, 2026-07-04). Classless workers
-  // take deployWithSecrets' bootstrap-deploy path instead.
+  // Loose == also catches the list endpoint omitting the field (undefined).
+  const remoteTag = script?.migration_tag == null ? null : script.migration_tag;
+  if (!script || remoteTag === "v1") return;
+  // Adoption/retag is ONLY correct when the classes are already live:
+  // tagging a CLASSLESS worker makes wrangler treat the v1 migrations as
+  // already applied and skip creating the classes — wedging every future
+  // deploy on 10061 (observed live on os-preview-3, 2026-07-04). Classless
+  // workers take deployWithSecrets' bootstrap-deploy path instead.
   const settings = await ctx
     .cf<{ bindings?: { type: string }[] }>(`/workers/scripts/${workerName}/settings`)
     .catch(() => null);
@@ -96,9 +97,28 @@ export async function adoptDoMigrationTag(ctx: CfContext, workerName: string) {
     console.log(`Worker ${workerName} has no live DO classes — skipping migration-tag adoption.`);
     return;
   }
-  console.log(`Adopting DO migration tag v1 on ${workerName} (was untagged/alchemy-era)`);
+  // Two alchemy-era shapes, one remedy — an empty-steps migration that lands
+  // the worker on tag v1 without touching classes:
+  //   tag null          → plain adoption ({new_tag: "v1"})
+  //   tag "alchemy:vN"  → rename ({old_tag: <remote>, new_tag: "v1"}); without
+  //     it wrangler warns "migration tag not found in your wrangler.json",
+  //     re-applies ALL migrations, and dies on CF 10074 (observed live on
+  //     semaphore-prd/tunnels-prd/streams-example-app-prd, 2026-07-04 — the
+  //     old deploy workflows kept re-tagging alchemy:vN until the cutover).
+  console.log(
+    `Adopting DO migration tag v1 on ${workerName} (was ${remoteTag === null ? "untagged" : `"${remoteTag}"`}/alchemy-era)`,
+  );
   const form = new FormData();
-  form.set("settings", JSON.stringify({ migrations: { new_tag: "v1", steps: [] } }));
+  form.set(
+    "settings",
+    JSON.stringify({
+      migrations: {
+        ...(remoteTag === null ? {} : { old_tag: remoteTag }),
+        new_tag: "v1",
+        steps: [],
+      },
+    }),
+  );
   await ctx.cf(`/workers/scripts/${workerName}/settings`, {
     method: "PATCH",
     body: form,


### PR DESCRIPTION
Two pieces of #1636 cutover fallout:

1. **alchemy:vN migration tags.** The old deploy workflows kept re-deploying semaphore/tunnels/streams with alchemy until the cutover merged, leaving their prd workers tagged `alchemy:v4/v5`. Wrangler can't find that tag in our config → re-applies all migrations → CF 10074 over live classes. `adoptDoMigrationTag` now renames any non-v1 tag to `v1` via an empty-steps migration (classes untouched). **Proven live on streams-example-app-prd** (`alchemy:v4` → v1, deploy green, health 200).
2. **envs.ts wasn't in any deploy workflow's `paths:`** — #1650's fix merged without retriggering Deploy OS. All five deploy workflows now watch `envs.ts` and `scripts/lib/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production deploy paths and Cloudflare worker migration state; incorrect tagging could wedge DO deploys, but changes are narrowly scoped to known alchemy-era remediation and CI triggers.
> 
> **Overview**
> Fixes post-cutover deploy failures where production workers still carried **`alchemy:vN`** Durable Object migration tags. **`adoptDoMigrationTag`** now treats any remote tag other than **`v1`** as needing remediation: untagged workers get a plain **`new_tag: v1`** adoption, while **`alchemy:vN`** workers get an empty-steps migration that **renames** the remote tag to **`v1`** via **`old_tag`**, so Wrangler stops re-applying migrations and hitting Cloudflare **10074** on live classes.
> 
> All five Depot deploy workflows (**auth**, **os**, **semaphore**, **streams-example-app**, **tunnels**) now trigger on changes to **`envs.ts`** and **`scripts/lib/**`**, so deploy-helper and environment config fixes on **`main`** actually run the affected deploy pipelines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bb2809d7a48b6de1c3f4b9942d43a8ec17abf34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->