### PR TITLE
Subscription status lines speak the spine's vocabulary, not 'configured asleep'

### DIFF
--- a/apps/os/src/components/stream-state-panel.tsx
+++ b/apps/os/src/components/stream-state-panel.tsx
@@ -859,16 +859,40 @@ function compareProcessorEntries(a: ProcessorPanelEntry, b: ProcessorPanelEntry)
   );
 }
 
+/**
+ * The row status speaks the subscription machinery's own vocabulary: durable
+ * subscriptions are desired state from a `subscription-configured` fact, and
+ * a missing live connection is a NORMAL spine state, not a vague sleep —
+ * wake mode gets re-poked when the watermark lags, push/webhook cursors are
+ * either acked to head, mid-drain, or in retry backoff, and `parked` is the
+ * spine's own give-up fact.
+ */
 function processorEntryStatus(entry: ProcessorPanelEntry, busy: boolean): string {
   if (entry.kind === "core") return "running";
   if (entry.connected) {
     if (busy && isLlmish(entry)) return "processing";
     return entry.subscriptionType === "configured" ? "connected durable" : "connected ephemeral";
   }
-  if (entry.runtimeSubscription?.parkedAtOffset != null) {
-    return `parked at #${entry.runtimeSubscription.parkedAtOffset}`;
+  const subscription = entry.runtimeSubscription;
+  if (subscription?.parkedAtOffset != null) {
+    return `subscription-parked at #${subscription.parkedAtOffset}`;
   }
-  if (entry.subscriptionType === "configured") return "configured asleep";
+  if (entry.subscriptionType === "configured") {
+    const configured =
+      entry.configuredAtOffset == null ? "configured" : `configured #${entry.configuredAtOffset}`;
+    if (subscription != null && subscription.nextAttemptAt !== null) {
+      return `${configured} · retry backoff (attempt ${subscription.attempt})`;
+    }
+    if (entry.deliveryMode === "wake") {
+      return `${configured} · poked on next append`;
+    }
+    if (subscription != null) {
+      return subscription.lag === 0
+        ? `${configured} · acked to head`
+        : `${configured} · draining, lag ${subscription.lag}`;
+    }
+    return configured;
+  }
   return "disconnected";
 }
 


### PR DESCRIPTION
Follow-up to #1906: 'configured asleep' conflated several distinct spine states. The row status now names the actual machinery state, anchored to the subscription's `subscription-configured` fact:

| state | label |
|---|---|
| wake, no connection | `configured #9 · poked on next append` |
| push/webhook, cursor at head | `configured #9 · acked to head` |
| push/webhook, cursor behind | `configured #9 · draining, lag N` |
| retry pending | `configured #9 · retry backoff (attempt N)` |
| parked | `subscription-parked at #N` |

Each maps 1:1 onto the delivery spine's states (watermark-lag re-poke, stream-owned cursor position, backoff row, park fact) — see stream-subscribers.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in the stream debug panel; no delivery, auth, or persistence logic is modified.
> 
> **Overview**
> **Replaces** the catch-all disconnected durable label **`configured asleep`** with status strings that match the delivery spine (`stream-subscribers.ts`): **`configured #N`** plus mode-specific suffixes for wake (**poked on next append**), push/webhook (**acked to head** / **draining, lag N**), and retry (**retry backoff (attempt N)**).
> 
> **Parked** subscriptions are labeled **`subscription-parked at #N`** instead of a generic parked-at offset string.
> 
> Adds a short comment on **`processorEntryStatus`** documenting that a missing live connection is normal spine state, not “sleep.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7faa65198d89d6b6af04da4598e3039e915ea520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +27 -3 | +19 -3 🟩🟩🟩🟩🟥 |
| **Total** | **+27 -3** | **+19 -3** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 5397fc4 and 7faa651, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->