### PR TITLE
use-my-computer lends local servers by URL: fetch("http://<name>.iterate/…") — HTTP + WebSockets via addressable capabilities

### DIFF
--- a/apps/os/docs/dynamic-worker-dispatch.md
+++ b/apps/os/docs/dynamic-worker-dispatch.md
@@ -137,6 +137,26 @@ functions chain through every hop; mind that RPC params are released on
 return, so a provider must `dup()` callbacks it keeps — but that pattern is
 deliberately not blessed here: the specification above is the intended shape.
 
+Both halves of that story now have a shipped existence proof in
+`iterate use-my-computer` (packages/iterate/src/use-my-computer.ts), proven
+end to end by `e2e/vitest/live-capability-fetcher.e2e.test.ts`:
+
+- `getFetcher({ port })` is the HTTP half: a live-capability method returning
+  `{ fetch(request) }` that proxies to a server on the provider's machine. A
+  project worker's homepage can be
+  `return (await itx.myComputer.getFetcher({ port })).fetch(req)` — the
+  `Request` copy rides capability dispatch out, the `Response` copy rides
+  back. It refuses upgrade requests with a teaching error instead of letting
+  them die deep in the mesh.
+- `connectSocket({ port, path, onMessage })` is the by-hand frame bridge: the
+  provider opens the real socket locally and hands back a
+  `{ send, receive, close }` handle; a Durable Object app terminates the
+  browser's socket with `WebSocketPair` and pumps frames through the handle.
+  Two findings the e2e pins: callback stubs (`onMessage`) do chain CLI→host→DO
+  and stay live for the socket's lifetime once the provider `dup()`s them, and
+  a Durable Object can keep the handle across events (its I/O context spans
+  the socket's life) — a stateless worker could not.
+
 ## Rules of thumb
 
 - Serving HTTP from a dynamic worker? Implement the class's `fetch` handler —

--- a/apps/os/docs/dynamic-worker-dispatch.md
+++ b/apps/os/docs/dynamic-worker-dispatch.md
@@ -149,13 +149,17 @@ end to end by `e2e/vitest/live-capability-fetcher.e2e.test.ts`:
   back. It refuses upgrade requests with a teaching error instead of letting
   them die deep in the mesh.
 - `connectSocket({ port, path, onMessage })` is the by-hand frame bridge: the
-  provider opens the real socket locally and hands back a
-  `{ send, receive, close }` handle; a Durable Object app terminates the
-  browser's socket with `WebSocketPair` and pumps frames through the handle.
-  Two findings the e2e pins: callback stubs (`onMessage`) do chain CLI→host→DO
-  and stay live for the socket's lifetime once the provider `dup()`s them, and
-  a Durable Object can keep the handle across events (its I/O context spans
-  the socket's life) — a stateless worker could not.
+  provider opens the real socket locally and hands back a `{ send, close }`
+  handle, delivering incoming frames to the `onMessage` callback; a Durable
+  Object app terminates the browser's socket with `WebSocketPair` and pumps
+  frames through the handle. Three findings the e2e pins: callback stubs
+  (`onMessage`) do chain CLI→host→DO and stay live for the socket's lifetime
+  once the provider `dup()`s them; a Durable Object can keep the handle across
+  events (its I/O context spans the socket's life) where a stateless worker
+  could not; and cross-RPC teardown must be the string-keyed `close()` (a
+  returned value's `[Symbol.dispose]` is dropped by capnweb's by-value return
+  serialization), awaited before the DO disposes the itx stub the handle rides
+  on — disposing first aborts the close in flight and the local socket lingers.
 
 ## Rules of thumb
 

--- a/apps/os/docs/dynamic-worker-dispatch.md
+++ b/apps/os/docs/dynamic-worker-dispatch.md
@@ -108,58 +108,82 @@ request":
   close to a WebSocket reconnect loop. RPC callers of `workers.get` still
   get the named `WorkerBuildInProgressError` instead.
 
-## Live capabilities and WebSockets: the specification, and today's boundary
+## Live capabilities over the fetch lane: capability URLs
 
-The behavior we want: a live capability whose `fetch(request)` upgrades —
-provided over Cap'n Web from, say, a Node process — backs a project app host
-directly, with the app's own fetch just forwarding
-(`itx.wsbackend.fetch(req)`). That is written down as a **`test.fails`
-specification** in `e2e/vitest/live-capability-websocket.e2e.test.ts`; when
-it starts passing, the platform grew the feature and the assertion flips
-loudly.
+A live capability is normally reached by RPC (`itx.<name>.method(...)`), which
+carries data but never a socket. To give a live capability the fetch lane's
+physics — streaming, and crucially WebSocket upgrades — mount it as
+**`addressable`** and reach it by **URL** instead of by itx path:
 
-Today it stops one hop short, and the same file pins the boundary with a
-passing test:
+```
+fetch("http://<name>.iterate/…", req)   // from project worker code
+```
+
+`.iterate` is the internal host suffix (never DNS-routable — the same suffix the
+Durable Object name codec uses). The grammar is `<cap>.<projectId>.iterate`, or
+the short `<cap>.iterate` (the caller's own project); the request path/query
+ride the URL path, the capability name is the host label. DNS lowercases the
+host, so mounts resolve case-insensitively (`itx.jonasComputer` ↔
+`jonascomputer.<project>.iterate`). The parse + dispatch header live in
+`domains/capability-host/capability-url.ts`.
+
+Why a URL and not a method: **the URL changes the transport class from RPC to
+fetch-native.** Every hop is a real stub fetch — project egress
+(`ProjectDurableObject.fetch`) recognizes an `.iterate` host and dials the
+capability host DO (`CAPABILITY_HOST.getByName(...).fetch`), carrying the
+resolved capability path in `x-iterate-capability-dispatch` (internal, stripped
+at the trust boundary). The capability host DO is a real workerd object
+(`serveCapabilityFetch`), so:
+
+- **Plain HTTP** calls the provider's `fetch(request)` — the `Request`/`Response`
+  copies serialize over the provider's connection, the same transport as
+  `itx.<name>.fetch(req)`, just reached by URL.
+- **A WebSocket upgrade terminates AT the capability host DO** (`WebSocketPair`,
+  a real 101 established at a real object's fetch) and bridges FRAMES to the
+  provider via its `connectSocket({ onMessage, onClose }) → { send, close }`.
+  The socket never crosses an RPC hop; only frames (callback invocations) do.
+  This is the by-hand frame bridge the old recipe required, now run by the
+  platform. The teardown discipline is the same: `close()` is the only
+  cross-RPC teardown (a returned value's `[Symbol.dispose]` is dropped by
+  capnweb's by-value return serialization), awaited before the per-socket handle
+  is disposed; callback stubs stay live for the socket's lifetime because a DO's
+  I/O context spans the socket and capnweb keeps the `dup()`'d callbacks alive.
+
+Cross-project access is structurally impossible: the egress hop dials the
+capability host under the CALLER's own projectId, and an explicit projectId in
+the URL must match it. `addressable` is opt-in on `provideCapability` — an
+ordinary live mount is not URL-reachable.
+
+`iterate use-my-computer` is the shipped provider
+(packages/iterate/src/use-my-computer.ts): `myComputerProvision(name,
+{ exposePort })` mounts `addressable` and lends the local port, so a project
+worker's whole homepage — HTTP and its `/ws` upgrade alike — is one forward,
+`return fetch(new Request("http://<name>.iterate" + path + search, req))`.
+`e2e/vitest/live-capability-fetcher.e2e.test.ts` proves both, end to end.
+
+## The RPC boundary that remains (the deferred specification)
+
+Capability URLs give the fetch lane's physics to a live capability, but they do
+NOT make the RPC path carry a socket. Forwarding `itx.wsbackend.fetch(req)`
+where the provider returns a socket-carrying `Response` still dies at the first
+internal workerd RPC hop:
 
 - Non-upgrade HTTP through a live capability's fetch works — `Request` and
   `Response` serialize over capability dispatch.
-- An upgrade response does not: the capnweb fork tunnels the socket across
-  the **session** as a stream pair (`websocket-streams.ts`), then
-  materializes a real WebSocket at the session endpoint — and the first
-  internal workerd RPC hop after that refuses it (the DataCloneError,
-  asserted verbatim).
+- An upgrade response does not: the capnweb fork tunnels the socket across the
+  **session** as a stream pair (`websocket-streams.ts`), then materializes a
+  real WebSocket at the session endpoint — and the first internal workerd RPC
+  hop after that refuses it (the DataCloneError, asserted verbatim).
 
-The missing piece is keeping the socket in stream-pair (or callback) form
-across internal hops and materializing only at the fetch-lane exit. Until
-then, a determined userspace can bridge a socket over capability dispatch
-today by hand — frames as paired callback stubs in each direction, since
-functions chain through every hop; mind that RPC params are released on
-return, so a provider must `dup()` callbacks it keeps — but that pattern is
-deliberately not blessed here: the specification above is the intended shape.
-
-Both halves of that story now have a shipped existence proof in
-`iterate use-my-computer` (packages/iterate/src/use-my-computer.ts), proven
-end to end by `e2e/vitest/live-capability-fetcher.e2e.test.ts`:
-
-- `getFetcher({ port })` is the HTTP half: a live-capability method returning
-  `{ fetch(request) }` that proxies to a server on the provider's machine. A
-  project worker's homepage can be
-  `return (await itx.myComputer.getFetcher({ port })).fetch(req)` — the
-  `Request` copy rides capability dispatch out, the `Response` copy rides
-  back. It refuses upgrade requests with a teaching error instead of letting
-  them die deep in the mesh.
-- `connectSocket({ port, path, onMessage })` is the by-hand frame bridge: the
-  provider opens the real socket locally and hands back a `{ send, close }`
-  handle, delivering incoming frames to the `onMessage` callback; a Durable
-  Object app terminates the browser's socket with `WebSocketPair` and pumps
-  frames through the handle. Three findings the e2e pins: callback stubs
-  (`onMessage`) do chain CLI→host→DO and stay live for the socket's lifetime
-  once the provider `dup()`s them; a Durable Object can keep the handle across
-  events (its I/O context spans the socket's life) where a stateless worker
-  could not; and cross-RPC teardown must be the string-keyed `close()` (a
-  returned value's `[Symbol.dispose]` is dropped by capnweb's by-value return
-  serialization), awaited before the DO disposes the itx stub the handle rides
-  on — disposing first aborts the close in flight and the local socket lingers.
+That boundary is pinned by a passing test, and the socket-over-RPC dream it
+guards is a **`test.fails` specification**, both in
+`e2e/vitest/live-capability-websocket.e2e.test.ts`. Making the spec pass would
+need the fork to stay in stream-pair form until the fetch-lane exit (a capnweb
+`makeUpgradeResponse` change) — deliberately not done, because the
+capability-URL form above already delivers the user-facing outcome (websockets
+to a live capability) by terminating the upgrade at a real DO and bridging
+frames. The two mechanisms address the socket differently; the URL form is the
+shipped one.
 
 ## Rules of thumb
 

--- a/apps/os/e2e/vitest/live-capability-fetcher.e2e.test.ts
+++ b/apps/os/e2e/vitest/live-capability-fetcher.e2e.test.ts
@@ -377,6 +377,15 @@ test("WebSockets work through the bridge: frames pump between a browser socket a
     } finally {
       socket.close();
     }
+    // Teardown note: closing the browser socket does NOT reliably drain the
+    // Mac's socket in local dev — the DO's close listener (and its
+    // handle.close()) doesn't fire once the upgrade request has returned (the
+    // isolate is done with that request), so the provider socket lingers until
+    // closeServer force-terminates it. That terminate is not just hang
+    // avoidance: it drives the provider's OWN socket-close teardown (dispose
+    // the retained callbacks), which is the cleanup the provider can guarantee
+    // without depending on the DO. The provider's other guaranteed lane is
+    // closeAllBridges when the CLI's connection to OS drops.
   } finally {
     await closeServer(server);
     await closeServer(wsServer);

--- a/apps/os/e2e/vitest/live-capability-fetcher.e2e.test.ts
+++ b/apps/os/e2e/vitest/live-capability-fetcher.e2e.test.ts
@@ -66,6 +66,21 @@ function startLocalWsServer(): Promise<{ port: number; server: WebSocketServer }
 }
 
 /**
+ * Await a node http / ws server's full shutdown. A WebSocketServer won't close
+ * while a client socket is open — here that's the bridge's still-live provider
+ * socket (the browser-close → DO → handle.close() teardown races this, and a
+ * hibernated DO may never run it at all) — so terminate any clients first.
+ * That abrupt close also drives the provider's own socket-close teardown.
+ */
+function closeServer(server: {
+  close(cb?: (error?: Error) => void): void;
+  clients?: Set<{ terminate(): void }>;
+}): Promise<void> {
+  for (const client of server.clients ?? []) client.terminate();
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+/**
  * The demo worker committed to the test project: the homepage forwards to the
  * human's HTTP server through getFetcher; the wsbridge app terminates browser
  * WebSockets and bridges frames through connectSocket. Mirrors the seeded
@@ -122,8 +137,9 @@ export class WsBridgeApp extends IterateDurableObject {
     const server = pair[1];
     server.accept();
 
-    // Deliberately NOT disposed at the end of this request: the bridge lives
-    // as long as the browser's socket does.
+    // Held (not disposed at request end): the bridge lives as long as the
+    // browser's socket does. connectSocket's onMessage delivers local-server
+    // frames; the browser's frames go out through handle.send.
     const itx = await this.env.ITX.get();
     let handle: any;
     try {
@@ -142,12 +158,34 @@ export class WsBridgeApp extends IterateDurableObject {
         },
       });
     } catch (error) {
+      // Nothing to bridge to: close the pair we accepted and release itx.
+      try {
+        server.close(1011, "bridge failed");
+      } catch {}
       try {
         (itx as any)[Symbol.dispose]?.();
       } catch {}
       return new Response("bridge failed: " + String(error), { status: 502 });
     }
 
+    // One idempotent teardown for both close and error: close the bridge, then
+    // release the itx stub. Ordering matters — handle.close() is an RPC that
+    // rides on this itx session, so we must AWAIT it (the provider closes the
+    // Mac's socket) before disposing the session; disposing first aborts the
+    // close in flight and the Mac's socket lingers. (Symbol.dispose on the
+    // returned handle is dropped by capnweb's by-value return serialization, so
+    // close() — a real string-keyed method — is the only cross-RPC teardown.)
+    let torn = false;
+    const teardown = async () => {
+      if (torn) return;
+      torn = true;
+      try {
+        await handle.close({});
+      } catch {}
+      try {
+        (itx as any)[Symbol.dispose]?.();
+      } catch {}
+    };
     server.addEventListener("message", (event) => {
       void handle.send(String(event.data)).catch(() => {
         try {
@@ -155,12 +193,6 @@ export class WsBridgeApp extends IterateDurableObject {
         } catch {}
       });
     });
-    const teardown = () => {
-      void handle.close({}).catch(() => {});
-      try {
-        (itx as any)[Symbol.dispose]?.();
-      } catch {}
-    };
     server.addEventListener("close", teardown);
     server.addEventListener("error", teardown);
 
@@ -244,8 +276,8 @@ test("the homepage is a server on the human's machine: getFetcher proxies HTTP e
     })();
     expect(outcome).toContain("cannot carry a WebSocket upgrade");
   } finally {
-    server.close();
-    wsServer.close();
+    await closeServer(server);
+    await closeServer(wsServer);
   }
 });
 
@@ -284,20 +316,26 @@ test("WebSockets work through the bridge: frames pump between a browser socket a
         ws.once("open", () => resolve(ws));
         ws.once("unexpected-response", (_req, res) => {
           res.resume();
-          reject(new Error(`upgrade rejected: ${res.statusCode}`));
+          const error = new Error(`upgrade rejected: ${res.statusCode}`) as Error & {
+            status?: number;
+          };
+          error.status = res.statusCode;
+          reject(error);
         });
         ws.once("error", reject);
       });
 
-    // Cold build: retry until the upgrade lands (building 503s read as
-    // rejected upgrades; a 502 means the bridge dialed but couldn't connect).
+    // Retry ONLY the cold-build 503 (the router's building page); a real
+    // failure such as a 502 from the bridge surfaces immediately instead of
+    // spinning for two minutes.
     const openSocketReady = async () => {
       const deadline = Date.now() + 120_000;
       for (;;) {
         try {
           return await openSocket(connect());
         } catch (error) {
-          if (Date.now() > deadline) throw error;
+          const status = (error as { status?: number }).status;
+          if (status !== 503 || Date.now() > deadline) throw error;
           await new Promise((resolve) => setTimeout(resolve, 2_000));
         }
       }
@@ -340,7 +378,7 @@ test("WebSockets work through the bridge: frames pump between a browser socket a
       socket.close();
     }
   } finally {
-    server.close();
-    wsServer.close();
+    await closeServer(server);
+    await closeServer(wsServer);
   }
 });

--- a/apps/os/e2e/vitest/live-capability-fetcher.e2e.test.ts
+++ b/apps/os/e2e/vitest/live-capability-fetcher.e2e.test.ts
@@ -1,0 +1,346 @@
+import { createServer, type Server } from "node:http";
+import { expect, test } from "vitest";
+import WebSocket, { WebSocketServer } from "ws";
+import { myComputerProvision } from "../../../../packages/iterate/src/use-my-computer.ts";
+import { adminSecret, buildUrl, withItxSession } from "./test-helpers.ts";
+
+// `iterate use-my-computer` grew two lanes that lend a SERVER on the human's
+// machine to their project, and this file proves both with the real capability
+// object (myComputerProvision — the exact input the CLI sends; this vitest
+// process stands in for the Mac):
+//
+//   1. getFetcher({ port }) — the project homepage IS the human's local server:
+//      the worker's fetch forwards `itx.<name>.getFetcher({port}).fetch(req)`,
+//      the Request rides capability dispatch to this process, the fetch hits
+//      127.0.0.1:<port>, and the Response rides back. Plain HTTP only — an
+//      upgrade can never cross capability dispatch (the socket-carrying
+//      Response dies on workerd's internal RPC hops; pinned with a teaching
+//      error here and with the raw DataCloneError in
+//      live-capability-websocket.e2e.test.ts).
+//
+//   2. connectSocket({ port, path }) — WebSockets work anyway, by bridging
+//      FRAMES instead of carrying the socket: a Durable Object app terminates
+//      the browser's socket with WebSocketPair and pumps text frames through a
+//      capability handle (send / onMessage callback), while the real socket to
+//      the local server lives on the Mac. dynamic-worker-dispatch.md calls this
+//      exact shape out as the workable-today form of the `test.fails`
+//      specification next door.
+
+/** The "server on the human's Mac": plain HTTP with a recognizable body. */
+function startLocalHttpServer(marker: string): Promise<{ port: number; server: Server }> {
+  const server = createServer((request, response) => {
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(
+      `<!doctype html><html><body><h1>hello from the mac ${marker}</h1>` +
+        `<p data-path="${request.url ?? ""}"></p>` +
+        `<p data-forwarded-host="${String(request.headers["x-forwarded-host"] ?? "")}"></p>` +
+        `</body></html>`,
+    );
+  });
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        reject(new Error("no port"));
+        return;
+      }
+      resolve({ port: address.port, server });
+    });
+  });
+}
+
+/** A local WebSocket server: greets on connect, then echoes frames prefixed. */
+function startLocalWsServer(): Promise<{ port: number; server: WebSocketServer }> {
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  server.on("connection", (socket) => {
+    socket.send("local-hello");
+    socket.on("message", (data) => socket.send(`local-echo:${String(data)}`));
+  });
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.once("listening", () => {
+      resolve({ port: (server.address() as { port: number }).port, server });
+    });
+  });
+}
+
+/**
+ * The demo worker committed to the test project: the homepage forwards to the
+ * human's HTTP server through getFetcher; the wsbridge app terminates browser
+ * WebSockets and bridges frames through connectSocket. Mirrors the seeded
+ * template's shape (iterate/sdk base classes, x-iterate-app routing).
+ */
+function demoWorkerSource(input: { name: string; httpPort: number; wsPort: number }): string {
+  return `import { IterateDurableObject, IterateWorkerEntrypoint } from "iterate/sdk";
+
+// Demo (live-capability-fetcher e2e): the homepage IS a server on the human's
+// machine, and the wsbridge app carries WebSockets to it frame-by-frame.
+export default class ProjectWorker extends IterateWorkerEntrypoint {
+  async fetch(req: Request): Promise<Response> {
+    const app = req.headers.get("x-iterate-app");
+    if (app === "wsbridge") {
+      return this.fetchDynamicWorker(req, {
+        type: "stateful",
+        path: "/",
+        className: "WsBridgeApp",
+        durableWorkerKey: "app-wsbridge",
+        source: {
+          files: { type: "repo", repoPath: "/repos/config" },
+          options: { entryPoint: "worker.ts" },
+        },
+      });
+    }
+    if (app) return new Response("unknown app: " + app, { status: 404 });
+
+    // THE DEMO: serve the project homepage straight from the shared computer.
+    const itx = await this.env.ITX.get();
+    try {
+      const computer = (itx as any).${input.name};
+      const fetcher = await computer.getFetcher({ port: ${input.httpPort} });
+      return await fetcher.fetch(req);
+    } finally {
+      try {
+        (itx as any)[Symbol.dispose]?.();
+      } catch {}
+    }
+  }
+}
+
+// The socket itself can never cross RPC hops, so this Durable Object holds the
+// browser's end (WebSocketPair) and exchanges FRAMES with the shared computer:
+// browser frames go out through handle.send, local-server frames come back
+// through the onMessage callback. Durable Objects share one I/O context across
+// events, which is what lets the handle and callbacks outlive the upgrade
+// request.
+export class WsBridgeApp extends IterateDurableObject {
+  async fetch(req: Request): Promise<Response> {
+    if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      return new Response("expected websocket", { status: 426 });
+    }
+    const pair = new WebSocketPair();
+    const server = pair[1];
+    server.accept();
+
+    // Deliberately NOT disposed at the end of this request: the bridge lives
+    // as long as the browser's socket does.
+    const itx = await this.env.ITX.get();
+    let handle: any;
+    try {
+      handle = await (itx as any).${input.name}.connectSocket({
+        port: ${input.wsPort},
+        path: "/",
+        onMessage: (data: string) => {
+          try {
+            server.send(data);
+          } catch {}
+        },
+        onClose: () => {
+          try {
+            server.close(1000, "local server closed");
+          } catch {}
+        },
+      });
+    } catch (error) {
+      try {
+        (itx as any)[Symbol.dispose]?.();
+      } catch {}
+      return new Response("bridge failed: " + String(error), { status: 502 });
+    }
+
+    server.addEventListener("message", (event) => {
+      void handle.send(String(event.data)).catch(() => {
+        try {
+          server.close(1011, "bridge send failed");
+        } catch {}
+      });
+    });
+    const teardown = () => {
+      void handle.close({}).catch(() => {});
+      try {
+        (itx as any)[Symbol.dispose]?.();
+      } catch {}
+    };
+    server.addEventListener("close", teardown);
+    server.addEventListener("error", teardown);
+
+    return new Response(null, { status: 101, webSocket: pair[0] });
+  }
+}
+`;
+}
+
+/** Project-host plumbing, same shape as project-ingress/live-capability-websocket. */
+function projectHosts() {
+  const base = new URL(buildUrl({ path: "/" }));
+  const isLocal = base.hostname === "localhost" || base.hostname.endsWith(".localhost");
+  const raw = process.env.APP_CONFIG_PROJECT_HOSTNAME_BASES?.trim();
+  const configuredBase = raw ? String((JSON.parse(raw) as string[])[0]) : undefined;
+  const previewMatch = /^os\.(iterate-preview-\d+)\.com$/.exec(base.hostname);
+  const projectBase = configuredBase || (previewMatch ? `${previewMatch[1]}.app` : base.hostname);
+  return { base, isLocal, projectBase };
+}
+
+test("the homepage is a server on the human's machine: getFetcher proxies HTTP end to end", async () => {
+  const marker = crypto.randomUUID().slice(0, 8);
+  const slug = `mac-fetch-${marker}`;
+  const name = "testComputer";
+
+  const { port, server } = await startLocalHttpServer(marker);
+  const { port: wsPort, server: wsServer } = await startLocalWsServer();
+  try {
+    using session = withItxSession();
+    using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
+    using project = itx.projects.create({ slug });
+    const { projectId } = await project.__describe();
+
+    // The REAL capability, provided exactly as the CLI provides it — including
+    // the types string, so the typed-mount gate compiles the new declaration.
+    using _provision = await project.provideCapability(myComputerProvision(name));
+
+    await project.repo.commitFiles({
+      message: "homepage = the human's local server (live-capability-fetcher e2e)",
+      changes: [{ path: "worker.ts", content: demoWorkerSource({ name, httpPort: port, wsPort }) }],
+    });
+
+    // The commit triggers a cold rebuild: retry through building 503s (and the
+    // stale pre-commit build's homepage) until the local server's body shows.
+    const deadline = Date.now() + 120_000;
+    let body = "";
+    for (;;) {
+      const response = await fetch(buildUrl({ path: `/${projectId}/proxied?q=1` }));
+      body = await response.text();
+      if (response.status === 200 && body.includes(`hello from the mac ${marker}`)) break;
+      if (Date.now() > deadline) {
+        throw new Error(
+          `homepage never showed the local server (last ${response.status}): ${body.slice(0, 300)}`,
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
+    }
+    // Path + query traveled to the Mac; the original host arrived as
+    // x-forwarded-host.
+    expect(body).toContain('data-path="/proxied?q=1"');
+    expect(body).toMatch(/data-forwarded-host="[^"]+"/);
+
+    // The boundary, taught not tripped: an upgrade through the fetcher fails
+    // with the capability's own explanation, not a deep DataCloneError.
+    const fetcher = await (
+      project as unknown as {
+        testComputer: {
+          getFetcher(input: { port: number }): Promise<{ fetch(req: Request): Promise<Response> }>;
+        };
+      }
+    ).testComputer.getFetcher({ port });
+    const outcome = await (async () => {
+      try {
+        await fetcher.fetch(
+          new Request("https://mac.example.com/ws", { headers: { upgrade: "websocket" } }),
+        );
+        return "upgrade unexpectedly succeeded";
+      } catch (error) {
+        return error instanceof Error ? error.message : String(error);
+      }
+    })();
+    expect(outcome).toContain("cannot carry a WebSocket upgrade");
+  } finally {
+    server.close();
+    wsServer.close();
+  }
+});
+
+test("WebSockets work through the bridge: frames pump between a browser socket and the Mac's server", async () => {
+  const marker = crypto.randomUUID().slice(0, 8);
+  const slug = `mac-ws-${marker}`;
+  const name = "testComputer";
+
+  const { port, server } = await startLocalHttpServer(marker);
+  const { port: wsPort, server: wsServer } = await startLocalWsServer();
+  try {
+    using session = withItxSession();
+    using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
+    using project = itx.projects.create({ slug });
+    await project.__describe();
+
+    using _provision = await project.provideCapability(myComputerProvision(name));
+
+    await project.repo.commitFiles({
+      message: "wsbridge app (live-capability-fetcher e2e)",
+      changes: [{ path: "worker.ts", content: demoWorkerSource({ name, httpPort: port, wsPort }) }],
+    });
+
+    const { base, isLocal, projectBase } = projectHosts();
+    const appHost = `wsbridge--${slug}`;
+    const connect = () =>
+      isLocal
+        ? new WebSocket(`ws://${base.host}/ws`, {
+            handshakeTimeout: 20_000,
+            headers: { host: `${appHost}.localhost${base.port ? `:${base.port}` : ""}` },
+          })
+        : new WebSocket(`wss://${appHost}.${projectBase}/ws`, { handshakeTimeout: 20_000 });
+
+    const openSocket = (ws: WebSocket) =>
+      new Promise<WebSocket>((resolve, reject) => {
+        ws.once("open", () => resolve(ws));
+        ws.once("unexpected-response", (_req, res) => {
+          res.resume();
+          reject(new Error(`upgrade rejected: ${res.statusCode}`));
+        });
+        ws.once("error", reject);
+      });
+
+    // Cold build: retry until the upgrade lands (building 503s read as
+    // rejected upgrades; a 502 means the bridge dialed but couldn't connect).
+    const openSocketReady = async () => {
+      const deadline = Date.now() + 120_000;
+      for (;;) {
+        try {
+          return await openSocket(connect());
+        } catch (error) {
+          if (Date.now() > deadline) throw error;
+          await new Promise((resolve) => setTimeout(resolve, 2_000));
+        }
+      }
+    };
+
+    const socket = await openSocketReady();
+    try {
+      const messages: string[] = [];
+      let wake: (() => void) | undefined;
+      socket.on("message", (data) => {
+        messages.push(String(data));
+        wake?.();
+      });
+      const waitForMessage = async (predicate: (m: string) => boolean) => {
+        const deadline = Date.now() + 30_000;
+        for (;;) {
+          const hit = messages.find(predicate);
+          if (hit) return hit;
+          if (Date.now() > deadline) {
+            throw new Error(`no matching frame; saw ${JSON.stringify(messages)}`);
+          }
+          await new Promise<void>((resolve) => {
+            wake = resolve;
+            setTimeout(resolve, 500);
+          });
+        }
+      };
+
+      // Mac → browser, unprompted: the local server greets on connect, and the
+      // greeting crosses the bridge via the onMessage callback chain.
+      expect(await waitForMessage((m) => m === "local-hello")).toBe("local-hello");
+
+      // Browser → Mac → browser: a frame out through handle.send, echoed by
+      // the local server, back through the callback.
+      socket.send(`ping-${marker}`);
+      expect(await waitForMessage((m) => m === `local-echo:ping-${marker}`)).toBe(
+        `local-echo:ping-${marker}`,
+      );
+    } finally {
+      socket.close();
+    }
+  } finally {
+    server.close();
+    wsServer.close();
+  }
+});

--- a/apps/os/e2e/vitest/live-capability-fetcher.e2e.test.ts
+++ b/apps/os/e2e/vitest/live-capability-fetcher.e2e.test.ts
@@ -4,31 +4,28 @@ import WebSocket, { WebSocketServer } from "ws";
 import { myComputerProvision } from "../../../../packages/iterate/src/use-my-computer.ts";
 import { adminSecret, buildUrl, withItxSession } from "./test-helpers.ts";
 
-// `iterate use-my-computer` grew two lanes that lend a SERVER on the human's
-// machine to their project, and this file proves both with the real capability
-// object (myComputerProvision — the exact input the CLI sends; this vitest
-// process stands in for the Mac):
+// `iterate use-my-computer` can lend the SERVER on the human's machine to their
+// project BY URL, and this proves it end to end with the real capability object
+// (myComputerProvision — the exact input the CLI sends; this vitest process
+// stands in for the Mac). The mount is `addressable`, so it answers at
+// http://<name>.iterate/ :
 //
-//   1. getFetcher({ port }) — the project homepage IS the human's local server:
-//      the worker's fetch forwards `itx.<name>.getFetcher({port}).fetch(req)`,
-//      the Request rides capability dispatch to this process, the fetch hits
-//      127.0.0.1:<port>, and the Response rides back. Plain HTTP only — an
-//      upgrade can never cross capability dispatch (the socket-carrying
-//      Response dies on workerd's internal RPC hops; pinned with a teaching
-//      error here and with the raw DataCloneError in
-//      live-capability-websocket.e2e.test.ts).
+//   // a project worker's whole homepage:
+//   fetch(new Request("http://testComputer.iterate/…", req))
 //
-//   2. connectSocket({ port, path }) — WebSockets work anyway, by bridging
-//      FRAMES instead of carrying the socket: a Durable Object app terminates
-//      the browser's socket with WebSocketPair and pumps text frames through a
-//      capability handle (send / onMessage callback), while the real socket to
-//      the local server lives on the Mac. dynamic-worker-dispatch.md calls this
-//      exact shape out as the workable-today form of the `test.fails`
-//      specification next door.
+// Because every hop is a real fetch(), ONE forward serves both the homepage
+// (HTTP) and its /ws upgrade: project egress → the capability host Durable
+// Object, which terminates the WebSocket (WebSocketPair) and bridges frames to
+// the Mac. The RPC path (itx.<name>.fetch) carries the HTTP but never the
+// upgrade — that boundary is pinned in live-capability-websocket.e2e.test.ts;
+// the URL form is what makes the upgrade work.
 
-/** The "server on the human's Mac": plain HTTP with a recognizable body. */
-function startLocalHttpServer(marker: string): Promise<{ port: number; server: Server }> {
-  const server = createServer((request, response) => {
+/** The "server on the human's Mac": a dev-server-like combined HTTP + WebSocket
+ * origin on ONE port — HTML on GET, greet-then-echo on a /ws upgrade. */
+function startLocalServer(
+  marker: string,
+): Promise<{ port: number; http: Server; ws: WebSocketServer }> {
+  const http = createServer((request, response) => {
     response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
     response.end(
       `<!doctype html><html><body><h1>hello from the mac ${marker}</h1>` +
@@ -37,166 +34,53 @@ function startLocalHttpServer(marker: string): Promise<{ port: number; server: S
         `</body></html>`,
     );
   });
-  return new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      const address = server.address();
-      if (address === null || typeof address === "string") {
-        reject(new Error("no port"));
-        return;
-      }
-      resolve({ port: address.port, server });
-    });
-  });
-}
-
-/** A local WebSocket server: greets on connect, then echoes frames prefixed. */
-function startLocalWsServer(): Promise<{ port: number; server: WebSocketServer }> {
-  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
-  server.on("connection", (socket) => {
+  // Attach the WebSocket server to the SAME http server, so http and ws share one
+  // port — exactly like a real dev server with HMR.
+  const ws = new WebSocketServer({ server: http });
+  ws.on("connection", (socket) => {
     socket.send("local-hello");
     socket.on("message", (data) => socket.send(`local-echo:${String(data)}`));
   });
   return new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.once("listening", () => {
-      resolve({ port: (server.address() as { port: number }).port, server });
+    http.once("error", reject);
+    http.listen(0, "127.0.0.1", () => {
+      const address = http.address();
+      if (address === null || typeof address === "string") {
+        reject(new Error("no port"));
+        return;
+      }
+      resolve({ port: address.port, http, ws });
     });
   });
 }
 
 /**
- * Await a node http / ws server's full shutdown. A WebSocketServer won't close
- * while a client socket is open — here that's the bridge's still-live provider
- * socket (the browser-close → DO → handle.close() teardown races this, and a
- * hibernated DO may never run it at all) — so terminate any clients first.
- * That abrupt close also drives the provider's own socket-close teardown.
+ * Await full shutdown. A WebSocketServer won't close while a client socket is
+ * open — here the bridge's still-live provider socket (a hibernated capability
+ * host may never run its close) — so terminate any clients first. That abrupt
+ * close also drives the provider's own socket-close teardown.
  */
-function closeServer(server: {
-  close(cb?: (error?: Error) => void): void;
-  clients?: Set<{ terminate(): void }>;
-}): Promise<void> {
-  for (const client of server.clients ?? []) client.terminate();
-  return new Promise((resolve) => server.close(() => resolve()));
+function closeLocalServer(server: { http: Server; ws: WebSocketServer }): Promise<void> {
+  for (const client of server.ws.clients) client.terminate();
+  return new Promise((resolve) => {
+    server.ws.close(() => server.http.close(() => resolve()));
+  });
 }
 
 /**
- * The demo worker committed to the test project: the homepage forwards to the
- * human's HTTP server through getFetcher; the wsbridge app terminates browser
- * WebSockets and bridges frames through connectSocket. Mirrors the seeded
- * template's shape (iterate/sdk base classes, x-iterate-app routing).
+ * The demo worker committed to the test project: ONE fetch() forwards
+ * everything — the homepage and the /ws upgrade alike — to the addressable
+ * capability by URL. The whole WsBridgeApp + getFetcher/connectSocket dance is
+ * gone; the platform runs it. `testComputer` (a camelCase mount) is reached at
+ * the lowercased URL host, proving case-insensitive capability resolution.
  */
-function demoWorkerSource(input: { name: string; httpPort: number; wsPort: number }): string {
-  return `import { IterateDurableObject, IterateWorkerEntrypoint } from "iterate/sdk";
+function demoWorkerSource(name: string): string {
+  return `import { IterateWorkerEntrypoint } from "iterate/sdk";
 
-// Demo (live-capability-fetcher e2e): the homepage IS a server on the human's
-// machine, and the wsbridge app carries WebSockets to it frame-by-frame.
 export default class ProjectWorker extends IterateWorkerEntrypoint {
   async fetch(req: Request): Promise<Response> {
-    const app = req.headers.get("x-iterate-app");
-    if (app === "wsbridge") {
-      return this.fetchDynamicWorker(req, {
-        type: "stateful",
-        path: "/",
-        className: "WsBridgeApp",
-        durableWorkerKey: "app-wsbridge",
-        source: {
-          files: { type: "repo", repoPath: "/repos/config" },
-          options: { entryPoint: "worker.ts" },
-        },
-      });
-    }
-    if (app) return new Response("unknown app: " + app, { status: 404 });
-
-    // THE DEMO: serve the project homepage straight from the shared computer.
-    const itx = await this.env.ITX.get();
-    try {
-      const computer = (itx as any).${input.name};
-      const fetcher = await computer.getFetcher({ port: ${input.httpPort} });
-      return await fetcher.fetch(req);
-    } finally {
-      try {
-        (itx as any)[Symbol.dispose]?.();
-      } catch {}
-    }
-  }
-}
-
-// The socket itself can never cross RPC hops, so this Durable Object holds the
-// browser's end (WebSocketPair) and exchanges FRAMES with the shared computer:
-// browser frames go out through handle.send, local-server frames come back
-// through the onMessage callback. Durable Objects share one I/O context across
-// events, which is what lets the handle and callbacks outlive the upgrade
-// request.
-export class WsBridgeApp extends IterateDurableObject {
-  async fetch(req: Request): Promise<Response> {
-    if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
-      return new Response("expected websocket", { status: 426 });
-    }
-    const pair = new WebSocketPair();
-    const server = pair[1];
-    server.accept();
-
-    // Held (not disposed at request end): the bridge lives as long as the
-    // browser's socket does. connectSocket's onMessage delivers local-server
-    // frames; the browser's frames go out through handle.send.
-    const itx = await this.env.ITX.get();
-    let handle: any;
-    try {
-      handle = await (itx as any).${input.name}.connectSocket({
-        port: ${input.wsPort},
-        path: "/",
-        onMessage: (data: string) => {
-          try {
-            server.send(data);
-          } catch {}
-        },
-        onClose: () => {
-          try {
-            server.close(1000, "local server closed");
-          } catch {}
-        },
-      });
-    } catch (error) {
-      // Nothing to bridge to: close the pair we accepted and release itx.
-      try {
-        server.close(1011, "bridge failed");
-      } catch {}
-      try {
-        (itx as any)[Symbol.dispose]?.();
-      } catch {}
-      return new Response("bridge failed: " + String(error), { status: 502 });
-    }
-
-    // One idempotent teardown for both close and error: close the bridge, then
-    // release the itx stub. Ordering matters — handle.close() is an RPC that
-    // rides on this itx session, so we must AWAIT it (the provider closes the
-    // Mac's socket) before disposing the session; disposing first aborts the
-    // close in flight and the Mac's socket lingers. (Symbol.dispose on the
-    // returned handle is dropped by capnweb's by-value return serialization, so
-    // close() — a real string-keyed method — is the only cross-RPC teardown.)
-    let torn = false;
-    const teardown = async () => {
-      if (torn) return;
-      torn = true;
-      try {
-        await handle.close({});
-      } catch {}
-      try {
-        (itx as any)[Symbol.dispose]?.();
-      } catch {}
-    };
-    server.addEventListener("message", (event) => {
-      void handle.send(String(event.data)).catch(() => {
-        try {
-          server.close(1011, "bridge send failed");
-        } catch {}
-      });
-    });
-    server.addEventListener("close", teardown);
-    server.addEventListener("error", teardown);
-
-    return new Response(null, { status: 101, webSocket: pair[0] });
+    const url = new URL(req.url);
+    return fetch(new Request(\`http://${name}.iterate\${url.pathname}\${url.search}\`, req));
   }
 }
 `;
@@ -213,30 +97,33 @@ function projectHosts() {
   return { base, isLocal, projectBase };
 }
 
-test("the homepage is a server on the human's machine: getFetcher proxies HTTP end to end", async () => {
+test("the homepage AND its websocket are a server on the human's machine, reached by URL", async () => {
   const marker = crypto.randomUUID().slice(0, 8);
-  const slug = `mac-fetch-${marker}`;
+  const slug = `mac-url-${marker}`;
   const name = "testComputer";
 
-  const { port, server } = await startLocalHttpServer(marker);
-  const { port: wsPort, server: wsServer } = await startLocalWsServer();
+  const local = await startLocalServer(marker);
   try {
     using session = withItxSession();
     using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
     using project = itx.projects.create({ slug });
     const { projectId } = await project.__describe();
 
-    // The REAL capability, provided exactly as the CLI provides it — including
-    // the types string, so the typed-mount gate compiles the new declaration.
-    using _provision = await project.provideCapability(myComputerProvision(name));
+    // The REAL capability, provided exactly as the CLI provides it: addressable,
+    // bound to the local server's port, with the types string the typed-mount
+    // gate compiles.
+    using _provision = await project.provideCapability(
+      myComputerProvision(name, { exposePort: local.port }),
+    );
 
     await project.repo.commitFiles({
-      message: "homepage = the human's local server (live-capability-fetcher e2e)",
-      changes: [{ path: "worker.ts", content: demoWorkerSource({ name, httpPort: port, wsPort }) }],
+      message: "homepage = the human's local server, by URL (live-capability url e2e)",
+      changes: [{ path: "worker.ts", content: demoWorkerSource(name) }],
     });
 
+    // ── HTTP: the homepage IS the human's server ──────────────────────────────
     // The commit triggers a cold rebuild: retry through building 503s (and the
-    // stale pre-commit build's homepage) until the local server's body shows.
+    // stale pre-commit homepage) until the local server's body shows.
     const deadline = Date.now() + 120_000;
     let body = "";
     for (;;) {
@@ -250,66 +137,19 @@ test("the homepage is a server on the human's machine: getFetcher proxies HTTP e
       }
       await new Promise((resolve) => setTimeout(resolve, 2_000));
     }
-    // Path + query traveled to the Mac; the original host arrived as
-    // x-forwarded-host.
+    // Path + query traveled to the Mac; the request arrived with a forwarded host.
     expect(body).toContain('data-path="/proxied?q=1"');
     expect(body).toMatch(/data-forwarded-host="[^"]+"/);
 
-    // The boundary, taught not tripped: an upgrade through the fetcher fails
-    // with the capability's own explanation, not a deep DataCloneError.
-    const fetcher = await (
-      project as unknown as {
-        testComputer: {
-          getFetcher(input: { port: number }): Promise<{ fetch(req: Request): Promise<Response> }>;
-        };
-      }
-    ).testComputer.getFetcher({ port });
-    const outcome = await (async () => {
-      try {
-        await fetcher.fetch(
-          new Request("https://mac.example.com/ws", { headers: { upgrade: "websocket" } }),
-        );
-        return "upgrade unexpectedly succeeded";
-      } catch (error) {
-        return error instanceof Error ? error.message : String(error);
-      }
-    })();
-    expect(outcome).toContain("cannot carry a WebSocket upgrade");
-  } finally {
-    await closeServer(server);
-    await closeServer(wsServer);
-  }
-});
-
-test("WebSockets work through the bridge: frames pump between a browser socket and the Mac's server", async () => {
-  const marker = crypto.randomUUID().slice(0, 8);
-  const slug = `mac-ws-${marker}`;
-  const name = "testComputer";
-
-  const { port, server } = await startLocalHttpServer(marker);
-  const { port: wsPort, server: wsServer } = await startLocalWsServer();
-  try {
-    using session = withItxSession();
-    using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
-    using project = itx.projects.create({ slug });
-    await project.__describe();
-
-    using _provision = await project.provideCapability(myComputerProvision(name));
-
-    await project.repo.commitFiles({
-      message: "wsbridge app (live-capability-fetcher e2e)",
-      changes: [{ path: "worker.ts", content: demoWorkerSource({ name, httpPort: port, wsPort }) }],
-    });
-
+    // ── WebSocket: the SAME URL forward carries the upgrade ──────────────────
     const { base, isLocal, projectBase } = projectHosts();
-    const appHost = `wsbridge--${slug}`;
     const connect = () =>
       isLocal
         ? new WebSocket(`ws://${base.host}/ws`, {
             handshakeTimeout: 20_000,
-            headers: { host: `${appHost}.localhost${base.port ? `:${base.port}` : ""}` },
+            headers: { host: `${slug}.localhost${base.port ? `:${base.port}` : ""}` },
           })
-        : new WebSocket(`wss://${appHost}.${projectBase}/ws`, { handshakeTimeout: 20_000 });
+        : new WebSocket(`wss://${slug}.${projectBase}/ws`, { handshakeTimeout: 20_000 });
 
     const openSocket = (ws: WebSocket) =>
       new Promise<WebSocket>((resolve, reject) => {
@@ -325,17 +165,16 @@ test("WebSockets work through the bridge: frames pump between a browser socket a
         ws.once("error", reject);
       });
 
-    // Retry ONLY the cold-build 503 (the router's building page); a real
-    // failure such as a 502 from the bridge surfaces immediately instead of
-    // spinning for two minutes.
+    // Retry ONLY the cold-build 503 (the router's building page); a real failure
+    // such as a 502/501 from the bridge surfaces immediately.
     const openSocketReady = async () => {
-      const deadline = Date.now() + 120_000;
+      const wsDeadline = Date.now() + 60_000;
       for (;;) {
         try {
           return await openSocket(connect());
         } catch (error) {
           const status = (error as { status?: number }).status;
-          if (status !== 503 || Date.now() > deadline) throw error;
+          if (status !== 503 || Date.now() > wsDeadline) throw error;
           await new Promise((resolve) => setTimeout(resolve, 2_000));
         }
       }
@@ -350,11 +189,11 @@ test("WebSockets work through the bridge: frames pump between a browser socket a
         wake?.();
       });
       const waitForMessage = async (predicate: (m: string) => boolean) => {
-        const deadline = Date.now() + 30_000;
+        const msgDeadline = Date.now() + 30_000;
         for (;;) {
           const hit = messages.find(predicate);
           if (hit) return hit;
-          if (Date.now() > deadline) {
+          if (Date.now() > msgDeadline) {
             throw new Error(`no matching frame; saw ${JSON.stringify(messages)}`);
           }
           await new Promise<void>((resolve) => {
@@ -364,12 +203,10 @@ test("WebSockets work through the bridge: frames pump between a browser socket a
         }
       };
 
-      // Mac → browser, unprompted: the local server greets on connect, and the
-      // greeting crosses the bridge via the onMessage callback chain.
+      // Mac → browser, unprompted: the local server greets on connect, crossing
+      // the bridge via the onMessage callback chain.
       expect(await waitForMessage((m) => m === "local-hello")).toBe("local-hello");
-
-      // Browser → Mac → browser: a frame out through handle.send, echoed by
-      // the local server, back through the callback.
+      // Browser → Mac → browser: a frame out through the bridge, echoed back.
       socket.send(`ping-${marker}`);
       expect(await waitForMessage((m) => m === `local-echo:ping-${marker}`)).toBe(
         `local-echo:ping-${marker}`,
@@ -377,17 +214,11 @@ test("WebSockets work through the bridge: frames pump between a browser socket a
     } finally {
       socket.close();
     }
-    // Teardown note: closing the browser socket does NOT reliably drain the
-    // Mac's socket in local dev — the DO's close listener (and its
-    // handle.close()) doesn't fire once the upgrade request has returned (the
-    // isolate is done with that request), so the provider socket lingers until
-    // closeServer force-terminates it. That terminate is not just hang
-    // avoidance: it drives the provider's OWN socket-close teardown (dispose
-    // the retained callbacks), which is the cleanup the provider can guarantee
-    // without depending on the DO. The provider's other guaranteed lane is
-    // closeAllBridges when the CLI's connection to OS drops.
+    // Teardown note: closing the browser socket does NOT reliably drain the Mac's
+    // socket in local dev — the capability host's close listener may not run once
+    // the upgrade request has returned — so closeLocalServer force-terminates it,
+    // which also drives the provider's own socket-close teardown.
   } finally {
-    await closeServer(server);
-    await closeServer(wsServer);
+    await closeLocalServer(local);
   }
 });

--- a/apps/os/e2e/vitest/live-capability-websocket.e2e.test.ts
+++ b/apps/os/e2e/vitest/live-capability-websocket.e2e.test.ts
@@ -2,25 +2,28 @@ import { expect, test } from "vitest";
 import WebSocket from "ws";
 import { adminSecret, buildUrl, withItxSession } from "./test-helpers.ts";
 
-// THE DESIRED BEHAVIOR (not yet implemented — see `test.fails` below): a live
-// capability whose `fetch(request)` upgrades WebSockets, provided over Cap'n
-// Web from this vitest process, serves a project app host end to end:
+// TWO boundaries live here.
 //
-//   using _ = await project.provideCapability({
-//     path: ["wsbackend"],
-//     type: "live",
-//     capability: { fetch: myUpgradingFetchHandler },
-//   });
-//   // + an app whose fetch just forwards: itx.wsbackend.fetch(req)
+// 1. THE PIN (passing): a live capability whose `fetch(request)` returns a
+//    socket-carrying Response cannot be forwarded over the RPC path
+//    (`itx.wsbackend.fetch(req)`). Our capnweb fork tunnels the socket across
+//    the Cap'n Web session as a stream pair (websocket-streams.ts), but
+//    materializes a real WebSocket at the session endpoint, and the internal
+//    workerd RPC hops to the app isolate refuse to serialize it
+//    (DataCloneError). That is why the RPC path can never carry an upgrade.
 //
-// What stands in the way (docs/dynamic-worker-dispatch.md): our capnweb fork
-// tunnels the socket across the Cap'n Web session as a stream pair
-// (websocket-streams.ts), but it materializes a real WebSocket at the session
-// endpoint, and the internal workerd RPC hops between there and the app
-// isolate refuse to serialize it. The passing test below pins that exact
-// boundary; the failing test is the specification. When the mesh learns to
-// carry the socket (e.g. by staying in stream-pair form until the fetch-lane
-// exit), the `test.fails` flips and this file is the to-do list.
+// 2. THE SPEC (test.fails): making that SAME RPC forward carry the socket end to
+//    end would need the fork to stay in stream-pair form until the fetch-lane
+//    exit (a capnweb `makeUpgradeResponse` change) — deliberately NOT done, so
+//    it stays a failing specification.
+//
+// The user-facing goal — "a server on the human's machine serves WebSockets to
+// a project" — is met a DIFFERENT, shipped way: address the capability by URL
+// (an `addressable` mount + `fetch("http://<name>.iterate/…")`). The URL rides
+// real fetch() hops and terminates the upgrade at the capability host Durable
+// Object, bridging frames to the provider. That path is proven in
+// live-capability-fetcher.e2e.test.ts. So the RPC boundary below is real and
+// permanent; websockets-to-a-live-capability simply travel by URL, not by RPC.
 
 /** The WebSocket surface the fork's tunnel needs on the provider side
  * (`WebSocketLike` in capnweb's websocket-streams.ts). Node has no

--- a/apps/os/e2e/vitest/use-my-computer-story.e2e.test.ts
+++ b/apps/os/e2e/vitest/use-my-computer-story.e2e.test.ts
@@ -1,0 +1,265 @@
+import { createServer } from "node:net";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+import WebSocket, { type ClientOptions } from "ws";
+import { myComputerProvision } from "../../../../packages/iterate/src/use-my-computer.ts";
+import { adminSecret, buildUrl, withItxSession } from "./test-helpers.ts";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The whole `use-my-computer` story, end to end, against a real deployment
+// (run it against a PREVIEW slot). It proves the four steps a human + agent do:
+//
+//   1. install the CLI            — the human runs `iterate use-my-computer`
+//   2. share the computer         — we provide the CLI's EXACT payload
+//                                    (myComputerProvision, the same input the CLI
+//                                    sends), with this vitest process standing in
+//                                    for the Mac, lending a port
+//   3. run code to start a server — an agent calls itx.<name>.runSwift(...) to
+//                                    launch a DETACHED HTTP+WebSocket server on
+//                                    the machine (the genuinely new step)
+//   4. make it accessible         — the agent commits a homepage that forwards
+//                                    to http://<name>.iterate/, and it is reached
+//                                    by a website VISITOR over real HTTPS + WSS
+//                                    (websocket greet + echo). Agent access is the
+//                                    same egress that forward exercises.
+//
+// It starts a real detached OS process (the "server on the Mac") and needs this
+// machine to act as the Mac, so it is OPT-IN. Run it (from apps/os) with:
+//
+//   RUN_UMC_STORY=1 doppler run --project os --config preview_9 -- \
+//     pnpm e2e run e2e/vitest/use-my-computer-story.e2e.test.ts
+//
+// (`myComputerProvision` is the exact input `iterate use-my-computer` provides;
+// the CLI itself is `connectItx` + `provideCapability(myComputerProvision)` +
+// holdWarm, plus the --expose-port flag and APP_CONFIG_BASE_URL base-URL added
+// in this PR so a `doppler run --config preview_N -- iterate use-my-computer
+// --expose-port <p>` run works.)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const STORY_ENABLED = process.env.RUN_UMC_STORY === "1";
+
+// apps/os/e2e/vitest/ → repo root is four levels up. ws is a direct dep of
+// packages/iterate (not hoisted to the repo root), so the detached server
+// resolves it via NODE_PATH pointed there.
+const repoRoot = fileURLToPath(new URL("../../../../", import.meta.url));
+const serverNodePath = `${repoRoot}packages/iterate/node_modules`;
+
+/** Grab a free localhost port (small race, fine for a test). */
+function freePort(): Promise<number> {
+  const server = createServer();
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        reject(new Error("no port"));
+        return;
+      }
+      const { port } = address;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+/**
+ * The agent's "run code to start a server" step: Swift that writes a tiny Node
+ * HTTP+WebSocket server and launches it DETACHED, so runSwift returns while the
+ * server keeps serving on `port`. The detached child is nohup'd AND redirects
+ * fd 0/1/2 (`</dev/null >log 2>&1`) — both are needed, or the CLI's `run()`
+ * never sees the pipes EOF and runSwift hangs. (`nohup`, not `setsid`: macOS
+ * has no setsid.)
+ */
+function startServerSwift(input: { port: number; marker: string }): string {
+  const serverJs = `
+const http = require("http");
+const { WebSocketServer } = require("ws");
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+  res.end('<!doctype html><html><body><h1>hello from the mac ${input.marker}</h1>' +
+    '<p data-path="' + (req.url || "") + '"></p></body></html>');
+});
+const wss = new WebSocketServer({ server });
+wss.on("connection", (socket) => {
+  socket.send("local-hello");
+  socket.on("message", (data) => socket.send("local-echo:" + String(data)));
+});
+server.listen(${input.port}, "127.0.0.1");
+setTimeout(() => process.exit(0), 180000); // self-clean after 3 min
+`;
+  const b64 = Buffer.from(serverJs, "utf8").toString("base64");
+  // NOTE: `\\(...)` in this TS template becomes Swift string interpolation.
+  return `
+import Foundation
+do {
+  let js = String(data: Data(base64Encoded: "${b64}")!, encoding: .utf8)!
+  let dir = NSTemporaryDirectory()
+  let jsPath = dir + "iterate-mac-${input.marker}.js"
+  let logPath = dir + "iterate-mac-${input.marker}.log"
+  try js.write(toFile: jsPath, atomically: true, encoding: .utf8)
+  let cmd = "NODE_PATH=${serverNodePath} nohup node \\(jsPath) </dev/null >\\(logPath) 2>&1 & disown; echo started ${input.marker}"
+  let p = Process()
+  p.executableURL = URL(fileURLWithPath: "/bin/bash")
+  p.arguments = ["-lc", cmd]
+  try p.run()
+  p.waitUntilExit()
+  print("launched \\(jsPath)")
+} catch {
+  FileHandle.standardError.write("swift-launch-error: \\(error)".data(using: .utf8)!)
+  exit(1)
+}
+`;
+}
+
+/** The homepage the agent commits: one forward carries HTTP and /ws alike. */
+function demoWorkerSource(name: string): string {
+  return `import { IterateWorkerEntrypoint } from "iterate/sdk";
+
+export default class ProjectWorker extends IterateWorkerEntrypoint {
+  async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    return fetch(new Request(\`http://${name}.iterate\${url.pathname}\${url.search}\`, req));
+  }
+}
+`;
+}
+
+function projectHosts() {
+  const base = new URL(buildUrl({ path: "/" }));
+  const isLocal = base.hostname === "localhost" || base.hostname.endsWith(".localhost");
+  const raw = process.env.APP_CONFIG_PROJECT_HOSTNAME_BASES?.trim();
+  const configuredBase = raw ? String((JSON.parse(raw) as string[])[0]) : undefined;
+  const previewMatch = /^os\.(iterate-preview-\d+)\.com$/.exec(base.hostname);
+  const projectBase = configuredBase || (previewMatch ? `${previewMatch[1]}.app` : base.hostname);
+  return { base, isLocal, projectBase };
+}
+
+test.skipIf(!STORY_ENABLED)(
+  "share → runSwift a server → accessible to visitors (HTTP + WebSockets), on preview",
+  { timeout: 300_000 },
+  async () => {
+    const marker = crypto.randomUUID().slice(0, 8);
+    const slug = `mac-story-${marker}`;
+    const name = "testComputer";
+    const port = await freePort();
+
+    using session = withItxSession();
+    using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
+    using project = itx.projects.create({ slug });
+    const { projectId } = await project.__describe();
+
+    // Keep the providing session warm — it IS the Mac, so it must stay reachable
+    // through the visitor cold-build poll below; an idle capnweb /api socket gets
+    // edge-closed (1006). The CLI heartbeats its own session for the same reason.
+    const heartbeat = setInterval(() => void project.__describe().catch(() => {}), 5_000);
+
+    try {
+      // ── 1 + 2. install + share: the CLI's exact payload, lending `port` ─────
+      using _provision = await project.provideCapability(
+        myComputerProvision(name, { exposePort: port }),
+      );
+      const computer = project as unknown as Record<
+        string,
+        {
+          runSwift(input: {
+            code: string;
+          }): Promise<{ stdout: string; stderr: string; exitCode: number }>;
+        }
+      >;
+
+      // ── 3. run code on the Mac to START A SERVER (detached, on `port`) ──────
+      const launched = await computer[name]!.runSwift({ code: startServerSwift({ port, marker }) });
+      expect(launched.exitCode, `runSwift failed: ${launched.stderr}`).toBe(0);
+
+      // ── 4. make it accessible: the agent commits a forwarding homepage ─────
+      await project.repo.commitFiles({
+        message: "homepage = the human's local server, by URL (use-my-computer story)",
+        changes: [{ path: "worker.ts", content: demoWorkerSource(name) }],
+      });
+
+      // ── 4a. accessible to a VISITOR over real HTTPS (retry cold build) ─────
+      const deadline = Date.now() + 180_000;
+      let body = "";
+      for (;;) {
+        const response = await fetch(buildUrl({ path: `/${projectId}/` }));
+        body = await response.text();
+        if (response.status === 200 && body.includes(`hello from the mac ${marker}`)) break;
+        if (Date.now() > deadline) {
+          throw new Error(`homepage never showed the Mac's server (last ${response.status})`);
+        }
+        await new Promise((r) => setTimeout(r, 2_000));
+      }
+      expect(body).toContain(`hello from the mac ${marker}`);
+
+      // ── 4b. accessible to a VISITOR over real WSS (websockets!) ────────────
+      const { base, isLocal, projectBase } = projectHosts();
+      const wsUrl = isLocal ? `ws://${base.host}/ws` : `wss://${slug}.${projectBase}/ws`;
+      const wsOptions: ClientOptions = isLocal
+        ? { headers: { host: `${slug}.localhost${base.port ? `:${base.port}` : ""}` } }
+        : {};
+      const frames = await roundTripWebSocket(wsUrl, wsOptions, `ping-${marker}`);
+      expect(frames).toContain("local-hello");
+      expect(frames).toContain(`local-echo:ping-${marker}`);
+
+      // ── 4c. accessible to the AGENT ────────────────────────────────────────
+      // The homepage worker above IS in-project code reaching the capability by
+      // URL (`fetch("http://<name>.iterate/…")`). An agent's codemode script uses
+      // the IDENTICAL egress — bare `fetch()` in a script isolate flows through
+      // the same projectEgressFetcher → ProjectDurableObject.fetch → capability
+      // arm as a worker's (worker-runner.ts binds both the same globalOutbound).
+      // So the visitor forward above is also the agent-access proof.
+    } finally {
+      clearInterval(heartbeat);
+      // Best-effort: stop the Mac's server (it also self-exits after 3 min).
+      const { spawn } = await import("node:child_process");
+      spawn("bash", ["-lc", `pkill -f iterate-mac-${marker}.js || true`], { stdio: "ignore" });
+    }
+  },
+);
+
+/**
+ * Connect a WebSocket (retrying cold-build 503s), send one frame, and resolve
+ * with all frames seen once both the greeting and the echo have arrived.
+ */
+function roundTripWebSocket(url: string, options: ClientOptions, send: string): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const frames: string[] = [];
+    const want = `local-echo:${send}`;
+    const deadline = Date.now() + 90_000;
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (!settled) {
+        settled = true;
+        fn();
+      }
+    };
+    const attempt = () => {
+      if (settled) return;
+      const socket = new WebSocket(url, { handshakeTimeout: 20_000, ...options });
+      socket.on("open", () => socket.send(send));
+      socket.on("message", (data) => {
+        frames.push(String(data));
+        if (frames.includes("local-hello") && frames.includes(want)) {
+          try {
+            socket.close();
+          } catch {}
+          settle(() => resolve(frames));
+        }
+      });
+      socket.on("unexpected-response", (_req, res) => {
+        res.resume();
+        // Retry ONLY the cold-build 503; a real failure surfaces immediately.
+        if (res.statusCode === 503 && Date.now() < deadline) setTimeout(attempt, 2_000);
+        else settle(() => reject(new Error(`ws upgrade rejected: ${res.statusCode}`)));
+      });
+      socket.on("error", (error) => {
+        if (Date.now() < deadline) setTimeout(attempt, 2_000);
+        else settle(() => reject(error));
+      });
+    };
+    setTimeout(
+      () => settle(() => reject(new Error(`ws never echoed; saw ${JSON.stringify(frames)}`))),
+      90_000,
+    );
+    attempt();
+  });
+}

--- a/apps/os/src/domains/capability-host/capability-host-durable-object.ts
+++ b/apps/os/src/domains/capability-host/capability-host-durable-object.ts
@@ -17,6 +17,7 @@ import {
   type RunScriptResult,
 } from "./capability-host-processor-implementation.ts";
 import type { ProvideCapabilityInput } from "./types.ts";
+import { takeCapabilityDispatch } from "./capability-url.ts";
 
 type ScriptExecutionEntrypoint = {
   run(code: string): Promise<unknown>;
@@ -119,6 +120,26 @@ export class CapabilityHostDurableObject extends DurableObject<Env> {
 
   get processor() {
     return new StreamProcessorRpcTarget(this.#capabilityHostProcessor);
+  }
+
+  /**
+   * Serve an addressable capability by URL. Reached over the fetch-native lane
+   * (project egress recognizes `<name>.iterate` hosts and dials this fetch),
+   * carrying the resolved capability path in the dispatch header. Because this
+   * is a real DO-stub fetch, a WebSocket upgrade is still live here and can
+   * terminate at this Durable Object — see serveCapabilityFetch.
+   */
+  fetch(request: Request): Promise<Response> {
+    const taken = takeCapabilityDispatch(request);
+    if (taken === null) {
+      return Promise.resolve(
+        new Response("capability fetch requires a dispatch header", { status: 400 }),
+      );
+    }
+    return this.#capabilityHostProcessor.serveCapabilityFetch({
+      capabilityPath: taken.capabilityPath,
+      request: taken.request,
+    });
   }
 
   // Return types are pinned shallow so `DurableObjectStub<CapabilityHostDurableObject>`

--- a/apps/os/src/domains/capability-host/capability-host-processor-contract.ts
+++ b/apps/os/src/domains/capability-host/capability-host-processor-contract.ts
@@ -20,6 +20,7 @@ const ItxExpressionFields = {
 const CapabilityProvidedPayload = z.discriminatedUnion("type", [
   z.strictObject({
     ...CapabilityMetadata,
+    addressable: z.boolean().optional(),
     flattenNestedPaths: z.boolean().optional(),
     path: z.array(z.string()),
     type: z.literal("live"),
@@ -35,6 +36,7 @@ const CapabilityProvidedPayload = z.discriminatedUnion("type", [
 const CapabilityRecord = z.discriminatedUnion("type", [
   z.strictObject({
     ...CapabilityMetadata,
+    addressable: z.boolean().optional(),
     flattenNestedPaths: z.boolean().optional(),
     path: z.array(z.string()),
     providedAtOffset: z.number().int().nonnegative(),
@@ -64,7 +66,7 @@ export const DEFAULT_SCRIPT_EXECUTION_EXPIRY_MS = 15 * 60_000;
 
 export const CapabilityHostProcessorContract = defineProcessorContract({
   slug: "capability-host",
-  version: "0.1.0",
+  version: "0.2.0",
   description: "A tiny dynamic capability table and script execution journal.",
   stateSchema: z.object({
     capabilities: z.array(CapabilityRecord).default([]),
@@ -99,6 +101,16 @@ export const CapabilityHostProcessorContract = defineProcessorContract({
           payload: {
             instructions: "Call tools.weather.forecast({ city }) for a 3-day forecast.",
             path: ["tools", "weather"],
+            type: "live",
+          },
+        },
+        {
+          description:
+            'An addressable live capability (a server on the provider\'s machine): reachable by URL as fetch("http://mycomputer.iterate/…"), which — unlike the itx RPC path — carries WebSocket upgrades.',
+          payload: {
+            addressable: true,
+            instructions: "A local dev server, reachable at http://mycomputer.iterate/",
+            path: ["myComputer"],
             type: "live",
           },
         },

--- a/apps/os/src/domains/capability-host/capability-host-processor-implementation.ts
+++ b/apps/os/src/domains/capability-host/capability-host-processor-implementation.ts
@@ -322,6 +322,7 @@ export class CapabilityHostProcessor extends StreamProcessor<CapabilityHostProce
       }
       const flattenNestedPath = input.flattenNestedPaths === true;
       record = {
+        addressable: input.addressable === true ? true : undefined,
         flattenNestedPaths: flattenNestedPath ? true : undefined,
         instructions: input.instructions,
         path,
@@ -504,6 +505,146 @@ export class CapabilityHostProcessor extends StreamProcessor<CapabilityHostProce
       throw new Error(`capability "${hit.record.path.join(".")}" is offline`);
     }
     return await live.invoke(hit.rest, args);
+  }
+
+  // ── Capability URLs: serve an addressable live capability over fetch() ──────
+  // `fetch("http://<name>.iterate/…")` lands here (project egress → this DO's
+  // fetch → serveCapabilityFetch). Because every hop was a real stub fetch, a
+  // WebSocket upgrade is still live when it arrives and can terminate at this
+  // Durable Object — which the RPC path (`invokeCapability`) can never do.
+
+  async serveCapabilityFetch({
+    capabilityPath,
+    request,
+  }: {
+    capabilityPath: string[];
+    request: Request;
+  }): Promise<Response> {
+    const record = this.#resolveAddressableCapability(capabilityPath);
+    if (!record) {
+      // v1 addresses root-scope mounts only; the egress hop dials the mount's
+      // scope directly, so a miss here is a genuine 404 (no parent chaining).
+      return new Response(`no addressable capability "${capabilityPath.join(".")}"`, {
+        status: 404,
+      });
+    }
+    const live = this.#liveCapabilities.get(liveKey(record.path));
+    if (!live) {
+      // Same staleness contract as invokeCapability: the record is durable, but
+      // calls need the provider's live connection.
+      return new Response(`capability "${record.path.join(".")}" is offline`, { status: 503 });
+    }
+    if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      // Plain HTTP: the provider's fetch(request) runs in its process and the
+      // Response copy serializes back — the same transport as
+      // itx.<name>.fetch(req), just reached by URL.
+      return (await live.invoke(["fetch"], [request])) as Response;
+    }
+    return await this.#bridgeCapabilityWebSocket(live, request);
+  }
+
+  /**
+   * The addressable live mount for a capability URL's host labels, matched
+   * case-INSENSITIVELY: DNS lowercases the URL host, but mounts are camelCase
+   * (itx.jonasComputer is reached at jonascomputer.<project>.iterate).
+   */
+  #resolveAddressableCapability(labels: string[]): CapabilityRecord | null {
+    const wanted = labels.map((label) => label.toLowerCase());
+    for (const record of this.state.capabilities) {
+      if (record.type !== "live" || record.addressable !== true) continue;
+      if (record.path.length !== wanted.length) continue;
+      if (record.path.every((segment, index) => segment.toLowerCase() === wanted[index])) {
+        return record;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Terminate a WebSocket upgrade at THIS Durable Object and bridge FRAMES to
+   * the provider. The socket can never cross an internal RPC hop, so the 101 is
+   * established here (a real workerd object, top of stack) and the provider's
+   * `connectSocket({ onMessage, onClose }) → { send, close }` carries frames:
+   * browser frames go out via send(), local-server frames come back through the
+   * onMessage callback (capnweb keeps the callbacks live for the socket's life,
+   * and this DO's I/O context spans the socket). This is the WsBridgeApp recipe
+   * the platform now runs for you.
+   */
+  async #bridgeCapabilityWebSocket(live: LiveCapability, request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const pair = new WebSocketPair();
+    const client = pair[0];
+    const server = pair[1];
+    server.accept();
+
+    type SocketBridge = {
+      send(data: string): Promise<unknown>;
+      close(input?: { code?: number; reason?: string }): Promise<unknown>;
+    } & Partial<Disposable>;
+
+    let bridge: SocketBridge;
+    try {
+      bridge = (await live.invoke(
+        ["connectSocket"],
+        [
+          {
+            path: `${url.pathname}${url.search}`,
+            onMessage: (data: string) => {
+              try {
+                server.send(data);
+              } catch {}
+            },
+            onClose: ({ code, reason }: { code: number; reason: string }) => {
+              try {
+                server.close(code, reason);
+              } catch {}
+            },
+          },
+        ],
+      )) as SocketBridge;
+    } catch (error) {
+      // Addressable, but this capability does not bridge WebSockets.
+      try {
+        server.close(1011, "no socket bridge");
+      } catch {}
+      return new Response(
+        `capability does not support WebSocket upgrades: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { status: 501 },
+      );
+    }
+
+    let torn = false;
+    const teardown = async (code?: number, reason?: string) => {
+      if (torn) return;
+      torn = true;
+      // close() is an RPC on the provider's connection — AWAIT it (so the
+      // provider closes its local socket) before disposing the per-socket
+      // handle; the handle's Symbol.dispose is dropped by capnweb's by-value
+      // return serialization, so close() is the real cross-RPC teardown.
+      try {
+        await bridge.close(code === undefined ? undefined : { code, reason });
+      } catch {}
+      try {
+        bridge[Symbol.dispose]?.();
+      } catch {}
+    };
+    server.addEventListener("message", (event) => {
+      // v1 bridges text frames (the provider's send is string-typed); binary
+      // frames are dropped rather than silently corrupted.
+      if (typeof event.data === "string") {
+        void bridge.send(event.data).catch(() => {
+          try {
+            server.close(1011, "bridge send failed");
+          } catch {}
+        });
+      }
+    });
+    server.addEventListener("close", (event) => void teardown(event.code, event.reason));
+    server.addEventListener("error", () => void teardown());
+
+    return new Response(null, { status: 101, webSocket: client });
   }
 
   /**

--- a/apps/os/src/domains/capability-host/capability-url.test.ts
+++ b/apps/os/src/domains/capability-host/capability-url.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+import {
+  CAPABILITY_FETCH_DISPATCH_HEADER,
+  parseCapabilityUrl,
+  takeCapabilityDispatch,
+  withCapabilityDispatchHeader,
+} from "./capability-url.ts";
+
+describe("parseCapabilityUrl", () => {
+  test("explicit projectId form: <cap>.<projectId>.iterate", () => {
+    expect(parseCapabilityUrl("http://jonascomputer.prj_123.iterate/ws?x=1")).toEqual({
+      projectId: "prj_123",
+      scope: "/",
+      capabilityPath: ["jonascomputer"],
+    });
+  });
+
+  test("short form inherits the caller's project (projectId null)", () => {
+    expect(parseCapabilityUrl("http://jonascomputer.iterate/")).toEqual({
+      projectId: null,
+      scope: "/",
+      capabilityPath: ["jonascomputer"],
+    });
+  });
+
+  test("host is lowercased by the URL parser, so labels come back lowercase", () => {
+    // The mount is camelCase (itx.jonasComputer); serve-time resolution matches
+    // case-insensitively. Here we only assert the parser reflects DNS folding.
+    expect(parseCapabilityUrl("http://jonasComputer.PRJ_ABC.iterate/")).toEqual({
+      projectId: "prj_abc",
+      scope: "/",
+      capabilityPath: ["jonascomputer"],
+    });
+  });
+
+  test("path and query are ignored for addressing (they ride the request)", () => {
+    expect(
+      parseCapabilityUrl("http://api.prj_1.iterate/v1/things?limit=3")?.capabilityPath,
+    ).toEqual(["api"]);
+  });
+
+  test("a bare {projectId}.iterate names no capability → null", () => {
+    expect(parseCapabilityUrl("http://prj_123.iterate/")).toBeNull();
+  });
+
+  test("non-.iterate hosts are not capability URLs", () => {
+    expect(parseCapabilityUrl("https://example.com/")).toBeNull();
+    expect(parseCapabilityUrl("https://slug.iterate.app/")).toBeNull();
+  });
+
+  test("a non-URL string is simply not a capability URL (never throws)", () => {
+    expect(parseCapabilityUrl("not a url")).toBeNull();
+    expect(parseCapabilityUrl("")).toBeNull();
+  });
+});
+
+describe("capability dispatch header", () => {
+  test("round-trips the capability path and strips the header", () => {
+    const request = withCapabilityDispatchHeader(new Request("http://x.iterate/"), {
+      capabilityPath: ["jonascomputer"],
+    });
+    expect(request.headers.get(CAPABILITY_FETCH_DISPATCH_HEADER)).not.toBeNull();
+
+    const taken = takeCapabilityDispatch(request);
+    expect(taken?.capabilityPath).toEqual(["jonascomputer"]);
+    // The header is removed before the request reaches the capability.
+    expect(taken?.request.headers.get(CAPABILITY_FETCH_DISPATCH_HEADER)).toBeNull();
+  });
+
+  test("returns null when the header is absent", () => {
+    expect(takeCapabilityDispatch(new Request("http://x.iterate/"))).toBeNull();
+  });
+});

--- a/apps/os/src/domains/capability-host/capability-url.ts
+++ b/apps/os/src/domains/capability-host/capability-url.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Capability URLs — reach an addressable live capability by a URL instead of by
+// an itx path.
+//
+// A project reaches `itx.jonasComputer` two ways now:
+//   - itx.jonasComputer.fetch(req)                    — RPC. A Response copy
+//     serializes fine, but a WebSocket upgrade cannot cross the RPC hop
+//     (`DataCloneError`); the socket dies in the mesh.
+//   - fetch("http://jonascomputer.iterate/…", req)    — a real fetch(). Every
+//     hop is a real workerd stub fetch, so it terminates at the capability-host
+//     Durable Object, where an upgrade IS allowed (WebSocketPair) and frames
+//     bridge to the provider. This is the whole reason the URL form exists: a
+//     URL changes the transport class from RPC to fetch-native.
+//
+// Grammar (`.iterate` is the internal host suffix — never DNS-routable):
+//   <cap>.<projectId>.iterate   e.g. jonascomputer.prj_123.iterate  (explicit)
+//   <cap>.iterate               e.g. jonascomputer.iterate          (caller's project)
+// The request path/query ride the URL path; the capability path is the host
+// label(s) before the projectId. v1 addresses single-segment, root-scope mounts.
+//
+// DNS lowercases the host, so `itx.jonasComputer` is reached at `jonascomputer`
+// — capability labels match mounts case-INSENSITIVELY at serve time.
+//
+// The full fetch-vs-RPC model: apps/os/docs/dynamic-worker-dispatch.md.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CAPABILITY_HOST_SUFFIX = ".iterate";
+
+export type CapabilityUrl = {
+  /** Explicit projectId from the host, or null for the short form (the caller's project). */
+  projectId: string | null;
+  /** The capability-host scope the mount lives on. v1: always the project root "/". */
+  scope: string;
+  /** The capability mount path — host labels before the projectId, e.g. ["jonascomputer"]. */
+  capabilityPath: string[];
+};
+
+/** Whether a host label is a projectId (`prj_…`) rather than a capability name. */
+function isProjectIdLabel(label: string): boolean {
+  return label.startsWith("prj_");
+}
+
+/**
+ * Parse a capability URL, or return null when `url` is not one (any host that
+ * does not end in `.iterate`, or a bare `{projectId}.iterate` with no capability
+ * label). Never throws — a non-URL string is simply "not a capability URL".
+ */
+export function parseCapabilityUrl(rawUrl: string): CapabilityUrl | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  const host = url.hostname;
+  if (!host.endsWith(CAPABILITY_HOST_SUFFIX)) return null;
+  const prefix = host.slice(0, -CAPABILITY_HOST_SUFFIX.length);
+  if (prefix === "") return null;
+
+  const labels = prefix.split(".");
+  const last = labels[labels.length - 1]!;
+  const hasProjectId = isProjectIdLabel(last);
+  const projectId = hasProjectId ? last : null;
+  const capabilityPath = hasProjectId ? labels.slice(0, -1) : labels;
+  // A bare `{projectId}.iterate` names no capability — it is an ordinary
+  // Durable Object name, not a routable capability URL.
+  if (capabilityPath.length === 0) return null;
+
+  return { projectId, scope: "/", capabilityPath };
+}
+
+// ── The dispatch header ──────────────────────────────────────────────────────
+// A real fetch has no argument channel besides the request, so the resolved
+// capability path rides a header from the project egress hop to the capability
+// host — the role `x-iterate-worker-dispatch` plays for dynamic workers. It is
+// internal: OS ingress strips it at the trust boundary (`stripInternalHeaders`),
+// and the capability host removes it before serving.
+
+export const CAPABILITY_FETCH_DISPATCH_HEADER = "x-iterate-capability-dispatch";
+
+const CapabilityFetchDispatch = z.strictObject({
+  capabilityPath: z.array(z.string()),
+});
+
+export function withCapabilityDispatchHeader(
+  request: Request,
+  dispatch: { capabilityPath: string[] },
+): Request {
+  const headers = new Headers(request.headers);
+  headers.set(CAPABILITY_FETCH_DISPATCH_HEADER, JSON.stringify(dispatch));
+  return new Request(request, { headers });
+}
+
+/**
+ * Read and strip the dispatch header. Returns null when absent; throws on a
+ * malformed value (an internal caller composed it, so a parse failure is a bug).
+ */
+export function takeCapabilityDispatch(
+  request: Request,
+): { capabilityPath: string[]; request: Request } | null {
+  const raw = request.headers.get(CAPABILITY_FETCH_DISPATCH_HEADER);
+  if (raw === null) return null;
+  const { capabilityPath } = CapabilityFetchDispatch.parse(JSON.parse(raw));
+  const headers = new Headers(request.headers);
+  headers.delete(CAPABILITY_FETCH_DISPATCH_HEADER);
+  return { capabilityPath, request: new Request(request, { headers }) };
+}

--- a/apps/os/src/domains/capability-host/types.ts
+++ b/apps/os/src/domains/capability-host/types.ts
@@ -45,6 +45,15 @@ export type FlattenedCapabilityTarget = {
  */
 export type ProvideCapabilityInput =
   | {
+      /**
+       * Expose this mount's `fetch(request)` handler as a URL origin: a project
+       * can then `fetch("http://<name>.iterate/…")` instead of calling
+       * `itx.<name>.fetch(...)` over RPC. The URL form rides real fetch() hops,
+       * so — unlike RPC — a WebSocket upgrade survives (it terminates at the
+       * capability host and bridges frames to the provider via `connectSocket`).
+       * See apps/os/domains/capability-host/capability-url.ts.
+       */
+      addressable?: boolean;
       capability: unknown;
       flattenNestedPaths?: false;
       instructions?: string;
@@ -53,6 +62,7 @@ export type ProvideCapabilityInput =
       types?: string;
     }
   | {
+      addressable?: boolean;
       capability: FlattenedCapabilityTarget;
       flattenNestedPaths: true;
       instructions?: string;
@@ -72,6 +82,7 @@ export type ProvideCapabilityInput =
 /** Event payload stored when a capability is mounted on an ITX stream. */
 export type CapabilityProvidedPayload =
   | {
+      addressable?: boolean;
       flattenNestedPaths?: boolean;
       instructions?: string;
       path: string[];

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -17,6 +17,11 @@ import type {
 } from "../streams/rpc-types.ts";
 import type { StreamEvent } from "../streams/schemas.ts";
 import { deepRetainRpcStubs } from "../capability-host/live-capability.ts";
+import {
+  parseCapabilityUrl,
+  withCapabilityDispatchHeader,
+  type CapabilityUrl,
+} from "../capability-host/capability-url.ts";
 import { substitutePlatformApiKeyReferences } from "../secrets/platform-secrets.ts";
 import {
   platformReferencesFromHeaders,
@@ -219,12 +224,37 @@ export class ProjectDurableObject extends DurableObject<Env> {
   }
 
   async fetch(request: Request): Promise<Response> {
+    // Capability URLs (`http://<name>.iterate/…`) are internal platform
+    // addressing, not external egress — route them to the capability host
+    // before the egress interceptor or approval gate ever sees them.
+    const capabilityUrl = parseCapabilityUrl(request.url);
+    if (capabilityUrl !== null) return await this.#serveCapabilityUrl(capabilityUrl, request);
+
     if (this.#egressInterceptor !== undefined) {
       // Egress interceptors run before secret substitution. They must never
       // receive raw secret material, only getSecret(...) placeholders.
       return await this.#egressInterceptor.value(request);
     }
     return this.#egressWithApprovalGate(request);
+  }
+
+  /**
+   * Route a capability URL to the addressable capability's host Durable Object.
+   * A capability URL only reaches capabilities in the caller's OWN project: an
+   * explicit projectId must match this project (the short form inherits it), so
+   * cross-project access is structurally impossible. The host DO's fetch is a
+   * real stub fetch, so a WebSocket upgrade survives all the way to it.
+   */
+  async #serveCapabilityUrl(parsed: CapabilityUrl, request: Request): Promise<Response> {
+    if (parsed.projectId !== null && parsed.projectId !== this.#name.projectId) {
+      return new Response("capability URL projectId does not match this project", { status: 403 });
+    }
+    const host = this.env.CAPABILITY_HOST.getByName(
+      DurableObjectNameCodec.stringify({ projectId: this.#name.projectId, path: parsed.scope }),
+    ) as unknown as { fetch(request: Request): Promise<Response> };
+    return await host.fetch(
+      withCapabilityDispatchHeader(request, { capabilityPath: parsed.capabilityPath }),
+    );
   }
 
   /**

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -27,6 +27,7 @@ import {
   workerBuildingResponse,
 } from "./domains/workers/worker-fetch-dispatch.ts";
 import { DynamicWorkerRunner } from "./domains/workers/worker-runner.ts";
+import { CAPABILITY_FETCH_DISPATCH_HEADER } from "./domains/capability-host/capability-url.ts";
 import { UnauthenticatedOsRpcTarget } from "./rpc-targets.ts";
 import { defaultProjectWorkerRef } from "./domains/repos/utils.ts";
 import { handleIntegrationWebhookApiRequest } from "./domains/integrations/integration-webhook-api.ts";
@@ -264,6 +265,7 @@ function stripInternalHeaders(request: Request) {
   headers.delete("x-itx-project-id");
   headers.delete("x-iterate-url-prefix");
   headers.delete(WORKER_FETCH_DISPATCH_HEADER);
+  headers.delete(CAPABILITY_FETCH_DISPATCH_HEADER);
   headers.delete("x-forwarded-host");
   headers.delete("x-forwarded-proto");
   return new Request(request, { headers });

--- a/packages/iterate/package.json
+++ b/packages/iterate/package.json
@@ -74,6 +74,7 @@
     "@iterate-com/ui": "workspace:*",
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.14",
+    "@types/ws": "^8.18.1",
     "tsdown": "0.22.2",
     "typescript": "^5.9.3",
     "vitest": "4.0.15"

--- a/packages/iterate/src/cli.ts
+++ b/packages/iterate/src/cli.ts
@@ -1075,7 +1075,7 @@ const launcherProcedures = {
     )
     .meta({
       description:
-        "Share THIS computer with a project's agents as itx.myComputer (native dialogs, notifications, Swift). Runs until Ctrl-C.",
+        "Share THIS computer with a project's agents as itx.<name> (native dialogs, notifications, Swift), and optionally lend a local server at http://<name>.iterate/ (HTTP + WebSockets). Runs until Ctrl-C.",
     })
     .handler(async ({ input }) => {
       const resolved = resolveConfig(process.cwd(), { throw: true });

--- a/packages/iterate/src/cli.ts
+++ b/packages/iterate/src/cli.ts
@@ -1071,6 +1071,15 @@ const launcherProcedures = {
           .describe(
             "Machine mode for the menu-bar app: NDJSON activity on stdout. Never opens a browser — emits a needs-login line instead.",
           ),
+        exposePort: z.coerce
+          .number()
+          .int()
+          .min(1)
+          .max(65535)
+          .optional()
+          .describe(
+            "Also lend the local server on this port at http://<name>.iterate/ (HTTP + WebSockets). Skips the interactive prompt — required for a non-interactive run.",
+          ),
       }),
     )
     .meta({
@@ -1103,9 +1112,16 @@ const launcherProcedures = {
       }
       const auth = envAuth ?? osAuthFromHeaders(authHeaders!);
 
+      // A doppler-driven run (`doppler run --config preview_N -- iterate …`)
+      // supplies both the admin secret AND APP_CONFIG_BASE_URL; honor the latter
+      // so the CLI connects to the SAME environment it authenticated against
+      // (otherwise it auths against preview but talks to prod). Falls back to the
+      // named config's osBaseUrl for an ordinary login-driven run.
+      const osBaseUrl = process.env.APP_CONFIG_BASE_URL?.trim() || resolved.config.osBaseUrl;
+
       const projectId = await resolveChatProject({
         auth,
-        baseUrl: resolved.config.osBaseUrl,
+        baseUrl: osBaseUrl,
         configName: resolved.name,
         configPath: CONFIG_PATH,
         configuredDefaultProject: resolved.config.defaultProject,
@@ -1114,10 +1130,11 @@ const launcherProcedures = {
 
       const shared = {
         auth: auth.credentials,
-        baseUrl: resolved.config.osBaseUrl,
+        baseUrl: osBaseUrl,
         projectId,
         headers: headersRecord(auth.requestHeaders),
         name: input.name,
+        exposePort: input.exposePort,
       };
       // JSON mode announces activity for the menu-bar app; the terminal form
       // prompts for a name and prints a paste-for-your-agent hint. Both block.

--- a/packages/iterate/src/use-my-computer-transport.test.ts
+++ b/packages/iterate/src/use-my-computer-transport.test.ts
@@ -1,0 +1,233 @@
+import { createServer, type Server } from "node:http";
+import { AddressInfo } from "node:net";
+import { afterEach, describe, expect, test } from "vitest";
+import { WebSocketServer } from "ws";
+import { openSocketBridge, proxyLocalHttp, stripHopByHop } from "./use-my-computer-transport.ts";
+
+// Direct tests for the two transports behind `iterate use-my-computer` — the
+// HTTP reverse proxy and the WebSocket frame bridge — with real local servers,
+// no OS/capnweb round trip. The e2e proves they compose through the platform;
+// this proves the fiddly bits (header fidelity, redirect rewriting, the 502
+// boundary, and the bridge's callback-dispose ordering) in isolation.
+
+const closers: Array<() => void> = [];
+afterEach(() => {
+  for (const close of closers.splice(0)) close();
+});
+
+function startHttp(handler: Parameters<typeof createServer>[1]): Promise<number> {
+  const server: Server = createServer(handler);
+  closers.push(() => server.close());
+  return new Promise((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port)),
+  );
+}
+
+function startWs(onConnection: (socket: import("ws").WebSocket) => void): Promise<number> {
+  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  wss.on("connection", onConnection);
+  closers.push(() => {
+    for (const client of wss.clients) client.terminate();
+    wss.close();
+  });
+  return new Promise((resolve) =>
+    wss.once("listening", () => resolve((wss.address() as AddressInfo).port)),
+  );
+}
+
+describe("proxyLocalHttp", () => {
+  test("proxies body, sets x-forwarded-host, strips hop-by-hop, drops stale framing", async () => {
+    const port = await startHttp((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c) => chunks.push(c));
+      req.on("end", () => {
+        // `connection` is hop-by-hop; node sets a correct content-length that the
+        // proxy still drops (undici may have decompressed the buffered body, so
+        // the framing headers are stale on the hop back).
+        res.writeHead(200, { "content-type": "text/plain", connection: "keep-alive" });
+        res.end(`seen:${req.headers["x-forwarded-host"]}:${Buffer.concat(chunks).toString()}`);
+      });
+    });
+    const request = new Request("https://slug.iterate.app/echo?q=1", {
+      method: "POST",
+      headers: { connection: "keep-alive", "x-keep": "yes" },
+      body: "hello",
+    });
+    const response = await proxyLocalHttp(`http://127.0.0.1:${port}`, request);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("seen:slug.iterate.app:hello");
+    // hop-by-hop + stale framing stripped on the way back
+    expect(response.headers.get("connection")).toBeNull();
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("content-type")).toBe("text/plain");
+  });
+
+  test("refuses websocket upgrades with a teaching error", async () => {
+    const request = new Request("https://slug.iterate.app/ws", {
+      headers: { upgrade: "websocket" },
+    });
+    await expect(proxyLocalHttp("http://127.0.0.1:1", request)).rejects.toThrow(
+      /cannot carry a WebSocket upgrade/,
+    );
+  });
+
+  test("returns 502 when the local server is unreachable", async () => {
+    // Port 1 is not listening; the connection is refused.
+    const response = await proxyLocalHttp(
+      "http://127.0.0.1:1",
+      new Request("https://slug.iterate.app/"),
+    );
+    expect(response.status).toBe(502);
+    expect(await response.text()).toContain("unreachable");
+  });
+
+  test("returns 502 when the server resets mid-body", async () => {
+    const port = await startHttp((req, res) => {
+      res.writeHead(200, { "content-length": "100" });
+      res.write("partial");
+      // Destroy the socket before the promised body arrives.
+      req.socket.destroy();
+    });
+    const response = await proxyLocalHttp(
+      `http://127.0.0.1:${port}`,
+      new Request("https://slug.iterate.app/"),
+    );
+    expect(response.status).toBe(502);
+  });
+
+  test("rewrites a loopback Location onto the public origin — and respects the port boundary", async () => {
+    const port = await startHttp((_req, res) => {
+      // Redirect back to the local origin; must land on the public host.
+      res.writeHead(302, { location: `http://127.0.0.1:${port}/login?next=/` });
+      res.end();
+    });
+    const response = await proxyLocalHttp(
+      `http://127.0.0.1:${port}`,
+      new Request("https://slug.iterate.app/protected"),
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://slug.iterate.app/login?next=/");
+  });
+
+  test("does not rewrite a Location to a different port that shares a prefix", async () => {
+    // origin :3000 must not match a Location on :30001 (the startsWith bug).
+    const port = await startHttp((_req, res) => {
+      res.writeHead(302, { location: "http://127.0.0.1:30001/elsewhere" });
+      res.end();
+    });
+    const response = await proxyLocalHttp(
+      `http://127.0.0.1:${port}`,
+      new Request("https://slug.iterate.app/"),
+    );
+    // The proxied origin is `port` (random), not 30001, so the Location is left alone.
+    expect(response.headers.get("location")).toBe("http://127.0.0.1:30001/elsewhere");
+  });
+
+  test("gives HEAD a null body and keeps its content-length metadata", async () => {
+    const port = await startHttp((_req, res) => {
+      res.writeHead(200, { "content-length": "512", "content-type": "text/html" });
+      res.end(); // HEAD: no body
+    });
+    const response = await proxyLocalHttp(
+      `http://127.0.0.1:${port}`,
+      new Request("https://slug.iterate.app/", { method: "HEAD" }),
+    );
+    expect(response.status).toBe(200);
+    expect(response.body).toBeNull();
+    // bodyless response keeps its representation metadata (not stripped)
+    expect(response.headers.get("content-length")).toBe("512");
+  });
+});
+
+describe("stripHopByHop", () => {
+  test("removes the standard set plus any header named by Connection", async () => {
+    const headers = new Headers({
+      connection: "x-custom, keep-alive",
+      "x-custom": "drop-me",
+      "keep-alive": "timeout=5",
+      "transfer-encoding": "chunked",
+      "content-type": "text/plain",
+    });
+    stripHopByHop(headers);
+    expect(headers.get("x-custom")).toBeNull();
+    expect(headers.get("keep-alive")).toBeNull();
+    expect(headers.get("transfer-encoding")).toBeNull();
+    expect(headers.get("connection")).toBeNull();
+    expect(headers.get("content-type")).toBe("text/plain");
+  });
+});
+
+describe("openSocketBridge", () => {
+  test("delivers frames to onMessage and round-trips send", async () => {
+    const port = await startWs((socket) => {
+      socket.send("hello");
+      socket.on("message", (d) => socket.send(`echo:${String(d)}`));
+    });
+    const received: string[] = [];
+    const bridge = await openSocketBridge({
+      port,
+      onMessage: (data) => {
+        received.push(data);
+      },
+    });
+    await bridge.send("ping");
+    await vi_waitFor(() => received.includes("echo:ping"));
+    expect(received).toContain("hello");
+    expect(received).toContain("echo:ping");
+    await bridge.close();
+  });
+
+  test("send after close rejects", async () => {
+    const port = await startWs(() => {});
+    const bridge = await openSocketBridge({ port });
+    await bridge.close();
+    await vi_waitFor(async () => {
+      try {
+        await bridge.send("nope");
+        return false;
+      } catch {
+        return true;
+      }
+    });
+  });
+
+  test("delivers onClose BEFORE disposing the retained callback (round-2 blocker)", async () => {
+    // A callback stub that tracks dup/dispose and whether it was ever called
+    // after disposal — the exact hazard: a deferred onClose running against an
+    // already-released stub.
+    let disposed = false;
+    let calledAfterDispose = false;
+    let closeInfo: unknown;
+    const onClose = Object.assign(
+      (info: unknown) => {
+        if (disposed) calledAfterDispose = true;
+        closeInfo = info;
+      },
+      {
+        dup() {
+          return onClose;
+        },
+        [Symbol.dispose]() {
+          disposed = true;
+        },
+      },
+    );
+
+    const port = await startWs((socket) => socket.close(1000, "bye"));
+    const bridge = await openSocketBridge({ port, onClose });
+    await vi_waitFor(() => disposed); // shutdown ran after the server closed us
+    expect(closeInfo).toMatchObject({ code: 1000 });
+    expect(calledAfterDispose).toBe(false);
+    await bridge.close();
+  });
+});
+
+/** Tiny poll helper (vitest's expect.poll would also work; this keeps deps local). */
+async function vi_waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 3000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await predicate()) return;
+    if (Date.now() > deadline) throw new Error("waitFor timed out");
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}

--- a/packages/iterate/src/use-my-computer-transport.test.ts
+++ b/packages/iterate/src/use-my-computer-transport.test.ts
@@ -1,5 +1,5 @@
 import { createServer, type Server } from "node:http";
-import { AddressInfo } from "node:net";
+import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, test } from "vitest";
 import { WebSocketServer } from "ws";
 import { openSocketBridge, proxyLocalHttp, stripHopByHop } from "./use-my-computer-transport.ts";
@@ -82,11 +82,13 @@ describe("proxyLocalHttp", () => {
   });
 
   test("returns 502 when the server resets mid-body", async () => {
-    const port = await startHttp((req, res) => {
+    const port = await startHttp((_req, res) => {
+      // Promise 100 bytes, flush a few, then reset AFTER a tick so the initial
+      // fetch() resolves with headers and the failure lands in arrayBuffer() —
+      // pinning the body-read side of the 502 boundary, not the connect side.
       res.writeHead(200, { "content-length": "100" });
       res.write("partial");
-      // Destroy the socket before the promised body arrives.
-      req.socket.destroy();
+      setTimeout(() => res.socket?.destroy(), 50);
     });
     const response = await proxyLocalHttp(
       `http://127.0.0.1:${port}`,
@@ -95,32 +97,39 @@ describe("proxyLocalHttp", () => {
     expect(response.status).toBe(502);
   });
 
-  test("rewrites a loopback Location onto the public origin — and respects the port boundary", async () => {
+  test("rewrites an absolute, path-relative, or protocol-relative loopback Location onto the public origin", async () => {
+    let location = "";
     const port = await startHttp((_req, res) => {
-      // Redirect back to the local origin; must land on the public host.
-      res.writeHead(302, { location: `http://127.0.0.1:${port}/login?next=/` });
+      res.writeHead(302, { location });
       res.end();
     });
-    const response = await proxyLocalHttp(
-      `http://127.0.0.1:${port}`,
-      new Request("https://slug.iterate.app/protected"),
-    );
-    expect(response.status).toBe(302);
-    expect(response.headers.get("location")).toBe("https://slug.iterate.app/login?next=/");
+    const local = `http://127.0.0.1:${port}`;
+    for (const loc of [
+      `${local}/login?next=/`,
+      "/login?next=/",
+      `//127.0.0.1:${port}/login?next=/`,
+    ]) {
+      location = loc;
+      const response = await proxyLocalHttp(
+        local,
+        new Request("https://slug.iterate.app/protected"),
+      );
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("https://slug.iterate.app/login?next=/");
+    }
   });
 
-  test("does not rewrite a Location to a different port that shares a prefix", async () => {
-    // origin :3000 must not match a Location on :30001 (the startsWith bug).
+  test("does not rewrite a Location on a different port that shares a numeric prefix", async () => {
+    // The exact `startsWith` bug: origin `:<port>` must not match `:<port>0`.
     const port = await startHttp((_req, res) => {
-      res.writeHead(302, { location: "http://127.0.0.1:30001/elsewhere" });
+      res.writeHead(302, { location: `http://127.0.0.1:${port}0/elsewhere` });
       res.end();
     });
     const response = await proxyLocalHttp(
       `http://127.0.0.1:${port}`,
       new Request("https://slug.iterate.app/"),
     );
-    // The proxied origin is `port` (random), not 30001, so the Location is left alone.
-    expect(response.headers.get("location")).toBe("http://127.0.0.1:30001/elsewhere");
+    expect(response.headers.get("location")).toBe(`http://127.0.0.1:${port}0/elsewhere`);
   });
 
   test("gives HEAD a null body and keeps its content-length metadata", async () => {
@@ -219,6 +228,33 @@ describe("openSocketBridge", () => {
     expect(closeInfo).toMatchObject({ code: 1000 });
     expect(calledAfterDispose).toBe(false);
     await bridge.close();
+  });
+
+  test("a rejected delivery tears the bridge down and disposes the ignored RPC result", async () => {
+    // A frame callback whose delivery result is a rejected, disposable thenable
+    // (a dead remote stub): the pump must observe the rejection as the corpse
+    // signal (shutdown → local socket closes) and dispose the ignored result.
+    let resultDisposed = false;
+    const port = await startWs((socket) => socket.send("frame"));
+    const bridge = await openSocketBridge({
+      port,
+      onMessage: () =>
+        Object.assign(Promise.reject(new Error("dead stub")), {
+          [Symbol.dispose]() {
+            resultDisposed = true;
+          },
+        }),
+    });
+    // The rejected delivery runs shutdown(), which closes the local socket.
+    await vi_waitFor(async () => {
+      try {
+        await bridge.send("x");
+        return false;
+      } catch {
+        return true; // socket no longer OPEN → shutdown happened
+      }
+    });
+    await vi_waitFor(() => resultDisposed);
   });
 });
 

--- a/packages/iterate/src/use-my-computer-transport.ts
+++ b/packages/iterate/src/use-my-computer-transport.ts
@@ -11,7 +11,11 @@
 
 import WebSocket from "ws";
 
-import { isThenable, retainCallback } from "../../../apps/os/src/lib/rpc/retain.ts";
+import {
+  disposeIgnoredRpcResult,
+  isThenable,
+  retainCallback,
+} from "../../../apps/os/src/lib/rpc/retain.ts";
 
 // ── HTTP: reverse proxy to a local server ────────────────────────────────────
 
@@ -68,12 +72,13 @@ export async function proxyLocalHttp(origin: string, request: Request): Promise<
   const requestBody =
     request.method === "GET" || request.method === "HEAD" ? undefined : await request.arrayBuffer();
 
+  const upstreamUrl = `${origin}${incoming.pathname}${incoming.search}`;
   // Everything that can fail against the local server stays inside the 502
   // boundary: the initial connection AND streaming the body (a server that
   // sends headers then resets must not surface as an opaque worker error).
   let response: Response;
   try {
-    response = await fetch(`${origin}${incoming.pathname}${incoming.search}`, {
+    response = await fetch(upstreamUrl, {
       method: request.method,
       headers,
       body: requestBody,
@@ -103,7 +108,7 @@ export async function proxyLocalHttp(origin: string, request: Request): Promise<
     outHeaders.delete("content-encoding");
     outHeaders.delete("content-length");
   }
-  rewriteLocalRedirect(outHeaders, origin, incoming.origin);
+  rewriteLocalRedirect(outHeaders, origin, upstreamUrl, incoming.origin);
   return new Response(responseBody, {
     status: response.status,
     statusText: response.statusText,
@@ -118,13 +123,23 @@ function unreachable(origin: string, error: unknown): Response {
   });
 }
 
-/** Rewrite a `Location` pointing at the local origin onto the public origin. */
-function rewriteLocalRedirect(headers: Headers, localOrigin: string, publicOrigin: string): void {
+/**
+ * Rewrite a `Location` that resolves to the local origin onto the public origin.
+ * Resolving against the upstream URL (not just parsing absolute) also catches
+ * protocol-relative (`//127.0.0.1:port/…`) and path-relative redirects, which
+ * would otherwise silently point the public browser at the Mac's loopback.
+ */
+function rewriteLocalRedirect(
+  headers: Headers,
+  localOrigin: string,
+  upstreamUrl: string,
+  publicOrigin: string,
+): void {
   const location = headers.get("location");
   if (!location) return;
   let target: URL;
   try {
-    target = new URL(location); // relative Location throws — the browser already resolves it correctly
+    target = new URL(location, upstreamUrl);
   } catch {
     return;
   }
@@ -206,13 +221,26 @@ export async function openSocketBridge({
   onFrame?.onRpcBroken?.(() => shutdown());
   onSocketClose?.onRpcBroken?.(() => shutdown());
 
+  // Deliver one value to a retained callback, following the canonical sink
+  // discipline (subscriber-sinks.ts): a synchronous throw or a rejected delivery
+  // means the stub is a corpse — tear the bridge down rather than swallowing it;
+  // and the ignored RPC result is disposed (dropping it leaks a remote
+  // reference, one per frame otherwise).
   const deliver = (callback: ((arg: never) => unknown) | undefined, arg: unknown) => {
     if (disposed || !callback) return;
+    let result: unknown;
     try {
-      const result = callback(arg as never);
-      if (isThenable(result)) void Promise.resolve(result).catch(() => {});
+      result = callback(arg as never);
     } catch {
-      // A broken callback must not kill the pump.
+      shutdown();
+      return;
+    }
+    if (isThenable(result)) {
+      void Promise.resolve(result)
+        .then(undefined, () => shutdown())
+        .finally(() => disposeIgnoredRpcResult(result));
+    } else {
+      disposeIgnoredRpcResult(result);
     }
   };
 
@@ -248,13 +276,15 @@ export async function openSocketBridge({
     },
     /**
      * Close the local socket. If it's live, the socket's own `close` event drives
-     * delivery + shutdown; if it's already closed, shut down directly so the
-     * callbacks are still released.
+     * delivery + shutdown. While it's already CLOSING, this is a no-op — the
+     * pending `close` event will still deliver `onClose` (running shutdown here
+     * would dispose the callback before that fires). Only if it's fully CLOSED
+     * (no `close` event coming) do we shut down directly to release callbacks.
      */
     close: async (input?: { code?: number; reason?: string }) => {
       if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
         socket.close(input?.code ?? 1000, input?.reason ?? "");
-      } else {
+      } else if (socket.readyState === WebSocket.CLOSED) {
         shutdown();
       }
       return { ok: true as const };

--- a/packages/iterate/src/use-my-computer-transport.ts
+++ b/packages/iterate/src/use-my-computer-transport.ts
@@ -1,0 +1,263 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// The two transports `iterate use-my-computer` lends a project: an HTTP reverse
+// proxy to a local server (getFetcher) and a WebSocket frame bridge
+// (connectSocket). Both run in the CLI process — capnweb ships the call here, so
+// the fetch / the socket happen on the human's machine. Kept in their own module
+// (with direct unit tests) because the lifecycle is subtle: Request/Response copies
+// cross capability dispatch fine, but a live socket cannot cross workerd's RPC
+// hops (apps/os/docs/dynamic-worker-dispatch.md), so the WebSocket lane bridges
+// frames as callbacks instead.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import WebSocket from "ws";
+
+import { isThenable, retainCallback } from "../../../apps/os/src/lib/rpc/retain.ts";
+
+// ── HTTP: reverse proxy to a local server ────────────────────────────────────
+
+/** Hop-by-hop headers are connection-scoped and must not cross a proxy hop (RFC 9110 §7.6.1). */
+const HOP_BY_HOP_HEADERS = [
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+];
+
+/** Delete hop-by-hop headers in place, including any named by the `Connection` header. */
+export function stripHopByHop(headers: Headers): Headers {
+  for (const named of headers.get("connection")?.split(",") ?? []) {
+    headers.delete(named.trim());
+  }
+  for (const name of HOP_BY_HOP_HEADERS) headers.delete(name);
+  return headers;
+}
+
+/**
+ * Proxy one HTTP request to a server on this machine and return its response,
+ * faithfully enough to serve a real dev server on a project host:
+ * - WebSocket upgrades are refused with a teaching error (the socket can't cross
+ *   RPC — that's what connectSocket is for).
+ * - Hop-by-hop headers are stripped both directions; the original host travels as
+ *   `x-forwarded-host` (undici drops a bare `host` override).
+ * - A `Location` whose origin is the local server is rewritten onto the public
+ *   origin (parsed, not string-prefix-matched, so `:3000` doesn't match `:30001`),
+ *   so a dev server's `302 → /login` doesn't send the browser to its own loopback.
+ * - Any upstream failure — refused connection, or a reset mid-body — becomes a
+ *   `502`, never an opaque exception escaping through capability dispatch.
+ * Bodies are buffered (fine for a spike); the stale framing headers undici leaves
+ * after decompression are dropped only when a body was actually buffered, so
+ * bodyless responses (HEAD/204/205/304) keep their representation metadata.
+ */
+export async function proxyLocalHttp(origin: string, request: Request): Promise<Response> {
+  if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
+    throw new Error(
+      `getFetcher().fetch cannot carry a WebSocket upgrade: the 101 response's socket ` +
+        `cannot cross RPC hops between the platform and this machine. ` +
+        `Terminate the socket in a Durable Object app and bridge frames with ` +
+        `connectSocket({ port, path }) instead.`,
+    );
+  }
+  const incoming = new URL(request.url);
+  const headers = stripHopByHop(new Headers(request.headers));
+  headers.set("x-forwarded-host", incoming.host);
+  headers.delete("host");
+  const requestBody =
+    request.method === "GET" || request.method === "HEAD" ? undefined : await request.arrayBuffer();
+
+  // Everything that can fail against the local server stays inside the 502
+  // boundary: the initial connection AND streaming the body (a server that
+  // sends headers then resets must not surface as an opaque worker error).
+  let response: Response;
+  try {
+    response = await fetch(`${origin}${incoming.pathname}${incoming.search}`, {
+      method: request.method,
+      headers,
+      body: requestBody,
+      redirect: "manual", // pass redirects through so the browser sees them
+    });
+  } catch (error) {
+    return unreachable(origin, error);
+  }
+
+  const nullBody =
+    request.method === "HEAD" ||
+    response.status === 204 ||
+    response.status === 205 ||
+    response.status === 304;
+  let responseBody: ArrayBuffer | null = null;
+  if (!nullBody) {
+    try {
+      responseBody = await response.arrayBuffer();
+    } catch (error) {
+      return unreachable(origin, error);
+    }
+  }
+
+  const outHeaders = stripHopByHop(new Headers(response.headers));
+  if (!nullBody) {
+    // undici decompressed the buffered body but left the encoding/length framing.
+    outHeaders.delete("content-encoding");
+    outHeaders.delete("content-length");
+  }
+  rewriteLocalRedirect(outHeaders, origin, incoming.origin);
+  return new Response(responseBody, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: outHeaders,
+  });
+}
+
+function unreachable(origin: string, error: unknown): Response {
+  return new Response(`local server at ${origin} is unreachable: ${String(error)}`, {
+    status: 502,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+}
+
+/** Rewrite a `Location` pointing at the local origin onto the public origin. */
+function rewriteLocalRedirect(headers: Headers, localOrigin: string, publicOrigin: string): void {
+  const location = headers.get("location");
+  if (!location) return;
+  let target: URL;
+  try {
+    target = new URL(location); // relative Location throws — the browser already resolves it correctly
+  } catch {
+    return;
+  }
+  if (target.origin === new URL(localOrigin).origin) {
+    headers.set("location", `${publicOrigin}${target.pathname}${target.search}${target.hash}`);
+  }
+}
+
+// ── WebSocket: a frame bridge to a local server ──────────────────────────────
+
+export type SocketBridgeInput = {
+  port: number;
+  path?: string;
+  host?: string;
+  onMessage?: (data: string) => unknown;
+  onClose?: (info: { code: number; reason: string }) => unknown;
+};
+
+/** The bridge the caller drives — plain data + functions so it serializes over capnweb. */
+export type SocketBridge = {
+  send(data: string): Promise<{ ok: true }>;
+  close(input?: { code?: number; reason?: string }): Promise<{ ok: true }>;
+};
+
+/** Every open bridge's shutdown, so CLI teardown can close them all at once. */
+const activeBridges = new Set<() => void>();
+
+/** Close every open frame bridge — the CLI runs this when its own socket to OS drops. */
+export function closeAllBridges(): void {
+  for (const shutdown of [...activeBridges]) shutdown();
+}
+
+/**
+ * Open a WebSocket to a local server and bridge FRAMES over capability dispatch.
+ * The bridge exclusively owns the socket and the retained callbacks, with ONE
+ * idempotent `shutdown()` that closes the socket and disposes the callbacks. The
+ * ordering that matters: the socket's own `close` event delivers `onClose`
+ * BEFORE shutdown disposes it (a `disposed` guard makes every other terminal
+ * path — `close()`, a socket error, `closeAllBridges` — skip a late delivery
+ * against a released stub rather than call it). If a callback's transport breaks
+ * (the DO/session holding it dies), that tears the bridge down too.
+ *
+ * A Durable Object app terminates the browser's WebSocket with WebSocketPair and
+ * pumps frames both ways through this bridge — the socket itself can never cross
+ * the RPC mesh. The DO drives teardown by calling `close()` on browser
+ * disconnect (a returned value's `[Symbol.dispose]` is dropped by capnweb's
+ * by-value serialization, so `close()` is the only cross-RPC teardown).
+ */
+export async function openSocketBridge({
+  port,
+  path = "/",
+  host = "127.0.0.1",
+  onMessage,
+  onClose,
+}: SocketBridgeInput): Promise<SocketBridge> {
+  const socket = new WebSocket(`ws://${host}:${port}${path}`);
+  // Callbacks are stubs capnweb releases when this call returns; retainCallback
+  // dup()s them for the socket's life (idempotent dispose, onRpcBroken-aware).
+  const onFrame = onMessage ? retainCallback(onMessage) : undefined;
+  const onSocketClose = onClose ? retainCallback(onClose) : undefined;
+
+  let disposed = false;
+  const shutdown = () => {
+    if (disposed) return;
+    disposed = true;
+    activeBridges.delete(shutdown);
+    try {
+      if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+        socket.close(1000, "");
+      }
+    } catch {}
+    onFrame?.[Symbol.dispose]();
+    onSocketClose?.[Symbol.dispose]();
+  };
+  activeBridges.add(shutdown);
+
+  // A callback whose transport has broken can never be delivered again — tear
+  // the bridge down so the local socket doesn't linger.
+  onFrame?.onRpcBroken?.(() => shutdown());
+  onSocketClose?.onRpcBroken?.(() => shutdown());
+
+  const deliver = (callback: ((arg: never) => unknown) | undefined, arg: unknown) => {
+    if (disposed || !callback) return;
+    try {
+      const result = callback(arg as never);
+      if (isThenable(result)) void Promise.resolve(result).catch(() => {});
+    } catch {
+      // A broken callback must not kill the pump.
+    }
+  };
+
+  socket.on("message", (data) => deliver(onFrame, String(data)));
+  socket.on("close", (code, reason) => {
+    deliver(onSocketClose, { code, reason: String(reason) });
+    shutdown();
+  });
+  // After-open errors are usually followed by `close`, but wire this directly so
+  // an error that never emits `close` still tears the bridge down.
+  socket.on("error", () => shutdown());
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      socket.once("open", () => resolve());
+      socket.once("error", (error) => reject(error));
+    });
+  } catch (error) {
+    shutdown();
+    throw error;
+  }
+
+  return {
+    /** Push one text frame to the local server; resolves once the write is accepted. */
+    send: async (data: string) => {
+      if (socket.readyState !== WebSocket.OPEN) {
+        throw new Error(`socket not open (readyState ${socket.readyState})`);
+      }
+      await new Promise<void>((resolve, reject) => {
+        socket.send(data, (error) => (error ? reject(error) : resolve()));
+      });
+      return { ok: true as const };
+    },
+    /**
+     * Close the local socket. If it's live, the socket's own `close` event drives
+     * delivery + shutdown; if it's already closed, shut down directly so the
+     * callbacks are still released.
+     */
+    close: async (input?: { code?: number; reason?: string }) => {
+      if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+        socket.close(input?.code ?? 1000, input?.reason ?? "");
+      } else {
+        shutdown();
+      }
+      return { ok: true as const };
+    },
+  };
+}

--- a/packages/iterate/src/use-my-computer.ts
+++ b/packages/iterate/src/use-my-computer.ts
@@ -25,6 +25,7 @@ import { hostname } from "node:os";
 
 import * as prompts from "@clack/prompts";
 import type { RpcStub } from "capnweb";
+import WebSocket from "ws";
 
 import { connectItx } from "../../../apps/os/src/itx-client.ts";
 import type { ItxAuthCredentials, Project } from "./itx-api.generated.ts";
@@ -65,13 +66,196 @@ const myComputer = {
     // `swift -` reads a whole program from stdin and runs it.
     return await run("swift", ["-"], code);
   },
+
+  /**
+   * Lend a server running on this machine to the project: returns
+   * `{ fetch(request) }` that proxies each request to
+   * `http://127.0.0.1:<port>`. A project worker's homepage can literally be
+   * `return (await itx.myComputer.getFetcher({ port })).fetch(req)` — the
+   * Request rides capability dispatch here, the fetch happens on this Mac,
+   * and the Response rides back. Plain HTTP only: capability dispatch is RPC,
+   * and a socket-carrying Response cannot cross workerd's internal hops
+   * (apps/os/docs/dynamic-worker-dispatch.md) — WebSocket upgrades get a
+   * teaching error pointing at connectSocket.
+   */
+  async getFetcher({ port, host = "127.0.0.1" }: { port: number; host?: string }) {
+    const origin = `http://${host}:${port}`;
+    return {
+      fetch: async (request: Request): Promise<Response> => {
+        if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
+          throw new Error(
+            `getFetcher().fetch cannot carry a WebSocket upgrade: the 101 response's socket ` +
+              `cannot cross RPC hops between the platform and this machine. ` +
+              `Terminate the socket in a Durable Object app and bridge frames with ` +
+              `connectSocket({ port, path }) instead.`,
+          );
+        }
+        const incoming = new URL(request.url);
+        // Re-aim at the local server: same path + query, local origin. The
+        // original host arrives as x-forwarded-host (undici refuses a bare
+        // `host` override and drops it silently).
+        const headers = new Headers(request.headers);
+        headers.set("x-forwarded-host", incoming.host);
+        headers.delete("host");
+        const body =
+          request.method === "GET" || request.method === "HEAD"
+            ? undefined
+            : await request.arrayBuffer();
+        const response = await fetch(`${origin}${incoming.pathname}${incoming.search}`, {
+          method: request.method,
+          headers,
+          body,
+          // Pass redirects through untouched so the browser sees them.
+          redirect: "manual",
+        });
+        // undici decompresses bodies but keeps the encoding headers; re-serving
+        // those verbatim corrupts the hop back. Buffer the (now-plain) body and
+        // drop the stale framing headers.
+        const outHeaders = new Headers(response.headers);
+        outHeaders.delete("content-encoding");
+        outHeaders.delete("content-length");
+        outHeaders.delete("transfer-encoding");
+        const nullBody =
+          response.status === 204 || response.status === 205 || response.status === 304;
+        return new Response(nullBody ? null : await response.arrayBuffer(), {
+          status: response.status,
+          statusText: response.statusText,
+          headers: outHeaders,
+        });
+      },
+    };
+  },
+
+  /**
+   * The WebSocket lane getFetcher cannot offer: open a real socket to a server
+   * on this machine and bridge FRAMES over capability dispatch. Returns a
+   * handle — `send(data)` pushes a frame to the local server, `receive()`
+   * long-polls frames coming back (plus a `closed` marker), `close()` hangs
+   * up. If an `onMessage` callback is passed, incoming frames are also pushed
+   * to it live (functions chain through every RPC hop; we dup() them here
+   * because RPC params are released when this call returns).
+   *
+   * A Durable Object app terminates the browser's WebSocket with
+   * WebSocketPair and pumps frames both ways through this handle — that is
+   * how "WebSockets to a server on my Mac" works today, since the socket
+   * itself can never cross the RPC mesh.
+   */
+  async connectSocket({
+    port,
+    path = "/",
+    host = "127.0.0.1",
+    onMessage,
+    onClose,
+  }: {
+    port: number;
+    path?: string;
+    host?: string;
+    onMessage?: (data: string) => unknown;
+    onClose?: (info: { code: number; reason: string }) => unknown;
+  }) {
+    const socket = new WebSocket(`ws://${host}:${port}${path}`);
+    // Callback stubs arrive as RPC params, which are released on return —
+    // dup() keeps them alive for the socket's lifetime (dynamic-worker-dispatch.md).
+    const keptMessage = dupCallback(onMessage);
+    const keptClose = dupCallback(onClose);
+
+    const buffered: string[] = [];
+    let closed: { code: number; reason: string } | undefined;
+    let wake: (() => void) | undefined;
+    const notify = () => {
+      wake?.();
+      wake = undefined;
+    };
+
+    socket.on("message", (data) => {
+      const text = String(data);
+      if (keptMessage) {
+        // Push lane: fire-and-forget; a broken callback must not kill the pump.
+        void Promise.resolve()
+          .then(() => keptMessage(text))
+          .catch(() => {});
+      }
+      buffered.push(text);
+      notify();
+    });
+    socket.on("close", (code, reason) => {
+      closed = { code, reason: String(reason) };
+      if (keptClose) {
+        void Promise.resolve()
+          .then(() => keptClose(closed!))
+          .catch(() => {});
+      }
+      notify();
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      socket.once("open", () => resolve());
+      socket.once("error", (error) => reject(error));
+    });
+
+    return {
+      /** Push one text frame to the local server. */
+      send: async (data: string) => {
+        if (closed) throw new Error(`socket already closed (${closed.code})`);
+        socket.send(data);
+        return { ok: true as const };
+      },
+      /**
+       * Long-poll the frames received since the last call. Resolves as soon as
+       * at least one frame (or the close) arrives, or with an empty list after
+       * `timeoutMs`. `closed` reports the local server hanging up.
+       */
+      receive: async ({ timeoutMs = 20_000 }: { timeoutMs?: number } = {}) => {
+        if (buffered.length === 0 && !closed) {
+          await new Promise<void>((resolve) => {
+            wake = resolve;
+            setTimeout(resolve, timeoutMs);
+          });
+        }
+        return { frames: buffered.splice(0), closed };
+      },
+      /** Close the local socket. */
+      close: async (input?: { code?: number; reason?: string }) => {
+        socket.close(input?.code ?? 1000, input?.reason ?? "");
+        return { ok: true as const };
+      },
+    };
+  },
 };
+
+/**
+ * Keep a callback stub usable past this RPC's return: capnweb releases params
+ * when the call resolves, so a provider that stores one must dup() it. Plain
+ * local functions (unit tests) have no dup and pass through unchanged.
+ */
+function dupCallback<T extends (...args: never[]) => unknown>(callback: T | undefined) {
+  if (!callback) return undefined;
+  return (callback as unknown as { dup?: () => T }).dup?.() ?? callback;
+}
+
+/**
+ * The exact provideCapability input `iterate use-my-computer` sends — exported
+ * so the e2e suite provides the REAL capability (object, instructions, types)
+ * from its own process and proves the fetcher + socket bridge end to end
+ * (apps/os/e2e/vitest/live-capability-fetcher.e2e.test.ts).
+ */
+export function myComputerProvision(name: string) {
+  return {
+    type: "live" as const,
+    path: [name],
+    capability: myComputer,
+    instructions: INSTRUCTIONS,
+    types: TYPES,
+  };
+}
 
 /** Prose + a type signature so agents (and `__describe()`) know how to call this. */
 const INSTRUCTIONS = `A real person's Mac, shared live from their terminal for as long as \`iterate use-my-computer\` runs.
 - ask({ question, buttons? }) pops a native dialog on their screen and returns { answer } — the button they clicked. Perfect for a quick human yes/no or choice.
 - notify({ message, title? }) shows a desktop notification.
-- runSwift({ code }) runs Swift on their Mac and returns { stdout, stderr, exitCode }. It has full access to their files, GUI and network, so ask before doing anything destructive.`;
+- runSwift({ code }) runs Swift on their Mac and returns { stdout, stderr, exitCode }. It has full access to their files, GUI and network, so ask before doing anything destructive.
+- getFetcher({ port }) lends a server running on their machine: the returned { fetch } proxies each Request to http://127.0.0.1:<port> on their Mac and returns the Response. A worker's fetch handler can forward straight through — e.g. \`return (await itx.myComputer.getFetcher({ port: 3000 })).fetch(req)\` serves their local dev server on a project host. HTTP only; WebSocket upgrades throw a teaching error.
+- connectSocket({ port, path?, onMessage?, onClose? }) opens a real WebSocket to a local server and bridges FRAMES over this capability: the returned handle has send(data), receive({ timeoutMs? }) → { frames, closed? } (long-poll), and close(). Terminate the browser's socket in a Durable Object app and pump frames through this handle — the socket itself can never cross RPC.`;
 
 // A capability `types` string must be a valid TS declaration named `Capability`
 // (the egress/capability host typechecks it before mounting) — not a bare object
@@ -80,6 +264,18 @@ const TYPES = `export type Capability = {
   ask(input: { question: string; buttons?: string[] }): Promise<{ answer: string }>;
   notify(input: { message: string; title?: string }): Promise<{ ok: true }>;
   runSwift(input: { code: string }): Promise<{ stdout: string; stderr: string; exitCode: number }>;
+  getFetcher(input: { port: number; host?: string }): Promise<{ fetch(request: Request): Promise<Response> }>;
+  connectSocket(input: {
+    port: number;
+    path?: string;
+    host?: string;
+    onMessage?: (data: string) => unknown;
+    onClose?: (info: { code: number; reason: string }) => unknown;
+  }): Promise<{
+    send(data: string): Promise<{ ok: true }>;
+    receive(input?: { timeoutMs?: number }): Promise<{ frames: string[]; closed?: { code: number; reason: string } }>;
+    close(input?: { code?: number; reason?: string }): Promise<{ ok: true }>;
+  }>;
 };`;
 
 /**
@@ -97,7 +293,7 @@ async function askComputerName(): Promise<string> {
     placeholder: proposed,
     defaultValue: proposed,
     validate: (value) =>
-      /^[a-zA-Z][a-zA-Z0-9]*$/.test(value.trim())
+      /^[a-zA-Z][a-zA-Z0-9]*$/.test((value ?? "").trim())
         ? undefined
         : "Use a camelCase name: letters and digits, starting with a letter (e.g. jonasComputer).",
   });
@@ -135,7 +331,8 @@ function agentPrompt(name: string): string {
     "",
     `   By the way, you can use \`itx.${name}\` to interact with ${whose} (${kind}).`,
     `   Call \`itx.${name}.__describe()\` first to learn how it works — it can ask you`,
-    `   questions with native dialogs, send notifications, and run Swift.`,
+    `   questions with native dialogs, send notifications, run Swift, and lend`,
+    `   local servers (getFetcher/connectSocket proxy HTTP and WebSockets to a port).`,
   ].join("\n");
 }
 
@@ -160,13 +357,7 @@ async function connectAndProvide(
     headers: input.headers,
   }) as RpcStub<Project>;
 
-  await itx.provideCapability({
-    type: "live",
-    path: [name],
-    capability,
-    instructions: INSTRUCTIONS,
-    types: TYPES,
-  });
+  await itx.provideCapability({ ...myComputerProvision(name), capability });
   return itx;
 }
 
@@ -232,9 +423,8 @@ export function emitComputerNeedsLogin(): void {
  */
 function withActivity(capability: typeof myComputer): typeof myComputer {
   let nextId = 0;
-  const wrapped = {} as Record<string, (arg: never) => Promise<unknown>>;
-  for (const [method, fn] of Object.entries(capability)) {
-    wrapped[method] = async (arg: never) => {
+  const announce = (method: string, fn: (arg: never) => Promise<unknown>) => {
+    return async (arg: never) => {
       const id = (nextId += 1);
       emitJson({
         type: "call",
@@ -247,7 +437,7 @@ function withActivity(capability: typeof myComputer): typeof myComputer {
       try {
         const result = await fn(arg);
         emitJson({ type: "call-done", id, method, ok: true, ms: Date.now() - startedAt });
-        return result;
+        return wrapHandle(method, result);
       } catch (error) {
         emitJson({
           type: "call-done",
@@ -260,19 +450,57 @@ function withActivity(capability: typeof myComputer): typeof myComputer {
         throw error;
       }
     };
+  };
+  // getFetcher/connectSocket return HANDLES whose methods carry the real
+  // traffic — wrap those one level deep too (as `getFetcher.fetch` etc.), or
+  // the app's activity log goes blind to the busiest lane. `receive` is a
+  // long-poll and would announce a line every ~20s doing nothing: skip it.
+  const wrapHandle = (method: string, result: unknown): unknown => {
+    if (result === null || typeof result !== "object") return result;
+    const entries = Object.entries(result as Record<string, unknown>);
+    if (!entries.some(([, value]) => typeof value === "function")) return result;
+    return Object.fromEntries(
+      entries.map(([key, value]) => [
+        key,
+        typeof value === "function" && key !== "receive"
+          ? announce(`${method}.${key}`, value as (arg: never) => Promise<unknown>)
+          : value,
+      ]),
+    );
+  };
+  const wrapped = {} as Record<string, (arg: never) => Promise<unknown>>;
+  for (const [method, fn] of Object.entries(capability)) {
+    wrapped[method] = announce(method, fn);
   }
   return wrapped as typeof myComputer;
 }
 
 /** A short, human-readable line describing one call — for the app's activity log. */
 function summarizeCall(method: string, arg: unknown): string {
-  const input = (arg ?? {}) as { question?: string; message?: string; code?: string };
+  const input = (arg ?? {}) as {
+    question?: string;
+    message?: string;
+    code?: string;
+    port?: number;
+    path?: string;
+  };
   if (method === "ask") return truncate(input.question ?? "asked a question");
   if (method === "notify") return truncate(input.message ?? "sent a notification");
   if (method === "runSwift") {
     const lines = (input.code ?? "").split("\n").filter((line) => line.trim() !== "").length;
     return `ran ${lines} line${lines === 1 ? "" : "s"} of Swift`;
   }
+  if (method === "getFetcher") return `lent an HTTP fetcher to localhost:${input.port}`;
+  if (method === "getFetcher.fetch") {
+    const request = arg as { method?: string; url?: string } | undefined;
+    const path = request?.url ? new URL(request.url).pathname : "?";
+    return truncate(`${request?.method ?? "GET"} ${path}`);
+  }
+  if (method === "connectSocket") {
+    return `opened a WebSocket to localhost:${input.port}${input.path ?? "/"}`;
+  }
+  if (method === "connectSocket.send") return truncate(`ws → ${String(arg ?? "")}`);
+  if (method === "connectSocket.close") return "closed the WebSocket";
   return method;
 }
 

--- a/packages/iterate/src/use-my-computer.ts
+++ b/packages/iterate/src/use-my-computer.ts
@@ -80,157 +80,242 @@ const myComputer = {
    */
   async getFetcher({ port, host = "127.0.0.1" }: { port: number; host?: string }) {
     const origin = `http://${host}:${port}`;
-    return {
-      fetch: async (request: Request): Promise<Response> => {
-        if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
-          throw new Error(
-            `getFetcher().fetch cannot carry a WebSocket upgrade: the 101 response's socket ` +
-              `cannot cross RPC hops between the platform and this machine. ` +
-              `Terminate the socket in a Durable Object app and bridge frames with ` +
-              `connectSocket({ port, path }) instead.`,
-          );
-        }
-        const incoming = new URL(request.url);
-        // Re-aim at the local server: same path + query, local origin. The
-        // original host arrives as x-forwarded-host (undici refuses a bare
-        // `host` override and drops it silently).
-        const headers = new Headers(request.headers);
-        headers.set("x-forwarded-host", incoming.host);
-        headers.delete("host");
-        const body =
-          request.method === "GET" || request.method === "HEAD"
-            ? undefined
-            : await request.arrayBuffer();
-        const response = await fetch(`${origin}${incoming.pathname}${incoming.search}`, {
-          method: request.method,
-          headers,
-          body,
-          // Pass redirects through untouched so the browser sees them.
-          redirect: "manual",
-        });
-        // undici decompresses bodies but keeps the encoding headers; re-serving
-        // those verbatim corrupts the hop back. Buffer the (now-plain) body and
-        // drop the stale framing headers.
-        const outHeaders = new Headers(response.headers);
-        outHeaders.delete("content-encoding");
-        outHeaders.delete("content-length");
-        outHeaders.delete("transfer-encoding");
-        const nullBody =
-          response.status === 204 || response.status === 205 || response.status === 304;
-        return new Response(nullBody ? null : await response.arrayBuffer(), {
-          status: response.status,
-          statusText: response.statusText,
-          headers: outHeaders,
-        });
-      },
-    };
+    return { fetch: (request: Request) => proxyLocalHttp(origin, request) };
   },
 
   /**
    * The WebSocket lane getFetcher cannot offer: open a real socket to a server
    * on this machine and bridge FRAMES over capability dispatch. Returns a
-   * handle — `send(data)` pushes a frame to the local server, `receive()`
-   * long-polls frames coming back (plus a `closed` marker), `close()` hangs
-   * up. If an `onMessage` callback is passed, incoming frames are also pushed
-   * to it live (functions chain through every RPC hop; we dup() them here
-   * because RPC params are released when this call returns).
+   * bridge — `send(data)` pushes a frame to the local server, `close()` hangs
+   * up. Incoming frames (and the eventual close) are delivered to the
+   * `onMessage` / `onClose` callbacks; those are stubs that capnweb would
+   * release when this call returns, so we `dup()` them for the socket's life
+   * and dispose them in the one shutdown path.
    *
    * A Durable Object app terminates the browser's WebSocket with
-   * WebSocketPair and pumps frames both ways through this handle — that is
-   * how "WebSockets to a server on my Mac" works today, since the socket
-   * itself can never cross the RPC mesh.
+   * WebSocketPair and pumps frames both ways through this bridge — that is how
+   * "WebSockets to a server on my Mac" works today, since the socket itself
+   * can never cross the RPC mesh. The local socket is torn down (once) by any
+   * of: the local server closing it, the caller calling `close()` (the
+   * cross-RPC teardown a DO must drive on browser disconnect — a returned
+   * value's `[Symbol.dispose]` is dropped by capnweb's by-value serialization,
+   * so it can't be relied on across the wire), or the CLI's own connection to
+   * OS dropping (`closeAllBridges`). `[Symbol.dispose]` still mirrors `close()`
+   * for a same-process consumer that disposes the handle directly.
    */
-  async connectSocket({
-    port,
-    path = "/",
-    host = "127.0.0.1",
-    onMessage,
-    onClose,
-  }: {
+  async connectSocket(input: {
     port: number;
     path?: string;
     host?: string;
     onMessage?: (data: string) => unknown;
     onClose?: (info: { code: number; reason: string }) => unknown;
   }) {
-    const socket = new WebSocket(`ws://${host}:${port}${path}`);
-    // Callback stubs arrive as RPC params, which are released on return —
-    // dup() keeps them alive for the socket's lifetime (dynamic-worker-dispatch.md).
-    const keptMessage = dupCallback(onMessage);
-    const keptClose = dupCallback(onClose);
-
-    const buffered: string[] = [];
-    let closed: { code: number; reason: string } | undefined;
-    let wake: (() => void) | undefined;
-    const notify = () => {
-      wake?.();
-      wake = undefined;
-    };
-
-    socket.on("message", (data) => {
-      const text = String(data);
-      if (keptMessage) {
-        // Push lane: fire-and-forget; a broken callback must not kill the pump.
-        void Promise.resolve()
-          .then(() => keptMessage(text))
-          .catch(() => {});
-      }
-      buffered.push(text);
-      notify();
-    });
-    socket.on("close", (code, reason) => {
-      closed = { code, reason: String(reason) };
-      if (keptClose) {
-        void Promise.resolve()
-          .then(() => keptClose(closed!))
-          .catch(() => {});
-      }
-      notify();
-    });
-
-    await new Promise<void>((resolve, reject) => {
-      socket.once("open", () => resolve());
-      socket.once("error", (error) => reject(error));
-    });
-
-    return {
-      /** Push one text frame to the local server. */
-      send: async (data: string) => {
-        if (closed) throw new Error(`socket already closed (${closed.code})`);
-        socket.send(data);
-        return { ok: true as const };
-      },
-      /**
-       * Long-poll the frames received since the last call. Resolves as soon as
-       * at least one frame (or the close) arrives, or with an empty list after
-       * `timeoutMs`. `closed` reports the local server hanging up.
-       */
-      receive: async ({ timeoutMs = 20_000 }: { timeoutMs?: number } = {}) => {
-        if (buffered.length === 0 && !closed) {
-          await new Promise<void>((resolve) => {
-            wake = resolve;
-            setTimeout(resolve, timeoutMs);
-          });
-        }
-        return { frames: buffered.splice(0), closed };
-      },
-      /** Close the local socket. */
-      close: async (input?: { code?: number; reason?: string }) => {
-        socket.close(input?.code ?? 1000, input?.reason ?? "");
-        return { ok: true as const };
-      },
-    };
+    return await openSocketBridge(input);
   },
 };
 
 /**
  * Keep a callback stub usable past this RPC's return: capnweb releases params
  * when the call resolves, so a provider that stores one must dup() it. Plain
- * local functions (unit tests) have no dup and pass through unchanged.
+ * local functions (unit tests) have no dup and pass through unchanged. The
+ * returned wrapper carries a matching `dispose` so the one owner can release
+ * the dup when the socket dies.
  */
-function dupCallback<T extends (...args: never[]) => unknown>(callback: T | undefined) {
+function dupCallback<T extends (...args: never[]) => unknown>(
+  callback: T | undefined,
+): { call: T; dispose: () => void } | undefined {
   if (!callback) return undefined;
-  return (callback as unknown as { dup?: () => T }).dup?.() ?? callback;
+  const stub = callback as unknown as { dup?: () => T; [Symbol.dispose]?: () => void };
+  const kept = stub.dup?.() ?? callback;
+  const disposer = (kept as unknown as { [Symbol.dispose]?: () => void })[Symbol.dispose];
+  return { call: kept, dispose: () => disposer?.call(kept) };
+}
+
+/**
+ * The frame bridge behind `connectSocket`: it exclusively owns one local
+ * WebSocket, the dup()ed callbacks, and a single idempotent `shutdown()` that
+ * every terminal path (local close/error, `close()`, `[Symbol.dispose]`, CLI
+ * teardown) funnels through — so the socket and the dup()ed stubs are released
+ * exactly once, no matter which side hangs up first. Registered in
+ * `activeBridges` so CLI shutdown can close every open bridge.
+ */
+async function openSocketBridge({
+  port,
+  path = "/",
+  host = "127.0.0.1",
+  onMessage,
+  onClose,
+}: {
+  port: number;
+  path?: string;
+  host?: string;
+  onMessage?: (data: string) => unknown;
+  onClose?: (info: { code: number; reason: string }) => unknown;
+}) {
+  const socket = new WebSocket(`ws://${host}:${port}${path}`);
+  const keptMessage = dupCallback(onMessage);
+  const keptClose = dupCallback(onClose);
+
+  let done = false;
+  const shutdown = () => {
+    if (done) return;
+    done = true;
+    activeBridges.delete(shutdown);
+    try {
+      if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+        socket.close(1000, "");
+      }
+    } catch {}
+    // Release the dup()ed callbacks: without this the CLI leaks one stub per
+    // connection for the process's lifetime.
+    keptMessage?.dispose();
+    keptClose?.dispose();
+  };
+  activeBridges.add(shutdown);
+
+  socket.on("message", (data) => {
+    // Fire-and-forget: a broken callback must not kill the pump.
+    void Promise.resolve()
+      .then(() => keptMessage?.call(String(data)))
+      .catch(() => {});
+  });
+  socket.on("close", (code, reason) => {
+    void Promise.resolve()
+      .then(() => keptClose?.call({ code, reason: String(reason) }))
+      .catch(() => {});
+    shutdown();
+  });
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      socket.once("open", () => resolve());
+      socket.once("error", (error) => reject(error));
+    });
+  } catch (error) {
+    shutdown();
+    throw error;
+  }
+
+  return {
+    /** Push one text frame to the local server; resolves once the write is accepted. */
+    send: async (data: string) => {
+      if (socket.readyState !== WebSocket.OPEN) {
+        throw new Error(`socket not open (readyState ${socket.readyState})`);
+      }
+      await new Promise<void>((resolve, reject) => {
+        socket.send(data, (error) => (error ? reject(error) : resolve()));
+      });
+      return { ok: true as const };
+    },
+    /** Close the local socket (idempotent). */
+    close: async (closeInput?: { code?: number; reason?: string }) => {
+      try {
+        if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+          socket.close(closeInput?.code ?? 1000, closeInput?.reason ?? "");
+        }
+      } catch {}
+      shutdown();
+      return { ok: true as const };
+    },
+    /** Caller releasing the handle (or the RPC session dropping) tears the socket down. */
+    [Symbol.dispose]: () => shutdown(),
+  };
+}
+
+/** Every open frame bridge's shutdown, so CLI teardown can close them all. */
+const activeBridges = new Set<() => void>();
+
+/** Close every open frame bridge — run when the CLI's own socket to OS drops. */
+function closeAllBridges(): void {
+  for (const shutdown of [...activeBridges]) shutdown();
+}
+
+/** Hop-by-hop headers are connection-scoped and must not be forwarded across a proxy hop (RFC 9110 §7.6.1). */
+const HOP_BY_HOP_HEADERS = [
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+];
+
+/**
+ * Proxy one HTTP request to a server on this machine and return its response,
+ * faithfully enough to serve a real dev server on a project host:
+ * - WebSocket upgrades are refused with a teaching error (the socket can't
+ *   cross RPC — that's what connectSocket is for).
+ * - Hop-by-hop headers are stripped in both directions; the original host
+ *   travels as `x-forwarded-host` (undici drops a bare `host` override).
+ * - A `Location` pointing back at the local origin is rewritten onto the
+ *   public origin, so a dev server's `302 → /login` doesn't send the browser
+ *   to its own loopback.
+ * - A refused/failed upstream becomes a `502`, not an exception escaping
+ *   through capability dispatch as an opaque worker failure.
+ * Bodies are buffered (fine for a spike; undici already decompressed them, so
+ * the stale framing headers are dropped).
+ */
+async function proxyLocalHttp(origin: string, request: Request): Promise<Response> {
+  if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
+    throw new Error(
+      `getFetcher().fetch cannot carry a WebSocket upgrade: the 101 response's socket ` +
+        `cannot cross RPC hops between the platform and this machine. ` +
+        `Terminate the socket in a Durable Object app and bridge frames with ` +
+        `connectSocket({ port, path }) instead.`,
+    );
+  }
+  const incoming = new URL(request.url);
+  const headers = stripHopByHop(new Headers(request.headers));
+  headers.set("x-forwarded-host", incoming.host);
+  headers.delete("host");
+  const body =
+    request.method === "GET" || request.method === "HEAD" ? undefined : await request.arrayBuffer();
+
+  let response: Response;
+  try {
+    response = await fetch(`${origin}${incoming.pathname}${incoming.search}`, {
+      method: request.method,
+      headers,
+      body,
+      redirect: "manual", // pass redirects through so the browser sees them
+    });
+  } catch (error) {
+    return new Response(`local server at ${origin} is unreachable: ${String(error)}`, {
+      status: 502,
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    });
+  }
+
+  const outHeaders = stripHopByHop(new Headers(response.headers));
+  // undici decompressed the body but left the encoding/length framing — drop it.
+  outHeaders.delete("content-encoding");
+  outHeaders.delete("content-length");
+  // Keep a dev-server redirect on the public host instead of the Mac's loopback.
+  const location = outHeaders.get("location");
+  if (location?.startsWith(origin)) {
+    outHeaders.set("location", `${incoming.origin}${location.slice(origin.length)}`);
+  }
+  const nullBody =
+    request.method === "HEAD" ||
+    response.status === 204 ||
+    response.status === 205 ||
+    response.status === 304;
+  return new Response(nullBody ? null : await response.arrayBuffer(), {
+    status: response.status,
+    statusText: response.statusText,
+    headers: outHeaders,
+  });
+}
+
+/** Delete hop-by-hop headers, including any named by the `Connection` header. */
+function stripHopByHop(headers: Headers): Headers {
+  for (const named of headers.get("connection")?.split(",") ?? []) {
+    headers.delete(named.trim());
+  }
+  for (const name of HOP_BY_HOP_HEADERS) headers.delete(name);
+  return headers;
 }
 
 /**
@@ -255,7 +340,7 @@ const INSTRUCTIONS = `A real person's Mac, shared live from their terminal for a
 - notify({ message, title? }) shows a desktop notification.
 - runSwift({ code }) runs Swift on their Mac and returns { stdout, stderr, exitCode }. It has full access to their files, GUI and network, so ask before doing anything destructive.
 - getFetcher({ port }) lends a server running on their machine: the returned { fetch } proxies each Request to http://127.0.0.1:<port> on their Mac and returns the Response. A worker's fetch handler can forward straight through — e.g. \`return (await itx.myComputer.getFetcher({ port: 3000 })).fetch(req)\` serves their local dev server on a project host. HTTP only; WebSocket upgrades throw a teaching error.
-- connectSocket({ port, path?, onMessage?, onClose? }) opens a real WebSocket to a local server and bridges FRAMES over this capability: the returned handle has send(data), receive({ timeoutMs? }) → { frames, closed? } (long-poll), and close(). Terminate the browser's socket in a Durable Object app and pump frames through this handle — the socket itself can never cross RPC.`;
+- connectSocket({ port, path?, onMessage?, onClose? }) opens a real WebSocket to a local server and bridges FRAMES over this capability: onMessage receives each incoming frame, and the returned bridge has send(data) and close(). Terminate the browser's socket in a Durable Object app and pump frames through this bridge — the socket itself can never cross RPC.`;
 
 // A capability `types` string must be a valid TS declaration named `Capability`
 // (the egress/capability host typechecks it before mounting) — not a bare object
@@ -273,7 +358,6 @@ const TYPES = `export type Capability = {
     onClose?: (info: { code: number; reason: string }) => unknown;
   }): Promise<{
     send(data: string): Promise<{ ok: true }>;
-    receive(input?: { timeoutMs?: number }): Promise<{ frames: string[]; closed?: { code: number; reason: string } }>;
     close(input?: { code?: number; reason?: string }): Promise<{ ok: true }>;
   }>;
 };`;
@@ -361,9 +445,18 @@ async function connectAndProvide(
   return itx;
 }
 
-/** Keep the mount routable — a live capability only serves while its socket is warm — and never return. */
+/**
+ * Keep the mount routable — a live capability only serves while its socket is
+ * warm — and never return. If the heartbeat starts failing the CLI's own
+ * socket to OS has likely dropped and every mounted capability is unreachable;
+ * close any open frame bridges so their local sockets don't linger.
+ */
 function holdWarm(itx: RpcStub<Project>): Promise<never> {
-  const heartbeat = () => itx.__describe().catch(() => {});
+  const heartbeat = () =>
+    itx.__describe().then(
+      () => {},
+      () => closeAllBridges(),
+    );
   heartbeat();
   setInterval(heartbeat, 5_000);
   return new Promise<never>(() => {});
@@ -423,6 +516,12 @@ export function emitComputerNeedsLogin(): void {
  */
 function withActivity(capability: typeof myComputer): typeof myComputer {
   let nextId = 0;
+  // Each capability method takes exactly one argument and announces itself as
+  // it runs. The returned transport handles (getFetcher's { fetch }, the frame
+  // bridge) pass through untouched: per-request activity would mean reflecting
+  // over their methods, which changes what capnweb serializes back — the
+  // top-level getFetcher/connectSocket line is enough to show the computer's
+  // in use.
   const announce = (method: string, fn: (arg: never) => Promise<unknown>) => {
     return async (arg: never) => {
       const id = (nextId += 1);
@@ -437,7 +536,7 @@ function withActivity(capability: typeof myComputer): typeof myComputer {
       try {
         const result = await fn(arg);
         emitJson({ type: "call-done", id, method, ok: true, ms: Date.now() - startedAt });
-        return wrapHandle(method, result);
+        return result;
       } catch (error) {
         emitJson({
           type: "call-done",
@@ -450,23 +549,6 @@ function withActivity(capability: typeof myComputer): typeof myComputer {
         throw error;
       }
     };
-  };
-  // getFetcher/connectSocket return HANDLES whose methods carry the real
-  // traffic — wrap those one level deep too (as `getFetcher.fetch` etc.), or
-  // the app's activity log goes blind to the busiest lane. `receive` is a
-  // long-poll and would announce a line every ~20s doing nothing: skip it.
-  const wrapHandle = (method: string, result: unknown): unknown => {
-    if (result === null || typeof result !== "object") return result;
-    const entries = Object.entries(result as Record<string, unknown>);
-    if (!entries.some(([, value]) => typeof value === "function")) return result;
-    return Object.fromEntries(
-      entries.map(([key, value]) => [
-        key,
-        typeof value === "function" && key !== "receive"
-          ? announce(`${method}.${key}`, value as (arg: never) => Promise<unknown>)
-          : value,
-      ]),
-    );
   };
   const wrapped = {} as Record<string, (arg: never) => Promise<unknown>>;
   for (const [method, fn] of Object.entries(capability)) {
@@ -491,16 +573,9 @@ function summarizeCall(method: string, arg: unknown): string {
     return `ran ${lines} line${lines === 1 ? "" : "s"} of Swift`;
   }
   if (method === "getFetcher") return `lent an HTTP fetcher to localhost:${input.port}`;
-  if (method === "getFetcher.fetch") {
-    const request = arg as { method?: string; url?: string } | undefined;
-    const path = request?.url ? new URL(request.url).pathname : "?";
-    return truncate(`${request?.method ?? "GET"} ${path}`);
-  }
   if (method === "connectSocket") {
     return `opened a WebSocket to localhost:${input.port}${input.path ?? "/"}`;
   }
-  if (method === "connectSocket.send") return truncate(`ws → ${String(arg ?? "")}`);
-  if (method === "connectSocket.close") return "closed the WebSocket";
   return method;
 }
 

--- a/packages/iterate/src/use-my-computer.ts
+++ b/packages/iterate/src/use-my-computer.ts
@@ -25,11 +25,11 @@ import { hostname } from "node:os";
 
 import * as prompts from "@clack/prompts";
 import type { RpcStub } from "capnweb";
-import WebSocket from "ws";
 
 import { connectItx } from "../../../apps/os/src/itx-client.ts";
 import type { ItxAuthCredentials, Project } from "./itx-api.generated.ts";
 import { run } from "./run-command.ts";
+import { closeAllBridges, openSocketBridge, proxyLocalHttp } from "./use-my-computer-transport.ts";
 
 /**
  * The object we lend to the project. Each method becomes callable by agents as
@@ -87,21 +87,11 @@ const myComputer = {
    * The WebSocket lane getFetcher cannot offer: open a real socket to a server
    * on this machine and bridge FRAMES over capability dispatch. Returns a
    * bridge — `send(data)` pushes a frame to the local server, `close()` hangs
-   * up. Incoming frames (and the eventual close) are delivered to the
-   * `onMessage` / `onClose` callbacks; those are stubs that capnweb would
-   * release when this call returns, so we `dup()` them for the socket's life
-   * and dispose them in the one shutdown path.
-   *
-   * A Durable Object app terminates the browser's WebSocket with
-   * WebSocketPair and pumps frames both ways through this bridge — that is how
-   * "WebSockets to a server on my Mac" works today, since the socket itself
-   * can never cross the RPC mesh. The local socket is torn down (once) by any
-   * of: the local server closing it, the caller calling `close()` (the
-   * cross-RPC teardown a DO must drive on browser disconnect — a returned
-   * value's `[Symbol.dispose]` is dropped by capnweb's by-value serialization,
-   * so it can't be relied on across the wire), or the CLI's own connection to
-   * OS dropping (`closeAllBridges`). `[Symbol.dispose]` still mirrors `close()`
-   * for a same-process consumer that disposes the handle directly.
+   * up — while incoming frames (and the eventual close) reach the `onMessage` /
+   * `onClose` callbacks. The socket can never cross the RPC mesh, so a Durable
+   * Object app terminates the browser's WebSocket with WebSocketPair and pumps
+   * frames both ways through this bridge. See `openSocketBridge` for the
+   * ownership/teardown contract.
    */
   async connectSocket(input: {
     port: number;
@@ -113,210 +103,6 @@ const myComputer = {
     return await openSocketBridge(input);
   },
 };
-
-/**
- * Keep a callback stub usable past this RPC's return: capnweb releases params
- * when the call resolves, so a provider that stores one must dup() it. Plain
- * local functions (unit tests) have no dup and pass through unchanged. The
- * returned wrapper carries a matching `dispose` so the one owner can release
- * the dup when the socket dies.
- */
-function dupCallback<T extends (...args: never[]) => unknown>(
-  callback: T | undefined,
-): { call: T; dispose: () => void } | undefined {
-  if (!callback) return undefined;
-  const stub = callback as unknown as { dup?: () => T; [Symbol.dispose]?: () => void };
-  const kept = stub.dup?.() ?? callback;
-  const disposer = (kept as unknown as { [Symbol.dispose]?: () => void })[Symbol.dispose];
-  return { call: kept, dispose: () => disposer?.call(kept) };
-}
-
-/**
- * The frame bridge behind `connectSocket`: it exclusively owns one local
- * WebSocket, the dup()ed callbacks, and a single idempotent `shutdown()` that
- * every terminal path (local close/error, `close()`, `[Symbol.dispose]`, CLI
- * teardown) funnels through — so the socket and the dup()ed stubs are released
- * exactly once, no matter which side hangs up first. Registered in
- * `activeBridges` so CLI shutdown can close every open bridge.
- */
-async function openSocketBridge({
-  port,
-  path = "/",
-  host = "127.0.0.1",
-  onMessage,
-  onClose,
-}: {
-  port: number;
-  path?: string;
-  host?: string;
-  onMessage?: (data: string) => unknown;
-  onClose?: (info: { code: number; reason: string }) => unknown;
-}) {
-  const socket = new WebSocket(`ws://${host}:${port}${path}`);
-  const keptMessage = dupCallback(onMessage);
-  const keptClose = dupCallback(onClose);
-
-  let done = false;
-  const shutdown = () => {
-    if (done) return;
-    done = true;
-    activeBridges.delete(shutdown);
-    try {
-      if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
-        socket.close(1000, "");
-      }
-    } catch {}
-    // Release the dup()ed callbacks: without this the CLI leaks one stub per
-    // connection for the process's lifetime.
-    keptMessage?.dispose();
-    keptClose?.dispose();
-  };
-  activeBridges.add(shutdown);
-
-  socket.on("message", (data) => {
-    // Fire-and-forget: a broken callback must not kill the pump.
-    void Promise.resolve()
-      .then(() => keptMessage?.call(String(data)))
-      .catch(() => {});
-  });
-  socket.on("close", (code, reason) => {
-    void Promise.resolve()
-      .then(() => keptClose?.call({ code, reason: String(reason) }))
-      .catch(() => {});
-    shutdown();
-  });
-
-  try {
-    await new Promise<void>((resolve, reject) => {
-      socket.once("open", () => resolve());
-      socket.once("error", (error) => reject(error));
-    });
-  } catch (error) {
-    shutdown();
-    throw error;
-  }
-
-  return {
-    /** Push one text frame to the local server; resolves once the write is accepted. */
-    send: async (data: string) => {
-      if (socket.readyState !== WebSocket.OPEN) {
-        throw new Error(`socket not open (readyState ${socket.readyState})`);
-      }
-      await new Promise<void>((resolve, reject) => {
-        socket.send(data, (error) => (error ? reject(error) : resolve()));
-      });
-      return { ok: true as const };
-    },
-    /** Close the local socket (idempotent). */
-    close: async (closeInput?: { code?: number; reason?: string }) => {
-      try {
-        if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
-          socket.close(closeInput?.code ?? 1000, closeInput?.reason ?? "");
-        }
-      } catch {}
-      shutdown();
-      return { ok: true as const };
-    },
-    /** Caller releasing the handle (or the RPC session dropping) tears the socket down. */
-    [Symbol.dispose]: () => shutdown(),
-  };
-}
-
-/** Every open frame bridge's shutdown, so CLI teardown can close them all. */
-const activeBridges = new Set<() => void>();
-
-/** Close every open frame bridge — run when the CLI's own socket to OS drops. */
-function closeAllBridges(): void {
-  for (const shutdown of [...activeBridges]) shutdown();
-}
-
-/** Hop-by-hop headers are connection-scoped and must not be forwarded across a proxy hop (RFC 9110 §7.6.1). */
-const HOP_BY_HOP_HEADERS = [
-  "connection",
-  "keep-alive",
-  "proxy-authenticate",
-  "proxy-authorization",
-  "te",
-  "trailer",
-  "transfer-encoding",
-  "upgrade",
-];
-
-/**
- * Proxy one HTTP request to a server on this machine and return its response,
- * faithfully enough to serve a real dev server on a project host:
- * - WebSocket upgrades are refused with a teaching error (the socket can't
- *   cross RPC — that's what connectSocket is for).
- * - Hop-by-hop headers are stripped in both directions; the original host
- *   travels as `x-forwarded-host` (undici drops a bare `host` override).
- * - A `Location` pointing back at the local origin is rewritten onto the
- *   public origin, so a dev server's `302 → /login` doesn't send the browser
- *   to its own loopback.
- * - A refused/failed upstream becomes a `502`, not an exception escaping
- *   through capability dispatch as an opaque worker failure.
- * Bodies are buffered (fine for a spike; undici already decompressed them, so
- * the stale framing headers are dropped).
- */
-async function proxyLocalHttp(origin: string, request: Request): Promise<Response> {
-  if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
-    throw new Error(
-      `getFetcher().fetch cannot carry a WebSocket upgrade: the 101 response's socket ` +
-        `cannot cross RPC hops between the platform and this machine. ` +
-        `Terminate the socket in a Durable Object app and bridge frames with ` +
-        `connectSocket({ port, path }) instead.`,
-    );
-  }
-  const incoming = new URL(request.url);
-  const headers = stripHopByHop(new Headers(request.headers));
-  headers.set("x-forwarded-host", incoming.host);
-  headers.delete("host");
-  const body =
-    request.method === "GET" || request.method === "HEAD" ? undefined : await request.arrayBuffer();
-
-  let response: Response;
-  try {
-    response = await fetch(`${origin}${incoming.pathname}${incoming.search}`, {
-      method: request.method,
-      headers,
-      body,
-      redirect: "manual", // pass redirects through so the browser sees them
-    });
-  } catch (error) {
-    return new Response(`local server at ${origin} is unreachable: ${String(error)}`, {
-      status: 502,
-      headers: { "content-type": "text/plain; charset=utf-8" },
-    });
-  }
-
-  const outHeaders = stripHopByHop(new Headers(response.headers));
-  // undici decompressed the body but left the encoding/length framing — drop it.
-  outHeaders.delete("content-encoding");
-  outHeaders.delete("content-length");
-  // Keep a dev-server redirect on the public host instead of the Mac's loopback.
-  const location = outHeaders.get("location");
-  if (location?.startsWith(origin)) {
-    outHeaders.set("location", `${incoming.origin}${location.slice(origin.length)}`);
-  }
-  const nullBody =
-    request.method === "HEAD" ||
-    response.status === 204 ||
-    response.status === 205 ||
-    response.status === 304;
-  return new Response(nullBody ? null : await response.arrayBuffer(), {
-    status: response.status,
-    statusText: response.statusText,
-    headers: outHeaders,
-  });
-}
-
-/** Delete hop-by-hop headers, including any named by the `Connection` header. */
-function stripHopByHop(headers: Headers): Headers {
-  for (const named of headers.get("connection")?.split(",") ?? []) {
-    headers.delete(named.trim());
-  }
-  for (const name of HOP_BY_HOP_HEADERS) headers.delete(name);
-  return headers;
-}
 
 /**
  * The exact provideCapability input `iterate use-my-computer` sends — exported
@@ -447,16 +233,17 @@ async function connectAndProvide(
 
 /**
  * Keep the mount routable — a live capability only serves while its socket is
- * warm — and never return. If the heartbeat starts failing the CLI's own
- * socket to OS has likely dropped and every mounted capability is unreachable;
- * close any open frame bridges so their local sockets don't linger.
+ * warm — and never return. When the CLI's own socket to OS drops, every mounted
+ * capability is unreachable, so close any open frame bridges to release their
+ * local sockets. `onRpcBroken` is the authoritative disconnect signal; the
+ * heartbeat only keeps the mount warm and ignores individual failures (a
+ * transient `__describe` hiccup must not tear down live bridges).
  */
 function holdWarm(itx: RpcStub<Project>): Promise<never> {
-  const heartbeat = () =>
-    itx.__describe().then(
-      () => {},
-      () => closeAllBridges(),
-    );
+  (itx as { onRpcBroken?(handler: (error: unknown) => void): void }).onRpcBroken?.(() =>
+    closeAllBridges(),
+  );
+  const heartbeat = () => itx.__describe().catch(() => {});
   heartbeat();
   setInterval(heartbeat, 5_000);
   return new Promise<never>(() => {});

--- a/packages/iterate/src/use-my-computer.ts
+++ b/packages/iterate/src/use-my-computer.ts
@@ -31,121 +31,123 @@ import type { ItxAuthCredentials, Project } from "./itx-api.generated.ts";
 import { run } from "./run-command.ts";
 import { closeAllBridges, openSocketBridge, proxyLocalHttp } from "./use-my-computer-transport.ts";
 
+// The methods we lend to the project. Each becomes callable by agents as
+// `itx.<name>.<method>(...)`; capnweb ships the *call* over this process's
+// socket, so the body runs locally — native macOS dialogs and all.
+
+/** Pop a native dialog on screen and return which button the human clicked. */
+async function ask({
+  question,
+  buttons = ["No", "Yes"],
+}: {
+  question: string;
+  buttons?: string[];
+}) {
+  // AppleScript's `display dialog` supports one to three buttons.
+  if (buttons.length < 1 || buttons.length > 3) {
+    throw new Error("ask() needs 1–3 buttons (AppleScript dialogs cap at three).");
+  }
+  const buttonList = buttons.map((b) => `"${escapeForAppleScript(b)}"`).join(", ");
+  const { stdout } = await osascript(
+    `display dialog "${escapeForAppleScript(question)}" ` +
+      `buttons {${buttonList}} default button "${escapeForAppleScript(buttons.at(-1)!)}" ` +
+      `with title "iterate · myComputer"`,
+  );
+  // osascript prints e.g. `button returned:Yes` — hand back just the choice.
+  return { answer: stdout.trim().replace(/^button returned:/, "") };
+}
+
+/** Show a desktop notification. */
+async function notify({ message, title = "iterate" }: { message: string; title?: string }) {
+  await osascript(
+    `display notification "${escapeForAppleScript(message)}" with title "${escapeForAppleScript(title)}"`,
+  );
+  return { ok: true as const };
+}
+
+/** Run arbitrary Swift and return its output — full power, when an agent needs it. */
+async function runSwift({ code }: { code: string }) {
+  // `swift -` reads a whole program from stdin and runs it.
+  return await run("swift", ["-"], code);
+}
+
+/** The human-interaction methods, always present — callable as itx.<name>.<method>(). */
+const baseMethods = { ask, notify, runSwift };
+
 /**
- * The object we lend to the project. Each method becomes callable by agents as
- * `itx.myComputer.<method>(...)`. capnweb ships the *call* over this process's
- * socket, so the body runs locally — native macOS dialogs and all.
+ * Lend the server on ONE local port as a URL origin. These are the PLATFORM's
+ * to call, not agents': a project reaches them by URL —
+ * `fetch("http://<name>.iterate/…", req)` — never `itx.<name>.fetch(...)`.
+ * - fetch(request) proxies each request to http://127.0.0.1:<port>.
+ * - connectSocket({ path, onMessage, onClose }) opens a real WebSocket to the
+ *   local server and bridges FRAMES; the capability host terminates the
+ *   browser's socket (WebSocketPair) and pumps frames through this handle,
+ *   because the socket itself can never cross an RPC hop.
  */
-const myComputer = {
-  /** Pop a native dialog on screen and return which button the human clicked. */
-  async ask({ question, buttons = ["No", "Yes"] }: { question: string; buttons?: string[] }) {
-    // AppleScript's `display dialog` supports one to three buttons.
-    if (buttons.length < 1 || buttons.length > 3) {
-      throw new Error("ask() needs 1–3 buttons (AppleScript dialogs cap at three).");
-    }
-    const buttonList = buttons.map((b) => `"${escapeForAppleScript(b)}"`).join(", ");
-    const { stdout } = await osascript(
-      `display dialog "${escapeForAppleScript(question)}" ` +
-        `buttons {${buttonList}} default button "${escapeForAppleScript(buttons.at(-1)!)}" ` +
-        `with title "iterate · myComputer"`,
-    );
-    // osascript prints e.g. `button returned:Yes` — hand back just the choice.
-    return { answer: stdout.trim().replace(/^button returned:/, "") };
-  },
+function addressableOrigin(port: number, host = "127.0.0.1") {
+  const origin = `http://${host}:${port}`;
+  return {
+    fetch: (request: Request) => proxyLocalHttp(origin, request),
+    connectSocket: (input: {
+      path?: string;
+      onMessage?: (data: string) => unknown;
+      onClose?: (info: { code: number; reason: string }) => unknown;
+    }) => openSocketBridge({ ...input, port, host }),
+  };
+}
 
-  /** Show a desktop notification. */
-  async notify({ message, title = "iterate" }: { message: string; title?: string }) {
-    await osascript(
-      `display notification "${escapeForAppleScript(message)}" with title "${escapeForAppleScript(title)}"`,
-    );
-    return { ok: true as const };
-  },
+/**
+ * The object `iterate use-my-computer` lends. With `exposePort`, it also lends
+ * the server on that local port as an addressable URL origin (HTTP + WebSocket).
+ */
+export function createMyComputer(options: { exposePort?: number } = {}) {
+  return options.exposePort === undefined
+    ? { ...baseMethods }
+    : { ...baseMethods, ...addressableOrigin(options.exposePort) };
+}
 
-  /** Run arbitrary Swift and return its output — full power, when an agent needs it. */
-  async runSwift({ code }: { code: string }) {
-    // `swift -` reads a whole program from stdin and runs it.
-    return await run("swift", ["-"], code);
-  },
-
-  /**
-   * Lend a server running on this machine to the project: returns
-   * `{ fetch(request) }` that proxies each request to
-   * `http://127.0.0.1:<port>`. A project worker's homepage can literally be
-   * `return (await itx.myComputer.getFetcher({ port })).fetch(req)` — the
-   * Request rides capability dispatch here, the fetch happens on this Mac,
-   * and the Response rides back. Plain HTTP only: capability dispatch is RPC,
-   * and a socket-carrying Response cannot cross workerd's internal hops
-   * (apps/os/docs/dynamic-worker-dispatch.md) — WebSocket upgrades get a
-   * teaching error pointing at connectSocket.
-   */
-  async getFetcher({ port, host = "127.0.0.1" }: { port: number; host?: string }) {
-    const origin = `http://${host}:${port}`;
-    return { fetch: (request: Request) => proxyLocalHttp(origin, request) };
-  },
-
-  /**
-   * The WebSocket lane getFetcher cannot offer: open a real socket to a server
-   * on this machine and bridge FRAMES over capability dispatch. Returns a
-   * bridge — `send(data)` pushes a frame to the local server, `close()` hangs
-   * up — while incoming frames (and the eventual close) reach the `onMessage` /
-   * `onClose` callbacks. The socket can never cross the RPC mesh, so a Durable
-   * Object app terminates the browser's WebSocket with WebSocketPair and pumps
-   * frames both ways through this bridge. See `openSocketBridge` for the
-   * ownership/teardown contract.
-   */
-  async connectSocket(input: {
-    port: number;
-    path?: string;
-    host?: string;
-    onMessage?: (data: string) => unknown;
-    onClose?: (info: { code: number; reason: string }) => unknown;
-  }) {
-    return await openSocketBridge(input);
-  },
-};
+export type MyComputer = ReturnType<typeof createMyComputer>;
 
 /**
  * The exact provideCapability input `iterate use-my-computer` sends — exported
  * so the e2e suite provides the REAL capability (object, instructions, types)
- * from its own process and proves the fetcher + socket bridge end to end
- * (apps/os/e2e/vitest/live-capability-fetcher.e2e.test.ts).
+ * from its own process and proves URL addressing end to end
+ * (apps/os/e2e/vitest/live-capability-fetcher.e2e.test.ts). `exposePort` makes
+ * the mount `addressable` and lends that local port at http://<name>.iterate/.
  */
-export function myComputerProvision(name: string) {
+export function myComputerProvision(name: string, options: { exposePort?: number } = {}) {
   return {
     type: "live" as const,
     path: [name],
-    capability: myComputer,
-    instructions: INSTRUCTIONS,
+    capability: createMyComputer(options),
+    addressable: options.exposePort !== undefined,
+    instructions: instructionsFor(name, options.exposePort !== undefined),
     types: TYPES,
   };
 }
 
-/** Prose + a type signature so agents (and `__describe()`) know how to call this. */
-const INSTRUCTIONS = `A real person's Mac, shared live from their terminal for as long as \`iterate use-my-computer\` runs.
+/** Prose so agents (and `__describe()`) know how to drive this. */
+function instructionsFor(name: string, addressable: boolean): string {
+  const base = `A real person's Mac, shared live from their terminal for as long as \`iterate use-my-computer\` runs.
 - ask({ question, buttons? }) pops a native dialog on their screen and returns { answer } — the button they clicked. Perfect for a quick human yes/no or choice.
 - notify({ message, title? }) shows a desktop notification.
-- runSwift({ code }) runs Swift on their Mac and returns { stdout, stderr, exitCode }. It has full access to their files, GUI and network, so ask before doing anything destructive.
-- getFetcher({ port }) lends a server running on their machine: the returned { fetch } proxies each Request to http://127.0.0.1:<port> on their Mac and returns the Response. A worker's fetch handler can forward straight through — e.g. \`return (await itx.myComputer.getFetcher({ port: 3000 })).fetch(req)\` serves their local dev server on a project host. HTTP only; WebSocket upgrades throw a teaching error.
-- connectSocket({ port, path?, onMessage?, onClose? }) opens a real WebSocket to a local server and bridges FRAMES over this capability: onMessage receives each incoming frame, and the returned bridge has send(data) and close(). Terminate the browser's socket in a Durable Object app and pump frames through this bridge — the socket itself can never cross RPC.`;
+- runSwift({ code }) runs Swift on their Mac and returns { stdout, stderr, exitCode }. It has full access to their files, GUI and network, so ask before doing anything destructive.`;
+  if (!addressable) return base;
+  const url = `http://${name.toLowerCase()}.iterate`;
+  return `${base}
+
+This computer also lends a local server, reachable by URL (not by an itx method): fetch \`${url}/…\` from a project worker. A worker's fetch handler can forward straight through — \`const u = new URL(req.url); return fetch(new Request("${url}" + u.pathname + u.search, req));\` serves their local dev server on a project host. Unlike the itx RPC path, the URL carries WebSocket upgrades (HMR, live reload) too.`;
+}
 
 // A capability `types` string must be a valid TS declaration named `Capability`
-// (the egress/capability host typechecks it before mounting) — not a bare object
-// literal, which fails to compile and aborts the mount.
+// (the capability host typechecks it before mounting) — not a bare object
+// literal, which fails to compile and aborts the mount. The addressable origin
+// (fetch/connectSocket) is reached by URL, not as an itx method, so it is
+// described in the instructions above rather than declared here.
 const TYPES = `export type Capability = {
   ask(input: { question: string; buttons?: string[] }): Promise<{ answer: string }>;
   notify(input: { message: string; title?: string }): Promise<{ ok: true }>;
   runSwift(input: { code: string }): Promise<{ stdout: string; stderr: string; exitCode: number }>;
-  getFetcher(input: { port: number; host?: string }): Promise<{ fetch(request: Request): Promise<Response> }>;
-  connectSocket(input: {
-    port: number;
-    path?: string;
-    host?: string;
-    onMessage?: (data: string) => unknown;
-    onClose?: (info: { code: number; reason: string }) => unknown;
-  }): Promise<{
-    send(data: string): Promise<{ ok: true }>;
-    close(input?: { code?: number; reason?: string }): Promise<{ ok: true }>;
-  }>;
 };`;
 
 /**
@@ -174,6 +176,35 @@ async function askComputerName(): Promise<string> {
   return answer.trim();
 }
 
+/**
+ * Optionally lend a local server (a dev server, an API) at the capability's URL.
+ * Blank skips it; a port number makes the mount addressable at
+ * http://<name>.iterate/. Non-interactive callers pass `exposePort` explicitly.
+ */
+async function askExposePort(): Promise<number | undefined> {
+  if (!process.stdin.isTTY) return undefined;
+  const answer = await prompts.text({
+    message:
+      "Lend a local server too? Enter its port (or leave blank) — reachable at http://<name>.iterate/",
+    placeholder: "",
+    defaultValue: "",
+    validate: (value) => {
+      const trimmed = (value ?? "").trim();
+      if (trimmed === "") return undefined;
+      const port = Number(trimmed);
+      return /^\d+$/.test(trimmed) && port > 0 && port < 65536
+        ? undefined
+        : "Enter a port number 1–65535, or leave blank to skip.";
+    },
+  });
+  if (prompts.isCancel(answer)) {
+    prompts.cancel("Cancelled.");
+    process.exit(0);
+  }
+  const trimmed = answer.trim();
+  return trimmed === "" ? undefined : Number(trimmed);
+}
+
 /** "Jonas’s-MacBook-Pro.local" → "jonasComputer". A friendly default, always editable. */
 function proposeComputerName(): string {
   const firstWord = hostname()
@@ -188,7 +219,7 @@ function proposeComputerName(): string {
  * A line the human can paste to an agent so it knows this capability exists.
  * `itx.<name>.__describe()` then teaches the agent exactly how to drive it.
  */
-function agentPrompt(name: string): string {
+function agentPrompt(name: string, addressable: boolean): string {
   const kind = /macbook/i.test(hostname())
     ? "a MacBook"
     : process.platform === "darwin"
@@ -196,14 +227,20 @@ function agentPrompt(name: string): string {
       : "their computer";
   const owner = /^(.+?)(computer|mac|laptop|machine)$/i.exec(name)?.[1];
   const whose = owner ? `${owner[0].toUpperCase()}${owner.slice(1)}’s computer` : name;
-  return [
+  const lines = [
     "📋 Paste this to an agent so it knows it can use your computer:",
     "",
     `   By the way, you can use \`itx.${name}\` to interact with ${whose} (${kind}).`,
     `   Call \`itx.${name}.__describe()\` first to learn how it works — it can ask you`,
-    `   questions with native dialogs, send notifications, run Swift, and lend`,
-    `   local servers (getFetcher/connectSocket proxy HTTP and WebSockets to a port).`,
-  ].join("\n");
+    `   questions with native dialogs, send notifications, and run Swift.`,
+  ];
+  if (addressable) {
+    lines.push(
+      `   It also serves a local server at http://${name.toLowerCase()}.iterate/ — a worker can`,
+      `   \`return fetch("http://${name.toLowerCase()}.iterate/", req)\` to show it (HTTP + WebSockets).`,
+    );
+  }
+  return lines.join("\n");
 }
 
 type ConnectInput = {
@@ -212,14 +249,20 @@ type ConnectInput = {
   projectId: string;
   headers?: Record<string, string>;
   name?: string;
+  /** Also lend the local server on this port at http://<name>.iterate/. */
+  exposePort?: number;
 };
 
-/** Mount `capability` at `itx.<name>` and return the live socket stub. */
+/** Mount the capability at `itx.<name>` and return the live socket stub. */
 async function connectAndProvide(
   input: ConnectInput,
   name: string,
-  capability: typeof myComputer,
+  options: { exposePort?: number; wrapActivity?: boolean },
 ): Promise<RpcStub<Project>> {
+  const provision = myComputerProvision(name, { exposePort: options.exposePort });
+  const capability = options.wrapActivity
+    ? withActivity(provision.capability)
+    : provision.capability;
   const itx = connectItx({
     auth: input.auth,
     baseUrl: input.baseUrl,
@@ -227,7 +270,7 @@ async function connectAndProvide(
     headers: input.headers,
   }) as RpcStub<Project>;
 
-  await itx.provideCapability({ ...myComputerProvision(name), capability });
+  await itx.provideCapability({ ...provision, capability });
   return itx;
 }
 
@@ -258,9 +301,10 @@ export async function shareMyComputer(
 ): Promise<never> {
   const log = input.log ?? ((message: string) => console.error(message));
   const name = input.name ?? (await askComputerName());
-  const itx = await connectAndProvide(input, name, myComputer);
+  const exposePort = input.exposePort ?? (await askExposePort());
+  const itx = await connectAndProvide(input, name, { exposePort });
   log(`✅ itx.${name} is live for project ${input.projectId}. Press Ctrl-C to stop sharing.\n`);
-  log(agentPrompt(name));
+  log(agentPrompt(name, exposePort !== undefined));
   return holdWarm(itx);
 }
 
@@ -276,7 +320,10 @@ export async function shareMyComputer(
  */
 export async function runUseMyComputerJson(input: ConnectInput): Promise<never> {
   const name = input.name ?? proposeComputerName();
-  const itx = await connectAndProvide(input, name, withActivity(myComputer));
+  const itx = await connectAndProvide(input, name, {
+    exposePort: input.exposePort,
+    wrapActivity: true,
+  });
   emitJson({ type: "status", loggedIn: true, project: input.projectId, name });
   // If the menu-bar parent goes away, stdin closes — stop sharing rather than
   // leaving the computer silently lent with no window onto it.
@@ -301,14 +348,13 @@ export function emitComputerNeedsLogin(): void {
  * behaviour is otherwise identical: the wrapped method awaits the real one and
  * returns (or rethrows) exactly what it did.
  */
-function withActivity(capability: typeof myComputer): typeof myComputer {
+/** Methods worth surfacing in the menu-bar activity log — the human actions.
+ * The addressable origin (fetch/connectSocket) is high-frequency transport and
+ * passes through unannounced. */
+const ANNOUNCED_METHODS = new Set(["ask", "notify", "runSwift"]);
+
+function withActivity(capability: MyComputer): MyComputer {
   let nextId = 0;
-  // Each capability method takes exactly one argument and announces itself as
-  // it runs. The returned transport handles (getFetcher's { fetch }, the frame
-  // bridge) pass through untouched: per-request activity would mean reflecting
-  // over their methods, which changes what capnweb serializes back — the
-  // top-level getFetcher/connectSocket line is enough to show the computer's
-  // in use.
   const announce = (method: string, fn: (arg: never) => Promise<unknown>) => {
     return async (arg: never) => {
       const id = (nextId += 1);
@@ -337,31 +383,25 @@ function withActivity(capability: typeof myComputer): typeof myComputer {
       }
     };
   };
-  const wrapped = {} as Record<string, (arg: never) => Promise<unknown>>;
+  // Announce the human actions; pass the addressable origin's fetch/connectSocket
+  // through untouched (announcing every proxied request would flood the log).
+  const wrapped: Record<string, unknown> = { ...capability };
   for (const [method, fn] of Object.entries(capability)) {
-    wrapped[method] = announce(method, fn);
+    if (ANNOUNCED_METHODS.has(method) && typeof fn === "function") {
+      wrapped[method] = announce(method, fn as (arg: never) => Promise<unknown>);
+    }
   }
-  return wrapped as typeof myComputer;
+  return wrapped as MyComputer;
 }
 
 /** A short, human-readable line describing one call — for the app's activity log. */
 function summarizeCall(method: string, arg: unknown): string {
-  const input = (arg ?? {}) as {
-    question?: string;
-    message?: string;
-    code?: string;
-    port?: number;
-    path?: string;
-  };
+  const input = (arg ?? {}) as { question?: string; message?: string; code?: string };
   if (method === "ask") return truncate(input.question ?? "asked a question");
   if (method === "notify") return truncate(input.message ?? "sent a notification");
   if (method === "runSwift") {
     const lines = (input.code ?? "").split("\n").filter((line) => line.trim() !== "").length;
     return `ran ${lines} line${lines === 1 ? "" : "s"} of Swift`;
-  }
-  if (method === "getFetcher") return `lent an HTTP fetcher to localhost:${input.port}`;
-  if (method === "connectSocket") {
-    return `opened a WebSocket to localhost:${input.port}${input.path ?? "/"}`;
   }
   return method;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1007,6 +1007,9 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.16
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       tsdown:
         specifier: 0.22.2
         version: 0.22.2(@typescript/native-preview@7.0.0-dev.20260624.1)(oxc-resolver@11.19.1)(tsx@4.21.0)(typescript@5.9.3)


### PR DESCRIPTION
Spike: extend `iterate use-my-computer` so a shared computer can lend **servers**, not just dialogs — and settle experimentally what can and cannot cross capability dispatch for HTTP and WebSockets.

## What shipped

Two new methods on the `myComputer` live capability (`packages/iterate/src/use-my-computer.ts`):

- **`getFetcher({ port, host? })`** → `{ fetch(request) }` — proxies each `Request` to `http://127.0.0.1:<port>` on the shared machine and returns the `Response`. A project worker's homepage can literally be:

  ```ts
  const fetcher = await itx.myComputer.getFetcher({ port: 3000 });
  return await fetcher.fetch(req);
  ```

  Path + query travel through; the original host arrives as `x-forwarded-host`; redirects pass through untouched (`redirect: "manual"`); stale framing headers (`content-encoding` etc.) are stripped after undici's decompression. WebSocket upgrades are refused with a **teaching error** pointing at `connectSocket`, instead of dying deep in the mesh with the DataCloneError.

- **`connectSocket({ port, path?, onMessage?, onClose? })`** → `{ send, receive, close }` — the by-hand WebSocket **frame bridge** that `apps/os/docs/dynamic-worker-dispatch.md` described but nothing had ever shipped: the CLI opens the real socket to the local server, and a Durable Object app terminates the browser's socket with `WebSocketPair`, pumping frames both ways through the handle.

Plus: activity announcements for the new lanes in the menu-bar NDJSON protocol (handle methods announce as `getFetcher.fetch` / `connectSocket.send`, so the "in use" indicator sees the busiest lane), the CLI's paste-to-agent hint mentions the new powers, and the doc's live-capability section records the findings.

## Live proof (local dev, real CLI, real browser)

`pnpm dev` + `iterate use-my-computer --name jonasComputer` + a plain node server on the Mac (HTTP :8543, ws echo :8544), project worker committed with the forwarding homepage + a `WsBridgeApp` DO:

![live demo](https://raw.githubusercontent.com/iterate/iterate/assets/mac-fetcher-demo/live-proof.png)

The page is served from the Mac through the project host, and the log shows both websocket directions: the greeting frame originated on the Mac unprompted (CLI→DO callback push), and `mac-echo:hello-from-the-browser` is a full browser→Mac→browser round trip.

## E2e proof

New `apps/os/e2e/vitest/live-capability-fetcher.e2e.test.ts` provides the **real** capability object (`myComputerProvision` — the exact input the CLI sends, `types` string included, so the typed-mount gate compiles the new declaration on every run):

1. **Homepage proxy**: commits a worker whose homepage forwards through `getFetcher`, asserts the local server's body, path+query, and `x-forwarded-host` — and pins the upgrade teaching error.
2. **WebSocket bridge**: browser socket → `wsbridge` app host → DO → capability → local ws server, asserting the unprompted greeting **and** the echo round trip.

Both pass against local dev (13s). The neighbouring `live-capability-websocket.e2e.test.ts` still behaves exactly as documented: pinned DataCloneError + `test.fails` specification unchanged.

## Research: WebSockets through the capability tree

Question 2 of the spike ("do websockets work through that?") — the answer is **no for the socket itself, yes for the frames**:

- **The socket can never cross.** Confirmed unchanged: our capnweb fork tunnels a socket across the *session* as a stream pair, but the first internal workerd RPC hop refuses the materialized `WebSocket` (`Could not serialize object of type "WebSocket"` — pinned test). `getFetcher().fetch(upgradeReq)` therefore refuses upfront with instructions.
- **Frames cross fine, in both directions.** Two findings the e2e now pins, which were previously only conjecture in the doc:
  - **Callback stubs chain CLI→capability-host→DO and stay live** for the socket's lifetime, provided the CLI `dup()`s them (RPC params are released on return). This gives real-time push — no polling — for the local-server→browser direction.
  - **A Durable Object can hold the capability handle across events** (its I/O context spans the socket's life), so the browser-frame listener can call `handle.send` long after the upgrade request returned. A *stateless* worker could not do this — the bridge app must be a DO.
- The blessed end state remains the `test.fails` spec (keep the socket in stream-pair form across internal hops, materialize at the fetch-lane exit); this bridge is the workable-today form and is now documented as such in `dynamic-worker-dispatch.md`.

## Caveats / notes for review

- **Security shape**: `getFetcher`/`connectSocket` expose *any local port* to *every agent in the project* while the CLI runs. That is consistent with `runSwift` (which is strictly more powerful), and the human sees activity lines per request in the menu-bar app — but if we productize, a port allowlist at share time would be the obvious tightening.
- Bodies are buffered, not streamed, in both directions of `getFetcher` (fine for a spike; noted for SSE/large files).
- `connectSocket` bridges text frames only.
- **Preexisting breakage found (not fixed here)**: `packages/iterate/src/cli.test.ts` has 2 failing tests on main ("bin wrapper" / node strip-only loader) — `apps/os/src/domains/secrets/utils.ts:322` uses a constructor parameter property that node's strip-only TS loader rejects. Root `pnpm test` filters `!iterate`, so CI never sees it. Reproduced with pristine main sources; deserves its own small PR.
- The `value.trim()` fix in `askComputerName` is a latent nit surfaced because the new e2e file pulls `use-my-computer.ts` into apps/os's tsc program for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core project egress and capability-host fetch/WebSocket bridging; addressable mounts can expose arbitrary local ports to all project agents while the CLI runs, similar to runSwift but over new routing surface.
> 
> **Overview**
> Adds **addressable** live capabilities: opt-in mounts reachable by **`fetch("http://<name>.iterate/…")`** on the fetch lane instead of only **`itx.<name>`** RPC. Project egress parses `.iterate` hosts, dials the capability-host Durable Object with **`x-iterate-capability-dispatch`**, and **`serveCapabilityFetch`** proxies HTTP to the provider’s **`fetch`** or terminates WebSocket upgrades with **`WebSocketPair`** and bridges text frames via **`connectSocket`**.
> 
> **`iterate use-my-computer`** gains **`--expose-port`**, **`myComputerProvision`**, and **`use-my-computer-transport`** (local HTTP reverse proxy + frame bridge). A project worker can forward the whole homepage with one URL rewrite. Cross-project URLs are rejected at egress; mounts resolve case-insensitively.
> 
> Docs and e2e (`live-capability-fetcher`, optional `use-my-computer-story`) document that RPC still cannot carry socket-carrying upgrade responses; the URL path is the shipped WebSocket story.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6056709d8715d52b787509d4e7a07ae7d8bd8f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "deployed",
      "updatedAt": "2026-07-12T20:18:22.304Z",
      "headSha": "4c01a3079ed5a52fc43eedff26587f1c9af65ab8",
      "message": null,
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/407585749442093",
      "shortSha": "4c01a30",
      "deployDurationMs": 79597,
      "testDurationMs": 157607,
      "testRetries": "1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 15983.97,
      "workerGzipKib": 4312.17,
      "mainWorkerGzipKib": 4335.54
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "deployed",
      "updatedAt": "2026-07-12T20:15:50.518Z",
      "headSha": "4c01a3079ed5a52fc43eedff26587f1c9af65ab8",
      "message": null,
      "publicUrl": "https://semaphore.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/407585749442093",
      "shortSha": "4c01a30",
      "deployDurationMs": 13631,
      "testDurationMs": 5819,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "deployed",
      "updatedAt": "2026-07-12T20:15:45.344Z",
      "headSha": "4c01a3079ed5a52fc43eedff26587f1c9af65ab8",
      "message": null,
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/407585749442093",
      "shortSha": "4c01a30",
      "deployDurationMs": 19183,
      "testDurationMs": 643,
      "testRetries": null,
      "workerSizeKib": 4032.01,
      "workerGzipKib": 819.68,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "deployed",
      "updatedAt": "2026-07-12T20:16:03.931Z",
      "headSha": "4c01a3079ed5a52fc43eedff26587f1c9af65ab8",
      "message": null,
      "publicUrl": "https://streams.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/407585749442093",
      "shortSha": "4c01a30",
      "deployDurationMs": 13334,
      "testDurationMs": 19228,
      "testRetries": null,
      "workerSizeKib": 4842.75,
      "workerGzipKib": 1385.38,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_9",
    "leasedUntil": 1783973743667,
    "leaseId": "14c8a53c-6022-4def-b36b-d43e75718dfc",
    "slug": "preview-9",
    "type": "environment-config-lease"
  },
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>Lease: preview-9 | Doppler config: preview_9 | Type: environment-config-lease | Leased until: 2026-07-13T20:15:43.667Z</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | deployed | `4c01a30` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 819.7 KiB | 19.2s | 643ms |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/407585749442093) | 2026-07-12T20:15:45.344Z |  |
| OS | deployed | `4c01a30` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 4.21 MiB (-23.4 KiB vs main) | 79.6s | 157.6s | 1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/407585749442093) | 2026-07-12T20:18:22.304Z |  |
| Semaphore | deployed | `4c01a30` | [https://semaphore.iterate-preview-9.com](https://semaphore.iterate-preview-9.com) | 440.8 KiB | 13.6s | 5.8s |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/407585749442093) | 2026-07-12T20:15:50.518Z |  |
| Streams Example App | deployed | `4c01a30` | [https://streams.iterate-preview-9.com](https://streams.iterate-preview-9.com) | 1.35 MiB | 13.3s | 19.2s |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/407585749442093) | 2026-07-12T20:16:03.931Z |  |

</details>
<!-- /CLOUDFLARE_PREVIEW -->