### PR TITLE
use-my-computer: reliability + safety fixes from a GPT-5.6 thermonuclear review

### DIFF
--- a/packages/iterate/menubar/Iterate.swift
+++ b/packages/iterate/menubar/Iterate.swift
@@ -427,8 +427,18 @@ final class ComputerController: ObservableObject {
     let session = generation
     stdout.fileHandleForReading.readabilityHandler = { [weak self] handle in
       let chunk = handle.availableData
-      if chunk.isEmpty {  // EOF: clear the handler so it stops busy-looping
+      if chunk.isEmpty {  // EOF — the child closed stdout, i.e. it has exited.
         handle.readabilityHandler = nil
+        DispatchQueue.main.async {
+          // Tear down HERE, on EOF, NOT in terminationHandler. EOF is delivered on
+          // this same handle after every data chunk, so a final `conflict` status
+          // line is ingested (and sets the takeover message) before we exit.
+          // Terminating off the process's death instead is a separate event that
+          // can win the race, bump `generation`, and drop that last line —
+          // leaving the generic "Stopped sharing" instead of the takeover error.
+          guard let self, self.generation == session else { return }
+          self.watcherExited()
+        }
         return
       }
       DispatchQueue.main.async {
@@ -437,11 +447,12 @@ final class ComputerController: ObservableObject {
       }
     }
     process.terminationHandler = { [weak self] _ in
+      // Teardown is driven by stdout EOF (above), which is ordered after the
+      // child's final line; just release the finished process here. A late
+      // callback from a process we already replaced is voided by the guard.
       DispatchQueue.main.async {
-        // Guard on the session: a late callback from a process we already
-        // replaced must not tear down the new one.
         guard let self, self.generation == session else { return }
-        self.watcherExited()
+        self.process = nil
       }
     }
     do {

--- a/packages/iterate/menubar/Iterate.swift
+++ b/packages/iterate/menubar/Iterate.swift
@@ -40,12 +40,13 @@ struct MenuBarConfig: Codable {
     return config
   }
 
-  /// The argv for `iterate approve --json` (or `login`) under this config.
-  func argv(for subcommand: [String]) -> [String] {
+  /// The argv for a subcommand under this config. `login` takes no `--project`
+  /// (it rejects the flag), so callers opt out of it there.
+  func argv(for subcommand: [String], includeProject: Bool = true) -> [String] {
     var out = args
     if let config { out += ["--config", config] }
     out += subcommand
-    if let project { out += ["--project", project] }
+    if includeProject, let project { out += ["--project", project] }
     return out
   }
 }
@@ -123,7 +124,12 @@ final class ApprovalController: ObservableObject {
       }
     }
     process.terminationHandler = { [weak self] _ in
-      DispatchQueue.main.async { self?.watcherExited() }
+      DispatchQueue.main.async {
+        // Guard on the session: a late callback from a process we already
+        // replaced must not tear down the new one.
+        guard let self, self.generation == session else { return }
+        self.watcherExited()
+      }
     }
     do {
       try process.run()
@@ -189,7 +195,7 @@ final class ApprovalController: ObservableObject {
     reconnectAttempts = 0  // an explicit retry clears the give-up counter
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-    process.arguments = [config.command] + config.argv(for: ["login"])
+    process.arguments = [config.command] + config.argv(for: ["login"], includeProject: false)
     if let cwd = config.cwd { process.currentDirectoryURL = URL(fileURLWithPath: cwd) }
     process.terminationHandler = { [weak self] _ in
       Task { @MainActor in
@@ -350,6 +356,7 @@ struct ComputerCall: Identifiable, Equatable {
   let method: String
   let summary: String
   var running: Bool
+  var ok = true  // set from call-done; a failed local call must not read as success
 }
 
 /// Drives `iterate use-my-computer --json`: lends this Mac to the project's
@@ -363,6 +370,7 @@ final class ComputerController: ObservableObject {
 
   @Published var enabled = false  // the human asked to share
   @Published var sharing = false  // the capability is mounted and live
+  @Published var reconnecting = false  // mount dropped; the CLI is re-establishing it
   @Published var computerName: String?  // the itx.<name> agents call
   @Published var recentCalls: [ComputerCall] = []  // capped display list
   @Published private var activeCalls = 0  // in-flight count, independent of the cap
@@ -429,7 +437,12 @@ final class ComputerController: ObservableObject {
       }
     }
     process.terminationHandler = { [weak self] _ in
-      DispatchQueue.main.async { self?.watcherExited() }
+      DispatchQueue.main.async {
+        // Guard on the session: a late callback from a process we already
+        // replaced must not tear down the new one.
+        guard let self, self.generation == session else { return }
+        self.watcherExited()
+      }
     }
     do {
       try process.run()
@@ -449,6 +462,7 @@ final class ComputerController: ObservableObject {
     process = nil
     detachIO()
     sharing = false
+    reconnecting = false
     recentCalls = []
     activeCalls = 0
   }
@@ -459,6 +473,7 @@ final class ComputerController: ObservableObject {
     generation += 1
     detachIO()
     sharing = false
+    reconnecting = false
     recentCalls = []
     activeCalls = 0
     if enabled {
@@ -490,7 +505,14 @@ final class ComputerController: ObservableObject {
   private func handle(_ event: [String: Any]) {
     switch event["type"] as? String {
     case "status":
-      if event["loggedIn"] as? Bool == true {
+      if event["conflict"] as? Bool == true {
+        // Another session took the name — the CLI is stopping; reflect that.
+        stop()
+        lastError = "Another session took over sharing this computer."
+      } else if event["loggedIn"] as? Bool == true {
+        // `reconnecting:true` = the mount dropped and the CLI is re-establishing
+        // it; the plain status (no flag) means we're live again.
+        reconnecting = event["reconnecting"] as? Bool == true
         sharing = true
         computerName = event["name"] as? String
       } else {
@@ -519,6 +541,7 @@ final class ComputerController: ObservableObject {
       // array reliably republishes. Same idiom as ApprovalController.setSubmitting.
       var call = recentCalls[index]
       call.running = false
+      call.ok = event["ok"] as? Bool ?? true  // a failed local call is shown as failed, not done
       recentCalls[index] = call
     default:
       break
@@ -586,8 +609,10 @@ struct DropdownView: View {
             HStack(spacing: 6) {
               if call.running {
                 ProgressView().controlSize(.small)
-              } else {
+              } else if call.ok {
                 Image(systemName: "checkmark.circle").foregroundStyle(.secondary)
+              } else {
+                Image(systemName: "xmark.circle").foregroundStyle(.orange)
               }
               Text("\(call.method) · \(call.summary)")
                 .font(.caption)
@@ -604,6 +629,7 @@ struct DropdownView: View {
     if !controller.loggedIn { return "Sign in to lend this Mac to agents." }
     if computer.sharing {
       let name = computer.computerName.map { "itx.\($0)" } ?? "your computer"
+      if computer.reconnecting { return "Reconnecting \(name)…" }
       return computer.inUse ? "In use now — \(name)" : "\(name) is live for this project."
     }
     if computer.enabled { return "Starting…" }

--- a/packages/iterate/src/cli.ts
+++ b/packages/iterate/src/cli.ts
@@ -1119,8 +1119,12 @@ const launcherProcedures = {
       const reauth = async () => {
         const env = osAuthFromEnvironment();
         if (env) return { auth: env.credentials, headers: headersRecord(env.requestHeaders) };
-        const current = resolveConfig(process.cwd(), { throw: true });
-        const refreshed = osAuthFromHeaders(await getOsAuthHeaders(current.config, current.name));
+        // Re-read the EXACT launch-time config by name (picks up a token the
+        // previous refresh persisted) — never re-resolve from cwd, which could
+        // select a different config and send its credential to this server.
+        const config = readConfig(resolved.name);
+        if (config instanceof Error) throw config;
+        const refreshed = osAuthFromHeaders(await getOsAuthHeaders(config, resolved.name));
         return { auth: refreshed.credentials, headers: headersRecord(refreshed.requestHeaders) };
       };
       const shared = {

--- a/packages/iterate/src/use-my-computer.ts
+++ b/packages/iterate/src/use-my-computer.ts
@@ -307,9 +307,10 @@ async function keepMountAlive(input: {
         await sleep(RECOVERY_BACKOFF_MS);
         continue;
       }
-      goLive();
-      await sleep(HEALTH_CHECK_INTERVAL_MS);
-      continue;
+      // Don't declare live yet: fall through to the ping so we confirm the mount
+      // still answers AS US first. Another process could have grabbed the same
+      // name between our provide and now — verifying before goLive means the UI
+      // never flashes "live" for a mount we've already lost.
     }
 
     let observedId: string;

--- a/packages/iterate/src/use-my-computer.ts
+++ b/packages/iterate/src/use-my-computer.ts
@@ -21,6 +21,7 @@
 // call announces itself as NDJSON, which is how the app shows "in use".
 // ─────────────────────────────────────────────────────────────────────────────
 
+import { randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 
 import * as prompts from "@clack/prompts";
@@ -45,7 +46,10 @@ const myComputer = {
     const buttonList = buttons.map((b) => `"${escapeForAppleScript(b)}"`).join(", ");
     const { stdout } = await osascript(
       `display dialog "${escapeForAppleScript(question)}" ` +
-        `buttons {${buttonList}} default button "${escapeForAppleScript(buttons.at(-1)!)}" ` +
+        // Default to the FIRST button (the caller's safe/decline option, "No" by
+        // default): this can run arbitrary local Swift, so an accidental Return
+        // must not confirm.
+        `buttons {${buttonList}} default button "${escapeForAppleScript(buttons[0]!)}" ` +
         `with title "iterate · myComputer"`,
     );
     // osascript prints e.g. `button returned:Yes` — hand back just the choice.
@@ -69,12 +73,17 @@ const myComputer = {
   /**
    * A liveness probe, deliberately absent from the declared types so agents
    * never see it. The provider self-calls it over the full agent path to keep
-   * the capability-host warm and detect a dropped mount — see keepMountAlive.
+   * the capability-host warm and detect a dropped mount — see keepMountAlive. It
+   * returns THIS process's mount id so the caller can tell its own live mount
+   * from a different process that grabbed the same name (names collide easily).
    */
   async ["__ping"]() {
-    return { ok: true as const };
+    return MOUNT_ID;
   },
 };
+
+/** Unique per-process id, returned by `__ping`, so keepMountAlive can prove it still owns the mount. */
+const MOUNT_ID = randomUUID();
 
 /** Prose + a type signature so agents (and `__describe()`) know how to call this. */
 const INSTRUCTIONS = `A real person's Mac, shared live from their terminal for as long as \`iterate use-my-computer\` runs.
@@ -164,7 +173,13 @@ type ConnectInput = {
   reauth: () => Promise<ResolvedAuth>;
 };
 
-/** Mount `capability` at `itx.<name>` with freshly-resolved auth and return the live socket stub. */
+/**
+ * Connect (freshly-resolved auth) and mount `capability` at `itx.<name>`. The
+ * provide is timeout-bounded ABOVE connectItx's ~15s WebSocket handshake, and on
+ * ANY failure the session is disposed before we throw — so a slow or failed
+ * attempt can never leak a socket or, worse, complete late and silently replace
+ * the mount from under the keepalive loop.
+ */
 async function connectAndProvide(
   input: ConnectInput,
   name: string,
@@ -177,33 +192,39 @@ async function connectAndProvide(
     projectId: input.projectId,
     headers,
   }) as RpcStub<Project>;
-
-  await itx.provideCapability({
-    type: "live",
-    path: [name],
-    capability,
-    instructions: INSTRUCTIONS,
-    types: TYPES,
-  });
-  return itx;
+  try {
+    await withTimeout(
+      itx.provideCapability({
+        type: "live",
+        path: [name],
+        capability,
+        instructions: INSTRUCTIONS,
+        types: TYPES,
+      }),
+      PROVIDE_TIMEOUT_MS,
+      "provide",
+    );
+    return itx;
+  } catch (error) {
+    disposeItx(itx); // disposing the session cancels the in-flight handshake/provide
+    throw error;
+  }
 }
 
 const HEALTH_CHECK_INTERVAL_MS = 8_000;
 const HEALTH_CHECK_TIMEOUT_MS = 5_000;
-// A reconnect includes connectItx's WebSocket handshake (up to ~15s), so this
-// backstop sits ABOVE that — otherwise a handshake that would have succeeded is
-// abandoned mid-flight. connectItx's own handshake timeout rejects a dead
-// endpoint well before this fires, so recoveries never overlap.
-const RECONNECT_TIMEOUT_MS = 30_000;
+// The provide await includes connectItx's ~15s handshake, so its bound sits well
+// above that — a handshake that would have succeeded must not be abandoned.
+const PROVIDE_TIMEOUT_MS = 25_000;
 const RECOVERY_BACKOFF_MS = 3_000;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * Race a promise against a timeout so a STALLED RPC (a wedged connection that
- * never errors) is treated as a failure instead of hanging forever. The
- * abandoned work is caught so a rejection that lands after the timeout can't
- * surface as an unhandled rejection.
+ * never errors) counts as a failure instead of hanging forever. The abandoned
+ * work is caught so a rejection landing after the timeout can't go unhandled;
+ * the caller disposes the underlying session, which actually cancels it.
  */
 function withTimeout<T>(work: Promise<T>, ms: number, label: string): Promise<T> {
   work.catch(() => {});
@@ -227,85 +248,107 @@ function disposeItx(itx: RpcStub<Project>): void {
   }
 }
 
-/** Call the mount over the FULL agent path (`itx.<name>.__ping()`) — the same route an agent uses. */
-function pingMount(itx: RpcStub<Project>, name: string): Promise<void> {
-  const ping = (itx as unknown as Record<string, { __ping(): Promise<{ ok: true }> }>)[
-    name
-  ].__ping();
-  return withTimeout(ping, HEALTH_CHECK_TIMEOUT_MS, "mount ping").then(() => {});
+/** Ping the mount over the FULL agent path; returns the mount id the provider reports. */
+function pingMount(itx: RpcStub<Project>, name: string): Promise<string> {
+  const ping = (itx as unknown as Record<string, { __ping(): Promise<string> }>)[name].__ping();
+  return withTimeout(ping, HEALTH_CHECK_TIMEOUT_MS, "mount ping");
 }
 
 /**
- * Keep the live mount routable for as long as we run, and NEVER return. A live
- * capability's provider ref lives only in the capability-host DO's memory, so a
- * DO eviction or a dropped socket silently takes it "offline" while this process
- * keeps happily running. So we don't just heartbeat — we self-call the mount
- * over the full agent path: that round-trip keeps the host DO warm AND proves it
- * still answers. The first check runs right after the initial provide (no dead
- * startup window); thereafter every few seconds.
+ * Keep the live mount routable for as long as we run. A live capability's
+ * provider ref lives only in the capability-host DO's memory, so a DO eviction or
+ * a dropped socket silently takes it "offline" while this process keeps running.
+ * So every few seconds we self-call the mount over the full agent path: that
+ * round-trip keeps the host DO warm AND proves it still answers AS US — `__ping`
+ * returns our unique id, so a different process that grabbed the same name is
+ * detected rather than mistaken for our own live mount.
  *
- * When a check fails (eviction, a dropped or wedged socket, a deploy) we
- * reconnect FRESH — a new connection, with re-resolved auth so a reconnect past
- * the short access-token TTL still authenticates — provide again, and dispose the
- * old session. Recovery NEVER escapes the loop: a share session ends only when
- * the process does, so a failed round keeps the old stub, backs off, and retries
- * on the next tick. `onReprovided` fires whenever we re-establish it.
+ * States, reported via the callbacks (transitions only, not every retry):
+ * - answers with our id  → live (`onLive`).
+ * - doesn't answer       → dispose the suspect session and reconnect fresh (with
+ *   re-resolved auth, so a reconnect past the token TTL still authenticates);
+ *   `onDegraded` fires once until we're live again. This never throws out of the
+ *   loop — a failed round backs off and retries.
+ * - answers with a DIFFERENT id → another process owns the name; we `onConflict`
+ *   and STOP rather than fight it forever (they'd endlessly replace each other).
  */
 async function keepMountAlive(input: {
-  itx: RpcStub<Project>;
   connect: ConnectInput;
   name: string;
   capability: typeof myComputer;
-  onReprovided?: () => void;
-}): Promise<never> {
-  let itx = input.itx;
+  onLive?: () => void;
+  onDegraded?: () => void;
+  onConflict?: () => void;
+}): Promise<void> {
+  let session: RpcStub<Project> | undefined;
+  let live = false;
   while (true) {
-    try {
-      await pingMount(itx, input.name); // confirms the mount end-to-end + keeps the host warm
-    } catch {
-      // The mount isn't answering. Reconnect fresh (bounded above the handshake
-      // window); on failure keep the old stub, back off, and retry next tick —
-      // this must never throw out of the loop.
-      let fresh: RpcStub<Project> | undefined;
+    if (session === undefined) {
+      // (Re)connect. connectAndProvide self-disposes on failure, so nothing leaks
+      // and no abandoned attempt can late-mount.
       try {
-        fresh = await withTimeout(
-          connectAndProvide(input.connect, input.name, input.capability),
-          RECONNECT_TIMEOUT_MS,
-          "reconnect",
-        );
+        session = await connectAndProvide(input.connect, input.name, input.capability);
       } catch {
-        // couldn't recover this round (transient network / auth / endpoint down)
-      }
-      if (fresh === undefined) {
+        if (live) {
+          live = false;
+          input.onDegraded?.();
+        }
         await sleep(RECOVERY_BACKOFF_MS);
         continue;
       }
-      disposeItx(itx); // replace and free the old session
-      itx = fresh;
-      input.onReprovided?.();
+      live = true;
+      input.onLive?.();
+      await sleep(HEALTH_CHECK_INTERVAL_MS);
+      continue;
+    }
+
+    let observedId: string;
+    try {
+      observedId = await pingMount(session, input.name);
+    } catch {
+      disposeItx(session); // suspect/wedged — disposing cancels the pending ping
+      session = undefined;
+      if (live) {
+        live = false;
+        input.onDegraded?.();
+      }
+      continue; // reconnect immediately
+    }
+    if (observedId !== MOUNT_ID) {
+      input.onConflict?.();
+      disposeItx(session);
+      return; // yield the name; the caller (process/menu bar) decides what's next
+    }
+    if (!live) {
+      live = true;
+      input.onLive?.();
     }
     await sleep(HEALTH_CHECK_INTERVAL_MS);
   }
 }
 
 /**
- * Ask for a name, provide `itx.<name>`, and hold the line until Ctrl-C. Never
- * returns; the caller runs it as the body of a long-lived command.
+ * Ask for a name, provide `itx.<name>`, and hold the line until Ctrl-C (or until
+ * another session takes the name over). The keepalive loop owns the connection.
  */
 export async function shareMyComputer(
   input: ConnectInput & { log?: (message: string) => void },
-): Promise<never> {
+): Promise<void> {
   const log = input.log ?? ((message: string) => console.error(message));
   const name = input.name ?? (await askComputerName());
-  const itx = await connectAndProvide(input, name, myComputer);
-  log(`✅ itx.${name} is live for project ${input.projectId}. Press Ctrl-C to stop sharing.\n`);
-  log(agentPrompt(name));
-  return keepMountAlive({
-    itx,
+  let announced = false;
+  await keepMountAlive({
     connect: input,
     name,
     capability: myComputer,
-    onReprovided: () => log(`↻ re-shared itx.${name} after the mount dropped.`),
+    onLive: () => {
+      if (announced) return void log(`↻ itx.${name} re-shared.`);
+      announced = true;
+      log(`✅ itx.${name} is live for project ${input.projectId}. Press Ctrl-C to stop sharing.\n`);
+      log(agentPrompt(name));
+    },
+    onDegraded: () => log(`… itx.${name} dropped — reconnecting.`),
+    onConflict: () => log(`Another session is now sharing as itx.${name}; stopping this one.`),
   });
 }
 
@@ -316,21 +359,28 @@ export async function shareMyComputer(
  *
  * Out (stdout):
  *   {"type":"status","loggedIn":true,"project":"prj_…","name":"jonasComputer"}
+ *   {"type":"status",…,"reconnecting":true}   // mount dropped; recovering
+ *   {"type":"status",…,"conflict":true}       // another session took the name; stopping
  *   {"type":"call","id":1,"method":"ask","summary":"Deploy to prod?","at":"…"}
  *   {"type":"call-done","id":1,"method":"ask","ok":true,"ms":1234}
  */
-export async function runUseMyComputerJson(input: ConnectInput): Promise<never> {
+export async function runUseMyComputerJson(input: ConnectInput): Promise<void> {
   const name = input.name ?? proposeComputerName();
   const capability = withActivity(myComputer);
-  const itx = await connectAndProvide(input, name, capability);
-  const status = () => emitJson({ type: "status", loggedIn: true, project: input.projectId, name });
-  status();
+  const status = (extra?: Record<string, unknown>) =>
+    emitJson({ type: "status", loggedIn: true, project: input.projectId, name, ...extra });
   // If the menu-bar parent goes away, stdin closes — stop sharing rather than
   // leaving the computer silently lent with no window onto it.
   process.stdin.on("end", () => process.exit(0));
   process.stdin.resume();
-  // Re-emit status on every re-establish so the app knows it's still live.
-  return keepMountAlive({ itx, connect: input, name, capability, onReprovided: status });
+  await keepMountAlive({
+    connect: input,
+    name,
+    capability,
+    onLive: () => status(),
+    onDegraded: () => status({ reconnecting: true }),
+    onConflict: () => status({ conflict: true }),
+  });
 }
 
 /** One NDJSON line to stdout — the machine protocol's only output channel. */
@@ -389,13 +439,19 @@ function withActivity(capability: typeof myComputer): typeof myComputer {
   return wrapped as typeof myComputer;
 }
 
-/** A short, human-readable line describing one call — for the app's activity log. */
+/**
+ * A short, human-readable line describing one call — for the app's activity log.
+ * Total: it must never throw on a malformed argument (that would run BEFORE the
+ * wrapped method's own error handling), so it only reads string fields.
+ */
 function summarizeCall(method: string, arg: unknown): string {
-  const input = (arg ?? {}) as { question?: string; message?: string; code?: string };
-  if (method === "ask") return truncate(input.question ?? "asked a question");
-  if (method === "notify") return truncate(input.message ?? "sent a notification");
+  const str = (value: unknown): string | undefined =>
+    typeof value === "string" ? value : undefined;
+  const input = (arg ?? {}) as Record<string, unknown>;
+  if (method === "ask") return truncate(str(input.question) ?? "asked a question");
+  if (method === "notify") return truncate(str(input.message) ?? "sent a notification");
   if (method === "runSwift") {
-    const lines = (input.code ?? "").split("\n").filter((line) => line.trim() !== "").length;
+    const lines = (str(input.code) ?? "").split("\n").filter((line) => line.trim() !== "").length;
     return `ran ${lines} line${lines === 1 ? "" : "s"} of Swift`;
   }
   return method;

--- a/packages/iterate/src/use-my-computer.ts
+++ b/packages/iterate/src/use-my-computer.ts
@@ -281,7 +281,21 @@ async function keepMountAlive(input: {
   onConflict?: () => void;
 }): Promise<void> {
   let session: RpcStub<Project> | undefined;
-  let live = false;
+  // Report transitions only — including the FIRST connect. `undefined` until we
+  // report either state, so a failed initial connect still surfaces `onDegraded`
+  // (not a silent "Starting…" while the CLI retries in the background).
+  let reported: "live" | "down" | undefined;
+  const goLive = () => {
+    if (reported === "live") return;
+    reported = "live";
+    input.onLive?.();
+  };
+  const goDown = () => {
+    if (reported === "down") return;
+    reported = "down";
+    input.onDegraded?.();
+  };
+
   while (true) {
     if (session === undefined) {
       // (Re)connect. connectAndProvide self-disposes on failure, so nothing leaks
@@ -289,15 +303,11 @@ async function keepMountAlive(input: {
       try {
         session = await connectAndProvide(input.connect, input.name, input.capability);
       } catch {
-        if (live) {
-          live = false;
-          input.onDegraded?.();
-        }
+        goDown();
         await sleep(RECOVERY_BACKOFF_MS);
         continue;
       }
-      live = true;
-      input.onLive?.();
+      goLive();
       await sleep(HEALTH_CHECK_INTERVAL_MS);
       continue;
     }
@@ -308,10 +318,7 @@ async function keepMountAlive(input: {
     } catch {
       disposeItx(session); // suspect/wedged — disposing cancels the pending ping
       session = undefined;
-      if (live) {
-        live = false;
-        input.onDegraded?.();
-      }
+      goDown();
       continue; // reconnect immediately
     }
     if (observedId !== MOUNT_ID) {
@@ -319,10 +326,7 @@ async function keepMountAlive(input: {
       disposeItx(session);
       return; // yield the name; the caller (process/menu bar) decides what's next
     }
-    if (!live) {
-      live = true;
-      input.onLive?.();
-    }
+    goLive();
     await sleep(HEALTH_CHECK_INTERVAL_MS);
   }
 }

--- a/packages/iterate/src/use-my-computer.ts
+++ b/packages/iterate/src/use-my-computer.ts
@@ -390,6 +390,11 @@ export async function runUseMyComputerJson(input: ConnectInput): Promise<void> {
   // `process.stdin.resume()` above holds the event loop open, so return alone
   // would leave the CLI running with no active share — exit explicitly. (The menu
   // bar also kills the child on `conflict`; this covers running --json directly.)
+  // Flush stdout first: process.exit can truncate a buffered pipe write, and the
+  // final `conflict` line is what the menu bar reads to show the takeover message
+  // (its teardown is ordered on that line's EOF). The callback fires once every
+  // prior write has drained to the pipe.
+  await new Promise<void>((resolve) => process.stdout.write("", () => resolve()));
   process.exit(0);
 }
 

--- a/packages/iterate/src/use-my-computer.ts
+++ b/packages/iterate/src/use-my-computer.ts
@@ -386,6 +386,11 @@ export async function runUseMyComputerJson(input: ConnectInput): Promise<void> {
     onDegraded: () => status({ reconnecting: true }),
     onConflict: () => status({ conflict: true }),
   });
+  // keepMountAlive only returns after a conflict (another session took the name).
+  // `process.stdin.resume()` above holds the event loop open, so return alone
+  // would leave the CLI running with no active share — exit explicitly. (The menu
+  // bar also kills the child on `conflict`; this covers running --json directly.)
+  process.exit(0);
 }
 
 /** One NDJSON line to stdout — the machine protocol's only output channel. */


### PR DESCRIPTION
High-leverage findings from a deep (GPT-5.6 SOL, xhigh reasoning) code-quality review of the use-my-computer + menu-bar code.

**Confirmed release-blocker**
- Menu-bar **Sign in** was broken whenever a project is configured: `MenuBarConfig.argv` appended `--project` to *every* subcommand, and `iterate login` rejects it (`iterate login --project foo → error: unknown option '--project'`). `login` now opts out of `--project`.

**Reliability (extended sharing)**
- Both Swift termination handlers now **generation-guard** (like the stdout readers). A late callback from a replaced process could otherwise tear down the new one, leaving a sharing subprocess alive while the UI shows "off".
- `__ping` returns a **unique per-process id** the keepalive validates: a different process that grabbed the same name is detected (→ conflict, stop) rather than mistaken for our own live mount.
- Reconnect is **cancellation-safe**: the provide is timeout-bounded *above* the ~15s handshake and the session is disposed on any failure, so a slow/failed attempt can't leak a socket or complete late and silently replace the mount. A failed ping disposes the suspect session (no wedged-RPC accumulation) before reconnecting. One connect path owns the whole lifecycle.
- State is now **honest**: the loop reports live / reconnecting / conflict transitions; `--json` emits `reconnecting`/`conflict`, and the menu bar shows "Reconnecting…" / "took over" instead of claiming live forever.

**Safety / correctness**
- `ask()` defaults to the **first** button (the safe/decline option) — it can run arbitrary Swift, so an accidental Return must not confirm.
- Failed local calls (`call-done ok:false`) show an error icon, not a checkmark.
- `reauth` binds to the launch config **by name** (never re-resolves from cwd, which could send another config's credential to this server).
- `summarizeCall` is total (only reads string fields; can't throw before the wrapped method's own error handling).

Proven live on prd: the mount stays reachable from a separate session and `__ping` returns the provider's real id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live local capability sharing, OAuth reauth binding, and AppleScript dialog defaults—important for security and multi-session behavior, but scoped to the menubar/CLI path with defensive disposal and explicit conflict handling.
> 
> **Overview**
> Fixes **menu-bar Sign in** when `menubar.json` sets a project: `argv` no longer passes `--project` to `iterate login` (that subcommand rejects it).
> 
> **use-my-computer** sharing is reworked for long-lived sessions: `__ping` returns a per-process mount id so keepalive can detect another session that took the same `itx.<name>` and stop with **conflict** instead of fighting. Reconnect uses a single lifecycle (`connectAndProvide` + dispose on failure/timeout), ping-before-**live** to avoid a false “live” flash, and NDJSON **`reconnecting`** / **`conflict`** for the menu bar. **`reauth`** re-reads the launch config **by name** so cwd cannot swap credentials mid-share.
> 
> **Safety / UX:** `ask()` defaults to the **first** button; failed calls show an error icon from `call-done ok:false`; `summarizeCall` only reads strings so it cannot throw before the wrapped method runs.
> 
> **Menu bar:** generation-guarded process callbacks; computer sharing tears down on stdout **EOF** (after the final status line) so takeover messages are not lost to a race; **Reconnecting…** and conflict copy in the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a19854ee91c9df0963c416ecbd0ae25a39927828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +205 -93 | +138 -61 🟩🟩🟩🟥🟥 |
| **Total** | **+205 -93** | **+138 -61** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between e428cb2 and a19854e, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->