### PR TITLE
Throughput tooltip reports the true peak, not the floored axis scale

### DIFF
--- a/apps/os/src/components/stream-processors-panel.tsx
+++ b/apps/os/src/components/stream-processors-panel.tsx
@@ -944,12 +944,15 @@ function isLlmish(entry: Pick<AgentUiPresenceEntry, "processor">): boolean {
  * glance, and honest about which direction spiked.
  */
 function ThroughputGraph({ ingress, egress }: { ingress: number[]; egress: number[] }) {
-  const max = Math.max(5, ...ingress, ...egress);
+  const peak = Math.max(...ingress, ...egress);
+  // The scale floors at 5/s so single events don't render as mountains; the
+  // tooltip reports the TRUE peak, not the floored axis.
+  const max = Math.max(5, peak);
   const ingressPoints = sparklinePoints(ingress, 368, 44, { max });
   const egressPoints = sparklinePoints(egress, 368, 44, { max });
   return (
     <svg viewBox="0 0 368 44" className="h-11 min-w-0 flex-1" preserveAspectRatio="none">
-      <title>{`Appends (area) and deliveries (dashed) per second over the last 60s; peak ${max}/s`}</title>
+      <title>{`Appends (area) and deliveries (dashed) per second over the last 60s; peak ${peak}/s`}</title>
       <polygon points={`2,42 ${ingressPoints} 366,42`} className="fill-sky-500/15" />
       <polyline
         points={ingressPoints}


### PR DESCRIPTION
One-liner follow-up to #1903 addressing [Bugbot's finding](https://github.com/iterate/iterate/pull/1903#discussion_r3566505789): `ThroughputGraph` floors the y-axis at 5/s for readability, and the tooltip was reporting that floor as the peak. It now states the true peak while keeping the floored scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only tooltip fix in the processors panel; no data or API behavior changes.
> 
> **Overview**
> Fixes misleading hover text on the stream processors **Throughput** sparkline: the chart still floors the shared ingress/egress scale at **5/s** so low traffic doesn’t look like a spike, but the SVG `<title>` now reports the **actual** peak rate from the 60s buckets instead of that floor value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 775d59257f68419cf4e96f5c0a2721afd2e93c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +5 -2 | +3 -2 🟩🟩🟩🟥🟥 |
| **Total** | **+5 -2** | **+3 -2** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between b2a9553 and 775d592, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->