### PR TITLE
Fix Slack bot recovery from revoked connection tokens

### DIFF
--- a/apps/os/docs/integrations.md
+++ b/apps/os/docs/integrations.md
@@ -80,12 +80,14 @@ just work**. Google connections are named from the account email; tokens live
 in the connection secret, refreshed on 401 by the Secret DO's shared
 `oauth-refresh-token` strategy (nothing token-shaped ever lands on a journal).
 
-Slack Web API calls never hold material: the request carries a
-`getSecret(path)` placeholder for the connection's token and traverses
-project egress, which substitutes it inside the Secret Durable Object and
-records `secret/used` audit events. There is **no fallback token** — a typo'd
-or disconnected connection name errors loudly instead of silently posting with
-a deployment-wide credential.
+Slack Web API calls normally never hold material: the request carries a
+`getSecret(path)` placeholder for the connection's token and traverses project
+egress, which substitutes it inside the Secret Durable Object and records
+`secret/used` audit events. If Slack rejects a live connection's token, trusted
+platform code may retry with the deployment Slack app's recovery token only
+after `auth.test` proves its team id matches the connection journal. A typo'd
+or disconnected connection still errors loudly instead of silently posting
+with a deployment-wide credential.
 
 **Status is a journal tail-fold for every provider** — one machine, no
 per-provider mechanism: `getConnection` pages backwards from the journal head

--- a/apps/os/docs/slack-preview-app-manifest.md
+++ b/apps/os/docs/slack-preview-app-manifest.md
@@ -262,10 +262,10 @@ match, or OS was not redeployed after the Doppler update.
    workspace.
 
 This writes the workspace bot token into the project secret
-`/secrets/integrations/slack/bot-token`, appends
-`events.iterate.com/slack/connected` on `/integrations/slack`, and claims the
-Slack team in the preview deployment's `/integrations/slack-team-directory`
-stream.
+`/secrets/integrations/slack/<connection>/bot-token`, appends
+`events.iterate.com/slack/connected` on
+`/integrations/slack/<connection>`, and claims the Slack team in the preview
+deployment's `/integrations/_directory` stream.
 
 If OS returns `slack_team_already_claimed`, that workspace is already claimed
 by a different project in the same preview deployment. Disconnect Slack from

--- a/apps/os/src/config.test.ts
+++ b/apps/os/src/config.test.ts
@@ -54,6 +54,7 @@ describe("AppConfig", () => {
       env: {
         APP_CONFIG: JSON.stringify(baseConfig),
         APP_CONFIG_INTEGRATIONS__SLACK: JSON.stringify({
+          botToken: "slack-bot-token",
           oauthClientId: "slack-client-id",
           oauthClientSecret: "slack-client-secret",
           webhookSigningSecret: "slack-signing-secret",
@@ -72,6 +73,7 @@ describe("AppConfig", () => {
     expect(parsed.integrations.slack?.webhookSigningSecret.exposeSecret()).toEqual(
       "slack-signing-secret",
     );
+    expect(parsed.integrations.slack?.botToken?.exposeSecret()).toEqual("slack-bot-token");
     expect(parsed.integrations.google?.oauthClientId).toEqual("google-client-id");
     expect(parsed.integrations.google?.oauthClientSecret.exposeSecret()).toEqual(
       "google-client-secret",

--- a/apps/os/src/config.ts
+++ b/apps/os/src/config.ts
@@ -145,6 +145,10 @@ export const AppConfig = z.object({
           oauthClientId: publicValue(z.string().trim().min(1)),
           oauthClientSecret: redacted(z.string().trim().min(1)),
           webhookSigningSecret: redacted(z.string().trim().min(1)),
+          /** Same-app recovery credential for a connected workspace whose
+           * stored token has been revoked. Outbound Slack code verifies its
+           * team id against the connection journal before using it. */
+          botToken: redacted(z.string().trim().min(1)).optional(),
           scopes: publicValue(z.array(SlackScope).default(DEFAULT_SLACK_BOT_SCOPES)),
         })
         .optional(),

--- a/apps/os/src/domains/integrations/slack-api.test.ts
+++ b/apps/os/src/domains/integrations/slack-api.test.ts
@@ -4,33 +4,132 @@
 // token in its Secret DO. Only the egress stub is mocked; the WebClient is real
 // (proving the custom Axios adapter works end to end).
 
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-const captured: { request?: Request } = {};
+const mocks = vi.hoisted(() => ({
+  expectedTeamId: "T0675PSN873",
+  fallbackTeamId: "T0675PSN873",
+  primaryResult: { ok: true, ts: "1700000000.000100" } as Record<string, unknown>,
+  deploymentRequests: [] as Request[],
+  requests: [] as Request[],
+}));
 vi.mock("../../env.ts", () => ({ itxEnv: { PROJECT: {} } }));
-vi.mock("../projects/egress.ts", () => ({
-  projectStub: () => ({
-    fetch: async (request: Request) => {
-      captured.request = request;
-      return Response.json({ ok: true, ts: "1700000000.000100" });
+vi.mock("~/config.ts", () => ({
+  parseConfig: () => ({
+    integrations: {
+      slack: { botToken: { exposeSecret: () => "deployment-slack-token" } },
     },
   }),
 }));
+vi.mock("../projects/egress.ts", () => ({
+  projectStub: () => ({
+    fetch: async (request: Request) => {
+      mocks.requests.push(request);
+      return Response.json(mocks.primaryResult);
+    },
+  }),
+}));
+vi.mock("./integration-streams.ts", () => ({
+  latestStreamEventOfTypes: async () => ({
+    payload: { teamId: mocks.expectedTeamId },
+    type: "events.iterate.com/slack/connected",
+  }),
+}));
 
-const { connectionSlackClient, normalizeSlackError, SLACK_CALL_GRAMMAR } =
+const { callProjectSlackWebApi, connectionSlackClient, normalizeSlackError, SLACK_CALL_GRAMMAR } =
   await import("./slack-api.ts");
 
 describe("connectionSlackClient", () => {
+  beforeEach(() => {
+    mocks.expectedTeamId = "T0675PSN873";
+    mocks.fallbackTeamId = "T0675PSN873";
+    mocks.primaryResult = { ok: true, ts: "1700000000.000100" };
+    mocks.deploymentRequests.length = 0;
+    mocks.requests.length = 0;
+    vi.stubGlobal("fetch", async (request: Request) => {
+      mocks.deploymentRequests.push(request);
+      if (new URL(request.url).pathname === "/api/auth.test") {
+        return Response.json({ ok: true, team_id: mocks.fallbackTeamId });
+      }
+      return Response.json({ ok: true, ts: "1700000000.000200" });
+    });
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
   test("a WebClient call rides project egress with a placeholder auth header", async () => {
     const slack = connectionSlackClient({ connection: "main", projectId: "prj_1" });
     const result = await slack.chat.postMessage({ channel: "C1", text: "hi" });
 
     expect(result.ok).toBe(true);
-    const request = captured.request!;
+    const request = mocks.requests[0]!;
     expect(new URL(request.url).href).toBe("https://slack.com/api/chat.postMessage");
     expect(request.headers.get("authorization")).toBe(
       'Bearer getSecret({ path: "/secrets/integrations/slack/main/bot-token" })',
     );
+  });
+
+  test("an invalid connection token retries with the same-workspace deployment token", async () => {
+    mocks.primaryResult = { error: "invalid_auth", ok: false };
+
+    const slack = connectionSlackClient({ connection: "main", projectId: "prj_1" });
+    const result = await slack.chat.postMessage({ channel: "C1", text: "hi" });
+
+    expect(result.ok).toBe(true);
+    expect(mocks.requests.map((request) => new URL(request.url).pathname)).toEqual([
+      "/api/chat.postMessage",
+    ]);
+    expect(mocks.deploymentRequests.map((request) => new URL(request.url).pathname)).toEqual([
+      "/api/auth.test",
+      "/api/chat.postMessage",
+    ]);
+    expect(mocks.deploymentRequests.map((request) => request.headers.get("authorization"))).toEqual(
+      ["Bearer deployment-slack-token", "Bearer deployment-slack-token"],
+    );
+  });
+
+  test("does not retry with a deployment token from another workspace", async () => {
+    mocks.primaryResult = { error: "invalid_auth", ok: false };
+    mocks.fallbackTeamId = "T_OTHER";
+
+    const slack = connectionSlackClient({ connection: "main", projectId: "prj_1" });
+
+    await expect(slack.chat.postMessage({ channel: "C1", text: "hi" })).rejects.toThrow(
+      "invalid_auth",
+    );
+    expect(mocks.requests).toHaveLength(1);
+    expect(mocks.deploymentRequests).toHaveLength(1);
+  });
+
+  test("the hand-rolled Web API path uses the same recovery policy", async () => {
+    mocks.primaryResult = { error: "token_revoked", ok: false };
+
+    const result = await callProjectSlackWebApi({
+      body: { channel: "C1", name: "eyes", timestamp: "1700000000.000100" },
+      connection: "main",
+      method: "reactions.add",
+      projectId: "prj_1",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mocks.deploymentRequests.map((request) => new URL(request.url).pathname)).toEqual([
+      "/api/auth.test",
+      "/api/reactions.add",
+    ]);
+  });
+
+  test("never retries auth.revoke with the deployment credential", async () => {
+    mocks.primaryResult = { error: "invalid_auth", ok: false };
+
+    await expect(
+      callProjectSlackWebApi({
+        body: {},
+        connection: "main",
+        method: "auth.revoke",
+        projectId: "prj_1",
+      }),
+    ).rejects.toThrow("invalid_auth");
+    expect(mocks.deploymentRequests).toHaveLength(0);
   });
 });
 

--- a/apps/os/src/domains/integrations/slack-api.ts
+++ b/apps/os/src/domains/integrations/slack-api.ts
@@ -5,36 +5,59 @@
 // through the project egress door with a `getSecret(path)`
 // placeholder in the authorization header, so token material never leaves the
 // secret DO's substitution pipeline and every outbound attempt lands on the
-// secret's audit trail. There is NO fallback token: a missing secret (typo'd
-// connection name, disconnected workspace) fails loudly instead of silently
-// posting with someone else's credential.
+// secret's audit trail. If a connected workspace's credential is rejected,
+// calls may retry with the deployment Slack app's origin-pinned token only
+// after auth.test proves that token belongs to the connection's recorded team.
+// A typo'd or disconnected connection still fails loudly.
 
 import { WebClient, type WebClientOptions } from "@slack/web-api";
 import { itxEnv } from "../../env.ts";
 import { isPathMissMessage } from "../../itx/path-proxy.ts";
 import { projectStub } from "../projects/egress.ts";
+import { fetchWithCredentialRedirects } from "../secrets/credential-fetch.ts";
 import {
   mintProjectFileUrl,
   putProjectFile,
   sanitizeFileFilename,
 } from "../files/project-files.ts";
 import type { AgentFileAttachment } from "../agents/agent-processor-contract.ts";
-import { slackBotTokenSecretPath } from "./utils.ts";
+import { latestStreamEventOfTypes } from "./integration-streams.ts";
+import {
+  integrationConnectionStreamPath,
+  readRecord,
+  readString,
+  SLACK_CONNECTED_EVENT_TYPE,
+  SLACK_DISCONNECTED_EVENT_TYPE,
+  slackBotTokenSecretPath,
+} from "./utils.ts";
 import { parseConfig } from "~/config.ts";
 
 type SlackWebApiResult = { error?: string; ok?: boolean } & Record<string, unknown>;
 
 type SlackEgressStub = { fetch(request: Request): Promise<Response> };
 
+const SLACK_DEPLOYMENT_TOKEN_ORIGINS = new Set(["https://files.slack.com", "https://slack.com"]);
+const SLACK_CREDENTIAL_ERRORS = new Set([
+  "account_inactive",
+  "invalid_auth",
+  "not_authed",
+  "token_expired",
+  "token_revoked",
+]);
+
 /**
  * An Axios adapter that sends WebClient's requests through the project egress
  * door instead of axios's Node transport (which doesn't exist at the edge). The
- * bot-token placeholder WebClient puts in the Authorization header is
- * substituted inside the Secret DO, so the real token never enters this isolate
- * and every call lands on the secret's audit trail — the SAME path as the
- * hand-rolled `callProjectSlackWebApi`, but driven by the real SDK.
+ * connection-token placeholder WebClient puts in the Authorization header is
+ * substituted inside the Secret DO, so that token never enters this isolate
+ * and every primary call lands on the secret's audit trail — the SAME path as
+ * the hand-rolled `callProjectSlackWebApi`, but driven by the real SDK.
  */
-function slackEgressAdapter(stub: SlackEgressStub): NonNullable<WebClientOptions["adapter"]> {
+function slackEgressAdapter(input: {
+  connection: string;
+  projectId: string;
+  stub: SlackEgressStub;
+}): NonNullable<WebClientOptions["adapter"]> {
   return async (config) => {
     const base = (config.baseURL ?? "").replace(/\/$/, "");
     const path = config.url ?? "";
@@ -46,16 +69,25 @@ function slackEgressAdapter(stub: SlackEgressStub): NonNullable<WebClientOptions
       if (value != null && typeof value !== "object") headers.set(key, String(value));
     }
     const method = (config.method ?? "post").toUpperCase();
-    const response = await stub.fetch(
-      new Request(url, {
+    const buildRequest = (placeholder: string) => {
+      const authorizedHeaders = new Headers(headers);
+      authorizedHeaders.set("authorization", `Bearer ${placeholder}`);
+      return new Request(url, {
         body:
           method === "GET" || method === "HEAD"
             ? undefined
             : ((config.data as BodyInit | null | undefined) ?? undefined),
-        headers,
+        headers: authorizedHeaders,
         method,
-      }),
-    );
+      });
+    };
+    const response = await fetchSlackWithCredentialRecovery({
+      buildRequest,
+      connection: input.connection,
+      method: slackMethodFromUrl(url),
+      projectId: input.projectId,
+      stub: input.stub,
+    });
     const text = await response.text();
     const responseHeaders: Record<string, string> = {};
     response.headers.forEach((value, key) => {
@@ -76,18 +108,23 @@ function slackEgressAdapter(stub: SlackEgressStub): NonNullable<WebClientOptions
 
 /**
  * A Slack WebClient for one named connection whose transport rides the project
- * egress door — the bot token stays in its Secret DO (a `getSecret(...)`
- * placeholder in the Authorization header, substituted downstream). The itx
- * caller surface `itx.integrations.slack["<connection>"]` replays the caller's
- * dotted Web API path (chat.postMessage, conversations.list, …) straight onto
- * this instance, so it IS the Slack SDK — no hand-mapped method table.
+ * egress door — its primary bot token stays in its Secret DO (a
+ * `getSecret(...)` placeholder in the Authorization header, substituted
+ * downstream). The itx caller surface
+ * `itx.integrations.slack["<connection>"]` replays the caller's dotted Web API
+ * path (chat.postMessage, conversations.list, …) straight onto this instance,
+ * so it IS the Slack SDK — no hand-mapped method table.
  */
 export function connectionSlackClient(input: { connection: string; projectId: string }): WebClient {
   const placeholder = `getSecret({ path: "${slackBotTokenSecretPath(input.connection)}" })`;
   return new WebClient(placeholder, {
     // Dials the project egress door (not the Secret DO directly, unlike
     // github/gmail) so project egress interceptors observe Slack calls.
-    adapter: slackEgressAdapter(projectStub(itxEnv.PROJECT, input.projectId)),
+    adapter: slackEgressAdapter({
+      connection: input.connection,
+      projectId: input.projectId,
+      stub: projectStub(itxEnv.PROJECT, input.projectId),
+    }),
     // The egress door + our own error handling own retries; the SDK's node-retry
     // timers are neither needed nor edge-friendly.
     retryConfig: { retries: 0 },
@@ -135,16 +172,21 @@ export async function callProjectSlackWebApi(input: {
   method: string;
   projectId: string;
 }): Promise<SlackWebApiResult> {
-  const placeholder = `getSecret({ path: "${slackBotTokenSecretPath(input.connection)}" })`;
-  const request = new Request(`https://slack.com/api/${input.method}`, {
-    body: JSON.stringify(input.body),
-    headers: {
-      authorization: `Bearer ${placeholder}`,
-      "content-type": "application/json; charset=utf-8",
-    },
-    method: "POST",
+  const response = await fetchSlackWithCredentialRecovery({
+    buildRequest: (credential) =>
+      new Request(`https://slack.com/api/${input.method}`, {
+        body: JSON.stringify(input.body),
+        headers: {
+          authorization: `Bearer ${credential}`,
+          "content-type": "application/json; charset=utf-8",
+        },
+        method: "POST",
+      }),
+    connection: input.connection,
+    method: input.method,
+    projectId: input.projectId,
+    stub: projectStub(itxEnv.PROJECT, input.projectId),
   });
-  const response = await projectStub(itxEnv.PROJECT, input.projectId).fetch(request);
   if (response.status === 404 || response.status === 400) {
     // secret_not_found / secret_reference errors from the secret pipeline —
     // not a Slack response. Name the connection so the failure is actionable.
@@ -163,9 +205,8 @@ export async function callProjectSlackWebApi(input: {
 
 /**
  * Downloads a Slack file's bytes (`url_private`) with one named connection's
- * bot token — the same secret-placeholder egress path as
- * callProjectSlackWebApi, and the same no-fallback stance: a missing secret
- * fails loudly instead of silently downloading with someone else's credential.
+ * bot token — the same secret-placeholder egress path and same-workspace
+ * credential recovery as callProjectSlackWebApi.
  * Slack answers unauthorized downloads with a 200 HTML login page, so HTML
  * responses count as auth failures.
  */
@@ -175,9 +216,20 @@ async function downloadProjectSlackFile(input: {
   url: string;
 }): Promise<{ bytes: Uint8Array; contentType: string | undefined }> {
   const placeholder = `getSecret({ path: "${slackBotTokenSecretPath(input.connection)}" })`;
-  const response = await projectStub(itxEnv.PROJECT, input.projectId).fetch(
-    new Request(input.url, { headers: { authorization: `Bearer ${placeholder}` } }),
-  );
+  const stub = projectStub(itxEnv.PROJECT, input.projectId);
+  const buildRequest = (credential: string) =>
+    new Request(input.url, { headers: { authorization: `Bearer ${credential}` } });
+  const primaryResponse = await stub.fetch(buildRequest(placeholder));
+  const response = isSlackFileCredentialFailure(primaryResponse)
+    ? await retrySlackRequestWithDeploymentCredential({
+        buildRequest,
+        connection: input.connection,
+        method: "files.download",
+        primaryResponse,
+        projectId: input.projectId,
+        stub,
+      })
+    : primaryResponse;
   if (!isUsableSlackFileResponse(response)) {
     throw new Error(`Slack file download failed: HTTP ${response.status}`);
   }
@@ -190,6 +242,128 @@ async function downloadProjectSlackFile(input: {
 function isUsableSlackFileResponse(response: Response): boolean {
   if (!response.ok) return false;
   return !(response.headers.get("content-type") ?? "").includes("text/html");
+}
+
+function isSlackFileCredentialFailure(response: Response): boolean {
+  return (
+    response.status === 401 ||
+    response.status === 403 ||
+    (response.headers.get("content-type") ?? "").includes("text/html")
+  );
+}
+
+function slackMethodFromUrl(url: string): string {
+  const pathname = new URL(url).pathname;
+  return pathname.startsWith("/api/") ? pathname.slice("/api/".length) : pathname;
+}
+
+async function fetchSlackWithCredentialRecovery(input: {
+  buildRequest: (placeholder: string) => Request;
+  connection: string;
+  method: string;
+  projectId: string;
+  stub: SlackEgressStub;
+}): Promise<Response> {
+  const primaryPlaceholder = `getSecret({ path: "${slackBotTokenSecretPath(input.connection)}" })`;
+  const primaryResponse = await input.stub.fetch(input.buildRequest(primaryPlaceholder));
+  if (!(await isSlackCredentialFailure(primaryResponse))) return primaryResponse;
+  return await retrySlackRequestWithDeploymentCredential({ ...input, primaryResponse });
+}
+
+/**
+ * Retry a rejected connection credential with the deployment bot token only
+ * when the connection is live and auth.test proves both credentials are for
+ * the same Slack team. Trusted platform code reads the config value only to
+ * build an origin-pinned Slack request; it never crosses project egress or an
+ * untrusted capability boundary.
+ */
+async function retrySlackRequestWithDeploymentCredential(input: {
+  buildRequest: (placeholder: string) => Request;
+  connection: string;
+  method: string;
+  primaryResponse: Response;
+  projectId: string;
+  stub: SlackEgressStub;
+}): Promise<Response> {
+  // Disconnect must never revoke the shared recovery credential when the
+  // connection credential is already dead.
+  if (input.method === "auth.revoke") return input.primaryResponse;
+
+  const expectedTeamId = await connectedSlackTeamId({
+    connection: input.connection,
+    projectId: input.projectId,
+  }).catch(() => null);
+  if (expectedTeamId === null) return input.primaryResponse;
+
+  const deploymentToken = readDeploymentSlackBotToken();
+  if (deploymentToken === null) return input.primaryResponse;
+  const authTestResponse = await fetchWithDeploymentSlackToken(
+    new Request("https://slack.com/api/auth.test", {
+      body: "{}",
+      headers: { "content-type": "application/json; charset=utf-8" },
+      method: "POST",
+    }),
+    deploymentToken,
+  ).catch(() => null);
+  if (authTestResponse === null) return input.primaryResponse;
+  const authTest = (await authTestResponse.json().catch(() => null)) as {
+    ok?: boolean;
+    team_id?: string;
+  } | null;
+  if (!authTestResponse.ok || authTest?.ok !== true || authTest.team_id !== expectedTeamId) {
+    return input.primaryResponse;
+  }
+
+  console.warn("Slack connection credential rejected; using verified deployment credential", {
+    connection: input.connection,
+    method: input.method,
+    projectId: input.projectId,
+    teamId: expectedTeamId,
+  });
+  return await fetchWithDeploymentSlackToken(input.buildRequest(deploymentToken), deploymentToken);
+}
+
+function readDeploymentSlackBotToken(): string | null {
+  try {
+    const token = parseConfig(itxEnv).integrations.slack?.botToken?.exposeSecret();
+    return token && token.trim() !== "" ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchWithDeploymentSlackToken(request: Request, token: string): Promise<Response> {
+  const headers = new Headers(request.headers);
+  headers.set("authorization", `Bearer ${token}`);
+  return await fetchWithCredentialRedirects(new Request(request, { headers }), {
+    assertUrlAllowed: (url) => {
+      if (!SLACK_DEPLOYMENT_TOKEN_ORIGINS.has(new URL(url).origin)) {
+        throw new Error("Slack deployment credential destination is not allowed");
+      }
+    },
+  });
+}
+
+async function connectedSlackTeamId(input: {
+  connection: string;
+  projectId: string;
+}): Promise<string | null> {
+  const event = await latestStreamEventOfTypes(
+    input.projectId,
+    integrationConnectionStreamPath("slack", input.connection),
+    [SLACK_CONNECTED_EVENT_TYPE, SLACK_DISCONNECTED_EVENT_TYPE],
+  );
+  if (event?.type !== SLACK_CONNECTED_EVENT_TYPE) return null;
+  return readString(readRecord(event.payload)?.teamId) ?? null;
+}
+
+async function isSlackCredentialFailure(response: Response): Promise<boolean> {
+  const result = (await response
+    .clone()
+    .json()
+    .catch(() => null)) as SlackWebApiResult | null;
+  if (typeof result?.error !== "string") return false;
+  return result.error.startsWith("secret_") || SLACK_CREDENTIAL_ERRORS.has(result.error);
 }
 
 /**

--- a/docs/slack-bot-token-migration.md
+++ b/docs/slack-bot-token-migration.md
@@ -18,8 +18,10 @@ Each Slack app should own its complete runtime config in
 ```
 
 OS Slack Web API calls use the connected project workspace bot token first. If
-a project has no connected Slack token, OS falls back to this environment's
-`APP_CONFIG_INTEGRATIONS__SLACK.botToken`.
+Slack rejects that token, OS verifies that this environment's
+`APP_CONFIG_INTEGRATIONS__SLACK.botToken` belongs to the connection's recorded
+Slack team before retrying with it. Projects without a live Slack connection
+cannot use the recovery token.
 
 `Niterate (CI bot)` is not the production Slack app. The production Slack app
 is `iterate`; `Niterate (CI bot)` is the visible identity associated with the

--- a/docs/slack-testing.md
+++ b/docs/slack-testing.md
@@ -30,14 +30,16 @@ The Doppler secrets are split by purpose:
 
 - `APP_CONFIG_INTEGRATIONS__SLACK` contains the Slack app credentials for the
   OS deployment: OAuth client ID, OAuth client secret, and webhook signing
-  secret. It also contains `botToken`, the deployment-level outbound fallback
-  for that same Slack app.
+  secret. It also contains `botToken`, a recovery credential for that same
+  Slack app.
 - The OS **Connect Slack** flow stores the workspace bot token for a project at
-  `/secrets/integrations/slack/bot-token` and claims the Slack team in the
-  deployment's `/integrations/slack-team-directory` stream.
-- Slack Web API calls use the project workspace token first. If the project has
-  no connected Slack token, OS falls back to
-  `APP_CONFIG_INTEGRATIONS__SLACK.botToken`.
+  `/secrets/integrations/slack/<connection>/bot-token` and claims the Slack
+  team in the deployment's `/integrations/_directory` stream.
+- Slack Web API calls use the connected project's workspace token first. If
+  Slack rejects that token, OS uses `auth.test` to prove that
+  `APP_CONFIG_INTEGRATIONS__SLACK.botToken` belongs to the connection's
+  journaled team before retrying. A typo'd or disconnected connection never
+  gets the recovery credential.
 
 ## Trigger actor for smoke tests
 
@@ -98,9 +100,9 @@ otherwise:
 - The app scope `chat:write.public` lets a Slack app post into public channels,
   so a bot user not appearing as a channel member does not rule out its app
   posting a reply.
-- If production has `APP_CONFIG_INTEGRATIONS__SLACK.botToken`, it can use that
-  fallback token for outbound Slack Web API calls when no project token is
-  available.
+- If production has `APP_CONFIG_INTEGRATIONS__SLACK.botToken`, it can recover
+  outbound Slack Web API calls from a missing, expired, or revoked connection
+  token after verifying the connection's Slack team.
 
 For a precise diagnosis, inspect the Slack event wrapper and traces:
 


### PR DESCRIPTION
## Summary

- restore the deployment Slack bot token as a typed recovery credential
- retry rejected connection credentials only after `auth.test` proves the recovery token belongs to the connection's journaled Slack team
- keep the primary project token in its Secret DO and the recovery token inside trusted, origin-pinned platform code
- never retry `auth.revoke` with the recovery token
- update Slack integration/runbook docs for named connection paths and the verified recovery rule

## Production diagnosis

For the reported `iterate` thread (`C08R1SMTZGD`, `1783944826.012449`):

- production accepted the correctly signed Slack webhook with HTTP 200
- the `iterate` project's Slack router journaled and routed the event to the expected agent stream
- the agent ran, but every Slack Web API side effect failed with `invalid_auth`
- the stored connection token is therefore revoked/stale
- the production deployment's configured Slack bot token passes `auth.test` as the expected `iterate` bot/workspace

The regression came from removing the configured fallback entirely: presence of a stale project secret prevented the healthy deployment credential from being used.

## Safety

Recovery is not an implicit connection. It is available only when:

1. the named Slack connection has a live `slack/connected` lifecycle fact,
2. the project credential failed with a credential-specific error, and
3. Slack `auth.test` reports the configured deployment token's `team_id` matches the connection journal.

A typo'd, disconnected, or different-workspace connection still fails. The configured token is sent only to `slack.com` / `files.slack.com` through the credential-aware redirect guard.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
  - OS: 1,220 passed, 1 skipped
- focused Slack/config regression suite: 54 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication for outbound Slack API calls and reads a deployment secret in trusted code; mitigations (team journal + auth.test, origin pinning, no auth.revoke retry) limit cross-workspace misuse but recovery still posts as the deployment app when a stale project token exists.
> 
> **Overview**
> Restores **deployment-level Slack `botToken`** in app config and uses it only as a **verified recovery path** when a live connection’s stored token is rejected—not as a blanket fallback for missing or wrong connections.
> 
> Outbound Slack traffic still goes through project egress with `getSecret` placeholders first. On credential-specific failures (`invalid_auth`, `token_revoked`, etc.), platform code may retry with `APP_CONFIG_INTEGRATIONS__SLACK.botToken` only after the connection journal shows `slack/connected` and **`auth.test`** confirms the recovery token’s `team_id` matches that journal. Recovery uses **origin-pinned** fetches to `slack.com` / `files.slack.com` (not project egress). **`auth.revoke`** never uses the recovery token. The WebClient adapter, `callProjectSlackWebApi`, and private file downloads share this policy.
> 
> Docs are updated for named connection secret paths, `/integrations/_directory`, and the recovery rules instead of “no fallback” / implicit deployment-wide posting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d06da2edc45c1b9763c85c09ad29ef9b9d71941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +213 -35 | +173 -20 🟩🟩🟩🟩🟥 |
| Tests | +107 -6 | +94 -6 🟩🟩🟩⬜⬜ |
| Docs | +28 -22 | +28 -22 🟩⬜⬜⬜⬜ |
| **Total** | **+348 -63** | **+295 -48** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 468d774 and 5d06da2, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-13T12:41:08.650Z",
      "headSha": "5d06da2edc45c1b9763c85c09ad29ef9b9d71941",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/231064211873675",
      "shortSha": "5d06da2",
      "cleanupDurationMs": 8686,
      "deployDurationMs": 108257,
      "testDurationMs": 243308,
      "testRetries": "2 retried: catalogue example \"stream-cross-post\" runs identically across runtimes (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 16103.36,
      "workerGzipKib": 4344.18,
      "mainWorkerGzipKib": 4342.98
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-13T12:41:02.872Z",
      "headSha": "5d06da2edc45c1b9763c85c09ad29ef9b9d71941",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/231064211873675",
      "shortSha": "5d06da2",
      "cleanupDurationMs": 2905,
      "deployDurationMs": 21133,
      "testDurationMs": 480,
      "testRetries": null,
      "workerSizeKib": 4033.03,
      "workerGzipKib": 820.09,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `5d06da2` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 820.1 KiB | 21.1s | 480ms |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/231064211873675) | 2026-07-13T12:41:02.872Z | Preview app released. |
| OS | released | `5d06da2` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 4.24 MiB (+1.2 KiB vs main) | 108.3s | 243.3s | 2 retried: catalogue example "stream-cross-post" runs identically across runtimes (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 8.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/231064211873675) | 2026-07-13T12:41:08.650Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->