### PR TITLE
docs.search ranks what a cold model means, not what code incidentally contains

### DIFF
--- a/apps/os/src/domains/itx/itx-api-graph.test.ts
+++ b/apps/os/src/domains/itx/itx-api-graph.test.ts
@@ -8,6 +8,7 @@ import {
   mountDeclaration,
   referencedPlatformTypeNames,
   searchScore,
+  weightedDeclarationScore,
   typeSlice,
 } from "./itx-api-graph.ts";
 
@@ -70,6 +71,30 @@ describe("typeSlice", () => {
     const a = typeSlice({ declarations: byName, rootName: "Agent", maxTokens: 2_000 });
     const b = typeSlice({ declarations: byName, rootName: "Agent", maxTokens: 2_000 });
     expect(a.sourceText).toBe(b.sourceText);
+  });
+});
+
+describe("weightedDeclarationScore", () => {
+  test("counts name/summary words fully and member-only words half", () => {
+    expect(
+      weightedDeclarationScore({
+        query: "stream append events",
+        ownText: "Stream One durable event stream",
+        memberText: "append appends events to the stream",
+      }),
+    ).toBe(2); // "stream" in own text (1), "append" + "events" member-only (0.5 each)
+  });
+
+  test("keeps hub declarations from matching wholesale on member text", () => {
+    // Every query word landing ONLY in member summaries scores half per
+    // word — a hub type no longer beats an example whose title matches.
+    expect(
+      weightedDeclarationScore({
+        query: "send message agent",
+        ownText: "Project the root project surface",
+        memberText: "agents send message to an agent streams repos",
+      }),
+    ).toBe(1.5);
   });
 });
 

--- a/apps/os/src/domains/itx/itx-api-graph.ts
+++ b/apps/os/src/domains/itx/itx-api-graph.ts
@@ -323,3 +323,32 @@ export function searchScore(query: string, haystack: string): number {
   }
   return score;
 }
+
+/**
+ * Per-word declaration relevance: full credit for words in the declaration's
+ * own name/summary, half credit for words found only in its members' text.
+ * Keeps hub declarations (whose member text matches almost anything) from
+ * crowding examples out of docs.search results.
+ */
+export function weightedDeclarationScore(input: {
+  query: string;
+  ownText: string;
+  memberText: string;
+}): number {
+  const own = input.ownText.toLowerCase();
+  const members = input.memberText.toLowerCase();
+  const words = [
+    ...new Set(
+      input.query
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter(Boolean),
+    ),
+  ];
+  let score = 0;
+  for (const word of words) {
+    if (own.includes(word)) score += 1;
+    else if (members.includes(word)) score += 0.5;
+  }
+  return score;
+}

--- a/apps/os/src/itx/browser-repl.test.ts
+++ b/apps/os/src/itx/browser-repl.test.ts
@@ -443,7 +443,7 @@ const persisted = answer();
       ids.add(example.id);
       expect(example.title.length).toBeGreaterThan(0);
       expect(example.description.length).toBeGreaterThan(0);
-      expect(["project", "session"]).toContain(example.context);
+      expect(["agent", "project", "session"]).toContain(example.context);
       expect(example.runtimes.length).toBeGreaterThan(0);
       // The statement compiler must accept the snippet — this catches
       // transform bugs around nested template literals, top-level classes,

--- a/apps/os/src/itx/examples.ts
+++ b/apps/os/src/itx/examples.ts
@@ -46,10 +46,13 @@ export type ItxExample = {
    * the docs door words its provenance claim from it.
    */
   e2eProven?: false;
-  /** The handle the snippet expects: a project itx (the normal case) or the
-   * OS Session — what authenticate() returns, not an itx (__describe /
-   * projects.list only). */
-  context: "project" | "session";
+  /** The handle the snippet expects: a project itx (the normal case), an
+   * AGENT itx (the project surface plus the agent's own mounts — chat,
+   * workspace, agent; the docs door serves these too since agents are its
+   * main audience, but the unattended matrix skips them: they need a live
+   * conversation), or the OS Session — what authenticate() returns, not an
+   * itx (__describe / projects.list only). */
+  context: "agent" | "project" | "session";
   description: string;
   id: string;
   /** Runtimes the snippet runs unattended in (the e2e matrix honors this). */
@@ -702,9 +705,9 @@ return { record }; // ["capability-provided", "capability-revoked"]
   },
   {
     id: "agent-send-message",
-    title: "Send a message to an agent",
+    title: "Send a message to an agent (also how you create one)",
     description:
-      "Agents live at /agents/<name> and are addressed through itx.agents.get(path). message() appends the unified message-received event to the agent's stream and returns it — the sender is derived from your scope; the agent's processors take it from there (use agent.ask({ message }) to wait for the reply when the agent has a model configured).",
+      "Agents live at /agents/<name> and are addressed through itx.agents.get(path). message() appends the unified message-received event to the agent's stream and returns it — the sender is derived from your scope; the agent's processors take it from there (use agent.ask({ message }) to wait for the reply when the agent has a model configured). This is ALSO how you create, spawn, or birth a new child agent / subagent to delegate work to: messaging a fresh /agents/** path births that agent with default policy — put everything the child needs in the message.",
     context: "project",
     runtimes: ALL_RUNTIMES,
     code: `
@@ -746,6 +749,30 @@ return {
   examplePasteReady: example.startsWith("async (itx) => {") && example.includes("// EXAMPLE"),
   streamTypesIncludeAppend: streamTypes.includes("append("),
 };
+`.trim(),
+  },
+  {
+    id: "chat-message-with-files",
+    e2eProven: false,
+    title: "Send a chat message with an attached image or file",
+    description:
+      "itx.chat.sendMessage accepts attachments: files: [{ filename, contentType, data }] where data is a Blob, Uint8Array, or base64 string (what itx.ai.run image models return). One call stores the bytes in project file storage AND attaches them to the message — attached images render inline in the chat and stay visible to you on later turns. Agent-scope only (itx.chat is the agent's conversation); needs a live agent conversation to observe, so run it interactively.",
+    context: "agent",
+    runtimes: ALL_RUNTIMES,
+    code: `
+// vars.data can be raw bytes or a base64 string — e.g. the b64_json an
+// ai-generate-image run returned. NEVER paste base64 into message text;
+// attach it and let the platform store + render it.
+const sent = await itx.chat.sendMessage(vars.caption ?? "Here you go!", {
+  files: [
+    {
+      filename: vars.filename ?? "picture.png",
+      contentType: vars.contentType ?? "image/png",
+      data: vars.data ?? new Blob(["hello from the examples catalogue"]),
+    },
+  ],
+});
+return { offset: sent.offset, type: sent.type };
 `.trim(),
   },
   {

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -4990,7 +4990,9 @@ class ItxDocsRpcTarget extends IterateRpcTarget<"Docs"> {
       if (score === 0) continue;
       scored.push({
         score,
-        proven: example.e2eProven,
+        // e2eProven?: false — ABSENT means proven (the matrix runs it);
+        // explicit false means interactive-only.
+        proven: example.e2eProven !== false,
         hit: {
           kind: "example",
           name: example.id,

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -151,6 +151,7 @@ import {
   firstSentence,
   mountDeclaration,
   searchScore,
+  weightedDeclarationScore,
   typeSlice,
   type DocsSearchHit,
 } from "./domains/itx/itx-api-graph.ts";
@@ -4926,7 +4927,10 @@ export class StreamProcessorRpcTarget<
 // agents and scripts browse known-good snippets instead of guessing at the
 // surface. Session-context entries are excluded: they run against the OS
 // Session (what authenticate() returns), which an itx holder does not have.
-const PROJECT_CONTEXT_EXAMPLES = ITX_EXAMPLES.filter((example) => example.context === "project");
+// Project AND agent context: the docs door answers agents above all, and an
+// agent itx is the project surface plus its own mounts. Session-only
+// examples stay out — a project/agent scope cannot run them.
+const PROJECT_CONTEXT_EXAMPLES = ITX_EXAMPLES.filter((example) => example.context !== "session");
 
 /**
  * The docs door: search + fetch over everything callable from this scope —
@@ -4974,16 +4978,19 @@ class ItxDocsRpcTarget extends IterateRpcTarget<"Docs"> {
    * field is the literal next call to make.
    */
   async search(input: { q: string }): Promise<DocsSearchHit[]> {
-    const scored: Array<{ hit: DocsSearchHit; score: number }> = [];
+    const scored: Array<{ hit: DocsSearchHit; score: number; proven?: boolean }> = [];
 
     for (const example of PROJECT_CONTEXT_EXAMPLES) {
-      const score = searchScore(
-        input.q,
-        `${example.id} ${example.title} ${example.description} ${example.code}`,
-      );
+      // Prose only, no code: code tokens made incidental matches (a fake
+      // capability demo containing "create"/"message" in its script) outrank
+      // the example whose TITLE says what the searcher wants. Recall for
+      // API-name queries still works — ids/titles/descriptions name their
+      // subjects, and type declarations cover the rest.
+      const score = searchScore(input.q, `${example.id} ${example.title} ${example.description}`);
       if (score === 0) continue;
       scored.push({
         score,
+        proven: example.e2eProven,
         hit: {
           kind: "example",
           name: example.id,
@@ -4997,10 +5004,16 @@ class ItxDocsRpcTarget extends IterateRpcTarget<"Docs"> {
       const memberText = Object.entries(declaration.memberSummaries)
         .map(([member, summary]) => `${member} ${summary}`)
         .join(" ");
-      const score = searchScore(
-        input.q,
-        `${declaration.name} ${declaration.summary} ${memberText}`,
-      );
+      // Hub declarations (Project, Docs, ...) carry every member's summary in
+      // their haystack and would match almost any query wholesale, crowding
+      // the examples out of the one screenful of hits. A word landing in the
+      // declaration's own name/summary counts fully; a member-only match
+      // counts half.
+      const score = weightedDeclarationScore({
+        query: input.q,
+        ownText: `${declaration.name} ${declaration.summary}`,
+        memberText,
+      });
       if (score === 0) continue;
       scored.push({
         score,
@@ -5044,6 +5057,10 @@ class ItxDocsRpcTarget extends IterateRpcTarget<"Docs"> {
         (a, b) =>
           b.score - a.score ||
           kindRank[a.hit.kind] - kindRank[b.hit.kind] ||
+          // Proven examples (run unattended against a live project on every
+          // change) outrank interactive-only ones — alphabetical order was
+          // deciding real ties before.
+          Number(b.proven ?? false) - Number(a.proven ?? false) ||
           a.hit.name.localeCompare(b.hit.name),
       )
       .slice(0, 12)
@@ -5112,6 +5129,19 @@ class ItxDocsRpcTarget extends IterateRpcTarget<"Docs"> {
       return typeSlice({
         declarations: ITX_API_DECLARATIONS_BY_NAME,
         rootName: input.name,
+        maxTokens,
+      }).sourceText;
+    }
+    // A builtin's itx member name ("docs", "workspace") is the natural thing
+    // to ask for after __describe(); resolve it to its declaration ("Docs")
+    // instead of erroring with unrelated closest-matches.
+    const caseInsensitive = [...ITX_API_DECLARATIONS_BY_NAME.keys()].find(
+      (name) => name.toLowerCase() === input.name.toLowerCase(),
+    );
+    if (caseInsensitive !== undefined) {
+      return typeSlice({
+        declarations: ITX_API_DECLARATIONS_BY_NAME,
+        rootName: caseInsensitive,
         maxTokens,
       }).sourceText;
     }


### PR DESCRIPTION
Fixes the four `itx.docs` ranking flaws from the prd docs-door audit (a subagent running the system prompt's own recipes cold), each reproduced live before fixing:

1. **Code tokens polluted the haystack**: `q: "slack post message channel notify"` ranked `provide-live-flattened` (the `itx.fakeSlack` capability-provider demo) *above* `slack-post-message`, purely on incidental code tokens — a cold model pastes a script that mounts a fake echo capability. Examples now score on id/title/description only.
2. **Hub declarations matched wholesale**: `Project`'s haystack is every member summary, so it was #1 for "birth agent spawn subagent…" and #2 for the gmail query, crowding examples out of the 12-hit screenful. Member-only word matches now count half (`weightedDeclarationScore`, unit-tested beside `searchScore`).
3. **Ties broke alphabetically**: proven examples (run unattended against a live project on every change) now outrank interactive-only ones at equal score.
4. **`docs.get({ name: "docs" })`** errored with `ai-generate-audio, ai-generate-image, ai-generate-video` as "closest matches". Builtin member names now resolve case-insensitively to their declaration (`docs` → `Docs`).

Plus the two catalogue gaps the audit hit:
- **"create a child agent" was undiscoverable**: no natural phrasing (create/spawn/birth/subagent/delegate) surfaced `agent-send-message`, the platform's own idiom (messaging a fresh `/agents/**` path births the agent). Its title/description now say so in the words users use.
- **New `chat-message-with-files` example** for the send-an-image task (top hits were type declarations only). Introduces `context: "agent"` — served by the docs door (agents are its main audience; an agent itx is the project surface plus its own mounts) but skipped by the unattended e2e matrix (needs a live conversation).

Verified: 2 new scorer unit tests; 1045 apps/os tests green; typecheck/lint clean. Post-merge I'll rerun the audit's failing queries against prd to confirm the rankings flipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Search ranking and docs lookup behavior changes are localized to the docs door and example metadata; no auth, data migration, or breaking API contracts.
> 
> **Overview**
> **`itx.docs.search`** is tuned so cold agents see the right examples first: example hits score only on id/title/description (not script code), type hits use **`weightedDeclarationScore`** (full weight on declaration name/summary, half on member-only text), and at equal score **e2e-proven** examples beat interactive-only ones. **`docs.get`** now resolves builtin member names case-insensitively to their declaration (e.g. `docs` → `Docs`).
> 
> The examples catalogue adds **`context: "agent"`** (docs door serves agent + project examples; session-only stay excluded), a new **`chat-message-with-files`** snippet, and clearer **agent-send-message** copy for create/spawn/birth/subagent discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54be66338180a68e2090f973d43d930ad85107b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +104 -16 | +70 -13 🟩🟩🟩🟩🟥 |
| Tests | +26 -1 | +22 -1 🟩⬜⬜⬜⬜ |
| **Total** | **+130 -17** | **+92 -14** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 1a7caef and 54be663, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-11T11:48:20.293Z",
      "headSha": "54be66338180a68e2090f973d43d930ad85107b8",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/572811967499140",
      "shortSha": "54be663",
      "cleanupDurationMs": 9061,
      "deployDurationMs": 67761,
      "testDurationMs": 153523,
      "testRetries": "2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · the seeded hello and counter apps work after creating a project (specs x1)",
      "workerSizeKib": 15911.31,
      "workerGzipKib": 4288.09,
      "mainWorkerGzipKib": 4288.46
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-11T11:48:12.163Z",
      "headSha": "cec28dddef3366c3f6547114285500d650e881ae",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/378467066073589",
      "shortSha": "cec28dd",
      "cleanupDurationMs": 928,
      "deployDurationMs": 13668,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-11T11:48:14.508Z",
      "headSha": "54be66338180a68e2090f973d43d930ad85107b8",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/572811967499140",
      "shortSha": "54be663",
      "cleanupDurationMs": 3271,
      "deployDurationMs": 17657,
      "testDurationMs": 486,
      "testRetries": null,
      "workerSizeKib": 4031.76,
      "workerGzipKib": 819.4,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-11T11:48:12.113Z",
      "headSha": "cec28dddef3366c3f6547114285500d650e881ae",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/378467066073589",
      "shortSha": "cec28dd",
      "cleanupDurationMs": 874,
      "deployDurationMs": 16041,
      "workerSizeKib": 4807.89,
      "workerGzipKib": 1373.33,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `54be663` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 819.4 KiB | 17.7s | 486ms |  | 3.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/572811967499140) | 2026-07-11T11:48:14.508Z | Preview app released. |
| OS | released | `54be663` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.19 MiB (-0.4 KiB vs main) | 67.8s | 153.5s | 2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · the seeded hello and counter apps work after creating a project (specs x1) | 9.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/572811967499140) | 2026-07-11T11:48:20.293Z | Preview app released. |
| Semaphore | released | `cec28dd` | [https://semaphore.iterate-preview-3.com](https://semaphore.iterate-preview-3.com) | 440.8 KiB | 13.7s |  |  | 928ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/378467066073589) | 2026-07-11T11:48:12.163Z | Preview app released. |
| Streams Example App | released | `cec28dd` | [https://streams.iterate-preview-3.com](https://streams.iterate-preview-3.com) | 1.34 MiB | 16.0s |  |  | 874ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/378467066073589) | 2026-07-11T11:48:12.113Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->