### PR TITLE
Stream delivery: a not-ready receiver is backoff, not poison (fixes bootstrap poison-skips)

### DIFF
--- a/apps/os/src/domains/repos/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/repo-durable-object.ts
@@ -31,7 +31,14 @@ import type {
 } from "./types.ts";
 import { countOccurrences, replaceLiteralOccurrences } from "./edit-utils.ts";
 import { diffFileMaps } from "./line-diff.ts";
-import { CONFIG_REPO_PATH, RepoArtifactNameCodec, base64ToBytes, bytesToBase64 } from "./utils.ts";
+import {
+  CONFIG_REPO_PATH,
+  RepoArtifactNameCodec,
+  RepoNotSeededError,
+  base64ToBytes,
+  bytesToBase64,
+  classifyRepoAccessError,
+} from "./utils.ts";
 import { projectRepoSeedFiles } from "./project-repo-seed.ts";
 import { RepoProcessor } from "./repo-processor-implementation.ts";
 
@@ -208,9 +215,13 @@ export class RepoDurableObject extends DurableObject<Env> {
         // branch tip. Project repos are small; correctness beats depth tuning.
         const filesystem = new InMemoryFs();
         const git = createGit(filesystem, REPO_DIR);
-        await git.clone({ branch, url: repo.remote, ...credentials });
+        try {
+          await git.clone({ branch, url: repo.remote, ...credentials });
+        } catch (error) {
+          throw classifyRepoAccessError(error);
+        }
         const [branchHead] = await git.log({ depth: 1 });
-        if (!branchHead) throw new Error("Repo has no commits.");
+        if (!branchHead) throw new RepoNotSeededError("Repo has no commits.");
         try {
           await git.checkout({ ref: input.commitOid, force: true });
         } catch (error) {
@@ -238,15 +249,19 @@ export class RepoDurableObject extends DurableObject<Env> {
     const clone = async () => {
       const filesystem = new InMemoryFs();
       const git = createGit(filesystem, REPO_DIR);
-      await git.clone({
-        branch,
-        ...(input.historyDepth === "full" ? {} : { depth: input.historyDepth || 1 }),
-        singleBranch: true,
-        url: repo.remote,
-        ...credentials,
-      });
+      try {
+        await git.clone({
+          branch,
+          ...(input.historyDepth === "full" ? {} : { depth: input.historyDepth || 1 }),
+          singleBranch: true,
+          url: repo.remote,
+          ...credentials,
+        });
+      } catch (error) {
+        throw classifyRepoAccessError(error);
+      }
       const [head] = await git.log({ depth: 1 });
-      if (!head) throw new Error("Repo has no commits.");
+      if (!head) throw new RepoNotSeededError("Repo has no commits.");
       return { filesystem, git, head };
     };
 
@@ -1002,7 +1017,9 @@ export class RepoDurableObject extends DurableObject<Env> {
     this.#artifactTokenPromise ??= artifactToken(this.requireArtifacts(), artifactName).catch(
       (error: unknown) => {
         this.#artifactTokenPromise = undefined;
-        throw error;
+        // A missing Artifacts repo is the pre-seed window (createArtifactRepo
+        // hasn't run), the same "not ready yet" every unseeded clone signals.
+        throw classifyRepoAccessError(error);
       },
     );
     return {

--- a/apps/os/src/domains/repos/utils.test.ts
+++ b/apps/os/src/domains/repos/utils.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "vitest";
 import { countOccurrences, replaceLiteralOccurrences } from "./edit-utils.ts";
-import { RepoArtifactNameCodec, base64ToBytes, bytesToBase64 } from "./utils.ts";
+import {
+  RepoArtifactNameCodec,
+  RepoNotSeededError,
+  base64ToBytes,
+  bytesToBase64,
+  classifyRepoAccessError,
+  isRepoNotSeededError,
+} from "./utils.ts";
 
 describe("RepoArtifactNameCodec", () => {
   test("round-trips project-scoped repo paths", () => {
@@ -45,6 +52,48 @@ describe("repo binary base64 lane", () => {
 
   test("rejects junk base64 with a caller-friendly error", () => {
     expect(() => base64ToBytes("not base64!!!")).toThrow(/contentBase64 must be valid base64/);
+  });
+});
+
+describe("classifyRepoAccessError", () => {
+  test("wraps isomorphic-git's missing-ref clone failure (the unseeded-remote shape)", () => {
+    // What an empty Artifacts remote actually produces: the server answers
+    // HEAD with a branch that has no commits, and isomorphic-git's clone
+    // fails resolving it (observed verbatim during every prd bootstrap).
+    const raw = Object.assign(new Error("Could not find refs/heads/master."), {
+      code: "NotFoundError",
+    });
+    const classified = classifyRepoAccessError(raw);
+    expect(classified).toBeInstanceOf(RepoNotSeededError);
+    expect(isRepoNotSeededError(classified)).toBe(true);
+    expect((classified as Error).message).toContain("refs/heads/master");
+    expect((classified as Error).cause).toBe(raw);
+  });
+
+  test("wraps a missing Artifacts repo (NOT_FOUND — the pre-createArtifactRepo window)", () => {
+    const raw = Object.assign(new Error("repo not found"), { code: "NOT_FOUND" });
+    expect(isRepoNotSeededError(classifyRepoAccessError(raw))).toBe(true);
+  });
+
+  test("passes every other failure through unchanged", () => {
+    const network = new Error("fetch failed");
+    expect(classifyRepoAccessError(network)).toBe(network);
+    // A NotFoundError about something other than a ref (a missing object id)
+    // is repo corruption or a bad caller input, not the unseeded window.
+    const object = Object.assign(new Error("Could not find deadbeef."), {
+      code: "NotFoundError",
+    });
+    expect(classifyRepoAccessError(object)).toBe(object);
+    expect(classifyRepoAccessError(undefined)).toBe(undefined);
+    expect(classifyRepoAccessError("string error")).toBe("string error");
+  });
+
+  test("isRepoNotSeededError matches by name, the only identity that survives Workers RPC", () => {
+    expect(
+      isRepoNotSeededError(Object.assign(new Error("x"), { name: "RepoNotSeededError" })),
+    ).toBe(true);
+    expect(isRepoNotSeededError(new Error("x"))).toBe(false);
+    expect(isRepoNotSeededError(null)).toBe(false);
   });
 });
 

--- a/apps/os/src/domains/repos/utils.ts
+++ b/apps/os/src/domains/repos/utils.ts
@@ -55,6 +55,44 @@ export function defaultProjectWorkerRef(): StatelessDynamicWorkerRef {
   };
 }
 
+/**
+ * The repo stream exists but its git data does not (yet): the Artifacts repo
+ * was never created, or was created and awaits its seed commit. Every project
+ * bootstrap has this window — the config repo's stream and its dependents
+ * (the project worker feed) come alive before the seed lands — so callers
+ * must be able to tell "not seeded YET, retry" from a real failure. Matched
+ * by NAME because the error crosses Workers RPC (which preserves `error.name`
+ * but not class identity).
+ */
+export class RepoNotSeededError extends Error {
+  static readonly NAME = "RepoNotSeededError";
+  override readonly name = RepoNotSeededError.NAME;
+}
+
+export function isRepoNotSeededError(error: unknown): boolean {
+  return (error as { name?: string } | null)?.name === RepoNotSeededError.NAME;
+}
+
+/**
+ * Wraps a branch-clone failure as {@link RepoNotSeededError} when it means
+ * "the remote has no such ref/commits" — isomorphic-git's NotFoundError for a
+ * ref (an empty Artifacts remote answers HEAD with a branch that has no
+ * commits, observed as "Could not find refs/heads/master"), or the Artifacts
+ * repo itself missing (`NOT_FOUND` — created lazily by the bootstrap saga).
+ * Anything else returns unchanged.
+ */
+export function classifyRepoAccessError(error: unknown): unknown {
+  const { code, message } = (error ?? {}) as { code?: unknown; message?: unknown };
+  const notSeeded =
+    code === "NOT_FOUND" ||
+    (code === "NotFoundError" && typeof message === "string" && message.includes("refs/"));
+  if (!notSeeded) return error;
+  return new RepoNotSeededError(
+    `Repo has no commits yet (unseeded or still seeding): ${typeof message === "string" ? message : String(error)}`,
+    { cause: error },
+  );
+}
+
 function normalizeRepoPath(path: string): string {
   if (path === "") return "/";
   return path.startsWith("/") ? path : `/${path}`;

--- a/apps/os/src/domains/streams/rpc-types.ts
+++ b/apps/os/src/domains/streams/rpc-types.ts
@@ -138,6 +138,30 @@ export type StreamPushEventBatch = {
 };
 
 /**
+ * A push receiver's declaration that it cannot accept ANY batch right now —
+ * part of the delivery contract, not an implementation detail. The spine
+ * treats a rejection carrying this name as "the receiver is down/not ready"
+ * and routes it to the backoff/park lane even under `onPoison: "skip"`,
+ * because poison confirmation is a verdict about ONE event and an unavailable
+ * receiver fails every event: skip-confirming during an outage window steps
+ * over healthy events forever (the bootstrap incarnation: the project-worker
+ * feed dialed before the config repo seeded, and permanently skipped the
+ * events that raced the seed).
+ *
+ * Matched by NAME, not instanceof: the rejection crosses Workers RPC hops
+ * (loopback itx roots, DO bindings), which preserve `error.name` but not
+ * class identity.
+ */
+export class StreamReceiverUnavailableError extends Error {
+  static readonly NAME = "StreamReceiverUnavailableError";
+  override readonly name = StreamReceiverUnavailableError.NAME;
+}
+
+export function isStreamReceiverUnavailableError(error: unknown): boolean {
+  return (error as { name?: string } | null)?.name === StreamReceiverUnavailableError.NAME;
+}
+
+/**
  * One webhook delivery: a single committed event POSTed as JSON to the
  * subscription's URL. Deliberately per-EVENT (external webhook consumers
  * expect individual events, and per-event acking gives mid-batch

--- a/apps/os/src/domains/streams/stream-subscribers.test.ts
+++ b/apps/os/src/domains/streams/stream-subscribers.test.ts
@@ -18,6 +18,7 @@ import type {
   StreamSubscriberWakeRequest,
   StreamWebhookDelivery,
 } from "./rpc-types.ts";
+import { StreamReceiverUnavailableError } from "./rpc-types.ts";
 import type { StreamEvent, StreamEventInput } from "./schemas.ts";
 import type { SubscriptionCursorRow, SubscriptionCursorStore } from "./stream-storage.ts";
 import { StreamSubscribers, type SubscriberDial } from "./stream-subscribers.ts";
@@ -1192,5 +1193,87 @@ describe("StreamSubscribers", () => {
     expect(h.pushes[1]!.events.map((event) => event.offset)).toEqual([3]);
     expect(h.row("k")?.ackedOffset).toBe(3);
     expect(h.storageReads()).toBeGreaterThan(readsBefore);
+  });
+
+  it("x. a receiver-unavailable rejection backs off whole under onPoison skip — no bisect, no skips (the bootstrap window)", async () => {
+    const h = makeHarness();
+    h.configure(pushPayload({ onPoison: "skip" }), 0);
+    h.append(evt(1, "a"), evt(2, "a"), evt(3, "a"));
+
+    // The prd bootstrap incarnation: the project-worker feed dials before the
+    // config repo has seeded, so EVERY delivery rejects with the receiver's
+    // unavailability declaration — a statement about the receiver, never a
+    // verdict about any one event. (Thrown name-only, the way it actually
+    // arrives after crossing Workers RPC hops.)
+    let ready = false;
+    h.dialImpl.push = async () => {
+      if (!ready) {
+        throw Object.assign(new Error("project worker is not ready yet"), {
+          name: "StreamReceiverUnavailableError",
+        });
+      }
+    };
+
+    h.subscribers.wake();
+    await h.settle();
+
+    // First failure: the batch stays WHOLE (no bisect), nothing is skipped,
+    // the cursor holds — just a backoff row and an armed alarm.
+    expect(h.pushes.map((batch) => batch.events.map((event) => event.offset))).toEqual([[1, 2, 3]]);
+    expect(h.factsOfType(ERROR_OCCURRED)).toHaveLength(0);
+    expect(h.row("k")).toMatchObject({ ackedOffset: 0, attempt: 1 });
+    expect(h.armedAlarms.length).toBeGreaterThan(0);
+
+    // Stay unavailable well past SKIP_CONFIRM_ATTEMPTS: before this routing,
+    // three fast retries were enough to "confirm" a healthy event as poison
+    // and step over it forever (offset 1 of every fresh project's root
+    // stream lost to the config-repo seed race).
+    for (let round = 0; round < SKIP_CONFIRM_ATTEMPTS + 1; round += 1) {
+      const next = h.store.minNextAttemptAt();
+      if (next === null) break;
+      h.advanceTo(Math.max(h.now(), next) + 1);
+      h.subscribers.onAlarm();
+      await h.settle();
+    }
+    expect(h.factsOfType(ERROR_OCCURRED)).toHaveLength(0);
+    expect(h.factsOfType(PARKED)).toHaveLength(0);
+    expect(h.row("k")?.ackedOffset).toBe(0);
+    expect(h.pushes.every((batch) => batch.events.length === 3)).toBe(true);
+
+    // The receiver comes up (seed landed, worker built): the next retry
+    // delivers the ORIGINAL batch intact and the failure state clears.
+    ready = true;
+    const next = h.store.minNextAttemptAt();
+    expect(next).not.toBeNull();
+    h.advanceTo(Math.max(h.now(), next!) + 1);
+    h.subscribers.onAlarm();
+    await h.settle();
+    expect(h.pushes.at(-1)!.events.map((event) => event.offset)).toEqual([1, 2, 3]);
+    expect(h.row("k")).toMatchObject({ ackedOffset: 3, attempt: 0, nextAttemptAt: null });
+    expect(h.factsOfType(ERROR_OCCURRED)).toHaveLength(0);
+  });
+
+  it("y. sustained receiver unavailability parks loudly instead of mass-skipping the backlog", async () => {
+    const h = makeHarness();
+    h.configure(pushPayload({ onPoison: "skip" }), 0);
+    h.append(evt(1, "a"), evt(2, "a"), evt(3, "a"));
+    h.dialImpl.push = async () => {
+      throw new StreamReceiverUnavailableError("still not ready");
+    };
+
+    await driveUntilParked(h);
+
+    // The whole outage produced ZERO poison verdicts: no event was stepped
+    // over, the cursor never moved, and the park is the loud, resumable end
+    // state MAX_DELIVERY_ATTEMPTS exists for.
+    expect(h.factsOfType(ERROR_OCCURRED)).toHaveLength(0);
+    const parkedFacts = h.factsOfType(PARKED);
+    expect(parkedFacts).toHaveLength(1);
+    expect(parkedFacts[0].payload).toMatchObject({ subscriptionKey: "k", atOffset: 0 });
+    expect(h.row("k")?.ackedOffset).toBe(0);
+    expect(
+      h.pushes.every((batch) => batch.events.map((event) => event.offset).join(",") === "1,2,3"),
+    ).toBe(true);
+    expect(h.pushes).toHaveLength(MAX_DELIVERY_ATTEMPTS);
   });
 });

--- a/apps/os/src/domains/streams/stream-subscribers.ts
+++ b/apps/os/src/domains/streams/stream-subscribers.ts
@@ -40,6 +40,7 @@ import type {
   StreamSubscriberWakeRequest,
   StreamWebhookDelivery,
 } from "./rpc-types.ts";
+import { isStreamReceiverUnavailableError } from "./rpc-types.ts";
 import type {
   CoreProcessorState,
   StreamSubscriberDescriptor,
@@ -647,6 +648,19 @@ export class StreamSubscribers {
     error: unknown;
   }): "continue" | "stop" {
     const { subscriptionKey, config, matched, error } = args;
+    // A receiver that DECLARED itself unavailable (see
+    // StreamReceiverUnavailableError) is down, not poisoned: no bisecting, no
+    // skip confirmation — the same batch backs off and redelivers whole, and
+    // sustained unavailability parks loudly like any other outage. Known
+    // wrinkle: the backoff attempts accrued here share the row's counter with
+    // skip confirmation, so a genuine poison event arriving the moment the
+    // receiver recovers can confirm in fewer than SKIP_CONFIRM_ATTEMPTS lone
+    // tries — a mis-skip needs a poison event racing the recovery boundary,
+    // versus today's guaranteed skip of healthy events during the outage.
+    if (isStreamReceiverUnavailableError(error)) {
+      this.#onDeliveryFailure(subscriptionKey, error);
+      return "stop";
+    }
     if (config.onPoison === "skip") {
       if (matched.length > 1) {
         // Bisect: retry immediately with a halved batch. Bounded by

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -60,7 +60,12 @@ import { projectStub } from "./domains/projects/egress.ts";
 import { ProjectProcessorContract } from "./domains/projects/project-processor-contract.ts";
 import { projectEgressFetcher } from "./domains/projects/utils.ts";
 import { RepoProcessorContract } from "./domains/repos/repo-processor-contract.ts";
-import { CONFIG_REPO_PATH, defaultProjectWorkerRef } from "./domains/repos/utils.ts";
+import {
+  CONFIG_REPO_PATH,
+  defaultProjectWorkerRef,
+  isRepoNotSeededError,
+} from "./domains/repos/utils.ts";
+import { isWorkerBuildInProgressError } from "./domains/workers/worker-loader.ts";
 import type { SandboxDurableObject } from "./domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts";
 import {
   DEFAULT_SANDBOX_INSTANCE_TYPE,
@@ -214,6 +219,7 @@ import type {
   StreamSubscriptionHandle,
   WakeableStreamProcessorRpc,
 } from "./domains/streams/rpc-types.ts";
+import { StreamReceiverUnavailableError } from "./domains/streams/rpc-types.ts";
 import type { StreamProcessorHost } from "./domains/streams/stream-processor-host.ts";
 import type { LiveUpdate } from "./lib/live-state/protocol.ts";
 import { LiveState, type LiveStateSubscription } from "./lib/live-state/engine.ts";
@@ -4121,9 +4127,27 @@ export class ProjectRpcTarget extends IterateRpcTarget<"Project"> {
    * Same trust model as `worker.processEventBatch` itself: any project
    * principal may call it.
    */
-  processEventBatch(batch: StreamPushEventBatch): Promise<void> {
+  async processEventBatch(batch: StreamPushEventBatch): Promise<void> {
     this.#indexStreamActivity(batch);
-    return this.worker.processEventBatch(batch);
+    try {
+      return await this.worker.processEventBatch(batch);
+    } catch (error) {
+      // The bootstrap window: the worker cannot be MATERIALIZED yet (config
+      // repo unseeded, or its first build still in flight). That is this
+      // receiver being unavailable, not the batch being poison — say so in
+      // the delivery contract's vocabulary so the spine backs off and
+      // redelivers instead of skip-confirming real events. (A skipped
+      // `child-stream-created` is an agent the worker never applies policy
+      // to; this exact race skipped offset 1 of every fresh project's root
+      // stream against the config-repo seed.)
+      if (isRepoNotSeededError(error) || isWorkerBuildInProgressError(error)) {
+        throw new StreamReceiverUnavailableError(
+          `project worker is not ready yet: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
   }
 
   /**

--- a/specs/reactivity.spec.ts
+++ b/specs/reactivity.spec.ts
@@ -90,16 +90,18 @@ test("reactivity page processor panel goes live and repaints from a server push"
   await using projectFixture = await helpers.createFixture("reactivity-processor");
 
   await page.goto(`/projects/${projectFixture.project.slug}/reactivity`);
-  // The processor panel must actually be LIVE (an onStateChange push
+  // The processor panel must actually be LIVE (a live-state push
   // subscription), not silently erroring behind a loader fallback.
   await page.getByTestId("reactivity-status").getByText("live").waitFor();
   await page.getByTestId("reactivity-phase").getByText("ready").waitFor();
 
-  const offsetBefore = await metricNumber(page, "reactivity-processor-offset");
+  // #1810 removed the processor-offset metric; "State updates" is its
+  // live-state analogue (how many times the folded slice pushed).
+  const pushesBefore = await metricNumber(page, "reactivity-state-push-count");
 
   // Birth a brand-new child stream SERVER-SIDE (no page interaction at all):
-  // that changes project processor state (streams[]), and the server must
-  // push the new checkpoint into the open page.
+  // that changes the project's folded state (streams[]), and the server must
+  // push the new fold into the open page.
   using adminSession = await connectAdminItx(baseURL!);
   using adminProject = adminSession.projects.get(projectFixture.project.id);
   using stream = adminProject.streams.get(`/spec-processor-push/${Date.now().toString(36)}`);
@@ -109,8 +111,8 @@ test("reactivity page processor panel goes live and repaints from a server push"
   });
 
   await expect
-    .poll(() => metricNumber(page, "reactivity-processor-offset"))
-    .toBeGreaterThan(offsetBefore);
+    .poll(() => metricNumber(page, "reactivity-state-push-count"))
+    .toBeGreaterThan(pushesBefore);
 });
 
 async function metricNumber(page: Page, testId: string) {


### PR DESCRIPTION
## Incident

Every fresh project bootstrap (observed on every prd/preview reset, most recently after the #1808 prd reset) logs this on the root stream:

> `subscription "project-worker" skipped poison event at offset 1 after 3 attempts: Could not find refs/heads/master`

That line is not cosmetic. The project-worker push feed (`onPoison: "skip"`, `deliver: "all"`) dials `processEventBatch` → builds the project worker from the config repo. Until the bootstrap saga seeds that repo, **every** delivery fails ("Could not find refs/heads/master" is isomorphic-git failing to clone the empty Artifacts remote). The spine cannot tell "receiver not ready" from "receiver rejected this event", so after `SKIP_CONFIRM_ATTEMPTS` (3) fast retries (~3–7s of backoff — reliably faster than the seed) it declares the event poison and **steps over it permanently**.

Consequences of events lost in that window:

- The skipped event is gone from the worker's view forever — the feed's cursor is past it and #1823's idempotent re-announce appends nothing new, so it can never heal this.
- If the skipped event is a `child-stream-created` (a config-repo stream or an agent born mid-bootstrap), the worker never applies agent policy — the #1823 incident's second lane.
- Under a slower seed, `MAX_CONSECUTIVE_SKIPS` (3) **parks the entire feed**: the worker then receives nothing until a manual resume.

## Fix

Unavailability becomes a first-class part of the delivery contract instead of being indistinguishable from poison:

- **`StreamReceiverUnavailableError`** (streams/rpc-types.ts): a named error — name-matched because it crosses Workers RPC hops — that a push receiver throws to declare "I cannot accept ANY batch yet".
- **Spine** (stream-subscribers.ts): a rejection carrying that name routes to the existing backoff/park lane even under `onPoison: "skip"` — no bisect, no skip confirmation, the batch redelivers whole. Sustained unavailability still parks loudly at `MAX_DELIVERY_ATTEMPTS` (~3.5h), which is the intended end state for a genuinely dead receiver.
- **`RepoNotSeededError`** (repos/utils.ts): the repo DO now classifies the two unseeded shapes — isomorphic-git's missing-ref clone failure and a missing Artifacts repo (`NOT_FOUND`, the pre-`createArtifactRepo` window) — into one named error instead of leaking raw clone internals.
- **`ProjectRpcTarget.processEventBatch`** (rpc-targets.ts) — the documented platform adaptation point for exactly this kind of envelope evolution — translates `RepoNotSeededError` / `WorkerBuildInProgressError` into `StreamReceiverUnavailableError`.

Together with #1823 (announce-on-every-wake) this closes both lanes that made child-stream birth announcements unreliable: #1823 heals announcements that never **landed** on the ancestor; this PR stops announcements that landed from being **skipped out of the project-worker feed**. Bootstrap now produces zero `stream/error-occurred` facts.

## Regression tests

- `stream-subscribers.test.ts` **x**: a skip-mode subscription rejecting with the unavailable name (thrown name-only, the cross-RPC shape) backs off whole — no bisect, no skip facts, cursor held past `SKIP_CONFIRM_ATTEMPTS` — then delivers the original batch intact on recovery. **Verified red against the previous spine** (bisects + skips), green with the fix.
- `stream-subscribers.test.ts` **y**: sustained unavailability parks loudly with zero events stepped over (previously: two healthy events skipped, then park). Also verified red-then-green.
- `repos/utils.test.ts`: `classifyRepoAccessError` wraps exactly the unseeded shapes (missing ref, `NOT_FOUND`) and passes every other failure through; name-based matching pinned.

## Known residual

`withDeliveryTimeout` (60s) can still time a delivery out while a cold worker build is legitimately in flight; timeout errors keep today's poison semantics (a userspace worker that hangs on one event is exactly the poison case). Rarely bites: freshly seeded repos share one content-hash-keyed build artifact, so real cold builds are one-per-content, not one-per-project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stream delivery semantics for skip-mode subscriptions and project worker batch handling during bootstrap; incorrect classification could delay delivery or mask real poison events, but scope is bounded with regression tests.
> 
> **Overview**
> Fixes a bootstrap race where the **project-worker** push feed (`onPoison: "skip"`) permanently skipped healthy events when the config repo was still unseeded or the worker was still building.
> 
> **Delivery contract:** Adds **`StreamReceiverUnavailableError`** (name-matched across Workers RPC). Push receivers throw it to mean “I can’t accept any batch yet.” **`stream-subscribers`** routes that rejection through normal **backoff/park** even under skip mode—no bisect, no poison confirmation, full batch redelivery when the receiver recovers.
> 
> **Repo layer:** **`RepoNotSeededError`** plus **`classifyRepoAccessError`** wrap empty/missing Artifacts remotes and clone failures; the repo DO uses them on clone and artifact token minting. **`ProjectRpcTarget.processEventBatch`** maps **`RepoNotSeededError`** and **`WorkerBuildInProgressError`** into **`StreamReceiverUnavailableError`**.
> 
> Tests cover unavailable-receiver behavior under skip mode and repo error classification. The reactivity spec now asserts **`reactivity-state-push-count`** instead of the removed processor-offset metric.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd59374d9175e5a3b778c53399cb50f8c05c0e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +132 -15 | +76 -15 🟩🟩🟩🟥⬜ |
| Tests | +141 -7 | +102 -4 🟩🟩🟩🟩🟩 |
| **Total** | **+273 -22** | **+178 -19** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 219f001 and 3bd5937, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-09T22:52:09.218Z",
      "headSha": "3bd59374d9175e5a3b778c53399cb50f8c05c0e2",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/193836304863811",
      "shortSha": "3bd5937",
      "cleanupDurationMs": 9320,
      "deployDurationMs": 61845,
      "testDurationMs": 411153,
      "testRetries": "5 retried: agent runs an itx script that appends a proof event, then replies (vitest x1) · agent answers after llm model is selected (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · inbound Slack webhook routes to a slack agent that attempts a Web API reply (vitest x1, still failed) · onboarding agent replies to a chat message in the feed (specs x1, still failed)",
      "workerSizeKib": 15692.48,
      "workerGzipKib": 4241.71,
      "mainWorkerGzipKib": 4240.75
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-09T22:52:02.136Z",
      "headSha": "3bd59374d9175e5a3b778c53399cb50f8c05c0e2",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/193836304863811",
      "shortSha": "3bd5937",
      "cleanupDurationMs": 2236,
      "deployDurationMs": 16959,
      "testDurationMs": 499,
      "testRetries": null,
      "workerSizeKib": 4031.55,
      "workerGzipKib": 819.3,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-09T22:52:00.621Z",
      "headSha": "df3a2618f58e319a6576377d8bfac51e4e5da41d",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/40765935424079",
      "shortSha": "df3a261",
      "cleanupDurationMs": 720,
      "deployDurationMs": 14656,
      "testDurationMs": 19982,
      "testRetries": null,
      "workerSizeKib": 4693.94,
      "workerGzipKib": 1349.82,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `3bd5937` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 819.3 KiB | 17.0s | 499ms |  | 2.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/193836304863811) | 2026-07-09T22:52:02.136Z | Preview app released. |
| OS | released | `3bd5937` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.14 MiB (+1.0 KiB vs main) | 61.8s | 411.2s | 5 retried: agent runs an itx script that appends a proof event, then replies (vitest x1) · agent answers after llm model is selected (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · inbound Slack webhook routes to a slack agent that attempts a Web API reply (vitest x1, still failed) · onboarding agent replies to a chat message in the feed (specs x1, still failed) | 9.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/193836304863811) | 2026-07-09T22:52:09.218Z | Preview app released. |
| Streams Example App | released | `df3a261` | [https://streams.iterate-preview-3.com](https://streams.iterate-preview-3.com) | 1.32 MiB | 14.7s | 20.0s |  | 720ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/40765935424079) | 2026-07-09T22:52:00.621Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->