### PR TITLE
Collapse the ingress routing pass

### DIFF
--- a/apps/os/src/ingress.test.ts
+++ b/apps/os/src/ingress.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { decideIngressRoute, apiWorkerRequest, type IngressResolvers } from "./ingress.ts";
+import { decideIngressRoute, type IngressResolvers } from "./ingress.ts";
 
 const PREVIEW_CONFIG = {
   baseUrl: "https://os.iterate-preview-2.com",
@@ -230,16 +230,16 @@ it("honors x-forwarded-host for host classification", async () => {
   });
 });
 
-it("apiWorkerRequest forwards project hosts and itx paths, keeps the app lane", () => {
-  const forward = (url: string, headers?: HeadersInit) =>
-    apiWorkerRequest({ config: DEV_CONFIG, request: new Request(url, { headers }) });
+it("ignores the deleted ingress-hostname handoff header", async () => {
+  const route = await decideIngressRoute({
+    config: DEV_CONFIG,
+    headers: { "x-iterate-ingress-hostname": "demo.localhost:56455" },
+    method: "GET",
+    resolvers: resolversThatShouldNotBeUsed(),
+    url: "http://localhost:56455/projects/demo",
+  });
 
-  expect(forward("http://localhost:56455/projects/demo")).toBeNull();
-  expect(forward("http://localhost:56455/api")).not.toBeNull();
-  expect(forward("http://localhost:56455/prj_123/x")).not.toBeNull();
-  expect(forward("http://demo.localhost:56455/")).not.toBeNull();
-  expect(forward("http://hello--demo.localhost:56455/")).not.toBeNull();
-  expect(forward("https://unknown-host.example.com/")).not.toBeNull();
+  expect(route).toMatchObject({ lane: "os" });
 });
 
 function resolversThatShouldNotBeUsed(): IngressResolvers {

--- a/apps/os/src/ingress.ts
+++ b/apps/os/src/ingress.ts
@@ -150,20 +150,10 @@ function isApiWorkerLanePath(pathname: string): boolean {
   return false;
 }
 
-/**
- * The externally-visible host for a request: tunnels (captun) and the ingress
- * worker present the original host via forwarding headers; otherwise the
- * request URL is already the truth.
- */
-function requestIngressHost(request: Request): string {
-  return requestIngressHostFrom(request.headers, new URL(request.url));
-}
-
+/** The externally-visible host for a request. */
 function requestIngressHostFrom(headers: Headers, url: URL): string {
   return normalizeIngressHost(
-    headers.get("x-iterate-ingress-hostname") ??
-      headers.get("x-forwarded-host")?.replace(/:\d+$/, "") ??
-      url.hostname,
+    headers.get("x-forwarded-host")?.replace(/:\d+$/, "") ?? url.hostname,
   );
 }
 
@@ -184,28 +174,4 @@ function isOsHost(input: {
     const base = normalizeIngressHost(normalizeProjectHostnameBase(rawBase));
     return input.host === base && (base === "localhost" || base.endsWith(".localhost"));
   });
-}
-
-/**
- * Cheap synchronous pre-filter answering "does this request belong to the
- * api pipeline": anything that is not the OS host (project platform hosts
- * and custom-hostname candidates alike), plus the api path lanes and the
- * /prj_ path lane on the OS host. The api pipeline then runs the full
- * `decideIngressRoute` (with directory resolvers) and owns the 404 for
- * hosts that resolve to nothing. TODO: collapse into one decideIngressRoute
- * pass in worker.ts — vestige of the deleted multi-worker topology.
- */
-export function apiWorkerRequest(input: {
-  config: { baseUrl?: string; projectHostnameBases?: readonly string[] };
-  request: Request;
-}): Request | null {
-  const url = new URL(input.request.url);
-  const host = requestIngressHost(input.request);
-  const bases = input.config.projectHostnameBases ?? [];
-  if (!isOsHost({ baseUrl: input.config.baseUrl, bases, host, requestUrl: url })) {
-    return input.request;
-  }
-  if (isApiWorkerLanePath(url.pathname)) return input.request;
-  if (/^\/prj_[^/]/.test(url.pathname)) return input.request;
-  return null;
 }

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -21,7 +21,7 @@ import { withEvlog } from "@iterate-com/shared/evlog";
 import { trustedInternalAuthContext } from "./auth.ts";
 import { e2eFixtureResponse } from "./e2e-fixtures.ts";
 import type { Env } from "./env.ts";
-import { apiWorkerRequest, decideIngressRoute, type IngressResolvers } from "./ingress.ts";
+import { decideIngressRoute, type IngressResolvers } from "./ingress.ts";
 import { readProjectByHostname, resolveProjectIdBySlug } from "./project-directory.ts";
 import { isWorkerBuildInProgressError } from "./domains/workers/worker-loader.ts";
 import {
@@ -96,11 +96,15 @@ export default {
     const mcpRequest = rewriteMcpHostRequest({ config, request });
     if (mcpRequest) return await appFetch(mcpRequest, ctx, config);
 
-    const apiRequest = apiWorkerRequest({ config, request });
-    if (apiRequest) return await apiFetch(apiRequest, env, ctx, config);
+    const route = await decideIngressRoute({
+      config,
+      headers: request.headers,
+      method: request.method,
+      resolvers: directoryResolvers(config, env),
+      url: request.url,
+    });
+    if (route.lane !== "os") return await apiFetch(request, ctx, config, route);
 
-    // Everything else is the OS host (project + custom hostnames all took the
-    // api lane above, which owns the 404 for hosts that resolve to nothing).
     return await appFetch(request, ctx, config);
   },
 };
@@ -139,19 +143,16 @@ async function appFetch(request: Request, ctx: ExecutionContext, config: AppConf
  * and project ingress — every lane `decideIngressRoute` (src/ingress.ts) can
  * resolve.
  */
-async function apiFetch(request: Request, env: Env, ctx: ExecutionContext, config: AppConfig) {
+async function apiFetch(
+  request: Request,
+  ctx: ExecutionContext,
+  config: AppConfig,
+  route: Exclude<Awaited<ReturnType<typeof decideIngressRoute>>, { lane: "os" }>,
+) {
   const url = new URL(request.url);
 
   const fixtureResponse = await e2eFixtureResponse(request);
   if (fixtureResponse !== null) return fixtureResponse;
-
-  const route = await decideIngressRoute({
-    config,
-    headers: request.headers,
-    method: request.method,
-    resolvers: directoryResolvers(config, env),
-    url: request.url,
-  });
 
   if (route.lane === "project") {
     const project = await new ProjectCollectionRpcTarget({
@@ -223,12 +224,10 @@ function directoryResolvers(config: AppConfig, env: Env): IngressResolvers {
 
 function stripInternalHeaders(request: Request) {
   const headers = new Headers(request.headers);
-  headers.delete("x-iterate-resolved-ingress");
   headers.delete("x-iterate-app");
   headers.delete("x-itx-project-id");
   headers.delete("x-iterate-url-prefix");
   headers.delete("x-forwarded-host");
   headers.delete("x-forwarded-proto");
-  headers.delete("x-iterate-ingress-hostname");
   return new Request(request, { headers });
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #1661 section 3.3. The single-worker migration left a small multi-worker routing vestige behind: `apiWorkerRequest()` first guessed whether a request should enter the API pipeline, and then `apiFetch()` called `decideIngressRoute()` again to make the real routing decision.

This PR collapses that into one `decideIngressRoute()` call from `worker.fetch`, then passes the result into `apiFetch`.

## What changed

- Removed the `apiWorkerRequest()` pre-filter and its TODO.
- Changed `worker.fetch` to call `decideIngressRoute()` once after MCP host rewriting.
- Changed `apiFetch` to accept the already-decided route instead of deciding again.
- Preserved existing e2e-fixture ordering: fixtures still get first chance inside the API lane before project/not-found handling.
- Removed the dead `x-iterate-ingress-hostname` read from ingress host selection.
- Removed dead stripping for `x-iterate-resolved-ingress` and `x-iterate-ingress-hostname`; neither header is produced by current `apps/os/src` code.
- Replaced the deleted pre-filter unit test with a regression asserting `x-iterate-ingress-hostname` no longer affects host classification.

## LOC breakdown

```text
apps/os/src/ingress.test.ts | 20 ++++++++++----------
apps/os/src/ingress.ts      | 38 ++------------------------------------
apps/os/src/worker.ts       | 31 +++++++++++++++----------------
Total: 3 files, +27/-62
```

## Code example

Before, routing was split across a pre-filter and the real resolver:

```ts
const apiRequest = apiWorkerRequest({ config, request });
if (apiRequest) return await apiFetch(apiRequest, env, ctx, config);
// apiFetch then called decideIngressRoute(...)
```

Now the worker makes the one routing decision up front:

```ts
const route = await decideIngressRoute({
  config,
  headers: request.headers,
  method: request.method,
  resolvers: directoryResolvers(config, env),
  url: request.url,
});
if (route.lane !== "os") return await apiFetch(request, ctx, config, route);
return await appFetch(request, ctx, config);
```

## Possible negative impacts

- Every non-MCP request now reaches `decideIngressRoute()` directly from `worker.fetch`. OS-host app requests still return before resolver lookups, so the hot app lane remains cheap.
- The deleted `x-iterate-ingress-hostname` support means that header can no longer override host classification. That is intentional: the old ingress-worker handoff no longer exists, and current production code strips the header before this decision anyway.
- API fixture handling remains inside `apiFetch`, so unknown-host fixture requests keep the existing behavior.

## Considerations

- `x-forwarded-host` support remains in `decideIngressRoute()` for direct callers/tests, but `worker.fetch` still strips it at the trust boundary before routing.
- Project, API, OS, and not-found lanes all still use the same `decideIngressRoute()` logic; the change removes only the duplicate classification layer.
- This PR intentionally does not change MCP host rewriting. That still happens before normal OS/project/API route selection.

## Other options considered

- Keep `apiWorkerRequest()` and only delete the dead headers. Rejected because the explicit TODO and duplicate route classification would remain.
- Move fixture handling before route selection in `worker.fetch`. Rejected to keep the existing API-lane fixture ordering and avoid broadening the fixture path outside the current routing flow.
- Export a named `IngressRoute` type. Rejected because the worker only needs the return type from `decideIngressRoute()` once.

## Validation

- `pnpm --dir apps/os exec vitest run src/ingress.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the central request entrypoint and host classification for all traffic; behavior should match prior lanes but mis-routing would affect every request path.
> 
> **Overview**
> **Ingress routing is now decided once** in `worker.fetch` via `decideIngressRoute`, instead of a synchronous `apiWorkerRequest` pre-filter followed by a second classification inside `apiFetch`.
> 
> Non-OS lanes (`api`, `project`, `notFound`) still go through the API pipeline; the pre-decided route is passed into `apiFetch`, which no longer calls `decideIngressRoute` again. E2E fixture handling stays first inside that pipeline.
> 
> **Dead multi-worker vestiges are removed:** `apiWorkerRequest` and its unit test; host selection no longer honors `x-iterate-ingress-hostname` (only `x-forwarded-host` or the request URL). `stripInternalHeaders` drops stripping for headers the OS no longer sets. A regression test asserts the old ingress-hostname header cannot steer routing on the OS app lane.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f5b79b571b9129dd4268271a9bf385171fcbe7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-04T22:06:57.297Z",
      "headSha": "2f5b79b571b9129dd4268271a9bf385171fcbe7e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/487718059097132",
      "shortSha": "2f5b79b",
      "cleanupDurationMs": 5276,
      "deployDurationMs": 47034,
      "testDurationMs": 70956
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-04T22:06:55.716Z",
      "headSha": "2f5b79b571b9129dd4268271a9bf385171fcbe7e",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/487718059097132",
      "shortSha": "2f5b79b",
      "cleanupDurationMs": 3689,
      "deployDurationMs": 20914,
      "testDurationMs": 214
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `2f5b79b` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 20.9s | 214ms | 3.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/487718059097132) | 2026-07-04T22:06:55.716Z | Preview app released. |
| OS | released | `2f5b79b` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 47.0s | 71.0s | 5.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/487718059097132) | 2026-07-04T22:06:57.297Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->