### PR TITLE
CI: per-group LOC report on PRs

### DIFF
--- a/.depot/workflows/loc-report.yml
+++ b/.depot/workflows/loc-report.yml
@@ -1,0 +1,25 @@
+name: LOC report
+on:
+  pull_request: {}
+  workflow_dispatch: {}
+concurrency:
+  group: loc-report-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  loc-report:
+    runs-on:
+      size: 8x32
+      image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    env:
+      ITERATE_BOT_GITHUB_TOKEN: ${{ secrets.ITERATE_BOT_GITHUB_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          clean: false
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Reconcile dependencies (baked)
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Post LOC report
+        run: pnpm tsx scripts/ci/loc-report.ts

--- a/scripts/ci/github.ts
+++ b/scripts/ci/github.ts
@@ -35,7 +35,13 @@ export function getEventName() {
 /** The subset of GitHub webhook event payload fields our CI scripts read. */
 export type GithubEventPayload = {
   action?: string;
-  pull_request?: { number: number; body?: string | null; merged?: boolean };
+  pull_request?: {
+    number: number;
+    body?: string | null;
+    merged?: boolean;
+    base?: { ref: string; sha: string };
+    head?: { sha: string };
+  };
 };
 
 export function readEventPayload() {

--- a/scripts/ci/loc-report.ts
+++ b/scripts/ci/loc-report.ts
@@ -1,0 +1,186 @@
+import { execFileSync } from "node:child_process";
+import { matchesGlob } from "node:path";
+
+import { isMainModule } from "../../packages/shared/src/dev/is-main-module.ts";
+import { getOctokit, getRepo, readEventPayload } from "./github.ts";
+
+/**
+ * Ordered, first-match-wins. Every changed file lands in the first group whose
+ * glob matches it, so the rows partition the diff exactly and Total is honest.
+ */
+export const groups: Array<{ name: string; glob: string }> = [
+  { name: "Generated", glob: "{pnpm-lock.yaml,**/.generated/**,**/generated/**,**/*.generated.*}" },
+  { name: "Tests", glob: "{**/*.{test,spec}.*,**/{e2e,tests,__tests__,test-helpers}/**}" },
+  { name: "UI components", glob: "{packages/ui/**,**/components/**}" },
+  { name: "Docs", glob: "{docs/**,**/*.md}" },
+  { name: "CI & scripts", glob: "{.depot/**,.github/**,scripts/**,**/scripts/**}" },
+  { name: "Config", glob: "**/*.{json,jsonc,json5,yml,yaml,toml}" },
+  { name: "Product", glob: "{apps,packages}/**" },
+  // "Other" is the code-level fallback for anything unmatched (globs skip dotfiles, so a
+  // literal `**` catch-all wouldn't actually catch everything).
+  { name: "Other", glob: "" },
+];
+
+const commentMarker = "<!-- iterate-loc-report -->";
+
+export type ChangedFile = {
+  path: string;
+  previousPath: string;
+  added: number;
+  removed: number;
+  binary: boolean;
+};
+
+/** Parses `git diff --numstat -z -M` output (NUL-separated, rename-aware). */
+export function parseNumstat(raw: string): ChangedFile[] {
+  const tokens = raw.split("\0");
+  const files: ChangedFile[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    if (!tokens[i]) continue;
+    const [added, removed, ...pathParts] = tokens[i].split("\t");
+    const inlinePath = pathParts.join("\t");
+    // Renamed entries have an empty inline path followed by two NUL-terminated paths.
+    const previousPath = inlinePath || tokens[++i];
+    const path = inlinePath || tokens[++i];
+    const binary = added === "-";
+    files.push({
+      path,
+      previousPath,
+      added: binary ? 0 : Number(added),
+      removed: binary ? 0 : Number(removed),
+      binary,
+    });
+  }
+  return files;
+}
+
+export function getChangedFiles(baseRef: string, headRef: string): ChangedFile[] {
+  const raw = execFileSync("git", ["diff", "--numstat", "-z", "-M", `${baseRef}...${headRef}`], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return parseNumstat(raw);
+}
+
+export type GroupRow = { name: string; files: number; added: number; removed: number };
+
+export function computeReport(files: ChangedFile[]) {
+  const rows: GroupRow[] = groups.map((group) => ({
+    name: group.name,
+    files: 0,
+    added: 0,
+    removed: 0,
+  }));
+  for (const file of files) {
+    const index = groups.findIndex((group) => group.glob && matchesGlob(file.path, group.glob));
+    const row = rows[index === -1 ? rows.length - 1 : index];
+    row.files += 1;
+    row.added += file.added;
+    row.removed += file.removed;
+  }
+  const total: GroupRow = {
+    name: "Total",
+    files: files.length,
+    added: rows.reduce((sum, row) => sum + row.added, 0),
+    removed: rows.reduce((sum, row) => sum + row.removed, 0),
+  };
+  return { rows: rows.filter((row) => row.files > 0), total };
+}
+
+/**
+ * Renders the report as a ```diff code block - the only way GitHub markdown
+ * gives us colors. Rows are prefixed +/- by net sign so they render green/red.
+ */
+export function renderTable(report: ReturnType<typeof computeReport>) {
+  const cells = [
+    ["Group", "Files", "Added", "Removed", "Net"],
+    ...[...report.rows, report.total].map((row) => {
+      const net = row.added - row.removed;
+      return [
+        row.name,
+        String(row.files),
+        `+${row.added}`,
+        `-${row.removed}`,
+        net > 0 ? `+${net}` : String(net),
+      ];
+    }),
+  ];
+  const widths = cells[0].map((_, column) => Math.max(...cells.map((row) => row[column].length)));
+  const lines = cells.map((row, rowIndex) => {
+    const body = row
+      .map((cell, column) =>
+        column === 0 ? cell.padEnd(widths[column]) : cell.padStart(widths[column] + 2),
+      )
+      .join("");
+    if (rowIndex === 0) return `  ${body}`;
+    const net = Number(row[4]);
+    const prefix = net > 0 ? "+" : net < 0 ? "-" : " ";
+    return `${prefix} ${body}`;
+  });
+  return ["```diff", ...lines, "```"].join("\n");
+}
+
+function renderComment(report: ReturnType<typeof computeReport>, baseSha: string, headSha: string) {
+  return [
+    "### LOC report",
+    commentMarker,
+    "",
+    renderTable(report),
+    "",
+    `<sub>Lines changed between ${baseSha.slice(0, 7)} and ${headSha.slice(0, 7)}, bucketed first-match-wins into the groups defined in \`scripts/ci/loc-report.ts\`.</sub>`,
+  ].join("\n");
+}
+
+function ensureCommitAvailable(sha: string) {
+  try {
+    execFileSync("git", ["cat-file", "-e", `${sha}^{commit}`], { stdio: "ignore" });
+  } catch {
+    execFileSync("git", ["fetch", "--no-tags", "origin", sha], { stdio: "inherit" });
+  }
+}
+
+export async function postLocReport() {
+  const payload = process.env.GITHUB_EVENT_PATH ? readEventPayload() : undefined;
+  const pullRequest = payload?.pull_request;
+
+  if (!pullRequest?.base?.sha || !pullRequest.head?.sha) {
+    const baseRef = process.argv[2] || "origin/main";
+    const headRef = process.argv[3] || "HEAD";
+    console.log(`No pull request context - printing report for ${baseRef}...${headRef}\n`);
+    const report = computeReport(getChangedFiles(baseRef, headRef));
+    console.log(renderTable(report));
+    return;
+  }
+
+  const baseSha = pullRequest.base.sha;
+  const headSha = pullRequest.head.sha;
+  ensureCommitAvailable(baseSha);
+  ensureCommitAvailable(headSha);
+  const report = computeReport(getChangedFiles(baseSha, headSha));
+  const body = renderComment(report, baseSha, headSha);
+  console.log(body);
+
+  const github = getOctokit();
+  const repo = getRepo();
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    ...repo,
+    issue_number: pullRequest.number,
+    per_page: 100,
+  });
+  const existing = comments.find((comment) => comment.body?.includes(commentMarker));
+  if (existing) {
+    await github.rest.issues.updateComment({ ...repo, comment_id: existing.id, body });
+    console.log(`Updated existing LOC report comment ${existing.id}`);
+  } else {
+    const { data: created } = await github.rest.issues.createComment({
+      ...repo,
+      issue_number: pullRequest.number,
+      body,
+    });
+    console.log(`Created LOC report comment ${created.id}`);
+  }
+}
+
+if (isMainModule(import.meta.url)) {
+  await postLocReport();
+}

--- a/scripts/ci/loc-report.ts
+++ b/scripts/ci/loc-report.ts
@@ -248,7 +248,9 @@ export function renderTable(report: ReturnType<typeof computeReport>) {
   };
   return [
     "| Group | Changes |",
-    "| --- | --- |",
+    // Right-align: bars are a constant five squares, so they stack flush right
+    // and the numbers right-justify against them instead of leaving them ragged.
+    "| --- | ---: |",
     ...report.rows.map((row) => line(row, (text) => text)),
     line(report.total, (text) => `**${text}**`),
   ].join("\n");

--- a/scripts/ci/loc-report.ts
+++ b/scripts/ci/loc-report.ts
@@ -3,27 +3,40 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { extname, join, matchesGlob } from "node:path";
 
+import { markdownAnnotator } from "../../packages/shared/src/dev/markdown-annotator.ts";
 import { isMainModule } from "../../packages/shared/src/dev/is-main-module.ts";
 import { getOctokit, getRepo, readEventPayload } from "./github.ts";
 
 /**
- * Ordered, first-match-wins. Every changed file lands in the first group whose
- * glob matches it, so the rows partition the diff exactly and Total is honest.
+ * Array order is match order: first-match-wins, most-specific globs first, so
+ * every changed file lands in exactly one group and Total is honest.
+ * `priority` is display order (lower = higher in the table): what a reviewer
+ * cares about most goes first - product code, then UI, then tests; supporting
+ * churn (CI, config, docs) after; generated noise last.
  */
-export const groups: Array<{ name: string; glob: string }> = [
-  { name: "Generated", glob: "{pnpm-lock.yaml,**/.generated/**,**/generated/**,**/*.generated.*}" },
-  { name: "Tests", glob: "{**/*.{test,spec}.*,**/{e2e,tests,__tests__,test-helpers}/**}" },
-  { name: "UI components", glob: "{packages/ui/**,**/components/**}" },
-  { name: "Docs", glob: "{docs/**,**/*.md}" },
-  { name: "CI & scripts", glob: "{.depot/**,.github/**,scripts/**,**/scripts/**}" },
-  { name: "Config", glob: "**/*.{json,jsonc,json5,yml,yaml,toml}" },
-  { name: "Product", glob: "{apps,packages}/**" },
+export const groups: Array<{ name: string; glob: string; priority: number }> = [
+  {
+    name: "Generated",
+    glob: "{pnpm-lock.yaml,**/.generated/**,**/generated/**,**/*.generated.*}",
+    priority: 8,
+  },
+  {
+    name: "Tests",
+    glob: "{**/*.{test,spec}.*,**/{e2e,tests,__tests__,test-helpers}/**}",
+    priority: 3,
+  },
+  { name: "UI components", glob: "{packages/ui/**,**/components/**}", priority: 2 },
+  { name: "Docs", glob: "{docs/**,**/*.md}", priority: 6 },
+  { name: "CI & scripts", glob: "{.depot/**,.github/**,scripts/**,**/scripts/**}", priority: 4 },
+  { name: "Config", glob: "**/*.{json,jsonc,json5,yml,yaml,toml}", priority: 5 },
+  { name: "Product", glob: "{apps,packages}/**", priority: 1 },
   // "Other" is the code-level fallback for anything unmatched (globs skip dotfiles, so a
   // literal `**` catch-all wouldn't actually catch everything).
-  { name: "Other", glob: "" },
+  { name: "Other", glob: "", priority: 7 },
 ];
 
-const commentMarker = "<!-- iterate-loc-report -->";
+/** markdownAnnotator label for the managed PR-body section. */
+const bodySectionLabel = "loc-report";
 
 export type ChangedFile = {
   path: string;
@@ -178,11 +191,18 @@ export function stripJsComments(source: string): string {
   return result;
 }
 
-export type GroupRow = { name: string; files: number; added: number; removed: number };
+export type GroupRow = {
+  name: string;
+  priority: number;
+  files: number;
+  added: number;
+  removed: number;
+};
 
 export function computeReport(files: ChangedFile[]) {
   const rows: GroupRow[] = groups.map((group) => ({
     name: group.name,
+    priority: group.priority,
     files: 0,
     added: 0,
     removed: 0,
@@ -196,50 +216,58 @@ export function computeReport(files: ChangedFile[]) {
   }
   const total: GroupRow = {
     name: "Total",
+    priority: Infinity,
     files: files.length,
     added: rows.reduce((sum, row) => sum + row.added, 0),
     removed: rows.reduce((sum, row) => sum + row.removed, 0),
   };
-  return { rows: rows.filter((row) => row.files > 0), total };
+  const populated = rows.filter((row) => row.files > 0);
+  populated.sort((a, b) => a.priority - b.priority);
+  return { rows: populated, total };
 }
 
 /**
- * Renders the report as a ```diff code block - the only way GitHub markdown
- * gives us colors. Rows are prefixed +/- by net sign so they render green/red.
+ * Renders the report as a markdown table mimicking GitHub's own diffstat: +added,
+ * -removed, and a five-square bar. Squares fill proportionally to the group's
+ * share of the largest group's churn, split green/red by its add/remove ratio.
  */
 export function renderTable(report: ReturnType<typeof computeReport>) {
-  const cells = [
-    ["Group", "Files", "Added", "Removed", "Net"],
-    ...[...report.rows, report.total].map((row) => {
-      const net = row.added - row.removed;
-      return [
-        row.name,
-        String(row.files),
-        `+${row.added}`,
-        `-${row.removed}`,
-        net > 0 ? `+${net}` : String(net),
-      ];
-    }),
-  ];
-  const widths = cells[0].map((_, column) => Math.max(...cells.map((row) => row[column].length)));
-  const lines = cells.map((row, rowIndex) => {
-    const body = row
-      .map((cell, column) =>
-        column === 0 ? cell.padEnd(widths[column]) : cell.padStart(widths[column] + 2),
-      )
-      .join("");
-    if (rowIndex === 0) return `  ${body}`;
-    const net = Number(row[4]);
-    const prefix = net > 0 ? "+" : net < 0 ? "-" : " ";
-    return `${prefix} ${body}`;
-  });
-  return ["```diff", ...lines, "```"].join("\n");
+  const count = (n: number, sign: "+" | "-" | "") =>
+    n === 0 ? "0" : `${sign}${Math.abs(n).toLocaleString("en-US")}`;
+  const maxChurn = Math.max(...report.rows.map((row) => row.added + row.removed), 1);
+  const bar = (row: GroupRow) => {
+    const churn = row.added + row.removed;
+    if (churn === 0) return "⬜⬜⬜⬜⬜";
+    const filled = row.name === "Total" ? 5 : Math.max(1, Math.round((5 * churn) / maxChurn));
+    const green = Math.round((filled * row.added) / churn);
+    return "🟩".repeat(green) + "🟥".repeat(filled - green) + "⬜".repeat(5 - filled);
+  };
+  const line = (row: GroupRow, wrap: (text: string) => string) => {
+    const net = row.added - row.removed;
+    const cells = [
+      wrap(row.name),
+      wrap(String(row.files)),
+      wrap(count(row.added, "+")),
+      wrap(count(row.removed, "-")),
+      wrap(count(net, net > 0 ? "+" : "-")),
+    ];
+    return `| ${cells.join(" | ")} | ${bar(row)} |`;
+  };
+  return [
+    "| Group | Files | Added | Removed | Net | |",
+    "| --- | ---: | ---: | ---: | ---: | --- |",
+    ...report.rows.map((row) => line(row, (text) => text)),
+    line(report.total, (text) => `**${text}**`),
+  ].join("\n");
 }
 
-function renderComment(report: ReturnType<typeof computeReport>, baseSha: string, headSha: string) {
+export function renderBodySection(
+  report: ReturnType<typeof computeReport>,
+  baseSha: string,
+  headSha: string,
+) {
   return [
     "### LOC report",
-    commentMarker,
     "",
     renderTable(report),
     "",
@@ -273,28 +301,17 @@ export async function postLocReport() {
   ensureCommitAvailable(baseSha);
   ensureCommitAvailable(headSha);
   const report = computeReport(getChangedFiles(baseSha, headSha));
-  const body = renderComment(report, baseSha, headSha);
-  console.log(body);
+  const section = renderBodySection(report, baseSha, headSha);
+  console.log(section);
 
   const github = getOctokit();
   const repo = getRepo();
-  const comments = await github.paginate(github.rest.issues.listComments, {
-    ...repo,
-    issue_number: pullRequest.number,
-    per_page: 100,
-  });
-  const existing = comments.find((comment) => comment.body?.includes(commentMarker));
-  if (existing) {
-    await github.rest.issues.updateComment({ ...repo, comment_id: existing.id, body });
-    console.log(`Updated existing LOC report comment ${existing.id}`);
-  } else {
-    const { data: created } = await github.rest.issues.createComment({
-      ...repo,
-      issue_number: pullRequest.number,
-      body,
-    });
-    console.log(`Created LOC report comment ${created.id}`);
-  }
+  // Fetch the body fresh rather than trusting the event payload - the PR
+  // description may have been edited since the event fired.
+  const { data: pr } = await github.rest.pulls.get({ ...repo, pull_number: pullRequest.number });
+  const body = markdownAnnotator(pr.body || "", bodySectionLabel).update(section);
+  await github.rest.pulls.update({ ...repo, pull_number: pullRequest.number, body });
+  console.log(`Updated LOC report section in PR #${pullRequest.number} body`);
 }
 
 if (isMainModule(import.meta.url)) {

--- a/scripts/ci/loc-report.ts
+++ b/scripts/ci/loc-report.ts
@@ -232,8 +232,8 @@ export function computeReport(files: ChangedFile[]) {
  * share of the largest group's churn, split green/red by its add/remove ratio.
  */
 export function renderTable(report: ReturnType<typeof computeReport>) {
-  const count = (n: number, sign: "+" | "-" | "") =>
-    n === 0 ? "0" : `${sign}${Math.abs(n).toLocaleString("en-US")}`;
+  // Always signed, even +0/-0, matching GitHub's own diffstat.
+  const count = (n: number, sign: "+" | "-") => `${sign}${Math.abs(n).toLocaleString("en-US")}`;
   const maxChurn = Math.max(...report.rows.map((row) => row.added + row.removed), 1);
   const bar = (row: GroupRow) => {
     const churn = row.added + row.removed;

--- a/scripts/ci/loc-report.ts
+++ b/scripts/ci/loc-report.ts
@@ -243,19 +243,12 @@ export function renderTable(report: ReturnType<typeof computeReport>) {
     return "🟩".repeat(green) + "🟥".repeat(filled - green) + "⬜".repeat(5 - filled);
   };
   const line = (row: GroupRow, wrap: (text: string) => string) => {
-    const net = row.added - row.removed;
-    const cells = [
-      wrap(row.name),
-      wrap(String(row.files)),
-      wrap(count(row.added, "+")),
-      wrap(count(row.removed, "-")),
-      wrap(count(net, net > 0 ? "+" : "-")),
-    ];
-    return `| ${cells.join(" | ")} | ${bar(row)} |`;
+    const changes = `${count(row.added, "+")} ${count(row.removed, "-")}`;
+    return `| ${wrap(row.name)} | ${wrap(changes)} ${bar(row)} |`;
   };
   return [
-    "| Group | Files | Added | Removed | Net | |",
-    "| --- | ---: | ---: | ---: | ---: | --- |",
+    "| Group | Changes |",
+    "| --- | --- |",
     ...report.rows.map((row) => line(row, (text) => text)),
     line(report.total, (text) => `**${text}**`),
   ].join("\n");
@@ -267,8 +260,6 @@ export function renderBodySection(
   headSha: string,
 ) {
   return [
-    "### LOC report",
-    "",
     renderTable(report),
     "",
     `<sub>Source lines changed (blank lines and JS comments ignored) between ${baseSha.slice(0, 7)} and ${headSha.slice(0, 7)}, bucketed first-match-wins into the groups defined in \`scripts/ci/loc-report.ts\`.</sub>`,

--- a/scripts/ci/loc-report.ts
+++ b/scripts/ci/loc-report.ts
@@ -1,5 +1,7 @@
 import { execFileSync } from "node:child_process";
-import { matchesGlob } from "node:path";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { extname, join, matchesGlob } from "node:path";
 
 import { isMainModule } from "../../packages/shared/src/dev/is-main-module.ts";
 import { getOctokit, getRepo, readEventPayload } from "./github.ts";
@@ -54,12 +56,126 @@ export function parseNumstat(raw: string): ChangedFile[] {
   return files;
 }
 
+const gitMaxBuffer = 64 * 1024 * 1024;
+
+/**
+ * Changed files between merge-base(base, head) and head, with added/removed
+ * counted as SLOC: blank lines never count, and for JS-ish files line and
+ * block comments are stripped first. Counts come from diffing the
+ * stripped before/after contents, so multiline comment blocks and
+ * comment-only changes fall out naturally.
+ */
 export function getChangedFiles(baseRef: string, headRef: string): ChangedFile[] {
   const raw = execFileSync("git", ["diff", "--numstat", "-z", "-M", `${baseRef}...${headRef}`], {
     encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
+    maxBuffer: gitMaxBuffer,
   });
-  return parseNumstat(raw);
+  const mergeBase = execFileSync("git", ["merge-base", baseRef, headRef], {
+    encoding: "utf8",
+  }).trim();
+  return parseNumstat(raw).map((file) => {
+    if (file.binary) return file;
+    const before = significantLines(gitShow(mergeBase, file.previousPath), file.previousPath);
+    const after = significantLines(gitShow(headRef, file.path), file.path);
+    return { ...file, ...slocDiffCounts(before, after) };
+  });
+}
+
+const jsExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"]);
+
+function significantLines(content: string, path: string) {
+  const stripped = jsExtensions.has(extname(path)) ? stripJsComments(content) : content;
+  return stripped
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .join("\n");
+}
+
+/** Contents of `path` at `ref`, or "" when it doesn't exist there (added/deleted files). */
+function gitShow(ref: string, path: string) {
+  try {
+    return execFileSync("git", ["show", `${ref}:${path}`], {
+      encoding: "utf8",
+      maxBuffer: gitMaxBuffer,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return "";
+  }
+}
+
+function slocDiffCounts(before: string, after: string) {
+  if (before === after) return { added: 0, removed: 0 };
+  const dir = mkdtempSync(join(tmpdir(), "loc-report-"));
+  try {
+    writeFileSync(join(dir, "before"), before && `${before}\n`);
+    writeFileSync(join(dir, "after"), after && `${after}\n`);
+    let out = "";
+    try {
+      out = execFileSync(
+        "git",
+        ["diff", "--no-index", "--numstat", "--", join(dir, "before"), join(dir, "after")],
+        { encoding: "utf8", maxBuffer: gitMaxBuffer },
+      );
+    } catch (error) {
+      // git diff --no-index exits 1 when the files differ; the numstat is still on stdout
+      out = (error as { stdout?: string }).stdout || "";
+    }
+    const [added, removed] = out.split("\t");
+    return { added: Number(added) || 0, removed: Number(removed) || 0 };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Removes line (`//`) and block comments, tracking string/template-literal
+ * state so things like "http://..." survive. Known limitation: regex
+ * literals aren't tracked, so a regex containing `//` or `/*` will eat the
+ * rest of its line (or until a block-comment closer) - rare enough to ignore for now.
+ * Newlines inside block comments are preserved so line structure survives.
+ */
+export function stripJsComments(source: string): string {
+  let result = "";
+  let state: "code" | "single" | "double" | "template" = "code";
+  for (let i = 0; i < source.length; i++) {
+    const char = source[i];
+    const next = source[i + 1];
+    if (state === "code") {
+      if (char === "/" && next === "/") {
+        while (i < source.length && source[i] !== "\n") i++;
+        i--;
+        continue;
+      }
+      if (char === "/" && next === "*") {
+        i += 2;
+        while (i < source.length && !(source[i] === "*" && source[i + 1] === "/")) {
+          if (source[i] === "\n") result += "\n";
+          i++;
+        }
+        i++;
+        continue;
+      }
+      if (char === "'") state = "single";
+      else if (char === '"') state = "double";
+      else if (char === "`") state = "template";
+      result += char;
+      continue;
+    }
+    // inside a string/template literal
+    if (char === "\\") {
+      result += char + (next || "");
+      i++;
+      continue;
+    }
+    const closed =
+      (state === "single" && (char === "'" || char === "\n")) ||
+      (state === "double" && (char === '"' || char === "\n")) ||
+      (state === "template" && char === "`");
+    if (closed) state = "code";
+    result += char;
+  }
+  return result;
 }
 
 export type GroupRow = { name: string; files: number; added: number; removed: number };
@@ -127,7 +243,7 @@ function renderComment(report: ReturnType<typeof computeReport>, baseSha: string
     "",
     renderTable(report),
     "",
-    `<sub>Lines changed between ${baseSha.slice(0, 7)} and ${headSha.slice(0, 7)}, bucketed first-match-wins into the groups defined in \`scripts/ci/loc-report.ts\`.</sub>`,
+    `<sub>Source lines changed (blank lines and JS comments ignored) between ${baseSha.slice(0, 7)} and ${headSha.slice(0, 7)}, bucketed first-match-wins into the groups defined in \`scripts/ci/loc-report.ts\`.</sub>`,
   ].join("\n");
 }
 

--- a/tasks/ci-loc-report.md
+++ b/tasks/ci-loc-report.md
@@ -1,15 +1,16 @@
 ---
-status: in-progress
+status: in-review
 size: small
+pr: https://github.com/iterate/iterate/pull/1715
 ---
 
 # CI workflow: LOC-changed report on PRs, by group
 
 ## Status summary
 
-Spec fleshed out, implementation not started. Plan: a Depot workflow + `scripts/ci/loc-report.ts`
-that posts a sticky PR comment with a per-group net-LOC table. Second commit switches counting to
-SLOC (ignoring JS comments).
+Implemented, PR open (#1715). Workflow + script + SLOC follow-up all pushed; validated locally
+against real merged-PR diffs and via `depot ci run`. Remaining: automatic `pull_request` runs
+only start once this lands on main (Depot registers triggers from the default branch).
 
 ## Motivation
 
@@ -19,41 +20,65 @@ lockfile churn". PRs should show a small table of net LOC change broken down by 
 
 ## Spec
 
-- [ ] New Depot workflow `.depot/workflows/loc-report.yml` triggered on `pull_request`, calling a
-      script per repo convention (thin YAML, logic in `scripts/ci`).
-- [ ] `scripts/ci/loc-report.ts` computes the diff between the PR base and head (merge-base
+- [x] New Depot workflow `.depot/workflows/loc-report.yml` triggered on `pull_request`, calling a
+      script per repo convention (thin YAML, logic in `scripts/ci`). _Thin wrapper around
+      `pnpm tsx scripts/ci/loc-report.ts`; `fetch-depth: 0` so the merge-base is available._
+- [x] `scripts/ci/loc-report.ts` computes the diff between the PR base and head (merge-base
       three-dot diff, like GitHub's Files Changed tab) and buckets changed files into hardcoded
-      groups: `Array<{ name: string; glob: string }>`.
-- [ ] Posts a **sticky comment** on the PR (marker comment, update-in-place on synchronize) with a
-      table: group | files | added | removed | net.
-- [ ] Colors: GitHub markdown has no real color support in tables, so render the table inside a
-      ```diff code block — each group's row is prefixed `+`/`-`/` ` by net sign, which GitHub
-      renders green/red. (Assumption delineated below.)
-- [ ] Script is runnable locally with no PR context (prints the table instead of commenting), so
-      it can be tested against any base/head pair.
-- [ ] Follow-up commit (same PR, pushed separately): count **SLOC** instead of raw lines — strip
-      JS `//` and `/* ... */` comments before counting, for JS-ish files
-      (`.ts/.tsx/.js/.jsx/.mjs/.cjs/.mts/.cts`).
+      groups: `Array<{ name: string; glob: string }>`. _`git diff --numstat -z -M` parsed
+      rename-aware; groups matched with `node:path` `matchesGlob`._
+- [x] Posts a **sticky comment** on the PR (marker comment, update-in-place on synchronize) with a
+      table: group | files | added | removed | net. _Marker `<!-- iterate-loc-report -->`, upsert
+      via Octokit issues API using `ITERATE_BOT_GITHUB_TOKEN`._
+- [x] Colors: render the table inside a ```diff code block — each group's row is prefixed
+    `+`/`-`/` ` by net sign, which GitHub renders green/red. _`renderTable` computes column
+      widths and prefixes rows by net sign.\_
+- [x] Script is runnable locally with no PR context (prints the table instead of commenting).
+      _`pnpm tsx scripts/ci/loc-report.ts [base] [head]`, defaults `origin/main HEAD`._
+- [x] Follow-up commit: count **SLOC** — strip JS `//` and `/* ... */` comments before counting.
+      _`stripJsComments` is a small string/template-literal-aware state machine; per-file counts
+      come from `git diff --no-index --numstat` over the stripped before/after contents._
 
 ## Decisions / assumptions (made while AFK)
 
 - **First-match-wins grouping.** The user said overlapping groups need no special protection.
   Rather than double-counting, the group array is ordered most-specific-first and each file lands
-  in the first matching group, with a final `**` catch-all ("Other"). This makes the groups an
-  exact partition so a Total row is meaningful. Trivial to change to multi-count later.
-- **Groups** (initial hardcoded set, ordered): Generated (incl. `pnpm-lock.yaml` and
-  `**/.generated/**`), Tests, UI components (`packages/ui` + `**/components/**`), Docs,
+  in the first matching group, with a code-level "Other" fallback (a literal `**` glob doesn't
+  match dotfiles, so the fallback lives in code, not in a glob). This makes the groups an exact
+  partition so the Total row is meaningful. Trivial to change to multi-count later.
+- **Groups** (ordered): Generated (`pnpm-lock.yaml`, `**/.generated/**`, `**/generated/**`,
+  `**/*.generated.*`), Tests, UI components (`packages/ui` + `**/components/**`), Docs,
   CI & scripts, Config, Product (remaining `apps/**` + `packages/**`), Other.
-- **Rename handling**: use git rename detection so pure renames don't show up as huge +/-.
-- **SLOC definition**: after stripping comments, lines that are empty/whitespace-only don't count.
-  Added/removed SLOC per file is computed by diffing the comment-stripped before/after contents
-  (`git diff --no-index --numstat`), so multiline `/* */` blocks are handled naturally. String
-  literals are tracked so `"http://..."` isn't treated as a comment; regex literals are not
-  (known, acceptable limitation — "for now" per the ask).
+- **Rename handling**: git rename detection (`-M`) so pure renames don't show up as huge +/-.
+- **SLOC definition**: blank lines never count (for all text files, not just JS); JS-ish files
+  additionally get comments stripped. Added/removed per file is computed by diffing the
+  comment-stripped before/after contents, so multiline `/* */` blocks are handled naturally.
+  String literals are tracked so `"http://..."` isn't treated as a comment; regex literals are
+  not (known, acceptable limitation — "for now" per the ask). "Before" content is taken at the
+  merge-base, matching the three-dot diff.
 - **Trigger gotcha**: Depot registers triggers from the default branch, so the automatic
   `pull_request` runs only start once this lands on main. Validated pre-merge via
   `depot ci run --workflow .depot/workflows/loc-report.yml` and by running the script locally.
 
 ## Implementation log
 
-(append as work proceeds)
+- Sample output against merged sandbox-platform PR (3296aa87a), SLOC mode:
+
+  ```
+    Group         Files  Added  Removed    Net
+  + Generated         2    +11      -10     +1
+  + Tests            10   +138      -26   +112
+  + Docs              6   +478      -42   +436
+  + CI & scripts      6    +66      -38    +28
+  + Product          22   +593      -82   +511
+  + Other             7    +30       -2    +28
+  + Total            53  +1316     -200  +1116
+  ```
+
+  (raw-line mode counted +1939/-315 for the same diff — blanks and comments were ~30% of it.)
+
+- `stripJsComments` covered by a 12-case ad-hoc harness during development (trailing/whole-line
+  `//`, single/multiline blocks, strings containing `//` and `/* */`, escapes, template
+  literals spanning lines, division, jsdoc, unterminated block). Worth promoting to a real test
+  file if this script grows.
+- `GithubEventPayload` in `scripts/ci/github.ts` gained optional `base`/`head` sha fields.

--- a/tasks/ci-loc-report.md
+++ b/tasks/ci-loc-report.md
@@ -31,7 +31,7 @@ lockfile churn". PRs should show a small table of net LOC change broken down by 
       table: group | files | added | removed | net. _Marker `<!-- iterate-loc-report -->`, upsert
       via Octokit issues API using `ITERATE_BOT_GITHUB_TOKEN`._
 - [x] Colors: render the table inside a ```diff code block — each group's row is prefixed
-    `+`/`-`/` ` by net sign, which GitHub renders green/red. _`renderTable` computes column
+`+`/`-`/` ` by net sign, which GitHub renders green/red. _`renderTable` computes column
       widths and prefixes rows by net sign.\_
 - [x] Script is runnable locally with no PR context (prints the table instead of commenting).
       _`pnpm tsx scripts/ci/loc-report.ts [base] [head]`, defaults `origin/main HEAD`._

--- a/tasks/ci-loc-report.md
+++ b/tasks/ci-loc-report.md
@@ -1,0 +1,59 @@
+---
+status: in-progress
+size: small
+---
+
+# CI workflow: LOC-changed report on PRs, by group
+
+## Status summary
+
+Spec fleshed out, implementation not started. Plan: a Depot workflow + `scripts/ci/loc-report.ts`
+that posts a sticky PR comment with a per-group net-LOC table. Second commit switches counting to
+SLOC (ignoring JS comments).
+
+## Motivation
+
+An important review signal is how many lines of code a PR adds/removes — but "added to the
+product" is a very different signal to "added to tests", "added to docs", or "regenerated
+lockfile churn". PRs should show a small table of net LOC change broken down by group.
+
+## Spec
+
+- [ ] New Depot workflow `.depot/workflows/loc-report.yml` triggered on `pull_request`, calling a
+      script per repo convention (thin YAML, logic in `scripts/ci`).
+- [ ] `scripts/ci/loc-report.ts` computes the diff between the PR base and head (merge-base
+      three-dot diff, like GitHub's Files Changed tab) and buckets changed files into hardcoded
+      groups: `Array<{ name: string; glob: string }>`.
+- [ ] Posts a **sticky comment** on the PR (marker comment, update-in-place on synchronize) with a
+      table: group | files | added | removed | net.
+- [ ] Colors: GitHub markdown has no real color support in tables, so render the table inside a
+      ```diff code block — each group's row is prefixed `+`/`-`/` ` by net sign, which GitHub
+      renders green/red. (Assumption delineated below.)
+- [ ] Script is runnable locally with no PR context (prints the table instead of commenting), so
+      it can be tested against any base/head pair.
+- [ ] Follow-up commit (same PR, pushed separately): count **SLOC** instead of raw lines — strip
+      JS `//` and `/* ... */` comments before counting, for JS-ish files
+      (`.ts/.tsx/.js/.jsx/.mjs/.cjs/.mts/.cts`).
+
+## Decisions / assumptions (made while AFK)
+
+- **First-match-wins grouping.** The user said overlapping groups need no special protection.
+  Rather than double-counting, the group array is ordered most-specific-first and each file lands
+  in the first matching group, with a final `**` catch-all ("Other"). This makes the groups an
+  exact partition so a Total row is meaningful. Trivial to change to multi-count later.
+- **Groups** (initial hardcoded set, ordered): Generated (incl. `pnpm-lock.yaml` and
+  `**/.generated/**`), Tests, UI components (`packages/ui` + `**/components/**`), Docs,
+  CI & scripts, Config, Product (remaining `apps/**` + `packages/**`), Other.
+- **Rename handling**: use git rename detection so pure renames don't show up as huge +/-.
+- **SLOC definition**: after stripping comments, lines that are empty/whitespace-only don't count.
+  Added/removed SLOC per file is computed by diffing the comment-stripped before/after contents
+  (`git diff --no-index --numstat`), so multiline `/* */` blocks are handled naturally. String
+  literals are tracked so `"http://..."` isn't treated as a comment; regex literals are not
+  (known, acceptable limitation — "for now" per the ask).
+- **Trigger gotcha**: Depot registers triggers from the default branch, so the automatic
+  `pull_request` runs only start once this lands on main. Validated pre-merge via
+  `depot ci run --workflow .depot/workflows/loc-report.yml` and by running the script locally.
+
+## Implementation log
+
+(append as work proceeds)

--- a/tasks/complete/2026-07-07-ci-loc-report.md
+++ b/tasks/complete/2026-07-07-ci-loc-report.md
@@ -84,3 +84,18 @@ lockfile churn". PRs should show a small table of net LOC change broken down by 
   literals spanning lines, division, jsdoc, unterminated block). Worth promoting to a real test
   file if this script grows.
 - `GithubEventPayload` in `scripts/ci/github.ts` gained optional `base`/`head` sha fields.
+
+## Post-review iteration (same day)
+
+Feedback from Misha addressed in a follow-up commit:
+
+1. The ```diff code-block rendering looked bad (whole rows solid green/red). Replaced with a
+markdown table mimicking GitHub's own diffstat: `+418`/`-1` columns plus a five-square
+   🟩🟥⬜ bar per row (squares fill by the group's share of the largest group's churn, split
+   green/red by add/remove ratio).
+2. The report now lives in a managed fenced section of the **PR body** (via `markdownAnnotator`,
+   label `loc-report`) instead of a sticky comment, like the preview deployment report. The
+   legacy comment on #1715 was deleted manually.
+3. Added a `priority` prop to groups: array order stays the first-match-wins _match_ order
+   (specific globs first), `priority` is the _display_ order - Product first, then
+   UI components, Tests, CI & scripts, Config, Docs, Other, Generated last.

--- a/tasks/complete/2026-07-07-ci-loc-report.md
+++ b/tasks/complete/2026-07-07-ci-loc-report.md
@@ -1,5 +1,5 @@
 ---
-status: in-review
+status: done
 size: small
 pr: https://github.com/iterate/iterate/pull/1715
 ---
@@ -8,9 +8,10 @@ pr: https://github.com/iterate/iterate/pull/1715
 
 ## Status summary
 
-Implemented, PR open (#1715). Workflow + script + SLOC follow-up all pushed; validated locally
-against real merged-PR diffs and via `depot ci run`. Remaining: automatic `pull_request` runs
-only start once this lands on main (Depot registers triggers from the default branch).
+Done, PR open (#1715). Workflow + script + SLOC follow-up all pushed and validated end-to-end:
+the workflow ran automatically on the PR itself and posted/updated the sticky comment in place,
+so the "triggers only register from main" gotcha turned out not to apply here — the new
+workflow's `pull_request` runs started pre-merge.
 
 ## Motivation
 
@@ -56,9 +57,10 @@ lockfile churn". PRs should show a small table of net LOC change broken down by 
   String literals are tracked so `"http://..."` isn't treated as a comment; regex literals are
   not (known, acceptable limitation — "for now" per the ask). "Before" content is taken at the
   merge-base, matching the three-dot diff.
-- **Trigger gotcha**: Depot registers triggers from the default branch, so the automatic
-  `pull_request` runs only start once this lands on main. Validated pre-merge via
-  `depot ci run --workflow .depot/workflows/loc-report.yml` and by running the script locally.
+- **Trigger gotcha**: docs/depot-ci.md warns triggers register from the default branch, but
+  empirically the new workflow's `pull_request` trigger ran on this very PR pre-merge, posted
+  the comment, and updated it in place on subsequent pushes. Also validated via
+  `depot ci run --workflow .depot/workflows/loc-report.yml` and local script runs.
 
 ## Implementation log
 


### PR DESCRIPTION
Adds a CI check that reports the net lines-of-code change of every PR bucketed into groups (product, tests, UI components, docs, generated, …) — because "+800 lines" reads very differently when it's tests or lockfile churn vs product code.

- **Workflow**: `.depot/workflows/loc-report.yml` — thin wrapper, runs on `pull_request`.
- **Where it shows up**: a managed fenced section of the **PR body** (via `markdownAnnotator`, like the preview deployment report), updated in place on every push. See the "LOC report" section at the bottom of this description — produced by this PR's own workflow run.
- **Logic**: `scripts/ci/loc-report.ts` — groups are a hardcoded `Array<{ name: string; glob: string; priority: number }>`. Array order is the first-match-wins *match* order (specific globs first, code-level "Other" fallback) so the rows partition the diff exactly; `priority` is *display* order — Product first, generated churn last. Runnable locally with no PR context: `pnpm tsx scripts/ci/loc-report.ts [base] [head]`.
- **Rendering**: markdown table mimicking GitHub's own diffstat — one `+added -removed` cell per group plus a five-square 🟩🟥⬜ bar per row (filled by the group's share of the largest group's churn, split green/red by add/remove ratio).
- **SLOC**: blank lines never count, and JS-ish files get `//` and `/* ... */` comments stripped (string/template-literal aware) before counting, by diffing the stripped merge-base vs head contents per file — so comment-only churn doesn't inflate the numbers. Regex literals aren't tracked; known "for now" limitation.

Real output for the recently-merged sandbox-platform PR (#1676), SLOC mode:

| Group | Changes |
| --- | ---: |
| Product | +593 -82 🟩🟩🟩🟩🟥 |
| Tests | +138 -26 🟩⬜⬜⬜⬜ |
| CI & scripts | +66 -38 🟩⬜⬜⬜⬜ |
| Docs | +478 -42 🟩🟩🟩🟩⬜ |
| Other | +30 -2 🟩⬜⬜⬜⬜ |
| Generated | +11 -10 🟩⬜⬜⬜⬜ |
| **Total** | **+1,316 -200** 🟩🟩🟩🟩🟥 |

(Raw-line counting said +1,939/−315 for that same diff — blanks and comments were ~30% of it.)

Task file: `tasks/complete/2026-07-07-ci-loc-report.md` — includes assumptions made while fleshing this out and the post-review iteration log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- loc-report -->
| Group | Changes |
| --- | ---: |
| CI & scripts | +283 -1 🟩🟩🟩🟩🟩 |
| Docs | +84 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+367 -1** 🟩🟩🟩🟩🟩 |

<sub>Source lines changed (blank lines and JS comments ignored) between 97c785f and c00e9e5, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only automation that updates PR descriptions with a bot token; no runtime product or auth path changes.
> 
> **Overview**
> Adds **per-PR source-line churn reporting** so reviewers can see whether growth is mostly product code, tests, docs, generated files, etc., instead of a single raw diff size.
> 
> A new **Depot workflow** (`.depot/workflows/loc-report.yml`) runs on `pull_request`, checks out full history, and runs `scripts/ci/loc-report.ts`. That script diffs **base…head** (rename-aware), buckets each changed file with **first-match-wins globs** (Product, Tests, UI, Docs, CI, Config, Generated, Other), and counts **SLOC** by stripping blank lines and JS comments before per-file add/remove. It renders a **GitHub-style markdown table** (`+added -removed` plus emoji bars) and **updates a managed `loc-report` section in the PR body** (same pattern as other CI reports), fetching the latest description over the API. Without PR context it prints the table locally for `[base] [head]`.
> 
> `scripts/ci/github.ts` extends the webhook payload type with optional `pull_request.base` / `head` SHAs. A completed task note documents behavior and follow-ups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c00e9e5e0bb11020b300b7474be84859cc42fcc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

