### PR TITLE
Front-load MCP source pointers

### DIFF
--- a/apps/os/src/domains/inbound-mcp-server/exec-typescript-description.test.ts
+++ b/apps/os/src/domains/inbound-mcp-server/exec-typescript-description.test.ts
@@ -34,18 +34,23 @@ describe("inbound MCP client guidance", () => {
     expect(EXEC_TYPESCRIPT_DESCRIPTION).not.toMatch(/JavaScript|```js(?:\s|$)|\bITX\b/);
   });
 
-  it("front-loads an example and deeper-doc pointers before clients truncate the description", () => {
-    const clientPreview = EXEC_TYPESCRIPT_DESCRIPTION.slice(0, 2_000);
+  it("puts the fence contract and source pointers before aggressively truncated previews", () => {
+    const clientPreview = EXEC_TYPESCRIPT_DESCRIPTION.slice(0, 600);
 
     expect(clientPreview).toContain("```ts");
+    expect(clientPreview).toContain("https://github.com/iterate/iterate");
+    expect(clientPreview).toContain("apps/os/src/README.md");
+    expect(clientPreview).toContain("apps/os/docs/");
+  });
+
+  it("front-loads a runnable discovery example before normal client truncation", () => {
+    const clientPreview = EXEC_TYPESCRIPT_DESCRIPTION.slice(0, 1_500);
+
     expect(clientPreview).toContain("async (itx) => {");
     expect(clientPreview).toContain("itx.docs.search");
     expect(clientPreview).toContain("fetchCall");
     expect(clientPreview).toContain("itx.docs.get");
     expect(clientPreview).toContain("itx.docs.typecheck");
-    expect(clientPreview).toContain("https://github.com/iterate/iterate");
-    expect(clientPreview).toContain("apps/os/src/README.md");
-    expect(clientPreview).toContain("apps/os/docs/");
   });
 
   it("keeps platform-agent turn-taking mechanics out of MCP guidance", () => {

--- a/apps/os/src/domains/inbound-mcp-server/exec-typescript-description.ts
+++ b/apps/os/src/domains/inbound-mcp-server/exec-typescript-description.ts
@@ -21,8 +21,10 @@ export function inboundMcpServerInstructions(input: { withAgent: boolean }): str
 
 export const EXEC_TYPESCRIPT_DESCRIPTION = [
   "Execute TypeScript against an Iterate project. Pass exactly one async arrow function as code: async (itx) => { ... }. Its JSON-serializable return value becomes this tool result; a thrown error becomes the tool error.",
+  "STANDARD TYPESCRIPT FENCE: open examples with ```ts. Pass only the function inside the fence as exec_typescript.code.",
+  "DEEPER DOCS: https://github.com/iterate/iterate — start with apps/os/src/README.md, apps/os/docs/, apps/os/src/itx/examples.ts, and apps/os/src/itx-api.generated.ts.",
   "",
-  "QUICK START (examples use the standard ts fence; pass only the function inside the fence as exec_typescript.code):",
+  "QUICK START:",
   "```ts",
   "async (itx) => {",
   "  const project = await itx.__describe();",


### PR DESCRIPTION
Follow-up to #1921 after production verification with a fresh Claude CLI showed its ToolSearch preview truncates earlier than expected.

- Put the standard `ts` fence contract in the first two lines
- Put the GitHub, `apps/os/src/README.md`, and `apps/os/docs/` pointers before the quick-start example
- Add regression coverage for an aggressively truncated 600-character preview

Production verification will be repeated after merge and deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes to MCP tool description ordering; no runtime behavior or security-sensitive logic.
> 
> **Overview**
> **Reorders the `exec_typescript` tool description** so MCP clients that truncate tool text early (e.g. ~600 characters) still see the essentials.
> 
> The **standard ` ```ts ` fence contract** and **DEEPER DOCS** line (GitHub repo, `apps/os/src/README.md`, `apps/os/docs/`, examples, generated API) now appear **immediately after the opening sentence**, before **QUICK START**. The quick-start header is shortened because fence rules are no longer repeated there.
> 
> **Tests** split truncation coverage: a **600-character** preview must include the fence and source pointers; a **1,500-character** preview must still include the runnable discovery example (`async (itx) =>`, `itx.docs.search`, `fetchCall`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a2b6f323fb864a4fddf6badce020c217173e58d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +3 -1 | +3 -1 🟩🟩⬜⬜⬜ |
| Tests | +10 -5 | +8 -5 🟩🟩🟩🟥🟥 |
| **Total** | **+13 -6** | **+11 -6** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 0e16315 and 3a2b6f3, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-13T12:12:12.092Z",
      "headSha": "3a2b6f323fb864a4fddf6badce020c217173e58d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/439651504076049",
      "shortSha": "3a2b6f3",
      "cleanupDurationMs": 9537,
      "deployDurationMs": 91165,
      "testDurationMs": 173022,
      "testRetries": "1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 16092.99,
      "workerGzipKib": 4341.82,
      "mainWorkerGzipKib": 4341.75
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-13T12:12:05.623Z",
      "headSha": "3a2b6f323fb864a4fddf6badce020c217173e58d",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/439651504076049",
      "shortSha": "3a2b6f3",
      "cleanupDurationMs": 3065,
      "deployDurationMs": 18335,
      "testDurationMs": 580,
      "testRetries": null,
      "workerSizeKib": 4033.03,
      "workerGzipKib": 819.81,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `3a2b6f3` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 819.8 KiB | 18.3s | 580ms |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/439651504076049) | 2026-07-13T12:12:05.623Z | Preview app released. |
| OS | released | `3a2b6f3` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.24 MiB (+0.1 KiB vs main) | 91.2s | 173.0s | 1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 9.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/439651504076049) | 2026-07-13T12:12:12.092Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->