### PR TITLE
[codex] Make agent sandbox identity creation lazy

### DIFF
--- a/apps/os/src/domains/projects/project-processor-implementation.ts
+++ b/apps/os/src/domains/projects/project-processor-implementation.ts
@@ -307,20 +307,6 @@ export class ProjectProcessor extends StreamProcessor<
                 systemPrompt: agentSystemPromptForPath(childPath),
               }),
             );
-            // Every agent owns the sandbox at its own path under /sandboxes
-            // (`itx.sandbox` → agentSandboxPath). Awaiting the get mints the
-            // Durable Object and pins its identity durably — that IS creation;
-            // no container starts here (the first command boots it, idle puts
-            // it back to sleep), so agent birth stays cheap however many
-            // agents a project accumulates. Non-fatal on purpose:
-            // `itx.sandbox` re-ensures identity on every use, so this is eager
-            // minting only — and in container-less local dev the sandbox
-            // constructor throws, which must not wedge agent birth.
-            await this.deps.itx.sandboxes
-              .get(agentSandboxPath(childPath))
-              .catch((error: unknown) => {
-                console.error(`agent sandbox create failed for ${childPath}`, error);
-              });
             return;
           }
 
@@ -474,7 +460,9 @@ function agentBirthCertificateEvents(input: {
     // and replays with the stream. A durable itx-expression, not a live mount:
     // every `itx.sandbox.<method>(...)` re-evaluates
     // `itx.sandboxes.get(/sandboxes/cloudflare<agent path>)` against the agent's own itx
-    // at call time, so nothing here holds a connection or a container open.
+    // at call time. Agent birth itself does not call `sandboxes.get`, because
+    // that mints the container-backed Durable Object identity and creates
+    // Cloudflare container inventory rows even before a Linux container starts.
     {
       type: "events.iterate.com/capability-host/capability-provided" as const,
       idempotencyKey: `capability-host/sandbox-provided:${input.projectId}:${input.childPath}`,

--- a/apps/os/src/domains/projects/project-processor.test.ts
+++ b/apps/os/src/domains/projects/project-processor.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Stream, StreamEvent, StreamEventInput } from "../../types.ts";
+import type { ProjectRpcTarget } from "../../rpc-targets.ts";
+import { ProjectProcessor } from "./project-processor-implementation.ts";
+
+class MemoryStream implements Stream {
+  events: StreamEvent[] = [];
+
+  constructor(readonly path: string) {}
+
+  async __describe() {
+    return { instructions: `in-memory stream ${this.path}`, types: "", children: {} };
+  }
+
+  async append(...inputs: StreamEventInput[]): Promise<StreamEvent[]> {
+    return inputs.map((input) => {
+      const existing =
+        input.idempotencyKey === undefined
+          ? undefined
+          : this.events.find((event) => event.idempotencyKey === input.idempotencyKey);
+      if (existing !== undefined) return existing;
+
+      const offset = this.events.length + 1;
+      const event: StreamEvent = {
+        ...input,
+        createdAt: new Date(offset).toISOString(),
+        offset,
+      };
+      this.events.push(event);
+      return event;
+    });
+  }
+
+  at(): Stream {
+    return this;
+  }
+
+  async getEvent(
+    input: { offset: number } | { idempotencyKey: string },
+  ): Promise<StreamEvent | undefined> {
+    if ("offset" in input) return this.events.find((event) => event.offset === input.offset);
+    return this.events.find((event) => event.idempotencyKey === input.idempotencyKey);
+  }
+
+  async getEvents(input: Parameters<Stream["getEvents"]>[0] = {}): Promise<StreamEvent[]> {
+    const { afterOffset = 0, limit = 500 } = input;
+    const beforeOffset = input.beforeOffset ?? Number.MAX_SAFE_INTEGER;
+    return this.events
+      .filter((event) => event.offset > afterOffset)
+      .filter((event) => event.offset < beforeOffset)
+      .filter(
+        (event) =>
+          input.eventTypes === undefined ||
+          input.eventTypes.includes("*") ||
+          input.eventTypes.includes(event.type),
+      )
+      .slice(0, limit);
+  }
+
+  readEvents(input: Parameters<Stream["readEvents"]>[0] = {}) {
+    let afterOffset = input.afterOffset ?? 0;
+    return {
+      next: async () => {
+        const page = await this.getEvents({ ...input, afterOffset });
+        afterOffset = page.at(-1)?.offset ?? afterOffset;
+        return page;
+      },
+      [Symbol.dispose]() {},
+    };
+  }
+
+  async waitForEvent(input: {
+    afterOffset?: number;
+    eventTypes?: readonly string[];
+    predicate?: (event: StreamEvent) => boolean | Promise<boolean>;
+    timeoutMs: number;
+  }): Promise<StreamEvent> {
+    const match = this.events.find((event) => {
+      if (input.afterOffset !== undefined && event.offset <= input.afterOffset) return false;
+      if (input.eventTypes !== undefined && !input.eventTypes.includes(event.type)) return false;
+      return true;
+    });
+    if (match !== undefined && (input.predicate === undefined || (await input.predicate(match)))) {
+      return match;
+    }
+    throw new Error("MemoryStream timed out waiting for event");
+  }
+
+  async getProcessorRuntimeState(): Promise<null> {
+    return null;
+  }
+
+  async runtimeState() {
+    return { coreProcessorState: null, runtime: { connections: {} } };
+  }
+
+  async subscribe(): Promise<never> {
+    throw new Error("MemoryStream does not implement subscribe().");
+  }
+}
+
+class MemoryStreamNetwork {
+  readonly streams = new Map<string, MemoryStream>();
+
+  get(path: string): MemoryStream {
+    let stream = this.streams.get(path);
+    if (stream === undefined) {
+      stream = new MemoryStream(path);
+      this.streams.set(path, stream);
+    }
+    return stream;
+  }
+
+  eventsAt(path: string): StreamEvent[] {
+    return this.get(path).events;
+  }
+}
+
+function event(type: string, payload: Record<string, unknown>, offset = 1): StreamEvent {
+  return {
+    type,
+    payload,
+    createdAt: new Date(offset).toISOString(),
+    offset,
+  };
+}
+
+function makeHarness() {
+  const network = new MemoryStreamNetwork();
+  const getSandbox = vi.fn(async () => ({}));
+  const itx = {
+    projectId: "prj_test",
+    sandboxes: { get: getSandbox },
+    streams: { get: (path: string) => network.get(path) },
+  } as unknown as ProjectRpcTarget;
+  const processor = new ProjectProcessor({
+    stream: network.get("/"),
+    defaultLlmProvider: "openai-ws",
+    itx,
+  });
+  return { getSandbox, network, processor };
+}
+
+describe("ProjectProcessor agent birth", () => {
+  it("mounts itx.sandbox without minting the sandbox Durable Object identity", async () => {
+    const { getSandbox, network, processor } = makeHarness();
+
+    await processor.ingest({
+      events: [
+        event("events.iterate.com/stream/child-stream-created", {
+          childPath: "/agents/demo",
+        }),
+      ],
+      streamMaxOffset: 1,
+    });
+
+    expect(getSandbox).not.toHaveBeenCalled();
+
+    const sandboxMount = network
+      .eventsAt("/agents/demo")
+      .find(
+        (streamEvent) =>
+          streamEvent.type === "events.iterate.com/capability-host/capability-provided",
+      );
+    expect(sandboxMount?.payload).toMatchObject({
+      expression: ["sandboxes", ["get", "/sandboxes/cloudflare/agents/demo"]],
+      path: ["sandbox"],
+      type: "itx-expression",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Remove eager agent sandbox identity minting from project stream processing.
- Keep `itx.sandbox` mounted as a lazy `itx-expression`, so sandbox use still resolves on first call.
- Add a regression test proving agent birth does not call `sandboxes.get` while still providing the sandbox capability.

## Why

Creating agent streams was eagerly calling `sandboxes.get(...)`. In Cloudflare preview environments, that mints the container-backed Durable Object identity and can create container inventory rows even before the Linux container starts. With many agent threads, that can consume account-level container memory budget far earlier than actual sandbox usage would suggest.

## Validation

- `pnpm --dir apps/os exec vitest run src/domains/projects/project-processor.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm exec oxlint apps/os/src/domains/projects/project-processor-implementation.ts apps/os/src/domains/projects/project-processor.test.ts --threads 1 --deny-warnings`
- `pnpm --dir apps/os test:unit`
- `git diff --check`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-07T22:18:43.935Z",
      "headSha": "09859ad64914ffc49755e9107a0c426a54620993",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/298434487802533",
      "shortSha": "09859ad",
      "cleanupDurationMs": 5433,
      "deployDurationMs": 154176,
      "testDurationMs": 106948,
      "testRetries": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-07T22:18:41.868Z",
      "headSha": "09859ad64914ffc49755e9107a0c426a54620993",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/298434487802533",
      "shortSha": "09859ad",
      "cleanupDurationMs": 3363,
      "deployDurationMs": 18109,
      "testDurationMs": 521,
      "testRetries": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-07T22:18:39.664Z",
      "headSha": "feee35a24ce51051172412b17203479423b00444",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/57442955490305",
      "shortSha": "feee35a",
      "cleanupDurationMs": 1157,
      "deployDurationMs": 17458,
      "testDurationMs": 6812,
      "testRetries": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-07T22:18:39.586Z",
      "headSha": "feee35a24ce51051172412b17203479423b00444",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/57442955490305",
      "shortSha": "feee35a",
      "cleanupDurationMs": 1075,
      "deployDurationMs": 15810,
      "testDurationMs": 17839,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `09859ad` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 18.1s | 521ms |  | 3.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/298434487802533) | 2026-07-07T22:18:41.868Z | Preview app released. |
| OS | released | `09859ad` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 154.2s | 106.9s |  | 5.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/298434487802533) | 2026-07-07T22:18:43.935Z | Preview app released. |
| Semaphore | released | `feee35a` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 17.5s | 6.8s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/57442955490305) | 2026-07-07T22:18:39.664Z | Preview app released. |
| Streams Example App | released | `feee35a` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 15.8s | 17.8s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/57442955490305) | 2026-07-07T22:18:39.586Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core project stream processing for every new agent path; behavior change is intentional (defer identity minting) but could affect timing if anything assumed sandboxes existed immediately after birth.
> 
> **Overview**
> **Stops eager sandbox Durable Object minting when new agent streams are born.** The `stream/child-stream-created` handler no longer calls `itx.sandboxes.get(agentSandboxPath(...))` during agent birth.
> 
> Agents still get **`itx.sandbox`** via the existing birth-certificate `capability-provided` event: a lazy `itx-expression` that resolves `sandboxes.get` on first sandbox use, not at stream creation. Comments in `agentBirthCertificateEvents` now document that distinction and why eager `get` was removed (container inventory / account budget in Cloudflare preview).
> 
> Adds **`project-processor.test.ts`** with an ingest harness asserting agent birth appends the sandbox mount expression but never invokes `sandboxes.get`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09859ad64914ffc49755e9107a0c426a54620993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +3 -15 | +0 -5 🟥⬜⬜⬜⬜ |
| Tests | +171 -0 | +149 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+174 -15** | **+149 -5** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between c93c571 and 09859ad, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->