### PR TITLE
LOC report: put linguist-generated files in the Generated group

### DIFF
--- a/scripts/ci/loc-report.ts
+++ b/scripts/ci/loc-report.ts
@@ -15,11 +15,9 @@ import { getOctokit, getRepo, readEventPayload } from "./github.ts";
  * churn (CI, config, docs) after; generated noise last.
  */
 export const groups: Array<{ name: string; glob: string; priority: number }> = [
-  {
-    name: "Generated",
-    glob: "{pnpm-lock.yaml,**/.generated/**,**/generated/**,**/*.generated.*}",
-    priority: 8,
-  },
+  // Files with linguist-generated set in .gitattributes (e.g. pnpm-lock.yaml,
+  // routeTree.gen.ts) also land here, ahead of every glob - see computeReport.
+  { name: "Generated", glob: "{**/.generated/**,**/generated/**,**/*.generated.*}", priority: 8 },
   {
     name: "Tests",
     glob: "{**/*.{test,spec}.*,**/{e2e,tests,__tests__,test-helpers}/**}",
@@ -44,6 +42,7 @@ export type ChangedFile = {
   added: number;
   removed: number;
   binary: boolean;
+  generated: boolean;
 };
 
 /** Parses `git diff --numstat -z -M` output (NUL-separated, rename-aware). */
@@ -64,6 +63,7 @@ export function parseNumstat(raw: string): ChangedFile[] {
       added: binary ? 0 : Number(added),
       removed: binary ? 0 : Number(removed),
       binary,
+      generated: false, // filled in by getChangedFiles, which can ask git
     });
   }
   return files;
@@ -86,12 +86,36 @@ export function getChangedFiles(baseRef: string, headRef: string): ChangedFile[]
   const mergeBase = execFileSync("git", ["merge-base", baseRef, headRef], {
     encoding: "utf8",
   }).trim();
-  return parseNumstat(raw).map((file) => {
-    if (file.binary) return file;
+  const files = parseNumstat(raw);
+  const generated = linguistGeneratedPaths(files.map((file) => file.path));
+  return files.map((file) => {
+    const marked = { ...file, generated: generated.has(file.path) };
+    if (marked.binary) return marked;
     const before = significantLines(gitShow(mergeBase, file.previousPath), file.previousPath);
     const after = significantLines(gitShow(headRef, file.path), file.path);
-    return { ...file, ...slocDiffCounts(before, after) };
+    return { ...marked, ...slocDiffCounts(before, after) };
   });
+}
+
+/**
+ * Paths whose `linguist-generated` attribute is set in .gitattributes - the
+ * same source of truth GitHub uses to collapse generated files in diffs.
+ * One batched `git check-attr` call; output is path/attr/value triplets.
+ */
+function linguistGeneratedPaths(paths: string[]): Set<string> {
+  const generated = new Set<string>();
+  if (paths.length === 0) return generated;
+  const out = execFileSync("git", ["check-attr", "--stdin", "-z", "linguist-generated"], {
+    encoding: "utf8",
+    input: paths.join("\0"),
+    maxBuffer: gitMaxBuffer,
+  });
+  const tokens = out.split("\0");
+  for (let i = 0; i + 2 < tokens.length; i += 3) {
+    const value = tokens[i + 2];
+    if (value === "true" || value === "set") generated.add(tokens[i]);
+  }
+  return generated;
 }
 
 const jsExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"]);
@@ -208,7 +232,9 @@ export function computeReport(files: ChangedFile[]) {
     removed: 0,
   }));
   for (const file of files) {
-    const index = groups.findIndex((group) => group.glob && matchesGlob(file.path, group.glob));
+    const index = file.generated
+      ? groups.findIndex((group) => group.name === "Generated")
+      : groups.findIndex((group) => group.glob && matchesGlob(file.path, group.glob));
     const row = rows[index === -1 ? rows.length - 1 : index];
     row.files += 1;
     row.added += file.added;

--- a/tasks/ci-loc-report-linguist-generated.md
+++ b/tasks/ci-loc-report-linguist-generated.md
@@ -1,0 +1,49 @@
+---
+status: in-progress
+size: small
+follows-up: https://github.com/iterate/iterate/pull/1715
+---
+
+# LOC report: respect linguist-generated=true
+
+## Status summary
+
+Spec fleshed out, implementation starting. Follow-up to #1715: any file marked
+`linguist-generated=true` via `.gitattributes` should land in the "Generated" group of the
+LOC report, without maintaining a parallel glob list.
+
+## Motivation
+
+The LOC report's "Generated" group is a hardcoded glob, but the repo already declares what's
+generated: `.gitattributes` marks `**/pnpm-lock.yaml`, `**/db/migrations/meta/*`,
+`.github/workflows/*`, and `**/routeTree.gen.ts` as `linguist-generated=true` (it's what makes
+GitHub collapse them in diffs). The report should agree with that single source of truth.
+
+## Spec
+
+- [ ] Files with the `linguist-generated` attribute set land in the "Generated" group,
+      regardless of glob matching order (generated beats every other group, including Tests).
+- [ ] No sync step to forget: query git at runtime with one batched
+      `git check-attr linguist-generated --stdin -z` call for all changed files.
+- [ ] Drop `pnpm-lock.yaml` from the Generated glob — it's covered by `.gitattributes` now.
+      Keep `**/.generated/**`, `**/generated/**`, `**/*.generated.*` since those aren't marked
+      in `.gitattributes`.
+- [ ] Local mode (`pnpm tsx scripts/ci/loc-report.ts [base] [head]`) behaves identically.
+
+## Decisions / assumptions (made while AFK)
+
+- **Runtime `git check-attr` instead of eslint-plugin-codegen.** The prompt suggested codegen
+  to keep a glob list in sync with `.gitattributes`; asking git directly is simpler and can't
+  drift — it also honors nested `.gitattributes` files if any appear later, and any attribute
+  value semantics (`true`/`set` count, `false`/`unspecified` don't). Codegen would add a lint
+  dependency and a failure mode (out-of-date generated block) for no gain.
+- `.github/workflows/*` is marked linguist-generated in this repo (legacy of the old TS
+  workflow generator), so `claude-assistant.yml` changes will count as Generated rather than
+  CI & scripts. The report honors the attribute; if that's wrong, fix `.gitattributes`.
+- `git check-attr` consults the checked-out `.gitattributes`, so results reflect the head
+  commit's attributes (CI checks out the PR head). Deleted files still resolve fine because
+  attribute lookup doesn't need the file to exist.
+
+## Implementation log
+
+(append as work proceeds)

--- a/tasks/ci-loc-report-linguist-generated.md
+++ b/tasks/ci-loc-report-linguist-generated.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: in-review
 size: small
 follows-up: https://github.com/iterate/iterate/pull/1715
 ---
@@ -8,9 +8,9 @@ follows-up: https://github.com/iterate/iterate/pull/1715
 
 ## Status summary
 
-Spec fleshed out, implementation starting. Follow-up to #1715: any file marked
-`linguist-generated=true` via `.gitattributes` should land in the "Generated" group of the
-LOC report, without maintaining a parallel glob list.
+Implemented (PR #1718). Follow-up to #1715: files marked `linguist-generated=true` via
+`.gitattributes` land in the "Generated" group, queried from git at runtime - no glob list to
+keep in sync.
 
 ## Motivation
 
@@ -21,14 +21,14 @@ GitHub collapse them in diffs). The report should agree with that single source 
 
 ## Spec
 
-- [ ] Files with the `linguist-generated` attribute set land in the "Generated" group,
+- [x] Files with the `linguist-generated` attribute set land in the "Generated" group,
       regardless of glob matching order (generated beats every other group, including Tests).
-- [ ] No sync step to forget: query git at runtime with one batched
+- [x] No sync step to forget: query git at runtime with one batched
       `git check-attr linguist-generated --stdin -z` call for all changed files.
-- [ ] Drop `pnpm-lock.yaml` from the Generated glob — it's covered by `.gitattributes` now.
+- [x] Drop `pnpm-lock.yaml` from the Generated glob — it's covered by `.gitattributes` now.
       Keep `**/.generated/**`, `**/generated/**`, `**/*.generated.*` since those aren't marked
       in `.gitattributes`.
-- [ ] Local mode (`pnpm tsx scripts/ci/loc-report.ts [base] [head]`) behaves identically.
+- [x] Local mode (`pnpm tsx scripts/ci/loc-report.ts [base] [head]`) behaves identically.
 
 ## Decisions / assumptions (made while AFK)
 
@@ -46,4 +46,9 @@ GitHub collapse them in diffs). The report should agree with that single source 
 
 ## Implementation log
 
-(append as work proceeds)
+- `getChangedFiles` marks each file via one `git check-attr --stdin -z linguist-generated`
+  call; `computeReport` routes marked files straight to the Generated group before glob
+  matching. `ChangedFile` gained a required `generated` boolean.
+- Verified against real merged commits: `fd0793b74` (routeTree.gen.ts -> Generated, previously
+  Product) and `b35a93f0a` (pnpm-lock.yaml still Generated via the attribute after removing it
+  from the glob).


### PR DESCRIPTION
Follow-up to #1715. The LOC report's "Generated" group was a hardcoded glob, but the repo already declares what's generated: `.gitattributes` marks `**/pnpm-lock.yaml`, `**/db/migrations/meta/*`, `.github/workflows/*`, and `**/routeTree.gen.ts` as `linguist-generated=true`. The report now agrees with that single source of truth: any changed file whose `linguist-generated` attribute is set lands in "Generated", beating every glob group.

Instead of eslint-plugin-codegen keeping a glob list in sync, the script asks git directly — one batched `git check-attr linguist-generated --stdin -z` call per run. Nothing to drift, and future `.gitattributes` edits (or nested `.gitattributes` files) are picked up automatically.

`pnpm-lock.yaml` is dropped from the Generated glob since the attribute covers it; the `**/.generated/**`-style globs stay because those paths aren't marked in `.gitattributes`.

Task file: `tasks/ci-loc-report-linguist-generated.md` (first commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- loc-report -->
| Group | Changes |
| --- | ---: |
| CI & scripts | +27 -9 🟩🟩🟩🟥⬜ |
| Docs | +43 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+70 -9** 🟩🟩🟩🟩🟥 |

<sub>Source lines changed (blank lines and JS comments ignored) between 3126c8b and 60634e1, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the CI LOC report script and documentation; no runtime product, auth, or data paths are affected.
> 
> **Overview**
> The PR LOC report now treats **`.gitattributes` `linguist-generated`** as the source of truth for the **Generated** bucket, aligned with how GitHub collapses diffs, instead of relying only on a hardcoded glob.
> 
> **`getChangedFiles`** batches **`git check-attr linguist-generated`** for all changed paths and sets a **`generated`** flag on each **`ChangedFile`**. **`computeReport`** sends those files to **Generated** before any glob match (so e.g. **`routeTree.gen.ts`** no longer lands in Product). **`pnpm-lock.yaml`** is removed from the Generated glob because the attribute covers it; **`**/.generated/**`**-style globs remain for paths not marked in **`.gitattributes`**.
> 
> A task note documents the approach and tradeoffs (e.g. **`.github/workflows/*`** counting as Generated when marked linguist-generated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60634e192b079123ca0e171c686c4bfb9f65f451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->