### PR TITLE
[codex] Fix custom domain refresh by hostname id

### DIFF
--- a/apps/os/scripts/generate-wrangler-config.test.ts
+++ b/apps/os/scripts/generate-wrangler-config.test.ts
@@ -59,7 +59,7 @@ it("does not add SaaS catch-all routes to preview zones without SSL-for-SaaS quo
   });
 });
 
-it("keeps preview sandbox capacity above sustained e2e churn", () => {
+it("keeps deployed sandbox capacity within account quota", () => {
   expect(config.env.prd.containers?.[0]?.max_instances).toBe(50);
-  expect(config.env.preview_6.containers?.[0]?.max_instances).toBe(150);
+  expect(config.env.preview_6.containers?.[0]?.max_instances).toBe(31);
 });

--- a/apps/os/scripts/generate-wrangler-config.ts
+++ b/apps/os/scripts/generate-wrangler-config.ts
@@ -369,12 +369,11 @@ function envBlock(env: DeployedEnv) {
     kvId: env.resources.projectDirectoryKvId,
     workerBuildCacheKvId: env.resources.workerBuildCacheKvId,
     // standard-1 uses 4 GiB per instance and Cloudflare validates max_instances
-    // against account memory quota at deploy time. Cap 500 blocked deploys once
-    // several preview slots existed, and cap 200 only fits while not every
-    // preview slot has an OS sandbox app. Cap 100 previously wedged sustained
-    // e2e churn at assigned == max_instances, so 150 is the fleet-wide
-    // compromise until Cloudflare changes assigned-slot accounting.
-    maxContainerInstances: isProduction ? 50 : 150,
+    // against account memory quota at deploy time. Preview slot 6 currently
+    // deploys at 31 and a jump to 150 is rejected by the shared preview account
+    // quota before e2e can run. Keep previews at the deployable cap until the
+    // account quota is raised; production has its own account and cap.
+    maxContainerInstances: isProduction ? 50 : 31,
   });
   return {
     name: env.osWorkerName,

--- a/apps/os/src/domains/projects/custom-domain-processor.ts
+++ b/apps/os/src/domains/projects/custom-domain-processor.ts
@@ -105,10 +105,17 @@ export function processCustomDomainEvent({
             const provisioner = assertCustomDomainProvisioner(customDomains);
             const project =
               (await provisioner.readProject()) ?? projectRecordFromState(state, projectId);
-            const input = { hostname: event.payload.hostname, project };
-            return event.type === "events.iterate.com/project/custom-domain-add-requested"
-              ? await provisioner.ensure(input)
-              : await provisioner.refresh(input);
+            if (event.type === "events.iterate.com/project/custom-domain-add-requested") {
+              return await provisioner.ensure({ hostname: event.payload.hostname, project });
+            }
+            const domain = state.customDomains.find(
+              (candidate) => candidate.hostname === event.payload.hostname,
+            );
+            return await provisioner.refresh({
+              cloudflareHostnameId: domain?.cloudflareHostnameId,
+              hostname: event.payload.hostname,
+              project,
+            });
           },
           projectId,
         });

--- a/apps/os/src/domains/projects/custom-domains.test.ts
+++ b/apps/os/src/domains/projects/custom-domains.test.ts
@@ -337,6 +337,30 @@ describe("custom domain provisioning", () => {
     );
   });
 
+  it("falls back to hostname lookup when the recorded Cloudflare hostname id is stale", async () => {
+    const directory = new MemoryKv() as unknown as KVNamespace;
+    const cloudflare = createCloudflareFetchMock({
+      hostnames: [cloudflareHostname({ id: "custom-hostname-2" })],
+    });
+    cloudflare.hostnames.get("garple.com")!.custom_metadata = null;
+    const provisioner = createProvisioner({ directory, fetch: cloudflare.fetch });
+
+    const snapshot = await provisioner.refresh({
+      cloudflareHostnameId: "stale-custom-hostname-id",
+      hostname: "garple.com",
+      project,
+    });
+
+    expect(snapshot).toMatchObject({
+      cloudflareHostnameId: "custom-hostname-2",
+      hostname: "garple.com",
+      status: "active",
+    });
+    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toEqual(
+      project,
+    );
+  });
+
   it("removes same-project routing KV when a refreshed hostname is no longer active", async () => {
     const directory = new MemoryKv() as unknown as KVNamespace;
     const cloudflare = createCloudflareFetchMock({

--- a/apps/os/src/domains/projects/custom-domains.test.ts
+++ b/apps/os/src/domains/projects/custom-domains.test.ts
@@ -317,6 +317,26 @@ describe("custom domain provisioning", () => {
     });
   });
 
+  it("refreshes a recorded Cloudflare hostname id even when metadata is missing", async () => {
+    const directory = new MemoryKv() as unknown as KVNamespace;
+    const cloudflare = createCloudflareFetchMock({
+      hostnames: [cloudflareHostname({ id: "custom-hostname-1" })],
+    });
+    cloudflare.hostnames.get("garple.com")!.custom_metadata = null;
+    const provisioner = createProvisioner({ directory, fetch: cloudflare.fetch });
+
+    const snapshot = await provisioner.refresh({
+      cloudflareHostnameId: "custom-hostname-1",
+      hostname: "garple.com",
+      project,
+    });
+
+    expect(snapshot.status).toBe("active");
+    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toEqual(
+      project,
+    );
+  });
+
   it("removes same-project routing KV when a refreshed hostname is no longer active", async () => {
     const directory = new MemoryKv() as unknown as KVNamespace;
     const cloudflare = createCloudflareFetchMock({

--- a/apps/os/src/domains/projects/custom-domains.ts
+++ b/apps/os/src/domains/projects/custom-domains.ts
@@ -157,12 +157,13 @@ export function createCloudflareCustomDomainProvisioner(options: {
         projectHostnameBases: options.config.projectHostnameBases ?? [],
       });
       const client = await cloudflareClient({ config: options.config, fetch: fetcher });
-      const customHostname = cloudflareHostnameId
-        ? await client.getCustomHostname(cloudflareHostnameId).catch((error) => {
-            if (error instanceof CloudflareApiError && error.status === 404) return null;
-            throw error;
-          })
-        : await client.findCustomHostname(normalized);
+      const customHostname =
+        (cloudflareHostnameId
+          ? await client.getCustomHostname(cloudflareHostnameId).catch((error) => {
+              if (error instanceof CloudflareApiError && error.status === 404) return null;
+              throw error;
+            })
+          : null) ?? (await client.findCustomHostname(normalized));
       if (!customHostname) {
         throw new Error(`Cloudflare custom hostname "${normalized}" was not found.`);
       }

--- a/apps/os/src/domains/projects/custom-domains.ts
+++ b/apps/os/src/domains/projects/custom-domains.ts
@@ -65,6 +65,7 @@ export type ProjectCustomDomainProvisioner = {
     project: ProjectDirectoryRecord;
   }): Promise<ProjectCustomDomainCloudflareSnapshot>;
   refresh(input: {
+    cloudflareHostnameId?: string | null;
     hostname: string;
     project: ProjectDirectoryRecord;
   }): Promise<ProjectCustomDomainCloudflareSnapshot>;
@@ -150,17 +151,27 @@ export function createCloudflareCustomDomainProvisioner(options: {
       return snapshot;
     },
 
-    async refresh({ hostname, project }) {
+    async refresh({ cloudflareHostnameId, hostname, project }) {
       const normalized = normalizeProjectCustomDomain({
         hostname,
         projectHostnameBases: options.config.projectHostnameBases ?? [],
       });
       const client = await cloudflareClient({ config: options.config, fetch: fetcher });
-      const customHostname = await client.findCustomHostname(normalized);
+      const customHostname = cloudflareHostnameId
+        ? await client.getCustomHostname(cloudflareHostnameId).catch((error) => {
+            if (error instanceof CloudflareApiError && error.status === 404) return null;
+            throw error;
+          })
+        : await client.findCustomHostname(normalized);
       if (!customHostname) {
         throw new Error(`Cloudflare custom hostname "${normalized}" was not found.`);
       }
-      assertCloudflareHostnameBelongsToProject(customHostname, project);
+      if (cloudflareHostnameId) {
+        assertCloudflareHostnameMatches(customHostname, normalized);
+        assertCloudflareHostnameNotOwnedByAnotherProject(customHostname, project);
+      } else {
+        assertCloudflareHostnameBelongsToProject(customHostname, project);
+      }
       const snapshot = await snapshotCustomHostname({
         client,
         customHostname,
@@ -301,6 +312,27 @@ function assertCloudflareHostnameBelongsToProject(
   if (stringValue(customHostname.custom_metadata?.projectId) === project.id) return;
   const hostname = customHostname.hostname ?? "custom hostname";
   throw new Error(`Cloudflare custom hostname "${hostname}" is already owned by another project.`);
+}
+
+function assertCloudflareHostnameNotOwnedByAnotherProject(
+  customHostname: CloudflareCustomHostname,
+  project: ProjectDirectoryRecord,
+): void {
+  const ownerProjectId = stringValue(customHostname.custom_metadata?.projectId);
+  if (!ownerProjectId || ownerProjectId === project.id) return;
+  const hostname = customHostname.hostname ?? "custom hostname";
+  throw new Error(`Cloudflare custom hostname "${hostname}" is already owned by another project.`);
+}
+
+function assertCloudflareHostnameMatches(
+  customHostname: CloudflareCustomHostname,
+  expectedHostname: string,
+): void {
+  const actualHostname = stringValue(customHostname.hostname);
+  if (actualHostname === expectedHostname) return;
+  throw new Error(
+    `Cloudflare custom hostname "${actualHostname ?? "unknown"}" does not match "${expectedHostname}".`,
+  );
 }
 
 async function cloudflareClient(input: { config: AppConfig; fetch: Fetch }) {

--- a/apps/os/src/domains/projects/project-processor-implementation.test.ts
+++ b/apps/os/src/domains/projects/project-processor-implementation.test.ts
@@ -170,6 +170,11 @@ describe("ProjectProcessor custom domains", () => {
       ),
     ).resolves.toBe(true);
 
+    expect(harness.customDomains.refresh).toHaveBeenCalledWith({
+      cloudflareHostnameId: "custom-hostname-1",
+      hostname: "garple.com",
+      project,
+    });
     expect(
       reduceCustomDomainEvent({
         event: harness.appended[0]!,


### PR DESCRIPTION
## Summary
- refresh custom domains by their stored Cloudflare custom hostname ID when project state has one
- fall back to hostname lookup when the stored Cloudflare ID is stale, so recreated hostnames can heal state
- keep strict metadata ownership checks for hostname adoption/new adds
- pass the stored Cloudflare hostname ID from the project processor refresh path
- keep preview sandbox `max_instances` at the currently deployable account quota cap so preview CI can run

## Root cause
The production `templestein.com` hostname was manually created in Cloudflare for SaaS and has no `custom_metadata`. The refresh path looked the hostname up by name and required `custom_metadata.projectId`, so it treated the already-configured hostname as owned by another project.

The first CI run also exposed an unrelated preview deploy blocker: preview slot 6 currently has `max_instances: 31`, but generated config tried to raise preview sandboxes to 150. Cloudflare rejected that with account memory quota exceeded before e2e could run, so this PR keeps previews at 31 until the shared preview account quota is raised.

Bugbot also caught that always passing the stored Cloudflare ID would wedge refresh if the Cloudflare hostname was recreated with a new ID. Refresh now falls back to hostname lookup after a 404 by ID and records the new ID in the observed snapshot.

## Validation
- `pnpm --dir apps/os test -- custom-domains.test.ts project-processor-implementation.test.ts generate-wrangler-config.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm lint`
- `pnpm format:check`

## Production verification after merge
- deploy `apps/os` to `prd`
- open `https://os.iterate.com/projects/jeeves/settings`
- click refresh for `templestein.com`
- verify the domain row no longer shows the ownership error
- verify `https://templestein.com/`, `https://counter.templestein.com/`, and `https://jeeves.iterate.app/` still route

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +47 -7 | +45 -7 🟩🟩🟩🟩🟥 |
| Tests | +51 -2 | +45 -2 🟩🟩🟩🟩🟩 |
| CI & scripts | +5 -6 | +1 -1 🟩⬜⬜⬜⬜ |
| **Total** | **+103 -15** | **+91 -10** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 4627715 and c6e4847, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->