### PR TITLE
[codex] Restore canonical event docs routes

### DIFF
--- a/apps/os/src/components/event-docs-pages.tsx
+++ b/apps/os/src/components/event-docs-pages.tsx
@@ -25,7 +25,7 @@ export function EventDocsIndexPage(input: {
             {input.eventDocs.map((event) => (
               <Link
                 key={event.type}
-                to="/$eventDocsProcessorSlug/$"
+                to="/docs/streams/processors/$processorSlug/events/$"
                 params={event.routeParams}
                 className="block px-4 py-3 hover:bg-muted/60"
               >
@@ -47,7 +47,7 @@ export function EventDocsIndexPage(input: {
             {input.processorDocs.map((processor) => (
               <Link
                 key={processor.contractSlug}
-                to="/$eventDocsProcessorSlug"
+                to="/docs/streams/processors/$processorSlug"
                 params={processor.routeParams}
                 className="block px-4 py-3 hover:bg-muted/60"
               >
@@ -84,7 +84,7 @@ export function ProcessorOverviewPage({ processor }: { processor: ProcessorDoc }
                 {processor.events.map((event) => (
                   <Link
                     key={event.type}
-                    to="/$eventDocsProcessorSlug/$"
+                    to="/docs/streams/processors/$processorSlug/events/$"
                     params={event.routeParams}
                     className="block px-4 py-3 hover:bg-muted/60"
                   >
@@ -115,7 +115,7 @@ export function ProcessorOverviewPage({ processor }: { processor: ProcessorDoc }
                 {processor.dependencies.map((dep) => (
                   <Link
                     key={dep.contractSlug}
-                    to="/$eventDocsProcessorSlug"
+                    to="/docs/streams/processors/$processorSlug"
                     params={dep.routeParams}
                     className="block rounded-md border px-3 py-2 font-mono text-sm hover:bg-muted/60"
                   >
@@ -167,7 +167,7 @@ export function EventDocPage({ event }: { event: EventDoc }) {
           />
           <DocSection title="Processor">
             <Link
-              to="/$eventDocsProcessorSlug"
+              to="/docs/streams/processors/$processorSlug"
               params={event.processor.routeParams}
               className="block rounded-md border px-3 py-2 font-mono text-sm hover:bg-muted/60"
             >
@@ -226,7 +226,7 @@ function EventReferenceList(input: {
             event.href && event.routeParams ? (
               <Link
                 key={event.type}
-                to="/$eventDocsProcessorSlug/$"
+                to="/docs/streams/processors/$processorSlug/events/$"
                 params={event.routeParams}
                 className="block break-all px-4 py-3 font-mono text-sm hover:bg-muted/60"
               >

--- a/apps/os/src/lib/event-docs.test.ts
+++ b/apps/os/src/lib/event-docs.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   eventDocs,
   getEventDocByPath,
+  getEventDocByProcessorRoute,
   getEventDocByType,
+  getEventDocsRouteTarget,
   getProcessorDocByPath,
   processorDocs,
 } from "~/lib/event-docs.ts";
@@ -13,23 +15,83 @@ describe("event docs catalog", () => {
 
     expect(processor?.slug).toBe("stream");
     expect(processor?.contractSlug).toBe("core");
-    expect(processor?.href).toBe("/stream");
+    expect(processor?.href).toBe("/docs/streams/processors/stream");
+    expect(processor?.routeParams).toEqual({ processorSlug: "stream" });
   });
 
   it("maps event URL paths to public docs pages", () => {
     const event = getEventDocByPath("stream/created");
 
     expect(event?.type).toBe("events.iterate.com/stream/created");
-    expect(event?.href).toBe("/stream/created");
+    expect(event?.href).toBe("/docs/streams/processors/stream/events/created");
     expect(event?.routeParams).toEqual({
-      eventDocsProcessorSlug: "stream",
+      processorSlug: "stream",
       _splat: "created",
     });
     expect(getEventDocByType("events.iterate.com/stream/created")).toBe(event);
   });
 
+  it("keeps events whose public path does not start with the processor slug under the processor", () => {
+    const event = getEventDocByPath("agents/user-message-received");
+
+    expect(event?.processor.slug).toBe("agent");
+    expect(event?.href).toBe("/docs/streams/processors/agent/events/agents/user-message-received");
+    expect(event?.routeParams).toEqual({
+      processorSlug: "agent",
+      _splat: "agents/user-message-received",
+    });
+  });
+
+  it("does not resolve events under the wrong processor route", () => {
+    expect(
+      getEventDocByProcessorRoute({
+        processorSlug: "stream",
+        eventPath: "agents/user-message-received",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("resolves processor aliases before checking route event ownership", () => {
+    expect(
+      getEventDocByProcessorRoute({
+        processorSlug: "core",
+        eventPath: "created",
+      }),
+    ).toMatchObject({
+      processor: { slug: "stream" },
+      href: "/docs/streams/processors/stream/events/created",
+    });
+  });
+
   it("keeps the stream/create alias navigable", () => {
     expect(getEventDocByPath("stream/create")).toBe(getEventDocByPath("stream/created"));
+  });
+
+  it("resolves an empty splat match as the processor overview", () => {
+    const target = getEventDocsRouteTarget({
+      eventDocsProcessorSlug: "stream",
+      _splat: undefined,
+    });
+
+    expect(target).toMatchObject({
+      kind: "processor",
+      processor: { contractSlug: "core", href: "/docs/streams/processors/stream" },
+    });
+  });
+
+  it("resolves a non-empty splat match as an event page", () => {
+    const target = getEventDocsRouteTarget({
+      eventDocsProcessorSlug: "stream",
+      _splat: "created",
+    });
+
+    expect(target).toMatchObject({
+      kind: "event",
+      event: {
+        type: "events.iterate.com/stream/created",
+        href: "/docs/streams/processors/stream/events/created",
+      },
+    });
   });
 
   it("builds a non-empty processor and event catalog", () => {

--- a/apps/os/src/lib/event-docs.ts
+++ b/apps/os/src/lib/event-docs.ts
@@ -15,6 +15,7 @@ import { CoreProcessorContract } from "~/domains/streams/core-processor-contract
 
 const EVENT_TYPE_PREFIX = "events.iterate.com/";
 const EVENT_TYPE_URL_PREFIX = "https://events.iterate.com/";
+const PROCESSOR_DOCS_BASE_PATH = "/docs/streams/processors";
 
 type EventDefinitionForDocs = {
   description?: string;
@@ -73,7 +74,7 @@ export type EventReferenceDoc = {
 
 export type EventRouteParams = {
   _splat: string;
-  eventDocsProcessorSlug: string;
+  processorSlug: string;
 };
 
 export type ProcessorDoc = ProcessorReferenceDoc & {
@@ -88,9 +89,13 @@ export type ProcessorReferenceDoc = {
   description?: string;
   docsPath: string;
   href: string;
-  routeParams: { eventDocsProcessorSlug: string };
+  routeParams: { processorSlug: string };
   slug: string;
 };
+
+type EventDocsRouteTarget =
+  | { kind: "event"; event: EventDoc }
+  | { kind: "processor"; processor: ProcessorDoc };
 
 export const processorDocs = buildProcessorDocs();
 export const eventDocs = processorDocs.flatMap((processor) => processor.events);
@@ -116,6 +121,32 @@ export function getEventDocByPath(path: string) {
 
 export function getEventDocByType(type: string) {
   return eventsByType.get(type);
+}
+
+export function getEventDocByProcessorRoute(input: { eventPath: string; processorSlug: string }) {
+  const processor = getProcessorDocByPath(input.processorSlug);
+  if (!processor) return undefined;
+
+  const event =
+    getEventDocByPath(`${processor.slug}/${input.eventPath}`) ?? getEventDocByPath(input.eventPath);
+  if (event?.processor.slug !== processor.slug) return undefined;
+  return event;
+}
+
+export function getEventDocsRouteTarget(input: {
+  _splat?: string | undefined;
+  eventDocsProcessorSlug: string;
+}) {
+  if (!input._splat) {
+    const processor = getProcessorDocByPath(input.eventDocsProcessorSlug);
+    return processor ? ({ kind: "processor", processor } satisfies EventDocsRouteTarget) : null;
+  }
+
+  const event = getEventDocByProcessorRoute({
+    processorSlug: input.eventDocsProcessorSlug,
+    eventPath: input._splat,
+  });
+  return event ? ({ kind: "event", event } satisfies EventDocsRouteTarget) : null;
 }
 
 function buildProcessorDocs(): ProcessorDoc[] {
@@ -165,8 +196,8 @@ function processorReferenceDoc(contract: ProcessorContractForDocs): ProcessorRef
     ...(contract.description == null ? {} : { description: contract.description }),
     contractSlug: contract.slug,
     docsPath,
-    href: publicDocsPath(docsPath),
-    routeParams: { eventDocsProcessorSlug: docsPath },
+    href: processorDocsPathForSlug(docsPath),
+    routeParams: { processorSlug: docsPath },
     slug: docsPath,
   };
 }
@@ -178,17 +209,24 @@ function buildEventDoc(args: {
 }): EventDoc {
   const eventPath = eventPathFromType(args.type);
   const examples = eventExamples(args.definition.examples);
+  const processorEventPath = eventPathForProcessor({
+    eventPath,
+    processorSlug: args.processor.slug,
+  });
   return {
     ...(args.definition.description == null ? {} : { description: args.definition.description }),
     eventPath,
     examples,
-    href: publicDocsPath(eventPath),
+    href: `${processorDocsPathForSlug(args.processor.slug)}/events/${processorEventPath}`,
     payloadJsonSchema: eventPayloadJsonSchema({
       examples,
       payloadSchema: args.definition.payloadSchema,
     }),
     processor: args.processor,
-    routeParams: eventRouteParams(eventPath),
+    routeParams: {
+      processorSlug: args.processor.slug,
+      _splat: processorEventPath,
+    },
     type: args.type,
   };
 }
@@ -261,15 +299,17 @@ function eventPathFromType(type: string) {
   return cleanEventPath(type);
 }
 
-function eventRouteParams(eventPath: string): EventRouteParams {
-  const [eventDocsProcessorSlug = eventPath, ...splatParts] = eventPath.split("/");
-  return { eventDocsProcessorSlug, _splat: splatParts.join("/") };
-}
-
 function cleanEventPath(path: string) {
   return path.replace(/^\/+|\/+$/g, "");
 }
 
-function publicDocsPath(path: string) {
-  return `/${cleanEventPath(path)}`;
+function processorDocsPathForSlug(processorSlug: string) {
+  return `${PROCESSOR_DOCS_BASE_PATH}/${cleanEventPath(processorSlug)}`;
+}
+
+function eventPathForProcessor(input: { eventPath: string; processorSlug: string }) {
+  const processorPrefix = `${input.processorSlug}/`;
+  return input.eventPath.startsWith(processorPrefix)
+    ? input.eventPath.slice(processorPrefix.length)
+    : input.eventPath;
 }

--- a/apps/os/src/routeTree.gen.ts
+++ b/apps/os/src/routeTree.gen.ts
@@ -9,10 +9,12 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as DocsRouteImport } from './routes/docs'
 import { Route as AdminRouteImport } from './routes/admin'
 import { Route as AppRouteImport } from './routes/_app'
 import { Route as EventDocsProcessorSlugRouteImport } from './routes/$eventDocsProcessorSlug'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as DocsIndexRouteImport } from './routes/docs.index'
 import { Route as AdminIndexRouteImport } from './routes/admin/index'
 import { Route as SignUpSplatRouteImport } from './routes/sign-up.$'
 import { Route as SignInSplatRouteImport } from './routes/sign-in.$'
@@ -31,8 +33,10 @@ import { Route as AdminStreamsIndexRouteImport } from './routes/admin/streams/in
 import { Route as AppProjectsIndexRouteImport } from './routes/_app/projects/index'
 import { Route as AdminStreamsProjectIdRouteRouteImport } from './routes/admin/streams/$projectId/route'
 import { Route as AppProjectsProjectSlugRouteRouteImport } from './routes/_app/projects/$projectSlug/route'
+import { Route as DocsStreamsProcessorsIndexRouteImport } from './routes/docs.streams.processors.index'
 import { Route as AdminStreamsProjectIdIndexRouteImport } from './routes/admin/streams/$projectId/index'
 import { Route as AppProjectsProjectSlugIndexRouteImport } from './routes/_app/projects/$projectSlug/index'
+import { Route as DocsStreamsProcessorsProcessorSlugRouteImport } from './routes/docs.streams.processors.$processorSlug'
 import { Route as AdminStreamsProjectIdSplatRouteImport } from './routes/admin/streams/$projectId/$'
 import { Route as AppProjectsProjectSlugSettingsRouteImport } from './routes/_app/projects/$projectSlug/settings'
 import { Route as AppProjectsProjectSlugReplRouteImport } from './routes/_app/projects/$projectSlug/repl'
@@ -47,8 +51,14 @@ import { Route as AppProjectsProjectSlugStreamsSplatRouteImport } from './routes
 import { Route as AppProjectsProjectSlugSecretsSecretIdRouteImport } from './routes/_app/projects/$projectSlug/secrets/$secretId'
 import { Route as AppProjectsProjectSlugReposSplatRouteImport } from './routes/_app/projects/$projectSlug/repos/$'
 import { Route as AppProjectsProjectSlugAgentsNewRouteImport } from './routes/_app/projects/$projectSlug/agents/new'
+import { Route as DocsStreamsProcessorsProcessorSlugEventsSplatRouteImport } from './routes/docs.streams.processors.$processorSlug.events.$'
 import { Route as AppProjectsProjectSlugAgentsStreamsSplatRouteImport } from './routes/_app/projects/$projectSlug/agents/streams/$'
 
+const DocsRoute = DocsRouteImport.update({
+  id: '/docs',
+  path: '/docs',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AdminRoute = AdminRouteImport.update({
   id: '/admin',
   path: '/admin',
@@ -67,6 +77,11 @@ const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const DocsIndexRoute = DocsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => DocsRoute,
 } as any)
 const AdminIndexRoute = AdminIndexRouteImport.update({
   id: '/',
@@ -161,6 +176,12 @@ const AppProjectsProjectSlugRouteRoute =
     path: '/$projectSlug',
     getParentRoute: () => AppProjectsRouteRoute,
   } as any)
+const DocsStreamsProcessorsIndexRoute =
+  DocsStreamsProcessorsIndexRouteImport.update({
+    id: '/streams/processors/',
+    path: '/streams/processors/',
+    getParentRoute: () => DocsRoute,
+  } as any)
 const AdminStreamsProjectIdIndexRoute =
   AdminStreamsProjectIdIndexRouteImport.update({
     id: '/',
@@ -172,6 +193,12 @@ const AppProjectsProjectSlugIndexRoute =
     id: '/',
     path: '/',
     getParentRoute: () => AppProjectsProjectSlugRouteRoute,
+  } as any)
+const DocsStreamsProcessorsProcessorSlugRoute =
+  DocsStreamsProcessorsProcessorSlugRouteImport.update({
+    id: '/streams/processors/$processorSlug',
+    path: '/streams/processors/$processorSlug',
+    getParentRoute: () => DocsRoute,
   } as any)
 const AdminStreamsProjectIdSplatRoute =
   AdminStreamsProjectIdSplatRouteImport.update({
@@ -257,6 +284,12 @@ const AppProjectsProjectSlugAgentsNewRoute =
     path: '/agents/new',
     getParentRoute: () => AppProjectsProjectSlugRouteRoute,
   } as any)
+const DocsStreamsProcessorsProcessorSlugEventsSplatRoute =
+  DocsStreamsProcessorsProcessorSlugEventsSplatRouteImport.update({
+    id: '/events/$',
+    path: '/events/$',
+    getParentRoute: () => DocsStreamsProcessorsProcessorSlugRoute,
+  } as any)
 const AppProjectsProjectSlugAgentsStreamsSplatRoute =
   AppProjectsProjectSlugAgentsStreamsSplatRouteImport.update({
     id: '/agents/streams/$',
@@ -268,6 +301,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$eventDocsProcessorSlug': typeof EventDocsProcessorSlugRouteWithChildren
   '/admin': typeof AdminRouteWithChildren
+  '/docs': typeof DocsRouteWithChildren
   '/projects': typeof AppProjectsRouteRouteWithChildren
   '/admin/streams': typeof AdminStreamsRouteRouteWithChildren
   '/$eventDocsProcessorSlug/$': typeof EventDocsProcessorSlugSplatRoute
@@ -282,6 +316,7 @@ export interface FileRoutesByFullPath {
   '/sign-in/$': typeof SignInSplatRoute
   '/sign-up/$': typeof SignUpSplatRoute
   '/admin/': typeof AdminIndexRoute
+  '/docs/': typeof DocsIndexRoute
   '/projects/$projectSlug': typeof AppProjectsProjectSlugRouteRouteWithChildren
   '/admin/streams/$projectId': typeof AdminStreamsProjectIdRouteRouteWithChildren
   '/projects/': typeof AppProjectsIndexRoute
@@ -291,8 +326,10 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/repl': typeof AppProjectsProjectSlugReplRoute
   '/projects/$projectSlug/settings': typeof AppProjectsProjectSlugSettingsRoute
   '/admin/streams/$projectId/$': typeof AdminStreamsProjectIdSplatRoute
+  '/docs/streams/processors/$processorSlug': typeof DocsStreamsProcessorsProcessorSlugRouteWithChildren
   '/projects/$projectSlug/': typeof AppProjectsProjectSlugIndexRoute
   '/admin/streams/$projectId/': typeof AdminStreamsProjectIdIndexRoute
+  '/docs/streams/processors/': typeof DocsStreamsProcessorsIndexRoute
   '/projects/$projectSlug/agents/new': typeof AppProjectsProjectSlugAgentsNewRoute
   '/projects/$projectSlug/repos/$': typeof AppProjectsProjectSlugReposSplatRoute
   '/projects/$projectSlug/secrets/$secretId': typeof AppProjectsProjectSlugSecretsSecretIdRoute
@@ -303,6 +340,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/secrets/': typeof AppProjectsProjectSlugSecretsIndexRoute
   '/projects/$projectSlug/streams/': typeof AppProjectsProjectSlugStreamsIndexRoute
   '/projects/$projectSlug/agents/streams/$': typeof AppProjectsProjectSlugAgentsStreamsSplatRoute
+  '/docs/streams/processors/$processorSlug/events/$': typeof DocsStreamsProcessorsProcessorSlugEventsSplatRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -319,6 +357,7 @@ export interface FileRoutesByTo {
   '/sign-in/$': typeof SignInSplatRoute
   '/sign-up/$': typeof SignUpSplatRoute
   '/admin': typeof AdminIndexRoute
+  '/docs': typeof DocsIndexRoute
   '/projects': typeof AppProjectsIndexRoute
   '/admin/streams': typeof AdminStreamsIndexRoute
   '/projects/$projectSlug/integrations': typeof AppProjectsProjectSlugIntegrationsRoute
@@ -326,8 +365,10 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/repl': typeof AppProjectsProjectSlugReplRoute
   '/projects/$projectSlug/settings': typeof AppProjectsProjectSlugSettingsRoute
   '/admin/streams/$projectId/$': typeof AdminStreamsProjectIdSplatRoute
+  '/docs/streams/processors/$processorSlug': typeof DocsStreamsProcessorsProcessorSlugRouteWithChildren
   '/projects/$projectSlug': typeof AppProjectsProjectSlugIndexRoute
   '/admin/streams/$projectId': typeof AdminStreamsProjectIdIndexRoute
+  '/docs/streams/processors': typeof DocsStreamsProcessorsIndexRoute
   '/projects/$projectSlug/agents/new': typeof AppProjectsProjectSlugAgentsNewRoute
   '/projects/$projectSlug/repos/$': typeof AppProjectsProjectSlugReposSplatRoute
   '/projects/$projectSlug/secrets/$secretId': typeof AppProjectsProjectSlugSecretsSecretIdRoute
@@ -338,6 +379,7 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/secrets': typeof AppProjectsProjectSlugSecretsIndexRoute
   '/projects/$projectSlug/streams': typeof AppProjectsProjectSlugStreamsIndexRoute
   '/projects/$projectSlug/agents/streams/$': typeof AppProjectsProjectSlugAgentsStreamsSplatRoute
+  '/docs/streams/processors/$processorSlug/events/$': typeof DocsStreamsProcessorsProcessorSlugEventsSplatRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -345,6 +387,7 @@ export interface FileRoutesById {
   '/$eventDocsProcessorSlug': typeof EventDocsProcessorSlugRouteWithChildren
   '/_app': typeof AppRouteWithChildren
   '/admin': typeof AdminRouteWithChildren
+  '/docs': typeof DocsRouteWithChildren
   '/_app/projects': typeof AppProjectsRouteRouteWithChildren
   '/admin/streams': typeof AdminStreamsRouteRouteWithChildren
   '/$eventDocsProcessorSlug/$': typeof EventDocsProcessorSlugSplatRoute
@@ -359,6 +402,7 @@ export interface FileRoutesById {
   '/sign-in/$': typeof SignInSplatRoute
   '/sign-up/$': typeof SignUpSplatRoute
   '/admin/': typeof AdminIndexRoute
+  '/docs/': typeof DocsIndexRoute
   '/_app/projects/$projectSlug': typeof AppProjectsProjectSlugRouteRouteWithChildren
   '/admin/streams/$projectId': typeof AdminStreamsProjectIdRouteRouteWithChildren
   '/_app/projects/': typeof AppProjectsIndexRoute
@@ -368,8 +412,10 @@ export interface FileRoutesById {
   '/_app/projects/$projectSlug/repl': typeof AppProjectsProjectSlugReplRoute
   '/_app/projects/$projectSlug/settings': typeof AppProjectsProjectSlugSettingsRoute
   '/admin/streams/$projectId/$': typeof AdminStreamsProjectIdSplatRoute
+  '/docs/streams/processors/$processorSlug': typeof DocsStreamsProcessorsProcessorSlugRouteWithChildren
   '/_app/projects/$projectSlug/': typeof AppProjectsProjectSlugIndexRoute
   '/admin/streams/$projectId/': typeof AdminStreamsProjectIdIndexRoute
+  '/docs/streams/processors/': typeof DocsStreamsProcessorsIndexRoute
   '/_app/projects/$projectSlug/agents/new': typeof AppProjectsProjectSlugAgentsNewRoute
   '/_app/projects/$projectSlug/repos/$': typeof AppProjectsProjectSlugReposSplatRoute
   '/_app/projects/$projectSlug/secrets/$secretId': typeof AppProjectsProjectSlugSecretsSecretIdRoute
@@ -380,6 +426,7 @@ export interface FileRoutesById {
   '/_app/projects/$projectSlug/secrets/': typeof AppProjectsProjectSlugSecretsIndexRoute
   '/_app/projects/$projectSlug/streams/': typeof AppProjectsProjectSlugStreamsIndexRoute
   '/_app/projects/$projectSlug/agents/streams/$': typeof AppProjectsProjectSlugAgentsStreamsSplatRoute
+  '/docs/streams/processors/$processorSlug/events/$': typeof DocsStreamsProcessorsProcessorSlugEventsSplatRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -387,6 +434,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$eventDocsProcessorSlug'
     | '/admin'
+    | '/docs'
     | '/projects'
     | '/admin/streams'
     | '/$eventDocsProcessorSlug/$'
@@ -401,6 +449,7 @@ export interface FileRouteTypes {
     | '/sign-in/$'
     | '/sign-up/$'
     | '/admin/'
+    | '/docs/'
     | '/projects/$projectSlug'
     | '/admin/streams/$projectId'
     | '/projects/'
@@ -410,8 +459,10 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/repl'
     | '/projects/$projectSlug/settings'
     | '/admin/streams/$projectId/$'
+    | '/docs/streams/processors/$processorSlug'
     | '/projects/$projectSlug/'
     | '/admin/streams/$projectId/'
+    | '/docs/streams/processors/'
     | '/projects/$projectSlug/agents/new'
     | '/projects/$projectSlug/repos/$'
     | '/projects/$projectSlug/secrets/$secretId'
@@ -422,6 +473,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/secrets/'
     | '/projects/$projectSlug/streams/'
     | '/projects/$projectSlug/agents/streams/$'
+    | '/docs/streams/processors/$processorSlug/events/$'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -438,6 +490,7 @@ export interface FileRouteTypes {
     | '/sign-in/$'
     | '/sign-up/$'
     | '/admin'
+    | '/docs'
     | '/projects'
     | '/admin/streams'
     | '/projects/$projectSlug/integrations'
@@ -445,8 +498,10 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/repl'
     | '/projects/$projectSlug/settings'
     | '/admin/streams/$projectId/$'
+    | '/docs/streams/processors/$processorSlug'
     | '/projects/$projectSlug'
     | '/admin/streams/$projectId'
+    | '/docs/streams/processors'
     | '/projects/$projectSlug/agents/new'
     | '/projects/$projectSlug/repos/$'
     | '/projects/$projectSlug/secrets/$secretId'
@@ -457,12 +512,14 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/secrets'
     | '/projects/$projectSlug/streams'
     | '/projects/$projectSlug/agents/streams/$'
+    | '/docs/streams/processors/$processorSlug/events/$'
   id:
     | '__root__'
     | '/'
     | '/$eventDocsProcessorSlug'
     | '/_app'
     | '/admin'
+    | '/docs'
     | '/_app/projects'
     | '/admin/streams'
     | '/$eventDocsProcessorSlug/$'
@@ -477,6 +534,7 @@ export interface FileRouteTypes {
     | '/sign-in/$'
     | '/sign-up/$'
     | '/admin/'
+    | '/docs/'
     | '/_app/projects/$projectSlug'
     | '/admin/streams/$projectId'
     | '/_app/projects/'
@@ -486,8 +544,10 @@ export interface FileRouteTypes {
     | '/_app/projects/$projectSlug/repl'
     | '/_app/projects/$projectSlug/settings'
     | '/admin/streams/$projectId/$'
+    | '/docs/streams/processors/$processorSlug'
     | '/_app/projects/$projectSlug/'
     | '/admin/streams/$projectId/'
+    | '/docs/streams/processors/'
     | '/_app/projects/$projectSlug/agents/new'
     | '/_app/projects/$projectSlug/repos/$'
     | '/_app/projects/$projectSlug/secrets/$secretId'
@@ -498,6 +558,7 @@ export interface FileRouteTypes {
     | '/_app/projects/$projectSlug/secrets/'
     | '/_app/projects/$projectSlug/streams/'
     | '/_app/projects/$projectSlug/agents/streams/$'
+    | '/docs/streams/processors/$processorSlug/events/$'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -505,6 +566,7 @@ export interface RootRouteChildren {
   EventDocsProcessorSlugRoute: typeof EventDocsProcessorSlugRouteWithChildren
   AppRoute: typeof AppRouteWithChildren
   AdminRoute: typeof AdminRouteWithChildren
+  DocsRoute: typeof DocsRouteWithChildren
   ApiSplatRoute: typeof ApiSplatRoute
   ApiHealthRoute: typeof ApiHealthRoute
   ApiMcpRoute: typeof ApiMcpRoute
@@ -515,6 +577,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/docs': {
+      id: '/docs'
+      path: '/docs'
+      fullPath: '/docs'
+      preLoaderRoute: typeof DocsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/admin': {
       id: '/admin'
       path: '/admin'
@@ -542,6 +611,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/docs/': {
+      id: '/docs/'
+      path: '/'
+      fullPath: '/docs/'
+      preLoaderRoute: typeof DocsIndexRouteImport
+      parentRoute: typeof DocsRoute
     }
     '/admin/': {
       id: '/admin/'
@@ -669,6 +745,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppProjectsProjectSlugRouteRouteImport
       parentRoute: typeof AppProjectsRouteRoute
     }
+    '/docs/streams/processors/': {
+      id: '/docs/streams/processors/'
+      path: '/streams/processors'
+      fullPath: '/docs/streams/processors/'
+      preLoaderRoute: typeof DocsStreamsProcessorsIndexRouteImport
+      parentRoute: typeof DocsRoute
+    }
     '/admin/streams/$projectId/': {
       id: '/admin/streams/$projectId/'
       path: '/'
@@ -682,6 +765,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/projects/$projectSlug/'
       preLoaderRoute: typeof AppProjectsProjectSlugIndexRouteImport
       parentRoute: typeof AppProjectsProjectSlugRouteRoute
+    }
+    '/docs/streams/processors/$processorSlug': {
+      id: '/docs/streams/processors/$processorSlug'
+      path: '/streams/processors/$processorSlug'
+      fullPath: '/docs/streams/processors/$processorSlug'
+      preLoaderRoute: typeof DocsStreamsProcessorsProcessorSlugRouteImport
+      parentRoute: typeof DocsRoute
     }
     '/admin/streams/$projectId/$': {
       id: '/admin/streams/$projectId/$'
@@ -780,6 +870,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/projects/$projectSlug/agents/new'
       preLoaderRoute: typeof AppProjectsProjectSlugAgentsNewRouteImport
       parentRoute: typeof AppProjectsProjectSlugRouteRoute
+    }
+    '/docs/streams/processors/$processorSlug/events/$': {
+      id: '/docs/streams/processors/$processorSlug/events/$'
+      path: '/events/$'
+      fullPath: '/docs/streams/processors/$processorSlug/events/$'
+      preLoaderRoute: typeof DocsStreamsProcessorsProcessorSlugEventsSplatRouteImport
+      parentRoute: typeof DocsStreamsProcessorsProcessorSlugRoute
     }
     '/_app/projects/$projectSlug/agents/streams/$': {
       id: '/_app/projects/$projectSlug/agents/streams/$'
@@ -931,11 +1028,42 @@ const AdminRouteChildren: AdminRouteChildren = {
 
 const AdminRouteWithChildren = AdminRoute._addFileChildren(AdminRouteChildren)
 
+interface DocsStreamsProcessorsProcessorSlugRouteChildren {
+  DocsStreamsProcessorsProcessorSlugEventsSplatRoute: typeof DocsStreamsProcessorsProcessorSlugEventsSplatRoute
+}
+
+const DocsStreamsProcessorsProcessorSlugRouteChildren: DocsStreamsProcessorsProcessorSlugRouteChildren =
+  {
+    DocsStreamsProcessorsProcessorSlugEventsSplatRoute:
+      DocsStreamsProcessorsProcessorSlugEventsSplatRoute,
+  }
+
+const DocsStreamsProcessorsProcessorSlugRouteWithChildren =
+  DocsStreamsProcessorsProcessorSlugRoute._addFileChildren(
+    DocsStreamsProcessorsProcessorSlugRouteChildren,
+  )
+
+interface DocsRouteChildren {
+  DocsIndexRoute: typeof DocsIndexRoute
+  DocsStreamsProcessorsProcessorSlugRoute: typeof DocsStreamsProcessorsProcessorSlugRouteWithChildren
+  DocsStreamsProcessorsIndexRoute: typeof DocsStreamsProcessorsIndexRoute
+}
+
+const DocsRouteChildren: DocsRouteChildren = {
+  DocsIndexRoute: DocsIndexRoute,
+  DocsStreamsProcessorsProcessorSlugRoute:
+    DocsStreamsProcessorsProcessorSlugRouteWithChildren,
+  DocsStreamsProcessorsIndexRoute: DocsStreamsProcessorsIndexRoute,
+}
+
+const DocsRouteWithChildren = DocsRoute._addFileChildren(DocsRouteChildren)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   EventDocsProcessorSlugRoute: EventDocsProcessorSlugRouteWithChildren,
   AppRoute: AppRouteWithChildren,
   AdminRoute: AdminRouteWithChildren,
+  DocsRoute: DocsRouteWithChildren,
   ApiSplatRoute: ApiSplatRoute,
   ApiHealthRoute: ApiHealthRoute,
   ApiMcpRoute: ApiMcpRoute,

--- a/apps/os/src/routes/$eventDocsProcessorSlug.$.tsx
+++ b/apps/os/src/routes/$eventDocsProcessorSlug.$.tsx
@@ -1,18 +1,15 @@
-import { createFileRoute, notFound } from "@tanstack/react-router";
-import { EventDocPage } from "~/components/event-docs-pages.tsx";
-import { getEventDocByPath } from "~/lib/event-docs.ts";
+import { createFileRoute, notFound, redirect } from "@tanstack/react-router";
+import { getEventDocsRouteTarget } from "~/lib/event-docs.ts";
 
 export const Route = createFileRoute("/$eventDocsProcessorSlug/$")({
-  beforeLoad: ({ context }) => {
+  beforeLoad: ({ context, params }) => {
     if (!context.isEventDocsHost) throw notFound();
-  },
-  component: EventDocsEventRoute,
-});
 
-function EventDocsEventRoute() {
-  const { _splat, eventDocsProcessorSlug } = Route.useParams();
-  if (!_splat) throw notFound();
-  const event = getEventDocByPath(`${eventDocsProcessorSlug}/${_splat}`);
-  if (!event) throw notFound();
-  return <EventDocPage event={event} />;
-}
+    const target = getEventDocsRouteTarget(params);
+    if (!target) throw notFound();
+    throw redirect({
+      href: target.kind === "processor" ? target.processor.href : target.event.href,
+      replace: true,
+    });
+  },
+});

--- a/apps/os/src/routes/$eventDocsProcessorSlug.tsx
+++ b/apps/os/src/routes/$eventDocsProcessorSlug.tsx
@@ -1,20 +1,16 @@
-import { Outlet, createFileRoute, notFound, useMatches } from "@tanstack/react-router";
-import { ProcessorOverviewPage } from "~/components/event-docs-pages.tsx";
+import { Outlet, createFileRoute, notFound, redirect } from "@tanstack/react-router";
 import { getProcessorDocByPath } from "~/lib/event-docs.ts";
 
 export const Route = createFileRoute("/$eventDocsProcessorSlug")({
-  beforeLoad: ({ context }) => {
+  beforeLoad: ({ context, location, params }) => {
     if (!context.isEventDocsHost) throw notFound();
+
+    const pathSegments = location.pathname.split("/").filter(Boolean);
+    if (pathSegments.length !== 1) return;
+
+    const processor = getProcessorDocByPath(params.eventDocsProcessorSlug);
+    if (!processor) throw notFound();
+    throw redirect({ href: processor.href, replace: true });
   },
-  component: EventDocsProcessorRoute,
+  component: () => <Outlet />,
 });
-
-function EventDocsProcessorRoute() {
-  const matches = useMatches();
-  const { eventDocsProcessorSlug } = Route.useParams();
-  if (matches.at(-1)?.routeId === "/$eventDocsProcessorSlug/$") return <Outlet />;
-
-  const processor = getProcessorDocByPath(eventDocsProcessorSlug);
-  if (!processor) throw notFound();
-  return <ProcessorOverviewPage processor={processor} />;
-}

--- a/apps/os/src/routes/docs.index.tsx
+++ b/apps/os/src/routes/docs.index.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/docs/")({
+  beforeLoad: () => {
+    throw redirect({ to: "/docs/streams/processors", replace: true });
+  },
+});

--- a/apps/os/src/routes/docs.streams.processors.$processorSlug.events.$.tsx
+++ b/apps/os/src/routes/docs.streams.processors.$processorSlug.events.$.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute, notFound, redirect } from "@tanstack/react-router";
+import { EventDocPage } from "~/components/event-docs-pages.tsx";
+import { getEventDocByProcessorRoute } from "~/lib/event-docs.ts";
+
+export const Route = createFileRoute("/docs/streams/processors/$processorSlug/events/$")({
+  component: ProcessorEventRoute,
+});
+
+function ProcessorEventRoute() {
+  const { _splat, processorSlug } = Route.useParams();
+  if (!_splat) throw notFound();
+  const event = getEventDocByProcessorRoute({ processorSlug, eventPath: _splat });
+  if (!event) throw notFound();
+  if (event.routeParams.processorSlug !== processorSlug || event.routeParams._splat !== _splat) {
+    throw redirect({ href: event.href, replace: true });
+  }
+  return <EventDocPage event={event} />;
+}

--- a/apps/os/src/routes/docs.streams.processors.$processorSlug.tsx
+++ b/apps/os/src/routes/docs.streams.processors.$processorSlug.tsx
@@ -1,0 +1,19 @@
+import { Outlet, createFileRoute, notFound, redirect, useMatches } from "@tanstack/react-router";
+import { ProcessorOverviewPage } from "~/components/event-docs-pages.tsx";
+import { getProcessorDocByPath } from "~/lib/event-docs.ts";
+
+export const Route = createFileRoute("/docs/streams/processors/$processorSlug")({
+  component: ProcessorRoute,
+});
+
+function ProcessorRoute() {
+  const matches = useMatches();
+  const { processorSlug } = Route.useParams();
+  const processor = getProcessorDocByPath(processorSlug);
+  if (!processor) throw notFound();
+  if (matches.at(-1)?.routeId === "/docs/streams/processors/$processorSlug/events/$") {
+    return <Outlet />;
+  }
+  if (processor.slug !== processorSlug) throw redirect({ href: processor.href, replace: true });
+  return <ProcessorOverviewPage processor={processor} />;
+}

--- a/apps/os/src/routes/docs.streams.processors.index.tsx
+++ b/apps/os/src/routes/docs.streams.processors.index.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { EventDocsIndexPage } from "~/components/event-docs-pages.tsx";
+import { eventDocs, processorDocs } from "~/lib/event-docs.ts";
+
+export const Route = createFileRoute("/docs/streams/processors/")({
+  component: () => <EventDocsIndexPage eventDocs={eventDocs} processorDocs={processorDocs} />,
+});

--- a/apps/os/src/routes/docs.tsx
+++ b/apps/os/src/routes/docs.tsx
@@ -1,0 +1,5 @@
+import { Outlet, createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/docs")({
+  component: () => <Outlet />,
+});


### PR DESCRIPTION
## What changed

Restores the old canonical docs route shape for generated event docs:

- `/docs/streams/processors`
- `/docs/streams/processors/:processorSlug`
- `/docs/streams/processors/:processorSlug/events/*`

The short `events.iterate.com/:processor` and `events.iterate.com/:processor/*` event-type URLs now stay host-gated and redirect to those canonical docs pages.

## Why

`events.iterate.com/stream` could be matched by the top-level splat child route, so the processor overview URL could fall into event lookup behavior and 404/spinner instead of rendering docs. Using canonical docs routes makes the route tree unambiguous, while redirects preserve the public event-type URLs.

## Validation

- `pnpm --dir apps/os exec vitest run src/lib/event-docs.test.ts`
- `pnpm --dir apps/os exec oxlint ...touched files...`
- `pnpm --dir apps/os exec oxfmt --check ...touched files...`
- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/os test`

Also reviewed with two parallel agents; both flagged the same nested-route outlet and processor/event mismatch risks, which this PR addresses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public routing and URL contracts for event docs changed across hosts and redirects; regressions would surface as 404s or wrong pages, but behavior is covered by expanded unit tests and alias/ownership guards.
> 
> **Overview**
> **Restores canonical event documentation URLs** under `/docs/streams/processors`, processor overviews at `…/$processorSlug`, and event pages at `…/$processorSlug/events/*`, with new TanStack routes rendering the index, processor, and event pages there.
> 
> **Short `events.iterate.com` paths** (`/:processor` and `/:processor/*`) remain host-gated and now **redirect** to those canonical URLs instead of rendering docs inline, avoiding ambiguous splat matching (e.g. `/stream` hitting event lookup).
> 
> The **event-docs catalog** now builds `href` and link params from `/docs/streams/processors/…`, adds **`getEventDocByProcessorRoute`** and **`getEventDocsRouteTarget`** so resolution respects processor ownership and aliases (e.g. `core` → `stream`), and keeps events whose public path does not start with the processor slug under the owning processor route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b2e8941e174a151a2b3cc4d777dcd831387602d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-06T19:00:44.011Z",
      "headSha": "4b2e8941e174a151a2b3cc4d777dcd831387602d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/206272836779202",
      "shortSha": "4b2e894",
      "cleanupDurationMs": 4430,
      "deployDurationMs": 53233,
      "testDurationMs": 173450,
      "testRetries": "1 retried: itx > Project repos, workers, runScript, and dynamic worker refs compose (vitest x1)"
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-06T19:00:42.493Z",
      "headSha": "4b2e8941e174a151a2b3cc4d777dcd831387602d",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/206272836779202",
      "shortSha": "4b2e894",
      "cleanupDurationMs": 2909,
      "deployDurationMs": 17847,
      "testDurationMs": 835,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `4b2e894` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 17.8s | 835ms |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/206272836779202) | 2026-07-06T19:00:42.493Z | Preview app released. |
| OS | released | `4b2e894` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 53.2s | 173.4s | 1 retried: itx > Project repos, workers, runScript, and dynamic worker refs compose (vitest x1) | 4.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/206272836779202) | 2026-07-06T19:00:44.011Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->