### PR TITLE
Rename the cross-post sink Stream.ingest to acceptCrossPost

### DIFF
--- a/apps/os/e2e/vitest/github-backed-repo.e2e.test.ts
+++ b/apps/os/e2e/vitest/github-backed-repo.e2e.test.ts
@@ -44,7 +44,7 @@ test("github webhooks about a linked repository cross-post onto the repo stream"
       },
       delivery: {
         mode: "push",
-        expression: ["streams", ["get", repoPath], "ingest"],
+        expression: ["streams", ["get", repoPath], "acceptCrossPost"],
       },
       deliver: "new",
     },

--- a/apps/os/e2e/vitest/stream-security.e2e.test.ts
+++ b/apps/os/e2e/vitest/stream-security.e2e.test.ts
@@ -78,7 +78,11 @@ test("append accepts an offset assertion on a subscription-configured core event
       subscriptionKey: `cross-post-${marker}`,
       delivery: {
         mode: "push",
-        expression: ["streams", ["get", `/e2e/security/offset-assert-target/${marker}`], "ingest"],
+        expression: [
+          "streams",
+          ["get", `/e2e/security/offset-assert-target/${marker}`],
+          "acceptCrossPost",
+        ],
       },
       selector: { eventTypes: [STREAM_EVENT_TYPE] },
     },

--- a/apps/os/e2e/vitest/streams.e2e.test.ts
+++ b/apps/os/e2e/vitest/streams.e2e.test.ts
@@ -3,7 +3,7 @@
 // These deliberately cover only deployment-style ITX/WebSocket behavior: project
 // stream access, append/read, replay/live subscriptions, unsubscribe,
 // state-only subscription pushes, and cross-posting (durable push subscriptions
-// targeting another stream's ingest sink, via the crossPostTo sugar). Unit and
+// targeting another stream's acceptCrossPost sink, via the crossPostTo sugar). Unit and
 // workerd-only stream regression tests stay out of this file.
 
 import { expect, test } from "vitest";
@@ -427,7 +427,7 @@ test("cross-posts do not recursively copy events that are already cross-posted",
   using source = project.streams.get(sourcePath);
   using target = project.streams.get(targetPath);
 
-  // Loop protection is structural: ingest never appends an event whose
+  // Loop protection is structural: acceptCrossPost never appends an event whose
   // provenance chain already contains the receiving stream, so wiring two
   // streams at each other is safe.
   await Promise.all([
@@ -482,7 +482,7 @@ test("global cross-posts stay in the global namespace — a project stream is un
   // A delivery expression evaluates against the source stream's OWN authority
   // root. For a global (projectId: null) stream that is the deployment root,
   // whose `streams` collection is the deployment-wide (projectId: null)
-  // namespace — so `["streams", ["get", path], "ingest"]` from a global source
+  // namespace — so `["streams", ["get", path], "acceptCrossPost"]` from a global source
   // can only ever name another GLOBAL stream. A project stream at the same
   // path is a different coordinate entirely: smuggling events across the
   // project boundary is unexpressible, not checked.

--- a/apps/os/src/domains/email/email-processors.test.ts
+++ b/apps/os/src/domains/email/email-processors.test.ts
@@ -111,8 +111,8 @@ class MemoryStream implements Stream {
     throw new Error("MemoryStream does not implement subscribe().");
   }
 
-  async ingest(): Promise<never> {
-    throw new Error("MemoryStream does not implement ingest().");
+  async acceptCrossPost(): Promise<never> {
+    throw new Error("MemoryStream does not implement acceptCrossPost().");
   }
 
   async crossPostTo(): Promise<never> {

--- a/apps/os/src/domains/integrations/slack-processors.test.ts
+++ b/apps/os/src/domains/integrations/slack-processors.test.ts
@@ -118,8 +118,8 @@ class MemoryStream implements Stream {
     throw new Error("MemoryStream does not implement subscribe().");
   }
 
-  async ingest(): Promise<never> {
-    throw new Error("MemoryStream does not implement ingest().");
+  async acceptCrossPost(): Promise<never> {
+    throw new Error("MemoryStream does not implement acceptCrossPost().");
   }
 
   async crossPostTo(): Promise<never> {

--- a/apps/os/src/domains/projects/project-processor.test.ts
+++ b/apps/os/src/domains/projects/project-processor.test.ts
@@ -102,8 +102,8 @@ class MemoryStream implements Stream {
     throw new Error("MemoryStream does not implement subscribe().");
   }
 
-  async ingest(): Promise<never> {
-    throw new Error("MemoryStream does not implement ingest().");
+  async acceptCrossPost(): Promise<never> {
+    throw new Error("MemoryStream does not implement acceptCrossPost().");
   }
 
   async crossPostTo(): Promise<never> {

--- a/apps/os/src/domains/repos/github-link.test.ts
+++ b/apps/os/src/domains/repos/github-link.test.ts
@@ -237,7 +237,7 @@ describe("linkRepoToGithub", () => {
 
     // The cross-post push subscription on the connection stream: GitHub
     // webhooks about exactly this repository copy onto the repo's own stream
-    // via its `ingest` sink.
+    // via its `acceptCrossPost` sink.
     const subscription = network.streams
       .get(CONNECTION_STREAM)
       ?.find((event) => event.type === "events.iterate.com/stream/subscription-configured");
@@ -249,7 +249,7 @@ describe("linkRepoToGithub", () => {
       },
       delivery: {
         mode: "push",
-        expression: ["streams", ["get", "/repos/project"], "ingest"],
+        expression: ["streams", ["get", "/repos/project"], "acceptCrossPost"],
       },
       deliver: "new",
     });

--- a/apps/os/src/domains/repos/github-link.ts
+++ b/apps/os/src/domains/repos/github-link.ts
@@ -8,8 +8,8 @@
 //   2. records the link on the Repo Durable Object (KV for the mirror-push hot
 //      path + a `repo/github-link-configured` fact on the repo stream);
 //   3. installs a cross-post subscription on the connection stream — a push
-//      subscription whose expression addresses the repo stream's `ingest`
-//      sink — so every GitHub webhook about that repository is copied onto
+//      subscription whose expression addresses the repo stream's
+//      `acceptCrossPost` sink — so every GitHub webhook about that repository is copied onto
 //      the repo's own stream, durably and at-least-once. The generic stream
 //      subscription primitive, not GitHub-special routing.
 //
@@ -67,7 +67,7 @@ function githubCrossPostSubscriptionEvent(input: {
       },
       delivery: {
         mode: "push",
-        expression: ["streams", ["get", input.repoPath], "ingest"],
+        expression: ["streams", ["get", input.repoPath], "acceptCrossPost"],
       },
       // Live-tail: webhooks that arrived before the link existed are not this
       // repo's history. Explicit (though "new" is the default) because on a

--- a/apps/os/src/domains/repos/pr-agent.test.ts
+++ b/apps/os/src/domains/repos/pr-agent.test.ts
@@ -120,8 +120,8 @@ class MemoryStream implements Stream {
     throw new Error("MemoryStream does not implement subscribe().");
   }
 
-  async ingest(): Promise<never> {
-    throw new Error("MemoryStream does not implement ingest().");
+  async acceptCrossPost(): Promise<never> {
+    throw new Error("MemoryStream does not implement acceptCrossPost().");
   }
 
   async crossPostTo(): Promise<never> {

--- a/apps/os/src/domains/scheduler/scheduler-processor.test.ts
+++ b/apps/os/src/domains/scheduler/scheduler-processor.test.ts
@@ -100,8 +100,8 @@ class MemoryStream implements Stream {
     throw new Error("MemoryStream does not implement subscribe().");
   }
 
-  async ingest(): Promise<never> {
-    throw new Error("MemoryStream does not implement ingest().");
+  async acceptCrossPost(): Promise<never> {
+    throw new Error("MemoryStream does not implement acceptCrossPost().");
   }
 
   async crossPostTo(): Promise<never> {

--- a/apps/os/src/domains/streams/README.md
+++ b/apps/os/src/domains/streams/README.md
@@ -14,7 +14,7 @@ for B's events to be **cross-posted onto A** — real copies, appended to A's
 own log, each carrying the full provenance chain in
 `source.crossPostedFrom` (source stream, offset, type, the subscription that
 carried the hop; multi-hop chains are legal up to a cap of 5, and loops are
-structurally impossible — a copy is never ingested by a stream already on its
+structurally impossible — a copy is never accepted by a stream already on its
 chain). Copying with provenance IS the mechanism; design around it, not
 against it.
 
@@ -38,9 +38,9 @@ await itx.streams.get("/integrations/github/mine").crossPostTo({
 ```
 
 `crossPostTo` is sugar for a **push subscription** (below) whose expression
-addresses the destination stream's `ingest` sink; the appended
+addresses the destination stream's `acceptCrossPost` sink; the appended
 `subscription-configured` event is the real interface. Delivery is durable and
-at-least-once (cursor + retries + parking), and `ingest` derives idempotency
+at-least-once (cursor + retries + parking), and `acceptCrossPost` derives idempotency
 keys from the source coordinate, so at-least-once delivery collapses to
 exactly-once appends.
 
@@ -101,21 +101,21 @@ with**. Wake and push share ONE addressing grammar: a persisted itx
 expression naming the method to invoke on the ordinary domain surface
 (`["agents", ["get", path], "processor", "wakeStreamSubscriber"]`,
 `["processEventBatch"]` — the project root's own dispatch point, which
-delegates to the project worker — `["streams", ["get", path], "ingest"]`);
+delegates to the project worker — `["streams", ["get", path], "acceptCrossPost"]`);
 webhook is the same cursor machinery pointed at plain HTTP:
 
-|                         | ephemeral                              | durable `wake`                                                      | durable `push`                                                  | durable `webhook`                                |
-| ----------------------- | -------------------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------ |
-| who                     | browsers, tests, `waitForEvent`        | DO-hosted processors (stateful folds)                               | stateless effects: the project worker feed, cross-post `ingest` | external HTTP receivers                          |
-| subscription            | `subscribe()` (session)                | config event, `delivery: {mode:"wake", expression, processorSlug?}` | config event, `delivery: {mode:"push", expression}`             | config event, `delivery: {mode:"webhook", url}`  |
-| offset owner            | client, in-memory                      | **subscriber** — `{offset, state}` snapshot, atomic with the fold   | **stream** — spine cursor row, atomic with the log              | **stream** — same cursor row, advanced per EVENT |
-| stream-side row         | none                                   | observational watermark (poke coalescing, lag)                      | authoritative cursor                                            | authoritative cursor                             |
-| sink arrives as         | `subscribe()` parameter                | returned from the expression-named poke                             | named by a persisted itx expression                             | the configured URL                               |
-| warm transport          | retained one-way callback              | retained one-way sink                                               | fresh awaited call per batch                                    | one `fetch` POST per event                       |
-| return frames per batch | **zero** (result disposed unpulled)    | one, non-gating (pulled as the liveness signal)                     | one, awaited (**the ack** that advances the cursor)             | the 2xx response (**the ack**), per event        |
-| retry / failure         | client's problem                       | spine: backoff rows + alarm → parked fact                           | same spine, same machine (+ `onPoison: park \| skip`)           | same spine, same machine, per-event granularity  |
-| replay                  | `replayAfterOffset` arg                | subscriber's checkpoint decides                                     | `deliver: "all" \| "new" \| {afterOffset}` + `cursor-set`       | same as push                                     |
-| filter                  | `selector` / `eventTypes` on subscribe | processor `contract.consumes` (announced on the poke)               | `selector: {eventTypes?, condition?}` in config                 | same selector shape                              |
+|                         | ephemeral                              | durable `wake`                                                      | durable `push`                                                | durable `webhook`                                |
+| ----------------------- | -------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------ |
+| who                     | browsers, tests, `waitForEvent`        | DO-hosted processors (stateful folds)                               | stateless effects: the project worker feed, `acceptCrossPost` | external HTTP receivers                          |
+| subscription            | `subscribe()` (session)                | config event, `delivery: {mode:"wake", expression, processorSlug?}` | config event, `delivery: {mode:"push", expression}`           | config event, `delivery: {mode:"webhook", url}`  |
+| offset owner            | client, in-memory                      | **subscriber** — `{offset, state}` snapshot, atomic with the fold   | **stream** — spine cursor row, atomic with the log            | **stream** — same cursor row, advanced per EVENT |
+| stream-side row         | none                                   | observational watermark (poke coalescing, lag)                      | authoritative cursor                                          | authoritative cursor                             |
+| sink arrives as         | `subscribe()` parameter                | returned from the expression-named poke                             | named by a persisted itx expression                           | the configured URL                               |
+| warm transport          | retained one-way callback              | retained one-way sink                                               | fresh awaited call per batch                                  | one `fetch` POST per event                       |
+| return frames per batch | **zero** (result disposed unpulled)    | one, non-gating (pulled as the liveness signal)                     | one, awaited (**the ack** that advances the cursor)           | the 2xx response (**the ack**), per event        |
+| retry / failure         | client's problem                       | spine: backoff rows + alarm → parked fact                           | same spine, same machine (+ `onPoison: park \| skip`)         | same spine, same machine, per-event granularity  |
+| replay                  | `replayAfterOffset` arg                | subscriber's checkpoint decides                                     | `deliver: "all" \| "new" \| {afterOffset}` + `cursor-set`     | same as push                                     |
+| filter                  | `selector` / `eventTypes` on subscribe | processor `contract.consumes` (announced on the poke)               | `selector: {eventTypes?, condition?}` in config               | same selector shape                              |
 
 The pump never awaits a delivery on the ephemeral and wake lanes — that is
 what keeps warm append→processed latency in single-digit milliseconds (voice
@@ -157,7 +157,7 @@ Doctrine, worth memorizing:
   code.** A selector (`{eventTypes?, condition?}` — one shape on every lane,
   [JSONata](https://jsonata.org/) conditions must evaluate to exactly `true`)
   may reject events, never construct output. Transforms live in named
-  receivers: `ingest` documents its own `params.transform`. When an effect
+  receivers: `acceptCrossPost` documents its own `params.transform`. When an effect
   needs real code, it goes in the project worker — typed, reviewed, in the
   repo.
 - **Persist the name, re-derive the authority.** A delivery expression
@@ -262,21 +262,21 @@ announcements and checkpoints.
 
 ## File map
 
-| File                         | Role                                                                                                                       |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `stream-durable-object.ts`   | The stream: append commit point, core processor, birth certificate, the dial (pokes, push expressions, webhooks), `ingest` |
-| `core-processor-contract.ts` | Core contract: reduced-state schema (v11) + the `events.iterate.com/stream/*` event catalog                                |
-| `stream-storage.ts`          | Chunked SQLite event log (2 MB cell limit → JS chunking) + the spine's `subscriptions` cursor rows                         |
-| `stream-subscribers.ts`      | Every subscriber, one module: sink table, connection pump, the durable spine (ports-only; no RPC, no clock)                |
-| `subscriber-sinks.ts`        | The RPC quarantine: stub retention (dup/dispose/onRpcBroken, pulled-vs-disposed results)                                   |
-| `subscriber-math.ts`         | Pure spine math: backoff, initial cursors, bisect, delivery ids (table-tested)                                             |
-| `event-selector.ts`          | `EventSelector` — THE filter shape on every lane; shared JSONata compile cache                                             |
-| `processor-contracts.ts`     | `defineProcessorContract` + event-type → payload-schema resolution machinery                                               |
-| `stream-processor.ts`        | The `StreamProcessor` base class (batch ingest, checkpointing, hooks)                                                      |
-| `stream-processor-host.ts`   | Hosts processors in a DO; answers pokes with `{checkpoint, sink, …}`                                                       |
-| `schemas.ts`                 | `StreamEvent` / `StreamEventInput` zod schemas (incl. `crossPostedFrom` provenance)                                        |
-| `utils.ts`                   | Stream path resolution + wake-subscription event builder                                                                   |
-| `client-libraries/`          | Browser mirror host and browser-side processors                                                                            |
+| File                         | Role                                                                                                                                |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `stream-durable-object.ts`   | The stream: append commit point, core processor, birth certificate, the dial (pokes, push expressions, webhooks), `acceptCrossPost` |
+| `core-processor-contract.ts` | Core contract: reduced-state schema (v11) + the `events.iterate.com/stream/*` event catalog                                         |
+| `stream-storage.ts`          | Chunked SQLite event log (2 MB cell limit → JS chunking) + the spine's `subscriptions` cursor rows                                  |
+| `stream-subscribers.ts`      | Every subscriber, one module: sink table, connection pump, the durable spine (ports-only; no RPC, no clock)                         |
+| `subscriber-sinks.ts`        | The RPC quarantine: stub retention (dup/dispose/onRpcBroken, pulled-vs-disposed results)                                            |
+| `subscriber-math.ts`         | Pure spine math: backoff, initial cursors, bisect, delivery ids (table-tested)                                                      |
+| `event-selector.ts`          | `EventSelector` — THE filter shape on every lane; shared JSONata compile cache                                                      |
+| `processor-contracts.ts`     | `defineProcessorContract` + event-type → payload-schema resolution machinery                                                        |
+| `stream-processor.ts`        | The `StreamProcessor` base class (batch ingest, checkpointing, hooks)                                                               |
+| `stream-processor-host.ts`   | Hosts processors in a DO; answers pokes with `{checkpoint, sink, …}`                                                                |
+| `schemas.ts`                 | `StreamEvent` / `StreamEventInput` zod schemas (incl. `crossPostedFrom` provenance)                                                 |
+| `utils.ts`                   | Stream path resolution + wake-subscription event builder                                                                            |
+| `client-libraries/`          | Browser mirror host and browser-side processors                                                                                     |
 
 Public capability surface (`Stream`, `StreamEventBatch`, `ProcessEventBatch`,
 …) is defined in `src/domains/streams/rpc-types.ts` (and projected into the

--- a/apps/os/src/domains/streams/core-processor-contract.ts
+++ b/apps/os/src/domains/streams/core-processor-contract.ts
@@ -40,7 +40,7 @@ import { defineProcessorContract } from "./processor-contracts.ts";
 //      to a persisted itx expression) plus selector / deliver / onPoison;
 //      spine facts (subscription-parked/-resumed/-cursor-set) fold into the
 //      subscription records; cross-post rules deleted (a cross-post is a push
-//      subscription addressing the target stream's `ingest`); worker wake
+//      subscription addressing the target stream's `acceptCrossPost`); worker wake
 //      targets deleted (stateless workers consume via push).
 // - 11: one addressing grammar for every durable mode — wake targets are itx
 //      expressions too, naming the domain node's processor (`["agents",
@@ -99,7 +99,7 @@ export type StreamSubscriptionType = z.infer<typeof StreamSubscriptionType>;
  * - `push`: the subscriber is a stateless effect named by the expression
  *   (`["processEventBatch"]` — the project root's own dispatch point the
  *   birth-certificate worker feed names, `["streams", ["get", path],
- *   "ingest"]`, …). The stream owns the AUTHORITATIVE cursor, dials the
+ *   "acceptCrossPost"]`, …). The stream owns the AUTHORITATIVE cursor, dials the
  *   expression fresh per batch, and advances only on a successful awaited
  *   call.
  * - `webhook`: push semantics over plain HTTP, one event per POST — the
@@ -172,7 +172,7 @@ const SubscriptionConfiguredPayload = z
      * (the frame carries the configured event). The platform never interprets
      * this bag — the generic spine filters and dials, nothing more; a NAMED
      * receiver documents and applies its own params (selectors filter, receivers
-     * transform). `Stream.ingest` reads `params.transform` here, for example.
+     * transform). `Stream.acceptCrossPost` reads `params.transform` here, for example.
      */
     params: z.record(z.string(), z.unknown()).optional(),
   })
@@ -446,7 +446,7 @@ export const CoreProcessorContract = defineProcessorContract({
             },
             delivery: {
               mode: "push",
-              expression: ["streams", ["get", "/repos/root"], "ingest"],
+              expression: ["streams", ["get", "/repos/root"], "acceptCrossPost"],
             },
             deliver: "new",
           },

--- a/apps/os/src/domains/streams/cross-post.ts
+++ b/apps/os/src/domains/streams/cross-post.ts
@@ -3,15 +3,16 @@
 // THE LOCALITY RULE (streams README): a processor on stream A can only react
 // to events ON stream A; reacting to stream B means copying B's events onto A.
 // This module is the receiving half of that copy — the logic behind
-// `Stream.ingest`, an ordinary push SINK (`(batch) => void`) that source
-// streams address with `{ delivery: { mode: "push", expression: ["streams",
-// ["get", targetPath], "ingest"] } }` (sugar: `crossPostTo`). Everything
+// `Stream.acceptCrossPost`, an ordinary push SINK (`(batch) => void`) that
+// source streams address with `{ delivery: { mode: "push", expression:
+// ["streams", ["get", targetPath], "acceptCrossPost"] } }` (sugar:
+// `crossPostTo`). Everything
 // cross-post-specific lives here, in named receiver code, and the generic
 // delivery spine knows none of it (selectors filter; receivers transform):
 //
 // - provenance: every hop appends itself to `source.crossPostedFrom`, so a
 //   multi-hop route stays legible end to end;
-// - loop protection: structural (never ingest an event whose chain already
+// - loop protection: structural (never accept an event whose chain already
 //   contains this stream) with a hop cap as the backstop;
 // - idempotency: keys derive from the SOURCE coordinate, so at-least-once
 //   delivery collapses to exactly-once appends;
@@ -36,17 +37,17 @@ type CrossPostProvenanceChain = NonNullable<NonNullable<StreamEvent["source"]>["
  */
 const MAX_CROSS_POST_HOPS = 5;
 
-/** The receiver params `ingest` understands (the `params` bag on
+/** The receiver params `acceptCrossPost` understands (the `params` bag on
  * `subscription-configured`). Loose: unknown keys are someone else's params. */
-const IngestParams = z.looseObject({
+const AcceptCrossPostParams = z.looseObject({
   transform: z.string().trim().min(1).optional(),
 });
 
 /**
- * What an ingest transform may construct. Strict, so a typo'd key fails as a
- * recorded per-event error instead of silently vanishing from the copy.
+ * What a cross-post transform may construct. Strict, so a typo'd key fails as
+ * a recorded per-event error instead of silently vanishing from the copy.
  */
-const IngestTransformResult = z.strictObject({
+const CrossPostTransformResult = z.strictObject({
   type: z.string().trim().min(1).optional(),
   payload: z.record(z.string(), z.unknown()).optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
@@ -67,15 +68,16 @@ export function buildCrossPostAppendInput(args: {
 }
 
 /**
- * Everything `Stream.ingest` appends for one delivered batch: the transformed,
- * provenance-stamped copies plus any per-event transform-failure facts. Pure —
- * the Stream Durable Object appends the result in its own synchronous turn.
+ * Everything `Stream.acceptCrossPost` appends for one delivered batch: the
+ * transformed, provenance-stamped copies plus any per-event transform-failure
+ * facts. Pure — the Stream Durable Object appends the result in its own
+ * synchronous turn.
  */
-export function buildIngestAppendInputs(
+export function buildAcceptCrossPostAppendInputs(
   batch: StreamPushEventBatch,
   self: { projectId: string | null; path: string },
 ): StreamEventInput[] {
-  const params = IngestParams.parse(batch.configuredEvent.payload?.params ?? {});
+  const params = AcceptCrossPostParams.parse(batch.configuredEvent.payload?.params ?? {});
   const transform =
     params.transform === undefined ? undefined : compileJsonataExpression(params.transform);
 
@@ -92,9 +94,9 @@ export function buildIngestAppendInputs(
       type: event.type,
     };
     const crossPostedFrom: CrossPostProvenanceChain = [...chain, hop];
-    // Structural loop protection: never ingest an event whose provenance
+    // Structural loop protection: never accept an event whose provenance
     // chain already contains this stream (including the source hop itself
-    // when someone wires a stream to ingest into itself).
+    // when someone wires a stream to cross-post into itself).
     const selfOnChain = crossPostedFrom.some(
       (entry) => entry.projectId === self.projectId && entry.path === self.path,
     );
@@ -103,7 +105,7 @@ export function buildIngestAppendInputs(
     let body: Pick<StreamEvent, "type" | "payload" | "metadata"> = event;
     if (transform !== undefined) {
       try {
-        const produced = IngestTransformResult.parse(transform.evaluate(event));
+        const produced = CrossPostTransformResult.parse(transform.evaluate(event));
         body = {
           type: produced.type ?? event.type,
           ...(produced.payload === undefined
@@ -123,9 +125,9 @@ export function buildIngestAppendInputs(
         // subscription on an event that will never transform differently).
         inputs.push({
           type: "events.iterate.com/stream/error-occurred",
-          idempotencyKey: `ingest-transform-failed:${batch.subscriptionKey}:${event.path}@${event.offset}`,
+          idempotencyKey: `cross-post-transform-failed:${batch.subscriptionKey}:${event.path}@${event.offset}`,
           payload: {
-            message: `ingest transform for subscription "${batch.subscriptionKey}" failed on ${event.path}@${event.offset}: ${String(error)}`,
+            message: `cross-post transform for subscription "${batch.subscriptionKey}" failed on ${event.path}@${event.offset}: ${String(error)}`,
           },
         });
         continue;

--- a/apps/os/src/domains/streams/event-selector.ts
+++ b/apps/os/src/domains/streams/event-selector.ts
@@ -45,7 +45,7 @@ export type CompiledEventSelector = {
   matches(event: StreamEvent): boolean;
 };
 
-// Compiled-expression cache: selector conditions (and ingest transforms,
+// Compiled-expression cache: selector conditions (and cross-post transforms,
 // which share this compiler) re-evaluate on every matching append, and a
 // stream's expression set is small and stable, so compile-once is the
 // sensible steady state. Bounded so pathological churn of expressions cannot
@@ -57,7 +57,7 @@ const MAX_COMPILED_EXPRESSIONS = 200;
 /**
  * Parse a JSONata expression, throwing on invalid input. Used for selector
  * `condition`s (must evaluate to exactly `true` to match) and for
- * `Stream.ingest` transforms (construct the cross-posted event body) — one
+ * `Stream.acceptCrossPost` transforms (construct the cross-posted event body) — one
  * compiler, one cache, one language for everything expression-shaped that
  * evaluates against a committed event.
  */

--- a/apps/os/src/domains/streams/processor-contracts.ts
+++ b/apps/os/src/domains/streams/processor-contracts.ts
@@ -28,7 +28,7 @@ import {
  * at module load, so a bad example fails CI instead of bricking a worker boot.
  */
 export type EventExample = {
-  /** What this example shows, e.g. "Push delivery to another stream's ingest". */
+  /** What this example shows, e.g. "Push delivery to another stream's acceptCrossPost". */
   description: string;
   /** The example payload, in the payload schema's input shape. */
   payload: unknown;

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -4,7 +4,7 @@ import type { Env } from "../../env.ts";
 import type { Stream } from "../../itx-api.generated.ts";
 import { StreamSubscriptionRpcTarget } from "../../rpc-targets.ts";
 import { DurableObjectNameCodec } from "../durable-object-names.ts";
-import { buildIngestAppendInputs } from "./cross-post.ts";
+import { buildAcceptCrossPostAppendInputs } from "./cross-post.ts";
 import type {
   ProcessorRuntimeState,
   StreamPushEventBatch,
@@ -805,12 +805,12 @@ export class StreamDurableObject extends DurableObject<Env> {
    * Cross-post receiving end — an ordinary push SINK on the target stream
    * (`(batch) => void`, the same shape every subscriber provides), reached by
    * a source stream's push subscription (sugar: `crossPostTo`). All
-   * cross-post semantics — provenance, loop protection, idempotency keys, the
-   * optional JSONata transform — live in `cross-post.ts`; this method only
-   * appends the built inputs in its own synchronous turn.
+   * cross-post semantics — provenance, loop protection, idempotency keys,
+   * the optional JSONata transform — live in `cross-post.ts`; this method
+   * only appends the built inputs in its own synchronous turn.
    */
-  ingest(batch: StreamPushEventBatch): void {
-    const inputs = buildIngestAppendInputs(batch, {
+  acceptCrossPost(batch: StreamPushEventBatch): void {
+    const inputs = buildAcceptCrossPostAppendInputs(batch, {
       projectId: this.name.projectId,
       path: this.name.path,
     });

--- a/apps/os/src/domains/streams/subscriber-sinks.ts
+++ b/apps/os/src/domains/streams/subscriber-sinks.ts
@@ -300,7 +300,7 @@ export function createSubscriberDial(deps: {
      * One push delivery: evaluate the expression to a sink and invoke it with
      * the batch — `["processEventBatch"]` reaches the project root's own
      * dispatch point (which delegates to the project worker) and
-     * `["streams", ["get", path], "ingest"]` reaches a sibling stream —
+     * `["streams", ["get", path], "acceptCrossPost"]` reaches a sibling stream —
      * through exactly the calls ordinary user code would make. The
      * awaited resolve is the ack; a reject propagates to the spine's
      * retry/park machine. The authority root is cached across deliveries and
@@ -370,7 +370,7 @@ export function createSubscriberDial(deps: {
  * so the invocation happens receiver-bound on the remote side. Reading the
  * method as a property and applying it locally worked in-process but DETACHED
  * the method from `this` across the real loopback RPC hop on deployed workerd
- * (thermo round 2, blocker 1: every ingest delivery failed with "Cannot read
+ * (thermo round 2, blocker 1: every cross-post delivery failed with "Cannot read
  * properties of undefined (reading 'auth')"). Config validation enforces the
  * tail shape at append time; this re-check protects hand-edited state.
  */

--- a/apps/os/src/domains/streams/test-helpers.ts
+++ b/apps/os/src/domains/streams/test-helpers.ts
@@ -127,8 +127,8 @@ export class MemoryStream implements Stream {
     throw new Error("MemoryStream does not implement subscribe().");
   }
 
-  async ingest(): Promise<never> {
-    throw new Error("MemoryStream does not implement ingest().");
+  async acceptCrossPost(): Promise<never> {
+    throw new Error("MemoryStream does not implement acceptCrossPost().");
   }
 
   async crossPostTo(): Promise<never> {

--- a/apps/os/src/itx-api.generated.ts
+++ b/apps/os/src/itx-api.generated.ts
@@ -933,13 +933,13 @@ export interface Stream {
    * appends the batch's events into THIS stream with provenance stamping,
    * structural loop protection, and source-derived idempotency keys. A source
    * stream cross-posts here by configuring
-   * `{ delivery: { mode: "push", expression: ["streams", ["get", path], "ingest"] } }`.
+   * `{ delivery: { mode: "push", expression: ["streams", ["get", path], "acceptCrossPost"] } }`.
    */
-  ingest(batch: StreamPushEventBatch): Promise<void>;
+  acceptCrossPost(batch: StreamPushEventBatch): Promise<void>;
   /**
    * "When events matching this land HERE, post them onto stream `path`" — the
    * cross-post verb. Pure sugar over appending a `subscription-configured`
-   * push subscription targeting the destination's `ingest` sink; the appended
+   * push subscription targeting the destination's `acceptCrossPost` sink; the appended
    * event (returned) is the real interface and shows in the log like any
    * other config. Same-`key` calls replace the previous cross-post; remove
    * with `removeCrossPost`. Copies carry the full provenance chain

--- a/apps/os/src/itx/examples.ts
+++ b/apps/os/src/itx/examples.ts
@@ -953,7 +953,7 @@ return { link, github: state.state.github, lastGithubPush: state.state.lastGithu
     id: "stream-cross-post",
     title: "Cross-post matching events between streams",
     description:
-      "stream.crossPostTo({ path, eventTypes, condition? }) copies every later matching event onto the target stream — sugar over a durable push subscription targeting the destination's ingest sink, so copies are at-least-once. The optional condition is a JSONata expression over the whole event that must evaluate to exactly true. Copies carry source.crossPostedFrom (the full hop chain), cross-posts never copy into a stream already on the chain (cycles are safe), and removeCrossPost({ path }) removes one.",
+      "stream.crossPostTo({ path, eventTypes, condition? }) copies every later matching event onto the target stream — sugar over a durable push subscription targeting the destination's acceptCrossPost sink, so copies are at-least-once. The optional condition is a JSONata expression over the whole event that must evaluate to exactly true. Copies carry source.crossPostedFrom (the full hop chain), cross-posts never copy into a stream already on the chain (cycles are safe), and removeCrossPost({ path }) removes one.",
     context: "project",
     runtimes: ALL_RUNTIMES,
     code: `

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -488,22 +488,23 @@ export class StreamRpcTarget extends IterateRpcTarget<"Stream"> {
    * appends the batch's events into THIS stream with provenance stamping,
    * structural loop protection, and source-derived idempotency keys. A source
    * stream cross-posts here by configuring
-   * `{ delivery: { mode: "push", expression: ["streams", ["get", path], "ingest"] } }`.
+   * `{ delivery: { mode: "push", expression: ["streams", ["get", path], "acceptCrossPost"] } }`.
    */
-  ingest(batch: StreamPushEventBatch): Promise<void> {
-    // Only the platform's own delivery spine dials ingest: it arrives through
-    // a push expression evaluated against the project's trusted itx root. A
-    // session principal appending copies would bypass provenance stamping.
+  acceptCrossPost(batch: StreamPushEventBatch): Promise<void> {
+    // Only the platform's own delivery spine dials acceptCrossPost: it arrives
+    // through a push expression evaluated against the project's trusted itx
+    // root. A session principal appending copies would bypass provenance
+    // stamping.
     if (this.props.auth.principal !== "trusted-internal") {
-      throw new Error("ingest is dialed by stream push subscriptions, not sessions");
+      throw new Error("acceptCrossPost is dialed by stream push subscriptions, not sessions");
     }
-    return Promise.resolve(this.durableObjectStub.ingest(batch));
+    return Promise.resolve(this.durableObjectStub.acceptCrossPost(batch));
   }
 
   /**
    * "When events matching this land HERE, post them onto stream `path`" — the
    * cross-post verb. Pure sugar over appending a `subscription-configured`
-   * push subscription targeting the destination's `ingest` sink; the appended
+   * push subscription targeting the destination's `acceptCrossPost` sink; the appended
    * event (returned) is the real interface and shows in the log like any
    * other config. Same-`key` calls replace the previous cross-post; remove
    * with `removeCrossPost`. Copies carry the full provenance chain
@@ -540,7 +541,10 @@ export class StreamRpcTarget extends IterateRpcTarget<"Stream"> {
       type: "events.iterate.com/stream/subscription-configured",
       payload: {
         subscriptionKey: args.key ?? `cross-post:${destination}`,
-        delivery: { mode: "push", expression: ["streams", ["get", destination], "ingest"] },
+        delivery: {
+          mode: "push",
+          expression: ["streams", ["get", destination], "acceptCrossPost"],
+        },
         ...(Object.keys(selector).length === 0 ? {} : { selector }),
         ...(args.deliver === undefined ? {} : { deliver: args.deliver }),
         ...(args.transform === undefined ? {} : { params: { transform: args.transform } }),

--- a/apps/os/src/types-source.generated.ts
+++ b/apps/os/src/types-source.generated.ts
@@ -938,13 +938,13 @@ export interface Stream {
    * appends the batch's events into THIS stream with provenance stamping,
    * structural loop protection, and source-derived idempotency keys. A source
    * stream cross-posts here by configuring
-   * \`{ delivery: { mode: "push", expression: ["streams", ["get", path], "ingest"] } }\`.
+   * \`{ delivery: { mode: "push", expression: ["streams", ["get", path], "acceptCrossPost"] } }\`.
    */
-  ingest(batch: StreamPushEventBatch): Promise<void>;
+  acceptCrossPost(batch: StreamPushEventBatch): Promise<void>;
   /**
    * "When events matching this land HERE, post them onto stream \`path\`" — the
    * cross-post verb. Pure sugar over appending a \`subscription-configured\`
-   * push subscription targeting the destination's \`ingest\` sink; the appended
+   * push subscription targeting the destination's \`acceptCrossPost\` sink; the appended
    * event (returned) is the real interface and shows in the log like any
    * other config. Same-\`key\` calls replace the previous cross-post; remove
    * with \`removeCrossPost\`. Copies carry the full provenance chain

--- a/packages/iterate/src/itx-api.generated.ts
+++ b/packages/iterate/src/itx-api.generated.ts
@@ -933,13 +933,13 @@ export interface Stream {
    * appends the batch's events into THIS stream with provenance stamping,
    * structural loop protection, and source-derived idempotency keys. A source
    * stream cross-posts here by configuring
-   * `{ delivery: { mode: "push", expression: ["streams", ["get", path], "ingest"] } }`.
+   * `{ delivery: { mode: "push", expression: ["streams", ["get", path], "acceptCrossPost"] } }`.
    */
-  ingest(batch: StreamPushEventBatch): Promise<void>;
+  acceptCrossPost(batch: StreamPushEventBatch): Promise<void>;
   /**
    * "When events matching this land HERE, post them onto stream `path`" — the
    * cross-post verb. Pure sugar over appending a `subscription-configured`
-   * push subscription targeting the destination's `ingest` sink; the appended
+   * push subscription targeting the destination's `acceptCrossPost` sink; the appended
    * event (returned) is the real interface and shows in the log like any
    * other config. Same-`key` calls replace the previous cross-post; remove
    * with `removeCrossPost`. Copies carry the full provenance chain


### PR DESCRIPTION
## What

Renames the cross-post receiving sink on streams from `ingest` to `acceptCrossPost`, so the committed delivery expression reads as what it does:

```jsonc
// before
{ "delivery": { "mode": "push", "expression": ["streams", ["get", "/"], "ingest"] } }
// after
{ "delivery": { "mode": "push", "expression": ["streams", ["get", "/"], "acceptCrossPost"] } }
```

## Why

A `subscription-configured` event's push expression is the only durable record of what a cross-post does, and the delivery spine is deliberately generic (it evaluates an address and calls it — all semantics live behind the named sink). That means the sink's *name* is the one place the semantics can be legible in the event log. `ingest` didn't say "provenance-stamped, loop-protected, idempotent copy"; `acceptCrossPost` nearly does.

## Scope

Pure rename, no behavior change:

- `StreamRpcTarget.acceptCrossPost` + `StreamDurableObject.acceptCrossPost` (guard message included)
- expression builders: `crossPostTo` sugar, `github-link.ts` webhook fan-out
- `cross-post.ts` internals: `buildAcceptCrossPostAppendInputs`, `AcceptCrossPostParams`, `CrossPostTransformResult`, and the transform-failure fact strings (`cross-post-transform-failed:` idempotency prefix)
- docs (`streams/README.md`, event-doc examples), itx examples, e2e comments/expressions, MemoryStream test stubs
- regenerated `itx-api.generated.ts` / `types-source.generated.ts` (+ `packages/iterate` copy)

**Not touched:** `StreamProcessor.ingest` — the processor base class's batch/checkpoint lane is a different surface with the same word; it keeps its name.

## Deployment note

Committed `subscription-configured` events referencing `"ingest"` (existing GitHub repo links, any prior `crossPostTo` configs) will fail delivery and park after deploy. Fix is re-appending the subscription (re-link the repo / re-run `crossPostTo`, which replaces by key) or an env reset. No compat alias by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pure rename but breaks all in-flight durable push subscriptions that still dial `ingest` after deploy, affecting GitHub webhook cross-posts and any prior `crossPostTo` configs until reconfigured.
> 
> **Overview**
> Renames the **cross-post receiving sink** on streams from `Stream.ingest` to **`acceptCrossPost`**, so durable push delivery expressions read as what they do (e.g. `["streams", ["get", path], "acceptCrossPost"]` instead of `"ingest"`). **`crossPostTo`**, **`github-link`** webhook fan-out, **`StreamDurableObject` / RPC**, and regenerated **`itx-api`** types all use the new name; **`cross-post.ts`** helpers are renamed (`buildAcceptCrossPostAppendInputs`, transform-failure facts use a `cross-post-transform-failed:` idempotency prefix).
> 
> **`StreamProcessor.ingest`** (processor batch/checkpoint lane) is **unchanged**.
> 
> **Deploy:** committed `subscription-configured` events that still reference `"ingest"` will fail delivery until subscriptions are re-appended (re-link repo / re-run `crossPostTo`); there is no compatibility alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a6b06c66b1ad682a162de1f5ef492e2f0aa7f02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +55 -49 | +22 -19 🟩🟩🟥⬜⬜ |
| Tests | +21 -17 | +17 -13 🟩🟥⬜⬜⬜ |
| Docs | +32 -32 | +32 -32 🟩🟩🟩🟥🟥 |
| Generated | +9 -9 | +5 -5 🟩⬜⬜⬜⬜ |
| **Total** | **+117 -107** | **+76 -69** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 0ce7169 and 2a6b06c, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-09T20:39:43.576Z",
      "headSha": "2a6b06c66b1ad682a162de1f5ef492e2f0aa7f02",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/523802072247687",
      "shortSha": "2a6b06c",
      "cleanupDurationMs": 9689,
      "deployDurationMs": 68804,
      "workerSizeKib": 15483.17,
      "workerGzipKib": 4182.61,
      "mainWorkerGzipKib": 4203.05
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-09T20:39:34.819Z",
      "headSha": "2a6b06c66b1ad682a162de1f5ef492e2f0aa7f02",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/523802072247687",
      "shortSha": "2a6b06c",
      "cleanupDurationMs": 929,
      "deployDurationMs": 15473,
      "workerSizeKib": 1914.69,
      "workerGzipKib": 440.77,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-09T20:39:36.683Z",
      "headSha": "2a6b06c66b1ad682a162de1f5ef492e2f0aa7f02",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/523802072247687",
      "shortSha": "2a6b06c",
      "cleanupDurationMs": 2792,
      "deployDurationMs": 22062,
      "workerSizeKib": 4031.52,
      "workerGzipKib": 819.41,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-09T20:39:34.782Z",
      "headSha": "2a6b06c66b1ad682a162de1f5ef492e2f0aa7f02",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/523802072247687",
      "shortSha": "2a6b06c",
      "cleanupDurationMs": 889,
      "deployDurationMs": 14510,
      "workerSizeKib": 4563.32,
      "workerGzipKib": 1315.35,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `2a6b06c` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 819.4 KiB | 22.1s |  |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/523802072247687) | 2026-07-09T20:39:36.683Z | Preview app released. |
| OS | released | `2a6b06c` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.08 MiB (-20.4 KiB vs main) | 68.8s |  |  | 9.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/523802072247687) | 2026-07-09T20:39:43.576Z | Preview app released. |
| Semaphore | released | `2a6b06c` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 440.8 KiB | 15.5s |  |  | 929ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/523802072247687) | 2026-07-09T20:39:34.819Z | Preview app released. |
| Streams Example App | released | `2a6b06c` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 1.28 MiB | 14.5s |  |  | 889ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/523802072247687) | 2026-07-09T20:39:34.782Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->