### PR TITLE
Fix agent feed virtualization and composer layout

### DIFF
--- a/apps/os/src/components/agent-feed.tsx
+++ b/apps/os/src/components/agent-feed.tsx
@@ -1,6 +1,7 @@
 import {
   memo,
   useCallback,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -48,6 +49,8 @@ import type { StreamBrowserDatabase } from "~/domains/streams/client-libraries/b
 import { linkOptionsForStreamPath } from "~/lib/stream-routes.ts";
 /** How many rows past the virtualizer's window the tail query prefetches. */
 const TAIL_PREFETCH_ROWS = 32;
+/** Cap on rows retained across window shifts (memory bound for long feeds). */
+const MAX_RETAINED_ROWS = 2000;
 
 /**
  * The clean agent chat feed: user and assistant messages plus archived
@@ -122,31 +125,37 @@ export function AgentFeedView({
   const queuedCount = queuedUserMessages.length === 0 ? 0 : 1;
   const totalCount = itemCount + liveCount + queuedCount;
 
+  // Settled rows are append-only at dense indices, so the index is a stable
+  // key for them. The live activity and queued panel keep their own keys:
+  // their index shifts up every time a settled row lands, and keying them by
+  // index would hand the (often tall) live block's cached measurement to the
+  // new settled row — a visible jump right when a turn settles.
+  const hasLive = live != null;
+  const getItemKey = useCallback(
+    (index: number) => {
+      if (index < itemCount) return index;
+      return hasLive && index === itemCount ? "live" : "queued";
+    },
+    [itemCount, hasLive],
+  );
+
   const virtualizer = useVirtualizer({
     count: totalCount,
     getScrollElement: () => scrollRef.current,
     estimateSize: () => 56,
-    // Agent feed rows are append-only and addressed by dense local_index, so
-    // the virtual index is a stable item key for TanStack's end anchoring.
-    getItemKey: (index) => index,
+    getItemKey,
     anchorTo: "end",
     followOnAppend: true,
     scrollEndThreshold: 80,
     overscan: 16,
-    directDomUpdates: true,
+    // Deliberately NOT directDomUpdates: in that mode the virtualizer owns
+    // each row's transform and the container height, and this feed's async
+    // row loading (SQL windows resolving after the rows render) triggers
+    // remeasurement storms the direct-DOM path loses track of — the browser
+    // clamps scrollTop against a stale container height and the end anchor
+    // strands mid-history. The classic mode below (JSX-owned styles) rides
+    // the same anchorTo/followOnAppend machinery and holds the pin.
   });
-
-  // Open at the newest content. anchorTo/followOnAppend only act on option
-  // UPDATES — when the deduped query registry already knows the count on the
-  // first render (e.g. re-keyed remount for a previously-opened stream), there
-  // is no 0→N transition for followOnAppend to chase, so set the initial
-  // position explicitly. scrollToEnd's reconcile loop absorbs estimated→
-  // measured size drift.
-  useLayoutEffect(() => {
-    virtualizer.scrollToEnd();
-    // useVirtualizer returns one stable instance for the component's lifetime,
-    // so this runs once on mount; later appends are followOnAppend's job.
-  }, [virtualizer]);
 
   const virtualItems = virtualizer.getVirtualItems();
   const first = virtualItems[0]?.index ?? 0;
@@ -155,6 +164,14 @@ export function AgentFeedView({
   // the unfiltered Pretty+debug path can address rows by local_index directly.
   const denseWindow = query !== "" || !showDebug;
   const windowLimit = Math.max(0, last + 1 + TAIL_PREFETCH_ROWS - first);
+  // While the feed is opening (initial end-pin below), anchor the row window
+  // to the TAIL regardless of the virtualizer's not-yet-scrolled range: the
+  // opening jump must land on rows with real measured sizes, or estimate
+  // error makes the total shrink under the clamped scroll offset and strands
+  // the reader mid-history. Once pinned, the virtualizer's range drives the
+  // window again.
+  const [initialPinDone, setInitialPinDone] = useState(false);
+  const windowStart = initialPinDone ? first : Math.max(0, itemCount - windowLimit);
   const rowClauses: string[] = [];
   const rowParams: Array<string | number> = [];
   if (!showDebug) rowClauses.push(DEBUG_KINDS_SQL);
@@ -172,31 +189,90 @@ export function AgentFeedView({
       : `SELECT local_index, json(data) AS data FROM ${AGENT_UI_FEED_TABLE}
          WHERE local_index >= ? AND local_index < ?
          ORDER BY local_index ASC`,
-    denseWindow ? [...rowParams, windowLimit, first] : [first, last + 1 + TAIL_PREFETCH_ROWS],
+    denseWindow
+      ? [...rowParams, windowLimit, windowStart]
+      : [windowStart, windowStart + windowLimit],
   );
-  // Retain the last committed rows across range re-queries so already-visible
-  // rows don't flash to skeletons while the shifted window's SQL runs. The
-  // retained rows are only valid for the filter they were fetched under —
-  // reusing them across a filter change would briefly show unfiltered rows.
+  // Retain rows across range re-queries by MERGING each resolved window into
+  // the previously-loaded rows (bounded below). Replacing the map with just
+  // the latest window would forget loaded rows the moment the window shifts;
+  // rows scrolled back into view would then re-render as skeletons, and the
+  // skeleton's measurement would overwrite the row's real size — with an
+  // end-anchored virtualizer those size collapses cascade into the total
+  // thrashing and the scroll position stranding mid-history. The retained
+  // rows are only valid for the filter they were fetched under — reusing
+  // them across a filter change would briefly show unfiltered rows.
   const filterKey = `${showDebug ? "debug" : "pretty"}:${query}`;
-  const lastRowsRef = useRef<{ filterKey: string; rows: Map<number, AgentUiItem> } | null>(null);
+  const lastRowsRef = useRef<{
+    filterKey: string;
+    rows: Map<number, { raw: string; item: AgentUiItem }>;
+  } | null>(null);
   const itemsByIndex = useMemo(() => {
-    if (rowsResult.status !== "ok") {
-      const retained = lastRowsRef.current;
-      return retained?.filterKey === filterKey ? retained.rows : new Map<number, AgentUiItem>();
-    }
-    const rows = new Map<number, AgentUiItem>();
+    const retained =
+      lastRowsRef.current?.filterKey === filterKey
+        ? lastRowsRef.current.rows
+        : new Map<number, { raw: string; item: AgentUiItem }>();
+    if (rowsResult.status !== "ok") return retained;
+    const rows = new Map(retained);
     rowsResult.data.forEach((row, position) => {
-      const index = denseWindow ? first + position : Number(row.local_index);
+      const index = denseWindow ? windowStart + position : Number(row.local_index);
+      const raw = String(row.data);
+      // Identity stability is load-bearing: rows re-parse (new object) ONLY
+      // when their JSON changed. Handing memoized rows fresh-but-equal items
+      // on every window re-query re-renders their markdown, whose async
+      // re-parse collapses the row to empty for a frame — and a burst of
+      // rows momentarily measuring ~16px is exactly the kind of size storm
+      // that breaks the virtualizer's end anchor.
+      if (rows.get(index)?.raw === raw) return;
       try {
-        rows.set(index, JSON.parse(String(row.data)) as AgentUiItem);
+        rows.set(index, { raw, item: JSON.parse(raw) as AgentUiItem });
       } catch {
         // Skip unparseable rows; the row stays a skeleton.
       }
     });
+    // Keep memory bounded on very long histories: drop the oldest-inserted
+    // entries once well past what any viewport plus overscan can show.
+    if (rows.size > MAX_RETAINED_ROWS) {
+      const excess = rows.size - MAX_RETAINED_ROWS;
+      let dropped = 0;
+      for (const key of rows.keys()) {
+        if (dropped >= excess) break;
+        rows.delete(key);
+        dropped++;
+      }
+    }
     lastRowsRef.current = { filterKey, rows };
     return rows;
-  }, [rowsResult.data, rowsResult.status, filterKey, first, denseWindow]);
+  }, [rowsResult.data, rowsResult.status, filterKey, windowStart, denseWindow]);
+
+  // Open at the newest content. A single scrollToEnd on mount can't get
+  // there: the count and each row window resolve asynchronously, and a jump
+  // against estimated sizes lands short. So while the feed is opening,
+  // re-pin the end on every data wave, and stop once the pin has stuck (tail
+  // row's real data rendered and the reader is still at the end) — from then
+  // on TanStack's anchorTo/followOnAppend own the tail natively. A reader
+  // who starts scrolling during the load takes over immediately (listeners
+  // below).
+  useLayoutEffect(() => {
+    if (initialPinDone || totalCount === 0) return;
+    const tailRowLoaded = itemCount === 0 || itemsByIndex.has(itemCount - 1);
+    if (tailRowLoaded && virtualizer.isAtEnd()) {
+      setInitialPinDone(true);
+      return;
+    }
+    virtualizer.scrollToEnd();
+  }, [initialPinDone, totalCount, itemCount, itemsByIndex, virtualizer]);
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (element == null) return;
+    const takeOver = () => setInitialPinDone(true);
+    const events = ["wheel", "touchstart", "keydown"] as const;
+    for (const name of events) element.addEventListener(name, takeOver, { passive: true });
+    return () => {
+      for (const name of events) element.removeEventListener(name, takeOver);
+    };
+  }, []);
 
   // Stable identity so the memoized settled rows skip the per-chunk re-renders
   // driven by the live streaming state.
@@ -226,7 +302,7 @@ export function AgentFeedView({
             const index = virtualItem.index;
             const isLiveItem = live != null && index === itemCount;
             const isQueuedItem = index === itemCount + liveCount && queuedCount > 0;
-            const item = index < itemCount ? itemsByIndex.get(index) : undefined;
+            const item = index < itemCount ? itemsByIndex.get(index)?.item : undefined;
             return (
               <div
                 key={virtualItem.key}
@@ -248,7 +324,15 @@ export function AgentFeedView({
                     onInterrupt={onInterruptQueuedMessages}
                   />
                 ) : item == null ? (
-                  <div className="my-2 h-10 rounded-xl bg-muted/40" />
+                  // Not-yet-loaded rows must measure exactly estimateSize
+                  // (56px, margins don't count toward offsetHeight): the
+                  // initial jump to the end renders these before their SQL
+                  // window resolves, and if they measured smaller the total
+                  // size would shrink under the scroll offset and break the
+                  // end anchor before the real rows arrive.
+                  <div className="h-14 py-2">
+                    <div className="h-full rounded-xl bg-muted/40" />
+                  </div>
                 ) : (
                   <AgentFeedItemRow
                     item={item}
@@ -364,9 +448,16 @@ const AgentFeedItemRow = memo(function AgentFeedItemRow({
             <MessageViaLabel via={item.via} className="text-muted-foreground" />
           )}
           {/* Settled messages never stream, so skip streamdown's unpaired-
-              marker balancing — it appends a phantom `*` to text like "17 * 23". */}
+              marker balancing — it appends a phantom `*` to text like "17 * 23".
+              mode="static" is load-bearing for the virtualized feed: streaming
+              mode paints EMPTY on mount and fills the markdown in a deferred
+              transition, so every row mounting in the virtual window measures
+              ~16px before snapping to its real height — a measurement storm
+              that breaks the virtualizer's end anchor. Static mode renders
+              synchronously; the first measurement is the real one. */}
           <MessageResponse
             className="min-w-0 max-w-full overflow-hidden"
+            mode="static"
             parseIncompleteMarkdown={false}
           >
             {item.text}
@@ -633,9 +724,12 @@ function UserMessageBody({ item }: { item: AgentUiMessageItem }) {
         // Slack text is converted to markdown-ish (mentions, [label](url)
         // links) by the reducer — render it through the markdown path so
         // links come out clickable instead of as raw syntax. Settled text
-        // never streams, so skip the unpaired-marker balancing.
+        // never streams, so skip the unpaired-marker balancing; mode="static"
+        // renders synchronously (see the assistant bubble for why that keeps
+        // the virtualizer's measurements sane).
         <MessageResponse
           className="min-w-0 max-w-full overflow-hidden"
+          mode="static"
           parseIncompleteMarkdown={false}
         >
           {item.text}

--- a/apps/os/src/components/feed-items-view.tsx
+++ b/apps/os/src/components/feed-items-view.tsx
@@ -1,4 +1,4 @@
-import { memo, useLayoutEffect, useMemo, useRef } from "react";
+import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { cn } from "@iterate-com/ui/lib/utils";
 import { useStreamQuery } from "~/domains/streams/client-libraries/browser/hooks/use-stream-query.ts";
@@ -13,6 +13,8 @@ import {
 
 /** How many rows past the virtualizer's window the tail query prefetches. */
 const TAIL_PREFETCH_ROWS = 32;
+/** Cap on rows retained across window shifts (memory bound for long feeds). */
+const MAX_RETAINED_ROWS = 2000;
 
 /**
  * Renders the browser-event-feed processor's `feed_items` collection: one row
@@ -62,24 +64,25 @@ export function FeedItemsView({
     followOnAppend: true,
     scrollEndThreshold: 80,
     overscan: 16,
-    directDomUpdates: true,
+    // NOT directDomUpdates — see agent-feed.tsx: async row windows break the
+    // direct-DOM path's end anchor; classic JSX-owned styles hold it.
   });
-
-  // Open at the newest items; later appends are followOnAppend's job (see
-  // agent-feed.tsx for why the initial position is set explicitly).
-  useLayoutEffect(() => {
-    virtualizer.scrollToEnd();
-  }, [virtualizer]);
 
   const virtualItems = virtualizer.getVirtualItems();
   const first = virtualItems[0]?.index ?? 0;
   const last = virtualItems.at(-1)?.index ?? -1;
+  // While the view is opening (initial end-pin below), anchor the row window
+  // to the tail so the opening jump lands on rows with real measured sizes —
+  // see agent-feed.tsx for the stranding failure mode this prevents.
+  const [initialPinDone, setInitialPinDone] = useState(false);
+  const virtualWindowSize = Math.max(0, last + 1 + TAIL_PREFETCH_ROWS - first);
+  const windowFirst = initialPinDone ? first : Math.max(0, itemCount - virtualWindowSize);
   // Fetch one row before the window (when there is one) so the topmost visible
   // row has its predecessor available for the colour-coded time delta — the
-  // window's `first` row would otherwise never see index `first - 1`.
-  const prefetchBefore = first > 0 ? 1 : 0;
-  const queryOffset = first - prefetchBefore;
-  const windowSize = Math.max(0, last + 1 + TAIL_PREFETCH_ROWS - first) + prefetchBefore;
+  // window's first row would otherwise never see the index before it.
+  const prefetchBefore = windowFirst > 0 ? 1 : 0;
+  const queryOffset = windowFirst - prefetchBefore;
+  const windowSize = virtualWindowSize + prefetchBefore;
   // Dense ascending local_index means OFFSET/LIMIT over the ordered (and
   // possibly filtered) collection IS the virtualizer's row window.
   const rowsResult = useStreamQuery(
@@ -89,27 +92,62 @@ export function FeedItemsView({
      ORDER BY local_index ASC LIMIT ? OFFSET ?`,
     [...params, windowSize, queryOffset],
   );
-  // Retain the last committed rows across range re-queries so a shifting
-  // window doesn't blank already-visible rows to skeletons. The retained rows
-  // are only valid for the filter they were fetched under (see agent-feed).
+  // Retain rows across range re-queries by MERGING each resolved window into
+  // the previously-loaded rows: forgetting off-window rows would re-render
+  // them as skeletons on the way back, and the skeleton's measurement would
+  // overwrite the row's real size (see agent-feed.tsx for the end-anchor
+  // failure this causes). Off-window group rows can go briefly stale (their
+  // event_count grows in place) until the window query for their range
+  // resolves again. The retained rows are only valid for the filter they
+  // were fetched under.
   const lastRowsRef = useRef<{ where: string; rows: Map<number, Record<string, unknown>> } | null>(
     null,
   );
   const retainKey = `${where}:${params.join(" ")}`;
   const rowsByIndex = useMemo(() => {
-    if (rowsResult.status !== "ok") {
-      const retained = lastRowsRef.current;
-      return retained?.where === retainKey
-        ? retained.rows
+    const retained =
+      lastRowsRef.current?.where === retainKey
+        ? lastRowsRef.current.rows
         : new Map<number, Record<string, unknown>>();
-    }
-    const rows = new Map<number, Record<string, unknown>>();
+    if (rowsResult.status !== "ok") return retained;
+    const rows = new Map(retained);
     rowsResult.data.forEach((row, position) => {
       rows.set(queryOffset + position, row);
     });
+    if (rows.size > MAX_RETAINED_ROWS) {
+      const excess = rows.size - MAX_RETAINED_ROWS;
+      let dropped = 0;
+      for (const key of rows.keys()) {
+        if (dropped >= excess) break;
+        rows.delete(key);
+        dropped++;
+      }
+    }
     lastRowsRef.current = { where: retainKey, rows };
     return rows;
   }, [rowsResult.data, rowsResult.status, retainKey, queryOffset]);
+
+  // Open at the newest items: re-pin the end on every async data wave until
+  // the pin sticks, then hand the tail to anchorTo/followOnAppend (see
+  // agent-feed.tsx for why a one-shot mount scroll gets stranded).
+  useLayoutEffect(() => {
+    if (initialPinDone || itemCount === 0) return;
+    if (rowsByIndex.has(itemCount - 1) && virtualizer.isAtEnd()) {
+      setInitialPinDone(true);
+      return;
+    }
+    virtualizer.scrollToEnd();
+  }, [initialPinDone, itemCount, rowsByIndex, virtualizer]);
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (element == null) return;
+    const takeOver = () => setInitialPinDone(true);
+    const events = ["wheel", "touchstart", "keydown"] as const;
+    for (const name of events) element.addEventListener(name, takeOver, { passive: true });
+    return () => {
+      for (const name of events) element.removeEventListener(name, takeOver);
+    };
+  }, []);
 
   return (
     <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
@@ -141,7 +179,12 @@ export function FeedItemsView({
                 style={{ transform: `translateY(${item.start}px)` }}
               >
                 {row == null ? (
-                  <div className="h-8 bg-muted/30" />
+                  // Must measure exactly estimateSize (44px) — see the
+                  // agent-feed skeleton for why smaller placeholders break
+                  // the end anchor during the initial jump.
+                  <div className="h-11 py-1.5">
+                    <div className="h-full bg-muted/30" />
+                  </div>
                 ) : (
                   <FeedItemRow
                     row={row}

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -292,7 +292,13 @@ export function ProjectStreamView({
   const modeBody =
     caps.agentFeed && caps.rawFeed ? (
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <div className="relative min-h-0 flex-[3] overflow-hidden border-b">{agentFeed}</div>
+        {/* Both pane wrappers must be flex columns: the feeds size themselves
+            with flex-1 and only scroll internally when a flex parent
+            constrains them — in a block wrapper they grow to content height
+            and the pane just clips them at the top. */}
+        <div className="relative flex min-h-0 flex-[3] flex-col overflow-hidden border-b">
+          {agentFeed}
+        </div>
         <div className="relative flex min-h-0 flex-[2] flex-col overflow-hidden">
           <div className="flex h-7 shrink-0 items-center border-b bg-muted/30 px-4">
             <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
@@ -302,7 +308,7 @@ export function ProjectStreamView({
               click a row to inspect · arrow keys page
             </span>
           </div>
-          <div className="relative min-h-0 flex-1 overflow-hidden">{rawFeed}</div>
+          <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">{rawFeed}</div>
         </div>
       </div>
     ) : (

--- a/apps/os/src/routes/_app/projects/$projectSlug/agents/streams/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/agents/streams/$.tsx
@@ -79,7 +79,11 @@ function ProjectAgentDetailContent() {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="min-h-0 flex-1">
+      {/* Must be a flex column: the stream view sizes itself with flex-1 and
+          relies on this parent constraining it — in a block wrapper it grows
+          to content height, the feed never scrolls internally, and the
+          composer is pushed below the fold. */}
+      <div className="flex min-h-0 flex-1 flex-col">
         <ProjectStreamView
           autoFocusMessageComposer
           emptyLabel="No events on this agent stream yet."

--- a/tasks/browser-single-feed-items-handoff.md
+++ b/tasks/browser-single-feed-items-handoff.md
@@ -1,0 +1,217 @@
+---
+state: todo
+priority: high
+size: large
+tags: [os, streams, browser-feed, sqlite, agent-feed]
+---
+
+# Browser stream feed should have one feed item abstraction
+
+## User intent
+
+The browser stream mirror should expose one feed item abstraction, not a
+"pretty feed" table plus a separate "raw grouped feed" table that the React view
+tries to stitch together.
+
+Target model:
+
+- One browser feed item abstraction for anything rendered in the stream feed.
+- Two user-facing SQLite content tables for a stream path:
+  - `events`: raw committed stream events.
+  - `feed_items`: derived rendered rows.
+- `feed_items` has one total monotonic ordering within the stream path. The UI
+  should render `ORDER BY local_index` (or equivalent), not union two feed
+  tables and invent ordering in React.
+
+Internal processor bookkeeping tables such as `processor_state` / mirror meta
+may still exist unless the owner literally wants only two SQLite tables total.
+Do not confuse those internals with the two content-table model above.
+
+## What went wrong
+
+PR #1837 kept two feed abstractions:
+
+- `agent_feed_items`: nice agent rows.
+- `feed_items`: raw grouped/debug rows.
+
+Then Pretty + raw rendered those as split panes. A later attempted correction
+started heading toward a SQL `UNION` of those two tables. That is still the
+wrong model. The owner wants one feed item stream in the browser, with pretty
+and raw rows interspersed because they are both feed items.
+
+Do not solve this by:
+
+- Adding another table for agent rows.
+- Sorting two feed tables together in the view.
+- Rendering Pretty + raw as a raw rail under/next to the chat.
+- Moving processor runtime state into the browser DB. Runtime lag/cursor/parked
+  state belongs to the server itx runtime surface.
+
+## Current code shape
+
+Relevant files:
+
+- `apps/os/src/components/project-stream-view.tsx`
+  - Owns the browser stream view and currently wires three browser processors.
+- `apps/os/src/components/agent-feed.tsx`
+  - Renders nice agent rows from `agent_feed_items`.
+- `apps/os/src/components/feed-items-view.tsx`
+  - Renders grouped raw rows from `feed_items`.
+- `apps/os/src/domains/streams/client-libraries/processors/agent-ui-processor.ts`
+  - Owns `agent_feed_items` and agent reduced state.
+- `apps/os/src/domains/streams/client-libraries/processors/browser-event-feed/implementation.ts`
+  - Owns `feed_items` for raw grouped rows.
+- `packages/ui/src/components/events/agent-ui-reducer.ts`
+  - Shared reducer that derives nice agent UI items and live state.
+
+As of this handoff, the branch should not contain partial code changes from the
+aborted interleaving attempt. Start from current `origin/main`.
+
+## Desired data model
+
+`events` remains the raw append-only browser mirror.
+
+`feed_items` should become the single rendered-feed projection. Suggested
+columns:
+
+```sql
+CREATE TABLE feed_items (
+  local_index INTEGER PRIMARY KEY,
+  kind TEXT NOT NULL,
+  first_offset INTEGER NOT NULL,
+  last_offset INTEGER NOT NULL,
+  event_count INTEGER NOT NULL DEFAULT 1,
+  data BLOB NOT NULL
+);
+
+CREATE INDEX feed_items_offsets_idx
+  ON feed_items(first_offset, last_offset);
+
+CREATE INDEX feed_items_kind_idx
+  ON feed_items(kind);
+```
+
+`local_index` is the total feed order. Important: stream processors replay
+batches, so this must be deterministic/idempotent. A plain SQLite
+`AUTOINCREMENT` insert is probably wrong unless there is also a stable
+idempotency key and replay does not allocate a second row. The existing browser
+processors already use a reducer-state `nextLocalIndex`; that pattern matches
+at-least-once replay better than relying on SQLite allocation.
+
+Potential `kind` values:
+
+- `agent.user-message`
+- `agent.assistant-message`
+- `agent.activity`
+- `agent.stream-woken`
+- `agent.child-stream-created`
+- `agent.stream-paused`
+- `agent.stream-resumed`
+- `raw.group`
+- `raw.singleton`
+
+Names are not important; the invariant is that every rendered row is a
+`feed_items` row.
+
+## Ordering semantics
+
+The feed projector, not the React view, owns ordering.
+
+For each event, the projector can emit zero, one, or multiple feed item
+mutations. When multiple feed rows are caused by the same offset, the projector
+must choose an order and assign `local_index` in that order.
+
+Agent activity is the hard case:
+
+- If the owner wants the activity row to appear where work started, create the
+  `agent.activity` feed item when the activity opens and update it in place as
+  steps complete.
+- If the owner wants the activity row to appear retrospectively, create it when
+  the activity settles.
+
+Current pretty-feed behavior visually implies "activity appears between the
+user message and the assistant response", so creating the activity row at start
+and updating it later is likely the right product model.
+
+Raw grouping is also an update-in-place case:
+
+- A `raw.group` row starts at its first event.
+- Later same-type events update that row's `last_offset`, `event_count`, and
+  `data`.
+- The row keeps its original `local_index`.
+
+That means Pretty + raw is interspersed at feed-item granularity, not necessarily
+one visible raw row per event.
+
+## Processor architecture
+
+One processor should own writes to `feed_items`. Two independent processors
+writing the same table cannot safely coordinate a single total `local_index`
+without a central allocator, and a central allocator is unnecessary complexity.
+
+Likely shape:
+
+- Keep `browser-raw-events` as the owner of `events`.
+- Replace/consolidate `agent-ui-processor` and `browser-event-feed` feed-row
+  writes into one browser feed projector that owns `feed_items`.
+- That projector can reuse/refactor the existing agent reducer and raw grouping
+  logic, but it must produce one ordered stream of feed item insert/update ops.
+- Agent live state, presence, and token usage can still be reduced state for the
+  feed projector if the view needs them for the live tail/header. They should
+  not require a separate `agent_feed_items` table.
+
+If keeping a separate `agent-ui` processor for live state is unavoidable, it
+must not own a second feed table. Also avoid two processors both writing
+`feed_items` unless there is a reviewed design for idempotent ordering.
+
+## View behavior
+
+The React feed should have one virtualized list over `feed_items`.
+
+Modes become filters over the same table:
+
+- Pretty: show nice agent rows, hide raw debug rows.
+- Pretty + raw: show nice agent rows and selected raw rows in one list ordered
+  by `local_index`.
+- Raw: show raw/debug feed rows and keep raw event inspector access.
+
+Pretty + raw should still support choosing which raw groups/event types to show.
+Filtering raw rows must not remove nice rows unless the mode/search explicitly
+says so. A useful SQL shape is:
+
+```sql
+WHERE
+  kind NOT LIKE 'raw.%'
+  OR (kind LIKE 'raw.%' AND <raw filters>)
+ORDER BY local_index ASC
+```
+
+Search semantics need a product call:
+
+- Search could apply to nice rows only in Pretty + raw, while raw type/component
+  filters apply only to raw rows.
+- Or search could apply to both. The previous direction was "Pretty + raw search
+  is for the pretty feed"; raw rows are controlled by raw filters.
+
+## Migration / rebuild stance
+
+These browser mirrors are disposable projections. Prefer a schema-version bump
+and local rebuild over a complicated migration. The new projector should clear
+old `agent_feed_items` usage and rebuild `feed_items` from `events`.
+
+If old `agent_feed_items` tables remain in existing browser DB files, they
+should be ignored or dropped as part of cleanup. The product model should not
+read from them.
+
+## Acceptance criteria
+
+- There is no `agent_feed_items` user-facing content table in the active feed
+  path.
+- Pretty, Pretty + raw, and Raw are all backed by `feed_items`.
+- Pretty + raw is one scrolling list, not split panes.
+- Raw grouped debug access remains available from Pretty + raw by clicking raw
+  rows / opening the raw event inspector.
+- Raw filters in Pretty + raw can select which raw groups/event types appear.
+- Feed ordering is a single deterministic per-stream `local_index`.
+- Runtime subscription state in the processor sheet is fetched from server itx
+  runtime state, not browser SQLite.


### PR DESCRIPTION
## What was broken

The agent stream feed in apps/os was visibly broken: rows rendered with overlapping/stale positions, the feed opened stranded mid-history instead of at the latest message, and the composer floated mid-page with dead space below instead of pinning to the bottom.

## Root causes and fixes

**1. Mixed virtualizer modes (`agent-feed.tsx`, `feed-items-view.tsx`).** The code set `directDomUpdates: true` (the virtualizer writes row transforms and the container height straight to the DOM) while *also* writing `transform`/`height` from JSX — so every React render (16ms live-stream ticks) overwrote the virtualizer's DOM writes with stale offsets. Now on the classic documented idiom: JSX owns the styles, and the virtualizer keeps `anchorTo: "end"` + `followOnAppend` per the TanStack Virtual chat example.

**2. Streamdown's streaming mode vs measurement (`agent-feed.tsx`).** Settled message bubbles rendered markdown in streamdown's default streaming mode, which paints **empty** on mount and fills content in a deferred transition — every row mounting into the virtual window measured ~16px, then snapped to its real height. That measurement storm collapsed the total size under the scroll offset and broke the end anchor. Settled messages never stream, so they now render `mode="static"` (synchronous; first measurement is the real one).

**3. Async row windows vs a one-shot initial scroll.** The count and each row window resolve asynchronously from SQLite, so `scrollToEnd()` on mount landed on estimates and stranded once real sizes arrived. While the feed opens, the row window is anchored to the tail (real data before the jump) and an end-pin effect re-asserts `scrollToEnd` on each data wave until the tail row is loaded and the pin sticks; wheel/touch/keys hand control to the reader immediately. Row retention now **merges** across window shifts (bounded) with per-row identity stability, so loaded rows never regress to skeletons and equal data never re-renders memoized rows. Placeholders measure exactly `estimateSize`.

**4. Broken flex height chains.** The agents route wrapped the stream view in a `display: block` div, so the view's `flex-1` never constrained it — the feed grew to content height (7000px+), never scrolled internally, and pushed the composer below the fold. The Pretty+raw split panes had the same bug. Both wrappers are flex columns now.

Also gives the live activity / queued panel stable virtualizer keys so their measurements travel with them as settled rows land.

## Verified on local dev against a 134-event seeded stream

- Opens at the latest message; composer pinned to the bottom
- Smooth scrolling through history with no overlap, drift, or flicker
- Reading history is never yanked by appends; `followOnAppend` chases new messages while pinned at the end
- Composer send works end-to-end (message bubble + settled activity row + agent reply)
- Pretty, Pretty+raw (both panes), and Raw modes all scroll internally and anchor to the end

Also checks in `tasks/browser-single-feed-items-handoff.md` — the larger single-`feed_items` refactor described there remains open; this PR fixes the rendering/virtualization layer it will build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only virtualization and layout fixes in stream feed components; no auth, persistence, or API contract changes beyond local scroll behavior.
> 
> **Overview**
> **Fixes agent and raw stream feeds** that opened mid-history, overlapped rows, and left the composer floating with dead space below.
> 
> **Virtualization (`agent-feed.tsx`, `feed-items-view.tsx`):** Drops `directDomUpdates` so JSX owns transforms/height and end-anchoring stays consistent with async row loads. Live activity and the queued panel get stable virtual keys (`"live"` / `"queued"`) so measurements don’t jump when a turn settles. Row caches **merge** across SQL window shifts (capped at 2000 rows) with JSON **raw-string** identity so memoized rows don’t re-mount markdown. Placeholders match `estimateSize` (56px / 44px). Settled bubbles use `MessageResponse` **`mode="static"`** so first paint isn’t ~16px empty streamdown.
> 
> **Opening at the tail:** While loading, the row query anchors to the **tail** (not the virtualizer’s initial range); a layout effect re-`scrollToEnd`s until the tail row is loaded and the pin sticks, then `anchorTo` / `followOnAppend` take over. Wheel, touch, and keydown end the initial pin immediately.
> 
> **Layout:** Agent route and Pretty+raw split panes use **flex columns** so `flex-1` feeds scroll inside the pane instead of growing to full content height and pushing the composer off-screen.
> 
> Also adds **`tasks/browser-single-feed-items-handoff.md`** describing a future single-`feed_items` refactor; **not** implemented here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ee75416bf8bdbde35019c3a32e8bec1a95ef5bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-10T08:46:28.065Z",
      "headSha": "3ee75416bf8bdbde35019c3a32e8bec1a95ef5bb",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/192118004682082",
      "shortSha": "3ee7541",
      "cleanupDurationMs": 9878,
      "deployDurationMs": 74568,
      "testDurationMs": 140212,
      "testRetries": "1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 15738.83,
      "workerGzipKib": 4255.79,
      "mainWorkerGzipKib": 4255.79
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-10T08:46:20.814Z",
      "headSha": "3ee75416bf8bdbde35019c3a32e8bec1a95ef5bb",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/192118004682082",
      "shortSha": "3ee7541",
      "cleanupDurationMs": 2624,
      "deployDurationMs": 19609,
      "testDurationMs": 486,
      "testRetries": null,
      "workerSizeKib": 4031.55,
      "workerGzipKib": 819.38,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `3ee7541` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 819.4 KiB | 19.6s | 486ms |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/192118004682082) | 2026-07-10T08:46:20.814Z | Preview app released. |
| OS | released | `3ee7541` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.16 MiB (±0 vs main) | 74.6s | 140.2s | 1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 9.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/192118004682082) | 2026-07-10T08:46:28.065Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +5 -1 | +3 -1 🟩⬜⬜⬜⬜ |
| UI components | +201 -58 | +114 -34 🟩🟩🟩🟩🟥 |
| Docs | +217 -0 | +164 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+423 -59** | **+281 -35** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 996c1ed and 3ee7541, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->