### PR TITLE
task: move ci-loc-report-linguist-generated to complete

### DIFF
--- a/tasks/complete/2026-07-07-ci-loc-report-linguist-generated.md
+++ b/tasks/complete/2026-07-07-ci-loc-report-linguist-generated.md
@@ -1,5 +1,5 @@
 ---
-status: in-review
+status: done
 size: small
 follows-up: https://github.com/iterate/iterate/pull/1715
 ---
@@ -8,7 +8,7 @@ follows-up: https://github.com/iterate/iterate/pull/1715
 
 ## Status summary
 
-Implemented (PR #1718). Follow-up to #1715: files marked `linguist-generated=true` via
+Done, merged in PR #1718. Follow-up to #1715: files marked `linguist-generated=true` via
 `.gitattributes` land in the "Generated" group, queried from git at runtime - no glob list to
 keep in sync.
 


### PR DESCRIPTION
Housekeeping: #1718 merged with its task file still in `tasks/` marked `in-review`. Moves it to `tasks/complete/` with the date prefix and marks it done, per the task-system convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- loc-report -->
| Group | Changes |
| --- | ---: |
| Docs | +2 -2 🟩🟩🟩🟥🟥 |
| **Total** | **+2 -2** 🟩🟩🟩🟥🟥 |

<sub>Source lines changed (blank lines and JS comments ignored) between aaf17a7 and 53d9a33, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only task-tracking markdown changes; no application or CI logic is modified in this diff.
> 
> **Overview**
> **Task housekeeping** for the LOC-report / `linguist-generated` follow-up: the task doc is finalized under `tasks/complete/` and its front matter **`status` is set from `in-review` to `done`**.
> 
> The **Status summary** is updated to state the work shipped in **PR #1718** (runtime `git check-attr` for Generated grouping), replacing the older “implemented, in review” wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53d9a33f58952ab60b6e7fc06921d08b66e44e1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->