### PR TITLE
[codex] fix Artifacts repo event subscriptions

### DIFF
--- a/apps/os/scripts/event-queue-resources.test.ts
+++ b/apps/os/scripts/event-queue-resources.test.ts
@@ -1,0 +1,99 @@
+import { expect, it } from "vitest";
+
+import {
+  ensureWorkerEventQueue,
+  listArtifactEventSubscriptions,
+  listArtifactRepos,
+} from "../src/domains/events/cloudflare-event-subscriptions.ts";
+import { ensureWorkerEventQueueResources } from "./event-queue-resources.ts";
+
+it("lists artifact event subscriptions with Cloudflare's accepted page size", async () => {
+  const calls: Array<{ body?: unknown; method: string; path: string }> = [];
+  const ctx = {
+    cf: async <T>(path: string, init?: RequestInit): Promise<T> => {
+      calls.push({
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+        method: init?.method ?? "GET",
+        path,
+      });
+
+      if (path === "/queues?page=1&per_page=100") {
+        return [{ queue_id: "queue-1", queue_name: "os-prd-events" }] as T;
+      }
+      if (path === "/event_subscriptions/subscriptions?page=1&per_page=100") {
+        return [] as T;
+      }
+      if (path === "/artifacts/namespaces/os-prd-repos/repos?page=1&per_page=100") {
+        return [{ name: "prj_123--Lw" }] as T;
+      }
+      if (path === "/event_subscriptions/subscriptions" && init?.method === "POST") {
+        return { id: "subscription-1" } as T;
+      }
+      throw new Error(`unexpected Cloudflare call ${init?.method ?? "GET"} ${path}`);
+    },
+  } satisfies Parameters<typeof ensureWorkerEventQueueResources>[0];
+
+  await ensureWorkerEventQueueResources(ctx, "os-prd");
+
+  expect(calls.map((call) => `${call.method} ${call.path}`)).toEqual([
+    "GET /queues?page=1&per_page=100",
+    "GET /event_subscriptions/subscriptions?page=1&per_page=100",
+    "POST /event_subscriptions/subscriptions",
+    "GET /artifacts/namespaces/os-prd-repos/repos?page=1&per_page=100",
+    "POST /event_subscriptions/subscriptions",
+  ]);
+  expect(calls[2]?.body).toMatchObject({
+    destination: { queue_id: "queue-1", type: "queues.queue" },
+    name: "os-prd-artifact-account-events",
+    source: { type: "artifacts" },
+  });
+  expect(calls[4]?.body).toMatchObject({
+    destination: { queue_id: "queue-1", type: "queues.queue" },
+    name: expect.stringMatching(/^os-prd-artifact-repo-prj_123--Lw-[0-9a-f]{12}$/),
+    source: { namespace: "os-prd-repos", repo_name: "prj_123--Lw", type: "artifacts.repo" },
+  });
+});
+
+it("paginates Cloudflare list endpoints with the accepted page size", async () => {
+  const calls: string[] = [];
+  const api = async <T>(path: string): Promise<T> => {
+    calls.push(path);
+
+    if (path === "/queues?page=1&per_page=100") {
+      return Array.from({ length: 100 }, (_, index) => ({
+        queue_id: `queue-${index}`,
+        queue_name: `unrelated-${index}`,
+      })) as T;
+    }
+    if (path === "/queues?page=2&per_page=100") {
+      return [{ queue_id: "queue-target", queue_name: "os-prd-events" }] as T;
+    }
+    if (path === "/event_subscriptions/subscriptions?page=1&per_page=100") {
+      return Array.from({ length: 100 }, (_, index) => ({ id: `subscription-${index}` })) as T;
+    }
+    if (path === "/event_subscriptions/subscriptions?page=2&per_page=100") {
+      return [{ id: "subscription-target" }] as T;
+    }
+    if (path === "/artifacts/namespaces/os-prd-repos/repos?page=1&per_page=100") {
+      return Array.from({ length: 100 }, (_, index) => ({ name: `repo-${index}` })) as T;
+    }
+    if (path === "/artifacts/namespaces/os-prd-repos/repos?page=2&per_page=100") {
+      return [{ name: "repo-target" }] as T;
+    }
+    throw new Error(`unexpected Cloudflare call ${path}`);
+  };
+
+  await expect(ensureWorkerEventQueue(api, "os-prd")).resolves.toMatchObject({
+    queue_id: "queue-target",
+  });
+  await expect(listArtifactEventSubscriptions(api)).resolves.toHaveLength(101);
+  await expect(listArtifactRepos(api, "os-prd-repos")).resolves.toHaveLength(101);
+  expect(calls).toEqual([
+    "/queues?page=1&per_page=100",
+    "/queues?page=2&per_page=100",
+    "/event_subscriptions/subscriptions?page=1&per_page=100",
+    "/event_subscriptions/subscriptions?page=2&per_page=100",
+    "/artifacts/namespaces/os-prd-repos/repos?page=1&per_page=100",
+    "/artifacts/namespaces/os-prd-repos/repos?page=2&per_page=100",
+  ]);
+});

--- a/apps/os/scripts/event-queue-resources.ts
+++ b/apps/os/scripts/event-queue-resources.ts
@@ -1,18 +1,24 @@
-import { workerEventsQueueName } from "../src/queue-names.ts";
+import {
+  deleteArtifactEventSubscription,
+  desiredArtifactAccountEventSubscription,
+  desiredArtifactRepoEventSubscription,
+  ensureArtifactEventSubscription,
+  ensureWorkerEventQueue,
+  listArtifactEventSubscriptions,
+  listArtifactRepos,
+  type QueueRecord,
+} from "../src/domains/events/cloudflare-event-subscriptions.ts";
 import type { DeployableEnv, EnvContext } from "../../../scripts/lib/env-context.ts";
 
 type QueueResourceContext = Pick<EnvContext<DeployableEnv>, "cf">;
-
-type QueueRecord = {
-  queue_id: string;
-  queue_name: string;
-};
 
 export async function ensureWorkerEventsQueue(
   ctx: QueueResourceContext,
   workerName: string,
 ): Promise<QueueRecord> {
-  return await ensureQueue(ctx, workerEventsQueueName(workerName));
+  const queue = await ensureWorkerEventQueue(ctx.cf, workerName);
+  console.log(`Queue ${queue.queue_name} exists (${queue.queue_id})`);
+  return queue;
 }
 
 export async function ensureWorkerEventQueueResources(
@@ -27,112 +33,47 @@ export async function ensureWorkerEventQueueResources(
   return eventQueue;
 }
 
-async function ensureQueue(ctx: QueueResourceContext, queueName: string): Promise<QueueRecord> {
-  const queues = await ctx.cf<QueueRecord[]>(`/queues?per_page=1000`);
-  const existing = queues.find((queue) => queue.queue_name === queueName);
-  if (existing) {
-    console.log(`Queue ${queueName} exists (${existing.queue_id})`);
-    return existing;
-  }
-
-  const created = await ctx.cf<QueueRecord>(`/queues`, {
-    method: "POST",
-    body: JSON.stringify({ queue_name: queueName }),
-  });
-  console.log(`created Queue ${queueName} (${created.queue_id})`);
-  return created;
-}
-
-type DesiredArtifactEventSubscription = {
-  events: string[];
-  name: string;
-  source: Record<string, string>;
-};
-
-type ArtifactEventSubscription = {
-  destination?: { queue_id?: string; type?: string };
-  enabled?: boolean;
-  events?: string[];
-  id: string;
-  name?: string;
-  source?: Record<string, string | undefined>;
-};
-
 async function ensureArtifactEventSubscriptions(
   ctx: QueueResourceContext,
   input: { queueId: string; workerName: string },
 ): Promise<void> {
-  const desired: DesiredArtifactEventSubscription[] = [
-    {
-      name: `${input.workerName}-artifact-account-events`,
-      source: { type: "artifacts" },
-      events: ["repo.created", "repo.deleted", "repo.forked", "repo.imported"],
-    },
-    {
-      name: `${input.workerName}-artifact-repo-events`,
-      source: {
-        type: "artifacts.repo",
-        namespace: `${input.workerName}-repos`,
-        repo_name: "*",
-      },
-      events: ["pushed", "cloned", "fetched"],
-    },
-  ];
+  const existing = await listArtifactEventSubscriptions(ctx.cf);
+  const legacyWildcard = existing.find(
+    (subscription) => subscription.name === `${input.workerName}-artifact-repo-events`,
+  );
+  if (legacyWildcard) {
+    await deleteArtifactEventSubscription(ctx.cf, legacyWildcard.id);
+    existing.splice(existing.indexOf(legacyWildcard), 1);
+    console.log(`Artifact event subscription ${legacyWildcard.name} deleted`);
+  }
 
-  const existing = await listArtifactEventSubscriptions(ctx);
-  for (const subscription of desired) {
-    const current = existing.find((candidate) => candidate.name === subscription.name);
-    if (current && artifactEventSubscriptionMatches(current, subscription, input.queueId)) {
-      console.log(`Artifact event subscription ${subscription.name} unchanged`);
-      continue;
-    }
+  logEnsure(
+    await ensureArtifactEventSubscription(ctx.cf, {
+      desired: desiredArtifactAccountEventSubscription(input.workerName),
+      existing,
+      queueId: input.queueId,
+    }),
+    `${input.workerName}-artifact-account-events`,
+  );
 
-    if (current) {
-      await artifactEventSubscriptionsApi(ctx, "DELETE", `/${current.id}`);
-    }
-    await artifactEventSubscriptionsApi(ctx, "POST", "", {
-      name: subscription.name,
-      enabled: true,
-      source: subscription.source,
-      destination: { type: "queues.queue", queue_id: input.queueId },
-      events: subscription.events,
+  const namespace = `${input.workerName}-repos`;
+  const repos = await listArtifactRepos(ctx.cf, namespace);
+  for (const repo of repos) {
+    const desired = await desiredArtifactRepoEventSubscription({
+      repoName: repo.name,
+      workerName: input.workerName,
     });
-    console.log(
-      `Artifact event subscription ${subscription.name} ${current ? "recreated" : "created"}`,
+    logEnsure(
+      await ensureArtifactEventSubscription(ctx.cf, {
+        desired,
+        existing,
+        queueId: input.queueId,
+      }),
+      desired.name,
     );
   }
 }
 
-async function listArtifactEventSubscriptions(ctx: QueueResourceContext) {
-  return await artifactEventSubscriptionsApi<ArtifactEventSubscription[]>(
-    ctx,
-    "GET",
-    `?per_page=1000`,
-  );
-}
-
-function artifactEventSubscriptionMatches(
-  current: ArtifactEventSubscription,
-  desired: DesiredArtifactEventSubscription,
-  queueId: string,
-): boolean {
-  if (current.enabled !== true) return false;
-  if (current.destination?.type !== "queues.queue") return false;
-  if (current.destination.queue_id !== queueId) return false;
-  if ([...(current.events ?? [])].sort().join(",") !== [...desired.events].sort().join(",")) {
-    return false;
-  }
-  return Object.entries(desired.source).every(([key, value]) => current.source?.[key] === value);
-}
-
-async function artifactEventSubscriptionsApi<T = unknown>(
-  ctx: QueueResourceContext,
-  method: "DELETE" | "GET" | "POST",
-  path: string,
-  body?: unknown,
-): Promise<T> {
-  return await ctx.cf<T>(`/event_subscriptions/subscriptions${path}`, {
-    method,
-    body: body === undefined ? undefined : JSON.stringify(body),
-  });
+function logEnsure(result: "created" | "recreated" | "unchanged", subscriptionName: string) {
+  console.log(`Artifact event subscription ${subscriptionName} ${result}`);
 }

--- a/apps/os/src/domains/events/cloudflare-event-subscriptions.ts
+++ b/apps/os/src/domains/events/cloudflare-event-subscriptions.ts
@@ -1,0 +1,221 @@
+import { workerEventsQueueName } from "../../queue-names.ts";
+
+/**
+ * Cloudflare Artifacts event subscriptions expose account-level repo lifecycle
+ * events and exact-repo Git activity events. The `artifacts.repo` source needs
+ * the concrete artifact repo name, so we backfill existing repos at deploy time
+ * and add repo subscriptions when account-level create/import/fork events land.
+ *
+ * https://developers.cloudflare.com/queues/event-subscriptions/events-schemas/#artifacts
+ */
+export function desiredArtifactAccountEventSubscription(
+  workerName: string,
+): DesiredArtifactEventSubscription {
+  return {
+    name: `${workerName}-artifact-account-events`,
+    source: { type: "artifacts" },
+    events: ["repo.created", "repo.deleted", "repo.forked", "repo.imported"],
+  };
+}
+
+export async function desiredArtifactRepoEventSubscription(input: {
+  repoName: string;
+  workerName: string;
+}): Promise<DesiredArtifactEventSubscription> {
+  return {
+    name: await artifactRepoEventSubscriptionName(input.workerName, input.repoName),
+    source: {
+      type: "artifacts.repo",
+      namespace: `${input.workerName}-repos`,
+      repo_name: input.repoName,
+    },
+    events: ["pushed", "cloned", "fetched"],
+  };
+}
+
+async function artifactRepoEventSubscriptionName(workerName: string, repoName: string) {
+  const prefix = repoName.replaceAll(/[^a-zA-Z0-9._-]/g, "_").slice(0, 48);
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(repoName));
+  const hash = Array.from(new Uint8Array(digest.slice(0, 6)))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  return `${workerName}-artifact-repo-${prefix}-${hash}`;
+}
+
+export async function ensureWorkerEventQueue(api: CloudflareAccountApi, workerName: string) {
+  return await ensureQueue(api, workerEventsQueueName(workerName));
+}
+
+export async function listArtifactRepos(
+  api: CloudflareAccountApi,
+  namespace: string,
+): Promise<Array<{ name: string }>> {
+  return await listCloudflarePages(
+    api,
+    `/artifacts/namespaces/${encodeURIComponent(namespace)}/repos`,
+  );
+}
+
+export async function listArtifactEventSubscriptions(api: CloudflareAccountApi) {
+  return await listCloudflarePages<ArtifactEventSubscription>(
+    api,
+    `/event_subscriptions/subscriptions`,
+  );
+}
+
+export async function ensureArtifactEventSubscription(
+  api: CloudflareAccountApi,
+  input: {
+    desired: DesiredArtifactEventSubscription;
+    existing: ArtifactEventSubscription[];
+    queueId: string;
+  },
+): Promise<"created" | "recreated" | "unchanged"> {
+  const current = input.existing.find((candidate) => candidate.name === input.desired.name);
+  if (current && artifactEventSubscriptionMatches(current, input.desired, input.queueId)) {
+    return "unchanged";
+  }
+
+  if (current) {
+    await artifactEventSubscriptionsApi(api, "DELETE", `/${current.id}`);
+  }
+  const created = await artifactEventSubscriptionsApi<ArtifactEventSubscription>(api, "POST", "", {
+    name: input.desired.name,
+    enabled: true,
+    source: input.desired.source,
+    destination: { type: "queues.queue", queue_id: input.queueId },
+    events: input.desired.events,
+  });
+  input.existing.splice(
+    current === undefined ? input.existing.length : input.existing.indexOf(current),
+    current === undefined ? 0 : 1,
+    {
+      ...created,
+      destination: { type: "queues.queue", queue_id: input.queueId },
+      enabled: true,
+      events: input.desired.events,
+      name: input.desired.name,
+      source: input.desired.source,
+    },
+  );
+  return current ? "recreated" : "created";
+}
+
+export async function deleteArtifactEventSubscription(
+  api: CloudflareAccountApi,
+  subscriptionId: string,
+): Promise<void> {
+  await artifactEventSubscriptionsApi(api, "DELETE", `/${subscriptionId}`);
+}
+
+export async function queueIdForWorkerEventQueue(
+  api: CloudflareAccountApi,
+  workerName: string,
+): Promise<string> {
+  return (await ensureWorkerEventQueue(api, workerName)).queue_id;
+}
+
+export function createCloudflareAccountApi(input: {
+  accountId: string;
+  apiToken: string;
+}): CloudflareAccountApi {
+  return async <T>(path: string, init?: RequestInit): Promise<T> => {
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${input.accountId}${path}`,
+      {
+        ...init,
+        headers: {
+          authorization: `Bearer ${input.apiToken}`,
+          ...(init?.body && typeof init.body === "string"
+            ? { "content-type": "application/json" }
+            : {}),
+          ...init?.headers,
+        },
+      },
+    );
+    const body = (await response.json().catch(() => null)) as {
+      errors?: unknown;
+      result?: unknown;
+      success?: boolean;
+    } | null;
+    if (!response.ok || body?.success === false) {
+      throw new Error(
+        `Cloudflare API ${init?.method ?? "GET"} ${path} failed (${response.status}): ${JSON.stringify(body?.errors ?? body).slice(0, 500)}`,
+      );
+    }
+    return body?.result as T;
+  };
+}
+
+async function ensureQueue(api: CloudflareAccountApi, queueName: string): Promise<QueueRecord> {
+  const queues = await listCloudflarePages<QueueRecord>(api, `/queues`);
+  const existing = queues.find((queue) => queue.queue_name === queueName);
+  if (existing) return existing;
+
+  return await api<QueueRecord>(`/queues`, {
+    method: "POST",
+    body: JSON.stringify({ queue_name: queueName }),
+  });
+}
+
+function artifactEventSubscriptionMatches(
+  current: ArtifactEventSubscription,
+  desired: DesiredArtifactEventSubscription,
+  queueId: string,
+): boolean {
+  if (current.enabled !== true) return false;
+  if (current.destination?.type !== "queues.queue") return false;
+  if (current.destination.queue_id !== queueId) return false;
+  if ([...(current.events ?? [])].sort().join(",") !== [...desired.events].sort().join(",")) {
+    return false;
+  }
+  return Object.entries(desired.source).every(([key, value]) => current.source?.[key] === value);
+}
+
+async function listCloudflarePages<T>(
+  api: CloudflareAccountApi,
+  path: string,
+  perPage = 100,
+): Promise<T[]> {
+  const results: T[] = [];
+  for (let page = 1; ; page++) {
+    const separator = path.includes("?") ? "&" : "?";
+    const items = await api<T[]>(`${path}${separator}page=${page}&per_page=${perPage}`);
+    results.push(...items);
+    if (items.length < perPage) return results;
+  }
+}
+
+async function artifactEventSubscriptionsApi<T = unknown>(
+  api: CloudflareAccountApi,
+  method: "DELETE" | "GET" | "POST",
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  return await api<T>(`/event_subscriptions/subscriptions${path}`, {
+    method,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+type CloudflareAccountApi = <T = unknown>(path: string, init?: RequestInit) => Promise<T>;
+
+export type QueueRecord = {
+  queue_id: string;
+  queue_name: string;
+};
+
+type DesiredArtifactEventSubscription = {
+  events: string[];
+  name: string;
+  source: Record<string, string>;
+};
+
+type ArtifactEventSubscription = {
+  destination?: { queue_id?: string; type?: string };
+  enabled?: boolean;
+  events?: string[];
+  id: string;
+  name?: string;
+  source?: Record<string, string | undefined>;
+};

--- a/apps/os/src/domains/events/event-queue-entrypoint.ts
+++ b/apps/os/src/domains/events/event-queue-entrypoint.ts
@@ -3,13 +3,25 @@ import type { StreamEventInput } from "../../types.ts";
 import { DurableObjectNameCodec } from "../durable-object-names.ts";
 import { RepoArtifactNameCodec } from "../repos/utils.ts";
 import { workerEventsQueueName } from "../../queue-names.ts";
+import {
+  createCloudflareAccountApi,
+  desiredArtifactRepoEventSubscription,
+  ensureArtifactEventSubscription,
+  listArtifactEventSubscriptions,
+  queueIdForWorkerEventQueue,
+} from "./cloudflare-event-subscriptions.ts";
 
 export const GLOBAL_CLOUDFLARE_EVENTS_STREAM_PATH = "/cloudflare/events";
 export const CLOUDFLARE_EVENT_RECEIVED_TYPE = "events.iterate.com/cloudflare/event-received";
 export const REPO_CLOUDFLARE_ARTIFACT_EVENT_RECEIVED_TYPE =
   "events.iterate.com/repo/cloudflare-artifact-event-received";
 
-type EventQueueEnv = Pick<Env, "ARTIFACTS_NAMESPACE" | "STREAM" | "WORKER_SELF">;
+type EventQueueEnv = Pick<
+  Env,
+  "ARTIFACTS_ACCOUNT_ID" | "ARTIFACTS_NAMESPACE" | "STREAM" | "WORKER_SELF"
+> & {
+  APP_CONFIG_CLOUDFLARE__API_TOKEN?: string;
+};
 
 export function isWorkerEventsQueue(queue: string, env: Pick<Env, "WORKER_SELF">): boolean {
   return queue === workerEventsQueueName(env.WORKER_SELF);
@@ -94,11 +106,61 @@ async function appendRepoArtifactEventIfAddressable(input: {
   const cloudflareEventType = typeof input.event.type === "string" ? input.event.type : undefined;
   if (cloudflareEventType !== undefined) payload.cloudflareEventType = cloudflareEventType;
 
+  if (cloudflareEventType !== undefined && shouldEnsureRepoEventSubscription(cloudflareEventType)) {
+    try {
+      await ensureRepoEventSubscriptionIfConfigured({
+        env: input.env,
+        repoName: artifactRepo.repoName,
+      });
+    } catch (error) {
+      console.warn("[event-queue] failed to ensure artifact repo subscription", {
+        error,
+        repoName: artifactRepo.repoName,
+      });
+    }
+  }
+
   await appendToStream(input.env, streamAddress, {
     type: REPO_CLOUDFLARE_ARTIFACT_EVENT_RECEIVED_TYPE,
     idempotencyKey: `cf-artifact-event:${input.message.id}`,
     payload,
   });
+}
+
+function shouldEnsureRepoEventSubscription(cloudflareEventType: string): boolean {
+  return [
+    "cf.artifacts.repo.created",
+    "cf.artifacts.repo.forked",
+    "cf.artifacts.repo.imported",
+  ].includes(cloudflareEventType);
+}
+
+async function ensureRepoEventSubscriptionIfConfigured(input: {
+  env: EventQueueEnv;
+  repoName: string;
+}) {
+  const apiToken = input.env.APP_CONFIG_CLOUDFLARE__API_TOKEN?.trim();
+  if (!apiToken) {
+    console.warn("[event-queue] Cloudflare API token unavailable; cannot subscribe repo events");
+    return;
+  }
+
+  const api = createCloudflareAccountApi({
+    accountId: input.env.ARTIFACTS_ACCOUNT_ID,
+    apiToken,
+  });
+  const [queueId, existing, desired] = await Promise.all([
+    queueIdForWorkerEventQueue(api, input.env.WORKER_SELF),
+    listArtifactEventSubscriptions(api),
+    desiredArtifactRepoEventSubscription({
+      repoName: input.repoName,
+      workerName: input.env.WORKER_SELF,
+    }),
+  ]);
+  const result = await ensureArtifactEventSubscription(api, { desired, existing, queueId });
+  if (result !== "unchanged") {
+    console.log(`[event-queue] artifact repo subscription ${desired.name} ${result}`);
+  }
 }
 
 function artifactRepoReferenceFromCloudflareEvent(

--- a/apps/os/src/domains/events/event-queue-handler.test.ts
+++ b/apps/os/src/domains/events/event-queue-handler.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { Env } from "../../env.ts";
 import type { StreamEventInput } from "../../types.ts";
 import { DurableObjectNameCodec } from "../durable-object-names.ts";
@@ -16,10 +16,14 @@ type RecordedAppend = {
   name: string;
 };
 
-function createEnv() {
+function createEnv(options: { cloudflareApiToken?: string } = {}) {
   const appends: RecordedAppend[] = [];
   const env = {
+    ARTIFACTS_ACCOUNT_ID: "account-1",
     ARTIFACTS_NAMESPACE: "os-prd-repos",
+    ...(options.cloudflareApiToken === undefined
+      ? {}
+      : { APP_CONFIG_CLOUDFLARE__API_TOKEN: options.cloudflareApiToken }),
     STREAM: {
       getByName: vi.fn((name: string) => ({
         append: vi.fn(async (...events: StreamEventInput[]) => {
@@ -29,7 +33,10 @@ function createEnv() {
       })),
     },
     WORKER_SELF: "os-prd",
-  } as unknown as Pick<Env, "ARTIFACTS_NAMESPACE" | "STREAM" | "WORKER_SELF">;
+  } as unknown as Pick<
+    Env,
+    "ARTIFACTS_ACCOUNT_ID" | "ARTIFACTS_NAMESPACE" | "STREAM" | "WORKER_SELF"
+  > & { APP_CONFIG_CLOUDFLARE__API_TOKEN?: string };
 
   return { appends, env };
 }
@@ -49,6 +56,11 @@ function eventsFor(appends: RecordedAppend[], name: string): StreamEventInput[] 
 describe("event queue handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   test("recognizes the worker event queue", () => {
@@ -127,6 +139,118 @@ describe("event queue handler", () => {
       }),
     ]);
     expect(message.ack).toHaveBeenCalledOnce();
+  });
+
+  test("subscribes addressable created repos to repo-level Artifact events", async () => {
+    const { appends, env } = createEnv({ cloudflareApiToken: "cf-token" });
+    const artifactName = RepoArtifactNameCodec.stringify({
+      path: "/",
+      projectId: "prj_123",
+    });
+    const cfEvent = {
+      type: "cf.artifacts.repo.created",
+      source: { type: "artifacts", namespace: "os-prd-repos", repoName: artifactName },
+      payload: { repoId: "repo-1" },
+    };
+    const calls: Array<{ body?: unknown; method: string; path: string }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: URL | RequestInfo, init?: RequestInit) => {
+        const path = new URL(String(url)).pathname + new URL(String(url)).search;
+        calls.push({
+          body: init?.body ? JSON.parse(String(init.body)) : undefined,
+          method: init?.method ?? "GET",
+          path,
+        });
+        if (path === "/client/v4/accounts/account-1/queues?page=1&per_page=100") {
+          return Response.json({
+            success: true,
+            result: [{ queue_id: "queue-1", queue_name: "os-prd-events" }],
+          });
+        }
+        if (
+          path ===
+          "/client/v4/accounts/account-1/event_subscriptions/subscriptions?page=1&per_page=100"
+        ) {
+          return Response.json({ success: true, result: [] });
+        }
+        if (
+          path === "/client/v4/accounts/account-1/event_subscriptions/subscriptions" &&
+          init?.method === "POST"
+        ) {
+          return Response.json({ success: true, result: { id: "subscription-1" } });
+        }
+        return Response.json({ success: false, errors: [{ message: path }] }, { status: 404 });
+      }),
+    );
+    const message = createMessage(cfEvent, "msg-created");
+
+    await handleEventQueueBatch(createBatch([message]), env);
+
+    expect(calls.map((call) => `${call.method} ${call.path}`)).toEqual([
+      "GET /client/v4/accounts/account-1/queues?page=1&per_page=100",
+      "GET /client/v4/accounts/account-1/event_subscriptions/subscriptions?page=1&per_page=100",
+      "POST /client/v4/accounts/account-1/event_subscriptions/subscriptions",
+    ]);
+    expect(calls[2]?.body).toMatchObject({
+      destination: { queue_id: "queue-1", type: "queues.queue" },
+      events: ["pushed", "cloned", "fetched"],
+      name: expect.stringMatching(/^os-prd-artifact-repo-prj_123--Lw-[0-9a-f]{12}$/),
+      source: {
+        namespace: "os-prd-repos",
+        repo_name: artifactName,
+        type: "artifacts.repo",
+      },
+    });
+
+    const repoName = DurableObjectNameCodec.stringify({ path: "/", projectId: "prj_123" });
+    expect(eventsFor(appends, repoName)).toEqual([
+      expect.objectContaining({
+        idempotencyKey: "cf-artifact-event:msg-created",
+        type: REPO_CLOUDFLARE_ARTIFACT_EVENT_RECEIVED_TYPE,
+      }),
+    ]);
+    expect(message.ack).toHaveBeenCalledOnce();
+  });
+
+  test("still routes created repo events when repo subscription setup fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { appends, env } = createEnv({ cloudflareApiToken: "cf-token" });
+    const artifactName = RepoArtifactNameCodec.stringify({
+      path: "/",
+      projectId: "prj_123",
+    });
+    const cfEvent = {
+      type: "cf.artifacts.repo.created",
+      source: { type: "artifacts", namespace: "os-prd-repos", repoName: artifactName },
+      payload: { repoId: "repo-1" },
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json(
+          { success: false, errors: [{ message: "temporary outage" }] },
+          { status: 503 },
+        ),
+      ),
+    );
+    const message = createMessage(cfEvent, "msg-created");
+
+    await handleEventQueueBatch(createBatch([message]), env);
+
+    const repoName = DurableObjectNameCodec.stringify({ path: "/", projectId: "prj_123" });
+    expect(eventsFor(appends, repoName)).toEqual([
+      expect.objectContaining({
+        idempotencyKey: "cf-artifact-event:msg-created",
+        type: REPO_CLOUDFLARE_ARTIFACT_EVENT_RECEIVED_TYPE,
+      }),
+    ]);
+    expect(warn).toHaveBeenCalledWith(
+      "[event-queue] failed to ensure artifact repo subscription",
+      expect.objectContaining({ repoName: artifactName }),
+    );
+    expect(message.ack).toHaveBeenCalledOnce();
+    warn.mockRestore();
   });
 
   test("does not route incomplete forked events to the source repo", async () => {

--- a/scripts/lib/env-context.ts
+++ b/scripts/lib/env-context.ts
@@ -96,7 +96,15 @@ export async function resolveEnvContext<E extends DeployableEnv>(options: {
     }
     // Fail loudly instead of silently acting on a truncated listing.
     const info = body?.result_info;
-    if (info?.total_count && Array.isArray(body.result) && body.result.length < info.total_count) {
+    const explicitPage = new URL(`https://api.cloudflare.com/client/v4${path}`).searchParams.has(
+      "page",
+    );
+    if (
+      !explicitPage &&
+      info?.total_count &&
+      Array.isArray(body.result) &&
+      body.result.length < info.total_count
+    ) {
       throw new Error(
         `Cloudflare API ${path} returned page 1 of ${info.total_count} results — raise per_page or paginate.`,
       );


### PR DESCRIPTION
## Summary

This hotfix makes the production event queue setup handle Cloudflare Artifacts event subscriptions in the shape Cloudflare actually accepts:

- `ensure-resources` now lists Queues and Event Subscriptions with `per_page=100`; Cloudflare rejected the previous `per_page=1000` request in production.
- The OS worker event queue remains the general-purpose deployment queue: `${workerName}-events`, for example `os-prd-events`.
- Artifact account lifecycle events still subscribe once per deployment with `source.type = "artifacts"`.
- Artifact Git activity events are now subscribed once per concrete repo with `source.type = "artifacts.repo"`, `namespace`, and exact `repo_name`.
- The old attempted wildcard subscription named `${workerName}-artifact-repo-events` is deleted during resource reconciliation because Cloudflare accepts the object but does not deliver repo activity events for `repo_name: "*"`.
- When a `repo.created`, `repo.imported`, or `repo.forked` account event lands, the queue consumer best-effort creates the matching per-repo subscription too. If Cloudflare's management API is unavailable, the original event still gets appended; the deploy-time resource script can backfill the subscription later.

Cloudflare reference: https://developers.cloudflare.com/queues/event-subscriptions/events-schemas/#artifacts

## Subscription Shapes

Account-level lifecycle subscription:

```ts
{
  name: `${workerName}-artifact-account-events`,
  source: { type: "artifacts" },
  destination: { type: "queues.queue", queue_id: queueId },
  events: ["repo.created", "repo.deleted", "repo.forked", "repo.imported"],
  enabled: true,
}
```

Repo-level Git activity subscription:

```ts
{
  name: "os-prd-artifact-repo-prj_123--Lw-<12 hex chars>",
  source: {
    type: "artifacts.repo",
    namespace: "os-prd-repos",
    repo_name: "prj_123--Lw",
  },
  destination: { type: "queues.queue", queue_id: queueId },
  events: ["pushed", "cloned", "fetched"],
  enabled: true,
}
```

## Artifact Name Encoding

OS repo artifacts use `RepoArtifactNameCodec` so Cloudflare's `repoName` is reversible without a lookup table:

```ts
RepoArtifactNameCodec.stringify({ projectId: "prj_123", path: "/" })
// "prj_123--Lw"

RepoArtifactNameCodec.parse("prj_123--Lw")
// { projectId: "prj_123", path: "/" }

DurableObjectNameCodec.stringify({ projectId: "prj_123", path: "/" })
// "prj_123.iterate/"
```

The artifact name format is:

```ts
`${artifactProjectId}--${base64Url(normalizedPath)}`
```

For project-scoped repos, `artifactProjectId` is the stable project id such as `prj_123`. Deployment-wide repos use the reserved `global` id. The path is normalized to a leading slash and then base64url encoded without padding, so `/` becomes `Lw`.

That means the event queue can handle a Cloudflare event like this:

```ts
{
  type: "cf.artifacts.repo.pushed",
  source: {
    type: "artifacts.repo",
    namespace: "os-prd-repos",
    repoName: "prj_123--Lw",
  },
}
```

by parsing `repoName` back to `{ projectId: "prj_123", path: "/" }`, then appending to the stream Durable Object named by `DurableObjectNameCodec.stringify({ projectId: "prj_123", path: "/" })`.

Repo-level subscription names include a sanitized repo-name prefix plus the first 6 bytes of a SHA-256 digest of the full repo name:

```ts
`${workerName}-artifact-repo-${safePrefix}-${hash12}`
```

The prefix keeps Cloudflare dashboard rows readable; the digest prevents collisions when long or unusual artifact names are truncated/sanitized.

## Runtime Flow

1. Cloudflare delivers account-level Artifact events to the general OS event queue.
2. The queue consumer appends every Cloudflare event to the global `/cloudflare/events` stream.
3. If the event references this deployment's Artifacts namespace and the repo name is decodable, the consumer appends `events.iterate.com/repo/cloudflare-artifact-event-received` to that repo stream.
4. For newly created/imported/forked repos, the consumer also best-effort ensures the exact repo-level Git activity subscription exists.
5. Future `pushed`, `cloned`, and `fetched` events arrive on the same general queue and fan out to the same repo stream using the reversible artifact name.

## Validation

- `pnpm --dir apps/os exec vitest run src/domains/events/event-queue-handler.test.ts scripts/event-queue-resources.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm format:check`

## Production Finding

PR #1682 deployed the queue consumer to `os-prd`, but production smoke showed no `repo.pushed`/`repo.cloned` events after a successful Git clone and push. The account-level `repo.created` event did arrive, which proved the queue and stream fanout path worked. The missing events were isolated to the repo-level subscription shape: `repo_name: "*"` was accepted by Cloudflare's API but did not match repo activity. This PR switches to exact repo subscriptions and backfills existing repos through `ensure-resources`.


<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-06T19:19:44.327Z",
      "headSha": "d9dc8d4193583f54a4f8f8ea3a40f17184123d71",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/460972995434157",
      "shortSha": "d9dc8d4",
      "cleanupDurationMs": 11353,
      "deployDurationMs": 53705,
      "testDurationMs": 97744,
      "testRetries": "1 retried: catalogue example \"discover-tree\" runs identically across runtimes (vitest x1)"
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-06T19:19:35.898Z",
      "headSha": "d9dc8d4193583f54a4f8f8ea3a40f17184123d71",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/460972995434157",
      "shortSha": "d9dc8d4",
      "cleanupDurationMs": 2921,
      "deployDurationMs": 18728,
      "testDurationMs": 658,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `d9dc8d4` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 18.7s | 658ms |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/460972995434157) | 2026-07-06T19:19:35.898Z | Preview app released. |
| OS | released | `d9dc8d4` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 53.7s | 97.7s | 1 retried: catalogue example "discover-tree" runs identically across runtimes (vitest x1) | 11.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/460972995434157) | 2026-07-06T19:19:44.327Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deploy-time and runtime Cloudflare subscription management for the production event pipeline; misconfiguration could miss Git activity events, though stream fanout is preserved when subscription setup fails.
> 
> **Overview**
> Fixes production Artifact Git activity delivery by replacing the accepted-but-nonfunctional wildcard `artifacts.repo` subscription with **one subscription per concrete repo** (`pushed`, `cloned`, `fetched`), while keeping a single account-level subscription for repo lifecycle events.
> 
> Cloudflare list calls now use **`per_page=100` with pagination** (production rejected `per_page=1000`). Subscription and queue reconciliation logic moves into **`cloudflare-event-subscriptions.ts`**; deploy **`ensure-resources`** deletes the legacy `${workerName}-artifact-repo-events` wildcard, backfills per-repo subs for every repo in the namespace, and tests cover pagination and subscription shapes.
> 
> The **queue consumer** best-effort creates the matching per-repo subscription when `repo.created`, `repo.imported`, or `repo.forked` events arrive (via `APP_CONFIG_CLOUDFLARE__API_TOKEN`); failures are logged but the event still fans out to the repo stream. **`env-context`** only errors on truncated single-page listings when the request did not already specify `page`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8527149da283072708b3db4a7a942aec9f8355f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->