### PR TITLE
Typecheck script-execution-requested itx blocks before running them

### DIFF
--- a/apps/os/src/domains/capability-host/capability-host-durable-object.ts
+++ b/apps/os/src/domains/capability-host/capability-host-durable-object.ts
@@ -10,7 +10,7 @@ import type {
 } from "../streams/rpc-types.ts";
 import { StreamProcessorRpcTarget } from "../../rpc-targets.ts";
 import { itxForScope, StreamRpcTarget } from "../../rpc-targets.ts";
-import { checkCapabilityTypes } from "../typecheck/virtual-project.ts";
+import { checkCapabilityTypes, checkItxScriptForExecution } from "../typecheck/virtual-project.ts";
 import {
   CapabilityHostProcessor,
   type ParentCapabilityHost,
@@ -69,6 +69,8 @@ export class CapabilityHostDurableObject extends DurableObject<Env> {
         scriptExecutionEntrypoint: this.#scriptExecutionEntrypoint(),
         validateCapabilityTypes: (types) =>
           checkCapabilityTypes({ types, typechecker: this.env.TYPECHECKER }),
+        typecheckScript: (input) =>
+          checkItxScriptForExecution({ ...input, typechecker: this.env.TYPECHECKER }),
       }),
   );
 

--- a/apps/os/src/domains/capability-host/capability-host-processor-contract.ts
+++ b/apps/os/src/domains/capability-host/capability-host-processor-contract.ts
@@ -132,7 +132,7 @@ export const CapabilityHostProcessorContract = defineProcessorContract({
     },
     "events.iterate.com/capability-host/script-execution-requested": {
       description:
-        "A script should run in this capability scope. Before any attempt starts, the code is typechecked against the scope's capability types: a script that provably mis-calls a typed surface settles straight to an error completion carrying the compiler errors, without ever running (no started event). The check is permissive — unknown/untyped capabilities, non-async block shapes, and checker failures all let the script run unchecked.",
+        "A script should run in this capability scope. Before any attempt starts, the code is typechecked against the scope's capability types: a script with a PROVABLE error — a syntax error, or a near-miss typo where the compiler names the fix (\"Did you mean 'get'?\") — settles straight to an error completion carrying the compiler errors, without ever running (no started event). Everything less certain runs: capabilities are provided dynamically and declared types can lag the runtime, so bare property/argument mismatches, unknown/untyped capabilities, non-async block shapes, and checker failures all let the script run unchecked.",
       payloadSchema: z.looseObject({
         code: z.string(),
         executionId: z.string(),

--- a/apps/os/src/domains/capability-host/capability-host-processor-contract.ts
+++ b/apps/os/src/domains/capability-host/capability-host-processor-contract.ts
@@ -131,7 +131,8 @@ export const CapabilityHostProcessorContract = defineProcessorContract({
       ],
     },
     "events.iterate.com/capability-host/script-execution-requested": {
-      description: "A script should run in this capability scope.",
+      description:
+        "A script should run in this capability scope. Before any attempt starts, the code is typechecked against the scope's capability types: a script that provably mis-calls a typed surface settles straight to an error completion carrying the compiler errors, without ever running (no started event). The check is permissive — unknown/untyped capabilities, non-async block shapes, and checker failures all let the script run unchecked.",
       payloadSchema: z.looseObject({
         code: z.string(),
         executionId: z.string(),

--- a/apps/os/src/domains/capability-host/capability-host-processor-implementation.ts
+++ b/apps/os/src/domains/capability-host/capability-host-processor-implementation.ts
@@ -7,6 +7,7 @@ import type { CapabilityDescription } from "../itx/describe.ts";
 import type { StreamEvent } from "../streams/schemas.ts";
 import type { JsonValue } from "../workers/schemas.ts";
 import type { CapabilityHost, Project } from "../../itx-api.generated.ts";
+import type { ScriptExecutionCheck } from "../typecheck/virtual-project.ts";
 import type {
   CapabilityProvidedPayload,
   CapabilityRecord,
@@ -131,6 +132,12 @@ export class CapabilityHostProcessor extends StreamProcessor<CapabilityHostProce
   #now: (() => number) | undefined;
   #parent: ParentCapabilityHost | undefined;
   #validateCapabilityTypes: ((types: string) => Promise<string[]>) | undefined;
+  #typecheckScript:
+    | ((input: {
+        capabilities: CapabilityDescription[];
+        code: string;
+      }) => Promise<ScriptExecutionCheck>)
+    | undefined;
   #liveCapabilities = new Map<string, LiveCapability>();
 
   constructor(
@@ -151,6 +158,16 @@ export class CapabilityHostProcessor extends StreamProcessor<CapabilityHostProce
        * test harness runs without one, which skips validation.
        */
       validateCapabilityTypes?: (types: string) => Promise<string[]>;
+      /**
+       * Pre-execution typecheck of a requested script against this scope's
+       * capability types (checkItxScriptForExecution in production; absent in
+       * the node test harness, which skips the gate). Only a `problems`
+       * verdict blocks the run — see ScriptExecutionCheck.
+       */
+      typecheckScript?: (input: {
+        capabilities: CapabilityDescription[];
+        code: string;
+      }) => Promise<ScriptExecutionCheck>;
     },
   ) {
     super(args);
@@ -160,6 +177,7 @@ export class CapabilityHostProcessor extends StreamProcessor<CapabilityHostProce
     this.#now = args.now;
     this.#parent = args.parent;
     this.#validateCapabilityTypes = args.validateCapabilityTypes;
+    this.#typecheckScript = args.typecheckScript;
   }
 
   protected override reduce({
@@ -260,7 +278,15 @@ export class CapabilityHostProcessor extends StreamProcessor<CapabilityHostProce
       if (this.#liveExecutions.has(executionId)) continue;
       if (execution.status === "requested" && now < execution.expiresAt) {
         this.#liveExecutions.add(executionId);
-        args.runInBackground(() => this.#executeScript({ code: execution.code, executionId }));
+        // The batch's own fold, NOT this.state: the durable checkpoint (and
+        // the state getter behind it) advances only after this hook returns,
+        // and the typecheck gate must see capabilities provided in the same
+        // batch as the request or it would judge the script against a stale
+        // scope.
+        const capabilities = args.state.capabilities;
+        args.runInBackground(() =>
+          this.#executeScript({ capabilities, code: execution.code, executionId }),
+        );
         continue;
       }
       settle.push({
@@ -520,8 +546,12 @@ export class CapabilityHostProcessor extends StreamProcessor<CapabilityHostProce
   // declared at. A nearer scope shadows a farther one at the same path (same rule
   // as `resolveLongestPrefix` above), so the caller — usually an LLM deciding what
   // it can invoke — sees exactly one entry per reachable path and where it lives.
-  async describeCapabilities(): Promise<CapabilityDescription[]> {
-    const local: CapabilityDescription[] = this.state.capabilities.map((record) => ({
+  describeCapabilities(): Promise<CapabilityDescription[]> {
+    return this.#describeCapabilitiesFrom(this.state.capabilities);
+  }
+
+  async #describeCapabilitiesFrom(records: CapabilityRecord[]): Promise<CapabilityDescription[]> {
+    const local: CapabilityDescription[] = records.map((record) => ({
       instructions: record.instructions,
       path: record.path,
       providedAtOffset: record.providedAtOffset,
@@ -564,8 +594,48 @@ export class CapabilityHostProcessor extends StreamProcessor<CapabilityHostProce
     return completed;
   }
 
-  async #executeScript(input: { code: string; executionId: string }) {
+  /**
+   * The pre-execution typecheck gate: a script whose OWN code provably
+   * mis-calls a typed surface settles as an error completion without running
+   * — the model reads compiler errors instead of paying a failed run.
+   * Permissive everywhere the checker lacks knowledge (unknown types,
+   * unchecked verdicts, checker failures): the gate may only ever block on
+   * proof. Returns the completion error, or null to proceed.
+   */
+  async #typecheckRejection(code: string, records: CapabilityRecord[]): Promise<string | null> {
+    const typecheckScript = this.#typecheckScript;
+    if (typecheckScript === undefined) return null;
     try {
+      const capabilities = await this.#describeCapabilitiesFrom(records);
+      const checked = await typecheckScript({ capabilities, code });
+      if (checked.verdict !== "problems") return null;
+      return [
+        "Script was NOT executed: it does not typecheck against this scope's capability types.",
+        ...checked.problems,
+        "Fix the type errors and resend the whole corrected script.",
+      ].join("\n");
+    } catch (error) {
+      // The gate must never fail a script for the checker's own failure — an
+      // unreachable sidecar or a parent-scope dial error means unchecked.
+      console.warn("[capability-host] script typecheck skipped", { error });
+      return null;
+    }
+  }
+
+  async #executeScript(input: {
+    capabilities: CapabilityRecord[];
+    code: string;
+    executionId: string;
+  }) {
+    try {
+      // The typecheck gate runs BEFORE the started evidence: it has no side
+      // effects, so a rejected script provably never ran (requested →
+      // completed, no started event) and the reconciler doctrine is untouched.
+      const rejection = await this.#typecheckRejection(input.code, input.capabilities);
+      if (rejection !== null) {
+        await this.#appendCompletion({ executionId: input.executionId, error: rejection });
+        return;
+      }
       // Started-evidence lands durably BEFORE the script body runs, so the
       // fold can always tell "provably never ran" (requested, startable late)
       // from "may have half-run" (started, settle-only). Deliberately OUTSIDE

--- a/apps/os/src/domains/capability-host/capability-host-processor-implementation.ts
+++ b/apps/os/src/domains/capability-host/capability-host-processor-implementation.ts
@@ -595,12 +595,13 @@ export class CapabilityHostProcessor extends StreamProcessor<CapabilityHostProce
   }
 
   /**
-   * The pre-execution typecheck gate: a script whose OWN code provably
-   * mis-calls a typed surface settles as an error completion without running
-   * — the model reads compiler errors instead of paying a failed run.
-   * Permissive everywhere the checker lacks knowledge (unknown types,
-   * unchecked verdicts, checker failures): the gate may only ever block on
-   * proof. Returns the completion error, or null to proceed.
+   * The pre-execution typecheck gate: a script whose OWN code carries a
+   * provable error (a syntax error, a near-miss typo the compiler can name
+   * the fix for) settles as an error completion without running — the model
+   * reads compiler errors instead of paying a failed run. Permissive
+   * everywhere the checker lacks knowledge (unknown types, unchecked
+   * verdicts, checker failures): the gate may only ever block on proof.
+   * Returns the completion error, or null to proceed.
    */
   async #typecheckRejection(code: string, records: CapabilityRecord[]): Promise<string | null> {
     const typecheckScript = this.#typecheckScript;

--- a/apps/os/src/domains/capability-host/script-execution-typecheck.test.ts
+++ b/apps/os/src/domains/capability-host/script-execution-typecheck.test.ts
@@ -1,0 +1,213 @@
+// The pre-execution typecheck gate: a `problems` verdict settles the request
+// as an error completion WITHOUT running it (and without a started event —
+// the gate has no side effects, so a rejected script provably never ran);
+// every other outcome — clean, unchecked, a throwing checker, no checker
+// wired at all — lets the script run. The verdict policy itself (what counts
+// as a provable problem) lives in checkItxScriptForExecution and is tested
+// against the real compiler in domains/typecheck/virtual-project.test.ts;
+// here the checker is a stub and the subject is the gate's plumbing.
+
+import { describe, expect, it, vi } from "vitest";
+import type { Project } from "../../itx-api.generated.ts";
+import type { CapabilityDescription } from "../itx/describe.ts";
+import type { ScriptExecutionCheck } from "../typecheck/virtual-project.ts";
+import { MemoryStream } from "../streams/test-helpers.ts";
+import {
+  CapabilityHostProcessor,
+  type ParentCapabilityHost,
+} from "./capability-host-processor-implementation.ts";
+
+const T = {
+  provided: "events.iterate.com/capability-host/capability-provided",
+  requested: "events.iterate.com/capability-host/script-execution-requested",
+  started: "events.iterate.com/capability-host/script-execution-started",
+  completed: "events.iterate.com/capability-host/script-execution-completed",
+} as const;
+
+function makeProcessor(options: {
+  stream: MemoryStream;
+  run?: (code: string) => Promise<unknown>;
+  parent?: ParentCapabilityHost;
+  typecheckScript?: (input: {
+    capabilities: CapabilityDescription[];
+    code: string;
+  }) => Promise<ScriptExecutionCheck>;
+}) {
+  return new CapabilityHostProcessor({
+    stream: options.stream,
+    itx: {} as Project,
+    path: "/",
+    projectId: null,
+    parent: options.parent,
+    scriptExecutionEntrypoint: {
+      run:
+        options.run ??
+        (() => {
+          throw new Error("must not run in this scenario");
+        }),
+    },
+    typecheckScript: options.typecheckScript,
+  });
+}
+
+async function requestScript(stream: MemoryStream, processor: CapabilityHostProcessor) {
+  const [requested] = await stream.append({
+    type: T.requested,
+    payload: { code: "async (itx) => itx.streams.gett('/')", executionId: "exec-1" },
+  });
+  await processor.ingest({ events: stream.events, streamMaxOffset: requested!.offset });
+}
+
+function completion(stream: MemoryStream) {
+  return stream.events.find((event) => event.type === T.completed);
+}
+
+describe("script execution typecheck gate", () => {
+  it("a problems verdict settles as an error completion — never started, never run", async () => {
+    const stream = new MemoryStream();
+    const processor = makeProcessor({
+      stream,
+      typecheckScript: async () => ({
+        verdict: "problems",
+        problems: ["script:1:32 — Property 'gett' does not exist. Did you mean 'get'? (TS2551)"],
+      }),
+    });
+    await requestScript(stream, processor);
+
+    await vi.waitFor(() => {
+      const completed = completion(stream);
+      expect(completed?.payload).toMatchObject({
+        executionId: "exec-1",
+        error: expect.stringContaining("NOT executed"),
+      });
+      expect((completed!.payload as { error: string }).error).toContain("Did you mean 'get'");
+      // Shared with the run/settle lanes, so a race collapses to one completion.
+      expect(completed?.idempotencyKey).toBe("capability-host/script-execution-completed@exec-1");
+    });
+    expect(stream.events.some((event) => event.type === T.started)).toBe(false);
+  });
+
+  it("a clean verdict runs the script normally", async () => {
+    const stream = new MemoryStream();
+    const ran: string[] = [];
+    const processor = makeProcessor({
+      stream,
+      run: async (code) => {
+        ran.push(code);
+        return 42;
+      },
+      typecheckScript: async () => ({ verdict: "clean" }),
+    });
+    await requestScript(stream, processor);
+
+    await vi.waitFor(() => {
+      expect(completion(stream)?.payload).toMatchObject({ executionId: "exec-1", result: 42 });
+    });
+    expect(stream.events.some((event) => event.type === T.started)).toBe(true);
+    expect(ran).toHaveLength(1);
+  });
+
+  it("an unchecked verdict runs the script (permissive on unknowns)", async () => {
+    const stream = new MemoryStream();
+    const ran: string[] = [];
+    const processor = makeProcessor({
+      stream,
+      run: async (code) => {
+        ran.push(code);
+        return null;
+      },
+      typecheckScript: async () => ({ verdict: "unchecked", reason: "typechecker unavailable" }),
+    });
+    await requestScript(stream, processor);
+
+    await vi.waitFor(() => expect(completion(stream)).toBeDefined());
+    expect(completion(stream)?.payload).not.toHaveProperty("error");
+    expect(ran).toHaveLength(1);
+  });
+
+  it("a THROWING checker runs the script — the gate must never fail a script for its own failure", async () => {
+    const stream = new MemoryStream();
+    const ran: string[] = [];
+    const processor = makeProcessor({
+      stream,
+      run: async (code) => {
+        ran.push(code);
+        return "ok";
+      },
+      typecheckScript: () => Promise.reject(new Error("sidecar dial failed")),
+    });
+    await requestScript(stream, processor);
+
+    await vi.waitFor(() => {
+      expect(completion(stream)?.payload).toMatchObject({ executionId: "exec-1", result: "ok" });
+    });
+    expect(ran).toHaveLength(1);
+  });
+
+  it("no checker wired (node harness) runs the script", async () => {
+    const stream = new MemoryStream();
+    const ran: string[] = [];
+    const processor = makeProcessor({
+      stream,
+      run: async (code) => {
+        ran.push(code);
+        return "ok";
+      },
+    });
+    await requestScript(stream, processor);
+
+    await vi.waitFor(() => expect(completion(stream)).toBeDefined());
+    expect(ran).toHaveLength(1);
+  });
+
+  it("the checker sees this scope's mounts AND inherited capabilities", async () => {
+    const stream = new MemoryStream();
+    const seen: CapabilityDescription[][] = [];
+    const inherited: CapabilityDescription = {
+      path: ["tools", "weather"],
+      scope: "/",
+      type: "itx-expression",
+      types: "export type Forecast = { forecast(): Promise<string> };",
+    };
+    const processor = makeProcessor({
+      stream,
+      run: async () => null,
+      parent: {
+        invokeCapability: () => Promise.reject(new Error("unused")),
+        describeCapabilities: async () => [inherited],
+      },
+      typecheckScript: async ({ capabilities }) => {
+        seen.push(capabilities);
+        return { verdict: "clean" };
+      },
+    });
+    await stream.append({
+      type: T.provided,
+      payload: { path: ["local"], type: "live", types: "export type Local = { ping(): void };" },
+    });
+    await requestScript(stream, processor);
+
+    await vi.waitFor(() => expect(completion(stream)).toBeDefined());
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.map((capability) => capability.path.join("."))).toEqual(
+      expect.arrayContaining(["local", "tools.weather"]),
+    );
+  });
+
+  it("a rejected execution deletes its obligation — the reconciler never re-runs it", async () => {
+    const stream = new MemoryStream();
+    const processor = makeProcessor({
+      stream,
+      typecheckScript: async () => ({ verdict: "problems", problems: ["script:1 — nope (TS1)"] }),
+    });
+    await requestScript(stream, processor);
+    await vi.waitFor(() => expect(completion(stream)).toBeDefined());
+
+    // Deliver everything again (a later batch after the completion): the fold
+    // holds no obligation, so nothing re-runs and no second completion lands.
+    const last = stream.events.at(-1)!;
+    await processor.ingest({ events: stream.events, streamMaxOffset: last.offset });
+    expect(stream.events.filter((event) => event.type === T.completed)).toHaveLength(1);
+    expect(processor.state.scriptExecutions).toEqual({});
+  });
+});

--- a/apps/os/src/domains/typecheck/virtual-project.test.ts
+++ b/apps/os/src/domains/typecheck/virtual-project.test.ts
@@ -367,11 +367,12 @@ test("execution gate: a wrong call into the typed surface blocks with the caller
   expect(problems[0]).toContain("Did you mean 'get'");
 });
 
-test("execution gate: a typo'd typed-mount call blocks; anything on an untyped mount runs", async () => {
-  const typo = await gate("async (itx) => itx.tools.weather.forecast({ city: 42 })", [
+test("execution gate: a near-miss typo on a typed mount blocks; anything else on mounts runs", async () => {
+  const typo = await gate("async (itx) => itx.tools.weather.forecastt({ city: 'Berlin' })", [
     WEATHER_MOUNT,
   ]);
   expect(typo.verdict).toBe("problems");
+  expect((typo as { problems: string[] }).problems[0]).toContain("Did you mean 'forecast'");
 
   const untyped = await gate("async (itx) => itx.legacy.whatever(1, { deep: true })", [
     { path: ["legacy"], type: "live" },
@@ -379,10 +380,38 @@ test("execution gate: a typo'd typed-mount call blocks; anything on an untyped m
   expect(untyped).toEqual({ verdict: "clean" });
 });
 
-test("execution gate: calling a capability that does not exist at all blocks", async () => {
-  const checked = await gate("async (itx) => itx.nonexistent.doThing()");
-  expect(checked.verdict).toBe("problems");
-  expect((checked as { problems: string[] }).problems[0]).toContain("nonexistent");
+test("execution gate: only NEAR-MISS proof blocks — bare mismatches are unprovable and run", async () => {
+  // The declared surface lags the runtime in places (preview e2e:
+  // CloudflareSandbox.exec exists at runtime but not in types, handle results
+  // declared {}), so property/argument mismatches without a did-you-mean must
+  // never block. These all failed loudly in preview until this policy.
+  for (const code of [
+    // A capability nobody declared — journal-legal via dynamic provides.
+    "async (itx) => itx.nonexistent.doThing()",
+    // Wrong argument type into the platform surface — types may lag runtime.
+    "async (itx) => itx.docs.search(42)",
+    // Wrong argument shape into a typed mount.
+    "async (itx) => itx.tools.weather.forecast({ city: 42 })",
+  ]) {
+    const checked = await gate(code, [WEATHER_MOUNT]);
+    expect(checked, code).toEqual({ verdict: "clean" });
+  }
+});
+
+test("execution gate: provide-then-use in one script stays green (dynamic mounts are invisible to a static check)", async () => {
+  // The canonical catalogue example shape that preview e2e runs: mount a
+  // capability, then call it through the itx proxy two lines later.
+  const checked = await gate(
+    `async (itx) => {
+      await itx.capabilityHost.provideCapability({
+        type: "itx-expression",
+        path: ["demoStream"],
+        expression: ["streams", ["get", "/"]],
+      });
+      return await itx.demoStream.getEvents({ afterOffset: 0, limit: 10 });
+    }`,
+  );
+  expect(checked).toEqual({ verdict: "clean" });
 });
 
 test("execution gate: a stale BROKEN mount never vetoes a script that doesn't deserve it", async () => {
@@ -517,14 +546,15 @@ test("execution gate: runtime idioms that execute fine stay green", async () => 
   }
 });
 
-test("execution gate: genuine script bugs the run would only surface at runtime DO block", async () => {
+test("execution gate: provable script bugs the run would only surface at runtime DO block", async () => {
   const buggy = [
-    // Misspelled local — TS2552/2304 in the script's own code.
+    // Misspelled local with a near-miss — TS2552 names the fix.
     "async (itx) => { const count = 1; return cuont + 1; }",
-    // Wrong argument type into the platform surface.
-    "async (itx) => itx.docs.search(42)",
-    // Syntax error.
+    // Misspelled platform member with a near-miss — TS2551 names the fix.
+    "async (itx) => itx.streams.gett('/')",
+    // Syntax errors — the runtime's loader would reject these anyway.
     "async (itx) => { const = 1; }",
+    "async (itx) => { return JSON.parse('{'; }",
   ];
   for (const code of buggy) {
     const checked = await gate(code);

--- a/apps/os/src/domains/typecheck/virtual-project.test.ts
+++ b/apps/os/src/domains/typecheck/virtual-project.test.ts
@@ -14,6 +14,7 @@ import { runTypecheck, npmPackagesMentioned } from "./run-typecheck.ts";
 import {
   checkCapabilityTypes,
   checkItxScript,
+  checkItxScriptForExecution,
   mountModuleText,
   type Typechecker,
 } from "./virtual-project.ts";
@@ -347,4 +348,186 @@ test("openapi: references materialize at check time — schemas never ride the j
     typechecker,
   });
   expect(broken.some((p) => p.includes("type generation failed"))).toBe(true);
+});
+
+// ─── The execution gate: checkItxScriptForExecution ─────────────────────────
+// Same compiler, different policy: only PROVABLE errors in the script's own
+// code block a run. The suite below is half true-positives, half attempts to
+// break the gate with scripts that run fine at runtime and must not bounce.
+
+async function gate(code: string, capabilities: CapabilityDescription[] = []) {
+  return await checkItxScriptForExecution({ capabilities, code, typechecker });
+}
+
+test("execution gate: a wrong call into the typed surface blocks with the caller's line numbers", async () => {
+  const checked = await gate(`async (itx) => {\n  return await itx.streams.gett("/");\n}`);
+  expect(checked.verdict).toBe("problems");
+  const problems = (checked as { problems: string[] }).problems;
+  expect(problems[0]).toContain("script:2");
+  expect(problems[0]).toContain("Did you mean 'get'");
+});
+
+test("execution gate: a typo'd typed-mount call blocks; anything on an untyped mount runs", async () => {
+  const typo = await gate("async (itx) => itx.tools.weather.forecast({ city: 42 })", [
+    WEATHER_MOUNT,
+  ]);
+  expect(typo.verdict).toBe("problems");
+
+  const untyped = await gate("async (itx) => itx.legacy.whatever(1, { deep: true })", [
+    { path: ["legacy"], type: "live" },
+  ]);
+  expect(untyped).toEqual({ verdict: "clean" });
+});
+
+test("execution gate: calling a capability that does not exist at all blocks", async () => {
+  const checked = await gate("async (itx) => itx.nonexistent.doThing()");
+  expect(checked.verdict).toBe("problems");
+  expect((checked as { problems: string[] }).problems[0]).toContain("nonexistent");
+});
+
+test("execution gate: a stale BROKEN mount never vetoes a script that doesn't deserve it", async () => {
+  const staleMount: CapabilityDescription[] = [
+    { path: ["stale"], type: "live", types: "export type Stale = Goone;" },
+  ];
+  // A clean script in a scope with a rotten journaled declaration runs.
+  expect(await gate("async (itx) => itx.stale.anything()", staleMount)).toEqual({
+    verdict: "clean",
+  });
+  // …but the script's OWN provable errors still block in the same scope.
+  const ownTypo = await gate("async (itx) => itx.streams.gett('/')", staleMount);
+  expect(ownTypo.verdict).toBe("problems");
+});
+
+test("execution gate: unresolved modules never block (acquisition failure ≠ proof)", async () => {
+  // fake-gone 404s in the fake registry — the mount module errors AND the
+  // script's own import errors are both unresolved-module class, so it runs.
+  const checked = await gate('async (itx) => { const m = await import("fake-gone"); return m; }', [
+    { path: ["gone"], type: "itx-expression", types: 'export type G = import("fake-gone").X;' },
+  ]);
+  expect(checked).toEqual({ verdict: "clean" });
+});
+
+test("execution gate: shapes the checker doesn't model run unchecked (raw runScript callers)", async () => {
+  for (const code of [
+    "(itx) => itx.streams.gett('/')", // plain arrow — runtime accepts it
+    "(async function (itx) { return 1; })",
+    "function f(itx) { return 1; }",
+  ]) {
+    const checked = await gate(code);
+    expect(checked.verdict, code).toBe("unchecked");
+  }
+});
+
+test("execution gate: oversized scripts and non-string code run unchecked", async () => {
+  const huge = await gate(`async (itx) => { ${"x;".repeat(150_000)} }`);
+  expect(huge.verdict).toBe("unchecked");
+  const notString = await checkItxScriptForExecution({
+    capabilities: [],
+    code: ["async (itx) => {}"] as unknown as string,
+    typechecker,
+  });
+  expect(notString.verdict).toBe("unchecked");
+});
+
+test("execution gate: a compiler crash and an unreachable checker both run unchecked", async () => {
+  const crashing: Typechecker = {
+    check: (input) =>
+      runTypecheck({
+        compiler: {
+          compile: () => {
+            throw new Error("Worker exceeded memory limit.");
+          },
+        },
+        fetchImpl: () => Promise.reject(new Error("no network")),
+        files: input.files,
+      }),
+  };
+  const crashed = await checkItxScriptForExecution({
+    capabilities: [],
+    code: "async (itx) => {}",
+    typechecker: crashing,
+  });
+  expect(crashed.verdict).toBe("unchecked");
+
+  const unreachable: Typechecker = {
+    check: () => Promise.reject(new Error("sidecar dial failed")),
+  };
+  const failed = await checkItxScriptForExecution({
+    capabilities: [],
+    code: "async (itx) => {}",
+    typechecker: unreachable,
+  });
+  expect(failed.verdict).toBe("unchecked");
+});
+
+test("execution gate: a hanging checker hits the deadline and runs unchecked", async () => {
+  const hanging: Typechecker = { check: () => new Promise(() => {}) };
+  const checked = await checkItxScriptForExecution({
+    capabilities: [],
+    code: "async (itx) => {}",
+    deadlineMs: 25,
+    typechecker: hanging,
+  });
+  expect(checked.verdict).toBe("unchecked");
+  expect((checked as { reason: string }).reason).toContain("exceeded 25ms");
+});
+
+test("execution gate: runtime idioms that execute fine stay green", async () => {
+  const scripts = [
+    // Extra declared params — the runtime calls fn(itx), extras are undefined.
+    "async (itx, extra, more) => itx.docs.search({ q: 'x' })",
+    // Destructured itx parameter.
+    "async ({ streams, docs }) => { await streams.get('/'); await docs.search({ q: 'x' }); }",
+    // Runtime globals: web platform + nodejs_compat.
+    `async (itx) => {
+      const res = await fetch(new URL("https://example.com/?q=" + crypto.randomUUID()));
+      const body = new TextDecoder().decode(new Uint8Array(await res.arrayBuffer()));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      console.log(structuredClone({ body: atob(btoa(body)) }), performance.now());
+      return Buffer.from(process?.env?.HOME ?? "x").toString("base64");
+    }`,
+    // using-declarations: the runtime's own wrapper uses \`using\`, so the
+    // shimmed Symbol.dispose/Disposable must keep scripts with them green.
+    `async (itx) => {
+      const handle = { [Symbol.dispose]: () => {} };
+      { using h = handle; void h; }
+      return null;
+    }`,
+    // Async generators, for-await, Map/Set, regex, template literals, classes.
+    `async (itx) => {
+      class Acc { total = 0; add(n) { this.total += n; return this; } }
+      async function* numbers() { yield 1; yield 2; }
+      const acc = new Acc();
+      for await (const n of numbers()) acc.add(n);
+      const seen = new Map([["k", new Set([1])]]);
+      return \`total=\${acc.total} \${/\\d+/.test("42")} \${seen.size}\`;
+    }`,
+    // try/catch with unknown error narrowing and rethrow.
+    `async (itx) => {
+      try {
+        return await itx.streams.get("/");
+      } catch (error) {
+        throw new Error("wrapped: " + (error instanceof Error ? error.message : String(error)));
+      }
+    }`,
+  ];
+  for (const code of scripts) {
+    const checked = await gate(code);
+    expect(checked, code.slice(0, 60)).toEqual({ verdict: "clean" });
+  }
+});
+
+test("execution gate: genuine script bugs the run would only surface at runtime DO block", async () => {
+  const buggy = [
+    // Misspelled local — TS2552/2304 in the script's own code.
+    "async (itx) => { const count = 1; return cuont + 1; }",
+    // Wrong argument type into the platform surface.
+    "async (itx) => itx.docs.search(42)",
+    // Syntax error.
+    "async (itx) => { const = 1; }",
+  ];
+  for (const code of buggy) {
+    const checked = await gate(code);
+    expect(checked.verdict, code).toBe("problems");
+  }
 });

--- a/apps/os/src/domains/typecheck/virtual-project.ts
+++ b/apps/os/src/domains/typecheck/virtual-project.ts
@@ -70,8 +70,8 @@ ${[
   "AbortController",
   "AbortSignal",
   // nodejs_compat globals — dynamic workers run with the flag, so scripts
-  // legitimately reach these; unshimmed they would fail the EXECUTION gate
-  // (checkItxScriptForExecution) for code that runs fine.
+  // legitimately reach these; unshimmed, code that runs fine reports errors
+  // to every reader (the docs door, the execution gate's near-miss check).
   "Buffer",
   "Event",
   "EventTarget",
@@ -275,25 +275,39 @@ export type ScriptExecutionCheck =
  * acquisition; past it the script runs unchecked rather than stall. */
 const EXECUTION_CHECK_DEADLINE_MS = 10_000;
 
-/** Unresolved-module diagnostics never block execution: "Cannot find module"
- * conflates a typo'd specifier with a failed/absent type acquisition, and the
- * runtime's own loader error is the truthful verdict for the former. */
-const UNRESOLVED_MODULE_CODES = new Set([
-  2307, // Cannot find module 'X'
-  2792, // Cannot find module 'X'. Did you mean to set moduleResolution…
-  7016, // Could not find a declaration file for module 'X'
+/**
+ * What the gate may block on — an ALLOWLIST, because blocking is only sound
+ * for errors that hold regardless of how complete the declared type surface
+ * is. Near-miss typos qualify: the compiler PROVED a correct alternative
+ * exists ("Did you mean 'get'?"). Bare "does not exist" / wrong-argument
+ * errors do not: capabilities are provided dynamically (a script may mount
+ * `itx.demoStream` and call it two lines later — journal-legal, invisible to
+ * a static check), and the declared surface demonstrably lags the runtime in
+ * places (preview e2e: `CloudflareSandbox.exec` exists at runtime but not in
+ * types, handle results declared `{}`). The advisory door (checkItxScript)
+ * still reports everything.
+ */
+const NEAR_MISS_TYPO_CODES = new Set([
+  2551, // Property 'X' does not exist on type 'T'. Did you mean 'Y'?
+  2552, // Cannot find name 'X'. Did you mean 'Y'?
 ]);
+
+/** TS grammar diagnostics live in the 1xxx range. Unparseable code is the one
+ * verdict that needs no type knowledge at all — the runtime's module loader
+ * would reject the same script with a worse message. */
+const isSyntaxError = (code: number) => code >= 1000 && code < 2000;
 
 /**
  * The pre-execution typecheck for a `script-execution-requested` block:
  * everything checkItxScript checks, read through the permissive-by-default
  * policy above. Blocking requires an error diagnostic in the script's OWN
- * code (`script.ts`) that is not an unresolved module. Everything the checker
- * cannot vouch for runs unchecked instead: shapes the agent extractor never
- * produces (raw runScript callers send plain function expressions), oversized
- * scripts, broken mount declarations (stale journals must not veto unrelated
- * scripts), compiler crashes, an unreachable typechecker, and the deadline.
- * Never throws.
+ * code (`script.ts`) from the allowlist: a syntax error or a near-miss typo.
+ * Everything the checker cannot vouch for runs instead — property/argument
+ * mismatches (dynamic mounts and surface gaps make them unprovable), shapes
+ * the agent extractor never produces (raw runScript callers send plain
+ * function expressions), oversized scripts, broken mount declarations (stale
+ * journals must not veto unrelated scripts), compiler crashes, an unreachable
+ * typechecker, and the deadline. Never throws.
  */
 export async function checkItxScriptForExecution(input: {
   capabilities: CapabilityDescription[];
@@ -332,7 +346,7 @@ export async function checkItxScriptForExecution(input: {
     (diagnostic) =>
       diagnostic.category === "error" &&
       diagnostic.fileName === "script.ts" &&
-      !UNRESOLVED_MODULE_CODES.has(diagnostic.code),
+      (isSyntaxError(diagnostic.code) || NEAR_MISS_TYPO_CODES.has(diagnostic.code)),
   );
   if (blocking.length === 0) return { verdict: "clean" };
   const problems = formatProblems(blocking, {

--- a/apps/os/src/domains/typecheck/virtual-project.ts
+++ b/apps/os/src/domains/typecheck/virtual-project.ts
@@ -69,6 +69,16 @@ ${[
   "TextDecoder",
   "AbortController",
   "AbortSignal",
+  // nodejs_compat globals — dynamic workers run with the flag, so scripts
+  // legitimately reach these; unshimmed they would fail the EXECUTION gate
+  // (checkItxScriptForExecution) for code that runs fine.
+  "Buffer",
+  "Event",
+  "EventTarget",
+  "DOMException",
+  "MessageChannel",
+  "MessagePort",
+  "WebSocketPair",
 ]
   // Optional type params so generic uses (ReadableStream<Uint8Array>,
   // workers-flavored Request<CfProperties>) resolve like the bare name.
@@ -87,6 +97,13 @@ ${[
   "btoa",
   "crypto",
   "performance",
+  // nodejs_compat / workerd value-only globals (see the typed list above).
+  "process",
+  "navigator",
+  "caches",
+  "scheduler",
+  "self",
+  "reportError",
 ]
   .map((name) => `declare var ${name}: any;`)
   .join("\n")}
@@ -189,12 +206,31 @@ export async function checkItxScript(input: {
         "before it, comments included.",
     ];
   }
+  const project = assembleScriptProject(input.capabilities, input.code);
+  const { diagnostics, notes } = await input.typechecker.check({ files: project.files });
+  const problems = formatProblems(diagnostics, {
+    label: "script",
+    primaryFile: "script.ts",
+    // The script's first line is preceded by the prelude lines, so subtract
+    // them: reported positions match the code the caller sent.
+    lineOffset: -project.preludeLineCount,
+  });
+  // Notes only contextualize failures — see checkCapabilityTypes.
+  return problems.length > 0 ? [...problems, ...notes] : [];
+}
+
+/** The virtual project for one script check — shared by the advisory door
+ * (checkItxScript) and the execution gate (checkItxScriptForExecution). */
+function assembleScriptProject(
+  capabilities: CapabilityDescription[],
+  code: string,
+): { files: Record<string, string>; preludeLineCount: number } {
   const files: Record<string, string> = { ...SHARED_FILES };
   // Each mount is its own single-path intersection term: `{ tools: { weather:
   // T } } & { tools: U }` merges correctly even when one mount's path prefixes
   // another's (both are journal-legal — dispatch is longest-prefix).
   const mountTerms: string[] = [];
-  for (const capability of input.capabilities) {
+  for (const capability of capabilities) {
     if (capability.type === "builtin") continue;
     const dottedPath = capability.path.join(".");
     const exportedName = capability.types ? firstExportedTypeName(capability.types) : undefined;
@@ -211,24 +247,116 @@ export async function checkItxScript(input: {
         .reduce((type, segment) => `{ ${segment}: ${type} }`, typeReference),
     );
   }
-
   const prelude = [
     `import type { Project } from "./itx-types";`,
     `type Itx = ${["Project", ...mountTerms].join(" & ")};`,
-    `const script: (itx: Itx) => unknown = (`,
+    // Rest params so a script declaring extra parameters (the runtime calls
+    // fn(itx), extras just stay undefined) stays assignable.
+    `const script: (itx: Itx, ...rest: any[]) => unknown = (`,
   ];
-  files["script.ts"] = [...prelude, input.code, ");"].join("\n");
+  files["script.ts"] = [...prelude, code, ");"].join("\n");
+  return { files, preludeLineCount: prelude.length };
+}
 
-  const { diagnostics, notes } = await input.typechecker.check({ files });
-  const problems = formatProblems(diagnostics, {
+/**
+ * How the execution gate reads a script check: `problems` blocks the run;
+ * `clean` and `unchecked` both let it proceed. Distinct from checkItxScript
+ * (the advisory docs door), which reports everything — the gate blocks only
+ * on errors it can PROVE against surfaces it can see, because a script must
+ * never be stopped by what the checker doesn't know.
+ */
+export type ScriptExecutionCheck =
+  | { verdict: "clean" }
+  | { verdict: "problems"; problems: string[] }
+  | { verdict: "unchecked"; reason: string };
+
+/** Wall-clock budget for the pre-execution check. Generous enough for a cold
+ * sidecar isolate (wasm instantiation + first compile) plus npm type
+ * acquisition; past it the script runs unchecked rather than stall. */
+const EXECUTION_CHECK_DEADLINE_MS = 10_000;
+
+/** Unresolved-module diagnostics never block execution: "Cannot find module"
+ * conflates a typo'd specifier with a failed/absent type acquisition, and the
+ * runtime's own loader error is the truthful verdict for the former. */
+const UNRESOLVED_MODULE_CODES = new Set([
+  2307, // Cannot find module 'X'
+  2792, // Cannot find module 'X'. Did you mean to set moduleResolution…
+  7016, // Could not find a declaration file for module 'X'
+]);
+
+/**
+ * The pre-execution typecheck for a `script-execution-requested` block:
+ * everything checkItxScript checks, read through the permissive-by-default
+ * policy above. Blocking requires an error diagnostic in the script's OWN
+ * code (`script.ts`) that is not an unresolved module. Everything the checker
+ * cannot vouch for runs unchecked instead: shapes the agent extractor never
+ * produces (raw runScript callers send plain function expressions), oversized
+ * scripts, broken mount declarations (stale journals must not veto unrelated
+ * scripts), compiler crashes, an unreachable typechecker, and the deadline.
+ * Never throws.
+ */
+export async function checkItxScriptForExecution(input: {
+  capabilities: CapabilityDescription[];
+  code: string;
+  typechecker: Typechecker;
+  deadlineMs?: number;
+}): Promise<ScriptExecutionCheck> {
+  if (typeof input.code !== "string") {
+    return { verdict: "unchecked", reason: `code is ${typeof input.code}, not a string` };
+  }
+  if (input.code.length > MAX_SCRIPT_CHARS) {
+    return {
+      verdict: "unchecked",
+      reason: `script is ${input.code.length} characters, over the check limit`,
+    };
+  }
+  if (!RUNTIME_SCRIPT_SHAPE.test(input.code.trim())) {
+    return { verdict: "unchecked", reason: "not the async block shape the checker models" };
+  }
+  const project = assembleScriptProject(input.capabilities, input.code);
+  let checked: TypecheckResult;
+  try {
+    checked = await withDeadline(
+      input.typechecker.check({ files: project.files }),
+      input.deadlineMs ?? EXECUTION_CHECK_DEADLINE_MS,
+    );
+  } catch (error) {
+    return { verdict: "unchecked", reason: `typechecker unavailable (${String(error)})` };
+  }
+  // runTypecheck's crash guard reports a compiler crash as a code-0 error
+  // diagnostic — a check that DIDN'T HAPPEN, not a verdict on the script.
+  if (checked.diagnostics.some((diagnostic) => diagnostic.code === 0)) {
+    return { verdict: "unchecked", reason: "type checking crashed" };
+  }
+  const blocking = checked.diagnostics.filter(
+    (diagnostic) =>
+      diagnostic.category === "error" &&
+      diagnostic.fileName === "script.ts" &&
+      !UNRESOLVED_MODULE_CODES.has(diagnostic.code),
+  );
+  if (blocking.length === 0) return { verdict: "clean" };
+  const problems = formatProblems(blocking, {
     label: "script",
     primaryFile: "script.ts",
-    // The script's first line is preceded by the prelude lines, so subtract
-    // them: reported positions match the code the caller sent.
-    lineOffset: -prelude.length,
+    lineOffset: -project.preludeLineCount,
   });
-  // Notes only contextualize failures — see checkCapabilityTypes.
-  return problems.length > 0 ? [...problems, ...notes] : [];
+  return { verdict: "problems", problems: [...problems, ...checked.notes] };
+}
+
+/** Race a check against its wall-clock budget. Promise.race keeps a handler
+ * on the losing check, so a late rejection never surfaces as unhandled. */
+async function withDeadline<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`typecheck exceeded ${ms}ms`)), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /**


### PR DESCRIPTION
## What

Every `script-execution-requested` block is now typechecked against its scope's capability types **before** it runs. A script with a *provable* error settles straight to an error completion carrying the compiler errors — `requested → completed`, **no `started` event**, nothing executed — and flows back to the model through the existing corrective lane:

```
Script was NOT executed: it does not typecheck against this scope's capability types.
script:1:27 — Property 'gett' does not exist on type 'ProjectStreamCollection'. Did you mean 'get'? (TS2551)
Fix the type errors and resend the whole corrected script.
```

This covers both the agent codemode lane and `runScript` handles — the gate lives in the capability-host processor's `#executeScript`, in front of the started-evidence append, so the reconciler doctrine (`requested` = provably never ran) is untouched and the rejection shares the completion idempotency key with the run/settle lanes.

## What counts as proof — permissive everywhere else

Blocking is an **allowlist** of errors that hold regardless of how complete the declared type surface is:

- **syntax errors** (TS 1xxx) — the runtime's module loader would reject the same script with a worse message
- **near-miss typos** (TS2551/TS2552) — the compiler proves a correct alternative exists ("Did you mean 'get'?")

Everything else runs:

| situation | why it must not block |
|---|---|
| bare property/argument mismatches (TS2339/TS2345/…) | capabilities are provided dynamically — provide-then-use in one script is journal-legal and invisible to a static check — and the declared surface provably lags the runtime in places (see below) |
| untyped / unknown mounts | `any` |
| unresolved modules (TS2307/…) | acquisition failure ≠ typo proof |
| broken *stale* mount declarations in old journals | can't veto unrelated scripts |
| compiler crash, unreachable sidecar, 10s deadline | unchecked → runs |
| non-async shapes (raw `runScript` callers send plain function expressions) | unchecked → runs |
| oversized scripts (>200k chars) | unchecked → runs |

The advisory door (`itx.docs.typecheck`) still reports everything — only the execution gate reads through this policy.

### How the policy got here

The first push blocked on *all* script-own error diagnostics. **Preview e2e disproved that policy within one run**: six catalogue examples plus the pipelining and cross-scope-provide specs failed on bare TS2339s that are runtime-legal — capabilities provided then called through the itx proxy two lines later, `CloudflareSandbox.exec` existing at runtime but not in declared types, handle results typed `{}`. That's exactly the drift the permissive rule exists for, so blocking flipped to the allowlist above. (The type-surface gaps the gate exposed — sandbox `exec`/`instanceType`, `{}` handle results — are worth fixing separately; they mislead `docs.get` readers too.)

Three more false-positive classes were found by unit-level break-it testing and fixed before the first push: missing `nodejs_compat` shims (`Buffer`, `process`, … exist at runtime for dynamic workers), extra script parameters (the runtime calls `fn(itx)`; the check prelude now takes rest params), and a stale-state race — the gate reads the **batch's own fold**, not `this.state`, because the checkpoint advances only after `processEventBatch` returns and a script calling a same-batch-provided mount must not be judged against a stale scope.

## Speed impact

Measured with the real tswasm compiler (node bench) and live against a dev deployment:

- **wasm instantiation**: 44ms (once per sidecar isolate; Cloudflare precompiles wasm at upload)
- **first check in an isolate** (cold compile of the full platform surface): ~143ms bench / ~95ms live
- **warm checks**: median **40ms**, p90 45ms (bench); ~40ms live on the same sidecar
- **live `runScript` round trip including the gate**: 108–131ms over 6 consecutive runs
- **agent turns**: unchanged at 5–7.5s in live smoke — the check is ~1% of a codemode turn

The check is serial in front of execution (it gates it), so every script pays the warm ~40ms plus one sidecar RPC and one `describeCapabilities` (parent-DO hop). A gate-*blocked* turn is net faster than before: the old path paid a full script load + run + failed turn + retry; the new path returns compiler errors immediately. Worst case is hard-capped: past the 10s deadline the script runs unchecked. npm-typed mounts pay type acquisition on first check per isolate (Cache-API-backed, same as the advisory door).

## Testing

- **32 unit tests** across two suites:
  - `virtual-project.test.ts` (real tswasm compiler): true positives (near-miss typos into platform surface and typed mounts, misspelled locals, syntax errors — all block with the caller's line numbers) and a break-it suite (provide-then-use dynamic mounts, bare mismatches, stale broken mounts, unresolved modules, `using` declarations, destructured/extra params, async generators, `Buffer`/`process`/web globals, compiler crash, hanging checker → deadline, plain-arrow shapes — all run).
  - `script-execution-typecheck.test.ts` (processor harness): rejected scripts never start and never run, shared completion idempotency key, clean/unchecked/throwing-checker/absent-checker all execute, the gate sees same-batch mounts AND parent-scope inherited capabilities, rejected obligations never re-run on refold.
- **Live against a dev deployment** (real sidecar, real DO wiring):
  - typo'd `runScript` blocked with did-you-mean at the right position; clean scripts run; plain-arrow shape runs unchecked; runtime throws still surface as runtime errors
  - agent codemode smoke: normal turn answers in 7.5s; an agent instructed to run a typo'd call got gated, read the compiler error, and reported it verbatim — corrective loop closed
  - journal audit: rejected execution shows `requested → completed:error` with no `started`; clean ones show all three
  - the previously-failing e2e specs re-run locally after the allowlist fix: examples-matrix 24/26 with **zero** gate rejections (the 2 fails are local `*.localhost` DNS resolution, absent in CI), itx-agents cross-scope-provide and all 3 pipelining specs green
- `pnpm typecheck && pnpm lint && pnpm format && pnpm test` all green (full suite: 1088 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the script execution path for all codemode and runScript callers and adds a sidecar dependency on every run (~40ms warm); permissive allowlisting limits false blocks but mis-tuned policy could still break e2e scripts that rely on undeclared APIs.
> 
> **Overview**
> Adds a **pre-execution typecheck gate** on `script-execution-requested` / `runScript`: capability-host runs `checkItxScriptForExecution` against local and inherited mounts **before** appending `script-execution-started`. A **`problems`** verdict completes with compiler errors and the script never runs; **`clean`** and **`unchecked`** proceed as today.
> 
> **Policy** (new `checkItxScriptForExecution` in `virtual-project.ts`): only **provable** script errors block—syntax (1xxx) and near-miss typos (TS2551/2552 with “Did you mean”). Bare property/argument mismatches, dynamic mounts, stale broken mount modules, checker outages, timeouts (~10s), and non-modeled script shapes run **unchecked**. Advisory `checkItxScript` still reports all errors.
> 
> **Wiring**: DO injects `typecheckScript` → sidecar; reconciler passes **`args.state.capabilities`** from the current batch (same-batch provides visible to the gate). Script assembly is shared via `assembleScriptProject`; prelude adds **rest params** for extra `itx` args; **nodejs_compat** globals are shimmed so runtime-legal scripts aren’t flagged.
> 
> **Tests**: processor gate plumbing (`script-execution-typecheck.test.ts`) and compiler policy suite in `virtual-project.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e416970ece7ac73c45d434ba6d87250e670ec3bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +233 -17 | +152 -13 🟩🟩⬜⬜⬜ |
| Tests | +426 -0 | +353 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+659 -17** | **+505 -13** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 70934eb and e416970, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-11T22:05:00.873Z",
      "headSha": "e416970ece7ac73c45d434ba6d87250e670ec3bd",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/98040689286752",
      "shortSha": "e416970",
      "cleanupDurationMs": 10642,
      "deployDurationMs": 71500,
      "testDurationMs": 191716,
      "testRetries": "15 retried: itx > Agent scripts can send web-chat messages (with file attachments) and call project tools (vitest x1) · itx > New agent streams install processors and replay existing child events (vitest x1) · itx > Dynamic worker env.ITX.get() is scoped by project and agent host path (vitest x1) · itx > MCP built-in connects directly and mounts as a described capability (vitest x1) · itx > ITX expression capabilities mount project workers, streams, method aliases, and functions (vitest x1) · itx > ITX expression capabilities resolve aliases against the current ITX host path (vitest x1) · itx > Project repos, workers, runScript, and dynamic worker refs compose (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · concurrent long-running ITX scripts all complete (vitest x1) · subscription and subscribe inputs are validated at the door (vitest x1) · reactivity page processor panel goes live and repaints from a server push (specs x1) · runs \"scheduler-agent-checkin\" through the project REPL (specs x1) · runs \"provide-live-capability\" through the project REPL (specs x1) · runs \"provide-itx-expression\" through the project REPL (specs x1) · runs \"workspace-edit-and-push\" through the project REPL (specs x1)",
      "workerSizeKib": 15936.5,
      "workerGzipKib": 4297.28,
      "mainWorkerGzipKib": 4294.8
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-11T22:04:53.093Z",
      "headSha": "e416970ece7ac73c45d434ba6d87250e670ec3bd",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/98040689286752",
      "shortSha": "e416970",
      "cleanupDurationMs": 2859,
      "deployDurationMs": 17588,
      "testDurationMs": 729,
      "testRetries": null,
      "workerSizeKib": 4031.76,
      "workerGzipKib": 819.32,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `e416970` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 819.3 KiB | 17.6s | 729ms |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/98040689286752) | 2026-07-11T22:04:53.093Z | Preview app released. |
| OS | released | `e416970` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 4.20 MiB (+2.5 KiB vs main) | 71.5s | 191.7s | 15 retried: itx > Agent scripts can send web-chat messages (with file attachments) and call project tools (vitest x1) · itx > New agent streams install processors and replay existing child events (vitest x1) · itx > Dynamic worker env.ITX.get() is scoped by project and agent host path (vitest x1) · itx > MCP built-in connects directly and mounts as a described capability (vitest x1) · itx > ITX expression capabilities mount project workers, streams, method aliases, and functions (vitest x1) · itx > ITX expression capabilities resolve aliases against the current ITX host path (vitest x1) · itx > Project repos, workers, runScript, and dynamic worker refs compose (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · concurrent long-running ITX scripts all complete (vitest x1) · subscription and subscribe inputs are validated at the door (vitest x1) · reactivity page processor panel goes live and repaints from a server push (specs x1) · runs "scheduler-agent-checkin" through the project REPL (specs x1) · runs "provide-live-capability" through the project REPL (specs x1) · runs "provide-itx-expression" through the project REPL (specs x1) · runs "workspace-edit-and-push" through the project REPL (specs x1) | 10.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/98040689286752) | 2026-07-11T22:05:00.873Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->
