### PR TITLE
[codex] Add stream wake marker tooltip

### DIFF
--- a/apps/os/src/components/agent-feed.tsx
+++ b/apps/os/src/components/agent-feed.tsx
@@ -8,7 +8,13 @@ import {
   type ReactNode,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { BanIcon, ChevronRightIcon, CodeIcon, PaperclipIcon } from "lucide-react";
+import {
+  BanIcon,
+  ChevronRightIcon,
+  CircleQuestionMarkIcon,
+  CodeIcon,
+  PaperclipIcon,
+} from "lucide-react";
 import type {
   AgentUiActivity,
   AgentUiCodeStep,
@@ -28,6 +34,7 @@ import { Button } from "@iterate-com/ui/components/button";
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@iterate-com/ui/components/empty";
 import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
 import { Spinner } from "@iterate-com/ui/components/spinner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@iterate-com/ui/components/tooltip";
 import { cn } from "@iterate-com/ui/lib/utils";
 import { AGENT_UI_FEED_TABLE } from "~/domains/streams/client-libraries/processors/agent-ui-processor.ts";
 import { useStreamQuery } from "~/domains/streams/client-libraries/browser/hooks/use-stream-query.ts";
@@ -295,13 +302,35 @@ function StreamWakeRow({ item }: { item: Extract<AgentUiItem, { kind: "stream-wo
       data-kind="stream-woken"
     >
       <div className="h-px flex-1 bg-purple-500/45" />
-      <time
-        className="font-mono text-xs font-medium text-purple-700 dark:text-purple-300"
-        dateTime={dateTime}
-        title={formatDateTime(item.timestampMs)}
-      >
-        {item.text}
-      </time>
+      <div className="flex shrink-0 items-center gap-1.5">
+        <time
+          className="font-mono text-xs font-medium text-purple-700 dark:text-purple-300"
+          dateTime={dateTime}
+          title={formatDateTime(item.timestampMs)}
+        >
+          {item.text}
+        </time>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                aria-label="Why did this stream Durable Object wake?"
+                className="inline-flex size-4 items-center justify-center rounded-full text-purple-700/75 transition-colors hover:text-purple-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/60 dark:text-purple-300/75 dark:hover:text-purple-200"
+              />
+            }
+          >
+            <CircleQuestionMarkIcon className="size-3.5" aria-hidden="true" />
+          </TooltipTrigger>
+          <TooltipContent className="max-w-80 text-left leading-snug">
+            <p>
+              This can happen when the Durable Object is evicted or crashed, and most often when we
+              do a production deployment. All Durable Objects currently crash and do not recover
+              cleanly; we will fix that in the future.
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
       <div className="h-px flex-1 bg-purple-500/45" />
     </div>
   );


### PR DESCRIPTION
## Summary
- Add a small question-mark tooltip beside the stream Durable Object wake marker.
- Explain that wake markers can come from eviction, crashes, and most often production deploys, and note the current recovery limitation.

## Validation
- pnpm exec oxlint apps/os/src/components/agent-feed.tsx --deny-warnings
- pnpm --dir apps/os typecheck

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-07T14:42:41.668Z",
      "headSha": "0584d566da4a24ed1469eef636b79a8792cabec8",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/382663896920472",
      "shortSha": "0584d56",
      "cleanupDurationMs": 3916,
      "deployDurationMs": 164621
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-07T14:42:40.432Z",
      "headSha": "0584d566da4a24ed1469eef636b79a8792cabec8",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/382663896920472",
      "shortSha": "0584d56",
      "cleanupDurationMs": 2676,
      "deployDurationMs": 31922
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `0584d56` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 31.9s |  |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/382663896920472) | 2026-07-07T14:42:40.432Z | Preview app released. |
| OS | released | `0584d56` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 164.6s |  |  | 3.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/382663896920472) | 2026-07-07T14:42:41.668Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only copy and tooltip in the agent feed; no changes to stream, auth, or data handling.
> 
> **Overview**
> Adds a **question-mark control** next to the purple “stream woken” divider in the agent feed so users can learn why that marker appears.
> 
> `StreamWakeRow` now wraps the timestamp in a flex row and uses the shared `Tooltip` with `CircleQuestionMarkIcon`. The copy explains wakes from **eviction, crashes, and especially production deploys**, and notes that Durable Objects do not yet recover cleanly after crashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0584d566da4a24ed1469eef636b79a8792cabec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->