### PR TITLE
Mark the stream-view lazy fallback and repo bootstrap panel as loading states

### DIFF
--- a/apps/os/src/components/project-stream-view.lazy.tsx
+++ b/apps/os/src/components/project-stream-view.lazy.tsx
@@ -17,8 +17,11 @@ export function ProjectStreamView(props: ProjectStreamViewProps) {
   return (
     <Suspense
       fallback={
-        <div className="grid min-h-0 flex-1 place-items-center p-6 text-sm text-muted-foreground">
-          Loading stream view
+        <div
+          className="grid min-h-0 flex-1 place-items-center p-6 text-sm text-muted-foreground"
+          data-spinner="true"
+        >
+          Loading stream view…
         </div>
       }
     >

--- a/apps/os/src/routes/_app/projects/$projectSlug/repos/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/repos/$.tsx
@@ -66,7 +66,11 @@ function ProjectRepoDetailContent() {
     ) : state.initialized ? (
       <RepoIde key={`${project.id}:${repoPath}`} projectId={project.id} repoPath={repoPath} />
     ) : (
-      <div className="overflow-y-auto p-4">
+      // data-spinner: this panel is live bootstrap progress (the processor
+      // pushes each step in), and right after repos.create it can also show a
+      // momentarily-stale checkpoint on a repo that IS already initialized —
+      // waits must keep extending until the live push replaces it.
+      <div className="overflow-y-auto p-4" data-spinner="true">
         <div className="mx-auto w-full max-w-2xl rounded-lg border bg-card">
           <InfoRow label="Created" value={state.created ? "yes" : "not yet"} />
           <InfoRow label="Initialized" value={state.initialized ? "yes" : "not yet"} />


### PR DESCRIPTION
## Why

The `repo-ide-svg-index-preview` / `repo-ide-markdown-preview` playwright specs flaked on cold preview slots (first file-tree click timing out, passing on retry). The specs were fine — the flake was two product loading states that are invisible to the e2e spinner-waiter, which by policy fails an action fast when the target isn't ready and no visible loading state is present (`SPEC_ACTION_TIMEOUT_MS` stays tight on purpose; see `e2e-policy/budgets.ts`).

## The two no-spinner windows

1. **`project-stream-view.lazy.tsx`** — the chunk-load fallback said "Loading stream view": no `data-spinner`, no trailing ellipsis, so it matched none of the waiter's spinner selectors. This window is crossed on **every** cold navigation to a stream-view page while the large CodeMirror/feed chunk downloads — fast locally and on retry (warm edge), seconds on a cold slot. It likely also explains other first-click-after-goto spec retries (reactivity, REPL, chat feed).
2. **`repos/$.tsx`** — the repo bootstrap InfoRow panel ("Created / Initialized: not yet") shows when the repo processor's checkpoint briefly lags a just-completed `repos.create`, with no spinner marker while the live push catches up.

## Proof

Reproduced the mechanism deterministically with a throwaway spec that delays the stream-view chunk 5s via `page.route`, then clicks the file tree:

- **Fix reverted:** exact CI failure signature — `locator.click: Timeout 1ms exceeded` waiting for `[data-item-path="icon.svg"]`, with the spinner-waiter's "update the product code to add a spinner" suggestion.
- **With fix:** passes — the waiter rides the now-visible spinner through the slow load.

Both repo-ide specs pass locally; typecheck/lint/format clean. No timeout budgets widened, no specs touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markup and loading-copy only; no auth, data, or business-logic changes—improves e2e detectability of existing loading states.
> 
> **Overview**
> Two product loading UIs were invisible to the e2e **spinner waiter** (no `data-spinner`), which caused tight-timeout flakes on cold navigations and right after repo creation.
> 
> The **lazy stream view** Suspense fallback now sets `data-spinner="true"` and uses a trailing ellipsis on “Loading stream view…”, so chunk-load waits are recognized while the CodeMirror/feed bundle downloads.
> 
> The **repo bootstrap** InfoRow panel (shown when the processor checkpoint lags behind a completed init) now wraps that progress UI with `data-spinner="true"` and documents why waits must extend through stale “not yet” states until live state catches up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92da5190a6d7fe783930cfea8c6d730ef9e89ba4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +5 -1 | +1 -1 🟩⬜⬜⬜⬜ |
| UI components | +5 -2 | +5 -2 🟩🟩🟩🟩🟥 |
| **Total** | **+10 -3** | **+6 -3** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 93067c4 and 92da519, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-09T19:15:00.105Z",
      "headSha": "92da5190a6d7fe783930cfea8c6d730ef9e89ba4",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/146420770124099",
      "shortSha": "92da519",
      "cleanupDurationMs": 12183,
      "deployDurationMs": 80374,
      "testDurationMs": 316848,
      "testRetries": "3 retried: catalogue example \"stream-cross-post\" runs identically across runtimes (vitest x1) · agent runs an itx script that appends a proof event, then replies (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 15468.42,
      "workerGzipKib": 4177.58,
      "mainWorkerGzipKib": 4181.13
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-09T19:14:48.702Z",
      "headSha": "92da5190a6d7fe783930cfea8c6d730ef9e89ba4",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/146420770124099",
      "shortSha": "92da519",
      "cleanupDurationMs": 778,
      "deployDurationMs": 15081,
      "testDurationMs": 5830,
      "testRetries": null,
      "workerSizeKib": 1914.69,
      "workerGzipKib": 440.77,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-09T19:14:51.282Z",
      "headSha": "92da5190a6d7fe783930cfea8c6d730ef9e89ba4",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/146420770124099",
      "shortSha": "92da519",
      "cleanupDurationMs": 3356,
      "deployDurationMs": 18876,
      "testDurationMs": 636,
      "testRetries": null,
      "workerSizeKib": 4031.52,
      "workerGzipKib": 819.3,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-09T19:14:48.942Z",
      "headSha": "92da5190a6d7fe783930cfea8c6d730ef9e89ba4",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/146420770124099",
      "shortSha": "92da519",
      "cleanupDurationMs": 1013,
      "deployDurationMs": 13494,
      "testDurationMs": 19793,
      "testRetries": null,
      "workerSizeKib": 4554.48,
      "workerGzipKib": 1312.72,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `92da519` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 819.3 KiB | 18.9s | 636ms |  | 3.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/146420770124099) | 2026-07-09T19:14:51.282Z | Preview app released. |
| OS | released | `92da519` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.08 MiB (-3.6 KiB vs main) | 80.4s | 316.8s | 3 retried: catalogue example "stream-cross-post" runs identically across runtimes (vitest x1) · agent runs an itx script that appends a proof event, then replies (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 12.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/146420770124099) | 2026-07-09T19:15:00.105Z | Preview app released. |
| Semaphore | released | `92da519` | [https://semaphore.iterate-preview-1.com](https://semaphore.iterate-preview-1.com) | 440.8 KiB | 15.1s | 5.8s |  | 778ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/146420770124099) | 2026-07-09T19:14:48.702Z | Preview app released. |
| Streams Example App | released | `92da519` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.28 MiB | 13.5s | 19.8s |  | 1.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/146420770124099) | 2026-07-09T19:14:48.942Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->