### PR TITLE
Fix integrations page latency and hydration

### DIFF
--- a/apps/os/src/domains/integrations/connect-flows.ts
+++ b/apps/os/src/domains/integrations/connect-flows.ts
@@ -44,8 +44,8 @@ import {
   appendConnectionDirectoryEvent,
   appendConnectionDirectoryEvents,
   integrationStreamStub,
+  latestStreamEventOfTypes,
   lookupConnectionClaim,
-  streamEventsNewestFirst,
 } from "./integration-streams.ts";
 import { callProjectSlackWebApi } from "./slack-api.ts";
 import { SlackProcessorContract } from "./slack-processor-contract.ts";
@@ -926,14 +926,16 @@ async function latestLifecycleFact(input: {
   slug: string;
 }): Promise<{ connected: boolean; payload: Record<string, unknown> } | null> {
   const path = integrationConnectionStreamPath(input.slug, input.connection);
-  for await (const event of streamEventsNewestFirst(input.projectId, path)) {
-    if (event.type !== input.connectedType && event.type !== input.disconnectedType) continue;
-    return {
-      connected: event.type === input.connectedType,
-      payload: readRecord(event.payload) ?? {},
-    };
-  }
-  return null;
+  const event = await latestStreamEventOfTypes(input.projectId, path, [
+    input.connectedType,
+    input.disconnectedType,
+  ]);
+  return event === null
+    ? null
+    : {
+        connected: event.type === input.connectedType,
+        payload: readRecord(event.payload) ?? {},
+      };
 }
 
 /** The "never connected" status — also google's disconnected shape (its

--- a/apps/os/src/domains/integrations/google-connection.test.ts
+++ b/apps/os/src/domains/integrations/google-connection.test.ts
@@ -7,6 +7,8 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { DurableObjectNameCodec } from "../durable-object-names.ts";
 import {
+  GITHUB_CONNECTED_EVENT_TYPE,
+  GITHUB_DISCONNECTED_EVENT_TYPE,
   GOOGLE_CONNECTED_EVENT_TYPE,
   GOOGLE_DISCONNECTED_EVENT_TYPE,
   integrationConnectionStreamPath,
@@ -17,7 +19,13 @@ import {
 // runtimeState + getEvents.
 const streamNetwork = vi.hoisted(() => {
   const streams = new Map<string, { offset: number; payload: unknown; type: string }[]>();
-  return { streams };
+  const getEventsCalls: Array<{
+    afterOffset?: number;
+    beforeOffset?: number;
+    eventTypes?: readonly string[];
+    limit?: number;
+  }> = [];
+  return { getEventsCalls, streams };
 });
 
 // connect-flows imports slack-api (disconnect's auth.revoke) and telegram-api
@@ -40,8 +48,22 @@ vi.mock("../../env.ts", () => ({
           async runtimeState() {
             return { coreProcessorState: { maxOffset: events.length } };
           },
-          async getEvents({ afterOffset = 0, beforeOffset = Infinity }) {
-            return events.filter((e) => e.offset > afterOffset && e.offset < beforeOffset);
+          async getEvents(input: {
+            afterOffset?: number;
+            beforeOffset?: number;
+            eventTypes?: readonly string[];
+            limit?: number;
+          }) {
+            streamNetwork.getEventsCalls.push(input);
+            const { afterOffset = 0, beforeOffset = Infinity, eventTypes, limit = 500 } = input;
+            return events
+              .filter(
+                (event) =>
+                  event.offset > afterOffset &&
+                  event.offset < beforeOffset &&
+                  (eventTypes === undefined || eventTypes.includes(event.type)),
+              )
+              .slice(0, limit);
           },
         };
       },
@@ -51,9 +73,14 @@ vi.mock("../../env.ts", () => ({
 
 const { getConnectionStatus } = await import("./connect-flows.ts");
 
-function seed(projectId: string, connection: string, events: { payload: unknown; type: string }[]) {
+function seed(
+  projectId: string,
+  connection: string,
+  events: { payload: unknown; type: string }[],
+  slug = "google",
+) {
   const name = DurableObjectNameCodec.stringify({
-    path: integrationConnectionStreamPath("google", connection),
+    path: integrationConnectionStreamPath(slug, connection),
     projectId,
   });
   streamNetwork.streams.set(
@@ -62,7 +89,43 @@ function seed(projectId: string, connection: string, events: { payload: unknown;
   );
 }
 
-afterEach(() => streamNetwork.streams.clear());
+afterEach(() => {
+  streamNetwork.getEventsCalls.length = 0;
+  streamNetwork.streams.clear();
+});
+
+test("connection status filters lifecycle facts before reading a webhook-heavy journal", async () => {
+  seed(
+    "prj_1",
+    "install-1",
+    [
+      {
+        type: GITHUB_CONNECTED_EVENT_TYPE,
+        payload: {
+          connection: "install-1",
+          externalId: "115079265",
+          installationId: "115079265",
+        },
+      },
+      ...Array.from({ length: 15_385 }, (_, index) => ({
+        type: "events.iterate.com/github/webhook-received",
+        payload: { index },
+      })),
+    ],
+    "github",
+  );
+
+  expect(
+    await getConnectionStatus({ connection: "install-1", projectId: "prj_1", provider: "github" }),
+  ).toMatchObject({ connected: true, externalId: "115079265" });
+  expect(streamNetwork.getEventsCalls).toEqual([
+    {
+      afterOffset: 0,
+      eventTypes: [GITHUB_CONNECTED_EVENT_TYPE, GITHUB_DISCONNECTED_EVENT_TYPE],
+      limit: 500,
+    },
+  ]);
+});
 
 describe("getConnectionStatus (google)", () => {
   test("connected fact yields display metadata (no tokens)", async () => {

--- a/apps/os/src/domains/integrations/integration-streams.ts
+++ b/apps/os/src/domains/integrations/integration-streams.ts
@@ -34,32 +34,31 @@ async function readAllStreamEvents(projectId: string | null, path: string): Prom
   }
 }
 
-const TAIL_PAGE_SIZE = 200;
+const FILTERED_PAGE_SIZE = 500;
 
 /**
- * A stream's events NEWEST FIRST, paged backwards from the journal head.
+ * The latest event matching any of the requested types.
  *
- * Integration journals grow forever (one token-refreshed event per Gmail-token
- * expiry, one webhook per Slack message), but lifecycle questions ("is this
- * connection connected? what is its current token?") are answered by the most
- * recent few facts. Folding over this generator makes those reads O(tail) and
- * — because it is ONE iteration, not one fold per page — accumulators in the
- * consuming fold naturally span page boundaries.
+ * Integration journals grow forever (one webhook per GitHub or Slack event),
+ * while lifecycle questions only need connected/disconnected facts. Filtering
+ * in Stream storage keeps unrelated event chunks and one-RPC-per-tail-page
+ * round trips out of the status path. Page forward in the unlikely case a
+ * connection has more than 500 lifecycle transitions so latest still wins.
  */
-export async function* streamEventsNewestFirst(
+export async function latestStreamEventOfTypes(
   projectId: string | null,
   path: string,
-): AsyncGenerator<StreamEvent> {
+  eventTypes: readonly string[],
+): Promise<StreamEvent | null> {
   const stream = integrationStreamStub(projectId, path);
-  const { coreProcessorState } = await stream.runtimeState();
-  let beforeOffset = coreProcessorState.maxOffset + 1;
-  while (beforeOffset > 1) {
-    // getEvents bounds are exclusive on both ends, so consecutive windows
-    // (afterOffset, beforeOffset) tile the offset space with no gap/overlap.
-    const afterOffset = Math.max(0, beforeOffset - 1 - TAIL_PAGE_SIZE);
-    const page = await stream.getEvents({ afterOffset, beforeOffset });
-    for (let index = page.length - 1; index >= 0; index -= 1) yield page[index]!;
-    beforeOffset = afterOffset + 1;
+  let afterOffset = 0;
+  let latest: StreamEvent | null = null;
+  for (;;) {
+    const page = await stream.getEvents({ afterOffset, eventTypes, limit: FILTERED_PAGE_SIZE });
+    if (page.length === 0) return latest;
+    latest = page.at(-1)!;
+    if (page.length < FILTERED_PAGE_SIZE) return latest;
+    afterOffset = latest.offset;
   }
 }
 

--- a/apps/os/src/lib/route-breadcrumbs.ts
+++ b/apps/os/src/lib/route-breadcrumbs.ts
@@ -2,6 +2,8 @@ import { StreamPath } from "~/lib/stream-links.ts";
 
 export type RouteBreadcrumbStaticData = {
   breadcrumb?: string;
+  /** Marks a client-only route as a stream page before its loader data exists. */
+  streamPage?: boolean;
 };
 
 export type RouteBreadcrumbLoaderData = {
@@ -23,6 +25,10 @@ export type StreamBreadcrumb = {
 
 export function breadcrumbStaticData(breadcrumb: string): RouteBreadcrumbStaticData {
   return { breadcrumb };
+}
+
+export function streamPageStaticData(): RouteBreadcrumbStaticData {
+  return { streamPage: true };
 }
 
 export function breadcrumbLoaderData<T extends RouteBreadcrumbLoaderData>(data: T): T {

--- a/apps/os/src/routes/_app.tsx
+++ b/apps/os/src/routes/_app.tsx
@@ -37,7 +37,13 @@ function AppLayout() {
   // presence + Feed/State inside the stream view) — a page publishing a
   // streamBreadcrumb IS a stream page. Only the few non-stream pages
   // (projects list, new-project, session REPL) get this minimal shell header.
-  const isStreamPage = activeStreamBreadcrumb(matches) != null;
+  // Project routes are client-only, so their loader data is absent from the
+  // server render. Static route data keeps the shell's first client render
+  // identical to SSR; the loader breadcrumb takes over after the route loads.
+  const isStreamPage =
+    matches.some(
+      (match) => (match.staticData as RouteBreadcrumbStaticData | undefined)?.streamPage === true,
+    ) || activeStreamBreadcrumb(matches) != null;
   // The projects list is the one app page with no project context, so the
   // stream ⌘K switcher has nothing to act on — hide its pill and don't mount
   // the palette here, which also drops its global ⌘K key handler.

--- a/apps/os/src/routes/_app/projects/$projectSlug/integrations.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/integrations.tsx
@@ -67,7 +67,11 @@ import type { Project } from "../../../../itx-api.generated.ts";
 import { ItxBoundary } from "~/components/itx-boundary.tsx";
 import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import { StreamPathPill } from "~/components/stream-path-pill.tsx";
-import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
+import {
+  breadcrumbLoaderData,
+  streamBreadcrumb,
+  streamPageStaticData,
+} from "~/lib/route-breadcrumbs.ts";
 import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 import { useItx, useItxQuery, useLiveState } from "~/itx/itx-react.tsx";
 
@@ -146,6 +150,7 @@ const BUILTIN_API_INTEGRATIONS = [
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/integrations")({
   validateSearch: Search,
+  staticData: streamPageStaticData(),
   ssr: false,
   loader: ({ context }) =>
     breadcrumbLoaderData({

--- a/specs/integrations-hydration.spec.ts
+++ b/specs/integrations-hydration.spec.ts
@@ -1,0 +1,18 @@
+import { expect } from "@playwright/test";
+import { test } from "./test-support/test.ts";
+
+test("hydrates the client-only integrations route without rebuilding the shell", async ({
+  helpers,
+  page,
+}) => {
+  await using fixture = await helpers.createFixture("integrations-hydration");
+  const hydrationErrors: Error[] = [];
+  page.on("pageerror", (error) => {
+    if (error.message.includes("Hydration failed")) hydrationErrors.push(error);
+  });
+
+  await page.goto(`/projects/${fixture.project.slug}/integrations`);
+  await expect(page.getByRole("heading", { name: "Connectable integrations" })).toBeVisible();
+
+  expect(hydrationErrors).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- read connection lifecycle status with an event-type-filtered stream query instead of walking every webhook in the journal
- mark the client-only integrations route as a stream page in static route data so SSR and the first client render agree
- add regressions for a 15,386-event GitHub journal and the direct-load hydration path

## Production diagnosis

The `iterate` project's GitHub integration journal has 15,386 events, with its lifecycle fact near the beginning. `getConnectionStatus` walked the full journal in 200-event reverse pages, taking 12.6–14.3s on warm production requests and suspending the entire integrations page. The equivalent filtered storage query took 28–112ms.

React 418 was separate: because the project subtree is `ssr: false`, the server lacked the loader's stream breadcrumb and rendered the ordinary shell header. The first client render knew this was a stream page and omitted it, forcing React to discard and rebuild that subtree.

## Verification

- `pnpm test` — 1,177 OS tests passed, all workspace test suites passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `APP_CONFIG_BASE_URL=http://localhost:<port> pnpm spec specs/integrations-hydration.spec.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the integration status read path used on every built-in connection card; behavior should match prior lifecycle semantics but depends on `getEvents` type filtering being correct. The hydration fix is low-risk UI routing metadata.
> 
> **Overview**
> Fixes **integrations page load time** and **React hydration mismatch** on the client-only integrations route.
> 
> **Connection status** no longer walks integration journals newest-first in 200-event tail pages. `latestLifecycleFact` now calls **`latestStreamEventOfTypes`**, which requests **`getEvents` with `eventTypes`** (connected/disconnected only) and pages forward until it has the latest matching fact—so webhook-heavy GitHub journals avoid tens of thousands of irrelevant reads.
> 
> **Shell layout** treats routes as stream pages when **`staticData.streamPage`** is set, not only when loader `streamBreadcrumb` exists. The integrations route sets **`streamPageStaticData()`** so SSR and the first client render both omit the default app header (loader data is missing on SSR because the route is **`ssr: false`**).
> 
> Adds a unit test for a **15k+ event** journal (asserts a single filtered `getEvents` call) and a Playwright spec that direct-loading integrations produces **no hydration errors**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a65525c112c0f156ab9b3e2fcb8fdf6f8df1418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-13T10:07:16.319Z",
      "headSha": "7a65525c112c0f156ab9b3e2fcb8fdf6f8df1418",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/205819487265622",
      "shortSha": "7a65525",
      "cleanupDurationMs": 8811,
      "deployDurationMs": 78160,
      "testDurationMs": 176072,
      "testRetries": "2 retried: agent runs an itx script that appends a proof event, then replies (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 16069.44,
      "workerGzipKib": 4335.47,
      "mainWorkerGzipKib": 4335.67
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-13T10:07:10.329Z",
      "headSha": "7a65525c112c0f156ab9b3e2fcb8fdf6f8df1418",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/205819487265622",
      "shortSha": "7a65525",
      "cleanupDurationMs": 2814,
      "deployDurationMs": 21855,
      "testDurationMs": 467,
      "testRetries": null,
      "workerSizeKib": 4032.01,
      "workerGzipKib": 819.66,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `7a65525` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 819.7 KiB | 21.9s | 467ms |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/205819487265622) | 2026-07-13T10:07:10.329Z | Preview app released. |
| OS | released | `7a65525` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.23 MiB (-0.2 KiB vs main) | 78.2s | 176.1s | 2 retried: agent runs an itx script that appends a proof event, then replies (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 8.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/205819487265622) | 2026-07-13T10:07:16.319Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +48 -30 | +37 -21 🟩🟩🟥⬜⬜ |
| Tests | +87 -6 | +82 -6 🟩🟩🟩🟩🟩 |
| **Total** | **+135 -36** | **+119 -27** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 226953d and 7a65525, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->