### PR TITLE
point claude at spec/AGENTS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ from your machine, and when you need a public callback URL. Doppler/Cloudflare/d
 - [Testing](docs/testing.md) — test lanes, how to run them against any environment, the canonical env vars, and the retry/timeout policy (one retry layer, fail-fast watchdogs, retry telemetry)
 - [Vitest patterns](docs/vitest-patterns.md)
 - [Domain objects & stream processors](docs/domain-objects-and-stream-processors.md)
+- [Playwright specs](./spec/AGENTS.md) - instructions for agents writing playwright tests
 
 ### Tasks & agent docs
 

--- a/specs/AGENTS.md
+++ b/specs/AGENTS.md
@@ -14,6 +14,8 @@ Avoid doing `await myButton.waitFor()` and then `await runButton.click()`. It's 
 
 The default `actionTimeout` in your playwright config should be _very aggressive_ and short. The `spinner-waiter` plugin allows this. If and when test fail because of this, there are two recommended courses of action, neither of which involves just bumping an assertion timeout. The first is of course to just figure out why the UI is sometimes slow and fix it. But if that's not possible, or beyond the scope of the work you're doing, the second recommended fix is to add a loading spinner to the product UI - we've identified a slow part of your app, so real users should also see a loading spinner, or some text like "Loading..."/"Pending..."/"Creating foobar..." etc.
 
+If you've really come up against a case where you truly think it's better to add `{ timeout: 10_000 }` or some such, you MUST leave a // comment explaining why so we can more easily fix the underlying issue later.
+
 ## Error UI
 
 For common developer pitfalls, instead of littering your test code with defensive try/catch statements and custom selectors for app error UI, just add the `data-type="error"` attribute to relevant UI elements. Then, the `ui-error-reporter` plugin will pick up any errors on screen automatically (including toasts rendered using the `sonner` library). The plugin will find elements annotated in this way and include their text content in error reports, so agents and humans will quickly be able to get an indication of what went wrong.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, CI config, or test code impact.
> 
> **Overview**
> Adds a **Development** doc entry in `README.md` pointing agents at `./spec/AGENTS.md` for Playwright spec authoring, alongside existing agent docs like `apps/os/AGENTS.md`.
> 
> Updates **`specs/AGENTS.md`** timeout guidance: if a test author overrides action/assertion timeouts (e.g. `{ timeout: 10_000 }`), they **must** add a `//` comment explaining why, so flaky/slow UI can be tracked and fixed later instead of silently raising limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a21c5b41e3b77b9f33394150f641d4bf2740905d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Docs | +3 -0 | +2 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+3 -0** | **+2 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 2231559 and a21c5b4, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->