### PR TITLE
Render child stream events in agent feed

### DIFF
--- a/apps/os/src/components/agent-feed.tsx
+++ b/apps/os/src/components/agent-feed.tsx
@@ -7,12 +7,14 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { Link } from "@tanstack/react-router";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   BanIcon,
   ChevronRightIcon,
   CircleQuestionMarkIcon,
   CodeIcon,
+  GitBranchIcon,
   PaperclipIcon,
 } from "lucide-react";
 import type {
@@ -39,6 +41,7 @@ import { cn } from "@iterate-com/ui/lib/utils";
 import { AGENT_UI_FEED_TABLE } from "~/domains/streams/client-libraries/processors/agent-ui-processor.ts";
 import { useStreamQuery } from "~/domains/streams/client-libraries/browser/hooks/use-stream-query.ts";
 import type { StreamBrowserDatabase } from "~/domains/streams/client-libraries/browser/stream-browser-db.ts";
+import { linkOptionsForStreamPath } from "~/lib/stream-routes.ts";
 /** How many rows past the virtualizer's window the tail query prefetches. */
 const TAIL_PREFETCH_ROWS = 32;
 
@@ -64,6 +67,7 @@ export function AgentFeedView({
   isPending = false,
   isInterruptingQueuedMessages = false,
   onInterruptQueuedMessages,
+  projectSlug,
 }: {
   database: StreamBrowserDatabase;
   liveState: AgentUiState | null;
@@ -72,6 +76,7 @@ export function AgentFeedView({
   isPending?: boolean;
   isInterruptingQueuedMessages?: boolean;
   onInterruptQueuedMessages?: () => Promise<void> | void;
+  projectSlug?: string;
 }) {
   const query = search.trim().toLowerCase();
   const countResult = useStreamQuery(
@@ -223,6 +228,7 @@ export function AgentFeedView({
                     item={item}
                     expandedIds={expandedIds}
                     onToggle={toggleExpanded}
+                    projectSlug={projectSlug}
                   />
                 )}
               </div>
@@ -242,13 +248,19 @@ const AgentFeedItemRow = memo(function AgentFeedItemRow({
   item,
   expandedIds,
   onToggle,
+  projectSlug,
 }: {
   item: AgentUiItem;
   expandedIds: ReadonlySet<string>;
   onToggle: (id: string) => void;
+  projectSlug?: string;
 }) {
   if (item.kind === "stream-woken") {
     return <StreamWakeRow item={item} />;
+  }
+
+  if (item.kind === "child-stream-created") {
+    return <ChildStreamCreatedRow item={item} projectSlug={projectSlug} />;
   }
 
   if (item.kind !== "activity") {
@@ -292,6 +304,45 @@ const AgentFeedItemRow = memo(function AgentFeedItemRow({
     />
   );
 });
+
+function ChildStreamCreatedRow({
+  item,
+  projectSlug,
+}: {
+  item: Extract<AgentUiItem, { kind: "child-stream-created" }>;
+  projectSlug?: string;
+}) {
+  const dateTime = formatDateTimeAttribute(item.timestampMs);
+  const streamLabel = compactStreamPath(item.childPath);
+  const linkOptions =
+    projectSlug == null ? null : linkOptionsForStreamPath(projectSlug, item.childPath);
+
+  return (
+    <div
+      className="flex items-center gap-2 py-2 text-xs text-muted-foreground"
+      data-testid="agent-feed-child-stream-created"
+      data-kind="child-stream-created"
+    >
+      <div className="h-px min-w-8 flex-1 bg-border/70" />
+      <GitBranchIcon className="size-3.5 shrink-0 text-muted-foreground/70" aria-hidden="true" />
+      <span className="shrink-0">Created child stream</span>
+      {linkOptions == null ? (
+        <span className="min-w-0 truncate font-mono text-foreground/70">{streamLabel}</span>
+      ) : (
+        <Link
+          {...linkOptions}
+          className="min-w-0 truncate font-mono text-foreground/80 underline-offset-4 hover:text-foreground hover:underline"
+        >
+          {streamLabel}
+        </Link>
+      )}
+      <time className="sr-only" dateTime={dateTime}>
+        {formatDateTime(item.timestampMs)}
+      </time>
+      <div className="h-px min-w-8 flex-1 bg-border/70" />
+    </div>
+  );
+}
 
 function StreamWakeRow({ item }: { item: Extract<AgentUiItem, { kind: "stream-woken" }> }) {
   const dateTime = formatDateTimeAttribute(item.timestampMs);
@@ -891,4 +942,11 @@ function stringifyResult(result: unknown): string {
   } catch {
     return String(result);
   }
+}
+
+function compactStreamPath(path: string): string {
+  if (path.length <= 64) return path;
+  const segments = path.split("/").filter(Boolean);
+  if (segments.length <= 3) return path;
+  return `.../${segments.slice(-3).join("/")}`;
 }

--- a/apps/os/src/components/agent-ui-reducer.test.ts
+++ b/apps/os/src/components/agent-ui-reducer.test.ts
@@ -371,6 +371,24 @@ describe("agent-ui reducer", () => {
     expect(state.presence).toMatchObject([{ subscriptionKey: "agent:agent", connected: false }]);
   });
 
+  it("shows child stream creation events in the agent feed", () => {
+    const state = reduceAll([
+      {
+        type: "events.iterate.com/stream/child-stream-created",
+        payload: { childPath: "/agents/test/child" },
+      },
+    ]);
+
+    expect(state.items).toEqual([
+      {
+        kind: "child-stream-created",
+        id: "child-stream-created-1",
+        childPath: "/agents/test/child",
+        timestampMs: Date.parse("2026-06-11T00:00:01.000Z"),
+      },
+    ]);
+  });
+
   it("settles a completed LLM request even without an assistant message", () => {
     const state = reduceAll([
       {

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -73,6 +73,7 @@ export function ProjectStreamView({
   messageComposer,
   panel,
   projectId,
+  projectSlug,
   streamSource,
   streamPath,
 }: {
@@ -89,6 +90,7 @@ export function ProjectStreamView({
    */
   panel?: ReactNode;
   projectId: string | null;
+  projectSlug?: string;
   streamSource?: ItxStreamSource;
   streamPath: string;
 }) {
@@ -252,6 +254,7 @@ export function ProjectStreamView({
                 search={feedSearch}
                 emptyLabel={connectionLabel}
                 isInterruptingQueuedMessages={interrupt?.isInterrupting ?? false}
+                projectSlug={projectSlug}
                 // The reduced-state row only exists once the processor has
                 // checkpointed; an already-subscribed empty stream is "nothing
                 // here yet", not "connecting".

--- a/apps/os/src/domains/streams/client-libraries/processors/agent-ui-processor.ts
+++ b/apps/os/src/domains/streams/client-libraries/processors/agent-ui-processor.ts
@@ -24,7 +24,7 @@ import type { SqlClient, SqlValue } from "../browser/stream-browser-db.ts";
 export const AGENT_UI_FEED_TABLE = "agent_feed_items";
 
 /** Bumped into the writer-lock name so a schema change lets a fresh tab take over. */
-export const AGENT_UI_SCHEMA_VERSION = 6;
+export const AGENT_UI_SCHEMA_VERSION = 7;
 
 // planAgentUiOps still types its events against packages/ui's shared Event
 // type; deriving the parameter type here keeps this file free of
@@ -34,7 +34,7 @@ type AgentUiReducerEvents = Parameters<typeof planAgentUiOps>[1];
 
 export const AgentUiProcessorContract = defineProcessorContract({
   slug: "agent-ui",
-  version: "0.1.1",
+  version: "0.1.2",
   description:
     "Browser-side processor that folds agent streams (including partial LLM chunks) into settled chat rows in SQLite plus a live in-flight activity in reduced state.",
   // itx derives a processor's empty fold from `stateSchema.parse({})`

--- a/apps/os/src/routes/_app/projects/$projectSlug/agents/streams/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/agents/streams/$.tsx
@@ -88,6 +88,7 @@ function ProjectAgentDetailContent() {
         placeholder: "Message this agent",
       }}
       projectId={project.id}
+      projectSlug={project.slug}
       streamPath={streamPath}
     />
   );

--- a/apps/os/src/routes/_app/projects/$projectSlug/streams/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/streams/$.tsx
@@ -53,6 +53,7 @@ function ProjectStreamDetailContent() {
         placeholder: "Message this stream",
       }}
       projectId={project.id}
+      projectSlug={project.slug}
       streamPath={streamPath}
     />
   );

--- a/packages/ui/src/components/events/agent-ui-reducer.ts
+++ b/packages/ui/src/components/events/agent-ui-reducer.ts
@@ -87,7 +87,18 @@ export type AgentUiStreamWakeItem = {
   timestampMs: number;
 };
 
-export type AgentUiItem = AgentUiMessageItem | AgentUiActivity | AgentUiStreamWakeItem;
+export type AgentUiChildStreamItem = {
+  kind: "child-stream-created";
+  id: string;
+  childPath: string;
+  timestampMs: number;
+};
+
+export type AgentUiItem =
+  | AgentUiMessageItem
+  | AgentUiActivity
+  | AgentUiStreamWakeItem
+  | AgentUiChildStreamItem;
 
 export type AgentUiProcessorAnnouncement = {
   slug: string;
@@ -172,6 +183,7 @@ const CODEMODE_SCRIPT_EXECUTION_COMPLETED =
 const STREAM_SUBSCRIBER_CONNECTED = "events.iterate.com/stream/subscriber-connected";
 const STREAM_SUBSCRIBER_DISCONNECTED = "events.iterate.com/stream/subscriber-disconnected";
 const STREAM_WOKEN = "events.iterate.com/stream/woken";
+const STREAM_CHILD_STREAM_CREATED = "events.iterate.com/stream/child-stream-created";
 const STREAM_WAKE_LABEL = "Stream durable object woke";
 
 // ---------------------------------------------------------------------------
@@ -466,6 +478,17 @@ function reduceAgentUiEvent(previous: AgentUiState, event: Event, ops: AgentUiOp
         kind: "stream-woken",
         id: `stream-woken-${event.offset}`,
         text: STREAM_WAKE_LABEL,
+        timestampMs,
+      });
+    }
+
+    case STREAM_CHILD_STREAM_CREATED: {
+      const childPath = readString(event, "childPath");
+      if (childPath == null) return state;
+      return emitItem(state, ops, {
+        kind: "child-stream-created",
+        id: `child-stream-created-${event.offset}`,
+        childPath,
         timestampMs,
       });
     }


### PR DESCRIPTION
## What

- Render `events.iterate.com/stream/child-stream-created` events in the agent feed.
- Link each child stream row to the appropriate project stream route.
- Bump the browser agent-ui processor schema/version so existing local feed mirrors rebuild with the new row type.

## Why

Child stream creation is currently visible in the raw event feed but hidden in the agent chat preset, which makes it harder to follow when an agent fans work out into child streams.

## Checks

- `pnpm --dir apps/os exec vitest run src/components/agent-ui-reducer.test.ts --reporter verbose`
- `pnpm --dir apps/os typecheck`
- `pnpm lint`
- `pnpm exec oxfmt --check apps/os/src/components/agent-feed.tsx apps/os/src/components/project-stream-view.tsx apps/os/src/routes/_app/projects/\$projectSlug/agents/streams/\$.tsx apps/os/src/routes/_app/projects/\$projectSlug/streams/\$.tsx apps/os/src/domains/streams/client-libraries/processors/agent-ui-processor.ts apps/os/src/components/agent-ui-reducer.test.ts packages/ui/src/components/events/agent-ui-reducer.ts`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-07T18:31:50.580Z",
      "headSha": "e787293ad58501554ffe54e941cba036e83663d5",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/404684933045742",
      "shortSha": "e787293",
      "cleanupDurationMs": 4652,
      "deployDurationMs": 150143,
      "testDurationMs": 158169,
      "testRetries": "5 retried: sandbox egress > is MITM-intercepted and routed through project egress with secret substitution (vitest x1) · append after idle teardown re-wakes configured subscriber from its checkpoint (vitest x1) · stream rules cannot cross-post project stream events into global streams (vitest x1) · project REPL accepts a forged session (specs x1) · reactivity page processor panel goes live and repaints from a server push (specs x1)"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-07T18:31:47.031Z",
      "headSha": "e787293ad58501554ffe54e941cba036e83663d5",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/404684933045742",
      "shortSha": "e787293",
      "cleanupDurationMs": 1098,
      "deployDurationMs": 16334,
      "testDurationMs": 6640,
      "testRetries": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-07T18:31:49.215Z",
      "headSha": "e787293ad58501554ffe54e941cba036e83663d5",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/404684933045742",
      "shortSha": "e787293",
      "cleanupDurationMs": 3282,
      "deployDurationMs": 17891,
      "testDurationMs": 639,
      "testRetries": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-07T18:31:47.032Z",
      "headSha": "e787293ad58501554ffe54e941cba036e83663d5",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/404684933045742",
      "shortSha": "e787293",
      "cleanupDurationMs": 1096,
      "deployDurationMs": 14766,
      "testDurationMs": 14764,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `e787293` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 17.9s | 639ms |  | 3.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/404684933045742) | 2026-07-07T18:31:49.215Z | Preview app released. |
| OS | released | `e787293` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 150.1s | 158.2s | 5 retried: sandbox egress > is MITM-intercepted and routed through project egress with secret substitution (vitest x1) · append after idle teardown re-wakes configured subscriber from its checkpoint (vitest x1) · stream rules cannot cross-post project stream events into global streams (vitest x1) · project REPL accepts a forged session (specs x1) · reactivity page processor panel goes live and repaints from a server push (specs x1) | 4.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/404684933045742) | 2026-07-07T18:31:50.580Z | Preview app released. |
| Semaphore | released | `e787293` | [https://semaphore.iterate-preview-6.com](https://semaphore.iterate-preview-6.com) | 16.3s | 6.6s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/404684933045742) | 2026-07-07T18:31:47.031Z | Preview app released. |
| Streams Example App | released | `e787293` | [https://streams.iterate-preview-6.com](https://streams.iterate-preview-6.com) | 14.8s | 14.8s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/404684933045742) | 2026-07-07T18:31:47.032Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Changes |
| --- | ---: |
| Product | +4 -2 🟩⬜⬜⬜⬜ |
| UI components | +79 -1 🟩🟩🟩🟩🟩 |
| Tests | +16 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+99 -3** 🟩🟩🟩🟩🟩 |

<sub>Source lines changed (blank lines and JS comments ignored) between df3732a and e787293, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and feed-reducer changes only; optional navigation links when project context is present. Schema bump clears/rebuilds local SQLite mirrors on upgrade, which is intentional and low operational risk.
> 
> **Overview**
> **Child stream creation** is now visible in the agent chat preset, not only in the raw event feed.
> 
> The agent-ui reducer folds `events.iterate.com/stream/child-stream-created` into a new settled feed item (`child-stream-created` with `childPath` and timestamp). The feed renders a divider row (“Created child stream”) with a truncated path; when `projectSlug` is passed from project stream routes, the path links via `linkOptionsForStreamPath`.
> 
> `projectSlug` is threaded through `ProjectStreamView` → `AgentFeedView` → row components. The browser agent-ui processor **schema version 7** / contract **0.1.2** bump forces local feed mirrors to rebuild so existing clients pick up the new row type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e787293ad58501554ffe54e941cba036e83663d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->