### PR TITLE
[codex] Fix npx iterate inside repo checkouts

### DIFF
--- a/packages/iterate/bin/iterate.js
+++ b/packages/iterate/bin/iterate.js
@@ -28,6 +28,13 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const pkgRoot = dirname(__dirname);
 
+// `npx iterate` and `bunx iterate` should exercise the package that the runner
+// just installed. Normal installed/global executions still delegate to local
+// repo source below, which keeps monorepo development fast.
+const isEphemeralPackageRunner = () =>
+  process.env.npm_command === "exec" &&
+  (process.env.npm_lifecycle_event === "npx" || process.env.npm_lifecycle_event === "bunx");
+
 /**
  * Find a local version of the iterate CLI that differs from the currently
  * running script. Returns an importable module path, or null.
@@ -64,7 +71,7 @@ const findLocalModule = () => {
   return null;
 };
 
-const localModule = findLocalModule();
+const localModule = isEphemeralPackageRunner() ? null : findLocalModule();
 if (localModule) {
   const { runCli } = await import(localModule);
   await runCli();

--- a/packages/iterate/package.json
+++ b/packages/iterate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iterate",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "CLI for iterate",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/iterate/src/cli.test.ts
+++ b/packages/iterate/src/cli.test.ts
@@ -1,3 +1,8 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, test, vi } from "vitest";
 import {
   defaultBareInvocationToChat,
@@ -153,6 +158,96 @@ describe("defaultBareInvocationToChat", () => {
 
     const help = ["--help"];
     expect(defaultBareInvocationToChat(help)).toBe(help);
+  });
+});
+
+describe("bin wrapper", () => {
+  test("can load repo source through Node's strip-only TypeScript loader", () => {
+    const binPath = fileURLToPath(new URL("../bin/iterate.js", import.meta.url));
+    const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+    const result = spawnSync(process.execPath, [binPath, "--help"], {
+      cwd: packageRoot,
+      encoding: "utf8",
+      env: { ...process.env, NO_COLOR: "1" },
+    });
+
+    expect(result.stderr).not.toContain("ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX");
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain("iterate");
+  });
+
+  test("npx-style execution uses the published package instead of repo source", () => {
+    const sourceBinPath = fileURLToPath(new URL("../bin/iterate.js", import.meta.url));
+    const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+    const tempRoot = mkdtempSync(join(tmpdir(), "iterate-bin-test-"));
+    const fakePackageRoot = join(tempRoot, "node_modules", "iterate");
+    const fakeBinDir = join(fakePackageRoot, "bin");
+    const fakeDistDir = join(fakePackageRoot, "dist");
+    const fakeBinPath = join(fakeBinDir, "iterate.js");
+
+    try {
+      mkdirSync(fakeBinDir, { recursive: true });
+      mkdirSync(fakeDistDir, { recursive: true });
+      writeFileSync(join(fakePackageRoot, "package.json"), '{"type":"module"}\n');
+      writeFileSync(fakeBinPath, readFileSync(sourceBinPath));
+      writeFileSync(
+        join(fakeDistDir, "index.mjs"),
+        "export async function runCli() { console.log('fake published dist'); }\n",
+      );
+
+      const result = spawnSync(process.execPath, [fakeBinPath], {
+        cwd: packageRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          npm_command: "exec",
+          npm_lifecycle_event: "npx",
+        },
+      });
+
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+      expect(result.stdout.trim()).toBe("fake published dist");
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("normal installed execution still delegates to repo source", () => {
+    const sourceBinPath = fileURLToPath(new URL("../bin/iterate.js", import.meta.url));
+    const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+    const tempRoot = mkdtempSync(join(tmpdir(), "iterate-bin-test-"));
+    const fakePackageRoot = join(tempRoot, "node_modules", "iterate");
+    const fakeBinDir = join(fakePackageRoot, "bin");
+    const fakeDistDir = join(fakePackageRoot, "dist");
+    const fakeBinPath = join(fakeBinDir, "iterate.js");
+
+    try {
+      mkdirSync(fakeBinDir, { recursive: true });
+      mkdirSync(fakeDistDir, { recursive: true });
+      writeFileSync(join(fakePackageRoot, "package.json"), '{"type":"module"}\n');
+      writeFileSync(fakeBinPath, readFileSync(sourceBinPath));
+      writeFileSync(
+        join(fakeDistDir, "index.mjs"),
+        "export async function runCli() { console.log('fake published dist'); }\n",
+      );
+
+      const result = spawnSync(process.execPath, [fakeBinPath, "--help"], {
+        cwd: packageRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NO_COLOR: "1",
+          npm_command: "",
+          npm_lifecycle_event: "",
+        },
+      });
+
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+      expect(result.stdout).not.toContain("fake published dist");
+      expect(`${result.stdout}\n${result.stderr}`).toContain("Iterate CLI");
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
   });
 });
 

--- a/packages/iterate/src/cli.ts
+++ b/packages/iterate/src/cli.ts
@@ -214,11 +214,11 @@ function resolveConfig(
 }
 
 class StoredOsSessionError extends Error {
-  constructor(
-    readonly reason: "missing" | "expired",
-    message: string,
-  ) {
+  readonly reason: "missing" | "expired";
+
+  constructor(reason: "missing" | "expired", message: string) {
     super(message);
+    this.reason = reason;
     this.name = "StoredOsSessionError";
   }
 }

--- a/packages/iterate/tsconfig.json
+++ b/packages/iterate/tsconfig.json
@@ -11,6 +11,7 @@
       "@iterate-com/ui/*": ["../ui/src/*"]
     },
     "strict": true,
+    "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true,
     "isolatedModules": true,
     "noUncheckedSideEffectImports": true,


### PR DESCRIPTION
## Summary
- make npx/bunx-style execution use the published package dist instead of delegating into repo source
- remove a TypeScript parameter property that Node strip-only loading cannot parse
- add regression coverage for repo-source loading and npx-style published package execution
- bump packages/iterate to 0.2.7 for the npm hotfix

## Validation
- pnpm --filter ./packages/iterate test
- pnpm --filter ./packages/iterate typecheck
- pnpm --filter ./packages/iterate build
- pnpm exec oxlint packages/iterate/src/cli.ts packages/iterate/src/cli.test.ts packages/iterate/bin/iterate.js
- pnpm exec oxfmt --check packages/iterate
- npm pack --pack-destination /tmp
- npx --yes --package /tmp/iterate-0.2.7.tgz iterate --help
- bunx -p /tmp/iterate-0.2.7.tgz iterate --help

Build still emits the existing rolldown-plugin-dts:fake-js sourcemap warning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI bootstrap and TypeScript syntax compatibility only; behavior change is scoped to npx/bunx vs local delegation, with tests covering the paths.
> 
> **Overview**
> Fixes **`npx iterate`** and **`bunx iterate`** inside monorepo checkouts so they run the **installed package** (`dist`) instead of delegating into **repo `src`**, which could break or diverge from what users expect from the runner.
> 
> The bin wrapper skips local delegation when `npm_command === "exec"` and the lifecycle event is **`npx`** or **`bunx`**; normal installs still delegate to local repo source for fast dev.
> 
> **`StoredOsSessionError`** drops the constructor parameter property in favor of an explicit `readonly reason` field so Node’s strip-only TypeScript loader can load **`cli.ts`** without `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`. **`erasableSyntaxOnly`** is enabled in the package tsconfig.
> 
> Adds **bin wrapper** regression tests (help via strip-only load, npx vs normal delegation) and bumps **`iterate`** to **0.2.7**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf2c4d15ab44d55f4d30246bb6f979c6376088f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->