### PR TITLE
iterate CLI fixes: pnpm iterate via bun + use-my-computer capability types compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "os": "cd apps/os && pnpm",
     "skills:sync": "npx skills add . --skill '*' -a claude-code -a opencode -g -y",
     "skills:list": "npx skills list -g -a claude-code -a opencode",
-    "iterate": "node ./packages/iterate/bin/iterate.js",
+    "iterate": "bun ./packages/iterate/bin/iterate.js",
     "preview": "trpc-cli scripts/preview/preview.ts",
     "preview:ci": "./scripts/preview/run-ci-locally.sh",
     "lint": "oxlint . --threads 1 --deny-warnings",

--- a/packages/iterate/src/use-my-computer.ts
+++ b/packages/iterate/src/use-my-computer.ts
@@ -73,11 +73,14 @@ const INSTRUCTIONS = `A real person's Mac, shared live from their terminal for a
 - notify({ message, title? }) shows a desktop notification.
 - runSwift({ code }) runs Swift on their Mac and returns { stdout, stderr, exitCode }. It has full access to their files, GUI and network, so ask before doing anything destructive.`;
 
-const TYPES = `{
+// A capability `types` string must be a valid TS declaration named `Capability`
+// (the egress/capability host typechecks it before mounting) — not a bare object
+// literal, which fails to compile and aborts the mount.
+const TYPES = `export type Capability = {
   ask(input: { question: string; buttons?: string[] }): Promise<{ answer: string }>;
   notify(input: { message: string; title?: string }): Promise<{ ok: true }>;
   runSwift(input: { code: string }): Promise<{ stdout: string; stderr: string; exitCode: number }>;
-}`;
+};`;
 
 /**
  * Ask what agents should call this computer, and mount the capability there —


### PR DESCRIPTION
Two small `iterate` CLI fixes.

### 1. `pnpm iterate` runs via `bun`, not `node`
The root `iterate` script used `node`, whose strip-only TypeScript loader chokes on a parameter property in `apps/os` reached through the CLI's import graph, so `pnpm iterate <cmd>` errored (`ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`). `bun` runs the TS source directly:

```bash
pnpm iterate approve --project <slug> --menubar
pnpm iterate use-my-computer --project <slug>
```

### 2. `use-my-computer` capability `types` must compile
The capability host now typechecks a mount's `types` before accepting it (typed capability mounts). `use-my-computer` sent a bare object-literal body (`{ ask(...): … }`), which fails to compile — so the live mount was rejected a few seconds after connecting (menu bar showed "stopped sharing your computer") and no `capability-provided` event was journaled. Wrapping it as `export type Capability = { … }` (the documented format) fixes the mount, and the `capability-provided` event now lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)