### PR TITLE
[codex] Run ITX scripts through loopback executor

### DIFF
--- a/apps/os/e2e/vitest/script-execution-concurrency.e2e.test.ts
+++ b/apps/os/e2e/vitest/script-execution-concurrency.e2e.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Repro for Cloudflare Dynamic Worker Loader owner-side saturation.
+ *
+ * Each runScript call below becomes a distinct inline Dynamic Worker source.
+ * On deployed Workers, five concurrent long-lived script starts from one
+ * capability-host DO currently trips "Too many concurrent dynamic workers".
+ */
+import { test } from "vitest";
+import { createTestProject } from "../test-support/create-test-project.ts";
+
+const SCRIPT_COUNT = 5;
+const SCRIPT_HOLD_MS = 30_000;
+const MAX_CONCURRENT_COMPLETION_MS = 50_000;
+
+test(
+  "concurrent long-running ITX scripts all complete",
+  { timeout: 90_000 },
+  async ({ expect }) => {
+    await using handle = await createTestProject({ slugPrefix: "script-concurrency" });
+    using itx = handle.itx();
+
+    const marker = crypto.randomUUID();
+    const startedAt = Date.now();
+    const executions = await Promise.allSettled(
+      Array.from({ length: SCRIPT_COUNT }, (_, index) =>
+        itx.capabilityHost.runScript(`async () => {
+          const marker = ${JSON.stringify(marker)};
+          const index = ${index};
+          await new Promise((resolve) => setTimeout(resolve, ${SCRIPT_HOLD_MS}));
+          return { index, marker };
+        }`),
+      ),
+    );
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(formatSettledExecutions(executions)).toEqual({
+      fulfilled: Array.from({ length: SCRIPT_COUNT }, (_, index) => ({
+        index,
+        marker,
+      })),
+      rejected: [],
+    });
+    expect(elapsedMs).toBeLessThan(MAX_CONCURRENT_COMPLETION_MS);
+  },
+);
+
+function formatSettledExecutions(executions: PromiseSettledResult<{ result: unknown }>[]): {
+  fulfilled: unknown[];
+  rejected: string[];
+} {
+  return {
+    fulfilled: executions
+      .filter((execution) => execution.status === "fulfilled")
+      .map((execution) => execution.value.result),
+    rejected: executions
+      .filter((execution) => execution.status === "rejected")
+      .map((execution) =>
+        execution.reason instanceof Error ? execution.reason.message : String(execution.reason),
+      ),
+  };
+}

--- a/apps/os/e2e/vitest/script-execution-concurrency.e2e.test.ts
+++ b/apps/os/e2e/vitest/script-execution-concurrency.e2e.test.ts
@@ -1,9 +1,12 @@
 /**
- * Repro for Cloudflare Dynamic Worker Loader owner-side saturation.
+ * Regression coverage for Cloudflare Dynamic Worker Loader owner-side
+ * saturation.
  *
  * Each runScript call below becomes a distinct inline Dynamic Worker source.
- * On deployed Workers, five concurrent long-lived script starts from one
- * capability-host DO currently trips "Too many concurrent dynamic workers".
+ * On deployed Workers, five concurrent long-lived scripts from one
+ * capability-host scope must all complete instead of sharing one Durable Object
+ * as the dynamic-loader owner and tripping "Too many concurrent dynamic
+ * workers".
  */
 import { test } from "vitest";
 import { createTestProject } from "../test-support/create-test-project.ts";

--- a/apps/os/e2e/vitest/script-execution-concurrency.e2e.test.ts
+++ b/apps/os/e2e/vitest/script-execution-concurrency.e2e.test.ts
@@ -3,7 +3,7 @@
  * saturation.
  *
  * Each runScript call below becomes a distinct inline Dynamic Worker source.
- * On deployed Workers, five concurrent long-lived scripts from one
+ * On deployed Workers, twenty concurrent long-lived scripts from one
  * capability-host scope must all complete instead of sharing one Durable Object
  * as the dynamic-loader owner and tripping "Too many concurrent dynamic
  * workers".
@@ -11,7 +11,7 @@
 import { test } from "vitest";
 import { createTestProject } from "../test-support/create-test-project.ts";
 
-const SCRIPT_COUNT = 5;
+const SCRIPT_COUNT = 20;
 const SCRIPT_HOLD_MS = 30_000;
 const MAX_CONCURRENT_COMPLETION_MS = 50_000;
 

--- a/apps/os/src/domains/capability-host/capability-host-durable-object.ts
+++ b/apps/os/src/domains/capability-host/capability-host-durable-object.ts
@@ -3,7 +3,6 @@ import type { Env } from "../../env.ts";
 import type { CapabilityDescription } from "../../types.ts";
 import { trustedInternalAuthContext } from "../../auth.ts";
 import { DurableObjectNameCodec, parentScopePath } from "../durable-object-names.ts";
-import { DynamicWorkerRunner } from "../workers/worker-runner.ts";
 import {
   createStreamProcessorHost,
   type StreamSubscriberWakeRequest,
@@ -16,6 +15,19 @@ import {
   type ProvideCapabilityInput,
   type RunScriptResult,
 } from "./capability-host-processor-implementation.ts";
+
+type ScriptExecutionEntrypoint = {
+  run(code: string): Promise<unknown>;
+};
+
+type ScriptExecutionLoopbackExports = {
+  ScriptExecutionEntrypoint(input: {
+    props: {
+      projectId: string;
+      scopePath: string;
+    };
+  }): ScriptExecutionEntrypoint;
+};
 
 /**
  * One capability scope: the durable dynamic-capability table and script
@@ -49,15 +61,23 @@ export class CapabilityHostDurableObject extends DurableObject<Env> {
         // chain.
         parent: this.#parentCapabilityHost(),
         path: this.#name.path,
-        // Scripts execute in THIS scope — the runner is minted once for it.
-        dynamicWorkers: new DynamicWorkerRunner({
-          exports: this.ctx.exports,
-          projectId: this.#name.projectId,
-          scopePath: this.#name.path,
-          waitUntil: (promise) => this.ctx.waitUntil(promise),
-        }),
+        scriptExecutionEntrypoint: this.#scriptExecutionEntrypoint(),
       }),
   );
+
+  #scriptExecutionEntrypoint(): ScriptExecutionEntrypoint {
+    // Scripts execute in THIS scope, but the Dynamic Worker load happens in a
+    // stateless loopback entrypoint instead of this Durable Object. Keep the
+    // type shallow to avoid deep-instantiating the generated `ctx.exports`
+    // WorkerEntrypoint type through the Durable Object's processor field.
+    const exports = this.ctx.exports as unknown as ScriptExecutionLoopbackExports;
+    return exports.ScriptExecutionEntrypoint({
+      props: {
+        scopePath: this.#name.path,
+        projectId: this.#name.projectId,
+      },
+    });
+  }
 
   #parentCapabilityHost(): ParentCapabilityHost | undefined {
     const parentPath = parentScopePath(this.#name.path);

--- a/apps/os/src/domains/capability-host/capability-host-processor-implementation.ts
+++ b/apps/os/src/domains/capability-host/capability-host-processor-implementation.ts
@@ -11,10 +11,8 @@ import type {
   JsonValue,
   ProjectRpcTarget,
   RevokeCapabilityInput,
-  StatelessDynamicWorkerRef,
   StreamEvent,
 } from "../../types.ts";
-import type { DynamicWorkerRunner } from "../workers/worker-runner.ts";
 import { retainLiveCapabilityProvider, type LiveCapability } from "./live-capability.ts";
 import { CapabilityHostProcessorContract } from "./capability-host-processor-contract.ts";
 import {
@@ -31,6 +29,11 @@ type CompletedPayload = {
   executionId: string;
   result?: JsonValue;
 };
+
+type ScriptExecutionEntrypoint = {
+  run(code: string): Promise<unknown>;
+};
+
 const INVALID_PATH_SEGMENTS = new Set([
   // Mount names only — INVOCATION paths may end in __describe (intercepted in
   // invokeCapability below); a MOUNT named __describe would be unreachable.
@@ -103,7 +106,7 @@ export class CapabilityHostProcessor extends StreamProcessor<
   readonly contract = CapabilityHostProcessorContract;
   #itx: ProjectRpcTarget;
   #path: string;
-  #dynamicWorkers: DynamicWorkerRunner;
+  #scriptExecutionEntrypoint: ScriptExecutionEntrypoint;
   #parent: ParentCapabilityHost | undefined;
   #liveCapabilities = new Map<string, LiveCapability>();
 
@@ -112,7 +115,7 @@ export class CapabilityHostProcessor extends StreamProcessor<
       itx: ProjectRpcTarget;
       path: string;
       /** Runs run-script workers in this scope. */
-      dynamicWorkers: DynamicWorkerRunner;
+      scriptExecutionEntrypoint: ScriptExecutionEntrypoint;
       // The enclosing scope, or undefined at the project root ("/"). Present for
       // every nested scope (agents, sub-agents, agent namespaces) so capability
       // lookups that miss locally can fall through to the surrounding scope.
@@ -122,7 +125,7 @@ export class CapabilityHostProcessor extends StreamProcessor<
     super(args);
     this.#itx = args.itx;
     this.#path = normalizePath(args.path);
-    this.#dynamicWorkers = args.dynamicWorkers;
+    this.#scriptExecutionEntrypoint = args.scriptExecutionEntrypoint;
     this.#parent = args.parent;
   }
 
@@ -420,47 +423,11 @@ export class CapabilityHostProcessor extends StreamProcessor<
     };
 
     try {
-      // Scripts execute inside THIS scope: the loaded worker's env.ITX resolves
-      // to the same path this processor owns, not the script ref's path.
-      const result = await this.#dynamicWorkers.invokeCapability({
-        path: ["run"],
-        ref: this.#scriptWorkerRef(input.code),
-      });
+      const result = await this.#scriptExecutionEntrypoint.run(input.code);
       await complete({ result });
     } catch (error) {
       await complete({ error: error instanceof Error ? error.message : String(error) });
     }
-  }
-
-  #scriptWorkerRef(code: string): StatelessDynamicWorkerRef {
-    const source = `
-      import { WorkerEntrypoint } from "cloudflare:workers";
-      const fn = ${code};
-      export class ScriptEntrypoint extends WorkerEntrypoint {
-        async run() {
-          const itx = await this.env.ITX.get();
-          return await fn(itx);
-        }
-      }
-    `;
-    // runScript is deliberately expressed as a stateless inline DynamicWorkerRef. That
-    // keeps script execution on the same DynamicWorkerRunner dispatch path as project
-    // workers and provided stateless capabilities; ITX adds only the journal events.
-    // `bundle: false` over plain JavaScript is the loader-ready fast path in
-    // resolveWorkerSource: scripts run on every agent turn and must not pay a
-    // build round trip.
-    return {
-      path: this.#path,
-      source: {
-        files: {
-          files: { "main.js": source },
-          type: "inline",
-        },
-        options: { bundle: false, entryPoint: "main.js" },
-      },
-      entrypoint: "ScriptEntrypoint",
-      type: "stateless",
-    };
   }
 }
 

--- a/apps/os/src/domains/capability-host/script-execution-entrypoint.ts
+++ b/apps/os/src/domains/capability-host/script-execution-entrypoint.ts
@@ -4,11 +4,6 @@ import type { JsonValue, StatelessDynamicWorkerRef } from "../../types.ts";
 import { normalizePath } from "../durable-object-names.ts";
 import { DynamicWorkerRunner } from "../workers/worker-runner.ts";
 
-type ScriptExecutionEntrypointProps = {
-  projectId: string;
-  scopePath: string;
-};
-
 /**
  * Stateless loopback executor for capability-host runScript.
  *
@@ -18,7 +13,7 @@ type ScriptExecutionEntrypointProps = {
  */
 export class ScriptExecutionEntrypoint extends WorkerEntrypoint<
   Env,
-  ScriptExecutionEntrypointProps
+  { projectId: string; scopePath: string }
 > {
   async run(code: string): Promise<JsonValue | undefined> {
     const projectId = this.ctx.props.projectId;

--- a/apps/os/src/domains/capability-host/script-execution-entrypoint.ts
+++ b/apps/os/src/domains/capability-host/script-execution-entrypoint.ts
@@ -4,7 +4,7 @@ import type { JsonValue, StatelessDynamicWorkerRef } from "../../types.ts";
 import { normalizePath } from "../durable-object-names.ts";
 import { DynamicWorkerRunner } from "../workers/worker-runner.ts";
 
-export type ScriptExecutionEntrypointProps = {
+type ScriptExecutionEntrypointProps = {
   projectId: string;
   scopePath: string;
 };

--- a/apps/os/src/domains/capability-host/script-execution-entrypoint.ts
+++ b/apps/os/src/domains/capability-host/script-execution-entrypoint.ts
@@ -1,0 +1,72 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
+import type { Env } from "../../env.ts";
+import type { JsonValue, StatelessDynamicWorkerRef } from "../../types.ts";
+import { normalizePath } from "../durable-object-names.ts";
+import { DynamicWorkerRunner } from "../workers/worker-runner.ts";
+
+export type ScriptExecutionEntrypointProps = {
+  projectId: string;
+  scopePath: string;
+};
+
+/**
+ * Stateless loopback executor for capability-host runScript.
+ *
+ * The capability-host Durable Object journals script lifecycle events, but this
+ * entrypoint owns the Dynamic Worker load and invocation. That keeps concurrent
+ * script starts from sharing the DO as the Worker Loader owner.
+ */
+export class ScriptExecutionEntrypoint extends WorkerEntrypoint<
+  Env,
+  ScriptExecutionEntrypointProps
+> {
+  async run(code: string): Promise<JsonValue | undefined> {
+    const projectId = this.ctx.props.projectId;
+    const scopePath = normalizePath(this.ctx.props.scopePath);
+    const dynamicWorkers = new DynamicWorkerRunner({
+      exports: this.ctx.exports,
+      projectId,
+      scopePath,
+      waitUntil: (promise) => this.ctx.waitUntil(promise),
+    });
+
+    // Scripts execute inside THIS scope: the loaded worker's env.ITX resolves
+    // to the same path the capability host owns.
+    const result = await dynamicWorkers.invokeCapability({
+      path: ["run"],
+      ref: scriptWorkerRef({ code, scopePath }),
+    });
+    return result === undefined ? undefined : (JSON.parse(JSON.stringify(result)) as JsonValue);
+  }
+}
+
+function scriptWorkerRef(input: { code: string; scopePath: string }): StatelessDynamicWorkerRef {
+  const source = `
+    import { WorkerEntrypoint } from "cloudflare:workers";
+    const fn = ${input.code};
+    export class ScriptEntrypoint extends WorkerEntrypoint {
+      async run() {
+        const itx = await this.env.ITX.get();
+        return await fn(itx);
+      }
+    }
+  `;
+  // runScript is deliberately expressed as a stateless inline DynamicWorkerRef.
+  // That keeps script execution on the same DynamicWorkerRunner dispatch path as
+  // project workers and provided stateless capabilities; ITX adds only the
+  // journal events. `bundle: false` over plain JavaScript is the loader-ready
+  // fast path in resolveWorkerSource: scripts run on every agent turn and must
+  // not pay a build round trip.
+  return {
+    path: input.scopePath,
+    source: {
+      files: {
+        files: { "main.js": source },
+        type: "inline",
+      },
+      options: { bundle: false, entryPoint: "main.js" },
+    },
+    entrypoint: "ScriptEntrypoint",
+    type: "stateless",
+  };
+}

--- a/apps/os/src/lib/worker-env.d.ts
+++ b/apps/os/src/lib/worker-env.d.ts
@@ -16,6 +16,7 @@ export interface CloudflareEnv extends OsEnv {}
 type WorkerMainModule = {
   ItxEntrypoint: (typeof import("../domains/itx/itx-entrypoint.ts"))["ItxEntrypoint"];
   ProjectEgressEntrypoint: (typeof import("../domains/projects/egress.ts"))["ProjectEgressEntrypoint"];
+  ScriptExecutionEntrypoint: (typeof import("../domains/capability-host/script-execution-entrypoint.ts"))["ScriptExecutionEntrypoint"];
 };
 
 declare global {

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -74,6 +74,7 @@ export { StatefulWorkerDurableObject } from "./domains/workers/stateful-worker-d
 export { StreamDurableObject } from "./domains/streams/stream-durable-object.ts";
 export { ItxEntrypoint } from "./domains/itx/itx-entrypoint.ts";
 export { ProjectEgressEntrypoint } from "./domains/projects/egress.ts";
+export { ScriptExecutionEntrypoint } from "./domains/capability-host/script-execution-entrypoint.ts";
 // The container-outbound gateway. The container runtime dials it through
 // `ctx.exports.ContainerProxy` to route intercepted sandbox egress; every
 // sandbox container's outbound HTTP(S) reaches it before anything leaves the


### PR DESCRIPTION
## What changed

This PR fixes the deployed Dynamic Worker Loader contention pinned by the e2e regression.

- Adds `ScriptExecutionEntrypoint`, a stateless named loopback entrypoint exported from `apps/os/src/worker.ts`.
- `CapabilityHostDurableObject` now gives `CapabilityHostProcessor` a scoped `ctx.exports.ScriptExecutionEntrypoint({ props: { projectId, scopePath } })` stub instead of constructing a `DynamicWorkerRunner` inside the Durable Object.
- `runScript` still journals request/completion events in the capability-host stream, but Dynamic Worker `load` and invocation now happen inside the stateless entrypoint.
- The e2e regression now starts twenty long-running `itx.capabilityHost.runScript(...)` calls concurrently and expects all twenty to complete.

## Why

On deployed Cloudflare Workers, one Durable Object can only own four concurrent fresh Dynamic Worker starts. The old OS path loaded the script Dynamic Worker from the capability-host Durable Object, so more than four overlapping long-running ITX scripts could leave at least one rejected with:

```text
Too many concurrent dynamic workers
```

The owner that loads the Dynamic Worker must also invoke/forward to it. This PR moves that owner to a stateless named WorkerEntrypoint invocation, so each script execution gets its own loader-owning invocation instead of sharing the capability-host DO's four slots.

## Deployed vs local behavior

Before this fix, the regression behaved like this:

- deployed preview Worker: failed with 4 fulfilled scripts and 1 `Too many concurrent dynamic workers` rejection
- local Vite/Miniflare OS dev: passed with all scripts fulfilled

So the cap appears to be a hosted Cloudflare Workers runtime behavior, not something Miniflare reproduced in this setup.

## Minimal standalone reproduction

Public repo: https://github.com/iterate/cloudflare-dynamic-worker-do-limit-repro

The minimal repo includes both the failure and the fix:

- `worker.ts` is at the repo root and is 48 lines.
- `/` routes to one Durable Object that directly loads five Dynamic Workers: 4 succeed, 1 fails.
- `/entrypoint` routes through a named `Executor` service binding that loads/awaits the Dynamic Worker: all 5 succeed.
- Live deployment verified on 2026-07-07: https://dynamic-worker-do-limit-repro.iterate-dev-preview.workers.dev
- Verified version: `a0a4f0d6-9456-40bc-8a4b-44bb97073838`

## Remaining caveat

This fixes the Dynamic Worker Loader owner cap for overlapping scripts. It does not turn `runScript` into a durable five-hour execution primitive: script execution still starts from stream processor background work backed by the host's `ctx.waitUntil`. If we need robust multi-hour execution across runtime restarts/retries, the next shape should be a `ScriptExecutionWorkflow` that owns the executor call and appends completion idempotently.

## Validation

Local checks run on this branch:

```bash
pnpm exec oxfmt --check apps/os/e2e/vitest/script-execution-concurrency.e2e.test.ts
pnpm --dir apps/os exec oxlint e2e/vitest/script-execution-concurrency.e2e.test.ts
pnpm --dir apps/os exec tsc --noEmit --pretty false --project tsconfig.json
doppler run --config dev -- pnpm exec vitest run --config e2e/vitest.config.ts --project node e2e/vitest/script-execution-concurrency.e2e.test.ts
```

Results:

- format: passed
- focused oxlint: passed
- `apps/os` typecheck: passed
- local e2e: passed in 35.74s with 20 concurrent 30s scripts

Previous deployed preview CI for commit `cc372cb40` did not reach e2e: preview_1 OS deploy failed while creating the sandbox container app with Cloudflare account memory quota exceeded (`max_instances: 500`). That failure is outside this Dynamic Worker change; lint/typecheck/test checks passed. New CI for commit `f04616bfd` is running.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-07T14:19:09.408Z",
      "headSha": "f04616bfd52141ec2cca322004763d70485a69fc",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/461650460576948",
      "shortSha": "f04616b",
      "cleanupDurationMs": 6458,
      "deployDurationMs": 163558,
      "testDurationMs": 475141,
      "testRetries": "2 retried: catalogue example \"sandbox-exec\" runs identically across runtimes (vitest x1) · runs \"sandbox-exec\" through the project REPL (specs x1)"
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-07T14:19:07.213Z",
      "headSha": "f04616bfd52141ec2cca322004763d70485a69fc",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/461650460576948",
      "shortSha": "f04616b",
      "cleanupDurationMs": 4258,
      "deployDurationMs": 29504,
      "testDurationMs": 457,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `f04616b` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 29.5s | 457ms |  | 4.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/461650460576948) | 2026-07-07T14:19:07.213Z | Preview app released. |
| OS | released | `f04616b` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 163.6s | 475.1s | 2 retried: catalogue example "sandbox-exec" runs identically across runtimes (vitest x1) · runs "sandbox-exec" through the project REPL (specs x1) | 6.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/461650460576948) | 2026-07-07T14:19:09.408Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->