### PR TITLE
Bake python3 into the sandbox image

### DIFF
--- a/apps/os/docs/cloudflare-sandboxes.md
+++ b/apps/os/docs/cloudflare-sandboxes.md
@@ -175,6 +175,11 @@ is real but minimal: `@openai/codex` is a single ~280MB statically-linked Rust
 binary (npm pulls linux-x64 only — nothing to trim), pulled once per instance
 and cached in Cloudflare's registry.
 
+**Runtimes on PATH:** Node (from the base image) and **Python 3 + pip** (baked
+because codex reaches for Python by default — a prd agent hit
+`python3: command not found` without it). Add another language the same way in
+the Dockerfile if a coding workflow needs it.
+
 Claude Code is **not baked yet** (it adds another ~240MB self-contained binary,
 and we have no Anthropic key wired to exercise it). Add it the same way — a
 `RUN curl -fsSL https://claude.ai/install.sh | bash` line (its native installer,

--- a/apps/os/sandbox/Dockerfile
+++ b/apps/os/sandbox/Dockerfile
@@ -20,6 +20,16 @@ FROM docker.io/cloudflare/sandbox:0.12.3
 ENV CI=true \
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
+# Python 3 + pip. Codex reaches for Python constantly (it is the default
+# language for a "write a script" ask), and the base image has no python3 —
+# verified live on prd: an agent asked codex to write and run a Python file and
+# got `python3: command not found` (exit 127). A coding sandbox that can't run
+# the most common scripting language is a sharp edge; ~50 MB is worth it.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3 python3-pip \
+  && rm -rf /var/lib/apt/lists/* \
+  && python3 --version
+
 # Codex CLI (OpenAI). npm global; its bin lands on the exec shell's PATH
 # (/usr/local/bin). Uses OPENAI_API_KEY, injected via the sandbox env-var map
 # as a getSecret placeholder and substituted at egress (never in the container).


### PR DESCRIPTION
Follow-up to #1676, from proving that PR live on prd.

## What & why
The prd proof (an @iterate agent driving codex in its sandbox over real chat) surfaced one genuine gap: **codex reaches for Python by default**, and the sandbox image had no `python3`. The agent had codex write `haiku.py`, ran `python3 haiku.py`, and got:

```
bash: line 396: python3: command not found
```
(exit 127) — succeeding only when redirected to Node. A coding sandbox that can't run the most common scripting language is a sharp edge, so this bakes `python3` + `pip` in.

## Cost
+~230 MB unpacked (3.05 → **3.28 GB**), comfortably under `standard-1`'s 8 GB disk. Same build-time bake rationale as codex itself (runtime installs fail through the MITM'd egress). Verified in a local `docker build`: `python3 3.10.12`, `codex 0.142.5`, and `node v22.23.1` all on PATH.

## Deferred (noted in #1676, not in this PR)
- prd R2 presign keys (backups currently stream through the DO binding — works, slower)
- registry pruning for stale preview images
- named-tunnel server-side machinery for `x--y.iterate.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time image layer only (~230 MB); no app logic, auth, or egress changes—main operational note is slightly larger pulls on cold starts.
> 
> **Overview**
> Fixes **Codex-driven workflows failing on `python3: command not found`** by installing **Python 3 + pip** at **Docker build time** in `apps/os/sandbox/Dockerfile` (same bake pattern as Codex—runtime installs are unreliable through MITM’d egress).
> 
> **`cloudflare-sandboxes.md`** now documents **runtimes on PATH**: Node from the base image plus baked Python, with a note to add other languages the same way in the Dockerfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53e7df26506ebb9ebb41ec50386070b0eab2f0ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-07T08:48:49.672Z",
      "headSha": "53e7df26506ebb9ebb41ec50386070b0eab2f0ea",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/298065431617895",
      "shortSha": "53e7df2",
      "cleanupDurationMs": 4405,
      "deployDurationMs": 152405,
      "testDurationMs": 148872,
      "testRetries": "1 retried: itx > Agent scripts can send web-chat messages and call project tools (vitest x1)"
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-07T08:48:48.183Z",
      "headSha": "53e7df26506ebb9ebb41ec50386070b0eab2f0ea",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/298065431617895",
      "shortSha": "53e7df2",
      "cleanupDurationMs": 2913,
      "deployDurationMs": 20390,
      "testDurationMs": 604,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `53e7df2` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 20.4s | 604ms |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/298065431617895) | 2026-07-07T08:48:48.183Z | Preview app released. |
| OS | released | `53e7df2` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 152.4s | 148.9s | 1 retried: itx > Agent scripts can send web-chat messages and call project tools (vitest x1) | 4.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/298065431617895) | 2026-07-07T08:48:49.672Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->