### PR TITLE
Move significant-columns LOC report task to complete

### DIFF
--- a/tasks/complete/2026-07-07-ci-loc-report-significant-columns.md
+++ b/tasks/complete/2026-07-07-ci-loc-report-significant-columns.md
@@ -1,5 +1,5 @@
 ---
-status: in-review
+status: done
 size: small
 follows-up: https://github.com/iterate/iterate/pull/1715
 ---


### PR DESCRIPTION
Housekeeping: #1723 merged with its task file still in `tasks/` marked `in-review`. Moves it to `tasks/complete/` with the date prefix and marks it done, per the task-system convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Docs | +1 -1 | +1 -1 🟩🟩🟩🟥🟥 |
| **Total** | **+1 -1** | **+1 -1** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 7625712 and ac288f6, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only task status update with no runtime or CI behavior changes.
> 
> **Overview**
> **Task housekeeping** for the LOC report work that shipped in PR #1723: the task file is relocated under `tasks/complete/` with the usual date prefix, and front matter **`status`** changes from `in-review` to **`done`**.
> 
> No application or CI script changes in this diff—only the task tracker reflects that the “Lines vs Significant” columns spec is finished.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac288f69a8b798585219ff9ba11f1d5edb748841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->