### PR TITLE
Split preview cleanup into its own Depot workflow; retire retry-poisoned expect.poll in itx e2e

### DIFF
--- a/.depot/workflows/cloudflare-preview-cleanup.yml
+++ b/.depot/workflows/cloudflare-preview-cleanup.yml
@@ -1,0 +1,87 @@
+# Preview cleanup on PR close — the other half of the preview lifecycle in
+# cloudflare-previews.yml. Cleanup lives in its own workflow because every run
+# of a workflow re-emits all of its job check names on the head SHA: when
+# deploy and cleanup shared one workflow with complementary `if:`s, the
+# `closed`-event run re-reported "Preview / deploy + e2e" as skipped,
+# clobbering the earlier success on every merged PR (GitHub displays the
+# latest check run per name).
+#
+# The concurrency groups below are copied VERBATIM from cloudflare-previews.yml
+# so the two workflows still coordinate: closing a PR mid-deploy cancels the
+# in-flight deploy run (cancel-in-progress on the shared workflow-level group)
+# and the job-level lifecycle group serializes whatever remains — cleanup never
+# races a deploy for the same preview slot.
+#
+# Depot registers automatic triggers when this file is on the default branch —
+# branch-only changes to the `on:` block do not take effect until merged.
+#
+# Secrets (depot ci secrets --org 0p91s0lz49): DOPPLER_TOKEN,
+# ITERATE_BOT_GITHUB_TOKEN.
+#
+# Keep the `paths` list below identical to cloudflare-previews.yml's, so a
+# close runs cleanup for exactly the PRs that could have deployed a preview.
+
+name: Cloudflare Preview Cleanup (Depot CI)
+
+on:
+  pull_request:
+    types:
+      - closed
+    paths:
+      - .depot/workflows/cloudflare-previews.yml
+      - packages/shared/**
+      - packages/ui/**
+      - packages/mock-http-proxy/**
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - patches/**
+      - scripts/preview/**
+      - envs.ts
+      - scripts/lib/**
+      - apps/iterate-com/**
+      - apps/auth-example/**
+      - apps/os/**
+      - apps/auth/**
+      - apps/auth-contract/**
+      - apps/os/src/domains/streams/**
+      - apps/semaphore/**
+      - apps/streams-example-app/**
+
+concurrency:
+  group: cloudflare-previews-${{ github.event.pull_request.number || inputs.pull-request-number }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    name: Preview / cleanup
+    runs-on: depot-ubuntu-24.04
+    concurrency:
+      group: cloudflare-preview-lifecycle-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Install Doppler CLI
+        run: |-
+          for i in 1 2 3; do curl -sfLS https://cli.doppler.com/install.sh | sh -s -- --no-package-manager && break; echo "Attempt $i failed, retrying in 5s..."; sleep 5; done
+          doppler --version || { echo 'Failed to install Doppler CLI after 3 attempts'; exit 1; }
+      - name: Preview / cleanup
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ITERATE_BOT_GITHUB_TOKEN || github.token }}
+        run: |-
+          set -euo pipefail
+          doppler run --project _shared --config prd -- pnpm preview cleanup \
+            --github-token "$GITHUB_TOKEN" \
+            --pull-request-number "${{ github.event.pull_request.number }}"

--- a/.depot/workflows/cloudflare-previews.yml
+++ b/.depot/workflows/cloudflare-previews.yml
@@ -1,13 +1,19 @@
-# The whole preview lifecycle — deploy + e2e on open/reopen/synchronize, and
-# cleanup on close — lives here on Depot CI. Depot CI picks up jobs in ~7s
-# where GitHub Actions runner assignment took 20s-3m39s (measured 2026-07-02,
-# once ~40min during a webhook incident).
+# Preview deploy + e2e on open/reopen/synchronize lives here on Depot CI;
+# cleanup on close lives in cloudflare-preview-cleanup.yml. Depot CI picks up
+# jobs in ~7s where GitHub Actions runner assignment took 20s-3m39s (measured
+# 2026-07-02, once ~40min during a webhook incident).
 #
-# Deploy and cleanup share one workflow so the concurrency groups coordinate
-# them: closing a PR mid-deploy cancels the in-flight deploy run
-# (cancel-in-progress at the workflow level) and then runs cleanup — the two
-# never race the same preview slot. (When deploy ran on Depot and cleanup on
-# GitHub, a close during a run tore down the slot under the deploy.)
+# Cleanup is a SEPARATE workflow because every run of a workflow re-emits all
+# of its job check names on the head SHA: when deploy and cleanup shared this
+# file with complementary `if:`s, the `closed`-event run re-reported
+# "Preview / deploy + e2e" as skipped, clobbering the earlier success on every
+# merged PR (GitHub displays the latest check run per name). The two workflows
+# still coordinate through the same concurrency groups (copied verbatim in the
+# cleanup file): closing a PR mid-deploy cancels the in-flight deploy run
+# (cancel-in-progress on the shared workflow-level group) and the job-level
+# lifecycle group serializes whatever remains — the two never race the same
+# preview slot. (When deploy ran on Depot and cleanup on GitHub, a close
+# during a run tore down the slot under the deploy.)
 #
 # Depot registers automatic triggers when this file is on the default branch —
 # branch-only changes to the `on:` block do not take effect until merged. Test
@@ -29,15 +35,14 @@ name: Cloudflare Previews (Depot CI)
 # marking ready for review, or a manual dispatch (dispatch passes
 # --allow-draft below). The policy lives in scripts/preview/preview.ts
 # (decideDraftPreviewPolicy) where it's unit-tested; the trigger types beyond
-# open/reopen/synchronize/close just make sure the script runs whenever a
-# PR's draft or label state changes, so it can claim a slot or give one back.
+# open/reopen/synchronize just make sure the script runs whenever a PR's
+# draft or label state changes, so it can claim a slot or give one back.
 on:
   pull_request:
     types:
       - opened
       - reopened
       - synchronize
-      - closed
       - ready_for_review
       - converted_to_draft
       - labeled
@@ -76,8 +81,7 @@ jobs:
     # Label events for anything but the preview opt-in label change nothing
     # about the preview lifecycle — skip the checkout+install entirely.
     if: |-
-      github.event.action != 'closed' &&
-        (github.event.action != 'labeled' || github.event.label.name == 'preview') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'preview') &&
         (github.event.action != 'unlabeled' || github.event.label.name == 'preview')
     name: Preview / deploy + e2e
     # 8-core: the job is network-bound (waiting on deployed slots), not
@@ -142,37 +146,3 @@ jobs:
           path: test-results
           include-hidden-files: true
           if-no-files-found: ignore
-  cleanup:
-    if: github.event.action == 'closed'
-    name: Preview / cleanup
-    runs-on: depot-ubuntu-24.04
-    concurrency:
-      group: cloudflare-preview-lifecycle-${{ github.event.pull_request.number }}
-      cancel-in-progress: false
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-      - name: Install dependencies
-        run: pnpm install
-      - name: Install Doppler CLI
-        run: |-
-          for i in 1 2 3; do curl -sfLS https://cli.doppler.com/install.sh | sh -s -- --no-package-manager && break; echo "Attempt $i failed, retrying in 5s..."; sleep 5; done
-          doppler --version || { echo 'Failed to install Doppler CLI after 3 attempts'; exit 1; }
-      - name: Preview / cleanup
-        env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.ITERATE_BOT_GITHUB_TOKEN || github.token }}
-        run: |-
-          set -euo pipefail
-          doppler run --project _shared --config prd -- pnpm preview cleanup \
-            --github-token "$GITHUB_TOKEN" \
-            --pull-request-number "${{ github.event.pull_request.number }}"

--- a/apps/os/e2e/vitest/admin-project.itx.e2e.test.ts
+++ b/apps/os/e2e/vitest/admin-project.itx.e2e.test.ts
@@ -6,6 +6,7 @@
  */
 import { test } from "vitest";
 import { createTestProject } from "../test-support/create-test-project.ts";
+import { waitForCondition } from "../test-support/wait-for-condition.ts";
 import type { StreamEvent } from "../../src/domains/streams/schemas.ts";
 
 test("creates a disposable project and uses project streams through itx", async ({ expect }) => {
@@ -41,17 +42,23 @@ test("creates a disposable project and uses project streams through itx", async 
   expect(events.map((event) => event.type)).toContain(eventType);
   expect(events.find((event) => event.type === eventType)?.payload).toMatchObject({ marker });
 
-  await expect
-    .poll(() => seen.some((event) => event.type === eventType && event.payload?.marker === marker))
-    .toBe(true);
+  // waitForCondition, not expect.poll: expect.poll loses the test context on
+  // vitest retry in the CI-parallel lane and turns any first-attempt flake
+  // into a hard "expect.poll() must be called inside a test" failure. The
+  // timeouts keep expect.poll's 1s default deadline.
+  await waitForCondition(
+    () => seen.some((event) => event.type === eventType && event.payload?.marker === marker),
+    { description: "the subscription to deliver the appended event", timeoutMs: 1_000 },
+  );
 
   subscription.unsubscribe();
 
   // The project processor folds the new stream into its reduced state.
-  await expect
-    .poll(async () => {
+  await waitForCondition(
+    async () => {
       const snapshot = await itx.processor.snapshot();
       return snapshot.state.streams.some((item) => item.path === streamPath);
-    })
-    .toBe(true);
+    },
+    { description: "the project processor to fold the new stream into state", timeoutMs: 1_000 },
+  );
 });

--- a/apps/os/e2e/vitest/agent-tools.itx.e2e.test.ts
+++ b/apps/os/e2e/vitest/agent-tools.itx.e2e.test.ts
@@ -7,6 +7,7 @@
  */
 import { test } from "vitest";
 import { createTestProject } from "../test-support/create-test-project.ts";
+import { waitForCondition } from "../test-support/wait-for-condition.ts";
 
 const PROOF_STREAM = "/e2e/agent-tools-proof";
 const PROOF_TYPE = "events.iterate.test/agent-tools-proof";
@@ -32,18 +33,23 @@ test(
 
     // The reply may arrive before or after the script completes depending on
     // how the model ordered its actions — poll both effects independently.
+    // (waitForCondition, not expect.poll: expect.poll loses the test context
+    // on vitest retry in the CI-parallel lane and turns any first-attempt
+    // flake into a hard "expect.poll() must be called inside a test" failure.)
     using itx = handle.itx();
-    await expect
-      .poll(
-        async () => {
-          const events = await itx.streams.get(PROOF_STREAM).getEvents({});
-          return events.some(
-            (event) => event.type === PROOF_TYPE && event.payload?.marker === marker,
-          );
-        },
-        { interval: 1_000, timeout: 120_000 },
-      )
-      .toBe(true);
+    await waitForCondition(
+      async () => {
+        const events = await itx.streams.get(PROOF_STREAM).getEvents({});
+        return events.some(
+          (event) => event.type === PROOF_TYPE && event.payload?.marker === marker,
+        );
+      },
+      {
+        description: "the proof event to land on the target stream",
+        intervalMs: 1_000,
+        timeoutMs: 120_000,
+      },
+    );
 
     const agentEvents = await agent.stream.getEvents({ limit: 500 });
     const types = agentEvents.map((event) => event.type.replace("events.iterate.com/", ""));

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -79,8 +79,9 @@ describe("preview workflow scope", () => {
     expect(cloudflarePreviewSharedPaths).toContain("scripts/preview/**");
     expect(cloudflarePreviewSharedPaths).toContain("packages/ui/**");
     expect(cloudflarePreviewAdditionalTriggerPaths).toContain("apps/iterate-com/**");
-    // The preview lifecycle is one Depot CI workflow; a change to it triggers
-    // a full-fleet preview and must be mirrored in that file's own paths list.
+    // The preview deploy + e2e lifecycle is one Depot CI workflow (cleanup
+    // has its own, with mirrored paths); a change to it triggers a full-fleet
+    // preview and must be mirrored in that file's own paths list.
     expect(cloudflarePreviewSharedPaths).toContain(".depot/workflows/cloudflare-previews.yml");
     // Dependency manifests can change every app's build output; a diff that
     // touches only them must select the full fleet, not "no apps affected"

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -1162,9 +1162,10 @@ export const cloudflareAppSharedPaths = [
 ] as const;
 
 export const cloudflarePreviewSharedPaths = [
-  // The preview deploy + e2e + cleanup lifecycle is one Depot CI workflow.
-  // Keep this in sync with that file's own `on.pull_request.paths` list: a
-  // change to the workflow (or the shared preview orchestration) triggers a
+  // The preview deploy + e2e lifecycle is one Depot CI workflow; cleanup on
+  // close lives in cloudflare-preview-cleanup.yml, which mirrors the same
+  // paths. Keep this in sync with both files' `on.pull_request.paths` lists:
+  // a change to the workflow (or the shared preview orchestration) triggers a
   // full-fleet preview.
   ".depot/workflows/cloudflare-previews.yml",
   ...cloudflareAppSharedPaths,


### PR DESCRIPTION
Two independent CI/test hygiene fixes, both previously diagnosed.

## 1. Preview check-name clobber: split `cleanup` out of `cloudflare-previews.yml`

Diagnosis: https://github.com/iterate/iterate/pull/1789#issuecomment-4924765915

`cloudflare-previews.yml` hosted both the `preview` (deploy + e2e) job and the `cleanup` job with complementary `if:` conditions (`!= 'closed'` / `== 'closed'`). Every pull_request event run re-emits BOTH job check names on the head SHA, so the `closed`-event run after a merge re-reported **Preview / deploy + e2e** as *skipped*, clobbering the earlier *success* under GitHub's latest-check-run-per-name display — every merged PR falsely showed its preview as skipped.

The split:

- New `.depot/workflows/cloudflare-preview-cleanup.yml` with `on: pull_request: types: [closed]` and a paths list identical to the preview workflow's, holding the `cleanup` job unchanged (same job name, runner, steps, secrets).
- `closed` removed from `cloudflare-previews.yml`'s trigger types; the now-structural `action == 'closed'` / `!= 'closed'` conditions dropped. The draft/label gating in the preview job's `if:` is intact, as are all other trigger types (`ready_for_review`, `converted_to_draft`, `labeled`, `unlabeled`) and the `workflow_dispatch` lane.
- **Concurrency copied verbatim**: the cleanup workflow uses the identical workflow-level group (`cloudflare-previews-<pr>`, `cancel-in-progress: true`) and the identical job-level lifecycle group (`cloudflare-preview-lifecycle-<pr>`, `cancel-in-progress: false`), so a merge that lands mid-deploy still cancels the in-flight deploy run and serializes whatever remains — cleanup never races a deploy for the same preview slot, exactly as before.
- There is no notify/summary job in this workflow, so no `needs:` edges to rehome.
- Stale "one workflow" comments in `scripts/preview/preview.ts` / `preview.test.ts` updated; the paths-scope unit tests still pass (86/86).

**Caveat:** Depot registers automatic triggers from the DEFAULT branch — the new `closed` trigger (and the removal of `closed` from the preview workflow) only takes effect after this merges. Until then this PR's own close event still routes through the old registration.

## 2. Retry-poisoned `expect.poll` in the itx e2e suites

Diagnosis: https://github.com/iterate/iterate/pull/1792#issuecomment-4924950995

In the CI-parallel e2e lane, vitest `expect.poll()` loses the test context on retry and dies with `expect.poll() must be called inside a test` — any first-attempt flake becomes a hard failure. `streams.e2e.test.ts` was already converted in aad040446 (#1792); this converts the remaining sites to the house `waitForCondition` helper:

- `apps/os/e2e/vitest/agent-tools.itx.e2e.test.ts` — proof-event poll (kept `intervalMs: 1_000`, `timeoutMs: 120_000`)
- `apps/os/e2e/vitest/admin-project.itx.e2e.test.ts` — subscription-delivery and processor-snapshot polls (both used `expect.poll`'s implicit defaults, kept as explicit `timeoutMs: 1_000`)

All three were `.toBe(true)` on boolean predicates, so the predicates pass through unchanged. A sweep of `apps/os/e2e` finds no other `expect.poll` callers.

## Verification

- `pnpm typecheck` ✅, `pnpm format` ✅, oxlint clean (0 warnings/errors; ran with explicit `-c .oxlintrc.json` because this worktree is nested inside another checkout whose ancestor config shadows it — failure reproduces on clean `origin/main`, unrelated to this change)
- `scripts/preview/preview.test.ts` 86/86 ✅
- Both workflow YAMLs parse; concurrency group strings and paths lists verified byte-identical across the two files
- e2e suites intentionally not run locally — this PR's preview run exercises them on a real slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow split and test-helper swaps only; cleanup behavior and concurrency coordination are preserved, with no production runtime changes.
> 
> **Overview**
> Fixes two CI hygiene issues: **merged PRs falsely showing Preview / deploy + e2e as skipped**, and **itx e2e flakes turning into hard failures on Vitest retry**.
> 
> **Preview workflows:** Preview cleanup on PR close moves from `cloudflare-previews.yml` into new **`cloudflare-preview-cleanup.yml`** (`pull_request` `closed` only). The deploy workflow drops the `closed` trigger and the `cleanup` job so a close run no longer re-emits **Preview / deploy + e2e** as skipped on the head SHA. Concurrency groups and `paths` stay aligned with the deploy workflow; comments in `scripts/preview/preview.ts` and `preview.test.ts` note the two-workflow split.
> 
> **itx e2e:** `admin-project.itx.e2e.test.ts` and `agent-tools.itx.e2e.test.ts` replace **`expect.poll`** with **`waitForCondition`** so the CI-parallel lane does not hit `expect.poll() must be called inside a test` when Vitest retries after a first-attempt flake. Timeouts match the prior polls (including 120s for the agent proof-event wait).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d40d2d920e5eaeb58ba0c2312b9b90565bed29ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +34 -20 | +24 -18 🟩⬜⬜⬜⬜ |
| CI & scripts | +109 -51 | +101 -48 🟩🟩🟩🟥🟥 |
| **Total** | **+143 -71** | **+125 -66** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 7b0b074 and d40d2d9, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-09T18:12:14.932Z",
      "headSha": "d40d2d920e5eaeb58ba0c2312b9b90565bed29ff",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/199639559105798",
      "shortSha": "d40d2d9",
      "cleanupDurationMs": 11131,
      "deployDurationMs": 71466,
      "testDurationMs": 215606,
      "testRetries": "14 retried: itx > Authenticated internal auth itx can create project and append to stream (vitest x1) · itx > Project describe exposes self-describing builtin capabilities (vitest x1) · itx > Trusted internal root can access global streams and repos (vitest x1) · itx > Project egress substitutes path-addressed secrets for explicit and project worker fetches (vitest x1) · itx > Project egress intercept catches explicit and worker fetches before secret substitution (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · subscription and subscribe inputs are validated at the door (vitest x1) · stream subscribe replays history, tails live appends, and unsubscribes (vitest x1) · state-only stream subscribe pushes initial state immediately, then state after appends (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1) · project REPL accepts a forged session (specs x1) · reactivity page repaints from a stream subscription after a page action (specs x1) · reactivity page appends a batch and renders every delivered marker (specs x1) · a commented tsconfig still schema-validates (comments are tolerated) (specs x1)",
      "workerSizeKib": 15399.03,
      "workerGzipKib": 4161.3,
      "mainWorkerGzipKib": 4161.41
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-09T18:12:04.541Z",
      "headSha": "d40d2d920e5eaeb58ba0c2312b9b90565bed29ff",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/199639559105798",
      "shortSha": "d40d2d9",
      "cleanupDurationMs": 737,
      "deployDurationMs": 14521,
      "testDurationMs": 6884,
      "testRetries": null,
      "workerSizeKib": 1913.73,
      "workerGzipKib": 440.69,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-09T18:12:06.818Z",
      "headSha": "d40d2d920e5eaeb58ba0c2312b9b90565bed29ff",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/199639559105798",
      "shortSha": "d40d2d9",
      "cleanupDurationMs": 3011,
      "deployDurationMs": 20742,
      "testDurationMs": 622,
      "testRetries": null,
      "workerSizeKib": 3992.8,
      "workerGzipKib": 812.23,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-09T18:12:04.586Z",
      "headSha": "d40d2d920e5eaeb58ba0c2312b9b90565bed29ff",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/199639559105798",
      "shortSha": "d40d2d9",
      "cleanupDurationMs": 775,
      "deployDurationMs": 13733,
      "testDurationMs": 16503,
      "testRetries": null,
      "workerSizeKib": 4527.13,
      "workerGzipKib": 1305.64,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `d40d2d9` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 812.2 KiB | 20.7s | 622ms |  | 3.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/199639559105798) | 2026-07-09T18:12:06.818Z | Preview app released. |
| OS | released | `d40d2d9` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 4.06 MiB (-0.1 KiB vs main) | 71.5s | 215.6s | 14 retried: itx > Authenticated internal auth itx can create project and append to stream (vitest x1) · itx > Project describe exposes self-describing builtin capabilities (vitest x1) · itx > Trusted internal root can access global streams and repos (vitest x1) · itx > Project egress substitutes path-addressed secrets for explicit and project worker fetches (vitest x1) · itx > Project egress intercept catches explicit and worker fetches before secret substitution (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · subscription and subscribe inputs are validated at the door (vitest x1) · stream subscribe replays history, tails live appends, and unsubscribes (vitest x1) · state-only stream subscribe pushes initial state immediately, then state after appends (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1) · project REPL accepts a forged session (specs x1) · reactivity page repaints from a stream subscription after a page action (specs x1) · reactivity page appends a batch and renders every delivered marker (specs x1) · a commented tsconfig still schema-validates (comments are tolerated) (specs x1) | 11.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/199639559105798) | 2026-07-09T18:12:14.932Z | Preview app released. |
| Semaphore | released | `d40d2d9` | [https://semaphore.iterate-preview-7.com](https://semaphore.iterate-preview-7.com) | 440.7 KiB | 14.5s | 6.9s |  | 737ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/199639559105798) | 2026-07-09T18:12:04.541Z | Preview app released. |
| Streams Example App | released | `d40d2d9` | [https://streams.iterate-preview-7.com](https://streams.iterate-preview-7.com) | 1.28 MiB | 13.7s | 16.5s |  | 775ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/199639559105798) | 2026-07-09T18:12:04.586Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->