### PR TITLE
Agents UI: LLM request inspector replays the exact model context from the event mirror

### DIFF
--- a/apps/os/src/components/agent-feed.tsx
+++ b/apps/os/src/components/agent-feed.tsx
@@ -9,6 +9,7 @@ import {
   PaperclipIcon,
   PauseIcon,
   PlayIcon,
+  ScrollTextIcon,
 } from "lucide-react";
 import type {
   AgentUiActivity,
@@ -92,11 +93,14 @@ export const AgentFeedItemRow = memo(function AgentFeedItemRow({
   item,
   toggledIds,
   onToggle,
+  onInspectLlmRequest,
   projectSlug,
 }: {
   item: AgentUiItem;
   toggledIds: ReadonlySet<string>;
   onToggle: (id: string) => void;
+  /** Opens the LLM request inspector at this llmRequestOffset (llm steps only). */
+  onInspectLlmRequest?: (llmRequestOffset: number) => void;
   projectSlug?: string;
 }) {
   if (item.kind === "stream-woken") {
@@ -166,6 +170,7 @@ export const AgentFeedItemRow = memo(function AgentFeedItemRow({
         expanded={toggledIds.has(item.id)}
         toggledIds={toggledIds}
         onToggle={onToggle}
+        onInspectLlmRequest={onInspectLlmRequest}
       />
     );
   }
@@ -296,11 +301,13 @@ function AgentActivityRow({
   expanded,
   toggledIds,
   onToggle,
+  onInspectLlmRequest,
 }: {
   activity: AgentUiActivity;
   expanded: boolean;
   toggledIds: ReadonlySet<string>;
   onToggle: (id: string) => void;
+  onInspectLlmRequest?: (llmRequestOffset: number) => void;
 }) {
   const interrupted = activityWasInterrupted(activity);
 
@@ -351,6 +358,7 @@ function AgentActivityRow({
                 step={step}
                 expanded={toggledIds.has(step.id) !== defaultExpanded}
                 onToggle={onToggle}
+                onInspectLlmRequest={onInspectLlmRequest}
               />
             );
           })}
@@ -525,40 +533,73 @@ function AgentActivityStep({
   step,
   expanded,
   onToggle,
+  onInspectLlmRequest,
 }: {
   step: AgentUiStep;
   expanded: boolean;
   onToggle: (id: string) => void;
+  onInspectLlmRequest?: (llmRequestOffset: number) => void;
 }) {
   return (
     <div className="flex flex-col">
-      <Button
-        variant="ghost"
-        size="xs"
-        aria-expanded={expanded}
-        onClick={() => onToggle(step.id)}
-        className="-ml-2 self-start font-normal"
-      >
-        {step.kind === "llm" ? (
-          <span className="shrink-0 text-[11px] leading-none text-muted-foreground/50">✦</span>
-        ) : (
-          <CodeIcon className="size-3 text-muted-foreground" />
-        )}
-        <span className="font-mono text-xs text-foreground/70">{stepLabel(step)}</span>
-        <span className="font-mono text-xs text-muted-foreground/70">{stepMeta(step)}</span>
-        <ChevronRightIcon
-          className={cn(
-            "size-2 text-muted-foreground/50 transition-transform",
-            expanded && "rotate-90",
+      <div className="-ml-2 flex items-center gap-0.5 self-start">
+        <Button
+          variant="ghost"
+          size="xs"
+          aria-expanded={expanded}
+          onClick={() => onToggle(step.id)}
+          className="font-normal"
+        >
+          {step.kind === "llm" ? (
+            <span className="shrink-0 text-[11px] leading-none text-muted-foreground/50">✦</span>
+          ) : (
+            <CodeIcon className="size-3 text-muted-foreground" />
           )}
-        />
-      </Button>
+          <span className="font-mono text-xs text-foreground/70">{stepLabel(step)}</span>
+          <span className="font-mono text-xs text-muted-foreground/70">{stepMeta(step)}</span>
+          <ChevronRightIcon
+            className={cn(
+              "size-2 text-muted-foreground/50 transition-transform",
+              expanded && "rotate-90",
+            )}
+          />
+        </Button>
+        {step.kind === "llm" && onInspectLlmRequest != null ? (
+          <InspectLlmRequestButton
+            llmRequestOffset={step.llmRequestOffset}
+            onInspectLlmRequest={onInspectLlmRequest}
+          />
+        ) : null}
+      </div>
       {expanded ? (
         <div className="flex flex-col gap-2 pb-2.5 pl-5 pt-0.5">
           {step.kind === "llm" ? <LlmStepDetail step={step} /> : <CodeStepDetail step={step} />}
         </div>
       ) : null}
     </div>
+  );
+}
+
+/** Opens the LLM request inspector: the exact context this request sent to
+ * the model, replayed from the local event mirror (llm-request-inspector-panel). */
+function InspectLlmRequestButton({
+  llmRequestOffset,
+  onInspectLlmRequest,
+}: {
+  llmRequestOffset: number;
+  onInspectLlmRequest: (llmRequestOffset: number) => void;
+}) {
+  return (
+    <Button
+      variant="ghost"
+      size="xs"
+      title="Show the exact context sent to the model"
+      data-testid="agent-feed-inspect-llm-request"
+      onClick={() => onInspectLlmRequest(llmRequestOffset)}
+      className="text-muted-foreground/60 hover:text-foreground"
+    >
+      <ScrollTextIcon className="size-3" />
+    </Button>
   );
 }
 
@@ -709,10 +750,12 @@ export function AgentLiveActivity({
   live,
   toggledIds,
   onToggle,
+  onInspectLlmRequest,
 }: {
   live: AgentUiActivity;
   toggledIds: ReadonlySet<string>;
   onToggle: (id: string) => void;
+  onInspectLlmRequest?: (llmRequestOffset: number) => void;
 }) {
   const runningSteps = live.steps.filter((step) => step.status === "running");
   const liveStep = runningSteps.at(-1);
@@ -723,6 +766,13 @@ export function AgentLiveActivity({
     doneSteps.length > 0 ||
     runningSteps.some((step) => step.kind === "code" || liveStepHasVisibleContent(step));
 
+  // The in-flight request's context is already committed history (the fold
+  // reads offsets ≤ llmRequestOffset), so "what is it chewing on right now"
+  // is inspectable mid-turn from the live label row.
+  const runningLlmStep = runningSteps
+    .filter((step): step is AgentUiLlmStep => step.kind === "llm")
+    .at(-1);
+
   if (!working && activityWasInterrupted(live)) {
     return (
       <AgentActivityRow
@@ -730,6 +780,7 @@ export function AgentLiveActivity({
         expanded={toggledIds.has(live.id)}
         toggledIds={toggledIds}
         onToggle={onToggle}
+        onInspectLlmRequest={onInspectLlmRequest}
       />
     );
   }
@@ -742,6 +793,12 @@ export function AgentLiveActivity({
           <span className="text-sm font-medium text-amber-700 dark:text-amber-500">
             {liveActivityLabel(runningSteps)}
           </span>
+          {runningLlmStep != null && onInspectLlmRequest != null ? (
+            <InspectLlmRequestButton
+              llmRequestOffset={runningLlmStep.llmRequestOffset}
+              onInspectLlmRequest={onInspectLlmRequest}
+            />
+          ) : null}
         </div>
       ) : null}
       {showStepRail ? (
@@ -758,6 +815,7 @@ export function AgentLiveActivity({
               step={step}
               expanded={toggledIds.has(`live:${step.id}`)}
               onToggle={toggleLive}
+              onInspectLlmRequest={onInspectLlmRequest}
             />
           ))}
           {runningSteps.map((step) =>

--- a/apps/os/src/components/agent-feed.tsx
+++ b/apps/os/src/components/agent-feed.tsx
@@ -32,6 +32,14 @@ import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
 import { Spinner } from "@iterate-com/ui/components/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@iterate-com/ui/components/tooltip";
 import { cn } from "@iterate-com/ui/lib/utils";
+import {
+  formatClockTime,
+  formatDateTime,
+  formatDateTimeAttribute,
+  formatFileSize,
+  formatSeconds,
+  formatTokens,
+} from "~/lib/feed-format.ts";
 import { linkOptionsForStreamPath } from "~/lib/stream-routes.ts";
 
 // The clean agent chat rows: user and assistant messages plus archived
@@ -944,50 +952,8 @@ function ThinkingBlock({ children }: { children: ReactNode }) {
 }
 
 // ---------------------------------------------------------------------------
-// Formatting
+// Formatting (number/time formatters live in ~/lib/feed-format.ts)
 // ---------------------------------------------------------------------------
-
-function formatTokens(count: number | undefined): string {
-  if (count == null) return "?";
-  if (count < 1000) return String(count);
-  return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
-}
-
-function formatSeconds(durationMs: number): string {
-  if (durationMs < 1000) return `${Math.round(durationMs)} ms`;
-  const seconds = durationMs / 1000;
-  if (seconds < 60) return `${seconds.toFixed(1).replace(/\.0$/, "")} s`;
-  const minutes = Math.floor(seconds / 60);
-  return `${minutes}m ${Math.round(seconds % 60)}s`;
-}
-
-function formatFileSize(size: number): string {
-  if (size < 1024) return `${size} B`;
-  const kilobytes = size / 1024;
-  if (kilobytes < 1024) return `${kilobytes.toFixed(1).replace(/\.0$/, "")} KB`;
-  return `${(kilobytes / 1024).toFixed(1).replace(/\.0$/, "")} MB`;
-}
-
-function formatClockTime(timestampMs: number): string {
-  return new Date(timestampMs).toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  });
-}
-
-function formatDateTime(timestampMs: number): string {
-  return new Date(timestampMs).toLocaleString([], {
-    dateStyle: "medium",
-    timeStyle: "medium",
-  });
-}
-
-function formatDateTimeAttribute(timestampMs: number): string | undefined {
-  const date = new Date(timestampMs);
-  if (Number.isNaN(date.getTime())) return undefined;
-  return date.toISOString();
-}
 
 function stringifyResult(result: unknown): string {
   if (typeof result === "string") return result;

--- a/apps/os/src/components/llm-request-inspector-panel.tsx
+++ b/apps/os/src/components/llm-request-inspector-panel.tsx
@@ -1,6 +1,7 @@
 import { memo, useMemo, useState } from "react";
 import { CheckIcon, CopyIcon, XIcon } from "lucide-react";
 import { Button } from "@iterate-com/ui/components/button";
+import { toast } from "@iterate-com/ui/components/sonner";
 import { MessageResponse } from "@iterate-com/ui/components/ai-elements/message";
 import { cn } from "@iterate-com/ui/lib/utils";
 import { useStreamQuery } from "~/domains/streams/client-libraries/browser/hooks/use-stream-query.ts";
@@ -106,11 +107,15 @@ export function LlmRequestInspectorPanel({
           title="Copy the request's messages as JSON"
           onClick={async () => {
             if (replay == null) return;
-            await navigator.clipboard.writeText(
-              JSON.stringify({ messages: replay.messages }, null, 2),
-            );
-            setCopied(true);
-            setTimeout(() => setCopied(false), 1500);
+            try {
+              await navigator.clipboard.writeText(
+                JSON.stringify({ messages: replay.messages }, null, 2),
+              );
+              setCopied(true);
+              window.setTimeout(() => setCopied(false), 2_000);
+            } catch {
+              toast.error("Failed to copy to clipboard");
+            }
           }}
         >
           {copied ? <CheckIcon className="size-3.5" /> : <CopyIcon className="size-3.5" />}

--- a/apps/os/src/components/llm-request-inspector-panel.tsx
+++ b/apps/os/src/components/llm-request-inspector-panel.tsx
@@ -6,6 +6,7 @@ import { MessageResponse } from "@iterate-com/ui/components/ai-elements/message"
 import { cn } from "@iterate-com/ui/lib/utils";
 import { useStreamQuery } from "~/domains/streams/client-libraries/browser/hooks/use-stream-query.ts";
 import type { StreamBrowserDatabase } from "~/domains/streams/client-libraries/browser/stream-browser-db.ts";
+import { formatDateTime, formatSeconds } from "~/lib/feed-format.ts";
 import {
   LLM_REPLAY_EVENT_TYPES,
   replayLlmRequest,
@@ -79,7 +80,7 @@ export function LlmRequestInspectorPanel({
               "The exact context sent to the model"
             ) : (
               <>
-                {new Date(replay.requestedAt).toLocaleString()} ·{" "}
+                {formatDateTime(Date.parse(replay.requestedAt))} ·{" "}
                 {replay.messages.length.toLocaleString()} messages ·{" "}
                 {(totalChars ?? 0).toLocaleString()} chars
                 <OutcomeBadge outcome={replay.outcome} />
@@ -109,9 +110,10 @@ export function LlmRequestInspectorPanel({
           onClick={async () => {
             if (replay == null) return;
             try {
-              await navigator.clipboard.writeText(
-                JSON.stringify({ messages: replay.messages }, null, 2),
-              );
+              // The wire shape only: `id` is this panel's row identity, not
+              // part of what the model received.
+              const messages = replay.messages.map(({ role, content }) => ({ role, content }));
+              await navigator.clipboard.writeText(JSON.stringify({ messages }, null, 2));
               setCopied(true);
               window.setTimeout(() => setCopied(false), 2_000);
             } catch {
@@ -129,15 +131,8 @@ export function LlmRequestInspectorPanel({
       <div className="min-h-0 flex-1 overflow-y-auto border-t">
         {replay != null ? (
           <div className="flex flex-col">
-            {replay.messages.map((message, index) => (
-              <ReplayMessageSection
-                // Positional identity is stable: the replayed request is an
-                // immutable fact of the journal, so index-keyed rows never
-                // reorder under the same offset.
-                key={index}
-                message={message}
-                renderMode={renderMode}
-              />
+            {replay.messages.map((message) => (
+              <ReplayMessageSection key={message.id} message={message} renderMode={renderMode} />
             ))}
           </div>
         ) : eventsResult.status === "pending" ? (
@@ -225,14 +220,6 @@ const ReplayMessageSection = memo(
   },
   (previous, next) =>
     previous.renderMode === next.renderMode &&
-    previous.message.role === next.message.role &&
+    previous.message.id === next.message.id &&
     previous.message.content === next.message.content,
 );
-
-function formatSeconds(durationMs: number): string {
-  if (durationMs < 1000) return `${Math.round(durationMs)} ms`;
-  const seconds = durationMs / 1000;
-  if (seconds < 60) return `${seconds.toFixed(1).replace(/\.0$/, "")} s`;
-  const minutes = Math.floor(seconds / 60);
-  return `${minutes}m ${Math.round(seconds % 60)}s`;
-}

--- a/apps/os/src/components/llm-request-inspector-panel.tsx
+++ b/apps/os/src/components/llm-request-inspector-panel.tsx
@@ -1,0 +1,236 @@
+import { memo, useMemo, useState } from "react";
+import { CheckIcon, CopyIcon, XIcon } from "lucide-react";
+import { Button } from "@iterate-com/ui/components/button";
+import { MessageResponse } from "@iterate-com/ui/components/ai-elements/message";
+import { cn } from "@iterate-com/ui/lib/utils";
+import { useStreamQuery } from "~/domains/streams/client-libraries/browser/hooks/use-stream-query.ts";
+import type { StreamBrowserDatabase } from "~/domains/streams/client-libraries/browser/stream-browser-db.ts";
+import {
+  LLM_REPLAY_EVENT_TYPES,
+  replayLlmRequest,
+  type LlmRequestReplayMessage,
+} from "~/lib/llm-request-replay.ts";
+
+/**
+ * LLM-request inspection side panel: the EXACT context one request sent to
+ * the model, replayed locally from the raw-event mirror. The processor never
+ * stores request bodies — it rebuilds them from committed history per attempt
+ * — so this panel runs the same pure fold (see ~/lib/llm-request-replay.ts)
+ * over the same events and shows the resulting messages verbatim, including
+ * the flattened attachment hint lines. Works retroactively for every request
+ * in the journal, at zero storage cost.
+ *
+ * Fidelity caveat: the replay is exact as long as the deployed fold semantics
+ * match the ones that built the original request — the trade we make for not
+ * duplicating every prompt into the journal.
+ */
+export function LlmRequestInspectorPanel({
+  database,
+  llmRequestOffset,
+  onClose,
+}: {
+  /** The raw-event mirror (the `events` table), NOT the feed-items database. */
+  database: StreamBrowserDatabase;
+  /** The llm-request-requested event's offset — the request's identity. */
+  llmRequestOffset: number;
+  onClose: () => void;
+}) {
+  // The whole consumed subset, unbounded above: the fold self-filters to
+  // offsets ≤ llmRequestOffset, and the request's outcome (completed /
+  // cancelled) lands ABOVE it. Bulk emitted-only types (response chunks)
+  // never leave SQLite.
+  const eventsResult = useStreamQuery(
+    database,
+    `SELECT json(raw_jsonb) AS raw_json FROM events
+     WHERE type IN (${LLM_REPLAY_EVENT_TYPES.map(() => "?").join(", ")})
+     ORDER BY offset ASC`,
+    [...LLM_REPLAY_EVENT_TYPES],
+  );
+  const replay = useMemo(
+    () =>
+      eventsResult.status === "ok"
+        ? replayLlmRequest({
+            rawEventJsons: eventsResult.data.map((sqlRow) => String(sqlRow.raw_json)),
+            llmRequestOffset,
+          })
+        : null,
+    [eventsResult.status, eventsResult.data, llmRequestOffset],
+  );
+
+  const [renderMode, setRenderMode] = useState<"markdown" | "plain">("markdown");
+  const [copied, setCopied] = useState(false);
+  const totalChars = replay?.messages.reduce((sum, message) => sum + message.content.length, 0);
+
+  return (
+    <aside
+      className="absolute inset-y-0 right-0 z-30 flex w-full flex-col rounded-tl-2xl bg-background shadow-2xl md:w-1/2"
+      data-testid="llm-request-inspector"
+    >
+      <div className="flex shrink-0 items-start gap-2 px-5 pb-2 pt-4">
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-mono text-sm font-semibold">
+            LLM request #{llmRequestOffset}
+            {replay == null ? "" : ` · ${replay.model}`}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {replay == null ? (
+              "The exact context sent to the model"
+            ) : (
+              <>
+                {new Date(replay.requestedAt).toLocaleString()} ·{" "}
+                {replay.messages.length.toLocaleString()} messages ·{" "}
+                {(totalChars ?? 0).toLocaleString()} chars
+                <OutcomeBadge outcome={replay.outcome} />
+              </>
+            )}
+          </div>
+        </div>
+        <Button variant="ghost" size="icon" title="Close" onClick={onClose}>
+          <XIcon className="size-4" />
+        </Button>
+      </div>
+      <div className="flex shrink-0 flex-wrap items-center gap-2 px-5 pb-3">
+        <Button
+          size="sm"
+          variant="outline"
+          aria-pressed={renderMode === "plain"}
+          title="Toggle between rendered markdown and the verbatim wire text"
+          onClick={() => setRenderMode(renderMode === "markdown" ? "plain" : "markdown")}
+        >
+          {renderMode === "markdown" ? "Markdown" : "Plain text"}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={replay == null}
+          title="Copy the request's messages as JSON"
+          onClick={async () => {
+            if (replay == null) return;
+            await navigator.clipboard.writeText(
+              JSON.stringify({ messages: replay.messages }, null, 2),
+            );
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+          }}
+        >
+          {copied ? <CheckIcon className="size-3.5" /> : <CopyIcon className="size-3.5" />}
+          Copy JSON
+        </Button>
+        <span className="ml-auto text-[10px] text-muted-foreground/70">
+          replayed from the local event mirror
+        </span>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto border-t">
+        {replay != null ? (
+          <div className="flex flex-col">
+            {replay.messages.map((message, index) => (
+              <ReplayMessageSection
+                // Positional identity is stable: the replayed request is an
+                // immutable fact of the journal, so index-keyed rows never
+                // reorder under the same offset.
+                key={index}
+                message={message}
+                renderMode={renderMode}
+              />
+            ))}
+          </div>
+        ) : eventsResult.status === "pending" ? (
+          <p className="px-5 py-3 text-sm text-muted-foreground">Opening local SQLite mirror…</p>
+        ) : (
+          <p className="px-5 py-3 text-sm text-muted-foreground">
+            No LLM request at offset #{llmRequestOffset} in the local mirror (yet). If this stream
+            is still syncing, the request will appear once its events arrive.
+          </p>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function OutcomeBadge({
+  outcome,
+}: {
+  outcome: NonNullable<ReturnType<typeof replayLlmRequest>>["outcome"];
+}) {
+  if (outcome == null) return <> · in flight</>;
+  const duration = outcome.durationMs == null ? "" : ` in ${formatSeconds(outcome.durationMs)}`;
+  return (
+    <>
+      {" · "}
+      <span
+        className={cn(
+          outcome.status === "success" && "text-emerald-600 dark:text-emerald-500",
+          outcome.status === "failure" && "text-destructive",
+          outcome.status === "cancelled" && "text-amber-600 dark:text-amber-500",
+        )}
+        title={outcome.errorMessage ?? undefined}
+      >
+        {outcome.status}
+        {duration}
+      </span>
+    </>
+  );
+}
+
+// Memoized on (message, renderMode): the mirror query re-resolves whenever the
+// stream appends a consumed event, but a settled request's messages are
+// value-identical across resolves — re-rendering the markdown for a long
+// transcript on every append would burn main-thread time for nothing.
+// `message` objects are rebuilt per resolve, so compare by content value.
+const ReplayMessageSection = memo(
+  function ReplayMessageSection({
+    message,
+    renderMode,
+  }: {
+    message: LlmRequestReplayMessage;
+    renderMode: "markdown" | "plain";
+  }) {
+    return (
+      <section className="border-b border-border/60 px-5 py-3">
+        <div className="mb-2 flex items-baseline gap-2">
+          <span
+            className={cn(
+              "font-mono text-[10px] font-semibold uppercase tracking-wider",
+              message.role === "system" && "text-purple-700 dark:text-purple-300",
+              message.role === "user" && "text-blue-700 dark:text-blue-300",
+              message.role === "assistant" && "text-emerald-700 dark:text-emerald-400",
+            )}
+          >
+            {message.role}
+          </span>
+          <span className="font-mono text-[10px] text-muted-foreground/60">
+            {message.content.length.toLocaleString()} chars
+          </span>
+        </div>
+        {renderMode === "markdown" ? (
+          // Settled text never streams; static mode renders synchronously and
+          // skips streaming markdown's unpaired-marker balancing (see the
+          // agent feed's settled rows for the full story).
+          <MessageResponse
+            className="min-w-0 max-w-full overflow-hidden text-sm"
+            mode="static"
+            parseIncompleteMarkdown={false}
+          >
+            {message.content}
+          </MessageResponse>
+        ) : (
+          <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-foreground">
+            {message.content}
+          </pre>
+        )}
+      </section>
+    );
+  },
+  (previous, next) =>
+    previous.renderMode === next.renderMode &&
+    previous.message.role === next.message.role &&
+    previous.message.content === next.message.content,
+);
+
+function formatSeconds(durationMs: number): string {
+  if (durationMs < 1000) return `${Math.round(durationMs)} ms`;
+  const seconds = durationMs / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1).replace(/\.0$/, "")} s`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m ${Math.round(seconds % 60)}s`;
+}

--- a/apps/os/src/components/llm-request-inspector-panel.tsx
+++ b/apps/os/src/components/llm-request-inspector-panel.tsx
@@ -9,6 +9,7 @@ import type { StreamBrowserDatabase } from "~/domains/streams/client-libraries/b
 import {
   LLM_REPLAY_EVENT_TYPES,
   replayLlmRequest,
+  type LlmRequestReplay,
   type LlmRequestReplayMessage,
 } from "~/lib/llm-request-replay.ts";
 
@@ -152,11 +153,7 @@ export function LlmRequestInspectorPanel({
   );
 }
 
-function OutcomeBadge({
-  outcome,
-}: {
-  outcome: NonNullable<ReturnType<typeof replayLlmRequest>>["outcome"];
-}) {
+function OutcomeBadge({ outcome }: { outcome: LlmRequestReplay["outcome"] }) {
   if (outcome == null) return <> · in flight</>;
   const duration = outcome.durationMs == null ? "" : ` in ${formatSeconds(outcome.durationMs)}`;
   return (

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -193,28 +193,10 @@ export function ProjectStreamView({
     window.location.reload();
   }
 
-  const getProcessorRuntimeState = useCallback(
-    async (subscriptionKey: string) => {
-      const stream = await resolvedStreamSource(streamPath);
-      const [runtimeState, streamRuntimeState] = await Promise.all([
-        stream.getProcessorRuntimeState({ subscriptionKey }),
-        stream.runtimeState(),
-      ]);
-      return {
-        runtimeState,
-        // The itx Stream.runtimeState() types coreProcessorState as
-        // unknown; parse out the slice this panel needs.
-        streamMaxOffset: parseBrowserCoreProcessorState(streamRuntimeState.coreProcessorState)
-          .maxOffset,
-      };
-    },
-    [resolvedStreamSource, streamPath],
-  );
-  const getStreamRuntimeState = useCallback(
-    async (): Promise<StreamRuntimeDebugState> =>
-      (await resolvedStreamSource(streamPath)).runtimeState(),
-    [resolvedStreamSource, streamPath],
-  );
+  const { getProcessorRuntimeState, getStreamRuntimeState } = useProcessorsPanelDebugState({
+    resolvedStreamSource,
+    streamPath,
+  });
 
   const connectionLabel =
     snapshot.connectionError ??
@@ -280,22 +262,7 @@ export function ProjectStreamView({
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
         {modeBody}
-        {caps.eventInspector && panels.inspectedOffset != null ? (
-          <RawEventInspectorPanel
-            database={store.streamDatabase}
-            offset={panels.inspectedOffset}
-            onNavigate={panels.inspectEvent}
-            onClose={panels.closeInspector}
-          />
-        ) : panels.inspectedLlmRequestOffset != null ? (
-          // Replays the request from the RAW events mirror (not feed_items):
-          // the fold reads the journal, the same source the processor read.
-          <LlmRequestInspectorPanel
-            database={store.streamDatabase}
-            llmRequestOffset={panels.inspectedLlmRequestOffset}
-            onClose={panels.closeLlmRequestInspector}
-          />
-        ) : null}
+        <StreamInspectorOverlay caps={caps} panels={panels} database={store.streamDatabase} />
       </div>
 
       <div className="shrink-0 px-4 pb-2.5 pt-2.5">
@@ -391,6 +358,46 @@ export function ProjectStreamView({
 }
 
 /**
+ * The feed's right-edge inspector, or nothing. At most one inspector holds
+ * the edge (useStreamViewPanels keeps their URL keys mutually exclusive):
+ * the raw-event inspector when the mode offers it and `?event=` is set,
+ * else the LLM request inspector when `?llmRequest=` is set — the latter in
+ * EVERY mode, so a shared link works regardless of the viewer's tab. Both
+ * read the RAW events mirror (not feed_items): the fold reads the journal,
+ * the same source the processor read.
+ */
+function StreamInspectorOverlay({
+  caps,
+  panels,
+  database,
+}: {
+  caps: ReturnType<typeof modeCapabilities>;
+  panels: ReturnType<typeof useStreamViewPanels>;
+  database: StreamBrowserDatabase;
+}) {
+  if (caps.eventInspector && panels.inspectedOffset != null) {
+    return (
+      <RawEventInspectorPanel
+        database={database}
+        offset={panels.inspectedOffset}
+        onNavigate={panels.inspectEvent}
+        onClose={panels.closeInspector}
+      />
+    );
+  }
+  if (panels.inspectedLlmRequestOffset != null) {
+    return (
+      <LlmRequestInspectorPanel
+        database={database}
+        llmRequestOffset={panels.inspectedLlmRequestOffset}
+        onClose={panels.closeLlmRequestInspector}
+      />
+    );
+  }
+  return null;
+}
+
+/**
  * Full-panel layouts relegate the feed to this right-edge sheet behind the
  * header's Events button (`?events=true`). Children are the filter row +
  * feed column the split layout renders inline.
@@ -440,6 +447,42 @@ function StreamEventsSheet({ children, streamPath }: { children: ReactNode; stre
       </SheetContent>
     </Sheet>
   );
+}
+
+/**
+ * The processors sheet's on-demand debug accessors: server-side runtime state
+ * for one processor subscription (plus the stream's max offset for lag math)
+ * and for the stream itself. Dialed fresh per call — debug reads must see the
+ * server's CURRENT state, not a cached snapshot.
+ */
+function useProcessorsPanelDebugState(args: {
+  resolvedStreamSource: ItxStreamSource;
+  streamPath: string;
+}) {
+  const { resolvedStreamSource, streamPath } = args;
+  const getProcessorRuntimeState = useCallback(
+    async (subscriptionKey: string) => {
+      const stream = await resolvedStreamSource(streamPath);
+      const [runtimeState, streamRuntimeState] = await Promise.all([
+        stream.getProcessorRuntimeState({ subscriptionKey }),
+        stream.runtimeState(),
+      ]);
+      return {
+        runtimeState,
+        // The itx Stream.runtimeState() types coreProcessorState as
+        // unknown; parse out the slice this panel needs.
+        streamMaxOffset: parseBrowserCoreProcessorState(streamRuntimeState.coreProcessorState)
+          .maxOffset,
+      };
+    },
+    [resolvedStreamSource, streamPath],
+  );
+  const getStreamRuntimeState = useCallback(
+    async (): Promise<StreamRuntimeDebugState> =>
+      (await resolvedStreamSource(streamPath)).runtimeState(),
+    [resolvedStreamSource, streamPath],
+  );
+  return { getProcessorRuntimeState, getStreamRuntimeState };
 }
 
 /**

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -30,6 +30,7 @@ import {
 import { AgentTokenUsageStrip } from "~/components/agent-feed.tsx";
 import { StreamFeedView } from "~/components/stream-feed-view.tsx";
 import { RawEventInspectorPanel } from "~/components/raw-event-inspector-panel.tsx";
+import { LlmRequestInspectorPanel } from "~/components/llm-request-inspector-panel.tsx";
 import { StreamFeedFilterRow } from "~/components/stream-feed-filters.tsx";
 import {
   StreamProcessorsPanel,
@@ -264,6 +265,7 @@ export function ProjectStreamView({
       }}
       liveState={caps.agentFeed ? agentUiState : null}
       {...(caps.eventInspector ? { onInspectEvent: panels.inspectEvent } : {})}
+      {...(caps.agentFeed ? { onInspectLlmRequest: panels.inspectLlmRequest } : {})}
       emptyLabel={connectionLabel}
       isInterruptingQueuedMessages={interrupt?.isInterrupting ?? false}
       projectSlug={projectSlug}
@@ -284,6 +286,14 @@ export function ProjectStreamView({
             offset={panels.inspectedOffset}
             onNavigate={panels.inspectEvent}
             onClose={panels.closeInspector}
+          />
+        ) : panels.inspectedLlmRequestOffset != null ? (
+          // Replays the request from the RAW events mirror (not feed_items):
+          // the fold reads the journal, the same source the processor read.
+          <LlmRequestInspectorPanel
+            database={store.streamDatabase}
+            llmRequestOffset={panels.inspectedLlmRequestOffset}
+            onClose={panels.closeLlmRequestInspector}
           />
         ) : null}
       </div>

--- a/apps/os/src/components/stream-feed-view.tsx
+++ b/apps/os/src/components/stream-feed-view.tsx
@@ -66,6 +66,7 @@ export function StreamFeedView({
   isPending = false,
   liveState,
   onInspectEvent,
+  onInspectLlmRequest,
   projectSlug,
   isInterruptingQueuedMessages = false,
   onInterruptQueuedMessages,
@@ -79,6 +80,8 @@ export function StreamFeedView({
   liveState: AgentUiState | null;
   /** Opens the raw-event inspector panel at this offset (raw rows only). */
   onInspectEvent?: (offset: number) => void;
+  /** Opens the LLM request inspector at this llmRequestOffset (llm steps only). */
+  onInspectLlmRequest?: (llmRequestOffset: number) => void;
   projectSlug?: string;
   isInterruptingQueuedMessages?: boolean;
   onInterruptQueuedMessages?: () => Promise<void> | void;
@@ -335,6 +338,7 @@ export function StreamFeedView({
                     live={live}
                     toggledIds={toggledIds}
                     onToggle={toggleExpanded}
+                    onInspectLlmRequest={onInspectLlmRequest}
                   />
                 ) : isQueuedItem ? (
                   <QueuedMessagesPanel
@@ -357,6 +361,7 @@ export function StreamFeedView({
                     item={row.agentItem}
                     toggledIds={toggledIds}
                     onToggle={toggleExpanded}
+                    onInspectLlmRequest={onInspectLlmRequest}
                     projectSlug={projectSlug}
                   />
                 ) : (

--- a/apps/os/src/components/stream-feed-view.tsx
+++ b/apps/os/src/components/stream-feed-view.tsx
@@ -5,7 +5,10 @@ import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@iterate-com/u
 import { Spinner } from "@iterate-com/ui/components/spinner";
 import { cn } from "@iterate-com/ui/lib/utils";
 import { useStreamQuery } from "~/domains/streams/client-libraries/browser/hooks/use-stream-query.ts";
-import type { StreamBrowserDatabase } from "~/domains/streams/client-libraries/browser/stream-browser-db.ts";
+import type {
+  SqlValue,
+  StreamBrowserDatabase,
+} from "~/domains/streams/client-libraries/browser/stream-browser-db.ts";
 import {
   AGENT_KIND_PREFIX,
   type RawFeedItemData,
@@ -181,80 +184,7 @@ export function StreamFeedView({
   const prefetchBefore = windowFirst > 0 ? 1 : 0;
   const queryOffset = windowFirst - prefetchBefore;
   const windowSize = virtualWindowSize + prefetchBefore;
-  // The filtered collection is ordered by local_index, so OFFSET/LIMIT over it
-  // IS the virtualizer's row window in dense positions.
-  const rowsResult = useStreamQuery(
-    database,
-    `SELECT local_index, kind, first_offset, last_offset, event_count, json(data) AS data
-     FROM feed_items WHERE ${whereSql}
-     ORDER BY local_index ASC LIMIT ? OFFSET ?`,
-    [...params, windowSize, queryOffset],
-  );
-  // Retain rows across range re-queries by MERGING each resolved window into
-  // the previously-loaded rows (bounded below). Replacing the map with just
-  // the latest window would forget loaded rows the moment the window shifts;
-  // rows scrolled back into view would then re-render as skeletons, and the
-  // skeleton's measurement would overwrite the row's real size — with an
-  // end-anchored virtualizer those size collapses cascade into the total
-  // thrashing and the scroll position stranding mid-history. The retained
-  // rows are only valid for the filter they were fetched under — reusing
-  // them across a filter change would briefly show unfiltered rows.
-  const retainKey = `${whereSql}:${params.join(" ")}`;
-  const lastRowsRef = useRef<{
-    retainKey: string;
-    rows: Map<number, { fingerprint: string; row: FeedRow }>;
-  } | null>(null);
-  const rowsByIndex = useMemo(() => {
-    const retained =
-      lastRowsRef.current?.retainKey === retainKey
-        ? lastRowsRef.current.rows
-        : new Map<number, { fingerprint: string; row: FeedRow }>();
-    if (rowsResult.status !== "ok") return retained;
-    const rows = new Map(retained);
-    rowsResult.data.forEach((sqlRow, position) => {
-      const index = queryOffset + position;
-      const kind = String(sqlRow.kind);
-      const raw = String(sqlRow.data);
-      // Identity stability is load-bearing: rows re-parse (new object) ONLY
-      // when their JSON changed. Handing memoized rows fresh-but-equal items
-      // on every window re-query re-renders their markdown, whose async
-      // re-parse collapses the row to empty for a frame — and a burst of
-      // rows momentarily measuring ~16px is exactly the kind of size storm
-      // that breaks the virtualizer's end anchor.
-      const fingerprint = `${kind}:${raw}`;
-      if (rows.get(index)?.fingerprint === fingerprint) return;
-      try {
-        const isAgent = kind.startsWith(AGENT_KIND_PREFIX);
-        const parsed = JSON.parse(raw) as AgentUiItem | RawFeedItemData;
-        rows.set(index, {
-          fingerprint,
-          row: {
-            kind,
-            firstOffset: Number(sqlRow.first_offset),
-            lastOffset: Number(sqlRow.last_offset),
-            eventCount: Number(sqlRow.event_count),
-            agentItem: isAgent ? (parsed as AgentUiItem) : null,
-            rawData: isAgent ? null : (parsed as RawFeedItemData),
-          },
-        });
-      } catch {
-        // Skip unparseable rows; the row stays a skeleton.
-      }
-    });
-    // Keep memory bounded on very long histories: drop the oldest-inserted
-    // entries once well past what any viewport plus overscan can show.
-    if (rows.size > MAX_RETAINED_ROWS) {
-      const excess = rows.size - MAX_RETAINED_ROWS;
-      let dropped = 0;
-      for (const key of rows.keys()) {
-        if (dropped >= excess) break;
-        rows.delete(key);
-        dropped++;
-      }
-    }
-    lastRowsRef.current = { retainKey, rows };
-    return rows;
-  }, [rowsResult.data, rowsResult.status, retainKey, queryOffset]);
+  const rowsByIndex = useRetainedFeedRows({ database, whereSql, params, queryOffset, windowSize });
 
   // All SCROLLING at the tail is owned by the stick (see the hook's docs):
   // it opens the feed at the newest content, holds the bottom through async
@@ -381,6 +311,99 @@ export function StreamFeedView({
       </div>
     </div>
   );
+}
+
+/**
+ * The virtualizer's row window as parsed, identity-stable rows: a live SQL
+ * LIMIT/OFFSET query over the filtered collection's dense positions, merged
+ * into previously-loaded rows (bounded at MAX_RETAINED_ROWS). Retention is
+ * load-bearing, not a cache nicety: replacing the map with just the latest
+ * window would forget loaded rows the moment the window shifts; rows scrolled
+ * back into view would then re-render as skeletons, and the skeleton's
+ * measurement would overwrite the row's real size — with an end-anchored
+ * virtualizer those size collapses cascade into the total thrashing and the
+ * scroll position stranding mid-history. The retained rows are only valid for
+ * the filter they were fetched under — reusing them across a filter change
+ * would briefly show unfiltered rows.
+ */
+function useRetainedFeedRows({
+  database,
+  whereSql,
+  params,
+  queryOffset,
+  windowSize,
+}: {
+  database: StreamBrowserDatabase;
+  whereSql: string;
+  params: SqlValue[];
+  queryOffset: number;
+  windowSize: number;
+}): ReadonlyMap<number, { fingerprint: string; row: FeedRow }> {
+  // The filtered collection is ordered by local_index, so OFFSET/LIMIT over it
+  // IS the virtualizer's row window in dense positions.
+  const rowsResult = useStreamQuery(
+    database,
+    `SELECT local_index, kind, first_offset, last_offset, event_count, json(data) AS data
+     FROM feed_items WHERE ${whereSql}
+     ORDER BY local_index ASC LIMIT ? OFFSET ?`,
+    [...params, windowSize, queryOffset],
+  );
+  const retainKey = `${whereSql}:${params.join(" ")}`;
+  const lastRowsRef = useRef<{
+    retainKey: string;
+    rows: Map<number, { fingerprint: string; row: FeedRow }>;
+  } | null>(null);
+  return useMemo(() => {
+    const retained =
+      lastRowsRef.current?.retainKey === retainKey
+        ? lastRowsRef.current.rows
+        : new Map<number, { fingerprint: string; row: FeedRow }>();
+    if (rowsResult.status !== "ok") return retained;
+    const rows = new Map(retained);
+    rowsResult.data.forEach((sqlRow, position) => {
+      const index = queryOffset + position;
+      const kind = String(sqlRow.kind);
+      const raw = String(sqlRow.data);
+      // Identity stability is load-bearing: rows re-parse (new object) ONLY
+      // when their JSON changed. Handing memoized rows fresh-but-equal items
+      // on every window re-query re-renders their markdown, whose async
+      // re-parse collapses the row to empty for a frame — and a burst of
+      // rows momentarily measuring ~16px is exactly the kind of size storm
+      // that breaks the virtualizer's end anchor.
+      const fingerprint = `${kind}:${raw}`;
+      if (rows.get(index)?.fingerprint === fingerprint) return;
+      try {
+        const isAgent = kind.startsWith(AGENT_KIND_PREFIX);
+        const parsed = JSON.parse(raw) as AgentUiItem | RawFeedItemData;
+        rows.set(index, {
+          fingerprint,
+          row: {
+            kind,
+            firstOffset: Number(sqlRow.first_offset),
+            lastOffset: Number(sqlRow.last_offset),
+            eventCount: Number(sqlRow.event_count),
+            agentItem: isAgent ? (parsed as AgentUiItem) : null,
+            rawData: isAgent ? null : (parsed as RawFeedItemData),
+          },
+        });
+      } catch {
+        // Skip unparseable rows; the row stays a skeleton.
+      }
+    });
+    // Keep memory bounded on very long histories: drop the oldest-inserted
+    // entries once well past what any viewport plus overscan can show.
+    if (rows.size > MAX_RETAINED_ROWS) {
+      const excess = rows.size - MAX_RETAINED_ROWS;
+      let dropped = 0;
+      for (const key of rows.keys()) {
+        if (dropped >= excess) break;
+        rows.delete(key);
+        dropped++;
+      }
+    }
+    lastRowsRef.current = { retainKey, rows };
+    return rows;
+  }, [rowsResult.data, rowsResult.status, retainKey, queryOffset]);
 }
 
 const RawFeedItemRow = memo(function RawFeedItemRow({

--- a/apps/os/src/lib/feed-format.ts
+++ b/apps/os/src/lib/feed-format.ts
@@ -1,0 +1,52 @@
+// Display formatters for the agent feed and its inspector panels: compact,
+// human-scale renderings of the numbers the stream produces (token counts,
+// durations, file sizes, timestamps). Pure string functions — no locale
+// state, no React.
+
+/** `950`, `2.5k` — compact token count; `?` when the model reported none. */
+export function formatTokens(count: number | undefined): string {
+  if (count == null) return "?";
+  if (count < 1000) return String(count);
+  return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+}
+
+/** `950 ms`, `2.4 s`, `1m 40s` — duration from milliseconds. */
+export function formatSeconds(durationMs: number): string {
+  if (durationMs < 1000) return `${Math.round(durationMs)} ms`;
+  const seconds = durationMs / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1).replace(/\.0$/, "")} s`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m ${Math.round(seconds % 60)}s`;
+}
+
+/** `950 B`, `1.5 KB`, `2.3 MB` — file size from bytes. */
+export function formatFileSize(size: number): string {
+  if (size < 1024) return `${size} B`;
+  const kilobytes = size / 1024;
+  if (kilobytes < 1024) return `${kilobytes.toFixed(1).replace(/\.0$/, "")} KB`;
+  return `${(kilobytes / 1024).toFixed(1).replace(/\.0$/, "")} MB`;
+}
+
+/** Locale time-of-day with seconds, for step start times. */
+export function formatClockTime(timestampMs: number): string {
+  return new Date(timestampMs).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+/** Locale date + time, for row tooltips and sr-only timestamps. */
+export function formatDateTime(timestampMs: number): string {
+  return new Date(timestampMs).toLocaleString([], {
+    dateStyle: "medium",
+    timeStyle: "medium",
+  });
+}
+
+/** ISO string for `<time dateTime>`; undefined when the timestamp is invalid. */
+export function formatDateTimeAttribute(timestampMs: number): string | undefined {
+  const date = new Date(timestampMs);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date.toISOString();
+}

--- a/apps/os/src/lib/llm-request-replay.test.ts
+++ b/apps/os/src/lib/llm-request-replay.test.ts
@@ -60,8 +60,8 @@ describe("replayLlmRequest", () => {
     expect(replay).not.toBeNull();
     expect(replay?.model).toBe("openai/gpt-5.5");
     expect(replay?.messages).toEqual([
-      { role: "system", content: "You are **demo**." },
-      { role: "user", content: "hello" },
+      { id: "3:0", role: "system", content: "You are **demo**." },
+      { id: "3:1", role: "user", content: "hello" },
     ]);
     // Settled by the completed event that references this offset.
     expect(replay?.outcome).toEqual({ status: "success", durationMs: 1234, errorMessage: null });
@@ -129,6 +129,6 @@ describe("replayLlmRequest", () => {
   it("skips malformed rows like the processor's own fold does", () => {
     const rows = ["not json", JSON.stringify({ half: "an event" }), ...conversationRows()];
     const replay = replayLlmRequest({ rawEventJsons: rows, llmRequestOffset: 3 });
-    expect(replay?.messages.at(-1)).toEqual({ role: "user", content: "hello" });
+    expect(replay?.messages.at(-1)).toEqual({ id: "3:1", role: "user", content: "hello" });
   });
 });

--- a/apps/os/src/lib/llm-request-replay.test.ts
+++ b/apps/os/src/lib/llm-request-replay.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { replayLlmRequest } from "./llm-request-replay.ts";
+
+// Raw rows exactly as the browser mirror returns them: the full committed
+// event JSON, one string per row (json(raw_jsonb)).
+let nextOffset = 1;
+function row(type: string, payload: Record<string, unknown>, offset?: number): string {
+  const at = offset ?? nextOffset;
+  nextOffset = at + 1;
+  return JSON.stringify({
+    type,
+    payload,
+    offset: at,
+    createdAt: `2026-07-11T00:00:${String(at).padStart(2, "0")}.000Z`,
+    path: "/agents/web/demo",
+  });
+}
+
+function conversationRows(): string[] {
+  nextOffset = 1;
+  return [
+    row("events.iterate.com/agent/system-prompt-updated", { systemPrompt: "You are **demo**." }),
+    row("events.iterate.com/agent/input-added", {
+      content: "hello",
+      llmRequestPolicy: { behaviour: "after-current-request" },
+    }),
+    row("events.iterate.com/agent/llm-request-requested", {
+      model: "openai/gpt-5.5",
+      requestId: "llm-request:gen-0",
+    }),
+    row("events.iterate.com/agent/output-added", { content: "hi there", llmRequestOffset: 3 }),
+    row("events.iterate.com/agent/llm-request-completed", {
+      durationMs: 1234,
+      llmRequestOffset: 3,
+      result: { status: "success" },
+    }),
+    row("events.iterate.com/agent/input-added", {
+      content: "look at this",
+      files: [
+        {
+          contentType: "image/png",
+          filename: "cat.png",
+          path: "/agents/web/demo/abc-cat.png",
+          size: 12345,
+          url: "https://files.example/abc-cat.png",
+        },
+      ],
+      llmRequestPolicy: { behaviour: "after-current-request" },
+    }),
+    row("events.iterate.com/agent/llm-request-requested", {
+      model: "openai/gpt-5.5",
+      requestId: "llm-request:gen-1",
+    }),
+  ];
+}
+
+describe("replayLlmRequest", () => {
+  it("rebuilds the exact wire messages for a request offset", () => {
+    const replay = replayLlmRequest({ rawEventJsons: conversationRows(), llmRequestOffset: 3 });
+    expect(replay).not.toBeNull();
+    expect(replay?.model).toBe("openai/gpt-5.5");
+    expect(replay?.messages).toEqual([
+      { role: "system", content: "You are **demo**." },
+      { role: "user", content: "hello" },
+    ]);
+    // Settled by the completed event that references this offset.
+    expect(replay?.outcome).toEqual({ status: "success", durationMs: 1234, errorMessage: null });
+  });
+
+  it("includes prior turns and flattens attachments to hint lines for later requests", () => {
+    const replay = replayLlmRequest({ rawEventJsons: conversationRows(), llmRequestOffset: 7 });
+    expect(replay?.messages.map((message) => message.role)).toEqual([
+      "system",
+      "user",
+      "assistant",
+      "user",
+    ]);
+    const lastMessage = replay?.messages.at(-1);
+    expect(lastMessage?.content).toContain("look at this");
+    // The hint line IS what the model saw — the file never travels inline.
+    expect(lastMessage?.content).toContain('itx.files.get("/agents/web/demo/abc-cat.png")');
+    // No completion for this request yet.
+    expect(replay?.outcome).toBeNull();
+  });
+
+  it("reports failed and cancelled outcomes", () => {
+    const failed = replayLlmRequest({
+      rawEventJsons: [
+        ...conversationRows(),
+        row("events.iterate.com/agent/llm-request-completed", {
+          durationMs: 30012,
+          llmRequestOffset: 7,
+          result: { status: "failure", error: { message: "LLM request timed out" } },
+        }),
+      ],
+      llmRequestOffset: 7,
+    });
+    expect(failed?.outcome).toEqual({
+      status: "failure",
+      durationMs: 30012,
+      errorMessage: "LLM request timed out",
+    });
+
+    const cancelled = replayLlmRequest({
+      rawEventJsons: [
+        ...conversationRows(),
+        row("events.iterate.com/agent/llm-request-cancelled", {
+          phase: "requested",
+          reason: "interrupted-by-user-input",
+          llmRequestOffset: 7,
+        }),
+      ],
+      llmRequestOffset: 7,
+    });
+    expect(cancelled?.outcome).toEqual({
+      status: "cancelled",
+      durationMs: null,
+      errorMessage: null,
+    });
+  });
+
+  it("returns null when the offset has no llm-request-requested event", () => {
+    expect(replayLlmRequest({ rawEventJsons: conversationRows(), llmRequestOffset: 2 })).toBeNull();
+    expect(
+      replayLlmRequest({ rawEventJsons: conversationRows(), llmRequestOffset: 99 }),
+    ).toBeNull();
+  });
+
+  it("skips malformed rows like the processor's own fold does", () => {
+    const rows = ["not json", JSON.stringify({ half: "an event" }), ...conversationRows()];
+    const replay = replayLlmRequest({ rawEventJsons: rows, llmRequestOffset: 3 });
+    expect(replay?.messages.at(-1)).toEqual({ role: "user", content: "hello" });
+  });
+});

--- a/apps/os/src/lib/llm-request-replay.ts
+++ b/apps/os/src/lib/llm-request-replay.ts
@@ -21,6 +21,9 @@ import { StreamEvent } from "~/domains/streams/schemas.ts";
 export const LLM_REPLAY_EVENT_TYPES: readonly string[] = AgentProcessorContract.consumes;
 
 export type LlmRequestReplayMessage = {
+  /** Stable identity: a message IS its position in the replayed request (the
+   * journal is immutable, so the same offset always folds to the same list). */
+  id: string;
   role: "system" | "user" | "assistant";
   /** Flattened exactly as sent: file attachments become their hint lines. */
   content: string;
@@ -92,7 +95,8 @@ export function replayLlmRequest(input: {
 
   const body = buildAgentLlmRequestBody({ events, llmRequestOffset: input.llmRequestOffset });
   return {
-    messages: body.messages.map((message) => ({
+    messages: body.messages.map((message, position) => ({
+      id: `${input.llmRequestOffset}:${position}`,
       role: message.role,
       content: flattenMessageToText(message),
     })),

--- a/apps/os/src/lib/llm-request-replay.ts
+++ b/apps/os/src/lib/llm-request-replay.ts
@@ -1,0 +1,129 @@
+import { z } from "zod";
+import { AgentProcessorContract } from "~/domains/agents/agent-processor-contract.ts";
+import {
+  buildAgentLlmRequestBody,
+  flattenMessageToText,
+} from "~/domains/agents/agent-processor-implementation.ts";
+import { StreamEvent } from "~/domains/streams/schemas.ts";
+
+// The agent processor never journals an LLM request's input — it REBUILDS it
+// from committed history on every attempt (buildAgentLlmRequestBody), keyed by
+// the llm-request-requested event's offset. That makes the exact wire request
+// a pure function of (events, llmRequestOffset), and the browser already
+// mirrors the events — so the UI replays the same fold locally instead of
+// storing a second copy of every prompt.
+
+/**
+ * The event types the replay needs from the local mirror: exactly what the
+ * agent processor consumes (its prompt fold reads nothing else), which also
+ * carries the request-lifecycle events the header derives model/outcome from.
+ */
+export const LLM_REPLAY_EVENT_TYPES: readonly string[] = AgentProcessorContract.consumes;
+
+export type LlmRequestReplayMessage = {
+  role: "system" | "user" | "assistant";
+  /** Flattened exactly as sent: file attachments become their hint lines. */
+  content: string;
+};
+
+export type LlmRequestReplay = {
+  messages: LlmRequestReplayMessage[];
+  /** From the llm-request-requested event at the replayed offset. */
+  model: string;
+  requestedAt: string;
+  /** Null while the request is still in flight. */
+  outcome: {
+    status: "success" | "failure" | "cancelled";
+    durationMs: number | null;
+    errorMessage: string | null;
+  } | null;
+};
+
+// Display slices of the lifecycle payloads (the contract's schemas stay the
+// source of truth; these read just the fields the panel shows). Loose on
+// purpose: a payload that grew fields must still replay.
+const RequestedPayloadSlice = z.looseObject({ model: z.string() });
+const CompletedPayloadSlice = z.looseObject({
+  durationMs: z.number(),
+  llmRequestOffset: z.number(),
+  result: z.union([
+    z.looseObject({ status: z.literal("success") }),
+    z.looseObject({ status: z.literal("failure"), error: z.looseObject({ message: z.string() }) }),
+  ]),
+});
+const CancelledPayloadSlice = z.looseObject({
+  phase: z.literal("requested"),
+  llmRequestOffset: z.number(),
+});
+
+/**
+ * Replays one LLM request's exact wire messages from mirrored raw events.
+ * Rows that fail to parse are skipped like the processor's own fold skips
+ * them (raw appends are accepted by design; a malformed event is a fact of
+ * the log). Returns null when no llm-request-requested event exists at the
+ * given offset — the mirror hasn't caught up, or the offset isn't a request.
+ */
+export function replayLlmRequest(input: {
+  rawEventJsons: readonly string[];
+  llmRequestOffset: number;
+}): LlmRequestReplay | null {
+  const events: StreamEvent[] = [];
+  for (const rawJson of input.rawEventJsons) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawJson);
+    } catch {
+      continue;
+    }
+    const result = StreamEvent.safeParse(parsed);
+    if (result.success) events.push(result.data);
+  }
+
+  const requestedEvent = events.find(
+    (event) =>
+      event.offset === input.llmRequestOffset &&
+      event.type === "events.iterate.com/agent/llm-request-requested",
+  );
+  const requested =
+    requestedEvent === undefined
+      ? undefined
+      : RequestedPayloadSlice.safeParse(requestedEvent.payload);
+  if (requestedEvent === undefined || requested === undefined || !requested.success) return null;
+
+  const body = buildAgentLlmRequestBody({ events, llmRequestOffset: input.llmRequestOffset });
+  return {
+    messages: body.messages.map((message) => ({
+      role: message.role,
+      content: flattenMessageToText(message),
+    })),
+    model: requested.data.model,
+    requestedAt: requestedEvent.createdAt,
+    outcome: replayOutcome(events, input.llmRequestOffset),
+  };
+}
+
+/** The request's settled outcome: completed beats cancelled (a late completion
+ * under the shared idempotency key is the durable fact); null = in flight. */
+function replayOutcome(
+  events: readonly StreamEvent[],
+  llmRequestOffset: number,
+): LlmRequestReplay["outcome"] {
+  for (const event of events) {
+    if (event.type !== "events.iterate.com/agent/llm-request-completed") continue;
+    const parsed = CompletedPayloadSlice.safeParse(event.payload);
+    if (!parsed.success || parsed.data.llmRequestOffset !== llmRequestOffset) continue;
+    const result = parsed.data.result;
+    return {
+      status: result.status,
+      durationMs: parsed.data.durationMs,
+      errorMessage: result.status === "failure" ? result.error.message : null,
+    };
+  }
+  for (const event of events) {
+    if (event.type !== "events.iterate.com/agent/llm-request-cancelled") continue;
+    const parsed = CancelledPayloadSlice.safeParse(event.payload);
+    if (!parsed.success || parsed.data.llmRequestOffset !== llmRequestOffset) continue;
+    return { status: "cancelled", durationMs: null, errorMessage: null };
+  }
+  return null;
+}

--- a/apps/os/src/lib/stream-view-search.ts
+++ b/apps/os/src/lib/stream-view-search.ts
@@ -42,6 +42,8 @@ export const StreamViewSearch = z.object({
   to: z.number().optional().catch(undefined),
   /** Offset of the raw event open in the inspector side panel. */
   event: z.number().optional().catch(undefined),
+  /** llm-request-requested offset open in the LLM request inspector panel. */
+  llmRequest: z.number().optional().catch(undefined),
   /** Whether the mode's search/filter row is open. */
   filter: z.boolean().optional().catch(undefined),
   /** Whether the processors sheet is open (overview when processor is absent). */
@@ -193,20 +195,24 @@ export function useStreamViewSearch(): {
 
 /**
  * URL state for the stream view's right-edge overlays — the raw-event
- * inspector, the processors sheet, and (on full-panel layouts) the Events
- * sheet. They share the same screen edge, so every setter keeps them
- * mutually exclusive; if a hand-edited URL asks for more than one, the
- * inspector beats the processors sheet, which beats the Events sheet.
- * (The inspector renders INSIDE the Events sheet's feed, so those two
- * compose rather than compete.)
+ * inspector, the LLM request inspector, the processors sheet, and (on
+ * full-panel layouts) the Events sheet. They share the same screen edge, so
+ * every setter keeps them mutually exclusive; if a hand-edited URL asks for
+ * more than one, the raw-event inspector beats the LLM request inspector,
+ * which beats the processors sheet, which beats the Events sheet. (The
+ * inspectors render INSIDE the Events sheet's feed, so those compose rather
+ * than compete.)
  */
 export function useStreamViewPanels(): {
   inspectedOffset: number | null;
+  inspectedLlmRequestOffset: number | null;
   focusedProcessorKey: string | null;
   processorsPanelOpen: boolean;
   eventsSheetOpen: boolean;
   inspectEvent: (offset: number) => void;
   closeInspector: () => void;
+  inspectLlmRequest: (llmRequestOffset: number) => void;
+  closeLlmRequestInspector: () => void;
   focusProcessor: (subscriptionKey: string) => void;
   openProcessorsOverview: () => void;
   closeProcessorsPanel: () => void;
@@ -215,22 +221,54 @@ export function useStreamViewPanels(): {
 } {
   const { search, setSearch } = useStreamViewSearch();
   const inspectedOffset = search.event ?? null;
+  // The raw-event inspector wins a hand-edited URL naming both inspectors.
+  const inspectedLlmRequestOffset = inspectedOffset == null ? (search.llmRequest ?? null) : null;
   const focusedProcessorKey = search.processor ?? null;
   const processorsPanelOpen =
-    inspectedOffset == null && (search.panel === true || focusedProcessorKey != null);
+    inspectedOffset == null &&
+    inspectedLlmRequestOffset == null &&
+    (search.panel === true || focusedProcessorKey != null);
   const eventsSheetOpen = search.events === true && !processorsPanelOpen;
   const inspectEvent = useCallback(
-    (offset: number) => setSearch({ event: offset, panel: undefined, processor: undefined }),
+    (offset: number) =>
+      setSearch({ event: offset, llmRequest: undefined, panel: undefined, processor: undefined }),
     [setSearch],
   );
   const closeInspector = useCallback(() => setSearch({ event: undefined }), [setSearch]);
+  const inspectLlmRequest = useCallback(
+    (llmRequestOffset: number) =>
+      setSearch({
+        llmRequest: llmRequestOffset,
+        event: undefined,
+        panel: undefined,
+        processor: undefined,
+      }),
+    [setSearch],
+  );
+  const closeLlmRequestInspector = useCallback(
+    () => setSearch({ llmRequest: undefined }),
+    [setSearch],
+  );
   const focusProcessor = useCallback(
     (subscriptionKey: string) =>
-      setSearch({ panel: true, processor: subscriptionKey, event: undefined, events: undefined }),
+      setSearch({
+        panel: true,
+        processor: subscriptionKey,
+        event: undefined,
+        llmRequest: undefined,
+        events: undefined,
+      }),
     [setSearch],
   );
   const openProcessorsOverview = useCallback(
-    () => setSearch({ panel: true, processor: undefined, event: undefined, events: undefined }),
+    () =>
+      setSearch({
+        panel: true,
+        processor: undefined,
+        event: undefined,
+        llmRequest: undefined,
+        events: undefined,
+      }),
     [setSearch],
   );
   const closeProcessorsPanel = useCallback(
@@ -244,11 +282,14 @@ export function useStreamViewPanels(): {
   const closeEventsSheet = useCallback(() => setSearch({ events: undefined }), [setSearch]);
   return {
     inspectedOffset,
+    inspectedLlmRequestOffset,
     focusedProcessorKey,
     processorsPanelOpen,
     eventsSheetOpen,
     inspectEvent,
     closeInspector,
+    inspectLlmRequest,
+    closeLlmRequestInspector,
     focusProcessor,
     openProcessorsOverview,
     closeProcessorsPanel,

--- a/apps/os/src/lib/stream-view-search.ts
+++ b/apps/os/src/lib/stream-view-search.ts
@@ -213,8 +213,9 @@ const RELEASE_PANEL_EDGE = {
  * inspector, the LLM request inspector, the processors sheet, and (on
  * full-panel layouts) the Events sheet. They share the same screen edge, so
  * every setter keeps them mutually exclusive; if a hand-edited URL asks for
- * more than one, the raw-event inspector beats the LLM request inspector,
- * which beats the processors sheet, which beats the Events sheet.
+ * more than one, either inspector beats the processors sheet, which beats
+ * the Events sheet (between the two inspectors, StreamInspectorOverlay picks
+ * whichever the active mode can render, raw-event inspector first).
  */
 export function useStreamViewPanels(): {
   inspectedOffset: number | null;
@@ -234,8 +235,12 @@ export function useStreamViewPanels(): {
 } {
   const { search, setSearch } = useStreamViewSearch();
   const inspectedOffset = search.event ?? null;
-  // The raw-event inspector wins a hand-edited URL naming both inspectors.
-  const inspectedLlmRequestOffset = inspectedOffset == null ? (search.llmRequest ?? null) : null;
+  // Both inspector offsets are surfaced as-is. Openers keep them mutually
+  // exclusive, so both set = a stale or hand-edited URL; precedence between
+  // them is the RENDERER's call (StreamInspectorOverlay): only it knows
+  // whether the mode can actually show the raw inspector, and suppressing
+  // the LLM offset here would leave the edge empty in modes that can't.
+  const inspectedLlmRequestOffset = search.llmRequest ?? null;
   const focusedProcessorKey = search.processor ?? null;
   const processorsPanelOpen =
     inspectedOffset == null &&

--- a/apps/os/src/lib/stream-view-search.ts
+++ b/apps/os/src/lib/stream-view-search.ts
@@ -194,14 +194,27 @@ export function useStreamViewSearch(): {
 }
 
 /**
+ * Every key that claims the stream view's right screen edge. Openers spread
+ * this before setting their own key, so mutual exclusion is structural — a
+ * new edge surface joins by adding its key here rather than patching every
+ * other opener. (`events` is deliberately absent: the inspectors render
+ * INSIDE the Events sheet's feed, so they compose with it rather than
+ * compete; the processor sheet openers clear it themselves.)
+ */
+const RELEASE_PANEL_EDGE = {
+  event: undefined,
+  llmRequest: undefined,
+  panel: undefined,
+  processor: undefined,
+} satisfies Partial<StreamViewSearch>;
+
+/**
  * URL state for the stream view's right-edge overlays — the raw-event
  * inspector, the LLM request inspector, the processors sheet, and (on
  * full-panel layouts) the Events sheet. They share the same screen edge, so
  * every setter keeps them mutually exclusive; if a hand-edited URL asks for
  * more than one, the raw-event inspector beats the LLM request inspector,
- * which beats the processors sheet, which beats the Events sheet. (The
- * inspectors render INSIDE the Events sheet's feed, so those compose rather
- * than compete.)
+ * which beats the processors sheet, which beats the Events sheet.
  */
 export function useStreamViewPanels(): {
   inspectedOffset: number | null;
@@ -230,19 +243,13 @@ export function useStreamViewPanels(): {
     (search.panel === true || focusedProcessorKey != null);
   const eventsSheetOpen = search.events === true && !processorsPanelOpen;
   const inspectEvent = useCallback(
-    (offset: number) =>
-      setSearch({ event: offset, llmRequest: undefined, panel: undefined, processor: undefined }),
+    (offset: number) => setSearch({ ...RELEASE_PANEL_EDGE, event: offset }),
     [setSearch],
   );
   const closeInspector = useCallback(() => setSearch({ event: undefined }), [setSearch]);
   const inspectLlmRequest = useCallback(
     (llmRequestOffset: number) =>
-      setSearch({
-        llmRequest: llmRequestOffset,
-        event: undefined,
-        panel: undefined,
-        processor: undefined,
-      }),
+      setSearch({ ...RELEASE_PANEL_EDGE, llmRequest: llmRequestOffset }),
     [setSearch],
   );
   const closeLlmRequestInspector = useCallback(
@@ -252,23 +259,15 @@ export function useStreamViewPanels(): {
   const focusProcessor = useCallback(
     (subscriptionKey: string) =>
       setSearch({
+        ...RELEASE_PANEL_EDGE,
+        events: undefined,
         panel: true,
         processor: subscriptionKey,
-        event: undefined,
-        llmRequest: undefined,
-        events: undefined,
       }),
     [setSearch],
   );
   const openProcessorsOverview = useCallback(
-    () =>
-      setSearch({
-        panel: true,
-        processor: undefined,
-        event: undefined,
-        llmRequest: undefined,
-        events: undefined,
-      }),
+    () => setSearch({ ...RELEASE_PANEL_EDGE, events: undefined, panel: true }),
     [setSearch],
   );
   const closeProcessorsPanel = useCallback(


### PR DESCRIPTION
## What

Every LLM step in the agent feed (settled activities and the live rail) gets a scroll-text icon that opens a right-edge inspector panel showing **exactly** what was sent to the model for that request: the system prompt and every message, rendered as markdown (with a plain-text toggle showing the verbatim wire text, including flattened attachment hint lines), plus model, timing, size, and outcome. The open request is URL-backed (`?llmRequest=<offset>`), so any inspected request is a shareable link.


## How — replay, not storage

The agent processor never journals an LLM request's input: it **rebuilds** it from committed history on every attempt (`buildAgentLlmRequestBody`, keyed by the `llm-request-requested` event's offset). That makes the exact wire request a pure function of `(events, llmRequestOffset)` — and the browser already mirrors the full event log into local SQLite. So the panel replays the same fold, client-side, over the same events:

- **Zero storage cost** — no duplicated prompt copies in the journal (the naive "copy the history onto llm-request-started" approach is quadratic: every request re-embeds the whole conversation, and every copy syncs to every browser mirror).
- **Works retroactively** for every request already in any agent's journal.
- **One source of truth** — `~/lib/llm-request-replay.ts` imports the processor's own `buildAgentLlmRequestBody` / `flattenMessageToText` (already client-safe: the browser-feed processor extends `StreamProcessor` in the browser today), so the UI can't drift from what the processor sends.

Fidelity caveat, stated in the panel's docstring: the replay is exact as long as the deployed fold semantics match the ones that built the original request. If reducer semantics ever change materially, a content hash on `llm-request-started` would let the UI flag drift — deliberately not added until it bites.

## Pieces

- `apps/os/src/lib/llm-request-replay.ts` — pure replay over mirrored raw-event JSON rows → flattened messages + model/requestedAt/outcome (unit-tested, including attachment hint lines, failed/cancelled outcomes, and malformed-row skipping).
- `apps/os/src/components/llm-request-inspector-panel.tsx` — the panel, styled after the raw-event inspector `aside`; per-message markdown via static-mode streamdown, memoized by content value so live appends don't re-render settled transcripts.
- `?llmRequest=` search param + panel plumbing in `stream-view-search.ts`, mutually exclusive with the raw-event inspector (`?event=` wins on hand-edited URLs) and the processors sheet.
- Trigger threading through `StreamFeedView` → `AgentFeedItemRow`/`AgentLiveActivity` → activity steps. The live rail gets the button too — an in-flight request's context is already committed history, so you can inspect what the model is chewing on mid-turn.

## Verified

- `pnpm typecheck && pnpm lint && pnpm format && pnpm test` (1009 passed).
- Live against local dev with the onboarding agent: button on settled + live LLM steps; panel header (model, timestamp, message count, chars, success/failure badge with duration); markdown + plain-text toggle; multi-turn replay includes script-result reflections and the new user message verbatim; deep link survives reload; close clears the param; both directions of raw-inspector ↔ LLM-panel mutual exclusion.

## Screenshots

Markdown view — the replayed system prompt and messages, with model / size / outcome in the header:

![LLM request inspector, markdown view](https://raw.githubusercontent.com/iterate/iterate/a31799f10faace1ed3e65599c9894fe083b8f689/llm-request-inspector-markdown.png)

Plain-text view — the verbatim wire text (what the model literally received):

![LLM request inspector, plain-text view](https://raw.githubusercontent.com/iterate/iterate/a31799f10faace1ed3e65599c9894fe083b8f689/llm-request-inspector-plain.png)

## Quality round (post-review)

A strict maintainability pass + react-doctor over the PR surface (now **zero react-doctor diagnostics on every touched file**):

- `~/lib/feed-format.ts` — one canonical home for the feed's display formatters; `agent-feed.tsx` returns under its pre-PR size instead of crossing 1k lines.
- Right-edge panel mutual exclusion is structural (`RELEASE_PANEL_EDGE` spread) instead of five hand-maintained key lists; `StreamInspectorOverlay` names the "which inspector holds the edge" policy.
- `useRetainedFeedRows` / `useProcessorsPanelDebugState` pull cohesive data concerns out of the two big view components — the virtualizer choreography (#1847/#1848) is untouched.
- Replay messages carry a stable `id` (their position in the immutable request); Copy JSON strips it to keep the wire shape exact.
- Locale dates render via the shared helper; clipboard failures surface as toasts.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI and read-only replay over existing processor code; no auth, persistence, or server contract changes beyond a new URL search param.
> 
> **Overview**
> Adds an **LLM request inspector** so users can see the exact prompt/context sent for any agent turn, without storing duplicate bodies in the journal.
> 
> **Replay path:** New `replayLlmRequest` reuses the agent processor’s `buildAgentLlmRequestBody` / `flattenMessageToText` over mirrored raw events (unit-tested). A side panel queries the local SQLite event mirror, shows messages (markdown or plain wire text), model/metadata, outcome, and copy-as-JSON.
> 
> **UI wiring:** LLM activity steps (settled and live) get a scroll-text control that opens the panel via URL `?llmRequest=<offset>` (shareable). `StreamInspectorOverlay` picks raw-event vs LLM inspector; `RELEASE_PANEL_EDGE` keeps right-edge panels mutually exclusive.
> 
> **Refactors:** Display formatters move to `~/lib/feed-format.ts`; virtualizer row retention becomes `useRetainedFeedRows`; processor debug hooks become `useProcessorsPanelDebugState`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5f2acae61708ced7f9c6ed78fdf3a5df0b6e4db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +240 -10 | +166 -4 🟩🟩⬜⬜⬜ |
| UI components | +498 -168 | +410 -139 🟩🟩🟩🟩🟥 |
| Tests | +134 -0 | +121 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+872 -178** | **+697 -143** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between d7e37a8 and e5f2aca, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-11T08:25:42.871Z",
      "headSha": "e5f2acae61708ced7f9c6ed78fdf3a5df0b6e4db",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/59874441240455",
      "shortSha": "e5f2aca",
      "cleanupDurationMs": 12983,
      "deployDurationMs": 58709,
      "testDurationMs": 118219,
      "testRetries": "2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · creates a project and uses project streams through v4 ITX (vitest x1)",
      "workerSizeKib": 15881,
      "workerGzipKib": 4278.6,
      "mainWorkerGzipKib": 4279.24
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-11T08:25:30.804Z",
      "headSha": "575910c18690bb808399b899efddad56ad275634",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/256129852037070",
      "shortSha": "575910c",
      "cleanupDurationMs": 913,
      "deployDurationMs": 15418,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-11T08:25:32.717Z",
      "headSha": "e5f2acae61708ced7f9c6ed78fdf3a5df0b6e4db",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/59874441240455",
      "shortSha": "e5f2aca",
      "cleanupDurationMs": 2823,
      "deployDurationMs": 17018,
      "testDurationMs": 459,
      "testRetries": null,
      "workerSizeKib": 4031.76,
      "workerGzipKib": 819.4,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-11T08:25:30.825Z",
      "headSha": "575910c18690bb808399b899efddad56ad275634",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/256129852037070",
      "shortSha": "575910c",
      "cleanupDurationMs": 928,
      "deployDurationMs": 23357,
      "workerSizeKib": 4781.96,
      "workerGzipKib": 1365.14,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `e5f2aca` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 819.4 KiB | 17.0s | 459ms |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/59874441240455) | 2026-07-11T08:25:32.717Z | Preview app released. |
| OS | released | `e5f2aca` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.18 MiB (-0.6 KiB vs main) | 58.7s | 118.2s | 2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · creates a project and uses project streams through v4 ITX (vitest x1) | 13.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/59874441240455) | 2026-07-11T08:25:42.871Z | Preview app released. |
| Semaphore | released | `575910c` | [https://semaphore.iterate-preview-3.com](https://semaphore.iterate-preview-3.com) | 440.8 KiB | 15.4s |  |  | 913ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/256129852037070) | 2026-07-11T08:25:30.804Z | Preview app released. |
| Streams Example App | released | `575910c` | [https://streams.iterate-preview-3.com](https://streams.iterate-preview-3.com) | 1.33 MiB | 23.4s |  |  | 928ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/256129852037070) | 2026-07-11T08:25:30.825Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->
