### PR TITLE
Serialize agent script Dynamic Worker loads

### DIFF
--- a/apps/os/src/domains/capability-host/capability-host-processor-implementation.ts
+++ b/apps/os/src/domains/capability-host/capability-host-processor-implementation.ts
@@ -106,6 +106,9 @@ export class CapabilityHostProcessor extends StreamProcessor<
   #dynamicWorkers: DynamicWorkerRunner;
   #parent: ParentCapabilityHost | undefined;
   #liveCapabilities = new Map<string, LiveCapability>();
+  // Each runScript body is a distinct inline Dynamic Worker source. Queue script
+  // starts so one delivered batch cannot exceed Cloudflare's cold-load backpressure.
+  #scriptExecutionChain: Promise<unknown> = Promise.resolve();
 
   constructor(
     args: StreamProcessorConstructorArgs<typeof CapabilityHostProcessorContract, object> & {
@@ -190,9 +193,11 @@ export class CapabilityHostProcessor extends StreamProcessor<
   >[0]): undefined {
     if (event.type !== "events.iterate.com/capability-host/script-execution-requested") return;
     if (state.pendingScriptExecutions[event.payload.executionId] !== true) return;
-    runInBackground(() =>
+    const execution = this.#scriptExecutionChain.then(() =>
       this.#executeScript({ code: event.payload.code, executionId: event.payload.executionId }),
     );
+    this.#scriptExecutionChain = execution.catch(() => undefined);
+    runInBackground(() => execution);
   }
 
   async provideCapability(input: ProvideCapabilityInput) {

--- a/apps/os/src/domains/capability-host/capability-host-processor.test.ts
+++ b/apps/os/src/domains/capability-host/capability-host-processor.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import type { ProjectRpcTarget, Stream, StreamEvent, StreamEventInput } from "../../types.ts";
+import type { DynamicWorkerRunner } from "../workers/worker-runner.ts";
+import { CapabilityHostProcessor } from "./capability-host-processor-implementation.ts";
+
+function memoryStream() {
+  const events: StreamEvent[] = [];
+  return {
+    events,
+    stream: {
+      async append(...inputs: StreamEventInput[]): Promise<StreamEvent[]> {
+        const appended = inputs.map((input) => {
+          const event: StreamEvent = {
+            ...input,
+            createdAt: new Date(events.length + 1).toISOString(),
+            offset: events.length + 1,
+          };
+          events.push(event);
+          return event;
+        });
+        return appended;
+      },
+    } as Stream,
+  };
+}
+
+function scriptRequested(code: string, executionId: string, offset: number): StreamEvent {
+  return {
+    createdAt: new Date(offset).toISOString(),
+    offset,
+    payload: { code, executionId },
+    type: "events.iterate.com/capability-host/script-execution-requested",
+  };
+}
+
+async function waitUntil(predicate: () => boolean) {
+  const deadline = Date.now() + 1_000;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error("timed out waiting for condition");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe("CapabilityHostProcessor script execution", () => {
+  it("serializes pending script workers from one delivered batch", async () => {
+    const { events, stream } = memoryStream();
+    const releases: Array<() => void> = [];
+    let inFlight = 0;
+    let maxConcurrent = 0;
+    let started = 0;
+    const dynamicWorkers = {
+      async invokeCapability(): Promise<string> {
+        const callNumber = ++started;
+        inFlight += 1;
+        maxConcurrent = Math.max(maxConcurrent, inFlight);
+        return await new Promise<string>((resolve) => {
+          releases.push(() => {
+            inFlight -= 1;
+            resolve(`result-${callNumber}`);
+          });
+        });
+      },
+    } as unknown as DynamicWorkerRunner;
+
+    const processor = new CapabilityHostProcessor({
+      dynamicWorkers,
+      itx: {} as ProjectRpcTarget,
+      path: "/agents/web/test",
+      stream,
+    });
+
+    await processor.ingest({
+      events: [
+        scriptRequested("async () => 1", "one", 1),
+        scriptRequested("async () => 2", "two", 2),
+        scriptRequested("async () => 3", "three", 3),
+      ],
+      streamMaxOffset: 3,
+    });
+
+    expect(started).toBe(1);
+    expect(maxConcurrent).toBe(1);
+
+    releases.shift()?.();
+    await waitUntil(() => started === 2);
+    expect(maxConcurrent).toBe(1);
+
+    releases.shift()?.();
+    await waitUntil(() => started === 3);
+    expect(maxConcurrent).toBe(1);
+
+    releases.shift()?.();
+    await waitUntil(
+      () =>
+        events.filter(
+          (event) => event.type === "events.iterate.com/capability-host/script-execution-completed",
+        ).length === 3,
+    );
+    expect(maxConcurrent).toBe(1);
+  });
+});

--- a/docs/repros/cloudflare-dynamic-workers-concurrency/README.md
+++ b/docs/repros/cloudflare-dynamic-workers-concurrency/README.md
@@ -1,0 +1,95 @@
+# Cloudflare Dynamic Workers concurrency repro
+
+Minimal repro for the undocumented `Too many concurrent dynamic workers` behavior.
+
+This directory is intentionally standalone. It does not import product code and does not require changes to the repo root config.
+
+## Observed behavior
+
+The deployed Worker exposes endpoints that use a Worker Loader binding directly:
+
+- `/distinct?count=24` concurrently calls `env.LOADER.load(...)` with 24 different source strings, then invokes each Dynamic Worker's default `fetch` entrypoint.
+- `/same-source-get?count=24` is the control path: it loads one cached Dynamic Worker via `env.LOADER.get(...)` and invokes that same source 24 times concurrently.
+- `/same-source-load?count=24` is an extra control: it calls `env.LOADER.load(...)` 24 times with identical source bytes.
+
+In affected deployments, `/distinct` returns a mix of successes and errors. The errors include:
+
+```text
+Too many concurrent dynamic workers
+```
+
+The same-source cached control is expected to return 24 successes.
+
+## Expected behavior
+
+Cloudflare's Dynamic Workers docs describe `load()` as creating a fresh Dynamic Worker for one-time execution and `get(id, callback)` as reusing a cached Dynamic Worker. The docs also say Dynamic Workers can spin up an unlimited number of Workers on demand, while normal Workers limits are documented separately.
+
+Expected platform behavior is one of:
+
+- all 24 direct, depth-1 Dynamic Worker loads succeed, or
+- Cloudflare documents a per-invocation/per-isolate concurrency limit for distinct Dynamic Worker sources and provides deterministic throttling guidance.
+
+## Deploy
+
+From this directory:
+
+```bash
+npx wrangler@latest deploy worker.ts --name cloudflare-dynamic-workers-concurrency-repro
+```
+
+Assumption: current Wrangler accepts a Worker Loader binding in config as:
+
+```jsonc
+{
+  "main": "worker.ts",
+  "compatibility_date": "2026-07-07",
+  "worker_loaders": [{ "binding": "LOADER" }],
+}
+```
+
+If the CLI form above cannot attach the binding directly, create a temporary `wrangler.jsonc` with that snippet next to `worker.ts` and deploy with `npx wrangler@latest deploy --config wrangler.jsonc`.
+
+Use the deployed `workers.dev` URL from Wrangler output as `BASE_URL`.
+
+## Run
+
+```bash
+BASE_URL=https://cloudflare-dynamic-workers-concurrency-repro.<subdomain>.workers.dev bash run.sh
+```
+
+or:
+
+```bash
+bash run.sh https://cloudflare-dynamic-workers-concurrency-repro.<subdomain>.workers.dev
+```
+
+The script prints pass/fail lines for:
+
+- same-source cached control success
+- distinct-source repro observation
+
+You can adjust the fan-out while staying below 32 total Worker invocations:
+
+```bash
+COUNT=16 bash run.sh https://cloudflare-dynamic-workers-concurrency-repro.<subdomain>.workers.dev
+COUNT=24 bash run.sh https://cloudflare-dynamic-workers-concurrency-repro.<subdomain>.workers.dev
+```
+
+Direct endpoint checks:
+
+```bash
+curl -sS "$BASE_URL/same-source-get?count=24"
+curl -sS "$BASE_URL/distinct?count=24"
+curl -sS "$BASE_URL/same-source-load?count=24"
+```
+
+## Why this is not the documented Worker invocation chain limit
+
+This repro is a single parent Worker request doing parallel, depth-1 Dynamic Worker invocations. The Dynamic Worker code does not call another Worker, does not use service bindings, and has `globalOutbound: null`.
+
+With the default `count=24`, the shape is at most one parent Worker plus 24 direct Dynamic Worker invocations. That is below a 32 Worker-run chain threshold, and it is not a chain: there is no nested Worker-to-Worker recursion. The same-source control performs comparable fan-out from the same parent request and is expected to succeed, which points at concurrent distinct Dynamic Worker source loading rather than generic Worker invocation depth.
+
+Relevant Cloudflare docs:
+
+- Dynamic Workers getting started: https://developers.cloudflare.com/dynamic-workers/getting-started/
+- Workers limits: https://developers.cloudflare.com/workers/platform/limits/

--- a/docs/repros/cloudflare-dynamic-workers-concurrency/run.sh
+++ b/docs/repros/cloudflare-dynamic-workers-concurrency/run.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${1:-${BASE_URL:-}}"
+COUNT="${COUNT:-24}"
+
+if [[ -z "${BASE_URL}" ]]; then
+  echo "usage: BASE_URL=https://<worker> bash run.sh"
+  echo "   or: bash run.sh https://<worker>"
+  exit 2
+fi
+
+node --input-type=module - "${BASE_URL%/}" "${COUNT}" <<'NODE'
+const [baseUrl, countRaw] = process.argv.slice(2);
+const count = Number.parseInt(countRaw, 10);
+
+async function call(path) {
+  const response = await fetch(`${baseUrl}${path}`);
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    throw new Error(`${path} returned non-JSON status=${response.status}: ${text.slice(0, 500)}`);
+  }
+  if (!response.ok) {
+    throw new Error(`${path} returned HTTP ${response.status}: ${JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+function hasConcurrentDynamicWorkerError(body) {
+  return body.errorSummary?.some((entry) =>
+    String(entry.message).includes("Too many concurrent dynamic workers"),
+  );
+}
+
+function printResult(label, body) {
+  const summary = body.errorSummary?.length
+    ? body.errorSummary.map((entry) => `${entry.count}x ${entry.message}`).join("; ")
+    : "none";
+  console.log(
+    `${label}: success=${body.successCount}/${body.count} errors=${body.errorCount} elapsed=${body.elapsedMs}ms`,
+  );
+  console.log(`  error summary: ${summary}`);
+}
+
+let failed = false;
+
+const control = await call(`/same-source-get?count=${count}`);
+printResult("same-source-get control", control);
+if (control.errorCount === 0) {
+  console.log("PASS same-source-get control succeeded");
+} else {
+  console.log("FAIL same-source-get control had errors");
+  failed = true;
+}
+
+const distinct = await call(`/distinct?count=${count}`);
+printResult("distinct-source load repro", distinct);
+if (hasConcurrentDynamicWorkerError(distinct)) {
+  console.log("PASS repro observed: distinct concurrent sources hit Too many concurrent dynamic workers");
+} else {
+  console.log("FAIL repro not observed: distinct concurrent sources did not report the expected error");
+  failed = true;
+}
+
+process.exit(failed ? 1 : 0);
+NODE

--- a/docs/repros/cloudflare-dynamic-workers-concurrency/worker.ts
+++ b/docs/repros/cloudflare-dynamic-workers-concurrency/worker.ts
@@ -1,0 +1,218 @@
+type DynamicWorkerSource = {
+  compatibilityDate: string;
+  globalOutbound: null;
+  mainModule: string;
+  modules: Record<string, string>;
+};
+
+type DynamicWorkerStub = {
+  getEntrypoint(name?: string): {
+    fetch(request: Request): Response | Promise<Response>;
+  };
+};
+
+type DynamicWorkerLoader = {
+  load(source: DynamicWorkerSource): DynamicWorkerStub;
+  get(
+    id: string,
+    load: () => DynamicWorkerSource | Promise<DynamicWorkerSource>,
+  ): DynamicWorkerStub;
+};
+
+interface Env {
+  LOADER: DynamicWorkerLoader;
+}
+
+type ProbeResult =
+  | {
+      body: unknown;
+      elapsedMs: number;
+      index: number;
+      ok: true;
+      status: number;
+    }
+  | {
+      elapsedMs: number;
+      error: {
+        message: string;
+        name?: string;
+        stack?: string;
+      };
+      index: number;
+      ok: false;
+    };
+
+const COMPATIBILITY_DATE = "2026-07-07";
+const DEFAULT_COUNT = 24;
+const MAX_COUNT = 64;
+const SAME_SOURCE_CACHE_ID = "same-source-control-v1";
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const count = parseCount(url.searchParams.get("count"));
+
+    if (url.pathname === "/" || url.pathname === "/help") {
+      return json({
+        endpoints: {
+          "/distinct?count=24":
+            "Concurrently loads count distinct Dynamic Worker sources with LOADER.load().",
+          "/same-source-get?count=24":
+            "Control: invokes one cached Dynamic Worker source count times concurrently with LOADER.get().",
+          "/same-source-load?count=24":
+            "Control: concurrently calls LOADER.load() count times with identical source bytes.",
+        },
+      });
+    }
+
+    if (url.pathname === "/health") {
+      return json({ ok: true });
+    }
+
+    if (url.pathname === "/distinct") {
+      return json(
+        await runCase("distinct-load", count, (index) =>
+          env.LOADER.load(workerSource(`distinct-${index}`)),
+        ),
+      );
+    }
+
+    if (url.pathname === "/same-source-get") {
+      const worker = env.LOADER.get(SAME_SOURCE_CACHE_ID, () => workerSource("same-source-get"));
+      return json(await runCase("same-source-get", count, () => worker));
+    }
+
+    if (url.pathname === "/same-source-load") {
+      const source = workerSource("same-source-load");
+      return json(await runCase("same-source-load", count, () => env.LOADER.load(source)));
+    }
+
+    return json({ error: "not found" }, 404);
+  },
+};
+
+async function runCase(
+  name: string,
+  count: number,
+  workerForIndex: (index: number) => DynamicWorkerStub,
+) {
+  const startedAt = Date.now();
+  const results = await Promise.all(
+    Array.from({ length: count }, (_, index) => invokeProbe(index, workerForIndex)),
+  );
+  const successCount = results.filter((result) => result.ok).length;
+  const errorCount = count - successCount;
+
+  return {
+    case: name,
+    count,
+    elapsedMs: Date.now() - startedAt,
+    errorCount,
+    errorSummary: summarizeErrors(results),
+    results,
+    successCount,
+  };
+}
+
+async function invokeProbe(
+  index: number,
+  workerForIndex: (index: number) => DynamicWorkerStub,
+): Promise<ProbeResult> {
+  const startedAt = Date.now();
+  try {
+    const worker = workerForIndex(index);
+    const response = await worker
+      .getEntrypoint()
+      .fetch(new Request(`https://dynamic-worker-probe.local/?index=${index}`));
+    const text = await response.text();
+    return {
+      body: parseBody(text),
+      elapsedMs: Date.now() - startedAt,
+      index,
+      ok: response.ok,
+      status: response.status,
+    };
+  } catch (error) {
+    return {
+      elapsedMs: Date.now() - startedAt,
+      error: normalizeError(error),
+      index,
+      ok: false,
+    };
+  }
+}
+
+function workerSource(label: string): DynamicWorkerSource {
+  return {
+    compatibilityDate: COMPATIBILITY_DATE,
+    globalOutbound: null,
+    mainModule: "index.js",
+    modules: {
+      "index.js": `
+        const loadedAt = Date.now();
+
+        export default {
+          async fetch(request) {
+            const url = new URL(request.url);
+            return new Response(JSON.stringify({
+              ok: true,
+              index: Number(url.searchParams.get("index")),
+              label: ${JSON.stringify(label)},
+              loadedAt,
+            }), {
+              headers: { "content-type": "application/json; charset=utf-8" },
+            });
+          },
+        };
+      `,
+    },
+  };
+}
+
+function parseCount(raw: string | null): number {
+  if (raw === null) return DEFAULT_COUNT;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_COUNT;
+  return Math.min(parsed, MAX_COUNT);
+}
+
+function summarizeErrors(results: ProbeResult[]) {
+  const summary = new Map<string, { count: number; name?: string; message: string }>();
+  for (const result of results) {
+    if (result.ok) continue;
+    const key = `${result.error.name ?? "Error"}:${result.error.message}`;
+    const existing = summary.get(key);
+    if (existing === undefined) {
+      summary.set(key, { count: 1, name: result.error.name, message: result.error.message });
+    } else {
+      existing.count += 1;
+    }
+  }
+  return [...summary.values()];
+}
+
+function normalizeError(error: unknown): { message: string; name?: string; stack?: string } {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+    };
+  }
+  return { message: String(error) };
+}
+
+function parseBody(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function json(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value, null, 2), {
+    headers: { "content-type": "application/json; charset=utf-8" },
+    status,
+  });
+}


### PR DESCRIPTION
## Summary

- Queue `runScript` Dynamic Worker starts per capability host so one stream delivery batch cannot cold-load many distinct inline script workers concurrently.
- Add a processor regression test that proves a batch of pending script requests starts only one worker at a time.
- Add a standalone Cloudflare Dynamic Workers repro under `docs/repros/cloudflare-dynamic-workers-concurrency/` for the undocumented `Too many concurrent dynamic workers` behavior.

## Diagnosis

Production stream `/agents/web/2026-07-07t08-44-14-887z` hit `Too many concurrent dynamic workers` after several agent script requests. Preview repros showed that concurrent unique Dynamic Worker sources fail above four, while byte-identical cached worker invocations succeed. The failing production scripts were `runScript` requests using `itx.chat`/`itx.sandbox.exec`, not nested project worker recursion.

## Verification

- `pnpm --dir apps/os test:unit src/domains/capability-host/capability-host-processor.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm exec oxlint apps/os/src/domains/capability-host/capability-host-processor-implementation.ts apps/os/src/domains/capability-host/capability-host-processor.test.ts docs/repros/cloudflare-dynamic-workers-concurrency/worker.ts --deny-warnings`
- `bash -n docs/repros/cloudflare-dynamic-workers-concurrency/run.sh`

## Notes

The Cloudflare repro is intentionally standalone and documents the Worker Loader binding assumption. It has not been deployed independently yet. The preview slot request earlier acquired `preview_8`, but the forced OS preview deploy hit the account container memory quota before this fix commit was added.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> Teardown skipped: Slot preview-8 no longer belongs to pr-1693: it is now leased by pr-1717 (https://github.com/iterate/iterate/pull/1717). Their deployment has replaced this PR's apps on preview_8.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-07T21:20:44.350Z",
      "headSha": "3f3792c775bb630c37156b1d2fd64056f300e2bf",
      "message": "Teardown skipped: Slot preview-8 no longer belongs to pr-1693: it is now leased by pr-1717 (https://github.com/iterate/iterate/pull/1717). Their deployment has replaced this PR's apps on preview_8.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/330333400766661",
      "shortSha": "3f3792c",
      "deployDurationMs": 141935
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-07T21:20:44.350Z",
      "headSha": "3f3792c775bb630c37156b1d2fd64056f300e2bf",
      "message": "Teardown skipped: Slot preview-8 no longer belongs to pr-1693: it is now leased by pr-1717 (https://github.com/iterate/iterate/pull/1717). Their deployment has replaced this PR's apps on preview_8.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/330333400766661",
      "shortSha": "3f3792c",
      "deployDurationMs": 18579
    }
  },
  "environmentConfigLease": null,
  "notice": "Teardown skipped: Slot preview-8 no longer belongs to pr-1693: it is now leased by pr-1717 (https://github.com/iterate/iterate/pull/1717). Their deployment has replaced this PR's apps on preview_8."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `3f3792c` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 18.6s |  |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/330333400766661) | 2026-07-07T21:20:44.350Z | Teardown skipped: Slot preview-8 no longer belongs to pr-1693: it is now leased by pr-1717 (https://github.com/iterate/iterate/pull/1717). Their deployment has replaced this PR's ... |
| OS | released | `3f3792c` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 141.9s |  |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/330333400766661) | 2026-07-07T21:20:44.350Z | Teardown skipped: Slot preview-8 no longer belongs to pr-1693: it is now leased by pr-1717 (https://github.com/iterate/iterate/pull/1717). Their deployment has replaced this PR's ... |

</details>
<!-- /CLOUDFLARE_PREVIEW -->