### PR TITLE
Flip prd to the AI Gateway BYOK lane; itx cf.ai.run passes options through

### DIFF
--- a/apps/os/src/domains/itx/cf-capabilities.ts
+++ b/apps/os/src/domains/itx/cf-capabilities.ts
@@ -43,6 +43,21 @@ export type CfMarkdownConversionArgs =
   | []
   | [documents: CfMarkdownDocument | CfMarkdownDocument[], options?: CfMarkdownConversionOptions];
 
+/** The Workers AI binding's per-call options (`env.AI.run`'s third argument),
+ * published structurally so itx callers can route a call through a specific
+ * AI Gateway configuration — e.g. `{ gateway: { id: "default", skipCache: true } }`. */
+export type CfAiRunOptions = {
+  gateway?: {
+    id: string;
+    cacheKey?: string;
+    cacheTtl?: number;
+    skipCache?: boolean;
+    metadata?: Record<string, number | string | boolean | null>;
+    collectLog?: boolean;
+  };
+  returnRawResponse?: boolean;
+};
+
 export type CfBrowserQuickAction =
   | "content"
   | "screenshot"

--- a/apps/os/src/itx-api.generated.ts
+++ b/apps/os/src/itx-api.generated.ts
@@ -266,8 +266,11 @@ export interface Ai {
   __describe(): Promise<Description>;
   /** List the Workers AI model catalog. */
   models(): Promise<unknown>;
-  /** Run one model invocation (`run("@cf/meta/llama-3.1-8b-instruct", { prompt })`). */
-  run(model: string, body: unknown): Promise<unknown>;
+  /** Run one model invocation (`run("@cf/meta/llama-3.1-8b-instruct", { prompt })`).
+   * The optional third argument is the binding's own options object — e.g.
+   * `{ gateway: { id: "default", skipCache: true } }` — passed through to
+   * `env.AI.run`; its `gateway` wins over any constructor-provided one. */
+  run(model: string, body: unknown, options?: CfAiRunOptions): Promise<unknown>;
   /** Convert documents (`{ name, blob }`) to Markdown; call with no args for the supported-format list. */
   toMarkdown(
     ...args: CfMarkdownConversionArgs
@@ -1615,6 +1618,21 @@ export type StreamIndexRow = {
   lastType: string;
   /** How many events we've observed on the stream. */
   eventCount: number;
+};
+
+/** The Workers AI binding's per-call options (`env.AI.run`'s third argument),
+ * published structurally so itx callers can route a call through a specific
+ * AI Gateway configuration — e.g. `{ gateway: { id: "default", skipCache: true } }`. */
+export type CfAiRunOptions = {
+  gateway?: {
+    id: string;
+    cacheKey?: string;
+    cacheTtl?: number;
+    skipCache?: boolean;
+    metadata?: Record<string, number | string | boolean | null>;
+    collectLog?: boolean;
+  };
+  returnRawResponse?: boolean;
 };
 
 export type CfMarkdownConversionArgs =

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -185,6 +185,7 @@ import type {
   CfBrowserQuickAction,
   CfBrowserQuickActionOptions,
   CfImageTransformInput,
+  CfAiRunOptions,
   CfMarkdownConversionArgs,
   CfMarkdownConversionResult,
   CfMarkdownSupportedFormat,
@@ -1801,11 +1802,14 @@ class AiRpcTarget extends IterateRpcTarget<"Ai"> {
     return Promise.resolve(env.AI.models());
   }
 
-  /** Run one model invocation (`run("@cf/meta/llama-3.1-8b-instruct", { prompt })`). */
-  run(model: string, body: unknown): Promise<unknown> {
-    const options: AiRunOptions | undefined =
-      this.props.gateway === undefined ? undefined : { gateway: this.props.gateway };
-    return env.AI.run(model, body as Record<string, unknown>, options);
+  /** Run one model invocation (`run("@cf/meta/llama-3.1-8b-instruct", { prompt })`).
+   * The optional third argument is the binding's own options object — e.g.
+   * `{ gateway: { id: "default", skipCache: true } }` — passed through to
+   * `env.AI.run`; its `gateway` wins over any constructor-provided one. */
+  run(model: string, body: unknown, options?: CfAiRunOptions): Promise<unknown> {
+    const gateway = options?.gateway ?? this.props.gateway;
+    const merged = gateway === undefined ? options : { ...options, gateway };
+    return env.AI.run(model, body as Record<string, unknown>, merged as AiRunOptions | undefined);
   }
 
   /** Convert documents (`{ name, blob }`) to Markdown; call with no args for the supported-format list. */

--- a/apps/os/src/types-source.generated.ts
+++ b/apps/os/src/types-source.generated.ts
@@ -271,8 +271,11 @@ export interface Ai {
   __describe(): Promise<Description>;
   /** List the Workers AI model catalog. */
   models(): Promise<unknown>;
-  /** Run one model invocation (\`run("@cf/meta/llama-3.1-8b-instruct", { prompt })\`). */
-  run(model: string, body: unknown): Promise<unknown>;
+  /** Run one model invocation (\`run("@cf/meta/llama-3.1-8b-instruct", { prompt })\`).
+   * The optional third argument is the binding's own options object — e.g.
+   * \`{ gateway: { id: "default", skipCache: true } }\` — passed through to
+   * \`env.AI.run\`; its \`gateway\` wins over any constructor-provided one. */
+  run(model: string, body: unknown, options?: CfAiRunOptions): Promise<unknown>;
   /** Convert documents (\`{ name, blob }\`) to Markdown; call with no args for the supported-format list. */
   toMarkdown(
     ...args: CfMarkdownConversionArgs
@@ -1620,6 +1623,21 @@ export type StreamIndexRow = {
   lastType: string;
   /** How many events we've observed on the stream. */
   eventCount: number;
+};
+
+/** The Workers AI binding's per-call options (\`env.AI.run\`'s third argument),
+ * published structurally so itx callers can route a call through a specific
+ * AI Gateway configuration — e.g. \`{ gateway: { id: "default", skipCache: true } }\`. */
+export type CfAiRunOptions = {
+  gateway?: {
+    id: string;
+    cacheKey?: string;
+    cacheTtl?: number;
+    skipCache?: boolean;
+    metadata?: Record<string, number | string | boolean | null>;
+    collectLog?: boolean;
+  };
+  returnRawResponse?: boolean;
 };
 
 export type CfMarkdownConversionArgs =

--- a/envs.ts
+++ b/envs.ts
@@ -143,9 +143,11 @@ export const envs = {
     authBaseUrl: "https://auth.iterate.com",
     projectHostnameBases: ["iterate.app"],
     cloudflareForSaasProjectHostnameBases: ["iterate.app"],
-    // Unified billing for now; flipping prd to BYOK (still without the
-    // response cache) is a deliberate follow-up once previews have soaked.
-    cloudflareAiGatewayTransport: "unified",
+    // BYOK, like every other env: unified billing meters OpenAI-prompt-cached
+    // tokens at the uncached price (~6x at our hit rate), and BYOK benchmarked
+    // latency-neutral-or-better. NO response cache here — that knob stays
+    // preview/dev-only; a real user must never receive a cached agent reply.
+    cloudflareAiGatewayTransport: "byok",
     resources: {
       projectDirectoryKvId: "79d78df2e83b46d2b9083533e9f189c4",
       workerBuildCacheKvId: "43306c224d364c7aa804c3ff762c4d08",

--- a/packages/iterate/src/itx-api.generated.ts
+++ b/packages/iterate/src/itx-api.generated.ts
@@ -266,8 +266,11 @@ export interface Ai {
   __describe(): Promise<Description>;
   /** List the Workers AI model catalog. */
   models(): Promise<unknown>;
-  /** Run one model invocation (`run("@cf/meta/llama-3.1-8b-instruct", { prompt })`). */
-  run(model: string, body: unknown): Promise<unknown>;
+  /** Run one model invocation (`run("@cf/meta/llama-3.1-8b-instruct", { prompt })`).
+   * The optional third argument is the binding's own options object — e.g.
+   * `{ gateway: { id: "default", skipCache: true } }` — passed through to
+   * `env.AI.run`; its `gateway` wins over any constructor-provided one. */
+  run(model: string, body: unknown, options?: CfAiRunOptions): Promise<unknown>;
   /** Convert documents (`{ name, blob }`) to Markdown; call with no args for the supported-format list. */
   toMarkdown(
     ...args: CfMarkdownConversionArgs
@@ -1615,6 +1618,21 @@ export type StreamIndexRow = {
   lastType: string;
   /** How many events we've observed on the stream. */
   eventCount: number;
+};
+
+/** The Workers AI binding's per-call options (`env.AI.run`'s third argument),
+ * published structurally so itx callers can route a call through a specific
+ * AI Gateway configuration — e.g. `{ gateway: { id: "default", skipCache: true } }`. */
+export type CfAiRunOptions = {
+  gateway?: {
+    id: string;
+    cacheKey?: string;
+    cacheTtl?: number;
+    skipCache?: boolean;
+    metadata?: Record<string, number | string | boolean | null>;
+    collectLog?: boolean;
+  };
+  returnRawResponse?: boolean;
 };
 
 export type CfMarkdownConversionArgs =


### PR DESCRIPTION
Follow-ups to #1849, now that previews have soaked green.

## prd → BYOK

`cloudflareAiGatewayTransport: "unified" → "byok"` for prd. Unified billing meters OpenAI-prompt-cached tokens at the uncached price (~6× at our ~95% hit rate — confirmed with Cloudflare); BYOK bills our own OpenAI key with the real cache discount, and benchmarked latency-neutral-or-better (median +29% decode throughput, tighter TTFT tail). **prd still gets NO response cache** — that knob stays preview/dev-only.

Prerequisites verified before the flip: prd's `APP_CONFIG_OPEN_AI_API_KEY` is live (200 against api.openai.com), and the prd account's gateway `default` is the one already carrying our traffic.

## itx `cf.ai.run` options passthrough

`itx.integrations.cf.ai.run(model, body, options)` silently dropped its third argument (gateway options only existed via constructor props nobody set). It now passes binding options through — `options.gateway` wins over constructor props — published as `CfAiRunOptions` in the itx contract (the generator can't serialize the `Env`-derived internal type; regenerated `itx-api.generated.ts` + package copy + types-source).

**Proven live** with a cache-key collision: two *different* prompts sharing a forced `gateway.cacheKey` — the second request replayed the first one's answer (`asked BANANA, got APPLE`), which is only possible if the options reach the gateway.

## Rollout note

On merge, prd agents' LLM turns switch to our OpenAI key via the gateway universal endpoint. Same gateway, same analytics, same models; `cloudflareAiGatewayResponseCacheStatus` will be absent on prd (no cache TTL configured — correct). Will verify with a live prd agent turn + analytics after deploy and report real numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Merging flips production agent LLM routing and billing to BYOK on deploy; incorrect gateway options could change caching or routing for scripted `cf.ai.run` calls.
> 
> **Overview**
> **Production** switches `cloudflareAiGatewayTransport` from **unified** to **BYOK** so agent LLM traffic bills against the deployment OpenAI key with real prompt-cache pricing; comments clarify prd still has **no** AI Gateway response cache (that stays preview/dev-only).
> 
> **ITX Workers AI** exposes a new `CfAiRunOptions` type and extends `Ai.run(model, body, options?)` so per-call binding options (especially `gateway`) reach `env.AI.run`. The RPC implementation merges options with any constructor default gateway, with **per-call `options.gateway` winning**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e25dd445d996b458eb346bbfc9a2448acb1acb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +24 -5 | +16 -4 🟩🟩⬜⬜⬜ |
| Other | +5 -3 | +1 -1 🟩⬜⬜⬜⬜ |
| Generated | +60 -6 | +43 -4 🟩🟩🟩🟩🟩 |
| **Total** | **+89 -14** | **+60 -9** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 58d7bd2 and 2e25dd4, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->