### PR TITLE
Evict the corpse, not its successor: unmap the transport before wake()

### DIFF
--- a/apps/os/src/itx/itx-react.tsx
+++ b/apps/os/src/itx/itx-react.tsx
@@ -226,6 +226,15 @@ export function reconnectItx(address?: ItxAddress): void {
   const context = address?.projectId;
   const promise = sockets.get(context);
   if (!promise) return;
+  // Capture and unmap the transport BEFORE wake(): useSyncExternalStore's
+  // change handler synchronously re-reads getSnapshot → socketFor, which
+  // dials a fresh socket and OVERWRITES this context's socketTransports slot.
+  // Reading the slot after wake() closed that fresh successor at
+  // readyState=0 while the corpse — carrying every pending call — was never
+  // closed (prd-observed: composer sends stranded forever behind a spinner,
+  // one leaked socket per eviction, one wasted dial per eviction).
+  const ws = socketTransports.get(context);
+  if (ws !== undefined) socketTransports.delete(context);
   sockets.delete(context);
   wake();
   // CLOSE the transport, don't just unmap it: capnweb tears the session down
@@ -233,12 +242,8 @@ export function reconnectItx(address?: ItxAddress): void {
   // Unmapping alone leaves a ghost session that in-flight calls — a composer
   // send, a suspended query — hang on forever, and on a half-open socket the
   // OS may never deliver a close for us. The close listener's identity guards
-  // make this safe against the map already pointing at a successor.
-  const ws = socketTransports.get(context);
-  if (ws !== undefined) {
-    socketTransports.delete(context);
-    ws.close();
-  }
+  // make this safe regardless of what the map points at by now.
+  ws?.close();
   void promise.then((itx) => (itx as Partial<Disposable>)[Symbol.dispose]?.()).catch(() => {});
 }
 

--- a/specs/stream-resume-after-suspend.spec.ts
+++ b/specs/stream-resume-after-suspend.spec.ts
@@ -344,7 +344,9 @@ test("feed resumes after the /api WebSocket goes half-open (no close frame)", as
   page,
   baseURL,
 }) => {
-  test.setTimeout(240_000);
+  // The greeting-settle wait (up to 120s) stacks on the probe window and the
+  // two send assertions, so this lane gets the heavy ceiling.
+  test.setTimeout(300_000);
   await using fixture = await helpers.createFixture("suspend-halfopen");
   if (!baseURL) throw new Error("Playwright baseURL fixture is required.");
   await installSocketKillSwitch(page);
@@ -358,6 +360,11 @@ test("feed resumes after the /api WebSocket goes half-open (no close frame)", as
   const keys = runtimeDebugKeys(fixture.project.id);
   await waitForSubscribed(page, keys);
 
+  // The onboarding greeting turn may still be streaming, and a live turn swaps
+  // the send button for "Stop generation" — wait for the settled composer so
+  // the mid-outage send below has a button to click.
+  await page.getByRole("button", { name: "Send message" }).waitFor({ timeout: 120_000 });
+
   // Blackhole the transport WITHOUT a close event — what a suspend-killed TCP
   // connection looks like when the OS never surfaces the death. Every capnweb
   // call now hangs; the socket map still holds the corpse, so recovery needs
@@ -368,6 +375,20 @@ test("feed resumes after the /api WebSocket goes half-open (no close frame)", as
   );
   console.log(`muted sockets: ${JSON.stringify(mutedUrls)}`);
   expect(mutedUrls.length, "expected at least one live /api WebSocket to mute").toBeGreaterThan(0);
+
+  // Send DURING the outage, before anything has noticed the death. The call
+  // rides the corpse session; it can only settle when eviction CLOSES that
+  // socket (capnweb rejects pending calls on transport close, the composer
+  // surfaces the error and keeps the draft). The historical bug: eviction
+  // closed the freshly-dialed SUCCESSOR instead (wake()'s synchronous
+  // getSnapshot re-dial overwrote the transport slot before it was read), so
+  // the corpse survived and the composer spun forever with no error — even
+  // while the feed looked fully recovered.
+  const sentDuringOutage = `during-outage-${Date.now()}`;
+  await spinnerWaiter.settings.run({ disabled: true }, async () => {
+    await page.getByPlaceholder("Message this agent").fill(sentDuringOutage);
+    await page.getByRole("button", { name: "Send message" }).click();
+  });
 
   // Two probe intervals + two probe timeouts before the transport is evicted.
   await page.waitForTimeout(PROBE_NOTICE_MS + 10_000);
@@ -393,19 +414,32 @@ test("feed resumes after the /api WebSocket goes half-open (no close frame)", as
     `marker at offset ${marker!.offset} should be delivered after the transport is evicted and re-dialed — see the __streamRuntimeDebug dump above`,
   ).toBe(true);
 
-  // The user's half of the story: after recovery, a send from the BROWSER
-  // composer must settle and paint. Historically eviction only unmapped the
-  // dead session (never closed it), so a send could hang forever on the ghost
-  // even while the feed looked recovered. The feed's live "Thinking…" state
-  // renders two spinner-matching elements, so spinner-waiter sits this out
-  // (same per-call override as agent-chat.spec.ts).
+  // The user's half of the story: the stranded mid-outage send must SETTLE —
+  // either it landed, or it rejected (composer re-enables, draft retained) and
+  // a resend on the recovered transport lands. Never a forever-spinner. The
+  // feed's live "Thinking…" state renders two spinner-matching elements, so
+  // spinner-waiter sits this out (same per-call override as agent-chat.spec.ts).
   await spinnerWaiter.settings.run({ disabled: true }, async () => {
-    const sent = `resumed-${Date.now()}`;
-    await page.getByPlaceholder("Message this agent").fill(sent);
-    await page.getByRole("button", { name: "Send message" }).click();
-    await page
+    const sendButton = page.getByRole("button", { name: "Send message" });
+    const sentRow = page
       .locator('[data-testid="agent-feed-message"][data-kind="user"]')
-      .getByText(sent)
-      .waitFor({ timeout: 30_000 });
+      .getByText(sentDuringOutage);
+    await expect(async () => {
+      // Settled = the message painted (it landed) OR the button re-enabled
+      // (it rejected and the draft is back). A still-spinning composer with
+      // no row is the stranded-on-a-ghost-session wedge.
+      const landed = await sentRow.isVisible();
+      const enabled = await sendButton.isEnabled();
+      expect(
+        landed || enabled,
+        "the mid-outage send never settled — stranded on a ghost session",
+      ).toBe(true);
+    }).toPass({ timeout: 60_000, intervals: [1_000] });
+    if (!(await sentRow.isVisible())) {
+      // The stranded call rejected; the composer kept the draft — resend on
+      // the recovered transport.
+      await sendButton.click();
+    }
+    await sentRow.waitFor({ timeout: 30_000 });
   });
 });


### PR DESCRIPTION
Follow-up to #1880, found by the post-merge **live prd bug hunt** (reproduced 3× against os.iterate.com with per-socket lifecycle instrumentation).

## The bug

`reconnectItx` read `socketTransports.get(context)` **after** `wake()` — but `useSyncExternalStore`'s change handler synchronously re-reads `getSnapshot → socketFor`, which dials a fresh socket and **overwrites the transport slot**. So every eviction closed the **freshly-dialed successor** at `readyState=0` (observed close code 1006) while the half-open corpse — carrying every pending capnweb call — was never closed.

Consequences observed live in prd:
- A composer send issued during the outage window **stranded forever**: spinner on, no error, user cannot send again without a full reload — while the feed looked perfectly recovered (`stream-view-composer` awaits the send with no deadline).
- One never-closed socket leaked per eviction (live-socket census grew 2 → 3 → 4 across three suspend cycles).
- One wasted dial per eviction (successor killed, second dial does the recovery).

Feed recovery itself was unaffected (which is why #1880's suite stayed green — it only sent *after* recovery).

## The fix

Capture and unmap the transport **before** `wake()`, close it after. All eviction lanes funnel through `reconnectItx`, so this fixes `evictItxSocket`, `reconnectAllItx`, and the manual session-change lane in one move.

## Regression proof

The half-open lane in `specs/stream-resume-after-suspend.spec.ts` now also sends **during** the outage and asserts the stranded call settles (rejects with draft retained → resend lands, or lands directly) — **red without this fix (send never settles in 60s), green with it** (verified by reverting the fix and rerunning). Full suite 4/4 green locally; 1116 unit tests pass.

The rest of the prd hunt's verdicts (eviction stampede, 3× repeated suspend cycles, two-tab follower clean-close, ⌘K stack): **sound** — details on #1880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core browser WebSocket lifecycle used by all ITX consumers (eviction, reconnectAll, session refresh); the ordering change is narrow but recovery paths are user-critical.
> 
> **Overview**
> **Fixes ITX socket eviction closing the wrong WebSocket**, which left half-open “corpse” sessions alive and stranded composer sends on an infinite spinner while the feed looked healthy.
> 
> In `reconnectItx`, the transport is now **read and removed from `socketTransports` before `wake()`**. `useSyncExternalStore` listeners run synchronously on wake and can dial a successor that overwrites the map; closing after wake had been killing that fresh socket (often at `readyState=0`) instead of the dead one, so pending capnweb calls never got transport-close rejection and sockets leaked per eviction.
> 
> The half-open Playwright lane in `stream-resume-after-suspend.spec.ts` now waits for a settled composer, **sends during the muted outage**, and asserts that send settles (message visible or Send re-enabled, with optional resend)—behavior that failed without this fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8700ad769007370040e36c85ae5a4cbad54d9272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +11 -6 | +3 -5 🟥⬜⬜⬜⬜ |
| Tests | +47 -13 | +22 -7 🟩🟩🟩🟩🟥 |
| **Total** | **+58 -19** | **+25 -12** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between c1c526b and 8700ad7, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-12T00:05:00.939Z",
      "headSha": "8700ad769007370040e36c85ae5a4cbad54d9272",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/519323979159215",
      "shortSha": "8700ad7",
      "cleanupDurationMs": 9674,
      "deployDurationMs": 77499,
      "testDurationMs": 180927,
      "testRetries": "2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · markdown files get a sanitized Code | Preview toggle in the repo IDE (specs x1)",
      "workerSizeKib": 15976.47,
      "workerGzipKib": 4309.5,
      "mainWorkerGzipKib": 4316.16
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-12T00:04:52.027Z",
      "headSha": "8700ad769007370040e36c85ae5a4cbad54d9272",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/519323979159215",
      "shortSha": "8700ad7",
      "cleanupDurationMs": 759,
      "deployDurationMs": 15744,
      "testDurationMs": 17024,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-12T00:04:54.209Z",
      "headSha": "8700ad769007370040e36c85ae5a4cbad54d9272",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/519323979159215",
      "shortSha": "8700ad7",
      "cleanupDurationMs": 2939,
      "deployDurationMs": 20111,
      "testDurationMs": 528,
      "testRetries": null,
      "workerSizeKib": 4032.01,
      "workerGzipKib": 819.56,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-12T00:04:53.122Z",
      "headSha": "8700ad769007370040e36c85ae5a4cbad54d9272",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/519323979159215",
      "shortSha": "8700ad7",
      "cleanupDurationMs": 1848,
      "deployDurationMs": 15323,
      "testDurationMs": 18239,
      "testRetries": null,
      "workerSizeKib": 4842.25,
      "workerGzipKib": 1385.2,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `8700ad7` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 819.6 KiB | 20.1s | 528ms |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/519323979159215) | 2026-07-12T00:04:54.209Z | Preview app released. |
| OS | released | `8700ad7` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 4.21 MiB (-6.7 KiB vs main) | 77.5s | 180.9s | 2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · markdown files get a sanitized Code \| Preview toggle in the repo IDE (specs x1) | 9.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/519323979159215) | 2026-07-12T00:05:00.939Z | Preview app released. |
| Semaphore | released | `8700ad7` | [https://semaphore.iterate-preview-7.com](https://semaphore.iterate-preview-7.com) | 440.8 KiB | 15.7s | 17.0s |  | 759ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/519323979159215) | 2026-07-12T00:04:52.027Z | Preview app released. |
| Streams Example App | released | `8700ad7` | [https://streams.iterate-preview-7.com](https://streams.iterate-preview-7.com) | 1.35 MiB | 15.3s | 18.2s |  | 1.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/519323979159215) | 2026-07-12T00:04:53.122Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->