### PR TITLE
syncFromGithub: never delete the Artifacts repo (fixes destroyed-repo data loss)

### DIFF
--- a/apps/os/src/components/add-repo-from-github.tsx
+++ b/apps/os/src/components/add-repo-from-github.tsx
@@ -220,10 +220,15 @@ function AddRepoFromGithubWizard({
           `${input.path} already exists. To back an existing repo with GitHub, use the GitHub panel on that repo's page.`,
         );
       }
+      // Claim the path for this wizard instance BEFORE the create round-trip:
+      // the live repo list records the path the moment the repo's stream is
+      // born (its first append), seconds before create() resolves — without
+      // the exemption already in place, the taken-path gate red-flags the very
+      // repo this mutation is creating while it is still being seeded.
+      setCreatedHere((previous) => new Set(previous).add(input.path));
       // create is "create if it does not exist yet", so a retry after a
       // mid-flow failure is safe and finishes the job.
       await itx.repos.create({ path: input.path });
-      setCreatedHere((previous) => new Set(previous).add(input.path));
       const repo = itx.repos.get(input.path);
       const link = await repo.linkGithub({
         connection,

--- a/apps/os/src/domains/repos/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/repo-durable-object.ts
@@ -749,10 +749,10 @@ export class RepoDurableObject extends DurableObject<Env> {
     // destroyed state the old delete+import lane could leave behind): the
     // transfer force-pushes the whole adopted history, so a brand-new empty
     // artifact is a fine starting point. A recreated artifact invalidates any
-    // token minted against its predecessor — drop the cache so the transfer
-    // re-mints.
-    await this.getOrCreateArtifact(this.artifactName());
-    this.#artifactTokenPromise = undefined;
+    // token minted against its predecessor — drop the cache (only then; the
+    // usual already-exists case keeps the one-token-per-isolate economy).
+    const artifact = await this.getOrCreateArtifact(this.artifactName());
+    if (artifact.created) this.#artifactTokenPromise = undefined;
     await this.#transferGithubHistoryInProcess({ branch, depth: input.depth, link, token });
 
     // The adopted head is recorded for read-your-write, then the head cache
@@ -1000,17 +1000,19 @@ export class RepoDurableObject extends DurableObject<Env> {
     };
   }
 
-  private async getOrCreateArtifact(name: string) {
+  private async getOrCreateArtifact(name: string): Promise<{ created: boolean }> {
     try {
-      return await this.requireArtifacts().create(name, {
+      await this.requireArtifacts().create(name, {
         setDefaultBranch: REPO_DEFAULT_BRANCH,
       });
+      return { created: true };
     } catch (error) {
       // Only the race we mean to tolerate. The old blind catch masked real
       // failures (an INTERNAL_ERROR here fell through to get(), which then
       // reported a misleading NOT_FOUND).
       if ((error as { code?: string }).code !== "ALREADY_EXISTS") throw error;
-      return await this.requireArtifacts().get(name);
+      await this.requireArtifacts().get(name);
+      return { created: false };
     }
   }
 

--- a/apps/os/src/domains/repos/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/repo-durable-object.ts
@@ -691,12 +691,11 @@ export class RepoDurableObject extends DurableObject<Env> {
    * store, unreferenced). The adopted head is live for worker builds the
    * moment this returns — same read-your-write boundary as commitFiles.
    *
-   * PUBLIC repositories transfer server-side (Artifacts imports straight
-   * from GitHub — any history size). PRIVATE repositories transfer in-process
-   * (the import service supports public sources only), where big histories
-   * need `depth`. `depth` prunes the adopted history to the newest N commits
-   * either way — GitHub retains the full history, so nothing is lost and a
-   * later deeper sync can widen the window.
+   * The history transfers in-process (checkout-free clone from GitHub +
+   * force-push to the Artifacts remote), so big histories need `depth` —
+   * which prunes the adopted history to the newest N commits. GitHub retains
+   * the full history, so nothing is lost and a later deeper sync can widen
+   * the window.
    */
   syncFromGithub(input: { depth?: number; force?: boolean } = {}): Promise<GithubSyncResult> {
     return this.#serializeWrite(() => this.#syncFromGithub(input));
@@ -734,55 +733,27 @@ export class RepoDurableObject extends DurableObject<Env> {
       }
     }
 
-    // Two transfer lanes, picked by source visibility (probed BEFORE anything
-    // destructive happens):
+    // ONE transfer lane: clone GitHub in this isolate and force-push to the
+    // Artifacts remote. Deliberately NOT the server-side Artifacts import —
+    // import cannot overwrite an existing name, and the delete-then-reimport
+    // dance it forces is unsafe: `artifacts.delete()` is acknowledged first
+    // and applied asynchronously, so re-importing under the same name races
+    // the queued delete (observed live 2026-07-10: the import won the
+    // ALREADY_EXISTS retry loop, then the late delete destroyed the freshly
+    // imported repo, leaving no git data at all). The cost is memory: every
+    // object inflates in this isolate, so big histories need `depth` (this
+    // monorepo: a 21MB pack inflates to ~290MB, past the 128MB limit); GitHub
+    // keeps the full history, so a later deeper sync can widen the window.
     //
-    // - PUBLIC source: server-side Artifacts import (delete + import under the
-    //   same name — the remote URL is name-derived, so nothing else moves). No
-    //   repo bytes enter this isolate, so arbitrarily large histories sync.
-    //   The service supports public HTTPS remotes only (proven live: private
-    //   URLs answer REMOTE_AUTH_REQUIRED "Only public repositories" even with
-    //   embedded credentials).
-    // - PRIVATE source: in-DO git transfer (checkout-free clone + push). Every
-    //   object inflates in memory here, so big private histories need `depth`
-    //   (this monorepo: a 21MB pack inflates to ~290MB, past the 128MB limit);
-    //   small ones sync whole.
-    if (await githubRepoIsPublic(link)) {
-      // Reads hitting the brief delete->import window fail like any mid-force
-      // clone would and succeed on retry. Deleting the repo revokes its
-      // tokens, including this isolate's cached one — drop it so gitAccess
-      // re-mints against the imported repo.
-      const artifacts = this.requireArtifacts();
-      const artifactName = this.artifactName();
-      await artifacts.delete(artifactName);
-      this.#artifactTokenPromise = undefined;
-      // The delete is eventually consistent: an immediate import can still see
-      // the old name (observed live as ALREADY_EXISTS) — retry with backoff.
-      for (let attempt = 1; ; attempt++) {
-        try {
-          await artifacts.import({
-            source: {
-              url: `https://github.com/${link.owner}/${link.repo}.git`,
-              branch,
-              ...(input.depth === undefined ? {} : { depth: input.depth }),
-            },
-            target: { name: artifactName },
-          });
-          break;
-        } catch (error) {
-          const code = (error as { code?: string }).code;
-          if (code === "ALREADY_EXISTS" && attempt <= 5) {
-            await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
-            continue;
-          }
-          throw new Error(
-            `Artifacts import of ${link.owner}/${link.repo}#${branch} failed (the repo is deleted until a retried sync succeeds): ${redactGitCredentials(String(error))}`,
-          );
-        }
-      }
-    } else {
-      await this.#transferGithubHistoryInProcess({ branch, depth: input.depth, link, token });
-    }
+    // The get-or-create heals a repo whose Artifacts repo is missing (the
+    // destroyed state the old delete+import lane could leave behind): the
+    // transfer force-pushes the whole adopted history, so a brand-new empty
+    // artifact is a fine starting point. A recreated artifact invalidates any
+    // token minted against its predecessor — drop the cache so the transfer
+    // re-mints.
+    await this.getOrCreateArtifact(this.artifactName());
+    this.#artifactTokenPromise = undefined;
+    await this.#transferGithubHistoryInProcess({ branch, depth: input.depth, link, token });
 
     // The adopted head is recorded for read-your-write, then the head cache
     // is invalidated and rebuilt through getHead's own cold-miss path (a
@@ -1287,21 +1258,6 @@ function repoHeadStorageKey(branch: string) {
 /** The git-over-HTTPS remote of a linked GitHub repository. */
 function githubRemoteUrl(link: { owner: string; repo: string }): string {
   return `https://github.com/${link.owner}/${link.repo}.git`;
-}
-
-/**
- * Whether a GitHub repository is publicly clonable, probed with an
- * UNAUTHENTICATED smart-HTTP ref advertisement: 200 = public, 401/404 =
- * private (GitHub answers 404 for hidden private repos). Decides the sync
- * transfer lane BEFORE anything destructive happens — the Artifacts import
- * service supports public sources only.
- */
-async function githubRepoIsPublic(link: { owner: string; repo: string }): Promise<boolean> {
-  const response = await fetch(`${githubRemoteUrl(link)}/info/refs?service=git-upload-pack`, {
-    headers: { "user-agent": "iterate-os" },
-  });
-  await response.body?.cancel();
-  return response.ok;
 }
 
 /**

--- a/apps/os/src/itx-api.generated.ts
+++ b/apps/os/src/itx-api.generated.ts
@@ -847,9 +847,8 @@ export interface Repo {
    * unless `force: true` discards them. The synced head is immediately live
    * for worker builds.
    *
-   * Public repositories transfer server-side (any history size); private
-   * ones transfer in-process, where big histories need `depth`. `depth`
-   * prunes to the newest N commits — GitHub retains the full history, and a
+   * The history transfers in-process, so big histories need `depth` — it
+   * prunes to the newest N commits. GitHub retains the full history, and a
    * later deeper sync can always widen the window.
    */
   syncFromGithub(input: { depth?: number; force?: boolean }): Promise<GithubSyncResult>;

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -955,9 +955,8 @@ class RepoRpcTarget extends IterateRpcTarget<"Repo"> {
    * unless `force: true` discards them. The synced head is immediately live
    * for worker builds.
    *
-   * Public repositories transfer server-side (any history size); private
-   * ones transfer in-process, where big histories need `depth`. `depth`
-   * prunes to the newest N commits — GitHub retains the full history, and a
+   * The history transfers in-process, so big histories need `depth` — it
+   * prunes to the newest N commits. GitHub retains the full history, and a
    * later deeper sync can always widen the window.
    */
   syncFromGithub(input: { depth?: number; force?: boolean } = {}): Promise<GithubSyncResult> {

--- a/apps/os/src/types-source.generated.ts
+++ b/apps/os/src/types-source.generated.ts
@@ -852,9 +852,8 @@ export interface Repo {
    * unless \`force: true\` discards them. The synced head is immediately live
    * for worker builds.
    *
-   * Public repositories transfer server-side (any history size); private
-   * ones transfer in-process, where big histories need \`depth\`. \`depth\`
-   * prunes to the newest N commits — GitHub retains the full history, and a
+   * The history transfers in-process, so big histories need \`depth\` — it
+   * prunes to the newest N commits. GitHub retains the full history, and a
    * later deeper sync can always widen the window.
    */
   syncFromGithub(input: { depth?: number; force?: boolean }): Promise<GithubSyncResult>;

--- a/packages/iterate/src/itx-api.generated.ts
+++ b/packages/iterate/src/itx-api.generated.ts
@@ -847,9 +847,8 @@ export interface Repo {
    * unless `force: true` discards them. The synced head is immediately live
    * for worker builds.
    *
-   * Public repositories transfer server-side (any history size); private
-   * ones transfer in-process, where big histories need `depth`. `depth`
-   * prunes to the newest N commits — GitHub retains the full history, and a
+   * The history transfers in-process, so big histories need `depth` — it
+   * prunes to the newest N commits. GitHub retains the full history, and a
    * later deeper sync can always widen the window.
    */
   syncFromGithub(input: { depth?: number; force?: boolean }): Promise<GithubSyncResult>;


### PR DESCRIPTION
## What broke

Adding `iterate/captun` (a **public** repo) through the repos-page "Add from GitHub" wizard on prd:

1. The wizard showed a red "`/repos/captun` already exists" error during its own add.
2. The submit button flickered between states.
3. The user landed on `/projects/iterate/repos/captun` showing `Repo has no commits yet (unseeded or still seeding): Repository not found` — the repo's git data was **gone**.

## Root cause (symptom 3, the data loss)

`syncFromGithub`'s public-source lane did `artifacts.delete(name)` then `artifacts.import({target: {name}})`. But `artifacts.delete()` is acknowledged-then-applied-**async**. The import retried through `ALREADY_EXISTS` until the delete propagated, the import then succeeded — and the **queued delete landed afterwards, destroying the freshly imported repo**. The `/repos/captun` stream shows the exact sequence: `cf.artifacts.repo.created` at 05:22:24.390 → `cf.artifacts.repo.deleted` at 05:22:24.587, and no `github-synced` ever. Delete-then-recreate-same-name is fundamentally unsafe on this API (import cannot overwrite).

**Fix:** one non-destructive transfer lane for public and private sources alike — checkout-free clone from GitHub, force-push to the existing Artifacts remote (the lane private repos always used). A get-or-create before the transfer heals repos the old lane left destroyed. Big histories still need `depth` (in-isolate memory bound), same as private repos before; GitHub retains full history so a later deeper sync can widen the window.

## Root cause (symptoms 1–2, the false "already exists")

The project processor records a repo path into `state.repos` the moment the repo **stream** is born (first append of `create-requested`), but the wizard only added the path to its `createdHere` taken-path-gate exemption after `repos.create()` resolved — seconds later, post-seeding. In that window the live list update flipped `pathTaken` → red "already exists" `FieldError` + disabled-button flicker, on the wizard's own in-flight add. The exemption is now claimed before the create round-trip (safe: create is idempotent, and the exemption existing on a failed attempt is exactly the designed retry lane).

## Prd repair

`/repos/captun` was repaired live by re-running `syncFromGithub({force: true})` (the destroyed state let the old import lane succeed with no delete race): now serves captun's real `main` at `ddc905d`, 109 files, full history.

## Testing

- `pnpm typecheck && pnpm lint && pnpm format && pnpm test` all green (itx-api/types-source regenerated for the docstring change).
- The sync lanes have no CI coverage (real-GitHub half is prod-smoke-proven only) — the memory note from #1822 flagged the real-GitHub happy path as unproven, and this is exactly where it broke. After preview deploy I'll smoke the wizard end-to-end against a public repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core GitHub→Artifacts sync and artifact lifecycle on the repo Durable Object—the path that previously caused production data loss; public repos lose server-side import and are subject to isolate memory limits unless `depth` is used.
> 
> **Overview**
> **`syncFromGithub` no longer deletes and re-imports Artifacts repos for public GitHub sources.** That delete-then-import path could leave git data destroyed when an async delete landed after a successful import. Sync now always clones from GitHub in the Durable Object and force-pushes to the existing Artifacts remote (same lane private repos used). **`getOrCreateArtifact`** runs first and returns whether the artifact was newly created so a missing repo can be healed and cached tokens are cleared only when the artifact was recreated. **`githubRepoIsPublic`** and the server-side import/retry loop are removed; large histories still need **`depth`** because everything transfers in-isolate.
> 
> The **Add from GitHub** wizard now adds the path to **`createdHere` before `repos.create()`**, so the live project repo list does not treat the in-flight create as a collision and show a false “already exists” error.
> 
> Generated **`syncFromGithub`** docstrings are updated to describe in-process transfer only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee80363026a9ab36dee11d82ef7746678eca843d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +32 -75 | +8 -40 🟩🟥🟥🟥🟥 |
| UI components | +6 -1 | +1 -1 🟩⬜⬜⬜⬜ |
| Generated | +6 -9 | +2 -3 🟥⬜⬜⬜⬜ |
| **Total** | **+44 -85** | **+11 -44** 🟩🟥🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 092d9b9 and ee80363, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> Teardown skipped: Slot preview-4 no longer belongs to pr-1835: it is now leased by pr-1836 (https://github.com/iterate/iterate/pull/1836). Their deployment has replaced this PR's apps on preview_4.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-10T05:52:44.673Z",
      "headSha": "ee80363026a9ab36dee11d82ef7746678eca843d",
      "message": "Teardown skipped: Slot preview-4 no longer belongs to pr-1835: it is now leased by pr-1836 (https://github.com/iterate/iterate/pull/1836). Their deployment has replaced this PR's apps on preview_4.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/31188484858959",
      "shortSha": "ee80363",
      "deployDurationMs": 62294,
      "testDurationMs": 201469,
      "testRetries": null,
      "workerSizeKib": 15730.46,
      "workerGzipKib": 4252.59,
      "mainWorkerGzipKib": 4253.04
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-10T05:52:44.673Z",
      "headSha": "ee80363026a9ab36dee11d82ef7746678eca843d",
      "message": "Teardown skipped: Slot preview-4 no longer belongs to pr-1835: it is now leased by pr-1836 (https://github.com/iterate/iterate/pull/1836). Their deployment has replaced this PR's apps on preview_4.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/31188484858959",
      "shortSha": "ee80363",
      "deployDurationMs": 18769,
      "testDurationMs": 481,
      "testRetries": null,
      "workerSizeKib": 4031.55,
      "workerGzipKib": 819.39,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": "Teardown skipped: Slot preview-4 no longer belongs to pr-1835: it is now leased by pr-1836 (https://github.com/iterate/iterate/pull/1836). Their deployment has replaced this PR's apps on preview_4."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `ee80363` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 819.4 KiB | 18.8s | 481ms |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/31188484858959) | 2026-07-10T05:52:44.673Z | Teardown skipped: Slot preview-4 no longer belongs to pr-1835: it is now leased by pr-1836 (https://github.com/iterate/iterate/pull/1836). Their deployment has replaced this PR's ... |
| OS | released | `ee80363` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 4.15 MiB (-0.4 KiB vs main) | 62.3s | 201.5s |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/31188484858959) | 2026-07-10T05:52:44.673Z | Teardown skipped: Slot preview-4 no longer belongs to pr-1835: it is now leased by pr-1836 (https://github.com/iterate/iterate/pull/1836). Their deployment has replaced this PR's ... |

</details>
<!-- /CLOUDFLARE_PREVIEW -->