### PR TITLE
[codex] tune preview sandbox container cap

### DIFF
--- a/apps/os/scripts/generate-wrangler-config.test.ts
+++ b/apps/os/scripts/generate-wrangler-config.test.ts
@@ -58,3 +58,8 @@ it("does not add SaaS catch-all routes to preview zones without SSL-for-SaaS quo
     zone_name: "iterate-preview-6.app",
   });
 });
+
+it("keeps preview sandbox capacity above sustained e2e churn", () => {
+  expect(config.env.prd.containers?.[0]?.max_instances).toBe(50);
+  expect(config.env.preview_6.containers?.[0]?.max_instances).toBe(150);
+});

--- a/apps/os/scripts/generate-wrangler-config.ts
+++ b/apps/os/scripts/generate-wrangler-config.ts
@@ -369,10 +369,12 @@ function envBlock(env: DeployedEnv) {
     kvId: env.resources.projectDirectoryKvId,
     workerBuildCacheKvId: env.resources.workerBuildCacheKvId,
     // standard-1 uses 4 GiB per instance and Cloudflare validates max_instances
-    // against account memory quota at deploy time. The old preview cap of 500
-    // was viable for lite instances because it reserved 128000 MiB; 31
-    // standard-1 instances reserve 126976 MiB and fit that same quota.
-    maxContainerInstances: isProduction ? 50 : 31,
+    // against account memory quota at deploy time. Cap 500 blocked deploys once
+    // several preview slots existed, and cap 200 only fits while not every
+    // preview slot has an OS sandbox app. Cap 100 previously wedged sustained
+    // e2e churn at assigned == max_instances, so 150 is the fleet-wide
+    // compromise until Cloudflare changes assigned-slot accounting.
+    maxContainerInstances: isProduction ? 50 : 150,
   });
   return {
     name: env.osWorkerName,

--- a/docs/preview-e2e-flake-hunt.md
+++ b/docs/preview-e2e-flake-hunt.md
@@ -53,7 +53,7 @@ to be reset; reference = v6frpcasd5hp70rrhv37kmr4`) during an active
   600s watchdog — sandbox starts degraded as the instance pool saturated at
   `assigned == 100` even with destroy-on-idle (see the marathon5 addendum
   under flake 23). Preview cap raised 100 → 500 for the marathon, then reset
-  to 31 after Cloudflare rejected 500 against the preview account memory quota.
+  to 150 after Cloudflare rejected 500 against the preview account memory quota.
 - **marathon6** `gb1g4sg7rs`: 25 clean at a steady ~60-90s/run — cap 500
   eliminated the saturation slowdown entirely (pool rode at `assigned: 491`
   with NO latency growth, where cap-100 marathons were at 3-5min/run by run
@@ -62,10 +62,13 @@ to be reset; reference = v6frpcasd5hp70rrhv37kmr4`) during an active
   remote timeout crashed the bare tsx process. Fix: the smoke now makes 3
   attempts, each with a fresh session + project, matching the vitest lane's
   `retry: 2` policy; a broken slot still fails all three inside ~5min.
-- **2026-07-07 quota correction**: the preview cap was reduced 500 → 31.
+- **2026-07-07 quota correction**: the preview cap was reduced 500 → 150.
   Cap 500 helped a single marathon slot, but multiple preview slots at
   `standard-1` exceeded the dev/preview account memory quota and blocked new
-  deploys.
+  deploys. Cap 200 fits a partially populated preview fleet, but not all nine
+  preview slots once each carries the OS sandbox app. Cap 100 previously
+  wedged at `assigned == max_instances`; 150 is the fleet-wide compromise
+  until Cloudflare changes assigned-slot accounting.
 - **marathon7** `pvtfkq146g`: 21 clean, run 22 failed in
   `streams-example-app`'s vitest lane: `Network connection lost.` on a
   392ms-old fresh WebSocket (edge blip) — and that suite had NO retry config
@@ -581,14 +584,14 @@ sandbox-exec went ~20-40s (runs 1-10) → 2.1-2.8min (runs 30-32, shaving the
 happened at exactly `assigned == max_instances` (20, then 100). Response:
 preview cap raised 100 → **500** (`generate-wrangler-config.ts`) so a whole
 50-run marathon's cumulative creations (~3-8 sandboxes/run) never saturate
-the pool. On 2026-07-07 this was reduced to **31** because several preview
+the pool. On 2026-07-07 this was reduced to **150** because several preview
 slots at 500 `standard-1` instances exceeded the dev/preview account memory
-quota and blocked deploys; 31 standard-1 instances fit the same quota as the
-old 500-lite cap. Destroy remains correct — it is what lets an idle fleet drain
-back to zero instead of holding slots forever. If sustained-churn claim latency
-reproduces near the deployable cap, this becomes a Cloudflare Containers
-escalation (pool-manager degradation under DO-binding churn), not an app-side
-fix.
+quota and blocked deploys; 200 fit the currently populated fleet but did not
+leave room for all nine preview slots to carry OS sandbox apps. Destroy
+remains correct — it is what lets an idle fleet drain back to zero instead of
+holding slots forever. If sustained-churn claim latency reproduces at 150,
+this becomes a Cloudflare Containers escalation (pool-manager degradation
+under DO-binding churn), not an app-side fix.
 
 ### 21. Blank route-pending panel fast-fails the first wait after `goto`
 


### PR DESCRIPTION
## Summary
- set OS preview sandbox container `max_instances` to 150 while keeping production at 50
- add a generated-config regression test for the production/preview split
- document why 150 is the quota-fit compromise after 100 wedged under sustained churn and 200 did not leave room for all preview slots

## Validation
- `pnpm --dir apps/os exec vitest run scripts/generate-wrangler-config.test.ts`
- `pnpm exec oxfmt --check apps/os/scripts/generate-wrangler-config.ts apps/os/scripts/generate-wrangler-config.test.ts docs/preview-e2e-flake-hunt.md`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deployed preview infrastructure limits (memory quota vs. sandbox pool saturation); mis-tuning could block deploys or reintroduce e2e marathon wedges, but scope is config generation and docs only.
> 
> **Overview**
> Raises the **preview** OS sandbox container `max_instances` from **31 → 150** in `generate-wrangler-config.ts`, while **production stays at 50**. The generator comments and `docs/preview-e2e-flake-hunt.md` now record why **150** is the fleet-wide compromise: **100** wedged sustained preview e2e when `assigned == max_instances`, **500** broke deploys against the preview account memory quota, and **200** did not leave room for all nine preview slots on `standard-1` instances.
> 
> Adds a regression test in `generate-wrangler-config.test.ts` that `prd` containers use **50** and `preview_6` uses **150**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e312ac477a3f72b18230c68d503fab0cf193a5f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Changes |
| --- | ---: |
| Tests | +4 -0 🟩⬜⬜⬜⬜ |
| CI & scripts | +1 -1 🟩⬜⬜⬜⬜ |
| Docs | +13 -10 🟩🟩🟩🟥🟥 |
| **Total** | **+18 -11** 🟩🟩🟩🟥🟥 |

<sub>Source lines changed (blank lines and JS comments ignored) between 2d7c0d2 and e312ac4, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-07T20:25:37.822Z",
      "headSha": "70467b33cd87dd846b52a72ed5b71439ac107f8d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/493550625206139",
      "shortSha": "70467b3",
      "cleanupDurationMs": 4557,
      "deployDurationMs": 172146,
      "testDurationMs": 194131,
      "testRetries": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-07T20:25:36.080Z",
      "headSha": "70467b33cd87dd846b52a72ed5b71439ac107f8d",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/493550625206139",
      "shortSha": "70467b3",
      "cleanupDurationMs": 2811,
      "deployDurationMs": 18001,
      "testDurationMs": 571,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `70467b3` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 18.0s | 571ms |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/493550625206139) | 2026-07-07T20:25:36.080Z | Preview app released. |
| OS | released | `70467b3` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 172.1s | 194.1s |  | 4.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/493550625206139) | 2026-07-07T20:25:37.822Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->