### PR TITLE
menubar: "Use my computer" — lend your Mac to a project's agents, and show it in use

### DIFF
--- a/packages/iterate/README.md
+++ b/packages/iterate/README.md
@@ -45,6 +45,7 @@ npx iterate config list
 - `iterate login` - authenticate with browser-based OAuth
 - `iterate logout` - remove the stored session for the current config
 - `iterate approve` - be the human in the loop for a project's egress (see below)
+- `iterate use-my-computer` - lend this Mac to a project's agents (see below)
 - `iterate orgs list`
 - `iterate config ...`
 - `iterate os ...`
@@ -111,6 +112,24 @@ iterate os itx run --context <project-id> --eval '
 
 Inside an `iterate/iterate` clone the same runs as
 `doppler run --config <env> -- pnpm cli itx run --context <project-id> --eval '…'`.
+
+## Use my computer (`iterate use-my-computer`)
+
+Lend this Mac to a project's agents. It mounts a live capability at
+`itx.<name>` — agents call `ask` (native dialog), `notify` (desktop
+notification) and `runSwift` (arbitrary Swift), and the calls run **right here**
+on your machine, over the socket, as you. Runs until Ctrl-C.
+
+```bash
+iterate use-my-computer --project <id-or-slug>              # prompts for a name, prints a paste-for-your-agent hint
+iterate use-my-computer --project <id-or-slug> --name jonasComputer
+```
+
+It's also built into the **menu-bar app** (`iterate approve --menubar`): flip
+**Use my computer** on to share, and the dropdown shows each call as it happens —
+a green dot appears in the menu bar while an agent is actively using your Mac.
+Sharing is opt-in, stops when you flip it off or quit, and the toggle drives the
+same `iterate use-my-computer --json` under the hood.
 
 ### Testing a held request
 

--- a/packages/iterate/menubar/Iterate.swift
+++ b/packages/iterate/menubar/Iterate.swift
@@ -493,7 +493,13 @@ final class ComputerController: ObservableObject {
       guard let id = event["id"] as? Int,
         let index = recentCalls.firstIndex(where: { $0.id == id })
       else { return }
-      recentCalls[index].running = false
+      // Reassign the whole element (not a nested mutation) so the @Published
+      // array reliably republishes — otherwise the spinner, `inUse`, and the
+      // menu-bar dot can stay stuck after the call finishes. Same idiom as
+      // ApprovalController.setSubmitting.
+      var call = recentCalls[index]
+      call.running = false
+      recentCalls[index] = call
     default:
       break
     }

--- a/packages/iterate/menubar/Iterate.swift
+++ b/packages/iterate/menubar/Iterate.swift
@@ -14,6 +14,7 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 import AppKit
+import Combine
 import Foundation
 import SwiftUI
 import UserNotifications
@@ -375,6 +376,19 @@ final class ComputerController: ObservableObject {
   private var stdoutHandle: FileHandle?
   private var buffer = Data()
   private var generation = 0  // bumped on every stop(); voids stale stdout chunks
+  private var cancellables = Set<AnyCancellable>()
+
+  private init() {
+    // If the app loses its session, stop sharing immediately — the mount is
+    // dead anyway, and otherwise the computer could stay lent while the toggle
+    // greys out with no way to revoke but quitting.
+    ApprovalController.shared.$loggedIn
+      .dropFirst()
+      .sink { [weak self] loggedIn in
+        if !loggedIn { self?.stop() }
+      }
+      .store(in: &cancellables)
+  }
 
   /// Turn sharing on or off — safe to drive straight from a Toggle binding.
   func setEnabled(_ on: Bool) {
@@ -554,7 +568,9 @@ struct DropdownView: View {
         Toggle("", isOn: Binding(get: { computer.enabled }, set: { computer.setEnabled($0) }))
           .labelsHidden()
           .toggleStyle(.switch)
-          .disabled(!controller.loggedIn)
+          // Need a session to START sharing, but never trap an ACTIVE share
+          // behind a greyed-out switch — always allow turning it off.
+          .disabled(!controller.loggedIn && !computer.enabled)
       }
       if computer.sharing {
         if computer.recentCalls.isEmpty {

--- a/packages/iterate/menubar/Iterate.swift
+++ b/packages/iterate/menubar/Iterate.swift
@@ -340,10 +340,171 @@ final class ApprovalController: ObservableObject {
   }
 }
 
+// MARK: - Use my computer
+
+/// One agent call to this computer, for the activity list. `running` flips off
+/// when its `call-done` lands.
+struct ComputerCall: Identifiable, Equatable {
+  let id: Int
+  let method: String
+  let summary: String
+  var running: Bool
+}
+
+/// Drives `iterate use-my-computer --json`: lends this Mac to the project's
+/// agents and surfaces each call they make, so the menu bar can show it in use.
+///
+/// Deliberately simpler than ApprovalController: sharing is opt-in (a conscious
+/// act), so if the watcher exits we just stop sharing and let the human
+/// re-enable — no silent auto-reconnect that would re-lend the machine.
+final class ComputerController: ObservableObject {
+  static let shared = ComputerController()
+
+  @Published var enabled = false  // the human asked to share
+  @Published var sharing = false  // the capability is mounted and live
+  @Published var computerName: String?  // the itx.<name> agents call
+  @Published var recentCalls: [ComputerCall] = []
+  @Published var lastError: String?
+
+  /// A call is running right now — the menu bar's "in use" indicator.
+  var inUse: Bool { recentCalls.contains { $0.running } }
+
+  private let config = MenuBarConfig.load()
+  private var process: Process?
+  private var stdinHandle: FileHandle?
+  private var stdoutHandle: FileHandle?
+  private var buffer = Data()
+  private var generation = 0  // bumped on every stop(); voids stale stdout chunks
+
+  /// Turn sharing on or off — safe to drive straight from a Toggle binding.
+  func setEnabled(_ on: Bool) {
+    guard on != enabled else { return }
+    enabled = on
+    if on { start() } else { stop() }
+  }
+
+  private func start() {
+    stop()
+    enabled = true  // stop() cleared it; we ARE (re)starting
+    lastError = nil
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = [config.command] + config.argv(for: ["use-my-computer", "--json"])
+    if let cwd = config.cwd { process.currentDirectoryURL = URL(fileURLWithPath: cwd) }
+
+    let stdout = Pipe()
+    let stdin = Pipe()  // held open so the child lives; closing it stops sharing
+    process.standardOutput = stdout
+    process.standardInput = stdin
+    self.stdoutHandle = stdout.fileHandleForReading
+    self.stdinHandle = stdin.fileHandleForWriting
+
+    let session = generation
+    stdout.fileHandleForReading.readabilityHandler = { [weak self] handle in
+      let chunk = handle.availableData
+      if chunk.isEmpty {  // EOF: clear the handler so it stops busy-looping
+        handle.readabilityHandler = nil
+        return
+      }
+      DispatchQueue.main.async {
+        guard let self, self.generation == session else { return }  // stale chunk
+        self.ingest(chunk)
+      }
+    }
+    process.terminationHandler = { [weak self] _ in
+      DispatchQueue.main.async { self?.watcherExited() }
+    }
+    do {
+      try process.run()
+      self.process = process
+    } catch {
+      enabled = false
+      detachIO()
+      lastError = "Could not share your computer: \(error.localizedDescription)"
+    }
+  }
+
+  func stop() {
+    generation += 1  // any late stdout chunk from this session is now stale
+    enabled = false
+    process?.terminationHandler = nil
+    process?.terminate()
+    process = nil
+    detachIO()
+    sharing = false
+    recentCalls = []
+  }
+
+  /// The watcher exited on its own (lost socket, needs-login, crash). We're no
+  /// longer sharing — say so honestly rather than silently re-lending the Mac.
+  private func watcherExited() {
+    generation += 1
+    detachIO()
+    sharing = false
+    recentCalls = []
+    if enabled {
+      enabled = false
+      if lastError == nil { lastError = "Stopped sharing your computer." }
+    }
+  }
+
+  /// Drop this session's pipes/handles and any half-read line.
+  private func detachIO() {
+    stdoutHandle?.readabilityHandler = nil
+    stdoutHandle = nil
+    stdinHandle = nil
+    buffer = Data()
+  }
+
+  private func ingest(_ chunk: Data) {
+    buffer.append(chunk)
+    while let newline = buffer.firstIndex(of: 0x0A) {
+      let lineData = buffer.subdata(in: buffer.startIndex..<newline)
+      buffer.removeSubrange(buffer.startIndex...newline)
+      guard let object = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any] else {
+        continue
+      }
+      handle(object)
+    }
+  }
+
+  private func handle(_ event: [String: Any]) {
+    switch event["type"] as? String {
+    case "status":
+      if event["loggedIn"] as? Bool == true {
+        sharing = true
+        computerName = event["name"] as? String
+      } else {
+        // No session — login is the approver's job; just stop and say so.
+        stop()
+        lastError = "Sign in first, then share your computer."
+      }
+    case "call":
+      guard let id = event["id"] as? Int else { return }
+      recentCalls.insert(
+        ComputerCall(
+          id: id,
+          method: event["method"] as? String ?? "?",
+          summary: event["summary"] as? String ?? "",
+          running: true),
+        at: 0)
+      if recentCalls.count > 5 { recentCalls.removeLast(recentCalls.count - 5) }
+    case "call-done":
+      guard let id = event["id"] as? Int,
+        let index = recentCalls.firstIndex(where: { $0.id == id })
+      else { return }
+      recentCalls[index].running = false
+    default:
+      break
+    }
+  }
+}
+
 // MARK: - Views
 
 struct DropdownView: View {
   @EnvironmentObject var controller: ApprovalController
+  @EnvironmentObject var computer: ComputerController
 
   var body: some View {
     VStack(alignment: .leading, spacing: 10) {
@@ -360,8 +521,10 @@ struct DropdownView: View {
         }
       }
       Divider()
+      computerSection
+      Divider()
       HStack {
-        if let error = controller.lastError {
+        if let error = controller.lastError ?? computer.lastError {
           Text(error).font(.caption).foregroundStyle(.red).lineLimit(2)
         }
         Spacer()
@@ -370,6 +533,53 @@ struct DropdownView: View {
     }
     .padding(14)
     .frame(width: 340)
+  }
+
+  /// "Use my computer" — a toggle to lend this Mac to the project's agents, and,
+  /// while shared, a live list of the calls they make (the machine "in use").
+  @ViewBuilder private var computerSection: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack(alignment: .top) {
+        VStack(alignment: .leading, spacing: 2) {
+          Text("Use my computer").font(.callout).bold()
+          Text(computerStatusLine).font(.caption2).foregroundStyle(.secondary).lineLimit(2)
+        }
+        Spacer()
+        Toggle("", isOn: Binding(get: { computer.enabled }, set: { computer.setEnabled($0) }))
+          .labelsHidden()
+          .toggleStyle(.switch)
+          .disabled(!controller.loggedIn)
+      }
+      if computer.sharing {
+        if computer.recentCalls.isEmpty {
+          Text("Waiting for an agent to use it…").font(.caption).foregroundStyle(.secondary)
+        } else {
+          ForEach(computer.recentCalls) { call in
+            HStack(spacing: 6) {
+              if call.running {
+                ProgressView().controlSize(.small)
+              } else {
+                Image(systemName: "checkmark.circle").foregroundStyle(.secondary)
+              }
+              Text("\(call.method) · \(call.summary)")
+                .font(.caption)
+                .foregroundStyle(call.running ? .primary : .secondary)
+                .lineLimit(1)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private var computerStatusLine: String {
+    if !controller.loggedIn { return "Sign in to lend this Mac to agents." }
+    if computer.sharing {
+      let name = computer.computerName.map { "itx.\($0)" } ?? "your computer"
+      return computer.inUse ? "In use now — \(name)" : "\(name) is live for this project."
+    }
+    if computer.enabled { return "Starting…" }
+    return "Let agents run dialogs, notifications and Swift here."
   }
 
   @ViewBuilder private var header: some View {
@@ -483,6 +693,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     ApprovalController.shared.start()  // connect at launch, not on first open
+    // Computer sharing is opt-in — it stays idle until the human flips it on.
+  }
+
+  /// Tear down both watchers on quit so we never leave the computer shared (or an
+  /// approver running) behind a closed menu bar.
+  func applicationWillTerminate(_ notification: Notification) {
+    ComputerController.shared.stop()
+    ApprovalController.shared.stop()
   }
 
   /// Show the banner even when the app is frontmost.
@@ -514,15 +732,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 struct IterateApp: App {
   @NSApplicationDelegateAdaptor(AppDelegate.self) private var delegate
   @StateObject private var controller = ApprovalController.shared
+  @StateObject private var computer = ComputerController.shared
 
   var body: some Scene {
     MenuBarExtra {
-      DropdownView().environmentObject(controller)
+      DropdownView().environmentObject(controller).environmentObject(computer)
     } label: {
-      // The 𝑖 template mark, plus a count when requests are waiting.
+      // The 𝑖 template mark, a count when requests are waiting, and a green dot
+      // while an agent is actively using this computer.
       Image(nsImage: IterateIcon.mark)
       if controller.requests.count > 0 {
         Text("\(controller.requests.count)")
+      }
+      if computer.inUse {
+        Image(systemName: "circle.fill").foregroundStyle(.green)
       }
     }
     .menuBarExtraStyle(.window)

--- a/packages/iterate/menubar/Iterate.swift
+++ b/packages/iterate/menubar/Iterate.swift
@@ -364,11 +364,14 @@ final class ComputerController: ObservableObject {
   @Published var enabled = false  // the human asked to share
   @Published var sharing = false  // the capability is mounted and live
   @Published var computerName: String?  // the itx.<name> agents call
-  @Published var recentCalls: [ComputerCall] = []
+  @Published var recentCalls: [ComputerCall] = []  // capped display list
+  @Published private var activeCalls = 0  // in-flight count, independent of the cap
   @Published var lastError: String?
 
-  /// A call is running right now — the menu bar's "in use" indicator.
-  var inUse: Bool { recentCalls.contains { $0.running } }
+  /// A call is running right now — the menu bar's "in use" indicator. Counted
+  /// separately from `recentCalls` so a slow call that scrolls off the capped
+  /// display list still keeps the indicator honest.
+  var inUse: Bool { activeCalls > 0 }
 
   private let config = MenuBarConfig.load()
   private var process: Process?
@@ -447,6 +450,7 @@ final class ComputerController: ObservableObject {
     detachIO()
     sharing = false
     recentCalls = []
+    activeCalls = 0
   }
 
   /// The watcher exited on its own (lost socket, needs-login, crash). We're no
@@ -456,6 +460,7 @@ final class ComputerController: ObservableObject {
     detachIO()
     sharing = false
     recentCalls = []
+    activeCalls = 0
     if enabled {
       enabled = false
       if lastError == nil { lastError = "Stopped sharing your computer." }
@@ -495,6 +500,7 @@ final class ComputerController: ObservableObject {
       }
     case "call":
       guard let id = event["id"] as? Int else { return }
+      activeCalls += 1
       recentCalls.insert(
         ComputerCall(
           id: id,
@@ -504,13 +510,13 @@ final class ComputerController: ObservableObject {
         at: 0)
       if recentCalls.count > 5 { recentCalls.removeLast(recentCalls.count - 5) }
     case "call-done":
-      guard let id = event["id"] as? Int,
-        let index = recentCalls.firstIndex(where: { $0.id == id })
-      else { return }
+      guard let id = event["id"] as? Int else { return }
+      // Decrement the in-flight count even if the row already scrolled off the
+      // capped list, so `inUse` and the menu-bar dot don't stay stuck on.
+      if activeCalls > 0 { activeCalls -= 1 }
+      guard let index = recentCalls.firstIndex(where: { $0.id == id }) else { return }
       // Reassign the whole element (not a nested mutation) so the @Published
-      // array reliably republishes — otherwise the spinner, `inUse`, and the
-      // menu-bar dot can stay stuck after the call finishes. Same idiom as
-      // ApprovalController.setSubmitting.
+      // array reliably republishes. Same idiom as ApprovalController.setSubmitting.
       var call = recentCalls[index]
       call.running = false
       recentCalls[index] = call

--- a/packages/iterate/src/cli.ts
+++ b/packages/iterate/src/cli.ts
@@ -22,7 +22,11 @@ import type {
   Session,
   Stream,
 } from "./itx-api.generated.ts";
-import { shareMyComputer } from "./use-my-computer.ts";
+import {
+  emitComputerNeedsLogin,
+  runUseMyComputerJson,
+  shareMyComputer,
+} from "./use-my-computer.ts";
 import { runApprovalCli } from "./approve.ts";
 import { emitNeedsLogin, runApprovalJson } from "./approve-json.ts";
 import { launchMenubarApp } from "./menubar-app.ts";
@@ -1060,6 +1064,13 @@ const launcherProcedures = {
           .describe(
             "Name agents use to reach this computer (camelCase; the itx.<name> path). Prompted if omitted.",
           ),
+        json: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "Machine mode for the menu-bar app: NDJSON activity on stdout. Never opens a browser — emits a needs-login line instead.",
+          ),
       }),
     )
     .meta({
@@ -1070,7 +1081,8 @@ const launcherProcedures = {
       const resolved = resolveConfig(process.cwd(), { throw: true });
 
       // Auth, exactly like `chat`: env secrets win (doppler/e2e), otherwise use
-      // the stored `iterate login` session, kicking off a browser login if none.
+      // the stored `iterate login` session. In JSON mode we never open a
+      // browser — a missing session is reported so the app can drive login.
       const envAuth = osAuthFromEnvironment();
       let authHeaders: OsAuthHeaders | undefined;
       if (!envAuth) {
@@ -1078,6 +1090,10 @@ const launcherProcedures = {
           authHeaders = await getOsAuthHeaders(resolved.config, resolved.name);
         } catch (error) {
           if (!shouldAutoLoginForChat(error)) throw error;
+          if (input.json) {
+            emitComputerNeedsLogin();
+            return;
+          }
           console.error(
             `No active session for ${resolved.config.osBaseUrl}. Starting browser login...`,
           );
@@ -1096,14 +1112,20 @@ const launcherProcedures = {
         explicitProject: input.project,
       });
 
-      // Prompts for a name, provides itx.<name>, then blocks until Ctrl-C.
-      await shareMyComputer({
+      const shared = {
         auth: auth.credentials,
         baseUrl: resolved.config.osBaseUrl,
         projectId,
         headers: headersRecord(auth.requestHeaders),
         name: input.name,
-      });
+      };
+      // JSON mode announces activity for the menu-bar app; the terminal form
+      // prompts for a name and prints a paste-for-your-agent hint. Both block.
+      if (input.json) {
+        await runUseMyComputerJson(shared);
+        return;
+      }
+      await shareMyComputer(shared);
     }),
 
   approve: os

--- a/packages/iterate/src/menubar-app.ts
+++ b/packages/iterate/src/menubar-app.ts
@@ -82,5 +82,8 @@ export async function launchMenubarApp(input: {
   const open = await run("open", [APP_PATH]);
   if (open.exitCode !== 0) throw new Error(`Could not launch the app: ${open.stderr.trim()}`);
   log(`Launched Iterate for project "${input.project}" (config ${input.configName}).`);
-  log("It lives in your menu bar — click the 𝑖 to sign in and approve requests.");
+  log(
+    "It lives in your menu bar — click the 𝑖 to sign in, approve requests, and " +
+      "share your computer with the project's agents.",
+  );
 }

--- a/packages/iterate/src/use-my-computer.ts
+++ b/packages/iterate/src/use-my-computer.ts
@@ -14,6 +14,11 @@
 // project a remote reference to a plain JavaScript object. Calls to it are RPCs
 // that come home to this process. Everything below is just (a) that object and
 // (b) keeping the socket alive so agents can reach it.
+//
+// Two front-ends ride the same core: the terminal command (shareMyComputer,
+// prints a paste-for-your-agent hint) and the machine one the menu-bar app
+// drives (runUseMyComputerJson) — the latter wraps the capability so every agent
+// call announces itself as NDJSON, which is how the app shows "in use".
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { hostname } from "node:os";
@@ -131,24 +136,20 @@ function agentPrompt(name: string): string {
   ].join("\n");
 }
 
-/**
- * Ask for a name, provide `itx.<name>`, and hold the line until Ctrl-C.
- *
- * A live mount only routes while its socket is warm, so we send a small
- * heartbeat to keep it hot. Never returns; the caller runs it as the body of a
- * long-lived command.
- */
-export async function shareMyComputer(input: {
+type ConnectInput = {
   auth: ItxAuthCredentials;
   baseUrl: string;
   projectId: string;
   headers?: Record<string, string>;
   name?: string;
-  log?: (message: string) => void;
-}): Promise<never> {
-  const log = input.log ?? ((message: string) => console.error(message));
-  const name = input.name ?? (await askComputerName());
+};
 
+/** Mount `capability` at `itx.<name>` and return the live socket stub. */
+async function connectAndProvide(
+  input: ConnectInput,
+  name: string,
+  capability: typeof myComputer,
+): Promise<RpcStub<Project>> {
   const itx = connectItx({
     auth: input.auth,
     baseUrl: input.baseUrl,
@@ -159,20 +160,120 @@ export async function shareMyComputer(input: {
   await itx.provideCapability({
     type: "live",
     path: [name],
-    capability: myComputer,
+    capability,
     instructions: INSTRUCTIONS,
     types: TYPES,
   });
-  log(`✅ itx.${name} is live for project ${input.projectId}. Press Ctrl-C to stop sharing.\n`);
-  log(agentPrompt(name));
+  return itx;
+}
 
-  // A live mount only routes while its socket is warm, so ping now and then to
-  // keep it hot (ignoring transient errors), and hold open until Ctrl-C.
+/** Keep the mount routable — a live capability only serves while its socket is warm — and never return. */
+function holdWarm(itx: RpcStub<Project>): Promise<never> {
   const heartbeat = () => itx.__describe().catch(() => {});
   heartbeat();
   setInterval(heartbeat, 5_000);
   return new Promise<never>(() => {});
 }
+
+/**
+ * Ask for a name, provide `itx.<name>`, and hold the line until Ctrl-C. Never
+ * returns; the caller runs it as the body of a long-lived command.
+ */
+export async function shareMyComputer(
+  input: ConnectInput & { log?: (message: string) => void },
+): Promise<never> {
+  const log = input.log ?? ((message: string) => console.error(message));
+  const name = input.name ?? (await askComputerName());
+  const itx = await connectAndProvide(input, name, myComputer);
+  log(`✅ itx.${name} is live for project ${input.projectId}. Press Ctrl-C to stop sharing.\n`);
+  log(agentPrompt(name));
+  return holdWarm(itx);
+}
+
+/**
+ * The machine front-end the menu-bar app drives. Same live mount, but the
+ * capability is wrapped so every agent call announces itself as NDJSON on
+ * stdout — that stream is how the app shows the computer being used.
+ *
+ * Out (stdout):
+ *   {"type":"status","loggedIn":true,"project":"prj_…","name":"jonasComputer"}
+ *   {"type":"call","id":1,"method":"ask","summary":"Deploy to prod?","at":"…"}
+ *   {"type":"call-done","id":1,"method":"ask","ok":true,"ms":1234}
+ */
+export async function runUseMyComputerJson(input: ConnectInput): Promise<never> {
+  const name = input.name ?? proposeComputerName();
+  const itx = await connectAndProvide(input, name, withActivity(myComputer));
+  emitJson({ type: "status", loggedIn: true, project: input.projectId, name });
+  // If the menu-bar parent goes away, stdin closes — stop sharing rather than
+  // leaving the computer silently lent with no window onto it.
+  process.stdin.on("end", () => process.exit(0));
+  process.stdin.resume();
+  return holdWarm(itx);
+}
+
+/** One NDJSON line to stdout — the machine protocol's only output channel. */
+function emitJson(line: Record<string, unknown>): void {
+  process.stdout.write(`${JSON.stringify(line)}\n`);
+}
+
+/** Emitted (and the process exits) when there is no usable session yet. */
+export function emitComputerNeedsLogin(): void {
+  emitJson({ type: "status", loggedIn: false });
+}
+
+/**
+ * Wrap each capability method so it emits `call` before running and `call-done`
+ * after — the menu-bar app reads these to show which agent action is live. The
+ * behaviour is otherwise identical: the wrapped method awaits the real one and
+ * returns (or rethrows) exactly what it did.
+ */
+function withActivity(capability: typeof myComputer): typeof myComputer {
+  let nextId = 0;
+  const wrapped = {} as Record<string, (arg: never) => Promise<unknown>>;
+  for (const [method, fn] of Object.entries(capability)) {
+    wrapped[method] = async (arg: never) => {
+      const id = (nextId += 1);
+      emitJson({
+        type: "call",
+        id,
+        method,
+        summary: summarizeCall(method, arg),
+        at: new Date().toISOString(),
+      });
+      const startedAt = Date.now();
+      try {
+        const result = await fn(arg);
+        emitJson({ type: "call-done", id, method, ok: true, ms: Date.now() - startedAt });
+        return result;
+      } catch (error) {
+        emitJson({
+          type: "call-done",
+          id,
+          method,
+          ok: false,
+          ms: Date.now() - startedAt,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+    };
+  }
+  return wrapped as typeof myComputer;
+}
+
+/** A short, human-readable line describing one call — for the app's activity log. */
+function summarizeCall(method: string, arg: unknown): string {
+  const input = (arg ?? {}) as { question?: string; message?: string; code?: string };
+  if (method === "ask") return truncate(input.question ?? "asked a question");
+  if (method === "notify") return truncate(input.message ?? "sent a notification");
+  if (method === "runSwift") {
+    const lines = (input.code ?? "").split("\n").filter((line) => line.trim() !== "").length;
+    return `ran ${lines} line${lines === 1 ? "" : "s"} of Swift`;
+  }
+  return method;
+}
+
+const truncate = (text: string) => (text.length > 80 ? `${text.slice(0, 79)}…` : text);
 
 // ── tiny local helpers ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
Stacked on #1868 (egress approvals). Adds the **other half** of the menu-bar app: it already lends *you* to a project (approve egress); this lends your *computer*.

## What it does

`iterate use-my-computer` already mounts a live `itx.<name>` capability whose calls run on your Mac — `ask` (native dialog), `notify` (desktop notification), `runSwift` (arbitrary Swift). This surfaces it in the menu-bar app and shows when an agent is actively using it.

- **Toggle in the dropdown** — flip **Use my computer** on (enabled once you're signed in) to share; off (or quit) to stop. Opt-in by design.
- **Live activity** — while shared, the dropdown lists recent calls as they happen (`ask · Deploy to prod?`, spinner while running), and a **green dot appears in the menu bar** whenever a call is in flight. That's the "show when the machine is being used."
- **`iterate use-my-computer --json`** — the machine front-end the app drives. Same live mount, but each agent call emits `call` / `call-done` NDJSON with a one-line summary. Never opens a browser (emits a needs-login line); exits when the parent's stdin closes so the computer is never left silently shared behind a dead app.

## How it's built

- `use-my-computer.ts`: split connect/provide from the warm-hold; added `runUseMyComputerJson` + a `withActivity` wrapper that instruments each capability method with `call`/`call-done` (result/error passthrough unchanged).
- `cli.ts`: `--json` flag on `use-my-computer`, mirroring `approve --json`'s auth/needs-login handling.
- `Iterate.swift`: a new `ComputerController` that mirrors the approver's **hardened stdout lifecycle** (generation-guarded chunks, EOF handling, `detachIO`) but deliberately **does not auto-reconnect** — re-lending your machine should be a conscious act. Both watchers are torn down on quit.

## Out-of-model note

Unlike egress approvals (where secret material never reaches the approval device), `runSwift`/`ask` calls execute on your Mac as you — that's the whole point of `use-my-computer`, and it's why sharing is explicit, visible, and one-click revocable.

## How to test

macOS, human-in-the-loop (like the Touch ID path, not CI-automatable):

1. `iterate approve --project <slug> --menubar` — launches the app (rebuilds on the new Swift).
2. Sign in, flip **Use my computer** on → dropdown shows `itx.<name> is live`.
3. From an agent / itx script: `await itx.<name>.ask({ question: "Deploy to prod?" })` — a native dialog pops, the menu-bar shows a green dot + the call in the list, and it clears when done.
4. Quit the app → sharing stops (the child exits on stdin close / terminate).

Gates green locally: typecheck, lint, knip, `packages/iterate` build, and `swiftc -typecheck` on the menu-bar sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Agents can run native dialogs, notifications, and arbitrary Swift on the user's Mac when sharing is enabled; the PR adds visibility and revocability but the underlying capability is inherently high-privilege local execution.
> 
> **Overview**
> Extends the Iterate menu-bar app (alongside egress approve) so you can **opt in to lending your Mac** to a project's agents via the same live `itx.<name>` capability as `iterate use-my-computer`.
> 
> **CLI:** `use-my-computer` gains **`--json`** — NDJSON on stdout (`status`, `call`, `call-done`) for the app, no browser auto-login (emits needs-login instead), and exits when parent stdin closes so sharing isn't left on silently. `use-my-computer.ts` splits connect/mount from the warm hold and wraps capability methods with **`withActivity`** for that stream; terminal mode unchanged.
> 
> **Menu bar (Swift):** New **`ComputerController`** spawns `iterate use-my-computer --json`, parses NDJSON with the same generation-guarded stdout lifecycle as the approver but **no auto-reconnect** on exit. Dropdown adds a **Use my computer** toggle, live call list, and a **green menu-bar dot** while calls are in flight; sharing stops on logout, toggle off, or quit (both watchers torn down).
> 
> **Docs:** README documents the command and menubar integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a3daaffafc8b652f76d788fc55c0f6584b17e55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +403 -26 | +341 -15 🟩🟩🟩🟩🟩 |
| Docs | +19 -0 | +15 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+422 -26** | **+356 -15** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 1a28a18 and 6a3daaf, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->