### PR TITLE
Agent prompt caching: compaction rides the conversation's cached prefix (0% → 99.6% measured)

### DIFF
--- a/apps/os/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/os/src/domains/agents/agent-processor-implementation.ts
@@ -393,25 +393,34 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
       });
       if (resetsSinceMeasurement.length > 0) return;
 
-      const transcript = state.history
-        .map(
-          (message) =>
-            `${message.role === "user" ? "User" : "Assistant"}:\n${flattenMessageToText(message)}`,
-        )
-        .join("\n\n");
+      // Same transport as normal turns: BYOK carries the per-agent
+      // prompt_cache_key, so this request lands on the shard that already
+      // holds the conversation's prefix (and the cache discount lands on our
+      // bill — the unified lane meters cached tokens at the uncached price).
       const summary = await runWorkersAiAttempt({
         ai,
+        transport: this.deps.cloudflareAiGatewayTransport?.(),
         deadlineMs: DEFAULT_AGENT_LLM_REQUEST_EXPIRY_MS,
-        messages: [
-          { role: "system", content: AGENT_COMPACTION_PROMPT },
-          { role: "user", content: transcript },
-        ],
+        messages: buildAgentCompactionRequestBody(state).messages.map((message) => ({
+          role: message.role,
+          content: flattenMessageToText(message),
+        })),
         model: state.llmConfig.model,
         onChunk: async () => {},
       });
 
       const stateNow = reduceAgentEvents(await this.#readConsumedEvents());
       const carriedForward = stateNow.history.slice(state.history.length);
+      // The summary turn's own usage rides the reason string: compaction has
+      // no llm-request-requested offset, so a token-usage-reported event (its
+      // reducer keys on one, and its processEvent arm is this very trigger)
+      // does not fit — but the cached/input split is the whole evidence that
+      // the prefix-reuse above worked, so it must land in the journal.
+      const usage = normalizeLlmUsage(summary.usage);
+      const usageNote =
+        usage === undefined
+          ? ""
+          : `; summary llm usage: input=${usage.inputTokens} cached=${usage.cachedInputTokens ?? 0} output=${usage.outputTokens}`;
       await this.append({
         type: "events.iterate.com/agent/history-reset",
         idempotencyKey: this.idempotencyKey(`history-reset@${triggerOffset}`),
@@ -424,7 +433,7 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
             },
             ...carriedForward,
           ],
-          reason: `compaction@${triggerOffset}: ~${contextTokens} tokens > ${thresholdTokens}`,
+          reason: `compaction@${triggerOffset}: ~${contextTokens} tokens > ${thresholdTokens}${usageNote}`,
         },
       });
     } catch {
@@ -1176,12 +1185,20 @@ function renderFileHintLine(file: AgentFileAttachment): string {
 // =============================================================================
 
 /**
- * System prompt for the summary turn. The summary becomes the agent's ENTIRE
+ * Instruction for the summary turn. The summary becomes the agent's ENTIRE
  * memory of everything before the reset, so it optimizes for retrieval keys —
  * names, paths, ids, decisions — over narrative flow.
+ *
+ * It rides as the LAST message of the compaction request, behind the
+ * conversation exactly as normal turns send it — never as a fresh system
+ * prompt with the transcript re-rendered behind it. Compaction fires at the
+ * biggest prompt this agent will ever send (~half the context window), and
+ * the tail position means that whole prompt is a prefix the provider already
+ * has cached from the previous turn (90% input discount on gpt-5.5) instead
+ * of a from-scratch prompt sharing no bytes with it.
  */
 const AGENT_COMPACTION_PROMPT = [
-  "You are compacting an AI agent's conversation history because it is close to overflowing the model's context window. Write a summary that will REPLACE the transcript below as the agent's only memory of it.",
+  "You are compacting this AI agent conversation because it is close to overflowing the model's context window. Do not respond to the messages above. Instead, write a summary that will REPLACE everything above as the agent's only memory of it.",
   "",
   "Preserve, with their exact spellings:",
   "- who the user is, what they are trying to achieve, and their standing preferences or instructions",
@@ -1192,6 +1209,27 @@ const AGENT_COMPACTION_PROMPT = [
   "",
   "Write dense prose. No preamble, no headings about the summarization itself — output only the summary.",
 ].join("\n");
+
+/**
+ * The compaction request: the conversation EXACTLY as `buildAgentLlmRequestBody`
+ * sends it — same system prompt, same history messages — with the summarize
+ * instruction appended as the trailing message. Byte-identity with the normal
+ * turn's prefix is the point (guarded by a test): the provider's prompt cache
+ * matches on exact prefixes, so any re-rendering of the transcript would turn
+ * the most expensive request in an agent's life into a full cache miss.
+ */
+export function buildAgentCompactionRequestBody(state: {
+  systemPrompt: AgentState["systemPrompt"];
+  history: AgentState["history"];
+}): { messages: AgentChatMessage[] } {
+  return {
+    messages: [
+      { role: "system" as const, content: state.systemPrompt },
+      ...state.history,
+      { role: "system" as const, content: AGENT_COMPACTION_PROMPT },
+    ],
+  };
+}
 
 // =============================================================================
 // Context windows: model → the window the token-usage-reported payload claims.

--- a/apps/os/src/domains/agents/agent-processors.test.ts
+++ b/apps/os/src/domains/agents/agent-processors.test.ts
@@ -1842,7 +1842,10 @@ describe("token usage and history reset", () => {
           async run(model, body) {
             const { messages } = body as { messages: { role: string; content: string }[] };
             aiCalls.push({ model, messages });
-            if (messages[0]!.content.includes("compacting an AI agent's conversation history")) {
+            // The summarize instruction rides as the LAST message, behind the
+            // conversation exactly as normal turns send it (prompt-cache
+            // prefix reuse) — so that is where compaction is recognizable.
+            if (messages.at(-1)!.content.includes("compacting this AI agent conversation")) {
               return { response: "The user likes teal and is building STICKYMEETING." };
             }
             // A turn that ran at over half of gpt-5.5's 272k window.
@@ -1884,13 +1887,27 @@ describe("token usage and history reset", () => {
 
     const compactionCalls = () =>
       aiCalls.filter((call) =>
-        call.messages[0]!.content.includes("compacting an AI agent's conversation history"),
+        call.messages.at(-1)!.content.includes("compacting this AI agent conversation"),
       );
     expect(compactionCalls()).toHaveLength(1);
     // The summary sees the whole conversation and runs on the agent's model.
     expect(compactionCalls()[0]!.model).toBe("openai/gpt-5.5");
-    expect(compactionCalls()[0]!.messages[1]!.content).toContain("User:\nremember: I like teal");
-    expect(compactionCalls()[0]!.messages[1]!.content).toContain("Assistant:\nnoted!");
+    // The compaction request extends the normal turn's request byte for byte
+    // (same system prompt, same history messages) so the provider's prompt
+    // cache — an exact-prefix match — covers the biggest request an agent
+    // ever makes. Divergence only at the tail: the turn's trailing clock
+    // message versus the summarize instruction.
+    const turnRequest = aiCalls[0]!;
+    const compactionRequest = compactionCalls()[0]!;
+    expect(compactionRequest.messages.slice(0, turnRequest.messages.length - 1)).toEqual(
+      turnRequest.messages.slice(0, -1),
+    );
+    expect(compactionRequest.messages).toMatchObject([
+      { role: "system", content: DEFAULT_AGENT_SYSTEM_PROMPT },
+      { role: "user", content: expect.stringContaining("remember: I like teal") },
+      { role: "assistant", content: expect.stringContaining("noted!") },
+      { role: "system", content: expect.stringContaining("output only the summary") },
+    ]);
     expect(reset.payload).toMatchObject({
       systemPrompt: DEFAULT_AGENT_SYSTEM_PROMPT,
       history: [
@@ -1917,6 +1934,106 @@ describe("token usage and history reset", () => {
     expect(
       stream.events.filter((event) => event.type === "events.iterate.com/agent/history-reset"),
     ).toHaveLength(1);
+  });
+
+  it("compaction rides the BYOK transport with the conversation's prompt cache key and journals the cache split", async () => {
+    const stream = new MemoryStream();
+    const encoder = new TextEncoder();
+    const sse = (frames: unknown[]) =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const frame of frames) {
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(frame)}\n\n`));
+          }
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          controller.close();
+        },
+      });
+    const gatewayBodies: { prompt_cache_key?: string; messages: { content: string }[] }[] = [];
+    const agent = new AgentProcessor({
+      stream,
+      path: stream.path,
+      projectId: null,
+      ai: {
+        run: async () => {
+          throw new Error("unified lane must not be dialed when BYOK transport is configured");
+        },
+        gateway: () => ({
+          run: async ({ query }: { query: unknown }) => {
+            const body = query as (typeof gatewayBodies)[number];
+            gatewayBodies.push(body);
+            const isCompaction = body.messages
+              .at(-1)!
+              .content.includes("compacting this AI agent conversation");
+            return new Response(
+              sse(
+                isCompaction
+                  ? [
+                      {
+                        choices: [{ delta: { content: "Summary.", role: "assistant" }, index: 0 }],
+                      },
+                      {
+                        choices: [],
+                        usage: {
+                          prompt_tokens: 141_000,
+                          completion_tokens: 20,
+                          prompt_tokens_details: { cached_tokens: 140_800 },
+                        },
+                      },
+                    ]
+                  : [
+                      { choices: [{ delta: { content: "noted!", role: "assistant" }, index: 0 }] },
+                      { choices: [], usage: { prompt_tokens: 140_000, completion_tokens: 500 } },
+                    ],
+              ),
+            );
+          },
+        }),
+      },
+      cloudflareAiGatewayTransport: () => ({
+        kind: "byok",
+        gatewayId: "default",
+        openaiApiKey: "sk-test",
+        openaiPromptCacheKey: "prj_x:/agents/main",
+      }),
+    });
+    const cursors = new Map<object, number>();
+    const deliver = () => deliverNewEvents({ processor: agent, stream, cursors });
+
+    await stream.append({
+      type: "events.iterate.com/agents/message-received",
+      payload: { content: "remember: I like teal", from: { kind: "user", origin: "web" } },
+    });
+    await deliver();
+    await deliver();
+    await deliver();
+    await stream.waitForEvent({
+      eventTypes: ["events.iterate.com/agent/llm-request-requested"],
+      timeoutMs: 2_000,
+    });
+    await deliver();
+    await stream.waitForEvent({
+      eventTypes: ["events.iterate.com/agent/llm-request-completed"],
+      timeoutMs: 2_000,
+    });
+    await deliver();
+
+    const reset = stream.events.find(
+      (event) => event.type === "events.iterate.com/agent/history-reset",
+    )!;
+    expect(reset).toBeDefined();
+    // Both the turn and the summary rode the gateway with the SAME cache key,
+    // so the summary lands on the shard already holding the turn's prefix.
+    expect(gatewayBodies).toHaveLength(2);
+    expect(gatewayBodies.map((body) => body.prompt_cache_key)).toEqual([
+      "prj_x:/agents/main",
+      "prj_x:/agents/main",
+    ]);
+    // The journaled reason carries the measured cache split — the live
+    // evidence that prefix reuse worked (or didn't) for every compaction.
+    expect(reset.payload?.reason).toMatch(
+      /; summary llm usage: input=141000 cached=140800 output=20$/,
+    );
   });
 
   it("an under-threshold usage report does not compact", async () => {

--- a/apps/os/src/domains/agents/agent-processors.test.ts
+++ b/apps/os/src/domains/agents/agent-processors.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { StreamEventInput } from "../streams/schemas.ts";
 import {
   AgentProcessor,
+  buildAgentCompactionRequestBody,
   buildAgentLlmRequestBody,
   contextWindowTokens,
   flattenMessageToText,
@@ -1934,6 +1935,27 @@ describe("token usage and history reset", () => {
     expect(
       stream.events.filter((event) => event.type === "events.iterate.com/agent/history-reset"),
     ).toHaveLength(1);
+  });
+
+  it("buildAgentCompactionRequestBody extends the conversation verbatim with the instruction last", () => {
+    const state = {
+      systemPrompt: "You are terse.",
+      history: [
+        { role: "user" as const, content: "remember: I like teal" },
+        { role: "assistant" as const, content: "noted!" },
+      ],
+    };
+    const body = buildAgentCompactionRequestBody(state);
+    // The cached-prefix property: everything but the trailing instruction is
+    // the conversation exactly as buildAgentLlmRequestBody sends it.
+    expect(body.messages.slice(0, -1)).toEqual([
+      { role: "system", content: "You are terse." },
+      ...state.history,
+    ]);
+    expect(body.messages.at(-1)).toMatchObject({
+      role: "system",
+      content: expect.stringContaining("compacting this AI agent conversation"),
+    });
   });
 
   it("compaction rides the BYOK transport with the conversation's prompt cache key and journals the cache split", async () => {


### PR DESCRIPTION
## Goal

Get gpt-5.5 prompt (KV) caching in the agent loop to basically 100% of what's cacheable, with measurements.

## Baseline: measured prd before touching anything

Dumped every `token-usage-reported` event in prd via `itx.streams.get(path).getEvents(...)`:

| prd project | requests | input tokens | cached | hit rate |
|---|---|---|---|---|
| `iterate` (all agents, all time) | 171 | 7,037,260 | 6,380,544 | **90.7%** |
| busiest single agent, warm turns | 36 | 2,067,055 | 1,980,928 | 95.8% (steady-state 97–99%) |

The turn loop is already healthy — trailing clock message, per-agent `prompt_cache_key`, append-only fold. The residual ~9% is: first turns (cold by definition), one-shot agents (100% cold), brand-new input tokens each turn, occasional shard/write-latency dips — **and one class of request that never showed up in this data at all**.

## The bug: compaction was a full cache miss on the agent's biggest-ever request

Compaction fires when a turn crosses ~136k tokens (half of gpt-5.5's 272k operating window). The summary request was built as `[fresh compaction system prompt, whole transcript re-rendered into one user message]` and dialed **without the BYOK transport**. Three compounding costs:

1. **Zero prefix reuse.** OpenAI's cache matches exact prefixes; a re-rendered transcript shares no bytes with the conversation the provider already has cached from the previous turn. ~136k tokens at the uncached $5/1M rate, every compaction.
2. **No `prompt_cache_key`** — the request wasn't even routed to the conversation's cache shard.
3. **Unified billing** meters OpenAI-cached tokens at the uncached price anyway (the reason every env is BYOK — see `workers-ai-transport.ts`).
4. **Invisible**: unlike normal turns, the summary's usage was never journaled — which is why the prd audit couldn't see it.

## The fix

- `buildAgentCompactionRequestBody()`: the compaction request is now the conversation **exactly as `buildAgentLlmRequestBody` sends it** — same system prompt, same history messages, flattened identically — with the summarize instruction appended as the **trailing** message (same pattern as the trailing clock: per-request content at the tail leaves every cached prefix intact).
- Compaction passes `cloudflareAiGatewayTransport` — same BYOK lane, same per-agent `prompt_cache_key`, so it lands on the shard already holding the conversation's prefix.
- The summary's measured cache split is journaled in the `history-reset` reason (compaction has no `llm-request-requested` offset for a `token-usage-reported` event to key on), so every future compaction carries its own evidence.

## Benchmarks

**Isolated A/B against OpenAI** (real gpt-5.5, exact request shapes the transport sends, ~30k-token conversation):

| request | prompt tokens | cached | hit | latency |
|---|---|---|---|---|
| turn 1 (cold) | 16,785 | 0 | 0% | 1.9s |
| turn 2 (warm loop) | 30,815 | 16,640 | 54%* | 1.9s |
| **compaction, OLD shape** | 28,107 | **0** | **0%** | **10.5s** |
| **compaction, NEW shape** | 30,849 | **30,464** | **98.8%** | **4.2s** |
| turn 3 (warm loop) | 30,831 | 30,464 | 98.8% | 2.7s |

\* half of turn 2's prompt is a brand-new 13k-token document — everything cacheable was hit.

**End to end through the real code path** (local dev server on this branch → AgentProcessor → AI Gateway BYOK → OpenAI; drove a real agent past the threshold with 13k-token pastes; full ladder in the PR comment below):

```
compaction@396: ~142980 tokens > 136000; summary llm usage: input=143140 cached=142592 output=687
```

**99.6% cached on a 143k-token compaction.** At gpt-5.5 pricing ($5/1M input, $0.50/1M cached): ~$0.72 → ~$0.074 per compaction, **9.7x cheaper**, plus 2.5x faster prefill — and it now bills at the cached rate at all (BYOK) instead of unified's uncached metering.

## Why this is "basically 100%"

Every repeated byte is now cached on every request type the agent makes. What remains uncached is structural, not fixable client-side: first request of a conversation (someone has to write the prefix; writes are free on gpt-5.5), tokens that are genuinely new each turn, hits rounded to 128-token boundaries, and idle expiry (gpt-5.5 retention is 24h-only server-side, nothing to set). Verified best practices we already follow: trailing clock (never in the system prompt), static tool surface (scripts, no `tools` array), append-only history, deterministic folds, per-conversation `prompt_cache_key` (OpenAI's own recommendation for agent platforms — per-project keys would breach the ~15 req/min per-key shard budget under swarms for a ~2k-token cross-agent win).

Deliberately not done here, noted for later: Responses API with encrypted reasoning items (OpenAI docs claim 40–80% better cache utilization for reasoning models — a transport rework, not a tweak), and a `prompt_cache_key` on the legacy unified lane (no billing benefit there).

## Tests

- Compaction test now asserts the compaction request extends the normal turn's request **byte for byte** (captured request prefix deep-equal), with the instruction last.
- New test: compaction rides BYOK with the same `prompt_cache_key` as normal turns and journals the measured cache split in the reset reason.
- `pnpm typecheck` / `lint` / `format` / `test` all green (1090 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the highest-token compaction LLM path (cost, latency, and summary quality) but keeps the same stop-the-world `history-reset` behavior with strong test coverage.
> 
> **Overview**
> **Agent compaction** no longer builds a fresh system prompt plus a re-rendered transcript. It now uses **`buildAgentCompactionRequestBody`**: the same system prompt and history as a normal turn, with the summarize instruction as the **last** message so OpenAI’s exact-prefix prompt cache can match the prior turn (instead of a full miss on ~136k+ token summaries).
> 
> Compaction **`runWorkersAiAttempt`** calls now pass **`cloudflareAiGatewayTransport`** (BYOK + per-agent **`prompt_cache_key`**) like regular turns, so summaries hit the right cache shard and cached input bills at the discounted rate.
> 
> The **`history-reset`** **`reason`** string now includes **summary LLM usage** (`input` / `cached` / `output`) because compaction has no `llm-request-requested` offset for a separate `token-usage-reported` event.
> 
> Tests assert **byte-for-byte prefix** alignment between turn and compaction requests, plus gateway **`prompt_cache_key`** reuse and journaled cache splits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea4e4563e78f5c7c18a3ce8261624ee8b74b9fdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +51 -13 | +24 -12 🟩⬜⬜⬜⬜ |
| Tests | +143 -4 | +125 -4 🟩🟩🟩🟩🟩 |
| **Total** | **+194 -17** | **+149 -16** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between a4a35ea and ea4e456, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-11T22:59:29.158Z",
      "headSha": "fe0ec510462f4f323efafcde3495dea0df903913",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/471111657277269",
      "shortSha": "fe0ec51",
      "cleanupDurationMs": 8565,
      "deployDurationMs": 74206,
      "testDurationMs": 148445,
      "testRetries": "5 retried: agent runs an itx script that appends a proof event, then replies (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · stream getEvents defaults to a bounded page and supports event type filters (vitest x1) · crossPostTo copies matching events with source provenance (vitest x1) · reactivity page appends a batch and renders every delivered marker (specs x1)",
      "workerSizeKib": 15938.06,
      "workerGzipKib": 4298.15,
      "mainWorkerGzipKib": 4297.72
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-11T22:59:23.129Z",
      "headSha": "fe0ec510462f4f323efafcde3495dea0df903913",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/471111657277269",
      "shortSha": "fe0ec51",
      "cleanupDurationMs": 2533,
      "deployDurationMs": 22348,
      "testDurationMs": 503,
      "testRetries": null,
      "workerSizeKib": 4031.76,
      "workerGzipKib": 819.33,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `fe0ec51` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 819.3 KiB | 22.3s | 503ms |  | 2.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/471111657277269) | 2026-07-11T22:59:23.129Z | Preview app released. |
| OS | released | `fe0ec51` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.20 MiB (+0.4 KiB vs main) | 74.2s | 148.4s | 5 retried: agent runs an itx script that appends a proof event, then replies (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · stream getEvents defaults to a bounded page and supports event type filters (vitest x1) · crossPostTo copies matching events with source provenance (vitest x1) · reactivity page appends a batch and renders every delivered marker (specs x1) | 8.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/471111657277269) | 2026-07-11T22:59:29.158Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->