### PR TITLE
[codex] Add Cloudflare artifact dashboard links

### DIFF
--- a/apps/os/src/config.test.ts
+++ b/apps/os/src/config.test.ts
@@ -1,7 +1,7 @@
 import { inspect } from "node:util";
 import { describe, expect, it } from "vitest";
 import { parseAppConfigFromEnv } from "@iterate-com/shared/config";
-import { AppConfig } from "./config.ts";
+import { AppConfig, parseConfig } from "./config.ts";
 
 const baseConfig = {
   openAiApiKey: "openai-api-key",
@@ -32,6 +32,17 @@ describe("AppConfig", () => {
         },
       }).adminApiSecret?.exposeSecret(),
     ).toEqual("admin-api-secret-example");
+  });
+
+  it("exposes the bound Cloudflare Artifacts config as public config", () => {
+    const config = parseConfig({
+      APP_CONFIG: JSON.stringify(baseConfig),
+      ARTIFACTS_ACCOUNT_ID: "04b3b57291ef2626c6a8daa9d47065a7",
+      ARTIFACTS_NAMESPACE: "os-prd-repos",
+    });
+
+    expect(config.cloudflare.accountId).toEqual("04b3b57291ef2626c6a8daa9d47065a7");
+    expect(config.cloudflare.artifactsNamespace).toEqual("os-prd-repos");
   });
 
   it("accepts structured Slack and Google integration runtime config", () => {

--- a/apps/os/src/config.ts
+++ b/apps/os/src/config.ts
@@ -81,6 +81,8 @@ export const AppConfig = z.object({
   openAiApiKey: redacted(z.string().trim().min(1)),
   cloudflare: z
     .object({
+      accountId: publicValue(z.string().trim().min(1)).optional(),
+      artifactsNamespace: publicValue(z.string().trim().min(1)).optional(),
       apiToken: redacted(z.string().trim().min(1)).optional(),
     })
     .default({}),
@@ -125,9 +127,46 @@ export type AppConfig = z.output<typeof AppConfig>;
  * carriers). Accepts `unknown` so callers don't need a cast at every site.
  */
 export function parseConfig(env: unknown): AppConfig {
-  return parseAppConfigFromEnv({
+  const config = parseAppConfigFromEnv({
     configSchema: AppConfig,
     prefix: "APP_CONFIG_",
     env: env as Record<string, unknown>,
   });
+  const artifactBindings = {
+    accountId: readStringBinding(env, "ARTIFACTS_ACCOUNT_ID"),
+    namespace: readStringBinding(env, "ARTIFACTS_NAMESPACE"),
+  };
+
+  if (
+    (config.cloudflare.accountId || !artifactBindings.accountId) &&
+    (config.cloudflare.artifactsNamespace || !artifactBindings.namespace)
+  ) {
+    return config;
+  }
+
+  return {
+    ...config,
+    cloudflare: {
+      ...config.cloudflare,
+      ...(config.cloudflare.accountId || !artifactBindings.accountId
+        ? {}
+        : { accountId: artifactBindings.accountId as AppConfig["cloudflare"]["accountId"] }),
+      ...(config.cloudflare.artifactsNamespace || !artifactBindings.namespace
+        ? {}
+        : {
+            artifactsNamespace:
+              artifactBindings.namespace as AppConfig["cloudflare"]["artifactsNamespace"],
+          }),
+    },
+  };
+}
+
+function readStringBinding(env: unknown, key: string) {
+  if (env === null || typeof env !== "object") return null;
+
+  const value = (env as Record<string, unknown>)[key];
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }

--- a/apps/os/src/lib/artifact-viewer-url.test.ts
+++ b/apps/os/src/lib/artifact-viewer-url.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildArtifactViewerUrl } from "./artifact-viewer-url.ts";
+import {
+  buildArtifactViewerUrl,
+  buildCloudflareArtifactDashboardUrl,
+} from "./artifact-viewer-url.ts";
 
 describe("buildArtifactViewerUrl", () => {
   it("derives the artifact viewer host from the OS app base URL", () => {
@@ -37,5 +40,45 @@ describe("buildArtifactViewerUrl", () => {
         artifactName: "iterate-config-base",
       }),
     ).toBe("http://os-artifacts.localhost:5173/iterate-config-base");
+  });
+});
+
+describe("buildCloudflareArtifactDashboardUrl", () => {
+  it("links directly to Cloudflare's artifact repo file listing", () => {
+    expect(
+      buildCloudflareArtifactDashboardUrl({
+        accountId: "04b3b57291ef2626c6a8daa9d47065a7",
+        artifactName: "app-todo-app",
+      }),
+    ).toBe(
+      "https://dash.cloudflare.com/04b3b57291ef2626c6a8daa9d47065a7/workers/artifacts/namespaces/default/repos/app-todo-app",
+    );
+  });
+
+  it("encodes artifact names and supports non-default namespaces", () => {
+    expect(
+      buildCloudflareArtifactDashboardUrl({
+        accountId: "04b3b57291ef2626c6a8daa9d47065a7",
+        artifactName: "proj__os__01krnehrkefqdrpxksbm9t4kxy--project",
+        namespace: "preview.repos",
+      }),
+    ).toBe(
+      "https://dash.cloudflare.com/04b3b57291ef2626c6a8daa9d47065a7/workers/artifacts/namespaces/preview.repos/repos/proj__os__01krnehrkefqdrpxksbm9t4kxy--project",
+    );
+  });
+
+  it("returns null without a valid Cloudflare account ID", () => {
+    expect(
+      buildCloudflareArtifactDashboardUrl({
+        accountId: "",
+        artifactName: "app-todo-app",
+      }),
+    ).toBeNull();
+    expect(
+      buildCloudflareArtifactDashboardUrl({
+        accountId: "not-an-account-id",
+        artifactName: "app-todo-app",
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/os/src/lib/artifact-viewer-url.ts
+++ b/apps/os/src/lib/artifact-viewer-url.ts
@@ -1,4 +1,5 @@
 const artifactNamePattern = /^[a-z0-9][a-z0-9._-]*$/i;
+const cloudflareAccountIdPattern = /^[a-f0-9]{32}$/i;
 
 export function buildArtifactViewerUrl(input: { appBaseUrl?: string; artifactName: string }) {
   if (!artifactNamePattern.test(input.artifactName)) return null;
@@ -19,6 +20,30 @@ export function buildArtifactViewerUrl(input: { appBaseUrl?: string; artifactNam
   url.search = "";
   url.hash = "";
   return url.toString();
+}
+
+export function buildCloudflareArtifactDashboardUrl(input: {
+  accountId?: string;
+  artifactName: string;
+  namespace?: string;
+}) {
+  const accountId = input.accountId?.trim();
+  const namespace = input.namespace ?? "default";
+
+  if (!accountId || !cloudflareAccountIdPattern.test(accountId)) return null;
+  if (!artifactNamePattern.test(input.artifactName)) return null;
+  if (!artifactNamePattern.test(namespace)) return null;
+
+  return [
+    "https://dash.cloudflare.com",
+    encodeURIComponent(accountId),
+    "workers",
+    "artifacts",
+    "namespaces",
+    encodeURIComponent(namespace),
+    "repos",
+    encodeURIComponent(input.artifactName),
+  ].join("/");
 }
 
 function artifactViewerHostname(appHostname: string) {

--- a/apps/os/src/lib/public-route-config.ts
+++ b/apps/os/src/lib/public-route-config.ts
@@ -26,6 +26,8 @@ export const getPublicConfigServerFn = createServerFn({ method: "GET" }).handler
 
 export type PublicRouteConfig = {
   baseUrl?: string;
+  cloudflareAccountId?: string;
+  cloudflareArtifactsNamespace?: string;
   mcpBaseUrl?: string;
   projectHostnameBases: string[];
 };
@@ -36,6 +38,8 @@ export const getPublicRouteConfig = createServerFn({ method: "GET" }).handler(
 
     return {
       baseUrl: config.baseUrl,
+      cloudflareAccountId: config.cloudflare.accountId,
+      cloudflareArtifactsNamespace: config.cloudflare.artifactsNamespace,
       mcpBaseUrl: config.mcp?.baseUrl,
       projectHostnameBases: config.projectHostnameBases ?? [],
     };

--- a/apps/os/src/routes/_app/projects/$projectSlug/repos/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/repos/index.tsx
@@ -26,7 +26,7 @@ import {
 import { ItxBoundary } from "~/components/itx-boundary.tsx";
 import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import { RepoArtifactNameCodec } from "~/domains/repos/utils.ts";
-import { buildArtifactViewerUrl } from "~/lib/artifact-viewer-url.ts";
+import { buildCloudflareArtifactDashboardUrl } from "~/lib/artifact-viewer-url.ts";
 import { formatRelativeTime } from "~/lib/format-relative-time.ts";
 import { getPublicRouteConfig } from "~/lib/public-route-config.ts";
 import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
@@ -243,12 +243,14 @@ function ProjectReposIndexContent() {
                 </TableRow>
               ) : (
                 visibleRepos.map((repo) => {
-                  const artifactViewerUrl = buildArtifactViewerUrl({
-                    appBaseUrl: routeConfig.baseUrl,
-                    artifactName: RepoArtifactNameCodec.stringify({
-                      projectId: project.id,
-                      path: repo.path,
-                    }),
+                  const artifactName = RepoArtifactNameCodec.stringify({
+                    projectId: project.id,
+                    path: repo.path,
+                  });
+                  const artifactDashboardUrl = buildCloudflareArtifactDashboardUrl({
+                    accountId: routeConfig.cloudflareAccountId,
+                    artifactName,
+                    namespace: routeConfig.cloudflareArtifactsNamespace,
                   });
                   const repoSplat = repoPathToSplat(repo.path);
 
@@ -271,15 +273,25 @@ function ProjectReposIndexContent() {
                         {formatRelativeTime(repo.createdAt)}
                       </TableCell>
                       <TableCell className="w-32">
-                        <a
-                          className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-                          href={artifactViewerUrl ?? "#"}
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          <ExternalLink className="size-4" />
-                          Artifact
-                        </a>
+                        {artifactDashboardUrl ? (
+                          <a
+                            className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+                            href={artifactDashboardUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            <ExternalLink className="size-4" />
+                            Artifact
+                          </a>
+                        ) : (
+                          <span
+                            className="inline-flex items-center gap-1 text-sm text-muted-foreground"
+                            title="Cloudflare account ID is not configured."
+                          >
+                            <ExternalLink className="size-4" />
+                            Artifact
+                          </span>
+                        )}
                       </TableCell>
                     </TableRow>
                   );

--- a/packages/shared/src/config.test.ts
+++ b/packages/shared/src/config.test.ts
@@ -336,6 +336,7 @@ describe("public config helpers", () => {
         enabled: publicValue(z.boolean()),
       }),
     }),
+    maybePublic: publicValue(z.string()).optional(),
     tags: publicValue(z.array(z.string())),
   });
 
@@ -351,6 +352,7 @@ describe("public config helpers", () => {
           enabled: true,
         },
       },
+      maybePublic: "shown",
       tags: ["alpha", "beta"],
     });
 
@@ -366,6 +368,7 @@ describe("public config helpers", () => {
           enabled: true,
         },
       },
+      maybePublic: "shown",
       tags: ["alpha", "beta"],
     });
     expect(getPublicConfig(config, Config)).toEqual({
@@ -377,6 +380,7 @@ describe("public config helpers", () => {
           enabled: true,
         },
       },
+      maybePublic: "shown",
       tags: ["alpha", "beta"],
     });
   });

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -197,6 +197,11 @@ function extractPublicConfigSchemaInternal(schema: z.ZodTypeAny): z.ZodTypeAny |
     return z.object(publicShape);
   }
 
+  if (schema instanceof z.ZodOptional) {
+    const publicInnerSchema = extractPublicConfigSchemaInternal(schema.unwrap() as z.ZodTypeAny);
+    return publicInnerSchema ? publicInnerSchema.optional() : null;
+  }
+
   if (schema instanceof z.ZodArray) {
     const publicElementSchema = extractPublicConfigSchemaInternal(schema.element as z.ZodTypeAny);
     if (!publicElementSchema) {


### PR DESCRIPTION
## Summary

- Adds a Cloudflare dashboard artifact URL builder for repo artifacts.
- Exposes the bound Cloudflare artifacts account ID through OS public route config.
- Updates the OS repos page Artifact link to open Cloudflare's artifact repo file listing.
- Preserves optional public config extraction in the shared config helper.

## Validation

- pnpm --dir apps/os test:unit src/lib/artifact-viewer-url.test.ts src/config.test.ts
- pnpm --dir packages/shared test src/config.test.ts
- pnpm --dir apps/os typecheck
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI and public config changes; only non-secret Cloudflare account and namespace identifiers are exposed to the client.
> 
> **Overview**
> Project **Artifact** links on the repos list now open **Cloudflare’s Workers Artifacts repo file listing** in the dashboard instead of the `os-artifacts` viewer host.
> 
> OS config gains optional public **`cloudflare.accountId`** and **`cloudflare.artifactsNamespace`**. **`parseConfig`** fills those from worker bindings **`ARTIFACTS_ACCOUNT_ID`** and **`ARTIFACTS_NAMESPACE`** when they are not already set via `APP_CONFIG`. **`getPublicRouteConfig`** exposes them to the UI. A new **`buildCloudflareArtifactDashboardUrl`** builds validated dashboard URLs (32-char account ID, optional namespace). When the account ID is missing or invalid, the Artifact control stays visible but non-clickable with a tooltip.
> 
> In **`packages/shared`**, **`extractPublicConfigSchema`** now unwraps **`ZodOptional`** so optional **`publicValue`** fields are included in the public config schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8d927de96df6d5ef4bf36624a58168204049967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-04T19:48:15.954Z",
      "headSha": "b8d927de96df6d5ef4bf36624a58168204049967",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/340738310326999",
      "shortSha": "b8d927d",
      "cleanupDurationMs": 5993,
      "deployDurationMs": 43989,
      "testDurationMs": 162368
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-04T19:48:11.183Z",
      "headSha": "b8d927de96df6d5ef4bf36624a58168204049967",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/340738310326999",
      "shortSha": "b8d927d",
      "cleanupDurationMs": 1218,
      "deployDurationMs": 18415,
      "testDurationMs": 6929
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-04T19:48:14.309Z",
      "headSha": "b8d927de96df6d5ef4bf36624a58168204049967",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/340738310326999",
      "shortSha": "b8d927d",
      "cleanupDurationMs": 4341,
      "deployDurationMs": 20485,
      "testDurationMs": 717
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-04T19:48:11.344Z",
      "headSha": "b8d927de96df6d5ef4bf36624a58168204049967",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-2.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/340738310326999",
      "shortSha": "b8d927d",
      "cleanupDurationMs": 1373,
      "deployDurationMs": 14551,
      "testDurationMs": 16658
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `b8d927d` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 20.5s | 717ms | 4.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/340738310326999) | 2026-07-04T19:48:14.309Z | Preview app released. |
| OS | released | `b8d927d` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 44.0s | 162.4s | 6.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/340738310326999) | 2026-07-04T19:48:15.954Z | Preview app released. |
| Semaphore | released | `b8d927d` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 18.4s | 6.9s | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/340738310326999) | 2026-07-04T19:48:11.183Z | Preview app released. |
| Streams Example App | released | `b8d927d` | [https://streams-example-app-preview-2.iterate-dev-preview.workers.dev](https://streams-example-app-preview-2.iterate-dev-preview.workers.dev) | 14.6s | 16.7s | 1.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/340738310326999) | 2026-07-04T19:48:11.344Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->