### PR TITLE
fix(os): recover orphaned openai-ws LLM requests + per-request deadline

### DIFF
--- a/apps/os/src/domains/agents/agent-processors.test.ts
+++ b/apps/os/src/domains/agents/agent-processors.test.ts
@@ -914,6 +914,71 @@ describe("minimal web-chat agent processors", () => {
       expect.arrayContaining(["events.iterate.com/agent/output-added"]),
     );
   });
+
+  it("fails orphaned requests a dead incarnation left behind (recovery sweep)", async () => {
+    // Regression for the 2026-07-07 prd email-thread wedge: an incarnation
+    // accepted a request (runInBackground advanced the checkpoint), got
+    // evicted before completing it, and the agent queued every later input
+    // behind the never-completing request forever.
+    const stream = new MemoryStream();
+    // Incarnation 1: accepted the request and appended started, then died —
+    // simulated by writing the events directly, never running a processor.
+    const [requested] = await stream.append({
+      type: "events.iterate.com/agent/llm-request-requested",
+      payload: { model: "gpt-test", provider: "openai-ws", requestId: "llm-request:gen-1" },
+    });
+    await stream.append({
+      type: "events.iterate.com/openai-ws/llm-request-started",
+      payload: { llmRequestId: requested!.offset, model: "gpt-test" },
+    });
+
+    // Incarnation 2: fresh processor (empty #liveExecutions), catching up.
+    const openAiWs = new OpenAiWsProcessor({
+      stream,
+      apiKey: "sk-test",
+      createResponsesWebSocketClient: async () => {
+        throw new Error("should not dial during orphan recovery");
+      },
+      readStreamEvents: () => stream.getEvents(),
+    });
+    // Deliver only the STARTED event (the requested event is before the
+    // checkpoint of a caught-up-but-restarted instance in the real incident;
+    // any batch works — the sweep reads folded state, not the batch).
+    await openAiWs.ingest({
+      events: stream.events.filter((event) => event.offset > requested!.offset),
+      streamMaxOffset: stream.events.length,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const completions = stream.events.filter(
+      (event) => event.type === "events.iterate.com/agent/llm-request-completed",
+    );
+    expect(completions).toHaveLength(1);
+    expect(completions[0]!.payload).toMatchObject({
+      llmRequestId: requested!.offset,
+      provider: "openai-ws",
+      result: { status: "failure", error: { message: expect.stringContaining("orphaned") } },
+    });
+
+    // A LIVE request in this incarnation is never swept: accept a new request
+    // (execution registers synchronously) and deliver the batch — no failure
+    // completion appears for it while it runs.
+    const [second] = await stream.append({
+      type: "events.iterate.com/agent/llm-request-requested",
+      payload: { model: "gpt-test", provider: "openai-ws", requestId: "llm-request:gen-2" },
+    });
+    await openAiWs.ingest({
+      events: [second!],
+      streamMaxOffset: stream.events.length,
+    });
+    const sweptSecond = stream.events.filter(
+      (event) =>
+        event.type === "events.iterate.com/agent/llm-request-completed" &&
+        (event.payload as { llmRequestId: number }).llmRequestId === second!.offset &&
+        JSON.stringify(event.payload).includes("orphaned"),
+    );
+    expect(sweptSecond).toHaveLength(0);
+  });
 });
 
 describe("file attachments in the LLM request", () => {

--- a/apps/os/src/domains/agents/openai-ws-processor-contract.ts
+++ b/apps/os/src/domains/agents/openai-ws-processor-contract.ts
@@ -10,8 +10,15 @@ export const OpenAiWsProcessorContract = defineProcessorContract({
   version: "0.1.0",
   description: "Runs agent LLM requests through OpenAI Responses WebSocket mode.",
   stateSchema: z.object({
+    /**
+     * Per-request lifecycle fold. "requested" is set from the agent's
+     * llm-request-requested (this provider only) BEFORE any execution work, so
+     * a request the executing incarnation died on — between accepting it and
+     * appending its completion — is visible as an orphan to the next
+     * incarnation's recovery sweep (see recoverOrphanedRequests).
+     */
     requests: z
-      .record(z.string(), z.object({ status: z.enum(["started", "completed"]) }))
+      .record(z.string(), z.object({ status: z.enum(["requested", "started", "completed"]) }))
       .default({}),
   }),
   events: {

--- a/apps/os/src/domains/agents/openai-ws-processor-implementation.ts
+++ b/apps/os/src/domains/agents/openai-ws-processor-implementation.ts
@@ -57,6 +57,10 @@ const OpenAiWebSocketReadyState = {
   Open: 1,
 } as const;
 
+/** Hard wall-clock cap per response (see #withRequestDeadline). Generous —
+ * long reasoning turns are minutes, not tens of minutes. */
+const OPENAI_WS_REQUEST_DEADLINE_MS = 10 * 60_000;
+
 export class OpenAiWsProcessor extends StreamProcessor<
   typeof OpenAiWsProcessorContract,
   {
@@ -83,11 +87,30 @@ export class OpenAiWsProcessor extends StreamProcessor<
    */
   #executionChain: Promise<unknown> = Promise.resolve();
 
+  /**
+   * llmRequestIds with an execution alive in THIS incarnation. A request the
+   * durable fold shows incomplete but that no live execution owns was
+   * orphaned — the incarnation running it was evicted (deploy, hibernation)
+   * or its socket wedged past the deadline — and must be failed, or it
+   * occupies the agent's currentRequest forever and every later input queues
+   * behind it (the 2026-07-07 prd email-thread wedge).
+   */
+  readonly #liveExecutions = new Set<number>();
+
   protected override reduce({
     event,
     state,
   }: Parameters<StreamProcessor<typeof OpenAiWsProcessorContract>["reduce"]>[0]) {
     switch (event.type) {
+      case "events.iterate.com/agent/llm-request-requested": {
+        if (event.payload.provider !== OpenAiWsProcessorContract.slug) return state;
+        const key = String(event.offset);
+        if (state.requests[key]?.status === "completed") return state;
+        return {
+          ...state,
+          requests: { ...state.requests, [key]: { status: "requested" as const } },
+        };
+      }
       case "events.iterate.com/openai-ws/llm-request-started":
         return {
           ...state,
@@ -118,9 +141,50 @@ export class OpenAiWsProcessor extends StreamProcessor<
     if (event.payload.provider !== OpenAiWsProcessorContract.slug) return;
     const llmRequestId = event.offset;
     if (state.requests[String(llmRequestId)]?.status === "completed") return;
+    // Registered synchronously, before any await: the same batch's orphan
+    // sweep must see this request as live.
+    this.#liveExecutions.add(llmRequestId);
     const execution = this.#executionChain.then(() => this.#executeRequest({ event }));
     this.#executionChain = execution.catch(() => undefined);
     runInBackground(() => execution);
+  }
+
+  /**
+   * After every batch: fail requests the durable fold shows incomplete but
+   * that no execution in THIS incarnation owns. Such a request's executing
+   * incarnation is gone (eviction mid-request advances the checkpoint —
+   * executions are runInBackground — so the requested event never redelivers)
+   * and nothing else will ever complete it; without this sweep it occupies
+   * the agent's currentRequest forever and every later input queues behind
+   * it. The failure completions use the exact idempotency keys of the normal
+   * completion path, so any race resolves to one durable outcome.
+   */
+  protected override async processEventBatch(
+    args: Parameters<StreamProcessor<typeof OpenAiWsProcessorContract>["processEventBatch"]>[0],
+  ): Promise<void> {
+    await super.processEventBatch(args);
+    const orphaned = Object.entries(args.state.requests)
+      .filter(
+        ([id, request]) => request.status !== "completed" && !this.#liveExecutions.has(Number(id)),
+      )
+      .map(([id]) => Number(id));
+    if (orphaned.length === 0) return;
+    args.blockProcessorWhile(async () => {
+      for (const llmRequestId of orphaned) {
+        console.error("[openai-ws] failing orphaned llm request", { llmRequestId });
+        await this.#appendCompletion({
+          llmRequestId,
+          durationMs: 0,
+          result: {
+            status: "failure" as const,
+            error: {
+              message:
+                "LLM request orphaned: the incarnation executing it went away before completing (eviction or wedged socket). Failed by the recovery sweep; the agent's next trigger reschedules.",
+            },
+          },
+        });
+      }
+    });
   }
 
   async #executeRequest(input: { event: LlmRequestRequestedEvent }): Promise<void> {
@@ -148,24 +212,28 @@ export class OpenAiWsProcessor extends StreamProcessor<
       const attemptedPreviousResponseId = this.#previousResponseId;
       let completion;
       try {
-        completion = await this.#createAndConsumeResponse({
-          messages: body.messages,
-          model,
-          previousResponseId: attemptedPreviousResponseId,
-          sourceEvent: input.event,
-        });
+        completion = await this.#withRequestDeadline(
+          this.#createAndConsumeResponse({
+            messages: body.messages,
+            model,
+            previousResponseId: attemptedPreviousResponseId,
+            sourceEvent: input.event,
+          }),
+        );
       } catch (error) {
         if (attemptedPreviousResponseId === null || !isPreviousResponseNotFoundError(error)) {
           throw error;
         }
         this.#previousResponseId = null;
-        completion = await this.#createAndConsumeResponse({
-          idempotencyScope: `retry-without-previous-response:${attemptedPreviousResponseId}`,
-          messages: body.messages,
-          model,
-          previousResponseId: null,
-          sourceEvent: input.event,
-        });
+        completion = await this.#withRequestDeadline(
+          this.#createAndConsumeResponse({
+            idempotencyScope: `retry-without-previous-response:${attemptedPreviousResponseId}`,
+            messages: body.messages,
+            model,
+            previousResponseId: null,
+            sourceEvent: input.event,
+          }),
+        );
       }
       const durationMs = Date.now() - startedAt;
       const providerResult = {
@@ -183,54 +251,77 @@ export class OpenAiWsProcessor extends StreamProcessor<
         if (completion.responseId !== undefined) this.#previousResponseId = completion.responseId;
       }
 
-      await this.stream.append(
-        {
-          type: "events.iterate.com/openai-ws/llm-request-completed",
-          idempotencyKey: `openai-ws/provider-completed@${llmRequestId}`,
-          payload: {
-            durationMs,
-            llmRequestId,
-            result: providerResult,
-          },
-        },
-        {
-          type: "events.iterate.com/agent/llm-request-completed",
-          idempotencyKey: `openai-ws/agent-completed@${llmRequestId}`,
-          payload: {
-            durationMs,
-            llmRequestId,
-            provider: "openai-ws",
-            result: providerResult,
-          },
-        },
-      );
+      await this.#appendCompletion({ durationMs, llmRequestId, result: providerResult });
     } catch (error) {
-      const durationMs = Date.now() - startedAt;
-      const failure = {
-        status: "failure" as const,
-        error: { message: stringifyError(error) },
-      };
-      await this.stream.append(
-        {
-          type: "events.iterate.com/openai-ws/llm-request-completed",
-          idempotencyKey: `openai-ws/provider-completed@${llmRequestId}`,
-          payload: {
-            durationMs,
-            llmRequestId,
-            result: failure,
-          },
+      await this.#appendCompletion({
+        durationMs: Date.now() - startedAt,
+        llmRequestId,
+        result: {
+          status: "failure" as const,
+          error: { message: stringifyError(error) },
         },
-        {
-          type: "events.iterate.com/agent/llm-request-completed",
-          idempotencyKey: `openai-ws/agent-completed@${llmRequestId}`,
-          payload: {
-            durationMs,
-            llmRequestId,
-            provider: "openai-ws",
-            result: failure,
-          },
+      });
+    } finally {
+      this.#liveExecutions.delete(llmRequestId);
+    }
+  }
+
+  /** The one durable outcome of a request — provider + agent completion pair.
+   * Success, in-execution failure, and the orphan sweep all land here with
+   * identical idempotency keys, so races collapse at the append dedup layer. */
+  async #appendCompletion(input: {
+    durationMs: number;
+    llmRequestId: number;
+    result:
+      | { status: "success"; rawResponse?: unknown; usage?: unknown }
+      | { status: "failure"; error: { message: string }; rawResponse?: unknown };
+  }): Promise<void> {
+    await this.stream.append(
+      {
+        type: "events.iterate.com/openai-ws/llm-request-completed",
+        idempotencyKey: `openai-ws/provider-completed@${input.llmRequestId}`,
+        payload: {
+          durationMs: input.durationMs,
+          llmRequestId: input.llmRequestId,
+          result: input.result,
         },
-      );
+      },
+      {
+        type: "events.iterate.com/agent/llm-request-completed",
+        idempotencyKey: `openai-ws/agent-completed@${input.llmRequestId}`,
+        payload: {
+          durationMs: input.durationMs,
+          llmRequestId: input.llmRequestId,
+          provider: "openai-ws",
+          result: input.result,
+        },
+      },
+    );
+  }
+
+  /**
+   * Hard cap on one response's wall clock. A Responses WebSocket that stops
+   * yielding frames would otherwise hang the execution forever (the DO stays
+   * alive on keepAlive, nothing completes, the agent wedges). On timeout the
+   * connection is dropped so the next request opens a fresh socket instead of
+   * inheriting the wedged one.
+   */
+  async #withRequestDeadline<T>(work: Promise<T>): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        this.#connection = null;
+        reject(
+          new Error(
+            `OpenAI request exceeded the ${OPENAI_WS_REQUEST_DEADLINE_MS / 1000}s deadline; dropping the socket.`,
+          ),
+        );
+      }, OPENAI_WS_REQUEST_DEADLINE_MS);
+    });
+    try {
+      return await Promise.race([work, deadline]);
+    } finally {
+      clearTimeout(timer);
     }
   }
 


### PR DESCRIPTION
Fixes the live prd wedge on the nustom email thread (t42): an incarnation accepted an LLM request — `runInBackground` advances the checkpoint, so the requested event never redelivers — then was evicted before completing it. Nothing ever fails such a request, so the agent's `currentRequest` stays occupied forever and **every later input queues behind it**. The thread went silent mid-conversation.

Two layers in the openai-ws provider processor:

1. **Orphan sweep after every batch.** The durable fold now tracks `requested` (set from the agent's `llm-request-requested`, this provider only) alongside `started`/`completed`. Any incomplete request with no live execution in the current incarnation (in-memory `#liveExecutions`, registered synchronously at accept time) gets a failure completion. Failure completions use the *normal completion path's idempotency keys*, so any race collapses to one durable outcome. The agent's next trigger then reschedules cleanly.
2. **10-minute hard deadline per response consume.** A Responses WebSocket that stops yielding frames now fails the request and drops the socket (fresh connection next request), instead of hanging the execution chain until eviction converts it into case 1.

Regression test simulates the incident: incarnation 1 writes requested+started and dies; a fresh processor's first batch sweeps the orphan into a failure completion, while a request accepted by the live incarnation is never swept.

The sibling cloudflare-ai processor has the same structural exposure (single AI.run call is platform-bounded, but eviction mid-run orphans identically) — follow-up candidate; this PR fixes the provider prd runs on.

Also relevant: the state-fold enum gains `"requested"` — old snapshots parse unchanged (values widen only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent LLM completion paths and post-batch side effects; behavior is guarded by idempotent completions and a targeted regression test, but incorrect sweeping could fail in-flight requests.
> 
> **Overview**
> Fixes agent threads that **stall forever** when an OpenAI WebSocket provider incarnation accepts an LLM request, advances the checkpoint via `runInBackground`, then dies before emitting a completion—later inputs stay queued behind a never-clearing `currentRequest`.
> 
> **Orphan recovery:** Durable fold now records **`requested`** (from `llm-request-requested`) in addition to `started`/`completed`. After each batch, incomplete requests with no entry in in-memory `#liveExecutions` get failure completions via shared `#appendCompletion` (same idempotency keys as normal success/failure). Live accepts register in `#liveExecutions` synchronously before any `await` so the same batch’s sweep does not fail them.
> 
> **Hang protection:** Response consumption is wrapped in a **10-minute** `#withRequestDeadline`; on timeout the cached socket is cleared so the next request dials fresh.
> 
> Regression test covers dead-incarnation orphan sweep vs. in-flight request not swept.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c0604be7ab69ec6913cc957d14acdf90e82a3e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +157 -59 | +113 -59 🟩🟩🟩🟥🟥 |
| Tests | +65 -0 | +48 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+222 -59** | **+161 -59** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between c93c571 and 0c0604b, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->