### PR TITLE
Streams: one drain for push+webhook, live-tail fast path, debounced checkpoint, cached dial roots, seek orthogonalized (v13)

### DIFF
--- a/apps/os/src/domains/streams/README.md
+++ b/apps/os/src/domains/streams/README.md
@@ -139,7 +139,8 @@ log):
     │  failure                              ▲ │ backoff min(30m, 1s·2^n) ±20% jitter,
     └───────────▶ retrying ─────────────────┘ │ one DO alarm = MIN(next_attempt_at)
                                               ▼
-                              parked ── subscription-resumed {afterOffset?} ──▶ active
+                              parked ── subscription-resumed ──▶ active
+                              (a redrive appends cursor-set first — resume is a pure un-park)
 ```
 
 Doctrine, worth memorizing:

--- a/apps/os/src/domains/streams/core-processor-contract.ts
+++ b/apps/os/src/domains/streams/core-processor-contract.ts
@@ -50,7 +50,11 @@ import { defineProcessorContract } from "./processor-contracts.ts";
 // - 12: dead derived state deleted — `processorsBySlug` (written on every
 //      connect fold, read by nothing; announcements live on presence facts)
 //      and `metadata` + its `metadata-updated` event (no appender, no reader).
-export const CORE_STATE_VERSION = 12;
+// - 13: seek verbs orthogonalized — `subscription-resumed` loses `afterOffset`
+//      (resume = pure un-park at the cursor where delivery stopped);
+//      `subscription-cursor-set` is the one and only seek. A redrive is two
+//      facts (cursor-set + resumed), each honest about what it did.
+export const CORE_STATE_VERSION = 13;
 
 // Restored from the old built-in circuit-breaker processor. These defaults are
 // intentionally high for normal browser/load tests; the breaker exists to stop
@@ -501,10 +505,9 @@ export const CoreProcessorContract = defineProcessorContract({
     },
     "events.iterate.com/stream/subscription-resumed": {
       description:
-        "Operator/agent verb: un-parks a subscription and kicks delivery. Optionally moves the cursor (`afterOffset`, exclusive) in the same act — the redrive.",
+        "Operator/agent verb: un-parks a subscription and kicks delivery, resuming at the cursor where it stopped. Moving the cursor is a different act with its own fact — append `subscription-cursor-set` first for a redrive (skip past a bad offset, replay a window).",
       payloadSchema: z.object({
         subscriptionKey: z.string().trim().min(1),
-        afterOffset: z.number().int().min(0).optional(),
       }),
       examples: [
         {
@@ -512,16 +515,11 @@ export const CoreProcessorContract = defineProcessorContract({
             "Un-parks a subscription after the receiver recovered; delivery resumes from the cursor where it stopped.",
           payload: { subscriptionKey: "ops-webhook" },
         },
-        {
-          description:
-            "The redrive: un-parks the project worker feed and moves the cursor past a bad offset in the same act.",
-          payload: { subscriptionKey: "project-worker", afterOffset: 1874 },
-        },
       ],
     },
     "events.iterate.com/stream/subscription-cursor-set": {
       description:
-        "Operator/agent verb: explicitly seeks a push subscription's cursor (exclusive afterOffset semantics: 0 replays everything). The audited form of replay — the cursor row itself is storage, but moving it deliberately is a fact.",
+        "Operator/agent verb: THE seek — explicitly moves a push subscription's cursor (exclusive afterOffset semantics: 0 replays everything). The audited form of replay — the cursor row itself is storage, but moving it deliberately is a fact. For a parked subscription, follow with `subscription-resumed` to restart delivery.",
       payloadSchema: z.object({
         subscriptionKey: z.string().trim().min(1),
         afterOffset: z.number().int().min(0),

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -81,7 +81,15 @@ export class StreamDurableObject extends DurableObject<Env> {
   readonly #subscribers = new StreamSubscribers({
     idleTeardownMs: idleTeardownMs(this.env),
     hooks: {
-      readEvents: (args) => this.getEvents(args),
+      // Straight to the sized log read: the spine wants byte lengths for its
+      // batch cap (getEvents would re-stringify to size a batch), and its
+      // limits are already bounded well under the public read clamp.
+      readEvents: (args) =>
+        this.#log.getRangeSized({
+          afterOffset: args.afterOffset,
+          beforeOffset: Number.MAX_SAFE_INTEGER,
+          limit: args.limit,
+        }),
       coreState: () => this.#coreProcessorState,
       store: this.#subscriptionCursorStore,
       dial: createSubscriberDial({
@@ -157,6 +165,7 @@ export class StreamDurableObject extends DurableObject<Env> {
     // post-commit fan-out; this call re-arms the alarm for the next due retry
     // (wake() itself only attempts rows whose backoff has elapsed).
     this.#subscribers.onAlarm();
+    this.#flushCoreProcessorState();
   }
 
   /**
@@ -268,10 +277,13 @@ export class StreamDurableObject extends DurableObject<Env> {
     // Output Gates hold responses until writes are durable:
     // https://developers.cloudflare.com/durable-objects/api/sql-storage/
     // https://blog.cloudflare.com/sqlite-in-durable-objects/
-    // Keep this section await-free: event rows + core state are the append boundary.
-    this.#log.insert(newEvents);
-    this.#writeCoreProcessorState(workingState);
+    // Keep this section await-free: event rows + core state are the append
+    // boundary. The KV state checkpoint is DEBOUNCED (see
+    // #checkpointCoreProcessorState) — event rows are the durable truth, and
+    // boot catch-up folds past a lagging checkpoint by design.
+    const byteLengths = this.#log.insert(newEvents);
     this.#coreProcessorState = workingState;
+    this.#checkpointCoreProcessorState(newEvents.length);
 
     // 3. Post-commit fan-out. Core side effects are fire-and-forget where
     // async, so nothing here can fail the append. One wake covers every lane:
@@ -279,9 +291,13 @@ export class StreamDurableObject extends DurableObject<Env> {
     // lagging push subscriptions drain. The spine triggers on WATERMARK LAG,
     // never on event types — a subscriber-disconnected fact whose teardown
     // pre-advanced the watermark reconciles to a no-op instead of needing the
-    // event-type carve-out the old reconciler carried.
+    // event-type carve-out the old reconciler carried. The wake hands over the
+    // just-committed events (sized by the log write) so caught-up consumers
+    // skip the per-lane SQLite re-read.
     for (const reduced of reducedEvents) this.#processEvent(reduced);
-    this.#subscribers.wake();
+    this.#subscribers.wake(
+      newEvents.map((event, index) => ({ event, byteLength: byteLengths[index]! })),
+    );
 
     // Re-arm (or clear) the idle timer against the post-append connection set,
     // so a stream that just went quiet sheds its durable delivery sessions
@@ -696,7 +712,7 @@ export class StreamDurableObject extends DurableObject<Env> {
           "events.iterate.com/stream/subscription-resumed",
           args.event,
         );
-        this.#subscribers.onResumed(event.payload.subscriptionKey, event.payload.afterOffset);
+        this.#subscribers.onResumed(event.payload.subscriptionKey);
         return;
       }
       case "events.iterate.com/stream/subscription-cursor-set": {
@@ -868,9 +884,48 @@ export class StreamDurableObject extends DurableObject<Env> {
   }
 
   #stateVersionWritten = false;
+  /** True while `#coreProcessorState` is ahead of the KV checkpoint. */
+  #checkpointDirty = false;
+  #eventsSinceCheckpoint = 0;
+  #checkpointWrittenAtMs = 0;
+  /** Debounce bounds: checkpoint at least every N events / T ms of appends. */
+  static readonly #CHECKPOINT_EVERY_EVENTS = 64;
+  static readonly #CHECKPOINT_MAX_LAG_MS = 1_000;
+
+  /**
+   * The debounced per-append checkpoint. Serializing the full core state into
+   * KV on EVERY append is O(state) write amplification per event — on a busy
+   * agent stream the state (config payloads, roster) easily outweighs the
+   * event. Event rows are the commit boundary and the durable truth; the KV
+   * checkpoint is a rebuild accelerator, and boot ALWAYS folds log rows past
+   * it (`#catchUpCoreProcessorState`, paged) — so a checkpoint that lags by a
+   * bounded window (64 events / 1s) costs a small constructor fold, never
+   * correctness. Alarm and idle teardown flush so a stream going quiet
+   * checkpoints before it hibernates.
+   */
+  #checkpointCoreProcessorState(newEventCount: number): void {
+    this.#eventsSinceCheckpoint += newEventCount;
+    const now = Date.now();
+    if (
+      this.#eventsSinceCheckpoint < StreamDurableObject.#CHECKPOINT_EVERY_EVENTS &&
+      now - this.#checkpointWrittenAtMs < StreamDurableObject.#CHECKPOINT_MAX_LAG_MS
+    ) {
+      this.#checkpointDirty = true;
+      return;
+    }
+    this.#writeCoreProcessorState(this.#coreProcessorState);
+  }
+
+  /** Write the checkpoint now if the in-memory state is ahead of it. */
+  #flushCoreProcessorState(): void {
+    if (this.#checkpointDirty) this.#writeCoreProcessorState(this.#coreProcessorState);
+  }
 
   #writeCoreProcessorState(state: CoreProcessorState): void {
     this.ctx.storage.kv.put("state", state);
+    this.#checkpointDirty = false;
+    this.#eventsSinceCheckpoint = 0;
+    this.#checkpointWrittenAtMs = Date.now();
     // The version is a constant per deploy; re-putting it on every append is
     // pure write amplification. Once per incarnation is exactly as durable.
     if (!this.#stateVersionWritten) {
@@ -1097,6 +1152,9 @@ export class StreamDurableObject extends DurableObject<Env> {
   /** Sever every idle durable connection now — the idle timer's action, exposed for tests/operators. */
   runIdleTeardownNow(): void {
     this.#subscribers.runIdleTeardownNow();
+    // A stream going quiet checkpoints before it hibernates, so the next wake
+    // rebuilds from a fresh checkpoint instead of folding the debounce window.
+    this.#flushCoreProcessorState();
   }
 
   /**

--- a/apps/os/src/domains/streams/stream-storage.test.ts
+++ b/apps/os/src/domains/streams/stream-storage.test.ts
@@ -95,6 +95,29 @@ describe("StreamEventLog.getRange", () => {
     expect(read(log, { afterOffset: 0, eventTypes: [], limit: 3 })).toEqual([]);
   });
 
+  it("insert reports serialized byte lengths and getRangeSized reads the same sizes back", () => {
+    const log = new StreamEventLog(wrapSqlStorage(new DatabaseSync(":memory:")), "/tests/stream");
+    const committedEvents = [
+      event(1, "events.iterate.com/test/sized"),
+      event(2, "events.iterate.com/test/sized"),
+    ];
+
+    const insertedByteLengths = log.insert(committedEvents);
+    expect(insertedByteLengths).toEqual(
+      committedEvents.map((entry) => new TextEncoder().encode(JSON.stringify(entry)).byteLength),
+    );
+
+    // The sized read sums the chunk rows already in hand — no re-stringify —
+    // and must agree exactly with what insert serialized.
+    const sized = log.getRangeSized({
+      afterOffset: 0,
+      beforeOffset: Number.MAX_SAFE_INTEGER,
+      limit: 10,
+    });
+    expect(sized.map((entry) => entry.byteLength)).toEqual(insertedByteLengths);
+    expect(sized.map((entry) => entry.event)).toEqual(committedEvents);
+  });
+
   it("adds the stream path when reading legacy stored events", () => {
     const sql = wrapSqlStorage(new DatabaseSync(":memory:"));
     const log = new StreamEventLog(sql, "/legacy/stream");

--- a/apps/os/src/domains/streams/stream-storage.ts
+++ b/apps/os/src/domains/streams/stream-storage.ts
@@ -26,6 +26,13 @@ import { StreamEvent as StreamEventSchema } from "./schemas.ts";
 const EVENT_CHUNK_SIZE = 512 * 1024;
 const textEncoder = new TextEncoder();
 
+/**
+ * A committed event paired with its serialized byte length (the exact bytes
+ * stored in `event_chunks`). Delivery batching sizes batches against the byte
+ * cap with these instead of re-stringifying every event on every read.
+ */
+export type SizedStreamEvent = { event: StreamEvent; byteLength: number };
+
 export class StreamEventLog {
   constructor(
     readonly sql: SqlStorage,
@@ -62,7 +69,13 @@ export class StreamEventLog {
     );
   }
 
-  insert(events: readonly StreamEvent[]): void {
+  /**
+   * Returns each event's serialized byte length (the exact bytes written to
+   * `event_chunks`), so the commit path can hand delivery fan-out a sized
+   * fresh tail without anyone re-stringifying what was just serialized here.
+   */
+  insert(events: readonly StreamEvent[]): number[] {
+    const byteLengths: number[] = [];
     for (const event of events) {
       this.sql.exec(
         "insert into events (offset, type, created_at, idempotency_key) values (?, ?, ?, ?)",
@@ -72,6 +85,7 @@ export class StreamEventLog {
         event.idempotencyKey ?? null,
       );
       const rawJsonBytes = textEncoder.encode(JSON.stringify(event));
+      byteLengths.push(rawJsonBytes.byteLength);
       for (const [chunkIndex, chunk] of chunkBytes(rawJsonBytes, EVENT_CHUNK_SIZE)) {
         this.sql.exec(
           "insert into event_chunks (offset, chunk_index, chunk_bytes) values (?, ?, ?)",
@@ -81,6 +95,7 @@ export class StreamEventLog {
         );
       }
     }
+    return byteLengths;
   }
 
   getByOffset(offset: number): StreamEvent | undefined {
@@ -106,6 +121,20 @@ export class StreamEventLog {
     eventTypes?: readonly string[];
     limit: number;
   }): StreamEvent[] {
+    return this.getRangeSized(args).map((sized) => sized.event);
+  }
+
+  /**
+   * `getRange` plus each event's serialized byte length, summed from the
+   * chunk rows already in hand — so delivery batching can enforce its byte
+   * cap without re-stringifying every event it just parsed.
+   */
+  getRangeSized(args: {
+    afterOffset: number;
+    beforeOffset: number;
+    eventTypes?: readonly string[];
+    limit: number;
+  }): SizedStreamEvent[] {
     if (args.eventTypes?.length === 0) return [];
     const eventTypes =
       args.eventTypes === undefined || args.eventTypes.includes("*") ? undefined : args.eventTypes;
@@ -144,7 +173,10 @@ export class StreamEventLog {
         eventChunks.push(chunk.chunkBytes);
       }
     }
-    return [...chunksByOffset.values()].map((eventChunks) => this.#parseEvent(eventChunks));
+    return [...chunksByOffset.values()].map((eventChunks) => ({
+      event: this.#parseEvent(eventChunks),
+      byteLength: eventChunks.reduce((sum, chunk) => sum + chunk.byteLength, 0),
+    }));
   }
 
   #readEventFromChunks(offset: number): StreamEvent {
@@ -420,9 +452,12 @@ function* chunkBytes(value: Uint8Array, chunkSize: number): Generator<[number, A
   if (chunkIndex === 0) yield [0, new ArrayBuffer(0)];
 }
 
+// Shared across calls: each decode sequence runs synchronously to its final
+// flush inside the single-threaded DO, so no two decodes can interleave.
+const chunkDecoder = new TextDecoder();
+
 function decodeChunks(chunks: ArrayBuffer[]): string {
-  const textDecoder = new TextDecoder();
   let value = "";
-  for (const chunk of chunks) value += textDecoder.decode(chunk, { stream: true });
-  return value + textDecoder.decode();
+  for (const chunk of chunks) value += chunkDecoder.decode(chunk, { stream: true });
+  return value + chunkDecoder.decode();
 }

--- a/apps/os/src/domains/streams/stream-subscribers.teardown.test.ts
+++ b/apps/os/src/domains/streams/stream-subscribers.teardown.test.ts
@@ -116,7 +116,10 @@ function makeFaithfulHarness(pokeImpl?: PokeImpl) {
     idleTeardownMs: 60_000,
     hooks: {
       readEvents: ({ afterOffset, limit }) =>
-        log.filter((event) => event.offset > afterOffset).slice(0, limit),
+        log
+          .filter((event) => event.offset > afterOffset)
+          .slice(0, limit)
+          .map((event) => ({ event, byteLength: JSON.stringify(event).length })),
       coreState: () =>
         CoreProcessorContract.stateSchema.parse({
           projectId: "p1",

--- a/apps/os/src/domains/streams/stream-subscribers.test.ts
+++ b/apps/os/src/domains/streams/stream-subscribers.test.ts
@@ -194,11 +194,17 @@ function makeHarness() {
     },
   };
 
+  let storageReads = 0;
   const subscribers = new StreamSubscribers({
     idleTeardownMs: 60_000,
     hooks: {
-      readEvents: ({ afterOffset, limit }) =>
-        log.filter((event) => event.offset > afterOffset).slice(0, limit),
+      readEvents: ({ afterOffset, limit }) => {
+        storageReads += 1;
+        return log
+          .filter((event) => event.offset > afterOffset)
+          .slice(0, limit)
+          .map((event) => ({ event, byteLength: JSON.stringify(event).length }));
+      },
       coreState: (): CoreProcessorState =>
         CoreProcessorContract.stateSchema.parse({
           projectId: "p1",
@@ -249,6 +255,7 @@ function makeHarness() {
     log,
     settle,
     append: (...events: StreamEvent[]) => log.push(...events),
+    storageReads: () => storageReads,
     now: () => now,
     advanceTo: (ms: number) => {
       now = ms;
@@ -482,7 +489,7 @@ describe("StreamSubscribers", () => {
     expect(h.configured["k"].parkedAtOffset).toBe(0);
   });
 
-  it("e. resume: onResumed retries immediately; onResumed with afterOffset seeks the cursor", async () => {
+  it("e. resume: onResumed retries immediately; a redrive is cursor-set then resume", async () => {
     const h = makeHarness();
     h.configure(pushPayload(), 0);
     h.append(evt(1, "a"), evt(2, "b"));
@@ -504,8 +511,10 @@ describe("StreamSubscribers", () => {
     expect(h.pushes.at(-1)?.attempt).toBe(1);
     expect(h.row("k")).toMatchObject({ ackedOffset: 2, attempt: 0, nextAttemptAt: null });
 
-    // Resume with afterOffset is the redrive: the cursor seeks first.
-    h.subscribers.onResumed("k", 0);
+    // The redrive is two facts, each honest about what it did: cursor-set is
+    // THE seek, resume is a pure un-park (v13 orthogonalization).
+    h.subscribers.onCursorSet("k", 0);
+    h.subscribers.onResumed("k");
     await h.settle();
     expect(h.pushes).toHaveLength(MAX_DELIVERY_ATTEMPTS + 2);
     expect(h.pushes.at(-1)?.events.map((event) => event.offset)).toEqual([1, 2]);
@@ -1148,5 +1157,40 @@ describe("StreamSubscribers", () => {
     expect(conditionFacts).toHaveLength(1);
     expect(conditionFacts[0]!.idempotencyKey).toBe("selector-condition-failed:k:1");
     expect(h.row("k")?.ackedOffset).toBe(2);
+  });
+
+  it("w. live-tail fast path: a caught-up drain consumes the handed-over tail without a storage read", async () => {
+    const h = makeHarness();
+    h.configure(pushPayload(), 0);
+
+    // Append hands the freshly committed events to wake() — the tailing drain
+    // (cursor 0, tail starts at offset 1) must deliver them without ever
+    // touching hooks.readEvents... except for the one catch-up read that
+    // proves it drained to the tail (the loop's final "caught up" probe reads
+    // an empty window THROUGH the tail check, which self-disqualifies there).
+    const fresh = [evt(1, "a"), evt(2, "b")];
+    h.append(...fresh);
+    h.subscribers.wake(fresh.map((event) => ({ event, byteLength: 64 })));
+    await h.settle();
+
+    expect(h.pushes).toHaveLength(1);
+    expect(h.pushes[0]!.events.map((event) => event.offset)).toEqual([1, 2]);
+    expect(h.row("k")?.ackedOffset).toBe(2);
+    // Exactly one storage read: the empty caught-up probe after the tail was
+    // consumed. The delivered batch itself came from the handed-over events.
+    expect(h.storageReads()).toBe(1);
+
+    // A STALE tail self-disqualifies by offset: the next append reaches the
+    // drain without a handover (offset 3 ≠ stale tail's first offset 1), so
+    // the batch falls back to a storage read. Correctness never depends on
+    // tail freshness.
+    h.append(evt(3, "c"));
+    const readsBefore = h.storageReads();
+    h.subscribers.wake();
+    await h.settle();
+    expect(h.pushes).toHaveLength(2);
+    expect(h.pushes[1]!.events.map((event) => event.offset)).toEqual([3]);
+    expect(h.row("k")?.ackedOffset).toBe(3);
+    expect(h.storageReads()).toBeGreaterThan(readsBefore);
   });
 });

--- a/apps/os/src/domains/streams/stream-subscribers.ts
+++ b/apps/os/src/domains/streams/stream-subscribers.ts
@@ -50,7 +50,7 @@ import type {
 } from "./core-processor-contract.ts";
 import { StreamSubscriberDescriptor as StreamSubscriberDescriptorSchema } from "./core-processor-contract.ts";
 import { compileEventSelector, type CompiledEventSelector } from "./event-selector.ts";
-import type { SubscriptionCursorStore } from "./stream-storage.ts";
+import type { SizedStreamEvent, SubscriptionCursorStore } from "./stream-storage.ts";
 import {
   retainGetProcessorRuntimeState,
   retainProcessEventBatch,
@@ -164,8 +164,12 @@ export type SubscriberDial = {
 
 /** The policy/storage seams the owning Stream Durable Object provides. */
 type StreamSubscribersHooks = {
-  /** Synchronous committed-event range read from stream storage. */
-  readEvents(args: { afterOffset: number; limit: number }): StreamEvent[];
+  /**
+   * Synchronous committed-event range read from stream storage, sized: each
+   * event arrives with its serialized byte length so batch construction can
+   * enforce the byte cap without re-stringifying what storage just parsed.
+   */
+  readEvents(args: { afterOffset: number; limit: number }): SizedStreamEvent[];
   /** Current core reduced state, read in the same synchronous block as each delivery. */
   coreState(): CoreProcessorState;
   /** The spine's durable cursor rows (SQLite next to the event log). */
@@ -233,11 +237,27 @@ export class StreamSubscribers {
   // ===========================================================================
 
   /**
+   * The just-committed events of the most recent append, handed over by the
+   * commit path so caught-up pumps and drains consume them directly instead
+   * of re-reading (and re-parsing) them from SQLite once per delivery lane.
+   * Correctness is offset-gated, never freshness-gated: `#readBatch` uses the
+   * tail only when its first offset is exactly `afterOffset + 1`, so a stale
+   * tail (more appends since, a rewound cursor) either still IS the right
+   * contiguous window or self-disqualifies and falls back to storage.
+   */
+  #freshTail: SizedStreamEvent[] = [];
+
+  /**
    * Re-arm every live connection's pump and reconcile durable subscriptions
    * (poke lagging wake subscribers without a connection, drain lagging push
    * subscriptions that are due). Never throws; never blocks the append.
+   *
+   * `freshTail` is the live-tail fast path: append passes what it just
+   * committed (already sized by the log write) so tailing consumers skip the
+   * storage round trip.
    */
-  wake(): void {
+  wake(freshTail?: SizedStreamEvent[]): void {
+    if (freshTail !== undefined && freshTail.length > 0) this.#freshTail = freshTail;
     for (const connection of this.#connections.values()) connection.wake();
     if (this.#tearingDown) return;
     try {
@@ -451,10 +471,21 @@ export class StreamSubscribers {
           if (row === undefined) return;
           if (row.nextAttemptAt !== null && row.nextAttemptAt > this.#hooks.now()) return;
 
-          const limit = Math.min(
-            this.#batchLimits.get(subscriptionKey) ?? DELIVERY_BATCH_LIMIT,
-            DELIVERY_BATCH_LIMIT,
-          );
+          // Webhook mode IS the push drain pinned to batch size 1: external
+          // receivers get single-event POSTs, each ack covers exactly one
+          // offset (mid-batch resume for free), the poison machinery always
+          // sees the true delivery unit (bisecting is structurally moot), and
+          // the per-iteration staleness checks above run per EVENT — a
+          // removed/replaced webhook can never keep POSTing a stale batch to
+          // the old URL. The cost is one row/config re-read per event on a
+          // backlog, noise against the HTTP POST itself.
+          const limit =
+            config.delivery.mode === "webhook"
+              ? 1
+              : Math.min(
+                  this.#batchLimits.get(subscriptionKey) ?? DELIVERY_BATCH_LIMIT,
+                  DELIVERY_BATCH_LIMIT,
+                );
           const events = this.#readBatch(row.ackedOffset, limit);
           const lastOffset = events.at(-1)?.offset;
           if (lastOffset === undefined) return; // caught up
@@ -478,77 +509,38 @@ export class StreamSubscribers {
             payload: entry.latestConfiguredEvent.payload,
           };
 
-          if (config.delivery.mode === "webhook") {
-            if (state.projectId === null) return; // unreachable: rejected at append (egress attribution)
-            // Webhook delivery is per EVENT on the same cursor machinery: each
-            // 2xx acks that single offset, so a failure mid-batch resumes at
-            // the exact event that failed. The poison machinery sees the true
-            // delivery unit (one event), which makes bisecting moot — a
-            // webhook "batch" is already its own poison isolate.
-            const url = config.delivery.url;
-            for (const event of matched) {
-              // Re-check the config per EVENT: the outer loop's staleness
-              // checks run per batch, and a removed/replaced webhook must not
-              // keep POSTing the rest of a 100-event batch to the old URL.
-              const currentEntry =
-                this.#hooks.coreState().configuredSubscribersByKey[subscriptionKey];
-              if (
-                currentEntry === undefined ||
-                currentEntry.parkedAtOffset !== undefined ||
-                currentEntry.latestConfiguredEvent.offset !== entry.latestConfiguredEvent.offset
-              ) {
-                return; // whatever changed it already re-reconciled
-              }
-              const attempt = (this.#hooks.store.get(subscriptionKey)?.attempt ?? 0) + 1;
-              try {
-                await withDeliveryTimeout(
-                  this.#hooks.dial.webhook(url, {
-                    projectId: state.projectId,
-                    path: state.path,
-                    event,
-                    subscriptionKey,
-                    deliveryId: deliveryId(subscriptionKey, event.offset, event.offset),
-                    attempt,
-                    configuredEvent,
-                  }),
-                  `webhook ${subscriptionKey}`,
-                );
-              } catch (error) {
-                // "continue" = confirmed poison stepped over (and acked);
-                // "stop" = backed off or parked — the alarm/resume owns the
-                // future, and everything delivered so far is already acked.
-                if (
-                  this.#onPushFailure({ subscriptionKey, config, matched: [event], error }) ===
-                  "continue"
-                ) {
-                  continue;
-                }
-                return;
-              }
-              this.#hooks.store.ack(subscriptionKey, event.offset, row.epoch);
-              this.#consecutiveSkips.delete(subscriptionKey);
-            }
-            // Cover any trailing non-matching events the selector skipped.
-            this.#hooks.store.ack(subscriptionKey, lastOffset, row.epoch);
-            continue;
-          }
-
-          const batch: StreamPushEventBatch = {
-            projectId: state.projectId,
-            path: state.path,
-            events: matched,
-            streamMaxOffset: state.maxOffset,
-            subscriptionKey,
-            deliveryId: deliveryId(subscriptionKey, matched[0]!.offset, lastOffset),
-            attempt: row.attempt + 1,
-            configuredEvent,
-          };
-
           try {
-            await withDeliveryTimeout(
-              this.#hooks.dial.push(config.delivery.expression, batch),
-              `push ${subscriptionKey}`,
-            );
+            if (config.delivery.mode === "webhook") {
+              if (state.projectId === null) return; // unreachable: rejected at append (egress attribution)
+              await withDeliveryTimeout(
+                this.#hooks.dial.webhook(config.delivery.url, {
+                  projectId: state.projectId,
+                  path: state.path,
+                  // Exactly one: the batch-limit-1 read above IS webhook mode.
+                  event: matched[0]!,
+                  subscriptionKey,
+                  deliveryId: deliveryId(subscriptionKey, matched[0]!.offset, lastOffset),
+                  attempt: row.attempt + 1,
+                  configuredEvent,
+                }),
+                `webhook ${subscriptionKey}`,
+              );
+            } else {
+              const batch: StreamPushEventBatch = {
+                projectId: state.projectId,
+                path: state.path,
+                events: matched,
+                streamMaxOffset: state.maxOffset,
+                subscriptionKey,
+                deliveryId: deliveryId(subscriptionKey, matched[0]!.offset, lastOffset),
+                attempt: row.attempt + 1,
+                configuredEvent,
+              };
+              await withDeliveryTimeout(
+                this.#hooks.dial.push(config.delivery.expression, batch),
+                `push ${subscriptionKey}`,
+              );
+            }
           } catch (error) {
             // "continue" = the failure handler already moved the goalposts
             // (halved the bisect window or stepped over confirmed poison) and
@@ -559,11 +551,11 @@ export class StreamSubscribers {
             }
             return;
           }
-          // Fenced on the epoch read above: a seek (cursor-set, resume-with-
-          // offset, replacement deliver, remove+recreate) that landed while
-          // this delivery was in flight bumped the epoch, and this ack no-ops
-          // instead of clobbering it — the next iteration re-reads the row
-          // and drains from wherever the seek pointed.
+          // Fenced on the epoch read above: a seek (cursor-set, replacement
+          // deliver, remove+recreate) that landed while this delivery was in
+          // flight bumped the epoch, and this ack no-ops instead of
+          // clobbering it — the next iteration re-reads the row and drains
+          // from wherever the seek pointed.
           this.#hooks.store.ack(subscriptionKey, lastOffset, row.epoch);
           this.#batchLimits.delete(subscriptionKey);
           this.#consecutiveSkips.delete(subscriptionKey);
@@ -579,16 +571,29 @@ export class StreamSubscribers {
     );
   }
 
-  /** Read up to `limit` events after `afterOffset`, shrinking under the byte cap. */
+  /**
+   * Read up to `limit` events after `afterOffset`, shrinking under the byte
+   * cap. A reader positioned exactly at the last commit's tail consumes the
+   * handed-over fresh events instead of re-reading them from SQLite — the
+   * committed objects are byte-for-byte what a read-back would parse (append
+   * strict-parses the body and stamps `path` before commit).
+   */
   #readBatch(afterOffset: number, limit: number): StreamEvent[] {
-    const events = this.#hooks.readEvents({ afterOffset, limit });
-    if (events.length <= 1) return events;
+    const sized =
+      this.#freshTail[0]?.event.offset === afterOffset + 1
+        ? this.#freshTail.length > limit
+          ? this.#freshTail.slice(0, limit)
+          : this.#freshTail
+        : this.#hooks.readEvents({ afterOffset, limit });
+    if (sized.length <= 1) return sized.map((entry) => entry.event);
     let bytes = 0;
-    for (let index = 0; index < events.length; index += 1) {
-      bytes += JSON.stringify(events[index]).length;
-      if (bytes > DELIVERY_BATCH_BYTE_LIMIT && index > 0) return events.slice(0, index);
+    for (let index = 0; index < sized.length; index += 1) {
+      bytes += sized[index]!.byteLength;
+      if (bytes > DELIVERY_BATCH_BYTE_LIMIT && index > 0) {
+        return sized.slice(0, index).map((entry) => entry.event);
+      }
     }
-    return events;
+    return sized.map((entry) => entry.event);
   }
 
   /**
@@ -799,14 +804,15 @@ export class StreamSubscribers {
     this.wake();
   }
 
-  /** A `subscription-resumed` fact committed: un-park (the fold already cleared it) and kick. */
-  onResumed(subscriptionKey: string, afterOffset?: number): void {
-    if (afterOffset !== undefined) {
-      this.#hooks.store.setCursor(subscriptionKey, afterOffset);
-    } else {
-      const row = this.#hooks.store.get(subscriptionKey);
-      if (row !== undefined) this.#hooks.store.ack(subscriptionKey, row.ackedOffset);
-    }
+  /**
+   * A `subscription-resumed` fact committed: un-park (the fold already
+   * cleared it), clear the backoff/failure streak, and kick. Resume is a PURE
+   * un-park — moving the cursor is `subscription-cursor-set`'s job, its own
+   * fact; a redrive appends both.
+   */
+  onResumed(subscriptionKey: string): void {
+    const row = this.#hooks.store.get(subscriptionKey);
+    if (row !== undefined) this.#hooks.store.ack(subscriptionKey, row.ackedOffset);
     this.#consecutiveSkips.delete(subscriptionKey);
     this.#batchLimits.delete(subscriptionKey);
     this.wake();

--- a/apps/os/src/domains/streams/subscriber-sinks.ts
+++ b/apps/os/src/domains/streams/subscriber-sinks.ts
@@ -231,6 +231,38 @@ export function createSubscriberDial(deps: {
     }
   };
 
+  /**
+   * The push lane's CACHED authority root. The authority is the ambient
+   * trusted context at the stream's own fixed scope — there is nothing
+   * per-delivery to re-derive — so re-minting the loopback chain (an awaited
+   * RPC round trip plus target-graph construction) on every batch bought
+   * nothing and sat directly on the ack latency path; at trickle rates every
+   * append paid it. Any delivery failure disposes the chain and the next
+   * attempt re-mints (bounds a wedged chain); the chain is same-isolate, so
+   * holding it pins memory, not cross-isolate duration. The WAKE lane stays
+   * per-acquisition: its chain's lifetime is tied to the sink the poke
+   * returns (see `onDisposed` below).
+   */
+  let pushRoot: Promise<{ root: unknown; dispose: () => void }> | undefined;
+  const acquirePushRoot = () => {
+    if (pushRoot === undefined) {
+      const acquiring = acquireAuthorityRoot();
+      pushRoot = acquiring;
+      // A failed mint must not cache a forever-rejected promise.
+      acquiring.catch(() => {
+        if (pushRoot === acquiring) pushRoot = undefined;
+      });
+    }
+    return pushRoot;
+  };
+  const invalidatePushRoot = (chain: Promise<{ root: unknown; dispose: () => void }>) => {
+    if (pushRoot === chain) pushRoot = undefined;
+    void chain.then((acquired) => acquired.dispose()).catch(() => {});
+  };
+
+  /** The webhook lane's cached project-egress fetcher (same policy as `pushRoot`). */
+  let webhookEgress: ReturnType<typeof projectEgressFetcher> | undefined;
+
   return {
     /**
      * One poke: evaluate the wake expression to the handshake response —
@@ -271,14 +303,20 @@ export function createSubscriberDial(deps: {
      * `["streams", ["get", path], "ingest"]` reaches a sibling stream —
      * through exactly the calls ordinary user code would make. The
      * awaited resolve is the ack; a reject propagates to the spine's
-     * retry/park machine.
+     * retry/park machine. The authority root is cached across deliveries and
+     * dropped on failure (see `acquirePushRoot`).
      */
     async push(expression: ItxExpression, batch: StreamPushEventBatch) {
-      const { root, dispose } = await acquireAuthorityRoot();
+      const chain = acquirePushRoot();
+      const { root } = await chain;
       try {
         await evaluateItxExpression(root, toInvocation(expression, batch));
-      } finally {
-        dispose();
+      } catch (error) {
+        // The failure may BE a broken chain; drop it so the retry re-mints.
+        // A concurrent delivery mid-evaluate on the same chain fails with it
+        // and retries on a fresh one — the spine's backoff owns both.
+        invalidatePushRoot(chain);
+        throw error;
       }
     },
 
@@ -298,10 +336,14 @@ export function createSubscriberDial(deps: {
       if (deps.projectId === null) {
         throw new Error("webhook subscriptions require a project-scoped stream");
       }
-      const egress = projectEgressFetcher(
+      // Cached like the push root (webhook drains deliver per EVENT, so a
+      // per-POST loopback mint would be paid at the highest possible rate);
+      // any failure drops it and the retry re-mints.
+      webhookEgress ??= projectEgressFetcher(
         deps.exports as ExecutionContext["exports"],
         deps.projectId,
       );
+      const egress = webhookEgress;
       try {
         const response = await egress.fetch(url, {
           method: "POST",
@@ -313,9 +355,10 @@ export function createSubscriberDial(deps: {
         if (!response.ok) {
           throw new Error(`webhook responded ${response.status} ${response.statusText}`);
         }
-      } finally {
-        // The egress fetcher is a per-acquisition loopback stub.
+      } catch (error) {
+        if (webhookEgress === egress) webhookEgress = undefined;
         (egress as Partial<Disposable>)[Symbol.dispose]?.();
+        throw error;
       }
     },
   };


### PR DESCRIPTION
The remaining deep-review items judged worth taking (from the [findings report](https://github.com/iterate/iterate/pull/1787) deferred in #1792), in one PR as requested. Core state bumps to **v13**; deployed envs need the usual erase/reset (previews erase on entry, prd gets an erase + redeploy after merge).

## Drain unification (report 5)

**Webhook mode is now literally the push drain pinned to batch size 1.** The 50-line inner per-event loop (its own attempt read, timeout wrap, failure call, per-event config re-check, trailing ack) is deleted; the mode differs only in which dial the delivery step calls. Everything the inner loop hand-implemented falls out of the ordinary path structurally: per-event acks (mid-batch resume), poison-bisect mootness, retry-stable deliveryIds, and — the part that used to be a bug (#1792's stale-URL fix) — per-event staleness checks, because each loop iteration now IS one event. Cost: one row/config re-read per event on a webhook backlog, noise against the HTTP POST itself.

## Perf (report items 2, 3-full, 5 — the review's biggest hot-path costs)

- **Live-tail fast path.** Append hands the just-committed events (already sized by the log write) to `wake()`; any caught-up consumer whose cursor sits exactly at the tail consumes them directly instead of re-reading + re-parsing them from SQLite once per delivery lane. Correctness is offset-gated, never freshness-gated: a stale tail self-disqualifies and falls back to storage (scenario `w` pins both paths, counting storage reads).
- **Byte accounting from the log.** `insert()` returns each event's serialized byte length and `getRangeSized()` sums the chunk rows already in hand, so the drain's batch byte cap no longer `JSON.stringify`s every event on every read (at the 1MB cap that alone was ~1.4ms per batch, serialized into delivery latency).
- **Debounced core-state checkpoint.** The KV `state` put — O(state) serialization per append, the review's measured 2–50MB/s of redundant write amplification at volume — now writes at most once per 64 events / 1s, flushed on alarm and idle teardown. Event rows remain the commit boundary and the durable truth; boot already folds log rows past a lagging checkpoint (`#catchUpCoreProcessorState`, paged) — a bounded-window checkpoint costs a small constructor fold, never correctness.
- **Cached push authority root + webhook egress fetcher.** The push dial minted a fresh loopback binding + itx root per delivery — an awaited RPC round trip on the ack latency path, paid per append at trickle rates. The authority is the ambient trusted context at the stream's own fixed scope (nothing per-delivery to re-derive), so the chain is cached and dropped on any delivery failure (retry re-mints). The wake lane deliberately stays per-acquisition: its chain's lifetime is tied to the sink the poke returns.
- Freebie from the review: `decodeChunks` reuses one module-level `TextDecoder`.

## Seek orthogonalization (report 6, v13)

Seek was spelled three ways. Now: **`subscription-cursor-set` is THE seek; `subscription-resumed` is a pure un-park** (its `afterOffset` is gone). A redrive appends both facts, each honest about what it did — no more "resumed" events on subscriptions that were never parked, and the audit log distinguishes "operator seeked" from "operator un-parked". (`deliver` on a replacement config stays: that's declarative initial-cursor policy carried by the config itself, not an imperative seek.)

## Deliberately NOT taken

- **In-memory cursor-row mirror (perf 4)** — a write-through cache inside the class that performs all the writes is an invalidation bug farm; deferred until profiling says the 2 no-op SQL statements/subscription/append matter.
- **Schema tweaks from perf 7** (drop AUTOINCREMENT/FK) — table-shape churn for 5–15ms/s at extreme rates; not worth it now.

## Test plan

- [x] New scenario `w` (live-tail fast path: tail consumed with zero batch storage reads; stale tail self-disqualifies), storage sized-read test (insert byte lengths == sized read-back), scenario `e` rewritten to the two-fact redrive
- [x] All existing webhook scenarios (`o`, `p`, `q`) pass unchanged through the collapsed drain — per-event acks, mid-batch resume, poison isolation
- [x] 783 apps/os unit tests green; tsc/lint/format/knip clean; itx api regenerated (no public contract drift)
- [x] Fresh-state local e2e: lifecycle + streams + wire green; wire numbers hold or improve (baseline p50 1.8ms)

Debounce flush-on-alarm/teardown has no node harness to pin it (the DO isn't unit-instantiable); its safety net — paged catch-up past a stale checkpoint — is existing tested behavior, and a missed flush costs a bounded constructor fold, not correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the durable delivery spine, append fan-out, and a breaking v13 event shape for `subscription-resumed`; mitigated by extensive unit tests and existing log replay on version mismatch, but deployed streams need the planned state reset.
> 
> **Overview**
> **Core state v13** splits seek from resume: `subscription-resumed` is only an un-park (optional `afterOffset` removed); **`subscription-cursor-set` is the sole seek**, so a redrive is two facts (`cursor-set` then `resume`). Contract, README spine diagram, and `onResumed` handling follow that model.
> 
> **Delivery hot path:** append passes **sized** just-committed events into `wake()` so tailing drains can skip SQLite re-reads when the cursor lines up (`#freshTail` / offset gate). The log **`insert` returns byte lengths** and **`getRangeSized`** sums chunk bytes so batch byte caps no longer re-`JSON.stringify` on every read; the DO spine reads via `getRangeSized` directly.
> 
> **KV core-state checkpointing** is debounced (every 64 events or 1s) with **flush on alarm and idle teardown**; SQL event rows stay the commit boundary and catch-up still folds past a lagging checkpoint.
> 
> **Push/webhook drain** collapses to one loop: webhook mode is **batch limit 1** on the same path as push (per-event acks and staleness checks structurally). **`subscriber-sinks`** caches the push authority root and webhook egress fetcher, invalidating on delivery failure (wake stays per-acquisition).
> 
> Minor: shared module-level `TextDecoder` for chunk decode; new tests for sized reads and live-tail storage-read behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fda18455aa9f2cd3367b5f5b116e3f92505b211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +266 -126 | +144 -100 🟩🟩🟩🟥🟥 |
| Tests | +76 -6 | +54 -5 🟩⬜⬜⬜⬜ |
| Docs | +2 -1 | +2 -1 🟩⬜⬜⬜⬜ |
| **Total** | **+344 -133** | **+200 -106** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between af04122 and 2fda184, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-09T19:02:55.804Z",
      "headSha": "2fda18455aa9f2cd3367b5f5b116e3f92505b211",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/322819210610863",
      "shortSha": "2fda184",
      "cleanupDurationMs": 10716,
      "deployDurationMs": 70975,
      "testDurationMs": 262378,
      "testRetries": "2 retried: itx > Project worker births agents: policy from itx.agents.defaults, appended by the seeded template (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 15472.86,
      "workerGzipKib": 4179.42,
      "mainWorkerGzipKib": 4177.65
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-09T19:02:47.874Z",
      "headSha": "2fda18455aa9f2cd3367b5f5b116e3f92505b211",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/322819210610863",
      "shortSha": "2fda184",
      "cleanupDurationMs": 2783,
      "deployDurationMs": 18894,
      "testDurationMs": 581,
      "testRetries": null,
      "workerSizeKib": 4031.52,
      "workerGzipKib": 819.29,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-09T19:02:45.851Z",
      "headSha": "2fda18455aa9f2cd3367b5f5b116e3f92505b211",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/322819210610863",
      "shortSha": "2fda184",
      "cleanupDurationMs": 759,
      "deployDurationMs": 16492,
      "testDurationMs": 19774,
      "testRetries": null,
      "workerSizeKib": 4559.07,
      "workerGzipKib": 1314.58,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `2fda184` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 819.3 KiB | 18.9s | 581ms |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/322819210610863) | 2026-07-09T19:02:47.874Z | Preview app released. |
| OS | released | `2fda184` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.08 MiB (+1.8 KiB vs main) | 71.0s | 262.4s | 2 retried: itx > Project worker births agents: policy from itx.agents.defaults, appended by the seeded template (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 10.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/322819210610863) | 2026-07-09T19:02:55.804Z | Preview app released. |
| Streams Example App | released | `2fda184` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.28 MiB | 16.5s | 19.8s |  | 759ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/322819210610863) | 2026-07-09T19:02:45.851Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->