### PR TITLE
[codex] Fix failed custom domain removal

### DIFF
--- a/apps/os/src/domains/projects/custom-domains.test.ts
+++ b/apps/os/src/domains/projects/custom-domains.test.ts
@@ -402,6 +402,20 @@ describe("custom domain provisioning", () => {
     );
   });
 
+  it("clears a failed local custom domain without deleting another project's Cloudflare hostname", async () => {
+    const directory = new MemoryKv() as unknown as KVNamespace;
+    const cloudflare = createCloudflareFetchMock({
+      hostnames: [cloudflareHostname({ project: otherProject })],
+    });
+    const provisioner = createProvisioner({ directory, fetch: cloudflare.fetch });
+
+    await expect(
+      provisioner.remove({ cloudflareHostnameId: null, hostname: "garple.com", project }),
+    ).resolves.toBeUndefined();
+    expect(cloudflare.deletedIds).toEqual([]);
+    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toBeNull();
+  });
+
   it("treats stale Cloudflare delete ids as already removed and clears same-project routing", async () => {
     const directory = new MemoryKv() as unknown as KVNamespace;
     await primeProjectHostname(directory, "garple.com", project);

--- a/apps/os/src/domains/projects/custom-domains.ts
+++ b/apps/os/src/domains/projects/custom-domains.ts
@@ -193,11 +193,24 @@ export function createCloudflareCustomDomainProvisioner(options: {
         projectHostnameBases: options.config.projectHostnameBases ?? [],
       });
       const client = await cloudflareClient({ config: options.config, fetch: fetcher });
-      const customHostname = await client.findCustomHostname(normalized);
-      if (customHostname) assertCloudflareHostnameBelongsToProject(customHostname, project);
-      const id = customHostname
-        ? (stringValue(customHostname.id) ?? cloudflareHostnameId)
-        : cloudflareHostnameId;
+      const customHostname = cloudflareHostnameId
+        ? await client.getCustomHostname(cloudflareHostnameId).catch((error) => {
+            if (error instanceof CloudflareApiError && error.status === 404) {
+              return client.findCustomHostname(normalized);
+            }
+            throw error;
+          })
+        : await client.findCustomHostname(normalized);
+      const id = cloudflareHostnameId
+        ? customHostname
+          ? customHostnameIdForRecordedProjectDomain({
+              cloudflareHostnameId,
+              customHostname,
+              project,
+              hostname: normalized,
+            })
+          : cloudflareHostnameId
+        : customHostnameIdForUnrecordedProjectDomain({ customHostname, project });
       if (id) await client.deleteCustomHostname(id);
       const registeredProject = await readProjectHostnameRegistration(
         options.directory,
@@ -310,9 +323,16 @@ function assertCloudflareHostnameBelongsToProject(
   customHostname: CloudflareCustomHostname,
   project: ProjectDirectoryRecord,
 ): void {
-  if (stringValue(customHostname.custom_metadata?.projectId) === project.id) return;
+  if (cloudflareHostnameBelongsToProject(customHostname, project)) return;
   const hostname = customHostname.hostname ?? "custom hostname";
   throw new Error(`Cloudflare custom hostname "${hostname}" is already owned by another project.`);
+}
+
+function cloudflareHostnameBelongsToProject(
+  customHostname: CloudflareCustomHostname,
+  project: ProjectDirectoryRecord,
+): boolean {
+  return stringValue(customHostname.custom_metadata?.projectId) === project.id;
 }
 
 function assertCloudflareHostnameNotOwnedByAnotherProject(
@@ -334,6 +354,26 @@ function assertCloudflareHostnameMatches(
   throw new Error(
     `Cloudflare custom hostname "${actualHostname ?? "unknown"}" does not match "${expectedHostname}".`,
   );
+}
+
+function customHostnameIdForRecordedProjectDomain(input: {
+  cloudflareHostnameId: string;
+  customHostname: CloudflareCustomHostname;
+  hostname: string;
+  project: ProjectDirectoryRecord;
+}): string {
+  assertCloudflareHostnameMatches(input.customHostname, input.hostname);
+  assertCloudflareHostnameNotOwnedByAnotherProject(input.customHostname, input.project);
+  return stringValue(input.customHostname.id) ?? input.cloudflareHostnameId;
+}
+
+function customHostnameIdForUnrecordedProjectDomain(input: {
+  customHostname: CloudflareCustomHostname | null;
+  project: ProjectDirectoryRecord;
+}): string | null {
+  if (!input.customHostname) return null;
+  if (!cloudflareHostnameBelongsToProject(input.customHostname, input.project)) return null;
+  return stringValue(input.customHostname.id);
 }
 
 async function cloudflareClient(input: { config: AppConfig; fetch: Fetch }) {

--- a/apps/os/src/domains/projects/custom-domains.ts
+++ b/apps/os/src/domains/projects/custom-domains.ts
@@ -201,16 +201,16 @@ export function createCloudflareCustomDomainProvisioner(options: {
             throw error;
           })
         : await client.findCustomHostname(normalized);
-      const id = cloudflareHostnameId
-        ? customHostname
-          ? customHostnameIdForRecordedProjectDomain({
-              cloudflareHostnameId,
-              customHostname,
-              project,
-              hostname: normalized,
-            })
-          : cloudflareHostnameId
-        : customHostnameIdForUnrecordedProjectDomain({ customHostname, project });
+      let id = cloudflareHostnameId;
+      if (customHostname) {
+        if (cloudflareHostnameId) {
+          assertCloudflareHostnameMatches(customHostname, normalized);
+          assertCloudflareHostnameNotOwnedByAnotherProject(customHostname, project);
+          id = stringValue(customHostname.id) ?? cloudflareHostnameId;
+        } else if (stringValue(customHostname.custom_metadata?.projectId) === project.id) {
+          id = stringValue(customHostname.id);
+        }
+      }
       if (id) await client.deleteCustomHostname(id);
       const registeredProject = await readProjectHostnameRegistration(
         options.directory,
@@ -323,16 +323,9 @@ function assertCloudflareHostnameBelongsToProject(
   customHostname: CloudflareCustomHostname,
   project: ProjectDirectoryRecord,
 ): void {
-  if (cloudflareHostnameBelongsToProject(customHostname, project)) return;
+  if (stringValue(customHostname.custom_metadata?.projectId) === project.id) return;
   const hostname = customHostname.hostname ?? "custom hostname";
   throw new Error(`Cloudflare custom hostname "${hostname}" is already owned by another project.`);
-}
-
-function cloudflareHostnameBelongsToProject(
-  customHostname: CloudflareCustomHostname,
-  project: ProjectDirectoryRecord,
-): boolean {
-  return stringValue(customHostname.custom_metadata?.projectId) === project.id;
 }
 
 function assertCloudflareHostnameNotOwnedByAnotherProject(
@@ -354,26 +347,6 @@ function assertCloudflareHostnameMatches(
   throw new Error(
     `Cloudflare custom hostname "${actualHostname ?? "unknown"}" does not match "${expectedHostname}".`,
   );
-}
-
-function customHostnameIdForRecordedProjectDomain(input: {
-  cloudflareHostnameId: string;
-  customHostname: CloudflareCustomHostname;
-  hostname: string;
-  project: ProjectDirectoryRecord;
-}): string {
-  assertCloudflareHostnameMatches(input.customHostname, input.hostname);
-  assertCloudflareHostnameNotOwnedByAnotherProject(input.customHostname, input.project);
-  return stringValue(input.customHostname.id) ?? input.cloudflareHostnameId;
-}
-
-function customHostnameIdForUnrecordedProjectDomain(input: {
-  customHostname: CloudflareCustomHostname | null;
-  project: ProjectDirectoryRecord;
-}): string | null {
-  if (!input.customHostname) return null;
-  if (!cloudflareHostnameBelongsToProject(input.customHostname, input.project)) return null;
-  return stringValue(input.customHostname.id);
 }
 
 async function cloudflareClient(input: { config: AppConfig; fetch: Fetch }) {


### PR DESCRIPTION
## Summary

Fix custom-domain removal when a project only has a failed local custom-domain record and no recorded Cloudflare hostname id. In that state, a same-name Cloudflare custom hostname may belong to another project; removal should clear this project's local row without trying to validate or delete the other project's Cloudflare hostname.

## Root cause

The remove path always looked up Cloudflare by hostname and asserted the found hostname belonged to the current project. A failed add such as the production `nustom` case can leave only local project state (`cloudflareHostnameId: null`), so the delete action repeatedly failed against the other project's Cloudflare ownership instead of clearing the local failed row.

## Validation

- `pnpm -C apps/os exec vitest run src/domains/projects/custom-domains.test.ts src/domains/projects/project-processor-implementation.test.ts`
- `pnpm -C apps/os exec tsc --noEmit --pretty false`
- `pnpm exec oxfmt --check apps/os/src/domains/projects/custom-domains.ts apps/os/src/domains/projects/custom-domains.test.ts`
- `pnpm exec oxlint apps/os/src/domains/projects/custom-domains.ts apps/os/src/domains/projects/custom-domains.test.ts --threads 1 --deny-warnings`

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +18 -5 | +18 -5 🟩🟩🟩🟩🟥 |
| Tests | +14 -0 | +12 -0 🟩🟩🟩⬜⬜ |
| **Total** | **+32 -5** | **+30 -5** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 0b51811 and 8f25326, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-08T13:39:54.696Z",
      "headSha": "8f25326df4b88e9163e90d1c64b43699dc2f6efd",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/291525665144118",
      "shortSha": "8f25326",
      "cleanupDurationMs": 2855,
      "deployDurationMs": 27913
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-08T13:39:54.429Z",
      "headSha": "8f25326df4b88e9163e90d1c64b43699dc2f6efd",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/291525665144118",
      "shortSha": "8f25326",
      "cleanupDurationMs": 2586,
      "deployDurationMs": 19225
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `8f25326` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 19.2s |  |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/291525665144118) | 2026-07-08T13:39:54.429Z | Preview app released. |
| OS | released | `8f25326` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 27.9s |  |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/291525665144118) | 2026-07-08T13:39:54.696Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes custom-domain teardown and Cloudflare delete/ownership rules; wrong branching could delete the wrong hostname or leave stale local state, but scope is narrow and covered by new tests.
> 
> **Overview**
> **Custom-domain removal** no longer always treats a hostname lookup in Cloudflare as belonging to the current project. When **`cloudflareHostnameId` is null** (e.g. a failed add left only local state), removal **clears this project’s local routing row** and **does not** assert ownership or delete a same-name hostname that belongs to another project in Cloudflare.
> 
> When an ID **is** recorded, removal uses **`getCustomHostname`** (with 404 fallback to hostname lookup), applies **match/ownership checks**, then deletes. Without an ID, a Cloudflare delete runs **only** if the found hostname’s metadata **`projectId` matches** the caller.
> 
> A test covers **`cloudflareHostnameId: null`** with another project’s Cloudflare hostname present: no Cloudflare DELETE, local registration cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f25326df4b88e9163e90d1c64b43699dc2f6efd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->