### PR TITLE
Streams: re-announce ancestors on every wake (heals orphaned newborn streams)

### DIFF
--- a/apps/os/e2e/vitest/stream-ancestor-announcements.e2e.test.ts
+++ b/apps/os/e2e/vitest/stream-ancestor-announcements.e2e.test.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "vitest";
+import { waitForCondition } from "../test-support/wait-for-condition.ts";
+import { adminSecret, withItxSession } from "./test-helpers.ts";
+
+// Ancestor announcements are load-bearing platform state: integration listing
+// walks childPaths, and the project processor's birth reactions (mechanics,
+// agent policy) trigger on the root's `child-stream-created` fold. These tests
+// pin the two guarantees that keep a newborn stream from being orphaned:
+//
+// 1. A newborn stream announces itself to EVERY ancestor, root included.
+// 2. An announcement lost in flight — the 2026-07-09 prd incident: a deploy
+//    rollover recycled the isolate mid birth turn, orphaning a Telegram
+//    connection stream and its chat stream — heals on the stream's next wake,
+//    because every `woken` fact re-announces with idempotent appends.
+
+const announcementKey = (ancestorPath: string, childPath: string) =>
+  `child-stream-created:${ancestorPath}:${childPath}`;
+
+test("a newborn stream announces itself to every ancestor", async () => {
+  const marker = crypto.randomUUID();
+  const childPath = `/announce-birth-${marker}/child`;
+
+  using session = withItxSession();
+  using itx = session.authenticate({
+    type: "admin-secret",
+    secret: adminSecret(),
+  });
+  using project = itx.projects.create({ slug: `announce-birth-${marker}` });
+  using root = project.streams.get("/");
+  using parent = project.streams.get(`/announce-birth-${marker}`);
+  using child = project.streams.get(childPath);
+
+  await child.append({
+    type: "events.iterate.test/announce-probe",
+    payload: { marker },
+  });
+
+  await waitForCondition(
+    async () =>
+      (await root.getEvent({ idempotencyKey: announcementKey("/", childPath) })) !== undefined &&
+      (await parent.getEvent({
+        idempotencyKey: announcementKey(`/announce-birth-${marker}`, childPath),
+      })) !== undefined,
+    {
+      description: `child-stream-created announcements for ${childPath} on / and its parent`,
+      timeoutMs: 10_000,
+    },
+  );
+  const onRoot = await root.getEvent({ idempotencyKey: announcementKey("/", childPath) });
+  expect(onRoot?.payload).toEqual({ childPath });
+});
+
+test("a lost ancestor announcement heals on the stream's next wake", async () => {
+  const marker = crypto.randomUUID();
+  const childPath = `/announce-heal-${marker}/child`;
+
+  using session = withItxSession();
+  using itx = session.authenticate({
+    type: "admin-secret",
+    secret: adminSecret(),
+  });
+  using project = itx.projects.create({ slug: `announce-heal-${marker}` });
+  using root = project.streams.get("/");
+  using child = project.streams.get(childPath);
+
+  // Simulate the lost announcement through public verbs: a paused root
+  // rejects `child-stream-created`, so the birth announcement fails exactly
+  // like one dropped by an isolate death — and the birth itself must still
+  // succeed (a sick ancestor must never brick a newborn).
+  await root.append({
+    type: "events.iterate.com/stream/paused",
+    payload: { reason: `announce-heal e2e ${marker}` },
+  });
+  try {
+    await child.append({
+      type: "events.iterate.test/announce-probe",
+      payload: { marker },
+    });
+    // Give the (background) birth announcement time to fail against the
+    // paused root before resuming; the heal below must come from the re-wake,
+    // not from a slow first attempt landing after the resume.
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    const lost = await root.getEvent({ idempotencyKey: announcementKey("/", childPath) });
+    expect(lost).toBeUndefined();
+  } finally {
+    await root.append({ type: "events.iterate.com/stream/resumed", payload: {} });
+  }
+
+  // Next incarnation: `woken` re-announces. Without the re-announce-on-wake
+  // behavior the stream stays orphaned forever (the prd incident). kill()
+  // aborts its own incarnation, so the RPC itself always rejects.
+  await child.kill().catch(() => undefined);
+  await child.getEvents({ limit: 1 });
+
+  await waitForCondition(
+    async () =>
+      (await root.getEvent({ idempotencyKey: announcementKey("/", childPath) })) !== undefined,
+    {
+      description: `root child-stream-created announcement for ${childPath} after re-wake`,
+      timeoutMs: 10_000,
+    },
+  );
+  const healed = await root.getEvent({ idempotencyKey: announcementKey("/", childPath) });
+  expect(healed?.payload).toEqual({ childPath });
+});

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -723,7 +723,18 @@ export class StreamDurableObject extends DurableObject<Env> {
         this.#subscribers.onCursorSet(event.payload.subscriptionKey, event.payload.afterOffset);
         return;
       }
-      case "events.iterate.com/stream/created":
+      case "events.iterate.com/stream/woken":
+        // Every incarnation re-announces this stream to its ancestors, not
+        // just the birth one. The appends are idempotent (stable key per
+        // ancestor/path pair, deduped in the ancestor's log), so re-announcing
+        // is a cheap no-op once landed — and an announcement lost in flight
+        // (isolate recycled by a deploy mid birth turn, transient ancestor
+        // failure) heals on the next wake instead of orphaning the stream:
+        // ancestors would otherwise never fold `child-stream-created`, leaving
+        // listings blind and birth reactions unarmed forever. Fire-and-forget
+        // by design — a newborn must never block its own boot on ancestor
+        // health (the parent's processor may be mid-append INTO this stream,
+        // so waiting on the parent's ack here is a reentrant deadlock).
         this.#announceToAncestors(args);
         return;
       default:


### PR DESCRIPTION
## Incident

2026-07-09 ~21:22Z, prd: Jonas connected a Telegram bot — toast said connected, but `integrations.list()` stayed empty and the bot never answered. The connection stream and its routed chat stream both existed and held the inbound messages; what was missing was the `child-stream-created` announcement on **every** ancestor (root included). Without it, integration listing is blind and the project processor's birth reactions (mechanics, agent policy) never arm, so no agent ever booted on the chat stream. A second, independent hit the same evening: a probe agent born mid project bootstrap was orphaned the same way.

## Root cause

Ancestor announcements fired exactly once per stream lifetime — a fire-and-forget `waitUntil` side effect of reducing the stream's own `stream/created` event. The two orphaned streams were born at 21:22:09Z and ~21:23Z, exactly while prd rolled over the #1814/#1797 deploys: the isolate was recycled mid birth turn and the in-memory announcement work died with it. Historical catch-up never replays side effects, so nothing ever healed it.

## Fix

Trigger the announcement from `stream/woken` instead of `stream/created`. Every incarnation appends `woken` (birth included, immediately after `created`), and the announcement appends are idempotent (stable key per ancestor/path pair), so:

- a landed announcement re-checks as a cheap idempotency hit (no new events, no new deliveries);
- a lost announcement heals on the stream's next wake;
- **already-orphaned prd streams self-heal on their next wake** — no data surgery.

Deliberately fire-and-forget rather than blocking the birth turn: the parent's processor may be mid-append INTO the newborn (project bootstrap does exactly this), so gating the newborn's boot on the parent's ack via `blockConcurrencyWhile` is a reentrant deadlock — live-proven against the dev server, where it wedged project creation and reset the DO at the 30s cap.

## Regression test

`stream-ancestor-announcements.e2e.test.ts` simulates the lost announcement with public verbs only (a paused root rejects `child-stream-created`, birth still succeeds), then proves `kill()` + re-dial heals it. Verified red against the previous behavior, green with the fix. A second test pins that newborns announce to every ancestor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core stream birth/orchestration paths that drive integration listing and project processors, but behavior for already-landed announcements stays a cheap idempotency no-op and announcements remain fire-and-forget.
> 
> **Overview**
> Fixes a production incident where **ancestor `child-stream-created` announcements** could be lost when an isolate died mid birth turn, leaving new streams invisible to integration listing and project birth reactions.
> 
> **`StreamDurableObject`** now runs `#announceToAncestors` on **`events.iterate.com/stream/woken`** instead of `stream/created`. Every incarnation (including birth, right after `created`) re-announces to all ancestors with the same idempotent keys, so a missed announcement heals on the next wake without blocking boot.
> 
> Adds **`stream-ancestor-announcements.e2e.test.ts`**: newborns must announce on root and parent; a paused root simulates a dropped announcement, then `kill()` + re-dial must heal the root announcement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9995250f8bfeff725f76081eda800eb73ceb9ad6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-09T22:08:43.562Z",
      "headSha": "9995250f8bfeff725f76081eda800eb73ceb9ad6",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/63541340323309",
      "shortSha": "9995250",
      "cleanupDurationMs": 8023,
      "deployDurationMs": 69739,
      "workerSizeKib": 15679.69,
      "workerGzipKib": 4232.83,
      "mainWorkerGzipKib": 4229.52
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-09T22:08:36.513Z",
      "headSha": "9995250f8bfeff725f76081eda800eb73ceb9ad6",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/63541340323309",
      "shortSha": "9995250",
      "cleanupDurationMs": 970,
      "deployDurationMs": 15180,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-09T22:08:39.130Z",
      "headSha": "9995250f8bfeff725f76081eda800eb73ceb9ad6",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/63541340323309",
      "shortSha": "9995250",
      "cleanupDurationMs": 3587,
      "deployDurationMs": 26534,
      "workerSizeKib": 4031.55,
      "workerGzipKib": 819.29,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-09T22:08:36.595Z",
      "headSha": "9995250f8bfeff725f76081eda800eb73ceb9ad6",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/63541340323309",
      "shortSha": "9995250",
      "cleanupDurationMs": 1049,
      "deployDurationMs": 14192,
      "workerSizeKib": 4682.36,
      "workerGzipKib": 1345.93,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `9995250` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 819.3 KiB | 26.5s |  |  | 3.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/63541340323309) | 2026-07-09T22:08:39.130Z | Preview app released. |
| OS | released | `9995250` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.13 MiB (+3.3 KiB vs main) | 69.7s |  |  | 8.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/63541340323309) | 2026-07-09T22:08:43.562Z | Preview app released. |
| Semaphore | released | `9995250` | [https://semaphore.iterate-preview-3.com](https://semaphore.iterate-preview-3.com) | 440.8 KiB | 15.2s |  |  | 970ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/63541340323309) | 2026-07-09T22:08:36.513Z | Preview app released. |
| Streams Example App | released | `9995250` | [https://streams.iterate-preview-3.com](https://streams.iterate-preview-3.com) | 1.31 MiB | 14.2s |  |  | 1.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/63541340323309) | 2026-07-09T22:08:36.595Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +12 -1 | +1 -1 🟩⬜⬜⬜⬜ |
| Tests | +105 -0 | +74 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+117 -1** | **+75 -1** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between a4b6762 and 9995250, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->