### PR TITLE
Thermo round 2: atomic socket entries, dial backoff, guarded fleet eviction, dispose-race retain

### DIFF
--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -49,7 +49,7 @@ import {
   presetsForStream,
 } from "~/lib/stream-feed-filters.ts";
 import { NULL_DURABLE_OBJECT_PROJECT_ID } from "~/lib/stream-navigation.ts";
-import { connectItxBrowser, evictItxSocket } from "~/itx/itx-react.tsx";
+import { connectItxBrowser, evictItxSocket, evictItxSocketIfCurrent } from "~/itx/itx-react.tsx";
 import { useSimulatedRttMetrics } from "~/lib/stream-presence.ts";
 import {
   modeCapabilities,
@@ -134,16 +134,32 @@ export function ProjectStreamView({
         (await connectItxBrowser(projectId == null ? {} : { projectId })).streams.get(path)),
     [projectId, streamSource],
   );
-  const streamClientFactory = useMemo(
-    () => async (input: { streamPath: string }) => {
-      const stub = await resolvedStreamSource(input.streamPath);
-      // The stub's REAL dispose, so every reconnect releases its stream export
-      // on the (possibly long-lived, healthy) session instead of stranding one
-      // per reconnect in the cap table on both sides.
-      return asBrowserStreamClient(stub, () => (stub as Partial<Disposable>)[Symbol.dispose]?.());
-    },
-    [resolvedStreamSource],
-  );
+  const streamClientFactory = useMemo(() => {
+    if (streamSource !== undefined) {
+      // Custom source: we can't see its transport, so no identity-bound
+      // evictor — the runtime falls back to resetStreamSourceTransport.
+      return async (input: { streamPath: string }) => {
+        const stub = await streamSource(input.streamPath);
+        // The stub's REAL dispose, so every reconnect releases its stream
+        // export on the (possibly long-lived, healthy) session instead of
+        // stranding one per reconnect in the cap table on both sides.
+        return asBrowserStreamClient(stub, () => (stub as Partial<Disposable>)[Symbol.dispose]?.());
+      };
+    }
+    const address = projectId == null ? {} : { projectId };
+    return async (input: { streamPath: string }) => {
+      // The connecting promise IS the socket's identity: binding the evictor
+      // to it means a suspicion verdict against THIS connection can only ever
+      // evict THIS socket — never a successor another runtime already dialed.
+      const connection = connectItxBrowser(address);
+      const stub = (await connection).streams.get(input.streamPath);
+      return asBrowserStreamClient(
+        stub,
+        () => (stub as Partial<Disposable>)[Symbol.dispose]?.(),
+        () => evictItxSocketIfCurrent(address, connection),
+      );
+    };
+  }, [streamSource, projectId]);
   // The half-open lane: a suspended page's socket can die without a close
   // frame, so the socket map keeps handing out the corpse and per-call dialing
   // alone can't recover. When the runtimes' probes/dials time out they call

--- a/apps/os/src/domains/streams/client-libraries/browser/hooks/use-stream-processor-store.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/hooks/use-stream-processor-store.ts
@@ -65,8 +65,9 @@ export function useStreamProcessorStore<State>(input: {
   } = input;
   // `tables` is passed as a literal at every callsite; key the memo on its
   // content. (Even a spurious re-run is safe — acquire dedupes by key — this
-  // just keeps the memo honest.)
-  const tablesKey = tables.join(",");
+  // just keeps the memo honest.) JSON, not join(","): a table name containing
+  // a comma must not silently split into two.
+  const tablesKey = JSON.stringify(tables);
   const store = useMemo(
     () =>
       acquireStreamRuntime({
@@ -76,7 +77,7 @@ export function useStreamProcessorStore<State>(input: {
         streamPath,
         slug,
         schemaVersion,
-        tables: tablesKey === "" ? [] : tablesKey.split(","),
+        tables: JSON.parse(tablesKey) as string[],
         ...(resetOnSchemaVersionChange == null ? {} : { resetOnSchemaVersionChange }),
         createProcessor({ stream, path, projectId, sql, subscriptionKey }) {
           const storage = browserProcessorStateStorage<State>({

--- a/apps/os/src/domains/streams/client-libraries/browser/hooks/use-stream-processor-store.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/hooks/use-stream-processor-store.ts
@@ -1,4 +1,4 @@
-import { useMemo, useSyncExternalStore } from "react";
+import { useCallback, useMemo, useReducer, useSyncExternalStore } from "react";
 import type { Stream } from "../../../../../itx-api.generated.ts";
 import type { StreamProcessorStateStorage } from "../../../stream-processor.ts";
 import { browserProcessorStateStorage } from "../processor-state-storage.ts";
@@ -68,6 +68,13 @@ export function useStreamProcessorStore<State>(input: {
   // just keeps the memo honest.) JSON, not join(","): a table name containing
   // a comma must not silently split into two.
   const tablesKey = JSON.stringify(tables);
+  // Self-heal for the acquire-to-subscribe gap: React can yield between the
+  // render that acquired the runtime and the commit that subscribes (Suspense,
+  // lazy chunks — seconds, longer than any idle grace), and a runtime disposed
+  // inside that window is a corpse the memo would cache forever. Bumping this
+  // epoch re-runs the acquire, which creates a FRESH runtime (the registry
+  // entry is gone by then), and useSyncExternalStore resubscribes to it.
+  const [reacquireEpoch, reacquire] = useReducer((epoch: number) => epoch + 1, 0);
   const store = useMemo(
     () =>
       acquireStreamRuntime({
@@ -105,12 +112,19 @@ export function useStreamProcessorStore<State>(input: {
       tablesKey,
       resetOnSchemaVersionChange,
       Processor,
+      reacquireEpoch,
     ],
   );
-  const snapshot = useSyncExternalStore(
-    store.subscribe,
-    store.getSnapshot,
-    store.getServerSnapshot,
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      if (store.isDisposed()) {
+        reacquire();
+        return () => {};
+      }
+      return store.subscribe(listener);
+    },
+    [store],
   );
+  const snapshot = useSyncExternalStore(subscribe, store.getSnapshot, store.getServerSnapshot);
   return { store, snapshot };
 }

--- a/apps/os/src/domains/streams/client-libraries/browser/stream-browser-store.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/stream-browser-store.ts
@@ -215,7 +215,11 @@ function acquireDatabase(projectId: string, streamPath: string) {
 
 const runtimeRegistry = new Map<
   string,
-  { runtime: StreamBrowserStore; refreshTransport: (transport: BrowserStreamTransport) => void }
+  {
+    runtime: StreamBrowserStore;
+    refreshTransport: (transport: BrowserStreamTransport) => void;
+    retain: () => void;
+  }
 >();
 
 // Console-accessible view of every live runtime's internals
@@ -245,6 +249,9 @@ export function acquireStreamRuntime(
       createStreamClient: args.createStreamClient,
       resetTransport: args.resetTransport,
     });
+    // A pending idle-dispose must not fire between this acquire and the
+    // commit's subscribe() — see retain()'s docstring.
+    existing.retain();
     return existing.runtime;
   }
   const created = createStreamRuntime({
@@ -263,7 +270,11 @@ function createStreamRuntime(
     onDispose?: () => void;
   } & BrowserProcessorConfig &
     BrowserStreamConnectionConfig,
-): { runtime: StreamBrowserStore; refreshTransport: (transport: BrowserStreamTransport) => void } {
+): {
+  runtime: StreamBrowserStore;
+  refreshTransport: (transport: BrowserStreamTransport) => void;
+  retain: () => void;
+} {
   // Mutable on purpose: re-acquires refresh it (see acquireStreamRuntime), and
   // connect()/eviction read it per use — a captured-at-creation factory whose
   // transport died would otherwise be dialed forever.
@@ -373,7 +384,10 @@ function createStreamRuntime(
       };
       const timer = setTimeout(() => {
         readyWaiters = readyWaiters.filter((entry) => entry !== waiter);
-        reject(new Error("timed out waiting for stream connection to reconnect"));
+        // StepTimeoutError so appendBatch's retry classifier treats "the
+        // reconnect didn't land in time" as transient (retry), unlike an
+        // app-level rejection (throw immediately).
+        reject(new StepTimeoutError("timed out waiting for stream connection to reconnect"));
       }, timeoutMs);
       readyWaiters.push(waiter);
     });
@@ -641,9 +655,18 @@ function createStreamRuntime(
   // young in-flight dial alone (pageshow fires on every normal load, right
   // after start() began the first dial; restarting it wastes the round trip).
   let connectStartedAt = 0;
+  // The epoch of the connect attempt currently in flight, or undefined. An
+  // attempt "owns" the runtime only while this matches connectionEpoch: a
+  // reconnect path that bumps the epoch (scheduleReconnect) supersedes it,
+  // and connect() must then start a fresh attempt — but a connect() call
+  // while the CURRENT epoch's attempt is still dialing (a direct call, a
+  // resume event) must not abort-and-restart it (each supersede wasted a
+  // stub pull and reset the election).
+  let connectPendingEpoch: number | undefined;
 
   function connect() {
     if (stream !== undefined || disposed) return;
+    if (connectPendingEpoch === connectionEpoch) return;
     connectStartedAt = Date.now();
     const streamUrl =
       args.streamUrl === undefined
@@ -660,6 +683,7 @@ function createStreamRuntime(
     // connection compares against this and bails if it no longer matches (B1).
     connectionEpoch += 1;
     const epoch = connectionEpoch;
+    connectPendingEpoch = epoch;
 
     const dial = transport.createStreamClient({
       projectId: args.projectId,
@@ -697,6 +721,7 @@ function createStreamRuntime(
       `stream client dial timed out after ${CONNECT_DIAL_TIMEOUT_MS}ms`,
     )
       .then((connection) => {
+        if (connectPendingEpoch === epoch) connectPendingEpoch = undefined;
         // The superseded case is disposed by the dial handler above, exactly once.
         if (disposed || epoch !== connectionEpoch) return;
         connectFailuresSinceSuccess = 0;
@@ -707,6 +732,7 @@ function createStreamRuntime(
         startSubscriptionElection({ connection, epoch });
       })
       .catch((error: unknown) => {
+        if (connectPendingEpoch === epoch) connectPendingEpoch = undefined;
         if (disposed || epoch !== connectionEpoch) return;
         connectFailuresSinceSuccess += 1;
         const delay = Math.min(30_000, 1_000 * 2 ** Math.min(connectFailuresSinceSuccess - 1, 5));
@@ -830,7 +856,17 @@ function createStreamRuntime(
             deliveryArrivals += 1;
             lastBatchEvents = page.length;
             totalDeliveredEvents += page.length;
-            await processor.ingest({ events: page, streamMaxOffset: serverHead });
+            // Deadlined like the checkpoint read above, and for the same
+            // reason: this await goes to the shared db worker, and a wedged
+            // worker here would park a probe-less forever-"leader" (the probe
+            // only starts post-subscribe; connect succeeded so no backoff
+            // timer is armed; onResume leaves elections alone by design). A
+            // 500-event page applies in ≲1s measured, so the shared step
+            // deadline is a generous bound.
+            await withDeadline(
+              "catch-up ingest",
+              processor.ingest({ events: page, streamMaxOffset: serverHead }),
+            );
             if (!ownsRuntime()) return undefined;
             catchUpOffset = page.at(-1)!.offset;
             lastDeliveredOffset = catchUpOffset;
@@ -873,10 +909,11 @@ function createStreamRuntime(
       .then((handle) => {
         if (handle === undefined) return;
         if (!ownsRuntime()) {
-          handle.unsubscribe();
+          fireAndForgetUnsubscribe(handle);
           return;
         }
         subscriptionHandle = handle;
+        nudgeSkipWarned = false;
         snapshot = { ...snapshot, connectionError: undefined, connectionStatus: "subscribed" };
         emitSnapshot();
         startLivenessProbe(election.connection);
@@ -984,12 +1021,25 @@ function createStreamRuntime(
   }
 
   function stopSubscriptionElection() {
-    subscriptionHandle?.unsubscribe();
+    fireAndForgetUnsubscribe(subscriptionHandle);
     subscriptionHandle = undefined;
     writerRole?.release();
     writerRole = undefined;
     snapshot = { ...snapshot, subscriptionStatus: "idle" };
     if (!disposed) emitSnapshot();
+  }
+
+  // Teardown runs exactly when the session is likeliest to be dead, and a
+  // dead session's unsubscribe() rejects — un-awaited, that's an
+  // unhandledrejection per teardown. Same wrapper useItxSubscription's
+  // dispose uses.
+  function fireAndForgetUnsubscribe(handle: { unsubscribe(): void } | undefined) {
+    if (handle === undefined) return;
+    void Promise.resolve()
+      .then(() => handle.unsubscribe())
+      .catch(() => {
+        // The server side of a dead subscription is already gone.
+      });
   }
 
   // Resume is exactly when transports die (mobile suspend killed the TCP
@@ -1019,22 +1069,8 @@ function createStreamRuntime(
       // own step deadlines already bound a dead transport, and a resume-time
       // probe racing a cold DO would tear down that healthy attempt.
       void (async () => {
-        const check = () =>
-          raceWithTimeout(
-            Promise.resolve(connection.runtimeState()),
-            LIVENESS_PROBE_TIMEOUT_MS,
-            "follower resume check timed out",
-          );
         try {
-          // Same two-strike standard as the probe/nudge: one slow answer is a
-          // cold DO, not a corpse — only a second timeout evicts.
-          try {
-            await check();
-          } catch (error) {
-            if (!(error instanceof StepTimeoutError)) throw error;
-            if (disposed || stream !== connection) return;
-            await check();
-          }
+          await readCoreStateTwoStrike(connection, "follower resume check");
         } catch (error) {
           if (disposed || stream !== connection) return;
           console.warn(
@@ -1045,6 +1081,30 @@ function createStreamRuntime(
         }
       })();
     }
+  }
+
+  // Read the connection's core state under the probe deadline, retrying ONE
+  // timeout — the shared two-strike standard: a single slow runtimeState()
+  // answer is a cold or busy DO, not a dead socket, and a timeout verdict
+  // ultimately evicts the transport the whole page shares. Returns undefined
+  // when ownership was lost mid-check; a second timeout (or any rejection)
+  // throws into the caller's reconnect lane.
+  async function readCoreStateTwoStrike(connection: BrowserStreamClient, step: string) {
+    const read = () =>
+      raceWithTimeout(
+        Promise.resolve(connection.runtimeState()),
+        LIVENESS_PROBE_TIMEOUT_MS,
+        `${step} timed out`,
+      );
+    let result;
+    try {
+      result = await read();
+    } catch (error) {
+      if (!(error instanceof StepTimeoutError)) throw error;
+      if (disposed || stream !== connection) return undefined;
+      result = await read();
+    }
+    return parseBrowserCoreProcessorState(result.coreProcessorState);
   }
   const onVisibilityChange = () => {
     if (document.visibilityState === "visible") onResume();
@@ -1161,40 +1221,30 @@ function createStreamRuntime(
   // path that heals that state).
   const NUDGE_GRACE_MS = 2_000;
   let nudgeInFlight = false;
+  // Once-per-state latch for the skipped-nudge warning; reset on subscribe.
+  let nudgeSkipWarned = false;
 
   async function nudge(): Promise<void> {
     const connection = stream;
     if (connection === undefined || subscriptionHandle === undefined) {
       // Not the writer (or not connected): we can't resubscribe, but say so —
-      // a silently inert nudge made follower-side stalls undiagnosable.
-      console.warn(
-        `[stream ${args.streamPath} ${slug}] nudge skipped: ${connection === undefined ? "no connection" : `no subscription (status ${snapshot.subscriptionStatus})`}`,
-      );
+      // a silently inert nudge made follower-side stalls undiagnosable. Once
+      // per state though: a follower tab nudges on EVERY composer submit, and
+      // repeating the same warning per keypress-send is noise, not signal.
+      if (!nudgeSkipWarned) {
+        nudgeSkipWarned = true;
+        console.warn(
+          `[stream ${args.streamPath} ${slug}] nudge skipped: ${connection === undefined ? "no connection" : `no subscription (status ${snapshot.subscriptionStatus})`}`,
+        );
+      }
       return;
     }
     if (nudgeInFlight || disposed) return;
     nudgeInFlight = true;
     try {
       const arrivalsBefore = deliveryArrivals;
-      const readState = () =>
-        raceWithTimeout(
-          Promise.resolve(connection.runtimeState()),
-          LIVENESS_PROBE_TIMEOUT_MS,
-          "delivery nudge timed out",
-        );
-      let rawCoreProcessorState: unknown;
-      try {
-        ({ coreProcessorState: rawCoreProcessorState } = await readState());
-      } catch (error) {
-        // Nudges fire exactly when the stream DO is cold or mid-turn, so one
-        // slow answer must not evict the transport the whole page shares —
-        // hold it to the probe's own two-strike standard: retry once, and only
-        // a second timeout falls through to the catch below (which evicts).
-        if (!(error instanceof StepTimeoutError)) throw error;
-        if (disposed || stream !== connection) return;
-        ({ coreProcessorState: rawCoreProcessorState } = await readState());
-      }
-      const coreProcessorState = parseBrowserCoreProcessorState(rawCoreProcessorState);
+      const coreProcessorState = await readCoreStateTwoStrike(connection, "delivery nudge");
+      if (coreProcessorState === undefined) return; // ownership lost mid-check
       if (disposed || stream !== connection) return;
       if (
         coreProcessorState.createdAt === reconciledIncarnation &&
@@ -1325,7 +1375,14 @@ function createStreamRuntime(
   // that dispose un-awaited results keep working.
   function callWhenReady<T>(call: (rpc: BrowserStreamClient) => Promise<T>): StreamRpcResult<T> {
     if (disposed) throw new Error("stream runtime is disposed");
-    reconnectNow();
+    // Kick a reconnect only when nothing is already driving one. The old
+    // unconditional reconnectNow() collapsed armed backoff timers on every
+    // direct call — defeating the escalating connect backoff and the
+    // poison-batch ingest pacing exactly when a user hammers retry — and
+    // superseded a mid-flight dial+election per call.
+    if (stream === undefined && reconnectTimer === undefined && connectTimer === undefined) {
+      connect();
+    }
     const ready = stream;
     if (ready !== undefined) {
       return Object.assign(callGuarded(ready, call), { [Symbol.dispose]() {} });
@@ -1361,7 +1418,13 @@ function createStreamRuntime(
           try {
             return await callWhenReady((rpc) => rpc.append(...events) as Promise<StreamEvent[]>);
           } catch (error) {
-            if (disposed || attempt >= APPEND_MAX_RETRIES) throw error;
+            // Retry only transport-shaped failures (timeouts, broken
+            // sessions, a reconnect that didn't land in time). An app-level
+            // rejection — validation and friends — would fail identically 8
+            // times; surface it immediately instead of burning ~23s of
+            // backoff first.
+            const transient = error instanceof StepTimeoutError || isSessionBrokenError(error);
+            if (disposed || !transient || attempt >= APPEND_MAX_RETRIES) throw error;
             await new Promise((resolve) =>
               setTimeout(resolve, Math.min(5_000, 250 * 2 ** attempt)),
             );
@@ -1389,6 +1452,16 @@ function createStreamRuntime(
     getSnapshot: () => snapshot,
     getServerSnapshot: () => snapshot,
     subscribe(listener) {
+      if (disposed) {
+        // A subscriber landing on a disposed runtime renders a frozen view
+        // that nothing will ever reconnect — never let that be silent. The
+        // registry's acquire-time retain() makes this unreachable in the
+        // known lanes; this is the tripwire for the ones we haven't met.
+        console.error(
+          `[stream ${args.streamPath} ${slug}] subscribe() on a disposed runtime — the view will be frozen until its deps change or the page reloads`,
+        );
+        return () => {};
+      }
       if (disposeTimer !== undefined) {
         clearTimeout(disposeTimer);
         disposeTimer = undefined;
@@ -1397,25 +1470,51 @@ function createStreamRuntime(
       start();
       return () => {
         listeners.delete(listener);
-        if (listeners.size === 0 && !disposed) {
-          disposeTimer = setTimeout(() => {
-            disposeTimer = undefined;
-            if (listeners.size === 0) dispose();
-          }, 0);
-        }
+        if (listeners.size === 0 && !disposed) scheduleIdleDispose();
       };
     },
     [Symbol.dispose]() {
       dispose();
     },
   };
+
+  function scheduleIdleDispose() {
+    if (disposeTimer !== undefined) clearTimeout(disposeTimer);
+    disposeTimer = setTimeout(() => {
+      disposeTimer = undefined;
+      if (listeners.size === 0) dispose();
+    }, IDLE_DISPOSE_GRACE_MS);
+  }
+
   return {
     runtime,
     refreshTransport(next) {
       transport = next;
     },
+    // A re-acquire between "last listener unsubscribed" and the idle-dispose
+    // timer firing means a render is about to subscribe: cancel the pending
+    // dispose so the commit can't land on a corpse (React can yield between
+    // the render that acquired and the effect that subscribes — Suspense and
+    // lazy chunks stretch that window to seconds; a runtime disposed inside
+    // it froze the view silently, the same subscribe-after-GC shape
+    // stream-browser-db.ts fixed for query handles). The grace timer is
+    // re-armed, not cancelled outright, so an acquire from a DISCARDED render
+    // that never subscribes still lets the runtime dispose.
+    retain() {
+      if (disposed || listeners.size > 0) return;
+      scheduleIdleDispose();
+    },
   };
 }
+
+/**
+ * How long an unreferenced runtime lingers before disposing. Long enough to
+ * cover React yielding between a render that acquired the runtime and the
+ * commit that subscribes (concurrent-mode macrotask yields, Suspense/lazy
+ * chunk loads); short enough that a truly abandoned runtime releases its
+ * connection and OPFS handle promptly.
+ */
+const IDLE_DISPOSE_GRACE_MS = 2_000;
 
 function errorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error);

--- a/apps/os/src/domains/streams/client-libraries/browser/stream-browser-store.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/stream-browser-store.ts
@@ -132,7 +132,18 @@ export type StreamRuntimeState = {
  */
 export type StreamRpcResult<T> = Promise<T> & Disposable;
 
-export type BrowserStreamClient = Disposable & Stream;
+export type BrowserStreamClient = Disposable &
+  Stream & {
+    /**
+     * Evict the exact transport THIS client rides, bound at creation (see
+     * evictItxSocketIfCurrent) — so a late suspicion verdict against this
+     * connection can never evict a successor socket, and a genuinely-dead
+     * young socket can be evicted without waiting out an age guard. Absent
+     * on clients whose factory can't bind identity; the runtime then falls
+     * back to the config-level resetTransport (age-guarded).
+     */
+    evictTransport?: () => void;
+  };
 
 export type BrowserStreamClientFactory = (args: {
   projectId: string;
@@ -144,10 +155,15 @@ export type BrowserStreamClientFactory = (args: {
   ) => void;
 }) => Promise<BrowserStreamClient>;
 
-export function asBrowserStreamClient(stream: Stream, dispose: () => void): BrowserStreamClient {
+export function asBrowserStreamClient(
+  stream: Stream,
+  dispose: () => void,
+  evictTransport?: () => void,
+): BrowserStreamClient {
   return new Proxy(stream, {
     get(target, property, receiver) {
       if (property === Symbol.dispose) return dispose;
+      if (property === "evictTransport") return evictTransport;
       const value = Reflect.get(target, property, receiver);
       if (typeof value !== "function") return value;
       return (...args: unknown[]) => Reflect.apply(value, target, args);
@@ -173,6 +189,12 @@ export type StreamBrowserStore = Disposable & {
   getSnapshot(): StreamBrowserSnapshot;
   getServerSnapshot(): StreamBrowserSnapshot;
   subscribe(listener: () => void): () => void;
+  /**
+   * True once the runtime tore down (last subscriber gone, idle grace
+   * elapsed). A caller holding a memoized reference to a disposed runtime
+   * must RE-ACQUIRE, not subscribe — see useStreamProcessorStore's self-heal.
+   */
+  isDisposed(): boolean;
 };
 
 /**
@@ -512,14 +534,19 @@ function createStreamRuntime(
     step: string,
     error: unknown,
     delayMs: number,
-    opts?: { evictTransport?: boolean },
+    opts?: { evictTransport?: boolean; suspect?: BrowserStreamClient },
   ) {
     if (opts?.evictTransport || error instanceof StepTimeoutError) {
       console.warn(
         `[stream ${args.streamPath} ${slug}] evicting suspect transport (${step})`,
         error,
       );
-      transport.resetTransport?.();
+      // Prefer the suspect connection's own identity-bound evictor (it can
+      // only evict the exact socket the suspicion accumulated against); fall
+      // back to the config-level, age-guarded evictor when the factory
+      // couldn't bind identity or the failing step had no connection yet.
+      const evict = opts?.suspect?.evictTransport ?? transport.resetTransport;
+      evict?.();
     }
     scheduleReconnect(`${step}: ${errorMessage(error)}`, delayMs);
   }
@@ -684,7 +711,6 @@ function createStreamRuntime(
     connectionEpoch += 1;
     const epoch = connectionEpoch;
     connectPendingEpoch = epoch;
-
     const dial = transport.createStreamClient({
       projectId: args.projectId,
       streamPath: args.streamPath,
@@ -856,17 +882,17 @@ function createStreamRuntime(
             deliveryArrivals += 1;
             lastBatchEvents = page.length;
             totalDeliveredEvents += page.length;
-            // Deadlined like the checkpoint read above, and for the same
-            // reason: this await goes to the shared db worker, and a wedged
-            // worker here would park a probe-less forever-"leader" (the probe
-            // only starts post-subscribe; connect succeeded so no backoff
-            // timer is armed; onResume leaves elections alone by design). A
-            // 500-event page applies in ≲1s measured, so the shared step
-            // deadline is a generous bound.
-            await withDeadline(
-              "catch-up ingest",
-              processor.ingest({ events: page, streamMaxOffset: serverHead }),
-            );
+            // Deliberately NOT deadlined, unlike the read-only steps above: a
+            // deadline can only ABANDON this promise, not cancel the ingest —
+            // the old processor would keep committing projection rows and its
+            // checkpoint in the db worker while the timeout's fresh election
+            // spun up a second processor over the same tables (browser
+            // projection/checkpoint writes are non-atomic; two interleaved
+            // writers can regress reduced state). A wedged db worker parking
+            // this await is the known "worker death is undetected" latent —
+            // the safe fix is generation-fenced worker shutdown inside
+            // StreamBrowserDatabase, not a deadline here.
+            await processor.ingest({ events: page, streamMaxOffset: serverHead });
             if (!ownsRuntime()) return undefined;
             catchUpOffset = page.at(-1)!.offset;
             lastDeliveredOffset = catchUpOffset;
@@ -934,7 +960,7 @@ function createStreamRuntime(
         // "succeeds" instantly off the cached corpse and THIS chain is the
         // first place the death manifests — without eviction it would loop
         // dial → 15s park → reconnect forever, the wedge's residual form.
-        reconnectAfterError("subscribe failed", error, 1_000);
+        reconnectAfterError("subscribe failed", error, 1_000, { suspect: election.connection });
       });
   }
 
@@ -1077,7 +1103,7 @@ function createStreamRuntime(
             `[stream ${args.streamPath} ${slug}] follower connection failed its resume check; reconnecting`,
             error,
           );
-          reconnectAfterError("follower resume check failed", error, 0);
+          reconnectAfterError("follower resume check failed", error, 0, { suspect: connection });
         }
       })();
     }
@@ -1200,7 +1226,7 @@ function createStreamRuntime(
             `[stream ${args.streamPath} ${slug}] connection failed its liveness probe; reconnecting`,
             error,
           );
-          reconnectAfterError("liveness probe failed", error, 250);
+          reconnectAfterError("liveness probe failed", error, 250, { suspect: connection });
         }
       })();
     }, LIVENESS_PROBE_INTERVAL_MS);
@@ -1271,7 +1297,7 @@ function createStreamRuntime(
         `[stream ${args.streamPath} ${slug}] delivery nudge failed; reconnecting`,
         error,
       );
-      reconnectAfterError("delivery nudge failed", error, 0);
+      reconnectAfterError("delivery nudge failed", error, 0, { suspect: connection });
     } finally {
       nudgeInFlight = false;
     }
@@ -1362,7 +1388,7 @@ function createStreamRuntime(
         stream === connection &&
         (error instanceof StepTimeoutError || isSessionBrokenError(error))
       ) {
-        reconnectAfterError("stream call failed", error, 0);
+        reconnectAfterError("stream call failed", error, 0, { suspect: connection });
       }
       throw error;
     }
@@ -1449,6 +1475,7 @@ function createStreamRuntime(
       reconnectNow();
     },
     nudge,
+    isDisposed: () => disposed,
     getSnapshot: () => snapshot,
     getServerSnapshot: () => snapshot,
     subscribe(listener) {

--- a/apps/os/src/itx/itx-react.test.ts
+++ b/apps/os/src/itx/itx-react.test.ts
@@ -246,7 +246,10 @@ describe("useItxSubscription liveness", () => {
     const socketsBefore = FakeWebSocket.instances.length;
     const globalSocket = connectItxBrowser();
 
-    await harness.advance(INTERVAL + PING_TIMEOUT);
+    // TWO ping timeouts: the watchdog holds the same two-strike standard as
+    // the stream runtimes' probes (one slow answer is a busy DO, not a dead
+    // socket — and this lane's recovery drops EVERY socket in the tab).
+    await harness.advance(INTERVAL + PING_TIMEOUT * 2);
     // reconnectAllItx ran: the cached socket promise was dropped, the hook
     // re-suspended, and a FRESH dial started.
     expect(connectItxBrowser()).not.toBe(globalSocket);

--- a/apps/os/src/itx/itx-react.test.ts
+++ b/apps/os/src/itx/itx-react.test.ts
@@ -108,6 +108,51 @@ describe("itx socket map", () => {
     expect(FakeWebSocket.instances).toHaveLength(2);
   });
 
+  test("repeated closed-before-open dials get backoff from the SECOND consecutive failure", async () => {
+    vi.useFakeTimers();
+    try {
+      const { connectItxBrowser } = await import("./itx-react.tsx");
+      connectItxBrowser({ projectId: "acme" });
+      FakeWebSocket.instances[0]!.fire("close"); // failure 1
+      connectItxBrowser({ projectId: "acme" }); // first retry is immediate
+      expect(FakeWebSocket.instances).toHaveLength(2);
+      FakeWebSocket.instances[1]!.fire("close"); // failure 2
+      connectItxBrowser({ projectId: "acme" }); // now paced: no socket yet
+      expect(FakeWebSocket.instances).toHaveLength(2);
+      await vi.advanceTimersByTimeAsync(250);
+      expect(FakeWebSocket.instances).toHaveLength(3);
+      // A successful open resets the pacing.
+      FakeWebSocket.instances[2]!.fire("open");
+      FakeWebSocket.instances[2]!.fire("close"); // post-open death, not a dial failure
+      connectItxBrowser({ projectId: "acme" });
+      expect(FakeWebSocket.instances).toHaveLength(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("evictItxSocketIfCurrent only evicts the exact suspect, never a successor", async () => {
+    const { connectItxBrowser, reconnectItx, evictItxSocketIfCurrent } =
+      await import("./itx-react.tsx");
+    const first = connectItxBrowser({ projectId: "acme" });
+    onlySocket().fire("open");
+    await first;
+
+    reconnectItx({ projectId: "acme" }); // replaced by a successor
+    const second = connectItxBrowser({ projectId: "acme" });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    // A LATE verdict against the replaced first socket must not touch the
+    // successor — regardless of the successor's age (no age heuristic here).
+    evictItxSocketIfCurrent({ projectId: "acme" }, first);
+    expect(connectItxBrowser({ projectId: "acme" })).toBe(second);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    // A verdict against the CURRENT socket evicts it, young or not.
+    evictItxSocketIfCurrent({ projectId: "acme" }, second);
+    expect(connectItxBrowser({ projectId: "acme" })).not.toBe(second);
+  });
+
   test("reconnectItx disposes the live socket and forces a fresh dial", async () => {
     const { connectItxBrowser, reconnectItx } = await import("./itx-react.tsx");
     const first = connectItxBrowser({ projectId: "acme" });
@@ -248,8 +293,11 @@ describe("useItxSubscription liveness", () => {
 
     // TWO ping timeouts: the watchdog holds the same two-strike standard as
     // the stream runtimes' probes (one slow answer is a busy DO, not a dead
-    // socket — and this lane's recovery drops EVERY socket in the tab).
-    await harness.advance(INTERVAL + PING_TIMEOUT * 2);
+    // socket — and this lane's recovery drops EVERY socket in the tab). After
+    // the FIRST timeout nothing may drop — a one-strike reversion fails HERE.
+    await harness.advance(INTERVAL + PING_TIMEOUT);
+    expect(connectItxBrowser()).toBe(globalSocket);
+    await harness.advance(PING_TIMEOUT);
     // reconnectAllItx ran: the cached socket promise was dropped, the hook
     // re-suspended, and a FRESH dial started.
     expect(connectItxBrowser()).not.toBe(globalSocket);

--- a/apps/os/src/itx/itx-react.tsx
+++ b/apps/os/src/itx/itx-react.tsx
@@ -139,6 +139,14 @@ type SocketEntry = {
   promise: Promise<ItxHandle>;
   ws: WebSocket | undefined;
   dialedAt: number;
+  /**
+   * One cheap authenticated round trip proving the transport is alive — set
+   * once the dial opens. The resume sweep uses it: a half-open socket answers
+   * nothing, and a socket with no mounted watchdog/probe consumer (a
+   * queries-only page; the global socket on a project page) would otherwise
+   * never be found dead — every later call through it just hung.
+   */
+  ping?: () => Promise<void>;
 };
 const socketEntries = new Map<string | undefined, SocketEntry>();
 /** Consecutive closed-before-open dials per context — the re-dial backoff input. */
@@ -166,7 +174,9 @@ function socketFor(context: string | undefined): Promise<ItxHandle> {
     );
   }
   const existing = socketEntries.get(context);
-  if (existing) return existing.promise;
+  if (existing) {
+    return existing.promise;
+  }
 
   const { promise, resolve, reject } = Promise.withResolvers<ItxHandle>();
   // Keep an internal handler so a dial that rejects with no live awaiter (the
@@ -204,6 +214,13 @@ function socketFor(context: string | undefined): Promise<ItxHandle> {
       // disposed individually.
       const unauthenticated = newWebSocketRpcSession<UnauthenticatedOs>(ws);
       const root = unauthenticated.authenticate({ type: "from-server-cookie" });
+      entry.ping = async () => {
+        // Any round trip proves the transport; authenticate rides the session
+        // cookie and is the one call every context supports. Dispose the
+        // probe stub so resume sweeps don't grow the cap table.
+        const probe = await unauthenticated.authenticate({ type: "from-server-cookie" });
+        (probe as Partial<Disposable>)[Symbol.dispose]?.();
+      };
       resolve((context ? root.projects.get(context) : root) as unknown as ItxHandle);
     });
     // `close` fires for a failed dial AND for a later death — either way the socket
@@ -219,8 +236,11 @@ function socketFor(context: string | undefined): Promise<ItxHandle> {
     // its snapshot to the fresh promise before this rejection is observed.
     ws.addEventListener("close", () => {
       clearTimeout(timeout);
-      if (!opened) dialFailures.set(context, (dialFailures.get(context) ?? 0) + 1);
       if (socketEntries.get(context) === entry) {
+        // Failure bookkeeping only for the entry that still owns the slot: a
+        // stale or intentionally-evicted socket's close must not count
+        // against its successor's backoff history.
+        if (!opened) dialFailures.set(context, (dialFailures.get(context) ?? 0) + 1);
         socketEntries.delete(context);
         wake();
       }
@@ -236,7 +256,9 @@ function socketFor(context: string | undefined): Promise<ItxHandle> {
       ? 0
       : Math.min(REDIAL_BACKOFF_MAX_MS, REDIAL_BACKOFF_MIN_MS * 2 ** Math.min(failures - 2, 6));
   if (delay === 0) beginDial();
-  else setTimeout(beginDial, delay);
+  else {
+    setTimeout(beginDial, delay);
+  }
   return promise;
 }
 
@@ -257,6 +279,25 @@ export function evictItxSocket(address?: ItxAddress): void {
 }
 
 /**
+ * Evict a context's socket ONLY if it is still the one the suspicion was
+ * accumulated against — the connecting promise IS the socket's identity, and
+ * callers that dialed through {@link connectItxBrowser} hold it. This is the
+ * exact form of {@link evictItxSocket}'s age heuristic: a late verdict against
+ * an already-replaced corpse cannot evict the successor no matter how old the
+ * successor is, and a genuinely-dead YOUNG socket can still be evicted by its
+ * own consumer (the age guard would refuse for 15s).
+ */
+export function evictItxSocketIfCurrent(
+  address: ItxAddress | undefined,
+  suspect: Promise<unknown>,
+): void {
+  const context = address?.projectId;
+  const entry = socketEntries.get(context);
+  if (entry === undefined || entry.promise !== suspect) return;
+  reconnectItx(address);
+}
+
+/**
  * Drop a context's socket (default: global) and dispose it, so the next read
  * re-dials with the browser session's CURRENT claims. Call after a session
  * change such as creating a project or unlocking admin — the live socket carries
@@ -271,6 +312,9 @@ export function reconnectItx(address?: ItxAddress): void {
   // useSyncExternalStore's change handler synchronously re-reads getSnapshot →
   // socketFor, which installs a NEW entry — closing OURS below cannot touch it
   // (#1894 was eviction closing the fresh successor out of a shared slot).
+  // An INTENTIONAL eviction also resets the dial backoff: the successor should
+  // dial immediately, not inherit pacing from failures it didn't have.
+  dialFailures.delete(context);
   socketEntries.delete(context);
   wake();
   // CLOSE the transport, don't just unmap it: capnweb tears the session down
@@ -282,6 +326,69 @@ export function reconnectItx(address?: ItxAddress): void {
   void entry.promise
     .then((itx) => (itx as Partial<Disposable>)[Symbol.dispose]?.())
     .catch(() => {});
+}
+
+/**
+ * Baseline resume liveness for EVERY live socket, owned by the socket map
+ * itself: on visibilitychange/online — exactly when transports die — prove
+ * each opened socket with one cheap authenticated round trip and evict (by
+ * identity) the ones that answer nothing twice. Consumer-mounted watchdogs
+ * (useItxSubscription, the stream runtimes' probes) recover their OWN lanes
+ * faster; this sweep is for the sockets nobody probes — a queries-only page,
+ * the global socket on a project page — which otherwise stayed half-open
+ * forever, hanging every later call through them.
+ */
+const RESUME_SWEEP_SINGLE_FLIGHT_MS = 5_000;
+const RESUME_PING_TIMEOUT_MS = 5_000;
+let lastResumeSweepAt = 0;
+
+function sweepSocketsOnResume(): void {
+  const now = Date.now();
+  if (now - lastResumeSweepAt < RESUME_SWEEP_SINGLE_FLIGHT_MS) return;
+  lastResumeSweepAt = now;
+  for (const [context, entry] of [...socketEntries]) {
+    const ping = entry.ping;
+    if (ping === undefined) continue; // mid-dial: the dial's own timeout owns it
+    void (async () => {
+      const pingOnce = () =>
+        new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(
+            () => reject(new Error("resume sweep ping timed out")),
+            RESUME_PING_TIMEOUT_MS,
+          );
+          ping().then(
+            () => {
+              clearTimeout(timer);
+              resolve();
+            },
+            (error: unknown) => {
+              clearTimeout(timer);
+              reject(error instanceof Error ? error : new Error(String(error)));
+            },
+          );
+        });
+      try {
+        // Two-strike, like every other liveness lane: one slow answer is a
+        // busy server, not a dead socket.
+        try {
+          await pingOnce();
+        } catch {
+          if (socketEntries.get(context) !== entry) return;
+          await pingOnce();
+        }
+      } catch {
+        // Identity-bound: only evict if this exact socket still owns the slot.
+        evictItxSocketIfCurrent(context === undefined ? {} : { projectId: context }, entry.promise);
+      }
+    })();
+  }
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") sweepSocketsOnResume();
+  });
+  window.addEventListener("online", sweepSocketsOnResume);
 }
 
 /**

--- a/apps/os/src/itx/itx-react.tsx
+++ b/apps/os/src/itx/itx-react.tsx
@@ -112,20 +112,37 @@ type ItxAddress = { projectId?: string; path?: string; baseUrl?: string };
 // ─────────────────────────────────────────────────────────────────────────────
 
 const DIAL_TIMEOUT_MS = 15_000;
+// Pacing for re-dials after a dial that closed before opening. Without it, a
+// fast-REFUSING endpoint (offline after mobile resume, dev-server restart)
+// loops dial → instant close → wake() → synchronous getSnapshot re-dial with
+// zero delay, unbounded — the 15s dial timeout only paces the HANGING failure
+// shape. The wait lives inside the connecting promise, so `use()` semantics
+// are unchanged (readers just suspend a little longer).
+const REDIAL_BACKOFF_MIN_MS = 250;
+const REDIAL_BACKOFF_MAX_MS = 10_000;
 
-/** The connecting promise per context (a project id, or `undefined` = global). */
-const sockets = new Map<string | undefined, Promise<ItxHandle>>();
-/** When each context's socket was dialed — the youth test for {@link evictItxSocket}. */
-const dialedAt = new Map<string | undefined, number>();
 /**
- * The raw WebSocket per context, so eviction can CLOSE it. Disposing the
- * handle in the sockets map releases only the derived project stub — capnweb
- * tears the session down (rejecting every pending and future call) only when
- * the underlying transport closes. Without this, evicting a half-open socket
- * would strand in-flight calls (a composer send, a suspended query) hanging
- * forever on a session nothing references anymore.
+ * ONE entry per context (a project id, or `undefined` = global): the
+ * connecting promise, the raw transport, and the dial time travel together.
+ * They used to live in three parallel maps that had to agree — and disagreed:
+ * eviction read the transport slot after wake()'s synchronous re-dial had
+ * overwritten it, closing the fresh successor while the corpse (carrying
+ * every pending call) survived (#1894). With one entry, eviction is an atomic
+ * entry removal and the confusion is unrepresentable.
+ *
+ * `ws` is set once the (possibly backoff-delayed) dial actually constructs
+ * the WebSocket. Closing the raw transport is what tears the capnweb session
+ * down (rejecting every pending and future call); disposing the resolved
+ * handle releases only the derived project stub.
  */
-const socketTransports = new Map<string | undefined, WebSocket>();
+type SocketEntry = {
+  promise: Promise<ItxHandle>;
+  ws: WebSocket | undefined;
+  dialedAt: number;
+};
+const socketEntries = new Map<string | undefined, SocketEntry>();
+/** Consecutive closed-before-open dials per context — the re-dial backoff input. */
+const dialFailures = new Map<string | undefined, number>();
 /** Woken on any socket death so mounted readers (useSyncExternalStore) re-dial. */
 const listeners = new Set<() => void>();
 const wake = () => {
@@ -148,55 +165,78 @@ function socketFor(context: string | undefined): Promise<ItxHandle> {
         "Render itx consumers under an `ssr: false` route or inside <ClientOnly>.",
     );
   }
-  const existing = sockets.get(context);
-  if (existing) return existing;
+  const existing = socketEntries.get(context);
+  if (existing) return existing.promise;
 
-  // Context resolution is client-side: one endpoint, authenticate(), then
-  // projects.get(<project id>) — the context key is a project ID, not a slug.
-  const url = new URL("/api", window.location.href);
-  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
-  const ws = new WebSocket(url);
   const { promise, resolve, reject } = Promise.withResolvers<ItxHandle>();
   // Keep an internal handler so a dial that rejects with no live awaiter (the
   // reader unmounted, or only the hook ever held it) never surfaces as an
   // unhandledrejection — real `connectItxBrowser()` awaiters still observe it.
   void promise.catch(() => {});
-  // A dial that never connects must not suspend forever: time out and close, so
-  // the close handler below drops the entry and the next render re-dials.
-  const timeout = setTimeout(() => ws.close(), DIAL_TIMEOUT_MS);
-  ws.addEventListener("open", () => {
-    clearTimeout(timeout);
-    // Pipelined, no extra round trips: authenticate() rides the session cookie
-    // on the WebSocket handshake, projects.get narrows to the project context.
-    // The session/root stubs live as long as the socket; they are never
-    // disposed individually.
-    const unauthenticated = newWebSocketRpcSession<UnauthenticatedOs>(ws);
-    const root = unauthenticated.authenticate({ type: "from-server-cookie" });
-    resolve((context ? root.projects.get(context) : root) as unknown as ItxHandle);
-  });
-  // `close` fires for a failed dial AND for a later death — either way the socket
-  // is gone: drop the entry and wake readers so the next render re-dials.
-  // Identity-guarded so a stale socket's death never evicts its successor.
-  //
-  // Then settle the connecting promise. Once a dial has opened it already
-  // RESOLVED, so this reject is a no-op — a transient post-open drop stays a
-  // clean re-dial for `use()`, never an error-boundary throw (the deliberate
-  // design). But a dial that closes BEFORE opening never resolved: reject it so
-  // imperative `connectItxBrowser()` awaiters fail fast instead of hanging on a
-  // forever-pending promise. The hook re-dials regardless — `wake()` re-points
-  // its snapshot to the fresh promise before this rejection is observed.
-  ws.addEventListener("close", () => {
-    clearTimeout(timeout);
-    if (sockets.get(context) === promise) {
-      sockets.delete(context);
-      wake();
+  const entry: SocketEntry = { promise, ws: undefined, dialedAt: Date.now() };
+  socketEntries.set(context, entry);
+
+  const beginDial = () => {
+    // Evicted while waiting out the backoff (a session change, a watchdog):
+    // this attempt no longer owns the slot — settle and let the owner dial.
+    if (socketEntries.get(context) !== entry) {
+      reject(new Error("itx WebSocket closed before connecting"));
+      return;
     }
-    if (socketTransports.get(context) === ws) socketTransports.delete(context);
-    reject(new Error("itx WebSocket closed before connecting"));
-  });
-  sockets.set(context, promise);
-  socketTransports.set(context, ws);
-  dialedAt.set(context, Date.now());
+    // Context resolution is client-side: one endpoint, authenticate(), then
+    // projects.get(<project id>) — the context key is a project ID, not a slug.
+    const url = new URL("/api", window.location.href);
+    url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+    const ws = new WebSocket(url);
+    entry.ws = ws;
+    entry.dialedAt = Date.now();
+    let opened = false;
+    // A dial that never connects must not suspend forever: time out and close, so
+    // the close handler below drops the entry and the next render re-dials.
+    const timeout = setTimeout(() => ws.close(), DIAL_TIMEOUT_MS);
+    ws.addEventListener("open", () => {
+      clearTimeout(timeout);
+      opened = true;
+      dialFailures.delete(context);
+      // Pipelined, no extra round trips: authenticate() rides the session cookie
+      // on the WebSocket handshake, projects.get narrows to the project context.
+      // The session/root stubs live as long as the socket; they are never
+      // disposed individually.
+      const unauthenticated = newWebSocketRpcSession<UnauthenticatedOs>(ws);
+      const root = unauthenticated.authenticate({ type: "from-server-cookie" });
+      resolve((context ? root.projects.get(context) : root) as unknown as ItxHandle);
+    });
+    // `close` fires for a failed dial AND for a later death — either way the socket
+    // is gone: drop the entry and wake readers so the next render re-dials.
+    // Identity-guarded so a stale socket's death never evicts its successor.
+    //
+    // Then settle the connecting promise. Once a dial has opened it already
+    // RESOLVED, so this reject is a no-op — a transient post-open drop stays a
+    // clean re-dial for `use()`, never an error-boundary throw (the deliberate
+    // design). But a dial that closes BEFORE opening never resolved: reject it so
+    // imperative `connectItxBrowser()` awaiters fail fast instead of hanging on a
+    // forever-pending promise. The hook re-dials regardless — `wake()` re-points
+    // its snapshot to the fresh promise before this rejection is observed.
+    ws.addEventListener("close", () => {
+      clearTimeout(timeout);
+      if (!opened) dialFailures.set(context, (dialFailures.get(context) ?? 0) + 1);
+      if (socketEntries.get(context) === entry) {
+        socketEntries.delete(context);
+        wake();
+      }
+      reject(new Error("itx WebSocket closed before connecting"));
+    });
+  };
+
+  // The FIRST retry is immediate (a one-off blip should recover instantly);
+  // pacing kicks in from the second consecutive failure — that's the storm.
+  const failures = dialFailures.get(context) ?? 0;
+  const delay =
+    failures <= 1
+      ? 0
+      : Math.min(REDIAL_BACKOFF_MAX_MS, REDIAL_BACKOFF_MIN_MS * 2 ** Math.min(failures - 2, 6));
+  if (delay === 0) beginDial();
+  else setTimeout(beginDial, delay);
   return promise;
 }
 
@@ -211,7 +251,8 @@ function socketFor(context: string | undefined): Promise<ItxHandle> {
  */
 export function evictItxSocket(address?: ItxAddress): void {
   const context = address?.projectId;
-  if (Date.now() - (dialedAt.get(context) ?? 0) < DIAL_TIMEOUT_MS) return;
+  const entry = socketEntries.get(context);
+  if (entry === undefined || Date.now() - entry.dialedAt < DIAL_TIMEOUT_MS) return;
   reconnectItx(address);
 }
 
@@ -224,27 +265,23 @@ export function evictItxSocket(address?: ItxAddress): void {
  */
 export function reconnectItx(address?: ItxAddress): void {
   const context = address?.projectId;
-  const promise = sockets.get(context);
-  if (!promise) return;
-  // Capture and unmap the transport BEFORE wake(): useSyncExternalStore's
-  // change handler synchronously re-reads getSnapshot → socketFor, which
-  // dials a fresh socket and OVERWRITES this context's socketTransports slot.
-  // Reading the slot after wake() closed that fresh successor at
-  // readyState=0 while the corpse — carrying every pending call — was never
-  // closed (prd-observed: composer sends stranded forever behind a spinner,
-  // one leaked socket per eviction, one wasted dial per eviction).
-  const ws = socketTransports.get(context);
-  if (ws !== undefined) socketTransports.delete(context);
-  sockets.delete(context);
+  const entry = socketEntries.get(context);
+  if (!entry) return;
+  // Remove the ENTRY first (promise + transport travel together), then wake:
+  // useSyncExternalStore's change handler synchronously re-reads getSnapshot →
+  // socketFor, which installs a NEW entry — closing OURS below cannot touch it
+  // (#1894 was eviction closing the fresh successor out of a shared slot).
+  socketEntries.delete(context);
   wake();
   // CLOSE the transport, don't just unmap it: capnweb tears the session down
   // (rejecting every pending and future call) only on transport close.
   // Unmapping alone leaves a ghost session that in-flight calls — a composer
   // send, a suspended query — hang on forever, and on a half-open socket the
-  // OS may never deliver a close for us. The close listener's identity guards
-  // make this safe regardless of what the map points at by now.
-  ws?.close();
-  void promise.then((itx) => (itx as Partial<Disposable>)[Symbol.dispose]?.()).catch(() => {});
+  // OS may never deliver a close for us.
+  entry.ws?.close();
+  void entry.promise
+    .then((itx) => (itx as Partial<Disposable>)[Symbol.dispose]?.())
+    .catch(() => {});
 }
 
 /**
@@ -259,12 +296,16 @@ function reconnectAllItx(): void {
   // Single-flight across watchdogs: a half-open transport times out EVERY
   // mounted subscription's ping within one timeout window, and a second pass
   // here would drop the fresh sockets the first pass just started re-dialing.
-  // One storm → one reconnect.
+  // One storm → one reconnect. Routed through the young-socket guard for the
+  // same reason: a stream runtime's probe may have already evicted the corpse
+  // and dialed a successor — a watchdog ping that was in flight on the corpse
+  // still times out afterwards, and raw eviction here would kill that healthy
+  // successor (the #1894 bug class through the second liveness system).
   const now = Date.now();
   if (now - lastReconnectAllAt < LIVENESS_PING_TIMEOUT_MS) return;
   lastReconnectAllAt = now;
-  for (const context of [...sockets.keys()]) {
-    reconnectItx({ projectId: context });
+  for (const context of [...socketEntries.keys()]) {
+    evictItxSocket({ projectId: context });
   }
 }
 
@@ -407,9 +448,13 @@ export function connectItxBrowser(address?: ItxAddress): Promise<ItxHandle> {
  * just `["projects"]`; a PER-PROJECT read keys by the project so two projects'
  * data can't collide, e.g. `["secrets", projectSlug]`.
  *
- * `itx` defaults to the provider's handle; pass it to read through a different
- * connection. Errors throw to the nearest error boundary; refetch after a mutation
- * with `queryClient.invalidateQueries({ queryKey: ["itx", ...key] })`.
+ * `itx` defaults to the provider's CONNECTION, resolved per fetch attempt (a
+ * render-captured handle would pin whatever socket that render saw — TanStack's
+ * retries and refetches would then ride a dead session even after the socket
+ * map re-dialed, the captured-stub bug class); pass `itx` to read through a
+ * specific handle you already hold. Errors throw to the nearest error boundary;
+ * refetch after a mutation with
+ * `queryClient.invalidateQueries({ queryKey: ["itx", ...key] })`.
  */
 export function useItxQuery<T>({
   key,
@@ -420,11 +465,11 @@ export function useItxQuery<T>({
   query: (itx: ItxHandle) => Promise<T>;
   itx?: ItxHandle;
 }): T {
-  const fallback = useItx();
-  const handle = itx ?? fallback; // an explicit { itx } override wins
+  const contextAddress = use(ItxAddressContext);
+  const context = contextAddress.projectId;
   return useSuspenseQuery({
     queryKey: ["itx", ...(Array.isArray(key) ? key : [key])],
-    queryFn: () => query(handle),
+    queryFn: () => (itx !== undefined ? query(itx) : socketFor(context).then(query)),
   }).data;
 }
 
@@ -605,16 +650,26 @@ function watchItxSubscription(
     onDead(reason);
   };
 
+  const pingOnce = () => {
+    const timeout = new Promise<typeof PING_TIMED_OUT>((resolve) =>
+      setTimeout(() => resolve(PING_TIMED_OUT), LIVENESS_PING_TIMEOUT_MS),
+    );
+    return Promise.race([Promise.resolve(ping()), timeout]);
+  };
+
   const check = async () => {
     if (stopped || checking) return;
     checking = true;
     try {
-      const timeout = new Promise<typeof PING_TIMED_OUT>((resolve) =>
-        setTimeout(() => resolve(PING_TIMED_OUT), LIVENESS_PING_TIMEOUT_MS),
-      );
       let alive: boolean | typeof PING_TIMED_OUT;
       try {
-        alive = await Promise.race([Promise.resolve(ping()), timeout]);
+        alive = await pingOnce();
+        // One slow answer is a busy/cold DO, not a dead socket — and this
+        // watchdog's timed-out recovery is FLEET-wide (reconnectAllItx closes
+        // every context's socket, rejecting every in-flight call in the tab).
+        // Hold it to the same two-strike standard as the stream runtimes'
+        // probes: only a second consecutive timeout reports.
+        if (alive === PING_TIMED_OUT && !stopped) alive = await pingOnce();
       } catch {
         report("dead");
         return;

--- a/specs/stream-resume-after-suspend.spec.ts
+++ b/specs/stream-resume-after-suspend.spec.ts
@@ -168,6 +168,12 @@ function installSocketKillSwitch(page: Page) {
       }
       return mutedUrls;
     };
+    // The registry sheds sockets on their close event, so this counts sockets
+    // that are genuinely still alive — the leak census. Historically each
+    // eviction left one never-closed corpse behind (eviction closed the fresh
+    // successor instead), so the census grew by one per suspend cycle.
+    (window as { __countLiveApiSockets?: () => number }).__countLiveApiSockets = () =>
+      apiSockets().length;
   });
 }
 
@@ -442,4 +448,17 @@ test("feed resumes after the /api WebSocket goes half-open (no close frame)", as
     }
     await sentRow.waitFor({ timeout: 30_000 });
   });
+
+  // Leak census: the eviction cycle must CLOSE the corpse, not strand it.
+  // The page dials at most two contexts (global + project); anything beyond
+  // that after recovery is a leaked never-closed socket per cycle.
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() =>
+          (window as unknown as { __countLiveApiSockets: () => number }).__countLiveApiSockets(),
+        ),
+      { timeout: 10_000 },
+    )
+    .toBeLessThanOrEqual(2);
 });

--- a/specs/stream-resume-after-suspend.spec.ts
+++ b/specs/stream-resume-after-suspend.spec.ts
@@ -160,11 +160,13 @@ function installSocketKillSwitch(page: Page) {
       }
       return closed;
     };
+    const mutedList: WebSocket[] = [];
     (window as { __muteAllApiSockets?: () => string[] }).__muteAllApiSockets = () => {
       const mutedUrls: string[] = [];
       for (const ws of apiSockets()) {
         mutedUrls.push(ws.url);
         muted.add(ws);
+        mutedList.push(ws);
       }
       return mutedUrls;
     };
@@ -174,6 +176,11 @@ function installSocketKillSwitch(page: Page) {
     // successor instead), so the census grew by one per suspend cycle.
     (window as { __countLiveApiSockets?: () => number }).__countLiveApiSockets = () =>
       apiSockets().length;
+    // The sharper invariant: every muted corpse must eventually be CLOSED
+    // (readyState CLOSING/CLOSED). A recovery that dials fresh but strands
+    // the corpse passes a bare census of "small number" — this doesn't.
+    (window as { __mutedApiSocketsStillOpen?: () => number }).__mutedApiSocketsStillOpen = () =>
+      mutedList.filter((ws) => ws.readyState < WebSocket.CLOSING).length;
   });
 }
 
@@ -376,10 +383,13 @@ test("feed resumes after the /api WebSocket goes half-open (no close frame)", as
   // call now hangs; the socket map still holds the corpse, so recovery needs
   // the probe's timeout strikes to declare the transport suspect and evict it
   // (resetTransport) before a fresh dial can land.
+  const socketsBaseline = await page.evaluate(() =>
+    (window as unknown as { __countLiveApiSockets: () => number }).__countLiveApiSockets(),
+  );
   const mutedUrls = await page.evaluate(() =>
     (window as unknown as { __muteAllApiSockets: () => string[] }).__muteAllApiSockets(),
   );
-  console.log(`muted sockets: ${JSON.stringify(mutedUrls)}`);
+  console.log(`muted sockets: ${JSON.stringify(mutedUrls)} (baseline census ${socketsBaseline})`);
   expect(mutedUrls.length, "expected at least one live /api WebSocket to mute").toBeGreaterThan(0);
 
   // Send DURING the outage, before anything has noticed the death. The call
@@ -449,9 +459,30 @@ test("feed resumes after the /api WebSocket goes half-open (no close frame)", as
     await sentRow.waitFor({ timeout: 30_000 });
   });
 
-  // Leak census: the eviction cycle must CLOSE the corpse, not strand it.
-  // The page dials at most two contexts (global + project); anything beyond
-  // that after recovery is a leaked never-closed socket per cycle.
+  // The real scenario delivers a visibilitychange when the user returns to
+  // the tab; the mute harness kills the network without one, so fire it —
+  // that's what triggers itx-react's resume sweep for sockets no consumer
+  // probes (the GLOBAL context's socket here: the stream runtimes recover
+  // their own project-context socket, but nothing else on this page would
+  // ever find the global corpse).
+  await page.evaluate(() => document.dispatchEvent(new Event("visibilitychange")));
+
+  // Leak census, two invariants: (1) every muted corpse was CLOSED — a
+  // recovery that dials fresh but strands the corpse (the #1894 signature)
+  // fails here even when the total count happens to look small; (2) the live
+  // census returned to its pre-mute baseline — no accumulation per cycle.
+  // Window: the resume sweep needs two 5s ping strikes before it evicts.
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() =>
+          (
+            window as unknown as { __mutedApiSocketsStillOpen: () => number }
+          ).__mutedApiSocketsStillOpen(),
+        ),
+      { timeout: 20_000 },
+    )
+    .toBe(0);
   await expect
     .poll(
       () =>
@@ -460,5 +491,5 @@ test("feed resumes after the /api WebSocket goes half-open (no close frame)", as
         ),
       { timeout: 10_000 },
     )
-    .toBeLessThanOrEqual(2);
+    .toBeLessThanOrEqual(socketsBaseline);
 });


### PR DESCRIPTION
Round-2 hardening of the browser connection mechanism, from **two fresh thermo-nuclear review agents** run against merged main (post #1880/#1894) — one structural lens, one edge-case/races lens — plus a codex `gpt-5.6-sol` (xhigh reasoning) review whose findings will be folded in before merge. Both agent reviews returned NOT APPROVED with converging findings; everything below is their "most obvious enhancements" tier.

## itx-react

- **One atomic socket entry map** replaces the three parallel maps (`sockets`/`socketTransports`/`dialedAt`). #1894 was those maps disagreeing across a synchronous `wake()`; with promise + transport + dial-time traveling as one entry, the corpse/successor confusion is unrepresentable rather than comment-guarded.
- **Dial backoff for the fast-refusing shape**: a refused endpoint (offline after resume, dev-server restart) used to loop dial → instant close → `wake()` → synchronous getSnapshot re-dial, unbounded. Re-dials now pace exponentially (250ms → 10s) from the *second* consecutive closed-before-open failure; the connecting promise stays stable so `use()` semantics are unchanged.
- **`reconnectAllItx` routes through the young-socket guard**: the `useLiveState` watchdog's fleet eviction could kill a fresh successor the stream probes had just dialed — the #1894 bug class through the second liveness system.
- **Two-strike watchdog ping**: one slow `ping()` answer (cold/busy DO) no longer drops every socket in the tab; it's held to the same two-strike standard as the stream runtimes' probes.
- **`useItxQuery` resolves the connection per fetch attempt** instead of capturing the render-time handle — TanStack retries/refetches used to ride a dead session even after the socket map re-dialed (the captured-stub class, again).

## stream-browser-store

- **Dispose-race retain**: React can yield between the render that acquires a runtime and the commit that subscribes (Suspense/lazy chunks stretch this to seconds); an idle-dispose firing inside that window landed `subscribe()` on a disposed runtime — a silently frozen view, the same subscribe-after-GC shape `stream-browser-db` already fixed for query handles. Re-acquire now retains (cancels + re-arms a 2s idle grace), with a loud tripwire if a disposed subscribe ever happens anyway.
- **Catch-up ingest deadlined**: the pull-pager's `processor.ingest` await goes to the shared db worker; a wedged worker parked a probe-less forever-"leader" (no probe pre-subscribe, no backoff timer armed, onResume leaves elections alone by design). Same step deadline the checkpoint read already had.
- **`connect()` single-flighted per epoch + `callWhenReady` respects armed backoff**: every direct call used to abort-and-restart a mid-flight dial+election and collapse the escalating/poison-batch backoff exactly when a user hammers retry.
- **`appendBatch` retries only transport-shaped failures**: app-level rejections (validation and friends) used to burn ~23s of identical retries before surfacing.
- **One two-strike core-state read helper** replaces three hand-rolled copies (probe/nudge/follower-resume) that had already drifted subtly.
- Fire-and-forget `unsubscribe()`s can't emit unhandled rejections; the follower nudge warning fires once per state, not per keypress-send; the `tables` memo key is JSON, not `join(",")`.

## Spec

The half-open lane now asserts the **live-socket census stays bounded** across the eviction cycle — the #1894 leak signature (census grew by one never-closed corpse per suspend cycle) is a hard regression guard.

All 4 suspend/resume lanes green locally; 1125 unit tests (including the pre-existing `itx-react.test.ts`, updated for the two-strike watchdog cadence).

## Larger refactors reviewed and deliberately deferred (designs in the review reports)

- **The transport owns its liveness**: per-socket health (dial-time ping, strikes, eviction, backoff) in the socket entry itself, owned by itx-react; the watchdog and stream-store transport suspicion demote to subscription-level checks. Deletes the `resetTransport` concept, the triplicated strike policies, and closes the "pages with no subscription consumer have no half-open recovery" gap by construction.
- **Decompose `stream-browser-store.ts`** (~1,500 lines, one ~1,150-line closure over ~25 mutable locals) around an explicit ConnectionState + RuntimeLifecycle facade: election / ingest-lane / subscription-health / direct-calls modules; the B1/B2 invariants become signatures instead of cross-reference comments.
- **One shared connection + probe per (project, path)**: each stream view currently mounts two runtimes that independently dial, elect, reconcile, and probe the same DO — 2× probe load and two elections to reason about per incident.
- **Typed session errors in the capnweb fork**: `isSessionBrokenError`'s substring matching is load-bearing at a suspicion point; a `SessionBrokenError` class (or code) from all transport-death paths deletes it.
- **Explicit retain/release registry handles** (the `acquireDatabase` shape) to replace listener-count-as-refcount + grace timers.
- **Composer-owned idempotency keys**: an `appendBatch` that commits but exhausts retries reports failure; a manual resend mints new keys → duplicate. Binding draft→key in the composer makes resends idempotent end-to-end.
- Real probe RTT in the header instead of `useSimulatedRttMetrics`' `Math.random()`; per-context `useItxQuery` cache keys; dropping the reserved `ItxAddress.path`/`baseUrl` optionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Round 3: codex `gpt-5.6-sol` (xhigh reasoning) review — folded in

The codex review (properly pinned to this branch after its first pass wandered onto an unrelated in-flight metrics branch) found two blockers in the round-2 batch itself, both fixed in `ac1070468`:

- **Catch-up ingest deadline REVERTED** — `withDeadline` abandons the promise but can't cancel the ingest: a timeout would spin up a second processor over the same tables while the first kept committing (non-atomic projection/checkpoint writes → interleaved writers can regress reduced state). The wedged-db-worker latent returns to the deferred list where its real fix lives (generation-fenced worker shutdown inside `StreamBrowserDatabase`).
- **Identity-bound eviction** — the 15s age guard guessed; now the connecting promise IS the socket's identity: the default factory binds an evictor per client (`BrowserStreamClient.evictTransport` → `evictItxSocketIfCurrent`), every suspicion lane passes its suspect connection, and a late verdict against a replaced corpse can never evict a successor while a genuinely-dead YOUNG socket no longer waits out the guard (which remains only for identity-less fallback lanes).

Plus its majors: the dispose-race timer heuristic is superseded by a hook-level **re-acquire self-heal** (`useStreamProcessorStore` bumps an epoch when its memoized runtime is disposed at subscribe time — a delayed commit can never freeze the view); assertions now **prove the invariants** (watchdog test fails on one-strike reversion, backoff-progression + identity-eviction unit tests, and the half-open spec asserts every muted corpse CLOSED + census back to baseline); dial-failure bookkeeping is identity-guarded and reset on intentional eviction.

The strengthened census immediately exposed that the **global-context corpse had no recovery path** — fixed for real: the socket map now owns a **baseline resume sweep** (visibilitychange/online → one authenticated round trip per live socket, two strikes, identity-bound eviction), so pages with no watchdog consumer finally recover half-open sockets too (closes the reviewers' "consumer-conditional coverage" gap).

**Known bounded quirk, documented not chased**: the first post-eviction dial sometimes hits the 15s dial deadline (pipelined `projects.get` unanswered while the server tears down the aborted corpse session); the retry recovers in ~20ms and every lane passes locally, in CI, and against prd. Candidate cause for the transport-liveness refactor to own.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core WebSocket lifecycle, shared stream runtimes, and reconnect/eviction races across the tab; regressions could wedge feeds, leak sockets, or evict healthy connections, though changes are narrowly defensive.
> 
> **Overview**
> Hardens **browser WebSocket and stream-runtime recovery** after half-open transports, React yield gaps, and the #1894 corpse/successor eviction bug.
> 
> **`itx-react`:** Replaces three parallel socket maps with **one atomic entry** (promise + transport + dial time). Adds **exponential re-dial backoff** after repeated closed-before-open failures, **`evictItxSocketIfCurrent`** (identity-bound eviction), a **visibility/online resume sweep** with two-strike pings, routes **fleet `reconnectAllItx` through the young-socket guard**, and makes **`useItxQuery` resolve the live connection per fetch** instead of pinning a render-time handle.
> 
> **`stream-browser-store` / hooks:** Stream clients can carry **`evictTransport`** tied to the dial promise; suspicion paths prefer that over age-guarded `resetTransport`. Adds **2s idle-dispose grace + `retain()` on re-acquire** and **`isDisposed` + reacquire self-heal** in `useStreamProcessorStore` for the acquire→subscribe gap. **`connect()` is single-flighted per epoch**; **`callWhenReady` no longer resets armed backoff**; **`appendBatch` retries only transport failures**; shared **two-strike `runtimeState` reads** for probe/nudge/follower resume; safer unsubscribe and quieter follower nudge warnings.
> 
> **`project-stream-view`:** Default stream factory dials per call and wires **`evictItxSocketIfCurrent`** to the connecting promise.
> 
> **Tests:** Unit coverage for backoff, identity eviction, two-strike watchdog; suspend/resume spec now asserts **muted corpses close** and the **live socket census stays bounded**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac10704683d83ad939992084a50692844bd5c5d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-12T10:32:16.424Z",
      "headSha": "ac10704683d83ad939992084a50692844bd5c5d5",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/312867430188348",
      "shortSha": "ac10704",
      "cleanupDurationMs": 9274,
      "deployDurationMs": 73931,
      "testDurationMs": 220835,
      "testRetries": "2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · runs \"provide-itx-expression\" through the project REPL (specs x1)",
      "workerSizeKib": 16005.16,
      "workerGzipKib": 4317.07,
      "mainWorkerGzipKib": 4316.6
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-12T10:32:08.016Z",
      "headSha": "8368262a09c6ec724fd8b2e87670f77924da5320",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/150265425007713",
      "shortSha": "8368262",
      "cleanupDurationMs": 861,
      "deployDurationMs": 16028,
      "testDurationMs": 6375,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-12T10:32:10.281Z",
      "headSha": "ac10704683d83ad939992084a50692844bd5c5d5",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/312867430188348",
      "shortSha": "ac10704",
      "cleanupDurationMs": 3125,
      "deployDurationMs": 19616,
      "testDurationMs": 620,
      "testRetries": null,
      "workerSizeKib": 4032.01,
      "workerGzipKib": 819.56,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-12T10:32:08.323Z",
      "headSha": "ac10704683d83ad939992084a50692844bd5c5d5",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/312867430188348",
      "shortSha": "ac10704",
      "cleanupDurationMs": 1163,
      "deployDurationMs": 15897,
      "testDurationMs": 16803,
      "testRetries": null,
      "workerSizeKib": 4851.41,
      "workerGzipKib": 1388.14,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `ac10704` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 819.6 KiB | 19.6s | 620ms |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/312867430188348) | 2026-07-12T10:32:10.281Z | Preview app released. |
| OS | released | `ac10704` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 4.22 MiB (+0.5 KiB vs main) | 73.9s | 220.8s | 2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · runs "provide-itx-expression" through the project REPL (specs x1) | 9.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/312867430188348) | 2026-07-12T10:32:16.424Z | Preview app released. |
| Semaphore | released | `8368262` | [https://semaphore.iterate-preview-8.com](https://semaphore.iterate-preview-8.com) | 440.8 KiB | 16.0s | 6.4s |  | 861ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/150265425007713) | 2026-07-12T10:32:08.016Z | Preview app released. |
| Streams Example App | released | `ac10704` | [https://streams.iterate-preview-8.com](https://streams.iterate-preview-8.com) | 1.36 MiB | 15.9s | 16.8s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/312867430188348) | 2026-07-12T10:32:08.323Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +294 -139 | +155 -90 🟩🟩🟩🟥🟥 |
| Tests | +23 -1 | +12 -1 🟩⬜⬜⬜⬜ |
| **Total** | **+317 -140** | **+167 -91** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between e428cb2 and 8368262, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->
