### PR TITLE
[codex] Tune stream side panels

### DIFF
--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -439,7 +439,7 @@ function StreamEventsSheet({ children, streamPath }: { children: ReactNode; stre
     >
       <SheetContent
         side="right"
-        className="flex w-full flex-col gap-0 p-0 sm:max-w-2xl"
+        className="flex w-full flex-col gap-0 p-0 data-[side=right]:sm:w-[56vw] data-[side=right]:sm:max-w-[92vw]"
         showCloseButton={false}
       >
         <SheetTitle className="sr-only">Stream events for {streamPath}</SheetTitle>

--- a/apps/os/src/components/stream-processors-panel.tsx
+++ b/apps/os/src/components/stream-processors-panel.tsx
@@ -278,7 +278,7 @@ export function StreamProcessorsPanel({
       <SheetContent
         side="right"
         showCloseButton={false}
-        className="flex h-full w-full flex-col gap-0 p-0 data-[side=right]:sm:w-[min(92vw,48rem)] data-[side=right]:sm:max-w-[min(92vw,55vw)]"
+        className="flex h-full w-full flex-col gap-0 p-0 data-[side=right]:sm:w-[56vw] data-[side=right]:sm:max-w-[92vw]"
       >
         <SheetTitle className="sr-only">
           {focused == null ? "Processors" : `Processor ${presenceLabel(focused)}`}

--- a/apps/os/src/components/stream-view-header.tsx
+++ b/apps/os/src/components/stream-view-header.tsx
@@ -183,7 +183,7 @@ export function StreamViewHeader({
             ) : null}
           </>
         )}
-        <StreamActionMenu kill={streamKill} pause={agentPause} />
+        {agentPause == null ? null : <StreamActionMenu kill={streamKill} pause={agentPause} />}
       </div>
     </header>
   );
@@ -236,13 +236,13 @@ function StreamActionMenu({
     kill: () => Promise<void>;
     pending: boolean;
   };
-  pause?: {
+  pause: {
     paused: boolean;
     pending: boolean;
     setPaused: (paused: boolean) => Promise<void>;
   };
 }) {
-  const PauseActionIcon = pause?.paused ? PlayIcon : PauseIcon;
+  const PauseActionIcon = pause.paused ? PlayIcon : PauseIcon;
 
   return (
     <DropdownMenu>
@@ -251,7 +251,7 @@ function StreamActionMenu({
           <Button
             variant="ghost"
             size="icon"
-            title={pause == null ? "Stream actions" : "Agent actions"}
+            title="Agent actions"
             className="rounded-full text-muted-foreground"
           />
         }
@@ -260,19 +260,15 @@ function StreamActionMenu({
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-44">
         <DropdownMenuGroup>
-          <DropdownMenuLabel>
-            {pause == null ? "Stream actions" : "Agent actions"}
-          </DropdownMenuLabel>
-          {pause == null ? null : (
-            <DropdownMenuItem
-              closeOnClick
-              disabled={pause.pending}
-              onClick={() => void pause.setPaused(!pause.paused)}
-            >
-              {pause.pending ? <Spinner /> : <PauseActionIcon />}
-              {pause.paused ? "Resume agent" : "Pause agent"}
-            </DropdownMenuItem>
-          )}
+          <DropdownMenuLabel>Agent actions</DropdownMenuLabel>
+          <DropdownMenuItem
+            closeOnClick
+            disabled={pause.pending}
+            onClick={() => void pause.setPaused(!pause.paused)}
+          >
+            {pause.pending ? <Spinner /> : <PauseActionIcon />}
+            {pause.paused ? "Resume agent" : "Pause agent"}
+          </DropdownMenuItem>
           <DropdownMenuItem
             closeOnClick
             disabled={kill.pending}

--- a/apps/os/src/routes/_app/projects/$projectSlug/integrations.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/integrations.tsx
@@ -725,7 +725,7 @@ function IntegrationFeedSheet({
   return (
     <Sheet open={feedPanel != null} onOpenChange={onOpenChange}>
       {feedPanel == null ? null : (
-        <SheetContent className="w-full gap-0 data-[side=right]:sm:w-[min(92vw,56rem)] data-[side=right]:sm:max-w-[min(92vw,56rem)]">
+        <SheetContent className="w-full gap-0 data-[side=right]:sm:w-[56vw] data-[side=right]:sm:max-w-[92vw]">
           <SheetHeader className="sr-only">
             <SheetTitle>{feedPanel.streamPath} feed</SheetTitle>
           </SheetHeader>


### PR DESCRIPTION
## Summary

- widen right-edge stream inspection sheets to 56vw on non-mobile viewports
- hide the shared stream action dropdown outside agent stream UI
- keep pause/resume and kill stream available from agent actions

## Validation

- `pnpm --dir apps/os typecheck`
- `pnpm lint`
- local visual check at `http://localhost:62620/projects/pr-ui-shot/repos/config?file=worker.ts&events=true`
- measured repo events sheet at 716.8px / 1280px = 56.0% viewport width

## Screenshots

Repo events sheet, desktop width:

![repo-events-sheet-desktop.png](https://github.com/user-attachments/assets/64586ff9-4954-4179-92d4-47724f7c3a95)

Repo stream header with non-agent actions hidden:

![repo-header-no-actions.png](https://github.com/user-attachments/assets/ce5420e6-b1a5-4f23-9482-9b9632cad3f7)

Agent stream action menu still available:

![agent-actions-menu.png](https://github.com/user-attachments/assets/50023e56-9900-4be4-8a05-2856f856861c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0df7387c358c40b889106f9b2b55e8b879301bff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-10T21:19:47.041Z",
      "headSha": "0df7387c358c40b889106f9b2b55e8b879301bff",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/557488189485815",
      "shortSha": "0df7387",
      "cleanupDurationMs": 9205,
      "deployDurationMs": 85603,
      "testDurationMs": 107853,
      "testRetries": "1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 15749.8,
      "workerGzipKib": 4259.72,
      "mainWorkerGzipKib": 4259.72
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-10T21:19:40.687Z",
      "headSha": "0df7387c358c40b889106f9b2b55e8b879301bff",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/557488189485815",
      "shortSha": "0df7387",
      "cleanupDurationMs": 2849,
      "deployDurationMs": 20652,
      "testDurationMs": 669,
      "testRetries": null,
      "workerSizeKib": 4031.55,
      "workerGzipKib": 819.23,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `0df7387` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 819.2 KiB | 20.7s | 669ms |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/557488189485815) | 2026-07-10T21:19:40.687Z | Preview app released. |
| OS | released | `0df7387` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 4.16 MiB (±0 vs main) | 85.6s | 107.9s | 1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 9.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/557488189485815) | 2026-07-10T21:19:47.041Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->