### PR TITLE
Container-class bootstrap: keep exporting live DO classes

### DIFF
--- a/scripts/lib/do-reset.ts
+++ b/scripts/lib/do-reset.ts
@@ -308,7 +308,14 @@ export async function ensureContainerClasses(input: {
     `container-class bootstrap: ${input.workerName} is missing ${missing.join(", ")} — ` +
       `legacy-creating them container-enabled before the exports deploy`,
   );
-  const stubExports = missing
+  // The upload replaces the whole worker script, so it must keep exporting
+  // every class existing Durable Objects depend on — the API rejects a
+  // script that drops one (error 10064). Stub the live classes alongside
+  // the missing ones (a live worker gaining new container classes is the
+  // normal case, e.g. a preview slot first deploying a branch that adds
+  // one); the next real deploy restores the real implementations.
+  const stubExports = [...missing, ...live.map((namespace) => namespace.className)]
+    .sort()
     .map((className) => `export class ${className} { constructor() {} }`)
     .join("\n");
   const form = new FormData();


### PR DESCRIPTION
## What

Fixes the recurring DO-bootstrap failure that wedged **preview_9**: every PR leasing the slot failed its `Preview / deploy + e2e` lane on the os app deploy with rotating Cloudflare 10064 errors:

```
PUT .../os-preview-9 → 403 code 10064:
"does not export class 'StreamDurableObject' which is depended on by existing Durable Objects"
```

## Why

`ensureContainerClasses` (`scripts/lib/do-reset.ts`, from #1762) legacy-creates container classes that are missing on a worker before its `exports` deploy. The bootstrap upload replaces the **whole worker script**, but its module only exported the *missing* container classes — dropping every export the worker's live DO namespaces depend on. On a fresh or freshly-parked worker that's fine; on a long-lived worker like `os-preview-9` (10 live classes: `AgentDurableObject`, `StreamDurableObject`, `SecretDurableObject`, …) Cloudflare rejects the upload. The "rotating class name" across retries was the API reporting one dropped export at a time.

This is the normal case whenever a deployed environment first deploys a branch that adds a new container class — so it would have recurred on every stale slot each time a `Sandbox*` instance type is added.

## Fix

The bootstrap module now stub-exports every **live** class alongside the missing ones:

```js
// before: only the missing container classes
export class SandboxBasicDurableObject { constructor() {} }
// after: those PLUS every class with live Durable Objects
export class AgentDurableObject { constructor() {} }
export class StreamDurableObject { constructor() {} }
// ...
```

The stubs only exist for the one bootstrap upload; the next real deploy restores the real implementations.

## Verified live

Ran the fixed bootstrap against `os-preview-9` (the exact PUT that was failing): it succeeded and created all six `Sandbox{Basic,Lite,Standard1-4}DurableObject` classes container-enabled. A re-run returns `{"action": "skipped", "missing": []}`, so **preview_9 is already unwedged for every PR** — even ones without this fix — since the bootstrap is now a no-op there. The slot serves the parked 503 until its next real deploy (same as post-erase), which the next leased PR's deploy lane performs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-09T13:53:25.801Z",
      "headSha": "49eca46cd1d9e1982b871c74acda08f96687d4fc",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/268370522449951",
      "shortSha": "49eca46",
      "cleanupDurationMs": 11177,
      "deployDurationMs": 69689,
      "workerSizeKib": 12100.09,
      "workerGzipKib": 3241.19,
      "mainWorkerGzipKib": 3241.19
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-09T13:53:15.246Z",
      "headSha": "49eca46cd1d9e1982b871c74acda08f96687d4fc",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/268370522449951",
      "shortSha": "49eca46",
      "cleanupDurationMs": 618,
      "deployDurationMs": 13843,
      "workerSizeKib": 1913.73,
      "workerGzipKib": 440.69,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-09T13:53:17.318Z",
      "headSha": "49eca46cd1d9e1982b871c74acda08f96687d4fc",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/268370522449951",
      "shortSha": "49eca46",
      "cleanupDurationMs": 2685,
      "deployDurationMs": 16726,
      "workerSizeKib": 3992.8,
      "workerGzipKib": 812,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-09T13:53:15.458Z",
      "headSha": "49eca46cd1d9e1982b871c74acda08f96687d4fc",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/268370522449951",
      "shortSha": "49eca46",
      "cleanupDurationMs": 823,
      "deployDurationMs": 13794,
      "workerSizeKib": 4628.98,
      "workerGzipKib": 1336.71,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `49eca46` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 812.0 KiB | 16.7s |  |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/268370522449951) | 2026-07-09T13:53:17.318Z | Preview app released. |
| OS | released | `49eca46` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 3.17 MiB (±0 vs main) | 69.7s |  |  | 11.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/268370522449951) | 2026-07-09T13:53:25.801Z | Preview app released. |
| Semaphore | released | `49eca46` | [https://semaphore.iterate-preview-1.com](https://semaphore.iterate-preview-1.com) | 440.7 KiB | 13.8s |  |  | 618ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/268370522449951) | 2026-07-09T13:53:15.246Z | Preview app released. |
| Streams Example App | released | `49eca46` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.31 MiB | 13.8s |  |  | 823ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/268370522449951) | 2026-07-09T13:53:15.458Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| CI & scripts | +8 -1 | +2 -1 🟩🟩🟩🟥🟥 |
| **Total** | **+8 -1** | **+2 -1** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 3ec38f9 and 49eca46, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path change in deploy/bootstrap scripting with no auth or data-model impact; behavior only affects the one-off bootstrap upload before exports deploy.
> 
> **Overview**
> Fixes preview deploy failures (**Cloudflare 10064**) when `ensureContainerClasses` legacy-creates missing container DO classes on a worker that already has other live Durable Object classes.
> 
> The bootstrap **PUT replaces the entire worker script**, but the generated `bootstrap.mjs` previously only exported the *missing* container classes. Cloudflare rejects uploads that drop exports still depended on by existing DOs (e.g. `StreamDurableObject` on long-lived preview slots).
> 
> **Change:** `stubExports` now includes **every live class name** from `getWorkerDoNamespaces` in addition to the missing container classes, deduped and sorted—same idea as the exports-tombstone parking path. Stubs are temporary; the following real deploy restores real implementations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49eca46cd1d9e1982b871c74acda08f96687d4fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->