### PR TITLE
[codex] Add stream wake markers to agent feed

### DIFF
--- a/apps/os/src/components/agent-feed.tsx
+++ b/apps/os/src/components/agent-feed.tsx
@@ -239,6 +239,10 @@ const AgentFeedItemRow = memo(function AgentFeedItemRow({
   expandedIds: ReadonlySet<string>;
   onToggle: (id: string) => void;
 }) {
+  if (item.kind === "stream-woken") {
+    return <StreamWakeRow item={item} />;
+  }
+
   if (item.kind !== "activity") {
     if (item.kind === "user") {
       return (
@@ -279,6 +283,28 @@ const AgentFeedItemRow = memo(function AgentFeedItemRow({
     />
   );
 });
+
+function StreamWakeRow({ item }: { item: Extract<AgentUiItem, { kind: "stream-woken" }> }) {
+  const dateTime = formatDateTimeAttribute(item.timestampMs);
+
+  return (
+    <div
+      className="flex items-center gap-3 py-3"
+      data-testid="agent-feed-stream-woken"
+      data-kind="stream-woken"
+    >
+      <div className="h-px flex-1 bg-purple-500/45" />
+      <time
+        className="font-mono text-xs font-medium text-purple-700 dark:text-purple-300"
+        dateTime={dateTime}
+        title={formatDateTime(item.timestampMs)}
+      >
+        {item.text}
+      </time>
+      <div className="h-px flex-1 bg-purple-500/45" />
+    </div>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Settled activity: the quiet "Ran code 2× · 3 requests · 7.4 s" row

--- a/apps/os/src/components/agent-ui-reducer.test.ts
+++ b/apps/os/src/components/agent-ui-reducer.test.ts
@@ -340,6 +340,37 @@ describe("agent-ui reducer", () => {
     expect(state.presence[1]).toMatchObject({ subscriptionKey: "browser:tab-1", connected: false });
   });
 
+  it("does not show the bootstrap stream wake in the agent feed", () => {
+    const state = reduceAll([
+      { type: "events.iterate.com/stream/created" },
+      { type: "events.iterate.com/stream/woken" },
+    ]);
+
+    expect(state.items).toEqual([]);
+  });
+
+  it("shows later stream wakes in the agent feed and clears presence", () => {
+    const state = reduceAll([
+      { type: "events.iterate.com/stream/created" },
+      { type: "events.iterate.com/stream/woken" },
+      {
+        type: "events.iterate.com/stream/subscriber-connected",
+        payload: { subscriptionKey: "agent:agent", direction: "outbound" },
+      },
+      { type: "events.iterate.com/stream/woken" },
+    ]);
+
+    expect(state.items).toEqual([
+      {
+        kind: "stream-woken",
+        id: "stream-woken-4",
+        text: "Stream durable object woke",
+        timestampMs: Date.parse("2026-06-11T00:00:04.000Z"),
+      },
+    ]);
+    expect(state.presence).toMatchObject([{ subscriptionKey: "agent:agent", connected: false }]);
+  });
+
   it("settles a completed LLM request even without an assistant message", () => {
     const state = reduceAll([
       {

--- a/apps/os/src/domains/streams/client-libraries/processors/agent-ui-processor.ts
+++ b/apps/os/src/domains/streams/client-libraries/processors/agent-ui-processor.ts
@@ -24,7 +24,7 @@ import type { SqlClient, SqlValue } from "../browser/stream-browser-db.ts";
 export const AGENT_UI_FEED_TABLE = "agent_feed_items";
 
 /** Bumped into the writer-lock name so a schema change lets a fresh tab take over. */
-export const AGENT_UI_SCHEMA_VERSION = 5;
+export const AGENT_UI_SCHEMA_VERSION = 6;
 
 // planAgentUiOps still types its events against packages/ui's shared Event
 // type; deriving the parameter type here keeps this file free of
@@ -102,8 +102,8 @@ const ensureAgentUiSchema = createSchemaEnsurer({
         {
           sql: `
             -- One row per settled agent feed item (user message, assistant
-            -- message, or a completed activity with its steps). local_index is
-            -- the dense, zero-based list position TanStack Virtual indexes.
+            -- message, completed activity, or stream wake marker). local_index
+            -- is the dense, zero-based list position TanStack Virtual indexes.
             CREATE TABLE IF NOT EXISTS agent_feed_items (
               local_index INTEGER PRIMARY KEY,
               kind TEXT NOT NULL,

--- a/packages/ui/src/components/events/agent-ui-reducer.ts
+++ b/packages/ui/src/components/events/agent-ui-reducer.ts
@@ -4,13 +4,14 @@ import type { Event } from "./types.ts";
 // Reduced state model + pure batch planner
 //
 // The agent UI is a clean chat: user message → activity ("Ran code 2× · 3
-// requests · 7.4 s") → assistant message. SETTLED items are emitted as ops
-// that the agent-ui processor writes into the `agent_feed_items` SQLite
-// table (the TanStack virtual list reads those rows); the reduced state holds
-// only what is still in flight — the live activity with partially streamed
-// thinking/response text, the presence roster, and the next dense row index.
-// The live part renders as one element below the list, straight from this
-// state, and exists only while work is active.
+// requests · 7.4 s") → assistant message, with quiet stream wake dividers.
+// SETTLED items are emitted as ops that the agent-ui processor writes into
+// the `agent_feed_items` SQLite table (the TanStack virtual list reads those
+// rows); the reduced state holds only what is still in flight — the live
+// activity with partially streamed thinking/response text, the presence
+// roster, and the next dense row index. The live part renders as one element
+// below the list, straight from this state, and exists only while work is
+// active.
 //
 // Mirrors `browser-event-feed`'s planFeedOps contract: `reduce` advances
 // state one event at a time, `processEventBatch` plans the whole batch from
@@ -69,7 +70,14 @@ export type AgentUiMessageItem = {
   timestampMs: number;
 };
 
-export type AgentUiItem = AgentUiMessageItem | AgentUiActivity;
+export type AgentUiStreamWakeItem = {
+  kind: "stream-woken";
+  id: string;
+  text: string;
+  timestampMs: number;
+};
+
+export type AgentUiItem = AgentUiMessageItem | AgentUiActivity | AgentUiStreamWakeItem;
 
 export type AgentUiProcessorAnnouncement = {
   slug: string;
@@ -153,6 +161,7 @@ const CODEMODE_SCRIPT_EXECUTION_COMPLETED =
 const STREAM_SUBSCRIBER_CONNECTED = "events.iterate.com/stream/subscriber-connected";
 const STREAM_SUBSCRIBER_DISCONNECTED = "events.iterate.com/stream/subscriber-disconnected";
 const STREAM_WOKEN = "events.iterate.com/stream/woken";
+const STREAM_WAKE_LABEL = "Stream durable object woke";
 
 // ---------------------------------------------------------------------------
 // Reducer
@@ -421,12 +430,19 @@ function reduceAgentUiEvent(previous: AgentUiState, event: Event, ops: AgentUiOp
     case STREAM_WOKEN: {
       // Every connection died with the previous stream incarnation; survivors
       // re-dial and re-land as fresh connected facts.
-      return {
+      const next = {
         ...state,
         presence: state.presence.map((entry) =>
           entry.connected ? { ...entry, connected: false } : entry,
         ),
       };
+      if (isInitialStreamWake(event)) return next;
+      return emitItem(next, ops, {
+        kind: "stream-woken",
+        id: `stream-woken-${event.offset}`,
+        text: STREAM_WAKE_LABEL,
+        timestampMs,
+      });
     }
 
     default:
@@ -448,6 +464,11 @@ function ensureLive(state: AgentUiState, offset: number, startedAtMs: number): A
     steps: [],
     startedAtMs,
   };
+}
+
+function isInitialStreamWake(event: Event): boolean {
+  // Brand-new streams commit stream/created at offset 1 and stream/woken at offset 2.
+  return event.offset <= 2;
 }
 
 function liveHasRunningStep(live: AgentUiActivity | null): boolean {


### PR DESCRIPTION
## Summary
- add a settled agent feed item for non-bootstrap stream/woken events
- render those items as a horizontal purple "Stream durable object woke" divider
- bump the agent-ui browser projection version so mirrors reprocess with the new markers

## Tests
- pnpm --dir apps/os exec vitest run src/components/agent-ui-reducer.test.ts
- pnpm --dir apps/os typecheck
- pnpm --filter @iterate-com/ui typecheck
- pnpm lint
- pnpm format:check

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-07T14:16:43.918Z",
      "headSha": "2508eee519b488ae1f2af73c7971f9a86e9b004b",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/171631965376614",
      "shortSha": "2508eee",
      "cleanupDurationMs": 5053,
      "deployDurationMs": 168762,
      "testDurationMs": 444742,
      "testRetries": "3 retried: catalogue example \"discover-tree\" runs identically across runtimes (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1) · runs \"sandbox-exec\" through the project REPL (specs x1)"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-07T14:16:39.813Z",
      "headSha": "2508eee519b488ae1f2af73c7971f9a86e9b004b",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/171631965376614",
      "shortSha": "2508eee",
      "cleanupDurationMs": 942,
      "deployDurationMs": 15688,
      "testDurationMs": 6860,
      "testRetries": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-07T14:16:41.868Z",
      "headSha": "2508eee519b488ae1f2af73c7971f9a86e9b004b",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/171631965376614",
      "shortSha": "2508eee",
      "cleanupDurationMs": 2986,
      "deployDurationMs": 25346,
      "testDurationMs": 538,
      "testRetries": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-07T14:16:39.738Z",
      "headSha": "2508eee519b488ae1f2af73c7971f9a86e9b004b",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/171631965376614",
      "shortSha": "2508eee",
      "cleanupDurationMs": 853,
      "deployDurationMs": 14368,
      "testDurationMs": 18875,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `2508eee` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 25.3s | 538ms |  | 3.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/171631965376614) | 2026-07-07T14:16:41.868Z | Preview app released. |
| OS | released | `2508eee` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 168.8s | 444.7s | 3 retried: catalogue example "discover-tree" runs identically across runtimes (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1) · runs "sandbox-exec" through the project REPL (specs x1) | 5.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/171631965376614) | 2026-07-07T14:16:43.918Z | Preview app released. |
| Semaphore | released | `2508eee` | [https://semaphore.iterate-preview-4.com](https://semaphore.iterate-preview-4.com) | 15.7s | 6.9s |  | 942ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/171631965376614) | 2026-07-07T14:16:39.813Z | Preview app released. |
| Streams Example App | released | `2508eee` | [https://streams.iterate-preview-4.com](https://streams.iterate-preview-4.com) | 14.4s | 18.9s |  | 853ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/171631965376614) | 2026-07-07T14:16:39.738Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Feed projection and display-only UI changes; schema version bump triggers mirror reprocessing but does not alter server auth or data paths.
> 
> **Overview**
> Non-bootstrap **`stream/woken`** events now become settled agent feed rows so users can see when the stream durable object woke again mid-session.
> 
> The agent-ui reducer adds a **`stream-woken`** item type (label **"Stream durable object woke"**), skips the first wake at offsets ≤2, and still marks subscriber presence disconnected on every wake. **`AgentFeed`** renders those rows as a purple horizontal divider with a timestamp. **`AGENT_UI_SCHEMA_VERSION`** is bumped to **6** so browser mirrors reproject feed history with the new markers.
> 
> Tests cover hiding the bootstrap wake and showing later wakes with presence cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2508eee519b488ae1f2af73c7971f9a86e9b004b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->