### PR TITLE
LLM trace panel: the response joins the request, behind a labelled "View trace" button

### DIFF
--- a/apps/os/src/components/agent-feed.tsx
+++ b/apps/os/src/components/agent-feed.tsx
@@ -39,6 +39,7 @@ import {
   formatFileSize,
   formatSeconds,
   formatTokens,
+  looksLikeCode,
 } from "~/lib/feed-format.ts";
 import { linkOptionsForStreamPath } from "~/lib/stream-routes.ts";
 
@@ -588,8 +589,9 @@ function AgentActivityStep({
   );
 }
 
-/** Opens the LLM request inspector: the exact context this request sent to
- * the model, replayed from the local event mirror (llm-request-inspector-panel). */
+/** Opens the LLM trace panel: the exact context this request sent to the
+ * model and the response it made, replayed from the local event mirror
+ * (llm-request-inspector-panel). */
 function InspectLlmRequestButton({
   llmRequestOffset,
   onInspectLlmRequest,
@@ -601,12 +603,13 @@ function InspectLlmRequestButton({
     <Button
       variant="ghost"
       size="xs"
-      title="Show the exact context sent to the model"
+      title="Show the exact request sent to the model and its response"
       data-testid="agent-feed-inspect-llm-request"
       onClick={() => onInspectLlmRequest(llmRequestOffset)}
-      className="text-muted-foreground/60 hover:text-foreground"
+      className="font-normal text-muted-foreground/70 hover:text-foreground"
     >
       <ScrollTextIcon className="size-3" />
+      <span className="font-mono text-xs">View trace</span>
     </Button>
   );
 }
@@ -864,12 +867,6 @@ function liveActivityLabel(runningSteps: AgentUiStep[]): string {
     parts.push(`Making ${llmCount} LLM request${llmCount === 1 ? "" : "s"}`);
   }
   return parts.join(" · ") || "Working…";
-}
-
-/** Code-mode agents stream itx code as their response; chat agents stream prose. */
-const CODE_START_PATTERN = /^\s*(async|await|function|const|let|import)\b/;
-function looksLikeCode(text: string): boolean {
-  return text.includes("```") || CODE_START_PATTERN.test(text);
 }
 
 function LiveStepStream({ step }: { step: AgentUiStep }) {

--- a/apps/os/src/components/llm-request-inspector-panel.tsx
+++ b/apps/os/src/components/llm-request-inspector-panel.tsx
@@ -160,6 +160,13 @@ export function LlmRequestInspectorPanel({
             <ReplayResponseSection replay={replay} renderMode={renderMode} />
             <ReplayMetricsSection stats={replay.stats} />
           </div>
+        ) : eventsResult.status === "error" || chunksResult.status === "error" ? (
+          // An errored query never resolves on its own — say so instead of
+          // presenting a permanent "opening" state as progress.
+          <p className="px-5 py-3 text-sm text-destructive">
+            Reading the local event mirror failed:{" "}
+            {(eventsResult.error ?? chunksResult.error)?.message ?? "unknown error"}
+          </p>
         ) : !loaded ? (
           <p className="px-5 py-3 text-sm text-muted-foreground">Opening local SQLite mirror…</p>
         ) : (

--- a/apps/os/src/components/llm-request-inspector-panel.tsx
+++ b/apps/os/src/components/llm-request-inspector-panel.tsx
@@ -3,29 +3,35 @@ import { CheckIcon, CopyIcon, XIcon } from "lucide-react";
 import { Button } from "@iterate-com/ui/components/button";
 import { toast } from "@iterate-com/ui/components/sonner";
 import { MessageResponse } from "@iterate-com/ui/components/ai-elements/message";
+import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
 import { cn } from "@iterate-com/ui/lib/utils";
 import { useStreamQuery } from "~/domains/streams/client-libraries/browser/hooks/use-stream-query.ts";
 import type { StreamBrowserDatabase } from "~/domains/streams/client-libraries/browser/stream-browser-db.ts";
-import { formatDateTime, formatSeconds } from "~/lib/feed-format.ts";
+import { formatDateTime, formatSeconds, looksLikeCode } from "~/lib/feed-format.ts";
 import {
   LLM_REPLAY_EVENT_TYPES,
+  LLM_RESPONSE_CHUNK_EVENT_TYPE,
   replayLlmRequest,
   type LlmRequestReplay,
   type LlmRequestReplayMessage,
 } from "~/lib/llm-request-replay.ts";
 
 /**
- * LLM-request inspection side panel: the EXACT context one request sent to
- * the model, replayed locally from the raw-event mirror. The processor never
- * stores request bodies — it rebuilds them from committed history per attempt
- * — so this panel runs the same pure fold (see ~/lib/llm-request-replay.ts)
- * over the same events and shows the resulting messages verbatim, including
- * the flattened attachment hint lines. Works retroactively for every request
- * in the journal, at zero storage cost.
+ * LLM trace side panel: the EXACT request one LLM call sent to the model and
+ * the response it made, replayed locally from the raw-event mirror. The
+ * processor never stores request bodies — it rebuilds them from committed
+ * history per attempt — so this panel runs the same pure fold (see
+ * ~/lib/llm-request-replay.ts) over the same events and shows the resulting
+ * messages verbatim, including the flattened attachment hint lines. The
+ * response side comes from the same journal: the committed output when the
+ * turn settled, re-assembled streamed chunks (reasoning included) when it
+ * didn't — which also makes an in-flight request's trace grow live as chunk
+ * events land. Works retroactively for every request in the journal, at zero
+ * storage cost.
  *
- * Fidelity caveat: the replay is exact as long as the deployed fold semantics
- * match the ones that built the original request — the trade we make for not
- * duplicating every prompt into the journal.
+ * Fidelity caveat: the request replay is exact as long as the deployed fold
+ * semantics match the ones that built the original request — the trade we
+ * make for not duplicating every prompt into the journal.
  */
 export function LlmRequestInspectorPanel({
   database,
@@ -41,7 +47,7 @@ export function LlmRequestInspectorPanel({
   // The whole consumed subset, unbounded above: the fold self-filters to
   // offsets ≤ llmRequestOffset, and the request's outcome (completed /
   // cancelled) lands ABOVE it. Bulk emitted-only types (response chunks)
-  // never leave SQLite.
+  // stay out of this transfer — the query below fetches only THIS request's.
   const eventsResult = useStreamQuery(
     database,
     `SELECT json(raw_jsonb) AS raw_json FROM events
@@ -49,15 +55,35 @@ export function LlmRequestInspectorPanel({
      ORDER BY offset ASC`,
     [...LLM_REPLAY_EVENT_TYPES],
   );
+  // This request's streamed chunks: reasoning text lives only here, and for a
+  // request that never settled with an output (cancelled / failed / still in
+  // flight) the re-assembled deltas are the only copy of the response.
+  const chunksResult = useStreamQuery(
+    database,
+    `SELECT json(raw_jsonb) AS raw_json FROM events
+     WHERE type = ? AND json_extract(raw_jsonb, '$.payload.llmRequestOffset') = ?
+     ORDER BY offset ASC`,
+    [LLM_RESPONSE_CHUNK_EVENT_TYPE, llmRequestOffset],
+  );
   const replay = useMemo(
     () =>
       eventsResult.status === "ok"
         ? replayLlmRequest({
             rawEventJsons: eventsResult.data.map((sqlRow) => String(sqlRow.raw_json)),
+            chunkEventJsons:
+              chunksResult.status === "ok"
+                ? chunksResult.data.map((sqlRow) => String(sqlRow.raw_json))
+                : [],
             llmRequestOffset,
           })
         : null,
-    [eventsResult.status, eventsResult.data, llmRequestOffset],
+    [
+      eventsResult.status,
+      eventsResult.data,
+      chunksResult.status,
+      chunksResult.data,
+      llmRequestOffset,
+    ],
   );
 
   const [renderMode, setRenderMode] = useState<"markdown" | "plain">("markdown");
@@ -72,17 +98,17 @@ export function LlmRequestInspectorPanel({
       <div className="flex shrink-0 items-start gap-2 px-5 pb-2 pt-4">
         <div className="min-w-0 flex-1">
           <div className="truncate font-mono text-sm font-semibold">
-            LLM request #{llmRequestOffset}
+            LLM trace #{llmRequestOffset}
             {replay == null ? "" : ` · ${replay.model}`}
           </div>
           <div className="text-xs text-muted-foreground">
             {replay == null ? (
-              "The exact context sent to the model"
+              "The exact request sent to the model, and its response"
             ) : (
               <>
                 {formatDateTime(Date.parse(replay.requestedAt))} ·{" "}
                 {replay.messages.length.toLocaleString()} messages ·{" "}
-                {(totalChars ?? 0).toLocaleString()} chars
+                {(totalChars ?? 0).toLocaleString()} chars in
                 <OutcomeBadge outcome={replay.outcome} />
               </>
             )}
@@ -134,6 +160,7 @@ export function LlmRequestInspectorPanel({
             {replay.messages.map((message) => (
               <ReplayMessageSection key={message.id} message={message} renderMode={renderMode} />
             ))}
+            <ReplayResponseSection replay={replay} renderMode={renderMode} />
           </div>
         ) : eventsResult.status === "pending" ? (
           <p className="px-5 py-3 text-sm text-muted-foreground">Opening local SQLite mirror…</p>
@@ -222,4 +249,88 @@ const ReplayMessageSection = memo(
     previous.renderMode === next.renderMode &&
     previous.message.id === next.message.id &&
     previous.message.content === next.message.content,
+);
+
+/**
+ * The trace's response half: reasoning ("thinking") first when the model
+ * streamed any, then the response text — as a code block when it's a codemode
+ * script (matching the feed's treatment), else through the markdown/plain
+ * toggle. A failed request shows its error here too; the "(partial…)" label
+ * marks chunk-reassembled text that never settled into a committed output.
+ */
+const ReplayResponseSection = memo(
+  function ReplayResponseSection({
+    replay,
+    renderMode,
+  }: {
+    replay: LlmRequestReplay;
+    renderMode: "markdown" | "plain";
+  }) {
+    const { response, outcome } = replay;
+    return (
+      <section className="border-b border-border/60 bg-muted/20 px-5 py-3">
+        <div className="mb-2 flex items-baseline gap-2">
+          <span className="font-mono text-[10px] font-semibold uppercase tracking-wider text-amber-700 dark:text-amber-400">
+            response
+          </span>
+          {response == null ? null : (
+            <span className="font-mono text-[10px] text-muted-foreground/60">
+              {response.text.length.toLocaleString()} chars
+              {response.source === "chunks" && outcome != null
+                ? " · partial (re-assembled from streamed chunks)"
+                : response.source === "chunks"
+                  ? " · streaming"
+                  : ""}
+            </span>
+          )}
+        </div>
+        {response == null || response.thinkingText === "" ? null : (
+          <div className="mb-2 max-w-full whitespace-pre-wrap rounded-xl bg-muted/50 px-4 py-3 text-sm italic leading-relaxed text-muted-foreground">
+            {response.thinkingText}
+          </div>
+        )}
+        {response == null || response.text === "" ? null : looksLikeCode(response.text) ? (
+          <SourceCodeBlock
+            code={response.text}
+            language="typescript"
+            className="max-h-96"
+            showCopyButton
+            showLineNumbers={false}
+            plainChrome
+          />
+        ) : renderMode === "markdown" ? (
+          <MessageResponse
+            className="min-w-0 max-w-full overflow-hidden text-sm"
+            mode="static"
+            parseIncompleteMarkdown={false}
+          >
+            {response.text}
+          </MessageResponse>
+        ) : (
+          <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-foreground">
+            {response.text}
+          </pre>
+        )}
+        {outcome?.errorMessage == null ? null : (
+          <pre className="mt-2 overflow-x-auto rounded-xl bg-destructive/5 px-4 py-2.5 font-mono text-xs leading-relaxed text-destructive">
+            {outcome.errorMessage}
+          </pre>
+        )}
+        {response == null && outcome?.errorMessage == null ? (
+          <p className="text-sm text-muted-foreground">
+            {outcome == null
+              ? "Nothing has streamed back yet."
+              : "The model returned no text for this request."}
+          </p>
+        ) : null}
+      </section>
+    );
+  },
+  (previous, next) =>
+    previous.renderMode === next.renderMode &&
+    previous.replay.response?.text === next.replay.response?.text &&
+    previous.replay.response?.thinkingText === next.replay.response?.thinkingText &&
+    previous.replay.response?.source === next.replay.response?.source &&
+    previous.replay.outcome?.status === next.replay.outcome?.status &&
+    previous.replay.outcome?.errorMessage === next.replay.outcome?.errorMessage,
 );

--- a/apps/os/src/components/llm-request-inspector-panel.tsx
+++ b/apps/os/src/components/llm-request-inspector-panel.tsx
@@ -382,7 +382,9 @@ function ReplayMetricsSection({ stats }: { stats: LlmRequestReplayStats }) {
               {tokens.inputTokens.toLocaleString()} tok
               {tokens.cachedInputTokens == null || tokens.cachedInputTokens === 0
                 ? ""
-                : ` (${tokens.cachedInputTokens.toLocaleString()} cached)`}
+                : ` (${tokens.cachedInputTokens.toLocaleString()} cached · ${Math.round(
+                    (tokens.cachedInputTokens / tokens.inputTokens) * 100,
+                  )}% hit rate)`}
             </dd>
             <dt className="text-muted-foreground/70">output</dt>
             <dd>
@@ -401,6 +403,24 @@ function ReplayMetricsSection({ stats }: { stats: LlmRequestReplayStats }) {
           <>
             <dt className="text-muted-foreground/70">streaming</dt>
             <dd>{streamingParts.join(" · ")}</dd>
+          </>
+        )}
+        {stats.gatewayCacheStatus == null ? null : (
+          <>
+            <dt className="text-muted-foreground/70">gateway</dt>
+            <dd>
+              response cache{" "}
+              <span
+                className={cn(
+                  stats.gatewayCacheStatus === "HIT" && "text-emerald-600 dark:text-emerald-500",
+                )}
+              >
+                {stats.gatewayCacheStatus}
+              </span>
+              {stats.gatewayCacheStatus === "HIT"
+                ? " — served from the AI Gateway cache without touching the model"
+                : ""}
+            </dd>
           </>
         )}
       </dl>

--- a/apps/os/src/components/llm-request-inspector-panel.tsx
+++ b/apps/os/src/components/llm-request-inspector-panel.tsx
@@ -14,6 +14,7 @@ import {
   replayLlmRequest,
   type LlmRequestReplay,
   type LlmRequestReplayMessage,
+  type LlmRequestReplayStats,
 } from "~/lib/llm-request-replay.ts";
 
 /**
@@ -65,25 +66,21 @@ export function LlmRequestInspectorPanel({
      ORDER BY offset ASC`,
     [LLM_RESPONSE_CHUNK_EVENT_TYPE, llmRequestOffset],
   );
+  // BOTH queries must resolve before replaying: chunks-still-pending is not
+  // "no chunks", and for a trace whose only response lives in chunks
+  // (cancelled / failed / in flight) rendering early would flash "the model
+  // returned no text" over a response that is about to appear.
+  const loaded = eventsResult.status === "ok" && chunksResult.status === "ok";
   const replay = useMemo(
     () =>
-      eventsResult.status === "ok"
+      loaded
         ? replayLlmRequest({
             rawEventJsons: eventsResult.data.map((sqlRow) => String(sqlRow.raw_json)),
-            chunkEventJsons:
-              chunksResult.status === "ok"
-                ? chunksResult.data.map((sqlRow) => String(sqlRow.raw_json))
-                : [],
+            chunkEventJsons: chunksResult.data.map((sqlRow) => String(sqlRow.raw_json)),
             llmRequestOffset,
           })
         : null,
-    [
-      eventsResult.status,
-      eventsResult.data,
-      chunksResult.status,
-      chunksResult.data,
-      llmRequestOffset,
-    ],
+    [loaded, eventsResult.data, chunksResult.data, llmRequestOffset],
   );
 
   const [renderMode, setRenderMode] = useState<"markdown" | "plain">("markdown");
@@ -108,7 +105,7 @@ export function LlmRequestInspectorPanel({
               <>
                 {formatDateTime(Date.parse(replay.requestedAt))} ·{" "}
                 {replay.messages.length.toLocaleString()} messages ·{" "}
-                {(totalChars ?? 0).toLocaleString()} chars in
+                {(totalChars ?? 0).toLocaleString()} chars
                 <OutcomeBadge outcome={replay.outcome} />
               </>
             )}
@@ -161,8 +158,9 @@ export function LlmRequestInspectorPanel({
               <ReplayMessageSection key={message.id} message={message} renderMode={renderMode} />
             ))}
             <ReplayResponseSection replay={replay} renderMode={renderMode} />
+            <ReplayMetricsSection stats={replay.stats} />
           </div>
-        ) : eventsResult.status === "pending" ? (
+        ) : !loaded ? (
           <p className="px-5 py-3 text-sm text-muted-foreground">Opening local SQLite mirror…</p>
         ) : (
           <p className="px-5 py-3 text-sm text-muted-foreground">
@@ -334,3 +332,89 @@ const ReplayResponseSection = memo(
     previous.replay.outcome?.status === next.replay.outcome?.status &&
     previous.replay.outcome?.errorMessage === next.replay.outcome?.errorMessage,
 );
+
+/**
+ * Everything else the journal recorded about the call: normalized token
+ * counts with context-window fullness, latency split into time-to-first-chunk
+ * (the dial → the first streamed token landing) and the generation window
+ * (with a derived tokens/second), and the transport's verbatim completion
+ * payload behind a disclosure. All timings come from the lifecycle events'
+ * own server-stamped append times.
+ */
+function ReplayMetricsSection({ stats }: { stats: LlmRequestReplayStats }) {
+  const { tokens } = stats;
+  const hasAnything =
+    tokens != null ||
+    stats.chunkCount > 0 ||
+    stats.generationMs != null ||
+    stats.rawResponse != null;
+  if (!hasAnything) return null;
+  const contextPercent =
+    tokens == null
+      ? null
+      : Math.round(((tokens.inputTokens + tokens.outputTokens) / tokens.maxContextTokens) * 1000) /
+        10;
+  const streamingParts = [
+    stats.timeToFirstChunkMs == null
+      ? null
+      : `first chunk after ${formatSeconds(stats.timeToFirstChunkMs)}`,
+    stats.generationMs == null ? null : `generated in ${formatSeconds(stats.generationMs)}`,
+    stats.chunkCount === 0 ? null : `${stats.chunkCount.toLocaleString()} chunks`,
+    stats.outputTokensPerSecond == null ? null : `${stats.outputTokensPerSecond} tok/s`,
+  ].filter((part) => part != null);
+  return (
+    <section className="px-5 py-3">
+      <div className="mb-2 font-mono text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+        metrics
+      </div>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 font-mono text-xs text-foreground/80">
+        {tokens == null ? null : (
+          <>
+            <dt className="text-muted-foreground/70">input</dt>
+            <dd>
+              {tokens.inputTokens.toLocaleString()} tok
+              {tokens.cachedInputTokens == null || tokens.cachedInputTokens === 0
+                ? ""
+                : ` (${tokens.cachedInputTokens.toLocaleString()} cached)`}
+            </dd>
+            <dt className="text-muted-foreground/70">output</dt>
+            <dd>
+              {tokens.outputTokens.toLocaleString()} tok
+              {tokens.reasoningOutputTokens == null || tokens.reasoningOutputTokens === 0
+                ? ""
+                : ` (${tokens.reasoningOutputTokens.toLocaleString()} reasoning)`}
+            </dd>
+            <dt className="text-muted-foreground/70">context</dt>
+            <dd>
+              {contextPercent}% of {Math.round(tokens.maxContextTokens / 1000)}k window
+            </dd>
+          </>
+        )}
+        {streamingParts.length === 0 ? null : (
+          <>
+            <dt className="text-muted-foreground/70">streaming</dt>
+            <dd>{streamingParts.join(" · ")}</dd>
+          </>
+        )}
+      </dl>
+      {stats.rawResponse == null ? null : (
+        <details className="mt-2">
+          <summary className="cursor-pointer font-mono text-xs text-muted-foreground/70 hover:text-foreground">
+            raw completion payload
+          </summary>
+          <pre className="mt-2 overflow-x-auto rounded-xl bg-muted/50 px-4 py-2.5 font-mono text-xs leading-relaxed text-muted-foreground">
+            {stringifyRawResponse(stats.rawResponse)}
+          </pre>
+        </details>
+      )}
+    </section>
+  );
+}
+
+function stringifyRawResponse(rawResponse: unknown): string {
+  try {
+    return JSON.stringify(rawResponse, null, 2) ?? String(rawResponse);
+  } catch {
+    return String(rawResponse);
+  }
+}

--- a/apps/os/src/lib/feed-format.ts
+++ b/apps/os/src/lib/feed-format.ts
@@ -27,6 +27,13 @@ export function formatFileSize(size: number): string {
   return `${(kilobytes / 1024).toFixed(1).replace(/\.0$/, "")} MB`;
 }
 
+/** Code-mode agents stream itx code as their response; chat agents stream
+ * prose. Decides whether LLM response text renders as a code block. */
+const CODE_START_PATTERN = /^\s*(async|await|function|const|let|import)\b/;
+export function looksLikeCode(text: string): boolean {
+  return text.includes("```") || CODE_START_PATTERN.test(text);
+}
+
 /** Locale time-of-day with seconds, for step start times. */
 export function formatClockTime(timestampMs: number): string {
   return new Date(timestampMs).toLocaleTimeString([], {

--- a/apps/os/src/lib/llm-request-replay.test.ts
+++ b/apps/os/src/lib/llm-request-replay.test.ts
@@ -119,6 +119,80 @@ describe("replayLlmRequest", () => {
     });
   });
 
+  it("returns the committed output as the response, with thinking from chunks", () => {
+    const chunkRows = [
+      row(
+        "events.iterate.com/agent/llm-response-chunk",
+        {
+          chunk: { choices: [{ delta: { reasoning_content: "let me think" } }] },
+          llmRequestOffset: 3,
+          sequence: 0,
+        },
+        50,
+      ),
+      row(
+        "events.iterate.com/agent/llm-response-chunk",
+        { chunk: { choices: [{ delta: { content: "hi " } }] }, llmRequestOffset: 3, sequence: 1 },
+        51,
+      ),
+      row(
+        "events.iterate.com/agent/llm-response-chunk",
+        { chunk: { choices: [{ delta: { content: "there" } }] }, llmRequestOffset: 3, sequence: 2 },
+        52,
+      ),
+    ];
+    const replay = replayLlmRequest({
+      rawEventJsons: conversationRows(),
+      chunkEventJsons: chunkRows,
+      llmRequestOffset: 3,
+    });
+    // The committed output-added text is authoritative over the streamed
+    // concatenation; thinking only ever exists in the chunks.
+    expect(replay?.response).toEqual({
+      text: "hi there",
+      thinkingText: "let me think",
+      source: "output",
+    });
+  });
+
+  it("re-assembles a partial response from chunks when no output committed", () => {
+    // Request 7 was cancelled mid-stream: chunks are the only copy. Sequence
+    // order wins even when rows arrive shuffled.
+    const chunkRows = [
+      row(
+        "events.iterate.com/agent/llm-response-chunk",
+        { chunk: { choices: [{ delta: { content: "world" } }] }, llmRequestOffset: 7, sequence: 1 },
+        60,
+      ),
+      row(
+        "events.iterate.com/agent/llm-response-chunk",
+        {
+          chunk: { choices: [{ delta: { content: "hello " } }] },
+          llmRequestOffset: 7,
+          sequence: 0,
+        },
+        61,
+      ),
+      // Another request's chunk must not bleed in.
+      row(
+        "events.iterate.com/agent/llm-response-chunk",
+        { chunk: { choices: [{ delta: { content: "NOPE" } }] }, llmRequestOffset: 3, sequence: 0 },
+        62,
+      ),
+    ];
+    const replay = replayLlmRequest({
+      rawEventJsons: conversationRows(),
+      chunkEventJsons: chunkRows,
+      llmRequestOffset: 7,
+    });
+    expect(replay?.response).toEqual({ text: "hello world", thinkingText: "", source: "chunks" });
+  });
+
+  it("reports no response when nothing streamed or committed", () => {
+    const replay = replayLlmRequest({ rawEventJsons: conversationRows(), llmRequestOffset: 7 });
+    expect(replay?.response).toBeNull();
+  });
+
   it("returns null when the offset has no llm-request-requested event", () => {
     expect(replayLlmRequest({ rawEventJsons: conversationRows(), llmRequestOffset: 2 })).toBeNull();
     expect(

--- a/apps/os/src/lib/llm-request-replay.test.ts
+++ b/apps/os/src/lib/llm-request-replay.test.ts
@@ -255,6 +255,7 @@ describe("replayLlmRequest", () => {
       generationMs: 4000,
       chunkCount: 2,
       outputTokensPerSecond: 25,
+      gatewayCacheStatus: "HIT",
       rawResponse: { streamed: true, cloudflareAiGatewayResponseCacheStatus: "HIT" },
     });
   });
@@ -267,6 +268,7 @@ describe("replayLlmRequest", () => {
       generationMs: null,
       chunkCount: 0,
       outputTokensPerSecond: null,
+      gatewayCacheStatus: null,
       rawResponse: null,
     });
   });

--- a/apps/os/src/lib/llm-request-replay.test.ts
+++ b/apps/os/src/lib/llm-request-replay.test.ts
@@ -188,6 +188,89 @@ describe("replayLlmRequest", () => {
     expect(replay?.response).toEqual({ text: "hello world", thinkingText: "", source: "chunks" });
   });
 
+  it("derives token counts, latency, and tokens/second from the lifecycle events", () => {
+    // Request 7 (still open in conversationRows). Timeline — createdAt encodes
+    // the offset as seconds (see row()): started at :10, first chunk at :11,
+    // last chunk at :14, completed at :15 → first chunk after 1s, generation
+    // window 4s, 100 output tok = 25 tok/s.
+    const rows = [
+      ...conversationRows(),
+      row(
+        "events.iterate.com/agent/llm-request-started",
+        { llmRequestOffset: 7, model: "openai/gpt-5.5" },
+        10,
+      ),
+      row(
+        "events.iterate.com/agent/llm-request-completed",
+        {
+          durationMs: 5000,
+          llmRequestOffset: 7,
+          result: {
+            status: "success",
+            rawResponse: { streamed: true, cloudflareAiGatewayResponseCacheStatus: "HIT" },
+          },
+        },
+        15,
+      ),
+      row(
+        "events.iterate.com/agent/token-usage-reported",
+        {
+          llmRequestOffset: 7,
+          model: "openai/gpt-5.5",
+          maxContextTokens: 272000,
+          inputTokens: 2500,
+          outputTokens: 100,
+          cachedInputTokens: 2400,
+          reasoningOutputTokens: 18,
+        },
+        16,
+      ),
+    ];
+    const chunkRows = [
+      row(
+        "events.iterate.com/agent/llm-response-chunk",
+        { chunk: { choices: [{ delta: { content: "a" } }] }, llmRequestOffset: 7, sequence: 0 },
+        11,
+      ),
+      row(
+        "events.iterate.com/agent/llm-response-chunk",
+        { chunk: { choices: [{ delta: { content: "b" } }] }, llmRequestOffset: 7, sequence: 1 },
+        14,
+      ),
+    ];
+    const replay = replayLlmRequest({
+      rawEventJsons: rows,
+      chunkEventJsons: chunkRows,
+      llmRequestOffset: 7,
+    });
+    expect(replay?.stats).toEqual({
+      tokens: {
+        inputTokens: 2500,
+        outputTokens: 100,
+        cachedInputTokens: 2400,
+        reasoningOutputTokens: 18,
+        maxContextTokens: 272000,
+      },
+      timeToFirstChunkMs: 1000,
+      generationMs: 4000,
+      chunkCount: 2,
+      outputTokensPerSecond: 25,
+      rawResponse: { streamed: true, cloudflareAiGatewayResponseCacheStatus: "HIT" },
+    });
+  });
+
+  it("reports empty stats when the journal has no usage or chunks", () => {
+    const replay = replayLlmRequest({ rawEventJsons: conversationRows(), llmRequestOffset: 7 });
+    expect(replay?.stats).toEqual({
+      tokens: null,
+      timeToFirstChunkMs: null,
+      generationMs: null,
+      chunkCount: 0,
+      outputTokensPerSecond: null,
+      rawResponse: null,
+    });
+  });
+
   it("reports no response when nothing streamed or committed", () => {
     const replay = replayLlmRequest({ rawEventJsons: conversationRows(), llmRequestOffset: 7 });
     expect(replay?.response).toBeNull();

--- a/apps/os/src/lib/llm-request-replay.ts
+++ b/apps/os/src/lib/llm-request-replay.ts
@@ -68,6 +68,10 @@ export type LlmRequestReplayStats = {
   chunkCount: number;
   /** Output tokens over the generation window. */
   outputTokensPerSecond: number | null;
+  /** AI Gateway response-cache verdict (`cf-aig-cache-status`: HIT/MISS…)
+   * where the transport recorded one — a HIT means the whole response was
+   * served from the gateway's cache without touching the model. */
+  gatewayCacheStatus: string | null;
   /** The completed event's verbatim result.rawResponse — whatever the
    * transport recorded (usage dialects, gateway cache status, …). */
   rawResponse: unknown;
@@ -128,6 +132,11 @@ const ChunkPayloadSlice = z.looseObject({
   chunk: z.unknown(),
   llmRequestOffset: z.number(),
   sequence: z.number(),
+});
+/** The transport stamps the gateway's `cf-aig-cache-status` header onto the
+ * rawResponse it journals (BYOK lane); absent everywhere else. */
+const GatewayCacheSlice = z.looseObject({
+  cloudflareAiGatewayResponseCacheStatus: z.string().nullable().optional(),
 });
 
 /**
@@ -302,13 +311,18 @@ function replayStats(input: {
       ? Math.round((tokens.outputTokens / (generationMs / 1000)) * 10) / 10
       : null;
 
+  const rawResponse = completed?.success ? (completed.data.result.rawResponse ?? null) : null;
+  const gatewayCacheStatus = GatewayCacheSlice.safeParse(rawResponse);
   return {
     tokens,
     timeToFirstChunkMs,
     generationMs,
     chunkCount: chunks.length,
     outputTokensPerSecond,
-    rawResponse: completed?.success ? (completed.data.result.rawResponse ?? null) : null,
+    gatewayCacheStatus: gatewayCacheStatus.success
+      ? (gatewayCacheStatus.data.cloudflareAiGatewayResponseCacheStatus ?? null)
+      : null,
+    rawResponse,
   };
 }
 

--- a/apps/os/src/lib/llm-request-replay.ts
+++ b/apps/os/src/lib/llm-request-replay.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { extractCloudflareChunkDeltas } from "@iterate-com/ui/components/events/agent-ui-reducer";
 import { AgentProcessorContract } from "~/domains/agents/agent-processor-contract.ts";
 import {
   buildAgentLlmRequestBody,
@@ -20,6 +21,14 @@ import { StreamEvent } from "~/domains/streams/schemas.ts";
  */
 export const LLM_REPLAY_EVENT_TYPES: readonly string[] = AgentProcessorContract.consumes;
 
+/**
+ * The streamed-chunk event type, for the trace panel's second mirror query.
+ * Chunks are emitted-only (the processor's fold never consumes them), so they
+ * ride outside LLM_REPLAY_EVENT_TYPES and are fetched per-request instead —
+ * one request's chunks, not every request's.
+ */
+export const LLM_RESPONSE_CHUNK_EVENT_TYPE = "events.iterate.com/agent/llm-response-chunk";
+
 export type LlmRequestReplayMessage = {
   /** Stable identity: a message IS its position in the replayed request (the
    * journal is immutable, so the same offset always folds to the same list). */
@@ -29,11 +38,25 @@ export type LlmRequestReplayMessage = {
   content: string;
 };
 
+export type LlmRequestReplayResponse = {
+  /** The response text: the committed output when the turn settled with one,
+   * else whatever streamed in before the request failed / was cancelled /
+   * is still in flight. */
+  text: string;
+  /** Streamed reasoning ("thinking") text, where the model reported any. */
+  thinkingText: string;
+  /** "output" = the committed output-added fact; "chunks" = re-assembled
+   * from streamed deltas (partial or pre-settle). */
+  source: "output" | "chunks";
+};
+
 export type LlmRequestReplay = {
   messages: LlmRequestReplayMessage[];
   /** From the llm-request-requested event at the replayed offset. */
   model: string;
   requestedAt: string;
+  /** Null when nothing has streamed or settled for this request yet. */
+  response: LlmRequestReplayResponse | null;
   /** Null while the request is still in flight. */
   outcome: {
     status: "success" | "failure" | "cancelled";
@@ -58,29 +81,33 @@ const CancelledPayloadSlice = z.looseObject({
   phase: z.literal("requested"),
   llmRequestOffset: z.number(),
 });
+const OutputPayloadSlice = z.looseObject({
+  content: z.string(),
+  llmRequestOffset: z.number(),
+});
+const ChunkPayloadSlice = z.looseObject({
+  chunk: z.unknown(),
+  llmRequestOffset: z.number(),
+  sequence: z.number(),
+});
 
 /**
- * Replays one LLM request's exact wire messages from mirrored raw events.
- * Rows that fail to parse are skipped like the processor's own fold skips
- * them (raw appends are accepted by design; a malformed event is a fact of
- * the log). Returns null when no llm-request-requested event exists at the
- * given offset — the mirror hasn't caught up, or the offset isn't a request.
+ * Replays one LLM request's exact wire messages — and its response — from
+ * mirrored raw events. `rawEventJsons` is the consumed subset
+ * (LLM_REPLAY_EVENT_TYPES); `chunkEventJsons` is this request's streamed
+ * chunks (LLM_RESPONSE_CHUNK_EVENT_TYPE), which fill in reasoning text and
+ * the partial response when no output ever committed. Rows that fail to
+ * parse are skipped like the processor's own fold skips them (raw appends
+ * are accepted by design; a malformed event is a fact of the log). Returns
+ * null when no llm-request-requested event exists at the given offset — the
+ * mirror hasn't caught up, or the offset isn't a request.
  */
 export function replayLlmRequest(input: {
   rawEventJsons: readonly string[];
+  chunkEventJsons?: readonly string[];
   llmRequestOffset: number;
 }): LlmRequestReplay | null {
-  const events: StreamEvent[] = [];
-  for (const rawJson of input.rawEventJsons) {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(rawJson);
-    } catch {
-      continue;
-    }
-    const result = StreamEvent.safeParse(parsed);
-    if (result.success) events.push(result.data);
-  }
+  const events = parseEventRows(input.rawEventJsons);
 
   const requestedEvent = events.find(
     (event) =>
@@ -102,8 +129,76 @@ export function replayLlmRequest(input: {
     })),
     model: requested.data.model,
     requestedAt: requestedEvent.createdAt,
+    response: replayResponse({
+      events,
+      chunkEvents: parseEventRows(input.chunkEventJsons ?? []),
+      llmRequestOffset: input.llmRequestOffset,
+    }),
     outcome: replayOutcome(events, input.llmRequestOffset),
   };
+}
+
+/** JSON rows → parsed StreamEvents, silently dropping malformed rows. */
+function parseEventRows(rawEventJsons: readonly string[]): StreamEvent[] {
+  const events: StreamEvent[] = [];
+  for (const rawJson of rawEventJsons) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawJson);
+    } catch {
+      continue;
+    }
+    const result = StreamEvent.safeParse(parsed);
+    if (result.success) events.push(result.data);
+  }
+  return events;
+}
+
+/**
+ * The request's response: the committed output-added text is authoritative
+ * when the turn settled with one; thinking text only ever exists in the
+ * streamed chunks. Without an output (cancelled, failed, or still in
+ * flight), the chunks' re-assembled partial text is all there is.
+ */
+function replayResponse(input: {
+  events: readonly StreamEvent[];
+  chunkEvents: readonly StreamEvent[];
+  llmRequestOffset: number;
+}): LlmRequestReplayResponse | null {
+  let outputText: string | null = null;
+  for (const event of input.events) {
+    if (event.type !== "events.iterate.com/agent/output-added") continue;
+    const parsed = OutputPayloadSlice.safeParse(event.payload);
+    if (!parsed.success || parsed.data.llmRequestOffset !== input.llmRequestOffset) continue;
+    outputText = parsed.data.content;
+    break;
+  }
+
+  const deltas = input.chunkEvents
+    .map((event) =>
+      event.type === LLM_RESPONSE_CHUNK_EVENT_TYPE
+        ? ChunkPayloadSlice.safeParse(event.payload)
+        : null,
+    )
+    .flatMap((parsed) =>
+      parsed?.success && parsed.data.llmRequestOffset === input.llmRequestOffset
+        ? [parsed.data]
+        : [],
+    )
+    .sort((a, b) => a.sequence - b.sequence);
+  let streamedText = "";
+  let thinkingText = "";
+  for (const delta of deltas) {
+    const { responseDelta, thinkingDelta } = extractCloudflareChunkDeltas(delta.chunk);
+    streamedText += responseDelta;
+    thinkingText += thinkingDelta;
+  }
+
+  if (outputText != null) return { text: outputText, thinkingText, source: "output" };
+  if (streamedText !== "" || thinkingText !== "") {
+    return { text: streamedText, thinkingText, source: "chunks" };
+  }
+  return null;
 }
 
 /** The request's settled outcome: completed beats cancelled (a late completion

--- a/apps/os/src/lib/llm-request-replay.ts
+++ b/apps/os/src/lib/llm-request-replay.ts
@@ -50,6 +50,29 @@ export type LlmRequestReplayResponse = {
   source: "output" | "chunks";
 };
 
+export type LlmRequestReplayStats = {
+  /** Normalized counts from token-usage-reported; null until the turn
+   * settled successfully (or when the vendor reported no parseable usage). */
+  tokens: {
+    inputTokens: number;
+    outputTokens: number;
+    cachedInputTokens: number | null;
+    reasoningOutputTokens: number | null;
+    maxContextTokens: number;
+  } | null;
+  /** llm-request-started (the dial) → the first streamed chunk landing. */
+  timeToFirstChunkMs: number | null;
+  /** First chunk → completion — the generation window; falls back to the
+   * last chunk for requests that never settled. */
+  generationMs: number | null;
+  chunkCount: number;
+  /** Output tokens over the generation window. */
+  outputTokensPerSecond: number | null;
+  /** The completed event's verbatim result.rawResponse — whatever the
+   * transport recorded (usage dialects, gateway cache status, …). */
+  rawResponse: unknown;
+};
+
 export type LlmRequestReplay = {
   messages: LlmRequestReplayMessage[];
   /** From the llm-request-requested event at the replayed offset. */
@@ -57,6 +80,7 @@ export type LlmRequestReplay = {
   requestedAt: string;
   /** Null when nothing has streamed or settled for this request yet. */
   response: LlmRequestReplayResponse | null;
+  stats: LlmRequestReplayStats;
   /** Null while the request is still in flight. */
   outcome: {
     status: "success" | "failure" | "cancelled";
@@ -73,9 +97,24 @@ const CompletedPayloadSlice = z.looseObject({
   durationMs: z.number(),
   llmRequestOffset: z.number(),
   result: z.union([
-    z.looseObject({ status: z.literal("success") }),
-    z.looseObject({ status: z.literal("failure"), error: z.looseObject({ message: z.string() }) }),
+    z.looseObject({ status: z.literal("success"), rawResponse: z.unknown().optional() }),
+    z.looseObject({
+      status: z.literal("failure"),
+      error: z.looseObject({ message: z.string() }),
+      rawResponse: z.unknown().optional(),
+    }),
   ]),
+});
+/** Any lifecycle payload's back-reference to its request (started, completed,
+ * chunks, usage all carry it) — the probe replayStats scopes events with. */
+const RequestScopedPayloadSlice = z.looseObject({ llmRequestOffset: z.number() });
+const TokenUsagePayloadSlice = z.looseObject({
+  llmRequestOffset: z.number(),
+  inputTokens: z.number(),
+  outputTokens: z.number(),
+  maxContextTokens: z.number(),
+  cachedInputTokens: z.number().optional(),
+  reasoningOutputTokens: z.number().optional(),
 });
 const CancelledPayloadSlice = z.looseObject({
   phase: z.literal("requested"),
@@ -108,6 +147,7 @@ export function replayLlmRequest(input: {
   llmRequestOffset: number;
 }): LlmRequestReplay | null {
   const events = parseEventRows(input.rawEventJsons);
+  const chunkEvents = parseEventRows(input.chunkEventJsons ?? []);
 
   const requestedEvent = events.find(
     (event) =>
@@ -129,11 +169,8 @@ export function replayLlmRequest(input: {
     })),
     model: requested.data.model,
     requestedAt: requestedEvent.createdAt,
-    response: replayResponse({
-      events,
-      chunkEvents: parseEventRows(input.chunkEventJsons ?? []),
-      llmRequestOffset: input.llmRequestOffset,
-    }),
+    response: replayResponse({ events, chunkEvents, llmRequestOffset: input.llmRequestOffset }),
+    stats: replayStats({ events, chunkEvents, llmRequestOffset: input.llmRequestOffset }),
     outcome: replayOutcome(events, input.llmRequestOffset),
   };
 }
@@ -199,6 +236,86 @@ function replayResponse(input: {
     return { text: streamedText, thinkingText, source: "chunks" };
   }
   return null;
+}
+
+/**
+ * Everything else the journal knows about this request: normalized token
+ * counts (token-usage-reported), latency derived from the lifecycle events'
+ * own timestamps (started = the dial, chunks = streaming, completed = done),
+ * and the completed event's verbatim rawResponse. All server-stamped append
+ * times, so the numbers are the stream's truth rather than a client clock.
+ */
+function replayStats(input: {
+  events: readonly StreamEvent[];
+  chunkEvents: readonly StreamEvent[];
+  llmRequestOffset: number;
+}): LlmRequestReplayStats {
+  const forThisRequest = (event: StreamEvent, type: string) => {
+    if (event.type !== type) return false;
+    const parsed = RequestScopedPayloadSlice.safeParse(event.payload);
+    return parsed.success && parsed.data.llmRequestOffset === input.llmRequestOffset;
+  };
+  const startedAt = timestampOf(
+    input.events.find((event) =>
+      forThisRequest(event, "events.iterate.com/agent/llm-request-started"),
+    ),
+  );
+  const completedEvent = input.events.find((event) =>
+    forThisRequest(event, "events.iterate.com/agent/llm-request-completed"),
+  );
+  const completedAt = timestampOf(completedEvent);
+  const completed =
+    completedEvent === undefined
+      ? undefined
+      : CompletedPayloadSlice.safeParse(completedEvent.payload);
+
+  const chunks = input.chunkEvents.filter((event) =>
+    forThisRequest(event, LLM_RESPONSE_CHUNK_EVENT_TYPE),
+  );
+  const firstChunkAt = timestampOf(chunks[0]);
+  const lastChunkAt = timestampOf(chunks.at(-1));
+
+  let tokens: LlmRequestReplayStats["tokens"] = null;
+  for (const event of input.events) {
+    if (event.type !== "events.iterate.com/agent/token-usage-reported") continue;
+    const parsed = TokenUsagePayloadSlice.safeParse(event.payload);
+    if (!parsed.success || parsed.data.llmRequestOffset !== input.llmRequestOffset) continue;
+    tokens = {
+      inputTokens: parsed.data.inputTokens,
+      outputTokens: parsed.data.outputTokens,
+      cachedInputTokens: parsed.data.cachedInputTokens ?? null,
+      reasoningOutputTokens: parsed.data.reasoningOutputTokens ?? null,
+      maxContextTokens: parsed.data.maxContextTokens,
+    };
+    break;
+  }
+
+  const timeToFirstChunkMs =
+    startedAt != null && firstChunkAt != null ? Math.max(0, firstChunkAt - startedAt) : null;
+  const generationEndAt = completedAt ?? lastChunkAt;
+  const generationMs =
+    firstChunkAt != null && generationEndAt != null
+      ? Math.max(0, generationEndAt - firstChunkAt)
+      : null;
+  const outputTokensPerSecond =
+    tokens != null && generationMs != null && generationMs > 0
+      ? Math.round((tokens.outputTokens / (generationMs / 1000)) * 10) / 10
+      : null;
+
+  return {
+    tokens,
+    timeToFirstChunkMs,
+    generationMs,
+    chunkCount: chunks.length,
+    outputTokensPerSecond,
+    rawResponse: completed?.success ? (completed.data.result.rawResponse ?? null) : null,
+  };
+}
+
+function timestampOf(event: StreamEvent | undefined): number | null {
+  if (event === undefined) return null;
+  const parsed = Date.parse(event.createdAt);
+  return Number.isNaN(parsed) ? null : parsed;
 }
 
 /** The request's settled outcome: completed beats cancelled (a late completion

--- a/packages/ui/src/components/events/agent-ui-reducer.ts
+++ b/packages/ui/src/components/events/agent-ui-reducer.ts
@@ -803,7 +803,14 @@ function updateLlmStep(
   return { ...state, live: { ...state.live, steps } };
 }
 
-function extractCloudflareChunkDeltas(chunk: unknown): {
+/**
+ * The response/thinking text deltas inside one streamed LLM chunk, across the
+ * vendor dialects we receive (Workers AI, OpenAI chat completions, Anthropic).
+ * Exported as the ONE place that knows chunk shapes: the live feed folds these
+ * into the streaming tail, and the LLM trace panel re-assembles a request's
+ * partial response from the same chunks.
+ */
+export function extractCloudflareChunkDeltas(chunk: unknown): {
   responseDelta: string;
   thinkingDelta: string;
 } {


### PR DESCRIPTION
Follow-up to #1863. The LLM request inspector becomes a full **trace** of one model call — request AND response — and its trigger stops hiding behind an icon.

## Response, from the same journal

The response side needs no new storage either, it's already in the event stream:

- **Settled turns**: the committed `output-added` text is authoritative.
- **Cancelled / failed / in-flight requests**: the response is re-assembled from that request's `llm-response-chunk` events (fetched per-offset — the bulk chunk traffic never rides the panel's main query). This is the only copy of a partial response, and it also makes an in-flight request's trace grow live as chunks land.
- **Reasoning ("thinking") text** only ever exists in the chunks, so it surfaces for both settled and partial traces where the model reported any.
- `extractCloudflareChunkDeltas` moves from private to exported in the agent-ui reducer, so the live feed and the trace panel share the ONE place that knows vendor chunk shapes (Workers AI / OpenAI chat completions / Anthropic).

Codemode responses render as syntax-highlighted code (the feed's `looksLikeCode` treatment, now canonical in `~/lib/feed-format.ts`); failures show their error inline in the response section; the header reads "LLM trace #N".

## The button

The icon-only trigger becomes an explicit **"View trace"** button on every LLM step (settled activities and the live rail).

![View trace button on an LLM step](https://raw.githubusercontent.com/iterate/iterate/b3f14f7442e46a70eeffbf297ffce4d358e74c24/llm-trace-view-button.png)

![Trace panel with the response section](https://raw.githubusercontent.com/iterate/iterate/b3f14f7442e46a70eeffbf297ffce4d358e74c24/llm-trace-response.png)

## Verified

- 3 new unit tests: output-authoritative response with chunk-sourced thinking, partial re-assembly honouring `sequence` order and per-request isolation, and the no-response case. All 1013 apps/os tests pass; typecheck/lint/knip clean.
- Live against local dev: trace #116 shows the full request plus its codemode response as a highlighted script; "View trace" renders on settled steps and opens the panel.


## Metrics (added after review)

Everything else the journal records about a call now renders under the response: normalized token counts from `token-usage-reported` (cached/reasoning breakdowns, context-window fullness), latency derived from the lifecycle events' own server-stamped append times (dial → first chunk, generation window, chunk count, output tokens/second), and the completed event's verbatim `result.rawResponse` behind a disclosure (vendor usage dialects, gateway cache status).

![Trace metrics with raw completion payload](https://raw.githubusercontent.com/iterate/iterate/b3f14f7442e46a70eeffbf297ffce4d358e74c24/llm-trace-metrics.png)

Both Bugbot findings addressed in the same push: the replay waits for BOTH mirror queries (chunks-still-pending ≠ "no chunks", so chunk-only traces no longer flash "the model returned no text"), and the header subtitle no longer collides with the outcome badge.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only replay and display over existing local event mirror data; no auth, persistence, or agent execution path changes.
> 
> **Overview**
> Turns the LLM request inspector into a full **LLM trace**: same locally replayed request context, plus the model’s response and call metrics, opened from a labeled **View trace** control on LLM steps (settled and in-flight).
> 
> **Replay** (`llm-request-replay.ts`) now accepts per-request `llm-response-chunk` rows from a second SQLite query. Response text prefers committed `output-added`; otherwise chunks are reassembled in `sequence` order (live/partial/cancelled). Reasoning comes from chunks via shared **`extractCloudflareChunkDeltas`** (exported from `agent-ui-reducer`). **Stats** add token usage, TTFC/generation latency, tok/s, gateway cache HIT, and optional raw completion JSON.
> 
> The **panel** adds response and metrics sections, renames to “LLM trace”, waits for **both** mirror queries before rendering (avoids a false empty response), and surfaces mirror read errors. **`looksLikeCode`** moves to `feed-format.ts` for feed + trace code rendering.
> 
> **Tests** cover output vs chunks, partial reassembly isolation, lifecycle-derived metrics, and empty cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0be9c683062954eb02f0a4b9993afb42f18e83e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +251 -18 | +184 -13 🟩🟩🟩🟩🟩 |
| UI components | +254 -28 | +202 -13 🟩🟩🟩🟩🟩 |
| Tests | +159 -0 | +145 -0 🟩🟩🟩⬜⬜ |
| **Total** | **+664 -46** | **+531 -26** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 46e8d47 and 0be9c68, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-11T10:21:32.032Z",
      "headSha": "0be9c683062954eb02f0a4b9993afb42f18e83e1",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/196252171766925",
      "shortSha": "0be9c68",
      "cleanupDurationMs": 10054,
      "deployDurationMs": 63518,
      "testDurationMs": 125516,
      "testRetries": "6 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · concurrent long-running ITX scripts all complete (vitest x1) · creates a project and uses project streams through v4 ITX (vitest x1) · stream subscribe replays history, tails live appends, and unsubscribes (vitest x1) · state-only stream subscribe pushes initial state immediately, then state after appends (vitest x1) · toggle an svg file between Code and its sandboxed Preview (specs x1)",
      "workerSizeKib": 15883.22,
      "workerGzipKib": 4279.29,
      "mainWorkerGzipKib": 4286.29
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-11T10:21:22.854Z",
      "headSha": "75eeea18ead64b022de85103a9746a004e3a43c4",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/261933595527380",
      "shortSha": "75eeea1",
      "cleanupDurationMs": 873,
      "deployDurationMs": 14631,
      "testDurationMs": 4530,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-11T10:21:25.013Z",
      "headSha": "0be9c683062954eb02f0a4b9993afb42f18e83e1",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/196252171766925",
      "shortSha": "0be9c68",
      "cleanupDurationMs": 3030,
      "deployDurationMs": 17886,
      "testDurationMs": 462,
      "testRetries": null,
      "workerSizeKib": 4031.76,
      "workerGzipKib": 819.32,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-11T10:21:22.619Z",
      "headSha": "75eeea18ead64b022de85103a9746a004e3a43c4",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/261933595527380",
      "shortSha": "75eeea1",
      "cleanupDurationMs": 633,
      "deployDurationMs": 16710,
      "testDurationMs": 16812,
      "testRetries": null,
      "workerSizeKib": 4784.19,
      "workerGzipKib": 1365.93,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `0be9c68` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 819.3 KiB | 17.9s | 462ms |  | 3.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/196252171766925) | 2026-07-11T10:21:25.013Z | Preview app released. |
| OS | released | `0be9c68` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 4.18 MiB (-7.0 KiB vs main) | 63.5s | 125.5s | 6 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · concurrent long-running ITX scripts all complete (vitest x1) · creates a project and uses project streams through v4 ITX (vitest x1) · stream subscribe replays history, tails live appends, and unsubscribes (vitest x1) · state-only stream subscribe pushes initial state immediately, then state after appends (vitest x1) · toggle an svg file between Code and its sandboxed Preview (specs x1) | 10.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/196252171766925) | 2026-07-11T10:21:32.032Z | Preview app released. |
| Semaphore | released | `75eeea1` | [https://semaphore.iterate-preview-5.com](https://semaphore.iterate-preview-5.com) | 440.8 KiB | 14.6s | 4.5s |  | 873ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/261933595527380) | 2026-07-11T10:21:22.854Z | Preview app released. |
| Streams Example App | released | `75eeea1` | [https://streams.iterate-preview-5.com](https://streams.iterate-preview-5.com) | 1.33 MiB | 16.7s | 16.8s |  | 633ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/261933595527380) | 2026-07-11T10:21:22.619Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->
