### PR TITLE
Streams playground: sign-out link in the sidebar

### DIFF
--- a/apps/streams-example-app/src/routes/-stream-page.tsx
+++ b/apps/streams-example-app/src/routes/-stream-page.tsx
@@ -1145,7 +1145,27 @@ function StreamSidebar({
       />
       <InsertEventsTool streamStore={streamStore} streamPath={streamView.path} />
       <StreamControlTool snapshot={snapshot} streamStore={streamStore} />
+      <SidebarFooter />
     </aside>
+  );
+}
+
+/**
+ * Sign-out link. Deployed playgrounds are admin-only (iterate-auth relying
+ * party), so a signed-in operator always has somewhere to go; the link hits
+ * the relying-party logout handler, which clears the session and returns
+ * here. On auth-less local dev there is no handler, but the link is harmless.
+ */
+function SidebarFooter() {
+  return (
+    <div className="mt-4 border-t border-[#e8ebf0] pt-3 text-xs">
+      <a
+        className="text-[#6b7280] underline underline-offset-2 hover:text-[#111827]"
+        href="/api/iterate-auth/logout"
+      >
+        Sign out
+      </a>
+    </div>
   );
 }
 


### PR DESCRIPTION
Follow-up to #1678. Deployed playgrounds are admin-only, so once you sign in there's no way to sign out from the UI — you stay logged in permanently. This adds a **Sign out** link at the bottom of the stream sidebar, pointing at the relying-party logout handler (`/api/iterate-auth/logout`), which clears the session and returns to the app. No-op on auth-less local dev.

Verified against a local worker with auth configured: the link renders inside `#stream-sidebar` and the logout endpoint 302s to the auth worker's logout with return-to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only addition reusing an established logout URL; no auth or stream logic changes.
> 
> **Overview**
> Adds a **Sign out** control at the bottom of the streams playground sidebar so operators on deployed, admin-only environments can end their session from the UI.
> 
> A new `SidebarFooter` renders below the existing sidebar tools with a bordered footer and a link to `/api/iterate-auth/logout`, the same relying-party logout route used elsewhere in the monorepo. That handler clears the session and returns to the app; without auth in local dev the link is effectively a no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b867ac7db98dc22bc029699ed550d719d71eef5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-06T18:04:18.925Z",
      "headSha": "b867ac7db98dc22bc029699ed550d719d71eef5a",
      "message": "Preview app released.",
      "publicUrl": "https://streams-example-app-preview-3.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/327293689751842",
      "shortSha": "b867ac7",
      "cleanupDurationMs": 785,
      "deployDurationMs": 16506,
      "testDurationMs": 19425,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Streams Example App | released | `b867ac7` | [https://streams-example-app-preview-3.iterate-dev-preview.workers.dev](https://streams-example-app-preview-3.iterate-dev-preview.workers.dev) | 16.5s | 19.4s |  | 785ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/327293689751842) | 2026-07-06T18:04:18.925Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->