### PR TITLE
Gate hardening: prd break-test findings (follow-up to #1882)

### DIFF
--- a/apps/os/src/domains/typecheck/compiler-cache.test.ts
+++ b/apps/os/src/domains/typecheck/compiler-cache.test.ts
@@ -1,0 +1,60 @@
+// The compiler cache's one job beyond memoization: after a mid-compile crash,
+// the NEXT get() must hand back a fresh instance, not the dead one. This is
+// what keeps the execution gate from failing open forever when the tswasm
+// program exits (see compiler-cache.ts).
+
+import { describe, expect, it } from "vitest";
+import { createCompilerCache } from "./compiler-cache.ts";
+
+describe("createCompilerCache", () => {
+  it("memoizes one instance across get() calls", async () => {
+    let built = 0;
+    const cache = createCompilerCache(async () => ({ id: ++built }));
+    const a = await cache.get();
+    const b = await cache.get();
+    expect(a).toBe(b);
+    expect(built).toBe(1);
+  });
+
+  it("re-instantiates after resetIfCurrent — the crash-recovery path", async () => {
+    let built = 0;
+    const cache = createCompilerCache(async () => ({ id: ++built }));
+    const dead = cache.get();
+    await dead;
+    // A compile on `dead` crashed; drop it.
+    cache.resetIfCurrent(dead);
+    const fresh = await cache.get();
+    expect((await dead).id).toBe(1);
+    expect(fresh.id).toBe(2);
+    expect(built).toBe(2);
+  });
+
+  it("resetIfCurrent is a no-op for a stale promise (a newer instance survives)", async () => {
+    let built = 0;
+    const cache = createCompilerCache(async () => ({ id: ++built }));
+    const first = cache.get();
+    await first;
+    cache.resetIfCurrent(first); // drops first
+    const second = cache.get();
+    await second;
+    // A late crash report for the ALREADY-replaced `first` must not evict the
+    // live `second`.
+    cache.resetIfCurrent(first);
+    expect(await cache.get()).toBe(await second);
+    expect(built).toBe(2);
+  });
+
+  it("does not cache a failed instantiation — the next get() retries", async () => {
+    let attempt = 0;
+    const cache = createCompilerCache(async () => {
+      attempt++;
+      if (attempt === 1) throw new Error("wasm instantiation failed");
+      return { id: attempt };
+    });
+    await expect(cache.get()).rejects.toThrow("wasm instantiation failed");
+    // Let the .catch() eviction settle before retrying.
+    await Promise.resolve();
+    const ok = await cache.get();
+    expect(ok.id).toBe(2);
+  });
+});

--- a/apps/os/src/domains/typecheck/compiler-cache.ts
+++ b/apps/os/src/domains/typecheck/compiler-cache.ts
@@ -1,0 +1,40 @@
+// One tswasm compiler per isolate, shared across checks — with the one
+// invalidation the memoization must have: a compiler that DIED mid-compile is
+// dropped, so the next check re-instantiates instead of reusing a corpse.
+//
+// The failure this closes (seen live in prd): the typescript-go wasm program
+// can exit permanently mid-`compile()` ("Go program has already exited"). The
+// old memoization only re-created the compiler when INSTANTIATION rejected, so
+// a post-instantiation death was cached forever — every later check returned
+// the crash diagnostic, which the execution gate reads as "unchecked" and
+// runs. That fails the gate OPEN durably (all projects share one sidecar
+// isolate) until traffic quiets enough for the isolate to be evicted.
+//
+// Kept free of cloudflare imports so it is unit-testable with a fake factory.
+
+/** A compiler cache: `get()` returns the shared instance (creating it once),
+ * `resetIfCurrent()` drops it so the next `get()` re-creates — call it when a
+ * compile crashed on the promise you were holding. */
+export interface CompilerCache<C> {
+  get(): Promise<C>;
+  resetIfCurrent(promise: Promise<C>): void;
+}
+
+export function createCompilerCache<C>(factory: () => Promise<C>): CompilerCache<C> {
+  let current: Promise<C> | undefined;
+  return {
+    get() {
+      const promise = (current ??= factory());
+      // A failed INSTANTIATION must not be cached — caching the rejection would
+      // poison every later get() until isolate death. Only clear if we are
+      // still the owner (a concurrent get() may already have replaced it).
+      promise.catch(() => {
+        if (current === promise) current = undefined;
+      });
+      return promise;
+    },
+    resetIfCurrent(promise) {
+      if (current === promise) current = undefined;
+    },
+  };
+}

--- a/apps/os/src/domains/typecheck/compiler-cache.ts
+++ b/apps/os/src/domains/typecheck/compiler-cache.ts
@@ -15,7 +15,7 @@
 /** A compiler cache: `get()` returns the shared instance (creating it once),
  * `resetIfCurrent()` drops it so the next `get()` re-creates — call it when a
  * compile crashed on the promise you were holding. */
-export interface CompilerCache<C> {
+interface CompilerCache<C> {
   get(): Promise<C>;
   resetIfCurrent(promise: Promise<C>): void;
 }

--- a/apps/os/src/domains/typecheck/typechecker-entrypoint.ts
+++ b/apps/os/src/domains/typecheck/typechecker-entrypoint.ts
@@ -9,6 +9,7 @@ import { createCachedFetch } from "@iterate-com/typm/cached-fetch";
 // 10 MiB compressed script limit (upload rejected, error 10027).
 import typescriptWasm from "tswasm/tswasm.wasm";
 import { runTypecheck, type TypecheckResult } from "./run-typecheck.ts";
+import { createCompilerCache } from "./compiler-cache.ts";
 
 /** The whole input is inert data: a virtual file map. The checker holds no
  * bindings and grants no authority; it does make outbound GETs the input
@@ -31,19 +32,12 @@ const typmFetch = createCachedFetch({
     url.startsWith("https://cdn.jsdelivr.net/") && !url.includes("/package/resolve/"),
 });
 
-/** One wasm instantiation per isolate, shared across requests. A failed
- * instantiation is NOT cached: caching the rejection would poison every
- * later check until isolate death, so the next check retries. */
-let compilerPromise: Promise<Compiler> | undefined;
-function compiler(): Promise<Compiler> {
-  const promise = (compilerPromise ??= createCompiler({
-    wasm: typescriptWasm as WebAssembly.Module,
-  }));
-  promise.catch(() => {
-    if (compilerPromise === promise) compilerPromise = undefined;
-  });
-  return promise;
-}
+/** One wasm instantiation per isolate, shared across requests. Drops the
+ * instance on a failed instantiation AND after a mid-compile crash (see
+ * compiler-cache.ts and the reset in `check`). */
+const compilerCache = createCompilerCache<Compiler>(() =>
+  createCompiler({ wasm: typescriptWasm as WebAssembly.Module }),
+);
 
 /**
  * The typechecker worker's entrypoint: a pure function worker (files in,
@@ -59,10 +53,21 @@ export class TypecheckerEntrypoint extends WorkerEntrypoint {
 
   async check(input: { files: Record<string, string> }): Promise<TypecheckResult> {
     const { files } = CheckInput.parse(input);
-    return await runTypecheck({
-      compiler: await compiler(),
+    const compilerPromise = compilerCache.get();
+    const result = await runTypecheck({
+      compiler: await compilerPromise,
       fetchImpl: typmFetch,
       files,
     });
+    // runTypecheck turns a mid-compile crash (the wasm program exiting) into a
+    // code-0 diagnostic. The compiler instance may now be permanently dead, so
+    // drop it: the next check re-instantiates rather than reusing the corpse
+    // and reporting a crash forever (which the gate reads as unchecked → the
+    // gate would silently fail open). Cheap re-instantiation (~40ms) is the
+    // right price to keep the gate honest.
+    if (result.diagnostics.some((diagnostic) => diagnostic.code === 0)) {
+      compilerCache.resetIfCurrent(compilerPromise);
+    }
+    return result;
   }
 }

--- a/apps/os/src/domains/typecheck/virtual-project.test.ts
+++ b/apps/os/src/domains/typecheck/virtual-project.test.ts
@@ -561,3 +561,78 @@ test("execution gate: provable script bugs the run would only surface at runtime
     expect(checked.verdict, code).toBe("problems");
   }
 });
+
+// ─── Regression: prd break-test findings (follow-up to #1882) ────────────────
+// Four false-positive / robustness holes the production break-test surfaced.
+// Each asserts the RUNTIME-legal behavior the gate must now preserve.
+
+test("execution gate regression: ES2024+ runtime features are not blocked as syntax errors (TS1501)", async () => {
+  // The regex `v` flag runs in workerd; pinning target es2022 reported TS1501
+  // ("only available when targeting es2024 or later") — a 1xxx code the gate
+  // blocked as if it were a parse error. matching the runtime target fixes it.
+  const vFlag = await gate("async (itx) => { const re = /[\\p{L}]/v; return re.test('x'); }");
+  expect(vFlag).toEqual({ verdict: "clean" });
+  // A sibling target-availability feature: top-level-style await already inside
+  // the async body is fine; `using` (ES2026 explicit resource management) too.
+  const using = await gate("async (itx) => { using d = { [Symbol.dispose]() {} }; void d; }");
+  expect(using).toEqual({ verdict: "clean" });
+});
+
+test("execution gate regression: near-miss on the runtime-extensible itx root does NOT block", async () => {
+  // provide-then-use in one script: the mount does not exist statically, and
+  // its near-miss to `agent` used to bounce it (TS2551 → blocked). The root is
+  // runtime-extensible, so this must run.
+  const provideThenUse = await gate(`async (itx) => {
+    await itx.capabilityHost.provideCapability({ type: "itx-expression", path: ["agentz"], expression: ["streams", ["get", "/"]] });
+    return typeof itx.agentz;
+  }`);
+  expect(provideThenUse).toEqual({ verdict: "clean" });
+
+  // A bare root-member typo (`itx.strems`) reads identically to a dynamic
+  // provide — indistinguishable statically — so it too must run (the price of
+  // a runtime-extensible root; sub-member typos below stay caught).
+  const rootTypo = await gate("async (itx) => itx.strems.get('/')");
+  expect(rootTypo).toEqual({ verdict: "clean" });
+
+  // The refinement must NOT weaken the flagship catches: near-miss on a
+  // CONCRETE sub-surface is still provable and still blocks.
+  const subMemberTypo = await gate("async (itx) => itx.streams.gett('/')");
+  expect(subMemberTypo.verdict).toBe("problems");
+  const mountTypo = await gate("async (itx) => itx.tools.weather.forecastt({ city: 'x' })", [
+    WEATHER_MOUNT,
+  ]);
+  expect(mountTypo.verdict).toBe("problems");
+  // A misspelled LOCAL (TS2552, not a root property) still blocks.
+  const localTypo = await gate("async (itx) => { const count = 1; return cuont + 1; }");
+  expect(localTypo.verdict).toBe("problems");
+});
+
+test("execution gate regression: pathologically-nested scripts bail to unchecked, never reaching tsc", async () => {
+  // ~1200-deep nesting wedged the host DO past its storage watchdog (tsc's
+  // recursive descent is synchronous; the deadline fires too late). The cheap
+  // depth guard bails to unchecked BEFORE the compiler is dialed — proven here
+  // by a poisoned typechecker that throws if it is ever called.
+  const exploding: Typechecker = {
+    check: () => Promise.reject(new Error("typechecker must not be dialed for deep scripts")),
+  };
+  const deep = `async (itx) => { const x = ${"[".repeat(1200)}1${"]".repeat(1200)}; return x; }`;
+  const checked = await checkItxScriptForExecution({
+    capabilities: [],
+    code: deep,
+    typechecker: exploding,
+  });
+  expect(checked.verdict).toBe("unchecked");
+  expect((checked as { reason: string }).reason).toContain("nesting");
+
+  // A normal script with ordinary nesting still reaches the real checker.
+  const shallow = await gate("async (itx) => itx.streams.gett('/')");
+  expect(shallow.verdict).toBe("problems");
+});
+
+test("execution gate regression: diagnostic columns are 1-based (match the line and editors)", async () => {
+  // `gett` sits at 1-based column 28 in `itx.streams.gett`; the message must
+  // read :28, not the tswasm-native 0-based :27.
+  const checked = await gate("async (itx) => itx.streams.gett('/')");
+  expect(checked.verdict).toBe("problems");
+  expect((checked as { problems: string[] }).problems[0]).toContain("script:1:28");
+});

--- a/apps/os/src/domains/typecheck/virtual-project.ts
+++ b/apps/os/src/domains/typecheck/virtual-project.ts
@@ -116,7 +116,12 @@ const SHARED_FILES: Record<string, string> = {
     compilerOptions: {
       module: "esnext",
       moduleResolution: "bundler",
-      target: "es2022",
+      // Match the runtime, not a fixed year: scripts run in workerd on current
+      // V8, so a feature the runtime has (the regex `v` flag, top-level await,
+      // import.meta) must not report a target-availability error (TS1501 and
+      // kin live in the 1xxx "syntax" range the gate blocks on). Pinning an old
+      // target made runtime-legal scripts un-runnable.
+      target: "esnext",
       strict: false,
       skipLibCheck: true,
     },
@@ -287,15 +292,62 @@ const EXECUTION_CHECK_DEADLINE_MS = 10_000;
  * types, handle results declared `{}`). The advisory door (checkItxScript)
  * still reports everything.
  */
-const NEAR_MISS_TYPO_CODES = new Set([
-  2551, // Property 'X' does not exist on type 'T'. Did you mean 'Y'?
-  2552, // Cannot find name 'X'. Did you mean 'Y'?
-]);
+const TS_PROPERTY_NEAR_MISS = 2551; // Property 'X' does not exist on type 'T'. Did you mean 'Y'?
+const TS_NAME_NEAR_MISS = 2552; // Cannot find name 'X'. Did you mean 'Y'?
 
 /** TS grammar diagnostics live in the 1xxx range. Unparseable code is the one
  * verdict that needs no type knowledge at all — the runtime's module loader
  * would reject the same script with a worse message. */
 const isSyntaxError = (code: number) => code >= 1000 && code < 2000;
+
+/** The itx root passed to a script (`itx: Itx`, where `Itx = Project & …mounts`)
+ * is RUNTIME-EXTENSIBLE: a script can `provideCapability` a new top-level path
+ * and call it two lines later, so a missing property ON THE ROOT is never
+ * provably wrong — even when it near-misses an existing member (`itx.agentz`
+ * vs `agent`, `itx.strems` vs `streams` read identically to a static check).
+ * A near-miss on a CONCRETE sub-surface (`itx.streams.gett` on
+ * `ProjectStreamCollection`, a typed mount's `T`) stays provable and blocks —
+ * those types are not extended by a provide. Message-shaped because the type
+ * name is the only signal tsc gives; the alias collapses to `Project` or `Itx`. */
+const isRootExtensibleMiss = (message: string) =>
+  /does not exist on type '(?:Project|Itx)'/.test(message);
+
+/** Whether a script-own diagnostic is provable enough to STOP a run. See the
+ * allowlist rationale on ScriptExecutionCheck. */
+function isProvableBlocker(diagnostic: TypecheckDiagnostic): boolean {
+  if (isSyntaxError(diagnostic.code)) return true;
+  // A missing local (`cuont`) is always provable — locals are not runtime-
+  // extensible the way the itx root is.
+  if (diagnostic.code === TS_NAME_NEAR_MISS) return true;
+  if (diagnostic.code === TS_PROPERTY_NEAR_MISS) return !isRootExtensibleMiss(diagnostic.message);
+  return false;
+}
+
+/** Bracket-nesting depth past which the script is handed to the runtime
+ * UNCHECKED instead of tsc. tsc's recursive-descent parser is synchronous and
+ * uninterruptible: a ~2KB script nesting `[[[…]]]` ~1200 deep blocked the host
+ * DO past its storage watchdog and forced a reset (the check's own deadline
+ * fires too late — the RPC is already in flight). V8 parses the same nesting
+ * in milliseconds, so bailing to the runtime is both safe and cheap. The cap
+ * sits far above any real script (1000-deep checked in ~200ms; real code is
+ * single digits). */
+const MAX_NESTING_DEPTH = 400;
+
+/** Cheap upper bound on bracket nesting — counts `([{` vs `)]}` without a
+ * parse. Brackets inside strings/comments inflate the count, which only makes
+ * the guard bail to UNCHECKED sooner: safe, since unchecked runs the script. */
+function exceedsNestingDepth(code: string, limit: number): boolean {
+  let depth = 0;
+  for (let i = 0; i < code.length; i++) {
+    const c = code[i];
+    if (c === "(" || c === "[" || c === "{") {
+      if (++depth > limit) return true;
+    } else if (c === ")" || c === "]" || c === "}") {
+      if (depth > 0) depth--;
+    }
+  }
+  return false;
+}
 
 /**
  * The pre-execution typecheck for a `script-execution-requested` block:
@@ -303,11 +355,13 @@ const isSyntaxError = (code: number) => code >= 1000 && code < 2000;
  * policy above. Blocking requires an error diagnostic in the script's OWN
  * code (`script.ts`) from the allowlist: a syntax error or a near-miss typo.
  * Everything the checker cannot vouch for runs instead — property/argument
- * mismatches (dynamic mounts and surface gaps make them unprovable), shapes
+ * mismatches (dynamic mounts and surface gaps make them unprovable), a
+ * near-miss on the runtime-extensible itx root (isRootExtensibleMiss), shapes
  * the agent extractor never produces (raw runScript callers send plain
- * function expressions), oversized scripts, broken mount declarations (stale
- * journals must not veto unrelated scripts), compiler crashes, an unreachable
- * typechecker, and the deadline. Never throws.
+ * function expressions), oversized or pathologically-nested scripts (the
+ * latter would wedge the host before the deadline fires), broken mount
+ * declarations (stale journals must not veto unrelated scripts), compiler
+ * crashes, an unreachable typechecker, and the deadline. Never throws.
  */
 export async function checkItxScriptForExecution(input: {
   capabilities: CapabilityDescription[];
@@ -326,6 +380,9 @@ export async function checkItxScriptForExecution(input: {
   }
   if (!RUNTIME_SCRIPT_SHAPE.test(input.code.trim())) {
     return { verdict: "unchecked", reason: "not the async block shape the checker models" };
+  }
+  if (exceedsNestingDepth(input.code, MAX_NESTING_DEPTH)) {
+    return { verdict: "unchecked", reason: `nesting deeper than ${MAX_NESTING_DEPTH}` };
   }
   const project = assembleScriptProject(input.capabilities, input.code);
   let checked: TypecheckResult;
@@ -346,7 +403,7 @@ export async function checkItxScriptForExecution(input: {
     (diagnostic) =>
       diagnostic.category === "error" &&
       diagnostic.fileName === "script.ts" &&
-      (isSyntaxError(diagnostic.code) || NEAR_MISS_TYPO_CODES.has(diagnostic.code)),
+      isProvableBlocker(diagnostic),
   );
   if (blocking.length === 0) return { verdict: "clean" };
   const problems = formatProblems(blocking, {
@@ -393,10 +450,10 @@ function formatProblems(
           diagnostic.line === undefined ? undefined : diagnostic.line + options.lineOffset;
         // Lines the assembly prepended (the prelude, an injected import) map
         // below 1 — report without a position rather than lying about one.
-        const position =
-          line === undefined || line < 1
-            ? ""
-            : `:${line}${diagnostic.column === undefined ? "" : `:${diagnostic.column}`}`;
+        // tswasm columns are 0-based; +1 to match the 1-based line and every
+        // editor's gutter (a `line:col` that disagrees on the col base misleads).
+        const column = diagnostic.column === undefined ? "" : `:${diagnostic.column + 1}`;
+        const position = line === undefined || line < 1 ? "" : `:${line}${column}`;
         return `${options.label}${position} — ${diagnostic.message} (TS${diagnostic.code})`;
       }
       const where = fileName.replace(/^mounts\//, "mount ").replace(/\.ts$/, "");


### PR DESCRIPTION
Follow-up to #1882. Four subagents ran **~305 probes against the gate in production**. The core behavior held up — correct blocks, correct journal shape (`requested → completed:error`, no `started`), no lost completions under concurrency, and permissive on every JS idiom, runtime global, and dynamic-capability case tried. They found **five holes**, fixed here, each with a regression test that pins the runtime-legal behavior.

## Findings & fixes

### HIGH — ES2024+ runtime features blocked as syntax errors
The tsconfig `target` was pinned `es2022`, so tsc emitted **TS1501** ("regular expression flag only available when targeting es2024 or later") for `/[\p{L}]/v` — a runtime-legal script (workerd runs current V8). TS1501 is in the 1xxx range the gate treats as a parse error, so it blocked. The `v`-flag script *ran* when routed through the unchecked lane, proving the false positive.
**Fix:** `target` now tracks the runtime (`esnext`), so target-availability diagnostics don't fire. Regression: the `v`-flag and `using` scripts return `clean`.

### HIGH — deep-nested literal wedges the host DO → reset
A ~2.4KB script with a ~1200-deep nested array literal blocked the capability-host DO for ~36s and forced a `Durable Object storage operation exceeded timeout` reset. tsc's recursive-descent parser is synchronous, so the 10s deadline fires too late — the RPC is already in flight. The identical nesting padded past the size cap (unchecked lane) ran in 175ms, isolating the cause to the check. Sharp cliff: depth 1000 fine (~200ms), 1200/1500 → reset.
**Fix:** a cheap pre-tsc bracket-depth guard (cap 400) bails such scripts to `unchecked` before the compiler is dialed. V8 parses deep nesting in ms, so running it is safe. Regression: a 1200-deep script returns `unchecked` and a poisoned typechecker proves the compiler is never called.

### HIGH — sidecar crash fails the gate open durably
A mid-compile wasm crash ("Go program has already exited") was cached forever: the old memoization only reset on failed *instantiation*, so after a resolved compiler died mid-`compile()`, every later check returned the code-0 crash diagnostic — which the gate reads as `unchecked` → the gate **failed open** for ~8 minutes (all projects share one `os-prd-typechecker` isolate), recovering only on eviction.
**Fix:** the compiler cache (new `compiler-cache.ts`, node-testable) drops a crashed instance so the next check re-instantiates (~40ms). The entrypoint calls `resetIfCurrent` when a check returns the code-0 crash sentinel. Regression: `compiler-cache.test.ts` covers memoize / reset-and-reinstantiate / stale-reset-is-noop / no-cache-on-failed-instantiation.

### MEDIUM — near-miss on the runtime-extensible itx root blocks provide-then-use
`provideCapability(["agentz"])` then `itx.agentz` in one script was blocked (TS2551 "does not exist on type 'Project'. Did you mean 'agent'?"). The root `Itx`/`Project` is runtime-extensible — a provide adds exactly that property — so a missing root property is never provable, even when it near-misses a member. `itx.strems` (a root-member typo) reads identically and now also runs (the price of an extensible root).
**Fix:** near-miss (TS2551) on the root `Project`/`Itx` type no longer blocks; near-miss on a concrete sub-surface (`ProjectStreamCollection`, a typed mount's `T`) and missing-local (TS2552) stay provable and still block. Regression asserts both directions, including that `itx.streams.gett` / `mount.forecastt` / a misspelled local still block.

### LOW — 0-based columns
Diagnostic columns were tswasm-native 0-based while lines were 1-based, so `line:col` disagreed with editors. **Fix:** `+1`. Regression pins `script:1:28` for `itx.streams.gett`.

## Not fixed here (reported, out of scope)
- **Agent turn ends silently when a script returns `undefined`** — pre-existing agent-loop behavior (returning nothing is how a turn ends); the gate's "resend" nudge can steer toward no-return resends. Worth a separate look.
- **`durable-object-crashed` mid-turn / "kill requested" on valid docs scripts** — correlated with sidecar memory pressure; the compiler-reset fix here should reduce the durable fallout, but the crash trigger itself is separate.
- **Provide-time `types` validation is an OOM/crash surface** (`checkCapabilityTypes` rejects on crash, unlike the exec gate) — pre-existing #1864 path.
- **Declared type-surface gaps** the gate exposed (`CloudflareSandbox.exec`/`instanceType`, `{}` handle results, `@slack/web-api` not resolving in prd) — these mislead `docs.get` readers too and deserve their own fix.

## Testing
- `compiler-cache.test.ts` (4 tests) + 4 regression tests in `virtual-project.test.ts` against the real tswasm compiler.
- `pnpm typecheck && pnpm lint && pnpm format && pnpm test` all green (os suite 1097 passing).
- The findings themselves came from ~305 live prd probes across four adversarial lanes (false-positives, true-positives + journal correctness, DoS/latency, and the real agent codemode loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core execution-gate blocking rules and typechecker isolate lifecycle; mistakes could block legitimate scripts or allow bad runs, but behavior is heavily regression-tested and skews permissive (unchecked) on ambiguity.
> 
> **Overview**
> Hardens the **pre-execution typecheck gate** using production break-test findings: fewer false blocks, safer behavior under wasm failure and pathological input, and clearer diagnostics.
> 
> **Typechecker sidecar:** Introduces `createCompilerCache` so a tswasm instance that dies mid-`compile()` is evicted (not only failed instantiation). `TypecheckerEntrypoint.check` calls `resetIfCurrent` when a code-0 crash diagnostic is returned, avoiding a shared isolate that stays “unchecked” and effectively fails the gate open.
> 
> **Gate policy (`checkItxScriptForExecution`):** Virtual project `target` is **`esnext`** so runtime-legal features (e.g. regex `v`, `using`) are not blocked as TS1501 syntax errors. **TS2551** near-misses on the runtime-extensible `Project`/`Itx` root no longer block (provide-then-use and root typos); sub-surface near-misses and TS2552 locals still block via `isProvableBlocker`. Scripts with bracket nesting **> 400** skip tsc and return **`unchecked`** to avoid wedging the host DO. Diagnostic **`line:col`** uses **1-based columns** in formatted problems.
> 
> Regression coverage: `compiler-cache.test.ts` and four tests in `virtual-project.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14950adbd9f4fc7645dfbead33eb8d97eb86c47b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +131 -29 | +60 -22 🟩🟩🟩🟩🟥 |
| Tests | +135 -0 | +90 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+266 -29** | **+150 -22** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between a4a35ea and 14950ad, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-11T22:52:51.949Z",
      "headSha": "14950adbd9f4fc7645dfbead33eb8d97eb86c47b",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/590319528377515",
      "shortSha": "14950ad",
      "cleanupDurationMs": 8933,
      "deployDurationMs": 67335,
      "testDurationMs": 183306,
      "testRetries": "4 retried: catalogue example \"typed-capability-mount\" runs identically across runtimes (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page repaints from a stream subscription after a page action (specs x1) · reactivity page replays already appended events after reload (specs x1)",
      "workerSizeKib": 15939.27,
      "workerGzipKib": 4298.47,
      "mainWorkerGzipKib": 4297.72
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-11T22:52:45.848Z",
      "headSha": "14950adbd9f4fc7645dfbead33eb8d97eb86c47b",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/590319528377515",
      "shortSha": "14950ad",
      "cleanupDurationMs": 2830,
      "deployDurationMs": 19144,
      "testDurationMs": 525,
      "testRetries": null,
      "workerSizeKib": 4031.76,
      "workerGzipKib": 819.35,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `14950ad` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 819.4 KiB | 19.1s | 525ms |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/590319528377515) | 2026-07-11T22:52:45.848Z | Preview app released. |
| OS | released | `14950ad` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 4.20 MiB (+0.8 KiB vs main) | 67.3s | 183.3s | 4 retried: catalogue example "typed-capability-mount" runs identically across runtimes (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page repaints from a stream subscription after a page action (specs x1) · reactivity page replays already appended events after reload (specs x1) | 8.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/590319528377515) | 2026-07-11T22:52:51.949Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->