### PR TITLE
Cover every OS fetch with evlog

### DIFF
--- a/apps/os/docs/architecture-and-operations.md
+++ b/apps/os/docs/architecture-and-operations.md
@@ -17,8 +17,14 @@ Traffic is dispatched on hostname and path:
 2. The MCP hostname (`mcp.iterate.com`) rewrites to the app's `/api/mcp`
    route.
 3. Everything else on the OS host lands on the TanStack Start dashboard
-   (SSR, server functions, assets) wrapped in one evlog "wide event" per
-   request.
+   (SSR, server functions, assets).
+
+Every fetch lane emits one accumulated evlog "wide event" at request exit:
+dashboard/MCP, HTTP itx, the WebSocket handshake, integration webhooks,
+project ingress, project files, and unresolved hosts. Events share stable
+environment/version fields plus an allowlisted ingress operation; project
+fields come only from the server-resolved route. Config, headers, query
+strings, and bodies are not copied into the event.
 
 The routing decision is one shared function (`src/ingress.ts`). Runtime
 config is parsed from `env` per request, never at module scope — isolates
@@ -82,6 +88,12 @@ the project-create server function and MCP `exec_typescript`).
 set headers). The dashboard's Start routes keep only `/api/mcp` and `/api/health`; the
 catch-all `src/routes/api.$.ts` returns 404 (integration callbacks return
 with the integrations domain).
+
+The request-wide WebSocket event covers only the initial `101` handshake. A
+socket can stay open across many logical itx calls, so per-call timing,
+outcome, connection/call IDs, and errors belong to the Cap'n Web `onCall`
+boundary rather than one socket-lifetime log. This is semantic boundary
+selection, not sampling: all request envelopes and logical calls are retained.
 
 ## Streams
 

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -17,7 +17,7 @@
 import handler from "@tanstack/react-start/server-entry";
 import { newHttpBatchRpcResponse, newWorkersWebSocketRpcResponse } from "capnweb";
 import { withEvlog } from "@iterate-com/shared/evlog";
-import type { Env } from "./env.ts";
+import { workerVersion, type Env } from "./env.ts";
 import { decideIngressRoute, type IngressResolvers } from "./ingress.ts";
 import { readProjectByHostname } from "./project-hostname-directory.ts";
 import { resolveProjectIdBySlug } from "./project-directory.ts";
@@ -87,9 +87,12 @@ export default {
     // isolate across binding-only deploys, so a module-scope copy can serve
     // stale secrets after a rotation. Parsing is pure and cheap.
     const config = parseConfig(env);
+    const deployment = { environment: env.WORKER_SELF, version: workerVersion(env) };
 
     const mcpRequest = rewriteMcpHostRequest({ config, request });
-    if (mcpRequest) return await appFetch(mcpRequest, ctx, config, { isEventDocsHost: false });
+    if (mcpRequest) {
+      return await appFetch(mcpRequest, ctx, config, deployment, { isEventDocsHost: false });
+    }
 
     const route = await decideIngressRoute({
       config,
@@ -98,9 +101,9 @@ export default {
       resolvers: directoryResolvers(config, env),
       url: request.url,
     });
-    if (route.lane !== "os") return await apiFetch(request, ctx, config, route);
+    if (route.lane !== "os") return await apiFetch(request, ctx, config, deployment, route);
 
-    return await appFetch(request, ctx, config, {
+    return await appFetch(request, ctx, config, deployment, {
       isEventDocsHost: route.hostKind === "eventDocs",
     });
   },
@@ -132,11 +135,13 @@ async function appFetch(
   request: Request,
   ctx: ExecutionContext,
   config: AppConfig,
+  deployment: { environment: string; version: string },
   host: { isEventDocsHost: boolean },
 ) {
   return withEvlog(
     { request, app: { name: "@iterate-com/os", slug: "os" }, config, executionCtx: ctx },
     async ({ log }) => {
+      log.set(deployment);
       // When baseUrl is not configured (for example workers.dev previews),
       // the request origin is the app's own URL. After this, baseUrl is
       // always set.
@@ -164,6 +169,22 @@ async function appFetch(
  * — every lane `decideIngressRoute` (src/ingress.ts) can resolve.
  */
 async function apiFetch(
+  request: Request,
+  ctx: ExecutionContext,
+  config: AppConfig,
+  deployment: { environment: string; version: string },
+  route: Exclude<Awaited<ReturnType<typeof decideIngressRoute>>, { lane: "os" }>,
+) {
+  return withEvlog(
+    { request, app: { name: "@iterate-com/os", slug: "os" }, config, executionCtx: ctx },
+    async ({ log }) => {
+      log.set({ ...deployment, ...apiIngressLogFields(request, route) });
+      return await apiFetchWithoutEvlog(request, ctx, config, route);
+    },
+  );
+}
+
+async function apiFetchWithoutEvlog(
   request: Request,
   ctx: ExecutionContext,
   config: AppConfig,
@@ -244,6 +265,51 @@ async function apiFetch(
     return newHttpBatchRpcResponse(request, unauthenticated);
   }
   return newWorkersWebSocketRpcResponse(request, unauthenticated);
+}
+
+function apiIngressLogFields(
+  request: Request,
+  route: Exclude<Awaited<ReturnType<typeof decideIngressRoute>>, { lane: "os" }>,
+) {
+  const path = new URL(request.url).pathname;
+  const operation =
+    route.lane === "project"
+      ? route.resolved.appSlug === FILES_APP_SLUG
+        ? "project_file"
+        : "project_fetch"
+      : route.lane === "notFound"
+        ? "not_found"
+        : path === "/api"
+          ? request.method === "POST"
+            ? "itx_http_batch"
+            : "itx_websocket_handshake"
+          : path === "/api/admin-cookie"
+            ? "admin_cookie"
+            : path.includes("/slack/")
+              ? "integration_slack_webhook"
+              : path.includes("/github/")
+                ? "integration_github_webhook"
+                : path.includes("/telegram/")
+                  ? "integration_telegram_webhook"
+                  : "api_not_found";
+
+  return {
+    ingress: {
+      lane: route.lane,
+      operation,
+      ...((route.lane === "project" || (route.lane === "api" && path === "/api")) && {
+        transport:
+          request.headers.get("upgrade")?.toLowerCase() === "websocket" ? "websocket" : "http",
+      }),
+      ...(route.lane === "project"
+        ? {
+            projectId: route.resolved.projectId,
+            appSlug: route.resolved.appSlug ?? undefined,
+            hostKind: route.fetch.headers.get("x-iterate-host-kind") ?? undefined,
+          }
+        : {}),
+    },
+  };
 }
 
 function directoryResolvers(config: AppConfig, env: Env): IngressResolvers {

--- a/packages/shared/src/evlog/logging.test.ts
+++ b/packages/shared/src/evlog/logging.test.ts
@@ -275,8 +275,15 @@ describe("apps logging pretty stdout", () => {
 
     await withEvlog(
       {
-        request: new Request("https://example.com/api/test/log-demo", {
+        request: new Request("https://example.com/api/test/log-demo?token=query-secret", {
           method: "POST",
+          headers: {
+            authorization: "Bearer auth-secret",
+            cookie: "session=cookie-secret",
+            "cf-ray": "ray-123",
+            traceparent: "00-trace-parent",
+          },
+          body: "body-secret",
         }),
         app: evlogApp,
         config: {
@@ -299,16 +306,56 @@ describe("apps logging pretty stdout", () => {
     expect(output).not.toContain("\u001b[");
 
     const parsed = JSON.parse(output.trimEnd()) as {
+      cfRay?: string;
+      config?: unknown;
       message: string;
+      requestId?: string;
       requestLogs: Array<{ level?: string; message?: string }>;
+      status?: number;
+      traceparent?: string;
     };
     expect(parsed.message).toMatch(/^POST \/api\/test\/log-demo 200 in \d+ms \(1 line\)$/);
     expect(parsed.message).not.toContain("\n");
+    expect(parsed).toMatchObject({
+      cfRay: "ray-123",
+      requestId: "ray-123",
+      status: 200,
+      traceparent: "00-trace-parent",
+    });
+    expect(parsed.config).toBeUndefined();
     expect(parsed.requestLogs).toEqual([
       expect.objectContaining({
         level: "info",
         message: "example.test.log-demo.received",
       }),
     ]);
+    expect(output).not.toContain("query-secret");
+    expect(output).not.toContain("auth-secret");
+    expect(output).not.toContain("cookie-secret");
+    expect(output).not.toContain("body-secret");
+  });
+
+  it("withEvlog emits one error event and preserves the thrown error", async () => {
+    const writeSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const failure = new Error("request exploded");
+
+    await expect(
+      withEvlog(
+        {
+          request: new Request("https://example.com/api"),
+          app: evlogApp,
+          config: { logs: { stdoutFormat: "raw", filtering: { rules: [] } } },
+        },
+        async () => {
+          throw failure;
+        },
+      ),
+    ).rejects.toBe(failure);
+
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    const output = String(writeSpy.mock.calls[0]![0]);
+    const parsed = JSON.parse(output.trimEnd()) as { status?: number; error?: unknown };
+    expect(parsed.status).toBe(500);
+    expect(parsed.error).toBeDefined();
   });
 });

--- a/packages/shared/src/evlog/with-evlog.ts
+++ b/packages/shared/src/evlog/with-evlog.ts
@@ -179,7 +179,6 @@ export async function withEvlog<TResponse extends Response>(
       slug: options.app.slug,
       packageName: options.app.name,
     },
-    config: options.config,
     ...createRequestContextFields(options.request),
   });
 

--- a/tasks/posthog-observability-gold-path.md
+++ b/tasks/posthog-observability-gold-path.md
@@ -1,0 +1,276 @@
+---
+state: draft
+priority: high
+size: large
+tags: [os, observability, posthog, logging, errors, session-replay]
+---
+
+# Gold-path PostHog observability for OS and itx
+
+Research captured 2026-07-13 while separating the PostHog product design from
+the first Cloudflare/capnweb distributed-tracing proof of concept.
+
+## Progress
+
+- Draft PR #1914 and the minimal `iterate/capnweb#3` fork prove one semantic
+  span/completion event per logical itx call over a long-running WebSocket.
+- Draft PR #1926 proves semantic alarm spans without inventing request
+  parentage across the time boundary.
+- Draft PR #1928 proves stateless, stateful, fetch-native, and loopback dynamic
+  worker spans; Cloudflare starts a separate trace at the `ctx.exports`
+  boundary, so the proof records both trace IDs honestly.
+- The next narrow slice wraps every OS fetch ingress lane in the existing
+  evlog request envelope and establishes safe environment, release, operation,
+  and trusted project correlation fields. It intentionally precedes a
+  PostHog sink so the sink receives a reviewed schema rather than arbitrary
+  config or request data.
+
+This task deliberately does **not** decide that logs belong only in Cloudflare.
+PostHog should at minimum own product-facing exception investigation, identity,
+sessions, and replay, and selected structured logs may also belong in PostHog.
+The implementation should establish the useful PostHog investigation experience
+without duplicating every Cloudflare invocation record or turning console output
+into an unbounded event stream.
+
+## Desired investigation experience
+
+For an unexpected browser or Worker failure, an operator should be able to:
+
+1. open one grouped PostHog issue with a useful, symbolicated stack;
+2. see the user, project, release, environment, logical itx call, and transport
+   connection involved;
+3. open the browser session replay when there was a browser session;
+4. find the corresponding structured logs and Cloudflare trace using shared
+   correlation fields;
+5. distinguish one underlying failure from the browser observing a server
+   failure; and
+6. avoid leaking scripts, prompts, request bodies, secrets, tokens, email
+   addresses, or sensitive URL query parameters into any telemetry sink.
+
+## Current repository state
+
+- OS currently depends on `posthog-js` 1.360.x. Current npm research found
+  newer releases and recommends upgrading to at least 1.380 before relying on
+  fetch tracing headers.
+- `packages/shared/src/posthog/posthog.ts` implements the existing first-party
+  proxy through the OS worker.
+- `packages/shared/src/evlog/with-evlog.ts` emits one accumulated request-wide
+  event and already preserves stable `appName` and `app.slug` fields for log
+  queries/dashboards. Successful PostHog proxy asset traffic is filtered.
+- The api/itx lane is not currently wrapped by `withEvlog`; the dashboard app
+  lane is.
+- The browser keeps one long-lived capnweb WebSocket per itx context. A PostHog
+  session can rotate while that socket remains alive, so socket-handshake
+  metadata is insufficient.
+- PR #1206, "Add request-wide OS logging and PostHog error capture", previously
+  provided request-wide async-local accumulation, structured errors, `waitUntil`
+  handling, PostHog output, and strong outside-in integration tests. The current
+  evlog is a smaller descendant, but its PostHog sink is absent.
+
+## Correlation contract
+
+Each logical itx call should carry a small observability envelope independent
+of business arguments:
+
+```ts
+type ItxObservabilityContext = {
+  connectionId: string;
+  itxCallId: string;
+  parentItxCallId?: string;
+  posthogDistinctId?: string;
+  posthogSessionId?: string;
+  projectId?: string;
+  environment: string;
+  release: string;
+};
+```
+
+The client must read the current PostHog identity/session when each call is
+sent, not once when the WebSocket connects. `projectId`, authorization, and
+other trusted tenant fields must be derived or verified on the server; client
+telemetry metadata is correlation input, not authority.
+
+Use the same `itxCallId`, `connectionId`, release, environment, and project ID
+in PostHog exceptions/logs and Cloudflare structured events. Cloudflare does
+not expose its native trace/span IDs to Worker application code, so do not
+invent a field that pretends to be Cloudflare's trace ID. Shared-field search
+is the initial bridge; a future exporter can provide a deeper link.
+
+## Browser gold path
+
+- Upgrade `posthog-js` and add `@posthog/react` if it is not already available.
+- Initialize with a pinned `defaults` date so SDK upgrades cannot silently
+  change collection behavior.
+- Keep automatic unhandled exception and unhandled-rejection capture enabled.
+- Install a root `PostHogErrorBoundary` for terminal React render failures.
+- For a genuinely handled terminal client failure, call
+  `posthog.captureException(error, properties)`. Do not construct `$exception`
+  events manually.
+- Keep console-error autocapture disabled. Explicit operational logs should use
+  an intentional logger/sink rather than scraping incidental console output.
+- Use `posthog.addExceptionStep(...)` for a few bounded, safe breadcrumbs before
+  high-risk operations. These are attached to a later exception rather than
+  emitted as separate product events.
+- After authentication, call `identify(stableUserId)` and
+  `group("project", stableProjectId)`. Reset on logout/identity transitions.
+- On SDK versions supporting it, restrict `tracing_headers` to exact owned HTTP
+  hostnames. This injects PostHog identity/session headers into fetch/XHR but
+  does not cover WebSockets; itx still needs the per-call envelope.
+- Treat validation failures, expected authorization failures, cancellation,
+  intentional socket closes, and ordinary reconnects as outcomes rather than
+  exceptions.
+- Unexpected WebSocket termination may be captured with an explicit `Error`
+  carrying the close code, phase, retry count, and connection ID. Suppress code
+  1000 and deliberate shutdowns.
+
+## Worker gold path
+
+- Use the current `posthog-node` Worker/workerd edge export rather than a
+  process-global Node autocapture integration.
+- Capture unexpected terminal errors exactly once at the outer HTTP request or
+  logical itx-call boundary. Inner code may enrich and rethrow, but must not
+  capture an error that the boundary will capture again.
+- Pass the original `Error` to `captureExceptionImmediate()` with:
+  `distinctId`, `$session_id`, `$groups: { project: projectId }`, release,
+  environment, operation/method, `itxCallId`, `connectionId`, safe request/CF
+  metadata, and a stable application error ID.
+- Schedule the immediate send with `ExecutionContext.waitUntil()`. PostHog
+  failure must never fail the product call.
+- Bound network timeouts/retries for the edge runtime; the SDK's ordinary Node
+  retry defaults are too generous for an observability side effect.
+- Validate Worker stack symbolication end to end. The edge build does not have
+  Node filesystem source-context support.
+
+## Server failures and browser replay
+
+A Worker exception cannot directly trigger the browser SDK's exception-based
+session-replay retention. The server should return a stable `errorId` for an
+unexpected itx failure. The browser then emits a **non-exception** marker such
+as `itx_server_error_observed`, sharing `errorId` and `itxCallId`, or explicitly
+starts replay capture according to the chosen retention policy.
+
+The Worker remains the sole owner of the `$exception`; the browser marker says
+that the affected session observed it. This prevents two PostHog issues for one
+underlying failure while retaining the replay buffer.
+
+Recommended replay policy:
+
+- low baseline recording plus 100% exception/session-trigger retention;
+- mask all inputs and text initially, then selectively unmask reviewed UI;
+- scrub URL queries and network metadata with
+  `maskCapturedNetworkRequestFn`;
+- never record bodies, authorization headers, secrets, scripts, prompts, or
+  capability arguments; and
+- verify that the pre-trigger buffer is present for server failures observed by
+  the client.
+
+## Logs in PostHog: decision to make
+
+Selected logs should be available in PostHog when they materially improve the
+issue + replay investigation. Candidate designs, in preferred evaluation order:
+
+1. **PostHog Logs through OTLP.** Evaluate Cloudflare's native OTLP export or a
+   small application OTLP sink into PostHog Logs. PostHog currently documents
+   OTLP log ingestion for JavaScript/Node; Cloudflare's destination support
+   should be verified against the actual account and PostHog region. Confirm
+   whether filtering can restrict export to the intentional `os.evlog.v1`
+   application events rather than all platform invocations.
+2. **One direct structured log per completed operation.** Reuse the same
+   accumulated wide event sent to Cloudflare, but send only errors, degraded
+   outcomes, or slow/high-value calls to PostHog Logs. Delivery must be
+   `waitUntil`-backed and failure-independent.
+3. **Exception enrichment only.** Attach bounded breadcrumbs and final operation
+   fields to exceptions, without a standalone PostHog log stream. This is the
+   lowest-volume fallback but may be insufficient for investigating anomalous
+   successful behavior.
+
+Do not send every `console.log`, every Cap'n Web frame, or raw business inputs.
+Do not encode logs as arbitrary product analytics events merely to make them
+searchable. Decide retention, volume/cost budgets, and filtering before enabling
+a second copy of every successful operation.
+
+Questions the spike must answer:
+
+- Can native Cloudflare OTLP export send only the desired application logs to
+  PostHog, and can a PostHog log link directly to session replay?
+- Does PostHog preserve `itxCallId`, project group, release, and session ID as
+  first-class searchable fields?
+- Are errors and slow successful operations enough, or should particular
+  security/agent/dynamic-worker outcomes always be retained?
+- Which sink owns redaction so Cloudflare and PostHog cannot diverge?
+- Should the existing first-party PostHog proxy move to a dedicated Worker so
+  ingestion traffic does not pollute OS invocation observability?
+
+## Source maps and releases
+
+- Generate production source maps for browser and Worker bundles.
+- Run `posthog-cli sourcemap inject` before deployment and upload immediately
+  with an explicit immutable release, ideally the deployed git SHA.
+- Use the same release value in browser initialization, Worker exception/log
+  properties, Cloudflare structured events, and deployments.
+- Also enable Cloudflare `upload_source_maps: true`; Cloudflare and PostHog need
+  their own uploads.
+- Add a production-like acceptance test with minified browser and Worker throws
+  and verify the displayed source file, line, and release in each product.
+
+## Grouping and noise policy
+
+- Start with PostHog's automatic grouping. Add `$exception_fingerprint` only
+  after observing a concrete grouping defect.
+- Never put request, user, project, connection, or call IDs into a fingerprint.
+- Normalize wrapped/cause-chain errors without destroying the original stack.
+- Classify known control-flow errors before the capture boundary.
+- Do not randomly sample unexpected exceptions. Reduce noise by correct
+  classification and single ownership.
+- Apply `before_send` as the final redaction and known-benign-event guard, not as
+  the primary application error classifier.
+
+## What to retain from PR #1206
+
+- illegal logging outside a real async-local scope;
+- one post-hoc accumulated event at operation exit;
+- structured custom errors and cause chains;
+- bounded messages/breadcrumbs collected during the operation;
+- causal context for `waitUntil` work;
+- independently failing stdout/PostHog sinks; and
+- outside-in integration tests covering success, expected 4xx, thrown 5xx,
+  custom errors, warnings/info, and rejected background work.
+
+Avoid restoring full parent-log cloning, Hono/oRPC-specific integration,
+JSONata runtime filtering, local temp buffers, or duplicate catch/capture/rethrow
+behavior.
+
+## Acceptance criteria
+
+- [ ] A minified unhandled browser error appears once, symbolicated, linked to
+      user, project, release, and replay.
+- [ ] A handled terminal Worker HTTP error appears once and is searchable in
+      both PostHog and Cloudflare by request/error ID.
+- [ ] An itx error on a long-lived socket after PostHog session rotation uses
+      the current call's session ID, creates one Worker exception, and retains
+      the affected browser replay through a non-exception marker.
+- [ ] The selected PostHog Logs path is tested with success, slow, degraded, and
+      error wide events; the retention/filter policy and volume budget are
+      documented.
+- [ ] Intentional close, validation, cancellation, and reconnect scenarios do
+      not create exception issues.
+- [ ] Secrets, bodies, scripts, prompts, auth headers, and query parameters are
+      absent from captured events, logs, and replay.
+- [ ] PostHog delivery failure does not alter product outcomes.
+
+## Primary references
+
+- PR #1206: https://github.com/iterate/iterate/pull/1206
+- Exception capture: https://posthog.com/docs/error-tracking/capture
+- Exception grouping: https://posthog.com/docs/error-tracking/grouping-issues
+- Browser configuration: https://posthog.com/docs/libraries/js/config
+- React error tracking: https://posthog.com/docs/error-tracking/installation/react
+- Node/Worker error tracking: https://posthog.com/docs/error-tracking/installation/node
+- Source maps: https://posthog.com/docs/error-tracking/upload-source-maps/web
+- Replay retention triggers:
+  https://posthog.com/docs/session-replay/how-to-control-which-sessions-you-record
+- Replay privacy: https://posthog.com/docs/session-replay/privacy
+- JavaScript logs: https://posthog.com/docs/logs/installation/javascript
+- Node logs: https://posthog.com/docs/logs/installation/nodejs
+- Link logs to replay: https://posthog.com/docs/logs/link-session-replay
+- Cloudflare proxy: https://posthog.com/docs/advanced/proxy/cloudflare


### PR DESCRIPTION
## Why

The dashboard lane already emitted one accumulated evlog request event, but the api pipeline did not. That left HTTP itx, the WebSocket handshake, integration webhooks, project-host traffic, project files, and unresolved hosts without the same clean request envelope.

This is the narrow prerequisite for the PostHog gold path captured in `tasks/posthog-observability-gold-path.md`. It establishes a reviewed, redacted schema before any second sink is added.

## What changes

- Wrap every `apiFetch` outcome in the existing `withEvlog` lifecycle, including early returns and thrown failures.
- Add stable deployment `environment` and `version` fields to both app and api request events.
- Add an allowlisted ingress lane/operation, transport where meaningful, and server-resolved project/app/host-kind fields.
- Remove the complete runtime config object from emitted wide events; config remains internal to stdout/filter policy.
- Document the WebSocket boundary: the request event covers the `101` handshake, while logical calls after connection belong to the Capnweb `onCall` instrumentation in #1914.
- Preserve the explicit successful `/posthog-proxy/**` noise rule. This is semantic filtering, not sampling.

## Capture and data policy

There is no sampling. Every OS request gets the request-envelope lifecycle, and every logical itx call remains eligible for its own semantic event/span. The event never copies a full URL, query string, hostname, headers, cookies, auth token, body, RPC arguments/results, script, prompt, email, or client-asserted project identity.

The new correlation fields are `requestId`, `cfRay`, `traceparent`, environment, version, lane, operation, transport, and the trusted project resolution where present.

## Verification

- OS typecheck passed.
- OS unit suite: 126 files passed, 1 skipped; 1,220 tests passed, 1 skipped.
- Shared package tests: 4 files / 39 tests passed.
- Targeted formatting and lint passed with no warnings.
- Unit coverage proves success and thrown-error events, one error event only, rethrow preservation, request correlation, and absence of config/query/auth/cookie/body values.
- Preview Cloudflare log evidence: pending deployment.

## Intentionally next

1. Add edge-safe PostHog exception capture at the outer HTTP and logical itx-call boundaries, exactly once per unexpected failure.
2. Carry the current browser PostHog session/identity on each logical call rather than once per long-running socket.
3. Add the non-exception browser marker that retains replay when a server error is observed.
4. Decide and prove the selected PostHog Logs path for reviewed evlog events; do not forward arbitrary console output or every platform invocation.

Related: #1914, #1926, #1928, iterate/capnweb#3.

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +70 -5 | +67 -5 🟩⬜⬜⬜⬜ |
| Tests | +48 -1 | +45 -1 🟩⬜⬜⬜⬜ |
| Docs | +290 -2 | +247 -2 🟩🟩🟩🟩🟩 |
| **Total** | **+408 -8** | **+359 -8** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between d7b8b78 and 5242931, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-13T13:41:48.040Z",
      "headSha": "524293112705bf07c3f258c81a6409cda6b9555e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/432844917373575",
      "shortSha": "5242931",
      "cleanupDurationMs": 8848,
      "deployDurationMs": 79875,
      "testDurationMs": 275407,
      "testRetries": "4 retried: catalogue example \"workspace-edit-and-push\" runs identically across runtimes (vitest x1) · egress human approvals > enrolled approval keys make unsigned grants inert; a signed grant releases (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · preview a staged snapshot from the readonly Index view (specs x1)",
      "workerSizeKib": 16104.87,
      "workerGzipKib": 4344.53,
      "mainWorkerGzipKib": 4344.18
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-13T13:41:40.321Z",
      "headSha": "524293112705bf07c3f258c81a6409cda6b9555e",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/432844917373575",
      "shortSha": "5242931",
      "cleanupDurationMs": 1126,
      "deployDurationMs": 16453,
      "testDurationMs": 7151,
      "testRetries": null,
      "workerSizeKib": 1914.74,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-13T13:41:42.408Z",
      "headSha": "524293112705bf07c3f258c81a6409cda6b9555e",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/432844917373575",
      "shortSha": "5242931",
      "cleanupDurationMs": 3210,
      "deployDurationMs": 21652,
      "testDurationMs": 675,
      "testRetries": null,
      "workerSizeKib": 4033.03,
      "workerGzipKib": 819.64,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-13T13:41:40.080Z",
      "headSha": "524293112705bf07c3f258c81a6409cda6b9555e",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/432844917373575",
      "shortSha": "5242931",
      "cleanupDurationMs": 876,
      "deployDurationMs": 21169,
      "testDurationMs": 16074,
      "testRetries": null,
      "workerSizeKib": 4904.37,
      "workerGzipKib": 1403.33,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `5242931` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 819.6 KiB | 21.7s | 675ms |  | 3.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/432844917373575) | 2026-07-13T13:41:42.408Z | Preview app released. |
| OS | released | `5242931` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.24 MiB (+0.3 KiB vs main) | 79.9s | 275.4s | 4 retried: catalogue example "workspace-edit-and-push" runs identically across runtimes (vitest x1) · egress human approvals > enrolled approval keys make unsigned grants inert; a signed grant releases (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · preview a staged snapshot from the readonly Index view (specs x1) | 8.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/432844917373575) | 2026-07-13T13:41:48.040Z | Preview app released. |
| Semaphore | released | `5242931` | [https://semaphore.iterate-preview-1.com](https://semaphore.iterate-preview-1.com) | 440.8 KiB | 16.5s | 7.2s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/432844917373575) | 2026-07-13T13:41:40.321Z | Preview app released. |
| Streams Example App | released | `5242931` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.37 MiB | 21.2s | 16.1s |  | 876ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/432844917373575) | 2026-07-13T13:41:40.080Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->