### PR TITLE
Reclaiming a preview slot always erases its data first

### DIFF
--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -353,7 +353,19 @@ Opening/pushing a PR that touches preview-relevant paths triggers the
 records the slot, per-app URLs and statuses; the workflow logs narrate every
 decision (which apps were selected and why, lease transitions, slot waits).
 Closing or merging the PR runs `pnpm preview cleanup`, which destroys the
-PR's apps and releases the slot — after verifying the PR still holds it.
+PR's apps (for os that means erasing the slot's data — auth D1 and
+project-directory KV) and releases the slot — after verifying the PR still
+holds it.
+
+Slot cleanliness is an **invariant of entry**, not a promise about exits:
+every handover — a fresh acquire, an adopted lease, a reclaim, an
+`assign`ed slot — erases the slot's data before the new holder gets it. So
+even when an exit path skips the cleanup erase (failed cleanup followed by
+lease expiry, `release --force`, a run cancelled mid-claim), the next tenant
+never sees the previous one's data; they just pay the ~half-minute wipe on
+their first deploy to that slot. The one deliberate exception is manual
+`preview acquire` (Story 4): it parks a slot without wiping it, so you can
+lease a slot precisely to inspect what's on it.
 
 ### Story 2: run what CI runs, locally
 
@@ -411,7 +423,8 @@ doppler run --project _shared --config prd -- pnpm preview acquire --slot 9    #
 doppler run --project os --config preview_9 -- pnpm auth:mint --admin --browser-url
 
 # Release when done. Workers/routes/DNS stay deployed — releasing a slot is
-# just giving the lease back; erase the data only if you want a clean slate:
+# just giving the lease back. You don't need to erase: the slot's next
+# holder erases on entry. Do it yourself only if the data shouldn't linger:
 (cd apps/os && pnpm erase-data --env preview_9)  # optional
 doppler run --project _shared --config prd -- pnpm preview release --slot 9 --lease-id <leaseId>
 ```
@@ -441,11 +454,18 @@ doppler run --project _shared --config prd -- pnpm preview reclaim --slot 4   # 
 doppler run --project _shared --config prd -- pnpm preview reconcile  # leases vs Doppler configs vs Cloudflare zones
 ```
 
+`reclaim --slot` takes the slot under a temporary lease of its own, **erases
+its data**, then returns it to the pool clean — the previous holder's
+projects, agents and schedules are gone, which is the point. If the erase
+fails, the temporary lease stays in place (the slot shows as held by
+`reclaim-<you>`) rather than a dirty slot going back in the pool.
+
 Orphaned leases are also garbage-collected automatically: when `preview
 deploy` finds every slot taken, it checks each `pr-N` holder against GitHub
-and reclaims a slot whose PR is closed before queueing. That is the **only**
-case automation takes a live lease — idle-but-open and manual holds always
-need a human running `reclaim --slot` / `--force`.
+and reclaims a slot whose PR is closed before queueing (erasing it on
+handover, like every acquire). That is the **only** case automation takes a
+live lease — idle-but-open and manual holds always need a human running
+`reclaim --slot` / `--force`.
 
 `--force` (on `acquire`, `release`, and `reclaim`) is the only way to take an
 actively-used lease from its holder. Every eviction logs an

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -859,6 +859,10 @@ function fakeSemaphore(overrides: Record<string, unknown> = {}) {
   };
 }
 
+// Every acquire path must be able to erase a reclaimed slot; tests that
+// never reclaim share this inert eraser.
+const noopEraseSlotData = async () => {};
+
 const previousLease = EnvironmentConfigLease.parse({
   dopplerConfig: "preview_2",
   leasedUntil: 1_700_000_000_000,
@@ -874,6 +878,7 @@ describe("claimEnvironmentConfigLease", () => {
     });
 
     const lease = await claimEnvironmentConfigLease({
+      eraseSlotData: noopEraseSlotData,
       createPreviewSemaphoreResourceClient: () => semaphore,
       holder: "pr-1600",
       leaseMs: 1000,
@@ -895,6 +900,7 @@ describe("claimEnvironmentConfigLease", () => {
     });
 
     const lease = await claimEnvironmentConfigLease({
+      eraseSlotData: noopEraseSlotData,
       createPreviewSemaphoreResourceClient: () => semaphore,
       holder: "pr-1600",
       leaseMs: 1000,
@@ -932,6 +938,7 @@ describe("claimEnvironmentConfigLease", () => {
     });
 
     const lease = await claimEnvironmentConfigLease({
+      eraseSlotData: noopEraseSlotData,
       createPreviewSemaphoreResourceClient: () => semaphore,
       holder: "pr-1600",
       leaseMs: 1000,
@@ -966,6 +973,7 @@ describe("claimEnvironmentConfigLease", () => {
     });
 
     const lease = await claimEnvironmentConfigLease({
+      eraseSlotData: noopEraseSlotData,
       createPreviewSemaphoreResourceClient: () => semaphore,
       holder: "pr-1600",
       leaseMs: 1000,
@@ -989,6 +997,7 @@ describe("claimEnvironmentConfigLease", () => {
 
     await expect(
       claimEnvironmentConfigLease({
+        eraseSlotData: noopEraseSlotData,
         createPreviewSemaphoreResourceClient: () => semaphore,
         holder: "pr-1600",
         leaseMs: 1000,
@@ -1017,6 +1026,7 @@ describe("acquireAnyEnvironmentConfigLease", () => {
     const semaphore = fakeSemaphore({ acquire });
 
     const lease = await acquireAnyEnvironmentConfigLease({
+      eraseSlotData: noopEraseSlotData,
       semaphore,
       holder: "pr-1600",
       leaseMs: 1000,
@@ -1047,6 +1057,7 @@ describe("acquireAnyEnvironmentConfigLease", () => {
 
     await expect(
       acquireAnyEnvironmentConfigLease({
+        eraseSlotData: noopEraseSlotData,
         semaphore,
         holder: "pr-1600",
         leaseMs: 1000,
@@ -1064,6 +1075,7 @@ describe("acquireAnyEnvironmentConfigLease", () => {
 
     await expect(
       acquireAnyEnvironmentConfigLease({
+        eraseSlotData: noopEraseSlotData,
         semaphore,
         holder: "pr-1600",
         leaseMs: 1000,
@@ -1247,6 +1259,7 @@ describe("orphaned lease garbage collection during acquire", () => {
     });
 
     const lease = await acquireAnyEnvironmentConfigLease({
+      eraseSlotData: noopEraseSlotData,
       semaphore,
       fetchPullRequestState: async () => "closed",
       holder: "pr-1600",
@@ -1257,6 +1270,77 @@ describe("orphaned lease garbage collection during acquire", () => {
     expect(lease.slug).toBe("preview-2");
     expect(acquireSpecific).toHaveBeenCalledWith(
       expect.objectContaining({ slug: "preview-2", holder: "pr-1600", force: true }),
+    );
+  });
+
+  it("erases the reclaimed slot's data before handing it over", async () => {
+    // A reclaim only happens because the dead holder's cleanup — which erases
+    // on the way out — never ran, so the slot is dirty by definition.
+    const eraseSlotData = vi.fn(async () => {});
+    const semaphore = fakeSemaphore({
+      acquire: vi.fn(async () => {
+        throw conflictError();
+      }),
+      acquireSpecific: vi.fn(async (input: { slug: string }) =>
+        fakeLease({ slug: input.slug, data: { dopplerConfig: "preview_2" }, holder: "pr-1600" }),
+      ),
+      list: vi.fn(async () => [leasedResource("preview-2", "pr-1580")]),
+    });
+
+    const lease = await acquireAnyEnvironmentConfigLease({
+      eraseSlotData,
+      semaphore,
+      fetchPullRequestState: async () => "closed",
+      holder: "pr-1600",
+      leaseMs: 1000,
+      waitTotalMs: 0,
+    });
+
+    expect(lease.slug).toBe("preview-2");
+    expect(eraseSlotData).toHaveBeenCalledExactlyOnceWith({
+      dopplerConfig: "preview_2",
+      slug: "preview-2",
+    });
+  });
+
+  it("a failed erase releases the reclaimed lease instead of handing over a dirty slot", async () => {
+    const eraseSlotData = vi.fn(async () => {
+      throw new Error("doppler exploded");
+    });
+    const release = vi.fn(async () => ({ released: true }));
+    const semaphore = fakeSemaphore({
+      acquire: vi.fn(async () => {
+        throw conflictError();
+      }),
+      acquireSpecific: vi.fn(async (input: { slug: string }) =>
+        fakeLease({
+          slug: input.slug,
+          data: { dopplerConfig: "preview_2" },
+          holder: "pr-1600",
+          leaseId: "11111111-2222-3333-4444-555555555555",
+        }),
+      ),
+      list: vi.fn(async () => [leasedResource("preview-2", "pr-1580")]),
+      release,
+    });
+
+    await expect(
+      acquireAnyEnvironmentConfigLease({
+        eraseSlotData,
+        semaphore,
+        fetchPullRequestState: async () => "closed",
+        holder: "pr-1600",
+        leaseMs: 1000,
+        waitTotalMs: 0,
+      }),
+    ).rejects.toThrow(/No preview slot became available/);
+
+    expect(eraseSlotData).toHaveBeenCalled();
+    expect(release).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slug: "preview-2",
+        leaseId: "11111111-2222-3333-4444-555555555555",
+      }),
     );
   });
 
@@ -1275,6 +1359,7 @@ describe("orphaned lease garbage collection during acquire", () => {
 
     await expect(
       acquireAnyEnvironmentConfigLease({
+        eraseSlotData: noopEraseSlotData,
         semaphore,
         fetchPullRequestState: async () => "open",
         holder: "pr-1600",
@@ -1297,6 +1382,7 @@ describe("orphaned lease garbage collection during acquire", () => {
 
     await expect(
       acquireAnyEnvironmentConfigLease({
+        eraseSlotData: noopEraseSlotData,
         semaphore,
         holder: "pr-1600",
         leaseMs: 1000,
@@ -1316,6 +1402,7 @@ describe("assignEnvironmentConfigLease", () => {
     });
 
     const result = await assignEnvironmentConfigLease({
+      eraseSlotData: noopEraseSlotData,
       holder: "pr-1600",
       leaseMs: 1000,
       recordedLease: previousLease,
@@ -1335,6 +1422,7 @@ describe("assignEnvironmentConfigLease", () => {
     });
 
     const result = await assignEnvironmentConfigLease({
+      eraseSlotData: noopEraseSlotData,
       holder: "pr-1600",
       leaseMs: 1000,
       recordedLease: previousLease,
@@ -1361,6 +1449,7 @@ describe("assignEnvironmentConfigLease", () => {
     });
 
     const result = await assignEnvironmentConfigLease({
+      eraseSlotData: noopEraseSlotData,
       holder: "pr-1600",
       leaseMs: 1000,
       recordedLease: previousLease,
@@ -1399,6 +1488,7 @@ describe("assignEnvironmentConfigLease", () => {
     });
 
     const result = await assignEnvironmentConfigLease({
+      eraseSlotData: noopEraseSlotData,
       force: true,
       holder: "pr-1600",
       leaseMs: 1000,
@@ -1429,6 +1519,7 @@ describe("assignEnvironmentConfigLease", () => {
 
     await expect(
       assignEnvironmentConfigLease({
+        eraseSlotData: noopEraseSlotData,
         holder: "pr-1600",
         leaseMs: 1000,
         recordedLease: null,
@@ -1445,6 +1536,7 @@ describe("assignEnvironmentConfigLease", () => {
     const semaphore = fakeSemaphore({ acquireSpecific });
 
     const result = await assignEnvironmentConfigLease({
+      eraseSlotData: noopEraseSlotData,
       force: true,
       holder: "pr-1600",
       leaseMs: 1000,

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -988,6 +988,43 @@ describe("claimEnvironmentConfigLease", () => {
     expect(semaphore.acquire).not.toHaveBeenCalled();
   });
 
+  it("erases an adopted slot that is not the PR body's recorded one", async () => {
+    // The adopted lease exists precisely because a previous run died before
+    // recording it — possibly mid-erase — so its provenance is unknown.
+    const eraseSlotData = vi.fn(async () => {});
+    const semaphore = fakeSemaphore({
+      acquireSpecific: vi.fn(async () =>
+        fakeLease({ slug: "preview-3", data: { dopplerConfig: "preview_three" } }),
+      ),
+      list: vi.fn(async () => [
+        {
+          data: { dopplerConfig: "preview_three" },
+          holder: "pr-1600",
+          lastAcquiredAt: null,
+          lastReleasedAt: null,
+          leaseState: "leased" as const,
+          leasedUntil: Date.now() + 60_000,
+          slug: "preview-3",
+        },
+      ]),
+    });
+
+    const lease = await claimEnvironmentConfigLease({
+      eraseSlotData,
+      createPreviewSemaphoreResourceClient: () => semaphore,
+      holder: "pr-1600",
+      leaseMs: 1000,
+      previousEnvironmentConfigLease: null,
+      waitTotalMs: 0,
+    });
+
+    expect(lease.slug).toBe("preview-3");
+    expect(eraseSlotData).toHaveBeenCalledExactlyOnceWith({
+      dopplerConfig: "preview_three",
+      slug: "preview-3",
+    });
+  });
+
   it("propagates unexpected semaphore errors instead of silently switching slots", async () => {
     const semaphore = fakeSemaphore({
       renew: vi.fn(async () => {
@@ -1275,14 +1312,16 @@ describe("orphaned lease garbage collection during acquire", () => {
 
   it("erases the reclaimed slot's data before handing it over", async () => {
     // A reclaim only happens because the dead holder's cleanup — which erases
-    // on the way out — never ran, so the slot is dirty by definition.
+    // on the way out — never ran, so the slot is dirty by definition. The
+    // deliberately non-conventional dopplerConfig pins that the erase target
+    // comes from the LEASE's data payload, not derived from the slug.
     const eraseSlotData = vi.fn(async () => {});
     const semaphore = fakeSemaphore({
       acquire: vi.fn(async () => {
         throw conflictError();
       }),
       acquireSpecific: vi.fn(async (input: { slug: string }) =>
-        fakeLease({ slug: input.slug, data: { dopplerConfig: "preview_2" }, holder: "pr-1600" }),
+        fakeLease({ slug: input.slug, data: { dopplerConfig: "preview_two" }, holder: "pr-1600" }),
       ),
       list: vi.fn(async () => [leasedResource("preview-2", "pr-1580")]),
     });
@@ -1298,7 +1337,7 @@ describe("orphaned lease garbage collection during acquire", () => {
 
     expect(lease.slug).toBe("preview-2");
     expect(eraseSlotData).toHaveBeenCalledExactlyOnceWith({
-      dopplerConfig: "preview_2",
+      dopplerConfig: "preview_two",
       slug: "preview-2",
     });
   });
@@ -1333,7 +1372,7 @@ describe("orphaned lease garbage collection during acquire", () => {
         leaseMs: 1000,
         waitTotalMs: 0,
       }),
-    ).rejects.toThrow(/No preview slot became available/);
+    ).rejects.toThrow(/Could not hand pr-1600 a clean slot/);
 
     expect(eraseSlotData).toHaveBeenCalled();
     expect(release).toHaveBeenCalledWith(
@@ -1342,6 +1381,64 @@ describe("orphaned lease garbage collection during acquire", () => {
         leaseId: "11111111-2222-3333-4444-555555555555",
       }),
     );
+  });
+
+  it("retries after a failed erase until the slot comes back clean", async () => {
+    // The failure path gives the lease back and loops; the next take of the
+    // same slot re-runs the erase. One transient doppler hiccup must not
+    // wedge the claim — and a dirty slot must never be the thing returned.
+    const eraseSlotData = vi
+      .fn(async () => {})
+      .mockRejectedValueOnce(new Error("transient doppler hiccup"));
+    const release = vi.fn(async () => ({ released: true }));
+    const semaphore = fakeSemaphore({
+      acquire: vi.fn(async () => {
+        throw conflictError();
+      }),
+      acquireSpecific: vi.fn(async (input: { slug: string }) =>
+        fakeLease({ slug: input.slug, holder: "pr-1600" }),
+      ),
+      list: vi.fn(async () => [leasedResource("preview-2", "pr-1580")]),
+      release,
+    });
+
+    const lease = await acquireAnyEnvironmentConfigLease({
+      eraseSlotData,
+      semaphore,
+      fetchPullRequestState: async () => "closed",
+      holder: "pr-1600",
+      leaseMs: 1000,
+      waitTotalMs: 60_000,
+    });
+
+    expect(lease.slug).toBe("preview-2");
+    expect(eraseSlotData).toHaveBeenCalledTimes(2);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("erases a freshly acquired slot too — cleanliness is an entry invariant", async () => {
+    // Plain acquire (no reclaim involved) must erase as well: exit paths like
+    // lease expiry after a failed cleanup return dirty slots to the pool as
+    // plain "available", and this is what makes them harmless.
+    const eraseSlotData = vi.fn(async () => {});
+    const acquire = vi.fn(async () =>
+      fakeLease({ slug: "preview-7", data: { dopplerConfig: "preview_seven" } }),
+    );
+    const semaphore = fakeSemaphore({ acquire });
+
+    const lease = await acquireAnyEnvironmentConfigLease({
+      eraseSlotData,
+      semaphore,
+      holder: "pr-1600",
+      leaseMs: 1000,
+      waitTotalMs: 0,
+    });
+
+    expect(lease.slug).toBe("preview-7");
+    expect(eraseSlotData).toHaveBeenCalledExactlyOnceWith({
+      dopplerConfig: "preview_seven",
+      slug: "preview-7",
+    });
   });
 
   it("never touches slots whose holder PR is open or manual", async () => {
@@ -1547,5 +1644,60 @@ describe("assignEnvironmentConfigLease", () => {
 
     expect(result.outcome).toBe("assigned");
     expect(acquireSpecific).toHaveBeenCalledWith(expect.objectContaining({ force: true }));
+  });
+
+  it("erases the wanted slot on handover — including a --force eviction", async () => {
+    const eraseSlotData = vi.fn(async () => {});
+    const semaphore = fakeSemaphore({
+      acquireSpecific: vi.fn(async () =>
+        fakeLease({ slug: "preview-5", data: { dopplerConfig: "preview_five" } }),
+      ),
+    });
+
+    const result = await assignEnvironmentConfigLease({
+      eraseSlotData,
+      force: true,
+      holder: "pr-1600",
+      leaseMs: 1000,
+      recordedLease: null,
+      semaphore,
+      wantedSlug: "preview-5",
+    });
+
+    expect(result.lease.slug).toBe("preview-5");
+    expect(eraseSlotData).toHaveBeenCalledExactlyOnceWith({
+      dopplerConfig: "preview_five",
+      slug: "preview-5",
+    });
+  });
+
+  it("a failed erase on the wanted slot gives the lease back and throws", async () => {
+    const eraseSlotData = vi.fn(async () => {
+      throw new Error("doppler exploded");
+    });
+    const release = vi.fn(async () => ({ released: true }));
+    const semaphore = fakeSemaphore({
+      acquireSpecific: vi.fn(async () =>
+        fakeLease({ slug: "preview-5", leaseId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" }),
+      ),
+      release,
+    });
+
+    await expect(
+      assignEnvironmentConfigLease({
+        eraseSlotData,
+        holder: "pr-1600",
+        leaseMs: 1000,
+        recordedLease: null,
+        semaphore,
+        wantedSlug: "preview-5",
+      }),
+    ).rejects.toThrow(/Erasing preview-5 failed/);
+    expect(release).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slug: "preview-5",
+        leaseId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      }),
+    );
   });
 });

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -732,6 +732,8 @@ export async function acquire(options: AcquireOptions) {
 
 /**
  * Release a preview slot lease. Pass the lease id from `preview acquire`, or --force to release someone else's (stale) lease.
+ * Does NOT erase the slot's data — that's safe, because every acquire erases
+ * on entry. Use `preview reclaim --slot N` to take back AND wipe in one step.
  */
 type ReleaseOptions = {
   /** Preview slot: a number (9) or slug (preview-9 / preview_9). */
@@ -823,7 +825,7 @@ export async function reclaim(options: ReclaimOptions = {}) {
       reclaimable: report
         .filter((slot) => slot.verdict === "orphaned" || slot.verdict === "idle")
         .map((slot) => `pnpm preview reclaim --slot ${slot.slug}`),
-      note: "orphaned = holder PR is closed, so its cleanup failed; idle = holder hasn't deployed/tested for a while; taking an active slot needs --force and clobbers live work",
+      note: "orphaned = holder PR is closed, so its cleanup failed; idle = holder hasn't deployed/tested for a while; reclaiming ERASES the slot's data before returning it to the pool; taking an active slot needs --force",
     };
   }
 
@@ -840,24 +842,37 @@ export async function reclaim(options: ReclaimOptions = {}) {
       [
         `${slug} is actively held by ${slot.holder ?? "unknown holder"}${slot.pullRequestUrl ? ` (${slot.pullRequestUrl})` : ""}:`,
         `  last used ${slot.lastUsedAgo ?? "recently"}, lease expires ${slot.leasedUntil ?? "soon"}.`,
-        "Taking it would clobber live work. Re-run with --force only after checking with the holder.",
+        "Taking it would ERASE their slot's data and clobber live work.",
+        "Re-run with --force only after checking with the holder.",
       ].join("\n"),
     );
   }
 
   logPreview(
-    `reclaiming ${slug} from ${slot.holder ?? "unknown holder"} (${slot.verdict}${slot.lastUsedAgo ? `, last used ${slot.lastUsedAgo}` : ""})`,
+    `reclaiming ${slug} from ${slot.holder ?? "unknown holder"} (${slot.verdict}${slot.lastUsedAgo ? `, last used ${slot.lastUsedAgo}` : ""}) — erasing its data before returning it to the pool`,
   );
-  // Erase BEFORE releasing: the stale lease still parks the slot, so nobody
-  // can acquire it and deploy fresh data mid-wipe. A reclaimed slot is dirty
-  // by definition (the holder's cleanup — which erases on the way out —
-  // didn't run), so an erase failure leaves the lease in place and throws
+  // Take the slot under OUR OWN fresh lease before erasing. The old holder's
+  // lease could expire mid-erase (the verdict is a snapshot), and destroying
+  // data on a slot another PR just acquired would wreck an innocent tenant —
+  // a fresh lease parks the slot for the whole wipe. An erase failure leaves
+  // that lease in place (parked and visible in this report) and throws
   // rather than returning a dirty slot to the pool.
+  const holder = `reclaim-${userInfo().username}`;
+  const taken = await semaphore.acquireSpecific({
+    type: ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE,
+    slug,
+    leaseMs: 30 * 60_000,
+    holder,
+    force: true,
+  });
+  if (!taken) {
+    throw new Error(`Could not take ${slug} from ${slot.holder ?? "its holder"} — retry.`);
+  }
   await makePreviewSlotDataEraser(runtime)({ dopplerConfig: slot.dopplerConfig, slug });
   const result = await semaphore.release({
     slug,
     type: ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE,
-    force: true,
+    leaseId: taken.leaseId,
   });
   return {
     released: result.released,
@@ -3144,7 +3159,6 @@ function parsePullRequestHolder(holder: string | null | undefined) {
  * it, and GitHub confirms that before we touch anything.
  */
 async function tryReclaimOrphanedEnvironmentConfigLease(input: {
-  eraseSlotData: EraseSlotData;
   fetchPullRequestState: PullRequestStateFetcher | null;
   holder: string;
   leaseMs: number;
@@ -3174,31 +3188,6 @@ async function tryReclaimOrphanedEnvironmentConfigLease(input: {
       logPreview(
         `reclaimed orphaned slot ${orphan.slug}: it was leased by ${orphan.holder ?? "unknown holder"} whose PR is closed (${orphan.pullRequestUrl ?? "no PR url"}) — their cleanup must have failed`,
       );
-      // The dead holder's cleanup is what erases a slot on the way out, and a
-      // reclaim only happens because that cleanup didn't run — so the slot
-      // still holds the dead PR's data. Erase before handing it over, while
-      // this fresh lease parks the slot against other takers.
-      try {
-        await input.eraseSlotData({
-          dopplerConfig: parseEnvironmentConfigLeaseData(lease.data).dopplerConfig,
-          slug: lease.slug,
-        });
-      } catch (error) {
-        // Never hand out a dirty slot. Give the lease back and try the next
-        // orphan; the acquire loop revisits this one on a later poll (erase
-        // failures are usually transient doppler/API hiccups).
-        logPreview(
-          `erase failed on reclaimed ${lease.slug} — releasing it rather than handing over a dirty slot: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        await input.semaphore
-          .release({ type: lease.type, slug: lease.slug, leaseId: lease.leaseId })
-          .catch((releaseError: unknown) => {
-            logPreview(
-              `failed to release ${lease.slug} after the failed erase (it will expire on its own): ${releaseError instanceof Error ? releaseError.message : String(releaseError)}`,
-            );
-          });
-        continue;
-      }
       return lease;
     }
   }
@@ -3207,14 +3196,54 @@ async function tryReclaimOrphanedEnvironmentConfigLease(input: {
 }
 
 /**
+ * Erase a just-acquired slot before it is handed to the caller, giving the
+ * lease back on failure. Returns true when the slot is clean and ours.
+ *
+ * This runs on EVERY handover — plain acquire included, not just reclaims —
+ * so slot cleanliness is an invariant of entry rather than an assumption
+ * about how the previous tenant exited. Every exit path that skips the
+ * cleanup erase (failed cleanup + 24h lease expiry, `release --force`, a run
+ * cancelled mid-claim) becomes harmless: whoever picks the slot up next
+ * wipes it first. A failed erase releases the lease rather than handing out
+ * a dirty slot, and the released slot is safe back in the pool because its
+ * next taker runs this same erase.
+ */
+async function eraseAcquiredSlotOrGiveItBack(input: {
+  eraseSlotData: EraseSlotData;
+  lease: { data: Record<string, unknown>; leaseId: string; slug: string; type: string };
+  semaphore: PreviewSemaphoreResourceClient;
+}) {
+  try {
+    await input.eraseSlotData({
+      dopplerConfig: parseEnvironmentConfigLeaseData(input.lease.data).dopplerConfig,
+      slug: input.lease.slug,
+    });
+    return true;
+  } catch (error) {
+    logPreview(
+      `erase failed on just-acquired ${input.lease.slug} — giving the lease back (the next taker erases before use): ${error instanceof Error ? error.message : String(error)}`,
+    );
+    await input.semaphore
+      .release({ type: input.lease.type, slug: input.lease.slug, leaseId: input.lease.leaseId })
+      .catch((releaseError: unknown) => {
+        logPreview(
+          `failed to release ${input.lease.slug} after the failed erase (it will expire on its own, and its next taker still erases first): ${releaseError instanceof Error ? releaseError.message : String(releaseError)}`,
+        );
+      });
+    return false;
+  }
+}
+
+/**
  * Acquire any free slot, queueing (via semaphore long-poll) while all slots
  * are leased. Orphaned leases (holder PR closed but cleanup failed) are
- * garbage-collected before waiting. Fails with the full holder table and
+ * garbage-collected before waiting. Every handed-out slot is erased first
+ * (see eraseAcquiredSlotOrGiveItBack). Fails with the full holder table and
  * remediation steps once `waitTotalMs` elapses.
  */
 async function acquireAnyEnvironmentConfigLease(input: {
   semaphore: PreviewSemaphoreResourceClient;
-  /** Required so no acquire path can hand out a reclaimed slot without wiping it. */
+  /** Required so no acquire path can hand out a slot without wiping it. */
   eraseSlotData: EraseSlotData;
   fetchPullRequestState?: PullRequestStateFetcher | null;
   holder: string;
@@ -3233,26 +3262,56 @@ async function acquireAnyEnvironmentConfigLease(input: {
     // polls, re-checking for freshly orphaned slots between polls.
     const waitMs = attempt === 1 ? 0 : Math.max(0, Math.min(slotWaitPerAttemptMs, remainingMs));
     try {
-      return await input.semaphore.acquire({
+      const acquired = await input.semaphore.acquire({
         type: ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE,
         leaseMs: input.leaseMs,
         waitMs,
         holder: input.holder,
       });
+      if (
+        await eraseAcquiredSlotOrGiveItBack({
+          eraseSlotData: input.eraseSlotData,
+          lease: acquired,
+          semaphore: input.semaphore,
+        })
+      ) {
+        return acquired;
+      }
+      // Bound the acquire→failed-erase→release cycle: without this check the
+      // loop would spin on a free-but-unerasable slot past the wait budget.
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Could not hand ${input.holder} a clean slot: erasing ${acquired.slug} kept failing and the ${formatDurationMs(input.waitTotalMs)} wait budget is spent.`,
+        );
+      }
+      continue;
     } catch (error) {
       if (!isNoSlotAvailableError(error)) {
         throw error;
       }
 
       const reclaimed = await tryReclaimOrphanedEnvironmentConfigLease({
-        eraseSlotData: input.eraseSlotData,
         fetchPullRequestState: input.fetchPullRequestState ?? null,
         holder: input.holder,
         leaseMs: input.leaseMs,
         semaphore: input.semaphore,
       });
       if (reclaimed) {
-        return reclaimed;
+        if (
+          await eraseAcquiredSlotOrGiveItBack({
+            eraseSlotData: input.eraseSlotData,
+            lease: reclaimed,
+            semaphore: input.semaphore,
+          })
+        ) {
+          return reclaimed;
+        }
+        if (Date.now() >= deadline) {
+          throw new Error(
+            `Could not hand ${input.holder} a clean slot: erasing ${reclaimed.slug} kept failing and the ${formatDurationMs(input.waitTotalMs)} wait budget is spent.`,
+          );
+        }
+        continue;
       }
       if (attempt === 1 && input.fetchPullRequestState) {
         logPreview(
@@ -3331,8 +3390,10 @@ async function claimEnvironmentConfigLease(input: {
   // held two slots and every deploy queued for 20 minutes). Adopt any lease the
   // semaphore already attributes to this holder before acquiring a fresh one.
   const adopted = await adoptExistingHolderLease({
+    eraseSlotData: input.eraseSlotData,
     holder: input.holder,
     leaseMs: input.leaseMs,
+    recordedSlug: previousLease?.slug ?? null,
     semaphore,
   });
   if (adopted) {
@@ -3442,6 +3503,18 @@ async function assignEnvironmentConfigLease(input: {
         ].join("\n"),
       );
     }
+    // Same entry invariant as every other handover — this also covers a
+    // --force eviction, where the acquired slot holds the evicted PR's data.
+    const clean = await eraseAcquiredSlotOrGiveItBack({
+      eraseSlotData: input.eraseSlotData,
+      lease: acquired,
+      semaphore: input.semaphore,
+    });
+    if (!clean) {
+      throw new Error(
+        `Erasing ${acquired.slug} failed, so its lease was given back rather than assigning a dirty slot. Retry, or pick another slot.`,
+      );
+    }
     lease = toEnvironmentConfigLease(acquired);
   } else {
     // A human is asking right now — fail fast with the holder table instead
@@ -3510,10 +3583,17 @@ function toEnvironmentConfigLease(lease: {
  * recorded-but-unrenewable slug is deliberately NOT excluded: if the list
  * still attributes it to this holder, re-issuing our own lease is idempotent
  * and adopting beats leasing a second slot.
+ *
+ * An adopted slug that is NOT the PR body's recorded slug has unknown
+ * provenance by construction (the run that acquired it died before recording
+ * — possibly mid-erase), so it is erased before it is handed over. The
+ * recorded slug is this PR's own live deployment and is never wiped here.
  */
 async function adoptExistingHolderLease(input: {
+  eraseSlotData: EraseSlotData;
   holder: string;
   leaseMs: number;
+  recordedSlug: string | null;
   semaphore: PreviewSemaphoreResourceClient;
 }): Promise<EnvironmentConfigLease | null> {
   const resources = await input.semaphore.list({ type: ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE });
@@ -3533,6 +3613,16 @@ async function adoptExistingHolderLease(input: {
         `lease adopted: the semaphore already had ${repaired.slug} leased to ${input.holder} ` +
           `(a previous run was cancelled before recording it); re-issued until ${formatUntil(repaired.expiresAt)}`,
       );
+      if (repaired.slug !== input.recordedSlug) {
+        const clean = await eraseAcquiredSlotOrGiveItBack({
+          eraseSlotData: input.eraseSlotData,
+          lease: repaired,
+          semaphore: input.semaphore,
+        });
+        if (!clean) {
+          continue;
+        }
+      }
       return toEnvironmentConfigLease(repaired);
     }
   }

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -169,6 +169,7 @@ export async function deploy(
   try {
     environmentConfigLease = await claimEnvironmentConfigLease({
       createPreviewSemaphoreResourceClient: runtime.createPreviewSemaphoreResourceClient,
+      eraseSlotData: makePreviewSlotDataEraser(runtime),
       fetchPullRequestState: makePullRequestStateFetcher(
         context.githubToken,
         context.repositoryFullName,
@@ -556,6 +557,7 @@ export async function assign(options: AssignOptions = {}) {
 
   const current = await readCloudflarePreviewState(context);
   const result = await assignEnvironmentConfigLease({
+    eraseSlotData: makePreviewSlotDataEraser(runtime),
     fetchPullRequestState: makePullRequestStateFetcher(
       context.githubToken,
       context.repositoryFullName,
@@ -846,6 +848,12 @@ export async function reclaim(options: ReclaimOptions = {}) {
   logPreview(
     `reclaiming ${slug} from ${slot.holder ?? "unknown holder"} (${slot.verdict}${slot.lastUsedAgo ? `, last used ${slot.lastUsedAgo}` : ""})`,
   );
+  // Erase BEFORE releasing: the stale lease still parks the slot, so nobody
+  // can acquire it and deploy fresh data mid-wipe. A reclaimed slot is dirty
+  // by definition (the holder's cleanup — which erases on the way out —
+  // didn't run), so an erase failure leaves the lease in place and throws
+  // rather than returning a dirty slot to the pool.
+  await makePreviewSlotDataEraser(runtime)({ dopplerConfig: slot.dopplerConfig, slug });
   const result = await semaphore.release({
     slug,
     type: ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE,
@@ -853,6 +861,7 @@ export async function reclaim(options: ReclaimOptions = {}) {
   });
   return {
     released: result.released,
+    erased: true,
     slug,
     reclaimedFrom: slot.holder,
     verdict: slot.verdict,
@@ -2896,6 +2905,46 @@ async function runPreviewDeployCommand(input: {
   });
 }
 
+/**
+ * Erase a preview slot's user data before handing the slot to a new holder.
+ * Reclaim paths MUST run this: a reclaim only ever happens because the
+ * previous holder's cleanup — which normally erases on the way out — failed
+ * or never ran, so a reclaimed slot is dirty by definition. Deploying over
+ * stale identity data breaks the next tenant (observed 2026-07-07 on
+ * preview-5: 208 orphaned project-directory KV keys against an empty auth D1
+ * → every itx project lookup answered "KV GET failed: 500").
+ */
+type EraseSlotData = (input: { dopplerConfig: string; slug: string }) => Promise<void>;
+
+/**
+ * The real {@link EraseSlotData}: the os app's destroy command, which is the
+ * erase-data script — it wipes the slot's auth D1 and project-directory KV
+ * (the data plane every preview app shares) and leaves infrastructure alone.
+ * The deploy that follows the reclaim re-seeds auth's OAuth client.
+ */
+function makePreviewSlotDataEraser(runtime: {
+  commandEnvironment: NodeJS.ProcessEnv;
+  repositoryRoot: string;
+  signal?: AbortSignal;
+}): EraseSlotData {
+  return async ({ dopplerConfig, slug }) => {
+    const startedAt = Date.now();
+    logPreview(`erasing ${slug} data before handover (doppler config ${dopplerConfig})`);
+    const result = await runPreviewDeployCommand({
+      app: cloudflarePreviewApps.os,
+      commandEnvironment: runtime.commandEnvironment,
+      dopplerConfig,
+      operation: "down",
+      repositoryRoot: runtime.repositoryRoot,
+      signal: runtime.signal,
+    });
+    if (result.exitCode !== 0) {
+      throw new Error(commandFailureMessage(result, `Erasing ${slug} data failed.`));
+    }
+    logPreview(`erased ${slug} data (${formatDurationMs(Date.now() - startedAt)})`);
+  };
+}
+
 function logPreview(message: string) {
   console.error(`[preview] ${message}`);
 }
@@ -3060,6 +3109,13 @@ async function classifyEnvironmentConfigLeases(input: {
       return {
         slug: resource.slug,
         verdict,
+        // What `eraseSlotData` needs to wipe the slot. Falls back to the
+        // slug-derived config (preview-3 → preview_3) for slots that have
+        // never been leased and so carry no data payload yet.
+        dopplerConfig:
+          typeof resource.data.dopplerConfig === "string" && resource.data.dopplerConfig.trim()
+            ? resource.data.dopplerConfig.trim()
+            : resource.slug.replaceAll("-", "_"),
         holder,
         pullRequestUrl: holderPullRequestUrl(holder),
         pullRequestState: holderPullRequestState,
@@ -3088,6 +3144,7 @@ function parsePullRequestHolder(holder: string | null | undefined) {
  * it, and GitHub confirms that before we touch anything.
  */
 async function tryReclaimOrphanedEnvironmentConfigLease(input: {
+  eraseSlotData: EraseSlotData;
   fetchPullRequestState: PullRequestStateFetcher | null;
   holder: string;
   leaseMs: number;
@@ -3117,6 +3174,31 @@ async function tryReclaimOrphanedEnvironmentConfigLease(input: {
       logPreview(
         `reclaimed orphaned slot ${orphan.slug}: it was leased by ${orphan.holder ?? "unknown holder"} whose PR is closed (${orphan.pullRequestUrl ?? "no PR url"}) — their cleanup must have failed`,
       );
+      // The dead holder's cleanup is what erases a slot on the way out, and a
+      // reclaim only happens because that cleanup didn't run — so the slot
+      // still holds the dead PR's data. Erase before handing it over, while
+      // this fresh lease parks the slot against other takers.
+      try {
+        await input.eraseSlotData({
+          dopplerConfig: parseEnvironmentConfigLeaseData(lease.data).dopplerConfig,
+          slug: lease.slug,
+        });
+      } catch (error) {
+        // Never hand out a dirty slot. Give the lease back and try the next
+        // orphan; the acquire loop revisits this one on a later poll (erase
+        // failures are usually transient doppler/API hiccups).
+        logPreview(
+          `erase failed on reclaimed ${lease.slug} — releasing it rather than handing over a dirty slot: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        await input.semaphore
+          .release({ type: lease.type, slug: lease.slug, leaseId: lease.leaseId })
+          .catch((releaseError: unknown) => {
+            logPreview(
+              `failed to release ${lease.slug} after the failed erase (it will expire on its own): ${releaseError instanceof Error ? releaseError.message : String(releaseError)}`,
+            );
+          });
+        continue;
+      }
       return lease;
     }
   }
@@ -3132,6 +3214,8 @@ async function tryReclaimOrphanedEnvironmentConfigLease(input: {
  */
 async function acquireAnyEnvironmentConfigLease(input: {
   semaphore: PreviewSemaphoreResourceClient;
+  /** Required so no acquire path can hand out a reclaimed slot without wiping it. */
+  eraseSlotData: EraseSlotData;
   fetchPullRequestState?: PullRequestStateFetcher | null;
   holder: string;
   leaseMs: number;
@@ -3161,6 +3245,7 @@ async function acquireAnyEnvironmentConfigLease(input: {
       }
 
       const reclaimed = await tryReclaimOrphanedEnvironmentConfigLease({
+        eraseSlotData: input.eraseSlotData,
         fetchPullRequestState: input.fetchPullRequestState ?? null,
         holder: input.holder,
         leaseMs: input.leaseMs,
@@ -3213,6 +3298,7 @@ async function acquireAnyEnvironmentConfigLease(input: {
  */
 async function claimEnvironmentConfigLease(input: {
   createPreviewSemaphoreResourceClient: () => PreviewSemaphoreResourceClient;
+  eraseSlotData: EraseSlotData;
   fetchPullRequestState?: PullRequestStateFetcher | null;
   holder: string;
   leaseMs: number;
@@ -3255,6 +3341,7 @@ async function claimEnvironmentConfigLease(input: {
 
   const lease = await acquireAnyEnvironmentConfigLease({
     semaphore,
+    eraseSlotData: input.eraseSlotData,
     fetchPullRequestState: input.fetchPullRequestState,
     holder: input.holder,
     leaseMs: input.leaseMs,
@@ -3274,6 +3361,7 @@ async function claimEnvironmentConfigLease(input: {
  * no longer records.
  */
 async function assignEnvironmentConfigLease(input: {
+  eraseSlotData: EraseSlotData;
   fetchPullRequestState?: PullRequestStateFetcher | null;
   force?: boolean;
   holder: string;
@@ -3361,6 +3449,7 @@ async function assignEnvironmentConfigLease(input: {
     lease = toEnvironmentConfigLease(
       await acquireAnyEnvironmentConfigLease({
         semaphore: input.semaphore,
+        eraseSlotData: input.eraseSlotData,
         fetchPullRequestState: input.fetchPullRequestState,
         holder: input.holder,
         leaseMs: input.leaseMs,


### PR DESCRIPTION
## The invariant

**Every slot handover erases the slot's data first.** Cleanliness is an invariant of *entry*, not an assumption about how the previous tenant exited.

This started as "reclaim should erase" (yesterday's preview-5 incident: #1714 reclaimed the slot from closed #1700 whose cleanup never ran — 208 stale project-directory KV keys against an empty auth D1, every itx lookup failing `KV GET failed: 500`). A self-review of that first version found its failure handling defeated itself — a failed erase released the lease and the very next plain acquire handed the dirty slot out anyway — and a lifecycle audit found the same dirty-slot hazard on paths no reclaim-time erase can reach (failed cleanup + 24h lease expiry returns a dirty slot to the pool as plain **available**; a cancelled run's adopted lease; `--force` evictions). Erasing at entry closes all of them with one rule.

## Where the erase happens

| Path | Behavior |
| --- | --- |
| Plain `semaphore.acquire` (CI claim) | erase after acquiring, before handover |
| Auto orphan-GC reclaim | same — one shared helper, both branches of `acquireAnyEnvironmentConfigLease` |
| Adopted lease (`adoptExistingHolderLease`) | erased when the adopted slug ≠ the PR body's recorded slug (unknown provenance — the run that acquired it died before recording, possibly mid-erase). The recorded slug is this PR's own live deployment and is never wiped |
| `assign` wanted-slot, incl. `--force` eviction | erased on handover; failed erase gives the lease back and throws |
| Manual `reclaim --slot N` | takes the slot under its own temporary lease (`reclaim-<user>`, 30 min) **before** erasing — the old holder's stale lease could expire mid-wipe and hand the slot to an innocent tenant — then releases it clean. Failed erase keeps the parking lease (visible in `preview status`) |
| Manual `preview acquire` | **deliberate exception**: parks a slot for inspection without wiping — the point of manually holding a slot is often to look at what's on it. The next CI tenant erases on entry regardless |

Failed erases never hand out a dirty slot: the lease is given back and the loop retries (sound now — whoever takes the slot next re-erases), bounded by the existing wait budget with explicit deadline errors.

The erase itself is the os app's destroy command (the erase-data script: auth D1 + project-directory KV, infrastructure untouched); the deploy that follows re-seeds auth's OAuth client. Cost: ~half a minute, paid only when a PR lands on a slot it didn't already hold — renewals of your own slot (the common case) never erase.

## Messaging & docs

- `reclaim` verdict note + `--force` error now say taking a slot **ERASES** the holder's data (previously "clobbers live work" only meant the deployment).
- `release` docstring: does not erase, and why that's safe.
- `docs/dev-environments.md`: states the entry invariant, its one exception, and what `reclaim --slot` actually does now.

## Tests

75 preview tests green (7 new): erase-target comes from the lease's data payload (pinned with a non-conventional dopplerConfig, not slug-derivable), plain-acquire erases, failed erase gives the lease back + retry-until-clean converges, adopted-unrecorded-slot erases, assign/force-evict erases + failed erase throws after giving the lease back. The manual `reclaim` command body is runtime-bound and stays untested — flagged, not hidden.

## Review provenance

Three review lanes ran against v1 of this PR (adversarial diff review, full slot-lifecycle audit, docs audit). This version fixes their blockers (F1 failed-erase self-defeat, F2 adopt bypass, F3 manual-reclaim expiry race, F5 misleading messaging, F6 test mutation escapes). Findings deliberately **not** in this PR, listed for follow-up: cleanup runs zero destroys when a run was cancelled before recording any apps; a stranded unrecorded lease when a PR closes right after claim; `syncPreviewInventory` can evict live holders on data mismatch; erase-data leaves orphaned scheduler DOs with self-perpetuating alarms (platform issue, not preview-specific); minor dead code (`fork-unavailable` status, parked retry machinery, unthreaded `projectHostnameBases`).

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-08T12:00:30.020Z",
      "headSha": "c263068f57ffc0e8063e8e29b878a4c3f511c2e2",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/471021297530677",
      "shortSha": "c263068",
      "cleanupDurationMs": 5484,
      "deployDurationMs": 172867,
      "testDurationMs": 142153,
      "testRetries": "4 retried: provider toggle: cloudflare-ai answers after llm-provider-selected (vitest x1) · creates a project and uses project streams through v4 ITX (vitest x1) · stream rules cannot cross-post project stream events into global streams (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1)"
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-08T12:00:25.300Z",
      "headSha": "c263068f57ffc0e8063e8e29b878a4c3f511c2e2",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/471021297530677",
      "shortSha": "c263068",
      "cleanupDurationMs": 762,
      "deployDurationMs": 15004,
      "testDurationMs": 6531,
      "testRetries": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-08T12:00:27.575Z",
      "headSha": "c263068f57ffc0e8063e8e29b878a4c3f511c2e2",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/471021297530677",
      "shortSha": "c263068",
      "cleanupDurationMs": 3035,
      "deployDurationMs": 17185,
      "testDurationMs": 767,
      "testRetries": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-08T12:00:25.370Z",
      "headSha": "c263068f57ffc0e8063e8e29b878a4c3f511c2e2",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/471021297530677",
      "shortSha": "c263068",
      "cleanupDurationMs": 828,
      "deployDurationMs": 13797,
      "testDurationMs": 15690,
      "testRetries": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `c263068` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 17.2s | 767ms |  | 3.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/471021297530677) | 2026-07-08T12:00:27.575Z | Preview app released. |
| OS | released | `c263068` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 172.9s | 142.2s | 4 retried: provider toggle: cloudflare-ai answers after llm-provider-selected (vitest x1) · creates a project and uses project streams through v4 ITX (vitest x1) · stream rules cannot cross-post project stream events into global streams (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1) | 5.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/471021297530677) | 2026-07-08T12:00:30.020Z | Preview app released. |
| Semaphore | released | `c263068` | [https://semaphore.iterate-preview-7.com](https://semaphore.iterate-preview-7.com) | 15.0s | 6.5s |  | 762ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/471021297530677) | 2026-07-08T12:00:25.300Z | Preview app released. |
| Streams Example App | released | `c263068` | [https://streams.iterate-preview-7.com](https://streams.iterate-preview-7.com) | 13.8s | 15.7s |  | 828ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/471021297530677) | 2026-07-08T12:00:25.370Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->
