### PR TITLE
Render itx CLI script failures message-first instead of a stack dump

### DIFF
--- a/apps/os/scripts/itx.test.ts
+++ b/apps/os/scripts/itx.test.ts
@@ -1,0 +1,27 @@
+import { expect, it } from "vitest";
+
+import { formatScriptError } from "./itx.ts";
+
+// Regression for the PR #1612 production smoke finding: remote script errors
+// (e.g. `repo.edit` rejecting a missing `message`) printed as a stack dump
+// with the actual error message buried mid-transport-frames. The rendering
+// must lead with the message and surface enumerable extras like the Slack
+// SDK's `code`/`data`.
+it("leads with the message and surfaces enumerable extras of remote errors", () => {
+  const remote = new Error("An API error occurred: not_authed");
+  Object.assign(remote, { code: "slack_webapi_platform_error", data: { error: "not_authed" } });
+
+  const rendered = formatScriptError(remote);
+
+  expect(rendered.startsWith("itx script failed: An API error occurred: not_authed\n")).toBe(true);
+  expect(rendered).toContain('code: "slack_webapi_platform_error"');
+  expect(rendered).toContain('data: {"error":"not_authed"}');
+  // The stack stays available but indented below the headline, without
+  // repeating the message line.
+  expect(rendered).toContain("  at ");
+  expect(rendered).not.toContain("Error: An API error occurred");
+});
+
+it("renders non-Error throws as JSON", () => {
+  expect(formatScriptError({ reason: "nope" })).toBe('itx script failed: {"reason":"nope"}\n');
+});

--- a/apps/os/scripts/itx.ts
+++ b/apps/os/scripts/itx.ts
@@ -56,13 +56,39 @@ export async function run(options: RunOptions) {
   using itx = options.context
     ? connectItx({ ...connection, projectId: options.context })
     : connectItx(connection);
-  const result = await script(itx, vars, RpcTarget);
+  const result = await script(itx, vars, RpcTarget).catch((error: unknown) => {
+    process.stderr.write(formatScriptError(error));
+    process.exit(1);
+  });
 
   // Exactly one JSON document on stdout — scripts and the e2e suite parse it.
   process.stdout.write(`${JSON.stringify(result ?? null, null, 2)}\n`);
 
   // The Cap'n Web WebSocket would otherwise keep the process alive.
   process.exit(0);
+}
+
+/**
+ * Message-first rendering for script failures. Most errors here are remote:
+ * they crossed the Cap'n Web transport, which keeps `message` and enumerable
+ * extras (Slack errors carry `code`/`data`) but replaces the stack with local
+ * transport frames — so the default stack-dump rendering buries the one line
+ * that matters under noise. Lead with the message, then the extras, then the
+ * (local) stack for whoever needs it.
+ */
+export function formatScriptError(error: unknown): string {
+  if (!(error instanceof Error)) return `itx script failed: ${JSON.stringify(error)}\n`;
+  const extras = Object.entries(error)
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => `  ${key}: ${JSON.stringify(value)}\n`);
+  const stack = error.stack?.startsWith(`${error.name}: ${error.message}`)
+    ? error.stack.slice(`${error.name}: ${error.message}`.length).trimStart()
+    : error.stack;
+  return [
+    `itx script failed: ${error.message}\n`,
+    ...extras,
+    ...(stack ? [`${stack.replace(/^/gm, "  ")}\n`] : []),
+  ].join("");
 }
 
 type ReplOptions = {


### PR DESCRIPTION
## What

`pnpm cli itx run` now catches script failures and prints them message-first: `itx script failed: <message>`, then enumerable extras (e.g. the Slack SDK's `code`/`data`), then the stack indented below. Exit code 1 as before. Unit tests cover the rendering.

## Why

Found during PR #1612 production smoke testing: `itx.repo.edit` rejecting a missing `message` printed as a truncated capnweb stack dump with the actual error buried mid-transport-frames. Remote errors that cross the Cap'n Web transport keep `message` and enumerable extras but their stack is local transport noise — rendering the stack first optimizes for exactly the wrong part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only stderr formatting and exit handling for `itx run`; no server, auth, or data-path changes.
> 
> **Overview**
> **`pnpm cli itx run`** now catches script failures, prints a **message-first** line on stderr (`itx script failed: …`), then enumerable error fields (e.g. Slack `code`/`data`), then an indented stack without repeating the headline. Non-`Error` throws are JSON-stringified. Exit code stays **1**.
> 
> Adds exported **`formatScriptError`** and **Vitest** coverage for remote-error shaping and non-Error throws—addressing production smoke where Cap'n Web transport stacks buried the real API message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64ba01230dc55680a8a5739ed6914401f00c08e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-04T21:01:57.866Z",
      "headSha": "64ba01230dc55680a8a5739ed6914401f00c08e5",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/417958902922709",
      "shortSha": "64ba012",
      "cleanupDurationMs": 5762,
      "deployDurationMs": 48971,
      "testDurationMs": 135743
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-04T21:01:56.200Z",
      "headSha": "64ba01230dc55680a8a5739ed6914401f00c08e5",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/417958902922709",
      "shortSha": "64ba012",
      "cleanupDurationMs": 4088,
      "deployDurationMs": 20592,
      "testDurationMs": 488
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `64ba012` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 20.6s | 488ms | 4.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/417958902922709) | 2026-07-04T21:01:56.200Z | Preview app released. |
| OS | released | `64ba012` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 49.0s | 135.7s | 5.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/417958902922709) | 2026-07-04T21:01:57.866Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->