### PR TITLE
[codex] Fix agent activity busy state

### DIFF
--- a/apps/os/src/components/agent-feed.tsx
+++ b/apps/os/src/components/agent-feed.tsx
@@ -35,15 +35,14 @@ import type { StreamBrowserDatabase } from "~/domains/streams/client-libraries/b
 const TAIL_PREFETCH_ROWS = 32;
 
 /**
- * The clean agent chat feed: user message → activity ("Ran code 2× · 3
- * requests · 7.4 s") → assistant message.
+ * The clean agent chat feed: user and assistant messages plus archived
+ * activity rows ("Ran code 2× · 3 requests · 7.4 s").
  *
  * Settled items are `agent_feed_items` rows written by the agent-ui
  * processor; the TanStack virtual list windows over them with reactive
- * SQLite queries. The in-flight activity — with live-streaming thinking and
- * response text — is the list's trailing virtual item, rendered straight from
- * the processor's reduced state, so the virtualizer's end anchoring tracks its
- * growth natively.
+ * SQLite queries. Active LLM/script work is the list's trailing virtual item,
+ * rendered straight from the processor's reduced state, so the virtualizer's
+ * end anchoring tracks its growth natively.
  *
  * Callers must remount this component when pointing it at a different
  * database (key it by the database identity): the virtualizer's measurement
@@ -565,13 +564,13 @@ function CodeStepDetail({ step }: { step: AgentUiCodeStep }) {
 }
 
 // ---------------------------------------------------------------------------
-// The live element: streaming thinking and code with a blinking cursor
+// The live element: active requests and running code with expandable detail
 // ---------------------------------------------------------------------------
 
 /**
- * Rendered below the virtual list whenever an activity is in flight. Receives
- * the live reduced state on every chunk: finished steps collapse upward into
- * quiet rows while the current step streams its thinking or code.
+ * Rendered below the virtual list whenever work is in flight. Receives the
+ * live reduced state on every chunk: finished steps collapse upward into quiet
+ * rows while current requests or scripts keep the busy indicator visible.
  */
 function AgentLiveActivity({
   live,
@@ -607,7 +606,7 @@ function AgentLiveActivity({
         <div className="flex h-7 items-center gap-2 self-start px-0.5">
           <Spinner className="size-3 shrink-0 text-amber-600" />
           <span className="text-sm font-medium text-amber-700 dark:text-amber-500">
-            {liveActivityLabel(live, liveStep)}
+            {liveActivityLabel(runningSteps)}
           </span>
         </div>
       ) : null}
@@ -648,15 +647,17 @@ function liveStepHasVisibleContent(step: AgentUiStep) {
   return step.thinkingText !== "" || step.responseText !== "";
 }
 
-function liveActivityLabel(live: AgentUiActivity, liveStep: AgentUiStep | undefined): string {
-  // Steps exist but none is running: the turn is between steps (or waiting to
-  // settle) — "Working…", not "Thinking…".
-  if (liveStep == null) return live.steps.length > 0 ? "Working…" : "Thinking…";
-  if (liveStep.kind === "code") return "Running code…";
-  if (liveStep.responseText !== "") {
-    return looksLikeCode(liveStep.responseText) ? "Writing code…" : "Responding…";
+function liveActivityLabel(runningSteps: AgentUiStep[]): string {
+  const scriptCount = runningSteps.filter((step) => step.kind === "code").length;
+  const llmCount = runningSteps.length - scriptCount;
+  const parts: string[] = [];
+  if (scriptCount > 0) {
+    parts.push(`Running ${scriptCount} script${scriptCount === 1 ? "" : "s"}`);
   }
-  return "Thinking…";
+  if (llmCount > 0) {
+    parts.push(`Making ${llmCount} LLM request${llmCount === 1 ? "" : "s"}`);
+  }
+  return parts.join(" · ") || "Working…";
 }
 
 /** Code-mode agents stream itx code as their response; chat agents stream prose. */

--- a/apps/os/src/components/agent-ui-reducer.test.ts
+++ b/apps/os/src/components/agent-ui-reducer.test.ts
@@ -1,7 +1,7 @@
 // Reducer coverage for the browser-side agent UI processor: a full simulated
 // turn — user message, LLM request with streamed thinking + response deltas,
-// code execution, completion, assistant reply — must reduce into the clean
-// chat shape the agent feed renders (items + live tail).
+// code execution, completion, assistant reply — must reduce into the chat
+// items and live active-work tail the agent feed renders.
 
 import { describe, expect, it } from "vitest";
 import type { Event } from "@iterate-com/ui/components/events/types";
@@ -82,7 +82,7 @@ describe("agent-ui reducer", () => {
     });
   });
 
-  it("settles the activity into items when the assistant responds", () => {
+  it("settles the activity into items when all work completes", () => {
     const state = reduceAll([
       {
         type: "events.iterate.com/agents/user-message-received",
@@ -156,6 +156,66 @@ describe("agent-ui reducer", () => {
       status: "running",
       code: "await itx.repo.readFile({ path: 'README.md' })",
       startedAtMs: Date.parse("2026-06-11T00:00:01.000Z"),
+    });
+  });
+
+  it("keeps the live indicator while a running script emits chat messages", () => {
+    const countdownEvents: Array<Partial<Event> & { type: string; payload?: unknown }> = [
+      {
+        type: "events.iterate.com/agent/llm-request-requested",
+        offset: 10,
+        payload: { model: "gpt-test", requestId: "llm-request:gen-0" },
+      },
+      {
+        type: "events.iterate.com/agent/output-added",
+        payload: {
+          llmRequestId: 10,
+          content:
+            "```js\nasync (itx) => {\n  await itx.chat.sendMessage({ message: '20' });\n  await new Promise((resolve) => setTimeout(resolve, 1000));\n}\n```",
+        },
+      },
+      {
+        type: "events.iterate.com/capability-host/script-execution-requested",
+        payload: {
+          executionId: "agent-output:11",
+          code: "async (itx) => {\n  await itx.chat.sendMessage({ message: '20' });\n  await new Promise((resolve) => setTimeout(resolve, 1000));\n}",
+        },
+      },
+      {
+        type: "events.iterate.com/agent/llm-request-completed",
+        payload: { llmRequestId: 10, result: { status: "success" } },
+      },
+      {
+        type: "events.iterate.com/agents/web-message-sent",
+        payload: { message: "20" },
+      },
+    ];
+    const running = reduceAll(countdownEvents);
+
+    expect(running.items).toMatchObject([{ kind: "assistant", text: "20" }]);
+    expect(running.live?.steps.at(-1)).toMatchObject({
+      kind: "code",
+      executionId: "agent-output:11",
+      status: "running",
+    });
+
+    const completed = reduceAll([
+      ...countdownEvents,
+      {
+        type: "events.iterate.com/capability-host/script-execution-completed",
+        payload: { executionId: "agent-output:11", ok: true, logs: [] },
+      },
+    ]);
+
+    expect(completed.live).toBeNull();
+    expect(completed.items.map((item) => item.kind)).toEqual(["assistant", "activity"]);
+    expect(completed.items[1]).toMatchObject({
+      kind: "activity",
+      status: "done",
+      steps: [
+        { kind: "llm", status: "done" },
+        { kind: "code", executionId: "agent-output:11", status: "done" },
+      ],
     });
   });
 
@@ -280,7 +340,7 @@ describe("agent-ui reducer", () => {
     expect(state.presence[1]).toMatchObject({ subscriptionKey: "browser:tab-1", connected: false });
   });
 
-  it("rolls multiple rounds into one activity; only chat messages settle it", () => {
+  it("settles a completed LLM request even without an assistant message", () => {
     const state = reduceAll([
       {
         type: "events.iterate.com/agent/llm-request-requested",
@@ -288,42 +348,26 @@ describe("agent-ui reducer", () => {
         payload: { model: "gpt-test" },
       },
       {
-        type: "events.iterate.com/capability-host/script-execution-requested",
-        payload: { executionId: "exec-1", code: "1+1" },
-      },
-      {
-        type: "events.iterate.com/capability-host/script-execution-completed",
-        payload: { executionId: "exec-1", outcome: { status: "success" } },
-      },
-      // The agent goes idle between rounds — the activity waits, not settles.
-      {
-        type: "events.iterate.com/agent/status-updated",
-        payload: { status: "idle", reason: "round complete" },
-      },
-      {
-        type: "events.iterate.com/agent/llm-request-requested",
-        offset: 20,
-        payload: { model: "gpt-test" },
-      },
-      {
-        type: "events.iterate.com/capability-host/script-execution-requested",
-        payload: { executionId: "exec-2", code: "2+2" },
-      },
-      {
-        type: "events.iterate.com/agents/web-message-sent",
-        payload: { message: "all done" },
+        type: "events.iterate.com/agent/llm-request-completed",
+        payload: {
+          llmRequestId: 7,
+          provider: "openai-ws",
+          durationMs: 250,
+          result: { status: "success" },
+        },
       },
     ]);
 
-    // One settled activity carrying every round's steps, then the reply.
     expect(state.live).toBeNull();
-    expect(state.items.map((item) => item.kind)).toEqual(["activity", "assistant"]);
+    expect(state.items.map((item) => item.kind)).toEqual(["activity"]);
     const activity = state.items[0];
     expect(activity).toMatchObject({ kind: "activity", status: "done" });
-    expect(activity?.kind === "activity" ? activity.steps : []).toHaveLength(4);
+    expect(activity?.kind === "activity" ? activity.steps : []).toMatchObject([
+      { kind: "llm", llmRequestId: 7, status: "done", outcome: "completed" },
+    ]);
   });
 
-  it("marks the live activity waiting on idle and resumes it on the next round", () => {
+  it("does not clear running work from idle status alone", () => {
     const state = reduceAll([
       {
         type: "events.iterate.com/agent/llm-request-requested",
@@ -337,7 +381,8 @@ describe("agent-ui reducer", () => {
     ]);
 
     expect(state.items).toHaveLength(0);
-    expect(state.live).toMatchObject({ kind: "activity", status: "waiting" });
+    expect(state.live).toMatchObject({ kind: "activity", status: "running" });
+    expect(state.live?.steps[0]).toMatchObject({ kind: "llm", status: "running" });
   });
 
   it("queues a user message that arrives mid-turn", () => {
@@ -483,8 +528,11 @@ describe("agent-ui reducer", () => {
       },
     ]);
 
-    expect(state.items).toHaveLength(0);
-    expect(state.live?.steps[0]).toMatchObject({
+    expect(state.live).toBeNull();
+    expect(state.items).toHaveLength(1);
+    const activity = state.items[0];
+    if (activity?.kind !== "activity") throw new Error("expected activity item");
+    expect(activity.steps[0]).toMatchObject({
       kind: "llm",
       status: "done",
       outcome: "cancelled",

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -201,10 +201,8 @@ export function ProjectStreamView({
   const connectionLabel =
     snapshot.connectionError ??
     (snapshot.connectionStatus === "subscribed" ? emptyLabel : snapshot.connectionStatus);
-  // Busy = a turn is actively running. A "waiting" activity (agent idle
-  // between rounds, not yet settled by a chat message) is not busy — the live
-  // feed already parks its spinner there, so the header must match.
-  const agentBusy = agentUiState?.live?.status === "running";
+  // Busy = work is actively running, independent of chat-message timing.
+  const agentBusy = agentUiState?.live?.steps.some((step) => step.status === "running") ?? false;
   const presence = agentUiState?.presence ?? [];
 
   return (

--- a/apps/os/src/domains/streams/client-libraries/processors/agent-ui-processor.ts
+++ b/apps/os/src/domains/streams/client-libraries/processors/agent-ui-processor.ts
@@ -24,7 +24,7 @@ import type { SqlClient, SqlValue } from "../browser/stream-browser-db.ts";
 export const AGENT_UI_FEED_TABLE = "agent_feed_items";
 
 /** Bumped into the writer-lock name so a schema change lets a fresh tab take over. */
-export const AGENT_UI_SCHEMA_VERSION = 4;
+export const AGENT_UI_SCHEMA_VERSION = 5;
 
 // planAgentUiOps still types its events against packages/ui's shared Event
 // type; deriving the parameter type here keeps this file free of

--- a/packages/ui/src/components/events/agent-ui-reducer.ts
+++ b/packages/ui/src/components/events/agent-ui-reducer.ts
@@ -10,7 +10,7 @@ import type { Event } from "./types.ts";
 // only what is still in flight — the live activity with partially streamed
 // thinking/response text, the presence roster, and the next dense row index.
 // The live part renders as one element below the list, straight from this
-// state.
+// state, and exists only while work is active.
 //
 // Mirrors `browser-event-feed`'s planFeedOps contract: `reduce` advances
 // state one event at a time, `processEventBatch` plans the whole batch from
@@ -56,11 +56,7 @@ export type AgentUiStep = AgentUiLlmStep | AgentUiCodeStep;
 export type AgentUiActivity = {
   kind: "activity";
   id: string;
-  /**
-   * "waiting" = the agent went idle but no chat message has settled the
-   * activity yet — further rounds roll into it ("Ran code 3× · 3 requests").
-   */
-  status: "running" | "waiting" | "done";
+  status: "running" | "done";
   steps: AgentUiStep[];
   startedAtMs: number;
   endedAtMs?: number;
@@ -93,7 +89,7 @@ export type AgentUiPresenceEntry = {
 };
 
 export type AgentUiState = {
-  /** The running activity (streaming thinking/code), or null when idle. */
+  /** The running activity (streaming thinking/code), or null when no work is active. */
   live: AgentUiActivity | null;
   /** User messages that landed while the current request was already running. */
   queuedUserMessages: AgentUiMessageItem[];
@@ -175,10 +171,8 @@ function reduceAgentUiEvent(previous: AgentUiState, event: Event, ops: AgentUiOp
       const text = readString(event, "content");
       if (text == null) return state;
       // A user message while steps are still running must not archive those
-      // steps as finished — the agent is still working. Only a quiescent live
-      // activity settles here; an active one keeps streaming and settles on
-      // its own terminal event.
-      const hasRunningStep = state.live?.steps.some((step) => step.status === "running") ?? false;
+      // steps as finished — the agent is still working.
+      const hasRunningStep = liveHasRunningStep(state.live);
       const item: AgentUiMessageItem = {
         kind: "user",
         id: `user-${event.offset}`,
@@ -188,28 +182,27 @@ function reduceAgentUiEvent(previous: AgentUiState, event: Event, ops: AgentUiOp
       if (hasRunningStep) {
         return { ...state, queuedUserMessages: [...state.queuedUserMessages, item] };
       }
-      const base = hasRunningStep ? state : settleLive(state, timestampMs, ops);
-      return emitItem(base, ops, item);
+      return emitItem(state, ops, item);
     }
 
     case "events.iterate.com/agents/web-message-sent":
     case "events.iterate.com/agents/tui-message-sent": {
       const text = readString(event, "message");
       if (text == null) return state;
-      const settled = settleLive(state, timestampMs, ops);
-      return emitItem(settled, ops, {
+      const item: AgentUiMessageItem = {
         kind: "assistant",
         id: `assistant-${event.offset}`,
         text,
         timestampMs,
-      });
+      };
+      return emitItem(state, ops, item);
     }
 
     case AGENT_LLM_REQUEST_REQUESTED: {
       const base =
         state.queuedUserMessages.length === 0
           ? state
-          : flushQueuedUserMessages(settleLive(state, timestampMs, ops), ops);
+          : flushQueuedUserMessages(settleLiveIfIdle(state, timestampMs, ops), ops);
       const live = ensureLive(base, event.offset, timestampMs);
       const model = readString(event, "model");
       const step: AgentUiLlmStep = {
@@ -305,35 +298,43 @@ function reduceAgentUiEvent(previous: AgentUiState, event: Event, ops: AgentUiOp
         isRecord(result?.error) && typeof result.error.message === "string"
           ? result.error.message
           : undefined;
-      return updateLlmStep(state, llmRequestId, (step) =>
-        step.outcome === "cancelled"
-          ? step
-          : {
-              ...step,
-              status: "done",
-              outcome: status === "success" ? "completed" : "failed",
-              ...(typeof payload?.provider === "string" ? { provider: payload.provider } : {}),
-              ...(typeof payload?.durationMs === "number"
-                ? { durationMs: payload.durationMs }
-                : {}),
-              ...(usage.input == null ? {} : { inputTokens: usage.input }),
-              ...(usage.output == null ? {} : { outputTokens: usage.output }),
-              ...(errorMessage == null ? {} : { errorMessage }),
-              ...(typeof result?.providerResponseId === "string"
-                ? { providerResponseId: result.providerResponseId }
-                : {}),
-            },
+      return settleLiveIfIdle(
+        updateLlmStep(state, llmRequestId, (step) =>
+          step.outcome === "cancelled"
+            ? step
+            : {
+                ...step,
+                status: "done",
+                outcome: status === "success" ? "completed" : "failed",
+                ...(typeof payload?.provider === "string" ? { provider: payload.provider } : {}),
+                ...(typeof payload?.durationMs === "number"
+                  ? { durationMs: payload.durationMs }
+                  : {}),
+                ...(usage.input == null ? {} : { inputTokens: usage.input }),
+                ...(usage.output == null ? {} : { outputTokens: usage.output }),
+                ...(errorMessage == null ? {} : { errorMessage }),
+                ...(typeof result?.providerResponseId === "string"
+                  ? { providerResponseId: result.providerResponseId }
+                  : {}),
+              },
+        ),
+        timestampMs,
+        ops,
       );
     }
 
     case AGENT_LLM_REQUEST_CANCELLED: {
       const llmRequestId = readNumber(event, "llmRequestId");
       if (llmRequestId == null) return state;
-      return updateLlmStep(state, llmRequestId, (step) => ({
-        ...step,
-        status: "done",
-        outcome: "cancelled",
-      }));
+      return settleLiveIfIdle(
+        updateLlmStep(state, llmRequestId, (step) => ({
+          ...step,
+          status: "done",
+          outcome: "cancelled",
+        })),
+        timestampMs,
+        ops,
+      );
     }
 
     case SCRIPT_EXECUTION_REQUESTED:
@@ -367,16 +368,13 @@ function reduceAgentUiEvent(previous: AgentUiState, event: Event, ops: AgentUiOp
       const step = steps[index];
       if (step == null || step.kind !== "code") return state;
       steps[index] = { ...step, status: "done", ...outcome };
-      return { ...state, live: { ...state.live, steps } };
+      const next = { ...state, live: { ...state.live, steps } };
+      return settleLiveIfIdle(next, timestampMs, ops);
     }
 
     case AGENT_STATUS_UPDATED: {
       if (readString(event, "status") !== "idle") return state;
-      // Idle does NOT settle: rounds within one conversation roll into a
-      // single activity, and only chat messages break it up. Mark the live
-      // activity waiting so the UI can park the spinner until the next round.
-      if (state.live == null) return state;
-      return { ...state, live: { ...state.live, status: "waiting" } };
+      return settleLiveIfIdle(state, timestampMs, ops);
     }
 
     case STREAM_SUBSCRIBER_CONNECTED: {
@@ -441,7 +439,7 @@ function reduceAgentUiEvent(previous: AgentUiState, event: Event, ops: AgentUiOp
 // ---------------------------------------------------------------------------
 
 function ensureLive(state: AgentUiState, offset: number, startedAtMs: number): AgentUiActivity {
-  // A new step resumes a waiting activity — that's the roll-up.
+  // Multiple simultaneous steps render as one live activity.
   if (state.live != null) return { ...state.live, status: "running" };
   return {
     kind: "activity",
@@ -450,6 +448,15 @@ function ensureLive(state: AgentUiState, offset: number, startedAtMs: number): A
     steps: [],
     startedAtMs,
   };
+}
+
+function liveHasRunningStep(live: AgentUiActivity | null): boolean {
+  return live?.steps.some((step) => step.status === "running") ?? false;
+}
+
+function settleLiveIfIdle(state: AgentUiState, endedAtMs: number, ops: AgentUiOp[]): AgentUiState {
+  if (liveHasRunningStep(state.live)) return state;
+  return settleLive(state, endedAtMs, ops);
 }
 
 /** Closes the live activity (if any) and emits it as a settled item. */


### PR DESCRIPTION
## Summary

Fixes the agent UI busy indicator so it is driven by active work rather than chat message timing. The reducer now keeps live activity only while an LLM request or script execution has a running step, and archives the activity when the last running step completes or is cancelled.

## Root Cause

The prior reducer used assistant chat messages as the settling boundary for the live activity. In the countdown stream, the script sent `20` immediately after starting, so the UI archived the live activity while the script kept running for the rest of the countdown. In Slack-style streams, completed LLM activity could also remain live because no chat message arrived to settle it.

## Changes

- Stop settling live activity from user/assistant message events.
- Settle activity from LLM completion/cancellation and script completion when no running steps remain.
- Derive the header busy indicator from running steps, not `live.status`.
- Update the live feed label to show active work counts like `Running 1 script` or `Making 1 LLM request`.
- Bump the agent-ui browser processor version so local stream mirrors reprocess with the new reducer semantics.
- Add regression coverage for the countdown ordering and LLM-completion-without-message case.

## Validation

- `pnpm --dir apps/os exec vitest run src/components/agent-ui-reducer.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm -w run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core feed/reducer semantics for when activity settles and how busy is shown; wrong edge cases could mis-order feed items or hide/show spinners, but scope is UI state reduction with added tests.
> 
> **Overview**
> Fixes the agent feed **busy indicator** and **live activity** lifecycle so they track **running LLM/script steps**, not when assistant messages arrive.
> 
> The **agent-ui reducer** no longer settles live activity on user or assistant chat events, and drops the **`waiting`** activity status. Activity archives via **`settleLiveIfIdle`** when the last step finishes (LLM completed/cancelled, script completed) or on idle status only if nothing is still running—so early chat output during a long script no longer clears the spinner, and finished LLM work without a message still settles.
> 
> **UI**: header **`agentBusy`** and the live tail label use **running step counts** (e.g. `Running 1 script · Making 1 LLM request`) instead of `live.status` or generic “Thinking…”. **`AGENT_UI_SCHEMA_VERSION`** is bumped to **5** so local mirrors reprocess. Regression tests cover countdown-with-mid-turn messages and LLM-only completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e171dd53354d0f53964f609655c3a7bc7b56af4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-07T12:06:26.411Z",
      "headSha": "9e171dd53354d0f53964f609655c3a7bc7b56af4",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/276534325556062",
      "shortSha": "9e171dd",
      "cleanupDurationMs": 4788,
      "deployDurationMs": 166755,
      "testDurationMs": 183295,
      "testRetries": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-07T12:06:22.342Z",
      "headSha": "9e171dd53354d0f53964f609655c3a7bc7b56af4",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/276534325556062",
      "shortSha": "9e171dd",
      "cleanupDurationMs": 716,
      "deployDurationMs": 19015,
      "testDurationMs": 6609,
      "testRetries": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-07T12:06:24.972Z",
      "headSha": "9e171dd53354d0f53964f609655c3a7bc7b56af4",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/276534325556062",
      "shortSha": "9e171dd",
      "cleanupDurationMs": 3344,
      "deployDurationMs": 17167,
      "testDurationMs": 559,
      "testRetries": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-07T12:06:22.490Z",
      "headSha": "9e171dd53354d0f53964f609655c3a7bc7b56af4",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/276534325556062",
      "shortSha": "9e171dd",
      "cleanupDurationMs": 859,
      "deployDurationMs": 27570,
      "testDurationMs": 17733,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `9e171dd` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 17.2s | 559ms |  | 3.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/276534325556062) | 2026-07-07T12:06:24.972Z | Preview app released. |
| OS | released | `9e171dd` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 166.8s | 183.3s |  | 4.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/276534325556062) | 2026-07-07T12:06:26.411Z | Preview app released. |
| Semaphore | released | `9e171dd` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 19.0s | 6.6s |  | 716ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/276534325556062) | 2026-07-07T12:06:22.342Z | Preview app released. |
| Streams Example App | released | `9e171dd` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 27.6s | 17.7s |  | 859ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/276534325556062) | 2026-07-07T12:06:22.490Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->