### PR TITLE
E2e retry/timeout tidy-up: one retry layer, named budgets, retry telemetry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,7 @@ from your machine, and when you need a public callback URL. Doppler/Cloudflare/d
 - [CLI scripts](docs/cli-scripts.md) — how to write normal TypeScript scripts and expose them as CLIs
 - [TypeScript conventions](docs/typescript-conventions.md)
 - [Design system & React](docs/design-system.md)
+- [Testing](docs/testing.md) — test lanes, how to run them against any environment, and the retry/timeout policy (one retry layer, fail-fast watchdogs, retry telemetry)
 - [Vitest patterns](docs/vitest-patterns.md)
 - [Domain objects & stream processors](docs/domain-objects-and-stream-processors.md)
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ from your machine, and when you need a public callback URL. Doppler/Cloudflare/d
 - [Slack testing](docs/slack-testing.md) — real Slack flows, preview app setup, and internal duplicate-bot caveats
 - [Slack preview OAuth clients](docs/slack-preview-oauth-clients.md) — bulk-create preview Slack apps and collect Doppler secrets
 - [Slack bot token migration](docs/slack-bot-token-migration.md) — per-app bot token fallback links and Doppler shape
-- [Testing](docs/testing.md) — test lanes, how to run them against any environment, and the canonical env vars
+- [Testing](docs/testing.md) — test lanes, how to run them against any environment, the canonical env vars, and the retry/timeout policy (one retry layer, fail-fast watchdogs, retry telemetry)
 - [Vitest patterns](docs/vitest-patterns.md)
 - [Domain objects & stream processors](docs/domain-objects-and-stream-processors.md)
 

--- a/apps/os/e2e/vitest.config.ts
+++ b/apps/os/e2e/vitest.config.ts
@@ -8,6 +8,11 @@ import {
   E2E_PROJECT_ROOT_KEY,
   E2E_RUN_ROOT_KEY,
 } from "@iterate-com/shared/test-support/vitest-e2e";
+import {
+  E2E_CI_RETRIES,
+  E2E_TEST_TIMEOUT_MS,
+  RetryTelemetryReporter,
+} from "@iterate-com/shared/test-support/e2e-policy";
 import { E2E_REPO_ROOT_KEY, E2E_RUN_SLUG_KEY } from "./test-support/provide-keys.ts";
 import { createVitestRunSlug } from "./test-support/vitest-naming.ts";
 import { resolveBaseUrl } from "./test-support/dev-server.ts";
@@ -66,6 +71,11 @@ export default defineConfig({
     sequence: { concurrent: ci },
     maxConcurrency: 2,
     passWithNoTests: true,
+    // Retry telemetry (policy rule 5 — see @iterate-com/shared
+    // test-support/e2e-policy/budgets.ts): reporters DO belong at the root
+    // test level and apply across projects — unlike `retry`, which vitest
+    // only reads from each project config (see the note on the node project).
+    reporters: ["default", new RetryTelemetryReporter()],
     projects: [
       {
         resolve: sharedResolve,
@@ -80,23 +90,20 @@ export default defineConfig({
           // #1601 fixed cold-slot creates to ~3-5s per saga under 4-way load
           // (tasks/os-cold-create-latency.md), so 120s is ample headroom
           // without letting a wedged saga eat the whole job.
-          hookTimeout: 120_000,
-          testTimeout: 120_000,
-          // Retries in CI: tests are self-contained (fresh project per
-          // test), so a rare load-induced or Cloudflare-retryable blip re-runs
-          // in seconds instead of failing the suite. Two retries, not one:
-          // platform faults arrive in bursts (observed: a DO-storage
-          // "Internal error ... caused object to be reset" hit attempt 1 AND
-          // attempt 2 of the same test ~10s apart during an active Cloudflare
-          // ENAM incident — docs/preview-e2e-flake-hunt.md run log 2026-07-05),
-          // so a single retry often re-rolls inside the same bad window. A
-          // genuinely broken test still fails all three attempts within its
-          // own per-test timeout — bounded, visible in the log, fail-fast.
+          hookTimeout: E2E_TEST_TIMEOUT_MS,
+          testTimeout: E2E_TEST_TIMEOUT_MS,
+          // One retry in CI, the only retry layer in the whole lane
+          // (docs/testing.md#retries-and-timeouts): tests are self-contained
+          // (fresh project per test), so a rare platform blip re-rolls in
+          // seconds. A burst that defeats the single retry fails the run —
+          // deliberately: platform weather should be visible, not absorbed
+          // (the 50-run marathon audit saw zero second retries; the
+          // RetryTelemetryReporter above counts the first ones).
           // Lives HERE and not at the root: vitest does not inherit `retry`
           // into project configs — the root-level retry silently never
           // applied (verified: a CI-profile run showed a failed test with
           // zero retry attempts).
-          retry: ci ? 2 : 0,
+          retry: ci ? E2E_CI_RETRIES : 0,
         },
       },
       {
@@ -114,8 +121,8 @@ export default defineConfig({
           testTimeout: 45_000,
           hookTimeout: 45_000,
           // See the node project: `retry` must live on each project config,
-          // and platform-fault bursts need two re-rolls.
-          retry: ci ? 2 : 0,
+          // and one retry is the policy.
+          retry: ci ? E2E_CI_RETRIES : 0,
           browser: {
             commands: {
               // Browser WebSockets cannot set Authorization headers, so the

--- a/apps/os/e2e/vitest/agent-tools.itx.e2e.test.ts
+++ b/apps/os/e2e/vitest/agent-tools.itx.e2e.test.ts
@@ -13,7 +13,9 @@ const PROOF_TYPE = "events.iterate.test/agent-tools-proof";
 
 test(
   "agent runs an itx script that appends a proof event, then replies",
-  { timeout: 300_000 },
+  // Full LLM codemode loop — heavy-test ceiling (E2E_HEAVY_TEST_TIMEOUT_MS);
+  // a healthy run is well under a minute.
+  { timeout: 240_000 },
   async ({ expect }) => {
     await using handle = await createTestProject({ slugPrefix: "agent-tools" });
     using agent = handle.agent("/agents/e2e-tools");
@@ -53,7 +55,8 @@ test(
 
 test(
   "provider toggle: cloudflare-ai answers after llm-provider-selected",
-  { timeout: 300_000 },
+  // See above — heavy-test ceiling.
+  { timeout: 240_000 },
   async ({ expect }) => {
     await using handle = await createTestProject({ slugPrefix: "provider-toggle" });
     using agent = handle.agent("/agents/e2e-provider");

--- a/apps/os/e2e/vitest/onboarding-smoke.ts
+++ b/apps/os/e2e/vitest/onboarding-smoke.ts
@@ -6,13 +6,15 @@
  *
  *   doppler run -- pnpm exec tsx e2e/vitest/onboarding-smoke.ts [baseUrl]
  *
- * Three attempts, a fresh project each: the lane's vitest tests get
- * `retry: 2` in CI for platform-fault bursts (Cloudflare DO-storage
- * transients, slow agent turns), and this script is the ONE gate in the lane
- * that used to run without any — a single 90s greeting tail took down the
- * whole run, as an uncaught remote rejection crashing the process no less
+ * Two attempts, a fresh project each — an attempt IS this gate's "test", so
+ * per the fleet retry policy (docs/testing.md#retries-and-timeouts) it gets
+ * exactly one retry, same as every vitest/playwright test. It used to run
+ * with none at all: a single 90s greeting tail took down the whole run, as
+ * an uncaught remote rejection crashing the process no less
  * (docs/preview-e2e-flake-hunt.md run log, marathon6 run 26). A genuinely
- * broken slot still fails all three attempts inside ~5 minutes.
+ * broken slot still fails both attempts inside ~3.5 minutes, and a slow
+ * greeting that needs attempt 2 is logged as retry telemetry rather than
+ * silently absorbed — the 90s tail is a real product-latency signal.
  */
 import { fileURLToPath } from "node:url";
 import { connectItx } from "../../src/itx-client.ts";
@@ -51,11 +53,17 @@ async function attemptOnboardingSmoke(): Promise<void> {
   );
 }
 
-const ATTEMPTS = 3;
+const ATTEMPTS = 2;
 let lastError: unknown;
 for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
   try {
     await attemptOnboardingSmoke();
+    if (attempt > 1) {
+      console.log(
+        `[retry-telemetry] onboarding smoke passed on attempt ${attempt}/${ATTEMPTS} — ` +
+          `attempt 1's failure above is a real (absorbed) failure`,
+      );
+    }
     process.exit(0);
   } catch (error) {
     lastError = error;

--- a/apps/semaphore/e2e/vitest.config.ts
+++ b/apps/semaphore/e2e/vitest.config.ts
@@ -1,15 +1,16 @@
 import { defineConfig } from "vitest/config";
+import { E2E_CI_RETRIES, E2E_TEST_TIMEOUT_MS } from "@iterate-com/shared/test-support/e2e-policy";
 
 export default defineConfig({
   test: {
     environment: "node",
     fileParallelism: false,
-    hookTimeout: 120_000,
+    hookTimeout: E2E_TEST_TIMEOUT_MS,
     include: ["./e2e/vitest/**/*.test.ts"],
-    testTimeout: 120_000,
-    // Fleet-wide CI retry policy (see apps/os/e2e/vitest.config.ts):
-    // platform-fault bursts need re-rolls; real regressions still fail all
-    // three attempts fast.
-    retry: process.env.CI ? 2 : 0,
+    testTimeout: E2E_TEST_TIMEOUT_MS,
+    // Fleet-wide CI retry policy (docs/testing.md#retries-and-timeouts): one
+    // retry re-rolls an isolated platform blip; a real regression still fails
+    // both attempts fast.
+    retry: process.env.CI ? E2E_CI_RETRIES : 0,
   },
 });

--- a/apps/streams-example-app/package.json
+++ b/apps/streams-example-app/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "catalog:cloudflare",
+    "@iterate-com/shared": "workspace:*",
     "@cloudflare/workers-types": "catalog:cloudflare",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/vite": "^4.3.0",

--- a/apps/streams-example-app/playwright.config.ts
+++ b/apps/streams-example-app/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
+import { E2E_CI_RETRIES } from "@iterate-com/shared/test-support/e2e-policy";
 
 const workerUrl = process.env.WORKER_URL;
 const localUrl = "http://127.0.0.1:5173";
@@ -8,10 +9,10 @@ export default defineConfig({
   timeout: 60_000,
   expect: { timeout: 15_000 },
   fullyParallel: false,
-  // Fleet-wide CI retry policy (see the root playwright.config.ts):
-  // platform-fault bursts need re-rolls; real regressions still fail all
-  // three attempts fast.
-  retries: process.env.CI ? 2 : 0,
+  // Fleet-wide CI retry policy (docs/testing.md#retries-and-timeouts): one
+  // retry re-rolls an isolated platform blip; a real regression still fails
+  // both attempts fast.
+  retries: process.env.CI ? E2E_CI_RETRIES : 0,
   webServer:
     workerUrl === undefined
       ? {

--- a/apps/streams-example-app/vitest.config.ts
+++ b/apps/streams-example-app/vitest.config.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
+import { E2E_CI_RETRIES } from "@iterate-com/shared/test-support/e2e-policy";
 
 export default defineConfig({
   resolve: {
@@ -11,11 +12,11 @@ export default defineConfig({
     environment: "node",
     include: ["e2e/vitest/**/*.test.ts"],
     testTimeout: 30_000,
-    // Fleet-wide CI retry policy (see apps/os/e2e/vitest.config.ts): each
-    // test opens its own fresh connection, so a retry re-rolls transient
-    // edge/platform faults ("Network connection lost." killed a marathon run
-    // here on a 392ms-old socket) while a real regression still fails all
-    // three attempts fast.
-    retry: process.env.CI ? 2 : 0,
+    // Fleet-wide CI retry policy (docs/testing.md#retries-and-timeouts):
+    // each test opens its own fresh connection, so one retry re-rolls a
+    // transient edge/platform fault ("Network connection lost." killed a
+    // marathon run here on a 392ms-old socket); a real regression still
+    // fails both attempts fast.
+    retry: process.env.CI ? E2E_CI_RETRIES : 0,
   },
 });

--- a/docs/preview-e2e-flake-hunt.md
+++ b/docs/preview-e2e-flake-hunt.md
@@ -1,5 +1,10 @@
 # Preview e2e flake hunt
 
+> This document is the evidence log — every flake, root cause, and marathon
+> run. The **policy** distilled from it (one retry layer, watchdog sizing,
+> retry telemetry) lives in [testing.md → Retries and
+> timeouts](testing.md#retries-and-timeouts).
+
 Goal: run the full preview e2e lane against a real preview environment 50
 times in a row without a single flake, fixing and documenting every failure
 encountered along the way.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,8 +1,10 @@
 # Testing: Unit, E2E, And Playwright Specs
 
-How the test lanes are organized, how to run each against any environment, and
-the canonical environment variables. For unit-test style (fake timers, inline
-snapshots, `test.for` tables), see [Vitest patterns](vitest-patterns.md).
+How the test lanes are organized, how to run each against any environment,
+the canonical environment variables, and [the retry/timeout
+policy](#retries-and-timeouts) every lane follows. For unit-test style (fake
+timers, inline snapshots, `test.for` tables), see
+[Vitest patterns](vitest-patterns.md).
 
 ## Lanes
 
@@ -50,20 +52,21 @@ doppler run --config dev -- env APP_CONFIG_BASE_URL=http://localhost:1234 pnpm e
 The rule: **one name per control, and no variable without a real setter**.
 `APP_CONFIG_*` variables come from the Doppler config and describe the
 deployment under test — tests never invent parallel names for them. The two
-`OS_E2E_TUI_*` variables are the only harness knobs. Nothing else exists (the
-root Playwright config additionally honors the Playwright-conventional `CI`
-and `VIDEO_MODE`).
+`OS_E2E_TUI_*` variables and `E2E_RETRY_TELEMETRY_FILE` are the only harness
+knobs. Nothing else exists (the root Playwright config additionally honors
+the Playwright-conventional `CI` and `VIDEO_MODE`).
 
-| Variable                         | Set by                                               | Controls                                                                                      | Default                         |
-| -------------------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------- |
-| `APP_CONFIG_BASE_URL`            | Doppler (deployed configs); unset in local configs   | THE deployment under test, for every lane                                                     | Local dev-server discovery file |
-| `APP_CONFIG_ADMIN_API_SECRET`    | Doppler                                              | Admin credential for the itx surface (project seeding, admin lanes)                           | None — lanes that need it throw |
-| `APP_CONFIG_INTEGRATIONS__SLACK` | Doppler                                              | Gates the slack-agent e2e suite (provides the Slack signing secret)                           | Unset → suite skips             |
-| `OS_E2E_TUI_PROJECT_ID`          | `e2e/tui-test/run.ts` (internal; passed to the spec) | The disposable project the TUI spec chats against                                             | Unset → TUI spec skips          |
-| `OS_E2E_TUI_SNAPSHOT`            | You                                                  | `"1"` opts into the manual aesthetic TUI snapshot test                                        | Skipped                         |
-| `GITHUB_SHA`                     | GitHub Actions (ambient)                             | Labels the preview-smoke seed project slug in CI                                              | `"manual"`                      |
-| `CI`                             | GitHub Actions                                       | Playwright: `forbidOnly`, 2 retries, trace on first retry, never reuse an existing dev server | Unset locally                   |
-| `VIDEO_MODE`                     | You                                                  | `"1"` makes Playwright record video with relaxed timeouts                                     | Video only retained on failure  |
+| Variable                         | Set by                                                  | Controls                                                                                                      | Default                         |
+| -------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `APP_CONFIG_BASE_URL`            | Doppler (deployed configs); unset in local configs      | THE deployment under test, for every lane                                                                     | Local dev-server discovery file |
+| `APP_CONFIG_ADMIN_API_SECRET`    | Doppler                                                 | Admin credential for the itx surface (project seeding, admin lanes)                                           | None — lanes that need it throw |
+| `APP_CONFIG_INTEGRATIONS__SLACK` | Doppler                                                 | Gates the slack-agent e2e suite (provides the Slack signing secret)                                           | Unset → suite skips             |
+| `E2E_RETRY_TELEMETRY_FILE`       | The preview lane (`scripts/preview/preview.ts`), or you | Where the vitest `RetryTelemetryReporter` writes its JSON (see [Retries and timeouts](#retries-and-timeouts)) | Unset → log line only, no file  |
+| `OS_E2E_TUI_PROJECT_ID`          | `e2e/tui-test/run.ts` (internal; passed to the spec)    | The disposable project the TUI spec chats against                                                             | Unset → TUI spec skips          |
+| `OS_E2E_TUI_SNAPSHOT`            | You                                                     | `"1"` opts into the manual aesthetic TUI snapshot test                                                        | Skipped                         |
+| `GITHUB_SHA`                     | GitHub Actions (ambient)                                | Labels the preview-smoke seed project slug in CI                                                              | `"manual"`                      |
+| `CI`                             | GitHub Actions                                          | Playwright: `forbidOnly`, one retry, trace on first retry, never reuse an existing dev server                 | Unset locally                   |
+| `VIDEO_MODE`                     | You                                                     | `"1"` makes Playwright record video with relaxed timeouts                                                     | Video only retained on failure  |
 
 ## Artifacts
 
@@ -76,3 +79,87 @@ and `VIDEO_MODE`).
 - **Preview CI** uploads all of the above (`test-results`,
   `apps/os/test-results`, `/tmp/os-e2e-*`) as a CI artifact — see
   `previewTestArtifacts` in `scripts/preview/preview.ts`.
+
+## Retries and timeouts
+
+Every number and retry knob in the e2e system follows five rules. The
+constants live in **`packages/shared/src/test-support/e2e-policy/budgets.ts`**
+(one file, every config imports it) and
+`scripts/preview/e2e-policy.test.ts` guards the invariants — including the
+files that can't import TypeScript constants (shell). The evidence behind the
+rules is the 50-consecutive-green-run marathon audit in
+[preview-e2e-flake-hunt.md](preview-e2e-flake-hunt.md) (~5,800 test
+executions: ~0.5% of tests needed their single retry, none ever needed a
+second, and every mechanism above the test layer either never fired or fired
+only on genuine infra wedges).
+
+1. **Retries live in exactly one layer: the individual test.** The test is
+   the smallest unit that owns its state — every test (and every
+   onboarding-smoke attempt) provisions its own project — so it is the
+   cheapest genuinely independent trial. `E2E_CI_RETRIES = 1` in CI, zero
+   locally, everywhere: retrying anything larger re-runs minutes of healthy
+   work to re-roll one six-second dice.
+2. **Everything above a test is a watchdog: it fails, it never retries.**
+   The preview vitest lane gets a hard `timeout`; a whole run gets a
+   kill-tree watchdog; the Depot job has `timeout-minutes`. Re-running a
+   killed run is the outer edge's job (the Depot re-run button, the next
+   push) — never automatic.
+3. **Watchdogs are sized to ~2× the healthy p99 of what they bound — never
+   to accommodate worst-case retry stacks.** A run burning retries against a
+   wedged platform _should_ get killed; both historical watchdog kills were
+   genuine infra wedges where retrying was hopeless.
+4. **Waits are progress-based; static budgets are backstops.** The
+   Playwright `actionTimeout` is a tight 750ms; the middlewright
+   spinner-waiter (see `patches/`) extends it — up to ~30s — only while the
+   app visibly reports progress. An app that goes blank fails fast instead
+   of being slept through: this exact tightness caught a real blank-render
+   product bug (flake 21). Don't widen budgets to paper over a missing
+   loading state.
+5. **Retries are measured, never silent.** With one retry, a
+   5%-probability real race turns a run red about once in 400 runs — but
+   shows up in retry telemetry about once in 20. The count is the detector;
+   see below.
+
+### The ladder
+
+| What it bounds             | Knob                                  | Where                                                                | Value                          | On expiry                   |
+| -------------------------- | ------------------------------------- | -------------------------------------------------------------------- | ------------------------------ | --------------------------- |
+| One UI action              | `actionTimeout` + spinner-waiter      | `playwright.config.ts` ← `SPEC_ACTION_TIMEOUT_MS`                    | 750ms (→ ~30s with spinner)    | fail the attempt            |
+| One assertion              | `expect.timeout`                      | `playwright.config.ts` ← `SPEC_EXPECT_TIMEOUT_MS`                    | 15s                            | fail the attempt            |
+| One Playwright spec        | `timeout`                             | `playwright.config.ts` ← `SPEC_TEST_TIMEOUT_MS`                      | 90s                            | retry once (CI)             |
+| One vitest e2e test/hook   | `testTimeout` / `hookTimeout`         | `apps/os/e2e/vitest.config.ts` ← `E2E_TEST_TIMEOUT_MS`               | 120s                           | retry once (CI)             |
+| A container-cold-boot test | per-test `{ timeout }`                | individual tests, capped at `E2E_HEAVY_TEST_TIMEOUT_MS`              | ≤ 240s                         | retry once (CI)             |
+| The onboarding smoke gate  | attempt loop                          | `apps/os/e2e/vitest/onboarding-smoke.ts`                             | 90s greeting wait              | one more attempt, then fail |
+| The preview vitest lane    | `timeout N pnpm e2e`                  | `scripts/preview/preview.ts` ← `OS_PREVIEW_VITEST_LANE_TIMEOUT_SECS` | 360s                           | **fail — never retry**      |
+| One whole preview run      | `RUN_TIMEOUT_SECS` kill-tree watchdog | `scripts/preview/flake-hunt-loop.sh` ← `PREVIEW_RUN_WATCHDOG_SECS`   | 600s                           | **kill — never retry**      |
+| The Depot CI job           | `timeout-minutes`                     | `.depot/workflows/*.yml`                                             | 30 (previews) / 300 (marathon) | outer edge: re-run button   |
+
+The ladder is strictly ordered and the guard test asserts it stays that way.
+Note the deliberate rule-3 consequence: the 360s lane watchdog does _not_
+budget for a heavy test double-burning its 240s cap, and the 600s run
+watchdog does not budget for the lane doing that twice.
+
+### Retry telemetry
+
+A retried test is a real failure that a re-roll absorbed — it must stay
+visible:
+
+- **Run log**: vitest lanes print `[retry-telemetry] N test(s) needed
+retries: ...` (the `RetryTelemetryReporter` in
+  `packages/shared/src/test-support/e2e-policy/`); the onboarding smoke
+  prints the same marker when it needed attempt 2. Grep any run log for
+  `retry-telemetry`.
+- **Preview CI**: the os lane writes the vitest telemetry JSON (via
+  `E2E_RETRY_TELEMETRY_FILE`) and Playwright's `playwright-results.json`;
+  `scripts/preview/preview.ts` folds both into a `retries` column in the
+  PR-body table and a `::notice::` annotation (escalating to `::warning::`
+  when ≥4 tests retried in one run — that smells slot-wide, not
+  probabilistic).
+- **Volume**: probabilistic regressions need run volume to detect — that is
+  what the on-demand marathon is for
+  (`.depot/workflows/preview-e2e-marathon.yml`, N consecutive runs of the
+  full preview lane on Depot). Watch the retry counts across a marathon, not
+  just the pass/fail streak.
+
+When telemetry trends up without failures, treat it exactly like a budget
+`::warning::`: find the cause, don't wait for red.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,6 +13,7 @@
     "./evlog/orpc-plugin": "./src/evlog/orpc-plugin.ts",
     "./apps/internal-router-contract": "./src/apps/internal-router-contract.ts",
     "./test-support/vitest-e2e": "./src/test-support/vitest-e2e/index.ts",
+    "./test-support/e2e-policy": "./src/test-support/e2e-policy/index.ts",
     "./request-logging": "./src/request-logging.ts",
     "./slugify": "./src/slugify.ts",
     "./posthog": {

--- a/packages/shared/src/test-support/e2e-policy/budgets.ts
+++ b/packages/shared/src/test-support/e2e-policy/budgets.ts
@@ -1,0 +1,73 @@
+/**
+ * The e2e retry policy and timeout ladder, in one place.
+ *
+ * The policy (evidence and rationale: docs/testing.md#retries-and-timeouts,
+ * distilled from the 50-run marathon audit in docs/preview-e2e-flake-hunt.md):
+ *
+ * 1. Retries live in exactly ONE layer: the individual test — the smallest
+ *    unit that owns its state (every test provisions its own project). One
+ *    retry in CI, zero locally.
+ * 2. Everything above a test is a watchdog: it fails, it never retries.
+ *    Re-running is the outer edge's job (Depot re-run / next push).
+ * 3. Watchdogs are sized to ~2x the healthy p99 of what they bound — never
+ *    to accommodate worst-case retry stacks. A run burning retries against a
+ *    wedged platform SHOULD get killed.
+ * 4. Waits are progress-based (spinner-waiter); static budgets are backstops.
+ * 5. Retries are measured, never silent (RetryTelemetryReporter next door).
+ *
+ * scripts/preview/e2e-policy.test.ts asserts the ladder stays ordered and
+ * that files which cannot import these constants (shell) stay in sync.
+ */
+
+/**
+ * Per-test retries in CI, everywhere (vitest `retry`, playwright `retries`).
+ * One, not two: across the 50-green-run marathon audit (~5,800 test
+ * executions) no test ever needed a second retry, and a platform-incident
+ * burst that defeats a single retry should fail the run — weather we want to
+ * see, not absorb. Zero locally so a flaky test stays loud at your desk.
+ */
+export const E2E_CI_RETRIES = 1;
+
+/**
+ * Playwright per-action wait. Deliberately tight: the middlewright
+ * spinner-waiter extends it (up to ~30s) only while the app visibly reports
+ * progress, so an app that goes blank fails fast instead of being slept
+ * through. This tightness is what caught the blank `ssr: false` outlet bug
+ * (flake 21) — do not widen it to paper over a missing loading state.
+ */
+export const SPEC_ACTION_TIMEOUT_MS = 750;
+
+/** Playwright `expect` polling budget — one UI assertion, not a whole flow. */
+export const SPEC_EXPECT_TIMEOUT_MS = 15_000;
+
+/** Playwright per-spec budget: a full product flow against a deployed slot. */
+export const SPEC_TEST_TIMEOUT_MS = 90_000;
+
+/**
+ * Vitest e2e per-test/per-hook budget: one itx flow against a deployed slot,
+ * including a project create saga (~3-5s cold, see #1601) with ample headroom.
+ */
+export const E2E_TEST_TIMEOUT_MS = 120_000;
+
+/**
+ * Ceiling for individual heavy tests that pay a container cold boot (sandbox
+ * exec, worker build, slack agent turns). Tests opt in per-test with
+ * `{ timeout: ... }`; nothing under apps/os/e2e may exceed this (guarded).
+ */
+export const E2E_HEAVY_TEST_TIMEOUT_MS = 240_000;
+
+/**
+ * Watchdog on the whole preview vitest lane (`timeout N pnpm e2e` in
+ * scripts/preview/preview.ts). Sits just above a healthy lane (itx monolith
+ * plus the heavy tests' own caps, running concurrently). Kills, never
+ * retries: a lane that blows this is wedged, not slow.
+ */
+export const OS_PREVIEW_VITEST_LANE_TIMEOUT_SECS = 360;
+
+/**
+ * Watchdog on one whole preview e2e run (flake-hunt-loop.sh, marathon). A
+ * healthy full-fleet run is a few minutes; per rule 3 this deliberately does
+ * NOT budget for a test double-burning its heavy-cap retry — both historical
+ * watchdog kills were genuine infra wedges where retrying was hopeless.
+ */
+export const PREVIEW_RUN_WATCHDOG_SECS = 600;

--- a/packages/shared/src/test-support/e2e-policy/index.ts
+++ b/packages/shared/src/test-support/e2e-policy/index.ts
@@ -1,0 +1,15 @@
+export {
+  E2E_CI_RETRIES,
+  E2E_HEAVY_TEST_TIMEOUT_MS,
+  E2E_TEST_TIMEOUT_MS,
+  OS_PREVIEW_VITEST_LANE_TIMEOUT_SECS,
+  PREVIEW_RUN_WATCHDOG_SECS,
+  SPEC_ACTION_TIMEOUT_MS,
+  SPEC_EXPECT_TIMEOUT_MS,
+  SPEC_TEST_TIMEOUT_MS,
+} from "./budgets.ts";
+export {
+  RetryTelemetryReporter,
+  type RetriedTestRecord,
+  type RetryTelemetryFile,
+} from "./retry-telemetry-reporter.ts";

--- a/packages/shared/src/test-support/e2e-policy/retry-telemetry-reporter.ts
+++ b/packages/shared/src/test-support/e2e-policy/retry-telemetry-reporter.ts
@@ -1,0 +1,97 @@
+import { writeFileSync } from "node:fs";
+
+/**
+ * One test that needed at least one retry, as recorded by
+ * RetryTelemetryReporter. `passedAfterRetry: false` means it burned its
+ * retries and still failed (the run is red anyway; the record explains why).
+ */
+export interface RetriedTestRecord {
+  fullName: string;
+  moduleId: string;
+  retryCount: number;
+  passedAfterRetry: boolean;
+  state: string;
+  durationMs: number;
+}
+
+/** Shape of the JSON file written to `$E2E_RETRY_TELEMETRY_FILE`. */
+export interface RetryTelemetryFile {
+  retried: RetriedTestRecord[];
+}
+
+/**
+ * The structural slice of vitest's reported-test API this reporter reads
+ * (`TestCase` / `TestDiagnostic` in vitest/node). Structural on purpose: the
+ * workspace resolves more than one vitest instance (apps pin different
+ * ranges), and importing `Reporter` from one instance makes the class
+ * unassignable in configs typed against another.
+ */
+interface ReportedTestCase {
+  fullName: string;
+  diagnostic(): { retryCount: number; flaky: boolean; duration: number } | undefined;
+  result(): { state: string };
+}
+
+/** Structural slice of vitest's `TestModule` (see {@link ReportedTestCase}). */
+interface ReportedTestModule {
+  moduleId: string;
+  children: { allTests(): Iterable<ReportedTestCase> };
+}
+
+/**
+ * Policy rule 5: retries are measured, never silent (see ./budgets.ts). A
+ * red run detects a 5%-probability race roughly once in 400 runs with one
+ * retry; counting retries detects it roughly once in 20. Vitest's built-in
+ * JSON reporter drops retry counts entirely (verified in 4.1.5), so this
+ * reporter walks the run via the reporter API — where `diagnostic()` does
+ * expose them — and:
+ *
+ * - writes {@link RetryTelemetryFile} to `$E2E_RETRY_TELEMETRY_FILE` when
+ *   set (the preview lane sets it and folds the result into the PR body —
+ *   scripts/preview/preview.ts);
+ * - prints a plain `[retry-telemetry] ...` line so retries are greppable in
+ *   any run log (deliberately ANSI-free: a previous log-grepping check was
+ *   silently defeated by vitest's colour codes).
+ *
+ * Telemetry must never fail a run: any error here is logged and swallowed.
+ */
+export class RetryTelemetryReporter {
+  onTestRunEnd(testModules: ReadonlyArray<ReportedTestModule>): void {
+    try {
+      const retried: RetriedTestRecord[] = [];
+      for (const testModule of testModules) {
+        for (const test of testModule.children.allTests()) {
+          const diagnostic = test.diagnostic();
+          if (!diagnostic || diagnostic.retryCount === 0) {
+            continue;
+          }
+          retried.push({
+            fullName: test.fullName,
+            moduleId: testModule.moduleId,
+            retryCount: diagnostic.retryCount,
+            passedAfterRetry: diagnostic.flaky,
+            state: test.result().state,
+            durationMs: Math.round(diagnostic.duration),
+          });
+        }
+      }
+
+      const outputFile = process.env.E2E_RETRY_TELEMETRY_FILE;
+      if (outputFile) {
+        const payload: RetryTelemetryFile = { retried };
+        writeFileSync(outputFile, JSON.stringify(payload, null, 2));
+      }
+      if (retried.length > 0) {
+        const details = retried
+          .map(
+            (record) =>
+              `${record.fullName} (x${record.retryCount}${record.passedAfterRetry ? "" : ", still failed"})`,
+          )
+          .join("; ");
+        console.log(`[retry-telemetry] ${retried.length} test(s) needed retries: ${details}`);
+      }
+    } catch (error) {
+      console.error("[retry-telemetry] failed to record retry telemetry:", error);
+    }
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,10 @@
 import { defineConfig, devices } from "@playwright/test";
+import {
+  E2E_CI_RETRIES,
+  SPEC_ACTION_TIMEOUT_MS,
+  SPEC_EXPECT_TIMEOUT_MS,
+  SPEC_TEST_TIMEOUT_MS,
+} from "@iterate-com/shared/test-support/e2e-policy";
 import { localOsDevServer } from "./apps/os/scripts/dev.ts";
 
 const videoMode = process.env.VIDEO_MODE === "1";
@@ -16,11 +22,10 @@ export default defineConfig({
   // dev server isn't hammered.
   fullyParallel: !!process.env.CI,
   forbidOnly: !!process.env.CI,
-  // Two retries, not one: platform faults arrive in bursts and a single retry
-  // often re-rolls inside the same bad window (see apps/os/e2e/vitest.config.ts
-  // for the observed double-fault). A real regression still fails all three
-  // attempts within the per-test timeout.
-  retries: process.env.CI ? 2 : 0,
+  // One retry in CI — the only retry layer, per the fleet-wide policy
+  // (docs/testing.md#retries-and-timeouts). A burst that defeats it fails
+  // the run on purpose: platform weather should be visible, not absorbed.
+  retries: process.env.CI ? E2E_CI_RETRIES : 0,
   workers: process.env.CI ? 6 : 1,
   outputDir: "test-results/playwright-output",
   reporter: [
@@ -28,10 +33,12 @@ export default defineConfig({
     ["html", { outputFolder: "test-results/playwright-html", open: "never" }],
     ["json", { outputFile: "test-results/playwright-results.json" }],
   ],
-  timeout: videoMode ? 300_000 : 90_000,
-  expect: { timeout: 15_000 },
+  timeout: videoMode ? 300_000 : SPEC_TEST_TIMEOUT_MS,
+  expect: { timeout: SPEC_EXPECT_TIMEOUT_MS },
   use: {
-    actionTimeout: videoMode ? 10_000 : 750,
+    // Tight on purpose; the middlewright spinner-waiter extends it only while
+    // the app visibly reports progress (see e2e-policy/budgets.ts).
+    actionTimeout: videoMode ? 10_000 : SPEC_ACTION_TIMEOUT_MS,
     baseURL: osBaseUrl,
     screenshot: "only-on-failure",
     trace: process.env.CI ? "on-first-retry" : "retain-on-failure",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -778,6 +778,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: catalog:cloudflare
         version: 4.20260621.1(patch_hash=ae8908e1d45f2ea02ffeabf1230701598cc2878240ef700403ff76df72677af2)
+      '@iterate-com/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0

--- a/scripts/preview/e2e-policy.test.ts
+++ b/scripts/preview/e2e-policy.test.ts
@@ -1,0 +1,191 @@
+import { readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  E2E_CI_RETRIES,
+  E2E_HEAVY_TEST_TIMEOUT_MS,
+  E2E_TEST_TIMEOUT_MS,
+  OS_PREVIEW_VITEST_LANE_TIMEOUT_SECS,
+  PREVIEW_RUN_WATCHDOG_SECS,
+  SPEC_ACTION_TIMEOUT_MS,
+  SPEC_EXPECT_TIMEOUT_MS,
+  SPEC_TEST_TIMEOUT_MS,
+} from "@iterate-com/shared/test-support/e2e-policy";
+import {
+  cloudflarePreviewApps,
+  defaultPreviewTestMaxAttempts,
+  previewInternals,
+} from "./preview.ts";
+
+// Guards the e2e retry/timeout policy (docs/testing.md#retries-and-timeouts):
+// the budget ladder stays ordered, files that cannot import the constants
+// (shell) stay in sync, and no second retry layer sneaks back in.
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+describe("budget ladder", () => {
+  it("stays strictly ordered: action < expect < spec < e2e test < heavy test < lane < run", () => {
+    const ladder = [
+      SPEC_ACTION_TIMEOUT_MS,
+      SPEC_EXPECT_TIMEOUT_MS,
+      SPEC_TEST_TIMEOUT_MS,
+      E2E_TEST_TIMEOUT_MS,
+      E2E_HEAVY_TEST_TIMEOUT_MS,
+      OS_PREVIEW_VITEST_LANE_TIMEOUT_SECS * 1000,
+      PREVIEW_RUN_WATCHDOG_SECS * 1000,
+    ];
+    for (let i = 1; i < ladder.length; i++) {
+      expect(ladder[i]).toBeGreaterThan(ladder[i - 1]!);
+    }
+  });
+
+  it("no inline per-test timeout under apps/os/e2e exceeds the heavy-test ceiling", () => {
+    // Case-sensitive `timeout:` matches vitest's per-test `{ timeout: N }`
+    // options without matching config-level testTimeout/hookTimeout.
+    const offenders: string[] = [];
+    const visit = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          visit(path);
+        } else if (entry.name.endsWith(".ts")) {
+          for (const match of readFileSync(path, "utf8").matchAll(/timeout:\s*([\d_]+)/g)) {
+            const value = Number(match[1]!.replaceAll("_", ""));
+            if (value > E2E_HEAVY_TEST_TIMEOUT_MS) {
+              offenders.push(`${path}: timeout ${value}`);
+            }
+          }
+        }
+      }
+    };
+    visit(resolve(repoRoot, "apps/os/e2e"));
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("retries live in exactly one layer", () => {
+  it("every e2e config takes its CI retry count from E2E_CI_RETRIES (which is 1)", () => {
+    expect(E2E_CI_RETRIES).toBe(1);
+    const configs = [
+      "playwright.config.ts",
+      "apps/os/e2e/vitest.config.ts",
+      "apps/semaphore/e2e/vitest.config.ts",
+      "apps/streams-example-app/vitest.config.ts",
+      "apps/streams-example-app/playwright.config.ts",
+    ];
+    for (const config of configs) {
+      const source = readFileSync(resolve(repoRoot, config), "utf8");
+      expect(source, `${config} must import the policy retry count`).toContain("E2E_CI_RETRIES");
+      expect(source, `${config} must not hardcode a CI retry count`).not.toMatch(
+        /retr(?:y|ies):\s*(?:process\.env\.CI|ci)\s*\?\s*\d/,
+      );
+    }
+  });
+
+  it("the os preview lane wraps vitest in a plain watchdog — no lane-level retry", () => {
+    const script = cloudflarePreviewApps.os.previewTestCommandArgs.at(-1)!;
+    expect(script).toContain(`timeout ${OS_PREVIEW_VITEST_LANE_TIMEOUT_SECS} pnpm e2e`);
+    // Exactly one invocation: a second occurrence means a retry wrapper came back.
+    expect(script.split("pnpm e2e --project node")).toHaveLength(2);
+  });
+
+  it("the whole-lane test command machinery stays pinned to a single attempt", () => {
+    expect(defaultPreviewTestMaxAttempts).toBe(1);
+  });
+
+  it("the onboarding smoke gets one retry, like every other test", () => {
+    const source = readFileSync(
+      resolve(repoRoot, "apps/os/e2e/vitest/onboarding-smoke.ts"),
+      "utf8",
+    );
+    expect(source).toContain("const ATTEMPTS = 2;");
+  });
+});
+
+describe("watchdogs the shell can't import stay in sync", () => {
+  it("flake-hunt-loop.sh defaults its run watchdog to PREVIEW_RUN_WATCHDOG_SECS", () => {
+    const source = readFileSync(resolve(repoRoot, "scripts/preview/flake-hunt-loop.sh"), "utf8");
+    expect(source).toContain(
+      `RUN_TIMEOUT_SECS="\${RUN_TIMEOUT_SECS:-${PREVIEW_RUN_WATCHDOG_SECS}}"`,
+    );
+  });
+});
+
+describe("retry telemetry parsers", () => {
+  it("reads the vitest RetryTelemetryReporter file", async () => {
+    const file = join(tmpdir(), `e2e-policy-test-vitest-${process.pid}.json`);
+    writeFileSync(
+      file,
+      JSON.stringify({
+        retried: [
+          {
+            fullName: "sandbox > executes",
+            moduleId: "/repo/apps/os/e2e/vitest/sandbox.test.ts",
+            retryCount: 1,
+            passedAfterRetry: true,
+            state: "passed",
+            durationMs: 5200,
+          },
+        ],
+      }),
+    );
+    await expect(previewInternals.readVitestRetryTelemetry(file)).resolves.toEqual([
+      { lane: "vitest", name: "sandbox > executes", retryCount: 1, passedAfterRetry: true },
+    ]);
+    rmSync(file);
+  });
+
+  it("reads Playwright's JSON report, including nested suites", async () => {
+    const file = join(tmpdir(), `e2e-policy-test-pw-${process.pid}.json`);
+    writeFileSync(
+      file,
+      JSON.stringify({
+        suites: [
+          {
+            title: "repl.spec.ts",
+            suites: [
+              {
+                title: "REPL",
+                specs: [
+                  {
+                    title: "runs a script",
+                    tests: [
+                      {
+                        status: "flaky",
+                        results: [
+                          { retry: 0, status: "failed" },
+                          { retry: 1, status: "passed" },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    title: "never retried",
+                    tests: [{ status: "expected", results: [{ retry: 0, status: "passed" }] }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    await expect(previewInternals.readPlaywrightRetryTelemetry(file)).resolves.toEqual([
+      { lane: "specs", name: "runs a script", retryCount: 1, passedAfterRetry: true },
+    ]);
+    rmSync(file);
+  });
+
+  it("renders a compact summary line", () => {
+    expect(
+      previewInternals.renderPreviewRetrySummary({
+        retried: [
+          { lane: "vitest", name: "a", retryCount: 1, passedAfterRetry: true },
+          { lane: "specs", name: "b", retryCount: 1, passedAfterRetry: false },
+        ],
+      }),
+    ).toBe("2 retried: a (vitest x1) · b (specs x1, still failed)");
+    expect(previewInternals.renderPreviewRetrySummary({ retried: [] })).toBeNull();
+  });
+});

--- a/scripts/preview/flake-hunt-loop.sh
+++ b/scripts/preview/flake-hunt-loop.sh
@@ -31,11 +31,15 @@ fi
 export CI=true
 
 mkdir -p "$LOG_DIR"
-# Fail-fast backstop for the whole run. A healthy full-fleet run is a few
-# minutes; the preview orchestration already bounds its vitest lane (360s) and
-# every test carries its own timeout, so this only catches a wedge that slips
-# both. 10 minutes kills such a wedge quickly instead of letting it sit (an
-# earlier bug let a startup wedge hang 9+ hours).
+# Watchdog for one whole run — it fails, it never retries, per the policy
+# (docs/testing.md#retries-and-timeouts). Sized to ~2x a healthy full-fleet
+# run (a few minutes), deliberately NOT to the worst-case retry stack: it MAY
+# kill a run legitimately burning per-test retries against a wedged platform,
+# and that is correct — both historical watchdog kills were genuine infra
+# wedges where retrying was hopeless (an earlier bug let a startup wedge hang
+# 9+ hours). The default must equal PREVIEW_RUN_WATCHDOG_SECS in
+# packages/shared/src/test-support/e2e-policy/budgets.ts; shell can't import
+# the constant, so scripts/preview/e2e-policy.test.ts guards the match.
 RUN_TIMEOUT_SECS="${RUN_TIMEOUT_SECS:-600}"
 
 # Full-fleet preflight. `preview deploy` selects apps by diffing the PR head

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -323,16 +323,16 @@ describe("cloudflare preview state helpers", () => {
     expect(body).toContain("## Summary");
     expect(body).toContain("## Environment Config Lease");
     expect(body).toContain(
-      "<summary>Lease: preview-2 | Doppler config: preview_2 | Type: environment-config-lease | Leased until: 2023-11-14T22:13:20.000Z</summary>\n\n| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |",
+      "<summary>Lease: preview-2 | Doppler config: preview_2 | Type: environment-config-lease | Leased until: 2023-11-14T22:13:20.000Z</summary>\n\n| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |",
     );
     expect(body).toContain("<!-- CLOUDFLARE_PREVIEW_STATE -->");
     expect(body).toContain("<!--\n{");
     expect(body).toContain("\n-->\n<!-- /CLOUDFLARE_PREVIEW_STATE -->");
     expect(body).toContain(
-      "| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |",
+      "| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |",
     );
     expect(body).toContain(
-      "| OS | deployed | `abcdef0` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 12.3s | 678ms |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/123) | 2026-04-02T10:00:00.000Z |  |",
+      "| OS | deployed | `abcdef0` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 12.3s | 678ms |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/123) | 2026-04-02T10:00:00.000Z |  |",
     );
   });
 
@@ -369,7 +369,7 @@ describe("cloudflare preview state helpers", () => {
     expect(body).toContain("Footer");
     expect(body).toContain("<summary>No active environment config lease.</summary>");
     expect(body).toContain(
-      "| OS | tests failed | `1234567` |  |  |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/456) | 2026-04-02T10:00:00.000Z | AssertionError: expected 2 to be +0 |",
+      "| OS | tests failed | `1234567` |  |  |  |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/456) | 2026-04-02T10:00:00.000Z | AssertionError: expected 2 to be +0 |",
     );
     expect(body).toContain("<details>");
     expect(body).toContain("<summary>OS failure details</summary>");

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { promises as dns } from "node:dns";
+import { readFile } from "node:fs/promises";
 import { userInfo } from "node:os";
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
@@ -11,6 +12,7 @@ import { createSemaphoreClient } from "../../apps/semaphore/src/contract.ts";
 import { markdownAnnotator } from "../../packages/shared/src/dev/markdown-annotator.ts";
 import { stripAnsi } from "../../packages/shared/src/dev/strip-ansi.ts";
 import { runCommand } from "../../packages/shared/src/node/run-command.ts";
+import { OS_PREVIEW_VITEST_LANE_TIMEOUT_SECS } from "../../packages/shared/src/test-support/e2e-policy/index.ts";
 
 // Flake-hunt notes for the preview e2e lane live in
 // docs/preview-e2e-flake-hunt.md.
@@ -348,6 +350,20 @@ export async function test(options: PullRequestCommandOptions = {}) {
       warnIfOverBudget("e2e", app.slug, testDurationMs, app.previewTestBudgetMs);
     }
 
+    // Collected pass or fail: on a red run the telemetry explains which tests
+    // burned their retry before the failure. Never fails the lane.
+    const retrySummary = app.collectRetryTelemetry
+      ? await app
+          .collectRetryTelemetry({ repositoryRoot: runtime.repositoryRoot })
+          .catch((error): PreviewRetrySummary | null => {
+            console.error(`[preview] retry telemetry collection failed for ${app.slug}:`, error);
+            return null;
+          })
+      : null;
+    if (retrySummary) {
+      announceRetryTelemetry(app.slug, retrySummary);
+    }
+
     return CloudflarePreviewAppEntry.parse({
       ...existingEntry,
       appDisplayName: app.displayName,
@@ -359,6 +375,7 @@ export async function test(options: PullRequestCommandOptions = {}) {
       runUrl: context.workflowRunUrl ?? existingEntry.runUrl ?? null,
       status: testResult.exitCode === 0 ? "deployed" : "tests-failed",
       testDurationMs,
+      testRetries: retrySummary ? renderPreviewRetrySummary(retrySummary) : null,
       updatedAt: new Date().toISOString(),
     } satisfies CloudflarePreviewAppEntry);
   });
@@ -824,7 +841,156 @@ export type CloudflarePreviewApp = {
    */
   previewDeployBudgetMs?: number;
   previewTestBudgetMs?: number;
+  /**
+   * Collect per-test retry telemetry after the app's preview test command
+   * finishes (pass or fail) — policy rule 5, retries are measured, never
+   * silent (docs/testing.md#retries-and-timeouts). Returns null when the
+   * lane produced no telemetry; must never throw a run-failing error (the
+   * caller logs and continues). The result lands in the run log, a
+   * `::notice::`/`::warning::` annotation, and the PR-body table.
+   */
+  collectRetryTelemetry?: (params: { repositoryRoot: string }) => Promise<PreviewRetrySummary>;
 };
+
+/**
+ * Aggregated retry telemetry for one app's preview e2e lane: every test that
+ * needed a re-roll, whichever sub-lane (vitest, playwright specs) it ran in.
+ * Why this exists: with one CI retry, a rare real race turns a run red about
+ * once in 400 runs, but shows up here about once in 20 — the count, not the
+ * run status, is the detector for probabilistic bugs.
+ */
+export type PreviewRetrySummary = {
+  retried: {
+    /** Which sub-lane observed the retry (e.g. "vitest", "specs"). */
+    lane: string;
+    name: string;
+    retryCount: number;
+    passedAfterRetry: boolean;
+  }[];
+};
+
+/**
+ * Where the os lane tells the vitest RetryTelemetryReporter (see
+ * packages/shared test-support/e2e-policy) to write its JSON. The lane
+ * removes the file before running so a previous run on the same machine
+ * (marathon loops) can't leak stale telemetry.
+ */
+const osVitestRetryTelemetryFile = "/tmp/os-preview-vitest-retries.json";
+
+/** Reads the JSON written by RetryTelemetryReporter (vitest sub-lane). */
+async function readVitestRetryTelemetry(filePath: string): Promise<PreviewRetrySummary["retried"]> {
+  const TelemetryFile = z.object({
+    retried: z.array(
+      z.object({
+        fullName: z.string(),
+        retryCount: z.number().int().positive(),
+        passedAfterRetry: z.boolean(),
+      }),
+    ),
+  });
+  const parsed = TelemetryFile.parse(JSON.parse(await readFile(filePath, "utf8")));
+  return parsed.retried.map((record) => ({
+    lane: "vitest",
+    name: record.fullName,
+    retryCount: record.retryCount,
+    passedAfterRetry: record.passedAfterRetry,
+  }));
+}
+
+/**
+ * Reads Playwright's JSON report (already written by the root
+ * playwright.config.ts json reporter). A retried spec has more than one
+ * result attempt; Playwright reports "flaky" for passed-after-retry.
+ */
+async function readPlaywrightRetryTelemetry(
+  filePath: string,
+): Promise<PreviewRetrySummary["retried"]> {
+  /** The subset of Playwright's JSON-reporter suite tree we walk. */
+  type PlaywrightJsonSuite = {
+    suites?: PlaywrightJsonSuite[];
+    specs?: {
+      title?: string;
+      tests?: { status?: string; results?: { retry?: number }[] }[];
+    }[];
+  };
+  const report = JSON.parse(await readFile(filePath, "utf8")) as {
+    suites?: PlaywrightJsonSuite[];
+  };
+  const retried: PreviewRetrySummary["retried"] = [];
+  const visit = (suite: PlaywrightJsonSuite) => {
+    for (const spec of suite.specs ?? []) {
+      for (const test of spec.tests ?? []) {
+        const retryCount = Math.max(0, ...(test.results ?? []).map((result) => result.retry ?? 0));
+        if (retryCount > 0) {
+          retried.push({
+            lane: "specs",
+            name: spec.title ?? "(unknown spec)",
+            retryCount,
+            passedAfterRetry: test.status === "flaky",
+          });
+        }
+      }
+    }
+    for (const child of suite.suites ?? []) {
+      visit(child);
+    }
+  };
+  for (const suite of report.suites ?? []) {
+    visit(suite);
+  }
+  return retried;
+}
+
+/**
+ * Reads one sub-lane's telemetry, treating a missing file as "no retries"
+ * (the sub-lane may have died before writing) and logging anything else —
+ * telemetry must never fail the lane.
+ */
+async function readRetryTelemetryLane(
+  label: string,
+  read: () => Promise<PreviewRetrySummary["retried"]>,
+): Promise<PreviewRetrySummary["retried"]> {
+  try {
+    return await read();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.error(`[preview] retry telemetry unreadable for ${label}:`, error);
+    }
+    return [];
+  }
+}
+
+/** One compact human line for the run log and the PR-body table. */
+function renderPreviewRetrySummary(summary: PreviewRetrySummary): string | null {
+  if (summary.retried.length === 0) {
+    return null;
+  }
+  const details = summary.retried
+    .map(
+      (record) =>
+        `${record.name} (${record.lane} x${record.retryCount}${record.passedAfterRetry ? "" : ", still failed"})`,
+    )
+    .join(" · ");
+  return `${summary.retried.length} retried: ${details}`;
+}
+
+/**
+ * Surfaces retry telemetry as a workflow annotation, mirroring
+ * warnIfOverBudget: one or two retried tests per run is the observed
+ * platform-flake floor (~0.5% of test executions) and gets a notice; a
+ * pile-up smells like a slot-wide problem and escalates to a warning.
+ */
+function announceRetryTelemetry(slug: string, summary: PreviewRetrySummary) {
+  const rendered = renderPreviewRetrySummary(summary);
+  if (!rendered) {
+    return;
+  }
+  const level = summary.retried.length >= 4 ? "warning" : "notice";
+  console.log(
+    `::${level} title=Preview e2e retries::${slug}: ${rendered}. A retried test is a real failure a ` +
+      `re-roll absorbed — see docs/testing.md#retries-and-timeouts.`,
+  );
+}
 
 // Deployed apps compile in @iterate-com/shared via many subpath exports (streams,
 // durable-object-utils, callable, codemode, config, evlog, ...), so trigger on the
@@ -925,24 +1091,22 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
         // lane in the background, the specs in the foreground. The vitest log
         // is replayed once the specs finish.
         //
-        // Bound the vitest lane and retry it once if it fails to START: vitest
-        // occasionally prints its banner then hangs before "RUN v<version>"
-        // (idle fork pool, no workers — no test has run, so vitest's own
-        // testTimeout can't fire), which would hang `wait "$E2E_PID"` until the
-        // CI job / marathon watchdog kills everything. A `timeout` + a single
-        // fresh retry turns that rare startup wedge into a self-healing restart.
-        // 360s is the fail-fast backstop: it sits just above a healthy lane
-        // (which runs the itx monolith plus the sandbox tests' own 240s
-        // per-test cap, concurrently) so a real wedge is caught in minutes, not
-        // left to stall — we'd rather fail fast and re-run than sit for ages.
-        // Retry ONLY on a timeout (rc=124) — the wedge signature. An earlier
-        // secondary check (`! grep "RUN v"`) was defeated by vitest's ANSI
-        // colour codes between "RUN" and the version, so it matched NOTHING and
-        // silently re-ran the whole lane every single time — doubling test load
-        // and sandbox-container churn. rc=0 means it ran; a non-124 non-zero is
-        // a real failure we must NOT paper over with a retry.
-        'run_vitest_node() { local rc=0; timeout 360 pnpm e2e --project node > /tmp/os-preview-vitest.log 2>&1 || rc=$?; if [ "$rc" -eq 124 ]; then echo "[preview] vitest node lane timed out (startup wedge) — retrying once"; rc=0; timeout 360 pnpm e2e --project node > /tmp/os-preview-vitest.log 2>&1 || rc=$?; fi; return $rc; }',
-        "run_vitest_node & E2E_PID=$!",
+        // The `timeout` on the vitest lane is a WATCHDOG, not a retry
+        // (docs/testing.md#retries-and-timeouts): it sits just above a
+        // healthy lane (the itx monolith plus the heavy tests' own 240s
+        // per-test caps, concurrently) and covers the one hang vitest's own
+        // testTimeout can't — a startup wedge before any test runs. Retries
+        // live in exactly one layer (the individual test), so a lane killed
+        // here fails the run visibly and is re-run from the outer edge. An
+        // rc=124 auto-retry used to live here; it fired zero times in ~200
+        // Depot runs and was the one place retry layers could stack.
+        //
+        // Retry telemetry: stale files are removed first (they survive from
+        // a previous run on the same machine — marathon loops), then the
+        // vitest lane writes its retry JSON for preview.ts to fold into the
+        // PR body alongside Playwright's playwright-results.json.
+        `rm -f ${osVitestRetryTelemetryFile} ../../test-results/playwright-results.json`,
+        `E2E_RETRY_TELEMETRY_FILE=${osVitestRetryTelemetryFile} timeout ${OS_PREVIEW_VITEST_LANE_TIMEOUT_SECS} pnpm e2e --project node > /tmp/os-preview-vitest.log 2>&1 & E2E_PID=$!`,
         'wait "$PW_INSTALL_PID" || { cat /tmp/os-preview-pw-install.log; exit 1; }',
         // Capture the specs' exit without aborting (set -e) so the vitest lane
         // always finishes and its log is replayed — a Playwright flake must not
@@ -953,6 +1117,19 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
         '[ "$E2E_OK" -eq 0 ] && [ "$SPEC_OK" -eq 0 ]',
       ].join("; "),
     ],
+    collectRetryTelemetry: async ({ repositoryRoot }) => {
+      const [vitest, specs] = await Promise.all([
+        readRetryTelemetryLane("os vitest lane", () =>
+          readVitestRetryTelemetry(osVitestRetryTelemetryFile),
+        ),
+        readRetryTelemetryLane("os playwright specs", () =>
+          readPlaywrightRetryTelemetry(
+            resolve(repositoryRoot, "test-results/playwright-results.json"),
+          ),
+        ),
+      ]);
+      return { retried: [...vitest, ...specs] };
+    },
   },
   semaphore: {
     slug: "semaphore",
@@ -1035,7 +1212,13 @@ const defaultPreviewLeaseMs = 24 * 60 * 60 * 1000;
 // returning immediately once the health endpoint is reachable.
 const defaultPreviewReadyTimeoutMs = 600_000;
 const defaultPreviewReadyUrlPath = "/api/__internal/health";
-const defaultPreviewTestMaxAttempts = 1;
+/**
+ * Whole-lane attempts for an app's preview test command. Pinned to 1 by the
+ * retry policy (docs/testing.md#retries-and-timeouts): retries live in the
+ * individual test; everything above only watches and fails. Exported so
+ * e2e-policy.test.ts can guard the pin.
+ */
+export const defaultPreviewTestMaxAttempts = 1;
 const defaultPreviewTestRetryDelayMs = 5_000;
 const defaultPreviewDeployConcurrency = 5;
 const ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE = "environment-config-lease" as const;
@@ -1085,6 +1268,8 @@ export const CloudflarePreviewAppEntry = z.object({
   cleanupDurationMs: z.number().nonnegative().finite().nullable().optional(),
   deployDurationMs: z.number().nonnegative().finite().nullable().optional(),
   testDurationMs: z.number().nonnegative().finite().nullable().optional(),
+  /** Rendered retry telemetry for the last test run (renderPreviewRetrySummary). */
+  testRetries: z.string().trim().min(1).nullable().optional(),
 });
 export type CloudflarePreviewAppEntry = z.infer<typeof CloudflarePreviewAppEntry>;
 
@@ -1464,6 +1649,7 @@ function renderPreviewAppTable(entries: z.infer<typeof CloudflarePreviewAppEntry
     "preview",
     "deploy duration",
     "test duration",
+    "retries",
     "cleanup duration",
     "workflow run",
     "updated",
@@ -1486,6 +1672,7 @@ function renderPreviewAppTableRow(entry: z.infer<typeof CloudflarePreviewAppEntr
     entry.publicUrl ? `[${entry.publicUrl}](${entry.publicUrl})` : "",
     entry.deployDurationMs != null ? formatDurationMs(entry.deployDurationMs) : "",
     entry.testDurationMs != null ? formatDurationMs(entry.testDurationMs) : "",
+    entry.testRetries ?? "",
     entry.cleanupDurationMs != null ? formatDurationMs(entry.cleanupDurationMs) : "",
     entry.runUrl ? `[Workflow run](${entry.runUrl})` : "",
     entry.updatedAt,
@@ -3558,8 +3745,11 @@ export const previewInternals = {
   orderPreviewDeployBatches,
   parseCloudflarePreviewState,
   parseEnvironmentConfigLeaseData,
+  readPlaywrightRetryTelemetry,
+  readVitestRetryTelemetry,
   reconcileEnvironmentConfigLeaseResources,
   renderCloudflarePreviewPullRequestBody,
+  renderPreviewRetrySummary,
   resolveAuthPreviewRootSecret,
   resolvePreviewCompareBaseSha,
   resolvePreviewReadinessUrls,

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -1071,6 +1071,12 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
       "-c",
       [
         "set -euo pipefail",
+        // Remove stale retry-telemetry files FIRST — before any step that can
+        // exit the lane early (the smoke gate below). They survive from a
+        // previous run on the same machine (marathon loops), and
+        // collectRetryTelemetry runs pass or fail, so a leftover file would
+        // report a previous run's retries against this one.
+        `rm -f ${osVitestRetryTelemetryFile} ../../test-results/playwright-results.json`,
         // The chromium download hits no deployed slot, so start it first and
         // let it overlap the smoke and the vitest lane; it's ready by the
         // time we reach the specs instead of adding ~4s in front of them.
@@ -1101,11 +1107,10 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
         // rc=124 auto-retry used to live here; it fired zero times in ~200
         // Depot runs and was the one place retry layers could stack.
         //
-        // Retry telemetry: stale files are removed first (they survive from
-        // a previous run on the same machine — marathon loops), then the
-        // vitest lane writes its retry JSON for preview.ts to fold into the
-        // PR body alongside Playwright's playwright-results.json.
-        `rm -f ${osVitestRetryTelemetryFile} ../../test-results/playwright-results.json`,
+        // Retry telemetry: the vitest lane writes its retry JSON (stale
+        // files were removed at the top of this script) for preview.ts to
+        // fold into the PR body alongside Playwright's
+        // playwright-results.json.
         `E2E_RETRY_TELEMETRY_FILE=${osVitestRetryTelemetryFile} timeout ${OS_PREVIEW_VITEST_LANE_TIMEOUT_SECS} pnpm e2e --project node > /tmp/os-preview-vitest.log 2>&1 & E2E_PID=$!`,
         'wait "$PW_INSTALL_PID" || { cat /tmp/os-preview-pw-install.log; exit 1; }',
         // Capture the specs' exit without aborting (set -e) so the vitest lane


### PR DESCRIPTION
Follow-up to #1664: the flake hunt proved the lane can go 50-for-50, but it left the retry/timeout story spread across seven files as unlabeled literals. This PR turns the evidence into explicit, guarded, documented policy — and net-deletes two retry mechanisms.

## Why (the evidence, in one paragraph)

The 50-green-run marathon audit: ~5,800 test executions, 17 vitest retries + ~10 Playwright retries (≈0.5% per-test platform-flake floor), **zero second retries anywhere**, the smoke never needed attempt 2, and the rc=124 lane re-run fired **zero times** in ~200 Depot runs. 8 of 10 retried tests failed fast (4–9s) and recovered fast. Meanwhile the retry topology had four layers whose interactions produced a ~12-minute worst-case time-to-red, and the budget ladder (750ms → 90s → 120s → 240s → 360s → 600s) had latent ordering inversions nobody could see.

## The policy (now in `docs/testing.md#retries-and-timeouts`, linked from the root README)

1. **Retries live in exactly one layer: the individual test** — the smallest unit that owns its state (every test provisions its own project). `E2E_CI_RETRIES = 1` in CI, zero locally, everywhere.
2. **Everything above a test is a watchdog: it fails, it never retries.** Re-running is the outer edge's job (Depot re-run button / next push).
3. **Watchdogs are sized to ~2× the healthy p99 of what they bound — never to accommodate worst-case retry stacks.** Both historical watchdog kills were genuine infra wedges; a run burning retries against a wedged platform *should* get killed.
4. **Waits are progress-based** (the 750ms actionTimeout + middlewright spinner-waiter stays the gold standard — it's what caught the blank-render product bug).
5. **Retries are measured, never silent** — a 5%-probability real race turns a run red ~1-in-400 runs, but shows in retry telemetry ~1-in-20. The count is the detector.

## What changed

**New shared primitives — `packages/shared/src/test-support/e2e-policy/`**
- `budgets.ts`: the named ladder (`E2E_CI_RETRIES`, `SPEC_ACTION/EXPECT/TEST_TIMEOUT_MS`, `E2E_TEST/HEAVY_TEST_TIMEOUT_MS`, `OS_PREVIEW_VITEST_LANE_TIMEOUT_SECS`, `PREVIEW_RUN_WATCHDOG_SECS`), each with a docstring stating what it bounds and how it was sized. All values unchanged except what `E2E_CI_RETRIES` replaces.
- `retry-telemetry-reporter.ts`: vitest's built-in JSON reporter drops retry counts entirely (verified in 4.1.5 source), so this custom reporter reads `diagnostic().retryCount` via the reporter API, writes JSON to `$E2E_RETRY_TELEMETRY_FILE`, and always prints a plain `[retry-telemetry] ...` log line. Typed structurally on purpose — the workspace resolves two vitest instances.

**Retries 2 → 1, five configs** (`apps/os/e2e/vitest.config.ts` node+browser, root `playwright.config.ts`, `apps/streams-example-app` vitest+playwright, `apps/semaphore/e2e/vitest.config.ts`), all importing `E2E_CI_RETRIES`. The old "two retries, faults arrive in bursts" comments are replaced with the honest tradeoff: a burst inside a platform incident now fails the run — deliberately; weather should be visible, not absorbed. The hard-won "retry must live on each project config, root-level silently never applies" note stays.

**`scripts/preview/preview.ts`**
- The `run_vitest_node()` rc=124 auto-retry wrapper is **deleted**; the lane keeps a plain `timeout 360` watchdog (fail, never retry). This was the one place retry layers could stack into the ~12-minute pathological case.
- New optional per-app `collectRetryTelemetry` hook; the os lane implements it by parsing the vitest telemetry JSON + Playwright's existing `playwright-results.json` (stale files are `rm -f`'d at lane start — they survive marathon loops).
- The PR-body table gains a **`retries` column**, and retried tests emit a `::notice::` annotation (escalating to `::warning::` at ≥4 in one run — that smells slot-wide, not probabilistic), mirroring the budget guardrail.
- `defaultPreviewTestMaxAttempts` (the dormant whole-lane retry machinery) is exported and pinned to 1 by the guard test.

**`apps/os/e2e/vitest/onboarding-smoke.ts`**: 3 → 2 attempts (an attempt is this gate's "test", so it gets one retry like everything else) and prints a `[retry-telemetry]` marker when attempt 2 saves the run — the 90s greeting tail is a real product-latency signal that should stay visible.

**Guard test — `scripts/preview/e2e-policy.test.ts`** (runs in root `pnpm test`): ladder strictly ordered; the shell watchdog default matches `PREVIEW_RUN_WATCHDOG_SECS`; the os lane embeds the watchdog constant and contains no retry wrapper; all five configs reference `E2E_CI_RETRIES` and hardcode nothing; no inline per-test timeout under `apps/os/e2e` exceeds the 240s heavy cap; parsers unit-tested against fixtures. **It caught a real violation on first run**: `agent-tools.itx.e2e.test.ts` had two 300s timeouts — above the heavy cap and incoherent with the 360s lane watchdog (a 300s test + one retry could never fit). Lowered to 240s; those tests finish in well under a minute in practice.

**Docs**: `docs/testing.md` gains the policy section with a full knob-map table (layer → file → knob → value → on-expiry behavior) and a "reading retry telemetry" guide; the root `README.md` blurb and `CLAUDE.md` (which was missing the Testing link entirely) point at it; `docs/preview-e2e-flake-hunt.md` gets a header note marking it as the evidence log behind the policy.

## Deliberately not touched

- **`specs/**` — zero diffs.** The Playwright specs stay verbatim; only config values changed.
- The middlewright spinner-waiter patch and the 750ms actionTimeout model — canonized, not modified.
- No budget increase anywhere (two were *lowered*: the 300s inline timeouts). No new retry layers. Container caps, `maxConcurrency: 2`, and the smoke's role as sequential gate all stay.

## Deferred (follow-ups, not this PR)

- Nightly marathon cron — needs a non-PR slot-lease holder design (leases are PR-attributed since #1599); the marathon stays on-demand.
- Retry telemetry for the semaphore/streams lanes (the reporter is already shared; wiring is mechanical once the os pattern proves out).
- Upstreaming the middlewright strict-mode patch.
- A task for the onboarding-greeting 90s latency tail (telemetry now at least counts it).

## Tradeoffs, stated

- `retry: 1`: a marathon4-style double-fault during a live Cloudflare incident now fails the run. Accepted — that's weather we want to see, and time-to-red on hang-class regressions roughly halves (~12min → ~6min worst case).
- streams-example-app gains `@iterate-com/shared` as a devDependency (3-line lockfile diff) → this PR triggers a full-fleet preview deploy via the shared-path rules. Expected.

## Verification

- `pnpm typecheck && pnpm lint && pnpm format && pnpm test` all green (guard test included).
- The reporter was smoke-tested end-to-end against a synthetic flaky test: correct log line + JSON (`retryCount: 1`, `passedAfterRetry: true`).
- The preview e2e run on this PR exercises the new lane shape for real; the `retries` column should appear in the table below when a retry occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI flake absorption (fewer retries) and preview lane failure behavior (no lane-level vitest restart), which can increase red runs during platform incidents but is intentional; guard tests and docs reduce regression risk.
> 
> **Overview**
> Codifies the marathon flake-hunt evidence as a **single shared e2e policy** (`packages/shared/test-support/e2e-policy`): named timeout/retry constants, a Vitest `RetryTelemetryReporter`, and `scripts/preview/e2e-policy.test.ts` guards so configs and shell watchdogs stay aligned.
> 
> **Retries: one layer only.** Fleet-wide CI retries drop **2 → 1** (`E2E_CI_RETRIES`) across OS/semaphore/streams Vitest and root Playwright configs, all importing the shared constant. The preview OS lane **removes** the `timeout` rc=124 vitest **lane re-run** wrapper—only a fail-fast lane watchdog remains. Onboarding smoke goes **3 → 2** attempts with `[retry-telemetry]` when attempt 2 saves the run.
> 
> **Telemetry & preview UX.** Preview collects Vitest + Playwright retry JSON, adds a **`retries`** column on the PR preview table, and emits `::notice::` / `::warning::` when many tests re-roll. Heavy agent-tool e2e per-test caps move **300s → 240s** to match `E2E_HEAVY_TEST_TIMEOUT_MS`.
> 
> **Docs** expand `docs/testing.md#retries-and-timeouts` (five rules, ladder table); README/CLAUDE link to it; flake-hunt doc points at the policy as the distilled rules vs evidence log.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 959448be97f4c9112b1ea5f70431a2aafb9ef9a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-06T11:13:29.294Z",
      "headSha": "959448be97f4c9112b1ea5f70431a2aafb9ef9a7",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/117522538326792",
      "shortSha": "959448b",
      "cleanupDurationMs": 6207,
      "deployDurationMs": 43722,
      "testDurationMs": 81113,
      "testRetries": "1 retried: runs \"browse-examples\" through the project REPL (specs x1)"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-06T11:13:24.593Z",
      "headSha": "959448be97f4c9112b1ea5f70431a2aafb9ef9a7",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/117522538326792",
      "shortSha": "959448b",
      "cleanupDurationMs": 1502,
      "deployDurationMs": 17067,
      "testDurationMs": 6039,
      "testRetries": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-06T11:13:27.924Z",
      "headSha": "959448be97f4c9112b1ea5f70431a2aafb9ef9a7",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/117522538326792",
      "shortSha": "959448b",
      "cleanupDurationMs": 4829,
      "deployDurationMs": 21104,
      "testDurationMs": 555,
      "testRetries": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-06T11:13:24.251Z",
      "headSha": "959448be97f4c9112b1ea5f70431a2aafb9ef9a7",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-6.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/117522538326792",
      "shortSha": "959448b",
      "cleanupDurationMs": 1152,
      "deployDurationMs": 15219,
      "testDurationMs": 16313,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `959448b` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 21.1s | 555ms |  | 4.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/117522538326792) | 2026-07-06T11:13:27.924Z | Preview app released. |
| OS | released | `959448b` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 43.7s | 81.1s | 1 retried: runs "browse-examples" through the project REPL (specs x1) | 6.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/117522538326792) | 2026-07-06T11:13:29.294Z | Preview app released. |
| Semaphore | released | `959448b` | [https://semaphore.iterate-preview-6.com](https://semaphore.iterate-preview-6.com) | 17.1s | 6.0s |  | 1.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/117522538326792) | 2026-07-06T11:13:24.593Z | Preview app released. |
| Streams Example App | released | `959448b` | [https://streams-example-app-preview-6.iterate-dev-preview.workers.dev](https://streams-example-app-preview-6.iterate-dev-preview.workers.dev) | 15.2s | 16.3s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/117522538326792) | 2026-07-06T11:13:24.251Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->