### PR TITLE
Remove fake stream telemetry

### DIFF
--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -44,7 +44,6 @@ import { StreamViewHeader } from "~/components/stream-view-header.tsx";
 import { presetsForStream } from "~/lib/stream-feed-filters.ts";
 import { NULL_DURABLE_OBJECT_PROJECT_ID } from "~/lib/stream-navigation.ts";
 import { useItx } from "~/itx/itx-react.tsx";
-import { useSimulatedRttMetrics } from "~/lib/stream-presence.ts";
 import {
   streamViewTab,
   useStreamViewPanels,
@@ -141,7 +140,6 @@ export function ProjectStreamView({
   const countResult = useStreamQuery(store.streamDatabase, `SELECT COUNT(*) AS count FROM events`);
   const eventCount = Number(countResult.data[0]?.count ?? 0);
   const agentUiState = useAgentUiReducedState(store.streamDatabase);
-  const metrics = useSimulatedRttMetrics();
 
   const { search } = useStreamViewSearch();
   const panels = useStreamViewPanels();
@@ -209,12 +207,7 @@ export function ProjectStreamView({
 
   return (
     <section className="flex min-h-0 flex-1 flex-col bg-background">
-      <StreamViewHeader
-        agentBusy={agentBusy}
-        metrics={metrics}
-        presence={presence}
-        streamPath={streamPath}
-      />
+      <StreamViewHeader agentBusy={agentBusy} presence={presence} streamPath={streamPath} />
       {search.filter !== true ? null : activeTab === "feed" ? (
         <StreamFeedFilterRow
           activePreset={activePreset}
@@ -287,7 +280,6 @@ export function ProjectStreamView({
             {panels.processorsPanelOpen ? (
               <StreamProcessorsPanel
                 presence={presence}
-                metrics={metrics}
                 eventCount={eventCount}
                 busy={agentBusy}
                 focusedKey={panels.focusedProcessorKey}

--- a/apps/os/src/components/stream-processors-panel.tsx
+++ b/apps/os/src/components/stream-processors-panel.tsx
@@ -5,14 +5,7 @@ import type { AgentUiPresenceEntry } from "@iterate-com/ui/components/events/age
 import { SerializedObjectCodeBlock } from "@iterate-com/ui/components/serialized-object-code-block";
 import { cn } from "@iterate-com/ui/lib/utils";
 import type { ProcessorRuntimeState } from "~/types.ts";
-import {
-  hashString,
-  presenceColorClasses,
-  presenceInitials,
-  presenceLabel,
-  sparklinePoints,
-  type RttMetrics,
-} from "~/lib/stream-presence.ts";
+import { presenceColorClasses, presenceInitials, presenceLabel } from "~/lib/stream-presence.ts";
 
 export function PresenceAvatar({
   entry,
@@ -52,9 +45,9 @@ export function PresenceAvatar({
 // ---------------------------------------------------------------------------
 
 /**
- * One abstraction for presence, metrics, and processor detail — everything is
- * a facet of "the stream's consumers". Overview lists every consumer with
- * (simulated) RTT/lag; clicking one drills into its announced contract.
+ * One abstraction for presence and processor detail — everything is a facet of
+ * "the stream's consumers". Overview lists every consumer; clicking one drills
+ * into its announced contract.
  */
 type ProcessorRuntimeStateResult = {
   runtimeState: ProcessorRuntimeState | null;
@@ -63,7 +56,6 @@ type ProcessorRuntimeStateResult = {
 
 export function StreamProcessorsPanel({
   presence,
-  metrics,
   eventCount,
   busy,
   focusedKey,
@@ -74,7 +66,6 @@ export function StreamProcessorsPanel({
   getProcessorRuntimeState,
 }: {
   presence: readonly AgentUiPresenceEntry[];
-  metrics: RttMetrics;
   eventCount: number;
   busy: boolean;
   /** Subscription key of the focused processor (URL-backed); null = overview. */
@@ -153,7 +144,6 @@ export function StreamProcessorsPanel({
       {focused == null ? (
         <ProcessorsOverview
           presence={presence}
-          metrics={metrics}
           eventCount={eventCount}
           busy={busy}
           focusedKey={focusedKey}
@@ -188,7 +178,6 @@ type ProcessorRuntimeStateLoad =
 
 function ProcessorsOverview({
   presence,
-  metrics,
   eventCount,
   busy,
   focusedKey,
@@ -197,7 +186,6 @@ function ProcessorsOverview({
   onClearClientDatabase,
 }: {
   presence: readonly AgentUiPresenceEntry[];
-  metrics: RttMetrics;
   eventCount: number;
   busy: boolean;
   focusedKey: string | null;
@@ -206,51 +194,28 @@ function ProcessorsOverview({
   onClearClientDatabase: () => Promise<void>;
 }) {
   const [clearState, setClearState] = useState<"idle" | "clearing" | "error">("idle");
-  const points = sparklinePoints(metrics.spark, 368, 44);
-  const area = `2,42 ${points} 366,42`;
 
   return (
     <>
       <div className="flex shrink-0 items-center gap-2 px-5 pb-2 pt-4">
         <div className="min-w-0 flex-1">
           <div className="text-base font-semibold">Processors</div>
-          <div className="text-xs text-muted-foreground">
-            presence · metrics · state, per consumer
-          </div>
+          <div className="text-xs text-muted-foreground">presence · state, per consumer</div>
         </div>
         <PanelCloseButton onClose={onClose} />
       </div>
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-5 pb-5 pt-2">
         <div className="rounded-2xl bg-muted/40 px-4 py-3.5">
-          <div className="flex items-baseline justify-between">
-            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-              Append round-trip
-            </span>
-            <span className="font-mono text-[10px] text-muted-foreground/70">simulated</span>
-          </div>
-          <div className="mt-2 flex items-end gap-3">
-            <span className="font-mono text-2xl font-semibold leading-none">
-              {metrics.rttNow}
-              <span className="text-xs text-muted-foreground">ms</span>
-            </span>
-            <svg viewBox="0 0 368 44" className="h-11 min-w-0 flex-1" preserveAspectRatio="none">
-              <polygon points={area} className="fill-emerald-500/10" />
-              <polyline
-                points={points}
-                fill="none"
-                className="stroke-emerald-600"
-                strokeWidth="1.5"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </div>
-          <div className="mt-3 flex gap-5">
-            <MetricStat label="p50" value={`${metrics.p50}ms`} />
-            <MetricStat label="p95" value={`${metrics.p95}ms`} />
-            <MetricStat label="events/s" value={(0.4 + (metrics.rttNow % 7) / 10).toFixed(1)} />
-            <MetricStat label="head" value={`#${eventCount}`} />
-          </div>
-          <div className="mt-3 flex justify-end">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Local mirror
+              </div>
+              <div className="mt-1 font-mono text-2xl font-semibold leading-none">
+                #{eventCount}
+              </div>
+              <div className="mt-1 text-xs text-muted-foreground">stream head</div>
+            </div>
             <Button
               variant="outline"
               size="sm"
@@ -272,10 +237,9 @@ function ProcessorsOverview({
           ) : null}
         </div>
         <div>
-          <div className="grid grid-cols-[minmax(0,1fr)_52px_44px] gap-1.5 px-3 pb-2 text-[10px] uppercase tracking-wider text-muted-foreground/70">
+          <div className="grid grid-cols-[minmax(0,1fr)_88px] gap-1.5 px-3 pb-2 text-[10px] uppercase tracking-wider text-muted-foreground/70">
             <span>Consumer</span>
-            <span className="text-right">RTT</span>
-            <span className="text-right">Lag</span>
+            <span className="text-right">Status</span>
           </div>
           <div className="flex flex-col">
             {presence.length === 0 ? (
@@ -289,7 +253,7 @@ function ProcessorsOverview({
                   type="button"
                   onClick={() => onFocus(entry.subscriptionKey)}
                   className={cn(
-                    "grid w-full grid-cols-[minmax(0,1fr)_52px_44px] items-center gap-1.5 rounded-xl px-3 py-2 text-left hover:bg-muted/40",
+                    "grid w-full grid-cols-[minmax(0,1fr)_88px] items-center gap-1.5 rounded-xl px-3 py-2 text-left hover:bg-muted/40",
                     entry.subscriptionKey === focusedKey &&
                       "bg-muted/60 ring-1 ring-inset ring-border",
                   )}
@@ -318,16 +282,21 @@ function ProcessorsOverview({
                       </span>
                     </span>
                   </span>
-                  <span className="text-right font-mono text-xs text-muted-foreground">
-                    {entry.connected ? `${fakeRtt(entry.subscriptionKey, metrics.rttNow)}ms` : "—"}
-                  </span>
                   <span
                     className={cn(
-                      "text-right font-mono text-xs",
-                      fakeLag(entry, busy) === "0" ? "text-muted-foreground" : "text-amber-600",
+                      "text-right text-xs",
+                      entry.connected
+                        ? busy && isLlmish(entry)
+                          ? "text-amber-600"
+                          : "text-emerald-600"
+                        : "text-muted-foreground",
                     )}
                   >
-                    {entry.connected ? fakeLag(entry, busy) : "—"}
+                    {entry.connected
+                      ? busy && isLlmish(entry)
+                        ? "processing"
+                        : "connected"
+                      : "offline"}
                   </span>
                 </button>
               ))
@@ -342,25 +311,6 @@ function ProcessorsOverview({
 function isLlmish(entry: AgentUiPresenceEntry): boolean {
   const slug = entry.processor?.slug ?? "";
   return ["agent", "openai-ws", "cloudflare-ai", "capability-host"].includes(slug);
-}
-
-/** Deterministic fake RTT for preview data; stable per subscription but still visibly live. */
-function fakeRtt(subscriptionKey: string, rttNow: number): number {
-  return 14 + (hashString(subscriptionKey) % 38) + (rttNow % 9);
-}
-
-function fakeLag(entry: AgentUiPresenceEntry, busy: boolean): string {
-  if (busy && isLlmish(entry)) return String(1 + (hashString(entry.subscriptionKey) % 3));
-  return "0";
-}
-
-function MetricStat({ label, value }: { label: string; value: string }) {
-  return (
-    <div>
-      <div className="text-[10px] uppercase tracking-wide text-muted-foreground/70">{label}</div>
-      <div className="mt-0.5 font-mono text-sm">{value}</div>
-    </div>
-  );
 }
 
 function ProcessorDetail({

--- a/apps/os/src/components/stream-view-header.tsx
+++ b/apps/os/src/components/stream-view-header.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon, FilterIcon } from "lucide-react";
+import { ActivityIcon, ChevronDownIcon, FilterIcon } from "lucide-react";
 import { Button } from "@iterate-com/ui/components/button";
 import { SidebarTrigger } from "@iterate-com/ui/components/sidebar";
 import { Tabs, TabsList, TabsTrigger } from "@iterate-com/ui/components/tabs";
@@ -7,7 +7,7 @@ import { cn } from "@iterate-com/ui/lib/utils";
 import { openGlobalCommandPalette } from "~/components/global-command-palette-events.ts";
 import { PresenceAvatar } from "~/components/stream-processors-panel.tsx";
 import { feedFiltersActive } from "~/lib/stream-feed-filters.ts";
-import { presenceLabel, sparklinePoints, type RttMetrics } from "~/lib/stream-presence.ts";
+import { presenceLabel } from "~/lib/stream-presence.ts";
 import {
   streamViewTab,
   useStreamViewPanels,
@@ -19,19 +19,17 @@ const MAX_PRESENCE_AVATARS = 4;
 
 /**
  * THE page header — the app renders no other. Pill path breadcrumb (⌘K
- * trigger) top-left; presence, metrics, Feed/State tabs, and the filter
- * toggle on the right. Tab/filter/panel state is read and written straight
+ * trigger) top-left; presence, Feed/State tabs, and the filter toggle on the
+ * right. Tab/filter/panel state is read and written straight
  * from the URL (stream-view-search.ts), so this component needs no callbacks
  * from the view it heads.
  */
 export function StreamViewHeader({
   agentBusy,
-  metrics,
   presence,
   streamPath,
 }: {
   agentBusy: boolean;
-  metrics: RttMetrics;
   presence: readonly AgentUiPresenceEntry[];
   streamPath: string;
 }) {
@@ -100,20 +98,12 @@ export function StreamViewHeader({
         <Button
           variant="ghost"
           size="sm"
-          title="Stream health & metrics"
+          title="Processors"
           onClick={openProcessorsOverview}
-          className="font-mono text-xs font-normal text-muted-foreground"
+          className="text-xs font-normal text-muted-foreground"
         >
-          <svg width="24" height="11" viewBox="0 0 26 12" className="shrink-0">
-            <polyline
-              points={sparklinePoints(metrics.spark.slice(-12), 26, 12)}
-              fill="none"
-              className="stroke-emerald-600"
-              strokeWidth="1.4"
-              strokeLinejoin="round"
-            />
-          </svg>
-          {metrics.rttNow}ms
+          <ActivityIcon className="size-3.5" />
+          Processors
         </Button>
         <Tabs
           value={streamViewTab(search)}

--- a/apps/os/src/lib/stream-presence.ts
+++ b/apps/os/src/lib/stream-presence.ts
@@ -1,66 +1,6 @@
-// Presence + (simulated) metrics helpers shared by the stream header chrome
-// and the processors panel.
+// Presence helpers shared by the stream header chrome and the processors panel.
 
-import { useEffect, useMemo, useState } from "react";
 import type { AgentUiPresenceEntry } from "@iterate-com/ui/components/events/agent-ui-reducer";
-
-// ---------------------------------------------------------------------------
-// Simulated round-trip metrics (per design — real data comes later)
-// ---------------------------------------------------------------------------
-
-export type RttMetrics = {
-  spark: number[];
-  rttNow: number;
-  p50: number;
-  p95: number;
-};
-
-const INITIAL_SPARK = [
-  42, 38, 51, 36, 44, 39, 35, 62, 41, 38, 36, 55, 40, 37, 43, 39, 112, 48, 38, 36, 41, 39, 37, 38,
-];
-
-/** Random-walk append RTT with the occasional spike, ticking every ~2.2s. */
-export function useSimulatedRttMetrics(): RttMetrics {
-  const [spark, setSpark] = useState<number[]>(INITIAL_SPARK);
-
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setSpark((previous) => {
-        const next = previous.slice(1);
-        const value =
-          Math.random() > 0.93
-            ? Math.round(120 + Math.random() * 160)
-            : Math.round(30 + Math.random() * 30);
-        next.push(value);
-        return next;
-      });
-    }, 2200);
-    return () => clearInterval(timer);
-  }, []);
-
-  return useMemo(() => {
-    const sorted = [...spark].sort((a, b) => a - b);
-    return {
-      spark,
-      rttNow: spark[spark.length - 1] ?? 0,
-      p50: sorted[Math.floor(sorted.length * 0.5)] ?? 0,
-      p95: sorted[Math.floor(sorted.length * 0.95)] ?? 0,
-    };
-  }, [spark]);
-}
-
-export function sparklinePoints(values: readonly number[], width: number, height: number): string {
-  const max = 400;
-  const count = values.length;
-  if (count === 0) return "";
-  return values
-    .map((value, index) => {
-      const x = 2 + index * ((width - 4) / Math.max(1, count - 1));
-      const y = height - 4 - (Math.min(value, max) / max) * (height - 8);
-      return `${x.toFixed(1)},${y.toFixed(1)}`;
-    })
-    .join(" ");
-}
 
 // ---------------------------------------------------------------------------
 // Presence avatars


### PR DESCRIPTION
## Summary

Follow-up to the PR #1661 architecture review, §3.8: the stream operations UI rendered fabricated telemetry (`fakeRtt()`, simulated append RTT sparkline, and synthetic `events/s`). This PR removes those fake operational numbers instead of keeping a simulated panel around until real ping metrics exist.

What changed:

- Removed `useSimulatedRttMetrics`, `RttMetrics`, and `sparklinePoints` from `apps/os/src/lib/stream-presence.ts`.
- Removed the simulated RTT sparkline and `rttNow` button from `StreamViewHeader`; the button is now a plain `Processors` affordance that still opens the same side panel.
- Removed the processor-panel `Append round-trip`, `p50`, `p95`, `events/s`, per-consumer fake RTT, and fake lag columns.
- Kept the genuinely observable data: processor presence/status and the local mirror stream head count.

## LOC Breakdown

`git diff --stat`:

```text
apps/os/src/components/project-stream-view.tsx      |  10 +-
apps/os/src/components/stream-processors-panel.tsx  | 108 ++++++---------------
apps/os/src/components/stream-view-header.tsx       |  26 ++---
apps/os/src/lib/stream-presence.ts                  |  62 +-----------
4 files changed, 39 insertions(+), 167 deletions(-)
```

Net effect: **128 lines removed**.

## Why This Is A No-Brainer

The panel is an operations surface. Showing deterministic/random latency and throughput values makes it look like the system has measured stream transport health when it has not. No telemetry is better than fabricated telemetry here.

Before:

```tsx
<MetricStat label="events/s" value={(0.4 + (metrics.rttNow % 7) / 10).toFixed(1)} />
{entry.connected ? `${fakeRtt(entry.subscriptionKey, metrics.rttNow)}ms` : "—"}
```

After:

```tsx
{entry.connected ? (busy && isLlmish(entry) ? "processing" : "connected") : "offline"}
```

## Possible Negative Impacts

- The header no longer has an animated sparkline/latency number, so the stream header is visually quieter.
- The processors panel loses the apparent per-subscriber RTT and lag columns. Those values were not real, so this is a product honesty tradeoff rather than a data loss.
- Anyone using the fake RTT display as a rough activity indicator will now use presence/status instead.

## Considerations

This deliberately does **not** add real socket ping metrics. The review called out that fabricated latency is worse than no latency; real ping telemetry should be a separate PR because it needs a source-of-truth design across the browser store and live connection layer.

## Other Options Considered

1. Keep the simulated chart but relabel it more aggressively as fake.
   - Rejected: still leaves fake numbers on an operations panel.
2. Hide only `events/s` and per-consumer RTT.
   - Rejected: the top-level simulated RTT model would remain and continue to imply measured transport latency.
3. Replace the chart with real ping timing in this PR.
   - Rejected: higher-risk behavior change and outside this no-brainer cleanup.

## Validation

- `pnpm --dir apps/os typecheck`
- `pnpm lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only cleanup removing fake numbers; observable presence, event count, and processor detail (including real lag in processor detail view) are unchanged.
> 
> **Overview**
> Removes **simulated** stream health metrics from the OS stream view so the operations UI no longer implies measured transport latency or throughput.
> 
> **`stream-presence.ts`** drops `useSimulatedRttMetrics`, `RttMetrics`, and `sparklinePoints` (the random-walk append RTT hook and sparkline helper). Presence avatar helpers stay.
> 
> **`project-stream-view`** stops wiring metrics into the header and processors panel.
> 
> **`stream-view-header`** replaces the sparkline + `rttNow` “Stream health & metrics” control with a plain **Processors** button (`ActivityIcon`) that still opens the same side panel.
> 
> **`stream-processors-panel`** removes the “Append round-trip” block (sparkline, p50/p95, fake `events/s`) and per-consumer **RTT** / **Lag** columns (`fakeRtt`, `fakeLag`, `MetricStat`). The overview now highlights **local mirror** stream head (`#eventCount`) and consumer **status** (connected / processing / offline) from real presence + `agentBusy`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fe4639a52c50e4e6b27b3a463a5b03d110475e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-04T21:45:18.673Z",
      "headSha": "4fe4639a52c50e4e6b27b3a463a5b03d110475e6",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/63466722478495",
      "shortSha": "4fe4639",
      "cleanupDurationMs": 5061,
      "deployDurationMs": 52086,
      "testDurationMs": 109548
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-04T21:45:17.270Z",
      "headSha": "4fe4639a52c50e4e6b27b3a463a5b03d110475e6",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/63466722478495",
      "shortSha": "4fe4639",
      "cleanupDurationMs": 3654,
      "deployDurationMs": 24105,
      "testDurationMs": 217
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `4fe4639` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 24.1s | 217ms | 3.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/63466722478495) | 2026-07-04T21:45:17.270Z | Preview app released. |
| OS | released | `4fe4639` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 52.1s | 109.5s | 5.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/63466722478495) | 2026-07-04T21:45:18.673Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->