### PR TITLE
Human-in-the-loop egress approvals: hold rules, signed grants, iterate approve CLI

### DIFF
--- a/apps/os/e2e/vitest/egress-approvals.e2e.test.ts
+++ b/apps/os/e2e/vitest/egress-approvals.e2e.test.ts
@@ -1,0 +1,283 @@
+// Proves human-in-the-loop egress approvals end-to-end: a request matching a
+// `hold` rule parks at the Project DO egress door with the caller's fetch
+// promise open, a "human" (this test, playing the `iterate approve` CLI's
+// role over the same itx surface) grants or rejects on the project stream,
+// and the door releases the real upstream call / refuses / auto-expires.
+// Once an approval key is enrolled, grants must carry a valid P-256
+// signature over the canonical approval.v1 message — an unsigned grant is
+// ignored and only the signed one releases.
+
+import { describe, expect, test } from "vitest";
+import {
+  buildApprovalMessage,
+  bytesToBase64,
+  type HumanApprovalRequestedPayload,
+} from "../../src/domains/projects/egress-approvals.ts";
+import { waitForCondition } from "../test-support/wait-for-condition.ts";
+import { startEgressEcho } from "./itx-capability-fixtures.ts";
+import { adminSecret, withItxSession } from "./test-helpers.ts";
+
+const RULES_CONFIGURED = "events.iterate.com/project/egress-rules-configured";
+const KEY_ADDED = "events.iterate.com/project/human-approval-key-added";
+const REQUESTED = "events.iterate.com/project/human-approval-requested";
+const GRANTED = "events.iterate.com/project/human-approval-granted";
+const REJECTED = "events.iterate.com/project/human-approval-rejected";
+const SETTLED = "events.iterate.com/project/human-approval-settled";
+
+describe("egress human approvals", () => {
+  test("hold → grant releases, hold → reject refuses, short timeouts expire", async () => {
+    const echo = await startEgressEcho();
+    using session = withItxSession();
+    using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
+
+    try {
+      using project = itx.projects.create({ slug: `egress-approvals-${crypto.randomUUID()}` });
+      const stream = project.streams.get("/");
+      const echoHost = new URL(echo.url).hostname;
+
+      await stream.append({
+        type: RULES_CONFIGURED,
+        payload: {
+          rules: [
+            {
+              ruleKey: "post-echo",
+              description: "POSTs to the echo need a human",
+              match: { hosts: [echoHost], methods: ["POST"] },
+              verdict: "hold",
+              approvalTimeoutMs: 60_000,
+            },
+            {
+              ruleKey: "never-delete",
+              description: "DELETEs to the echo are always refused",
+              match: { hosts: [echoHost], methods: ["DELETE"] },
+              verdict: "deny",
+            },
+            {
+              ruleKey: "impatient",
+              description: "PUTs expire almost immediately",
+              match: { hosts: [echoHost], methods: ["PUT"] },
+              verdict: "hold",
+              approvalTimeoutMs: 1_500,
+            },
+          ],
+        },
+      });
+      await waitForCondition(
+        async () => (await project.processor.snapshot()).state.egressRules.length === 3,
+        { description: "project processor to fold the egress rules" },
+      );
+
+      // ── grant lane: the held fetch resolves with the real upstream response.
+      const heldFetch = project.egress.fetch(
+        new Request(echo.url, {
+          method: "POST",
+          headers: { "x-approval-proof": "hold-me" },
+          body: "please approve",
+        }),
+      );
+      const requested = await stream.waitForEvent({
+        afterOffset: 0,
+        eventTypes: [REQUESTED],
+        timeoutMs: 30_000,
+      });
+      const requestedPayload = requested.payload as HumanApprovalRequestedPayload;
+      expect(requestedPayload).toMatchObject({
+        method: "POST",
+        ruleKey: "post-echo",
+        bodyPreview: "please approve",
+        secretPaths: [],
+      });
+      expect(requestedPayload.headers["x-approval-proof"]).toBe("hold-me");
+      expect(requestedPayload.bodySha256).toMatch(/^[0-9a-f]{64}$/);
+
+      await stream.append({
+        type: GRANTED,
+        payload: { approvalRequestEventOffset: requested.offset },
+      });
+      const releasedResponse = await heldFetch;
+      expect(releasedResponse.status).toBe(200);
+      const echoed = (await releasedResponse.json()) as { headers: Record<string, string> };
+      expect(echoed.headers["x-approval-proof"]).toBe("hold-me");
+
+      const settled = await stream.waitForEvent({
+        afterOffset: requested.offset,
+        eventTypes: [SETTLED],
+        timeoutMs: 30_000,
+      });
+      expect(settled.payload).toMatchObject({
+        approvalRequestEventOffset: requested.offset,
+        status: 200,
+      });
+
+      // ── reject lane: a human refusal turns into a 403 for the caller.
+      const rejectedFetch = project.egress.fetch(
+        new Request(echo.url, { method: "POST", body: "please reject" }),
+      );
+      const rejectedRequested = await stream.waitForEvent({
+        afterOffset: settled.offset,
+        eventTypes: [REQUESTED],
+        timeoutMs: 30_000,
+      });
+      await stream.append({
+        type: REJECTED,
+        payload: { approvalRequestEventOffset: rejectedRequested.offset, reason: "human" },
+      });
+      const rejectedResponse = await rejectedFetch;
+      expect(rejectedResponse.status).toBe(403);
+      await expect(rejectedResponse.json()).resolves.toMatchObject({
+        error: "approval_rejected",
+        ruleKey: "post-echo",
+      });
+
+      // ── deny lane: refused synchronously, no approval round-trip.
+      const deniedResponse = await project.egress.fetch(
+        new Request(echo.url, { method: "DELETE" }),
+      );
+      expect(deniedResponse.status).toBe(403);
+      await expect(deniedResponse.json()).resolves.toMatchObject({
+        error: "egress_denied",
+        ruleKey: "never-delete",
+      });
+
+      // ── expiry lane: nobody answers and the hold auto-rejects.
+      const expiredResponse = await project.egress.fetch(
+        new Request(echo.url, { method: "PUT", body: "too slow" }),
+      );
+      expect(expiredResponse.status).toBe(403);
+      await expect(expiredResponse.json()).resolves.toMatchObject({
+        error: "approval_expired",
+        ruleKey: "impatient",
+      });
+      // The expiry rejection is committed before the 403 returns, so a plain
+      // page read (no live wait) must already see it.
+      const rejections = await stream.getEvents({
+        afterOffset: rejectedRequested.offset,
+        eventTypes: [REJECTED],
+      });
+      expect(rejections.map((event) => (event.payload as { reason?: string }).reason)).toContain(
+        "expired",
+      );
+    } finally {
+      await echo.close();
+    }
+  }, 120_000);
+
+  test("enrolled approval keys make unsigned grants inert; a signed grant releases", async () => {
+    const echo = await startEgressEcho();
+    using session = withItxSession();
+    using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
+
+    try {
+      using project = itx.projects.create({
+        slug: `egress-approvals-signed-${crypto.randomUUID()}`,
+      });
+      // The signed message binds the real prj_… id (what the DO verifies with).
+      const projectId = (await project.processor.snapshot()).state.createRequest!.projectId;
+      const stream = project.streams.get("/");
+      const echoHost = new URL(echo.url).hostname;
+
+      // The human's keypair — what the Secure Enclave holds on a real Mac.
+      const pair = await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
+        "sign",
+        "verify",
+      ]);
+      const publicKey = bytesToBase64(
+        new Uint8Array(await crypto.subtle.exportKey("raw", pair.publicKey)),
+      );
+      const keyId = "e2e-test-key";
+
+      await stream.append(
+        {
+          type: RULES_CONFIGURED,
+          payload: {
+            rules: [
+              {
+                ruleKey: "post-echo-signed",
+                match: { hosts: [echoHost], methods: ["POST"] },
+                verdict: "hold",
+                approvalTimeoutMs: 60_000,
+              },
+            ],
+          },
+        },
+        { type: KEY_ADDED, payload: { keyId, publicKey, label: "e2e" } },
+      );
+      await waitForCondition(
+        async () => {
+          const state = (await project.processor.snapshot()).state;
+          return state.egressRules.length === 1 && state.humanApprovalKeys.length === 1;
+        },
+        { description: "project processor to fold the rule and the approval key" },
+      );
+
+      const heldFetch = project.egress.fetch(
+        new Request(echo.url, { method: "POST", body: "sign me" }),
+      );
+      const requested = await stream.waitForEvent({
+        afterOffset: 0,
+        eventTypes: [REQUESTED],
+        timeoutMs: 30_000,
+      });
+      const requestedPayload = requested.payload as HumanApprovalRequestedPayload;
+
+      // An unsigned grant (and one with a bad signature) must NOT release.
+      await stream.append(
+        { type: GRANTED, payload: { approvalRequestEventOffset: requested.offset } },
+        {
+          type: GRANTED,
+          payload: {
+            approvalRequestEventOffset: requested.offset,
+            keyId,
+            signature: bytesToBase64(new Uint8Array(64)),
+          },
+        },
+      );
+
+      const message = buildApprovalMessage({
+        projectId,
+        approvalRequestEventOffset: requested.offset,
+        requested: requestedPayload,
+        decision: "granted",
+      });
+      const signature = bytesToBase64(
+        new Uint8Array(
+          await crypto.subtle.sign(
+            { name: "ECDSA", hash: "SHA-256" },
+            pair.privateKey,
+            message as BufferSource,
+          ),
+        ),
+      );
+      await stream.append({
+        type: GRANTED,
+        payload: { approvalRequestEventOffset: requested.offset, keyId, signature },
+      });
+
+      const releasedResponse = await heldFetch;
+      expect(releasedResponse.status).toBe(200);
+
+      // The settled event proves release happened via the SIGNED grant path:
+      // it appends strictly after the signed grant's offset. (Had either
+      // unsigned/bad grant released, settle would have landed before it.)
+      const settled = await stream.waitForEvent({
+        afterOffset: requested.offset,
+        eventTypes: [SETTLED],
+        timeoutMs: 30_000,
+      });
+      expect(settled.payload).toMatchObject({
+        approvalRequestEventOffset: requested.offset,
+        status: 200,
+      });
+      const grants = await stream.getEvents({
+        afterOffset: requested.offset,
+        eventTypes: [GRANTED],
+      });
+      const signedGrantOffset = grants.find(
+        (event) => (event.payload as { signature?: string }).signature === signature,
+      )!.offset;
+      expect(settled.offset).toBeGreaterThan(signedGrantOffset);
+    } finally {
+      await echo.close();
+    }
+  }, 120_000);
+});

--- a/apps/os/src/domains/projects/egress-approvals.test.ts
+++ b/apps/os/src/domains/projects/egress-approvals.test.ts
@@ -5,9 +5,11 @@ import {
   bytesToBase64,
   canonicalJson,
   derSignatureToRaw,
+  evaluateGrant,
   matchEgressRule,
   verifyApprovalSignature,
   type EgressRule,
+  type HumanApprovalKey,
 } from "./egress-approvals.ts";
 
 const rule = (overrides: Partial<EgressRule> & Pick<EgressRule, "ruleKey">): EgressRule => ({
@@ -181,6 +183,54 @@ describe("verifyApprovalSignature", () => {
     await expect(verifyApprovalSignature({ publicKey: "AAAA", signature, message })).resolves.toBe(
       false,
     );
+  });
+
+  test("evaluateGrant: plain grants pass only until a key is enrolled; revoked keys don't count", async () => {
+    const alice = await keypair();
+    const enrolled: HumanApprovalKey = {
+      keyId: "alice",
+      publicKey: alice.publicKey,
+      label: "",
+      addedAt: "2026-01-01T00:00:00.000Z",
+      revokedAt: null,
+    };
+    const signature = await alice.sign(message);
+
+    // Phase 1 — nothing enrolled: a plain grant is accepted.
+    await expect(evaluateGrant({ grant: {}, keys: [], message })).resolves.toEqual({
+      accepted: true,
+    });
+    // Only revoked keys = nothing enrolled.
+    await expect(
+      evaluateGrant({
+        grant: {},
+        keys: [{ ...enrolled, revokedAt: "2026-01-02T00:00:00.000Z" }],
+        message,
+      }),
+    ).resolves.toEqual({ accepted: true });
+
+    // Phase 2 — a key is enrolled: unsigned/unknown/bad grants are refused...
+    await expect(evaluateGrant({ grant: {}, keys: [enrolled], message })).resolves.toMatchObject({
+      accepted: false,
+    });
+    await expect(
+      evaluateGrant({ grant: { keyId: "mallory", signature }, keys: [enrolled], message }),
+    ).resolves.toMatchObject({ accepted: false });
+    await expect(
+      evaluateGrant({ grant: { keyId: "alice" }, keys: [enrolled], message }),
+    ).resolves.toMatchObject({ accepted: false });
+    // ...a revoked key's own valid signature is refused...
+    await expect(
+      evaluateGrant({
+        grant: { keyId: "alice", signature },
+        keys: [{ ...enrolled, revokedAt: "2026-01-02T00:00:00.000Z" }],
+        message,
+      }),
+    ).resolves.toEqual({ accepted: true }); // revoked-only ⇒ back to phase 1
+    // ...and a valid signature from the enrolled key releases.
+    await expect(
+      evaluateGrant({ grant: { keyId: "alice", signature }, keys: [enrolled], message }),
+    ).resolves.toEqual({ accepted: true });
   });
 
   test("verifies a DER signature (the Secure Enclave shape) after derSignatureToRaw", async () => {

--- a/apps/os/src/domains/projects/egress-approvals.test.ts
+++ b/apps/os/src/domains/projects/egress-approvals.test.ts
@@ -1,0 +1,207 @@
+import { createPrivateKey, createSign, generateKeyPairSync } from "node:crypto";
+import { describe, expect, test } from "vitest";
+import {
+  buildApprovalMessage,
+  bytesToBase64,
+  canonicalJson,
+  derSignatureToRaw,
+  matchEgressRule,
+  verifyApprovalSignature,
+  type EgressRule,
+} from "./egress-approvals.ts";
+
+const rule = (overrides: Partial<EgressRule> & Pick<EgressRule, "ruleKey">): EgressRule => ({
+  description: "",
+  match: {},
+  verdict: "hold",
+  approvalTimeoutMs: 600_000,
+  ...overrides,
+});
+
+describe("matchEgressRule", () => {
+  const request = (overrides: Partial<Parameters<typeof matchEgressRule>[1]> = {}) => ({
+    method: "POST",
+    url: "https://api.stripe.com/v1/transfers",
+    secretPaths: [],
+    ...overrides,
+  });
+
+  test("matches host exactly and via *. wildcard, case-insensitively", () => {
+    const exact = rule({ ruleKey: "exact", match: { hosts: ["API.stripe.com"] } });
+    const wildcard = rule({ ruleKey: "wild", match: { hosts: ["*.stripe.com"] } });
+    expect(matchEgressRule([exact], request())?.ruleKey).toBe("exact");
+    expect(matchEgressRule([wildcard], request())?.ruleKey).toBe("wild");
+    // The wildcard needs a subdomain: bare stripe.com is not *.stripe.com.
+    expect(matchEgressRule([wildcard], request({ url: "https://stripe.com/x" }))).toBeUndefined();
+    expect(matchEgressRule([exact], request({ url: "https://evil.com/x" }))).toBeUndefined();
+    // Suffix tricks don't count as subdomains.
+    expect(
+      matchEgressRule([wildcard], request({ url: "https://notstripe.com/x" })),
+    ).toBeUndefined();
+  });
+
+  test("matches methods case-insensitively and pathPrefix literally", () => {
+    const posts = rule({ ruleKey: "posts", match: { methods: ["post", "DELETE"] } });
+    expect(matchEgressRule([posts], request())?.ruleKey).toBe("posts");
+    expect(matchEgressRule([posts], request({ method: "GET" }))).toBeUndefined();
+
+    const path = rule({ ruleKey: "path", match: { pathPrefix: "/v1/transfers" } });
+    expect(matchEgressRule([path], request())?.ruleKey).toBe("path");
+    expect(
+      matchEgressRule([path], request({ url: "https://api.stripe.com/v1/charges" })),
+    ).toBeUndefined();
+  });
+
+  test("matches on referenced secret paths regardless of destination", () => {
+    const secret = rule({ ruleKey: "secret", match: { secretPaths: ["/secrets/stripe/prod"] } });
+    expect(
+      matchEgressRule(
+        [secret],
+        request({ url: "https://anywhere.example", secretPaths: ["/secrets/stripe/prod"] }),
+      )?.ruleKey,
+    ).toBe("secret");
+    expect(matchEgressRule([secret], request())).toBeUndefined();
+  });
+
+  test("first match wins over the ordered list; matchers are conjunctive", () => {
+    const both = rule({
+      ruleKey: "both",
+      match: { hosts: ["api.stripe.com"], methods: ["POST"] },
+      verdict: "deny",
+    });
+    const fallback = rule({ ruleKey: "fallback", match: { hosts: ["api.stripe.com"] } });
+    expect(matchEgressRule([both, fallback], request())?.ruleKey).toBe("both");
+    expect(matchEgressRule([both, fallback], request({ method: "GET" }))?.ruleKey).toBe("fallback");
+    // A rule with an empty match object matches everything.
+    expect(matchEgressRule([rule({ ruleKey: "all" })], request())?.ruleKey).toBe("all");
+  });
+});
+
+describe("canonical approval message", () => {
+  test("canonicalJson is key-order independent, recursively", () => {
+    expect(canonicalJson({ b: 1, a: { d: [{ z: 1, y: 2 }], c: 3 } })).toBe(
+      canonicalJson({ a: { c: 3, d: [{ y: 2, z: 1 }] }, b: 1 }),
+    );
+  });
+
+  const requested = {
+    method: "POST",
+    url: "https://api.stripe.com/v1/transfers",
+    headers: { authorization: 'Bearer getSecret({ path: "/secrets/stripe/prod" })' },
+    bodySha256: "9c56cc51b374c3ba189210d5b6d4bf57790d351c96c47c02190ecf1e430ba0aa",
+    secretPaths: ["/secrets/stripe/prod"],
+  };
+
+  test("is deterministic and binds every covered field", () => {
+    const message = (overrides: Partial<Parameters<typeof buildApprovalMessage>[0]> = {}) =>
+      new TextDecoder().decode(
+        buildApprovalMessage({
+          projectId: "prj_1",
+          approvalRequestEventOffset: 42,
+          requested,
+          decision: "granted",
+          ...overrides,
+        }),
+      );
+    expect(message()).toBe(message());
+    expect(message({ decision: "rejected" })).not.toBe(message());
+    expect(message({ approvalRequestEventOffset: 43 })).not.toBe(message());
+    expect(message({ projectId: "prj_2" })).not.toBe(message());
+    expect(message({ requested: { ...requested, url: "https://evil.example" } })).not.toBe(
+      message(),
+    );
+  });
+});
+
+describe("verifyApprovalSignature", () => {
+  async function keypair() {
+    const pair = await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
+      "sign",
+      "verify",
+    ]);
+    const publicKey = bytesToBase64(
+      new Uint8Array(await crypto.subtle.exportKey("raw", pair.publicKey)),
+    );
+    const sign = async (message: Uint8Array) =>
+      bytesToBase64(
+        new Uint8Array(
+          await crypto.subtle.sign(
+            { name: "ECDSA", hash: "SHA-256" },
+            pair.privateKey,
+            message as BufferSource,
+          ),
+        ),
+      );
+    return { pair, publicKey, sign };
+  }
+
+  const message = buildApprovalMessage({
+    projectId: "prj_1",
+    approvalRequestEventOffset: 7,
+    requested: {
+      method: "DELETE",
+      url: "https://api.example.com/prod-db",
+      headers: {},
+      bodySha256: null,
+      secretPaths: [],
+    },
+    decision: "granted",
+  });
+
+  test("accepts a valid signature and refuses tampering, wrong keys, and garbage", async () => {
+    const alice = await keypair();
+    const mallory = await keypair();
+    const signature = await alice.sign(message);
+
+    await expect(
+      verifyApprovalSignature({ publicKey: alice.publicKey, signature, message }),
+    ).resolves.toBe(true);
+
+    const tampered = buildApprovalMessage({
+      projectId: "prj_1",
+      approvalRequestEventOffset: 8,
+      requested: {
+        method: "DELETE",
+        url: "https://api.example.com/prod-db",
+        headers: {},
+        bodySha256: null,
+        secretPaths: [],
+      },
+      decision: "granted",
+    });
+    await expect(
+      verifyApprovalSignature({ publicKey: alice.publicKey, signature, message: tampered }),
+    ).resolves.toBe(false);
+    await expect(
+      verifyApprovalSignature({ publicKey: mallory.publicKey, signature, message }),
+    ).resolves.toBe(false);
+    await expect(
+      verifyApprovalSignature({ publicKey: alice.publicKey, signature: "not-base64!!", message }),
+    ).resolves.toBe(false);
+    await expect(verifyApprovalSignature({ publicKey: "AAAA", signature, message })).resolves.toBe(
+      false,
+    );
+  });
+
+  test("verifies a DER signature (the Secure Enclave shape) after derSignatureToRaw", async () => {
+    // Mirror the enclave pipeline with node:crypto, which emits DER natively.
+    const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+    const publicKeyRaw = new Uint8Array(
+      // SPKI for P-256 is a fixed 26-byte header followed by the 65-byte point.
+      publicKey.export({ format: "der", type: "spki" }).subarray(-65),
+    );
+    const signer = createSign("SHA256");
+    signer.update(message);
+    const der = new Uint8Array(
+      signer.sign({ key: createPrivateKey(privateKey.export({ format: "pem", type: "pkcs8" })) }),
+    );
+
+    await expect(
+      verifyApprovalSignature({
+        publicKey: bytesToBase64(publicKeyRaw),
+        signature: bytesToBase64(derSignatureToRaw(der)),
+        message,
+      }),
+    ).resolves.toBe(true);
+  });
+});

--- a/apps/os/src/domains/projects/egress-approvals.ts
+++ b/apps/os/src/domains/projects/egress-approvals.ts
@@ -3,25 +3,26 @@ import { z } from "zod";
 // =============================================================================
 // Human-in-the-loop egress approvals.
 //
-// Pure policy + crypto helpers for the egress approval gate in
-// project-durable-object.ts. Two artifacts live here:
+// The whole idea: egress rules are project state; a held request is an open
+// fetch promise plus a `human-approval-requested` event; that event's OFFSET
+// is the held request's identity; humans answer by appending events; and
+// once approval keys are enrolled, a grant is unforgeable without the
+// enrolled private key. The lifecycle:
 //
-// 1. Egress rules — project-state data (set wholesale via
-//    `project/egress-rules-configured`) matched against every outbound
-//    request at the Project DO's egress decision point. A matched `hold`
-//    rule parks the request until a human grants or rejects it on the
-//    project stream; `deny` refuses it outright.
+//   requested ──(signed grant)──▶ granted ──▶ released ──▶ settled
+//        │
+//        ├──(human)────▶ rejected (reason: human)
+//        └──(timeout)──▶ rejected (reason: expired)
 //
-// 2. The approval signature scheme — a grant may carry an ECDSA P-256
-//    signature over a canonical message reconstructable by BOTH signer and
-//    verifier from the `human-approval-requested` event alone. Once a
-//    project has enrolled approval keys, grants MUST verify; rejections
-//    never require a signature (deny is the fail-safe direction).
+// This file is the pure half — rule matching and the signature scheme — used
+// by the gate in project-durable-object.ts (orchestration) and the
+// `iterate approve` CLI (the human's signer).
 //
-// The signature is computed over the canonical JSON bytes (not a detached
-// digest): WebCrypto's ECDSA and the Secure Enclave's
-// `ecdsaSignatureMessageX962SHA256` both hash the message internally, so
-// signer and verifier only ever exchange the raw 64-byte r‖s signature.
+// The signature covers canonical JSON bytes reconstructable by BOTH sides
+// from the requested event alone (no detached digest): WebCrypto's ECDSA and
+// the Secure Enclave's `ecdsaSignatureMessageX962SHA256` both hash the
+// message internally, so signer and verifier only ever exchange the raw
+// 64-byte r‖s signature.
 // =============================================================================
 
 /** Matchers of one egress rule. Absent fields match everything. */
@@ -90,8 +91,24 @@ export const HumanApprovalRequestedPayload = z.object({
 export type HumanApprovalRequestedPayload = z.output<typeof HumanApprovalRequestedPayload>;
 
 /** A held request's identity is the offset of its requested event — no minted ids. */
-export const HumanApprovalResolutionPayload = z.object({
+const HumanApprovalResolutionPayload = z.object({
   approvalRequestEventOffset: z.number().int().nonnegative(),
+});
+
+export const HumanApprovalGrantedPayload = HumanApprovalResolutionPayload.extend({
+  keyId: z.string().optional(),
+  /** Base64 raw 64-byte r‖s ECDSA P-256 signature over the canonical approval message. */
+  signature: z.string().optional(),
+});
+
+export const HumanApprovalRejectedPayload = HumanApprovalResolutionPayload.extend({
+  reason: z.enum(["human", "expired"]),
+  note: z.string().optional(),
+});
+
+export const HumanApprovalSettledPayload = HumanApprovalResolutionPayload.extend({
+  status: z.number().int().optional(),
+  error: z.string().optional(),
 });
 
 // -----------------------------------------------------------------------------
@@ -200,6 +217,31 @@ export function buildApprovalMessage(input: {
 // -----------------------------------------------------------------------------
 // Signature verification (WebCrypto, P-256, raw 64-byte r‖s signatures).
 // -----------------------------------------------------------------------------
+
+/**
+ * THE grant-acceptance policy, in one place: with no active keys enrolled a
+ * plain grant is accepted (phase 1); once any active key exists, a grant is
+ * accepted only with a valid signature from one of them. Everything else is
+ * ignored — never rejected — so a bad grant can't kill a hold that a good
+ * one (or a human rejection) would settle.
+ */
+export async function evaluateGrant(input: {
+  grant: { keyId?: string; signature?: string };
+  keys: readonly HumanApprovalKey[];
+  message: Uint8Array;
+}): Promise<{ accepted: true } | { accepted: false; reason: string }> {
+  const activeKeys = input.keys.filter((key) => key.revokedAt === null);
+  if (activeKeys.length === 0) return { accepted: true };
+  const key = activeKeys.find((candidate) => candidate.keyId === input.grant.keyId);
+  if (key === undefined) return { accepted: false, reason: "unknown or missing keyId" };
+  if (input.grant.signature === undefined) return { accepted: false, reason: "missing signature" };
+  const verified = await verifyApprovalSignature({
+    publicKey: key.publicKey,
+    signature: input.grant.signature,
+    message: input.message,
+  });
+  return verified ? { accepted: true } : { accepted: false, reason: "invalid signature" };
+}
 
 /** Verify a raw r‖s ECDSA-P256-SHA256 signature over the canonical message bytes. */
 export async function verifyApprovalSignature(input: {

--- a/apps/os/src/domains/projects/egress-approvals.ts
+++ b/apps/os/src/domains/projects/egress-approvals.ts
@@ -89,8 +89,6 @@ export const HumanApprovalRequestedPayload = z.object({
 
 export type HumanApprovalRequestedPayload = z.output<typeof HumanApprovalRequestedPayload>;
 
-type ApprovalDecision = "granted" | "rejected";
-
 /** A held request's identity is the offset of its requested event — no minted ids. */
 export const HumanApprovalResolutionPayload = z.object({
   approvalRequestEventOffset: z.number().int().nonnegative(),
@@ -182,7 +180,7 @@ export function buildApprovalMessage(input: {
     HumanApprovalRequestedPayload,
     "method" | "url" | "headers" | "bodySha256" | "secretPaths"
   >;
-  decision: ApprovalDecision;
+  decision: "granted" | "rejected";
 }): Uint8Array {
   return new TextEncoder().encode(
     canonicalJson({

--- a/apps/os/src/domains/projects/egress-approvals.ts
+++ b/apps/os/src/domains/projects/egress-approvals.ts
@@ -1,0 +1,299 @@
+import { z } from "zod";
+
+// =============================================================================
+// Human-in-the-loop egress approvals.
+//
+// Pure policy + crypto helpers for the egress approval gate in
+// project-durable-object.ts. Two artifacts live here:
+//
+// 1. Egress rules — project-state data (set wholesale via
+//    `project/egress-rules-configured`) matched against every outbound
+//    request at the Project DO's egress decision point. A matched `hold`
+//    rule parks the request until a human grants or rejects it on the
+//    project stream; `deny` refuses it outright.
+//
+// 2. The approval signature scheme — a grant may carry an ECDSA P-256
+//    signature over a canonical message reconstructable by BOTH signer and
+//    verifier from the `human-approval-requested` event alone. Once a
+//    project has enrolled approval keys, grants MUST verify; rejections
+//    never require a signature (deny is the fail-safe direction).
+//
+// The signature is computed over the canonical JSON bytes (not a detached
+// digest): WebCrypto's ECDSA and the Secure Enclave's
+// `ecdsaSignatureMessageX962SHA256` both hash the message internally, so
+// signer and verifier only ever exchange the raw 64-byte r‖s signature.
+// =============================================================================
+
+/** Matchers of one egress rule. Absent fields match everything. */
+export const EgressRuleMatch = z.object({
+  /** Hostnames, with `*.` wildcard support: "api.stripe.com", "*.stripe.com". */
+  hosts: z.array(z.string()).optional(),
+  /** HTTP methods (case-insensitive): ["POST", "DELETE"]. */
+  methods: z.array(z.string()).optional(),
+  /** URL path prefix: "/v1/transfers". */
+  pathPrefix: z.string().optional(),
+  /**
+   * Secret paths the request references (getSecret placeholders). This is the
+   * secret-aware trigger: "any request spending /secrets/stripe/prod needs a
+   * human", regardless of destination.
+   */
+  secretPaths: z.array(z.string()).optional(),
+});
+
+export const EgressRule = z.object({
+  /** Caller-provided identifier; the requested event names the rule that caught it. */
+  ruleKey: z.string().min(1),
+  /** Human-readable "why was this caught" line, shown on the approval prompt. */
+  description: z.string().default(""),
+  match: EgressRuleMatch.default({}),
+  verdict: z.enum(["hold", "deny"]),
+  /** How long a held request waits for a human before auto-rejecting. */
+  approvalTimeoutMs: z.number().int().positive().max(3_600_000).default(600_000),
+});
+
+export type EgressRule = z.output<typeof EgressRule>;
+
+/** One enrolled approval public key as reduced onto project processor state. */
+export const HumanApprovalKey = z.object({
+  keyId: z.string(),
+  /** Base64 of the uncompressed P-256 public point (65 bytes, 0x04‖X‖Y). */
+  publicKey: z.string(),
+  label: z.string().default(""),
+  addedAt: z.string(),
+  revokedAt: z.string().nullable().default(null),
+});
+
+export type HumanApprovalKey = z.output<typeof HumanApprovalKey>;
+
+/**
+ * The `human-approval-requested` payload fields the approval signature
+ * covers. Everything here is placeholder-form (getSecret(...) references,
+ * never material) — what the human approves is "a request that will spend
+ * this secret", and the material never reaches the approval device.
+ */
+export const HumanApprovalRequestedPayload = z.object({
+  method: z.string(),
+  url: z.string(),
+  /** All headers as they would be forwarded, placeholder form. */
+  headers: z.record(z.string(), z.string()),
+  /** Hex SHA-256 of the body bytes; null for bodyless requests. */
+  bodySha256: z.string().nullable().default(null),
+  /** First ~2KB of a UTF-8 body, for the approval UI only (NOT signed). */
+  bodyPreview: z.string().nullable().default(null),
+  /** Secret paths the request references — the "spends this secret" headline. */
+  secretPaths: z.array(z.string()).default([]),
+  /** The rule that caught the request. */
+  ruleKey: z.string(),
+  expiresAt: z.string(),
+});
+
+export type HumanApprovalRequestedPayload = z.output<typeof HumanApprovalRequestedPayload>;
+
+export type ApprovalDecision = "granted" | "rejected";
+
+/** A held request's identity is the offset of its requested event — no minted ids. */
+export const HumanApprovalResolutionPayload = z.object({
+  approvalRequestEventOffset: z.number().int().nonnegative(),
+});
+
+// -----------------------------------------------------------------------------
+// Rule matching.
+// -----------------------------------------------------------------------------
+
+/**
+ * First-match-wins over the ordered rule list; undefined means "allow".
+ * Matching is conjunctive within a rule: every present matcher must accept.
+ */
+export function matchEgressRule(
+  rules: readonly EgressRule[],
+  request: { method: string; url: string; secretPaths: readonly string[] },
+): EgressRule | undefined {
+  const url = new URL(request.url);
+  const method = request.method.toUpperCase();
+  return rules.find((rule) => {
+    const match = rule.match;
+    if (match.hosts !== undefined && !match.hosts.some((host) => hostMatches(url.hostname, host))) {
+      return false;
+    }
+    if (
+      match.methods !== undefined &&
+      !match.methods.some((candidate) => candidate.toUpperCase() === method)
+    ) {
+      return false;
+    }
+    if (match.pathPrefix !== undefined && !url.pathname.startsWith(match.pathPrefix)) {
+      return false;
+    }
+    if (
+      match.secretPaths !== undefined &&
+      !match.secretPaths.some((path) => request.secretPaths.includes(path))
+    ) {
+      return false;
+    }
+    return true;
+  });
+}
+
+/** "api.stripe.com" matches exactly; "*.stripe.com" matches any single-or-deeper subdomain. */
+function hostMatches(hostname: string, pattern: string): boolean {
+  const host = hostname.toLowerCase();
+  const candidate = pattern.toLowerCase();
+  if (candidate.startsWith("*."))
+    return host.endsWith(candidate.slice(1)) && host !== candidate.slice(2);
+  return host === candidate;
+}
+
+// -----------------------------------------------------------------------------
+// Canonical approval message (approval.v1).
+// -----------------------------------------------------------------------------
+
+/**
+ * JSON with recursively sorted object keys — the canonical form both signer
+ * and verifier serialize independently. Deterministic forever: a signature's
+ * meaning must stay recomputable from the requested event long after the fact.
+ */
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortKeysDeep(value));
+}
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+        .map(([key, entry]) => [key, sortKeysDeep(entry)]),
+    );
+  }
+  return value;
+}
+
+/**
+ * The exact bytes an approval signature covers. Reconstructable by both
+ * sides from the requested event alone: the CLI builds it from the event it
+ * received, the Project DO from the payload it appended. `bodyPreview` and
+ * `expiresAt` are deliberately excluded — the preview is a UI hint (the
+ * signature covers the body via its hash) and expiry is enforced server-side.
+ */
+export function buildApprovalMessage(input: {
+  projectId: string;
+  approvalRequestEventOffset: number;
+  requested: Pick<
+    HumanApprovalRequestedPayload,
+    "method" | "url" | "headers" | "bodySha256" | "secretPaths"
+  >;
+  decision: ApprovalDecision;
+}): Uint8Array {
+  return new TextEncoder().encode(
+    canonicalJson({
+      v: "approval.v1",
+      projectId: input.projectId,
+      approvalRequestEventOffset: input.approvalRequestEventOffset,
+      method: input.requested.method,
+      url: input.requested.url,
+      headers: input.requested.headers,
+      bodySha256: input.requested.bodySha256,
+      secretPaths: input.requested.secretPaths,
+      decision: input.decision,
+    }),
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Signature verification (WebCrypto, P-256, raw 64-byte r‖s signatures).
+// -----------------------------------------------------------------------------
+
+/** Verify a raw r‖s ECDSA-P256-SHA256 signature over the canonical message bytes. */
+export async function verifyApprovalSignature(input: {
+  /** Base64 uncompressed P-256 public point (65 bytes). */
+  publicKey: string;
+  /** Base64 raw 64-byte r‖s signature. */
+  signature: string;
+  message: Uint8Array;
+}): Promise<boolean> {
+  let publicKeyBytes: Uint8Array;
+  let signatureBytes: Uint8Array;
+  try {
+    publicKeyBytes = base64ToBytes(input.publicKey);
+    signatureBytes = base64ToBytes(input.signature);
+  } catch {
+    return false;
+  }
+  if (publicKeyBytes.length !== 65 || publicKeyBytes[0] !== 0x04) return false;
+  if (signatureBytes.length !== 64) return false;
+  let key: CryptoKey;
+  try {
+    key = await crypto.subtle.importKey(
+      "raw",
+      publicKeyBytes as BufferSource,
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["verify"],
+    );
+  } catch {
+    return false;
+  }
+  return crypto.subtle.verify(
+    { name: "ECDSA", hash: "SHA-256" },
+    key,
+    signatureBytes as BufferSource,
+    input.message as BufferSource,
+  );
+}
+
+/** A key's id is a fingerprint of its public point: first 16 hex chars of its SHA-256. */
+export async function approvalKeyId(publicKeyBase64: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    base64ToBytes(publicKeyBase64) as BufferSource,
+  );
+  return bytesToHex(new Uint8Array(digest)).slice(0, 16);
+}
+
+/**
+ * DER/ASN.1 ECDSA signature → raw 64-byte r‖s. The Secure Enclave (and most
+ * non-WebCrypto signers) emit DER; the platform only ever stores raw.
+ */
+export function derSignatureToRaw(der: Uint8Array): Uint8Array {
+  const read = (offset: number): { bytes: Uint8Array; next: number } => {
+    if (der[offset] !== 0x02) throw new Error("invalid DER signature: expected INTEGER");
+    const length = der[offset + 1]!;
+    const start = offset + 2;
+    let bytes = der.slice(start, start + length);
+    // Strip the sign-padding zero byte; left-pad back to 32.
+    while (bytes.length > 32 && bytes[0] === 0x00) bytes = bytes.slice(1);
+    if (bytes.length > 32) throw new Error("invalid DER signature: integer too long");
+    const padded = new Uint8Array(32);
+    padded.set(bytes, 32 - bytes.length);
+    return { bytes: padded, next: start + length };
+  };
+  if (der[0] !== 0x30) throw new Error("invalid DER signature: expected SEQUENCE");
+  // Sequence length may be long-form (0x81) for signatures crossing 127 bytes.
+  const headerLength = der[1] === 0x81 ? 3 : 2;
+  const r = read(headerLength);
+  const s = read(r.next);
+  const raw = new Uint8Array(64);
+  raw.set(r.bytes, 0);
+  raw.set(s.bytes, 32);
+  return raw;
+}
+
+export async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes as BufferSource);
+  return bytesToHex(new Uint8Array(digest));
+}
+
+export function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}

--- a/apps/os/src/domains/projects/egress-approvals.ts
+++ b/apps/os/src/domains/projects/egress-approvals.ts
@@ -25,7 +25,7 @@ import { z } from "zod";
 // =============================================================================
 
 /** Matchers of one egress rule. Absent fields match everything. */
-export const EgressRuleMatch = z.object({
+const EgressRuleMatch = z.object({
   /** Hostnames, with `*.` wildcard support: "api.stripe.com", "*.stripe.com". */
   hosts: z.array(z.string()).optional(),
   /** HTTP methods (case-insensitive): ["POST", "DELETE"]. */
@@ -89,7 +89,7 @@ export const HumanApprovalRequestedPayload = z.object({
 
 export type HumanApprovalRequestedPayload = z.output<typeof HumanApprovalRequestedPayload>;
 
-export type ApprovalDecision = "granted" | "rejected";
+type ApprovalDecision = "granted" | "rejected";
 
 /** A held request's identity is the offset of its requested event — no minted ids. */
 export const HumanApprovalResolutionPayload = z.object({

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -349,20 +349,32 @@ export class ProjectDurableObject extends DurableObject<Env> {
       body: bodyBytes as BodyInit | null,
       redirect: request.redirect,
     });
+    // Settling is bookkeeping about the outcome and must never CHANGE the
+    // outcome: a failed append logs, but the caller still gets whatever
+    // upstream truly returned (or the true upstream error).
     const settle = (payload: { status?: number; error?: string }) =>
-      stream.append({
-        type: "events.iterate.com/project/human-approval-settled",
-        idempotencyKey: `human-approval-settled:${approvalRequestEventOffset}`,
-        payload: { approvalRequestEventOffset, ...payload },
-      });
+      stream
+        .append({
+          type: "events.iterate.com/project/human-approval-settled",
+          idempotencyKey: `human-approval-settled:${approvalRequestEventOffset}`,
+          payload: { approvalRequestEventOffset, ...payload },
+        })
+        .catch((error: unknown) => {
+          console.warn("egress approval: settle append failed", {
+            approvalRequestEventOffset,
+            error,
+            projectId: this.#name.projectId,
+          });
+        });
+    let response: Response;
     try {
-      const response = await this.#egress(released);
-      await settle({ status: response.status });
-      return response;
+      response = await this.#egress(released);
     } catch (error) {
       await settle({ error: error instanceof Error ? error.message : String(error) });
       throw error;
     }
+    await settle({ status: response.status });
+    return response;
   }
 
   /**

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -389,12 +389,15 @@ export class ProjectDurableObject extends DurableObject<Env> {
         // Final sweep before declaring expiry: a verdict appended in the last
         // wait-chunk's shadow must still win — a human who granted just in
         // time is honored, not expired. Same processing path, page reads
-        // instead of live waits, until the backlog is dry.
+        // instead of live waits. The sweep is bounded to events CREATED
+        // before the deadline: the first younger event ends it, so other
+        // holds' ongoing resolutions on a busy stream can't keep an expired
+        // hold open.
         const [swept] = await stream.getEvents({
           afterOffset: cursor,
           eventTypes: resolutionEventTypes,
         });
-        if (swept === undefined) return "expired";
+        if (swept === undefined || Date.parse(swept.createdAt) > input.deadline) return "expired";
         event = swept;
       } else {
         try {

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -259,10 +259,19 @@ export class ProjectDurableObject extends DurableObject<Env> {
     return this.#holdForHumanApproval({ request, rule, secretPaths });
   }
 
-  /** The project's egress rules, from reduced state (folded before first read). */
+  #egressRulesFreshAt = 0;
+
+  /**
+   * The project's egress rules, from reduced state with BOUNDED staleness:
+   * push delivery normally keeps the fold current, but a wedged subscription
+   * must not leave policy arbitrarily stale — so at most every 5s an egress
+   * request pays one catch-up. (Grants are the trust boundary and always
+   * catch up; rules are policy, where seconds of lag are acceptable.)
+   */
   async #egressRules(): Promise<readonly EgressRule[]> {
-    if (!this.#projectProcessor.isLoaded) {
+    if (!this.#projectProcessor.isLoaded || Date.now() - this.#egressRulesFreshAt > 5_000) {
       await this.#processorHost.catchUp(ProjectProcessorContract.slug);
+      this.#egressRulesFreshAt = Date.now();
     }
     return this.#projectProcessor.currentState.egressRules;
   }
@@ -368,30 +377,43 @@ export class ProjectDurableObject extends DurableObject<Env> {
     requestedPayload: HumanApprovalRequestedPayload;
   }): Promise<"granted" | "rejected" | "expired"> {
     const stream = this.#ownStream();
+    const resolutionEventTypes = [
+      "events.iterate.com/project/human-approval-granted",
+      "events.iterate.com/project/human-approval-rejected",
+    ];
     let cursor = input.approvalRequestEventOffset;
     while (true) {
       const remaining = input.deadline - Date.now();
-      if (remaining <= 0) return "expired";
       let event;
-      try {
-        event = await stream.waitForEvent({
+      if (remaining <= 0) {
+        // Final sweep before declaring expiry: a verdict appended in the last
+        // wait-chunk's shadow must still win — a human who granted just in
+        // time is honored, not expired. Same processing path, page reads
+        // instead of live waits, until the backlog is dry.
+        const [swept] = await stream.getEvents({
           afterOffset: cursor,
-          eventTypes: [
-            "events.iterate.com/project/human-approval-granted",
-            "events.iterate.com/project/human-approval-rejected",
-          ],
-          timeoutMs: Math.min(remaining, 25_000),
+          eventTypes: resolutionEventTypes,
         });
-      } catch (error) {
-        // waitForEvent is a one-shot, not a durable waiter: chunk timeouts
-        // (and transient stream restarts) just re-arm from the same cursor.
-        if (
-          error instanceof Error &&
-          error.message.includes("Timed out waiting for stream event")
-        ) {
-          continue;
+        if (swept === undefined) return "expired";
+        event = swept;
+      } else {
+        try {
+          event = await stream.waitForEvent({
+            afterOffset: cursor,
+            eventTypes: resolutionEventTypes,
+            timeoutMs: Math.min(remaining, 25_000),
+          });
+        } catch (error) {
+          // waitForEvent is a one-shot, not a durable waiter: chunk timeouts
+          // (and transient stream restarts) just re-arm from the same cursor.
+          if (
+            error instanceof Error &&
+            error.message.includes("Timed out waiting for stream event")
+          ) {
+            continue;
+          }
+          throw error;
         }
-        throw error;
       }
 
       cursor = event.offset;

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -31,6 +31,14 @@ import { connectionFromIntegrationStreamPath } from "../integrations/utils.ts";
 import { EmailProcessor } from "../email/email-processor-implementation.ts";
 import { EmailProcessorContract } from "../email/email-processor-contract.ts";
 import type { ProjectEgressIntercept, ProjectEgressInterceptor } from "./egress.ts";
+import {
+  buildApprovalMessage,
+  matchEgressRule,
+  sha256Hex,
+  verifyApprovalSignature,
+  type EgressRule,
+  type HumanApprovalRequestedPayload,
+} from "./egress-approvals.ts";
 import { ProjectProcessorContract } from "./project-processor-contract.ts";
 import { ProjectProcessor } from "./project-processor-implementation.ts";
 import { StreamDatabase, type TouchInput } from "./stream-database.ts";
@@ -211,7 +219,252 @@ export class ProjectDurableObject extends DurableObject<Env> {
       // receive raw secret material, only getSecret(...) placeholders.
       return await this.#egressInterceptor.value(request);
     }
+    return this.#egressWithApprovalGate(request);
+  }
 
+  /**
+   * The human-approval gate in front of the egress lanes. Requests matching a
+   * `hold` rule park HERE — the caller's fetch promise stays open — until a
+   * grant/rejection lands on the project stream or the rule's timeout
+   * auto-rejects. Everything the gate sees and records is placeholder form:
+   * it runs before secret substitution, so approval events (and the approval
+   * UI reading them) can honestly say "this request spends /secrets/x"
+   * without material ever leaving the platform.
+   */
+  async #egressWithApprovalGate(request: Request): Promise<Response> {
+    const rules = await this.#egressRules();
+    if (rules.length === 0) return this.#egress(request);
+
+    // Secret references also feed rule matching (match.secretPaths); a
+    // malformed reference set is not this gate's error to report — the
+    // egress lanes below produce the canonical error response.
+    let secretPaths: string[] = [];
+    try {
+      secretPaths = secretReferencePathsFromRequest(request);
+    } catch {
+      return this.#egress(request);
+    }
+
+    const rule = matchEgressRule(rules, { method: request.method, url: request.url, secretPaths });
+    if (rule === undefined) return this.#egress(request);
+    if (rule.verdict === "deny") {
+      return approvalGateResponse({
+        code: "egress_denied",
+        detail: `Egress rule "${rule.ruleKey}" denies this request.`,
+        ruleKey: rule.ruleKey,
+      });
+    }
+    return this.#holdForHumanApproval({ request, rule, secretPaths });
+  }
+
+  /** The project's egress rules, from reduced state (folded before first read). */
+  async #egressRules(): Promise<readonly EgressRule[]> {
+    if (!this.#projectProcessor.isLoaded) {
+      await this.#processorHost.catchUp(ProjectProcessorContract.slug);
+    }
+    return this.#projectProcessor.currentState.egressRules;
+  }
+
+  /**
+   * Park one held request: append `human-approval-requested`, then live-tail
+   * the project stream for a resolution referencing that event's offset (the
+   * held request's identity — no minted ids). The wait is chunked so no
+   * single cross-DO call stays open longer than ~25s; the deadline spans the
+   * chunks. A Durable Object restart mid-hold fails the caller's fetch — the
+   * requested event survives and the audit trail stays truthful, but the
+   * MVP deliberately has no reconciler re-executing approved requests.
+   */
+  async #holdForHumanApproval(input: {
+    request: Request;
+    rule: EgressRule;
+    secretPaths: string[];
+  }): Promise<Response> {
+    const { request, rule } = input;
+    // Buffer the body up front: hashing consumes the stream, and the released
+    // request is re-built from these bytes after the human answers.
+    const bodyBytes = request.body === null ? null : new Uint8Array(await request.arrayBuffer());
+    const requestedPayload: HumanApprovalRequestedPayload = {
+      method: request.method,
+      url: request.url,
+      headers: Object.fromEntries(request.headers),
+      bodySha256: bodyBytes === null ? null : await sha256Hex(bodyBytes),
+      bodyPreview: bodyBytes === null ? null : utf8Preview(bodyBytes),
+      secretPaths: input.secretPaths,
+      ruleKey: rule.ruleKey,
+      expiresAt: new Date(Date.now() + rule.approvalTimeoutMs).toISOString(),
+    };
+
+    const stream = this.#ownStream();
+    const [requested] = await stream.append({
+      type: "events.iterate.com/project/human-approval-requested",
+      payload: requestedPayload,
+    });
+    const approvalRequestEventOffset = requested!.offset;
+
+    const resolution = await this.#awaitApprovalResolution({
+      approvalRequestEventOffset,
+      deadline: Date.now() + rule.approvalTimeoutMs,
+      requestedPayload,
+    });
+
+    if (resolution === "expired") {
+      await stream.append({
+        type: "events.iterate.com/project/human-approval-rejected",
+        idempotencyKey: `human-approval-expired:${approvalRequestEventOffset}`,
+        payload: { approvalRequestEventOffset, reason: "expired" },
+      });
+      return approvalGateResponse({
+        approvalRequestEventOffset,
+        code: "approval_expired",
+        detail: `No human answered within ${rule.approvalTimeoutMs}ms (rule "${rule.ruleKey}").`,
+        ruleKey: rule.ruleKey,
+      });
+    }
+    if (resolution === "rejected") {
+      return approvalGateResponse({
+        approvalRequestEventOffset,
+        code: "approval_rejected",
+        detail: `A human rejected this request (rule "${rule.ruleKey}").`,
+        ruleKey: rule.ruleKey,
+      });
+    }
+
+    // Granted: release the buffered request through the ordinary egress
+    // lanes, then record what actually happened — approval and outcome are
+    // separate facts.
+    const released = new Request(request.url, {
+      method: request.method,
+      headers: request.headers,
+      body: bodyBytes as BodyInit | null,
+      redirect: request.redirect,
+    });
+    const settle = (payload: { status?: number; error?: string }) =>
+      stream.append({
+        type: "events.iterate.com/project/human-approval-settled",
+        idempotencyKey: `human-approval-settled:${approvalRequestEventOffset}`,
+        payload: { approvalRequestEventOffset, ...payload },
+      });
+    try {
+      const response = await this.#egress(released);
+      await settle({ status: response.status });
+      return response;
+    } catch (error) {
+      await settle({ error: error instanceof Error ? error.message : String(error) });
+      throw error;
+    }
+  }
+
+  /**
+   * Live-tail resolutions for one held request. Grants verify against the
+   * enrolled key set: once ANY active approval key exists, an unsigned or
+   * badly-signed grant is ignored (the hold keeps waiting) — deny stays
+   * cheap, forging an approval requires the enrolled private key.
+   */
+  async #awaitApprovalResolution(input: {
+    approvalRequestEventOffset: number;
+    deadline: number;
+    requestedPayload: HumanApprovalRequestedPayload;
+  }): Promise<"granted" | "rejected" | "expired"> {
+    const stream = this.#ownStream();
+    let cursor = input.approvalRequestEventOffset;
+    while (true) {
+      const remaining = input.deadline - Date.now();
+      if (remaining <= 0) return "expired";
+      let event;
+      try {
+        event = await stream.waitForEvent({
+          afterOffset: cursor,
+          eventTypes: [
+            "events.iterate.com/project/human-approval-granted",
+            "events.iterate.com/project/human-approval-rejected",
+          ],
+          timeoutMs: Math.min(remaining, 25_000),
+        });
+      } catch (error) {
+        // waitForEvent is a one-shot, not a durable waiter: chunk timeouts
+        // (and transient stream restarts) just re-arm from the same cursor.
+        if (
+          error instanceof Error &&
+          error.message.includes("Timed out waiting for stream event")
+        ) {
+          continue;
+        }
+        throw error;
+      }
+      cursor = event.offset;
+
+      if (event.type === "events.iterate.com/project/human-approval-rejected") {
+        let payload;
+        try {
+          payload = ProjectProcessorContract.parseEvent(
+            "events.iterate.com/project/human-approval-rejected",
+            event,
+          ).payload;
+        } catch {
+          continue;
+        }
+        if (payload.approvalRequestEventOffset !== input.approvalRequestEventOffset) continue;
+        return "rejected";
+      }
+
+      let payload;
+      try {
+        payload = ProjectProcessorContract.parseEvent(
+          "events.iterate.com/project/human-approval-granted",
+          event,
+        ).payload;
+      } catch {
+        continue;
+      }
+      if (payload.approvalRequestEventOffset !== input.approvalRequestEventOffset) continue;
+
+      const activeKeys = this.#projectProcessor.currentState.humanApprovalKeys.filter(
+        (key) => key.revokedAt === null,
+      );
+      if (activeKeys.length === 0) return "granted";
+
+      const key = activeKeys.find((candidate) => candidate.keyId === payload.keyId);
+      if (key === undefined || payload.signature === undefined) {
+        console.warn("egress approval: unsigned or unknown-key grant ignored", {
+          approvalRequestEventOffset: input.approvalRequestEventOffset,
+          keyId: payload.keyId,
+          projectId: this.#name.projectId,
+        });
+        continue;
+      }
+      const verified = await verifyApprovalSignature({
+        publicKey: key.publicKey,
+        signature: payload.signature,
+        message: buildApprovalMessage({
+          projectId: this.#name.projectId,
+          approvalRequestEventOffset: input.approvalRequestEventOffset,
+          requested: input.requestedPayload,
+          decision: "granted",
+        }),
+      });
+      if (!verified) {
+        console.warn("egress approval: invalid grant signature ignored", {
+          approvalRequestEventOffset: input.approvalRequestEventOffset,
+          keyId: payload.keyId,
+          projectId: this.#name.projectId,
+        });
+        continue;
+      }
+      return "granted";
+    }
+  }
+
+  /** This Durable Object's own stream (the project stream for the "/" egress instance). */
+  #ownStream() {
+    return new StreamRpcTarget({
+      auth: trustedInternalAuthContext(),
+      path: this.#name.path,
+      projectId: this.#name.projectId,
+    });
+  }
+
+  /** The egress lanes proper: platform references, secret substitution, bare fetch. */
+  async #egress(request: Request): Promise<Response> {
     let secretPaths: string[];
     try {
       // Placeholders live in the request envelope: headers, or the URL for
@@ -269,5 +522,24 @@ export class ProjectDurableObject extends DurableObject<Env> {
         this.#egressInterceptor = undefined;
       },
     });
+  }
+}
+
+/** The approval gate's terminal responses: denied, rejected, or expired — never released. */
+function approvalGateResponse(body: {
+  approvalRequestEventOffset?: number;
+  code: "egress_denied" | "approval_rejected" | "approval_expired";
+  detail: string;
+  ruleKey: string;
+}): Response {
+  return Response.json({ error: body.code, ...body }, { status: 403 });
+}
+
+/** First 2KB of a body as UTF-8 for the approval UI; null when it does not decode. */
+function utf8Preview(bytes: Uint8Array): string | null {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes.slice(0, 2048));
+  } catch {
+    return null;
   }
 }

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -33,9 +33,11 @@ import { EmailProcessorContract } from "../email/email-processor-contract.ts";
 import type { ProjectEgressIntercept, ProjectEgressInterceptor } from "./egress.ts";
 import {
   buildApprovalMessage,
+  evaluateGrant,
+  HumanApprovalGrantedPayload,
+  HumanApprovalRejectedPayload,
   matchEgressRule,
   sha256Hex,
-  verifyApprovalSignature,
   type EgressRule,
   type HumanApprovalRequestedPayload,
 } from "./egress-approvals.ts";
@@ -392,84 +394,58 @@ export class ProjectDurableObject extends DurableObject<Env> {
         throw error;
       }
 
-      // Grants must judge the signature requirement against FRESH key state:
-      // push delivery to this processor can lag the stream, so an unsigned
-      // grant must not slip through while a human-approval-key-added event is
-      // committed but not yet folded. Catch up BEFORE advancing the cursor —
-      // a failed catch-up retries this same event instead of dropping it
-      // (bounded by the hold's deadline).
-      if (event.type === "events.iterate.com/project/human-approval-granted") {
-        try {
-          await this.#processorHost.catchUp(ProjectProcessorContract.slug);
-        } catch (error) {
-          console.warn("egress approval: catch-up before grant key check failed", {
-            approvalRequestEventOffset: input.approvalRequestEventOffset,
-            error,
-            projectId: this.#name.projectId,
-          });
-          continue;
-        }
-      }
       cursor = event.offset;
 
       if (event.type === "events.iterate.com/project/human-approval-rejected") {
-        let payload;
-        try {
-          payload = ProjectProcessorContract.parseEvent(
-            "events.iterate.com/project/human-approval-rejected",
-            event,
-          ).payload;
-        } catch {
-          continue;
+        const rejection = HumanApprovalRejectedPayload.safeParse(event.payload);
+        if (
+          rejection.success &&
+          rejection.data.approvalRequestEventOffset === input.approvalRequestEventOffset
+        ) {
+          return "rejected";
         }
-        if (payload.approvalRequestEventOffset !== input.approvalRequestEventOffset) continue;
-        return "rejected";
-      }
-
-      let payload;
-      try {
-        payload = ProjectProcessorContract.parseEvent(
-          "events.iterate.com/project/human-approval-granted",
-          event,
-        ).payload;
-      } catch {
         continue;
       }
-      if (payload.approvalRequestEventOffset !== input.approvalRequestEventOffset) continue;
 
-      const activeKeys = this.#projectProcessor.currentState.humanApprovalKeys.filter(
-        (key) => key.revokedAt === null,
-      );
-      if (activeKeys.length === 0) return "granted";
-
-      const key = activeKeys.find((candidate) => candidate.keyId === payload.keyId);
-      if (key === undefined || payload.signature === undefined) {
-        console.warn("egress approval: unsigned or unknown-key grant ignored", {
-          approvalRequestEventOffset: input.approvalRequestEventOffset,
-          keyId: payload.keyId,
-          projectId: this.#name.projectId,
-        });
+      const grant = HumanApprovalGrantedPayload.safeParse(event.payload);
+      if (
+        !grant.success ||
+        grant.data.approvalRequestEventOffset !== input.approvalRequestEventOffset
+      ) {
         continue;
       }
-      const verified = await verifyApprovalSignature({
-        publicKey: key.publicKey,
-        signature: payload.signature,
-        message: buildApprovalMessage({
-          projectId: this.#name.projectId,
-          approvalRequestEventOffset: input.approvalRequestEventOffset,
-          requested: input.requestedPayload,
-          decision: "granted",
-        }),
+
+      // Judge the grant against FRESH key state: push delivery to this
+      // processor can lag the stream, so an unsigned grant must not slip
+      // through while a human-approval-key-added event is committed but not
+      // yet folded. A grant we cannot judge (catch-up failed) or that
+      // evaluateGrant refuses is IGNORED, never fatal: the hold keeps
+      // waiting for a good grant, a human rejection, or expiry.
+      const verdict = await this.#processorHost
+        .catchUp(ProjectProcessorContract.slug)
+        .then(() =>
+          evaluateGrant({
+            grant: grant.data,
+            keys: this.#projectProcessor.currentState.humanApprovalKeys,
+            message: buildApprovalMessage({
+              projectId: this.#name.projectId,
+              approvalRequestEventOffset: input.approvalRequestEventOffset,
+              requested: input.requestedPayload,
+              decision: "granted",
+            }),
+          }),
+        )
+        .catch((error: unknown) => ({
+          accepted: false as const,
+          reason: `key state catch-up failed: ${error instanceof Error ? error.message : String(error)}`,
+        }));
+      if (verdict.accepted) return "granted";
+      console.warn("egress approval: grant ignored", {
+        approvalRequestEventOffset: input.approvalRequestEventOffset,
+        keyId: grant.data.keyId,
+        projectId: this.#name.projectId,
+        reason: verdict.reason,
       });
-      if (!verified) {
-        console.warn("egress approval: invalid grant signature ignored", {
-          approvalRequestEventOffset: input.approvalRequestEventOffset,
-          keyId: payload.keyId,
-          projectId: this.#name.projectId,
-        });
-        continue;
-      }
-      return "granted";
     }
   }
 

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -391,6 +391,25 @@ export class ProjectDurableObject extends DurableObject<Env> {
         }
         throw error;
       }
+
+      // Grants must judge the signature requirement against FRESH key state:
+      // push delivery to this processor can lag the stream, so an unsigned
+      // grant must not slip through while a human-approval-key-added event is
+      // committed but not yet folded. Catch up BEFORE advancing the cursor —
+      // a failed catch-up retries this same event instead of dropping it
+      // (bounded by the hold's deadline).
+      if (event.type === "events.iterate.com/project/human-approval-granted") {
+        try {
+          await this.#processorHost.catchUp(ProjectProcessorContract.slug);
+        } catch (error) {
+          console.warn("egress approval: catch-up before grant key check failed", {
+            approvalRequestEventOffset: input.approvalRequestEventOffset,
+            error,
+            projectId: this.#name.projectId,
+          });
+          continue;
+        }
+      }
       cursor = event.offset;
 
       if (event.type === "events.iterate.com/project/human-approval-rejected") {

--- a/apps/os/src/domains/projects/project-processor-contract.ts
+++ b/apps/os/src/domains/projects/project-processor-contract.ts
@@ -7,9 +7,11 @@ import { EmailProcessorContract } from "../email/email-processor-contract.ts";
 import { StreamListItem } from "../streams/schemas.ts";
 import {
   EgressRule,
+  HumanApprovalGrantedPayload,
   HumanApprovalKey,
+  HumanApprovalRejectedPayload,
   HumanApprovalRequestedPayload,
-  HumanApprovalResolutionPayload,
+  HumanApprovalSettledPayload,
 } from "./egress-approvals.ts";
 
 const ProjectCustomDomainStatus = z.enum([
@@ -369,10 +371,7 @@ export const ProjectProcessorContract = defineProcessorContract({
         "A human approved a held egress request. When the project has active approval keys, " +
         "`keyId` + `signature` (raw 64-byte r‖s ECDSA P-256 over the canonical approval.v1 " +
         "message, base64) are required and verified before the request is released.",
-      payloadSchema: HumanApprovalResolutionPayload.extend({
-        keyId: z.string().optional(),
-        signature: z.string().optional(),
-      }),
+      payloadSchema: HumanApprovalGrantedPayload,
       examples: [
         {
           description: "A signed grant from an enrolled Secure Enclave key releases the request.",
@@ -389,10 +388,7 @@ export const ProjectProcessorContract = defineProcessorContract({
       description:
         "A held egress request was refused — by a human, or automatically when its hold expired. " +
         "Rejections are deliberately unsigned: deny is the fail-safe direction.",
-      payloadSchema: HumanApprovalResolutionPayload.extend({
-        reason: z.enum(["human", "expired"]),
-        note: z.string().optional(),
-      }),
+      payloadSchema: HumanApprovalRejectedPayload,
       examples: [
         {
           description: "A human refused the request from the approval CLI.",
@@ -415,10 +411,7 @@ export const ProjectProcessorContract = defineProcessorContract({
       description:
         "What actually happened after a granted request was released: the upstream status, or the " +
         "delivery failure. Approval and outcome are separate facts — audits want both.",
-      payloadSchema: HumanApprovalResolutionPayload.extend({
-        status: z.number().int().optional(),
-        error: z.string().optional(),
-      }),
+      payloadSchema: HumanApprovalSettledPayload,
       examples: [
         {
           description: "The released Stripe transfer succeeded.",

--- a/apps/os/src/domains/projects/project-processor-contract.ts
+++ b/apps/os/src/domains/projects/project-processor-contract.ts
@@ -5,6 +5,12 @@ import { RepoProcessorContract } from "../repos/repo-processor-contract.ts";
 import { AgentProcessorContract } from "../agents/agent-processor-contract.ts";
 import { EmailProcessorContract } from "../email/email-processor-contract.ts";
 import { StreamListItem } from "../streams/schemas.ts";
+import {
+  EgressRule,
+  HumanApprovalKey,
+  HumanApprovalRequestedPayload,
+  HumanApprovalResolutionPayload,
+} from "./egress-approvals.ts";
 
 const ProjectCustomDomainStatus = z.enum([
   "requested",
@@ -72,6 +78,10 @@ export const ProjectProcessorContract = defineProcessorContract({
     secrets: z.array(StreamListItem).default([]),
     streams: z.array(StreamListItem).default([]),
     customDomains: z.array(ProjectCustomDomain).default([]),
+    /** Egress approval rules, replaced wholesale by egress-rules-configured. */
+    egressRules: z.array(EgressRule).default([]),
+    /** Enrolled human-approval public keys; once any is active, grants must be signed. */
+    humanApprovalKeys: z.array(HumanApprovalKey).default([]),
   }),
   events: {
     "events.iterate.com/project/create-requested": {
@@ -256,9 +266,182 @@ export const ProjectProcessorContract = defineProcessorContract({
         },
       ],
     },
+    "events.iterate.com/project/egress-rules-configured": {
+      description:
+        "Replace the project's egress approval rules wholesale. Every outbound request is matched " +
+        "against the ordered list at the Project DO's egress decision point (first match wins, no " +
+        "match allows): a `hold` verdict parks the request until a human grants or rejects it on " +
+        "this stream, `deny` refuses it outright.",
+      payloadSchema: z.object({
+        rules: z.array(EgressRule),
+      }),
+      examples: [
+        {
+          description:
+            "Mutating Stripe calls need a human; anything spending the production Stripe secret is held too, wherever it goes.",
+          payload: {
+            rules: [
+              {
+                ruleKey: "stripe-mutations",
+                description: "Mutating calls to the Stripe API",
+                match: { hosts: ["api.stripe.com"], methods: ["POST", "PUT", "DELETE"] },
+                verdict: "hold",
+                approvalTimeoutMs: 600_000,
+              },
+              {
+                ruleKey: "stripe-prod-secret",
+                description: "Any request spending the production Stripe key",
+                match: { secretPaths: ["/secrets/stripe/prod"] },
+                verdict: "hold",
+              },
+            ],
+          },
+        },
+      ],
+    },
+    "events.iterate.com/project/human-approval-key-added": {
+      description:
+        "Enroll a public key whose holder may grant held egress requests. Once any active key " +
+        "exists, grants MUST carry a valid ECDSA P-256 signature over the canonical approval " +
+        "message (approval.v1) — unsigned grants are ignored. Rejections never require a signature.",
+      payloadSchema: z.object({
+        keyId: z.string(),
+        /** Base64 uncompressed P-256 public point (65 bytes, 0x04‖X‖Y). */
+        publicKey: z.string(),
+        label: z.string().optional(),
+      }),
+      examples: [
+        {
+          description:
+            "The owner enrolled their MacBook's Secure Enclave key via `iterate approve --enroll`.",
+          payload: {
+            keyId: "9f2c47a1b8d3e605",
+            publicKey:
+              "BGx1uJ9lZ7Yw2cQ4vX8pR3nK6tA1sD5fG0hJ9kL2mN4oP7qS8uV3wY6zB1cE4gI7jM0nQ5rT8vX2yA5bD8fH1kN4pS7u",
+            label: "jonas-macbook-enclave",
+          },
+        },
+      ],
+    },
+    "events.iterate.com/project/human-approval-key-revoked": {
+      description: "Revoke an enrolled approval key; signatures from it stop being accepted.",
+      payloadSchema: z.object({
+        keyId: z.string(),
+      }),
+      examples: [
+        {
+          description: "The owner rotated their laptop and revoked the old enclave key.",
+          payload: {
+            keyId: "9f2c47a1b8d3e605",
+          },
+        },
+      ],
+    },
+    "events.iterate.com/project/human-approval-requested": {
+      description:
+        "An outbound request matched a `hold` rule and is parked at the egress door awaiting a " +
+        "human. Everything is placeholder form — getSecret(...) references, never material. The " +
+        "requested event's offset IS the held request's identity: grants and rejections reference " +
+        "it as approvalRequestEventOffset.",
+      payloadSchema: HumanApprovalRequestedPayload,
+      examples: [
+        {
+          description:
+            "An agent tried to move money: a POST to Stripe spending the production key waits for approval.",
+          payload: {
+            method: "POST",
+            url: "https://api.stripe.com/v1/transfers",
+            headers: {
+              authorization: 'Bearer getSecret({ path: "/secrets/stripe/prod" })',
+              "content-type": "application/x-www-form-urlencoded",
+            },
+            bodySha256: "9c56cc51b374c3ba189210d5b6d4bf57790d351c96c47c02190ecf1e430ba0aa",
+            bodyPreview: "amount=420000&currency=gbp&destination=acct_1MTfjCQ9PRzxCzLK",
+            secretPaths: ["/secrets/stripe/prod"],
+            ruleKey: "stripe-mutations",
+            expiresAt: "2026-07-10T12:34:56.000Z",
+          },
+        },
+      ],
+    },
+    "events.iterate.com/project/human-approval-granted": {
+      description:
+        "A human approved a held egress request. When the project has active approval keys, " +
+        "`keyId` + `signature` (raw 64-byte r‖s ECDSA P-256 over the canonical approval.v1 " +
+        "message, base64) are required and verified before the request is released.",
+      payloadSchema: HumanApprovalResolutionPayload.extend({
+        keyId: z.string().optional(),
+        signature: z.string().optional(),
+      }),
+      examples: [
+        {
+          description: "A signed grant from an enrolled Secure Enclave key releases the request.",
+          payload: {
+            approvalRequestEventOffset: 42,
+            keyId: "9f2c47a1b8d3e605",
+            signature:
+              "MEUCIQDx4Zc7HqzUnkl3RaW0mYtVbGJ5cD8fH1kN4pS7uMEUCIQDx4Zc7HqzUnkl3RaW0mYtVbGJ5c=",
+          },
+        },
+      ],
+    },
+    "events.iterate.com/project/human-approval-rejected": {
+      description:
+        "A held egress request was refused — by a human, or automatically when its hold expired. " +
+        "Rejections are deliberately unsigned: deny is the fail-safe direction.",
+      payloadSchema: HumanApprovalResolutionPayload.extend({
+        reason: z.enum(["human", "expired"]),
+        note: z.string().optional(),
+      }),
+      examples: [
+        {
+          description: "A human refused the request from the approval CLI.",
+          payload: {
+            approvalRequestEventOffset: 42,
+            reason: "human",
+          },
+        },
+        {
+          description:
+            "Nobody answered within the rule's approvalTimeoutMs; the hold auto-rejected.",
+          payload: {
+            approvalRequestEventOffset: 42,
+            reason: "expired",
+          },
+        },
+      ],
+    },
+    "events.iterate.com/project/human-approval-settled": {
+      description:
+        "What actually happened after a granted request was released: the upstream status, or the " +
+        "delivery failure. Approval and outcome are separate facts — audits want both.",
+      payloadSchema: HumanApprovalResolutionPayload.extend({
+        status: z.number().int().optional(),
+        error: z.string().optional(),
+      }),
+      examples: [
+        {
+          description: "The released Stripe transfer succeeded.",
+          payload: {
+            approvalRequestEventOffset: 42,
+            status: 200,
+          },
+        },
+        {
+          description: "The upstream call failed after release.",
+          payload: {
+            approvalRequestEventOffset: 42,
+            error: "connection refused",
+          },
+        },
+      ],
+    },
   },
   consumes: [
     "*",
+    "events.iterate.com/project/egress-rules-configured",
+    "events.iterate.com/project/human-approval-key-added",
+    "events.iterate.com/project/human-approval-key-revoked",
     "events.iterate.com/project/custom-domain-add-requested",
     "events.iterate.com/project/custom-domain-cloudflare-observed",
     "events.iterate.com/project/custom-domain-provision-failed",

--- a/apps/os/src/domains/projects/project-processor-implementation.test.ts
+++ b/apps/os/src/domains/projects/project-processor-implementation.test.ts
@@ -40,6 +40,8 @@ function projectState(
     created: true,
     createRequest: { projectId: project.id, slug: project.slug },
     customDomains,
+    egressRules: [],
+    humanApprovalKeys: [],
     onboardingActive: false,
     onboardingCompletedAt: null,
     repos: [],

--- a/apps/os/src/domains/projects/project-processor-implementation.ts
+++ b/apps/os/src/domains/projects/project-processor-implementation.ts
@@ -68,6 +68,32 @@ export class ProjectProcessor extends StreamProcessor<
         return recordStream(state, event.payload.path, event.createdAt);
       case "events.iterate.com/stream/child-stream-created":
         return recordStream(state, event.payload.childPath, event.createdAt);
+      case "events.iterate.com/project/egress-rules-configured":
+        return { ...state, egressRules: event.payload.rules };
+      case "events.iterate.com/project/human-approval-key-added":
+        if (state.humanApprovalKeys.some((key) => key.keyId === event.payload.keyId)) return state;
+        return {
+          ...state,
+          humanApprovalKeys: [
+            ...state.humanApprovalKeys,
+            {
+              keyId: event.payload.keyId,
+              publicKey: event.payload.publicKey,
+              label: event.payload.label ?? "",
+              addedAt: event.createdAt,
+              revokedAt: null,
+            },
+          ],
+        };
+      case "events.iterate.com/project/human-approval-key-revoked":
+        return {
+          ...state,
+          humanApprovalKeys: state.humanApprovalKeys.map((key) =>
+            key.keyId === event.payload.keyId && key.revokedAt === null
+              ? { ...key, revokedAt: event.createdAt }
+              : key,
+          ),
+        };
       default:
         return reduceCustomDomainEvent({ event, state }) ?? state;
     }

--- a/apps/os/src/itx-api.generated.ts
+++ b/apps/os/src/itx-api.generated.ts
@@ -1412,6 +1412,25 @@ export type ProjectProcessorState = {
     createdAt: string;
     updatedAt: string;
   }[];
+  egressRules: {
+    ruleKey: string;
+    description: string;
+    match: {
+      hosts?: string[] | undefined;
+      methods?: string[] | undefined;
+      pathPrefix?: string | undefined;
+      secretPaths?: string[] | undefined;
+    };
+    verdict: "deny" | "hold";
+    approvalTimeoutMs: number;
+  }[];
+  humanApprovalKeys: {
+    keyId: string;
+    publicKey: string;
+    label: string;
+    addedAt: string;
+    revokedAt: string | null;
+  }[];
 };
 
 /**

--- a/apps/os/src/lib/onboarding-agent.test.ts
+++ b/apps/os/src/lib/onboarding-agent.test.ts
@@ -7,6 +7,8 @@ const state = (overrides: Partial<ProjectProcessorState>): ProjectProcessorState
   createRequest: null,
   created: true,
   customDomains: [],
+  egressRules: [],
+  humanApprovalKeys: [],
   onboardingActive: false,
   onboardingCompletedAt: null,
   repos: [],

--- a/apps/os/src/types-source.generated.ts
+++ b/apps/os/src/types-source.generated.ts
@@ -1417,6 +1417,25 @@ export type ProjectProcessorState = {
     createdAt: string;
     updatedAt: string;
   }[];
+  egressRules: {
+    ruleKey: string;
+    description: string;
+    match: {
+      hosts?: string[] | undefined;
+      methods?: string[] | undefined;
+      pathPrefix?: string | undefined;
+      secretPaths?: string[] | undefined;
+    };
+    verdict: "deny" | "hold";
+    approvalTimeoutMs: number;
+  }[];
+  humanApprovalKeys: {
+    keyId: string;
+    publicKey: string;
+    label: string;
+    addedAt: string;
+    revokedAt: string | null;
+  }[];
 };
 
 /**

--- a/packages/iterate/src/approval-keys.ts
+++ b/packages/iterate/src/approval-keys.ts
@@ -1,0 +1,291 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Local approval keys for `iterate approve`.
+//
+// One key per project, stored under XDG config
+// (~/.config/iterate/approval-keys/<projectId>.json). Two kinds:
+//
+// - "secure-enclave" (macOS): the private key lives in the Secure Enclave and
+//   physically cannot leave it; every signature demands a fresh Touch ID /
+//   Face ID check (`.biometryCurrentSet`, so re-enrolling biometrics kills
+//   the key). The key file holds only the public half and the keychain tag.
+//   A tiny vendored Swift helper (compiled with swiftc on first use, cached
+//   next to the key files) does the two enclave operations.
+//
+// - "software" (everywhere else / --software): a WebCrypto P-256 key whose
+//   private JWK sits in the key file. Same protocol, none of the hardware
+//   guarantees — fine for CI and non-Mac development.
+//
+// Signatures are raw 64-byte r‖s over the canonical approval message; the
+// enclave emits DER, converted here before anything leaves the machine.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { spawn } from "node:child_process";
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod/v4";
+import {
+  approvalKeyId,
+  base64ToBytes,
+  bytesToBase64,
+  derSignatureToRaw,
+} from "../../../apps/os/src/domains/projects/egress-approvals.ts";
+
+const APPROVAL_KEYS_DIR = join(
+  process.env.XDG_CONFIG_HOME ? process.env.XDG_CONFIG_HOME : join(homedir(), ".config"),
+  "iterate",
+  "approval-keys",
+);
+
+const StoredApprovalKey = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("secure-enclave"),
+    keyId: z.string(),
+    /** Base64 uncompressed P-256 public point (65 bytes). */
+    publicKey: z.string(),
+    label: z.string(),
+    /** Keychain application tag the enclave key is stored under. */
+    keychainTag: z.string(),
+  }),
+  z.object({
+    kind: z.literal("software"),
+    keyId: z.string(),
+    publicKey: z.string(),
+    label: z.string(),
+    privateKeyJwk: z.record(z.string(), z.unknown()),
+  }),
+]);
+
+export type StoredApprovalKey = z.output<typeof StoredApprovalKey>;
+
+function keyPath(projectId: string): string {
+  return join(APPROVAL_KEYS_DIR, `${projectId}.json`);
+}
+
+export async function loadApprovalKey(projectId: string): Promise<StoredApprovalKey | null> {
+  let raw: string;
+  try {
+    raw = await readFile(keyPath(projectId), "utf8");
+  } catch {
+    return null;
+  }
+  return StoredApprovalKey.parse(JSON.parse(raw));
+}
+
+/**
+ * Generate and persist this project's approval key: Secure Enclave when the
+ * machine can (macOS + swiftc), software P-256 otherwise or when forced.
+ */
+export async function createApprovalKey(input: {
+  projectId: string;
+  label: string;
+  software?: boolean;
+  log?: (message: string) => void;
+}): Promise<StoredApprovalKey> {
+  const log = input.log ?? (() => {});
+  const useEnclave = input.software !== true && process.platform === "darwin";
+  let key: StoredApprovalKey;
+  if (useEnclave) {
+    log("Generating a Secure Enclave key (Touch ID guards every signature)...");
+    const helper = await ensureEnclaveHelper();
+    const keychainTag = `com.iterate.approve.${input.projectId}`;
+    const generated = await runJson(helper, ["generate", keychainTag]);
+    const publicKey = z.object({ publicKey: z.string() }).parse(generated).publicKey;
+    key = {
+      kind: "secure-enclave",
+      keyId: await approvalKeyId(publicKey),
+      publicKey,
+      label: input.label,
+      keychainTag,
+    };
+  } else {
+    log("Generating a software P-256 key (no Secure Enclave on this machine)...");
+    const pair = await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
+      "sign",
+      "verify",
+    ]);
+    const publicKey = bytesToBase64(
+      new Uint8Array(await crypto.subtle.exportKey("raw", pair.publicKey)),
+    );
+    key = {
+      kind: "software",
+      keyId: await approvalKeyId(publicKey),
+      publicKey,
+      label: input.label,
+      privateKeyJwk: (await crypto.subtle.exportKey("jwk", pair.privateKey)) as Record<
+        string,
+        unknown
+      >,
+    };
+  }
+  await mkdir(APPROVAL_KEYS_DIR, { recursive: true });
+  await writeFile(keyPath(input.projectId), `${JSON.stringify(key, null, 2)}\n`);
+  await chmod(keyPath(input.projectId), 0o600);
+  return key;
+}
+
+/** Sign the canonical approval message; returns the base64 raw 64-byte r‖s signature. */
+export async function signApprovalMessage(
+  key: StoredApprovalKey,
+  message: Uint8Array,
+): Promise<string> {
+  if (key.kind === "secure-enclave") {
+    const helper = await ensureEnclaveHelper();
+    const signed = await runJson(helper, ["sign", key.keychainTag, bytesToBase64(message)]);
+    const der = z.object({ signatureDer: z.string() }).parse(signed).signatureDer;
+    return bytesToBase64(derSignatureToRaw(base64ToBytes(der)));
+  }
+  const privateKey = await crypto.subtle.importKey(
+    "jwk",
+    key.privateKeyJwk as JsonWebKey,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    privateKey,
+    message as BufferSource,
+  );
+  return bytesToBase64(new Uint8Array(signature));
+}
+
+// ── the Secure Enclave helper ────────────────────────────────────────────────
+
+const HELPER_VERSION = 1;
+
+/**
+ * Compile the vendored Swift helper on first use (any Mac with the Xcode
+ * command-line tools has swiftc) and cache the binary next to the key files.
+ */
+async function ensureEnclaveHelper(): Promise<string> {
+  const helperPath = join(APPROVAL_KEYS_DIR, `enclave-signer-v${HELPER_VERSION}`);
+  try {
+    await readFile(helperPath);
+    return helperPath;
+  } catch {
+    // fall through to compile
+  }
+  await mkdir(APPROVAL_KEYS_DIR, { recursive: true });
+  const sourcePath = join(tmpdir(), `iterate-enclave-signer-${process.pid}.swift`);
+  await writeFile(sourcePath, ENCLAVE_SIGNER_SWIFT);
+  try {
+    const compile = await run("swiftc", ["-O", "-o", helperPath, sourcePath]);
+    if (compile.exitCode !== 0) {
+      throw new Error(
+        `swiftc failed (exit ${compile.exitCode}) — install the Xcode command-line tools ` +
+          `(xcode-select --install) or use --software.\n${compile.stderr.trim()}`,
+      );
+    }
+  } finally {
+    await rm(sourcePath, { force: true });
+  }
+  return helperPath;
+}
+
+async function runJson(command: string, args: string[]): Promise<unknown> {
+  const result = await run(command, args);
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `${command} ${args[0]} failed (exit ${result.exitCode}): ${result.stderr.trim() || "no output"}`,
+    );
+  }
+  return JSON.parse(result.stdout);
+}
+
+function run(command: string, args: string[]) {
+  return new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve, reject) => {
+    const child = spawn(command, args);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (data) => (stdout += data));
+    child.stderr.on("data", (data) => (stderr += data));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ stdout, stderr, exitCode: code ?? 1 }));
+  });
+}
+
+/**
+ * The whole enclave surface: `generate <tag>` mints a biometry-guarded P-256
+ * key in the Secure Enclave and prints its public point; `sign <tag>
+ * <messageBase64>` signs with `.ecdsaSignatureMessageX962SHA256` (the enclave
+ * hashes the message itself) and prints the DER signature. Vendored as a
+ * string so the published CLI needs no asset resolution.
+ */
+const ENCLAVE_SIGNER_SWIFT = `
+import Foundation
+import Security
+
+func fail(_ message: String) -> Never {
+  FileHandle.standardError.write((message + "\\n").data(using: .utf8)!)
+  exit(1)
+}
+
+func jsonOut(_ dict: [String: String]) {
+  let data = try! JSONSerialization.data(withJSONObject: dict)
+  print(String(data: data, encoding: .utf8)!)
+}
+
+let args = CommandLine.arguments
+guard args.count >= 3 else {
+  fail("usage: enclave-signer generate <tag> | sign <tag> <messageBase64>")
+}
+let command = args[1]
+let tag = args[2].data(using: .utf8)!
+
+switch command {
+case "generate":
+  var error: Unmanaged<CFError>?
+  guard let accessControl = SecAccessControlCreateWithFlags(
+    kCFAllocatorDefault,
+    kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+    [.privateKeyUsage, .biometryCurrentSet],
+    &error
+  ) else { fail("access control: \\(error!.takeRetainedValue())") }
+
+  let attributes: [String: Any] = [
+    kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
+    kSecAttrKeySizeInBits as String: 256,
+    kSecAttrTokenID as String: kSecAttrTokenIDSecureEnclave,
+    kSecPrivateKeyAttrs as String: [
+      kSecAttrIsPermanent as String: true,
+      kSecAttrApplicationTag as String: tag,
+      kSecAttrAccessControl as String: accessControl,
+    ],
+  ]
+  guard let privateKey = SecKeyCreateRandomKey(attributes as CFDictionary, &error) else {
+    fail("key generation failed: \\(error!.takeRetainedValue())")
+  }
+  guard let publicKey = SecKeyCopyPublicKey(privateKey),
+        let publicKeyData = SecKeyCopyExternalRepresentation(publicKey, &error) as Data? else {
+    fail("public key export failed")
+  }
+  jsonOut(["publicKey": publicKeyData.base64EncodedString()])
+
+case "sign":
+  guard args.count >= 4, let message = Data(base64Encoded: args[3]) else {
+    fail("sign needs <tag> <messageBase64>")
+  }
+  let query: [String: Any] = [
+    kSecClass as String: kSecClassKey,
+    kSecAttrApplicationTag as String: tag,
+    kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
+    kSecReturnRef as String: true,
+    kSecUseOperationPrompt as String: "Sign an iterate egress approval",
+  ]
+  var item: CFTypeRef?
+  let status = SecItemCopyMatching(query as CFDictionary, &item)
+  guard status == errSecSuccess else { fail("approval key not found in keychain: \\(status)") }
+  let privateKey = item as! SecKey
+  var error: Unmanaged<CFError>?
+  guard let signature = SecKeyCreateSignature(
+    privateKey, .ecdsaSignatureMessageX962SHA256, message as CFData, &error
+  ) as Data? else {
+    fail("signing failed: \\(error!.takeRetainedValue())")
+  }
+  jsonOut(["signatureDer": signature.base64EncodedString()])
+
+default:
+  fail("unknown command \\(command)")
+}
+`;

--- a/packages/iterate/src/approval-keys.ts
+++ b/packages/iterate/src/approval-keys.ts
@@ -19,7 +19,6 @@
 // enclave emits DER, converted here before anything leaves the machine.
 // ─────────────────────────────────────────────────────────────────────────────
 
-import { spawn } from "node:child_process";
 import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
@@ -30,6 +29,7 @@ import {
   bytesToBase64,
   derSignatureToRaw,
 } from "../../../apps/os/src/domains/projects/egress-approvals.ts";
+import { run } from "./run-command.ts";
 
 const APPROVAL_KEYS_DIR = join(
   process.env.XDG_CONFIG_HOME ? process.env.XDG_CONFIG_HOME : join(homedir(), ".config"),
@@ -191,18 +191,6 @@ async function runJson(command: string, args: string[]): Promise<unknown> {
     );
   }
   return JSON.parse(result.stdout);
-}
-
-function run(command: string, args: string[]) {
-  return new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve, reject) => {
-    const child = spawn(command, args);
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (data) => (stdout += data));
-    child.stderr.on("data", (data) => (stderr += data));
-    child.on("error", reject);
-    child.on("close", (code) => resolve({ stdout, stderr, exitCode: code ?? 1 }));
-  });
 }
 
 /**

--- a/packages/iterate/src/approve.ts
+++ b/packages/iterate/src/approve.ts
@@ -1,0 +1,210 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// `iterate approve` — be the human in the loop for a project's egress.
+//
+// The project's egress door parks outbound requests that match a `hold` rule
+// and appends `project/human-approval-requested` to the project stream. This
+// command is the other half: a tiny local stream processor that live-tails
+// those events over normal itx, shows each held request, and appends the
+// verdict — `human-approval-granted` (signed with the enrolled key when one
+// exists; Touch ID on the enclave path) or `human-approval-rejected`. The
+// moment the verdict lands, the Project DO releases (or refuses) the held
+// fetch, whose caller has been waiting the whole time.
+//
+// The prompt deliberately blocks the loop: requests arriving while a human
+// is deciding queue on the stream and replay from the cursor afterwards.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import * as prompts from "@clack/prompts";
+import type { RpcStub } from "capnweb";
+
+import { connectItx } from "../../../apps/os/src/itx-client.ts";
+import { buildApprovalMessage } from "../../../apps/os/src/domains/projects/egress-approvals.ts";
+import type { ItxAuthCredentials, Project, Stream, StreamEvent } from "./itx-api.generated.ts";
+import {
+  createApprovalKey,
+  loadApprovalKey,
+  signApprovalMessage,
+  type StoredApprovalKey,
+} from "./approval-keys.ts";
+
+const REQUESTED = "events.iterate.com/project/human-approval-requested";
+const GRANTED = "events.iterate.com/project/human-approval-granted";
+const REJECTED = "events.iterate.com/project/human-approval-rejected";
+const KEY_ADDED = "events.iterate.com/project/human-approval-key-added";
+
+/** The requested payload fields this UI renders and signs over. */
+type RequestedPayload = {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  bodySha256: string | null;
+  bodyPreview: string | null;
+  secretPaths: string[];
+  ruleKey: string;
+  expiresAt: string;
+};
+
+export async function runApprovalCli(input: {
+  auth: ItxAuthCredentials;
+  baseUrl: string;
+  projectId: string;
+  headers?: Record<string, string>;
+  enroll?: boolean;
+  softwareKey?: boolean;
+}): Promise<void> {
+  const itx = connectItx({
+    auth: input.auth,
+    baseUrl: input.baseUrl,
+    projectId: input.projectId,
+    headers: input.headers,
+  }) as RpcStub<Project>;
+  const stream = itx.streams.get("/") as RpcStub<Stream>;
+
+  prompts.intro(`iterate approve — project ${input.projectId}`);
+
+  let key = await loadApprovalKey(input.projectId);
+  if (input.enroll === true) {
+    key = await enroll({
+      existing: key,
+      projectId: input.projectId,
+      softwareKey: input.softwareKey,
+      stream,
+    });
+  }
+  prompts.log.info(
+    key === null
+      ? "No local approval key: grants will be plain events. Run with --enroll to sign approvals."
+      : `Grants are signed with ${key.kind} key ${key.keyId} (${key.label}).`,
+  );
+  prompts.log.step("Waiting for held egress requests... (Ctrl-C to stop)");
+
+  // Live tail from "now"; after the first event the cursor makes every
+  // waitForEvent replay-from-offset, so nothing lands unseen while a prompt
+  // is open. Each wait is a one-shot with a bounded timeout — timeouts just
+  // re-arm from the same cursor.
+  let cursor: number | undefined;
+  while (true) {
+    let event: StreamEvent;
+    try {
+      event = await stream.waitForEvent({
+        ...(cursor === undefined ? {} : { afterOffset: cursor }),
+        eventTypes: [REQUESTED],
+        timeoutMs: 60_000,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("Timed out waiting for stream event")) {
+        continue;
+      }
+      throw error;
+    }
+    cursor = event.offset;
+    const payload = event.payload as RequestedPayload;
+
+    if (Date.parse(payload.expiresAt) <= Date.now()) {
+      prompts.log.warn(`Skipping #${event.offset} ${payload.method} ${payload.url} — expired.`);
+      continue;
+    }
+
+    renderHeldRequest(event.offset, payload);
+    const approved = await prompts.confirm({
+      message: `Approve ${payload.method} ${new URL(payload.url).host}?`,
+      initialValue: false,
+    });
+    if (prompts.isCancel(approved)) {
+      prompts.outro("Stopped. Held requests will auto-reject on their timeouts.");
+      return;
+    }
+
+    if (approved) {
+      const grant: { approvalRequestEventOffset: number; keyId?: string; signature?: string } = {
+        approvalRequestEventOffset: event.offset,
+      };
+      if (key !== null) {
+        const spinner = prompts.spinner();
+        spinner.start(key.kind === "secure-enclave" ? "Signing — check Touch ID..." : "Signing...");
+        try {
+          grant.keyId = key.keyId;
+          grant.signature = await signApprovalMessage(
+            key,
+            buildApprovalMessage({
+              projectId: input.projectId,
+              approvalRequestEventOffset: event.offset,
+              requested: payload,
+              decision: "granted",
+            }),
+          );
+          spinner.stop("Signed.");
+        } catch (error) {
+          spinner.stop("Signing failed.");
+          prompts.log.error(error instanceof Error ? error.message : String(error));
+          continue;
+        }
+      }
+      await stream.append({ type: GRANTED, payload: grant });
+      prompts.log.success(`Granted #${event.offset} — request released.`);
+    } else {
+      await stream.append({
+        type: REJECTED,
+        payload: { approvalRequestEventOffset: event.offset, reason: "human" },
+      });
+      prompts.log.warn(`Rejected #${event.offset}.`);
+    }
+  }
+}
+
+async function enroll(input: {
+  existing: StoredApprovalKey | null;
+  projectId: string;
+  softwareKey?: boolean;
+  stream: RpcStub<Stream>;
+}): Promise<StoredApprovalKey> {
+  const key =
+    input.existing ??
+    (await createApprovalKey({
+      projectId: input.projectId,
+      label: `${process.env.USER ?? "user"}@${process.platform}`,
+      software: input.softwareKey,
+      log: (message) => prompts.log.info(message),
+    }));
+  // Idempotent: re-running --enroll re-appends the same key and the reducer
+  // ignores known keyIds.
+  await input.stream.append({
+    type: KEY_ADDED,
+    payload: { keyId: key.keyId, publicKey: key.publicKey, label: key.label },
+  });
+  prompts.log.success(
+    `Enrolled ${key.kind} key ${key.keyId}. Grants from this machine now require ${
+      key.kind === "secure-enclave" ? "Touch ID" : "this key file"
+    }.`,
+  );
+  return key;
+}
+
+function renderHeldRequest(offset: number, payload: RequestedPayload): void {
+  const secretLine =
+    payload.secretPaths.length === 0
+      ? []
+      : [
+          `spends secret${payload.secretPaths.length > 1 ? "s" : ""}: ${payload.secretPaths.join(", ")}`,
+        ];
+  const preview =
+    payload.bodyPreview !== null && payload.bodyPreview.length > 200
+      ? `${payload.bodyPreview.slice(0, 200)}…`
+      : payload.bodyPreview;
+  const bodyLines =
+    preview === null
+      ? payload.bodySha256 === null
+        ? []
+        : [`body: sha256 ${payload.bodySha256.slice(0, 16)}…`]
+      : [`body: ${preview}`];
+  prompts.note(
+    [
+      `${payload.method} ${payload.url}`,
+      ...secretLine,
+      ...bodyLines,
+      `rule: ${payload.ruleKey}`,
+      `expires: ${payload.expiresAt}`,
+    ].join("\n"),
+    `Held egress request #${offset}`,
+  );
+}

--- a/packages/iterate/src/approve.ts
+++ b/packages/iterate/src/approve.ts
@@ -18,7 +18,10 @@ import * as prompts from "@clack/prompts";
 import type { RpcStub } from "capnweb";
 
 import { connectItx } from "../../../apps/os/src/itx-client.ts";
-import { buildApprovalMessage } from "../../../apps/os/src/domains/projects/egress-approvals.ts";
+import {
+  buildApprovalMessage,
+  type HumanApprovalRequestedPayload,
+} from "../../../apps/os/src/domains/projects/egress-approvals.ts";
 import type { ItxAuthCredentials, Project, Stream, StreamEvent } from "./itx-api.generated.ts";
 import {
   createApprovalKey,
@@ -30,19 +33,8 @@ import {
 const REQUESTED = "events.iterate.com/project/human-approval-requested";
 const GRANTED = "events.iterate.com/project/human-approval-granted";
 const REJECTED = "events.iterate.com/project/human-approval-rejected";
+const SETTLED = "events.iterate.com/project/human-approval-settled";
 const KEY_ADDED = "events.iterate.com/project/human-approval-key-added";
-
-/** The requested payload fields this UI renders and signs over. */
-type RequestedPayload = {
-  method: string;
-  url: string;
-  headers: Record<string, string>;
-  bodySha256: string | null;
-  bodyPreview: string | null;
-  secretPaths: string[];
-  ruleKey: string;
-  expiresAt: string;
-};
 
 export async function runApprovalCli(input: {
   auth: ItxAuthCredentials;
@@ -98,7 +90,7 @@ export async function runApprovalCli(input: {
       throw error;
     }
     cursor = event.offset;
-    const payload = event.payload as RequestedPayload;
+    const payload = event.payload as HumanApprovalRequestedPayload;
 
     if (Date.parse(payload.expiresAt) <= Date.now()) {
       prompts.log.warn(`Skipping #${event.offset} ${payload.method} ${payload.url} — expired.`);
@@ -141,7 +133,9 @@ export async function runApprovalCli(input: {
         }
       }
       await stream.append({ type: GRANTED, payload: grant });
-      prompts.log.success(`Granted #${event.offset} — request released.`);
+      // Granting is a claim, not a fact — the egress door verifies the
+      // signature and settles the request. Report what actually happened.
+      await reportSettlement({ approvalRequestEventOffset: event.offset, stream });
     } else {
       await stream.append({
         type: REJECTED,
@@ -149,6 +143,46 @@ export async function runApprovalCli(input: {
       });
       prompts.log.warn(`Rejected #${event.offset}.`);
     }
+  }
+}
+
+/**
+ * Watch for the held request's settlement and report the truth: released
+ * with an upstream status, failed delivery, rejected meanwhile, or — if
+ * nothing lands in time — that the platform hasn't accepted the grant (an
+ * unverifiable signature is silently ignored server-side by design).
+ */
+async function reportSettlement(input: {
+  approvalRequestEventOffset: number;
+  stream: RpcStub<Stream>;
+}): Promise<void> {
+  const spinner = prompts.spinner();
+  spinner.start("Waiting for the egress door to settle the request...");
+  try {
+    const settled = await input.stream.waitForEvent({
+      afterOffset: input.approvalRequestEventOffset,
+      eventTypes: [SETTLED, REJECTED],
+      predicate: (candidate) =>
+        (candidate.payload as { approvalRequestEventOffset?: number })
+          .approvalRequestEventOffset === input.approvalRequestEventOffset,
+      timeoutMs: 30_000,
+    });
+    const outcome = settled.payload as { status?: number; error?: string; reason?: string };
+    if (settled.type === SETTLED && outcome.error === undefined) {
+      spinner.stop(`Released #${input.approvalRequestEventOffset} — upstream ${outcome.status}.`);
+    } else if (settled.type === SETTLED) {
+      spinner.stop(
+        `Released #${input.approvalRequestEventOffset} but delivery failed: ${outcome.error}`,
+      );
+    } else {
+      spinner.stop(
+        `#${input.approvalRequestEventOffset} was rejected (${outcome.reason}) before the grant landed.`,
+      );
+    }
+  } catch {
+    spinner.stop(
+      `Grant appended, but #${input.approvalRequestEventOffset} has not settled — the egress door may have ignored an unverifiable signature, or the hold already expired.`,
+    );
   }
 }
 

--- a/packages/iterate/src/cli.ts
+++ b/packages/iterate/src/cli.ts
@@ -23,6 +23,7 @@ import type {
   Stream,
 } from "./itx-api.generated.ts";
 import { shareMyComputer } from "./use-my-computer.ts";
+import { runApprovalCli } from "./approve.ts";
 import {
   CONFIG_PATH,
   Config,
@@ -1100,6 +1101,75 @@ const launcherProcedures = {
         projectId,
         headers: headersRecord(auth.requestHeaders),
         name: input.name,
+      });
+    }),
+
+  approve: os
+    .input(
+      z.object({
+        project: z
+          .string()
+          .trim()
+          .min(1)
+          .optional()
+          .describe(
+            "OS project id (prj_…) or slug. Defaults to the active config's defaultProject.",
+          ),
+        enroll: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "Generate this machine's approval key (Secure Enclave when available) and enroll it before listening.",
+          ),
+        softwareKey: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("With --enroll: force a software P-256 key instead of the Secure Enclave."),
+      }),
+    )
+    .meta({
+      description:
+        "Be the human in the loop for a project's egress: watch held outbound requests and approve or reject each one (Touch-ID-signed when an enclave key is enrolled). Runs until Ctrl-C.",
+    })
+    .handler(async ({ input }) => {
+      const resolved = resolveConfig(process.cwd(), { throw: true });
+
+      // Auth, exactly like `chat`: env secrets win (doppler/e2e), otherwise use
+      // the stored `iterate login` session, kicking off a browser login if none.
+      const envAuth = osAuthFromEnvironment();
+      let authHeaders: OsAuthHeaders | undefined;
+      if (!envAuth) {
+        try {
+          authHeaders = await getOsAuthHeaders(resolved.config, resolved.name);
+        } catch (error) {
+          if (!shouldAutoLoginForChat(error)) throw error;
+          console.error(
+            `No active session for ${resolved.config.osBaseUrl}. Starting browser login...`,
+          );
+          await loginToResolvedConfig(resolved);
+          authHeaders = await getOsAuthHeaders(resolved.config, resolved.name);
+        }
+      }
+      const auth = envAuth ?? osAuthFromHeaders(authHeaders!);
+
+      const projectId = await resolveChatProject({
+        auth,
+        baseUrl: resolved.config.osBaseUrl,
+        configName: resolved.name,
+        configPath: CONFIG_PATH,
+        configuredDefaultProject: resolved.config.defaultProject,
+        explicitProject: input.project,
+      });
+
+      await runApprovalCli({
+        auth: auth.credentials,
+        baseUrl: resolved.config.osBaseUrl,
+        projectId,
+        headers: headersRecord(auth.requestHeaders),
+        enroll: input.enroll,
+        softwareKey: input.softwareKey,
       });
     }),
 

--- a/packages/iterate/src/itx-api.generated.ts
+++ b/packages/iterate/src/itx-api.generated.ts
@@ -1412,6 +1412,25 @@ export type ProjectProcessorState = {
     createdAt: string;
     updatedAt: string;
   }[];
+  egressRules: {
+    ruleKey: string;
+    description: string;
+    match: {
+      hosts?: string[] | undefined;
+      methods?: string[] | undefined;
+      pathPrefix?: string | undefined;
+      secretPaths?: string[] | undefined;
+    };
+    verdict: "deny" | "hold";
+    approvalTimeoutMs: number;
+  }[];
+  humanApprovalKeys: {
+    keyId: string;
+    publicKey: string;
+    label: string;
+    addedAt: string;
+    revokedAt: string | null;
+  }[];
 };
 
 /**

--- a/packages/iterate/src/run-command.ts
+++ b/packages/iterate/src/run-command.ts
@@ -1,0 +1,16 @@
+import { spawn } from "node:child_process";
+
+/** Spawn a command, optionally feed it stdin, and collect its result. */
+export function run(command: string, args: string[], stdin?: string) {
+  return new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve, reject) => {
+    const child = spawn(command, args);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("error", reject);
+    // A signal-killed child reports a null code; surface that as a failure, not 0.
+    child.on("close", (code) => resolve({ stdout, stderr, exitCode: code ?? 1 }));
+    if (stdin !== undefined) child.stdin.end(stdin);
+  });
+}

--- a/packages/iterate/src/use-my-computer.ts
+++ b/packages/iterate/src/use-my-computer.ts
@@ -16,7 +16,6 @@
 // (b) keeping the socket alive so agents can reach it.
 // ─────────────────────────────────────────────────────────────────────────────
 
-import { spawn } from "node:child_process";
 import { hostname } from "node:os";
 
 import * as prompts from "@clack/prompts";
@@ -24,6 +23,7 @@ import type { RpcStub } from "capnweb";
 
 import { connectItx } from "../../../apps/os/src/itx-client.ts";
 import type { ItxAuthCredentials, Project } from "./itx-api.generated.ts";
+import { run } from "./run-command.ts";
 
 /**
  * The object we lend to the project. Each method becomes callable by agents as
@@ -175,21 +175,6 @@ export async function shareMyComputer(input: {
 }
 
 // ── tiny local helpers ───────────────────────────────────────────────────────
-
-/** Spawn a command, optionally feed it stdin, and collect its result. */
-function run(command: string, args: string[], stdin?: string) {
-  return new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve, reject) => {
-    const child = spawn(command, args);
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (d) => (stdout += d));
-    child.stderr.on("data", (d) => (stderr += d));
-    child.on("error", reject);
-    // A signal-killed child reports a null code; surface that as a failure, not 0.
-    child.on("close", (code) => resolve({ stdout, stderr, exitCode: code ?? 1 }));
-    if (stdin !== undefined) child.stdin.end(stdin);
-  });
-}
 
 /** Run an AppleScript snippet, throwing if osascript reports failure (e.g. the human cancels). */
 async function osascript(script: string) {


### PR DESCRIPTION
## What

Outbound requests from a project can now require a human. Egress rules (project state, set wholesale via `project/egress-rules-configured`) are matched at the Project DO's egress decision point — the one door all dynamic-worker and sandbox traffic already goes through. First match wins:

- **`hold`** parks the request with the caller's fetch promise open, appends `project/human-approval-requested` to the project stream, and waits for a resolution (or the rule's `approvalTimeoutMs`, default 10min, auto-rejects with reason `expired`).
- **`deny`** refuses synchronously with a 403.

A held request's identity is **the offset of its requested event** — no minted ids. Grants/rejections reference it as `approvalRequestEventOffset`. After release, `human-approval-settled` records what upstream actually returned — approval and outcome are separate facts.

Rules match on host (exact or `*.` wildcard), method, path prefix, and **referenced secret paths** — so "any request spending `/secrets/stripe/prod` needs a human" works regardless of destination, and the approval prompt can honestly say which secret a request spends: the gate runs pre-substitution, so events carry `getSecret(...)` placeholders, never material.

## Unforgeable approvals (Secure Enclave)

`project/human-approval-key-added` enrolls a P-256 public key. Once any active key exists, **grants must carry a valid signature** (raw 64-byte r‖s over the canonical `approval.v1` message — recomputable forever from the requested event alone) or they're ignored. Rejections never need a signature: deny is the fail-safe direction.

`iterate approve` is the human side: a local stream processor over normal itx that live-tails requested events, renders each held request (clack), and appends the verdict. `--enroll` mints this machine's key — on macOS a **Secure Enclave** key via a vendored single-file Swift helper (compiled with swiftc on first use, cached; `.biometryCurrentSet` forces Touch ID per signature and dies on biometric re-enrollment; DER→raw converted CLI-side), software P-256 elsewhere (`--software-key`).

## Demo

```bash
pnpm dev start --detach
# terminal 1 — enroll + listen (Touch ID on grants):
cd packages/iterate && bun bin/iterate.js approve --project <slug> --enroll
# terminal 2 — configure a rule and fire a held request:
doppler run --config dev -- pnpm cli itx run --project <slug> 'async (itx) => {
  await itx.streams.get("/").append({
    type: "events.iterate.com/project/egress-rules-configured",
    payload: { rules: [{ ruleKey: "post-httpbin", match: { hosts: ["httpbin.org"], methods: ["POST"] }, verdict: "hold", description: "POSTs to httpbin need a human" }] },
  });
  const res = await fetch("https://httpbin.org/post", { method: "POST", body: "hi" }); // ← hangs here until you answer
  return res.status;
}'
```

## Notes for review

- **Design deviation from the grilled plan**: instead of a `requireHumanApproval` flag on secrets (a second policy surface coupled to per-secret DO state), rules gained `match.secretPaths` — one policy surface, evaluated against the secret refs the egress path already extracts.
- The hold's cross-DO wait is chunked (≤25s per `waitForEvent` call, cursor-resumed) so no single RPC stays open for the whole TTL.
- MVP semantics: a DO restart mid-hold fails the caller's fetch; the requested event survives and the audit trail stays truthful. Reconciler-owned exactly-once release is the known follow-up.
- Deny returns 403 without an event; expiry appends `human-approval-rejected {reason: "expired"}` idempotently.
- `packages/iterate`'s own `tsgo` typecheck and `node bin/iterate.js` were already red on main (root typecheck/test exclude the package); `bun bin/iterate.js` and `pnpm --dir packages/iterate build` (what pkg-pr-new CI runs) are green including the new command.

## Testing

- Unit (`egress-approvals.test.ts`, 8 tests): rule matching (wildcards, conjunctive matchers, first-match-wins, secret paths), canonical message determinism + field binding, WebCrypto verify happy/tamper/wrong-key/garbage, DER→raw against a node:crypto-produced DER signature.
- E2e (`egress-approvals.e2e.test.ts`, green against local dev): hold→grant→release with the real upstream response + settled event; human reject→403; deny→403; 1.5s-timeout expiry→auto-reject; and with an enrolled key, unsigned + bad-signature grants are inert while the signed grant releases (settled lands strictly after it).
- Swift helper compiles clean (smoke-extracted + `swiftc`'d); full Touch ID loop needs a human — recipe above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the central project egress gate for all outbound traffic, including long-lived holds, crypto trust boundaries, and DO restart behavior mid-hold; mistakes could block or incorrectly release sensitive calls.
> 
> **Overview**
> Adds **human-in-the-loop egress approvals** on the Project Durable Object outbound path: configurable rules (`hold` / `deny`) are folded into project state and evaluated **before** secret substitution, using placeholder request metadata (including `getSecret` paths).
> 
> **`hold`** keeps the caller’s fetch open, appends `human-approval-requested` (identity = event offset), and waits on the project stream for grant/reject or timeout; **`deny`** returns 403 immediately. After a grant, the buffered request runs through normal egress and `human-approval-settled` records the upstream outcome.
> 
> New pure logic in `egress-approvals.ts` covers rule matching, canonical `approval.v1` messages, and P-256 grant verification; once any approval key is enrolled, unsigned or invalid grants are **ignored** (not fatal). The project processor contract/implementation gains egress rules, approval keys, and the related stream events.
> 
> **`iterate approve`** live-tails held requests over itx, prompts approve/reject, signs grants (Secure Enclave on macOS or software P-256), and supports `--enroll`. Unit and e2e tests cover matching, crypto, and full hold/grant/reject/deny/expiry/signed-grant flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b9163ea1f5b53256fe47b7918914a7d96f16686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +1,455 -16 | +1,140 -13 🟩🟩🟩🟩🟩 |
| Tests | +544 -0 | +474 -0 🟩🟩⬜⬜⬜ |
| Generated | +57 -0 | +57 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+2,056 -16** | **+1,671 -13** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 58d7bd2 and 3b9163e, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-11T09:39:39.656Z",
      "headSha": "3b9163ea1f5b53256fe47b7918914a7d96f16686",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/53244733118726",
      "shortSha": "3b9163e",
      "cleanupDurationMs": 10676,
      "deployDurationMs": 61587,
      "testDurationMs": 159451,
      "testRetries": "7 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · concurrent long-running ITX scripts all complete (vitest x1) · state-only stream subscribe pushes initial state immediately, then state after appends (vitest x1) · a new user can create a project through the UI form (specs x1) · runs \"files-roundtrip\" through the project REPL (specs x1) · toggle a markdown file between Code and its rendered Preview (specs x1) · toggle an svg file between Code and its sandboxed Preview (specs x1)",
      "workerSizeKib": 15765.56,
      "workerGzipKib": 4264.23,
      "mainWorkerGzipKib": 4259.72
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-11T09:39:30.050Z",
      "headSha": "a2d26a9f4fa09d48cd8c0df58d0520614f82d32f",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/151895720125133",
      "shortSha": "a2d26a9",
      "cleanupDurationMs": 1059,
      "deployDurationMs": 14347,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-11T09:39:32.422Z",
      "headSha": "3b9163ea1f5b53256fe47b7918914a7d96f16686",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/53244733118726",
      "shortSha": "3b9163e",
      "cleanupDurationMs": 3427,
      "deployDurationMs": 17113,
      "testDurationMs": 576,
      "testRetries": null,
      "workerSizeKib": 4031.55,
      "workerGzipKib": 819.21,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-11T09:39:30.099Z",
      "headSha": "a2d26a9f4fa09d48cd8c0df58d0520614f82d32f",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/151895720125133",
      "shortSha": "a2d26a9",
      "cleanupDurationMs": 1101,
      "deployDurationMs": 15512,
      "workerSizeKib": 4717.83,
      "workerGzipKib": 1357.63,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `3b9163e` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 819.2 KiB | 17.1s | 576ms |  | 3.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/53244733118726) | 2026-07-11T09:39:32.422Z | Preview app released. |
| OS | released | `3b9163e` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.16 MiB (+4.5 KiB vs main) | 61.6s | 159.5s | 7 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · concurrent long-running ITX scripts all complete (vitest x1) · state-only stream subscribe pushes initial state immediately, then state after appends (vitest x1) · a new user can create a project through the UI form (specs x1) · runs "files-roundtrip" through the project REPL (specs x1) · toggle a markdown file between Code and its rendered Preview (specs x1) · toggle an svg file between Code and its sandboxed Preview (specs x1) | 10.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/53244733118726) | 2026-07-11T09:39:39.656Z | Preview app released. |
| Semaphore | released | `a2d26a9` | [https://semaphore.iterate-preview-1.com](https://semaphore.iterate-preview-1.com) | 440.8 KiB | 14.3s |  |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/151895720125133) | 2026-07-11T09:39:30.050Z | Preview app released. |
| Streams Example App | released | `a2d26a9` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.33 MiB | 15.5s |  |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/151895720125133) | 2026-07-11T09:39:30.099Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->