### PR TITLE
Share team MCP servers in repo config

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,9 +1,6 @@
 {
   "mcpServers": {
-    "iterate": {
-      "url": "https://mcp__iterate.iterate.app/"
-    },
-    "cloudflare-api": {
+    "cloudflare": {
       "url": "https://mcp.cloudflare.com/mcp"
     },
     "exa": {
@@ -11,6 +8,12 @@
     },
     "context7": {
       "url": "https://mcp.context7.com/mcp"
+    },
+    "iterate": {
+      "url": "https://mcp.iterate.com"
+    },
+    "posthog": {
+      "url": "https://mcp-eu.posthog.com/mcp"
     }
   }
 }

--- a/.grok/config.toml
+++ b/.grok/config.toml
@@ -1,0 +1,23 @@
+# Project-scoped MCP servers for Grok (and any tool that reads .grok/config.toml).
+# Mirrored in .mcp.json (Claude), .cursor/mcp.json (Cursor), and opencode.json.
+# OAuth servers authenticate per-user on first use — no secrets in this file.
+
+[mcp_servers.cloudflare]
+url = "https://mcp.cloudflare.com/mcp"
+enabled = true
+
+[mcp_servers.exa]
+url = "https://mcp.exa.ai/mcp"
+enabled = true
+
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+enabled = true
+
+[mcp_servers.iterate]
+url = "https://mcp.iterate.com"
+enabled = true
+
+[mcp_servers.posthog]
+url = "https://mcp-eu.posthog.com/mcp"
+enabled = true

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,16 +1,24 @@
 {
   "mcpServers": {
-    "cloudflare-api": {
-      "type": "url",
+    "cloudflare": {
+      "type": "http",
       "url": "https://mcp.cloudflare.com/mcp"
     },
     "exa": {
-      "type": "url",
+      "type": "http",
       "url": "https://mcp.exa.ai/mcp"
     },
     "context7": {
-      "type": "url",
+      "type": "http",
       "url": "https://mcp.context7.com/mcp"
+    },
+    "iterate": {
+      "type": "http",
+      "url": "https://mcp.iterate.com"
+    },
+    "posthog": {
+      "type": "http",
+      "url": "https://mcp-eu.posthog.com/mcp"
     }
   }
 }

--- a/opencode.json
+++ b/opencode.json
@@ -1,33 +1,34 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
-    "cloudflare-api": {
+    "cloudflare": {
       "type": "remote",
       "url": "https://mcp.cloudflare.com/mcp",
       "enabled": true,
-      "oauth": false,
-      "headers": {
-        "Authorization": "Bearer {env:CLOUDFLARE_API_TOKEN}"
-      }
-    },
-    "posthog": {
-      "type": "remote",
-      "url": "https://mcp-eu.posthog.com/mcp",
-      "enabled": true,
-      "oauth": false,
-      "headers": {
-        "Authorization": "Bearer {env:POSTHOG_KEY}"
-      }
+      "oauth": {}
     },
     "exa": {
       "type": "remote",
       "url": "https://mcp.exa.ai/mcp",
-      "enabled": true
+      "enabled": true,
+      "oauth": {}
     },
     "context7": {
       "type": "remote",
       "url": "https://mcp.context7.com/mcp",
       "enabled": true
+    },
+    "iterate": {
+      "type": "remote",
+      "url": "https://mcp.iterate.com",
+      "enabled": true,
+      "oauth": {}
+    },
+    "posthog": {
+      "type": "remote",
+      "url": "https://mcp-eu.posthog.com/mcp",
+      "enabled": true,
+      "oauth": {}
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add shared MCP server configs for cloudflare, exa, context7, iterate, and posthog
- Cover Grok (`.grok/config.toml`), Claude (`.mcp.json`), Cursor (`.cursor/mcp.json`), and OpenCode (`opencode.json`)
- Use OAuth where needed (no secrets in git); fix iterate MCP URL

## Test plan
- [ ] Open repo in Grok/Claude/Cursor and confirm MCP servers appear
- [ ] Complete OAuth for cloudflare/iterate/posthog on first use

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes to local/editor MCP wiring; no application runtime or secrets committed, though teammates must re-auth via OAuth where tokens were removed.
> 
> **Overview**
> **Standardizes the same five remote MCP servers** (`cloudflare`, `exa`, `context7`, `iterate`, `posthog`) across **Grok** (new `.grok/config.toml`), **Claude** (`.mcp.json`), **Cursor** (`.cursor/mcp.json`), and **OpenCode** (`opencode.json`).
> 
> **Renames** `cloudflare-api` → `cloudflare` everywhere. **Fixes** the Iterate endpoint from `mcp__iterate.iterate.app` to `https://mcp.iterate.com`. **Adds** `posthog` (EU MCP URL) and **iterate** where they were missing from some editor configs.
> 
> **OpenCode** drops in-repo `Authorization: Bearer {env:...}` headers for Cloudflare and PostHog and uses **`oauth: {}`** instead (per-user OAuth on first use). **Claude** `.mcp.json` switches server `type` from `url` to `http`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90b2f95adfa0b407e833989fb009f1298416a8ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Config | +16 -15 | +16 -15 🟩🟩🟥⬜⬜ |
| Other | +42 -8 | +37 -8 🟩🟩🟩🟩🟥 |
| **Total** | **+58 -23** | **+53 -23** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 546b78e and 90b2f95, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->