### PR TITLE
POC: agent context compaction

### DIFF
--- a/tasks/agent-context-compaction.md
+++ b/tasks/agent-context-compaction.md
@@ -1,0 +1,93 @@
+---
+status: poc
+size: large
+---
+
+# Agent context compaction
+
+## Status summary
+
+POC in progress. Research phase done (survey of pi, opencode, codex, Claude Code compaction implementations — see "Prior art" below). This PR is a proof-of-concept of the core mechanism: compaction expressed as stream events folded by the agent reducer, triggered by provider-reported token usage. Tier-1 pruning, the deterministic script ledger, and snippets-catalogue promotion are specced but deliberately out of scope for the POC.
+
+## Why
+
+Agent history grows unbounded. `reduceAgentEvents` folds every `input-added`/`output-added` since the stream began into `state.history`, and `buildLlmChatRequest` sends all of it on every LLM call. There is no token counting, no context-window awareness, and the only size guard is the blunt 30KB `truncateScriptResult`. Long-lived channel agents (Slack threads that live for weeks) will eventually overflow any model's context window — and long before that, they'll degrade from context rot and burn money on tokens.
+
+## Design
+
+Full research writeup lives in the conversation that produced this task; the condensed decisions:
+
+### Representation: compaction is an event the reducer folds
+
+- `compaction-requested` `{reason: "manual" | "threshold" | "overflow", instructions?}`
+- `compaction-completed` `{summary, firstKeptOffset, tokensBefore}`
+
+The reducer folds `compaction-completed` by dropping history entries whose source event offset is below `firstKeptOffset` and prepending a synthetic user message containing the summary. This requires tagging each `ChatMessage` in reduced state with the offset of the event that produced it (internal field, stripped before the provider call).
+
+Nothing is ever deleted; the journal stays append-only; state remains a pure function of events; request-by-reference (`offset <= llmRequestId`) keeps working for both providers; resume/replay is free. A `compaction-requested` with no matching `compaction-completed` is retriable by construction (opencode persists its compaction request as a message part for the same crash-safety; our event journal gives us that for free).
+
+### Trigger: provider-reported usage vs. absolute headroom reserve
+
+- Type the currently-`z.unknown()` `usage` on `llm-request-completed`.
+- Small per-model context-window map (we have exactly two providers; a handful of models).
+- Fire when `lastUsage.totalTokens + charsOver4(messagesSinceLastUsage) > contextWindow − reserve`, reserve ≈ 24k (room for the next response AND for the compaction request itself). Absolute reserve, not a percentage — pi's approach; it's what you actually need and scales across window sizes.
+- Check when settling the next turn (before scheduling `llm-request-requested`), never mid-stream.
+
+### Summarization
+
+- Keep the newest ~20k (estimated) tokens of history verbatim; summarize everything older.
+- Rolling summary: the span to summarize starts at the previous compaction's `firstKeptOffset`, and the previous summary is fed into an "update this checkpoint" prompt (pi's rolling approach — cheap, stable across many rounds).
+- Serialize the span as labeled plain text (`[User]: … [Assistant]: …`) so the summarizer can't mistake it for a live conversation; system prompt forbids continuing the conversation.
+- Structured checkpoint format: Goal / Constraints & preferences / Progress / Key decisions / All user asks / **Entities & handles** / **Side effects already performed — do not repeat** / Current work + verbatim next step.
+- Same model/provider as the session for the POC.
+
+### itx-specific rules (this is where we differ from the prior art)
+
+Script executions are **stateless** (loopback entrypoint, no shared realm — `capability-host-durable-object.ts`), so conversation history is the only bridge between scripts. And capabilities carry no read-only hint, so scripts can never be assumed safe to re-run.
+
+1. **Protect script code, spend script results.** Script code is small, dense, and is the agent's in-context few-shot corpus for correct itx API usage. Results are the bloat. Summarization serializes script code verbatim and clips results (~2k chars).
+2. **Entities & handles** section is mandatory in the summary: exact IDs/URLs/keys returned by scripts (Slack ts, PR numbers, stream offsets, trigger keys). Losing one can leave the agent unable to act on an entity.
+3. **Side effects already performed** section is mandatory: the post-compaction duplicate Slack message is the nightmare scenario.
+4. Any future pruning placeholder must be neutral (`[old script result cleared]`) — never "re-run if needed".
+
+### Provider caveat
+
+The OpenAI WS provider uses `previous_response_id` continuation (sends only new messages, relies on server-retained context). The first request after a `compaction-completed` must reset that and do a full resend.
+
+### Guardrails
+
+- No auto re-compaction while a `compaction-requested` is pending or if the last compaction happened within the same settle cycle (thrash-loop protection — the #1 failure mode in Claude Code and pi both).
+- On summarization failure: journal a failure event, leave history untouched.
+
+## Prior art (condensed)
+
+- **pi** (earendil-works/pi-mono): absolute headroom reserve trigger from provider usage; rolling "update the previous summary" prompt; keep newest 20k tokens verbatim; cumulative `<read-files>/<modified-files>` blocks; append-only JSONL with compaction entries; one-shot overflow recovery via provider error regexes.
+- **opencode** (sst/opencode): two tiers — non-destructive tool-output pruning every turn (placeholder text, original kept in storage) before any LLM summary; compaction request persisted as a message ⇒ crash-safe retry; summary is an ordinary stored assistant message flagged `summary: true`.
+- **Claude Code**: auto-compact ~83.5% of effective window; escalating cascade (huge results to disk → placeholder-clear re-derivable tool results, keep newest 5 → session-memory notes → full 9-section summary); post-compact rehydration of recently-read files; prompt-cache preservation as an explicit design constraint.
+- **codex** (openai/codex): 90% trigger; local path re-seeds fresh history = user messages (newest-first, 20k budget) + prefixed summary, discards all tool traffic; steady-state 10KB tool-output truncation; stores full `replacement_history` snapshot for resume.
+
+Consensus we adopt: usage-based trigger with headroom, keep-recent-verbatim + summarize-old, durable/retriable compaction records, placeholder-clearing of bulky re-derivable outputs before expensive summarization, cache/continuation awareness.
+
+## POC checklist
+
+- [ ] Typed `usage` on `llm-request-completed` + per-model context window map + `estimateTokens` (chars/4) helper
+- [ ] `compaction-requested` / `compaction-completed` events in `agent-processor-contract.ts`
+- [ ] Reducer: source-offset tagging on history entries; fold `compaction-completed` (drop older, prepend summary message)
+- [ ] Threshold trigger in settle logic (append `compaction-requested` when over budget; thrash guard)
+- [ ] Summarization step: on `compaction-requested`, serialize the span, run summary LLM call, append `compaction-completed`
+- [ ] OpenAI WS provider: full resend (reset `previous_response_id`) after a compaction boundary
+- [ ] Tests in the existing `agent-processors.test.ts` style: reducer fold, trigger, end-to-end compact-then-continue
+
+## Follow-ups (out of POC scope)
+
+- [ ] Tier-1 pruning: `script-results-pruned` event, protect newest ~40k tokens, ≥20k reclaim minimum
+- [ ] Deterministic `<scripts-run>` ledger extracted from script events, merged across rolling compactions
+- [ ] Manual `/compact [focus instructions]` surface
+- [ ] Overflow recovery (provider context-exceeded error detection → compact once → retry)
+- [ ] Cheaper dedicated summarizer model config
+- [ ] Snippets-catalogue promotion: nudge agent to save proven scripts to the known-good snippets capability pre-compaction
+- [ ] Context-used % surfaced in UI/evlog
+
+## Implementation log
+
+(started 2026-07-09)


### PR DESCRIPTION
Proof-of-concept for compacting agent conversation history so long-lived channel agents don't overflow (or rot) their context window.

**Reference PR — intentionally closed.** Opened for review convenience; not intended to merge as-is.

## What's here (implemented, tests green)

Agent history today grows forever: every `input-added`/`output-added` since stream birth is folded into `state.history` and sent on every LLM call, with no token awareness at all. This POC adds compaction in the repo's own idiom — as events, folded by the reducer, so state stays a pure function of the journal:

- **Events**: `compaction-requested` / `compaction-completed` / `compaction-failed`. The reducer folds a completed compaction by dropping history older than `firstKeptOffset` and prepending the summary checkpoint as a user message. Append-only journal, deterministic replay, crash-safe retry all preserved.
- **Trigger**: typed `LlmUsage` from `llm-request-completed` (tolerant parse — a weird usage shape degrades to "no usage" rather than wedging the event) + chars/4 extrapolation for messages since, vs per-model context window − 24k reserve. Checked only at settle time. Per-agent window override via `llm-provider-selected.contextWindowTokens`.
- **Summarization rides the existing llm-request pipeline** as `purpose: "compaction"` — `buildAgentLlmRequestBody` emits the checkpoint prompt for that request, so both providers (Workers AI + OpenAI WS) work with zero provider-specific summarization code, and compaction inherits orphan recovery, cancellation, and idempotent completion for free. Output routes to `compaction-completed`, never script execution (a hallucinated code block in a summary can't cause side effects).
- **Rolling checkpoint**: newest ~20k tokens kept verbatim; previous summary folded into an "update the checkpoint" prompt. itx-aware sections: **Entities & handles** (IDs returned by scripts — the only bridge between stateless script executions) and **Side effects already performed — do not repeat**. Script code serialized verbatim; script results clipped to 2k.
- **openai-ws continuation**: request bodies carry a `compactionCount`; on mismatch the provider drops `previous_response_id` and does a full resend across the boundary.
- **Thrash guards**: pending compaction owns the request slot; one attempt per usage measurement; `lastUsage` cleared on fold so re-compaction waits for fresh usage; failures degrade to "no compaction", never a loop.

**Tests**: `agent-compaction.test.ts` — 9 specs (reducer fold, trigger, thrash guard, malformed usage, failure fallthrough, checkpoint prompt shape, compact-then-continue e2e on both providers incl. openai-ws full-resend proof). Full apps/os suite 742 passed; typecheck/lint/format green.

Design + prior-art survey (pi, opencode, codex, Claude Code) and the follow-up list (tier-1 script-result pruning, manual `/compact`, overflow recovery, scripts-run ledger, snippets-catalogue promotion): see `tasks/agent-context-compaction.md` in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)