### PR TITLE
dummy-petshop: webhook-delivery flake armor

### DIFF
--- a/apps/dummy-petshop/src/github-app.test.ts
+++ b/apps/dummy-petshop/src/github-app.test.ts
@@ -305,15 +305,26 @@ describe("GitHub App installation webhooks", () => {
     await shop("/__backdoor/apps", postJson({ publicKeyPem, webhookSecret: "wh-secret-123" }));
     const receiver = await startReceiver();
     try {
-      const fired = await (
-        await shop(
-          "/__backdoor/apps/fire-webhook",
-          postJson({ url: receiver.url, event: { event: "ping" } }),
-        )
-      ).json<{ status: number; signature: string }>();
+      // This test is about the SIGNATURE SHAPE, not TCP reliability: a
+      // loopback fetch can transiently fail in the CI sandbox (status 0), so
+      // status 0 gets a couple of retries — a genuinely broken delivery still
+      // fails, now with the carried error instead of a bare 0.
+      let fired: { status: number; signature: string; error?: string };
+      for (let attempt = 1; ; attempt += 1) {
+        fired = await (
+          await shop(
+            "/__backdoor/apps/fire-webhook",
+            postJson({ url: receiver.url, event: { event: "ping" } }),
+          )
+        ).json<{ status: number; signature: string; error?: string }>();
+        if (fired.status !== 0 || attempt >= 3) break;
+        console.warn(`webhook delivery attempt ${attempt} failed: ${fired.error}`);
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+      expect(fired.error).toBeUndefined();
       expect(fired.status).toBe(200);
 
-      const delivery = receiver.received[0];
+      const delivery = receiver.received.at(-1)!;
       expect(delivery.signature).toBe(hexHmac("wh-secret-123", delivery.body));
       expect(delivery.signature).toBe(fired.signature);
     } finally {

--- a/apps/dummy-petshop/src/worker.ts
+++ b/apps/dummy-petshop/src/worker.ts
@@ -529,17 +529,29 @@ async function deliverWebhook(input: {
   secret: string;
   payload: unknown;
   signatureHeader?: string;
-}): Promise<{ url: string; status: number; signature: string; payload: string }> {
+}): Promise<{ url: string; status: number; signature: string; payload: string; error?: string }> {
   const body = JSON.stringify(input.payload);
   const signature = `sha256=${await hmacSha256Hex(input.secret, body)}`;
   const signatureHeader = input.signatureHeader ?? "x-petshop-signature-256";
+  let error: string | undefined;
   const response = await fetch(input.url, {
     method: "POST",
     headers: { "content-type": "application/json", [signatureHeader]: signature },
     body,
     signal: AbortSignal.timeout(10_000),
-  }).catch(() => null);
-  return { url: input.url, status: response?.status ?? 0, signature, payload: body };
+  }).catch((cause: unknown) => {
+    // status 0 = the fetch itself failed; carry WHY (a bare 0 made transient
+    // CI loopback failures undiagnosable).
+    error = cause instanceof Error ? (cause.cause ?? cause).toString() : String(cause);
+    return null;
+  });
+  return {
+    url: input.url,
+    status: response?.status ?? 0,
+    signature,
+    payload: body,
+    ...(error === undefined ? {} : { error }),
+  };
 }
 
 async function backdoor(key: string, request: Request, deps: PetshopDeps): Promise<Response> {


### PR DESCRIPTION
The `deliver mode POSTs the x-hub-signature-256 header` test flaked on #1829 (`expected +0 to be 200`, passed on rerun, main green): `deliverWebhook` swallows any fetch rejection into a bare `status: 0`, and the loopback fetch to the test's ephemeral receiver can transiently fail in the CI sandbox — with zero diagnostics.

- `deliverWebhook` now carries **why** (an `error` field) when the fetch itself fails.
- The test retries `status 0` twice with a short pause — it asserts the signature shape, not TCP reliability. A genuinely broken delivery still fails, now with the carried error in the assertion output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the dummy-petshop test harness and webhook helper; no production auth or data paths.
> 
> **Overview**
> Addresses flaky CI on the GitHub App **deliver mode** webhook test where loopback `fetch` could fail with **`status: 0`** and no explanation.
> 
> **`deliverWebhook`** now includes an optional **`error`** string when the outbound POST fails (instead of only returning `status: 0`). Backdoor fire-webhook responses inherit that field automatically.
> 
> The signature-shape test **retries up to three times** on `status: 0` with a short delay, asserts **`error` is absent** on success, and reads the **last** captured delivery from the test receiver (so retries do not pick the wrong request).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4601d69001289d3a47759e2b00151b2be3ecd972. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +15 -3 | +13 -3 🟩🟩🟩🟥⬜ |
| Tests | +18 -7 | +14 -7 🟩🟩🟩🟥🟥 |
| **Total** | **+33 -10** | **+27 -10** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 8393475 and 4601d69, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->