### PR TITLE
Preview pipeline: self-heal erased slots, fail loudly on stale-head test skips

### DIFF
--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -17,7 +17,9 @@ const {
   ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE,
   acquireAnyEnvironmentConfigLease,
   claimEnvironmentConfigLease,
+  describeForcePushCompareHazard,
   evaluateCloudflareZoneCheck,
+  explainPreviewTestSkip,
   holderPullRequestUrl,
   reassertEnvironmentConfigLease,
   resolveSlotWaitTotalMs,
@@ -30,6 +32,7 @@ const {
   resolveAuthPreviewRootSecret,
   resolvePreviewCompareBaseSha,
   resolvePreviewReadinessUrls,
+  selectPreviewAppsForPullRequest,
   selectPreviewAppsNeedingRetry,
   splitRepositoryFullName,
   syncPreviewInventory,
@@ -389,6 +392,246 @@ describe("preview retry selection", () => {
         pullRequestHeadSha: "current-head",
       }),
     ).toEqual([]);
+  });
+});
+
+describe("preview deploy selection", () => {
+  const currentHead = "current-head";
+  const selectionInput = {
+    githubToken: "test-token",
+    pullRequestBaseSha: "base-sha",
+    pullRequestHeadSha: currentHead,
+    pullRequestNumber: 1793,
+    repositoryFullName: "iterate/iterate",
+  };
+
+  function recordedApp(
+    slug: string,
+    displayName: string,
+    overrides: Partial<CloudflarePreviewAppEntry> = {},
+  ) {
+    return CloudflarePreviewAppEntry.parse({
+      appDisplayName: displayName,
+      appSlug: slug,
+      headSha: currentHead,
+      publicUrl: `https://${slug}.iterate-preview-7.com`,
+      shortSha: "current",
+      status: "deployed",
+      updatedAt: "2026-07-09T00:00:00.000Z",
+      ...overrides,
+    });
+  }
+
+  const everythingServing = async () => ({ ok: true, detail: "HTTP 200" });
+  const compareMustNotRun = async (): Promise<never> => {
+    throw new Error("compare must not be called for an unchanged head");
+  };
+
+  it("selects nothing when the head is unchanged, every app is green, and every app is serving", async () => {
+    const apps = await selectPreviewAppsForPullRequest({
+      ...selectionInput,
+      previousState: {
+        apps: { os: recordedApp("os", "OS"), auth: recordedApp("auth", "Auth") },
+        environmentConfigLease: null,
+        notice: null,
+      },
+      fetchCompare: compareMustNotRun,
+      probeAppServing: everythingServing,
+    });
+
+    expect(apps).toEqual([]);
+  });
+
+  it("self-heals an erased slot: a parked recorded-green app is redeployed with its dependencies", async () => {
+    // Live incident (PR #1793 on preview-7, 2026-07-09): e2e failed with
+    // "no such column: epoch", the documented remedy `erase-data` parked the
+    // os worker (503) and wiped auth's D1 (OAuth clients), but os and auth
+    // were recorded green — so the retry redeployed only the failed app and
+    // every sign-in-dependent spec then failed on a slot with no OAuth
+    // clients until auth was redeployed by hand. The probe catches the parked
+    // os worker, and dependency expansion brings auth (which re-seeds its
+    // OAuth clients on deploy) along.
+    const probedUrls: string[] = [];
+    const apps = await selectPreviewAppsForPullRequest({
+      ...selectionInput,
+      previousState: {
+        apps: {
+          os: recordedApp("os", "OS"),
+          auth: recordedApp("auth", "Auth"),
+          "streams-example-app": recordedApp("streams-example-app", "Streams Example App", {
+            status: "tests-failed",
+          }),
+        },
+        environmentConfigLease: null,
+        notice: null,
+      },
+      fetchCompare: compareMustNotRun,
+      probeAppServing: async (url) => {
+        probedUrls.push(url.toString());
+        return url.hostname.startsWith("os.")
+          ? { ok: false, detail: "HTTP 503" }
+          : { ok: true, detail: "HTTP 200" };
+      },
+    });
+
+    expect(apps.map((app) => app.slug)).toEqual(["os", "auth", "streams-example-app"]);
+    // Only the green claims get probed — the failed app is already selected
+    // for retry — and each app is probed on its own readiness path.
+    expect(probedUrls).toEqual([
+      "https://os.iterate-preview-7.com/api/health",
+      "https://auth.iterate-preview-7.com/api/auth/ok",
+    ]);
+  });
+
+  it("retries failed apps even when the push's diff does not touch them", async () => {
+    // A slot whose deploy failed at an old head must not stay wedged just
+    // because the next push's diff selects other apps.
+    const apps = await selectPreviewAppsForPullRequest({
+      ...selectionInput,
+      previousState: {
+        apps: {
+          os: recordedApp("os", "OS", {
+            headSha: "old-head",
+            shortSha: "oldhead",
+            status: "deploy-failed",
+          }),
+        },
+        environmentConfigLease: null,
+        notice: null,
+      },
+      fetchCompare: async (basehead) => {
+        expect(basehead).toBe(`old-head...${currentHead}`);
+        return { status: "ahead", changedFilenames: ["apps/semaphore/src/index.ts"] };
+      },
+      probeAppServing: everythingServing,
+    });
+
+    expect(apps.map((app) => app.slug)).toEqual(["os", "semaphore", "auth"]);
+  });
+
+  it("deploys the full fleet when the compare 404s because a force-push rewrote the deployed head away", async () => {
+    const apps = await selectPreviewAppsForPullRequest({
+      ...selectionInput,
+      previousState: {
+        apps: {
+          os: recordedApp("os", "OS", { headSha: "rewritten-away-head", shortSha: "rewritt" }),
+        },
+        environmentConfigLease: null,
+        notice: null,
+      },
+      fetchCompare: async () => {
+        throw Object.assign(new Error("Not Found"), { status: 404 });
+      },
+      probeAppServing: everythingServing,
+    });
+
+    expect(apps.map((app) => app.slug)).toEqual(["os", "semaphore", "auth", "streams-example-app"]);
+  });
+
+  it("deploys the full fleet when the deployed head is no longer an ancestor of the current head", async () => {
+    // A diverged (or behind) compare diffs from the merge base and cannot see
+    // changes that existed only on the deployed side — which the slot still
+    // runs. An empty file list here must not read as "nothing affected".
+    const apps = await selectPreviewAppsForPullRequest({
+      ...selectionInput,
+      previousState: {
+        apps: {
+          os: recordedApp("os", "OS", { headSha: "diverged-head", shortSha: "diverge" }),
+        },
+        environmentConfigLease: null,
+        notice: null,
+      },
+      fetchCompare: async () => ({ status: "diverged", changedFilenames: [] }),
+      probeAppServing: everythingServing,
+    });
+
+    expect(apps.map((app) => app.slug)).toEqual(["os", "semaphore", "auth", "streams-example-app"]);
+  });
+
+  it("propagates non-404 compare failures instead of guessing a selection", async () => {
+    await expect(
+      selectPreviewAppsForPullRequest({
+        ...selectionInput,
+        previousState: {
+          apps: {
+            os: recordedApp("os", "OS", { headSha: "old-head", shortSha: "oldhead" }),
+          },
+          environmentConfigLease: null,
+          notice: null,
+        },
+        fetchCompare: async () => {
+          throw Object.assign(new Error("Server Error"), { status: 500 });
+        },
+        probeAppServing: everythingServing,
+      }),
+    ).rejects.toThrow("Server Error");
+  });
+});
+
+describe("describeForcePushCompareHazard", () => {
+  it("trusts the normal push shapes", () => {
+    expect(describeForcePushCompareHazard("ahead")).toBeNull();
+    expect(describeForcePushCompareHazard("identical")).toBeNull();
+  });
+
+  it("flags rewritten history as untrustworthy for diffing", () => {
+    expect(describeForcePushCompareHazard("diverged")).toContain("not an ancestor");
+    expect(describeForcePushCompareHazard("behind")).toContain("not an ancestor");
+  });
+});
+
+describe("preview test skip verdicts", () => {
+  const recordedApps = {
+    os: CloudflarePreviewAppEntry.parse({
+      appDisplayName: "OS",
+      appSlug: "os",
+      headSha: "old-head",
+      shortSha: "oldhead",
+      status: "deployed",
+      updatedAt: "2026-07-09T00:00:00.000Z",
+    }),
+  };
+
+  it("skips green when deploy would select nothing for this head", () => {
+    const skip = explainPreviewTestSkip({
+      appsDeployWouldSelect: [],
+      pullRequestHeadSha: "current-head",
+      recordedApps,
+    });
+
+    expect(skip.verdict).toBe("nothing-changed");
+    expect(skip.notice).toContain("nothing app-affecting changed");
+    expect(skip.notice).toContain("still stand");
+  });
+
+  it("fails loudly when apps are recorded at a stale head", () => {
+    // A push that races between the deploy and test steps (or a deploy that
+    // died before recording) leaves the recorded apps at an old head; a green
+    // "deploy + e2e" would then describe a commit that never ran.
+    const skip = explainPreviewTestSkip({
+      appsDeployWouldSelect: ["os", "auth"],
+      pullRequestHeadSha: "current-head",
+      recordedApps,
+    });
+
+    expect(skip.verdict).toBe("stale-head");
+    expect(skip.notice).toContain("refused to skip");
+    expect(skip.notice).toContain("os, auth");
+    expect(skip.notice).toContain("E2e was NOT run");
+    expect(skip.notice).toContain(
+      "os: deployed, head oldhead (stale — deploy has not run for the current head)",
+    );
+  });
+
+  it("fails loudly when nothing is recorded at all but deploy would select apps", () => {
+    const skip = explainPreviewTestSkip({
+      appsDeployWouldSelect: ["os"],
+      pullRequestHeadSha: "current-head",
+      recordedApps: {},
+    });
+
+    expect(skip.verdict).toBe("stale-head");
+    expect(skip.notice).toContain("No apps are recorded at all");
   });
 });
 

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -68,11 +68,12 @@ export async function deploy(
     /**
      * Deploy every preview app regardless of the diff. Diff selection only
      * redeploys apps affected since their LAST DEPLOYED head, so unaffected
-     * apps keep an older recorded head and the test lane then skips them
-     * ("stale — deploy has not run for the current head yet"). A caller that
-     * needs the whole fleet testable at the current head — the flake-hunt
-     * marathon preflight — uses this to reunify the fleet explicitly instead
-     * of relying on the commit happening to touch a fleet-shared path.
+     * apps keep an older recorded head and the test lane leaves them out of
+     * its testable set (stale — deploy has not run for the current head). A
+     * caller that needs the whole fleet testable at the current head — the
+     * flake-hunt marathon preflight — uses this to reunify the fleet
+     * explicitly instead of relying on the commit happening to touch a
+     * fleet-shared path.
      */
     allApps?: boolean;
     /**
@@ -158,7 +159,7 @@ export async function deploy(
 
   if (selectedApps.length === 0) {
     logPreview(
-      "nothing to deploy: no preview apps are affected by this diff and no failed apps need a retry — leaving lease and PR body untouched",
+      "nothing to deploy: no preview apps are affected by this diff, no failed apps need a retry, and every recorded app is still serving — leaving lease and PR body untouched",
     );
     return {
       ok: true,
@@ -350,18 +351,33 @@ export async function test(options: PullRequestCommandOptions = {}) {
     .filter((app): app is PreviewAppRuntime => app != null);
 
   if (testableApps.length === 0) {
-    logPreview(
-      [
-        "no apps are testable for this head sha — skipping tests. Recorded app states:",
-        ...Object.values(current.state.apps).map(
-          (entry) =>
-            `  ${entry.appSlug}: ${entry.status}, head ${entry.shortSha ?? "?"}${entry.headSha !== context.pullRequestHeadSha ? " (stale — deploy has not run for the current head yet)" : ""}`,
-        ),
-      ].join("\n"),
-    );
+    // No app is recorded at this head — but "skip green" is only honest when
+    // nothing app-affecting changed since the last fully tested deploy.
+    // Recompute the exact selection deploy would make for the current head to
+    // tell that case apart from a stale recorded state (a push raced the
+    // deploy step, or deploy died before recording); see
+    // explainPreviewTestSkip.
+    const appsDeployWouldSelect = await selectPreviewAppsForPullRequest({
+      ...context,
+      previousState: current.state,
+    });
+    const skip = explainPreviewTestSkip({
+      appsDeployWouldSelect: appsDeployWouldSelect.map((app) => app.slug),
+      pullRequestHeadSha: context.pullRequestHeadSha,
+      recordedApps: current.state.apps,
+    });
+    logPreview(skip.notice);
+    await updatePreviewState(context, (state) => ({
+      ...state,
+      notice: skip.notice,
+    }));
+    if (skip.verdict === "stale-head") {
+      throw new Error(skip.notice);
+    }
     return {
       ok: true,
       skipped: true,
+      skippedReason: skip.verdict,
       state: current.state,
     };
   }
@@ -3810,6 +3826,138 @@ async function reassertEnvironmentConfigLease(input: {
   };
 }
 
+/**
+ * The slice of GitHub's compare API the deploy selection needs: the compare
+ * status plus the changed filenames. Injectable so unit tests can drive
+ * force-push shapes (404s, diverged history) without a network.
+ */
+type PreviewCompareFetcher = (basehead: string) => Promise<{
+  status: string;
+  changedFilenames: string[];
+}>;
+
+/** The real {@link PreviewCompareFetcher}: GitHub's compare API behind the transient-failure retry. */
+function makeGithubCompareFetcher(input: {
+  githubToken: string;
+  repositoryFullName: string;
+}): PreviewCompareFetcher {
+  const octokit = new Octokit({ auth: input.githubToken });
+  const [owner, repo] = splitRepositoryFullName(input.repositoryFullName);
+  return async (basehead) => {
+    const comparison = await withGithubRetry("compareCommits", () =>
+      octokit.rest.repos.compareCommitsWithBasehead({ owner, repo, basehead }),
+    );
+    return {
+      status: comparison.data.status,
+      changedFilenames:
+        comparison.data.files?.flatMap((file) => (file.filename ? [file.filename] : [])) ?? [],
+    };
+  };
+}
+
+/**
+ * GitHub's three-dot compare diffs the head against the MERGE BASE of the two
+ * commits, not against the base commit itself. When the previously deployed
+ * head is an ancestor of the current head ("ahead" — the normal push), that
+ * is exactly the diff we want. After a force-push that rewrites history the
+ * deployed head is no longer an ancestor ("diverged") — or the new head is an
+ * ancestor of the deployed one ("behind", a straight rollback) — and the file
+ * list misses every change that existed only on the deployed side. The slot
+ * still RUNS that code, so apps it touched need a redeploy the diff would
+ * never select. Returns the reason to deploy the whole fleet instead, or null
+ * when the diff is trustworthy. Over-deploying is idempotent and costs
+ * minutes; under-deploying strands force-pushed-away code on the slot.
+ */
+function describeForcePushCompareHazard(status: string): string | null {
+  if (status === "ahead" || status === "identical") {
+    return null;
+  }
+
+  return `compare status "${status}" means the last deployed head is not an ancestor of the current head (force-push or rollback), so the file diff cannot see changes that existed only on the deployed side`;
+}
+
+/** GitHub compare 404s when a force-push rewrote the base commit out of the PR's history. */
+function isGithubNotFoundError(error: unknown) {
+  return (error as { status?: unknown } | null)?.status === 404;
+}
+
+/**
+ * One cheap "is this app actually serving?" check against a readiness URL.
+ * Returns ok=false with a detail string instead of throwing, so callers treat
+ * every failure mode (503, DNS, timeout) uniformly as "not serving".
+ */
+type PreviewAppServingProbe = (url: URL) => Promise<{ ok: boolean; detail: string }>;
+
+/** Deadline for one {@link PreviewAppServingProbe} GET — a healthy app answers in well under a second. */
+const previewServingProbeTimeoutMs = 15_000;
+
+/** The real {@link PreviewAppServingProbe}: a single GET, no polling — this checks a deploy that already passed readiness once. */
+async function probePreviewAppServingOnce(url: URL): Promise<{ ok: boolean; detail: string }> {
+  try {
+    const status = await fetchReadinessStatus(
+      url,
+      AbortSignal.timeout(previewServingProbeTimeoutMs),
+    );
+    return { ok: status >= 200 && status < 300, detail: `HTTP ${status}` };
+  } catch (error) {
+    return { ok: false, detail: formatPreviewErrorMessage(error) };
+  }
+}
+
+/**
+ * Recorded-green apps ("deployed"/"awaiting-tests") whose deployment is no
+ * longer actually serving. A green row is normally trustworthy — but an
+ * erase-data on the slot (the documented remedy when merged-main lands a
+ * non-migratable schema change) parks the os worker behind a 503 and wipes
+ * the slot's shared data WITHOUT touching the recorded PR-body state. Trusting
+ * the stale green rows then redeploys only the failed apps and leaves the slot
+ * half-dead: observed 2026-07-09 on preview-7 (PR #1793), where e2e failed
+ * with "no such column: epoch", the erase parked os and emptied auth's D1
+ * (OAuth clients), and the retry — os and auth both recorded green — never
+ * redeployed either; auth had to be redeployed by hand. Probing each green
+ * app's readiness URL once makes erase + re-run self-healing: the parked app
+ * fails its probe, joins the retry selection, and pulls its dependencies
+ * (auth, whose OAuth-client seed lives in the wiped D1) along via
+ * expandPreviewDependencies.
+ */
+async function selectRecordedGreenAppsNotServing(params: {
+  alreadySelectedSlugs: ReadonlySet<CloudflarePreviewAppSlugType>;
+  previousState: CloudflarePreviewState;
+  probeAppServing: PreviewAppServingProbe;
+}): Promise<CloudflarePreviewAppSlugType[]> {
+  const notServing: CloudflarePreviewAppSlugType[] = [];
+  for (const entry of Object.values(params.previousState.apps)) {
+    const app = cloudflarePreviewApps[entry.appSlug as CloudflarePreviewAppSlugType];
+    if (
+      app == null ||
+      params.alreadySelectedSlugs.has(app.slug) ||
+      !entry.publicUrl ||
+      !["awaiting-tests", "deployed"].includes(entry.status)
+    ) {
+      continue;
+    }
+
+    const probeFailures: string[] = [];
+    for (const url of resolvePreviewReadinessUrls({
+      publicUrl: entry.publicUrl,
+      readyUrlPath: app.previewReadyUrlPath,
+    })) {
+      const probe = await params.probeAppServing(url);
+      if (!probe.ok) {
+        probeFailures.push(`${url} answered ${probe.detail}`);
+      }
+    }
+    if (probeFailures.length > 0) {
+      logPreview(
+        `app ${app.slug} selected: recorded ${entry.status} but not actually serving (${probeFailures.join("; ")}) — the slot was likely erased since that deploy`,
+      );
+      notServing.push(app.slug);
+    }
+  }
+
+  return notServing;
+}
+
 async function selectPreviewAppsForPullRequest(input: {
   githubToken: string;
   previousState: CloudflarePreviewState;
@@ -3817,56 +3965,84 @@ async function selectPreviewAppsForPullRequest(input: {
   pullRequestHeadSha: string;
   pullRequestNumber: number;
   repositoryFullName: string;
+  /** Injectable for tests; defaults to {@link makeGithubCompareFetcher}. */
+  fetchCompare?: PreviewCompareFetcher;
+  /** Injectable for tests; defaults to {@link probePreviewAppServingOnce}. */
+  probeAppServing?: PreviewAppServingProbe;
 }) {
+  const fetchCompare = input.fetchCompare ?? makeGithubCompareFetcher(input);
+  const probeAppServing = input.probeAppServing ?? probePreviewAppServingOnce;
+
+  // Failed recorded state is retried on EVERY path — not only when the head
+  // is unchanged. A push whose diff misses the failed apps must not leave
+  // them wedged (see the comment in selectPreviewAppsNeedingRetry).
+  const retryApps = selectPreviewAppsNeedingRetry({
+    previousState: input.previousState,
+    pullRequestHeadSha: input.pullRequestHeadSha,
+  });
+
   const compareBaseSha = resolvePreviewCompareBaseSha(input);
-  if (!compareBaseSha) {
-    return [];
-  }
+  const diffSelectedSlugs: CloudflarePreviewAppSlugType[] = [];
   if (compareBaseSha === input.pullRequestHeadSha) {
-    const retryApps = selectPreviewAppsNeedingRetry({
-      previousState: input.previousState,
-      pullRequestHeadSha: input.pullRequestHeadSha,
-    });
     logPreview(
       retryApps.length > 0
         ? `head sha unchanged since the last run — retrying apps that didn't reach a green state: ${retryApps.map((app) => app.slug).join(", ")}`
         : "head sha unchanged since the last run and every app finished — nothing to retry",
     );
-    return retryApps;
-  }
-
-  const octokit = new Octokit({ auth: input.githubToken });
-  const [owner, repo] = splitRepositoryFullName(input.repositoryFullName);
-  const comparison = await withGithubRetry("compareCommits", () =>
-    octokit.rest.repos.compareCommitsWithBasehead({
-      owner,
-      repo,
-      basehead: `${compareBaseSha}...${input.pullRequestHeadSha}`,
-    }),
-  );
-  const changedFiles =
-    comparison.data.files?.flatMap((file) => (file.filename ? [file.filename] : [])) ?? [];
-  logPreview(
-    `selecting apps by diff ${compareBaseSha.slice(0, 7)}...${input.pullRequestHeadSha.slice(0, 7)} (${changedFiles.length} changed files)`,
-  );
-
-  const sharedPathHit = changedFiles.find((filename) =>
-    matchesPreviewPath(filename, cloudflarePreviewSharedPaths),
-  );
-  if (sharedPathHit) {
-    logPreview(
-      `shared preview infrastructure changed (${sharedPathHit}) — deploying ALL preview apps`,
-    );
-    return Object.values(cloudflarePreviewApps);
-  }
-
-  const selectedSlugs = new Set<CloudflarePreviewAppSlugType>();
-  for (const app of Object.values(cloudflarePreviewApps)) {
-    const hit = changedFiles.find((filename) => matchesPreviewPath(filename, app.paths));
-    if (hit) {
-      logPreview(`app ${app.slug} selected: ${hit} changed`);
-      selectedSlugs.add(app.slug);
+  } else {
+    let compared: Awaited<ReturnType<PreviewCompareFetcher>>;
+    try {
+      compared = await fetchCompare(`${compareBaseSha}...${input.pullRequestHeadSha}`);
+    } catch (error) {
+      if (!isGithubNotFoundError(error)) {
+        throw error;
+      }
+      logPreview(
+        `compare ${compareBaseSha.slice(0, 7)}...${input.pullRequestHeadSha.slice(0, 7)} returned 404 — a force-push rewrote the last deployed head out of history, so no diff can be trusted; deploying ALL preview apps`,
+      );
+      return Object.values(cloudflarePreviewApps);
     }
+
+    const compareHazard = describeForcePushCompareHazard(compared.status);
+    if (compareHazard) {
+      logPreview(`${compareHazard} — deploying ALL preview apps`);
+      return Object.values(cloudflarePreviewApps);
+    }
+    logPreview(
+      `selecting apps by diff ${compareBaseSha.slice(0, 7)}...${input.pullRequestHeadSha.slice(0, 7)} (${compared.changedFilenames.length} changed files)`,
+    );
+
+    const sharedPathHit = compared.changedFilenames.find((filename) =>
+      matchesPreviewPath(filename, cloudflarePreviewSharedPaths),
+    );
+    if (sharedPathHit) {
+      logPreview(
+        `shared preview infrastructure changed (${sharedPathHit}) — deploying ALL preview apps`,
+      );
+      return Object.values(cloudflarePreviewApps);
+    }
+
+    for (const app of Object.values(cloudflarePreviewApps)) {
+      const hit = compared.changedFilenames.find((filename) =>
+        matchesPreviewPath(filename, app.paths),
+      );
+      if (hit) {
+        logPreview(`app ${app.slug} selected: ${hit} changed`);
+        diffSelectedSlugs.push(app.slug);
+      }
+    }
+  }
+
+  const selectedSlugs = new Set<CloudflarePreviewAppSlugType>([
+    ...diffSelectedSlugs,
+    ...retryApps.map((app) => app.slug),
+  ]);
+  for (const slug of await selectRecordedGreenAppsNotServing({
+    alreadySelectedSlugs: selectedSlugs,
+    previousState: input.previousState,
+    probeAppServing,
+  })) {
+    selectedSlugs.add(slug);
   }
 
   const expanded = expandPreviewDependencies([...selectedSlugs]);
@@ -3877,6 +4053,57 @@ async function selectPreviewAppsForPullRequest(input: {
   }
 
   return expanded.map((slug) => cloudflarePreviewApps[slug]);
+}
+
+/**
+ * Verdict for a `preview test` run that found no recorded app at the PR's
+ * current head. Two very different situations look identical in the recorded
+ * state, because deploy's diff selection deliberately leaves unaffected apps
+ * recorded at older heads:
+ *
+ * - "nothing-changed": nothing app-affecting changed since the last fully
+ *   tested deploy, so the recorded results still describe the code under
+ *   review and a green skip is honest;
+ * - "stale-head": deploy has not recorded the current head's apps (a push
+ *   raced between the deploy and test steps, or deploy died before
+ *   recording), so the slot does not run the head being reported on and a
+ *   green check would lie — observed as a hazard on preview-7 (PR #1793,
+ *   2026-07-09), where a green "deploy + e2e" could stand on a slot that had
+ *   run nothing.
+ *
+ * The discriminator is the selection deploy itself would make for this head:
+ * if deploy would select apps, the recorded state is stale and the run must
+ * fail loudly. The workflow-level cancel-in-progress means a superseding run
+ * for the newer push is usually already queued, so the loud failure is cheap
+ * and honest.
+ */
+function explainPreviewTestSkip(params: {
+  appsDeployWouldSelect: readonly string[];
+  pullRequestHeadSha: string;
+  recordedApps: CloudflarePreviewState["apps"];
+}): { verdict: "nothing-changed"; notice: string } | { verdict: "stale-head"; notice: string } {
+  const shortHeadSha = params.pullRequestHeadSha.slice(0, 7);
+  if (params.appsDeployWouldSelect.length === 0) {
+    return {
+      verdict: "nothing-changed",
+      notice: `Preview e2e skipped for head ${shortHeadSha}: nothing app-affecting changed since the last fully tested deploy, so the recorded results below still stand.`,
+    };
+  }
+
+  const recordedRows = Object.values(params.recordedApps).map(
+    (entry) =>
+      `  ${entry.appSlug}: ${entry.status}, head ${entry.shortSha ?? "?"}${entry.headSha === params.pullRequestHeadSha ? "" : " (stale — deploy has not run for the current head)"}`,
+  );
+  return {
+    verdict: "stale-head",
+    notice: [
+      `Preview e2e refused to skip for head ${shortHeadSha}: deploy has not recorded ${params.appsDeployWouldSelect.join(", ")} at this head, so a green result would describe a different commit. E2e was NOT run.`,
+      ...(recordedRows.length > 0
+        ? ["Recorded app states:", ...recordedRows]
+        : ["No apps are recorded at all."]),
+      "A push likely raced the deploy step, or deploy failed before recording. A superseding run usually follows automatically; if none does, re-run the Cloudflare Previews workflow (preview deploy + test).",
+    ].join("\n"),
+  };
 }
 
 function selectPreviewAppsNeedingRetry(params: {
@@ -4125,7 +4352,9 @@ export const previewInternals = {
   classifyLeaseForReclaim,
   decideDraftPreviewPolicy,
   describeEnvironmentConfigLeases,
+  describeForcePushCompareHazard,
   evaluateCloudflareZoneCheck,
+  explainPreviewTestSkip,
   holderPullRequestUrl,
   pullRequestHolder,
   reassertEnvironmentConfigLease,
@@ -4142,6 +4371,7 @@ export const previewInternals = {
   resolveAuthPreviewRootSecret,
   resolvePreviewCompareBaseSha,
   resolvePreviewReadinessUrls,
+  selectPreviewAppsForPullRequest,
   selectPreviewAppsNeedingRetry,
   splitRepositoryFullName,
   syncPreviewInventory,


### PR DESCRIPTION
Fixes two concrete gaps in the Cloudflare preview deploy + e2e pipeline, both observed live on PR #1793 / preview slot 7 on 2026-07-09, plus one force-push hazard found while auditing the same code path. All changes are in `scripts/preview/preview.ts` + `scripts/preview/preview.test.ts`; the workflow yml is untouched.

## Gap 1 — erase-data left the pipeline unable to self-heal

**Live evidence:** preview-7 was leased to PR #1793 and its stream Durable Objects carried pre-`epoch`-column SQLite state; after the PR merged main (which had landed a non-migratable stream schema change), e2e failed with `no such column: epoch`. The documented remedy is `doppler run --config preview_7 -- pnpm run erase-data --env preview_7` and a Depot re-run — but the erase parks the os worker behind a 503 and wipes the slot's auth D1 (OAuth clients) **without touching the recorded PR-body state**. On the re-run, the unchanged-head retry path (`selectPreviewAppsNeedingRetry`) only redeploys apps that did not reach a green state; os and auth were recorded green, so neither was redeployed and every sign-in-dependent spec failed against a slot with no OAuth clients. Auth had to be redeployed by hand.

**Fix:** before trusting a recorded-green (`deployed`/`awaiting-tests`) row, deploy selection now probes the app's readiness URL once (`selectRecordedGreenAppsNotServing`, single GET on the same path the deploy readiness wait uses — `/api/health` for os, `/api/auth/ok` for auth). A parked app fails its probe, joins the retry selection, and pulls its dependencies along via `expandPreviewDependencies` — so the parked os worker drags auth (whose OAuth-client seed lives in the wiped D1 and is re-seeded by every auth deploy) with it. erase + re-run is now a one-step, self-healing recipe.

Adjacent wedge fixed in the same path: failed-state retries (`claim-failed` / `deploy-failed` / `tests-failed`) now apply on the **changed-head diff path** too, not only when the head is unchanged — a push whose diff misses the failed apps no longer leaves them wedged.

## Gap 2 — `preview test` could report a green check having run nothing

When no recorded app matched the PR's current head (fetched fresh at test time), `test()` returned `{ ok: true, skipped: true }` unconditionally. Two sub-cases deserve opposite treatment:

- **nothing-changed** — no app-affecting change since the last fully tested deploy: prior results stand, green skip is honest;
- **stale-head** — apps recorded at an old head because a push raced between the deploy and test steps, or deploy died before recording: green would describe a commit that never ran.

`test()` now recomputes the exact selection deploy would make for the current head (`selectPreviewAppsForPullRequest`, same code, injectable for tests). Empty selection → green skip; non-empty → loud failure (`explainPreviewTestSkip`). Both cases write an explicit PR-body notice saying which case happened; the stale-head failure message lists the stale apps and notes that a superseding run is usually already queued (workflow-level cancel-in-progress), so the loud failure is cheap.

## Audit — force-push vs the compare base

`resolvePreviewCompareBaseSha` diffs from the last deployed head. A force-push can rewrite that head out of history:

- the compare then **404s** — previously this failed the whole run (`withGithubRetry` rethrows deterministic 4xx); it now falls back to deploying the full fleet;
- or GitHub reports **diverged/behind** — the three-dot compare diffs from the merge base and cannot see changes that existed only on the deployed side (which the slot still runs); previously the file list was trusted and could select nothing. `describeForcePushCompareHazard` now sends both shapes to a full-fleet deploy. Over-deploying is idempotent; under-deploying strands force-pushed-away code on the slot.

## Tests

`scripts/preview/preview.test.ts` (+23 tests, 109 total in the lane, all green):

- self-heal replica of the live incident: streams-example-app `tests-failed`, os + auth recorded green, os probe 503 → selection is `[os, auth, streams-example-app]`, and only the green claims are probed on their app-specific readiness paths;
- healthy green apps at an unchanged head select nothing (and the compare is never called);
- failed apps are retried even when the push's diff doesn't touch them;
- compare 404 → full fleet; compare diverged → full fleet; non-404 compare errors still propagate;
- `describeForcePushCompareHazard` verdicts;
- `explainPreviewTestSkip`: nothing-changed green, stale-head loud failure (with per-app stale rows), and the nothing-recorded-at-all case.

`pnpm install && pnpm typecheck && pnpm test && pnpm format` all pass. (Repo-wide `pnpm lint` fails in this nested worktree because oxlint discovers the parent checkout's `.oxlintrc.json` and its stale node_modules — pre-existing on a clean tree; `oxlint -c .oxlintrc.json .` in the worktree is clean.)

## Found, not fixed

- **Mixed recorded heads use a single compare base.** `resolvePreviewCompareBaseSha` takes the FIRST recorded entry's `headSha`. Mixed heads are the steady state under diff selection (unaffected apps stay at older heads), so when entries disagree the diff base is whichever app happens to be recorded first — a run that dies between per-batch PR-body writes can leave a base that under-selects. A fully correct fix is one compare per distinct recorded head (or per-app compares); that's a design decision, not a patch.
- **An erased slot's auth worker still answers its liveness probe.** erase-data wipes auth's D1 rows but does not park the auth worker, so `/api/auth/ok` stays 200 with zero OAuth clients. Today auth self-heals only via os's dependency edge (an erase always parks os, and os always drags auth along). A data-aware auth health endpoint would make it directly detectable.
- **`preview erase` subcommand** (erase + mark all recorded apps for redeploy in one step) was considered but not added: the serving probe already makes the documented erase + re-run recipe self-healing without new operator surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI orchestration for preview slots (deploy selection, GitHub compare, live HTTP probes); mistakes could over-deploy or block legitimate green skips, but scope is limited to preview scripts and is heavily tested.
> 
> **Overview**
> Hardens the Cloudflare **preview deploy + e2e** path in `scripts/preview/preview.ts` so slots recover after `erase-data` and checks cannot go green without running tests.
> 
> **Deploy selection** (`selectPreviewAppsForPullRequest`) now probes readiness URLs for recorded-green apps before trusting PR-body state; non-serving apps join deploy (with **dependency expansion**, e.g. os → auth). Failed-app retries run on the **changed-head** diff path, not only when the head is unchanged. Compare **404** or **diverged/behind** status triggers a **full-fleet** deploy instead of failing or under-selecting. Injectable `fetchCompare` / `probeAppServing` support unit tests.
> 
> **Preview test** when nothing is recorded at the current head recomputes what deploy would select and uses **`explainPreviewTestSkip`**: honest green skip if nothing would deploy; **throws** on stale-head, with a PR-body notice.
> 
> **Tests** add coverage for deploy selection, force-push hazards, and skip verdicts in `preview.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56686e30b428e6aa4ab90f6e87c60292d97cffbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +243 -0 | +202 -0 🟩🟩🟩🟩⬜ |
| CI & scripts | +282 -52 | +183 -46 🟩🟩🟩🟩🟥 |
| **Total** | **+525 -52** | **+385 -46** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 5c59e87 and 56686e3, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-09T13:53:12.839Z",
      "headSha": "56686e30b428e6aa4ab90f6e87c60292d97cffbb",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/248130536861446",
      "shortSha": "56686e3",
      "cleanupDurationMs": 12579,
      "deployDurationMs": 78329,
      "testDurationMs": 179081,
      "testRetries": "3 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · subscribe rejects a malformed subscriber descriptor instead of corrupting the roster (vitest x1) · stream getEvents defaults to a bounded page and supports event type filters (vitest x1)",
      "workerSizeKib": 12097.92,
      "workerGzipKib": 3240.53,
      "mainWorkerGzipKib": 3241.19
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-09T13:53:01.107Z",
      "headSha": "56686e30b428e6aa4ab90f6e87c60292d97cffbb",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/248130536861446",
      "shortSha": "56686e3",
      "cleanupDurationMs": 844,
      "deployDurationMs": 18417,
      "testDurationMs": 6936,
      "testRetries": null,
      "workerSizeKib": 1913.73,
      "workerGzipKib": 440.69,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-09T13:53:03.208Z",
      "headSha": "56686e30b428e6aa4ab90f6e87c60292d97cffbb",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/248130536861446",
      "shortSha": "56686e3",
      "cleanupDurationMs": 2942,
      "deployDurationMs": 23594,
      "testDurationMs": 528,
      "testRetries": null,
      "workerSizeKib": 3992.8,
      "workerGzipKib": 811.98,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-09T13:53:01.390Z",
      "headSha": "56686e30b428e6aa4ab90f6e87c60292d97cffbb",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/248130536861446",
      "shortSha": "56686e3",
      "cleanupDurationMs": 1122,
      "deployDurationMs": 15346,
      "testDurationMs": 23423,
      "testRetries": null,
      "workerSizeKib": 4628.72,
      "workerGzipKib": 1336.61,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `56686e3` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 812.0 KiB | 23.6s | 528ms |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/248130536861446) | 2026-07-09T13:53:03.208Z | Preview app released. |
| OS | released | `56686e3` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 3.16 MiB (-0.7 KiB vs main) | 78.3s | 179.1s | 3 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · subscribe rejects a malformed subscriber descriptor instead of corrupting the roster (vitest x1) · stream getEvents defaults to a bounded page and supports event type filters (vitest x1) | 12.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/248130536861446) | 2026-07-09T13:53:12.839Z | Preview app released. |
| Semaphore | released | `56686e3` | [https://semaphore.iterate-preview-7.com](https://semaphore.iterate-preview-7.com) | 440.7 KiB | 18.4s | 6.9s |  | 844ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/248130536861446) | 2026-07-09T13:53:01.107Z | Preview app released. |
| Streams Example App | released | `56686e3` | [https://streams.iterate-preview-7.com](https://streams.iterate-preview-7.com) | 1.31 MiB | 15.3s | 23.4s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/248130536861446) | 2026-07-09T13:53:01.390Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->