### PR TITLE
Notify CI channel about PR updates

### DIFF
--- a/.depot/workflows/pr-dashboard.yml
+++ b/.depot/workflows/pr-dashboard.yml
@@ -3,9 +3,10 @@ on:
   pull_request:
     types:
       - opened
-      - closed
       - reopened
       - ready_for_review
+      - converted_to_draft
+      - closed
   push:
     branches:
       - "**/*pr-dashboard*"
@@ -29,5 +30,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Reconcile dependencies (baked)
         run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Notify PR update
+        if: github.event_name == 'pull_request'
+        run: pnpm tsx scripts/ci/notify.ts pr-update
       - name: Update PR dashboard
         run: pnpm tsx scripts/ci/pr-dashboard.ts

--- a/scripts/ci/github.ts
+++ b/scripts/ci/github.ts
@@ -37,11 +37,18 @@ export type GithubEventPayload = {
   action?: string;
   pull_request?: {
     number: number;
+    title?: string;
+    html_url?: string;
     body?: string | null;
+    draft?: boolean;
     merged?: boolean;
+    merged_by?: { login?: string | null } | null;
+    merge_commit_sha?: string | null;
+    user?: { login?: string | null } | null;
     base?: { ref: string; sha: string };
-    head?: { sha: string };
+    head?: { ref?: string; sha: string };
   };
+  sender?: { login?: string | null };
 };
 
 export function readEventPayload() {

--- a/scripts/ci/notify.ts
+++ b/scripts/ci/notify.ts
@@ -1,5 +1,5 @@
 import { isMainModule } from "../../packages/shared/src/dev/is-main-module.ts";
-import { getRunUrl } from "./github.ts";
+import { getRunUrl, readEventPayload, type GithubEventPayload } from "./github.ts";
 import { getSlackClient, slackChannelIds } from "./slack.ts";
 
 type DeployOptions = {
@@ -9,6 +9,8 @@ type DeployOptions = {
   runUrl: string;
   publicUrl?: string;
 };
+
+type PullRequestPayload = NonNullable<GithubEventPayload["pull_request"]>;
 
 export async function notifyDeploy({ app, status, commitSha, runUrl, publicUrl }: DeployOptions) {
   const slack = getSlackClient();
@@ -53,6 +55,88 @@ export async function notifyWorkflowFailure() {
   });
 }
 
+export async function notifyPullRequestUpdate() {
+  const payload = readEventPayload();
+  const message = formatPullRequestUpdateMessage(payload);
+  if (!message) {
+    console.log(`No #ci Slack PR update for pull_request action ${payload.action || "(missing)"}`);
+    return;
+  }
+
+  await getSlackClient().chat.postMessage({
+    channel: slackChannelIds["#ci"],
+    text: message,
+  });
+}
+
+function formatPullRequestUpdateMessage(payload: GithubEventPayload) {
+  const pullRequest = payload.pull_request;
+  if (!pullRequest) {
+    throw new Error("pull_request payload is required");
+  }
+
+  const detail = formatPullRequestUpdateDetail(payload.action, pullRequest);
+  if (!detail) return null;
+
+  const actor = getPullRequestActionActor(payload, pullRequest);
+  const author = pullRequest.user?.login;
+  const authorSuffix = author && author !== actor ? ` (author: ${slackEscape(author)})` : "";
+  const link = formatPullRequestLink(pullRequest);
+
+  return `${detail.prefix}: ${link}${detail.afterLink || ""} by ${slackEscape(actor)}${detail.afterActor || ""}${authorSuffix}`;
+}
+
+function formatPullRequestUpdateDetail(
+  action: string | undefined,
+  pullRequest: PullRequestPayload,
+) {
+  switch (action) {
+    case "opened":
+      return { prefix: `🟢 PR opened${pullRequest.draft ? " as draft" : ""}` };
+    case "reopened":
+      return { prefix: `🔁 PR reopened${pullRequest.draft ? " as draft" : ""}` };
+    case "ready_for_review":
+      return { prefix: "👀 PR marked ready for review" };
+    case "converted_to_draft":
+      return { prefix: "📝 PR converted to draft" };
+    case "closed":
+      if (pullRequest.merged) {
+        return {
+          prefix: "✅ PR merged",
+          afterLink: pullRequest.base?.ref ? ` into \`${slackEscape(pullRequest.base.ref)}\`` : "",
+          afterActor: pullRequest.merge_commit_sha
+            ? ` (${pullRequest.merge_commit_sha.slice(0, 7)})`
+            : "",
+        };
+      }
+      return { prefix: "⚪ PR closed without merge" };
+    default:
+      return null;
+  }
+}
+
+function getPullRequestActionActor(payload: GithubEventPayload, pullRequest: PullRequestPayload) {
+  return (
+    (payload.action === "closed" && pullRequest.merged
+      ? pullRequest.merged_by?.login
+      : undefined) ||
+    payload.sender?.login ||
+    process.env.GITHUB_ACTOR ||
+    pullRequest.user?.login ||
+    "unknown"
+  );
+}
+
+function formatPullRequestLink(pullRequest: PullRequestPayload) {
+  const title = pullRequest.title ? ` ${slackEscape(pullRequest.title)}` : "";
+  const label = `#${pullRequest.number}${title}`;
+  return pullRequest.html_url ? `<${pullRequest.html_url}|${label}>` : label;
+}
+
+function slackEscape(value: string) {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
 function readOption(name: string) {
   const value = process.env[name];
   if (!value) throw new Error(`${name} is required`);
@@ -74,6 +158,11 @@ async function main() {
 
   if (command === "workflow-failure") {
     await notifyWorkflowFailure();
+    return;
+  }
+
+  if (command === "pr-update") {
+    await notifyPullRequestUpdate();
     return;
   }
 


### PR DESCRIPTION
## Summary

- post CI Slack updates for PR lifecycle events in `#ci`
- include opened, reopened, ready for review, converted to draft, merged, and closed-without-merge events
- keep the existing PR dashboard update in the same workflow and guard the notification from the push-only dashboard test trigger
- tidy the notifier by centralizing PR update message formatting

## Validation

- `pnpm exec oxfmt --check scripts/ci/notify.ts scripts/ci/github.ts .depot/workflows/pr-dashboard.yml`
- `pnpm exec oxlint scripts/ci/notify.ts scripts/ci/github.ts`
- `pnpm --dir scripts typecheck`

Tests not run, per request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow steps and internal Slack notification scripts with no application runtime or auth/data-path impact.
> 
> **Overview**
> Adds **Slack notifications to `#ci`** when PRs hit key lifecycle events, wired into the existing **Daily PR dashboard** workflow so the dashboard refresh and alerts stay in one place.
> 
> The workflow now listens for **`converted_to_draft`** as well as open/reopen/ready/close, and runs **`pnpm tsx scripts/ci/notify.ts pr-update`** only on **`pull_request`** events so push-only dashboard test branches stay quiet. **`scripts/ci/github.ts`** extends the typed webhook payload with fields needed for messages (title, URL, draft/merge metadata, actors). **`scripts/ci/notify.ts`** adds centralized formatting for opened/reopened/ready/draft/merged/closed-without-merge and a new **`pr-update`** CLI entrypoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9de301267ac024cea60b063809a8929cdb031cf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| CI & scripts | +103 -3 | +91 -3 🟩🟩🟩🟩🟩 |
| **Total** | **+103 -3** | **+91 -3** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between a490819 and 9de3012, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->