### PR TITLE
Fix sandbox git HTTPS auth via GitHub integration

### DIFF
--- a/apps/os/docs/cloudflare-sandboxes.md
+++ b/apps/os/docs/cloudflare-sandboxes.md
@@ -134,13 +134,15 @@ value** — it would sit in the container's environment, its snapshots, and the
 connection, the sandbox plants `GH_TOKEN` automatically — a `getSecret`
 placeholder for the connection secret's `accessToken` (minted/substituted only
 at egress). `gh` reads it from the environment natively, and provisioning also
-sets a `git http."https://github.com/".extraheader` with a raw
-`AUTHORIZATION: Bearer $GH_TOKEN` header (a credential helper would send Basic
-auth — base64 — hiding the placeholder from egress substitution), so plain
-`git` and `gitCheckout` against github.com work too. Discovery runs per
-container start (a new connection is picked up on the next start); with
-several connections the lexicographically first connection name wins;
-`setEnvVars({ GH_TOKEN })` overrides the pick.
+sets a `git http."https://github.com/".extraheader` with
+`AUTHORIZATION: Basic base64(x-access-token:$GH_TOKEN)` — GitHub's git
+smart-HTTP endpoint rejects Bearer tokens (API-style) and wants Basic with
+username `x-access-token`. The placeholder rides inside the base64 payload;
+project egress peels Basic Authorization headers before substituting, so plain
+`git` and `gitCheckout` against github.com work without token bytes entering
+the container. Discovery runs per container start (a new connection is picked
+up on the next start); with several connections the lexicographically first
+connection name wins; `setEnvVars({ GH_TOKEN })` overrides the pick.
 
 **Nothing else is planted, and nothing is baked into the image.** There is no
 bundled coding agent and no automatic repo checkout — a sandbox starts as the

--- a/apps/os/docs/cloudflare-sandboxes.md
+++ b/apps/os/docs/cloudflare-sandboxes.md
@@ -140,9 +140,9 @@ smart-HTTP endpoint rejects Bearer tokens (API-style) and wants Basic with
 username `x-access-token`. The placeholder rides inside the base64 payload;
 project egress peels Basic Authorization headers before substituting, so plain
 `git` and `gitCheckout` against github.com work without token bytes entering
-the container. Provisioning also sets `user.name` / `user.email` to the
-first-party **`iterate[bot]`** GitHub App identity so commits show the app
-avatar. Discovery runs per container start (a new connection is picked up on
+the container. Provisioning also sets `user.name` / `user.email` to brand-lowercase
+**`iterate`** plus the first-party GitHub App bot noreply address so commits
+show the app avatar. Discovery runs per container start (a new connection is picked up on
 the next start); with several connections the lexicographically first
 connection name wins; `setEnvVars({ GH_TOKEN })` overrides the pick.
 

--- a/apps/os/docs/cloudflare-sandboxes.md
+++ b/apps/os/docs/cloudflare-sandboxes.md
@@ -140,8 +140,10 @@ smart-HTTP endpoint rejects Bearer tokens (API-style) and wants Basic with
 username `x-access-token`. The placeholder rides inside the base64 payload;
 project egress peels Basic Authorization headers before substituting, so plain
 `git` and `gitCheckout` against github.com work without token bytes entering
-the container. Discovery runs per container start (a new connection is picked
-up on the next start); with several connections the lexicographically first
+the container. Provisioning also sets `user.name` / `user.email` to the
+first-party **`iterate[bot]`** GitHub App identity so commits show the app
+avatar. Discovery runs per container start (a new connection is picked up on
+the next start); with several connections the lexicographically first
 connection name wins; `setEnvVars({ GH_TOKEN })` overrides the pick.
 
 **Nothing else is planted, and nothing is baked into the image.** There is no

--- a/apps/os/docs/integrations-and-secrets-design.md
+++ b/apps/os/docs/integrations-and-secrets-design.md
@@ -193,11 +193,12 @@ ALL container egress — including HTTPS, MITM'd with the Cloudflare container
 CA (`interceptHttps`) — routes through the project egress door. So sandboxes
 need no token bytes: the sandbox DO plants a placeholder `GH_TOKEN` per
 container start when the project has a GitHub connection, and the warm-up
-script sets a `git http.extraheader` with a raw Bearer placeholder (git's
-credential helpers send Basic auth — base64 — which would hide the placeholder
-from header substitution). Substitution + refresh-on-401 happen en route under
-the pin, exactly as for any other caller. There is no reveal lane, and none is
-needed.
+script sets a `git http.extraheader` with Basic auth
+(`x-access-token` + base64 of the placeholder — GitHub git rejects Bearer).
+Egress peels Basic Authorization headers so the placeholder is still
+discoverable and substitutable. Substitution + refresh-on-401 happen en route
+under the pin, exactly as for any other caller. There is no reveal lane, and
+none is needed.
 
 ## 6. The proof (apps/dummy-petshop)
 

--- a/apps/os/docs/integrations.md
+++ b/apps/os/docs/integrations.md
@@ -214,10 +214,11 @@ GitHub connects as a **GitHub App installation** (deep-link to
   connection secret's `accessToken` as a `getSecret` placeholder;
   lexicographically first connection when several exist), and `gh` reads it
   from the env natively. `git` gets a
-  `git http."https://github.com/".extraheader` with a raw Bearer placeholder
-  (set by the warm-up script) — deliberately not a credential helper or
-  `gh auth setup-git`, which send Basic auth (base64) and would hide the
-  placeholder from header substitution.
+  `git http."https://github.com/".extraheader` with Basic auth
+  (`x-access-token` + base64 of the placeholder — GitHub's git smart-HTTP
+  rejects Bearer). Project egress peels Basic Authorization headers before
+  substituting so the placeholder stays findable without putting token bytes
+  in the container.
 
 The provided-lane exhibits remain in the catalogue: `github-mcp-connect`
 (GitHub's MCP server mounted under the `github-mcp` slug — built-in slugs

--- a/apps/os/docs/sandboxes.md
+++ b/apps/os/docs/sandboxes.md
@@ -168,11 +168,12 @@ material as a value** — it would land on the durable stream.
 When the project has a GitHub connection, the sandbox plants **`GH_TOKEN`**
 automatically (a placeholder for the connection secret's `accessToken`,
 re-discovered per container start; lexicographically-first connection wins;
-`setEnvVars({ GH_TOKEN })` overrides) — so `gh` and git-over-https
-against github.com work out of the box, and `gitCheckout` is the way to get
-code into a sandbox. Nothing else is planted: there is no baked coding agent
-and no automatic repo checkout — a sandbox starts as the stock image plus
-whatever its snapshots carry.
+`setEnvVars({ GH_TOKEN })` overrides) and configures git with Basic
+`http.extraheader` for github.com — so `gh`, curl-with-Bearer, and
+git-over-https against github.com work out of the box, and `gitCheckout` is
+the way to get code into a sandbox. Nothing else is planted: there is no
+baked coding agent and no automatic repo checkout — a sandbox starts as the
+stock image plus whatever its snapshots carry.
 
 ## Egress: all sandbox traffic goes through project policy
 

--- a/apps/os/docs/sandboxes.md
+++ b/apps/os/docs/sandboxes.md
@@ -172,9 +172,9 @@ re-discovered per container start; lexicographically-first connection wins;
 `http.extraheader` for github.com — so `gh`, curl-with-Bearer, and
 git-over-https against github.com work out of the box, and `gitCheckout` is
 the way to get code into a sandbox. Every sandbox also gets stock git
-`user.name` / `user.email` as the first-party **`iterate[bot]`** identity
-(GitHub App noreply address) so commits pushed from the sandbox show the
-Iterate app avatar. Nothing else is planted: there is no baked coding agent
+`user.name` / `user.email` as **`iterate`** + the first-party GitHub App bot
+noreply address so commits pushed from the sandbox show the iterate app
+avatar. Nothing else is planted: there is no baked coding agent
 and no automatic repo checkout — a sandbox starts as the stock image plus
 whatever its snapshots carry.
 

--- a/apps/os/docs/sandboxes.md
+++ b/apps/os/docs/sandboxes.md
@@ -171,9 +171,12 @@ re-discovered per container start; lexicographically-first connection wins;
 `setEnvVars({ GH_TOKEN })` overrides) and configures git with Basic
 `http.extraheader` for github.com — so `gh`, curl-with-Bearer, and
 git-over-https against github.com work out of the box, and `gitCheckout` is
-the way to get code into a sandbox. Nothing else is planted: there is no
-baked coding agent and no automatic repo checkout — a sandbox starts as the
-stock image plus whatever its snapshots carry.
+the way to get code into a sandbox. Every sandbox also gets stock git
+`user.name` / `user.email` as the first-party **`iterate[bot]`** identity
+(GitHub App noreply address) so commits pushed from the sandbox show the
+Iterate app avatar. Nothing else is planted: there is no baked coding agent
+and no automatic repo checkout — a sandbox starts as the stock image plus
+whatever its snapshots carry.
 
 ## Egress: all sandbox traffic goes through project policy
 

--- a/apps/os/src/domains/integrations/utils.ts
+++ b/apps/os/src/domains/integrations/utils.ts
@@ -175,10 +175,13 @@ export const GITHUB_CONNECTION_EGRESS_URLS = [
 
 /**
  * Default git author/committer for commits the platform makes (sandbox `git`,
- * `itx.repo.commitFiles`, workspace publish, seed). Email is the first-party
- * Iterate GitHub App bot's `users.noreply.github.com` address so GitHub links
- * the commit to `iterate[bot]` and shows the app avatar — not a human and not
- * `support@…` (which would render as an unlinked gray identity).
+ * `itx.repo.commitFiles`, workspace publish, seed).
+ *
+ * - **name** is brand-lowercase `iterate` (never "Iterate") — see
+ *   docs/brand-and-tone-of-voice.md.
+ * - **email** is the first-party GitHub App bot noreply address so GitHub
+ *   links the commit to `iterate[bot]` and shows the app avatar (not a human,
+ *   not `support@…` which would render as an unlinked gray identity).
  *
  * Bot user id is public (`GET /users/iterate%5Bbot%5D` → 233973017); the
  * format is `{id}+{app-slug}[bot]@users.noreply.github.com`. Do not put a
@@ -186,7 +189,7 @@ export const GITHUB_CONNECTION_EGRESS_URLS = [
  */
 export const ITERATE_GITHUB_BOT_COMMIT_AUTHOR = {
   email: "233973017+iterate[bot]@users.noreply.github.com",
-  name: "iterate[bot]",
+  name: "iterate",
 } as const;
 
 /** Itx secret Durable Object path holding one Telegram connection's bot token. */

--- a/apps/os/src/domains/integrations/utils.ts
+++ b/apps/os/src/domains/integrations/utils.ts
@@ -173,6 +173,22 @@ export const GITHUB_CONNECTION_EGRESS_URLS = [
   "https://objects.githubusercontent.com",
 ];
 
+/**
+ * Default git author/committer for commits the platform makes (sandbox `git`,
+ * `itx.repo.commitFiles`, workspace publish, seed). Email is the first-party
+ * Iterate GitHub App bot's `users.noreply.github.com` address so GitHub links
+ * the commit to `iterate[bot]` and shows the app avatar — not a human and not
+ * `support@…` (which would render as an unlinked gray identity).
+ *
+ * Bot user id is public (`GET /users/iterate%5Bbot%5D` → 233973017); the
+ * format is `{id}+{app-slug}[bot]@users.noreply.github.com`. Do not put a
+ * project slug in name/email — that breaks avatar attribution.
+ */
+export const ITERATE_GITHUB_BOT_COMMIT_AUTHOR = {
+  email: "233973017+iterate[bot]@users.noreply.github.com",
+  name: "iterate[bot]",
+} as const;
+
 /** Itx secret Durable Object path holding one Telegram connection's bot token. */
 export function telegramBotTokenSecretPath(connection: string): string {
   return `/secrets/integrations/telegram/${connection}/bot-token`;

--- a/apps/os/src/domains/repos/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/repo-durable-object.ts
@@ -16,6 +16,7 @@ import { stableSha256 } from "../workers/utils.ts";
 import { DurableObjectNameCodec } from "../durable-object-names.ts";
 import { parseConfig } from "../../config.ts";
 import { mintGithubInstallationToken } from "../integrations/github-app.ts";
+import { ITERATE_GITHUB_BOT_COMMIT_AUTHOR } from "../integrations/utils.ts";
 import { ROOT_WORKSPACE_PATH } from "../workspaces/utils.ts";
 import type {
   CommitRepoFilesInput,
@@ -1074,7 +1075,10 @@ async function seedArtifactRepo(input: {
 
   try {
     await git.commit({
-      author: { email: "support@iterate.com", name: "Iterate" },
+      author: {
+        email: ITERATE_GITHUB_BOT_COMMIT_AUTHOR.email,
+        name: ITERATE_GITHUB_BOT_COMMIT_AUTHOR.name,
+      },
       message: "Seed minimal itx project worker",
     });
     await ensureBranchRef({ branch: input.branch, git });
@@ -1223,7 +1227,10 @@ async function mutateArtifactRepo<Extra extends Record<string, unknown>>(input: 
   }
 
   const commit = await git.commit({
-    author: input.author ?? { email: "support@iterate.com", name: "Iterate" },
+    author: input.author ?? {
+      email: ITERATE_GITHUB_BOT_COMMIT_AUTHOR.email,
+      name: ITERATE_GITHUB_BOT_COMMIT_AUTHOR.name,
+    },
     message: input.message,
   });
   // No force: writes are serialized by the DO's #writeChain, so a fresh

--- a/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
+++ b/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
@@ -14,6 +14,7 @@ import {
   assertSandboxPath,
   assertValidSleepAfter,
   githubTokenEnvForConnections,
+  SANDBOX_GITHUB_GIT_AUTH_SHELL,
 } from "../utils.ts";
 
 /**
@@ -859,25 +860,22 @@ export abstract class SandboxDurableObject extends Sandbox<Env> {
   /**
    * Make plain `git` (and therefore `gitCheckout`) authenticate against
    * github.com with the GH_TOKEN placeholder. `gh` reads GH_TOKEN from the
-   * environment natively, but stock git does not — it needs the
-   * `http.extraheader` config. A raw `AUTHORIZATION: Bearer <placeholder>`
-   * header (NOT a credential helper, which would send Basic auth — base64 —
-   * hiding the placeholder from egress substitution) is what lets the egress
-   * door swap in the real installation token. `$GH_TOKEN` expands INSIDE the
-   * container from the just-applied env map, so the placeholder string never
-   * needs shell-quoting here; when the project has no GitHub connection the
-   * guard makes this a no-op. Config lands on the ephemeral disk, hence
-   * re-run per container start. Best-effort: a hiccup must not fail
-   * provisioning — `gh` still works via the env var, and the next start
-   * retries.
+   * environment natively, but stock git does not — it needs
+   * `http.extraheader`. GitHub's git smart-HTTP endpoint only accepts Basic
+   * auth (`x-access-token:<token>`), not Bearer (API-style Bearer returns
+   * 401). The shell base64-encodes `x-access-token:$GH_TOKEN` into
+   * `AUTHORIZATION: Basic …`; project egress peels Basic headers so the
+   * placeholder is still substituted at the door (see
+   * {@link SANDBOX_GITHUB_GIT_AUTH_SHELL}). `$GH_TOKEN` expands INSIDE the
+   * container from the just-applied env map; when the project has no GitHub
+   * connection the guard makes this a no-op. Config lands on the ephemeral
+   * disk, hence re-run per container start. Best-effort: a hiccup must not
+   * fail provisioning — `gh`/curl still work via the env var, and the next
+   * start retries.
    */
   async #configureGitAuth(): Promise<void> {
     try {
-      await this.#redialOnInterruptedSessionSetup(() =>
-        super.exec(
-          'if [ -n "$GH_TOKEN" ]; then git config --global http."https://github.com/".extraheader "AUTHORIZATION: Bearer $GH_TOKEN"; fi',
-        ),
-      );
+      await this.#redialOnInterruptedSessionSetup(() => super.exec(SANDBOX_GITHUB_GIT_AUTH_SHELL));
     } catch (error) {
       console.warn("sandbox git auth configuration failed; git-over-https may 401", error);
     }

--- a/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
+++ b/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
@@ -14,7 +14,7 @@ import {
   assertSandboxPath,
   assertValidSleepAfter,
   githubTokenEnvForConnections,
-  SANDBOX_GITHUB_GIT_AUTH_SHELL,
+  SANDBOX_GIT_CONFIG_SHELL,
 } from "../utils.ts";
 
 /**
@@ -858,26 +858,16 @@ export abstract class SandboxDurableObject extends Sandbox<Env> {
   }
 
   /**
-   * Make plain `git` (and therefore `gitCheckout`) authenticate against
-   * github.com with the GH_TOKEN placeholder. `gh` reads GH_TOKEN from the
-   * environment natively, but stock git does not — it needs
-   * `http.extraheader`. GitHub's git smart-HTTP endpoint only accepts Basic
-   * auth (`x-access-token:<token>`), not Bearer (API-style Bearer returns
-   * 401). The shell base64-encodes `x-access-token:$GH_TOKEN` into
-   * `AUTHORIZATION: Basic …`; project egress peels Basic headers so the
-   * placeholder is still substituted at the door (see
-   * {@link SANDBOX_GITHUB_GIT_AUTH_SHELL}). `$GH_TOKEN` expands INSIDE the
-   * container from the just-applied env map; when the project has no GitHub
-   * connection the guard makes this a no-op. Config lands on the ephemeral
-   * disk, hence re-run per container start. Best-effort: a hiccup must not
-   * fail provisioning — `gh`/curl still work via the env var, and the next
-   * start retries.
+   * Plant stock git identity + (when `GH_TOKEN` is set) github.com HTTPS auth.
+   * See {@link SANDBOX_GIT_CONFIG_SHELL}. Identity always; auth only with a
+   * GitHub connection. Ephemeral disk → re-run per container start.
+   * Best-effort: a hiccup must not fail provisioning.
    */
-  async #configureGitAuth(): Promise<void> {
+  async #configureGit(): Promise<void> {
     try {
-      await this.#redialOnInterruptedSessionSetup(() => super.exec(SANDBOX_GITHUB_GIT_AUTH_SHELL));
+      await this.#redialOnInterruptedSessionSetup(() => super.exec(SANDBOX_GIT_CONFIG_SHELL));
     } catch (error) {
-      console.warn("sandbox git auth configuration failed; git-over-https may 401", error);
+      console.warn("sandbox git configuration failed; commits/git-over-https may misbehave", error);
     }
   }
 
@@ -1065,7 +1055,7 @@ export abstract class SandboxDurableObject extends Sandbox<Env> {
       // document env persistence across restart), so every guarded command
       // below runs with the configured vars.
       await this.#applyStoredEnvVars();
-      await this.#configureGitAuth();
+      await this.#configureGit();
       // A container restart mid-run reset the state for a NEW, empty disk —
       // everything this run did landed on the old one. Only the still-current
       // run may mark the workspace provisioned: a stale run setting the flag

--- a/apps/os/src/domains/sandboxes/utils.test.ts
+++ b/apps/os/src/domains/sandboxes/utils.test.ts
@@ -76,7 +76,11 @@ describe("githubTokenEnvForConnections", () => {
 });
 
 describe("SANDBOX_GIT_CONFIG_SHELL", () => {
-  test("plants iterate[bot] identity so GitHub shows the App avatar", () => {
+  test("plants lowercase iterate identity so GitHub shows the app avatar", () => {
+    expect(ITERATE_GITHUB_BOT_COMMIT_AUTHOR.name).toBe("iterate");
+    expect(ITERATE_GITHUB_BOT_COMMIT_AUTHOR.name).toBe(
+      ITERATE_GITHUB_BOT_COMMIT_AUTHOR.name.toLowerCase(),
+    );
     expect(SANDBOX_GIT_CONFIG_SHELL).toContain(
       `user.name '${ITERATE_GITHUB_BOT_COMMIT_AUTHOR.name}'`,
     );
@@ -84,6 +88,7 @@ describe("SANDBOX_GIT_CONFIG_SHELL", () => {
       `user.email '${ITERATE_GITHUB_BOT_COMMIT_AUTHOR.email}'`,
     );
     expect(SANDBOX_GIT_CONFIG_SHELL).toContain("users.noreply.github.com");
+    expect(SANDBOX_GIT_CONFIG_SHELL).toContain("iterate[bot]");
   });
 
   test("configures git extraheader as Basic x-access-token + base64 of GH_TOKEN placeholder", () => {

--- a/apps/os/src/domains/sandboxes/utils.test.ts
+++ b/apps/os/src/domains/sandboxes/utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { assertSandboxPath, githubTokenEnvForConnections, sandboxPathFor } from "./utils.ts";
+import {
+  assertSandboxPath,
+  githubTokenEnvForConnections,
+  sandboxPathFor,
+  SANDBOX_GITHUB_GIT_AUTH_SHELL,
+} from "./utils.ts";
 
 describe("sandboxPathFor", () => {
   test("a name mints /sandboxes/<name> — flat, no intermediate folders", () => {
@@ -66,5 +71,18 @@ describe("githubTokenEnvForConnections", () => {
       { connection: "install-10", integration: "github" },
     ]);
     expect(placeholder).toContain("/secrets/integrations/github/install-10");
+  });
+});
+
+describe("SANDBOX_GITHUB_GIT_AUTH_SHELL", () => {
+  test("configures git extraheader as Basic x-access-token + base64 of GH_TOKEN placeholder", () => {
+    // GitHub git smart-HTTP rejects Bearer; Basic with username x-access-token
+    // is the documented install-token shape. The shell base64-encodes so the
+    // placeholder still expands from $GH_TOKEN inside the container.
+    expect(SANDBOX_GITHUB_GIT_AUTH_SHELL).toContain('http."https://github.com/".extraheader');
+    expect(SANDBOX_GITHUB_GIT_AUTH_SHELL).toContain("AUTHORIZATION: Basic");
+    expect(SANDBOX_GITHUB_GIT_AUTH_SHELL).toContain("x-access-token:${GH_TOKEN}");
+    expect(SANDBOX_GITHUB_GIT_AUTH_SHELL).toContain("base64");
+    expect(SANDBOX_GITHUB_GIT_AUTH_SHELL).not.toContain("Bearer");
   });
 });

--- a/apps/os/src/domains/sandboxes/utils.test.ts
+++ b/apps/os/src/domains/sandboxes/utils.test.ts
@@ -3,8 +3,9 @@ import {
   assertSandboxPath,
   githubTokenEnvForConnections,
   sandboxPathFor,
-  SANDBOX_GITHUB_GIT_AUTH_SHELL,
+  SANDBOX_GIT_CONFIG_SHELL,
 } from "./utils.ts";
+import { ITERATE_GITHUB_BOT_COMMIT_AUTHOR } from "../integrations/utils.ts";
 
 describe("sandboxPathFor", () => {
   test("a name mints /sandboxes/<name> — flat, no intermediate folders", () => {
@@ -74,15 +75,25 @@ describe("githubTokenEnvForConnections", () => {
   });
 });
 
-describe("SANDBOX_GITHUB_GIT_AUTH_SHELL", () => {
+describe("SANDBOX_GIT_CONFIG_SHELL", () => {
+  test("plants iterate[bot] identity so GitHub shows the App avatar", () => {
+    expect(SANDBOX_GIT_CONFIG_SHELL).toContain(
+      `user.name '${ITERATE_GITHUB_BOT_COMMIT_AUTHOR.name}'`,
+    );
+    expect(SANDBOX_GIT_CONFIG_SHELL).toContain(
+      `user.email '${ITERATE_GITHUB_BOT_COMMIT_AUTHOR.email}'`,
+    );
+    expect(SANDBOX_GIT_CONFIG_SHELL).toContain("users.noreply.github.com");
+  });
+
   test("configures git extraheader as Basic x-access-token + base64 of GH_TOKEN placeholder", () => {
     // GitHub git smart-HTTP rejects Bearer; Basic with username x-access-token
     // is the documented install-token shape. The shell base64-encodes so the
     // placeholder still expands from $GH_TOKEN inside the container.
-    expect(SANDBOX_GITHUB_GIT_AUTH_SHELL).toContain('http."https://github.com/".extraheader');
-    expect(SANDBOX_GITHUB_GIT_AUTH_SHELL).toContain("AUTHORIZATION: Basic");
-    expect(SANDBOX_GITHUB_GIT_AUTH_SHELL).toContain("x-access-token:${GH_TOKEN}");
-    expect(SANDBOX_GITHUB_GIT_AUTH_SHELL).toContain("base64");
-    expect(SANDBOX_GITHUB_GIT_AUTH_SHELL).not.toContain("Bearer");
+    expect(SANDBOX_GIT_CONFIG_SHELL).toContain('http."https://github.com/".extraheader');
+    expect(SANDBOX_GIT_CONFIG_SHELL).toContain("AUTHORIZATION: Basic");
+    expect(SANDBOX_GIT_CONFIG_SHELL).toContain("x-access-token:${GH_TOKEN}");
+    expect(SANDBOX_GIT_CONFIG_SHELL).toContain("base64");
+    expect(SANDBOX_GIT_CONFIG_SHELL).not.toContain("Bearer");
   });
 });

--- a/apps/os/src/domains/sandboxes/utils.test.ts
+++ b/apps/os/src/domains/sandboxes/utils.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "vitest";
+import { ITERATE_GITHUB_BOT_COMMIT_AUTHOR } from "../integrations/utils.ts";
 import {
   assertSandboxPath,
   githubTokenEnvForConnections,
   sandboxPathFor,
   SANDBOX_GIT_CONFIG_SHELL,
 } from "./utils.ts";
-import { ITERATE_GITHUB_BOT_COMMIT_AUTHOR } from "../integrations/utils.ts";
 
 describe("sandboxPathFor", () => {
   test("a name mints /sandboxes/<name> — flat, no intermediate folders", () => {

--- a/apps/os/src/domains/sandboxes/utils.test.ts
+++ b/apps/os/src/domains/sandboxes/utils.test.ts
@@ -91,14 +91,15 @@ describe("SANDBOX_GIT_CONFIG_SHELL", () => {
     expect(SANDBOX_GIT_CONFIG_SHELL).toContain("iterate[bot]");
   });
 
-  test("configures git extraheader as Basic x-access-token + base64 of GH_TOKEN placeholder", () => {
+  test("configures git extraheader as Basic x-access-token + unwrapped base64 of GH_TOKEN", () => {
     // GitHub git smart-HTTP rejects Bearer; Basic with username x-access-token
-    // is the documented install-token shape. The shell base64-encodes so the
-    // placeholder still expands from $GH_TOKEN inside the container.
+    // is the documented install-token shape. base64 -w0 keeps the placeholder
+    // on one line so egress can peel/substitute it.
     expect(SANDBOX_GIT_CONFIG_SHELL).toContain('http."https://github.com/".extraheader');
     expect(SANDBOX_GIT_CONFIG_SHELL).toContain("AUTHORIZATION: Basic");
     expect(SANDBOX_GIT_CONFIG_SHELL).toContain("x-access-token:${GH_TOKEN}");
-    expect(SANDBOX_GIT_CONFIG_SHELL).toContain("base64");
+    expect(SANDBOX_GIT_CONFIG_SHELL).toContain("base64 -w0");
+    expect(SANDBOX_GIT_CONFIG_SHELL).not.toMatch(/tr -d/);
     expect(SANDBOX_GIT_CONFIG_SHELL).not.toContain("Bearer");
   });
 });

--- a/apps/os/src/domains/sandboxes/utils.ts
+++ b/apps/os/src/domains/sandboxes/utils.ts
@@ -1,5 +1,8 @@
 import { DurableObjectNameCodec } from "../durable-object-names.ts";
-import { githubAccessTokenPlaceholder } from "../integrations/utils.ts";
+import {
+  githubAccessTokenPlaceholder,
+  ITERATE_GITHUB_BOT_COMMIT_AUTHOR,
+} from "../integrations/utils.ts";
 import type { SandboxInstanceType } from "./instance-types.ts";
 
 /**
@@ -164,16 +167,24 @@ export function githubTokenEnvForConnections(
 }
 
 /**
- * Shell run on every container start when `GH_TOKEN` is set: configure stock
- * `git` so HTTPS to github.com sends Basic auth with username `x-access-token`
- * and password `$GH_TOKEN` (the egress placeholder).
+ * Shell run on every container start: stock git identity + optional GitHub HTTPS
+ * auth. Identity is always planted (local commits need an author even without a
+ * GitHub connection). Auth only runs when `GH_TOKEN` is set.
  *
- * GitHub's git smart-HTTP endpoint rejects `Authorization: Bearer …` (API-style)
- * with 401; it wants Basic. The placeholder is base64-encoded into the header
- * value inside the container — project egress peels Basic Authorization headers
- * before substituting (see `substituteSecretHeaders`), so the secret cell still
- * holds: the container never sees token bytes. `$GH_TOKEN` expands in the
- * container so `setEnvVars({ GH_TOKEN })` overrides still apply.
+ * - **Identity** — {@link ITERATE_GITHUB_BOT_COMMIT_AUTHOR} so commits pushed to
+ *   GitHub attribute to the Iterate App bot (logo in history). Project slug is
+ *   deliberately not in name/email (that would break avatar linking).
+ * - **Auth** — Basic `x-access-token:$GH_TOKEN` extraheader. GitHub git smart-HTTP
+ *   rejects Bearer; the placeholder is base64-encoded and peeled at egress
+ *   (`substituteSecretHeaders`) so token bytes never enter the container.
  */
-export const SANDBOX_GITHUB_GIT_AUTH_SHELL =
-  'if [ -n "$GH_TOKEN" ]; then git config --global http."https://github.com/".extraheader "AUTHORIZATION: Basic $(printf %s "x-access-token:${GH_TOKEN}" | base64 | tr -d "\\n")"; fi';
+export const SANDBOX_GIT_CONFIG_SHELL = [
+  `git config --global user.name ${shellSingleQuote(ITERATE_GITHUB_BOT_COMMIT_AUTHOR.name)}`,
+  `git config --global user.email ${shellSingleQuote(ITERATE_GITHUB_BOT_COMMIT_AUTHOR.email)}`,
+  `if [ -n "$GH_TOKEN" ]; then git config --global http."https://github.com/".extraheader "AUTHORIZATION: Basic $(printf %s "x-access-token:\${GH_TOKEN}" | base64 | tr -d "\\n")"; fi`,
+].join(" && ");
+
+/** Quote a literal for POSIX single-quoted shell (safe for `[bot]` emails). */
+function shellSingleQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}

--- a/apps/os/src/domains/sandboxes/utils.ts
+++ b/apps/os/src/domains/sandboxes/utils.ts
@@ -172,7 +172,7 @@ export function githubTokenEnvForConnections(
  * GitHub connection). Auth only runs when `GH_TOKEN` is set.
  *
  * - **Identity** — {@link ITERATE_GITHUB_BOT_COMMIT_AUTHOR} so commits pushed to
- *   GitHub attribute to the Iterate App bot (logo in history). Project slug is
+ *   GitHub attribute to the iterate app bot (logo in history). Project slug is
  *   deliberately not in name/email (that would break avatar linking).
  * - **Auth** — Basic `x-access-token:$GH_TOKEN` extraheader. GitHub git smart-HTTP
  *   rejects Bearer; the placeholder is base64-encoded and peeled at egress

--- a/apps/os/src/domains/sandboxes/utils.ts
+++ b/apps/os/src/domains/sandboxes/utils.ts
@@ -181,7 +181,9 @@ export function githubTokenEnvForConnections(
 export const SANDBOX_GIT_CONFIG_SHELL = [
   `git config --global user.name ${shellSingleQuote(ITERATE_GITHUB_BOT_COMMIT_AUTHOR.name)}`,
   `git config --global user.email ${shellSingleQuote(ITERATE_GITHUB_BOT_COMMIT_AUTHOR.email)}`,
-  `if [ -n "$GH_TOKEN" ]; then git config --global http."https://github.com/".extraheader "AUTHORIZATION: Basic $(printf %s "x-access-token:\${GH_TOKEN}" | base64 | tr -d "\\n")"; fi`,
+  // base64 -w0: single-line output (GNU coreutils on the stock sandbox image).
+  // Do not pipe through tr -d "\\n" — that deletes backslash and n, not newlines.
+  `if [ -n "$GH_TOKEN" ]; then git config --global http."https://github.com/".extraheader "AUTHORIZATION: Basic $(printf %s "x-access-token:\${GH_TOKEN}" | base64 -w0)"; fi`,
 ].join(" && ");
 
 /** Quote a literal for POSIX single-quoted shell (safe for `[bot]` emails). */

--- a/apps/os/src/domains/sandboxes/utils.ts
+++ b/apps/os/src/domains/sandboxes/utils.ts
@@ -162,3 +162,18 @@ export function githubTokenEnvForConnections(
     .sort();
   return first === undefined ? null : githubAccessTokenPlaceholder(first);
 }
+
+/**
+ * Shell run on every container start when `GH_TOKEN` is set: configure stock
+ * `git` so HTTPS to github.com sends Basic auth with username `x-access-token`
+ * and password `$GH_TOKEN` (the egress placeholder).
+ *
+ * GitHub's git smart-HTTP endpoint rejects `Authorization: Bearer …` (API-style)
+ * with 401; it wants Basic. The placeholder is base64-encoded into the header
+ * value inside the container — project egress peels Basic Authorization headers
+ * before substituting (see `substituteSecretHeaders`), so the secret cell still
+ * holds: the container never sees token bytes. `$GH_TOKEN` expands in the
+ * container so `setEnvVars({ GH_TOKEN })` overrides still apply.
+ */
+export const SANDBOX_GITHUB_GIT_AUTH_SHELL =
+  'if [ -n "$GH_TOKEN" ]; then git config --global http."https://github.com/".extraheader "AUTHORIZATION: Basic $(printf %s "x-access-token:${GH_TOKEN}" | base64 | tr -d "\\n")"; fi';

--- a/apps/os/src/domains/secrets/utils.test.ts
+++ b/apps/os/src/domains/secrets/utils.test.ts
@@ -155,6 +155,42 @@ describe("substituteSecretHeaders", () => {
     // Request cloned from the original).
     expect(substituted.headers.get("upgrade")).toBe("websocket");
   });
+
+  // GitHub git-over-HTTPS only accepts Basic (`x-access-token:<token>`), not
+  // Bearer. Sandboxes plant the placeholder inside the base64 credential so
+  // the container never holds token bytes; egress must peel, substitute, and
+  // re-encode or git clone/push always 401s.
+  test("substitutes a placeholder inside Basic Authorization base64", () => {
+    const path = "/secrets/integrations/github/install-42";
+    const placeholder = `getSecret({ path: "${path}", field: "accessToken" })`;
+    const encoded = btoa(`x-access-token:${placeholder}`);
+    const request = new Request(
+      "https://github.com/acme/repo.git/info/refs?service=git-upload-pack",
+      {
+        headers: { authorization: `Basic ${encoded}` },
+      },
+    );
+    expect(secretReferencesFromHeaders(request.headers)).toEqual([{ field: "accessToken", path }]);
+    const substituted = substituteSecretHeaders(request, ({ path: p, field }) => {
+      expect(p).toBe(path);
+      expect(field).toBe("accessToken");
+      return "ghs_install_token_abc";
+    });
+    expect(substituted.headers.get("authorization")).toBe(
+      `Basic ${btoa("x-access-token:ghs_install_token_abc")}`,
+    );
+  });
+
+  test("leaves non-placeholder Basic Authorization unchanged", () => {
+    const encoded = btoa("user:already-real-token");
+    const request = new Request("https://example.com", {
+      headers: { authorization: `Basic ${encoded}` },
+    });
+    const substituted = substituteSecretHeaders(request, () => {
+      throw new Error("resolver must not run");
+    });
+    expect(substituted.headers.get("authorization")).toBe(`Basic ${encoded}`);
+  });
 });
 
 describe("substituteSecretRequest", () => {

--- a/apps/os/src/domains/secrets/utils.ts
+++ b/apps/os/src/domains/secrets/utils.ts
@@ -13,6 +13,13 @@ import { normalizePath } from "../durable-object-names.ts";
  * placeholder outside the path fails loudly at substitution instead of
  * leaking the literal reference string to the provider. The `field` key is
  * optional; omit it for whole-material (plain-string) secrets.
+ *
+ * Headers may also carry the placeholder inside a **Basic** Authorization
+ * credential (`Authorization: Basic base64(user:getSecret(...))`). GitHub's
+ * git-over-HTTPS smart HTTP endpoint only accepts Basic (not Bearer), so
+ * sandbox git plants that shape; discovery and substitution peel the base64
+ * payload so the placeholder stays findable without putting token bytes in
+ * the container.
  */
 const SECRET_REFERENCE =
   /getSecret\(\s*\{\s*path\s*:\s*"([^"]+)"\s*(?:,\s*field\s*:\s*"([^"]+)"\s*)?\}\s*\)/g;
@@ -93,11 +100,85 @@ export function secretReferencePathsFromRequest(request: {
 }
 
 function collectSecretReferences(byKey: Map<string, SecretReference>, value: string): void {
-  for (const match of value.matchAll(SECRET_REFERENCE)) {
-    const path = normalizeSecretPath(match[1]!);
-    const field = match[2];
-    byKey.set(`${path} ${field ?? ""}`, field === undefined ? { path } : { field, path });
+  for (const candidate of headerValuesForSecretScan(value)) {
+    for (const match of candidate.matchAll(SECRET_REFERENCE)) {
+      const path = normalizeSecretPath(match[1]!);
+      const field = match[2];
+      byKey.set(`${path} ${field ?? ""}`, field === undefined ? { path } : { field, path });
+    }
   }
+}
+
+/**
+ * Values to scan for `getSecret(...)` placeholders: the raw header string,
+ * plus — when the header is HTTP Basic auth — the base64-decoded credential
+ * payload. Git (and anything else that only speaks Basic) base64-encodes
+ * `username:password` into `Authorization: Basic …`; without peeling that
+ * layer the placeholder inside the password is invisible to discovery and
+ * substitution.
+ */
+function headerValuesForSecretScan(value: string): string[] {
+  const decoded = decodeBasicAuthorizationCredential(value);
+  return decoded === null ? [value] : [value, decoded.credential];
+}
+
+/**
+ * Peel `Authorization: Basic <base64>` into its decoded `user:pass` payload.
+ * Returns null when the value is not Basic or the base64 is invalid. Callers
+ * re-encode with `btoa` after substitution (placeholders and tokens are
+ * ASCII, so the latin1 btoa/atob pair is the right codec).
+ */
+function decodeBasicAuthorizationCredential(
+  value: string,
+): { prefix: string; encoded: string; suffix: string; credential: string } | null {
+  const match = /^(\s*[Bb]asic\s+)([A-Za-z0-9+/]+=*)(\s*)$/.exec(value);
+  if (match === null) return null;
+  try {
+    return {
+      prefix: match[1]!,
+      encoded: match[2]!,
+      suffix: match[3]!,
+      credential: atob(match[2]!),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Substitute every `getSecret({ path… })` match in a plain header value. */
+function substituteSecretPlaceholdersInText(
+  value: string,
+  resolve: (reference: SecretReference) => string,
+): string {
+  return value.replaceAll(SECRET_REFERENCE, (_match, path: string, field: string | undefined) =>
+    resolve(
+      field === undefined
+        ? { path: normalizeSecretPath(path) }
+        : { field, path: normalizeSecretPath(path) },
+    ),
+  );
+}
+
+/**
+ * Substitute placeholders in one header value, including inside Basic auth
+ * base64 payloads. Non-Basic headers (Bearer, custom) substitute in place;
+ * Basic peels → substitutes the credential → re-encodes so the provider sees
+ * a real `user:token` pair.
+ */
+function substituteSecretPlaceholdersInHeaderValue(
+  value: string,
+  resolve: (reference: SecretReference) => string,
+): string {
+  const basic = decodeBasicAuthorizationCredential(value);
+  if (basic !== null) {
+    const substituted = substituteSecretPlaceholdersInText(basic.credential, resolve);
+    if (substituted !== basic.credential) {
+      return `${basic.prefix}${btoa(substituted)}${basic.suffix}`;
+    }
+    // No placeholder in the credential — still run plain substitution in case
+    // the scheme/prefix somehow carried one (it shouldn't), then return.
+  }
+  return substituteSecretPlaceholdersInText(value, resolve);
 }
 
 /**
@@ -119,27 +200,48 @@ function decodedUrl(url: string): string {
 export function platformReferencesFromHeaders(headers: Headers): PlatformReference[] {
   const byPath = new Map<string, PlatformReference>();
   headers.forEach((value) => {
-    for (const match of value.matchAll(PLATFORM_REFERENCE)) {
-      byPath.set(match[1]!, { platform: match[1]! });
+    for (const candidate of headerValuesForSecretScan(value)) {
+      for (const match of candidate.matchAll(PLATFORM_REFERENCE)) {
+        byPath.set(match[1]!, { platform: match[1]! });
+      }
     }
   });
   return [...byPath.values()];
 }
 
 /** Rewrites every `getSecret({ platform: ... })` placeholder in every header
- * using `resolve`. Runs in trusted platform code (the project egress door). */
+ * using `resolve`. Runs in trusted platform code (the project egress door).
+ * Peels Basic Authorization base64 the same way path-secret substitution does. */
 export function substitutePlatformHeaders(
   request: Request,
   resolve: (reference: PlatformReference) => string,
 ): Request {
   const headers = new Headers(request.headers);
   headers.forEach((value, name) => {
-    headers.set(
-      name,
-      value.replaceAll(PLATFORM_REFERENCE, (_match, platform: string) => resolve({ platform })),
-    );
+    headers.set(name, substitutePlatformPlaceholdersInHeaderValue(value, resolve));
   });
   return new Request(request, { headers });
+}
+
+function substitutePlatformPlaceholdersInText(
+  value: string,
+  resolve: (reference: PlatformReference) => string,
+): string {
+  return value.replaceAll(PLATFORM_REFERENCE, (_match, platform: string) => resolve({ platform }));
+}
+
+function substitutePlatformPlaceholdersInHeaderValue(
+  value: string,
+  resolve: (reference: PlatformReference) => string,
+): string {
+  const basic = decodeBasicAuthorizationCredential(value);
+  if (basic !== null) {
+    const substituted = substitutePlatformPlaceholdersInText(basic.credential, resolve);
+    if (substituted !== basic.credential) {
+      return `${basic.prefix}${btoa(substituted)}${basic.suffix}`;
+    }
+  }
+  return substitutePlatformPlaceholdersInText(value, resolve);
 }
 
 /**
@@ -174,6 +276,12 @@ export function selectSecretField(material: unknown, field?: string): string {
  * The resolver is handed the parsed reference and returns the substituted
  * string; it runs in the Secret DO (trusted platform code), so material bytes
  * are only ever handled here on the way out to a pinned host.
+ *
+ * Basic Authorization headers are special: the placeholder may live inside
+ * the base64 credential (`user:getSecret(...)`). That shape is required for
+ * GitHub git-over-HTTPS (Bearer is rejected with 401). Decode → substitute →
+ * re-encode so providers see a real token while the container still only held
+ * the placeholder.
  */
 export function substituteSecretHeaders(
   request: Request,
@@ -181,16 +289,7 @@ export function substituteSecretHeaders(
 ): Request {
   const headers = new Headers(request.headers);
   headers.forEach((value, name) => {
-    headers.set(
-      name,
-      value.replaceAll(SECRET_REFERENCE, (_match, path: string, field: string | undefined) =>
-        resolve(
-          field === undefined
-            ? { path: normalizeSecretPath(path) }
-            : { field, path: normalizeSecretPath(path) },
-        ),
-      ),
-    );
+    headers.set(name, substituteSecretPlaceholdersInHeaderValue(value, resolve));
   });
   return new Request(request, { headers });
 }

--- a/apps/os/src/domains/workspaces/workspace-core.ts
+++ b/apps/os/src/domains/workspaces/workspace-core.ts
@@ -1,5 +1,6 @@
 import { Workspace } from "@cloudflare/shell";
 import { createGit } from "@cloudflare/shell/git";
+import { ITERATE_GITHUB_BOT_COMMIT_AUTHOR } from "../integrations/utils.ts";
 import { countOccurrences, replaceLiteralOccurrences } from "../repos/edit-utils.ts";
 import type { RepoFileChange } from "../repos/types.ts";
 import type {
@@ -30,7 +31,10 @@ const WHITEOUTS_KEY = "whiteouts:v1";
 // everything else is disposable).
 const LEGACY_CLONE_SENTINEL_KEY = "workspace-cloned:v1";
 
-const DEFAULT_COMMIT_AUTHOR = { email: "support@iterate.com", name: "Iterate" };
+const DEFAULT_COMMIT_AUTHOR = {
+  email: ITERATE_GITHUB_BOT_COMMIT_AUTHOR.email,
+  name: ITERATE_GITHUB_BOT_COMMIT_AUTHOR.name,
+};
 
 // The Artifacts git endpoint intermittently returns 503 on a cold repo
 // (observed in preview e2e; the sandbox clone path carries the same loop).


### PR DESCRIPTION
## Summary

Git HTTPS (`git clone` / `git push` / `gitCheckout`) against github.com from a project sandbox was broken even when the project had a working GitHub App connection.

### Production repro (project `iterate`)

From a sandbox with `GH_TOKEN` planted as the connection secret placeholder:

| Request | Result |
| --- | --- |
| `curl -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/...` | **200** — egress substitutes the placeholder |
| `curl -H "Authorization: Bearer $GH_TOKEN" https://github.com/.../info/refs?service=git-upload-pack` | **401** `invalid credentials` |
| `git clone https://github.com/iterate/iterate.git` with `http.extraheader AUTHORIZATION: Bearer …` | **401** → `could not read Username for 'https://github.com'` |
| Unauthenticated public clone | **200** (so a *bad* Authorization header is worse than none) |

Root cause: GitHub's **git smart-HTTP** endpoint only accepts **Basic** auth (`x-access-token:<token>`). It does **not** accept API-style Bearer tokens. Sandboxes were planting Bearer via `git http.extraheader`, which always 401s.

We could not simply switch to Basic earlier without also teaching egress to peel base64: credential helpers / Basic hide the `getSecret(...)` placeholder from substitution. This PR does both.

### Fix

1. **Sandbox warm-up** — configure git with  
   `AUTHORIZATION: Basic base64(x-access-token:$GH_TOKEN)`  
   (`SANDBOX_GITHUB_GIT_AUTH_SHELL`).
2. **Secret (and platform) substitution** — when an `Authorization` header is Basic, decode → substitute placeholders → re-encode, so discovery and the Secret DO still see the placeholder without token bytes entering the container.

### Evidence in stream

Feedback on [sandbox-docs-fixer](https://os.iterate.com/projects/iterate/agents/streams/agents/slack/t0675psn873/c08r1smtzgd/ts-1783934737-655699/sandbox-docs-fixer): *GH_TOKEN works for `gh`/`curl` to the API, but not for `git clone`/push over HTTPS.*

## Test plan

- [x] Unit: Basic Authorization peel/substitute/re-encode (`secrets/utils.test.ts`)
- [x] Unit: sandbox git auth shell uses Basic, not Bearer (`sandboxes/utils.test.ts`)
- [x] Unit: platform-secrets tests still pass
- [ ] After deploy: create sandbox on a GitHub-connected project, `git clone https://github.com/<private-or-public-repo>.git`, confirm success
- [ ] After deploy: confirm `curl -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/...` still works
- [ ] After deploy: `git push` when the App installation has write access

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes secret/platform header substitution on the project egress path (security-sensitive), but behavior is narrowly scoped to Basic Authorization peel/re-encode with new unit coverage; sandbox git auth is best-effort and does not block provisioning.
> 
> **Overview**
> Fixes **git clone/push over HTTPS to github.com** from sandboxes when a GitHub connection plants `GH_TOKEN`. GitHub smart-HTTP rejects API-style **Bearer** tokens; warm-up now sets `http.extraheader` to **Basic** `base64(x-access-token:$GH_TOKEN)` so the placeholder still never holds real token bytes.
> 
> **Egress / secrets** decode **Basic** `Authorization` for discovery and substitution (path secrets and platform refs), then re-encode after resolving `getSecret(...)` — without this, placeholders inside base64 credentials were invisible and git always 401’d.
> 
> Sandboxes run **`SANDBOX_GIT_CONFIG_SHELL`** on each container start (renamed from auth-only provisioning): always sets git **`user.name` / `user.email`** to brand-lowercase **`iterate`** and the first-party app bot noreply email; GitHub HTTPS auth only when `GH_TOKEN` is set.
> 
> Platform-authored commits (repo seed/`commitFiles`, workspace publish) use shared **`ITERATE_GITHUB_BOT_COMMIT_AUTHOR`** instead of `support@iterate.com` / `Iterate` so GitHub shows the app avatar. Docs and unit tests cover Basic peel/substitute and the sandbox shell shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3bd1e682947c5a6fd1276c0bdf48b09d1ee7d2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-13T11:59:57.986Z",
      "headSha": "a3bd1e682947c5a6fd1276c0bdf48b09d1ee7d2d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/164629043105226",
      "shortSha": "a3bd1e6",
      "cleanupDurationMs": 9983,
      "deployDurationMs": 75841,
      "testDurationMs": 227796,
      "testRetries": "1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 16091.91,
      "workerGzipKib": 4341.54,
      "mainWorkerGzipKib": 4339.98
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-13T11:59:51.200Z",
      "headSha": "a3bd1e682947c5a6fd1276c0bdf48b09d1ee7d2d",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/164629043105226",
      "shortSha": "a3bd1e6",
      "cleanupDurationMs": 3194,
      "deployDurationMs": 20948,
      "testDurationMs": 227,
      "testRetries": null,
      "workerSizeKib": 4033.03,
      "workerGzipKib": 819.94,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-13T11:59:49.119Z",
      "headSha": "a3bd1e682947c5a6fd1276c0bdf48b09d1ee7d2d",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/164629043105226",
      "shortSha": "a3bd1e6",
      "cleanupDurationMs": 1110,
      "deployDurationMs": 14732,
      "testDurationMs": 5528,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-13T11:59:49.011Z",
      "headSha": "a3bd1e682947c5a6fd1276c0bdf48b09d1ee7d2d",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/164629043105226",
      "shortSha": "a3bd1e6",
      "cleanupDurationMs": 1000,
      "deployDurationMs": 13934,
      "testDurationMs": 18232,
      "testRetries": null,
      "workerSizeKib": 4891.89,
      "workerGzipKib": 1400.29,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `a3bd1e6` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 819.9 KiB | 20.9s | 227ms |  | 3.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/164629043105226) | 2026-07-13T11:59:51.200Z | Preview app released. |
| OS | released | `a3bd1e6` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.24 MiB (+1.6 KiB vs main) | 75.8s | 227.8s | 1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 10.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/164629043105226) | 2026-07-13T11:59:57.986Z | Preview app released. |
| Semaphore | released | `a3bd1e6` | [https://semaphore.iterate-preview-3.com](https://semaphore.iterate-preview-3.com) | 440.8 KiB | 14.7s | 5.5s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/164629043105226) | 2026-07-13T11:59:49.119Z | Preview app released. |
| Streams Example App | released | `a3bd1e6` | [https://streams.iterate-preview-3.com](https://streams.iterate-preview-3.com) | 1.37 MiB | 13.9s | 18.2s |  | 1.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/164629043105226) | 2026-07-13T11:59:49.011Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +191 -46 | +111 -32 🟩🟩🟩🟩🟥 |
| Tests | +72 -1 | +61 -1 🟩🟩⬜⬜⬜ |
| Docs | +29 -19 | +29 -19 🟩🟥⬜⬜⬜ |
| **Total** | **+292 -66** | **+201 -52** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 891dc70 and a3bd1e6, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->