### PR TITLE
Scheduler dashboard panel + processor parse-poison fix

### DIFF
--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -4,6 +4,7 @@ import {
   ArrowLeft,
   Box,
   Bug,
+  CalendarClock,
   Check,
   ChevronsLeft,
   ChevronsUpDown,
@@ -590,6 +591,7 @@ type ProjectStreamNavItemConfig = {
     | "/projects/$projectSlug/agents"
     | "/projects/$projectSlug/integrations"
     | "/projects/$projectSlug/sandboxes"
+    | "/projects/$projectSlug/scheduler"
     | "/projects/$projectSlug/secrets"
     | "/projects/$projectSlug/repos"
     | "/projects/$projectSlug/streams";
@@ -630,6 +632,13 @@ const PROJECT_STREAM_NAV_ITEMS: readonly ProjectStreamNavItemConfig[] = [
     label: "/sandboxes",
     streamPath: StreamPath.parse("/sandboxes"),
     to: "/projects/$projectSlug/sandboxes",
+  },
+  {
+    fuzzy: true,
+    icon: CalendarClock,
+    label: "/scheduler",
+    streamPath: StreamPath.parse("/scheduler"),
+    to: "/projects/$projectSlug/scheduler",
   },
   {
     fuzzy: true,

--- a/apps/os/src/domains/streams/stream-processor.test.ts
+++ b/apps/os/src/domains/streams/stream-processor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
-import type { Stream, StreamEvent } from "../../types.ts";
+import type { Stream, StreamEvent, StreamEventInput } from "../../types.ts";
 import { defineProcessorContract } from "./processor-contracts.ts";
 import { StreamProcessor } from "./stream-processor.ts";
 
@@ -193,5 +193,128 @@ describe("StreamProcessor.onStateChange", () => {
 
     handle.unsubscribe(); // idempotent: a second call must not double-dispose
     expect(dispose).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Streams accept raw appends by design, so a committed event can carry a
+// consumed TYPE with a shape the contract rejects. These tests pin the
+// skip-and-record behavior: the fold advances past the event (no wedged
+// checkpoint) and the skip is recorded on the stream, idempotently.
+describe("StreamProcessor parse-failure skipping", () => {
+  function unparseableEvent(offset?: number): StreamEvent {
+    nextOffset = offset ?? nextOffset + 1;
+    return {
+      type: "events.iterate.com/test/incremented",
+      payload: { by: "not-a-number" },
+      createdAt: new Date(nextOffset).toISOString(),
+      offset: nextOffset,
+    };
+  }
+
+  function recordingStream() {
+    const appends: StreamEventInput[] = [];
+    const stream = {
+      append: (...events: StreamEventInput[]) => {
+        appends.push(...events);
+        return Promise.resolve(
+          events.map((event, index) => ({
+            ...event,
+            offset: 1_000 + appends.length + index,
+            createdAt: new Date(0).toISOString(),
+          })),
+        );
+      },
+    } as unknown as Stream;
+    return { appends, stream };
+  }
+
+  function recordingCounter() {
+    nextOffset = 0;
+    const { appends, stream } = recordingStream();
+    return { appends, processor: new CounterProcessor({ stream }) };
+  }
+
+  it("skips an unparseable consumed-type event and folds the rest of the batch", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { processor } = recordingCounter();
+      await processor.ingest({
+        events: [incrementedEvent(2), unparseableEvent(), incrementedEvent(3)],
+        streamMaxOffset: 3,
+      });
+      await expect(processor.snapshot()).resolves.toEqual({ offset: 3, state: { count: 5 } });
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("advances the checkpoint past a batch containing only an unparseable event", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { processor } = recordingCounter();
+      await processor.ingest({ events: [unparseableEvent()], streamMaxOffset: 1 });
+      await expect(processor.snapshot()).resolves.toEqual({ offset: 1, state: { count: 0 } });
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("records each skip on the stream with an offset-scoped idempotency key", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { appends, processor } = recordingCounter();
+      await processor.ingest({
+        events: [incrementedEvent(1), unparseableEvent()],
+        streamMaxOffset: 2,
+      });
+
+      // The record append is fire-and-forget background work.
+      await vi.waitFor(() => expect(appends).toHaveLength(1));
+      expect(appends[0]).toMatchObject({
+        type: "events.iterate.com/stream/error-occurred",
+        idempotencyKey: "processor-event-parse-failed:test-counter:2",
+      });
+      expect(consoleError).toHaveBeenCalledTimes(1);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("redelivery of an already-skipped event neither re-reduces nor re-records", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { appends, processor } = recordingCounter();
+      const batch = [incrementedEvent(2), unparseableEvent()];
+      await processor.ingest({ events: batch, streamMaxOffset: 2 });
+      await vi.waitFor(() => expect(appends).toHaveLength(1));
+
+      await processor.ingest({ events: batch, streamMaxOffset: 2 });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      await expect(processor.snapshot()).resolves.toEqual({ offset: 2, state: { count: 2 } });
+      expect(appends).toHaveLength(1);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("a failing record append is logged, never rethrown into the batch", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      nextOffset = 0;
+      const processor = new CounterProcessor({
+        stream: {
+          append: () => Promise.reject(new Error("append transport down")),
+        } as unknown as Stream,
+      });
+
+      await processor.ingest({ events: [unparseableEvent()], streamMaxOffset: 1 });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // The skip committed even though recording it failed.
+      await expect(processor.snapshot()).resolves.toEqual({ offset: 1, state: { count: 0 } });
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });

--- a/apps/os/src/domains/streams/stream-processor.ts
+++ b/apps/os/src/domains/streams/stream-processor.ts
@@ -59,6 +59,13 @@ type ReducedEvent<Contract> = {
   state: ProcessorState<Contract>;
 };
 
+/**
+ * A consumed-type event whose shape failed the contract parse. Distinguished
+ * from `undefined` (type not consumed at all) so ingest can skip the event
+ * AND record the skip durably instead of silently dropping it.
+ */
+type ConsumedEventParseFailure = { parseError: z.ZodError };
+
 /** What `reduce` receives: one consumed event and the state to fold it into. */
 type ReduceArgs<Contract> = {
   event: ConsumedEvent<Contract>;
@@ -458,12 +465,15 @@ export abstract class StreamProcessor<
   /**
    * Reduce one raw stream event against explicit state, without touching the
    * processor's own state or checkpoint. Returns `undefined` for events this
-   * processor does not consume.
+   * processor does not consume, and a {@link ConsumedEventParseFailure} for
+   * events of a consumed TYPE whose shape fails the contract parse — streams
+   * accept raw appends by design, so a malformed event is a fact of the log,
+   * not an exception: throwing here would wedge the checkpoint on it forever.
    */
   #reduceRawEvent(args: {
     event: StreamEvent;
     state: ProcessorState<Contract>;
-  }): ReducedEvent<Contract> | undefined {
+  }): ReducedEvent<Contract> | ConsumedEventParseFailure | undefined {
     const eventDefinition = getConsumedEventDefinition({
       contract: this.contract,
       eventType: args.event.type,
@@ -472,10 +482,12 @@ export abstract class StreamProcessor<
 
     // Rebuilding the parser from the catalog key and payload schema keeps replay
     // and live delivery on the same validation path.
-    const event = getEventSchema({
+    const parsed = getEventSchema({
       type: args.event.type,
       payloadSchema: eventDefinition.payloadSchema,
-    }).parse(args.event) as ConsumedEvent<Contract>;
+    }).safeParse(args.event);
+    if (!parsed.success) return { parseError: parsed.error };
+    const event = parsed.data as ConsumedEvent<Contract>;
 
     const state = this.reduce({ event, state: args.state }) ?? args.state;
     assertObjectProcessorState({ processorSlug: this.contract.slug, value: state });
@@ -498,6 +510,7 @@ export abstract class StreamProcessor<
     let checkpointOffset = this.#checkpointOffset;
     const events: StreamEvent[] = [];
     const reducedEvents: ReducedEvent<Contract>[] = [];
+    const parseFailures: { event: StreamEvent; error: z.ZodError }[] = [];
 
     for (const event of args.events) {
       if (event.offset <= checkpointOffset) continue;
@@ -506,6 +519,10 @@ export abstract class StreamProcessor<
 
       const reduction = this.#reduceRawEvent({ event, state });
       if (reduction === undefined) continue;
+      if ("parseError" in reduction) {
+        parseFailures.push({ event, error: reduction.parseError });
+        continue;
+      }
       reducedEvents.push(reduction);
       state = reduction.state;
     }
@@ -549,6 +566,27 @@ export abstract class StreamProcessor<
       this.#notifyStateChange({ offset: checkpointOffset, state });
     }
     this.#resolveEventWaiters(events);
+
+    // Record skipped unparseable events AFTER the checkpoint commits, in the
+    // background: the raw event in the log is the authoritative record and the
+    // idempotency key dedupes redelivery, so a failing record append can never
+    // re-poison the batch it just rescued.
+    for (const { event, error } of parseFailures) {
+      const message =
+        `stream processor "${this.contract.slug}" skipped event at offset ` +
+        `${event.offset} ("${event.type}"): it fails the contract's schema`;
+      console.error(message, error);
+      this.runInBackground(() =>
+        this.stream.append({
+          type: "events.iterate.com/stream/error-occurred",
+          idempotencyKey: `processor-event-parse-failed:${this.contract.slug}:${event.offset}`,
+          payload: {
+            message,
+            error: { name: error.name, message: error.message },
+          },
+        }),
+      );
+    }
   }
 
   #appendEmitted(...input: EmittedInput<Contract>[]): Promise<StreamEvent[]> {

--- a/apps/os/src/lib/stream-routes.ts
+++ b/apps/os/src/lib/stream-routes.ts
@@ -48,6 +48,11 @@ export function linkOptionsForStreamPath(projectSlug: string, path: string) {
   if (streamPath === "/sandboxes") {
     return linkOptions({ to: "/projects/$projectSlug/sandboxes", params, search: {} });
   }
+  // The scheduler page shows the primary Scheduler; other /scheduler/**
+  // streams fall through to the generic stream page below.
+  if (streamPath === "/scheduler" || streamPath === "/scheduler/primary") {
+    return linkOptions({ to: "/projects/$projectSlug/scheduler", params, search: {} });
+  }
   if (streamPath === "/agents") {
     return linkOptions({ to: "/projects/$projectSlug/agents", params, search: {} });
   }

--- a/apps/os/src/routeTree.gen.ts
+++ b/apps/os/src/routeTree.gen.ts
@@ -39,6 +39,7 @@ import { Route as AppProjectsProjectSlugIndexRouteImport } from './routes/_app/p
 import { Route as DocsStreamsProcessorsProcessorSlugRouteImport } from './routes/docs.streams.processors.$processorSlug'
 import { Route as AdminStreamsProjectIdSplatRouteImport } from './routes/admin/streams/$projectId/$'
 import { Route as AppProjectsProjectSlugSettingsRouteImport } from './routes/_app/projects/$projectSlug/settings'
+import { Route as AppProjectsProjectSlugSchedulerRouteImport } from './routes/_app/projects/$projectSlug/scheduler'
 import { Route as AppProjectsProjectSlugReplRouteImport } from './routes/_app/projects/$projectSlug/repl'
 import { Route as AppProjectsProjectSlugReactivityRouteImport } from './routes/_app/projects/$projectSlug/reactivity'
 import { Route as AppProjectsProjectSlugIntegrationsRouteImport } from './routes/_app/projects/$projectSlug/integrations'
@@ -213,6 +214,12 @@ const AppProjectsProjectSlugSettingsRoute =
     path: '/settings',
     getParentRoute: () => AppProjectsProjectSlugRouteRoute,
   } as any)
+const AppProjectsProjectSlugSchedulerRoute =
+  AppProjectsProjectSlugSchedulerRouteImport.update({
+    id: '/scheduler',
+    path: '/scheduler',
+    getParentRoute: () => AppProjectsProjectSlugRouteRoute,
+  } as any)
 const AppProjectsProjectSlugReplRoute =
   AppProjectsProjectSlugReplRouteImport.update({
     id: '/repl',
@@ -331,6 +338,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/integrations': typeof AppProjectsProjectSlugIntegrationsRoute
   '/projects/$projectSlug/reactivity': typeof AppProjectsProjectSlugReactivityRoute
   '/projects/$projectSlug/repl': typeof AppProjectsProjectSlugReplRoute
+  '/projects/$projectSlug/scheduler': typeof AppProjectsProjectSlugSchedulerRoute
   '/projects/$projectSlug/settings': typeof AppProjectsProjectSlugSettingsRoute
   '/admin/streams/$projectId/$': typeof AdminStreamsProjectIdSplatRoute
   '/docs/streams/processors/$processorSlug': typeof DocsStreamsProcessorsProcessorSlugRouteWithChildren
@@ -371,6 +379,7 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/integrations': typeof AppProjectsProjectSlugIntegrationsRoute
   '/projects/$projectSlug/reactivity': typeof AppProjectsProjectSlugReactivityRoute
   '/projects/$projectSlug/repl': typeof AppProjectsProjectSlugReplRoute
+  '/projects/$projectSlug/scheduler': typeof AppProjectsProjectSlugSchedulerRoute
   '/projects/$projectSlug/settings': typeof AppProjectsProjectSlugSettingsRoute
   '/admin/streams/$projectId/$': typeof AdminStreamsProjectIdSplatRoute
   '/projects/$projectSlug': typeof AppProjectsProjectSlugIndexRoute
@@ -418,6 +427,7 @@ export interface FileRoutesById {
   '/_app/projects/$projectSlug/integrations': typeof AppProjectsProjectSlugIntegrationsRoute
   '/_app/projects/$projectSlug/reactivity': typeof AppProjectsProjectSlugReactivityRoute
   '/_app/projects/$projectSlug/repl': typeof AppProjectsProjectSlugReplRoute
+  '/_app/projects/$projectSlug/scheduler': typeof AppProjectsProjectSlugSchedulerRoute
   '/_app/projects/$projectSlug/settings': typeof AppProjectsProjectSlugSettingsRoute
   '/admin/streams/$projectId/$': typeof AdminStreamsProjectIdSplatRoute
   '/docs/streams/processors/$processorSlug': typeof DocsStreamsProcessorsProcessorSlugRouteWithChildren
@@ -466,6 +476,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/integrations'
     | '/projects/$projectSlug/reactivity'
     | '/projects/$projectSlug/repl'
+    | '/projects/$projectSlug/scheduler'
     | '/projects/$projectSlug/settings'
     | '/admin/streams/$projectId/$'
     | '/docs/streams/processors/$processorSlug'
@@ -506,6 +517,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/integrations'
     | '/projects/$projectSlug/reactivity'
     | '/projects/$projectSlug/repl'
+    | '/projects/$projectSlug/scheduler'
     | '/projects/$projectSlug/settings'
     | '/admin/streams/$projectId/$'
     | '/projects/$projectSlug'
@@ -552,6 +564,7 @@ export interface FileRouteTypes {
     | '/_app/projects/$projectSlug/integrations'
     | '/_app/projects/$projectSlug/reactivity'
     | '/_app/projects/$projectSlug/repl'
+    | '/_app/projects/$projectSlug/scheduler'
     | '/_app/projects/$projectSlug/settings'
     | '/admin/streams/$projectId/$'
     | '/docs/streams/processors/$processorSlug'
@@ -798,6 +811,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppProjectsProjectSlugSettingsRouteImport
       parentRoute: typeof AppProjectsProjectSlugRouteRoute
     }
+    '/_app/projects/$projectSlug/scheduler': {
+      id: '/_app/projects/$projectSlug/scheduler'
+      path: '/scheduler'
+      fullPath: '/projects/$projectSlug/scheduler'
+      preLoaderRoute: typeof AppProjectsProjectSlugSchedulerRouteImport
+      parentRoute: typeof AppProjectsProjectSlugRouteRoute
+    }
     '/_app/projects/$projectSlug/repl': {
       id: '/_app/projects/$projectSlug/repl'
       path: '/repl'
@@ -924,6 +944,7 @@ interface AppProjectsProjectSlugRouteRouteChildren {
   AppProjectsProjectSlugIntegrationsRoute: typeof AppProjectsProjectSlugIntegrationsRoute
   AppProjectsProjectSlugReactivityRoute: typeof AppProjectsProjectSlugReactivityRoute
   AppProjectsProjectSlugReplRoute: typeof AppProjectsProjectSlugReplRoute
+  AppProjectsProjectSlugSchedulerRoute: typeof AppProjectsProjectSlugSchedulerRoute
   AppProjectsProjectSlugSettingsRoute: typeof AppProjectsProjectSlugSettingsRoute
   AppProjectsProjectSlugIndexRoute: typeof AppProjectsProjectSlugIndexRoute
   AppProjectsProjectSlugAgentsNewRoute: typeof AppProjectsProjectSlugAgentsNewRoute
@@ -945,6 +966,7 @@ const AppProjectsProjectSlugRouteRouteChildren: AppProjectsProjectSlugRouteRoute
     AppProjectsProjectSlugReactivityRoute:
       AppProjectsProjectSlugReactivityRoute,
     AppProjectsProjectSlugReplRoute: AppProjectsProjectSlugReplRoute,
+    AppProjectsProjectSlugSchedulerRoute: AppProjectsProjectSlugSchedulerRoute,
     AppProjectsProjectSlugSettingsRoute: AppProjectsProjectSlugSettingsRoute,
     AppProjectsProjectSlugIndexRoute: AppProjectsProjectSlugIndexRoute,
     AppProjectsProjectSlugAgentsNewRoute: AppProjectsProjectSlugAgentsNewRoute,

--- a/apps/os/src/routes/_app/projects/$projectSlug/scheduler.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/scheduler.tsx
@@ -1,0 +1,189 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@iterate-com/ui/components/button";
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@iterate-com/ui/components/empty";
+import { toast } from "@iterate-com/ui/components/sonner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@iterate-com/ui/components/table";
+import { ItxBoundary } from "~/components/itx-boundary.tsx";
+import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
+import { SCHEDULER_PRIMARY_PATH } from "~/domains/scheduler/utils.ts";
+import { formatRelativeTime } from "~/lib/format-relative-time.ts";
+import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
+import { StreamViewSearch } from "~/lib/stream-view-search.ts";
+import { useItx, useItxQuery } from "~/itx/itx-react.tsx";
+import type { ScheduleView, SchedulerRecurrence } from "~/types.ts";
+
+export const Route = createFileRoute("/_app/projects/$projectSlug/scheduler")({
+  validateSearch: StreamViewSearch,
+  ssr: false,
+  loader: ({ context }) =>
+    breadcrumbLoaderData({
+      project: context.project,
+      streamBreadcrumb: streamBreadcrumb(context.project, SCHEDULER_PRIMARY_PATH),
+    }),
+  component: ProjectSchedulerPage,
+});
+
+function ProjectSchedulerPage() {
+  return (
+    <ItxBoundary>
+      <ProjectSchedulerContent />
+    </ItxBoundary>
+  );
+}
+
+function ProjectSchedulerContent() {
+  const { project } = Route.useLoaderData();
+  const itx = useItx();
+  const queryClient = useQueryClient();
+  // The list is the Scheduler's reduced state, read fresh from the Scheduler
+  // DO. Triggers fire server-side without a state push to this page, so
+  // mutations invalidate explicitly and the stream feed alongside shows the
+  // live event flow.
+  const schedules = useItxQuery({
+    key: ["scheduler", project.slug],
+    query: (itx) => itx.scheduler.list(),
+  });
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ["itx", "scheduler", project.slug] });
+
+  const triggerSchedule = useMutation({
+    mutationFn: async (key: string) => await itx.scheduler.trigger(key),
+    onSuccess: async (_result, key) => {
+      await invalidate();
+      toast.success(`Triggered "${key}"`);
+    },
+    onError: (error) => toast.error(`Failed to trigger: ${error.message}`),
+  });
+  const cancelSchedule = useMutation({
+    mutationFn: async (key: string) => await itx.scheduler.cancel(key),
+    onSuccess: async (_result, key) => {
+      await invalidate();
+      toast.success(`Cancelled "${key}"`);
+    },
+    onError: (error) => toast.error(`Failed to cancel: ${error.message}`),
+  });
+  const pendingKey = triggerSchedule.isPending
+    ? triggerSchedule.variables
+    : cancelSchedule.isPending
+      ? cancelSchedule.variables
+      : undefined;
+
+  const panel =
+    schedules.length === 0 ? (
+      <Empty className="rounded-lg border">
+        <EmptyHeader>
+          <EmptyTitle>No Schedules</EmptyTitle>
+          <EmptyDescription>
+            Schedules set via <code>itx.scheduler.set(...)</code> appear here — try the scheduler
+            examples in the REPL.
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    ) : (
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Key</TableHead>
+              <TableHead>Recurrence</TableHead>
+              <TableHead>Next trigger</TableHead>
+              <TableHead>Runs</TableHead>
+              <TableHead>Set</TableHead>
+              <TableHead />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {schedules
+              .toSorted((left, right) => compareByNextTrigger(left, right))
+              .map((schedule) => (
+                <TableRow key={schedule.key}>
+                  <TableCell className="min-w-[12rem] py-3 text-sm font-medium">
+                    <span className="block min-w-0 truncate" title={schedule.key}>
+                      {schedule.key}
+                    </span>
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap text-muted-foreground">
+                    {recurrenceLabel(schedule.recurrence)}
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap text-muted-foreground">
+                    {schedule.nextTriggerAt === null
+                      ? "—"
+                      : formatRelativeTime(schedule.nextTriggerAt)}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{schedule.runCount}</TableCell>
+                  <TableCell className="whitespace-nowrap text-muted-foreground">
+                    {formatRelativeTime(schedule.setAt)}
+                  </TableCell>
+                  <TableCell className="w-0">
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        disabled={pendingKey !== undefined}
+                        onClick={() => triggerSchedule.mutate(schedule.key)}
+                      >
+                        {pendingKey === schedule.key && triggerSchedule.isPending
+                          ? "Triggering..."
+                          : "Run now"}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        disabled={pendingKey !== undefined}
+                        onClick={() => cancelSchedule.mutate(schedule.key)}
+                      >
+                        {pendingKey === schedule.key && cancelSchedule.isPending
+                          ? "Cancelling..."
+                          : "Cancel"}
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+          </TableBody>
+        </Table>
+      </div>
+    );
+
+  return (
+    <ProjectStreamView
+      panel={panel}
+      projectId={project.id}
+      streamPath={SCHEDULER_PRIMARY_PATH}
+      emptyLabel="No events on the scheduler stream yet."
+    />
+  );
+}
+
+function recurrenceLabel(recurrence: SchedulerRecurrence) {
+  if ("at" in recurrence) return "once";
+  if ("every" in recurrence) return `every ${formatSeconds(recurrence.every)}`;
+  return recurrence.timezone ? `${recurrence.cron} (${recurrence.timezone})` : recurrence.cron;
+}
+
+function formatSeconds(seconds: number) {
+  if (seconds % 86_400 === 0 && seconds >= 86_400) return `${seconds / 86_400}d`;
+  if (seconds % 3_600 === 0 && seconds >= 3_600) return `${seconds / 3_600}h`;
+  if (seconds % 60 === 0 && seconds >= 60) return `${seconds / 60}m`;
+  return `${seconds}s`;
+}
+
+// Soonest next trigger first; exhausted (null) schedules sink to the bottom.
+function compareByNextTrigger(left: ScheduleView, right: ScheduleView) {
+  if (left.nextTriggerAt === null && right.nextTriggerAt === null)
+    return left.key.localeCompare(right.key);
+  if (left.nextTriggerAt === null) return 1;
+  if (right.nextTriggerAt === null) return -1;
+  const byTime = Date.parse(left.nextTriggerAt) - Date.parse(right.nextTriggerAt);
+  return byTime !== 0 ? byTime : left.key.localeCompare(right.key);
+}


### PR DESCRIPTION
Two follow-ups from the scheduler (#1698).

## 1. `/scheduler` dashboard page

The grill session's design endpoint: the UI list is just the Scheduler's reduced state. New project-scoped page at `/projects/:slug/scheduler`:

- Left: the `/scheduler/primary` stream view — the complete audit log (schedule-set, trigger-requested, trigger-completed…).
- Right panel: every Schedule from `itx.scheduler.list()` — key, recurrence (`once` / `every 1h` / cron + timezone), next trigger (relative), run count, set time — sorted soonest-first, with **Run now** (`scheduler.trigger`) and **Cancel** (`scheduler.cancel`) actions.
- Sidebar nav item (`/scheduler`, CalendarClock) and `linkOptionsForStreamPath` cases so ⌘K / breadcrumb navigation for `/scheduler` and `/scheduler/primary` land on the page; other `/scheduler/**` streams fall through to the generic stream page.

## 2. StreamProcessor: skip-and-record instead of parse-poison

Streams accept raw appends by design, so a committed event can carry a consumed TYPE with a shape the contract rejects. Previously `#reduceRawEvent` called `.parse()`: the batch threw, the host retried 3×, appended `stream/error-occurred`, and **disconnected the subscription — wedging the fold on that event forever** (re-handshakes replay the same event and re-fail; the platform-wide latent bug noted in the #1698 self-review).

Now:

- `safeParse`; a failing consumed-type event is **skipped** — the checkpoint advances past it, the rest of the batch folds normally. (Unknown types were already skipped; this makes malformed known types behave the same, plus a record.)
- The skip is **recorded** on the stream as `stream/error-occurred` with idempotency key `processor-event-parse-failed:<slug>:<offset>`, appended in the background *after* the checkpoint commits — a failing record append can never re-poison the batch it just rescued, and redelivery dedupes.
- The raw event remains in the log as the authoritative record, inspectable in the stream view.

The host's 3-retries-then-disconnect poison path is unchanged — it still guards genuine side-effect failures in `processEvent`/`processEventBatch`, which are transient-retryable in a way malformed data never is.

### Tests

5 new plain-node unit tests in `stream-processor.test.ts`: mid-batch skip folds the rest, only-poison batch still advances the checkpoint, offset-scoped idempotent record append, redelivery neither re-reduces nor re-records, failing record append is logged not rethrown. Full suite: 421 tests green.

## LOC

| Change | Lines |
| --- | --- |
| stream-processor.ts (skip-and-record) | +44 −11 |
| stream-processor.test.ts | +122 |
| scheduler.tsx (new page) | +196 |
| app-sidebar.tsx + stream-routes.ts + routeTree.gen.ts | +29 |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> StreamProcessor ingest/checkpoint behavior changed for all processors (malformed events are skipped rather than failing the batch); scheduler UI and mutations are isolated but touch operational scheduling controls.
> 
> **Overview**
> Adds a **project scheduler dashboard** at `/projects/:slug/scheduler`: sidebar `/scheduler` nav, stream-path routing for `/scheduler` and `/scheduler/primary`, and a page that pairs the primary scheduler stream with a table of `itx.scheduler.list()` (recurrence, next run, run count) plus **Run now** / **Cancel** via `trigger` / `cancel`.
> 
> Fixes **stream processor wedging** when a consumed event type has an invalid payload: `#reduceRawEvent` uses `safeParse`, **skips** bad events while still advancing the checkpoint, then **records** `stream/error-occurred` in the background with an offset-scoped idempotency key after the checkpoint commits. New unit tests cover batch folding, checkpoint advance, idempotent recording, redelivery, and failed record appends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17373222fc7867ca6ef6ec23edc7e0c6836abd02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-07T18:40:37.040Z",
      "headSha": "17373222fc7867ca6ef6ec23edc7e0c6836abd02",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/127243369109640",
      "shortSha": "1737322",
      "cleanupDurationMs": 4285,
      "deployDurationMs": 182597,
      "testDurationMs": 135098,
      "testRetries": "6 retried: itx > Trusted internal root can access global streams and repos (vitest x1) · itx > MCP built-in connects directly and mounts as a described capability (vitest x1) · itx > ITX expression capabilities resolve aliases against the current ITX host path (vitest x1) · configured durable object subscribers must target the stream project (vitest x1) · stream rules do not recursively cross-post events that are already cross-posted (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1)"
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-07T18:40:35.574Z",
      "headSha": "17373222fc7867ca6ef6ec23edc7e0c6836abd02",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/127243369109640",
      "shortSha": "1737322",
      "cleanupDurationMs": 2815,
      "deployDurationMs": 17518,
      "testDurationMs": 689,
      "testRetries": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-07T18:40:33.469Z",
      "headSha": "17373222fc7867ca6ef6ec23edc7e0c6836abd02",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/127243369109640",
      "shortSha": "1737322",
      "cleanupDurationMs": 708,
      "deployDurationMs": 19833,
      "testDurationMs": 18482,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `1737322` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 17.5s | 689ms |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/127243369109640) | 2026-07-07T18:40:35.574Z | Preview app released. |
| OS | released | `1737322` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 182.6s | 135.1s | 6 retried: itx > Trusted internal root can access global streams and repos (vitest x1) · itx > MCP built-in connects directly and mounts as a described capability (vitest x1) · itx > ITX expression capabilities resolve aliases against the current ITX host path (vitest x1) · configured durable object subscribers must target the stream project (vitest x1) · stream rules do not recursively cross-post events that are already cross-posted (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1) | 4.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/127243369109640) | 2026-07-07T18:40:37.040Z | Preview app released. |
| Streams Example App | released | `1737322` | [https://streams.iterate-preview-5.com](https://streams.iterate-preview-5.com) | 19.8s | 18.5s |  | 708ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/127243369109640) | 2026-07-07T18:40:33.469Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->