### PR TITLE
gpt-5.5 over BYOK is the only lane: byok config default, kimi erased

### DIFF
--- a/apps/os/e2e/vitest/agent-tools.itx.e2e.test.ts
+++ b/apps/os/e2e/vitest/agent-tools.itx.e2e.test.ts
@@ -50,7 +50,7 @@ test(
       {
         description: "the proof event to land on the target stream",
         intervalMs: 1_000,
-        // Kimi turns run 15-60s under preview-account load (measured live
+        // Turns run 15-60s under preview-account load (measured live
         // 2026-07-10: a healthy turn with a 31s LLM response); two turns plus
         // boot must fit, so this sits just under the 240s test ceiling.
         timeoutMs: 180_000,
@@ -92,8 +92,8 @@ test(
 
     const response = await agent.ask({
       message: "Reply with a short greeting.",
-      // Workers AI under preview load can sit past the 45s default — a kimi
-      // turn alone measured 31s healthy, worse when the shared per-minute
+      // Gateway turns under preview load can sit past the 45s default — a
+      // single turn measured 31s healthy, worse when the shared per-minute
       // budget is saturated and the retry backoff (10/20/60s) is riding.
       timeoutMs: 180_000,
     });

--- a/apps/os/src/components/agent-ui-reducer.test.ts
+++ b/apps/os/src/components/agent-ui-reducer.test.ts
@@ -955,7 +955,7 @@ describe("agent-ui reducer", () => {
         type: "events.iterate.com/agent/token-usage-reported",
         payload: {
           llmRequestOffset: 7,
-          model: "@cf/moonshotai/kimi-k2.7-code",
+          model: "@cf/test/totals-only-model",
           maxContextTokens: 256_000,
           inputTokens: 2_000,
           outputTokens: 150,
@@ -969,7 +969,7 @@ describe("agent-ui reducer", () => {
       totalCachedInputTokens: 800,
       totalReasoningOutputTokens: 10,
       lastReport: {
-        model: "@cf/moonshotai/kimi-k2.7-code",
+        model: "@cf/test/totals-only-model",
         maxContextTokens: 256_000,
         inputTokens: 2_000,
         outputTokens: 150,

--- a/apps/os/src/components/llm-request-inspector-panel.tsx
+++ b/apps/os/src/components/llm-request-inspector-panel.tsx
@@ -321,7 +321,10 @@ const ReplayResponseSection = memo(
             {outcome.errorMessage}
           </pre>
         )}
-        {response == null && outcome?.errorMessage == null ? (
+        {/* A committed output CAN be the empty string — an empty-text response
+            with no thinking must still say so instead of a bare header. */}
+        {(response == null || (response.text === "" && response.thinkingText === "")) &&
+        outcome?.errorMessage == null ? (
           <p className="text-sm text-muted-foreground">
             {outcome == null
               ? "Nothing has streamed back yet."

--- a/apps/os/src/config.ts
+++ b/apps/os/src/config.ts
@@ -85,6 +85,12 @@ export const AppConfig = z.object({
    * envs.ts via envShapedVars (APP_CONFIG_CLOUDFLARE_AI_GATEWAY__*), so this
    * is per-deployment, not per-Doppler-secret.
    *
+   * `byok` is the default AND what every deployed env sets explicitly: the
+   * platform is gpt-5.5-only, unified billing meters OpenAI-prompt-cached
+   * tokens at the uncached price (~6x at our hit rate), and BYOK benchmarked
+   * latency-neutral-or-better. The default matters for LOCAL DEV, which has
+   * no envs.ts entry — dev must ride the same lane as production.
+   *
    * `responseCacheTtlSeconds` opts the BYOK lane into the gateway's RESPONSE
    * cache (whole-answer replay — distinct from OpenAI's prompt cache, which
    * BYOK gets unconditionally). Only for deployments whose conversations are
@@ -92,7 +98,7 @@ export const AppConfig = z.object({
    */
   cloudflareAiGateway: z
     .object({
-      transport: z.enum(["unified", "byok"]).default("unified"),
+      transport: z.enum(["unified", "byok"]).default("byok"),
       id: z.string().trim().min(1).default("default"),
       responseCacheTtlSeconds: z.coerce.number().int().positive().optional(),
     })

--- a/apps/os/src/domains/agents/agent-processor-contract.ts
+++ b/apps/os/src/domains/agents/agent-processor-contract.ts
@@ -620,16 +620,6 @@ export const AgentProcessorContract = defineProcessorContract({
             reasoningOutputTokens: 0,
           },
         },
-        {
-          description: "A Workers AI model reports totals only — no cache/reasoning breakdown.",
-          payload: {
-            llmRequestOffset: 61,
-            model: "@cf/moonshotai/kimi-k2.7-code",
-            maxContextTokens: 256000,
-            inputTokens: 4096,
-            outputTokens: 118,
-          },
-        },
       ],
     },
     "events.iterate.com/agent/history-reset": {

--- a/apps/os/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/os/src/domains/agents/agent-processor-implementation.ts
@@ -1174,12 +1174,10 @@ const AGENT_COMPACTION_PROMPT = [
  * inherit their family's window. The OpenAI figures are our OPERATING window,
  * not the documented one: gpt-5.5's real window is 1.05M tokens, but 272k is
  * where OpenAI's pricing doubles, so compaction should treat that as full.
- * Kimi's documented window is 262,144; 256k is the safe round-down.
  */
 const MODEL_CONTEXT_WINDOW_TOKENS: Record<string, number> = {
   "openai/gpt-5.5": 272_000,
   "openai/gpt-5": 272_000,
-  "@cf/moonshotai/kimi-k2.7-code": 256_000,
 };
 
 /** Conservative floor for models not in the map. */

--- a/apps/os/src/domains/agents/agent-processors.test.ts
+++ b/apps/os/src/domains/agents/agent-processors.test.ts
@@ -1650,7 +1650,6 @@ describe("token usage and history reset", () => {
   it("longest-prefix matches context windows, with a conservative default", () => {
     expect(contextWindowTokens("openai/gpt-5.5")).toBe(272_000);
     expect(contextWindowTokens("openai/gpt-5.5-2026-01-15")).toBe(272_000);
-    expect(contextWindowTokens("@cf/moonshotai/kimi-k2.7-code")).toBe(256_000);
     expect(contextWindowTokens("@cf/qwen/qwen3-coder-plus")).toBe(128_000);
   });
 

--- a/apps/os/src/domains/agents/workers-ai-transport.test.ts
+++ b/apps/os/src/domains/agents/workers-ai-transport.test.ts
@@ -59,7 +59,7 @@ describe("runWorkersAiAttempt", () => {
         return { response: "ok" };
       },
     };
-    for (const model of ["openai/gpt-5.5", "@cf/moonshotai/kimi-k2.7-code"]) {
+    for (const model of ["openai/gpt-5.5", "@cf/test/non-openai-model"]) {
       await runWorkersAiAttempt({
         ai,
         deadlineMs: 1_000,
@@ -231,7 +231,7 @@ describe("the BYOK gateway lane", () => {
       },
       deadlineMs: 1_000,
       messages: [{ role: "user", content: "hi" }],
-      model: "@cf/moonshotai/kimi-k2.7-code",
+      model: "@cf/test/non-openai-model",
       onChunk: async () => {},
       transport: { kind: "byok", gatewayId: "default", openaiApiKey: "sk-test" },
     });


### PR DESCRIPTION
Everything runs **openai/gpt-5.5, medium effort, over the AI Gateway BYOK lane** — no exceptions.

## What was still off the lane

- **Local dev (and any unconfigured deployment) defaulted to `unified`**: every deployed env sets `cloudflareAiGateway.transport=byok` in envs.ts, but the config schema's default was `unified`. The default is now `byok`, so dev rides the same lane as production structurally instead of depending on a Doppler var being set. (Medium reasoning effort was already pinned in the transport for every `gpt-5*` model on both lanes.)
- **Kimi remnants erased**: the retired context-window map entry, the token-usage docs example on events.iterate.com, and every test fixture (dialect/routing tests now use neutral fake model ids like `@cf/test/non-openai-model` — they exercise code paths, not vendors). `grep -ri kimi` over the repo returns nothing.

## Where kimi sightings actually come from

Journal data, not code: `DEFAULT_AGENT_MODEL` has been gpt-5.5 since #1828, but agents born before that cutover carry an explicit kimi `llm-provider-selected` event in their event-sourced journals, so they keep using it forever. Deliberately **no fold shim** for this — those journals get healed by re-appending their provider selection (`configure({model})`, the event-sourced way) in a fleet sweep run alongside this PR.

## Verified

- Fresh dev turn after the flip: `llm-request-completed.rawResponse` carries `cloudflareAiGatewayResponseCacheStatus` (only the BYOK lane stamps it) — dev is on byok.
- `pnpm typecheck && pnpm lint && pnpm format && pnpm test` (1015 passed), knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the default gateway transport affects every local/unconfigured dev turn’s billing path and routing; Kimi removal is mostly cleanup but drops a known context-window mapping for that model id.
> 
> **Overview**
> Aligns **local and unconfigured deployments** with production by changing `cloudflareAiGateway.transport`’s schema default from **`unified` to `byok`**, with config comments explaining why (gpt-5.5-only platform, billing, dev parity).
> 
> **Removes retired Kimi/K2.7 references** from agent code and tests: the Workers AI context-window map entry, a `token-usage-reported` contract example, and fixtures now use neutral ids like `@cf/test/non-openai-model` / `@cf/test/totals-only-model`. E2E comments are vendor-neutral (“gateway turns” vs Kimi-specific wording).
> 
> **Fixes the LLM request inspector** so a settled response with **empty text and no thinking** still shows the “no text” placeholder instead of a bare **response** header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc54ea3c0f77370d3c64f22d2780221dd1165976. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +7 -13 | +1 -12 🟥🟥🟥🟥🟥 |
| UI components | +4 -1 | +4 -1 🟩🟩⬜⬜⬜ |
| Tests | +7 -8 | +4 -5 🟩🟥🟥⬜⬜ |
| **Total** | **+18 -22** | **+9 -18** 🟩🟩🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 5a0bda0 and fc54ea3, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-11T10:48:34.574Z",
      "headSha": "fc54ea3c0f77370d3c64f22d2780221dd1165976",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/572259051334454",
      "shortSha": "fc54ea3",
      "cleanupDurationMs": 9506,
      "deployDurationMs": 69762,
      "testDurationMs": 111733,
      "testRetries": "1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 15905.74,
      "workerGzipKib": 4286.27,
      "mainWorkerGzipKib": 4286.29
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-11T10:48:26.285Z",
      "headSha": "fc54ea3c0f77370d3c64f22d2780221dd1165976",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/572259051334454",
      "shortSha": "fc54ea3",
      "cleanupDurationMs": 1214,
      "deployDurationMs": 13857,
      "testDurationMs": 5774,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-11T10:48:27.980Z",
      "headSha": "fc54ea3c0f77370d3c64f22d2780221dd1165976",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/572259051334454",
      "shortSha": "fc54ea3",
      "cleanupDurationMs": 2909,
      "deployDurationMs": 16322,
      "testDurationMs": 473,
      "testRetries": null,
      "workerSizeKib": 4031.76,
      "workerGzipKib": 819.34,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-11T10:48:26.195Z",
      "headSha": "fc54ea3c0f77370d3c64f22d2780221dd1165976",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/572259051334454",
      "shortSha": "fc54ea3",
      "cleanupDurationMs": 1121,
      "deployDurationMs": 20189,
      "testDurationMs": 16185,
      "testRetries": null,
      "workerSizeKib": 4802.83,
      "workerGzipKib": 1371.65,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `fc54ea3` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 819.3 KiB | 16.3s | 473ms |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/572259051334454) | 2026-07-11T10:48:27.980Z | Preview app released. |
| OS | released | `fc54ea3` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.19 MiB (-0.0 KiB vs main) | 69.8s | 111.7s | 1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 9.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/572259051334454) | 2026-07-11T10:48:34.574Z | Preview app released. |
| Semaphore | released | `fc54ea3` | [https://semaphore.iterate-preview-3.com](https://semaphore.iterate-preview-3.com) | 440.8 KiB | 13.9s | 5.8s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/572259051334454) | 2026-07-11T10:48:26.285Z | Preview app released. |
| Streams Example App | released | `fc54ea3` | [https://streams.iterate-preview-3.com](https://streams.iterate-preview-3.com) | 1.34 MiB | 20.2s | 16.2s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/572259051334454) | 2026-07-11T10:48:26.195Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->