### PR TITLE
What the model reads is curated: Slack sans secrets, PR bodies once, strings raw

### DIFF
--- a/apps/os/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/os/src/domains/agents/agent-processor-implementation.ts
@@ -851,7 +851,7 @@ function reduceAgentEvent(input: { event: AgentConsumedEvent; state: AgentState 
       // so the label spells out the reply door.
       const content =
         from.kind === "agent"
-          ? `Message from agent ${from.path} (that agent cannot see your web chat — to reply to it: await itx.agents.get(${JSON.stringify(from.path)}).message(text)):\n${event.payload.content}`
+          ? `Message from agent ${from.path} (that agent cannot see this conversation — to reply to it: await itx.agents.get(${JSON.stringify(from.path)}).message(text)):\n${event.payload.content}`
           : event.payload.content;
       return {
         ...state,
@@ -1288,19 +1288,24 @@ async function scriptResultAgentInput(
   }
   if (payload.result === undefined) return null;
   const text = stringifyScriptResult(payload.result);
+  // String results are raw text, not JSON — the fence label, the spill
+  // file's extension, and the read-it-back recipe all say so honestly.
+  const isRawText = typeof payload.result === "string";
+  const fence = isRawText ? "```" : "```json";
   if (text.length > SCRIPT_RESULT_HISTORY_LIMIT && writeWorkspaceFile !== undefined) {
     try {
       const spilledPath = await spillScriptResult({
         executionId: payload.executionId,
+        extension: isRawText ? "txt" : "json",
         text,
         writeWorkspaceFile,
       });
       return [
         "Your script returned:",
-        "```json",
+        fence,
         text.slice(0, SCRIPT_RESULT_HISTORY_LIMIT),
         "```",
-        spillNotice({ path: spilledPath, totalChars: text.length }),
+        spillNotice({ isRawText, path: spilledPath, totalChars: text.length }),
       ].join("\n");
     } catch (error) {
       // Spilling is best effort: a workspace that cannot clone or write must
@@ -1311,10 +1316,16 @@ async function scriptResultAgentInput(
       });
     }
   }
-  return `Your script returned:\n\`\`\`json\n${truncateScriptResult(text)}\n\`\`\``;
+  return `Your script returned:\n${fence}\n${truncateScriptResult(text)}\n\`\`\``;
 }
 
 function stringifyScriptResult(result: unknown): string {
+  // A returned string renders as itself: JSON.stringify would escape every
+  // newline and quote, turning a fetched page or file into one unreadable
+  // escaped line the model pays to mentally unescape (seen live: an 8.8KB
+  // worker.ts as a single escape-riddled JSON string). Non-strings keep the
+  // pretty-printed JSON shape.
+  if (typeof result === "string") return result;
   try {
     return JSON.stringify(result, null, 2) ?? String(result);
   } catch {
@@ -1341,6 +1352,7 @@ const SCRIPT_RESULT_SPILL_DIR = "/script-results";
 /** Writes the full result text into the agent's workspace; returns its path. */
 async function spillScriptResult(input: {
   executionId: string;
+  extension: "json" | "txt";
   text: string;
   writeWorkspaceFile: NonNullable<AgentProcessorDeps["writeWorkspaceFile"]>;
 }): Promise<string> {
@@ -1348,7 +1360,7 @@ async function spillScriptResult(input: {
   // nested ignore every spill would ride along into workspace snapshot
   // commits (the overlay publish honors .gitignore).
   await input.writeWorkspaceFile({ content: "*\n", path: `${SCRIPT_RESULT_SPILL_DIR}/.gitignore` });
-  const path = `${SCRIPT_RESULT_SPILL_DIR}/${input.executionId.replace(/[^A-Za-z0-9._-]+/g, "-")}.json`;
+  const path = `${SCRIPT_RESULT_SPILL_DIR}/${input.executionId.replace(/[^A-Za-z0-9._-]+/g, "-")}.${input.extension}`;
   await input.writeWorkspaceFile({ content: input.text, path });
   return path;
 }
@@ -1358,13 +1370,21 @@ async function spillScriptResult(input: {
  * lives and a concrete next-script recipe for paging it, so the model reads
  * the file with plain JavaScript instead of re-running the expensive fetch.
  */
-function spillNotice(input: { path: string; totalChars: number }): string {
+function spillNotice(input: { isRawText: boolean; path: string; totalChars: number }): string {
+  const readRecipe = input.isRawText
+    ? [
+        `  const text = await itx.workspace.readFile(${JSON.stringify(input.path)});`,
+        "  return text.slice(30_000, 60_000); // page/regex to return only what you need",
+      ]
+    : [
+        `  const data = JSON.parse(await itx.workspace.readFile(${JSON.stringify(input.path)}));`,
+        "  return Object.keys(data); // then slice/filter/regex to return only what you need",
+      ];
   return [
     `…truncated: showing the first ${SCRIPT_RESULT_HISTORY_LIMIT.toLocaleString("en-US")} of ${input.totalChars.toLocaleString("en-US")} chars. The full result is saved in your workspace at ${JSON.stringify(input.path)} — don't re-fetch; read and filter it with plain JavaScript in your next script, e.g.:`,
     "```js",
     "async (itx) => {",
-    `  const data = JSON.parse(await itx.workspace.readFile(${JSON.stringify(input.path)}));`,
-    "  return Object.keys(data); // then slice/filter/regex to return only what you need",
+    ...readRecipe,
     "}",
     "```",
   ].join("\n");

--- a/apps/os/src/domains/agents/agent-processors.test.ts
+++ b/apps/os/src/domains/agents/agent-processors.test.ts
@@ -98,6 +98,25 @@ describe("minimal web-chat agent processors", () => {
     ).toBe(true);
   });
 
+  it("renders string results raw — no JSON escaping, no json fence label", async () => {
+    const stream = new MemoryStream();
+    const agent = new AgentProcessor({ stream, path: stream.path, projectId: null });
+
+    await stream.append({
+      type: "events.iterate.com/capability-host/script-execution-completed",
+      payload: { executionId: "agent-output:7", result: 'line one\nline "two"' },
+    });
+    await deliverNewEvents({ processor: agent, stream, cursors: new Map<object, number>() });
+
+    const content = stream.events.find(
+      (event) => event.type === "events.iterate.com/agent/input-added",
+    )?.payload?.content as string;
+    // The model reads the text itself, not an escaped JSON string of it.
+    expect(content).toContain('line one\nline "two"');
+    expect(content).not.toContain("\\n");
+    expect(content).not.toContain("```json");
+  });
+
   it("spills an oversized script result to a workspace file and references it", async () => {
     const stream = new MemoryStream();
     const writes: { content: string; path: string }[] = [];
@@ -159,8 +178,9 @@ describe("minimal web-chat agent processors", () => {
     await deliverNewEvents({ processor: agent, stream, cursors: new Map<object, number>() });
 
     const files = writes.filter((write) => !write.path.endsWith(".gitignore"));
-    expect(files.map((write) => write.path)).toEqual(["/script-results/agent-output-7.json"]);
-    expect(files[0]!.content).toBe(JSON.stringify(result, null, 2));
+    // A string result spills as itself — raw text file, no JSON escaping.
+    expect(files.map((write) => write.path)).toEqual(["/script-results/agent-output-7.txt"]);
+    expect(files[0]!.content).toBe(result);
   });
 
   it("falls back to inline truncation when the workspace spill fails", async () => {

--- a/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
+++ b/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
@@ -332,14 +332,98 @@ function slackWebhookSenderUserId(body: unknown): string | undefined {
   );
 }
 
+/**
+ * Envelope keys stripped from the model-facing transcript. `token` is
+ * Slack's webhook VERIFICATION SECRET — dumping it re-sends the secret to
+ * the LLM provider on every turn of every Slack agent. The rest is routing
+ * plumbing (event ids, authorization lists, dedup context) that drowns the
+ * message without telling the model anything actionable.
+ */
+const SLACK_ENVELOPE_NOISE = new Set([
+  "token",
+  "api_app_id",
+  "authorizations",
+  "authed_users",
+  "authed_teams",
+  "event_context",
+  "context_team_id",
+  "context_enterprise_id",
+  "event_id",
+  "event_time",
+  "is_ext_shared_channel",
+]);
+
+/** Event keys stripped for the same reason: `blocks` is the rich-text AST of
+ * the `text` field it sits next to (pure duplication at 10-50x the tokens);
+ * the rest is client/team bookkeeping. */
+const SLACK_EVENT_NOISE = new Set([
+  "blocks",
+  "client_msg_id",
+  "source_team",
+  "user_team",
+  "team",
+  "display_as_bot",
+  "is_locked",
+  "subscribed",
+]);
+
+/** Slack file objects carry dozens of thumbnail/preview fields; the model
+ * needs identity and type — the bytes ride separately as itx.files
+ * attachments on the same message. */
+const SLACK_FILE_KEYS = ["id", "name", "title", "mimetype", "filetype", "size", "mode"] as const;
+
+/**
+ * The model-facing transcript of one Slack webhook: the event's facts,
+ * curated rather than the raw wire payload (same posture as the email
+ * door's transcriber). Curation is by removal, not a whitelist, so rare
+ * event shapes (reactions, joins, interactivity payloads) keep their fields
+ * instead of arriving empty.
+ */
 function slackWebhookAgentInput(payload: unknown) {
   return [
     "`events.iterate.com/slack/webhook-received` event received",
     "",
     "```yaml",
-    stringifyYaml(payload).trimEnd(),
+    stringifyYaml(curateSlackWebhookPayload(payload)).trimEnd(),
     "```",
   ].join("\n");
+}
+
+function curateSlackWebhookPayload(payload: unknown): unknown {
+  const record = readRecord(payload);
+  if (record == null) return payload;
+  // headers are transport dedup facts (event id, request timestamp) — the
+  // curated body already carries everything the model can act on.
+  const { headers: _headers, ...envelope } = record;
+  const body = readRecord(record.body);
+  if (body == null) return envelope;
+  const curatedBody: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(body)) {
+    if (SLACK_ENVELOPE_NOISE.has(key)) continue;
+    curatedBody[key] = key === "event" ? curateSlackEvent(value) : value;
+  }
+  return { ...envelope, body: curatedBody };
+}
+
+function curateSlackEvent(event: unknown): unknown {
+  const record = readRecord(event);
+  if (record == null) return event;
+  const curated: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (SLACK_EVENT_NOISE.has(key)) continue;
+    curated[key] = key === "files" && Array.isArray(value) ? value.map(curateSlackFile) : value;
+  }
+  return curated;
+}
+
+function curateSlackFile(file: unknown): unknown {
+  const record = readRecord(file);
+  if (record == null) return file;
+  const curated: Record<string, unknown> = {};
+  for (const key of SLACK_FILE_KEYS) {
+    if (record[key] !== undefined) curated[key] = record[key];
+  }
+  return curated;
 }
 
 function isBotMessage(slackEvent: Record<string, unknown>): boolean {

--- a/apps/os/src/domains/integrations/slack-processors.test.ts
+++ b/apps/os/src/domains/integrations/slack-processors.test.ts
@@ -175,6 +175,9 @@ function humanMessageWebhookPayload(input: {
     headers: { slackEventId: input.eventId ?? "Ev123", slackRequestTimestamp: "1" },
     body: {
       type: "event_callback",
+      // Real webhooks carry the verification secret; the transcriber must
+      // strip it (asserted below) while the router still reads the rest.
+      token: "verification-secret",
       team_id: TEAM_ID,
       event_id: input.eventId ?? "Ev123",
       authorizations: [{ is_bot: true, user_id: "UBOT", bot_id: "BBOT" }],
@@ -184,6 +187,7 @@ function humanMessageWebhookPayload(input: {
         user: "UHUMAN",
         text: input.text ?? "hello agent",
         ts: input.ts ?? "111.222",
+        blocks: [{ type: "rich_text", elements: [] }],
         ...(input.threadTs === undefined ? {} : { thread_ts: input.threadTs }),
       },
     },
@@ -610,6 +614,16 @@ describe("SlackAgentProcessor", () => {
     expect(payload.content).toContain("hello agent");
     // The contract default (triggering) policy applies.
     expect(payload.llmRequestPolicy).toEqual({ behaviour: "after-current-request" });
+
+    // The transcript is CURATED: the webhook's verification token must never
+    // reach the LLM provider, and envelope/rich-text noise stays out while
+    // the facts (channel, sender, ts) stay in.
+    expect(payload.content).not.toContain("verification-secret");
+    expect(payload.content).not.toContain("authorizations");
+    expect(payload.content).not.toContain("blocks");
+    expect(payload.content).toContain("C123");
+    expect(payload.content).toContain("UHUMAN");
+    expect(payload.content).toContain("111.222");
 
     expect(slackCalls).toContainEqual({
       method: "reactions.add",

--- a/apps/os/src/domains/repos/pr-agent-processor-implementation.ts
+++ b/apps/os/src/domains/repos/pr-agent-processor-implementation.ts
@@ -167,7 +167,13 @@ function pullRequestWebhookAgentInput(
       draft: typeof pullRequest?.draft === "boolean" ? pullRequest.draft : undefined,
       headRef: readString(readRecord(pullRequest?.head)?.ref),
       baseRef: readString(readRecord(pullRequest?.base)?.ref),
-      body: readString(pullRequest?.body),
+      // The PR description rides ONLY on `opened`. Every other action would
+      // re-render the same multi-KB body — a real prd PR journal accumulated
+      // 53 near-identical walls from CI edits to its preview table, burying
+      // the eventual @mention under a megabyte of history. Edits announce
+      // themselves via `action: edited`; the current body is one
+      // pulls.get away if the model ever needs it.
+      body: readString(body.action) === "opened" ? readString(pullRequest?.body) : undefined,
     },
     sender: {
       login: readString(sender?.login),

--- a/apps/os/src/domains/repos/pr-agent.test.ts
+++ b/apps/os/src/domains/repos/pr-agent.test.ts
@@ -573,6 +573,38 @@ describe("PrAgentProcessor (transcriber)", () => {
     expect(openedInput.content).toContain("Add widgets");
   });
 
+  it("renders the PR description only on opened — edits announce without the body wall", async () => {
+    const network = new MemoryStreamNetwork();
+    const stream = network.get(AGENT_PATH);
+    const processor = new PrAgentProcessor({ stream, path: stream.path, projectId: null });
+    const cursors = new Map<object, number>();
+
+    await stream.append(
+      ROUTE_EVENT,
+      {
+        type: "events.iterate.com/github/webhook-received",
+        payload: webhookPayload(pullRequestBody({ action: "opened" })),
+      },
+      // CI bots edit PR bodies constantly (preview tables); a real prd
+      // journal accumulated 53 near-identical multi-KB body walls this way.
+      {
+        type: "events.iterate.com/github/webhook-received",
+        payload: webhookPayload(pullRequestBody({ action: "edited" })),
+      },
+    );
+    await deliverNewEvents({ cursors, processor, stream });
+
+    const inputs = agentInputs(stream).map(
+      (event) => (event.payload as { content: string }).content,
+    );
+    // inputs[0] is route context; opened carries the description, edited does not.
+    expect(inputs[1]).toContain("PR description");
+    expect(inputs[2]).toContain("edited");
+    expect(inputs[2]).not.toContain("PR description");
+    // The edit still announces the PR identity.
+    expect(inputs[2]).toContain("Add widgets");
+  });
+
   it("gates triggers on action, mention boundary, and PR-description mentions", async () => {
     const network = new MemoryStreamNetwork();
     const stream = network.get(AGENT_PATH);


### PR DESCRIPTION
Four transcript-rendering fixes from the prd context audit (four subagents reading real journals with one question: *does this text make sense to a cold model writing an `async (itx)` function?*). Each finding is evidence-quoted from live prd data.

## 1. Slack transcripts leaked the verification secret (and drowned the message)

`slackWebhookAgentInput` YAML-dumped the raw payload. Real render from a live thread: it **begins with `token: <Slack verification secret>`** — re-sent to the LLM provider on every turn of every Slack agent — followed by `authorizations`, the full `blocks` rich-text AST (a duplicate of the `text` field beside it, at 10–50× the tokens), and routing ids. Now curated **by removal** (the email door's posture): secrets and plumbing stripped, facts kept (channel, sender, ts, text, thread_ts, file identities), unknown event shapes keep their remaining fields so rare payloads stay debuggable. Test appends a fixture with the secret and asserts it never reaches the transcript.

## 2. PR agents rendered the full PR description on every webhook

PR #1852's own agent journal: **103 message renders totalling 1.17MB, 53 of them near-identical multi-KB body walls** from CI editing the preview table — all model-visible history burying the eventual @mention. The description now rides only on `action: opened`; edits still announce themselves (identity, action, sender) and the current body is one `pulls.get` away.

## 3. String results rendered as escaped JSON

`JSON.stringify` of a returned string turned fetched pages and read files into single `\n`-riddled escaped lines (seen live: an 8.8KB `worker.ts` as one JSON string). Strings now render **raw** — honest plain fence, `.txt` spill extension, and a page-through-text recipe (`text.slice(30_000, 60_000)`) instead of a `JSON.parse` one that would throw on the file.

## 4. Inter-agent mail said "your web chat"

False framing on Slack/Telegram/email agents; now "this conversation".

## Verified

New/updated unit tests for all four (secret-never-in-transcript, body-only-on-opened, raw-string render + spill, plus existing suites); 1041 apps/os tests green; typecheck/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LLM-facing transcript content and removes Slack verification secrets from model context; scope is presentation/curation with new tests, but mistakes could hide fields the model needs or leak secrets if curation regresses.
> 
> **Overview**
> Tightens what agents **see in history** so cold models get actionable text instead of secrets, duplicates, or escaped blobs.
> 
> **Slack webhooks** are transcribed with **curation by removal**: the verification `token`, routing envelope fields, rich-text `blocks`, and bloated file metadata are dropped before YAML hits the LLM; channel, sender, text, and thread facts stay. Tests assert the secret never appears in the transcript.
> 
> **GitHub PR webhooks** now include the full PR **description only when `action` is `opened`**; `edited` and other actions still announce identity and action without re-pasting the multi-KB body that CI preview bots were duplicating into journal history.
> 
> **Script return values** that are JavaScript **strings** render as **plain text** (plain fences, `.txt` workspace spills, and a `readFile` + `slice` paging recipe) instead of `JSON.stringify` escaping that turned fetched files into unreadable single lines.
> 
> **Inter-agent mail** wording changes from “your web chat” to **“this conversation”** so Slack/Telegram/email agents aren’t mis-framed.
> 
> Unit tests cover all four behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 111fcfafab6ff1140d26e90ccaa46b06d71136a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +120 -10 | +79 -10 🟩🟩🟩🟩🟥 |
| Tests | +68 -2 | +50 -2 🟩🟩🟩⬜⬜ |
| **Total** | **+188 -12** | **+129 -12** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 5cb886d and 111fcfa, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-11T11:36:32.845Z",
      "headSha": "111fcfafab6ff1140d26e90ccaa46b06d71136a6",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/220395161873528",
      "shortSha": "111fcfa",
      "cleanupDurationMs": 11265,
      "deployDurationMs": 74866,
      "testDurationMs": 112464,
      "testRetries": "2 retried: catalogue example \"journal-is-the-record\" runs identically across runtimes (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 15909.3,
      "workerGzipKib": 4287.52,
      "mainWorkerGzipKib": 4287.47
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-11T11:36:22.428Z",
      "headSha": "111fcfafab6ff1140d26e90ccaa46b06d71136a6",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/220395161873528",
      "shortSha": "111fcfa",
      "cleanupDurationMs": 844,
      "deployDurationMs": 14692,
      "testDurationMs": 6355,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-11T11:36:24.557Z",
      "headSha": "111fcfafab6ff1140d26e90ccaa46b06d71136a6",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/220395161873528",
      "shortSha": "111fcfa",
      "cleanupDurationMs": 2970,
      "deployDurationMs": 20973,
      "testDurationMs": 424,
      "testRetries": null,
      "workerSizeKib": 4031.76,
      "workerGzipKib": 819.26,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-11T11:36:22.318Z",
      "headSha": "111fcfafab6ff1140d26e90ccaa46b06d71136a6",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/220395161873528",
      "shortSha": "111fcfa",
      "cleanupDurationMs": 727,
      "deployDurationMs": 15263,
      "testDurationMs": 17301,
      "testRetries": null,
      "workerSizeKib": 4803.33,
      "workerGzipKib": 1371.84,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `111fcfa` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 819.3 KiB | 21.0s | 424ms |  | 3.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/220395161873528) | 2026-07-11T11:36:24.557Z | Preview app released. |
| OS | released | `111fcfa` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 4.19 MiB (+0.1 KiB vs main) | 74.9s | 112.5s | 2 retried: catalogue example "journal-is-the-record" runs identically across runtimes (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 11.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/220395161873528) | 2026-07-11T11:36:32.845Z | Preview app released. |
| Semaphore | released | `111fcfa` | [https://semaphore.iterate-preview-8.com](https://semaphore.iterate-preview-8.com) | 440.8 KiB | 14.7s | 6.4s |  | 844ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/220395161873528) | 2026-07-11T11:36:22.428Z | Preview app released. |
| Streams Example App | released | `111fcfa` | [https://streams.iterate-preview-8.com](https://streams.iterate-preview-8.com) | 1.34 MiB | 15.3s | 17.3s |  | 727ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/220395161873528) | 2026-07-11T11:36:22.318Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->