### PR TITLE
Agents: default to GPT-5.6 Sol

### DIFF
--- a/apps/os/e2e/vitest/agent-tools.itx.e2e.test.ts
+++ b/apps/os/e2e/vitest/agent-tools.itx.e2e.test.ts
@@ -79,7 +79,7 @@ test(
     // (llm-provider-selected wins over defaults), not any particular vendor;
     // asking the deployment keeps it green even if account model
     // availability shifts again (the 2026-07-10 lesson: a hardcoded
-    // openai/gpt-5.5 pin was unrunnable on the preview account until
+    // an explicit OpenAI model pin was unrunnable on the preview account until
     // unified billing was enabled, and watchdogged the whole lane).
     using defaultsItx = handle.itx();
     const policy = await defaultsItx.agents.defaults.forPath("/agents/e2e-model");

--- a/apps/os/src/config.ts
+++ b/apps/os/src/config.ts
@@ -86,10 +86,10 @@ export const AppConfig = z.object({
    * is per-deployment, not per-Doppler-secret.
    *
    * `byok` is the default AND what every deployed env sets explicitly: the
-   * platform is gpt-5.5-only, unified billing meters OpenAI-prompt-cached
-   * tokens at the uncached price (~6x at our hit rate), and BYOK benchmarked
-   * latency-neutral-or-better. The default matters for LOCAL DEV, which has
-   * no envs.ts entry — dev must ride the same lane as production.
+   * platform uses OpenAI GPT-5 reasoning models, unified billing meters
+   * prompt-cached tokens at the uncached price (~6x at our hit rate), and BYOK
+   * benchmarked latency-neutral-or-better. The default matters for LOCAL DEV,
+   * which has no envs.ts entry — dev must ride the same lane as production.
    *
    * `responseCacheTtlSeconds` opts the BYOK lane into the gateway's RESPONSE
    * cache (whole-answer replay — distinct from OpenAI's prompt cache, which

--- a/apps/os/src/domains/agents/agent-defaults.test.ts
+++ b/apps/os/src/domains/agents/agent-defaults.test.ts
@@ -93,6 +93,15 @@ describe("agentDefaultsForPath", () => {
     expect(provider?.payload).toMatchObject({ model: "openai/gpt-5.5" });
   });
 
+  it("uses GPT-5.6 Sol by default", () => {
+    const defaults = defaultsFor("/agents/demo");
+    expect(defaults.model).toBe("openai/gpt-5.6-sol");
+    const provider = defaults.events.find(
+      (event) => event.type === "events.iterate.com/agent/llm-provider-selected",
+    );
+    expect(provider?.payload).toMatchObject({ ifUnset: true, model: "openai/gpt-5.6-sol" });
+  });
+
   it("keys every event on (projectId, agentPath) so re-appends dedupe", () => {
     for (const event of defaultsFor("/agents/demo").events) {
       expect(event.idempotencyKey).toContain(PROJECT_ID);

--- a/apps/os/src/domains/agents/agent-processor-contract.ts
+++ b/apps/os/src/domains/agents/agent-processor-contract.ts
@@ -3,7 +3,7 @@ import { defineProcessorContract, type ProcessorState } from "../streams/process
 import { CapabilityHostProcessorContract } from "../capability-host/capability-host-processor-contract.ts";
 import { CoreProcessorContract } from "../streams/core-processor-contract.ts";
 
-export const DEFAULT_AGENT_MODEL = "openai/gpt-5.5";
+export const DEFAULT_AGENT_MODEL = "openai/gpt-5.6-sol";
 export const DEFAULT_AGENT_LLM_REQUEST_DEBOUNCE_MS = 250;
 export const DEFAULT_AGENT_MAX_AUTONOMOUS_TURNS = 100;
 
@@ -549,12 +549,12 @@ export const AgentProcessorContract = defineProcessorContract({
             "Agent birth applies the platform default model unless something already chose one.",
           payload: {
             ifUnset: true,
-            model: "openai/gpt-5.5",
+            model: "openai/gpt-5.6-sol",
           },
         },
         {
           description: "The project explicitly selects a Workers AI model.",
-          payload: { model: "openai/gpt-5.5" },
+          payload: { model: "openai/gpt-5.6-sol" },
         },
       ],
     },
@@ -571,7 +571,7 @@ export const AgentProcessorContract = defineProcessorContract({
             "A user input triggered a request, debounced 250ms so rapid-fire inputs collapse into one turn.",
           payload: {
             debounceMs: 250,
-            model: "openai/gpt-5.5",
+            model: "openai/gpt-5.6-sol",
             requestId: "llm-request:gen-3",
           },
         },
@@ -593,7 +593,7 @@ export const AgentProcessorContract = defineProcessorContract({
           description:
             "The debounce elapsed and the request went out; this event's own offset becomes the llmRequestOffset the processor answers to.",
           payload: {
-            model: "openai/gpt-5.5",
+            model: "openai/gpt-5.6-sol",
             requestId: "llm-request:gen-3",
           },
         },
@@ -608,7 +608,7 @@ export const AgentProcessorContract = defineProcessorContract({
       examples: [
         {
           description: "The agent picks up a prepared request and dials the AI binding.",
-          payload: { llmRequestOffset: 57, model: "openai/gpt-5.5" },
+          payload: { llmRequestOffset: 57, model: "openai/gpt-5.6-sol" },
         },
       ],
     },
@@ -693,7 +693,7 @@ export const AgentProcessorContract = defineProcessorContract({
             "An OpenAI model reports a mostly-cache-hit request at about a tenth of the model's window.",
           payload: {
             llmRequestOffset: 57,
-            model: "openai/gpt-5.5",
+            model: "openai/gpt-5.6-sol",
             maxContextTokens: 272000,
             inputTokens: 29295,
             outputTokens: 111,

--- a/apps/os/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/os/src/domains/agents/agent-processor-implementation.ts
@@ -1237,8 +1237,8 @@ function renderFileHintLine(file: AgentFileAttachment): string {
  * prompt with the transcript re-rendered behind it. Compaction fires at the
  * biggest prompt this agent will ever send (~half the context window), and
  * the tail position means that whole prompt is a prefix the provider already
- * has cached from the previous turn (90% input discount on gpt-5.5) instead
- * of a from-scratch prompt sharing no bytes with it.
+ * has cached from the previous turn (the provider's cached-input discount)
+ * instead of a from-scratch prompt sharing no bytes with it.
  */
 const AGENT_COMPACTION_PROMPT = [
   "You are compacting this AI agent conversation because it is close to overflowing the model's context window. Do not respond to the messages above. Instead, write a summary that will REPLACE everything above as the agent's only memory of it.",
@@ -1281,10 +1281,12 @@ export function buildAgentCompactionRequestBody(state: {
 /**
  * Context windows per model family, longest-prefix matched so dated variants
  * inherit their family's window. The OpenAI figures are our OPERATING window,
- * not the documented one: gpt-5.5's real window is 1.05M tokens, but 272k is
- * where OpenAI's pricing doubles, so compaction should treat that as full.
+ * not the documented one: GPT-5.6 Sol and GPT-5.5 have 1.05M-token windows,
+ * but 272k is where OpenAI's pricing doubles, so compaction should treat that
+ * as full.
  */
 const MODEL_CONTEXT_WINDOW_TOKENS: Record<string, number> = {
+  "openai/gpt-5.6": 272_000,
   "openai/gpt-5.5": 272_000,
   "openai/gpt-5": 272_000,
 };

--- a/apps/os/src/domains/agents/agent-processors.test.ts
+++ b/apps/os/src/domains/agents/agent-processors.test.ts
@@ -11,12 +11,13 @@ import {
 import { normalizeLlmUsage } from "./workers-ai-transport.ts";
 import {
   AgentProcessorContract,
+  DEFAULT_AGENT_MODEL,
   DEFAULT_AGENT_MAX_AUTONOMOUS_TURNS,
   DEFAULT_AGENT_SYSTEM_PROMPT,
 } from "./agent-processor-contract.ts";
 import { MemoryStream, deliverNewEvents, type ProcessorLike } from "./test-helpers.ts";
 
-function agentRequestEvents(content: string, model = "openai/gpt-5.5"): StreamEventInput[] {
+function agentRequestEvents(content: string, model = DEFAULT_AGENT_MODEL): StreamEventInput[] {
   return [
     {
       type: "events.iterate.com/agent/input-added",
@@ -1677,7 +1678,7 @@ describe("token usage and history reset", () => {
     );
     expect(report?.payload).toEqual({
       llmRequestOffset: requested!.offset,
-      model: "openai/gpt-5.5",
+      model: DEFAULT_AGENT_MODEL,
       maxContextTokens: 272_000,
       inputTokens: 2900,
       outputTokens: 111,
@@ -1772,6 +1773,8 @@ describe("token usage and history reset", () => {
   });
 
   it("longest-prefix matches context windows, with a conservative default", () => {
+    expect(contextWindowTokens("openai/gpt-5.6-sol")).toBe(272_000);
+    expect(contextWindowTokens("openai/gpt-5.6-sol-2026-07-13")).toBe(272_000);
     expect(contextWindowTokens("openai/gpt-5.5")).toBe(272_000);
     expect(contextWindowTokens("openai/gpt-5.5-2026-01-15")).toBe(272_000);
     expect(contextWindowTokens("@cf/qwen/qwen3-coder-plus")).toBe(128_000);
@@ -1944,7 +1947,7 @@ describe("token usage and history reset", () => {
             if (messages.at(-1)!.content.includes("compacting this AI agent conversation")) {
               return { response: "The user likes teal and is building STICKYMEETING." };
             }
-            // A turn that ran at over half of gpt-5.5's 272k window.
+            // A turn that ran at over half of GPT-5.6 Sol's 272k operating window.
             return {
               response: "noted!",
               usage: { prompt_tokens: 140_000, completion_tokens: 500 },
@@ -1987,7 +1990,7 @@ describe("token usage and history reset", () => {
       );
     expect(compactionCalls()).toHaveLength(1);
     // The summary sees the whole conversation and runs on the agent's model.
-    expect(compactionCalls()[0]!.model).toBe("openai/gpt-5.5");
+    expect(compactionCalls()[0]!.model).toBe(DEFAULT_AGENT_MODEL);
     // The compaction request extends the normal turn's request byte for byte
     // (same system prompt, same history messages) so the provider's prompt
     // cache — an exact-prefix match — covers the biggest request an agent

--- a/apps/os/src/domains/agents/workers-ai-transport.test.ts
+++ b/apps/os/src/domains/agents/workers-ai-transport.test.ts
@@ -4,6 +4,7 @@ import {
   maskCloudflareAiGatewayResponseCacheEntropy,
   runWorkersAiAttempt,
 } from "./workers-ai-transport.ts";
+import { DEFAULT_AGENT_MODEL } from "./agent-processor-contract.ts";
 import { agentDefaultsForPath } from "./agent-defaults.ts";
 import { buildAgentLlmRequestBody } from "./agent-processor-implementation.ts";
 
@@ -61,7 +62,7 @@ describe("runWorkersAiAttempt", () => {
         return { response: "ok" };
       },
     };
-    for (const model of ["openai/gpt-5.5", "@cf/test/non-openai-model"]) {
+    for (const model of [DEFAULT_AGENT_MODEL, "@cf/test/non-openai-model"]) {
       await runWorkersAiAttempt({
         ai,
         deadlineMs: 1_000,
@@ -103,7 +104,7 @@ describe("runWorkersAiAttempt", () => {
       ai: { run: async () => body },
       deadlineMs: 1_000,
       messages: [{ role: "user", content: "hi" }],
-      model: "openai/gpt-5.5",
+      model: DEFAULT_AGENT_MODEL,
       onChunk: async () => {},
     });
 
@@ -169,7 +170,7 @@ describe("the BYOK gateway lane", () => {
       ai: fake.ai,
       deadlineMs: 1_000,
       messages: [{ role: "user", content: "hi" }],
-      model: "openai/gpt-5.5",
+      model: DEFAULT_AGENT_MODEL,
       onChunk: async () => {},
       transport: {
         kind: "byok",
@@ -188,7 +189,7 @@ describe("the BYOK gateway lane", () => {
     expect(request.headers["cf-aig-cache-ttl"]).toBe("600");
     expect(request.headers["cf-aig-cache-key"]).toMatch(/^[0-9a-f]{64}$/);
     expect(request.query).toMatchObject({
-      model: "gpt-5.5",
+      model: "gpt-5.6-sol",
       prompt_cache_key: "prj_1:/agents/onboarding",
       reasoning_effort: "medium",
       stream: true,
@@ -205,7 +206,7 @@ describe("the BYOK gateway lane", () => {
       ai: fake.ai,
       deadlineMs: 1_000,
       messages: [{ role: "user", content: "hi" }],
-      model: "openai/gpt-5.5",
+      model: DEFAULT_AGENT_MODEL,
       onChunk: async () => {},
       transport: { kind: "byok", gatewayId: "default", openaiApiKey: "sk-test" },
     });
@@ -357,7 +358,7 @@ describe("cloudflareAiGatewayResponseCacheKey", () => {
         })),
         {
           type: "events.iterate.com/agent/llm-request-requested",
-          payload: { model: "openai/gpt-5.5", requestId: "llm-request:gen-0" },
+          payload: { model: DEFAULT_AGENT_MODEL, requestId: "llm-request:gen-0" },
           offset: defaults.events.length + 1,
           createdAt: input.requestedAt,
           path: "/agents/onboarding",

--- a/apps/os/src/domains/agents/workers-ai-transport.ts
+++ b/apps/os/src/domains/agents/workers-ai-transport.ts
@@ -227,7 +227,7 @@ export function maskCloudflareAiGatewayResponseCacheEntropy(serialized: string):
 
 /**
  * Extra chat-completions params for OpenAI reasoning models served through
- * Workers AI (`openai/gpt-5.5`, o-series, codex): pin reasoning effort to
+ * Workers AI (`openai/gpt-5.6-sol`, o-series, codex): pin reasoning effort to
  * medium (the pre-#1808 openai-ws posture) and ask streamed responses to
  * carry usage in their final chunk. Gated by model family — non-OpenAI
  * models reject unknown params with a whole-request failure, the same reason


### PR DESCRIPTION
## Summary

- default new agent processors to `openai/gpt-5.6-sol`
- keep reasoning effort pinned to `medium` through both Workers AI transport lanes
- preserve the 272K operating window where long-context pricing changes
- update default-sensitive contract examples and regression coverage

## AI Gateway / e2e cost

- preview and local dev remain on BYOK with a 7-day response-cache TTL
- cache keys still normalize per-project identity and the default-model request body
- the live cache e2e requires the second identical onboarding birth turn to report `HIT` and replay byte-identical output
- production remains response-cache-disabled

## Validation

- `pnpm install`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test`
- targeted agent default / processor / transport tests (71 passed)

Live preview e2e will be recorded in the PR checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching the platform default LLM affects every new agent and billing/latency for agent turns; behavior is covered by unit tests but rollout depends on Workers AI / gateway supporting `gpt-5.6-sol`.
> 
> **Overview**
> **Default agent model** moves from `openai/gpt-5.5` to **`openai/gpt-5.6-sol`** via `DEFAULT_AGENT_MODEL`, so new agents and birth-time `llm-provider-selected` events pick GPT-5.6 Sol unless a project override applies.
> 
> **Compaction / token reporting** adds longest-prefix context window mapping for `openai/gpt-5.6` (same **272K operating window** as GPT-5.5). Comments in config, transport, and e2e are generalized away from a hardcoded 5.5 pin.
> 
> **Tests and contract examples** follow the new default (`DEFAULT_AGENT_MODEL` in processor/transport tests, a new `agent-defaults` assertion). Explicit model overrides (e.g. still `gpt-5.5` in one test) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fcd745c9465dffced4030413e5bb2fe68b74229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-13T09:37:36.898Z",
      "headSha": "8fcd745c9465dffced4030413e5bb2fe68b74229",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/514527580414550",
      "shortSha": "8fcd745",
      "cleanupDurationMs": 8912,
      "deployDurationMs": 84899,
      "testDurationMs": 235294,
      "testRetries": "2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · runs \"stream-cross-post\" through the project REPL (specs x1)",
      "workerSizeKib": 16069.42,
      "workerGzipKib": 4335.67,
      "mainWorkerGzipKib": 4335.54
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-13T09:37:31.094Z",
      "headSha": "8fcd745c9465dffced4030413e5bb2fe68b74229",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/514527580414550",
      "shortSha": "8fcd745",
      "cleanupDurationMs": 3100,
      "deployDurationMs": 22743,
      "testDurationMs": 482,
      "testRetries": null,
      "workerSizeKib": 4032.01,
      "workerGzipKib": 819.61,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `8fcd745` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 819.6 KiB | 22.7s | 482ms |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/514527580414550) | 2026-07-13T09:37:31.094Z | Preview app released. |
| OS | released | `8fcd745` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 4.23 MiB (+0.1 KiB vs main) | 84.9s | 235.3s | 2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · runs "stream-cross-post" through the project REPL (specs x1) | 8.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/514527580414550) | 2026-07-13T09:37:36.898Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +18 -16 | +8 -7 🟩🟩🟥⬜⬜ |
| Tests | +24 -11 | +21 -9 🟩🟩🟩🟩🟥 |
| **Total** | **+42 -27** | **+29 -16** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 71e99e5 and 8fcd745, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->