### PR TITLE
use-my-computer: harden the keepalive loop (Bugbot follow-ups to #1892)

### DIFF
--- a/packages/iterate/src/cli.ts
+++ b/packages/iterate/src/cli.ts
@@ -1112,12 +1112,22 @@ const launcherProcedures = {
         explicitProject: input.project,
       });
 
+      // The share loop re-resolves credentials before every (re)connect so it
+      // survives the short access-token TTL over extended sharing: env secrets
+      // win (doppler/e2e, never expire), else re-read the stored session — which
+      // refreshes the OAuth token when it's near expiry.
+      const reauth = async () => {
+        const env = osAuthFromEnvironment();
+        if (env) return { auth: env.credentials, headers: headersRecord(env.requestHeaders) };
+        const current = resolveConfig(process.cwd(), { throw: true });
+        const refreshed = osAuthFromHeaders(await getOsAuthHeaders(current.config, current.name));
+        return { auth: refreshed.credentials, headers: headersRecord(refreshed.requestHeaders) };
+      };
       const shared = {
-        auth: auth.credentials,
         baseUrl: resolved.config.osBaseUrl,
         projectId,
-        headers: headersRecord(auth.requestHeaders),
         name: input.name,
+        reauth,
       };
       // JSON mode announces activity for the menu-bar app; the terminal form
       // prompts for a name and prints a paste-for-your-agent hint. Both block.

--- a/packages/iterate/src/use-my-computer.ts
+++ b/packages/iterate/src/use-my-computer.ts
@@ -148,25 +148,34 @@ function agentPrompt(name: string): string {
   ].join("\n");
 }
 
+/** Freshly-resolved credentials for one (re)connect. */
+type ResolvedAuth = { auth: ItxAuthCredentials; headers?: Record<string, string> };
+
 type ConnectInput = {
-  auth: ItxAuthCredentials;
   baseUrl: string;
   projectId: string;
-  headers?: Record<string, string>;
   name?: string;
+  /**
+   * Re-resolve (and refresh) credentials — called before EVERY (re)connect. The
+   * OS access token has a short (~15-minute) TTL, so a reconnect that reused the
+   * token captured at launch would fail once it expires; re-resolving picks up a
+   * refreshed token so extended sharing survives reconnects.
+   */
+  reauth: () => Promise<ResolvedAuth>;
 };
 
-/** Mount `capability` at `itx.<name>` and return the live socket stub. */
+/** Mount `capability` at `itx.<name>` with freshly-resolved auth and return the live socket stub. */
 async function connectAndProvide(
   input: ConnectInput,
   name: string,
   capability: typeof myComputer,
 ): Promise<RpcStub<Project>> {
+  const { auth, headers } = await input.reauth();
   const itx = connectItx({
-    auth: input.auth,
+    auth,
     baseUrl: input.baseUrl,
     projectId: input.projectId,
-    headers: input.headers,
+    headers,
   }) as RpcStub<Project>;
 
   await itx.provideCapability({
@@ -181,7 +190,11 @@ async function connectAndProvide(
 
 const HEALTH_CHECK_INTERVAL_MS = 8_000;
 const HEALTH_CHECK_TIMEOUT_MS = 5_000;
-const RECOVERY_TIMEOUT_MS = 12_000;
+// A reconnect includes connectItx's WebSocket handshake (up to ~15s), so this
+// backstop sits ABOVE that — otherwise a handshake that would have succeeded is
+// abandoned mid-flight. connectItx's own handshake timeout rejects a dead
+// endpoint well before this fires, so recoveries never overlap.
+const RECONNECT_TIMEOUT_MS = 30_000;
 const RECOVERY_BACKOFF_MS = 3_000;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -231,11 +244,11 @@ function pingMount(itx: RpcStub<Project>, name: string): Promise<void> {
  * still answers. The first check runs right after the initial provide (no dead
  * startup window); thereafter every few seconds.
  *
- * On any failure we recover, and recovery NEVER escapes the loop — a share
- * session ends only when the process does. Re-provide on the current socket
- * first (recovers a host-DO eviction that dropped the ref but left the
- * connection intact); else reconnect, disposing the old session. Every step is
- * timeout-bounded, and a recovery that fails entirely just backs off and retries
+ * When a check fails (eviction, a dropped or wedged socket, a deploy) we
+ * reconnect FRESH — a new connection, with re-resolved auth so a reconnect past
+ * the short access-token TTL still authenticates — provide again, and dispose the
+ * old session. Recovery NEVER escapes the loop: a share session ends only when
+ * the process does, so a failed round keeps the old stub, backs off, and retries
  * on the next tick. `onReprovided` fires whenever we re-establish it.
  */
 async function keepMountAlive(input: {
@@ -246,48 +259,29 @@ async function keepMountAlive(input: {
   onReprovided?: () => void;
 }): Promise<never> {
   let itx = input.itx;
-  const provide = (stub: RpcStub<Project>) =>
-    withTimeout(
-      stub.provideCapability({
-        type: "live",
-        path: [input.name],
-        capability: input.capability,
-        instructions: INSTRUCTIONS,
-        types: TYPES,
-      }),
-      RECOVERY_TIMEOUT_MS,
-      "re-provide",
-    );
-
   while (true) {
     try {
       await pingMount(itx, input.name); // confirms the mount end-to-end + keeps the host warm
     } catch {
-      // Recover this round. Any of these steps may fail; none may throw out of
-      // the loop. Re-provide on the current socket, else reconnect fresh.
-      let recovered: RpcStub<Project> | undefined;
+      // The mount isn't answering. Reconnect fresh (bounded above the handshake
+      // window); on failure keep the old stub, back off, and retry next tick —
+      // this must never throw out of the loop.
+      let fresh: RpcStub<Project> | undefined;
       try {
-        await provide(itx);
-        recovered = itx; // the current socket is still good
+        fresh = await withTimeout(
+          connectAndProvide(input.connect, input.name, input.capability),
+          RECONNECT_TIMEOUT_MS,
+          "reconnect",
+        );
       } catch {
-        try {
-          const fresh = await withTimeout(
-            connectAndProvide(input.connect, input.name, input.capability),
-            RECOVERY_TIMEOUT_MS,
-            "reconnect",
-          );
-          disposeItx(itx); // replace and free the old session
-          recovered = fresh;
-        } catch {
-          // Couldn't recover (transient network / auth). Keep the old stub — its
-          // next ping fails fast and retries recovery — and back off first.
-        }
+        // couldn't recover this round (transient network / auth / endpoint down)
       }
-      if (recovered === undefined) {
+      if (fresh === undefined) {
         await sleep(RECOVERY_BACKOFF_MS);
         continue;
       }
-      itx = recovered;
+      disposeItx(itx); // replace and free the old session
+      itx = fresh;
       input.onReprovided?.();
     }
     await sleep(HEALTH_CHECK_INTERVAL_MS);

--- a/packages/iterate/src/use-my-computer.ts
+++ b/packages/iterate/src/use-my-computer.ts
@@ -181,44 +181,62 @@ async function connectAndProvide(
 
 const HEALTH_CHECK_INTERVAL_MS = 8_000;
 const HEALTH_CHECK_TIMEOUT_MS = 5_000;
+const RECOVERY_TIMEOUT_MS = 12_000;
+const RECOVERY_BACKOFF_MS = 3_000;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
- * Call the mount over the FULL agent path (`itx.<name>.__ping()`) — the same
- * route an agent uses — bounded by a timeout so a STALLED round-trip (a wedged
- * connection that never errors) is treated as a failure and triggers recovery,
- * instead of hanging the keepalive loop forever.
+ * Race a promise against a timeout so a STALLED RPC (a wedged connection that
+ * never errors) is treated as a failure instead of hanging forever. The
+ * abandoned work is caught so a rejection that lands after the timeout can't
+ * surface as an unhandled rejection.
  */
-async function pingMount(itx: RpcStub<Project>, name: string): Promise<void> {
-  const ping = (itx as unknown as Record<string, { __ping(): Promise<{ ok: true }> }>)[
-    name
-  ].__ping();
-  ping.catch(() => {}); // a rejection that lands after we've timed out must not go unhandled
+function withTimeout<T>(work: Promise<T>, ms: number, label: string): Promise<T> {
+  work.catch(() => {});
   let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    await Promise.race([
-      ping,
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(
-          () => reject(new Error("mount ping timed out")),
-          HEALTH_CHECK_TIMEOUT_MS,
-        );
-      }),
-    ]);
-  } finally {
+  return Promise.race([
+    work,
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label} timed out`)), ms);
+    }),
+  ]).finally(() => {
     if (timer !== undefined) clearTimeout(timer);
+  });
+}
+
+/** Best-effort close of a capnweb session's socket, so recoveries don't leak connections. */
+function disposeItx(itx: RpcStub<Project>): void {
+  try {
+    (itx as unknown as { [Symbol.dispose]?: () => void })[Symbol.dispose]?.();
+  } catch {
+    // already gone
   }
 }
 
+/** Call the mount over the FULL agent path (`itx.<name>.__ping()`) — the same route an agent uses. */
+function pingMount(itx: RpcStub<Project>, name: string): Promise<void> {
+  const ping = (itx as unknown as Record<string, { __ping(): Promise<{ ok: true }> }>)[
+    name
+  ].__ping();
+  return withTimeout(ping, HEALTH_CHECK_TIMEOUT_MS, "mount ping").then(() => {});
+}
+
 /**
- * Keep the live mount routable for as long as we run, and never return. A live
+ * Keep the live mount routable for as long as we run, and NEVER return. A live
  * capability's provider ref lives only in the capability-host DO's memory, so a
  * DO eviction or a dropped socket silently takes it "offline" while this process
- * keeps happily running. So we don't just heartbeat — every few seconds we
- * self-call the mount over the full agent path: that round-trip keeps the host
- * DO warm AND proves the mount still answers. If it doesn't, we re-provide on the
- * current socket (recovers a DO eviction that dropped the ref but left our
- * connection intact); if THAT fails the connection is dead, so we reconnect and
- * provide fresh. `onReprovided` fires whenever we had to re-establish it.
+ * keeps happily running. So we don't just heartbeat — we self-call the mount
+ * over the full agent path: that round-trip keeps the host DO warm AND proves it
+ * still answers. The first check runs right after the initial provide (no dead
+ * startup window); thereafter every few seconds.
+ *
+ * On any failure we recover, and recovery NEVER escapes the loop — a share
+ * session ends only when the process does. Re-provide on the current socket
+ * first (recovers a host-DO eviction that dropped the ref but left the
+ * connection intact); else reconnect, disposing the old session. Every step is
+ * timeout-bounded, and a recovery that fails entirely just backs off and retries
+ * on the next tick. `onReprovided` fires whenever we re-establish it.
  */
 async function keepMountAlive(input: {
   itx: RpcStub<Project>;
@@ -229,27 +247,50 @@ async function keepMountAlive(input: {
 }): Promise<never> {
   let itx = input.itx;
   const provide = (stub: RpcStub<Project>) =>
-    stub.provideCapability({
-      type: "live",
-      path: [input.name],
-      capability: input.capability,
-      instructions: INSTRUCTIONS,
-      types: TYPES,
-    });
+    withTimeout(
+      stub.provideCapability({
+        type: "live",
+        path: [input.name],
+        capability: input.capability,
+        instructions: INSTRUCTIONS,
+        types: TYPES,
+      }),
+      RECOVERY_TIMEOUT_MS,
+      "re-provide",
+    );
+
   while (true) {
-    await new Promise((resolve) => setTimeout(resolve, HEALTH_CHECK_INTERVAL_MS));
     try {
-      await pingMount(itx, input.name);
-      continue; // mount answered — still live
+      await pingMount(itx, input.name); // confirms the mount end-to-end + keeps the host warm
     } catch {
-      // Mount not answering: re-provide on the current socket, else reconnect.
+      // Recover this round. Any of these steps may fail; none may throw out of
+      // the loop. Re-provide on the current socket, else reconnect fresh.
+      let recovered: RpcStub<Project> | undefined;
       try {
         await provide(itx);
+        recovered = itx; // the current socket is still good
       } catch {
-        itx = await connectAndProvide(input.connect, input.name, input.capability);
+        try {
+          const fresh = await withTimeout(
+            connectAndProvide(input.connect, input.name, input.capability),
+            RECOVERY_TIMEOUT_MS,
+            "reconnect",
+          );
+          disposeItx(itx); // replace and free the old session
+          recovered = fresh;
+        } catch {
+          // Couldn't recover (transient network / auth). Keep the old stub — its
+          // next ping fails fast and retries recovery — and back off first.
+        }
       }
+      if (recovered === undefined) {
+        await sleep(RECOVERY_BACKOFF_MS);
+        continue;
+      }
+      itx = recovered;
       input.onReprovided?.();
     }
+    await sleep(HEALTH_CHECK_INTERVAL_MS);
   }
 }
 


### PR DESCRIPTION
Follow-up to #1892 addressing four Bugbot findings on the extended-sharing keepalive:

1. **First keepalive waited 8s** (Medium) — the loop slept before its first ping, so nothing kept the host DO warm for the first 8s after `provideCapability`; an eviction in that window read as offline. Now the first ping runs immediately (also confirming the provide end-to-end), then the cadence.
2. **Reconnect failure stopped the share loop** (High) — a failed re-provide followed by a failed reconnect propagated out of `keepMountAlive`, so the CLI exited instead of continuing the intended never-returning share. Recovery now never escapes the loop: a failed round keeps the old stub, backs off, and retries on the next tick.
3. **Old socket leaked on reconnect** (Low) — the previous `itx` session is now disposed (`Symbol.dispose`) when a fresh connection replaces it.
4. **Recovery could hang** (Medium) — `provide` and `connectAndProvide` are now timeout-bounded like the ping (shared `withTimeout`), so a wedged half-open socket can't block the loop.

Re-verified live on prd: the mount comes online within seconds and stays reachable from a separate session, with no re-provide churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes long-running CLI networking, OAuth refresh on reconnect, and error-handling in the share loop; scope is localized to `use-my-computer` but affects agent access to live capabilities during outages.
> 
> **Overview**
> **Hardens the long-lived `use-my-computer` share loop** so mounts stay reachable and the CLI no longer exits on transient failures.
> 
> `ConnectInput` now takes a **`reauth` callback** (wired from `useMyComputer` in `cli.ts`) instead of one-shot credentials. **Every connect/reconnect** re-reads env secrets or refreshes the stored OAuth session so recovery still works after the short OS access-token TTL.
> 
> In **`keepMountAlive`**: the **first health ping runs immediately** (then every ~8s), not after an initial sleep. On failure the code **always reconnects fresh** (`connectAndProvide` with a **30s timeout** via shared **`withTimeout`**), **disposes** the old capnweb session, and on a failed recovery **backs off and retries** without throwing—so the share session only ends when the process does. Mount pings use the same timeout helper to avoid wedged RPCs hanging the loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9335aa30c188ae6ddd18761f06486cb3626fd523. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +93 -48 | +50 -35 🟩🟩🟩🟥🟥 |
| **Total** | **+93 -48** | **+50 -35** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between c1c526b and 9335aa3, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->