### PR TITLE
Add repo task board

### DIFF
--- a/apps/os/package.json
+++ b/apps/os/package.json
@@ -43,6 +43,7 @@
     "@codemirror/merge": "^6.12.2",
     "@codemirror/state": "^6.5.4",
     "@codemirror/view": "^6.39.16",
+    "@dnd-kit/react": "^0.5.0",
     "@iterate-com/auth": "workspace:*",
     "@iterate-com/auth-contract": "workspace:*",
     "@iterate-com/shared": "workspace:*",

--- a/apps/os/src/components/repo-ide/markdown-frontmatter.test.ts
+++ b/apps/os/src/components/repo-ide/markdown-frontmatter.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "vitest";
+import { projectMarkdownPreview } from "./markdown-frontmatter.ts";
+
+test("projects YAML frontmatter separately from the Markdown body", () => {
+  expect(
+    projectMarkdownPreview(
+      "---\nstate: backlog\nlabels: [demo, planning]\nsize: 3\n---\n\n# New task\n\nBody.\n",
+    ),
+  ).toEqual({
+    body: "\n# New task\n\nBody.\n",
+    metadata: [
+      { key: "state", value: "backlog" },
+      { key: "labels", value: "demo, planning" },
+      { key: "size", value: "3" },
+    ],
+  });
+});
+
+test("leaves ordinary or malformed Markdown untouched", () => {
+  expect(projectMarkdownPreview("# Plain Markdown\n")).toEqual({
+    body: "# Plain Markdown\n",
+    metadata: [],
+  });
+  const malformed = "---\nlabels: [broken\n---\n# Keep this visible\n";
+  expect(projectMarkdownPreview(malformed)).toEqual({ body: malformed, metadata: [] });
+});

--- a/apps/os/src/components/repo-ide/markdown-frontmatter.ts
+++ b/apps/os/src/components/repo-ide/markdown-frontmatter.ts
@@ -1,0 +1,51 @@
+import { parseDocument, type Document } from "yaml";
+
+export function parseMarkdownFrontmatter(content: string): {
+  body: string;
+  document: Document;
+  exists: boolean;
+} {
+  const match = /^---[ \t]*\r?\n([\s\S]*?)\r?\n(?:---|\.\.\.)[ \t]*(?:\r?\n|$)/.exec(content);
+  if (match === null) return { body: content, document: parseDocument(""), exists: false };
+  return {
+    body: content.slice(match[0].length),
+    document: parseDocument(match[1] ?? ""),
+    exists: true,
+  };
+}
+
+export function markdownFrontmatterRecord(document: Document): Record<string, unknown> {
+  try {
+    const value: unknown = document.toJS();
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+export function projectMarkdownPreview(content: string): {
+  body: string;
+  metadata: Array<{ key: string; value: string }>;
+} {
+  const frontmatter = parseMarkdownFrontmatter(content);
+  if (!frontmatter.exists || frontmatter.document.errors.length > 0)
+    return { body: content, metadata: [] };
+  return {
+    body: frontmatter.body,
+    metadata: Object.entries(markdownFrontmatterRecord(frontmatter.document)).map(
+      ([key, value]) => ({
+        key,
+        value: formatFrontmatterValue(value),
+      }),
+    ),
+  };
+}
+
+function formatFrontmatterValue(value: unknown): string {
+  if (Array.isArray(value)) return value.map(formatFrontmatterValue).join(", ");
+  if (typeof value === "object" && value !== null) return JSON.stringify(value);
+  if (value === null) return "null";
+  return String(value);
+}

--- a/apps/os/src/components/repo-ide/repo-editor-pane.tsx
+++ b/apps/os/src/components/repo-ide/repo-editor-pane.tsx
@@ -16,7 +16,12 @@ import { isPreviewablePath, repoFileKind } from "./repo-file-kinds.ts";
 import { useRepoFileJsonSchema } from "./repo-json-schema.ts";
 import { useRepoTypeScriptExtensions } from "./repo-typescript.ts";
 import { localFileToBase64, pickLocalFile } from "./local-file.ts";
-import { effectiveEntry, type FileChange, type FileEntry } from "./staged-changes.ts";
+import {
+  effectiveEntry,
+  textContentForEntry,
+  type FileChange,
+  type FileEntry,
+} from "./staged-changes.ts";
 import { useItxQuery } from "~/itx/itx-react.tsx";
 
 /**
@@ -81,10 +86,16 @@ export function RepoEditorPane({
   const headContent = headRead?.content;
   const working = change?.working;
   const staged = change?.staged;
+  const workingText = kind.kind === "text" ? textContentForEntry(working) : undefined;
+  const stagedText = kind.kind === "text" ? textContentForEntry(staged) : undefined;
+  const hasUndecodableTextEntry =
+    kind.kind === "text" &&
+    ((working?.type === "write-base64" && workingText === undefined) ||
+      (staged?.type === "write-base64" && stagedText === undefined));
 
   // Diffs and dirty checks run against the git-shaped baseline: the staged
   // snapshot when one exists, else HEAD.
-  const textBaseline = staged?.type === "write" ? staged.content : (headContent ?? undefined);
+  const textBaseline = stagedText ?? headContent ?? undefined;
 
   // TypeScript language service (diagnostics, hover, autocomplete) for
   // ts/tsx/js/jsx working-tree buffers — empty for everything else, and for
@@ -112,7 +123,7 @@ export function RepoEditorPane({
   const jsonSchema = useRepoFileJsonSchema({
     path,
     language: schemaLanguage,
-    content: working?.type === "write" ? working.content : (textBaseline ?? ""),
+    content: workingText ?? textBaseline ?? "",
   });
   // The readonly Index view renders the STAGED snapshot, so it must validate
   // against the schema that snapshot declares — not the working buffer's, whose
@@ -120,7 +131,7 @@ export function RepoEditorPane({
   const stagedJsonSchema = useRepoFileJsonSchema({
     path,
     language: schemaLanguage,
-    content: staged?.type === "write" ? staged.content : "",
+    content: stagedText ?? "",
   });
 
   // The plain editor carries vscode-style gutter bars for lines differing
@@ -174,7 +185,7 @@ export function RepoEditorPane({
   // chunk controls — inspection only.
   const stagedDiffExtensions = useMemo(
     () =>
-      stagedView && staged?.type === "write"
+      stagedView && stagedText !== undefined
         ? [
             unifiedMergeView({
               original: headContent ?? "",
@@ -183,7 +194,7 @@ export function RepoEditorPane({
             }),
           ]
         : [],
-    [stagedView, staged, headContent],
+    [stagedView, stagedText, headContent],
   );
 
   const editorExtensionsWithSchema = useMemo(
@@ -270,7 +281,7 @@ export function RepoEditorPane({
   const status =
     entry === undefined ? undefined : headHasPath ? ("modified" as const) : ("added" as const);
 
-  if (stagedView && staged?.type === "write" && kind.kind === "text") {
+  if (stagedView && stagedText !== undefined && kind.kind === "text") {
     // Same Code/Preview toggle as the working view, over the staged snapshot
     // — the Index pseudo-file stays readonly either way.
     const showStagedPreview = previewOpen && isPreviewablePath(path);
@@ -316,9 +327,9 @@ export function RepoEditorPane({
       >
         {showStagedPreview ? (
           kind.language === "markdown" ? (
-            <MarkdownPreview markdown={staged.content} />
+            <MarkdownPreview markdown={stagedText} />
           ) : (
-            <HtmlPreview html={staged.content} />
+            <HtmlPreview html={stagedText} />
           )
         ) : (
           <SourceCodeBlock
@@ -328,7 +339,7 @@ export function RepoEditorPane({
             showLineNumbers
             editable={false}
             wrapLongLines={false}
-            code={staged.content}
+            code={stagedText}
             language={kind.language}
             codeMirrorExtensions={stagedDiffExtensionsWithSchema}
             onChange={() => {}}
@@ -338,8 +349,8 @@ export function RepoEditorPane({
     );
   }
 
-  if (kind.kind === "text" && working?.type !== "write-base64" && staged?.type !== "write-base64") {
-    const value = working?.type === "write" ? working.content : (textBaseline ?? "");
+  if (kind.kind === "text" && !hasUndecodableTextEntry) {
+    const value = workingText ?? textBaseline ?? "";
     const stageText = (content: string) => {
       // Typing back to the baseline un-dirties the file, like vscode.
       if (content === textBaseline) onSetWorking(undefined);

--- a/apps/os/src/components/repo-ide/repo-editor-pane.tsx
+++ b/apps/os/src/components/repo-ide/repo-editor-pane.tsx
@@ -7,9 +7,11 @@ import { MessageResponse } from "@iterate-com/ui/components/ai-elements/message"
 import { Badge } from "@iterate-com/ui/components/badge";
 import { Button } from "@iterate-com/ui/components/button";
 import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
+import { Table, TableBody, TableCell, TableRow } from "@iterate-com/ui/components/table";
 import { Tabs, TabsList, TabsTrigger } from "@iterate-com/ui/components/tabs";
 import { changedLinesGutter } from "./change-gutter.ts";
 import { HtmlPreview } from "./html-preview.tsx";
+import { projectMarkdownPreview } from "./markdown-frontmatter.ts";
 import { isPreviewablePath, repoFileKind } from "./repo-file-kinds.ts";
 import { useRepoFileJsonSchema } from "./repo-json-schema.ts";
 import { useRepoTypeScriptExtensions } from "./repo-typescript.ts";
@@ -540,12 +542,31 @@ function CodePreviewToggle({
  * that prop without re-checking sanitization.
  */
 function MarkdownPreview({ markdown }: { markdown: string }) {
+  const preview = projectMarkdownPreview(markdown);
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">
       <div className="mx-auto w-full max-w-3xl px-8 py-6 text-sm">
+        {preview.metadata.length === 0 ? null : (
+          <div className="mb-6 overflow-hidden rounded-lg border bg-muted/20">
+            <Table className="text-xs">
+              <TableBody>
+                {preview.metadata.map((property) => (
+                  <TableRow key={property.key} className="hover:bg-transparent">
+                    <TableCell className="w-36 py-1.5 font-medium text-muted-foreground">
+                      {property.key}
+                    </TableCell>
+                    <TableCell className="py-1.5 font-mono whitespace-normal">
+                      {property.value}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
         {/* A settled document, not a stream — skip streamdown's unpaired-
             marker balancing (it appends a phantom `*` to text like "17 * 23"). */}
-        <MessageResponse parseIncompleteMarkdown={false}>{markdown}</MessageResponse>
+        <MessageResponse parseIncompleteMarkdown={false}>{preview.body}</MessageResponse>
       </div>
     </div>
   );

--- a/apps/os/src/components/repo-ide/repo-ide.tsx
+++ b/apps/os/src/components/repo-ide/repo-ide.tsx
@@ -339,7 +339,6 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
             selectedPath={selectedPath}
             onPatchSearch={patchSearch}
             onSetWorking={(path, entry) => store.setWorking(path, entry)}
-            onSetStaged={(path, entry) => store.setStaged(path, entry)}
             onDelete={removePath}
           />
         </Suspense>

--- a/apps/os/src/components/repo-ide/repo-ide.tsx
+++ b/apps/os/src/components/repo-ide/repo-ide.tsx
@@ -7,6 +7,7 @@ import {
   GitCommitVerticalIcon,
   GithubIcon,
   HistoryIcon,
+  ListTodoIcon,
   MinusIcon,
   PlusIcon,
   Undo2Icon,
@@ -26,6 +27,7 @@ import { CommitHistoryPanel } from "./commit-history-panel.tsx";
 import { RepoEditorPane } from "./repo-editor-pane.tsx";
 import { RepoGithubPanel } from "./repo-github-panel.tsx";
 import { RepoFileTree, type RepoTreeActions } from "./repo-file-tree.tsx";
+import { RepoTasksView } from "./repo-tasks-view.tsx";
 import {
   commitPlan,
   effectiveEntry,
@@ -57,6 +59,7 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
     file: selectedPath,
     diff,
     preview,
+    tasks,
     scm,
     gh,
     stagedView,
@@ -209,10 +212,10 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-row">
-      {/* vscode-style activity strip: Files / Source control / History / GitHub. */}
+      {/* vscode-style activity strip: Files / Tasks / Source control / History / GitHub. */}
       <div className="flex shrink-0 flex-col items-center gap-1 border-r px-1 py-2">
         <Button
-          variant={scm || gh || history ? "ghost" : "secondary"}
+          variant={tasks || scm || gh || history ? "ghost" : "secondary"}
           size="icon"
           title="Files"
           aria-label="Files"
@@ -222,6 +225,7 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
           onClick={() =>
             patchSearch({
               scm: undefined,
+              tasks: undefined,
               gh: undefined,
               staged: undefined,
               history: undefined,
@@ -233,6 +237,28 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
           <FilesIcon className="size-4" />
         </Button>
         <Button
+          variant={tasks ? "secondary" : "ghost"}
+          size="icon"
+          title="Tasks"
+          aria-label="Tasks"
+          onClick={() =>
+            patchSearch({
+              tasks: true,
+              scm: undefined,
+              gh: undefined,
+              history: undefined,
+              commit: undefined,
+              file: undefined,
+              diff: undefined,
+              preview: undefined,
+              staged: undefined,
+            })
+          }
+          className="text-muted-foreground"
+        >
+          <ListTodoIcon className="size-4" />
+        </Button>
+        <Button
           variant={scm ? "secondary" : "ghost"}
           size="icon"
           title="Source control"
@@ -240,7 +266,13 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
           // accessible name ("1"), beating the title.
           aria-label="Source control"
           onClick={() =>
-            patchSearch({ scm: true, gh: undefined, history: undefined, commit: undefined })
+            patchSearch({
+              scm: true,
+              tasks: undefined,
+              gh: undefined,
+              history: undefined,
+              commit: undefined,
+            })
           }
           className="relative text-muted-foreground"
         >
@@ -256,7 +288,13 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
           size="icon"
           title="History"
           onClick={() =>
-            patchSearch({ history: true, scm: undefined, gh: undefined, staged: undefined })
+            patchSearch({
+              history: true,
+              tasks: undefined,
+              scm: undefined,
+              gh: undefined,
+              staged: undefined,
+            })
           }
           className="text-muted-foreground"
         >
@@ -267,7 +305,13 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
           size="icon"
           title="GitHub"
           onClick={() =>
-            patchSearch({ gh: true, scm: undefined, history: undefined, commit: undefined })
+            patchSearch({
+              gh: true,
+              tasks: undefined,
+              scm: undefined,
+              history: undefined,
+              commit: undefined,
+            })
           }
           className="text-muted-foreground"
         >
@@ -275,137 +319,168 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
         </Button>
       </div>
 
-      <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
-        <ResizablePanel defaultSize="20%" minSize="10rem" className="min-w-0">
-          {history ? (
-            <Suspense
-              fallback={
-                <div className="p-3 text-xs text-muted-foreground" data-spinner="true">
-                  Loading history…
-                </div>
-              }
+      {tasks ? (
+        <Suspense
+          fallback={
+            <div
+              className="flex flex-1 items-center justify-center text-sm text-muted-foreground"
+              data-spinner="true"
             >
-              <CommitHistoryPanel
-                projectId={projectId}
-                repoPath={repoPath}
-                expandedOid={expandedCommitOid}
-                selectedPath={selectedPath}
-                onExpand={(oid) => patchSearch({ commit: oid })}
-                // selectFile clears diff/preview/staged too, so a lingering
-                // preview=true doesn't spuriously re-open Preview for the file
-                // you pick out of a commit (history/commit stay set — the
-                // commit diff keeps showing until you leave History).
-                onOpenFile={(path) => selectFile(path)}
-              />
-            </Suspense>
-          ) : gh ? (
-            // Own Suspense (like RepoEditorPane's): the panel's first
-            // connections read suspends, and without a local boundary that
-            // would bubble to the route's ItxBoundary and blank the whole IDE.
-            <Suspense
-              fallback={
-                <div className="p-3 text-xs text-muted-foreground" data-spinner="true">
-                  Loading…
-                </div>
-              }
-            >
-              <RepoGithubPanel projectId={projectId} repoPath={repoPath} />
-            </Suspense>
-          ) : scm ? (
-            <GitPanel
-              changes={changes}
-              headPathSet={headPathSet}
-              commitPending={commit.isPending}
-              onCommit={(message, reset) => commit.mutate(message, { onSuccess: reset })}
-              onStage={(path) => store.stage(path)}
-              onUnstage={(path) => store.unstage(path)}
-              onDiscard={(path) => store.discardWorking(path)}
-              onDiscardAll={() => store.discardAll()}
-              onOpen={(path, status) =>
-                patchSearch({
-                  file: path,
-                  diff: status === "modified" ? true : undefined,
-                  preview: undefined,
-                  staged: undefined,
-                })
-              }
-              onOpenStaged={(path) =>
-                patchSearch({ file: path, diff: undefined, preview: undefined, staged: true })
-              }
-            />
-          ) : (
-            <RepoFileTree
-              className="h-full"
-              headPaths={headPaths}
-              changes={changes}
-              selectedPath={selectedPath}
-              onSelect={selectFile}
-              actions={actions}
-            />
-          )}
-        </ResizablePanel>
-        <ResizableHandle />
-        <ResizablePanel className="flex min-w-0 flex-col">
-          {selectedPath === undefined ? (
-            <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
-              Select a file to view or edit it.
+              Loading tasks…
             </div>
-          ) : (
-            <Suspense
-              fallback={
-                <div
-                  className="flex flex-1 items-center justify-center text-sm text-muted-foreground"
-                  data-spinner="true"
-                >
-                  Loading {selectedPath}…
-                </div>
-              }
-            >
-              {history && expandedCommitOid !== undefined ? (
-                <CommitDiffPane
-                  key={`${selectedPath}:${expandedCommitOid}`}
+          }
+        >
+          <RepoTasksView
+            projectId={projectId}
+            repoPath={repoPath}
+            headCommitOid={files.commitOid}
+            headPaths={headPaths}
+            changes={changes}
+            selectedPath={selectedPath}
+            diffOpen={diff}
+            previewOpen={preview}
+            stagedView={stagedView}
+            onPatchSearch={patchSearch}
+            onSetWorking={(path, entry) => store.setWorking(path, entry)}
+            onSetStaged={(path, entry) => store.setStaged(path, entry)}
+            onStage={(path) => store.stage(path)}
+            onUnstage={(path) => store.unstage(path)}
+            onRestore={dropChange}
+          />
+        </Suspense>
+      ) : (
+        <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
+          <ResizablePanel defaultSize="20%" minSize="10rem" className="min-w-0">
+            {history ? (
+              <Suspense
+                fallback={
+                  <div className="p-3 text-xs text-muted-foreground" data-spinner="true">
+                    Loading history…
+                  </div>
+                }
+              >
+                <CommitHistoryPanel
                   projectId={projectId}
                   repoPath={repoPath}
-                  path={selectedPath}
-                  commitOid={expandedCommitOid}
+                  expandedOid={expandedCommitOid}
+                  selectedPath={selectedPath}
+                  onExpand={(oid) => patchSearch({ commit: oid })}
+                  // selectFile clears diff/preview/staged too, so a lingering
+                  // preview=true doesn't spuriously re-open Preview for the file
+                  // you pick out of a commit (history/commit stay set — the
+                  // commit diff keeps showing until you leave History).
+                  onOpenFile={(path) => selectFile(path)}
                 />
-              ) : (
-                <RepoEditorPane
-                  key={selectedPath}
-                  projectId={projectId}
-                  repoPath={repoPath}
-                  path={selectedPath}
-                  headCommitOid={files.commitOid}
-                  headHasPath={headPathSet.has(selectedPath)}
-                  change={changes.get(selectedPath)}
-                  diffOpen={diff}
-                  // Diff and preview are mutually exclusive views of the same
-                  // buffer — turning one on turns the other off.
-                  onToggleDiff={(open) =>
-                    patchSearch({ diff: open ? true : undefined, preview: undefined })
-                  }
-                  previewOpen={preview}
-                  onTogglePreview={(open) =>
-                    patchSearch({ preview: open ? true : undefined, diff: undefined })
-                  }
-                  onSetWorking={(entry) => store.setWorking(selectedPath, entry)}
-                  onSetStaged={(entry) => store.setStaged(selectedPath, entry)}
-                  onStageFile={() => store.stage(selectedPath)}
-                  onUnstageFile={() => {
-                    store.unstage(selectedPath);
-                    patchSearch({ staged: undefined });
-                  }}
-                  onOpenWorking={() =>
-                    patchSearch({ staged: undefined, diff: undefined, preview: undefined })
-                  }
-                  stagedView={stagedView && changes.get(selectedPath)?.staged !== undefined}
-                  onRestore={() => dropChange(selectedPath)}
-                />
-              )}
-            </Suspense>
-          )}
-        </ResizablePanel>
-      </ResizablePanelGroup>
+              </Suspense>
+            ) : gh ? (
+              // Own Suspense (like RepoEditorPane's): the panel's first
+              // connections read suspends, and without a local boundary that
+              // would bubble to the route's ItxBoundary and blank the whole IDE.
+              <Suspense
+                fallback={
+                  <div className="p-3 text-xs text-muted-foreground" data-spinner="true">
+                    Loading…
+                  </div>
+                }
+              >
+                <RepoGithubPanel projectId={projectId} repoPath={repoPath} />
+              </Suspense>
+            ) : scm ? (
+              <GitPanel
+                changes={changes}
+                headPathSet={headPathSet}
+                commitPending={commit.isPending}
+                onCommit={(message, reset) => commit.mutate(message, { onSuccess: reset })}
+                onStage={(path) => store.stage(path)}
+                onUnstage={(path) => store.unstage(path)}
+                onDiscard={(path) => store.discardWorking(path)}
+                onDiscardAll={() => store.discardAll()}
+                onOpen={(path, status) =>
+                  patchSearch({
+                    file: path,
+                    diff: status === "modified" ? true : undefined,
+                    preview: undefined,
+                    staged: undefined,
+                  })
+                }
+                onOpenStaged={(path) =>
+                  patchSearch({ file: path, diff: undefined, preview: undefined, staged: true })
+                }
+              />
+            ) : (
+              <RepoFileTree
+                className="h-full"
+                headPaths={headPaths}
+                changes={changes}
+                selectedPath={selectedPath}
+                onSelect={selectFile}
+                actions={actions}
+              />
+            )}
+          </ResizablePanel>
+          <ResizableHandle />
+          <ResizablePanel className="flex min-w-0 flex-col">
+            {selectedPath === undefined ? (
+              <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+                Select a file to view or edit it.
+              </div>
+            ) : (
+              <Suspense
+                fallback={
+                  <div
+                    className="flex flex-1 items-center justify-center text-sm text-muted-foreground"
+                    data-spinner="true"
+                  >
+                    Loading {selectedPath}…
+                  </div>
+                }
+              >
+                {history && expandedCommitOid !== undefined ? (
+                  <CommitDiffPane
+                    key={`${selectedPath}:${expandedCommitOid}`}
+                    projectId={projectId}
+                    repoPath={repoPath}
+                    path={selectedPath}
+                    commitOid={expandedCommitOid}
+                  />
+                ) : (
+                  <RepoEditorPane
+                    key={selectedPath}
+                    projectId={projectId}
+                    repoPath={repoPath}
+                    path={selectedPath}
+                    headCommitOid={files.commitOid}
+                    headHasPath={headPathSet.has(selectedPath)}
+                    change={changes.get(selectedPath)}
+                    diffOpen={diff}
+                    // Diff and preview are mutually exclusive views of the same
+                    // buffer — turning one on turns the other off.
+                    onToggleDiff={(open) =>
+                      patchSearch({ diff: open ? true : undefined, preview: undefined })
+                    }
+                    previewOpen={preview}
+                    onTogglePreview={(open) =>
+                      patchSearch({ preview: open ? true : undefined, diff: undefined })
+                    }
+                    onSetWorking={(entry) => store.setWorking(selectedPath, entry)}
+                    onSetStaged={(entry) => store.setStaged(selectedPath, entry)}
+                    onStageFile={() => store.stage(selectedPath)}
+                    onUnstageFile={() => {
+                      store.unstage(selectedPath);
+                      patchSearch({ staged: undefined });
+                    }}
+                    onOpenWorking={() =>
+                      patchSearch({ staged: undefined, diff: undefined, preview: undefined })
+                    }
+                    stagedView={stagedView && changes.get(selectedPath)?.staged !== undefined}
+                    onRestore={() => dropChange(selectedPath)}
+                  />
+                )}
+              </Suspense>
+            )}
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      )}
     </div>
   );
 }
@@ -603,8 +678,8 @@ function GitPanel({
  * IDE view state, URL-owned like every stream view's: `file` is the open
  * path, `diff` whether the HEAD↔staged diff is showing, `preview` whether a
  * markdown/html file shows its rendered preview instead of the editor,
- * `scm`/`gh`/`history` which sidebar shows instead of the file tree (Source
- * Control / GitHub / commit history), `commit` the expanded commit's oid
+ * `tasks`/`scm`/`gh`/`history` which sidebar shows instead of the file tree
+ * (task board / Source Control / GitHub / commit history), `commit` the expanded commit's oid
  * (which also pins the readonly commit diff the open file renders as). The
  * repo detail route validates these (RepoDetailSearch), so loose reads here
  * are safe.
@@ -614,6 +689,7 @@ function useRepoIdeSearch() {
     file?: string;
     diff?: boolean;
     preview?: boolean;
+    tasks?: boolean;
     scm?: boolean;
     gh?: boolean;
     staged?: boolean;
@@ -626,6 +702,7 @@ function useRepoIdeSearch() {
       file?: string | undefined;
       diff?: boolean | undefined;
       preview?: boolean | undefined;
+      tasks?: boolean | undefined;
       scm?: boolean | undefined;
       gh?: boolean | undefined;
       staged?: boolean | undefined;
@@ -646,6 +723,7 @@ function useRepoIdeSearch() {
     file: search.file,
     diff: search.diff === true,
     preview: search.preview === true,
+    tasks: search.tasks === true,
     scm: search.scm === true,
     gh: search.gh === true,
     stagedView: search.staged === true,

--- a/apps/os/src/components/repo-ide/repo-ide.tsx
+++ b/apps/os/src/components/repo-ide/repo-ide.tsx
@@ -337,15 +337,8 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
             headPaths={headPaths}
             changes={changes}
             selectedPath={selectedPath}
-            diffOpen={diff}
-            previewOpen={preview}
-            stagedView={stagedView}
             onPatchSearch={patchSearch}
             onSetWorking={(path, entry) => store.setWorking(path, entry)}
-            onSetStaged={(path, entry) => store.setStaged(path, entry)}
-            onStage={(path) => store.stage(path)}
-            onUnstage={(path) => store.unstage(path)}
-            onRestore={dropChange}
           />
         </Suspense>
       ) : (

--- a/apps/os/src/components/repo-ide/repo-ide.tsx
+++ b/apps/os/src/components/repo-ide/repo-ide.tsx
@@ -339,6 +339,8 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
             selectedPath={selectedPath}
             onPatchSearch={patchSearch}
             onSetWorking={(path, entry) => store.setWorking(path, entry)}
+            onSetStaged={(path, entry) => store.setStaged(path, entry)}
+            onDelete={removePath}
           />
         </Suspense>
       ) : (

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -619,27 +619,22 @@ function TaskEditorSheet({
   const taskPath = task?.path;
   useEffect(() => {
     if (taskPath === undefined) return;
-    const frame = requestAnimationFrame(() => {
+    const focusEditor = () => {
       const editor = editorRef.current;
       if (editor === null) return;
       editor.focus();
       editor.setSelectionRange(editor.value.length, editor.value.length);
-    });
-    return () => cancelAnimationFrame(frame);
+    };
+    const frame = requestAnimationFrame(focusEditor);
+    const timeout = window.setTimeout(focusEditor, 250);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.clearTimeout(timeout);
+    };
   }, [taskPath]);
 
   return (
-    <Sheet
-      open={task !== undefined}
-      onOpenChange={onOpenChange}
-      onOpenChangeComplete={(open) => {
-        if (!open) return;
-        const editor = editorRef.current;
-        if (editor === null) return;
-        editor.focus();
-        editor.setSelectionRange(editor.value.length, editor.value.length);
-      }}
-    >
+    <Sheet open={task !== undefined} onOpenChange={onOpenChange}>
       {task === undefined ? null : (
         <SheetContent
           initialFocus={editorRef}

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -500,7 +500,7 @@ function TaskColumn({
         <div className="group/task-footer mt-auto min-h-16 pt-3 pb-2">
           <Button
             variant="ghost"
-            className="h-10 w-full border border-dashed border-border/70 text-muted-foreground/60 opacity-100 transition-[opacity,background-color,color] pointer-fine:opacity-0 group-hover/task-footer:opacity-100 focus-visible:opacity-100 hover:bg-muted/70 hover:text-muted-foreground"
+            className="h-10 w-full border border-dashed border-border/70 text-muted-foreground/60 opacity-100 transition-[opacity,background-color,color] pointer-fine:opacity-0 group-hover/task-footer:opacity-100! focus-visible:opacity-100! hover:bg-muted/70 hover:text-muted-foreground"
             title={`Add task to ${creationLabel}`}
             aria-label={`Add task to ${creationLabel}`}
             onClick={onCreate}

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -5,9 +5,21 @@ import {
   CircleDashedIcon,
   CircleDotDashedIcon,
   CircleIcon,
+  FolderIcon,
   PlusIcon,
-  XIcon,
+  SearchIcon,
+  Trash2Icon,
 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@iterate-com/ui/components/alert-dialog";
 import { Badge } from "@iterate-com/ui/components/badge";
 import { Button } from "@iterate-com/ui/components/button";
 import { Input } from "@iterate-com/ui/components/input";
@@ -34,9 +46,10 @@ import {
   isRepoTaskPath,
   parseRepoTask,
   repoTaskCreationPaths,
+  repoTaskPathInDirectory,
+  taskDirectoryForFolder,
   taskStateColumns,
   taskStateLabel,
-  updateRepoTaskLabels,
   updateRepoTaskState,
   type RepoTask,
 } from "./repo-tasks.ts";
@@ -50,6 +63,8 @@ type SearchPatch = {
   staged?: boolean;
 };
 
+type GroupMode = "state" | "folder";
+
 export function RepoTasksView({
   projectId,
   repoPath,
@@ -59,6 +74,8 @@ export function RepoTasksView({
   selectedPath,
   onPatchSearch,
   onSetWorking,
+  onSetStaged,
+  onDelete,
 }: {
   projectId: string;
   repoPath: string;
@@ -68,6 +85,8 @@ export function RepoTasksView({
   selectedPath: string | undefined;
   onPatchSearch: (patch: SearchPatch) => void;
   onSetWorking: (path: string, entry: FileEntry | undefined) => void;
+  onSetStaged: (path: string, entry: FileEntry | undefined) => void;
+  onDelete: (path: string) => void;
 }) {
   const headTaskPaths = useMemo(() => headPaths.filter(isRepoTaskPath), [headPaths]);
   const headContents = useItxQuery({
@@ -117,14 +136,34 @@ export function RepoTasksView({
   };
   const selectTask = (path: string | undefined) =>
     onPatchSearch({ file: path, diff: undefined, preview: undefined, staged: undefined });
-  const createTask = (title: string, state: string) => {
-    const created = createRepoTask(title, effectivePaths);
+  const createTask = (title: string, state: string, folderPath: string) => {
+    const created = createRepoTask(title, effectivePaths, taskDirectoryForFolder(folderPath));
     if (created === null) return false;
     const content =
       state === "todo" ? created.content : updateRepoTaskState(created.content, state);
     onSetWorking(created.path, { type: "write", content });
     selectTask(created.path);
     return true;
+  };
+  const deleteTask = (task: RepoTask) => {
+    onSetStaged(task.path, undefined);
+    onDelete(task.path);
+    selectTask(undefined);
+  };
+  const moveTaskToFolder = (task: RepoTask, folderPath: string) => {
+    const targetPath = repoTaskPathInDirectory(
+      task.path,
+      taskDirectoryForFolder(folderPath),
+      effectivePaths,
+    );
+    if (targetPath === task.path) return;
+
+    const wasSelected = selectedPath === task.path;
+    onSetStaged(task.path, undefined);
+    onDelete(task.path);
+    onSetStaged(targetPath, undefined);
+    onSetWorking(targetPath, { type: "write", content: task.content });
+    if (wasSelected) selectTask(targetPath);
   };
 
   return (
@@ -133,7 +172,8 @@ export function RepoTasksView({
         tasks={tasks}
         columns={columns}
         onOpen={(task) => selectTask(task.path)}
-        onMove={(task, state) => writeTask(task, updateRepoTaskState(task.content, state))}
+        onMoveState={(task, state) => writeTask(task, updateRepoTaskState(task.content, state))}
+        onMoveFolder={moveTaskToFolder}
         onCreate={createTask}
       />
       <TaskEditorSheet
@@ -149,9 +189,8 @@ export function RepoTasksView({
           if (selectedTask !== undefined)
             writeTask(selectedTask, updateRepoTaskState(selectedTask.content, state));
         }}
-        onChangeLabels={(labels) => {
-          if (selectedTask !== undefined)
-            writeTask(selectedTask, updateRepoTaskLabels(selectedTask.content, labels));
+        onDelete={() => {
+          if (selectedTask !== undefined) deleteTask(selectedTask);
         }}
       />
     </div>
@@ -162,16 +201,40 @@ function TaskBoard({
   tasks,
   columns,
   onOpen,
-  onMove,
+  onMoveState,
+  onMoveFolder,
   onCreate,
 }: {
   tasks: readonly RepoTask[];
   columns: readonly string[];
   onOpen: (task: RepoTask) => void;
-  onMove: (task: RepoTask, state: string) => void;
-  onCreate: (title: string, state: string) => boolean;
+  onMoveState: (task: RepoTask, state: string) => void;
+  onMoveFolder: (task: RepoTask, folderPath: string) => void;
+  onCreate: (title: string, state: string, folderPath: string) => boolean;
 }) {
+  const [groupMode, setGroupMode] = useState<GroupMode>("state");
+  const [filter, setFilter] = useState("");
   const draggedPathRef = useRef<string | undefined>(undefined);
+  const filteredTasks = useMemo(() => {
+    const query = filter.trim().toLocaleLowerCase();
+    if (query === "") return tasks;
+    return tasks.filter((task) =>
+      [task.title, task.description, task.state, task.folderPath, ...task.labels].some((value) =>
+        value.toLocaleLowerCase().includes(query),
+      ),
+    );
+  }, [filter, tasks]);
+  const folderPaths = useMemo(() => {
+    const paths = [...new Set(tasks.map((task) => task.folderPath))];
+    if (paths.length === 0) return ["/"];
+    return paths.sort((left, right) => {
+      if (left === "/") return -1;
+      if (right === "/") return 1;
+      return left.localeCompare(right);
+    });
+  }, [tasks]);
+  const groups = groupMode === "state" ? columns : folderPaths;
+
   return (
     <DragDropProvider
       onDragStart={(event) => {
@@ -181,48 +244,97 @@ function TaskBoard({
         const path = String(event.operation.source?.id ?? "");
         if (!event.canceled) {
           const targetId = String(event.operation.target?.id ?? "");
-          const state = targetId.startsWith("task-state:")
-            ? targetId.slice("task-state:".length)
-            : "";
           const task = tasks.find((candidate) => candidate.path === path);
-          if (task !== undefined && state !== "" && task.state !== state) onMove(task, state);
+          if (task !== undefined && targetId.startsWith("task-state:")) {
+            const state = targetId.slice("task-state:".length);
+            if (state !== "" && task.state !== state) onMoveState(task, state);
+          } else if (task !== undefined && targetId.startsWith("task-folder:")) {
+            const folderPath = targetId.slice("task-folder:".length);
+            if (folderPath !== "" && task.folderPath !== folderPath) onMoveFolder(task, folderPath);
+          }
         }
         setTimeout(() => {
           if (draggedPathRef.current === path) draggedPathRef.current = undefined;
         });
       }}
     >
-      <div className="flex min-h-0 min-w-0 flex-1 gap-2 overflow-x-auto bg-muted/30 p-2">
-        {columns.map((state) => (
-          <TaskColumn
-            key={state}
-            state={state}
-            tasks={tasks.filter((task) => task.state === state)}
-            onOpen={(task) => {
-              if (draggedPathRef.current !== task.path) onOpen(task);
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-muted/30">
+        <div className="flex shrink-0 items-center gap-2 border-b bg-background px-2 py-2">
+          <div className="relative min-w-0 flex-1 sm:max-w-sm">
+            <SearchIcon
+              aria-hidden
+              className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              value={filter}
+              onChange={(event) => setFilter(event.currentTarget.value)}
+              aria-label="Filter tasks"
+              placeholder="Filter tasks"
+              className="h-8 bg-background pl-8"
+            />
+          </div>
+          <Select
+            value={groupMode}
+            onValueChange={(value) => {
+              if (value === "state" || value === "folder") setGroupMode(value);
             }}
-            onCreate={onCreate}
-          />
-        ))}
+          >
+            <SelectTrigger aria-label="Group tasks by" className="w-28 shrink-0">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectLabel>Group by</SelectLabel>
+                <SelectItem value="state">State</SelectItem>
+                <SelectItem value="folder">Folder</SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <span className="hidden shrink-0 text-xs tabular-nums text-muted-foreground sm:inline">
+            {filteredTasks.length} {filteredTasks.length === 1 ? "task" : "tasks"}
+          </span>
+        </div>
+        <div className="flex min-h-0 min-w-0 flex-1 snap-x snap-mandatory gap-2 overflow-x-auto p-2 sm:snap-none">
+          {groups.map((group) => (
+            <TaskColumn
+              key={`${groupMode}:${group}`}
+              groupMode={groupMode}
+              group={group}
+              tasks={filteredTasks.filter((task) =>
+                groupMode === "state" ? task.state === group : task.folderPath === group,
+              )}
+              onOpen={(task) => {
+                if (draggedPathRef.current !== task.path) onOpen(task);
+              }}
+              onCreate={(title) =>
+                groupMode === "state" ? onCreate(title, group, "/") : onCreate(title, "todo", group)
+              }
+            />
+          ))}
+        </div>
       </div>
     </DragDropProvider>
   );
 }
 
 function TaskColumn({
-  state,
+  groupMode,
+  group,
   tasks,
   onOpen,
   onCreate,
 }: {
-  state: string;
+  groupMode: GroupMode;
+  group: string;
   tasks: readonly RepoTask[];
   onOpen: (task: RepoTask) => void;
-  onCreate: (title: string, state: string) => boolean;
+  onCreate: (title: string) => boolean;
 }) {
-  const { ref, isDropTarget } = useDroppable({ id: `task-state:${state}`, accept: "repo-task" });
+  const dropId = `task-${groupMode}:${group}`;
+  const { ref, isDropTarget } = useDroppable({ id: dropId, accept: "repo-task" });
   const [creating, setCreating] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const label = groupMode === "state" ? taskStateLabel(group) : group;
   useEffect(() => {
     if (!creating) return;
     const frame = requestAnimationFrame(() => inputRef.current?.focus());
@@ -232,23 +344,27 @@ function TaskColumn({
   return (
     <section
       ref={ref}
-      data-task-state={state}
+      data-task-group={dropId}
       className={cn(
-        "flex min-h-full min-w-72 flex-1 basis-72 flex-col rounded-lg bg-background/70 transition-colors",
+        "flex min-h-full min-w-[calc(100vw-1rem)] flex-1 basis-72 snap-start flex-col rounded-lg bg-background/70 transition-colors sm:min-w-72",
         isDropTarget && "bg-accent/40",
       )}
     >
       <header className="flex h-12 shrink-0 items-center justify-between px-3">
         <div className="flex min-w-0 items-center gap-2">
-          <TaskStateIcon state={state} />
-          <h2 className="truncate text-sm font-medium">{taskStateLabel(state)}</h2>
+          {groupMode === "state" ? (
+            <TaskStateIcon state={group} />
+          ) : (
+            <FolderIcon aria-hidden className="size-4 shrink-0 text-muted-foreground" />
+          )}
+          <h2 className="truncate text-sm font-medium">{label}</h2>
           <span className="text-xs tabular-nums text-muted-foreground">{tasks.length}</span>
         </div>
         <Button
           variant="ghost"
           size="icon-sm"
-          title={`Add task to ${taskStateLabel(state)}`}
-          aria-label={`Add task to ${taskStateLabel(state)}`}
+          title={`Add task to ${label}`}
+          aria-label={`Add task to ${label}`}
           onClick={() => setCreating(true)}
         >
           <PlusIcon data-icon="inline-start" />
@@ -261,12 +377,12 @@ function TaskColumn({
             onSubmit={(event) => {
               event.preventDefault();
               const title = String(new FormData(event.currentTarget).get("title") ?? "");
-              if (onCreate(title, state)) setCreating(false);
+              if (onCreate(title)) setCreating(false);
             }}
           >
             <Input
               ref={inputRef}
-              aria-label={`New ${taskStateLabel(state)} task title`}
+              aria-label={`New ${label} task title`}
               name="title"
               placeholder="Task title"
               onKeyDown={(event) => {
@@ -300,6 +416,10 @@ function TaskCard({ task, onOpen }: { task: RepoTask; onOpen: (task: RepoTask) =
         isDragging && "opacity-40 shadow-none",
       )}
     >
+      <div className="mb-2 flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
+        <FolderIcon aria-hidden className="size-3 shrink-0" />
+        <span className="truncate font-mono">{task.folderPath}</span>
+      </div>
       <div className="flex items-start gap-2">
         <TaskStateIcon state={task.state} className="mt-0.5" />
         <span className="min-w-0 flex-1 text-sm font-medium leading-snug">{task.title}</span>
@@ -307,16 +427,15 @@ function TaskCard({ task, onOpen }: { task: RepoTask; onOpen: (task: RepoTask) =
       {summary === "" ? null : (
         <p className="mt-2 line-clamp-2 text-xs leading-relaxed text-muted-foreground">{summary}</p>
       )}
-      <div className="mt-3 flex min-w-0 flex-wrap items-center gap-1.5">
-        <span className="truncate font-mono text-[10px] text-muted-foreground">
-          {task.labels[0]}
-        </span>
-        {task.explicitLabels.map((label) => (
-          <Badge key={label} variant="secondary">
-            {label}
-          </Badge>
-        ))}
-      </div>
+      {task.labels.length === 0 ? null : (
+        <div className="mt-3 flex min-w-0 flex-wrap items-center gap-1.5">
+          {task.labels.map((label) => (
+            <Badge key={label} variant="secondary">
+              {label}
+            </Badge>
+          ))}
+        </div>
+      )}
     </button>
   );
 }
@@ -345,16 +464,17 @@ function TaskEditorSheet({
   onOpenChange,
   onChangeContent,
   onChangeState,
-  onChangeLabels,
+  onDelete,
 }: {
   task: RepoTask | undefined;
   columns: readonly string[];
   onOpenChange: (open: boolean) => void;
   onChangeContent: (content: string) => void;
   onChangeState: (state: string) => void;
-  onChangeLabels: (labels: string[]) => void;
+  onDelete: () => void;
 }) {
   const editorRef = useRef<HTMLTextAreaElement>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const taskPath = task?.path;
   useEffect(() => {
     if (taskPath === undefined) return;
@@ -371,11 +491,11 @@ function TaskEditorSheet({
         >
           <SheetHeader className="shrink-0 border-b pr-14">
             <SheetTitle>{task.title}</SheetTitle>
-            <SheetDescription className="font-mono text-xs">{task.path}</SheetDescription>
+            <SheetDescription className="truncate font-mono text-xs">{task.path}</SheetDescription>
           </SheetHeader>
-          <div className="flex shrink-0 flex-wrap items-center gap-2 border-b px-4 py-2">
+          <div className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
             <Select value={task.state} onValueChange={(value) => value && onChangeState(value)}>
-              <SelectTrigger aria-label="Task state" size="sm" className="w-36">
+              <SelectTrigger aria-label="Task state" size="sm" className="w-32 shrink-0">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -389,44 +509,20 @@ function TaskEditorSheet({
                 </SelectGroup>
               </SelectContent>
             </Select>
-            <Badge variant="outline">{task.labels[0]}</Badge>
-            {task.explicitLabels.map((label) => (
-              <span key={label} className="flex items-center gap-0.5">
-                <Badge variant="secondary">{label}</Badge>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  title={`Remove ${label}`}
-                  aria-label={`Remove ${label}`}
-                  onClick={() =>
-                    onChangeLabels(task.explicitLabels.filter((candidate) => candidate !== label))
-                  }
-                >
-                  <XIcon data-icon="inline-start" />
-                </Button>
-              </span>
-            ))}
-            <form
-              className="ml-auto flex items-center gap-1"
-              onSubmit={(event) => {
-                event.preventDefault();
-                const form = event.currentTarget;
-                const label = String(new FormData(form).get("label") ?? "").trim();
-                if (label === "") return;
-                onChangeLabels([...task.explicitLabels, label]);
-                form.reset();
-              }}
+            <div className="flex min-w-0 flex-1 items-center gap-1.5 text-xs text-muted-foreground">
+              <FolderIcon aria-hidden className="size-3.5 shrink-0" />
+              <span className="truncate font-mono">{task.folderPath}</span>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="shrink-0 text-muted-foreground hover:text-destructive"
+              title="Delete task"
+              aria-label="Delete task"
+              onClick={() => setDeleteOpen(true)}
             >
-              <Input
-                aria-label="New task label"
-                name="label"
-                placeholder="Add label"
-                className="h-8 w-28"
-              />
-              <Button type="submit" size="icon-sm" variant="ghost" aria-label="Add label">
-                <PlusIcon data-icon="inline-start" />
-              </Button>
-            </form>
+              <Trash2Icon data-icon="inline-start" />
+            </Button>
           </div>
           <Textarea
             ref={editorRef}
@@ -435,6 +531,29 @@ function TaskEditorSheet({
             onChange={(event) => onChangeContent(event.currentTarget.value)}
             className="min-h-0 flex-1 resize-none rounded-none border-0 px-5 py-4 font-mono text-sm leading-relaxed focus-visible:border-transparent focus-visible:ring-0"
           />
+          <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+            <AlertDialogContent size="sm">
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete {task.title}?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This adds the deletion of {task.path} to Source Control. You can restore it until
+                  you commit.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  variant="destructive"
+                  onClick={() => {
+                    setDeleteOpen(false);
+                    onDelete();
+                  }}
+                >
+                  Delete task
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </SheetContent>
       )}
     </Sheet>

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -326,14 +326,16 @@ function TaskBoard({
               className="h-8 bg-background pl-8"
             />
           </div>
-          <BoardDisplaySettings rowField={rowField} onChangeRowField={setRowField} />
-          <span className="hidden shrink-0 text-xs tabular-nums text-muted-foreground sm:inline">
-            {board.taskCount} {board.taskCount === 1 ? "task" : "tasks"}
-          </span>
+          <div className="ml-auto flex shrink-0 items-center gap-2">
+            <span className="hidden text-xs tabular-nums text-muted-foreground sm:inline">
+              {board.taskCount} {board.taskCount === 1 ? "task" : "tasks"}
+            </span>
+            <BoardDisplaySettings rowField={rowField} onChangeRowField={setRowField} />
+          </div>
         </div>
         <div ref={boardScrollRef} className="min-h-0 min-w-0 flex-1 overflow-auto p-2">
           <div className="flex min-h-full w-max min-w-full flex-col gap-4">
-            {board.rows.map((row) => (
+            {board.rows.map((row, rowIndex) => (
               <section
                 key={row.key}
                 data-task-row={row.key}
@@ -350,9 +352,6 @@ function TaskBoard({
                       <TagIcon aria-hidden className="size-4 shrink-0 text-muted-foreground" />
                     )}
                     <span className="truncate">{row.label}</span>
-                    <span className="text-xs tabular-nums text-muted-foreground">
-                      {row.tasks.length}
-                    </span>
                   </header>
                 )}
                 <div className="flex min-h-0 min-w-full flex-1 snap-x snap-mandatory gap-2 sm:snap-none">
@@ -364,6 +363,7 @@ function TaskBoard({
                       rowLabel={row.label}
                       tasks={cell.tasks}
                       visibleProperties={board.visibleProperties}
+                      showHeader={rowIndex === 0}
                       onOpen={(task) => {
                         if (draggedPathRef.current !== task.path) onOpen(task);
                       }}
@@ -443,6 +443,7 @@ function TaskColumn({
   rowLabel,
   tasks,
   visibleProperties,
+  showHeader,
   onOpen,
   onCreate,
 }: {
@@ -451,6 +452,7 @@ function TaskColumn({
   rowLabel: string | null;
   tasks: readonly RepoTask[];
   visibleProperties: RepoTaskBoardProjection["visibleProperties"];
+  showHeader: boolean;
   onOpen: (task: RepoTask) => void;
   onCreate: () => void;
 }) {
@@ -468,14 +470,16 @@ function TaskColumn({
         isDropTarget && "bg-accent/40",
       )}
     >
-      <header className="flex h-12 shrink-0 items-center px-3">
-        <div className="flex min-w-0 items-center gap-2">
-          <TaskStateIcon state={state} />
-          <h2 className="truncate text-sm font-medium">{label}</h2>
-          <span className="text-xs tabular-nums text-muted-foreground">{tasks.length}</span>
-        </div>
-      </header>
-      <div className="flex min-h-0 flex-1 flex-col px-2 pb-2">
+      {showHeader ? (
+        <header className="flex h-12 shrink-0 items-center px-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <TaskStateIcon state={state} />
+            <h2 className="truncate text-sm font-medium">{label}</h2>
+            <span className="text-xs tabular-nums text-muted-foreground">{tasks.length}</span>
+          </div>
+        </header>
+      ) : null}
+      <div className="flex min-h-0 flex-1 flex-col px-2 pb-1">
         <div className="flex flex-col gap-2">
           {tasks.map((task) => (
             <TaskCard
@@ -487,15 +491,17 @@ function TaskColumn({
             />
           ))}
         </div>
-        <Button
-          variant="ghost"
-          className="mt-2 h-10 w-full text-muted-foreground/50 hover:bg-muted/70 hover:text-muted-foreground"
-          title={`Add task to ${creationLabel}`}
-          aria-label={`Add task to ${creationLabel}`}
-          onClick={onCreate}
-        >
-          <PlusIcon className="size-5" data-icon="inline-start" />
-        </Button>
+        <div className="group/task-footer mt-auto min-h-16 pt-3 pb-2">
+          <Button
+            variant="ghost"
+            className="h-10 w-full border border-dashed border-border/70 text-muted-foreground/60 opacity-100 transition-[opacity,background-color,color] pointer-fine:opacity-0 group-hover/task-footer:opacity-100 focus-visible:opacity-100 hover:bg-muted/70 hover:text-muted-foreground"
+            title={`Add task to ${creationLabel}`}
+            aria-label={`Add task to ${creationLabel}`}
+            onClick={onCreate}
+          >
+            <PlusIcon className="size-5" data-icon="inline-start" />
+          </Button>
+        </div>
       </div>
     </section>
   );

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -149,8 +149,7 @@ export function RepoTasksView({
   const columns = taskStateColumns(tasks);
   const selectedTask = tasks.find((task) => task.path === selectedPath);
   const writeTask = (task: RepoTask, content: string) => {
-    const staged = changes.get(task.path)?.staged;
-    const baseline = staged?.type === "write" ? staged.content : headContents[task.path];
+    const baseline = textContentForEntry(changes.get(task.path)?.staged) ?? headContents[task.path];
     onSetWorking(task.path, content === baseline ? undefined : { type: "write", content });
   };
   const selectTask = (path: string | undefined) =>

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -625,19 +625,15 @@ function TaskEditorSheet({
       editor.focus();
       editor.setSelectionRange(editor.value.length, editor.value.length);
     };
-    const frame = requestAnimationFrame(focusEditor);
     const timeout = window.setTimeout(focusEditor, 250);
-    return () => {
-      cancelAnimationFrame(frame);
-      window.clearTimeout(timeout);
-    };
+    return () => window.clearTimeout(timeout);
   }, [taskPath]);
 
   return (
     <Sheet open={task !== undefined} onOpenChange={onOpenChange}>
       {task === undefined ? null : (
         <SheetContent
-          initialFocus={editorRef}
+          initialFocus={false}
           className="w-full gap-0 p-0 data-[side=right]:sm:w-[60vw] data-[side=right]:sm:max-w-[60vw]"
         >
           <SheetHeader className="shrink-0 border-b pr-14">

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -89,7 +89,6 @@ export function RepoTasksView({
   selectedPath,
   onPatchSearch,
   onSetWorking,
-  onSetStaged,
   onDelete,
 }: {
   projectId: string;
@@ -100,7 +99,6 @@ export function RepoTasksView({
   selectedPath: string | undefined;
   onPatchSearch: (patch: SearchPatch) => void;
   onSetWorking: (path: string, entry: FileEntry | undefined) => void;
-  onSetStaged: (path: string, entry: FileEntry | undefined) => void;
   onDelete: (path: string) => void;
 }) {
   const headTaskPaths = useMemo(() => headPaths.filter(isRepoTaskPath), [headPaths]);
@@ -161,7 +159,6 @@ export function RepoTasksView({
     selectTask(created.path);
   };
   const deleteTask = (task: RepoTask) => {
-    onSetStaged(task.path, undefined);
     onDelete(task.path);
     selectTask(undefined);
   };
@@ -169,9 +166,7 @@ export function RepoTasksView({
     if (targetPath === task.path) return true;
     if (effectivePaths.has(targetPath)) return false;
     const wasSelected = selectedPath === task.path;
-    onSetStaged(task.path, undefined);
     onDelete(task.path);
-    onSetStaged(targetPath, undefined);
     onSetWorking(targetPath, { type: "write", content });
     if (wasSelected) selectTask(targetPath);
     return true;

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -5,6 +5,7 @@ import {
   CircleDashedIcon,
   CircleDotDashedIcon,
   CircleIcon,
+  FilePenLineIcon,
   FolderIcon,
   PlusIcon,
   SearchIcon,
@@ -61,6 +62,7 @@ type SearchPatch = {
   diff?: boolean;
   preview?: boolean;
   staged?: boolean;
+  tasks?: boolean;
 };
 
 type GroupMode = "state" | "folder";
@@ -136,19 +138,29 @@ export function RepoTasksView({
   };
   const selectTask = (path: string | undefined) =>
     onPatchSearch({ file: path, diff: undefined, preview: undefined, staged: undefined });
-  const createTask = (title: string, state: string, folderPath: string) => {
-    const created = createRepoTask(title, effectivePaths, taskDirectoryForFolder(folderPath));
-    if (created === null) return false;
-    const content =
-      state === "todo" ? created.content : updateRepoTaskState(created.content, state);
+  const createTask = (state: string, folderPath: string) => {
+    const created = createRepoTask("New task", effectivePaths, taskDirectoryForFolder(folderPath));
+    if (created === null) return;
+    const initialContent = `${created.content}\n`;
+    const content = state === "todo" ? initialContent : updateRepoTaskState(initialContent, state);
     onSetWorking(created.path, { type: "write", content });
     selectTask(created.path);
-    return true;
   };
   const deleteTask = (task: RepoTask) => {
     onSetStaged(task.path, undefined);
     onDelete(task.path);
     selectTask(undefined);
+  };
+  const moveTaskToPath = (task: RepoTask, targetPath: string) => {
+    if (targetPath === task.path) return true;
+    if (effectivePaths.has(targetPath)) return false;
+    const wasSelected = selectedPath === task.path;
+    onSetStaged(task.path, undefined);
+    onDelete(task.path);
+    onSetStaged(targetPath, undefined);
+    onSetWorking(targetPath, { type: "write", content: task.content });
+    if (wasSelected) selectTask(targetPath);
+    return true;
   };
   const moveTaskToFolder = (task: RepoTask, folderPath: string) => {
     const targetPath = repoTaskPathInDirectory(
@@ -156,14 +168,17 @@ export function RepoTasksView({
       taskDirectoryForFolder(folderPath),
       effectivePaths,
     );
-    if (targetPath === task.path) return;
-
-    const wasSelected = selectedPath === task.path;
-    onSetStaged(task.path, undefined);
-    onDelete(task.path);
-    onSetStaged(targetPath, undefined);
-    onSetWorking(targetPath, { type: "write", content: task.content });
-    if (wasSelected) selectTask(targetPath);
+    moveTaskToPath(task, targetPath);
+  };
+  const renameTask = (task: RepoTask, path: string) => {
+    const targetPath = path.trim().replace(/^\/+/, "");
+    const segments = targetPath.split("/");
+    if (
+      !isRepoTaskPath(targetPath) ||
+      segments.some((segment) => segment === "" || segment === "." || segment === "..")
+    )
+      return false;
+    return moveTaskToPath(task, targetPath);
   };
 
   return (
@@ -189,6 +204,19 @@ export function RepoTasksView({
           if (selectedTask !== undefined)
             writeTask(selectedTask, updateRepoTaskState(selectedTask.content, state));
         }}
+        onRenamePath={(path) =>
+          selectedTask === undefined ? false : renameTask(selectedTask, path)
+        }
+        onOpenInEditor={() => {
+          if (selectedTask !== undefined)
+            onPatchSearch({
+              file: selectedTask.path,
+              tasks: undefined,
+              diff: undefined,
+              preview: undefined,
+              staged: undefined,
+            });
+        }}
         onDelete={() => {
           if (selectedTask !== undefined) deleteTask(selectedTask);
         }}
@@ -210,7 +238,7 @@ function TaskBoard({
   onOpen: (task: RepoTask) => void;
   onMoveState: (task: RepoTask, state: string) => void;
   onMoveFolder: (task: RepoTask, folderPath: string) => void;
-  onCreate: (title: string, state: string, folderPath: string) => boolean;
+  onCreate: (state: string, folderPath: string) => void;
 }) {
   const [groupMode, setGroupMode] = useState<GroupMode>("state");
   const [filter, setFilter] = useState("");
@@ -313,8 +341,8 @@ function TaskBoard({
               onOpen={(task) => {
                 if (draggedPathRef.current !== task.path) onOpen(task);
               }}
-              onCreate={(title) =>
-                groupMode === "state" ? onCreate(title, group, "/") : onCreate(title, "todo", group)
+              onCreate={() =>
+                groupMode === "state" ? onCreate(group, "/") : onCreate("todo", group)
               }
             />
           ))}
@@ -335,18 +363,11 @@ function TaskColumn({
   group: string;
   tasks: readonly RepoTask[];
   onOpen: (task: RepoTask) => void;
-  onCreate: (title: string) => boolean;
+  onCreate: () => void;
 }) {
   const dropId = `task-${groupMode}:${group}`;
   const { ref, isDropTarget } = useDroppable({ id: dropId, accept: "repo-task" });
-  const [creating, setCreating] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
   const label = groupMode === "state" ? taskStateLabel(group) : group;
-  useEffect(() => {
-    if (!creating) return;
-    const frame = requestAnimationFrame(() => inputRef.current?.focus());
-    return () => cancelAnimationFrame(frame);
-  }, [creating]);
 
   return (
     <section
@@ -357,7 +378,7 @@ function TaskColumn({
         isDropTarget && "bg-accent/40",
       )}
     >
-      <header className="flex h-12 shrink-0 items-center justify-between px-3">
+      <header className="flex h-12 shrink-0 items-center px-3">
         <div className="flex min-w-0 items-center gap-2">
           {groupMode === "state" ? (
             <TaskStateIcon state={group} />
@@ -367,42 +388,22 @@ function TaskColumn({
           <h2 className="truncate text-sm font-medium">{label}</h2>
           <span className="text-xs tabular-nums text-muted-foreground">{tasks.length}</span>
         </div>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          title={`Add task to ${label}`}
-          aria-label={`Add task to ${label}`}
-          onClick={() => setCreating(true)}
-        >
-          <PlusIcon data-icon="inline-start" />
-        </Button>
       </header>
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2 pb-2">
-        {creating ? (
-          <form
-            className="mb-2 rounded-lg border bg-card p-2 shadow-xs"
-            onSubmit={(event) => {
-              event.preventDefault();
-              const title = String(new FormData(event.currentTarget).get("title") ?? "");
-              if (onCreate(title)) setCreating(false);
-            }}
-          >
-            <Input
-              ref={inputRef}
-              aria-label={`New ${label} task title`}
-              name="title"
-              placeholder="Task title"
-              onKeyDown={(event) => {
-                if (event.key === "Escape") setCreating(false);
-              }}
-            />
-          </form>
-        ) : null}
         <div className="flex flex-col gap-2">
           {tasks.map((task) => (
             <TaskCard key={task.path} task={task} onOpen={onOpen} />
           ))}
         </div>
+        <Button
+          variant="ghost"
+          className="mt-2 h-10 w-full text-muted-foreground/50 hover:bg-muted/70 hover:text-muted-foreground"
+          title={`Add task to ${label}`}
+          aria-label={`Add task to ${label}`}
+          onClick={onCreate}
+        >
+          <PlusIcon className="size-5" data-icon="inline-start" />
+        </Button>
       </div>
     </section>
   );
@@ -471,6 +472,8 @@ function TaskEditorSheet({
   onOpenChange,
   onChangeContent,
   onChangeState,
+  onRenamePath,
+  onOpenInEditor,
   onDelete,
 }: {
   task: RepoTask | undefined;
@@ -478,6 +481,8 @@ function TaskEditorSheet({
   onOpenChange: (open: boolean) => void;
   onChangeContent: (content: string) => void;
   onChangeState: (state: string) => void;
+  onRenamePath: (path: string) => boolean;
+  onOpenInEditor: () => void;
   onDelete: () => void;
 }) {
   const editorRef = useRef<HTMLTextAreaElement>(null);
@@ -485,7 +490,12 @@ function TaskEditorSheet({
   const taskPath = task?.path;
   useEffect(() => {
     if (taskPath === undefined) return;
-    const frame = requestAnimationFrame(() => editorRef.current?.focus());
+    const frame = requestAnimationFrame(() => {
+      const editor = editorRef.current;
+      if (editor === null) return;
+      editor.focus();
+      editor.setSelectionRange(editor.value.length, editor.value.length);
+    });
     return () => cancelAnimationFrame(frame);
   }, [taskPath]);
 
@@ -498,7 +508,28 @@ function TaskEditorSheet({
         >
           <SheetHeader className="shrink-0 border-b pr-14">
             <SheetTitle>{task.title}</SheetTitle>
-            <SheetDescription className="truncate font-mono text-xs">{task.path}</SheetDescription>
+            <SheetDescription className="sr-only">
+              Edit the task Markdown and file metadata.
+            </SheetDescription>
+            <Input
+              key={task.path}
+              defaultValue={`/${task.path}`}
+              aria-label="Task file path"
+              className="h-6 rounded-none border-0 px-0 font-mono text-xs text-muted-foreground shadow-none focus-visible:ring-0"
+              onBlur={(event) => {
+                if (!onRenamePath(event.currentTarget.value))
+                  event.currentTarget.value = `/${task.path}`;
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  event.currentTarget.blur();
+                } else if (event.key === "Escape") {
+                  event.currentTarget.value = `/${task.path}`;
+                  event.currentTarget.blur();
+                }
+              }}
+            />
           </SheetHeader>
           <div className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
             <Select value={task.state} onValueChange={(value) => value && onChangeState(value)}>
@@ -520,6 +551,16 @@ function TaskEditorSheet({
               <FolderIcon aria-hidden className="size-3.5 shrink-0" />
               <span className="truncate font-mono">{task.folderPath}</span>
             </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="shrink-0 text-muted-foreground"
+              title="Open in editor"
+              onClick={onOpenInEditor}
+            >
+              <FilePenLineIcon data-icon="inline-start" />
+              Editor
+            </Button>
             <Button
               variant="ghost"
               size="icon-sm"

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -1,25 +1,9 @@
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { DragDropProvider, useDraggable, useDroppable } from "@dnd-kit/react";
 import { GripVerticalIcon, ListTodoIcon, PlusIcon, XIcon } from "lucide-react";
 import { Badge } from "@iterate-com/ui/components/badge";
 import { Button } from "@iterate-com/ui/components/button";
-import {
-  Card,
-  CardAction,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@iterate-com/ui/components/card";
-import { Empty, EmptyHeader, EmptyTitle } from "@iterate-com/ui/components/empty";
-import { Field, FieldGroup, FieldLabel } from "@iterate-com/ui/components/field";
 import { Input } from "@iterate-com/ui/components/input";
-import {
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from "@iterate-com/ui/components/resizable";
 import {
   Select,
   SelectContent,
@@ -29,8 +13,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@iterate-com/ui/components/select";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@iterate-com/ui/components/sheet";
+import { Textarea } from "@iterate-com/ui/components/textarea";
 import { cn } from "@iterate-com/ui/lib/utils";
-import { RepoEditorPane } from "./repo-editor-pane.tsx";
 import {
   createRepoTask,
   isRepoTaskPath,
@@ -59,15 +50,8 @@ export function RepoTasksView({
   headPaths,
   changes,
   selectedPath,
-  diffOpen,
-  previewOpen,
-  stagedView,
   onPatchSearch,
   onSetWorking,
-  onSetStaged,
-  onStage,
-  onUnstage,
-  onRestore,
 }: {
   projectId: string;
   repoPath: string;
@@ -75,15 +59,8 @@ export function RepoTasksView({
   headPaths: readonly string[];
   changes: WorkingTreeChanges;
   selectedPath: string | undefined;
-  diffOpen: boolean;
-  previewOpen: boolean;
-  stagedView: boolean;
   onPatchSearch: (patch: SearchPatch) => void;
   onSetWorking: (path: string, entry: FileEntry | undefined) => void;
-  onSetStaged: (path: string, entry: FileEntry | undefined) => void;
-  onStage: (path: string) => void;
-  onUnstage: (path: string) => void;
-  onRestore: (path: string) => void;
 }) {
   const headTaskPaths = useMemo(() => headPaths.filter(isRepoTaskPath), [headPaths]);
   const headContents = useItxQuery({
@@ -135,201 +112,80 @@ export function RepoTasksView({
     onPatchSearch({ file: path, diff: undefined, preview: undefined, staged: undefined });
 
   return (
-    <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
-      <ResizablePanel defaultSize="20%" minSize="12rem" className="min-w-0">
-        <TasksSidebar
-          tasks={tasks}
-          columns={columns}
-          selectedTask={selectedTask}
-          onShowBoard={() => selectTask(undefined)}
-          onCreate={(title, reset) => {
-            const created = createRepoTask(title, effectivePaths);
-            if (created === null) return;
-            onSetWorking(created.path, { type: "write", content: created.content });
-            reset();
-            selectTask(created.path);
-          }}
-          onChangeState={(state) => {
-            if (selectedTask !== undefined)
-              writeTask(selectedTask, updateRepoTaskState(selectedTask.content, state));
-          }}
-          onChangeLabels={(labels) => {
-            if (selectedTask !== undefined)
-              writeTask(selectedTask, updateRepoTaskLabels(selectedTask.content, labels));
-          }}
-        />
-      </ResizablePanel>
-      <ResizableHandle />
-      <ResizablePanel className="flex min-w-0 flex-col">
-        {selectedTask === undefined ? (
-          <TaskBoard
-            tasks={tasks}
-            columns={columns}
-            onOpen={(task) => selectTask(task.path)}
-            onMove={(task, state) => writeTask(task, updateRepoTaskState(task.content, state))}
-          />
-        ) : (
-          <RepoEditorPane
-            key={selectedTask.path}
-            projectId={projectId}
-            repoPath={repoPath}
-            path={selectedTask.path}
-            headCommitOid={headCommitOid}
-            headHasPath={headPaths.includes(selectedTask.path)}
-            change={changes.get(selectedTask.path)}
-            diffOpen={diffOpen}
-            onToggleDiff={(open) =>
-              onPatchSearch({ diff: open ? true : undefined, preview: undefined })
-            }
-            previewOpen={previewOpen}
-            onTogglePreview={(open) =>
-              onPatchSearch({ preview: open ? true : undefined, diff: undefined })
-            }
-            onSetWorking={(entry) => onSetWorking(selectedTask.path, entry)}
-            onSetStaged={(entry) => onSetStaged(selectedTask.path, entry)}
-            onStageFile={() => onStage(selectedTask.path)}
-            onUnstageFile={() => {
-              onUnstage(selectedTask.path);
-              onPatchSearch({ staged: undefined });
-            }}
-            onOpenWorking={() =>
-              onPatchSearch({ staged: undefined, diff: undefined, preview: undefined })
-            }
-            stagedView={stagedView && changes.get(selectedTask.path)?.staged !== undefined}
-            onRestore={() => onRestore(selectedTask.path)}
-          />
-        )}
-      </ResizablePanel>
-    </ResizablePanelGroup>
+    <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+      <TasksSidebar
+        taskCount={tasks.length}
+        onCreate={(title, reset) => {
+          const created = createRepoTask(title, effectivePaths);
+          if (created === null) return;
+          onSetWorking(created.path, { type: "write", content: created.content });
+          reset();
+          selectTask(created.path);
+        }}
+      />
+      <TaskBoard
+        tasks={tasks}
+        columns={columns}
+        onOpen={(task) => selectTask(task.path)}
+        onMove={(task, state) => writeTask(task, updateRepoTaskState(task.content, state))}
+      />
+      <TaskEditorSheet
+        task={selectedTask}
+        columns={columns}
+        onOpenChange={(open) => {
+          if (!open) selectTask(undefined);
+        }}
+        onChangeContent={(content) => {
+          if (selectedTask !== undefined) writeTask(selectedTask, content);
+        }}
+        onChangeState={(state) => {
+          if (selectedTask !== undefined)
+            writeTask(selectedTask, updateRepoTaskState(selectedTask.content, state));
+        }}
+        onChangeLabels={(labels) => {
+          if (selectedTask !== undefined)
+            writeTask(selectedTask, updateRepoTaskLabels(selectedTask.content, labels));
+        }}
+      />
+    </div>
   );
 }
 
 function TasksSidebar({
-  tasks,
-  columns,
-  selectedTask,
-  onShowBoard,
+  taskCount,
   onCreate,
-  onChangeState,
-  onChangeLabels,
 }: {
-  tasks: readonly RepoTask[];
-  columns: readonly string[];
-  selectedTask: RepoTask | undefined;
-  onShowBoard: () => void;
+  taskCount: number;
   onCreate: (title: string, reset: () => void) => void;
-  onChangeState: (state: string) => void;
-  onChangeLabels: (labels: string[]) => void;
 }) {
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      <div className="flex items-center justify-between border-b p-3">
+    <aside className="flex shrink-0 items-center gap-3 border-b p-3 md:h-full md:w-60 md:flex-col md:items-stretch md:border-r md:border-b-0">
+      <div className="flex items-center gap-2 md:justify-between">
         <div className="flex items-center gap-2">
-          <ListTodoIcon />
+          <ListTodoIcon className="size-4" />
           <span className="text-sm font-medium">Tasks</span>
         </div>
-        <Badge variant="secondary">{tasks.length}</Badge>
+        <Badge variant="secondary">{taskCount}</Badge>
       </div>
-      <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto p-3">
-        <Button
-          variant={selectedTask === undefined ? "secondary" : "ghost"}
-          className="w-full justify-start"
-          onClick={onShowBoard}
-        >
-          Board
+      <form
+        className="flex min-w-0 flex-1 gap-2 md:flex-none"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const form = event.currentTarget;
+          onCreate(String(new FormData(form).get("title") ?? ""), () => form.reset());
+        }}
+      >
+        <Input
+          aria-label="New task title"
+          name="title"
+          placeholder="New task"
+          className="min-w-0"
+        />
+        <Button type="submit" size="icon" title="Create task" aria-label="Create task">
+          <PlusIcon data-icon="inline-start" />
         </Button>
-
-        <form
-          onSubmit={(event) => {
-            event.preventDefault();
-            const form = event.currentTarget;
-            onCreate(String(new FormData(form).get("title") ?? ""), () => form.reset());
-          }}
-        >
-          <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="new-task-title">New task</FieldLabel>
-              <div className="flex gap-2">
-                <Input id="new-task-title" name="title" placeholder="Task title" />
-                <Button type="submit" size="icon" title="Create task" aria-label="Create task">
-                  <PlusIcon data-icon="inline-start" />
-                </Button>
-              </div>
-            </Field>
-          </FieldGroup>
-        </form>
-
-        {selectedTask === undefined ? null : (
-          <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="task-state">State</FieldLabel>
-              <Select
-                value={selectedTask.state}
-                onValueChange={(value) => value && onChangeState(value)}
-              >
-                <SelectTrigger id="task-state" className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    <SelectLabel>State</SelectLabel>
-                    {columns.map((state) => (
-                      <SelectItem key={state} value={state}>
-                        {taskStateLabel(state)}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </Field>
-            <Field>
-              <FieldLabel>Labels</FieldLabel>
-              <div className="flex flex-col gap-2">
-                <Badge variant="outline">{selectedTask.labels[0]}</Badge>
-                {selectedTask.explicitLabels.map((label) => (
-                  <div key={label} className="flex items-center justify-between gap-2">
-                    <Badge variant="secondary">{label}</Badge>
-                    <Button
-                      variant="ghost"
-                      size="icon-xs"
-                      title={`Remove ${label}`}
-                      aria-label={`Remove ${label}`}
-                      onClick={() =>
-                        onChangeLabels(
-                          selectedTask.explicitLabels.filter((candidate) => candidate !== label),
-                        )
-                      }
-                    >
-                      <XIcon data-icon="inline-start" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-            </Field>
-            <form
-              onSubmit={(event) => {
-                event.preventDefault();
-                const form = event.currentTarget;
-                const label = String(new FormData(form).get("label") ?? "").trim();
-                if (label === "") return;
-                onChangeLabels([...selectedTask.explicitLabels, label]);
-                form.reset();
-              }}
-            >
-              <Field>
-                <FieldLabel htmlFor="new-task-label">Add label</FieldLabel>
-                <div className="flex gap-2">
-                  <Input id="new-task-label" name="label" placeholder="Label" />
-                  <Button type="submit" size="icon" title="Add label" aria-label="Add label">
-                    <PlusIcon data-icon="inline-start" />
-                  </Button>
-                </div>
-              </Field>
-            </form>
-          </FieldGroup>
-        )}
-      </div>
-    </div>
+      </form>
+    </aside>
   );
 }
 
@@ -357,7 +213,7 @@ function TaskBoard({
         if (task !== undefined && state !== "" && task.state !== state) onMove(task, state);
       }}
     >
-      <div className="flex min-h-0 flex-1 gap-3 overflow-x-auto p-4">
+      <div className="flex min-h-0 min-w-0 flex-1 overflow-x-auto">
         {columns.map((state) => (
           <TaskColumn
             key={state}
@@ -382,63 +238,169 @@ function TaskColumn({
 }) {
   const { ref, isDropTarget } = useDroppable({ id: `task-state:${state}`, accept: "repo-task" });
   return (
-    <Card
+    <section
       ref={ref}
       data-task-state={state}
-      className={cn("min-h-full w-72 shrink-0 self-start", isDropTarget && "ring-2 ring-primary")}
+      className={cn(
+        "flex min-h-full w-72 shrink-0 flex-col border-r last:border-r-0",
+        isDropTarget && "bg-accent/40",
+      )}
     >
-      <CardHeader>
-        <CardTitle>{taskStateLabel(state)}</CardTitle>
-        <CardAction>
-          <Badge variant="secondary">{tasks.length}</Badge>
-        </CardAction>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-2">
+      <header className="flex h-12 shrink-0 items-center justify-between border-b px-4">
+        <h2 className="text-sm font-medium">{taskStateLabel(state)}</h2>
+        <span className="text-xs tabular-nums text-muted-foreground">{tasks.length}</span>
+      </header>
+      <div className="flex flex-1 flex-col">
         {tasks.length === 0 ? (
-          <Empty className="min-h-24 border">
-            <EmptyHeader>
-              <EmptyTitle>No tasks</EmptyTitle>
-            </EmptyHeader>
-          </Empty>
+          <p className="p-4 text-xs text-muted-foreground">Drop tasks here</p>
         ) : (
-          tasks.map((task) => <TaskCard key={task.path} task={task} onOpen={onOpen} />)
+          tasks.map((task) => <TaskRow key={task.path} task={task} onOpen={onOpen} />)
         )}
-      </CardContent>
-    </Card>
+      </div>
+    </section>
   );
 }
 
-function TaskCard({ task, onOpen }: { task: RepoTask; onOpen: (task: RepoTask) => void }) {
+function TaskRow({ task, onOpen }: { task: RepoTask; onOpen: (task: RepoTask) => void }) {
   const { ref, handleRef, isDragging } = useDraggable({ id: task.path, type: "repo-task" });
   const summary = task.description.replace(/\s+/g, " ").slice(0, 160);
   return (
-    <Card ref={ref} size="sm" data-task-path={task.path} className={cn(isDragging && "opacity-50")}>
-      <CardHeader>
-        <CardTitle>
-          <button type="button" className="text-left hover:underline" onClick={() => onOpen(task)}>
+    <article
+      ref={ref}
+      data-task-path={task.path}
+      className={cn(
+        "group border-b px-3 py-3 transition-colors hover:bg-muted/40",
+        isDragging && "opacity-50",
+      )}
+    >
+      <div className="flex items-start gap-1">
+        <Button
+          ref={handleRef}
+          variant="ghost"
+          size="icon-xs"
+          className="mt-0.5 shrink-0 text-muted-foreground opacity-40 group-hover:opacity-100"
+          title={`Drag ${task.title}`}
+          aria-label={`Drag ${task.title}`}
+        >
+          <GripVerticalIcon data-icon="inline-start" />
+        </Button>
+        <div className="min-w-0 flex-1">
+          <button
+            type="button"
+            className="block w-full text-left text-sm font-medium hover:underline"
+            onClick={() => onOpen(task)}
+          >
             {task.title}
           </button>
-        </CardTitle>
-        <CardAction>
-          <Button
-            ref={handleRef}
-            variant="ghost"
-            size="icon-sm"
-            title={`Drag ${task.title}`}
-            aria-label={`Drag ${task.title}`}
-          >
-            <GripVerticalIcon data-icon="inline-start" />
-          </Button>
-        </CardAction>
-        {summary === "" ? null : <CardDescription>{summary}</CardDescription>}
-      </CardHeader>
-      <CardFooter className="flex-wrap gap-1.5">
-        {task.labels.map((label, index) => (
-          <Badge key={label} variant={index === 0 ? "outline" : "secondary"}>
-            {label}
-          </Badge>
-        ))}
-      </CardFooter>
-    </Card>
+          {summary === "" ? null : (
+            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+              {summary}
+            </p>
+          )}
+          <div className="mt-2 flex flex-wrap gap-1">
+            {task.labels.map((label, index) => (
+              <Badge key={label} variant={index === 0 ? "outline" : "secondary"}>
+                {label}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function TaskEditorSheet({
+  task,
+  columns,
+  onOpenChange,
+  onChangeContent,
+  onChangeState,
+  onChangeLabels,
+}: {
+  task: RepoTask | undefined;
+  columns: readonly string[];
+  onOpenChange: (open: boolean) => void;
+  onChangeContent: (content: string) => void;
+  onChangeState: (state: string) => void;
+  onChangeLabels: (labels: string[]) => void;
+}) {
+  const editorRef = useRef<HTMLTextAreaElement>(null);
+  return (
+    <Sheet open={task !== undefined} onOpenChange={onOpenChange}>
+      {task === undefined ? null : (
+        <SheetContent
+          initialFocus={editorRef}
+          className="w-full gap-0 p-0 data-[side=right]:sm:w-[60vw] data-[side=right]:sm:max-w-[60vw]"
+        >
+          <SheetHeader className="shrink-0 border-b pr-14">
+            <SheetTitle>{task.title}</SheetTitle>
+            <SheetDescription className="font-mono text-xs">{task.path}</SheetDescription>
+          </SheetHeader>
+          <div className="flex shrink-0 flex-wrap items-center gap-2 border-b px-4 py-2">
+            <Select value={task.state} onValueChange={(value) => value && onChangeState(value)}>
+              <SelectTrigger aria-label="Task state" size="sm" className="w-36">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectLabel>State</SelectLabel>
+                  {columns.map((state) => (
+                    <SelectItem key={state} value={state}>
+                      {taskStateLabel(state)}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+            <Badge variant="outline">{task.labels[0]}</Badge>
+            {task.explicitLabels.map((label) => (
+              <span key={label} className="flex items-center gap-0.5">
+                <Badge variant="secondary">{label}</Badge>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  title={`Remove ${label}`}
+                  aria-label={`Remove ${label}`}
+                  onClick={() =>
+                    onChangeLabels(task.explicitLabels.filter((candidate) => candidate !== label))
+                  }
+                >
+                  <XIcon data-icon="inline-start" />
+                </Button>
+              </span>
+            ))}
+            <form
+              className="ml-auto flex items-center gap-1"
+              onSubmit={(event) => {
+                event.preventDefault();
+                const form = event.currentTarget;
+                const label = String(new FormData(form).get("label") ?? "").trim();
+                if (label === "") return;
+                onChangeLabels([...task.explicitLabels, label]);
+                form.reset();
+              }}
+            >
+              <Input
+                aria-label="New task label"
+                name="label"
+                placeholder="Add label"
+                className="h-8 w-28"
+              />
+              <Button type="submit" size="icon-sm" variant="ghost" aria-label="Add label">
+                <PlusIcon data-icon="inline-start" />
+              </Button>
+            </form>
+          </div>
+          <Textarea
+            ref={editorRef}
+            aria-label={`Edit ${task.title} Markdown`}
+            value={task.content}
+            onChange={(event) => onChangeContent(event.currentTarget.value)}
+            className="min-h-0 flex-1 resize-none rounded-none border-0 px-5 py-4 font-mono text-sm leading-relaxed focus-visible:border-transparent focus-visible:ring-0"
+          />
+        </SheetContent>
+      )}
+    </Sheet>
   );
 }

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -629,7 +629,17 @@ function TaskEditorSheet({
   }, [taskPath]);
 
   return (
-    <Sheet open={task !== undefined} onOpenChange={onOpenChange}>
+    <Sheet
+      open={task !== undefined}
+      onOpenChange={onOpenChange}
+      onOpenChangeComplete={(open) => {
+        if (!open) return;
+        const editor = editorRef.current;
+        if (editor === null) return;
+        editor.focus();
+        editor.setSelectionRange(editor.value.length, editor.value.length);
+      }}
+    >
       {task === undefined ? null : (
         <SheetContent
           initialFocus={editorRef}

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -69,7 +69,12 @@ import {
   type RepoTaskBoardQuery,
   type RepoTaskBoardRowField,
 } from "./repo-tasks.ts";
-import { effectiveEntry, type FileEntry, type WorkingTreeChanges } from "./staged-changes.ts";
+import {
+  effectiveEntry,
+  textContentForEntry,
+  type FileEntry,
+  type WorkingTreeChanges,
+} from "./staged-changes.ts";
 import { useItxQuery } from "~/itx/itx-react.tsx";
 
 type SearchPatch = {
@@ -122,7 +127,8 @@ export function RepoTasksView({
     for (const [path, change] of changes) {
       if (!isRepoTaskPath(path)) continue;
       const entry = effectiveEntry(change);
-      if (entry?.type === "write") contents.set(path, entry.content);
+      const content = textContentForEntry(entry);
+      if (content !== undefined) contents.set(path, content);
       else if (entry !== undefined) contents.delete(path);
     }
     return [...contents]

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -9,6 +9,8 @@ import {
   FolderIcon,
   PlusIcon,
   SearchIcon,
+  SlidersHorizontalIcon,
+  TagIcon,
   Trash2Icon,
 } from "lucide-react";
 import {
@@ -24,6 +26,14 @@ import {
 import { Badge } from "@iterate-com/ui/components/badge";
 import { Button } from "@iterate-com/ui/components/button";
 import { Input } from "@iterate-com/ui/components/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@iterate-com/ui/components/popover";
 import {
   Select,
   SelectContent,
@@ -46,13 +56,18 @@ import {
   createRepoTask,
   isRepoTaskPath,
   parseRepoTask,
+  queryRepoTaskBoard,
   repoTaskCreationPaths,
   repoTaskPathInDirectory,
   taskDirectoryForFolder,
   taskStateColumns,
   taskStateLabel,
+  updateRepoTaskLabels,
   updateRepoTaskState,
   type RepoTask,
+  type RepoTaskBoardProjection,
+  type RepoTaskBoardQuery,
+  type RepoTaskBoardRowField,
 } from "./repo-tasks.ts";
 import { effectiveEntry, type FileEntry, type WorkingTreeChanges } from "./staged-changes.ts";
 import { useItxQuery } from "~/itx/itx-react.tsx";
@@ -64,8 +79,6 @@ type SearchPatch = {
   staged?: boolean;
   tasks?: boolean;
 };
-
-type GroupMode = "state" | "folder";
 
 export function RepoTasksView({
   projectId,
@@ -138,11 +151,12 @@ export function RepoTasksView({
   };
   const selectTask = (path: string | undefined) =>
     onPatchSearch({ file: path, diff: undefined, preview: undefined, staged: undefined });
-  const createTask = (state: string, folderPath: string) => {
+  const createTask = (state: string, folderPath: string, labels?: readonly string[]) => {
     const created = createRepoTask("New task", effectivePaths, taskDirectoryForFolder(folderPath));
     if (created === null) return;
     const initialContent = `${created.content}\n`;
-    const content = state === "todo" ? initialContent : updateRepoTaskState(initialContent, state);
+    let content = state === "todo" ? initialContent : updateRepoTaskState(initialContent, state);
+    if (labels !== undefined && labels.length > 0) content = updateRepoTaskLabels(content, labels);
     onSetWorking(created.path, { type: "write", content });
     selectTask(created.path);
   };
@@ -151,24 +165,40 @@ export function RepoTasksView({
     onDelete(task.path);
     selectTask(undefined);
   };
-  const moveTaskToPath = (task: RepoTask, targetPath: string) => {
+  const moveTaskToPath = (task: RepoTask, targetPath: string, content = task.content) => {
     if (targetPath === task.path) return true;
     if (effectivePaths.has(targetPath)) return false;
     const wasSelected = selectedPath === task.path;
     onSetStaged(task.path, undefined);
     onDelete(task.path);
     onSetStaged(targetPath, undefined);
-    onSetWorking(targetPath, { type: "write", content: task.content });
+    onSetWorking(targetPath, { type: "write", content });
     if (wasSelected) selectTask(targetPath);
     return true;
   };
-  const moveTaskToFolder = (task: RepoTask, folderPath: string) => {
+  const moveTaskOnBoard = (
+    task: RepoTask,
+    state: string,
+    folderPath: string,
+    labels?: readonly string[],
+  ) => {
+    let content = state === task.state ? task.content : updateRepoTaskState(task.content, state);
+    if (
+      labels !== undefined &&
+      (labels.length !== task.labels.length ||
+        labels.some((label, index) => label !== task.labels[index]))
+    )
+      content = updateRepoTaskLabels(content, labels);
+    if (folderPath === task.folderPath) {
+      if (content !== task.content) writeTask(task, content);
+      return;
+    }
     const targetPath = repoTaskPathInDirectory(
       task.path,
       taskDirectoryForFolder(folderPath),
       effectivePaths,
     );
-    moveTaskToPath(task, targetPath);
+    moveTaskToPath(task, targetPath, content);
   };
   const renameTask = (task: RepoTask, path: string) => {
     const targetPath = path.trim().replace(/^\/+/, "");
@@ -185,10 +215,8 @@ export function RepoTasksView({
     <div className="flex min-h-0 min-w-0 flex-1">
       <TaskBoard
         tasks={tasks}
-        columns={columns}
         onOpen={(task) => selectTask(task.path)}
-        onMoveState={(task, state) => writeTask(task, updateRepoTaskState(task.content, state))}
-        onMoveFolder={moveTaskToFolder}
+        onMove={moveTaskOnBoard}
         onCreate={createTask}
       />
       <TaskEditorSheet
@@ -225,64 +253,62 @@ export function RepoTasksView({
   );
 }
 
+const TASK_CARD_PREFIX = "task-card:";
+const TASK_CELL_PREFIX = "task-cell:";
+
 function TaskBoard({
   tasks,
-  columns,
   onOpen,
-  onMoveState,
-  onMoveFolder,
+  onMove,
   onCreate,
 }: {
   tasks: readonly RepoTask[];
-  columns: readonly string[];
   onOpen: (task: RepoTask) => void;
-  onMoveState: (task: RepoTask, state: string) => void;
-  onMoveFolder: (task: RepoTask, folderPath: string) => void;
-  onCreate: (state: string, folderPath: string) => void;
+  onMove: (task: RepoTask, state: string, folderPath: string, labels?: readonly string[]) => void;
+  onCreate: (state: string, folderPath: string, labels?: readonly string[]) => void;
 }) {
-  const [groupMode, setGroupMode] = useState<GroupMode>("state");
+  const [rowField, setRowField] = useState<RepoTaskBoardRowField>("folder");
   const [filter, setFilter] = useState("");
   const draggedPathRef = useRef<string | undefined>(undefined);
   const boardScrollRef = useRef<HTMLDivElement>(null);
-  const filteredTasks = useMemo(() => {
-    const query = filter.trim().toLocaleLowerCase();
-    if (query === "") return tasks;
-    return tasks.filter((task) =>
-      [task.title, task.description, task.state, task.folderPath, ...task.labels].some((value) =>
-        value.toLocaleLowerCase().includes(query),
-      ),
-    );
-  }, [filter, tasks]);
-  const folderPaths = useMemo(() => {
-    const paths = [...new Set(tasks.map((task) => task.folderPath))];
-    if (paths.length === 0) return ["/"];
-    return paths.sort((left, right) => {
-      if (left === "/") return -1;
-      if (right === "/") return 1;
-      return left.localeCompare(right);
-    });
-  }, [tasks]);
-  const groups = groupMode === "state" ? columns : folderPaths;
+  const query = useMemo<RepoTaskBoardQuery>(
+    () => ({ filter, columns: "state", rows: rowField }),
+    [filter, rowField],
+  );
+  const board = useMemo<RepoTaskBoardProjection>(
+    () => queryRepoTaskBoard(tasks, query),
+    [query, tasks],
+  );
   useEffect(() => {
-    boardScrollRef.current?.scrollTo({ left: 0 });
-  }, [groupMode]);
+    boardScrollRef.current?.scrollTo({ left: 0, top: 0 });
+  }, [rowField]);
 
   return (
     <DragDropProvider
       onDragStart={(event) => {
-        draggedPathRef.current = String(event.operation.source?.id ?? "");
+        draggedPathRef.current = taskFromDragId(String(event.operation.source?.id ?? ""))?.path;
       }}
       onDragEnd={(event) => {
-        const path = String(event.operation.source?.id ?? "");
-        if (!event.canceled) {
-          const targetId = String(event.operation.target?.id ?? "");
-          const task = tasks.find((candidate) => candidate.path === path);
-          if (task !== undefined && targetId.startsWith("task-state:")) {
-            const state = targetId.slice("task-state:".length);
-            if (state !== "" && task.state !== state) onMoveState(task, state);
-          } else if (task !== undefined && targetId.startsWith("task-folder:")) {
-            const folderPath = targetId.slice("task-folder:".length);
-            if (folderPath !== "" && task.folderPath !== folderPath) onMoveFolder(task, folderPath);
+        const source = taskFromDragId(String(event.operation.source?.id ?? ""));
+        const path = source?.path;
+        if (!event.canceled && source !== undefined) {
+          const target = taskCellFromDropId(String(event.operation.target?.id ?? ""));
+          const task = tasks.find((candidate) => candidate.path === source.path);
+          const row = board.rows.find((candidate) => candidate.key === target?.rowKey);
+          if (task !== undefined && target !== undefined && row !== undefined) {
+            const folderPath = rowField === "folder" ? (row.value ?? "/") : task.folderPath;
+            const labels =
+              rowField === "label" && source.rowKey !== target.rowKey
+                ? row.value === null
+                  ? []
+                  : [row.value]
+                : undefined;
+            if (
+              task.state !== target.state ||
+              task.folderPath !== folderPath ||
+              labels !== undefined
+            )
+              onMove(task, target.state, folderPath, labels);
           }
         }
         setTimeout(() => {
@@ -305,101 +331,168 @@ function TaskBoard({
               className="h-8 bg-background pl-8"
             />
           </div>
-          <Select
-            value={groupMode}
-            onValueChange={(value) => {
-              if (value === "state" || value === "folder") setGroupMode(value);
-            }}
-          >
-            <SelectTrigger aria-label="Group tasks by" className="w-28 shrink-0">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectGroup>
-                <SelectLabel>Group by</SelectLabel>
-                <SelectItem value="state">State</SelectItem>
-                <SelectItem value="folder">Folder</SelectItem>
-              </SelectGroup>
-            </SelectContent>
-          </Select>
+          <BoardDisplaySettings rowField={rowField} onChangeRowField={setRowField} />
           <span className="hidden shrink-0 text-xs tabular-nums text-muted-foreground sm:inline">
-            {filteredTasks.length} {filteredTasks.length === 1 ? "task" : "tasks"}
+            {board.taskCount} {board.taskCount === 1 ? "task" : "tasks"}
           </span>
         </div>
-        <div
-          ref={boardScrollRef}
-          className="flex min-h-0 min-w-0 flex-1 snap-x snap-mandatory gap-2 overflow-x-auto p-2 sm:snap-none"
-        >
-          {groups.map((group) => (
-            <TaskColumn
-              key={`${groupMode}:${group}`}
-              groupMode={groupMode}
-              group={group}
-              tasks={filteredTasks.filter((task) =>
-                groupMode === "state" ? task.state === group : task.folderPath === group,
-              )}
-              onOpen={(task) => {
-                if (draggedPathRef.current !== task.path) onOpen(task);
-              }}
-              onCreate={() =>
-                groupMode === "state" ? onCreate(group, "/") : onCreate("todo", group)
-              }
-            />
-          ))}
+        <div ref={boardScrollRef} className="min-h-0 min-w-0 flex-1 overflow-auto p-2">
+          <div className="flex min-h-full w-max min-w-full flex-col gap-4">
+            {board.rows.map((row) => (
+              <section
+                key={row.key}
+                data-task-row={row.key}
+                className={cn(
+                  "flex min-w-full flex-col",
+                  board.rows.length === 1 && "min-h-full flex-1",
+                )}
+              >
+                {rowField === null ? null : (
+                  <header className="sticky left-0 flex h-9 w-fit max-w-[calc(100vw-4rem)] items-center gap-2 px-2 text-sm font-medium">
+                    {rowField === "folder" ? (
+                      <FolderIcon aria-hidden className="size-4 shrink-0 text-muted-foreground" />
+                    ) : (
+                      <TagIcon aria-hidden className="size-4 shrink-0 text-muted-foreground" />
+                    )}
+                    <span className="truncate">{row.label}</span>
+                    <span className="text-xs tabular-nums text-muted-foreground">
+                      {row.tasks.length}
+                    </span>
+                  </header>
+                )}
+                <div className="flex min-h-0 min-w-full flex-1 snap-x snap-mandatory gap-2 sm:snap-none">
+                  {row.cells.map((cell) => (
+                    <TaskColumn
+                      key={`${row.key}:${cell.state}`}
+                      state={cell.state}
+                      rowKey={row.key}
+                      rowLabel={row.label}
+                      tasks={cell.tasks}
+                      onOpen={(task) => {
+                        if (draggedPathRef.current !== task.path) onOpen(task);
+                      }}
+                      onCreate={() => {
+                        const labels =
+                          rowField === "label" && row.value !== null ? [row.value] : undefined;
+                        onCreate(
+                          cell.state,
+                          rowField === "folder" ? (row.value ?? "/") : "/",
+                          labels,
+                        );
+                      }}
+                    />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
         </div>
       </div>
     </DragDropProvider>
   );
 }
 
+function BoardDisplaySettings({
+  rowField,
+  onChangeRowField,
+}: {
+  rowField: RepoTaskBoardRowField;
+  onChangeRowField: (field: RepoTaskBoardRowField) => void;
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger render={<Button variant="outline" size="default" />}>
+        <SlidersHorizontalIcon data-icon="inline-start" />
+        Display
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-72 gap-4 p-4">
+        <PopoverHeader>
+          <PopoverTitle>Board display</PopoverTitle>
+          <PopoverDescription>
+            Choose the two dimensions used to query the tasks.
+          </PopoverDescription>
+        </PopoverHeader>
+        <div className="grid grid-cols-[1fr_auto] items-center gap-x-4 gap-y-3">
+          <span className="text-muted-foreground">Columns</span>
+          <Badge variant="secondary">Status</Badge>
+          <span className="text-muted-foreground">Rows</span>
+          <Select
+            value={rowField ?? "none"}
+            onValueChange={(value) => {
+              if (value === "none") onChangeRowField(null);
+              else if (value === "folder" || value === "label") onChangeRowField(value);
+            }}
+          >
+            <SelectTrigger aria-label="Task board row grouping" size="sm" className="w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectLabel>Group rows by</SelectLabel>
+                <SelectItem value="none">No grouping</SelectItem>
+                <SelectItem value="folder">Folder</SelectItem>
+                <SelectItem value="label">Label</SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 function TaskColumn({
-  groupMode,
-  group,
+  state,
+  rowKey,
+  rowLabel,
   tasks,
   onOpen,
   onCreate,
 }: {
-  groupMode: GroupMode;
-  group: string;
+  state: string;
+  rowKey: string;
+  rowLabel: string | null;
   tasks: readonly RepoTask[];
   onOpen: (task: RepoTask) => void;
   onCreate: () => void;
 }) {
-  const dropId = `task-${groupMode}:${group}`;
+  const dropId = `${TASK_CELL_PREFIX}${encodeURIComponent(rowKey)}:${encodeURIComponent(state)}`;
   const { ref, isDropTarget } = useDroppable({ id: dropId, accept: "repo-task" });
-  const label = groupMode === "state" ? taskStateLabel(group) : group;
+  const label = taskStateLabel(state);
+  const creationLabel = rowLabel === null ? label : `${label} in ${rowLabel}`;
 
   return (
     <section
       ref={ref}
-      data-task-group={dropId}
+      data-task-cell={dropId}
       className={cn(
-        "flex min-h-full min-w-full flex-1 basis-72 snap-start flex-col rounded-lg bg-background/70 transition-colors sm:min-w-72",
+        "flex min-h-52 min-w-[calc(100vw-3.5rem)] flex-1 basis-72 snap-start flex-col rounded-lg bg-background/70 transition-colors sm:min-w-72",
         isDropTarget && "bg-accent/40",
       )}
     >
       <header className="flex h-12 shrink-0 items-center px-3">
         <div className="flex min-w-0 items-center gap-2">
-          {groupMode === "state" ? (
-            <TaskStateIcon state={group} />
-          ) : (
-            <FolderIcon aria-hidden className="size-4 shrink-0 text-muted-foreground" />
-          )}
+          <TaskStateIcon state={state} />
           <h2 className="truncate text-sm font-medium">{label}</h2>
           <span className="text-xs tabular-nums text-muted-foreground">{tasks.length}</span>
         </div>
       </header>
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2 pb-2">
+      <div className="flex min-h-0 flex-1 flex-col px-2 pb-2">
         <div className="flex flex-col gap-2">
           {tasks.map((task) => (
-            <TaskCard key={task.path} task={task} onOpen={onOpen} />
+            <TaskCard
+              key={task.path}
+              task={task}
+              dragId={`${TASK_CARD_PREFIX}${encodeURIComponent(task.path)}:${encodeURIComponent(rowKey)}`}
+              onOpen={onOpen}
+            />
           ))}
         </div>
         <Button
           variant="ghost"
           className="mt-2 h-10 w-full text-muted-foreground/50 hover:bg-muted/70 hover:text-muted-foreground"
-          title={`Add task to ${label}`}
-          aria-label={`Add task to ${label}`}
+          title={`Add task to ${creationLabel}`}
+          aria-label={`Add task to ${creationLabel}`}
           onClick={onCreate}
         >
           <PlusIcon className="size-5" data-icon="inline-start" />
@@ -409,8 +502,30 @@ function TaskColumn({
   );
 }
 
-function TaskCard({ task, onOpen }: { task: RepoTask; onOpen: (task: RepoTask) => void }) {
-  const { ref, isDragging } = useDraggable({ id: task.path, type: "repo-task" });
+function taskFromDragId(id: string): { path: string; rowKey: string } | undefined {
+  if (!id.startsWith(TASK_CARD_PREFIX)) return undefined;
+  const [encodedPath, encodedRow] = id.slice(TASK_CARD_PREFIX.length).split(":", 2);
+  if (encodedPath === undefined || encodedRow === undefined) return undefined;
+  return { path: decodeURIComponent(encodedPath), rowKey: decodeURIComponent(encodedRow) };
+}
+
+function taskCellFromDropId(id: string): { rowKey: string; state: string } | undefined {
+  if (!id.startsWith(TASK_CELL_PREFIX)) return undefined;
+  const [encodedRow, encodedState] = id.slice(TASK_CELL_PREFIX.length).split(":", 2);
+  if (encodedRow === undefined || encodedState === undefined) return undefined;
+  return { rowKey: decodeURIComponent(encodedRow), state: decodeURIComponent(encodedState) };
+}
+
+function TaskCard({
+  task,
+  dragId,
+  onOpen,
+}: {
+  task: RepoTask;
+  dragId: string;
+  onOpen: (task: RepoTask) => void;
+}) {
+  const { ref, isDragging } = useDraggable({ id: dragId, type: "repo-task" });
   const summary = task.description.replace(/\s+/g, " ").slice(0, 160);
   return (
     <button

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -35,6 +35,7 @@ import {
   createRepoTask,
   isRepoTaskPath,
   parseRepoTask,
+  repoTaskCreationPaths,
   taskStateColumns,
   taskStateLabel,
   updateRepoTaskLabels,
@@ -117,13 +118,10 @@ export function RepoTasksView({
   }, [changes, headContents]);
 
   const effectivePaths = useMemo(() => {
-    const paths = new Set(headPaths);
-    for (const [path, change] of changes) {
-      const entry = effectiveEntry(change);
-      if (entry?.type === "delete") paths.delete(path);
-      else if (entry !== undefined) paths.add(path);
-    }
-    return paths;
+    return repoTaskCreationPaths(
+      headPaths,
+      [...changes].map(([path, change]) => [path, effectiveEntry(change)?.type] as const),
+    );
   }, [changes, headPaths]);
 
   const columns = taskStateColumns(tasks);

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -167,7 +167,7 @@ export function RepoTasksView({
   };
 
   return (
-    <div className="flex min-h-0 flex-1">
+    <div className="flex min-h-0 min-w-0 flex-1">
       <TaskBoard
         tasks={tasks}
         columns={columns}
@@ -215,6 +215,7 @@ function TaskBoard({
   const [groupMode, setGroupMode] = useState<GroupMode>("state");
   const [filter, setFilter] = useState("");
   const draggedPathRef = useRef<string | undefined>(undefined);
+  const boardScrollRef = useRef<HTMLDivElement>(null);
   const filteredTasks = useMemo(() => {
     const query = filter.trim().toLocaleLowerCase();
     if (query === "") return tasks;
@@ -234,6 +235,9 @@ function TaskBoard({
     });
   }, [tasks]);
   const groups = groupMode === "state" ? columns : folderPaths;
+  useEffect(() => {
+    boardScrollRef.current?.scrollTo({ left: 0 });
+  }, [groupMode]);
 
   return (
     <DragDropProvider
@@ -294,7 +298,10 @@ function TaskBoard({
             {filteredTasks.length} {filteredTasks.length === 1 ? "task" : "tasks"}
           </span>
         </div>
-        <div className="flex min-h-0 min-w-0 flex-1 snap-x snap-mandatory gap-2 overflow-x-auto p-2 sm:snap-none">
+        <div
+          ref={boardScrollRef}
+          className="flex min-h-0 min-w-0 flex-1 snap-x snap-mandatory gap-2 overflow-x-auto p-2 sm:snap-none"
+        >
           {groups.map((group) => (
             <TaskColumn
               key={`${groupMode}:${group}`}
@@ -346,7 +353,7 @@ function TaskColumn({
       ref={ref}
       data-task-group={dropId}
       className={cn(
-        "flex min-h-full min-w-[calc(100vw-1rem)] flex-1 basis-72 snap-start flex-col rounded-lg bg-background/70 transition-colors sm:min-w-72",
+        "flex min-h-full min-w-full flex-1 basis-72 snap-start flex-col rounded-lg bg-background/70 transition-colors sm:min-w-72",
         isDropTarget && "bg-accent/40",
       )}
     >

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -363,6 +363,7 @@ function TaskBoard({
                       rowKey={row.key}
                       rowLabel={row.label}
                       tasks={cell.tasks}
+                      visibleProperties={board.visibleProperties}
                       onOpen={(task) => {
                         if (draggedPathRef.current !== task.path) onOpen(task);
                       }}
@@ -441,6 +442,7 @@ function TaskColumn({
   rowKey,
   rowLabel,
   tasks,
+  visibleProperties,
   onOpen,
   onCreate,
 }: {
@@ -448,6 +450,7 @@ function TaskColumn({
   rowKey: string;
   rowLabel: string | null;
   tasks: readonly RepoTask[];
+  visibleProperties: RepoTaskBoardProjection["visibleProperties"];
   onOpen: (task: RepoTask) => void;
   onCreate: () => void;
 }) {
@@ -479,6 +482,7 @@ function TaskColumn({
               key={task.path}
               task={task}
               dragId={`${TASK_CARD_PREFIX}${encodeURIComponent(task.path)}:${encodeURIComponent(rowKey)}`}
+              visibleProperties={visibleProperties}
               onOpen={onOpen}
             />
           ))}
@@ -514,10 +518,12 @@ function taskCellFromDropId(id: string): { rowKey: string; state: string } | und
 function TaskCard({
   task,
   dragId,
+  visibleProperties,
   onOpen,
 }: {
   task: RepoTask;
   dragId: string;
+  visibleProperties: RepoTaskBoardProjection["visibleProperties"];
   onOpen: (task: RepoTask) => void;
 }) {
   const { ref, isDragging } = useDraggable({ id: dragId, type: "repo-task" });
@@ -534,18 +540,20 @@ function TaskCard({
         isDragging && "opacity-40 shadow-none",
       )}
     >
-      <div className="mb-2 flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
-        <FolderIcon aria-hidden className="size-3 shrink-0" />
-        <span className="truncate font-mono">{task.folderPath}</span>
-      </div>
+      {visibleProperties.folder ? (
+        <div className="mb-2 flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
+          <FolderIcon aria-hidden className="size-3 shrink-0" />
+          <span className="truncate font-mono">{task.folderPath}</span>
+        </div>
+      ) : null}
       <div className="flex items-start gap-2">
-        <TaskStateIcon state={task.state} className="mt-0.5" />
+        {visibleProperties.state ? <TaskStateIcon state={task.state} className="mt-0.5" /> : null}
         <span className="min-w-0 flex-1 text-sm font-medium leading-snug">{task.title}</span>
       </div>
       {summary === "" ? null : (
         <p className="mt-2 line-clamp-2 text-xs leading-relaxed text-muted-foreground">{summary}</p>
       )}
-      {task.labels.length === 0 ? null : (
+      {!visibleProperties.labels || task.labels.length === 0 ? null : (
         <div className="mt-3 flex min-w-0 flex-wrap items-center gap-1.5">
           {task.labels.map((label) => (
             <Badge key={label} variant="secondary">

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -1,0 +1,446 @@
+import { useMemo } from "react";
+import { DragDropProvider, useDraggable, useDroppable } from "@dnd-kit/react";
+import { GripVerticalIcon, ListTodoIcon, PlusIcon, XIcon } from "lucide-react";
+import { Badge } from "@iterate-com/ui/components/badge";
+import { Button } from "@iterate-com/ui/components/button";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@iterate-com/ui/components/card";
+import { Empty, EmptyHeader, EmptyTitle } from "@iterate-com/ui/components/empty";
+import { Field, FieldGroup, FieldLabel } from "@iterate-com/ui/components/field";
+import { Input } from "@iterate-com/ui/components/input";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@iterate-com/ui/components/resizable";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@iterate-com/ui/components/select";
+import { cn } from "@iterate-com/ui/lib/utils";
+import { RepoEditorPane } from "./repo-editor-pane.tsx";
+import {
+  createRepoTask,
+  isRepoTaskPath,
+  parseRepoTask,
+  taskStateColumns,
+  taskStateLabel,
+  updateRepoTaskLabels,
+  updateRepoTaskState,
+  type RepoTask,
+} from "./repo-tasks.ts";
+import { effectiveEntry, type FileEntry, type WorkingTreeChanges } from "./staged-changes.ts";
+import { useItxQuery } from "~/itx/itx-react.tsx";
+
+type SearchPatch = {
+  file?: string;
+  diff?: boolean;
+  preview?: boolean;
+  staged?: boolean;
+};
+
+export function RepoTasksView({
+  projectId,
+  repoPath,
+  headCommitOid,
+  headPaths,
+  changes,
+  selectedPath,
+  diffOpen,
+  previewOpen,
+  stagedView,
+  onPatchSearch,
+  onSetWorking,
+  onSetStaged,
+  onStage,
+  onUnstage,
+  onRestore,
+}: {
+  projectId: string;
+  repoPath: string;
+  headCommitOid: string;
+  headPaths: readonly string[];
+  changes: WorkingTreeChanges;
+  selectedPath: string | undefined;
+  diffOpen: boolean;
+  previewOpen: boolean;
+  stagedView: boolean;
+  onPatchSearch: (patch: SearchPatch) => void;
+  onSetWorking: (path: string, entry: FileEntry | undefined) => void;
+  onSetStaged: (path: string, entry: FileEntry | undefined) => void;
+  onStage: (path: string) => void;
+  onUnstage: (path: string) => void;
+  onRestore: (path: string) => void;
+}) {
+  const headTaskPaths = useMemo(() => headPaths.filter(isRepoTaskPath), [headPaths]);
+  const headContents = useItxQuery({
+    key: ["repo-task-files", projectId, repoPath, headCommitOid, headTaskPaths.join("\n")],
+    query: async (itx) => {
+      const reads = await Promise.all(
+        headTaskPaths.map(async (path) => ({
+          path,
+          read: await itx.repos.get(repoPath).readFile({ path, encoding: "utf8" }),
+        })),
+      );
+      return Object.fromEntries(
+        reads.flatMap(({ path, read }) => (read === null ? [] : [[path, read.content]])),
+      );
+    },
+  });
+
+  const tasks = useMemo(() => {
+    const contents = new Map(Object.entries(headContents));
+    for (const [path, change] of changes) {
+      if (!isRepoTaskPath(path)) continue;
+      const entry = effectiveEntry(change);
+      if (entry?.type === "write") contents.set(path, entry.content);
+      else if (entry !== undefined) contents.delete(path);
+    }
+    return [...contents]
+      .flatMap(([path, content]) => {
+        const task = parseRepoTask(path, content);
+        return task === null ? [] : [task];
+      })
+      .sort((left, right) => left.title.localeCompare(right.title));
+  }, [changes, headContents]);
+
+  const effectivePaths = useMemo(() => {
+    const paths = new Set(headPaths);
+    for (const [path, change] of changes) {
+      const entry = effectiveEntry(change);
+      if (entry?.type === "delete") paths.delete(path);
+      else if (entry !== undefined) paths.add(path);
+    }
+    return paths;
+  }, [changes, headPaths]);
+
+  const columns = taskStateColumns(tasks);
+  const selectedTask = tasks.find((task) => task.path === selectedPath);
+  const writeTask = (task: RepoTask, content: string) => {
+    const staged = changes.get(task.path)?.staged;
+    const baseline = staged?.type === "write" ? staged.content : headContents[task.path];
+    onSetWorking(task.path, content === baseline ? undefined : { type: "write", content });
+  };
+  const selectTask = (path: string | undefined) =>
+    onPatchSearch({ file: path, diff: undefined, preview: undefined, staged: undefined });
+
+  return (
+    <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
+      <ResizablePanel defaultSize="20%" minSize="12rem" className="min-w-0">
+        <TasksSidebar
+          tasks={tasks}
+          columns={columns}
+          selectedTask={selectedTask}
+          onShowBoard={() => selectTask(undefined)}
+          onCreate={(title, reset) => {
+            const created = createRepoTask(title, effectivePaths);
+            if (created === null) return;
+            onSetWorking(created.path, { type: "write", content: created.content });
+            reset();
+            selectTask(created.path);
+          }}
+          onChangeState={(state) => {
+            if (selectedTask !== undefined)
+              writeTask(selectedTask, updateRepoTaskState(selectedTask.content, state));
+          }}
+          onChangeLabels={(labels) => {
+            if (selectedTask !== undefined)
+              writeTask(selectedTask, updateRepoTaskLabels(selectedTask.content, labels));
+          }}
+        />
+      </ResizablePanel>
+      <ResizableHandle />
+      <ResizablePanel className="flex min-w-0 flex-col">
+        {selectedTask === undefined ? (
+          <TaskBoard
+            tasks={tasks}
+            columns={columns}
+            onOpen={(task) => selectTask(task.path)}
+            onMove={(task, state) => writeTask(task, updateRepoTaskState(task.content, state))}
+          />
+        ) : (
+          <RepoEditorPane
+            key={selectedTask.path}
+            projectId={projectId}
+            repoPath={repoPath}
+            path={selectedTask.path}
+            headCommitOid={headCommitOid}
+            headHasPath={headPaths.includes(selectedTask.path)}
+            change={changes.get(selectedTask.path)}
+            diffOpen={diffOpen}
+            onToggleDiff={(open) =>
+              onPatchSearch({ diff: open ? true : undefined, preview: undefined })
+            }
+            previewOpen={previewOpen}
+            onTogglePreview={(open) =>
+              onPatchSearch({ preview: open ? true : undefined, diff: undefined })
+            }
+            onSetWorking={(entry) => onSetWorking(selectedTask.path, entry)}
+            onSetStaged={(entry) => onSetStaged(selectedTask.path, entry)}
+            onStageFile={() => onStage(selectedTask.path)}
+            onUnstageFile={() => {
+              onUnstage(selectedTask.path);
+              onPatchSearch({ staged: undefined });
+            }}
+            onOpenWorking={() =>
+              onPatchSearch({ staged: undefined, diff: undefined, preview: undefined })
+            }
+            stagedView={stagedView && changes.get(selectedTask.path)?.staged !== undefined}
+            onRestore={() => onRestore(selectedTask.path)}
+          />
+        )}
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  );
+}
+
+function TasksSidebar({
+  tasks,
+  columns,
+  selectedTask,
+  onShowBoard,
+  onCreate,
+  onChangeState,
+  onChangeLabels,
+}: {
+  tasks: readonly RepoTask[];
+  columns: readonly string[];
+  selectedTask: RepoTask | undefined;
+  onShowBoard: () => void;
+  onCreate: (title: string, reset: () => void) => void;
+  onChangeState: (state: string) => void;
+  onChangeLabels: (labels: string[]) => void;
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex items-center justify-between border-b p-3">
+        <div className="flex items-center gap-2">
+          <ListTodoIcon />
+          <span className="text-sm font-medium">Tasks</span>
+        </div>
+        <Badge variant="secondary">{tasks.length}</Badge>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto p-3">
+        <Button
+          variant={selectedTask === undefined ? "secondary" : "ghost"}
+          className="w-full justify-start"
+          onClick={onShowBoard}
+        >
+          Board
+        </Button>
+
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            const form = event.currentTarget;
+            onCreate(String(new FormData(form).get("title") ?? ""), () => form.reset());
+          }}
+        >
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor="new-task-title">New task</FieldLabel>
+              <div className="flex gap-2">
+                <Input id="new-task-title" name="title" placeholder="Task title" />
+                <Button type="submit" size="icon" title="Create task" aria-label="Create task">
+                  <PlusIcon data-icon="inline-start" />
+                </Button>
+              </div>
+            </Field>
+          </FieldGroup>
+        </form>
+
+        {selectedTask === undefined ? null : (
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor="task-state">State</FieldLabel>
+              <Select
+                value={selectedTask.state}
+                onValueChange={(value) => value && onChangeState(value)}
+              >
+                <SelectTrigger id="task-state" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel>State</SelectLabel>
+                    {columns.map((state) => (
+                      <SelectItem key={state} value={state}>
+                        {taskStateLabel(state)}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </Field>
+            <Field>
+              <FieldLabel>Labels</FieldLabel>
+              <div className="flex flex-col gap-2">
+                <Badge variant="outline">{selectedTask.labels[0]}</Badge>
+                {selectedTask.explicitLabels.map((label) => (
+                  <div key={label} className="flex items-center justify-between gap-2">
+                    <Badge variant="secondary">{label}</Badge>
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      title={`Remove ${label}`}
+                      aria-label={`Remove ${label}`}
+                      onClick={() =>
+                        onChangeLabels(
+                          selectedTask.explicitLabels.filter((candidate) => candidate !== label),
+                        )
+                      }
+                    >
+                      <XIcon data-icon="inline-start" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </Field>
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                const form = event.currentTarget;
+                const label = String(new FormData(form).get("label") ?? "").trim();
+                if (label === "") return;
+                onChangeLabels([...selectedTask.explicitLabels, label]);
+                form.reset();
+              }}
+            >
+              <Field>
+                <FieldLabel htmlFor="new-task-label">Add label</FieldLabel>
+                <div className="flex gap-2">
+                  <Input id="new-task-label" name="label" placeholder="Label" />
+                  <Button type="submit" size="icon" title="Add label" aria-label="Add label">
+                    <PlusIcon data-icon="inline-start" />
+                  </Button>
+                </div>
+              </Field>
+            </form>
+          </FieldGroup>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TaskBoard({
+  tasks,
+  columns,
+  onOpen,
+  onMove,
+}: {
+  tasks: readonly RepoTask[];
+  columns: readonly string[];
+  onOpen: (task: RepoTask) => void;
+  onMove: (task: RepoTask, state: string) => void;
+}) {
+  return (
+    <DragDropProvider
+      onDragEnd={(event) => {
+        if (event.canceled) return;
+        const path = String(event.operation.source?.id ?? "");
+        const targetId = String(event.operation.target?.id ?? "");
+        const state = targetId.startsWith("task-state:")
+          ? targetId.slice("task-state:".length)
+          : "";
+        const task = tasks.find((candidate) => candidate.path === path);
+        if (task !== undefined && state !== "" && task.state !== state) onMove(task, state);
+      }}
+    >
+      <div className="flex min-h-0 flex-1 gap-3 overflow-x-auto p-4">
+        {columns.map((state) => (
+          <TaskColumn
+            key={state}
+            state={state}
+            tasks={tasks.filter((task) => task.state === state)}
+            onOpen={onOpen}
+          />
+        ))}
+      </div>
+    </DragDropProvider>
+  );
+}
+
+function TaskColumn({
+  state,
+  tasks,
+  onOpen,
+}: {
+  state: string;
+  tasks: readonly RepoTask[];
+  onOpen: (task: RepoTask) => void;
+}) {
+  const { ref, isDropTarget } = useDroppable({ id: `task-state:${state}`, accept: "repo-task" });
+  return (
+    <Card
+      ref={ref}
+      data-task-state={state}
+      className={cn("min-h-full w-72 shrink-0 self-start", isDropTarget && "ring-2 ring-primary")}
+    >
+      <CardHeader>
+        <CardTitle>{taskStateLabel(state)}</CardTitle>
+        <CardAction>
+          <Badge variant="secondary">{tasks.length}</Badge>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-2">
+        {tasks.length === 0 ? (
+          <Empty className="min-h-24 border">
+            <EmptyHeader>
+              <EmptyTitle>No tasks</EmptyTitle>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          tasks.map((task) => <TaskCard key={task.path} task={task} onOpen={onOpen} />)
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TaskCard({ task, onOpen }: { task: RepoTask; onOpen: (task: RepoTask) => void }) {
+  const { ref, handleRef, isDragging } = useDraggable({ id: task.path, type: "repo-task" });
+  const summary = task.description.replace(/\s+/g, " ").slice(0, 160);
+  return (
+    <Card ref={ref} size="sm" data-task-path={task.path} className={cn(isDragging && "opacity-50")}>
+      <CardHeader>
+        <CardTitle>
+          <button type="button" className="text-left hover:underline" onClick={() => onOpen(task)}>
+            {task.title}
+          </button>
+        </CardTitle>
+        <CardAction>
+          <Button
+            ref={handleRef}
+            variant="ghost"
+            size="icon-sm"
+            title={`Drag ${task.title}`}
+            aria-label={`Drag ${task.title}`}
+          >
+            <GripVerticalIcon data-icon="inline-start" />
+          </Button>
+        </CardAction>
+        {summary === "" ? null : <CardDescription>{summary}</CardDescription>}
+      </CardHeader>
+      <CardFooter className="flex-wrap gap-1.5">
+        {task.labels.map((label, index) => (
+          <Badge key={label} variant={index === 0 ? "outline" : "secondary"}>
+            {label}
+          </Badge>
+        ))}
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -1,6 +1,13 @@
-import { useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { DragDropProvider, useDraggable, useDroppable } from "@dnd-kit/react";
-import { GripVerticalIcon, ListTodoIcon, PlusIcon, XIcon } from "lucide-react";
+import {
+  CircleCheckIcon,
+  CircleDashedIcon,
+  CircleDotDashedIcon,
+  CircleIcon,
+  PlusIcon,
+  XIcon,
+} from "lucide-react";
 import { Badge } from "@iterate-com/ui/components/badge";
 import { Button } from "@iterate-com/ui/components/button";
 import { Input } from "@iterate-com/ui/components/input";
@@ -110,24 +117,24 @@ export function RepoTasksView({
   };
   const selectTask = (path: string | undefined) =>
     onPatchSearch({ file: path, diff: undefined, preview: undefined, staged: undefined });
+  const createTask = (title: string, state: string) => {
+    const created = createRepoTask(title, effectivePaths);
+    if (created === null) return false;
+    const content =
+      state === "todo" ? created.content : updateRepoTaskState(created.content, state);
+    onSetWorking(created.path, { type: "write", content });
+    selectTask(created.path);
+    return true;
+  };
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col md:flex-row">
-      <TasksSidebar
-        taskCount={tasks.length}
-        onCreate={(title, reset) => {
-          const created = createRepoTask(title, effectivePaths);
-          if (created === null) return;
-          onSetWorking(created.path, { type: "write", content: created.content });
-          reset();
-          selectTask(created.path);
-        }}
-      />
+    <div className="flex min-h-0 flex-1">
       <TaskBoard
         tasks={tasks}
         columns={columns}
         onOpen={(task) => selectTask(task.path)}
         onMove={(task, state) => writeTask(task, updateRepoTaskState(task.content, state))}
+        onCreate={createTask}
       />
       <TaskEditorSheet
         task={selectedTask}
@@ -151,75 +158,50 @@ export function RepoTasksView({
   );
 }
 
-function TasksSidebar({
-  taskCount,
-  onCreate,
-}: {
-  taskCount: number;
-  onCreate: (title: string, reset: () => void) => void;
-}) {
-  return (
-    <aside className="flex shrink-0 items-center gap-3 border-b p-3 md:h-full md:w-60 md:flex-col md:items-stretch md:border-r md:border-b-0">
-      <div className="flex items-center gap-2 md:justify-between">
-        <div className="flex items-center gap-2">
-          <ListTodoIcon className="size-4" />
-          <span className="text-sm font-medium">Tasks</span>
-        </div>
-        <Badge variant="secondary">{taskCount}</Badge>
-      </div>
-      <form
-        className="flex min-w-0 flex-1 gap-2 md:flex-none"
-        onSubmit={(event) => {
-          event.preventDefault();
-          const form = event.currentTarget;
-          onCreate(String(new FormData(form).get("title") ?? ""), () => form.reset());
-        }}
-      >
-        <Input
-          aria-label="New task title"
-          name="title"
-          placeholder="New task"
-          className="min-w-0"
-        />
-        <Button type="submit" size="icon" title="Create task" aria-label="Create task">
-          <PlusIcon data-icon="inline-start" />
-        </Button>
-      </form>
-    </aside>
-  );
-}
-
 function TaskBoard({
   tasks,
   columns,
   onOpen,
   onMove,
+  onCreate,
 }: {
   tasks: readonly RepoTask[];
   columns: readonly string[];
   onOpen: (task: RepoTask) => void;
   onMove: (task: RepoTask, state: string) => void;
+  onCreate: (title: string, state: string) => boolean;
 }) {
+  const draggedPathRef = useRef<string | undefined>(undefined);
   return (
     <DragDropProvider
+      onDragStart={(event) => {
+        draggedPathRef.current = String(event.operation.source?.id ?? "");
+      }}
       onDragEnd={(event) => {
-        if (event.canceled) return;
         const path = String(event.operation.source?.id ?? "");
-        const targetId = String(event.operation.target?.id ?? "");
-        const state = targetId.startsWith("task-state:")
-          ? targetId.slice("task-state:".length)
-          : "";
-        const task = tasks.find((candidate) => candidate.path === path);
-        if (task !== undefined && state !== "" && task.state !== state) onMove(task, state);
+        if (!event.canceled) {
+          const targetId = String(event.operation.target?.id ?? "");
+          const state = targetId.startsWith("task-state:")
+            ? targetId.slice("task-state:".length)
+            : "";
+          const task = tasks.find((candidate) => candidate.path === path);
+          if (task !== undefined && state !== "" && task.state !== state) onMove(task, state);
+        }
+        setTimeout(() => {
+          if (draggedPathRef.current === path) draggedPathRef.current = undefined;
+        });
       }}
     >
-      <div className="flex min-h-0 min-w-0 flex-1 overflow-x-auto">
+      <div className="flex min-h-0 min-w-0 flex-1 gap-2 overflow-x-auto bg-muted/30 p-2">
         {columns.map((state) => (
           <TaskColumn
             key={state}
             state={state}
             tasks={tasks.filter((task) => task.state === state)}
-            onOpen={onOpen}
+            onOpen={(task) => {
+              if (draggedPathRef.current !== task.path) onOpen(task);
+            }}
+            onCreate={onCreate}
           />
         ))}
       </div>
@@ -231,83 +213,130 @@ function TaskColumn({
   state,
   tasks,
   onOpen,
+  onCreate,
 }: {
   state: string;
   tasks: readonly RepoTask[];
   onOpen: (task: RepoTask) => void;
+  onCreate: (title: string, state: string) => boolean;
 }) {
   const { ref, isDropTarget } = useDroppable({ id: `task-state:${state}`, accept: "repo-task" });
+  const [creating, setCreating] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (!creating) return;
+    const frame = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, [creating]);
+
   return (
     <section
       ref={ref}
       data-task-state={state}
       className={cn(
-        "flex min-h-full w-72 shrink-0 flex-col border-r last:border-r-0",
+        "flex min-h-full min-w-72 flex-1 basis-72 flex-col rounded-lg bg-background/70 transition-colors",
         isDropTarget && "bg-accent/40",
       )}
     >
-      <header className="flex h-12 shrink-0 items-center justify-between border-b px-4">
-        <h2 className="text-sm font-medium">{taskStateLabel(state)}</h2>
-        <span className="text-xs tabular-nums text-muted-foreground">{tasks.length}</span>
+      <header className="flex h-12 shrink-0 items-center justify-between px-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <TaskStateIcon state={state} />
+          <h2 className="truncate text-sm font-medium">{taskStateLabel(state)}</h2>
+          <span className="text-xs tabular-nums text-muted-foreground">{tasks.length}</span>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          title={`Add task to ${taskStateLabel(state)}`}
+          aria-label={`Add task to ${taskStateLabel(state)}`}
+          onClick={() => setCreating(true)}
+        >
+          <PlusIcon data-icon="inline-start" />
+        </Button>
       </header>
-      <div className="flex flex-1 flex-col">
-        {tasks.length === 0 ? (
-          <p className="p-4 text-xs text-muted-foreground">Drop tasks here</p>
-        ) : (
-          tasks.map((task) => <TaskRow key={task.path} task={task} onOpen={onOpen} />)
-        )}
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2 pb-2">
+        {creating ? (
+          <form
+            className="mb-2 rounded-lg border bg-card p-2 shadow-xs"
+            onSubmit={(event) => {
+              event.preventDefault();
+              const title = String(new FormData(event.currentTarget).get("title") ?? "");
+              if (onCreate(title, state)) setCreating(false);
+            }}
+          >
+            <Input
+              ref={inputRef}
+              aria-label={`New ${taskStateLabel(state)} task title`}
+              name="title"
+              placeholder="Task title"
+              onKeyDown={(event) => {
+                if (event.key === "Escape") setCreating(false);
+              }}
+            />
+          </form>
+        ) : null}
+        <div className="flex flex-col gap-2">
+          {tasks.map((task) => (
+            <TaskCard key={task.path} task={task} onOpen={onOpen} />
+          ))}
+        </div>
       </div>
     </section>
   );
 }
 
-function TaskRow({ task, onOpen }: { task: RepoTask; onOpen: (task: RepoTask) => void }) {
-  const { ref, handleRef, isDragging } = useDraggable({ id: task.path, type: "repo-task" });
+function TaskCard({ task, onOpen }: { task: RepoTask; onOpen: (task: RepoTask) => void }) {
+  const { ref, isDragging } = useDraggable({ id: task.path, type: "repo-task" });
   const summary = task.description.replace(/\s+/g, " ").slice(0, 160);
   return (
-    <article
+    <button
+      type="button"
       ref={ref}
       data-task-path={task.path}
+      aria-label={task.title}
+      onClick={() => onOpen(task)}
       className={cn(
-        "group border-b px-3 py-3 transition-colors hover:bg-muted/40",
-        isDragging && "opacity-50",
+        "w-full cursor-grab rounded-lg border bg-card p-3 text-left shadow-xs transition-[background-color,border-color,box-shadow,opacity] hover:border-foreground/15 hover:bg-accent/30 hover:shadow-sm active:cursor-grabbing",
+        isDragging && "opacity-40 shadow-none",
       )}
     >
-      <div className="flex items-start gap-1">
-        <Button
-          ref={handleRef}
-          variant="ghost"
-          size="icon-xs"
-          className="mt-0.5 shrink-0 text-muted-foreground opacity-40 group-hover:opacity-100"
-          title={`Drag ${task.title}`}
-          aria-label={`Drag ${task.title}`}
-        >
-          <GripVerticalIcon data-icon="inline-start" />
-        </Button>
-        <div className="min-w-0 flex-1">
-          <button
-            type="button"
-            className="block w-full text-left text-sm font-medium hover:underline"
-            onClick={() => onOpen(task)}
-          >
-            {task.title}
-          </button>
-          {summary === "" ? null : (
-            <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
-              {summary}
-            </p>
-          )}
-          <div className="mt-2 flex flex-wrap gap-1">
-            {task.labels.map((label, index) => (
-              <Badge key={label} variant={index === 0 ? "outline" : "secondary"}>
-                {label}
-              </Badge>
-            ))}
-          </div>
-        </div>
+      <div className="flex items-start gap-2">
+        <TaskStateIcon state={task.state} className="mt-0.5" />
+        <span className="min-w-0 flex-1 text-sm font-medium leading-snug">{task.title}</span>
       </div>
-    </article>
+      {summary === "" ? null : (
+        <p className="mt-2 line-clamp-2 text-xs leading-relaxed text-muted-foreground">{summary}</p>
+      )}
+      <div className="mt-3 flex min-w-0 flex-wrap items-center gap-1.5">
+        <span className="truncate font-mono text-[10px] text-muted-foreground">
+          {task.labels[0]}
+        </span>
+        {task.explicitLabels.map((label) => (
+          <Badge key={label} variant="secondary">
+            {label}
+          </Badge>
+        ))}
+      </div>
+    </button>
   );
+}
+
+function TaskStateIcon({ state, className }: { state: string; className?: string }) {
+  const Icon =
+    state === "backlog"
+      ? CircleDashedIcon
+      : state === "done"
+        ? CircleCheckIcon
+        : state === "in-progress"
+          ? CircleDotDashedIcon
+          : CircleIcon;
+  const tone =
+    state === "done"
+      ? "text-emerald-500"
+      : state === "in-progress"
+        ? "text-primary"
+        : "text-muted-foreground";
+  return <Icon aria-hidden className={cn("size-4 shrink-0", tone, className)} />;
 }
 
 function TaskEditorSheet({
@@ -326,6 +355,13 @@ function TaskEditorSheet({
   onChangeLabels: (labels: string[]) => void;
 }) {
   const editorRef = useRef<HTMLTextAreaElement>(null);
+  const taskPath = task?.path;
+  useEffect(() => {
+    if (taskPath === undefined) return;
+    const frame = requestAnimationFrame(() => editorRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, [taskPath]);
+
   return (
     <Sheet open={task !== undefined} onOpenChange={onOpenChange}>
       {task === undefined ? null : (

--- a/apps/os/src/components/repo-ide/repo-tasks.test.ts
+++ b/apps/os/src/components/repo-ide/repo-tasks.test.ts
@@ -3,7 +3,9 @@ import {
   createRepoTask,
   isRepoTaskPath,
   parseRepoTask,
+  repoTaskPathInDirectory,
   repoTaskCreationPaths,
+  taskDirectoryForFolder,
   taskDirectoryForPath,
   taskStateColumns,
   updateRepoTaskLabels,
@@ -25,20 +27,21 @@ test("projects a bare Markdown file into a task", () => {
   ).toEqual({
     path: "apps/os/tasks/speed-up.md",
     taskDirectoryPath: "apps/os/tasks",
+    folderPath: "/apps/os",
     title: "Make OS faster",
     description: "Measure first.",
     state: "todo",
-    explicitLabels: [],
-    labels: ["folder:/apps/os"],
+    labels: [],
     content: "# Make OS faster\n\nMeasure first.\n",
   });
 });
 
-test("falls back to the filename and infers the root folder label", () => {
+test("falls back to the filename and infers the root folder", () => {
   const task = parseRepoTask("tasks/fix-auth.md", "There is no heading yet.");
   expect(task?.title).toBe("fix-auth");
   expect(task?.description).toBe("There is no heading yet.");
-  expect(task?.labels).toEqual(["folder:/"]);
+  expect(task?.folderPath).toBe("/");
+  expect(task?.labels).toEqual([]);
 });
 
 test("reads canonical and legacy frontmatter without requiring it", () => {
@@ -47,15 +50,15 @@ test("reads canonical and legacy frontmatter without requiring it", () => {
     "---\nstate: in-progress\nlabels: [ui, polish]\ntags: [polish, v1]\n---\n# Card\n",
   );
   expect(canonical?.state).toBe("in-progress");
-  expect(canonical?.explicitLabels).toEqual(["ui", "polish", "v1"]);
-  expect(canonical?.labels).toEqual(["folder:/packages/ui", "ui", "polish", "v1"]);
+  expect(canonical?.folderPath).toBe("/packages/ui");
+  expect(canonical?.labels).toEqual(["ui", "polish", "v1"]);
 
   const legacy = parseRepoTask(
     "tasks/legacy.md",
     "---\nstatus: in-review\ntags: backend\n---\nLegacy task\n",
   );
   expect(legacy?.state).toBe("in-review");
-  expect(legacy?.explicitLabels).toEqual(["backend"]);
+  expect(legacy?.labels).toEqual(["backend"]);
 });
 
 test("updates state while preserving unrelated YAML, comments, and Markdown", () => {
@@ -74,7 +77,7 @@ test("adds state frontmatter to a bare task and updates the legacy key in place"
   expect(legacy).not.toContain("state:");
 });
 
-test("updates explicit labels without serializing the inferred folder label", () => {
+test("updates labels stored in frontmatter", () => {
   const updated = updateRepoTaskLabels("# Labels\n", ["frontend", "frontend", "v1"]);
   expect(updated).toBe("---\nlabels:\n  - frontend\n  - v1\n---\n\n# Labels\n");
   expect(updated).not.toContain("folder:");
@@ -87,7 +90,7 @@ test("replaces mixed canonical and legacy labels without leaving stale tags", ()
   const content = "---\nlabels: [ui, polish]\ntags: [v1, polish]\n---\n# Mixed labels\n";
   const updated = updateRepoTaskLabels(content, ["ui"]);
 
-  expect(parseRepoTask("tasks/mixed-labels.md", updated)?.explicitLabels).toEqual(["ui"]);
+  expect(parseRepoTask("tasks/mixed-labels.md", updated)?.labels).toEqual(["ui"]);
   expect(updated).not.toContain("tags:");
 });
 
@@ -98,6 +101,22 @@ test("creates a bare task with a stable collision-free path", () => {
     content: "# Ship the board!\n",
   });
   expect(createRepoTask("   ", paths)).toBeNull();
+});
+
+test("creates tasks in a folder's conventional task directory", () => {
+  expect(taskDirectoryForFolder("/apps/os")).toBe("apps/os/tasks");
+  expect(taskDirectoryForFolder("/")).toBe("tasks");
+  expect(createRepoTask("Ship it", new Set(), taskDirectoryForFolder("/apps/os"))?.path).toBe(
+    "apps/os/tasks/ship-it.md",
+  );
+});
+
+test("picks a collision-free path when moving a task between folders", () => {
+  const paths = new Set(["tasks/plan.md", "apps/os/tasks/plan.md", "apps/os/tasks/plan-2.md"]);
+  expect(repoTaskPathInDirectory("tasks/plan.md", "apps/os/tasks", paths)).toBe(
+    "apps/os/tasks/plan-3.md",
+  );
+  expect(repoTaskPathInDirectory("tasks/plan.md", "tasks", paths)).toBe("tasks/plan.md");
 });
 
 test("reserves a task path that exists at HEAD while its deletion is pending", () => {

--- a/apps/os/src/components/repo-ide/repo-tasks.test.ts
+++ b/apps/os/src/components/repo-ide/repo-tasks.test.ts
@@ -149,6 +149,7 @@ test("queries a status board with folders as an independent row dimension", () =
   const board = queryRepoTaskBoard(tasks, { filter: "", columns: "state", rows: "folder" });
 
   expect(board.states).toEqual(["backlog", "todo", "in-progress", "done"]);
+  expect(board.visibleProperties).toEqual({ folder: false, state: false, labels: true });
   expect(board.rows.map((row) => row.label)).toEqual(["/", "/apps/os"]);
   expect(board.rows[1]?.cells.find((cell) => cell.state === "todo")?.tasks[0]?.title).toBe(
     "Test OS",
@@ -166,6 +167,7 @@ test("filters the board projection and can group multi-label tasks", () => {
   const byLabel = queryRepoTaskBoard([task], { filter: "card", columns: "state", rows: "label" });
 
   expect(byLabel.taskCount).toBe(1);
+  expect(byLabel.visibleProperties).toEqual({ folder: true, state: false, labels: false });
   expect(byLabel.rows.map((row) => row.label)).toEqual(["frontend", "polish"]);
   expect(
     queryRepoTaskBoard([task], { filter: "missing", columns: "state", rows: null }).taskCount,

--- a/apps/os/src/components/repo-ide/repo-tasks.test.ts
+++ b/apps/os/src/components/repo-ide/repo-tasks.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "vitest";
+import {
+  createRepoTask,
+  isRepoTaskPath,
+  parseRepoTask,
+  taskDirectoryForPath,
+  taskStateColumns,
+  updateRepoTaskLabels,
+  updateRepoTaskState,
+} from "./repo-tasks.ts";
+
+test("recognizes Markdown files in any tasks directory", () => {
+  expect(isRepoTaskPath("tasks/ship-it.md")).toBe(true);
+  expect(isRepoTaskPath("apps/os/tasks/ship-it.markdown")).toBe(true);
+  expect(isRepoTaskPath("apps/os/tasks/notes/ship-it.md")).toBe(true);
+  expect(isRepoTaskPath("apps/os/task/ship-it.md")).toBe(false);
+  expect(isRepoTaskPath("apps/os/tasks/ship-it.txt")).toBe(false);
+  expect(taskDirectoryForPath("apps/os/tasks/notes/ship-it.md")).toBe("apps/os/tasks");
+});
+
+test("projects a bare Markdown file into a task", () => {
+  expect(
+    parseRepoTask("apps/os/tasks/speed-up.md", "# Make OS faster\n\nMeasure first.\n"),
+  ).toEqual({
+    path: "apps/os/tasks/speed-up.md",
+    taskDirectoryPath: "apps/os/tasks",
+    title: "Make OS faster",
+    description: "Measure first.",
+    state: "todo",
+    explicitLabels: [],
+    labels: ["folder:apps/os"],
+    content: "# Make OS faster\n\nMeasure first.\n",
+  });
+});
+
+test("falls back to the filename and infers the root folder label", () => {
+  const task = parseRepoTask("tasks/fix-auth.md", "There is no heading yet.");
+  expect(task?.title).toBe("fix-auth");
+  expect(task?.description).toBe("There is no heading yet.");
+  expect(task?.labels).toEqual(["folder:."]);
+});
+
+test("reads canonical and legacy frontmatter without requiring it", () => {
+  const canonical = parseRepoTask(
+    "packages/ui/tasks/card.md",
+    "---\nstate: in-progress\nlabels: [ui, polish]\ntags: [polish, v1]\n---\n# Card\n",
+  );
+  expect(canonical?.state).toBe("in-progress");
+  expect(canonical?.explicitLabels).toEqual(["ui", "polish", "v1"]);
+  expect(canonical?.labels).toEqual(["folder:packages/ui", "ui", "polish", "v1"]);
+
+  const legacy = parseRepoTask(
+    "tasks/legacy.md",
+    "---\nstatus: in-review\ntags: backend\n---\nLegacy task\n",
+  );
+  expect(legacy?.state).toBe("in-review");
+  expect(legacy?.explicitLabels).toEqual(["backend"]);
+});
+
+test("updates state while preserving unrelated YAML, comments, and Markdown", () => {
+  const content = "---\n# keep this\nstate: todo\nsize: small\n---\n\n# Ship it\n\nBody.\n";
+  const updated = updateRepoTaskState(content, "in-progress");
+  expect(updated).toContain("# keep this");
+  expect(updated).toContain("state: in-progress");
+  expect(updated).toContain("size: small");
+  expect(updated.endsWith("\n# Ship it\n\nBody.\n")).toBe(true);
+});
+
+test("adds state frontmatter to a bare task and updates the legacy key in place", () => {
+  expect(updateRepoTaskState("# New task\n", "done")).toBe("---\nstate: done\n---\n\n# New task\n");
+  const legacy = updateRepoTaskState("---\nstatus: todo\n---\n# Old\n", "done");
+  expect(legacy).toContain("status: done");
+  expect(legacy).not.toContain("state:");
+});
+
+test("updates explicit labels without serializing the inferred folder label", () => {
+  const updated = updateRepoTaskLabels("# Labels\n", ["frontend", "frontend", "v1"]);
+  expect(updated).toBe("---\nlabels:\n  - frontend\n  - v1\n---\n\n# Labels\n");
+  expect(updated).not.toContain("folder:");
+
+  const removed = updateRepoTaskLabels(updated, []);
+  expect(removed).toBe("\n# Labels\n");
+});
+
+test("creates a bare task with a stable collision-free path", () => {
+  const paths = new Set(["tasks/ship-the-board.md", "tasks/ship-the-board-2.md"]);
+  expect(createRepoTask("  Ship the board!  ", paths)).toEqual({
+    path: "tasks/ship-the-board-3.md",
+    content: "# Ship the board!\n",
+  });
+  expect(createRepoTask("   ", paths)).toBeNull();
+});
+
+test("keeps the core columns and appends states found in the repo", () => {
+  const task = parseRepoTask("tasks/review.md", "---\nstate: in-review\n---\n# Review\n")!;
+  expect(taskStateColumns([task])).toEqual(["backlog", "todo", "in-progress", "done", "in-review"]);
+});

--- a/apps/os/src/components/repo-ide/repo-tasks.test.ts
+++ b/apps/os/src/components/repo-ide/repo-tasks.test.ts
@@ -3,6 +3,7 @@ import {
   createRepoTask,
   isRepoTaskPath,
   parseRepoTask,
+  repoTaskCreationPaths,
   taskDirectoryForPath,
   taskStateColumns,
   updateRepoTaskLabels,
@@ -82,6 +83,14 @@ test("updates explicit labels without serializing the inferred folder label", ()
   expect(removed).toBe("\n# Labels\n");
 });
 
+test("replaces mixed canonical and legacy labels without leaving stale tags", () => {
+  const content = "---\nlabels: [ui, polish]\ntags: [v1, polish]\n---\n# Mixed labels\n";
+  const updated = updateRepoTaskLabels(content, ["ui"]);
+
+  expect(parseRepoTask("tasks/mixed-labels.md", updated)?.explicitLabels).toEqual(["ui"]);
+  expect(updated).not.toContain("tags:");
+});
+
 test("creates a bare task with a stable collision-free path", () => {
   const paths = new Set(["tasks/ship-the-board.md", "tasks/ship-the-board-2.md"]);
   expect(createRepoTask("  Ship the board!  ", paths)).toEqual({
@@ -89,6 +98,12 @@ test("creates a bare task with a stable collision-free path", () => {
     content: "# Ship the board!\n",
   });
   expect(createRepoTask("   ", paths)).toBeNull();
+});
+
+test("reserves a task path that exists at HEAD while its deletion is pending", () => {
+  const paths = repoTaskCreationPaths(["tasks/reuse-me.md"], [["tasks/reuse-me.md", "delete"]]);
+
+  expect(createRepoTask("Reuse me", paths)?.path).toBe("tasks/reuse-me-2.md");
 });
 
 test("keeps the core columns and appends states found in the repo", () => {

--- a/apps/os/src/components/repo-ide/repo-tasks.test.ts
+++ b/apps/os/src/components/repo-ide/repo-tasks.test.ts
@@ -29,7 +29,7 @@ test("projects a bare Markdown file into a task", () => {
     description: "Measure first.",
     state: "todo",
     explicitLabels: [],
-    labels: ["folder:apps/os"],
+    labels: ["folder:/apps/os"],
     content: "# Make OS faster\n\nMeasure first.\n",
   });
 });
@@ -38,7 +38,7 @@ test("falls back to the filename and infers the root folder label", () => {
   const task = parseRepoTask("tasks/fix-auth.md", "There is no heading yet.");
   expect(task?.title).toBe("fix-auth");
   expect(task?.description).toBe("There is no heading yet.");
-  expect(task?.labels).toEqual(["folder:."]);
+  expect(task?.labels).toEqual(["folder:/"]);
 });
 
 test("reads canonical and legacy frontmatter without requiring it", () => {
@@ -48,7 +48,7 @@ test("reads canonical and legacy frontmatter without requiring it", () => {
   );
   expect(canonical?.state).toBe("in-progress");
   expect(canonical?.explicitLabels).toEqual(["ui", "polish", "v1"]);
-  expect(canonical?.labels).toEqual(["folder:packages/ui", "ui", "polish", "v1"]);
+  expect(canonical?.labels).toEqual(["folder:/packages/ui", "ui", "polish", "v1"]);
 
   const legacy = parseRepoTask(
     "tasks/legacy.md",

--- a/apps/os/src/components/repo-ide/repo-tasks.test.ts
+++ b/apps/os/src/components/repo-ide/repo-tasks.test.ts
@@ -3,6 +3,7 @@ import {
   createRepoTask,
   isRepoTaskPath,
   parseRepoTask,
+  queryRepoTaskBoard,
   repoTaskPathInDirectory,
   repoTaskCreationPaths,
   taskDirectoryForFolder,
@@ -137,4 +138,36 @@ test("reserves a task path that exists at HEAD while its deletion is pending", (
 test("keeps the core columns and appends states found in the repo", () => {
   const task = parseRepoTask("tasks/review.md", "---\nstate: in-review\n---\n# Review\n")!;
   expect(taskStateColumns([task])).toEqual(["backlog", "todo", "in-progress", "done", "in-review"]);
+});
+
+test("queries a status board with folders as an independent row dimension", () => {
+  const tasks = [
+    parseRepoTask("tasks/root.md", "# Root\n")!,
+    parseRepoTask("apps/os/tasks/ship.md", "---\nstate: in-progress\n---\n# Ship OS\n")!,
+    parseRepoTask("apps/os/tasks/test.md", "---\nlabels: [quality]\n---\n# Test OS\n")!,
+  ];
+  const board = queryRepoTaskBoard(tasks, { filter: "", columns: "state", rows: "folder" });
+
+  expect(board.states).toEqual(["backlog", "todo", "in-progress", "done"]);
+  expect(board.rows.map((row) => row.label)).toEqual(["/", "/apps/os"]);
+  expect(board.rows[1]?.cells.find((cell) => cell.state === "todo")?.tasks[0]?.title).toBe(
+    "Test OS",
+  );
+  expect(board.rows[1]?.cells.find((cell) => cell.state === "in-progress")?.tasks[0]?.title).toBe(
+    "Ship OS",
+  );
+});
+
+test("filters the board projection and can group multi-label tasks", () => {
+  const task = parseRepoTask(
+    "tasks/card.md",
+    "---\nlabels: [frontend, polish]\n---\n# Polish card\n",
+  )!;
+  const byLabel = queryRepoTaskBoard([task], { filter: "card", columns: "state", rows: "label" });
+
+  expect(byLabel.taskCount).toBe(1);
+  expect(byLabel.rows.map((row) => row.label)).toEqual(["frontend", "polish"]);
+  expect(
+    queryRepoTaskBoard([task], { filter: "missing", columns: "state", rows: null }).taskCount,
+  ).toBe(0);
 });

--- a/apps/os/src/components/repo-ide/repo-tasks.test.ts
+++ b/apps/os/src/components/repo-ide/repo-tasks.test.ts
@@ -61,6 +61,15 @@ test("reads canonical and legacy frontmatter without requiring it", () => {
   expect(legacy?.labels).toEqual(["backend"]);
 });
 
+test("uses an explicit title before the first heading", () => {
+  const task = parseRepoTask(
+    "tasks/rename-me.md",
+    "---\ntitle: Frontmatter title\n---\n# Heading title\n\nDescription.\n",
+  );
+  expect(task?.title).toBe("Frontmatter title");
+  expect(task?.description).toBe("Description.");
+});
+
 test("updates state while preserving unrelated YAML, comments, and Markdown", () => {
   const content = "---\n# keep this\nstate: todo\nsize: small\n---\n\n# Ship it\n\nBody.\n";
   const updated = updateRepoTaskState(content, "in-progress");

--- a/apps/os/src/components/repo-ide/repo-tasks.ts
+++ b/apps/os/src/components/repo-ide/repo-tasks.ts
@@ -15,6 +15,28 @@ export type RepoTask = {
   content: string;
 };
 
+export type RepoTaskBoardRowField = "folder" | "label" | null;
+
+export type RepoTaskBoardQuery = {
+  filter: string;
+  columns: "state";
+  rows: RepoTaskBoardRowField;
+};
+
+type RepoTaskBoardRow = {
+  key: string;
+  label: string | null;
+  value: string | null;
+  tasks: RepoTask[];
+  cells: Array<{ state: string; tasks: RepoTask[] }>;
+};
+
+export type RepoTaskBoardProjection = {
+  states: string[];
+  rows: RepoTaskBoardRow[];
+  taskCount: number;
+};
+
 /** Markdown files below any directory segment named `tasks` are repo tasks. */
 export function isRepoTaskPath(path: string): boolean {
   const segments = pathSegments(path);
@@ -151,6 +173,34 @@ export function taskStateColumns(tasks: readonly RepoTask[]): string[] {
   ];
 }
 
+/** Query tasks into the row × state cells consumed by the board renderer. */
+export function queryRepoTaskBoard(
+  tasks: readonly RepoTask[],
+  query: RepoTaskBoardQuery,
+): RepoTaskBoardProjection {
+  const states = taskStateColumns(tasks);
+  const filter = query.filter.trim().toLocaleLowerCase();
+  const matchingTasks = tasks.filter(
+    (task) =>
+      filter === "" ||
+      [task.title, task.description, task.state, task.folderPath, ...task.labels].some((value) =>
+        value.toLocaleLowerCase().includes(filter),
+      ),
+  );
+  const rowGroups = taskBoardRowGroups(matchingTasks, query.rows);
+  return {
+    states,
+    rows: rowGroups.map((row) => ({
+      ...row,
+      cells: states.map((state) => ({
+        state,
+        tasks: row.tasks.filter((task) => task.state === state),
+      })),
+    })),
+    taskCount: matchingTasks.length,
+  };
+}
+
 export function taskStateLabel(state: string): string {
   return state
     .split(/[-_\s]+/)
@@ -161,6 +211,53 @@ export function taskStateLabel(state: string): string {
 
 function pathSegments(path: string): string[] {
   return path.split("/").filter(Boolean);
+}
+
+function taskBoardRowGroups(
+  tasks: readonly RepoTask[],
+  rowField: RepoTaskBoardRowField,
+): Array<Pick<RepoTaskBoardRow, "key" | "label" | "value" | "tasks">> {
+  if (rowField === null) return [{ key: "all", label: null, value: null, tasks: [...tasks] }];
+
+  const groups = new Map<string, RepoTask[]>();
+  if (rowField === "folder") {
+    for (const task of tasks) {
+      const group = groups.get(task.folderPath) ?? [];
+      group.push(task);
+      groups.set(task.folderPath, group);
+    }
+    if (groups.size === 0) groups.set("/", []);
+    return [...groups]
+      .sort(([left], [right]) => {
+        if (left === "/") return -1;
+        if (right === "/") return 1;
+        return left.localeCompare(right);
+      })
+      .map(([folderPath, groupedTasks]) => ({
+        key: `folder:${folderPath}`,
+        label: folderPath,
+        value: folderPath,
+        tasks: groupedTasks,
+      }));
+  }
+
+  for (const task of tasks) {
+    const labels = task.labels.length === 0 ? [""] : task.labels;
+    for (const label of labels) {
+      const group = groups.get(label) ?? [];
+      group.push(task);
+      groups.set(label, group);
+    }
+  }
+  if (groups.size === 0) groups.set("", []);
+  return [...groups]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([label, groupedTasks]) => ({
+      key: `label:${label}`,
+      label: label === "" ? "No label" : label,
+      value: label === "" ? null : label,
+      tasks: groupedTasks,
+    }));
 }
 
 function firstHeading(body: string): { start: number; end: number; title: string } | undefined {

--- a/apps/os/src/components/repo-ide/repo-tasks.ts
+++ b/apps/os/src/components/repo-ide/repo-tasks.ts
@@ -7,10 +7,10 @@ const STANDARD_TASK_STATES = ["backlog", DEFAULT_TASK_STATE, "in-progress", "don
 export type RepoTask = {
   path: string;
   taskDirectoryPath: string;
+  folderPath: string;
   title: string;
   description: string;
   state: string;
-  explicitLabels: string[];
   labels: string[];
   content: string;
 };
@@ -21,7 +21,7 @@ export function isRepoTaskPath(path: string): boolean {
   return /\.(?:md|markdown)$/i.test(segments.at(-1) ?? "") && segments.includes("tasks");
 }
 
-/** The nearest `tasks` directory owns a task; its parent becomes the folder label. */
+/** The nearest `tasks` directory owns a task. */
 export function taskDirectoryForPath(path: string): string | null {
   if (!isRepoTaskPath(path)) return null;
   const segments = pathSegments(path);
@@ -36,26 +36,22 @@ export function parseRepoTask(path: string, content: string): RepoTask | null {
   const frontmatter = readFrontmatter(content);
   const metadata = documentRecord(frontmatter.document);
   const state = stringValue(metadata.state) ?? stringValue(metadata.status) ?? DEFAULT_TASK_STATE;
-  const explicitLabels = uniqueStrings([
-    ...stringArray(metadata.labels),
-    ...stringArray(metadata.tags),
-  ]);
-  const folderPath = taskDirectoryPath.split("/").slice(0, -1).join("/");
-  const folderLabel = `folder:/${folderPath}`;
+  const labels = uniqueStrings([...stringArray(metadata.labels), ...stringArray(metadata.tags)]);
+  const folderPath = `/${taskDirectoryPath.split("/").slice(0, -1).join("/")}`;
   const heading = firstHeading(frontmatter.body);
   const fallbackTitle = (pathSegments(path).at(-1) ?? "task").replace(/\.(?:md|markdown)$/i, "");
 
   return {
     path,
     taskDirectoryPath,
+    folderPath,
     title: heading?.title ?? fallbackTitle,
     description:
       heading === undefined
         ? frontmatter.body.trim()
         : `${frontmatter.body.slice(0, heading.start)}${frontmatter.body.slice(heading.end)}`.trim(),
     state,
-    explicitLabels,
-    labels: uniqueStrings([folderLabel, ...explicitLabels]),
+    labels,
     content,
   };
 }
@@ -71,7 +67,7 @@ export function updateRepoTaskState(content: string, state: string): string {
   });
 }
 
-/** Folder labels are inferred, so callers pass only labels that belong in YAML. */
+/** Change labels stored in YAML while preserving unrelated frontmatter and Markdown. */
 export function updateRepoTaskLabels(content: string, labels: readonly string[]): string {
   const normalized = uniqueStrings(labels);
   return updateFrontmatter(content, (document, metadata) => {
@@ -91,18 +87,48 @@ export function updateRepoTaskLabels(content: string, labels: readonly string[])
 export function createRepoTask(
   title: string,
   existingPaths: ReadonlySet<string>,
+  taskDirectoryPath = "tasks",
 ): { path: string; content: string } | null {
   const normalizedTitle = title.trim();
   if (normalizedTitle === "") return null;
 
   const base = slugify(normalizedTitle) || "task";
+  const directory = pathSegments(taskDirectoryPath).join("/") || "tasks";
   let suffix = 1;
-  let path = `tasks/${base}.md`;
+  let path = `${directory}/${base}.md`;
   while (existingPaths.has(path)) {
     suffix += 1;
-    path = `tasks/${base}-${suffix}.md`;
+    path = `${directory}/${base}-${suffix}.md`;
   }
   return { path, content: `# ${normalizedTitle}\n` };
+}
+
+/** The conventional task directory for a repo folder shown as `/apps/os`. */
+export function taskDirectoryForFolder(folderPath: string): string {
+  const directory = pathSegments(folderPath).join("/");
+  return directory === "" ? "tasks" : `${directory}/tasks`;
+}
+
+/** Pick a collision-free path when a task file moves to another task directory. */
+export function repoTaskPathInDirectory(
+  path: string,
+  taskDirectoryPath: string,
+  existingPaths: ReadonlySet<string>,
+): string {
+  const filename = pathSegments(path).at(-1) ?? "task.md";
+  const directory = pathSegments(taskDirectoryPath).join("/") || "tasks";
+  const directPath = `${directory}/${filename}`;
+  if (directPath === path || !existingPaths.has(directPath)) return directPath;
+
+  const extension = /\.(?:md|markdown)$/i.exec(filename)?.[0] ?? ".md";
+  const base = filename.slice(0, -extension.length) || "task";
+  let suffix = 2;
+  let candidate = `${directory}/${base}-${suffix}${extension}`;
+  while (existingPaths.has(candidate)) {
+    suffix += 1;
+    candidate = `${directory}/${base}-${suffix}${extension}`;
+  }
+  return candidate;
 }
 
 export function repoTaskCreationPaths(

--- a/apps/os/src/components/repo-ide/repo-tasks.ts
+++ b/apps/os/src/components/repo-ide/repo-tasks.ts
@@ -1,6 +1,6 @@
 import { parseDocument, type Document } from "yaml";
 
-export const DEFAULT_TASK_STATE = "todo";
+const DEFAULT_TASK_STATE = "todo";
 
 const STANDARD_TASK_STATES = ["backlog", DEFAULT_TASK_STATE, "in-progress", "done"] as const;
 
@@ -75,9 +75,16 @@ export function updateRepoTaskState(content: string, state: string): string {
 export function updateRepoTaskLabels(content: string, labels: readonly string[]): string {
   const normalized = uniqueStrings(labels);
   return updateFrontmatter(content, (document, metadata) => {
-    const key = metadata.labels === undefined && metadata.tags !== undefined ? "tags" : "labels";
-    if (normalized.length === 0) document.delete(key);
-    else document.set(key, normalized);
+    const usesLegacyTags = metadata.labels === undefined && metadata.tags !== undefined;
+    if (normalized.length === 0) {
+      document.delete("labels");
+      document.delete("tags");
+    } else if (usesLegacyTags) {
+      document.set("tags", normalized);
+    } else {
+      document.set("labels", normalized);
+      document.delete("tags");
+    }
   });
 }
 
@@ -96,6 +103,17 @@ export function createRepoTask(
     path = `tasks/${base}-${suffix}.md`;
   }
   return { path, content: `# ${normalizedTitle}\n` };
+}
+
+export function repoTaskCreationPaths(
+  headPaths: readonly string[],
+  changes: Iterable<readonly [path: string, type: "write" | "write-base64" | "delete" | undefined]>,
+): Set<string> {
+  const paths = new Set(headPaths);
+  for (const [path, type] of changes) {
+    if (type === "write" || type === "write-base64") paths.add(path);
+  }
+  return paths;
 }
 
 export function taskStateColumns(tasks: readonly RepoTask[]): string[] {

--- a/apps/os/src/components/repo-ide/repo-tasks.ts
+++ b/apps/os/src/components/repo-ide/repo-tasks.ts
@@ -40,8 +40,8 @@ export function parseRepoTask(path: string, content: string): RepoTask | null {
     ...stringArray(metadata.labels),
     ...stringArray(metadata.tags),
   ]);
-  const folderPath = taskDirectoryPath.split("/").slice(0, -1).join("/") || ".";
-  const folderLabel = `folder:${folderPath}`;
+  const folderPath = taskDirectoryPath.split("/").slice(0, -1).join("/");
+  const folderLabel = `folder:/${folderPath}`;
   const heading = firstHeading(frontmatter.body);
   const fallbackTitle = (pathSegments(path).at(-1) ?? "task").replace(/\.(?:md|markdown)$/i, "");
 

--- a/apps/os/src/components/repo-ide/repo-tasks.ts
+++ b/apps/os/src/components/repo-ide/repo-tasks.ts
@@ -1,4 +1,5 @@
-import { parseDocument, type Document } from "yaml";
+import type { Document } from "yaml";
+import { markdownFrontmatterRecord, parseMarkdownFrontmatter } from "./markdown-frontmatter.ts";
 
 const DEFAULT_TASK_STATE = "todo";
 
@@ -35,6 +36,11 @@ export type RepoTaskBoardProjection = {
   states: string[];
   rows: RepoTaskBoardRow[];
   taskCount: number;
+  visibleProperties: {
+    folder: boolean;
+    state: boolean;
+    labels: boolean;
+  };
 };
 
 /** Markdown files below any directory segment named `tasks` are repo tasks. */
@@ -55,8 +61,8 @@ export function parseRepoTask(path: string, content: string): RepoTask | null {
   const taskDirectoryPath = taskDirectoryForPath(path);
   if (taskDirectoryPath === null) return null;
 
-  const frontmatter = readFrontmatter(content);
-  const metadata = documentRecord(frontmatter.document);
+  const frontmatter = parseMarkdownFrontmatter(content);
+  const metadata = markdownFrontmatterRecord(frontmatter.document);
   const state = stringValue(metadata.state) ?? stringValue(metadata.status) ?? DEFAULT_TASK_STATE;
   const labels = uniqueStrings([...stringArray(metadata.labels), ...stringArray(metadata.tags)]);
   const folderPath = `/${taskDirectoryPath.split("/").slice(0, -1).join("/")}`;
@@ -198,6 +204,11 @@ export function queryRepoTaskBoard(
       })),
     })),
     taskCount: matchingTasks.length,
+    visibleProperties: {
+      folder: query.rows !== "folder",
+      state: query.columns !== "state",
+      labels: query.rows !== "label",
+    },
   };
 }
 
@@ -269,37 +280,12 @@ function firstHeading(body: string): { start: number; end: number; title: string
   return { start: match.index, end, title: match[1]!.trim() };
 }
 
-function readFrontmatter(content: string): {
-  body: string;
-  document: Document;
-  exists: boolean;
-} {
-  const match = /^---[ \t]*\r?\n([\s\S]*?)\r?\n(?:---|\.\.\.)[ \t]*(?:\r?\n|$)/.exec(content);
-  if (match === null) return { body: content, document: parseDocument(""), exists: false };
-  return {
-    body: content.slice(match[0].length),
-    document: parseDocument(match[1] ?? ""),
-    exists: true,
-  };
-}
-
-function documentRecord(document: Document): Record<string, unknown> {
-  try {
-    const value: unknown = document.toJS();
-    return typeof value === "object" && value !== null && !Array.isArray(value)
-      ? (value as Record<string, unknown>)
-      : {};
-  } catch {
-    return {};
-  }
-}
-
 function updateFrontmatter(
   content: string,
   update: (document: Document, metadata: Record<string, unknown>) => void,
 ): string {
-  const frontmatter = readFrontmatter(content);
-  update(frontmatter.document, documentRecord(frontmatter.document));
+  const frontmatter = parseMarkdownFrontmatter(content);
+  update(frontmatter.document, markdownFrontmatterRecord(frontmatter.document));
   const yaml = frontmatter.document.toString().trimEnd();
   if (yaml === "" || yaml === "{}") return frontmatter.body;
   const body = frontmatter.exists ? frontmatter.body : `\n${content}`;

--- a/apps/os/src/components/repo-ide/repo-tasks.ts
+++ b/apps/os/src/components/repo-ide/repo-tasks.ts
@@ -1,0 +1,194 @@
+import { parseDocument, type Document } from "yaml";
+
+export const DEFAULT_TASK_STATE = "todo";
+
+const STANDARD_TASK_STATES = ["backlog", DEFAULT_TASK_STATE, "in-progress", "done"] as const;
+
+export type RepoTask = {
+  path: string;
+  taskDirectoryPath: string;
+  title: string;
+  description: string;
+  state: string;
+  explicitLabels: string[];
+  labels: string[];
+  content: string;
+};
+
+/** Markdown files below any directory segment named `tasks` are repo tasks. */
+export function isRepoTaskPath(path: string): boolean {
+  const segments = pathSegments(path);
+  return /\.(?:md|markdown)$/i.test(segments.at(-1) ?? "") && segments.includes("tasks");
+}
+
+/** The nearest `tasks` directory owns a task; its parent becomes the folder label. */
+export function taskDirectoryForPath(path: string): string | null {
+  if (!isRepoTaskPath(path)) return null;
+  const segments = pathSegments(path);
+  const tasksIndex = segments.lastIndexOf("tasks");
+  return segments.slice(0, tasksIndex + 1).join("/");
+}
+
+export function parseRepoTask(path: string, content: string): RepoTask | null {
+  const taskDirectoryPath = taskDirectoryForPath(path);
+  if (taskDirectoryPath === null) return null;
+
+  const frontmatter = readFrontmatter(content);
+  const metadata = documentRecord(frontmatter.document);
+  const state = stringValue(metadata.state) ?? stringValue(metadata.status) ?? DEFAULT_TASK_STATE;
+  const explicitLabels = uniqueStrings([
+    ...stringArray(metadata.labels),
+    ...stringArray(metadata.tags),
+  ]);
+  const folderPath = taskDirectoryPath.split("/").slice(0, -1).join("/") || ".";
+  const folderLabel = `folder:${folderPath}`;
+  const heading = firstHeading(frontmatter.body);
+  const fallbackTitle = (pathSegments(path).at(-1) ?? "task").replace(/\.(?:md|markdown)$/i, "");
+
+  return {
+    path,
+    taskDirectoryPath,
+    title: heading?.title ?? fallbackTitle,
+    description:
+      heading === undefined
+        ? frontmatter.body.trim()
+        : `${frontmatter.body.slice(0, heading.start)}${frontmatter.body.slice(heading.end)}`.trim(),
+    state,
+    explicitLabels,
+    labels: uniqueStrings([folderLabel, ...explicitLabels]),
+    content,
+  };
+}
+
+/** Change only task metadata, preserving its Markdown body and unrelated YAML keys. */
+export function updateRepoTaskState(content: string, state: string): string {
+  const normalized = state.trim() || DEFAULT_TASK_STATE;
+  return updateFrontmatter(content, (document, metadata) => {
+    document.set(
+      metadata.state === undefined && metadata.status !== undefined ? "status" : "state",
+      normalized,
+    );
+  });
+}
+
+/** Folder labels are inferred, so callers pass only labels that belong in YAML. */
+export function updateRepoTaskLabels(content: string, labels: readonly string[]): string {
+  const normalized = uniqueStrings(labels);
+  return updateFrontmatter(content, (document, metadata) => {
+    const key = metadata.labels === undefined && metadata.tags !== undefined ? "tags" : "labels";
+    if (normalized.length === 0) document.delete(key);
+    else document.set(key, normalized);
+  });
+}
+
+export function createRepoTask(
+  title: string,
+  existingPaths: ReadonlySet<string>,
+): { path: string; content: string } | null {
+  const normalizedTitle = title.trim();
+  if (normalizedTitle === "") return null;
+
+  const base = slugify(normalizedTitle) || "task";
+  let suffix = 1;
+  let path = `tasks/${base}.md`;
+  while (existingPaths.has(path)) {
+    suffix += 1;
+    path = `tasks/${base}-${suffix}.md`;
+  }
+  return { path, content: `# ${normalizedTitle}\n` };
+}
+
+export function taskStateColumns(tasks: readonly RepoTask[]): string[] {
+  const unknown = new Set(tasks.map((task) => task.state));
+  for (const state of STANDARD_TASK_STATES) unknown.delete(state);
+  return [
+    ...STANDARD_TASK_STATES,
+    ...[...unknown].sort((left, right) => left.localeCompare(right)),
+  ];
+}
+
+export function taskStateLabel(state: string): string {
+  return state
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+    .join(" ");
+}
+
+function pathSegments(path: string): string[] {
+  return path.split("/").filter(Boolean);
+}
+
+function firstHeading(body: string): { start: number; end: number; title: string } | undefined {
+  const match = /^#\s+(.+?)\s*#*\s*$/m.exec(body);
+  if (match === null || match.index === undefined) return undefined;
+  let end = match.index + match[0].length;
+  if (body.slice(end, end + 2) === "\r\n") end += 2;
+  else if (body[end] === "\n") end += 1;
+  return { start: match.index, end, title: match[1]!.trim() };
+}
+
+function readFrontmatter(content: string): {
+  body: string;
+  document: Document;
+  exists: boolean;
+} {
+  const match = /^---[ \t]*\r?\n([\s\S]*?)\r?\n(?:---|\.\.\.)[ \t]*(?:\r?\n|$)/.exec(content);
+  if (match === null) return { body: content, document: parseDocument(""), exists: false };
+  return {
+    body: content.slice(match[0].length),
+    document: parseDocument(match[1] ?? ""),
+    exists: true,
+  };
+}
+
+function documentRecord(document: Document): Record<string, unknown> {
+  try {
+    const value: unknown = document.toJS();
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function updateFrontmatter(
+  content: string,
+  update: (document: Document, metadata: Record<string, unknown>) => void,
+): string {
+  const frontmatter = readFrontmatter(content);
+  update(frontmatter.document, documentRecord(frontmatter.document));
+  const yaml = frontmatter.document.toString().trimEnd();
+  if (yaml === "" || yaml === "{}") return frontmatter.body;
+  const body = frontmatter.exists ? frontmatter.body : `\n${content}`;
+  return `---\n${yaml}\n---\n${body}`;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+}
+
+function stringArray(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => (typeof item === "string" ? [item] : []));
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  const unique = new Set<string>();
+  for (const value of values) {
+    const normalized = value.trim();
+    if (normalized !== "") unique.add(normalized);
+  }
+  return [...unique];
+}
+
+function slugify(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/apps/os/src/components/repo-ide/repo-tasks.ts
+++ b/apps/os/src/components/repo-ide/repo-tasks.ts
@@ -45,7 +45,7 @@ export function parseRepoTask(path: string, content: string): RepoTask | null {
     path,
     taskDirectoryPath,
     folderPath,
-    title: heading?.title ?? fallbackTitle,
+    title: stringValue(metadata.title) ?? heading?.title ?? fallbackTitle,
     description:
       heading === undefined
         ? frontmatter.body.trim()

--- a/apps/os/src/components/repo-ide/staged-changes.test.ts
+++ b/apps/os/src/components/repo-ide/staged-changes.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 import {
   commitPlan,
   effectiveEntry,
+  textContentForEntry,
   workingTreeGitStatus,
   workingTreeStore,
   type FileEntry,
@@ -143,6 +144,19 @@ test("git status derives from the effective entry, staged or live", () => {
     { path: "doomed.ts", status: "deleted" },
   ]);
   expect(effectiveEntry(store.changes.get("doomed.ts")!)).toEqual({ type: "delete" });
+});
+
+test("text content decodes UTF-8 files written through the base64 upload lane", () => {
+  const markdown = "# Caf\u00e9 \u2615\n";
+  const bytes = new TextEncoder().encode(markdown);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+
+  expect(textContentForEntry({ type: "write-base64", contentBase64: btoa(binary) })).toBe(markdown);
+  expect(
+    textContentForEntry({ type: "write-base64", contentBase64: "not base64" }),
+  ).toBeUndefined();
+  expect(textContentForEntry({ type: "delete" })).toBeUndefined();
 });
 
 test("changes persist to storage under the repo+oid key and rehydrate on load", () => {

--- a/apps/os/src/components/repo-ide/staged-changes.ts
+++ b/apps/os/src/components/repo-ide/staged-changes.ts
@@ -174,6 +174,20 @@ export function effectiveEntry(change: FileChange): FileEntry | undefined {
   return change.working ?? change.staged;
 }
 
+/** Decode a text file regardless of which write lane produced it. Uploads use
+ * the base64 lane even for Markdown, so text consumers must decode valid UTF-8
+ * instead of treating every base64 entry as binary. */
+export function textContentForEntry(entry: FileEntry | undefined): string | undefined {
+  if (entry?.type === "write") return entry.content;
+  if (entry?.type !== "write-base64") return undefined;
+  try {
+    const bytes = Uint8Array.from(atob(entry.contentBase64.trim()), (char) => char.charCodeAt(0));
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return undefined;
+  }
+}
+
 /** The pierre-tree git-status annotation for every changed path. */
 export function workingTreeGitStatus(
   changes: WorkingTreeChanges,

--- a/apps/os/src/routes/_app/projects/$projectSlug/repos/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/repos/$.tsx
@@ -9,12 +9,13 @@ import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 import { useLiveState } from "~/itx/itx-react.tsx";
 
 /** The stream-view params plus the IDE's own view state (open file, diff,
- * markdown/html preview, source-control / GitHub sidebar, history sidebar +
- * expanded commit). */
+ * markdown/html preview, tasks/source-control/GitHub sidebar, history sidebar
+ * + expanded commit). */
 const RepoDetailSearch = StreamViewSearch.extend({
   file: z.string().optional().catch(undefined),
   diff: z.boolean().optional().catch(undefined),
   preview: z.boolean().optional().catch(undefined),
+  tasks: z.boolean().optional().catch(undefined),
   scm: z.boolean().optional().catch(undefined),
   gh: z.boolean().optional().catch(undefined),
   staged: z.boolean().optional().catch(undefined),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,6 +519,9 @@ importers:
       '@codemirror/view':
         specifier: ^6.39.16
         version: 6.39.16
+      '@dnd-kit/react':
+        specifier: ^0.5.0
+        version: 0.5.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@iterate-com/auth':
         specifier: workspace:*
         version: link:../auth
@@ -1858,6 +1861,27 @@ packages:
 
   '@dimforge/rapier2d-simd-compat@0.17.3':
     resolution: {integrity: sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg==}
+
+  '@dnd-kit/abstract@0.5.0':
+    resolution: {integrity: sha512-hi13iMJgjPX/KDYVKg5VeDIhmYiV6buc9bAX+tCLYf4QdyYjPbsXjn2sPo6m7fQ6SGJBEFgHJ2PemeKDUbwBaA==}
+
+  '@dnd-kit/collision@0.5.0':
+    resolution: {integrity: sha512-xUqRn3lS7oqLkT0AnnHS/STh/Czvwe1UapZFYiLbsUGxopMsQd4teaPCzPouOThoMdGEe+dHWjfqJl6t9iG4mQ==}
+
+  '@dnd-kit/dom@0.5.0':
+    resolution: {integrity: sha512-f2xFJp5SYQ8EW/Fbtaa8iBb66hpkWc7qa8vU826KW11/tb44sH+AisZnGtwOOTWTQ0GraqBDr5ixTErww+eKXw==}
+
+  '@dnd-kit/geometry@0.5.0':
+    resolution: {integrity: sha512-ubHQS1CiSDH8ssYH2xG5BnpwPSFP1tStXXjug7/Ba6qnQdu/EUH47l6QXKIksQnnanfVfDf0aGeevRxgZlj28A==}
+
+  '@dnd-kit/react@0.5.0':
+    resolution: {integrity: sha512-abQPLI8lmfVE+v/n+pqy5WFxrw6T2Yg0UQZsL78dp5DKci7dKTVDjvLWqvass+XTFtzJmsZEjk1NdqE6xG8Jiw==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@dnd-kit/state@0.5.0':
+    resolution: {integrity: sha512-y7XbabQqjF58Lk8YmDQuR8l6QjN+Kh4qlGEjUvHuIeasLk1QP+9L5diXS98VMxQIivyMmUtX2//f+3N7qPJX4w==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -4093,6 +4117,9 @@ packages:
 
   '@posthog/types@1.360.2':
     resolution: {integrity: sha512-U48CbtmX5kETZvWjaJVlublSA1aLV99m71TQtgxWksBMXINS/3C7j+KqlMO6wH7SuaEZQnjaxh1KYGH4nRCaaA==}
+
+  '@preact/signals-core@1.14.4':
+    resolution: {integrity: sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -12682,6 +12709,45 @@ snapshots:
   '@dimforge/rapier2d-simd-compat@0.17.3':
     optional: true
 
+  '@dnd-kit/abstract@0.5.0':
+    dependencies:
+      '@dnd-kit/geometry': 0.5.0
+      '@dnd-kit/state': 0.5.0
+      tslib: 2.8.1
+
+  '@dnd-kit/collision@0.5.0':
+    dependencies:
+      '@dnd-kit/abstract': 0.5.0
+      '@dnd-kit/geometry': 0.5.0
+      tslib: 2.8.1
+
+  '@dnd-kit/dom@0.5.0':
+    dependencies:
+      '@dnd-kit/abstract': 0.5.0
+      '@dnd-kit/collision': 0.5.0
+      '@dnd-kit/geometry': 0.5.0
+      '@dnd-kit/state': 0.5.0
+      tslib: 2.8.1
+
+  '@dnd-kit/geometry@0.5.0':
+    dependencies:
+      '@dnd-kit/state': 0.5.0
+      tslib: 2.8.1
+
+  '@dnd-kit/react@0.5.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/abstract': 0.5.0
+      '@dnd-kit/dom': 0.5.0
+      '@dnd-kit/state': 0.5.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/state@0.5.0':
+    dependencies:
+      '@preact/signals-core': 1.14.4
+      tslib: 2.8.1
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -14898,6 +14964,8 @@ snapshots:
   '@posthog/types@1.359.1': {}
 
   '@posthog/types@1.360.2': {}
+
+  '@preact/signals-core@1.14.4': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 


### PR DESCRIPTION
## Summary

- add a Tasks mode to the repo IDE that discovers Markdown files under any tasks directory
- project optional YAML frontmatter into task state and labels, with inferred folder labels and filename or H1 titles
- add a minimal shadcn kanban board with accessible dnd-kit state changes
- reuse the existing editor, working tree, staging, and commit flow for all task changes

## V1 boundaries

- new tasks are created in the root tasks directory without required frontmatter and default to Todo
- standard columns are Backlog, Todo, In Progress, and Done; custom states found in files are also shown
- dragging changes state only; cards remain title-sorted with no persisted manual ordering
- comments, attachments, dependencies, sizing, task events, and configurable task roots remain follow-up work

## Verification

- pnpm --dir apps/os test: 1187 passed, 1 skipped
- pnpm lint
- pnpm format:check
- pnpm install --frozen-lockfile --ignore-scripts
- browser-tested task creation, Markdown editing, labels, state selection, drag and drop, and Source Control visibility

## Known existing issue

- pnpm --dir apps/os typecheck reaches the workspace TypeScript check, then fails on the existing duplicate React ref-type errors in packages/ui/src/components/ai-elements/message.tsx and packages/ui/src/components/spinner.tsx; this change introduces no additional typecheck errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new UI surface (~1k+ LOC) that mutates repo files via drag/drop and path moves; behavior is well unit-tested but integrates tightly with working-tree semantics.
> 
> **Overview**
> Adds a **Tasks** activity mode to the repo IDE (`?tasks=true`), backed by Markdown files under any `tasks/` directory. Task **state**, **labels**, and titles come from optional YAML frontmatter (with legacy `status`/`tags` support); create, edit, drag-and-drop, rename, and delete all write through the existing working tree and Source Control commit path—no new backend.
> 
> The board is a status-column kanban with **@dnd-kit/react**, filter/search, row grouping by folder or label, per-column create, and a side sheet for raw Markdown editing. Supporting pieces include shared **markdown frontmatter** parsing, **`textContentForEntry`** so UTF-8 text in base64 upload entries works in the editor and on the board, and markdown preview showing frontmatter in a table above the rendered body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3147e8b8d5ea1cb0e279210a4c030ceb47342996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +3 -2 | +1 -0 🟩⬜⬜⬜⬜ |
| UI components | +1,375 -146 | +1,297 -134 🟩🟩🟩🟩🟩 |
| Tests | +215 -0 | +189 -0 🟩⬜⬜⬜⬜ |
| Config | +1 -0 | +1 -0 🟩⬜⬜⬜⬜ |
| Generated | +68 -0 | +54 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+1,662 -148** | **+1,542 -134** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 0e16315 and 3147e8b, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-13T17:44:14.821Z",
      "headSha": "3147e8b8d5ea1cb0e279210a4c030ceb47342996",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/259663541272380",
      "shortSha": "3147e8b",
      "cleanupDurationMs": 22116,
      "deployDurationMs": 78800,
      "testDurationMs": 233880,
      "testRetries": "7 retried: itx > Dynamic worker env.ITX.get() is scoped by project and agent host path (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · sandbox egress > is MITM-intercepted and routed through project egress with secret substitution (vitest x1) · ephemeral events are second-class rows: excluded from default reads, delivered on ephemeral subscriptions (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1) · reactivity page repaints from a stream subscription after a page action (specs x1) · runs \"scheduler-agent-checkin\" through the project REPL (specs x1)",
      "workerSizeKib": 16069.31,
      "workerGzipKib": 4335.41,
      "mainWorkerGzipKib": 4352.73
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-13T17:43:53.485Z",
      "headSha": "c4e68f575c8b2d4c15f5aa51ab4ffcc02c8addb4",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/421767011887841",
      "shortSha": "c4e68f5",
      "cleanupDurationMs": 777,
      "deployDurationMs": 25943,
      "testDurationMs": 6663,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-13T17:43:55.468Z",
      "headSha": "3147e8b8d5ea1cb0e279210a4c030ceb47342996",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/259663541272380",
      "shortSha": "3147e8b",
      "cleanupDurationMs": 2758,
      "deployDurationMs": 20004,
      "testDurationMs": 791,
      "testRetries": null,
      "workerSizeKib": 4033.03,
      "workerGzipKib": 819.83,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-13T17:43:53.412Z",
      "headSha": "c4e68f575c8b2d4c15f5aa51ab4ffcc02c8addb4",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/421767011887841",
      "shortSha": "c4e68f5",
      "cleanupDurationMs": 699,
      "deployDurationMs": 24828,
      "testDurationMs": 17643,
      "testRetries": null,
      "workerSizeKib": 4889.12,
      "workerGzipKib": 1399.19,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `3147e8b` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 819.8 KiB | 20.0s | 791ms |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/259663541272380) | 2026-07-13T17:43:55.468Z | Preview app released. |
| OS | released | `3147e8b` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.23 MiB (-17.3 KiB vs main) | 78.8s | 233.9s | 7 retried: itx > Dynamic worker env.ITX.get() is scoped by project and agent host path (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · sandbox egress > is MITM-intercepted and routed through project egress with secret substitution (vitest x1) · ephemeral events are second-class rows: excluded from default reads, delivered on ephemeral subscriptions (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1) · reactivity page repaints from a stream subscription after a page action (specs x1) · runs "scheduler-agent-checkin" through the project REPL (specs x1) | 22.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/259663541272380) | 2026-07-13T17:44:14.821Z | Preview app released. |
| Semaphore | released | `c4e68f5` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 440.8 KiB | 25.9s | 6.7s |  | 777ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/421767011887841) | 2026-07-13T17:43:53.485Z | Preview app released. |
| Streams Example App | released | `c4e68f5` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 1.37 MiB | 24.8s | 17.6s |  | 699ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/421767011887841) | 2026-07-13T17:43:53.412Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->