### PR TITLE
Stream view polish: no ⌘K on /projects, flicker-free inspector paging, two-column event-type filter

### DIFF
--- a/apps/os/src/components/feed-items-view.tsx
+++ b/apps/os/src/components/feed-items-view.tsx
@@ -291,9 +291,10 @@ function parseFeedItemData(raw: string): FeedItemData | null {
 }
 
 /**
- * Any-of event-type filter for the feed-items presets: a checkbox list of the
- * distinct primary event types currently in the local mirror (scoped to the
- * active preset's prefix so the offered types can actually match), with
+ * Any-of event-type filter for the feed-items presets: a roomy two-column grid
+ * of checkboxes, one per distinct primary event type currently in the local
+ * mirror (scoped to the active preset's prefix so the offered types can
+ * actually match), sorted alphabetically by display name and annotated with
  * per-type event counts.
  */
 export function FeedEventTypesFilter({
@@ -328,9 +329,13 @@ export function FeedEventTypesFilter({
   );
   const selected = value ?? [];
   // Stale URL values (hand-edited, or events not mirrored yet) must still
-  // render as selections so they can be unchecked.
+  // render as selections so they can be unchecked. Sort the merged set by the
+  // displayed short name so the two-column grid reads alphabetically (the SQL's
+  // ORDER BY is on the full type; the stale entries are appended out of band).
   const staleSelections = selected.filter((type) => !types.some((entry) => entry.type === type));
-  const options = [...staleSelections.map((type) => ({ count: 0, type })), ...types];
+  const options = [...staleSelections.map((type) => ({ count: 0, type })), ...types].sort((a, b) =>
+    shortEventType(a.type).localeCompare(shortEventType(b.type)),
+  );
 
   function toggle(type: string, checked: boolean) {
     const next = checked ? [...selected, type] : selected.filter((entry) => entry !== type);
@@ -358,18 +363,31 @@ export function FeedEventTypesFilter({
         </span>
         <ChevronDownIcon className="size-3 text-muted-foreground" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="max-h-80 overflow-y-auto">
-        {options.map((entry) => (
-          <DropdownMenuCheckboxItem
-            key={entry.type}
-            checked={selected.includes(entry.type)}
-            closeOnClick={false}
-            onCheckedChange={(checked) => toggle(entry.type, checked)}
-            className="font-mono text-xs"
-          >
-            {shortEventType(entry.type)} · {entry.count.toLocaleString()}
-          </DropdownMenuCheckboxItem>
-        ))}
+      <DropdownMenuContent align="start" className="w-[min(90vw,34rem)] max-w-[calc(100vw-2rem)]">
+        <div className="grid max-h-96 grid-cols-2 gap-x-1 overflow-y-auto">
+          {options.length === 0 ? (
+            <p className="col-span-2 px-2 py-1.5 text-xs text-muted-foreground">
+              No event types in the mirror yet.
+            </p>
+          ) : (
+            options.map((entry) => (
+              <DropdownMenuCheckboxItem
+                key={entry.type}
+                checked={selected.includes(entry.type)}
+                closeOnClick={false}
+                onCheckedChange={(checked) => toggle(entry.type, checked)}
+                className="min-w-0 font-mono text-xs"
+              >
+                <span className="min-w-0 flex-1 truncate" title={shortEventType(entry.type)}>
+                  {shortEventType(entry.type)}
+                </span>
+                <span className="shrink-0 text-muted-foreground">
+                  {entry.count.toLocaleString()}
+                </span>
+              </DropdownMenuCheckboxItem>
+            ))
+          )}
+        </div>
         {selected.length > 0 ? (
           <>
             <DropdownMenuSeparator />

--- a/apps/os/src/components/raw-event-inspector-panel.tsx
+++ b/apps/os/src/components/raw-event-inspector-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { ChevronLeftIcon, ChevronRightIcon, XIcon } from "lucide-react";
 import { Button } from "@iterate-com/ui/components/button";
 import { SerializedObjectCodeBlock } from "@iterate-com/ui/components/serialized-object-code-block";
@@ -57,12 +57,18 @@ export function RawEventInspectorPanel({
   const previousOffset = asNumber(previousResult.data[0]?.offset);
   const nextOffset = asNumber(nextResult.data[0]?.offset);
 
+  // The neighbour offsets change on every page, but the key handler itself must
+  // not: re-subscribing a window listener per keypress is pure churn. Read the
+  // current neighbours from a ref so the effect binds once (onNavigate is stable).
+  const neighboursRef = useRef({ previousOffset, nextOffset });
+  neighboursRef.current = { previousOffset, nextOffset };
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
       // The panel coexists with the composer and filter inputs (it is not a
       // modal, unlike the old sheet) — typing there must not page the log.
       if (isTypingTarget(event.target)) return;
+      const { previousOffset, nextOffset } = neighboursRef.current;
       if (event.key === "ArrowLeft" && previousOffset != null) {
         event.preventDefault();
         onNavigate(previousOffset);
@@ -74,7 +80,19 @@ export function RawEventInspectorPanel({
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [previousOffset, nextOffset, onNavigate]);
+  }, [onNavigate]);
+
+  // Parse + reorder only when the underlying row changes, not on every render:
+  // a fresh object identity would rebuild CodeMirror (its editor is keyed on
+  // the doc value) even when an incidental re-render left the event untouched.
+  const selectedRawJson = selected == null ? null : String(selected.raw_json);
+  const orderedEventData = useMemo(
+    () =>
+      selectedRawJson == null
+        ? null
+        : orderEventKeysForYamlDisplay(parseRawEventJson(selectedRawJson)),
+    [selectedRawJson],
+  );
 
   const selectedTimestamp = parseTimestamp(selected?.created_at);
   const sincePrevious = elapsedBetween(
@@ -141,20 +159,23 @@ export function RawEventInspectorPanel({
         </span>
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto border-t px-4 py-3">
-        {selectedResult.status === "pending" ? (
-          <p className="text-sm text-muted-foreground">Opening local SQLite mirror…</p>
-        ) : selected == null ? (
-          <p className="text-sm text-muted-foreground">
-            Event #{offset} is not in the local mirror (yet). Use Prev/Next to jump to the nearest
-            mirrored event.
-          </p>
-        ) : (
+        {orderedEventData != null ? (
+          // Paging seeds each new query with the prior row while SQLite catches
+          // up (stale-while-revalidate), so keep painting the last payload
+          // instead of flashing the placeholder — the swap is a clean SQL read.
           <SerializedObjectCodeBlock
-            data={orderEventKeysForYamlDisplay(parseRawEventJson(String(selected.raw_json)))}
+            data={orderedEventData}
             initialFormat="yaml"
             showToggle
             showCopyButton
           />
+        ) : selectedResult.status === "pending" ? (
+          <p className="text-sm text-muted-foreground">Opening local SQLite mirror…</p>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Event #{offset} is not in the local mirror (yet). Use Prev/Next to jump to the nearest
+            mirrored event.
+          </p>
         )}
       </div>
     </aside>

--- a/apps/os/src/routes/_app.tsx
+++ b/apps/os/src/routes/_app.tsx
@@ -38,6 +38,10 @@ function AppLayout() {
   // streamBreadcrumb IS a stream page. Only the few non-stream pages
   // (projects list, new-project, session REPL) get this minimal shell header.
   const isStreamPage = activeStreamBreadcrumb(matches) != null;
+  // The projects list is the one app page with no project context, so the
+  // stream ⌘K switcher has nothing to act on — hide its pill and don't mount
+  // the palette here, which also drops its global ⌘K key handler.
+  const isProjectsListPage = matches.at(-1)?.routeId === "/_app/projects/";
   const label = matches
     .map(
       (match) =>
@@ -55,23 +59,25 @@ function AppLayout() {
           <header className="flex shrink-0 items-center gap-3 px-4 pb-1 pt-2.5">
             <SidebarTrigger className="-ml-1 md:hidden" />
             {label ? <span className="truncate text-sm font-medium">{label}</span> : null}
-            <button
-              type="button"
-              aria-haspopup="dialog"
-              title="Switch or create a stream — ⌘K"
-              onClick={openGlobalCommandPalette}
-              className="ml-auto flex h-9 shrink-0 cursor-pointer items-center gap-2 rounded-full bg-muted px-3.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-            >
-              Streams
-              <kbd className="rounded bg-background px-1.5 py-px text-[10px]">⌘K</kbd>
-            </button>
+            {isProjectsListPage ? null : (
+              <button
+                type="button"
+                aria-haspopup="dialog"
+                title="Switch or create a stream — ⌘K"
+                onClick={openGlobalCommandPalette}
+                className="ml-auto flex h-9 shrink-0 cursor-pointer items-center gap-2 rounded-full bg-muted px-3.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+              >
+                Streams
+                <kbd className="rounded bg-background px-1.5 py-px text-[10px]">⌘K</kbd>
+              </button>
+            )}
           </header>
         )}
         <div className="flex min-h-0 flex-1 flex-col overflow-auto">
           <Outlet />
         </div>
       </SidebarInset>
-      <GlobalCommandPalette />
+      {isProjectsListPage ? null : <GlobalCommandPalette />}
     </SidebarProvider>
   );
 }


### PR DESCRIPTION
Three follow-ups to the stream-view resurrection (#1651).

### 1. No stream ⌘K on `/projects`
The projects list is the one app page with no project context, so the "Streams ⌘K" pill (and the global command palette + its ⌘K key handler) had nothing to act on there. Both are now dropped on that page only; every other page keeps the switcher.

### 2. Flicker-free raw-event inspector paging
Paging with the ← → arrows (or Prev/Next) flashed the "Opening local SQLite mirror…" placeholder over the payload on every step. Cause: the panel body was gated on the query's `pending` status, but the browser SQLite layer seeds each new point query with the previous row (stale-while-revalidate) and only flips `status` to `pending`. So there was always data to show — the placeholder was hiding it.

- Body now renders whenever a row is present and only shows the placeholder on a true cold start (no data yet).
- `parseRawEventJson` + `orderEventKeysForYamlDisplay` are memoized on the raw-json string — a fresh object identity each render was needlessly tearing down and rebuilding the CodeMirror editor.
- The arrow-key listener binds once via a ref instead of re-subscribing on every page.

(Reviewed the render path with a dedicated render-optimization pass; the paging swap is now a clean SQL read.)

### 3. Two-column event-type filter
The event-type filter dropdown is now a roomy two-column checkbox grid, sorted alphabetically by display name, instead of a cramped single-column list.

## Test plan
- `pnpm typecheck`, `pnpm lint`, `pnpm format` clean; feed-filter unit tests pass.
- Prod smoke after merge: `/projects` has no ⌘K pill, arrow paging in the inspector no longer flickers, and the event-type filter shows a two-column alphabetical grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and render-path tweaks on the projects list, inspector panel, and feed filter; no auth, API, or data-model changes.
> 
> **Overview**
> Polishes three stream-view UX areas: **projects list**, **raw-event inspector paging**, and the **feed event-type filter**.
> 
> On **`/_app/projects/`** only, the shell no longer shows the Streams **⌘K** pill and **`GlobalCommandPalette`** is not mounted, so the global ⌘K handler does not run where there is no project/stream context.
> 
> **`RawEventInspectorPanel`** keeps showing the last parsed payload while SQLite revalidates (stale-while-revalidate) instead of flashing “Opening local SQLite mirror…” on every arrow/page step. JSON parse + YAML key ordering are **`useMemo`**’d on the raw string to avoid rebuilding CodeMirror, and arrow-key navigation reads neighbour offsets from a **ref** so the window listener is registered once.
> 
> **`FeedEventTypesFilter`** switches from a narrow single-column list to a wider **two-column** checkbox grid: options sort by **`shortEventType`** display name, counts sit beside truncated labels, and an empty mirror shows a short message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aec1b789bbd9723a216baeea38c6a6378011ebf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-04T21:32:48.396Z",
      "headSha": "aec1b789bbd9723a216baeea38c6a6378011ebf4",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/80261478982203",
      "shortSha": "aec1b78",
      "cleanupDurationMs": 5178,
      "deployDurationMs": 43315,
      "testDurationMs": 196556
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-04T21:32:46.950Z",
      "headSha": "aec1b789bbd9723a216baeea38c6a6378011ebf4",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/80261478982203",
      "shortSha": "aec1b78",
      "cleanupDurationMs": 3728,
      "deployDurationMs": 19628,
      "testDurationMs": 486
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `aec1b78` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 19.6s | 486ms | 3.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/80261478982203) | 2026-07-04T21:32:46.950Z | Preview app released. |
| OS | released | `aec1b78` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 43.3s | 196.6s | 5.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/80261478982203) | 2026-07-04T21:32:48.396Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->