### PR TITLE
GitHub-backed repos follow-up: webhook ingress lane fix, link-flow hardening, IDE GitHub panel

### DIFF
--- a/apps/os/src/components/repo-ide/repo-github-panel.tsx
+++ b/apps/os/src/components/repo-ide/repo-github-panel.tsx
@@ -1,0 +1,244 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Link, useParams } from "@tanstack/react-router";
+import { ExternalLinkIcon } from "lucide-react";
+import { Button } from "@iterate-com/ui/components/button";
+import { Input } from "@iterate-com/ui/components/input";
+import { NativeSelect, NativeSelectOption } from "@iterate-com/ui/components/native-select";
+import { toast } from "@iterate-com/ui/components/sonner";
+import type { RepoProcessorState } from "../../domains/repos/repo-processor-contract.ts";
+import { useItx, useItxQuery, useItxState } from "~/itx/itx-react.tsx";
+
+/**
+ * The GitHub sidebar of the repo IDE: shows the repo's GitHub link (owner/
+ * repo, connection, last mirror-push outcome) with push/sync/unlink actions,
+ * or — when unlinked — a link form over the project's GitHub connections.
+ * Once linked, commits mirror to GitHub automatically and GitHub webhooks
+ * about the repository land on the repo's stream; the processor state is
+ * live, so link and push facts fold into this panel as they happen.
+ */
+export function RepoGithubPanel({ projectId, repoPath }: { projectId: string; repoPath: string }) {
+  const repoProcessor = useItxState<RepoProcessorState>(
+    (itx, setState) => itx.repos.get(repoPath).processor.onStateChange(setState),
+    [repoPath],
+  );
+  const state = repoProcessor.state;
+  if (state === undefined) {
+    return (
+      <div className="p-3 text-xs text-muted-foreground" data-spinner="true">
+        Loading…
+      </div>
+    );
+  }
+  return state.github === null ? (
+    <LinkForm projectId={projectId} repoPath={repoPath} />
+  ) : (
+    <LinkedPanel repoPath={repoPath} github={state.github} lastPush={state.lastGithubPush} />
+  );
+}
+
+function LinkedPanel({
+  repoPath,
+  github,
+  lastPush,
+}: {
+  repoPath: string;
+  github: NonNullable<RepoProcessorState["github"]>;
+  lastPush: RepoProcessorState["lastGithubPush"];
+}) {
+  const itx = useItx();
+  const push = useMutation({
+    mutationFn: () => itx.repos.get(repoPath).pushToGithub({}),
+    onSuccess: (result) => toast.success(`Pushed ${result.commitOid.slice(0, 7)} to GitHub.`),
+    onError: (error) => toast.error(error instanceof Error ? error.message : "Push failed."),
+  });
+  const sync = useMutation({
+    mutationFn: () => itx.repos.get(repoPath).syncFromGithub({}),
+    onSuccess: (result) =>
+      toast.success(
+        result.changed
+          ? `Synced to GitHub's head ${result.commitOid.slice(0, 7)}.`
+          : "Already at GitHub's head.",
+      ),
+    onError: (error) => toast.error(error instanceof Error ? error.message : "Sync failed."),
+  });
+  const unlink = useMutation({
+    mutationFn: () => itx.repos.get(repoPath).unlinkGithub(),
+    onSuccess: () => toast.success("GitHub link removed."),
+    onError: (error) => toast.error(error instanceof Error ? error.message : "Could not unlink."),
+  });
+  const busy = push.isPending || sync.isPending || unlink.isPending;
+
+  return (
+    <div className="flex flex-col gap-3 p-3">
+      <div className="flex flex-col gap-1">
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Linked repository
+        </span>
+        <a
+          className="flex items-center gap-1 font-mono text-xs underline underline-offset-2"
+          href={`https://github.com/${github.owner}/${github.repo}`}
+          rel="noreferrer"
+          target="_blank"
+        >
+          {github.owner}/{github.repo}
+          <ExternalLinkIcon className="size-3" />
+        </a>
+        <span className="text-xs text-muted-foreground">via {github.connection}</span>
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Last mirror push
+        </span>
+        {lastPush === null ? (
+          <span className="text-xs text-muted-foreground">None yet.</span>
+        ) : lastPush.ok ? (
+          <span className="text-xs text-muted-foreground">
+            ok — <span className="font-mono">{lastPush.commitOid?.slice(0, 7)}</span> at{" "}
+            {lastPush.at}
+          </span>
+        ) : (
+          <span className="break-all text-xs text-red-600">
+            failed at {lastPush.at}: {lastPush.error}
+          </span>
+        )}
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <Button
+          size="sm"
+          variant="outline"
+          className="text-xs"
+          disabled={busy}
+          onClick={() => push.mutate()}
+        >
+          {push.isPending ? "Pushing…" : "Push now"}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          className="text-xs"
+          disabled={busy}
+          onClick={() => sync.mutate()}
+        >
+          {sync.isPending ? "Syncing…" : "Sync from GitHub"}
+        </Button>
+        <Button
+          size="sm"
+          variant="destructive"
+          className="text-xs"
+          disabled={busy}
+          onClick={() => unlink.mutate()}
+        >
+          {unlink.isPending ? "Unlinking…" : "Unlink"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function LinkForm({ projectId, repoPath }: { projectId: string; repoPath: string }) {
+  const itx = useItx();
+  const params = useParams({ strict: false }) as { projectSlug?: string };
+  const connections = useItxQuery({
+    key: ["github-connections", projectId],
+    query: async (itx) => {
+      const entries = await itx.integrations.list();
+      // Only builtin GitHub connections can back a repo (they carry the App
+      // installation the mirror pushes authenticate through).
+      return entries.flatMap((entry) =>
+        entry.source === "builtin" && entry.integration === "github" ? [entry.connection] : [],
+      );
+    },
+  });
+  const [connection, setConnection] = useState("");
+  const [owner, setOwner] = useState("");
+  const [repo, setRepo] = useState("");
+  const link = useMutation({
+    mutationFn: () => itx.repos.get(repoPath).linkGithub({ connection, owner, repo }),
+    onSuccess: (result) => {
+      if (result.initialPush.ok) {
+        toast.success(
+          `Linked to ${result.owner}/${result.repo}${result.created ? " (created)" : ""}; mirror seeded at ${result.initialPush.commitOid?.slice(0, 7)}.`,
+        );
+      } else {
+        toast.warning(
+          `Linked to ${result.owner}/${result.repo}, but the initial push failed: ${result.initialPush.error}. Use "Sync from GitHub" to adopt its history, or "Push now" to retry.`,
+        );
+      }
+    },
+    onError: (error) => toast.error(error instanceof Error ? error.message : "Could not link."),
+  });
+
+  if (connections.length === 0) {
+    return (
+      <div className="p-3 text-xs text-muted-foreground">
+        Back this repo with GitHub by connecting a GitHub account on the{" "}
+        {params.projectSlug === undefined ? (
+          "integrations page"
+        ) : (
+          <Link
+            className="underline underline-offset-2"
+            to="/projects/$projectSlug/integrations"
+            params={{ projectSlug: params.projectSlug }}
+          >
+            integrations page
+          </Link>
+        )}
+        , then linking a repository here.
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className="flex flex-col gap-2 p-3"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (connection === "" || owner.trim() === "" || repo.trim() === "") return;
+        link.mutate();
+      }}
+    >
+      <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        Back this repo with GitHub
+      </span>
+      <p className="text-xs text-muted-foreground">
+        Commits mirror out automatically; GitHub webhooks about the repository land on this repo's
+        stream. The repository is created (private) if missing and the installation can create org
+        repositories.
+      </p>
+      <NativeSelect
+        size="sm"
+        className="w-full"
+        value={connection}
+        onChange={(event) => setConnection(event.target.value)}
+      >
+        <NativeSelectOption value="">Pick a connection…</NativeSelectOption>
+        {connections.map((name) => (
+          <NativeSelectOption key={name} value={name}>
+            {name}
+          </NativeSelectOption>
+        ))}
+      </NativeSelect>
+      <Input
+        placeholder="Owner (org)"
+        className="h-8 text-xs"
+        value={owner}
+        onChange={(event) => setOwner(event.target.value)}
+      />
+      <Input
+        placeholder="Repository"
+        className="h-8 text-xs"
+        value={repo}
+        onChange={(event) => setRepo(event.target.value)}
+      />
+      <Button
+        type="submit"
+        size="sm"
+        className="text-xs"
+        disabled={link.isPending || connection === "" || owner.trim() === "" || repo.trim() === ""}
+      >
+        {link.isPending ? "Linking…" : "Link to GitHub"}
+      </Button>
+    </form>
+  );
+}

--- a/apps/os/src/components/repo-ide/repo-github-panel.tsx
+++ b/apps/os/src/components/repo-ide/repo-github-panel.tsx
@@ -154,7 +154,11 @@ function LinkForm({ projectId, repoPath }: { projectId: string; repoPath: string
   const [owner, setOwner] = useState("");
   const [repo, setRepo] = useState("");
   const link = useMutation({
-    mutationFn: () => itx.repos.get(repoPath).linkGithub({ connection, owner, repo }),
+    // Trimmed at the call, not just in the enable-check: a padded owner/repo
+    // would store a link (and a full_name webhook condition) GitHub payloads
+    // never match — mirroring would work while cross-post silently didn't.
+    mutationFn: () =>
+      itx.repos.get(repoPath).linkGithub({ connection, owner: owner.trim(), repo: repo.trim() }),
     onSuccess: (result) => {
       if (result.initialPush.ok) {
         toast.success(

--- a/apps/os/src/components/repo-ide/repo-ide.tsx
+++ b/apps/os/src/components/repo-ide/repo-ide.tsx
@@ -231,7 +231,18 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
       <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
         <ResizablePanel defaultSize="20%" minSize="10rem" className="min-w-0">
           {gh ? (
-            <RepoGithubPanel projectId={projectId} repoPath={repoPath} />
+            // Own Suspense (like RepoEditorPane's): the panel's first
+            // connections read suspends, and without a local boundary that
+            // would bubble to the route's ItxBoundary and blank the whole IDE.
+            <Suspense
+              fallback={
+                <div className="p-3 text-xs text-muted-foreground" data-spinner="true">
+                  Loading…
+                </div>
+              }
+            >
+              <RepoGithubPanel projectId={projectId} repoPath={repoPath} />
+            </Suspense>
           ) : scm ? (
             <GitPanel
               changes={changes}

--- a/apps/os/src/components/repo-ide/repo-ide.tsx
+++ b/apps/os/src/components/repo-ide/repo-ide.tsx
@@ -5,6 +5,7 @@ import {
   FilesIcon,
   GitBranchIcon,
   GitCommitVerticalIcon,
+  GithubIcon,
   MinusIcon,
   PlusIcon,
   Undo2Icon,
@@ -20,6 +21,7 @@ import { toast } from "@iterate-com/ui/components/sonner";
 import { isBinaryRepoPath } from "./repo-file-kinds.ts";
 import { localFileToBase64, pickLocalFile } from "./local-file.ts";
 import { RepoEditorPane } from "./repo-editor-pane.tsx";
+import { RepoGithubPanel } from "./repo-github-panel.tsx";
 import { RepoFileTree, type RepoTreeActions } from "./repo-file-tree.tsx";
 import {
   commitPlan,
@@ -48,7 +50,7 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
   const changes = useWorkingTree(store);
   const headPaths = files.paths;
   const headPathSet = new Set(headPaths);
-  const { file: selectedPath, diff, scm, stagedView, patchSearch } = useRepoIdeSearch();
+  const { file: selectedPath, diff, scm, gh, stagedView, patchSearch } = useRepoIdeSearch();
 
   const selectFile = useCallback(
     (path: string | undefined) => patchSearch({ file: path, diff: undefined, staged: undefined }),
@@ -191,12 +193,12 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
       {/* vscode-style activity strip: Files / Source control. */}
       <div className="flex shrink-0 flex-col items-center gap-1 border-r px-1 py-2">
         <Button
-          variant={scm ? "ghost" : "secondary"}
+          variant={scm || gh ? "ghost" : "secondary"}
           size="icon"
           title="Files"
           // The Files view browses working-tree files; leaving the SCM view
           // also leaves any Index pseudo-file it had open.
-          onClick={() => patchSearch({ scm: undefined, staged: undefined })}
+          onClick={() => patchSearch({ scm: undefined, gh: undefined, staged: undefined })}
           className="text-muted-foreground"
         >
           <FilesIcon className="size-4" />
@@ -205,7 +207,7 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
           variant={scm ? "secondary" : "ghost"}
           size="icon"
           title="Source control"
-          onClick={() => patchSearch({ scm: true })}
+          onClick={() => patchSearch({ scm: true, gh: undefined })}
           className="relative text-muted-foreground"
         >
           <GitBranchIcon className="size-4" />
@@ -215,11 +217,22 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
             </span>
           )}
         </Button>
+        <Button
+          variant={gh ? "secondary" : "ghost"}
+          size="icon"
+          title="GitHub"
+          onClick={() => patchSearch({ gh: true, scm: undefined })}
+          className="text-muted-foreground"
+        >
+          <GithubIcon className="size-4" />
+        </Button>
       </div>
 
       <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
         <ResizablePanel defaultSize="20%" minSize="10rem" className="min-w-0">
-          {scm ? (
+          {gh ? (
+            <RepoGithubPanel projectId={projectId} repoPath={repoPath} />
+          ) : scm ? (
             <GitPanel
               changes={changes}
               headPathSet={headPathSet}
@@ -486,15 +499,17 @@ function GitPanel({
 
 /**
  * IDE view state, URL-owned like every stream view's: `file` is the open
- * path, `diff` whether the HEAD↔staged diff is showing, `scm` whether the
- * sidebar shows Source Control instead of the file tree. The repo detail
- * route validates these (RepoDetailSearch), so loose reads here are safe.
+ * path, `diff` whether the HEAD↔staged diff is showing, `scm`/`gh` which
+ * sidebar shows instead of the file tree (Source Control / GitHub). The repo
+ * detail route validates these (RepoDetailSearch), so loose reads here are
+ * safe.
  */
 function useRepoIdeSearch() {
   const search = useSearch({ strict: false }) as {
     file?: string;
     diff?: boolean;
     scm?: boolean;
+    gh?: boolean;
     staged?: boolean;
   };
   const navigate = useNavigate();
@@ -503,6 +518,7 @@ function useRepoIdeSearch() {
       file?: string | undefined;
       diff?: boolean | undefined;
       scm?: boolean | undefined;
+      gh?: boolean | undefined;
       staged?: boolean | undefined;
     }) => {
       void navigate({
@@ -519,6 +535,7 @@ function useRepoIdeSearch() {
     file: search.file,
     diff: search.diff === true,
     scm: search.scm === true,
+    gh: search.gh === true,
     stagedView: search.staged === true,
     patchSearch,
   };

--- a/apps/os/src/domains/repos/github-link.test.ts
+++ b/apps/os/src/domains/repos/github-link.test.ts
@@ -306,6 +306,15 @@ describe("linkRepoToGithub", () => {
       },
     });
 
+    // A failed old-rule removal aborts the re-link BEFORE anything changes:
+    // the link still names the old connection and a retry starts clean.
+    network.state.ruleRemoveAppendShouldFail = true;
+    await expect(linkRepoToGithub({ ...linkInput(), connection: otherConnection })).rejects.toThrow(
+      /rule-removed append exploded/,
+    );
+    expect(network.state.githubLink).toMatchObject({ connection: CONNECTION });
+    network.state.ruleRemoveAppendShouldFail = false;
+
     await linkRepoToGithub({ ...linkInput(), connection: otherConnection });
 
     // The new connection stream holds the rule; the old one got the removal.

--- a/apps/os/src/domains/repos/github-link.test.ts
+++ b/apps/os/src/domains/repos/github-link.test.ts
@@ -328,6 +328,50 @@ describe("linkRepoToGithub", () => {
     expect(oldRemoved?.payload).toEqual({ ruleId: "github-repo:/repos/project" });
     expect(network.state.githubLink).toMatchObject({ connection: otherConnection });
   });
+
+  test("a failed re-link restores the previous connection's rule", async () => {
+    seedConnectedFact();
+    await linkRepoToGithub(linkInput());
+
+    const otherConnection = "install-456";
+    const otherConnectionStream = DurableObjectNameCodec.stringify({
+      projectId: PROJECT_ID,
+      path: `/integrations/github/${otherConnection}`,
+    });
+    network.seedStream(otherConnectionStream, {
+      type: GITHUB_CONNECTED_EVENT_TYPE,
+      payload: {
+        connection: otherConnection,
+        externalId: "456",
+        installationId: "456",
+        projectId: PROJECT_ID,
+      },
+    });
+
+    // The old rule is removed first; when recording the new link then fails,
+    // the compensation must put the OLD connection's rule back so the still-
+    // recorded old link keeps its webhook lane.
+    network.state.configureLinkShouldFail = true;
+    await expect(linkRepoToGithub({ ...linkInput(), connection: otherConnection })).rejects.toThrow(
+      /link write exploded/,
+    );
+    expect(network.state.githubLink).toMatchObject({ connection: CONNECTION });
+
+    const oldStreamEvents = network.streams.get(CONNECTION_STREAM) ?? [];
+    const lastRuleFact = [...oldStreamEvents]
+      .reverse()
+      .find(
+        (e) =>
+          e.type === "events.iterate.com/stream/rule-configured" ||
+          e.type === "events.iterate.com/stream/rule-removed",
+      );
+    // The restore (a rule-configured) landed AFTER the removal.
+    expect(lastRuleFact?.type).toBe("events.iterate.com/stream/rule-configured");
+    expect(lastRuleFact?.payload).toMatchObject({
+      condition: 'payload.body.repository.full_name = "acme/widgets"',
+      ruleId: "github-repo:/repos/project",
+    });
+  });
 });
 
 describe("unlinkRepoFromGithub", () => {

--- a/apps/os/src/domains/repos/github-link.ts
+++ b/apps/os/src/domains/repos/github-link.ts
@@ -31,6 +31,27 @@ function githubCrossPostRuleId(repoPath: string): string {
   return `github-repo:${repoPath}`;
 }
 
+/** The cross-post rule copying one repository's GitHub webhooks from a
+ * connection stream onto the repo's own stream — built in one place so the
+ * install and the re-link compensation (restore) can never drift. */
+function githubCrossPostRuleEvent(input: {
+  owner: string;
+  repo: string;
+  repoPath: string;
+  ruleId: string;
+}) {
+  return {
+    type: "events.iterate.com/stream/rule-configured",
+    payload: {
+      condition: `payload.body.repository.full_name = ${JSON.stringify(`${input.owner}/${input.repo}`)}`,
+      eventTypes: [GITHUB_WEBHOOK_RECEIVED_EVENT_TYPE],
+      path: input.repoPath,
+      ruleId: input.ruleId,
+      type: "cross-post",
+    },
+  };
+}
+
 export async function linkRepoToGithub(input: {
   connection: string;
   owner: string;
@@ -100,7 +121,10 @@ export async function linkRepoToGithub(input: {
   // moved and a retry starts clean, whereas removing it later would let a
   // failure strand a live duplicate rule that a retried linkGithub (whose
   // stored link already names the new connection) could never find again.
-  // Same connection needs nothing: the rule-configured below replaces by id.
+  // If a LATER step fails, the compensation below reinstalls this exact rule
+  // (the previous link carries everything needed to rebuild it), so the old
+  // link never sits ruleless. Same connection needs nothing: the
+  // rule-configured below replaces by id.
   if (previous !== null && previous.connection !== input.connection) {
     await integrationStreamStub(
       input.projectId,
@@ -113,43 +137,56 @@ export async function linkRepoToGithub(input: {
   // the ones about the linked repository onto the repo's own stream. The rule
   // goes in BEFORE the link is recorded — "linked" must always imply
   // "webhooks route" — and the link write is the commit point: if it fails,
-  // the just-installed rule is rolled back.
+  // the just-installed rule is rolled back and the previous connection's rule
+  // (removed above) is reinstalled.
   const connectionStream = integrationStreamStub(
     input.projectId,
     integrationConnectionStreamPath("github", input.connection),
   );
-  await connectionStream.append({
-    type: "events.iterate.com/stream/rule-configured",
-    payload: {
-      condition: `payload.body.repository.full_name = ${JSON.stringify(`${owner}/${repo}`)}`,
-      eventTypes: [GITHUB_WEBHOOK_RECEIVED_EVENT_TYPE],
-      path: repoPath,
-      ruleId,
-      type: "cross-post",
-    },
-  });
   try {
+    await connectionStream.append(githubCrossPostRuleEvent({ owner, repo, repoPath, ruleId }));
     await repoStub.configureGithubLink(link);
   } catch (error) {
+    const compensations: string[] = [];
+    // Roll back the new rule (a no-op fold if the failure happened before it
+    // committed) and restore the previous connection's rule so the still-
+    // recorded old link keeps its webhook lane. Both best-effort: compensation
+    // failures are named in the surfaced error, and a re-run of linkGithub
+    // repairs everything (rules replace by id).
     try {
       await connectionStream.append({
         type: "events.iterate.com/stream/rule-removed",
         payload: { ruleId },
       });
     } catch (rollbackError) {
-      // A failed rollback leaves a live rule with no recorded link. Say so
-      // loudly in the surfaced error: re-running linkGithub replaces the rule
-      // by id, so the repair is one retry away — but only if the caller knows.
-      console.error("github link rollback failed; cross-post rule is orphaned", {
-        repoPath,
-        ruleId,
-        rollbackError,
-      });
-      throw new Error(
-        `${String(error)} (additionally, rolling back the webhook cross-post rule "${ruleId}" on the connection stream failed — re-run linkGithub to replace it, or unlink after a successful link: ${String(rollbackError)})`,
+      compensations.push(
+        `rolling back the webhook rule "${ruleId}" on connection "${input.connection}" failed (${String(rollbackError)})`,
       );
     }
-    throw error;
+    if (previous !== null && previous.connection !== input.connection) {
+      try {
+        await integrationStreamStub(
+          input.projectId,
+          integrationConnectionStreamPath("github", previous.connection),
+        ).append(
+          githubCrossPostRuleEvent({
+            owner: previous.owner,
+            repo: previous.repo,
+            repoPath,
+            ruleId,
+          }),
+        );
+      } catch (restoreError) {
+        compensations.push(
+          `restoring the previous webhook rule on connection "${previous.connection}" failed (${String(restoreError)})`,
+        );
+      }
+    }
+    if (compensations.length === 0) throw error;
+    console.error("github link compensation failed", { repoPath, ruleId, compensations });
+    throw new Error(
+      `${String(error)} (additionally: ${compensations.join("; ")} — re-run linkGithub to repair, rules replace by id)`,
+    );
   }
 
   // Seed the mirror right away so "linked" means "visible on GitHub", not

--- a/apps/os/src/domains/repos/github-link.ts
+++ b/apps/os/src/domains/repos/github-link.ts
@@ -86,6 +86,20 @@ export async function linkRepoToGithub(input: {
   const previous = await repoStub.getGithubLink();
   const ruleId = githubCrossPostRuleId(repoPath);
 
+  // Re-linking through a DIFFERENT connection: the previous connection's
+  // stream holds this repo's rule (same ruleId, other stream). Remove it
+  // FIRST, before anything else changes — if the removal fails nothing has
+  // moved and a retry starts clean, whereas removing it later would let a
+  // failure strand a live duplicate rule that a retried linkGithub (whose
+  // stored link already names the new connection) could never find again.
+  // Same connection needs nothing: the rule-configured below replaces by id.
+  if (previous !== null && previous.connection !== input.connection) {
+    await integrationStreamStub(
+      input.projectId,
+      integrationConnectionStreamPath("github", previous.connection),
+    ).append({ type: "events.iterate.com/stream/rule-removed", payload: { ruleId } });
+  }
+
   // The webhook lane: GitHub App webhooks already land verbatim on the
   // connection stream (`/integrations/github/<connection>`); this rule copies
   // the ones about the linked repository onto the repo's own stream. The rule
@@ -109,21 +123,25 @@ export async function linkRepoToGithub(input: {
   try {
     await repoStub.configureGithubLink(link);
   } catch (error) {
-    await connectionStream
-      .append({ type: "events.iterate.com/stream/rule-removed", payload: { ruleId } })
-      .catch(() => {});
+    try {
+      await connectionStream.append({
+        type: "events.iterate.com/stream/rule-removed",
+        payload: { ruleId },
+      });
+    } catch (rollbackError) {
+      // A failed rollback leaves a live rule with no recorded link. Say so
+      // loudly in the surfaced error: re-running linkGithub replaces the rule
+      // by id, so the repair is one retry away — but only if the caller knows.
+      console.error("github link rollback failed; cross-post rule is orphaned", {
+        repoPath,
+        ruleId,
+        rollbackError,
+      });
+      throw new Error(
+        `${String(error)} (additionally, rolling back the webhook cross-post rule "${ruleId}" on the connection stream failed — re-run linkGithub to replace it, or unlink after a successful link: ${String(rollbackError)})`,
+      );
+    }
     throw error;
-  }
-
-  // Re-linking through a DIFFERENT connection: the previous connection's
-  // stream still holds this repo's rule (same ruleId, other stream) — remove
-  // it so the old installation's webhooks stop cross-posting here. Same
-  // connection needs nothing: the rule-configured above replaced it by id.
-  if (previous !== null && previous.connection !== input.connection) {
-    await integrationStreamStub(
-      input.projectId,
-      integrationConnectionStreamPath("github", previous.connection),
-    ).append({ type: "events.iterate.com/stream/rule-removed", payload: { ruleId } });
   }
 
   // Seed the mirror right away so "linked" means "visible on GitHub", not

--- a/apps/os/src/domains/repos/github-link.ts
+++ b/apps/os/src/domains/repos/github-link.ts
@@ -39,6 +39,14 @@ export async function linkRepoToGithub(input: {
   repoPath: string;
 }): Promise<LinkGithubResult> {
   const repoPath = normalizePath(input.repoPath);
+  // Trim at the boundary: a padded owner/repo would store a link (and a
+  // full_name webhook condition) GitHub payloads never match — mirroring
+  // would appear to work while webhook cross-post silently didn't.
+  const owner = input.owner.trim();
+  const repo = input.repo.trim();
+  if (owner === "" || repo === "") {
+    throw new Error("linkGithub requires a non-empty owner and repo.");
+  }
   const status = await getConnectionStatus({
     connection: input.connection,
     projectId: input.projectId,
@@ -53,7 +61,7 @@ export async function linkRepoToGithub(input: {
   const octokit = connectionOctokit({ connection: input.connection, projectId: input.projectId });
   let created = false;
   try {
-    await octokit.rest.repos.get({ owner: input.owner, repo: input.repo });
+    await octokit.rest.repos.get({ owner, repo });
   } catch (error) {
     if ((error as { status?: number }).status !== 404) {
       throw normalizeGithubError(error, input.connection);
@@ -64,14 +72,14 @@ export async function linkRepoToGithub(input: {
     // the actionable "create it on GitHub first" case.
     try {
       await octokit.rest.repos.createInOrg({
-        name: input.repo,
-        org: input.owner,
+        name: repo,
+        org: owner,
         private: true,
       });
       created = true;
     } catch (createError) {
       throw new Error(
-        `GitHub repository ${input.owner}/${input.repo} does not exist and could not be created via connection "${input.connection}" (App installations can only create org repositories, and need Administration write). Create it on GitHub and link again. Cause: ${normalizeGithubError(createError, input.connection).message}`,
+        `GitHub repository ${owner}/${repo} does not exist and could not be created via connection "${input.connection}" (App installations can only create org repositories, and need Administration write). Create it on GitHub and link again. Cause: ${normalizeGithubError(createError, input.connection).message}`,
       );
     }
   }
@@ -79,8 +87,8 @@ export async function linkRepoToGithub(input: {
   const link: GithubRepoLink = {
     connection: input.connection,
     installationId: status.externalId,
-    owner: input.owner,
-    repo: input.repo,
+    owner,
+    repo,
   };
   const repoStub = repoDurableObjectStub(input.projectId, repoPath);
   const previous = await repoStub.getGithubLink();
@@ -113,7 +121,7 @@ export async function linkRepoToGithub(input: {
   await connectionStream.append({
     type: "events.iterate.com/stream/rule-configured",
     payload: {
-      condition: `payload.body.repository.full_name = ${JSON.stringify(`${input.owner}/${input.repo}`)}`,
+      condition: `payload.body.repository.full_name = ${JSON.stringify(`${owner}/${repo}`)}`,
       eventTypes: [GITHUB_WEBHOOK_RECEIVED_EVENT_TYPE],
       path: repoPath,
       ruleId,

--- a/apps/os/src/ingress.test.ts
+++ b/apps/os/src/ingress.test.ts
@@ -81,6 +81,26 @@ it("sends itx paths on the OS host to the api lane", async () => {
   }
 });
 
+it("sends integration webhook ingress paths to the api lane", async () => {
+  // The webhook door lives in the api pipeline (worker.ts), NOT the app
+  // router: a webhook path that stays on the "os" lane 404s in the SSR app —
+  // which is exactly how prd GitHub webhooks were silently dead until
+  // 2026-07-08 (the path below was missing from the lane predicate).
+  for (const path of [
+    "/api/integrations/slack/webhook",
+    "/api/integrations/slack/interactivity-webhook",
+    "/api/integrations/github/webhook",
+  ]) {
+    const route = await decideIngressRoute({
+      config: DEV_CONFIG,
+      method: "POST",
+      resolvers: resolversThatShouldNotBeUsed(),
+      url: `http://localhost:56455${path}`,
+    });
+    expect(route).toMatchObject({ lane: "api" });
+  }
+});
+
 it("rewrites the /prj_<id> path lane to the project sub-path", async () => {
   const route = await decideIngressRoute({
     config: DEV_CONFIG,

--- a/apps/os/src/ingress.ts
+++ b/apps/os/src/ingress.ts
@@ -141,17 +141,17 @@ function projectRoute(input: {
 
 /**
  * Path lanes served by the api pipeline on the OS host: the capnweb rpc
- * endpoint at exactly `/api` (plus its admin-cookie bridge), the Slack
- * webhook ingress lanes. Deliberately exact-match: other `/api/*` paths
- * (`/api/mcp`, `/api/health`, the OAuth
- * callback routes under `/api/integrations/...`) are app routes and stay on
- * the "os" lane.
+ * endpoint at exactly `/api` (plus its admin-cookie bridge), the Slack and
+ * GitHub webhook ingress lanes. Deliberately exact-match: other `/api/*`
+ * paths (`/api/mcp`, `/api/health`, the OAuth callback routes under
+ * `/api/integrations/...`) are app routes and stay on the "os" lane.
  */
 function isApiWorkerLanePath(pathname: string): boolean {
   if (pathname === "/api" || pathname === "/api/admin-cookie") return true;
   if (
     pathname === "/api/integrations/slack/webhook" ||
-    pathname === "/api/integrations/slack/interactivity-webhook"
+    pathname === "/api/integrations/slack/interactivity-webhook" ||
+    pathname === "/api/integrations/github/webhook"
   ) {
     return true;
   }

--- a/apps/os/src/routes/_app/projects/$projectSlug/repos/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/repos/$.tsx
@@ -10,11 +10,12 @@ import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 import { useItxState } from "~/itx/itx-react.tsx";
 
 /** The stream-view params plus the IDE's own view state (open file, diff,
- * source-control sidebar). */
+ * source-control / GitHub sidebar). */
 const RepoDetailSearch = StreamViewSearch.extend({
   file: z.string().optional().catch(undefined),
   diff: z.boolean().optional().catch(undefined),
   scm: z.boolean().optional().catch(undefined),
+  gh: z.boolean().optional().catch(undefined),
   staged: z.boolean().optional().catch(undefined),
 });
 


### PR DESCRIPTION
Follow-up to #1751, closing out what the live prd test and the last Bugbot rounds surfaced.

## Webhook ingress lane fix (the big one)

`/api/integrations/github/webhook` was never added to `isApiWorkerLanePath` in `ingress.ts` — only the Slack webhook paths were. GitHub webhook deliveries therefore fell through to the SSR app router and answered **404**: GitHub webhook ingestion in prd has never actually worked (the App's `/app/hook/deliveries` log confirms 404s for every delivery). One-line lane fix + a regression test asserting all three webhook ingress paths route to the api lane.

(Companion prd config fix already applied in Doppler: the GitHub App webhook secret was stored as `webhookSigningSecret` but the schema reads `webhookSecret`; renamed in prd/dev/preview roots.)

## Link-flow hardening (Bugbot findings from #1751 posted around/after merge)

- **Re-link through a different connection removes the old connection's rule FIRST.** Previously the new link was recorded before removing the old rule, so a failed removal stranded a duplicate rule that a retried `linkGithub` (whose stored link already names the new connection) could never find. Now a failure changes nothing and retry starts clean. Unit-tested.
- **A failed rule rollback is no longer silent.** If recording the link fails AND rolling back the just-installed rule also fails, the error now names the orphaned ruleId and the repair path (re-run linkGithub / unlink after a successful link), and the failure is logged.

## Repos UI: GitHub panel in the mini-IDE

The repo IDE (#1759) gains a third activity-strip icon (GitHub):

- **Linked**: owner/repo (linked to github.com), connection, last mirror-push outcome (ok/failed + oid + time), and Push now / Sync from GitHub / Unlink actions.
- **Unlinked**: a link form — GitHub connection picker (builtin connections from `itx.integrations.list()`), owner, repository — calling `repo.linkGithub` (create-on-link, private). A failed initial push warns with the sync/push repair options rather than failing the link.
- **No connections**: points at the integrations page.

State is the live repo processor push, so link/push facts fold into the panel as they land. Verified rendering against local dev (`?gh=true`).

## Live prd status (from the #1751 smoke on the nustom project)

Everything except webhooks is already **proven live**: `linkGithub` created `iterate/iterate-os-linked-repo-smoke` (private) via create-on-link and seeded the mirror; a `commitFiles` auto-mirrored with the identical commit oid; `syncFromGithub` fast-forwarded to a commit made directly on GitHub. The webhook cross-post leg is what this PR's ingress fix unblocks — will re-verify live after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ingress routing (production webhook path) and stream-rule ordering/compensation during link/re-link; UI changes are additive and low risk.
> 
> **Overview**
> **Fixes production GitHub webhook delivery** by routing `POST /api/integrations/github/webhook` to the API worker lane (same as Slack). Without this, requests hit the SSR app and return 404, so webhook ingestion never ran in prd. Adds a regression test for all integration webhook ingress paths.
> 
> **Hardens `linkRepoToGithub`** for connection switches and partial failures: trims `owner`/`repo` before storing webhook match conditions; removes the previous connection’s cross-post rule *before* installing the new one so a failed removal leaves state retryable; on link-write failure, rolls back the new rule and restores the old connection’s rule via a shared `githubCrossPostRuleEvent` helper, with explicit errors if compensation append fails. Unit tests cover abort-on-failed old-rule removal and restore-after-failed re-link.
> 
> **Adds a GitHub sidebar to the repo mini-IDE** (`?gh=true`): third activity icon, live processor state for link and last mirror push, link form (builtin GitHub connections) or linked view with push/sync/unlink, wrapped in local `Suspense` so connection listing doesn’t blank the whole IDE.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 040de1ba0c05595e3bf7c362bf806bddec0d0f7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +103 -39 | +73 -27 🟩🟥⬜⬜⬜ |
| UI components | +284 -8 | +258 -5 🟩🟩🟩🟩🟩 |
| Tests | +73 -0 | +57 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+460 -47** | **+388 -32** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 6a695fc and 040de1b, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-08T17:37:21.913Z",
      "headSha": "040de1ba0c05595e3bf7c362bf806bddec0d0f7a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/66998365531124",
      "shortSha": "040de1b",
      "cleanupDurationMs": 4277,
      "deployDurationMs": 153166,
      "testDurationMs": 137732,
      "testRetries": "2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page appends a batch and renders every delivered marker (specs x1)",
      "workerSizeKib": 11946.83,
      "workerGzipKib": 3192.18,
      "mainWorkerGzipKib": 3200.66
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-08T17:37:20.228Z",
      "headSha": "040de1ba0c05595e3bf7c362bf806bddec0d0f7a",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/66998365531124",
      "shortSha": "040de1b",
      "cleanupDurationMs": 2589,
      "deployDurationMs": 18266,
      "testDurationMs": 702,
      "testRetries": null,
      "workerSizeKib": 3992.8,
      "workerGzipKib": 812.23,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `040de1b` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 812.2 KiB | 18.3s | 702ms |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/66998365531124) | 2026-07-08T17:37:20.228Z | Preview app released. |
| OS | released | `040de1b` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 3.12 MiB (-8.5 KiB vs main) | 153.2s | 137.7s | 2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page appends a batch and renders every delivered marker (specs x1) | 4.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/66998365531124) | 2026-07-08T17:37:21.913Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->