### PR TITLE
Refold-safe processor side effects: freshness-gated acks + repo creation as an at-head obligation

### DIFF
--- a/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
+++ b/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
@@ -11,6 +11,11 @@
 // - Replay runs the same idempotency-keyed side effects as live delivery. The
 //   processor checkpoint is the guardrail; failed batches replay from the last
 //   fully processed offset.
+// - The Slack calls themselves are acknowledgement/cosmetic lanes and must be
+//   REFOLD-SAFE (docs/writing-stream-processors.md, "Refold safety"): the 👀
+//   ack only fires for fresh webhooks (webhookAckIsFresh), and the assistant
+//   status is repainted once per at-head batch from the latest lifecycle fact
+//   instead of once per event.
 //
 // Adaptation from legacy: the itx agent contract has no
 // `agent/status-updated` event. The Slack "is thinking..." status now keys off
@@ -22,7 +27,12 @@ import { stringify as stringifyYaml } from "yaml";
 import { z } from "zod";
 import { StreamProcessor } from "../streams/stream-processor.ts";
 import type { AgentFileAttachment } from "../agents/agent-processor-contract.ts";
-import { readRecord, readString, slackConnectionFromAgentPath } from "./utils.ts";
+import {
+  readRecord,
+  readString,
+  slackConnectionFromAgentPath,
+  webhookAckIsFresh,
+} from "./utils.ts";
 import {
   SlackAgentProcessorContract,
   type SlackAgentProcessorState,
@@ -35,6 +45,8 @@ export class SlackAgentProcessor extends StreamProcessor<
   SlackAgentProcessorContract,
   {
     callSlackApi?(method: string, body: Record<string, unknown>): Promise<void>;
+    /** Injectable clock for the acknowledgement freshness gates. */
+    now?: () => number;
     /** Downloads Slack-shared files into project file storage (see
      * storeSlackFilesForAgent in slack-api.ts). `storageKey` is stable per
      * webhook event so replays overwrite instead of duplicating. */
@@ -132,7 +144,7 @@ export class SlackAgentProcessor extends StreamProcessor<
             await appendAgentInput({
               llmRequestPolicy: { behaviour: "dont-trigger-request" },
             });
-            await this.#addEyesReactionForMessageTarget(target);
+            await this.#addEyesReactionForMessageTarget(target, event);
           });
           return;
         }
@@ -163,7 +175,7 @@ export class SlackAgentProcessor extends StreamProcessor<
                 executionId: `slack-bang-command-${event.offset}`,
               },
             });
-            await this.#addEyesReactionForMessageTarget(target);
+            await this.#addEyesReactionForMessageTarget(target, event);
           });
           return;
         }
@@ -191,40 +203,64 @@ export class SlackAgentProcessor extends StreamProcessor<
             }
           }
           await appendAgentInput(files == null ? {} : { files });
-          await this.#addEyesReactionForMessageTarget(target);
+          await this.#addEyesReactionForMessageTarget(target, event);
         });
         return;
       }
-      case "events.iterate.com/agent/llm-request-requested":
-      case "events.iterate.com/agent/llm-request-completed":
-      case "events.iterate.com/capability-host/script-execution-requested":
-      case "events.iterate.com/capability-host/script-execution-completed": {
-        const update = slackAgentStatusForEvent(event);
-        if (update == null || state.channel == null || state.threadTs == null) return;
-        const { channel, latestMessageTs, threadTs } = state;
-        blockProcessorWhile(async () => {
-          await this.#callSlackApi("assistant.threads.setStatus", {
-            channel_id: channel,
-            thread_ts: threadTs,
-            ...update.status,
-          });
-          if (update.clear && latestMessageTs != null) {
-            await this.#callSlackApi("reactions.remove", {
-              channel,
-              name: "eyes",
-              timestamp: latestMessageTs,
-            });
-          }
-        });
-        return;
-      }
+      // LLM/script lifecycle facts drive the assistant status, which is
+      // repainted once per batch in processEventBatch — nothing per event.
       default:
         return;
     }
   }
 
-  async #addEyesReactionForMessageTarget(target: SlackAgentTarget | null) {
+  /**
+   * The Slack assistant status is a REPAINT of current truth, not a per-event
+   * effect: the latest lifecycle fact in the batch wins and one setStatus
+   * paints it. Three gates make the lane refold-safe (and un-race per-event
+   * `blockProcessorWhile` closures, which run concurrently within a batch):
+   * only an at-head fold paints (a mid-catch-up batch's "current" is stale by
+   * construction), only a fresh fact paints (a refold's historical lifecycle
+   * facts must not touch months-old threads), and it paints at most once per
+   * batch. A crashed run's orphan settles via the provider reconcilers as a
+   * FRESH `llm-request-completed`, so a stuck "is thinking…" still clears.
+   */
+  protected override async processEventBatch(
+    args: Parameters<StreamProcessor<SlackAgentProcessorContract>["processEventBatch"]>[0],
+  ): Promise<void> {
+    await super.processEventBatch(args);
+    if (args.checkpointOffset < args.streamMaxOffset) return;
+    const latest = args.reducedEvents.findLast(
+      ({ event }) => slackAgentStatusForEvent(event) != null,
+    );
+    if (latest == null || !webhookAckIsFresh(latest.event, (this.deps.now ?? Date.now)())) return;
+    const update = slackAgentStatusForEvent(latest.event)!;
+    const { channel, latestMessageTs, threadTs } = args.state;
+    if (channel == null || threadTs == null) return;
+    args.blockProcessorWhile(async () => {
+      await this.#callSlackApi("assistant.threads.setStatus", {
+        channel_id: channel,
+        thread_ts: threadTs,
+        ...update.status,
+      });
+      if (update.clear && latestMessageTs != null) {
+        await this.#callSlackApi("reactions.remove", {
+          channel,
+          name: "eyes",
+          timestamp: latestMessageTs,
+        });
+      }
+    });
+  }
+
+  /** The 👀 ack means "your message was just picked up" — only fresh webhooks
+   * qualify (see WEBHOOK_ACK_FRESHNESS_MS for why stale ones must not). */
+  async #addEyesReactionForMessageTarget(
+    target: SlackAgentTarget | null,
+    event: { createdAt: string },
+  ) {
     if (target == null || target.isBotMessage || target.isReactionEvent) return;
+    if (!webhookAckIsFresh(event, (this.deps.now ?? Date.now)())) return;
     await this.#callSlackApi("reactions.add", {
       channel: target.channel,
       name: "eyes",

--- a/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
+++ b/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
@@ -215,26 +215,45 @@ export class SlackAgentProcessor extends StreamProcessor<
   }
 
   /**
+   * The latest status-relevant lifecycle fact this incarnation has seen but
+   * not yet painted. Behind-the-head batches defer painting to the at-head
+   * pass, but that pass's own batch may contain no lifecycle facts — a
+   * wake-lane batch stamped behind the head is followed by a trailing
+   * unfiltered catch-up that is often renders and inputs only, and a
+   * multi-page catch-up may fold the facts pages before the final one. The
+   * carry hands the deferred fact to whichever batch finally reaches head.
+   * In-memory on purpose: the status is a cosmetic lane, and a carry lost to
+   * an eviction is repaired by the next lifecycle fact (a revival's orphan
+   * settle IS a fresh `llm-request-completed`).
+   */
+  #unpaintedLifecycleFact: { createdAt: string; type: string } | undefined;
+
+  /**
    * The Slack assistant status is a REPAINT of current truth, not a per-event
-   * effect: the latest lifecycle fact in the batch wins and one setStatus
-   * paints it. Three gates make the lane refold-safe (and un-race per-event
+   * effect: the latest lifecycle fact wins and one setStatus paints it. Three
+   * gates make the lane refold-safe (and un-race per-event
    * `blockProcessorWhile` closures, which run concurrently within a batch):
-   * only an at-head fold paints (a mid-catch-up batch's "current" is stale by
-   * construction), only a fresh fact paints (a refold's historical lifecycle
-   * facts must not touch months-old threads), and it paints at most once per
-   * batch. A crashed run's orphan settles via the provider reconcilers as a
-   * FRESH `llm-request-completed`, so a stuck "is thinking…" still clears.
+   * only an at-head pass paints (a behind batch defers via the carry above),
+   * only a fresh fact paints (a refold's historical lifecycle facts must not
+   * touch months-old threads), and it paints at most once per batch. Unlike
+   * the repo reconciler this lane reads batch facts, not the fold — folding a
+   * cosmetic status into state isn't worth a schema change — which is exactly
+   * why behind batches need the carry where fold-based reconcilers don't.
    */
   protected override async processEventBatch(
     args: Parameters<StreamProcessor<SlackAgentProcessorContract>["processEventBatch"]>[0],
   ): Promise<void> {
     await super.processEventBatch(args);
-    if (args.checkpointOffset < args.streamMaxOffset) return;
-    const latest = args.reducedEvents.findLast(
-      ({ event }) => slackAgentStatusForEvent(event) != null,
-    );
-    if (latest == null || !webhookAckIsFresh(latest.event, (this.deps.now ?? Date.now)())) return;
-    const update = slackAgentStatusForEvent(latest.event)!;
+    const latest =
+      args.reducedEvents.findLast(({ event }) => slackAgentStatusForEvent(event) != null)?.event ??
+      this.#unpaintedLifecycleFact;
+    if (args.checkpointOffset < args.streamMaxOffset) {
+      this.#unpaintedLifecycleFact = latest;
+      return;
+    }
+    this.#unpaintedLifecycleFact = undefined;
+    if (latest == null || !webhookAckIsFresh(latest, (this.deps.now ?? Date.now)())) return;
+    const update = slackAgentStatusForEvent(latest)!;
     const { channel, latestMessageTs, threadTs } = args.state;
     if (channel == null || threadTs == null) return;
     args.blockProcessorWhile(async () => {

--- a/apps/os/src/domains/integrations/slack-processor-implementation.ts
+++ b/apps/os/src/domains/integrations/slack-processor-implementation.ts
@@ -6,7 +6,7 @@
 import { z } from "zod";
 import { StreamProcessor } from "../streams/stream-processor.ts";
 import type { StreamEventInput } from "../streams/schemas.ts";
-import { readRecord, readString, slackThreadStreamPath } from "./utils.ts";
+import { readRecord, readString, slackThreadStreamPath, webhookAckIsFresh } from "./utils.ts";
 import { SlackProcessorContract, type SlackProcessorState } from "./slack-processor-contract.ts";
 
 type SlackProcessorDeps = {
@@ -19,6 +19,8 @@ type SlackProcessorDeps = {
    * being forwarded". Best-effort: failures must not affect routing.
    */
   acknowledgeRoutedWebhook?(input: { payload: unknown }): Promise<void> | void;
+  /** Injectable clock for the acknowledgement freshness gate. */
+  now?: () => number;
   /**
    * The named connection this router serves — a projection of the host DO's
    * own name (`/integrations/slack/{connection}`), not folded state, so it is
@@ -87,9 +89,16 @@ export class SlackProcessor extends StreamProcessor<SlackProcessorContract, Slac
 
     // Independent of the forwarding appends below so the user-visible ack
     // races ahead of (possibly cold) stream creation rather than behind it.
-    runInBackground(async () => {
-      await this.deps.acknowledgeRoutedWebhook?.({ payload: event.payload });
-    });
+    // Fresh webhooks only: a refold or late wake replays historical webhooks,
+    // and re-acking those would resurrect 👀 on old messages, one Slack call
+    // per journaled webhook (see WEBHOOK_ACK_FRESHNESS_MS). The forwards below
+    // deliberately have no such gate — they are durable, idempotency-keyed
+    // obligations whose replays dedupe at the append layer.
+    if (webhookAckIsFresh(event, (this.deps.now ?? Date.now)())) {
+      runInBackground(async () => {
+        await this.deps.acknowledgeRoutedWebhook?.({ payload: event.payload });
+      });
+    }
 
     const forwardedWebhookEvent: StreamEventInput = {
       type: "events.iterate.com/slack/webhook-received",

--- a/apps/os/src/domains/integrations/slack-processors.test.ts
+++ b/apps/os/src/domains/integrations/slack-processors.test.ts
@@ -805,6 +805,54 @@ describe("SlackAgentProcessor", () => {
     ]);
   });
 
+  it("carries a behind-batch lifecycle fact to the at-head repaint", async () => {
+    const { cursors, processor, slackCalls, stream } = setup();
+
+    await stream.append({
+      type: "events.iterate.com/slack/webhook-received",
+      payload: humanMessageWebhookPayload({}),
+    });
+    await deliverNewEvents({ cursors, processor, stream });
+    slackCalls.length = 0;
+
+    // The completion lands in a batch stamped BEHIND the head (a render/input
+    // event already followed it — the wake-lane shape), and the trailing
+    // catch-up batch that reaches head contains no lifecycle facts at all.
+    // The repaint must not lose the completion: without the carry, Slack
+    // keeps "is thinking..." and the eyes reaction forever.
+    const [completed, render] = await stream.append(
+      {
+        type: "events.iterate.com/agent/llm-request-completed",
+        payload: {
+          durationMs: 10,
+          llmRequestId: 1,
+          provider: "openai-ws",
+          result: { status: "success" },
+        },
+      },
+      {
+        // Not consumed by slack-agent: stands in for the renders/inputs that
+        // typically trail a completion.
+        type: "events.iterate.com/agent/input-added",
+        payload: { content: "render" },
+      },
+    );
+    await processor.ingest({ events: [completed!], streamMaxOffset: render!.offset });
+    expect(slackCalls).toEqual([]); // behind the head: deferred, not painted
+
+    await processor.ingest({ events: [render!], streamMaxOffset: render!.offset });
+    expect(slackCalls).toEqual([
+      {
+        method: "assistant.threads.setStatus",
+        body: { channel_id: "C123", thread_ts: "111.222", status: "" },
+      },
+      {
+        method: "reactions.remove",
+        body: { channel: "C123", name: "eyes", timestamp: "111.222" },
+      },
+    ]);
+  });
+
   it("skips the stale 👀 ack on a late wake but still lands the agent input", async () => {
     const { clock, cursors, processor, slackCalls, stream } = setup();
 

--- a/apps/os/src/domains/integrations/slack-processors.test.ts
+++ b/apps/os/src/domains/integrations/slack-processors.test.ts
@@ -17,6 +17,10 @@ import {
 class MemoryStreamNetwork {
   readonly streams = new Map<string, MemoryStream>();
 
+  /** Injectable clock for createdAt stamps, so freshness-gated lanes (the 👀
+   * ack, the status repaint) can be tested on both sides of the horizon. */
+  constructor(readonly now: () => number = Date.now) {}
+
   get(path: string): MemoryStream {
     let stream = this.streams.get(path);
     if (stream === undefined) {
@@ -52,7 +56,7 @@ class MemoryStream implements Stream {
       if (existing !== undefined) return existing;
       const event: StreamEvent = {
         ...input,
-        createdAt: new Date(this.events.length + 1).toISOString(),
+        createdAt: new Date(this.network.now()).toISOString(),
         offset: this.events.length + 1,
         path: this.path,
       };
@@ -385,6 +389,54 @@ describe("SlackProcessor (webhook router)", () => {
     expect(network.eventsAt("/agents/slack/custom-route")).toHaveLength(1);
   });
 
+  it("refold: replaying the journal neither re-acknowledges nor duplicates forwards", async () => {
+    // THE refold test (docs/writing-stream-processors.md, "Refold safety").
+    const clock = { now: Date.parse("2026-07-09T12:00:00Z") };
+    const network = new MemoryStreamNetwork(() => clock.now);
+    const stream = network.get("/integrations/slack/nustom");
+    const acked: unknown[] = [];
+    const processor = new SlackProcessor({
+      stream,
+      connection: CONNECTION,
+      acknowledgeRoutedWebhook: ({ payload }) => {
+        acked.push(payload);
+      },
+      now: () => clock.now,
+    });
+    const cursors = new Map<object, number>();
+
+    await stream.append({
+      type: "events.iterate.com/slack/webhook-received",
+      payload: humanMessageWebhookPayload({}),
+    });
+    await deliverNewEvents({ cursors, processor, stream });
+    expect(acked).toHaveLength(1);
+    const routedPath = "/agents/slack/nustom/c123/ts-111-222";
+    expect(network.eventsAt(routedPath)).toHaveLength(2);
+
+    clock.now += 60 * 60_000;
+    const refoldAcked: unknown[] = [];
+    const refolded = new SlackProcessor({
+      stream,
+      connection: CONNECTION,
+      acknowledgeRoutedWebhook: ({ payload }) => {
+        refoldAcked.push(payload);
+      },
+      now: () => clock.now,
+    });
+    await deliverNewEvents({ cursors, processor: refolded, stream });
+
+    // The stale ack is skipped; the durable forwards replay and dedupe at the
+    // append layer (idempotency keys), leaving the routed stream unchanged.
+    expect(refoldAcked).toEqual([]);
+    expect(network.eventsAt(routedPath)).toHaveLength(2);
+    expect(
+      stream.events.filter(
+        (event) => event.type === "events.iterate.com/slack/thread-route-configured",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("ignores and never acknowledges webhooks that cannot be keyed as channel:thread_ts", async () => {
     const network = new MemoryStreamNetwork();
     const stream = network.get("/integrations/slack/nustom");
@@ -472,7 +524,8 @@ describe("SlackAgentProcessor", () => {
   function setup(deps?: {
     storeSlackFiles?: ConstructorParameters<typeof SlackAgentProcessor>[0]["storeSlackFiles"];
   }) {
-    const network = new MemoryStreamNetwork();
+    const clock = { now: Date.parse("2026-07-09T12:00:00Z") };
+    const network = new MemoryStreamNetwork(() => clock.now);
     const stream = network.get("/agents/slack/nustom/c123/ts-111-222");
     const slackCalls: Array<{ body: Record<string, unknown>; method: string }> = [];
     const processor = new SlackAgentProcessor({
@@ -480,10 +533,11 @@ describe("SlackAgentProcessor", () => {
       callSlackApi: async (method, body) => {
         slackCalls.push({ body, method });
       },
+      now: () => clock.now,
       ...(deps?.storeSlackFiles === undefined ? {} : { storeSlackFiles: deps.storeSlackFiles }),
     });
     const cursors = new Map<object, number>();
-    return { cursors, network, processor, slackCalls, stream };
+    return { clock, cursors, network, processor, slackCalls, stream };
   }
 
   it("turns a routed human message into triggering agent input and adds the eyes reaction", async () => {
@@ -708,6 +762,113 @@ describe("SlackAgentProcessor", () => {
         body: { channel: "C123", name: "eyes", timestamp: "111.222" },
       },
     ]);
+  });
+
+  it("repaints the status once per batch — the latest lifecycle fact wins", async () => {
+    const { cursors, processor, slackCalls, stream } = setup();
+
+    await stream.append({
+      type: "events.iterate.com/slack/webhook-received",
+      payload: humanMessageWebhookPayload({}),
+    });
+    await deliverNewEvents({ cursors, processor, stream });
+    slackCalls.length = 0;
+
+    // Requested and completed land in ONE batch: the status is a repaint of
+    // current truth, so only the final (cleared) status reaches Slack — no
+    // transient "is thinking..." call for a request that already finished.
+    await stream.append(
+      {
+        type: "events.iterate.com/agent/llm-request-requested",
+        payload: { model: "gpt-test", provider: "openai-ws", requestId: "llm-request:1" },
+      },
+      {
+        type: "events.iterate.com/agent/llm-request-completed",
+        payload: {
+          durationMs: 10,
+          llmRequestId: 1,
+          provider: "openai-ws",
+          result: { status: "success" },
+        },
+      },
+    );
+    await deliverNewEvents({ cursors, processor, stream });
+    expect(slackCalls).toEqual([
+      {
+        method: "assistant.threads.setStatus",
+        body: { channel_id: "C123", thread_ts: "111.222", status: "" },
+      },
+      {
+        method: "reactions.remove",
+        body: { channel: "C123", name: "eyes", timestamp: "111.222" },
+      },
+    ]);
+  });
+
+  it("skips the stale 👀 ack on a late wake but still lands the agent input", async () => {
+    const { clock, cursors, processor, slackCalls, stream } = setup();
+
+    // The webhook arrived while the processor's host was down; delivery
+    // happens 16 minutes later. The durable lane (agent input) must land —
+    // the ack lane must not pretend the message was "just picked up".
+    await stream.append({
+      type: "events.iterate.com/slack/webhook-received",
+      payload: humanMessageWebhookPayload({}),
+    });
+    clock.now += 16 * 60_000;
+    await deliverNewEvents({ cursors, processor, stream });
+
+    expect(
+      stream.events.filter((event) => event.type === "events.iterate.com/agent/input-added"),
+    ).toHaveLength(1);
+    expect(slackCalls.filter((call) => call.method === "reactions.add")).toHaveLength(0);
+  });
+
+  it("refold: replaying the full journal re-executes no Slack calls and appends nothing new", async () => {
+    // THE refold test (docs/writing-stream-processors.md, "Refold safety"):
+    // a state-schema deploy discards the checkpoint and replays the journal
+    // from offset 0 into a fresh instance. Durable lanes dedupe via
+    // idempotency keys; acknowledgement/cosmetic lanes must not re-fire.
+    const { clock, cursors, processor, slackCalls, stream } = setup();
+
+    await stream.append({
+      type: "events.iterate.com/slack/webhook-received",
+      payload: humanMessageWebhookPayload({}),
+    });
+    await deliverNewEvents({ cursors, processor, stream });
+    await stream.append({
+      type: "events.iterate.com/agent/llm-request-requested",
+      payload: { model: "gpt-test", provider: "openai-ws", requestId: "llm-request:1" },
+    });
+    await deliverNewEvents({ cursors, processor, stream });
+    await stream.append({
+      type: "events.iterate.com/agent/llm-request-completed",
+      payload: {
+        durationMs: 10,
+        llmRequestId: 1,
+        provider: "openai-ws",
+        result: { status: "success" },
+      },
+    });
+    await deliverNewEvents({ cursors, processor, stream });
+    expect(slackCalls.length).toBeGreaterThan(0);
+    const journalBeforeRefold = stream.events.length;
+
+    clock.now += 60 * 60_000;
+    const refoldCalls: Array<{ body: Record<string, unknown>; method: string }> = [];
+    const refolded = new SlackAgentProcessor({
+      stream,
+      callSlackApi: async (method, body) => {
+        refoldCalls.push({ body, method });
+      },
+      now: () => clock.now,
+    });
+    await deliverNewEvents({ cursors, processor: refolded, stream });
+
+    expect(refoldCalls).toEqual([]);
+    expect(stream.events).toHaveLength(journalBeforeRefold);
+    // The refolded state converged to the live processor's.
+    expect(refolded.state).toEqual(processor.state);
   });
 
   it("captures route context (including streamPath) in state without announcing anything", async () => {

--- a/apps/os/src/domains/integrations/utils.ts
+++ b/apps/os/src/domains/integrations/utils.ts
@@ -48,6 +48,22 @@ export const GITHUB_CONNECTED_EVENT_TYPE = "events.iterate.com/github/connected"
 export const GITHUB_DISCONNECTED_EVENT_TYPE = "events.iterate.com/github/disconnected";
 export const GITHUB_WEBHOOK_RECEIVED_EVENT_TYPE = "events.iterate.com/github/webhook-received";
 
+/**
+ * How old a webhook may be and still deserve its user-visible acknowledgement
+ * (the 👀 reaction, the assistant status). Acks mean "your message was just
+ * picked up" — they are only meaningful near arrival. A full journal refold
+ * (the normal aftermath of deploying a state-schema change) or a late wake
+ * replays historical webhooks; re-acking those would resurrect reactions on
+ * old messages, and a burst of them is a Slack rate-limit crash-loop
+ * (docs/writing-stream-processors.md, "Refold safety").
+ */
+const WEBHOOK_ACK_FRESHNESS_MS = 15 * 60_000;
+
+/** Whether an event is young enough for its acknowledgement lane to act. */
+export function webhookAckIsFresh(event: { createdAt: string }, now: number): boolean {
+  return now - Date.parse(event.createdAt) <= WEBHOOK_ACK_FRESHNESS_MS;
+}
+
 export function readRecord(value: unknown): Record<string, unknown> | null {
   return value != null && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)

--- a/apps/os/src/domains/repos/pr-agent.test.ts
+++ b/apps/os/src/domains/repos/pr-agent.test.ts
@@ -367,6 +367,112 @@ describe("RepoProcessor PR webhook forward (router)", () => {
   });
 });
 
+describe("RepoProcessor create lane (creation as an at-head obligation)", () => {
+  const CREATED_ARTIFACT = {
+    artifactName: "prj_1--Lw",
+    defaultBranch: "main",
+    remote: "https://example.artifacts.cloudflare.net/git/ns/prj_1--Lw.git",
+  };
+
+  function newCreatingRepoProcessor(stream: MemoryStream, createCalls: unknown[]) {
+    return new RepoProcessor({
+      stream,
+      createRepoArtifact: async (input) => {
+        createCalls.push(input);
+        return CREATED_ARTIFACT;
+      },
+      path: "/",
+      projectId: "prj_1",
+    });
+  }
+
+  const CREATE_REQUESTED = {
+    type: "events.iterate.com/repo/create-requested" as const,
+    payload: { projectId: "prj_1", path: "/" },
+  };
+
+  it("creates the artifact once at head and journals repo/created", async () => {
+    const network = new MemoryStreamNetwork();
+    const stream = network.get("/");
+    const createCalls: unknown[] = [];
+    const processor = newCreatingRepoProcessor(stream, createCalls);
+    const cursors = new Map<object, number>();
+
+    await stream.append(CREATE_REQUESTED);
+    await deliverNewEvents({ cursors, processor, stream });
+
+    expect(createCalls).toEqual([{ path: "/", projectId: "prj_1" }]);
+    const created = stream.events.filter(
+      (event) => event.type === "events.iterate.com/repo/created",
+    );
+    expect(created).toHaveLength(1);
+    expect(created[0]).toMatchObject({
+      idempotencyKey: "repo-created:prj_1:/",
+      payload: { ...CREATED_ARTIFACT, path: "/", projectId: "prj_1" },
+    });
+
+    // The self-appended created fact folds on the next delivery (offset order
+    // guarantees it precedes anything later), closing the obligation: the
+    // reconciler runs again at head and provably does not re-create.
+    await deliverNewEvents({ cursors, processor, stream });
+    expect(processor.state).toMatchObject({ createRequested: true, created: true });
+    expect(createCalls).toHaveLength(1);
+  });
+
+  it("defers creation while the fold is behind the head, then creates once caught up", async () => {
+    const network = new MemoryStreamNetwork();
+    const stream = network.get("/");
+    const createCalls: unknown[] = [];
+    const processor = newCreatingRepoProcessor(stream, createCalls);
+
+    const [requested, linked] = await stream.append(CREATE_REQUESTED, {
+      type: "events.iterate.com/repo/github-link-configured",
+      payload: GITHUB_LINK,
+    });
+
+    // A mid-catch-up batch (streamMaxOffset past its own tail, the catch-up
+    // pager's lookahead shape) must not act: the not-yet-folded remainder may
+    // contain the repo/created fact.
+    await processor.ingest({ events: [requested!], streamMaxOffset: 2 });
+    expect(createCalls).toHaveLength(0);
+
+    await processor.ingest({ events: [linked!], streamMaxOffset: 2 });
+    expect(createCalls).toHaveLength(1);
+  });
+
+  it("refold: a journal that already contains repo/created never re-creates", async () => {
+    // THE refold test (docs/writing-stream-processors.md, "Refold safety"):
+    // re-running createRepoArtifact would force-push the seed commit over
+    // whatever the user has committed since, so the fake here THROWS — the
+    // reconciler must never reach it when the at-head fold shows `created`.
+    const network = new MemoryStreamNetwork();
+    const stream = network.get("/");
+    const createCalls: unknown[] = [];
+    const processor = newCreatingRepoProcessor(stream, createCalls);
+    const cursors = new Map<object, number>();
+
+    await stream.append(CREATE_REQUESTED);
+    await deliverNewEvents({ cursors, processor, stream });
+    // Fold the self-appended created fact so the live state is settled.
+    await deliverNewEvents({ cursors, processor, stream });
+    expect(createCalls).toHaveLength(1);
+    const journalBeforeRefold = stream.events.length;
+
+    const refolded = new RepoProcessor({
+      stream,
+      createRepoArtifact: async () => {
+        throw new Error("refold must not re-create an existing repo");
+      },
+      path: "/",
+      projectId: "prj_1",
+    });
+    await deliverNewEvents({ cursors, processor: refolded, stream });
+
+    expect(stream.events).toHaveLength(journalBeforeRefold);
+    expect(refolded.state).toEqual(processor.state);
+  });
+});
+
 describe("PrAgentProcessor (transcriber)", () => {
   const AGENT_PATH = "/agents/repos/root/pull-requests/7";
   const ROUTE_EVENT = {

--- a/apps/os/src/domains/repos/repo-processor-contract.ts
+++ b/apps/os/src/domains/repos/repo-processor-contract.ts
@@ -20,6 +20,11 @@ export const RepoProcessorContract = defineProcessorContract({
   description: "Tiny fake repo projection for the ITX reference implementation.",
   stateSchema: z.object({
     artifactName: z.string().nullable().default(null),
+    /** An open creation OBLIGATION: `create-requested` folded, `created` not
+     * yet. The end-of-batch reconciler compares this pair at head — never
+     * event-time state, which a journal refold replays with `created` still
+     * false (docs/writing-stream-processors.md, "Refold safety"). */
+    createRequested: z.boolean().default(false),
     created: z.boolean().default(false),
     defaultBranch: z.string().nullable().default(null),
     github: GithubLinkPayload.nullable().default(null),

--- a/apps/os/src/domains/repos/repo-processor-implementation.ts
+++ b/apps/os/src/domains/repos/repo-processor-implementation.ts
@@ -27,6 +27,8 @@ export class RepoProcessor extends StreamProcessor<RepoProcessorContract, RepoPr
     state,
   }: Parameters<StreamProcessor<RepoProcessorContract>["reduce"]>[0]) {
     switch (event.type) {
+      case "events.iterate.com/repo/create-requested":
+        return { ...state, createRequested: true };
       case "events.iterate.com/repo/created":
         return {
           ...state,
@@ -83,7 +85,6 @@ export class RepoProcessor extends StreamProcessor<RepoProcessorContract, RepoPr
     blockProcessorWhile,
     event,
     state,
-    append,
   }: Parameters<StreamProcessor<RepoProcessorContract>["processEvent"]>[0]): undefined {
     if (event.type === "events.iterate.com/github/webhook-received") {
       // PR webhooks route to a per-PR agent stream, everything else (pushes,
@@ -126,12 +127,36 @@ export class RepoProcessor extends StreamProcessor<RepoProcessorContract, RepoPr
     }
 
     if (event.type !== "events.iterate.com/repo/create-requested") return;
+    // Address validation stays per-event (a mis-addressed request is a loud
+    // error); the creation itself is reconciled from the at-head fold in
+    // processEventBatch.
     this.#assertOwnCreateRequest(event);
-    if (state.created) return;
+  }
 
-    blockProcessorWhile(async () => {
-      const payload = await this.deps.createRepoArtifact(event.payload);
-      await append({
+  /**
+   * Creation is an OBLIGATION reconciled from the at-head fold, never a
+   * per-event reaction: a journal refold (the normal aftermath of a
+   * state-schema deploy) replays `create-requested` with event-time state in
+   * which `created` is still false, but the at-head fold has already absorbed
+   * the journaled `repo/created` fact — so `createRepoArtifact`, whose seeding
+   * force-pushes the seed commit and would clobber user commits, provably
+   * never re-runs. No expiry on purpose: "this repo should exist" does not go
+   * stale, and the vendor call is idempotent (get-or-create + re-seed of a
+   * fresh repo folds to a no-op), so a create-succeeded/append-failed retry is
+   * safe.
+   */
+  protected override async processEventBatch(
+    args: Parameters<StreamProcessor<RepoProcessorContract>["processEventBatch"]>[0],
+  ): Promise<void> {
+    await super.processEventBatch(args);
+    if (args.checkpointOffset < args.streamMaxOffset) return;
+    if (!args.state.createRequested || args.state.created) return;
+    args.blockProcessorWhile(async () => {
+      const payload = await this.deps.createRepoArtifact({
+        path: this.deps.path,
+        projectId: this.deps.projectId,
+      });
+      await args.append({
         type: "events.iterate.com/repo/created",
         idempotencyKey: `repo-created:${this.deps.projectId}:${this.deps.path}`,
         payload: {

--- a/apps/os/src/itx-api.generated.ts
+++ b/apps/os/src/itx-api.generated.ts
@@ -1862,6 +1862,7 @@ export type GithubSyncResult = {
  */
 export type RepoProcessorState = {
   artifactName: string | null;
+  createRequested: boolean;
   created: boolean;
   defaultBranch: string | null;
   github: { connection: string; installationId: string; owner: string; repo: string } | null;

--- a/apps/os/src/types-source.generated.ts
+++ b/apps/os/src/types-source.generated.ts
@@ -1867,6 +1867,7 @@ export type GithubSyncResult = {
  */
 export type RepoProcessorState = {
   artifactName: string | null;
+  createRequested: boolean;
   created: boolean;
   defaultBranch: string | null;
   github: { connection: string; installationId: string; owner: string; repo: string } | null;

--- a/docs/writing-stream-processors.md
+++ b/docs/writing-stream-processors.md
@@ -56,7 +56,8 @@ Legitimate answers:
 
 - _"the reconciler, via journaled evidence"_ — the obligation pattern below;
 - _"nothing — the outcome genuinely doesn't matter"_ — telemetry, best-effort
-  UX touches (a Slack reaction).
+  UX touches (a Slack reaction; these must also be freshness-gated — see
+  refold safety below).
 
 A naked `runInBackground` around consequential work is the exact bug class
 behind the 2026-06-10 and 2026-07-07 production wedges.
@@ -121,6 +122,64 @@ how far your fold sits from the stream head) before starting anything.
   this pattern (and its timer is a droppable attempt: losing it costs
   latency, never the request, because the settle logic re-derives it from
   the fold).
+
+## Refold safety: the whole journal will be replayed at you
+
+The checkpoint is a disposable CACHE of the fold. Whenever a stored snapshot
+stops parsing against the current state schema — the **normal aftermath of
+deploying a state-shape change** — the processor discards it and refolds from
+offset 0 (`StreamProcessor.#loadState`). That means `processEvent` runs again
+for every historical event, with **event-time state**: at each event, `state`
+is the fold up to that offset, not current truth.
+
+Event-time state is therefore NOT a guard. `if (state.created) return` does
+not protect a refold: the `created` fact folds _later_ in the replay, so the
+vendor call re-fires against a repo that already exists — and the repo
+processor's seeding force-pushes the seed commit over whatever the user has
+committed since. That was a real latent bug; the same shape would have
+re-added 👀 reactions to every historical Slack message (a rate-limit
+crash-loop inside `blockProcessorWhile`, with reaction resurrection as the
+user-visible symptom).
+
+Every side effect in a `process*` hook must be one of exactly three shapes:
+
+1. **An append with a stable idempotency key.** Safe by construction: the
+   stream dedupes the replay. This is why the durable forwards (Slack
+   router → thread stream, repo → PR-agent stream) need no other gate — a
+   refold re-dials the appends and they all collapse.
+2. **An obligation reconciled from the AT-HEAD fold** (the pattern above).
+   Safe because the final fold has absorbed every journaled completion:
+   requested-and-completed pairs cancel out _before_ the reconciler acts.
+   `RepoProcessor.processEventBatch` is the minimal example — fold
+   `createRequested`, reconcile `createRequested && !created` at head.
+3. **An acknowledgement/cosmetic lane gated on FRESHNESS** — compare
+   `event.createdAt` against an injected `now`. Acks mean "your message was
+   just picked up"; they are only meaningful near arrival, so stale replays
+   (and late wakes) skip them. The Slack 👀 ack and the assistant-status
+   repaint are the references (`webhookAckIsFresh` in
+   `integrations/utils.ts`); the status lane is additionally
+   latest-fact-wins, painted at most once per at-head batch.
+
+Vendor work that is **idempotent-by-overwrite** inside a durable lane
+(re-downloading Slack-shared files to a per-event storage key) is acceptable:
+wasteful on refold, never wrong.
+
+### The refold test
+
+Every processor whose `process*` hooks touch a vendor must have one. It is a
+few lines, and it doubles as scenario 4 below:
+
+1. Run the normal live flow against an in-memory stream, vendor fakes
+   recording.
+2. Advance the injected clock past the freshness horizon.
+3. Construct a SECOND, fresh processor instance over the SAME stream and
+   deliver the whole journal from offset 0 — that IS a refold.
+4. Assert: the fresh instance's vendor fakes saw **zero** calls (make a
+   dangerous fake THROW, so reaching it fails loudly), the journal gained
+   **zero** events, and the refolded state equals the live instance's.
+
+References: the "refold: …" tests in `slack-processors.test.ts` (agent
+status/ack + router ack/forwards) and `pr-agent.test.ts` (repo creation).
 
 ## What the host gives you for free (and what it demands)
 
@@ -232,7 +291,8 @@ Scenarios every obligation-carrying processor should have (crib from
 2. eviction before any attempt → provably-never-ran work starts late (or
    expires);
 3. expired obligation → settled without the vendor ever being dialed;
-4. full-journal refold → completions dedupe, nothing re-executes;
+4. full-journal refold → completions dedupe, nothing re-executes (the refold
+   test above — required for every processor that touches a vendor);
 5. the crash-loop breaker engaging on your processor's poison shape;
 6. a failed started-append → nothing runs, nothing settles, the live-set is
    released, and a later batch retries the whole attempt.
@@ -248,5 +308,10 @@ Scenarios every obligation-carrying processor should have (crib from
       `createdAt + DEFAULT` fallback covers raw appends).
 - [ ] A failed started-append never settles and never leaks the live-set.
 - [ ] Injected `now` dep for anything clock-dependent.
+- [ ] Every vendor side effect is one of the three refold-safe shapes:
+      idempotency-keyed append, at-head fold reconciliation, or
+      freshness-gated ack — never guarded by event-time state alone.
+- [ ] The refold test: a fresh instance fed the full journal re-executes no
+      vendor work, appends nothing new, and converges to the same state.
 - [ ] Hosting DO wires `alarm()` (and alarm slices if it schedules).
 - [ ] Harness scenarios 1–6 above.

--- a/packages/iterate/src/itx-api.generated.ts
+++ b/packages/iterate/src/itx-api.generated.ts
@@ -1862,6 +1862,7 @@ export type GithubSyncResult = {
  */
 export type RepoProcessorState = {
   artifactName: string | null;
+  createRequested: boolean;
   created: boolean;
   defaultBranch: string | null;
   github: { connection: string; installationId: string; owner: string; repo: string } | null;

--- a/tasks/refold-safe-processor-side-effects.md
+++ b/tasks/refold-safe-processor-side-effects.md
@@ -1,5 +1,5 @@
 ---
-state: todo
+state: done
 priority: medium
 size: small
 tags: [os, streams, processors, recovery]
@@ -12,28 +12,36 @@ Found 2026-07-09 by PR #1801's adversarial review (round 2). That PR made
 deploy path for a processor whose stored snapshot no longer parses
 (`StreamProcessor.#loadState` treats it as a cache miss). Reconcilers and
 render-appends are refold-safe (at-head gate + idempotency keys), but three
-processors still do per-event vendor work in `processEvent` guarded only by
+processors still did per-event vendor work in `processEvent` guarded only by
 event-time state, which a refold re-executes for the whole journal:
 
-1. **slack-agent** (`slack-agent-processor-implementation.ts` ~205-230):
-   `assistant.threads.setStatus` and `reactions.add`/`remove` re-fire for
-   every historical message. `#callSlackApi` tolerates `already_reacted` /
-   `no_reaction` but rethrows `rate_limited` inside `blockProcessorWhile` —
-   a refold burst becomes a rate-limit crash-loop, plus 👀 reactions
-   resurrected on old messages.
-2. **slack router** (`slack-processor-implementation.ts` ~90-92):
-   `acknowledgeRoutedWebhook` re-acks every historical webhook.
-3. **repo processor** (`repo-processor-implementation.ts` ~132-135):
-   `createRepoArtifact` re-runs because the `state.created` guard sees
-   event-time state (the `repo/created` event folds later in the replay) — a
-   real artifact-creation call against an already-created repo.
+1. **slack-agent**: `assistant.threads.setStatus` and `reactions.add`/`remove`
+   re-fired for every historical message — a rate-limit crash-loop inside
+   `blockProcessorWhile`, plus 👀 reactions resurrected on old messages.
+2. **slack router**: `acknowledgeRoutedWebhook` re-acked every historical
+   webhook.
+3. **repo processor**: `createRepoArtifact` re-ran because the
+   `state.created` guard sees event-time state — and its seeding force-pushes
+   the seed commit, clobbering user commits.
 
-Fix shape (per docs/writing-stream-processors.md): cosmetic/at-head-only
-lanes (Slack status/reactions, webhook acks) should gate on
-`checkpointOffset >= streamMaxOffset` exactly like the reconcilers — they are
-only meaningful at head; `createRepoArtifact` needs an idempotency check of
-its own (create-if-absent at the Artifacts API).
+## Resolution (done 2026-07-09)
 
-Must land before the first state-schema change ships to any of these three
-contracts; until then the hazard is latent (their schemas were untouched by
-PR #1801).
+- **slack-agent**: the 👀 ack is freshness-gated (`webhookAckIsFresh`,
+  15-minute horizon); the assistant status became a once-per-batch repaint of
+  the latest lifecycle fact, gated on at-head + freshness (this also un-raced
+  the per-event `blockProcessorWhile` closures, which run concurrently within
+  a batch).
+- **slack router**: the fast ack is freshness-gated; the durable forwards
+  keep replaying and dedupe via idempotency keys, as designed.
+- **repo**: creation is now an obligation reconciled from the at-head fold
+  (`createRequested` folded into state, `createRequested && !created` checked
+  in `processEventBatch`) — the schema change this required ships together
+  with the refold-safe code that performs the resulting refold.
+- Doctrine + the required **refold test** documented in
+  [writing-stream-processors.md](../docs/writing-stream-processors.md)
+  ("Refold safety"); refold tests added for all three processors
+  (`slack-processors.test.ts`, `pr-agent.test.ts`).
+- The remaining processor fleet was audited: every other vendor-touching lane
+  is idempotency-keyed, at-head-reconciled, or soft-fail
+  (project processor's worker probe re-runs on refold but is a bounded
+  read-only readiness wait).


### PR DESCRIPTION
## Why

PR #1801 made **"state-schema change ⇒ discard checkpoint ⇒ full journal refold"** the normal deploy path: when a processor's stored snapshot no longer parses, `StreamProcessor.#loadState` treats it as a cache miss and re-delivers the **entire journal** to `processEvent` from offset 0 — with **event-time state** at every event. Its adversarial review found three processors doing per-event vendor work that a refold would re-execute for the whole journal (tracked in `tasks/refold-safe-processor-side-effects.md`, closed by this PR).

## What changed — exact inventory

| Surface | Changed? |
| --- | --- |
| Event types / payload schemas | **No.** No events added, none changed, `consumes`/`emits` untouched, no idempotency key changed. Nothing wire-visible. |
| Reduced state (`stateSchema`) | **Yes, one contract**: `repo` gains `createRequested: boolean` (details below). slack-agent and slack router state is untouched. |
| Processor deps | slack-agent and slack router gain an **optional** `now?: () => number` (injectable clock, defaults to `Date.now`). No production callsite changes. |
| New shared helper | `webhookAckIsFresh(event, now)` in `integrations/utils.ts` (15-minute horizon). |
| Generated files | `itx-api.generated.ts` / `types-source.generated.ts` regenerated for the new repo state field. |

## 1. repo: creation becomes an at-head obligation (state schema changed)

**The bug.** The creation guard read event-time state, and a refold replays `create-requested` *before* the `repo/created` fact has folded:

```ts
// BEFORE (processEvent) — refold-UNSAFE
if (event.type !== "events.iterate.com/repo/create-requested") return;
this.#assertOwnCreateRequest(event);
if (state.created) return; // ← event-time state: on a refold, `created` folds LATER in the replay
blockProcessorWhile(async () => {
  const payload = await this.deps.createRepoArtifact(event.payload); // seeding force-pushes the seed commit!
  await append({ type: "events.iterate.com/repo/created", idempotencyKey: `repo-created:…`, … });
});
```

`createRepoArtifact`'s seeding does `git push --force` of the seed commit — a refold re-create would **clobber user commits** on seed paths.

**The fix.** The request is folded into state, and creation is reconciled from the **at-head fold**, which has already absorbed the journaled `repo/created` fact before the reconciler acts:

```ts
// stateSchema — the one reduced-state change in this PR
stateSchema: z.object({
  artifactName: z.string().nullable().default(null),
+ /** An open creation OBLIGATION: `create-requested` folded, `created` not yet. */
+ createRequested: z.boolean().default(false),
  created: z.boolean().default(false),
  …

// reduce — new case (this event previously wasn't folded at all)
+ case "events.iterate.com/repo/create-requested":
+   return { ...state, createRequested: true };
```

```ts
// AFTER (processEventBatch) — reconciled from folded truth, refold-safe
protected override async processEventBatch(args): Promise<void> {
  await super.processEventBatch(args);
  if (args.checkpointOffset < args.streamMaxOffset) return; // only an at-head fold may act
  if (!args.state.createRequested || args.state.created) return; // folded, not event-time
  args.blockProcessorWhile(async () => {
    const payload = await this.deps.createRepoArtifact({ path: this.deps.path, projectId: this.deps.projectId });
    await args.append({
      type: "events.iterate.com/repo/created",
      idempotencyKey: `repo-created:${this.deps.projectId}:${this.deps.path}`, // unchanged
      payload: { ...payload, path: this.deps.path, projectId: this.deps.projectId },
    });
  });
}
```

`processEvent` keeps only the per-event address assertion (`#assertOwnCreateRequest`). No expiry on purpose: "this repo should exist" does not go stale, and the vendor call is get-or-create idempotent, so a create-succeeded/append-failed retry is safe.

**Deploy effect of the schema change**: every repo stream's stored checkpoint stops parsing and refolds once — the exact path this PR makes safe, performed by the new code that ships it. Self-healing, no migration.

## 2. slack-agent: freshness-gated 👀 ack + status as a once-per-batch repaint (no schema change)

**The ack.** `reactions.add` fired for every replayed webhook — on a refold that resurrects 👀 on every historical message, and the burst runs inside `blockProcessorWhile` where a Slack `rate_limited` rethrow fails the batch (a crash-loop). Acks mean "your message was *just* picked up", so only fresh webhooks qualify:

```ts
// integrations/utils.ts (new)
const WEBHOOK_ACK_FRESHNESS_MS = 15 * 60_000;
export function webhookAckIsFresh(event: { createdAt: string }, now: number): boolean {
  return now - Date.parse(event.createdAt) <= WEBHOOK_ACK_FRESHNESS_MS;
}

// slack-agent, all three ack callsites route through:
async #addEyesReactionForMessageTarget(target, event) {
  if (target == null || target.isBotMessage || target.isReactionEvent) return;
+ if (!webhookAckIsFresh(event, (this.deps.now ?? Date.now)())) return;
  await this.#callSlackApi("reactions.add", { channel: target.channel, name: "eyes", timestamp: target.messageTs });
}
```

The durable lane is untouched: the `agent/input-added` append still always runs (late webhooks still reach the agent) and dedupes via its idempotency key on replay.

**The status.** Previously each of the four lifecycle facts (`llm-request-requested/completed`, `script-execution-requested/completed`) fired its own `assistant.threads.setStatus` from `processEvent`. Two problems: a refold replays every historical status flip, and — a real pre-existing race — per-event `blockProcessorWhile` closures run **concurrently** within a batch, so "is thinking…" could race its own clear. The status is a *repaint of current truth*, so it moved to `processEventBatch`: the **latest** lifecycle fact in the batch wins, painted at most once, gated on at-head + freshness:

```ts
// AFTER (processEventBatch) — was a per-event case in processEvent
protected override async processEventBatch(args): Promise<void> {
  await super.processEventBatch(args);
  if (args.checkpointOffset < args.streamMaxOffset) return;                 // at-head only
  const latest = args.reducedEvents.findLast(({ event }) => slackAgentStatusForEvent(event) != null);
  if (latest == null || !webhookAckIsFresh(latest.event, (this.deps.now ?? Date.now)())) return; // fresh only
  const update = slackAgentStatusForEvent(latest.event)!;
  // one setStatus (+ eyes remove on clear), from folded state — unchanged Slack calls
  …
}
```

A crashed run's orphan settles via the provider reconcilers (#1801) as a *fresh* `llm-request-completed`, so a stuck "is thinking…" still clears.

## 3. slack router: freshness-gated fast ack (no schema change)

```ts
// BEFORE: every routed webhook, including refold replays
runInBackground(async () => { await this.deps.acknowledgeRoutedWebhook?.({ payload: event.payload }); });

// AFTER: fresh webhooks only
+ if (webhookAckIsFresh(event, (this.deps.now ?? Date.now)())) {
    runInBackground(async () => { await this.deps.acknowledgeRoutedWebhook?.({ payload: event.payload }); });
+ }
```

The forwards below it are deliberately **not** gated — they are durable, idempotency-keyed obligations whose replays dedupe at the append layer.

## Doctrine + tests

- New **"Refold safety"** section in `docs/writing-stream-processors.md`: event-time state is not a guard; every vendor side effect must be one of three shapes — idempotency-keyed append, at-head fold reconciliation, or freshness-gated ack. Checklist extended with both rules.
- **The refold test** is now a documented requirement for every vendor-touching processor: run the live flow → advance the injected clock → feed the whole journal to a *fresh* instance → assert zero vendor calls (dangerous fakes THROW), zero new events, converged state.
- Tests added: refold tests for all three processors, plus late-wake ack skip, once-per-batch latest-fact-wins status, and mid-catch-up deferral of repo creation (`slack-processors.test.ts`, `pr-agent.test.ts`). The test `MemoryStreamNetwork` gained an injectable clock for the freshness gates.
- The rest of the processor fleet was audited clean: every other vendor-touching lane is idempotency-keyed, at-head-reconciled, or a bounded soft-fail probe (project processor's worker readiness wait).

**Live behavior is unchanged**: fresh events ack and paint exactly as before; only replays of history stop touching Slack/Artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-09T18:59:09.854Z",
      "headSha": "47d0d531585efcc92f2f326e649ac31a2571012c",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/573354949770493",
      "shortSha": "47d0d53",
      "cleanupDurationMs": 10800,
      "deployDurationMs": 75445,
      "workerSizeKib": 15472.14,
      "workerGzipKib": 4179.39,
      "mainWorkerGzipKib": 4177.65
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-09T18:59:00.022Z",
      "headSha": "2be8983719e03718672cef7136e5943ba3aefd26",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/182922125836593",
      "shortSha": "2be8983",
      "cleanupDurationMs": 966,
      "deployDurationMs": 14162,
      "testDurationMs": 10369,
      "testRetries": null,
      "workerSizeKib": 1913.73,
      "workerGzipKib": 440.69,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-09T18:59:01.885Z",
      "headSha": "47d0d531585efcc92f2f326e649ac31a2571012c",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/573354949770493",
      "shortSha": "47d0d53",
      "cleanupDurationMs": 2827,
      "deployDurationMs": 18890,
      "workerSizeKib": 4030.55,
      "workerGzipKib": 819.24,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-09T18:59:00.023Z",
      "headSha": "2be8983719e03718672cef7136e5943ba3aefd26",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/182922125836593",
      "shortSha": "2be8983",
      "cleanupDurationMs": 962,
      "deployDurationMs": 16121,
      "testDurationMs": 17611,
      "testRetries": null,
      "workerSizeKib": 4554.83,
      "workerGzipKib": 1312.83,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `47d0d53` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 819.2 KiB | 18.9s |  |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/573354949770493) | 2026-07-09T18:59:01.885Z | Preview app released. |
| OS | released | `47d0d53` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 4.08 MiB (+1.7 KiB vs main) | 75.4s |  |  | 10.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/573354949770493) | 2026-07-09T18:59:09.854Z | Preview app released. |
| Semaphore | released | `2be8983` | [https://semaphore.iterate-preview-6.com](https://semaphore.iterate-preview-6.com) | 440.7 KiB | 14.2s | 10.4s |  | 966ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/182922125836593) | 2026-07-09T18:59:00.022Z | Preview app released. |
| Streams Example App | released | `2be8983` | [https://streams.iterate-preview-6.com](https://streams.iterate-preview-6.com) | 1.28 MiB | 16.1s | 17.6s |  | 962ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/182922125836593) | 2026-07-09T18:59:00.023Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Slack integration UX and repo artifact creation on deploy-triggered refolds; behavior for live/fresh traffic is intended unchanged, but the repo `stateSchema` change forces a one-time refold per repo stream when this ships.
> 
> **Overview**
> Makes **full journal refolds** (normal after state-schema deploys) safe for three processors that previously re-fired vendor work on replay.
> 
> **Slack (router + agent):** Adds `webhookAckIsFresh` (15-minute horizon) and optional injectable `now`. Fast 👀 acks and agent eyes reactions only run for fresh events; durable forwards and agent input still replay and dedupe. **Assistant status** moves out of per-event `processEvent` into **`processEventBatch`**: one repaint per at-head batch from the latest LLM/script lifecycle fact, with freshness gating and an in-memory carry when lifecycle facts land in behind-the-head batches.
> 
> **Repo:** Adds folded **`createRequested`** to state and reconciles **`createRepoArtifact`** in **`processEventBatch`** when at head and `createRequested && !created`, instead of guarding on event-time `state.created` in `processEvent` (refold could re-seed and force-push over user commits).
> 
> **Docs/tests:** New **“Refold safety”** doctrine and required refold-test pattern in `writing-stream-processors.md`; refold and related scenarios in `slack-processors.test.ts` and `pr-agent.test.ts`. Generated API types pick up `createRequested`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47d0d531585efcc92f2f326e649ac31a2571012c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +147 -37 | +74 -37 🟩🟥⬜⬜⬜ |
| Tests | +318 -3 | +250 -3 🟩🟩🟩🟩🟩 |
| Docs | +97 -24 | +87 -24 🟩🟩⬜⬜⬜ |
| Generated | +3 -0 | +3 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+565 -64** | **+414 -64** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between af04122 and 47d0d53, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->