### PR TITLE
Agent: feed the response-so-far from an interrupted LLM request back to the model

### DIFF
--- a/apps/os/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/os/src/domains/agents/agent-processor-implementation.ts
@@ -29,6 +29,7 @@ import {
   type AgentFileAttachment,
 } from "./agent-processor-contract.ts";
 import {
+  extractChunkText,
   jsonCompatible,
   normalizeLlmUsage,
   runWorkersAiAttempt,
@@ -82,6 +83,10 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
   readonly #scheduledRequestTimers = new Map<string, { cancel: () => void }>();
   /** llmRequestOffsets with an execution alive in THIS incarnation. */
   readonly #liveLlmExecutions = new Set<number>();
+  /** Streamed assistant text so far by llmRequestOffset — what an interrupt
+   * hands back to the model as its "response so far". Incarnation-local best
+   * effort: an eviction loses it, and the crash-cancel path never had it. */
+  readonly #partialLlmResponseTexts = new Map<number, string>();
 
   #now(): number {
     return (this.deps.now ?? Date.now)();
@@ -152,7 +157,9 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
         if (event.payload.llmRequestPolicy.behaviour !== "interrupt-current-request") return;
         const interruptedRequest = previousState.currentRequest;
         if (interruptedRequest === null) return;
-        blockProcessorWhile(() => append(this.#cancelEventForCurrentRequest(interruptedRequest)));
+        blockProcessorWhile(() =>
+          append(...this.#cancelEventsForCurrentRequest(interruptedRequest)),
+        );
         return;
       }
       case "events.iterate.com/agents/web-message-sent": {
@@ -179,7 +186,7 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
         if (event.payload.llmRequestPolicy.behaviour !== "interrupt-current-request") return;
         const interrupted = previousState.currentRequest;
         if (interrupted === null) return;
-        blockProcessorWhile(() => append(this.#cancelEventForCurrentRequest(interrupted)));
+        blockProcessorWhile(() => append(...this.#cancelEventsForCurrentRequest(interrupted)));
         return;
       }
       case "events.iterate.com/agent/llm-request-scheduled":
@@ -644,22 +651,32 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
     };
   }
 
-  #cancelEventForCurrentRequest(request: NonNullable<AgentState["currentRequest"]>) {
+  /**
+   * The cancel for a user interrupt — plus, when this incarnation streamed
+   * any of the doomed attempt's text, a model-visible input carrying the
+   * response so far. Without it the next turn silently loses everything the
+   * user just watched stream; the model would repeat or contradict itself
+   * with no idea why. dont-trigger-request: the interrupting input is the
+   * trigger. Refold-safe: replays find an empty map and the cancel dedupes.
+   */
+  #cancelEventsForCurrentRequest(request: NonNullable<AgentState["currentRequest"]>) {
     if (request.phase === "scheduled") {
-      return {
-        type: "events.iterate.com/agent/llm-request-cancelled" as const,
-        idempotencyKey: this.idempotencyKey(
-          `llm-request-cancelled@scheduled:${request.scheduledOffset}`,
-        ),
-        payload: {
-          phase: "scheduled" as const,
-          reason: "interrupted-by-user-input" as const,
-          requestId: request.requestId,
+      return [
+        {
+          type: "events.iterate.com/agent/llm-request-cancelled" as const,
+          idempotencyKey: this.idempotencyKey(
+            `llm-request-cancelled@scheduled:${request.scheduledOffset}`,
+          ),
+          payload: {
+            phase: "scheduled" as const,
+            reason: "interrupted-by-user-input" as const,
+            requestId: request.requestId,
+          },
         },
-      };
+      ];
     }
 
-    return {
+    const cancelEvent = {
       type: "events.iterate.com/agent/llm-request-cancelled" as const,
       idempotencyKey: this.idempotencyKey(
         `llm-request-cancelled@requested:${request.llmRequestOffset}`,
@@ -670,6 +687,21 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
         llmRequestOffset: request.llmRequestOffset,
       },
     };
+    const partialResponse = this.#partialLlmResponseTexts.get(request.llmRequestOffset);
+    if (partialResponse === undefined || partialResponse.trim() === "") return [cancelEvent];
+    return [
+      cancelEvent,
+      {
+        type: "events.iterate.com/agent/input-added" as const,
+        idempotencyKey: this.idempotencyKey(
+          `render-interrupted-partial@${request.llmRequestOffset}`,
+        ),
+        payload: {
+          content: `Your in-progress response was interrupted by the user input above and cancelled. It never completed, and no code block in it was executed. Your response so far:\n\n${partialResponse}`,
+          llmRequestPolicy: { behaviour: "dont-trigger-request" as const },
+        },
+      },
+    ];
   }
 
   /**
@@ -715,6 +747,12 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
         })),
         model,
         onChunk: async (chunk, index) => {
+          // Accumulated text is what an interrupt hands back to the model as
+          // its "response so far" (#cancelEventsForCurrentRequest).
+          this.#partialLlmResponseTexts.set(
+            llmRequestOffset,
+            (this.#partialLlmResponseTexts.get(llmRequestOffset) ?? "") + extractChunkText(chunk),
+          );
           // Ephemeral: the durable truth is the output-added /
           // llm-request-completed pair below.
           await this.append({
@@ -788,6 +826,11 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
           },
         },
       });
+    } finally {
+      // The attempt is settled; a cancel for it can no longer be appended
+      // (the completion or the cancel already cleared currentRequest), so the
+      // accumulated text has no remaining reader.
+      this.#partialLlmResponseTexts.delete(llmRequestOffset);
     }
   }
 

--- a/apps/os/src/domains/agents/agent-processors.test.ts
+++ b/apps/os/src/domains/agents/agent-processors.test.ts
@@ -1274,6 +1274,84 @@ describe("interrupt and stray-request hygiene", () => {
     });
   });
 
+  it("an interrupt mid-stream feeds the response so far back as model-visible input", async () => {
+    const encoder = new TextEncoder();
+    let sse!: ReadableStreamDefaultController<Uint8Array>;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        sse = controller;
+      },
+    });
+    const stream = new MemoryStream();
+    const agent = new AgentProcessor({
+      stream,
+      path: stream.path,
+      projectId: null,
+      ai: {
+        async run() {
+          return body;
+        },
+      },
+    });
+    const cursors = new Map<object, number>();
+    const deliver = () => deliverNewEvents({ processor: agent, stream, cursors });
+
+    await stream.append(...agentRequestEvents("tell me a long story"));
+    await deliver(); // reconcile drives the requested obligation; the attempt starts draining
+    sse.enqueue(encoder.encode(`data: ${JSON.stringify({ response: "Once upon a time" })}\n\n`));
+    // The chunk event is the evidence the accumulator has seen the text.
+    await vi.waitFor(() => {
+      expect(
+        stream.events.some((event) => event.type === "events.iterate.com/agent/llm-response-chunk"),
+      ).toBe(true);
+    });
+
+    await stream.append({
+      type: "events.iterate.com/agent/input-added",
+      payload: {
+        content: "stop — different question",
+        llmRequestPolicy: { behaviour: "interrupt-current-request" },
+      },
+    });
+    await deliver(); // appends the cancel + the response-so-far input
+
+    const partialInput = stream.events.find(
+      (event) =>
+        event.type === "events.iterate.com/agent/input-added" &&
+        typeof event.payload?.content === "string" &&
+        event.payload.content.includes("Once upon a time"),
+    );
+    expect(partialInput?.payload?.content).toContain("Your response so far");
+    expect(partialInput?.payload).toMatchObject({
+      llmRequestPolicy: { behaviour: "dont-trigger-request" },
+    });
+    // The partial folds into history, so the NEXT request's prompt carries it.
+    const state = reduceAgentEvents(stream.events);
+    expect(
+      state.history.some(
+        (item) =>
+          item.role === "user" &&
+          typeof item.content === "string" &&
+          item.content.includes("Once upon a time"),
+      ),
+    ).toBe(true);
+
+    // Let the doomed attempt finish: its completion settles as stale, so no
+    // output-added doubles up with the partial already in history.
+    sse.enqueue(encoder.encode("data: [DONE]\n\n"));
+    sse.close();
+    await vi.waitFor(() => {
+      expect(
+        stream.events.some(
+          (event) => event.type === "events.iterate.com/agent/llm-request-completed",
+        ),
+      ).toBe(true);
+    });
+    expect(
+      stream.events.some((event) => event.type === "events.iterate.com/agent/output-added"),
+    ).toBe(false);
+  });
+
   it("settles a stray non-current requested obligation without dialing the AI binding", async () => {
     const stream = new MemoryStream();
     let dials = 0;

--- a/apps/os/src/domains/agents/workers-ai-transport.ts
+++ b/apps/os/src/domains/agents/workers-ai-transport.ts
@@ -367,7 +367,7 @@ function extractAssistantText(raw: unknown): string {
   throw new Error("AI response did not contain assistant text.");
 }
 
-function extractChunkText(chunk: unknown): string {
+export function extractChunkText(chunk: unknown): string {
   if (typeof chunk === "string") return chunk;
   if (typeof chunk !== "object" || chunk === null) return "";
   if ("response" in chunk && typeof chunk.response === "string") return chunk.response;


### PR DESCRIPTION
## What

When a user interrupt cancels an in-flight LLM request, the agent now feeds the text the request had streamed so far back to the model as a model-visible input on the next turn. We used to have this behaviour; the current processor's currency check (`#isRequestStillCurrent`) silently drops a cancelled attempt's entire output, so the next turn's prompt loses everything the user just watched stream — the model repeats or contradicts itself with no idea it was cut off.

## How

Deliberately minimal — no contract change, no new event types:

- `#executeLlmRequest` accumulates each attempt's streamed text per `llmRequestOffset` in an incarnation-local map, reusing the existing `onChunk` hook and the transport's `extractChunkText` (now exported). The entry is deleted when the attempt settles.
- `#cancelEventForCurrentRequest` becomes `#cancelEventsForCurrentRequest`: when an interrupt cancels a **requested**-phase attempt and the map holds non-empty text, the cancel is appended atomically with an `input-added` carrying the partial:

  > Your in-progress response was interrupted by the user input above and cancelled. It never completed, and no code block in it was executed. Your response so far: …

  `dont-trigger-request` — the interrupting input remains the turn's trigger.

## Why this shape

- **Rides `input-added`**, the platform's established lane for model-visible facts (script results, LLM failure renders, web-message reflections) — folds into history with zero reducer/contract changes.
- **Never executes partial scripts**: only `output-added` feeds codemode extraction, so a truncated ```js block in the partial cannot run.
- **Best effort by design**: an eviction loses the accumulator, and the crash-cancel path (`durable-object-crashed`) never had one — those cancels carry no partial, exactly as today.
- **Refold-safe**: the appends share the cancel's idempotency scope; replays find an empty map and everything dedupes.

## Testing

New unit test drives a real SSE stream through the processor, interrupts mid-stream, and asserts: the response-so-far input lands with `dont-trigger-request`, it folds into the next prompt's history, and the stale completion adds no duplicate `output-added`. Full agent-domain suite (85 tests), typecheck, lint, format all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core interrupt/cancel behavior for in-flight LLM turns; mitigated by existing `input-added` lane, no partial script execution, and a dedicated integration test.
> 
> **Overview**
> When a user **interrupts an in-flight LLM request**, the processor no longer drops streamed text on the next turn. It **accumulates chunk text** per `llmRequestOffset` during `#executeLlmRequest` (via exported `extractChunkText`) and, on cancel, may append an **`input-added`** alongside `llm-request-cancelled` that quotes the response so far with **`dont-trigger-request`**.
> 
> `#cancelEventForCurrentRequest` becomes **`#cancelEventsForCurrentRequest`** (array); interrupt handlers spread multiple events. Partial state is **incarnation-local** and cleared in a **`finally`** when the attempt settles. **No contract or reducer changes** — partials fold like other model-visible inputs and still skip codemode via no `output-added`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af26384d38ccbf4813943b8fe99c075769beeeee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-11T22:57:03.787Z",
      "headSha": "af26384d38ccbf4813943b8fe99c075769beeeee",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/307407555025440",
      "shortSha": "af26384",
      "cleanupDurationMs": 8677,
      "deployDurationMs": 81679,
      "testDurationMs": 129895,
      "testRetries": "2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · stream subscribe replays history, tails live appends, and unsubscribes (vitest x1)",
      "workerSizeKib": 15938.29,
      "workerGzipKib": 4298.16,
      "mainWorkerGzipKib": 4297.72
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-11T22:56:57.768Z",
      "headSha": "af26384d38ccbf4813943b8fe99c075769beeeee",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/307407555025440",
      "shortSha": "af26384",
      "cleanupDurationMs": 2655,
      "deployDurationMs": 22104,
      "testDurationMs": 686,
      "testRetries": null,
      "workerSizeKib": 4031.76,
      "workerGzipKib": 819.22,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `af26384` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 819.2 KiB | 22.1s | 686ms |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/307407555025440) | 2026-07-11T22:56:57.768Z | Preview app released. |
| OS | released | `af26384` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 4.20 MiB (+0.4 KiB vs main) | 81.7s | 129.9s | 2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · stream subscribe replays history, tails live appends, and unsubscribes (vitest x1) | 8.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/307407555025440) | 2026-07-11T22:57:03.787Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +58 -15 | +42 -15 🟩🟩🟩🟥⬜ |
| Tests | +78 -0 | +69 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+136 -15** | **+111 -15** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between a4a35ea and af26384, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->