### PR TITLE
Auth: streams playground RFC 8707 resources are its custom domains (fixes streams.iterate.com sign-in)

### DIFF
--- a/apps/auth/src/server/oauth-resources.ts
+++ b/apps/auth/src/server/oauth-resources.ts
@@ -31,15 +31,18 @@ export function getSemaphoreResourceBases() {
 
 /**
  * The streams playground is a relying party like OS and semaphore (browser
- * sign-in + bearer access tokens against its own workers.dev origin as the
- * RFC 8707 resource). Local dev is auth-less by design and needs no entry.
+ * sign-in + bearer access tokens against its own origin as the RFC 8707
+ * resource). These are the custom domains from envs.ts streamsExampleEnvs —
+ * the app derives its resource from the request origin, so the old
+ * workers.dev origins stopped matching the moment the custom domains went
+ * live (the token exchange then 400s with "requested resource invalid").
+ * Local dev is auth-less by design and needs no entry.
  */
 export function getStreamsExampleResourceBases() {
   return [
-    "https://streams-example-app-prd.iterate.workers.dev",
+    "https://streams.iterate.com",
     ...[1, 2, 3, 4, 5, 6, 7, 8, 9].map(
-      (previewNumber) =>
-        `https://streams-example-app-preview-${previewNumber}.iterate-dev-preview.workers.dev`,
+      (previewNumber) => `https://streams.iterate-preview-${previewNumber}.com`,
     ),
   ];
 }


### PR DESCRIPTION
## Summary

Production sign-in at streams.iterate.com fails at the OAuth callback with `invalid_request: requested resource invalid` (token endpoint 400).

Two stacked stale registrations from the playground's workers.dev → custom-domain move:

1. **OAuth client redirect URI** — already fixed operationally: re-ran the idempotent `apps/streams-example-app/scripts/sync-auth-client.ts` against prd, which re-registered `https://streams.iterate.com/api/iterate-auth/callback` on the existing client and mirrored it into `AUTH_SEED_OAUTH_CLIENTS` (survives auth redeploys). No code change needed.
2. **RFC 8707 resource allowlist** — this PR: `getStreamsExampleResourceBases()` still listed only the old workers.dev origins, but the app derives its `resource` from the request origin (`https://streams.iterate.com`), so the token exchange was rejected. Now lists the custom domains from `envs.ts` (`streams.iterate.com` + `streams.iterate-preview-N.com`), clean break from workers.dev.

Why no test caught it: preview e2e signs in via forge-minted `session-from-token`, which never exercises the authorization-code exchange.

`deploy-auth.yml` auto-deploys prd on merge (paths include `apps/auth/**`). Will verify the full browser sign-in flow on streams.iterate.com after the deploy lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow allowlist correction for a known broken sign-in path; no changes to core auth logic beyond trusted resource URLs.
> 
> **Overview**
> Fixes production sign-in at **streams.iterate.com**, where the token exchange failed with `requested resource invalid` because the streams app sends its **request origin** as the RFC 8707 resource while auth still allowed only the old **workers.dev** bases.
> 
> **`getStreamsExampleResourceBases()`** now lists `https://streams.iterate.com` and preview hosts `https://streams.iterate-preview-{N}.com`, matching `envs.ts` / semaphore-style patterns. Those bases still feed the OAuth valid-audience list and logout redirect allowlist via existing call sites—no other logic changes.
> 
> Commentary documents why workers.dev was dropped and that local streams dev stays auth-less.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cae734cc6b9aaa08f379038a289681ceaac932ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +8 -5 | +2 -3 🟩🟩🟥🟥🟥 |
| **Total** | **+8 -5** | **+2 -3** 🟩🟩🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 423af11 and cae734c, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->