### PR TITLE
BYOK lane through Cloudflare AI Gateway + response cache for e2e LLM turns

### DIFF
--- a/apps/os/e2e/vitest/agent-response-cache.e2e.test.ts
+++ b/apps/os/e2e/vitest/agent-response-cache.e2e.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import { adminSecret, withItxSession } from "./test-helpers.ts";
+
+const LLM_REQUEST_COMPLETED_TYPE = "events.iterate.com/agent/llm-request-completed";
+const WEB_MESSAGE_SENT_TYPE = "events.iterate.com/agents/web-message-sent";
+
+type LlmCompletionEvidence = {
+  cacheStatus: string | undefined;
+  greeting: string;
+};
+
+/**
+ * One onboarding birth turn, start to greeting: create a project, open the
+ * onboarding agent the way the dashboard chat page does (configure({})), and
+ * return the LLM completion's gateway-cache evidence plus the greeting text.
+ */
+async function runOnboardingBirthTurn(slug: string): Promise<LlmCompletionEvidence> {
+  using session = withItxSession();
+  using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
+  using project = itx.projects.create({ slug });
+  using agent = project.agents.get("/agents/onboarding");
+  await agent.configure({});
+  const greeting = await agent.stream.waitForEvent({
+    eventTypes: [WEB_MESSAGE_SENT_TYPE],
+    timeoutMs: 90_000,
+  });
+  // The FIRST completion is the birth turn — the request whose masked body is
+  // identical across projects by construction. Later turns (script results
+  // feeding back) may carry their own entropy and are not this test's claim.
+  const events = await agent.stream.getEvents({ eventTypes: [LLM_REQUEST_COMPLETED_TYPE] });
+  const completed = events.at(0) as
+    | {
+        payload?: {
+          result?: { rawResponse?: { cloudflareAiGatewayResponseCacheStatus?: unknown } };
+        };
+      }
+    | undefined;
+  const cacheStatus =
+    completed?.payload?.result?.rawResponse?.cloudflareAiGatewayResponseCacheStatus;
+  return {
+    cacheStatus: typeof cacheStatus === "string" ? cacheStatus : undefined,
+    greeting: String((greeting.payload as { message?: unknown } | undefined)?.message ?? ""),
+  };
+}
+
+describe("cloudflare AI Gateway response cache", () => {
+  test("a second project's onboarding turn replays the first one's answer from cache", async () => {
+    const marker = crypto.randomUUID().slice(0, 8);
+
+    // First turn seeds the cache (HIT if an earlier run already did).
+    const first = await runOnboardingBirthTurn(`aig-cache-a-${marker}`);
+    // This env runs the BYOK lane with the response cache on (envs.ts /
+    // local-dev vars); evidence missing means the lane regressed.
+    expect(first.cacheStatus).toMatch(/^(HIT|MISS)$/);
+
+    // The second project differs ONLY in minted identity (project id, agent
+    // path) — exactly what cloudflareAiGatewayResponseCacheKey masks — so its
+    // birth turn must replay the first one's response without touching OpenAI.
+    const second = await runOnboardingBirthTurn(`aig-cache-b-${marker}`);
+    expect(second.cacheStatus).toBe("HIT");
+
+    // A replay is byte-identical: same greeting, deterministic e2e for free.
+    expect(second.greeting).toBe(first.greeting);
+  }, 300_000);
+});

--- a/apps/os/scripts/generate-wrangler-config.ts
+++ b/apps/os/scripts/generate-wrangler-config.ts
@@ -95,6 +95,14 @@ export function envShapedVars(env: DeployedEnv) {
     APP_CONFIG_MCP__BASE_URL: env.mcpBaseUrl,
     APP_CONFIG_PROJECT_HOSTNAME_BASES: JSON.stringify(env.projectHostnameBases),
     APP_CONFIG_ITERATE_AUTH__ISSUER: `${env.authBaseUrl}/api/auth`,
+    APP_CONFIG_CLOUDFLARE_AI_GATEWAY__TRANSPORT: env.cloudflareAiGatewayTransport,
+    ...(env.cloudflareAiGatewayResponseCacheTtlSeconds === undefined
+      ? {}
+      : {
+          APP_CONFIG_CLOUDFLARE_AI_GATEWAY__RESPONSE_CACHE_TTL_SECONDS: String(
+            env.cloudflareAiGatewayResponseCacheTtlSeconds,
+          ),
+        }),
   };
 }
 
@@ -409,6 +417,12 @@ function localDevBindings() {
     ...bindings,
     vars: {
       ...bindings.vars,
+      // Local dev rides the BYOK lane with the response cache, same as the
+      // preview slots: agent-loop iteration replays yesterday's answers for
+      // free. In envShapedVars for deployed envs; spelled out here because
+      // local dev has no envs.ts entry.
+      APP_CONFIG_CLOUDFLARE_AI_GATEWAY__TRANSPORT: "byok",
+      APP_CONFIG_CLOUDFLARE_AI_GATEWAY__RESPONSE_CACHE_TTL_SECONDS: String(7 * 24 * 60 * 60),
       ...(process.env.PORT ? { APP_CONFIG_BASE_URL: `http://localhost:${process.env.PORT}` } : {}),
       // Local dev trusts forge-minted sessions by deriving the public key from
       // AUTH_FORGE_PRIVATE_JWK. Do not read APP_CONFIG_ITERATE_AUTH__JWKS from

--- a/apps/os/src/config.ts
+++ b/apps/os/src/config.ts
@@ -79,6 +79,24 @@ export const AppConfig = z.object({
     })
     .optional(),
   openAiApiKey: redacted(z.string().trim().min(1)),
+  /**
+   * How agent LLM turns travel through the Cloudflare AI Gateway — see
+   * CloudflareAiGatewayTransport in workers-ai-transport.ts. Values come from
+   * envs.ts via envShapedVars (APP_CONFIG_CLOUDFLARE_AI_GATEWAY__*), so this
+   * is per-deployment, not per-Doppler-secret.
+   *
+   * `responseCacheTtlSeconds` opts the BYOK lane into the gateway's RESPONSE
+   * cache (whole-answer replay — distinct from OpenAI's prompt cache, which
+   * BYOK gets unconditionally). Only for deployments whose conversations are
+   * synthetic (previews, local dev); never prd.
+   */
+  cloudflareAiGateway: z
+    .object({
+      transport: z.enum(["unified", "byok"]).default("unified"),
+      id: z.string().trim().min(1).default("default"),
+      responseCacheTtlSeconds: z.coerce.number().int().positive().optional(),
+    })
+    .prefault({}),
   cloudflare: z
     .object({
       accountId: publicValue(z.string().trim().min(1)).optional(),

--- a/apps/os/src/domains/agents/agent-durable-object.ts
+++ b/apps/os/src/domains/agents/agent-durable-object.ts
@@ -43,6 +43,22 @@ export class AgentDurableObject extends DurableObject<Env> {
       new AgentProcessor({
         ...deps,
         ai: this.env.AI,
+        // Resolved per attempt (not at construction) so a config problem
+        // fails the turn with a journaled error instead of bricking the DO.
+        // The OpenAI prompt_cache_key is per agent stream: repeated turns
+        // grow a shared prefix, and a stable key routes them to the same
+        // provider-side prompt-cache shard.
+        cloudflareAiGatewayTransport: () => {
+          const gateway = parseConfig(this.env).cloudflareAiGateway;
+          if (gateway.transport === "unified") return { kind: "unified" };
+          return {
+            kind: "byok",
+            gatewayId: gateway.id,
+            openaiApiKey: parseConfig(this.env).openAiApiKey.exposeSecret(),
+            openaiPromptCacheKey: `${this.#name.projectId}:${this.#name.path}`,
+            responseCacheTtlSeconds: gateway.responseCacheTtlSeconds,
+          };
+        },
         // Oversized script results spill into the agent's OWN workspace (the
         // same checkout itx.workspace resolves to), so the model can page
         // through the file instead of blowing its context window. The first

--- a/apps/os/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/os/src/domains/agents/agent-processor-implementation.ts
@@ -32,6 +32,7 @@ import {
   jsonCompatible,
   normalizeLlmUsage,
   runWorkersAiAttempt,
+  type CloudflareAiGatewayTransport,
   type WorkersAiBinding,
 } from "./workers-ai-transport.ts";
 
@@ -54,12 +55,19 @@ type AgentConsumedEvent = ReturnType<typeof AgentProcessorContract.parseEvent>;
  * - `llmRetryBackoffBaseMs` scales the failure-retry backoff (default
  *   AGENT_LLM_RETRY_BACKOFF_BASE_MS); tests shrink it so retry loops run in
  *   milliseconds.
+ * - `cloudflareAiGatewayTransport` resolves how attempts travel through the
+ *   gateway (unified billing vs the BYOK lane — see
+ *   CloudflareAiGatewayTransport). A function, not a value:
+ *   it reads deployment config and the host's secrets, and a bad config must
+ *   fail the ATTEMPT (journaled, retried) rather than DO construction.
+ *   Defaults to unified billing.
  */
 type AgentProcessorDeps = {
   ai?: WorkersAiBinding;
   writeWorkspaceFile?: (input: { content: string; path: string }) => Promise<void>;
   now?: () => number;
   llmRetryBackoffBaseMs?: number;
+  cloudflareAiGatewayTransport?: () => CloudflareAiGatewayTransport;
 };
 
 /** Page size for full-journal reads (prompt building, currency checks). */
@@ -680,6 +688,7 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
       });
       const completion = await runWorkersAiAttempt({
         ai,
+        transport: this.deps.cloudflareAiGatewayTransport?.(),
         // The attempt's whole vendor phase (dial + stream drain) self-caps at
         // the intent-expiry horizon, so a wedged binding releases the live
         // set here instead of pinning the obligation until the backstop.

--- a/apps/os/src/domains/agents/workers-ai-transport.test.ts
+++ b/apps/os/src/domains/agents/workers-ai-transport.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { runWorkersAiAttempt } from "./workers-ai-transport.ts";
+import {
+  cloudflareAiGatewayResponseCacheKey,
+  maskCloudflareAiGatewayResponseCacheEntropy,
+  runWorkersAiAttempt,
+} from "./workers-ai-transport.ts";
 
 describe("runWorkersAiAttempt", () => {
   it("cancels the response stream on deadline so no chunk lands after the failure", async () => {
@@ -107,5 +111,190 @@ describe("runWorkersAiAttempt", () => {
       completion_tokens: 5,
       total_tokens: 17,
     });
+  });
+});
+
+describe("the BYOK gateway lane", () => {
+  const encoder = new TextEncoder();
+  const sseBody = (frames: unknown[]) =>
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const frame of frames) {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(frame)}\n\n`));
+        }
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    });
+  const okFrames = [
+    { choices: [{ delta: { content: "OK", role: "assistant" }, index: 0 }] },
+    { choices: [], usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 } },
+  ];
+  type GatewayRequest = {
+    provider: string;
+    endpoint: string;
+    headers: Record<string, string>;
+    query: unknown;
+  };
+  const byokAi = (response: () => Response) => {
+    const requests: GatewayRequest[] = [];
+    const gatewayIds: string[] = [];
+    return {
+      requests,
+      gatewayIds,
+      ai: {
+        run: async () => {
+          throw new Error("unified lane must not be dialed");
+        },
+        gateway: (gatewayId: string) => {
+          gatewayIds.push(gatewayId);
+          return {
+            run: async (data: GatewayRequest) => {
+              requests.push(data);
+              return response();
+            },
+          };
+        },
+      },
+    };
+  };
+
+  it("dials the universal endpoint with our key, strips the model prefix, and pins the prompt cache key", async () => {
+    const fake = byokAi(
+      () => new Response(sseBody(okFrames), { headers: { "cf-aig-cache-status": "MISS" } }),
+    );
+    const completion = await runWorkersAiAttempt({
+      ai: fake.ai,
+      deadlineMs: 1_000,
+      messages: [{ role: "user", content: "hi" }],
+      model: "openai/gpt-5.5",
+      onChunk: async () => {},
+      transport: {
+        kind: "byok",
+        gatewayId: "default",
+        openaiApiKey: "sk-test",
+        openaiPromptCacheKey: "prj_1:/agents/onboarding",
+        responseCacheTtlSeconds: 600,
+      },
+    });
+
+    expect(fake.gatewayIds).toEqual(["default"]);
+    const request = fake.requests[0]!;
+    expect(request.provider).toBe("openai");
+    expect(request.endpoint).toBe("chat/completions");
+    expect(request.headers.authorization).toBe("Bearer sk-test");
+    expect(request.headers["cf-aig-cache-ttl"]).toBe("600");
+    expect(request.headers["cf-aig-cache-key"]).toMatch(/^[0-9a-f]{64}$/);
+    expect(request.query).toMatchObject({
+      model: "gpt-5.5",
+      prompt_cache_key: "prj_1:/agents/onboarding",
+      reasoning_effort: "medium",
+      stream: true,
+    });
+    expect(completion.text).toBe("OK");
+    expect(completion.rawResponse).toMatchObject({
+      cloudflareAiGatewayResponseCacheStatus: "MISS",
+    });
+  });
+
+  it("sends no cache headers when the response cache is not opted into", async () => {
+    const fake = byokAi(() => new Response(sseBody(okFrames)));
+    const completion = await runWorkersAiAttempt({
+      ai: fake.ai,
+      deadlineMs: 1_000,
+      messages: [{ role: "user", content: "hi" }],
+      model: "openai/gpt-5.5",
+      onChunk: async () => {},
+      transport: { kind: "byok", gatewayId: "default", openaiApiKey: "sk-test" },
+    });
+    const request = fake.requests[0]!;
+    expect(request.headers).not.toHaveProperty("cf-aig-cache-ttl");
+    expect(request.headers).not.toHaveProperty("cf-aig-cache-key");
+    // No header on the response either -> no cache-status claim in evidence.
+    expect(completion.rawResponse).not.toHaveProperty("cloudflareAiGatewayResponseCacheStatus");
+  });
+
+  it("falls back to unified billing for non-OpenAI models", async () => {
+    let unifiedDialed = false;
+    const completion = await runWorkersAiAttempt({
+      ai: {
+        run: async () => {
+          unifiedDialed = true;
+          return { response: "OK" };
+        },
+        gateway: () => {
+          throw new Error("gateway must not be dialed for non-OpenAI models");
+        },
+      },
+      deadlineMs: 1_000,
+      messages: [{ role: "user", content: "hi" }],
+      model: "@cf/moonshotai/kimi-k2.7-code",
+      onChunk: async () => {},
+      transport: { kind: "byok", gatewayId: "default", openaiApiKey: "sk-test" },
+    });
+    expect(unifiedDialed).toBe(true);
+    expect(completion.text).toBe("OK");
+  });
+
+  it("fails the attempt loudly on a non-2xx gateway response", async () => {
+    const fake = byokAi(() => new Response('{"error":"nope"}', { status: 401 }));
+    await expect(
+      runWorkersAiAttempt({
+        ai: fake.ai,
+        deadlineMs: 1_000,
+        messages: [{ role: "user", content: "hi" }],
+        model: "openai/gpt-5.5",
+        onChunk: async () => {},
+        transport: { kind: "byok", gatewayId: "default", openaiApiKey: "sk-test" },
+      }),
+    ).rejects.toThrow(/status 401/);
+  });
+});
+
+describe("cloudflareAiGatewayResponseCacheKey", () => {
+  it("masks minted identity so two fixtures' identical conversations share a key", async () => {
+    const bodyFor = (projectId: string, agentPath: string) => ({
+      model: "gpt-5.5",
+      messages: [
+        { role: "system", content: "You are the onboarding agent." },
+        {
+          role: "user",
+          content: `<project-context projectId="${projectId}" agentPath="${agentPath}" />\nStart onboarding now`,
+        },
+      ],
+      prompt_cache_key: `${projectId}:${agentPath}`,
+      stream: true,
+    });
+    const keyA = await cloudflareAiGatewayResponseCacheKey(
+      bodyFor("prj_0123456789abcdef0123456789abcdef", "/agents/onboarding"),
+    );
+    const keyB = await cloudflareAiGatewayResponseCacheKey(
+      bodyFor("prj_fedcba9876543210fedcba9876543210", "/agents/onboarding"),
+    );
+    expect(keyA).toBe(keyB);
+  });
+
+  it("keeps semantically different requests apart", async () => {
+    const bodyFor = (content: string) => ({
+      model: "gpt-5.5",
+      messages: [{ role: "user", content }],
+      stream: true,
+    });
+    const keyA = await cloudflareAiGatewayResponseCacheKey(bodyFor("What is 2+2?"));
+    const keyB = await cloudflareAiGatewayResponseCacheKey(bodyFor("What is 3+3?"));
+    expect(keyA).not.toBe(keyB);
+  });
+
+  it("masks signed-URL signatures and expiries but keeps the file identity", () => {
+    const masked = maskCloudflareAiGatewayResponseCacheEntropy(
+      JSON.stringify({
+        content:
+          "file: https://iterate-files--demo.iterate-preview-4.app/files/report.pdf?exp=1760000000&sig=deadbeef123",
+      }),
+    );
+    expect(masked).toContain("/files/report.pdf");
+    expect(masked).toContain("exp=MASKED");
+    expect(masked).toContain("sig=MASKED");
+    expect(masked).not.toContain("deadbeef123");
   });
 });

--- a/apps/os/src/domains/agents/workers-ai-transport.ts
+++ b/apps/os/src/domains/agents/workers-ai-transport.ts
@@ -8,8 +8,48 @@
 
 import { z } from "zod";
 
-/** The `env.AI` surface one attempt needs. */
-export type WorkersAiBinding = { run(model: string, body: unknown): Promise<unknown> };
+/** The `env.AI` surface one attempt needs. `gateway` is optional so bare test
+ * fakes stay two-line objects; the BYOK lane requires it and fails the attempt
+ * loudly when the host's binding lacks it. */
+export type WorkersAiBinding = {
+  run(model: string, body: unknown): Promise<unknown>;
+  gateway?(gatewayId: string): CloudflareAiGatewayBinding;
+};
+
+/** `env.AI.gateway(id)` — the universal-endpoint door used by the BYOK lane. */
+export type CloudflareAiGatewayBinding = {
+  run(data: {
+    provider: string;
+    endpoint: string;
+    headers: Record<string, string>;
+    query: unknown;
+  }): Promise<Response>;
+};
+
+/**
+ * How one attempt travels through the Cloudflare AI Gateway.
+ *
+ * - `unified`: `env.AI.run` partner models on Cloudflare's unified billing.
+ * - `byok`: the gateway's universal endpoint with OUR OpenAI key. Same
+ *   gateway (analytics, logs), two differences that matter: OpenAI's own
+ *   prompt-cache discount lands on our bill directly (unified billing meters
+ *   cached tokens at the uncached price), and the gateway's RESPONSE cache
+ *   works on this path (it never engages for partner models).
+ *   `responseCacheTtlSeconds` opts a deployment into that response cache —
+ *   replayed answers, near-zero cost; only sane where conversations are
+ *   synthetic (e2e/preview), never prd.
+ */
+export type CloudflareAiGatewayTransport =
+  | { kind: "unified" }
+  | {
+      kind: "byok";
+      gatewayId: string;
+      openaiApiKey: string;
+      /** OpenAI `prompt_cache_key`: stable per agent stream so repeated turns
+       * route to the same provider-side prompt-cache shard. */
+      openaiPromptCacheKey?: string;
+      responseCacheTtlSeconds?: number;
+    };
 
 type WorkersAiCompletion = {
   /** Assistant text — concatenated across chunks for streamed responses. */
@@ -40,12 +80,20 @@ export async function runWorkersAiAttempt(input: {
   messages: { role: "system" | "user" | "assistant"; content: string }[];
   model: string;
   onChunk: (chunk: unknown, index: number) => Promise<void>;
+  /** Defaults to unified billing when omitted (bare test hosts, non-OpenAI models). */
+  transport?: CloudflareAiGatewayTransport;
 }): Promise<WorkersAiCompletion> {
   const deadline = startDeadline({
     deadlineMs: input.deadlineMs,
     message: `LLM attempt timed out after ${input.deadlineMs / 60_000} minutes.`,
   });
   try {
+    const transport = input.transport ?? { kind: "unified" };
+    // BYOK carries an OpenAI key, so only OpenAI models can ride it; other
+    // vendors' models fall back to unified billing rather than failing.
+    if (transport.kind === "byok" && input.model.startsWith("openai/")) {
+      return await runByokAttempt({ ...input, deadline, transport });
+    }
     const raw = await deadline.race(
       input.ai.run(input.model, {
         messages: input.messages,
@@ -64,6 +112,105 @@ export async function runWorkersAiAttempt(input: {
   } finally {
     deadline.clear();
   }
+}
+
+/**
+ * The BYOK lane: dial the gateway's universal endpoint with our OpenAI key
+ * and drain the SSE response. A response-cache HIT replays the recorded SSE
+ * byte-identically, so the drain (and the caller's chunk journaling) is the
+ * same code either way; the verdict rides `cloudflareAiGatewayResponseCacheStatus`
+ * on the raw-response evidence.
+ */
+async function runByokAttempt(input: {
+  ai: WorkersAiBinding;
+  deadline: { race<T>(work: Promise<T>): Promise<T> };
+  messages: { role: "system" | "user" | "assistant"; content: string }[];
+  model: string;
+  onChunk: (chunk: unknown, index: number) => Promise<void>;
+  transport: Extract<CloudflareAiGatewayTransport, { kind: "byok" }>;
+}): Promise<WorkersAiCompletion> {
+  const { transport } = input;
+  const gateway = input.ai.gateway?.(transport.gatewayId);
+  if (gateway === undefined) {
+    throw new Error("AI binding does not expose gateway(); BYOK transport unavailable.");
+  }
+  const body = {
+    model: input.model.replace(/^openai\//, ""),
+    messages: input.messages,
+    stream: true,
+    ...openAiReasoningExtras(input.model),
+    ...(transport.openaiPromptCacheKey === undefined
+      ? {}
+      : { prompt_cache_key: transport.openaiPromptCacheKey }),
+  };
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${transport.openaiApiKey}`,
+    "content-type": "application/json",
+  };
+  const ttlSeconds = transport.responseCacheTtlSeconds;
+  if (ttlSeconds !== undefined) {
+    headers["cf-aig-cache-ttl"] = String(ttlSeconds);
+    headers["cf-aig-cache-key"] = await cloudflareAiGatewayResponseCacheKey(body);
+  }
+  const response = await input.deadline.race(
+    gateway.run({ provider: "openai", endpoint: "chat/completions", headers, query: body }),
+  );
+  if (!response.ok || response.body === null) {
+    const detail = await input.deadline.race(response.text()).catch(() => "");
+    throw new Error(
+      `AI Gateway BYOK request failed with status ${response.status}: ${detail.slice(0, 500)}`,
+    );
+  }
+  const cacheStatus = response.headers.get("cf-aig-cache-status");
+  const completion = await drainSseResponse({
+    body: response.body,
+    deadline: input.deadline,
+    onChunk: input.onChunk,
+  });
+  if (cacheStatus === null) return completion;
+  return {
+    ...completion,
+    rawResponse: {
+      ...(completion.rawResponse as Record<string, unknown>),
+      cloudflareAiGatewayResponseCacheStatus: cacheStatus,
+    },
+  };
+}
+
+/** Bump to invalidate every cached response at once (prompt-format overhauls,
+ * masking-rule changes). */
+const CLOUDFLARE_AI_GATEWAY_RESPONSE_CACHE_KEY_VERSION = "cloudflare-ai-gateway-response-cache-v1";
+
+/**
+ * The custom `cf-aig-cache-key` for one request body: a hash of the body with
+ * fixture-specific identity masked out, so two e2e runs whose conversations
+ * differ ONLY in minted ids replay each other's responses.
+ *
+ * Masking is deliberately narrow — id-shaped tokens only. Over-masking would
+ * alias semantically different requests (wrong answers from cache);
+ * under-masking is just a cache miss (costs money, never correctness).
+ * Everything not masked — prompts, message text, model, sampling params —
+ * stays in the hash, so any prompt change invalidates naturally.
+ */
+export async function cloudflareAiGatewayResponseCacheKey(body: unknown): Promise<string> {
+  const masked = maskCloudflareAiGatewayResponseCacheEntropy(JSON.stringify(body));
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`${CLOUDFLARE_AI_GATEWAY_RESPONSE_CACHE_KEY_VERSION}:${masked}`),
+  );
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+/** The masking half of the cache key, separated for tests. Masks: project ids,
+ * agent paths, signed-URL signature/expiry params, and the OpenAI
+ * `prompt_cache_key` (which is per-agent BY DESIGN — see LlmTransportConfig —
+ * and would otherwise defeat the cross-fixture cache it rides inside). */
+export function maskCloudflareAiGatewayResponseCacheEntropy(serialized: string): string {
+  return serialized
+    .replace(/prj_[0-9a-f]{32}/g, "prj_MASKED")
+    .replace(/\/agents\/[A-Za-z0-9._/-]*/g, "/agents/MASKED")
+    .replace(/([?&](?:signature|sig|expires|exp|token|key)=)[^"&\\\s]+/gi, "$1MASKED")
+    .replace(/"prompt_cache_key":"[^"]*"/g, '"prompt_cache_key":"MASKED"');
 }
 
 /**

--- a/envs.ts
+++ b/envs.ts
@@ -78,6 +78,22 @@ export interface DeployedEnv {
    * no SSL-for-SaaS quota unless Cloudflare explicitly provisions it.
    */
   cloudflareForSaasProjectHostnameBases: string[];
+  /**
+   * How agent LLM turns travel through the Cloudflare AI Gateway: `unified`
+   * = partner models on Cloudflare's unified billing; `byok` = the gateway's
+   * universal endpoint with our own OpenAI key (correct prompt-cache
+   * pricing, and the only path where the gateway's response cache works).
+   */
+  cloudflareAiGatewayTransport: "unified" | "byok";
+  /**
+   * Opts the BYOK lane into the AI Gateway RESPONSE cache (whole-answer
+   * replay for byte-identical normalized requests — see
+   * cloudflareAiGatewayResponseCacheKey). Only for envs whose conversations
+   * are synthetic: previews and dev, where e2e reruns should replay
+   * yesterday's answers for free. Leave unset on prd — a real user must
+   * never receive a cached agent reply.
+   */
+  cloudflareAiGatewayResponseCacheTtlSeconds?: number;
   /** IDs of the Cloudflare resources this env owns (created once by ensure-resources). */
   resources: {
     /** KV: slug -> project-id cache in front of the auth project directory. */
@@ -107,6 +123,10 @@ function previewSlot(n: number, resources: DeployedEnv["resources"]): DeployedEn
     authBaseUrl: `https://auth.iterate-preview-${n}.com`,
     projectHostnameBases: [`iterate-preview-${n}.app`],
     cloudflareForSaasProjectHostnameBases: [],
+    cloudflareAiGatewayTransport: "byok",
+    // 7 days: long enough that overnight marathons and PR-lifetime reruns
+    // replay each other, short enough that stale answers age out on their own.
+    cloudflareAiGatewayResponseCacheTtlSeconds: 7 * 24 * 60 * 60,
     resources,
   };
 }
@@ -123,6 +143,9 @@ export const envs = {
     authBaseUrl: "https://auth.iterate.com",
     projectHostnameBases: ["iterate.app"],
     cloudflareForSaasProjectHostnameBases: ["iterate.app"],
+    // Unified billing for now; flipping prd to BYOK (still without the
+    // response cache) is a deliberate follow-up once previews have soaked.
+    cloudflareAiGatewayTransport: "unified",
     resources: {
       projectDirectoryKvId: "79d78df2e83b46d2b9083533e9f189c4",
       workerBuildCacheKvId: "43306c224d364c7aa804c3ff762c4d08",


### PR DESCRIPTION
## What

Adds a **BYOK transport lane** for agent LLM turns — `env.AI.gateway(id).run()` (the gateway's universal endpoint) with our own OpenAI key — plus an opt-in **gateway response cache** that makes e2e LLM turns near-free and deterministic.

## Why

Investigated today (with Cloudflare, re the ~$550/day CI burn):

1. **Unified billing meters OpenAI-prompt-cached tokens at the uncached price** — ~6× overcharge at our ~95% prompt-cache hit rate. BYOK pockets OpenAI's cache discount directly.
2. **The gateway's response cache never engages for partner models** (verified empirically: zero hits even with forced `cacheKey`). It works perfectly on the BYOK path: `cf-aig-cache-status: HIT` replays the recorded SSE byte-identically in ~15ms at $0, streams included.
3. Benchmarked BYOK vs unified billing (8 interleaved trials each, cache off): BYOK is **not slower** — median +29% decode throughput, ~10% faster first content, much tighter TTFT tail.

## How

- **envs.ts knobs**: `cloudflareAiGatewayTransport: "unified" | "byok"` + `cloudflareAiGatewayResponseCacheTtlSeconds`. Previews + local dev = `byok` + 7-day response cache. **prd stays `unified`** (zero behavior change on merge; the BYOK flip for prd is a deliberate follow-up after preview soak) and never gets the response cache — a real user must never receive a cached agent reply.
- **Cache key normalization**: `cf-aig-cache-key` = SHA-256 of the request body with minted identity masked — project ids, agent paths, signed-URL `sig`/`exp`, `prompt_cache_key` — version-salted (`cloudflare-ai-gateway-response-cache-v1`) so one bump invalidates everything. Two e2e runs whose conversations differ only in minted ids share cache entries; any prompt change misses naturally. Under-masking costs a miss, never correctness.
- **OpenAI prompt cache** (the *other* cache — identifiers keep them apart everywhere): `prompt_cache_key` pinned per agent stream (`projectId:agentPath`) so multi-turn prompts route to the same provider-side shard.
- **Evidence**: `cloudflareAiGatewayResponseCacheStatus` (HIT/MISS) rides inside `llm-request-completed`'s `rawResponse` — visible in the stream inspector.

## Proof

- `agent-response-cache.e2e.test.ts`: creates two projects; the second one's onboarding birth turn must be a `HIT` with a **byte-identical greeting**. Passing against local dev (20s for both turns), which also proves `env.AI.gateway()` under the vite dev server.
- 11 new transport unit tests (BYOK request shape, cache headers on/off, non-OpenAI fallback, loud non-2xx failure, masking properties).
- Preview e2e on this PR is the deployed proof — the new spec runs in the lane.

## Notes

- First run per prompt-version still pays full price; cache is best-effort (early eviction degrades to cost, not failure).
- `itx.integrations.cf.ai.run()` silently drops its 3rd (options) arg — pre-existing, untouched here, worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all agent LLM calls are routed in preview/local (BYOK + whole-answer response cache); prd behavior is unchanged, but cache-key masking mistakes could theoretically serve wrong replies in synthetic envs only.
> 
> **Overview**
> Adds a **BYOK path** for agent LLM turns: OpenAI models can go through `env.AI.gateway()` with the deployment’s API key instead of unified Workers AI billing, while non-OpenAI models still use `env.AI.run`.
> 
> **Deployment wiring:** `envs.ts` sets previews and local dev to `byok` with a **7-day gateway response cache**; **prd stays `unified`** with no response cache. Wrangler generation and `AppConfig` expose `APP_CONFIG_CLOUDFLARE_AI_GATEWAY__*` for transport, gateway id, and optional TTL.
> 
> **Runtime behavior:** The agent DO resolves transport per attempt (BYOK includes per-stream `prompt_cache_key` and optional `cf-aig-cache-ttl` / `cf-aig-cache-key`). Cache keys hash a **masked** request body (project ids, agent paths, signed URL params, `prompt_cache_key`) so synthetic e2e runs with different minted identity can share entries; `cloudflareAiGatewayResponseCacheStatus` is recorded on completion evidence.
> 
> **Tests:** New transport unit tests for BYOK request shape, cache on/off, fallbacks, and masking; new e2e asserts a second onboarding project gets a cache **HIT** and the same greeting as the first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae613000388daaf7229ae0edeeec2fea70141e27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +192 -2 | +118 -1 🟩🟩🟩⬜⬜ |
| Tests | +255 -1 | +223 -1 🟩🟩🟩🟩🟩 |
| CI & scripts | +14 -0 | +10 -0 🟩⬜⬜⬜⬜ |
| Other | +23 -0 | +5 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+484 -3** | **+356 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 537d6bc and ae61300, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-10T13:39:53.761Z",
      "headSha": "ae613000388daaf7229ae0edeeec2fea70141e27",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/364041029491909",
      "shortSha": "ae61300",
      "cleanupDurationMs": 8826,
      "deployDurationMs": 78303,
      "testDurationMs": 166344,
      "testRetries": "3 retried: itx > Top-level RpcTarget live capabilities dispatch by member path (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · the seeded hello and counter apps work after creating a project (specs x1)",
      "workerSizeKib": 15747.95,
      "workerGzipKib": 4259,
      "mainWorkerGzipKib": 4257.29
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-10T13:39:45.932Z",
      "headSha": "ae613000388daaf7229ae0edeeec2fea70141e27",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/364041029491909",
      "shortSha": "ae61300",
      "cleanupDurationMs": 995,
      "deployDurationMs": 14213,
      "testDurationMs": 6914,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-10T13:39:47.750Z",
      "headSha": "ae613000388daaf7229ae0edeeec2fea70141e27",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/364041029491909",
      "shortSha": "ae61300",
      "cleanupDurationMs": 2811,
      "deployDurationMs": 31378,
      "testDurationMs": 505,
      "testRetries": null,
      "workerSizeKib": 4031.55,
      "workerGzipKib": 819.22,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-10T13:39:45.655Z",
      "headSha": "ae613000388daaf7229ae0edeeec2fea70141e27",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/364041029491909",
      "shortSha": "ae61300",
      "cleanupDurationMs": 714,
      "deployDurationMs": 14199,
      "testDurationMs": 16872,
      "testRetries": null,
      "workerSizeKib": 4709.94,
      "workerGzipKib": 1355.29,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `ae61300` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 819.2 KiB | 31.4s | 505ms |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/364041029491909) | 2026-07-10T13:39:47.750Z | Preview app released. |
| OS | released | `ae61300` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.16 MiB (+1.7 KiB vs main) | 78.3s | 166.3s | 3 retried: itx > Top-level RpcTarget live capabilities dispatch by member path (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · the seeded hello and counter apps work after creating a project (specs x1) | 8.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/364041029491909) | 2026-07-10T13:39:53.761Z | Preview app released. |
| Semaphore | released | `ae61300` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 440.8 KiB | 14.2s | 6.9s |  | 995ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/364041029491909) | 2026-07-10T13:39:45.932Z | Preview app released. |
| Streams Example App | released | `ae61300` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 1.32 MiB | 14.2s | 16.9s |  | 714ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/364041029491909) | 2026-07-10T13:39:45.655Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->