### PR TITLE
Draft PRs don't claim a preview lease unless they ask

### DIFF
--- a/.depot/workflows/cloudflare-previews.yml
+++ b/.depot/workflows/cloudflare-previews.yml
@@ -25,6 +25,12 @@
 
 name: Cloudflare Previews (Depot CI)
 
+# Draft PRs don't claim a preview slot unless they ask — the `preview` label,
+# marking ready for review, or a manual dispatch (dispatch passes
+# --allow-draft below). The policy lives in scripts/preview/preview.ts
+# (decideDraftPreviewPolicy) where it's unit-tested; the trigger types beyond
+# open/reopen/synchronize/close just make sure the script runs whenever a
+# PR's draft or label state changes, so it can claim a slot or give one back.
 on:
   pull_request:
     types:
@@ -32,6 +38,10 @@ on:
       - reopened
       - synchronize
       - closed
+      - ready_for_review
+      - converted_to_draft
+      - labeled
+      - unlabeled
     paths:
       - .depot/workflows/cloudflare-previews.yml
       - packages/shared/**
@@ -63,7 +73,12 @@ concurrency:
 
 jobs:
   preview:
-    if: github.event.action != 'closed'
+    # Label events for anything but the preview opt-in label change nothing
+    # about the preview lifecycle — skip the checkout+install entirely.
+    if: |-
+      github.event.action != 'closed' &&
+        (github.event.action != 'labeled' || github.event.label.name == 'preview') &&
+        (github.event.action != 'unlabeled' || github.event.label.name == 'preview')
     name: Preview / deploy + e2e
     # 8-core: the job is network-bound (waiting on deployed slots), not
     # CPU-bound. Depot metrics on a full run showed peak CPU ~30% and peak
@@ -99,9 +114,12 @@ jobs:
           WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |-
           set -euo pipefail
+          # A manual dispatch is an explicit ask for a preview, so it
+          # overrides the draft policy.
           doppler run --project _shared --config prd -- pnpm preview deploy \
             --github-token "$GITHUB_TOKEN" \
-            --pull-request-number "${{ github.event.pull_request.number || inputs.pull-request-number }}"
+            --pull-request-number "${{ github.event.pull_request.number || inputs.pull-request-number }}" \
+            ${{ github.event_name == 'workflow_dispatch' && '--allow-draft' || '' }}
       - name: Preview / e2e
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,11 @@ Before PRs:
 pnpm install && pnpm typecheck && pnpm lint && pnpm format && pnpm test
 ```
 
+**Draft PRs don't get a preview deployment** (or preview e2e). If you open a
+PR as a draft and want a preview environment, add the `preview` label; marking
+the PR ready for review also starts previews. Lease model details:
+[Dev environments](docs/dev-environments.md).
+
 ## Repository map
 
 **Start here:** `apps/os/`

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ Before PRs:
 pnpm install && pnpm typecheck && pnpm lint && pnpm format && pnpm test
 ```
 
+**Draft PRs don't get a preview deployment** (or preview e2e). If you open a
+PR as a draft and want a preview environment, add the `preview` label; marking
+the PR ready for review also starts previews. Lease model details:
+[Dev environments](docs/dev-environments.md).
+
 ## Repository map
 
 **Start here:** `apps/os/`

--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -309,6 +309,14 @@ invariants:
   `preview deploy` / `preview test` run renews the lease for 24h; closing the
   PR tears the apps down and releases it. Lease expiry is only the safety
   valve for abandoned PRs (no pushes for >24h).
+- **Draft PRs don't claim a slot unless they ask.** Drafts are the default
+  for agent-opened PRs, and nine slots don't survive a busy night of them. A
+  draft asks by wearing the `preview` label (durable — previews then behave
+  as for a ready PR), being marked ready for review, or a one-shot explicit
+  run (dispatching the `Cloudflare Previews` workflow, or
+  `pnpm preview deploy --allow-draft`; the next push re-applies the policy).
+  A draft that holds a slot without asking — e.g. a ready PR converted back
+  to draft — gives it back on the next lifecycle run.
 - **Nothing steals a live lease without a human `--force`.** Before running
   tests or destroying anything, the tooling re-asserts that the PR still
   holds the slot, and refuses (with an explanation naming the current holder)

--- a/scripts/preview/flake-hunt-loop.sh
+++ b/scripts/preview/flake-hunt-loop.sh
@@ -56,7 +56,9 @@ RUN_TIMEOUT_SECS="${RUN_TIMEOUT_SECS:-600}"
 if [ "$START_AT" -eq 1 ] && [ -z "${SKIP_PREFLIGHT_DEPLOY:-}" ]; then
   preflight="$LOG_DIR/preflight-deploy.log"
   echo "preflight: deploying full fleet for PR $PR_NUMBER (log: $preflight)"
-  doppler run --project _shared --config prd -- pnpm preview deploy --all-apps \
+  # --allow-draft: the marathon targets an arbitrary PR by number — an
+  # explicit ask, so the draft preview policy doesn't apply.
+  doppler run --project _shared --config prd -- pnpm preview deploy --all-apps --allow-draft \
     --pull-request-number "$PR_NUMBER" >"$preflight" 2>&1
   deploy_exit=$?
   if [ "$deploy_exit" -ne 0 ]; then

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -88,6 +88,84 @@ describe("preview workflow scope", () => {
   });
 });
 
+describe("draft preview policy", () => {
+  const { decideDraftPreviewPolicy } = previewInternals;
+
+  it("deploys ready PRs regardless of labels or leases", () => {
+    expect(
+      decideDraftPreviewPolicy({
+        allowDraft: false,
+        hasRecordedLease: false,
+        isDraft: false,
+        labels: [],
+      }),
+    ).toBe("deploy");
+  });
+
+  it("skips drafts that never had a slot", () => {
+    expect(
+      decideDraftPreviewPolicy({
+        allowDraft: false,
+        hasRecordedLease: false,
+        isDraft: true,
+        labels: ["bug"],
+      }),
+    ).toBe("skip");
+  });
+
+  it("gives a draft's slot back when it holds one without asking", () => {
+    expect(
+      decideDraftPreviewPolicy({
+        allowDraft: false,
+        hasRecordedLease: true,
+        isDraft: true,
+        labels: [],
+      }),
+    ).toBe("teardown");
+  });
+
+  it("deploys drafts wearing the preview label", () => {
+    expect(
+      decideDraftPreviewPolicy({
+        allowDraft: false,
+        hasRecordedLease: false,
+        isDraft: true,
+        labels: ["preview"],
+      }),
+    ).toBe("deploy");
+  });
+
+  it("deploys drafts when the caller explicitly allows it", () => {
+    expect(
+      decideDraftPreviewPolicy({
+        allowDraft: true,
+        hasRecordedLease: false,
+        isDraft: true,
+        labels: [],
+      }),
+    ).toBe("deploy");
+  });
+
+  it("wires the lifecycle events and the dispatch override into the workflow", () => {
+    const workflow = readFileSync(
+      resolve(repoRoot, ".depot/workflows/cloudflare-previews.yml"),
+      "utf8",
+    );
+
+    // Draft/label transitions must re-run the policy so a PR can claim a
+    // slot (ready_for_review, labeled) or give one back (converted_to_draft,
+    // unlabeled).
+    expect(workflow).toContain("- ready_for_review");
+    expect(workflow).toContain("- converted_to_draft");
+    expect(workflow).toContain("- labeled");
+    expect(workflow).toContain("- unlabeled");
+    // A manual dispatch is an explicit ask, so it bypasses the draft policy.
+    expect(workflow).toContain(
+      "${{ github.event_name == 'workflow_dispatch' && '--allow-draft' || '' }}",
+    );
+  });
+});
+
 describe("auth preview root secrets", () => {
   it("seeds from auth/dev when the preview root has no value", () => {
     const reads: string[] = [];

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -123,8 +123,13 @@ export async function deploy(
     if (!cleanupResult.ok) {
       throw new Error("Failed to tear down previews for a draft PR.");
     }
+    // Pin the post-teardown state in this write: the GitHub read inside
+    // updatePreviewState can be stale (read-after-write lag) and would
+    // otherwise resurrect the released lease and app rows — and this run's
+    // test step would then re-acquire the slot the draft just gave up.
     const update = await updatePreviewState(context, (state) => ({
       ...state,
+      ...cleanupResult.state,
       notice: draftPreviewNotice,
     }));
     return {

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -24,6 +24,35 @@ type PullRequestCommandOptions = {
   pullRequestNumber?: number;
 };
 
+/** Label a draft PR can wear to get previews despite the draft policy below. */
+const previewOptInLabel = "preview";
+
+const draftPreviewNotice = [
+  "This PR is a draft, so it doesn't claim a preview slot.",
+  `To get previews: add the \`${previewOptInLabel}\` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run.`,
+].join(" ");
+
+/**
+ * Draft PRs don't hold preview slots unless they ask: there are only nine
+ * slots and drafts are the default for agent-opened PRs, so a busy night of
+ * drafts was exhausting the fleet before any human asked for a preview.
+ * "Asking" = the `preview` label, marking ready for review, or an explicit
+ * `--allow-draft` run (the workflow_dispatch path). A draft that still holds
+ * a lease (it was ready once, or opted out again) gives its slot back.
+ */
+function decideDraftPreviewPolicy(input: {
+  allowDraft: boolean;
+  hasRecordedLease: boolean;
+  isDraft: boolean;
+  labels: string[];
+}): "deploy" | "skip" | "teardown" {
+  if (!input.isDraft || input.allowDraft || input.labels.includes(previewOptInLabel)) {
+    return "deploy";
+  }
+
+  return input.hasRecordedLease ? "teardown" : "skip";
+}
+
 /**
  * Deploy affected preview apps for a pull request without running preview e2e.
  */
@@ -39,6 +68,13 @@ export async function deploy(
      * of relying on the commit happening to touch a fleet-shared path.
      */
     allApps?: boolean;
+    /**
+     * Deploy even when the PR is a draft without the `preview` label. Draft
+     * PRs otherwise skip previews (or give their slot back); an explicit
+     * invocation — workflow_dispatch, the flake-hunt marathon, a human at a
+     * terminal — is an ask, so those callers pass this.
+     */
+    allowDraft?: boolean;
   } = {},
 ) {
   const runtime = createPreviewRuntime();
@@ -57,6 +93,49 @@ export async function deploy(
       ? `PR body records lease ${current.state.environmentConfigLease.slug} (doppler config ${current.state.environmentConfigLease.dopplerConfig}, recorded until ${formatUntil(current.state.environmentConfigLease.leasedUntil)})`
       : "PR body records no lease — this PR has no slot yet",
   );
+
+  const draftPolicy = decideDraftPreviewPolicy({
+    allowDraft: options.allowDraft === true,
+    hasRecordedLease: current.state.environmentConfigLease != null,
+    isDraft: context.pullRequestIsDraft,
+    labels: context.pullRequestLabels,
+  });
+  if (draftPolicy === "skip") {
+    logPreview(
+      `draft PR without the ${previewOptInLabel} label — not claiming a preview slot (mark ready, add the label, or pass --allow-draft)`,
+    );
+    const update = await updatePreviewState(context, (state) => ({
+      ...state,
+      notice: draftPreviewNotice,
+    }));
+    return {
+      ok: true,
+      skipped: true,
+      skippedReason: "draft",
+      state: update.state,
+    };
+  }
+  if (draftPolicy === "teardown") {
+    logPreview(
+      `draft PR without the ${previewOptInLabel} label holds ${current.state.environmentConfigLease?.slug} — tearing down and releasing the slot (mark ready, add the label, or pass --allow-draft to keep previews)`,
+    );
+    const cleanupResult = await cleanupPreviewForPullRequest({ ...runtime, context });
+    if (!cleanupResult.ok) {
+      throw new Error("Failed to tear down previews for a draft PR.");
+    }
+    const update = await updatePreviewState(context, (state) => ({
+      ...state,
+      notice: draftPreviewNotice,
+    }));
+    return {
+      ok: true,
+      skipped: true,
+      skippedReason: "draft",
+      releasedLease: cleanupResult.released,
+      state: update.state,
+    };
+  }
+
   const selectedApps = options.allApps
     ? (logPreview("--all-apps: deploying the full preview fleet regardless of diff"),
       Object.values(cloudflarePreviewApps))
@@ -1412,6 +1491,8 @@ type PullRequestPreviewContext = {
   githubToken: string;
   pullRequestBaseSha: string;
   pullRequestHeadSha: string;
+  pullRequestIsDraft: boolean;
+  pullRequestLabels: string[];
   pullRequestNumber: number;
   repositoryFullName: string;
   workflowRunUrl: string | null;
@@ -3732,6 +3813,8 @@ async function resolvePullRequestPreviewContext(params: {
     githubToken: params.githubToken,
     pullRequestBaseSha: pullRequest.data.base.sha,
     pullRequestHeadSha: pullRequest.data.head.sha,
+    pullRequestIsDraft: pullRequest.data.draft === true,
+    pullRequestLabels: pullRequest.data.labels.map((label) => label.name),
     pullRequestNumber: params.pullRequestNumber,
     repositoryFullName,
     workflowRunUrl:
@@ -3756,6 +3839,7 @@ export const previewInternals = {
   claimEnvironmentConfigLease,
   classifyEnvironmentConfigLeases,
   classifyLeaseForReclaim,
+  decideDraftPreviewPolicy,
   describeEnvironmentConfigLeases,
   evaluateCloudflareZoneCheck,
   holderPullRequestUrl,

--- a/tasks/complete/2026-07-07-draft-prs-no-preview-lease.md
+++ b/tasks/complete/2026-07-07-draft-prs-no-preview-lease.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 size: medium
 branch: draft-prs-no-preview-lease
 ---

--- a/tasks/draft-prs-no-preview-lease.md
+++ b/tasks/draft-prs-no-preview-lease.md
@@ -8,12 +8,15 @@ branch: draft-prs-no-preview-lease
 
 ## Status summary
 
-Spec written, implementation not started yet.
+Implemented and unit-tested; awaiting review. Policy function + deploy
+wiring, workflow trigger types, marathon opt-out, docs, and the `preview`
+label are all done. The new trigger types only take effect once this merges
+(Depot registers triggers from the default branch).
 
 ## Problem
 
 There are nine preview slots (`preview-1..9`), leased one-per-PR via the
-semaphore. Every PR that touches preview paths claims a slot on open — 
+semaphore. Every PR that touches preview paths claims a slot on open —
 including draft PRs, which are the default for agent-generated work (bedtime
 runs can open half a dozen drafts in one night). Drafts hold scarce slots
 that ready-for-review PRs then queue behind ("All preview slots are leased —
@@ -27,7 +30,7 @@ Draft PRs do not claim a preview lease. A draft opts back in by any of:
    exactly as for a ready PR (deploy on every synchronize).
 2. **Marking the PR ready for review** — previews start automatically.
 3. **Explicit dispatch** — `depot ci dispatch ... --workflow
-   cloudflare-previews.yml --input pull-request-number=N` or a manual
+cloudflare-previews.yml --input pull-request-number=N` or a manual
    `pnpm preview deploy --allow-draft ...`. This is one-shot: the next
    synchronize re-applies the draft policy, so use the label for a lasting
    opt-in.
@@ -67,15 +70,22 @@ from the default branch, so the new event types take effect after merge.
 
 ## Checklist
 
-- [ ] pure decision function (draft/labels/allow-draft/lease-held → deploy | skip | teardown) with unit tests
-- [ ] context carries `draft` + labels from the existing `pulls.get`
-- [ ] `deploy` applies the decision: skip with PR-body notice, or teardown + lease release
-- [ ] `--allow-draft` flag on `preview deploy` (trpc-cli picks it up from the options type)
-- [ ] workflow: new trigger types; dispatch passes `--allow-draft`
-- [ ] `flake-hunt-loop.sh` passes `--allow-draft` (marathon dispatches against an arbitrary PR)
-- [ ] docs: lease model section in `docs/dev-environments.md` ("A PR keeps its slot from first deploy until the PR closes" needs the draft caveat)
-- [ ] create the `preview` label in the repo (one-time `gh label create`)
+- [x] pure decision function (draft/labels/allow-draft/lease-held → deploy | skip | teardown) with unit tests _`decideDraftPreviewPolicy` in preview.ts, exported via `previewInternals`; "draft preview policy" describe block in preview.test.ts_
+- [x] context carries `draft` + labels from the existing `pulls.get` _`pullRequestIsDraft` + `pullRequestLabels` on `PullRequestPreviewContext`_
+- [x] `deploy` applies the decision: skip with PR-body notice, or teardown + lease release _teardown reuses `cleanupPreviewForPullRequest`; both paths set the `draftPreviewNotice` banner (stable text, no timestamp, so repeat runs don't churn the PR body)_
+- [x] `--allow-draft` flag on `preview deploy` (trpc-cli picks it up from the options type) _optional `allowDraft` on the deploy options_
+- [x] workflow: new trigger types; dispatch passes `--allow-draft` _also a job-level `if` skips labeled/unlabeled events for labels other than `preview`, and the test asserts the trigger list + dispatch override string_
+- [x] `flake-hunt-loop.sh` passes `--allow-draft` (marathon dispatches against an arbitrary PR)
+- [x] docs: lease model section in `docs/dev-environments.md` _new "Draft PRs don't claim a slot unless they ask" invariant bullet_
+- [x] create the `preview` label in the repo (one-time `gh label create`) _created during implementation_
 
 ## Implementation notes
 
-(log kept while implementing)
+- The claim path already clears the notice banner on success, so a draft
+  that goes ready loses the "draft — no slot" banner on its first deploy.
+- A one-shot `--allow-draft` deploy is deliberately reverted by the next
+  synchronize: deploy sees a draft holding a lease without the label and
+  tears it down. The label is the durable opt-in; documented in the docs
+  and in the PR-body notice.
+- `preview test` needed no change: teardown/skip leaves no recorded lease
+  and the test lane already exits early in that case.

--- a/tasks/draft-prs-no-preview-lease.md
+++ b/tasks/draft-prs-no-preview-lease.md
@@ -1,0 +1,81 @@
+---
+status: in-progress
+size: medium
+branch: draft-prs-no-preview-lease
+---
+
+# Draft PRs don't get a preview lease unless they ask
+
+## Status summary
+
+Spec written, implementation not started yet.
+
+## Problem
+
+There are nine preview slots (`preview-1..9`), leased one-per-PR via the
+semaphore. Every PR that touches preview paths claims a slot on open — 
+including draft PRs, which are the default for agent-generated work (bedtime
+runs can open half a dozen drafts in one night). Drafts hold scarce slots
+that ready-for-review PRs then queue behind ("All preview slots are leased —
+this PR is waiting in line").
+
+## Decision
+
+Draft PRs do not claim a preview lease. A draft opts back in by any of:
+
+1. **Adding the `preview` label** — the durable ask; previews then behave
+   exactly as for a ready PR (deploy on every synchronize).
+2. **Marking the PR ready for review** — previews start automatically.
+3. **Explicit dispatch** — `depot ci dispatch ... --workflow
+   cloudflare-previews.yml --input pull-request-number=N` or a manual
+   `pnpm preview deploy --allow-draft ...`. This is one-shot: the next
+   synchronize re-applies the draft policy, so use the label for a lasting
+   opt-in.
+
+When a leased PR is converted to draft (or the `preview` label is removed
+from a draft), the next lifecycle run tears its apps down and releases the
+slot.
+
+### Tradeoff (assumption, flagged for review)
+
+Draft PRs lose the preview e2e signal until they opt in or go ready. We
+think slot scarcity hurts more than early e2e helps — and marking ready
+kicks off deploy+e2e automatically — but if we'd rather keep e2e-by-default
+for drafts, invert the default and make this label opt-out instead.
+
+## Design
+
+The policy lives in `scripts/preview/preview.ts` (testable TypeScript), not
+in workflow `if:` expressions. `resolvePullRequestPreviewContext` already
+does `pulls.get`; it additionally records `draft` and label names. `deploy`
+consults a pure decision function:
+
+- ready PR, or draft with `preview` label, or `--allow-draft` → deploy as today
+- draft without label, no lease held → skip: log + PR body notice explaining
+  the three opt-in routes; claim nothing
+- draft without label, lease held → tear down recorded apps and release the
+  lease (same path as `cleanup`), with a notice saying why
+
+`preview test` needs no change: with no lease recorded it already skips.
+
+The workflow (`.depot/workflows/cloudflare-previews.yml`) grows trigger
+types `ready_for_review`, `converted_to_draft`, `labeled`, `unlabeled` — all
+routed to the existing preview job (the script decides what to do); `closed`
+stays routed to cleanup. The workflow_dispatch path passes `--allow-draft`
+since a dispatch is an explicit ask. Note: Depot only registers triggers
+from the default branch, so the new event types take effect after merge.
+
+## Checklist
+
+- [ ] pure decision function (draft/labels/allow-draft/lease-held → deploy | skip | teardown) with unit tests
+- [ ] context carries `draft` + labels from the existing `pulls.get`
+- [ ] `deploy` applies the decision: skip with PR-body notice, or teardown + lease release
+- [ ] `--allow-draft` flag on `preview deploy` (trpc-cli picks it up from the options type)
+- [ ] workflow: new trigger types; dispatch passes `--allow-draft`
+- [ ] `flake-hunt-loop.sh` passes `--allow-draft` (marathon dispatches against an arbitrary PR)
+- [ ] docs: lease model section in `docs/dev-environments.md` ("A PR keeps its slot from first deploy until the PR closes" needs the draft caveat)
+- [ ] create the `preview` label in the repo (one-time `gh label create`)
+
+## Implementation notes
+
+(log kept while implementing)

--- a/tasks/stealable-preview-leases.md
+++ b/tasks/stealable-preview-leases.md
@@ -1,0 +1,51 @@
+---
+status: ready
+size: medium
+---
+
+# Stealable preview leases for draft PRs
+
+Follow-up to `tasks/complete/2026-07-07-draft-prs-no-preview-lease.md` (PR
+#1720), which is the blunt v1: draft PRs skip previews entirely unless they
+opt in. The better shape (Misha's suggestion): drafts DO deploy and get e2e
+signal when capacity is spare, but their lease is second-class — a ready PR
+that finds no free slot may steal a draft's slot.
+
+## Sketch
+
+Slot selection for a ready PR, in priority order:
+
+1. a free slot (least-recently-released first, as today — freed slots rest)
+2. steal from the stalest draft-held lease (oldest `updatedAt`/renewal first)
+3. queue, as today
+
+## Design constraints (from the PR #1720 discussion)
+
+- **Only steal draft-held AND idle leases** (no renewal in ~30min). Renewals
+  happen at run start and runs take ~6–20min, so idle ≈ not mid-run. This
+  preserves the invariant that two PRs never deploy onto the same slot
+  concurrently — per-PR concurrency groups don't protect across PRs, and an
+  automated steal during a victim's in-flight deploy means both write workers
+  to the same slot. Under total contention with all-fresh drafts (bedtime),
+  ready PRs still queue; accepted.
+- **Steal must be atomic-ish in the semaphore** (check-idle → evict →
+  acquire): two ready PRs can target the same victim at once. This is a
+  semaphore-level feature (lease priority/stealability), not deploy-script
+  logic.
+- **Victim recovery mostly exists already**: deploy handles "my slot is
+  gone / someone took it" by claiming a fresh slot and redeploying the whole
+  fleet, and the PR-body banner machinery narrates slot moves. Add a banner
+  variant naming the thief PR and why ("you're a draft; mark ready or add
+  the `preview` label to hold a slot firmly").
+- Once this lands, the v1 policy (skip previews for drafts) should be
+  removed or reduced; the `preview` label could be repurposed as "don't
+  steal my draft's lease". Update `docs/dev-environments.md`, README/CLAUDE
+  "Before PRs" note, and the `decideDraftPreviewPolicy` unit tests.
+
+## Checklist
+
+- [ ] semaphore: leases carry a stealable/priority flag (or holder metadata enough to derive it) and an atomic steal operation
+- [ ] acquire path: free slots → stalest idle draft-held lease → queue
+- [ ] victim PR-body banner naming the thief and the opt-out
+- [ ] revert/soften the v1 draft-skip policy in `preview deploy`
+- [ ] docs + AGENTS/README note updated


### PR DESCRIPTION
## What

Draft PRs no longer claim one of the nine preview slots. A draft opts in by any of:

1. adding the `preview` label (durable — previews then behave exactly as for a ready PR),
2. marking the PR ready for review, or
3. an explicit one-shot run (`depot ci dispatch ... --input pull-request-number=N`, or `pnpm preview deploy --allow-draft --pull-request-number N`) — the next push re-applies the policy, so use the label for a lasting opt-in.

Converting a leased PR to draft (or removing the `preview` label from a draft) tears its preview apps down and releases the slot on the next lifecycle run. Skipped drafts get a PR-body notice naming the three opt-in routes.

## Why

Draft PRs are the default for agent-generated work — a bedtime run can open half a dozen at once — and each one was claiming a slot on open, so ready PRs ended up queueing behind drafts nobody had asked previews for ("All preview slots are leased — this PR is waiting in line").

**Tradeoff, flagged for review**: drafts lose the preview e2e signal until they opt in or go ready. Marking ready starts deploy+e2e automatically, so the signal arrives when review does. If we'd rather keep e2e-by-default, the same machinery supports inverting the label to an opt-out.

## How

- `decideDraftPreviewPolicy` in `scripts/preview/preview.ts` — a pure, unit-tested function (deploy | skip | teardown); the teardown path reuses the existing `cleanupPreviewForPullRequest`, so it carries the same lease-reassertion safety (never destroys a slot this PR no longer holds).
- The context resolver's existing `pulls.get` now also records `draft` + labels — no extra API calls.
- `.depot/workflows/cloudflare-previews.yml` gains `ready_for_review` / `converted_to_draft` / `labeled` / `unlabeled` trigger types, all routed to the existing preview job (the script decides). Label events for labels other than `preview` skip the job entirely. `workflow_dispatch` passes `--allow-draft`.
- The flake-hunt marathon preflight passes `--allow-draft` (dispatching against an arbitrary PR is an explicit ask).
- Docs: new invariant bullet in the lease model section of `docs/dev-environments.md`.
- The `preview` label has been created in the repo (green, with a pointer to the docs).

**Note**: Depot registers workflow triggers from the default branch only, so the new event types (and therefore the whole policy) take effect after merge. This PR is itself a draft and will still claim a slot under the pre-merge rules — a nice before/after demo.

Task file: `tasks/complete/2026-07-07-draft-prs-no-preview-lease.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- loc-report -->
| Group | Changes |
| --- | ---: |
| Tests | +66 -0 🟩🟩🟩⬜⬜ |
| CI & scripts | +87 -3 🟩🟩🟩⬜⬜ |
| Docs | +129 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+282 -3** 🟩🟩🟩🟩🟩 |

<sub>Source lines changed (blank lines and JS comments ignored) between aaf17a7 and 3a50a65, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-07T21:52:26.498Z",
      "headSha": "a460b514b29abfec6d5f128a533409c0b0fa6183",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/367402647117593",
      "shortSha": "a460b51",
      "cleanupDurationMs": 3651,
      "deployDurationMs": 181637,
      "testDurationMs": 170589,
      "testRetries": "3 retried: catalogue example \"sandbox-exec\" runs identically across runtimes (vitest x1) · sandbox egress > is MITM-intercepted and routed through project egress with secret substitution (vitest x1) · runs \"describe-project\" through the project REPL (specs x1)"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-07T21:52:23.708Z",
      "headSha": "a460b514b29abfec6d5f128a533409c0b0fa6183",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/367402647117593",
      "shortSha": "a460b51",
      "cleanupDurationMs": 859,
      "deployDurationMs": 17421,
      "testDurationMs": 6584,
      "testRetries": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-07T21:52:25.502Z",
      "headSha": "a460b514b29abfec6d5f128a533409c0b0fa6183",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/367402647117593",
      "shortSha": "a460b51",
      "cleanupDurationMs": 2652,
      "deployDurationMs": 21808,
      "testDurationMs": 613,
      "testRetries": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-07T21:52:23.532Z",
      "headSha": "a460b514b29abfec6d5f128a533409c0b0fa6183",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/367402647117593",
      "shortSha": "a460b51",
      "cleanupDurationMs": 679,
      "deployDurationMs": 15004,
      "testDurationMs": 27045,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `a460b51` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 21.8s | 613ms |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/367402647117593) | 2026-07-07T21:52:25.502Z | Preview app released. |
| OS | released | `a460b51` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 181.6s | 170.6s | 3 retried: catalogue example "sandbox-exec" runs identically across runtimes (vitest x1) · sandbox egress > is MITM-intercepted and routed through project egress with secret substitution (vitest x1) · runs "describe-project" through the project REPL (specs x1) | 3.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/367402647117593) | 2026-07-07T21:52:26.498Z | Preview app released. |
| Semaphore | released | `a460b51` | [https://semaphore.iterate-preview-6.com](https://semaphore.iterate-preview-6.com) | 17.4s | 6.6s |  | 859ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/367402647117593) | 2026-07-07T21:52:23.708Z | Preview app released. |
| Streams Example App | released | `a460b51` | [https://streams.iterate-preview-6.com](https://streams.iterate-preview-6.com) | 15.0s | 27.0s |  | 679ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/367402647117593) | 2026-07-07T21:52:23.532Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preview lease lifecycle and can tear down deployments when PRs become drafts; logic is centralized and tested but affects scarce shared preview infrastructure.
> 
> **Overview**
> **Draft PRs no longer consume one of the nine Cloudflare preview slots by default.** `preview deploy` now runs a unit-tested `decideDraftPreviewPolicy` (deploy | skip | teardown) using draft state and labels from the existing `pulls.get` call. Unlabeled drafts **skip** claiming a lease and get a PR-body notice; drafts that still hold a slot without opting in **tear down** via the existing cleanup path and release the lease.
> 
> **Opt-in paths:** the `preview` label, marking ready for review, or **`--allow-draft`** (manual workflow dispatch, flake-hunt preflight). The Depot **Cloudflare Previews** workflow adds `ready_for_review`, `converted_to_draft`, `labeled`, and `unlabeled` triggers (with job `if` filters so only `preview` label events run deploy), and passes `--allow-draft` on `workflow_dispatch`.
> 
> Docs (README, CLAUDE, dev-environments lease model) describe the behavior; tests cover the policy and workflow wiring. A follow-up task file sketches stealable draft leases for later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a50a65b3dd89e4c08bf9e11b1226420617395b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->