### PR TITLE
Streams playground behind apps/auth: deployed envs are iterate-admin only

### DIFF
--- a/apps/auth/src/server/auth-plugins.ts
+++ b/apps/auth/src/server/auth-plugins.ts
@@ -35,6 +35,7 @@ import {
   getOsMcpResourceBases,
   getOsResourceBases,
   getSemaphoreResourceBases,
+  getStreamsExampleResourceBases,
 } from "./oauth-resources.ts";
 import { isPlatformAdminUser } from "./platform-admin.ts";
 import {
@@ -87,6 +88,7 @@ export function getAuthPlugins(options: AuthPluginOptions) {
   const validAudiences = [
     ...osResourceBases,
     ...getSemaphoreResourceBases(),
+    ...getStreamsExampleResourceBases(),
     ...getOsMcpResourceBases(),
   ];
 

--- a/apps/auth/src/server/logout.ts
+++ b/apps/auth/src/server/logout.ts
@@ -1,4 +1,8 @@
-import { getOsResourceBases, getSemaphoreResourceBases } from "./oauth-resources.ts";
+import {
+  getOsResourceBases,
+  getSemaphoreResourceBases,
+  getStreamsExampleResourceBases,
+} from "./oauth-resources.ts";
 
 const LOCAL_DEVELOPMENT_REDIRECT_ORIGINS = [
   "http://localhost:5173",
@@ -29,6 +33,7 @@ export function resolveAuthLogoutReturnTo(input: {
     ...(input.publicOrigin ? [input.publicOrigin] : []),
     ...getOsResourceBases(),
     ...getSemaphoreResourceBases(),
+    ...getStreamsExampleResourceBases(),
     ...EXAMPLE_APP_REDIRECT_ORIGINS,
     ...LOCAL_DEVELOPMENT_REDIRECT_ORIGINS,
   ]);

--- a/apps/auth/src/server/oauth-resources.ts
+++ b/apps/auth/src/server/oauth-resources.ts
@@ -29,6 +29,21 @@ export function getSemaphoreResourceBases() {
   ];
 }
 
+/**
+ * The streams playground is a relying party like OS and semaphore (browser
+ * sign-in + bearer access tokens against its own workers.dev origin as the
+ * RFC 8707 resource). Local dev is auth-less by design and needs no entry.
+ */
+export function getStreamsExampleResourceBases() {
+  return [
+    "https://streams-example-app-prd.iterate.workers.dev",
+    ...[1, 2, 3, 4, 5, 6, 7, 8, 9].map(
+      (previewNumber) =>
+        `https://streams-example-app-preview-${previewNumber}.iterate-dev-preview.workers.dev`,
+    ),
+  ];
+}
+
 export function getOsMcpResourceBases() {
   return expandOAuthResourceAudienceVariants([
     "https://mcp.iterate.com",

--- a/apps/streams-example-app/e2e/auth.ts
+++ b/apps/streams-example-app/e2e/auth.ts
@@ -1,0 +1,80 @@
+import { streamsExampleEnvs } from "../../../envs.ts";
+import { mintForgedAccessToken, mintForgedIdToken } from "../../../scripts/auth/forge-token.ts";
+
+/**
+ * Forge-minted admin credentials for e2e against a DEPLOYED playground —
+ * the same mechanism as `pnpm auth:mint` and semaphore's e2e. Local dev
+ * (localhost WORKER_URL, or none) is auth-less, so everything here resolves
+ * to null and the suites run exactly as before.
+ */
+
+/** The deployed env matching WORKER_URL, or null for local dev. */
+export function resolveDeployedEnv(workerUrl: string | undefined) {
+  if (!workerUrl) return null;
+  const origin = new URL(workerUrl).origin;
+  if (new URL(origin).hostname === "localhost" || new URL(origin).hostname === "127.0.0.1") {
+    return null;
+  }
+  return (
+    Object.values(streamsExampleEnvs).find(
+      (candidate) => new URL(candidate.baseUrl).origin === origin,
+    ) ?? null
+  );
+}
+
+/** Mint an admin access token for the deployed playground (null on local dev). */
+export async function mintAdminAccessToken(workerUrl: string | undefined) {
+  const env = resolveDeployedEnv(workerUrl);
+  if (!env) return null;
+  const forgePrivateJwk = process.env.AUTH_FORGE_PRIVATE_JWK?.trim();
+  if (!forgePrivateJwk) {
+    throw new Error(
+      "AUTH_FORGE_PRIVATE_JWK is required to run e2e against a deployed playground. " +
+        "Run under the env's Doppler config (doppler run --project streams-example-app --config <env> -- ...).",
+    );
+  }
+  return await mintForgedAccessToken({
+    forgePrivateJwk,
+    issuer: `${env.authBaseUrl}/api/auth`,
+    audience: new URL(env.baseUrl).origin,
+    email: "streams-e2e@iterate.com",
+    admin: true,
+  });
+}
+
+/**
+ * Mint the access+id pair a browser session needs, for
+ * `/api/iterate-auth/session-from-token` (the Playwright sign-in lane).
+ */
+export async function mintAdminBrowserTokens(workerUrl: string | undefined) {
+  const env = resolveDeployedEnv(workerUrl);
+  if (!env) return null;
+  const forgePrivateJwk = process.env.AUTH_FORGE_PRIVATE_JWK?.trim();
+  const clientId = process.env.APP_CONFIG_ITERATE_AUTH__CLIENT_ID?.trim();
+  if (!forgePrivateJwk || !clientId) {
+    throw new Error(
+      "AUTH_FORGE_PRIVATE_JWK and APP_CONFIG_ITERATE_AUTH__CLIENT_ID are required to run browser " +
+        "e2e against a deployed playground. Run under the env's Doppler config.",
+    );
+  }
+  const base = {
+    forgePrivateJwk,
+    issuer: `${env.authBaseUrl}/api/auth`,
+    email: "streams-e2e@iterate.com",
+    admin: true,
+  };
+  return {
+    accessToken: await mintForgedAccessToken({
+      ...base,
+      audience: new URL(env.baseUrl).origin,
+    }),
+    idToken: await mintForgedIdToken({ ...base, clientId }),
+  };
+}
+
+// CLI: print an admin access token for the deployed WORKER_URL (empty on
+// local dev). The preview e2e lane exports it as STREAMS_PLAYGROUND_TOKEN.
+if (process.argv[1]?.endsWith("auth.ts")) {
+  const token = await mintAdminAccessToken(process.env.WORKER_URL);
+  console.log(token ?? "");
+}

--- a/apps/streams-example-app/e2e/helpers.ts
+++ b/apps/streams-example-app/e2e/helpers.ts
@@ -19,6 +19,11 @@ export function toStreamWebSocketUrl(args: { path: string; projectId?: string })
   const url = new URL(streamRpcPath({ path, projectId: args.projectId }), e2eWorkerUrl());
   if (url.protocol === "http:") url.protocol = "ws:";
   if (url.protocol === "https:") url.protocol = "wss:";
+  // Deployed playgrounds are admin-only; WebSockets cannot carry headers from
+  // every client, so the forge-minted e2e bearer rides as a query param
+  // (accepted only on /api/streams — see src/worker.ts). Unset locally.
+  const token = process.env.STREAMS_PLAYGROUND_TOKEN?.trim();
+  if (token) url.searchParams.set("access_token", token);
   return url.toString();
 }
 

--- a/apps/streams-example-app/e2e/playwright-global-setup.ts
+++ b/apps/streams-example-app/e2e/playwright-global-setup.ts
@@ -1,0 +1,33 @@
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { request } from "@playwright/test";
+import { mintAdminBrowserTokens } from "./auth.ts";
+
+export const STORAGE_STATE_PATH = "test-results/.auth/storage-state.json";
+
+/**
+ * Signs the browser suite in against a DEPLOYED playground: forge-mints an
+ * admin access+id pair, exchanges it for the normal session cookie via
+ * `/api/iterate-auth/session-from-token`, and saves the storage state every
+ * test reuses. Local dev is auth-less — no WORKER_URL, nothing to do.
+ */
+export default async function globalSetup() {
+  const workerUrl = process.env.WORKER_URL;
+  const tokens = await mintAdminBrowserTokens(workerUrl);
+  if (!tokens) return;
+
+  mkdirSync(dirname(STORAGE_STATE_PATH), { recursive: true });
+  const context = await request.newContext({ baseURL: workerUrl });
+  const response = await context.get(
+    `/api/iterate-auth/session-from-token?${new URLSearchParams({
+      access_token: tokens.accessToken,
+      id_token: tokens.idToken,
+      return_to: "/",
+    })}`,
+  );
+  if (!response.ok()) {
+    throw new Error(`session-from-token failed (${response.status()}): ${await response.text()}`);
+  }
+  await context.storageState({ path: STORAGE_STATE_PATH });
+  await context.dispose();
+}

--- a/apps/streams-example-app/package.json
+++ b/apps/streams-example-app/package.json
@@ -15,6 +15,8 @@
     "typecheck": "pnpm gen:wrangler && tsc --noEmit"
   },
   "dependencies": {
+    "@iterate-com/auth": "workspace:*",
+    "@iterate-com/shared": "workspace:*",
     "@journeyapps/wa-sqlite": "^1.7.0",
     "@tanstack/react-router": "^1.170.10",
     "@tanstack/react-start": "^1.168.18",
@@ -25,7 +27,6 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "catalog:cloudflare",
-    "@iterate-com/shared": "workspace:*",
     "@cloudflare/workers-types": "catalog:cloudflare",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/vite": "^4.3.0",

--- a/apps/streams-example-app/playwright.config.ts
+++ b/apps/streams-example-app/playwright.config.ts
@@ -6,6 +6,9 @@ const localUrl = "http://127.0.0.1:5173";
 
 export default defineConfig({
   testDir: "e2e/playwright",
+  // Deployed playgrounds are admin-only: the global setup forge-mints a
+  // session and saves its storage state; local dev is auth-less and skips it.
+  globalSetup: "./e2e/playwright-global-setup.ts",
   timeout: 60_000,
   expect: { timeout: 15_000 },
   fullyParallel: false,
@@ -23,6 +26,7 @@ export default defineConfig({
       : undefined,
   use: {
     baseURL: workerUrl ?? localUrl,
+    storageState: workerUrl === undefined ? undefined : "test-results/.auth/storage-state.json",
     trace: "retain-on-failure",
   },
   projects: [

--- a/apps/streams-example-app/playwright.config.ts
+++ b/apps/streams-example-app/playwright.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig, devices } from "@playwright/test";
 import { E2E_CI_RETRIES } from "@iterate-com/shared/test-support/e2e-policy";
+import { resolveDeployedEnv } from "./e2e/auth.ts";
+import { STORAGE_STATE_PATH } from "./e2e/playwright-global-setup.ts";
 
 const workerUrl = process.env.WORKER_URL;
 const localUrl = "http://127.0.0.1:5173";
+// The global setup writes the saved session only for a DEPLOYED (admin-only)
+// target; a loopback WORKER_URL is the auth-less playground. Gate storageState
+// on the SAME predicate so the config never points at a file setup skipped.
+const usesSavedSession = resolveDeployedEnv(workerUrl) !== null;
 
 export default defineConfig({
   testDir: "e2e/playwright",
@@ -26,7 +32,7 @@ export default defineConfig({
       : undefined,
   use: {
     baseURL: workerUrl ?? localUrl,
-    storageState: workerUrl === undefined ? undefined : "test-results/.auth/storage-state.json",
+    storageState: usesSavedSession ? STORAGE_STATE_PATH : undefined,
     trace: "retain-on-failure",
   },
   projects: [

--- a/apps/streams-example-app/scripts/deploy.ts
+++ b/apps/streams-example-app/scripts/deploy.ts
@@ -4,9 +4,10 @@
  *   pnpm run deploy --env preview_3
  *   pnpm run deploy --env prd
  *
- * workers.dev only — no routes, no DNS, no resources, no secrets (the
- * pipeline's secrets file is an empty `{}`, which preserves any existing
- * secrets and sets none). Runs the shared pipeline (scripts/lib/deploy-app.ts):
+ * workers.dev only — no routes, no DNS, no resources. Secrets are the
+ * iterate-auth relying-party credentials plus the JWKS baked in `prepare`
+ * (admin-only access on deployed envs). Runs the shared pipeline
+ * (scripts/lib/deploy-app.ts):
  * `vite build` with CLOUDFLARE_ENV=<env> (vite.config.ts regenerates
  * wrangler.jsonc from envs.ts before the cloudflare plugin reads it — the
  * build always sees a fresh config), deploy, then smoke-probe the health
@@ -15,7 +16,10 @@
 import { fileURLToPath } from "node:url";
 import { createBuiltInPrompts, createCli, isAgent, yamlTableConsoleLogger } from "trpc-cli";
 import { streamsExampleEnvs } from "../../../envs.ts";
+import { bakeStaticAuthJwks } from "../../../scripts/lib/bake-auth-jwks.ts";
 import { deployApp } from "../../../scripts/lib/deploy-app.ts";
+import { parseConfig } from "../src/config.ts";
+import { envShapedVars, REQUIRED_SECRETS } from "./generate-wrangler-config.ts";
 
 /** Deploy apps/streams-example-app to a deployed environment (see scripts/lib/deploy-app.ts for the pipeline). */
 export default async function deploy(
@@ -32,6 +36,22 @@ export default async function deploy(
     env: options.env,
     workerName: (env) => env.workerName,
     servingUrl: (env) => env.baseUrl,
+    requiredSecrets: REQUIRED_SECRETS,
+    prepare: async (ctx, secretValues) => {
+      // The playground verifies iterate sessions and bearer tokens against a
+      // static JWKS baked at deploy time (issuer keys + forge public key) —
+      // the same relying-party model as apps/os and apps/semaphore.
+      secretValues.APP_CONFIG_ITERATE_AUTH__JWKS = await bakeStaticAuthJwks({
+        authBaseUrl: ctx.env.authBaseUrl,
+        envName: ctx.name,
+        dopplerConfig: ctx.env.dopplerConfig,
+        secrets: ctx.secrets,
+      });
+
+      // Parse the exact env the worker will see (secrets + generated vars)
+      // with the worker's own schema — the strongest possible pre-flight.
+      parseConfig({ ...secretValues, ...envShapedVars(ctx.env) });
+    },
     smokes: (env) => [
       {
         url: `${env.baseUrl}/api/__internal/health`,

--- a/apps/streams-example-app/scripts/generate-wrangler-config.ts
+++ b/apps/streams-example-app/scripts/generate-wrangler-config.ts
@@ -8,7 +8,7 @@
  *
  * The top-level config is local dev; each deployed environment gets an env
  * block expanded from its streamsExampleEnvs entry. The app is workers.dev
- * only: no routes, no DNS, no resources, no secrets. Its one binding is the
+ * only: no routes, no DNS, no resources. Its one binding is the
  * same-script STREAM Durable Object — the app re-exports apps/os's
  * StreamDurableObject from its own worker entry (src/worker.ts) via the `~`
  * alias, so the class lives in this script.
@@ -19,6 +19,30 @@ import {
   OBSERVABILITY,
   writeGeneratedWranglerConfig,
 } from "../../../scripts/lib/wrangler-config.ts";
+
+/**
+ * Secrets every deployment needs, sourced from the env's Doppler config.
+ * `deploy.ts` builds its --secrets-file from exactly this list and fails
+ * before deploying when the Doppler config is missing one. The playground is
+ * admin-only on deployed envs (see src/iterate-auth.ts); local dev carries
+ * none of these and stays auth-less.
+ */
+export const REQUIRED_SECRETS = [
+  "APP_CONFIG_ITERATE_AUTH__CLIENT_ID",
+  "APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET",
+];
+
+/**
+ * Env-shaping config that is NOT secret and already lives in envs.ts —
+ * emitted as per-env `vars` so the worker's runtime base URL and auth issuer
+ * can never drift from the envs.ts entry that names the worker.
+ */
+export function envShapedVars(env: StreamsExampleEnv) {
+  return {
+    APP_CONFIG_BASE_URL: env.baseUrl,
+    APP_CONFIG_ITERATE_AUTH__ISSUER: `${env.authBaseUrl}/api/auth`,
+  };
+}
 
 /** Binding config identical across local dev and every deployed env. */
 function workerBindings() {
@@ -37,6 +61,8 @@ function envBlock(env: StreamsExampleEnv) {
     // The env's only public URL is its workers.dev origin (envs.ts baseUrl).
     workers_dev: true,
     ...workerBindings(),
+    secrets: { required: REQUIRED_SECRETS },
+    vars: envShapedVars(env),
   };
 }
 
@@ -48,11 +74,31 @@ const config = {
   name: "streams-example-app",
   main: "./src/worker.ts",
   compatibility_date: "2026-06-17",
-  compatibility_flags: ["nodejs_compat", "nodejs_compat_populate_process_env"],
+  // global_fetch_strictly_public: the iterate-auth login handler fetches the
+  // auth worker for OIDC discovery + token exchange; without the flag,
+  // same-zone subrequests would go to the zone origin instead of through
+  // Worker routes (~20s hang then 500 — same incident class as os/auth/
+  // semaphore). workers.dev origins are cross-zone to auth today, but the
+  // flag keeps this safe if the app ever gets a custom domain.
+  compatibility_flags: [
+    "nodejs_compat",
+    "nodejs_compat_populate_process_env",
+    "global_fetch_strictly_public",
+  ],
   // No `assets` here: the vite plugin injects the client build's assets
   // config into the OUTPUT wrangler.json (dist/…) that deploys actually use.
   migrations: [{ tag: "v1", new_sqlite_classes: ["StreamDurableObject"] }],
   ...workerBindings(),
+  // Local dev loads the iterate-auth keys from process.env when present (the
+  // vite plugin reads exactly `secrets.required`); absent keys leave the dev
+  // playground auth-less, which is the intended local mode.
+  secrets: {
+    required: [
+      ...REQUIRED_SECRETS,
+      "APP_CONFIG_ITERATE_AUTH__ISSUER",
+      "APP_CONFIG_ITERATE_AUTH__JWKS",
+    ],
+  },
   env: Object.fromEntries(
     Object.entries(streamsExampleEnvs).map(([name, env]) => [name, envBlock(env)]),
   ),

--- a/apps/streams-example-app/scripts/sync-auth-client.ts
+++ b/apps/streams-example-app/scripts/sync-auth-client.ts
@@ -1,0 +1,132 @@
+/**
+ * Provision streams-example-app-prd's relying-party credentials — the prd
+ * counterpart of `pnpm preview provision-auth-preview-configs` (which handles
+ * the preview slots). Idempotent; run it before deploying a playground that
+ * requires iterate auth:
+ *
+ *   doppler run --project auth --config prd -- pnpm --dir apps/streams-example-app exec tsx scripts/sync-auth-client.ts
+ *
+ * It ensures, in order:
+ *   1. an OAuth client on the prd auth worker (browser sign-in for the
+ *      playground's workers.dev origin), mirrored into AUTH_SEED_OAUTH_CLIENTS
+ *      so auth redeploys keep it;
+ *   2. APP_CONFIG_ITERATE_AUTH__CLIENT_ID/SECRET in streams-example-app/prd
+ *      Doppler;
+ *   3. the forge key in streams-example-app/prd (deploys bake its public half
+ *      into the worker's JWKS; e2e mints admin bearers with the private half)
+ *      — copied from os/prd together with AUTH_FORGE_ALLOW_PRODUCTION, the
+ *      deliberate production-minting opt-in os already made (#1499).
+ */
+import { execFileSync, spawnSync } from "node:child_process";
+import { createAuthContractClient } from "@iterate-com/auth-contract";
+import { streamsExampleEnvs } from "../../../envs.ts";
+
+type SeedOAuthClientSpec = {
+  clientId: string;
+  clientSecret: string;
+  clientName: string;
+  redirectURIs: string[];
+  referenceId?: string;
+  skipConsent?: boolean;
+};
+
+const env = streamsExampleEnvs.prd;
+const serviceToken = process.env.APP_CONFIG_SERVICE_AUTH_TOKEN?.trim();
+if (!serviceToken) {
+  throw new Error(
+    "APP_CONFIG_SERVICE_AUTH_TOKEN is required. Run through Doppler for auth prd: " +
+      "doppler run --project auth --config prd -- pnpm --dir apps/streams-example-app exec tsx scripts/sync-auth-client.ts",
+  );
+}
+
+const authClient = createAuthContractClient({ baseUrl: env.authBaseUrl, serviceToken });
+
+const referenceId = "streams-example-app:prd:web";
+const clientName = "Streams playground prd web";
+const redirectURIs = [`${env.baseUrl}/api/iterate-auth/callback`];
+const client = await authClient.internal.oauth.ensureClient({
+  referenceId,
+  clientName,
+  redirectURIs,
+  existingClientId: getDopplerSecret(
+    "streams-example-app",
+    "prd",
+    "APP_CONFIG_ITERATE_AUTH__CLIENT_ID",
+  ),
+  existingClientSecret: getDopplerSecret(
+    "streams-example-app",
+    "prd",
+    "APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET",
+  ),
+});
+
+setDopplerSecrets("streams-example-app", "prd", {
+  APP_CONFIG_ITERATE_AUTH__CLIENT_ID: client.clientId,
+  APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET: client.clientSecret,
+});
+console.log(`streams-example-app/prd OAuth client ensured (${client.clientId})`);
+
+upsertAuthSeedOAuthClient({
+  clientId: client.clientId,
+  clientSecret: client.clientSecret,
+  clientName,
+  redirectURIs,
+  referenceId,
+  skipConsent: true,
+});
+
+const forgePrivateJwk = getDopplerSecret("os", "prd", "AUTH_FORGE_PRIVATE_JWK");
+const allowProduction = getDopplerSecret("os", "prd", "AUTH_FORGE_ALLOW_PRODUCTION");
+if (!forgePrivateJwk || !allowProduction) {
+  throw new Error(
+    "os/prd is missing AUTH_FORGE_PRIVATE_JWK or AUTH_FORGE_ALLOW_PRODUCTION — cannot mirror the forge key.",
+  );
+}
+setDopplerSecrets("streams-example-app", "prd", {
+  AUTH_FORGE_PRIVATE_JWK: forgePrivateJwk,
+  AUTH_FORGE_ALLOW_PRODUCTION: allowProduction,
+});
+console.log("forge key mirrored into streams-example-app/prd");
+console.log(`done — issuer ${env.authBaseUrl}/api/auth`);
+
+function getDopplerSecret(project: string, config: string, name: string) {
+  try {
+    const value = execFileSync(
+      "doppler",
+      ["secrets", "get", name, "--plain", "--project", project, "--config", config],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    ).trim();
+    return value || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function setDopplerSecrets(project: string, config: string, secrets: Record<string, string>) {
+  for (const [key, value] of Object.entries(secrets)) {
+    const result = spawnSync(
+      "doppler",
+      ["secrets", "set", key, "--project", project, "--config", config, "--no-interactive"],
+      { input: value, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+    if (result.status !== 0) {
+      throw new Error(
+        `Failed to set ${key} for ${project}/${config}: ${result.stderr || result.stdout}`,
+      );
+    }
+  }
+}
+
+function upsertAuthSeedOAuthClient(client: SeedOAuthClientSpec) {
+  const raw = getDopplerSecret("auth", "prd", "AUTH_SEED_OAUTH_CLIENTS");
+  const clients: SeedOAuthClientSpec[] = raw ? (JSON.parse(raw) as SeedOAuthClientSpec[]) : [];
+  const index = clients.findIndex(
+    (candidate) =>
+      candidate.referenceId === client.referenceId || candidate.clientId === client.clientId,
+  );
+  if (index === -1) clients.push(client);
+  else clients[index] = client;
+  clients.sort((a, b) => (a.referenceId ?? a.clientId).localeCompare(b.referenceId ?? b.clientId));
+  setDopplerSecrets("auth", "prd", { AUTH_SEED_OAUTH_CLIENTS: JSON.stringify(clients) });
+  console.log("auth/prd AUTH_SEED_OAUTH_CLIENTS updated");
+}

--- a/apps/streams-example-app/src/config.ts
+++ b/apps/streams-example-app/src/config.ts
@@ -1,0 +1,43 @@
+import { parseAppConfigFromEnv, publicValue, redacted } from "@iterate-com/shared/config";
+import { z } from "zod";
+
+/**
+ * Playground runtime config, parsed from the `APP_CONFIG_*` env vars that
+ * deploys bake into the worker (secrets via `wrangler deploy --secrets-file`,
+ * env-shaped vars generated from the root envs.ts).
+ */
+
+/** A JSON Web Key Set as jose expects it (the auth issuer's keys, baked at deploy). */
+const JSONWebKeySet = z.object({
+  keys: z.array(z.looseObject({ kty: z.string().trim().min(1) })),
+});
+
+export const AppConfig = z.object({
+  // Deployed envs get APP_CONFIG_BASE_URL as a generated var from the same
+  // envs.ts entry that names the worker. Optional because local dev has no
+  // deployed base URL.
+  baseUrl: publicValue(z.url().optional()),
+  // Relying-party config against the env's apps/auth deployment — the same
+  // shape as apps/os and apps/semaphore. Optional so local dev stays the
+  // auth-less playground; every DEPLOYED env requires it (deploy.ts enforces
+  // the secrets), and when present the worker is admin-only.
+  iterateAuth: z
+    .object({
+      issuer: publicValue(z.url().default("https://auth.iterate.com/api/auth")),
+      clientId: publicValue(z.string().trim().min(1)),
+      clientSecret: redacted(z.string().trim().min(1)),
+      jwks: JSONWebKeySet.optional(),
+      resource: publicValue(z.url()).optional(),
+    })
+    .optional(),
+});
+export type AppConfig = z.output<typeof AppConfig>;
+
+/** Parse playground config from a worker env (the `cloudflare:workers` import). */
+export function parseConfig(env: unknown): AppConfig {
+  return parseAppConfigFromEnv({
+    configSchema: AppConfig,
+    prefix: "APP_CONFIG_",
+    env: env as Record<string, unknown>,
+  });
+}

--- a/apps/streams-example-app/src/iterate-auth.ts
+++ b/apps/streams-example-app/src/iterate-auth.ts
@@ -47,11 +47,22 @@ export function createStreamsIterateAuth(
   return auth;
 }
 
-/** The authenticated caller: session cookie wins (browser + WS upgrade), else bearer. */
+/**
+ * The authenticated caller: session cookie wins (browser + WS upgrade), else
+ * bearer. `responseHeaders` carries any rotated-session `Set-Cookie` that
+ * `authenticate()` produced when it refreshed an expiring token — the caller
+ * MUST merge it onto the response, or the browser keeps the stale token and
+ * refresh-token reuse eventually nukes the session.
+ */
 export async function resolveRequestAdmin(input: {
   auth: StreamsIterateAuth;
   headers: Headers;
-}): Promise<{ authenticated: boolean; isAdmin: boolean; email?: string }> {
+}): Promise<{
+  authenticated: boolean;
+  isAdmin: boolean;
+  email?: string;
+  responseHeaders: Headers;
+}> {
   const result = await input.auth.authenticate({
     headers: input.headers,
     includeUserInfo: false,
@@ -61,6 +72,7 @@ export async function resolveRequestAdmin(input: {
       authenticated: true,
       isAdmin: result.session.user.isAdmin === true || result.session.user.role === "admin",
       email: result.session.user.email,
+      responseHeaders: result.responseHeaders,
     };
   }
 
@@ -72,8 +84,9 @@ export async function resolveRequestAdmin(input: {
       isAdmin:
         accessToken[ITERATE_IS_ADMIN_CLAIM] === true || accessToken[ITERATE_ROLE_CLAIM] === "admin",
       email: typeof email === "string" ? email : undefined,
+      responseHeaders: result.responseHeaders,
     };
   }
 
-  return { authenticated: false, isAdmin: false };
+  return { authenticated: false, isAdmin: false, responseHeaders: result.responseHeaders };
 }

--- a/apps/streams-example-app/src/iterate-auth.ts
+++ b/apps/streams-example-app/src/iterate-auth.ts
@@ -1,0 +1,79 @@
+import { createIterateAuth } from "@iterate-com/auth/server";
+import { ITERATE_IS_ADMIN_CLAIM, ITERATE_ROLE_CLAIM } from "@iterate-com/shared/auth-claims";
+import type { AppConfig } from "./config.ts";
+
+/**
+ * Relying-party auth for the streams playground — the same model as
+ * apps/semaphore. Browsers sign in through `/api/iterate-auth/*` and carry
+ * the `iterate_session` cookie (sent on the capnweb WebSocket upgrade too);
+ * CLIs and node e2e present a bearer access token. Everything the playground
+ * serves runs with trusted-internal authority, so access is a single
+ * question: is the caller an iterate admin?
+ *
+ * When `iterateAuth` is absent from the config (local dev only — deploys
+ * require the secrets), the worker stays the historical auth-less
+ * playground.
+ */
+
+type StreamsIterateAuth = ReturnType<typeof createIterateAuth>;
+
+const authClients = new Map<string, StreamsIterateAuth>();
+
+/** Build (and cache) the iterate-auth relying-party client for this deployment. */
+export function createStreamsIterateAuth(
+  config: AppConfig,
+  requestUrl: string,
+): StreamsIterateAuth | null {
+  const authConfig = config.iterateAuth;
+  if (!authConfig) return null;
+
+  const requestOrigin = new URL(requestUrl).origin;
+  const baseOrigin = (config.baseUrl ?? requestOrigin).replace(/\/+$/, "");
+  const clientConfig = {
+    issuer: authConfig.issuer,
+    clientId: authConfig.clientId,
+    clientSecret: authConfig.clientSecret.exposeSecret(),
+    jwks: authConfig.jwks,
+    redirectURI: `${baseOrigin}/api/iterate-auth/callback`,
+    resource: [(authConfig.resource ?? baseOrigin).replace(/\/+$/, "")],
+    logoutReturnToOrigins: config.baseUrl ? [config.baseUrl] : undefined,
+  };
+  const cacheKey = JSON.stringify(clientConfig);
+  const cached = authClients.get(cacheKey);
+  if (cached) return cached;
+
+  const auth = createIterateAuth(clientConfig);
+  authClients.set(cacheKey, auth);
+  return auth;
+}
+
+/** The authenticated caller: session cookie wins (browser + WS upgrade), else bearer. */
+export async function resolveRequestAdmin(input: {
+  auth: StreamsIterateAuth;
+  headers: Headers;
+}): Promise<{ authenticated: boolean; isAdmin: boolean; email?: string }> {
+  const result = await input.auth.authenticate({
+    headers: input.headers,
+    includeUserInfo: false,
+  });
+  if (result.session) {
+    return {
+      authenticated: true,
+      isAdmin: result.session.user.isAdmin === true || result.session.user.role === "admin",
+      email: result.session.user.email,
+    };
+  }
+
+  const accessToken = await input.auth.authenticateBearer({ headers: input.headers });
+  if (accessToken) {
+    const email = accessToken.email;
+    return {
+      authenticated: true,
+      isAdmin:
+        accessToken[ITERATE_IS_ADMIN_CLAIM] === true || accessToken[ITERATE_ROLE_CLAIM] === "admin",
+      email: typeof email === "string" ? email : undefined,
+    };
+  }
+
+  return { authenticated: false, isAdmin: false };
+}

--- a/apps/streams-example-app/src/worker.ts
+++ b/apps/streams-example-app/src/worker.ts
@@ -1,6 +1,9 @@
 import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
+import { env as workerEnv } from "cloudflare:workers";
 import { newWorkersRpcResponse } from "capnweb";
 import { parseStreamRpcRequest } from "./lib/stream-rpc.ts";
+import { parseConfig } from "./config.ts";
+import { createStreamsIterateAuth, resolveRequestAdmin } from "./iterate-auth.ts";
 import { trustedInternalAuthContext } from "~/auth.ts";
 import { StreamRpcTarget } from "~/rpc-targets.ts";
 import { resolveStreamPath } from "~/domains/streams/utils.ts";
@@ -12,9 +15,12 @@ export { StreamDurableObject } from "~/domains/streams/stream-durable-object.ts"
  * The capnweb surface this playground serves at `/api/streams`.
  *
  * It wraps the itx `StreamRpcTarget` with `trustedInternalAuthContext()`:
- * the example app is an AUTH-LESS playground, so every caller gets the
- * trusted-internal (admin) authority instead of walking through the real
- * deployment's `UnauthenticatedOs.authenticate()` door.
+ * every caller who gets past the door below runs with the trusted-internal
+ * (admin) authority instead of walking through the real deployment's
+ * `UnauthenticatedOs.authenticate()` door. That door is iterate-auth: on
+ * deployed envs, only iterate admins (session cookie or bearer access token)
+ * reach the RPC surface or the UI. Local dev (no iterateAuth config) stays
+ * the historical auth-less playground.
  *
  * `kill()`/`reset()` are playground-only operator verbs on top of the public
  * `Stream` capability — the sidebar's restart/reset experiments need them, and
@@ -40,6 +46,20 @@ class PlaygroundStreamRpcTarget extends StreamRpcTarget {
   }
 }
 
+function notAnAdminResponse(email: string | undefined): Response {
+  const who = email ? ` as ${email}` : "";
+  return new Response(
+    `<!doctype html><html><body style="font-family:system-ui;display:grid;place-items:center;min-height:100svh;margin:0">
+      <div style="max-width:24rem;text-align:center">
+        <h1 style="font-size:1.1rem">Operator access required</h1>
+        <p style="color:#666;font-size:0.9rem">You are signed in${who}, but the streams playground requires an iterate admin identity.</p>
+        <p><a href="/api/iterate-auth/logout">Sign out</a></p>
+      </div>
+    </body></html>`,
+    { status: 403, headers: { "content-type": "text/html; charset=utf-8" } },
+  );
+}
+
 export default createServerEntry({
   async fetch(request) {
     const url = new URL(request.url);
@@ -48,7 +68,42 @@ export default createServerEntry({
       return new Response("ok", { headers: { "content-type": "text/plain" } });
     }
 
+    // Parsed per request, NOT at module scope (matching apps/os): a fresh
+    // DO-class worker's first deploy is a secrets-less bootstrap (see
+    // scripts/lib/deploy-helpers.ts), and a module-scope parse would fail
+    // Cloudflare's startup validation on that version before secrets land.
+    const config = parseConfig(workerEnv);
+    const auth = createStreamsIterateAuth(config, request.url);
+
+    // The relying-party handler (login/callback/logout/session/…).
+    const authResponse = auth?.handleRequest(request) ?? null;
+    if (authResponse) {
+      return authResponse;
+    }
+
+    // Browser WebSockets cannot set headers, so /api/streams also accepts the
+    // bearer as an `access_token` query param (RFC 6750 §2.3) — the lane the
+    // node e2e uses for the browser-client tests. Real browsers ride the
+    // session cookie on the upgrade instead.
+    const queryToken =
+      url.pathname === "/api/streams" ? url.searchParams.get("access_token") : null;
+    const headers = new Headers(request.headers);
+    if (queryToken && !headers.has("authorization")) {
+      headers.set("authorization", `Bearer ${queryToken}`);
+    }
+    const admin = auth ? await resolveRequestAdmin({ auth, headers }) : null;
+
     if (url.pathname === "/api/streams") {
+      if (auth && !admin?.isAdmin) {
+        return Response.json(
+          {
+            error: "unauthorized",
+            message:
+              "Authenticate with an iterate admin identity: sign in through /api/iterate-auth/login, or send an admin access token as `Authorization: Bearer <token>`.",
+          },
+          { status: 401 },
+        );
+      }
       const { projectId, path } = parseStreamRpcRequest({ url });
       return newWorkersRpcResponse(
         request,
@@ -58,6 +113,20 @@ export default createServerEntry({
           path,
         }),
       );
+    }
+
+    // Page routes: send signed-out visitors through login and back; show
+    // signed-in non-admins a sign-out page. Static assets never reach the
+    // worker, and they carry nothing sensitive (client code only).
+    if (auth && !admin?.isAdmin) {
+      if (!admin?.authenticated) {
+        const returnTo = `${url.pathname}${url.search}`;
+        return Response.redirect(
+          `${url.origin}/api/iterate-auth/login?${new URLSearchParams({ return_to: returnTo })}`,
+          302,
+        );
+      }
+      return notAnAdminResponse(admin.email);
     }
 
     // No COOP/COEP on purpose: the browser SQLite mirror uses wa-sqlite's OPFSCoopSyncVFS,

--- a/apps/streams-example-app/src/worker.ts
+++ b/apps/streams-example-app/src/worker.ts
@@ -134,6 +134,18 @@ export default createServerEntry({
     // made @sqlite.org/sqlite-wasm auto-install its async-proxy OPFS VFS and deadlock in
     // production builds.) Leaving it off also keeps OPFS working the same way
     // across Chrome, Edge, Safari and mobile Safari.
-    return handler.fetch(request, { context: {} });
+    const response = await handler.fetch(request, { context: {} });
+
+    // authenticate() may have refreshed an expiring session; hand the rotated
+    // cookie back to the browser or it keeps the stale token and refresh-token
+    // reuse eventually revokes the whole family. (Auth-less local dev has no
+    // admin object and nothing to merge.)
+    const setCookie = admin?.responseHeaders.get("set-cookie");
+    if (setCookie) {
+      const merged = new Response(response.body, response);
+      merged.headers.append("set-cookie", setCookie);
+      return merged;
+    }
+    return response;
   },
 });

--- a/envs.ts
+++ b/envs.ts
@@ -281,6 +281,12 @@ export interface StreamsExampleEnv {
   workerName: string;
   /** workers.dev origin (the account's workers.dev subdomain is fixed). */
   baseUrl: string;
+  /**
+   * The env's apps/auth deployment. The playground is a relying party of the
+   * same issuer as os: deploys bake the issuer's JWKS and requests
+   * authenticate with iterate sessions or bearer access tokens.
+   */
+  authBaseUrl: string;
 }
 
 function streamsExamplePreviewSlot(n: number): StreamsExampleEnv {
@@ -289,6 +295,7 @@ function streamsExamplePreviewSlot(n: number): StreamsExampleEnv {
     dopplerConfig: `preview_${n}`,
     workerName: `streams-example-app-preview-${n}`,
     baseUrl: `https://streams-example-app-preview-${n}.iterate-dev-preview.workers.dev`,
+    authBaseUrl: `https://auth.iterate-preview-${n}.com`,
   };
 }
 
@@ -298,6 +305,7 @@ export const streamsExampleEnvs = {
     dopplerConfig: "prd",
     workerName: "streams-example-app-prd",
     baseUrl: "https://streams-example-app-prd.iterate.workers.dev",
+    authBaseUrl: "https://auth.iterate.com",
   },
   preview_1: streamsExamplePreviewSlot(1),
   preview_2: streamsExamplePreviewSlot(2),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -759,6 +759,12 @@ importers:
 
   apps/streams-example-app:
     dependencies:
+      '@iterate-com/auth':
+        specifier: workspace:*
+        version: link:../auth
+      '@iterate-com/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       '@journeyapps/wa-sqlite':
         specifier: ^1.7.0
         version: 1.7.0
@@ -787,9 +793,6 @@ importers:
       '@cloudflare/workers-types':
         specifier: catalog:cloudflare
         version: 4.20260621.1(patch_hash=ae8908e1d45f2ea02ffeabf1230701598cc2878240ef700403ff76df72677af2)
-      '@iterate-com/shared':
-        specifier: workspace:*
-        version: link:../../packages/shared
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -1194,6 +1194,10 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
       "bash",
       "-c",
       [
+        // Deployed playgrounds are admin-only: the node vitest lane rides a
+        // forge-minted admin bearer (e2e/auth.ts); Playwright signs itself in
+        // via its global setup.
+        'export STREAMS_PLAYGROUND_TOKEN="$(pnpm exec tsx e2e/auth.ts)"',
         "pnpm exec playwright install chromium & install_pid=$!",
         "STREAM_STAGING_E2E=true pnpm vitest -t @preview & vitest_pid=$!",
         "install_status=0",
@@ -2228,16 +2232,19 @@ async function ensureAuthPreviewConfigs(input: { rotate: boolean }) {
   setDopplerSecrets("auth", "preview", rootValues);
   console.log("auth/preview root config ensured");
 
-  // Semaphore is a relying party of each slot's auth deployment: its deploys
-  // bake the forge public key into the JWKS, and its e2e mints admin bearer
-  // tokens with the private half. Seed the key once at the preview root so
-  // every preview_N branch config inherits it.
+  // Semaphore and the streams playground are relying parties of each slot's
+  // auth deployment: their deploys bake the forge public key into the JWKS,
+  // and their e2e mints admin bearer tokens with the private half. Seed the
+  // key once at each preview root so every preview_N branch config inherits
+  // it.
   const forgePrivateJwk =
     getDopplerSecret("semaphore", "preview", "AUTH_FORGE_PRIVATE_JWK") ||
     getDopplerSecret("os", "preview", "AUTH_FORGE_PRIVATE_JWK");
   if (!forgePrivateJwk) throw new Error("os/preview is missing AUTH_FORGE_PRIVATE_JWK");
   setDopplerSecrets("semaphore", "preview", { AUTH_FORGE_PRIVATE_JWK: forgePrivateJwk });
   console.log("semaphore/preview root config ensured");
+  setDopplerSecrets("streams-example-app", "preview", { AUTH_FORGE_PRIVATE_JWK: forgePrivateJwk });
+  console.log("streams-example-app/preview root config ensured");
 
   const workersSubdomain = await getWorkersDevSubdomain("streams-example-app", "preview");
   for (const slot of previewEnvironmentSlotNumbers) {
@@ -2248,6 +2255,7 @@ async function ensureAuthPreviewConfigs(input: { rotate: boolean }) {
     const streamsExampleOrigin = `https://streams-example-app-preview-${slot}.${workersSubdomain}.workers.dev`;
     const clientId = `os-preview-${slot}`;
     const semaphoreClientId = `semaphore-preview-${slot}`;
+    const streamsExampleClientId = `streams-example-app-preview-${slot}`;
 
     ensureDopplerConfig("auth", config);
     ensureDopplerConfig("semaphore", config);
@@ -2263,6 +2271,9 @@ async function ensureAuthPreviewConfigs(input: { rotate: boolean }) {
       parsedSeed.find((client) => client.clientId === clientId)?.clientSecret || freshSecret();
     const semaphoreClientSecret =
       parsedSeed.find((client) => client.clientId === semaphoreClientId)?.clientSecret ||
+      freshSecret();
+    const streamsExampleClientSecret =
+      parsedSeed.find((client) => client.clientId === streamsExampleClientId)?.clientSecret ||
       freshSecret();
 
     const existingServiceToken = input.rotate
@@ -2291,6 +2302,14 @@ async function ensureAuthPreviewConfigs(input: { rotate: boolean }) {
         referenceId: `semaphore:${config}:web`,
         skipConsent: true,
       },
+      {
+        clientId: streamsExampleClientId,
+        clientSecret: streamsExampleClientSecret,
+        clientName: `Streams playground preview ${slot} web`,
+        redirectURIs: [`${streamsExampleOrigin}/api/iterate-auth/callback`],
+        referenceId: `streams-example-app:${config}:web`,
+        skipConsent: true,
+      },
     ]);
 
     setDopplerSecrets("auth", config, {
@@ -2317,6 +2336,8 @@ async function ensureAuthPreviewConfigs(input: { rotate: boolean }) {
 
     setDopplerSecrets("streams-example-app", config, {
       APP_CONFIG_BASE_URL: streamsExampleOrigin,
+      APP_CONFIG_ITERATE_AUTH__CLIENT_ID: streamsExampleClientId,
+      APP_CONFIG_ITERATE_AUTH__CLIENT_SECRET: streamsExampleClientSecret,
     });
 
     if (input.rotate) {
@@ -2324,7 +2345,7 @@ async function ensureAuthPreviewConfigs(input: { rotate: boolean }) {
     }
 
     console.log(
-      `slot ${slot}: auth/${config} + os/${config} + semaphore/${config} + streams-example-app/${config} ensured (clients ${clientId}, ${semaphoreClientId})`,
+      `slot ${slot}: auth/${config} + os/${config} + semaphore/${config} + streams-example-app/${config} ensured (clients ${clientId}, ${semaphoreClientId}, ${streamsExampleClientId})`,
     );
   }
 


### PR DESCRIPTION
## What

Follow-up to #1656: **apps/streams-example-app** becomes a relying party of the env's auth worker. Until now, its deployed workers (on the **production Cloudflare account**) handed every anonymous visitor `trustedInternalAuthContext()` over `/api/streams` — full read/write/kill/reset on persistent Durable Objects.

### Access model (deployed envs)
- **UI**: signed-out visitors redirect through `/api/iterate-auth/login` and back; signed-in non-admins get a sign-out page. Static assets stay public (client code only).
- **`/api/streams`** (capnweb, HTTP + WebSocket): iterate-admin required via the `iterate_session` cookie (rides the WS upgrade), an `Authorization: Bearer` access token, or — since browser WebSockets can't set headers — an `access_token` query param (RFC 6750 §2.3), accepted on this path only.
- **Local dev**: no `iterateAuth` config → the historical auth-less playground, unchanged.

### Plumbing (all reused from the #1656 cutover)
- Deploys bake the static auth JWKS (issuer keys + forge public key) via `scripts/lib/bake-auth-jwks.ts` and require the OAuth client secrets; `StreamsExampleEnv` gains `authBaseUrl`.
- E2e self-authenticates against deployed envs: the vitest lane forge-mints an admin bearer (`e2e/auth.ts`; the URL helper appends it to WS URLs), Playwright signs in once via a `session-from-token` global setup and reuses the storage state. Spec bodies untouched; local runs unchanged.
- Auth worker: playground origins added to `validAudiences` and logout return-to origins.
- Provisioning **already done** (no CI race): all 9 preview slots have `streams-example-app-preview-N` OAuth clients + the forge key; prd client `ADWuDkvgjrmUUUxagoIBlLjgToLqYFim` is live on auth-prd with the forge key mirrored into `streams-example-app/prd`.

## Verification (local worker with auth configured)
- signed-out page → 302 to login; login → 302 to the issuer's authorize URL
- unauthenticated and **non-admin** `/api/streams` → 401
- admin bearer via header and via query param, plus the session-cookie WS lane → full vitest e2e suite green (20 passed, 1 expected-fail)
- standard auth-less local Playwright suite: 25/26 (the one failure reproduces identically on unmodified main — pre-existing, unrelated)

## Rollout
Merging auto-deploys auth-prd (audience allowlist) and streams-example-app-prd. First deploy to each slot/prd has the usual one-time old→new edge-propagation window on e2e (retry if hit). No secrets to delete — this app never had any.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Closes anonymous admin-equivalent access to persistent stream Durable Objects on production workers.dev; auth/OAuth audience and token-query handling must be correct to avoid lockouts or residual exposure.
> 
> **Overview**
> **Deployed** `streams-example-app` workers stop being a public auth-less playground: they become an iterate-auth relying party (same pattern as semaphore), and only **iterate admins** reach the UI and `/api/streams` capnweb/DO surface. **Local dev** without `iterateAuth` config is unchanged.
> 
> The worker adds `/api/iterate-auth/*`, per-request config parsing, admin checks (session cookie or bearer), UI redirect/login and a 403 for signed-in non-admins, and **`access_token` query param** on `/api/streams` only for WebSocket/e2e. Deploys now require OAuth client secrets, bake static JWKS in `prepare`, and wrangler gains `authBaseUrl`-driven vars plus `global_fetch_strictly_public`.
> 
> **apps/auth** registers streams playground workers.dev origins in OAuth **valid audiences** and **logout return-to** allowlists via `getStreamsExampleResourceBases()`.
> 
> **E2e/preview**: forge-minted admin tokens (`e2e/auth.ts`), `STREAMS_PLAYGROUND_TOKEN` for vitest WS URLs, Playwright global setup + saved session for deployed targets; preview provisioning seeds OAuth clients, Doppler secrets, and forge keys for each slot (`scripts/preview/preview.ts`, `sync-auth-client.ts` for prd).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e87e0a4db95f98c1a4bb999744b4f6e062166ef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-06T13:45:17.431Z",
      "headSha": "7db110f40e050bce2884eb3b25980a2c95d8e91b",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/462781551189210",
      "shortSha": "7db110f",
      "cleanupDurationMs": 4544,
      "deployDurationMs": 52220,
      "testDurationMs": 91369,
      "testRetries": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-06T13:45:13.453Z",
      "headSha": "7db110f40e050bce2884eb3b25980a2c95d8e91b",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/462781551189210",
      "shortSha": "7db110f",
      "cleanupDurationMs": 561,
      "deployDurationMs": 19705,
      "testDurationMs": 6356,
      "testRetries": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-06T13:45:15.807Z",
      "headSha": "7db110f40e050bce2884eb3b25980a2c95d8e91b",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/462781551189210",
      "shortSha": "7db110f",
      "cleanupDurationMs": 2913,
      "deployDurationMs": 23035,
      "testDurationMs": 244,
      "testRetries": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-06T13:45:13.582Z",
      "headSha": "e87e0a4db95f98c1a4bb999744b4f6e062166ef1",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-2.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/473243604568797",
      "shortSha": "e87e0a4",
      "cleanupDurationMs": 685,
      "deployDurationMs": 12790,
      "testDurationMs": 16758,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `7db110f` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 23.0s | 244ms |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/462781551189210) | 2026-07-06T13:45:15.807Z | Preview app released. |
| OS | released | `7db110f` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 52.2s | 91.4s |  | 4.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/462781551189210) | 2026-07-06T13:45:17.431Z | Preview app released. |
| Semaphore | released | `7db110f` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 19.7s | 6.4s |  | 561ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/462781551189210) | 2026-07-06T13:45:13.453Z | Preview app released. |
| Streams Example App | released | `e87e0a4` | [https://streams-example-app-preview-2.iterate-dev-preview.workers.dev](https://streams-example-app-preview-2.iterate-dev-preview.workers.dev) | 12.8s | 16.8s |  | 685ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/473243604568797) | 2026-07-06T13:45:13.582Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->