### PR TITLE
feat(os): agent-scoped email.send binds replies back to the sending agent

### DIFF
--- a/apps/os/src/domains/email/email-processors.test.ts
+++ b/apps/os/src/domains/email/email-processors.test.ts
@@ -310,6 +310,59 @@ describe("EmailProcessor (thread router)", () => {
     expect(processor.state.allowedSenders).toEqual(["jonas@example.com", "*@iterate.com"]);
   });
 
+  it("forwards replies to agent-initiated threads to the SENDING agent's stream", async () => {
+    // An agent-scoped itx.email.send binds its conversation to the calling
+    // agent: it appends this route event (streamPath = the agent's own path,
+    // NOT /agents/email/**) and a sent audit fact carrying the threadId.
+    const network = new MemoryStreamNetwork();
+    const stream = network.get("/integrations/email");
+    const processor = new EmailProcessor({ stream });
+    const cursors = new Map<object, number>();
+
+    await stream.append(
+      {
+        type: "events.iterate.com/email/thread-route-configured",
+        payload: {
+          threadId: "a1b2c3d4e5f6",
+          streamPath: "/agents/slack/conn/c123/ts-1",
+          counterpart: "jonas@example.com",
+        },
+      },
+      {
+        type: "events.iterate.com/email/sent",
+        payload: {
+          from: "acme@iterate.app",
+          messageId: "out-slack-1@iterate.app",
+          projectId: "prj_1",
+          subject: "Report you asked for",
+          to: "jonas@example.com",
+          threadId: "a1b2c3d4e5f6",
+        },
+      },
+    );
+    // Reply via the +t token…
+    await stream.append({
+      type: "events.iterate.com/email/received",
+      payload: receivedPayload({ threadTag: "a1b2c3d4e5f6", messageId: "reply-1@mail.example" }),
+    });
+    // …and a header-only reply to the bare address (In-Reply-To = OUR id).
+    await stream.append({
+      type: "events.iterate.com/email/received",
+      payload: receivedPayload({
+        messageId: "reply-2@mail.example",
+        inReplyTo: "out-slack-1@iterate.app",
+      }),
+    });
+    await deliverNewEvents({ cursors, processor, stream });
+
+    const forwarded = network
+      .eventsAt("/agents/slack/conn/c123/ts-1")
+      .filter((event) => event.type === "events.iterate.com/email/received");
+    expect(forwarded).toHaveLength(2);
+    // No stray /agents/email/t<n> threads were minted for either reply.
+    expect([...network.streams.keys()].filter((p) => p.startsWith("/agents/email/"))).toEqual([]);
+  });
+
   it("starts a new thread when an unknown +t tag arrives (no attacker-minted ids)", async () => {
     const network = new MemoryStreamNetwork();
     const stream = network.get("/integrations/email");

--- a/apps/os/src/domains/email/utils.ts
+++ b/apps/os/src/domains/email/utils.ts
@@ -104,6 +104,17 @@ export function emailAgentPath(threadId: string): string {
   return `/agents/email/t${threadId}`;
 }
 
+/**
+ * Thread id for an agent-INITIATED email conversation (an agent-scoped
+ * `itx.email.send`): random where inbound thread ids are stream offsets,
+ * because a send happens in an RPC action with no offset to key on. The `a`
+ * prefix marks agent-initiated threads in logs and Reply-To tags; the
+ * alphabet stays inside the `+t<threadId>` tag grammar (`[a-z0-9-]+`).
+ */
+export function mintOutboundEmailThreadId(): string {
+  return `a${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+}
+
 export function isEmailAgentPath(agentPath: string): boolean {
   const normalized = agentPath.toLowerCase();
   return normalized === "/agents/email" || normalized.startsWith("/agents/email/");

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -169,11 +169,13 @@ import {
   EMAIL_RECEIVED_EVENT_TYPE,
   EMAIL_SENT_EVENT_TYPE,
   isOwnProjectMail,
+  mintOutboundEmailThreadId,
   replySubject,
   type OutboundEmailAttachment,
   type SendEmailBinding,
 } from "./domains/email/utils.ts";
 import { EmailProcessorContract } from "./domains/email/email-processor-contract.ts";
+import { EmailAgentProcessorContract } from "./domains/email/email-agent-processor-contract.ts";
 
 type FetchOnly = Pick<Fetcher, "fetch">;
 
@@ -1289,11 +1291,11 @@ class EmailRpcTarget extends RpcTarget implements EmailCapability {
   async __describe() {
     return describeNode({
       instructions:
-        "First-party email: send({ to, subject, text, html }) delivers through Cloudflare Email Service from this project's own address (<slug>@<hostname base>). An explicit `from` must match that address — a project can never send as anyone else. Inside an email thread agent (/agents/email/t<id>), reply({ text }) answers the thread's counterpart with correct threading headers. Both take attachments: [{ path }] (project files via itx.files, any file type) or [{ filename, data }] (inline base64); limits 32 files / 5 MiB total. Both return { messageId }.",
+        "First-party email: send({ to, subject, text, html }) delivers through Cloudflare Email Service from this project's own address (<slug>@<hostname base>). An explicit `from` must match that address — a project can never send as anyone else. From ANY agent scope, send binds the conversation to the calling agent: replies to that mail arrive as this agent's inputs, and reply({ text }) answers the latest counterpart with correct threading headers. Both take attachments: [{ path }] (project files via itx.files, any file type) or [{ filename, data }] (inline base64); limits 32 files / 5 MiB total. Both return { messageId }.",
       children: {
-        send: "Send one email from the project's address; returns { from, messageId }.",
+        send: "Send one email from the project's address; agent scopes get replies routed back to them. Returns { from, messageId }.",
         reply:
-          "Reply within this email thread (email agent scopes only); returns { from, to, messageId }.",
+          "Reply within this agent's email conversation (email thread agents, or any agent that has sent/received project email); returns { from, to, messageId }.",
       },
       parent: "the project itx root",
     });
@@ -1302,10 +1304,19 @@ class EmailRpcTarget extends RpcTarget implements EmailCapability {
   async send(input: Parameters<EmailCapability["send"]>[0]) {
     const identity = await this.#senderIdentity();
     const attachments = await this.#resolveAttachments(input.attachments);
+    // Agent-scoped sends bind the conversation to the CALLING agent: the
+    // Reply-To carries a thread token routed to this agent's own stream, so
+    // the human's reply comes back as this agent's input — whether it is an
+    // email thread agent, a Slack agent, or any other agent scope.
+    const thread = await this.#bindOutboundThreadToAgent({ identity, request: input });
     const message = buildProjectEmailMessage({
       projectAddress: identity.projectAddress,
       projectName: identity.projectName,
-      request: { ...input, attachments },
+      request: {
+        ...input,
+        attachments,
+        ...(thread !== null && input.replyTo === undefined ? { replyTo: thread.replyTo } : {}),
+      },
     });
     const { from, messageId } = await this.#deliver({
       message,
@@ -1313,6 +1324,7 @@ class EmailRpcTarget extends RpcTarget implements EmailCapability {
         subject: input.subject,
         to: input.to,
         ...(input.inReplyTo === undefined ? {} : { inReplyTo: input.inReplyTo }),
+        ...(thread === null ? {} : { threadId: thread.threadId }),
         attachments,
       },
     });
@@ -1320,10 +1332,11 @@ class EmailRpcTarget extends RpcTarget implements EmailCapability {
   }
 
   async reply(input: Parameters<EmailCapability["reply"]>[0]) {
-    const threadId = emailThreadIdFromAgentPath(this.props.scopePath);
+    const threadId =
+      emailThreadIdFromAgentPath(this.props.scopePath) ?? (await this.#threadIdFromOwnRoute());
     if (threadId === null) {
       throw new Error(
-        `email.reply is only available inside an email thread agent scope (/agents/email/t<id>); this scope is "${this.props.scopePath}". Use email.send for new mail.`,
+        `email.reply needs an agent scope with a bound email thread (an email thread agent, or any agent that has sent/received project email); this scope is "${this.props.scopePath}". Use email.send for new mail.`,
       );
     }
     if (!input.text && !input.html) {
@@ -1376,6 +1389,95 @@ class EmailRpcTarget extends RpcTarget implements EmailCapability {
       },
     });
     return { from, to, messageId };
+  }
+
+  /**
+   * For an agent-scoped send: durably bind an email thread to the calling
+   * agent BEFORE the mail leaves, so a reply can never race the routing
+   * table. Establishes three facts, all idempotent:
+   * 1. `thread-route-configured` on `/integrations/email` — the router
+   *    forwards replies (token or header match) to this agent's stream.
+   * 2. The same route event on the agent's own stream — thread context for
+   *    the email-agent processor and `reply`'s thread lookup.
+   * 3. The email-agent processor subscription on the agent's stream — a
+   *    non-email agent (Slack, web chat, …) gains the transcriber that turns
+   *    forwarded replies into its input. Email thread agents had it at birth;
+   *    the identical idempotency key dedupes.
+   * Project-scoped sends return null and stay plain one-way mail.
+   */
+  async #bindOutboundThreadToAgent(input: {
+    identity: { slug: string; domain: string };
+    request: { to: string | string[]; subject: string };
+  }) {
+    const scopePath = this.props.scopePath;
+    if (!scopePath.startsWith("/agents/")) return null;
+    const threadId =
+      emailThreadIdFromAgentPath(scopePath) ??
+      (await this.#threadIdFromOwnRoute()) ??
+      mintOutboundEmailThreadId();
+    const firstRecipient = Array.isArray(input.request.to) ? input.request.to[0] : input.request.to;
+    const routeEvent = {
+      type: "events.iterate.com/email/thread-route-configured",
+      idempotencyKey: `email-route:${threadId}`,
+      payload: {
+        threadId,
+        streamPath: scopePath,
+        ...(firstRecipient === undefined ? {} : { counterpart: firstRecipient }),
+        subject: input.request.subject,
+      },
+    };
+    const durableObjectName = DurableObjectNameCodec.stringify({
+      projectId: this.props.projectId,
+      path: scopePath,
+    });
+    await Promise.all([
+      integrationStreamStub(this.props.projectId, EMAIL_INTEGRATION_STREAM_PATH).append(routeEvent),
+      integrationStreamStub(this.props.projectId, scopePath).append(
+        routeEvent,
+        buildDurableObjectProcessorSubscriptionConfiguredEvent({
+          durableObjectName,
+          idempotencyKey: `stream/subscription-configured:${durableObjectName}#${EmailAgentProcessorContract.slug}`,
+          processorSlug: EmailAgentProcessorContract.slug,
+          subscriberType: "agent",
+        }),
+      ),
+    ]);
+    return {
+      threadId,
+      replyTo: emailThreadReplyAddress({
+        slug: input.identity.slug,
+        domain: input.identity.domain,
+        threadId,
+      }),
+    };
+  }
+
+  /**
+   * The thread already bound to this agent scope, if any: the latest
+   * `thread-route-configured` on the agent's own stream that names this
+   * stream. Lets repeated sends reuse one conversation and lets `reply` work
+   * from non-email agent scopes.
+   */
+  async #threadIdFromOwnRoute(): Promise<string | null> {
+    if (!this.props.scopePath.startsWith("/agents/")) return null;
+    const stream = integrationStreamStub(this.props.projectId, this.props.scopePath);
+    let afterOffset = 0;
+    let threadId: string | null = null;
+    for (;;) {
+      const page = await stream.getEvents({
+        afterOffset,
+        eventTypes: ["events.iterate.com/email/thread-route-configured"],
+        limit: 500,
+      });
+      for (const event of page) {
+        const payload = event.payload as { streamPath?: string; threadId?: string };
+        if (payload.streamPath === this.props.scopePath && typeof payload.threadId === "string") {
+          threadId = payload.threadId;
+        }
+      }
+      if (page.length < 500) return threadId;
+      afterOffset = page[page.length - 1]!.offset;
+    }
   }
 
   /**

--- a/apps/os/src/types-source.generated.ts
+++ b/apps/os/src/types-source.generated.ts
@@ -463,6 +463,11 @@ export interface CloudflareIntegrations extends Describable {
  * thread's reply door — it derives the counterpart, \`Re:\` subject, threading
  * headers, and the thread's \`<slug>+t<threadId>@…\` Reply-To address from the
  * thread stream, so agents never assemble threading by hand.
+ *
+ * \`send\` from ANY agent scope (Slack, web chat, …) binds the conversation to
+ * the calling agent: the outgoing Reply-To carries a thread token routed to
+ * that agent's own stream, so the human's replies arrive as the agent's
+ * inputs and \`reply\` continues the conversation from there.
  */
 /**
  * One outbound email attachment: either a stored project file addressed by
@@ -506,9 +511,10 @@ export interface EmailCapability extends Describable {
     attachments?: EmailAttachmentInput[];
   }): Promise<{ from: string; messageId: string | null }>;
   /**
-   * Reply within this email thread (email agent scopes only). Sends to the
-   * thread counterpart with correct subject and threading headers derived
-   * from the thread stream. At least one of text/html is required.
+   * Reply within this agent's email conversation — an email thread agent, or
+   * any agent scope whose \`send\` bound a thread. Sends to the latest
+   * counterpart with correct subject and threading headers derived from the
+   * agent's stream. At least one of text/html is required.
    */
   reply(input: {
     text?: string;

--- a/apps/os/src/types.ts
+++ b/apps/os/src/types.ts
@@ -458,6 +458,11 @@ export interface CloudflareIntegrations extends Describable {
  * thread's reply door — it derives the counterpart, `Re:` subject, threading
  * headers, and the thread's `<slug>+t<threadId>@…` Reply-To address from the
  * thread stream, so agents never assemble threading by hand.
+ *
+ * `send` from ANY agent scope (Slack, web chat, …) binds the conversation to
+ * the calling agent: the outgoing Reply-To carries a thread token routed to
+ * that agent's own stream, so the human's replies arrive as the agent's
+ * inputs and `reply` continues the conversation from there.
  */
 /**
  * One outbound email attachment: either a stored project file addressed by
@@ -501,9 +506,10 @@ export interface EmailCapability extends Describable {
     attachments?: EmailAttachmentInput[];
   }): Promise<{ from: string; messageId: string | null }>;
   /**
-   * Reply within this email thread (email agent scopes only). Sends to the
-   * thread counterpart with correct subject and threading headers derived
-   * from the thread stream. At least one of text/html is required.
+   * Reply within this agent's email conversation — an email thread agent, or
+   * any agent scope whose `send` bound a thread. Sends to the latest
+   * counterpart with correct subject and threading headers derived from the
+   * agent's stream. At least one of text/html is required.
    */
   reply(input: {
     text?: string;


### PR DESCRIPTION
Follow-up to #1711, closing the "normal agent" gap found during prd e2e testing: a Slack/web-chat/any agent could SEND email (`itx.email.send`), but replies to that mail spawned a brand-new disconnected `/agents/email/t<n>` agent instead of returning to the sender.

## What changes

`itx.email.send` from ANY agent scope now binds the conversation to the calling agent, before the mail leaves (all appends durable + idempotent):

1. `email/thread-route-configured` on `/integrations/email` with `streamPath` = **the calling agent's own path** — the router already forwards to arbitrary stream paths, so replies (via the `+t` Reply-To token, or headers-only to the bare project address through the sent-Message-ID index) land on the sender's stream.
2. The same route event on the agent's own stream — thread context for the transcriber and for `reply`'s thread lookup.
3. The `email-agent` processor subscription on the agent's stream — non-email agents gain the transcriber that turns forwarded replies into `agent/input-added` (email thread agents had it from birth; identical idempotency key dedupes).
4. The outgoing `Reply-To` defaults to the thread token address; the `email/sent` audit fact carries `threadId` so the outbound Message-ID is indexed.

`email.reply` correspondingly works from any bound agent scope (it reads the thread off the agent's own stream) instead of requiring an `/agents/email/t<id>` path. Repeated sends from one agent reuse its bound thread — the agent is the conversation container.

Project-scoped (non-agent) sends are unchanged: plain one-way mail.

```js
// From a Slack thread agent:
await itx.email.send({ to: "customer@example.com", subject: "Your report", text: "Attached!", attachments: [{ path: "/reports/q2.pdf" }] });
// customer replies from their inbox → arrives as THIS Slack agent's next input
await itx.email.reply({ text: "Glad it helped!" });

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes durable routing, stream subscriptions, and reply targeting for agent email—incorrect binding could misroute customer replies or duplicate threads, though idempotent events and existing router behavior limit blast radius.
> 
> **Overview**
> **Agent-scoped outbound email** now treats the sending agent as the conversation home instead of spawning a separate `/agents/email/t<n>` thread when someone replies.
> 
> Before mail leaves, `#bindOutboundThreadToAgent` writes idempotent `thread-route-configured` events on `/integrations/email` and the agent stream (with `streamPath` = that agent), ensures the **email-agent** processor is subscribed on non-email agents, sets default **Reply-To** to the `+t<threadId>` address, and records **`threadId` on `email/sent`** for header-based routing. New agent-initiated thread ids come from **`mintOutboundEmailThreadId()`** (`a` + random hex); repeats reuse the latest route on the agent stream.
> 
> **`email.reply`** resolves the thread from the email agent path or that same route lookup, so Slack/web-chat agents can continue the thread. Project-scoped sends stay one-way. Contract/docs and a router test cover `+t` and In-Reply-To replies landing on the sender without minting `/agents/email/*` streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e66f7280cb67376159ff401bad91e5d6ccb6ccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +128 -9 | +85 -6 🟩🟩🟩🟩🟩 |
| Tests | +53 -0 | +44 -0 🟩🟩⬜⬜⬜ |
| Generated | +9 -3 | +9 -3 🟩⬜⬜⬜⬜ |
| **Total** | **+190 -12** | **+138 -9** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 7625712 and 0e66f72, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-07T21:13:58.863Z",
      "headSha": "0e66f7280cb67376159ff401bad91e5d6ccb6ccf",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/259940134587417",
      "shortSha": "0e66f72",
      "cleanupDurationMs": 3146,
      "deployDurationMs": 158173
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-07T21:13:58.653Z",
      "headSha": "0e66f7280cb67376159ff401bad91e5d6ccb6ccf",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/259940134587417",
      "shortSha": "0e66f72",
      "cleanupDurationMs": 2933,
      "deployDurationMs": 24424
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `0e66f72` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 24.4s |  |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/259940134587417) | 2026-07-07T21:13:58.653Z | Preview app released. |
| OS | released | `0e66f72` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 158.2s |  |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/259940134587417) | 2026-07-07T21:13:58.863Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->