### PR TITLE
Feed rows: click to inspect, wider panel, flat rows, colour-coded time deltas

### DIFF
--- a/apps/os/src/components/feed-items-view.tsx
+++ b/apps/os/src/components/feed-items-view.tsx
@@ -85,7 +85,12 @@ export function FeedItemsView({
   const virtualItems = virtualizer.getVirtualItems();
   const first = virtualItems[0]?.index ?? 0;
   const last = virtualItems.at(-1)?.index ?? -1;
-  const windowSize = Math.max(0, last + 1 + TAIL_PREFETCH_ROWS - first);
+  // Fetch one row before the window (when there is one) so the topmost visible
+  // row has its predecessor available for the colour-coded time delta — the
+  // window's `first` row would otherwise never see index `first - 1`.
+  const prefetchBefore = first > 0 ? 1 : 0;
+  const queryOffset = first - prefetchBefore;
+  const windowSize = Math.max(0, last + 1 + TAIL_PREFETCH_ROWS - first) + prefetchBefore;
   // Dense ascending local_index means OFFSET/LIMIT over the ordered (and
   // possibly filtered) collection IS the virtualizer's row window.
   const rowsResult = useStreamQuery(
@@ -93,7 +98,7 @@ export function FeedItemsView({
     `SELECT local_index, component, first_offset, last_offset, event_count, json(data) AS data
      FROM feed_items ${where}
      ORDER BY local_index ASC LIMIT ? OFFSET ?`,
-    [...params, windowSize, first],
+    [...params, windowSize, queryOffset],
   );
   // Retain the last committed rows across range re-queries so a shifting
   // window doesn't blank already-visible rows to skeletons. The retained rows
@@ -111,11 +116,11 @@ export function FeedItemsView({
     }
     const rows = new Map<number, Record<string, unknown>>();
     rowsResult.data.forEach((row, position) => {
-      rows.set(first + position, row);
+      rows.set(queryOffset + position, row);
     });
     lastRowsRef.current = { where: retainKey, rows };
     return rows;
-  }, [rowsResult.data, rowsResult.status, retainKey, first]);
+  }, [rowsResult.data, rowsResult.status, retainKey, queryOffset]);
 
   return (
     <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">

--- a/apps/os/src/components/feed-items-view.tsx
+++ b/apps/os/src/components/feed-items-view.tsx
@@ -1,8 +1,7 @@
-import { memo, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { memo, useLayoutEffect, useMemo, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { ChevronDownIcon, PanelRightOpenIcon } from "lucide-react";
+import { ChevronDownIcon } from "lucide-react";
 import { Button } from "@iterate-com/ui/components/button";
-import { SerializedObjectCodeBlock } from "@iterate-com/ui/components/serialized-object-code-block";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -16,7 +15,6 @@ import { useStreamQuery } from "~/domains/streams/client-libraries/browser/hooks
 import { Centered } from "~/components/centered.tsx";
 import type { StreamBrowserDatabase } from "~/domains/streams/client-libraries/browser/stream-browser-db.ts";
 import type { FeedItemData } from "~/domains/streams/client-libraries/processors/browser-event-feed/grouping.ts";
-import type { StreamEvent } from "~/types.ts";
 import {
   buildFeedItemsFilter,
   FEED_TYPE_EXPRESSION,
@@ -65,7 +63,6 @@ export function FeedItemsView({
   );
   const itemCount = Number(countResult.data[0]?.count ?? 0);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [expanded, setExpanded] = useState<ReadonlySet<number>>(new Set());
 
   const virtualizer = useVirtualizer({
     count: itemCount,
@@ -141,7 +138,6 @@ export function FeedItemsView({
         >
           {virtualItems.map((item) => {
             const row = rowsByIndex.get(item.index);
-            const localIndex = row == null ? item.index : Number(row.local_index);
             return (
               <div
                 className="absolute left-0 top-0 w-full"
@@ -151,20 +147,14 @@ export function FeedItemsView({
                 style={{ transform: `translateY(${item.start}px)` }}
               >
                 {row == null ? (
-                  <div className="my-1 h-9 rounded-xl bg-muted/40" />
+                  <div className="h-8 bg-muted/30" />
                 ) : (
                   <FeedItemRow
                     row={row}
-                    expanded={expanded.has(localIndex)}
+                    // The gap is measured from the previous row's LAST event, so
+                    // a group's delta is the idle time between groups, not within.
+                    previousCreatedAt={feedItemLastCreatedAt(rowsByIndex.get(item.index - 1))}
                     onInspectEvent={onInspectEvent}
-                    onToggle={() =>
-                      setExpanded((previous) => {
-                        const next = new Set(previous);
-                        if (next.has(localIndex)) next.delete(localIndex);
-                        else next.add(localIndex);
-                        return next;
-                      })
-                    }
                   />
                 )}
               </div>
@@ -177,14 +167,13 @@ export function FeedItemsView({
 }
 
 const FeedItemRow = memo(function FeedItemRow({
-  expanded,
   onInspectEvent,
-  onToggle,
+  previousCreatedAt,
   row,
 }: {
-  expanded: boolean;
   onInspectEvent: (offset: number) => void;
-  onToggle: () => void;
+  /** The previous row's last event time — the anchor for this row's gap. */
+  previousCreatedAt: string | undefined;
   row: Record<string, unknown>;
 }) {
   const data = parseFeedItemData(String(row.data));
@@ -194,92 +183,82 @@ const FeedItemRow = memo(function FeedItemRow({
   const firstOffset = Number(row.first_offset);
   const lastOffset = Number(row.last_offset);
   const createdAt = data?.events[0]?.createdAt;
-  const events = data?.events ?? [];
+  const deltaMs = elapsedMs(previousCreatedAt, createdAt);
 
+  // The whole row is the inspect trigger now (no inline expansion): a click
+  // opens the raw-event panel at this row's first offset.
   return (
-    <div className="py-0.5">
-      <div
-        className={cn(
-          "flex w-full items-center gap-1 rounded-xl bg-muted/40 pr-1.5 transition-colors",
-          "text-muted-foreground hover:bg-muted/70 hover:text-foreground",
-          expanded && "rounded-b-none bg-muted/70 text-foreground",
-        )}
-      >
-        <button
-          aria-expanded={expanded}
-          onClick={onToggle}
-          type="button"
-          className="flex min-w-0 flex-1 cursor-pointer items-baseline gap-2.5 py-2 pl-3.5 text-left font-mono text-xs"
-        >
-          <span className="shrink-0 tabular-nums">
-            {firstOffset === lastOffset ? `#${firstOffset}` : `#${firstOffset}–${lastOffset}`}
-          </span>
-          <span className="min-w-0 truncate text-foreground/80">{shortEventType(eventType)}</span>
-          {eventCount > 1 ? (
-            <span className="shrink-0 rounded-full bg-background px-1.5 py-px text-[10px]">
-              ×{eventCount.toLocaleString()}
-            </span>
-          ) : null}
-          {typeof createdAt === "string" ? (
-            <time className="ml-auto shrink-0 text-[10px]">
-              {new Date(createdAt).toLocaleTimeString()}
-            </time>
-          ) : null}
-        </button>
-        <button
-          type="button"
-          title="Inspect raw event"
-          onClick={() => onInspectEvent(firstOffset)}
-          className="shrink-0 cursor-pointer rounded-lg p-1.5 text-muted-foreground/70 hover:bg-background hover:text-foreground"
-          data-testid="stream-feed-inspect"
-        >
-          <PanelRightOpenIcon className="size-3.5" />
-        </button>
-      </div>
-      {expanded ? (
-        <div className="rounded-b-xl bg-muted/40 px-3.5 pb-3 pt-1">
-          {events.length > 1 ? (
-            <GroupEventList events={events} onInspectEvent={onInspectEvent} />
-          ) : (
-            <SerializedObjectCodeBlock data={events.length === 1 ? events : row.data} />
-          )}
-        </div>
+    <button
+      type="button"
+      title="Inspect raw event"
+      onClick={() => onInspectEvent(firstOffset)}
+      data-testid="stream-feed-inspect"
+      className={cn(
+        "flex w-full cursor-pointer items-baseline gap-2.5 border-b border-border/40 px-3.5 py-1.5",
+        "text-left font-mono text-xs text-muted-foreground transition-colors",
+        "hover:bg-muted/60 hover:text-foreground",
+      )}
+    >
+      <span className="shrink-0 tabular-nums text-muted-foreground/70">
+        {firstOffset === lastOffset ? `#${firstOffset}` : `#${firstOffset}–${lastOffset}`}
+      </span>
+      <span className="min-w-0 truncate text-foreground/80">{shortEventType(eventType)}</span>
+      {eventCount > 1 ? (
+        <span className="shrink-0 tabular-nums text-muted-foreground/60">
+          ×{eventCount.toLocaleString()}
+        </span>
       ) : null}
-    </div>
+      <span className="ml-auto flex shrink-0 items-baseline gap-2.5 tabular-nums">
+        {deltaMs != null ? (
+          <span
+            className={cn("text-[10px]", deltaColorClass(deltaMs))}
+            title="Time since previous event"
+          >
+            +{formatTimeDelta(deltaMs)}
+          </span>
+        ) : null}
+        {typeof createdAt === "string" ? (
+          <time className="text-[10px] text-muted-foreground/50">
+            {new Date(createdAt).toLocaleTimeString()}
+          </time>
+        ) : null}
+      </span>
+    </button>
   );
 });
 
-/**
- * The events inside an expanded group row, one line each — clicking a line
- * opens that event in the raw-event inspector (a collapsed run can hold up to
- * 200 events; a single JSON dump of all of them is unreadable).
- */
-function GroupEventList({
-  events,
-  onInspectEvent,
-}: {
-  events: readonly StreamEvent[];
-  onInspectEvent: (offset: number) => void;
-}) {
-  return (
-    <ul>
-      {events.map((event) => (
-        <li key={event.offset}>
-          <button
-            type="button"
-            onClick={() => onInspectEvent(event.offset)}
-            className="flex w-full cursor-pointer items-baseline gap-2.5 rounded-md px-2 py-1 text-left font-mono text-xs text-muted-foreground hover:bg-background hover:text-foreground"
-          >
-            <span className="shrink-0 tabular-nums">#{event.offset}</span>
-            <span className="min-w-0 truncate">{shortEventType(event.type)}</span>
-            <time className="ml-auto shrink-0 text-[10px]">
-              {new Date(event.createdAt).toLocaleTimeString()}
-            </time>
-          </button>
-        </li>
-      ))}
-    </ul>
-  );
+/** The last event's timestamp in a feed-items row, used as the next row's gap anchor. */
+function feedItemLastCreatedAt(row: Record<string, unknown> | undefined): string | undefined {
+  if (row == null) return undefined;
+  return parseFeedItemData(String(row.data))?.events.at(-1)?.createdAt;
+}
+
+/** Milliseconds between two ISO timestamps, clamped at 0; null if either is missing/unparseable. */
+function elapsedMs(from: string | undefined, to: string | undefined): number | null {
+  if (from == null || to == null) return null;
+  const fromMs = Date.parse(from);
+  const toMs = Date.parse(to);
+  if (Number.isNaN(fromMs) || Number.isNaN(toMs)) return null;
+  return Math.max(0, toMs - fromMs);
+}
+
+/** `950ms`, `3.2s`, `1m40s`, `2h5m` — compact, human-readable gap. */
+function formatTimeDelta(ms: number): string {
+  if (ms < 1_000) return `${ms}ms`;
+  if (ms < 60_000) return `${(Math.floor(ms / 100) / 10).toFixed(1).replace(/\.0$/, "")}s`;
+  const totalSeconds = Math.floor(ms / 1_000);
+  if (totalSeconds < 3_600) return `${Math.floor(totalSeconds / 60)}m${totalSeconds % 60}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  return `${Math.floor(totalMinutes / 60)}h${totalMinutes % 60}m`;
+}
+
+/** Colour by gap magnitude: near-instant is muted, a long pause runs hot. */
+function deltaColorClass(ms: number): string {
+  if (ms < 1_000) return "text-muted-foreground/40";
+  if (ms < 10_000) return "text-emerald-600 dark:text-emerald-500";
+  if (ms < 60_000) return "text-amber-600 dark:text-amber-500";
+  if (ms < 600_000) return "text-orange-600 dark:text-orange-500";
+  return "text-red-600 dark:text-red-500";
 }
 
 function parseFeedItemData(raw: string): FeedItemData | null {

--- a/apps/os/src/components/raw-event-inspector-panel.tsx
+++ b/apps/os/src/components/raw-event-inspector-panel.tsx
@@ -111,7 +111,7 @@ export function RawEventInspectorPanel({
 
   return (
     <aside
-      className="absolute inset-y-0 right-0 z-30 flex w-full max-w-lg flex-col rounded-tl-2xl bg-background shadow-2xl"
+      className="absolute inset-y-0 right-0 z-30 flex w-full flex-col rounded-tl-2xl bg-background shadow-2xl md:w-1/2"
       data-testid="raw-event-inspector"
     >
       <div className="flex shrink-0 items-start gap-2 px-5 pb-2 pt-4">


### PR DESCRIPTION
Follow-up to the stream-view resurrection (#1651 / #1662).

### Click the row to inspect
The whole feed row is the inspect trigger again — clicking anywhere on it opens the raw-event side panel at that row's first offset. The separate inspect button is gone.

### No more inline expansion
Removed the in-row event/group expansion entirely (`GroupEventList`, the `expanded` state, the in-row code block). The side panel is the single place to read a payload.

### Wider panel
The inspector is now half-width (`md:w-1/2`) instead of `max-w-lg`.

### Flat rows, not pills
Feed rows are flat lines separated by a hairline divider rather than rounded pill boxes; the `×count` is plain text instead of a pill badge.

### Colour-coded time deltas
Each row's one line now shows a human-readable, colour-coded gap since the previous row's last event — muted for near-instant, then green → amber → orange → red as the pause grows — next to the absolute time. This makes bursts vs. idle periods legible at a glance.

## Test plan
- `pnpm typecheck` / `pnpm lint` / `pnpm format` clean.
- Prod smoke after merge: clicking a feed row opens a half-width panel; rows are flat with colour-coded deltas; no inline expansion remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to feed rendering and inspector layout; no auth, data, or API surface changes.
> 
> **Overview**
> Stream feed rows are **flat, full-width inspect targets** instead of pill-shaped rows with a separate inspect control and inline expansion. Clicking a row opens the raw-event panel at that row’s first offset; `GroupEventList`, expanded state, and in-row JSON are removed so inspection lives only in the side panel.
> 
> Each row shows a **colour-coded gap** since the previous row’s last event (`+950ms`, `+3.2s`, etc.), anchored on group boundaries. The virtualized SQL window **prefetches one row above** the visible range so the top visible row can compute its delta.
> 
> The **raw-event inspector** is **half width on `md+`** (`md:w-1/2`) instead of `max-w-lg`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5b21d2f586a2b4e466c63ca6b77cea2ef6b8ecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-04T22:01:19.406Z",
      "headSha": "f5b21d2f586a2b4e466c63ca6b77cea2ef6b8ecd",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/194636622796111",
      "shortSha": "f5b21d2",
      "cleanupDurationMs": 5910,
      "deployDurationMs": 47207,
      "testDurationMs": 108754
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-04T22:01:17.793Z",
      "headSha": "f5b21d2f586a2b4e466c63ca6b77cea2ef6b8ecd",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/194636622796111",
      "shortSha": "f5b21d2",
      "cleanupDurationMs": 4292,
      "deployDurationMs": 21007,
      "testDurationMs": 804
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `f5b21d2` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 21.0s | 804ms | 4.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/194636622796111) | 2026-07-04T22:01:17.793Z | Preview app released. |
| OS | released | `f5b21d2` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 47.2s | 108.8s | 5.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/194636622796111) | 2026-07-04T22:01:19.406Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->