### PR TITLE
Fix main typecheck: telegram test MemoryStream needs kill()

### DIFF
--- a/apps/os/src/domains/integrations/telegram-processors.test.ts
+++ b/apps/os/src/domains/integrations/telegram-processors.test.ts
@@ -1014,6 +1014,8 @@ class MemoryStreamNetwork {
 class MemoryStream implements Stream {
   events: StreamEvent[] = [];
 
+  async kill(): Promise<void> {}
+
   async __describe() {
     return { instructions: "in-memory test stream", types: "", children: {} };
   }


### PR DESCRIPTION
Main's lint-typecheck is red at HEAD: #1766 (Telegram) and #1801 (kill on the Stream surface) crossed — the telegram test's in-file MemoryStream lacks `kill()` while the generated `Stream` type now requires it. One-line fix, same shape as the slack/email test helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only stub change with no production or runtime behavior impact.
> 
> **Overview**
> Restores **main typecheck** after the generated `Stream` type gained a required **`kill()`** method while the Telegram integration test’s in-file **`MemoryStream`** did not implement it.
> 
> Adds a no-op **`async kill(): Promise<void> {}`** on that test double, matching the Slack and email processor test helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ef805e34c9f47c29a697ae152556168bbc8b8f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +2 -0 | +1 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+2 -0** | **+1 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between a5929b8 and 0ef805e, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-09T21:01:00.760Z",
      "headSha": "0ef805e34c9f47c29a697ae152556168bbc8b8f9",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/34750157318866",
      "shortSha": "0ef805e",
      "cleanupDurationMs": 10110,
      "deployDurationMs": 70829,
      "testDurationMs": 125732,
      "testRetries": null,
      "workerSizeKib": 15560.85,
      "workerGzipKib": 4202.96,
      "mainWorkerGzipKib": 4202.96
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-09T21:00:53.284Z",
      "headSha": "0ef805e34c9f47c29a697ae152556168bbc8b8f9",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/34750157318866",
      "shortSha": "0ef805e",
      "cleanupDurationMs": 2631,
      "deployDurationMs": 19999,
      "testDurationMs": 717,
      "testRetries": null,
      "workerSizeKib": 4031.55,
      "workerGzipKib": 819.37,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `0ef805e` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 819.4 KiB | 20.0s | 717ms |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/34750157318866) | 2026-07-09T21:00:53.284Z | Preview app released. |
| OS | released | `0ef805e` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 4.10 MiB (±0 vs main) | 70.8s | 125.7s |  | 10.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/34750157318866) | 2026-07-09T21:01:00.760Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->