### PR TITLE
Codemode: don't cut scripts at fences embedded in string literals

### DIFF
--- a/apps/os/e2e/vitest/agent-codemode-fence.itx.e2e.test.ts
+++ b/apps/os/e2e/vitest/agent-codemode-fence.itx.e2e.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Goal coverage: an assistant reply whose script embeds a markdown fence
+ * inside a string literal executes in full. No LLM involved — the reply is
+ * synthesized directly on the agent stream, exactly as an LLM provider
+ * journals it (agent/output-added), and the script then runs in a real
+ * dynamic worker. Repro of a prd incident (agents/web/2026-07-09t14-21-45-359z):
+ * agents that send markdown-formatted chat messages write scripts containing
+ * ``` inside strings; the reply used to be cut at that inner fence, the
+ * unparseable prefix failed with "Invalid or unexpected token", and the
+ * user-visible message never went out.
+ */
+import { test } from "vitest";
+import { createTestProject } from "../test-support/create-test-project.ts";
+import { waitForCondition } from "../test-support/wait-for-condition.ts";
+
+test(
+  "a script that embeds a markdown fence in a string literal runs in full",
+  { timeout: 240_000 },
+  async ({ expect }) => {
+    await using handle = await createTestProject({ slugPrefix: "codemode-fence" });
+    using agent = handle.agent("/agents/e2e-codemode-fence");
+
+    // The reply an LLM provider would journal: prose, then one fenced script
+    // whose sendMessage argument itself contains a ```text block.
+    const marker = crypto.randomUUID().slice(0, 8);
+    const script = [
+      "async (itx) => {",
+      `  await itx.chat.sendMessage("Tail (${marker}):\\n\`\`\`text\\n" + "0123456789".slice(-4) + "\\n\`\`\`");`,
+      "}",
+    ].join("\n");
+    await agent.stream.append({
+      type: "events.iterate.com/agent/output-added",
+      payload: { content: `Reading the saved output now.\n\n\`\`\`js\n${script}\n\`\`\`` },
+    });
+
+    // Sync on the script finishing, keeping its error (if any) so a
+    // regression reports the actual script failure instead of a poll timeout.
+    let completionError: string | null = null;
+    await waitForCondition(
+      async () => {
+        const events = await agent.stream.getEvents({
+          eventTypes: ["events.iterate.com/capability-host/script-execution-completed"],
+          limit: 100,
+        });
+        const completion = events.at(0);
+        if (completion === undefined) return false;
+        completionError =
+          typeof completion.payload?.error === "string" ? completion.payload.error : null;
+        return true;
+      },
+      { description: "the agent's script to finish", intervalMs: 1_000, timeoutMs: 120_000 },
+    );
+    expect(completionError).toBeNull();
+
+    // The user-visible outcome: the exact message the script sent, fence and
+    // all — proof the code AFTER the embedded ``` executed.
+    const messages = await agent.stream.getEvents({
+      eventTypes: ["events.iterate.com/agents/web-message-sent"],
+      limit: 100,
+    });
+    const sent = messages.map((event) => String(event.payload?.message ?? ""));
+    expect(sent).toContainEqual(expect.stringContaining(marker));
+    expect(sent).toContainEqual(expect.stringContaining("```text\n6789\n```"));
+  },
+);

--- a/apps/os/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/os/src/domains/agents/agent-processor-implementation.ts
@@ -589,7 +589,15 @@ function spillNotice(input: { path: string; totalChars: number }): string {
 }
 
 function extractAsyncJsSnippet(content: string): string | null {
-  const fenced = content.match(/```(?:js|javascript|ts|typescript)?\s*([\s\S]*?)```/i);
+  // Fences count only at line starts: scripts legitimately carry ``` inside
+  // string literals (chat messages formatted as markdown), and in valid JS
+  // those always sit mid-line — a raw newline cannot appear in a string
+  // literal, and an unescaped ``` would terminate a template literal. A fence
+  // match anywhere used to cut the script at the first embedded ``` and
+  // execute an unparseable prefix (unclosed string literal).
+  const fenced = content.match(
+    /^[ \t]*```(?:js|javascript|ts|typescript)?[ \t]*\n([\s\S]*?)\n[ \t]*```[ \t]*$/im,
+  );
   const code = (fenced?.[1] ?? content).trim();
   return /^async\s*(?:function|\()/.test(code) || /^\(?async\s*\(/.test(code) ? code : null;
 }

--- a/apps/os/src/domains/agents/agent-processors.test.ts
+++ b/apps/os/src/domains/agents/agent-processors.test.ts
@@ -395,6 +395,30 @@ describe("minimal web-chat agent processors", () => {
     });
   });
 
+  it("extracts the whole script when a string literal embeds a markdown fence", async () => {
+    const stream = new MemoryStream();
+    const agent = new AgentProcessor({ stream });
+
+    // Mirrors a prd incident (agents/web/2026-07-09t14-21-45-359z): a chat
+    // message formatted as markdown puts ``` inside the script's string
+    // literal; extraction must not cut the script at that inner fence.
+    const script = [
+      "async (itx) => {",
+      '  await itx.chat.sendMessage("Tail:\\n```text\\n" + "0123456789".slice(-4) + "\\n```");',
+      "}",
+    ].join("\n");
+    await stream.append({
+      type: "events.iterate.com/agent/output-added",
+      payload: { content: `Reading the saved output now.\n\n\`\`\`js\n${script}\n\`\`\`` },
+    });
+    await deliverNewEvents({ processor: agent, stream, cursors: new Map() });
+
+    const requested = stream.events.find(
+      (event) => event.type === "events.iterate.com/capability-host/script-execution-requested",
+    );
+    expect(requested?.payload?.code).toBe(script);
+  });
+
   it("treats MCP-origin messages like any other inbound user message", async () => {
     const stream = new MemoryStream();
     const agent = new AgentProcessor({ stream });
@@ -745,6 +769,48 @@ describe("minimal web-chat agent processors", () => {
       result: { status: "success", usage: { total_tokens: 7 } },
     });
     expect(output.payload).toMatchObject({ content: "```js\nasync (itx) => {}\n```" });
+  });
+
+  it("fails an openai-ws request that ends incomplete instead of keeping partial output", async () => {
+    const stream = new MemoryStream();
+    const openAiWs = new OpenAiWsProcessor({
+      stream,
+      apiKey: "sk-test",
+      createResponsesWebSocketClient: async () =>
+        fakeResponsesWebSocket(() => [
+          { type: "response.output_text.delta", delta: '```js\nasync (itx) => { const s = "cut' },
+          {
+            type: "response.incomplete",
+            response: {
+              id: "resp_1",
+              incomplete_details: { reason: "max_output_tokens" },
+              status: "incomplete",
+              usage: { total_tokens: 9 },
+            },
+          },
+        ]),
+      readStreamEvents: () => stream.getEvents(),
+    });
+
+    await stream.append(...openAiWsRequestEvents("hello over ws"));
+    await deliverNewEvents({ processor: openAiWs, stream, cursors: new Map() });
+    const completed = await stream.waitForEvent({
+      eventTypes: ["events.iterate.com/agent/llm-request-completed"],
+      timeoutMs: 2_000,
+    });
+
+    expect(completed.payload).toMatchObject({
+      provider: "openai-ws",
+      result: {
+        status: "failure",
+        error: { message: expect.stringContaining("max_output_tokens") },
+      },
+    });
+    // A truncated response must never become an assistant turn — executing a
+    // prefix of a script is worse than failing the request and retrying.
+    expect(
+      stream.events.some((event) => event.type === "events.iterate.com/agent/output-added"),
+    ).toBe(false);
   });
 
   it("retries openai-ws once with full input when a previous response id expires", async () => {

--- a/apps/os/src/domains/agents/agent-processors.test.ts
+++ b/apps/os/src/domains/agents/agent-processors.test.ts
@@ -730,7 +730,10 @@ describe("minimal web-chat agent processors", () => {
           { type: "response.output_text.delta", delta: "\n```" },
           {
             type: "response.completed",
-            response: { id: "resp_1", usage: { total_tokens: 7 } },
+            // The real API sends incomplete_details as an explicit null on
+            // completed responses; a schema that rejects null here makes the
+            // consumer skip the terminal frame and wait forever.
+            response: { id: "resp_1", incomplete_details: null, usage: { total_tokens: 7 } },
           },
         ]);
         sockets.push(socket);

--- a/apps/os/src/domains/agents/openai-ws-processor-implementation.ts
+++ b/apps/os/src/domains/agents/openai-ws-processor-implementation.ts
@@ -46,7 +46,9 @@ const OpenAiResponsesStreamMessage = z.looseObject({
   response: z
     .looseObject({
       id: z.string().optional(),
-      incomplete_details: z.looseObject({ reason: z.string().optional() }).optional(),
+      // Explicitly null (not absent) on completed responses — .nullish(), or
+      // the terminal frame fails parsing and the consumer waits forever.
+      incomplete_details: z.looseObject({ reason: z.string().nullish() }).nullish(),
       usage: z.unknown().optional(),
     })
     .optional(),

--- a/apps/os/src/domains/agents/openai-ws-processor-implementation.ts
+++ b/apps/os/src/domains/agents/openai-ws-processor-implementation.ts
@@ -46,6 +46,7 @@ const OpenAiResponsesStreamMessage = z.looseObject({
   response: z
     .looseObject({
       id: z.string().optional(),
+      incomplete_details: z.looseObject({ reason: z.string().optional() }).optional(),
       usage: z.unknown().optional(),
     })
     .optional(),
@@ -408,6 +409,18 @@ export class OpenAiWsProcessor extends StreamProcessor<
           text,
           ...(usage === undefined ? {} : { usage }),
         };
+      }
+
+      if (parsed.data.type === "response.incomplete") {
+        // A terminal frame like response.completed, but the output was cut
+        // short (max_output_tokens, content filter). Keeping the partial text
+        // would hand the agent a prefix of a script — fail the request
+        // instead so it retries like any other provider failure.
+        this.#previousResponseId = null;
+        const reason = parsed.data.response?.incomplete_details?.reason;
+        throw new Error(
+          `OpenAI response ended incomplete${reason === undefined ? "" : ` (${reason})`}; discarding partial output.`,
+        );
       }
 
       if (parsed.data.type === "response.failed" || parsed.data.type === "error") {


### PR DESCRIPTION
## The bug

A prd agent turn ([agents/web/2026-07-09t14-21-45-359z](https://os.iterate.com/projects/iterate/agents/streams/agents/web/2026-07-09t14-21-45-359z?filter=true), llmRequestId 463) failed with `Invalid or unexpected token`. The raw OpenAI response on the stream shows the model's script was **complete and valid** — it ended with:

```js
await itx.chat.sendMessage("Last 100 chars of the saved `noise` output:\n```text\n" + data.noise.slice(-100) + "\n```");
}
```

`extractAsyncJsSnippet`'s lazy fence match (`/```(?:js|...)?\s*([\s\S]*?)```/`) stopped at the first ``` ` ``` ` anywhere in the reply — here the ` ```text ` **inside the script's string literal** — so the agent executed an unparseable prefix ending mid-string. Deterministic, and common: any script that sends a markdown-formatted chat message embeds fences in strings.

## The fix

Fences now count only at line starts. In valid JS an embedded fence always sits mid-line: raw newlines are illegal in string literals (` \n ` is two chars there), and an unescaped ``` ` ``` ` would terminate a template literal. Sibling non-script blocks in the same reply still parse as before (lazy match to the first line-start closing fence).

## response.incomplete handling

While in the consumer: the OpenAI Responses WebSocket's `response.incomplete` terminal frame (max_output_tokens, content filter) previously fell through the frame switch, so the consumer waited for frames that never come until the 10-minute deadline orphaned the request. It now fails the request immediately and discards the partial output — a truncated response must never become an assistant turn (executing a prefix of a script is exactly the bug above, arriving via a different door).

## Tests

- **e2e** (`agent-codemode-fence.itx.e2e.test.ts`): implementation-blind — journals an assistant reply (`agent/output-added`, exactly as an LLM provider would) whose script embeds a ` ```text ` fence in a string, lets it run in a real dynamic worker, and asserts the sent chat message, fence and all. Before the fix it failed with the verbatim prd error (`Uncaught SyntaxError: Invalid or unexpected token`); green after.
- **Unit**: fence-in-string extraction red/green, and `response.incomplete` → failure completion with no `agent/output-added` (previously timed out waiting for a completion that never came).
- Full `pnpm typecheck && pnpm lint && pnpm format && pnpm test` green; `agent-tools` (real-LLM codemode loop), `agent-script-result-spill`, and the new e2e all pass against a local dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how codemode parses LLM output and how OpenAI WS terminal frames are handled; incorrect fence rules could still mis-extract scripts, but scope is limited to agent script extraction and the openai-ws provider path with strong test coverage.
> 
> **Overview**
> Fixes codemode script extraction when assistant output includes **markdown fences inside string literals** (e.g. `sendMessage` with a ` ```text ` block). `extractAsyncJsSnippet` now treats fences only at **line starts**, so inner fences no longer truncate the script into invalid JS that failed with `Invalid or unexpected token`.
> 
> For **OpenAI Responses WebSocket**, `response.incomplete` is handled as a terminal failure (partial output discarded, no `agent/output-added`), and the stream schema accepts `incomplete_details: null` on completed responses so `response.completed` parses instead of hanging.
> 
> Adds an e2e test that journals a fenced script with an embedded fence and runs it in a real worker, plus unit coverage for extraction and incomplete WS responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eec5b6fca78ed324ed70ce26ff3d9e59e4819f2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +24 -1 | +11 -1 🟩⬜⬜⬜⬜ |
| Tests | +135 -1 | +100 -1 🟩🟩🟩🟩🟩 |
| **Total** | **+159 -2** | **+111 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between a1f2f76 and eec5b6f, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-09T17:09:36.335Z",
      "headSha": "eec5b6fca78ed324ed70ce26ff3d9e59e4819f2c",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/138881063262101",
      "shortSha": "eec5b6f",
      "cleanupDurationMs": 14747,
      "deployDurationMs": 94500,
      "testDurationMs": 232402,
      "testRetries": "1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 15500.06,
      "workerGzipKib": 4191.7,
      "mainWorkerGzipKib": 4191.59
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-09T17:09:24.463Z",
      "headSha": "eec5b6fca78ed324ed70ce26ff3d9e59e4819f2c",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/138881063262101",
      "shortSha": "eec5b6f",
      "cleanupDurationMs": 2871,
      "deployDurationMs": 18256,
      "testDurationMs": 546,
      "testRetries": null,
      "workerSizeKib": 3992.8,
      "workerGzipKib": 811.98,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `eec5b6f` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 812.0 KiB | 18.3s | 546ms |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/138881063262101) | 2026-07-09T17:09:24.463Z | Preview app released. |
| OS | released | `eec5b6f` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 4.09 MiB (+0.1 KiB vs main) | 94.5s | 232.4s | 1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 14.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/138881063262101) | 2026-07-09T17:09:36.335Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->