### PR TITLE
[codex] add kill controls for streams and durable objects

### DIFF
--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState, type ReactNode } from "react";
 import { FilterIcon, XIcon } from "lucide-react";
 import { Button } from "@iterate-com/ui/components/button";
 import { Sheet, SheetContent, SheetTitle } from "@iterate-com/ui/components/sheet";
+import { toast } from "@iterate-com/ui/components/sonner";
 import { Tabs, TabsList, TabsTrigger } from "@iterate-com/ui/components/tabs";
 import type {
   AgentUiLlmStep,
@@ -159,6 +160,7 @@ export function ProjectStreamView({
   const agentPauseState = useStreamPauseState(store.streamDatabase);
   const metrics = useSimulatedRttMetrics();
   const [pauseMutationPending, setPauseMutationPending] = useState(false);
+  const [killMutationPending, setKillMutationPending] = useState(false);
 
   const { search, setSearch } = useStreamViewSearch();
   const panels = useStreamViewPanels();
@@ -246,6 +248,29 @@ export function ProjectStreamView({
         },
       }
     : undefined;
+  const streamKillControl = {
+    pending: killMutationPending,
+    kill: async () => {
+      if (killMutationPending) return;
+      setKillMutationPending(true);
+      try {
+        const stream = await resolvedStreamSource(streamPath);
+        await stream.kill();
+        toast.success("Stream killed");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (message.toLowerCase().includes("kill requested")) {
+          toast.success("Stream killed");
+        } else {
+          toast.error(`Failed to kill stream: ${message}`);
+          return;
+        }
+      } finally {
+        setKillMutationPending(false);
+      }
+      nudgeDeliveries();
+    },
+  };
 
   const filterRow =
     search.filter !== true ? null : activeTab === "feed" ? (
@@ -357,6 +382,7 @@ export function ProjectStreamView({
           eventsToggle={{ eventCount }}
           metrics={metrics}
           presence={presence}
+          streamKill={streamKillControl}
           streamPath={streamPath}
         />
         <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">{panel}</div>
@@ -427,6 +453,7 @@ export function ProjectStreamView({
           agentPause={agentPauseControl}
           metrics={metrics}
           presence={presence}
+          streamKill={streamKillControl}
           streamPath={streamPath}
         />
       ) : null}

--- a/apps/os/src/components/stream-view-header.tsx
+++ b/apps/os/src/components/stream-view-header.tsx
@@ -1,4 +1,11 @@
-import { FilterIcon, HistoryIcon, MoreHorizontalIcon, PauseIcon, PlayIcon } from "lucide-react";
+import {
+  CircleStopIcon,
+  FilterIcon,
+  HistoryIcon,
+  MoreHorizontalIcon,
+  PauseIcon,
+  PlayIcon,
+} from "lucide-react";
 import { Badge } from "@iterate-com/ui/components/badge";
 import { Button } from "@iterate-com/ui/components/button";
 import {
@@ -40,6 +47,7 @@ export function StreamViewHeader({
   eventsToggle,
   metrics,
   presence,
+  streamKill,
   streamPath,
 }: {
   agentBusy: boolean;
@@ -48,6 +56,10 @@ export function StreamViewHeader({
     pending: boolean;
     reason: string | null;
     setPaused: (paused: boolean) => Promise<void>;
+  };
+  streamKill: {
+    kill: () => Promise<void>;
+    pending: boolean;
   };
   /**
    * Full-panel layouts relegate the feed to a sheet; this renders the header
@@ -189,22 +201,27 @@ export function StreamViewHeader({
             </Button>
           </>
         )}
-        {agentPause == null ? null : <AgentActionMenu pause={agentPause} />}
+        <StreamActionMenu kill={streamKill} pause={agentPause} />
       </div>
     </header>
   );
 }
 
-function AgentActionMenu({
+function StreamActionMenu({
+  kill,
   pause,
 }: {
-  pause: {
+  kill: {
+    kill: () => Promise<void>;
+    pending: boolean;
+  };
+  pause?: {
     paused: boolean;
     pending: boolean;
     setPaused: (paused: boolean) => Promise<void>;
   };
 }) {
-  const Icon = pause.paused ? PlayIcon : PauseIcon;
+  const PauseActionIcon = pause?.paused ? PlayIcon : PauseIcon;
 
   return (
     <DropdownMenu>
@@ -213,7 +230,7 @@ function AgentActionMenu({
           <Button
             variant="ghost"
             size="icon"
-            title="Agent actions"
+            title={pause == null ? "Stream actions" : "Agent actions"}
             className="rounded-full text-muted-foreground"
           />
         }
@@ -222,14 +239,27 @@ function AgentActionMenu({
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-44">
         <DropdownMenuGroup>
-          <DropdownMenuLabel>Agent actions</DropdownMenuLabel>
+          <DropdownMenuLabel>
+            {pause == null ? "Stream actions" : "Agent actions"}
+          </DropdownMenuLabel>
+          {pause == null ? null : (
+            <DropdownMenuItem
+              closeOnClick
+              disabled={pause.pending}
+              onClick={() => void pause.setPaused(!pause.paused)}
+            >
+              {pause.pending ? <Spinner /> : <PauseActionIcon />}
+              {pause.paused ? "Resume agent" : "Pause agent"}
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem
             closeOnClick
-            disabled={pause.pending}
-            onClick={() => void pause.setPaused(!pause.paused)}
+            disabled={kill.pending}
+            variant="destructive"
+            onClick={() => void kill.kill()}
           >
-            {pause.pending ? <Spinner /> : <Icon />}
-            {pause.paused ? "Resume agent" : "Pause agent"}
+            {kill.pending ? <Spinner /> : <CircleStopIcon />}
+            Kill stream
           </DropdownMenuItem>
         </DropdownMenuGroup>
       </DropdownMenuContent>

--- a/apps/os/src/domains/agents/agent-durable-object.ts
+++ b/apps/os/src/domains/agents/agent-durable-object.ts
@@ -189,6 +189,11 @@ export class AgentDurableObject extends DurableObject<Env> {
     return this.#processorHost.handleAlarm();
   }
 
+  /** Abort the current Durable Object incarnation; the next request boots it again. */
+  kill(): void {
+    this.ctx.abort("kill requested");
+  }
+
   get processor() {
     return new StreamProcessorRpcTarget(this.#agentProcessor);
   }

--- a/apps/os/src/domains/capability-host/capability-host-durable-object.ts
+++ b/apps/os/src/domains/capability-host/capability-host-durable-object.ts
@@ -105,6 +105,11 @@ export class CapabilityHostDurableObject extends DurableObject<Env> {
     return this.#processorHost.handleAlarm();
   }
 
+  /** Abort the current Durable Object incarnation; the next request boots it again. */
+  kill(): void {
+    this.ctx.abort("kill requested");
+  }
+
   get processor() {
     return new StreamProcessorRpcTarget(this.#capabilityHostProcessor);
   }

--- a/apps/os/src/domains/email/email-processors.test.ts
+++ b/apps/os/src/domains/email/email-processors.test.ts
@@ -35,6 +35,8 @@ class MemoryStream implements Stream {
     return { instructions: "in-memory test stream", types: "", children: {} };
   }
 
+  async kill(): Promise<void> {}
+
   constructor(
     readonly network: MemoryStreamNetwork,
     readonly path: string,

--- a/apps/os/src/domains/integrations/slack-processors.test.ts
+++ b/apps/os/src/domains/integrations/slack-processors.test.ts
@@ -42,6 +42,8 @@ class MemoryStream implements Stream {
     return { instructions: "in-memory test stream", types: "", children: {} };
   }
 
+  async kill(): Promise<void> {}
+
   constructor(
     readonly network: MemoryStreamNetwork,
     readonly path: string,

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -133,6 +133,11 @@ export class ProjectDurableObject extends DurableObject<Env> {
     };
   }
 
+  /** Abort the current Durable Object incarnation; the next request boots it again. */
+  kill(): void {
+    this.ctx.abort("kill requested");
+  }
+
   get processor() {
     return new StreamProcessorRpcTarget(this.#projectProcessor, {
       // Lists served from this snapshot (child streams, secrets) must reflect

--- a/apps/os/src/domains/projects/project-processor.test.ts
+++ b/apps/os/src/domains/projects/project-processor.test.ts
@@ -13,6 +13,8 @@ class MemoryStream implements Stream {
     return { instructions: `in-memory stream ${this.path}`, types: "", children: {} };
   }
 
+  async kill(): Promise<void> {}
+
   async append(...inputs: StreamEventInput[]): Promise<StreamEvent[]> {
     return inputs.map((input) => {
       const existing =

--- a/apps/os/src/domains/repos/pr-agent.test.ts
+++ b/apps/os/src/domains/repos/pr-agent.test.ts
@@ -44,6 +44,8 @@ class MemoryStream implements Stream {
     return { instructions: "in-memory test stream", types: "", children: {} };
   }
 
+  async kill(): Promise<void> {}
+
   constructor(
     readonly network: MemoryStreamNetwork,
     readonly path: string,

--- a/apps/os/src/domains/repos/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/repo-durable-object.ts
@@ -79,6 +79,11 @@ export class RepoDurableObject extends DurableObject<Env> {
     return this.#host.handleAlarm();
   }
 
+  /** Abort the current Durable Object incarnation; the next request boots it again. */
+  kill(): void {
+    this.ctx.abort("kill requested");
+  }
+
   get processor() {
     return new StreamProcessorRpcTarget(this.#repoProcessor);
   }

--- a/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
+++ b/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
@@ -276,6 +276,11 @@ export abstract class SandboxDurableObject extends Sandbox<Env> {
     return this.#identity().projectId;
   }
 
+  /** Abort the current Durable Object incarnation; the next request boots it again. */
+  kill(): void {
+    this.ctx.abort("kill requested");
+  }
+
   /**
    * Create the sandbox: write the durable record that makes it exist. The
    * instance type is validated against THIS class (the collection routed here

--- a/apps/os/src/domains/sandboxes/utils.ts
+++ b/apps/os/src/domains/sandboxes/utils.ts
@@ -22,7 +22,8 @@ import type { SandboxInstanceType } from "./instance-types.ts";
  *   anything since the last snapshot.
  * - `start()` boots the container now instead of lazily; `sleep()` snapshots
  *   and tears down now instead of waiting for `sleepAfter` (the SDK's
- *   `stop()` forwards to it); `destroy()` is permanent — the name is retired.
+ *   `stop()` forwards to it); `kill()` aborts the Durable Object incarnation;
+ *   `destroy()` is permanent — the name is retired.
  * - `__describe()` (the capability-tree convention) carries the durable
  *   record as structured extras ({ path, instanceType, createdAt, sleepAfter }).
  * - `setEnvVars(vars)` is DURABLE here (persisted, re-applied every start,
@@ -33,7 +34,10 @@ import type { SandboxInstanceType } from "./instance-types.ts";
  * - `mountBucket` and `exposePort` are unavailable (they throw): /workspace
  *   snapshots cover persistence, and `tunnels` covers public URLs.
  */
-export type CloudflareSandbox = object;
+export type CloudflareSandbox = object & {
+  /** Abort the current sandbox Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
+};
 
 /** What `itx.sandboxes.create` takes — Cloudflare's own vocabulary
  * (instance types, `SandboxOptions.sleepAfter`/`keepAlive`) plus a name. */

--- a/apps/os/src/domains/scheduler/scheduler-durable-object.ts
+++ b/apps/os/src/domains/scheduler/scheduler-durable-object.ts
@@ -131,6 +131,11 @@ export class SchedulerDurableObject extends DurableObject<Env> {
     return this.#processorHost.wakeStreamSubscriber(args);
   }
 
+  /** Abort the current Durable Object incarnation; the next request boots it again. */
+  kill(): void {
+    this.ctx.abort("kill requested");
+  }
+
   get processor() {
     return new StreamProcessorRpcTarget(this.#schedulerProcessor);
   }

--- a/apps/os/src/domains/scheduler/scheduler-processor.test.ts
+++ b/apps/os/src/domains/scheduler/scheduler-processor.test.ts
@@ -33,6 +33,8 @@ class MemoryStream implements Stream {
     return { instructions: "in-memory test stream", types: "", children: {} };
   }
 
+  async kill(): Promise<void> {}
+
   async append(...inputs: StreamEventInput[]): Promise<StreamEvent[]> {
     return inputs.map((input) => {
       if (input.type === this.failAppendsOfType) {

--- a/apps/os/src/domains/secrets/secret-durable-object.ts
+++ b/apps/os/src/domains/secrets/secret-durable-object.ts
@@ -68,6 +68,11 @@ export class SecretDurableObject extends DurableObject<Env> {
     return this.#processorHost.handleAlarm();
   }
 
+  /** Abort the current Durable Object incarnation; the next request boots it again. */
+  kill(): void {
+    this.ctx.abort("kill requested");
+  }
+
   get processor() {
     return new StreamProcessorRpcTarget(this.#secretProcessor, {
       catchUpBeforeSnapshot: () => this.#processorHost.catchUp(SecretProcessorContract.slug),

--- a/apps/os/src/domains/streams/client-libraries/browser/stream-browser-store.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/stream-browser-store.ts
@@ -126,11 +126,7 @@ export type StreamBrowserStore = Disposable & {
   getProcessorRuntimeState(args: {
     subscriptionKey: SubscriptionKey;
   }): StreamRpcResult<ProcessorRuntimeState | null>;
-  /**
-   * Mirror reset is local-only on itx: the `Stream` capability has
-   * no `kill()`/`reset()`, so this clears the local tables + checkpoint and
-   * reconnects, letting reconcile + replay rebuild the mirror from the server.
-   */
+  /** Clear local tables + checkpoint and reconnect, letting reconcile + replay rebuild the mirror from the server. */
   clearLocalDatabase(): Promise<void>;
   /**
    * On-demand delivery check for when the caller knows the server is about to

--- a/apps/os/src/domains/streams/test-helpers.ts
+++ b/apps/os/src/domains/streams/test-helpers.ts
@@ -31,6 +31,8 @@ export class MemoryStream implements Stream {
     return { instructions: "in-memory test stream", types: "", children: {} };
   }
 
+  async kill(): Promise<void> {}
+
   async append(...inputs: StreamEventInput[]): Promise<StreamEvent[]> {
     const appended = inputs.map((input) => {
       const existing =

--- a/apps/os/src/domains/workers/schemas.ts
+++ b/apps/os/src/domains/workers/schemas.ts
@@ -158,8 +158,12 @@ export type StatefulDynamicWorkerRef = DynamicWorkerRefBase & {
 /** Worker recipe accepted by `workers.get` and worker-backed capabilities. */
 export type DynamicWorkerRef = StatelessDynamicWorkerRef | StatefulDynamicWorkerRef;
 
-/** Dynamic worker RPC stub plus the disposal operation owned by the caller. */
-export type DynamicWorkerCapability<T extends object = Record<string, unknown>> = T & Disposable;
+/** Dynamic worker RPC stub plus platform-owned lifecycle operations. */
+export type DynamicWorkerCapability<T extends object = Record<string, unknown>> = T &
+  Disposable & {
+    /** Abort the stateful worker Durable Object incarnation. Stateless worker refs reject. */
+    kill(): Promise<void>;
+  };
 
 /**
  * Per-stub dispatch options for `DynamicWorkerCollection.get`.

--- a/apps/os/src/domains/workers/stateful-worker-durable-object.ts
+++ b/apps/os/src/domains/workers/stateful-worker-durable-object.ts
@@ -94,6 +94,16 @@ export class StatefulWorkerDurableObject extends DurableObject<Env> {
       : await replayPath({ args, path, target });
   }
 
+  /** Abort the hosted facet and current outer Durable Object incarnation. */
+  kill(): void {
+    try {
+      this.ctx.facets.abort(FACET_NAME, `kill requested for ${this.ctx.id.name}`);
+    } catch (error) {
+      console.warn(`stateful worker facet kill skipped for ${this.ctx.id.name}`, error);
+    }
+    this.ctx.abort("kill requested");
+  }
+
   async #facet(ref: StatefulDynamicWorkerRef, buildBudgetMs?: number): Promise<unknown> {
     this.#assertRefMatchesName(ref);
 

--- a/apps/os/src/domains/workers/worker-runner.ts
+++ b/apps/os/src/domains/workers/worker-runner.ts
@@ -32,6 +32,7 @@ type StatefulWorkerRpc = {
     path: string[];
     ref: StatefulDynamicWorkerRef;
   }): Promise<unknown>;
+  kill(): Promise<void>;
 };
 
 /**
@@ -205,6 +206,11 @@ export class DynamicWorkerRunner {
     return flattenNestedPath
       ? await invokePreferringFlattenedPath({ args, path, target })
       : await replayPath({ args, path, target });
+  }
+
+  /** Abort a stateful dynamic worker's outer Durable Object and hosted facet. */
+  async kill(ref: StatefulDynamicWorkerRef): Promise<void> {
+    await this.#statefulWorker(ref).kill();
   }
 
   async #load(

--- a/apps/os/src/domains/workspaces/workspace-durable-object.ts
+++ b/apps/os/src/domains/workspaces/workspace-durable-object.ts
@@ -83,6 +83,11 @@ export class WorkspaceDurableObject extends DurableObject<Env> {
     return `workspace ${this.#name.projectId}:${this.#name.path}`;
   }
 
+  /** Abort the current Durable Object incarnation; the next request boots it again. */
+  kill(): void {
+    this.ctx.abort("kill requested");
+  }
+
   // -- clone-on-first-touch gate ------------------------------------------
 
   // In-flight clone, shared by every concurrent first call. Reset on failure

--- a/apps/os/src/itx-api.generated.ts
+++ b/apps/os/src/itx-api.generated.ts
@@ -96,6 +96,8 @@ export interface Project {
   __describe(): Promise<ProjectDescription>;
   /** Formatted dashboard/debug info for this itx scope, suitable for Slack messages. */
   debug(): Promise<string>;
+  /** Abort this Project Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   /** The project stream processor (snapshot/state; `state.created` flips when bootstrap lands). */
   processor: WakeableStreamProcessorRpc<ProjectProcessorState>;
   /** Workers AI: run(model, body), models(). */
@@ -317,6 +319,8 @@ export interface Agent {
   }): Promise<{ event: StreamEvent; files: AgentFileAttachment[] }>;
   /** Includes `whoami` (`"agent <projectId>:<agentPath>"`), `projectId`, `agentPath`. */
   __describe(): Promise<Description & { agentPath: string; projectId: string; whoami: string }>;
+  /** Abort this Agent Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
 }
 
 /** Agent-local web chat response tool exposed inside agent script execution. */
@@ -368,6 +372,8 @@ export interface CapabilityHost {
     executionId: string;
     result: unknown;
   }>;
+  /** Abort this Capability Host Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
 }
 
 /** Catalog of capability scopes within one project (`itx.capabilityHosts`). */
@@ -687,6 +693,8 @@ export interface Scheduler {
   set(input: SetScheduleInput): Promise<ScheduleView>;
   /** Remove a key. Idempotent; an in-flight Trigger completes as `skipped`. */
   cancel(key: string): Promise<void>;
+  /** Abort this Scheduler Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   list(): Promise<ScheduleView[]>;
   /** Run a Schedule now. Advances a recurring Schedule's clock and consumes a one-shot. */
   trigger(key: string): Promise<{ executionId: string }>;
@@ -715,6 +723,8 @@ export interface Repo {
   create(): Promise<Repo>;
   /** Repo identity string (debug). */
   whoami(): Promise<string>;
+  /** Abort this Repo Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   /** Commit a batch of file changes; use `edit` for a targeted single-string replacement. */
   commitFiles(input: CommitRepoFilesInput): Promise<CommitRepoFilesResult>;
   /**
@@ -897,6 +907,8 @@ export interface Stream {
       >;
     };
   }>;
+  /** Abort the current Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   /**
    * Live EPHEMERAL event delivery: `processEventBatch` is called for every
    * committed batch (optionally replayed from `replayAfterOffset`); returns an
@@ -1033,6 +1045,8 @@ export interface Secret {
   __describe(): Promise<Description & SecretDescription>;
   /** Egress fetch with this secret's placeholders substituted server-side. */
   fetch(request: Request): Promise<Response>;
+  /** Abort this Secret Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   /** Set the secret material and/or its egress allowlist. */
   update(input: SecretUpdateInput): Promise<StreamEvent>;
   /** The secret stream processor; its public state IS the SecretDescription. */
@@ -1057,6 +1071,8 @@ export interface Workspace {
   __describe(): Promise<Description>;
   /** Workspace identity string (debug). */
   whoami(): Promise<string>;
+  /** Abort this Workspace Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   /** File contents, or null when the path does not exist. */
   readFile(path: string): Promise<string | null>;
   /** Raw file bytes (use for binaries — readFile text-decodes), or null when missing. */
@@ -1376,8 +1392,12 @@ export type StreamPushEventBatch = {
   configuredEvent: Pick<StreamEvent, "type" | "offset" | "createdAt" | "path" | "payload">;
 };
 
-/** Dynamic worker RPC stub plus the disposal operation owned by the caller. */
-export type DynamicWorkerCapability<T extends object = Record<string, unknown>> = T & Disposable;
+/** Dynamic worker RPC stub plus platform-owned lifecycle operations. */
+export type DynamicWorkerCapability<T extends object = Record<string, unknown>> = T &
+  Disposable & {
+    /** Abort the stateful worker Durable Object incarnation. Stateless worker refs reject. */
+    kill(): Promise<void>;
+  };
 
 /** One entry of a session's project catalog (`session.projects.list()`). */
 export type ProjectListEntry = {
@@ -1709,7 +1729,8 @@ export type SandboxInstanceType =
  *   anything since the last snapshot.
  * - `start()` boots the container now instead of lazily; `sleep()` snapshots
  *   and tears down now instead of waiting for `sleepAfter` (the SDK's
- *   `stop()` forwards to it); `destroy()` is permanent — the name is retired.
+ *   `stop()` forwards to it); `kill()` aborts the Durable Object incarnation;
+ *   `destroy()` is permanent — the name is retired.
  * - `__describe()` (the capability-tree convention) carries the durable
  *   record as structured extras ({ path, instanceType, createdAt, sleepAfter }).
  * - `setEnvVars(vars)` is DURABLE here (persisted, re-applied every start,
@@ -1720,7 +1741,10 @@ export type SandboxInstanceType =
  * - `mountBucket` and `exposePort` are unavailable (they throw): /workspace
  *   snapshots cover persistence, and `tunnels` covers public URLs.
  */
-export type CloudflareSandbox = object;
+export type CloudflareSandbox = object & {
+  /** Abort the current sandbox Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
+};
 
 /** The scheduler's reduced state: the one object the UI, alarm, and executor read. */
 export type SchedulerProcessorState = {

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -321,13 +321,14 @@ function parallelOpenApiTarget(input: { egress: FetchOnly; parent: string }): Op
 export class StreamRpcTarget extends IterateRpcTarget<"Stream"> {
   async __describe(): Promise<Description> {
     return describeNode({
-      instructions: `A durable event stream at path "${this.props.path}": append(events), readEvents(), getEvents(), waitForEvent(), subscribe(), crossPostTo(). Streams are the coordination primitive — processors and agents communicate by appending and reducing events. THE LOCALITY RULE: a processor on stream A can only react to events ON stream A; to react to another stream's events, cross-post them here (copies carry full source.crossPostedFrom provenance chains).`,
+      instructions: `A durable event stream at path "${this.props.path}": append(events), readEvents(), getEvents(), waitForEvent(), subscribe(), crossPostTo(), kill(). Streams are the coordination primitive — processors and agents communicate by appending and reducing events. THE LOCALITY RULE: a processor on stream A can only react to events ON stream A; to react to another stream's events, cross-post them here (copies carry full source.crossPostedFrom provenance chains).`,
       children: {
         append: "Commit events; returns them with offsets.",
         at: "The stream at a sub-path.",
         crossPostTo: "Copy matching events onto another stream (optionally JSONata-transformed).",
         getEvent: "One event by offset or idempotencyKey.",
         getEvents: "Read one bounded page of events.",
+        kill: "Abort the current Durable Object incarnation; the next request boots it again.",
         readEvents: "Create a pager for bounded event pages.",
         removeCrossPost: "Remove a cross-post configured by crossPostTo.",
         subscribe: "Ephemeral live event delivery; returns an unsubscribe handle.",
@@ -436,6 +437,11 @@ export class StreamRpcTarget extends IterateRpcTarget<"Stream"> {
     };
   }> {
     return this.durableObjectStub.runtimeState();
+  }
+
+  /** Abort the current Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void> {
+    return Promise.resolve(this.durableObjectStub.kill());
   }
 
   /**
@@ -618,6 +624,7 @@ class SchedulerRpcTarget extends IterateRpcTarget<"Scheduler"> {
         "outcome is an event on this stream.",
       children: {
         cancel: "Remove a Schedule by key (idempotent).",
+        kill: "Abort this Scheduler Durable Object incarnation; the next request boots it again.",
         list: "Every Schedule, reduced from the stream.",
         processor: "The scheduler stream processor (snapshot/state).",
         set: "Upsert a Schedule: { key, recurrence, script, metadata? }.",
@@ -662,6 +669,11 @@ class SchedulerRpcTarget extends IterateRpcTarget<"Scheduler"> {
   /** Remove a key. Idempotent; an in-flight Trigger completes as `skipped`. */
   cancel(key: string): Promise<void> {
     return this.#durableObjectStub.cancelSchedule(key);
+  }
+
+  /** Abort this Scheduler Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void> {
+    return Promise.resolve(this.#durableObjectStub.kill());
   }
 
   list(): Promise<ScheduleView[]> {
@@ -766,6 +778,7 @@ class RepoRpcTarget extends IterateRpcTarget<"Repo"> {
           "Commit a batch of file changes ({ message, changes }); each change is { path, content } for text, { path, contentBase64 } for binary, or { path, delete: true }.",
         create: "Create the repo if it does not exist yet.",
         edit: "Replace an exact string in one file and commit it; oldString must match once unless replaceAll is true.",
+        kill: "Abort this Repo Durable Object incarnation; the next request boots it again.",
         linkGithub:
           "Back this repo with a GitHub repository via a named GitHub connection ({ connection, owner, repo }); commits mirror out, webhooks cross-post in.",
         listFiles: "List file paths.",
@@ -816,6 +829,11 @@ class RepoRpcTarget extends IterateRpcTarget<"Repo"> {
   /** Repo identity string (debug). */
   whoami(): Promise<string> {
     return this.#durableObjectStub.whoami();
+  }
+
+  /** Abort this Repo Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void> {
+    return Promise.resolve(this.#durableObjectStub.kill());
   }
 
   /** Commit a batch of file changes; use `edit` for a targeted single-string replacement. */
@@ -1104,7 +1122,7 @@ class SandboxCollectionRpcTarget extends IterateRpcTarget<"SandboxCollection"> {
   async __describe(): Promise<Description> {
     return describeNode({
       instructions:
-        "The project's sandboxes — real Linux containers, explicitly created and kept like pets. create({ name, instanceType? }) makes one at /sandboxes/<name> (names are one path segment; instance types are Cloudflare's, fixed for life: lite, basic (default), standard-1..4 — https://developers.cloudflare.com/containers/platform-details/limits/); get(path) returns its bare Cloudflare Sandbox SDK stub (exec, files, processes, sessions, gitCheckout, code interpreter, tunnels — https://developers.cloudflare.com/sandbox/api/) plus start()/sleep()/destroy() and __describe() like every node. The first command boots the container; after sleepAfter idle it is snapshotted and torn down — /workspace survives via the snapshot, nothing else does. Nothing is preinstalled beyond the stock image (Ubuntu, Node, Bun, git).",
+        "The project's sandboxes — real Linux containers, explicitly created and kept like pets. create({ name, instanceType? }) makes one at /sandboxes/<name> (names are one path segment; instance types are Cloudflare's, fixed for life: lite, basic (default), standard-1..4 — https://developers.cloudflare.com/containers/platform-details/limits/); get(path) returns its bare Cloudflare Sandbox SDK stub (exec, files, processes, sessions, gitCheckout, code interpreter, tunnels — https://developers.cloudflare.com/sandbox/api/) plus start()/sleep()/destroy()/kill() and __describe() like every node. The first command boots the container; after sleepAfter idle it is snapshotted and torn down — /workspace survives via the snapshot, nothing else does. Nothing is preinstalled beyond the stock image (Ubuntu, Node, Bun, git).",
       children: {
         create: "Create a sandbox (strict: existing/destroyed names are errors). Returns { path }.",
         get: "The sandbox at a created path (boots the container on first use).",
@@ -1305,6 +1323,7 @@ class WorkspaceRpcTarget extends IterateRpcTarget<"Workspace"> {
         exists: "Whether a path exists.",
         git: "Git over this checkout: status/add/rm/commit/log/diff/push — push goes to this workspace's own branch.",
         glob: "Files matching a glob pattern.",
+        kill: "Abort this Workspace Durable Object incarnation; the next request boots it again.",
         mkdir: "Create a directory ({ recursive } for parents).",
         mv: "Move/rename a file or directory.",
         readDir: "List a directory (defaults to the root).",
@@ -1339,6 +1358,11 @@ class WorkspaceRpcTarget extends IterateRpcTarget<"Workspace"> {
   /** Workspace identity string (debug). */
   whoami(): Promise<string> {
     return this.durableObjectStub.whoami();
+  }
+
+  /** Abort this Workspace Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void> {
+    return Promise.resolve(this.durableObjectStub.kill());
   }
 
   /** File contents, or null when the path does not exist. */
@@ -1548,6 +1572,7 @@ class SecretRpcTarget extends IterateRpcTarget<"Secret"> {
       instructions: `The secret at "${this.props.path}": __describe() for metadata (audit, egress, hasMaterial, refresh — never the value), update() to set value/egress/refresh, fetch() to use it in an egress request via placeholder substitution.`,
       children: {
         fetch: "Egress fetch with secret placeholders substituted server-side.",
+        kill: "Abort this Secret Durable Object incarnation; the next request boots it again.",
         update: "Set the value, egress URLs, and/or refresh strategy.",
       },
       parent: "itx.secrets.get(path)",
@@ -1573,6 +1598,11 @@ class SecretRpcTarget extends IterateRpcTarget<"Secret"> {
   /** Egress fetch with this secret's placeholders substituted server-side. */
   fetch(request: Request): Promise<Response> {
     return this.durableObjectStub.fetch(request);
+  }
+
+  /** Abort this Secret Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void> {
+    return Promise.resolve(this.durableObjectStub.kill());
   }
 
   /** Set the secret material and/or its egress allowlist. */
@@ -2879,6 +2909,7 @@ class AgentRpcTarget extends IterateRpcTarget<"Agent"> {
         ask: "Send a message and wait for the agent's next chat reply.",
         capabilityHost: "This agent scope's durable capability table.",
         chat: "The agent's web-chat door (sendMessage).",
+        kill: "Abort this Agent Durable Object incarnation; the next request boots it again.",
         processor: "The agent stream processor (snapshot/state).",
         provideCapability: "Shortcut: mount a capability on THIS agent's scope.",
         revokeCapability: "Shortcut: remove a mount from THIS agent's scope.",
@@ -2890,6 +2921,11 @@ class AgentRpcTarget extends IterateRpcTarget<"Agent"> {
       projectId: this.#props.projectId,
       whoami: `agent ${this.#props.projectId}:${this.#path}`,
     });
+  }
+
+  /** Abort this Agent Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void> {
+    return Promise.resolve(this.durableObjectStub.kill());
   }
 }
 
@@ -2940,9 +2976,9 @@ class DynamicWorkerCollectionRpcTarget extends IterateRpcTarget<"DynamicWorkerCo
  * RPC wrapper around a single DynamicWorkerRef.
  *
  * The returned object is a path proxy: unknown properties become path segments
- * and eventually call `invokeCapability`. Dynamic workers do not share a fixed
- * method surface, so this wrapper deliberately exposes no method names beyond
- * the flattened capability dispatcher.
+ * and eventually call `invokeCapability`. Dynamic workers reserve a tiny
+ * platform lifecycle surface (`invokeCapability`, `kill`, disposal); everything
+ * else belongs to the loaded worker.
  */
 class DynamicWorkerRpcTarget extends IterateRpcRelay<"DynamicWorkerCapability"> {
   readonly #buildBudgetMs: number | undefined;
@@ -3009,6 +3045,7 @@ class DynamicWorkerRpcTarget extends IterateRpcRelay<"DynamicWorkerCapability"> 
         'To ask the worker to describe ITSELF (boots it; only works if its code implements `__describe`), call `invokeCapability({ path: ["__describe"] })`.',
       children: {
         invokeCapability: "Explicit dispatch into the worker: { path, args, flattenNestedPath? }.",
+        kill: "Abort the stateful worker Durable Object incarnation; stateless worker refs reject.",
       },
       parent: `itx.workers of this project (itx scope path "${this.#ref.path}")`,
       ref: {
@@ -3046,6 +3083,14 @@ class DynamicWorkerRpcTarget extends IterateRpcRelay<"DynamicWorkerCapability"> 
       path,
       ref: this.#ref,
     });
+  }
+
+  /** Abort the stateful worker Durable Object incarnation; stateless worker refs reject. */
+  async kill(): Promise<void> {
+    if (this.#ref.type !== "stateful") {
+      throw new Error("Dynamic worker kill() only applies to stateful worker refs.");
+    }
+    await this.#runner.kill(this.#ref);
   }
 }
 
@@ -3485,6 +3530,7 @@ class CapabilityHostRpcTarget extends IterateRpcTarget<"CapabilityHost"> {
       children: {
         invokeCapability:
           "Explicit dynamic dispatch ({ path, args }); dotted calls compile to this.",
+        kill: "Abort this Capability Host Durable Object incarnation; the next request boots it again.",
         provideCapability: "Mount a capability on THIS scope; returns a revoke handle.",
         revokeCapability: "Remove a mount from THIS scope.",
         runScript: "Run an async (itx) => {...} script in this scope.",
@@ -3502,6 +3548,11 @@ class CapabilityHostRpcTarget extends IterateRpcTarget<"CapabilityHost"> {
     result: unknown;
   }> {
     return await this.#durableObject.runScript(code);
+  }
+
+  /** Abort this Capability Host Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void> {
+    return Promise.resolve(this.#durableObject.kill());
   }
 }
 
@@ -3554,6 +3605,7 @@ const PROJECT_BUILTIN_BLIPS: Record<string, string> = {
     "Project file storage: files.get(path) → put({ data, contentType }), bytes(), url() (signed public link), delete(). Agent scopes: prefer itx.agent.addFiles to store AND attach in one call.",
   integrations:
     'Integration connections, each at /integrations/<slug>/<connection>: list() enumerates them; itx.integrations.slack["<connection>"].chat.postMessage({ channel, text }), itx.integrations.google["<connection>"].gmail.request({ path, query }), itx.integrations.github["<connection>"].rest.repos.get({ owner, repo }) (a wrapped Octokit); other slugs resolve through the project capability table. Cloudflare first-party bindings live at itx.integrations.cf.{ai,browser,images,videos}.',
+  kill: "Abort this Project Durable Object incarnation; the next request boots it again.",
   mcp: "Ad-hoc MCP clients: connect(url); itx.mcp.exa is the built-in Exa web search.",
   openapi: "Ad-hoc OpenAPI clients: connect(spec).",
   parallel: "Parallel API: preconfigured OpenAPI client using Iterate's platform API key.",
@@ -3696,6 +3748,11 @@ export class ProjectRpcTarget extends IterateRpcTarget<"Project"> {
       `Path: \`${streamPath}\``,
       `Project: \`${project?.slug ?? this.#props.projectId}\``,
     ].join("\n");
+  }
+
+  /** Abort this Project Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void> {
+    return Promise.resolve(this.durableObjectStub.kill());
   }
 
   /** The project stream processor (snapshot/state; `state.created` flips when bootstrap lands). */

--- a/apps/os/src/types-source.generated.ts
+++ b/apps/os/src/types-source.generated.ts
@@ -101,6 +101,8 @@ export interface Project {
   __describe(): Promise<ProjectDescription>;
   /** Formatted dashboard/debug info for this itx scope, suitable for Slack messages. */
   debug(): Promise<string>;
+  /** Abort this Project Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   /** The project stream processor (snapshot/state; \`state.created\` flips when bootstrap lands). */
   processor: WakeableStreamProcessorRpc<ProjectProcessorState>;
   /** Workers AI: run(model, body), models(). */
@@ -322,6 +324,8 @@ export interface Agent {
   }): Promise<{ event: StreamEvent; files: AgentFileAttachment[] }>;
   /** Includes \`whoami\` (\`"agent <projectId>:<agentPath>"\`), \`projectId\`, \`agentPath\`. */
   __describe(): Promise<Description & { agentPath: string; projectId: string; whoami: string }>;
+  /** Abort this Agent Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
 }
 
 /** Agent-local web chat response tool exposed inside agent script execution. */
@@ -373,6 +377,8 @@ export interface CapabilityHost {
     executionId: string;
     result: unknown;
   }>;
+  /** Abort this Capability Host Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
 }
 
 /** Catalog of capability scopes within one project (\`itx.capabilityHosts\`). */
@@ -692,6 +698,8 @@ export interface Scheduler {
   set(input: SetScheduleInput): Promise<ScheduleView>;
   /** Remove a key. Idempotent; an in-flight Trigger completes as \`skipped\`. */
   cancel(key: string): Promise<void>;
+  /** Abort this Scheduler Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   list(): Promise<ScheduleView[]>;
   /** Run a Schedule now. Advances a recurring Schedule's clock and consumes a one-shot. */
   trigger(key: string): Promise<{ executionId: string }>;
@@ -720,6 +728,8 @@ export interface Repo {
   create(): Promise<Repo>;
   /** Repo identity string (debug). */
   whoami(): Promise<string>;
+  /** Abort this Repo Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   /** Commit a batch of file changes; use \`edit\` for a targeted single-string replacement. */
   commitFiles(input: CommitRepoFilesInput): Promise<CommitRepoFilesResult>;
   /**
@@ -902,6 +912,8 @@ export interface Stream {
       >;
     };
   }>;
+  /** Abort the current Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   /**
    * Live EPHEMERAL event delivery: \`processEventBatch\` is called for every
    * committed batch (optionally replayed from \`replayAfterOffset\`); returns an
@@ -1038,6 +1050,8 @@ export interface Secret {
   __describe(): Promise<Description & SecretDescription>;
   /** Egress fetch with this secret's placeholders substituted server-side. */
   fetch(request: Request): Promise<Response>;
+  /** Abort this Secret Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   /** Set the secret material and/or its egress allowlist. */
   update(input: SecretUpdateInput): Promise<StreamEvent>;
   /** The secret stream processor; its public state IS the SecretDescription. */
@@ -1062,6 +1076,8 @@ export interface Workspace {
   __describe(): Promise<Description>;
   /** Workspace identity string (debug). */
   whoami(): Promise<string>;
+  /** Abort this Workspace Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   /** File contents, or null when the path does not exist. */
   readFile(path: string): Promise<string | null>;
   /** Raw file bytes (use for binaries — readFile text-decodes), or null when missing. */
@@ -1381,8 +1397,12 @@ export type StreamPushEventBatch = {
   configuredEvent: Pick<StreamEvent, "type" | "offset" | "createdAt" | "path" | "payload">;
 };
 
-/** Dynamic worker RPC stub plus the disposal operation owned by the caller. */
-export type DynamicWorkerCapability<T extends object = Record<string, unknown>> = T & Disposable;
+/** Dynamic worker RPC stub plus platform-owned lifecycle operations. */
+export type DynamicWorkerCapability<T extends object = Record<string, unknown>> = T &
+  Disposable & {
+    /** Abort the stateful worker Durable Object incarnation. Stateless worker refs reject. */
+    kill(): Promise<void>;
+  };
 
 /** One entry of a session's project catalog (\`session.projects.list()\`). */
 export type ProjectListEntry = {
@@ -1714,7 +1734,8 @@ export type SandboxInstanceType =
  *   anything since the last snapshot.
  * - \`start()\` boots the container now instead of lazily; \`sleep()\` snapshots
  *   and tears down now instead of waiting for \`sleepAfter\` (the SDK's
- *   \`stop()\` forwards to it); \`destroy()\` is permanent — the name is retired.
+ *   \`stop()\` forwards to it); \`kill()\` aborts the Durable Object incarnation;
+ *   \`destroy()\` is permanent — the name is retired.
  * - \`__describe()\` (the capability-tree convention) carries the durable
  *   record as structured extras ({ path, instanceType, createdAt, sleepAfter }).
  * - \`setEnvVars(vars)\` is DURABLE here (persisted, re-applied every start,
@@ -1725,7 +1746,10 @@ export type SandboxInstanceType =
  * - \`mountBucket\` and \`exposePort\` are unavailable (they throw): /workspace
  *   snapshots cover persistence, and \`tunnels\` covers public URLs.
  */
-export type CloudflareSandbox = object;
+export type CloudflareSandbox = object & {
+  /** Abort the current sandbox Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
+};
 
 /** The scheduler's reduced state: the one object the UI, alarm, and executor read. */
 export type SchedulerProcessorState = {

--- a/packages/iterate/src/itx-api.generated.ts
+++ b/packages/iterate/src/itx-api.generated.ts
@@ -96,6 +96,8 @@ export interface Project {
   __describe(): Promise<ProjectDescription>;
   /** Formatted dashboard/debug info for this itx scope, suitable for Slack messages. */
   debug(): Promise<string>;
+  /** Abort this Project Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   /** The project stream processor (snapshot/state; `state.created` flips when bootstrap lands). */
   processor: WakeableStreamProcessorRpc<ProjectProcessorState>;
   /** Workers AI: run(model, body), models(). */
@@ -317,6 +319,8 @@ export interface Agent {
   }): Promise<{ event: StreamEvent; files: AgentFileAttachment[] }>;
   /** Includes `whoami` (`"agent <projectId>:<agentPath>"`), `projectId`, `agentPath`. */
   __describe(): Promise<Description & { agentPath: string; projectId: string; whoami: string }>;
+  /** Abort this Agent Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
 }
 
 /** Agent-local web chat response tool exposed inside agent script execution. */
@@ -368,6 +372,8 @@ export interface CapabilityHost {
     executionId: string;
     result: unknown;
   }>;
+  /** Abort this Capability Host Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
 }
 
 /** Catalog of capability scopes within one project (`itx.capabilityHosts`). */
@@ -687,6 +693,8 @@ export interface Scheduler {
   set(input: SetScheduleInput): Promise<ScheduleView>;
   /** Remove a key. Idempotent; an in-flight Trigger completes as `skipped`. */
   cancel(key: string): Promise<void>;
+  /** Abort this Scheduler Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   list(): Promise<ScheduleView[]>;
   /** Run a Schedule now. Advances a recurring Schedule's clock and consumes a one-shot. */
   trigger(key: string): Promise<{ executionId: string }>;
@@ -715,6 +723,8 @@ export interface Repo {
   create(): Promise<Repo>;
   /** Repo identity string (debug). */
   whoami(): Promise<string>;
+  /** Abort this Repo Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   /** Commit a batch of file changes; use `edit` for a targeted single-string replacement. */
   commitFiles(input: CommitRepoFilesInput): Promise<CommitRepoFilesResult>;
   /**
@@ -897,6 +907,8 @@ export interface Stream {
       >;
     };
   }>;
+  /** Abort the current Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   /**
    * Live EPHEMERAL event delivery: `processEventBatch` is called for every
    * committed batch (optionally replayed from `replayAfterOffset`); returns an
@@ -1033,6 +1045,8 @@ export interface Secret {
   __describe(): Promise<Description & SecretDescription>;
   /** Egress fetch with this secret's placeholders substituted server-side. */
   fetch(request: Request): Promise<Response>;
+  /** Abort this Secret Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   /** Set the secret material and/or its egress allowlist. */
   update(input: SecretUpdateInput): Promise<StreamEvent>;
   /** The secret stream processor; its public state IS the SecretDescription. */
@@ -1057,6 +1071,8 @@ export interface Workspace {
   __describe(): Promise<Description>;
   /** Workspace identity string (debug). */
   whoami(): Promise<string>;
+  /** Abort this Workspace Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
   /** File contents, or null when the path does not exist. */
   readFile(path: string): Promise<string | null>;
   /** Raw file bytes (use for binaries — readFile text-decodes), or null when missing. */
@@ -1376,8 +1392,12 @@ export type StreamPushEventBatch = {
   configuredEvent: Pick<StreamEvent, "type" | "offset" | "createdAt" | "path" | "payload">;
 };
 
-/** Dynamic worker RPC stub plus the disposal operation owned by the caller. */
-export type DynamicWorkerCapability<T extends object = Record<string, unknown>> = T & Disposable;
+/** Dynamic worker RPC stub plus platform-owned lifecycle operations. */
+export type DynamicWorkerCapability<T extends object = Record<string, unknown>> = T &
+  Disposable & {
+    /** Abort the stateful worker Durable Object incarnation. Stateless worker refs reject. */
+    kill(): Promise<void>;
+  };
 
 /** One entry of a session's project catalog (`session.projects.list()`). */
 export type ProjectListEntry = {
@@ -1709,7 +1729,8 @@ export type SandboxInstanceType =
  *   anything since the last snapshot.
  * - `start()` boots the container now instead of lazily; `sleep()` snapshots
  *   and tears down now instead of waiting for `sleepAfter` (the SDK's
- *   `stop()` forwards to it); `destroy()` is permanent — the name is retired.
+ *   `stop()` forwards to it); `kill()` aborts the Durable Object incarnation;
+ *   `destroy()` is permanent — the name is retired.
  * - `__describe()` (the capability-tree convention) carries the durable
  *   record as structured extras ({ path, instanceType, createdAt, sleepAfter }).
  * - `setEnvVars(vars)` is DURABLE here (persisted, re-applied every start,
@@ -1720,7 +1741,10 @@ export type SandboxInstanceType =
  * - `mountBucket` and `exposePort` are unavailable (they throw): /workspace
  *   snapshots cover persistence, and `tunnels` covers public URLs.
  */
-export type CloudflareSandbox = object;
+export type CloudflareSandbox = object & {
+  /** Abort the current sandbox Durable Object incarnation; the next request boots it again. */
+  kill(): Promise<void>;
+};
 
 /** The scheduler's reduced state: the one object the UI, alarm, and executor read. */
 export type SchedulerProcessorState = {


### PR DESCRIPTION
## Summary

- add public `kill()` methods for streams and durable-object-backed ITX surfaces
- expose stream kill in the OS stream/agent header action menu
- extend generated ITX types, sandbox typing, and stateful worker lifecycle handling

## Impact

Operators and scripts can abort wedged stream and durable object incarnations directly. Stateful dynamic worker refs now expose a platform `kill()` lifecycle method; stateless refs reject with a clear error.

## Validation

- `pnpm test:unit src/itx-api.generated.test.ts src/types-source.generated.test.ts`
- `pnpm typecheck` in `apps/os`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Kill forcibly aborts live Durable Object incarnations (including agents, sandboxes, and stateful workers), which can drop in-flight work and is now one click away in the UI.
> 
> **Overview**
> Adds a **platform-wide `kill()` lifecycle** that aborts the current Durable Object incarnation via `ctx.abort("kill requested")`, so the next RPC boots a fresh instance—aimed at wedged streams, agents, sandboxes, and other long-lived DOs.
> 
> **OS UI:** The stream view header’s action menu (renamed from agent-only to **Stream actions** / **Agent actions**) gains a destructive **Kill stream** item. `ProjectStreamView` resolves the stream, calls `stream.kill()`, shows toasts (treating `"kill requested"` as success), and nudges local delivery mirrors.
> 
> **Backend / API:** `kill()` is wired on stream RPC and across DO types (project, agent, capability host, repo, scheduler, secret, workspace, sandbox, stateful workers). Stateful dynamic workers also abort the hosted facet; **stateless worker refs reject** `kill()`. Generated ITX types, `StreamRpcTarget` discovery text, sandbox `CloudflareSandbox` typing, and in-memory `Stream` test doubles are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d7e3018aa94c52d8fe124af94e5ba073dc2428e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +133 -14 | +85 -4 🟩🟩🟩🟩🟩 |
| UI components | +68 -11 | +68 -11 🟩🟩🟩🟥⬜ |
| Tests | +10 -0 | +5 -0 🟩⬜⬜⬜⬜ |
| Generated | +84 -12 | +58 -8 🟩🟩🟩🟩⬜ |
| **Total** | **+295 -37** | **+216 -23** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 93067c4 and 2d7e301, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-09T19:33:54.591Z",
      "headSha": "2d7e3018aa94c52d8fe124af94e5ba073dc2428e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/548678535457313",
      "shortSha": "2d7e301",
      "cleanupDurationMs": 14869,
      "deployDurationMs": 75601,
      "testDurationMs": 182986,
      "testRetries": "2 retried: catalogue example \"append-and-read-stream\" runs identically across runtimes (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 15482.88,
      "workerGzipKib": 4182.09,
      "mainWorkerGzipKib": 4181.13
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-09T19:33:42.641Z",
      "headSha": "2d7e3018aa94c52d8fe124af94e5ba073dc2428e",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/548678535457313",
      "shortSha": "2d7e301",
      "cleanupDurationMs": 2917,
      "deployDurationMs": 16994,
      "testDurationMs": 564,
      "testRetries": null,
      "workerSizeKib": 4031.52,
      "workerGzipKib": 819.32,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-09T19:33:40.342Z",
      "headSha": "2d7e3018aa94c52d8fe124af94e5ba073dc2428e",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/548678535457313",
      "shortSha": "2d7e301",
      "cleanupDurationMs": 614,
      "deployDurationMs": 12964,
      "testDurationMs": 17764,
      "testRetries": null,
      "workerSizeKib": 4563.1,
      "workerGzipKib": 1315.33,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `2d7e301` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 819.3 KiB | 17.0s | 564ms |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/548678535457313) | 2026-07-09T19:33:42.641Z | Preview app released. |
| OS | released | `2d7e301` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.08 MiB (+1.0 KiB vs main) | 75.6s | 183.0s | 2 retried: catalogue example "append-and-read-stream" runs identically across runtimes (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 14.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/548678535457313) | 2026-07-09T19:33:54.591Z | Preview app released. |
| Streams Example App | released | `2d7e301` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.28 MiB | 13.0s | 17.8s |  | 614ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/548678535457313) | 2026-07-09T19:33:40.342Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->