### PR TITLE
[codex] restore artifact event queue routing

### DIFF
--- a/apps/os/scripts/deploy.ts
+++ b/apps/os/scripts/deploy.ts
@@ -36,6 +36,7 @@ import {
   REQUIRED_SECRETS,
   writeWranglerConfig,
 } from "./generate-wrangler-config.ts";
+import { ensureWorkerEventsQueue } from "./event-queue-resources.ts";
 
 /** Deploy apps/os to a deployed environment (see scripts/lib/deploy-app.ts for the pipeline). */
 export default async function deploy(
@@ -67,6 +68,12 @@ export default async function deploy(
       // Parse the exact env the worker will see (secrets + generated vars) with
       // the worker's own schema — the strongest possible pre-flight.
       parseConfig({ ...secretValues, ...envShapedVars(ctx.env) });
+
+      // Wrangler validates queue consumers during deploy, so the queue itself
+      // has to exist before uploading a version that binds it. Artifact event
+      // subscriptions are reconciled by ensure-resources because they are
+      // account-level producer wiring, not a code deploy prerequisite.
+      await ensureWorkerEventsQueue(ctx, ctx.env.osWorkerName);
 
       // The builder sidecar deploys FIRST: the os worker's BUILDER service
       // binding is by name, and a binding to a not-yet-existing script fails

--- a/apps/os/scripts/ensure-resources.ts
+++ b/apps/os/scripts/ensure-resources.ts
@@ -3,12 +3,14 @@
  *
  *   pnpm ensure-resources --env preview_9
  *
- * Idempotent and create-only — it NEVER deletes anything. For each resource
- * (the project-directory KV, the auth D1 database, proxied DNS records for
- * every routed hostname) it creates whatever is missing, then compares
- * reality against the env's `resources` entry in envs.ts and prints the
- * exact snippet to paste when they differ. IDs live in git, so the last
- * step of bringing up a new env is always a reviewed commit.
+ * Idempotent and create-only for data-bearing resources. For each durable
+ * resource (the project-directory KV, the auth D1 database, proxied DNS
+ * records for every routed hostname) it creates whatever is missing, then
+ * compares reality against the env's `resources` entry in envs.ts and prints
+ * the exact snippet to paste when they differ. Event-subscription wiring may
+ * be recreated to repair destination/source drift; it carries no app data. IDs
+ * live in git, so the last step of bringing up a new env is always a reviewed
+ * commit.
  *
  * CI never runs this: a deploy with a missing/mismatched ID fails loudly and
  * tells you to run it yourself.
@@ -18,6 +20,7 @@ import { envs } from "../../../envs.ts";
 import { ensureD1, ensureProxiedDnsRecord } from "../../../scripts/lib/deploy-helpers.ts";
 import { resolveEnvContext } from "../../../scripts/lib/env-context.ts";
 import { reconcileResources } from "../../../scripts/lib/wrangler-config.ts";
+import { ensureWorkerEventQueueResources } from "./event-queue-resources.ts";
 
 /** Ensure apps/os's Cloudflare resources exist for an environment (create-only, idempotent). */
 export default async function ensureResources(
@@ -69,6 +72,12 @@ export default async function ensureResources(
     await cf(`/r2/buckets`, { method: "POST", body: JSON.stringify({ name: r2BucketName }) });
     console.log(`created R2 bucket ${r2BucketName}`);
   }
+
+  // ---- Queues: deployment event queue + Cloudflare Artifacts subscriptions -
+  // One general-purpose queue per OS worker. Artifacts event subscriptions are
+  // today's producer; future account-level event sources can share the same
+  // consumer and dispatch by message shape in src/domains/events.
+  await ensureWorkerEventQueueResources(ctx, env.osWorkerName);
 
   // ---- D1: auth database ------------------------------------------------------
   // apps/auth's ensure-resources also creates this database; both are

--- a/apps/os/scripts/event-queue-resources.ts
+++ b/apps/os/scripts/event-queue-resources.ts
@@ -1,0 +1,138 @@
+import { workerEventsQueueName } from "../src/queue-names.ts";
+import type { DeployableEnv, EnvContext } from "../../../scripts/lib/env-context.ts";
+
+type QueueResourceContext = Pick<EnvContext<DeployableEnv>, "cf">;
+
+type QueueRecord = {
+  queue_id: string;
+  queue_name: string;
+};
+
+export async function ensureWorkerEventsQueue(
+  ctx: QueueResourceContext,
+  workerName: string,
+): Promise<QueueRecord> {
+  return await ensureQueue(ctx, workerEventsQueueName(workerName));
+}
+
+export async function ensureWorkerEventQueueResources(
+  ctx: QueueResourceContext,
+  workerName: string,
+): Promise<QueueRecord> {
+  const eventQueue = await ensureWorkerEventsQueue(ctx, workerName);
+  await ensureArtifactEventSubscriptions(ctx, {
+    queueId: eventQueue.queue_id,
+    workerName,
+  });
+  return eventQueue;
+}
+
+async function ensureQueue(ctx: QueueResourceContext, queueName: string): Promise<QueueRecord> {
+  const queues = await ctx.cf<QueueRecord[]>(`/queues?per_page=1000`);
+  const existing = queues.find((queue) => queue.queue_name === queueName);
+  if (existing) {
+    console.log(`Queue ${queueName} exists (${existing.queue_id})`);
+    return existing;
+  }
+
+  const created = await ctx.cf<QueueRecord>(`/queues`, {
+    method: "POST",
+    body: JSON.stringify({ queue_name: queueName }),
+  });
+  console.log(`created Queue ${queueName} (${created.queue_id})`);
+  return created;
+}
+
+type DesiredArtifactEventSubscription = {
+  events: string[];
+  name: string;
+  source: Record<string, string>;
+};
+
+type ArtifactEventSubscription = {
+  destination?: { queue_id?: string; type?: string };
+  enabled?: boolean;
+  events?: string[];
+  id: string;
+  name?: string;
+  source?: Record<string, string | undefined>;
+};
+
+async function ensureArtifactEventSubscriptions(
+  ctx: QueueResourceContext,
+  input: { queueId: string; workerName: string },
+): Promise<void> {
+  const desired: DesiredArtifactEventSubscription[] = [
+    {
+      name: `${input.workerName}-artifact-account-events`,
+      source: { type: "artifacts" },
+      events: ["repo.created", "repo.deleted", "repo.forked", "repo.imported"],
+    },
+    {
+      name: `${input.workerName}-artifact-repo-events`,
+      source: {
+        type: "artifacts.repo",
+        namespace: `${input.workerName}-repos`,
+        repo_name: "*",
+      },
+      events: ["pushed", "cloned", "fetched"],
+    },
+  ];
+
+  const existing = await listArtifactEventSubscriptions(ctx);
+  for (const subscription of desired) {
+    const current = existing.find((candidate) => candidate.name === subscription.name);
+    if (current && artifactEventSubscriptionMatches(current, subscription, input.queueId)) {
+      console.log(`Artifact event subscription ${subscription.name} unchanged`);
+      continue;
+    }
+
+    if (current) {
+      await artifactEventSubscriptionsApi(ctx, "DELETE", `/${current.id}`);
+    }
+    await artifactEventSubscriptionsApi(ctx, "POST", "", {
+      name: subscription.name,
+      enabled: true,
+      source: subscription.source,
+      destination: { type: "queues.queue", queue_id: input.queueId },
+      events: subscription.events,
+    });
+    console.log(
+      `Artifact event subscription ${subscription.name} ${current ? "recreated" : "created"}`,
+    );
+  }
+}
+
+async function listArtifactEventSubscriptions(ctx: QueueResourceContext) {
+  return await artifactEventSubscriptionsApi<ArtifactEventSubscription[]>(
+    ctx,
+    "GET",
+    `?per_page=1000`,
+  );
+}
+
+function artifactEventSubscriptionMatches(
+  current: ArtifactEventSubscription,
+  desired: DesiredArtifactEventSubscription,
+  queueId: string,
+): boolean {
+  if (current.enabled !== true) return false;
+  if (current.destination?.type !== "queues.queue") return false;
+  if (current.destination.queue_id !== queueId) return false;
+  if ([...(current.events ?? [])].sort().join(",") !== [...desired.events].sort().join(",")) {
+    return false;
+  }
+  return Object.entries(desired.source).every(([key, value]) => current.source?.[key] === value);
+}
+
+async function artifactEventSubscriptionsApi<T = unknown>(
+  ctx: QueueResourceContext,
+  method: "DELETE" | "GET" | "POST",
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  return await ctx.cf<T>(`/event_subscriptions/subscriptions${path}`, {
+    method,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}

--- a/apps/os/scripts/generate-wrangler-config.ts
+++ b/apps/os/scripts/generate-wrangler-config.ts
@@ -23,6 +23,7 @@ import {
   OBSERVABILITY,
   writeGeneratedWranglerConfig,
 } from "../../../scripts/lib/wrangler-config.ts";
+import { workerEventsQueueName } from "../src/queue-names.ts";
 
 /**
  * Secrets every deployment MUST have (deploy.ts fails before uploading when
@@ -157,6 +158,17 @@ function workerBindings(input: {
     ai: { binding: "AI" },
     worker_loaders: [{ binding: "LOADER" }],
     artifacts: [{ binding: "ARTIFACTS", namespace: `${input.workerName}-repos` }],
+    queues: {
+      consumers: [
+        {
+          queue: workerEventsQueueName(input.workerName),
+          max_batch_size: 10,
+          max_batch_timeout: 5,
+          max_retries: 3,
+          retry_delay: 30,
+        },
+      ],
+    },
     // Sandbox workspace backups (ensure-resources.ts creates the bucket; the
     // sandbox DO snapshots /workspace here on idle and restores on start).
     // The binding MUST be named BACKUP_BUCKET — the Sandbox SDK reads it from

--- a/apps/os/src/domains/events/event-queue-entrypoint.ts
+++ b/apps/os/src/domains/events/event-queue-entrypoint.ts
@@ -1,0 +1,147 @@
+import type { Env } from "../../env.ts";
+import type { StreamEventInput } from "../../types.ts";
+import { DurableObjectNameCodec } from "../durable-object-names.ts";
+import { RepoArtifactNameCodec } from "../repos/utils.ts";
+import { workerEventsQueueName } from "../../queue-names.ts";
+
+export const GLOBAL_CLOUDFLARE_EVENTS_STREAM_PATH = "/cloudflare/events";
+export const CLOUDFLARE_EVENT_RECEIVED_TYPE = "events.iterate.com/cloudflare/event-received";
+export const REPO_CLOUDFLARE_ARTIFACT_EVENT_RECEIVED_TYPE =
+  "events.iterate.com/repo/cloudflare-artifact-event-received";
+
+type EventQueueEnv = Pick<Env, "ARTIFACTS_NAMESPACE" | "STREAM" | "WORKER_SELF">;
+
+export function isWorkerEventsQueue(queue: string, env: Pick<Env, "WORKER_SELF">): boolean {
+  return queue === workerEventsQueueName(env.WORKER_SELF);
+}
+
+export async function handleEventQueueBatch(
+  batch: MessageBatch,
+  env: EventQueueEnv,
+): Promise<void> {
+  if (!isWorkerEventsQueue(batch.queue, env)) {
+    console.warn(`[event-queue] received batch from unexpected queue ${batch.queue}`);
+  }
+
+  for (const message of batch.messages) {
+    try {
+      const cloudflareEvent = cloudflareEventFromMessageBody(message.body);
+      if (cloudflareEvent === null) {
+        console.warn(`[event-queue] ignoring unrecognized message ${message.id}`);
+        message.ack();
+        continue;
+      }
+
+      await appendRepoArtifactEventIfAddressable({ env, message, event: cloudflareEvent });
+      await appendCloudflareCapture({ env, message });
+      message.ack();
+    } catch (error) {
+      console.error(`[event-queue] failed to process message ${message.id}`, error);
+      message.retry();
+    }
+  }
+}
+
+function cloudflareEventFromMessageBody(body: unknown): Record<string, unknown> | null {
+  const event = asRecord(body);
+  if (event === null) return null;
+  if (typeof event.type !== "string" || !event.type.startsWith("cf.")) return null;
+  const source = asRecord(event.source);
+  if (source === null || typeof source.type !== "string") return null;
+  return event;
+}
+
+async function appendCloudflareCapture(input: {
+  env: EventQueueEnv;
+  message: Message;
+}): Promise<void> {
+  await appendToStream(
+    input.env,
+    { projectId: null, path: GLOBAL_CLOUDFLARE_EVENTS_STREAM_PATH },
+    {
+      type: CLOUDFLARE_EVENT_RECEIVED_TYPE,
+      idempotencyKey: `cf-event:${input.message.id}`,
+      payload: { body: input.message.body },
+    },
+  );
+}
+
+async function appendRepoArtifactEventIfAddressable(input: {
+  env: EventQueueEnv;
+  event: Record<string, unknown>;
+  message: Message;
+}): Promise<void> {
+  const artifactRepo = artifactRepoReferenceFromCloudflareEvent(input.event);
+  if (artifactRepo === null) return;
+  if (artifactRepo.namespace !== input.env.ARTIFACTS_NAMESPACE) return;
+
+  let streamAddress: { projectId: string | null; path: string };
+  try {
+    streamAddress = RepoArtifactNameCodec.parse(artifactRepo.repoName);
+  } catch (error) {
+    console.warn(
+      `[event-queue] artifact repo name is not addressable: ${artifactRepo.repoName}`,
+      error,
+    );
+    return;
+  }
+
+  const payload: Record<string, unknown> = {
+    artifactName: artifactRepo.repoName,
+    body: input.message.body,
+    namespace: artifactRepo.namespace,
+  };
+  const cloudflareEventType = typeof input.event.type === "string" ? input.event.type : undefined;
+  if (cloudflareEventType !== undefined) payload.cloudflareEventType = cloudflareEventType;
+
+  await appendToStream(input.env, streamAddress, {
+    type: REPO_CLOUDFLARE_ARTIFACT_EVENT_RECEIVED_TYPE,
+    idempotencyKey: `cf-artifact-event:${input.message.id}`,
+    payload,
+  });
+}
+
+function artifactRepoReferenceFromCloudflareEvent(
+  event: Record<string, unknown>,
+): { namespace: string; repoName: string } | null {
+  const eventType = typeof event.type === "string" ? event.type : undefined;
+  const payload = asRecord(event.payload);
+  if (eventType === "cf.artifacts.repo.forked") {
+    if (payload === null) return null;
+    const targetNamespace = readString(payload.namespace);
+    const targetRepoName = readString(payload.repoName) ?? readString(payload.repo_name);
+    if (targetNamespace !== null && targetRepoName !== null) {
+      return { namespace: targetNamespace, repoName: targetRepoName };
+    }
+    return null;
+  }
+
+  const source = asRecord(event.source);
+  if (source === null) return null;
+  const sourceType = readString(source.type);
+  if (sourceType !== "artifacts" && sourceType !== "artifacts.repo") return null;
+
+  const namespace = readString(source.namespace);
+  const repoName = readString(source.repoName) ?? readString(source.repo_name);
+  if (namespace === null || repoName === null) return null;
+  return { namespace, repoName };
+}
+
+function appendToStream(
+  env: Pick<Env, "STREAM">,
+  address: { projectId: string | null; path: string },
+  event: StreamEventInput,
+) {
+  return env.STREAM.getByName(
+    DurableObjectNameCodec.stringify(address, { allowNullProjectId: true }),
+  ).append(event);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}

--- a/apps/os/src/domains/events/event-queue-handler.test.ts
+++ b/apps/os/src/domains/events/event-queue-handler.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { Env } from "../../env.ts";
+import type { StreamEventInput } from "../../types.ts";
+import { DurableObjectNameCodec } from "../durable-object-names.ts";
+import { RepoArtifactNameCodec } from "../repos/utils.ts";
+import {
+  CLOUDFLARE_EVENT_RECEIVED_TYPE,
+  GLOBAL_CLOUDFLARE_EVENTS_STREAM_PATH,
+  REPO_CLOUDFLARE_ARTIFACT_EVENT_RECEIVED_TYPE,
+  handleEventQueueBatch,
+  isWorkerEventsQueue,
+} from "./event-queue-entrypoint.ts";
+
+type RecordedAppend = {
+  events: StreamEventInput[];
+  name: string;
+};
+
+function createEnv() {
+  const appends: RecordedAppend[] = [];
+  const env = {
+    ARTIFACTS_NAMESPACE: "os-prd-repos",
+    STREAM: {
+      getByName: vi.fn((name: string) => ({
+        append: vi.fn(async (...events: StreamEventInput[]) => {
+          appends.push({ name, events });
+          return [];
+        }),
+      })),
+    },
+    WORKER_SELF: "os-prd",
+  } as unknown as Pick<Env, "ARTIFACTS_NAMESPACE" | "STREAM" | "WORKER_SELF">;
+
+  return { appends, env };
+}
+
+function createMessage(body: unknown, id = "msg-1") {
+  return { id, body, ack: vi.fn(), retry: vi.fn(), timestamp: new Date(), attempts: 1 };
+}
+
+function createBatch(messages: ReturnType<typeof createMessage>[]) {
+  return { queue: "os-prd-events", messages } as unknown as MessageBatch;
+}
+
+function eventsFor(appends: RecordedAppend[], name: string): StreamEventInput[] {
+  return appends.filter((append) => append.name === name).flatMap((append) => append.events);
+}
+
+describe("event queue handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("recognizes the worker event queue", () => {
+    const { env } = createEnv();
+
+    expect(isWorkerEventsQueue("os-prd-events", env)).toBe(true);
+    expect(isWorkerEventsQueue("os-prd-artifact-events", env)).toBe(false);
+  });
+
+  test("captures Cloudflare events globally and fans artifact events out to the repo stream", async () => {
+    const { appends, env } = createEnv();
+    const artifactName = RepoArtifactNameCodec.stringify({
+      path: "/repos/project",
+      projectId: "prj_123",
+    });
+    const cfEvent = {
+      type: "cf.artifacts.repo.pushed",
+      source: { type: "artifacts.repo", namespace: "os-prd-repos", repoName: artifactName },
+      payload: { after: "bbb", before: "aaa", ref: "refs/heads/main" },
+    };
+    const message = createMessage(cfEvent, "msg-pushed");
+
+    await handleEventQueueBatch(createBatch([message]), env);
+
+    const globalName = DurableObjectNameCodec.stringify(
+      { path: GLOBAL_CLOUDFLARE_EVENTS_STREAM_PATH, projectId: null },
+      { allowNullProjectId: true },
+    );
+    const repoName = DurableObjectNameCodec.stringify({
+      path: "/repos/project",
+      projectId: "prj_123",
+    });
+    expect(eventsFor(appends, globalName)).toEqual([
+      {
+        type: CLOUDFLARE_EVENT_RECEIVED_TYPE,
+        idempotencyKey: "cf-event:msg-pushed",
+        payload: { body: cfEvent },
+      },
+    ]);
+    expect(eventsFor(appends, repoName)).toEqual([
+      {
+        type: REPO_CLOUDFLARE_ARTIFACT_EVENT_RECEIVED_TYPE,
+        idempotencyKey: "cf-artifact-event:msg-pushed",
+        payload: {
+          artifactName,
+          body: cfEvent,
+          cloudflareEventType: "cf.artifacts.repo.pushed",
+          namespace: "os-prd-repos",
+        },
+      },
+    ]);
+    expect(message.ack).toHaveBeenCalledOnce();
+    expect(message.retry).not.toHaveBeenCalled();
+  });
+
+  test("routes forked events to the target artifact repo when Cloudflare sends one", async () => {
+    const { appends, env } = createEnv();
+    const targetArtifactName = RepoArtifactNameCodec.stringify({
+      path: "/",
+      projectId: "prj_target",
+    });
+    const cfEvent = {
+      type: "cf.artifacts.repo.forked",
+      source: { type: "artifacts", namespace: "external-repos", repoName: "source-repo" },
+      payload: { namespace: "os-prd-repos", repoName: targetArtifactName },
+    };
+    const message = createMessage(cfEvent, "msg-forked");
+
+    await handleEventQueueBatch(createBatch([message]), env);
+
+    const repoName = DurableObjectNameCodec.stringify({ path: "/", projectId: "prj_target" });
+    expect(eventsFor(appends, repoName)).toEqual([
+      expect.objectContaining({
+        idempotencyKey: "cf-artifact-event:msg-forked",
+        type: REPO_CLOUDFLARE_ARTIFACT_EVENT_RECEIVED_TYPE,
+      }),
+    ]);
+    expect(message.ack).toHaveBeenCalledOnce();
+  });
+
+  test("does not route incomplete forked events to the source repo", async () => {
+    const { appends, env } = createEnv();
+    const sourceArtifactName = RepoArtifactNameCodec.stringify({
+      path: "/",
+      projectId: "prj_source",
+    });
+    const cfEvent = {
+      type: "cf.artifacts.repo.forked",
+      source: { type: "artifacts", namespace: "os-prd-repos", repoName: sourceArtifactName },
+      payload: { namespace: "os-prd-repos" },
+    };
+    const message = createMessage(cfEvent, "msg-incomplete-fork");
+
+    await handleEventQueueBatch(createBatch([message]), env);
+
+    const sourceRepoName = DurableObjectNameCodec.stringify({
+      path: "/",
+      projectId: "prj_source",
+    });
+    expect(eventsFor(appends, sourceRepoName)).toEqual([]);
+    expect(appends).toHaveLength(1);
+    expect(appends[0]!.events[0]).toEqual(
+      expect.objectContaining({ idempotencyKey: "cf-event:msg-incomplete-fork" }),
+    );
+    expect(message.ack).toHaveBeenCalledOnce();
+  });
+
+  test("captures but does not fan out events from another artifact namespace", async () => {
+    const { appends, env } = createEnv();
+    const cfEvent = {
+      type: "cf.artifacts.repo.pushed",
+      source: { type: "artifacts.repo", namespace: "os-preview-1-repos", repoName: "x--Lw" },
+    };
+    const message = createMessage(cfEvent, "msg-other-namespace");
+
+    await handleEventQueueBatch(createBatch([message]), env);
+
+    expect(appends).toHaveLength(1);
+    expect(appends[0]!.events[0]).toEqual(
+      expect.objectContaining({ idempotencyKey: "cf-event:msg-other-namespace" }),
+    );
+    expect(message.ack).toHaveBeenCalledOnce();
+  });
+
+  test("captures malformed artifact names without retrying poison messages", async () => {
+    const { appends, env } = createEnv();
+    const cfEvent = {
+      type: "cf.artifacts.repo.deleted",
+      source: { type: "artifacts", namespace: "os-prd-repos", repoName: "not-decodable" },
+    };
+    const message = createMessage(cfEvent, "msg-bad-name");
+
+    await handleEventQueueBatch(createBatch([message]), env);
+
+    expect(appends).toHaveLength(1);
+    expect(appends[0]!.events[0]).toEqual(
+      expect.objectContaining({ idempotencyKey: "cf-event:msg-bad-name" }),
+    );
+    expect(message.ack).toHaveBeenCalledOnce();
+    expect(message.retry).not.toHaveBeenCalled();
+  });
+
+  test("acknowledges unrecognized future queue messages without treating them as Cloudflare events", async () => {
+    const { appends, env } = createEnv();
+    const message = createMessage({ type: "internal.future", payload: { ok: true } }, "msg-future");
+
+    await handleEventQueueBatch(createBatch([message]), env);
+
+    expect(appends).toEqual([]);
+    expect(message.ack).toHaveBeenCalledOnce();
+    expect(message.retry).not.toHaveBeenCalled();
+  });
+
+  test("retries a message when stream append fails and keeps processing the rest", async () => {
+    const { env } = createEnv();
+    const first = createMessage(
+      {
+        type: "cf.artifacts.repo.created",
+        source: { type: "artifacts", namespace: "os-prd-repos", repoName: "global--Lw" },
+      },
+      "msg-fail",
+    );
+    const second = createMessage(
+      {
+        type: "cf.artifacts.repo.deleted",
+        source: { type: "artifacts", namespace: "os-prd-repos", repoName: "global--Lw" },
+      },
+      "msg-ok",
+    );
+    vi.mocked(env.STREAM.getByName).mockReturnValueOnce({
+      append: vi.fn(async () => {
+        throw new Error("stream unavailable");
+      }),
+    } as never);
+
+    await handleEventQueueBatch(createBatch([first, second]), env);
+
+    expect(first.retry).toHaveBeenCalledOnce();
+    expect(first.ack).not.toHaveBeenCalled();
+    expect(second.ack).toHaveBeenCalledOnce();
+    expect(second.retry).not.toHaveBeenCalled();
+  });
+
+  test("does not globally capture an addressable artifact event until repo fanout succeeds", async () => {
+    const { appends, env } = createEnv();
+    const artifactName = RepoArtifactNameCodec.stringify({
+      path: "/repos/project",
+      projectId: "prj_123",
+    });
+    const message = createMessage(
+      {
+        type: "cf.artifacts.repo.pushed",
+        source: { type: "artifacts.repo", namespace: "os-prd-repos", repoName: artifactName },
+      },
+      "msg-repo-fails",
+    );
+    vi.mocked(env.STREAM.getByName).mockReturnValueOnce({
+      append: vi.fn(async () => {
+        throw new Error("repo stream unavailable");
+      }),
+    } as never);
+
+    await handleEventQueueBatch(createBatch([message]), env);
+
+    expect(appends).toEqual([]);
+    expect(message.retry).toHaveBeenCalledOnce();
+    expect(message.ack).not.toHaveBeenCalled();
+  });
+});

--- a/apps/os/src/queue-names.ts
+++ b/apps/os/src/queue-names.ts
@@ -1,0 +1,5 @@
+const WORKER_EVENTS_QUEUE_SUFFIX = "-events";
+
+export function workerEventsQueueName(workerName: string): string {
+  return `${workerName}${WORKER_EVENTS_QUEUE_SUFFIX}`;
+}

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -35,6 +35,10 @@ import { handleCapnwebAdminCookieRequest } from "./auth/admin-auth-cookie.ts";
 import { rewriteMcpHostRequest } from "./ingress/mcp-host-rewrite.ts";
 import { AppConfig, parseConfig } from "./config.ts";
 import type { RequestContext } from "./request-context.ts";
+import {
+  handleEventQueueBatch,
+  isWorkerEventsQueue,
+} from "./domains/events/event-queue-entrypoint.ts";
 
 /** Long enough for warm-cache loads and quick bundles; past it, show the page. */
 const PROJECT_HOST_BUILD_BUDGET_MS = 15_000;
@@ -106,6 +110,15 @@ export default {
     if (route.lane !== "os") return await apiFetch(request, ctx, config, route);
 
     return await appFetch(request, ctx, config);
+  },
+
+  async queue(batch: MessageBatch, env: Env) {
+    if (isWorkerEventsQueue(batch.queue, env)) {
+      await handleEventQueueBatch(batch, env);
+      return;
+    }
+
+    console.warn(`[os] received queue batch from unhandled queue ${batch.queue}`);
   },
 };
 


### PR DESCRIPTION
## Summary

This PR restores the Cloudflare Event Subscriptions path for OS artifact updates, but brings it back as a general-purpose worker event queue rather than an artifact-only queue.

The new queue is named from the worker name: WORKER_SELF + "-events". For example, production uses an "os-prd-events" queue and preview slot 7 uses "os-preview-7-events". Cloudflare Artifacts is the first producer wired into it, but the queue name and consumer entrypoint are intentionally not artifact-specific so future event producers can share the same ingestion surface.

At a high level, the flow is:

~~~text
Cloudflare Artifacts event subscription
  -> Queue: <os worker name>-events
  -> apps/os worker queue() handler
  -> global stream: global.iterate/cloudflare/events
  -> optional repo stream fanout decoded from the artifact repo name
~~~

## What Changed

- Added a worker queue consumer for the general OS event queue in the generated Wrangler config.
- Added a queue entrypoint in the OS worker that processes batches from that queue.
- Added deploy-time queue creation, because Wrangler validates queue consumers before it will upload a worker version.
- Added ensure-resources wiring for Cloudflare Artifacts event subscriptions into the queue.
- Added global Cloudflare event capture on the deployment-wide stream path "/cloudflare/events".
- Added repo-stream fanout for addressable Cloudflare Artifacts repo events.
- Added focused tests for queue recognition, artifact routing, namespace filtering, fork target routing, poison-message behavior, retry behavior, and the ordering guarantees around repo fanout/global capture.

## Resource Setup

The generated OS Wrangler config now includes one consumer on the per-worker event queue:

~~~ts
queues: {
  consumers: [
    {
      queue: workerEventsQueueName(input.workerName),
      max_batch_size: 10,
      max_batch_timeout: 5,
      max_retries: 3,
      retry_delay: 30,
    },
  ],
}
~~~

The deploy script creates that queue before the final Wrangler deploy:

~~~ts
await ensureWorkerEventsQueue(ctx, ctx.env.osWorkerName);
~~~

That is deliberately in deploy, not only in ensure-resources, because a missing queue causes Wrangler deploy itself to fail before the worker can be uploaded.

ensure-resources still owns the account-level producer wiring. It ensures the same queue and reconciles these Cloudflare Artifacts subscriptions:

~~~ts
{
  name: "<worker>-artifact-account-events",
  source: { type: "artifacts" },
  events: ["repo.created", "repo.deleted", "repo.forked", "repo.imported"],
}

{
  name: "<worker>-artifact-repo-events",
  source: {
    type: "artifacts.repo",
    namespace: "<worker>-repos",
    repo_name: "*",
  },
  events: ["pushed", "cloned", "fetched"],
}
~~~

If a subscription with the expected name exists but points at the wrong queue, source, event list, or disabled state, ensure-resources deletes and recreates it. That wiring carries no application data, so recreate-on-drift is safer than silently leaving a stale destination in place.

## Queue Processing

The worker now exports a queue handler that delegates to the event queue entrypoint:

~~~ts
export default {
  async queue(batch, env) {
    await handleEventQueueBatch(batch, env);
  },
};
~~~

The handler currently recognizes Cloudflare Event Subscriptions payloads by shape: the body must be an object with a type beginning with "cf." and a source object with a string source.type. Unknown future queue messages are acknowledged and logged instead of being misclassified as Cloudflare events.

Recognized Cloudflare events are captured on the global stream with this event type:

~~~ts
"events.iterate.com/cloudflare/event-received"
~~~

Addressable Cloudflare Artifacts repo events also fan out to the repo stream with this event type:

~~~ts
"events.iterate.com/repo/cloudflare-artifact-event-received"
~~~

Queue message IDs are used as idempotency keys:

~~~ts
{
  type: "events.iterate.com/cloudflare/event-received",
  idempotencyKey: "cf-event:" + message.id,
  payload: { body: message.body },
}

{
  type: "events.iterate.com/repo/cloudflare-artifact-event-received",
  idempotencyKey: "cf-artifact-event:" + message.id,
  payload: {
    artifactName,
    body: message.body,
    cloudflareEventType,
    namespace,
  },
}
~~~

For addressable artifact events, repo fanout is attempted before global capture. If repo fanout fails, the message is retried and the event is not left in a global-only state. If repo fanout succeeds and global capture then fails, the message is retried; the second repo append is safe because the repo fanout idempotency key is stable.

Malformed or unaddressable artifact repo names are different: those are treated as poison for repo fanout, captured globally, and acknowledged. That preserves an audit trail without burning queue retries on data that cannot be routed.

## Artifact Name Encoding

Cloudflare Artifacts gives us a namespace plus a repo name. The repo name must be reversible back to the OS stream address or we would need a separate lookup database. This PR relies on the existing RepoArtifactNameCodec to make that direction possible.

The OS repo address is:

~~~ts
type RepoArtifactNameParts = {
  projectId: string | null;
  path: string;
};
~~~

RepoArtifactNameCodec encodes that address as:

~~~text
<artifact project id>--<base64url(normalized path)>
~~~

Rules:

- path is normalized to a leading slash before encoding. "" becomes "/" and "repos/project" becomes "/repos/project".
- projectId null is encoded as the reserved artifact project id "global".
- a real projectId must be non-empty, must not be "global", and must not contain URL delimiter characters "/", "?", or "#".
- the path is UTF-8 base64url encoded, with + changed to -, / changed to _, and padding removed.
- parsing uses the last "--" separator, so project ids can still contain ordinary hyphens.

Examples:

~~~ts
RepoArtifactNameCodec.stringify({ projectId: "prj_123", path: "/" });
// "prj_123--Lw"

RepoArtifactNameCodec.stringify({ projectId: "prj_123", path: "/repos/project" });
// "prj_123--L3JlcG9zL3Byb2plY3Q"

RepoArtifactNameCodec.stringify({ projectId: null, path: "/" });
// "global--Lw"
~~~

The important part for this PR is that parsing is lossless:

~~~ts
RepoArtifactNameCodec.parse("prj_123--L3JlcG9zL3Byb2plY3Q");
// { projectId: "prj_123", path: "/repos/project" }
~~~

## How Artifact Names Become Stream Durable Object Names

Stream Durable Objects use DurableObjectNameCodec, whose shape is URL-like:

~~~text
<project id>.iterate<path>
~~~

For deployment-wide resources, callers opt into null project ids with allowNullProjectId. In that mode projectId null maps to the reserved host "global.iterate".

Examples:

~~~ts
DurableObjectNameCodec.stringify({ projectId: "prj_123", path: "/" });
// "prj_123.iterate/"

DurableObjectNameCodec.stringify({ projectId: "prj_123", path: "/repos/project" });
// "prj_123.iterate/repos/project"

DurableObjectNameCodec.stringify(
  { projectId: null, path: "/cloudflare/events" },
  { allowNullProjectId: true },
);
// "global.iterate/cloudflare/events"
~~~

The queue handler bridges the two codecs directly:

~~~ts
const streamAddress = RepoArtifactNameCodec.parse(artifactRepo.repoName);
const streamDurableObjectName = DurableObjectNameCodec.stringify(streamAddress, {
  allowNullProjectId: true,
});

await env.STREAM.getByName(streamDurableObjectName).append(event);
~~~

So a Cloudflare event like this:

~~~json
{
  "type": "cf.artifacts.repo.pushed",
  "source": {
    "type": "artifacts.repo",
    "namespace": "os-prd-repos",
    "repoName": "prj_123--L3JlcG9zL3Byb2plY3Q"
  }
}
~~~

routes to this Stream Durable Object:

~~~text
prj_123.iterate/repos/project
~~~

No separate lookup table is needed. The Cloudflare repo name carries the project id and stream path in a reversible form.

## Forked Events

Fork events are special because the source repository may be the repository that was forked from, while the event we want in OS is usually about the target repository that was created. For "cf.artifacts.repo.forked", the handler uses the target repo from payload.namespace plus payload.repoName or payload.repo_name.

Example:

~~~json
{
  "type": "cf.artifacts.repo.forked",
  "source": {
    "type": "artifacts",
    "namespace": "external-repos",
    "repoName": "source-repo"
  },
  "payload": {
    "namespace": "os-prd-repos",
    "repoName": "prj_target--Lw"
  }
}
~~~

That routes to:

~~~text
prj_target.iterate/
~~~

If a fork event does not include a complete target namespace and target repo name in the payload, the handler does not fall back to the source repo. It captures the event globally only. That avoids notifying the wrong repo stream for same-namespace forks.

## Validation

Local validation run for this PR:

~~~sh
pnpm --dir apps/os exec vitest run src/domains/events/event-queue-handler.test.ts
pnpm lint
pnpm typecheck
pnpm knip
pnpm test
~~~

CI validation on the PR includes:

- Lint and Typecheck / lint-typecheck
- Test / test
- Cloudflare Previews / deploy + e2e
- autofix.ci / autofix

## Self-Review Notes

- The queue is intentionally general-purpose. The only artifact-specific code today is the Cloudflare Artifacts producer wiring and the artifact repo event fanout branch.
- Deploy only ensures the queue itself, because that is a Wrangler deploy prerequisite. ensure-resources handles producer wiring and can repair subscription drift.
- Event routing remains lookup-free because RepoArtifactNameCodec.parse returns exactly the address DurableObjectNameCodec.stringify needs for Stream DO lookup.
- Addressable artifact fanout happens before global capture to avoid a global-only record if repo fanout is the failing side.
- Unknown future queue messages are acknowledged and logged so this queue can evolve without poisoning Cloudflare retries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches deploy prerequisites and async event ingestion into Stream DOs; miswired subscriptions or queue handling could drop or misroute artifact signals, though idempotency keys and explicit ack/retry behavior limit duplicate and poison-message impact.
> 
> **Overview**
> Restores a **per-worker `${WORKER_SELF}-events` queue** for OS: wrangler gets a queue consumer binding, deploy creates the queue before upload (Wrangler validates consumers), and `ensure-resources` provisions the queue plus **Cloudflare Artifacts event subscriptions** (account- and repo-scoped) with recreate-on-drift reconciliation.
> 
> The OS worker gains a **`queue` handler** that processes recognized `cf.*` subscription payloads: every message is appended to the global stream at `/cloudflare/events`, and addressable artifact repo events are **fanned out** to the repo stream via `RepoArtifactNameCodec` (including fork targets from payload). Unknown messages are acked; stream failures retry; repo fan-out must succeed before global capture for addressable artifact events.
> 
> Adds **`event-queue-resources.ts`**, shared **`workerEventsQueueName`**, and unit tests for routing, namespaces, poison messages, and partial batch failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82fb0b1ca42d768b0854da18a616b5cbcd14e08e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-06T18:38:49.787Z",
      "headSha": "82fb0b1ca42d768b0854da18a616b5cbcd14e08e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/501674520671456",
      "shortSha": "82fb0b1",
      "cleanupDurationMs": 5593,
      "deployDurationMs": 55354,
      "testDurationMs": 95892,
      "testRetries": "2 retried: itx > Trusted internal root can access global streams and repos (vitest x1) · inbound Slack webhook routes to a slack agent that attempts a Web API reply (vitest x1)"
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-06T18:38:47.474Z",
      "headSha": "82fb0b1ca42d768b0854da18a616b5cbcd14e08e",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/501674520671456",
      "shortSha": "82fb0b1",
      "cleanupDurationMs": 3274,
      "deployDurationMs": 28191,
      "testDurationMs": 556,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `82fb0b1` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 28.2s | 556ms |  | 3.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/501674520671456) | 2026-07-06T18:38:47.474Z | Preview app released. |
| OS | released | `82fb0b1` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 55.4s | 95.9s | 2 retried: itx > Trusted internal root can access global streams and repos (vitest x1) · inbound Slack webhook routes to a slack agent that attempts a Web API reply (vitest x1) | 5.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/501674520671456) | 2026-07-06T18:38:49.787Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->