### PR TITLE
Event docs: contract examples, schema field tables, and processor cross-references

### DIFF
--- a/apps/os/src/components/event-docs-pages.tsx
+++ b/apps/os/src/components/event-docs-pages.tsx
@@ -1,10 +1,229 @@
 import { Link } from "@tanstack/react-router";
-import type { EventDoc, ProcessorDoc } from "~/lib/event-docs.ts";
+import { useMemo, useState } from "react";
+import type {
+  EventDoc,
+  EventReferenceDoc,
+  ProcessorDoc,
+  ProcessorReferenceDoc,
+} from "~/lib/event-docs.ts";
+
+// =============================================================================
+// JSON-schema presentation helpers.
+//
+// The docs pages render the `z.toJSONSchema(...)` output of each event's
+// payload schema as a readable field table (name, type, required,
+// description) instead of a raw JSON dump. These helpers walk the handful of
+// JSON Schema shapes our zod contracts actually produce: objects, records,
+// arrays, enums, literals, (discriminated) unions, and nullables.
+// =============================================================================
+
+type SchemaFieldRow = {
+  children: SchemaFieldRow[];
+  description: string | undefined;
+  name: string;
+  required: boolean;
+  typeLabel: string;
+};
+
+/** Nesting cap for the field table — deeper shapes fall back to the raw schema block. */
+const MAX_FIELD_DEPTH = 5;
+const PAYLOAD_PREVIEW_MAX_LENGTH = 88;
+
+function asSchemaObject(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+/** The `anyOf`/`oneOf` variant list of a schema, or null when it is not a union. */
+function schemaVariants(schema: Record<string, unknown>): unknown[] | null {
+  if (Array.isArray(schema.anyOf)) return schema.anyOf;
+  if (Array.isArray(schema.oneOf)) return schema.oneOf;
+  return null;
+}
+
+/** Compact TypeScript-flavored type label for one schema node. */
+function schemaTypeLabel(value: unknown): string {
+  if (value === true || value === undefined) return "any";
+  const schema = asSchemaObject(value);
+  if (!schema) return "any";
+  if ("const" in schema) return JSON.stringify(schema.const);
+  if (Array.isArray(schema.enum)) {
+    return schema.enum.map((option) => JSON.stringify(option)).join(" | ");
+  }
+
+  const variants = schemaVariants(schema);
+  if (variants) {
+    const labels = [...new Set(variants.map(schemaTypeLabel))];
+    return labels.join(" | ");
+  }
+  if (Array.isArray(schema.allOf)) return schema.allOf.map(schemaTypeLabel).join(" & ");
+
+  const type = schema.type;
+  if (Array.isArray(type)) return type.join(" | ");
+  if (type === "array") {
+    const itemLabel = schemaTypeLabel(schema.items);
+    return itemLabel.includes("|") || itemLabel.includes("&")
+      ? `(${itemLabel})[]`
+      : `${itemLabel}[]`;
+  }
+  if (
+    type === "object" ||
+    (type === undefined && ("properties" in schema || "additionalProperties" in schema))
+  ) {
+    const properties = asSchemaObject(schema.properties);
+    if (properties && Object.keys(properties).length > 0) return "object";
+    const additional = schema.additionalProperties;
+    if (additional !== undefined && additional !== false) {
+      return `Record<string, ${schemaTypeLabel(additional === true ? undefined : additional)}>`;
+    }
+    return "object";
+  }
+  if (typeof type === "string") return type;
+  return "any";
+}
+
+function schemaFieldRows(value: unknown, depth = 0): SchemaFieldRow[] {
+  if (depth >= MAX_FIELD_DEPTH) return [];
+  const schema = asSchemaObject(value);
+  if (!schema) return [];
+  const properties = asSchemaObject(schema.properties);
+  if (!properties) return [];
+  const required = new Set(Array.isArray(schema.required) ? schema.required : []);
+
+  return Object.entries(properties).map(([name, propertySchema]) => {
+    const property = asSchemaObject(propertySchema);
+    return {
+      children: schemaChildRows(propertySchema, depth + 1),
+      description: typeof property?.description === "string" ? property.description : undefined,
+      name,
+      required: required.has(name),
+      typeLabel: schemaTypeLabel(propertySchema),
+    };
+  });
+}
+
+/** Nested rows under one field: object properties, array items, record values, union variants. */
+function schemaChildRows(value: unknown, depth: number): SchemaFieldRow[] {
+  if (depth >= MAX_FIELD_DEPTH) return [];
+  const schema = asSchemaObject(value);
+  if (!schema) return [];
+
+  const variants = schemaVariants(schema);
+  if (variants) {
+    const objectVariants = variants
+      .map(asSchemaObject)
+      .filter(
+        (variant): variant is Record<string, unknown> =>
+          variant != null && asSchemaObject(variant.properties) != null,
+      );
+    if (objectVariants.length === 0) {
+      const nonNull = variants.filter((variant) => asSchemaObject(variant)?.type !== "null");
+      return nonNull.length === 1 ? schemaChildRows(nonNull[0], depth) : [];
+    }
+    if (objectVariants.length === 1) return schemaFieldRows(objectVariants[0], depth);
+    return objectVariants.map((variant, index) => ({
+      children: schemaFieldRows(variant, depth + 1),
+      description: typeof variant.description === "string" ? variant.description : undefined,
+      name: variantLabel(variant, index),
+      // Variants are alternatives, not optional fields — never badge them.
+      required: true,
+      typeLabel: "object",
+    }));
+  }
+
+  if (schema.type === "array") return schemaChildRows(schema.items, depth);
+  if (asSchemaObject(schema.properties)) return schemaFieldRows(schema, depth);
+
+  const additional = asSchemaObject(schema.additionalProperties);
+  if (additional && asSchemaObject(additional.properties)) {
+    return [
+      {
+        children: schemaFieldRows(additional, depth + 1),
+        description:
+          typeof additional.description === "string" ? additional.description : undefined,
+        name: "[key: string]",
+        required: false,
+        typeLabel: schemaTypeLabel(additional),
+      },
+    ];
+  }
+  return [];
+}
+
+/** Label a union variant by its discriminator literal when it has one. */
+function variantLabel(variant: Record<string, unknown>, index: number): string {
+  const properties = asSchemaObject(variant.properties);
+  if (properties) {
+    for (const [name, propertySchema] of Object.entries(properties)) {
+      const property = asSchemaObject(propertySchema);
+      if (property && "const" in property) return `${name}: ${JSON.stringify(property.const)}`;
+    }
+  }
+  return `variant ${index + 1}`;
+}
+
+/** One-line payload shape summary for listings, e.g. `{ subscriptionKey, delivery, selector? }`. */
+function payloadPreview(value: unknown): string {
+  const schema = asSchemaObject(value);
+  if (!schema) return "";
+
+  const variants = schemaVariants(schema);
+  if (variants) {
+    const previews = [
+      ...new Set(variants.map((variant) => payloadPreview(variant) || schemaTypeLabel(variant))),
+    ];
+    return truncatePreview(previews.join(" | "));
+  }
+
+  const properties = asSchemaObject(schema.properties);
+  if (properties) {
+    const names = Object.keys(properties);
+    if (names.length === 0) {
+      const loose =
+        schema.additionalProperties !== undefined && schema.additionalProperties !== false;
+      return loose ? "{ …any }" : "{}";
+    }
+    const required = new Set(Array.isArray(schema.required) ? schema.required : []);
+    const body = names.map((name) => (required.has(name) ? name : `${name}?`)).join(", ");
+    return truncatePreview(`{ ${body} }`);
+  }
+  return truncatePreview(schemaTypeLabel(schema));
+}
+
+function truncatePreview(preview: string): string {
+  if (preview.length <= PAYLOAD_PREVIEW_MAX_LENGTH) return preview;
+  return `${preview.slice(0, PAYLOAD_PREVIEW_MAX_LENGTH - 1)}…`;
+}
+
+// =============================================================================
+// Pages.
+// =============================================================================
 
 export function EventDocsIndexPage(input: {
   eventDocs: readonly EventDoc[];
   processorDocs: readonly ProcessorDoc[];
 }) {
+  const [query, setQuery] = useState("");
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const sections = useMemo(() => {
+    return input.processorDocs
+      .map((processor) => {
+        const processorMatches =
+          normalizedQuery.length === 0 ||
+          processor.contractSlug.toLowerCase().includes(normalizedQuery) ||
+          processor.slug.toLowerCase().includes(normalizedQuery) ||
+          (processor.description ?? "").toLowerCase().includes(normalizedQuery);
+        const events = processorMatches
+          ? processor.events
+          : processor.events.filter((event) => eventMatchesQuery(event, normalizedQuery));
+        return { events, processor, processorMatches };
+      })
+      .filter((section) => section.processorMatches || section.events.length > 0);
+  }, [input.processorDocs, normalizedQuery]);
+
+  const visibleEventCount = sections.reduce((count, section) => count + section.events.length, 0);
+
   return (
     <EventDocsShell>
       <header className="space-y-3 border-b px-6 py-8 md:px-10">
@@ -15,31 +234,71 @@ export function EventDocsIndexPage(input: {
           Event type reference
         </h1>
         <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
-          Public documentation generated from the stream processor contracts in OS.
+          Public documentation generated from the stream processor contracts in OS: every processor,
+          the event types it owns, their payload schemas and example events, and how processors
+          consume, emit, and depend on each other.
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {input.processorDocs.length} processors · {input.eventDocs.length} event types
         </p>
       </header>
       <main className="grid gap-8 px-6 py-8 md:grid-cols-[minmax(0,1fr)_18rem] md:px-10">
-        <section className="space-y-3">
-          <h2 className="text-sm font-semibold">Event types</h2>
-          <div className="divide-y rounded-md border">
-            {input.eventDocs.map((event) => (
-              <Link
-                key={event.type}
-                to="/docs/streams/processors/$processorSlug/events/$"
-                params={event.routeParams}
-                className="block px-4 py-3 hover:bg-muted/60"
+        <section className="space-y-8">
+          <input
+            type="search"
+            value={query}
+            onChange={(changeEvent) => setQuery(changeEvent.target.value)}
+            placeholder="Filter by event type, processor, or description…"
+            aria-label="Filter event types"
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+          {sections.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Nothing matches “{query.trim()}”.</p>
+          ) : (
+            sections.map(({ events, processor }) => (
+              <section
+                key={processor.contractSlug}
+                id={`processor-${processor.slug}`}
+                className="space-y-3"
               >
-                <span className="block break-all font-mono text-sm text-foreground">
-                  {event.type}
-                </span>
-                {event.description ? (
-                  <span className="mt-1 block text-sm text-muted-foreground">
-                    {event.description}
-                  </span>
-                ) : null}
-              </Link>
-            ))}
-          </div>
+                <div className="space-y-1">
+                  <h2 className="font-mono text-base font-semibold">
+                    <Link
+                      to="/docs/streams/processors/$processorSlug"
+                      params={processor.routeParams}
+                      className="hover:underline"
+                    >
+                      {processor.contractSlug}
+                    </Link>
+                    {processor.version ? (
+                      <span className="ml-2 text-xs font-normal text-muted-foreground">
+                        v{processor.version}
+                      </span>
+                    ) : null}
+                  </h2>
+                  {processor.description ? (
+                    <p className="text-sm text-muted-foreground">{processor.description}</p>
+                  ) : null}
+                </div>
+                {events.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    This processor owns no event types.
+                  </p>
+                ) : (
+                  <div className="divide-y rounded-md border">
+                    {events.map((event) => (
+                      <EventListRow key={event.type} event={event} />
+                    ))}
+                  </div>
+                )}
+              </section>
+            ))
+          )}
+          {normalizedQuery.length > 0 ? (
+            <p className="text-xs text-muted-foreground">
+              Showing {visibleEventCount} of {input.eventDocs.length} event types.
+            </p>
+          ) : null}
         </section>
         <aside className="space-y-3">
           <h2 className="text-sm font-semibold">Processors</h2>
@@ -55,7 +314,11 @@ export function EventDocsIndexPage(input: {
                   {processor.contractSlug}
                 </span>
                 <span className="mt-1 block text-xs text-muted-foreground">
-                  {processor.events.length} owned event{processor.events.length === 1 ? "" : "s"}
+                  {processor.events.length} owned ·{" "}
+                  {processor.consumesAllEvents
+                    ? "consumes *"
+                    : `consumes ${processor.consumes.length}`}{" "}
+                  · emits {processor.emits.length}
                 </span>
               </Link>
             ))}
@@ -63,6 +326,14 @@ export function EventDocsIndexPage(input: {
         </aside>
       </main>
     </EventDocsShell>
+  );
+}
+
+function eventMatchesQuery(event: EventDoc, normalizedQuery: string): boolean {
+  if (normalizedQuery.length === 0) return true;
+  return (
+    event.type.toLowerCase().includes(normalizedQuery) ||
+    (event.description ?? "").toLowerCase().includes(normalizedQuery)
   );
 }
 
@@ -75,56 +346,56 @@ export function ProcessorOverviewPage({ processor }: { processor: ProcessorDoc }
         description={processor.description}
       />
       <main className="grid gap-8 px-6 py-8 md:grid-cols-[minmax(0,1fr)_18rem] md:px-10">
-        <section className="space-y-4">
+        <section className="space-y-6">
           <DocSection title="Owned event types">
             {processor.events.length === 0 ? (
               <p className="text-sm text-muted-foreground">This processor owns no event types.</p>
             ) : (
               <div className="divide-y rounded-md border">
                 {processor.events.map((event) => (
-                  <Link
-                    key={event.type}
-                    to="/docs/streams/processors/$processorSlug/events/$"
-                    params={event.routeParams}
-                    className="block px-4 py-3 hover:bg-muted/60"
-                  >
-                    <span className="block break-all font-mono text-sm">{event.type}</span>
-                    {event.description ? (
-                      <span className="mt-1 block text-sm text-muted-foreground">
-                        {event.description}
-                      </span>
-                    ) : null}
-                  </Link>
+                  <EventListRow key={event.type} event={event} showCrossReferences />
                 ))}
               </div>
             )}
           </DocSection>
-          <EventReferenceList title="Consumes" events={processor.consumes} />
+          <DocSection title="Consumes">
+            {processor.consumesAllEvents ? (
+              <p className="text-sm text-muted-foreground">
+                Consumes <span className="font-mono">*</span> — every event on the stream reaches
+                this processor's reducer
+                {processor.consumes.length > 0 ? ", with these types named explicitly:" : "."}
+              </p>
+            ) : null}
+            <EventReferenceList
+              events={processor.consumes}
+              emptyLabel={processor.consumesAllEvents ? null : "This processor consumes no events."}
+              ownContractSlug={processor.contractSlug}
+            />
+          </DocSection>
+          <DocSection title="Emits">
+            <EventReferenceList
+              events={processor.emits}
+              emptyLabel="This processor emits no events."
+              ownContractSlug={processor.contractSlug}
+            />
+          </DocSection>
         </section>
         <aside className="space-y-4">
           <InfoList
             items={[
+              ["Contract slug", processor.contractSlug],
               ["Version", processor.version ?? "unversioned"],
               ["Public path", processor.href],
               ["Owned events", String(processor.events.length)],
+              [
+                "Consumes",
+                processor.consumesAllEvents ? "* (all events)" : String(processor.consumes.length),
+              ],
+              ["Emits", String(processor.emits.length)],
             ]}
           />
-          {processor.dependencies.length === 0 ? null : (
-            <DocSection title="Dependencies">
-              <div className="space-y-2">
-                {processor.dependencies.map((dep) => (
-                  <Link
-                    key={dep.contractSlug}
-                    to="/docs/streams/processors/$processorSlug"
-                    params={dep.routeParams}
-                    className="block rounded-md border px-3 py-2 font-mono text-sm hover:bg-muted/60"
-                  >
-                    {dep.contractSlug}
-                  </Link>
-                ))}
-              </div>
-            </DocSection>
-          )}
+          <ProcessorLinkList title="Depends on" processors={processor.dependencies} />
+          <ProcessorLinkList title="Depended on by" processors={processor.dependents} />
         </aside>
       </main>
     </EventDocsShell>
@@ -142,43 +413,88 @@ export function EventDocPage({ event }: { event: EventDoc }) {
       <main className="grid gap-8 px-6 py-8 md:grid-cols-[minmax(0,1fr)_18rem] md:px-10">
         <section className="space-y-6">
           <DocSection title="Payload schema">
-            <JsonBlock value={event.payloadJsonSchema} />
+            <SchemaView schema={event.payloadJsonSchema} />
           </DocSection>
-          {event.examples.length === 0 ? null : (
-            <DocSection title="Examples">
+          <DocSection title="Examples">
+            {event.examples.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No examples documented for this event type yet.
+              </p>
+            ) : (
               <div className="space-y-4">
-                {event.examples.map((example) => (
+                {event.examples.map((example, index) => (
                   <div key={example.description} className="space-y-2">
                     <p className="text-sm text-muted-foreground">{example.description}</p>
                     <JsonBlock value={example.payload} />
+                    {index === 0 ? (
+                      <CommittedEventExample event={event} payload={example.payload} />
+                    ) : null}
                   </div>
                 ))}
               </div>
-            </DocSection>
-          )}
+            )}
+          </DocSection>
         </section>
         <aside className="space-y-4">
           <InfoList
             items={[
               ["URL path", event.href],
-              ["Processor", event.processor.contractSlug],
+              ["Owned by", event.processor.contractSlug],
               ["Event path", event.eventPath],
+              ["Examples", String(event.examples.length)],
             ]}
           />
-          <DocSection title="Processor">
-            <Link
-              to="/docs/streams/processors/$processorSlug"
-              params={event.processor.routeParams}
-              className="block rounded-md border px-3 py-2 font-mono text-sm hover:bg-muted/60"
-            >
-              {event.processor.contractSlug}
-            </Link>
+          <DocSection title="Owned by">
+            <ProcessorLink processor={event.processor} />
           </DocSection>
+          <ProcessorLinkList title="Emitted by" processors={event.emittedBy} />
+          <ProcessorLinkList
+            title="Consumed by"
+            processors={event.consumedBy}
+            footnote="Processors that consume every event (*) are not listed."
+          />
         </aside>
       </main>
     </EventDocsShell>
   );
 }
+
+/**
+ * The first example payload wrapped in the committed-event envelope, so
+ * readers see what an actual stream row for this type looks like. Offset,
+ * createdAt, and path are assigned by the stream at commit time; the values
+ * here are illustrative.
+ */
+function CommittedEventExample({ event, payload }: { event: EventDoc; payload: unknown }) {
+  const committedEvent = {
+    type: event.type,
+    payload,
+    metadata: {},
+    source: {
+      processor: {
+        slug: event.processor.contractSlug,
+        version: event.processor.version ?? "0.1.0",
+      },
+    },
+    offset: 42,
+    createdAt: "2026-07-09T12:34:56.789Z",
+    path: "<stream path>",
+  };
+  return (
+    <details className="rounded-md border">
+      <summary className="cursor-pointer px-4 py-2 text-sm text-muted-foreground hover:text-foreground">
+        As a committed stream event (envelope fields are illustrative)
+      </summary>
+      <div className="border-t p-2">
+        <JsonBlock value={committedEvent} bare />
+      </div>
+    </details>
+  );
+}
+
+// =============================================================================
+// Shared building blocks.
+// =============================================================================
 
 function EventDocsShell({ children }: { children: React.ReactNode }) {
   return <div className="min-h-screen bg-background text-foreground">{children}</div>;
@@ -212,35 +528,126 @@ function DocSection({ children, title }: { children: React.ReactNode; title: str
   );
 }
 
+/** One event in a listing: link, description, payload shape preview, cross-reference counts. */
+function EventListRow({
+  event,
+  showCrossReferences = false,
+}: {
+  event: EventDoc;
+  showCrossReferences?: boolean;
+}) {
+  const preview = payloadPreview(event.payloadJsonSchema);
+  const meta: string[] = [];
+  if (event.examples.length > 0) {
+    meta.push(`${event.examples.length} example${event.examples.length === 1 ? "" : "s"}`);
+  }
+  if (showCrossReferences) {
+    if (event.emittedBy.length > 0) meta.push(`emitted by ${event.emittedBy.length}`);
+    if (event.consumedBy.length > 0) meta.push(`consumed by ${event.consumedBy.length}`);
+  }
+
+  return (
+    <Link
+      to="/docs/streams/processors/$processorSlug/events/$"
+      params={event.routeParams}
+      className="block px-4 py-3 hover:bg-muted/60"
+    >
+      <span className="block break-all font-mono text-sm text-foreground">{event.type}</span>
+      {event.description ? (
+        <span className="mt-1 block text-sm text-muted-foreground">{event.description}</span>
+      ) : null}
+      {preview ? (
+        <span className="mt-1 block break-all font-mono text-xs text-muted-foreground">
+          payload: {preview}
+        </span>
+      ) : null}
+      {meta.length > 0 ? (
+        <span className="mt-1 block text-xs text-muted-foreground">{meta.join(" · ")}</span>
+      ) : null}
+    </Link>
+  );
+}
+
 function EventReferenceList(input: {
-  events: readonly { href?: string; routeParams?: EventDoc["routeParams"]; type: string }[];
+  emptyLabel: string | null;
+  events: readonly EventReferenceDoc[];
+  /** Rows owned by other processors get an "owned by" chip naming their contract. */
+  ownContractSlug: string;
+}) {
+  if (input.events.length === 0) {
+    return input.emptyLabel ? (
+      <p className="text-sm text-muted-foreground">{input.emptyLabel}</p>
+    ) : null;
+  }
+  return (
+    <div className="divide-y rounded-md border">
+      {input.events.map((event) => {
+        const ownedElsewhere =
+          event.ownerContractSlug != null && event.ownerContractSlug !== input.ownContractSlug;
+        const body = (
+          <>
+            <span className="block break-all font-mono text-sm">
+              {event.type}
+              {ownedElsewhere ? (
+                <span className="ml-2 rounded-sm border px-1.5 py-0.5 font-sans text-xs text-muted-foreground">
+                  owned by {event.ownerContractSlug}
+                </span>
+              ) : null}
+            </span>
+            {event.description ? (
+              <span className="mt-1 block text-sm text-muted-foreground">{event.description}</span>
+            ) : null}
+          </>
+        );
+        return event.href && event.routeParams ? (
+          <Link
+            key={event.type}
+            to="/docs/streams/processors/$processorSlug/events/$"
+            params={event.routeParams}
+            className="block px-4 py-3 hover:bg-muted/60"
+          >
+            {body}
+          </Link>
+        ) : (
+          <div key={event.type} className="px-4 py-3">
+            {body}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ProcessorLinkList(input: {
+  footnote?: string;
+  processors: readonly ProcessorReferenceDoc[];
   title: string;
 }) {
+  if (input.processors.length === 0) return null;
   return (
     <DocSection title={input.title}>
-      {input.events.length === 0 ? (
-        <p className="text-sm text-muted-foreground">None.</p>
-      ) : (
-        <div className="divide-y rounded-md border">
-          {input.events.map((event) =>
-            event.href && event.routeParams ? (
-              <Link
-                key={event.type}
-                to="/docs/streams/processors/$processorSlug/events/$"
-                params={event.routeParams}
-                className="block break-all px-4 py-3 font-mono text-sm hover:bg-muted/60"
-              >
-                {event.type}
-              </Link>
-            ) : (
-              <div key={event.type} className="break-all px-4 py-3 font-mono text-sm">
-                {event.type}
-              </div>
-            ),
-          )}
-        </div>
-      )}
+      <div className="space-y-2">
+        {input.processors.map((processor) => (
+          <ProcessorLink key={processor.contractSlug} processor={processor} />
+        ))}
+      </div>
+      {input.footnote ? <p className="text-xs text-muted-foreground">{input.footnote}</p> : null}
     </DocSection>
+  );
+}
+
+function ProcessorLink({ processor }: { processor: ProcessorReferenceDoc }) {
+  return (
+    <Link
+      to="/docs/streams/processors/$processorSlug"
+      params={processor.routeParams}
+      className="block rounded-md border px-3 py-2 hover:bg-muted/60"
+    >
+      <span className="block font-mono text-sm">{processor.contractSlug}</span>
+      {processor.description ? (
+        <span className="mt-1 block text-xs text-muted-foreground">{processor.description}</span>
+      ) : null}
+    </Link>
   );
 }
 
@@ -257,9 +664,112 @@ function InfoList({ items }: { items: readonly [string, string][] }) {
   );
 }
 
-function JsonBlock({ value }: { value: unknown }) {
+/** Field table plus collapsible raw JSON schema for one event payload. */
+function SchemaView({ schema }: { schema: unknown }) {
+  const schemaObject = asSchemaObject(schema);
+  const variants = schemaObject ? schemaVariants(schemaObject) : null;
+  const rows = schemaFieldRows(schema);
+  // zod's `.loose()` objects emit `additionalProperties: {}` (any schema
+  // other than `false` means extra keys are accepted).
+  const allowsAdditionalProperties =
+    schemaObject != null &&
+    schemaObject.additionalProperties !== undefined &&
+    schemaObject.additionalProperties !== false;
+
   return (
-    <pre className="max-h-[32rem] overflow-auto rounded-md border bg-muted/40 p-4 text-xs leading-5">
+    <div className="space-y-3">
+      {variants ? (
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">One of {variants.length} shapes:</p>
+          {variants.map((variant, index) => {
+            const variantObject = asSchemaObject(variant);
+            const variantRows = schemaFieldRows(variant);
+            return (
+              <div
+                key={variantObject ? variantLabel(variantObject, index) : index}
+                className="rounded-md border"
+              >
+                <p className="border-b px-4 py-2 font-mono text-xs text-muted-foreground">
+                  {variantObject ? variantLabel(variantObject, index) : `variant ${index + 1}`}
+                </p>
+                {variantRows.length > 0 ? (
+                  <FieldRows rows={variantRows} />
+                ) : (
+                  <p className="px-4 py-3 font-mono text-sm text-muted-foreground">
+                    {schemaTypeLabel(variant)}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      ) : rows.length > 0 ? (
+        <div className="rounded-md border">
+          <FieldRows rows={rows} />
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          {allowsAdditionalProperties
+            ? "Free-form payload — any JSON object is accepted."
+            : "This event carries no payload fields."}
+        </p>
+      )}
+      {rows.length > 0 && allowsAdditionalProperties ? (
+        <p className="text-xs text-muted-foreground">
+          Additional properties beyond the listed fields are allowed.
+        </p>
+      ) : null}
+      <details className="rounded-md border">
+        <summary className="cursor-pointer px-4 py-2 text-sm text-muted-foreground hover:text-foreground">
+          Raw JSON schema
+        </summary>
+        <div className="border-t p-2">
+          <JsonBlock value={schema} bare />
+        </div>
+      </details>
+    </div>
+  );
+}
+
+function FieldRows({ rows, depth = 0 }: { depth?: number; rows: readonly SchemaFieldRow[] }) {
+  return (
+    <div className={depth === 0 ? "divide-y" : "divide-y border-t"}>
+      {rows.map((row) => (
+        <div key={row.name} className="py-2" style={{ paddingLeft: `${depth * 1.25 + 1}rem` }}>
+          <div className="flex flex-wrap items-baseline gap-x-2 pr-4">
+            <span className="font-mono text-sm text-foreground">{row.name}</span>
+            <span className="break-all font-mono text-xs text-muted-foreground">
+              {row.typeLabel}
+            </span>
+            {row.required ? null : (
+              <span className="rounded-sm border px-1 text-[0.65rem] uppercase tracking-wide text-muted-foreground">
+                optional
+              </span>
+            )}
+          </div>
+          {row.description ? (
+            <p className="mt-1 pr-4 text-sm text-muted-foreground">{row.description}</p>
+          ) : null}
+          {row.children.length > 0 ? (
+            <div className="mt-2 -ml-0">
+              <FieldRows rows={row.children} depth={depth + 1} />
+            </div>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function JsonBlock({ bare = false, value }: { bare?: boolean; value: unknown }) {
+  return (
+    <pre
+      className={
+        bare
+          ? "max-h-[32rem] overflow-auto rounded-md bg-muted/40 p-4 text-xs leading-5"
+          : "max-h-[32rem] overflow-auto rounded-md border bg-muted/40 p-4 text-xs leading-5"
+      }
+    >
       <code>{JSON.stringify(value, null, 2)}</code>
     </pre>
   );

--- a/apps/os/src/domains/agents/agent-processor-contract.ts
+++ b/apps/os/src/domains/agents/agent-processor-contract.ts
@@ -219,12 +219,30 @@ export const AgentProcessorContract = defineProcessorContract({
       payloadSchema: z.object({
         systemPrompt: z.string().optional(),
       }),
+      examples: [
+        {
+          description: "A project configures the agent with a custom system prompt at setup time.",
+          payload: {
+            systemPrompt:
+              "You are the support agent for Acme Corp. Answer billing questions concisely and escalate refund requests to a human.",
+          },
+        },
+      ],
     },
     "events.iterate.com/agent/system-prompt-updated": {
       description: "Updates the system prompt used for future LLM requests.",
       payloadSchema: z.object({
         systemPrompt: z.string(),
       }),
+      examples: [
+        {
+          description: "The system prompt is replaced for every LLM request from here on.",
+          payload: {
+            systemPrompt:
+              "You are Acme's release manager. Track open pull requests and nag reviewers politely.",
+          },
+        },
+      ],
     },
     "events.iterate.com/agent/input-added": {
       description: "A normalized model-visible input was added.",
@@ -234,6 +252,33 @@ export const AgentProcessorContract = defineProcessorContract({
         files: z.array(AgentFileAttachment).optional(),
         llmRequestPolicy: LlmRequestPolicy,
       }),
+      examples: [
+        {
+          description:
+            "A script result becomes a model-visible input; the next LLM turn starts once the current request (if any) finishes.",
+          payload: {
+            content: 'Script result:\n```json\n{ "unread": 4 }\n```',
+            llmRequestPolicy: { behaviour: "after-current-request" },
+          },
+        },
+        {
+          description:
+            "A file lands in the conversation as an attachment, recorded without triggering an LLM turn.",
+          payload: {
+            content: "[Files attached: report.pdf]",
+            files: [
+              {
+                contentType: "application/pdf",
+                filename: "report.pdf",
+                path: "/uploads/2026-07-09/report.pdf",
+                size: 482133,
+                url: "https://iterate-files--acme.iterate.app/uploads/2026-07-09/report.pdf?exp=1783555200&sig=8c1f2ab9d4e7c0a3",
+              },
+            ],
+            llmRequestPolicy: { behaviour: "dont-trigger-request" },
+          },
+        },
+      ],
     },
     "events.iterate.com/agents/user-message-received": {
       description:
@@ -242,6 +287,16 @@ export const AgentProcessorContract = defineProcessorContract({
         content: z.string(),
         origin: z.enum(["web", "mcp"]),
       }),
+      examples: [
+        {
+          description: "A user sends a chat message from the web UI.",
+          payload: { content: "What's on my calendar today?", origin: "web" },
+        },
+        {
+          description: "An MCP client asks the agent a question on the project owner's behalf.",
+          payload: { content: "Summarize the open incidents in this project.", origin: "mcp" },
+        },
+      ],
     },
     "events.iterate.com/agents/web-message-sent": {
       description: "A visible agent message was sent to the web UI.",
@@ -250,6 +305,15 @@ export const AgentProcessorContract = defineProcessorContract({
         /** Files attached to the message — see {@link AgentFileAttachment}. */
         files: z.array(AgentFileAttachment).optional(),
       }),
+      examples: [
+        {
+          description: "The agent sends a visible chat reply to the web UI.",
+          payload: {
+            message:
+              "You have 4 unread emails. The two that look important are from Dana (contract renewal) and GitHub (a failing build on main).",
+          },
+        },
+      ],
     },
     "events.iterate.com/agent/output-added": {
       description: "The LLM provider produced assistant output.",
@@ -257,6 +321,17 @@ export const AgentProcessorContract = defineProcessorContract({
         content: z.string(),
         llmRequestId: z.number().int().positive().optional(),
       }),
+      examples: [
+        {
+          description:
+            "The model answered with a codemode script; llmRequestId is the offset of the llm-request-requested event it answers.",
+          payload: {
+            content:
+              '```js\nasync (itx) => {\n  await itx.chat.sendMessage("Checking your email now...");\n}\n```',
+            llmRequestId: 57,
+          },
+        },
+      ],
     },
     "events.iterate.com/agent/llm-provider-selected": {
       description: "Selects the model for future LLM requests.",
@@ -265,6 +340,21 @@ export const AgentProcessorContract = defineProcessorContract({
         model: z.string().min(1),
         provider: AgentLlmProvider,
       }),
+      examples: [
+        {
+          description:
+            "Agent birth applies the platform default model unless something already chose one.",
+          payload: {
+            ifUnset: true,
+            model: "@cf/moonshotai/kimi-k2.7-code",
+            provider: "cloudflare-ai",
+          },
+        },
+        {
+          description: "The project explicitly switches the agent to an OpenAI model.",
+          payload: { model: "gpt-5.5", provider: "openai-ws" },
+        },
+      ],
     },
     "events.iterate.com/agent/llm-request-scheduled": {
       description: "An LLM request was scheduled after a trigger.",
@@ -274,6 +364,18 @@ export const AgentProcessorContract = defineProcessorContract({
         provider: AgentLlmProvider,
         requestId: z.string(),
       }),
+      examples: [
+        {
+          description:
+            "A user input triggered a request, debounced 250ms so rapid-fire inputs collapse into one turn.",
+          payload: {
+            debounceMs: 250,
+            model: "@cf/moonshotai/kimi-k2.7-code",
+            provider: "cloudflare-ai",
+            requestId: "llm-request:gen-3",
+          },
+        },
+      ],
     },
     "events.iterate.com/agent/llm-request-requested": {
       description:
@@ -283,6 +385,17 @@ export const AgentProcessorContract = defineProcessorContract({
         provider: AgentLlmProvider,
         requestId: z.string(),
       }),
+      examples: [
+        {
+          description:
+            "The debounce elapsed and the request went out; this event's own offset becomes the llmRequestId the provider answers to.",
+          payload: {
+            model: "@cf/moonshotai/kimi-k2.7-code",
+            provider: "cloudflare-ai",
+            requestId: "llm-request:gen-3",
+          },
+        },
+      ],
     },
     "events.iterate.com/agent/llm-request-completed": {
       description: "A provider processor finished an LLM request.",
@@ -303,6 +416,34 @@ export const AgentProcessorContract = defineProcessorContract({
           }),
         ]),
       }),
+      examples: [
+        {
+          description:
+            "The provider returned assistant output, with token usage as the model reported it.",
+          payload: {
+            durationMs: 2340,
+            llmRequestId: 57,
+            provider: "cloudflare-ai",
+            result: {
+              status: "success",
+              usage: { completion_tokens: 118, prompt_tokens: 4096, total_tokens: 4214 },
+            },
+          },
+        },
+        {
+          description:
+            "The provider call failed; the error becomes a model-visible input so the agent can react.",
+          payload: {
+            durationMs: 30012,
+            llmRequestId: 61,
+            provider: "openai-ws",
+            result: {
+              error: { message: "Provider request timed out after 30000ms" },
+              status: "failure",
+            },
+          },
+        },
+      ],
     },
     "events.iterate.com/agent/llm-request-cancelled": {
       description: "The current scheduled or requested LLM request was cancelled.",
@@ -318,6 +459,20 @@ export const AgentProcessorContract = defineProcessorContract({
           llmRequestId: z.number().int().positive(),
         }),
       ]),
+      examples: [
+        {
+          description: "New user input interrupted a request still in its debounce window.",
+          payload: {
+            phase: "scheduled",
+            reason: "interrupted-by-user-input",
+            requestId: "llm-request:gen-4",
+          },
+        },
+        {
+          description: "New user input interrupted a request already running at the provider.",
+          payload: { phase: "requested", reason: "interrupted-by-user-input", llmRequestId: 58 },
+        },
+      ],
     },
     "events.iterate.com/agent/loop-stopped": {
       description:
@@ -327,6 +482,17 @@ export const AgentProcessorContract = defineProcessorContract({
         reason: z.string().trim().min(1),
         triggerOffset: z.number().int().positive(),
       }),
+      examples: [
+        {
+          description:
+            "The circuit breaker halted an agent that chained 20 autonomous script turns without human input.",
+          payload: {
+            maxAutonomousTurns: 20,
+            reason: "Agent circuit breaker stopped after 20 consecutive autonomous turns.",
+            triggerOffset: 143,
+          },
+        },
+      ],
     },
   },
   processorDeps: [CapabilityHostProcessorContract],

--- a/apps/os/src/domains/agents/cloudflare-ai-processor-contract.ts
+++ b/apps/os/src/domains/agents/cloudflare-ai-processor-contract.ts
@@ -18,6 +18,13 @@ export const CloudflareAiProcessorContract = defineProcessorContract({
         llmRequestId: z.number().int().positive(),
         model: z.string().min(1),
       }),
+      examples: [
+        {
+          description:
+            "The provider picks up a scheduled request; llmRequestId is the stream offset of the agent's llm-request-requested event.",
+          payload: { llmRequestId: 117, model: "@cf/moonshotai/kimi-k2.7-code" },
+        },
+      ],
     },
     "events.iterate.com/cloudflare-ai/llm-response-chunk": {
       description: "One streamed provider chunk received from the AI binding.",
@@ -26,6 +33,12 @@ export const CloudflareAiProcessorContract = defineProcessorContract({
         llmRequestId: z.number().int().positive(),
         sequence: z.number().int().nonnegative(),
       }),
+      examples: [
+        {
+          description: "The first streamed Workers AI delta of a response.",
+          payload: { chunk: { response: "Hello" }, llmRequestId: 117, sequence: 0 },
+        },
+      ],
     },
     "events.iterate.com/cloudflare-ai/llm-request-completed": {
       description: "The Cloudflare AI processor finished an agent LLM request.",
@@ -45,6 +58,33 @@ export const CloudflareAiProcessorContract = defineProcessorContract({
           }),
         ]),
       }),
+      examples: [
+        {
+          description: "The request finished successfully after a few seconds of streaming.",
+          payload: {
+            durationMs: 2843,
+            llmRequestId: 117,
+            result: {
+              status: "success",
+              usage: { completion_tokens: 96, prompt_tokens: 412, total_tokens: 508 },
+            },
+          },
+        },
+        {
+          description: "The request failed because the model was temporarily overloaded.",
+          payload: {
+            durationMs: 4519,
+            llmRequestId: 121,
+            result: {
+              error: {
+                message:
+                  "InferenceUpstreamError: 3040: Capacity temporarily exceeded for @cf/moonshotai/kimi-k2.7-code, please try again",
+              },
+              status: "failure",
+            },
+          },
+        },
+      ],
     },
   },
   processorDeps: [AgentProcessorContract],

--- a/apps/os/src/domains/agents/openai-ws-processor-contract.ts
+++ b/apps/os/src/domains/agents/openai-ws-processor-contract.ts
@@ -28,6 +28,13 @@ export const OpenAiWsProcessorContract = defineProcessorContract({
         llmRequestId: z.number().int().positive(),
         model: z.string().min(1),
       }),
+      examples: [
+        {
+          description:
+            "The provider picks up a scheduled request; llmRequestId is the stream offset of the agent's llm-request-requested event.",
+          payload: { llmRequestId: 117, model: "gpt-5.5" },
+        },
+      ],
     },
     "events.iterate.com/openai-ws/llm-response-chunk": {
       description: "One raw frame received from the OpenAI Responses WebSocket.",
@@ -36,6 +43,16 @@ export const OpenAiWsProcessorContract = defineProcessorContract({
         llmRequestId: z.number().int().positive(),
         sequence: z.number().int().nonnegative(),
       }),
+      examples: [
+        {
+          description: "The first output text delta frame of a response.",
+          payload: {
+            chunk: { type: "response.output_text.delta", delta: "Hello" },
+            llmRequestId: 117,
+            sequence: 0,
+          },
+        },
+      ],
     },
     "events.iterate.com/openai-ws/llm-request-completed": {
       description: "The OpenAI WebSocket processor finished an agent LLM request.",
@@ -55,6 +72,32 @@ export const OpenAiWsProcessorContract = defineProcessorContract({
           }),
         ]),
       }),
+      examples: [
+        {
+          description: "The request finished successfully after a few seconds of streaming.",
+          payload: {
+            durationMs: 4127,
+            llmRequestId: 117,
+            result: {
+              status: "success",
+              usage: { input_tokens: 1204, output_tokens: 87, total_tokens: 1291 },
+            },
+          },
+        },
+        {
+          description: "The request failed after hitting the per-response deadline.",
+          payload: {
+            durationMs: 600004,
+            llmRequestId: 121,
+            result: {
+              error: {
+                message: "OpenAI request exceeded the 600s deadline; dropping the socket.",
+              },
+              status: "failure",
+            },
+          },
+        },
+      ],
     },
   },
   processorDeps: [AgentProcessorContract],

--- a/apps/os/src/domains/capability-host/capability-host-processor-contract.ts
+++ b/apps/os/src/domains/capability-host/capability-host-processor-contract.ts
@@ -66,14 +66,56 @@ export const CapabilityHostProcessorContract = defineProcessorContract({
     "events.iterate.com/capability-host/capability-provided": {
       description: "A capability was mounted at a path.",
       payloadSchema: CapabilityProvidedPayload,
+      examples: [
+        {
+          description:
+            "A live capability object mounted at tools.weather; it lives only as long as the providing session.",
+          payload: {
+            instructions: "Call tools.weather.forecast({ city }) for a 3-day forecast.",
+            path: ["tools", "weather"],
+            type: "live",
+          },
+        },
+        {
+          description:
+            "An OpenAPI connection persisted as an itx expression and mounted at pets; each use re-evaluates the expression.",
+          payload: {
+            expression: [
+              "openapi",
+              ["connect", { specUrl: "https://petstore.example.com/openapi.json" }],
+            ],
+            instructions: "The pet store API. List pets with pets.listPets().",
+            path: ["pets"],
+            type: "itx-expression",
+            types:
+              "export type Capability = { listPets(): Promise<{ id: number; name: string }[]> };",
+          },
+        },
+      ],
     },
     "events.iterate.com/capability-host/capability-revoked": {
       description: "A dynamic capability was removed.",
       payloadSchema: CapabilityRevokedPayload,
+      examples: [
+        {
+          description:
+            "The current mount at pets is removed; pass providedAtOffset to revoke one exact mount instead.",
+          payload: { path: ["pets"] },
+        },
+      ],
     },
     "events.iterate.com/capability-host/script-execution-requested": {
       description: "A script should run in this capability scope.",
       payloadSchema: z.looseObject({ code: z.string(), executionId: z.string() }),
+      examples: [
+        {
+          description: "An agent codemode turn asks the scope to run a script.",
+          payload: {
+            code: 'async (itx) => {\n  await itx.chat.sendMessage("Checking your email now...");\n}',
+            executionId: "d0f7f2a4-9c1b-4e0e-8f3a-2b7c6d5e4a31",
+          },
+        },
+      ],
     },
     "events.iterate.com/capability-host/script-execution-completed": {
       description: "A script finished running in this capability scope.",
@@ -82,6 +124,22 @@ export const CapabilityHostProcessorContract = defineProcessorContract({
         executionId: z.string(),
         result: z.unknown().optional(),
       }),
+      examples: [
+        {
+          description: "The script finished and returned a value.",
+          payload: {
+            executionId: "d0f7f2a4-9c1b-4e0e-8f3a-2b7c6d5e4a31",
+            result: { unreadCount: 3 },
+          },
+        },
+        {
+          description: "The script threw; the error message is journaled.",
+          payload: {
+            error: "TypeError: itx.gmail.listMesages is not a function",
+            executionId: "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+          },
+        },
+      ],
     },
   },
   consumes: [

--- a/apps/os/src/domains/integrations/slack-processor-contract.ts
+++ b/apps/os/src/domains/integrations/slack-processor-contract.ts
@@ -41,6 +41,30 @@ export const SlackProcessorContract = defineProcessorContract({
       description:
         "Raw Slack Events API callback body, appended by the webhook route to `/integrations/slack/{connection}` and forwarded unchanged to routed thread streams.",
       payloadSchema: z.object({ body: z.record(z.string(), z.unknown()) }).loose(),
+      examples: [
+        {
+          description:
+            "A threaded Slack message, as Slack's Events API delivers it (trimmed to the typical fields).",
+          payload: {
+            body: {
+              type: "event_callback",
+              team_id: "T0XYZ1234",
+              api_app_id: "A0AB12CD3",
+              event: {
+                type: "message",
+                channel: "C0AB12CD3",
+                user: "U0DE45FG6",
+                text: "Hey @iterate, can you take a look at this?",
+                ts: "1751980451.204569",
+                thread_ts: "1751980423.123456",
+                channel_type: "channel",
+              },
+              event_id: "Ev0HI78JK9",
+              event_time: 1751980451,
+            },
+          },
+        },
+      ],
     },
     "events.iterate.com/slack/thread-route-configured": {
       description:
@@ -50,6 +74,17 @@ export const SlackProcessorContract = defineProcessorContract({
         threadTs: z.string(),
         streamPath: z.string(),
       }),
+      examples: [
+        {
+          description:
+            "A fresh Slack thread gets its own routed agent stream (`/agents/slack/{connection}/{channel}/ts-{threadTs}`, channel and ts sanitized to lowercase kebab).",
+          payload: {
+            channel: "C0AB12CD3",
+            threadTs: "1751980423.123456",
+            streamPath: "/agents/slack/acme/c0ab12cd3/ts-1751980423-123456",
+          },
+        },
+      ],
     },
   },
   consumes: [

--- a/apps/os/src/domains/projects/project-processor-contract.ts
+++ b/apps/os/src/domains/projects/project-processor-contract.ts
@@ -83,6 +83,26 @@ export const ProjectProcessorContract = defineProcessorContract({
          * project state (e.g. the inbound email sender allowlist). */
         creatorEmail: z.string().optional(),
       }),
+      examples: [
+        {
+          description:
+            "A dashboard signup created the project: onboarding starts and the creator's email seeds the inbound-email sender allowlist.",
+          payload: {
+            onboardingActive: true,
+            projectId: "prj_01jzp3v9qkfxeb2m4n8r7wd5ha",
+            slug: "acme-inc",
+            creatorEmail: "jane@acme-inc.com",
+          },
+        },
+        {
+          description:
+            "An admin/CLI create: no creating user, so no onboarding and no allowlist seed.",
+          payload: {
+            projectId: "prj_01jzq8t2m5xcnd4w9e6b3vf7kp",
+            slug: "acme-staging",
+          },
+        },
+      ],
     },
     "events.iterate.com/project/created": {
       description: "The project root was created.",
@@ -90,34 +110,118 @@ export const ProjectProcessorContract = defineProcessorContract({
         projectId: z.string(),
         slug: z.string(),
       }),
+      examples: [
+        {
+          description:
+            "The bootstrap saga finished: the root repo exists and the project worker answered its probe.",
+          payload: {
+            projectId: "prj_01jzp3v9qkfxeb2m4n8r7wd5ha",
+            slug: "acme-inc",
+          },
+        },
+      ],
     },
     "events.iterate.com/project/onboarding-completed": {
       description: "The project owner completed the onboarding agent flow.",
       payloadSchema: z.object({
         agentPath: z.string(),
       }),
+      examples: [
+        {
+          description: "The onboarding agent marked its flow done for the project owner.",
+          payload: {
+            agentPath: "/agents/onboarding",
+          },
+        },
+      ],
     },
     "events.iterate.com/project/custom-domain-add-requested": {
       description: "A custom domain should be provisioned and routed to this project.",
       payloadSchema: z.object({
         hostname: z.string(),
       }),
+      examples: [
+        {
+          description: "The owner asked to serve the project on their own domain.",
+          payload: {
+            hostname: "app.acme-inc.com",
+          },
+        },
+      ],
     },
     "events.iterate.com/project/custom-domain-refresh-requested": {
       description: "Refresh Cloudflare status for a custom domain.",
       payloadSchema: z.object({
         hostname: z.string(),
       }),
+      examples: [
+        {
+          description:
+            "A dashboard refresh re-polls Cloudflare while the domain is pending validation.",
+          payload: {
+            hostname: "app.acme-inc.com",
+          },
+        },
+      ],
     },
     "events.iterate.com/project/custom-domain-remove-requested": {
       description: "A custom domain should be removed from this project.",
       payloadSchema: z.object({
         hostname: z.string(),
       }),
+      examples: [
+        {
+          description: "The owner asked to detach their domain from the project.",
+          payload: {
+            hostname: "app.acme-inc.com",
+          },
+        },
+      ],
     },
     "events.iterate.com/project/custom-domain-cloudflare-observed": {
       description: "Cloudflare custom-hostname status observed for a project custom domain.",
       payloadSchema: ProjectCustomDomainCloudflareSnapshot,
+      examples: [
+        {
+          description:
+            "First observation after provisioning: certificate validation is pending, so the owner still has DNS records to create.",
+          payload: {
+            cloudflareHostnameId: "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
+            error: null,
+            hostname: "app.acme-inc.com",
+            hostnameStatus: "pending",
+            ownershipVerification: {
+              name: "_cf-custom-hostname.app.acme-inc.com",
+              value: "5cc07c04-ea62-4a5d-b4b0-069bc47533f8",
+            },
+            sslStatus: "pending_validation",
+            status: "pending_validation",
+            validationRecords: [
+              {
+                name: "_acme-challenge.app.acme-inc.com",
+                status: "pending",
+                value: "ca3-f8e2b4c9d1a04e7f9b6c3d2e1f0a5b4c",
+              },
+            ],
+            wildcard: true,
+          },
+        },
+        {
+          description:
+            "A later refresh observed the hostname and certificate both active: the domain now routes to the project.",
+          payload: {
+            cloudflareHostnameId: "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
+            error: null,
+            hostname: "app.acme-inc.com",
+            hostnameStatus: "active",
+            ownershipVerification: null,
+            sslStatus: "active",
+            status: "active",
+            validationRecords: [],
+            wildcard: true,
+          },
+        },
+      ],
     },
     "events.iterate.com/project/custom-domain-provision-failed": {
       description: "Custom-domain provisioning failed before an observed Cloudflare status.",
@@ -125,12 +229,31 @@ export const ProjectProcessorContract = defineProcessorContract({
         error: z.string(),
         hostname: z.string(),
       }),
+      examples: [
+        {
+          description: "Cloudflare rejected the custom-hostname create call.",
+          payload: {
+            error:
+              "Cloudflare /zones/f1e2d3c4b5a69788c9d0e1f2a3b4c5d6/custom_hostnames failed with 409: Duplicate custom hostname found.",
+            hostname: "app.acme-inc.com",
+          },
+        },
+      ],
     },
     "events.iterate.com/project/custom-domain-removed": {
       description: "A custom domain was removed from Cloudflare and routing KV.",
       payloadSchema: z.object({
         hostname: z.string(),
       }),
+      examples: [
+        {
+          description:
+            "The remove request completed: Cloudflare and routing KV no longer know the hostname.",
+          payload: {
+            hostname: "app.acme-inc.com",
+          },
+        },
+      ],
     },
   },
   consumes: [

--- a/apps/os/src/domains/repos/repo-processor-contract.ts
+++ b/apps/os/src/domains/repos/repo-processor-contract.ts
@@ -43,6 +43,15 @@ export const RepoProcessorContract = defineProcessorContract({
         projectId: z.string().nullable(),
         path: z.string(),
       }),
+      examples: [
+        {
+          description: 'Project bootstrap requested the root repo at path "/".',
+          payload: {
+            projectId: "prj_01jzp3v9qkfxeb2m4n8r7wd5ha",
+            path: "/",
+          },
+        },
+      ],
     },
     "events.iterate.com/repo/created": {
       description: "The repo was created.",
@@ -53,10 +62,36 @@ export const RepoProcessorContract = defineProcessorContract({
         projectId: z.string().nullable(),
         remote: z.string(),
       }),
+      examples: [
+        {
+          description:
+            "The project's root repo finished bootstrapping: its git remote is a Cloudflare Artifacts repository named after the project id and path.",
+          payload: {
+            artifactName: "prj_01jzp3v9qkfxeb2m4n8r7wd5ha--Lw",
+            defaultBranch: "main",
+            path: "/",
+            projectId: "prj_01jzp3v9qkfxeb2m4n8r7wd5ha",
+            remote:
+              "https://6d7f0e2c4b9a5138f2ce7a1b8d3e4f50.artifacts.cloudflare.net/git/os-prd-repos/prj_01jzp3v9qkfxeb2m4n8r7wd5ha--Lw.git",
+          },
+        },
+      ],
     },
     "events.iterate.com/repo/github-link-configured": {
       description: "The repo was linked to a GitHub repository (mirror-out on every commit).",
       payloadSchema: GithubLinkPayload,
+      examples: [
+        {
+          description:
+            "The repo was linked to acme-inc/acme-config through the GitHub App installation's connection.",
+          payload: {
+            connection: "install-87654321",
+            installationId: "87654321",
+            owner: "acme-inc",
+            repo: "acme-config",
+          },
+        },
+      ],
     },
     "events.iterate.com/repo/github-unlinked": {
       description: "The repo's GitHub link was removed.",
@@ -65,6 +100,16 @@ export const RepoProcessorContract = defineProcessorContract({
         owner: z.string(),
         repo: z.string(),
       }),
+      examples: [
+        {
+          description: "The link to acme-inc/acme-config was removed; mirroring stops.",
+          payload: {
+            connection: "install-87654321",
+            owner: "acme-inc",
+            repo: "acme-config",
+          },
+        },
+      ],
     },
     "events.iterate.com/repo/github-push-completed": {
       description: "A mirror push delivered the branch head to the linked GitHub repository.",
@@ -74,6 +119,17 @@ export const RepoProcessorContract = defineProcessorContract({
         owner: z.string(),
         repo: z.string(),
       }),
+      examples: [
+        {
+          description: "The default branch's new head was mirrored to GitHub after a commit.",
+          payload: {
+            branch: "main",
+            commitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
+            owner: "acme-inc",
+            repo: "acme-config",
+          },
+        },
+      ],
     },
     "events.iterate.com/repo/github-push-failed": {
       description:
@@ -85,6 +141,32 @@ export const RepoProcessorContract = defineProcessorContract({
         owner: z.string(),
         repo: z.string(),
       }),
+      examples: [
+        {
+          description:
+            "GitHub rejected the mirror push as non-fast-forward: GitHub has commits this repo does not.",
+          payload: {
+            branch: "main",
+            commitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
+            error:
+              'Error: GitHub push of main was rejected (non-fast-forward means GitHub has commits this repo does not; use syncFromGithub() to adopt them or pushToGithub({ force: true }) to overwrite): {"refs/heads/main":"fetch first"}',
+            owner: "acme-inc",
+            repo: "acme-config",
+          },
+        },
+        {
+          description:
+            "The push failed before a head was resolved (null commitOid): the connection's installation token could not be minted.",
+          payload: {
+            branch: "main",
+            commitOid: null,
+            error:
+              'Error: GitHub connection "install-87654321" has no usable installation token (HttpError: Not Found). Use itx.integrations.list() to see connections.',
+            owner: "acme-inc",
+            repo: "acme-config",
+          },
+        },
+      ],
     },
     "events.iterate.com/repo/github-synced": {
       description: "The repo adopted the linked GitHub repository's branch head (syncFromGithub).",
@@ -96,11 +178,63 @@ export const RepoProcessorContract = defineProcessorContract({
         previousCommitOid: z.string().nullable(),
         repo: z.string(),
       }),
+      examples: [
+        {
+          description: "A fast-forward sync adopted GitHub's newer branch head.",
+          payload: {
+            branch: "main",
+            commitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
+            forced: false,
+            owner: "acme-inc",
+            previousCommitOid: "4c1a9b0e2d3f5a6b7c8d9e0f1a2b3c4d5e6f7a80",
+            repo: "acme-config",
+          },
+        },
+        {
+          description: "A forced sync overwrote diverged local history with GitHub's branch head.",
+          payload: {
+            branch: "main",
+            commitOid: "b7e2f0a9c8d14e3fa6570b2c9d8e1f4a3b5c6d70",
+            forced: true,
+            owner: "acme-inc",
+            previousCommitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
+            repo: "acme-config",
+          },
+        },
+      ],
     },
     "events.iterate.com/github/webhook-received": {
       description:
         "One GitHub webhook delivery, captured verbatim on the connection stream and cross-posted here by the repo's linkGithub rule. Maximally loose: bodies are GitHub's, stored rows must always re-parse.",
       payloadSchema: z.object({}).loose(),
+      examples: [
+        {
+          description:
+            "A push delivery (trimmed): GitHub's webhook body under `body`, plus the delivery headers and the routing installation id.",
+          payload: {
+            body: {
+              ref: "refs/heads/main",
+              before: "4c1a9b0e2d3f5a6b7c8d9e0f1a2b3c4d5e6f7a80",
+              after: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
+              commits: [
+                {
+                  id: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
+                  message: "Update worker routing",
+                  author: { name: "Jane Doe", email: "jane@acme-inc.com" },
+                },
+              ],
+              repository: { full_name: "acme-inc/acme-config" },
+              sender: { login: "jane-doe" },
+              installation: { id: 87654321 },
+            },
+            headers: {
+              githubDelivery: "72d3162e-cc78-11e3-81ab-4c9367dc0958",
+              githubEvent: "push",
+            },
+            installationId: "87654321",
+          },
+        },
+      ],
     },
     "events.iterate.com/github-pr/route-configured": {
       description:
@@ -116,6 +250,21 @@ export const RepoProcessorContract = defineProcessorContract({
           streamPath: z.string(),
         })
         .loose(),
+      examples: [
+        {
+          description:
+            "The first PR webhook for acme-inc/acme-config#42 bound its agent stream to the pull request.",
+          payload: {
+            connection: "install-87654321",
+            installationId: "87654321",
+            number: 42,
+            owner: "acme-inc",
+            repo: "acme-config",
+            repoPath: "/",
+            streamPath: "/agents/repos/root/pull-requests/42",
+          },
+        },
+      ],
     },
   },
   processorDeps: [CoreProcessorContract],

--- a/apps/os/src/domains/sandboxes/sandbox-processor-contract.ts
+++ b/apps/os/src/domains/sandboxes/sandbox-processor-contract.ts
@@ -29,60 +29,152 @@ const SANDBOX_EVENTS = {
       keepAlive: z.boolean().optional(),
       env: z.record(z.string(), z.string().nullable()).optional(),
     }),
+    examples: [
+      {
+        description:
+          'itx.sandboxes.create claims "/sandboxes/main": a basic instance that sleeps after 10 idle minutes, with a getSecret-placeholder env var substituted only at egress.',
+        payload: {
+          path: "/sandboxes/main",
+          instanceType: "basic",
+          sleepAfter: "10m",
+          env: {
+            GH_TOKEN:
+              'getSecret({ path: "/secrets/integrations/github/acme", field: "accessToken" })',
+          },
+        },
+      },
+    ],
   },
   "events.iterate.com/sandbox/created": {
     description:
       "The sandbox exists: identity and configuration are durably stored and itx.sandboxes.get(path) resolves it. No container is running yet — the first command (or start()) boots one.",
     payloadSchema: z.object({ instanceType: SandboxInstanceType }),
+    examples: [
+      {
+        description: "A basic sandbox finished setup and is ready to boot on the first command.",
+        payload: { instanceType: "basic" },
+      },
+    ],
   },
   "events.iterate.com/sandbox/start-requested": {
     description:
       "start() was called: boot the container now (rather than lazily on the first command). `started` confirms the boot.",
     payloadSchema: z.object({}),
+    examples: [
+      {
+        description: "start() was called to boot the container ahead of the first command.",
+        payload: {},
+      },
+    ],
   },
   "events.iterate.com/sandbox/started": {
     description:
       "The sandbox container booted (the SDK's onStart hook) — after an explicit start() OR implicitly because a command reached a stopped sandbox. /workspace is restored from the newest snapshot before commands run.",
     payloadSchema: z.object({}),
+    examples: [
+      {
+        description: "A command reached a stopped sandbox, so a fresh container booted implicitly.",
+        payload: {},
+      },
+    ],
   },
   "events.iterate.com/sandbox/sleep-requested": {
     description:
       "sleep() was called (Cloudflare's word for what the idle timer does, on demand): snapshot /workspace, then tear the container down. The sandbox stays created — the next start (or command) boots a fresh container and restores the snapshot. The SDK's stop() forwards here so no spelling skips the snapshot.",
     payloadSchema: z.object({}),
+    examples: [
+      {
+        description:
+          "sleep() was called: snapshot /workspace, then tear the container down until the next command.",
+        payload: {},
+      },
+    ],
   },
   "events.iterate.com/sandbox/stopped": {
     description:
       "The sandbox container exited (the SDK's onStop hook) — after an explicit sleep(), the idle timer (sleepAfter), or a destroy. May be appended on a LATER wake: the SDK delivers a stop that happened while the Durable Object was hibernated on the next wake.",
     payloadSchema: z.object({}),
+    examples: [
+      {
+        description: "The idle timer expired and the container exited.",
+        payload: {},
+      },
+    ],
   },
   "events.iterate.com/sandbox/destroy-requested": {
     description: "destroy() was called: tear the sandbox down permanently. `destroyed` confirms.",
     payloadSchema: z.object({}),
+    examples: [
+      {
+        description: "destroy() was called: tear the sandbox down permanently.",
+        payload: {},
+      },
+    ],
   },
   "events.iterate.com/sandbox/destroyed": {
     description:
       "The sandbox is permanently gone: container torn down and the identity tombstoned — the path can never be created again (pick a new name). Workspace snapshots in R2 age out on their ttl.",
     payloadSchema: z.object({}),
+    examples: [
+      {
+        description:
+          "The teardown landed: the container is gone and the path is tombstoned forever.",
+        payload: {},
+      },
+    ],
   },
   "events.iterate.com/sandbox/workspace-restored": {
     description:
       "/workspace was restored from the named R2 snapshot into the fresh container — what makes stop/sleep survivable: files under /workspace come back, everything else on the container disk is gone.",
     payloadSchema: z.object({ backupId: z.string() }),
+    examples: [
+      {
+        description:
+          "A fresh container restored /workspace from the newest snapshot (backup ids are the SDK's random UUIDs).",
+        payload: { backupId: "3f2c9a4e-8b1d-4e7a-9c6f-2d5b8a1e4f7c" },
+      },
+    ],
   },
   "events.iterate.com/sandbox/backup-created": {
     description:
       "/workspace was snapshotted to R2 (an explicit sleep() or the idle timer); this backup is what the next start restores.",
     payloadSchema: z.object({ backupId: z.string() }),
+    examples: [
+      {
+        description: "The idle timer snapshotted /workspace to R2 before stopping the container.",
+        payload: { backupId: "3f2c9a4e-8b1d-4e7a-9c6f-2d5b8a1e4f7c" },
+      },
+    ],
   },
   "events.iterate.com/sandbox/backup-failed": {
     description:
       "A workspace snapshot failed; the container still stops, and the previous good backup (if any) remains the restore source.",
     payloadSchema: z.object({ error: z.string() }),
+    examples: [
+      {
+        description:
+          "The snapshot could not be archived; the previous good backup remains the restore source.",
+        payload: { error: "createBackup failed: container exited before the archive completed" },
+      },
+    ],
   },
   "events.iterate.com/sandbox/configured": {
     description:
       "The sandbox's env-var map changed (setEnvVars, or `env` at create). `env` is the map set in this change (key → value; null = key unset); values are conventionally `getSecret({ path })` placeholders substituted only at egress, or non-secret literals. NEVER put raw secret material in a value — it lands on this durable stream.",
     payloadSchema: z.object({ env: z.record(z.string(), z.string().nullable()) }),
+    examples: [
+      {
+        description:
+          "setEnvVars set GH_TOKEN to a getSecret placeholder (substituted only at egress) and unset DEBUG.",
+        payload: {
+          env: {
+            GH_TOKEN:
+              'getSecret({ path: "/secrets/integrations/github/acme", field: "accessToken" })',
+            DEBUG: null,
+          },
+        },
+      },
+    ],
   },
 } as const;
 

--- a/apps/os/src/domains/secrets/secret-processor-contract.ts
+++ b/apps/os/src/domains/secrets/secret-processor-contract.ts
@@ -67,6 +67,33 @@ export const SecretProcessorContract = defineProcessorContract({
         // `null` clears a configured strategy; omitted leaves it unchanged.
         refresh: SecretRefresh.nullable().optional(),
       }),
+      examples: [
+        {
+          description:
+            "A Slack bot token is stored: encrypted-at-rest material plus the egress origins it may be substituted into.",
+          payload: {
+            encryptedMaterial: {
+              algorithm: "AES-GCM-SHA256",
+              ciphertext: "nJ2xkV8mPqvGdL5tYw3eBg==",
+              iv: "9EMTZWEeC2Iy5W5m",
+            },
+            egress: { urls: ["https://slack.com", "https://files.slack.com"] },
+          },
+        },
+        {
+          description:
+            "A GitHub connection secret gets the github-app-installation refresh strategy: the DO mints installation tokens on demand, signing with the platform-owned App key.",
+          payload: {
+            refresh: {
+              kind: "github-app-installation",
+              apiBase: "https://api.github.com",
+              appId: "312345",
+              installationId: "45678901",
+              privateKey: { platform: "integrations.github" },
+            },
+          },
+        },
+      ],
     },
     "events.iterate.com/secret/used": {
       description: "Records that secret material was substituted into an egress request.",
@@ -75,6 +102,17 @@ export const SecretProcessorContract = defineProcessorContract({
         usedBy: z.string().optional(),
         url: z.string().optional(),
       }),
+      examples: [
+        {
+          description:
+            "The secret's material was substituted into a Slack Web API call at the egress door.",
+          payload: {
+            usedAt: "2026-07-08T14:31:09.412Z",
+            usedBy: "prj_b9f2c81d4e6a4f0a9c3d7e5b1a8f2c4d",
+            url: "https://slack.com/api/chat.postMessage",
+          },
+        },
+      ],
     },
   },
   consumes: ["events.iterate.com/secret/updated", "events.iterate.com/secret/used"],

--- a/apps/os/src/domains/streams/core-processor-contract.ts
+++ b/apps/os/src/domains/streams/core-processor-contract.ts
@@ -356,27 +356,111 @@ export const CoreProcessorContract = defineProcessorContract({
         projectId: z.string().trim().min(1).nullable(),
         path: z.string().trim().min(1),
       }),
+      examples: [
+        {
+          description: "A project's agent stream is created.",
+          payload: { projectId: "prj_01jzp3v9qkfxeb2m4n8r7wd5ha", path: "/agents/onboarding" },
+        },
+        {
+          description: "A deployment-global stream (no owning project) is created.",
+          payload: { projectId: null, path: "/repos/iterate-config-base" },
+        },
+      ],
     },
     "events.iterate.com/stream/woken": {
       description: "Records that a Durable Object incarnation has started running this stream.",
       payloadSchema: z.object({
         incarnationId: z.string().trim().min(1),
       }),
+      examples: [
+        {
+          description:
+            "A fresh Durable Object incarnation starts running the stream after hibernation.",
+          payload: { incarnationId: "b7f9d2c4-3a1e-4f68-9c05-8d2e6a41f7b3" },
+        },
+      ],
     },
     "events.iterate.com/stream/configured": {
       description: "Configures core stream runtime policy.",
       payloadSchema: StreamConfiguredPayload,
+      examples: [
+        {
+          description: "Sets an explicit append circuit-breaker budget for a capture stream.",
+          payload: {
+            config: { circuitBreaker: { burstCapacity: 100_000, refillRatePerMinute: 6_000_000 } },
+          },
+        },
+      ],
     },
     "events.iterate.com/stream/child-stream-created": {
       description: "Records the immediate child stream segment under this stream.",
       payloadSchema: z.object({
         childPath: z.string().trim().min(1),
       }),
+      examples: [
+        {
+          description: "The project root stream learns a new agent stream was born beneath it.",
+          payload: { childPath: "/agents/onboarding" },
+        },
+        {
+          description:
+            "An ancestor stream records a newborn Slack thread agent; the reducer folds the full path down to the immediate child segment.",
+          payload: { childPath: "/agents/slack/main/C0788AB12CD/ts-1751884800-123456" },
+        },
+      ],
     },
     "events.iterate.com/stream/subscription-configured": {
       description:
         "Configures or replaces a durable subscription for this stream (wake or push delivery; latest event per subscriptionKey wins). Re-configuring keeps the existing delivery cursor unless `deliver` is set, and clears any parked state — new config is a fresh chance.",
       payloadSchema: SubscriptionConfiguredPayload,
+      examples: [
+        {
+          description:
+            "Wake delivery: the agent processor hosted on the agent's Durable Object folds this stream; the subscriber owns its own checkpoint, so no deliver/onPoison here.",
+          payload: {
+            subscriptionKey: "prj_01jzp3v9qkfxeb2m4n8r7wd5ha.iterate/agents/onboarding#agent",
+            delivery: {
+              mode: "wake",
+              expression: [
+                "agents",
+                ["get", "/agents/onboarding"],
+                "processor",
+                "wakeStreamSubscriber",
+              ],
+              processorSlug: "agent",
+            },
+          },
+        },
+        {
+          description:
+            "Push delivery: cross-posts one repository's GitHub webhooks from a connection stream onto the repo's own stream, live-tailing from now.",
+          payload: {
+            subscriptionKey: "github-repo:/repos/root",
+            selector: {
+              eventTypes: ["events.iterate.com/github/webhook-received"],
+              condition: 'payload.body.repository.full_name = "acme/widgets"',
+            },
+            delivery: {
+              mode: "push",
+              expression: ["streams", ["get", "/repos/root"], "ingest"],
+            },
+            deliver: "new",
+          },
+        },
+        {
+          description:
+            "Webhook delivery: one HTTP POST per event to an external receiver, stepping over a poison event instead of parking the whole feed.",
+          payload: {
+            subscriptionKey: "ops-webhook",
+            delivery: {
+              mode: "webhook",
+              url: "https://hooks.example.com/iterate/stream-events",
+            },
+            deliver: "new",
+            onPoison: "skip",
+          },
+        },
+      ],
     },
     "events.iterate.com/stream/subscription-removed": {
       description:
@@ -384,6 +468,12 @@ export const CoreProcessorContract = defineProcessorContract({
       payloadSchema: z.object({
         subscriptionKey: z.string().trim().min(1),
       }),
+      examples: [
+        {
+          description: "Unlinking a repo from GitHub revokes its webhook cross-post subscription.",
+          payload: { subscriptionKey: "github-repo:/repos/root" },
+        },
+      ],
     },
     "events.iterate.com/stream/subscription-parked": {
       description:
@@ -395,6 +485,19 @@ export const CoreProcessorContract = defineProcessorContract({
         attempts: z.number().int().positive(),
         error: z.string().trim().min(1).optional(),
       }),
+      examples: [
+        {
+          description:
+            "A webhook receiver stayed down through the whole retry ladder, so delivery gave up loudly.",
+          payload: {
+            subscriptionKey: "ops-webhook",
+            atOffset: 1874,
+            attempts: 15,
+            error:
+              "webhook POST https://hooks.example.com/iterate/stream-events failed with status 503",
+          },
+        },
+      ],
     },
     "events.iterate.com/stream/subscription-resumed": {
       description:
@@ -403,6 +506,18 @@ export const CoreProcessorContract = defineProcessorContract({
         subscriptionKey: z.string().trim().min(1),
         afterOffset: z.number().int().min(0).optional(),
       }),
+      examples: [
+        {
+          description:
+            "Un-parks a subscription after the receiver recovered; delivery resumes from the cursor where it stopped.",
+          payload: { subscriptionKey: "ops-webhook" },
+        },
+        {
+          description:
+            "The redrive: un-parks the project worker feed and moves the cursor past a bad offset in the same act.",
+          payload: { subscriptionKey: "project-worker", afterOffset: 1874 },
+        },
+      ],
     },
     "events.iterate.com/stream/subscription-cursor-set": {
       description:
@@ -411,6 +526,18 @@ export const CoreProcessorContract = defineProcessorContract({
         subscriptionKey: z.string().trim().min(1),
         afterOffset: z.number().int().min(0),
       }),
+      examples: [
+        {
+          description:
+            "Replays the stream's full history into the project worker feed (afterOffset is exclusive; 0 replays everything).",
+          payload: { subscriptionKey: "project-worker", afterOffset: 0 },
+        },
+        {
+          description:
+            "Seeks a cross-post subscription's cursor forward: events at or below offset 512 are never delivered.",
+          payload: { subscriptionKey: "github-repo:/repos/root", afterOffset: 512 },
+        },
+      ],
     },
     "events.iterate.com/stream/subscriber-connected": {
       description:
@@ -420,6 +547,51 @@ export const CoreProcessorContract = defineProcessorContract({
         subscriptionType: StreamSubscriptionType,
         subscriber: StreamSubscriberDescriptor.optional(),
       }),
+      examples: [
+        {
+          description:
+            "A wake subscription's poke handshake completed: the hosted agent processor connected and announced its contract (consumes/emits abridged).",
+          payload: {
+            subscriptionKey: "prj_01jzp3v9qkfxeb2m4n8r7wd5ha.iterate/agents/onboarding#agent",
+            subscriptionType: "configured",
+            subscriber: {
+              processor: {
+                announcement: {
+                  slug: "agent",
+                  version: "0.3.1",
+                  description:
+                    "Maintains model-visible web-chat history and requests LLM work from a provider processor.",
+                  consumes: [
+                    "events.iterate.com/agent/input-added",
+                    "events.iterate.com/agents/user-message-received",
+                    "events.iterate.com/agent/llm-request-completed",
+                  ],
+                  emits: [
+                    "events.iterate.com/agent/input-added",
+                    "events.iterate.com/agent/llm-request-scheduled",
+                  ],
+                  ownedEvents: [
+                    {
+                      type: "events.iterate.com/agent/input-added",
+                      description: "A normalized model-visible input was added.",
+                    },
+                    { type: "events.iterate.com/agent/llm-request-scheduled" },
+                  ],
+                },
+              },
+            },
+          },
+        },
+        {
+          description:
+            "An anonymous ephemeral watcher: a browser stream-viewer tab live-tailing the log.",
+          payload: {
+            subscriptionKey: "d4f8a1b2-6c3e-4e9a-8b57-0f1c2d3e4a5b",
+            subscriptionType: "ephemeral",
+            subscriber: { description: "browser" },
+          },
+        },
+      ],
     },
     "events.iterate.com/stream/subscriber-disconnected": {
       description:
@@ -428,6 +600,23 @@ export const CoreProcessorContract = defineProcessorContract({
         subscriptionKey: z.string().trim().min(1),
         reason: StreamSubscriberDisconnectReason,
       }),
+      examples: [
+        {
+          description: "A stream-viewer tab closed and unsubscribed.",
+          payload: {
+            subscriptionKey: "d4f8a1b2-6c3e-4e9a-8b57-0f1c2d3e4a5b",
+            reason: "unsubscribed",
+          },
+        },
+        {
+          description:
+            "The stream went quiet past its idle window and dropped its configured connections so everyone can hibernate; the durable config is kept and the next append re-wakes.",
+          payload: {
+            subscriptionKey: "prj_01jzp3v9qkfxeb2m4n8r7wd5ha.iterate/agents/onboarding#agent",
+            reason: "idle",
+          },
+        },
+      ],
     },
     "events.iterate.com/stream/error-occurred": {
       description: "Records a structured stream or processor runner error.",
@@ -442,18 +631,53 @@ export const CoreProcessorContract = defineProcessorContract({
           })
           .optional(),
       }),
+      examples: [
+        {
+          description:
+            'The delivery spine stepped over a confirmed poison event on an onPoison: "skip" subscription.',
+          payload: {
+            message:
+              'subscription "project-worker" skipped poison event at offset 812 after 3 attempts: receiver rejected payload',
+          },
+        },
+        {
+          description:
+            "A processor skipped an event that fails its contract's schema, with the structured cause attached.",
+          payload: {
+            message:
+              'stream processor "agent" skipped event at offset 42 ("events.iterate.com/agent/input-added"): it fails the contract\'s schema',
+            error: {
+              name: "ZodError",
+              message: 'Invalid input: expected string, received number at "content"',
+            },
+          },
+        },
+      ],
     },
     "events.iterate.com/stream/paused": {
       description: "Records that the stream is paused and should reject ordinary appends.",
       payloadSchema: z.object({
         reason: z.string().trim().min(1).optional(),
       }),
+      examples: [
+        {
+          description:
+            "The stream paused itself after its append circuit breaker tripped on a runaway producer.",
+          payload: { reason: "circuit breaker tripped: burst rate limit exceeded" },
+        },
+      ],
     },
     "events.iterate.com/stream/resumed": {
       description: "Records that the stream has resumed accepting ordinary appends.",
       payloadSchema: z.object({
         reason: z.string().trim().min(1).optional(),
       }),
+      examples: [
+        {
+          description: "An operator reopened the stream after investigating a tripped breaker.",
+          payload: { reason: "operator resumed after raising the circuit-breaker budget" },
+        },
+      ],
     },
   },
   consumes: [

--- a/apps/os/src/domains/streams/processor-contracts.ts
+++ b/apps/os/src/domains/streams/processor-contracts.ts
@@ -21,10 +21,24 @@ import {
 // payload types from the same declaration and typos fail at the definition site.
 // =============================================================================
 
-/** One owned event: its payload schema plus optional human description. */
+/**
+ * One documented example payload for an owned event, rendered on the public
+ * event docs site (events.iterate.com). The payload must parse against the
+ * event's `payloadSchema` — enforced by the event-docs unit tests rather than
+ * at module load, so a bad example fails CI instead of bricking a worker boot.
+ */
+export type EventExample = {
+  /** What this example shows, e.g. "Push delivery to another stream's ingest". */
+  description: string;
+  /** The example payload, in the payload schema's input shape. */
+  payload: unknown;
+};
+
+/** One owned event: its payload schema plus optional human description and examples. */
 export type EventDefinition<PayloadOutput = unknown, PayloadInput = PayloadOutput> = {
   description?: string;
   payloadSchema: z.ZodType<PayloadOutput, PayloadInput>;
+  examples?: readonly EventExample[];
 };
 
 /** A contract's owned events, keyed by the durable event type string. */

--- a/apps/os/src/lib/event-docs.test.ts
+++ b/apps/os/src/lib/event-docs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  documentedProcessorContracts,
   eventDocs,
   getEventDocByPath,
   getEventDocByProcessorRoute,
@@ -97,5 +98,77 @@ describe("event docs catalog", () => {
   it("builds a non-empty processor and event catalog", () => {
     expect(processorDocs.length).toBeGreaterThan(5);
     expect(eventDocs.length).toBeGreaterThan(10);
+  });
+});
+
+describe("event docs examples", () => {
+  it("documents at least one example for every owned event type", () => {
+    const undocumented = eventDocs
+      .filter((event) => event.examples.length === 0)
+      .map((event) => event.type);
+    expect(
+      undocumented,
+      "every contract event needs an `examples` entry for the docs site",
+    ).toEqual([]);
+  });
+
+  it("parses every example payload against its event's payload schema", () => {
+    for (const contract of documentedProcessorContracts) {
+      for (const [type, definition] of Object.entries(contract.events)) {
+        for (const example of definition.examples ?? []) {
+          const result = definition.payloadSchema.safeParse(example.payload);
+          expect(
+            result.success,
+            `${type} example "${example.description}" must parse: ${result.error}`,
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("keeps every example payload JSON-serializable", () => {
+    for (const event of eventDocs) {
+      for (const example of event.examples) {
+        const roundTripped: unknown = JSON.parse(JSON.stringify(example.payload));
+        expect(roundTripped, `${event.type} example "${example.description}"`).toEqual(
+          example.payload,
+        );
+      }
+    }
+  });
+});
+
+describe("event docs cross-references", () => {
+  it("links events to the processors that emit and consume them", () => {
+    const event = getEventDocByType("events.iterate.com/agent/llm-request-completed");
+
+    expect(event?.emittedBy.map((processor) => processor.contractSlug)).toEqual(
+      expect.arrayContaining(["cloudflare-ai", "openai-ws"]),
+    );
+    expect(event?.consumedBy.map((processor) => processor.contractSlug)).toEqual(
+      expect.arrayContaining(["agent", "slack-agent"]),
+    );
+  });
+
+  it("links processor consumes/emits rows to owned event docs", () => {
+    const processor = getProcessorDocByPath("project");
+
+    expect(processor?.consumesAllEvents).toBe(true);
+    expect(processor?.emits.map((event) => event.type)).toContain(
+      "events.iterate.com/stream/subscription-configured",
+    );
+    const foreignEmit = processor?.emits.find(
+      (event) => event.type === "events.iterate.com/repo/create-requested",
+    );
+    expect(foreignEmit?.ownerContractSlug).toBe("repo");
+    expect(foreignEmit?.href).toBe("/docs/streams/processors/repo/events/create-requested");
+  });
+
+  it("links processor dependencies in both directions", () => {
+    const agent = getProcessorDocByPath("agent");
+    const capabilityHost = getProcessorDocByPath("capability-host");
+
+    expect(agent?.dependencies.map((dep) => dep.contractSlug)).toContain("capability-host");
+    expect(capabilityHost?.dependents.map((dep) => dep.contractSlug)).toContain("agent");
   });
 });

--- a/apps/os/src/lib/event-docs.ts
+++ b/apps/os/src/lib/event-docs.ts
@@ -19,7 +19,7 @@ const PROCESSOR_DOCS_BASE_PATH = "/docs/streams/processors";
 
 type EventDefinitionForDocs = {
   description?: string;
-  examples?: unknown;
+  examples?: readonly { description: string; payload: unknown }[];
   payloadSchema: z.ZodType;
 };
 
@@ -49,8 +49,20 @@ const processorContracts = [
   BrowserEventFeedContract,
 ] as const satisfies readonly ProcessorContractForDocs[];
 
+/**
+ * The contracts the public event docs are generated from, in docs order —
+ * exported so tests can validate documentation invariants (e.g. that every
+ * example payload parses against its event's payload schema) against the same
+ * list the site renders.
+ */
+export const documentedProcessorContracts: readonly ProcessorContractForDocs[] = processorContracts;
+
 export type EventDoc = {
+  /** Processors that list this event type in `consumes` (owner included; wildcard consumers excluded). */
+  consumedBy: ProcessorReferenceDoc[];
   description?: string;
+  /** Processors that list this event type in `emits`. */
+  emittedBy: ProcessorReferenceDoc[];
   eventPath: string;
   examples: EventExampleDoc[];
   href: string;
@@ -68,6 +80,8 @@ export type EventExampleDoc = {
 export type EventReferenceDoc = {
   description?: string;
   href?: string;
+  /** Contract slug of the processor that owns (defines) this event type. */
+  ownerContractSlug?: string;
   routeParams?: EventRouteParams;
   type: string;
 };
@@ -79,9 +93,13 @@ export type EventRouteParams = {
 
 export type ProcessorDoc = ProcessorReferenceDoc & {
   consumes: EventReferenceDoc[];
+  /** True when the contract's `consumes` includes the `"*"` wildcard. */
+  consumesAllEvents: boolean;
   dependencies: ProcessorReferenceDoc[];
+  /** Processors that list this contract in their `processorDeps`. */
+  dependents: ProcessorReferenceDoc[];
+  emits: EventReferenceDoc[];
   events: EventDoc[];
-  version?: string;
 };
 
 export type ProcessorReferenceDoc = {
@@ -91,6 +109,7 @@ export type ProcessorReferenceDoc = {
   href: string;
   routeParams: { processorSlug: string };
   slug: string;
+  version?: string;
 };
 
 type EventDocsRouteTarget =
@@ -154,12 +173,41 @@ function buildProcessorDocs(): ProcessorDoc[] {
   const referencesByContractSlug = new Map(
     references.map((processor) => [processor.contractSlug, processor]),
   );
+
+  // Cross-reference indexes over the full contract list, built before any
+  // event doc so every event can link back to the processors that consume,
+  // emit, or depend on it.
+  const consumersByType = new Map<string, ProcessorReferenceDoc[]>();
+  const emittersByType = new Map<string, ProcessorReferenceDoc[]>();
+  const dependentsByContractSlug = new Map<string, ProcessorReferenceDoc[]>();
+  processorContracts.forEach((contract, index) => {
+    const reference = references[index];
+    for (const type of contract.consumes) {
+      if (type === "*") continue;
+      pushMapArray(consumersByType, type, reference);
+    }
+    for (const type of contract.emits ?? []) {
+      pushMapArray(emittersByType, type, reference);
+    }
+    for (const dep of contract.processorDeps ?? []) {
+      pushMapArray(dependentsByContractSlug, dep.slug, reference);
+    }
+  });
+
   const eventReferencesByType = new Map<string, EventReferenceDoc>();
 
-  const docs = processorContracts.map((contract, index) => {
+  const docs = processorContracts.map((contract: ProcessorContractForDocs, index) => {
     const processor = references[index];
     const events = Object.entries(contract.events)
-      .map(([type, definition]) => buildEventDoc({ definition, processor, type }))
+      .map(([type, definition]) =>
+        buildEventDoc({
+          consumedBy: consumersByType.get(type) ?? [],
+          definition,
+          emittedBy: emittersByType.get(type) ?? [],
+          processor,
+          type,
+        }),
+      )
       .sort((a, b) => a.eventPath.localeCompare(b.eventPath));
 
     for (const event of events) {
@@ -168,9 +216,11 @@ function buildProcessorDocs(): ProcessorDoc[] {
 
     return {
       ...processor,
-      ...(contract.version == null ? {} : { version: contract.version }),
       consumes: [],
+      consumesAllEvents: contract.consumes.includes("*"),
       dependencies: [],
+      dependents: [],
+      emits: [],
       events,
     } satisfies ProcessorDoc;
   });
@@ -186,14 +236,28 @@ function buildProcessorDocs(): ProcessorDoc[] {
       dependencies: (contract.processorDeps ?? [])
         .map((dep) => referencesByContractSlug.get(dep.slug))
         .filter((dep): dep is ProcessorReferenceDoc => dep != null),
+      dependents: dependentsByContractSlug.get(contract.slug) ?? [],
+      emits: (contract.emits ?? [])
+        .map((type) => eventReferencesByType.get(type))
+        .filter((event): event is EventReferenceDoc => event != null),
     };
   });
+}
+
+function pushMapArray<Key, Value>(map: Map<Key, Value[]>, key: Key, value: Value) {
+  const values = map.get(key);
+  if (values === undefined) {
+    map.set(key, [value]);
+  } else {
+    values.push(value);
+  }
 }
 
 function processorReferenceDoc(contract: ProcessorContractForDocs): ProcessorReferenceDoc {
   const docsPath = processorDocsPath(contract);
   return {
     ...(contract.description == null ? {} : { description: contract.description }),
+    ...(contract.version == null ? {} : { version: contract.version }),
     contractSlug: contract.slug,
     docsPath,
     href: processorDocsPathForSlug(docsPath),
@@ -203,24 +267,30 @@ function processorReferenceDoc(contract: ProcessorContractForDocs): ProcessorRef
 }
 
 function buildEventDoc(args: {
+  consumedBy: ProcessorReferenceDoc[];
   definition: EventDefinitionForDocs;
+  emittedBy: ProcessorReferenceDoc[];
   processor: ProcessorReferenceDoc;
   type: string;
 }): EventDoc {
   const eventPath = eventPathFromType(args.type);
-  const examples = eventExamples(args.definition.examples);
   const processorEventPath = eventPathForProcessor({
     eventPath,
     processorSlug: args.processor.slug,
   });
   return {
     ...(args.definition.description == null ? {} : { description: args.definition.description }),
+    consumedBy: args.consumedBy,
+    emittedBy: args.emittedBy,
     eventPath,
-    examples,
+    examples: (args.definition.examples ?? []).map((example) => ({
+      description: example.description,
+      payload: example.payload,
+    })),
     href: `${processorDocsPathForSlug(args.processor.slug)}/events/${processorEventPath}`,
-    payloadJsonSchema: eventPayloadJsonSchema({
-      examples,
-      payloadSchema: args.definition.payloadSchema,
+    payloadJsonSchema: z.toJSONSchema(args.definition.payloadSchema, {
+      io: "input",
+      unrepresentable: "any",
     }),
     processor: args.processor,
     routeParams: {
@@ -235,52 +305,10 @@ function eventReferenceDoc(event: EventDoc): EventReferenceDoc {
   return {
     ...(event.description == null ? {} : { description: event.description }),
     href: event.href,
+    ownerContractSlug: event.processor.contractSlug,
     routeParams: event.routeParams,
     type: event.type,
   };
-}
-
-function eventPayloadJsonSchema(args: {
-  examples: readonly { payload: unknown }[];
-  payloadSchema: z.ZodType;
-}) {
-  const jsonSchema = z.toJSONSchema(args.payloadSchema, {
-    io: "input",
-    unrepresentable: "any",
-  });
-
-  if (args.examples.length === 0) return jsonSchema;
-  if (typeof jsonSchema !== "object" || jsonSchema === null || Array.isArray(jsonSchema)) {
-    return jsonSchema;
-  }
-
-  return {
-    ...jsonSchema,
-    examples: args.examples.map((example) => example.payload),
-  };
-}
-
-function eventExamples(examples: unknown): EventExampleDoc[] {
-  if (!Array.isArray(examples)) return [];
-
-  return examples
-    .map((example) => {
-      if (
-        typeof example === "object" &&
-        example !== null &&
-        "description" in example &&
-        "payload" in example &&
-        typeof example.description === "string"
-      ) {
-        return {
-          description: example.description,
-          payload: example.payload,
-        };
-      }
-
-      return null;
-    })
-    .filter((example): example is EventExampleDoc => example != null);
 }
 
 function processorDocsPath(contract: ProcessorContractForDocs) {


### PR DESCRIPTION
Makes [events.iterate.com](https://events.iterate.com/) a fully explorable reference for stream processors and their event types: richer schema rendering, example events everywhere, and processors/events cross-linked in both directions.

## What changed

### Examples are first-class in the contracts
- `EventDefinition` (`processor-contracts.ts`) gains `examples?: readonly EventExample[]` (`{ description, payload }`).
- ~80 realistic examples added, covering **every one of the 70 owned event types** across all 13 documented contracts. Payloads mirror real append sites (real subscription-key formats, itx wake/push expressions, actual GitHub/Slack webhook envelopes, provider usage shapes, `getSecret` placeholder grammar, …).
- Enforced by test rather than at module load (a bad example should fail CI, not brick a worker boot): every owned event must have ≥1 example, every example must parse against its `payloadSchema`, and every payload must JSON round-trip.

### Cross-references in the docs model (`event-docs.ts`)
- Per event: which processors **emit** it and which **consume** it (wildcard `*` consumers noted separately).
- Per processor: linked **Consumes** and **Emits** lists with "owned by X" attribution on foreign events, **dependencies and dependents** (both directions of `processorDeps`), and a `consumes *` flag.

### UI rework (`event-docs-pages.tsx`)
- Payload schemas render as nested **field tables** (name, TS-flavored type label, optional badge, description); discriminated unions render as labeled variant blocks (`mode: "wake"` / `"push"` / `"webhook"`). Raw JSON schema stays available in a collapsible.
- Event pages show all examples with descriptions, plus a collapsible **"as a committed stream event"** block wrapping the first example in the offset/createdAt/path/source envelope.
- Listings carry one-line payload signatures (`payload: { subscriptionKey, delivery, selector?, … }`) and example counts; the index groups events by processor with a client-side **filter box**.

## Screenshots

### Index — grouped by processor, payload signatures, filter
![index](https://raw.githubusercontent.com/iterate/iterate/2edf307f886ad1227c673493c7ec7abdc42e6a07/01-index.png)

### Filtering ("parked" → 2 of 70)
![filter](https://raw.githubusercontent.com/iterate/iterate/2edf307f886ad1227c673493c7ec7abdc42e6a07/02-index-filter.png)

### Event page — discriminated-union field table + cross-references
![subscription-configured schema](https://raw.githubusercontent.com/iterate/iterate/2edf307f886ad1227c673493c7ec7abdc42e6a07/04-event-schema.png)

### Examples + committed-event envelope
![examples](https://raw.githubusercontent.com/iterate/iterate/2edf307f886ad1227c673493c7ec7abdc42e6a07/05-event-examples.png)

### Top-level union payload (llm-request-cancelled)
![union payload](https://raw.githubusercontent.com/iterate/iterate/2edf307f886ad1227c673493c7ec7abdc42e6a07/06-event-union.png)

### Processor overview — owned events, consumes/emits, dependencies both ways
![agent processor](https://raw.githubusercontent.com/iterate/iterate/2edf307f886ad1227c673493c7ec7abdc42e6a07/03-processor-agent.png)

(Screenshots live on the throwaway `assets/event-docs-screenshots` branch, not in this diff.)

## Verification
- All 739 apps/os unit tests pass (15 event-docs tests, 6 new: example presence/validity/serializability + cross-reference links in both directions).
- `pnpm typecheck`, `pnpm lint`, `pnpm format`, `pnpm knip` all green.
- Manually verified in local dev: index + filter, processor pages, union/loose/empty payload event pages, committed-event envelope blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to public documentation UI, doc catalog generation, and illustrative contract metadata; runtime stream/processor behavior is unchanged.
> 
> **Overview**
> Turns **events.iterate.com** into a browsable stream-processor reference: contracts now carry documented examples, the docs model links processors and events both ways, and the UI renders schemas and listings instead of flat JSON dumps.
> 
> **Contracts & tests:** `EventDefinition` adds optional `examples` (`description` + `payload`). Every owned event across the documented processor contracts gets realistic examples; CI requires at least one per event, schema validation, and JSON serializability (`documentedProcessorContracts` exported for tests).
> 
> **Docs model (`event-docs.ts`):** Events gain `emittedBy` / `consumedBy`; processors gain linked `consumes` / `emits` (with **owned by** on foreign types), `consumesAllEvents`, and **dependents** alongside existing dependencies.
> 
> **UI (`event-docs-pages.tsx`):** Payload JSON Schema is shown as nested **field tables** (TS-style types, optional badges, union variants); raw schema stays in a collapsible. Index groups events by processor with search, payload one-liners, and richer processor sidebar stats. Event pages add a **committed stream event** envelope for the first example; processor/event sidebars surface emit/consume/dependency graphs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ecc9d6e00c35e8b96c916d540ad81f72b4dd4ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-09T17:23:17.755Z",
      "headSha": "2ecc9d6e00c35e8b96c916d540ad81f72b4dd4ac",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/384816950803041",
      "shortSha": "2ecc9d6",
      "cleanupDurationMs": 11259,
      "deployDurationMs": 67945,
      "testDurationMs": 182060,
      "testRetries": "3 retried: agent runs an itx script that appends a proof event, then replies (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · a commented tsconfig still schema-validates (comments are tolerated) (specs x1)",
      "workerSizeKib": 15545.21,
      "workerGzipKib": 4202.07,
      "mainWorkerGzipKib": 4161.41
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-09T17:23:09.277Z",
      "headSha": "2ecc9d6e00c35e8b96c916d540ad81f72b4dd4ac",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/384816950803041",
      "shortSha": "2ecc9d6",
      "cleanupDurationMs": 2779,
      "deployDurationMs": 17210,
      "testDurationMs": 645,
      "testRetries": null,
      "workerSizeKib": 3992.8,
      "workerGzipKib": 812.13,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-09T17:23:07.204Z",
      "headSha": "2ecc9d6e00c35e8b96c916d540ad81f72b4dd4ac",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/384816950803041",
      "shortSha": "2ecc9d6",
      "cleanupDurationMs": 704,
      "deployDurationMs": 13576,
      "testDurationMs": 16953,
      "testRetries": null,
      "workerSizeKib": 4653.23,
      "workerGzipKib": 1342.92,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `2ecc9d6` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 812.1 KiB | 17.2s | 645ms |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/384816950803041) | 2026-07-09T17:23:09.277Z | Preview app released. |
| OS | released | `2ecc9d6` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.10 MiB (+40.7 KiB vs main) | 67.9s | 182.1s | 3 retried: agent runs an itx script that appends a proof event, then replies (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · a commented tsconfig still schema-validates (comments are tolerated) (specs x1) | 11.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/384816950803041) | 2026-07-09T17:23:17.755Z | Preview app released. |
| Streams Example App | released | `2ecc9d6` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.31 MiB | 13.6s | 17.0s |  | 704ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/384816950803041) | 2026-07-09T17:23:07.204Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +1,064 -54 | +1,036 -47 🟩🟩🟩🟩🟩 |
| UI components | +604 -94 | +538 -94 🟩🟩🟩⬜⬜ |
| Tests | +73 -0 | +64 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+1,741 -148** | **+1,638 -141** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between a1f2f76 and 2ecc9d6, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->