### PR TITLE
iterate CLI: `use-my-computer` — lend your Mac to a project's agents

### DIFF
--- a/packages/iterate/src/cli.ts
+++ b/packages/iterate/src/cli.ts
@@ -22,6 +22,7 @@ import type {
   Session,
   Stream,
 } from "./itx-api.generated.ts";
+import { shareMyComputer } from "./use-my-computer.ts";
 import {
   CONFIG_PATH,
   Config,
@@ -1032,6 +1033,74 @@ const launcherProcedures = {
         env.ITERATE_BEARER_TOKEN = token;
       }
       await runInheritedProcess({ ...command, env });
+    }),
+
+  useMyComputer: os
+    .input(
+      z.object({
+        project: z
+          .string()
+          .trim()
+          .min(1)
+          .optional()
+          .describe(
+            "OS project id (prj_…) or slug. Defaults to the active config's defaultProject.",
+          ),
+        name: z
+          .string()
+          .trim()
+          .regex(
+            /^[a-zA-Z][a-zA-Z0-9]*$/,
+            "Use a camelCase name: letters and digits, starting with a letter.",
+          )
+          .optional()
+          .describe(
+            "Name agents use to reach this computer (camelCase; the itx.<name> path). Prompted if omitted.",
+          ),
+      }),
+    )
+    .meta({
+      description:
+        "Share THIS computer with a project's agents as itx.myComputer (native dialogs, notifications, Swift). Runs until Ctrl-C.",
+    })
+    .handler(async ({ input }) => {
+      const resolved = resolveConfig(process.cwd(), { throw: true });
+
+      // Auth, exactly like `chat`: env secrets win (doppler/e2e), otherwise use
+      // the stored `iterate login` session, kicking off a browser login if none.
+      const envAuth = osAuthFromEnvironment();
+      let authHeaders: OsAuthHeaders | undefined;
+      if (!envAuth) {
+        try {
+          authHeaders = await getOsAuthHeaders(resolved.config, resolved.name);
+        } catch (error) {
+          if (!shouldAutoLoginForChat(error)) throw error;
+          console.error(
+            `No active session for ${resolved.config.osBaseUrl}. Starting browser login...`,
+          );
+          await loginToResolvedConfig(resolved);
+          authHeaders = await getOsAuthHeaders(resolved.config, resolved.name);
+        }
+      }
+      const auth = envAuth ?? osAuthFromHeaders(authHeaders!);
+
+      const projectId = await resolveChatProject({
+        auth,
+        baseUrl: resolved.config.osBaseUrl,
+        configName: resolved.name,
+        configPath: CONFIG_PATH,
+        configuredDefaultProject: resolved.config.defaultProject,
+        explicitProject: input.project,
+      });
+
+      // Prompts for a name, provides itx.<name>, then blocks until Ctrl-C.
+      await shareMyComputer({
+        auth: auth.credentials,
+        baseUrl: resolved.config.osBaseUrl,
+        projectId,
+        headers: headersRecord(auth.requestHeaders),
+        name: input.name,
+      });
     }),
 
   orgs: {

--- a/packages/iterate/src/use-my-computer.ts
+++ b/packages/iterate/src/use-my-computer.ts
@@ -1,0 +1,207 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// `iterate use-my-computer` — lend your laptop to a project's AI agents.
+//
+// The whole idea in three sentences:
+//   1. You open one WebSocket to your Iterate project and "provide" a capability
+//      called `myComputer` onto it.
+//   2. From then on, any agent in that project can call `itx.myComputer.ask(...)`,
+//      `itx.myComputer.notify(...)` or `itx.myComputer.runSwift(...)`.
+//   3. Because it's a *live* capability, the agent's call travels back down your
+//      WebSocket and the code runs right here — on your Mac, as you, with your
+//      screen, files and network. There is no server-side sandbox in between.
+//
+// That's the trick: `provideCapability({ type: "live", capability })` hands the
+// project a remote reference to a plain JavaScript object. Calls to it are RPCs
+// that come home to this process. Everything below is just (a) that object and
+// (b) keeping the socket alive so agents can reach it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { spawn } from "node:child_process";
+import { hostname } from "node:os";
+
+import * as prompts from "@clack/prompts";
+import type { RpcStub } from "capnweb";
+
+import { connectItx } from "../../../apps/os/src/itx-client.ts";
+import type { ItxAuthCredentials, Project } from "./itx-api.generated.ts";
+
+/**
+ * The object we lend to the project. Each method becomes callable by agents as
+ * `itx.myComputer.<method>(...)`. capnweb ships the *call* over this process's
+ * socket, so the body runs locally — native macOS dialogs and all.
+ */
+const myComputer = {
+  /** Pop a native dialog on screen and return which button the human clicked. */
+  async ask({ question, buttons = ["No", "Yes"] }: { question: string; buttons?: string[] }) {
+    // AppleScript's `display dialog` supports one to three buttons.
+    if (buttons.length < 1 || buttons.length > 3) {
+      throw new Error("ask() needs 1–3 buttons (AppleScript dialogs cap at three).");
+    }
+    const buttonList = buttons.map((b) => `"${escapeForAppleScript(b)}"`).join(", ");
+    const { stdout } = await osascript(
+      `display dialog "${escapeForAppleScript(question)}" ` +
+        `buttons {${buttonList}} default button "${escapeForAppleScript(buttons.at(-1)!)}" ` +
+        `with title "iterate · myComputer"`,
+    );
+    // osascript prints e.g. `button returned:Yes` — hand back just the choice.
+    return { answer: stdout.trim().replace(/^button returned:/, "") };
+  },
+
+  /** Show a desktop notification. */
+  async notify({ message, title = "iterate" }: { message: string; title?: string }) {
+    await osascript(
+      `display notification "${escapeForAppleScript(message)}" with title "${escapeForAppleScript(title)}"`,
+    );
+    return { ok: true as const };
+  },
+
+  /** Run arbitrary Swift and return its output — full power, when an agent needs it. */
+  async runSwift({ code }: { code: string }) {
+    // `swift -` reads a whole program from stdin and runs it.
+    return await run("swift", ["-"], code);
+  },
+};
+
+/** Prose + a type signature so agents (and `__describe()`) know how to call this. */
+const INSTRUCTIONS = `A real person's Mac, shared live from their terminal for as long as \`iterate use-my-computer\` runs.
+- ask({ question, buttons? }) pops a native dialog on their screen and returns { answer } — the button they clicked. Perfect for a quick human yes/no or choice.
+- notify({ message, title? }) shows a desktop notification.
+- runSwift({ code }) runs Swift on their Mac and returns { stdout, stderr, exitCode }. It has full access to their files, GUI and network, so ask before doing anything destructive.`;
+
+const TYPES = `{
+  ask(input: { question: string; buttons?: string[] }): Promise<{ answer: string }>;
+  notify(input: { message: string; title?: string }): Promise<{ ok: true }>;
+  runSwift(input: { code: string }): Promise<{ stdout: string; stderr: string; exitCode: number }>;
+}`;
+
+/**
+ * Ask what agents should call this computer, and mount the capability there —
+ * e.g. answering "jonasComputer" makes it `itx.jonasComputer`. We propose a
+ * camelCase name from the hostname; the human can accept it or type their own.
+ */
+async function askComputerName(): Promise<string> {
+  const proposed = proposeComputerName();
+  // Non-interactive (piped output, an agent): just take the proposal.
+  if (!process.stdin.isTTY) return proposed;
+
+  const answer = await prompts.text({
+    message: "What should agents call this computer? (camelCase — it becomes the itx.<name> path)",
+    placeholder: proposed,
+    defaultValue: proposed,
+    validate: (value) =>
+      /^[a-zA-Z][a-zA-Z0-9]*$/.test(value.trim())
+        ? undefined
+        : "Use a camelCase name: letters and digits, starting with a letter (e.g. jonasComputer).",
+  });
+  if (prompts.isCancel(answer)) {
+    prompts.cancel("Cancelled.");
+    process.exit(0);
+  }
+  return answer.trim();
+}
+
+/** "Jonas’s-MacBook-Pro.local" → "jonasComputer". A friendly default, always editable. */
+function proposeComputerName(): string {
+  const firstWord = hostname()
+    .replace(/\.local$/i, "")
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)[0];
+  const cleaned = firstWord?.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return cleaned ? `${cleaned}Computer` : "myComputer";
+}
+
+/**
+ * A line the human can paste to an agent so it knows this capability exists.
+ * `itx.<name>.__describe()` then teaches the agent exactly how to drive it.
+ */
+function agentPrompt(name: string): string {
+  const kind = /macbook/i.test(hostname())
+    ? "a MacBook"
+    : process.platform === "darwin"
+      ? "a Mac"
+      : "their computer";
+  const owner = /^(.+?)(computer|mac|laptop|machine)$/i.exec(name)?.[1];
+  const whose = owner ? `${owner[0].toUpperCase()}${owner.slice(1)}’s computer` : name;
+  return [
+    "📋 Paste this to an agent so it knows it can use your computer:",
+    "",
+    `   By the way, you can use \`itx.${name}\` to interact with ${whose} (${kind}).`,
+    `   Call \`itx.${name}.__describe()\` first to learn how it works — it can ask you`,
+    `   questions with native dialogs, send notifications, and run Swift.`,
+  ].join("\n");
+}
+
+/**
+ * Ask for a name, provide `itx.<name>`, and hold the line until Ctrl-C.
+ *
+ * A live mount only routes while its socket is warm, so we send a small
+ * heartbeat to keep it hot. Never returns; the caller runs it as the body of a
+ * long-lived command.
+ */
+export async function shareMyComputer(input: {
+  auth: ItxAuthCredentials;
+  baseUrl: string;
+  projectId: string;
+  headers?: Record<string, string>;
+  name?: string;
+  log?: (message: string) => void;
+}): Promise<never> {
+  const log = input.log ?? ((message: string) => console.error(message));
+  const name = input.name ?? (await askComputerName());
+
+  const itx = connectItx({
+    auth: input.auth,
+    baseUrl: input.baseUrl,
+    projectId: input.projectId,
+    headers: input.headers,
+  }) as RpcStub<Project>;
+
+  await itx.provideCapability({
+    type: "live",
+    path: [name],
+    capability: myComputer,
+    instructions: INSTRUCTIONS,
+    types: TYPES,
+  });
+  log(`✅ itx.${name} is live for project ${input.projectId}. Press Ctrl-C to stop sharing.\n`);
+  log(agentPrompt(name));
+
+  // A live mount only routes while its socket is warm, so ping now and then to
+  // keep it hot (ignoring transient errors), and hold open until Ctrl-C.
+  const heartbeat = () => itx.__describe().catch(() => {});
+  heartbeat();
+  setInterval(heartbeat, 5_000);
+  return new Promise<never>(() => {});
+}
+
+// ── tiny local helpers ───────────────────────────────────────────────────────
+
+/** Spawn a command, optionally feed it stdin, and collect its result. */
+function run(command: string, args: string[], stdin?: string) {
+  return new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve, reject) => {
+    const child = spawn(command, args);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("error", reject);
+    // A signal-killed child reports a null code; surface that as a failure, not 0.
+    child.on("close", (code) => resolve({ stdout, stderr, exitCode: code ?? 1 }));
+    if (stdin !== undefined) child.stdin.end(stdin);
+  });
+}
+
+/** Run an AppleScript snippet, throwing if osascript reports failure (e.g. the human cancels). */
+async function osascript(script: string) {
+  const result = await run("osascript", ["-e", script]);
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `osascript failed (exit ${result.exitCode}): ${result.stderr.trim() || "no output"}`,
+    );
+  }
+  return result;
+}
+
+/** Escape a string for embedding in an AppleScript double-quoted literal. */
+const escapeForAppleScript = (text: string) =>
+  text.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r/g, "\\r").replace(/\n/g, "\\n");


### PR DESCRIPTION
## What

Adds an **`iterate use-my-computer`** command that shares *this* computer with a project's AI agents by providing a live `itx.myComputer` capability over the CLI's OAuth session.

Once running, any agent in the project can call:

- **`ask({ question, buttons? })`** — pop a native macOS dialog, return the button the human clicked
- **`notify({ message, title? })`** — desktop notification
- **`runSwift({ code })`** — run Swift on the machine, return `{ stdout, stderr, exitCode }`

```bash
iterate login            # browser OAuth (one time)
iterate use-my-computer  # shares this Mac with your default project's agents
```

## How it works

`provideCapability({ type: "live", capability })` hands the project a remote reference to a plain JavaScript object. Because it's a **live** mount, an agent's call travels back down the provider's WebSocket and runs **locally** — on your Mac, as you, with your screen/files/network. There's no server-side sandbox in between. The capability self-describes via `__describe()`, so agents are told exactly how to call it.

## Files

- **`packages/iterate/src/use-my-computer.ts`** (new) — the whole thing, intentionally small and heavily commented as a "look how easy itx makes this" reference: the `myComputer` object + `shareMyComputer()` (connect → provide → heartbeat).
- **`packages/iterate/src/cli.ts`** — a thin `useMyComputer` procedure doing OAuth + project resolution (mirrors `chat`), registered as the `use-my-computer` command.

## Proof

Verified end-to-end against **production** (`os.iterate.com`): started the command, then invoked `itx.myComputer.notify(...)` and `itx.myComputer.ask(...)` from a separate itx client — the notification and native dialog appeared and the clicked button (`{ "answer": "Ridiculously easy" }`) round-tripped back.

## Notes

- A `type: "live"` mount only routes while its socket is warm — an idle edge stops routing within seconds — so `shareMyComputer` sends a 5s heartbeat. There's no reconnect logic in the script by design (kept minimal); a dropped connection means re-running the command. Making live mounts survive idle/reconnect transparently is a transport-layer concern worth a follow-up.
- macOS-only (uses `osascript` / `swift`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Agents in the project can trigger local macOS UI and arbitrary Swift with the user’s privileges; scope is limited to whoever runs the command and which project they share with, but misuse or prompt injection could drive destructive local actions.
> 
> **Overview**
> Adds **`iterate use-my-computer`**, a long-running CLI command that registers a **live** `itx.<name>` capability on a chosen OS project so agents can invoke methods on the user’s Mac while the process stays connected.
> 
> **`packages/iterate/src/use-my-computer.ts`** implements the shared object (`ask` via AppleScript dialogs, `notify`, `runSwift`), optional camelCase naming (CLI flag or prompt), `provideCapability({ type: "live", … })` with agent-facing instructions/types, a 5s `__describe` heartbeat to keep the mount routable, and blocks until Ctrl-C.
> 
> **`packages/iterate/src/cli.ts`** wires **`useMyComputer`** with the same config/OAuth/project resolution pattern as **`chat`** (env auth overrides, auto-login on missing session), then calls **`shareMyComputer`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77b319420a5eff5261271b5bca95bfc71d455075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +276 -0 | +195 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+276 -0** | **+195 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between d605564 and 77b3194, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->