### PR TITLE
Streams massive-throughput investigation: bench harness + findings

### DIFF
--- a/apps/os/src/domains/streams/client-libraries/browser/stream-browser-store.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/stream-browser-store.ts
@@ -691,11 +691,25 @@ function createStreamRuntime(
         // requested, so the server can never outrun the mirror here — and a
         // page failure just reconnects and resumes from the checkpoint.
         let catchUpOffset = checkpoint.offset;
-        if (serverMaxOffset - catchUpOffset > CATCHUP_THRESHOLD_EVENTS) {
+        let serverHead = serverMaxOffset;
+        if (serverHead - catchUpOffset > CATCHUP_THRESHOLD_EVENTS) {
           console.info(
-            `[stream ${args.streamPath} ${slug}] mirror is ${serverMaxOffset - catchUpOffset} events behind; pull-paging before subscribing`,
+            `[stream ${args.streamPath} ${slug}] mirror is ${serverHead - catchUpOffset} events behind; pull-paging before subscribing`,
           );
-          while (serverMaxOffset - catchUpOffset > CATCHUP_THRESHOLD_EVENTS) {
+          for (;;) {
+            if (serverHead - catchUpOffset <= CATCHUP_THRESHOLD_EVENTS) {
+              // The head we were chasing was captured before these pages
+              // applied. A stream that kept appending meanwhile could be far
+              // ahead of it — re-read the live head before trusting the exit,
+              // or the subscription would dump the accumulated gap after all.
+              const { coreProcessorState: rawHeadState } = await withDeadline(
+                "catch-up head re-read",
+                election.connection.runtimeState(),
+              );
+              if (!ownsRuntime()) return undefined;
+              serverHead = parseBrowserCoreProcessorState(rawHeadState).maxOffset;
+              if (serverHead - catchUpOffset <= CATCHUP_THRESHOLD_EVENTS) break;
+            }
             const page = (await withDeadline(
               "catch-up page read",
               election.connection.getEvents({
@@ -708,7 +722,7 @@ function createStreamRuntime(
             deliveryArrivals += 1;
             lastBatchEvents = page.length;
             totalDeliveredEvents += page.length;
-            await processor.ingest({ events: page, streamMaxOffset: serverMaxOffset });
+            await processor.ingest({ events: page, streamMaxOffset: serverHead });
             if (!ownsRuntime()) return undefined;
             catchUpOffset = page.at(-1)!.offset;
             lastDeliveredOffset = catchUpOffset;

--- a/apps/os/src/domains/streams/client-libraries/browser/stream-browser-store.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/stream-browser-store.ts
@@ -28,6 +28,32 @@ import {
 
 const LIVE_PROGRESS_NOTIFICATION_MS = 16;
 const DEFAULT_STREAM_PROJECT_ID = "default";
+
+// --- Catch-up + flow-control tuning ----------------------------------------------------
+// The server's live subscription pump is deliberately one-directional: it never waits for
+// the client (see stream-subscribers.ts #open). That is perfect for the live tail and
+// fatal for a cold mirror thousands of events behind — the whole backlog gets blasted at
+// the socket faster than SQLite can apply it (measured: ~20k events/s delivered vs
+// ~1-4k events/s applied; a 1M-event replay ballooned a browser tab to >1.3GB of queued
+// batches and redelivered 3.26× through reconnect churn). So the leader PULLS history
+// with paged `getEvents` reads — client-paced, so backpressure is structural — and only
+// subscribes for the tail once it is within CATCHUP_THRESHOLD_EVENTS of the head.
+
+/** How far behind the server head a checkpoint may be before we page instead of subscribe. */
+const CATCHUP_THRESHOLD_EVENTS = 1_000;
+/** `getEvents` page size (its server-side maximum). */
+const CATCHUP_PAGE_LIMIT = 500;
+/**
+ * Live-tail safety valve: if the un-applied delivery backlog exceeds this many events, the
+ * subscription has outrun SQLite. Cut the connection (dropping the queued batches — the
+ * superseded-election guard already discards them) and reconnect; the fresh election
+ * pull-pages back to the head at the mirror's own pace. One control action when
+ * overwhelmed, zero protocol chatter in steady state — delivery frames stay one-way.
+ */
+const MAX_PENDING_INGEST_EVENTS = 20_000;
+
+/** Retries for `appendBatch` across reconnects/stream-DO restarts (~30s of backoff). */
+const APPEND_MAX_RETRIES = 8;
 export type StreamBrowserConnectionStatus = "connecting" | "connected" | "closed" | "error";
 
 /**
@@ -254,6 +280,10 @@ function createStreamRuntime(
   let readyWaiters: Array<{ resolve: () => void; reject: (error: Error) => void }> = [];
   // Self-heal backoff for browser-side ingest failures (C1).
   let ingestFailureCount = 0;
+  // Events delivered by the live subscription but not yet applied to SQLite — the
+  // in-memory backlog the MAX_PENDING_INGEST_EVENTS valve bounds. Reset whenever the
+  // connection is replaced (the superseded-election guard discards the queue with it).
+  let pendingIngestEvents = 0;
   // The server incarnation this connection reconciled against, how far deliveries have
   // progressed, and a counter bumped every time a delivery ARRIVES (before the possibly-slow
   // ingest). The liveness probe compares these against fresh runtimeState() so an
@@ -389,6 +419,7 @@ function createStreamRuntime(
   function scheduleReconnect(connectionError: string, delayMs: number) {
     if (disposed) return;
     connectionEpoch += 1;
+    pendingIngestEvents = 0;
     stopLivenessProbe();
     stopSubscriptionElection();
     stream?.[Symbol.dispose]();
@@ -447,7 +478,9 @@ function createStreamRuntime(
   // core state's per-DO-restart `incarnationId`. If our recorded incarnation differs from
   // the server's, the offset comparison is meaningless — rebuild the mirror. Otherwise fall
   // back to the offset check: discard when the server has fewer committed events than we do.
-  async function reconcileLocalMirrorWithServer(rpc: BrowserStreamClient) {
+  async function reconcileLocalMirrorWithServer(
+    rpc: BrowserStreamClient,
+  ): Promise<{ serverMaxOffset: number }> {
     // Deliberately a throwaway instance: processors memoize their checkpoint on
     // first read, so the real instance must be created after any discard below.
     const processor = args.createProcessor({
@@ -461,6 +494,7 @@ function createStreamRuntime(
     const localMaxOffset = checkpoint.offset;
     const { coreProcessorState: rawCoreProcessorState } = await rpc.runtimeState();
     const coreProcessorState = parseBrowserCoreProcessorState(rawCoreProcessorState);
+    const reconciled = { serverMaxOffset: coreProcessorState.maxOffset };
     const serverIncarnation = coreProcessorState.createdAt;
     reconciledIncarnation = serverIncarnation;
     const localIncarnation = await streamDatabase.readMirrorIncarnation(slug);
@@ -486,7 +520,7 @@ function createStreamRuntime(
       await discardLocalMirror();
       await streamDatabase.writeMirrorSchemaVersion(slug, schemaVersion);
       await recordServerIncarnation(serverIncarnation);
-      return;
+      return reconciled;
     }
 
     if (localMaxOffset <= 0) {
@@ -496,7 +530,7 @@ function createStreamRuntime(
         await streamDatabase.writeMirrorSchemaVersion(slug, schemaVersion);
       }
       await recordServerIncarnation(serverIncarnation);
-      return;
+      return reconciled;
     }
 
     if (localIncarnation !== serverIncarnation) {
@@ -510,7 +544,7 @@ function createStreamRuntime(
       );
       await discardLocalMirror();
       await recordServerIncarnation(serverIncarnation);
-      return;
+      return reconciled;
     }
 
     if (coreProcessorState.maxOffset < localMaxOffset) {
@@ -525,6 +559,7 @@ function createStreamRuntime(
       await streamDatabase.writeMirrorSchemaVersion(slug, schemaVersion);
     }
     await recordServerIncarnation(serverIncarnation);
+    return reconciled;
   }
 
   function connect() {
@@ -629,7 +664,10 @@ function createStreamRuntime(
         if (!ownsRuntime()) return undefined;
         snapshot = { ...snapshot, subscriptionStatus: "leader" };
         emitSnapshot();
-        await withDeadline("reconcile", reconcileLocalMirrorWithServer(election.connection));
+        const { serverMaxOffset } = await withDeadline(
+          "reconcile",
+          reconcileLocalMirrorWithServer(election.connection),
+        );
         // Re-check after every await: a step that settles late (after this
         // election was superseded) must not write runtime-wide fields like
         // lastDeliveredOffset over the current election's values.
@@ -646,9 +684,39 @@ function createStreamRuntime(
         // subscription, no probe, and no error.
         const checkpoint = await withDeadline("checkpoint read", processor.snapshot());
         if (!ownsRuntime()) return undefined;
-        lastDeliveredOffset = checkpoint.offset;
+
+        // Far behind the head? PULL history with paged reads before opening the
+        // one-directional subscription (see the flow-control block up top). Each
+        // page is fetched, applied, and checkpointed before the next is
+        // requested, so the server can never outrun the mirror here — and a
+        // page failure just reconnects and resumes from the checkpoint.
+        let catchUpOffset = checkpoint.offset;
+        if (serverMaxOffset - catchUpOffset > CATCHUP_THRESHOLD_EVENTS) {
+          console.info(
+            `[stream ${args.streamPath} ${slug}] mirror is ${serverMaxOffset - catchUpOffset} events behind; pull-paging before subscribing`,
+          );
+          while (serverMaxOffset - catchUpOffset > CATCHUP_THRESHOLD_EVENTS) {
+            const page = (await withDeadline(
+              "catch-up page read",
+              election.connection.getEvents({
+                afterOffset: catchUpOffset,
+                limit: CATCHUP_PAGE_LIMIT,
+              }),
+            )) as StreamEvent[];
+            if (!ownsRuntime()) return undefined;
+            if (page.length === 0) break; // server truth moved (reset?); subscribe reconciles
+            deliveryArrivals += 1;
+            lastBatchEvents = page.length;
+            totalDeliveredEvents += page.length;
+            await processor.ingest({ events: page, streamMaxOffset: serverMaxOffset });
+            if (!ownsRuntime()) return undefined;
+            catchUpOffset = page.at(-1)!.offset;
+            lastDeliveredOffset = catchUpOffset;
+          }
+        }
+        lastDeliveredOffset = catchUpOffset;
         return {
-          replayAfterOffset: checkpoint.offset,
+          replayAfterOffset: catchUpOffset,
           subscriber: {
             description: "browser",
             processor: {
@@ -724,6 +792,20 @@ function createStreamRuntime(
     // checkpoint of) the current election's processor on the same tables — and
     // it must not count as delivery progress either (see below).
     if (disposed || stream !== election.connection) return;
+    // Live-tail safety valve (see MAX_PENDING_INGEST_EVENTS): the server pump
+    // is one-directional and can outrun SQLite; queued-but-unapplied events
+    // otherwise accumulate in JS memory without bound. Cutting the connection
+    // discards the queue (every queued ingest bails on the superseded-election
+    // guard above) and the fresh election pull-pages from the checkpoint.
+    pendingIngestEvents += batch.events.length;
+    if (pendingIngestEvents > MAX_PENDING_INGEST_EVENTS) {
+      pendingIngestEvents = 0;
+      console.warn(
+        `[stream ${args.streamPath} ${slug}] delivery outran the local mirror (> ${MAX_PENDING_INGEST_EVENTS} events queued); reconnecting to catch up at the mirror's pace`,
+      );
+      scheduleReconnect("delivery outran the local mirror", 0);
+      return;
+    }
     // Count the arrival HERE, for the current election only, and BEFORE the
     // (possibly slow) ingest await: the liveness probe reads a bumped counter
     // as "deliveries are flowing", so a long ingest must not look stalled,
@@ -733,6 +815,7 @@ function createStreamRuntime(
     totalDeliveredEvents += batch.events.length;
     try {
       await processor.ingest(batch);
+      pendingIngestEvents = Math.max(0, pendingIngestEvents - batch.events.length);
       ingestFailureCount = 0;
       lastDeliveredOffset = Math.max(lastDeliveredOffset, batch.streamMaxOffset);
     } catch (error) {
@@ -937,6 +1020,7 @@ function createStreamRuntime(
     totalDeliveredEvents,
     lastBatchEvents,
     ingestFailures,
+    pendingIngestEvents,
     reconciledIncarnation,
     started,
     disposed,
@@ -981,9 +1065,33 @@ function createStreamRuntime(
   return {
     streamDatabase,
     appendBatch(appendArgs) {
-      // The itx Stream capability appends variadically; the batch
-      // arg shape is kept for consumers of the store.
-      return callWhenReady((rpc) => rpc.append(...appendArgs.events) as Promise<StreamEvent[]>);
+      // The itx Stream capability appends variadically; the batch arg shape is
+      // kept for consumers of the store.
+      //
+      // Durability: every event gets an idempotency key (unless the caller set
+      // one), which makes retrying safe — a batch that COMMITTED but lost its
+      // ack (socket died, DO evicted/killed/overloaded mid-response) returns
+      // the same committed events on retry instead of appending duplicates.
+      // Combined with callWhenReady's reconnect-wait, an appendBatch caller
+      // survives a stream DO eviction mid-blast with zero loss and zero dupes.
+      const events = appendArgs.events.map((event) =>
+        event.idempotencyKey === undefined
+          ? { ...event, idempotencyKey: crypto.randomUUID() }
+          : event,
+      );
+      const promise = (async () => {
+        for (let attempt = 0; ; attempt++) {
+          try {
+            return await callWhenReady((rpc) => rpc.append(...events) as Promise<StreamEvent[]>);
+          } catch (error) {
+            if (disposed || attempt >= APPEND_MAX_RETRIES) throw error;
+            await new Promise((resolve) =>
+              setTimeout(resolve, Math.min(5_000, 250 * 2 ** attempt)),
+            );
+          }
+        }
+      })();
+      return Object.assign(promise, { [Symbol.dispose]() {} });
     },
     runtimeState() {
       return callWhenReady((rpc) => rpc.runtimeState() as Promise<StreamRuntimeState>);

--- a/apps/os/src/domains/streams/stream-subscribers.test.ts
+++ b/apps/os/src/domains/streams/stream-subscribers.test.ts
@@ -553,7 +553,7 @@ describe("StreamSubscribers", () => {
 
     h.subscribers.wake();
     await h.settle();
-    for (let round = 0; round < 20 && h.row("k")?.ackedOffset !== 4; round += 1) {
+    for (let round = 0; round < 40 && h.row("k")?.ackedOffset !== 4; round += 1) {
       const next = h.store.minNextAttemptAt();
       if (next === null) break;
       h.advanceTo(Math.max(h.now(), next) + 1);
@@ -562,21 +562,28 @@ describe("StreamSubscribers", () => {
     }
 
     // The full deterministic delivery transcript: batch limits halve toward 1
-    // (100, 50, 25, 12, 6, 3, 1) until offset 2 is isolated, the lone event
-    // must fail SKIP_CONFIRM_ATTEMPTS deliveries, then delivery steps over it.
+    // (1000, 500, 250, 125, 62, 31, 15, 7, 3, 1) until offset 2 is isolated,
+    // the lone event must fail SKIP_CONFIRM_ATTEMPTS deliveries, then delivery
+    // steps over it.
     expect(h.pushes.map((batch) => batch.events.map((event) => event.offset))).toEqual([
-      [1, 2, 3, 4], // limit 100
-      [1, 2, 3, 4], // limit 50
-      [1, 2, 3, 4], // limit 25
-      [1, 2, 3, 4], // limit 12
-      [1, 2, 3, 4], // limit 6
+      [1, 2, 3, 4], // limit 1000
+      [1, 2, 3, 4], // limit 500
+      [1, 2, 3, 4], // limit 250
+      [1, 2, 3, 4], // limit 125
+      [1, 2, 3, 4], // limit 62
+      [1, 2, 3, 4], // limit 31
+      [1, 2, 3, 4], // limit 15
+      [1, 2, 3, 4], // limit 7
       [1, 2, 3], // limit 3
       [1], // limit 1 — clean, delivered; bisect window resets
-      [2, 3, 4], // limit 100 again
-      [2, 3, 4], // limit 50
-      [2, 3, 4], // limit 25
-      [2, 3, 4], // limit 12
-      [2, 3, 4], // limit 6
+      [2, 3, 4], // limit 1000 again
+      [2, 3, 4], // limit 500
+      [2, 3, 4], // limit 250
+      [2, 3, 4], // limit 125
+      [2, 3, 4], // limit 62
+      [2, 3, 4], // limit 31
+      [2, 3, 4], // limit 15
+      [2, 3, 4], // limit 7
       [2, 3, 4], // limit 3
       [2], // isolated: confirm attempt 1 -> backoff
       [2], // confirm attempt 2 (alarm) -> backoff

--- a/apps/os/src/domains/streams/stream-subscribers.ts
+++ b/apps/os/src/domains/streams/stream-subscribers.ts
@@ -862,10 +862,10 @@ export class StreamSubscribers {
         while (open) {
           let events: StreamEvent[] = [];
           if (deliverEvents) {
-            // Same byte-capped read as the push drain: 100 near-2MB events in
-            // one live batch would blow the RPC frame limit and turn into a
-            // delivery failure the subscriber can never get past.
-            const readEvents = this.#readBatch(cursor, 100);
+            // Same byte-capped read as the push drain: a batch of near-2MB
+            // events in one live frame would blow the RPC frame limit and turn
+            // into a delivery failure the subscriber can never get past.
+            const readEvents = this.#readBatch(cursor, DELIVERY_BATCH_LIMIT);
             const lastOffset = readEvents.at(-1)?.offset;
             if (lastOffset === undefined) {
               // Caught up; the next append wakes us again. The first drain

--- a/apps/os/src/domains/streams/subscriber-math.test.ts
+++ b/apps/os/src/domains/streams/subscriber-math.test.ts
@@ -21,7 +21,7 @@ describe("tuning constants", () => {
     expect(MAX_DELIVERY_ATTEMPTS).toBe(15);
     expect(SKIP_CONFIRM_ATTEMPTS).toBe(3);
     expect(MAX_CONSECUTIVE_SKIPS).toBe(3);
-    expect(DELIVERY_BATCH_LIMIT).toBe(100);
+    expect(DELIVERY_BATCH_LIMIT).toBe(1000);
     expect(DELIVERY_BATCH_BYTE_LIMIT).toBe(1024 * 1024);
   });
 });
@@ -103,10 +103,10 @@ describe("halveBatchLimit", () => {
   it("walks the full bisect ladder from DELIVERY_BATCH_LIMIT down to 1 and stays there", () => {
     const steps: number[] = [];
     let limit = DELIVERY_BATCH_LIMIT;
-    while (steps.length < 10) {
+    while (steps.length < 13) {
       limit = halveBatchLimit(limit);
       steps.push(limit);
     }
-    expect(steps).toEqual([50, 25, 12, 6, 3, 1, 1, 1, 1, 1]);
+    expect(steps).toEqual([500, 250, 125, 62, 31, 15, 7, 3, 1, 1, 1, 1, 1]);
   });
 });

--- a/apps/os/src/domains/streams/subscriber-math.ts
+++ b/apps/os/src/domains/streams/subscriber-math.ts
@@ -29,8 +29,14 @@ export const SKIP_CONFIRM_ATTEMPTS = 3;
  */
 export const MAX_CONSECUTIVE_SKIPS = 3;
 
-/** Events per delivery batch (also the bisect ceiling). */
-export const DELIVERY_BATCH_LIMIT = 100;
+/**
+ * Events per delivery batch (also the bisect ceiling). The byte cap below is
+ * the real frame guard; this count cap exists so the poison bisect has a
+ * finite ladder and a single drain iteration stays a bounded read. 1000 small
+ * events ≈ 300KB — measured ~10× fewer pump pushes and ~4× faster browser
+ * SQLite ingest than the previous 100 on catch-up-heavy workloads.
+ */
+export const DELIVERY_BATCH_LIMIT = 1000;
 
 /** Soft cap on a delivery frame's payload bytes (large events shrink the batch). */
 export const DELIVERY_BATCH_BYTE_LIMIT = 1024 * 1024;

--- a/apps/streams-example-app/e2e/playwright/stream-browser.spec.ts
+++ b/apps/streams-example-app/e2e/playwright/stream-browser.spec.ts
@@ -879,6 +879,140 @@ test("kill reconnects and appends a new woken event", async ({ page }) => {
   await expect(eventMeta(page, "events.iterate.com/stream/woken")).toHaveCount(2);
 });
 
+// The stream DO can die at any moment (eviction, deploy, explicit kill) and browser-side
+// appends must survive it with zero loss AND zero duplication: appendBatch stamps an
+// idempotency key on every event and retries across the reconnect, so a batch that
+// committed-but-lost-its-ack dedupes instead of double-appending, and one that never
+// committed lands after the DO reboots.
+test("killing the stream DO mid-blast loses no appends and duplicates none", async ({ page }) => {
+  const streamPath = `/e2e/${crypto.randomUUID()}`;
+  await page.goto(streamRoute({ path: streamPath }));
+  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
+
+  const insertedCount = 3000;
+  await page.getByLabel("Count").fill(String(insertedCount));
+  await page.getByLabel("Batch size").fill("50");
+  await page.getByLabel("Seconds").fill("3");
+  await page.getByRole("button", { name: "Stream random events" }).click();
+  await expect(page.getByTestId("insert-state")).toHaveText("inserting");
+
+  // Kill the DO while the blast is in flight (twice, for good measure).
+  await page.waitForTimeout(500);
+  await page.getByRole("button", { name: "Kill" }).click();
+  await page.waitForTimeout(1_000);
+  await page.getByRole("button", { name: "Kill" }).click();
+
+  // The blast must still complete cleanly — retried batches, not errors.
+  await expect(page.getByTestId("insert-state")).toHaveText("done", { timeout: 60_000 });
+
+  // Exactly `insertedCount` generated events: none lost, none duplicated.
+  // Control events (created/woken/subscriber-*) vary with the kills, so count
+  // only the generated types via the filter dropdown.
+  await expect
+    .poll(
+      () =>
+        page.getByLabel("Event type filter").evaluate((element) => {
+          if (!(element instanceof HTMLSelectElement)) throw new Error("not a select");
+          return [...element.options]
+            .filter((option) => option.value.startsWith("events.iterate.com/random/"))
+            .reduce((sum, option) => sum + Number(/\((\d+)\)$/.exec(option.text)?.[1] ?? 0), 0);
+        }),
+      { timeout: 60_000 },
+    )
+    .toBe(insertedCount);
+});
+
+// Same guarantee from a FOLLOWER tab: appends ride the follower's own connection (no
+// leadership required), survive a mid-blast DO kill, and both tabs' mirrors converge on
+// the exact same count.
+test("two tabs: follower blast survives a DO kill and both mirrors converge", async ({
+  context,
+  page,
+}) => {
+  const streamPath = `/e2e/${crypto.randomUUID()}`;
+  const otherPage = await context.newPage();
+  await Promise.all([
+    page.goto(streamRoute({ path: streamPath })),
+    otherPage.goto(streamRoute({ path: streamPath })),
+  ]);
+  await Promise.all([
+    expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible(),
+    expect(eventMeta(otherPage, "events.iterate.com/stream/created").first()).toBeVisible(),
+  ]);
+
+  const leader = (await isLeader(page)) ? page : otherPage;
+  const follower = leader === page ? otherPage : page;
+  await expect(follower.getByTestId("subscription-status")).toContainText(/follower|leader/);
+
+  const insertedCount = 2000;
+  await follower.getByLabel("Count").fill(String(insertedCount));
+  await follower.getByLabel("Batch size").fill("50");
+  await follower.getByLabel("Seconds").fill("3");
+  await follower.getByRole("button", { name: "Stream random events" }).click();
+  await expect(follower.getByTestId("insert-state")).toHaveText("inserting");
+
+  await leader.waitForTimeout(500);
+  await leader.getByRole("button", { name: "Kill" }).click();
+
+  await expect(follower.getByTestId("insert-state")).toHaveText("done", { timeout: 60_000 });
+
+  const generatedCount = (scope: Page) =>
+    scope.getByLabel("Event type filter").evaluate((element) => {
+      if (!(element instanceof HTMLSelectElement)) throw new Error("not a select");
+      return [...element.options]
+        .filter((option) => option.value.startsWith("events.iterate.com/random/"))
+        .reduce((sum, option) => sum + Number(/\((\d+)\)$/.exec(option.text)?.[1] ?? 0), 0);
+    });
+  await expect.poll(() => generatedCount(leader), { timeout: 60_000 }).toBe(insertedCount);
+  await expect.poll(() => generatedCount(follower), { timeout: 60_000 }).toBe(insertedCount);
+});
+
+// A cold mirror far behind the head must PULL history (paged getEvents, client-paced)
+// instead of letting the one-directional subscription blast the whole backlog at it —
+// that's the flow-control fix for the 1M-replay memory blowup. This pins the behavior:
+// a fresh browser context opening a stream thousands of events deep catches up exactly
+// (no loss, no duplication) and ends live-subscribed.
+test("cold open of a deep stream pull-pages history and converges exactly", async ({ browser }) => {
+  const seedContext = await browser.newContext();
+  const seedPage = await seedContext.newPage();
+  const streamPath = `/e2e/${crypto.randomUUID()}`;
+  await seedPage.goto(streamRoute({ path: streamPath }));
+  await expect(eventMeta(seedPage, "events.iterate.com/stream/created").first()).toBeVisible();
+
+  const insertedCount = 5000;
+  await seedPage.getByLabel("Count").fill(String(insertedCount));
+  await seedPage.getByLabel("Batch size").fill("500");
+  await seedPage.getByLabel("Seconds").fill("0");
+  await seedPage.getByRole("button", { name: "Stream random events" }).click();
+  await expect(seedPage.getByTestId("insert-state")).toHaveText("done", { timeout: 60_000 });
+  await seedContext.close();
+
+  // Fresh context = fresh OPFS origin = checkpoint 0, thousands behind the head.
+  const coldContext = await browser.newContext();
+  const coldPage = await coldContext.newPage();
+  const consoleLines: string[] = [];
+  coldPage.on("console", (message) => consoleLines.push(message.text()));
+  await coldPage.goto(streamRoute({ path: streamPath }));
+  await expect(coldPage.getByTestId("stream-status")).toHaveText("subscribed", {
+    timeout: 60_000,
+  });
+  await expect
+    .poll(
+      () =>
+        coldPage.getByLabel("Event type filter").evaluate((element) => {
+          if (!(element instanceof HTMLSelectElement)) throw new Error("not a select");
+          return [...element.options]
+            .filter((option) => option.value.startsWith("events.iterate.com/random/"))
+            .reduce((sum, option) => sum + Number(/\((\d+)\)$/.exec(option.text)?.[1] ?? 0), 0);
+        }),
+      { timeout: 120_000 },
+    )
+    .toBe(insertedCount);
+  // The catch-up must have gone through the pull lane, not the subscription blast.
+  expect(consoleLines.some((line) => line.includes("pull-paging before subscribing"))).toBe(true);
+  await coldContext.close();
+});
+
 // Catches stale local OPFS mirrors after server reset. This is the deployed-worker race that
 // led to old local rows surviving; the browser now discards impossible local state and shows
 // the fresh server stream.

--- a/apps/streams-example-app/scripts/bench/README.md
+++ b/apps/streams-example-app/scripts/bench/README.md
@@ -1,0 +1,70 @@
+# Stream throughput / latency bench
+
+Node-side harnesses for measuring the streams backend and the browser mirror
+under load. All of them speak the playground's capnweb WebSocket
+(`/api/streams`), so they exercise the same lane the browser client uses.
+
+## Auth
+
+Local dev needs nothing. Deployed environments need an admin bearer:
+
+```bash
+export STREAMS_PLAYGROUND_TOKEN=$(doppler run --project streams-example-app --config <env> -- \
+  env WORKER_URL=https://<streams host> pnpm exec tsx e2e/auth.ts | tail -1)
+```
+
+Tokens expire after 1h — a sudden `WebSocket connection failed.` on connect
+usually means re-mint, not outage.
+
+## Scripts
+
+```bash
+# single-append RTT distribution (commit + network floor)
+pnpm exec tsx scripts/bench/bench-stream.mts rtt wss://<host>/api/streams /bench-rtt 100
+
+# batched append throughput + correctness (acked vs server offset delta)
+pnpm exec tsx scripts/bench/bench-stream.mts burst wss://<host>/api/streams /bench-b100 100000 100 64 20
+
+# getEvents paging throughput
+pnpm exec tsx scripts/bench/bench-stream.mts read wss://<host>/api/streams /bench-b100 0 100000 500
+
+# paced sustained load with a 1s server-head timeline (for subscriber-lag analysis)
+pnpm exec tsx scripts/bench/sustained-load.mts wss://<host>/api/streams /lat-test 5000 200 30
+
+# end-to-end latency pings (pair with the browser sampler below)
+pnpm exec tsx scripts/bench/ping-latency.mts wss://<host>/api/streams /lat-test 20 800
+```
+
+## Browser-side sampler
+
+For append→mirror latency and replay-progress curves, run this in the stream
+page's console (or via browser automation) and correlate timestamps with the
+ping/sustained-load output — both sides use the machine's wall clock:
+
+```js
+window.__latSamples = [];
+window.__lastOff = -1;
+window.__latPoll = setInterval(() => {
+  const d = globalThis.__streamRuntimeDebug?.();
+  const v = d && Object.values(d)[0];
+  if (!v) return;
+  if (window.__lastOff !== v.lastDeliveredOffset) {
+    window.__lastOff = v.lastDeliveredOffset;
+    window.__latSamples.push({ offset: v.lastDeliveredOffset, t: Date.now() });
+  }
+}, 5);
+```
+
+`__streamRuntimeDebug()` also exposes `deliveryArrivals` / `totalDeliveredEvents`,
+which is how you spot redundant redelivery after connection churn.
+
+## Known sharp edges these scripts measure (see PR notes)
+
+- Unpaced floods of >~1000 in-flight append calls make the Durable Object shed
+  load: in-flight calls fail `Network connection lost.`, a few commit without
+  acks (retry without idempotency keys ⇒ duplicates).
+- The delivery lane dies after ~1000 pushed batches per WebSocket connection
+  (worker invocation subrequest budget), so big replays reconnect-thrash and
+  redeliver.
+- Browser OPFS ingest is far slower than the server's delivery rate and there
+  is no backpressure; monster replays balloon memory.

--- a/apps/streams-example-app/scripts/bench/bench-stream.mts
+++ b/apps/streams-example-app/scripts/bench/bench-stream.mts
@@ -51,13 +51,11 @@ function makePayload(bytes: number, index: number) {
   return { index, sentAt: Date.now(), pad: "x".repeat(Math.max(0, bytes)) };
 }
 
-type CoreState = { coreProcessorState: { maxOffset: number } };
-
 const connection = withStreamConnectionFromNode({ url });
 const stream = connection.stream;
 
 async function maxOffset(): Promise<number> {
-  const state = (await stream.runtimeState()) as CoreState;
+  const state = (await stream.runtimeState()) as { coreProcessorState: { maxOffset: number } };
   return state.coreProcessorState.maxOffset;
 }
 

--- a/apps/streams-example-app/scripts/bench/bench-stream.mts
+++ b/apps/streams-example-app/scripts/bench/bench-stream.mts
@@ -1,0 +1,166 @@
+// Stream backend benchmark harness (node → capnweb WebSocket → worker → Stream DO).
+//
+// Subcommands:
+//   state <wsBase> <path>                        print the stream's maxOffset
+//   rtt   <wsBase> <path> [n]                    sequential single-event appends; latency distribution
+//   burst <wsBase> <path> <count> <batchSize> [payloadBytes] [concurrency]
+//         append `count` events in batches; concurrency 0 fires every batch at once
+//         (deliberately abusive — expect DO overload shedding above ~1000 in-flight),
+//         concurrency N keeps N batches in flight. Always cross-checks the ack count
+//         against the server's offset delta, so silent loss/duplication is visible.
+//   read  <wsBase> <path> <fromOffset> <toOffset> [pageSize]   getEvents paging throughput
+//
+// Deployed environments require STREAMS_PLAYGROUND_TOKEN (see e2e/auth.ts):
+//   doppler run --project streams-example-app --config <env> -- \
+//     env WORKER_URL=https://streams.<domain> pnpm exec tsx e2e/auth.ts
+//
+// Example:
+//   STREAMS_PLAYGROUND_TOKEN=... pnpm exec tsx scripts/bench/bench-stream.mts \
+//     burst wss://streams.iterate-preview-3.com/api/streams /bench-b100 100000 100 64 20
+import { withStreamConnectionFromNode } from "../../src/lib/node-stream-connection.ts";
+
+// The overload error a shedding Durable Object sends back can crash capnweb's
+// read loop during deserialization; keep the process alive so the run still
+// reports what it measured.
+process.on("uncaughtException", (error) => {
+  console.error("UNCAUGHT (continuing):", error instanceof Error ? error.message : error);
+});
+
+const [cmd, wsBase, path, ...rest] = process.argv.slice(2);
+if (cmd === undefined || wsBase === undefined || path === undefined) {
+  console.error("usage: bench-stream.mts <state|rtt|burst|read> <wsBase> <path> [...]");
+  process.exit(1);
+}
+const token = process.env.STREAMS_PLAYGROUND_TOKEN;
+const url = `${wsBase}?path=${encodeURIComponent(path)}&projectId=default${
+  token ? `&access_token=${token}` : ""
+}`;
+
+function percentile(sorted: number[], p: number) {
+  return sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))];
+}
+
+function summarize(label: string, samples: number[]) {
+  const s = [...samples].sort((a, b) => a - b);
+  console.log(
+    `${label}: n=${s.length} p50=${percentile(s, 50)?.toFixed(1)}ms p90=${percentile(s, 90)?.toFixed(1)}ms p99=${percentile(s, 99)?.toFixed(1)}ms min=${s[0]?.toFixed(1)} max=${s.at(-1)?.toFixed(1)}`,
+  );
+}
+
+function makePayload(bytes: number, index: number) {
+  return { index, sentAt: Date.now(), pad: "x".repeat(Math.max(0, bytes)) };
+}
+
+type CoreState = { coreProcessorState: { maxOffset: number } };
+
+const connection = withStreamConnectionFromNode({ url });
+const stream = connection.stream;
+
+async function maxOffset(): Promise<number> {
+  const state = (await stream.runtimeState()) as CoreState;
+  return state.coreProcessorState.maxOffset;
+}
+
+if (cmd === "state") {
+  console.log(JSON.stringify({ maxOffset: await maxOffset() }));
+} else if (cmd === "rtt") {
+  const n = Number(rest[0] ?? 100);
+  await stream.runtimeState(); // warm the socket + DO
+  const samples: number[] = [];
+  for (let i = 0; i < n; i++) {
+    const t0 = performance.now();
+    await stream.append({
+      type: "events.iterate.com/random/ping-sent",
+      payload: makePayload(64, i),
+    });
+    samples.push(performance.now() - t0);
+  }
+  summarize(`rtt append(1) ${path}`, samples);
+} else if (cmd === "burst") {
+  const count = Number(rest[0] ?? 100_000);
+  const batchSize = Number(rest[1] ?? 100);
+  const payloadBytes = Number(rest[2] ?? 64);
+  const concurrency = Number(rest[3] ?? 0);
+  const before = await maxOffset();
+  const batchCount = Math.ceil(count / batchSize);
+  const latencies: number[] = [];
+  let acked = 0;
+  const failures = new Map<string, number>();
+  const t0 = performance.now();
+
+  const runBatch = async (batchIndex: number) => {
+    const startIndex = batchIndex * batchSize;
+    const events = Array.from({ length: Math.min(batchSize, count - startIndex) }, (_, i) => ({
+      type: "events.iterate.com/random/ping-sent",
+      payload: makePayload(payloadBytes, startIndex + i),
+    }));
+    const b0 = performance.now();
+    try {
+      const committed = (await stream.append(...events)) as unknown[];
+      latencies.push(performance.now() - b0);
+      acked += committed.length;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      failures.set(message, (failures.get(message) ?? 0) + 1);
+    }
+  };
+
+  if (concurrency > 0) {
+    let next = 0;
+    await Promise.all(
+      Array.from({ length: concurrency }, async () => {
+        while (next < batchCount) await runBatch(next++);
+      }),
+    );
+  } else {
+    await Promise.all(Array.from({ length: batchCount }, (_, i) => runBatch(i)));
+  }
+  const wallMs = performance.now() - t0;
+  const after = await maxOffset();
+  console.log(
+    JSON.stringify({
+      path,
+      count,
+      batchSize,
+      payloadBytes,
+      concurrency,
+      wallMs: Math.round(wallMs),
+      eventsPerSec: Math.round((acked / wallMs) * 1000),
+      acked,
+      before,
+      after,
+      offsetDelta: after - before,
+      correct: after - before === acked && acked === count,
+    }),
+  );
+  summarize("batch append latency", latencies);
+  for (const [message, n] of failures) console.log(`FAIL x${n}: ${message.slice(0, 160)}`);
+} else if (cmd === "read") {
+  const from = Number(rest[0] ?? 0);
+  const to = Number(rest[1] ?? 10_000);
+  const pageSize = Number(rest[2] ?? 500);
+  let cursor = from;
+  let total = 0;
+  const t0 = performance.now();
+  while (cursor < to) {
+    const page = (await stream.getEvents({ afterOffset: cursor, limit: pageSize })) as {
+      offset: number;
+    }[];
+    if (page.length === 0) break;
+    total += page.length;
+    cursor = page.at(-1)!.offset;
+  }
+  const wallMs = performance.now() - t0;
+  console.log(
+    JSON.stringify({
+      read: total,
+      pageSize,
+      wallMs: Math.round(wallMs),
+      eventsPerSec: Math.round((total / wallMs) * 1000),
+    }),
+  );
+} else {
+  console.error("unknown command", cmd);
+  process.exit(1);
+}
+connection[Symbol.dispose]();

--- a/apps/streams-example-app/scripts/bench/bench-stream.mts
+++ b/apps/streams-example-app/scripts/bench/bench-stream.mts
@@ -141,9 +141,13 @@ if (cmd === "state") {
   let total = 0;
   const t0 = performance.now();
   while (cursor < to) {
-    const page = (await stream.getEvents({ afterOffset: cursor, limit: pageSize })) as {
-      offset: number;
-    }[];
+    // beforeOffset bounds the window: without it the final page can spill past
+    // `to` on a stream whose tail keeps growing, over-counting the read rate.
+    const page = (await stream.getEvents({
+      afterOffset: cursor,
+      beforeOffset: to + 1,
+      limit: pageSize,
+    })) as { offset: number }[];
     if (page.length === 0) break;
     total += page.length;
     cursor = page.at(-1)!.offset;

--- a/apps/streams-example-app/scripts/bench/ping-latency.mts
+++ b/apps/streams-example-app/scripts/bench/ping-latency.mts
@@ -1,0 +1,34 @@
+// Appends N single "ping" events (one per interval) and prints {offset, sentAt, ackAt}
+// pairs. Pair with a browser-side sampler polling __streamRuntimeDebug's
+// lastDeliveredOffset (see README.md) to measure append→browser-mirror latency.
+// Usage:
+//   pnpm exec tsx scripts/bench/ping-latency.mts <wsBase> <path> [n] [intervalMs]
+import { withStreamConnectionFromNode } from "../../src/lib/node-stream-connection.ts";
+
+const [wsBase, path, nArg, intervalArg] = process.argv.slice(2);
+if (wsBase === undefined || path === undefined) {
+  console.error("usage: ping-latency.mts <wsBase> <path> [n] [intervalMs]");
+  process.exit(1);
+}
+const n = Number(nArg ?? 20);
+const intervalMs = Number(intervalArg ?? 1000);
+const token = process.env.STREAMS_PLAYGROUND_TOKEN;
+const url = `${wsBase}?path=${encodeURIComponent(path)}&projectId=default${
+  token ? `&access_token=${token}` : ""
+}`;
+const connection = withStreamConnectionFromNode({ url });
+const stream = connection.stream;
+await stream.runtimeState(); // warm the socket + DO
+
+const pings: { offset: number; sentAt: number; ackAt: number }[] = [];
+for (let i = 0; i < n; i++) {
+  const sentAt = Date.now();
+  const [committed] = (await stream.append({
+    type: "events.iterate.com/random/ping-sent",
+    payload: { ping: i, sentAt },
+  })) as { offset: number }[];
+  pings.push({ offset: committed!.offset, sentAt, ackAt: Date.now() });
+  await new Promise((resolve) => setTimeout(resolve, intervalMs));
+}
+console.log(JSON.stringify(pings));
+connection[Symbol.dispose]();

--- a/apps/streams-example-app/scripts/bench/sustained-load.mts
+++ b/apps/streams-example-app/scripts/bench/sustained-load.mts
@@ -1,0 +1,80 @@
+// Paced sustained load: <ratePerSec> events/sec in batches of <batchSize> for <seconds>,
+// with a 1s server-head sampler so a subscriber's lag can be computed against the
+// printed timeline. Usage:
+//   pnpm exec tsx scripts/bench/sustained-load.mts <wsBase> <path> [ratePerSec] [batchSize] [seconds]
+import { withStreamConnectionFromNode } from "../../src/lib/node-stream-connection.ts";
+
+process.on("uncaughtException", (error) => {
+  console.error("UNCAUGHT (continuing):", error instanceof Error ? error.message : error);
+});
+
+const [wsBase, path, rateArg, batchArg, secondsArg] = process.argv.slice(2);
+if (wsBase === undefined || path === undefined) {
+  console.error("usage: sustained-load.mts <wsBase> <path> [ratePerSec] [batchSize] [seconds]");
+  process.exit(1);
+}
+const ratePerSec = Number(rateArg ?? 5000);
+const batchSize = Number(batchArg ?? 200);
+const seconds = Number(secondsArg ?? 30);
+const token = process.env.STREAMS_PLAYGROUND_TOKEN;
+const url = `${wsBase}?path=${encodeURIComponent(path)}&projectId=default${
+  token ? `&access_token=${token}` : ""
+}`;
+
+type CoreState = { coreProcessorState: { maxOffset: number } };
+
+const connection = withStreamConnectionFromNode({ url });
+const stream = connection.stream;
+await stream.runtimeState();
+
+const intervalMs = 1000 / (ratePerSec / batchSize);
+const timeline: { t: number; maxOffset: number }[] = [];
+let failures = 0;
+let acked = 0;
+const t0 = Date.now();
+
+const sampler = setInterval(() => {
+  void (async () => {
+    try {
+      const state = (await stream.runtimeState()) as CoreState;
+      timeline.push({ t: Date.now(), maxOffset: state.coreProcessorState.maxOffset });
+    } catch {
+      // A dropped sample is fine; the load half keeps its own failure count.
+    }
+  })();
+}, 1000);
+
+let batchIndex = 0;
+const totalBatches = Math.ceil((ratePerSec * seconds) / batchSize);
+await new Promise<void>((done) => {
+  const timer = setInterval(() => {
+    if (batchIndex >= totalBatches) {
+      clearInterval(timer);
+      done();
+      return;
+    }
+    const index = batchIndex++;
+    const events = Array.from({ length: batchSize }, (_, i) => ({
+      type: "events.iterate.com/random/metric-recorded",
+      payload: { index: index * batchSize + i, sentAt: Date.now() },
+    }));
+    void (stream.append(...events) as Promise<unknown[]>).then(
+      (committed) => (acked += committed.length),
+      () => (failures += 1),
+    );
+  }, intervalMs);
+});
+await new Promise((resolve) => setTimeout(resolve, 3000));
+clearInterval(sampler);
+console.log(
+  JSON.stringify({
+    ratePerSec,
+    batchSize,
+    seconds,
+    acked,
+    failedBatches: failures,
+    wallMs: Date.now() - t0,
+    timeline,
+  }),
+);
+connection[Symbol.dispose]();

--- a/apps/streams-example-app/scripts/bench/sustained-load.mts
+++ b/apps/streams-example-app/scripts/bench/sustained-load.mts
@@ -21,8 +21,6 @@ const url = `${wsBase}?path=${encodeURIComponent(path)}&projectId=default${
   token ? `&access_token=${token}` : ""
 }`;
 
-type CoreState = { coreProcessorState: { maxOffset: number } };
-
 const connection = withStreamConnectionFromNode({ url });
 const stream = connection.stream;
 await stream.runtimeState();
@@ -36,7 +34,9 @@ const t0 = Date.now();
 const sampler = setInterval(() => {
   void (async () => {
     try {
-      const state = (await stream.runtimeState()) as CoreState;
+      const state = (await stream.runtimeState()) as {
+        coreProcessorState: { maxOffset: number };
+      };
       timeline.push({ t: Date.now(), maxOffset: state.coreProcessorState.maxOffset });
     } catch {
       // A dropped sample is fine; the load half keeps its own failure count.


### PR DESCRIPTION
## What

Massive-throughput investigation of the streams stack, in three parts:

1. **Bench harness** (`apps/streams-example-app/scripts/bench/`): append RTT / burst throughput / read paging / sustained load / end-to-end latency pings, each cross-checking acked events against the server's offset delta so loss/duplication can't hide. Findings with full numbers live in the PR comments (№1 prd, №2 preview).

2. **Correctness + flow-control fixes** in the shared `apps/os/src/domains/streams` stack (apps/os UI and the example app both consume it). Delivery frames stay strictly one-directional worker→client — no acks added:
   - `appendBatch` stamps an idempotency key on every event and retries across reconnects: a stream-DO eviction/kill/overload mid-blast loses nothing and duplicates nothing.
   - A leader >1000 events behind the head **pull-pages** history via `getEvents` (client-paced ⇒ structural backpressure), re-reading the live head before trusting the exit, and only then opens the live subscription. A 20k-event live-tail valve cuts back into the pull lane if delivery ever outruns SQLite.
   - `DELIVERY_BATCH_LIMIT` 100 → 1000 under the existing 1MB byte cap (~10× fewer pump pushes on catch-up).

3. **Regression pins** (playwright): DO killed twice mid-blast → exactly 3000 events; follower-tab blast + leader kill → both tabs converge on exactly 2000 (multi-tab); cold open of a deep stream must engage the pull lane (console breadcrumb asserted) and converge exactly. The kill pin was verified to fail with retries disabled.

Bugbot findings both fixed (stale-head catch-up exit, read-bench window bound) and threads resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-11T11:09:52.456Z",
      "headSha": "e6ae8be70f58bb6d161bba9437521fb276789607",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/365036055272020",
      "shortSha": "e6ae8be",
      "cleanupDurationMs": 9481,
      "deployDurationMs": 77688,
      "testDurationMs": 131364,
      "testRetries": "2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · runs \"secrets-lifecycle\" through the project REPL (specs x1)",
      "workerSizeKib": 15883.95,
      "workerGzipKib": 4279.17,
      "mainWorkerGzipKib": 4286.27
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-11T11:09:43.585Z",
      "headSha": "2cb2ca096102ec429501691a7289861308d8561a",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/272384325759787",
      "shortSha": "2cb2ca0",
      "cleanupDurationMs": 607,
      "deployDurationMs": 14298,
      "testDurationMs": 5888,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-11T11:09:45.665Z",
      "headSha": "e6ae8be70f58bb6d161bba9437521fb276789607",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/365036055272020",
      "shortSha": "e6ae8be",
      "cleanupDurationMs": 2685,
      "deployDurationMs": 15361,
      "testDurationMs": 580,
      "testRetries": null,
      "workerSizeKib": 4031.76,
      "workerGzipKib": 819.5,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-11T11:09:43.723Z",
      "headSha": "e6ae8be70f58bb6d161bba9437521fb276789607",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/365036055272020",
      "shortSha": "e6ae8be",
      "cleanupDurationMs": 742,
      "deployDurationMs": 21557,
      "testDurationMs": 15864,
      "testRetries": null,
      "workerSizeKib": 4784.92,
      "workerGzipKib": 1365.9,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `e6ae8be` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 819.5 KiB | 15.4s | 580ms |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/365036055272020) | 2026-07-11T11:09:45.665Z | Preview app released. |
| OS | released | `e6ae8be` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 4.18 MiB (-7.1 KiB vs main) | 77.7s | 131.4s | 2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · runs "secrets-lifecycle" through the project REPL (specs x1) | 9.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/365036055272020) | 2026-07-11T11:09:52.456Z | Preview app released. |
| Semaphore | released | `2cb2ca0` | [https://semaphore.iterate-preview-4.com](https://semaphore.iterate-preview-4.com) | 440.8 KiB | 14.3s | 5.9s |  | 607ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/272384325759787) | 2026-07-11T11:09:43.585Z | Preview app released. |
| Streams Example App | released | `e6ae8be` | [https://streams.iterate-preview-4.com](https://streams.iterate-preview-4.com) | 1.33 MiB | 21.6s | 15.9s |  | 742ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/365036055272020) | 2026-07-11T11:09:43.723Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->
