### PR TITLE
[codex] Hide assistant MCP tool behind opt-in

### DIFF
--- a/apps/os/docs/debugging-deployed-os-workers.md
+++ b/apps/os/docs/debugging-deployed-os-workers.md
@@ -81,6 +81,14 @@ cd apps/os
 doppler run --config prd -- pnpm cli claude-mcp
 ```
 
+By default the MCP server exposes only `exec_js`. If you deliberately want the
+plain-language project-agent bridge too, opt in with the URL parameter via the
+CLI flag:
+
+```bash
+doppler run --config prd -- pnpm cli claude-mcp --with-agent
+```
+
 For previews, run under the preview Doppler config:
 
 ```bash

--- a/apps/os/e2e/vitest/mcp-oauth.e2e.test.ts
+++ b/apps/os/e2e/vitest/mcp-oauth.e2e.test.ts
@@ -242,8 +242,8 @@ test("project MCP OAuth opaque-token flow", async () => {
   expect(token.access_token.split(".").length, "token is opaque, not a JWT").toBe(1);
 
   // 8. Use the opaque token against the real OS MCP endpoint.
-  const mcp = async (body: unknown) => {
-    const res = await fetch(`${mcpOrigin}/`, {
+  const mcp = async (body: unknown, search = "") => {
+    const res = await fetch(`${mcpOrigin}/${search}`, {
       method: "POST",
       headers: {
         authorization: `Bearer ${token.access_token}`,
@@ -277,6 +277,13 @@ test("project MCP OAuth opaque-token flow", async () => {
   expect(tools.status, "MCP tools/list").toBe(200);
   const toolNames = tools.parsed.result?.tools?.map((tool) => tool.name) ?? [];
   expect(toolNames, "opaque token grants the project MCP tool surface").toContain("exec_js");
+  expect(toolNames, "assistant tool is hidden by default").not.toContain("ask_assistant");
+
+  const agentTools = await mcp({ jsonrpc: "2.0", id: 3, method: "tools/list" }, "?withAgent=true");
+  expect(agentTools.status, "MCP tools/list with agent opt-in").toBe(200);
+  const agentToolNames = agentTools.parsed.result?.tools?.map((tool) => tool.name) ?? [];
+  expect(agentToolNames, "agent opt-in keeps exec_js").toContain("exec_js");
+  expect(agentToolNames, "agent opt-in exposes assistant tool").toContain("ask_assistant");
 
   console.log(
     `MCP OAuth e2e passed for ${osBaseUrl.toString()} (opaque token → tools: ${toolNames.join(", ")})`,

--- a/apps/os/scripts/cli.test.ts
+++ b/apps/os/scripts/cli.test.ts
@@ -72,6 +72,32 @@ it("prefers the configured canonical MCP URL", async () => {
   void info;
 });
 
+it("can opt into the assistant MCP tool with a URL parameter", async () => {
+  using env = temporaryEnv({
+    APP_CONFIG_ADMIN_API_SECRET: "secret",
+    APP_CONFIG_MCP__BASE_URL: "https://mcp.iterate.com",
+  });
+  using fetch = temporaryGlobal(
+    "fetch",
+    vi.fn(async () => new Response("event: message\ndata: {}\n\n", { status: 200 })),
+  );
+  using info = temporaryConsoleInfo();
+
+  await claudeMcp({ withAgent: true });
+
+  expect(fetch.fn).toHaveBeenCalledWith(
+    "https://mcp.iterate.com/?withAgent=true",
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: "Bearer secret",
+      }),
+    }),
+  );
+  expect(info.lines.join("\n")).toContain('"url":"https://mcp.iterate.com/?withAgent=true"');
+
+  void env;
+});
+
 it("rejects 401 with an admin token hint", async () => {
   using env = temporaryEnv({
     APP_CONFIG_ADMIN_API_SECRET: "wrong",

--- a/apps/os/scripts/cli.ts
+++ b/apps/os/scripts/cli.ts
@@ -20,6 +20,8 @@ type ClaudeMcpOptions = {
   baseHost?: string;
   /** Initial prompt passed to Claude before entering interactive mode. */
   prompt?: string;
+  /** Include the ask_assistant tool in addition to exec_js. */
+  withAgent?: boolean;
 };
 
 /** Print the Claude Code command for the remote OS MCP server after an admin-token preflight. */
@@ -31,7 +33,10 @@ export async function claudeMcp(options: ClaudeMcpOptions = {}) {
   const baseHost = options.baseHost?.trim();
   const prompt = options.prompt?.trim() || DEFAULT_INITIAL_PROMPT;
   const adminToken = requireEnv("APP_CONFIG_ADMIN_API_SECRET");
-  const mcpUrl = baseHost ? normalizeBaseUrl(baseHost) : defaultMcpUrlFromEnv();
+  const mcpUrl = applyClaudeMcpToolOptions(
+    baseHost ? normalizeBaseUrl(baseHost) : defaultMcpUrlFromEnv(),
+    options,
+  );
   await assertMcpAdminBearerAccepted({ mcpUrl, token: adminToken });
   const command = [
     "claude",
@@ -152,6 +157,14 @@ function isLocalhostHostname(hostname: string) {
     hostname === "::1" ||
     hostname === "[::1]"
   );
+}
+
+function applyClaudeMcpToolOptions(baseUrl: string, options: Pick<ClaudeMcpOptions, "withAgent">) {
+  if (!options.withAgent) return baseUrl;
+
+  const parsed = new URL(baseUrl);
+  parsed.searchParams.set("withAgent", "true");
+  return parsed.toString();
 }
 
 async function assertMcpAdminBearerAccepted(input: { mcpUrl: string; token: string }) {

--- a/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-handler.ts
@@ -15,6 +15,7 @@ import { env } from "cloudflare:workers";
 import packageJson from "../../../package.json" with { type: "json" };
 import { ensureMcpSessionAgentReady } from "./mcp-session-agent-ready.ts";
 import { resolveMcpSessionAgentPath } from "./mcp-session-agent-path.ts";
+import { readInboundMcpToolOptions, type InboundMcpToolOptions } from "./mcp-tool-options.ts";
 import { trustedInternalAuthContext } from "~/auth.ts";
 import { authenticateAdminApiSecret, readBearerToken } from "~/auth/admin.ts";
 import { createAuthWorkerServiceClient } from "~/auth/auth-worker-service.ts";
@@ -96,7 +97,11 @@ export async function handleInboundMcpRequest(input: {
   const auth = await resolveMcpAuth(input);
   if (auth instanceof Response) return auth;
 
-  const server = createServer({ ...input, auth });
+  const server = createServer({
+    ...input,
+    auth,
+    toolOptions: readInboundMcpToolOptions(input.request),
+  });
   const handler = createMcpHandler(server, {
     enableJsonResponse: true,
     route: MCP_START_MOUNT_PATH,
@@ -110,6 +115,7 @@ function createServer(input: {
   context: RequestContext;
   env: Env;
   request: Request;
+  toolOptions: InboundMcpToolOptions;
 }) {
   const server = new McpServer(
     { name: "os", version: packageJson.version },
@@ -117,7 +123,9 @@ function createServer(input: {
       instructions: [
         "This is an Iterate OS project MCP server.",
         "Use exec_js to run a JavaScript async arrow function against a project.",
-        "Use ask_assistant to ask the project's assistant agent in plain language.",
+        ...(input.toolOptions.withAgent
+          ? ["Use ask_assistant to ask the project's assistant agent in plain language."]
+          : []),
         "Prefer several small single-purpose calls (fetch data, return it, look at it, act) over one giant defensive script; use Promise.all inside a call to parallelize independent requests.",
       ].join("\n"),
     },
@@ -187,64 +195,66 @@ function createServer(input: {
     },
   );
 
-  server.registerTool(
-    "ask_assistant",
-    {
-      title: "Ask assistant",
-      description:
-        "Ask this project's assistant agent in plain language. Blocks until the assistant replies (up to two minutes) and returns its reply. Conversation history lives on this MCP session's agent stream; asks are a plain chat conversation, so send them one at a time — concurrent asks on one session interleave like two people typing into the same chat.",
-      inputSchema: AskAssistantInput,
-    },
-    async (rawInput) => {
-      const parsedInput = AskAssistantInput.parse(rawInput);
-      const project = await resolveProject(parsedInput.project);
-      const agentPath = await resolveSessionAgentPath();
+  if (input.toolOptions.withAgent) {
+    server.registerTool(
+      "ask_assistant",
+      {
+        title: "Ask assistant",
+        description:
+          "Ask this project's assistant agent in plain language. Blocks until the assistant replies (up to two minutes) and returns its reply. Conversation history lives on this MCP session's agent stream; asks are a plain chat conversation, so send them one at a time — concurrent asks on one session interleave like two people typing into the same chat.",
+        inputSchema: AskAssistantInput,
+      },
+      async (rawInput) => {
+        const parsedInput = AskAssistantInput.parse(rawInput);
+        const project = await resolveProject(parsedInput.project);
+        const agentPath = await resolveSessionAgentPath();
 
-      // agents.ask appends the message and waits for the agent's next chat
-      // reply server-side. Reply matching is by order on the session stream,
-      // not per-request correlation — the session belongs to this one MCP
-      // client, so interleaved replies are the client's own doing (same trust
-      // model as one person running exec_js mid-conversation).
-      let reply;
-      try {
-        const projectItx = await projectItxFor(project.id);
-        await ensureMcpSessionAgentReady({ agentPath, projectItx });
-        reply = await projectItx.agents.get(agentPath).ask({
-          message: parsedInput.message,
-          origin: "mcp",
-          timeoutMs: ASK_ASSISTANT_TIMEOUT_MS,
-        });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: `The assistant did not reply in time: ${message}. The session transcript is the ${agentPath} stream.`,
-            },
-          ],
-          isError: true,
-        };
-      }
+        // agents.ask appends the message and waits for the agent's next chat
+        // reply server-side. Reply matching is by order on the session stream,
+        // not per-request correlation — the session belongs to this one MCP
+        // client, so interleaved replies are the client's own doing (same trust
+        // model as one person running exec_js mid-conversation).
+        let reply;
+        try {
+          const projectItx = await projectItxFor(project.id);
+          await ensureMcpSessionAgentReady({ agentPath, projectItx });
+          reply = await projectItx.agents.get(agentPath).ask({
+            message: parsedInput.message,
+            origin: "mcp",
+            timeoutMs: ASK_ASSISTANT_TIMEOUT_MS,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `The assistant did not reply in time: ${message}. The session transcript is the ${agentPath} stream.`,
+              },
+            ],
+            isError: true,
+          };
+        }
 
-      const message = reply.payload?.message;
-      if (typeof message !== "string" || message.trim() === "") {
+        const message = reply.payload?.message;
+        if (typeof message !== "string" || message.trim() === "") {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Assistant reply event ${reply.offset} did not include a message. The session transcript is the ${agentPath} stream.`,
+              },
+            ],
+            isError: true,
+          };
+        }
         return {
-          content: [
-            {
-              type: "text" as const,
-              text: `Assistant reply event ${reply.offset} did not include a message. The session transcript is the ${agentPath} stream.`,
-            },
-          ],
-          isError: true,
+          content: [{ type: "text" as const, text: message }],
+          isError: false,
         };
-      }
-      return {
-        content: [{ type: "text" as const, text: message }],
-        isError: false,
-      };
-    },
-  );
+      },
+    );
+  }
 
   return server;
 }

--- a/apps/os/src/domains/inbound-mcp-server/mcp-tool-options.test.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-tool-options.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { readInboundMcpToolOptions } from "./mcp-tool-options.ts";
+
+describe("readInboundMcpToolOptions", () => {
+  it("defaults to the exec_js-only surface", () => {
+    expect(readInboundMcpToolOptions(new Request("https://mcp.test/api/mcp"))).toEqual({
+      withAgent: false,
+    });
+  });
+
+  it("enables the assistant tool only with an explicit URL opt-in", () => {
+    expect(
+      readInboundMcpToolOptions(new Request("https://mcp.test/api/mcp?withAgent=true")),
+    ).toEqual({
+      withAgent: true,
+    });
+
+    expect(
+      readInboundMcpToolOptions(new Request("https://mcp.test/api/mcp?withAgent=false")),
+    ).toEqual({
+      withAgent: false,
+    });
+  });
+});

--- a/apps/os/src/domains/inbound-mcp-server/mcp-tool-options.ts
+++ b/apps/os/src/domains/inbound-mcp-server/mcp-tool-options.ts
@@ -1,0 +1,10 @@
+export type InboundMcpToolOptions = {
+  withAgent: boolean;
+};
+
+export function readInboundMcpToolOptions(request: Request): InboundMcpToolOptions {
+  const url = new URL(request.url);
+  return {
+    withAgent: url.searchParams.get("withAgent") === "true",
+  };
+}


### PR DESCRIPTION
## Summary

- Default the inbound OS MCP server to the single `exec_js` tool.
- Gate `ask_assistant` behind an explicit `?withAgent=true` URL option.
- Add `pnpm cli claude-mcp --with-agent` so operators can opt into the assistant bridge deliberately.
- Update OAuth e2e coverage and production debugging docs for the new default.

## Why

The assistant bridge is useful in narrow cases, but it makes the default MCP surface ambiguous for smoke tests and coding clients. The default path should prove and expose the direct JavaScript execution surface only; agent chat can stay available as an explicit opt-in.

## Validation

- `pnpm --dir apps/os test`
- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/os cli claude-mcp --help | rg -n "with-agent|claude-mcp|Options"`

## Production smoke notes

- Confirmed Claude Code can connect to production `https://mcp.iterate.com` via the repo `claude-mcp` flow.
- Confirmed production project `iterate` resolves as `prj_d08f4599397a4e37b6467ce1e2b07bae`.
- Confirmed Claude Code updated the existing project website through MCP `exec_js`, producing project repo commit `bc64a4842f469e4746616dedc6dbf21706be281a`.

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +77 -57 | +70 -51 🟩🟩🟩🟥🟥 |
| Tests | +59 -2 | +51 -2 🟩🟩⬜⬜⬜ |
| CI & scripts | +14 -1 | +11 -1 🟩⬜⬜⬜⬜ |
| Docs | +8 -0 | +6 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+158 -60** | **+138 -54** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between c3420d6 and a514124, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-10T06:52:53.918Z",
      "headSha": "a514124ca861f986c75df140eb1f1dd5aa020a8b",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/160334749280854",
      "shortSha": "a514124",
      "cleanupDurationMs": 8110,
      "deployDurationMs": 77578,
      "workerSizeKib": 15737.09,
      "workerGzipKib": 4255.39,
      "mainWorkerGzipKib": 4255.32
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-10T06:52:46.562Z",
      "headSha": "a514124ca861f986c75df140eb1f1dd5aa020a8b",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/160334749280854",
      "shortSha": "a514124",
      "cleanupDurationMs": 748,
      "deployDurationMs": 13494,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-10T06:52:48.294Z",
      "headSha": "a514124ca861f986c75df140eb1f1dd5aa020a8b",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/160334749280854",
      "shortSha": "a514124",
      "cleanupDurationMs": 2477,
      "deployDurationMs": 20186,
      "workerSizeKib": 4031.55,
      "workerGzipKib": 819.47,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-10T06:52:46.659Z",
      "headSha": "a514124ca861f986c75df140eb1f1dd5aa020a8b",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/160334749280854",
      "shortSha": "a514124",
      "cleanupDurationMs": 837,
      "deployDurationMs": 13083,
      "workerSizeKib": 4707.5,
      "workerGzipKib": 1354.58,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `a514124` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 819.5 KiB | 20.2s |  |  | 2.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/160334749280854) | 2026-07-10T06:52:48.294Z | Preview app released. |
| OS | released | `a514124` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.16 MiB (+0.1 KiB vs main) | 77.6s |  |  | 8.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/160334749280854) | 2026-07-10T06:52:53.918Z | Preview app released. |
| Semaphore | released | `a514124` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 440.8 KiB | 13.5s |  |  | 748ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/160334749280854) | 2026-07-10T06:52:46.562Z | Preview app released. |
| Streams Example App | released | `a514124` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 1.32 MiB | 13.1s |  |  | 837ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/160334749280854) | 2026-07-10T06:52:46.659Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Intentional MCP surface narrowing—clients that relied on ask_assistant without the query param must opt in; auth and exec_js paths are unchanged.
> 
> **Overview**
> The inbound OS MCP server now advertises **`exec_js` only** by default; **`ask_assistant`** is registered only when the request URL includes **`?withAgent=true`**. Server instructions mention the assistant tool only in that mode.
> 
> **`readInboundMcpToolOptions`** parses the query string; **`claude-mcp`** gains **`--with-agent`**, which appends that parameter to the MCP URL used for preflight and Claude’s HTTP MCP config. Debugging docs describe the new default and the flag.
> 
> OAuth e2e and unit tests lock in: default **`tools/list`** omits **`ask_assistant`**, opt-in restores it alongside **`exec_js`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a514124ca861f986c75df140eb1f1dd5aa020a8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->