### PR TITLE
syncFromGithub/pushToGithub: checkout-free clones fit big repos in the isolate

### DIFF
--- a/apps/os/src/domains/repos/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/repo-durable-object.ts
@@ -103,6 +103,13 @@ export class RepoDurableObject extends DurableObject<Env> {
     // stale head forever (the cache never self-invalidates).
     const raced = this.ctx.storage.kv.get<unknown>(repoHeadStorageKey(branch));
     if (isRepoHeadRecord(raced)) return { branch, ...raced };
+    // Same staleness rule against the recorded push: a checkout that lags the
+    // last pushed head (snapshot retries exhausted, or a syncFromGithub moved
+    // the branch while this clone was in flight) may be SERVED once, but must
+    // never be CACHED — an un-invalidatable cache entry would pin builds to
+    // the pre-sync head forever.
+    const pushed = this.ctx.storage.kv.get<string>(`repo-pushed-head:${branch}`);
+    if (typeof pushed === "string" && pushed !== head.commitOid) return { branch, ...head };
     this.ctx.storage.kv.put(repoHeadStorageKey(branch), head);
     return { branch, ...head };
   }
@@ -494,60 +501,74 @@ export class RepoDurableObject extends DurableObject<Env> {
 
     // `noCheckout`: the sync only moves OBJECTS from GitHub to Artifacts; the
     // working tree would double peak memory (and the content hash that used
-    // to need it is repaired lazily below). This is what lets a monorepo-
-    // sized history fit the 128MB isolate.
-    const filesystem = new InMemoryFs();
-    const git = createGit(filesystem, REPO_DIR);
-    try {
-      await git.clone({
-        branch,
-        noCheckout: true,
-        singleBranch: true,
-        url: githubRemoteUrl(link),
-        username: "x-access-token",
-        password: token,
+    // to need it is repaired via getHead below). Scoped in its own closure so
+    // the clone's in-memory fs is unreachable — collectable — before the
+    // head-cache rebuild clones again. Both together are what let a
+    // monorepo-sized history fit the 128MB isolate.
+    const headOid = await (async () => {
+      const filesystem = new InMemoryFs();
+      const git = createGit(filesystem, REPO_DIR);
+      try {
+        await git.clone({
+          branch,
+          noCheckout: true,
+          singleBranch: true,
+          url: githubRemoteUrl(link),
+          username: "x-access-token",
+          password: token,
+        });
+      } catch (error) {
+        throw new Error(
+          `Could not clone ${link.owner}/${link.repo}#${branch} from GitHub (missing branch or empty repository?): ${String(error)}`,
+        );
+      }
+      const [head] = await git.log({ depth: 1 });
+      if (!head) throw new Error(`GitHub ${link.owner}/${link.repo}#${branch} has no commits.`);
+      if (head.oid === previousCommitOid) return null;
+
+      await git.remote({ add: { name: "artifacts", url: repo.remote } });
+      const pushed = await git.push({
+        force: input.force === true,
+        ref: branch,
+        remote: "artifacts",
+        username: "x",
+        password: repo.token,
       });
-    } catch (error) {
-      throw new Error(
-        `Could not clone ${link.owner}/${link.repo}#${branch} from GitHub (missing branch or empty repository?): ${String(error)}`,
-      );
-    }
-    const [head] = await git.log({ depth: 1 });
-    if (!head) throw new Error(`GitHub ${link.owner}/${link.repo}#${branch} has no commits.`);
+      if (!pushed.ok) {
+        throw new Error(
+          `syncFromGithub is not a fast-forward: this repo has commits GitHub does not. Pass force: true to discard them and adopt GitHub's head. (${JSON.stringify(pushed.refs)})`,
+        );
+      }
+      return head.oid;
+    })();
 
-    if (head.oid === previousCommitOid) {
-      return { branch, changed: false, commitOid: head.oid, forced: false, previousCommitOid };
-    }
-
-    await git.remote({ add: { name: "artifacts", url: repo.remote } });
-    const pushed = await git.push({
-      force: input.force === true,
-      ref: branch,
-      remote: "artifacts",
-      username: "x",
-      password: repo.token,
-    });
-    if (!pushed.ok) {
-      throw new Error(
-        `syncFromGithub is not a fast-forward: this repo has commits GitHub does not. Pass force: true to discard them and adopt GitHub's head. (${JSON.stringify(pushed.refs)})`,
-      );
+    if (headOid === null) {
+      return {
+        branch,
+        changed: false,
+        commitOid: previousCommitOid!,
+        forced: false,
+        previousCommitOid,
+      };
     }
 
-    // The adopted head is recorded for read-your-write, but the head CACHE is
-    // invalidated instead of recomputed: computing the contentHash here would
-    // need a full checkout (the memory hog this sync deliberately avoids).
-    // The next getHead() cold-misses and repairs the cache from a shallow
-    // depth-1 clone — the same lazy path a brand-new incarnation uses — so
-    // the synced head is still immediately live for worker builds.
-    this.#recordPushedHead({ branch, commitOid: head.oid });
+    // The adopted head is recorded for read-your-write, then the head cache
+    // is invalidated and rebuilt through getHead's own cold-miss path rather
+    // than recomputed inline (the inline contentHash needed a full checkout —
+    // the memory hog this sync deliberately avoids). Ordering matters: with
+    // the pushed head recorded first, getHead's lags-the-push guard keeps any
+    // concurrently in-flight pre-sync checkout from repopulating the cache
+    // with the old head.
+    this.#recordPushedHead({ branch, commitOid: headOid });
     this.ctx.storage.kv.delete(repoHeadStorageKey(branch));
+    await this.getHead({ branch });
 
     await this.#host.stream.append({
       type: "events.iterate.com/repo/github-synced",
-      idempotencyKey: `github-synced:${link.owner}/${link.repo}:${head.oid}`,
+      idempotencyKey: `github-synced:${link.owner}/${link.repo}:${headOid}`,
       payload: {
         branch,
-        commitOid: head.oid,
+        commitOid: headOid,
         forced: input.force === true,
         owner: link.owner,
         previousCommitOid,
@@ -557,7 +578,7 @@ export class RepoDurableObject extends DurableObject<Env> {
     return {
       branch,
       changed: true,
-      commitOid: head.oid,
+      commitOid: headOid,
       forced: input.force === true,
       previousCommitOid,
     };

--- a/apps/os/src/domains/repos/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/repo-durable-object.ts
@@ -399,12 +399,16 @@ export class RepoDurableObject extends DurableObject<Env> {
       const token = await this.#mintGithubToken(link);
 
       // Full single-branch clone: a mirror push must be able to send every
-      // commit GitHub is missing, not just the tip.
+      // commit GitHub is missing, not just the tip. `noCheckout` because a
+      // push only moves objects — materializing the working tree in the
+      // in-memory fs roughly doubles peak memory for zero benefit, and the
+      // 128MB isolate limit is the real bound on how big a repo can mirror.
       const clone = async () => {
         const filesystem = new InMemoryFs();
         const git = createGit(filesystem, REPO_DIR);
         await git.clone({
           branch,
+          noCheckout: true,
           singleBranch: true,
           url: repo.remote,
           username: "x",
@@ -488,11 +492,16 @@ export class RepoDurableObject extends DurableObject<Env> {
     const previous = this.ctx.storage.kv.get<unknown>(repoHeadStorageKey(branch));
     const previousCommitOid = isRepoHeadRecord(previous) ? previous.commitOid : null;
 
+    // `noCheckout`: the sync only moves OBJECTS from GitHub to Artifacts; the
+    // working tree would double peak memory (and the content hash that used
+    // to need it is repaired lazily below). This is what lets a monorepo-
+    // sized history fit the 128MB isolate.
     const filesystem = new InMemoryFs();
     const git = createGit(filesystem, REPO_DIR);
     try {
       await git.clone({
         branch,
+        noCheckout: true,
         singleBranch: true,
         url: githubRemoteUrl(link),
         username: "x-access-token",
@@ -524,11 +533,14 @@ export class RepoDurableObject extends DurableObject<Env> {
       );
     }
 
+    // The adopted head is recorded for read-your-write, but the head CACHE is
+    // invalidated instead of recomputed: computing the contentHash here would
+    // need a full checkout (the memory hog this sync deliberately avoids).
+    // The next getHead() cold-misses and repairs the cache from a shallow
+    // depth-1 clone — the same lazy path a brand-new incarnation uses — so
+    // the synced head is still immediately live for worker builds.
     this.#recordPushedHead({ branch, commitOid: head.oid });
-    this.ctx.storage.kv.put(repoHeadStorageKey(branch), {
-      commitOid: head.oid,
-      contentHash: await repoContentHash(await readCheckoutFiles(filesystem)),
-    });
+    this.ctx.storage.kv.delete(repoHeadStorageKey(branch));
 
     await this.#host.stream.append({
       type: "events.iterate.com/repo/github-synced",


### PR DESCRIPTION
Live-testing `syncFromGithub` on the real `iterate/iterate` monorepo (linked at nustom `/repos/iterate`) hit the Repo DO's 128MB isolate limit — yet the repo's entire single-branch pack is only **20.6 MiB** (17.4 MB checkout). The data was never the problem; the implementation amplified it:

1. the clone materialized the full **working tree** in the in-memory fs (JS string doubling on top of pack + inflation transients), and
2. the sync then built a **second full file map** just to recompute the head-cache content hash.

Neither `syncFromGithub` nor `pushToGithub` ever reads files — a git push only moves objects. So:

- both clones are now `noCheckout: true`;
- the sync stops recomputing the content hash inline: it records the pushed head (read-your-write) and **invalidates** the cached head, letting `getHead`'s existing cold-miss path repair it from a shallow depth-1 clone — the synced head remains immediately live for worker builds, with one extra shallow clone on the next resolve.

Will verify live on prd after merge by syncing `iterate/iterate` into nustom's `/repos/iterate` (the exact case that OOM'd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authoritative branch head caching and GitHub↔Artifacts sync ordering; incorrect cache behavior could serve stale builds, but changes are narrowly scoped with explicit race guards.
> 
> **Overview**
> Fixes Repo DO OOM on large monorepos during **`syncFromGithub`** / **`pushToGithub`** by cloning with **`noCheckout: true`** (object transfer only—no in-memory working tree), and by restructuring **`syncFromGithub`** so the GitHub clone’s filesystem can be collected before the next step.
> 
> After a successful sync, the head cache is no longer rebuilt with an inline full checkout + **`contentHash`**. It **`#recordPushedHead`**, **deletes** the cached head, and **`getHead`** repairs **`contentHash`** on its existing cold-miss path (one shallow checkout).
> 
> **`getHead`** adds a **`repo-pushed-head`** staleness guard: a checkout that lags the last recorded push may be returned once but **must not** be written to the durable head cache, so concurrent pre-sync clones cannot pin builds to an old head.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4533d7a97f0829513fed0c4cf86eccedd8f3eb1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +74 -41 | +51 -39 🟩🟩🟩🟥🟥 |
| **Total** | **+74 -41** | **+51 -39** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between a95bb57 and 4533d7a, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-08T19:38:20.652Z",
      "headSha": "4533d7a97f0829513fed0c4cf86eccedd8f3eb1c",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/417637101664687",
      "shortSha": "4533d7a",
      "cleanupDurationMs": 5179,
      "deployDurationMs": 56057,
      "testDurationMs": 130855,
      "testRetries": "2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1)",
      "workerSizeKib": 11977.65,
      "workerGzipKib": 3203.4,
      "mainWorkerGzipKib": 3205.79
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-08T19:38:18.341Z",
      "headSha": "4533d7a97f0829513fed0c4cf86eccedd8f3eb1c",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/417637101664687",
      "shortSha": "4533d7a",
      "cleanupDurationMs": 2866,
      "deployDurationMs": 18829,
      "testDurationMs": 514,
      "testRetries": null,
      "workerSizeKib": 3992.8,
      "workerGzipKib": 811.97,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `4533d7a` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 812.0 KiB | 18.8s | 514ms |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/417637101664687) | 2026-07-08T19:38:18.341Z | Preview app released. |
| OS | released | `4533d7a` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 3.13 MiB (-2.4 KiB vs main) | 56.1s | 130.9s | 2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1) | 5.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/417637101664687) | 2026-07-08T19:38:20.652Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->