### PR TITLE
Provide-time type validation gets the execution gate's guards (break-test follow-up)

### DIFF
--- a/apps/os/src/domains/typecheck/virtual-project.test.ts
+++ b/apps/os/src/domains/typecheck/virtual-project.test.ts
@@ -267,6 +267,15 @@ test("an unreachable / hung sidecar at provide time allows the mount (deadline, 
       deadlineMs: 25,
     }),
   ).toEqual([]);
+
+  // The export-less rule is LOCAL (no compiler) — a permissive checker failure
+  // must NOT let an export-less declaration slip into the journal as `any`.
+  const exportLess = await checkCapabilityTypes({
+    types: "export const x = 1;",
+    typechecker: unreachable,
+  });
+  expect(exportLess).toHaveLength(1);
+  expect(exportLess[0]).toContain("exports no top-level type");
 });
 
 test("a pathologically nested type is REJECTED at provide time (durable — must not wedge future checks)", async () => {

--- a/apps/os/src/domains/typecheck/virtual-project.test.ts
+++ b/apps/os/src/domains/typecheck/virtual-project.test.ts
@@ -222,9 +222,13 @@ test("npm specifier scan finds bare packages in code and ignores prose", () => {
   expect(npmPackagesMentioned(files).sort()).toEqual(["@slack/web-api", "zod"]);
 });
 
-test("a compiler crash comes back as a clean problem, not an infra throw", async () => {
-  // A type-compute bomb can OOM the wasm isolate; the raw throw used to leak
-  // "Worker exceeded memory limit." / non-JSON output to the provide caller.
+test("a compiler crash at provide time ALLOWS the mount — a crash is not proof the types are wrong", async () => {
+  // A type-compute bomb can OOM the wasm isolate. The raw throw used to leak
+  // to the provide caller; then it was surfaced as a problem — which
+  // hard-rejected a mount the compiler merely failed to check. A crash is
+  // "the check didn't happen", not a verdict: allow the mount (same stance as
+  // the execution gate's `unchecked`). Real type errors still reject (see the
+  // typo test above), so this loses nothing but the false reject.
   const crashing: Typechecker = {
     check: (input) =>
       runTypecheck({
@@ -241,9 +245,47 @@ test("a compiler crash comes back as a clean problem, not an infra throw", async
     types: "export type T = 1;",
     typechecker: crashing,
   });
+  expect(problems).toEqual([]);
+});
+
+test("an unreachable / hung sidecar at provide time allows the mount (deadline, no hard reject)", async () => {
+  const unreachable: Typechecker = {
+    check: () => Promise.reject(new Error("sidecar dial failed")),
+  };
+  expect(
+    await checkCapabilityTypes({
+      types: "export type T = { x(): void };",
+      typechecker: unreachable,
+    }),
+  ).toEqual([]);
+
+  const hanging: Typechecker = { check: () => new Promise(() => {}) };
+  expect(
+    await checkCapabilityTypes({
+      types: "export type T = { x(): void };",
+      typechecker: hanging,
+      deadlineMs: 25,
+    }),
+  ).toEqual([]);
+});
+
+test("a pathologically nested type is REJECTED at provide time (durable — must not wedge future checks)", async () => {
+  // Unlike an ephemeral script (which the gate runs unchecked), a `types`
+  // string is journaled and re-compiled by every later script check, so a
+  // parser-wedging nesting must be kept out of the journal. A poisoned checker
+  // proves the guard bails before tsc is ever dialed.
+  const exploding: Typechecker = {
+    check: () => Promise.reject(new Error("typechecker must not be dialed for deep types")),
+  };
+  const deep = `export type T = ${"[".repeat(1200)}number${"]".repeat(1200)};`;
+  const problems = await checkCapabilityTypes({ types: deep, typechecker: exploding });
   expect(problems).toHaveLength(1);
-  expect(problems[0]).toContain("type checking crashed");
-  expect(problems[0]).toContain("too complex");
+  expect(problems[0]).toContain("nesting");
+
+  // A normal declaration still reaches the real checker and compiles clean.
+  expect(
+    await checkCapabilityTypes({ types: "export type T = { x(): Promise<void> };", typechecker }),
+  ).toEqual([]);
 });
 
 test("compiling-but-export-less types are rejected as an authoring mistake", async () => {

--- a/apps/os/src/domains/typecheck/virtual-project.ts
+++ b/apps/os/src/domains/typecheck/virtual-project.ts
@@ -148,24 +148,56 @@ function mountFileName(dottedPath: string): string {
 
 /**
  * Typecheck one mount's `types` string — the provide-time validation. Returns
- * problems as printable strings; empty means the declaration compiles against
- * the platform surface (npm `import("pkg")` references included).
+ * problems as printable strings; empty means the mount may be journaled (the
+ * declaration either compiled clean or the checker couldn't render a verdict).
+ *
+ * A `types` string is DURABLE: it enters the journal and every later script
+ * check in the scope re-compiles it. So this shares the execution gate's
+ * sidecar guards, with one deliberate difference in what a guard means:
+ * - A checker CRASH (code-0) or an unreachable/hung sidecar (throw, deadline)
+ *   is not proof the types are wrong — allow the mount rather than hard-reject
+ *   a valid declaration (and, since `provideCapability` is reachable from a
+ *   running script, rather than throwing an infra error into that script).
+ *   This mirrors checkItxScriptForExecution's permissive-on-non-proof stance.
+ * - Pathological NESTING, by contrast, is rejected, not skipped: unlike an
+ *   ephemeral script (which the gate runs unchecked), a type that would wedge
+ *   tsc's parser must never enter the journal, or it wedges every future check
+ *   in the scope.
+ * Real, deterministic type errors still reject — that is the whole point.
  */
 export async function checkCapabilityTypes(input: {
   types: string;
   typechecker: Typechecker;
+  deadlineMs?: number;
 }): Promise<string[]> {
   if (input.types.length > MAX_SCRIPT_CHARS) {
     return [
       `types — ${input.types.length} characters is over the ${MAX_SCRIPT_CHARS}-character check limit.`,
     ];
   }
+  if (exceedsNestingDepth(input.types, MAX_NESTING_DEPTH)) {
+    return [
+      `types — nesting deeper than ${MAX_NESTING_DEPTH} levels; simplify the declaration ` +
+        `(a type this deep would wedge the checker on every future script in this scope).`,
+    ];
+  }
   const fileName = mountFileName("provided");
   const moduleText = mountModuleText(input.types);
-  const { diagnostics, notes } = await input.typechecker.check({
-    files: { ...SHARED_FILES, [fileName]: moduleText },
-  });
-  const problems = formatProblems(diagnostics, {
+  let checked: TypecheckResult;
+  try {
+    checked = await withDeadline(
+      input.typechecker.check({ files: { ...SHARED_FILES, [fileName]: moduleText } }),
+      input.deadlineMs ?? EXECUTION_CHECK_DEADLINE_MS,
+    );
+  } catch {
+    // Unreachable or hung sidecar — not a verdict. Allow the mount.
+    return [];
+  }
+  // A code-0 crash diagnostic means "the check didn't happen", not "the types
+  // are wrong" — drop it so a transient compiler crash never hard-rejects a
+  // valid mount (the execution gate treats the same signal as `unchecked`).
+  const realErrors = checked.diagnostics.filter((diagnostic) => diagnostic.code !== 0);
+  const problems = formatProblems(realErrors, {
     label: "types",
     primaryFile: fileName,
     lineOffset: moduleText === input.types ? 0 : -1, // the injected import line
@@ -183,7 +215,7 @@ export async function checkCapabilityTypes(input: {
   // Notes are CONTEXT for failures (a budget-tripped npm package reads as a
   // plain typo without them), never verdicts: typm warns on perfectly
   // successful acquisitions, and a warning must not fail a compiling mount.
-  return problems.length > 0 ? [...problems, ...notes] : [];
+  return problems.length > 0 ? [...problems, ...checked.notes] : [];
 }
 
 /**

--- a/apps/os/src/domains/typecheck/virtual-project.ts
+++ b/apps/os/src/domains/typecheck/virtual-project.ts
@@ -181,6 +181,19 @@ export async function checkCapabilityTypes(input: {
         `(a type this deep would wedge the checker on every future script in this scope).`,
     ];
   }
+  // A declaration that exports no top-level type is an authoring mistake, not
+  // a typed mount: the first exported type IS the contract, and without one the
+  // mount would silently degrade to `any` (or worse — the namespace-nested case
+  // used to poison the whole scope's typecheck). This rule is LOCAL — it needs
+  // no compiler — so it holds even when the sidecar is unreachable below; a
+  // permissive checker failure must not let an export-less mount slip in.
+  const exportLess =
+    firstExportedTypeName(input.types) === undefined
+      ? [
+          "types — exports no top-level type/interface/class/enum; " +
+            "the FIRST exported declaration names the mount's type.",
+        ]
+      : [];
   const fileName = mountFileName("provided");
   const moduleText = mountModuleText(input.types);
   let checked: TypecheckResult;
@@ -190,8 +203,9 @@ export async function checkCapabilityTypes(input: {
       input.deadlineMs ?? EXECUTION_CHECK_DEADLINE_MS,
     );
   } catch {
-    // Unreachable or hung sidecar — not a verdict. Allow the mount.
-    return [];
+    // Unreachable or hung sidecar — not a verdict on compilation, so allow the
+    // mount, but the local export-less rule still applies.
+    return exportLess;
   }
   // A code-0 crash diagnostic means "the check didn't happen", not "the types
   // are wrong" — drop it so a transient compiler crash never hard-rejects a
@@ -202,20 +216,13 @@ export async function checkCapabilityTypes(input: {
     primaryFile: fileName,
     lineOffset: moduleText === input.types ? 0 : -1, // the injected import line
   });
-  // A declaration that compiles but exports no top-level type is an authoring
-  // mistake, not a typed mount: the first exported type IS the contract, and
-  // without one the mount would silently degrade to `any` (or worse — the
-  // namespace-nested case used to poison the whole scope's typecheck).
-  if (problems.length === 0 && firstExportedTypeName(input.types) === undefined) {
-    problems.push(
-      "types — compiles but exports no top-level type/interface/class/enum; " +
-        "the FIRST exported declaration names the mount's type.",
-    );
-  }
+  // Only surface the export-less rule when nothing else failed — a compile
+  // error already tells the author their declaration is broken.
+  if (problems.length === 0) return exportLess;
   // Notes are CONTEXT for failures (a budget-tripped npm package reads as a
   // plain typo without them), never verdicts: typm warns on perfectly
   // successful acquisitions, and a warning must not fail a compiling mount.
-  return problems.length > 0 ? [...problems, ...checked.notes] : [];
+  return [...problems, ...checked.notes];
 }
 
 /**


### PR DESCRIPTION
Follow-up to the #1882 / #1887 gate break-test, which — after the gate itself was hardened — surfaced **four out-of-scope findings**. This PR takes on the one with a clean, high-value fix, and covers **two of the four findings at once**. The other two are documented below with the reasoning for not changing them.

## Fixed: provide-time `types` validation robustness (findings #2 + #3)

`checkCapabilityTypes` was the **last unguarded `env.TYPECHECKER.check` on a Durable Object hot path**. `provideCapability` is reachable from a running script (`itx.provideCapability({ types })`), and the validation call had no deadline, no try/catch, and no nesting guard — everything `checkItxScriptForExecution` already has. Two things the break-test hit in prd:

1. **A transient sidecar crash hard-rejected a valid mount.** The code-0 "type checking crashed" diagnostic was surfaced as a problem, and `provideCapability` throws on any problem — so a perfectly valid declaration failed to mount whenever the shared sidecar isolate was momentarily crashed or OOM'd.
2. **Pathological `types` were an OOM/wedge surface, and the infra error propagated into the calling script.** A deeply-nested / recursive `types` string reached tsc unguarded; the resulting "Worker exceeded memory limit" / "Go program has already exited" rejection travelled up through `provideCapability` into the script that called it — a contributor to the `durable-object-crashed` mid-turn resets (finding #2's tractable root: this was the only `TYPECHECKER.check` without the guard the execution gate carries).

### The fix
`checkCapabilityTypes` now mirrors `checkItxScriptForExecution`, with **one deliberate asymmetry a durable declaration demands**:

- **checker CRASH (code-0) / unreachable / hung (deadline) → allow the mount.** A crash is "the check didn't happen", not proof the types are wrong. It must not hard-reject a valid mount, and — since the call can originate inside a running script — must not throw an infra error into that script. Same permissive-on-non-proof stance as the execution gate.
- **pathological NESTING → reject (not skip).** Unlike an ephemeral script (which the gate runs unchecked), a `types` string is **journaled and re-compiled by every later script check in the scope** — one that would wedge tsc's parser must never enter the journal in the first place. The cheap bracket-depth guard bails before tsc is dialed.
- **real, deterministic type errors still reject** — the whole point of provide-time validation is preserved.

This also improves connect-time auto-typing (`#describeExpressionTypes`): a transient crash now keeps the self-described types instead of silently dropping them to `any`.

### Tests
`virtual-project.test.ts`, real tswasm compiler: crash-allows (replaces the old "crash → hard reject" assertion), unreachable/hung-allows via deadline, deep-nesting-rejects (a poisoned checker proves tsc is never dialed), and the existing typo-still-rejects case. Full os suite green (1116 passing).

## Investigated, not changed (with reasons)

**Finding #1 — agent turn ends silently when a script returns `undefined`.** This is by-design and load-bearing: "returning no value is how an agent ends its turn" (`scriptResultAgentInput`, tested in `agent-processors.test.ts`). The code cannot distinguish "did work via a side-effect, correctly ending" from "returned nothing by mistake" without scanning for a `web-message-sent` between the request and completion offsets. A fix (nudge-if-no-side-effect) changes turn-ending semantics and risks a retry-loop on the agent hot path, so it needs its **own PR with prd agent e2e**, not a hardening bundle. Flagging for a dedicated follow-up.

**Finding #4 — declared type-surface gaps.**
- `instanceType` is **already declared** on `SandboxCreateInput` (`domains/sandboxes/utils.ts`); the break-test's `{ sandboxName }` was a stale read (the real key is `name`). No change needed.
- `CloudflareSandbox.exec` is a **deliberate** type omission (the alias docstring states the SDK surface is not re-declared, to avoid drift — "same stance as `McpClientRpc`"). Crucially, **#1887 already made the gate permissive on bare TS2339**, so `itx.<sandbox>.exec()` no longer blocks; the impact is now advisory-only. Not overriding a documented design decision in a hardening PR.
- `@slack/web-api` unresolved is a **type-acquisition budget degradation** (its ~7.6MB `.d.ts` tree + 12 transitive deps blow the 20MB / 40-package `TYPM_LIMITS`). Raising the budget directly **worsens the sidecar memory pressure this PR is reducing**, and the gate is already permissive on unresolved modules — so it's advisory-only too. Left as-is; a real fix (slim hand-authored `WebClient` type, or a budget bump paired with sidecar memory limits) is its own tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes validation policy on `provideCapability` (allows mounts when the checker crashes or is unavailable) while adding a hard reject for deep nesting; real type errors still block.
> 
> **Overview**
> **`checkCapabilityTypes`** (used when `provideCapability` validates journaled `types` on a DO hot path) now uses the same sidecar protections as the execution gate, with policy tuned for durable declarations.
> 
> It adds a **bracket nesting cap** that rejects pathological `types` before tsc runs (unlike scripts, bad nesting in the journal would wedge every later check in the scope). It wraps the typechecker call in **`withDeadline`** and **try/catch** so unreachable or hung sidecars no longer throw into the calling script. **Code-0 crash diagnostics** are dropped so transient compiler failures allow the mount instead of hard-rejecting. The **export-less top-level type** rule runs locally first and still applies when the sidecar is down, so export-less declarations cannot slip through as `any`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adb54c151ab58a2579cd7697533c02754b457d7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +56 -17 | +27 -11 🟩🟩🟩🟩🟥 |
| Tests | +56 -5 | +38 -3 🟩🟩🟩🟩🟩 |
| **Total** | **+112 -22** | **+65 -14** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 216a034 and adb54c1, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-11T23:25:32.581Z",
      "headSha": "adb54c151ab58a2579cd7697533c02754b457d7e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/217988618520195",
      "shortSha": "adb54c1",
      "cleanupDurationMs": 13514,
      "deployDurationMs": 70594,
      "testDurationMs": 187113,
      "testRetries": "1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 15974.52,
      "workerGzipKib": 4309.22,
      "mainWorkerGzipKib": 4308.61
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-11T23:25:22.102Z",
      "headSha": "adb54c151ab58a2579cd7697533c02754b457d7e",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/217988618520195",
      "shortSha": "adb54c1",
      "cleanupDurationMs": 3031,
      "deployDurationMs": 18654,
      "testDurationMs": 629,
      "testRetries": null,
      "workerSizeKib": 4032.01,
      "workerGzipKib": 819.6,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `adb54c1` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 819.6 KiB | 18.7s | 629ms |  | 3.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/217988618520195) | 2026-07-11T23:25:22.102Z | Preview app released. |
| OS | released | `adb54c1` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.21 MiB (+0.6 KiB vs main) | 70.6s | 187.1s | 1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 13.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/217988618520195) | 2026-07-11T23:25:32.581Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->