### PR TITLE
Clamp the live streaming code block and pin it to the tail

### DIFF
--- a/apps/os/src/components/agent-feed.tsx
+++ b/apps/os/src/components/agent-feed.tsx
@@ -1050,10 +1050,27 @@ function LiveStepStream({ step }: { step: AgentUiStep }) {
   );
 }
 
-/** Amber-tinted block the response/code streams into, character by character. */
+/** Amber-tinted block the response/code streams into, character by character.
+ * Clamped to the same height as settled code and tail-pinned so the newest
+ * tokens stay visible: a long codemode turn (minutes, thousands of chunks)
+ * otherwise grows to fill the viewport and reads as one never-ending code
+ * block. Scrolling up unpins; returning to the bottom re-pins. */
 function StreamingCodeBlock({ code }: { code: string }) {
+  const preRef = useRef<HTMLPreElement>(null);
+  const pinnedRef = useRef(true);
+  useLayoutEffect(() => {
+    const el = preRef.current;
+    if (el && pinnedRef.current) el.scrollTop = el.scrollHeight;
+  }, [code]);
   return (
-    <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-xl bg-amber-50 px-4 py-3 font-mono text-xs leading-relaxed text-foreground dark:bg-amber-950/20">
+    <pre
+      ref={preRef}
+      onScroll={(event) => {
+        const el = event.currentTarget;
+        pinnedRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 24;
+      }}
+      className="max-h-80 overflow-y-auto overflow-x-auto whitespace-pre-wrap break-words rounded-xl bg-amber-50 px-4 py-3 font-mono text-xs leading-relaxed text-foreground dark:bg-amber-950/20"
+    >
       {code}
       <StreamingCursor className="bg-amber-600" />
     </pre>


### PR DESCRIPTION
The last UX item from the 2026-07-10 prd research-thread incident: a long codemode turn (77s, 2,159 chunks) streamed into an unclamped `<pre>` that grew to fill the viewport — the transcript read as one never-ending code block, while settled code sits in tidy `max-h-80` collapsed rows.

The live `StreamingCodeBlock` now gets the same `max-h-80` clamp and stays pinned to the newest tokens as chunks arrive. Scrolling up unpins (so you can inspect earlier code mid-stream); returning to the bottom re-pins.

**Verified live** against local dev with a deliberately long generated script: mid-stream the block measured `clientHeight: 320` with `scrollHeight: 6498` (20× the window) and `pinnedToBottom: true`. Three consecutive long turns rendered correctly and settled into their usual collapsed activity rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI-only change to streaming code presentation in `agent-feed.tsx`; no auth, data, or API impact.
> 
> **Overview**
> The live **`StreamingCodeBlock`** in the agent feed no longer grows without bound during long codemode streams. It now uses the same **`max-h-80`** height cap as settled code in activity rows, with **`overflow-y-auto`** so excess content scrolls inside the block.
> 
> As new chunks arrive, a **`useLayoutEffect`** keeps the viewport pinned to the bottom when the user is following the stream. Scrolling up clears that pin (within ~24px of the bottom); scrolling back to the end re-enables auto-scroll to the newest tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d151f1ef37d99be0a12ad95b0fffcc39be98d70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +19 -2 | +14 -1 🟩🟩🟩🟩🟩 |
| **Total** | **+19 -2** | **+14 -1** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 996c1ed and 2d151f1, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-10T11:24:29.583Z",
      "headSha": "2d151f1ef37d99be0a12ad95b0fffcc39be98d70",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/505959363224722",
      "shortSha": "2d151f1",
      "cleanupDurationMs": 8560,
      "deployDurationMs": 66323,
      "testDurationMs": 171257,
      "testRetries": "3 retried: itx > Trusted internal root can access global streams and repos (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1)",
      "workerSizeKib": 15738.82,
      "workerGzipKib": 4255.78,
      "mainWorkerGzipKib": 4255.79
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-10T11:24:24.020Z",
      "headSha": "2d151f1ef37d99be0a12ad95b0fffcc39be98d70",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/505959363224722",
      "shortSha": "2d151f1",
      "cleanupDurationMs": 2993,
      "deployDurationMs": 16015,
      "testDurationMs": 497,
      "testRetries": null,
      "workerSizeKib": 4031.55,
      "workerGzipKib": 819.21,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `2d151f1` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 819.2 KiB | 16.0s | 497ms |  | 3.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/505959363224722) | 2026-07-10T11:24:24.020Z | Preview app released. |
| OS | released | `2d151f1` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.16 MiB (-0.0 KiB vs main) | 66.3s | 171.3s | 3 retried: itx > Trusted internal root can access global streams and repos (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1) | 8.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/505959363224722) | 2026-07-10T11:24:29.583Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->