### PR TITLE
Time-ago labels never say a past event is in the future

### DIFF
--- a/apps/os/src/components/repo-ide/commit-history-panel.tsx
+++ b/apps/os/src/components/repo-ide/commit-history-panel.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
 import type { RepoCommitFileChange } from "~/domains/repos/types.ts";
-import { formatRelativeTime } from "~/lib/format-relative-time.ts";
+import { formatTimeAgo } from "~/lib/format-relative-time.ts";
 import { useItxQuery } from "~/itx/itx-react.tsx";
 
 /**
@@ -64,7 +64,7 @@ export function CommitHistoryPanel({
                   <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
                     <span className="min-w-0 truncate">{commit.author.name}</span>
                     <span className="shrink-0">
-                      {formatRelativeTime(new Date(commit.timestamp).toISOString())}
+                      {formatTimeAgo(new Date(commit.timestamp).toISOString())}
                     </span>
                     <span className="ml-auto shrink-0 font-mono">{commit.oid.slice(0, 7)}</span>
                   </span>

--- a/apps/os/src/components/stream-switcher-dialog.tsx
+++ b/apps/os/src/components/stream-switcher-dialog.tsx
@@ -13,7 +13,7 @@ import { normalizePath } from "~/domains/durable-object-names.ts";
 import { StreamTree } from "~/components/stream-tree.tsx";
 import type { StreamNavigator } from "~/lib/stream-navigation.ts";
 import { streamPathParent } from "~/lib/stream-links.ts";
-import { formatRelativeTime } from "~/lib/format-relative-time.ts";
+import { formatTimeAgo } from "~/lib/format-relative-time.ts";
 import { useLiveState } from "~/itx/itx-react.tsx";
 
 // A full canonical StreamPath of at least one segment: leading slash, lowercase
@@ -276,7 +276,7 @@ export function StreamSwitcherDialog({
                       className="ml-auto shrink-0 text-[11px] tabular-nums text-muted-foreground"
                       data-testid="stream-switcher-last-active"
                     >
-                      {formatRelativeTime(row.lastActivityAt, now)}
+                      {formatTimeAgo(row.lastActivityAt, now)}
                     </span>
                     <span className="w-10 shrink-0 text-right font-mono text-[10px] tabular-nums text-muted-foreground/60">
                       {row.eventCount}

--- a/apps/os/src/lib/format-relative-time.test.ts
+++ b/apps/os/src/lib/format-relative-time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatRelativeTime } from "./format-relative-time.ts";
+import { formatRelativeTime, formatTimeAgo } from "./format-relative-time.ts";
 
 describe("formatRelativeTime", () => {
   const now = Date.parse("2026-07-09T12:00:00Z");
@@ -16,5 +16,22 @@ describe("formatRelativeTime", () => {
 
   it("defaults nowMs to the clock for existing call sites", () => {
     expect(formatRelativeTime(new Date().toISOString())).toBe("just now");
+  });
+});
+
+describe("formatTimeAgo", () => {
+  const now = Date.parse("2026-07-09T12:00:00Z");
+
+  it("never says a past event is in the future — skewed-fresh clamps to 'just now'", () => {
+    // Server↔browser clock skew (or a caller's coarse clock tick) can stamp
+    // an event a few seconds "ahead" of the reader's clock.
+    expect(formatTimeAgo("2026-07-09T12:00:04Z", now)).toBe("just now");
+    expect(formatTimeAgo("2026-07-09T12:03:00Z", now)).toBe("just now"); // even wild skew
+    expect(formatRelativeTime("2026-07-09T12:03:00Z", now)).toBe("in 3 minutes"); // the two-sided form, for contrast
+  });
+
+  it("formats genuinely past events like formatRelativeTime", () => {
+    expect(formatTimeAgo("2026-07-09T11:57:00Z", now)).toBe("3 minutes ago");
+    expect(formatTimeAgo("2026-07-06T12:00:00Z", now)).toBe("3 days ago");
   });
 });

--- a/apps/os/src/lib/format-relative-time.ts
+++ b/apps/os/src/lib/format-relative-time.ts
@@ -1,5 +1,19 @@
 /**
+ * Relative time for a timestamp that records something that HAPPENED — clock
+ * skew between the server that stamped it and the browser (plus a caller's
+ * coarse clock tick) can put it a few seconds "in the future", and a past
+ * event must never read "in a few seconds". The delta is clamped at zero:
+ * skewed-fresh is "just now".
+ */
+export function formatTimeAgo(value: string, nowMs: number = Date.now()) {
+  return formatRelativeTime(value, Math.max(nowMs, new Date(value).getTime()));
+}
+
+/**
  * Coarse "3 days ago" / "in 2 hours" relative time, shared by list views.
+ * For timestamps of PAST events use {@link formatTimeAgo} instead — it clamps
+ * server↔browser clock skew; this two-sided form is for values that are
+ * legitimately in the future (the scheduler's next trigger).
  * Pass `nowMs` when the caller re-renders on its own clock tick (a live list),
  * so the label is a pure function of its inputs instead of reading the clock
  * mid-render.

--- a/apps/os/src/routes/_app/projects/$projectSlug/repos/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/repos/index.tsx
@@ -27,7 +27,7 @@ import { ItxBoundary } from "~/components/itx-boundary.tsx";
 import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import { RepoArtifactNameCodec } from "~/domains/repos/utils.ts";
 import { buildCloudflareArtifactDashboardUrl } from "~/lib/artifact-viewer-url.ts";
-import { formatRelativeTime } from "~/lib/format-relative-time.ts";
+import { formatTimeAgo } from "~/lib/format-relative-time.ts";
 import { getPublicRouteConfig } from "~/lib/public-route-config.ts";
 import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
 import { StreamViewSearch } from "~/lib/stream-view-search.ts";
@@ -271,7 +271,7 @@ function ProjectReposIndexContent() {
                           </Link>
                         </TableCell>
                         <TableCell className="w-40 text-muted-foreground">
-                          {formatRelativeTime(repo.createdAt)}
+                          {formatTimeAgo(repo.createdAt)}
                         </TableCell>
                         <TableCell className="w-32">
                           {artifactDashboardUrl ? (

--- a/apps/os/src/routes/_app/projects/$projectSlug/scheduler.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/scheduler.tsx
@@ -15,7 +15,7 @@ import type { ScheduleView, SchedulerRecurrence } from "../../../../domains/sche
 import { ItxBoundary } from "~/components/itx-boundary.tsx";
 import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import { SCHEDULER_PRIMARY_PATH } from "~/domains/scheduler/utils.ts";
-import { formatRelativeTime } from "~/lib/format-relative-time.ts";
+import { formatRelativeTime, formatTimeAgo } from "~/lib/format-relative-time.ts";
 import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
 import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 import { useItx, useItxQuery } from "~/itx/itx-react.tsx";
@@ -120,7 +120,7 @@ function ProjectSchedulerContent() {
                   </TableCell>
                   <TableCell className="text-muted-foreground">{schedule.runCount}</TableCell>
                   <TableCell className="whitespace-nowrap text-muted-foreground">
-                    {formatRelativeTime(schedule.setAt)}
+                    {formatTimeAgo(schedule.setAt)}
                   </TableCell>
                   <TableCell className="w-0">
                     <div className="flex justify-end gap-2">

--- a/apps/os/src/routes/_app/projects/$projectSlug/secrets/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/secrets/index.tsx
@@ -27,7 +27,7 @@ import { toast } from "@iterate-com/ui/components/sonner";
 import { Textarea } from "@iterate-com/ui/components/textarea";
 import { ItxBoundary } from "~/components/itx-boundary.tsx";
 import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
-import { formatRelativeTime } from "~/lib/format-relative-time.ts";
+import { formatTimeAgo } from "~/lib/format-relative-time.ts";
 import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
 import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 import { useItx, useLiveState } from "~/itx/itx-react.tsx";
@@ -332,7 +332,7 @@ function ProjectSecretsIndexContent() {
                     <span className="truncate">{secretNameFromPath(secret.path)}</span>
                   </Link>
                   <div className="truncate text-xs text-muted-foreground">
-                    {secret.path} · Created {formatRelativeTime(secret.createdAt)}
+                    {secret.path} · Created {formatTimeAgo(secret.createdAt)}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
⌘K rows sometimes read **"in a few seconds"** — server↔browser clock skew (plus the dialog's coarse 5s clock tick) can put `lastActivityAt` slightly ahead of the reader's clock, and `formatRelativeTime` renders negative deltas as future time.

New `formatTimeAgo` clamps the delta at zero (skewed-fresh is **"just now"**), and every past-event call site now uses it: ⌘K rows, commit history, repo/secret `createdAt`, the scheduler's `setAt`. The two-sided `formatRelativeTime` remains for values that are legitimately in the future (the scheduler's `nextTriggerAt`). Unit tests cover the skew clamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small display-helper change and import swaps in list UI; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes **"in a few seconds"** on past timestamps when server↔browser clock skew (or a coarse UI clock tick) puts the stamp slightly ahead of the reader's clock.
> 
> Adds **`formatTimeAgo`**, which clamps the effective `now` to at least the event time so skewed-fresh reads **"just now"** instead of future tense. Past-event UI now uses it: ⌘K **last active**, commit history, repo/secret **createdAt**, and scheduler **setAt**. **`formatRelativeTime`** stays for legitimately future values (scheduler **nextTriggerAt**), with docs calling out when to use each. Tests cover the skew clamp vs the two-sided helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16c8f4ab0f0729f63e291869d275cc09c68229f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +20 -6 | +9 -6 🟩🟩🟩🟥🟥 |
| UI components | +4 -4 | +4 -4 🟩🟩🟥⬜⬜ |
| Tests | +18 -1 | +13 -1 🟩🟩🟩🟩🟩 |
| **Total** | **+42 -11** | **+26 -11** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between aaf3664 and 16c8f4a, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> Preview e2e skipped for head 16c8f4a: nothing app-affecting changed since the last fully tested deploy, so the recorded results below still stand.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-09T23:08:11.800Z",
      "headSha": "af4cb8337179ae34d5b32a7a8f0060275ce60079",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/537085330541257",
      "shortSha": "af4cb83",
      "cleanupDurationMs": 9100,
      "deployDurationMs": 64480,
      "workerSizeKib": 15696.31,
      "workerGzipKib": 4243.1,
      "mainWorkerGzipKib": 4242.97
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-09T23:08:05.634Z",
      "headSha": "af4cb8337179ae34d5b32a7a8f0060275ce60079",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/537085330541257",
      "shortSha": "af4cb83",
      "cleanupDurationMs": 2931,
      "deployDurationMs": 20609,
      "workerSizeKib": 4031.55,
      "workerGzipKib": 819.47,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": "Preview e2e skipped for head 16c8f4a: nothing app-affecting changed since the last fully tested deploy, so the recorded results below still stand."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `af4cb83` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 819.5 KiB | 20.6s |  |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/537085330541257) | 2026-07-09T23:08:05.634Z | Preview app released. |
| OS | released | `af4cb83` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.14 MiB (+0.1 KiB vs main) | 64.5s |  |  | 9.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/537085330541257) | 2026-07-09T23:08:11.800Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->