### PR TITLE
Repo IDE: opening a file from history clears preview/diff/staged

### DIFF
--- a/apps/os/src/components/repo-ide/repo-ide.tsx
+++ b/apps/os/src/components/repo-ide/repo-ide.tsx
@@ -291,7 +291,7 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
                 expandedOid={expandedCommitOid}
                 selectedPath={selectedPath}
                 onExpand={(oid) => patchSearch({ commit: oid })}
-                onOpenFile={(path) => patchSearch({ file: path })}
+                onOpenFile={selectFile}
               />
             </Suspense>
           ) : gh ? (


### PR DESCRIPTION
## What

Opening a file from the **History** panel now lands on the editable Code buffer, clearing any lingering `preview` / `diff` / `staged` URL params — matching how the file tree and Source Control open files.

## Why

`RepoIde`'s history panel was the only file-open path that patched just `{ file }`:

```tsx
// before — clears nothing
onOpenFile={(path) => patchSearch({ file: path })}

// after — reuse the canonical open-a-file callback
onOpenFile={selectFile}
// selectFile = (path) => patchSearch({ file: path, diff: undefined, preview: undefined, staged: undefined })
```

Every sibling already clears the mutually-exclusive view params (`selectFile` for the tree, `onOpen`/`onOpenStaged` in the Source Control panel). Because the history handler didn't, this sequence misbehaved:

1. Open a markdown/HTML file, toggle **Preview** (`preview=true` in the URL).
2. Switch to **History**, expand a commit, open another previewable file.
3. The new file opens in **Preview** instead of the editable buffer, because `preview=true` stayed in the URL.

`history` and `commit` are intentionally left untouched, so the sidebar stays in the History view while you browse files within a commit.

## Scope

Pre-existing bug on `main` — it became reachable once **#1767** (the `preview` param) and **#1769** (the history panel) both merged. Surfaced by Cursor Bugbot on #1768 (Medium). One-line change; `tsc`, oxlint, and oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": "This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +1 -1 | +1 -1 🟩🟩🟩🟥🟥 |
| **Total** | **+1 -1** | **+1 -1** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 9f3f9fb and b04c52a, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->