### PR TITLE
[codex] Default iterate CLI to chat

### DIFF
--- a/packages/iterate/README.md
+++ b/packages/iterate/README.md
@@ -1,79 +1,52 @@
 # iterate
 
-⚠️⚠️⚠️ Coming soon! `npx iterate` is a work-in-progress CLI for managing [iterate.com](https://iterate.com) agents ⚠️⚠️⚠️
-
 CLI for Iterate.
 
-Runs as a thin bootstrapper that:
+`npx iterate` opens the Iterate chat terminal UI. It is equivalent to
+`npx iterate chat`.
 
-1. Resolves an `iterate/iterate` checkout.
-2. Clones/install deps when needed.
-3. Loads local command routers from that checkout.
-4. Exposes commands like `iterate os itx ...` and `iterate orgs list`.
+The package also runs as a thin bootstrapper: inside this repo it delegates to
+the local `packages/iterate` source, and from npm it runs the published build.
 
 ## Requirements
 
 - Node `>=22`
-- `git`
-- `pnpm` or `corepack`
+- Bun, for the current OpenTUI-based chat terminal runtime
 
 ## Quick start
 
 Run without installing globally:
 
 ```bash
-npx iterate --help
+npx iterate
 ```
 
-Initial setup (writes auth + launcher config):
+If you are not logged in yet, `iterate chat` starts the browser OAuth flow. The
+auth flow asks for project access and can create your first organization and
+project before returning to the CLI.
 
 ```bash
-npx iterate setup \
-  --os-base-url https://dev-yourname-os.dev.iterate.com \
-  --auth-base-url https://auth.iterate.com \
-  --daemon-base-url http://localhost:3001 \
-  --admin-password-env-var-name APP_CONFIG_SERVICE_AUTH_TOKEN \
-  --user-email dev-yourname@iterate.com \
-  --scope global
-```
-
-Then run commands:
-
-```bash
-npx iterate config local
-npx iterate login
 npx iterate chat
+```
+
+For help and other commands:
+
+```bash
+npx iterate --help
+npx iterate login
 npx iterate orgs list
-npx iterate os project list
+npx iterate config list
 ```
 
 ## Commands
 
-- `iterate setup` - configure auth + launcher defaults
-- `iterate chat` - open the production Iterate chat terminal UI
-- `iterate doctor` - print resolved config/runtime info
-- `iterate install` - force clone/install for resolved checkout
+- `iterate` - open chat
+- `iterate chat` - open the Iterate agent chat terminal UI
+- `iterate login` - authenticate with browser-based OAuth
+- `iterate logout` - remove the stored session for the current config
 - `iterate orgs list`
+- `iterate config ...`
 - `iterate os ...`
-- `iterate daemon ...`
-
-`setup --scope global` writes auth + launcher values into `global`; `setup --scope workspace` writes them into `workspaces[process.cwd()]`.
-
-For local auth development, set `authBaseUrl` to `http://localhost:7101`. If you omit it and
-your `osBaseUrl` is `http://localhost:*` or `*.iterate-dev.com`, the CLI defaults to
-`http://localhost:7101`.
-
-To bootstrap a local repo config quickly, run:
-
-```bash
-npx iterate config local
-```
-
-That creates a `local` config with:
-
-- `osBaseUrl = https://<your-username>.iterate-dev.com`
-- `authBaseUrl = http://localhost:7101`
-- `daemonBaseUrl = http://localhost:3001`
 
 ## Config file
 
@@ -89,20 +62,11 @@ Config shape:
     "default": {
       "osBaseUrl": "https://os.iterate.com",
       "authBaseUrl": "https://auth.iterate.com",
-      "daemonBaseUrl": "http://localhost:3000",
-      "auth": {
-        "strategy": "device"
-      }
+      "defaultProject": "my-project"
     },
     "dev": {
-      "osBaseUrl": "https://dev-yourname-os.dev.iterate.com",
-      "authBaseUrl": "https://auth-dev-yourname.iterate.com",
-      "daemonBaseUrl": "http://localhost:3001",
-      "auth": {
-        "strategy": "admin",
-        "adminPasswordEnvVarName": "APP_CONFIG_SERVICE_AUTH_TOKEN",
-        "userEmail": "dev-yourname@iterate.com"
-      }
+      "osBaseUrl": "http://localhost:54896",
+      "authBaseUrl": "http://localhost:7101"
     }
   },
   "default": "default",
@@ -114,33 +78,20 @@ Config shape:
 
 Config resolution priority: `--config` flag > workspace match (walk up from cwd) > `default` key > single-config auto-select.
 
-Auth strategies:
-
-- `device` — interactive browser-based login (RFC 8628 device flow). Run `iterate login`.
-- `admin` — CI/automation impersonation via admin password env var.
-
 ## Local iterate dev
 
-If you run inside an `iterate/iterate` clone, the CLI auto-detects it. In that mode, default `autoInstall` is `false`.
-
-You can pin explicitly:
-
-```bash
-npx iterate setup \
-  --os-base-url https://dev-yourname-os.dev.iterate.com \
-  --daemon-base-url http://localhost:3001 \
-  --admin-password-env-var-name APP_CONFIG_SERVICE_AUTH_TOKEN \
-  --user-email dev-yourname@iterate.com \
-  --scope workspace
-```
+If you run inside an `iterate/iterate` clone, the CLI auto-detects it and
+delegates to the local source instead of the published build.
 
 ## Publishing (maintainers)
 
 From repo root:
 
 ```bash
+pnpm --filter ./packages/iterate build
 pnpm --filter ./packages/iterate typecheck
-pnpm oxlint packages/iterate/bin/iterate.js
-pnpm oxfmt --check packages/iterate
+pnpm --filter ./packages/iterate test
+pnpm exec oxlint packages/iterate/src/cli.ts packages/iterate/src/cli.test.ts
+pnpm exec oxfmt --check packages/iterate
 pnpm --filter ./packages/iterate publish --access public
 ```

--- a/packages/iterate/src/cli.test.ts
+++ b/packages/iterate/src/cli.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import {
+  defaultBareInvocationToChat,
+  ensureBearerAuthHeadersForChat,
   oauthResourceForOsBaseUrl,
   refreshOAuthSession,
   resolveChatProject,
@@ -137,6 +139,58 @@ describe("verifyOsSession", () => {
     });
     expect(description.principal).toBe("user_123");
     expect(fake.disposeAuthenticated).toHaveBeenCalledOnce();
+  });
+});
+
+describe("defaultBareInvocationToChat", () => {
+  test("runs chat for a bare invocation", () => {
+    expect(defaultBareInvocationToChat([])).toEqual(["chat"]);
+  });
+
+  test("leaves explicit commands and flags untouched", () => {
+    const explicit = ["chat", "--project", "prj_123"];
+    expect(defaultBareInvocationToChat(explicit)).toBe(explicit);
+
+    const help = ["--help"];
+    expect(defaultBareInvocationToChat(help)).toBe(help);
+  });
+});
+
+describe("ensureBearerAuthHeadersForChat", () => {
+  test("uses an existing bearer session without logging in", async () => {
+    const login = vi.fn();
+    await expect(
+      ensureBearerAuthHeadersForChat({
+        getAuthHeaders: async () => ({ authorization: "Bearer token_123" }),
+        login,
+        osBaseUrl: "https://os.iterate.com",
+      }),
+    ).resolves.toEqual({ authorization: "Bearer token_123" });
+
+    expect(login).not.toHaveBeenCalled();
+  });
+
+  test("logs in when the stored session is not usable as a bearer token", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const login = vi.fn();
+    const getAuthHeaders = vi
+      .fn<() => Promise<{ authorization?: string; cookie?: string }>>()
+      .mockResolvedValueOnce({ cookie: "session=old" })
+      .mockResolvedValueOnce({ authorization: "Bearer token_new" });
+
+    await expect(
+      ensureBearerAuthHeadersForChat({
+        getAuthHeaders,
+        login,
+        osBaseUrl: "https://os.iterate.com",
+      }),
+    ).resolves.toEqual({ authorization: "Bearer token_new" });
+
+    expect(login).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(
+      "Stored session for https://os.iterate.com cannot be used for chat. Starting browser login...",
+    );
+    consoleError.mockRestore();
   });
 });
 

--- a/packages/iterate/src/cli.ts
+++ b/packages/iterate/src/cli.ts
@@ -78,6 +78,15 @@ const firstNonFlagArgument = (args: string[]): string | undefined => {
   return undefined;
 };
 
+export const defaultBareInvocationToChat = (args: string[]) =>
+  args.length === 0 ? ["chat"] : args;
+
+const applyDefaultBareInvocation = () => {
+  const args = process.argv.slice(2);
+  const nextArgs = defaultBareInvocationToChat(args);
+  if (nextArgs !== args) process.argv.splice(2, args.length, ...nextArgs);
+};
+
 const resolveStreamTuiEntrypointPath = () => {
   const moduleDir = import.meta.dirname;
   const candidates = [
@@ -204,6 +213,16 @@ function resolveConfig(
   return result;
 }
 
+class StoredOsSessionError extends Error {
+  constructor(
+    readonly reason: "missing" | "expired",
+    message: string,
+  ) {
+    super(message);
+    this.name = "StoredOsSessionError";
+  }
+}
+
 /**
  * Get auth headers for OS API calls based on the resolved config's stored session.
  * OAuth sessions are refreshed when possible.
@@ -211,13 +230,19 @@ function resolveConfig(
 const getOsAuthHeaders = async (config: Config, configName?: string): Promise<OsAuthHeaders> => {
   let session = config.session;
   if (!session) {
-    throw new Error(`Not logged in to ${config.osBaseUrl}. Run \`iterate login\` first.`);
+    throw new StoredOsSessionError(
+      "missing",
+      `Not logged in to ${config.osBaseUrl}. Run \`iterate login\` first.`,
+    );
   }
   if (sessionNeedsRefresh(session)) {
     if (session.refreshToken && session.clientId) {
       session = await refreshOAuthSession({ config, configName, session });
     } else {
-      throw new Error(`Session expired for ${config.osBaseUrl}. Run \`iterate login\` again.`);
+      throw new StoredOsSessionError(
+        "expired",
+        `Session expired for ${config.osBaseUrl}. Run \`iterate login\` again.`,
+      );
     }
   }
   if (session.token) {
@@ -767,6 +792,49 @@ const oauthLogin = async (config: Config): Promise<StoredSession> => {
   return session;
 };
 
+const loginToResolvedConfig = async (resolved: { name: string; config: Config }) => {
+  const { config } = resolved;
+
+  console.error(`Logging in to ${config.authBaseUrl}...`);
+  const oauthResult = await oauthLogin(config);
+  updateConfigSession(resolved.name, oauthResult);
+  // Update in-memory config so subsequent verification and calls see the token.
+  config.session = oauthResult;
+
+  await verifyOsSession({
+    authHeaders: await getOsAuthHeaders(config, resolved.name),
+    baseUrl: config.osBaseUrl,
+  }).catch((error: unknown) => {
+    throw new Error(`Failed to verify OS session: ${errorMessage(error)}`);
+  });
+
+  return oauthResult;
+};
+
+const shouldAutoLoginForChat = (error: unknown) =>
+  error instanceof StoredOsSessionError &&
+  (error.reason === "missing" || error.reason === "expired");
+
+export const ensureBearerAuthHeadersForChat = async (input: {
+  getAuthHeaders: () => Promise<OsAuthHeaders>;
+  login: () => Promise<void>;
+  osBaseUrl: string;
+}) => {
+  let authHeaders = await input.getAuthHeaders();
+  if (authHeaders.authorization) return authHeaders;
+
+  console.error(
+    `Stored session for ${input.osBaseUrl} cannot be used for chat. Starting browser login...`,
+  );
+  await input.login();
+  authHeaders = await input.getAuthHeaders();
+  if (authHeaders.authorization) return authHeaders;
+
+  throw new Error(
+    `Stored session for ${input.osBaseUrl} has no bearer token. Run \`iterate login\` again.`,
+  );
+};
+
 const loadRemoteProcedures = async (params: {
   baseUrl: string;
 }): Promise<{ procedures: ParsedRouter }> => {
@@ -861,20 +929,7 @@ const launcherProcedures = {
     })
     .handler(async () => {
       const resolved = resolveConfig(process.cwd(), { throw: true });
-      const { config } = resolved;
-
-      console.error(`Logging in to ${config.authBaseUrl}...`);
-      const oauthResult = await oauthLogin(config);
-      updateConfigSession(resolved.name, oauthResult);
-      // Update in-memory config so subsequent verification and calls see the token.
-      config.session = oauthResult;
-
-      await verifyOsSession({
-        authHeaders: await getOsAuthHeaders(config, resolved.name),
-        baseUrl: config.osBaseUrl,
-      }).catch((error: unknown) => {
-        throw new Error(`Failed to verify OS session: ${errorMessage(error)}`);
-      });
+      const oauthResult = await loginToResolvedConfig(resolved);
       return {
         message: "Logged in successfully",
         expiresAt: oauthResult.expiresAt,
@@ -921,12 +976,34 @@ const launcherProcedures = {
       const resolved = resolveConfig(process.cwd(), { throw: true });
       const envAuth = osAuthFromEnvironment();
       let storedAuthHeaders: OsAuthHeaders | undefined;
+      let didAutoLogin = false;
+      const loginForChat = async () => {
+        didAutoLogin = true;
+        storedAuthHeaders = undefined;
+        await loginToResolvedConfig(resolved);
+      };
       const getStoredAuthHeaders = async () => {
-        storedAuthHeaders ??= await getOsAuthHeaders(resolved.config, resolved.name);
+        if (storedAuthHeaders) return storedAuthHeaders;
+        try {
+          storedAuthHeaders = await getOsAuthHeaders(resolved.config, resolved.name);
+        } catch (error) {
+          if (didAutoLogin || !shouldAutoLoginForChat(error)) throw error;
+          console.error(
+            `No active session for ${resolved.config.osBaseUrl}. Starting browser login...`,
+          );
+          await loginForChat();
+          storedAuthHeaders = await getOsAuthHeaders(resolved.config, resolved.name);
+        }
         return storedAuthHeaders;
       };
+      const getStoredBearerAuthHeaders = () =>
+        ensureBearerAuthHeadersForChat({
+          getAuthHeaders: getStoredAuthHeaders,
+          login: loginForChat,
+          osBaseUrl: resolved.config.osBaseUrl,
+        });
       const project = await resolveChatProject({
-        auth: envAuth ?? osAuthFromHeaders(await getStoredAuthHeaders()),
+        auth: envAuth ?? osAuthFromHeaders(await getStoredBearerAuthHeaders()),
         baseUrl: resolved.config.osBaseUrl,
         configName: resolved.name,
         configPath: CONFIG_PATH,
@@ -945,7 +1022,7 @@ const launcherProcedures = {
       // bearer token; the capnweb WebSocket authenticates once at connect.
       const env: Record<string, string | undefined> = { ITERATE_CONFIG_NAME: resolved.name };
       if (!envAuth) {
-        const headers = await getStoredAuthHeaders();
+        const headers = await getStoredBearerAuthHeaders();
         const token = headers.authorization?.replace(/^Bearer /, "");
         if (!token) {
           throw new Error(
@@ -1103,6 +1180,7 @@ const launcherProcedures = {
 export const getCli = async () => {
   // Parse custom top-level flags early, before trpc-cli sees the args.
   configFlagOverride = consumeCliStringFlag("--config");
+  applyDefaultBareInvocation();
   const requestedRootCommand = firstNonFlagArgument(process.argv.slice(2));
   const shouldLoadRemoteRouters =
     !requestedRootCommand ||


### PR DESCRIPTION
## Summary

- default bare `iterate` invocations to the local `chat` command while leaving explicit commands and flags alone
- make `iterate chat` start browser OAuth login when the stored OS session is missing, expired, or not usable as a bearer token
- update the npm-facing README to match the current CLI surface and document the Bun runtime requirement

## Self-review notes

- The default is applied after the existing host-level `--config` flag is consumed and before `trpc-cli` command discovery, so explicit local commands still avoid remote router loading and `iterate --help` stays help.
- The chat auto-login path reuses the same login + OS verification flow as `iterate login`; it does not add a second OAuth implementation.
- Inherited env auth still wins for Doppler/admin/e2e flows.
- I replaced brittle exact-message matching with a private `StoredOsSessionError` for missing/expired stored OS sessions.
- No API schemas, env vars, DB schema, or high-level service contracts changed.

## Runtime caveat

The current chat TUI still launches Bun because this package currently depends on OpenTUI `0.1.102`, whose core runtime imports `bun:ffi`. I asked a parallel agent to research current OpenTUI: latest stable appears to support Node narrowly in `0.4.x`, but native rendering requires Node `26.3.0` plus `--experimental-ffi` (and permissions flags when enabled). So this PR keeps the Bun requirement honest instead of claiming ordinary Node/npm `npx` is enough.

## Validation

- `pnpm --filter ./packages/iterate test`
- `pnpm --filter ./packages/iterate typecheck`
- `pnpm --filter ./packages/iterate build`
- `pnpm exec oxlint packages/iterate/src/cli.ts packages/iterate/src/cli.test.ts`
- `pnpm exec oxfmt --check packages/iterate/README.md packages/iterate/src/cli.ts packages/iterate/src/cli.test.ts`
- `git diff --check`

`pnpm --filter ./packages/iterate build` still emits the existing `rolldown-plugin-dts:fake-js` sourcemap warning but exits successfully. I did not run a live browser OAuth login against production.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth/session handling on the chat path (auto-login and bearer enforcement), which is security-sensitive but reuses the existing login flow without new contracts.
> 
> **Overview**
> **Bare `npx iterate` now opens chat** by rewriting empty argv to `chat` before command discovery, while explicit subcommands and flags (e.g. `--help`) are unchanged.
> 
> **`iterate chat` can start browser OAuth automatically** when the stored OS session is missing, expired, or only usable as a cookie (not a bearer token). Login is centralized in `loginToResolvedConfig` (shared with `iterate login`), with `StoredOsSessionError` distinguishing missing vs expired sessions for the auto-login path. Environment admin/bearer auth still bypasses stored sessions.
> 
> The **npm README** is updated to describe chat-first usage, Bun for the OpenTUI TUI, and a slimmer config/command surface (less setup/daemon/admin-auth detail).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be15dc62ec83a1efaada46fcb96c07769b258c3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->