### PR TITLE
linkGithub: name the real cause when the repo exists but the installation can't see it

### DIFF
--- a/apps/os/src/domains/repos/github-link.test.ts
+++ b/apps/os/src/domains/repos/github-link.test.ts
@@ -104,6 +104,24 @@ const network = vi.hoisted(() => {
               return Response.json({ message: "Not Found" }, { status: 404 });
             }
             if (request.method === "POST" && /^\/orgs\/[^/]+\/repos$/.test(url.pathname)) {
+              if (network.state.githubCreateStatus === 422) {
+                // What real GitHub answers when the name is taken — the shape
+                // the exists-but-not-selected detection keys off.
+                return Response.json(
+                  {
+                    errors: [
+                      {
+                        code: "custom",
+                        field: "name",
+                        message: "name already exists on this account",
+                        resource: "Repository",
+                      },
+                    ],
+                    message: "Repository creation failed.",
+                  },
+                  { status: 422 },
+                );
+              }
               if (network.state.githubCreateStatus !== 201) {
                 return Response.json(
                   { message: "Resource not accessible by integration" },
@@ -245,6 +263,25 @@ describe("linkRepoToGithub", () => {
     network.state.githubCreateStatus = 403;
 
     await expect(linkRepoToGithub(linkInput())).rejects.toThrow(/could not be created/);
+    // Nothing was linked and no rule was installed.
+    expect(network.repoCalls).toEqual([]);
+    expect(
+      network.streams
+        .get(CONNECTION_STREAM)
+        ?.some((event) => event.type === "events.iterate.com/stream/rule-configured"),
+    ).toBe(false);
+  });
+
+  test("names the real cause when the repo exists but the installation cannot see it", async () => {
+    seedConnectedFact();
+    // GET /repos 404s (unselected repos are invisible to the installation)
+    // while the create 422s on the taken name — the exists-but-no-access case.
+    network.state.githubRepoExists = false;
+    network.state.githubCreateStatus = 422;
+
+    await expect(linkRepoToGithub(linkInput())).rejects.toThrow(
+      /exists, but connection "install-789" \(App installation 789\) has no access to it.*github\.com\/organizations\/acme\/settings\/installations\/789/,
+    );
     // Nothing was linked and no rule was installed.
     expect(network.repoCalls).toEqual([]);
     expect(

--- a/apps/os/src/domains/repos/github-link.ts
+++ b/apps/os/src/domains/repos/github-link.ts
@@ -25,6 +25,18 @@ import {
 } from "../integrations/utils.ts";
 import type { GithubRepoLink, LinkGithubResult } from "./types.ts";
 
+/** Whether a failed repo-create was GitHub's 422 "name already exists" — the
+ * tell that the repository IS there but the installation cannot see it (an App
+ * installed with "selected repositories" answers 404 on `GET /repos/...` for
+ * unselected repos, so create-on-link runs into the existing name). */
+function isGithubNameAlreadyExistsError(error: unknown): boolean {
+  const e = error as { message?: string; response?: { data?: unknown }; status?: number };
+  if (e.status !== 422) return false;
+  const data = e.response?.data;
+  const text = typeof data === "string" ? data : JSON.stringify(data ?? "");
+  return text.includes("name already exists") || (e.message ?? "").includes("name already exists");
+}
+
 /** The one rule id a repo's GitHub webhook cross-post rule lives under, so
  * re-linking replaces it and unlinking knows what to remove. */
 function githubCrossPostRuleId(repoPath: string): string {
@@ -99,6 +111,15 @@ export async function linkRepoToGithub(input: {
       });
       created = true;
     } catch (createError) {
+      // "name already exists" means the earlier 404 was an ACCESS miss, not a
+      // missing repo: the App is installed with "selected repositories" and
+      // this one is not selected. Say so — the generic message below claims
+      // the repository "does not exist", the opposite of the truth.
+      if (isGithubNameAlreadyExistsError(createError)) {
+        throw new Error(
+          `GitHub repository ${owner}/${repo} exists, but connection "${input.connection}" (App installation ${status.externalId}) has no access to it — the App is installed with "selected repositories" and this one is not selected. An org owner can grant access under Repository access at https://github.com/organizations/${owner}/settings/installations/${status.externalId}, then link again.`,
+        );
+      }
       throw new Error(
         `GitHub repository ${owner}/${repo} does not exist and could not be created via connection "${input.connection}" (App installations can only create org repositories, and need Administration write). Create it on GitHub and link again. Cause: ${normalizeGithubError(createError, input.connection).message}`,
       );


### PR DESCRIPTION
## What

Linking a repo to GitHub failed in prd with:

> GitHub repository iterate/config does not exist and could not be created via connection "install-115079265" ... Cause: GitHub API failed with HTTP 422: Repository creation failed.: {"resource":"Repository","code":"custom","field":"name","message":"name already exists on this account"}

The repository **does** exist — the App installation just can't see it. A GitHub App installed with "selected repositories" answers 404 on `GET /repos/{owner}/{repo}` for unselected repos, so `linkRepoToGithub`'s create-on-link path runs into the taken name and the surfaced error claims the opposite of the truth ("does not exist ... create it on GitHub").

## Fix

Detect the 422 "name already exists" create failure and throw the accurate, actionable error: the repo exists, the connection's installation has no access, and an org owner can grant it under **Repository access** at `https://github.com/organizations/<org>/settings/installations/<id>`.

Verified against prd: installation 115079265 (`iterate` App, `repository_selection: selected`) sees only `iterate/iterate` and `iterate/iterate-os-linked-repo-smoke`, which reproduces exactly this failure for `iterate/config`.

## Tests

- New unit test: GET 404 + create 422 name-exists → error names the no-access cause and the installation settings URL, and nothing is linked / no rule installed.
- Fake GitHub in `github-link.test.ts` now answers the real 422 name-exists shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Error-handling-only change on the GitHub link path; no auth, persistence, or linking success-path behavior changes beyond clearer failures for one misconfiguration case.
> 
> **Overview**
> **`linkRepoToGithub`** no longer tells users a repo “does not exist” when GitHub returns **404 on `GET /repos`** (typical for Apps limited to **selected repositories**) and then **422 “name already exists”** on create.
> 
> It adds **`isGithubNameAlreadyExistsError`** and, in that case, throws an error that the repository **exists**, the named connection’s installation **cannot see it**, and points org owners to **Repository access** on the installation settings URL. Other create failures still use the generic “missing / could not be created” message.
> 
> Tests extend the in-memory fake GitHub API with the real **422 name-exists** payload and assert the new message, with **no link or webhook rule** written.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01af9491fd23929e9bc693022d97f8b002fee0a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +21 -0 | +12 -0 🟩🟩⬜⬜⬜ |
| Tests | +37 -0 | +30 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+58 -0** | **+42 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between e7ed619 and 01af949, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> This PR's slot changed from preview-4 to preview-5 at 2026-07-08T19:04:25.666Z (the old lease lapsed and someone else took the slot). Everything below refers to the new slot.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-08T19:14:17.798Z",
      "headSha": "01af9491fd23929e9bc693022d97f8b002fee0a0",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/504369482159417",
      "shortSha": "01af949",
      "cleanupDurationMs": 4463,
      "deployDurationMs": 123063,
      "testDurationMs": 248912,
      "testRetries": "2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · runs \"journal-is-the-record\" through the project REPL (specs x1)",
      "workerSizeKib": 11976.31,
      "workerGzipKib": 3203.23,
      "mainWorkerGzipKib": 3202.78
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-08T19:14:16.220Z",
      "headSha": "01af9491fd23929e9bc693022d97f8b002fee0a0",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/504369482159417",
      "shortSha": "01af949",
      "cleanupDurationMs": 2882,
      "deployDurationMs": 21551,
      "testDurationMs": 543,
      "testRetries": null,
      "workerSizeKib": 3992.8,
      "workerGzipKib": 812.23,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": "This PR's slot changed from preview-4 to preview-5 at 2026-07-08T19:04:25.666Z (the old lease lapsed and someone else took the slot). Everything below refers to the new slot."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `01af949` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 812.2 KiB | 21.6s | 543ms |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/504369482159417) | 2026-07-08T19:14:16.220Z | Preview app released. |
| OS | released | `01af949` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 3.13 MiB (+0.4 KiB vs main) | 123.1s | 248.9s | 2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · runs "journal-is-the-record" through the project REPL (specs x1) | 4.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/504369482159417) | 2026-07-08T19:14:17.798Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->