### PR TITLE
Strip legacy dev-name fallbacks from auth preview seeding

### DIFF
--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -81,13 +81,12 @@ describe("preview workflow scope", () => {
 });
 
 describe("auth preview root secrets", () => {
-  it("falls back through legacy dev names for the email sender domain", () => {
+  it("seeds from auth/dev when the preview root has no value", () => {
     const reads: string[] = [];
-    const values = new Map([["auth:dev:RESEND_BOT_DOMAIN", "nustom.com"]]);
+    const values = new Map([["auth:dev:APP_CONFIG_EMAIL_SENDER_DOMAIN", "nustom.com"]]);
 
     const value = resolveAuthPreviewRootSecret({
       appConfigName: "APP_CONFIG_EMAIL_SENDER_DOMAIN",
-      legacyDevNames: ["APP_CONFIG_RESEND_DOMAIN", "RESEND_BOT_DOMAIN"],
       readSecret: (project, config, name) => {
         reads.push(`${project}:${config}:${name}`);
         return values.get(`${project}:${config}:${name}`) ?? null;
@@ -98,22 +97,18 @@ describe("auth preview root secrets", () => {
     expect(reads).toEqual([
       "auth:preview:APP_CONFIG_EMAIL_SENDER_DOMAIN",
       "auth:dev:APP_CONFIG_EMAIL_SENDER_DOMAIN",
-      "auth:dev:APP_CONFIG_RESEND_DOMAIN",
-      "auth:dev:RESEND_BOT_DOMAIN",
     ]);
   });
 
-  it("keeps an existing preview root value ahead of dev fallbacks", () => {
+  it("keeps an existing preview root value ahead of the dev fallback", () => {
     const values = new Map([
       ["auth:preview:APP_CONFIG_EMAIL_SENDER_DOMAIN", "preview.example.com"],
       ["auth:dev:APP_CONFIG_EMAIL_SENDER_DOMAIN", "dev.example.com"],
-      ["auth:dev:RESEND_BOT_DOMAIN", "legacy.example.com"],
     ]);
 
     expect(
       resolveAuthPreviewRootSecret({
         appConfigName: "APP_CONFIG_EMAIL_SENDER_DOMAIN",
-        legacyDevNames: ["RESEND_BOT_DOMAIN"],
         readSecret: (project, config, name) => values.get(`${project}:${config}:${name}`) ?? null,
       }),
     ).toBe("preview.example.com");

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -1040,18 +1040,15 @@ const defaultPreviewTestRetryDelayMs = 5_000;
 const defaultPreviewDeployConcurrency = 5;
 const ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE = "environment-config-lease" as const;
 const previewEnvironmentSlotNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
+// auth/preview root inherits these from auth/dev when it doesn't already carry
+// its own value. All are canonical APP_CONFIG_* names (the AppConfig port,
+// #1594); the pre-port legacy flat names are gone from every auth config.
 const sharedAuthPreviewSecretsCopiedFromDev = [
-  { appConfigName: "APP_CONFIG_GOOGLE_CLIENT_ID", legacyDevNames: ["GOOGLE_CLIENT_ID"] },
-  { appConfigName: "APP_CONFIG_GOOGLE_CLIENT_SECRET", legacyDevNames: ["GOOGLE_CLIENT_SECRET"] },
-  {
-    appConfigName: "APP_CONFIG_EMAIL_SENDER_DOMAIN",
-    legacyDevNames: ["APP_CONFIG_RESEND_DOMAIN", "RESEND_BOT_DOMAIN"],
-  },
-  { appConfigName: "APP_CONFIG_SIGNUP_ALLOWLIST", legacyDevNames: ["SIGNUP_ALLOWLIST"] },
-] as const satisfies readonly {
-  appConfigName: string;
-  legacyDevNames: readonly string[];
-}[];
+  "APP_CONFIG_GOOGLE_CLIENT_ID",
+  "APP_CONFIG_GOOGLE_CLIENT_SECRET",
+  "APP_CONFIG_EMAIL_SENDER_DOMAIN",
+  "APP_CONFIG_SIGNUP_ALLOWLIST",
+] as const;
 
 export const EnvironmentConfigLease = z.object({
   dopplerConfig: z.string().trim().min(1),
@@ -2003,38 +2000,25 @@ function commandFailureSummary(result: { stderr: string; stdout: string }) {
   return output || "command failed";
 }
 
+// Prefer an existing preview-root value; otherwise seed it from auth/dev.
 function resolveAuthPreviewRootSecret(input: {
   appConfigName: string;
-  legacyDevNames: readonly string[];
   readSecret: (project: string, config: string, name: string) => string | null;
 }) {
-  const previewValue = input.readSecret("auth", "preview", input.appConfigName);
-  if (previewValue) return previewValue;
-
-  const devValue = input.readSecret("auth", "dev", input.appConfigName);
-  if (devValue) return devValue;
-
-  for (const legacyName of input.legacyDevNames) {
-    const legacyValue = input.readSecret("auth", "dev", legacyName);
-    if (legacyValue) return legacyValue;
-  }
-
-  return null;
+  return (
+    input.readSecret("auth", "preview", input.appConfigName) ||
+    input.readSecret("auth", "dev", input.appConfigName)
+  );
 }
 
 async function ensureAuthPreviewConfigs(input: { rotate: boolean }) {
   const rootValues: Record<string, string> = {
     APP_CONFIG_EMAIL_OTP_ENABLED: "true",
   };
-  for (const { appConfigName, legacyDevNames } of sharedAuthPreviewSecretsCopiedFromDev) {
-    // Prefer an existing preview-root value; otherwise seed it from auth/dev.
-    const value = resolveAuthPreviewRootSecret({
-      appConfigName,
-      legacyDevNames,
-      readSecret: getDopplerSecret,
-    });
+  for (const appConfigName of sharedAuthPreviewSecretsCopiedFromDev) {
+    const value = resolveAuthPreviewRootSecret({ appConfigName, readSecret: getDopplerSecret });
     if (!value) {
-      throw new Error(`auth/dev is missing ${[appConfigName, ...legacyDevNames].join(" or ")}`);
+      throw new Error(`auth/dev is missing ${appConfigName}`);
     }
     rootValues[appConfigName] = value;
   }


### PR DESCRIPTION
## Summary
Follow-up cleanup after the email-OTP → Cloudflare Email Service cutover (#1634). Removes the last Resend-flavored cruft.

- **Doppler (done out of band):** deleted dead keys from all four auth configs — `APP_CONFIG_RESEND_API_KEY` + `APP_CONFIG_RESEND_DOMAIN` (dev, dev_global, preview, prd), plus `RESEND_BOT_API_KEY`, `RESEND_BOT_DOMAIN`, and the stale `VITE_ENABLE_EMAIL_OTP_SIGNIN` (preview). Nothing read or shipped them since the Resend send path was removed.
- **This PR:** the AppConfig port (#1594) is fully rolled out — every auth config carries the canonical `APP_CONFIG_*` names — so the pre-port `legacyDevNames` fallbacks (`GOOGLE_CLIENT_ID`, `SIGNUP_ALLOWLIST`, and the dead `RESEND_*`/`RESEND_BOT_*` names) never fire. Collapsed `sharedAuthPreviewSecretsCopiedFromDev` to a plain name list and simplified `resolveAuthPreviewRootSecret` to a `preview → dev` lookup.

Verified `auth/dev` and `auth/preview` both carry all four canonical names before removing the fallback, so preview seeding is unaffected.

## Verification
- `pnpm --dir scripts test preview.test.ts` (59 passed)
- scripts typecheck, `oxlint`, `oxfmt` clean
- Repo grep for `resend`: only the OTP "Resend code" button label and a provider-list mention in the inbound-email task doc remain (both legitimate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to preview provisioning after verified Doppler migration; failure mode is a clear error if `auth/dev` lacks a canonical key.
> 
> **Overview**
> Removes **pre–AppConfig port** fallback lookups when seeding `auth/preview` from `auth/dev` during preview provisioning.
> 
> `sharedAuthPreviewSecretsCopiedFromDev` is now a plain list of four canonical `APP_CONFIG_*` keys (Google OAuth, email sender domain, signup allowlist). **`resolveAuthPreviewRootSecret`** only checks `auth/preview` then `auth/dev` for that name—no more `legacyDevNames` chain (`GOOGLE_CLIENT_ID`, `RESEND_BOT_DOMAIN`, etc.). Missing secrets error on the single canonical key.
> 
> Tests were updated to assert the shorter read order and canonical-only seeding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0302a520472c02be1d3af925dcca255c08f2d5f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-06T11:13:57.660Z",
      "headSha": "0302a520472c02be1d3af925dcca255c08f2d5f5",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/319793072651210",
      "shortSha": "0302a52",
      "cleanupDurationMs": 6040,
      "deployDurationMs": 54433,
      "testDurationMs": 176581
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-06T11:13:52.810Z",
      "headSha": "0302a520472c02be1d3af925dcca255c08f2d5f5",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/319793072651210",
      "shortSha": "0302a52",
      "cleanupDurationMs": 1184,
      "deployDurationMs": 17769,
      "testDurationMs": 5342
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-06T11:13:55.897Z",
      "headSha": "0302a520472c02be1d3af925dcca255c08f2d5f5",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/319793072651210",
      "shortSha": "0302a52",
      "cleanupDurationMs": 4266,
      "deployDurationMs": 22840,
      "testDurationMs": 518
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-06T11:13:52.897Z",
      "headSha": "0302a520472c02be1d3af925dcca255c08f2d5f5",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-3.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/319793072651210",
      "shortSha": "0302a52",
      "cleanupDurationMs": 1262,
      "deployDurationMs": 16087,
      "testDurationMs": 14318
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `0302a52` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 22.8s | 518ms | 4.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/319793072651210) | 2026-07-06T11:13:55.897Z | Preview app released. |
| OS | released | `0302a52` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 54.4s | 176.6s | 6.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/319793072651210) | 2026-07-06T11:13:57.660Z | Preview app released. |
| Semaphore | released | `0302a52` | [https://semaphore.iterate-preview-3.com](https://semaphore.iterate-preview-3.com) | 17.8s | 5.3s | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/319793072651210) | 2026-07-06T11:13:52.810Z | Preview app released. |
| Streams Example App | released | `0302a52` | [https://streams-example-app-preview-3.iterate-dev-preview.workers.dev](https://streams-example-app-preview-3.iterate-dev-preview.workers.dev) | 16.1s | 14.3s | 1.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/319793072651210) | 2026-07-06T11:13:52.897Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->