### PR TITLE
[codex] Restore public event type docs

### DIFF
--- a/apps/os/scripts/deploy.ts
+++ b/apps/os/scripts/deploy.ts
@@ -91,6 +91,7 @@ export default async function deploy(
         ok: (status) => status === 200 || (status >= 300 && status < 400),
         label: "dashboard",
       },
+      { url: `${env.eventDocsBaseUrl}/`, ok: (status) => status === 200, label: "event docs" },
       { url: `${env.baseUrl}/api`, ok: (status) => status < 500, label: "os api" },
     ],
   });

--- a/apps/os/scripts/ensure-resources.ts
+++ b/apps/os/scripts/ensure-resources.ts
@@ -81,6 +81,7 @@ export default async function ensureResources(
   // records here (create-only; deploys never touch DNS).
   const hostRecords = [
     new URL(env.baseUrl).hostname,
+    new URL(env.eventDocsBaseUrl).hostname,
     new URL(env.mcpBaseUrl).hostname,
     ...env.projectHostnameBases.flatMap((base) => [base, `*.${base}`]),
   ];

--- a/apps/os/scripts/generate-wrangler-config.test.ts
+++ b/apps/os/scripts/generate-wrangler-config.test.ts
@@ -31,3 +31,12 @@ it("binds the os worker to its own env's builder sidecar", () => {
     expect(builderNames, envName).toContain(builder?.service);
   }
 });
+
+it("routes public event docs hosts to the os worker", () => {
+  const productionRoutes = config.env.prd.routes ?? [];
+
+  expect(productionRoutes).toContainEqual({
+    pattern: "events.iterate.com/*",
+    zone_name: "iterate.com",
+  });
+});

--- a/apps/os/scripts/generate-wrangler-config.ts
+++ b/apps/os/scripts/generate-wrangler-config.ts
@@ -189,9 +189,9 @@ function workerBindings(input: {
 }
 
 /**
- * Every hostname routed to the os worker: the app base URL, the MCP host,
- * and the project-host patterns. The zone is the hostname minus its first
- * label for app/MCP hosts; project bases are themselves zones.
+ * Every hostname routed to the os worker: the app base URL, public event docs,
+ * the MCP host, and the project-host patterns. The zone is the hostname minus
+ * its first label for app/MCP/event-docs hosts; project bases are themselves zones.
  *
  * Project bases get three patterns: `base/*`, `*.base/*`, and `*base/*`.
  * The catch-all `*base/*` should subsume the others, but the live preview
@@ -202,9 +202,11 @@ function workerBindings(input: {
 function routes(env: DeployedEnv) {
   const appHost = new URL(env.baseUrl).hostname;
   const mcpHost = new URL(env.mcpBaseUrl).hostname;
+  const eventDocsHost = new URL(env.eventDocsBaseUrl).hostname;
   const zoneOf = (host: string) => host.split(".").slice(1).join(".");
   return [
     { pattern: `${appHost}/*`, zone_name: zoneOf(appHost) },
+    { pattern: `${eventDocsHost}/*`, zone_name: zoneOf(eventDocsHost) },
     { pattern: `${mcpHost}/*`, zone_name: zoneOf(mcpHost) },
     ...env.projectHostnameBases.flatMap((base) => [
       { pattern: `${base}/*`, zone_name: base },

--- a/apps/os/src/components/event-docs-pages.tsx
+++ b/apps/os/src/components/event-docs-pages.tsx
@@ -26,10 +26,7 @@ export function EventDocsIndexPage(input: {
               <Link
                 key={event.type}
                 to="/$eventDocsProcessorSlug/$"
-                params={{
-                  eventDocsProcessorSlug: event.eventPath.split("/")[0] ?? event.eventPath,
-                  _splat: event.eventPath.split("/").slice(1).join("/"),
-                }}
+                params={event.routeParams}
                 className="block px-4 py-3 hover:bg-muted/60"
               >
                 <span className="block break-all font-mono text-sm text-foreground">
@@ -49,13 +46,13 @@ export function EventDocsIndexPage(input: {
           <div className="divide-y rounded-md border">
             {input.processorDocs.map((processor) => (
               <Link
-                key={processor.contract.slug}
+                key={processor.contractSlug}
                 to="/$eventDocsProcessorSlug"
-                params={{ eventDocsProcessorSlug: processor.docsPath }}
+                params={processor.routeParams}
                 className="block px-4 py-3 hover:bg-muted/60"
               >
                 <span className="block font-mono text-sm text-foreground">
-                  {processor.contract.slug}
+                  {processor.contractSlug}
                 </span>
                 <span className="mt-1 block text-xs text-muted-foreground">
                   {processor.events.length} owned event{processor.events.length === 1 ? "" : "s"}
@@ -74,8 +71,8 @@ export function ProcessorOverviewPage({ processor }: { processor: ProcessorDoc }
     <EventDocsShell>
       <EventDocsHeader
         eyebrow="Stream processor"
-        title={processor.contract.slug}
-        description={processor.contract.description}
+        title={processor.contractSlug}
+        description={processor.description}
       />
       <main className="grid gap-8 px-6 py-8 md:grid-cols-[minmax(0,1fr)_18rem] md:px-10">
         <section className="space-y-4">
@@ -88,10 +85,7 @@ export function ProcessorOverviewPage({ processor }: { processor: ProcessorDoc }
                   <Link
                     key={event.type}
                     to="/$eventDocsProcessorSlug/$"
-                    params={{
-                      eventDocsProcessorSlug: event.eventPath.split("/")[0] ?? event.eventPath,
-                      _splat: event.eventPath.split("/").slice(1).join("/"),
-                    }}
+                    params={event.routeParams}
                     className="block px-4 py-3 hover:bg-muted/60"
                   >
                     <span className="block break-all font-mono text-sm">{event.type}</span>
@@ -110,22 +104,22 @@ export function ProcessorOverviewPage({ processor }: { processor: ProcessorDoc }
         <aside className="space-y-4">
           <InfoList
             items={[
-              ["Version", processor.contract.version ?? "unversioned"],
+              ["Version", processor.version ?? "unversioned"],
               ["Public path", processor.href],
               ["Owned events", String(processor.events.length)],
             ]}
           />
-          {processor.processorDeps.length === 0 ? null : (
+          {processor.dependencies.length === 0 ? null : (
             <DocSection title="Dependencies">
               <div className="space-y-2">
-                {processor.processorDeps.map((dep) => (
+                {processor.dependencies.map((dep) => (
                   <Link
-                    key={dep.contract.slug}
+                    key={dep.contractSlug}
                     to="/$eventDocsProcessorSlug"
-                    params={{ eventDocsProcessorSlug: dep.docsPath }}
+                    params={dep.routeParams}
                     className="block rounded-md border px-3 py-2 font-mono text-sm hover:bg-muted/60"
                   >
-                    {dep.contract.slug}
+                    {dep.contractSlug}
                   </Link>
                 ))}
               </div>
@@ -167,17 +161,17 @@ export function EventDocPage({ event }: { event: EventDoc }) {
           <InfoList
             items={[
               ["URL path", event.href],
-              ["Processor", event.processor.contract.slug],
+              ["Processor", event.processor.contractSlug],
               ["Event path", event.eventPath],
             ]}
           />
           <DocSection title="Processor">
             <Link
               to="/$eventDocsProcessorSlug"
-              params={{ eventDocsProcessorSlug: event.processor.docsPath }}
+              params={event.processor.routeParams}
               className="block rounded-md border px-3 py-2 font-mono text-sm hover:bg-muted/60"
             >
-              {event.processor.contract.slug}
+              {event.processor.contractSlug}
             </Link>
           </DocSection>
         </aside>
@@ -219,7 +213,7 @@ function DocSection({ children, title }: { children: React.ReactNode; title: str
 }
 
 function EventReferenceList(input: {
-  events: readonly { href?: string; type: string }[];
+  events: readonly { href?: string; routeParams?: EventDoc["routeParams"]; type: string }[];
   title: string;
 }) {
   return (
@@ -229,14 +223,11 @@ function EventReferenceList(input: {
       ) : (
         <div className="divide-y rounded-md border">
           {input.events.map((event) =>
-            event.href ? (
+            event.href && event.routeParams ? (
               <Link
                 key={event.type}
                 to="/$eventDocsProcessorSlug/$"
-                params={{
-                  eventDocsProcessorSlug: event.href.replace(/^\/+/u, "").split("/")[0] ?? "",
-                  _splat: event.href.replace(/^\/+/u, "").split("/").slice(1).join("/"),
-                }}
+                params={event.routeParams}
                 className="block break-all px-4 py-3 font-mono text-sm hover:bg-muted/60"
               >
                 {event.type}

--- a/apps/os/src/components/event-docs-pages.tsx
+++ b/apps/os/src/components/event-docs-pages.tsx
@@ -1,0 +1,275 @@
+import { Link } from "@tanstack/react-router";
+import type { EventDoc, ProcessorDoc } from "~/lib/event-docs.ts";
+
+export function EventDocsIndexPage(input: {
+  eventDocs: readonly EventDoc[];
+  processorDocs: readonly ProcessorDoc[];
+}) {
+  return (
+    <EventDocsShell>
+      <header className="space-y-3 border-b px-6 py-8 md:px-10">
+        <p className="text-sm font-medium uppercase tracking-normal text-muted-foreground">
+          events.iterate.com
+        </p>
+        <h1 className="max-w-3xl text-3xl font-semibold tracking-normal text-foreground">
+          Event type reference
+        </h1>
+        <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+          Public documentation generated from the stream processor contracts in OS.
+        </p>
+      </header>
+      <main className="grid gap-8 px-6 py-8 md:grid-cols-[minmax(0,1fr)_18rem] md:px-10">
+        <section className="space-y-3">
+          <h2 className="text-sm font-semibold">Event types</h2>
+          <div className="divide-y rounded-md border">
+            {input.eventDocs.map((event) => (
+              <Link
+                key={event.type}
+                to="/$eventDocsProcessorSlug/$"
+                params={{
+                  eventDocsProcessorSlug: event.eventPath.split("/")[0] ?? event.eventPath,
+                  _splat: event.eventPath.split("/").slice(1).join("/"),
+                }}
+                className="block px-4 py-3 hover:bg-muted/60"
+              >
+                <span className="block break-all font-mono text-sm text-foreground">
+                  {event.type}
+                </span>
+                {event.description ? (
+                  <span className="mt-1 block text-sm text-muted-foreground">
+                    {event.description}
+                  </span>
+                ) : null}
+              </Link>
+            ))}
+          </div>
+        </section>
+        <aside className="space-y-3">
+          <h2 className="text-sm font-semibold">Processors</h2>
+          <div className="divide-y rounded-md border">
+            {input.processorDocs.map((processor) => (
+              <Link
+                key={processor.contract.slug}
+                to="/$eventDocsProcessorSlug"
+                params={{ eventDocsProcessorSlug: processor.docsPath }}
+                className="block px-4 py-3 hover:bg-muted/60"
+              >
+                <span className="block font-mono text-sm text-foreground">
+                  {processor.contract.slug}
+                </span>
+                <span className="mt-1 block text-xs text-muted-foreground">
+                  {processor.events.length} owned event{processor.events.length === 1 ? "" : "s"}
+                </span>
+              </Link>
+            ))}
+          </div>
+        </aside>
+      </main>
+    </EventDocsShell>
+  );
+}
+
+export function ProcessorOverviewPage({ processor }: { processor: ProcessorDoc }) {
+  return (
+    <EventDocsShell>
+      <EventDocsHeader
+        eyebrow="Stream processor"
+        title={processor.contract.slug}
+        description={processor.contract.description}
+      />
+      <main className="grid gap-8 px-6 py-8 md:grid-cols-[minmax(0,1fr)_18rem] md:px-10">
+        <section className="space-y-4">
+          <DocSection title="Owned event types">
+            {processor.events.length === 0 ? (
+              <p className="text-sm text-muted-foreground">This processor owns no event types.</p>
+            ) : (
+              <div className="divide-y rounded-md border">
+                {processor.events.map((event) => (
+                  <Link
+                    key={event.type}
+                    to="/$eventDocsProcessorSlug/$"
+                    params={{
+                      eventDocsProcessorSlug: event.eventPath.split("/")[0] ?? event.eventPath,
+                      _splat: event.eventPath.split("/").slice(1).join("/"),
+                    }}
+                    className="block px-4 py-3 hover:bg-muted/60"
+                  >
+                    <span className="block break-all font-mono text-sm">{event.type}</span>
+                    {event.description ? (
+                      <span className="mt-1 block text-sm text-muted-foreground">
+                        {event.description}
+                      </span>
+                    ) : null}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </DocSection>
+          <EventReferenceList title="Consumes" events={processor.consumes} />
+        </section>
+        <aside className="space-y-4">
+          <InfoList
+            items={[
+              ["Version", processor.contract.version ?? "unversioned"],
+              ["Public path", processor.href],
+              ["Owned events", String(processor.events.length)],
+            ]}
+          />
+          {processor.processorDeps.length === 0 ? null : (
+            <DocSection title="Dependencies">
+              <div className="space-y-2">
+                {processor.processorDeps.map((dep) => (
+                  <Link
+                    key={dep.contract.slug}
+                    to="/$eventDocsProcessorSlug"
+                    params={{ eventDocsProcessorSlug: dep.docsPath }}
+                    className="block rounded-md border px-3 py-2 font-mono text-sm hover:bg-muted/60"
+                  >
+                    {dep.contract.slug}
+                  </Link>
+                ))}
+              </div>
+            </DocSection>
+          )}
+        </aside>
+      </main>
+    </EventDocsShell>
+  );
+}
+
+export function EventDocPage({ event }: { event: EventDoc }) {
+  return (
+    <EventDocsShell>
+      <EventDocsHeader
+        eyebrow="Event type"
+        title={event.type}
+        description={event.description ?? "No description provided."}
+      />
+      <main className="grid gap-8 px-6 py-8 md:grid-cols-[minmax(0,1fr)_18rem] md:px-10">
+        <section className="space-y-6">
+          <DocSection title="Payload schema">
+            <JsonBlock value={event.payloadJsonSchema} />
+          </DocSection>
+          {event.examples.length === 0 ? null : (
+            <DocSection title="Examples">
+              <div className="space-y-4">
+                {event.examples.map((example) => (
+                  <div key={example.description} className="space-y-2">
+                    <p className="text-sm text-muted-foreground">{example.description}</p>
+                    <JsonBlock value={example.payload} />
+                  </div>
+                ))}
+              </div>
+            </DocSection>
+          )}
+        </section>
+        <aside className="space-y-4">
+          <InfoList
+            items={[
+              ["URL path", event.href],
+              ["Processor", event.processor.contract.slug],
+              ["Event path", event.eventPath],
+            ]}
+          />
+          <DocSection title="Processor">
+            <Link
+              to="/$eventDocsProcessorSlug"
+              params={{ eventDocsProcessorSlug: event.processor.docsPath }}
+              className="block rounded-md border px-3 py-2 font-mono text-sm hover:bg-muted/60"
+            >
+              {event.processor.contract.slug}
+            </Link>
+          </DocSection>
+        </aside>
+      </main>
+    </EventDocsShell>
+  );
+}
+
+function EventDocsShell({ children }: { children: React.ReactNode }) {
+  return <div className="min-h-screen bg-background text-foreground">{children}</div>;
+}
+
+function EventDocsHeader(input: { description?: string; eyebrow: string; title: string }) {
+  return (
+    <header className="space-y-3 border-b px-6 py-8 md:px-10">
+      <Link to="/" className="text-sm text-muted-foreground hover:text-foreground">
+        events.iterate.com
+      </Link>
+      <p className="text-sm font-medium uppercase tracking-normal text-muted-foreground">
+        {input.eyebrow}
+      </p>
+      <h1 className="max-w-4xl break-words font-mono text-2xl font-semibold tracking-normal text-foreground">
+        {input.title}
+      </h1>
+      {input.description ? (
+        <p className="max-w-3xl text-sm leading-6 text-muted-foreground">{input.description}</p>
+      ) : null}
+    </header>
+  );
+}
+
+function DocSection({ children, title }: { children: React.ReactNode; title: string }) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-sm font-semibold">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function EventReferenceList(input: {
+  events: readonly { href?: string; type: string }[];
+  title: string;
+}) {
+  return (
+    <DocSection title={input.title}>
+      {input.events.length === 0 ? (
+        <p className="text-sm text-muted-foreground">None.</p>
+      ) : (
+        <div className="divide-y rounded-md border">
+          {input.events.map((event) =>
+            event.href ? (
+              <Link
+                key={event.type}
+                to="/$eventDocsProcessorSlug/$"
+                params={{
+                  eventDocsProcessorSlug: event.href.replace(/^\/+/u, "").split("/")[0] ?? "",
+                  _splat: event.href.replace(/^\/+/u, "").split("/").slice(1).join("/"),
+                }}
+                className="block break-all px-4 py-3 font-mono text-sm hover:bg-muted/60"
+              >
+                {event.type}
+              </Link>
+            ) : (
+              <div key={event.type} className="break-all px-4 py-3 font-mono text-sm">
+                {event.type}
+              </div>
+            ),
+          )}
+        </div>
+      )}
+    </DocSection>
+  );
+}
+
+function InfoList({ items }: { items: readonly [string, string][] }) {
+  return (
+    <dl className="divide-y rounded-md border text-sm">
+      {items.map(([label, value]) => (
+        <div key={label} className="space-y-1 px-3 py-2">
+          <dt className="text-xs text-muted-foreground">{label}</dt>
+          <dd className="break-all font-mono">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function JsonBlock({ value }: { value: unknown }) {
+  return (
+    <pre className="max-h-[32rem] overflow-auto rounded-md border bg-muted/40 p-4 text-xs leading-5">
+      <code>{JSON.stringify(value, null, 2)}</code>
+    </pre>
+  );
+}

--- a/apps/os/src/ingress.test.ts
+++ b/apps/os/src/ingress.test.ts
@@ -19,7 +19,7 @@ it("keeps the OS host on the app lane", async () => {
     url: "https://os.iterate-preview-2.com/projects/demo",
   });
 
-  expect(route).toMatchObject({ lane: "os" });
+  expect(route).toMatchObject({ lane: "os", hostKind: "dashboard" });
 });
 
 it("keeps the event docs host on the app lane", async () => {
@@ -30,7 +30,32 @@ it("keeps the event docs host on the app lane", async () => {
     url: "https://events.iterate-preview-2.com/stream/created",
   });
 
-  expect(route).toMatchObject({ lane: "os" });
+  expect(route).toMatchObject({ lane: "os", hostKind: "eventDocs" });
+});
+
+it("does not let api or project path lanes steal the event docs host", async () => {
+  for (const path of ["/api", "/api/admin-cookie", "/prj_123/increment"]) {
+    const route = await decideIngressRoute({
+      config: PREVIEW_CONFIG,
+      method: "GET",
+      resolvers: resolversThatShouldNotBeUsed(),
+      url: `https://events.iterate-preview-2.com${path}`,
+    });
+
+    expect(route).toMatchObject({ lane: "os", hostKind: "eventDocs" });
+  }
+});
+
+it("honors x-forwarded-host when classifying event docs hosts", async () => {
+  const route = await decideIngressRoute({
+    config: PREVIEW_CONFIG,
+    headers: { "x-forwarded-host": "events.iterate-preview-2.com" },
+    method: "GET",
+    resolvers: resolversThatShouldNotBeUsed(),
+    url: "https://os.iterate-preview-2.com/stream/created",
+  });
+
+  expect(route).toMatchObject({ lane: "os", hostKind: "eventDocs" });
 });
 
 it("treats the bare localhost project-host base as an OS app-host alias", async () => {

--- a/apps/os/src/ingress.test.ts
+++ b/apps/os/src/ingress.test.ts
@@ -22,6 +22,17 @@ it("keeps the OS host on the app lane", async () => {
   expect(route).toMatchObject({ lane: "os" });
 });
 
+it("keeps the event docs host on the app lane", async () => {
+  const route = await decideIngressRoute({
+    config: PREVIEW_CONFIG,
+    method: "GET",
+    resolvers: resolversThatShouldNotBeUsed(),
+    url: "https://events.iterate-preview-2.com/stream/created",
+  });
+
+  expect(route).toMatchObject({ lane: "os" });
+});
+
 it("treats the bare localhost project-host base as an OS app-host alias", async () => {
   const route = await decideIngressRoute({
     config: DEV_CONFIG,

--- a/apps/os/src/ingress.ts
+++ b/apps/os/src/ingress.ts
@@ -39,7 +39,7 @@ export type IngressResolvers = {
 };
 
 type IngressRoute =
-  | { lane: "os" }
+  | { lane: "os"; hostKind: "dashboard" | "eventDocs" }
   | { lane: "api" }
   | {
       lane: "project";
@@ -60,7 +60,10 @@ export async function decideIngressRoute(input: {
   const host = requestIngressHostFrom(headers, url);
   const bases = input.config.projectHostnameBases ?? [];
 
-  if (isOsHost({ baseUrl: input.config.baseUrl, bases, host, requestUrl: url })) {
+  const osHostKind = osHostKindFor({ baseUrl: input.config.baseUrl, bases, host, requestUrl: url });
+  if (osHostKind) {
+    if (osHostKind === "eventDocs") return { lane: "os", hostKind: osHostKind };
+
     const [head, ...pathSegments] = url.pathname.split("/").filter(Boolean);
     if (head !== undefined && head.startsWith("prj_")) {
       // The /prj_<id>/... path lane: the project worker sees the sub-path,
@@ -79,7 +82,7 @@ export async function decideIngressRoute(input: {
       });
     }
     if (isApiWorkerLanePath(url.pathname)) return { lane: "api" };
-    return { lane: "os" };
+    return { lane: "os", hostKind: osHostKind };
   }
 
   for (const candidate of parseProjectPlatformHosts({ bases, host })) {
@@ -158,29 +161,33 @@ function requestIngressHostFrom(headers: Headers, url: URL): string {
   );
 }
 
-function isOsHost(input: {
+function osHostKindFor(input: {
   baseUrl: string | undefined;
   bases: readonly string[];
   host: string;
   requestUrl: URL;
-}): boolean {
+}): "dashboard" | "eventDocs" | null {
   // No configured baseUrl (workers.dev previews): the request's own origin is
   // the app — same fallback the pre-migration router used.
   const appHostname = normalizeIngressHost(
     new URL(input.baseUrl ?? input.requestUrl.toString()).hostname,
   );
-  if (input.host === appHostname) return true;
+  if (input.host === appHostname) return "dashboard";
   if (
     isEventDocsHostname({
       appBaseUrl: input.baseUrl,
-      requestUrl: input.requestUrl.toString(),
+      requestHostname: input.host,
     })
   ) {
-    return true;
+    return "eventDocs";
   }
   // Local dev serves the app on the bare loopback base itself.
-  return input.bases.some((rawBase) => {
+  const isLocalAppHost = input.bases.some((rawBase) => {
     const base = normalizeIngressHost(normalizeProjectHostnameBase(rawBase));
-    return input.host === base && (base === "localhost" || base.endsWith(".localhost"));
+    if (input.host !== base || (base !== "localhost" && !base.endsWith(".localhost"))) {
+      return false;
+    }
+    return true;
   });
+  return isLocalAppHost ? "dashboard" : null;
 }

--- a/apps/os/src/ingress.ts
+++ b/apps/os/src/ingress.ts
@@ -28,6 +28,7 @@
  */
 import { normalizeIngressHost } from "~/ingress/host-headers.ts";
 import { parseProjectPlatformHosts } from "~/ingress/project-platform-host-routing.ts";
+import { isEventDocsHostname } from "~/lib/event-docs-host.ts";
 import { normalizeProjectHostnameBase } from "~/lib/project-host-routing.ts";
 
 export type IngressResolvers = {
@@ -169,6 +170,14 @@ function isOsHost(input: {
     new URL(input.baseUrl ?? input.requestUrl.toString()).hostname,
   );
   if (input.host === appHostname) return true;
+  if (
+    isEventDocsHostname({
+      appBaseUrl: input.baseUrl,
+      requestUrl: input.requestUrl.toString(),
+    })
+  ) {
+    return true;
+  }
   // Local dev serves the app on the bare loopback base itself.
   return input.bases.some((rawBase) => {
     const base = normalizeIngressHost(normalizeProjectHostnameBase(rawBase));

--- a/apps/os/src/lib/event-docs-host.test.ts
+++ b/apps/os/src/lib/event-docs-host.test.ts
@@ -20,7 +20,7 @@ describe("event docs host", () => {
     expect(
       isEventDocsHostname({
         appBaseUrl: "https://os.iterate-preview-3.com",
-        requestUrl: "https://events.iterate-preview-3.com/stream",
+        requestHostname: "events.iterate-preview-3.com",
       }),
     ).toBe(true);
   });

--- a/apps/os/src/lib/event-docs-host.test.ts
+++ b/apps/os/src/lib/event-docs-host.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { eventDocsHostnameForAppBaseUrl, isEventDocsHostname } from "~/lib/event-docs-host.ts";
+
+describe("event docs host", () => {
+  it("derives the production event docs host from the OS production host", () => {
+    expect(eventDocsHostnameForAppBaseUrl("https://os.iterate.com")).toBe("events.iterate.com");
+  });
+
+  it("derives sibling event docs hosts for preview OS hosts", () => {
+    expect(eventDocsHostnameForAppBaseUrl("https://os.iterate-preview-3.com")).toBe(
+      "events.iterate-preview-3.com",
+    );
+  });
+
+  it("does not derive a routed event docs host for localhost", () => {
+    expect(eventDocsHostnameForAppBaseUrl("http://localhost:5173")).toBeNull();
+  });
+
+  it("recognizes the configured event docs request host", () => {
+    expect(
+      isEventDocsHostname({
+        appBaseUrl: "https://os.iterate-preview-3.com",
+        requestUrl: "https://events.iterate-preview-3.com/stream",
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/os/src/lib/event-docs-host.ts
+++ b/apps/os/src/lib/event-docs-host.ts
@@ -1,0 +1,29 @@
+import { normalizeRequestHostname } from "~/lib/project-host-routing.ts";
+
+export const PRODUCTION_EVENT_DOCS_HOSTNAME = "events.iterate.com";
+
+export function eventDocsHostnameForAppBaseUrl(baseUrl: string | undefined) {
+  if (!baseUrl) return null;
+
+  const hostname = normalizeRequestHostname(new URL(baseUrl).hostname);
+  if (hostname.startsWith("localhost") || hostname === "127.0.0.1" || hostname === "::1") {
+    return null;
+  }
+
+  if (hostname === "os.iterate.com") return PRODUCTION_EVENT_DOCS_HOSTNAME;
+  if (hostname.startsWith("os.")) return `events.${hostname.slice("os.".length)}`;
+  return null;
+}
+
+export function isEventDocsHostname(input: {
+  appBaseUrl: string | undefined;
+  requestUrl: string | undefined;
+}) {
+  if (!input.requestUrl) return false;
+
+  const requestHostname = normalizeRequestHostname(new URL(input.requestUrl).hostname);
+  return (
+    requestHostname === PRODUCTION_EVENT_DOCS_HOSTNAME ||
+    requestHostname === eventDocsHostnameForAppBaseUrl(input.appBaseUrl)
+  );
+}

--- a/apps/os/src/lib/event-docs-host.ts
+++ b/apps/os/src/lib/event-docs-host.ts
@@ -1,6 +1,6 @@
 import { normalizeRequestHostname } from "~/lib/project-host-routing.ts";
 
-export const PRODUCTION_EVENT_DOCS_HOSTNAME = "events.iterate.com";
+const PRODUCTION_EVENT_DOCS_HOSTNAME = "events.iterate.com";
 
 export function eventDocsHostnameForAppBaseUrl(baseUrl: string | undefined) {
   if (!baseUrl) return null;

--- a/apps/os/src/lib/event-docs-host.ts
+++ b/apps/os/src/lib/event-docs-host.ts
@@ -17,11 +17,11 @@ export function eventDocsHostnameForAppBaseUrl(baseUrl: string | undefined) {
 
 export function isEventDocsHostname(input: {
   appBaseUrl: string | undefined;
-  requestUrl: string | undefined;
+  requestHostname: string | undefined;
 }) {
-  if (!input.requestUrl) return false;
+  if (!input.requestHostname) return false;
 
-  const requestHostname = normalizeRequestHostname(new URL(input.requestUrl).hostname);
+  const requestHostname = normalizeRequestHostname(input.requestHostname);
   return (
     requestHostname === PRODUCTION_EVENT_DOCS_HOSTNAME ||
     requestHostname === eventDocsHostnameForAppBaseUrl(input.appBaseUrl)

--- a/apps/os/src/lib/event-docs.test.ts
+++ b/apps/os/src/lib/event-docs.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  eventDocs,
+  getEventDocByPath,
+  getEventDocByType,
+  getProcessorDocByPath,
+  processorDocs,
+} from "~/lib/event-docs.ts";
+
+describe("event docs catalog", () => {
+  it("documents the stream processor at the public stream slug", () => {
+    const processor = getProcessorDocByPath("stream");
+
+    expect(processor?.slug).toBe("stream");
+    expect(processor?.contract.slug).toBe("core");
+    expect(processor?.href).toBe("/stream");
+  });
+
+  it("maps event URL paths to public docs pages", () => {
+    const event = getEventDocByPath("stream/created");
+
+    expect(event?.type).toBe("events.iterate.com/stream/created");
+    expect(event?.href).toBe("/stream/created");
+    expect(getEventDocByType("events.iterate.com/stream/created")).toBe(event);
+  });
+
+  it("keeps the stream/create alias navigable", () => {
+    expect(getEventDocByPath("stream/create")).toBe(getEventDocByPath("stream/created"));
+  });
+
+  it("builds a non-empty processor and event catalog", () => {
+    expect(processorDocs.length).toBeGreaterThan(5);
+    expect(eventDocs.length).toBeGreaterThan(10);
+  });
+});

--- a/apps/os/src/lib/event-docs.test.ts
+++ b/apps/os/src/lib/event-docs.test.ts
@@ -12,7 +12,7 @@ describe("event docs catalog", () => {
     const processor = getProcessorDocByPath("stream");
 
     expect(processor?.slug).toBe("stream");
-    expect(processor?.contract.slug).toBe("core");
+    expect(processor?.contractSlug).toBe("core");
     expect(processor?.href).toBe("/stream");
   });
 
@@ -21,6 +21,10 @@ describe("event docs catalog", () => {
 
     expect(event?.type).toBe("events.iterate.com/stream/created");
     expect(event?.href).toBe("/stream/created");
+    expect(event?.routeParams).toEqual({
+      eventDocsProcessorSlug: "stream",
+      _splat: "created",
+    });
     expect(getEventDocByType("events.iterate.com/stream/created")).toBe(event);
   });
 

--- a/apps/os/src/lib/event-docs.ts
+++ b/apps/os/src/lib/event-docs.ts
@@ -1,0 +1,271 @@
+import { z } from "zod";
+import { AgentProcessorContract } from "~/domains/agents/agent-processor-contract.ts";
+import { CloudflareAiProcessorContract } from "~/domains/agents/cloudflare-ai-processor-contract.ts";
+import { OpenAiWsProcessorContract } from "~/domains/agents/openai-ws-processor-contract.ts";
+import { CapabilityHostProcessorContract } from "~/domains/capability-host/capability-host-processor-contract.ts";
+import { SlackAgentProcessorContract } from "~/domains/integrations/slack-agent-processor-contract.ts";
+import { SlackProcessorContract } from "~/domains/integrations/slack-processor-contract.ts";
+import { ProjectProcessorContract } from "~/domains/projects/project-processor-contract.ts";
+import { RepoProcessorContract } from "~/domains/repos/repo-processor-contract.ts";
+import { SandboxProcessorContract } from "~/domains/sandboxes/sandbox-processor-contract.ts";
+import { SecretProcessorContract } from "~/domains/secrets/secret-processor-contract.ts";
+import { BrowserEventFeedContract } from "~/domains/streams/client-libraries/processors/browser-event-feed/contract.ts";
+import { BrowserRawEventsContract } from "~/domains/streams/client-libraries/processors/browser-raw-events/contract.ts";
+import { CoreProcessorContract } from "~/domains/streams/core-processor-contract.ts";
+
+const EVENT_TYPE_PREFIX = "events.iterate.com/";
+const EVENT_TYPE_URL_PREFIX = "https://events.iterate.com/";
+
+type EventDefinitionForDocs = {
+  description?: string;
+  examples?: unknown;
+  payloadSchema?: z.ZodType;
+};
+
+type ProcessorContractForDocs = {
+  consumes: readonly string[];
+  description?: string;
+  emits?: readonly string[];
+  events: Record<string, EventDefinitionForDocs>;
+  processorDeps?: readonly unknown[];
+  slug: string;
+  version?: string;
+};
+
+const processorContracts = [
+  CoreProcessorContract,
+  ProjectProcessorContract,
+  RepoProcessorContract,
+  AgentProcessorContract,
+  CloudflareAiProcessorContract,
+  OpenAiWsProcessorContract,
+  CapabilityHostProcessorContract,
+  SecretProcessorContract,
+  SandboxProcessorContract,
+  SlackProcessorContract,
+  SlackAgentProcessorContract,
+  BrowserRawEventsContract,
+  BrowserEventFeedContract,
+] as const satisfies readonly ProcessorContractForDocs[];
+
+export type EventDoc = {
+  description?: string;
+  eventPath: string;
+  eventSlug: string;
+  examples: EventExampleDoc[];
+  href: string;
+  payloadJsonSchema: unknown;
+  processor: ProcessorDoc;
+  type: string;
+};
+
+export type EventExampleDoc = {
+  description: string;
+  payload: unknown;
+};
+
+export type EventReferenceDoc = {
+  description?: string;
+  href?: string;
+  type: string;
+};
+
+export type ProcessorDoc = {
+  consumes: EventReferenceDoc[];
+  contract: ProcessorContractForDocs;
+  docsPath: string;
+  events: EventDoc[];
+  href: string;
+  processorDeps: ProcessorDoc[];
+  slug: string;
+  unresolvedConsumes: string[];
+  unresolvedEmits: string[];
+};
+
+export const processorDocs = buildProcessorDocs();
+export const eventDocs = processorDocs.flatMap((processor) => processor.events);
+
+const eventsByPath = new Map(eventDocs.map((event) => [event.eventPath, event]));
+const eventsByType = new Map(eventDocs.map((event) => [event.type, event]));
+const processorsByPath = new Map(processorDocs.map((processor) => [processor.docsPath, processor]));
+const processorsBySlug = new Map(
+  processorDocs.map((processor) => [processor.contract.slug, processor]),
+);
+
+const streamCreatedEvent = eventsByPath.get("stream/created");
+if (streamCreatedEvent) eventsByPath.set("stream/create", streamCreatedEvent);
+
+export function getProcessorDocByPath(path: string) {
+  const cleanPath = cleanEventPath(path);
+  return processorsByPath.get(cleanPath) ?? processorsBySlug.get(cleanPath);
+}
+
+export function getEventDocByPath(path: string) {
+  return eventsByPath.get(cleanEventPath(path));
+}
+
+export function getEventDocByType(type: string) {
+  return eventsByType.get(type);
+}
+
+function buildProcessorDocs(): ProcessorDoc[] {
+  const baseDocs = processorContracts.map((contract) => buildBaseProcessorDoc(contract));
+  const docsBySlug = new Map(baseDocs.map((processor) => [processor.contract.slug, processor]));
+  const eventReferencesByType = new Map(
+    baseDocs.flatMap((processor) =>
+      processor.events.map((event) => [
+        event.type,
+        {
+          type: event.type,
+          href: event.href,
+          description: event.description,
+        } satisfies EventReferenceDoc,
+      ]),
+    ),
+  );
+
+  return baseDocs.map((processor) => ({
+    ...processor,
+    consumes: resolveEventReferences({
+      eventReferencesByType,
+      types: processor.contract.consumes.filter((type) => type !== "*"),
+    }),
+    processorDeps: (processor.contract.processorDeps ?? [])
+      .map((dep) => (hasProcessorSlug(dep) ? docsBySlug.get(dep.slug) : undefined))
+      .filter((dep): dep is ProcessorDoc => dep != null),
+    unresolvedConsumes: processor.contract.consumes.filter(
+      (type) => type !== "*" && !eventReferencesByType.has(type),
+    ),
+    unresolvedEmits: (processor.contract.emits ?? []).filter(
+      (type) => !eventReferencesByType.has(type),
+    ),
+  }));
+}
+
+function buildBaseProcessorDoc(contract: ProcessorContractForDocs): ProcessorDoc {
+  const docsPath = processorDocsPath(contract);
+  const processor: ProcessorDoc = {
+    contract,
+    docsPath,
+    href: publicDocsPath(docsPath),
+    slug: docsPath,
+    events: [],
+    consumes: [],
+    processorDeps: [],
+    unresolvedConsumes: [],
+    unresolvedEmits: [],
+  };
+
+  processor.events = Object.entries(contract.events)
+    .map(([type, definition]) => buildEventDoc({ definition, processor, type }))
+    .sort((a, b) => a.eventPath.localeCompare(b.eventPath));
+
+  return processor;
+}
+
+function buildEventDoc(args: {
+  definition: EventDefinitionForDocs;
+  processor: ProcessorDoc;
+  type: string;
+}): EventDoc {
+  const eventPath = eventPathFromType(args.type);
+  const examples = eventExamples(args.definition.examples);
+  const [, ...eventSlugParts] = eventPath.split("/");
+  return {
+    ...(args.definition.description == null ? {} : { description: args.definition.description }),
+    eventPath,
+    eventSlug: eventSlugParts.join("/"),
+    examples,
+    href: publicDocsPath(eventPath),
+    payloadJsonSchema: eventPayloadJsonSchema({
+      examples,
+      payloadSchema: args.definition.payloadSchema,
+    }),
+    processor: args.processor,
+    type: args.type,
+  };
+}
+
+function resolveEventReferences(args: {
+  eventReferencesByType: ReadonlyMap<string, EventReferenceDoc>;
+  types: readonly string[];
+}) {
+  return args.types
+    .map((type) => args.eventReferencesByType.get(type))
+    .filter((event): event is EventReferenceDoc => event != null);
+}
+
+function eventPayloadJsonSchema(args: {
+  examples: readonly { payload: unknown }[];
+  payloadSchema: z.ZodType | undefined;
+}) {
+  if (!args.payloadSchema) return { description: "No payload schema defined." };
+
+  const jsonSchema = z.toJSONSchema(args.payloadSchema, {
+    io: "input",
+    unrepresentable: "any",
+  });
+
+  if (args.examples.length === 0) return jsonSchema;
+  if (typeof jsonSchema !== "object" || jsonSchema === null || Array.isArray(jsonSchema)) {
+    return jsonSchema;
+  }
+
+  return {
+    ...jsonSchema,
+    examples: args.examples.map((example) => example.payload),
+  };
+}
+
+function eventExamples(examples: unknown): EventExampleDoc[] {
+  if (!Array.isArray(examples)) return [];
+
+  return examples
+    .map((example) => {
+      if (
+        typeof example === "object" &&
+        example !== null &&
+        "description" in example &&
+        "payload" in example &&
+        typeof example.description === "string"
+      ) {
+        return {
+          description: example.description,
+          payload: example.payload,
+        };
+      }
+
+      return null;
+    })
+    .filter((example): example is EventExampleDoc => example != null);
+}
+
+function processorDocsPath(contract: ProcessorContractForDocs) {
+  const firstEventType = Object.keys(contract.events)[0];
+  if (!firstEventType) return contract.slug;
+  return eventPathFromType(firstEventType).split("/")[0] ?? contract.slug;
+}
+
+function eventPathFromType(type: string) {
+  if (type.startsWith(EVENT_TYPE_PREFIX)) {
+    return cleanEventPath(type.slice(EVENT_TYPE_PREFIX.length));
+  }
+  if (type.startsWith(EVENT_TYPE_URL_PREFIX)) {
+    return cleanEventPath(type.slice(EVENT_TYPE_URL_PREFIX.length));
+  }
+  return cleanEventPath(type);
+}
+
+function cleanEventPath(path: string) {
+  return path.replace(/^\/+|\/+$/g, "");
+}
+
+function publicDocsPath(path: string) {
+  return `/${cleanEventPath(path)}`;
+}
+
+function hasProcessorSlug(value: unknown): value is { slug: string } {
+  return (
+    typeof value === "object" && value !== null && "slug" in value && typeof value.slug === "string"
+  );
+}

--- a/apps/os/src/lib/event-docs.ts
+++ b/apps/os/src/lib/event-docs.ts
@@ -19,7 +19,7 @@ const EVENT_TYPE_URL_PREFIX = "https://events.iterate.com/";
 type EventDefinitionForDocs = {
   description?: string;
   examples?: unknown;
-  payloadSchema?: z.ZodType;
+  payloadSchema: z.ZodType;
 };
 
 type ProcessorContractForDocs = {
@@ -27,7 +27,7 @@ type ProcessorContractForDocs = {
   description?: string;
   emits?: readonly string[];
   events: Record<string, EventDefinitionForDocs>;
-  processorDeps?: readonly unknown[];
+  processorDeps?: readonly { slug: string }[];
   slug: string;
   version?: string;
 };
@@ -51,11 +51,11 @@ const processorContracts = [
 export type EventDoc = {
   description?: string;
   eventPath: string;
-  eventSlug: string;
   examples: EventExampleDoc[];
   href: string;
   payloadJsonSchema: unknown;
-  processor: ProcessorDoc;
+  processor: ProcessorReferenceDoc;
+  routeParams: EventRouteParams;
   type: string;
 };
 
@@ -67,19 +67,29 @@ export type EventExampleDoc = {
 export type EventReferenceDoc = {
   description?: string;
   href?: string;
+  routeParams?: EventRouteParams;
   type: string;
 };
 
-export type ProcessorDoc = {
+export type EventRouteParams = {
+  _splat: string;
+  eventDocsProcessorSlug: string;
+};
+
+export type ProcessorDoc = ProcessorReferenceDoc & {
   consumes: EventReferenceDoc[];
-  contract: ProcessorContractForDocs;
-  docsPath: string;
+  dependencies: ProcessorReferenceDoc[];
   events: EventDoc[];
+  version?: string;
+};
+
+export type ProcessorReferenceDoc = {
+  contractSlug: string;
+  description?: string;
+  docsPath: string;
   href: string;
-  processorDeps: ProcessorDoc[];
+  routeParams: { eventDocsProcessorSlug: string };
   slug: string;
-  unresolvedConsumes: string[];
-  unresolvedEmits: string[];
 };
 
 export const processorDocs = buildProcessorDocs();
@@ -88,8 +98,8 @@ export const eventDocs = processorDocs.flatMap((processor) => processor.events);
 const eventsByPath = new Map(eventDocs.map((event) => [event.eventPath, event]));
 const eventsByType = new Map(eventDocs.map((event) => [event.type, event]));
 const processorsByPath = new Map(processorDocs.map((processor) => [processor.docsPath, processor]));
-const processorsBySlug = new Map(
-  processorDocs.map((processor) => [processor.contract.slug, processor]),
+const processorsByContractSlug = new Map(
+  processorDocs.map((processor) => [processor.contractSlug, processor]),
 );
 
 const streamCreatedEvent = eventsByPath.get("stream/created");
@@ -97,7 +107,7 @@ if (streamCreatedEvent) eventsByPath.set("stream/create", streamCreatedEvent);
 
 export function getProcessorDocByPath(path: string) {
   const cleanPath = cleanEventPath(path);
-  return processorsByPath.get(cleanPath) ?? processorsBySlug.get(cleanPath);
+  return processorsByPath.get(cleanPath) ?? processorsByContractSlug.get(cleanPath);
 }
 
 export function getEventDocByPath(path: string) {
@@ -109,72 +119,68 @@ export function getEventDocByType(type: string) {
 }
 
 function buildProcessorDocs(): ProcessorDoc[] {
-  const baseDocs = processorContracts.map((contract) => buildBaseProcessorDoc(contract));
-  const docsBySlug = new Map(baseDocs.map((processor) => [processor.contract.slug, processor]));
-  const eventReferencesByType = new Map(
-    baseDocs.flatMap((processor) =>
-      processor.events.map((event) => [
-        event.type,
-        {
-          type: event.type,
-          href: event.href,
-          description: event.description,
-        } satisfies EventReferenceDoc,
-      ]),
-    ),
+  const references = processorContracts.map((contract) => processorReferenceDoc(contract));
+  const referencesByContractSlug = new Map(
+    references.map((processor) => [processor.contractSlug, processor]),
   );
+  const eventReferencesByType = new Map<string, EventReferenceDoc>();
 
-  return baseDocs.map((processor) => ({
-    ...processor,
-    consumes: resolveEventReferences({
-      eventReferencesByType,
-      types: processor.contract.consumes.filter((type) => type !== "*"),
-    }),
-    processorDeps: (processor.contract.processorDeps ?? [])
-      .map((dep) => (hasProcessorSlug(dep) ? docsBySlug.get(dep.slug) : undefined))
-      .filter((dep): dep is ProcessorDoc => dep != null),
-    unresolvedConsumes: processor.contract.consumes.filter(
-      (type) => type !== "*" && !eventReferencesByType.has(type),
-    ),
-    unresolvedEmits: (processor.contract.emits ?? []).filter(
-      (type) => !eventReferencesByType.has(type),
-    ),
-  }));
+  const docs = processorContracts.map((contract, index) => {
+    const processor = references[index];
+    const events = Object.entries(contract.events)
+      .map(([type, definition]) => buildEventDoc({ definition, processor, type }))
+      .sort((a, b) => a.eventPath.localeCompare(b.eventPath));
+
+    for (const event of events) {
+      eventReferencesByType.set(event.type, eventReferenceDoc(event));
+    }
+
+    return {
+      ...processor,
+      ...(contract.version == null ? {} : { version: contract.version }),
+      consumes: [],
+      dependencies: [],
+      events,
+    } satisfies ProcessorDoc;
+  });
+
+  return docs.map((processor, index) => {
+    const contract = processorContracts[index];
+    return {
+      ...processor,
+      consumes: contract.consumes
+        .filter((type) => type !== "*")
+        .map((type) => eventReferencesByType.get(type))
+        .filter((event): event is EventReferenceDoc => event != null),
+      dependencies: (contract.processorDeps ?? [])
+        .map((dep) => referencesByContractSlug.get(dep.slug))
+        .filter((dep): dep is ProcessorReferenceDoc => dep != null),
+    };
+  });
 }
 
-function buildBaseProcessorDoc(contract: ProcessorContractForDocs): ProcessorDoc {
+function processorReferenceDoc(contract: ProcessorContractForDocs): ProcessorReferenceDoc {
   const docsPath = processorDocsPath(contract);
-  const processor: ProcessorDoc = {
-    contract,
+  return {
+    ...(contract.description == null ? {} : { description: contract.description }),
+    contractSlug: contract.slug,
     docsPath,
     href: publicDocsPath(docsPath),
+    routeParams: { eventDocsProcessorSlug: docsPath },
     slug: docsPath,
-    events: [],
-    consumes: [],
-    processorDeps: [],
-    unresolvedConsumes: [],
-    unresolvedEmits: [],
   };
-
-  processor.events = Object.entries(contract.events)
-    .map(([type, definition]) => buildEventDoc({ definition, processor, type }))
-    .sort((a, b) => a.eventPath.localeCompare(b.eventPath));
-
-  return processor;
 }
 
 function buildEventDoc(args: {
   definition: EventDefinitionForDocs;
-  processor: ProcessorDoc;
+  processor: ProcessorReferenceDoc;
   type: string;
 }): EventDoc {
   const eventPath = eventPathFromType(args.type);
   const examples = eventExamples(args.definition.examples);
-  const [, ...eventSlugParts] = eventPath.split("/");
   return {
     ...(args.definition.description == null ? {} : { description: args.definition.description }),
     eventPath,
-    eventSlug: eventSlugParts.join("/"),
     examples,
     href: publicDocsPath(eventPath),
     payloadJsonSchema: eventPayloadJsonSchema({
@@ -182,25 +188,24 @@ function buildEventDoc(args: {
       payloadSchema: args.definition.payloadSchema,
     }),
     processor: args.processor,
+    routeParams: eventRouteParams(eventPath),
     type: args.type,
   };
 }
 
-function resolveEventReferences(args: {
-  eventReferencesByType: ReadonlyMap<string, EventReferenceDoc>;
-  types: readonly string[];
-}) {
-  return args.types
-    .map((type) => args.eventReferencesByType.get(type))
-    .filter((event): event is EventReferenceDoc => event != null);
+function eventReferenceDoc(event: EventDoc): EventReferenceDoc {
+  return {
+    ...(event.description == null ? {} : { description: event.description }),
+    href: event.href,
+    routeParams: event.routeParams,
+    type: event.type,
+  };
 }
 
 function eventPayloadJsonSchema(args: {
   examples: readonly { payload: unknown }[];
-  payloadSchema: z.ZodType | undefined;
+  payloadSchema: z.ZodType;
 }) {
-  if (!args.payloadSchema) return { description: "No payload schema defined." };
-
   const jsonSchema = z.toJSONSchema(args.payloadSchema, {
     io: "input",
     unrepresentable: "any",
@@ -256,16 +261,15 @@ function eventPathFromType(type: string) {
   return cleanEventPath(type);
 }
 
+function eventRouteParams(eventPath: string): EventRouteParams {
+  const [eventDocsProcessorSlug = eventPath, ...splatParts] = eventPath.split("/");
+  return { eventDocsProcessorSlug, _splat: splatParts.join("/") };
+}
+
 function cleanEventPath(path: string) {
   return path.replace(/^\/+|\/+$/g, "");
 }
 
 function publicDocsPath(path: string) {
   return `/${cleanEventPath(path)}`;
-}
-
-function hasProcessorSlug(value: unknown): value is { slug: string } {
-  return (
-    typeof value === "object" && value !== null && "slug" in value && typeof value.slug === "string"
-  );
 }

--- a/apps/os/src/lib/root-auth-snapshot.ts
+++ b/apps/os/src/lib/root-auth-snapshot.ts
@@ -6,7 +6,6 @@ import {
   normalizeRequestHostname,
   resolveProjectSlugFromHostname,
 } from "~/lib/project-host-routing.ts";
-import { isEventDocsHostname } from "~/lib/event-docs-host.ts";
 
 type RootAuthSnapshot = {
   authSession: PublicSessionResponse;
@@ -50,10 +49,7 @@ export const fetchRootAuthSnapshot: () => Promise<RootAuthSnapshot> = createServ
       baseUrl: context.config.baseUrl,
       requestUrl: context.rawRequest?.url,
     }),
-    isEventDocsHost: isEventDocsHostname({
-      appBaseUrl: context.config.baseUrl,
-      requestUrl: context.rawRequest?.url,
-    }),
+    isEventDocsHost: context.isEventDocsHost,
   };
 });
 

--- a/apps/os/src/lib/root-auth-snapshot.ts
+++ b/apps/os/src/lib/root-auth-snapshot.ts
@@ -6,6 +6,7 @@ import {
   normalizeRequestHostname,
   resolveProjectSlugFromHostname,
 } from "~/lib/project-host-routing.ts";
+import { isEventDocsHostname } from "~/lib/event-docs-host.ts";
 
 type RootAuthSnapshot = {
   authSession: PublicSessionResponse;
@@ -18,6 +19,7 @@ type RootAuthSnapshot = {
    * `?redirect=` return address.
    */
   appOrigin: string | undefined;
+  isEventDocsHost: boolean;
 };
 
 /**
@@ -46,6 +48,10 @@ export const fetchRootAuthSnapshot: () => Promise<RootAuthSnapshot> = createServ
     }),
     appOrigin: resolveAppOrigin({
       baseUrl: context.config.baseUrl,
+      requestUrl: context.rawRequest?.url,
+    }),
+    isEventDocsHost: isEventDocsHostname({
+      appBaseUrl: context.config.baseUrl,
       requestUrl: context.rawRequest?.url,
     }),
   };

--- a/apps/os/src/request-context.ts
+++ b/apps/os/src/request-context.ts
@@ -17,6 +17,7 @@ import type { Principal } from "~/auth/principal.ts";
 export interface RequestContext {
   /** Runtime config with `baseUrl` defaulted to the request origin. */
   config: AppConfig;
+  isEventDocsHost: boolean;
   log: SharedRequestLogger;
   rawRequest?: Request;
   /** `ExecutionContext.waitUntil`, for work that should outlive the response. */

--- a/apps/os/src/routeTree.gen.ts
+++ b/apps/os/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as AdminRouteImport } from './routes/admin'
 import { Route as AppRouteImport } from './routes/_app'
+import { Route as EventDocsProcessorSlugRouteImport } from './routes/$eventDocsProcessorSlug'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AdminIndexRouteImport } from './routes/admin/index'
 import { Route as SignUpSplatRouteImport } from './routes/sign-up.$'
@@ -23,6 +24,7 @@ import { Route as AdminReplRouteImport } from './routes/admin/repl'
 import { Route as AdminProjectsRouteImport } from './routes/admin/projects'
 import { Route as AppNewProjectRouteImport } from './routes/_app/new-project'
 import { Route as AppItxReplRouteImport } from './routes/_app/itx-repl'
+import { Route as EventDocsProcessorSlugSplatRouteImport } from './routes/$eventDocsProcessorSlug.$'
 import { Route as AdminStreamsRouteRouteImport } from './routes/admin/streams/route'
 import { Route as AppProjectsRouteRouteImport } from './routes/_app/projects/route'
 import { Route as AdminStreamsIndexRouteImport } from './routes/admin/streams/index'
@@ -54,6 +56,11 @@ const AdminRoute = AdminRouteImport.update({
 } as any)
 const AppRoute = AppRouteImport.update({
   id: '/_app',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const EventDocsProcessorSlugRoute = EventDocsProcessorSlugRouteImport.update({
+  id: '/$eventDocsProcessorSlug',
+  path: '/$eventDocsProcessorSlug',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -116,6 +123,12 @@ const AppItxReplRoute = AppItxReplRouteImport.update({
   path: '/itx-repl',
   getParentRoute: () => AppRoute,
 } as any)
+const EventDocsProcessorSlugSplatRoute =
+  EventDocsProcessorSlugSplatRouteImport.update({
+    id: '/$',
+    path: '/$',
+    getParentRoute: () => EventDocsProcessorSlugRoute,
+  } as any)
 const AdminStreamsRouteRoute = AdminStreamsRouteRouteImport.update({
   id: '/streams',
   path: '/streams',
@@ -253,9 +266,11 @@ const AppProjectsProjectSlugAgentsStreamsSplatRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/$eventDocsProcessorSlug': typeof EventDocsProcessorSlugRouteWithChildren
   '/admin': typeof AdminRouteWithChildren
   '/projects': typeof AppProjectsRouteRouteWithChildren
   '/admin/streams': typeof AdminStreamsRouteRouteWithChildren
+  '/$eventDocsProcessorSlug/$': typeof EventDocsProcessorSlugSplatRoute
   '/itx-repl': typeof AppItxReplRoute
   '/new-project': typeof AppNewProjectRoute
   '/admin/projects': typeof AdminProjectsRoute
@@ -291,6 +306,8 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/$eventDocsProcessorSlug': typeof EventDocsProcessorSlugRouteWithChildren
+  '/$eventDocsProcessorSlug/$': typeof EventDocsProcessorSlugSplatRoute
   '/itx-repl': typeof AppItxReplRoute
   '/new-project': typeof AppNewProjectRoute
   '/admin/projects': typeof AdminProjectsRoute
@@ -325,10 +342,12 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/$eventDocsProcessorSlug': typeof EventDocsProcessorSlugRouteWithChildren
   '/_app': typeof AppRouteWithChildren
   '/admin': typeof AdminRouteWithChildren
   '/_app/projects': typeof AppProjectsRouteRouteWithChildren
   '/admin/streams': typeof AdminStreamsRouteRouteWithChildren
+  '/$eventDocsProcessorSlug/$': typeof EventDocsProcessorSlugSplatRoute
   '/_app/itx-repl': typeof AppItxReplRoute
   '/_app/new-project': typeof AppNewProjectRoute
   '/admin/projects': typeof AdminProjectsRoute
@@ -366,9 +385,11 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/$eventDocsProcessorSlug'
     | '/admin'
     | '/projects'
     | '/admin/streams'
+    | '/$eventDocsProcessorSlug/$'
     | '/itx-repl'
     | '/new-project'
     | '/admin/projects'
@@ -404,6 +425,8 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/$eventDocsProcessorSlug'
+    | '/$eventDocsProcessorSlug/$'
     | '/itx-repl'
     | '/new-project'
     | '/admin/projects'
@@ -437,10 +460,12 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/$eventDocsProcessorSlug'
     | '/_app'
     | '/admin'
     | '/_app/projects'
     | '/admin/streams'
+    | '/$eventDocsProcessorSlug/$'
     | '/_app/itx-repl'
     | '/_app/new-project'
     | '/admin/projects'
@@ -477,6 +502,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  EventDocsProcessorSlugRoute: typeof EventDocsProcessorSlugRouteWithChildren
   AppRoute: typeof AppRouteWithChildren
   AdminRoute: typeof AdminRouteWithChildren
   ApiSplatRoute: typeof ApiSplatRoute
@@ -501,6 +527,13 @@ declare module '@tanstack/react-router' {
       path: ''
       fullPath: '/'
       preLoaderRoute: typeof AppRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/$eventDocsProcessorSlug': {
+      id: '/$eventDocsProcessorSlug'
+      path: '/$eventDocsProcessorSlug'
+      fullPath: '/$eventDocsProcessorSlug'
+      preLoaderRoute: typeof EventDocsProcessorSlugRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -586,6 +619,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/itx-repl'
       preLoaderRoute: typeof AppItxReplRouteImport
       parentRoute: typeof AppRoute
+    }
+    '/$eventDocsProcessorSlug/$': {
+      id: '/$eventDocsProcessorSlug/$'
+      path: '/$'
+      fullPath: '/$eventDocsProcessorSlug/$'
+      preLoaderRoute: typeof EventDocsProcessorSlugSplatRouteImport
+      parentRoute: typeof EventDocsProcessorSlugRoute
     }
     '/admin/streams': {
       id: '/admin/streams'
@@ -751,6 +791,20 @@ declare module '@tanstack/react-router' {
   }
 }
 
+interface EventDocsProcessorSlugRouteChildren {
+  EventDocsProcessorSlugSplatRoute: typeof EventDocsProcessorSlugSplatRoute
+}
+
+const EventDocsProcessorSlugRouteChildren: EventDocsProcessorSlugRouteChildren =
+  {
+    EventDocsProcessorSlugSplatRoute: EventDocsProcessorSlugSplatRoute,
+  }
+
+const EventDocsProcessorSlugRouteWithChildren =
+  EventDocsProcessorSlugRoute._addFileChildren(
+    EventDocsProcessorSlugRouteChildren,
+  )
+
 interface AppProjectsProjectSlugRouteRouteChildren {
   AppProjectsProjectSlugIntegrationsRoute: typeof AppProjectsProjectSlugIntegrationsRoute
   AppProjectsProjectSlugReactivityRoute: typeof AppProjectsProjectSlugReactivityRoute
@@ -879,6 +933,7 @@ const AdminRouteWithChildren = AdminRoute._addFileChildren(AdminRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  EventDocsProcessorSlugRoute: EventDocsProcessorSlugRouteWithChildren,
   AppRoute: AppRouteWithChildren,
   AdminRoute: AdminRouteWithChildren,
   ApiSplatRoute: ApiSplatRoute,

--- a/apps/os/src/router-context.ts
+++ b/apps/os/src/router-context.ts
@@ -15,6 +15,8 @@ export type RouterContext = {
   queryClient: QueryClient;
   authSession?: PublicSessionResponse;
   authError?: SignInAuthError;
+  appOrigin?: string;
   currentProjectHostSlug?: string | null;
+  isEventDocsHost?: boolean;
   iterateAuthIssuer?: string;
 };

--- a/apps/os/src/routes/$eventDocsProcessorSlug.$.tsx
+++ b/apps/os/src/routes/$eventDocsProcessorSlug.$.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { EventDocPage } from "~/components/event-docs-pages.tsx";
+import { getEventDocByPath } from "~/lib/event-docs.ts";
+
+export const Route = createFileRoute("/$eventDocsProcessorSlug/$")({
+  beforeLoad: ({ context }) => {
+    if (!context.isEventDocsHost) throw notFound();
+  },
+  component: EventDocsEventRoute,
+});
+
+function EventDocsEventRoute() {
+  const { _splat, eventDocsProcessorSlug } = Route.useParams();
+  if (!_splat) throw notFound();
+  const event = getEventDocByPath(`${eventDocsProcessorSlug}/${_splat}`);
+  if (!event) throw notFound();
+  return <EventDocPage event={event} />;
+}

--- a/apps/os/src/routes/$eventDocsProcessorSlug.tsx
+++ b/apps/os/src/routes/$eventDocsProcessorSlug.tsx
@@ -1,0 +1,20 @@
+import { Outlet, createFileRoute, notFound, useMatches } from "@tanstack/react-router";
+import { ProcessorOverviewPage } from "~/components/event-docs-pages.tsx";
+import { getProcessorDocByPath } from "~/lib/event-docs.ts";
+
+export const Route = createFileRoute("/$eventDocsProcessorSlug")({
+  beforeLoad: ({ context }) => {
+    if (!context.isEventDocsHost) throw notFound();
+  },
+  component: EventDocsProcessorRoute,
+});
+
+function EventDocsProcessorRoute() {
+  const matches = useMatches();
+  const { eventDocsProcessorSlug } = Route.useParams();
+  if (matches.at(-1)?.routeId === "/$eventDocsProcessorSlug/$") return <Outlet />;
+
+  const processor = getProcessorDocByPath(eventDocsProcessorSlug);
+  if (!processor) throw notFound();
+  return <ProcessorOverviewPage processor={processor} />;
+}

--- a/apps/os/src/routes/__root.tsx
+++ b/apps/os/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import {
   Outlet,
   Scripts,
   createRootRouteWithContext,
+  notFound,
   useHydrated,
 } from "@tanstack/react-router";
 import { extractPublicConfigSchema } from "@iterate-com/shared/config";
@@ -35,8 +36,12 @@ const rootAuthSnapshotQueryOptions = {
 };
 
 export const Route = createRootRouteWithContext<RouterContext>()({
-  beforeLoad: async ({ context }) => {
-    return await context.queryClient.ensureQueryData(rootAuthSnapshotQueryOptions);
+  beforeLoad: async ({ context, location }) => {
+    const snapshot = await context.queryClient.ensureQueryData(rootAuthSnapshotQueryOptions);
+    if (snapshot.isEventDocsHost && !isPotentialEventDocsPagePath(location.pathname)) {
+      throw notFound();
+    }
+    return snapshot;
   },
   loader: async ({ context }) => {
     const config = PublicConfigSchema.parse(JSON.parse(await getPublicConfigServerFn()));
@@ -65,6 +70,20 @@ export const Route = createRootRouteWithContext<RouterContext>()({
   // https://github.com/TanStack/router/blob/main/examples/react/start-basic/src/routes/__root.tsx
   notFoundComponent: () => <DefaultNotFoundComponent />,
 });
+
+const EVENT_DOCS_RESERVED_ROOT_SEGMENTS = new Set([
+  "admin",
+  "api",
+  "posthog-proxy",
+  "projects",
+  "sign-in",
+  "sign-up",
+]);
+
+function isPotentialEventDocsPagePath(pathname: string) {
+  const [head] = pathname.split("/").filter(Boolean);
+  return head == null || !EVENT_DOCS_RESERVED_ROOT_SEGMENTS.has(head);
+}
 
 function RootDocument({ children }: { children: ReactNode }) {
   const isHydrated = useHydrated();

--- a/apps/os/src/routes/index.tsx
+++ b/apps/os/src/routes/index.tsx
@@ -1,10 +1,16 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { requireAuthenticatedRootRedirectTargetFromSession } from "../lib/auth.ts";
+import { EventDocsIndexPage } from "~/components/event-docs-pages.tsx";
+import { eventDocs, processorDocs } from "~/lib/event-docs.ts";
 import { ONBOARDING_AGENT_PATH } from "~/lib/onboarding-agent.ts";
 import { getRootProjectRedirectServerFn } from "~/lib/project-server-fns.ts";
 
 export const Route = createFileRoute("/")({
   loader: async ({ context, location }) => {
+    if (context.isEventDocsHost) {
+      return { kind: "event-docs" as const };
+    }
+
     const target = requireAuthenticatedRootRedirectTargetFromSession(
       context.authSession,
       location,
@@ -44,5 +50,11 @@ export const Route = createFileRoute("/")({
       replace: true,
     });
   },
-  component: () => null,
+  component: IndexRoute,
 });
+
+function IndexRoute() {
+  const data = Route.useLoaderData();
+  if (data?.kind !== "event-docs") return null;
+  return <EventDocsIndexPage eventDocs={eventDocs} processorDocs={processorDocs} />;
+}

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -94,7 +94,7 @@ export default {
     const config = parseConfig(env);
 
     const mcpRequest = rewriteMcpHostRequest({ config, request });
-    if (mcpRequest) return await appFetch(mcpRequest, ctx, config);
+    if (mcpRequest) return await appFetch(mcpRequest, ctx, config, { isEventDocsHost: false });
 
     const route = await decideIngressRoute({
       config,
@@ -105,7 +105,9 @@ export default {
     });
     if (route.lane !== "os") return await apiFetch(request, ctx, config, route);
 
-    return await appFetch(request, ctx, config);
+    return await appFetch(request, ctx, config, {
+      isEventDocsHost: route.hostKind === "eventDocs",
+    });
   },
 };
 
@@ -114,7 +116,12 @@ export default {
  * /api routes (inbound MCP, health). Every request emits one structured
  * "wide event" log line.
  */
-async function appFetch(request: Request, ctx: ExecutionContext, config: AppConfig) {
+async function appFetch(
+  request: Request,
+  ctx: ExecutionContext,
+  config: AppConfig,
+  host: { isEventDocsHost: boolean },
+) {
   return withEvlog(
     { request, app: { name: "@iterate-com/os", slug: "os" }, config, executionCtx: ctx },
     async ({ log }) => {
@@ -127,6 +134,7 @@ async function appFetch(request: Request, ctx: ExecutionContext, config: AppConf
 
       const context: RequestContext = {
         config: requestConfig,
+        isEventDocsHost: host.isEventDocsHost,
         log,
         rawRequest: request,
         waitUntil: (promise) => ctx.waitUntil(promise),

--- a/envs.ts
+++ b/envs.ts
@@ -62,6 +62,8 @@ export interface DeployedEnv {
   baseUrl: string;
   /** MCP host origin, e.g. https://mcp.iterate.com */
   mcpBaseUrl: string;
+  /** Public event type docs origin, e.g. https://events.iterate.com */
+  eventDocsBaseUrl: string;
   /** Auth app origin, e.g. https://auth.iterate.com */
   authBaseUrl: string;
   /**
@@ -96,6 +98,7 @@ function previewSlot(n: number, resources: DeployedEnv["resources"]): DeployedEn
     authWorkerName: `auth-preview-${n}`,
     baseUrl: `https://os.iterate-preview-${n}.com`,
     mcpBaseUrl: `https://mcp.iterate-preview-${n}.com`,
+    eventDocsBaseUrl: `https://events.iterate-preview-${n}.com`,
     authBaseUrl: `https://auth.iterate-preview-${n}.com`,
     projectHostnameBases: [`iterate-preview-${n}.app`],
     resources,
@@ -110,6 +113,7 @@ export const envs = {
     authWorkerName: "auth-prd",
     baseUrl: "https://os.iterate.com",
     mcpBaseUrl: "https://mcp.iterate.com",
+    eventDocsBaseUrl: "https://events.iterate.com",
     authBaseUrl: "https://auth.iterate.com",
     projectHostnameBases: ["iterate.app"],
     resources: {


### PR DESCRIPTION
## What changed

Restores a light public event type reference on the OS app:

- Adds a contract-derived event docs catalog from current OS stream processor contracts.
- Serves public docs pages on `events.iterate.com` and sibling preview hosts such as `events.iterate-preview-3.com`.
- Adds public routes for `/`, `/<processor-or-namespace>`, and `/<event/type/path>` so event type identifiers resolve to readable pages.
- Keeps normal OS/project ingress behavior intact by routing only the derived event-docs host through the app lane.

## Why

The old event-docs portal was removed during the ITX/Alchemy reset, but the event naming contract still says `events.iterate.com/...` identifiers should resolve to documentation. This brings back the smallest useful version backed by the current processor contracts instead of resurrecting the removed docs portal.

## Validation

- `pnpm --dir apps/os exec vitest run src/lib/event-docs.test.ts src/lib/event-docs-host.test.ts src/ingress.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/os exec oxlint src/lib/event-docs.ts src/lib/event-docs-host.ts src/components/event-docs-pages.tsx src/routes/index.tsx 'src/routes/$eventDocsProcessorSlug.tsx' 'src/routes/$eventDocsProcessorSlug.$.tsx' src/ingress.ts src/lib/root-auth-snapshot.ts src/ingress.test.ts src/lib/event-docs.test.ts src/lib/event-docs-host.test.ts`
- `pnpm --dir apps/os exec oxfmt --check src/lib/event-docs.ts src/lib/event-docs-host.ts src/components/event-docs-pages.tsx src/routes/index.tsx 'src/routes/$eventDocsProcessorSlug.tsx' 'src/routes/$eventDocsProcessorSlug.$.tsx' src/ingress.ts src/lib/root-auth-snapshot.ts src/ingress.test.ts src/lib/event-docs.test.ts src/lib/event-docs-host.test.ts src/routeTree.gen.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core ingress routing and adds a new public hostname surface, but changes are read-only docs with explicit host gating and solid test coverage.
> 
> **Overview**
> Restores **public event type documentation** on dedicated `events.iterate.com` (and preview sibling) hosts, generated from existing stream processor contracts instead of a separate docs portal.
> 
> **Infra:** Adds `eventDocsBaseUrl` to deployed env config, Cloudflare worker routes, proxied DNS in `ensure-resources`, and a deploy smoke check for the docs origin.
> 
> **Routing:** Ingress now distinguishes `dashboard` vs `eventDocs` OS hosts; the event-docs host always stays on the app lane (including `/api` and `/prj_*` paths) and passes `isEventDocsHost` through request/router context.
> 
> **App:** New contract-derived catalog (`event-docs.ts`) with index, processor overview, and per-event pages (JSON Schema + examples); TanStack routes are gated to the event-docs host, with root reserved paths blocked on that host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cb3a0bc278daa71ff4aab9bb73b5e79a2d24af4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-06T18:31:55.608Z",
      "headSha": "4cb3a0bc278daa71ff4aab9bb73b5e79a2d24af4",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/52581941168376",
      "shortSha": "4cb3a0b",
      "cleanupDurationMs": 5121,
      "deployDurationMs": 62139,
      "testDurationMs": 97758,
      "testRetries": "1 retried: itx > Authenticated internal auth itx can create project and append to stream (vitest x1)"
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-06T18:31:53.567Z",
      "headSha": "4cb3a0bc278daa71ff4aab9bb73b5e79a2d24af4",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/52581941168376",
      "shortSha": "4cb3a0b",
      "cleanupDurationMs": 3077,
      "deployDurationMs": 19923,
      "testDurationMs": 557,
      "testRetries": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-06T18:31:51.436Z",
      "headSha": "4cb3a0bc278daa71ff4aab9bb73b5e79a2d24af4",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/52581941168376",
      "shortSha": "4cb3a0b",
      "cleanupDurationMs": 945,
      "deployDurationMs": 17503,
      "testDurationMs": 6358,
      "testRetries": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-06T18:31:51.832Z",
      "headSha": "4cb3a0bc278daa71ff4aab9bb73b5e79a2d24af4",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-6.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/52581941168376",
      "shortSha": "4cb3a0b",
      "cleanupDurationMs": 1339,
      "deployDurationMs": 15671,
      "testDurationMs": 16224,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `4cb3a0b` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 19.9s | 557ms |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/52581941168376) | 2026-07-06T18:31:53.567Z | Preview app released. |
| OS | released | `4cb3a0b` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 62.1s | 97.8s | 1 retried: itx > Authenticated internal auth itx can create project and append to stream (vitest x1) | 5.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/52581941168376) | 2026-07-06T18:31:55.608Z | Preview app released. |
| Semaphore | released | `4cb3a0b` | [https://semaphore.iterate-preview-6.com](https://semaphore.iterate-preview-6.com) | 17.5s | 6.4s |  | 945ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/52581941168376) | 2026-07-06T18:31:51.436Z | Preview app released. |
| Streams Example App | released | `4cb3a0b` | [https://streams-example-app-preview-6.iterate-dev-preview.workers.dev](https://streams-example-app-preview-6.iterate-dev-preview.workers.dev) | 15.7s | 16.2s |  | 1.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/52581941168376) | 2026-07-06T18:31:51.832Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->