### PR TITLE
Fix main: finish the acceptCrossPost rename (config-repo bootstrap + telegram test double)

### DIFF
--- a/apps/os/docs/stream-subscribers-design.md
+++ b/apps/os/docs/stream-subscribers-design.md
@@ -229,7 +229,7 @@ onPoison: "skip", delivery: {mode: "push", expression: ["worker", "processEventB
   by #1761) and #1761's derived pump special-case. Worker return = ack; throw = nack. The project
   processor's `child-stream-created` hook keeps appending only the _other_ subscriptions.
 - **Cross-post** — `{subscriptionKey: "cross-post:<id>", selector, onPoison: "park", delivery:
-{mode: "push", expression: ["streams", ["get", targetPath], "ingest"]}}`. New first-party
+{mode: "push", expression: ["streams", ["get", targetPath], "acceptCrossPost"]}}`. New first-party
   `Stream.ingest({from, events})` on the receiving stream carries what `#crossPostMatchingRules`
   does today: `crossPostedFrom` hop chain, cycle guard, `MAX_CROSS_POST_HOPS`, idempotency keys
   `xpost:{fromProject}:{fromPath}:{offset}` (at-least-once delivery collapses to exactly-once

--- a/apps/os/src/domains/integrations/telegram-processors.test.ts
+++ b/apps/os/src/domains/integrations/telegram-processors.test.ts
@@ -1014,6 +1014,8 @@ class MemoryStreamNetwork {
 class MemoryStream implements Stream {
   events: StreamEvent[] = [];
 
+  async kill(): Promise<void> {}
+
   async __describe() {
     return { instructions: "in-memory test stream", types: "", children: {} };
   }

--- a/apps/os/src/domains/integrations/telegram-processors.test.ts
+++ b/apps/os/src/domains/integrations/telegram-processors.test.ts
@@ -1094,8 +1094,8 @@ class MemoryStream implements Stream {
     throw new Error("MemoryStream does not implement subscribe().");
   }
 
-  async ingest(): Promise<never> {
-    throw new Error("MemoryStream does not implement ingest().");
+  async acceptCrossPost(): Promise<never> {
+    throw new Error("MemoryStream does not implement acceptCrossPost().");
   }
 
   async crossPostTo(): Promise<never> {

--- a/apps/os/src/domains/projects/project-processor-implementation.ts
+++ b/apps/os/src/domains/projects/project-processor-implementation.ts
@@ -142,7 +142,10 @@ export class ProjectProcessor extends StreamProcessor<
                     // The key crossPostTo would pick for destination "/", so
                     // `removeCrossPost({ path: "/" })` can manage this rule.
                     subscriptionKey: "cross-post:/",
-                    delivery: { mode: "push", expression: ["streams", ["get", "/"], "ingest"] },
+                    delivery: {
+                      mode: "push",
+                      expression: ["streams", ["get", "/"], "acceptCrossPost"],
+                    },
                     deliver: "all",
                   },
                 },

--- a/apps/os/src/domains/projects/project-processor.test.ts
+++ b/apps/os/src/domains/projects/project-processor.test.ts
@@ -182,7 +182,7 @@ describe("ProjectProcessor bootstrap", () => {
     // stream `/` — full history, so the saga's repo/created arrives too.
     expect(configRepo[1]!.payload).toMatchObject({
       subscriptionKey: "cross-post:/",
-      delivery: { mode: "push", expression: ["streams", ["get", "/"], "ingest"] },
+      delivery: { mode: "push", expression: ["streams", ["get", "/"], "acceptCrossPost"] },
       deliver: "all",
     });
     expect(configRepo[2]!.payload).toEqual({ path: "/repos/config", projectId: "prj_test" });


### PR DESCRIPTION
Three PRs merged within minutes today (#1766 Telegram, #1815 config repo, #1816 ingest→acceptCrossPost rename), each tested against a pre-others main. Two semantic races landed:

1. **New-project creation is broken on main**: #1816 renamed `Stream.ingest` → `acceptCrossPost` but missed #1815's just-merged bootstrap, whose persisted cross-post expression still dials `["streams", ["get", "/"], "ingest"]` — the config repo's `repo/created` never reaches `/`, so the creation saga never completes. Fixed here (implementation + unit test + design doc line).
2. **Main typecheck is red**: the telegram test `MemoryStream` (#1766) is missing both `kill()` (#1812) and `acceptCrossPost()` (#1816). This PR fixes both; the `kill()` hunk is the same change as #1817 and dedupes on whichever merges second — note #1817 alone leaves main red (it doesn't cover `acceptCrossPost`).

Verified: apps/os typecheck clean, integrations + projects unit suites green, lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small alignment fixes to persisted push expressions and test doubles; no new behavior beyond restoring cross-post delivery after the API rename.
> 
> **Overview**
> Completes the **`Stream.ingest` → `acceptCrossPost`** rename where three parallel merges left gaps.
> 
> The config-repo bootstrap **`subscription-configured`** cross-post rule now pushes to `["streams", ["get", "/"], "acceptCrossPost"]` instead of the removed **`ingest`** method, so config-repo events (including **`repo/created`**) reach the project stream **`/`** again and the creation saga can finish. The project bootstrap unit test and stream-subscribers design doc are updated to match.
> 
> The Telegram integration test **`MemoryStream`** stub implements **`kill()`** and **`acceptCrossPost()`** (replacing **`ingest()`**) so **`Stream`** typing stays valid after the rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34aecad1d910a6673b932765dc7865acd82714d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +4 -1 | +4 -1 🟩🟩🟩🟥⬜ |
| Tests | +5 -3 | +4 -3 🟩🟩🟩🟥🟥 |
| Docs | +1 -1 | +1 -1 🟩⬜⬜⬜⬜ |
| **Total** | **+10 -5** | **+9 -5** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between a5929b8 and 34aecad, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->