### PR TITLE
Workspaces: reset can't race root materialization

### DIFF
--- a/apps/os/src/domains/workspaces/workspace-core.ts
+++ b/apps/os/src/domains/workspaces/workspace-core.ts
@@ -324,16 +324,29 @@ export class WorkspaceCore {
    * workspace branch).
    */
   async reset(): Promise<void> {
-    // Settle any in-flight materialization or write first — even a FAILING
-    // one (that is exactly when reset is needed), hence catch-and-ignore.
-    await this.#rootRefresh?.catch(() => {});
-    await this.#writeChain.catch(() => {});
-    this.#rootRefresh = undefined;
-    this.#overlayReady = undefined;
-    this.#kv.delete(ROOT_HEAD_KEY);
-    this.#kv.delete(WHITEOUTS_KEY);
-    this.#kv.delete(LEGACY_CLONE_SENTINEL_KEY);
-    await this.#wipeFilesystem();
+    // The wipe OCCUPIES the single-flight materialization slot for its whole
+    // duration: #ensureFreshRoot always awaits the slot before deciding to
+    // materialize, so no clone can interleave with the rm sweep or observe
+    // the cleared head key mid-wipe. It chains BEHIND any in-flight
+    // materialization (even a failing one — that is exactly when reset is
+    // needed, hence catch-and-ignore) and runs on the write chain, so
+    // concurrent overlay writes queue behind it rather than landing on a
+    // half-wiped tree.
+    const wipe = () =>
+      this.#serializeWrite(async () => {
+        this.#overlayReady = undefined;
+        this.#kv.delete(ROOT_HEAD_KEY);
+        this.#kv.delete(WHITEOUTS_KEY);
+        this.#kv.delete(LEGACY_CLONE_SENTINEL_KEY);
+        await this.#wipeFilesystem();
+      });
+    const run = (this.#rootRefresh ?? Promise.resolve()).catch(() => {}).then(wipe);
+    // Only vacate the slot if a newer occupant hasn't replaced this one.
+    const occupant: Promise<void> = run.finally(() => {
+      if (this.#rootRefresh === occupant) this.#rootRefresh = undefined;
+    });
+    this.#rootRefresh = occupant;
+    await occupant;
   }
 
   /**


### PR DESCRIPTION
Follow-on for Bugbot's post-merge finding on #1804 ("Root reset races materialization", medium): `reset()` awaited an in-flight `#rootRefresh` once, then cleared the slot and wiped — so a concurrent `readFile`/`listAllFiles` could kick a NEW `#materializeRoot` while the wipe was mid-sweep, interleaving clone writes with `rm` and leaving a stale head key over an empty/partial tree.

Fix: the wipe now **occupies the single-flight materialization slot** for its whole duration (readers always await the slot before deciding to materialize, so no clone can overlap the sweep or observe the cleared head key mid-wipe), chains behind any in-flight materialization — even a failing one, which is exactly when reset is needed — and runs on the write chain so overlay writes queue behind it.

Verified: typecheck, workspace unit tests, workspace overlay e2e green against local dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace lifecycle concurrency in `WorkspaceCore.reset()`; incorrect ordering could still wedge root/overlay state, but the change is localized and aligns with existing `#ensureFreshRoot` single-flight behavior.
> 
> **Overview**
> Fixes a **race between `reset()` and root materialization** where the wipe could clear `#rootRefresh` and KV head keys while a concurrent read started a new clone mid-filesystem sweep.
> 
> **`reset()`** now **holds the same single-flight `#rootRefresh` slot** for the entire wipe: it chains behind any in-flight materialization (failures included), runs KV clears and `#wipeFilesystem()` inside **`#serializeWrite`** so overlay writes cannot interleave, and only clears the slot in `finally` if this run is still the occupant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c6d810df2714463c3836dd803c561eac5cfbd38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +23 -10 | +14 -8 🟩🟩🟩🟥🟥 |
| **Total** | **+23 -10** | **+14 -8** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 07f25a3 and 5c6d810, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->