### PR TITLE
Fix Codex MCP OAuth issuer callback compatibility

### DIFF
--- a/apps/auth/src/server/oauth-metadata.test.ts
+++ b/apps/auth/src/server/oauth-metadata.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { makeAuthorizationResponseIssuerOptional } from "./oauth-metadata.ts";
+
+describe("OAuth metadata compatibility", () => {
+  it("does not advertise the authorization-response issuer as required", async () => {
+    const response = Response.json(
+      {
+        issuer: "https://auth.iterate.com/api/auth",
+        authorization_response_iss_parameter_supported: true,
+        code_challenge_methods_supported: ["S256"],
+      },
+      {
+        headers: {
+          "cache-control": "public, max-age=3600",
+        },
+      },
+    );
+
+    const compatibleResponse = await makeAuthorizationResponseIssuerOptional(response);
+    const metadata = (await compatibleResponse.json()) as Record<string, unknown>;
+
+    assert.equal("authorization_response_iss_parameter_supported" in metadata, false);
+    assert.equal(metadata.issuer, "https://auth.iterate.com/api/auth");
+    assert.deepEqual(metadata.code_challenge_methods_supported, ["S256"]);
+    assert.equal(compatibleResponse.headers.get("cache-control"), "public, max-age=3600");
+  });
+});

--- a/apps/auth/src/server/oauth-metadata.ts
+++ b/apps/auth/src/server/oauth-metadata.ts
@@ -1,0 +1,24 @@
+const AUTHORIZATION_RESPONSE_ISS_SUPPORT = "authorization_response_iss_parameter_supported";
+
+/**
+ * Codex 0.144.3 drops `iss` while forwarding its OAuth callback to RMCP. If
+ * discovery advertises RFC 9207 support, RMCP consequently rejects an otherwise
+ * valid callback as missing its issuer. Keep emitting `iss` in authorization
+ * responses, but do not advertise it as mandatory until that client handoff is
+ * fixed.
+ */
+export async function makeAuthorizationResponseIssuerOptional(
+  response: Response,
+): Promise<Response> {
+  const metadata = (await response.json()) as Record<string, unknown>;
+  delete metadata[AUTHORIZATION_RESPONSE_ISS_SUPPORT];
+
+  const headers = new Headers(response.headers);
+  headers.delete("content-length");
+
+  return Response.json(metadata, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/apps/auth/src/server/worker.ts
+++ b/apps/auth/src/server/worker.ts
@@ -18,6 +18,7 @@ import { hono, variablesProvider, type Variables } from "./utils/hono.ts";
 import { appRouter } from "./orpc/index.ts";
 import type { CloudflareEnv } from "./env.ts";
 import { appendSetCookieHeaders, resolveAuthLogoutReturnTo } from "./logout.ts";
+import { makeAuthorizationResponseIssuerOptional } from "./oauth-metadata.ts";
 
 const app = hono();
 const allowedBrowserOrigins = new Set(getAllowedBrowserOrigins());
@@ -38,17 +39,17 @@ app.use(
   variablesProvider(),
 );
 
-app.get("/api/auth/.well-known/openid-configuration", (c) =>
-  oauthProviderOpenIdConfigMetadata(auth)(c.req.raw),
+app.get("/api/auth/.well-known/openid-configuration", async (c) =>
+  makeAuthorizationResponseIssuerOptional(await oauthProviderOpenIdConfigMetadata(auth)(c.req.raw)),
 );
-app.get(`/.well-known/openid-configuration${AUTH_ISSUER_PATH}`, (c) =>
-  oauthProviderOpenIdConfigMetadata(auth)(c.req.raw),
+app.get(`/.well-known/openid-configuration${AUTH_ISSUER_PATH}`, async (c) =>
+  makeAuthorizationResponseIssuerOptional(await oauthProviderOpenIdConfigMetadata(auth)(c.req.raw)),
 );
-app.get("/api/auth/.well-known/oauth-authorization-server", (c) =>
-  oauthProviderAuthServerMetadata(auth)(c.req.raw),
+app.get("/api/auth/.well-known/oauth-authorization-server", async (c) =>
+  makeAuthorizationResponseIssuerOptional(await oauthProviderAuthServerMetadata(auth)(c.req.raw)),
 );
-app.get(`/.well-known/oauth-authorization-server${AUTH_ISSUER_PATH}`, (c) =>
-  oauthProviderAuthServerMetadata(auth)(c.req.raw),
+app.get(`/.well-known/oauth-authorization-server${AUTH_ISSUER_PATH}`, async (c) =>
+  makeAuthorizationResponseIssuerOptional(await oauthProviderAuthServerMetadata(auth)(c.req.raw)),
 );
 app.all("/api/auth/oauth2/authorize", async (c) =>
   preserveOAuthResourceRedirect(c.req.raw, await auth.handler(c.req.raw)),


### PR DESCRIPTION
## Summary

- keep emitting the OAuth authorization-response issuer
- stop advertising the issuer response parameter as required until Codex forwards it to RMCP
- apply the compatibility metadata consistently to OAuth and OpenID discovery routes
- add a regression test that preserves the rest of the discovery document and response headers

## Why

Codex 0.144.3 receives the correct `iss` query parameter from Iterate auth, but its local callback bridge forwards only the code and state to RMCP. Because Iterate discovery advertised RFC 9207 support, RMCP then rejected the callback as missing its required issuer.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- local browser authorization flow confirmed the callback still contains the exact issuer
- local discovery response confirmed the RFC 9207 capability flag is omitted while issuer and endpoints remain intact

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the OAuth/OIDC discovery contract seen by MCP clients; scope is limited to one metadata flag and behavior is covered by a test, but it affects interoperability-sensitive auth flows.
> 
> **Overview**
> **OAuth/OpenID discovery** responses no longer include `authorization_response_iss_parameter_supported`, so clients like RMCP do not treat the authorization callback `iss` as mandatory when Codex’s bridge forwards only `code` and `state`. Authorization responses are unchanged and still include `iss`.
> 
> A new `makeAuthorizationResponseIssuerOptional` helper strips that field from the JSON metadata (and refreshes headers) and is applied to all four discovery routes in `worker.ts` (OpenID and OAuth authorization server, with and without the `/api/auth` path prefix). A regression test checks that other metadata and `cache-control` are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da78c618d3533e3b894ef6feda9b57c6a000796a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +33 -8 | +23 -8 🟩🟩🟩🟩🟥 |
| Tests | +28 -0 | +25 -0 🟩🟩🟩🟩⬜ |
| **Total** | **+61 -8** | **+48 -8** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between fe171ee and da78c61, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-13T10:26:45.120Z",
      "headSha": "da78c618d3533e3b894ef6feda9b57c6a000796a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/588522160416548",
      "shortSha": "da78c61",
      "cleanupDurationMs": 9007,
      "deployDurationMs": 77495,
      "testDurationMs": 168607,
      "testRetries": "5 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · sandbox egress > is MITM-intercepted and routed through project egress with secret substitution (vitest x1) · concurrent long-running ITX scripts all complete (vitest x1) · wake expressions traverse dynamic dispatch surfaces (the slack router shape) (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1)",
      "workerSizeKib": 16069.44,
      "workerGzipKib": 4335.47,
      "mainWorkerGzipKib": 4335.67
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-13T10:26:39.468Z",
      "headSha": "da78c618d3533e3b894ef6feda9b57c6a000796a",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/588522160416548",
      "shortSha": "da78c61",
      "cleanupDurationMs": 3352,
      "deployDurationMs": 20597,
      "testDurationMs": 472,
      "testRetries": null,
      "workerSizeKib": 4033.03,
      "workerGzipKib": 819.96,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `da78c61` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 820.0 KiB | 20.6s | 472ms |  | 3.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/588522160416548) | 2026-07-13T10:26:39.468Z | Preview app released. |
| OS | released | `da78c61` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 4.23 MiB (-0.2 KiB vs main) | 77.5s | 168.6s | 5 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · sandbox egress > is MITM-intercepted and routed through project egress with secret substitution (vitest x1) · concurrent long-running ITX scripts all complete (vitest x1) · wake expressions traverse dynamic dispatch surfaces (the slack router shape) (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1) | 9.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/588522160416548) | 2026-07-13T10:26:45.120Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->