### PR TITLE
mcp-oauth callback: return to the initiating thread, not "/"

### DIFF
--- a/apps/os/src/domains/integrations/integration-api.ts
+++ b/apps/os/src/domains/integrations/integration-api.ts
@@ -17,6 +17,8 @@ import {
   McpOAuthError,
 } from "~/domains/itx/mcp-oauth.ts";
 import { projectEgressFetcher } from "~/domains/projects/utils.ts";
+import { readProjectById } from "~/project-directory.ts";
+import { streamPathToSplat } from "~/lib/stream-links.ts";
 
 export async function handleIntegrationApiRequest(input: {
   auth: Principal | null | undefined;
@@ -173,7 +175,21 @@ async function handleMcpOAuthCallback(input: {
         console.error("mcp-oauth: failed to notify", result.notify, cause);
       }
     }
-    return redirectResponse("/");
+    // Land the user back in the thread that started the flow — NOT "/", which for
+    // a user still mid-onboarding resolves to the onboarding thread and loses
+    // their place. `notify` is the initiating agent's stream path (agent scopes
+    // only); fall back to "/" when there is no agent scope or the slug won't
+    // resolve.
+    let redirectTo = "/";
+    if (result.notify?.startsWith("/agents/")) {
+      const record = await readProjectById(itxEnv.PROJECT_DIRECTORY, state.projectId).catch(
+        () => null,
+      );
+      if (record?.slug) {
+        redirectTo = `/projects/${encodeURIComponent(record.slug)}/agents/streams/${streamPathToSplat(result.notify)}`;
+      }
+    }
+    return redirectResponse(redirectTo);
   } catch (cause) {
     if (!(cause instanceof McpOAuthError)) console.error("mcp-oauth: callback failed", cause);
     return redirectWithError(null, "mcp_oauth_failed");


### PR DESCRIPTION
## Bug

The `/api/mcp-oauth/callback` (from #1905) redirected to `/` on success. For a user **still mid-onboarding**, `/` resolves server-side (`getRootProjectRedirectServerFn`) to the onboarding thread `/agents/onboarding` — so finishing an OAuth sign-in bounced them onto onboarding instead of back to the conversation that initiated the connection.

## Fix

Redirect to the **thread that started the flow**. `state.notify` is the initiating agent's stream path (present for agent scopes — the same value already used to message the agent). Resolve the project slug (`readProjectById`) and land on the thread's route:

```
/projects/<slug>/agents/streams/<agent-path>    e.g. /projects/acme/agents/streams/agents/my-thread
```

Falls back to `/` when there's no agent scope (e.g. a dashboard/CLI-initiated flow) or the slug can't be resolved. Uses the existing `streamPathToSplat` so the path encodes exactly as the `/projects/$projectSlug/agents/streams/$` route decodes it.

Integrations + mcp-oauth unit suites green; typecheck/lint/knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small post-OAuth redirect change in integration-api; no auth, token storage, or secret-write behavior changes.
> 
> **Overview**
> After a successful **MCP OAuth** callback, the browser no longer always goes to `/`. Success redirects now send users back to the **agent thread that started the flow**, using `result.notify` (stream path), project slug from `readProjectById`, and `streamPathToSplat` for the `/projects/$slug/agents/streams/$` route.
> 
> This fixes mid-onboarding users being dropped on the onboarding thread when `/` resolves server-side to onboarding. **Fallback** to `/` remains when `notify` is missing, not an `/agents/` path, or the project slug cannot be resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2722b882d6cf30481b099c058def15d00dcc870c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-12T18:26:36.503Z",
      "headSha": "2722b882d6cf30481b099c058def15d00dcc870c",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/233667787505318",
      "shortSha": "2722b88",
      "cleanupDurationMs": 7286,
      "deployDurationMs": 78140,
      "testDurationMs": 165039,
      "testRetries": "2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page replays already appended events after reload (specs x1)",
      "workerSizeKib": 16069.34,
      "workerGzipKib": 4335.54,
      "mainWorkerGzipKib": 4335.46
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-12T18:26:31.953Z",
      "headSha": "2722b882d6cf30481b099c058def15d00dcc870c",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/233667787505318",
      "shortSha": "2722b88",
      "cleanupDurationMs": 2733,
      "deployDurationMs": 16493,
      "testDurationMs": 614,
      "testRetries": null,
      "workerSizeKib": 4032.01,
      "workerGzipKib": 819.35,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `2722b88` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 819.4 KiB | 16.5s | 614ms |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/233667787505318) | 2026-07-12T18:26:31.953Z | Preview app released. |
| OS | released | `2722b88` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 4.23 MiB (+0.1 KiB vs main) | 78.1s | 165.0s | 2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page replays already appended events after reload (specs x1) | 7.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/233667787505318) | 2026-07-12T18:26:36.503Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +17 -1 | +12 -1 🟩🟩🟩🟩🟩 |
| **Total** | **+17 -1** | **+12 -1** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between bd477c4 and 2722b88, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->