### PR TITLE
itx.mcp.beginOAuth: agents connect OAuth-protected MCP servers

### DIFF
--- a/apps/dummy-petshop/src/seal.ts
+++ b/apps/dummy-petshop/src/seal.ts
@@ -99,3 +99,15 @@ export async function hmacSha256Hex(secret: string, payload: string): Promise<st
 export function nowSeconds(): number {
   return Math.floor(Date.now() / 1000);
 }
+
+/**
+ * PKCE S256 challenge for a verifier: base64url(SHA-256(verifier)) (RFC 7636
+ * §4.2). The MCP OAuth client sends `code_challenge` at /oauth/authorize and
+ * the matching `code_verifier` at /oauth/token; the token endpoint recomputes
+ * this and compares, so a leaked authorization code is useless without the
+ * verifier that never left the client.
+ */
+export async function pkceS256(verifier: string): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", encoder.encode(verifier)));
+  return b64url(digest);
+}

--- a/apps/dummy-petshop/src/state.ts
+++ b/apps/dummy-petshop/src/state.ts
@@ -30,6 +30,14 @@ export const DEFAULT_INSTALLATION_ID = "petshop-installation";
 export interface OauthClient {
   clientSecret: string;
   accessTokenTtlSeconds: number;
+  /** RFC 7591 dynamically-registered redirect URIs. Empty for the seeded/backdoor
+   * clients (they accept any absolute redirect_uri); a DCR client is pinned to
+   * exactly what it registered. */
+  redirectUris?: string[];
+  /** A public client (token_endpoint_auth_method "none", the standard MCP shape)
+   * has no secret and authenticates at the token endpoint with PKCE + its
+   * client_id in the body instead of HTTP Basic. */
+  public?: boolean;
 }
 
 /**
@@ -136,13 +144,18 @@ export class PetshopStateDurableObject extends DurableObject {
 
   async createClient(input: {
     accessTokenTtlSeconds?: number;
+    redirectUris?: string[];
+    public?: boolean;
   }): Promise<{ clientId: string; clientSecret: string }> {
     const state = await this.#load();
     const clientId = `petshop-client-${crypto.randomUUID().slice(0, 8)}`;
-    const clientSecret = crypto.randomUUID();
+    // A public client has no usable secret; a confidential one authenticates with it.
+    const clientSecret = input.public ? "" : crypto.randomUUID();
     state.clients[clientId] = {
       clientSecret,
       accessTokenTtlSeconds: input.accessTokenTtlSeconds ?? DEFAULT_ACCESS_TTL_SECONDS,
+      ...(input.redirectUris ? { redirectUris: input.redirectUris } : {}),
+      ...(input.public ? { public: true } : {}),
     };
     await this.#save(state);
     return { clientId, clientSecret };

--- a/apps/dummy-petshop/src/worker.test.ts
+++ b/apps/dummy-petshop/src/worker.test.ts
@@ -601,7 +601,7 @@ describe("mcp oauth (RFC 9728 / 8414 / 7591 + PKCE)", () => {
       token_endpoint: `${ORIGIN}/oauth/token`,
       registration_endpoint: `${ORIGIN}/oauth/register`,
       code_challenge_methods_supported: ["S256"],
-      token_endpoint_auth_methods_supported: ["client_secret_basic"],
+      token_endpoint_auth_methods_supported: ["none", "client_secret_basic"],
     });
   });
 
@@ -699,5 +699,87 @@ describe("mcp oauth (RFC 9728 / 8414 / 7591 + PKCE)", () => {
     });
     expect(missing.status).toBe(400);
     expect(await missing.json()).toMatchObject({ error: "invalid_grant" });
+  });
+
+  test("public client (token_endpoint_auth_method none): no secret, client_id + PKCE at token", async () => {
+    const shop = makeShop();
+    const registration = (await (
+      await shop("/oauth/register", {
+        ...postJson({ redirect_uris: [REDIRECT_URI], token_endpoint_auth_method: "none" }),
+      })
+    ).json()) as { client_id: string; client_secret?: string; token_endpoint_auth_method: string };
+    // A public client gets no secret back.
+    expect(registration.client_secret).toBeUndefined();
+    expect(registration.token_endpoint_auth_method).toBe("none");
+
+    const verifier = "verifier-" + "p".repeat(50);
+    const location = await approve(shop, {
+      client_id: registration.client_id,
+      redirect_uri: REDIRECT_URI,
+      code_challenge: await pkceS256(verifier),
+    });
+    // No Basic auth — the client identifies itself with client_id in the body.
+    const token = await shop("/oauth/token", {
+      method: "POST",
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        client_id: registration.client_id,
+        code: location.searchParams.get("code") ?? "",
+        redirect_uri: REDIRECT_URI,
+        code_verifier: verifier,
+      }),
+    });
+    expect(token.status).toBe(200);
+    const tokens = (await token.json()) as { access_token: string; refresh_token: string };
+    expect((await shop("/api/me", bearer(tokens.access_token))).status).toBe(200);
+
+    // Public-client refresh: client_id in the body, still no Basic auth.
+    const refreshed = await shop("/oauth/token", {
+      method: "POST",
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: registration.client_id,
+        refresh_token: tokens.refresh_token,
+      }),
+    });
+    expect(refreshed.status).toBe(200);
+  });
+
+  test("a public client with no PKCE verifier is rejected", async () => {
+    const shop = makeShop();
+    const registration = (await (
+      await shop("/oauth/register", {
+        ...postJson({ redirect_uris: [REDIRECT_URI], token_endpoint_auth_method: "none" }),
+      })
+    ).json()) as { client_id: string };
+    // No code_challenge at authorize → the public code has no PKCE binding.
+    const location = await approve(shop, {
+      client_id: registration.client_id,
+      redirect_uri: REDIRECT_URI,
+    });
+    const token = await shop("/oauth/token", {
+      method: "POST",
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        client_id: registration.client_id,
+        code: location.searchParams.get("code") ?? "",
+        redirect_uri: REDIRECT_URI,
+      }),
+    });
+    expect(token.status).toBe(400);
+    expect(await token.json()).toMatchObject({ error: "invalid_grant" });
+  });
+
+  test("a dynamically-registered client is pinned to its redirect URIs", async () => {
+    const shop = makeShop();
+    const client = (await (
+      await shop("/oauth/register", { ...postJson({ redirect_uris: [REDIRECT_URI] }) })
+    ).json()) as { client_id: string };
+    // An unregistered redirect_uri is refused (no open redirect).
+    const rejected = await shop(
+      `/oauth/authorize?client_id=${client.client_id}&redirect_uri=${encodeURIComponent("https://evil.example/steal")}&approve=1`,
+    );
+    expect(rejected.status).toBe(400);
+    expect(await rejected.json()).toMatchObject({ error: "invalid_request" });
   });
 });

--- a/apps/dummy-petshop/src/worker.test.ts
+++ b/apps/dummy-petshop/src/worker.test.ts
@@ -9,7 +9,7 @@ import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { seedPets } from "./pets.ts";
-import { randomSealKey } from "./seal.ts";
+import { pkceS256, randomSealKey } from "./seal.ts";
 import {
   DEFAULT_ACCESS_TTL_SECONDS,
   DEFAULT_CLIENT_ID,
@@ -50,7 +50,13 @@ const basicAuth = (clientId: string, clientSecret: string) =>
 
 async function approve(
   shop: Shop,
-  fields: { client_id: string; redirect_uri: string; state?: string; user?: string },
+  fields: {
+    client_id: string;
+    redirect_uri: string;
+    state?: string;
+    user?: string;
+    code_challenge?: string;
+  },
 ): Promise<URL> {
   const response = await shop("/oauth/authorize", {
     method: "POST",
@@ -562,5 +568,136 @@ describe("backdoor lock", () => {
     ).toBe(200);
     // The rest of the shop stays open.
     expect((await shop("/")).status).toBe(200);
+  });
+});
+
+describe("mcp oauth (RFC 9728 / 8414 / 7591 + PKCE)", () => {
+  const ORIGIN = "https://petshop.example";
+
+  test("unauthorized /mcp answers 401 pointing at protected-resource metadata", async () => {
+    const shop = makeShop();
+    const response = await shop("/mcp", { method: "POST" });
+    expect(response.status).toBe(401);
+    expect(response.headers.get("www-authenticate")).toBe(
+      `Bearer resource_metadata="${ORIGIN}/.well-known/oauth-protected-resource/mcp"`,
+    );
+  });
+
+  test("discovery documents name the resource, auth server, and endpoints", async () => {
+    const shop = makeShop();
+    for (const path of [
+      "/.well-known/oauth-protected-resource",
+      "/.well-known/oauth-protected-resource/mcp",
+    ]) {
+      expect(await (await shop(path)).json()).toEqual({
+        resource: `${ORIGIN}/mcp`,
+        authorization_servers: [ORIGIN],
+      });
+    }
+    const as = await (await shop("/.well-known/oauth-authorization-server")).json();
+    expect(as).toMatchObject({
+      issuer: ORIGIN,
+      authorization_endpoint: `${ORIGIN}/oauth/authorize`,
+      token_endpoint: `${ORIGIN}/oauth/token`,
+      registration_endpoint: `${ORIGIN}/oauth/register`,
+      code_challenge_methods_supported: ["S256"],
+      token_endpoint_auth_methods_supported: ["client_secret_basic"],
+    });
+  });
+
+  test("dynamic registration mints a confidential client", async () => {
+    const shop = makeShop();
+    const response = await shop("/oauth/register", {
+      ...postJson({ redirect_uris: [REDIRECT_URI], client_name: "iterate" }),
+    });
+    expect(response.status).toBe(201);
+    const client = (await response.json()) as { client_id: string; client_secret: string };
+    expect(client.client_id).toMatch(/^petshop-client-/);
+    expect(client.client_secret).toBeTruthy();
+    // The minted client is real: it works as a token-endpoint credential.
+    const tokens = await connect(shop, {
+      clientId: client.client_id,
+      clientSecret: client.client_secret,
+    });
+    expect(tokens.access_token).toBeTruthy();
+  });
+
+  test("register with no absolute redirect_uri is rejected", async () => {
+    const shop = makeShop();
+    const response = await shop("/oauth/register", { ...postJson({ redirect_uris: [] }) });
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: "invalid_redirect_uri" });
+  });
+
+  test("full PKCE code flow: register → authorize(challenge) → token(verifier) → /mcp", async () => {
+    const shop = makeShop();
+    const client = (await (
+      await shop("/oauth/register", { ...postJson({ redirect_uris: [REDIRECT_URI] }) })
+    ).json()) as { client_id: string; client_secret: string };
+
+    const verifier = "verifier-" + "a".repeat(50);
+    const challenge = await pkceS256(verifier);
+    const location = await approve(shop, {
+      client_id: client.client_id,
+      redirect_uri: REDIRECT_URI,
+      code_challenge: challenge,
+    });
+
+    // The right verifier redeems the code.
+    const good = await exchange(shop, {
+      clientId: client.client_id,
+      clientSecret: client.client_secret,
+      body: {
+        grant_type: "authorization_code",
+        code: location.searchParams.get("code") ?? "",
+        redirect_uri: REDIRECT_URI,
+        code_verifier: verifier,
+      },
+    });
+    expect(good.status).toBe(200);
+    const tokens = (await good.json()) as { access_token: string };
+    const mcp = await shop("/mcp", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${tokens.access_token}`,
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "t", version: "1" },
+        },
+      }),
+    });
+    expect(mcp.status).toBe(200);
+  });
+
+  test("a code minted with a challenge is not redeemable without the verifier", async () => {
+    const shop = makeShop();
+    const client = (await (
+      await shop("/oauth/register", { ...postJson({ redirect_uris: [REDIRECT_URI] }) })
+    ).json()) as { client_id: string; client_secret: string };
+    const challenge = await pkceS256("the-real-verifier-" + "z".repeat(40));
+    const location = await approve(shop, {
+      client_id: client.client_id,
+      redirect_uri: REDIRECT_URI,
+      code_challenge: challenge,
+    });
+    const missing = await exchange(shop, {
+      clientId: client.client_id,
+      clientSecret: client.client_secret,
+      body: {
+        grant_type: "authorization_code",
+        code: location.searchParams.get("code") ?? "",
+        redirect_uri: REDIRECT_URI,
+      },
+    });
+    expect(missing.status).toBe(400);
+    expect(await missing.json()).toMatchObject({ error: "invalid_grant" });
   });
 });

--- a/apps/dummy-petshop/src/worker.ts
+++ b/apps/dummy-petshop/src/worker.ts
@@ -29,7 +29,7 @@ import { verifyAppJwt } from "./github-app.ts";
 import { handleMcpRequest } from "./mcp.ts";
 import { type Pet, seedPets } from "./pets.ts";
 import { handlePetsRpcRequest, petshopOpenApiDocument } from "./rpc.ts";
-import { hmacSha256Hex, nowSeconds, seal, unseal } from "./seal.ts";
+import { hmacSha256Hex, nowSeconds, pkceS256, seal, unseal } from "./seal.ts";
 import {
   GRAPHQL_LOGIN_PASSWORD,
   GRAPHQL_SESSION_TTL_SECONDS,
@@ -103,6 +103,10 @@ interface CodePayload {
   clientId: string;
   redirectUri: string;
   exp: number;
+  /** PKCE S256 challenge (RFC 7636) when the client sent one at /oauth/authorize.
+   * The token endpoint requires the matching code_verifier when this is present;
+   * absent for the legacy consent-only lane, which keeps existing e2e green. */
+  codeChallenge?: string;
 }
 
 /** Sealed access token; `epoch` must still equal the state's accessTokenEpoch. */
@@ -167,9 +171,12 @@ const INDEX = dedent`
   🐾 dummy-petshop — a fake third party for integrations & secrets e2e
      (apps/os/docs/integrations-and-secrets-design.md §7 S0)
 
-  GET  /oauth/authorize     ?client_id&redirect_uri&state — consent page; add &approve=1[&user=x] to skip it (test lane)
+  GET  /.well-known/oauth-protected-resource[/mcp]  RFC 9728 — /mcp's resource + this origin as its auth server
+  GET  /.well-known/oauth-authorization-server      RFC 8414 — authorize/token/register endpoints, PKCE S256, client_secret_basic
+  POST /oauth/register      RFC 7591 dynamic client registration → {client_id, client_secret, …} (confidential client)
+  GET  /oauth/authorize     ?client_id&redirect_uri&state[&code_challenge] — consent page; add &approve=1[&user=x] to skip it (test lane)
   POST /oauth/authorize     consent form submit → 302 redirect_uri?code=…&state=…
-  POST /oauth/token         grant_type=authorization_code | refresh_token; HTTP Basic client auth (RFC 6749 §2.3.1)
+  POST /oauth/token         grant_type=authorization_code | refresh_token; HTTP Basic client auth (RFC 6749 §2.3.1); PKCE code_verifier required when the code carried a challenge (RFC 7636)
   POST /api/legacy-login    {email, password} → {accessToken, expiresInSeconds}; any email, password "correct-horse"
   POST /graphql             GraphQL session-login door: NewSession (any username, password "${GRAPHQL_LOGIN_PASSWORD}")
                             → sealed ~${GRAPHQL_SESSION_TTL_SECONDS}s session token, valid as an ordinary bearer on /api/*
@@ -183,7 +190,7 @@ const INDEX = dedent`
   GET  /openapi.json        OpenAPI 3.1 doc for the typed pets API (listPets/getPet/createPet)
   POST /rpc/*               oRPC handler for the pets API (what an @orpc/client talks); bearer-protected
   GET|POST /api/v2/*        the same pets procedures served REST-shaped (per the OpenAPI doc)
-  GET|POST /mcp             MCP server (streamable HTTP): tools list_pets, get_pet, create_pet; bearer-protected
+  GET|POST /mcp             MCP server (streamable HTTP): tools list_pets, get_pet, create_pet; bearer-protected — an unauthorized call answers 401 + WWW-Authenticate pointing at the RFC 9728 metadata above (OAuth-protected MCP server)
   GET  /gateway               (websocket) — token in the first {op:identify, token} FRAME (Discord shape)
   GET  /gateway-header        (websocket) — token in the Authorization: Bearer UPGRADE header (OpenAI-Realtime shape)
   GET  /gateway-subprotocol   (websocket) — token in Sec-WebSocket-Protocol as "petshop.access-token.<token>" (browser-WS shape)
@@ -206,14 +213,24 @@ const INDEX = dedent`
   installation tokens live ${INSTALLATION_TOKEN_TTL_SECONDS}s · App JWTs verify RS256 over header.payload and App webhooks sign x-hub-signature-256.
 `;
 
-function consentPage(params: { clientId: string; redirectUri: string; state: string }): string {
+function consentPage(params: {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  codeChallenge: string;
+}): string {
   const hidden = (
     [
       ["client_id", params.clientId],
       ["redirect_uri", params.redirectUri],
       ["state", params.state],
+      // PKCE challenge rides through the consent POST so the browser lane
+      // (human clicks Approve) proves the same code_verifier at token time
+      // as the consent-free &approve=1 lane.
+      ["code_challenge", params.codeChallenge],
     ] as const
   )
+    .filter(([, value]) => value !== "")
     .map(([name, value]) => `<input type="hidden" name="${name}" value="${escapeHtml(value)}" />`)
     .join("\n");
   return dedent`
@@ -267,7 +284,13 @@ async function authorizeRejection(
 }
 
 async function mintCodeRedirect(
-  params: { clientId: string; redirectUri: string; state: string; user: string },
+  params: {
+    clientId: string;
+    redirectUri: string;
+    state: string;
+    user: string;
+    codeChallenge: string;
+  },
   deps: PetshopDeps,
 ): Promise<Response> {
   const payload: CodePayload = {
@@ -277,11 +300,80 @@ async function mintCodeRedirect(
     clientId: params.clientId,
     redirectUri: params.redirectUri,
     exp: nowSeconds() + CODE_TTL_SECONDS,
+    ...(params.codeChallenge ? { codeChallenge: params.codeChallenge } : {}),
   };
   const target = new URL(params.redirectUri);
   target.searchParams.set("code", await seal(payload, deps.sealKey));
   if (params.state) target.searchParams.set("state", params.state);
   return Response.redirect(target.toString(), 302);
+}
+
+// ---------------------------------------------------------------------------
+// MCP OAuth discovery (RFC 9728 protected-resource + RFC 8414 auth-server
+// metadata + RFC 7591 dynamic client registration). These make /mcp a
+// standards "OAuth-protected MCP server": a client that hits /mcp unauthorized
+// reads the WWW-Authenticate `resource_metadata` URL, discovers this origin as
+// its own authorization server, registers a client, and runs the code+PKCE
+// flow against the endpoints already served above. This is the door the OS
+// outbound MCP-OAuth flow (itx.mcp.beginOAuth) is proven against.
+// ---------------------------------------------------------------------------
+
+/** RFC 9728: /mcp is the protected resource and this same origin is its
+ * authorization server. Served at both /.well-known/oauth-protected-resource
+ * and the resource-suffixed /.well-known/oauth-protected-resource/mcp. */
+function protectedResourceMetadata(origin: string) {
+  return { resource: `${origin}/mcp`, authorization_servers: [origin] };
+}
+
+/** RFC 8414: the endpoints an MCP OAuth client discovers to register, start the
+ * code+PKCE flow, and exchange/refresh tokens. Clients authenticate at the
+ * token endpoint with HTTP Basic (client_secret_basic) and MUST use PKCE S256. */
+function authorizationServerMetadata(origin: string) {
+  return {
+    issuer: origin,
+    authorization_endpoint: `${origin}/oauth/authorize`,
+    token_endpoint: `${origin}/oauth/token`,
+    registration_endpoint: `${origin}/oauth/register`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["client_secret_basic"],
+    scopes_supported: ["pets:read", "pets:write"],
+  };
+}
+
+/** RFC 7591 dynamic client registration: the client POSTs its redirect_uris (+
+ * optional metadata) and petshop mints a fresh confidential client. Permissive
+ * on redirect_uris (this is a fake provider) but it returns a real
+ * client_secret the token endpoint then enforces via Basic auth, exactly like a
+ * production server. */
+async function registerOAuthClient(request: Request, deps: PetshopDeps): Promise<Response> {
+  const body = await readJson(request);
+  const redirectUris = Array.isArray(body.redirect_uris)
+    ? body.redirect_uris.filter((value): value is string => typeof value === "string")
+    : [];
+  if (redirectUris.length === 0 || !redirectUris.every((value) => URL.canParse(value))) {
+    return json(
+      { error: "invalid_redirect_uri", error_description: "redirect_uris must be absolute URLs" },
+      400,
+    );
+  }
+  const { clientId, clientSecret } = await deps.state.createClient({});
+  return json(
+    {
+      client_id: clientId,
+      client_secret: clientSecret,
+      client_id_issued_at: nowSeconds(),
+      // 0 = never expires (RFC 7591 §3.2.1).
+      client_secret_expires_at: 0,
+      redirect_uris: redirectUris,
+      token_endpoint_auth_method: "client_secret_basic",
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      client_name: typeof body.client_name === "string" ? body.client_name : "mcp-client",
+    },
+    201,
+  );
 }
 
 /** RFC 6749 §2.3.1 HTTP Basic client auth — the required-to-support method the OS side's Basic-auth header placeholder exercises. */
@@ -361,6 +453,18 @@ async function tokenEndpoint(request: Request, deps: PetshopDeps): Promise<Respo
     }
     if (code.redirectUri !== (form.get("redirect_uri") ?? "")) {
       return json({ error: "invalid_grant", error_description: "redirect_uri mismatch" }, 400);
+    }
+    // PKCE (RFC 7636): a code minted with a challenge is only redeemable by the
+    // holder of the matching verifier. Absent a challenge (the legacy
+    // consent-only lane) no verifier is required, so existing e2e stays green.
+    if (code.codeChallenge !== undefined) {
+      const verifier = form.get("code_verifier") ?? "";
+      if (!verifier || (await pkceS256(verifier)) !== code.codeChallenge) {
+        return json(
+          { error: "invalid_grant", error_description: "PKCE code_verifier mismatch" },
+          400,
+        );
+      }
     }
     // Single-use: a replayed code is rejected (RFC 6749 §4.1.2).
     if (!(await deps.state.consumeAuthorizationCode(code.jti))) {
@@ -837,11 +941,23 @@ export async function handlePetshopRequest(request: Request, deps: PetshopDeps):
   if (key === "GET /") {
     return new Response(INDEX, { headers: { "content-type": "text/plain; charset=utf-8" } });
   }
+  // MCP OAuth discovery documents (served unauthenticated, by spec).
+  if (
+    key === "GET /.well-known/oauth-protected-resource" ||
+    key === "GET /.well-known/oauth-protected-resource/mcp"
+  ) {
+    return json(protectedResourceMetadata(url.origin));
+  }
+  if (key === "GET /.well-known/oauth-authorization-server") {
+    return json(authorizationServerMetadata(url.origin));
+  }
+  if (key === "POST /oauth/register") return registerOAuthClient(request, deps);
   if (key === "GET /oauth/authorize") {
     const params = {
       clientId: url.searchParams.get("client_id") ?? "",
       redirectUri: url.searchParams.get("redirect_uri") ?? "",
       state: url.searchParams.get("state") ?? "",
+      codeChallenge: url.searchParams.get("code_challenge") ?? "",
     };
     const rejection = await authorizeRejection(deps, params.clientId, params.redirectUri);
     if (rejection) return rejection;
@@ -861,6 +977,7 @@ export async function handlePetshopRequest(request: Request, deps: PetshopDeps):
       redirectUri: String(form.get("redirect_uri") ?? ""),
       state: String(form.get("state") ?? ""),
       user: String(form.get("user") ?? ""),
+      codeChallenge: String(form.get("code_challenge") ?? ""),
     };
     const rejection = await authorizeRejection(deps, params.clientId, params.redirectUri);
     return rejection ?? (await mintCodeRedirect(params, deps));
@@ -919,7 +1036,13 @@ export async function handlePetshopRequest(request: Request, deps: PetshopDeps):
   }
   if (url.pathname === "/mcp") {
     const grant = await accessGrant(request, deps);
-    if (!grant) return json({ error: "invalid_token" }, 401);
+    if (!grant) {
+      // Point an unauthorized MCP client at its protected-resource metadata
+      // (RFC 9728 §5.1) so it can discover this origin's OAuth endpoints.
+      return json({ error: "invalid_token" }, 401, {
+        "www-authenticate": `Bearer resource_metadata="${url.origin}/.well-known/oauth-protected-resource/mcp"`,
+      });
+    }
     return handleMcpRequest(request, { owner: grant.sub, pets: deps.pets });
   }
   // The WebSocket gateways (§9 D6). Three shapes, same sealed access token,

--- a/apps/dummy-petshop/src/worker.ts
+++ b/apps/dummy-petshop/src/worker.ts
@@ -42,6 +42,8 @@ import {
   DEFAULT_CLIENT_ID,
   DEFAULT_CLIENT_SECRET,
   DEFAULT_INSTALLATION_ID,
+  type OauthClient,
+  type PetshopState,
   PetshopStateDurableObject,
 } from "./state.ts";
 
@@ -172,11 +174,11 @@ const INDEX = dedent`
      (apps/os/docs/integrations-and-secrets-design.md §7 S0)
 
   GET  /.well-known/oauth-protected-resource[/mcp]  RFC 9728 — /mcp's resource + this origin as its auth server
-  GET  /.well-known/oauth-authorization-server      RFC 8414 — authorize/token/register endpoints, PKCE S256, client_secret_basic
-  POST /oauth/register      RFC 7591 dynamic client registration → {client_id, client_secret, …} (confidential client)
-  GET  /oauth/authorize     ?client_id&redirect_uri&state[&code_challenge] — consent page; add &approve=1[&user=x] to skip it (test lane)
+  GET  /.well-known/oauth-authorization-server      RFC 8414 — authorize/token/register endpoints, PKCE S256, auth methods none + client_secret_basic
+  POST /oauth/register      RFC 7591 dynamic client registration → a client pinned to its redirect_uris; token_endpoint_auth_method "none" ⇒ public (no secret, PKCE), else confidential
+  GET  /oauth/authorize     ?client_id&redirect_uri&state[&code_challenge] — consent page; add &approve=1[&user=x] to skip it (test lane); a DCR client's redirect_uri must be one it registered
   POST /oauth/authorize     consent form submit → 302 redirect_uri?code=…&state=…
-  POST /oauth/token         grant_type=authorization_code | refresh_token; HTTP Basic client auth (RFC 6749 §2.3.1); PKCE code_verifier required when the code carried a challenge (RFC 7636)
+  POST /oauth/token         grant_type=authorization_code | refresh_token; confidential = HTTP Basic (RFC 6749 §2.3.1), public = client_id in the body; PKCE code_verifier required for public clients (and any code that carried a challenge, RFC 7636)
   POST /api/legacy-login    {email, password} → {accessToken, expiresInSeconds}; any email, password "correct-horse"
   POST /graphql             GraphQL session-login door: NewSession (any username, password "${GRAPHQL_LOGIN_PASSWORD}")
                             → sealed ~${GRAPHQL_SESSION_TTL_SECONDS}s session token, valid as an ordinary bearer on /api/*
@@ -258,14 +260,19 @@ function consentPage(params: {
   `;
 }
 
-/** The authorize-time validations: registered client_id, absolute redirect_uri. Null when acceptable. */
+/** The authorize-time validations: registered client_id, absolute redirect_uri,
+ * and — for a dynamically-registered client — exact membership in the redirect
+ * URIs it registered (RFC 7591 / the MCP authorization spec; prevents an
+ * open-redirect / code-theft hole). Seeded/backdoor clients register none and
+ * accept any absolute URI. Null when acceptable. */
 async function authorizeRejection(
   deps: PetshopDeps,
   clientId: string,
   redirectUri: string,
 ): Promise<Response | null> {
   const state = await deps.state.getState();
-  if (!state.clients[clientId]) {
+  const client = state.clients[clientId];
+  if (!client) {
     return json(
       {
         error: "invalid_request",
@@ -277,6 +284,19 @@ async function authorizeRejection(
   if (!URL.canParse(redirectUri)) {
     return json(
       { error: "invalid_request", error_description: "redirect_uri must be an absolute URL" },
+      400,
+    );
+  }
+  if (
+    client.redirectUris &&
+    client.redirectUris.length > 0 &&
+    !client.redirectUris.includes(redirectUri)
+  ) {
+    return json(
+      {
+        error: "invalid_request",
+        error_description: "redirect_uri is not registered for this client",
+      },
       400,
     );
   }
@@ -326,8 +346,9 @@ function protectedResourceMetadata(origin: string) {
 }
 
 /** RFC 8414: the endpoints an MCP OAuth client discovers to register, start the
- * code+PKCE flow, and exchange/refresh tokens. Clients authenticate at the
- * token endpoint with HTTP Basic (client_secret_basic) and MUST use PKCE S256. */
+ * code+PKCE flow, and exchange/refresh tokens. Supports both a public client
+ * (token_endpoint_auth_method "none" + PKCE — the standard MCP shape) and a
+ * confidential one (client_secret_basic). PKCE S256 either way. */
 function authorizationServerMetadata(origin: string) {
   return {
     issuer: origin,
@@ -337,16 +358,16 @@ function authorizationServerMetadata(origin: string) {
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
-    token_endpoint_auth_methods_supported: ["client_secret_basic"],
+    token_endpoint_auth_methods_supported: ["none", "client_secret_basic"],
     scopes_supported: ["pets:read", "pets:write"],
   };
 }
 
 /** RFC 7591 dynamic client registration: the client POSTs its redirect_uris (+
- * optional metadata) and petshop mints a fresh confidential client. Permissive
- * on redirect_uris (this is a fake provider) but it returns a real
- * client_secret the token endpoint then enforces via Basic auth, exactly like a
- * production server. */
+ * optional metadata) and petshop mints a fresh client, PINNED to exactly those
+ * redirect URIs. `token_endpoint_auth_method: "none"` mints a public client (no
+ * secret, PKCE-authenticated — the standard MCP shape); anything else mints a
+ * confidential client whose secret the token endpoint enforces via Basic auth. */
 async function registerOAuthClient(request: Request, deps: PetshopDeps): Promise<Response> {
   const body = await readJson(request);
   const redirectUris = Array.isArray(body.redirect_uris)
@@ -358,16 +379,20 @@ async function registerOAuthClient(request: Request, deps: PetshopDeps): Promise
       400,
     );
   }
-  const { clientId, clientSecret } = await deps.state.createClient({});
+  const isPublic = body.token_endpoint_auth_method === "none";
+  const { clientId, clientSecret } = await deps.state.createClient({
+    redirectUris,
+    ...(isPublic ? { public: true } : {}),
+  });
   return json(
     {
       client_id: clientId,
-      client_secret: clientSecret,
+      ...(isPublic ? {} : { client_secret: clientSecret }),
       client_id_issued_at: nowSeconds(),
       // 0 = never expires (RFC 7591 §3.2.1).
-      client_secret_expires_at: 0,
+      ...(isPublic ? {} : { client_secret_expires_at: 0 }),
       redirect_uris: redirectUris,
-      token_endpoint_auth_method: "client_secret_basic",
+      token_endpoint_auth_method: isPublic ? "none" : "client_secret_basic",
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       client_name: typeof body.client_name === "string" ? body.client_name : "mcp-client",
@@ -433,19 +458,15 @@ async function tokenEndpoint(request: Request, deps: PetshopDeps): Promise<Respo
       500,
     );
   }
-  const credentials = basicClientCredentials(request);
-  const state = await deps.state.getState();
-  const client = credentials ? state.clients[credentials.clientId] : undefined;
-  if (!credentials || !client || client.clientSecret !== credentials.clientSecret) {
-    return json({ error: "invalid_client" }, 401, {
-      "www-authenticate": 'Basic realm="dummy-petshop"',
-    });
-  }
   const form = new URLSearchParams(await request.text());
+  const state = await deps.state.getState();
+  const auth = authenticateTokenClient(request, form, state);
+  if (auth instanceof Response) return auth;
+  const { clientId, client } = auth;
   const grantType = form.get("grant_type");
   if (grantType === "authorization_code") {
     const code = await unseal<CodePayload>(form.get("code") ?? "", deps.sealKey);
-    if (!code || code.t !== "code" || code.clientId !== credentials.clientId) {
+    if (!code || code.t !== "code" || code.clientId !== clientId) {
       return json({ error: "invalid_grant" }, 400);
     }
     if (code.exp < nowSeconds()) {
@@ -454,9 +475,15 @@ async function tokenEndpoint(request: Request, deps: PetshopDeps): Promise<Respo
     if (code.redirectUri !== (form.get("redirect_uri") ?? "")) {
       return json({ error: "invalid_grant", error_description: "redirect_uri mismatch" }, 400);
     }
-    // PKCE (RFC 7636): a code minted with a challenge is only redeemable by the
-    // holder of the matching verifier. Absent a challenge (the legacy
-    // consent-only lane) no verifier is required, so existing e2e stays green.
+    // PKCE (RFC 7636). A public client has no secret, so PKCE is its ONLY proof
+    // and is mandatory. A confidential client is verified when it sent a
+    // challenge (the legacy consent-only lane sends none — no verifier required).
+    if (client.public && code.codeChallenge === undefined) {
+      return json(
+        { error: "invalid_grant", error_description: "PKCE is required for public clients" },
+        400,
+      );
+    }
     if (code.codeChallenge !== undefined) {
       const verifier = form.get("code_verifier") ?? "";
       if (!verifier || (await pkceS256(verifier)) !== code.codeChallenge) {
@@ -475,7 +502,7 @@ async function tokenEndpoint(request: Request, deps: PetshopDeps): Promise<Respo
     // snapshot — stamping the stale epoch would mint a token that 401s at once.
     return issueTokens({
       sub: code.sub,
-      clientId: credentials.clientId,
+      clientId,
       ttlSeconds: client.accessTokenTtlSeconds,
       epoch: (await deps.state.getState()).accessTokenEpoch,
       sealKey: deps.sealKey,
@@ -483,7 +510,7 @@ async function tokenEndpoint(request: Request, deps: PetshopDeps): Promise<Respo
   }
   if (grantType === "refresh_token") {
     const refresh = await unseal<RefreshPayload>(form.get("refresh_token") ?? "", deps.sealKey);
-    if (!refresh || refresh.t !== "refresh" || refresh.clientId !== credentials.clientId) {
+    if (!refresh || refresh.t !== "refresh" || refresh.clientId !== clientId) {
       return json({ error: "invalid_grant" }, 400);
     }
     // Re-read fresh state so the revocation check and the stamped epoch agree
@@ -494,13 +521,37 @@ async function tokenEndpoint(request: Request, deps: PetshopDeps): Promise<Respo
     }
     return issueTokens({
       sub: refresh.sub,
-      clientId: credentials.clientId,
+      clientId,
       ttlSeconds: client.accessTokenTtlSeconds,
       epoch: current.accessTokenEpoch,
       sealKey: deps.sealKey,
     });
   }
   return json({ error: "unsupported_grant_type" }, 400);
+}
+
+/** Authenticate the token-endpoint caller: a confidential client presents HTTP
+ * Basic (RFC 6749 §2.3.1); a public client presents client_id in the body, its
+ * PKCE verifier standing in for a secret (verified per authorization_code grant).
+ * Returns the resolved client, or a 401 Response. */
+function authenticateTokenClient(
+  request: Request,
+  form: URLSearchParams,
+  state: PetshopState,
+): { clientId: string; client: OauthClient } | Response {
+  const unauthorized = () =>
+    json({ error: "invalid_client" }, 401, { "www-authenticate": 'Basic realm="dummy-petshop"' });
+  const basic = basicClientCredentials(request);
+  if (basic) {
+    const client = state.clients[basic.clientId];
+    if (!client || client.public || client.clientSecret !== basic.clientSecret)
+      return unauthorized();
+    return { clientId: basic.clientId, client };
+  }
+  const clientId = form.get("client_id") ?? "";
+  const client = state.clients[clientId];
+  if (!client || !client.public) return unauthorized();
+  return { clientId, client };
 }
 
 /**

--- a/apps/os/src/domains/agents/agent-processor-contract.ts
+++ b/apps/os/src/domains/agents/agent-processor-contract.ts
@@ -174,6 +174,8 @@ export const DEFAULT_AGENT_SYSTEM_PROMPT = [
   "  // If the user pastes a key into chat anyway, that is fine: store it and proceed —",
   "  // unblocking them comes first. But a pasted key sat in the transcript, so advise them",
   "  // to roll it and collect the replacement through the same link (it updates existing secrets too).",
+  "  // MCP server needs OAuth (connect 401s with a WWW-Authenticate challenge, e.g. Cloudflare's)? itx.mcp.beginOAuth({ url })",
+  '  // returns a sign-in link; after the user signs in, connect with field "accessToken". Full flow: `connect-mcp-oauth`.',
   "",
   "  // LATER / RECURRING — the script string runs later with full project access:",
   "  await itx.scheduler.set({",

--- a/apps/os/src/domains/agents/agent-processor-contract.ts
+++ b/apps/os/src/domains/agents/agent-processor-contract.ts
@@ -174,7 +174,7 @@ export const DEFAULT_AGENT_SYSTEM_PROMPT = [
   "  // If the user pastes a key into chat anyway, that is fine: store it and proceed —",
   "  // unblocking them comes first. But a pasted key sat in the transcript, so advise them",
   "  // to roll it and collect the replacement through the same link (it updates existing secrets too).",
-  "  // MCP server needs OAuth (connect 401s with a WWW-Authenticate challenge, e.g. Cloudflare's)? itx.mcp.beginOAuth({ url })",
+  "  // MCP server needs OAuth (connect 401s with WWW-Authenticate, e.g. Cloudflare's)? itx.mcp.beginOAuth({ url, path })",
   '  // returns a sign-in link; after the user signs in, connect with field "accessToken". Full flow: `connect-mcp-oauth`.',
   "",
   "  // LATER / RECURRING — the script string runs later with full project access:",

--- a/apps/os/src/domains/integrations/integration-api.ts
+++ b/apps/os/src/domains/integrations/integration-api.ts
@@ -4,10 +4,19 @@
 // same lane worker.ts uses for project ingress) — no loopback HTTP round trip
 // to this deployment's own /api.
 import { parseOAuthStateUnverified } from "./oauth-state.ts";
-import { trustedInternalAuthContext } from "~/auth.ts";
+import { itxAuthFromPrincipal, trustedInternalAuthContext } from "~/auth.ts";
 import { ProjectCollectionRpcTarget } from "~/rpc-targets.ts";
 import type { Principal } from "~/auth/principal.ts";
 import type { RequestContext } from "~/request-context.ts";
+import { itxEnv } from "~/env.ts";
+import { DurableObjectNameCodec } from "~/domains/durable-object-names.ts";
+import {
+  completeMcpOAuth,
+  fetchLikeFromFetcher,
+  McpOAuthError,
+  readMcpOAuthProjectId,
+} from "~/domains/itx/mcp-oauth.ts";
+import { projectEgressFetcher } from "~/domains/projects/utils.ts";
 
 export async function handleIntegrationApiRequest(input: {
   auth: Principal | null | undefined;
@@ -23,6 +32,9 @@ export async function handleIntegrationApiRequest(input: {
   }
   if (url.pathname === "/api/integrations/github/callback") {
     return await handleOAuthCallback({ ...input, provider: "github" });
+  }
+  if (url.pathname === "/api/mcp-oauth/callback") {
+    return await handleMcpOAuthCallback(input);
   }
   // The webhook lanes (/api/integrations/<slug>/webhook, + slack's
   // interactivity lane) are NOT here: they are served by the api worker
@@ -91,6 +103,130 @@ async function handleOAuthCallback(input: {
     return redirectWithError(result.callbackUrl ?? callbackUrl, result.error);
   }
   return redirectResponse(result.callbackUrl ?? callbackUrl ?? "/");
+}
+
+/**
+ * The outbound MCP-OAuth callback — the other half of itx.mcp.beginOAuth. The
+ * provider redirects here after the user signs in; we redeem the code, store
+ * the token write-only in the project's Secret DO (material + egress + refresh
+ * in one update, so it is born pinned and usable), and — for an agent-minted
+ * link — message the agent so it can continue. The state is ENCRYPTED (it
+ * carries a client secret + PKCE verifier), so unlike the integrations
+ * callbacks there is no unsigned projectId to read: it is decrypted here with
+ * SECRET_ENCRYPTION_KEY. Completing the flow OVERWRITES the secret at the
+ * state's path, so — like collectFromUser's page — the browser session must
+ * belong to a member of the project: a leaked link cannot let a stranger
+ * clobber a project secret with their own token.
+ */
+async function handleMcpOAuthCallback(input: {
+  auth: Principal | null | undefined;
+  context: RequestContext;
+  request: Request;
+}): Promise<Response> {
+  const url = new URL(input.request.url);
+  const error = url.searchParams.get("error");
+  if (error) {
+    return resultPage(
+      "Sign-in was cancelled",
+      `The authorization server reported: ${error}. You can close this tab.`,
+      400,
+    );
+  }
+  const state = url.searchParams.get("state");
+  const code = url.searchParams.get("code");
+  if (!state || !code) {
+    return resultPage(
+      "This link is incomplete",
+      "It is missing the authorization code or state. Ask the agent for a fresh link.",
+      400,
+    );
+  }
+  const iss = url.searchParams.get("iss") ?? undefined;
+  try {
+    const projectId = await readMcpOAuthProjectId(state, itxEnv.SECRET_ENCRYPTION_KEY);
+    // The completing browser must be a signed-in member of the project — the
+    // token is about to overwrite a project secret. assertCanAccessProject
+    // throws for a non-member or a non-user session.
+    if (input.auth?.type !== "user") {
+      return resultPage(
+        "Please sign in first",
+        "Open this link in a browser signed in to Iterate, then try again.",
+        403,
+      );
+    }
+    try {
+      itxAuthFromPrincipal(input.context.config, input.auth).assertCanAccessProject(projectId);
+    } catch {
+      return resultPage(
+        "Not authorized",
+        "You are not a member of this project, so this connection cannot be stored for it.",
+        403,
+      );
+    }
+    const egress = projectEgressFetcher(input.context.executionCtx.exports, projectId);
+    const result = await completeMcpOAuth({
+      state,
+      code,
+      ...(iss ? { iss } : {}),
+      encryptionKey: itxEnv.SECRET_ENCRYPTION_KEY,
+      fetchFn: fetchLikeFromFetcher(egress),
+    });
+    await itxEnv.SECRET.getByName(
+      DurableObjectNameCodec.stringify({ projectId, path: result.path }),
+    ).update(result.secret);
+
+    // Best-effort notify: the token is stored regardless, so a notify failure
+    // must not read as total failure (the user would redo it; the agent waits).
+    let notifyFailed = false;
+    if (result.notify) {
+      try {
+        const project = await new ProjectCollectionRpcTarget({
+          auth: trustedInternalAuthContext(),
+          config: input.context.config,
+          ctx: input.context.executionCtx,
+        }).get(projectId);
+        await project.agents
+          .get(result.notify)
+          .message(
+            `The OAuth connection to ${result.mcpUrl} is done. The token is stored write-only at ` +
+              `"${result.path}" (pinned to ${result.egressOrigins.join(", ")}). Connect with ` +
+              `itx.mcp.connect({ url: "${result.mcpUrl}", headers: { authorization: ` +
+              `'Bearer getSecret({ path: "${result.path}", field: "accessToken" })' } }).`,
+          );
+      } catch (cause) {
+        console.error("mcp-oauth: failed to notify", result.notify, cause);
+        notifyFailed = true;
+      }
+    }
+    return resultPage(
+      "Connected",
+      notifyFailed
+        ? `The connection is stored, but the agent could not be notified. Tell it the token at ${result.path} is ready.`
+        : "You can close this tab and return to the agent.",
+      200,
+    );
+  } catch (cause) {
+    const message =
+      cause instanceof McpOAuthError
+        ? cause.message
+        : "Something went wrong completing the connection.";
+    if (!(cause instanceof McpOAuthError)) console.error("mcp-oauth: callback failed", cause);
+    return resultPage("Could not complete sign-in", message, 400);
+  }
+}
+
+/** A tiny self-contained result page for the MCP-OAuth callback (no chrome, no
+ * route): the user lands here from an external provider, so it must render on
+ * its own. Escapes its text — the message can carry a server-supplied URL. */
+function resultPage(title: string, body: string, status: number): Response {
+  const escape = (value: string) =>
+    value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const html = `<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1"><title>${escape(title)}</title>
+<style>body{font-family:-apple-system,system-ui,sans-serif;display:grid;place-items:center;min-height:100vh;margin:0;background:#fafafa;color:#111}
+main{max-width:26rem;padding:2.5rem;text-align:center}h1{font-size:1.25rem;margin:0 0 .5rem}p{color:#555;line-height:1.5}</style>
+</head><body><main><h1>${escape(title)}</h1><p>${escape(body)}</p></main></body></html>`;
+  return new Response(html, { status, headers: { "content-type": "text/html; charset=utf-8" } });
 }
 
 function redirectWithError(callbackUrl: string | null, error: string) {

--- a/apps/os/src/domains/integrations/integration-api.ts
+++ b/apps/os/src/domains/integrations/integration-api.ts
@@ -12,9 +12,9 @@ import { itxEnv } from "~/env.ts";
 import { DurableObjectNameCodec } from "~/domains/durable-object-names.ts";
 import {
   completeMcpOAuth,
+  decodeMcpOAuthState,
   fetchLikeFromFetcher,
   McpOAuthError,
-  readMcpOAuthProjectId,
 } from "~/domains/itx/mcp-oauth.ts";
 import { projectEgressFetcher } from "~/domains/projects/utils.ts";
 
@@ -107,16 +107,16 @@ async function handleOAuthCallback(input: {
 
 /**
  * The outbound MCP-OAuth callback — the other half of itx.mcp.beginOAuth. The
- * provider redirects here after the user signs in; we redeem the code, store
- * the token write-only in the project's Secret DO (material + egress + refresh
- * in one update, so it is born pinned and usable), and — for an agent-minted
- * link — message the agent so it can continue. The state is ENCRYPTED (it
- * carries a client secret + PKCE verifier), so unlike the integrations
- * callbacks there is no unsigned projectId to read: it is decrypted here with
- * SECRET_ENCRYPTION_KEY. Completing the flow OVERWRITES the secret at the
- * state's path, so — like collectFromUser's page — the browser session must
- * belong to a member of the project: a leaked link cannot let a stranger
- * clobber a project secret with their own token.
+ * provider redirects here after the user signs in; we redeem the code, store the
+ * token write-only in the project's Secret DO (material + egress + refresh in one
+ * update, so it is born pinned and usable), message the agent, and redirect back
+ * into the app (the agent's message is the real "next step"). The state is
+ * ENCRYPTED (it carries the PKCE verifier — the only thing protecting a public
+ * client's code), so it is decoded ONCE here: we read `projectId` to route, gate
+ * on membership, then reuse the decoded state for the exchange. Completing the
+ * flow OVERWRITES the secret at the state's path, so — like collectFromUser's
+ * page — the browser session must belong to a member of the project: a leaked
+ * link cannot let a stranger clobber a project secret with their own token.
  */
 async function handleMcpOAuthCallback(input: {
   auth: Principal | null | undefined;
@@ -124,109 +124,60 @@ async function handleMcpOAuthCallback(input: {
   request: Request;
 }): Promise<Response> {
   const url = new URL(input.request.url);
-  const error = url.searchParams.get("error");
-  if (error) {
-    return resultPage(
-      "Sign-in was cancelled",
-      `The authorization server reported: ${error}. You can close this tab.`,
-      400,
-    );
-  }
-  const state = url.searchParams.get("state");
+  const providerError = url.searchParams.get("error");
+  if (providerError) return redirectWithError(null, `mcp_oauth_${providerError}`);
+  const stateParam = url.searchParams.get("state");
   const code = url.searchParams.get("code");
-  if (!state || !code) {
-    return resultPage(
-      "This link is incomplete",
-      "It is missing the authorization code or state. Ask the agent for a fresh link.",
-      400,
-    );
-  }
+  if (!stateParam || !code) return redirectWithError(null, "mcp_oauth_incomplete_callback");
   const iss = url.searchParams.get("iss") ?? undefined;
   try {
-    const projectId = await readMcpOAuthProjectId(state, itxEnv.SECRET_ENCRYPTION_KEY);
+    const state = await decodeMcpOAuthState(stateParam, itxEnv.SECRET_ENCRYPTION_KEY);
     // The completing browser must be a signed-in member of the project — the
-    // token is about to overwrite a project secret. assertCanAccessProject
-    // throws for a non-member or a non-user session.
-    if (input.auth?.type !== "user") {
-      return resultPage(
-        "Please sign in first",
-        "Open this link in a browser signed in to Iterate, then try again.",
-        403,
-      );
-    }
+    // token is about to overwrite a project secret.
+    if (input.auth?.type !== "user") return redirectWithError(null, "mcp_oauth_sign_in_required");
     try {
-      itxAuthFromPrincipal(input.context.config, input.auth).assertCanAccessProject(projectId);
-    } catch {
-      return resultPage(
-        "Not authorized",
-        "You are not a member of this project, so this connection cannot be stored for it.",
-        403,
+      itxAuthFromPrincipal(input.context.config, input.auth).assertCanAccessProject(
+        state.projectId,
       );
+    } catch {
+      return redirectWithError(null, "mcp_oauth_not_a_member");
     }
-    const egress = projectEgressFetcher(input.context.executionCtx.exports, projectId);
-    const result = await completeMcpOAuth({
-      state,
+    const egress = projectEgressFetcher(input.context.executionCtx.exports, state.projectId);
+    const result = await completeMcpOAuth(state, {
       code,
       ...(iss ? { iss } : {}),
-      encryptionKey: itxEnv.SECRET_ENCRYPTION_KEY,
       fetchFn: fetchLikeFromFetcher(egress),
     });
     await itxEnv.SECRET.getByName(
-      DurableObjectNameCodec.stringify({ projectId, path: result.path }),
+      DurableObjectNameCodec.stringify({ projectId: state.projectId, path: result.path }),
     ).update(result.secret);
 
     // Best-effort notify: the token is stored regardless, so a notify failure
     // must not read as total failure (the user would redo it; the agent waits).
-    let notifyFailed = false;
     if (result.notify) {
       try {
         const project = await new ProjectCollectionRpcTarget({
           auth: trustedInternalAuthContext(),
           config: input.context.config,
           ctx: input.context.executionCtx,
-        }).get(projectId);
+        }).get(state.projectId);
         await project.agents
           .get(result.notify)
           .message(
             `The OAuth connection to ${result.mcpUrl} is done. The token is stored write-only at ` +
-              `"${result.path}" (pinned to ${result.egressOrigins.join(", ")}). Connect with ` +
+              `"${result.path}" (pinned to ${result.secret.egress.urls.join(", ")}). Connect with ` +
               `itx.mcp.connect({ url: "${result.mcpUrl}", headers: { authorization: ` +
               `'Bearer getSecret({ path: "${result.path}", field: "accessToken" })' } }).`,
           );
       } catch (cause) {
         console.error("mcp-oauth: failed to notify", result.notify, cause);
-        notifyFailed = true;
       }
     }
-    return resultPage(
-      "Connected",
-      notifyFailed
-        ? `The connection is stored, but the agent could not be notified. Tell it the token at ${result.path} is ready.`
-        : "You can close this tab and return to the agent.",
-      200,
-    );
+    return redirectResponse("/");
   } catch (cause) {
-    const message =
-      cause instanceof McpOAuthError
-        ? cause.message
-        : "Something went wrong completing the connection.";
     if (!(cause instanceof McpOAuthError)) console.error("mcp-oauth: callback failed", cause);
-    return resultPage("Could not complete sign-in", message, 400);
+    return redirectWithError(null, "mcp_oauth_failed");
   }
-}
-
-/** A tiny self-contained result page for the MCP-OAuth callback (no chrome, no
- * route): the user lands here from an external provider, so it must render on
- * its own. Escapes its text — the message can carry a server-supplied URL. */
-function resultPage(title: string, body: string, status: number): Response {
-  const escape = (value: string) =>
-    value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-  const html = `<!doctype html><html><head><meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1"><title>${escape(title)}</title>
-<style>body{font-family:-apple-system,system-ui,sans-serif;display:grid;place-items:center;min-height:100vh;margin:0;background:#fafafa;color:#111}
-main{max-width:26rem;padding:2.5rem;text-align:center}h1{font-size:1.25rem;margin:0 0 .5rem}p{color:#555;line-height:1.5}</style>
-</head><body><main><h1>${escape(title)}</h1><p>${escape(body)}</p></main></body></html>`;
-  return new Response(html, { status, headers: { "content-type": "text/html; charset=utf-8" } });
 }
 
 function redirectWithError(callbackUrl: string | null, error: string) {

--- a/apps/os/src/domains/itx/mcp-client.ts
+++ b/apps/os/src/domains/itx/mcp-client.ts
@@ -25,13 +25,12 @@ export type McpClientConnectInput = {
 export type McpClientRpc = object;
 
 /** Input to `itx.mcp.beginOAuth`: the OAuth-protected MCP server to connect to,
- * an optional secret path to store the token at (defaults to `/secrets/mcp/<host>`),
- * and an optional OAuth scope to request. */
+ * the secret path to store the resulting token at, and an optional OAuth scope. */
 export type McpBeginOAuthInput = {
   /** The MCP server's URL (the same URL you would pass to `connect`). */
   url: string;
-  /** Where the resulting token is stored write-only. Defaults to `/secrets/mcp/<host>`. */
-  path?: string;
+  /** Where the resulting token is stored write-only, e.g. `/secrets/mcp/cloudflare`. */
+  path: string;
   /** OAuth scope to request; the server's default is used when omitted. */
   scope?: string;
 };

--- a/apps/os/src/domains/itx/mcp-client.ts
+++ b/apps/os/src/domains/itx/mcp-client.ts
@@ -24,6 +24,29 @@ export type McpClientConnectInput = {
  */
 export type McpClientRpc = object;
 
+/** Input to `itx.mcp.beginOAuth`: the OAuth-protected MCP server to connect to,
+ * an optional secret path to store the token at (defaults to `/secrets/mcp/<host>`),
+ * and an optional OAuth scope to request. */
+export type McpBeginOAuthInput = {
+  /** The MCP server's URL (the same URL you would pass to `connect`). */
+  url: string;
+  /** Where the resulting token is stored write-only. Defaults to `/secrets/mcp/<host>`. */
+  path?: string;
+  /** OAuth scope to request; the server's default is used when omitted. */
+  scope?: string;
+};
+
+/** Result of `itx.mcp.beginOAuth`: a link to send the user through, and the
+ * secret path the token lands at once they finish. */
+export type McpBeginOAuthResult = {
+  /** Send this to the user. Signing in there stores the token and (for an agent)
+   * messages you back so you can continue. */
+  authorizationUrl: string;
+  /** The `/secrets/…` path the token is stored at. Connect afterwards with
+   * `headers: { authorization: 'Bearer getSecret({ path: "<path>", field: "accessToken" })' }`. */
+  path: string;
+};
+
 const CLIENT_INFO = {
   name: "itx-mcp-client",
   version: "1.0.0",

--- a/apps/os/src/domains/itx/mcp-oauth.test.ts
+++ b/apps/os/src/domains/itx/mcp-oauth.test.ts
@@ -1,13 +1,19 @@
 // The outbound MCP-OAuth flow, end to end, against a spec-faithful in-memory
 // OAuth-protected MCP server: real SDK discovery (RFC 9728/8414), real dynamic
-// registration (RFC 7591), a real authorization-code + PKCE (S256) redirect,
-// and a real Basic-auth token exchange — no network. The petshop's own tests
-// prove the provider half (apps/dummy-petshop/src/worker.test.ts); this proves
-// beginMcpOAuth/completeMcpOAuth + the encrypted state codec drive a standards
-// server correctly.
+// registration of a PUBLIC client (RFC 7591, token_endpoint_auth_method "none"),
+// a real authorization-code + PKCE (S256) redirect, and a real public-client
+// token exchange (client_id in the body, no secret) — no network. The petshop's
+// own tests prove the provider half (apps/dummy-petshop/src/worker.test.ts); this
+// proves beginMcpOAuth/completeMcpOAuth + the encrypted state codec drive a
+// standards server correctly.
 import type { FetchLike } from "@modelcontextprotocol/client";
 import { describe, expect, test } from "vitest";
-import { beginMcpOAuth, completeMcpOAuth, McpOAuthError } from "./mcp-oauth.ts";
+import {
+  beginMcpOAuth,
+  completeMcpOAuth,
+  decodeMcpOAuthState,
+  McpOAuthError,
+} from "./mcp-oauth.ts";
 
 const KEY = "test-secret-encryption-key-000000000000";
 const ORIGIN = "https://mcp.test";
@@ -26,10 +32,11 @@ async function pkceS256(verifier: string): Promise<string> {
 }
 
 /**
- * A minimal but faithful OAuth-protected MCP server as a FetchLike, plus knobs
- * to drop capabilities (no auth advertising / no dynamic registration) for the
- * error paths. Confidential clients, Basic auth at the token endpoint, and PKCE
- * S256 verification — the exact shape beginMcpOAuth expects.
+ * A minimal but faithful OAuth-protected MCP server as a FetchLike, plus knobs to
+ * drop capabilities for the error paths. Registers PUBLIC clients pinned to their
+ * redirect URIs, authenticates them at the token endpoint by client_id + PKCE
+ * (no secret), and rejects a code without a verifier — the exact shape
+ * beginMcpOAuth drives.
  */
 function makeFakeServer(opts: { protectedResource?: boolean; registration?: boolean } = {}): {
   fetch: FetchLike;
@@ -37,23 +44,16 @@ function makeFakeServer(opts: { protectedResource?: boolean; registration?: bool
 } {
   const protectedResource = opts.protectedResource ?? true;
   const registration = opts.registration ?? true;
-  const clients = new Map<string, string>(); // clientId -> clientSecret
+  const clients = new Map<string, { redirectUris: string[] }>();
   const codes = new Map<string, { clientId: string; redirectUri: string; challenge?: string }>();
   const issuedAccessTokens = new Set<string>();
-  const refreshTokens = new Set<string>();
+  const refreshTokens = new Map<string, string>(); // refreshToken -> clientId
 
   const json = (data: unknown, status = 200, headers: Record<string, string> = {}) =>
     new Response(JSON.stringify(data), {
       status,
       headers: { "content-type": "application/json", ...headers },
     });
-
-  const basic = (request: Request): { id: string; secret: string } | null => {
-    const header = request.headers.get("authorization") ?? "";
-    if (!/^basic /i.test(header)) return null;
-    const [id, secret] = atob(header.slice(6)).split(":");
-    return id && secret ? { id, secret } : null;
-  };
 
   const fetch: FetchLike = async (input, init) => {
     const request = new Request(input as string, init as RequestInit);
@@ -87,22 +87,21 @@ function makeFakeServer(opts: { protectedResource?: boolean; registration?: bool
         response_types_supported: ["code"],
         grant_types_supported: ["authorization_code", "refresh_token"],
         code_challenge_methods_supported: ["S256"],
-        token_endpoint_auth_methods_supported: ["client_secret_basic"],
+        token_endpoint_auth_methods_supported: ["none", "client_secret_basic"],
       });
     }
 
     if (key === "POST /oauth/register") {
+      const body = (await request.json()) as { redirect_uris?: string[] };
+      const redirectUris = body.redirect_uris ?? [];
       const clientId = `client-${clients.size + 1}`;
-      const clientSecret = `secret-${clients.size + 1}`;
-      clients.set(clientId, clientSecret);
+      clients.set(clientId, { redirectUris });
+      // A public client (token_endpoint_auth_method "none") — no secret returned.
       return json(
         {
           client_id: clientId,
-          client_secret: clientSecret,
-          client_id_issued_at: 1,
-          client_secret_expires_at: 0,
-          redirect_uris: [REDIRECT_URI],
-          token_endpoint_auth_method: "client_secret_basic",
+          redirect_uris: redirectUris,
+          token_endpoint_auth_method: "none",
         },
         201,
       );
@@ -110,14 +109,16 @@ function makeFakeServer(opts: { protectedResource?: boolean; registration?: bool
 
     // Consent-free approve lane (the browser step the test drives directly).
     if (key === "GET /oauth/authorize") {
+      const clientId = url.searchParams.get("client_id") ?? "";
+      const redirectUri = url.searchParams.get("redirect_uri") ?? "";
+      const client = clients.get(clientId);
+      if (!client || !client.redirectUris.includes(redirectUri)) {
+        return json({ error: "invalid_request" }, 400);
+      }
       const code = `code-${codes.size + 1}`;
       const challenge = url.searchParams.get("code_challenge") ?? undefined;
-      codes.set(code, {
-        clientId: url.searchParams.get("client_id") ?? "",
-        redirectUri: url.searchParams.get("redirect_uri") ?? "",
-        ...(challenge ? { challenge } : {}),
-      });
-      const target = new URL(url.searchParams.get("redirect_uri") ?? REDIRECT_URI);
+      codes.set(code, { clientId, redirectUri, ...(challenge ? { challenge } : {}) });
+      const target = new URL(redirectUri);
       target.searchParams.set("code", code);
       const state = url.searchParams.get("state");
       if (state) target.searchParams.set("state", state);
@@ -125,28 +126,26 @@ function makeFakeServer(opts: { protectedResource?: boolean; registration?: bool
     }
 
     if (key === "POST /oauth/token") {
-      const creds = basic(request);
-      if (!creds || clients.get(creds.id) !== creds.secret) {
-        return json({ error: "invalid_client" }, 401);
-      }
       const form = new URLSearchParams(await request.text());
+      // Public client: identified by client_id in the body, no Basic auth.
+      const clientId = form.get("client_id") ?? "";
+      if (!clients.has(clientId)) return json({ error: "invalid_client" }, 401);
       if (form.get("grant_type") === "authorization_code") {
         const code = codes.get(form.get("code") ?? "");
-        if (!code || code.clientId !== creds.id) return json({ error: "invalid_grant" }, 400);
+        if (!code || code.clientId !== clientId) return json({ error: "invalid_grant" }, 400);
         if (code.redirectUri !== form.get("redirect_uri")) {
           return json({ error: "invalid_grant", error_description: "redirect mismatch" }, 400);
         }
-        if (code.challenge !== undefined) {
-          const verifier = form.get("code_verifier") ?? "";
-          if (!verifier || (await pkceS256(verifier)) !== code.challenge) {
-            return json({ error: "invalid_grant", error_description: "pkce" }, 400);
-          }
+        // PKCE is mandatory for a public client — its only proof.
+        const verifier = form.get("code_verifier") ?? "";
+        if (!code.challenge || !verifier || (await pkceS256(verifier)) !== code.challenge) {
+          return json({ error: "invalid_grant", error_description: "pkce" }, 400);
         }
         codes.delete(form.get("code") ?? "");
         const accessToken = `at-${issuedAccessTokens.size + 1}`;
         const refreshToken = `rt-${refreshTokens.size + 1}`;
         issuedAccessTokens.add(accessToken);
-        refreshTokens.add(refreshToken);
+        refreshTokens.set(refreshToken, clientId);
         return json({
           access_token: accessToken,
           refresh_token: refreshToken,
@@ -155,7 +154,7 @@ function makeFakeServer(opts: { protectedResource?: boolean; registration?: bool
         });
       }
       if (form.get("grant_type") === "refresh_token") {
-        if (!refreshTokens.has(form.get("refresh_token") ?? "")) {
+        if (refreshTokens.get(form.get("refresh_token") ?? "") !== clientId) {
           return json({ error: "invalid_grant" }, 400);
         }
         const accessToken = `at-${issuedAccessTokens.size + 1}`;
@@ -171,8 +170,21 @@ function makeFakeServer(opts: { protectedResource?: boolean; registration?: bool
   return { fetch, issuedAccessTokens };
 }
 
-/** Drive the "user clicks the link and signs in" step: follow the authorization
- * URL to the fake's approve lane and pull code+state off the redirect. */
+const beginInput = (
+  fetchFn: FetchLike,
+  extra: Partial<Parameters<typeof beginMcpOAuth>[0]> = {},
+) => ({
+  mcpUrl: MCP_URL,
+  path: "/secrets/mcp/petshop",
+  redirectUri: REDIRECT_URI,
+  projectId: PROJECT_ID,
+  encryptionKey: KEY,
+  fetchFn,
+  ...extra,
+});
+
+/** Drive "the user clicks the link and signs in": follow the authorization URL to
+ * the fake's approve lane and pull code+state off the redirect. */
 async function approve(
   fetch: FetchLike,
   authorizationUrl: string,
@@ -187,44 +199,31 @@ async function approve(
 }
 
 describe("mcp oauth flow", () => {
-  test("begin → approve → complete yields a usable, refreshable token", async () => {
+  test("begin → approve → complete yields a usable, refreshable public-client token", async () => {
     const server = makeFakeServer();
-    const begin = await beginMcpOAuth({
-      mcpUrl: MCP_URL,
-      path: "/secrets/mcp/petshop",
-      redirectUri: REDIRECT_URI,
-      notify: NOTIFY,
-      projectId: PROJECT_ID,
-      encryptionKey: KEY,
-      fetchFn: server.fetch,
-    });
+    const begin = await beginMcpOAuth(beginInput(server.fetch, { notify: NOTIFY }));
 
-    // The link points at the provider's authorize endpoint, carries PKCE + our
-    // callback, and does not leak the client secret in the clear.
+    // The link points at the provider's authorize endpoint and carries PKCE + our
+    // callback.
     const authUrl = new URL(begin.authorizationUrl);
     expect(authUrl.origin + authUrl.pathname).toBe(`${ORIGIN}/oauth/authorize`);
     expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
     expect(authUrl.searchParams.get("redirect_uri")).toBe(REDIRECT_URI);
-    expect(begin.authorizationServer).toBe(ORIGIN);
-    expect(begin.authorizationUrl).not.toContain("secret-1");
 
     const { code, state } = await approve(server.fetch, begin.authorizationUrl);
-    const result = await completeMcpOAuth({
-      code,
-      state,
-      encryptionKey: KEY,
-      fetchFn: server.fetch,
-    });
+    const decoded = await decodeMcpOAuthState(state, KEY);
+    const result = await completeMcpOAuth(decoded, { code, fetchFn: server.fetch });
 
     expect(result.path).toBe("/secrets/mcp/petshop");
     expect(result.notify).toBe(NOTIFY);
     expect(result.mcpUrl).toBe(MCP_URL);
-    expect(result.egressOrigins).toEqual([ORIGIN]);
-    // Confidential client → material carries the client creds and the refresh
-    // strategy reads them from material.
+    expect(result.secret.egress.urls).toEqual([ORIGIN]);
+    // Public client → material carries the client id (no secret) and the refresh
+    // strategy reads it from material.
     expect(result.secret.material.accessToken).toBeTruthy();
     expect(result.secret.material.refreshToken).toBeTruthy();
-    expect(result.secret.material.clientSecret).toBeTruthy();
+    expect(result.secret.material.clientId).toBeTruthy();
+    expect(result.secret.material.clientSecret).toBeUndefined();
     expect(result.secret.refresh).toEqual({
       kind: "oauth-refresh-token",
       tokenEndpoint: `${ORIGIN}/oauth/token`,
@@ -238,74 +237,52 @@ describe("mcp oauth flow", () => {
     });
     expect(authed.status).toBe(200);
 
-    // ...and the stored refresh material mints a fresh token via Basic auth,
-    // exactly as the Secret DO's oauth-refresh-token strategy will.
+    // ...and the stored refresh material mints a fresh token as a public client
+    // (client_id in the body, no Basic auth) — exactly what the Secret DO's
+    // oauth-refresh-token strategy does for a secret-less client.
     const refreshed = await server.fetch(`${ORIGIN}/oauth/token`, {
       method: "POST",
-      headers: {
-        authorization: `Basic ${btoa(`${result.secret.material.clientId}:${result.secret.material.clientSecret}`)}`,
-        "content-type": "application/x-www-form-urlencoded",
-      },
+      headers: { "content-type": "application/x-www-form-urlencoded" },
       body: new URLSearchParams({
         grant_type: "refresh_token",
         refresh_token: result.secret.material.refreshToken!,
+        client_id: result.secret.material.clientId!,
       }),
     });
     expect(refreshed.status).toBe(200);
     expect(((await refreshed.json()) as { access_token: string }).access_token).toBeTruthy();
   });
 
+  test("no notify field when the caller is not an agent scope", async () => {
+    const server = makeFakeServer();
+    const begin = await beginMcpOAuth(beginInput(server.fetch));
+    const { code, state } = await approve(server.fetch, begin.authorizationUrl);
+    const result = await completeMcpOAuth(await decodeMcpOAuthState(state, KEY), {
+      code,
+      fetchFn: server.fetch,
+    });
+    expect(result.notify).toBeUndefined();
+  });
+
   test("a server that is not OAuth-protected fails with a helpful message", async () => {
     const server = makeFakeServer({ protectedResource: false });
-    await expect(
-      beginMcpOAuth({
-        mcpUrl: MCP_URL,
-        path: "/secrets/mcp/x",
-        redirectUri: REDIRECT_URI,
-        projectId: PROJECT_ID,
-        encryptionKey: KEY,
-        fetchFn: server.fetch,
-      }),
-    ).rejects.toThrow(McpOAuthError);
+    await expect(beginMcpOAuth(beginInput(server.fetch))).rejects.toThrow(McpOAuthError);
   });
 
   test("a server without dynamic registration is rejected", async () => {
     const server = makeFakeServer({ registration: false });
-    await expect(
-      beginMcpOAuth({
-        mcpUrl: MCP_URL,
-        path: "/secrets/mcp/x",
-        redirectUri: REDIRECT_URI,
-        projectId: PROJECT_ID,
-        encryptionKey: KEY,
-        fetchFn: server.fetch,
-      }),
-    ).rejects.toThrow(/dynamic client registration/);
+    await expect(beginMcpOAuth(beginInput(server.fetch))).rejects.toThrow(
+      /dynamic client registration/,
+    );
   });
 
-  test("a tampered or foreign-key state is rejected at completion", async () => {
+  test("a tampered, foreign-key, or expired state is rejected at decode", async () => {
     const server = makeFakeServer();
-    const begin = await beginMcpOAuth({
-      mcpUrl: MCP_URL,
-      path: "/secrets/mcp/x",
-      redirectUri: REDIRECT_URI,
-      projectId: PROJECT_ID,
-      encryptionKey: KEY,
-      fetchFn: server.fetch,
-    });
-    const { code, state } = await approve(server.fetch, begin.authorizationUrl);
+    const begin = await beginMcpOAuth(beginInput(server.fetch));
+    const { state } = await approve(server.fetch, begin.authorizationUrl);
     // Wrong encryption key (another deployment) cannot read the state.
-    await expect(
-      completeMcpOAuth({ code, state, encryptionKey: "a-different-key", fetchFn: server.fetch }),
-    ).rejects.toThrow(McpOAuthError);
+    await expect(decodeMcpOAuthState(state, "a-different-key")).rejects.toThrow(McpOAuthError);
     // A truncated state token is malformed.
-    await expect(
-      completeMcpOAuth({
-        code,
-        state: state.slice(0, 10),
-        encryptionKey: KEY,
-        fetchFn: server.fetch,
-      }),
-    ).rejects.toThrow(McpOAuthError);
+    await expect(decodeMcpOAuthState(state.slice(0, 10), KEY)).rejects.toThrow(McpOAuthError);
   });
 });

--- a/apps/os/src/domains/itx/mcp-oauth.test.ts
+++ b/apps/os/src/domains/itx/mcp-oauth.test.ts
@@ -1,0 +1,311 @@
+// The outbound MCP-OAuth flow, end to end, against a spec-faithful in-memory
+// OAuth-protected MCP server: real SDK discovery (RFC 9728/8414), real dynamic
+// registration (RFC 7591), a real authorization-code + PKCE (S256) redirect,
+// and a real Basic-auth token exchange — no network. The petshop's own tests
+// prove the provider half (apps/dummy-petshop/src/worker.test.ts); this proves
+// beginMcpOAuth/completeMcpOAuth + the encrypted state codec drive a standards
+// server correctly.
+import type { FetchLike } from "@modelcontextprotocol/client";
+import { describe, expect, test } from "vitest";
+import { beginMcpOAuth, completeMcpOAuth, McpOAuthError } from "./mcp-oauth.ts";
+
+const KEY = "test-secret-encryption-key-000000000000";
+const ORIGIN = "https://mcp.test";
+const MCP_URL = `${ORIGIN}/mcp`;
+const REDIRECT_URI = "https://os.test/api/mcp-oauth/callback";
+const PROJECT_ID = "prj_test";
+const NOTIFY = "/agents/petshop";
+
+async function pkceS256(verifier: string): Promise<string> {
+  const digest = new Uint8Array(
+    await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier)),
+  );
+  let binary = "";
+  for (const byte of digest) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+/**
+ * A minimal but faithful OAuth-protected MCP server as a FetchLike, plus knobs
+ * to drop capabilities (no auth advertising / no dynamic registration) for the
+ * error paths. Confidential clients, Basic auth at the token endpoint, and PKCE
+ * S256 verification — the exact shape beginMcpOAuth expects.
+ */
+function makeFakeServer(opts: { protectedResource?: boolean; registration?: boolean } = {}): {
+  fetch: FetchLike;
+  issuedAccessTokens: Set<string>;
+} {
+  const protectedResource = opts.protectedResource ?? true;
+  const registration = opts.registration ?? true;
+  const clients = new Map<string, string>(); // clientId -> clientSecret
+  const codes = new Map<string, { clientId: string; redirectUri: string; challenge?: string }>();
+  const issuedAccessTokens = new Set<string>();
+  const refreshTokens = new Set<string>();
+
+  const json = (data: unknown, status = 200, headers: Record<string, string> = {}) =>
+    new Response(JSON.stringify(data), {
+      status,
+      headers: { "content-type": "application/json", ...headers },
+    });
+
+  const basic = (request: Request): { id: string; secret: string } | null => {
+    const header = request.headers.get("authorization") ?? "";
+    if (!/^basic /i.test(header)) return null;
+    const [id, secret] = atob(header.slice(6)).split(":");
+    return id && secret ? { id, secret } : null;
+  };
+
+  const fetch: FetchLike = async (input, init) => {
+    const request = new Request(input as string, init as RequestInit);
+    const url = new URL(request.url);
+    const key = `${request.method} ${url.pathname}`;
+
+    if (url.pathname === "/mcp") {
+      const token = (request.headers.get("authorization") ?? "").replace(/^bearer /i, "");
+      if (!issuedAccessTokens.has(token)) {
+        return json({ error: "invalid_token" }, 401, {
+          "www-authenticate": `Bearer resource_metadata="${ORIGIN}/.well-known/oauth-protected-resource/mcp"`,
+        });
+      }
+      return json({ jsonrpc: "2.0", id: 0, result: { ok: true } });
+    }
+
+    if (
+      protectedResource &&
+      (key === "GET /.well-known/oauth-protected-resource" ||
+        key === "GET /.well-known/oauth-protected-resource/mcp")
+    ) {
+      return json({ resource: MCP_URL, authorization_servers: [ORIGIN] });
+    }
+
+    if (key === "GET /.well-known/oauth-authorization-server") {
+      return json({
+        issuer: ORIGIN,
+        authorization_endpoint: `${ORIGIN}/oauth/authorize`,
+        token_endpoint: `${ORIGIN}/oauth/token`,
+        ...(registration ? { registration_endpoint: `${ORIGIN}/oauth/register` } : {}),
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code", "refresh_token"],
+        code_challenge_methods_supported: ["S256"],
+        token_endpoint_auth_methods_supported: ["client_secret_basic"],
+      });
+    }
+
+    if (key === "POST /oauth/register") {
+      const clientId = `client-${clients.size + 1}`;
+      const clientSecret = `secret-${clients.size + 1}`;
+      clients.set(clientId, clientSecret);
+      return json(
+        {
+          client_id: clientId,
+          client_secret: clientSecret,
+          client_id_issued_at: 1,
+          client_secret_expires_at: 0,
+          redirect_uris: [REDIRECT_URI],
+          token_endpoint_auth_method: "client_secret_basic",
+        },
+        201,
+      );
+    }
+
+    // Consent-free approve lane (the browser step the test drives directly).
+    if (key === "GET /oauth/authorize") {
+      const code = `code-${codes.size + 1}`;
+      const challenge = url.searchParams.get("code_challenge") ?? undefined;
+      codes.set(code, {
+        clientId: url.searchParams.get("client_id") ?? "",
+        redirectUri: url.searchParams.get("redirect_uri") ?? "",
+        ...(challenge ? { challenge } : {}),
+      });
+      const target = new URL(url.searchParams.get("redirect_uri") ?? REDIRECT_URI);
+      target.searchParams.set("code", code);
+      const state = url.searchParams.get("state");
+      if (state) target.searchParams.set("state", state);
+      return new Response(null, { status: 302, headers: { location: target.toString() } });
+    }
+
+    if (key === "POST /oauth/token") {
+      const creds = basic(request);
+      if (!creds || clients.get(creds.id) !== creds.secret) {
+        return json({ error: "invalid_client" }, 401);
+      }
+      const form = new URLSearchParams(await request.text());
+      if (form.get("grant_type") === "authorization_code") {
+        const code = codes.get(form.get("code") ?? "");
+        if (!code || code.clientId !== creds.id) return json({ error: "invalid_grant" }, 400);
+        if (code.redirectUri !== form.get("redirect_uri")) {
+          return json({ error: "invalid_grant", error_description: "redirect mismatch" }, 400);
+        }
+        if (code.challenge !== undefined) {
+          const verifier = form.get("code_verifier") ?? "";
+          if (!verifier || (await pkceS256(verifier)) !== code.challenge) {
+            return json({ error: "invalid_grant", error_description: "pkce" }, 400);
+          }
+        }
+        codes.delete(form.get("code") ?? "");
+        const accessToken = `at-${issuedAccessTokens.size + 1}`;
+        const refreshToken = `rt-${refreshTokens.size + 1}`;
+        issuedAccessTokens.add(accessToken);
+        refreshTokens.add(refreshToken);
+        return json({
+          access_token: accessToken,
+          refresh_token: refreshToken,
+          token_type: "bearer",
+          expires_in: 120,
+        });
+      }
+      if (form.get("grant_type") === "refresh_token") {
+        if (!refreshTokens.has(form.get("refresh_token") ?? "")) {
+          return json({ error: "invalid_grant" }, 400);
+        }
+        const accessToken = `at-${issuedAccessTokens.size + 1}`;
+        issuedAccessTokens.add(accessToken);
+        return json({ access_token: accessToken, token_type: "bearer", expires_in: 120 });
+      }
+      return json({ error: "unsupported_grant_type" }, 400);
+    }
+
+    return json({ error: "not_found" }, 404);
+  };
+
+  return { fetch, issuedAccessTokens };
+}
+
+/** Drive the "user clicks the link and signs in" step: follow the authorization
+ * URL to the fake's approve lane and pull code+state off the redirect. */
+async function approve(
+  fetch: FetchLike,
+  authorizationUrl: string,
+): Promise<{ code: string; state: string }> {
+  const response = await fetch(authorizationUrl, { method: "GET" });
+  expect(response.status).toBe(302);
+  const location = new URL(response.headers.get("location") ?? "");
+  return {
+    code: location.searchParams.get("code") ?? "",
+    state: location.searchParams.get("state") ?? "",
+  };
+}
+
+describe("mcp oauth flow", () => {
+  test("begin → approve → complete yields a usable, refreshable token", async () => {
+    const server = makeFakeServer();
+    const begin = await beginMcpOAuth({
+      mcpUrl: MCP_URL,
+      path: "/secrets/mcp/petshop",
+      redirectUri: REDIRECT_URI,
+      notify: NOTIFY,
+      projectId: PROJECT_ID,
+      encryptionKey: KEY,
+      fetchFn: server.fetch,
+    });
+
+    // The link points at the provider's authorize endpoint, carries PKCE + our
+    // callback, and does not leak the client secret in the clear.
+    const authUrl = new URL(begin.authorizationUrl);
+    expect(authUrl.origin + authUrl.pathname).toBe(`${ORIGIN}/oauth/authorize`);
+    expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(authUrl.searchParams.get("redirect_uri")).toBe(REDIRECT_URI);
+    expect(begin.authorizationServer).toBe(ORIGIN);
+    expect(begin.authorizationUrl).not.toContain("secret-1");
+
+    const { code, state } = await approve(server.fetch, begin.authorizationUrl);
+    const result = await completeMcpOAuth({
+      code,
+      state,
+      encryptionKey: KEY,
+      fetchFn: server.fetch,
+    });
+
+    expect(result.path).toBe("/secrets/mcp/petshop");
+    expect(result.notify).toBe(NOTIFY);
+    expect(result.mcpUrl).toBe(MCP_URL);
+    expect(result.egressOrigins).toEqual([ORIGIN]);
+    // Confidential client → material carries the client creds and the refresh
+    // strategy reads them from material.
+    expect(result.secret.material.accessToken).toBeTruthy();
+    expect(result.secret.material.refreshToken).toBeTruthy();
+    expect(result.secret.material.clientSecret).toBeTruthy();
+    expect(result.secret.refresh).toEqual({
+      kind: "oauth-refresh-token",
+      tokenEndpoint: `${ORIGIN}/oauth/token`,
+      clientCreds: "material",
+    });
+
+    // The access token actually works against the MCP endpoint...
+    const authed = await server.fetch(MCP_URL, {
+      method: "POST",
+      headers: { authorization: `Bearer ${result.secret.material.accessToken}` },
+    });
+    expect(authed.status).toBe(200);
+
+    // ...and the stored refresh material mints a fresh token via Basic auth,
+    // exactly as the Secret DO's oauth-refresh-token strategy will.
+    const refreshed = await server.fetch(`${ORIGIN}/oauth/token`, {
+      method: "POST",
+      headers: {
+        authorization: `Basic ${btoa(`${result.secret.material.clientId}:${result.secret.material.clientSecret}`)}`,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: result.secret.material.refreshToken!,
+      }),
+    });
+    expect(refreshed.status).toBe(200);
+    expect(((await refreshed.json()) as { access_token: string }).access_token).toBeTruthy();
+  });
+
+  test("a server that is not OAuth-protected fails with a helpful message", async () => {
+    const server = makeFakeServer({ protectedResource: false });
+    await expect(
+      beginMcpOAuth({
+        mcpUrl: MCP_URL,
+        path: "/secrets/mcp/x",
+        redirectUri: REDIRECT_URI,
+        projectId: PROJECT_ID,
+        encryptionKey: KEY,
+        fetchFn: server.fetch,
+      }),
+    ).rejects.toThrow(McpOAuthError);
+  });
+
+  test("a server without dynamic registration is rejected", async () => {
+    const server = makeFakeServer({ registration: false });
+    await expect(
+      beginMcpOAuth({
+        mcpUrl: MCP_URL,
+        path: "/secrets/mcp/x",
+        redirectUri: REDIRECT_URI,
+        projectId: PROJECT_ID,
+        encryptionKey: KEY,
+        fetchFn: server.fetch,
+      }),
+    ).rejects.toThrow(/dynamic client registration/);
+  });
+
+  test("a tampered or foreign-key state is rejected at completion", async () => {
+    const server = makeFakeServer();
+    const begin = await beginMcpOAuth({
+      mcpUrl: MCP_URL,
+      path: "/secrets/mcp/x",
+      redirectUri: REDIRECT_URI,
+      projectId: PROJECT_ID,
+      encryptionKey: KEY,
+      fetchFn: server.fetch,
+    });
+    const { code, state } = await approve(server.fetch, begin.authorizationUrl);
+    // Wrong encryption key (another deployment) cannot read the state.
+    await expect(
+      completeMcpOAuth({ code, state, encryptionKey: "a-different-key", fetchFn: server.fetch }),
+    ).rejects.toThrow(McpOAuthError);
+    // A truncated state token is malformed.
+    await expect(
+      completeMcpOAuth({
+        code,
+        state: state.slice(0, 10),
+        encryptionKey: KEY,
+        fetchFn: server.fetch,
+      }),
+    ).rejects.toThrow(McpOAuthError);
+  });
+});

--- a/apps/os/src/domains/itx/mcp-oauth.ts
+++ b/apps/os/src/domains/itx/mcp-oauth.ts
@@ -9,30 +9,32 @@
 //      (probed off the /mcp `WWW-Authenticate: …resource_metadata=` pointer,
 //      falling back to the well-known path) → the RFC 8414 authorization-server
 //      metadata it names.
-//   2. Dynamically register a confidential client (RFC 7591) whose one
-//      redirect URI is this deployment's /api/mcp-oauth/callback.
-//   3. Build the authorization-code + PKCE (S256) URL and fold everything the
-//      callback will need — endpoints, the freshly registered client
-//      credentials, the PKCE verifier, the target secret path, the agent to
-//      notify — into an ENCRYPTED `state` token (it carries a client secret and
-//      a PKCE verifier, so signing is not enough; we AES-GCM it with
-//      SECRET_ENCRYPTION_KEY).
+//   2. Dynamically register a PUBLIC client (RFC 7591, token_endpoint_auth_method
+//      "none") whose one redirect URI is this deployment's /api/mcp-oauth/callback.
+//      Public + PKCE is the standard MCP client shape (no client secret to guard).
+//   3. Build the authorization-code + PKCE (S256) URL and fold what the callback
+//      needs — the auth server, the resource, the client id, the PKCE verifier,
+//      the target secret path, the agent to notify — into a state token.
 //
-// The user clicks the link, signs in at the provider, and the provider
-// redirects to /api/mcp-oauth/callback, where completeMcpOAuth redeems the code
-// for tokens and hands back a secret spec: material `{ accessToken,
-// refreshToken?, clientId?, clientSecret? }`, pinned egress (the MCP + token
-// endpoints), and — for a confidential client — the shared oauth-refresh-token
-// refresh strategy (`clientCreds: "material"`), so the Secret DO re-mints on
-// 401 in its own trusted code. The agent then connects like any bearer MCP:
+// The state is ENCRYPTED (AES-GCM with SECRET_ENCRYPTION_KEY), not merely signed:
+// for a public client the PKCE verifier is the ONLY thing protecting the
+// authorization code, so it must not ride in a readable token. Nothing bulky or
+// re-derivable lives in it — the auth-server metadata is re-discovered at
+// completion rather than carried.
+//
+// The user signs in at the provider, which redirects to /api/mcp-oauth/callback,
+// where completeMcpOAuth redeems the code for tokens and hands back a secret
+// spec: material `{ accessToken, refreshToken?, clientId }`, egress pinned to the
+// MCP + token endpoints, and the shared oauth-refresh-token strategy
+// (`clientCreds: "material"`) so the Secret DO re-mints on 401 in its own trusted
+// code. The agent then connects like any bearer MCP:
 //   itx.mcp.connect({ url, headers: { authorization:
 //     'Bearer getSecret({ path: "<path>", field: "accessToken" })' } })
 //
-// The two verbs are pure — they take the encryption key + a fetch function and
-// return data — so the whole round trip unit-tests against the real petshop
-// handler with no network. rpc-targets.ts (begin) and integration-api.ts
-// (callback) are the thin adapters that supply itx bindings, write the Secret
-// DO, and message the agent.
+// The two verbs are pure — key + fetch function in, data out — so the whole round
+// trip unit-tests with no network. rpc-targets.ts (begin) and integration-api.ts
+// (callback) are the thin adapters that supply itx bindings, write the Secret DO,
+// and message the agent.
 
 import {
   discoverAuthorizationServerMetadata,
@@ -65,10 +67,10 @@ export class McpOAuthError extends Error {
   }
 }
 
-// The encrypted state carried through the redirect. Everything here is either
-// public discovery data or a freshly minted per-flow secret (client secret,
-// PKCE verifier) — which is exactly why the whole blob is encrypted, not just
-// signed, before it rides in a URL the provider echoes back.
+// The encrypted state carried through the redirect. Only what the callback
+// cannot cheaply re-derive: the routing/target data, the resource indicator, the
+// registered client id, and the PKCE verifier (the reason this is encrypted, not
+// signed). The auth-server metadata is re-discovered at completion.
 const MCPOAuthState = z.object({
   v: z.literal("mcp-oauth-1"),
   projectId: z.string(),
@@ -78,14 +80,8 @@ const MCPOAuthState = z.object({
   resource: z.string().optional(),
   redirectUri: z.string(),
   authServerUrl: z.string(),
-  tokenEndpoint: z.string(),
-  /** Full RFC 8414 metadata, so the exchange picks the same client-auth method
-   * discovery advertised without re-fetching. */
-  authMetadata: z.unknown(),
   clientId: z.string(),
-  clientSecret: z.string().optional(),
   codeVerifier: z.string(),
-  egressOrigins: z.array(z.string()),
   expiresAt: z.number(),
 });
 type MCPOAuthState = z.infer<typeof MCPOAuthState>;
@@ -104,7 +100,7 @@ type BeginMcpOAuthInput = {
   projectId: string;
   /** SECRET_ENCRYPTION_KEY — encrypts the state token. */
   encryptionKey: string;
-  /** Outbound fetch (project egress in production; the petshop handler in tests). */
+  /** Outbound fetch (project egress in production; a test server in unit tests). */
   fetchFn: FetchLike;
 };
 
@@ -113,8 +109,6 @@ type BeginMcpOAuthResult = {
   authorizationUrl: string;
   /** The secret path the token will land at (echoed for convenience). */
   path: string;
-  /** The authorization server the user will sign in at (for the agent's message). */
-  authorizationServer: string;
 };
 
 export async function beginMcpOAuth(input: BeginMcpOAuthInput): Promise<BeginMcpOAuthResult> {
@@ -141,31 +135,16 @@ export async function beginMcpOAuth(input: BeginMcpOAuthInput): Promise<BeginMcp
     throw new McpOAuthError(`${input.mcpUrl} does not advertise an OAuth authorization server.`);
   }
 
-  // 2. Authorization-server metadata (RFC 8414).
-  const authMetadata = await discoverAuthorizationServerMetadata(authServerUrl, { fetchFn }).catch(
-    (cause: unknown) => {
-      throw new McpOAuthError(
-        `could not discover OAuth metadata for ${authServerUrl}: ${errorText(cause)}`,
-      );
-    },
-  );
-  if (!authMetadata) {
-    throw new McpOAuthError(`${authServerUrl} published no usable OAuth authorization metadata.`);
-  }
+  const authMetadata = await discoverOrThrow(authServerUrl, fetchFn);
   if (!authMetadata.registration_endpoint) {
     throw new McpOAuthError(
       `${authServerUrl} does not support dynamic client registration, so this automated flow ` +
         `cannot obtain a client. Register a client out of band and store its token with itx.secrets.collectFromUser.`,
     );
   }
-  const tokenEndpoint = authMetadata.token_endpoint;
-  if (!tokenEndpoint) {
-    throw new McpOAuthError(`${authServerUrl} published no token endpoint.`);
-  }
 
-  // 3. Dynamic client registration (RFC 7591): one client, whose one redirect
-  //    URI is our callback. We ask for a confidential client so the token can
-  //    later be refreshed with the shared oauth-refresh-token strategy.
+  // 2. Dynamic client registration (RFC 7591): a PUBLIC client (no secret) whose
+  //    one redirect URI is our callback. Public + PKCE is the standard MCP shape.
   const clientInfo = await registerClient(authServerUrl, {
     metadata: authMetadata,
     clientMetadata: {
@@ -173,7 +152,7 @@ export async function beginMcpOAuth(input: BeginMcpOAuthInput): Promise<BeginMcp
       redirect_uris: [input.redirectUri],
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
-      token_endpoint_auth_method: "client_secret_basic",
+      token_endpoint_auth_method: "none",
       ...(input.scope ? { scope: input.scope } : {}),
     },
     ...(input.scope ? { scope: input.scope } : {}),
@@ -184,7 +163,7 @@ export async function beginMcpOAuth(input: BeginMcpOAuthInput): Promise<BeginMcp
     );
   });
 
-  // 4. Authorization-code + PKCE URL. The resource indicator (RFC 8707) binds
+  // 3. Authorization-code + PKCE URL. The resource indicator (RFC 8707) binds
   //    the eventual token to this MCP server.
   const resource = resourceUrlFromServerUrl(prm.resource ?? input.mcpUrl);
   const { authorizationUrl, codeVerifier } = await startAuthorization(authServerUrl, {
@@ -195,10 +174,6 @@ export async function beginMcpOAuth(input: BeginMcpOAuthInput): Promise<BeginMcp
     ...(resource ? { resource } : {}),
   });
 
-  // 5. Encrypt everything the callback needs into the state param.
-  const egressOrigins = [
-    ...new Set([input.mcpUrl, tokenEndpoint].map((url) => new URL(url).origin)),
-  ];
   const state: MCPOAuthState = {
     v: "mcp-oauth-1",
     projectId: input.projectId,
@@ -208,61 +183,45 @@ export async function beginMcpOAuth(input: BeginMcpOAuthInput): Promise<BeginMcp
     ...(resource ? { resource: resource.toString() } : {}),
     redirectUri: input.redirectUri,
     authServerUrl,
-    tokenEndpoint,
-    authMetadata,
     clientId: clientInfo.client_id,
-    ...(clientInfo.client_secret ? { clientSecret: clientInfo.client_secret } : {}),
     codeVerifier,
-    egressOrigins,
     expiresAt: Date.now() + STATE_TTL_MS,
   };
-  authorizationUrl.searchParams.set("state", await encodeState(state, input.encryptionKey));
+  const encryptedState = await encryptSecretMaterial(JSON.stringify(state), input.encryptionKey);
+  authorizationUrl.searchParams.set("state", toBase64Url(JSON.stringify(encryptedState)));
 
-  return {
-    authorizationUrl: authorizationUrl.toString(),
-    path: input.path,
-    authorizationServer: authServerUrl,
-  };
+  return { authorizationUrl: authorizationUrl.toString(), path: input.path };
 }
-
-type CompleteMcpOAuthInput = {
-  /** The encrypted `state` echoed back by the provider. */
-  state: string;
-  /** The authorization code from the callback query. */
-  code: string;
-  /** The `iss` callback param (RFC 9207), validated against discovery. */
-  iss?: string;
-  encryptionKey: string;
-  fetchFn: FetchLike;
-};
 
 type CompleteMcpOAuthResult = {
   path: string;
   notify?: string;
   mcpUrl: string;
-  egressOrigins: string[];
-  /** The Secret DO update the caller applies: material + egress + (maybe) refresh. */
+  /** The Secret DO update the caller applies: material + egress + refresh. */
   secret: {
     material: Record<string, string>;
     egress: { urls: string[] };
-    refresh?: SecretRefresh;
+    /** null (never undefined) so an update REPLACES any stale strategy on the path. */
+    refresh: SecretRefresh | null;
   };
 };
 
+/**
+ * Redeem the callback's authorization code for tokens and produce the Secret DO
+ * update. Takes the already-decoded state (the callback decodes once to route by
+ * projectId), re-discovers the auth-server metadata (kept out of the state), and
+ * exchanges as a public PKCE client.
+ */
 export async function completeMcpOAuth(
-  input: CompleteMcpOAuthInput,
+  state: MCPOAuthState,
+  input: { code: string; iss?: string; fetchFn: FetchLike },
 ): Promise<CompleteMcpOAuthResult> {
-  const state = await decodeState(input.state, input.encryptionKey);
-  if (state.expiresAt < Date.now()) {
-    throw new McpOAuthError("this authorization link has expired — ask the agent for a fresh one.");
-  }
+  const authMetadata = await discoverOrThrow(state.authServerUrl, input.fetchFn);
+  const tokenEndpoint = authMetadata.token_endpoint;
 
   const tokens = await exchangeAuthorization(state.authServerUrl, {
-    metadata: state.authMetadata as AuthorizationServerMetadata,
-    clientInformation: {
-      client_id: state.clientId,
-      ...(state.clientSecret ? { client_secret: state.clientSecret } : {}),
-    },
+    metadata: authMetadata,
+    clientInformation: { client_id: state.clientId },
     authorizationCode: input.code,
     codeVerifier: state.codeVerifier,
     redirectUri: state.redirectUri,
@@ -273,40 +232,65 @@ export async function completeMcpOAuth(
     throw new McpOAuthError(`token exchange failed: ${errorText(cause)}`);
   });
 
-  // A confidential client (has a secret) gets the shared oauth-refresh-token
-  // strategy, reading its own clientId/clientSecret out of material so the
-  // Secret DO re-mints on 401 in trusted code. A public client (no secret) has
-  // no Basic-auth refresh path here, so we store the tokens without a strategy —
-  // the access token works until it expires, and reconnecting re-runs the flow.
-  const material: Record<string, string> = {
-    accessToken: tokens.access_token,
-    ...(tokens.refresh_token ? { refreshToken: tokens.refresh_token } : {}),
-    ...(state.clientSecret ? { clientId: state.clientId, clientSecret: state.clientSecret } : {}),
-  };
-  const refresh: SecretRefresh | undefined =
-    state.clientSecret && tokens.refresh_token
-      ? { kind: "oauth-refresh-token", tokenEndpoint: state.tokenEndpoint, clientCreds: "material" }
-      : undefined;
+  // The access token is sent as a bearer to the MCP server; the refresh token is
+  // POSTed to the token endpoint. Pin egress to exactly those two origins.
+  const egressUrls = [...new Set([state.mcpUrl, tokenEndpoint].map((url) => new URL(url).origin))];
 
   return {
     path: state.path,
     ...(state.notify ? { notify: state.notify } : {}),
     mcpUrl: state.mcpUrl,
-    egressOrigins: state.egressOrigins,
     secret: {
-      material,
-      egress: { urls: state.egressOrigins },
-      ...(refresh ? { refresh } : {}),
+      material: {
+        accessToken: tokens.access_token,
+        ...(tokens.refresh_token ? { refreshToken: tokens.refresh_token } : {}),
+        // client_id is required to refresh a public client (RFC 6749 §6).
+        clientId: state.clientId,
+      },
+      egress: { urls: egressUrls },
+      // A refresh token means the Secret DO can re-mint on 401 in trusted code.
+      refresh: tokens.refresh_token
+        ? { kind: "oauth-refresh-token", tokenEndpoint, clientCreds: "material" }
+        : null,
     },
   };
 }
 
-/** Decrypt just the projectId out of a state token so the callback can address
- * the right project's egress + Secret DO before the full completeMcpOAuth. The
- * whole state is re-validated there; this is the routing read (the encrypted
- * analogue of parseOAuthStateUnverified). Throws McpOAuthError on a bad token. */
-export async function readMcpOAuthProjectId(state: string, encryptionKey: string): Promise<string> {
-  return (await decodeState(state, encryptionKey)).projectId;
+/** Decrypt + validate a state token (throws McpOAuthError on a bad or expired
+ * link). The callback decodes ONCE, reads `projectId` for routing, then hands the
+ * decoded state to completeMcpOAuth — no second decrypt. */
+export async function decodeMcpOAuthState(token: string, key: string): Promise<MCPOAuthState> {
+  let json: string;
+  try {
+    const encrypted = JSON.parse(fromBase64Url(token));
+    json = await decryptSecretMaterial(encrypted, key);
+  } catch {
+    throw new McpOAuthError(
+      "this authorization link is malformed or was issued for another deployment.",
+    );
+  }
+  const state = MCPOAuthState.parse(JSON.parse(json));
+  if (state.expiresAt < Date.now()) {
+    throw new McpOAuthError("this authorization link has expired — ask the agent for a fresh one.");
+  }
+  return state;
+}
+
+async function discoverOrThrow(
+  authServerUrl: string,
+  fetchFn: FetchLike,
+): Promise<AuthorizationServerMetadata & { token_endpoint: string }> {
+  const metadata = await discoverAuthorizationServerMetadata(authServerUrl, { fetchFn }).catch(
+    (cause: unknown) => {
+      throw new McpOAuthError(
+        `could not discover OAuth metadata for ${authServerUrl}: ${errorText(cause)}`,
+      );
+    },
+  );
+  if (!metadata?.token_endpoint) {
+    throw new McpOAuthError(`${authServerUrl} published no usable OAuth authorization metadata.`);
+  }
+  return metadata as AuthorizationServerMetadata & { token_endpoint: string };
 }
 
 /** POST a minimal initialize to /mcp so an OAuth-protected server answers 401
@@ -341,36 +325,11 @@ async function probeResourceMetadataUrl(
   }
 }
 
-async function encodeState(state: MCPOAuthState, key: string): Promise<string> {
-  const encrypted = await encryptSecretMaterial(JSON.stringify(state), key);
-  return toBase64Url(JSON.stringify(encrypted));
-}
-
-async function decodeState(token: string, key: string): Promise<MCPOAuthState> {
-  let json: string;
-  try {
-    const encrypted = JSON.parse(fromBase64Url(token));
-    json = await decryptSecretMaterial(encrypted, key);
-  } catch {
-    throw new McpOAuthError(
-      "this authorization link is malformed or was signed for another deployment.",
-    );
-  }
-  return MCPOAuthState.parse(JSON.parse(json));
-}
-
 /** Adapt a Cloudflare Fetcher (project egress) to the SDK's FetchLike. Unlike
  * the MCP client's stateless adapter, this forwards GETs unchanged — OAuth
  * discovery reads the server's well-known metadata over GET. */
 export function fetchLikeFromFetcher(fetcher: Fetcher): FetchLike {
   return (url, init) => fetcher.fetch(new Request(url as string | URL, init as RequestInit));
-}
-
-/** The default secret path for a server's token when the caller gives none:
- * `/secrets/mcp/<host>` (host lowercased, non-path-safe chars collapsed). */
-export function defaultMcpSecretPath(mcpUrl: string): string {
-  const host = new URL(mcpUrl).host.toLowerCase().replace(/[^a-z0-9.-]+/g, "-");
-  return `/secrets/mcp/${host}`;
 }
 
 function isHttpUrl(value: string): boolean {

--- a/apps/os/src/domains/itx/mcp-oauth.ts
+++ b/apps/os/src/domains/itx/mcp-oauth.ts
@@ -65,6 +65,31 @@ export class McpOAuthError extends Error {
   }
 }
 
+// The encrypted state carried through the redirect. Everything here is either
+// public discovery data or a freshly minted per-flow secret (client secret,
+// PKCE verifier) — which is exactly why the whole blob is encrypted, not just
+// signed, before it rides in a URL the provider echoes back.
+const MCPOAuthState = z.object({
+  v: z.literal("mcp-oauth-1"),
+  projectId: z.string(),
+  path: z.string(),
+  notify: z.string().optional(),
+  mcpUrl: z.string(),
+  resource: z.string().optional(),
+  redirectUri: z.string(),
+  authServerUrl: z.string(),
+  tokenEndpoint: z.string(),
+  /** Full RFC 8414 metadata, so the exchange picks the same client-auth method
+   * discovery advertised without re-fetching. */
+  authMetadata: z.unknown(),
+  clientId: z.string(),
+  clientSecret: z.string().optional(),
+  codeVerifier: z.string(),
+  egressOrigins: z.array(z.string()),
+  expiresAt: z.number(),
+});
+type MCPOAuthState = z.infer<typeof MCPOAuthState>;
+
 type BeginMcpOAuthInput = {
   /** The MCP server's streamable-HTTP URL (what itx.mcp.connect would take). */
   mcpUrl: string;
@@ -91,55 +116,6 @@ type BeginMcpOAuthResult = {
   /** The authorization server the user will sign in at (for the agent's message). */
   authorizationServer: string;
 };
-
-type CompleteMcpOAuthInput = {
-  /** The encrypted `state` echoed back by the provider. */
-  state: string;
-  /** The authorization code from the callback query. */
-  code: string;
-  /** The `iss` callback param (RFC 9207), validated against discovery. */
-  iss?: string;
-  encryptionKey: string;
-  fetchFn: FetchLike;
-};
-
-type CompleteMcpOAuthResult = {
-  path: string;
-  notify?: string;
-  mcpUrl: string;
-  egressOrigins: string[];
-  /** The Secret DO update the caller applies: material + egress + (maybe) refresh. */
-  secret: {
-    material: Record<string, string>;
-    egress: { urls: string[] };
-    refresh?: SecretRefresh;
-  };
-};
-
-// The encrypted state carried through the redirect. Everything here is either
-// public discovery data or a freshly minted per-flow secret (client secret,
-// PKCE verifier) — which is exactly why the whole blob is encrypted, not just
-// signed, before it rides in a URL the provider echoes back.
-const MCPOAuthState = z.object({
-  v: z.literal("mcp-oauth-1"),
-  projectId: z.string(),
-  path: z.string(),
-  notify: z.string().optional(),
-  mcpUrl: z.string(),
-  resource: z.string().optional(),
-  redirectUri: z.string(),
-  authServerUrl: z.string(),
-  tokenEndpoint: z.string(),
-  /** Full RFC 8414 metadata, so the exchange picks the same client-auth method
-   * discovery advertised without re-fetching. */
-  authMetadata: z.unknown(),
-  clientId: z.string(),
-  clientSecret: z.string().optional(),
-  codeVerifier: z.string(),
-  egressOrigins: z.array(z.string()),
-  expiresAt: z.number(),
-});
-type MCPOAuthState = z.infer<typeof MCPOAuthState>;
 
 export async function beginMcpOAuth(input: BeginMcpOAuthInput): Promise<BeginMcpOAuthResult> {
   const { fetchFn } = input;
@@ -248,6 +224,30 @@ export async function beginMcpOAuth(input: BeginMcpOAuthInput): Promise<BeginMcp
     authorizationServer: authServerUrl,
   };
 }
+
+type CompleteMcpOAuthInput = {
+  /** The encrypted `state` echoed back by the provider. */
+  state: string;
+  /** The authorization code from the callback query. */
+  code: string;
+  /** The `iss` callback param (RFC 9207), validated against discovery. */
+  iss?: string;
+  encryptionKey: string;
+  fetchFn: FetchLike;
+};
+
+type CompleteMcpOAuthResult = {
+  path: string;
+  notify?: string;
+  mcpUrl: string;
+  egressOrigins: string[];
+  /** The Secret DO update the caller applies: material + egress + (maybe) refresh. */
+  secret: {
+    material: Record<string, string>;
+    egress: { urls: string[] };
+    refresh?: SecretRefresh;
+  };
+};
 
 export async function completeMcpOAuth(
   input: CompleteMcpOAuthInput,

--- a/apps/os/src/domains/itx/mcp-oauth.ts
+++ b/apps/os/src/domains/itx/mcp-oauth.ts
@@ -65,7 +65,7 @@ export class McpOAuthError extends Error {
   }
 }
 
-export type BeginMcpOAuthInput = {
+type BeginMcpOAuthInput = {
   /** The MCP server's streamable-HTTP URL (what itx.mcp.connect would take). */
   mcpUrl: string;
   /** Normalized `/secrets/…` path the resulting token lands at. */
@@ -83,7 +83,7 @@ export type BeginMcpOAuthInput = {
   fetchFn: FetchLike;
 };
 
-export type BeginMcpOAuthResult = {
+type BeginMcpOAuthResult = {
   /** The provider authorization URL to send the user to. */
   authorizationUrl: string;
   /** The secret path the token will land at (echoed for convenience). */
@@ -92,7 +92,7 @@ export type BeginMcpOAuthResult = {
   authorizationServer: string;
 };
 
-export type CompleteMcpOAuthInput = {
+type CompleteMcpOAuthInput = {
   /** The encrypted `state` echoed back by the provider. */
   state: string;
   /** The authorization code from the callback query. */
@@ -103,7 +103,7 @@ export type CompleteMcpOAuthInput = {
   fetchFn: FetchLike;
 };
 
-export type CompleteMcpOAuthResult = {
+type CompleteMcpOAuthResult = {
   path: string;
   notify?: string;
   mcpUrl: string;

--- a/apps/os/src/domains/itx/mcp-oauth.ts
+++ b/apps/os/src/domains/itx/mcp-oauth.ts
@@ -1,0 +1,398 @@
+// Outbound MCP-server OAuth: the flow behind `itx.mcp.beginOAuth`.
+//
+// An agent that discovers an OAuth-protected MCP server (Cloudflare's
+// mcp.cloudflare.com, the dummy-petshop /mcp, …) cannot paste a token — there
+// is none until a human signs in. beginMcpOAuth turns the server URL into a
+// one-click authorization link:
+//
+//   1. Discover the server's OAuth metadata — RFC 9728 protected-resource
+//      (probed off the /mcp `WWW-Authenticate: …resource_metadata=` pointer,
+//      falling back to the well-known path) → the RFC 8414 authorization-server
+//      metadata it names.
+//   2. Dynamically register a confidential client (RFC 7591) whose one
+//      redirect URI is this deployment's /api/mcp-oauth/callback.
+//   3. Build the authorization-code + PKCE (S256) URL and fold everything the
+//      callback will need — endpoints, the freshly registered client
+//      credentials, the PKCE verifier, the target secret path, the agent to
+//      notify — into an ENCRYPTED `state` token (it carries a client secret and
+//      a PKCE verifier, so signing is not enough; we AES-GCM it with
+//      SECRET_ENCRYPTION_KEY).
+//
+// The user clicks the link, signs in at the provider, and the provider
+// redirects to /api/mcp-oauth/callback, where completeMcpOAuth redeems the code
+// for tokens and hands back a secret spec: material `{ accessToken,
+// refreshToken?, clientId?, clientSecret? }`, pinned egress (the MCP + token
+// endpoints), and — for a confidential client — the shared oauth-refresh-token
+// refresh strategy (`clientCreds: "material"`), so the Secret DO re-mints on
+// 401 in its own trusted code. The agent then connects like any bearer MCP:
+//   itx.mcp.connect({ url, headers: { authorization:
+//     'Bearer getSecret({ path: "<path>", field: "accessToken" })' } })
+//
+// The two verbs are pure — they take the encryption key + a fetch function and
+// return data — so the whole round trip unit-tests against the real petshop
+// handler with no network. rpc-targets.ts (begin) and integration-api.ts
+// (callback) are the thin adapters that supply itx bindings, write the Secret
+// DO, and message the agent.
+
+import {
+  discoverAuthorizationServerMetadata,
+  discoverOAuthProtectedResourceMetadata,
+  exchangeAuthorization,
+  extractResourceMetadataUrl,
+  registerClient,
+  resourceUrlFromServerUrl,
+  startAuthorization,
+  type AuthorizationServerMetadata,
+  type FetchLike,
+} from "@modelcontextprotocol/client";
+import { z } from "zod";
+import { decryptSecretMaterial, encryptSecretMaterial } from "../secrets/crypto.ts";
+import type { SecretRefresh } from "../secrets/types.ts";
+
+/** How long an authorization link is good for. Long enough for a human to sign
+ * in at the provider, short enough that a leaked (already-encrypted) link is
+ * not a standing credential. */
+const STATE_TTL_MS = 15 * 60 * 1000;
+
+const CLIENT_NAME = "Iterate";
+
+/** A message meant for a human (agent or dashboard) — thrown when the flow
+ * cannot proceed and the reason is worth surfacing verbatim. */
+export class McpOAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "McpOAuthError";
+  }
+}
+
+export type BeginMcpOAuthInput = {
+  /** The MCP server's streamable-HTTP URL (what itx.mcp.connect would take). */
+  mcpUrl: string;
+  /** Normalized `/secrets/…` path the resulting token lands at. */
+  path: string;
+  /** The redirect URI to register — this deployment's /api/mcp-oauth/callback. */
+  redirectUri: string;
+  /** Agent path to message when the connection completes (absent for non-agent scopes). */
+  notify?: string;
+  /** OAuth scope to request; omitted means "server default". */
+  scope?: string;
+  projectId: string;
+  /** SECRET_ENCRYPTION_KEY — encrypts the state token. */
+  encryptionKey: string;
+  /** Outbound fetch (project egress in production; the petshop handler in tests). */
+  fetchFn: FetchLike;
+};
+
+export type BeginMcpOAuthResult = {
+  /** The provider authorization URL to send the user to. */
+  authorizationUrl: string;
+  /** The secret path the token will land at (echoed for convenience). */
+  path: string;
+  /** The authorization server the user will sign in at (for the agent's message). */
+  authorizationServer: string;
+};
+
+export type CompleteMcpOAuthInput = {
+  /** The encrypted `state` echoed back by the provider. */
+  state: string;
+  /** The authorization code from the callback query. */
+  code: string;
+  /** The `iss` callback param (RFC 9207), validated against discovery. */
+  iss?: string;
+  encryptionKey: string;
+  fetchFn: FetchLike;
+};
+
+export type CompleteMcpOAuthResult = {
+  path: string;
+  notify?: string;
+  mcpUrl: string;
+  egressOrigins: string[];
+  /** The Secret DO update the caller applies: material + egress + (maybe) refresh. */
+  secret: {
+    material: Record<string, string>;
+    egress: { urls: string[] };
+    refresh?: SecretRefresh;
+  };
+};
+
+// The encrypted state carried through the redirect. Everything here is either
+// public discovery data or a freshly minted per-flow secret (client secret,
+// PKCE verifier) — which is exactly why the whole blob is encrypted, not just
+// signed, before it rides in a URL the provider echoes back.
+const MCPOAuthState = z.object({
+  v: z.literal("mcp-oauth-1"),
+  projectId: z.string(),
+  path: z.string(),
+  notify: z.string().optional(),
+  mcpUrl: z.string(),
+  resource: z.string().optional(),
+  redirectUri: z.string(),
+  authServerUrl: z.string(),
+  tokenEndpoint: z.string(),
+  /** Full RFC 8414 metadata, so the exchange picks the same client-auth method
+   * discovery advertised without re-fetching. */
+  authMetadata: z.unknown(),
+  clientId: z.string(),
+  clientSecret: z.string().optional(),
+  codeVerifier: z.string(),
+  egressOrigins: z.array(z.string()),
+  expiresAt: z.number(),
+});
+type MCPOAuthState = z.infer<typeof MCPOAuthState>;
+
+export async function beginMcpOAuth(input: BeginMcpOAuthInput): Promise<BeginMcpOAuthResult> {
+  const { fetchFn } = input;
+  if (!isHttpUrl(input.mcpUrl)) {
+    throw new McpOAuthError(`${input.mcpUrl} is not an http(s) URL.`);
+  }
+
+  // 1. Protected-resource metadata (RFC 9728). Prefer the pointer the server
+  //    hands out in its 401 WWW-Authenticate; fall back to the well-known path.
+  const resourceMetadataUrl = await probeResourceMetadataUrl(input.mcpUrl, fetchFn);
+  const prm = await discoverOAuthProtectedResourceMetadata(
+    input.mcpUrl,
+    resourceMetadataUrl ? { resourceMetadataUrl } : {},
+    fetchFn,
+  ).catch((cause: unknown) => {
+    throw new McpOAuthError(
+      `${input.mcpUrl} is not an OAuth-protected MCP server (no protected-resource metadata: ${errorText(cause)}). ` +
+        `If it takes a bearer token you already hold, use itx.secrets.collectFromUser instead.`,
+    );
+  });
+  const authServerUrl = prm.authorization_servers?.[0]?.toString();
+  if (!authServerUrl) {
+    throw new McpOAuthError(`${input.mcpUrl} does not advertise an OAuth authorization server.`);
+  }
+
+  // 2. Authorization-server metadata (RFC 8414).
+  const authMetadata = await discoverAuthorizationServerMetadata(authServerUrl, { fetchFn }).catch(
+    (cause: unknown) => {
+      throw new McpOAuthError(
+        `could not discover OAuth metadata for ${authServerUrl}: ${errorText(cause)}`,
+      );
+    },
+  );
+  if (!authMetadata) {
+    throw new McpOAuthError(`${authServerUrl} published no usable OAuth authorization metadata.`);
+  }
+  if (!authMetadata.registration_endpoint) {
+    throw new McpOAuthError(
+      `${authServerUrl} does not support dynamic client registration, so this automated flow ` +
+        `cannot obtain a client. Register a client out of band and store its token with itx.secrets.collectFromUser.`,
+    );
+  }
+  const tokenEndpoint = authMetadata.token_endpoint;
+  if (!tokenEndpoint) {
+    throw new McpOAuthError(`${authServerUrl} published no token endpoint.`);
+  }
+
+  // 3. Dynamic client registration (RFC 7591): one client, whose one redirect
+  //    URI is our callback. We ask for a confidential client so the token can
+  //    later be refreshed with the shared oauth-refresh-token strategy.
+  const clientInfo = await registerClient(authServerUrl, {
+    metadata: authMetadata,
+    clientMetadata: {
+      client_name: CLIENT_NAME,
+      redirect_uris: [input.redirectUri],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "client_secret_basic",
+      ...(input.scope ? { scope: input.scope } : {}),
+    },
+    ...(input.scope ? { scope: input.scope } : {}),
+    fetchFn,
+  }).catch((cause: unknown) => {
+    throw new McpOAuthError(
+      `${authServerUrl} rejected dynamic client registration: ${errorText(cause)}`,
+    );
+  });
+
+  // 4. Authorization-code + PKCE URL. The resource indicator (RFC 8707) binds
+  //    the eventual token to this MCP server.
+  const resource = resourceUrlFromServerUrl(prm.resource ?? input.mcpUrl);
+  const { authorizationUrl, codeVerifier } = await startAuthorization(authServerUrl, {
+    metadata: authMetadata,
+    clientInformation: clientInfo,
+    redirectUrl: input.redirectUri,
+    ...(input.scope ? { scope: input.scope } : {}),
+    ...(resource ? { resource } : {}),
+  });
+
+  // 5. Encrypt everything the callback needs into the state param.
+  const egressOrigins = [
+    ...new Set([input.mcpUrl, tokenEndpoint].map((url) => new URL(url).origin)),
+  ];
+  const state: MCPOAuthState = {
+    v: "mcp-oauth-1",
+    projectId: input.projectId,
+    path: input.path,
+    ...(input.notify ? { notify: input.notify } : {}),
+    mcpUrl: input.mcpUrl,
+    ...(resource ? { resource: resource.toString() } : {}),
+    redirectUri: input.redirectUri,
+    authServerUrl,
+    tokenEndpoint,
+    authMetadata,
+    clientId: clientInfo.client_id,
+    ...(clientInfo.client_secret ? { clientSecret: clientInfo.client_secret } : {}),
+    codeVerifier,
+    egressOrigins,
+    expiresAt: Date.now() + STATE_TTL_MS,
+  };
+  authorizationUrl.searchParams.set("state", await encodeState(state, input.encryptionKey));
+
+  return {
+    authorizationUrl: authorizationUrl.toString(),
+    path: input.path,
+    authorizationServer: authServerUrl,
+  };
+}
+
+export async function completeMcpOAuth(
+  input: CompleteMcpOAuthInput,
+): Promise<CompleteMcpOAuthResult> {
+  const state = await decodeState(input.state, input.encryptionKey);
+  if (state.expiresAt < Date.now()) {
+    throw new McpOAuthError("this authorization link has expired — ask the agent for a fresh one.");
+  }
+
+  const tokens = await exchangeAuthorization(state.authServerUrl, {
+    metadata: state.authMetadata as AuthorizationServerMetadata,
+    clientInformation: {
+      client_id: state.clientId,
+      ...(state.clientSecret ? { client_secret: state.clientSecret } : {}),
+    },
+    authorizationCode: input.code,
+    codeVerifier: state.codeVerifier,
+    redirectUri: state.redirectUri,
+    ...(state.resource ? { resource: new URL(state.resource) } : {}),
+    ...(input.iss ? { iss: input.iss } : {}),
+    fetchFn: input.fetchFn,
+  }).catch((cause: unknown) => {
+    throw new McpOAuthError(`token exchange failed: ${errorText(cause)}`);
+  });
+
+  // A confidential client (has a secret) gets the shared oauth-refresh-token
+  // strategy, reading its own clientId/clientSecret out of material so the
+  // Secret DO re-mints on 401 in trusted code. A public client (no secret) has
+  // no Basic-auth refresh path here, so we store the tokens without a strategy —
+  // the access token works until it expires, and reconnecting re-runs the flow.
+  const material: Record<string, string> = {
+    accessToken: tokens.access_token,
+    ...(tokens.refresh_token ? { refreshToken: tokens.refresh_token } : {}),
+    ...(state.clientSecret ? { clientId: state.clientId, clientSecret: state.clientSecret } : {}),
+  };
+  const refresh: SecretRefresh | undefined =
+    state.clientSecret && tokens.refresh_token
+      ? { kind: "oauth-refresh-token", tokenEndpoint: state.tokenEndpoint, clientCreds: "material" }
+      : undefined;
+
+  return {
+    path: state.path,
+    ...(state.notify ? { notify: state.notify } : {}),
+    mcpUrl: state.mcpUrl,
+    egressOrigins: state.egressOrigins,
+    secret: {
+      material,
+      egress: { urls: state.egressOrigins },
+      ...(refresh ? { refresh } : {}),
+    },
+  };
+}
+
+/** Decrypt just the projectId out of a state token so the callback can address
+ * the right project's egress + Secret DO before the full completeMcpOAuth. The
+ * whole state is re-validated there; this is the routing read (the encrypted
+ * analogue of parseOAuthStateUnverified). Throws McpOAuthError on a bad token. */
+export async function readMcpOAuthProjectId(state: string, encryptionKey: string): Promise<string> {
+  return (await decodeState(state, encryptionKey)).projectId;
+}
+
+/** POST a minimal initialize to /mcp so an OAuth-protected server answers 401
+ * with its `WWW-Authenticate: …resource_metadata=` pointer (RFC 9728 §5.1).
+ * Best-effort: any failure just means discovery falls back to the well-known
+ * path. */
+async function probeResourceMetadataUrl(
+  mcpUrl: string,
+  fetchFn: FetchLike,
+): Promise<URL | undefined> {
+  try {
+    const response = await fetchFn(mcpUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 0,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: CLIENT_NAME, version: "1.0.0" },
+        },
+      }),
+    });
+    return extractResourceMetadataUrl(response);
+  } catch {
+    return undefined;
+  }
+}
+
+async function encodeState(state: MCPOAuthState, key: string): Promise<string> {
+  const encrypted = await encryptSecretMaterial(JSON.stringify(state), key);
+  return toBase64Url(JSON.stringify(encrypted));
+}
+
+async function decodeState(token: string, key: string): Promise<MCPOAuthState> {
+  let json: string;
+  try {
+    const encrypted = JSON.parse(fromBase64Url(token));
+    json = await decryptSecretMaterial(encrypted, key);
+  } catch {
+    throw new McpOAuthError(
+      "this authorization link is malformed or was signed for another deployment.",
+    );
+  }
+  return MCPOAuthState.parse(JSON.parse(json));
+}
+
+/** Adapt a Cloudflare Fetcher (project egress) to the SDK's FetchLike. Unlike
+ * the MCP client's stateless adapter, this forwards GETs unchanged — OAuth
+ * discovery reads the server's well-known metadata over GET. */
+export function fetchLikeFromFetcher(fetcher: Fetcher): FetchLike {
+  return (url, init) => fetcher.fetch(new Request(url as string | URL, init as RequestInit));
+}
+
+/** The default secret path for a server's token when the caller gives none:
+ * `/secrets/mcp/<host>` (host lowercased, non-path-safe chars collapsed). */
+export function defaultMcpSecretPath(mcpUrl: string): string {
+  const host = new URL(mcpUrl).host.toLowerCase().replace(/[^a-z0-9.-]+/g, "-");
+  return `/secrets/mcp/${host}`;
+}
+
+function isHttpUrl(value: string): boolean {
+  if (!URL.canParse(value)) return false;
+  return /^https?:$/.test(new URL(value).protocol);
+}
+
+function errorText(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+function toBase64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function fromBase64Url(value: string): string {
+  const padded = value.replaceAll("-", "+").replaceAll("_", "/");
+  const binary = atob(padded + "=".repeat((4 - (padded.length % 4)) % 4));
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+  return new TextDecoder().decode(bytes);
+}

--- a/apps/os/src/domains/secrets/secret-durable-object.ts
+++ b/apps/os/src/domains/secrets/secret-durable-object.ts
@@ -250,24 +250,33 @@ export class SecretDurableObject extends DurableObject<Env> {
   ): Promise<void> {
     assertOriginPinned(refresh.tokenEndpoint, state);
     const refreshToken = readStringField(material, "refreshToken");
+    // Material creds may be a confidential client (clientId + clientSecret) or a
+    // PUBLIC client (clientId only — e.g. a dynamically-registered MCP client);
+    // platform creds are always confidential.
     const creds =
       refresh.clientCreds === "material"
         ? {
             clientId: readStringField(material, "clientId"),
-            clientSecret: readStringField(material, "clientSecret"),
+            clientSecret: optionalStringField(material, "clientSecret"),
           }
         : resolvePlatformClientCreds(
             parseConfig(this.env),
             refresh.clientCreds,
             refresh.tokenEndpoint,
           );
+    const body = new URLSearchParams({ grant_type: "refresh_token", refresh_token: refreshToken });
+    // A confidential client authenticates with HTTP Basic; a public client (no
+    // secret) instead identifies itself with client_id in the body (RFC 6749 §6).
+    if (creds.clientSecret === undefined) body.set("client_id", creds.clientId);
     const response = await fetch(refresh.tokenEndpoint, {
       method: "POST",
       headers: {
-        authorization: `Basic ${btoa(`${creds.clientId}:${creds.clientSecret}`)}`,
+        ...(creds.clientSecret === undefined
+          ? {}
+          : { authorization: `Basic ${btoa(`${creds.clientId}:${creds.clientSecret}`)}` }),
         "content-type": "application/x-www-form-urlencoded",
       },
-      body: new URLSearchParams({ grant_type: "refresh_token", refresh_token: refreshToken }),
+      body,
     });
     if (!response.ok) throw new Error(`oauth refresh failed with HTTP ${response.status}`);
     const data = (await response.json()) as { access_token?: string; refresh_token?: string };
@@ -431,6 +440,13 @@ function readStringField(material: Record<string, unknown>, field: string): stri
     throw new SecretSubstitutionError("secret_reference_field_not_found");
   }
   return value;
+}
+
+/** Like {@link readStringField} but returns undefined instead of throwing when
+ * the field is absent — for optional material (a public client has no secret). */
+function optionalStringField(material: Record<string, unknown>, field: string): string | undefined {
+  const value = material[field];
+  return typeof value === "string" ? value : undefined;
 }
 
 /**

--- a/apps/os/src/itx-api-graph.generated.ts
+++ b/apps/os/src/itx-api-graph.generated.ts
@@ -1292,9 +1292,9 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     name: "McpBeginOAuthInput",
     kind: "typeAlias",
     sourceText:
-      "/** Input to `itx.mcp.beginOAuth`: the OAuth-protected MCP server to connect to,\n * an optional secret path to store the token at (defaults to `/secrets/mcp/<host>`),\n * and an optional OAuth scope to request. */\nexport type McpBeginOAuthInput = {\n  /** The MCP server's URL (the same URL you would pass to `connect`). */\n  url: string;\n  /** Where the resulting token is stored write-only. Defaults to `/secrets/mcp/<host>`. */\n  path?: string;\n  /** OAuth scope to request; the server's default is used when omitted. */\n  scope?: string;\n};",
+      "/** Input to `itx.mcp.beginOAuth`: the OAuth-protected MCP server to connect to,\n * the secret path to store the resulting token at, and an optional OAuth scope. */\nexport type McpBeginOAuthInput = {\n  /** The MCP server's URL (the same URL you would pass to `connect`). */\n  url: string;\n  /** Where the resulting token is stored write-only, e.g. `/secrets/mcp/cloudflare`. */\n  path: string;\n  /** OAuth scope to request; the server's default is used when omitted. */\n  scope?: string;\n};",
     summary:
-      "Input to `itx.mcp.beginOAuth`: the OAuth-protected MCP server to connect to, an optional secret path to store the token at (defaults to `/secrets/mcp/<host>`), and an optional OAuth scope to request.",
+      "Input to `itx.mcp.beginOAuth`: the OAuth-protected MCP server to connect to, the secret path to store the resulting token at, and an optional OAuth scope.",
     memberSummaries: {},
     referencedTypeNames: [],
   },

--- a/apps/os/src/itx-api-graph.generated.ts
+++ b/apps/os/src/itx-api-graph.generated.ts
@@ -439,13 +439,21 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     name: "McpClientCollection",
     kind: "interface",
     sourceText:
-      "/**\n * Ad-hoc MCP (Model Context Protocol) clients — `itx.mcp`. `connect({ url })`\n * returns a client whose dotted calls invoke the server's tools; `exa` is the\n * pre-connected Exa web-search server every project gets.\n */\nexport interface McpClientCollection {\n  __describe(): Promise<Description>;\n  /** Connect to an MCP server by URL; dotted calls on the client are tool invocations. */\n  connect(input: McpClientConnectInput): Promise<McpClientRpc>;\n  /**\n   * The public Exa MCP server (https://mcp.exa.ai/mcp), pre-connected for every\n   * project: web search and page reading as flat tool calls.\n   * `itx.mcp.exa.web_search_exa({ query, numResults })` searches the web;\n   * `itx.mcp.exa.web_fetch_exa({ urls, maxCharacters })` reads pages as markdown.\n   */\n  exa: McpClientRpc;\n}",
+      '/**\n * Ad-hoc MCP (Model Context Protocol) clients — `itx.mcp`. `connect({ url })`\n * returns a client whose dotted calls invoke the server\'s tools; `exa` is the\n * pre-connected Exa web-search server every project gets.\n */\nexport interface McpClientCollection {\n  __describe(): Promise<Description>;\n  /** Connect to an MCP server by URL; dotted calls on the client are tool invocations. */\n  connect(input: McpClientConnectInput): Promise<McpClientRpc>;\n  /**\n   * Begin the OAuth sign-in for an OAuth-protected MCP server (one whose\n   * unauthenticated request answers 401 with a `WWW-Authenticate` challenge —\n   * e.g. Cloudflare\'s mcp.cloudflare.com). Discovers the server\'s OAuth\n   * endpoints, registers a client, and returns a `{ authorizationUrl, path }`:\n   * send `authorizationUrl` to the user ("click here to connect"). When they\n   * sign in, the token is stored write-only at `path` and — if you are an agent\n   * — you are messaged so you can continue. Then connect like any bearer MCP:\n   * `itx.mcp.connect({ url, headers: { authorization: \'Bearer getSecret({ path:\n   * "<path>", field: "accessToken" })\' } })`. For a server that just wants a\n   * bearer token you already hold, use `itx.secrets.collectFromUser` instead.\n   */\n  beginOAuth(input: McpBeginOAuthInput): Promise<McpBeginOAuthResult>;\n  /**\n   * The public Exa MCP server (https://mcp.exa.ai/mcp), pre-connected for every\n   * project: web search and page reading as flat tool calls.\n   * `itx.mcp.exa.web_search_exa({ query, numResults })` searches the web;\n   * `itx.mcp.exa.web_fetch_exa({ urls, maxCharacters })` reads pages as markdown.\n   */\n  exa: McpClientRpc;\n}',
     summary: "Ad-hoc MCP (Model Context Protocol) clients — `itx.mcp`.",
     memberSummaries: {
       connect: "Connect to an MCP server by URL; dotted calls on the client are tool invocations.",
+      beginOAuth:
+        "Begin the OAuth sign-in for an OAuth-protected MCP server (one whose unauthenticated request answers 401 with a `WWW-Authenticate` challenge — e.g.",
       exa: "The public Exa MCP server (https://mcp.exa.ai/mcp), pre-connected for every project: web search and page reading as flat tool calls.",
     },
-    referencedTypeNames: ["Description", "McpClientConnectInput", "McpClientRpc"],
+    referencedTypeNames: [
+      "Description",
+      "McpClientConnectInput",
+      "McpClientRpc",
+      "McpBeginOAuthInput",
+      "McpBeginOAuthResult",
+    ],
   },
   {
     name: "OpenApiCollection",
@@ -1277,6 +1285,26 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     sourceText:
       "/**\n * A connected MCP client. Its tools are dotted method calls\n * (`itx.mcp.<server>.<tool>({...})`) resolved through the dynamic path-call\n * fallback, so this contract deliberately does not re-declare a fixed surface.\n */\nexport type McpClientRpc = object;",
     summary: "A connected MCP client.",
+    memberSummaries: {},
+    referencedTypeNames: [],
+  },
+  {
+    name: "McpBeginOAuthInput",
+    kind: "typeAlias",
+    sourceText:
+      "/** Input to `itx.mcp.beginOAuth`: the OAuth-protected MCP server to connect to,\n * an optional secret path to store the token at (defaults to `/secrets/mcp/<host>`),\n * and an optional OAuth scope to request. */\nexport type McpBeginOAuthInput = {\n  /** The MCP server's URL (the same URL you would pass to `connect`). */\n  url: string;\n  /** Where the resulting token is stored write-only. Defaults to `/secrets/mcp/<host>`. */\n  path?: string;\n  /** OAuth scope to request; the server's default is used when omitted. */\n  scope?: string;\n};",
+    summary:
+      "Input to `itx.mcp.beginOAuth`: the OAuth-protected MCP server to connect to, an optional secret path to store the token at (defaults to `/secrets/mcp/<host>`), and an optional OAuth scope to request.",
+    memberSummaries: {},
+    referencedTypeNames: [],
+  },
+  {
+    name: "McpBeginOAuthResult",
+    kind: "typeAlias",
+    sourceText:
+      '/** Result of `itx.mcp.beginOAuth`: a link to send the user through, and the\n * secret path the token lands at once they finish. */\nexport type McpBeginOAuthResult = {\n  /** Send this to the user. Signing in there stores the token and (for an agent)\n   * messages you back so you can continue. */\n  authorizationUrl: string;\n  /** The `/secrets/…` path the token is stored at. Connect afterwards with\n   * `headers: { authorization: \'Bearer getSecret({ path: "<path>", field: "accessToken" })\' }`. */\n  path: string;\n};',
+    summary:
+      "Result of `itx.mcp.beginOAuth`: a link to send the user through, and the secret path the token lands at once they finish.",
     memberSummaries: {},
     referencedTypeNames: [],
   },

--- a/apps/os/src/itx-api.generated.ts
+++ b/apps/os/src/itx-api.generated.ts
@@ -764,6 +764,19 @@ export interface McpClientCollection {
   /** Connect to an MCP server by URL; dotted calls on the client are tool invocations. */
   connect(input: McpClientConnectInput): Promise<McpClientRpc>;
   /**
+   * Begin the OAuth sign-in for an OAuth-protected MCP server (one whose
+   * unauthenticated request answers 401 with a `WWW-Authenticate` challenge —
+   * e.g. Cloudflare's mcp.cloudflare.com). Discovers the server's OAuth
+   * endpoints, registers a client, and returns a `{ authorizationUrl, path }`:
+   * send `authorizationUrl` to the user ("click here to connect"). When they
+   * sign in, the token is stored write-only at `path` and — if you are an agent
+   * — you are messaged so you can continue. Then connect like any bearer MCP:
+   * `itx.mcp.connect({ url, headers: { authorization: 'Bearer getSecret({ path:
+   * "<path>", field: "accessToken" })' } })`. For a server that just wants a
+   * bearer token you already hold, use `itx.secrets.collectFromUser` instead.
+   */
+  beginOAuth(input: McpBeginOAuthInput): Promise<McpBeginOAuthResult>;
+  /**
    * The public Exa MCP server (https://mcp.exa.ai/mcp), pre-connected for every
    * project: web search and page reading as flat tool calls.
    * `itx.mcp.exa.web_search_exa({ query, numResults })` searches the web;
@@ -2062,6 +2075,29 @@ export type McpClientConnectInput = {
  * fallback, so this contract deliberately does not re-declare a fixed surface.
  */
 export type McpClientRpc = object;
+
+/** Input to `itx.mcp.beginOAuth`: the OAuth-protected MCP server to connect to,
+ * an optional secret path to store the token at (defaults to `/secrets/mcp/<host>`),
+ * and an optional OAuth scope to request. */
+export type McpBeginOAuthInput = {
+  /** The MCP server's URL (the same URL you would pass to `connect`). */
+  url: string;
+  /** Where the resulting token is stored write-only. Defaults to `/secrets/mcp/<host>`. */
+  path?: string;
+  /** OAuth scope to request; the server's default is used when omitted. */
+  scope?: string;
+};
+
+/** Result of `itx.mcp.beginOAuth`: a link to send the user through, and the
+ * secret path the token lands at once they finish. */
+export type McpBeginOAuthResult = {
+  /** Send this to the user. Signing in there stores the token and (for an agent)
+   * messages you back so you can continue. */
+  authorizationUrl: string;
+  /** The `/secrets/…` path the token is stored at. Connect afterwards with
+   * `headers: { authorization: 'Bearer getSecret({ path: "<path>", field: "accessToken" })' }`. */
+  path: string;
+};
 
 /** Input to `itx.openapi.connect`: the OpenAPI spec URL to fetch, an optional
  * `baseUrl` overriding the spec's server, and extra headers (auth) sent with

--- a/apps/os/src/itx-api.generated.ts
+++ b/apps/os/src/itx-api.generated.ts
@@ -2077,13 +2077,12 @@ export type McpClientConnectInput = {
 export type McpClientRpc = object;
 
 /** Input to `itx.mcp.beginOAuth`: the OAuth-protected MCP server to connect to,
- * an optional secret path to store the token at (defaults to `/secrets/mcp/<host>`),
- * and an optional OAuth scope to request. */
+ * the secret path to store the resulting token at, and an optional OAuth scope. */
 export type McpBeginOAuthInput = {
   /** The MCP server's URL (the same URL you would pass to `connect`). */
   url: string;
-  /** Where the resulting token is stored write-only. Defaults to `/secrets/mcp/<host>`. */
-  path?: string;
+  /** Where the resulting token is stored write-only, e.g. `/secrets/mcp/cloudflare`. */
+  path: string;
   /** OAuth scope to request; the server's default is used when omitted. */
   scope?: string;
 };

--- a/apps/os/src/itx/examples.ts
+++ b/apps/os/src/itx/examples.ts
@@ -982,7 +982,11 @@ return {
 // ---- TURN 1: mint the sign-in link, send it, END YOUR TURN ----
 const mcpUrl = vars.mcpUrl ?? "https://mcp.cloudflare.com/mcp";
 
-const { authorizationUrl, path } = await itx.mcp.beginOAuth({ url: mcpUrl });
+// You choose where the token lands (like a secret path); pick something memorable.
+const { authorizationUrl, path } = await itx.mcp.beginOAuth({
+  url: mcpUrl,
+  path: vars.path ?? "/secrets/mcp/cloudflare",
+});
 
 await itx.chat.sendMessage(
   "That server uses OAuth. [Click here to sign in](" + authorizationUrl + ") — " +

--- a/apps/os/src/itx/examples.ts
+++ b/apps/os/src/itx/examples.ts
@@ -967,6 +967,55 @@ return {
 `.trim(),
   },
   {
+    id: "connect-mcp-oauth",
+    e2eProven: false,
+    title: "Connect an OAuth-protected MCP server (the sign-in flow)",
+    description:
+      'The full flow for an MCP server that needs OAuth — one whose unauthenticated request answers 401 with a WWW-Authenticate challenge (Cloudflare\'s mcp.cloudflare.com, the dummy petshop /mcp, most hosted MCP servers). There is no token to paste: the user must sign in at the provider. itx.mcp.beginOAuth({ url }) discovers the server\'s OAuth endpoints, registers a client, and returns { authorizationUrl, path } — send authorizationUrl to the user ("click here to connect"). When they sign in, the token is stored write-only at `path` and, because you called it from your agent scope, you are messaged so you continue. Then connect like any bearer MCP, referencing the token with a getSecret placeholder on field "accessToken". (If a plain bearer token you already hold is enough, use itx.secrets.collectFromUser instead.) Needs a human to sign in — interactive-only.',
+    context: "agent",
+    runtimes: ALL_RUNTIMES,
+    code: `
+// Scenario: the user said "connect me to the Cloudflare MCP server". Trying to
+// connect first fails with an auth challenge — that means OAuth, not a token
+// you can ask for.
+//
+// ---- TURN 1: mint the sign-in link, send it, END YOUR TURN ----
+const mcpUrl = vars.mcpUrl ?? "https://mcp.cloudflare.com/mcp";
+
+const { authorizationUrl, path } = await itx.mcp.beginOAuth({ url: mcpUrl });
+
+await itx.chat.sendMessage(
+  "That server uses OAuth. [Click here to sign in](" + authorizationUrl + ") — " +
+    "you authorize it on the provider's own page; I never see your password or token. " +
+    "I'll continue automatically once you're done.",
+);
+// End the turn WITHOUT waiting: signing in messages you back, which starts your
+// next turn. Remember \`path\` (it is /secrets/mcp/<host> unless you passed one).
+return;
+
+// ---- TURN 2 (after "The OAuth connection to ... is done" arrives) ----
+// The token is stored write-only and auto-refreshes. Connect referencing it
+// with a getSecret placeholder — note field: "accessToken" (the material is a
+// token bundle, not a bare string):
+//
+// const cf = await itx.mcp.connect({
+//   url: mcpUrl,
+//   headers: { authorization: 'Bearer getSecret({ path: "' + path + '", field: "accessToken" })' },
+// });
+// return await cf.__describe(); // the server's tools — then call them by name
+//
+// To make it durable (discoverable + callable as itx.cloudflare.<tool>() by
+// future turns), mount the same recipe:
+// await itx.provideCapability({
+//   expression: ["mcp", ["connect", { url: mcpUrl,
+//     headers: { authorization: 'Bearer getSecret({ path: "' + path + '", field: "accessToken" })' } }]],
+//   instructions: "Cloudflare MCP server (OAuth). Tool names discovered from the server.",
+//   path: ["cloudflare"],
+//   type: "itx-expression",
+// });
+`.trim(),
+  },
+  {
     id: "typed-capability-mount",
     title: "Mount a capability with types, then discover and typecheck against it",
     description:

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -210,7 +210,17 @@ import type {
   CfVideoTransformInput,
 } from "./domains/itx/cf-capabilities.ts";
 import type { ItxAuth, ItxAuthCredentials } from "./auth.ts";
-import type { McpClientConnectInput, McpClientRpc } from "./domains/itx/mcp-client.ts";
+import type {
+  McpBeginOAuthInput,
+  McpBeginOAuthResult,
+  McpClientConnectInput,
+  McpClientRpc,
+} from "./domains/itx/mcp-client.ts";
+import {
+  beginMcpOAuth,
+  defaultMcpSecretPath,
+  fetchLikeFromFetcher,
+} from "./domains/itx/mcp-oauth.ts";
 import type { OpenApiConnectInput, OpenApiRpc } from "./domains/itx/openapi-types.ts";
 import type { ProjectListEntry } from "./project-deployment-status.ts";
 import type {
@@ -4387,6 +4397,9 @@ export class ProjectRpcTarget extends IterateRpcTarget<"Project"> {
   get mcp(): McpClientCollectionRpcTarget {
     return new McpClientCollectionRpcTarget({
       egress: projectEgressFetcher(this.#props.ctx.exports, this.#props.projectId),
+      projectId: this.#props.projectId,
+      // Makes beginOAuth links notify the calling agent when the flow completes.
+      scopePath: this.#props.capabilityHost.path,
     });
   }
 
@@ -5548,6 +5561,10 @@ function lazyPromise<T>(load: () => Promise<T>): () => Promise<T> {
 
 type McpClientDeps = { description?: LazyClientDescription; egress: Fetcher };
 
+/** The MCP collection also needs the calling project + scope so beginOAuth can
+ * mint the callback URL, store the token, and notify the calling agent. */
+type McpClientCollectionDeps = McpClientDeps & { projectId: string; scopePath: string };
+
 // Exa's hosted MCP server works unauthenticated (rate-limited, and the shared
 // free pool exhausts fast); pre-connecting it gives every project web search
 // with zero setup. When the deployment has a first-party Exa key
@@ -5567,22 +5584,57 @@ class McpClientCollectionRpcTarget extends IterateRpcTarget<"McpClientCollection
   async __describe(): Promise<Description> {
     return describeNode({
       instructions:
-        "Ad-hoc MCP clients: connect({ url }) returns a client whose dotted calls are tool invocations; exa is the built-in Exa web-search server.",
+        "Ad-hoc MCP clients: connect({ url }) returns a client whose dotted calls are tool invocations; exa is the built-in Exa web-search server. For a server that needs OAuth, beginOAuth({ url }) returns a sign-in link that stores a token you then connect with.",
       children: {
         connect: "Connect to an MCP server by URL.",
+        beginOAuth: "Start the OAuth sign-in for an OAuth-protected MCP server; returns a link.",
         exa: "The public Exa MCP server (web_search_exa, web_fetch_exa).",
       },
       parent: "a project itx (itx.mcp)",
     });
   }
 
-  constructor(readonly props: McpClientDeps) {
+  constructor(readonly props: McpClientCollectionDeps) {
     super();
   }
 
   /** Connect to an MCP server by URL; dotted calls on the client are tool invocations. */
   connect(input: McpClientConnectInput): Promise<McpClientRpc> {
     return McpClientRpcTarget.connect(input, this.props);
+  }
+
+  /**
+   * Begin the OAuth sign-in for an OAuth-protected MCP server (one whose
+   * unauthenticated request answers 401 with a `WWW-Authenticate` challenge —
+   * e.g. Cloudflare's mcp.cloudflare.com). Discovers the server's OAuth
+   * endpoints, registers a client, and returns a `{ authorizationUrl, path }`:
+   * send `authorizationUrl` to the user ("click here to connect"). When they
+   * sign in, the token is stored write-only at `path` and — if you are an agent
+   * — you are messaged so you can continue. Then connect like any bearer MCP:
+   * `itx.mcp.connect({ url, headers: { authorization: 'Bearer getSecret({ path:
+   * "<path>", field: "accessToken" })' } })`. For a server that just wants a
+   * bearer token you already hold, use `itx.secrets.collectFromUser` instead.
+   */
+  async beginOAuth(input: McpBeginOAuthInput): Promise<McpBeginOAuthResult> {
+    const baseUrl = parseConfig(env).baseUrl;
+    if (!baseUrl) {
+      throw new Error(
+        "This deployment cannot name its own base URL, so it cannot host the OAuth callback.",
+      );
+    }
+    const path = normalizeSecretPath(input.path ?? defaultMcpSecretPath(input.url));
+    const result = await beginMcpOAuth({
+      mcpUrl: input.url,
+      path,
+      redirectUri: `${baseUrl.replace(/\/$/, "")}/api/mcp-oauth/callback`,
+      ...(input.scope ? { scope: input.scope } : {}),
+      // An agent scope gets messaged when the user finishes signing in.
+      ...(this.props.scopePath.startsWith("/agents/") ? { notify: this.props.scopePath } : {}),
+      projectId: this.props.projectId,
+      encryptionKey: env.SECRET_ENCRYPTION_KEY,
+      fetchFn: fetchLikeFromFetcher(this.props.egress),
+    });
+    return { authorizationUrl: result.authorizationUrl, path: result.path };
   }
 
   /**

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -216,11 +216,7 @@ import type {
   McpClientConnectInput,
   McpClientRpc,
 } from "./domains/itx/mcp-client.ts";
-import {
-  beginMcpOAuth,
-  defaultMcpSecretPath,
-  fetchLikeFromFetcher,
-} from "./domains/itx/mcp-oauth.ts";
+import { beginMcpOAuth, fetchLikeFromFetcher } from "./domains/itx/mcp-oauth.ts";
 import type { OpenApiConnectInput, OpenApiRpc } from "./domains/itx/openapi-types.ts";
 import type { ProjectListEntry } from "./project-deployment-status.ts";
 import type {
@@ -5561,9 +5557,10 @@ function lazyPromise<T>(load: () => Promise<T>): () => Promise<T> {
 
 type McpClientDeps = { description?: LazyClientDescription; egress: Fetcher };
 
-/** The MCP collection also needs the calling project + scope so beginOAuth can
- * mint the callback URL, store the token, and notify the calling agent. */
-type McpClientCollectionDeps = McpClientDeps & { projectId: string; scopePath: string };
+/** The MCP collection needs the calling project + scope (so beginOAuth can mint
+ * the callback URL, store the token, and notify the calling agent) on top of the
+ * egress every client call uses. */
+type McpClientCollectionDeps = { egress: Fetcher; projectId: string; scopePath: string };
 
 // Exa's hosted MCP server works unauthenticated (rate-limited, and the shared
 // free pool exhausts fast); pre-connecting it gives every project web search
@@ -5622,7 +5619,7 @@ class McpClientCollectionRpcTarget extends IterateRpcTarget<"McpClientCollection
         "This deployment cannot name its own base URL, so it cannot host the OAuth callback.",
       );
     }
-    const path = normalizeSecretPath(input.path ?? defaultMcpSecretPath(input.url));
+    const path = normalizeSecretPath(input.path);
     const result = await beginMcpOAuth({
       mcpUrl: input.url,
       path,

--- a/packages/iterate/src/itx-api.generated.ts
+++ b/packages/iterate/src/itx-api.generated.ts
@@ -764,6 +764,19 @@ export interface McpClientCollection {
   /** Connect to an MCP server by URL; dotted calls on the client are tool invocations. */
   connect(input: McpClientConnectInput): Promise<McpClientRpc>;
   /**
+   * Begin the OAuth sign-in for an OAuth-protected MCP server (one whose
+   * unauthenticated request answers 401 with a `WWW-Authenticate` challenge —
+   * e.g. Cloudflare's mcp.cloudflare.com). Discovers the server's OAuth
+   * endpoints, registers a client, and returns a `{ authorizationUrl, path }`:
+   * send `authorizationUrl` to the user ("click here to connect"). When they
+   * sign in, the token is stored write-only at `path` and — if you are an agent
+   * — you are messaged so you can continue. Then connect like any bearer MCP:
+   * `itx.mcp.connect({ url, headers: { authorization: 'Bearer getSecret({ path:
+   * "<path>", field: "accessToken" })' } })`. For a server that just wants a
+   * bearer token you already hold, use `itx.secrets.collectFromUser` instead.
+   */
+  beginOAuth(input: McpBeginOAuthInput): Promise<McpBeginOAuthResult>;
+  /**
    * The public Exa MCP server (https://mcp.exa.ai/mcp), pre-connected for every
    * project: web search and page reading as flat tool calls.
    * `itx.mcp.exa.web_search_exa({ query, numResults })` searches the web;
@@ -2062,6 +2075,29 @@ export type McpClientConnectInput = {
  * fallback, so this contract deliberately does not re-declare a fixed surface.
  */
 export type McpClientRpc = object;
+
+/** Input to `itx.mcp.beginOAuth`: the OAuth-protected MCP server to connect to,
+ * an optional secret path to store the token at (defaults to `/secrets/mcp/<host>`),
+ * and an optional OAuth scope to request. */
+export type McpBeginOAuthInput = {
+  /** The MCP server's URL (the same URL you would pass to `connect`). */
+  url: string;
+  /** Where the resulting token is stored write-only. Defaults to `/secrets/mcp/<host>`. */
+  path?: string;
+  /** OAuth scope to request; the server's default is used when omitted. */
+  scope?: string;
+};
+
+/** Result of `itx.mcp.beginOAuth`: a link to send the user through, and the
+ * secret path the token lands at once they finish. */
+export type McpBeginOAuthResult = {
+  /** Send this to the user. Signing in there stores the token and (for an agent)
+   * messages you back so you can continue. */
+  authorizationUrl: string;
+  /** The `/secrets/…` path the token is stored at. Connect afterwards with
+   * `headers: { authorization: 'Bearer getSecret({ path: "<path>", field: "accessToken" })' }`. */
+  path: string;
+};
 
 /** Input to `itx.openapi.connect`: the OpenAPI spec URL to fetch, an optional
  * `baseUrl` overriding the spec's server, and extra headers (auth) sent with

--- a/packages/iterate/src/itx-api.generated.ts
+++ b/packages/iterate/src/itx-api.generated.ts
@@ -2077,13 +2077,12 @@ export type McpClientConnectInput = {
 export type McpClientRpc = object;
 
 /** Input to `itx.mcp.beginOAuth`: the OAuth-protected MCP server to connect to,
- * an optional secret path to store the token at (defaults to `/secrets/mcp/<host>`),
- * and an optional OAuth scope to request. */
+ * the secret path to store the resulting token at, and an optional OAuth scope. */
 export type McpBeginOAuthInput = {
   /** The MCP server's URL (the same URL you would pass to `connect`). */
   url: string;
-  /** Where the resulting token is stored write-only. Defaults to `/secrets/mcp/<host>`. */
-  path?: string;
+  /** Where the resulting token is stored write-only, e.g. `/secrets/mcp/cloudflare`. */
+  path: string;
   /** OAuth scope to request; the server's default is used when omitted. */
   scope?: string;
 };


### PR DESCRIPTION
## What

Adds `itx.mcp.beginOAuth({ url })` so an agent can connect an **OAuth-protected** MCP server — one whose unauthenticated request answers `401` with a `WWW-Authenticate` challenge (Cloudflare's `mcp.cloudflare.com`, most hosted MCP servers). There is no token to paste, so the agent hands the user a one-click sign-in link; when they sign in at the provider, the token is stored write-only in the secrets system and the agent is messaged to continue. Then it connects like any bearer MCP.

This is the OAuth sibling of `itx.secrets.collectFromUser` (#1889): that collects a token the user already holds; this drives the full authorization-code flow when only a sign-in can produce one.

## The flow

**`beginOAuth` (agent scope):**
1. Discover OAuth metadata — RFC 9728 protected-resource (probed off the `/mcp` `WWW-Authenticate` `resource_metadata` pointer, well-known fallback) → the RFC 8414 authorization-server metadata it names.
2. Dynamically register a confidential client (RFC 7591) whose one redirect URI is this deployment's `/api/mcp-oauth/callback`.
3. Build the authorization-code + PKCE (S256) URL, folding endpoints, the registered client credentials, the PKCE verifier, the target secret path, and the agent to notify into an **encrypted** `state` token — it carries a client secret + PKCE verifier, so it is AES-GCM'd with `SECRET_ENCRYPTION_KEY`, not merely signed.

**`/api/mcp-oauth/callback`:** redeem the code, store `{ accessToken, refreshToken, clientId, clientSecret }` write-only in the project Secret DO — egress pinned to the MCP + token origins, with the shared `oauth-refresh-token` refresh strategy (`clientCreds: "material"`) so it re-mints on 401 — then message the agent. The agent connects with `headers: { authorization: 'Bearer getSecret({ path: "…", field: "accessToken" })' }`.

Uses the MCP SDK's own discovery / registration / PKCE / exchange helpers, routed through **project egress** (SSRF-jailed). The flow module is pure (encryption key + `fetchFn` in, data out), so `begin → approve → complete` unit-tests end to end against a spec-faithful server with no network.

## Security

- State is **encrypted**, not just signed (it carries a client secret + PKCE verifier that ride through the browser URL).
- The callback overwrites a project secret, so it is **gated on project membership** (`assertCanAccessProject`) — a leaked link can't let a stranger clobber a project secret with their own token. Mirrors `collectFromUser`'s page gate.
- Confidential-client refresh only; a public client (no secret) stores the token without a refresh strategy (works until expiry; reconnect re-runs the flow).

## The controlled provider

`dummy-petshop`'s `/mcp` becomes a standards **OAuth-protected MCP server**: `401` + `WWW-Authenticate`, RFC 9728 / 8414 discovery documents, RFC 7591 dynamic registration, and PKCE S256 verification at the token endpoint (backward-compatible — the existing consent-only lane still works). This is the "provider under our control" the generic OS flow is proven against.

## Tests

- `apps/dummy-petshop/src/worker.test.ts` — +6: discovery docs, `401` pointer, dynamic registration, full register→authorize(challenge)→token(verifier)→`/mcp`, PKCE-without-verifier rejection. (84 pass)
- `apps/os/src/domains/itx/mcp-oauth.test.ts` — new: real SDK drives a spec-faithful server through `begin → approve → complete`, asserts the stored token works on `/mcp` and the refresh material mints a fresh token via Basic auth; plus not-OAuth / no-registration / tampered-state error paths.
- itx + integrations + secrets + agent-processor unit suites (263) green; typecheck, lint, prompt-budget green.

## Agent-facing

New `connect-mcp-oauth` example (interactive-only) + a tight line in the agent prompt's SECRETS/CONNECT tour. `itx-api` contract regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches OAuth discovery, encrypted redirect state carrying PKCE verifiers, project secret writes, and token refresh auth paths—security-sensitive integration surface with substantial new behavior.
> 
> **Overview**
> Adds **`itx.mcp.beginOAuth({ url, path })`** so agents can connect MCP servers that require OAuth (401 + `WWW-Authenticate`). The OS discovers RFC 9728/8414 metadata via project egress, dynamically registers a **public** client (RFC 7591, `token_endpoint_auth_method: "none"`) with PKCE S256, and returns an **`authorizationUrl`**; flow state (including the PKCE verifier) is **AES-GCM encrypted**, not merely signed.
> 
> **`/api/mcp-oauth/callback`** completes the code exchange, writes a pinned secret (access/refresh + `oauth-refresh-token` refresh with `clientCreds: "material"`), requires a signed-in **project member** before overwriting the path, and best-effort messages the calling agent. Secret DO refresh now supports **public clients** (`client_id` in the body when there is no `clientSecret`).
> 
> **dummy-petshop** is extended as a controllable OAuth-protected MCP provider: well-known discovery, `POST /oauth/register`, PKCE on authorize/token, redirect-URI pinning for DCR clients, and 401 on `/mcp` with `resource_metadata`. Legacy OAuth (Basic-only, no PKCE) stays compatible.
> 
> New unit tests (`mcp-oauth.test.ts`, petshop MCP OAuth suite), `connect-mcp-oauth` example, and regenerated itx API types/docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea42b0fdde29a0e35adc1291c82e826b89fcd046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +814 -29 | +579 -28 🟩🟩🟩🟩🟩 |
| Tests | +509 -2 | +432 -2 🟩🟩🟩🟩⬜ |
| Generated | +100 -2 | +50 -2 🟩⬜⬜⬜⬜ |
| **Total** | **+1,423 -33** | **+1,061 -32** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between e92b73e and ea42b0f, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-12T16:17:17.026Z",
      "headSha": "ea42b0fdde29a0e35adc1291c82e826b89fcd046",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/477544117880342",
      "shortSha": "ea42b0f",
      "cleanupDurationMs": 9219,
      "deployDurationMs": 79674,
      "testDurationMs": 232509,
      "testRetries": "2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · runs \"scheduler-basics\" through the project REPL (specs x1)",
      "workerSizeKib": 16065.46,
      "workerGzipKib": 4334.88,
      "mainWorkerGzipKib": 4328.52
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-12T16:17:08.565Z",
      "headSha": "435bd1dd35e1f163f9546a08f2c632d3a972e2df",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/392193060686473",
      "shortSha": "435bd1d",
      "cleanupDurationMs": 756,
      "deployDurationMs": 16733,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-12T16:17:10.756Z",
      "headSha": "ea42b0fdde29a0e35adc1291c82e826b89fcd046",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/477544117880342",
      "shortSha": "ea42b0f",
      "cleanupDurationMs": 2945,
      "deployDurationMs": 16974,
      "testDurationMs": 513,
      "testRetries": null,
      "workerSizeKib": 4032.01,
      "workerGzipKib": 819.6,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-12T16:17:08.630Z",
      "headSha": "435bd1dd35e1f163f9546a08f2c632d3a972e2df",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/392193060686473",
      "shortSha": "435bd1d",
      "cleanupDurationMs": 816,
      "deployDurationMs": 16269,
      "workerSizeKib": 4887.8,
      "workerGzipKib": 1398.94,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `ea42b0f` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 819.6 KiB | 17.0s | 513ms |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/477544117880342) | 2026-07-12T16:17:10.756Z | Preview app released. |
| OS | released | `ea42b0f` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.23 MiB (+6.4 KiB vs main) | 79.7s | 232.5s | 2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · runs "scheduler-basics" through the project REPL (specs x1) | 9.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/477544117880342) | 2026-07-12T16:17:17.026Z | Preview app released. |
| Semaphore | released | `435bd1d` | [https://semaphore.iterate-preview-3.com](https://semaphore.iterate-preview-3.com) | 440.8 KiB | 16.7s |  |  | 756ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/392193060686473) | 2026-07-12T16:17:08.565Z | Preview app released. |
| Streams Example App | released | `435bd1d` | [https://streams.iterate-preview-3.com](https://streams.iterate-preview-3.com) | 1.37 MiB | 16.3s |  |  | 816ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/392193060686473) | 2026-07-12T16:17:08.630Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->