### PR TITLE
Spike per-call ITX tracing across WebSockets

### DIFF
--- a/apps/os/e2e/vitest/itx-core.e2e.test.ts
+++ b/apps/os/e2e/vitest/itx-core.e2e.test.ts
@@ -67,7 +67,16 @@ describe("itx", () => {
     expect(messages).toContainEqual([
       expect.any(Number),
       "out",
-      ["push", ["pipeline", 1, ["projects", "create"], [{ slug: "alice-project" }]]],
+      [
+        "push",
+        ["pipeline", 1, ["projects", "create"], [{ slug: "alice-project" }]],
+        expect.objectContaining({
+          callId: expect.any(String),
+          client: "node",
+          connectionId: expect.any(String),
+          version: 1,
+        }),
+      ],
     ]);
 
     using stream = project.streams.get("/");

--- a/apps/os/src/itx-client.ts
+++ b/apps/os/src/itx-client.ts
@@ -7,6 +7,7 @@ import {
 import { withOwnedRpcSession } from "./domains/itx/utils.ts";
 import type { ItxAuthCredentials } from "./auth.ts";
 import type { Agent, Project, Session, UnauthenticatedOs } from "./itx-api.generated.ts";
+import { createItxClientObservability } from "./itx/itx-call-metadata.ts";
 
 export type ItxWebSocketMessage = [timestamp: number, direction: "in" | "out", data: unknown];
 
@@ -61,6 +62,7 @@ function connect<T extends CapnRpcCompatible<T>>(
   url: string,
   headers?: Record<string, string>,
   onWebSocketMessage?: (message: ItxWebSocketMessage) => void,
+  projectId?: string,
 ): CapnRpcStub<T> {
   // 15s: cold deployments answer the upgrade only after the worker chain has
   // loaded, but #1601's route-healing + the preview slot warmup mean the first
@@ -80,8 +82,11 @@ function connect<T extends CapnRpcCompatible<T>>(
     socket.on("message", (data) => record("in", data));
   }
 
+  const observability = createItxClientObservability({ client: "node", projectId });
   return newWebSocketRpcSession<T>(
     socket as unknown as Parameters<typeof newWebSocketRpcSession>[0],
+    undefined,
+    { getCallMetadata: observability.getCallMetadata },
   );
 }
 
@@ -109,6 +114,7 @@ export function connectItx(
     websocketUrl("/api", input),
     input.headers,
     input.onWebSocketMessage,
+    "projectId" in input ? input.projectId : undefined,
   );
   if (!("auth" in input)) return session;
 

--- a/apps/os/src/itx/itx-call-metadata.test.ts
+++ b/apps/os/src/itx/itx-call-metadata.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { createItxClientObservability, parseItxCallMetadata } from "./itx-call-metadata.ts";
+
+describe("itx call metadata", () => {
+  test("keeps a connection ID stable and creates a call ID per RPC", () => {
+    const observability = createItxClientObservability({ client: "node", projectId: "prj_test" });
+    const first = observability.getCallMetadata();
+    const second = observability.getCallMetadata();
+
+    expect(first.connectionId).toBe(observability.connectionId);
+    expect(second.connectionId).toBe(first.connectionId);
+    expect(second.callId).not.toBe(first.callId);
+    expect(first).toMatchObject({ client: "node", projectId: "prj_test", version: 1 });
+  });
+
+  test("accepts the bounded v1 shape and rejects malformed peer input", () => {
+    const valid = {
+      version: 1,
+      callId: "call-1",
+      connectionId: "connection-1",
+      client: "browser",
+    } as const;
+
+    expect(parseItxCallMetadata(valid)).toEqual(valid);
+    expect(parseItxCallMetadata({ ...valid, client: "spoofed" })).toBeUndefined();
+    expect(parseItxCallMetadata({ ...valid, callId: "x".repeat(129) })).toBeUndefined();
+    expect(parseItxCallMetadata(null)).toBeUndefined();
+  });
+});

--- a/apps/os/src/itx/itx-call-metadata.ts
+++ b/apps/os/src/itx/itx-call-metadata.ts
@@ -1,0 +1,62 @@
+/**
+ * Tiny, application-independent context sent beside each Cap'n Web call.
+ *
+ * One connection ID groups calls made over the same long-lived WebSocket. A
+ * fresh call ID identifies the logical RPC within that connection. This is
+ * protocol metadata, not a method argument, so adding observability never
+ * changes the public itx contract.
+ */
+export type ItxCallMetadata = {
+  version: 1;
+  callId: string;
+  connectionId: string;
+  client: "browser" | "node";
+  projectId?: string;
+};
+
+type ItxClientObservabilityInput = Pick<ItxCallMetadata, "client" | "projectId">;
+
+export function createItxClientObservability(input: ItxClientObservabilityInput) {
+  const connectionId = crypto.randomUUID();
+
+  return {
+    connectionId,
+    getCallMetadata: (): ItxCallMetadata => ({
+      version: 1,
+      callId: crypto.randomUUID(),
+      connectionId,
+      client: input.client,
+      ...(input.projectId === undefined ? {} : { projectId: input.projectId }),
+    }),
+  };
+}
+
+const MAX_IDENTIFIER_LENGTH = 128;
+
+function isIdentifier(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= MAX_IDENTIFIER_LENGTH;
+}
+
+/** Treat all peer-supplied observability metadata as untrusted wire input. */
+export function parseItxCallMetadata(value: unknown): ItxCallMetadata | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+
+  const candidate = value as Partial<Record<keyof ItxCallMetadata, unknown>>;
+  if (
+    candidate.version !== 1 ||
+    !isIdentifier(candidate.callId) ||
+    !isIdentifier(candidate.connectionId) ||
+    (candidate.client !== "browser" && candidate.client !== "node") ||
+    (candidate.projectId !== undefined && !isIdentifier(candidate.projectId))
+  ) {
+    return undefined;
+  }
+
+  return {
+    version: 1,
+    callId: candidate.callId,
+    connectionId: candidate.connectionId,
+    client: candidate.client,
+    ...(candidate.projectId === undefined ? {} : { projectId: candidate.projectId }),
+  };
+}

--- a/apps/os/src/itx/itx-call-metadata.ts
+++ b/apps/os/src/itx/itx-call-metadata.ts
@@ -6,7 +6,7 @@
  * protocol metadata, not a method argument, so adding observability never
  * changes the public itx contract.
  */
-export type ItxCallMetadata = {
+type ItxCallMetadata = {
   version: 1;
   callId: string;
   connectionId: string;

--- a/apps/os/src/itx/itx-observability.ts
+++ b/apps/os/src/itx/itx-observability.ts
@@ -1,0 +1,118 @@
+import { tracing } from "cloudflare:workers";
+import type { RpcCallInfo, RpcSessionOptions } from "capnweb";
+import { parseItxCallMetadata } from "./itx-call-metadata.ts";
+
+type ItxTransport = "http" | "websocket";
+
+function targetName(target: unknown): string {
+  if (typeof target !== "object" || target === null) return "Callable";
+  const name = target.constructor?.name;
+  return typeof name === "string" && name.length > 0 ? name : "RpcTarget";
+}
+
+function rpcMethod(info: RpcCallInfo): string {
+  const path = info.path.map(String).join(".") || "call";
+  return `${targetName(info.target)}.${path}`.slice(0, 256);
+}
+
+function errorType(error: unknown): string {
+  if (error instanceof Error && error.name.length > 0) return error.name.slice(0, 128);
+  return typeof error;
+}
+
+type ItxRpcLog = {
+  message: "itx rpc completed";
+  event: "itx.rpc";
+  schema_version: 1;
+  outcome: "ok" | "error";
+  duration_ms: number;
+  rpc_method: string;
+  rpc_system: "capnweb";
+  transport: ItxTransport;
+  call_id: string;
+  connection_id: string;
+  server_session_id: string;
+  client: "browser" | "node" | "unknown";
+  project_id?: string;
+  error_type?: string;
+};
+
+function writeCompletion(event: ItxRpcLog) {
+  if (event.outcome === "error") {
+    console.error(event);
+  } else {
+    console.log(event);
+  }
+}
+
+/**
+ * Make each logical itx call the application span beneath the WebSocket event.
+ * Calls on one socket share a connection ID but receive independent call IDs,
+ * logs, timings, and platform-operation children.
+ */
+export function createItxRpcSessionOptions(transport: ItxTransport): RpcSessionOptions {
+  const serverSessionId = crypto.randomUUID();
+
+  return {
+    onCall: (info, invoke) => {
+      const metadata = parseItxCallMetadata(info.metadata);
+      const callId = metadata?.callId ?? crypto.randomUUID();
+      const connectionId = metadata?.connectionId ?? serverSessionId;
+      const method = rpcMethod(info);
+      const startedAt = performance.now();
+
+      return tracing.enterSpan("itx.rpc", async (span) => {
+        span.setAttribute("rpc.system", "capnweb");
+        span.setAttribute("rpc.method", method);
+        span.setAttribute("itx.transport", transport);
+        span.setAttribute("itx.call.id", callId);
+        span.setAttribute("itx.connection.id", connectionId);
+        span.setAttribute("itx.server_session.id", serverSessionId);
+        span.setAttribute("itx.client", metadata?.client ?? "unknown");
+        span.setAttribute("itx.project.id", metadata?.projectId);
+
+        try {
+          const result = await invoke();
+          span.setAttribute("itx.outcome", "ok");
+          writeCompletion({
+            message: "itx rpc completed",
+            event: "itx.rpc",
+            schema_version: 1,
+            outcome: "ok",
+            duration_ms: Math.round((performance.now() - startedAt) * 100) / 100,
+            rpc_method: method,
+            rpc_system: "capnweb",
+            transport,
+            call_id: callId,
+            connection_id: connectionId,
+            server_session_id: serverSessionId,
+            client: metadata?.client ?? "unknown",
+            ...(metadata?.projectId === undefined ? {} : { project_id: metadata.projectId }),
+          });
+          return result;
+        } catch (error) {
+          const type = errorType(error);
+          span.setAttribute("itx.outcome", "error");
+          span.setAttribute("error.type", type);
+          writeCompletion({
+            message: "itx rpc completed",
+            event: "itx.rpc",
+            schema_version: 1,
+            outcome: "error",
+            duration_ms: Math.round((performance.now() - startedAt) * 100) / 100,
+            rpc_method: method,
+            rpc_system: "capnweb",
+            transport,
+            call_id: callId,
+            connection_id: connectionId,
+            server_session_id: serverSessionId,
+            client: metadata?.client ?? "unknown",
+            ...(metadata?.projectId === undefined ? {} : { project_id: metadata.projectId }),
+            error_type: type,
+          });
+          throw error;
+        }
+      });
+    },
+  };
+}

--- a/apps/os/src/itx/itx-observability.ts
+++ b/apps/os/src/itx/itx-observability.ts
@@ -7,12 +7,12 @@ type ItxTransport = "http" | "websocket";
 function targetName(target: unknown): string {
   if (typeof target !== "object" || target === null) return "Callable";
   const name = target.constructor?.name;
-  return typeof name === "string" && name.length > 0 ? name : "RpcTarget";
+  return typeof name === "string" && name.length > 0 ? name.replace(/RpcTarget$/, "") : "Rpc";
 }
 
 function rpcMethod(info: RpcCallInfo): string {
   const path = info.path.map(String).join(".") || "call";
-  return `${targetName(info.target)}.${path}`.slice(0, 256);
+  return (info.path.length > 1 ? path : `${targetName(info.target)}.${path}`).slice(0, 256);
 }
 
 function errorType(error: unknown): string {
@@ -61,7 +61,7 @@ export function createItxRpcSessionOptions(transport: ItxTransport): RpcSessionO
       const method = rpcMethod(info);
       const startedAt = performance.now();
 
-      return tracing.enterSpan("itx.rpc", async (span) => {
+      return tracing.enterSpan(`itx ${method}`.slice(0, 256), async (span) => {
         span.setAttribute("rpc.system", "capnweb");
         span.setAttribute("rpc.method", method);
         span.setAttribute("itx.transport", transport);

--- a/apps/os/src/itx/itx-react.tsx
+++ b/apps/os/src/itx/itx-react.tsx
@@ -90,6 +90,7 @@ import { newWebSocketRpcSession, type RpcStub } from "capnweb";
 import type { LiveStateRpc } from "../domains/streams/rpc-types.ts";
 import type { Project, Session, UnauthenticatedOs } from "../itx-api.generated.ts";
 import { createLiveStateStore } from "../lib/live-state/store.ts";
+import { createItxClientObservability } from "./itx-call-metadata.ts";
 
 /**
  * The handle type is context-dependent: a project connection holds the project
@@ -198,6 +199,7 @@ function socketFor(context: string | undefined): Promise<ItxHandle> {
     const url = new URL("/api", window.location.href);
     url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
     const ws = new WebSocket(url);
+    const observability = createItxClientObservability({ client: "browser", projectId: context });
     entry.ws = ws;
     entry.dialedAt = Date.now();
     let opened = false;
@@ -212,7 +214,9 @@ function socketFor(context: string | undefined): Promise<ItxHandle> {
       // on the WebSocket handshake, projects.get narrows to the project context.
       // The session/root stubs live as long as the socket; they are never
       // disposed individually.
-      const unauthenticated = newWebSocketRpcSession<UnauthenticatedOs>(ws);
+      const unauthenticated = newWebSocketRpcSession<UnauthenticatedOs>(ws, undefined, {
+        getCallMetadata: observability.getCallMetadata,
+      });
       const root = unauthenticated.authenticate({ type: "from-server-cookie" });
       entry.ping = async () => {
         // Any round trip proves the transport; authenticate rides the session

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -40,6 +40,7 @@ import {
   handleEventQueueBatch,
   isWorkerEventsQueue,
 } from "./domains/events/event-queue-entrypoint.ts";
+import { createItxRpcSessionOptions } from "./itx/itx-observability.ts";
 
 /** Long enough for warm-cache loads and quick bundles; past it, show the page. */
 const PROJECT_HOST_BUILD_BUDGET_MS = 15_000;
@@ -241,9 +242,13 @@ async function apiFetch(
     requestUrl: request.url,
   });
   if (request.method === "POST") {
-    return newHttpBatchRpcResponse(request, unauthenticated);
+    return newHttpBatchRpcResponse(request, unauthenticated, createItxRpcSessionOptions("http"));
   }
-  return newWorkersWebSocketRpcResponse(request, unauthenticated);
+  return newWorkersWebSocketRpcResponse(
+    request,
+    unauthenticated,
+    createItxRpcSessionOptions("websocket"),
+  );
 }
 
 function directoryResolvers(config: AppConfig, env: Env): IngressResolvers {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ overrides:
   agents>x402: '-'
   axios: 1.13.6
   baseline-browser-mapping: ^2.9.14
-  capnweb: https://github.com/iterate/capnweb/releases/download/v0.8.0-websocket.1/capnweb-0.8.0.tgz
+  capnweb: https://github.com/iterate/capnweb.git#0182f2c3c6176cd68d994c02c208a0a7102c7a70
   quicktype-core>readable-stream: npm:vite-compatible-readable-stream@3.6.1
   srvx: 0.11.12
   wrangler: 4.107.0
@@ -601,8 +601,8 @@ importers:
         specifier: ^0.11.0
         version: 0.11.0(@babel/core@7.29.0)(@babel/runtime@7.28.6)(@cloudflare/codemode@0.3.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@tanstack/ai@0.10.2)(ai@6.0.159(zod@4.3.6))(zod@4.3.6))(@cloudflare/workers-types@4.20260621.1(patch_hash=ae8908e1d45f2ea02ffeabf1230701598cc2878240ef700403ff76df72677af2))(@tanstack/ai@0.10.2)(ai@6.0.159(zod@4.3.6))(react@19.2.4)(rolldown@1.1.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)
       capnweb:
-        specifier: https://github.com/iterate/capnweb/releases/download/v0.8.0-websocket.1/capnweb-0.8.0.tgz
-        version: https://github.com/iterate/capnweb/releases/download/v0.8.0-websocket.1/capnweb-0.8.0.tgz(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
+        specifier: https://github.com/iterate/capnweb.git#0182f2c3c6176cd68d994c02c208a0a7102c7a70
+        version: https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
       captun:
         specifier: https://github.com/iterate/captun/releases/download/v0.0.3-websocket.6aa1207/captun-0.0.3.tgz
         version: https://github.com/iterate/captun/releases/download/v0.0.3-websocket.6aa1207/captun-0.0.3.tgz(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(effect@3.19.19)(valibot@1.2.0(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(ws@8.19.0)
@@ -870,8 +870,8 @@ importers:
         specifier: ^3.14.5
         version: 3.14.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       capnweb:
-        specifier: https://github.com/iterate/capnweb/releases/download/v0.8.0-websocket.1/capnweb-0.8.0.tgz
-        version: https://github.com/iterate/capnweb/releases/download/v0.8.0-websocket.1/capnweb-0.8.0.tgz(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
+        specifier: https://github.com/iterate/capnweb.git#0182f2c3c6176cd68d994c02c208a0a7102c7a70
+        version: https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -983,8 +983,8 @@ importers:
         specifier: 1.13.14
         version: 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)
       capnweb:
-        specifier: https://github.com/iterate/capnweb/releases/download/v0.8.0-websocket.1/capnweb-0.8.0.tgz
-        version: https://github.com/iterate/capnweb/releases/download/v0.8.0-websocket.1/capnweb-0.8.0.tgz(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
+        specifier: https://github.com/iterate/capnweb.git#0182f2c3c6176cd68d994c02c208a0a7102c7a70
+        version: https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -6894,8 +6894,8 @@ packages:
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
-  capnweb@https://github.com/iterate/capnweb/releases/download/v0.8.0-websocket.1/capnweb-0.8.0.tgz:
-    resolution: {tarball: https://github.com/iterate/capnweb/releases/download/v0.8.0-websocket.1/capnweb-0.8.0.tgz}
+  capnweb@https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70:
+    resolution: {tarball: https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70}
     version: 0.8.0
 
   captun@https://github.com/iterate/captun/releases/download/v0.0.3-websocket.6aa1207/captun-0.0.3.tgz:
@@ -12419,7 +12419,7 @@ snapshots:
     dependencies:
       '@cloudflare/containers': 0.3.7
       aws4fetch: 1.0.20
-      capnweb: https://github.com/iterate/capnweb/releases/download/v0.8.0-websocket.1/capnweb-0.8.0.tgz(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
+      capnweb: https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
       hono: 4.12.27
 
   '@cloudflare/shell@0.3.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@tanstack/ai@0.10.2)(ai@6.0.159(zod@4.3.6))(zod@4.3.6)':
@@ -18433,13 +18433,13 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
-  capnweb@https://github.com/iterate/capnweb/releases/download/v0.8.0-websocket.1/capnweb-0.8.0.tgz(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24): {}
+  capnweb@https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24): {}
 
   captun@https://github.com/iterate/captun/releases/download/v0.0.3-websocket.6aa1207/captun-0.0.3.tgz(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(effect@3.19.19)(valibot@1.2.0(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(ws@8.19.0):
     dependencies:
       '@inquirer/prompts': 8.4.3(@types/node@25.6.0)
       '@orpc/server': 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)
-      capnweb: https://github.com/iterate/capnweb/releases/download/v0.8.0-websocket.1/capnweb-0.8.0.tgz(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
+      capnweb: https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
       trpc-cli: 0.14.1(@orpc/server@1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0))(@trpc/server@11.12.0(typescript@5.9.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(effect@3.19.19)(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
@@ -18459,7 +18459,7 @@ snapshots:
     dependencies:
       '@inquirer/prompts': 8.4.3(@types/node@26.1.1)
       '@orpc/server': 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)
-      capnweb: https://github.com/iterate/capnweb/releases/download/v0.8.0-websocket.1/capnweb-0.8.0.tgz(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
+      capnweb: https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
       trpc-cli: 0.14.1(@orpc/server@1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0))(@trpc/server@11.12.0(typescript@5.9.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(effect@3.19.19)(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ overrides:
   agents>x402: '-'
   axios: 1.13.6
   baseline-browser-mapping: ^2.9.14
-  capnweb: https://github.com/iterate/capnweb.git#0182f2c3c6176cd68d994c02c208a0a7102c7a70
+  capnweb: https://github.com/iterate/capnweb.git#f404ba297d164676e9e079b80afe10df8bf7ff1b
   quicktype-core>readable-stream: npm:vite-compatible-readable-stream@3.6.1
   srvx: 0.11.12
   wrangler: 4.107.0
@@ -58,9 +58,6 @@ patchedDependencies:
   '@journeyapps/wa-sqlite@1.7.0':
     hash: 628f45a8b65f5811216d637fb5cc4584db8f69a125d1ae417c4e49bc38ebca83
     path: patches/@journeyapps__wa-sqlite@1.7.0.patch
-  capnweb@0.8.0:
-    hash: e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24
-    path: patches/capnweb@0.8.0.patch
 
 importers:
 
@@ -601,8 +598,8 @@ importers:
         specifier: ^0.11.0
         version: 0.11.0(@babel/core@7.29.0)(@babel/runtime@7.28.6)(@cloudflare/codemode@0.3.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@tanstack/ai@0.10.2)(ai@6.0.159(zod@4.3.6))(zod@4.3.6))(@cloudflare/workers-types@4.20260621.1(patch_hash=ae8908e1d45f2ea02ffeabf1230701598cc2878240ef700403ff76df72677af2))(@tanstack/ai@0.10.2)(ai@6.0.159(zod@4.3.6))(react@19.2.4)(rolldown@1.1.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)
       capnweb:
-        specifier: https://github.com/iterate/capnweb.git#0182f2c3c6176cd68d994c02c208a0a7102c7a70
-        version: https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
+        specifier: https://github.com/iterate/capnweb.git#f404ba297d164676e9e079b80afe10df8bf7ff1b
+        version: https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b
       captun:
         specifier: https://github.com/iterate/captun/releases/download/v0.0.3-websocket.6aa1207/captun-0.0.3.tgz
         version: https://github.com/iterate/captun/releases/download/v0.0.3-websocket.6aa1207/captun-0.0.3.tgz(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(effect@3.19.19)(valibot@1.2.0(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(ws@8.19.0)
@@ -870,8 +867,8 @@ importers:
         specifier: ^3.14.5
         version: 3.14.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       capnweb:
-        specifier: https://github.com/iterate/capnweb.git#0182f2c3c6176cd68d994c02c208a0a7102c7a70
-        version: https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
+        specifier: https://github.com/iterate/capnweb.git#f404ba297d164676e9e079b80afe10df8bf7ff1b
+        version: https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -983,8 +980,8 @@ importers:
         specifier: 1.13.14
         version: 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)
       capnweb:
-        specifier: https://github.com/iterate/capnweb.git#0182f2c3c6176cd68d994c02c208a0a7102c7a70
-        version: https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
+        specifier: https://github.com/iterate/capnweb.git#f404ba297d164676e9e079b80afe10df8bf7ff1b
+        version: https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -6894,8 +6891,8 @@ packages:
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
-  capnweb@https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70:
-    resolution: {tarball: https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70}
+  capnweb@https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b:
+    resolution: {tarball: https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b}
     version: 0.8.0
 
   captun@https://github.com/iterate/captun/releases/download/v0.0.3-websocket.6aa1207/captun-0.0.3.tgz:
@@ -12419,7 +12416,7 @@ snapshots:
     dependencies:
       '@cloudflare/containers': 0.3.7
       aws4fetch: 1.0.20
-      capnweb: https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
+      capnweb: https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b
       hono: 4.12.27
 
   '@cloudflare/shell@0.3.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@tanstack/ai@0.10.2)(ai@6.0.159(zod@4.3.6))(zod@4.3.6)':
@@ -18433,13 +18430,13 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
-  capnweb@https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24): {}
+  capnweb@https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b: {}
 
   captun@https://github.com/iterate/captun/releases/download/v0.0.3-websocket.6aa1207/captun-0.0.3.tgz(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(effect@3.19.19)(valibot@1.2.0(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(ws@8.19.0):
     dependencies:
       '@inquirer/prompts': 8.4.3(@types/node@25.6.0)
       '@orpc/server': 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)
-      capnweb: https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
+      capnweb: https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b
       trpc-cli: 0.14.1(@orpc/server@1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0))(@trpc/server@11.12.0(typescript@5.9.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(effect@3.19.19)(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
@@ -18459,7 +18456,7 @@ snapshots:
     dependencies:
       '@inquirer/prompts': 8.4.3(@types/node@26.1.1)
       '@orpc/server': 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)
-      capnweb: https://codeload.github.com/iterate/capnweb/tar.gz/0182f2c3c6176cd68d994c02c208a0a7102c7a70(patch_hash=e344999b4917e71122b7b2b1838077c1837447247e8e5c7c9c63dfedd913db24)
+      capnweb: https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b
       trpc-cli: 0.14.1(@orpc/server@1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0))(@trpc/server@11.12.0(typescript@5.9.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(effect@3.19.19)(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ overrides:
   agents>x402: '-'
   axios: 1.13.6
   baseline-browser-mapping: ^2.9.14
-  capnweb: https://github.com/iterate/capnweb.git#f404ba297d164676e9e079b80afe10df8bf7ff1b
+  capnweb: https://github.com/iterate/capnweb.git#7923a82215f966fa692acd733f99e35be3536b09
   quicktype-core>readable-stream: npm:vite-compatible-readable-stream@3.6.1
   srvx: 0.11.12
   wrangler: 4.107.0
@@ -598,8 +598,8 @@ importers:
         specifier: ^0.11.0
         version: 0.11.0(@babel/core@7.29.0)(@babel/runtime@7.28.6)(@cloudflare/codemode@0.3.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@tanstack/ai@0.10.2)(ai@6.0.159(zod@4.3.6))(zod@4.3.6))(@cloudflare/workers-types@4.20260621.1(patch_hash=ae8908e1d45f2ea02ffeabf1230701598cc2878240ef700403ff76df72677af2))(@tanstack/ai@0.10.2)(ai@6.0.159(zod@4.3.6))(react@19.2.4)(rolldown@1.1.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)
       capnweb:
-        specifier: https://github.com/iterate/capnweb.git#f404ba297d164676e9e079b80afe10df8bf7ff1b
-        version: https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b
+        specifier: https://github.com/iterate/capnweb.git#7923a82215f966fa692acd733f99e35be3536b09
+        version: https://codeload.github.com/iterate/capnweb/tar.gz/7923a82215f966fa692acd733f99e35be3536b09
       captun:
         specifier: https://github.com/iterate/captun/releases/download/v0.0.3-websocket.6aa1207/captun-0.0.3.tgz
         version: https://github.com/iterate/captun/releases/download/v0.0.3-websocket.6aa1207/captun-0.0.3.tgz(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(effect@3.19.19)(valibot@1.2.0(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(ws@8.19.0)
@@ -867,8 +867,8 @@ importers:
         specifier: ^3.14.5
         version: 3.14.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       capnweb:
-        specifier: https://github.com/iterate/capnweb.git#f404ba297d164676e9e079b80afe10df8bf7ff1b
-        version: https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b
+        specifier: https://github.com/iterate/capnweb.git#7923a82215f966fa692acd733f99e35be3536b09
+        version: https://codeload.github.com/iterate/capnweb/tar.gz/7923a82215f966fa692acd733f99e35be3536b09
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -980,8 +980,8 @@ importers:
         specifier: 1.13.14
         version: 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)
       capnweb:
-        specifier: https://github.com/iterate/capnweb.git#f404ba297d164676e9e079b80afe10df8bf7ff1b
-        version: https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b
+        specifier: https://github.com/iterate/capnweb.git#7923a82215f966fa692acd733f99e35be3536b09
+        version: https://codeload.github.com/iterate/capnweb/tar.gz/7923a82215f966fa692acd733f99e35be3536b09
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -6891,8 +6891,8 @@ packages:
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
-  capnweb@https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b:
-    resolution: {tarball: https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b}
+  capnweb@https://codeload.github.com/iterate/capnweb/tar.gz/7923a82215f966fa692acd733f99e35be3536b09:
+    resolution: {tarball: https://codeload.github.com/iterate/capnweb/tar.gz/7923a82215f966fa692acd733f99e35be3536b09}
     version: 0.8.0
 
   captun@https://github.com/iterate/captun/releases/download/v0.0.3-websocket.6aa1207/captun-0.0.3.tgz:
@@ -12416,7 +12416,7 @@ snapshots:
     dependencies:
       '@cloudflare/containers': 0.3.7
       aws4fetch: 1.0.20
-      capnweb: https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b
+      capnweb: https://codeload.github.com/iterate/capnweb/tar.gz/7923a82215f966fa692acd733f99e35be3536b09
       hono: 4.12.27
 
   '@cloudflare/shell@0.3.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@tanstack/ai@0.10.2)(ai@6.0.159(zod@4.3.6))(zod@4.3.6)':
@@ -18430,13 +18430,13 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
-  capnweb@https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b: {}
+  capnweb@https://codeload.github.com/iterate/capnweb/tar.gz/7923a82215f966fa692acd733f99e35be3536b09: {}
 
   captun@https://github.com/iterate/captun/releases/download/v0.0.3-websocket.6aa1207/captun-0.0.3.tgz(@opentelemetry/api@1.9.0)(@trpc/server@11.12.0(typescript@5.9.3))(@types/node@25.6.0)(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(crossws@0.4.4(srvx@0.11.12))(effect@3.19.19)(valibot@1.2.0(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(ws@8.19.0):
     dependencies:
       '@inquirer/prompts': 8.4.3(@types/node@25.6.0)
       '@orpc/server': 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)
-      capnweb: https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b
+      capnweb: https://codeload.github.com/iterate/capnweb/tar.gz/7923a82215f966fa692acd733f99e35be3536b09
       trpc-cli: 0.14.1(@orpc/server@1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0))(@trpc/server@11.12.0(typescript@5.9.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(effect@3.19.19)(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
@@ -18456,7 +18456,7 @@ snapshots:
     dependencies:
       '@inquirer/prompts': 8.4.3(@types/node@26.1.1)
       '@orpc/server': 1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0)
-      capnweb: https://codeload.github.com/iterate/capnweb/tar.gz/f404ba297d164676e9e079b80afe10df8bf7ff1b
+      capnweb: https://codeload.github.com/iterate/capnweb/tar.gz/7923a82215f966fa692acd733f99e35be3536b09
       trpc-cli: 0.14.1(@orpc/server@1.13.14(@opentelemetry/api@1.9.0)(crossws@0.4.4(srvx@0.11.12))(ws@8.19.0))(@trpc/server@11.12.0(typescript@5.9.3))(@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3)))(effect@3.19.19)(valibot@1.2.0(typescript@5.9.3))(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -75,7 +75,7 @@ overrides:
   agents>x402: '-'
   axios: 1.13.6
   baseline-browser-mapping: ^2.9.14
-  capnweb: https://github.com/iterate/capnweb.git#f404ba297d164676e9e079b80afe10df8bf7ff1b
+  capnweb: https://github.com/iterate/capnweb.git#7923a82215f966fa692acd733f99e35be3536b09
   quicktype-core>readable-stream: npm:vite-compatible-readable-stream@3.6.1
   srvx: 0.11.12
   wrangler: 4.107.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -75,7 +75,7 @@ overrides:
   agents>x402: '-'
   axios: 1.13.6
   baseline-browser-mapping: ^2.9.14
-  capnweb: https://github.com/iterate/capnweb.git#0182f2c3c6176cd68d994c02c208a0a7102c7a70
+  capnweb: https://github.com/iterate/capnweb.git#f404ba297d164676e9e079b80afe10df8bf7ff1b
   quicktype-core>readable-stream: npm:vite-compatible-readable-stream@3.6.1
   srvx: 0.11.12
   wrangler: 4.107.0
@@ -92,4 +92,3 @@ patchedDependencies:
   '@cloudflare/worker-bundler@0.2.1': patches/@cloudflare__worker-bundler@0.2.1.patch
   '@cloudflare/workers-types@4.20260621.1': patches/@cloudflare__workers-types@4.20260621.1.patch
   '@journeyapps/wa-sqlite@1.7.0': patches/@journeyapps__wa-sqlite@1.7.0.patch
-  capnweb@0.8.0: patches/capnweb@0.8.0.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -75,7 +75,7 @@ overrides:
   agents>x402: '-'
   axios: 1.13.6
   baseline-browser-mapping: ^2.9.14
-  capnweb: https://github.com/iterate/capnweb/releases/download/v0.8.0-websocket.1/capnweb-0.8.0.tgz
+  capnweb: https://github.com/iterate/capnweb.git#0182f2c3c6176cd68d994c02c208a0a7102c7a70
   quicktype-core>readable-stream: npm:vite-compatible-readable-stream@3.6.1
   srvx: 0.11.12
   wrangler: 4.107.0

--- a/tasks/posthog-observability-gold-path.md
+++ b/tasks/posthog-observability-gold-path.md
@@ -1,0 +1,261 @@
+---
+state: draft
+priority: high
+size: large
+tags: [os, observability, posthog, logging, errors, session-replay]
+---
+
+# Gold-path PostHog observability for OS and itx
+
+Research captured 2026-07-13 while separating the PostHog product design from
+the first Cloudflare/capnweb distributed-tracing proof of concept.
+
+This task deliberately does **not** decide that logs belong only in Cloudflare.
+PostHog should at minimum own product-facing exception investigation, identity,
+sessions, and replay, and selected structured logs may also belong in PostHog.
+The implementation should establish the useful PostHog investigation experience
+without duplicating every Cloudflare invocation record or turning console output
+into an unbounded event stream.
+
+## Desired investigation experience
+
+For an unexpected browser or Worker failure, an operator should be able to:
+
+1. open one grouped PostHog issue with a useful, symbolicated stack;
+2. see the user, project, release, environment, logical itx call, and transport
+   connection involved;
+3. open the browser session replay when there was a browser session;
+4. find the corresponding structured logs and Cloudflare trace using shared
+   correlation fields;
+5. distinguish one underlying failure from the browser observing a server
+   failure; and
+6. avoid leaking scripts, prompts, request bodies, secrets, tokens, email
+   addresses, or sensitive URL query parameters into any telemetry sink.
+
+## Current repository state
+
+- OS currently depends on `posthog-js` 1.360.x. Current npm research found
+  newer releases and recommends upgrading to at least 1.380 before relying on
+  fetch tracing headers.
+- `packages/shared/src/posthog/posthog.ts` implements the existing first-party
+  proxy through the OS worker.
+- `packages/shared/src/evlog/with-evlog.ts` emits one accumulated request-wide
+  event and already preserves stable `appName` and `app.slug` fields for log
+  queries/dashboards. Successful PostHog proxy asset traffic is filtered.
+- The api/itx lane is not currently wrapped by `withEvlog`; the dashboard app
+  lane is.
+- The browser keeps one long-lived capnweb WebSocket per itx context. A PostHog
+  session can rotate while that socket remains alive, so socket-handshake
+  metadata is insufficient.
+- PR #1206, "Add request-wide OS logging and PostHog error capture", previously
+  provided request-wide async-local accumulation, structured errors, `waitUntil`
+  handling, PostHog output, and strong outside-in integration tests. The current
+  evlog is a smaller descendant, but its PostHog sink is absent.
+
+## Correlation contract
+
+Each logical itx call should carry a small observability envelope independent
+of business arguments:
+
+```ts
+type ItxObservabilityContext = {
+  connectionId: string;
+  itxCallId: string;
+  parentItxCallId?: string;
+  posthogDistinctId?: string;
+  posthogSessionId?: string;
+  projectId?: string;
+  environment: string;
+  release: string;
+};
+```
+
+The client must read the current PostHog identity/session when each call is
+sent, not once when the WebSocket connects. `projectId`, authorization, and
+other trusted tenant fields must be derived or verified on the server; client
+telemetry metadata is correlation input, not authority.
+
+Use the same `itxCallId`, `connectionId`, release, environment, and project ID
+in PostHog exceptions/logs and Cloudflare structured events. Cloudflare does
+not expose its native trace/span IDs to Worker application code, so do not
+invent a field that pretends to be Cloudflare's trace ID. Shared-field search
+is the initial bridge; a future exporter can provide a deeper link.
+
+## Browser gold path
+
+- Upgrade `posthog-js` and add `@posthog/react` if it is not already available.
+- Initialize with a pinned `defaults` date so SDK upgrades cannot silently
+  change collection behavior.
+- Keep automatic unhandled exception and unhandled-rejection capture enabled.
+- Install a root `PostHogErrorBoundary` for terminal React render failures.
+- For a genuinely handled terminal client failure, call
+  `posthog.captureException(error, properties)`. Do not construct `$exception`
+  events manually.
+- Keep console-error autocapture disabled. Explicit operational logs should use
+  an intentional logger/sink rather than scraping incidental console output.
+- Use `posthog.addExceptionStep(...)` for a few bounded, safe breadcrumbs before
+  high-risk operations. These are attached to a later exception rather than
+  emitted as separate product events.
+- After authentication, call `identify(stableUserId)` and
+  `group("project", stableProjectId)`. Reset on logout/identity transitions.
+- On SDK versions supporting it, restrict `tracing_headers` to exact owned HTTP
+  hostnames. This injects PostHog identity/session headers into fetch/XHR but
+  does not cover WebSockets; itx still needs the per-call envelope.
+- Treat validation failures, expected authorization failures, cancellation,
+  intentional socket closes, and ordinary reconnects as outcomes rather than
+  exceptions.
+- Unexpected WebSocket termination may be captured with an explicit `Error`
+  carrying the close code, phase, retry count, and connection ID. Suppress code
+  1000 and deliberate shutdowns.
+
+## Worker gold path
+
+- Use the current `posthog-node` Worker/workerd edge export rather than a
+  process-global Node autocapture integration.
+- Capture unexpected terminal errors exactly once at the outer HTTP request or
+  logical itx-call boundary. Inner code may enrich and rethrow, but must not
+  capture an error that the boundary will capture again.
+- Pass the original `Error` to `captureExceptionImmediate()` with:
+  `distinctId`, `$session_id`, `$groups: { project: projectId }`, release,
+  environment, operation/method, `itxCallId`, `connectionId`, safe request/CF
+  metadata, and a stable application error ID.
+- Schedule the immediate send with `ExecutionContext.waitUntil()`. PostHog
+  failure must never fail the product call.
+- Bound network timeouts/retries for the edge runtime; the SDK's ordinary Node
+  retry defaults are too generous for an observability side effect.
+- Validate Worker stack symbolication end to end. The edge build does not have
+  Node filesystem source-context support.
+
+## Server failures and browser replay
+
+A Worker exception cannot directly trigger the browser SDK's exception-based
+session-replay retention. The server should return a stable `errorId` for an
+unexpected itx failure. The browser then emits a **non-exception** marker such
+as `itx_server_error_observed`, sharing `errorId` and `itxCallId`, or explicitly
+starts replay capture according to the chosen retention policy.
+
+The Worker remains the sole owner of the `$exception`; the browser marker says
+that the affected session observed it. This prevents two PostHog issues for one
+underlying failure while retaining the replay buffer.
+
+Recommended replay policy:
+
+- low baseline recording plus 100% exception/session-trigger retention;
+- mask all inputs and text initially, then selectively unmask reviewed UI;
+- scrub URL queries and network metadata with
+  `maskCapturedNetworkRequestFn`;
+- never record bodies, authorization headers, secrets, scripts, prompts, or
+  capability arguments; and
+- verify that the pre-trigger buffer is present for server failures observed by
+  the client.
+
+## Logs in PostHog: decision to make
+
+Selected logs should be available in PostHog when they materially improve the
+issue + replay investigation. Candidate designs, in preferred evaluation order:
+
+1. **PostHog Logs through OTLP.** Evaluate Cloudflare's native OTLP export or a
+   small application OTLP sink into PostHog Logs. PostHog currently documents
+   OTLP log ingestion for JavaScript/Node; Cloudflare's destination support
+   should be verified against the actual account and PostHog region. Confirm
+   whether filtering can restrict export to the intentional `os.evlog.v1`
+   application events rather than all platform invocations.
+2. **One direct structured log per completed operation.** Reuse the same
+   accumulated wide event sent to Cloudflare, but send only errors, degraded
+   outcomes, or slow/high-value calls to PostHog Logs. Delivery must be
+   `waitUntil`-backed and failure-independent.
+3. **Exception enrichment only.** Attach bounded breadcrumbs and final operation
+   fields to exceptions, without a standalone PostHog log stream. This is the
+   lowest-volume fallback but may be insufficient for investigating anomalous
+   successful behavior.
+
+Do not send every `console.log`, every Cap'n Web frame, or raw business inputs.
+Do not encode logs as arbitrary product analytics events merely to make them
+searchable. Decide retention, volume/cost budgets, and filtering before enabling
+a second copy of every successful operation.
+
+Questions the spike must answer:
+
+- Can native Cloudflare OTLP export send only the desired application logs to
+  PostHog, and can a PostHog log link directly to session replay?
+- Does PostHog preserve `itxCallId`, project group, release, and session ID as
+  first-class searchable fields?
+- Are errors and slow successful operations enough, or should particular
+  security/agent/dynamic-worker outcomes always be retained?
+- Which sink owns redaction so Cloudflare and PostHog cannot diverge?
+- Should the existing first-party PostHog proxy move to a dedicated Worker so
+  ingestion traffic does not pollute OS invocation observability?
+
+## Source maps and releases
+
+- Generate production source maps for browser and Worker bundles.
+- Run `posthog-cli sourcemap inject` before deployment and upload immediately
+  with an explicit immutable release, ideally the deployed git SHA.
+- Use the same release value in browser initialization, Worker exception/log
+  properties, Cloudflare structured events, and deployments.
+- Also enable Cloudflare `upload_source_maps: true`; Cloudflare and PostHog need
+  their own uploads.
+- Add a production-like acceptance test with minified browser and Worker throws
+  and verify the displayed source file, line, and release in each product.
+
+## Grouping and noise policy
+
+- Start with PostHog's automatic grouping. Add `$exception_fingerprint` only
+  after observing a concrete grouping defect.
+- Never put request, user, project, connection, or call IDs into a fingerprint.
+- Normalize wrapped/cause-chain errors without destroying the original stack.
+- Classify known control-flow errors before the capture boundary.
+- Do not randomly sample unexpected exceptions. Reduce noise by correct
+  classification and single ownership.
+- Apply `before_send` as the final redaction and known-benign-event guard, not as
+  the primary application error classifier.
+
+## What to retain from PR #1206
+
+- illegal logging outside a real async-local scope;
+- one post-hoc accumulated event at operation exit;
+- structured custom errors and cause chains;
+- bounded messages/breadcrumbs collected during the operation;
+- causal context for `waitUntil` work;
+- independently failing stdout/PostHog sinks; and
+- outside-in integration tests covering success, expected 4xx, thrown 5xx,
+  custom errors, warnings/info, and rejected background work.
+
+Avoid restoring full parent-log cloning, Hono/oRPC-specific integration,
+JSONata runtime filtering, local temp buffers, or duplicate catch/capture/rethrow
+behavior.
+
+## Acceptance criteria
+
+- [ ] A minified unhandled browser error appears once, symbolicated, linked to
+      user, project, release, and replay.
+- [ ] A handled terminal Worker HTTP error appears once and is searchable in
+      both PostHog and Cloudflare by request/error ID.
+- [ ] An itx error on a long-lived socket after PostHog session rotation uses
+      the current call's session ID, creates one Worker exception, and retains
+      the affected browser replay through a non-exception marker.
+- [ ] The selected PostHog Logs path is tested with success, slow, degraded, and
+      error wide events; the retention/filter policy and volume budget are
+      documented.
+- [ ] Intentional close, validation, cancellation, and reconnect scenarios do
+      not create exception issues.
+- [ ] Secrets, bodies, scripts, prompts, auth headers, and query parameters are
+      absent from captured events, logs, and replay.
+- [ ] PostHog delivery failure does not alter product outcomes.
+
+## Primary references
+
+- PR #1206: https://github.com/iterate/iterate/pull/1206
+- Exception capture: https://posthog.com/docs/error-tracking/capture
+- Exception grouping: https://posthog.com/docs/error-tracking/grouping-issues
+- Browser configuration: https://posthog.com/docs/libraries/js/config
+- React error tracking: https://posthog.com/docs/error-tracking/installation/react
+- Node/Worker error tracking: https://posthog.com/docs/error-tracking/installation/node
+- Source maps: https://posthog.com/docs/error-tracking/upload-source-maps/web
+- Replay retention triggers:
+  https://posthog.com/docs/session-replay/how-to-control-which-sessions-you-record
+- Replay privacy: https://posthog.com/docs/session-replay/privacy
+- JavaScript logs: https://posthog.com/docs/logs/installation/javascript
+- Node logs: https://posthog.com/docs/logs/installation/nodejs
+- Link logs to replay: https://posthog.com/docs/logs/link-session-replay
+- Cloudflare proxy: https://posthog.com/docs/advanced/proxy/cloudflare


### PR DESCRIPTION
## What this proves

- one immutable Cap’n Web fork seam carries optional observability metadata beside RPC arguments
- every logical ITX operation on one WebSocket gets its own operation-named custom span, such as `itx streams.list` or `itx Stream.getEvents`
- calls on the same socket share `connection_id` while retaining distinct `call_id` values
- Durable Object work started by an ITX call is parented beneath the correct application span
- Workers Logs receives one clean structured completion object per logical call
- the same path records failures as error spans and error-level structured logs

Fork change: https://github.com/iterate/capnweb/pull/3, pinned to `7923a82215f966fa692acd733f99e35be3536b09`.

PostHog research is deliberately parked in `tasks/posthog-observability-gold-path.md` so this PR stays focused on the Cloudflare proof.

## Preview evidence

Preview: https://os.iterate-preview-7.com

### Current readable-label proof

[Open the clean readable-label trace in Cloudflare](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/workers-and-pages/observability/traces/3475e6d72207f5c29825fd944e56826e)

A read-only CLI probe ran from `2026-07-13T11:50:08Z` to `2026-07-13T11:50:11Z` against commit `90ab6cb`, worker version `bd96d5ac-9272-4280-9007-42efd0946360`. Cloudflare retained a six-span trace:

```text
trace 3475e6d72207f5c29825fd944e56826e
GET /api                              1,120 ms
├─ itx UnauthenticatedOs.authenticate     0 ms
├─ itx projects.get                        0 ms
└─ itx streams.list                      164 ms
   └─ durable_object_subrequest          182 ms
```

The three ITX spans share `connection_id = ff0b3fd6-7a06-4c13-aaa6-f6614c932c67`, have distinct call IDs, and are direct children of request span `0a21ec4ac76d33ad`. The Durable Object subrequest is a direct child of `itx streams.list`.

[Open the richer seven-call readable-label trace](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/workers-and-pages/observability/traces/7e53118aabec0baa197453db8e4f8f20). It shows `itx Project.__describe`, `itx streams.get`, `itx Stream.getEvents`, and `itx Stream.__describe` as well as the three names above. It also contains 124 automatic/platform spans, which is useful evidence for the trace-size boundary discussed below.

### Original full nesting and failure proof

The trace below predates operation-specific span names. Its textual tree appends each span's indexed `rpc.method`; the Cloudflare UI row itself displays the then-static `itx.rpc` name.

[Open the captured success trace in Cloudflare](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/workers-and-pages/observability/traces/c2246f18ea118dc2c42c4aa30d8985a0)

Probe window: `2026-07-13T10:44:21.813Z` to `2026-07-13T10:44:23.463Z` on worker version `14f21e5f-ee00-467d-843b-79d76149e4b3`. The worker code was deployed from `7227e1b`; the following `b403d99` commit only updates the raw-frame e2e expectation.

One CLI script made four sequential project operations. Including authentication, project selection, and pipelined getters, Cloudflare recorded eight logical calls on one socket:

```text
trace c2246f18ea118dc2c42c4aa30d8985a0
GET /api  ca6ae99b86ad5423  1,650 ms
├─ itx.rpc authenticate       52abd3f68a6e35ad  call e5e8c911…    0 ms
├─ itx.rpc projects.get       731c30291a407a6f  call 1f8b5bc2…    0 ms
├─ itx.rpc Project.__describe 3b66bb005d308f2c  call a0a32f62…  245 ms
│  ├─ durable_object_subrequest 5f2b8cd0b30ebe6c              245 ms
│  └─ durable_object_subrequest 72f3512d0fac62f4              338 ms
├─ itx.rpc streams.list       38212193b3bc2490  call adc1d08a…  164 ms
│  └─ durable_object_subrequest 107c18d50f203f9b              504 ms
├─ itx.rpc streams.get        8999478b2102eb40  call bf07bedb…    0 ms
├─ itx.rpc Stream.getEvents   3c1e89a5e345054b  call edf8dcab…  280 ms
│  └─ durable_object_subrequest 18c49a2ffbdd040d              328 ms
├─ itx.rpc streams.get        0152d11bbdefad6a  call aa35e03b…    0 ms
└─ itx.rpc Stream.__describe  835f7d27ba7cd1e0  call ff33825f…    0 ms

15 spans total: 1 request root, 8 custom ITX spans, 4 Durable Object subrequests, and 2 Durable Object storage spans.
```

All eight custom spans share:

- `connection_id = 8ad29c72-4cd9-4420-911f-028e00adcf9c`
- `server_session_id = 4915152d-f0f7-4219-9255-148d3b814a58`
- `project_id = prj_28be5ee540ac4d08a2d270519647b2bd`
- `transport = websocket`, `client = node`, `rpc.system = capnweb`

Workers Logs contains eight matching `cloudflare-workers` events. A representative indexed log line is:

```json
{"message":"itx rpc completed","event":"itx.rpc","outcome":"ok","duration_ms":281,"rpc_method":"StreamRpcTarget.getEvents","rpc_system":"capnweb","transport":"websocket","call_id":"edf8dcab-3ab0-463b-8940-360c004bbef2","connection_id":"8ad29c72-4cd9-4420-911f-028e00adcf9c","server_session_id":"4915152d-f0f7-4219-9255-148d3b814a58","client":"node","project_id":"prj_28be5ee540ac4d08a2d270519647b2bd","schema_version":1}
```

The trace dataset and Workers Logs dataset both index `call_id`, so a log line joins exactly to its custom span. `connection_id` is the intentional cross-call grouping key for the long-running socket. Cloudflare also attributes console output emitted inside `enterSpan` to that active span in its trace UI and OpenTelemetry exports.

### Failure proof

[Open the captured failure trace in Cloudflare](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/workers-and-pages/observability/traces/4faa6d6df185f3a85a604e1636d03ae8)

At `2026-07-13T10:48:04.514Z`, an invalid `getEvents({ limit: 0 })` call produced:

- trace `4faa6d6df185f3a85a604e1636d03ae8`
- span `e595a13e2ea6bf5f`, parent `8dae2454e59fa8d0`
- call `03b45a81-c555-4146-ad31-559d93644c3d`
- `outcome = error`, `error.type = Error`, span duration 85 ms
- a matching error-level structured log with `error_type = Error` and duration 86 ms

### WebSocket conclusion

Cloudflare treats the WebSocket fetch as the trace root, so calls on one socket are sibling application spans in one connection-level trace. This is useful for a bounded CLI/script session: every call has an independent name, duration, outcome, call ID, log line, and correctly parented platform work.

#### Trace-size boundary

This repo intentionally captures every request. The shared Wrangler configuration sets `head_sampling_rate: 1` for requests, persisted logs, and persisted traces across the OS worker, builder and typechecker sidecars, and generated dynamic workers. There is no sampling policy in this proof.

With full capture, every WebSocket upgrade starts a retained connection-level trace. That is useful for a bounded CLI or script session, but a long-lived browser session can still become visually large. Suppressing some custom spans would not solve that problem: it would remove the useful application row per RPC while Cloudflare automatic Durable Object, `jsrpc`, and storage spans continued to accumulate. The multi-minute automatic `jsrpc` rows in the richer captured trace demonstrate this boundary.

The current [Cloudflare custom-spans API](https://developers.cloudflare.com/workers/observability/traces/custom-spans/) automatically uses the active request context. It does not expose manual parent selection, manual span lifetimes, or a way to start each RPC as a detached trace root. There is therefore no honest per-call trace split to add in this PR.

The decision for this proof of concept is:

- retain 100% request, log, and trace coverage
- keep operation names low-cardinality; IDs remain attributes and structured-log fields
- emit one custom span and one completion log per logical RPC
- keep `connection_id` for session grouping and `call_id` for an exact log/span join
- treat long-session bounding as a transport-lifecycle follow-up, not a tracing-fork or sampling feature

The likely production boundary is a maximum browser connection age and/or call budget, followed by reconnecting at a capability-safe point. Capability handles are stateful and promise-pipelined, so connection rotation must first prove what happens to live handles and in-flight calls. CLI scripts and other naturally short sessions can keep the single connection-level trace. Alarm-originated work and dynamic-worker-originated calls remain explicit follow-ups after this WebSocket proof.

## Verification

- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/os test:unit` — 1,178 passed, 1 skipped
- `pnpm --dir apps/os build`
- `pnpm knip`
- focused preview e2e against preview 7 — 6 passed
- targeted oxlint and oxfmt checks
- fork type tests, build, and focused cross-runtime test across six runtimes


<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +198 -3 | +166 -3 🟩🟩🟩🟩⬜ |
| Tests | +39 -1 | +35 -1 🟩⬜⬜⬜⬜ |
| Config | +1 -2 | +1 -2 🟥⬜⬜⬜⬜ |
| Docs | +261 -0 | +222 -0 🟩🟩🟩🟩🟩 |
| Generated | +13 -16 | +13 -16 🟥⬜⬜⬜⬜ |
| **Total** | **+512 -22** | **+437 -22** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 546b78e and 90ab6cb, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-13T17:16:31.227Z",
      "headSha": "90ab6cb81a57ec5e476e1b72048354073e59eaca",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/321275522510216",
      "shortSha": "90ab6cb",
      "cleanupDurationMs": 10292,
      "deployDurationMs": 77690,
      "testDurationMs": 193027,
      "testRetries": "11 retried: agent runs an itx script that appends a proof event, then replies (vitest x1) · itx > Agent scripts can send web-chat messages (with file attachments) and call project tools (vitest x1) · the boundary, pinned: a socket-carrying Response dies crossing the worker mesh (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · concurrent long-running ITX scripts all complete (vitest x1) · configured processor subscriptions are recorded as configured runtime connections (vitest x1) · delivery expressions must end in a property step, rejected before commit (vitest x1) · global streams reject webhook subscriptions before commit (vitest x1) · reactivity page delivers an appended event to another open tab (specs x1) · runs \"scheduler-basics\" through the project REPL (specs x1) · runs \"repo-commit-files\" through the project REPL (specs x1)",
      "workerSizeKib": 16074.88,
      "workerGzipKib": 4336.97,
      "mainWorkerGzipKib": 4335.47
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-13T17:16:21.689Z",
      "headSha": "90ab6cb81a57ec5e476e1b72048354073e59eaca",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/321275522510216",
      "shortSha": "90ab6cb",
      "cleanupDurationMs": 751,
      "deployDurationMs": 14341,
      "testDurationMs": 6758,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-13T17:16:24.179Z",
      "headSha": "90ab6cb81a57ec5e476e1b72048354073e59eaca",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/321275522510216",
      "shortSha": "90ab6cb",
      "cleanupDurationMs": 3238,
      "deployDurationMs": 18714,
      "testDurationMs": 690,
      "testRetries": null,
      "workerSizeKib": 4032.01,
      "workerGzipKib": 819.61,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-13T17:16:21.862Z",
      "headSha": "90ab6cb81a57ec5e476e1b72048354073e59eaca",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/321275522510216",
      "shortSha": "90ab6cb",
      "cleanupDurationMs": 917,
      "deployDurationMs": 14281,
      "testDurationMs": 17751,
      "testRetries": null,
      "workerSizeKib": 4890.04,
      "workerGzipKib": 1399.54,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `90ab6cb` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 819.6 KiB | 18.7s | 690ms |  | 3.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/321275522510216) | 2026-07-13T17:16:24.179Z | Preview app released. |
| OS | released | `90ab6cb` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 4.24 MiB (+1.5 KiB vs main) | 77.7s | 193.0s | 11 retried: agent runs an itx script that appends a proof event, then replies (vitest x1) · itx > Agent scripts can send web-chat messages (with file attachments) and call project tools (vitest x1) · the boundary, pinned: a socket-carrying Response dies crossing the worker mesh (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · concurrent long-running ITX scripts all complete (vitest x1) · configured processor subscriptions are recorded as configured runtime connections (vitest x1) · delivery expressions must end in a property step, rejected before commit (vitest x1) · global streams reject webhook subscriptions before commit (vitest x1) · reactivity page delivers an appended event to another open tab (specs x1) · runs "scheduler-basics" through the project REPL (specs x1) · runs "repo-commit-files" through the project REPL (specs x1) | 10.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/321275522510216) | 2026-07-13T17:16:31.227Z | Preview app released. |
| Semaphore | released | `90ab6cb` | [https://semaphore.iterate-preview-7.com](https://semaphore.iterate-preview-7.com) | 440.8 KiB | 14.3s | 6.8s |  | 751ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/321275522510216) | 2026-07-13T17:16:21.689Z | Preview app released. |
| Streams Example App | released | `90ab6cb` | [https://streams.iterate-preview-7.com](https://streams.iterate-preview-7.com) | 1.37 MiB | 14.3s | 17.8s |  | 917ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/321275522510216) | 2026-07-13T17:16:21.862Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->




