### PR TITLE
Trace dynamic worker boundaries

### DIFF
--- a/apps/os/src/domains/itx/itx-entrypoint.ts
+++ b/apps/os/src/domains/itx/itx-entrypoint.ts
@@ -25,7 +25,7 @@ export class ItxEntrypoint extends WorkerEntrypoint<Env, ItxEntrypointProps> {
   async get() {
     const { path, projectId } = scopeFromItxEntrypointProps(this.ctx.props);
     const scopeName = path.replace(/[^a-zA-Z0-9_./:$-]+/g, "_").slice(0, 120);
-    return tracing.enterSpan(`itx binding.get ${scopeName}`, (span) => {
+    return tracing.enterSpan(`itx binding.get ${scopeName}`, async (span) => {
       span.setAttribute("iterate.scope.path", path);
       span.setAttribute("iterate.scope.type", projectId === null ? "global" : "project");
       if (projectId === null) {

--- a/apps/os/src/domains/itx/itx-entrypoint.ts
+++ b/apps/os/src/domains/itx/itx-entrypoint.ts
@@ -1,4 +1,4 @@
-import { WorkerEntrypoint } from "cloudflare:workers";
+import { tracing, WorkerEntrypoint } from "cloudflare:workers";
 import { trustedInternalAuthContext } from "../../auth.ts";
 import type { Env } from "../../env.ts";
 import { deploymentItxForTrustedInternal, itxForScope } from "../../rpc-targets.ts";
@@ -24,15 +24,21 @@ import { scopeFromItxEntrypointProps, type ItxEntrypointProps } from "./utils.ts
 export class ItxEntrypoint extends WorkerEntrypoint<Env, ItxEntrypointProps> {
   async get() {
     const { path, projectId } = scopeFromItxEntrypointProps(this.ctx.props);
-    if (projectId === null) {
-      // The deployment-global scope: what a GLOBAL (projectId: null) stream's
-      // delivery dial evaluates expressions against. It is the same root a
-      // trusted-internal session sees — deployment-wide repos/streams — so a
-      // global repo stream's wake expression walks the identical shape a
-      // project stream's does.
-      return deploymentItxForTrustedInternal({ ctx: this.ctx });
-    }
-    return itxForScope({ auth: trustedInternalAuthContext(), ctx: this.ctx, path, projectId });
+    const scopeName = path.replace(/[^a-zA-Z0-9_./:$-]+/g, "_").slice(0, 120);
+    return tracing.enterSpan(`itx binding.get ${scopeName}`, (span) => {
+      span.setAttribute("iterate.scope.path", path);
+      span.setAttribute("iterate.scope.type", projectId === null ? "global" : "project");
+      if (projectId === null) {
+        // The deployment-global scope: what a GLOBAL (projectId: null) stream's
+        // delivery dial evaluates expressions against. It is the same root a
+        // trusted-internal session sees — deployment-wide repos/streams — so a
+        // global repo stream's wake expression walks the identical shape a
+        // project stream's does.
+        return deploymentItxForTrustedInternal({ ctx: this.ctx });
+      }
+      span.setAttribute("iterate.project.id", projectId);
+      return itxForScope({ auth: trustedInternalAuthContext(), ctx: this.ctx, path, projectId });
+    });
   }
 
   /**

--- a/apps/os/src/domains/workers/worker-runner.ts
+++ b/apps/os/src/domains/workers/worker-runner.ts
@@ -1,3 +1,4 @@
+import { tracing } from "cloudflare:workers";
 import { itxEnv as env } from "../../env.ts";
 import { itxEntrypointBinding, itxEntrypointProps } from "../itx/utils.ts";
 import { projectEgressFetcher } from "../projects/utils.ts";
@@ -143,14 +144,19 @@ export class DynamicWorkerRunner {
     ref: DynamicWorkerRef;
     request: Request;
   }): Promise<Response> {
-    if (ref.type === "stateful") {
-      const stub = env.WORKER.getByName(
-        statefulWorkerDurableObjectName(this.#projectId, ref),
-      ) as unknown as Fetcher;
-      return await stub.fetch(withWorkerFetchDispatchHeader(request, { buildBudgetMs, ref }));
-    }
-    const entrypoint = await this.#getStatelessEntrypoint<Fetcher>(ref, buildBudgetMs);
-    return await entrypoint.fetch(request);
+    return this.#trace(ref, "fetch", `worker fetch ${workerTraceReceiver(ref)}`, async (span) => {
+      span.setAttribute("http.request.method", request.method);
+      const response =
+        ref.type === "stateful"
+          ? await (
+              env.WORKER.getByName(
+                statefulWorkerDurableObjectName(this.#projectId, ref),
+              ) as unknown as Fetcher
+            ).fetch(withWorkerFetchDispatchHeader(request, { buildBudgetMs, ref }))
+          : await (await this.#getStatelessEntrypoint<Fetcher>(ref, buildBudgetMs)).fetch(request);
+      span.setAttribute("http.response.status_code", response.status);
+      return response;
+    });
   }
 
   async invokeCapability({
@@ -184,28 +190,36 @@ export class DynamicWorkerRunner {
       );
     }
 
-    if (ref.type === "stateful") {
-      // Method replay must happen inside StatefulWorkerDurableObject. Returning
-      // a dynamic facet stub through one DO and then invoking it from another RPC
-      // target has produced opaque internal RPC failures; keeping the replay at
-      // the owning DO boundary also keeps storage affinity explicit. Stateful
-      // refs are also deliberately lazy: mounting a worker capability only
-      // commits the recipe to the stream, while this first real invocation is the
-      // point where source loading, version-marker writes, and facet restarts are
-      // allowed to mutate durable runtime state.
-      return await this.#statefulWorker(ref).invokeCapability({
-        args,
-        buildBudgetMs,
-        flattenNestedPath,
-        path,
-        ref,
-      });
-    }
+    const operation = traceNamePart(path.length === 0 ? "root" : path.join("."));
+    return this.#trace(
+      ref,
+      operation,
+      `worker call ${workerTraceReceiver(ref)}.${operation}`,
+      async () => {
+        if (ref.type === "stateful") {
+          // Method replay must happen inside StatefulWorkerDurableObject. Returning
+          // a dynamic facet stub through one DO and then invoking it from another RPC
+          // target has produced opaque internal RPC failures; keeping the replay at
+          // the owning DO boundary also keeps storage affinity explicit. Stateful
+          // refs are also deliberately lazy: mounting a worker capability only
+          // commits the recipe to the stream, while this first real invocation is the
+          // point where source loading, version-marker writes, and facet restarts are
+          // allowed to mutate durable runtime state.
+          return await this.#statefulWorker(ref).invokeCapability({
+            args,
+            buildBudgetMs,
+            flattenNestedPath,
+            path,
+            ref,
+          });
+        }
 
-    const target = await this.#getStatelessEntrypoint(ref, buildBudgetMs);
-    return flattenNestedPath
-      ? await invokePreferringFlattenedPath({ args, path, target })
-      : await replayPath({ args, path, target });
+        const target = await this.#getStatelessEntrypoint(ref, buildBudgetMs);
+        return flattenNestedPath
+          ? await invokePreferringFlattenedPath({ args, path, target })
+          : await replayPath({ args, path, target });
+      },
+    );
   }
 
   /** Abort a stateful dynamic worker's outer Durable Object and hosted facet. */
@@ -242,6 +256,47 @@ export class DynamicWorkerRunner {
       statefulWorkerDurableObjectName(this.#projectId, ref),
     ) as unknown as StatefulWorkerRpc;
   }
+
+  #trace<T>(
+    ref: DynamicWorkerRef,
+    operation: string,
+    name: string,
+    callback: (span: {
+      setAttribute(name: string, value: boolean | number | string): void;
+    }) => Promise<T>,
+  ): Promise<T> {
+    return tracing.enterSpan(name, async (span) => {
+      span.setAttribute("iterate.project.id", this.#projectId);
+      span.setAttribute("iterate.scope.path", this.#scopePath);
+      span.setAttribute("iterate.worker.operation", operation);
+      span.setAttribute("iterate.worker.source", ref.source.files.type);
+      span.setAttribute("iterate.worker.type", ref.type);
+      if (ref.type === "stateful") {
+        span.setAttribute("iterate.worker.class", ref.className);
+        span.setAttribute("iterate.worker.durable_key", ref.durableWorkerKey);
+      } else {
+        span.setAttribute("iterate.worker.entrypoint", ref.entrypoint ?? "default");
+      }
+      try {
+        return await callback(span);
+      } catch (error) {
+        span.setAttribute("error.type", error instanceof Error ? error.name : typeof error);
+        throw error;
+      }
+    });
+  }
+}
+
+function workerTraceReceiver(ref: DynamicWorkerRef): string {
+  return traceNamePart(
+    ref.type === "stateful"
+      ? `${ref.className}:${ref.durableWorkerKey}`
+      : (ref.entrypoint ?? "default"),
+  );
+}
+
+function traceNamePart(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_./:$-]+/g, "_").slice(0, 120);
 }
 
 /**


### PR DESCRIPTION
## Why

This is the dynamic-worker slice after the ITX proof in #1914 and alarm proof in #1926. Cloudflare already emits low-level Worker Loader, `ctx.exports`, JS-RPC, fetch, and Durable Object spans, but their generic labels do not say which project worker, entrypoint/class, or capability operation is running.

Worker Loader and loopback `ctx.exports` execution may start separate Cloudflare traces. This patch does not invent parentage that the runtime does not expose. It adds compact semantic boundaries and stable application fields so split traces can be found by the same project/scope/worker identity; Cloudflare's Ray ID remains the native same-request join where it is present.

## What this adds

- `worker fetch <receiver>` around the real fetch-native dispatch lane.
- `worker call <receiver>.<operation>` around capability replay.
- `itx binding.get <scope>` when dynamic userspace calls `env.ITX.get()` in the loopback trace.
- Semantic fields for project ID, scope path, worker type, source type, operation, and entrypoint or class/durable key.
- HTTP method/status on the worker fetch boundary and `error.type` on thrown operations.

Representative shape:

```text
... caller trace
└─ worker call ProjectWorker.github.issues.list
   └─ Worker Loader / JS-RPC / Durable Object spans owned by Cloudflare

... loopback trace when worker code asks for ITX
└─ itx binding.get /agents/researcher
```

## Volume and data policy

There is deliberately no sampling: request, trace, and log capture remains at 100%. The patch adds exactly one custom span per dynamic worker fetch/call and one per actual `env.ITX.get()`. It does not add spans for source resolution internals, method replay segments, SQL/KV, or individual events.

No source text, props, arguments, request/response bodies, headers, URL query strings, or secrets enter span names or attributes. User-controlled name fragments are sanitized and capped at 120 characters.

## Verification

- OS unit suite: 126 files passed, 1 skipped; 1,216 tests passed, 1 skipped.
- OS production Vite build passed (client, server, builder, and typechecker bundles).
- OS typecheck passed.
- Targeted formatting and lint passed with no warnings.
- Preview deployed to `os-preview-5` as Worker version `a5896e6f-19b7-4966-bd73-c384e5849741`; gzip is 4,343.77 KiB, 0.41 KiB smaller than main.
- [Stateless capability trace](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/workers-and-pages/observability/traces/a7a413850dffc2e6485f517c0cbaf781): `worker call TraceProof.identify` has project, scope, inline source, stateless type, entrypoint, and operation.
- [Loopback ITX trace from the same probe](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/workers-and-pages/observability/traces/f05861a3d2785b7142cf6e4906b89d13): `itx binding.get /proof-1304` is parented under the automatic `jsrpc` span and carries the same project/scope identity. Cloudflare starts a separate trace at this `ctx.exports` boundary; the patch does not fabricate cross-trace parentage.
- [Stateful capability trace](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/workers-and-pages/observability/traces/3dccd3a318dd896c54bbafc9343e132b): `worker call TraceCounter:observability-proof.increment` has class, durable key, and operation.
- [Project-host fetch trace](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/workers-and-pages/observability/traces/2041a80008a1fe45fac15bf40686a7af): `worker fetch default` has repo source plus HTTP `POST` / `200`.

## Follow-ups (intentionally separate)

1. Carry an explicit durable causation ID in event/scheduler envelopes for calls that originate after a time boundary; do not pretend alarms are children of the request that armed them.
2. Land the PostHog exception/replay/logging gold path captured in the observability task.
3. Export raw stream observations to Workers Analytics Engine and validate the dashboard path.

Related: #1914, #1926, and iterate/capnweb#3.

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +100 -39 | +84 -26 🟩🟩🟩🟩🟥 |
| **Total** | **+100 -39** | **+84 -26** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between d7b8b78 and 14c86ad, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-13T17:16:24.688Z",
      "headSha": "14c86ad356ee45aab1fa2f64a9a21f55e1973524",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/562667839379659",
      "shortSha": "14c86ad",
      "cleanupDurationMs": 11171,
      "deployDurationMs": 82891,
      "testDurationMs": 244641,
      "testRetries": "3 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · runs \"scheduler-agent-checkin\" through the project REPL (specs x1) · runs \"provide-itx-expression\" through the project REPL (specs x1)",
      "workerSizeKib": 16100.61,
      "workerGzipKib": 4343.77,
      "mainWorkerGzipKib": 4344.18
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-13T17:16:14.534Z",
      "headSha": "9e6bb9d0a7fcd7508ab50c072ef213581ceb1a51",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/343195065104774",
      "shortSha": "9e6bb9d",
      "cleanupDurationMs": 1014,
      "deployDurationMs": 17117,
      "testDurationMs": 5540,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-13T17:16:16.493Z",
      "headSha": "14c86ad356ee45aab1fa2f64a9a21f55e1973524",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/562667839379659",
      "shortSha": "14c86ad",
      "cleanupDurationMs": 2972,
      "deployDurationMs": 18504,
      "testDurationMs": 721,
      "testRetries": null,
      "workerSizeKib": 4033.03,
      "workerGzipKib": 819.85,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-13T17:16:14.106Z",
      "headSha": "9e6bb9d0a7fcd7508ab50c072ef213581ceb1a51",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/343195065104774",
      "shortSha": "9e6bb9d",
      "cleanupDurationMs": 583,
      "deployDurationMs": 17199,
      "testDurationMs": 19199,
      "testRetries": null,
      "workerSizeKib": 4897.94,
      "workerGzipKib": 1401.59,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `14c86ad` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 819.9 KiB | 18.5s | 721ms |  | 3.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/562667839379659) | 2026-07-13T17:16:16.493Z | Preview app released. |
| OS | released | `14c86ad` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 4.24 MiB (-0.4 KiB vs main) | 82.9s | 244.6s | 3 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · runs "scheduler-agent-checkin" through the project REPL (specs x1) · runs "provide-itx-expression" through the project REPL (specs x1) | 11.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/562667839379659) | 2026-07-13T17:16:24.688Z | Preview app released. |
| Semaphore | released | `9e6bb9d` | [https://semaphore.iterate-preview-5.com](https://semaphore.iterate-preview-5.com) | 440.8 KiB | 17.1s | 5.5s |  | 1.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/343195065104774) | 2026-07-13T17:16:14.534Z | Preview app released. |
| Streams Example App | released | `9e6bb9d` | [https://streams.iterate-preview-5.com](https://streams.iterate-preview-5.com) | 1.37 MiB | 17.2s | 19.2s |  | 583ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/343195065104774) | 2026-07-13T17:16:14.106Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->
