### PR TITLE
BYOK lane: explicit cf-aig-skip-cache when no response-cache TTL is configured

### DIFF
--- a/apps/os/src/domains/agents/workers-ai-transport.test.ts
+++ b/apps/os/src/domains/agents/workers-ai-transport.test.ts
@@ -210,6 +210,9 @@ describe("the BYOK gateway lane", () => {
     const request = fake.requests[0]!;
     expect(request.headers).not.toHaveProperty("cf-aig-cache-ttl");
     expect(request.headers).not.toHaveProperty("cf-aig-cache-key");
+    // ...and the gateway's dashboard-level cache default is explicitly
+    // opted out of: no-TTL deployments must never serve a cached reply.
+    expect(request.headers["cf-aig-skip-cache"]).toBe("true");
     // No header on the response either -> no cache-status claim in evidence.
     expect(completion.rawResponse).not.toHaveProperty("cloudflareAiGatewayResponseCacheStatus");
   });

--- a/apps/os/src/domains/agents/workers-ai-transport.ts
+++ b/apps/os/src/domains/agents/workers-ai-transport.ts
@@ -151,6 +151,13 @@ async function runByokAttempt(input: {
   if (ttlSeconds !== undefined) {
     headers["cf-aig-cache-ttl"] = String(ttlSeconds);
     headers["cf-aig-cache-key"] = await cloudflareAiGatewayResponseCacheKey(body);
+  } else {
+    // No TTL configured means this deployment must NEVER serve a cached
+    // reply (prd). Said explicitly per request: the gateway otherwise falls
+    // back to its dashboard-level cache setting, which is account state this
+    // code can't see — live prd evidence showed cache lookups (MISS) even
+    // with no cache headers sent.
+    headers["cf-aig-skip-cache"] = "true";
   }
   const response = await input.deadline.race(
     gateway.run({ provider: "openai", endpoint: "chat/completions", headers, query: body }),


### PR DESCRIPTION
Hardening found while verifying #1853 on prd: the live BYOK evidence showed `cf-aig-cache-status: MISS` on prd turns even though we send no cache headers there — meaning the gateway consults its **dashboard-level cache setting**, account state our code can't see. The "prd never serves a cached agent reply" guarantee was one dashboard toggle away from silently breaking.

Now the no-TTL path (prd) sends `cf-aig-skip-cache: true` explicitly per request, making the opt-out code-enforced. Cache-opted deployments (previews/dev) are unchanged. One line + a test assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow transport header change on the existing no-TTL BYOK path; preview/dev caching with TTL is untouched.
> 
> **Overview**
> **BYOK requests without `responseCacheTtlSeconds` now send `cf-aig-skip-cache: true`** so Cloudflare AI Gateway cannot serve a cached reply from account-level dashboard cache settings.
> 
> Previously the no-TTL path (typical production) omitted cache headers entirely; live evidence showed the gateway still performed cache lookups. Opt-in response caching (`cf-aig-cache-ttl` / `cf-aig-cache-key`) is unchanged when a TTL is configured.
> 
> The BYOK test for the no-cache-header case now asserts `cf-aig-skip-cache` is `"true"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2f3699c7435709d2884a6300cfa9561bb3cea67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +7 -0 | +2 -0 🟩🟩🟩🟩🟩 |
| Tests | +3 -0 | +1 -0 🟩🟩🟩⬜⬜ |
| **Total** | **+10 -0** | **+3 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 644dc97 and c2f3699, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->