### PR TITLE
Incremental event-type counts: lift the deep-mirror live-tail ceiling

### DIFF
--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -16,6 +16,7 @@ import type { StreamBrowserDatabase } from "~/domains/streams/client-libraries/b
 import { asBrowserStreamClient } from "~/domains/streams/client-libraries/browser/stream-browser-store.ts";
 import {
   BROWSER_RAW_EVENTS_SCHEMA_VERSION,
+  BROWSER_RAW_EVENTS_TABLES,
   BrowserRawEventsContract,
   BrowserRawEventsProcessor,
   type BrowserRawEventsState,
@@ -134,7 +135,7 @@ export function ProjectStreamView({
     streamPath,
     slug: BrowserRawEventsContract.slug,
     schemaVersion: BROWSER_RAW_EVENTS_SCHEMA_VERSION,
-    tables: ["events"],
+    tables: BROWSER_RAW_EVENTS_TABLES,
     Processor: BrowserRawEventsProcessor,
   });
   const { store: feedStore, snapshot: feedSnapshot } = useStreamProcessorStore<BrowserFeedState>({
@@ -148,7 +149,13 @@ export function ProjectStreamView({
     Processor: BrowserFeedProcessor,
   });
 
-  const countResult = useStreamQuery(store.streamDatabase, `SELECT COUNT(*) AS count FROM events`);
+  // Trigger-maintained counts (O(#types)) instead of COUNT(*) (full mirror
+  // scan): this query re-runs after every delivered batch and shares the one
+  // OPFS connection with ingest writes — see the raw-events processor schema.
+  const countResult = useStreamQuery(
+    store.streamDatabase,
+    `SELECT COALESCE(SUM(n), 0) AS count FROM event_type_counts`,
+  );
   const eventCount = Number(countResult.data[0]?.count ?? 0);
   const agentUiState = useAgentUiReducedState(feedStore.streamDatabase);
   const metrics = useSimulatedRttMetrics();

--- a/apps/os/src/components/raw-event-inspector-panel.tsx
+++ b/apps/os/src/components/raw-event-inspector-panel.tsx
@@ -47,9 +47,13 @@ export function RawEventInspectorPanel({
     `SELECT offset, created_at FROM events WHERE offset > ? ORDER BY offset ASC LIMIT 1`,
     [offset],
   );
+  // Offsets are dense (local_index = offset - 1 is a table CHECK), so the
+  // selected event's 1-based position IS its offset; the total comes from the
+  // trigger-maintained counts. The old COUNT(*) range scan re-ran on every
+  // delivered batch while the panel was open and rescanned the mirror.
   const positionResult = useStreamQuery(
     database,
-    `SELECT COUNT(*) AS position, (SELECT COUNT(*) FROM events) AS total FROM events WHERE offset <= ?`,
+    `SELECT ? AS position, (SELECT COALESCE(SUM(n), 0) FROM event_type_counts) AS total`,
     [offset],
   );
 

--- a/apps/os/src/domains/streams/client-libraries/browser/processor-state-storage.test.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/processor-state-storage.test.ts
@@ -222,3 +222,76 @@ describe("browser raw events schema version reset", () => {
     await expect(insert(3)).rejects.toThrow(/append continuously/);
   });
 });
+
+// The event_type_counts table replaces the UI's reactive COUNT(*) full scans
+// (they starve ingest on deep mirrors — see the schema comment). Its one
+// invariant: it always equals what COUNT(*) GROUP BY type would return.
+describe("browser raw events incremental type counts", () => {
+  const typedEvent = (offset: number, type: string): StreamEvent => ({
+    ...rawEvent(offset),
+    type,
+  });
+
+  const countsByType = async (sql: SqlClient) =>
+    Object.fromEntries(
+      (await sql.exec(`SELECT type, n FROM event_type_counts ORDER BY type`)).map((row) => [
+        row.type,
+        Number(row.n),
+      ]),
+    );
+
+  it("tracks per-type counts through ingest, matching COUNT(*)", async () => {
+    const sql = wrap(new DatabaseSync(":memory:"));
+    const processor = createRawEventsProcessor(sql);
+
+    await processor.ingest({
+      events: [typedEvent(1, "a"), typedEvent(2, "b"), typedEvent(3, "a")],
+      streamMaxOffset: 3,
+    });
+    await processor.ingest({ events: [typedEvent(4, "a")], streamMaxOffset: 4 });
+
+    expect(await countsByType(sql)).toEqual({ a: 3, b: 1 });
+    const scanned = await sql.exec(`SELECT type, COUNT(*) AS n FROM events GROUP BY type`);
+    expect(Object.fromEntries(scanned.map((row) => [row.type, Number(row.n)]))).toEqual(
+      await countsByType(sql),
+    );
+  });
+
+  it("does not double-count a replayed duplicate (RAISE IGNORE skips the count trigger)", async () => {
+    const db = new DatabaseSync(":memory:");
+    const firstLoad = createRawEventsProcessor(wrap(db));
+    await firstLoad.ingest({
+      events: [typedEvent(1, "a"), typedEvent(2, "a")],
+      streamMaxOffset: 2,
+    });
+
+    // A fresh page load resumes and the server replays an already-mirrored
+    // offset: the before-insert trigger swallows it, so the count trigger
+    // must never fire for it.
+    const secondLoad = createRawEventsProcessor(wrap(db));
+    await secondLoad.ingest({
+      events: [typedEvent(2, "a"), typedEvent(3, "a")],
+      streamMaxOffset: 3,
+    });
+
+    expect(await countsByType(wrap(db))).toEqual({ a: 3 });
+  });
+
+  it("a schema version reset drops the counts with the mirror", async () => {
+    const db = new DatabaseSync(":memory:");
+    const firstLoad = createRawEventsProcessor(wrap(db));
+    await firstLoad.ingest({ events: [typedEvent(1, "a")], streamMaxOffset: 1 });
+    expect(await countsByType(wrap(db))).toEqual({ a: 1 });
+
+    db.exec(`PRAGMA user_version = ${BROWSER_RAW_EVENTS_SCHEMA_VERSION - 1}`);
+    const secondLoad = createRawEventsProcessor(wrap(db));
+    await secondLoad.ingest({
+      events: [typedEvent(1, "b"), typedEvent(2, "b")],
+      streamMaxOffset: 2,
+    });
+
+    // Only the rebuilt mirror's counts survive; nothing carried over from the
+    // dropped generation.
+    expect(await countsByType(wrap(db))).toEqual({ b: 2 });
+  });
+});

--- a/apps/os/src/domains/streams/client-libraries/processors/browser-raw-events/implementation.ts
+++ b/apps/os/src/domains/streams/client-libraries/processors/browser-raw-events/implementation.ts
@@ -5,7 +5,15 @@ import type { SqlClient, SqlValue } from "../../browser/stream-browser-db.ts";
 import { BrowserRawEventsContract } from "./contract.ts";
 export { BrowserRawEventsContract } from "./contract.ts";
 
-export const BROWSER_RAW_EVENTS_SCHEMA_VERSION = 4;
+export const BROWSER_RAW_EVENTS_SCHEMA_VERSION = 5;
+
+/**
+ * Tables this processor owns. Views pass this to the runtime so a mirror
+ * discard clears the projection AND its derived counts together — clearing
+ * `events` alone would leave stale totals behind (rows are append-only, so
+ * the counts trigger has no delete arm to reconcile them).
+ */
+export const BROWSER_RAW_EVENTS_TABLES = ["events", "event_type_counts"];
 
 export type BrowserRawEventsState = Record<string, never>;
 
@@ -55,7 +63,9 @@ const ensureBrowserRawEventsSchema = createSchemaEnsurer({
       await sql.batch(
         [
           { sql: `DROP TRIGGER IF EXISTS events_before_insert` },
+          { sql: `DROP TRIGGER IF EXISTS events_count_after_insert` },
           { sql: `DROP TABLE IF EXISTS events` },
+          { sql: `DROP TABLE IF EXISTS event_type_counts` },
           { sql: `PRAGMA user_version = ${BROWSER_RAW_EVENTS_SCHEMA_VERSION}` },
         ],
         { transaction: true },
@@ -89,6 +99,39 @@ const ensureBrowserRawEventsSchema = createSchemaEnsurer({
         {
           sql: `
             CREATE INDEX IF NOT EXISTS events_type_local_index ON events (type, local_index)
+          `,
+        },
+        {
+          sql: `
+            -- Incrementally-maintained per-type row counts. The UI's reactive
+            -- count queries (total, per-type, filter dropdown) re-run after
+            -- every delivered batch; COUNT(*) over the events table rescans
+            -- the whole mirror, and because reads and ingest writes share the
+            -- one OPFS connection, those rescans throttle live-tail apply on
+            -- deep mirrors (measured: 1M rows → ~12s tail lag at 5k events/s
+            -- with the counts as full scans). Reading this table is O(#types).
+            --
+            -- Kept correct by events_count_after_insert below. There is no
+            -- delete arm on purpose: mirror rows are append-only, and the only
+            -- delete is the whole-mirror clear, which clears this table in the
+            -- same discard (see BROWSER_RAW_EVENTS_TABLES).
+            CREATE TABLE IF NOT EXISTS event_type_counts (
+              type TEXT PRIMARY KEY,
+              n INTEGER NOT NULL
+            ) WITHOUT ROWID
+          `,
+        },
+        {
+          sql: `
+            -- Fires only for rows that actually insert: a replayed duplicate is
+            -- swallowed by events_before_insert's RAISE(IGNORE) first, so it
+            -- never double-counts.
+            CREATE TRIGGER IF NOT EXISTS events_count_after_insert
+            AFTER INSERT ON events
+            BEGIN
+              INSERT INTO event_type_counts (type, n) VALUES (NEW.type, 1)
+              ON CONFLICT (type) DO UPDATE SET n = n + 1;
+            END
           `,
         },
         {

--- a/apps/streams-example-app/src/routes/-stream-page.tsx
+++ b/apps/streams-example-app/src/routes/-stream-page.tsx
@@ -33,6 +33,7 @@ import {
 import { browserProcessorStateStorage } from "~/domains/streams/client-libraries/browser/processor-state-storage.ts";
 import {
   BROWSER_RAW_EVENTS_SCHEMA_VERSION,
+  BROWSER_RAW_EVENTS_TABLES,
   BrowserRawEventsContract,
   BrowserRawEventsProcessor,
   type BrowserRawEventsState,
@@ -204,7 +205,7 @@ function useStreamProcessor(
 const RAW_EVENTS_RUNTIME: BrowserProcessorConfig = {
   slug: BrowserRawEventsContract.slug,
   schemaVersion: BROWSER_RAW_EVENTS_SCHEMA_VERSION,
-  tables: ["events"],
+  tables: BROWSER_RAW_EVENTS_TABLES,
   createProcessor({ stream, path, projectId, sql, subscriptionKey }) {
     const storage = browserProcessorStateStorage<BrowserRawEventsState>({
       sql,
@@ -233,17 +234,24 @@ function useRawEventsView(args: {
     streamProjectId: args.streamProjectId,
     ...RAW_EVENTS_RUNTIME,
   });
-  const totalCountResult = useStreamQuery(db, `SELECT COUNT(*) AS count FROM events`);
+  // Counts come from the trigger-maintained event_type_counts table, not
+  // COUNT(*) over the mirror: these queries re-run reactively after every
+  // delivered batch, and a full-scan count on a deep mirror starves the shared
+  // OPFS connection that ingest writes ride on (see the processor's schema).
+  const totalCountResult = useStreamQuery(
+    db,
+    `SELECT COALESCE(SUM(n), 0) AS count FROM event_type_counts`,
+  );
   const countResult = useStreamQuery(
     db,
     args.eventTypeFilter === ""
-      ? `SELECT COUNT(*) AS count FROM events`
-      : `SELECT COUNT(*) AS count FROM events WHERE type = ?`,
+      ? `SELECT COALESCE(SUM(n), 0) AS count FROM event_type_counts`
+      : `SELECT COALESCE(SUM(n), 0) AS count FROM event_type_counts WHERE type = ?`,
     args.eventTypeFilter === "" ? [] : [args.eventTypeFilter],
   );
   const eventTypesResult = useStreamQuery(
     db,
-    `SELECT type, COUNT(*) AS count FROM events GROUP BY type ORDER BY type ASC`,
+    `SELECT type, n AS count FROM event_type_counts ORDER BY type ASC`,
   );
   const eventCount = Number(countResult.data[0]?.count ?? 0);
   const totalEventCount = Number(totalCountResult.data[0]?.count ?? 0);


### PR DESCRIPTION
## What

Implements (and will prove, in comments below) the optimization candidate from #1870: the stream views' reactive count queries were O(N) scans over the `events` mirror, re-run after every delivered batch on the same single OPFS connection ingest writes ride — so on deep mirrors, counting throttled ingesting.

**Measured cost of the old reactive set at 1M rows** (native `node:sqlite`; wa-sqlite over OPFS is several times slower):

| Query | per run |
| --- | --- |
| `SELECT type, COUNT(*) … GROUP BY type` (filter dropdown) | **30.6ms** |
| `SELECT COUNT(*) … WHERE offset <= ?` (inspector position) | **13.5ms** |
| `SELECT COUNT(*) FROM events` (total; SQLite fast-path) | 0.09ms |
| new: `SELECT … FROM event_type_counts` (any of them) | **~0.00ms** |

With change notifications every 16ms during ingest, the GROUP BY alone could consume the whole connection budget — this is why the 1M-deep mirror in #1870's findings capped at ~2.3k events/s ingest with 12s tail lag under a 5k/s offered rate (tripping the flow-control valve), while a shallow mirror kept pace at 73ms lag.

## How

A `event_type_counts(type, n)` table maintained by an `AFTER INSERT` trigger **in the same insert transaction** — zero extra round trips, and replayed duplicates never count because the existing continuity trigger `RAISE(IGNORE)`s them before insert. Mirror rows are append-only and the only delete is the whole-mirror discard, which clears both tables together (`BROWSER_RAW_EVENTS_TABLES`), so there is deliberately no delete arm. Schema v4 → v5 rebuilds mirrors on next load. Both apps' views read the counts table; the inspector's position is the offset itself (offsets are dense by table CHECK).

## Correctness pins

- New unit tests: counts always equal `COUNT(*) GROUP BY type` through batched ingest; replay-dedupe doesn't double-count; a schema-version reset drops counts with the mirror.
- The exact-count playwright pins from #1870 (kill-DO-twice-mid-blast = exactly 3000, multi-tab convergence = exactly 2000, cold-open deep stream = exactly 5000) now read through the counts table end-to-end.
- Note: `event type filter…` and `random bulk insert…` specs fail on my machine **identically on a clean checkout** (pre-existing local-env exact-count flake; verified by stash/run/pop). Preview CI is the gate.

## Proof plan (results to follow as comments)

Re-run #1870's deep-mirror battery against this PR's preview: 1M-event stream, sustained 5k events/s live tail — before this PR the mirror collapsed to ~2.3k/s with 12s lag and a valve trip; the target is keeping pace like the shallow case. Plus 1M cold-replay wall time (206s before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema v5 rebuilds local mirrors on upgrade and count correctness depends on trigger + discard semantics; wrong totals or stale counts would affect filters and headers but not server data.
> 
> **Overview**
> Replaces reactive **`COUNT(*)`** scans over the browser `events` mirror with reads from an **`event_type_counts`** table kept in sync by an **`AFTER INSERT`** trigger on each real insert (replayed duplicates still skip via the existing **`RAISE(IGNORE)`** path).
> 
> **`BrowserRawEventsProcessor`** bumps schema **v4 → v5**, creates the counts table and trigger, drops them on version reset, and exports **`BROWSER_RAW_EVENTS_TABLES`** so mirror discard clears **`events`** and counts together. OS **`project-stream-view`**, **`raw-event-inspector-panel`** (position = offset; total from **`SUM(n)`**), and the streams example app’s filter/total queries all use the counts table instead of full-table scans.
> 
> Adds unit tests for ingest parity with **`GROUP BY`**, replay dedupe, and schema reset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f29f713498ffb1f90d5be9a05f6fc12d05643a0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +57 -6 | +46 -6 🟩🟩🟩🟩🟥 |
| UI components | +14 -3 | +7 -3 🟩⬜⬜⬜⬜ |
| Tests | +73 -0 | +54 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+144 -9** | **+107 -9** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 5cb886d and f29f713, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-11T11:46:14.511Z",
      "headSha": "f29f713498ffb1f90d5be9a05f6fc12d05643a0f",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/526284343307317",
      "shortSha": "f29f713",
      "cleanupDurationMs": 10921,
      "deployDurationMs": 71785,
      "testDurationMs": 126527,
      "testRetries": "4 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · concurrent long-running ITX scripts all complete (vitest x1) · stream subscribe replays history, tails live appends, and unsubscribes (vitest x1) · state-only stream subscribe pushes initial state immediately, then state after appends (vitest x1)",
      "workerSizeKib": 15906.24,
      "workerGzipKib": 4286.47,
      "mainWorkerGzipKib": 4287.47
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-11T11:46:05.005Z",
      "headSha": "f29f713498ffb1f90d5be9a05f6fc12d05643a0f",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/526284343307317",
      "shortSha": "f29f713",
      "cleanupDurationMs": 1410,
      "deployDurationMs": 14132,
      "testDurationMs": 5206,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-11T11:46:07.538Z",
      "headSha": "f29f713498ffb1f90d5be9a05f6fc12d05643a0f",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/526284343307317",
      "shortSha": "f29f713",
      "cleanupDurationMs": 3934,
      "deployDurationMs": 19042,
      "testDurationMs": 652,
      "testRetries": null,
      "workerSizeKib": 4031.76,
      "workerGzipKib": 819.33,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-11T11:46:05.034Z",
      "headSha": "f29f713498ffb1f90d5be9a05f6fc12d05643a0f",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/526284343307317",
      "shortSha": "f29f713",
      "cleanupDurationMs": 1426,
      "deployDurationMs": 14911,
      "testDurationMs": 16302,
      "testRetries": null,
      "workerSizeKib": 4803.33,
      "workerGzipKib": 1371.84,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `f29f713` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 819.3 KiB | 19.0s | 652ms |  | 3.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/526284343307317) | 2026-07-11T11:46:07.538Z | Preview app released. |
| OS | released | `f29f713` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 4.19 MiB (-1.0 KiB vs main) | 71.8s | 126.5s | 4 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · concurrent long-running ITX scripts all complete (vitest x1) · stream subscribe replays history, tails live appends, and unsubscribes (vitest x1) · state-only stream subscribe pushes initial state immediately, then state after appends (vitest x1) | 10.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/526284343307317) | 2026-07-11T11:46:14.511Z | Preview app released. |
| Semaphore | released | `f29f713` | [https://semaphore.iterate-preview-5.com](https://semaphore.iterate-preview-5.com) | 440.8 KiB | 14.1s | 5.2s |  | 1.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/526284343307317) | 2026-07-11T11:46:05.005Z | Preview app released. |
| Streams Example App | released | `f29f713` | [https://streams.iterate-preview-5.com](https://streams.iterate-preview-5.com) | 1.34 MiB | 14.9s | 16.3s |  | 1.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/526284343307317) | 2026-07-11T11:46:05.034Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->