### PR TITLE
Native Swift approver: dialog + Touch ID in one gesture, key lifecycle

### DIFF
--- a/packages/iterate/src/approval-keys.ts
+++ b/packages/iterate/src/approval-keys.ts
@@ -136,7 +136,10 @@ export async function signApprovalMessage(
 ): Promise<string> {
   if (key.kind === "secure-enclave") {
     const approver = await ensureEnclaveApprover();
-    const signed = await runJson(approver, ["sign", key.keyBlob, bytesToBase64(message)]);
+    const signed = await runJson(approver, ["sign"], {
+      keyBlob: key.keyBlob,
+      message: bytesToBase64(message),
+    });
     const der = z.object({ signatureDer: z.string() }).parse(signed).signatureDer;
     return bytesToBase64(derSignatureToRaw(base64ToBytes(der)));
   }
@@ -174,12 +177,11 @@ export async function promptNativeApproval(input: {
       signatureDer: z.string().optional(),
     })
     .parse(
-      await runJson(approver, [
-        "approve",
-        input.key.keyBlob,
-        bytesToBase64(input.message),
-        Buffer.from(JSON.stringify(input.request)).toString("base64"),
-      ]),
+      await runJson(approver, ["approve"], {
+        keyBlob: input.key.keyBlob,
+        message: bytesToBase64(input.message),
+        request: input.request,
+      }),
     );
   if (answer.decision !== "granted") return { decision: answer.decision };
   return {
@@ -230,8 +232,12 @@ async function ensureEnclaveApprover(): Promise<string> {
   return binaryPath;
 }
 
-async function runJson(command: string, args: string[]): Promise<unknown> {
-  const result = await run(command, args);
+/**
+ * Run an approver command. Anything key-bearing travels as a JSON envelope on
+ * STDIN — argv is world-readable via ps, so the key blob never goes there.
+ */
+async function runJson(command: string, args: string[], stdin?: object): Promise<unknown> {
+  const result = await run(command, args, stdin === undefined ? undefined : JSON.stringify(stdin));
   if (result.exitCode !== 0) {
     throw new Error(
       `${command} ${args[0]} failed (exit ${result.exitCode}): ${result.stderr.trim() || "no output"}`,

--- a/packages/iterate/src/approval-keys.ts
+++ b/packages/iterate/src/approval-keys.ts
@@ -7,9 +7,13 @@
 // - "secure-enclave" (macOS): the private key lives in the Secure Enclave and
 //   physically cannot leave it; every signature demands a fresh Touch ID /
 //   Face ID check (`.biometryCurrentSet`, so re-enrolling biometrics kills
-//   the key). The key file holds only the public half and the keychain tag.
-//   A tiny vendored Swift helper (compiled with swiftc on first use, cached
-//   next to the key files) does the two enclave operations.
+//   the key). The key file holds the public half plus the CryptoKit
+//   `dataRepresentation` blob — an encrypted handle only this machine's
+//   enclave can use (no keychain: ad-hoc binaries lack the entitlement, same
+//   approach as age-plugin-se). Deleting the key file destroys the only
+//   handle. The native side is enclave-approver.swift — one file compiled
+//   with swiftc on first use (cache keyed by source hash, next to the key
+//   files) that owns keygen, signing, and the native approval dialog.
 //
 // - "software" (everywhere else / --software): a WebCrypto P-256 key whose
 //   private JWK sits in the key file. Same protocol, none of the hardware
@@ -19,8 +23,9 @@
 // enclave emits DER, converted here before anything leaves the machine.
 // ─────────────────────────────────────────────────────────────────────────────
 
+import { createHash } from "node:crypto";
 import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { homedir, tmpdir } from "node:os";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { z } from "zod/v4";
 import {
@@ -44,8 +49,8 @@ const StoredApprovalKey = z.discriminatedUnion("kind", [
     /** Base64 uncompressed P-256 public point (65 bytes). */
     publicKey: z.string(),
     label: z.string(),
-    /** Keychain application tag the enclave key is stored under. */
-    keychainTag: z.string(),
+    /** Base64 CryptoKit dataRepresentation — the enclave key's only handle. */
+    keyBlob: z.string(),
   }),
   z.object({
     kind: z.literal("software"),
@@ -87,16 +92,16 @@ export async function createApprovalKey(input: {
   let key: StoredApprovalKey;
   if (useEnclave) {
     log("Generating a Secure Enclave key (Touch ID guards every signature)...");
-    const helper = await ensureEnclaveHelper();
-    const keychainTag = `com.iterate.approve.${input.projectId}`;
-    const generated = await runJson(helper, ["generate", keychainTag]);
-    const publicKey = z.object({ publicKey: z.string() }).parse(generated).publicKey;
+    const approver = await ensureEnclaveApprover();
+    const generated = z
+      .object({ publicKey: z.string(), keyBlob: z.string() })
+      .parse(await runJson(approver, ["generate"]));
     key = {
       kind: "secure-enclave",
-      keyId: await approvalKeyId(publicKey),
-      publicKey,
+      keyId: await approvalKeyId(generated.publicKey),
+      publicKey: generated.publicKey,
       label: input.label,
-      keychainTag,
+      keyBlob: generated.keyBlob,
     };
   } else {
     log("Generating a software P-256 key (no Secure Enclave on this machine)...");
@@ -130,8 +135,8 @@ export async function signApprovalMessage(
   message: Uint8Array,
 ): Promise<string> {
   if (key.kind === "secure-enclave") {
-    const helper = await ensureEnclaveHelper();
-    const signed = await runJson(helper, ["sign", key.keychainTag, bytesToBase64(message)]);
+    const approver = await ensureEnclaveApprover();
+    const signed = await runJson(approver, ["sign", key.keyBlob, bytesToBase64(message)]);
     const der = z.object({ signatureDer: z.string() }).parse(signed).signatureDer;
     return bytesToBase64(derSignatureToRaw(base64ToBytes(der)));
   }
@@ -150,37 +155,79 @@ export async function signApprovalMessage(
   return bytesToBase64(new Uint8Array(signature));
 }
 
-// ── the Secure Enclave helper ────────────────────────────────────────────────
-
-const HELPER_VERSION = 1;
+/**
+ * One native dialog for one held request; approving signs in the same
+ * gesture (dialog button → Touch ID sheet), so what the human read is what
+ * the signature covers. Secure Enclave keys only — software keys have no
+ * native moment worth a dialog.
+ */
+export async function promptNativeApproval(input: {
+  key: Extract<StoredApprovalKey, { kind: "secure-enclave" }>;
+  message: Uint8Array;
+  /** The human-approval-requested payload, rendered by the dialog. */
+  request: Record<string, unknown>;
+}): Promise<{ decision: "granted"; signature: string } | { decision: "rejected" | "ignored" }> {
+  const approver = await ensureEnclaveApprover();
+  const answer = z
+    .object({
+      decision: z.enum(["granted", "rejected", "ignored"]),
+      signatureDer: z.string().optional(),
+    })
+    .parse(
+      await runJson(approver, [
+        "approve",
+        input.key.keyBlob,
+        bytesToBase64(input.message),
+        Buffer.from(JSON.stringify(input.request)).toString("base64"),
+      ]),
+    );
+  if (answer.decision !== "granted") return { decision: answer.decision };
+  return {
+    decision: "granted",
+    signature: bytesToBase64(derSignatureToRaw(base64ToBytes(answer.signatureDer!))),
+  };
+}
 
 /**
- * Compile the vendored Swift helper on first use (any Mac with the Xcode
- * command-line tools has swiftc) and cache the binary next to the key files.
+ * Destroy the LOCAL key material. The key file holds the enclave key's only
+ * handle (or the software key's private JWK), so deleting it is the
+ * destruction. The caller appends the `human-approval-key-revoked` event —
+ * deletion and revocation are separate acts, and revocation is the one that
+ * changes what the platform accepts.
  */
-async function ensureEnclaveHelper(): Promise<string> {
-  const helperPath = join(APPROVAL_KEYS_DIR, `enclave-signer-v${HELPER_VERSION}`);
+export async function deleteApprovalKey(projectId: string): Promise<void> {
+  await rm(keyPath(projectId), { force: true });
+}
+
+// ── the native enclave approver ──────────────────────────────────────────────
+
+/**
+ * Compile enclave-approver.swift on first use (any Mac with the Xcode
+ * command-line tools has swiftc) and cache the binary next to the key files,
+ * keyed by source hash — editing the Swift transparently recompiles.
+ */
+async function ensureEnclaveApprover(): Promise<string> {
+  const sourcePath = join(import.meta.dirname, "enclave-approver.swift");
+  const source = await readFile(sourcePath, "utf8");
+  const binaryPath = join(
+    APPROVAL_KEYS_DIR,
+    `enclave-approver-${createHash("sha256").update(source).digest("hex").slice(0, 8)}`,
+  );
   try {
-    await readFile(helperPath);
-    return helperPath;
+    await readFile(binaryPath);
+    return binaryPath;
   } catch {
     // fall through to compile
   }
   await mkdir(APPROVAL_KEYS_DIR, { recursive: true });
-  const sourcePath = join(tmpdir(), `iterate-enclave-signer-${process.pid}.swift`);
-  await writeFile(sourcePath, ENCLAVE_SIGNER_SWIFT);
-  try {
-    const compile = await run("swiftc", ["-O", "-o", helperPath, sourcePath]);
-    if (compile.exitCode !== 0) {
-      throw new Error(
-        `swiftc failed (exit ${compile.exitCode}) — install the Xcode command-line tools ` +
-          `(xcode-select --install) or use --software.\n${compile.stderr.trim()}`,
-      );
-    }
-  } finally {
-    await rm(sourcePath, { force: true });
+  const compile = await run("swiftc", ["-O", "-o", binaryPath, sourcePath]);
+  if (compile.exitCode !== 0) {
+    throw new Error(
+      `swiftc failed (exit ${compile.exitCode}) — install the Xcode command-line tools ` +
+        `(xcode-select --install) or use --software-key.\n${compile.stderr.trim()}`,
+    );
   }
-  return helperPath;
+  return binaryPath;
 }
 
 async function runJson(command: string, args: string[]): Promise<unknown> {
@@ -192,88 +239,3 @@ async function runJson(command: string, args: string[]): Promise<unknown> {
   }
   return JSON.parse(result.stdout);
 }
-
-/**
- * The whole enclave surface: `generate <tag>` mints a biometry-guarded P-256
- * key in the Secure Enclave and prints its public point; `sign <tag>
- * <messageBase64>` signs with `.ecdsaSignatureMessageX962SHA256` (the enclave
- * hashes the message itself) and prints the DER signature. Vendored as a
- * string so the published CLI needs no asset resolution.
- */
-const ENCLAVE_SIGNER_SWIFT = `
-import Foundation
-import Security
-
-func fail(_ message: String) -> Never {
-  FileHandle.standardError.write((message + "\\n").data(using: .utf8)!)
-  exit(1)
-}
-
-func jsonOut(_ dict: [String: String]) {
-  let data = try! JSONSerialization.data(withJSONObject: dict)
-  print(String(data: data, encoding: .utf8)!)
-}
-
-let args = CommandLine.arguments
-guard args.count >= 3 else {
-  fail("usage: enclave-signer generate <tag> | sign <tag> <messageBase64>")
-}
-let command = args[1]
-let tag = args[2].data(using: .utf8)!
-
-switch command {
-case "generate":
-  var error: Unmanaged<CFError>?
-  guard let accessControl = SecAccessControlCreateWithFlags(
-    kCFAllocatorDefault,
-    kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-    [.privateKeyUsage, .biometryCurrentSet],
-    &error
-  ) else { fail("access control: \\(error!.takeRetainedValue())") }
-
-  let attributes: [String: Any] = [
-    kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
-    kSecAttrKeySizeInBits as String: 256,
-    kSecAttrTokenID as String: kSecAttrTokenIDSecureEnclave,
-    kSecPrivateKeyAttrs as String: [
-      kSecAttrIsPermanent as String: true,
-      kSecAttrApplicationTag as String: tag,
-      kSecAttrAccessControl as String: accessControl,
-    ],
-  ]
-  guard let privateKey = SecKeyCreateRandomKey(attributes as CFDictionary, &error) else {
-    fail("key generation failed: \\(error!.takeRetainedValue())")
-  }
-  guard let publicKey = SecKeyCopyPublicKey(privateKey),
-        let publicKeyData = SecKeyCopyExternalRepresentation(publicKey, &error) as Data? else {
-    fail("public key export failed")
-  }
-  jsonOut(["publicKey": publicKeyData.base64EncodedString()])
-
-case "sign":
-  guard args.count >= 4, let message = Data(base64Encoded: args[3]) else {
-    fail("sign needs <tag> <messageBase64>")
-  }
-  let query: [String: Any] = [
-    kSecClass as String: kSecClassKey,
-    kSecAttrApplicationTag as String: tag,
-    kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
-    kSecReturnRef as String: true,
-    kSecUseOperationPrompt as String: "Sign an iterate egress approval",
-  ]
-  var item: CFTypeRef?
-  let status = SecItemCopyMatching(query as CFDictionary, &item)
-  guard status == errSecSuccess else { fail("approval key not found in keychain: \\(status)") }
-  let privateKey = item as! SecKey
-  var error: Unmanaged<CFError>?
-  guard let signature = SecKeyCreateSignature(
-    privateKey, .ecdsaSignatureMessageX962SHA256, message as CFData, &error
-  ) as Data? else {
-    fail("signing failed: \\(error!.takeRetainedValue())")
-  }
-  jsonOut(["signatureDer": signature.base64EncodedString()])
-
-default:
-  fail("unknown command \\(command)")
-}
-`;

--- a/packages/iterate/src/approve.ts
+++ b/packages/iterate/src/approve.ts
@@ -25,7 +25,9 @@ import {
 import type { ItxAuthCredentials, Project, Stream, StreamEvent } from "./itx-api.generated.ts";
 import {
   createApprovalKey,
+  deleteApprovalKey,
   loadApprovalKey,
+  promptNativeApproval,
   signApprovalMessage,
   type StoredApprovalKey,
 } from "./approval-keys.ts";
@@ -35,6 +37,7 @@ const GRANTED = "events.iterate.com/project/human-approval-granted";
 const REJECTED = "events.iterate.com/project/human-approval-rejected";
 const SETTLED = "events.iterate.com/project/human-approval-settled";
 const KEY_ADDED = "events.iterate.com/project/human-approval-key-added";
+const KEY_REVOKED = "events.iterate.com/project/human-approval-key-revoked";
 
 export async function runApprovalCli(input: {
   auth: ItxAuthCredentials;
@@ -43,6 +46,9 @@ export async function runApprovalCli(input: {
   headers?: Record<string, string>;
   enroll?: boolean;
   softwareKey?: boolean;
+  native?: boolean;
+  revoke?: boolean;
+  keys?: boolean;
 }): Promise<void> {
   const itx = connectItx({
     auth: input.auth,
@@ -55,6 +61,9 @@ export async function runApprovalCli(input: {
   prompts.intro(`iterate approve — project ${input.projectId}`);
 
   let key = await loadApprovalKey(input.projectId);
+  if (input.keys === true) return listKeys({ itx, localKey: key });
+  if (input.revoke === true) return revokeKey({ key, projectId: input.projectId, stream });
+
   if (input.enroll === true) {
     key = await enroll({
       existing: key,
@@ -63,12 +72,22 @@ export async function runApprovalCli(input: {
       stream,
     });
   }
+  const native = input.native === true;
+  if (native && key?.kind !== "secure-enclave") {
+    throw new Error(
+      "--native needs a Secure Enclave key: run `iterate approve --enroll` on this Mac (without --software-key).",
+    );
+  }
   prompts.log.info(
     key === null
       ? "No local approval key: grants will be plain events. Run with --enroll to sign approvals."
       : `Grants are signed with ${key.kind} key ${key.keyId} (${key.label}).`,
   );
-  prompts.log.step("Waiting for held egress requests... (Ctrl-C to stop)");
+  prompts.log.step(
+    native
+      ? "Waiting for held egress requests — approvals pop native dialogs... (Ctrl-C to stop)"
+      : "Waiting for held egress requests... (Ctrl-C to stop)",
+  );
 
   // Live tail from "now"; after the first event the cursor makes every
   // waitForEvent replay-from-offset, so nothing lands unseen while a prompt
@@ -98,33 +117,38 @@ export async function runApprovalCli(input: {
     }
 
     renderHeldRequest(event.offset, payload);
-    const approved = await prompts.confirm({
-      message: `Approve ${payload.method} ${new URL(payload.url).host}?`,
-      initialValue: false,
+    const message = buildApprovalMessage({
+      projectId: input.projectId,
+      approvalRequestEventOffset: event.offset,
+      requested: payload,
+      decision: "granted",
     });
-    if (prompts.isCancel(approved)) {
-      prompts.outro("Stopped. Held requests will auto-reject on their timeouts.");
-      return;
-    }
 
-    if (approved) {
-      const grant: { approvalRequestEventOffset: number; keyId?: string; signature?: string } = {
-        approvalRequestEventOffset: event.offset,
-      };
-      if (key !== null) {
+    // The human moment. Native mode: one dialog whose Approve button leads
+    // straight into the Touch ID sheet — reading and signing are the same
+    // gesture. Terminal mode: y/n, then sign.
+    let verdict: { decision: "granted"; signature?: string } | { decision: "rejected" | "ignored" };
+    if (native) {
+      verdict = await promptNativeApproval({
+        key: key as Extract<StoredApprovalKey, { kind: "secure-enclave" }>,
+        message,
+        request: payload as unknown as Record<string, unknown>,
+      });
+    } else {
+      const approved = await prompts.confirm({
+        message: `Approve ${payload.method} ${new URL(payload.url).host}?`,
+        initialValue: false,
+      });
+      if (prompts.isCancel(approved)) {
+        prompts.outro("Stopped. Held requests will auto-reject on their timeouts.");
+        return;
+      }
+      verdict = { decision: approved ? "granted" : "rejected" };
+      if (approved && key !== null) {
         const spinner = prompts.spinner();
         spinner.start(key.kind === "secure-enclave" ? "Signing — check Touch ID..." : "Signing...");
         try {
-          grant.keyId = key.keyId;
-          grant.signature = await signApprovalMessage(
-            key,
-            buildApprovalMessage({
-              projectId: input.projectId,
-              approvalRequestEventOffset: event.offset,
-              requested: payload,
-              decision: "granted",
-            }),
-          );
+          verdict = { decision: "granted", signature: await signApprovalMessage(key, message) };
           spinner.stop("Signed.");
         } catch (error) {
           spinner.stop("Signing failed.");
@@ -132,18 +156,76 @@ export async function runApprovalCli(input: {
           continue;
         }
       }
-      await stream.append({ type: GRANTED, payload: grant });
-      // Granting is a claim, not a fact — the egress door verifies the
-      // signature and settles the request. Report what actually happened.
-      await reportSettlement({ approvalRequestEventOffset: event.offset, stream });
-    } else {
+    }
+
+    if (verdict.decision === "ignored") {
+      prompts.log.info(`Ignored #${event.offset} — it can be answered elsewhere or expire.`);
+      continue;
+    }
+    if (verdict.decision === "rejected") {
       await stream.append({
         type: REJECTED,
         payload: { approvalRequestEventOffset: event.offset, reason: "human" },
       });
       prompts.log.warn(`Rejected #${event.offset}.`);
+      continue;
     }
+    await stream.append({
+      type: GRANTED,
+      payload: {
+        approvalRequestEventOffset: event.offset,
+        ...(key === null ? {} : { keyId: key.keyId, signature: verdict.signature }),
+      },
+    });
+    // Granting is a claim, not a fact — the egress door verifies the
+    // signature and settles the request. Report what actually happened.
+    await reportSettlement({ approvalRequestEventOffset: event.offset, stream });
   }
+}
+
+/** `--keys`: the project's enrolled approval keys, with this machine's marked. */
+async function listKeys(input: {
+  itx: RpcStub<Project>;
+  localKey: StoredApprovalKey | null;
+}): Promise<void> {
+  const snapshot = await input.itx.processor.snapshot();
+  const keys = snapshot.state.humanApprovalKeys;
+  if (keys.length === 0) {
+    prompts.outro("No approval keys enrolled — grants are plain events. Enroll with --enroll.");
+    return;
+  }
+  for (const key of keys) {
+    const marks = [
+      key.keyId === input.localKey?.keyId ? "this machine" : null,
+      key.revokedAt === null ? null : `revoked ${key.revokedAt}`,
+    ].filter((mark) => mark !== null);
+    prompts.log.info(
+      `${key.keyId}  ${key.label}  added ${key.addedAt}${marks.length > 0 ? `  (${marks.join(", ")})` : ""}`,
+    );
+  }
+  prompts.outro(`${keys.filter((key) => key.revokedAt === null).length} active key(s).`);
+}
+
+/**
+ * `--revoke`: stop the platform accepting this machine's key, then destroy
+ * the local material. Order matters — the event is the act that changes what
+ * grants are accepted; local deletion is just hygiene after it.
+ */
+async function revokeKey(input: {
+  key: StoredApprovalKey | null;
+  projectId: string;
+  stream: RpcStub<Stream>;
+}): Promise<void> {
+  if (input.key === null) {
+    prompts.outro("No local approval key for this project — nothing to revoke.");
+    return;
+  }
+  await input.stream.append({ type: KEY_REVOKED, payload: { keyId: input.key.keyId } });
+  await deleteApprovalKey(input.projectId);
+  prompts.outro(
+    `Revoked ${input.key.kind} key ${input.key.keyId} and destroyed the local material. ` +
+      "If it was the last active key, grants fall back to plain events.",
+  );
 }
 
 /**

--- a/packages/iterate/src/approve.ts
+++ b/packages/iterate/src/approve.ts
@@ -64,6 +64,24 @@ export async function runApprovalCli(input: {
   if (input.keys === true) return listKeys({ itx, localKey: key });
   if (input.revoke === true) return revokeKey({ key, projectId: input.projectId, stream });
 
+  // --native preconditions come BEFORE --enroll: failing after enrolling
+  // would leave a key side effect the human didn't ask for.
+  const native = input.native === true;
+  if (native) {
+    if (process.platform !== "darwin") throw new Error("--native is macOS-only.");
+    if (input.softwareKey === true) {
+      throw new Error("--native needs a Secure Enclave key; drop --software-key.");
+    }
+    if (key !== null && key.kind !== "secure-enclave") {
+      throw new Error(
+        "--native needs a Secure Enclave key, but this project's local key is a software key. Revoke it (--revoke) and re-enroll on this Mac.",
+      );
+    }
+    if (key === null && input.enroll !== true) {
+      throw new Error("--native needs an enrolled Secure Enclave key: run with --enroll first.");
+    }
+  }
+
   if (input.enroll === true) {
     key = await enroll({
       existing: key,
@@ -71,12 +89,6 @@ export async function runApprovalCli(input: {
       softwareKey: input.softwareKey,
       stream,
     });
-  }
-  const native = input.native === true;
-  if (native && key?.kind !== "secure-enclave") {
-    throw new Error(
-      "--native needs a Secure Enclave key: run `iterate approve --enroll` on this Mac (without --software-key).",
-    );
   }
   prompts.log.info(
     key === null
@@ -129,11 +141,18 @@ export async function runApprovalCli(input: {
     // gesture. Terminal mode: y/n, then sign.
     let verdict: { decision: "granted"; signature?: string } | { decision: "rejected" | "ignored" };
     if (native) {
-      verdict = await promptNativeApproval({
-        key: key as Extract<StoredApprovalKey, { kind: "secure-enclave" }>,
-        message,
-        request: payload as unknown as Record<string, unknown>,
-      });
+      try {
+        verdict = await promptNativeApproval({
+          key: key as Extract<StoredApprovalKey, { kind: "secure-enclave" }>,
+          message,
+          request: payload as unknown as Record<string, unknown>,
+        });
+      } catch (error) {
+        // A cancelled Touch ID sheet exits the approver non-zero; treat it
+        // like Ignore — the hold keeps waiting, the loop keeps listening.
+        prompts.log.error(error instanceof Error ? error.message : String(error));
+        verdict = { decision: "ignored" };
+      }
     } else {
       const approved = await prompts.confirm({
         message: `Approve ${payload.method} ${new URL(payload.url).host}?`,

--- a/packages/iterate/src/approve.ts
+++ b/packages/iterate/src/approve.ts
@@ -141,18 +141,15 @@ export async function runApprovalCli(input: {
     // gesture. Terminal mode: y/n, then sign.
     let verdict: { decision: "granted"; signature?: string } | { decision: "rejected" | "ignored" };
     if (native) {
-      try {
-        verdict = await promptNativeApproval({
-          key: key as Extract<StoredApprovalKey, { kind: "secure-enclave" }>,
-          message,
-          request: payload as unknown as Record<string, unknown>,
-        });
-      } catch (error) {
-        // A cancelled Touch ID sheet exits the approver non-zero; treat it
-        // like Ignore — the hold keeps waiting, the loop keeps listening.
-        prompts.log.error(error instanceof Error ? error.message : String(error));
-        verdict = { decision: "ignored" };
-      }
+      // A cancelled Touch ID sheet comes back as "ignored" (the approver
+      // distinguishes it); anything else thrown here is structural — broken
+      // helper, bad blob — and should stop the loop loudly, not loop as
+      // silent Ignores.
+      verdict = await promptNativeApproval({
+        key: key as Extract<StoredApprovalKey, { kind: "secure-enclave" }>,
+        message,
+        request: payload as unknown as Record<string, unknown>,
+      });
     } else {
       const approved = await prompts.confirm({
         message: `Approve ${payload.method} ${new URL(payload.url).host}?`,

--- a/packages/iterate/src/cli.ts
+++ b/packages/iterate/src/cli.ts
@@ -1127,6 +1127,25 @@ const launcherProcedures = {
           .optional()
           .default(false)
           .describe("With --enroll: force a software P-256 key instead of the Secure Enclave."),
+        native: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "macOS: approve via native dialogs — the Approve button leads straight into Touch ID. Needs an enrolled Secure Enclave key.",
+          ),
+        keys: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("List the project's enrolled approval keys and exit."),
+        revoke: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "Revoke this machine's approval key (append key-revoked, destroy local material) and exit.",
+          ),
       }),
     )
     .meta({
@@ -1170,6 +1189,9 @@ const launcherProcedures = {
         headers: headersRecord(auth.requestHeaders),
         enroll: input.enroll,
         softwareKey: input.softwareKey,
+        native: input.native,
+        keys: input.keys,
+        revoke: input.revoke,
       });
     }),
 

--- a/packages/iterate/src/enclave-approver.swift
+++ b/packages/iterate/src/enclave-approver.swift
@@ -14,21 +14,20 @@
 // fresh Touch ID check (re-enrolling biometrics invalidates the key).
 // Approving a request is a biometric act — that is the unforgeability story.
 //
-// Commands (all results are one-line JSON on stdout):
-//   generate                                mint a key
-//                                           -> {"publicKey": b64 X9.63,
-//                                               "keyBlob": b64 handle}
-//   public-key <keyBlobBase64>              read back the public point
-//                                           -> {"publicKey": b64 X9.63}
-//   sign <keyBlobBase64> <messageBase64>    Touch ID, then sign
-//                                           -> {"signatureDer": base64}
-//   approve <keyBlobBase64> <messageBase64> <requestJsonBase64>
-//                                           native dialog for one held egress
-//                                           request; approving signs in the
-//                                           same gesture
-//                                           -> {"decision":"granted","signatureDer":...}
-//                                            | {"decision":"rejected"}
-//                                            | {"decision":"ignored"}
+// Commands (results are one-line JSON on stdout; every command except
+// `generate` reads a JSON envelope from STDIN — never argv, which any local
+// process can read via ps):
+//   generate                     mint a key
+//                                -> {"publicKey": b64 X9.63, "keyBlob": b64 handle}
+//   public-key                   stdin {"keyBlob"}
+//                                -> {"publicKey": b64 X9.63}
+//   sign                         stdin {"keyBlob", "message": b64}; Touch ID, then sign
+//                                -> {"signatureDer": base64}
+//   approve                      stdin {"keyBlob", "message": b64, "request": {...}};
+//                                native dialog for one held egress request;
+//                                approving signs in the same gesture
+//                                -> {"decision":"granted","signatureDer":...}
+//                                 | {"decision":"rejected"} | {"decision":"ignored"}
 
 import AppKit
 import CryptoKit
@@ -70,7 +69,21 @@ func signMessage(blobBase64: String, message: Data, reason: String) -> Data {
 
 let args = CommandLine.arguments
 guard args.count >= 2 else {
-  fail("usage: enclave-approver generate | public-key <keyBlob> | sign <keyBlob> <messageBase64> | approve <keyBlob> <messageBase64> <requestJsonBase64>")
+  fail("usage: enclave-approver generate | public-key | sign | approve (inputs as JSON on stdin)")
+}
+
+/// The stdin envelope for key-holding commands: {"keyBlob", "message"?, "request"?}.
+func readStdinEnvelope() -> (keyBlob: String, message: Data?, request: [String: Any]?) {
+  let raw = FileHandle.standardInput.readDataToEndOfFile()
+  guard let envelope = try? JSONSerialization.jsonObject(with: raw) as? [String: Any],
+    let keyBlob = envelope["keyBlob"] as? String
+  else { fail("stdin must be a JSON object with at least keyBlob") }
+  var message: Data?
+  if let messageBase64 = envelope["message"] as? String {
+    guard let decoded = Data(base64Encoded: messageBase64) else { fail("message is not base64") }
+    message = decoded
+  }
+  return (keyBlob, message, envelope["request"] as? [String: Any])
 }
 
 switch args[1] {
@@ -96,23 +109,24 @@ case "generate":
   }
 
 case "public-key":
-  guard args.count >= 3 else { fail("public-key needs <keyBlob>") }
-  jsonOut(["publicKey": loadKey(blobBase64: args[2]).publicKey.x963Representation.base64EncodedString()])
+  let envelope = readStdinEnvelope()
+  jsonOut([
+    "publicKey": loadKey(blobBase64: envelope.keyBlob).publicKey.x963Representation
+      .base64EncodedString()
+  ])
 
 case "sign":
-  guard args.count >= 4, let message = Data(base64Encoded: args[3]) else {
-    fail("sign needs <keyBlob> <messageBase64>")
-  }
+  let envelope = readStdinEnvelope()
+  guard let message = envelope.message else { fail("sign needs message on stdin") }
   let signature = signMessage(
-    blobBase64: args[2], message: message, reason: "sign an iterate egress approval")
+    blobBase64: envelope.keyBlob, message: message, reason: "sign an iterate egress approval")
   jsonOut(["signatureDer": signature.base64EncodedString()])
 
 case "approve":
-  guard args.count >= 5,
-    let message = Data(base64Encoded: args[3]),
-    let requestData = Data(base64Encoded: args[4]),
-    let request = try? JSONSerialization.jsonObject(with: requestData) as? [String: Any]
-  else { fail("approve needs <keyBlob> <messageBase64> <requestJsonBase64>") }
+  let envelope = readStdinEnvelope()
+  guard let message = envelope.message, let request = envelope.request else {
+    fail("approve needs message and request on stdin")
+  }
 
   // One native dialog per held request. Approving signs in the same gesture:
   // the button click leads straight into the Touch ID sheet, so what the
@@ -147,7 +161,7 @@ case "approve":
   switch response {
   case .alertFirstButtonReturn:
     let signature = signMessage(
-      blobBase64: args[2], message: message,
+      blobBase64: envelope.keyBlob, message: message,
       reason: "approve \(method) to \(URL(string: url)?.host ?? url)")
     jsonOut(["decision": "granted", "signatureDer": signature.base64EncodedString()])
   case .alertSecondButtonReturn:

--- a/packages/iterate/src/enclave-approver.swift
+++ b/packages/iterate/src/enclave-approver.swift
@@ -1,0 +1,161 @@
+// The native half of `iterate approve` on macOS: a single-file app that owns
+// the Secure Enclave key and the human moment. The Node CLI does transport
+// (streams over itx) and shells out here for everything the enclave and the
+// screen must do. Compiled on first use with swiftc (cache keyed by source
+// hash — see approval-keys.ts), so there is nothing to install or notarize.
+//
+// Keys are CryptoKit `SecureEnclave.P256` keys, NOT keychain items: an
+// ad-hoc-signed CLI binary lacks the keychain entitlement (errSecMissing-
+// Entitlement -34018), so — like age-plugin-se — the key's opaque
+// `dataRepresentation` blob is handed back to the caller to store in its own
+// key file. The blob is an encrypted handle: it only works on this machine's
+// enclave, the private scalar never leaves the silicon, and the access
+// control [.privateKeyUsage, .biometryCurrentSet] makes every signature a
+// fresh Touch ID check (re-enrolling biometrics invalidates the key).
+// Approving a request is a biometric act — that is the unforgeability story.
+//
+// Commands (all results are one-line JSON on stdout):
+//   generate                                mint a key
+//                                           -> {"publicKey": b64 X9.63,
+//                                               "keyBlob": b64 handle}
+//   public-key <keyBlobBase64>              read back the public point
+//                                           -> {"publicKey": b64 X9.63}
+//   sign <keyBlobBase64> <messageBase64>    Touch ID, then sign
+//                                           -> {"signatureDer": base64}
+//   approve <keyBlobBase64> <messageBase64> <requestJsonBase64>
+//                                           native dialog for one held egress
+//                                           request; approving signs in the
+//                                           same gesture
+//                                           -> {"decision":"granted","signatureDer":...}
+//                                            | {"decision":"rejected"}
+//                                            | {"decision":"ignored"}
+
+import AppKit
+import CryptoKit
+import Foundation
+import LocalAuthentication
+
+func fail(_ message: String) -> Never {
+  FileHandle.standardError.write((message + "\n").data(using: .utf8)!)
+  exit(1)
+}
+
+func jsonOut(_ object: [String: Any]) {
+  let data = try! JSONSerialization.data(withJSONObject: object)
+  print(String(data: data, encoding: .utf8)!)
+}
+
+func loadKey(blobBase64: String, context: LAContext? = nil) -> SecureEnclave.P256.Signing.PrivateKey {
+  guard let blob = Data(base64Encoded: blobBase64) else { fail("key blob is not base64") }
+  do {
+    return try SecureEnclave.P256.Signing.PrivateKey(
+      dataRepresentation: blob, authenticationContext: context)
+  } catch {
+    fail("could not load the enclave key from its blob (wrong machine, or biometrics re-enrolled?): \(error)")
+  }
+}
+
+/// Touch ID happens HERE: the key's access control demands a fresh biometric
+/// check for every signature, presented with `reason`.
+func signMessage(blobBase64: String, message: Data, reason: String) -> Data {
+  let context = LAContext()
+  context.localizedReason = reason
+  let key = loadKey(blobBase64: blobBase64, context: context)
+  do {
+    return try key.signature(for: message).derRepresentation
+  } catch {
+    fail("signing failed: \(error)")
+  }
+}
+
+let args = CommandLine.arguments
+guard args.count >= 2 else {
+  fail("usage: enclave-approver generate | public-key <keyBlob> | sign <keyBlob> <messageBase64> | approve <keyBlob> <messageBase64> <requestJsonBase64>")
+}
+
+switch args[1] {
+case "generate":
+  guard SecureEnclave.isAvailable else { fail("this machine has no Secure Enclave") }
+  var error: Unmanaged<CFError>?
+  guard
+    let accessControl = SecAccessControlCreateWithFlags(
+      kCFAllocatorDefault,
+      kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+      [.privateKeyUsage, .biometryCurrentSet],
+      &error
+    )
+  else { fail("access control: \(error!.takeRetainedValue())") }
+  do {
+    let key = try SecureEnclave.P256.Signing.PrivateKey(accessControl: accessControl)
+    jsonOut([
+      "publicKey": key.publicKey.x963Representation.base64EncodedString(),
+      "keyBlob": key.dataRepresentation.base64EncodedString(),
+    ])
+  } catch {
+    fail("key generation failed: \(error)")
+  }
+
+case "public-key":
+  guard args.count >= 3 else { fail("public-key needs <keyBlob>") }
+  jsonOut(["publicKey": loadKey(blobBase64: args[2]).publicKey.x963Representation.base64EncodedString()])
+
+case "sign":
+  guard args.count >= 4, let message = Data(base64Encoded: args[3]) else {
+    fail("sign needs <keyBlob> <messageBase64>")
+  }
+  let signature = signMessage(
+    blobBase64: args[2], message: message, reason: "sign an iterate egress approval")
+  jsonOut(["signatureDer": signature.base64EncodedString()])
+
+case "approve":
+  guard args.count >= 5,
+    let message = Data(base64Encoded: args[3]),
+    let requestData = Data(base64Encoded: args[4]),
+    let request = try? JSONSerialization.jsonObject(with: requestData) as? [String: Any]
+  else { fail("approve needs <keyBlob> <messageBase64> <requestJsonBase64>") }
+
+  // One native dialog per held request. Approving signs in the same gesture:
+  // the button click leads straight into the Touch ID sheet, so what the
+  // human read is what the signature covers.
+  let app = NSApplication.shared
+  app.setActivationPolicy(.accessory)
+
+  let method = request["method"] as? String ?? "?"
+  let url = request["url"] as? String ?? "?"
+  let secretPaths = request["secretPaths"] as? [String] ?? []
+  var lines = ["\(method) \(url)"]
+  if !secretPaths.isEmpty {
+    lines.append("spends secret\(secretPaths.count > 1 ? "s" : ""): \(secretPaths.joined(separator: ", "))")
+  }
+  if let preview = request["bodyPreview"] as? String {
+    lines.append("body: \(preview.count > 200 ? String(preview.prefix(200)) + "…" : preview)")
+  }
+  if let ruleKey = request["ruleKey"] as? String { lines.append("rule: \(ruleKey)") }
+  if let expiresAt = request["expiresAt"] as? String { lines.append("expires: \(expiresAt)") }
+
+  let alert = NSAlert()
+  alert.messageText = "Approve this egress request?"
+  alert.informativeText = lines.joined(separator: "\n")
+  alert.alertStyle = .warning
+  alert.addButton(withTitle: "Approve & Sign")
+  alert.addButton(withTitle: "Reject")
+  alert.addButton(withTitle: "Ignore")
+
+  app.activate(ignoringOtherApps: true)
+  let response = alert.runModal()
+
+  switch response {
+  case .alertFirstButtonReturn:
+    let signature = signMessage(
+      blobBase64: args[2], message: message,
+      reason: "approve \(method) to \(URL(string: url)?.host ?? url)")
+    jsonOut(["decision": "granted", "signatureDer": signature.base64EncodedString()])
+  case .alertSecondButtonReturn:
+    jsonOut(["decision": "rejected"])
+  default:
+    jsonOut(["decision": "ignored"])
+  }
+
+default:
+  fail("unknown command \(args[1])")
+}

--- a/packages/iterate/src/enclave-approver.swift
+++ b/packages/iterate/src/enclave-approver.swift
@@ -55,16 +55,19 @@ func loadKey(blobBase64: String, context: LAContext? = nil) -> SecureEnclave.P25
 }
 
 /// Touch ID happens HERE: the key's access control demands a fresh biometric
-/// check for every signature, presented with `reason`.
-func signMessage(blobBase64: String, message: Data, reason: String) -> Data {
+/// check for every signature, presented with `reason`. Throws so callers can
+/// tell a cancelled sheet from a structural failure.
+func signMessage(blobBase64: String, message: Data, reason: String) throws -> Data {
   let context = LAContext()
   context.localizedReason = reason
   let key = loadKey(blobBase64: blobBase64, context: context)
-  do {
-    return try key.signature(for: message).derRepresentation
-  } catch {
-    fail("signing failed: \(error)")
-  }
+  return try key.signature(for: message).derRepresentation
+}
+
+/// LAError.userCancel and friends surface wrapped by CryptoKit; match on the
+/// description rather than unwrapping every layering variant.
+func isCancellation(_ error: Error) -> Bool {
+  return "\(error)".lowercased().contains("cancel")
 }
 
 let args = CommandLine.arguments
@@ -118,9 +121,13 @@ case "public-key":
 case "sign":
   let envelope = readStdinEnvelope()
   guard let message = envelope.message else { fail("sign needs message on stdin") }
-  let signature = signMessage(
-    blobBase64: envelope.keyBlob, message: message, reason: "sign an iterate egress approval")
-  jsonOut(["signatureDer": signature.base64EncodedString()])
+  do {
+    let signature = try signMessage(
+      blobBase64: envelope.keyBlob, message: message, reason: "sign an iterate egress approval")
+    jsonOut(["signatureDer": signature.base64EncodedString()])
+  } catch {
+    fail("signing failed: \(error)")
+  }
 
 case "approve":
   let envelope = readStdinEnvelope()
@@ -160,10 +167,20 @@ case "approve":
 
   switch response {
   case .alertFirstButtonReturn:
-    let signature = signMessage(
-      blobBase64: envelope.keyBlob, message: message,
-      reason: "approve \(method) to \(URL(string: url)?.host ?? url)")
-    jsonOut(["decision": "granted", "signatureDer": signature.base64EncodedString()])
+    do {
+      let signature = try signMessage(
+        blobBase64: envelope.keyBlob, message: message,
+        reason: "approve \(method) to \(URL(string: url)?.host ?? url)")
+      jsonOut(["decision": "granted", "signatureDer": signature.base64EncodedString()])
+    } catch {
+      // A cancelled Touch ID sheet is the human changing their mind — Ignore.
+      // Anything else is structural and must fail loudly, not loop silently.
+      if isCancellation(error) {
+        jsonOut(["decision": "ignored"])
+      } else {
+        fail("signing failed: \(error)")
+      }
+    }
   case .alertSecondButtonReturn:
     jsonOut(["decision": "rejected"])
   default:

--- a/packages/iterate/tsdown.config.ts
+++ b/packages/iterate/tsdown.config.ts
@@ -8,6 +8,9 @@ export default defineConfig([
       resolver: "tsc",
     },
     sourcemap: true,
+    // The native half of `iterate approve` ships as Swift source, compiled
+    // on the user's Mac on first use (see approval-keys.ts).
+    copy: [{ from: "src/enclave-approver.swift", to: "dist" }],
   },
   {
     // No dts here: the generated itx contract crashes rolldown-plugin-dts's


### PR DESCRIPTION
Stacked on #1852. The native half of `iterate approve` grows from a vendored signer string into a real single-file app, and the CLI gets the minimum key lifecycle.

## The Swift app (`enclave-approver.swift`)

One file, compiled with swiftc on first use (cache keyed by source hash, so editing it transparently recompiles), no install/notarization. Commands: `generate`, `public-key`, `sign`, and the app moment — **`approve`**: a native dialog rendering the held request (method, URL, secrets it spends, body preview, rule, expiry) whose **Approve & Sign button leads straight into the Touch ID sheet** — reading and signing are the same gesture, so what the human read is what the signature covers. Reject and Ignore are one click.

## The `-34018` lesson (real-world finding)

The #1852 helper stored the enclave key as a keychain item — which **fails with `errSecMissingEntitlement` from any ad-hoc-signed binary**, i.e. everything swiftc produces. Live-tested on a real Mac and rebuilt the way `age-plugin-se` does it: **CryptoKit `SecureEnclave.P256`**, whose `dataRepresentation` is an opaque encrypted handle stored in our own 0600 key file. No keychain, no entitlements; the private scalar never leaves the silicon, `.biometryCurrentSet` still forces fresh Touch ID per signature, and deleting the key file destroys the only handle. Keygen → load → destroy proven live on this Mac (the two biometric moments — sign and the dialog — are inherently human-only; demo below).

## Key lifecycle (minimum certificate management)

- `iterate approve --enroll` — mint + enroll (as before, now blob-based)
- `iterate approve --keys` — the project's enrolled keys from reduced state, this machine's marked, revoked ones labelled
- `iterate approve --revoke` — append `human-approval-key-revoked`, **then** destroy local material: the event is the act that changes what the platform accepts; deletion is hygiene after it
- `iterate approve --native` — dialog mode (requires an enclave key)

Server-side revocation semantics already shipped and unit-tested in #1852 (`evaluateGrant` refuses revoked keys; revoking the last active key falls back to plain grants).

## Demo (macOS)

```bash
cd packages/iterate
bun bin/iterate.js approve --project <slug> --enroll --native
# fire a rule-matched fetch from an itx script (recipe in #1852) —
# a native dialog pops; Approve & Sign → Touch ID → request released.
bun bin/iterate.js approve --project <slug> --keys
bun bin/iterate.js approve --project <slug> --revoke
```

## Notes

- The `.swift` ships in the npm package via tsdown `copy` (resolved next to the module in both `src/` and `dist/`).
- No apps/os changes at all — this PR is purely the human's side.
- Gates: lint, knip, package build, `--help` smoke all green; Swift compiles clean (zero warnings — LAContext replaced the deprecated `kSecUseOperationPrompt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how egress approval signatures are produced and stored locally (Secure Enclave handles, biometric UX, and key revocation), which directly affects human authorization for outbound requests.
> 
> **Overview**
> **macOS Secure Enclave approval keys** no longer use keychain tags (which break under ad-hoc `swiftc` binaries). Enrolled keys now persist a CryptoKit `dataRepresentation` **key blob** in the local key file; the vendored inline Swift signer is replaced by **`enclave-approver.swift`**, compiled on first use with a **source-hash cache** and invoked with **key material on stdin** (not argv).
> 
> **`iterate approve`** gains **`--native`** (native dialog → Touch ID in one gesture via `approve`), **`--keys`** (list enrolled keys), and **`--revoke`** (append `human-approval-key-revoked`, then delete local key material). The listen loop handles **ignored** verdicts (e.g. cancelled biometrics) and wires grants through the unified verdict path.
> 
> The Swift source is **copied into `dist`** at package build time so published CLI can compile the approver next to the module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e330f664ca83350f1187ff7c21b357a115d8a00c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +434 -151 | +361 -127 🟩🟩🟩🟩🟥 |
| **Total** | **+434 -151** | **+361 -127** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 3b9163e and e330f66, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->