### PR TITLE
fix(os): server-side root redirect + kill loopback /api fetches

### DIFF
--- a/apps/os/src/auth.ts
+++ b/apps/os/src/auth.ts
@@ -183,7 +183,7 @@ export async function resolveItxAuth(input: {
       headers: new Headers({ authorization: `Bearer ${credentials.token}` }),
     });
     if (!accessToken) throw new Error("missing or invalid auth");
-    return contextFromPrincipal(config, principalFromAccessToken(accessToken));
+    return itxAuthFromPrincipal(config, principalFromAccessToken(accessToken));
   }
 
   // from-server-cookie: the admin cookie wins (browser REPL admin + Playwright
@@ -198,7 +198,7 @@ export async function resolveItxAuth(input: {
   if (!auth) throw new Error("iterate auth is not configured");
   const result = await auth.authenticate({ headers: input.headers, includeUserInfo: false });
   if (!result.session) throw new Error("missing or invalid auth");
-  return contextFromPrincipal(config, principalFromSession(result.session));
+  return itxAuthFromPrincipal(config, principalFromSession(result.session));
 }
 
 function assertAdminSecret(config: AppConfig, secret: string): void {
@@ -209,7 +209,14 @@ function assertAdminSecret(config: AppConfig, secret: string): void {
   if (!admin) throw new Error("missing or invalid auth");
 }
 
-function contextFromPrincipal(config: AppConfig, principal: Principal): ItxAuthContext {
+/**
+ * The itx auth context for an already-authenticated principal — the in-process
+ * lane. Server-side code that already holds the request middleware's principal
+ * (server functions, server routes) builds its session objects through this
+ * instead of re-presenting credentials to the `/api` door: same confinement
+ * (claims + directory fallback), no loopback HTTP round trip.
+ */
+export function itxAuthFromPrincipal(config: AppConfig, principal: Principal): ItxAuthContext {
   if (principal.type === "admin") {
     return new ItxAuthContext({ isAdmin: true, principal: "admin" });
   }

--- a/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
@@ -11,18 +11,17 @@ import { oauthResourceAudienceVariants } from "@iterate-com/shared/oauth-resourc
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createMcpHandler } from "agents/mcp";
 import { z } from "zod";
-// oxlint-disable-next-line iterate/no-capnweb-http-batch -- exec_js is a one-shot request-scoped call: a single pipelined batch (authenticate -> runScript) with no socket lifecycle to manage.
-import { newHttpBatchRpcSession } from "capnweb";
 import { env } from "cloudflare:workers";
 import packageJson from "../../../package.json" with { type: "json" };
 import { ensureMcpSessionAgentReady } from "./mcp-session-agent-ready.ts";
 import { resolveMcpSessionAgentPath } from "./mcp-session-agent-path.ts";
+import { trustedInternalAuthContext } from "~/auth.ts";
 import { authenticateAdminApiSecret, readBearerToken } from "~/auth/admin.ts";
 import { createAuthWorkerServiceClient } from "~/auth/auth-worker-service.ts";
 import { principalFromAccessToken } from "~/auth/principal.ts";
 import { MCP_START_MOUNT_PATH, resolveMcpBaseUrl } from "~/lib/mcp-base-url.ts";
 import { readProjectBySlug } from "~/project-directory.ts";
-import type { UnauthenticatedOs } from "~/types.ts";
+import { ProjectCollectionRpcTarget } from "~/rpc-targets.ts";
 import type { RequestContext } from "~/request-context.ts";
 
 type ProjectGrant = {
@@ -103,9 +102,7 @@ export async function handleInboundMcpRequest(input: {
     route: MCP_START_MOUNT_PATH,
     sessionIdGenerator: undefined,
   });
-  return withCorsHeaders(
-    await handler(input.request, input.env, mcpExecutionContext(input.context)),
-  );
+  return withCorsHeaders(await handler(input.request, input.env, input.context.executionCtx));
 }
 
 function createServer(input: {
@@ -141,6 +138,15 @@ function createServer(input: {
   // /agents/mcp/request-* stream instead of minting a stream per call.
   let sessionAgentPath: Promise<string> | undefined;
   const resolveSessionAgentPath = () => (sessionAgentPath ??= resolveMcpSessionAgentPath(input));
+  // In-process itx: resolveProject verified the caller's access (OAuth project
+  // grants / admin secret), so the tool then runs with first-party authority
+  // in this same worker — no loopback HTTP batch to our own /api.
+  const projectItxFor = (projectId: string) =>
+    new ProjectCollectionRpcTarget({
+      auth: trustedInternalAuthContext(),
+      config: input.context.config,
+      ctx: input.context.executionCtx,
+    }).get(projectId);
 
   server.registerTool(
     "exec_js",
@@ -153,20 +159,15 @@ function createServer(input: {
       const parsedInput = ExecJsInput.parse(rawInput);
       const project = await resolveProject(parsedInput.project);
 
-      // Access was verified above (OAuth project grants / admin secret), so the
-      // script runs through the itx admin lane over one pipelined
-      // HTTP batch. runScript executes the async arrow function in a fresh
-      // dynamic-worker isolate scoped to this MCP session's agent stream, so
-      // the session transcript at /agents/mcp/** records every execution.
+      // runScript executes the async arrow function in a fresh dynamic-worker
+      // isolate scoped to this MCP session's agent stream, so the session
+      // transcript at /agents/mcp/** records every execution.
       try {
         const agentPath = await resolveSessionAgentPath();
-        const session = engineBatchSession(input.context);
-        const root = session.authenticate({
-          type: "admin-secret",
-          secret: requireAdminSecret(input.context),
-        });
-        const sessionAgent = root.projects.get(project.id).agents.get(agentPath);
-        const execution = await sessionAgent.capabilityHost.runScript(parsedInput.code);
+        const projectItx = await projectItxFor(project.id);
+        const execution = await projectItx.agents
+          .get(agentPath)
+          .capabilityHost.runScript(parsedInput.code);
         return {
           content: [
             {
@@ -206,11 +207,7 @@ function createServer(input: {
       // model as one person running exec_js mid-conversation).
       let reply;
       try {
-        const root = engineBatchSession(input.context).authenticate({
-          type: "admin-secret",
-          secret: requireAdminSecret(input.context),
-        });
-        const projectItx = await root.projects.get(project.id);
+        const projectItx = await projectItxFor(project.id);
         await ensureMcpSessionAgentReady({ agentPath, projectItx });
         reply = await projectItx.agents.get(agentPath).ask({
           message: parsedInput.message,
@@ -427,21 +424,6 @@ async function resolveToolProject(
   return project;
 }
 
-function requireAdminSecret(context: RequestContext): string {
-  const secret = context.config.adminApiSecret?.exposeSecret();
-  if (!secret) throw new Error("Admin API secret is not configured.");
-  return secret;
-}
-
-function engineBatchSession(context: RequestContext) {
-  const baseUrl = (context.config.baseUrl ?? "").replace(/\/+$/, "");
-  if (!baseUrl) throw new Error("baseUrl is not configured");
-  // oxlint-disable-next-line iterate/no-capnweb-http-batch -- one-shot pipelined batch per exec_js call; no socket lifecycle to manage.
-  return newHttpBatchRpcSession<UnauthenticatedOs>(
-    new Request(`${baseUrl}/api`, { method: "POST" }),
-  );
-}
-
 function requireScope(auth: McpAuth, scope: string) {
   if (auth.authType === "admin_api_secret") return;
   if (!auth.scopes.includes(scope)) {
@@ -491,15 +473,6 @@ function unauthorizedMcpResponse(
       "WWW-Authenticate": `Bearer resource_metadata="${metadataUrl}"`,
     },
   });
-}
-
-function mcpExecutionContext(context: RequestContext): ExecutionContext {
-  return {
-    exports: {} as Cloudflare.Exports,
-    passThroughOnException() {},
-    props: {},
-    waitUntil: (promise: Promise<unknown>) => context.waitUntil(promise),
-  } as ExecutionContext;
 }
 
 function withCorsHeaders(response: Response) {

--- a/apps/os/src/domains/integrations/integration-api.ts
+++ b/apps/os/src/domains/integrations/integration-api.ts
@@ -1,16 +1,11 @@
 // The /api/integrations/* HTTP surface, mounted under the Start catch-all
-// route (src/routes/api.$.ts) in the app worker.
-//
-// Resurrected from the pre-migration integration-api.ts (git history). The app
-// worker has no itx bindings, so every itx effect goes through a
-// one-shot pipelined capnweb HTTP batch against this deployment's own
-// /api surface using the admin API secret — the same request-scoped
-// pattern the inbound MCP exec_js tool uses.
-
-// oxlint-disable-next-line iterate/no-capnweb-http-batch -- integration callbacks/webhooks are one-shot request-scoped calls: a single pipelined batch (authenticate -> route/complete) with no socket lifecycle to manage.
-import { newHttpBatchRpcSession } from "capnweb";
-import type { UnauthenticatedOs } from "../../types.ts";
+// route (src/routes/api.$.ts). Everything runs in the one OS worker, so itx
+// effects call the session RpcTargets in-process (first-party authority, the
+// same lane worker.ts uses for project ingress) — no loopback HTTP round trip
+// to this deployment's own /api.
 import { parseOAuthStateUnverified } from "./oauth-state.ts";
+import { trustedInternalAuthContext } from "~/auth.ts";
+import { ProjectCollectionRpcTarget } from "~/rpc-targets.ts";
 import type { Principal } from "~/auth/principal.ts";
 import type { RequestContext } from "~/request-context.ts";
 
@@ -31,22 +26,6 @@ export async function handleIntegrationApiRequest(input: {
   // worker (src/domains/integrations/slack-webhook-api.ts), which has the
   // engine bindings and routes events directly — no RPC round trip.
   return null;
-}
-
-/** One-shot pipelined capnweb batch against this deployment's own itx surface. */
-function engineBatchSession(context: RequestContext) {
-  const baseUrl = (context.config.baseUrl ?? "").replace(/\/+$/, "");
-  if (!baseUrl) throw new Error("baseUrl is not configured");
-  // oxlint-disable-next-line iterate/no-capnweb-http-batch -- one-shot pipelined batch per integration request; no socket lifecycle to manage.
-  return newHttpBatchRpcSession<UnauthenticatedOs>(
-    new Request(`${baseUrl}/api`, { method: "POST" }),
-  );
-}
-
-function requireAdminSecret(context: RequestContext): string {
-  const secret = context.config.adminApiSecret?.exposeSecret();
-  if (!secret) throw new Error("Admin API secret is not configured.");
-  return secret;
 }
 
 async function handleOAuthCallback(input: {
@@ -75,12 +54,14 @@ async function handleOAuthCallback(input: {
   const userId = input.auth?.type === "user" ? input.auth.userId : null;
   if (userId === null) return new Response("OAuth callback user mismatch.", { status: 403 });
 
-  const session = engineBatchSession(input.context);
-  const root = session.authenticate({
-    type: "admin-secret",
-    secret: requireAdminSecret(input.context),
-  });
-  const project = root.projects.get(unverified.projectId);
+  // First-party authority: the caller's session was checked above, and the
+  // state signature is verified itx-side; completing the connect is this
+  // worker's own doing, not something the browser is authorized for.
+  const project = await new ProjectCollectionRpcTarget({
+    auth: trustedInternalAuthContext(),
+    config: input.context.config,
+    ctx: input.context.executionCtx,
+  }).get(unverified.projectId);
   const result =
     input.provider === "slack"
       ? await project.integrations.completeSlackConnect({ code, state, userId })

--- a/apps/os/src/lib/project-server-fns.ts
+++ b/apps/os/src/lib/project-server-fns.ts
@@ -1,7 +1,6 @@
 import { createServerFn } from "@tanstack/react-start";
-// oxlint-disable-next-line iterate/no-capnweb-http-batch -- server functions are one-shot request-scoped calls: a single pipelined batch (authenticate -> list) with no socket lifecycle to manage.
-import { newHttpBatchRpcSession } from "capnweb";
 import { env } from "cloudflare:workers";
+import { itxAuthFromPrincipal } from "~/auth.ts";
 import { authenticateCapnwebAdmin } from "~/auth/admin-auth-cookie.ts";
 import { getUserPrincipal } from "~/auth/principal.ts";
 import { isOnboardingActive } from "~/lib/onboarding-agent.ts";
@@ -11,7 +10,8 @@ import {
   type RootProjectRedirectDecision,
 } from "~/lib/project-root-redirect.ts";
 import { readProjectBySlug } from "~/project-directory.ts";
-import type { ProjectDeploymentStatus, UnauthenticatedOs } from "~/types.ts";
+import { ProjectCollectionRpcTarget } from "~/rpc-targets.ts";
+import type { ProjectDeploymentStatus } from "~/types.ts";
 import type { RequestContext } from "~/request-context.ts";
 
 /**
@@ -24,9 +24,13 @@ import type { RequestContext } from "~/request-context.ts";
  * server-side:
  * - `getProjectBySlugServerFn` — the project layout's `beforeLoad` (SSR).
  * - `getRootProjectRedirectServerFn` — the root `/` redirect decision (SSR);
- *   a thin proxy over the engine's `session.projects.list()`, plus the
- *   signup handoff for the one auth-created project that still needs its OS
- *   bootstrap.
+ *   the engine's `session.projects.list()` plus the signup handoff for the
+ *   one auth-created project that still needs its OS bootstrap.
+ *
+ * Both run in the OS worker itself, so they call the itx session objects
+ * in-process (`ProjectCollectionRpcTarget` on the middleware-resolved
+ * principal) — no loopback HTTP round trip to `/api`, and no capnweb
+ * HTTP-batch one-shot limit on follow-up calls.
  *
  * Project deletion is deliberately absent rather than half-implemented:
  * the archival verb (auth-worker archive + engine teardown + UI) has not
@@ -52,9 +56,9 @@ export type Project = {
 type ProjectWithIngressUrl = Project & { ingressUrl: string };
 
 /**
- * The root `/` redirect decision. It runs during SSR (itx is client-only), so
- * it proxies the engine's `session.projects.list()` through one pipelined
- * capnweb HTTP batch that forwards the caller's cookie.
+ * The root `/` redirect decision, made entirely server-side so `/` answers
+ * with one redirect straight to the final page (onboarding agent stream,
+ * project home, or the projects list) before anything renders.
  *
  * A brand-new auth signup creates the user/org/project records in auth before
  * OS has a project stream. When that single auth-known project is still
@@ -72,16 +76,21 @@ export const getRootProjectRedirectServerFn: (input?: {
     preferredProjectSlug: input?.preferredProjectSlug ?? null,
   }))
   .handler(async ({ context, data }) => {
+    // The middleware-resolved principal, not the /api cookie door: the root
+    // redirect must follow the signed-in user's claims even when the capnweb
+    // admin cookie rides the same request.
+    const principal = context.principal;
+    if (!principal) return { kind: "projects" };
+
     try {
-      const session = engineBatchSession(context);
-      const root = session.authenticate({ type: "from-server-cookie" });
-      // Explicit "mine": the admin cookie may ride the same request, and the
-      // root redirect must follow the signed-in user's claims, never the
-      // deployment listing.
-      const projects = await root.projects.list({ scope: "mine" });
+      const projects = new ProjectCollectionRpcTarget({
+        auth: itxAuthFromPrincipal(context.config, principal),
+        config: context.config,
+        ctx: context.executionCtx,
+      });
       const decision = chooseRootProjectRedirect({
         preferredProjectSlug: data.preferredProjectSlug,
-        projects,
+        projects: await projects.list({ scope: "mine" }),
       });
 
       if (
@@ -90,7 +99,7 @@ export const getRootProjectRedirectServerFn: (input?: {
         decision.project.deploymentStatus === "ready"
       ) {
         try {
-          const project = await root.projects.get(decision.project.id);
+          const project = await projects.get(decision.project.id);
           const { state } = await project.processor.snapshot();
           // The agent stream route can render before the agent capability is
           // listed. `onboardingActive` is the phase marker; waiting for the
@@ -98,8 +107,8 @@ export const getRootProjectRedirectServerFn: (input?: {
           decision.onboarding = isOnboardingActive(state);
         } catch {
           // Do not guess "home" on a transient project snapshot failure. The
-          // /projects client path has the retrying self-heal, while direct home
-          // would strand an in-progress signup away from onboarding.
+          // /projects list still shows the project, while direct home would
+          // strand an in-progress signup away from onboarding.
           return { kind: "projects" };
         }
       }
@@ -110,7 +119,7 @@ export const getRootProjectRedirectServerFn: (input?: {
         decision.project.deploymentStatus === "missing"
       ) {
         try {
-          await root.projects.create({
+          await projects.create({
             projectId: decision.project.id,
             slug: decision.project.slug,
             waitUntilCreated: false,
@@ -202,20 +211,6 @@ function withIngressUrl(
       appBaseUrl: context.config.baseUrl,
     }) ?? `${(context.config.baseUrl ?? "").replace(/\/+$/, "")}/${project.id}`;
   return { ...project, ingressUrl };
-}
-
-function engineBatchSession(context: RequestContext) {
-  const baseUrl = (context.config.baseUrl ?? "").replace(/\/+$/, "");
-  if (!baseUrl) throw new Error("baseUrl is not configured");
-  const cookie = context.rawRequest?.headers.get("cookie");
-  if (!cookie) throw new Error("Sign in to reach the project engine.");
-  // oxlint-disable-next-line iterate/no-capnweb-http-batch -- one-shot pipelined batch per request; no socket lifecycle to manage in a server function.
-  return newHttpBatchRpcSession<UnauthenticatedOs>(
-    new Request(`${baseUrl}/api`, {
-      method: "POST",
-      headers: { cookie },
-    }),
-  );
 }
 
 function organizationSlugForProject(

--- a/apps/os/src/request-context.ts
+++ b/apps/os/src/request-context.ts
@@ -22,6 +22,12 @@ export interface RequestContext {
   rawRequest?: Request;
   /** `ExecutionContext.waitUntil`, for work that should outlive the response. */
   waitUntil: (promise: Promise<unknown>) => void;
+  /**
+   * The invocation's full `ExecutionContext` — what in-process itx
+   * construction (`itxForScope`, `ProjectCollectionRpcTarget`) needs beyond
+   * `waitUntil`: the loopback entrypoints on `ctx.exports`.
+   */
+  executionCtx: ExecutionContext;
   // Set by the iterate auth request middleware (src/auth/middleware.ts).
   principal?: Principal | null;
   iterateAuthSession?: AuthenticatedSession | null;

--- a/apps/os/src/routes/_app/projects/index.tsx
+++ b/apps/os/src/routes/_app/projects/index.tsx
@@ -4,17 +4,15 @@ import {
   useQueryClient,
   type UseMutationResult,
 } from "@tanstack/react-query";
-import { useCallback, useEffect, useReducer, useRef } from "react";
-import { Link, createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
+import { useCallback, useEffect, useRef } from "react";
+import { Link, createFileRoute } from "@tanstack/react-router";
 import { FolderPlus } from "lucide-react";
 import { useAuthClient } from "@iterate-com/auth/client";
 import { Badge } from "@iterate-com/ui/components/badge";
 import { Button } from "@iterate-com/ui/components/button";
 import { Identifier } from "@iterate-com/ui/components/identifier";
 import { toast } from "@iterate-com/ui/components/sonner";
-import { ONBOARDING_AGENT_PATH, hasActiveOnboardingAgent } from "~/lib/onboarding-agent.ts";
 import { normalizeProjectHostnameBase } from "~/lib/project-host-routing.ts";
-import { getRootProjectRedirectServerFn } from "~/lib/project-server-fns.ts";
 import { getPublicRouteConfig } from "~/lib/public-route-config.ts";
 import {
   fetchProjectsList,
@@ -32,38 +30,15 @@ type OrganizationSummary = {
 
 const NO_ORGANIZATIONS: OrganizationSummary[] = [];
 
+// The plain projects list. The root `/` owns the redirect decision (single
+// project → onboarding agent or project home, server-side before rendering);
+// navigating here directly always shows the list — the sidebar's "All
+// projects" must not hijack single-project users back into their project.
 export const Route = createFileRoute("/_app/projects/")({
   ssr: false,
-  loader: async () => {
-    const decision = await getRootProjectRedirectServerFn({
-      data: { preferredProjectSlug: null },
-    });
-
-    if (decision.kind === "project") {
-      if (decision.onboarding) {
-        throw redirect({
-          to: "/projects/$projectSlug/agents/streams/$",
-          params: {
-            projectSlug: decision.project.slug,
-            _splat: ONBOARDING_AGENT_PATH,
-          },
-          search: {},
-          replace: true,
-        });
-      }
-
-      throw redirect({
-        to: "/projects/$projectSlug",
-        params: { projectSlug: decision.project.slug },
-        search: {},
-        replace: true,
-      });
-    }
-
-    return {
-      routeConfig: await getPublicRouteConfig(),
-    };
-  },
+  loader: async () => ({
+    routeConfig: await getPublicRouteConfig(),
+  }),
   pendingComponent: ProjectsIndexPending,
   component: ProjectsIndexPage,
 });
@@ -84,7 +59,6 @@ function buildProjectHostname(input: { slug: string; projectHostnameBases: reado
 
 function ProjectsIndexPage() {
   const { routeConfig } = Route.useLoaderData();
-  const navigate = useNavigate();
   const { session } = useAuthClient();
   const organizations = session?.authenticated ? session.session.organizations : NO_ORGANIZATIONS;
   const isAdmin = session?.authenticated ? session.user.isAdmin === true : false;
@@ -132,14 +106,13 @@ function ProjectsIndexPage() {
   });
 
   // Auth onboarding creates the project container on auth only, so a
-  // brand-new user's first project always arrives here as "missing" — run
-  // the set-up for them instead of asking them to press the button. The single
-  // project case is owned by the onboarding redirect below; this fallback keeps
-  // multi-project recovery automatic without hijacking users into one project.
+  // brand-new user's first project arrives as "missing" — run the set-up for
+  // them instead of asking them to press the button. The root `/` normally
+  // bootstraps the single-project case before redirecting; this covers direct
+  // navigations here and any project the server-side handoff missed.
   const autoSetUpProjectIds = useRef(new Set<string>());
   const recoverProjectMutate = recoverProject.mutate;
   useEffect(() => {
-    if ((data ?? []).length === 1) return;
     for (const project of data ?? []) {
       if (project.deploymentStatus !== "missing") continue;
       if (autoSetUpProjectIds.current.has(project.id)) continue;
@@ -147,83 +120,6 @@ function ProjectsIndexPage() {
       recoverProjectMutate(project);
     }
   }, [data, recoverProjectMutate]);
-
-  const onboardingRedirectInFlightProjectIds = useRef(new Set<string>());
-  const [onboardingRedirectRetry, retryOnboardingRedirect] = useReducer((value) => value + 1, 0);
-  useEffect(() => {
-    const project = data?.length === 1 ? data[0]! : null;
-    if (project == null) return;
-    if (project.deploymentStatus === "unknown") return;
-    if (onboardingRedirectInFlightProjectIds.current.has(project.id)) return;
-    onboardingRedirectInFlightProjectIds.current.add(project.id);
-
-    let cancelled = false;
-    let retryTimer: ReturnType<typeof setTimeout> | null = null;
-    const finishRedirectAttempt = () => {
-      onboardingRedirectInFlightProjectIds.current.delete(project.id);
-    };
-    const retryRedirectAttempt = () => {
-      if (cancelled) return;
-      finishRedirectAttempt();
-      retryTimer = setTimeout(() => {
-        if (!cancelled) retryOnboardingRedirect();
-      }, 1_000);
-    };
-
-    void (async () => {
-      let shouldRetry = false;
-      try {
-        const itx = await connectItxBrowser();
-        if (project.deploymentStatus === "missing") {
-          const organizationSlug = organizationSlugFor(project);
-          await itx.projects.create({
-            projectId: project.id,
-            slug: project.slug,
-            waitUntilCreated: false,
-            ...(organizationSlug === undefined ? {} : { organizationSlug }),
-          });
-        } else {
-          const projectItx = await itx.projects.get(project.id);
-          let inOnboarding = false;
-          for (let attempt = 0; attempt < 20 && !cancelled; attempt += 1) {
-            const { state } = await projectItx.processor.snapshot();
-            if (!state.onboardingActive) return;
-            if (hasActiveOnboardingAgent(state)) {
-              inOnboarding = true;
-              break;
-            }
-            await new Promise((resolve) => setTimeout(resolve, 500));
-          }
-          if (!inOnboarding) {
-            shouldRetry = true;
-            return;
-          }
-        }
-
-        if (cancelled) return;
-        await navigate({
-          to: "/projects/$projectSlug/agents/streams/$",
-          params: { projectSlug: project.slug, _splat: ONBOARDING_AGENT_PATH },
-          search: {},
-          replace: true,
-        });
-      } catch {
-        shouldRetry = true;
-      } finally {
-        if (shouldRetry) {
-          retryRedirectAttempt();
-        } else {
-          finishRedirectAttempt();
-        }
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      if (retryTimer != null) clearTimeout(retryTimer);
-      finishRedirectAttempt();
-    };
-  }, [data, navigate, onboardingRedirectRetry, organizationSlugFor]);
 
   return (
     <section className="space-y-5 p-4">

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -148,6 +148,7 @@ async function appFetch(
 
       const context: RequestContext = {
         config: requestConfig,
+        executionCtx: ctx,
         isEventDocsHost: host.isEventDocsHost,
         log,
         rawRequest: request,

--- a/specs/signup.spec.ts
+++ b/specs/signup.spec.ts
@@ -19,13 +19,16 @@ test("can sign up with an email one-time passcode", async ({ page }) => {
   await signUpWithEmailOtp(page, { email: uniqueSignupEmail("signup"), projectSlug: slug });
 
   // Back on OS, signed in: onboarding created the first project's container
-  // on auth, and /projects auto-runs the engine set-up for it. The pending
-  // state renders its data-spinner section twice during the redirect, which
-  // trips spinner-waiter's strict-mode isVisible — sit it out. Once the
-  // bootstrap finishes, the project row's name becomes a link. The cold-slot
+  // on auth, and the root `/` starts the engine bootstrap and redirects
+  // server-side straight to the onboarding agent stream. The agent page's
+  // loading states render two spinner-matching elements at once, which trips
+  // spinner-waiter's strict-mode isVisible — sit it out. The cold-slot
   // OAuth-callback straggle traced back to zombie worker routes, which the
   // deploy now verifies + heals (tasks/os-cold-create-latency.md).
-  await spinnerWaiter.settings.run({ disabled: true }, () =>
-    page.getByRole("link", { name: slug }).waitFor({ timeout: 60_000 }),
-  );
+  await spinnerWaiter.settings.run({ disabled: true }, async () => {
+    await page.waitForURL(`**/projects/${slug}/agents/streams/agents/onboarding`, {
+      timeout: 60_000,
+    });
+    await page.getByPlaceholder("Message this agent").waitFor({ timeout: 60_000 });
+  });
 });


### PR DESCRIPTION
## What changed

The root `/` → onboarding redirect decision has been **silently broken since PR #1658 landed**: capnweb HTTP-batch sessions are one-shot — calls made after the first `await` are silently dropped and their awaits reject ("Batch RPC request ended."). `getRootProjectRedirectServerFn` awaited `projects.list()` and *then* called `processor.snapshot()` / `projects.create()`, so both always threw and every interesting case degraded to `/projects`, where fresh signups rode the slow client-side polling path (projects-table flicker, 20×500ms snapshot polls, client navigate).

This PR fixes the bug by deleting the pattern that caused it: **server-side code in the OS worker no longer dials its own `/api` over loopback HTTP.** Everything runs in one worker, so it constructs the itx session RpcTargets in-process (the same lane `worker.ts` already uses for project ingress).

- `auth.ts`: export `itxAuthFromPrincipal` — build the `ItxAuthContext` straight from the middleware-resolved principal (same confinement: claims + directory fallback; no cookie re-verification).
- `request-context.ts` / `worker.ts`: `RequestContext` carries the real `ExecutionContext` (RpcTargets need `ctx.exports`).
- `getRootProjectRedirectServerFn`: in-process `ProjectCollectionRpcTarget` on the user principal. `/` now answers with **one 307 straight to the final page** (onboarding agent stream / project home / projects list) before anything renders — no flicker.
- `/projects` is a plain list page again: the duplicated loader redirect and the entire polling/retry redirect effect are deleted. The auto-setup effect stays as self-heal (now covering single-project cases) but never hijack-navigates — "All projects" can't bounce a single-project user back into their project.
- `integration-api.ts` (Slack/Google OAuth callbacks) and `mcp-handler.ts` (`exec_js`, `ask_assistant`): same in-process lane with first-party authority (caller access was already verified per-request; previously these authenticated to themselves with the admin API secret). **This also fixes `ask_assistant`**, which carried the same dead-batch bug (post-await `ensureMcpSessionAgentReady` + `.ask()` on a spent batch).
- `mcp-handler.ts`: the hand-rolled fake `ExecutionContext` shim is gone — the real one is passed through.
- `specs/signup.spec.ts`: now asserts the intended landing (onboarding agent composer) instead of the degraded `/projects` table it used to codify.

Zero `newHttpBatchRpcSession` loopback call sites remain in `apps/os/src` (browser/CLI WebSocket dials are untouched).

Net: −138 lines.

## How I verified it

- **Root redirect, live:** forged single-project session against local dev — `GET /` returns a single `307` with `Location: /projects/<slug>/agents/streams/agents/onboarding`, and the browser lands on the agent composer with no intermediate render.
- **MCP, live:** admin-secret MCP smoke over `/api/mcp` — `exec_js` returns the project describe in 56ms, `ask_assistant` returns a real agent reply ("pong", ~2s). `ask_assistant` did not work at all before this PR.
- `pnpm typecheck`, `pnpm lint`, `pnpm format`, 366 apps/os unit tests, and 25/26 root Playwright specs pass locally (the `sandbox-exec` REPL example fails on local dev containers config, pre-existing on main; the real email-OTP signup specs are blocked locally by shared dev auth returning 500 on `/oauth2/authorize` for new users — also pre-existing on main).
- Integrations OAuth callback happy path needs a real vendor code exchange; it's covered by typecheck and uses the identical construction proven live in the other three call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth context construction and first-party internal authority for MCP and OAuth callbacks; behavior is improved but these are sensitive request paths with broader blast radius than UI-only changes.
> 
> **Overview**
> **Server-side itx no longer dials its own `/api` over loopback HTTP.** Capnweb HTTP-batch sessions are one-shot, so any path that `await`ed a first RPC and then called another (root redirect after `projects.list()`, MCP `ask_assistant` after auth) was failing and degrading behavior. The OS worker now constructs `ProjectCollectionRpcTarget` in-process using `RequestContext.executionCtx` and either `itxAuthFromPrincipal` (user-scoped server fns) or `trustedInternalAuthContext()` (MCP tools and integration OAuth callbacks after access checks).
> 
> **Root `/` redirect is fixed:** `getRootProjectRedirectServerFn` can chain `list`, `processor.snapshot`, and `projects.create` on the middleware principal and issue a single server-side redirect to onboarding, project home, or `/projects` without client flicker.
> 
> **`/projects` is a plain list again** — loader redirects and client polling/onboarding hijack effects are removed; auto-setup for `missing` projects remains as self-heal only.
> 
> MCP passes the real `ExecutionContext` into the handler; signup e2e now expects landing on the onboarding agent composer instead of the projects table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ac5efa78f682fe4fee73e714c6ef5cd79bf9265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> Teardown skipped: Slot preview-4 no longer belongs to pr-1710: it is now leased by pr-1716 (https://github.com/iterate/iterate/pull/1716). Their deployment has replaced this PR's apps on preview_4.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-07T18:17:06.454Z",
      "headSha": "7ac5efa78f682fe4fee73e714c6ef5cd79bf9265",
      "message": "Teardown skipped: Slot preview-4 no longer belongs to pr-1710: it is now leased by pr-1716 (https://github.com/iterate/iterate/pull/1716). Their deployment has replaced this PR's apps on preview_4.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/494999465578345",
      "shortSha": "7ac5efa",
      "deployDurationMs": 174833,
      "testDurationMs": 381683,
      "testRetries": "2 retried: runs \"provide-itx-expression\" through the project REPL (specs x1) · runs \"sandbox-exec\" through the project REPL (specs x1)"
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-07T18:17:06.454Z",
      "headSha": "7ac5efa78f682fe4fee73e714c6ef5cd79bf9265",
      "message": "Teardown skipped: Slot preview-4 no longer belongs to pr-1710: it is now leased by pr-1716 (https://github.com/iterate/iterate/pull/1716). Their deployment has replaced this PR's apps on preview_4.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/494999465578345",
      "shortSha": "7ac5efa",
      "deployDurationMs": 18097,
      "testDurationMs": 580,
      "testRetries": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-07T18:17:06.454Z",
      "headSha": "7ac5efa78f682fe4fee73e714c6ef5cd79bf9265",
      "message": "Teardown skipped: Slot preview-4 no longer belongs to pr-1710: it is now leased by pr-1716 (https://github.com/iterate/iterate/pull/1716). Their deployment has replaced this PR's apps on preview_4.",
      "publicUrl": "https://semaphore.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/494999465578345",
      "shortSha": "7ac5efa",
      "deployDurationMs": 15685,
      "testDurationMs": 8150,
      "testRetries": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-07T18:17:06.454Z",
      "headSha": "7ac5efa78f682fe4fee73e714c6ef5cd79bf9265",
      "message": "Teardown skipped: Slot preview-4 no longer belongs to pr-1710: it is now leased by pr-1716 (https://github.com/iterate/iterate/pull/1716). Their deployment has replaced this PR's apps on preview_4.",
      "publicUrl": "https://streams.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/494999465578345",
      "shortSha": "7ac5efa",
      "deployDurationMs": 16422,
      "testDurationMs": 19117,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": "Teardown skipped: Slot preview-4 no longer belongs to pr-1710: it is now leased by pr-1716 (https://github.com/iterate/iterate/pull/1716). Their deployment has replaced this PR's apps on preview_4."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `7ac5efa` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 18.1s | 580ms |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/494999465578345) | 2026-07-07T18:17:06.454Z | Teardown skipped: Slot preview-4 no longer belongs to pr-1710: it is now leased by pr-1716 (https://github.com/iterate/iterate/pull/1716). Their deployment has replaced this PR's ... |
| OS | released | `7ac5efa` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 174.8s | 381.7s | 2 retried: runs "provide-itx-expression" through the project REPL (specs x1) · runs "sandbox-exec" through the project REPL (specs x1) |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/494999465578345) | 2026-07-07T18:17:06.454Z | Teardown skipped: Slot preview-4 no longer belongs to pr-1710: it is now leased by pr-1716 (https://github.com/iterate/iterate/pull/1716). Their deployment has replaced this PR's ... |
| Semaphore | released | `7ac5efa` | [https://semaphore.iterate-preview-4.com](https://semaphore.iterate-preview-4.com) | 15.7s | 8.2s |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/494999465578345) | 2026-07-07T18:17:06.454Z | Teardown skipped: Slot preview-4 no longer belongs to pr-1710: it is now leased by pr-1716 (https://github.com/iterate/iterate/pull/1716). Their deployment has replaced this PR's ... |
| Streams Example App | released | `7ac5efa` | [https://streams.iterate-preview-4.com](https://streams.iterate-preview-4.com) | 16.4s | 19.1s |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/494999465578345) | 2026-07-07T18:17:06.454Z | Teardown skipped: Slot preview-4 no longer belongs to pr-1710: it is now leased by pr-1716 (https://github.com/iterate/iterate/pull/1716). Their deployment has replaced this PR's ... |

</details>
<!-- /CLOUDFLARE_PREVIEW -->