### PR TITLE
Harden secret paths + collect-link egress (codex thermonuclear review)

### DIFF
--- a/apps/os/src/domains/secrets/utils.test.ts
+++ b/apps/os/src/domains/secrets/utils.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, test } from "vitest";
 import {
   computeHmacHex,
   computeSignatureBase64Url,
+  normalizeSecretPath,
   secretReferencePathsFromRequest,
   secretReferencesFromHeaders,
   secretReferencesFromRequest,
@@ -15,6 +16,38 @@ import {
   substituteSecretRequest,
   timingSafeStringEqual,
 } from "./utils.ts";
+
+describe("normalizeSecretPath", () => {
+  test("accepts canonical secret paths (bare name and sub-path)", () => {
+    expect(normalizeSecretPath("/secrets/acme")).toBe("/secrets/acme");
+    expect(normalizeSecretPath("secrets/acme")).toBe("/secrets/acme");
+    expect(normalizeSecretPath("/secrets/github/app-1")).toBe("/secrets/github/app-1");
+    expect(normalizeSecretPath("/secrets/oauth.token_v2")).toBe("/secrets/oauth.token_v2");
+  });
+
+  test("rejects paths outside /secrets/", () => {
+    expect(() => normalizeSecretPath("/agents/victim")).toThrow(/must start with/);
+  });
+
+  // The path becomes a Durable Object name reparsed with WHATWG URL, which
+  // collapses dot segments and splits on ?/# — so a path that survives here
+  // but changes under URL parsing would address a different object than the
+  // one displayed. These must all be rejected, not silently rewritten.
+  test.each([
+    "/secrets/../agents/victim",
+    "/secrets/./x",
+    "/secrets/x/../y",
+    "/secrets/a?b",
+    "/secrets/a#f",
+    "/secrets/a%2e%2e/b",
+    "/secrets/a b",
+    "/secrets/a\\b",
+    "/secrets/x/",
+    "/secrets//y",
+  ])("rejects non-canonical path %j", (path) => {
+    expect(() => normalizeSecretPath(path)).toThrow();
+  });
+});
 
 describe("selectSecretField", () => {
   test("no field returns whole material iff it is a string", () => {

--- a/apps/os/src/domains/secrets/utils.ts
+++ b/apps/os/src/domains/secrets/utils.ts
@@ -38,6 +38,21 @@ export function normalizeSecretPath(path: string): string {
   if (!normalized.startsWith("/secrets/")) {
     throw new Error(`secret path must start with "/secrets/", got "${normalized}"`);
   }
+  // A secret path becomes a Durable Object name (`durable-object-names.ts`),
+  // and that name is reparsed with WHATWG `URL` — which collapses `.`/`..`
+  // segments and splits on `?`/`#`. So `/secrets/../agents/x` addresses one DO
+  // but reparses to a DIFFERENT path than the one shown in audit/UI. Reject
+  // anything non-canonical in this shared helper (every secret op flows
+  // through it) so the addressed path and the displayed path cannot diverge.
+  // eslint-disable-next-line no-control-regex -- control chars are exactly what we reject
+  if (/[\u0000-\u0020\u007f?#%\\]/.test(normalized)) {
+    throw new Error(`secret path has an illegal character: "${normalized}"`);
+  }
+  for (const segment of normalized.slice(1).split("/")) {
+    if (segment === "" || segment === "." || segment === "..") {
+      throw new Error(`secret path has an empty or dot segment: "${normalized}"`);
+    }
+  }
   return normalized;
 }
 

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -1704,29 +1704,36 @@ class SecretCollectionRpcTarget extends IterateRpcTarget<"SecretCollection"> {
     if (!path.isWellFormed()) {
       throw new Error("collectFromUser paths must be well-formed strings (no lone surrogates).");
     }
-    const egressUrls = [...new Set(input.egress.urls)];
-    if (egressUrls.length === 0) {
+    if (input.egress.urls.length === 0) {
       throw new Error(
         "collectFromUser needs at least one egress URL: the user is shown where the value can ever be sent, and a secret pinned to nothing can never be used.",
       );
     }
-    // Validate the pin at mint, so a bad list fails on the caller that can
-    // fix it — not as a raw "Invalid URL" in the user's face at submit time.
-    // Userinfo is rejected: it would ride a plaintext, shareable chat URL
-    // while origin-pinning ignores it anyway.
-    for (const url of egressUrls) {
-      const parsed = URL.canParse(url) ? new URL(url) : null;
-      if (parsed === null || !/^https?:$/.test(parsed.protocol)) {
-        throw new Error(
-          `collectFromUser egress URLs must be absolute http(s) URLs; got ${JSON.stringify(url)}.`,
-        );
-      }
-      if (parsed.username !== "" || parsed.password !== "") {
-        throw new Error(
-          `collectFromUser egress URLs must not carry credentials; got ${JSON.stringify(url)}.`,
-        );
-      }
-    }
+    // Pin to ORIGINS, not URLs. Enforcement (assertOriginPinned) only ever
+    // compares origins, so a pin of "https://api.acme.com/safe" would in fact
+    // authorize the whole origin — the page must not display a promise
+    // narrower than what is enforced. Normalizing here also dedupes. Userinfo
+    // is rejected: it would ride a plaintext, shareable chat URL while
+    // origin-pinning ignores it anyway. Bad input fails on the caller that can
+    // fix it, not as a raw "Invalid URL" in the user's face at submit time.
+    const egressOrigins = [
+      ...new Set(
+        input.egress.urls.map((url) => {
+          const parsed = URL.canParse(url) ? new URL(url) : null;
+          if (parsed === null || !/^https?:$/.test(parsed.protocol)) {
+            throw new Error(
+              `collectFromUser egress URLs must be absolute http(s) URLs; got ${JSON.stringify(url)}.`,
+            );
+          }
+          if (parsed.username !== "" || parsed.password !== "") {
+            throw new Error(
+              `collectFromUser egress URLs must not carry credentials; got ${JSON.stringify(url)}.`,
+            );
+          }
+          return parsed.origin;
+        }),
+      ),
+    ];
     const project = await readProjectById(env.PROJECT_DIRECTORY, this.props.projectId);
     if (!project?.slug) {
       throw new Error(`Project ${this.props.projectId} has no slug; cannot build a page URL.`);
@@ -1743,7 +1750,7 @@ class SecretCollectionRpcTarget extends IterateRpcTarget<"SecretCollection"> {
       projectSlug: project.slug,
       search: {
         path,
-        egress: egressUrls,
+        egress: egressOrigins,
         ...(input.description === undefined ? {} : { description: input.description }),
         ...(scopePath.startsWith("/agents/") ? { notify: scopePath } : {}),
       },


### PR DESCRIPTION
Follow-up to #1889/#1896. A deep code-quality + security review (codex, gpt-5.6-sol, extra-high reasoning) of the collect-secret feature surfaced several findings; this PR lands the two that are cheap, unambiguously correct, and belong in the canonical layer. The larger structural items are deferred and listed below for a decision.

## Landed

**1. `normalizeSecretPath` rejects non-canonical paths (canonical helper — hardens every secret op).**
A secret path becomes a Durable Object name, and that name is reparsed with WHATWG `URL`, which collapses `.`/`..` segments and splits on `?`/`#`. So `/secrets/../agents/x` addressed one object but reparsed to a *different* path than the one shown in audit/UI — an identity-confusion gap. The shared helper now rejects dot/empty segments, whitespace, control chars, and `?`/`#`/`%`/`\`. 10 rejection cases added; existing canonical paths (`/secrets/github/app-1`, `/secrets/oauth.token_v2`) still pass.

**2. `collectFromUser` pins egress to ORIGINS, not URLs.**
Enforcement (`assertOriginPinned`) only ever compares origins, so a pin of `https://api.acme.com/safe` in fact authorized the whole origin. The collect page displayed the full URL — a promise narrower than what's enforced. Normalizing to `.origin` at mint makes the displayed promise match enforcement exactly, and dedupes.

## Deferred (change the feature's shape — flagging for a decision, not doing here)

- **Signed / one-use collection token** instead of the current unsigned, replayable link whose `path`/`egress`/`notify`/`description` are all editable query params. The link is gated behind org-membership + project access, so only an already-authorized member can act on it, but a crafted link could still trick that member into overwriting the wrong secret, repinning egress, or notifying an arbitrary agent.
- **Compare-and-set overwrite** semantics (the current overwrite warning is a TOCTOU read, not an invariant).
- **Durable notification obligation** so a closed tab after store can't drop the agent wake (today it's a best-effort browser-side sequence with honest "saved, but tell the agent yourself" copy).

## Notes
Pure-function changes with unit coverage (secrets utils: 29 tests, 10 new). Typecheck/lint/link round-trip all green. Local dev boot is currently wedged on an unrelated Cloudflare remote-binding flake, so the deployed path is covered by preview e2e; the underlying collect-secret feature is separately prd-proven end-to-end (Exa + Cloudflare MCP journeys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared secret-path gate used by every secret operation and collect-link minting; incorrect validation could break legitimate paths or leave edge cases open.
> 
> **Overview**
> **`normalizeSecretPath`** now rejects paths that could diverge from the Durable Object identity after WHATWG URL reparsing: dot/empty segments (`..`, `.`, trailing slashes), control chars/whitespace, and `?`/`#`/`%`/`\`. Canonical `/secrets/…` paths still pass; **10 new unit tests** cover rejection cases.
> 
> **`collectFromUser`** stores **origins** (from validated http(s) URLs) in the collect link instead of full URLs, so the UI’s egress promise matches **`assertOriginPinned`** (origin-only enforcement) and duplicate origins are deduped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a86918f1aa5c95d34e94dc8356874be8753ce70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +42 -20 | +28 -16 🟩🟩🟩🟥🟥 |
| Tests | +33 -0 | +26 -0 🟩🟩🟩⬜⬜ |
| **Total** | **+75 -20** | **+54 -16** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between e428cb2 and 5a86918, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-12T09:17:10.753Z",
      "headSha": "5a86918f1aa5c95d34e94dc8356874be8753ce70",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/431429693517834",
      "shortSha": "5a86918",
      "cleanupDurationMs": 11453,
      "deployDurationMs": 80029,
      "testDurationMs": 150636,
      "testRetries": "1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 16003.73,
      "workerGzipKib": 4316.6,
      "mainWorkerGzipKib": 4316.7
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-12T09:17:02.372Z",
      "headSha": "5a86918f1aa5c95d34e94dc8356874be8753ce70",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/431429693517834",
      "shortSha": "5a86918",
      "cleanupDurationMs": 3069,
      "deployDurationMs": 20246,
      "testDurationMs": 418,
      "testRetries": null,
      "workerSizeKib": 4032.01,
      "workerGzipKib": 819.43,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `5a86918` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 819.4 KiB | 20.2s | 418ms |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/431429693517834) | 2026-07-12T09:17:02.372Z | Preview app released. |
| OS | released | `5a86918` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 4.22 MiB (-0.1 KiB vs main) | 80.0s | 150.6s | 1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 11.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/431429693517834) | 2026-07-12T09:17:10.753Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->