### PR TITLE
Update stale architecture docs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -30,31 +30,41 @@ A user-facing project routing label that can appear in hostnames and URLs.
 _Avoid_: project ID, stable project identity
 
 **Stream Runtime**:
-The shared implementation and core types for durable append-only streams.
+The OS implementation and core contracts for durable append-only streams,
+centered on `apps/os/src/domains/streams`.
 _Avoid_: Events app stream implementation
 
-**OS Streams API**:
-OS-owned oRPC procedures that expose project stream operations by thinly wrapping the Stream Runtime.
-_Avoid_: OS Stream API, Events app stream API, Events contract
+**StreamCollection**:
+The project-bound itx catalog (`itx.streams`) that vends path-addressed
+**Stream** handles. Admin sessions also expose `session.streams` for
+deployment-wide streams.
+_Avoid_: StreamsCapability, OS Streams API, Events app stream API, Events contract
 
-**StreamsCapability**:
-A project-bound RPC capability for stream operations, optionally narrowed to a default Event Stream Path.
+**Stream**:
+A path-addressed RPC capability for one durable event stream: append events,
+page committed history, wait for or subscribe to events, and inspect runtime
+state.
 _Avoid_: StreamCapability, generic stream client
 
 **Secret**:
-A project-scoped credential record whose Secret Material may be read by authorized OS runtime capabilities.
+A project-scoped credential record whose Secret Material is write-only through
+the public itx surface and may be used only by authorized server-side runtime
+paths such as egress and integrations.
 _Avoid_: environment variable, integration, connection
 
 **Secret Material**:
-The raw credential value stored for a Secret.
+The raw credential value stored encrypted for a Secret. Public itx APIs do not
+return it.
 _Avoid_: token, key, secret metadata
 
 **Secret Metadata**:
-Non-material descriptive or operational data returned with a Secret, such as provider, scope, expiry, or connection details.
+Non-material descriptive or operational data returned with a Secret, such as
+egress allowlists and audit state.
 _Avoid_: secret, secret value
 
-**SecretsCapability**:
-A project-bound RPC capability for reading and managing Secrets for one ProjectId.
+**SecretCollection**:
+A project-bound itx catalog (`itx.secrets`) for creating, listing, and updating
+Secret records.
 _Avoid_: global secret client, egress proxy
 
 **OAuth Client Configuration**:
@@ -101,15 +111,17 @@ _Avoid_: app config, runtime config
 - A **ProjectId** identifies durable stream storage.
 - A **ProjectSlug** may route users to a project, but must not be used as durable stream identity.
 - Project-scoped stream APIs should carry **ProjectId**, not parallel slug and ID fields.
-- **Stream Runtime** belongs in shared code; app contracts may import or re-export its core types.
-- OS uses the **OS Streams API** for stream access; the standalone Events app that once owned streams has been deleted.
-- A **StreamsCapability** is always scoped to one **ProjectId**.
-- A **StreamsCapability** may be narrowed to one default stream path, making path arguments optional for operations such as append and read.
-- In a narrowed **StreamsCapability**, stream paths without a leading slash, including `./` paths, are relative to the default stream path.
-- In a narrowed **StreamsCapability**, stream paths with a leading slash are absolute within the same **ProjectId** and still constrained by capability policy.
+- **Stream Runtime** lives in OS today; reusable callers should program
+  against the public itx contract in `apps/os/src/types.ts`.
+- OS uses **StreamCollection** and **Stream** for public stream access; the
+  standalone Events app that once owned streams has been deleted.
+- A project **StreamCollection** is scoped to one **ProjectId**.
+- A **Stream** path is absolute within its ProjectId; nested handles are
+  created with `stream.at(path)`.
 - In the current OS secrets slice, every **Secret** belongs to exactly one **ProjectId**.
 - A **Secret** may have **Secret Metadata** in addition to **Secret Material**.
-- For the current OS secrets/codemode slice, `getSecret` returns raw **Secret Material** and **Secret Metadata**, not a Secret Reference for later egress substitution.
+- `getSecret({ path })` is an egress placeholder string. It is not a public
+  secret-read API and does not return raw **Secret Material**.
 - **OAuth Client Configuration** belongs in **App Config** because workers and local/Docker runtimes need it when handling OAuth callbacks and webhooks.
 - A **Connection** may yield a project-wide **Secret** that runtime capabilities can read.
 - In the current OS secrets slice, every **Connection** is project-level; user-level and organization-level Connections are out of scope.
@@ -120,16 +132,12 @@ _Avoid_: app config, runtime config
 - Google Connections are project-level in the current OS secrets slice.
 - Navigating to or reading a project stream may initialize that stream; a separate create command is not required for ordinary stream discovery.
 - In OS, **Processor Subscriptions** deliver events to processors hosted inside the relevant domain Durable Object through `createStreamProcessorHost`; domain Durable Objects remain command and capability owners and inject runtime dependencies.
-- The OS `packages/streams` migration is a POC cutover, not a backwards-compatible data migration; existing stream histories may be discarded.
-- During the OS `packages/streams` migration, OS-specific processor contracts stay in OS code for now; `@iterate-com/streams` remains app-agnostic runtime infrastructure.
-- The first OS `packages/streams` migration slice is creating and accessing a **Project** through oRPC with current OS behavior preserved after the stream cutover.
-- The first OS `packages/streams` migration slice used host-side compatibility where needed while keeping processor dependencies explicit.
-- The first OS `packages/streams` migration slice keeps broad project stream append authority; stream safety and event-type policy are out of scope.
-- The OS `packages/streams` migration uses only the new **Processor Subscription** event schema; legacy callable subscription events are not translated.
-- **SecretsCapability** and **Workspace** lifecycle are out of scope for the first OS `packages/streams` migration slice.
+- Processor contracts and implementations live with their OS domains unless a
+  reusable runtime boundary is explicitly extracted later.
 - **App Config** is available inside deployed app code.
 - **Deployment Config** is available to deploy scripts only.
-- Cloudflare API credentials and cross-script binding script names belong in **Deployment Config**, not **App Config**.
+- Cloudflare API credentials, worker names, resource IDs, hostnames, and
+  generated binding layout belong in **Deployment Config**, not **App Config**.
 
 ## Example dialogue
 
@@ -145,8 +153,8 @@ _Avoid_: app config, runtime config
 > **Dev:** "Can I use the project slug in a Durable Object name?"
 > **Domain expert:** "No — use **ProjectId** for durable identity. **ProjectSlug** is routing language."
 
-> **Dev:** "Should a Worker script name used for a cross-script Durable Object binding live in App Config?"
-> **Domain expert:** "No — that is **Deployment Config**, because only the deploy scripts need it to create the binding."
+> **Dev:** "Should a Cloudflare worker name or Durable Object binding layout live in App Config?"
+> **Domain expert:** "No — that is **Deployment Config**. Running app code receives typed bindings; deploy scripts generate the binding layout from envs.ts."
 
 ## Flagged ambiguities
 
@@ -154,19 +162,15 @@ _Avoid_: app config, runtime config
 - "dependencies" was used for both public processor contracts and backend services — resolved: use **Processor dependencies** for public contracts/catalogs and **Runtime dependencies** for backend services.
 - "well-behaved processor defaults" sounded moralizing and vague — resolved: use **Standard processor behavior** for the shared self-registration pieces.
 - "project" identity was mixed between slugs and IDs — resolved: use **ProjectId** for durable identity and **ProjectSlug** for routing labels.
-- Durable stream implementation was treated as app-owned — resolved: use **ProjectId** as the project-scoped API identifier and keep stream runtime infrastructure app-agnostic.
-- OS stream access was coupled to the Events contract — resolved: expose an **OS Streams API** that wraps the shared Stream Runtime directly.
+- Durable stream implementation was treated as app-owned or shared depending on
+  the migration phase — resolved for today's code: the runtime lives under OS,
+  and the public contract is `StreamCollection` / `Stream` in `types.ts`.
+- OS stream access was coupled to the Events contract — resolved: expose
+  **StreamCollection** and **Stream** over itx directly.
 - Processor subscriptions were described as WebSocket callbacks or domain Durable Object `afterAppend` callbacks — resolved: use **Processor Subscriptions** delivered to hosted stream processors.
-- Stream migration was initially discussed as a staged compatibility move with side-by-side bindings — resolved for the POC: cut over the existing `STREAM` binding and port functionality until tests pass again.
-- Moving all stream processor contracts into `@iterate-com/streams` would make the generic stream runtime OS-aware — resolved for now: keep OS-specific processor contracts in OS code.
-- "Getting started" could mean proving a domain processor such as Repo first or proving raw stream browsing first — resolved: start by replacing old streams in OS and proving a **Project** can be created and accessed through oRPC after the cutover, without intentionally bypassing current Project lifecycle behavior.
-- Porting Project lifecycle directly to `packages/streams` processor shape could front-load contract churn — resolved for the first slice: use a compatibility adapter for existing OS processor contracts if it keeps current behavior intact.
-- Stream append policy could be tightened during the cutover — resolved for the POC: leave broad append authority in place and focus on getting the new runtime working.
-- Legacy callable subscription events could be translated during migration — resolved for the hardcore cutover: emit and consume only the new `packages/streams` **Processor Subscription** schema.
-- Secrets and workspaces were listed as possible stream-owned domain objects — resolved for the first slice: keep them as existing capabilities/stateful surfaces.
 - "app config" mixed runtime-readable values with deployment-only values — resolved: use **App Config** for app-readable runtime configuration and **Deployment Config** for deploy-script-only inputs.
-- "stream API" and "streams API" were both used for OS's project stream surface — resolved: use **OS Streams API** and **StreamsCapability** because callers can operate over a project-scoped set of streams, not only one stream.
-- "getSecret" was used both as a raw credential read and as a placeholder for later egress substitution — resolved for the current OS secrets/codemode slice: `getSecret` is a raw **Secret Material** read through **SecretsCapability**.
+- "stream API" and "streams API" were both used for OS's project stream surface — resolved: use **StreamCollection** for the catalog and **Stream** for one path-addressed handle.
+- "getSecret" was used both as a raw credential read and as a placeholder for later egress substitution — resolved for the current OS secrets slice: `getSecret({ path })` is a placeholder consumed by egress; public secret APIs never return material.
 - "Slack OAuth client" could mean the OAuth app config, a workspace connection, or a token — resolved: provider OAuth app settings are **OAuth Client Configuration** in **App Config**.
 - "Slack connection" could mean the OAuth app, workspace claim, or token — resolved: the Slack workspace grant is a **Slack Team Claim**, an instance of **Provider Claim**, and its token is a project-wide **Secret**.
 - "Google connection" was initially considered user-scoped because OS1 works that way — resolved for the current OS secrets slice: Google Connections are project-level, and user-level Secrets are out of scope.

--- a/apps/os/docs/sandboxes.md
+++ b/apps/os/docs/sandboxes.md
@@ -58,10 +58,11 @@ the same allow/deny/secret-substitution policy as the rest of the project.
 
 Wiring (three points):
 
-- `src/workers/sandbox.ts` re-exports `ContainerProxy` from
-  `@cloudflare/containers` — the SDK dials it via `ctx.exports.ContainerProxy`
-  to route intercepted egress; without the export, interception throws at
-  container start.
+- `src/worker.ts` re-exports `ContainerProxy` from `@cloudflare/sandbox` —
+  the SDK dials it via `ctx.exports.ContainerProxy` to route intercepted
+  egress; without the export, interception throws at container start. This is
+  a same-script WorkerEntrypoint export on the OS worker, not a separate
+  sandbox worker.
 - `CloudflareSandboxDurableObject` sets `static outbound` (the catch-all egress
   handler) and `interceptHttps = true`. The handler runs in the ContainerProxy
   WorkerEntrypoint, so it only has the container's opaque Durable Object id; it

--- a/apps/os/docs/worker-topology.md
+++ b/apps/os/docs/worker-topology.md
@@ -79,9 +79,10 @@ run rarely, if ever, since orphaned storage costs pennies.
 
 ## Notes
 
-- **streams-example-app** (`apps/streams-example-app`) binds the Stream DO
-  cross-script; its `script_name` is `os-prd` in the single-worker world
-  (update it when that app is next deployed).
+- **streams-example-app** (`apps/streams-example-app`) re-exports OS's
+  `StreamDurableObject` class from its own worker entry and binds it
+  same-script (`class_name` only, no `script_name`). It shares stream code with
+  OS, not OS's Durable Object namespace.
 - The `ARTIFACTS` binding type exists only on deployed workers; local dev
   has no Cloudflare Artifacts emulation and repo code feature-checks
   `env.ARTIFACTS`.


### PR DESCRIPTION
## Summary

This is the docs-only follow-up for the architecture review's "docs drift" finding. It updates the live architecture language so agents and humans do not learn stale topology or capability names from the repo docs.

Changed docs:

- `CONTEXT.md` now names the current public stream and secret surfaces (`StreamCollection`, `Stream`, `SecretCollection`) instead of migration-era names like `OS Streams API`, `StreamsCapability`, and `SecretsCapability`.
- `CONTEXT.md` no longer describes the old `packages/streams` migration as active work, and no longer claims `getSecret({ path })` returns raw secret material. It describes it as the current egress placeholder string.
- `apps/os/docs/worker-topology.md` now says `streams-example-app` re-exports the stream Durable Object into its own worker and binds it same-script, rather than claiming it cross-script binds `os-prd`.
- `apps/os/docs/sandboxes.md` now points at the actual `src/worker.ts` `ContainerProxy` re-export from `@cloudflare/sandbox`, not the deleted `src/workers/sandbox.ts` path.

## LOC breakdown

| File | Additions | Deletions | Why |
| --- | ---: | ---: | --- |
| `CONTEXT.md` | 43 | 39 | Replace stale vocabulary and remove obsolete stream-migration assertions. |
| `apps/os/docs/sandboxes.md` | 5 | 4 | Correct the ContainerProxy export location and same-script wording. |
| `apps/os/docs/worker-topology.md` | 4 | 3 | Correct the `streams-example-app` binding model. |
| **Total** | **52** | **46** | Docs only. |

## Examples

Current stream language now points at the public contract names:

```ts
const stream = itx.streams.get("/agents/onboarding");
await stream.append({ type: "events.iterate.example/thing-happened" });
const events = await stream.getEvents({ afterOffset: 0 });
```

Current secret language now describes the actual public shape: secret material is written to the secret object, then referenced by egress placeholders. It is not read back through itx.

```ts
await itx.secrets.get("/secrets/github").update({
  material: "ghp_...",
  egress: { urls: ["https://api.github.com/*"] },
});

await itx.egress.fetch(
  new Request("https://api.github.com/user", {
    headers: { authorization: 'Bearer getSecret({ path: "/secrets/github" })' },
  }),
);
```

## Possible negative impacts

- This removes some migration-history language from `CONTEXT.md`. That is intentional: `CONTEXT.md` is the live language guide, not an archive. Historical decisions still belong in ADRs and older design docs.
- Some old terms remain in `_Avoid_` lists where they are explicitly marked as language not to use. That keeps the docs useful for agents that see those stale terms in older branches or comments.
- No runtime behavior changes. This should not affect deploys, generated code, or test behavior.

## Considerations

- I kept this as a narrow correction rather than rewriting all docs named in the review. `apps/os/README.md` and `apps/os/docs/architecture-and-operations.md` are already on the single-worker topology on current `main`.
- `apps/os/docs/itx-design.md` and related historical docs still contain old names, but they are historical design records. This PR leaves them alone instead of rewriting history.
- `streams-example-app` shares the stream implementation code, not OS's Durable Object namespace. The worker topology note now makes that distinction explicit.

## Other options considered

- Delete `CONTEXT.md` entirely and replace it with links to `apps/os/src/README.md` and `apps/os/src/types.ts`. That would be cleaner long-term, but this PR keeps the existing language guide and only removes the false parts.
- Move every stale term into ADRs. That is broader than needed here and would mix a docs correctness fix with documentation architecture work.

## Validation

- `pnpm exec oxfmt --check CONTEXT.md apps/os/docs/sandboxes.md apps/os/docs/worker-topology.md`
- `git diff --check origin/main..HEAD`
- Searched touched docs for stale phrases from the review: `packages/streams`, `@iterate-com/streams`, `SecretsCapability`, `src/workers/sandbox`, `script_name.*os-prd`, and raw secret-material-read claims.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only corrections to vocabulary and topology; no application, deploy, or test behavior changes.
> 
> **Overview**
> Updates **live** architecture docs so they match today's OS surface names and deployment model, without changing runtime code.
> 
> **`CONTEXT.md`** renames the public stream/secret vocabulary to **`StreamCollection`**, **`Stream`**, and **`SecretCollection`** (and `itx.streams` / `stream.at(path)`), and drops migration-era framing (`OS Streams API`, `StreamsCapability`, `SecretsCapability`, active `packages/streams` cutover bullets). It now states that **stream runtime** lives under OS with the contract in `apps/os/src/types.ts`, that **secret material** is write-only on the public itx surface, and that **`getSecret({ path })`** is an **egress placeholder**, not a secret-read API. **Deployment config** guidance is expanded (worker names, binding layout, resource IDs).
> 
> **`apps/os/docs/sandboxes.md`** corrects **ContainerProxy** wiring to **`src/worker.ts`** re-exporting from **`@cloudflare/sandbox`** on the **same-script** OS worker (replacing the removed `src/workers/sandbox.ts` path).
> 
> **`apps/os/docs/worker-topology.md`** fixes **`streams-example-app`**: it **re-exports** `StreamDurableObject` in its own worker with a **same-script** binding, sharing stream **code** but not OS's DO namespace (not a cross-script bind to `os-prd`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05639a5c002b04dbdb8dae16c8b684442e1c17c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> All preview slots are leased — this PR is waiting in line for one (since 2026-07-04T22:04:17.109Z).
>   preview-2  leased by pr-1661 until 2026-07-05T21:18:57.932Z (23h15m left) | https://github.com/iterate/iterate/pull/1661
>   preview-3  leased by pr-1664 until 2026-07-05T22:01:10.195Z (23h57m left) | https://github.com/iterate/iterate/pull/1664
>   preview-4  leased by pr-1639 until 2026-07-05T21:51:22.347Z (23h47m left) | https://github.com/iterate/iterate/pull/1639
>   preview-5  leased by pr-1634 until 2026-07-05T22:03:29.497Z (23h59m left) | https://github.com/iterate/iterate/pull/1634
>   preview-6  leased by pr-1656 until 2026-07-05T21:42:53.009Z (23h39m left) | https://github.com/iterate/iterate/pull/1656
>   preview-7  leased by pr-1666 until 2026-07-05T21:57:46.117Z (23h53m left) | https://github.com/iterate/iterate/pull/1666
>   preview-8  leased by pr-1670 until 2026-07-05T22:03:39.955Z (23h59m left) | https://github.com/iterate/iterate/pull/1670
>   preview-9  leased by pr-1665 until 2026-07-05T21:57:42.529Z (23h53m left) | https://github.com/iterate/iterate/pull/1665
>   preview-1  leased by pr-1508 until 2026-07-05T21:44:33.096Z (23h40m left) | https://github.com/iterate/iterate/pull/1508

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": "All preview slots are leased — this PR is waiting in line for one (since 2026-07-04T22:04:17.109Z).\n  preview-2  leased by pr-1661 until 2026-07-05T21:18:57.932Z (23h15m left) | https://github.com/iterate/iterate/pull/1661\n  preview-3  leased by pr-1664 until 2026-07-05T22:01:10.195Z (23h57m left) | https://github.com/iterate/iterate/pull/1664\n  preview-4  leased by pr-1639 until 2026-07-05T21:51:22.347Z (23h47m left) | https://github.com/iterate/iterate/pull/1639\n  preview-5  leased by pr-1634 until 2026-07-05T22:03:29.497Z (23h59m left) | https://github.com/iterate/iterate/pull/1634\n  preview-6  leased by pr-1656 until 2026-07-05T21:42:53.009Z (23h39m left) | https://github.com/iterate/iterate/pull/1656\n  preview-7  leased by pr-1666 until 2026-07-05T21:57:46.117Z (23h53m left) | https://github.com/iterate/iterate/pull/1666\n  preview-8  leased by pr-1670 until 2026-07-05T22:03:39.955Z (23h59m left) | https://github.com/iterate/iterate/pull/1670\n  preview-9  leased by pr-1665 until 2026-07-05T21:57:42.529Z (23h53m left) | https://github.com/iterate/iterate/pull/1665\n  preview-1  leased by pr-1508 until 2026-07-05T21:44:33.096Z (23h40m left) | https://github.com/iterate/iterate/pull/1508"
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->