### PR TITLE
Persistent sandbox /workspace via backup/restore lifecycle hooks + repo always checked out

### DIFF
--- a/apps/os/docs/sandboxes.md
+++ b/apps/os/docs/sandboxes.md
@@ -86,15 +86,22 @@ pushed.
 The sandbox subclass turns its container lifecycle into ordinary stream
 events, appended to the stream at the sandbox's **own path** — for an agent's
 sandbox that is the agent's own journal, so the agent (and anything tailing
-the stream) sees its sandbox's history:
+the stream) sees its sandbox's history. The event catalog is the **sandbox
+processor contract** (`sandbox-processor-contract.ts`); the Durable Object
+builds every event through it (`SandboxProcessorContract.buildEvent`), so
+emission and declaration cannot drift. `SandboxProcessor`
+(`sandbox-processor-implementation.ts`) holds the contract and folds the
+events into a small status projection (`running`, `lastBackupId`) — it takes
+no actions and is not yet wired to a processor host.
 
-| Hook / moment              | Event (`events.iterate.com/sandbox/…`)                                                                                                    |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `onStart`                  | `container-started`                                                                                                                       |
-| workspace restored         | `workspace-restored` (with `backupId`)                                                                                                    |
-| workspace freshly cloned   | `workspace-cloned`                                                                                                                        |
-| `onActivityExpired` backup | `backup-created` / `backup-failed`                                                                                                        |
-| `onStop`                   | `container-stopped` (may arrive on wake — the SDK delivers a stop that happened while the Durable Object was hibernated on the next wake) |
+| Hook / moment                | Event (`events.iterate.com/sandbox/…`)                                                                                                    |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `onStart`                    | `container-started`                                                                                                                       |
+| workspace restored           | `workspace-restored` (with `backupId`)                                                                                                    |
+| workspace freshly cloned     | `workspace-cloned`                                                                                                                        |
+| background provisioning died | `workspace-setup-failed` (with `error`; the next `ensureProjectRepo()` retries from scratch)                                              |
+| `onActivityExpired` backup   | `backup-created` (with `backupId`) / `backup-failed` (with `error`)                                                                       |
+| `onStop`                     | `container-stopped` (may arrive on wake — the SDK delivers a stop that happened while the Durable Object was hibernated on the next wake) |
 
 Appends are best-effort by design: lifecycle telemetry never blocks or fails a
 container start/stop.

--- a/apps/os/docs/sandboxes.md
+++ b/apps/os/docs/sandboxes.md
@@ -25,27 +25,89 @@ await sandbox.readFile("/workspace/repo/README.md");
 await sandbox.startProcess("bun server.js");
 ```
 
-Lifecycle is the SDK's best-practice default, unchanged: getting a sandbox is
-cheap (no container), the first command boots it, and the SDK's durable
-`sleepAfter` idle alarm (default 10m) stops it again. Durable Object storage
-and identity survive sleep; the container filesystem does not — every start
-re-provisions (the repo clone below), which is what makes a sandbox
+Lifecycle is the SDK's best-practice default: getting a sandbox is cheap (no
+container), the first command boots it, and the SDK's durable `sleepAfter`
+idle alarm (3m) stops it again. Durable Object storage and identity survive
+sleep. The container's own disk does **not** — but `/workspace` does, because
+it is a persistent R2 mount (see below), which is what makes a sandbox
 restorable rather than merely long-lived.
 
 `get(path)` returns the **bare `@cloudflare/sandbox` Durable Object stub** —
 no wrapper. Everything the SDK exposes (exec, files, processes, git, ports,
 tunnels, `destroy()`, …) is callable directly; see the
-[Sandbox SDK docs](https://developers.cloudflare.com/sandbox/). Getting a
-sandbox is cheap; the first command starts the container. Every container
-start also kicks off a clone of the project repo to `/workspace/repo`
-(credentials are embedded in the git remote, so `git pull`/`push` work inside
-the sandbox); `await sandbox.ensureProjectRepo()` before work that depends on
-it. The clone cannot run synchronously inside container startup:
-`onStart` executes inside the container framework's `blockConcurrencyWhile`,
-which has a hard ~30s budget, kills the fresh container on cancellation, and
-input-gates timer events — so nothing in there can even bound itself with a
-deadline. Slow cold starts (first boot under Rosetta locally) would brick the
-sandbox instead of merely delaying the clone.
+[Sandbox SDK docs](https://developers.cloudflare.com/sandbox/).
+
+## Persistent `/workspace` (R2 mount)
+
+Cloudflare container disk is **ephemeral** — there is no persistent volume, and
+a sandbox that sleeps loses its filesystem. The Cloudflare-idiomatic fix is the
+Sandbox SDK's [`mountBucket`](https://developers.cloudflare.com/sandbox/api/storage/):
+mount an R2 bucket as a filesystem path and everything written there lives in
+R2. So `onStart` mounts a per-sandbox **prefix** (`/{projectId}{path}`) of the
+env's `SANDBOX_STORAGE` bucket at `/workspace`, and everything under it — the
+repo checkout, build outputs, anything the agent writes — survives sleep,
+restart, and code redeploys.
+
+- **One bucket per env**, named `${osWorkerName}-sandboxes` (addressed by name
+  like the `ARTIFACTS` namespace, so no per-env id in `envs.ts`).
+  `ensure-resources` creates it (create-only). Each sandbox is isolated to its
+  own prefix, so a container only ever sees its own workspace.
+- **Deployed envs** use the credential-less **R2-binding mount**, which the SDK
+  routes over the very same container egress interception described below — no
+  S3 credentials ever enter the container. Local dev uses miniflare's local R2
+  binding (`localBucket`), selected by the `SANDBOX_STORAGE_MODE` var that
+  `generate-wrangler-config.ts` sets per env.
+- The mount is done in `onStart`, which the SDK runs inside
+  `blockConcurrencyWhile` **before** serving any command — so `/workspace` is
+  always backed by R2 before anything writes to it.
+
+## The project repo is always checked out
+
+Every sandbox has the project repo at `/workspace/repo` (credentials are
+embedded in the git remote, so `git pull`/`push` work inside the sandbox);
+`await sandbox.ensureProjectRepo()` before work that depends on it. Because the
+workspace is persistent, the clone runs **once** and then survives sleep: every
+later start re-mounts and finds the checkout already there (a fast marker
+check), so the repo is always present without re-cloning.
+
+The clone itself cannot run synchronously inside container startup: `onStart`
+executes inside the container framework's `blockConcurrencyWhile`, which has a
+hard ~30s budget, kills the fresh container on cancellation, and input-gates
+timer events — so nothing in there can even bound itself with a deadline. Slow
+cold clones (first boot under Rosetta locally) would brick the sandbox instead
+of merely delaying the checkout. So `onStart` mounts synchronously (fast) and
+kicks the checkout off in the background; `ensureProjectRepo()` is the awaitable
+guarantee.
+
+### Other persistence mechanisms Cloudflare documents, and why not them
+
+Cloudflare offers **no native persistent disk / volume** for containers — all
+container disk is
+[ephemeral](https://developers.cloudflare.com/containers/faq/). The remaining
+options, and why the R2 `mountBucket` above won:
+
+- **[Backup & restore](https://developers.cloudflare.com/sandbox/api/backups/)**
+  (`createBackup`/`restoreBackup`) snapshots a directory to R2. It's excellent
+  for _fast boot_ (restore a warmed workspace in ~2s vs a ~30s clone + install),
+  but it is **snapshot-granular, not continuous**: anything written since the
+  last backup is lost on an unexpected sleep, and the caller must store and
+  manage backup handles. We want a durable filesystem, not point-in-time
+  snapshots, so a live mount fits the requirement directly. (A future
+  optimisation could _add_ restore-from-backup on top of the mount to speed cold
+  boots — orthogonal to durability.)
+- **[Raw R2 FUSE mount](https://developers.cloudflare.com/containers/examples/r2-fuse-mount/)**
+  installed by hand in the Dockerfile (s3fs/tigrisfs) is exactly what
+  `mountBucket` does — but the SDK method does it managed, credential-less, and
+  over the egress interception we already run, so no Dockerfile changes and no
+  S3 credentials inside the container.
+- **Durable Object storage** (`ctx.storage`) is key/value, not a filesystem —
+  right for the small identity record this class already keeps, not a repo
+  checkout or build tree.
+
+Trade-off to know: FUSE-mounted object storage has higher per-op latency than
+local disk (Cloudflare: "not native SSD-like performance"). For an agent
+workspace — a one-time clone then edit/build/run — that is an acceptable price
+for durability.
 
 ## Egress: all sandbox traffic goes through project policy
 
@@ -58,10 +120,9 @@ the same allow/deny/secret-substitution policy as the rest of the project.
 
 Wiring (three points):
 
-- `src/workers/sandbox.ts` re-exports `ContainerProxy` from
-  `@cloudflare/containers` — the SDK dials it via `ctx.exports.ContainerProxy`
-  to route intercepted egress; without the export, interception throws at
-  container start.
+- `src/worker.ts` re-exports `ContainerProxy` from `@cloudflare/sandbox` — the
+  SDK dials it via `ctx.exports.ContainerProxy` to route intercepted egress;
+  without the export, interception throws at container start.
 - `CloudflareSandboxDurableObject` sets `static outbound` (the catch-all egress
   handler) and `interceptHttps = true`. The handler runs in the ContainerProxy
   WorkerEntrypoint, so it only has the container's opaque Durable Object id; it

--- a/apps/os/docs/sandboxes.md
+++ b/apps/os/docs/sandboxes.md
@@ -66,14 +66,15 @@ hung off the SDK's own lifecycle hooks:
 Plumbing: **one bucket per env**, `${osWorkerName}-sandboxes`, created by
 `ensure-resources` (create-only) and bound as `BACKUP_BUCKET` — that exact
 binding name is the SDK's contract, as are the `BACKUP_BUCKET_NAME` /
-`CLOUDFLARE_R2_ACCOUNT_ID` vars and `R2_ACCESS_KEY_ID` /
-`R2_SECRET_ACCESS_KEY` presigning secrets (optional Doppler secrets; an env
-without them still runs sandboxes, it just re-clones every start). Deployed
-envs transfer archives via presigned `*.r2.cloudflarestorage.com` URLs — real
-hosts, so backup traffic flows **through project egress like every other
-container request**. Local dev sets `SANDBOX_BACKUP_MODE=local`: archives
-stream through miniflare's local R2 binding, since presigned URLs don't exist
-under `wrangler dev`.
+`CLOUDFLARE_R2_ACCOUNT_ID` vars and the `R2_ACCESS_KEY_ID` /
+`R2_SECRET_ACCESS_KEY` presigning secrets. The secrets are optional and select
+the transfer mode: **with** them the SDK presigns
+`*.r2.cloudflarestorage.com` URLs and the container transfers archives
+directly — fast, and through project egress like every other container
+request; **without** them (local dev always — presigned URLs don't exist under
+`wrangler dev` — and any deployed env until R2 keys are minted into Doppler)
+archives stream through the Durable Object's `BACKUP_BUCKET` binding — slower,
+but zero-config, and persistence works either way.
 
 **Honest limit:** this is snapshot-granular, not a continuously-persistent
 disk. A container that _crashes_ (rather than idling out) loses what changed

--- a/apps/os/docs/sandboxes.md
+++ b/apps/os/docs/sandboxes.md
@@ -48,13 +48,15 @@ with the Sandbox SDK's
 hung off the SDK's own lifecycle hooks:
 
 - **`onActivityExpired`** (the idle-timer hook — the one moment the container
-  is still running but about to stop; `onStop` is too late, the container is
-  already gone) snapshots `/workspace` with
+  is still running but about to go away; `onStop` is too late, the container
+  is already gone) snapshots `/workspace` with
   [`createBackup`](https://developers.cloudflare.com/sandbox/api/backups/) —
-  gitignore-aware and `node_modules`-excluded, so archives stay small — and
-  stores the returned handle in Durable Object storage. A backup failure never
-  wedges the container awake; the handle keeps pointing at the last good
-  snapshot.
+  gitignore-aware and `node_modules`-excluded, so archives stay small — stores
+  the returned handle in Durable Object storage, then **destroys** the
+  container (not the SDK's stop: a stopped container keeps its instance
+  assignment against `max_instances` forever — see the method's docstring; the
+  snapshot is what makes destroy loss-free). A backup failure never wedges the
+  container alive; the handle keeps pointing at the last good snapshot.
 - **`onStart`** provisions the workspace in the background: restore the newest
   snapshot (seconds), then clone the repo if the checkout is still missing.
   `ensureProjectRepo()` is the awaitable guarantee.

--- a/apps/os/docs/sandboxes.md
+++ b/apps/os/docs/sandboxes.md
@@ -28,86 +28,113 @@ await sandbox.startProcess("bun server.js");
 Lifecycle is the SDK's best-practice default: getting a sandbox is cheap (no
 container), the first command boots it, and the SDK's durable `sleepAfter`
 idle alarm (3m) stops it again. Durable Object storage and identity survive
-sleep. The container's own disk does **not** — but `/workspace` does, because
-it is a persistent R2 mount (see below), which is what makes a sandbox
-restorable rather than merely long-lived.
+sleep. The container's own disk does **not** — but `/workspace` comes back,
+because going to sleep snapshots it to R2 and the next start restores it (see
+below), which is what makes a sandbox restorable rather than merely
+long-lived.
 
 `get(path)` returns the **bare `@cloudflare/sandbox` Durable Object stub** —
 no wrapper. Everything the SDK exposes (exec, files, processes, git, ports,
 tunnels, `destroy()`, …) is callable directly; see the
 [Sandbox SDK docs](https://developers.cloudflare.com/sandbox/).
 
-## Persistent `/workspace` (R2 mount)
+## `/workspace` persists across sleep (R2 backup/restore)
 
-Cloudflare container disk is **ephemeral** — there is no persistent volume, and
-a sandbox that sleeps loses its filesystem. The Cloudflare-idiomatic fix is the
-Sandbox SDK's [`mountBucket`](https://developers.cloudflare.com/sandbox/api/storage/):
-mount an R2 bucket as a filesystem path and everything written there lives in
-R2. So `onStart` mounts a per-sandbox **prefix** (`/{projectId}{path}`) of the
-env's `SANDBOX_STORAGE` bucket at `/workspace`, and everything under it — the
-repo checkout, build outputs, anything the agent writes — survives sleep,
-restart, and code redeploys.
+Cloudflare container disk is **ephemeral** — there is no persistent volume
+([FAQ](https://developers.cloudflare.com/containers/faq/)), and a sandbox that
+sleeps loses its filesystem. `CloudflareSandboxDurableObject` closes that gap
+with the Sandbox SDK's
+[backup/restore](https://developers.cloudflare.com/sandbox/guides/backup-restore/),
+hung off the SDK's own lifecycle hooks:
 
-- **One bucket per env**, named `${osWorkerName}-sandboxes` (addressed by name
-  like the `ARTIFACTS` namespace, so no per-env id in `envs.ts`).
-  `ensure-resources` creates it (create-only). Each sandbox is isolated to its
-  own prefix, so a container only ever sees its own workspace.
-- **Deployed envs** use the credential-less **R2-binding mount**, which the SDK
-  routes over the very same container egress interception described below — no
-  S3 credentials ever enter the container. Local dev uses miniflare's local R2
-  binding (`localBucket`), selected by the `SANDBOX_STORAGE_MODE` var that
-  `generate-wrangler-config.ts` sets per env.
-- The mount is done in `onStart`, which the SDK runs inside
-  `blockConcurrencyWhile` **before** serving any command — so `/workspace` is
-  always backed by R2 before anything writes to it.
+- **`onActivityExpired`** (the idle-timer hook — the one moment the container
+  is still running but about to stop; `onStop` is too late, the container is
+  already gone) snapshots `/workspace` with
+  [`createBackup`](https://developers.cloudflare.com/sandbox/api/backups/) —
+  gitignore-aware and `node_modules`-excluded, so archives stay small — and
+  stores the returned handle in Durable Object storage. A backup failure never
+  wedges the container awake; the handle keeps pointing at the last good
+  snapshot.
+- **`onStart`** provisions the workspace in the background: restore the newest
+  snapshot (seconds), then clone the repo if the checkout is still missing.
+  `ensureProjectRepo()` is the awaitable guarantee.
+- Backups expire after **90 days idle** (SDK `ttl`): long enough that any
+  still-wanted workspace comes back intact, short enough that e2e churn
+  doesn't accumulate in R2 forever. An expired workspace degrades to a fresh
+  clone.
+
+Plumbing: **one bucket per env**, `${osWorkerName}-sandboxes`, created by
+`ensure-resources` (create-only) and bound as `BACKUP_BUCKET` — that exact
+binding name is the SDK's contract, as are the `BACKUP_BUCKET_NAME` /
+`CLOUDFLARE_R2_ACCOUNT_ID` vars and `R2_ACCESS_KEY_ID` /
+`R2_SECRET_ACCESS_KEY` presigning secrets (optional Doppler secrets; an env
+without them still runs sandboxes, it just re-clones every start). Deployed
+envs transfer archives via presigned `*.r2.cloudflarestorage.com` URLs — real
+hosts, so backup traffic flows **through project egress like every other
+container request**. Local dev sets `SANDBOX_BACKUP_MODE=local`: archives
+stream through miniflare's local R2 binding, since presigned URLs don't exist
+under `wrangler dev`.
+
+**Honest limit:** this is snapshot-granular, not a continuously-persistent
+disk. A container that _crashes_ (rather than idling out) loses what changed
+since the last snapshot. Durable work belongs in the repo — committed and
+pushed.
+
+## Lifecycle hooks → stream events
+
+The sandbox subclass turns its container lifecycle into ordinary stream
+events, appended to the stream at the sandbox's **own path** — for an agent's
+sandbox that is the agent's own journal, so the agent (and anything tailing
+the stream) sees its sandbox's history:
+
+| Hook / moment              | Event (`events.iterate.com/sandbox/…`)                                                                                                    |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `onStart`                  | `container-started`                                                                                                                       |
+| workspace restored         | `workspace-restored` (with `backupId`)                                                                                                    |
+| workspace freshly cloned   | `workspace-cloned`                                                                                                                        |
+| `onActivityExpired` backup | `backup-created` / `backup-failed`                                                                                                        |
+| `onStop`                   | `container-stopped` (may arrive on wake — the SDK delivers a stop that happened while the Durable Object was hibernated on the next wake) |
+
+Appends are best-effort by design: lifecycle telemetry never blocks or fails a
+container start/stop.
 
 ## The project repo is always checked out
 
 Every sandbox has the project repo at `/workspace/repo` (credentials are
 embedded in the git remote, so `git pull`/`push` work inside the sandbox);
-`await sandbox.ensureProjectRepo()` before work that depends on it. Because the
-workspace is persistent, the clone runs **once** and then survives sleep: every
-later start re-mounts and finds the checkout already there (a fast marker
-check), so the repo is always present without re-cloning.
+`await sandbox.ensureProjectRepo()` before work that depends on it. Because
+the workspace is snapshot-restored, the clone effectively runs **once**: later
+starts restore the checkout from the backup (a fast marker probe makes the
+clone a no-op), and only a first boot — or an expired/failed backup — pays for
+a full clone.
 
-The clone itself cannot run synchronously inside container startup: `onStart`
+Provisioning cannot run synchronously inside container startup: `onStart`
 executes inside the container framework's `blockConcurrencyWhile`, which has a
-hard ~30s budget, kills the fresh container on cancellation, and input-gates
-timer events — so nothing in there can even bound itself with a deadline. Slow
-cold clones (first boot under Rosetta locally) would brick the sandbox instead
-of merely delaying the checkout. So `onStart` mounts synchronously (fast) and
-kicks the checkout off in the background; `ensureProjectRepo()` is the awaitable
+hard ~30s budget, kills the fresh container on cancellation (verified live —
+an over-budget `onStart` resets the Durable Object), and input-gates timer
+events — so nothing in there can even bound itself with a deadline. So
+`onStart` only kicks provisioning off; `ensureProjectRepo()` is the awaitable
 guarantee.
 
 ### Other persistence mechanisms Cloudflare documents, and why not them
 
-Cloudflare offers **no native persistent disk / volume** for containers — all
-container disk is
-[ephemeral](https://developers.cloudflare.com/containers/faq/). The remaining
-options, and why the R2 `mountBucket` above won:
-
-- **[Backup & restore](https://developers.cloudflare.com/sandbox/api/backups/)**
-  (`createBackup`/`restoreBackup`) snapshots a directory to R2. It's excellent
-  for _fast boot_ (restore a warmed workspace in ~2s vs a ~30s clone + install),
-  but it is **snapshot-granular, not continuous**: anything written since the
-  last backup is lost on an unexpected sleep, and the caller must store and
-  manage backup handles. We want a durable filesystem, not point-in-time
-  snapshots, so a live mount fits the requirement directly. (A future
-  optimisation could _add_ restore-from-backup on top of the mount to speed cold
-  boots — orthogonal to durability.)
+- **[`mountBucket`](https://developers.cloudflare.com/sandbox/api/storage/)**
+  (the SDK's "persistent storage": R2 as a live FUSE filesystem) was tried
+  first — continuous persistence beats snapshots on paper. It is incompatible
+  with our egress model in practice: its credential-less R2-binding mode sends
+  s3fs traffic to the magic host `r2.internal`, serviced by the SDK's own
+  per-host container-egress interceptor, which our catch-all
+  all-egress-through-project-policy handler necessarily swallows. Verified
+  broken on a real preview — every filesystem op on the mount returned
+  `Input/output error`. Composing the two would mean exempting storage traffic
+  from project egress policy; backup/restore needs no exemption (presigned
+  transfers are plain HTTPS to real hosts, through project egress).
 - **[Raw R2 FUSE mount](https://developers.cloudflare.com/containers/examples/r2-fuse-mount/)**
-  installed by hand in the Dockerfile (s3fs/tigrisfs) is exactly what
-  `mountBucket` does — but the SDK method does it managed, credential-less, and
-  over the egress interception we already run, so no Dockerfile changes and no
-  S3 credentials inside the container.
+  hand-rolled in the Dockerfile is the same mechanism minus the management —
+  same conflict, plus S3 credentials inside the container.
 - **Durable Object storage** (`ctx.storage`) is key/value, not a filesystem —
-  right for the small identity record this class already keeps, not a repo
-  checkout or build tree.
-
-Trade-off to know: FUSE-mounted object storage has higher per-op latency than
-local disk (Cloudflare: "not native SSD-like performance"). For an agent
-workspace — a one-time clone then edit/build/run — that is an acceptable price
-for durability.
+  right for the identity record and the backup handle this class keeps, not a
+  repo checkout or build tree.
 
 ## Egress: all sandbox traffic goes through project policy
 

--- a/apps/os/scripts/ensure-resources.ts
+++ b/apps/os/scripts/ensure-resources.ts
@@ -55,6 +55,21 @@ export default async function ensureResources(
   const kv = await ensureKv(`${env.osWorkerName}-project-directory`);
   const buildCacheKv = await ensureKv(`${env.osWorkerName}-worker-build-cache`);
 
+  // ---- R2: sandbox persistent storage -----------------------------------------
+  // Every sandbox mounts a prefix of this bucket at /workspace so its
+  // filesystem survives the container sleeping (container disk is ephemeral).
+  // Addressed by name (`${osWorkerName}-sandboxes`), so — unlike KV/D1 — there
+  // is no id to reconcile into envs.ts; create-if-missing is the whole story.
+  // Wiping a sandbox's data is erase-data's job, never this create-only script.
+  const r2BucketName = `${env.osWorkerName}-sandboxes`;
+  const r2 = await cf<{ buckets: { name: string }[] }>(`/r2/buckets?per_page=1000`);
+  if (r2.buckets.some((bucket) => bucket.name === r2BucketName)) {
+    console.log(`R2 bucket ${r2BucketName} exists`);
+  } else {
+    await cf(`/r2/buckets`, { method: "POST", body: JSON.stringify({ name: r2BucketName }) });
+    console.log(`created R2 bucket ${r2BucketName}`);
+  }
+
   // ---- D1: auth database ------------------------------------------------------
   // apps/auth's ensure-resources also creates this database; both are
   // create-only idempotent, so whichever runs first wins harmlessly.

--- a/apps/os/scripts/ensure-resources.ts
+++ b/apps/os/scripts/ensure-resources.ts
@@ -55,12 +55,12 @@ export default async function ensureResources(
   const kv = await ensureKv(`${env.osWorkerName}-project-directory`);
   const buildCacheKv = await ensureKv(`${env.osWorkerName}-worker-build-cache`);
 
-  // ---- R2: sandbox persistent storage -----------------------------------------
-  // Every sandbox mounts a prefix of this bucket at /workspace so its
-  // filesystem survives the container sleeping (container disk is ephemeral).
-  // Addressed by name (`${osWorkerName}-sandboxes`), so — unlike KV/D1 — there
-  // is no id to reconcile into envs.ts; create-if-missing is the whole story.
-  // Wiping a sandbox's data is erase-data's job, never this create-only script.
+  // ---- R2: sandbox workspace backups --------------------------------------
+  // Sandboxes snapshot /workspace into this bucket when they idle out and
+  // restore it on the next start (container disk is ephemeral). Addressed by
+  // name (`${osWorkerName}-sandboxes`), so — unlike KV/D1 — there is no id to
+  // reconcile into envs.ts; create-if-missing is the whole story. Wiping a
+  // sandbox's data is erase-data's job, never this create-only script's.
   const r2BucketName = `${env.osWorkerName}-sandboxes`;
   const r2 = await cf<{ buckets: { name: string }[] }>(`/r2/buckets?per_page=1000`);
   if (r2.buckets.some((bucket) => bucket.name === r2BucketName)) {

--- a/apps/os/scripts/generate-wrangler-config.ts
+++ b/apps/os/scripts/generate-wrangler-config.ts
@@ -120,11 +120,6 @@ function workerBindings(input: {
    * churn spins sandboxes faster than they idle out, and a saturated cap
    * 503s every sandbox exec (observed live at 10/10 on preview-3). */
   maxContainerInstances?: number;
-  /** Local dev (the top-level config): sandbox workspace backups stream
-   * through miniflare's local R2 binding instead of presigned
-   * `*.r2.cloudflarestorage.com` URLs, which don't exist under `wrangler
-   * dev`. */
-  localDev?: boolean;
 }) {
   return {
     vars: {
@@ -137,7 +132,6 @@ function workerBindings(input: {
       // from Doppler (OPTIONAL_SECRETS).
       BACKUP_BUCKET_NAME: `${input.workerName}-sandboxes`,
       CLOUDFLARE_R2_ACCOUNT_ID: input.accountId,
-      SANDBOX_BACKUP_MODE: input.localDev ? "local" : "presigned",
     },
     durable_objects: {
       bindings: Object.entries(DO_CLASSES).map(([name, class_name]) => ({ name, class_name })),
@@ -256,7 +250,7 @@ export const config = {
   // image on Docker/OrbStack and pairs each container with a proxy-everything
   // egress sidecar (see docs/sandboxes.md). Deploys ignore the dev section.
   dev: { enable_containers: process.env.OS_SANDBOX_CONTAINER_LOCAL_DEV === "true" },
-  ...workerBindings({ workerName: "os", accountId: "", localDev: true }),
+  ...workerBindings({ workerName: "os", accountId: "" }),
   // Local dev loads optional secrets and the env-shaping keys from Doppler
   // too (deployed envs get the latter as generated vars — see envShapedVars).
   secrets: { required: [...REQUIRED_SECRETS, ...OPTIONAL_SECRETS, ...ENV_SHAPED_KEYS] },

--- a/apps/os/scripts/generate-wrangler-config.ts
+++ b/apps/os/scripts/generate-wrangler-config.ts
@@ -113,12 +113,18 @@ function workerBindings(input: {
    * churn spins sandboxes faster than they idle out, and a saturated cap
    * 503s every sandbox exec (observed live at 10/10 on preview-3). */
   maxContainerInstances?: number;
+  /** Local dev (the top-level config): sandboxes mount their persistent R2
+   * store through miniflare's local R2 binding rather than the credential-less
+   * egress mount, which needs FUSE/presigned URLs unavailable under
+   * `wrangler dev`. */
+  localDev?: boolean;
 }) {
   return {
     vars: {
       WORKER_SELF: input.workerName,
       ARTIFACTS_ACCOUNT_ID: input.accountId,
       ARTIFACTS_NAMESPACE: `${input.workerName}-repos`,
+      SANDBOX_STORAGE_MODE: input.localDev ? "local" : "r2-egress",
     },
     durable_objects: {
       bindings: Object.entries(DO_CLASSES).map(([name, class_name]) => ({ name, class_name })),
@@ -144,6 +150,11 @@ function workerBindings(input: {
     ai: { binding: "AI" },
     worker_loaders: [{ binding: "LOADER" }],
     artifacts: [{ binding: "ARTIFACTS", namespace: `${input.workerName}-repos` }],
+    // Persistent storage for sandbox workspaces (ensure-resources.ts creates
+    // it; the sandbox DO mounts a per-sandbox prefix at /workspace). Addressed
+    // by name, so — unlike KV/D1 — no per-env id in envs.ts. In local dev
+    // miniflare provides this bucket automatically.
+    r2_buckets: [{ binding: "SANDBOX_STORAGE", bucket_name: `${input.workerName}-sandboxes` }],
     containers: [
       {
         class_name: DO_CLASSES.SANDBOX,
@@ -231,7 +242,7 @@ export const config = {
   // image on Docker/OrbStack and pairs each container with a proxy-everything
   // egress sidecar (see docs/sandboxes.md). Deploys ignore the dev section.
   dev: { enable_containers: process.env.OS_SANDBOX_CONTAINER_LOCAL_DEV === "true" },
-  ...workerBindings({ workerName: "os", accountId: "" }),
+  ...workerBindings({ workerName: "os", accountId: "", localDev: true }),
   // Local dev loads optional secrets and the env-shaping keys from Doppler
   // too (deployed envs get the latter as generated vars — see envShapedVars).
   secrets: { required: [...REQUIRED_SECRETS, ...OPTIONAL_SECRETS, ...ENV_SHAPED_KEYS] },

--- a/apps/os/scripts/generate-wrangler-config.ts
+++ b/apps/os/scripts/generate-wrangler-config.ts
@@ -57,6 +57,13 @@ export const OPTIONAL_SECRETS = [
   "APP_CONFIG_POSTHOG",
   "APP_CONFIG_SLACK_BOT_TOKEN",
   "APP_CONFIG_X_AI_API_KEY",
+  // R2 S3-API credentials the Sandbox SDK uses to presign workspace-backup
+  // transfers (exact names the SDK reads). Optional: an env without them
+  // still runs sandboxes — backups fail loudly in logs and every container
+  // start falls back to a fresh repo clone. Local dev never needs them
+  // (SANDBOX_BACKUP_MODE=local streams through the local R2 binding).
+  "R2_ACCESS_KEY_ID",
+  "R2_SECRET_ACCESS_KEY",
 ];
 
 /**
@@ -113,10 +120,10 @@ function workerBindings(input: {
    * churn spins sandboxes faster than they idle out, and a saturated cap
    * 503s every sandbox exec (observed live at 10/10 on preview-3). */
   maxContainerInstances?: number;
-  /** Local dev (the top-level config): sandboxes mount their persistent R2
-   * store through miniflare's local R2 binding rather than the credential-less
-   * egress mount, which needs FUSE/presigned URLs unavailable under
-   * `wrangler dev`. */
+  /** Local dev (the top-level config): sandbox workspace backups stream
+   * through miniflare's local R2 binding instead of presigned
+   * `*.r2.cloudflarestorage.com` URLs, which don't exist under `wrangler
+   * dev`. */
   localDev?: boolean;
 }) {
   return {
@@ -124,7 +131,13 @@ function workerBindings(input: {
       WORKER_SELF: input.workerName,
       ARTIFACTS_ACCOUNT_ID: input.accountId,
       ARTIFACTS_NAMESPACE: `${input.workerName}-repos`,
-      SANDBOX_STORAGE_MODE: input.localDev ? "local" : "r2-egress",
+      // Sandbox workspace backup config — names the Sandbox SDK reads from
+      // the env verbatim (BACKUP_BUCKET_NAME, CLOUDFLARE_R2_ACCOUNT_ID);
+      // the R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY presigning secrets ride in
+      // from Doppler (OPTIONAL_SECRETS).
+      BACKUP_BUCKET_NAME: `${input.workerName}-sandboxes`,
+      CLOUDFLARE_R2_ACCOUNT_ID: input.accountId,
+      SANDBOX_BACKUP_MODE: input.localDev ? "local" : "presigned",
     },
     durable_objects: {
       bindings: Object.entries(DO_CLASSES).map(([name, class_name]) => ({ name, class_name })),
@@ -150,11 +163,12 @@ function workerBindings(input: {
     ai: { binding: "AI" },
     worker_loaders: [{ binding: "LOADER" }],
     artifacts: [{ binding: "ARTIFACTS", namespace: `${input.workerName}-repos` }],
-    // Persistent storage for sandbox workspaces (ensure-resources.ts creates
-    // it; the sandbox DO mounts a per-sandbox prefix at /workspace). Addressed
-    // by name, so — unlike KV/D1 — no per-env id in envs.ts. In local dev
-    // miniflare provides this bucket automatically.
-    r2_buckets: [{ binding: "SANDBOX_STORAGE", bucket_name: `${input.workerName}-sandboxes` }],
+    // Sandbox workspace backups (ensure-resources.ts creates the bucket; the
+    // sandbox DO snapshots /workspace here on idle and restores on start).
+    // The binding MUST be named BACKUP_BUCKET — the Sandbox SDK reads it from
+    // the env by that exact name. Addressed by name, so — unlike KV/D1 — no
+    // per-env id in envs.ts. In local dev miniflare provides it automatically.
+    r2_buckets: [{ binding: "BACKUP_BUCKET", bucket_name: `${input.workerName}-sandboxes` }],
     containers: [
       {
         class_name: DO_CLASSES.SANDBOX,

--- a/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
+++ b/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
@@ -4,6 +4,10 @@ import type { Env } from "../../../env.ts";
 import { DurableObjectNameCodec } from "../../durable-object-names.ts";
 import { projectStub } from "../../projects/egress.ts";
 import { PROJECT_REPO_PATH } from "../../repos/utils.ts";
+import {
+  SandboxProcessorContract,
+  type SandboxLifecycleEventInput,
+} from "../sandbox-processor-contract.ts";
 import { normalizeSandboxPath } from "../utils.ts";
 
 /**
@@ -238,7 +242,10 @@ export class CloudflareSandboxDurableObject extends Sandbox<Env> {
 
   override async onStart(): Promise<void> {
     await super.onStart();
-    this.#emitLifecycleEvent("container-started");
+    this.#emitLifecycleEvent({
+      type: "events.iterate.com/sandbox/container-started",
+      payload: {},
+    });
     // Provision the workspace — restore the last backup, clone the repo if the
     // checkout is still missing — in the BACKGROUND. It cannot run inside
     // `onStart` itself: `onStart` executes in the container framework's
@@ -253,9 +260,13 @@ export class CloudflareSandboxDurableObject extends Sandbox<Env> {
     this.#workspaceReady = undefined;
     this.#workspaceProvisioned = false;
     this.ctx.waitUntil(
-      this.#ensureWorkspace().catch((error: unknown) =>
-        console.error("sandbox workspace setup failed", error),
-      ),
+      this.#ensureWorkspace().catch((error: unknown) => {
+        console.error("sandbox workspace setup failed", error);
+        this.#emitLifecycleEvent({
+          type: "events.iterate.com/sandbox/workspace-setup-failed",
+          payload: { error: String(error) },
+        });
+      }),
     );
   }
 
@@ -275,7 +286,10 @@ export class CloudflareSandboxDurableObject extends Sandbox<Env> {
       await this.#backupWorkspace();
     } catch (error) {
       console.error("sandbox workspace backup failed", error);
-      this.#emitLifecycleEvent("backup-failed", { error: String(error) });
+      this.#emitLifecycleEvent({
+        type: "events.iterate.com/sandbox/backup-failed",
+        payload: { error: String(error) },
+      });
     }
     await super.onActivityExpired();
   }
@@ -284,7 +298,10 @@ export class CloudflareSandboxDurableObject extends Sandbox<Env> {
     await super.onStop();
     // May fire late: if the Durable Object was hibernated when the container
     // exited, the SDK delivers this on the next wake.
-    this.#emitLifecycleEvent("container-stopped");
+    this.#emitLifecycleEvent({
+      type: "events.iterate.com/sandbox/container-stopped",
+      payload: {},
+    });
   }
 
   /**
@@ -314,7 +331,10 @@ export class CloudflareSandboxDurableObject extends Sandbox<Env> {
       ...(this.#canPresignBackupTransfers() ? {} : { localBucket: true }),
     });
     this.ctx.storage.kv.put(BACKUP_HANDLE_STORAGE_KEY, backup);
-    this.#emitLifecycleEvent("backup-created", { backupId: backup.id });
+    this.#emitLifecycleEvent({
+      type: "events.iterate.com/sandbox/backup-created",
+      payload: { backupId: backup.id },
+    });
   }
 
   #canPresignBackupTransfers(): boolean {
@@ -337,7 +357,10 @@ export class CloudflareSandboxDurableObject extends Sandbox<Env> {
     try {
       const result = await this.restoreBackup(backup);
       if (!result.success) return false;
-      this.#emitLifecycleEvent("workspace-restored", { backupId: backup.id });
+      this.#emitLifecycleEvent({
+        type: "events.iterate.com/sandbox/workspace-restored",
+        payload: { backupId: backup.id },
+      });
       return true;
     } catch (error) {
       console.warn("sandbox workspace restore failed, falling back to clone", error);
@@ -386,7 +409,12 @@ export class CloudflareSandboxDurableObject extends Sandbox<Env> {
       // would let the idle backup snapshot a half-provisioned /workspace over
       // the last good backup.
       if (this.#workspaceReady !== run) return;
-      if (!restored) this.#emitLifecycleEvent("workspace-cloned");
+      if (!restored) {
+        this.#emitLifecycleEvent({
+          type: "events.iterate.com/sandbox/workspace-cloned",
+          payload: {},
+        });
+      }
       this.#workspaceProvisioned = true;
     })().catch((error: unknown) => {
       // Let the next ensure retry instead of caching the failure forever —
@@ -403,27 +431,26 @@ export class CloudflareSandboxDurableObject extends Sandbox<Env> {
    * Append a lifecycle event to the stream at this sandbox's own path — for an
    * agent's sandbox that is the agent's own journal, so the agent (and anyone
    * tailing the stream) sees container starts/stops, snapshots, and restores
-   * as ordinary history. Best-effort by design: lifecycle telemetry must never
-   * block or fail container start/stop, so errors are logged and dropped.
+   * as ordinary history. The event catalog is the sandbox processor contract
+   * (sandbox-processor-contract.ts); building through it keeps emission and
+   * declaration from drifting. Best-effort by design: lifecycle telemetry must
+   * never block or fail container start/stop, so errors are logged and
+   * dropped.
    */
-  #emitLifecycleEvent(kind: string, payload: Record<string, unknown> = {}): void {
+  #emitLifecycleEvent(input: SandboxLifecycleEventInput): void {
     try {
+      const event = SandboxProcessorContract.buildEvent(input);
       const { projectId, path } = this.#identity();
       const stream = this.env.STREAM.getByName(
         DurableObjectNameCodec.stringify({ projectId, path }),
       );
       this.ctx.waitUntil(
-        Promise.resolve(
-          stream.append({
-            type: `events.iterate.com/sandbox/${kind}`,
-            payload,
-          }),
-        ).catch((error: unknown) =>
-          console.warn(`sandbox lifecycle event append failed (${kind})`, error),
+        Promise.resolve(stream.append(event)).catch((error: unknown) =>
+          console.warn(`sandbox lifecycle event append failed (${input.type})`, error),
         ),
       );
     } catch (error) {
-      console.warn(`sandbox lifecycle event skipped (${kind})`, error);
+      console.warn(`sandbox lifecycle event skipped (${input.type})`, error);
     }
   }
 

--- a/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
+++ b/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
@@ -368,20 +368,35 @@ export class CloudflareSandboxDurableObject extends Sandbox<Env> {
   }
 
   #ensureWorkspace(): Promise<void> {
-    this.#workspaceReady ??= (async () => {
+    if (this.#workspaceReady !== undefined) return this.#workspaceReady;
+    // `run` is only read inside the closures below, which execute strictly
+    // after the assignment at the bottom (the first read sits behind two
+    // awaits) — initialized to undefined so TS's definite-assignment analysis
+    // doesn't have to prove that ordering.
+    let run: Promise<void> | undefined = undefined;
+    run = (async () => {
       const restored = await this.#restoreWorkspace();
       // Clone when the restore didn't produce a checkout (no backup yet, the
       // backup expired, or it somehow predates the repo). #cloneProjectRepo
       // probes the marker itself, so a restored checkout makes this a no-op.
       await this.#cloneProjectRepo();
+      // A container restart mid-run reset the state for a NEW, empty disk —
+      // everything this run did landed on the old one. Only the still-current
+      // run may mark the workspace provisioned: a stale run setting the flag
+      // would let the idle backup snapshot a half-provisioned /workspace over
+      // the last good backup.
+      if (this.#workspaceReady !== run) return;
       if (!restored) this.#emitLifecycleEvent("workspace-cloned");
       this.#workspaceProvisioned = true;
     })().catch((error: unknown) => {
-      // Let the next ensure retry instead of caching the failure forever.
-      this.#workspaceReady = undefined;
+      // Let the next ensure retry instead of caching the failure forever —
+      // but only clear OUR OWN registration; a stale failing run must not
+      // clobber the promise of the newer run that replaced it.
+      if (this.#workspaceReady === run) this.#workspaceReady = undefined;
       throw error;
     });
-    return this.#workspaceReady;
+    this.#workspaceReady = run;
+    return run;
   }
 
   /**

--- a/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
+++ b/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
@@ -293,6 +293,14 @@ export class CloudflareSandboxDurableObject extends Sandbox<Env> {
    * fast; reinstalling dependencies is the restored workspace's job. The
    * handle is only overwritten AFTER `createBackup` succeeds, so a failed
    * backup can never orphan the previous good snapshot.
+   *
+   * Transfer mode is chosen by what the env provides: with R2 S3 credentials
+   * the SDK presigns `*.r2.cloudflarestorage.com` URLs and the container
+   * transfers directly (fast, and through project egress like all container
+   * traffic); without them — local dev always, a deployed env until keys are
+   * minted — archives stream through the Durable Object's BACKUP_BUCKET
+   * binding (the SDK's `localBucket` mode: slower, but zero-config and the
+   * only mode `wrangler dev` supports).
    */
   async #backupWorkspace(): Promise<void> {
     if (!this.#workspaceProvisioned) return;
@@ -303,10 +311,18 @@ export class CloudflareSandboxDurableObject extends Sandbox<Env> {
       ttl: SANDBOX_BACKUP_TTL_SECONDS,
       gitignore: true,
       excludes: ["node_modules"],
-      ...(this.env.SANDBOX_BACKUP_MODE === "local" ? { localBucket: true } : {}),
+      ...(this.#canPresignBackupTransfers() ? {} : { localBucket: true }),
     });
     this.ctx.storage.kv.put(BACKUP_HANDLE_STORAGE_KEY, backup);
     this.#emitLifecycleEvent("backup-created", { backupId: backup.id });
+  }
+
+  #canPresignBackupTransfers(): boolean {
+    return Boolean(
+      this.env.R2_ACCESS_KEY_ID &&
+      this.env.R2_SECRET_ACCESS_KEY &&
+      this.env.CLOUDFLARE_R2_ACCOUNT_ID,
+    );
   }
 
   /**

--- a/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
+++ b/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
@@ -6,8 +6,16 @@ import { projectStub } from "../../projects/egress.ts";
 import { PROJECT_REPO_PATH } from "../../repos/utils.ts";
 import { normalizeSandboxPath } from "../utils.ts";
 
-/** Where the project repo is cloned inside every sandbox container. */
-const SANDBOX_PROJECT_REPO_DIR = "/workspace/repo";
+/**
+ * The persistent workspace root inside every sandbox container. This path is
+ * an R2 mount (see {@link CloudflareSandboxDurableObject}), so everything
+ * under it — including the repo checkout below — survives the container
+ * sleeping. Nothing outside it does: container disk is ephemeral.
+ */
+const SANDBOX_WORKSPACE_DIR = "/workspace";
+
+/** Where the project repo is checked out — on the persistent workspace mount. */
+const SANDBOX_PROJECT_REPO_DIR = `${SANDBOX_WORKSPACE_DIR}/repo`;
 
 // The container-outbound handler runs in the ContainerProxy WorkerEntrypoint,
 // not on a sandbox instance, so it only gets the container's opaque Durable
@@ -41,21 +49,48 @@ const IDENTITY_STORAGE_KEY = "iterate-sandbox-identity";
  * IS the SDK's — `itx.sandboxes.get(path)` returns this object's bare RPC stub
  * (exec, files, processes, ports, gitCheckout, …) with nothing wrapped on top.
  *
- * Lifecycle is the SDK's, unchanged: getting the stub is cheap (no container),
- * the first command boots the container, and the SDK's durable `sleepAfter`
- * idle alarm (default 10m) stops it again. Identity and Durable Object storage
- * survive sleep; the container FILESYSTEM does not — restorability comes from
- * `onStart` re-provisioning (the repo clone below).
+ * Lifecycle is the SDK's: getting the stub is cheap (no container), the first
+ * command boots the container, and the SDK's durable `sleepAfter` idle alarm
+ * (3m, see below) stops it again. Identity and Durable Object storage survive
+ * sleep. The container's own disk does NOT — but `/workspace` does, because it
+ * is a persistent R2 mount (see behavior 1).
  *
- * Two behaviors are added over the stock SDK class:
+ * Three behaviors are added over the stock SDK class:
  *
- * 1. Every container start kicks off a clone of the project repo to
- *    {@link SANDBOX_PROJECT_REPO_DIR}, so code in the sandbox finds the
- *    project's source checked out. Container filesystems are ephemeral — a
- *    restart is a fresh disk — which is why the clone re-runs per start rather
- *    than once at creation; `ensureProjectRepo()` is the awaitable guarantee.
+ * 1. `/workspace` is PERSISTENT. Container disk is ephemeral — Cloudflare
+ *    offers no persistent volume — so the Cloudflare-idiomatic answer is the
+ *    Sandbox SDK's `mountBucket`: `onStart` mounts a per-sandbox prefix
+ *    (`/{projectId}{path}`) of the env's {@link Env.SANDBOX_STORAGE} R2 bucket
+ *    at {@link SANDBOX_WORKSPACE_DIR}, so files written there live in R2 and
+ *    survive sleep/restart. The mount happens in `onStart`, which the SDK runs
+ *    inside `blockConcurrencyWhile` before serving any command — so the mount
+ *    is always in place before anything writes to `/workspace`.
+ *    Docs: https://developers.cloudflare.com/sandbox/api/storage/ and the
+ *    ephemeral-disk statement at
+ *    https://developers.cloudflare.com/containers/faq/.
  *
- * 2. ALL container egress is routed through the project's egress decision
+ *    Alternatives Cloudflare documents, and why not here:
+ *    - `createBackup`/`restoreBackup`
+ *      (https://developers.cloudflare.com/sandbox/api/backups/) snapshot a
+ *      directory to R2. Snapshot-granular, not continuous: work since the last
+ *      backup is lost on an unexpected sleep, and the caller must persist and
+ *      manage backup handles. We want a durable filesystem, not point-in-time
+ *      snapshots, so a live mount is the better fit.
+ *    - A raw R2 FUSE mount wired up in the Dockerfile (s3fs/tigrisfs by hand,
+ *      https://developers.cloudflare.com/containers/examples/r2-fuse-mount/) is
+ *      what `mountBucket` does for us — but managed, credential-less, and over
+ *      the egress interception we already run — so no Dockerfile changes and no
+ *      S3 credentials in the container.
+ *    - Durable Object storage (`ctx.storage`) is key/value, not a filesystem —
+ *      right for small identity/metadata (as used above), not a repo checkout.
+ *
+ * 2. The project repo is ALWAYS checked out at {@link SANDBOX_PROJECT_REPO_DIR}.
+ *    Because the workspace is persistent, the clone runs once and then survives
+ *    sleep; every later start re-mounts and finds the checkout already there.
+ *    `onStart` verifies/kicks off the checkout on every start and
+ *    `ensureProjectRepo()` is the awaitable guarantee for repo-dependent work.
+ *
+ * 3. ALL container egress is routed through the project's egress decision
  *    point, exactly like a dynamic worker's `globalOutbound` — see the
  *    `outbound` handler below. `interceptHttps` extends that to HTTPS by
  *    man-in-the-middling TLS with the Cloudflare-provided container CA (the
@@ -174,20 +209,54 @@ export class CloudflareSandboxDurableObject extends Sandbox<Env> {
 
   override async onStart(): Promise<void> {
     await super.onStart();
-    // `onStart` runs inside the container framework's blockConcurrencyWhile:
-    // a hard ~30s budget whose cancellation resets the Durable Object AND
-    // tears the fresh container down — and timer events are input-gated, so
-    // the work cannot even bound itself with a deadline in here. The clone
-    // therefore only STARTS here and completes in the background; a caller
-    // that needs the repo deterministically awaits `ensureProjectRepo()`.
+    // Mount the persistent workspace FIRST. `onStart` runs inside the
+    // container framework's blockConcurrencyWhile, so it completes before any
+    // command RPC is served — mounting here guarantees `/workspace` is backed
+    // by R2 before anything writes to it (otherwise early writes would land on
+    // the ephemeral disk and vanish, or be hidden when the mount overlays the
+    // path). A fresh container starts unmounted, so this runs every start.
+    await this.#mountWorkspace();
+
+    // The repo checkout lives on the now-persistent workspace, so it is cloned
+    // once and survives sleep; a later start re-mounts and finds it already
+    // there (the marker check below returns fast). The clone can still exceed
+    // onStart's hard ~30s budget on a cold repo — and timer events are
+    // input-gated in here, so it cannot bound itself with a deadline — so it
+    // only STARTS here and finishes in the background; `ensureProjectRepo()`
+    // is the awaitable guarantee for callers that need the repo.
     //
-    // Each start is a fresh container filesystem, so a clone promise from a
+    // Each start is a fresh container process, so a clone promise from a
     // previous container must not satisfy this one.
     this.#repoClone = undefined;
     this.ctx.waitUntil(
       this.#ensureRepoClone().catch((error: unknown) =>
         console.error("sandbox project repo clone failed", error),
       ),
+    );
+  }
+
+  /**
+   * Mount this sandbox's slice of the env's persistent R2 store at
+   * {@link SANDBOX_WORKSPACE_DIR}. Each sandbox gets an isolated `prefix`
+   * (`/{projectId}{path}`) of the one shared bucket, so a container only ever
+   * sees its own workspace and cannot read another sandbox's files.
+   *
+   * Deployed envs use the credential-less R2-binding mount, which the SDK
+   * routes over the SAME container egress interception this class already runs
+   * (see the `outbound` handler) — no S3 credentials ever enter the container.
+   * Local dev uses miniflare's local R2 binding (`localBucket`), since the
+   * FUSE/presigned-URL path is unavailable under `wrangler dev`.
+   *
+   * Mount modes and options:
+   * https://developers.cloudflare.com/sandbox/api/storage/
+   */
+  async #mountWorkspace(): Promise<void> {
+    const { projectId, path } = this.#identity();
+    const prefix = `/${projectId}${path}`;
+    await this.mountBucket(
+      "SANDBOX_STORAGE",
+      SANDBOX_WORKSPACE_DIR,
+      this.env.SANDBOX_STORAGE_MODE === "local" ? { localBucket: true, prefix } : { prefix },
     );
   }
 

--- a/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
+++ b/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
@@ -179,26 +179,48 @@ export class CloudflareSandboxDurableObject extends Sandbox<Env> {
   override sleepAfter = "3m";
 
   /**
-   * Idle expiry DESTROYS the container instead of the SDK's stop (SIGTERM).
-   * A stopped container keeps its instance ASSIGNED to this Durable Object,
-   * and assignments count against the app's max_instances and never expire on
-   * their own (`wrangler containers info` on a slot mid-marathon: active 0,
-   * assigned 99 — including day-old idle slots still holding their last run's
+   * Idle expiry: SNAPSHOT `/workspace`, then DESTROY the container.
+   *
+   * This is the one moment a pre-sleep snapshot is possible — the idle timer
+   * fired but the container is STILL RUNNING (`onStop` is too late: the
+   * container is already gone, and that hook can even fire on a later wake).
+   * A backup failure must never wedge the container alive — it holds an
+   * instance slot against the namespace cap — so failures are logged and
+   * emitted as events, and the teardown proceeds regardless; the durable
+   * handle still points at the last good backup.
+   *
+   * DESTROY, not the SDK's stop (SIGTERM): a stopped container keeps its
+   * instance ASSIGNED to this Durable Object, and assignments count against
+   * the app's max_instances and never expire on their own
+   * (`wrangler containers info` on a slot mid-marathon: active 0, assigned 99
+   * — including day-old idle slots still holding their last run's
    * assignments; only destroy or an app rollout releases them). Every e2e
-   * fixture creates a fresh sandbox DO, so stop-on-idle leaks ~7-8 assignments
-   * per preview e2e run and the cap wedges every new sandbox start after
-   * ~a dozen runs — the real mechanism behind the recurring "Container is
-   * starting/provisioning" windows (docs/preview-e2e-flake-hunt.md flake 23,
-   * superseding the flake 19/20 theories). Destroy costs us nothing extra: a
-   * sandbox filesystem is ephemeral across sleep anyway (see class docs), so
-   * stop-then-wake and destroy-then-wake are the same cold boot + re-clone.
-   * The SDK's keepAlive guard is preserved (its own override skips shutdown
-   * when a caller enabled keepAlive; the field is private, hence the cast).
+   * fixture creates a fresh sandbox DO, so stop-on-idle leaks ~7-8
+   * assignments per preview e2e run and the cap wedges every new sandbox
+   * start after ~a dozen runs — the real mechanism behind the recurring
+   * "Container is starting/provisioning" windows
+   * (docs/preview-e2e-flake-hunt.md flake 23, superseding the flake 19/20
+   * theories). Destroy costs nothing BECAUSE of the snapshot above: the next
+   * wake restores `/workspace` from it, so destroy-then-wake and
+   * stop-then-wake land in the same place (destroy leaves Durable Object
+   * storage — the identity and backup handle — intact; the SDK's doDestroy
+   * deletes only its own port/tunnel/runtime keys). The SDK's keepAlive guard
+   * is preserved (its own override skips shutdown when a caller enabled
+   * keepAlive; the field is private, hence the cast).
    */
   override async onActivityExpired(): Promise<void> {
     const keepAlive = (this as unknown as { keepAliveEnabled?: boolean }).keepAliveEnabled === true;
     if (keepAlive) {
       return super.onActivityExpired();
+    }
+    try {
+      await this.#backupWorkspace();
+    } catch (error) {
+      console.error("sandbox workspace backup failed", error);
+      this.#emitLifecycleEvent({
+        type: "events.iterate.com/sandbox/backup-failed",
+        payload: { error: String(error) },
+      });
     }
     await this.destroy();
   }
@@ -293,30 +315,6 @@ export class CloudflareSandboxDurableObject extends Sandbox<Env> {
         });
       }),
     );
-  }
-
-  /**
-   * The idle-timer hook: fires when `sleepAfter` expires and the container is
-   * STILL RUNNING — the one moment a pre-sleep snapshot is possible (`onStop`
-   * is too late: the container is already gone, and the hook can even fire on
-   * a later wake). Snapshot `/workspace`, then let the SDK stop the container.
-   *
-   * A backup failure must never wedge the container awake — the container
-   * holds an instance slot against the namespace cap — so failures are logged
-   * and emitted as events, and the stop proceeds regardless; the durable
-   * handle still points at the last good backup.
-   */
-  override async onActivityExpired(): Promise<void> {
-    try {
-      await this.#backupWorkspace();
-    } catch (error) {
-      console.error("sandbox workspace backup failed", error);
-      this.#emitLifecycleEvent({
-        type: "events.iterate.com/sandbox/backup-failed",
-        payload: { error: String(error) },
-      });
-    }
-    await super.onActivityExpired();
   }
 
   override async onStop(): Promise<void> {

--- a/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
+++ b/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
@@ -1,5 +1,5 @@
 import type { OutboundHandler } from "@cloudflare/containers";
-import { Sandbox } from "@cloudflare/sandbox";
+import { Sandbox, type DirectoryBackup } from "@cloudflare/sandbox";
 import type { Env } from "../../../env.ts";
 import { DurableObjectNameCodec } from "../../durable-object-names.ts";
 import { projectStub } from "../../projects/egress.ts";
@@ -7,15 +7,28 @@ import { PROJECT_REPO_PATH } from "../../repos/utils.ts";
 import { normalizeSandboxPath } from "../utils.ts";
 
 /**
- * The persistent workspace root inside every sandbox container. This path is
- * an R2 mount (see {@link CloudflareSandboxDurableObject}), so everything
- * under it — including the repo checkout below — survives the container
- * sleeping. Nothing outside it does: container disk is ephemeral.
+ * The workspace root inside every sandbox container: what the backup/restore
+ * cycle persists (see {@link CloudflareSandboxDurableObject}). Everything under
+ * it survives idle sleep via the R2 backup; nothing outside it does — container
+ * disk is ephemeral.
  */
 const SANDBOX_WORKSPACE_DIR = "/workspace";
 
-/** Where the project repo is checked out — on the persistent workspace mount. */
+/** Where the project repo is checked out, inside the persisted workspace. */
 const SANDBOX_PROJECT_REPO_DIR = `${SANDBOX_WORKSPACE_DIR}/repo`;
+
+/**
+ * How long a sandbox's workspace backup survives without the sandbox waking
+ * again (the SDK GCs backups after their ttl). 90 days: long enough that any
+ * plausibly-still-wanted workspace comes back intact, short enough that the
+ * churn of short-lived sandboxes (e2e runs a fresh project per test) does not
+ * accumulate in R2 forever. Durable work belongs in the repo (committed and
+ * pushed); the workspace backup is for everything in flight around it.
+ */
+const SANDBOX_BACKUP_TTL_SECONDS = 90 * 24 * 60 * 60;
+
+/** Durable pointer to the newest good workspace backup (a DirectoryBackup). */
+const BACKUP_HANDLE_STORAGE_KEY = "iterate-sandbox-workspace-backup";
 
 // The container-outbound handler runs in the ContainerProxy WorkerEntrypoint,
 // not on a sandbox instance, so it only gets the container's opaque Durable
@@ -52,43 +65,55 @@ const IDENTITY_STORAGE_KEY = "iterate-sandbox-identity";
  * Lifecycle is the SDK's: getting the stub is cheap (no container), the first
  * command boots the container, and the SDK's durable `sleepAfter` idle alarm
  * (3m, see below) stops it again. Identity and Durable Object storage survive
- * sleep. The container's own disk does NOT — but `/workspace` does, because it
- * is a persistent R2 mount (see behavior 1).
+ * sleep. The container's own disk does NOT — but `/workspace` comes back,
+ * because going to sleep snapshots it to R2 and the next start restores it
+ * (see behavior 1). Lifecycle transitions are also appended as events to the
+ * stream at this sandbox's own path — for an agent's sandbox that is the
+ * agent's own journal (see `#emitLifecycleEvent`).
  *
  * Three behaviors are added over the stock SDK class:
  *
- * 1. `/workspace` is PERSISTENT. Container disk is ephemeral — Cloudflare
- *    offers no persistent volume — so the Cloudflare-idiomatic answer is the
- *    Sandbox SDK's `mountBucket`: `onStart` mounts a per-sandbox prefix
- *    (`/{projectId}{path}`) of the env's {@link Env.SANDBOX_STORAGE} R2 bucket
- *    at {@link SANDBOX_WORKSPACE_DIR}, so files written there live in R2 and
- *    survive sleep/restart. The mount happens in `onStart`, which the SDK runs
- *    inside `blockConcurrencyWhile` before serving any command — so the mount
- *    is always in place before anything writes to `/workspace`.
- *    Docs: https://developers.cloudflare.com/sandbox/api/storage/ and the
- *    ephemeral-disk statement at
- *    https://developers.cloudflare.com/containers/faq/.
+ * 1. `/workspace` PERSISTS ACROSS SLEEP. Container disk is ephemeral —
+ *    Cloudflare offers no persistent volume
+ *    (https://developers.cloudflare.com/containers/faq/) — so this class uses
+ *    the Sandbox SDK's backup/restore
+ *    (https://developers.cloudflare.com/sandbox/guides/backup-restore/):
+ *    `onActivityExpired` (the idle-timer hook, the one moment the container is
+ *    still running but about to stop) snapshots `/workspace` to the env's
+ *    {@link Env.BACKUP_BUCKET} R2 bucket, and the next `onStart` restores the
+ *    newest snapshot before falling back to a fresh repo clone. Snapshots are
+ *    gitignore-aware (no node_modules etc.), so they stay small and restore
+ *    fast (~seconds, vs a cold clone).
  *
- *    Alternatives Cloudflare documents, and why not here:
- *    - `createBackup`/`restoreBackup`
- *      (https://developers.cloudflare.com/sandbox/api/backups/) snapshot a
- *      directory to R2. Snapshot-granular, not continuous: work since the last
- *      backup is lost on an unexpected sleep, and the caller must persist and
- *      manage backup handles. We want a durable filesystem, not point-in-time
- *      snapshots, so a live mount is the better fit.
- *    - A raw R2 FUSE mount wired up in the Dockerfile (s3fs/tigrisfs by hand,
- *      https://developers.cloudflare.com/containers/examples/r2-fuse-mount/) is
- *      what `mountBucket` does for us — but managed, credential-less, and over
- *      the egress interception we already run — so no Dockerfile changes and no
- *      S3 credentials in the container.
+ *    Known window: this is snapshot-granular. A container that CRASHES (rather
+ *    than idling out) loses whatever changed since the last snapshot — durable
+ *    work belongs in the repo, committed and pushed.
+ *
+ *    Alternatives Cloudflare documents, and why not:
+ *    - `mountBucket` (https://developers.cloudflare.com/sandbox/api/storage/)
+ *      mounts R2 as a live FUSE filesystem — continuous persistence, tried
+ *      first. Its R2-binding mode routes s3fs traffic to the magic host
+ *      `r2.internal`, serviced by the SDK's own per-host container-egress
+ *      interceptor — which our catch-all `outbound` handler (behavior 3)
+ *      necessarily swallows, and the two cannot compose without exempting
+ *      storage traffic from project egress policy. Verified broken on a real
+ *      preview (every filesystem op → I/O error). Backup/restore has no such
+ *      conflict: its transfers are plain HTTPS to the real
+ *      `*.r2.cloudflarestorage.com` host via presigned URLs, which flow
+ *      THROUGH project egress like any other request.
+ *    - A raw R2 FUSE mount hand-rolled in the Dockerfile
+ *      (https://developers.cloudflare.com/containers/examples/r2-fuse-mount/)
+ *      is the same mechanism as `mountBucket`, minus the management — same
+ *      conflict.
  *    - Durable Object storage (`ctx.storage`) is key/value, not a filesystem —
- *      right for small identity/metadata (as used above), not a repo checkout.
+ *      right for identity and the backup handle (as used here), not a repo
+ *      checkout.
  *
  * 2. The project repo is ALWAYS checked out at {@link SANDBOX_PROJECT_REPO_DIR}.
- *    Because the workspace is persistent, the clone runs once and then survives
- *    sleep; every later start re-mounts and finds the checkout already there.
- *    `onStart` verifies/kicks off the checkout on every start and
- *    `ensureProjectRepo()` is the awaitable guarantee for repo-dependent work.
+ *    Every container start provisions the workspace — restore the last
+ *    snapshot if one exists, then clone the repo if the checkout is still
+ *    missing — and `ensureProjectRepo()` is the awaitable guarantee for
+ *    repo-dependent work.
  *
  * 3. ALL container egress is routed through the project's egress decision
  *    point, exactly like a dynamic worker's `globalOutbound` — see the
@@ -205,85 +230,170 @@ export class CloudflareSandboxDurableObject extends Sandbox<Env> {
     return stored;
   }
 
-  #repoClone: Promise<void> | undefined;
+  #workspaceReady: Promise<void> | undefined;
+  // Whether the CURRENT container's workspace was fully provisioned (restored
+  // or cloned). Gates the idle-time backup: snapshotting a half-provisioned
+  // workspace would overwrite the pointer to the last GOOD backup.
+  #workspaceProvisioned = false;
 
   override async onStart(): Promise<void> {
     await super.onStart();
-    // Mount the persistent workspace FIRST. `onStart` runs inside the
-    // container framework's blockConcurrencyWhile, so it completes before any
-    // command RPC is served — mounting here guarantees `/workspace` is backed
-    // by R2 before anything writes to it (otherwise early writes would land on
-    // the ephemeral disk and vanish, or be hidden when the mount overlays the
-    // path). A fresh container starts unmounted, so this runs every start.
-    await this.#mountWorkspace();
-
-    // The repo checkout lives on the now-persistent workspace, so it is cloned
-    // once and survives sleep; a later start re-mounts and finds it already
-    // there (the marker check below returns fast). The clone can still exceed
-    // onStart's hard ~30s budget on a cold repo — and timer events are
-    // input-gated in here, so it cannot bound itself with a deadline — so it
-    // only STARTS here and finishes in the background; `ensureProjectRepo()`
-    // is the awaitable guarantee for callers that need the repo.
+    this.#emitLifecycleEvent("container-started");
+    // Provision the workspace — restore the last backup, clone the repo if the
+    // checkout is still missing — in the BACKGROUND. It cannot run inside
+    // `onStart` itself: `onStart` executes in the container framework's
+    // blockConcurrencyWhile, which has a hard ~30s budget and resets the
+    // Durable Object on overrun (verified live), and a cold clone or a large
+    // restore can exceed it — and timer events are input-gated in here, so the
+    // work cannot even bound itself with a deadline. Callers that need the
+    // workspace await `ensureProjectRepo()`.
     //
-    // Each start is a fresh container process, so a clone promise from a
-    // previous container must not satisfy this one.
-    this.#repoClone = undefined;
+    // Each start is a fresh container process (empty disk), so a readiness
+    // promise from a previous container must not satisfy this one.
+    this.#workspaceReady = undefined;
+    this.#workspaceProvisioned = false;
     this.ctx.waitUntil(
-      this.#ensureRepoClone().catch((error: unknown) =>
-        console.error("sandbox project repo clone failed", error),
+      this.#ensureWorkspace().catch((error: unknown) =>
+        console.error("sandbox workspace setup failed", error),
       ),
     );
   }
 
   /**
-   * Mount this sandbox's slice of the env's persistent R2 store at
-   * {@link SANDBOX_WORKSPACE_DIR}. Each sandbox gets an isolated `prefix`
-   * (`/{projectId}{path}`) of the one shared bucket, so a container only ever
-   * sees its own workspace and cannot read another sandbox's files.
+   * The idle-timer hook: fires when `sleepAfter` expires and the container is
+   * STILL RUNNING — the one moment a pre-sleep snapshot is possible (`onStop`
+   * is too late: the container is already gone, and the hook can even fire on
+   * a later wake). Snapshot `/workspace`, then let the SDK stop the container.
    *
-   * Deployed envs use the credential-less R2-binding mount, which the SDK
-   * routes over the SAME container egress interception this class already runs
-   * (see the `outbound` handler) — no S3 credentials ever enter the container.
-   * Local dev uses miniflare's local R2 binding (`localBucket`), since the
-   * FUSE/presigned-URL path is unavailable under `wrangler dev`.
-   *
-   * Mount modes and options:
-   * https://developers.cloudflare.com/sandbox/api/storage/
+   * A backup failure must never wedge the container awake — the container
+   * holds an instance slot against the namespace cap — so failures are logged
+   * and emitted as events, and the stop proceeds regardless; the durable
+   * handle still points at the last good backup.
    */
-  async #mountWorkspace(): Promise<void> {
-    const { projectId, path } = this.#identity();
-    const prefix = `/${projectId}${path}`;
-    await this.mountBucket(
-      "SANDBOX_STORAGE",
-      SANDBOX_WORKSPACE_DIR,
-      this.env.SANDBOX_STORAGE_MODE === "local" ? { localBucket: true, prefix } : { prefix },
-    );
+  override async onActivityExpired(): Promise<void> {
+    try {
+      await this.#backupWorkspace();
+    } catch (error) {
+      console.error("sandbox workspace backup failed", error);
+      this.#emitLifecycleEvent("backup-failed", { error: String(error) });
+    }
+    await super.onActivityExpired();
+  }
+
+  override async onStop(): Promise<void> {
+    await super.onStop();
+    // May fire late: if the Durable Object was hibernated when the container
+    // exited, the SDK delivers this on the next wake.
+    this.#emitLifecycleEvent("container-stopped");
   }
 
   /**
-   * The project repo clone, awaitable: resolves once `/workspace/repo` holds
-   * a completed clone for the CURRENT container. Idempotent and safe to call
-   * any time — the clone starts automatically on every container start, so
-   * this usually returns fast; await it before work that depends on the repo.
+   * Snapshot `/workspace` to R2 and move the durable handle to the new backup.
+   * Gitignore-aware and node_modules-free, so archives stay small and restores
+   * fast; reinstalling dependencies is the restored workspace's job. The
+   * handle is only overwritten AFTER `createBackup` succeeds, so a failed
+   * backup can never orphan the previous good snapshot.
    */
-  async ensureProjectRepo(): Promise<void> {
-    // A container restart mid-await resets `#repoClone` (fresh filesystem),
-    // so a clone that completed against the PREVIOUS container must not
-    // satisfy this call — loop until the run we awaited is still current.
-    while (true) {
-      const run = this.#ensureRepoClone();
-      await run;
-      if (this.#repoClone === run) return;
+  async #backupWorkspace(): Promise<void> {
+    if (!this.#workspaceProvisioned) return;
+    const { projectId, path } = this.#identity();
+    const backup = await this.createBackup({
+      dir: SANDBOX_WORKSPACE_DIR,
+      name: `${projectId}${path}`,
+      ttl: SANDBOX_BACKUP_TTL_SECONDS,
+      gitignore: true,
+      excludes: ["node_modules"],
+      ...(this.env.SANDBOX_BACKUP_MODE === "local" ? { localBucket: true } : {}),
+    });
+    this.ctx.storage.kv.put(BACKUP_HANDLE_STORAGE_KEY, backup);
+    this.#emitLifecycleEvent("backup-created", { backupId: backup.id });
+  }
+
+  /**
+   * Restore the newest workspace backup into the fresh container, if one
+   * exists. Returns whether `/workspace` now holds a restored snapshot; any
+   * failure (expired ttl, deleted object, transfer error) degrades to `false`
+   * so provisioning falls back to a clean clone rather than failing the start.
+   */
+  async #restoreWorkspace(): Promise<boolean> {
+    const backup = this.ctx.storage.kv.get<DirectoryBackup>(BACKUP_HANDLE_STORAGE_KEY);
+    if (backup === undefined) return false;
+    try {
+      const result = await this.restoreBackup(backup);
+      if (!result.success) return false;
+      this.#emitLifecycleEvent("workspace-restored", { backupId: backup.id });
+      return true;
+    } catch (error) {
+      console.warn("sandbox workspace restore failed, falling back to clone", error);
+      return false;
     }
   }
 
-  #ensureRepoClone(): Promise<void> {
-    this.#repoClone ??= this.#cloneProjectRepo().catch((error: unknown) => {
+  /**
+   * The workspace guarantee, awaitable: resolves once `/workspace` is
+   * provisioned for the CURRENT container — the last backup restored (fast)
+   * and `/workspace/repo` holding a completed checkout (cloned fresh when the
+   * backup lacked one or there was no backup). Idempotent and safe to call any
+   * time — provisioning starts automatically on every container start, so this
+   * usually returns quickly; await it before work that depends on the repo.
+   *
+   * Named `ensureProjectRepo` for its callers — the repo is the thing they
+   * wait on — but it guarantees the whole workspace.
+   */
+  async ensureProjectRepo(): Promise<void> {
+    // A container restart mid-await resets `#workspaceReady` (fresh disk), so
+    // a promise that completed against the PREVIOUS container must not satisfy
+    // this call — loop until the run we awaited is still current.
+    while (true) {
+      const run = this.#ensureWorkspace();
+      await run;
+      if (this.#workspaceReady === run) return;
+    }
+  }
+
+  #ensureWorkspace(): Promise<void> {
+    this.#workspaceReady ??= (async () => {
+      const restored = await this.#restoreWorkspace();
+      // Clone when the restore didn't produce a checkout (no backup yet, the
+      // backup expired, or it somehow predates the repo). #cloneProjectRepo
+      // probes the marker itself, so a restored checkout makes this a no-op.
+      await this.#cloneProjectRepo();
+      if (!restored) this.#emitLifecycleEvent("workspace-cloned");
+      this.#workspaceProvisioned = true;
+    })().catch((error: unknown) => {
       // Let the next ensure retry instead of caching the failure forever.
-      this.#repoClone = undefined;
+      this.#workspaceReady = undefined;
       throw error;
     });
-    return this.#repoClone;
+    return this.#workspaceReady;
+  }
+
+  /**
+   * Append a lifecycle event to the stream at this sandbox's own path — for an
+   * agent's sandbox that is the agent's own journal, so the agent (and anyone
+   * tailing the stream) sees container starts/stops, snapshots, and restores
+   * as ordinary history. Best-effort by design: lifecycle telemetry must never
+   * block or fail container start/stop, so errors are logged and dropped.
+   */
+  #emitLifecycleEvent(kind: string, payload: Record<string, unknown> = {}): void {
+    try {
+      const { projectId, path } = this.#identity();
+      const stream = this.env.STREAM.getByName(
+        DurableObjectNameCodec.stringify({ projectId, path }),
+      );
+      this.ctx.waitUntil(
+        Promise.resolve(
+          stream.append({
+            type: `events.iterate.com/sandbox/${kind}`,
+            payload,
+          }),
+        ).catch((error: unknown) =>
+          console.warn(`sandbox lifecycle event append failed (${kind})`, error),
+        ),
+      );
+    } catch (error) {
+      console.warn(`sandbox lifecycle event skipped (${kind})`, error);
+    }
   }
 
   async #cloneProjectRepo(): Promise<void> {

--- a/apps/os/src/domains/sandboxes/sandbox-processor-contract.ts
+++ b/apps/os/src/domains/sandboxes/sandbox-processor-contract.ts
@@ -1,0 +1,90 @@
+import { z } from "zod";
+import { defineProcessorContract } from "../streams/processor-contracts.ts";
+
+/**
+ * The event catalog, spelled out as a const so
+ * {@link SandboxLifecycleEventInput} can be derived from it — the contract
+ * object's own `events` key loses the literal payload-schema pairing needed
+ * for that mapped type.
+ */
+const SANDBOX_EVENTS = {
+  "events.iterate.com/sandbox/container-started": {
+    description:
+      "The sandbox container booted (the SDK's onStart hook). Workspace provisioning starts in the background right after this.",
+    payloadSchema: z.object({}),
+  },
+  "events.iterate.com/sandbox/container-stopped": {
+    description:
+      "The sandbox container exited (the SDK's onStop hook). May be appended on a LATER wake: the SDK delivers a stop that happened while the Durable Object was hibernated on the next wake.",
+    payloadSchema: z.object({}),
+  },
+  "events.iterate.com/sandbox/workspace-restored": {
+    description: "/workspace was restored from the named R2 snapshot into the fresh container.",
+    payloadSchema: z.object({ backupId: z.string() }),
+  },
+  "events.iterate.com/sandbox/workspace-cloned": {
+    description:
+      "/workspace was provisioned by a fresh project-repo clone (no snapshot existed, it expired, or its restore failed).",
+    payloadSchema: z.object({}),
+  },
+  "events.iterate.com/sandbox/workspace-setup-failed": {
+    description:
+      "Background workspace provisioning failed after its retries; the next ensureProjectRepo() call retries from scratch.",
+    payloadSchema: z.object({ error: z.string() }),
+  },
+  "events.iterate.com/sandbox/backup-created": {
+    description:
+      "/workspace was snapshotted to R2 as the container idled out (the SDK's onActivityExpired hook); this backup is what the next start restores.",
+    payloadSchema: z.object({ backupId: z.string() }),
+  },
+  "events.iterate.com/sandbox/backup-failed": {
+    description:
+      "The idle-time workspace snapshot failed; the container still stops, and the previous good backup (if any) remains the restore source.",
+    payloadSchema: z.object({ error: z.string() }),
+  },
+} as const;
+
+/**
+ * The contract for a sandbox's lifecycle events — the public declaration of
+ * what `CloudflareSandboxDurableObject` appends to the stream at the sandbox's
+ * OWN path (for an agent's sandbox, the agent's journal). The Durable Object
+ * is the appender — it builds every event through this contract
+ * (`SandboxProcessorContract.buildEvent`), so emission and declaration cannot
+ * drift; the processor itself only folds the events into a small status
+ * projection and takes no actions (`emits: []`).
+ *
+ * Event order tells the persistence story: container-started →
+ * workspace-restored | workspace-cloned → … → backup-created →
+ * container-stopped, then the next start restores the named backup.
+ */
+export const SandboxProcessorContract = defineProcessorContract({
+  slug: "sandbox",
+  version: "0.1.0",
+  description:
+    "Sandbox container lifecycle: starts/stops, workspace restore-or-clone provisioning, and the idle-time R2 workspace snapshots.",
+  stateSchema: z.object({
+    /** Whether the container is up, as of the latest lifecycle event. */
+    running: z.boolean().default(false),
+    /** The newest workspace snapshot — what the next container start restores. */
+    lastBackupId: z.string().nullable().default(null),
+  }),
+  events: SANDBOX_EVENTS,
+  consumes: [
+    "events.iterate.com/sandbox/container-started",
+    "events.iterate.com/sandbox/container-stopped",
+    "events.iterate.com/sandbox/backup-created",
+  ],
+  emits: [],
+});
+
+/**
+ * One lifecycle event as the sandbox Durable Object appends it: the event
+ * type paired with ITS OWN payload shape (derived per entry from the catalog,
+ * which a plain `{ type, payload }` union over `keyof events` would not give).
+ */
+export type SandboxLifecycleEventInput = {
+  [Type in keyof typeof SANDBOX_EVENTS]: {
+    type: Type;
+    payload: z.input<(typeof SANDBOX_EVENTS)[Type]["payloadSchema"]>;
+  };
+}[keyof typeof SANDBOX_EVENTS];

--- a/apps/os/src/domains/sandboxes/sandbox-processor-implementation.ts
+++ b/apps/os/src/domains/sandboxes/sandbox-processor-implementation.ts
@@ -1,0 +1,31 @@
+import { StreamProcessor } from "../streams/stream-processor.ts";
+import { SandboxProcessorContract } from "./sandbox-processor-contract.ts";
+
+/**
+ * The sandbox lifecycle processor: folds the events declared by
+ * {@link SandboxProcessorContract} into a small status projection (is the
+ * container running, which snapshot would a restart restore). Deliberately
+ * takes NO actions — the lifecycle itself is driven by the Sandbox SDK's hooks
+ * inside `CloudflareSandboxDurableObject`, which appends these events; this
+ * class exists to hold the contract and give stream consumers a folded view.
+ * Not yet wired to a processor host anywhere.
+ */
+export class SandboxProcessor extends StreamProcessor<typeof SandboxProcessorContract> {
+  readonly contract = SandboxProcessorContract;
+
+  protected override reduce({
+    event,
+    state,
+  }: Parameters<StreamProcessor<typeof SandboxProcessorContract>["reduce"]>[0]) {
+    switch (event.type) {
+      case "events.iterate.com/sandbox/container-started":
+        return { ...state, running: true };
+      case "events.iterate.com/sandbox/container-stopped":
+        return { ...state, running: false };
+      case "events.iterate.com/sandbox/backup-created":
+        return { ...state, lastBackupId: event.payload.backupId };
+      default:
+        return state;
+    }
+  }
+}

--- a/apps/os/src/domains/sandboxes/sandbox-processor.test.ts
+++ b/apps/os/src/domains/sandboxes/sandbox-processor.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { Stream, StreamEvent } from "../../types.ts";
+import { SandboxProcessorContract } from "./sandbox-processor-contract.ts";
+import { SandboxProcessor } from "./sandbox-processor-implementation.ts";
+
+const neverStream = new Proxy({} as Stream, {
+  get(_target, property) {
+    throw new Error(`Unexpected stream access: ${String(property)}`);
+  },
+});
+
+let nextOffset = 0;
+function event(type: string, payload: Record<string, unknown> = {}): StreamEvent {
+  nextOffset += 1;
+  return { type, payload, createdAt: new Date(nextOffset).toISOString(), offset: nextOffset };
+}
+
+function sandboxProcessor() {
+  nextOffset = 0;
+  return new SandboxProcessor({ stream: neverStream });
+}
+
+describe("SandboxProcessor", () => {
+  it("folds the idle-out/restore lifecycle into running + lastBackupId", async () => {
+    const processor = sandboxProcessor();
+    // The sequence observed live on preview_7: boot, clone, idle-out snapshot,
+    // stop, wake, restore of that same snapshot.
+    await processor.ingest({
+      events: [
+        event("events.iterate.com/sandbox/container-started"),
+        event("events.iterate.com/sandbox/workspace-cloned"),
+        event("events.iterate.com/sandbox/backup-created", { backupId: "bkp-1" }),
+        event("events.iterate.com/sandbox/container-stopped"),
+      ],
+      streamMaxOffset: nextOffset,
+    });
+    await expect(processor.snapshot()).resolves.toMatchObject({
+      state: { lastBackupId: "bkp-1", running: false },
+    });
+
+    await processor.ingest({
+      events: [
+        event("events.iterate.com/sandbox/container-started"),
+        event("events.iterate.com/sandbox/workspace-restored", { backupId: "bkp-1" }),
+      ],
+      streamMaxOffset: nextOffset,
+    });
+    await expect(processor.snapshot()).resolves.toMatchObject({
+      state: { lastBackupId: "bkp-1", running: true },
+    });
+  });
+
+  it("ignores events outside its catalog", async () => {
+    const processor = sandboxProcessor();
+    await processor.ingest({
+      events: [event("events.iterate.com/agent/turn-started")],
+      streamMaxOffset: nextOffset,
+    });
+    await expect(processor.snapshot()).resolves.toMatchObject({
+      state: { lastBackupId: null, running: false },
+    });
+  });
+});
+
+describe("SandboxProcessorContract.buildEvent", () => {
+  it("validates lifecycle payloads against the catalog", () => {
+    expect(
+      SandboxProcessorContract.buildEvent({
+        type: "events.iterate.com/sandbox/backup-created",
+        payload: { backupId: "bkp-1" },
+      }),
+    ).toMatchObject({ payload: { backupId: "bkp-1" } });
+
+    expect(() =>
+      SandboxProcessorContract.buildEvent({
+        type: "events.iterate.com/sandbox/backup-created",
+        // @ts-expect-error — the wrong payload shape must fail at runtime too
+        payload: { wrong: true },
+      }),
+    ).toThrow();
+  });
+});

--- a/apps/os/src/env.ts
+++ b/apps/os/src/env.ts
@@ -56,22 +56,36 @@ export interface Env {
     import("./domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts").CloudflareSandboxDurableObject
   >;
   /**
-   * Persistent storage for sandbox containers. Container disk is ephemeral —
-   * a sandbox that sleeps loses its filesystem — so every sandbox mounts a
-   * prefix of this R2 bucket at `/workspace` (see
-   * CloudflareSandboxDurableObject), making that path durable across
-   * sleep/restart. One bucket per env (`${WORKER_SELF}-sandboxes`); each
-   * sandbox is isolated to its own `/{projectId}{path}` prefix.
+   * Workspace persistence for sandbox containers. Container disk is
+   * ephemeral — a sandbox that sleeps loses its filesystem — so the sandbox
+   * Durable Object snapshots `/workspace` to this R2 bucket on idle and
+   * restores it on the next start (the Sandbox SDK's backup/restore:
+   * https://developers.cloudflare.com/sandbox/guides/backup-restore/). One
+   * bucket per env (`${WORKER_SELF}-sandboxes`). The binding MUST be named
+   * `BACKUP_BUCKET` — the SDK reads it from the env by that exact name.
    */
-  SANDBOX_STORAGE: R2Bucket;
+  BACKUP_BUCKET: R2Bucket;
+  /** The {@link Env.BACKUP_BUCKET} bucket's name — the SDK presigns transfer
+   * URLs against `https://{CLOUDFLARE_R2_ACCOUNT_ID}.r2.cloudflarestorage.com/
+   * {BACKUP_BUCKET_NAME}/…`, so it needs the name, not just the binding. */
+  BACKUP_BUCKET_NAME: string;
+  /** Account owning {@link Env.BACKUP_BUCKET}, for the SDK's presigned URLs. */
+  CLOUDFLARE_R2_ACCOUNT_ID: string;
   /**
-   * How sandboxes reach {@link SANDBOX_STORAGE}. Deployed envs use
-   * `"r2-egress"` (a credential-less R2 mount over the container egress
-   * interception we already run); local dev uses `"local"` (miniflare's local
-   * R2 binding, since FUSE/presigned URLs are unavailable under `wrangler
-   * dev`). Set per env by generate-wrangler-config.ts.
+   * How sandbox workspace backups move to R2. Deployed envs use `"presigned"`
+   * (the SDK presigns `*.r2.cloudflarestorage.com` URLs and the container
+   * transfers directly — through project egress like all container traffic;
+   * requires the R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY secrets). Local dev
+   * uses `"local"` (archives stream through the Durable Object's local R2
+   * binding — presigned URLs don't exist under `wrangler dev`). Set per env
+   * by generate-wrangler-config.ts.
    */
-  SANDBOX_STORAGE_MODE: "r2-egress" | "local";
+  SANDBOX_BACKUP_MODE: "presigned" | "local";
+  /** R2 S3-API credentials for presigning backup transfers (Doppler secret;
+   * absent in local dev, where SANDBOX_BACKUP_MODE is "local"). */
+  R2_ACCESS_KEY_ID?: string;
+  /** See {@link Env.R2_ACCESS_KEY_ID}. */
+  R2_SECRET_ACCESS_KEY?: string;
   SECRET: DurableObjectNamespace<
     import("./domains/secrets/secret-durable-object.ts").SecretDurableObject
   >;

--- a/apps/os/src/env.ts
+++ b/apps/os/src/env.ts
@@ -72,17 +72,15 @@ export interface Env {
   /** Account owning {@link Env.BACKUP_BUCKET}, for the SDK's presigned URLs. */
   CLOUDFLARE_R2_ACCOUNT_ID: string;
   /**
-   * How sandbox workspace backups move to R2. Deployed envs use `"presigned"`
-   * (the SDK presigns `*.r2.cloudflarestorage.com` URLs and the container
-   * transfers directly — through project egress like all container traffic;
-   * requires the R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY secrets). Local dev
-   * uses `"local"` (archives stream through the Durable Object's local R2
-   * binding — presigned URLs don't exist under `wrangler dev`). Set per env
-   * by generate-wrangler-config.ts.
+   * R2 S3-API credentials for presigning backup transfers (optional Doppler
+   * secret). When present, the SDK presigns `*.r2.cloudflarestorage.com` URLs
+   * and the container transfers archives directly — fast, and through project
+   * egress like all container traffic. When absent (local dev always; a
+   * deployed env until someone mints keys), the sandbox falls back to the
+   * SDK's bucket-binding transfer: archives stream through the Durable
+   * Object's {@link Env.BACKUP_BUCKET} binding — slower, but zero-config and
+   * the only mode `wrangler dev` supports.
    */
-  SANDBOX_BACKUP_MODE: "presigned" | "local";
-  /** R2 S3-API credentials for presigning backup transfers (Doppler secret;
-   * absent in local dev, where SANDBOX_BACKUP_MODE is "local"). */
   R2_ACCESS_KEY_ID?: string;
   /** See {@link Env.R2_ACCESS_KEY_ID}. */
   R2_SECRET_ACCESS_KEY?: string;

--- a/apps/os/src/env.ts
+++ b/apps/os/src/env.ts
@@ -55,6 +55,23 @@ export interface Env {
   SANDBOX: DurableObjectNamespace<
     import("./domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts").CloudflareSandboxDurableObject
   >;
+  /**
+   * Persistent storage for sandbox containers. Container disk is ephemeral —
+   * a sandbox that sleeps loses its filesystem — so every sandbox mounts a
+   * prefix of this R2 bucket at `/workspace` (see
+   * CloudflareSandboxDurableObject), making that path durable across
+   * sleep/restart. One bucket per env (`${WORKER_SELF}-sandboxes`); each
+   * sandbox is isolated to its own `/{projectId}{path}` prefix.
+   */
+  SANDBOX_STORAGE: R2Bucket;
+  /**
+   * How sandboxes reach {@link SANDBOX_STORAGE}. Deployed envs use
+   * `"r2-egress"` (a credential-less R2 mount over the container egress
+   * interception we already run); local dev uses `"local"` (miniflare's local
+   * R2 binding, since FUSE/presigned URLs are unavailable under `wrangler
+   * dev`). Set per env by generate-wrangler-config.ts.
+   */
+  SANDBOX_STORAGE_MODE: "r2-egress" | "local";
   SECRET: DurableObjectNamespace<
     import("./domains/secrets/secret-durable-object.ts").SecretDurableObject
   >;


### PR DESCRIPTION
Follow-up to #1654. Two guarantees: **`/workspace` survives the container sleeping**, and **the project repo is always checked out at `/workspace/repo`**. Plus: sandbox lifecycle is now visible as stream events.

## Why backup/restore and not `mountBucket`

Cloudflare containers have **no persistent disk** — all container disk is [ephemeral](https://developers.cloudflare.com/containers/faq/). The SDK offers two persistence mechanisms; we tried both, on a real preview:

1. **`mountBucket`** (R2 as live FUSE fs) — *incompatible with our egress model*. Its credential-less R2-binding mode sends s3fs traffic to the magic host `r2.internal`, serviced by the SDK's own per-host container-egress interceptor, which our all-egress-through-project-policy catch-all (#1654) necessarily swallows. Verified broken live: every fs op on the mount → `Input/output error`. Composing them would mean exempting storage traffic from project egress policy.
2. **[Backup/restore](https://developers.cloudflare.com/sandbox/guides/backup-restore/)** (`createBackup`/`restoreBackup`) — **no conflict**: transfers are presigned URLs against the real `*.r2.cloudflarestorage.com` host, flowing **through project egress like every other container request** (verified live: R2 endpoint answers through the egress path). Snapshot-granular is the accepted trade-off; documented.

## How it works (SDK lifecycle hooks on our existing subclass)

- **`onActivityExpired`** — the idle-timer hook, the one moment the container is still running but about to stop (`onStop` is too late: container already gone, and it can even arrive on a later wake) — snapshots `/workspace` via `createBackup` (gitignore-aware, `node_modules` excluded, 90d ttl) and stores the handle in DO storage. The handle only moves after success; a backup failure never wedges the container awake.
- **`onStart`** — provisions in the background (restore newest snapshot → clone repo if checkout still missing); `ensureProjectRepo()` is the awaitable guarantee. Backup is gated on a fully-provisioned workspace so a bad start can't clobber the last good snapshot.
- **Lifecycle → stream events**: `container-started`/`container-stopped`, `workspace-restored`/`workspace-cloned`, `backup-created`/`backup-failed` are appended to the stream at the sandbox's own path — an agent's sandbox journals into the agent's own stream. Best-effort by design.

## Plumbing

- One R2 bucket per env, `${osWorkerName}-sandboxes`, created by `ensure-resources` (create-only), bound as `BACKUP_BUCKET` (exact name = SDK contract) + `BACKUP_BUCKET_NAME`/`CLOUDFLARE_R2_ACCOUNT_ID` vars. Buckets already created for preview slots 1–9; prd bucket created by `ensure-resources` on rollout.
- **Transfer mode picked at runtime from creds presence**: with `R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY` (optional Doppler secrets, not yet minted) the SDK presigns and the container transfers directly (fast); without them, archives stream through the DO's R2 binding — slower but zero-config, works deployed, and the only mode `wrangler dev` supports. **No manual rollout step required.**

## Verification (preview_7, real containers + real R2)

- Boot → repo cloned → marker files written to `/workspace`
- R2 endpoint reachable from inside the sandbox **through project egress** (de-risks presigned mode)
- Idle out (3m) → backup → container stops → wake → **workspace restored** (markers + repo present) — see PR comments for the transcript
- Egress properties from #1654 unchanged (MITM + project policy + secret substitution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-06T10:02:19.315Z",
      "headSha": "90ce201dc03c1df416796a0181028b1d20e6c025",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/414891342750641",
      "shortSha": "90ce201",
      "cleanupDurationMs": 8892,
      "deployDurationMs": 52817,
      "testDurationMs": 82759
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-06T10:02:11.396Z",
      "headSha": "90ce201dc03c1df416796a0181028b1d20e6c025",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/414891342750641",
      "shortSha": "90ce201",
      "cleanupDurationMs": 967,
      "deployDurationMs": 17823,
      "testDurationMs": 5972
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-06T10:02:14.718Z",
      "headSha": "90ce201dc03c1df416796a0181028b1d20e6c025",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/414891342750641",
      "shortSha": "90ce201",
      "cleanupDurationMs": 4288,
      "deployDurationMs": 22210,
      "testDurationMs": 518
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-06T10:02:11.497Z",
      "headSha": "90ce201dc03c1df416796a0181028b1d20e6c025",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-8.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/414891342750641",
      "shortSha": "90ce201",
      "cleanupDurationMs": 1063,
      "deployDurationMs": 16415,
      "testDurationMs": 16523
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `90ce201` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 22.2s | 518ms | 4.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/414891342750641) | 2026-07-06T10:02:14.718Z | Preview app released. |
| OS | released | `90ce201` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 52.8s | 82.8s | 8.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/414891342750641) | 2026-07-06T10:02:19.315Z | Preview app released. |
| Semaphore | released | `90ce201` | [https://semaphore.iterate-preview-8.com](https://semaphore.iterate-preview-8.com) | 17.8s | 6.0s | 967ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/414891342750641) | 2026-07-06T10:02:11.396Z | Preview app released. |
| Streams Example App | released | `90ce201` | [https://streams-example-app-preview-8.iterate-dev-preview.workers.dev](https://streams-example-app-preview-8.iterate-dev-preview.workers.dev) | 16.4s | 16.5s | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/414891342750641) | 2026-07-06T10:02:11.497Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core sandbox idle/start provisioning, R2 backups, and destroy-on-idle behavior; failures degrade to fresh clones but wrong backup gating or restore bugs could lose in-flight workspace state since last idle snapshot.
> 
> **Overview**
> Sandboxes now **keep `/workspace` across idle sleep** by snapshotting it to R2 on idle (`onActivityExpired` via the Sandbox SDK’s `createBackup`), storing the handle in Durable Object storage, then **destroying** the container (still required to release `max_instances` slots). On wake, **`onStart` restores** the latest backup in the background and only clones `/workspace/repo` when the checkout is missing—so `ensureProjectRepo()` usually waits on restore, not a full clone.
> 
> **Plumbing:** per-env `${worker}-sandboxes` R2 bucket (`ensure-resources` + `BACKUP_BUCKET` binding and SDK vars); optional `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` choose presigned container transfers vs DO binding streaming (local dev).
> 
> **Observability:** lifecycle hooks append typed **`events.iterate.com/sandbox/*`** events to the stream at the sandbox path via `SandboxProcessorContract`; new `SandboxProcessor` folds `running` / `lastBackupId` (not wired to a host yet). Docs expanded (backup/restore vs `mountBucket` + egress).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90ce201dc03c1df416796a0181028b1d20e6c025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->