### PR TITLE
Semaphore README: document the dashboard and claim/release actions

### DIFF
--- a/apps/semaphore/README.md
+++ b/apps/semaphore/README.md
@@ -86,6 +86,20 @@ preview inventory from this package, run:
 doppler run --project semaphore --config prd -- pnpm --dir apps/semaphore seed:environment-config-leases
 ```
 
+## Dashboard
+
+The signed-in dashboard at `/resources/` shows the preview-slot fleet as a
+grid sorted by most recent activity: card color is lease state (amber =
+leased, green = available), and each card carries the holder (linked to its
+PR), lease expiry, last acquired/released times, per-app links, and an
+expandable raw JSON view. Two operator actions run against the coordinator:
+
+- **Release** (leased slots) — confirm-gated; evicts the current lease.
+- **Claim for PR…** (available slots) — records a `pr-<n>` holder with the
+  standard 24h preview lease, the dashboard equivalent of
+  `pnpm preview acquire`. Claiming marks ownership so CI will not deploy
+  over the slot; deploying to it remains the PR flow's job.
+
 ## Contract
 
 `src/contract.ts` contains the oRPC contract, schemas, and local client helper.

--- a/apps/semaphore/src/routeTree.gen.ts
+++ b/apps/semaphore/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as NotAnAdminRouteImport } from './routes/not-an-admin'
 import { Route as HealthRouteImport } from './routes/health'
 import { Route as AppRouteImport } from './routes/_app'
 import { Route as IndexRouteImport } from './routes/index'
@@ -18,6 +19,11 @@ import { Route as AppResourcesIndexRouteImport } from './routes/_app/resources.i
 import { Route as ApiOrpcSplatRouteImport } from './routes/api.orpc.$'
 import { Route as AppResourcesTypeSlugRouteImport } from './routes/_app/resources.$type.$slug'
 
+const NotAnAdminRoute = NotAnAdminRouteImport.update({
+  id: '/not-an-admin',
+  path: '/not-an-admin',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const HealthRoute = HealthRouteImport.update({
   id: '/health',
   path: '/health',
@@ -61,6 +67,7 @@ const AppResourcesTypeSlugRoute = AppResourcesTypeSlugRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/health': typeof HealthRoute
+  '/not-an-admin': typeof NotAnAdminRoute
   '/resources': typeof AppResourcesRouteWithChildren
   '/api/$': typeof ApiSplatRoute
   '/api/orpc/$': typeof ApiOrpcSplatRoute
@@ -70,6 +77,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/health': typeof HealthRoute
+  '/not-an-admin': typeof NotAnAdminRoute
   '/api/$': typeof ApiSplatRoute
   '/api/orpc/$': typeof ApiOrpcSplatRoute
   '/resources': typeof AppResourcesIndexRoute
@@ -80,6 +88,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/_app': typeof AppRouteWithChildren
   '/health': typeof HealthRoute
+  '/not-an-admin': typeof NotAnAdminRoute
   '/_app/resources': typeof AppResourcesRouteWithChildren
   '/api/$': typeof ApiSplatRoute
   '/api/orpc/$': typeof ApiOrpcSplatRoute
@@ -91,6 +100,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/health'
+    | '/not-an-admin'
     | '/resources'
     | '/api/$'
     | '/api/orpc/$'
@@ -100,6 +110,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/health'
+    | '/not-an-admin'
     | '/api/$'
     | '/api/orpc/$'
     | '/resources'
@@ -109,6 +120,7 @@ export interface FileRouteTypes {
     | '/'
     | '/_app'
     | '/health'
+    | '/not-an-admin'
     | '/_app/resources'
     | '/api/$'
     | '/api/orpc/$'
@@ -120,12 +132,20 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AppRoute: typeof AppRouteWithChildren
   HealthRoute: typeof HealthRoute
+  NotAnAdminRoute: typeof NotAnAdminRoute
   ApiSplatRoute: typeof ApiSplatRoute
   ApiOrpcSplatRoute: typeof ApiOrpcSplatRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/not-an-admin': {
+      id: '/not-an-admin'
+      path: '/not-an-admin'
+      fullPath: '/not-an-admin'
+      preLoaderRoute: typeof NotAnAdminRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/health': {
       id: '/health'
       path: '/health'
@@ -213,6 +233,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AppRoute: AppRouteWithChildren,
   HealthRoute: HealthRoute,
+  NotAnAdminRoute: NotAnAdminRoute,
   ApiSplatRoute: ApiSplatRoute,
   ApiOrpcSplatRoute: ApiOrpcSplatRoute,
 }

--- a/apps/semaphore/src/routes/_app.tsx
+++ b/apps/semaphore/src/routes/_app.tsx
@@ -14,7 +14,8 @@ export const Route = createFileRoute("/_app")({
   // The whole dashboard requires a signed-in iterate admin — the same
   // apps/auth identity the API lanes verify. Unauthenticated visitors go
   // through the relying-party login handler (served by the request
-  // middleware, outside the route tree — hence redirect by href).
+  // middleware, outside the route tree — hence redirect by href); signed-in
+  // non-admins go to /not-an-admin, which offers a sign-out button.
   beforeLoad: async ({ location }) => {
     const auth = await fetchAuthSnapshot();
     if (!auth.authenticated) {
@@ -25,9 +26,7 @@ export const Route = createFileRoute("/_app")({
       });
     }
     if (!auth.isAdmin) {
-      throw new Error(
-        `Signed in${auth.email ? ` as ${auth.email}` : ""}, but semaphore is operator tooling and requires an iterate admin. Sign out at /api/iterate-auth/logout.`,
-      );
+      throw redirect({ to: "/not-an-admin/" });
     }
     return { auth };
   },

--- a/apps/semaphore/src/routes/not-an-admin.tsx
+++ b/apps/semaphore/src/routes/not-an-admin.tsx
@@ -1,0 +1,45 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { fetchAuthSnapshot } from "~/lib/auth-snapshot.ts";
+
+export const Route = createFileRoute("/not-an-admin")({
+  // Landing spot for signed-in non-admins (the /_app gate redirects here).
+  // Anyone who doesn't belong here gets bounced to the right place instead.
+  beforeLoad: async () => {
+    const auth = await fetchAuthSnapshot();
+    if (!auth.authenticated) {
+      throw redirect({ to: "/", replace: true });
+    }
+    if (auth.isAdmin) {
+      throw redirect({ to: "/resources/", replace: true });
+    }
+    return { auth };
+  },
+  component: NotAnAdminPage,
+});
+
+function NotAnAdminPage() {
+  const { auth } = Route.useRouteContext();
+
+  return (
+    <main className="grid min-h-svh place-items-center bg-background p-4 text-foreground">
+      <div className="w-full max-w-sm space-y-6 rounded-lg border bg-card p-8 text-center">
+        <div className="space-y-2">
+          <h1 className="text-lg font-medium tracking-tight">Operator access required</h1>
+          <p className="text-sm text-muted-foreground">
+            You are signed in{auth.email ? ` as ${auth.email}` : ""}, but semaphore is operator
+            tooling and requires an iterate admin identity.
+          </p>
+        </div>
+        <a
+          href="/api/iterate-auth/logout"
+          className="block w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+        >
+          Sign out
+        </a>
+        <p className="text-xs text-muted-foreground">
+          Sign back in with an admin account, or ask an admin to grant your account the role.
+        </p>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Documents the new signed-in dashboard (grid, state-colored cards, recency sort) and its two operator actions (Release / Claim for PR) in the semaphore README.

Doubles as the post-cutover smoke test for #1656: this is the first fresh PR whose Cloudflare preview lane must claim its environment-config lease from the new prd semaphore using a forge-minted admin bearer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README and front-door routing/UX only; no API, lease coordinator, or auth verification logic changes.
> 
> **Overview**
> Adds a **Dashboard** section to the semaphore README describing the signed-in `/resources/` fleet grid (lease-state colors, holder/PR links, expiry and activity metadata, raw JSON) and the two coordinator actions: **Release** for leased slots and **Claim for PR…** for available slots (24h `pr-<n>` holder, CI ownership without deploying).
> 
> Separately improves **operator auth UX**: the `/_app` gate no longer throws for signed-in non-admins; it redirects to a new **`/not-an-admin`** route with a clear message and sign-out link. That page bounces unauthenticated users home and admins to `/resources/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9bc6bf6df8690c870f8f8309d96861bf8b65d7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-06T13:06:18.715Z",
      "headSha": "c9bc6bf6df8690c870f8f8309d96861bf8b65d7f",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/558208581718844",
      "shortSha": "c9bc6bf",
      "cleanupDurationMs": 788,
      "deployDurationMs": 25706,
      "testDurationMs": 6588,
      "testRetries": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-06T13:06:21.047Z",
      "headSha": "c9bc6bf6df8690c870f8f8309d96861bf8b65d7f",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/558208581718844",
      "shortSha": "c9bc6bf",
      "cleanupDurationMs": 3116,
      "deployDurationMs": 25850,
      "testDurationMs": 564,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `c9bc6bf` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 25.9s | 564ms |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/558208581718844) | 2026-07-06T13:06:21.047Z | Preview app released. |
| Semaphore | released | `c9bc6bf` | [https://semaphore.iterate-preview-8.com](https://semaphore.iterate-preview-8.com) | 25.7s | 6.6s |  | 788ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/558208581718844) | 2026-07-06T13:06:18.715Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->