### PR TITLE
Responsive stream metrics: 5s rates, per-second throughput series, windows named on every stat

### DIFF
--- a/apps/os/src/components/stream-processors-panel.tsx
+++ b/apps/os/src/components/stream-processors-panel.tsx
@@ -91,7 +91,7 @@ type ProcessorPanelEntry = {
  * Overview poll cadence while the sheet is open. Also the observer signal for
  * the stream's throttled ping sampling (see runtimeState in rpc-targets.ts).
  */
-const STREAM_RUNTIME_POLL_MS = 2_000;
+const STREAM_RUNTIME_POLL_MS = 1_000;
 
 const CORE_PROCESSOR_KEY = "__stream-core__";
 const CORE_PROCESSOR_ANNOUNCEMENT: AgentUiProcessorAnnouncement = {
@@ -384,7 +384,9 @@ function ProcessorsOverview({
             <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
               Connection RTT
             </span>
-            <span className="font-mono text-[10px] text-muted-foreground/70">this browser</span>
+            <span className="font-mono text-[10px] text-muted-foreground/70">
+              this browser · sampled each poll
+            </span>
           </div>
           <div className="mt-2 flex items-end gap-3">
             <span className="font-mono text-2xl font-semibold leading-none">
@@ -407,11 +409,19 @@ function ProcessorsOverview({
             )}
           </div>
           <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2">
-            <MetricStat label="p50" value={rtt === null ? "—" : `${rtt.p50}ms`} />
-            <MetricStat label="p95" value={rtt === null ? "—" : `${rtt.p95}ms`} />
             <MetricStat
-              label="append"
-              title="Append call → commit acknowledged (this browser's own appends)"
+              label="p50 · 32 samples"
+              title="Median of the last 32 RTT samples"
+              value={rtt === null ? "—" : `${rtt.p50}ms`}
+            />
+            <MetricStat
+              label="p95 · 32 samples"
+              title="95th percentile (nearest-rank) of the last 32 RTT samples"
+              value={rtt === null ? "—" : `${rtt.p95}ms`}
+            />
+            <MetricStat
+              label="append · last"
+              title="Most recent append call → commit acknowledged (this browser's own appends)"
               value={
                 subscriber?.appendRoundTripMs == null
                   ? "—"
@@ -419,40 +429,79 @@ function ProcessorsOverview({
               }
             />
             <MetricStat
-              label="own loop"
-              title="Append call → this browser's own subscription ingested the committed event"
+              label="own loop · last"
+              title="Most recent append call → this browser's own subscription ingested the committed event"
               value={
                 subscriber?.consumeOwnAppendMs == null
                   ? "—"
                   : `${subscriber.consumeOwnAppendMs.last}ms`
               }
             />
+          </div>
+
+          <div className="mt-4 flex items-baseline justify-between border-t border-border/60 pt-3">
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Throughput
+            </span>
+            <span className="font-mono text-[10px] text-muted-foreground/70">
+              this stream · 1s buckets · last 60s
+            </span>
+          </div>
+          {throughput === undefined ? (
+            <div className="mt-2 h-11 text-xs text-muted-foreground/70">measuring…</div>
+          ) : (
+            <div className="mt-2 flex items-end gap-3">
+              <span
+                className="font-mono text-2xl font-semibold leading-none"
+                title="Appends committed per second, trailing 5s"
+              >
+                {formatRate(throughput.ingress.perSecond5s)}
+                <span className="text-xs text-muted-foreground">ev/s</span>
+              </span>
+              <ThroughputGraph
+                ingress={throughput.ingress.series.counts}
+                egress={throughput.egress.series.counts}
+              />
+            </div>
+          )}
+          <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2">
             <MetricStat
-              label="events/s"
-              title="Appends committed on this stream over the last minute"
-              value={
-                throughput === undefined ? "—" : throughput.ingressLastMinute.perSecond.toFixed(1)
-              }
-            />
-            <MetricStat
-              label="in"
-              title="Bytes appended over the last minute"
+              label="in · 5s"
+              title="Bytes appended per second, trailing 5s"
               value={
                 throughput === undefined
                   ? "—"
-                  : formatBytesPerSecond(throughput.ingressLastMinute.bytes)
+                  : formatBytesPerSecond(throughput.ingress.bytesPerSecond5s)
               }
             />
             <MetricStat
-              label="out"
-              title="Bytes delivered to all subscribers over the last minute"
+              label="out · 5s"
+              title="Bytes delivered to all subscribers per second, trailing 5s"
               value={
                 throughput === undefined
                   ? "—"
-                  : formatBytesPerSecond(throughput.egressLastMinute.bytes)
+                  : formatBytesPerSecond(throughput.egress.bytesPerSecond5s)
               }
             />
-            <MetricStat label="head" value={`#${eventCount}`} />
+            <MetricStat
+              label="events · 60s"
+              title="Appends committed in the last minute (delivered in the last minute in parens)"
+              value={
+                throughput === undefined
+                  ? "—"
+                  : `${throughput.ingress.lastMinute.count} (${throughput.egress.lastMinute.count} out)`
+              }
+            />
+            <MetricStat label="head" title="Stream head offset" value={`#${eventCount}`} />
+            <MetricStat
+              label="measuring"
+              title={
+                throughput === undefined
+                  ? "Metrics are in-memory and reset when the stream Durable Object restarts"
+                  : `Since ${throughput.measuredSince} (in-memory; resets on stream restart)`
+              }
+              value={throughput === undefined ? "—" : sinceLabel(throughput.measuredSince)}
+            />
           </div>
           <div className="mt-3 flex justify-end">
             <Button
@@ -887,6 +936,52 @@ function readAnnouncement(value: unknown): AgentUiProcessorAnnouncement | null {
 function isLlmish(entry: Pick<AgentUiPresenceEntry, "processor">): boolean {
   const slug = entry.processor?.slug ?? "";
   return ["agent", "capability-host"].includes(slug);
+}
+
+/**
+ * Both throughput directions on one shared scale: ingress (appends) as the
+ * filled area, egress (deliveries) as the dashed line — comparable at a
+ * glance, and honest about which direction spiked.
+ */
+function ThroughputGraph({ ingress, egress }: { ingress: number[]; egress: number[] }) {
+  const max = Math.max(5, ...ingress, ...egress);
+  const ingressPoints = sparklinePoints(ingress, 368, 44, { max });
+  const egressPoints = sparklinePoints(egress, 368, 44, { max });
+  return (
+    <svg viewBox="0 0 368 44" className="h-11 min-w-0 flex-1" preserveAspectRatio="none">
+      <title>{`Appends (area) and deliveries (dashed) per second over the last 60s; peak ${max}/s`}</title>
+      <polygon points={`2,42 ${ingressPoints} 366,42`} className="fill-sky-500/15" />
+      <polyline
+        points={ingressPoints}
+        fill="none"
+        className="stroke-sky-600"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+      <polyline
+        points={egressPoints}
+        fill="none"
+        strokeDasharray="3 2"
+        className="stroke-emerald-600/80"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+/** Rates jitter less as "12" / "3.4" / "0.2" than as raw floats. */
+function formatRate(perSecond: number): string {
+  if (perSecond >= 10) return String(Math.round(perSecond));
+  return perSecond.toFixed(1);
+}
+
+/** Compact "how long has this window been collecting" caption. */
+function sinceLabel(measuredSinceIso: string): string {
+  const seconds = Math.max(0, Math.round((Date.now() - Date.parse(measuredSinceIso)) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  return `${(seconds / 3600).toFixed(1)}h`;
 }
 
 function MetricStat({ label, value, title }: { label: string; value: string; title?: string }) {

--- a/apps/os/src/domains/streams/stream-runtime-metrics.test.ts
+++ b/apps/os/src/domains/streams/stream-runtime-metrics.test.ts
@@ -81,16 +81,44 @@ describe("MinuteBuckets", () => {
   });
 });
 
+describe("MinuteBuckets windows and series", () => {
+  it("short windows report responsive rates; old buckets fall out", () => {
+    const buckets = new MinuteBuckets();
+    const t0 = 100_000_000;
+    buckets.bump(t0, 30, 3_000); // 10s ago — outside a 5s window
+    buckets.bump(t0 + 8_000, 10, 1_000); // 2s ago — inside
+    expect(buckets.window(t0 + 10_000, 5)).toEqual({ count: 10, bytes: 1_000 });
+    expect(buckets.window(t0 + 10_000, 60)).toEqual({ count: 40, bytes: 4_000 });
+  });
+
+  it("series is exactly 60 per-second entries, oldest→newest, silent seconds zero", () => {
+    const buckets = new MinuteBuckets();
+    const t0 = 100_000_000;
+    buckets.bump(t0, 7, 700); // now − 59s: the oldest visible bucket
+    buckets.bump(t0 + 59_000, 2, 200); // the current second
+    const series = buckets.series(t0 + 59_000);
+    expect(series.counts).toHaveLength(60);
+    expect(series.counts[0]).toBe(7);
+    expect(series.counts[59]).toBe(2);
+    expect(series.counts.reduce((sum, n) => sum + n, 0)).toBe(9);
+    expect(series.bytes[0]).toBe(700);
+    expect(series.bytes[59]).toBe(200);
+  });
+});
+
 describe("StreamRuntimeMetrics", () => {
-  it("reports measuredSince and both windows", () => {
+  it("reports measuredSince plus responsive rates, minute totals, and the series", () => {
     const metrics = new StreamRuntimeMetrics(1_700_000_000_000);
     metrics.ingress.bump(1_700_000_010_000, 4, 4000);
     metrics.egress.bump(1_700_000_010_000, 8, 8000);
-    expect(metrics.report(1_700_000_010_500)).toEqual({
-      measuredSince: "2023-11-14T22:13:20.000Z",
-      ingressLastMinute: { count: 4, bytes: 4000, perSecond: 4 / 60 },
-      egressLastMinute: { count: 8, bytes: 8000, perSecond: 8 / 60 },
-    });
+    const report = metrics.report(1_700_000_010_500);
+    expect(report.measuredSince).toBe("2023-11-14T22:13:20.000Z");
+    expect(report.ingress.perSecond5s).toBe(4 / 5);
+    expect(report.ingress.bytesPerSecond5s).toBe(4000 / 5);
+    expect(report.ingress.lastMinute).toEqual({ count: 4, bytes: 4000, perSecond: 4 / 60 });
+    expect(report.ingress.series.counts.reduce((sum, n) => sum + n, 0)).toBe(4);
+    expect(report.egress.perSecond5s).toBe(8 / 5);
+    expect(report.egress.lastMinute.bytes).toBe(8000);
   });
 });
 

--- a/apps/os/src/domains/streams/stream-runtime-metrics.ts
+++ b/apps/os/src/domains/streams/stream-runtime-metrics.ts
@@ -100,27 +100,71 @@ export class MinuteBuckets {
   }
 
   lastMinute(nowMs: number): MinuteWindow {
+    const { count, bytes } = this.window(nowMs, 60);
+    return { count, bytes, perSecond: count / 60 };
+  }
+
+  /** Totals over the trailing `seconds` (≤60) — short windows make responsive rates. */
+  window(nowMs: number, seconds: number): { count: number; bytes: number } {
     const nowSecond = Math.floor(nowMs / 1000);
     let count = 0;
     let bytes = 0;
     for (let slot = 0; slot < 60; slot += 1) {
       const second = this.#seconds[slot]!;
-      if (second < 0 || second > nowSecond || second <= nowSecond - 60) continue;
+      if (second < 0 || second > nowSecond || second <= nowSecond - seconds) continue;
       count += this.#counts[slot]!;
       bytes += this.#bytes[slot]!;
     }
-    return { count, bytes, perSecond: count / 60 };
+    return { count, bytes };
+  }
+
+  /**
+   * The raw per-second buckets, oldest→newest, always exactly 60 entries
+   * (silent seconds are zero) — what a UI graphs directly, so the graph is
+   * the measurement rather than a client-side reconstruction of it.
+   */
+  series(nowMs: number): ThroughputSeries {
+    const nowSecond = Math.floor(nowMs / 1000);
+    const counts = new Array<number>(60).fill(0);
+    const bytes = new Array<number>(60).fill(0);
+    for (let slot = 0; slot < 60; slot += 1) {
+      const second = this.#seconds[slot]!;
+      if (second < 0 || second > nowSecond || second <= nowSecond - 60) continue;
+      const index = 59 - (nowSecond - second);
+      counts[index] = this.#counts[slot]!;
+      bytes[index] = this.#bytes[slot]!;
+    }
+    return { counts, bytes };
   }
 }
+
+/** Per-second buckets over the trailing minute, oldest→newest, length 60. */
+export type ThroughputSeries = {
+  counts: number[];
+  bytes: number[];
+};
+
+/**
+ * One direction's throughput report: a responsive trailing-5s rate (the
+ * number UIs show), the full-minute totals, and the raw 1s series for graphs.
+ */
+export type ThroughputReport = {
+  /** Events per second over the trailing 5 seconds. */
+  perSecond5s: number;
+  /** Payload bytes per second over the trailing 5 seconds. */
+  bytesPerSecond5s: number;
+  lastMinute: MinuteWindow;
+  series: ThroughputSeries;
+};
 
 /** What `runtimeState()` reports for the stream's own throughput. */
 export type StreamThroughputMetrics = {
   /** ISO timestamp when this incarnation started measuring (metrics reset on eviction). */
   measuredSince: string;
   /** Appends committed (all producers). */
-  ingressLastMinute: MinuteWindow;
+  ingress: ThroughputReport;
   /** Deliveries dispatched (all lanes, all subscribers). */
-  egressLastMinute: MinuteWindow;
+  egress: ThroughputReport;
 };
 
 /** The stream Durable Object's in-memory throughput accounting. */
@@ -134,10 +178,19 @@ export class StreamRuntimeMetrics {
   }
 
   report(nowMs: number): StreamThroughputMetrics {
+    const direction = (buckets: MinuteBuckets): ThroughputReport => {
+      const trailing5s = buckets.window(nowMs, 5);
+      return {
+        perSecond5s: trailing5s.count / 5,
+        bytesPerSecond5s: trailing5s.bytes / 5,
+        lastMinute: buckets.lastMinute(nowMs),
+        series: buckets.series(nowMs),
+      };
+    };
     return {
       measuredSince: new Date(this.#measuredSinceMs).toISOString(),
-      ingressLastMinute: this.ingress.lastMinute(nowMs),
-      egressLastMinute: this.egress.lastMinute(nowMs),
+      ingress: direction(this.ingress),
+      egress: direction(this.egress),
     };
   }
 }

--- a/apps/os/src/domains/streams/test-helpers.ts
+++ b/apps/os/src/domains/streams/test-helpers.ts
@@ -25,6 +25,15 @@ import {
  * on purpose: a change to the runtime shape becomes a one-line edit here
  * instead of the same mechanical edit in every test double.
  */
+function emptyThroughputReport() {
+  return {
+    perSecond5s: 0,
+    bytesPerSecond5s: 0,
+    lastMinute: { count: 0, bytes: 0, perSecond: 0 },
+    series: { counts: new Array(60).fill(0), bytes: new Array(60).fill(0) },
+  };
+}
+
 export function emptyStreamRuntimeState() {
   return {
     coreProcessorState: null,
@@ -33,8 +42,8 @@ export function emptyStreamRuntimeState() {
       subscriptions: {},
       metrics: {
         measuredSince: new Date(0).toISOString(),
-        ingressLastMinute: { count: 0, bytes: 0, perSecond: 0 },
-        egressLastMinute: { count: 0, bytes: 0, perSecond: 0 },
+        ingress: emptyThroughputReport(),
+        egress: emptyThroughputReport(),
       },
     },
   };

--- a/apps/os/src/itx-api-graph.generated.ts
+++ b/apps/os/src/itx-api-graph.generated.ts
@@ -1530,10 +1530,10 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     name: "StreamThroughputMetrics",
     kind: "typeAlias",
     sourceText:
-      "/** What `runtimeState()` reports for the stream's own throughput. */\nexport type StreamThroughputMetrics = {\n  /** ISO timestamp when this incarnation started measuring (metrics reset on eviction). */\n  measuredSince: string;\n  /** Appends committed (all producers). */\n  ingressLastMinute: MinuteWindow;\n  /** Deliveries dispatched (all lanes, all subscribers). */\n  egressLastMinute: MinuteWindow;\n};",
+      "/** What `runtimeState()` reports for the stream's own throughput. */\nexport type StreamThroughputMetrics = {\n  /** ISO timestamp when this incarnation started measuring (metrics reset on eviction). */\n  measuredSince: string;\n  /** Appends committed (all producers). */\n  ingress: ThroughputReport;\n  /** Deliveries dispatched (all lanes, all subscribers). */\n  egress: ThroughputReport;\n};",
     summary: "What `runtimeState()` reports for the stream's own throughput.",
     memberSummaries: {},
-    referencedTypeNames: ["MinuteWindow"],
+    referencedTypeNames: ["ThroughputReport"],
   },
   {
     name: "ProcessEventBatch",
@@ -1821,13 +1821,14 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     referencedTypeNames: ["ItxExpression"],
   },
   {
-    name: "MinuteWindow",
+    name: "ThroughputReport",
     kind: "typeAlias",
     sourceText:
-      '/** One rolling-minute throughput window. */\nexport type MinuteWindow = {\n  /** Events in the last 60 seconds. */\n  count: number;\n  /** Payload bytes in the last 60 seconds. */\n  bytes: number;\n  /** `count / 60` — the "events/s over the last minute" number. */\n  perSecond: number;\n};',
-    summary: "One rolling-minute throughput window.",
+      "/**\n * One direction's throughput report: a responsive trailing-5s rate (the\n * number UIs show), the full-minute totals, and the raw 1s series for graphs.\n */\nexport type ThroughputReport = {\n  /** Events per second over the trailing 5 seconds. */\n  perSecond5s: number;\n  /** Payload bytes per second over the trailing 5 seconds. */\n  bytesPerSecond5s: number;\n  lastMinute: MinuteWindow;\n  series: ThroughputSeries;\n};",
+    summary:
+      "One direction's throughput report: a responsive trailing-5s rate (the number UIs show), the full-minute totals, and the raw 1s series for graphs.",
     memberSummaries: {},
-    referencedTypeNames: [],
+    referencedTypeNames: ["MinuteWindow", "ThroughputSeries"],
   },
   {
     name: "StreamEventBatch",
@@ -1941,6 +1942,24 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     sourceText:
       "/** One commit returned by `WorkspaceGit.log` (the config repo's main history). */\nexport type WorkspaceGitLogEntry = {\n  author: { email: string; name: string };\n  message: string;\n  oid: string;\n  /** Epoch milliseconds. */\n  timestamp: number;\n};",
     summary: "One commit returned by `WorkspaceGit.log` (the config repo's main history).",
+    memberSummaries: {},
+    referencedTypeNames: [],
+  },
+  {
+    name: "MinuteWindow",
+    kind: "typeAlias",
+    sourceText:
+      '/** One rolling-minute throughput window. */\nexport type MinuteWindow = {\n  /** Events in the last 60 seconds. */\n  count: number;\n  /** Payload bytes in the last 60 seconds. */\n  bytes: number;\n  /** `count / 60` — the "events/s over the last minute" number. */\n  perSecond: number;\n};',
+    summary: "One rolling-minute throughput window.",
+    memberSummaries: {},
+    referencedTypeNames: [],
+  },
+  {
+    name: "ThroughputSeries",
+    kind: "typeAlias",
+    sourceText:
+      "/** Per-second buckets over the trailing minute, oldest→newest, length 60. */\nexport type ThroughputSeries = {\n  counts: number[];\n  bytes: number[];\n};",
+    summary: "Per-second buckets over the trailing minute, oldest→newest, length 60.",
     memberSummaries: {},
     referencedTypeNames: [],
   },

--- a/apps/os/src/itx-api.generated.ts
+++ b/apps/os/src/itx-api.generated.ts
@@ -2477,9 +2477,9 @@ export type StreamThroughputMetrics = {
   /** ISO timestamp when this incarnation started measuring (metrics reset on eviction). */
   measuredSince: string;
   /** Appends committed (all producers). */
-  ingressLastMinute: MinuteWindow;
+  ingress: ThroughputReport;
   /** Deliveries dispatched (all lanes, all subscribers). */
-  egressLastMinute: MinuteWindow;
+  egress: ThroughputReport;
 };
 
 /**
@@ -2836,14 +2836,17 @@ export type SubscriptionDelivery =
   | { mode: "push"; expression: ItxExpression }
   | { mode: "webhook"; url: string };
 
-/** One rolling-minute throughput window. */
-export type MinuteWindow = {
-  /** Events in the last 60 seconds. */
-  count: number;
-  /** Payload bytes in the last 60 seconds. */
-  bytes: number;
-  /** `count / 60` — the "events/s over the last minute" number. */
-  perSecond: number;
+/**
+ * One direction's throughput report: a responsive trailing-5s rate (the
+ * number UIs show), the full-minute totals, and the raw 1s series for graphs.
+ */
+export type ThroughputReport = {
+  /** Events per second over the trailing 5 seconds. */
+  perSecond5s: number;
+  /** Payload bytes per second over the trailing 5 seconds. */
+  bytesPerSecond5s: number;
+  lastMinute: MinuteWindow;
+  series: ThroughputSeries;
 };
 
 /**
@@ -3002,6 +3005,22 @@ export type WorkspaceGitLogEntry = {
   oid: string;
   /** Epoch milliseconds. */
   timestamp: number;
+};
+
+/** One rolling-minute throughput window. */
+export type MinuteWindow = {
+  /** Events in the last 60 seconds. */
+  count: number;
+  /** Payload bytes in the last 60 seconds. */
+  bytes: number;
+  /** `count / 60` — the "events/s over the last minute" number. */
+  perSecond: number;
+};
+
+/** Per-second buckets over the trailing minute, oldest→newest, length 60. */
+export type ThroughputSeries = {
+  counts: number[];
+  bytes: number[];
 };
 
 /** One Cloudflare Images transform step (width, height, fit, rotate, …),

--- a/apps/os/src/lib/feed-format.ts
+++ b/apps/os/src/lib/feed-format.ts
@@ -27,10 +27,10 @@ export function formatFileSize(size: number): string {
   return `${(kilobytes / 1024).toFixed(1).replace(/\.0$/, "")} MB`;
 }
 
-/** Human bytes-per-second from a rolling one-minute byte total. */
-export function formatBytesPerSecond(bytesPerMinute: number): string {
-  if (bytesPerMinute <= 0) return "0 B/s";
-  return `${formatFileSize(Math.round(bytesPerMinute / 60))}/s`;
+/** Human bytes-per-second rate. */
+export function formatBytesPerSecond(bytesPerSecond: number): string {
+  if (bytesPerSecond <= 0) return "0 B/s";
+  return `${formatFileSize(Math.round(bytesPerSecond))}/s`;
 }
 
 /** Code-mode agents stream itx code as their response; chat agents stream

--- a/apps/os/src/lib/stream-presence.ts
+++ b/apps/os/src/lib/stream-presence.ts
@@ -21,7 +21,7 @@ export type BrowserStreamMetricsView = BrowserStreamMetrics & {
 };
 
 const SPARK_LENGTH = 24;
-const METRICS_POLL_MS = 2_000;
+const METRICS_POLL_MS = 1_000;
 
 /** Poll the store's measured metrics and accumulate the RTT sparkline. */
 export function useBrowserStreamMetrics(store: {
@@ -36,6 +36,7 @@ export function useBrowserStreamMetrics(store: {
   useEffect(() => {
     let spark: number[] = [];
     let lastSampleAt = 0;
+    let lastSerialized = "";
     const tick = () => {
       const current = store.metrics();
       const rtt = current.transportRttMs;
@@ -43,7 +44,13 @@ export function useBrowserStreamMetrics(store: {
         lastSampleAt = rtt.lastAt;
         spark = [...spark.slice(-(SPARK_LENGTH - 1)), rtt.last];
       }
-      setView({ ...current, spark });
+      // Change-gated: ticks without a new sample (a quiet stream between
+      // probes) must not rerender the whole stream view every second.
+      const next = { ...current, spark };
+      const serialized = JSON.stringify(next);
+      if (serialized === lastSerialized) return;
+      lastSerialized = serialized;
+      setView(next);
     };
     tick();
     const timer = setInterval(tick, METRICS_POLL_MS);
@@ -53,11 +60,16 @@ export function useBrowserStreamMetrics(store: {
   return view;
 }
 
-export function sparklinePoints(values: readonly number[], width: number, height: number): string {
-  // Scale to the window's own max (floored so ordinary sub-100ms jitter
-  // doesn't render as drama), instead of a hardcoded ceiling that flattens
-  // fast connections and clips slow ones.
-  const max = Math.max(100, ...values);
+export function sparklinePoints(
+  values: readonly number[],
+  width: number,
+  height: number,
+  opts: {
+    /** Shared scale for multi-series graphs; defaults to this series' own max, floored at 100 (RTT jitter shouldn't render as drama). */
+    max?: number;
+  } = {},
+): string {
+  const max = opts.max ?? Math.max(100, ...values);
   const count = values.length;
   if (count === 0) return "";
   return values

--- a/packages/iterate/src/itx-api.generated.ts
+++ b/packages/iterate/src/itx-api.generated.ts
@@ -2477,9 +2477,9 @@ export type StreamThroughputMetrics = {
   /** ISO timestamp when this incarnation started measuring (metrics reset on eviction). */
   measuredSince: string;
   /** Appends committed (all producers). */
-  ingressLastMinute: MinuteWindow;
+  ingress: ThroughputReport;
   /** Deliveries dispatched (all lanes, all subscribers). */
-  egressLastMinute: MinuteWindow;
+  egress: ThroughputReport;
 };
 
 /**
@@ -2836,14 +2836,17 @@ export type SubscriptionDelivery =
   | { mode: "push"; expression: ItxExpression }
   | { mode: "webhook"; url: string };
 
-/** One rolling-minute throughput window. */
-export type MinuteWindow = {
-  /** Events in the last 60 seconds. */
-  count: number;
-  /** Payload bytes in the last 60 seconds. */
-  bytes: number;
-  /** `count / 60` — the "events/s over the last minute" number. */
-  perSecond: number;
+/**
+ * One direction's throughput report: a responsive trailing-5s rate (the
+ * number UIs show), the full-minute totals, and the raw 1s series for graphs.
+ */
+export type ThroughputReport = {
+  /** Events per second over the trailing 5 seconds. */
+  perSecond5s: number;
+  /** Payload bytes per second over the trailing 5 seconds. */
+  bytesPerSecond5s: number;
+  lastMinute: MinuteWindow;
+  series: ThroughputSeries;
 };
 
 /**
@@ -3002,6 +3005,22 @@ export type WorkspaceGitLogEntry = {
   oid: string;
   /** Epoch milliseconds. */
   timestamp: number;
+};
+
+/** One rolling-minute throughput window. */
+export type MinuteWindow = {
+  /** Events in the last 60 seconds. */
+  count: number;
+  /** Payload bytes in the last 60 seconds. */
+  bytes: number;
+  /** `count / 60` — the "events/s over the last minute" number. */
+  perSecond: number;
+};
+
+/** Per-second buckets over the trailing minute, oldest→newest, length 60. */
+export type ThroughputSeries = {
+  counts: number[];
+  bytes: number[];
 };
 
 /** One Cloudflare Images transform step (width, height, fit, rotate, …),


### PR DESCRIPTION
## What

Follow-up to #1895 (per review feedback on the live prd panel): the numbers were minute-averages — a burst smeared into a small number that took 60 seconds to decay — and nothing said which timeframe anything was measured over.

### Responsive numbers
- The stream DO now reports, per direction (ingress = appends, egress = deliveries): **trailing-5s rates** (the number UIs show), the minute totals, and the **raw 60×1s bucket series**.
- Panel polls every **1s** while open. TanStack's focus-gating pauses polling in hidden tabs — which also pauses the stream's observer-driven ping sampling, exactly the right coupling (a hidden tab isn't observing). Refetch fires on refocus.
- The browser metrics hook ticks at 1s with **change-gated setState**, so quiet streams don't rerender the stream view every second.

### Timeframes named on every stat
The card is now two labeled sections:
- **CONNECTION RTT** — `this browser · sampled each poll`; `p50/p95 · 32 samples`; `append · last`; `own loop · last`.
- **THROUGHPUT** — `this stream · 1s buckets · last 60s`; `events/s`, `in`, `out` over a `· 5s` window; `events · 60s` totals (in + out); `measuring Xm` caption with a tooltip stating metrics are in-memory and reset on stream restart.

### A graph that means something
The throughput graph renders the server's actual 1s buckets — appends as a filled area, deliveries as a dashed line, on one **shared scale** (peak stated in the tooltip). The graph is the measurement, not a client-side reconstruction from poll deltas. The RTT sparkline stays for the browser's own samples.

## Live-verified (local dev)
A 12-event burst shows **2.4 ev/s** (12/5s), **377 B/s in / 1.1 KB/s out** within one poll; the burst falls out of the 5s window seconds later while `events · 60s` keeps the minute total; append 67ms / own loop 86ms populate on send.

## Also noticed
- `formatBytesPerSecond` now takes a true per-second rate (was a bytes-per-minute divide hidden in the formatter).
- `sparklinePoints` accepts a shared `max` for multi-series graphs.
- The `emptyStreamRuntimeState()` dedupe from #1895 paid off immediately: this shape change was a one-line stub edit instead of eight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to `StreamThroughputMetrics` on `runtimeState()` affects any RPC consumers; scope is mostly debug UI and in-memory metrics with solid unit tests.
> 
> **Overview**
> Stream **`runtimeState()` throughput** is reshaped from flat minute windows (`ingressLastMinute` / `egressLastMinute`) to per-direction **`ThroughputReport`** objects: trailing **5s** event and byte rates, minute totals, and a **60×1s** `series` for charts. **`MinuteBuckets`** gains **`window()`** and **`series()`**; tests and **`emptyStreamRuntimeState()`** follow the new shape (generated API types updated).
> 
> The **processors panel** splits metrics into **Connection RTT** and **Throughput** sections with explicit time windows on labels, polls runtime every **1s** (was 2s), and adds a **`ThroughputGraph`** (ingress area + egress dashed line on a shared scale from server buckets). **`formatBytesPerSecond`** now expects a true per-second rate; **`sparklinePoints`** accepts optional shared **`max`**.
> 
> **`useBrowserStreamMetrics`** also polls at 1s and **change-gates** `setState` via JSON serialization so quiet streams avoid full-view rerenders when samples are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 311eaf45414f39257e3bdbd86909f9a3f1dab959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +93 -19 | +71 -15 🟩🟩🟩🟥⬜ |
| UI components | +113 -18 | +102 -18 🟩🟩🟩🟩🟥 |
| Tests | +34 -6 | +32 -6 🟩🟩⬜⬜⬜ |
| Generated | +83 -26 | +57 -18 🟩🟩🟥⬜⬜ |
| **Total** | **+323 -69** | **+262 -57** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 8ae677c and 311eaf4, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-12T14:43:00.972Z",
      "headSha": "311eaf45414f39257e3bdbd86909f9a3f1dab959",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/255466075128615",
      "shortSha": "311eaf4",
      "cleanupDurationMs": 8773,
      "deployDurationMs": 81619,
      "workerSizeKib": 16045.06,
      "workerGzipKib": 4328.69,
      "mainWorkerGzipKib": 4327.67
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-12T14:42:56.119Z",
      "headSha": "311eaf45414f39257e3bdbd86909f9a3f1dab959",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/255466075128615",
      "shortSha": "311eaf4",
      "cleanupDurationMs": 3916,
      "deployDurationMs": 20084,
      "workerSizeKib": 4032.01,
      "workerGzipKib": 819.66,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-12T14:42:53.344Z",
      "headSha": "311eaf45414f39257e3bdbd86909f9a3f1dab959",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/255466075128615",
      "shortSha": "311eaf4",
      "cleanupDurationMs": 1137,
      "deployDurationMs": 15592,
      "workerSizeKib": 4874.72,
      "workerGzipKib": 1394.81,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `311eaf4` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 819.7 KiB | 20.1s |  |  | 3.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/255466075128615) | 2026-07-12T14:42:56.119Z | Preview app released. |
| OS | released | `311eaf4` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.23 MiB (+1.0 KiB vs main) | 81.6s |  |  | 8.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/255466075128615) | 2026-07-12T14:43:00.972Z | Preview app released. |
| Streams Example App | released | `311eaf4` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 1.36 MiB | 15.6s |  |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/255466075128615) | 2026-07-12T14:42:53.344Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->