### PR TITLE
pnpm getin: one command into local OS

### DIFF
--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -190,6 +190,13 @@ doppler run --project os --config dev -- pnpm auth:mint --email agent+test@nusto
 # → opens straight onto /projects/my-proj
 ```
 
+**`pnpm getin` automates this whole recipe for local dev**: it finds (or
+detached-starts) the worktree's dev server, gets-or-creates the `test` project,
+mints `test+test@nustom.com` with matching claims, and opens the sign-in URL in
+your browser. `pnpm getin -w [name]` runs it against another worktree
+(bare `-w` lists them, most recently touched first); `--print` prints the URL
+instead of opening it.
+
 A signed-in _human_ never hits this: the real OAuth flow walks you through
 creating an org + project on first sign-in (`+test@nustom.com` test emails with
 OTP `424242` work for that flow too, fully headless).

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test:onboarding:production": "pnpm -r --parallel --filter '!iterate' test:onboarding:production",
     "clean": "rm -rf ./**/node_modules",
     "super-reset": "pnpm i && pnpm -r --parallel --filter '!iterate' super-reset",
-    "auth:mint": "tsx scripts/auth/mint-session.ts"
+    "auth:mint": "tsx scripts/auth/mint-session.ts",
+    "getin": "trpc-cli scripts/getin.ts"
   },
   "devDependencies": {
     "@iterate-com/auth-contract": "workspace:*",

--- a/scripts/getin.ts
+++ b/scripts/getin.ts
@@ -1,0 +1,278 @@
+import { spawnSync } from "node:child_process";
+import { statSync } from "node:fs";
+import { basename, join } from "node:path";
+import { createInterface } from "node:readline/promises";
+import { fileURLToPath } from "node:url";
+import { readDevServerInfo } from "../apps/os/scripts/lib/dev-server-info.ts";
+
+// `pnpm getin` — one command into local OS, no recipe to remember.
+//
+// Automates the minting recipe from docs/dev-environments.md ("Acting as
+// users and admins"): make sure the worktree's dev server is running, get or
+// create a project for the test identity via the itx operator path, mint a
+// forged session with org+project claims, and open the one-shot browser
+// sign-in URL.
+//
+// Runs as a trpc-cli module CLI (`trpc-cli scripts/getin.ts` from the root
+// `getin` script) — the default export is the only command.
+//
+//   pnpm getin                 # open local OS signed in as test+test@nustom.com
+//   pnpm getin --print         # print the sign-in URL instead of opening it
+//   pnpm getin -w              # pick a worktree (most recently touched first)
+//   pnpm getin -w getin        # run in the named worktree
+//
+// Doppler-wrapped subcommands run from apps/os so the project resolves to
+// `os` and the config to whatever `doppler setup` chose for this worktree
+// (dev, dev_<you>, ...). Local dev only — for previews/prod use the manual
+// `auth:mint` recipe.
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const APP_ROOT = join(REPO_ROOT, "apps/os");
+
+export type GetinOptions = {
+  /** identity email to mint (default test+test@nustom.com)
+   * @alias e
+   */
+  email?: string;
+  /** project slug to get or create (default test) */
+  slug?: string;
+  /** doppler config override (default: this worktree's `doppler setup` choice) */
+  config?: string;
+  /** print the one-shot sign-in URL instead of opening the browser */
+  print?: boolean;
+  /** run in another worktree — pass a directory name, branch, or path; bare -w picks interactively, most recently touched first
+   * @alias w
+   */
+  worktree?: boolean | string;
+};
+
+/** get into local OS: ensure the dev server, get-or-create the test project, mint a session, open the browser */
+export default async function getin(options?: GetinOptions) {
+  const email = options?.email || "test+test@nustom.com";
+  const slug = options?.slug || "test";
+  const config = options?.config;
+
+  if (options?.worktree !== undefined && options.worktree !== false) {
+    const ref = typeof options.worktree === "string" ? options.worktree : undefined;
+    return runInWorktree(ref, [
+      ...(options.email ? ["--email", options.email] : []),
+      ...(options.slug ? ["--slug", options.slug] : []),
+      ...(config ? ["--config", config] : []),
+      ...(options.print ? ["--print"] : []),
+    ]);
+  }
+
+  const devServer = ensureDevServer(config);
+  console.log(`dev server: ${devServer.baseUrl} (pid ${devServer.pid})`);
+
+  const project = getOrCreateProject(devServer.baseUrl, slug, config);
+  console.log(`project: ${project.slug} (${project.id})`);
+
+  // OS authorizes from claims, so when the project has no auth-side org (the
+  // operator/admin lane leaves organizationId null) a synthetic org is enough
+  // — see docs/dev-environments.md.
+  const org = project.organizationId
+    ? {
+        id: project.organizationId,
+        slug: project.organizationSlug || "org",
+        name: project.organizationName || "Org",
+        role: "admin",
+      }
+    : { id: "org_getin", slug: "getin", name: "Getin", role: "admin" };
+
+  const url = mintBrowserUrl({ baseUrl: devServer.baseUrl, email, org, project, config });
+
+  if (options?.print) {
+    console.log(url);
+    return;
+  }
+  console.log(`opening ${devServer.baseUrl} as ${email} ...`);
+  spawnSync("open", [url]);
+}
+
+// ---------------------------------------------------------------------------
+
+async function runInWorktree(ref: string | undefined, passthroughArgs: string[]) {
+  const worktrees = listWorktrees();
+  let target = ref
+    ? worktrees.find((w) => basename(w.path) === ref || w.branch === ref || w.path === ref)
+    : undefined;
+  if (ref && !target) {
+    console.error(`No worktree matching "${ref}". Known worktrees:`);
+    for (const w of worktrees) console.error(`  ${basename(w.path)} (${w.branch ?? "detached"})`);
+    process.exit(1);
+  }
+  target = target ?? (await promptForWorktree(worktrees));
+  console.log(`running pnpm getin in ${target.path} ...`);
+  const result = spawnSync("pnpm", ["getin", ...passthroughArgs], {
+    cwd: target.path,
+    stdio: "inherit",
+  });
+  process.exit(result.status ?? 1);
+}
+
+function listWorktrees() {
+  const out = run("git", ["worktree", "list", "--porcelain"], REPO_ROOT);
+  const worktrees: { path: string; branch: string | undefined; touchedAt: number }[] = [];
+  for (const block of out.split("\n\n").filter(Boolean)) {
+    const path = block.match(/^worktree (.+)$/m)?.[1];
+    if (!path) continue;
+    const branch = block.match(/^branch refs\/heads\/(.+)$/m)?.[1];
+    worktrees.push({ path, branch, touchedAt: touchedAt(path) });
+  }
+  return worktrees.sort((a, b) => b.touchedAt - a.touchedAt);
+}
+
+/** "Most recently touched": newest of HEAD commit time and worktree-root mtime. */
+function touchedAt(worktreePath: string) {
+  let commitMs = 0;
+  try {
+    const seconds = run("git", ["-C", worktreePath, "log", "-1", "--format=%ct"], REPO_ROOT);
+    commitMs = Number(seconds) * 1000;
+  } catch {
+    // brand-new worktree with no commits, or path gone — fall back to mtime
+  }
+  let mtimeMs = 0;
+  try {
+    mtimeMs = statSync(worktreePath).mtimeMs;
+  } catch {
+    // stale worktree entry whose directory was deleted
+  }
+  return Math.max(commitMs, mtimeMs);
+}
+
+async function promptForWorktree(worktrees: ReturnType<typeof listWorktrees>) {
+  worktrees.forEach((w, i) => {
+    const label = `${basename(w.path)} (${w.branch ?? "detached"}, touched ${ago(w.touchedAt)})`;
+    console.log(`${i + 1}. ${label}`);
+  });
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await rl.question(`worktree [1-${worktrees.length}] (default 1): `);
+  rl.close();
+  const index = answer.trim() === "" ? 0 : Number(answer.trim()) - 1;
+  const target = worktrees[index];
+  if (!target) {
+    console.error(`Invalid selection "${answer.trim()}".`);
+    process.exit(1);
+  }
+  return target;
+}
+
+function ago(timestampMs: number) {
+  const minutes = Math.round((Date.now() - timestampMs) / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  if (minutes < 60 * 24) return `${Math.round(minutes / 60)}h ago`;
+  return `${Math.round(minutes / (60 * 24))}d ago`;
+}
+
+function ensureDevServer(config: string | undefined) {
+  const live = readDevServerInfo(APP_ROOT, { requireLive: true });
+  if (live) return live;
+  console.log("no live dev server — starting one detached ...");
+  const result = spawnSync(
+    "pnpm",
+    ["dev", "start", "--detach", ...(config ? ["--config", config] : [])],
+    { cwd: APP_ROOT, stdio: ["ignore", "inherit", "inherit"] },
+  );
+  if (result.status !== 0) throw new Error("pnpm dev start --detach failed (see output above).");
+  const started = readDevServerInfo(APP_ROOT, { requireLive: true });
+  if (!started) throw new Error("Dev server started but published no discovery info.");
+  return started;
+}
+
+type ProjectClaim = {
+  id: string;
+  slug: string;
+  organizationId: string | null;
+  organizationSlug: string | null;
+  organizationName: string | null;
+};
+
+function getOrCreateProject(
+  baseUrl: string,
+  slug: string,
+  config: string | undefined,
+): ProjectClaim {
+  const script = [
+    `const slug = ${JSON.stringify(slug)};`,
+    `const projects = await itx.projects.list({ scope: "deployment" });`,
+    `const existing = projects.find((p) => p.slug === slug);`,
+    `if (existing) return existing;`,
+    `const project = await itx.projects.create({ slug });`,
+    `const description = await project.__describe();`,
+    `return { id: description.projectId, slug, organizationId: null, organizationSlug: null, organizationName: null };`,
+  ].join("\n");
+  const out = runViaDoppler(
+    [
+      "pnpm",
+      "exec",
+      "tsx",
+      "scripts/cli.ts",
+      "itx",
+      "run",
+      "--base-url",
+      baseUrl,
+      "--eval",
+      script,
+    ],
+    config,
+  );
+  // itx run prints exactly one JSON document on stdout
+  return JSON.parse(out.slice(out.indexOf("{"))) as ProjectClaim;
+}
+
+function mintBrowserUrl(input: {
+  baseUrl: string;
+  email: string;
+  org: { id: string; slug: string; name: string; role: string };
+  project: ProjectClaim;
+  config: string | undefined;
+}) {
+  const out = runViaDoppler(
+    [
+      "pnpm",
+      "exec",
+      "tsx",
+      join(REPO_ROOT, "scripts/auth/mint-session.ts"),
+      "--email",
+      input.email,
+      "--orgs",
+      JSON.stringify([input.org]),
+      "--projects",
+      JSON.stringify([
+        { id: input.project.id, slug: input.project.slug, organizationId: input.org.id },
+      ]),
+      "--base-url",
+      input.baseUrl,
+      "--browser-url",
+    ],
+    input.config,
+  );
+  const url = out.trim().split("\n").at(-1)!;
+  if (!url.startsWith("http")) throw new Error(`auth:mint printed no URL:\n${out}`);
+  return url;
+}
+
+/**
+ * Run a command under `doppler run` from apps/os, where the project resolves
+ * to `os` and the config to this worktree's `doppler setup` choice — that
+ * config carries the forge key, admin API secret, and auth issuer.
+ */
+function runViaDoppler(command: string[], config: string | undefined) {
+  const dopplerArgs = ["run", ...(config ? ["--config", config] : []), "--", ...command];
+  return run("doppler", dopplerArgs, APP_ROOT);
+}
+
+function run(command: string, commandArgs: string[], cwd: string) {
+  const result = spawnSync(command, commandArgs, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    const summary = `${command} ${commandArgs.slice(0, 4).join(" ")} ...`;
+    throw new Error(`${summary} failed (exit ${result.status})`);
+  }
+  return result.stdout;
+}

--- a/scripts/getin.ts
+++ b/scripts/getin.ts
@@ -34,8 +34,10 @@ export type GetinOptions = {
    * @alias e
    */
   email?: string;
-  /** project slug to get or create (default test) */
-  slug?: string;
+  /** project slug to get or create (default test), or a prj_ id that must already exist
+   * @alias p
+   */
+  project?: string;
   /** doppler config override (default: this worktree's `doppler setup` choice) */
   config?: string;
   /** print the one-shot sign-in URL instead of opening the browser */
@@ -49,14 +51,14 @@ export type GetinOptions = {
 /** get into local OS: ensure the dev server, get-or-create the test project, mint a session, open the browser */
 export default async function getin(options?: GetinOptions) {
   const email = options?.email || "test+test@nustom.com";
-  const slug = options?.slug || "test";
+  const projectRef = options?.project || "test";
   const config = options?.config;
 
   if (options?.worktree !== undefined && options.worktree !== false) {
     const ref = typeof options.worktree === "string" ? options.worktree : undefined;
     return runInWorktree(ref, [
       ...(options.email ? ["--email", options.email] : []),
-      ...(options.slug ? ["--slug", options.slug] : []),
+      ...(options.project ? ["--project", options.project] : []),
       ...(config ? ["--config", config] : []),
       ...(options.print ? ["--print"] : []),
     ]);
@@ -65,7 +67,7 @@ export default async function getin(options?: GetinOptions) {
   const devServer = ensureDevServer(config);
   console.log(`dev server: ${devServer.baseUrl} (pid ${devServer.pid})`);
 
-  const project = getOrCreateProject(devServer.baseUrl, slug, config);
+  const project = getOrCreateProject(devServer.baseUrl, projectRef, config);
   console.log(`project: ${project.slug} (${project.id})`);
 
   // OS authorizes from claims, so when the project has no auth-side org (the
@@ -188,19 +190,22 @@ type ProjectClaim = {
   organizationName: string | null;
 };
 
+/** `ref` is a prj_ id (must already exist) or a slug (created when missing). */
 function getOrCreateProject(
   baseUrl: string,
-  slug: string,
+  ref: string,
   config: string | undefined,
 ): ProjectClaim {
   const script = [
-    `const slug = ${JSON.stringify(slug)};`,
+    `const ref = ${JSON.stringify(ref)};`,
+    `const byId = ref.startsWith("prj_");`,
     `const projects = await itx.projects.list({ scope: "deployment" });`,
-    `const existing = projects.find((p) => p.slug === slug);`,
+    `const existing = projects.find((p) => (byId ? p.id === ref : p.slug === ref));`,
     `if (existing) return existing;`,
-    `const project = await itx.projects.create({ slug });`,
+    `if (byId) throw new Error("No project with id " + ref + " on this deployment.");`,
+    `const project = await itx.projects.create({ slug: ref });`,
     `const description = await project.__describe();`,
-    `return { id: description.projectId, slug, organizationId: null, organizationSlug: null, organizationName: null };`,
+    `return { id: description.projectId, slug: ref, organizationId: null, organizationSlug: null, organizationName: null };`,
   ].join("\n");
   const out = runViaDoppler(
     [

--- a/tasks/complete/2026-07-08-getin.md
+++ b/tasks/complete/2026-07-08-getin.md
@@ -18,7 +18,7 @@ One dumb-ish wrapper so you never have to remember the minting recipe. `pnpm get
 Steps, in order:
 
 1. **Dev server**: read `apps/os/.dev-server/dev-server.json` via `readDevServerInfo(appRoot, { requireLive: true })`; if no live server, `pnpm dev start --detach` in `apps/os` and re-read.
-2. **Get-or-create project**: `doppler run -- pnpm exec tsx scripts/cli.ts itx run --eval ...` from `apps/os` — `projects.list({scope:"deployment"})`, find slug, else `projects.create({slug})`. Default slug `test`.
+2. **Get-or-create project**: `doppler run -- pnpm exec tsx scripts/cli.ts itx run --eval ...` from `apps/os` — `projects.list({scope:"deployment"})`, match a `prj_` id (must exist) or a slug (created when missing). Default `test`.
 3. **Org**: OS authorizes from claims, so when the project has no auth-side org (operator lane leaves `organizationId` null) a synthetic `org_getin` claim is used; a real `organizationId` on the project wins when present.
 4. **Mint**: run `scripts/auth/mint-session.ts --email --orgs --projects --browser-url` under the same doppler wrap. Default email `test+test@nustom.com`.
 5. **Open**: `open <url>`; `--print` prints instead.
@@ -27,7 +27,7 @@ Doppler: subcommands run under `doppler run` with cwd `apps/os`, so the project 
 
 ## Flags
 
-- `--email/-e`, `--slug`, `--config`, `--print`
+- `--email/-e`, `--project/-p` (slug to get-or-create, or a `prj_` id that must exist), `--config`, `--print`
 - `--worktree/-w [ref]` — typed `boolean | string`, so bare `-w` prompts (worktrees ordered by most recently touched = newest of HEAD commit time and root mtime) and `-w <ref>` matches directory name, branch, or path, then re-runs `pnpm getin` there with remaining flags passed through.
 
 ## Checklist

--- a/tasks/complete/2026-07-08-getin.md
+++ b/tasks/complete/2026-07-08-getin.md
@@ -1,5 +1,5 @@
 ---
-status: in-review
+status: done
 size: small
 branch: getin
 pr: https://github.com/iterate/iterate/pull/1760
@@ -7,7 +7,7 @@ pr: https://github.com/iterate/iterate/pull/1760
 
 # `pnpm getin` — one command to get into local OS
 
-**Status summary**: implemented and verified end-to-end (dev-server discovery, project get-or-create idempotency, sign-in URL sets a session cookie, `-w` named + interactive). Remaining: human review.
+**Status summary**: implemented and verified end-to-end (dev-server discovery, project get-or-create idempotency, sign-in URL sets a session cookie, `-w` named + interactive). CI green; awaiting review/merge.
 
 One dumb-ish wrapper so you never have to remember the minting recipe. `pnpm getin` from the repo root ends with a browser tab open on the local OS dashboard, signed in as a test identity, with an org and project that exist. It automates the exact recipe documented in `docs/dev-environments.md` ("Acting as users and admins" → the `--orgs`/`--projects` recipe).
 

--- a/tasks/getin.md
+++ b/tasks/getin.md
@@ -1,47 +1,51 @@
 ---
-status: in-progress
+status: in-review
 size: small
 branch: getin
+pr: https://github.com/iterate/iterate/pull/1760
 ---
 
 # `pnpm getin` — one command to get into local OS
 
-**Status summary**: spec written, implementation not started.
+**Status summary**: implemented and verified end-to-end (dev-server discovery, project get-or-create idempotency, sign-in URL sets a session cookie, `-w` named + interactive). Remaining: human review.
 
-One dumb-ish wrapper so you never have to remember the minting recipe. `pnpm getin` from the repo root should end with a browser tab open on the local OS dashboard, signed in as a test identity, with an org and project that exist. It automates the exact recipe documented in `docs/dev-environments.md` ("Acting as users and admins" → the `--orgs`/`--projects` recipe).
+One dumb-ish wrapper so you never have to remember the minting recipe. `pnpm getin` from the repo root ends with a browser tab open on the local OS dashboard, signed in as a test identity, with an org and project that exist. It automates the exact recipe documented in `docs/dev-environments.md` ("Acting as users and admins" → the `--orgs`/`--projects` recipe).
 
 ## Behavior
 
-`pnpm getin [flags]`, implemented as `scripts/getin.ts` (plain TypeScript per `docs/cli-scripts.md`), wired as `"getin": "tsx scripts/getin.ts"` in the root package.json.
+`pnpm getin [flags]` = `trpc-cli scripts/getin.ts` — a trpc-cli **module-mode** CLI (per Misha's mid-task request): the default-exported `getin(options)` function is the only command, flags and help text derive from the `GetinOptions` type and its jsdoc.
 
 Steps, in order:
 
-1. **Doppler env**: if the forge/auth env (`AUTH_FORGE_PRIVATE_JWK`, `APP_CONFIG_ITERATE_AUTH__ISSUER`) is missing, re-exec itself under `doppler run --project os --config dev --`. `--config <name>` overrides the config (preview slots etc. left out of scope — this is a local-dev convenience).
-2. **Dev server**: read `apps/os/.dev-server/dev-server.json` via `readDevServerInfo(appRoot, { requireLive: true })`. If no live server, run `pnpm dev start --detach` in `apps/os` and use the discovery info it returns.
-3. **Get-or-create project**: shell out to the operator path from `apps/os`: `pnpm cli itx run --base-url <baseUrl> --eval '...'` — list projects, find one with the target slug, else `itx.projects.create({ slug })`. Default slug `test`. (itx has `projects.list()` / `projects.create({slug})` — see `apps/os/src/README.md`.)
-4. **Org**: per the documented recipe, OS authorizes from claims, so the org claim can be deterministic/synthetic (`org_getin` / slug `getin`) unless the project row reports a real `organizationId`, in which case use that.
-5. **Mint**: run `pnpm auth:mint --email <email> --orgs <json> --projects <json> --browser-url` (or import the same building blocks) to get the one-shot sign-in URL. Default email `test+test@nustom.com`.
-6. **Open**: `open <url>` (darwin). `--print` prints the URL instead of opening — useful for agents and for piping to other browsers.
+1. **Dev server**: read `apps/os/.dev-server/dev-server.json` via `readDevServerInfo(appRoot, { requireLive: true })`; if no live server, `pnpm dev start --detach` in `apps/os` and re-read.
+2. **Get-or-create project**: `doppler run -- pnpm exec tsx scripts/cli.ts itx run --eval ...` from `apps/os` — `projects.list({scope:"deployment"})`, find slug, else `projects.create({slug})`. Default slug `test`.
+3. **Org**: OS authorizes from claims, so when the project has no auth-side org (operator lane leaves `organizationId` null) a synthetic `org_getin` claim is used; a real `organizationId` on the project wins when present.
+4. **Mint**: run `scripts/auth/mint-session.ts --email --orgs --projects --browser-url` under the same doppler wrap. Default email `test+test@nustom.com`.
+5. **Open**: `open <url>`; `--print` prints instead.
+
+Doppler: subcommands run under `doppler run` with cwd `apps/os`, so the project resolves to `os` and the config to the worktree's `doppler setup` choice (`dev`, `dev_<you>`); `--config` overrides.
 
 ## Flags
 
-- `--email <email>` — identity to mint (default `test+test@nustom.com`)
-- `--slug <slug>` — project slug to get-or-create (default `test`)
-- `--config <doppler config>` — default `dev`
-- `--print` — print the sign-in URL instead of `open`ing it
-- `--worktree <name>` / `-w [name]` — run `pnpm getin` in that worktree instead (matched by worktree directory name or path from `git worktree list`). Bare `-w` with no value prompts interactively: list all worktrees (including the main checkout), ordered by most recently touched (newest of HEAD commit time and worktree-root mtime), pick by number. Remaining flags pass through to the re-invocation.
+- `--email/-e`, `--slug`, `--config`, `--print`
+- `--worktree/-w [ref]` — typed `boolean | string`, so bare `-w` prompts (worktrees ordered by most recently touched = newest of HEAD commit time and root mtime) and `-w <ref>` matches directory name, branch, or path, then re-runs `pnpm getin` there with remaining flags passed through.
 
 ## Checklist
 
-- [ ] `scripts/getin.ts` with the flow above
-- [ ] root package.json `getin` script
-- [ ] `-w`/`--worktree` selection incl. interactive prompt ordered by most-recently-touched
-- [ ] verify `pnpm getin -w` end-to-end — confirm pnpm doesn't swallow bare `-w` (it's pnpm's own `--workspace-root` alias; if it does swallow it, document `pnpm getin -- -w` or pick a different short flag)
-- [ ] mention in `docs/dev-environments.md` next to the manual recipe
+- [x] `scripts/getin.ts` with the flow above — _module-mode trpc-cli commands file; helpers below the command per repo test/file conventions_
+- [x] root package.json `getin` script — _`"getin": "trpc-cli scripts/getin.ts"`, same shape as the `preview` script_
+- [x] `-w`/`--worktree` selection incl. interactive prompt ordered by most-recently-touched — _`boolean | string` option; readline numbered prompt, default 1_
+- [x] verify `pnpm getin -w` end-to-end — _pnpm 10 forwards bare `-w` to the script verbatim (tested; it is NOT swallowed as `--workspace-root`)_
+- [x] mention in `docs/dev-environments.md` next to the manual recipe — _paragraph after the `--orgs/--projects` recipe block_
 
-## Assumptions (made while Misha was AFK-ish)
+## Assumptions
 
 - Local-dev only (dev Doppler config family); pointing at previews/prod stays with the manual `auth:mint` recipe.
 - Fixed OTP test-email convention means `test+test@nustom.com` is safe and standard here.
 - "Find the running dev process" = the existing `.dev-server/dev-server.json` discovery file with a liveness check, not process-table grepping.
-- Re-running is idempotent: same email, same slug, same (or reused) org claim — `getin` twice should not create a second project.
+- Re-running is idempotent: same email, same slug, same synthetic org claim — verified (second run reused `prj_a5dd64f6...`).
+
+## Implementation log
+
+- Verified in the `getin` worktree against `dev_misha`: fresh detached dev-server start (first attempt hit a transient miniflare "remote connection" failure; retry succeeded), project `test` created once and found on re-run, `curl` of the minted URL returned 302 + `iterate_session` cookie, `-w getin` and piped `echo 1 | pnpm getin -w` both re-invoked correctly.
+- `runInWorktree` spawns `pnpm getin` in the target worktree, so a worktree whose branch predates this feature fails with pnpm's "Missing script: getin" — acceptable until this merges to main.

--- a/tasks/getin.md
+++ b/tasks/getin.md
@@ -1,0 +1,47 @@
+---
+status: in-progress
+size: small
+branch: getin
+---
+
+# `pnpm getin` — one command to get into local OS
+
+**Status summary**: spec written, implementation not started.
+
+One dumb-ish wrapper so you never have to remember the minting recipe. `pnpm getin` from the repo root should end with a browser tab open on the local OS dashboard, signed in as a test identity, with an org and project that exist. It automates the exact recipe documented in `docs/dev-environments.md` ("Acting as users and admins" → the `--orgs`/`--projects` recipe).
+
+## Behavior
+
+`pnpm getin [flags]`, implemented as `scripts/getin.ts` (plain TypeScript per `docs/cli-scripts.md`), wired as `"getin": "tsx scripts/getin.ts"` in the root package.json.
+
+Steps, in order:
+
+1. **Doppler env**: if the forge/auth env (`AUTH_FORGE_PRIVATE_JWK`, `APP_CONFIG_ITERATE_AUTH__ISSUER`) is missing, re-exec itself under `doppler run --project os --config dev --`. `--config <name>` overrides the config (preview slots etc. left out of scope — this is a local-dev convenience).
+2. **Dev server**: read `apps/os/.dev-server/dev-server.json` via `readDevServerInfo(appRoot, { requireLive: true })`. If no live server, run `pnpm dev start --detach` in `apps/os` and use the discovery info it returns.
+3. **Get-or-create project**: shell out to the operator path from `apps/os`: `pnpm cli itx run --base-url <baseUrl> --eval '...'` — list projects, find one with the target slug, else `itx.projects.create({ slug })`. Default slug `test`. (itx has `projects.list()` / `projects.create({slug})` — see `apps/os/src/README.md`.)
+4. **Org**: per the documented recipe, OS authorizes from claims, so the org claim can be deterministic/synthetic (`org_getin` / slug `getin`) unless the project row reports a real `organizationId`, in which case use that.
+5. **Mint**: run `pnpm auth:mint --email <email> --orgs <json> --projects <json> --browser-url` (or import the same building blocks) to get the one-shot sign-in URL. Default email `test+test@nustom.com`.
+6. **Open**: `open <url>` (darwin). `--print` prints the URL instead of opening — useful for agents and for piping to other browsers.
+
+## Flags
+
+- `--email <email>` — identity to mint (default `test+test@nustom.com`)
+- `--slug <slug>` — project slug to get-or-create (default `test`)
+- `--config <doppler config>` — default `dev`
+- `--print` — print the sign-in URL instead of `open`ing it
+- `--worktree <name>` / `-w [name]` — run `pnpm getin` in that worktree instead (matched by worktree directory name or path from `git worktree list`). Bare `-w` with no value prompts interactively: list all worktrees (including the main checkout), ordered by most recently touched (newest of HEAD commit time and worktree-root mtime), pick by number. Remaining flags pass through to the re-invocation.
+
+## Checklist
+
+- [ ] `scripts/getin.ts` with the flow above
+- [ ] root package.json `getin` script
+- [ ] `-w`/`--worktree` selection incl. interactive prompt ordered by most-recently-touched
+- [ ] verify `pnpm getin -w` end-to-end — confirm pnpm doesn't swallow bare `-w` (it's pnpm's own `--workspace-root` alias; if it does swallow it, document `pnpm getin -- -w` or pick a different short flag)
+- [ ] mention in `docs/dev-environments.md` next to the manual recipe
+
+## Assumptions (made while Misha was AFK-ish)
+
+- Local-dev only (dev Doppler config family); pointing at previews/prod stays with the manual `auth:mint` recipe.
+- Fixed OTP test-email convention means `test+test@nustom.com` is safe and standard here.
+- "Find the running dev process" = the existing `.dev-server/dev-server.json` discovery file with a liveness check, not process-table grepping.
+- Re-running is idempotent: same email, same slug, same (or reused) org claim — `getin` twice should not create a second project.


### PR DESCRIPTION
Adds a root `pnpm getin` command that gets you into the local OS dashboard in one step, so you don't have to remember the minting recipe from `docs/dev-environments.md`:

```bash
pnpm getin              # → browser tab open on local OS, signed in as test+test@nustom.com,
                        #   with org + project claims for a project that exists (created if needed)
pnpm getin -w           # → pick a worktree (ordered by most recently touched), run there
pnpm getin -w getin     # → run in the named worktree (directory name, branch, or path)
pnpm getin --print      # → print the sign-in URL instead of opening the browser
pnpm getin --help       # → flags: --email/-e, --project/-p (slug or prj_ id), --config, --print, -w/--worktree
```

It's a trpc-cli **module-mode** CLI (`"getin": "trpc-cli scripts/getin.ts"`, same shape as the root `preview` script): the default-exported `getin(options)` function is the only command, and flags/help derive from the `GetinOptions` type and its jsdoc — `worktree?: boolean | string` is what makes bare `-w` (interactive picker) vs `-w name` work.

Under the hood it: finds the running dev server via the `.dev-server` discovery file (or `pnpm dev start --detach`) → gets-or-creates the `test` project via the itx operator path (`itx run --eval`, under `doppler run` from `apps/os` so the worktree's own config applies) → mints org+project claims with `mint-session.ts` → `open`s the one-shot browser sign-in URL.

Verified end-to-end against `dev_misha`: fresh detached dev-server start, project created once and reused on re-run (idempotent), minted URL answers 302 + `iterate_session` cookie, and both `-w getin` and the bare `-w` interactive picker re-invoke correctly. Also confirmed pnpm 10 forwards bare `-w` to the script rather than eating it as `--workspace-root`.

Task file: `tasks/complete/2026-07-08-getin.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| CI & scripts | +283 -0 | +215 -0 🟩🟩🟩🟩🟩 |
| Config | +2 -1 | +2 -1 🟩⬜⬜⬜⬜ |
| Docs | +58 -0 | +41 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+343 -1** | **+258 -1** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 35db0be and fef38a2, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local-only developer convenience script; reuses existing Doppler-wrapped mint and itx operator paths with no production or runtime app changes.
> 
> **Overview**
> Adds **`pnpm getin`**, a root trpc-cli wrapper that automates the manual dev-server + project + `auth:mint` recipe from `docs/dev-environments.md`.
> 
> The new `scripts/getin.ts` flow: ensure a live local OS dev server (read `.dev-server/dev-server.json` or `pnpm dev start --detach`), get-or-create a project via `itx run` under Doppler from `apps/os`, mint org/project claims with `mint-session.ts` (synthetic `org_getin` when the project has no auth org), then `open` the browser sign-in URL. Flags include `--email`, `--project`, `--config`, `--print`, and **`--worktree/-w`** to run in another git worktree (interactive picker sorted by recency).
> 
> Root `package.json` gains `"getin": "trpc-cli scripts/getin.ts"` (same pattern as `preview`). Docs add a short pointer to `getin` beside the existing minting steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fef38a2245e8f6740f0747cfefda6d9a1e89897d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->