### PR TITLE
[codex] Fix event docs SSR redirects

### DIFF
--- a/apps/os/src/routeTree.gen.ts
+++ b/apps/os/src/routeTree.gen.ts
@@ -42,6 +42,7 @@ import { Route as AppProjectsProjectSlugSettingsRouteImport } from './routes/_ap
 import { Route as AppProjectsProjectSlugReplRouteImport } from './routes/_app/projects/$projectSlug/repl'
 import { Route as AppProjectsProjectSlugReactivityRouteImport } from './routes/_app/projects/$projectSlug/reactivity'
 import { Route as AppProjectsProjectSlugIntegrationsRouteImport } from './routes/_app/projects/$projectSlug/integrations'
+import { Route as DocsStreamsProcessorsProcessorSlugIndexRouteImport } from './routes/docs.streams.processors.$processorSlug.index'
 import { Route as AppProjectsProjectSlugStreamsIndexRouteImport } from './routes/_app/projects/$projectSlug/streams/index'
 import { Route as AppProjectsProjectSlugSecretsIndexRouteImport } from './routes/_app/projects/$projectSlug/secrets/index'
 import { Route as AppProjectsProjectSlugSandboxesIndexRouteImport } from './routes/_app/projects/$projectSlug/sandboxes/index'
@@ -230,6 +231,12 @@ const AppProjectsProjectSlugIntegrationsRoute =
     path: '/integrations',
     getParentRoute: () => AppProjectsProjectSlugRouteRoute,
   } as any)
+const DocsStreamsProcessorsProcessorSlugIndexRoute =
+  DocsStreamsProcessorsProcessorSlugIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => DocsStreamsProcessorsProcessorSlugRoute,
+  } as any)
 const AppProjectsProjectSlugStreamsIndexRoute =
   AppProjectsProjectSlugStreamsIndexRouteImport.update({
     id: '/streams/',
@@ -339,6 +346,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/sandboxes/': typeof AppProjectsProjectSlugSandboxesIndexRoute
   '/projects/$projectSlug/secrets/': typeof AppProjectsProjectSlugSecretsIndexRoute
   '/projects/$projectSlug/streams/': typeof AppProjectsProjectSlugStreamsIndexRoute
+  '/docs/streams/processors/$processorSlug/': typeof DocsStreamsProcessorsProcessorSlugIndexRoute
   '/projects/$projectSlug/agents/streams/$': typeof AppProjectsProjectSlugAgentsStreamsSplatRoute
   '/docs/streams/processors/$processorSlug/events/$': typeof DocsStreamsProcessorsProcessorSlugEventsSplatRoute
 }
@@ -365,7 +373,6 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/repl': typeof AppProjectsProjectSlugReplRoute
   '/projects/$projectSlug/settings': typeof AppProjectsProjectSlugSettingsRoute
   '/admin/streams/$projectId/$': typeof AdminStreamsProjectIdSplatRoute
-  '/docs/streams/processors/$processorSlug': typeof DocsStreamsProcessorsProcessorSlugRouteWithChildren
   '/projects/$projectSlug': typeof AppProjectsProjectSlugIndexRoute
   '/admin/streams/$projectId': typeof AdminStreamsProjectIdIndexRoute
   '/docs/streams/processors': typeof DocsStreamsProcessorsIndexRoute
@@ -378,6 +385,7 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/sandboxes': typeof AppProjectsProjectSlugSandboxesIndexRoute
   '/projects/$projectSlug/secrets': typeof AppProjectsProjectSlugSecretsIndexRoute
   '/projects/$projectSlug/streams': typeof AppProjectsProjectSlugStreamsIndexRoute
+  '/docs/streams/processors/$processorSlug': typeof DocsStreamsProcessorsProcessorSlugIndexRoute
   '/projects/$projectSlug/agents/streams/$': typeof AppProjectsProjectSlugAgentsStreamsSplatRoute
   '/docs/streams/processors/$processorSlug/events/$': typeof DocsStreamsProcessorsProcessorSlugEventsSplatRoute
 }
@@ -425,6 +433,7 @@ export interface FileRoutesById {
   '/_app/projects/$projectSlug/sandboxes/': typeof AppProjectsProjectSlugSandboxesIndexRoute
   '/_app/projects/$projectSlug/secrets/': typeof AppProjectsProjectSlugSecretsIndexRoute
   '/_app/projects/$projectSlug/streams/': typeof AppProjectsProjectSlugStreamsIndexRoute
+  '/docs/streams/processors/$processorSlug/': typeof DocsStreamsProcessorsProcessorSlugIndexRoute
   '/_app/projects/$projectSlug/agents/streams/$': typeof AppProjectsProjectSlugAgentsStreamsSplatRoute
   '/docs/streams/processors/$processorSlug/events/$': typeof DocsStreamsProcessorsProcessorSlugEventsSplatRoute
 }
@@ -472,6 +481,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/sandboxes/'
     | '/projects/$projectSlug/secrets/'
     | '/projects/$projectSlug/streams/'
+    | '/docs/streams/processors/$processorSlug/'
     | '/projects/$projectSlug/agents/streams/$'
     | '/docs/streams/processors/$processorSlug/events/$'
   fileRoutesByTo: FileRoutesByTo
@@ -498,7 +508,6 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/repl'
     | '/projects/$projectSlug/settings'
     | '/admin/streams/$projectId/$'
-    | '/docs/streams/processors/$processorSlug'
     | '/projects/$projectSlug'
     | '/admin/streams/$projectId'
     | '/docs/streams/processors'
@@ -511,6 +520,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/sandboxes'
     | '/projects/$projectSlug/secrets'
     | '/projects/$projectSlug/streams'
+    | '/docs/streams/processors/$processorSlug'
     | '/projects/$projectSlug/agents/streams/$'
     | '/docs/streams/processors/$processorSlug/events/$'
   id:
@@ -557,6 +567,7 @@ export interface FileRouteTypes {
     | '/_app/projects/$projectSlug/sandboxes/'
     | '/_app/projects/$projectSlug/secrets/'
     | '/_app/projects/$projectSlug/streams/'
+    | '/docs/streams/processors/$processorSlug/'
     | '/_app/projects/$projectSlug/agents/streams/$'
     | '/docs/streams/processors/$processorSlug/events/$'
   fileRoutesById: FileRoutesById
@@ -808,6 +819,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppProjectsProjectSlugIntegrationsRouteImport
       parentRoute: typeof AppProjectsProjectSlugRouteRoute
     }
+    '/docs/streams/processors/$processorSlug/': {
+      id: '/docs/streams/processors/$processorSlug/'
+      path: '/'
+      fullPath: '/docs/streams/processors/$processorSlug/'
+      preLoaderRoute: typeof DocsStreamsProcessorsProcessorSlugIndexRouteImport
+      parentRoute: typeof DocsStreamsProcessorsProcessorSlugRoute
+    }
     '/_app/projects/$projectSlug/streams/': {
       id: '/_app/projects/$projectSlug/streams/'
       path: '/streams'
@@ -1029,11 +1047,14 @@ const AdminRouteChildren: AdminRouteChildren = {
 const AdminRouteWithChildren = AdminRoute._addFileChildren(AdminRouteChildren)
 
 interface DocsStreamsProcessorsProcessorSlugRouteChildren {
+  DocsStreamsProcessorsProcessorSlugIndexRoute: typeof DocsStreamsProcessorsProcessorSlugIndexRoute
   DocsStreamsProcessorsProcessorSlugEventsSplatRoute: typeof DocsStreamsProcessorsProcessorSlugEventsSplatRoute
 }
 
 const DocsStreamsProcessorsProcessorSlugRouteChildren: DocsStreamsProcessorsProcessorSlugRouteChildren =
   {
+    DocsStreamsProcessorsProcessorSlugIndexRoute:
+      DocsStreamsProcessorsProcessorSlugIndexRoute,
     DocsStreamsProcessorsProcessorSlugEventsSplatRoute:
       DocsStreamsProcessorsProcessorSlugEventsSplatRoute,
   }

--- a/apps/os/src/routes/docs.streams.processors.$processorSlug.events.$.tsx
+++ b/apps/os/src/routes/docs.streams.processors.$processorSlug.events.$.tsx
@@ -3,16 +3,20 @@ import { EventDocPage } from "~/components/event-docs-pages.tsx";
 import { getEventDocByProcessorRoute } from "~/lib/event-docs.ts";
 
 export const Route = createFileRoute("/docs/streams/processors/$processorSlug/events/$")({
+  loader: ({ params }) => {
+    const { _splat, processorSlug } = params;
+    if (!_splat) throw notFound();
+    const event = getEventDocByProcessorRoute({ processorSlug, eventPath: _splat });
+    if (!event) throw notFound();
+    if (event.routeParams.processorSlug !== processorSlug || event.routeParams._splat !== _splat) {
+      throw redirect({ href: event.href, replace: true });
+    }
+    return { event };
+  },
   component: ProcessorEventRoute,
 });
 
 function ProcessorEventRoute() {
-  const { _splat, processorSlug } = Route.useParams();
-  if (!_splat) throw notFound();
-  const event = getEventDocByProcessorRoute({ processorSlug, eventPath: _splat });
-  if (!event) throw notFound();
-  if (event.routeParams.processorSlug !== processorSlug || event.routeParams._splat !== _splat) {
-    throw redirect({ href: event.href, replace: true });
-  }
+  const { event } = Route.useLoaderData();
   return <EventDocPage event={event} />;
 }

--- a/apps/os/src/routes/docs.streams.processors.$processorSlug.index.tsx
+++ b/apps/os/src/routes/docs.streams.processors.$processorSlug.index.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { ProcessorOverviewPage } from "~/components/event-docs-pages.tsx";
+
+export const Route = createFileRoute("/docs/streams/processors/$processorSlug/")({
+  beforeLoad: ({ context, params }) => {
+    if (context.processor.slug !== params.processorSlug) {
+      throw redirect({ href: context.processor.href, replace: true });
+    }
+  },
+  component: ProcessorIndexRoute,
+});
+
+function ProcessorIndexRoute() {
+  const { processor } = Route.useRouteContext();
+  return <ProcessorOverviewPage processor={processor} />;
+}

--- a/apps/os/src/routes/docs.streams.processors.$processorSlug.tsx
+++ b/apps/os/src/routes/docs.streams.processors.$processorSlug.tsx
@@ -1,19 +1,11 @@
-import { Outlet, createFileRoute, notFound, redirect, useMatches } from "@tanstack/react-router";
-import { ProcessorOverviewPage } from "~/components/event-docs-pages.tsx";
+import { Outlet, createFileRoute, notFound } from "@tanstack/react-router";
 import { getProcessorDocByPath } from "~/lib/event-docs.ts";
 
 export const Route = createFileRoute("/docs/streams/processors/$processorSlug")({
-  component: ProcessorRoute,
+  beforeLoad: ({ params }) => {
+    const processor = getProcessorDocByPath(params.processorSlug);
+    if (!processor) throw notFound();
+    return { processor };
+  },
+  component: () => <Outlet />,
 });
-
-function ProcessorRoute() {
-  const matches = useMatches();
-  const { processorSlug } = Route.useParams();
-  const processor = getProcessorDocByPath(processorSlug);
-  if (!processor) throw notFound();
-  if (matches.at(-1)?.routeId === "/docs/streams/processors/$processorSlug/events/$") {
-    return <Outlet />;
-  }
-  if (processor.slug !== processorSlug) throw redirect({ href: processor.href, replace: true });
-  return <ProcessorOverviewPage processor={processor} />;
-}


### PR DESCRIPTION
## Summary

Follow-up to #1684. The public event docs are live again, but docs-prefixed alias URLs such as `/docs/streams/processors/core` and `/docs/streams/processors/core/events/created` were still producing SSR `200` loading shells because their canonical redirects were thrown from React render.

This moves canonicalization into route lifecycle hooks:

- make `/docs/streams/processors/$processorSlug` a layout route that validates the processor and renders an outlet
- add an index child for processor overview pages and processor alias redirects
- move event alias/not-found handling into the event route loader

## Validation

- `pnpm --dir apps/os exec vitest run src/lib/event-docs.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/os exec oxlint 'src/routes/docs.streams.processors.$processorSlug.tsx' 'src/routes/docs.streams.processors.$processorSlug.index.tsx' 'src/routes/docs.streams.processors.$processorSlug.events.$.tsx' src/routeTree.gen.ts`
- `pnpm --dir apps/os exec oxfmt --check 'src/routes/docs.streams.processors.$processorSlug.tsx' 'src/routes/docs.streams.processors.$processorSlug.index.tsx' 'src/routes/docs.streams.processors.$processorSlug.events.$.tsx' src/routeTree.gen.ts`
- `pnpm --dir apps/os test`
- Local SSR smoke with `Host: events.iterate.com`:
  - `/docs/streams/processors/core` -> `307 /docs/streams/processors/stream`
  - `/docs/streams/processors/core/events/created` -> `307 /docs/streams/processors/stream/events/created`
  - `/docs/streams/processors/stream/events/created` -> `200` with payload schema

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to public event-docs routing and redirect behavior; no auth or data-layer changes.
> 
> **Overview**
> Fixes **SSR returning `200` loading shells** for docs-prefixed processor/event alias URLs (e.g. `/docs/streams/processors/core`) by moving canonicalization out of React render and into TanStack Router lifecycle hooks.
> 
> The **`$processorSlug` route becomes a layout**: it validates the processor in `beforeLoad`, puts it on route context, and renders an `<Outlet />`. A new **index child** serves the overview and issues **alias redirects** in `beforeLoad` when the URL slug does not match the canonical processor slug.
> 
> The **event splat route** now resolves the event, handles `notFound`, and canonical redirects inside a **`loader`**, with the component only reading loader data. Generated **`routeTree.gen.ts`** registers the new index route and updates `fileRoutesByTo` so the processor path resolves to the index route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 787cf64578d238c45d8c573d7f07f3d471fc435f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-06T19:12:46.828Z",
      "headSha": "787cf64578d238c45d8c573d7f07f3d471fc435f",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/357954812040618",
      "shortSha": "787cf64",
      "cleanupDurationMs": 4607,
      "deployDurationMs": 59512,
      "testDurationMs": 137662,
      "testRetries": "4 retried: itx > ITX expression capabilities reject self-aliases at provide time (vitest x1) · itx > Worker capabilities cover project/agent, stateful/stateless, repo/inline refs and env.ITX cross-calls (vitest x1) · itx > Nested plain-object live capability members survive after provideCapability returns (vitest x1) · runs \"dynamic-worker-stateless\" through the project REPL (specs x1)"
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-06T19:12:45.078Z",
      "headSha": "787cf64578d238c45d8c573d7f07f3d471fc435f",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/357954812040618",
      "shortSha": "787cf64",
      "cleanupDurationMs": 2855,
      "deployDurationMs": 22546,
      "testDurationMs": 949,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `787cf64` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 22.5s | 949ms |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/357954812040618) | 2026-07-06T19:12:45.078Z | Preview app released. |
| OS | released | `787cf64` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 59.5s | 137.7s | 4 retried: itx > ITX expression capabilities reject self-aliases at provide time (vitest x1) · itx > Worker capabilities cover project/agent, stateful/stateless, repo/inline refs and env.ITX cross-calls (vitest x1) · itx > Nested plain-object live capability members survive after provideCapability returns (vitest x1) · runs "dynamic-worker-stateless" through the project REPL (specs x1) | 4.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/357954812040618) | 2026-07-06T19:12:46.828Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->