### PR TITLE
[codex] Move context meter into composer width

### DIFF
--- a/apps/os/src/components/agent-feed.tsx
+++ b/apps/os/src/components/agent-feed.tsx
@@ -287,7 +287,7 @@ export function AgentTokenUsageStrip({ tokenUsage }: { tokenUsage: AgentUiTokenU
   return (
     <div
       title={breakdown}
-      className="flex shrink-0 items-center justify-end gap-3 px-4 pb-1 font-mono text-[11px] text-muted-foreground"
+      className="flex shrink-0 items-center justify-end gap-3 font-mono text-[11px] text-muted-foreground"
     >
       <span className={contextPercent >= 80 ? "text-destructive" : undefined}>
         context {formatTokens(contextTokens)}/{formatTokens(last.maxContextTokens)} (

--- a/apps/os/src/components/agent-pill-composer.tsx
+++ b/apps/os/src/components/agent-pill-composer.tsx
@@ -95,7 +95,7 @@ export function AgentPillComposer({
   }
 
   return (
-    <div className="mx-auto w-full max-w-3xl">
+    <div className="w-full">
       {error == null ? null : (
         <p className="mb-2 ml-4 truncate font-mono text-xs text-destructive" role="alert">
           {error}

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -326,23 +326,25 @@ export function ProjectStreamView({
         ) : null}
       </div>
 
-      {caps.agentFeed && agentUiState?.tokenUsage != null ? (
-        <AgentTokenUsageStrip tokenUsage={agentUiState.tokenUsage} />
-      ) : null}
       <div className="shrink-0 px-4 pb-4 pt-2.5">
-        <StreamViewComposer
-          autoFocusMessage={autoFocusMessageComposer}
-          {...(defaultComposerMode == null
-            ? caps.agentFeed
-              ? { defaultMode: "message" as const }
-              : { defaultMode: "raw" as const }
-            : { defaultMode: defaultComposerMode })}
-          interrupt={interrupt}
-          {...(messageComposer == null ? {} : { messageComposer })}
-          onNudgeDeliveries={nudgeDeliveries}
-          presence={presence}
-          store={store}
-        />
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-1">
+          {caps.agentFeed && agentUiState?.tokenUsage != null ? (
+            <AgentTokenUsageStrip tokenUsage={agentUiState.tokenUsage} />
+          ) : null}
+          <StreamViewComposer
+            autoFocusMessage={autoFocusMessageComposer}
+            {...(defaultComposerMode == null
+              ? caps.agentFeed
+                ? { defaultMode: "message" as const }
+                : { defaultMode: "raw" as const }
+              : { defaultMode: defaultComposerMode })}
+            interrupt={interrupt}
+            {...(messageComposer == null ? {} : { messageComposer })}
+            onNudgeDeliveries={nudgeDeliveries}
+            presence={presence}
+            store={store}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed
- Moved the agent token/context usage strip into the same max-width footer container as the composer.
- Let the pill composer fill its parent container so the footer owns the shared width constraint.

## Why
The context indicator was aligned against the full feed width, which made it float far to the right of the composer.

## Validation
- pnpm --dir apps/os typecheck
- pnpm exec oxlint apps/os/src/components/agent-feed.tsx apps/os/src/components/agent-pill-composer.tsx apps/os/src/components/project-stream-view.tsx --threads 1 --deny-warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only CSS and component structure changes in the stream footer with no logic or data-path changes.
> 
> **Overview**
> The agent **token/context usage strip** now sits in the same `max-w-3xl` footer column as the stream composer, directly above it, instead of spanning the full feed width above the footer.
> 
> **`AgentPillComposer`** no longer applies its own `max-w-3xl` centering so the parent footer owns the shared width constraint. The strip drops extra horizontal/bottom padding so alignment comes from the footer wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 386b924313a4738cb39878291dfa4b15bdb0801c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +20 -18 | +20 -18 🟩🟩🟩🟥🟥 |
| **Total** | **+20 -18** | **+20 -18** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 8c62174 and 386b924, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-10T06:29:31.736Z",
      "headSha": "386b924313a4738cb39878291dfa4b15bdb0801c",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/340644081173900",
      "shortSha": "386b924",
      "cleanupDurationMs": 7974,
      "deployDurationMs": 96255,
      "workerSizeKib": 15736.76,
      "workerGzipKib": 4255.32,
      "mainWorkerGzipKib": 4255.34
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-10T06:29:26.328Z",
      "headSha": "386b924313a4738cb39878291dfa4b15bdb0801c",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/340644081173900",
      "shortSha": "386b924",
      "cleanupDurationMs": 2563,
      "deployDurationMs": 22393,
      "workerSizeKib": 4031.55,
      "workerGzipKib": 819.4,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `386b924` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 819.4 KiB | 22.4s |  |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/340644081173900) | 2026-07-10T06:29:26.328Z | Preview app released. |
| OS | released | `386b924` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 4.16 MiB (-0.0 KiB vs main) | 96.3s |  |  | 8.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/340644081173900) | 2026-07-10T06:29:31.736Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->