### PR TITLE
Route sandbox OpenAI egress through Cloudflare AI Gateway

### DIFF
--- a/apps/os/docs/sandboxes.md
+++ b/apps/os/docs/sandboxes.md
@@ -209,15 +209,14 @@ Wiring (three points):
 
 ### OpenAI → Cloudflare AI Gateway
 
-Outbound calls to **`api.openai.com`** are rewritten at project egress onto the
-deployment's Cloudflare AI Gateway OpenAI provider-native base (same BYOK key
-and gateway id the agent Durable Object uses). The platform OpenAI key is
-injected there; sandboxes should plant a placeholder or any dummy
-`OPENAI_API_KEY` — the real key never needs to enter the container. Gateway
-requests carry `cf-aig-metadata` with at least `{ projectId, source:
-"project-egress" }` for log filtering. Implementation:
-`openai-ai-gateway-egress.ts` + `ProjectDurableObject.#egressOpenAiViaAiGateway`
-(Workers AI gateway binding preferred; REST rewrite as fallback).
+JSON **POST/PUT** to **`api.openai.com`** (chat/completions, responses, …) are
+routed at project egress through the Workers AI **gateway binding** — same door
+and platform OpenAI key as agent BYOK. Requests carry `cf-aig-metadata` with at
+least `{ projectId, source: "project-egress" }`. Sandboxes should plant a
+placeholder or dummy `OPENAI_API_KEY`; the real key is injected only in trusted
+egress code. Other methods (e.g. GET `/v1/models`) are **not** rewritten and
+use normal project egress. Implementation: `openai-ai-gateway-egress.ts` +
+`ProjectDurableObject.#egressOpenAiViaAiGateway`.
 
 ## Deployment
 

--- a/apps/os/docs/sandboxes.md
+++ b/apps/os/docs/sandboxes.md
@@ -210,12 +210,14 @@ Wiring (three points):
 ### OpenAI → Cloudflare AI Gateway
 
 JSON **POST/PUT** to **`api.openai.com`** (chat/completions, responses, …) are
-routed at project egress through the Workers AI **gateway binding** — same door
-and platform OpenAI key as agent BYOK. Requests carry `cf-aig-metadata` with at
-least `{ projectId, source: "project-egress" }`. Sandboxes should plant a
-placeholder or dummy `OPENAI_API_KEY`; the real key is injected only in trusted
-egress code. Other methods (e.g. GET `/v1/models`) are **not** rewritten and
-use normal project egress. Implementation: `openai-ai-gateway-egress.ts` +
+routed at **project egress** (sandbox MITM, worker `egress.fetch`, …) through
+the Workers AI **gateway binding only** — same door and **platform** OpenAI key
+as agent BYOK. Caller `Authorization` is replaced; plant a dummy/placeholder
+`OPENAI_API_KEY` in the container. Requests carry `cf-aig-metadata` with at
+least `{ projectId, source: "project-egress" }`, plus BYOK-parity collect-log
+headers. `OpenAI-*` and `Accept` caller headers are forwarded. Other methods
+(e.g. GET `/v1/models`) are **not** rewritten and use normal project egress
+(dummy keys will 401). Implementation: `openai-ai-gateway-egress.ts` +
 `ProjectDurableObject.#egressOpenAiViaAiGateway`.
 
 ## Deployment

--- a/apps/os/docs/sandboxes.md
+++ b/apps/os/docs/sandboxes.md
@@ -207,6 +207,18 @@ Wiring (three points):
   `SANDBOX_INTERCEPT_HTTPS` is set, which the SDK sets from the `interceptHttps`
   flag — so no Dockerfile change is needed for the container to trust it.
 
+### OpenAI → Cloudflare AI Gateway
+
+Outbound calls to **`api.openai.com`** are rewritten at project egress onto the
+deployment's Cloudflare AI Gateway OpenAI provider-native base (same BYOK key
+and gateway id the agent Durable Object uses). The platform OpenAI key is
+injected there; sandboxes should plant a placeholder or any dummy
+`OPENAI_API_KEY` — the real key never needs to enter the container. Gateway
+requests carry `cf-aig-metadata` with at least `{ projectId, source:
+"project-egress" }` for log filtering. Implementation:
+`openai-ai-gateway-egress.ts` + `ProjectDurableObject.#egressOpenAiViaAiGateway`
+(Workers AI gateway binding preferred; REST rewrite as fallback).
+
 ## Deployment
 
 The domain lives in `src/domains/sandboxes/`; the container classes are

--- a/apps/os/src/domains/projects/openai-ai-gateway-egress.test.ts
+++ b/apps/os/src/domains/projects/openai-ai-gateway-egress.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "vitest";
+import type { AppConfig } from "../../config.ts";
+import {
+  isOpenAiPublicApiRequest,
+  openAiAiGatewayRoutingFromConfig,
+  openAiAiGatewayUrl,
+  rewriteOpenAiRequestToAiGateway,
+} from "./openai-ai-gateway-egress.ts";
+
+describe("isOpenAiPublicApiRequest", () => {
+  test("matches api.openai.com only", () => {
+    expect(isOpenAiPublicApiRequest(new Request("https://api.openai.com/v1/models"))).toBe(true);
+    expect(
+      isOpenAiPublicApiRequest(
+        new Request("https://gateway.ai.cloudflare.com/v1/x/y/openai/models"),
+      ),
+    ).toBe(false);
+    expect(isOpenAiPublicApiRequest(new Request("https://example.com/v1/models"))).toBe(false);
+  });
+});
+
+describe("openAiAiGatewayUrl", () => {
+  test("maps /v1/<rest> onto the OpenAI provider-native gateway path", () => {
+    expect(
+      openAiAiGatewayUrl({
+        accountId: "acc",
+        gatewayId: "default",
+        openAiUrl: "https://api.openai.com/v1/chat/completions",
+      }),
+    ).toBe("https://gateway.ai.cloudflare.com/v1/acc/default/openai/chat/completions");
+
+    expect(
+      openAiAiGatewayUrl({
+        accountId: "acc",
+        gatewayId: "default",
+        openAiUrl: "https://api.openai.com/v1/responses?foo=1",
+      }),
+    ).toBe("https://gateway.ai.cloudflare.com/v1/acc/default/openai/responses?foo=1");
+  });
+
+  test("handles bare /v1", () => {
+    expect(
+      openAiAiGatewayUrl({
+        accountId: "acc",
+        gatewayId: "gw",
+        openAiUrl: "https://api.openai.com/v1",
+      }),
+    ).toBe("https://gateway.ai.cloudflare.com/v1/acc/gw/openai");
+  });
+});
+
+describe("rewriteOpenAiRequestToAiGateway", () => {
+  test("injects platform key, metadata, and skip-cache; drops host", async () => {
+    const body = JSON.stringify({ model: "gpt-4.1-mini", messages: [] });
+    const request = new Request("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        authorization: 'Bearer getSecret({ path: "/secrets/openai-api-key" })',
+        "content-type": "application/json",
+        host: "api.openai.com",
+      },
+      body,
+    });
+
+    const rewritten = rewriteOpenAiRequestToAiGateway({
+      request,
+      accountId: "acc-1",
+      gatewayId: "default",
+      openaiApiKey: "sk-platform",
+      metadata: { projectId: "prj_abc", source: "project-egress", caller: "sandbox" },
+      skipCache: true,
+      cfAigAuthorization: "cf-token",
+    });
+
+    expect(rewritten.url).toBe(
+      "https://gateway.ai.cloudflare.com/v1/acc-1/default/openai/chat/completions",
+    );
+    expect(rewritten.headers.get("authorization")).toBe("Bearer sk-platform");
+    expect(rewritten.headers.get("cf-aig-skip-cache")).toBe("true");
+    expect(rewritten.headers.get("cf-aig-authorization")).toBe("Bearer cf-token");
+    expect(rewritten.headers.get("host")).toBeNull();
+    expect(JSON.parse(rewritten.headers.get("cf-aig-metadata")!)).toEqual({
+      projectId: "prj_abc",
+      source: "project-egress",
+      caller: "sandbox",
+    });
+    expect(await rewritten.text()).toBe(body);
+  });
+});
+
+describe("openAiAiGatewayRoutingFromConfig", () => {
+  test("returns null without accountId", () => {
+    const config = {
+      openAiApiKey: { exposeSecret: () => "sk" },
+      cloudflareAiGateway: { id: "default" },
+      cloudflare: {},
+    } as unknown as AppConfig;
+    expect(openAiAiGatewayRoutingFromConfig(config)).toBeNull();
+  });
+
+  test("maps config fields and skipCache from responseCacheTtlSeconds", () => {
+    const base = {
+      openAiApiKey: { exposeSecret: () => "sk-x" },
+      cloudflareAiGateway: { id: "default" },
+      cloudflare: {
+        accountId: "acc",
+        apiToken: { exposeSecret: () => "cfut_x" },
+      },
+    };
+
+    expect(
+      openAiAiGatewayRoutingFromConfig({
+        ...base,
+        cloudflareAiGateway: { id: "default" },
+      } as unknown as AppConfig),
+    ).toEqual({
+      accountId: "acc",
+      gatewayId: "default",
+      openaiApiKey: "sk-x",
+      cfAigAuthorization: "cfut_x",
+      skipCache: true,
+    });
+
+    expect(
+      openAiAiGatewayRoutingFromConfig({
+        ...base,
+        cloudflareAiGateway: { id: "e2e", responseCacheTtlSeconds: 600 },
+      } as unknown as AppConfig),
+    ).toMatchObject({ gatewayId: "e2e", skipCache: false });
+  });
+});

--- a/apps/os/src/domains/projects/openai-ai-gateway-egress.test.ts
+++ b/apps/os/src/domains/projects/openai-ai-gateway-egress.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, test } from "vitest";
 import type { AppConfig } from "../../config.ts";
 import {
+  applyOpenAiAiGatewayCacheHeaders,
   isOpenAiPublicApiRequest,
   openAiAiGatewayRoutingFromConfig,
-  openAiAiGatewayUrl,
   openAiGatewayBindingEndpoint,
-  rewriteOpenAiRequestToAiGateway,
 } from "./openai-ai-gateway-egress.ts";
 
 describe("isOpenAiPublicApiRequest", () => {
@@ -20,98 +19,35 @@ describe("isOpenAiPublicApiRequest", () => {
   });
 });
 
-describe("openAiAiGatewayUrl", () => {
-  test("maps /v1/<rest> onto the OpenAI provider-native gateway path", () => {
-    expect(
-      openAiAiGatewayUrl({
-        accountId: "acc",
-        gatewayId: "default",
-        openAiUrl: "https://api.openai.com/v1/chat/completions",
-      }),
-    ).toBe("https://gateway.ai.cloudflare.com/v1/acc/default/openai/chat/completions");
-
-    expect(
-      openAiAiGatewayUrl({
-        accountId: "acc",
-        gatewayId: "default",
-        openAiUrl: "https://api.openai.com/v1/responses?foo=1",
-      }),
-    ).toBe("https://gateway.ai.cloudflare.com/v1/acc/default/openai/responses?foo=1");
-  });
-
-  test("handles bare /v1", () => {
-    expect(
-      openAiAiGatewayUrl({
-        accountId: "acc",
-        gatewayId: "gw",
-        openAiUrl: "https://api.openai.com/v1",
-      }),
-    ).toBe("https://gateway.ai.cloudflare.com/v1/acc/gw/openai");
-  });
-});
-
 describe("openAiGatewayBindingEndpoint", () => {
-  test("includes query string", () => {
-    expect(openAiGatewayBindingEndpoint("https://api.openai.com/v1/chat/completions?x=1")).toBe(
-      "chat/completions?x=1",
+  test("includes path after /v1 and query string", () => {
+    expect(openAiGatewayBindingEndpoint("https://api.openai.com/v1/chat/completions")).toBe(
+      "chat/completions",
+    );
+    expect(openAiGatewayBindingEndpoint("https://api.openai.com/v1/responses?foo=1")).toBe(
+      "responses?foo=1",
     );
   });
 });
 
-describe("rewriteOpenAiRequestToAiGateway", () => {
-  test("injects platform key, metadata, and skip-cache; drops host", async () => {
-    const body = JSON.stringify({ model: "gpt-4.1-mini", messages: [] });
-    const request = new Request("https://api.openai.com/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        authorization: 'Bearer getSecret({ path: "/secrets/openai-api-key" })',
-        "content-type": "application/json",
-        host: "api.openai.com",
-      },
-      body,
-    });
-
-    const rewritten = await rewriteOpenAiRequestToAiGateway({
-      request,
-      accountId: "acc-1",
-      gatewayId: "default",
-      openaiApiKey: "sk-platform",
-      metadata: { projectId: "prj_abc", source: "project-egress", caller: "sandbox" },
-      cfAigAuthorization: "cf-token",
-      bodyForCacheKey: { model: "gpt-4.1-mini", messages: [] },
-    });
-
-    expect(rewritten.url).toBe(
-      "https://gateway.ai.cloudflare.com/v1/acc-1/default/openai/chat/completions",
-    );
-    expect(rewritten.headers.get("authorization")).toBe("Bearer sk-platform");
-    expect(rewritten.headers.get("cf-aig-skip-cache")).toBe("true");
-    expect(rewritten.headers.get("cf-aig-authorization")).toBe("Bearer cf-token");
-    expect(rewritten.headers.get("host")).toBeNull();
-    expect(JSON.parse(rewritten.headers.get("cf-aig-metadata")!)).toEqual({
-      projectId: "prj_abc",
-      source: "project-egress",
-      caller: "sandbox",
-    });
-    expect(await rewritten.text()).toBe(body);
+describe("applyOpenAiAiGatewayCacheHeaders", () => {
+  test("sets skip-cache when no TTL", async () => {
+    const headers: Record<string, string> = {};
+    await applyOpenAiAiGatewayCacheHeaders({ headers, body: { model: "x" } });
+    expect(headers["cf-aig-skip-cache"]).toBe("true");
+    expect(headers["cf-aig-cache-ttl"]).toBeUndefined();
   });
 
-  test("sets cache-ttl and cache-key when responseCacheTtlSeconds is set", async () => {
-    const rewritten = await rewriteOpenAiRequestToAiGateway({
-      request: new Request("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        body: "{}",
-      }),
-      accountId: "acc",
-      gatewayId: "default",
-      openaiApiKey: "sk",
-      metadata: { projectId: "prj_x", source: "project-egress" },
+  test("sets cache-ttl and cache-key when TTL is set", async () => {
+    const headers: Record<string, string> = {};
+    await applyOpenAiAiGatewayCacheHeaders({
+      headers,
+      body: { model: "gpt-4.1-mini" },
       responseCacheTtlSeconds: 600,
-      bodyForCacheKey: { model: "gpt-4.1-mini" },
     });
-    expect(rewritten.headers.get("cf-aig-cache-ttl")).toBe("600");
-    expect(rewritten.headers.get("cf-aig-cache-key")).toMatch(/^[0-9a-f]{64}$/);
-    expect(rewritten.headers.get("cf-aig-skip-cache")).toBeNull();
+    expect(headers["cf-aig-cache-ttl"]).toBe("600");
+    expect(headers["cf-aig-cache-key"]).toMatch(/^[0-9a-f]{64}$/);
+    expect(headers["cf-aig-skip-cache"]).toBeUndefined();
   });
 });
 
@@ -125,33 +61,28 @@ describe("openAiAiGatewayRoutingFromConfig", () => {
     expect(openAiAiGatewayRoutingFromConfig(config)).toBeNull();
   });
 
-  test("maps config fields including optional response cache TTL", () => {
-    const base = {
-      openAiApiKey: { exposeSecret: () => "sk-x" },
-      cloudflareAiGateway: { id: "default" },
-      cloudflare: {
-        accountId: "acc",
-        apiToken: { exposeSecret: () => "cfut_x" },
-      },
-    };
-
+  test("maps gateway id, platform key, and optional cache TTL", () => {
     expect(
       openAiAiGatewayRoutingFromConfig({
-        ...base,
+        openAiApiKey: { exposeSecret: () => "sk-x" },
         cloudflareAiGateway: { id: "default" },
+        cloudflare: { accountId: "acc" },
       } as unknown as AppConfig),
     ).toEqual({
-      accountId: "acc",
       gatewayId: "default",
       openaiApiKey: "sk-x",
-      cfAigAuthorization: "cfut_x",
     });
 
     expect(
       openAiAiGatewayRoutingFromConfig({
-        ...base,
+        openAiApiKey: { exposeSecret: () => "sk-x" },
         cloudflareAiGateway: { id: "e2e", responseCacheTtlSeconds: 600 },
+        cloudflare: { accountId: "acc" },
       } as unknown as AppConfig),
-    ).toMatchObject({ gatewayId: "e2e", responseCacheTtlSeconds: 600 });
+    ).toEqual({
+      gatewayId: "e2e",
+      openaiApiKey: "sk-x",
+      responseCacheTtlSeconds: 600,
+    });
   });
 });

--- a/apps/os/src/domains/projects/openai-ai-gateway-egress.test.ts
+++ b/apps/os/src/domains/projects/openai-ai-gateway-egress.test.ts
@@ -3,6 +3,7 @@ import type { AppConfig } from "../../config.ts";
 import {
   applyOpenAiAiGatewayCacheHeaders,
   isOpenAiPublicApiRequest,
+  openAiAiGatewayBindingHeaders,
   openAiAiGatewayRoutingFromConfig,
   openAiGatewayBindingEndpoint,
 } from "./openai-ai-gateway-egress.ts";
@@ -48,6 +49,53 @@ describe("applyOpenAiAiGatewayCacheHeaders", () => {
     expect(headers["cf-aig-cache-ttl"]).toBe("600");
     expect(headers["cf-aig-cache-key"]).toMatch(/^[0-9a-f]{64}$/);
     expect(headers["cf-aig-skip-cache"]).toBeUndefined();
+  });
+});
+
+describe("openAiAiGatewayBindingHeaders", () => {
+  test("injects platform key, collect-log, metadata; forwards OpenAI-* and Accept", () => {
+    const headers = openAiAiGatewayBindingHeaders({
+      openaiApiKey: "sk-platform",
+      projectId: "proj_test",
+      requestHeaders: new Headers({
+        authorization: "Bearer dummy-from-sandbox",
+        "content-type": "application/json",
+        "openai-beta": "responses=v1",
+        "OpenAI-Organization": "org-xyz",
+        accept: "text/event-stream",
+        "x-iterate-sandbox": "sbx-1",
+        "x-custom-noise": "drop-me",
+      }),
+    });
+    expect(headers.authorization).toBe("Bearer sk-platform");
+    expect(headers["content-type"]).toBe("application/json");
+    expect(headers["cf-aig-collect-log"]).toBe("true");
+    expect(headers["cf-aig-collect-log-payload"]).toBe("true");
+    expect(JSON.parse(headers["cf-aig-metadata"]!)).toEqual({
+      projectId: "proj_test",
+      source: "project-egress",
+      caller: "sbx-1",
+    });
+    expect(headers["openai-beta"]).toBe("responses=v1");
+    expect(headers["openai-organization"]).toBe("org-xyz");
+    expect(headers.accept).toBe("text/event-stream");
+    expect(headers["x-custom-noise"]).toBeUndefined();
+    expect(headers["x-iterate-sandbox"]).toBeUndefined();
+  });
+
+  test("replaces caller authorization even when it looks like a real key", () => {
+    const headers = openAiAiGatewayBindingHeaders({
+      openaiApiKey: "sk-platform",
+      projectId: "proj_test",
+      requestHeaders: new Headers({
+        authorization: "Bearer sk-customer-real",
+      }),
+    });
+    expect(headers.authorization).toBe("Bearer sk-platform");
+    expect(JSON.parse(headers["cf-aig-metadata"]!)).toEqual({
+      projectId: "proj_test",
+      source: "project-egress",
+    });
   });
 });
 

--- a/apps/os/src/domains/projects/openai-ai-gateway-egress.test.ts
+++ b/apps/os/src/domains/projects/openai-ai-gateway-egress.test.ts
@@ -4,6 +4,7 @@ import {
   isOpenAiPublicApiRequest,
   openAiAiGatewayRoutingFromConfig,
   openAiAiGatewayUrl,
+  openAiGatewayBindingEndpoint,
   rewriteOpenAiRequestToAiGateway,
 } from "./openai-ai-gateway-egress.ts";
 
@@ -49,6 +50,14 @@ describe("openAiAiGatewayUrl", () => {
   });
 });
 
+describe("openAiGatewayBindingEndpoint", () => {
+  test("includes query string", () => {
+    expect(openAiGatewayBindingEndpoint("https://api.openai.com/v1/chat/completions?x=1")).toBe(
+      "chat/completions?x=1",
+    );
+  });
+});
+
 describe("rewriteOpenAiRequestToAiGateway", () => {
   test("injects platform key, metadata, and skip-cache; drops host", async () => {
     const body = JSON.stringify({ model: "gpt-4.1-mini", messages: [] });
@@ -62,14 +71,14 @@ describe("rewriteOpenAiRequestToAiGateway", () => {
       body,
     });
 
-    const rewritten = rewriteOpenAiRequestToAiGateway({
+    const rewritten = await rewriteOpenAiRequestToAiGateway({
       request,
       accountId: "acc-1",
       gatewayId: "default",
       openaiApiKey: "sk-platform",
       metadata: { projectId: "prj_abc", source: "project-egress", caller: "sandbox" },
-      skipCache: true,
       cfAigAuthorization: "cf-token",
+      bodyForCacheKey: { model: "gpt-4.1-mini", messages: [] },
     });
 
     expect(rewritten.url).toBe(
@@ -86,6 +95,24 @@ describe("rewriteOpenAiRequestToAiGateway", () => {
     });
     expect(await rewritten.text()).toBe(body);
   });
+
+  test("sets cache-ttl and cache-key when responseCacheTtlSeconds is set", async () => {
+    const rewritten = await rewriteOpenAiRequestToAiGateway({
+      request: new Request("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        body: "{}",
+      }),
+      accountId: "acc",
+      gatewayId: "default",
+      openaiApiKey: "sk",
+      metadata: { projectId: "prj_x", source: "project-egress" },
+      responseCacheTtlSeconds: 600,
+      bodyForCacheKey: { model: "gpt-4.1-mini" },
+    });
+    expect(rewritten.headers.get("cf-aig-cache-ttl")).toBe("600");
+    expect(rewritten.headers.get("cf-aig-cache-key")).toMatch(/^[0-9a-f]{64}$/);
+    expect(rewritten.headers.get("cf-aig-skip-cache")).toBeNull();
+  });
 });
 
 describe("openAiAiGatewayRoutingFromConfig", () => {
@@ -98,7 +125,7 @@ describe("openAiAiGatewayRoutingFromConfig", () => {
     expect(openAiAiGatewayRoutingFromConfig(config)).toBeNull();
   });
 
-  test("maps config fields and skipCache from responseCacheTtlSeconds", () => {
+  test("maps config fields including optional response cache TTL", () => {
     const base = {
       openAiApiKey: { exposeSecret: () => "sk-x" },
       cloudflareAiGateway: { id: "default" },
@@ -118,7 +145,6 @@ describe("openAiAiGatewayRoutingFromConfig", () => {
       gatewayId: "default",
       openaiApiKey: "sk-x",
       cfAigAuthorization: "cfut_x",
-      skipCache: true,
     });
 
     expect(
@@ -126,6 +152,6 @@ describe("openAiAiGatewayRoutingFromConfig", () => {
         ...base,
         cloudflareAiGateway: { id: "e2e", responseCacheTtlSeconds: 600 },
       } as unknown as AppConfig),
-    ).toMatchObject({ gatewayId: "e2e", skipCache: false });
+    ).toMatchObject({ gatewayId: "e2e", responseCacheTtlSeconds: 600 });
   });
 });

--- a/apps/os/src/domains/projects/openai-ai-gateway-egress.ts
+++ b/apps/os/src/domains/projects/openai-ai-gateway-egress.ts
@@ -1,0 +1,148 @@
+/**
+ * Route project-egress traffic aimed at OpenAI's public API through Cloudflare
+ * AI Gateway so sandbox coding agents (Codex, etc.) get the same BYOK path,
+ * observability, and spend controls as platform agents — without teaching every
+ * CLI about gateway URLs.
+ *
+ * OpenAI host → AI Gateway OpenAI provider-native base:
+ *   https://api.openai.com/v1/<rest>
+ *   → https://gateway.ai.cloudflare.com/v1/<accountId>/<gatewayId>/openai/<rest>
+ *
+ * Runs only in trusted Project DO egress (after interceptors / approval). The
+ * platform OpenAI key is injected here deliberately: project egress does NOT
+ * expose `getSecret({ platform: "openAiApiKey" })` (see platform-secrets.ts);
+ * sandbox CLIs plant a placeholder or dummy key and this door rewrites + pays.
+ */
+
+import type { AppConfig } from "../../config.ts";
+
+/** True when the request targets OpenAI's public API host (http or https). */
+export function isOpenAiPublicApiRequest(request: Request): boolean {
+  try {
+    return new URL(request.url).hostname === "api.openai.com";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build the AI Gateway OpenAI provider-native URL for one OpenAI API request.
+ * Preserves query string; maps `/v1/<rest>` → `/v1/<account>/<gateway>/openai/<rest>`.
+ */
+export function openAiAiGatewayUrl(input: {
+  accountId: string;
+  gatewayId: string;
+  openAiUrl: string;
+}): string {
+  const src = new URL(input.openAiUrl);
+  if (src.hostname !== "api.openai.com") {
+    throw new Error(`openAiAiGatewayUrl: expected api.openai.com, got ${src.hostname}`);
+  }
+  // `/v1/chat/completions` → `chat/completions`; bare `/v1` or `/v1/` → ""
+  const rest = src.pathname.replace(/^\/v1\/?/, "");
+  const path =
+    rest.length === 0
+      ? `/v1/${input.accountId}/${input.gatewayId}/openai`
+      : `/v1/${input.accountId}/${input.gatewayId}/openai/${rest}`;
+  return `https://gateway.ai.cloudflare.com${path}${src.search}`;
+}
+
+/** Metadata stamped on every rewritten request (AI Gateway allows ≤5 entries). */
+export type OpenAiAiGatewayMetadata = {
+  projectId: string;
+  source: "project-egress";
+  /** Optional sandbox / agent path when known from headers; otherwise omitted. */
+  caller?: string;
+};
+
+/**
+ * Rewrite an OpenAI API Request onto AI Gateway and inject the platform key +
+ * gateway headers. Does not fetch — caller runs fetch / fetchWithCredentialRedirects.
+ */
+export function rewriteOpenAiRequestToAiGateway(input: {
+  request: Request;
+  accountId: string;
+  gatewayId: string;
+  openaiApiKey: string;
+  metadata: OpenAiAiGatewayMetadata;
+  /** When the gateway requires Authenticated Gateway, pass a CF API token with AI Gateway Run. */
+  cfAigAuthorization?: string;
+  /** prd-style: never serve a cached whole-answer (matches workers-ai-transport). */
+  skipCache?: boolean;
+}): Request {
+  const gatewayUrl = openAiAiGatewayUrl({
+    accountId: input.accountId,
+    gatewayId: input.gatewayId,
+    openAiUrl: input.request.url,
+  });
+
+  const headers = new Headers(input.request.headers);
+  // Drop hop-by-hop headers that confuse the gateway edge.
+  headers.delete("host");
+  headers.delete("connection");
+  headers.delete("keep-alive");
+  headers.delete("transfer-encoding");
+  headers.delete("upgrade");
+  headers.delete("proxy-connection");
+
+  headers.set("Authorization", `Bearer ${input.openaiApiKey}`);
+  headers.set("cf-aig-metadata", JSON.stringify(compactMetadata(input.metadata)));
+  if (input.skipCache) {
+    headers.set("cf-aig-skip-cache", "true");
+  } else {
+    headers.delete("cf-aig-skip-cache");
+  }
+  if (input.cfAigAuthorization !== undefined && input.cfAigAuthorization.length > 0) {
+    headers.set("cf-aig-authorization", `Bearer ${input.cfAigAuthorization}`);
+  }
+
+  // duplex required when re-streaming a request body in some runtimes.
+  const init: RequestInit & { duplex?: "half" } = {
+    method: input.request.method,
+    headers,
+    redirect: "manual",
+  };
+  if (input.request.method !== "GET" && input.request.method !== "HEAD") {
+    init.body = input.request.body;
+    if (input.request.body !== null) {
+      init.duplex = "half";
+    }
+  }
+  return new Request(gatewayUrl, init);
+}
+
+/** Pull gateway routing inputs from typed AppConfig; null when rewrite is impossible. */
+export function openAiAiGatewayRoutingFromConfig(config: AppConfig): {
+  accountId: string;
+  gatewayId: string;
+  openaiApiKey: string;
+  cfAigAuthorization?: string;
+  skipCache: boolean;
+} | null {
+  const accountId = config.cloudflare.accountId;
+  if (accountId === undefined || accountId.length === 0) return null;
+  const gatewayId = config.cloudflareAiGateway.id;
+  const openaiApiKey = config.openAiApiKey.exposeSecret();
+  const cfToken = config.cloudflare.apiToken?.exposeSecret();
+  return {
+    accountId,
+    gatewayId,
+    openaiApiKey,
+    ...(cfToken !== undefined && cfToken.length > 0 ? { cfAigAuthorization: cfToken } : {}),
+    // Match agent BYOK: only preview/dev set a response-cache TTL; prd skips.
+    skipCache: config.cloudflareAiGateway.responseCacheTtlSeconds === undefined,
+  };
+}
+
+function compactMetadata(
+  metadata: OpenAiAiGatewayMetadata,
+): Record<string, string | number | boolean | null> {
+  const out: Record<string, string | number | boolean | null> = {
+    projectId: metadata.projectId,
+    source: metadata.source,
+  };
+  if (metadata.caller !== undefined && metadata.caller.length > 0) {
+    out.caller = metadata.caller;
+  }
+  return out;
+}

--- a/apps/os/src/domains/projects/openai-ai-gateway-egress.ts
+++ b/apps/os/src/domains/projects/openai-ai-gateway-egress.ts
@@ -48,7 +48,7 @@ export function openAiAiGatewayUrl(input: {
 }
 
 /** Metadata stamped on every rewritten request (AI Gateway allows ≤5 entries). */
-export type OpenAiAiGatewayMetadata = {
+type OpenAiAiGatewayMetadata = {
   projectId: string;
   source: "project-egress";
   /** Optional sandbox / agent path when known from headers; otherwise omitted. */

--- a/apps/os/src/domains/projects/openai-ai-gateway-egress.ts
+++ b/apps/os/src/domains/projects/openai-ai-gateway-egress.ts
@@ -15,6 +15,7 @@
  */
 
 import type { AppConfig } from "../../config.ts";
+import { cloudflareAiGatewayResponseCacheKey } from "../agents/workers-ai-transport.ts";
 
 /** True when the request targets OpenAI's public API host (http or https). */
 export function isOpenAiPublicApiRequest(request: Request): boolean {
@@ -56,10 +57,39 @@ type OpenAiAiGatewayMetadata = {
 };
 
 /**
+ * Apply gateway cache headers to match agent BYOK (`workers-ai-transport.ts`):
+ * - with TTL: `cf-aig-cache-ttl` + `cf-aig-cache-key` (body-derived)
+ * - without: `cf-aig-skip-cache: true` so dashboard defaults never serve cache
+ */
+export async function applyOpenAiAiGatewayCacheHeaders(input: {
+  headers: Headers | Record<string, string>;
+  body: unknown;
+  responseCacheTtlSeconds?: number;
+}): Promise<void> {
+  const set = (name: string, value: string) => {
+    if (input.headers instanceof Headers) input.headers.set(name, value);
+    else input.headers[name] = value;
+  };
+  const del = (name: string) => {
+    if (input.headers instanceof Headers) input.headers.delete(name);
+    else delete input.headers[name];
+  };
+  if (input.responseCacheTtlSeconds !== undefined) {
+    set("cf-aig-cache-ttl", String(input.responseCacheTtlSeconds));
+    set("cf-aig-cache-key", await cloudflareAiGatewayResponseCacheKey(input.body));
+    del("cf-aig-skip-cache");
+  } else {
+    set("cf-aig-skip-cache", "true");
+    del("cf-aig-cache-ttl");
+    del("cf-aig-cache-key");
+  }
+}
+
+/**
  * Rewrite an OpenAI API Request onto AI Gateway and inject the platform key +
  * gateway headers. Does not fetch — caller runs fetch / fetchWithCredentialRedirects.
  */
-export function rewriteOpenAiRequestToAiGateway(input: {
+export async function rewriteOpenAiRequestToAiGateway(input: {
   request: Request;
   accountId: string;
   gatewayId: string;
@@ -67,9 +97,10 @@ export function rewriteOpenAiRequestToAiGateway(input: {
   metadata: OpenAiAiGatewayMetadata;
   /** When the gateway requires Authenticated Gateway, pass a CF API token with AI Gateway Run. */
   cfAigAuthorization?: string;
-  /** prd-style: never serve a cached whole-answer (matches workers-ai-transport). */
-  skipCache?: boolean;
-}): Request {
+  responseCacheTtlSeconds?: number;
+  /** Optional pre-read body for cache key (avoids consuming request.body twice). */
+  bodyForCacheKey?: unknown;
+}): Promise<Request> {
   const gatewayUrl = openAiAiGatewayUrl({
     accountId: input.accountId,
     gatewayId: input.gatewayId,
@@ -87,11 +118,11 @@ export function rewriteOpenAiRequestToAiGateway(input: {
 
   headers.set("Authorization", `Bearer ${input.openaiApiKey}`);
   headers.set("cf-aig-metadata", JSON.stringify(compactMetadata(input.metadata)));
-  if (input.skipCache) {
-    headers.set("cf-aig-skip-cache", "true");
-  } else {
-    headers.delete("cf-aig-skip-cache");
-  }
+  await applyOpenAiAiGatewayCacheHeaders({
+    headers,
+    body: input.bodyForCacheKey ?? null,
+    responseCacheTtlSeconds: input.responseCacheTtlSeconds,
+  });
   if (input.cfAigAuthorization !== undefined && input.cfAigAuthorization.length > 0) {
     headers.set("cf-aig-authorization", `Bearer ${input.cfAigAuthorization}`);
   }
@@ -117,21 +148,31 @@ export function openAiAiGatewayRoutingFromConfig(config: AppConfig): {
   gatewayId: string;
   openaiApiKey: string;
   cfAigAuthorization?: string;
-  skipCache: boolean;
+  responseCacheTtlSeconds?: number;
 } | null {
   const accountId = config.cloudflare.accountId;
   if (accountId === undefined || accountId.length === 0) return null;
   const gatewayId = config.cloudflareAiGateway.id;
   const openaiApiKey = config.openAiApiKey.exposeSecret();
   const cfToken = config.cloudflare.apiToken?.exposeSecret();
+  const ttl = config.cloudflareAiGateway.responseCacheTtlSeconds;
   return {
     accountId,
     gatewayId,
     openaiApiKey,
     ...(cfToken !== undefined && cfToken.length > 0 ? { cfAigAuthorization: cfToken } : {}),
-    // Match agent BYOK: only preview/dev set a response-cache TTL; prd skips.
-    skipCache: config.cloudflareAiGateway.responseCacheTtlSeconds === undefined,
+    ...(ttl !== undefined ? { responseCacheTtlSeconds: ttl } : {}),
   };
+}
+
+/**
+ * Endpoint string for `AI.gateway().run`: path after `/v1/` plus any query
+ * (so `?foo=1` is not dropped relative to the REST rewrite path).
+ */
+export function openAiGatewayBindingEndpoint(openAiUrl: string): string {
+  const url = new URL(openAiUrl);
+  const rest = url.pathname.replace(/^\/v1\/?/, "");
+  return `${rest}${url.search}`;
 }
 
 function compactMetadata(

--- a/apps/os/src/domains/projects/openai-ai-gateway-egress.ts
+++ b/apps/os/src/domains/projects/openai-ai-gateway-egress.ts
@@ -1,17 +1,12 @@
 /**
- * Route project-egress traffic aimed at OpenAI's public API through Cloudflare
- * AI Gateway so sandbox coding agents (Codex, etc.) get the same BYOK path,
- * observability, and spend controls as platform agents — without teaching every
- * CLI about gateway URLs.
+ * Route sandbox OpenAI JSON API calls through Cloudflare AI Gateway via the
+ * Workers AI binding (`env.AI.gateway(id).run`) — same door agent BYOK uses.
  *
- * OpenAI host → AI Gateway OpenAI provider-native base:
- *   https://api.openai.com/v1/<rest>
- *   → https://gateway.ai.cloudflare.com/v1/<accountId>/<gatewayId>/openai/<rest>
+ * Only JSON POST/PUT to `api.openai.com` are handled (chat/completions,
+ * responses, …). Other methods fall through to normal project egress.
  *
- * Runs only in trusted Project DO egress (after interceptors / approval). The
- * platform OpenAI key is injected here deliberately: project egress does NOT
- * expose `getSecret({ platform: "openAiApiKey" })` (see platform-secrets.ts);
- * sandbox CLIs plant a placeholder or dummy key and this door rewrites + pays.
+ * The platform OpenAI key is injected in trusted Project DO code; sandboxes
+ * plant a dummy/placeholder `OPENAI_API_KEY` and never need the real key.
  */
 
 import type { AppConfig } from "../../config.ts";
@@ -25,36 +20,6 @@ export function isOpenAiPublicApiRequest(request: Request): boolean {
     return false;
   }
 }
-
-/**
- * Build the AI Gateway OpenAI provider-native URL for one OpenAI API request.
- * Preserves query string; maps `/v1/<rest>` → `/v1/<account>/<gateway>/openai/<rest>`.
- */
-export function openAiAiGatewayUrl(input: {
-  accountId: string;
-  gatewayId: string;
-  openAiUrl: string;
-}): string {
-  const src = new URL(input.openAiUrl);
-  if (src.hostname !== "api.openai.com") {
-    throw new Error(`openAiAiGatewayUrl: expected api.openai.com, got ${src.hostname}`);
-  }
-  // `/v1/chat/completions` → `chat/completions`; bare `/v1` or `/v1/` → ""
-  const rest = src.pathname.replace(/^\/v1\/?/, "");
-  const path =
-    rest.length === 0
-      ? `/v1/${input.accountId}/${input.gatewayId}/openai`
-      : `/v1/${input.accountId}/${input.gatewayId}/openai/${rest}`;
-  return `https://gateway.ai.cloudflare.com${path}${src.search}`;
-}
-
-/** Metadata stamped on every rewritten request (AI Gateway allows ≤5 entries). */
-type OpenAiAiGatewayMetadata = {
-  projectId: string;
-  source: "project-egress";
-  /** Optional sandbox / agent path when known from headers; otherwise omitted. */
-  caller?: string;
-};
 
 /**
  * Apply gateway cache headers to match agent BYOK (`workers-ai-transport.ts`):
@@ -85,105 +50,33 @@ export async function applyOpenAiAiGatewayCacheHeaders(input: {
   }
 }
 
-/**
- * Rewrite an OpenAI API Request onto AI Gateway and inject the platform key +
- * gateway headers. Does not fetch — caller runs fetch / fetchWithCredentialRedirects.
- */
-export async function rewriteOpenAiRequestToAiGateway(input: {
-  request: Request;
-  accountId: string;
-  gatewayId: string;
-  openaiApiKey: string;
-  metadata: OpenAiAiGatewayMetadata;
-  /** When the gateway requires Authenticated Gateway, pass a CF API token with AI Gateway Run. */
-  cfAigAuthorization?: string;
-  responseCacheTtlSeconds?: number;
-  /** Optional pre-read body for cache key (avoids consuming request.body twice). */
-  bodyForCacheKey?: unknown;
-}): Promise<Request> {
-  const gatewayUrl = openAiAiGatewayUrl({
-    accountId: input.accountId,
-    gatewayId: input.gatewayId,
-    openAiUrl: input.request.url,
-  });
-
-  const headers = new Headers(input.request.headers);
-  // Drop hop-by-hop headers that confuse the gateway edge.
-  headers.delete("host");
-  headers.delete("connection");
-  headers.delete("keep-alive");
-  headers.delete("transfer-encoding");
-  headers.delete("upgrade");
-  headers.delete("proxy-connection");
-
-  headers.set("Authorization", `Bearer ${input.openaiApiKey}`);
-  headers.set("cf-aig-metadata", JSON.stringify(compactMetadata(input.metadata)));
-  await applyOpenAiAiGatewayCacheHeaders({
-    headers,
-    body: input.bodyForCacheKey ?? null,
-    responseCacheTtlSeconds: input.responseCacheTtlSeconds,
-  });
-  if (input.cfAigAuthorization !== undefined && input.cfAigAuthorization.length > 0) {
-    headers.set("cf-aig-authorization", `Bearer ${input.cfAigAuthorization}`);
-  }
-
-  // duplex required when re-streaming a request body in some runtimes.
-  const init: RequestInit & { duplex?: "half" } = {
-    method: input.request.method,
-    headers,
-    redirect: "manual",
-  };
-  if (input.request.method !== "GET" && input.request.method !== "HEAD") {
-    init.body = input.request.body;
-    if (input.request.body !== null) {
-      init.duplex = "half";
-    }
-  }
-  return new Request(gatewayUrl, init);
-}
-
-/** Pull gateway routing inputs from typed AppConfig; null when rewrite is impossible. */
+/** Pull binding-path inputs from typed AppConfig; null when routing is impossible. */
 export function openAiAiGatewayRoutingFromConfig(config: AppConfig): {
-  accountId: string;
   gatewayId: string;
   openaiApiKey: string;
-  cfAigAuthorization?: string;
   responseCacheTtlSeconds?: number;
 } | null {
-  const accountId = config.cloudflare.accountId;
-  if (accountId === undefined || accountId.length === 0) return null;
-  const gatewayId = config.cloudflareAiGateway.id;
-  const openaiApiKey = config.openAiApiKey.exposeSecret();
-  const cfToken = config.cloudflare.apiToken?.exposeSecret();
-  const ttl = config.cloudflareAiGateway.responseCacheTtlSeconds;
+  // accountId is not required for the Workers AI binding path.
+  if (config.cloudflare.accountId === undefined || config.cloudflare.accountId.length === 0) {
+    // Still require a deployed-shaped config so local miniflare without CF account
+    // does not accidentally try to call a missing gateway binding with real keys.
+    // Preview/prd always set ARTIFACTS_ACCOUNT_ID → cloudflare.accountId.
+    return null;
+  }
   return {
-    accountId,
-    gatewayId,
-    openaiApiKey,
-    ...(cfToken !== undefined && cfToken.length > 0 ? { cfAigAuthorization: cfToken } : {}),
-    ...(ttl !== undefined ? { responseCacheTtlSeconds: ttl } : {}),
+    gatewayId: config.cloudflareAiGateway.id,
+    openaiApiKey: config.openAiApiKey.exposeSecret(),
+    ...(config.cloudflareAiGateway.responseCacheTtlSeconds !== undefined
+      ? { responseCacheTtlSeconds: config.cloudflareAiGateway.responseCacheTtlSeconds }
+      : {}),
   };
 }
 
 /**
- * Endpoint string for `AI.gateway().run`: path after `/v1/` plus any query
- * (so `?foo=1` is not dropped relative to the REST rewrite path).
+ * Endpoint string for `AI.gateway().run`: path after `/v1/` plus any query.
  */
 export function openAiGatewayBindingEndpoint(openAiUrl: string): string {
   const url = new URL(openAiUrl);
   const rest = url.pathname.replace(/^\/v1\/?/, "");
   return `${rest}${url.search}`;
-}
-
-function compactMetadata(
-  metadata: OpenAiAiGatewayMetadata,
-): Record<string, string | number | boolean | null> {
-  const out: Record<string, string | number | boolean | null> = {
-    projectId: metadata.projectId,
-    source: metadata.source,
-  };
-  if (metadata.caller !== undefined && metadata.caller.length > 0) {
-    out.caller = metadata.caller;
-  }
-  return out;
 }

--- a/apps/os/src/domains/projects/openai-ai-gateway-egress.ts
+++ b/apps/os/src/domains/projects/openai-ai-gateway-egress.ts
@@ -1,12 +1,20 @@
 /**
- * Route sandbox OpenAI JSON API calls through Cloudflare AI Gateway via the
- * Workers AI binding (`env.AI.gateway(id).run`) — same door agent BYOK uses.
+ * Route project-egress OpenAI JSON API calls through Cloudflare AI Gateway via
+ * the Workers AI binding (`env.AI.gateway(id).run`) — same door agent BYOK uses.
  *
- * Only JSON POST/PUT to `api.openai.com` are handled (chat/completions,
- * responses, …). Other methods fall through to normal project egress.
+ * Scope: **all** project egress (sandbox MITM, project worker `egress.fetch`,
+ * etc.), not a sandbox-only branch. JSON POST/PUT to `api.openai.com` only;
+ * other methods fall through to normal project egress (GET /models with a
+ * dummy key will still 401).
  *
- * The platform OpenAI key is injected in trusted Project DO code; sandboxes
- * plant a dummy/placeholder `OPENAI_API_KEY` and never need the real key.
+ * The platform OpenAI key is always injected in trusted Project DO code (same
+ * key agent BYOK uses). Callers should plant a dummy/placeholder
+ * `OPENAI_API_KEY`; customer keys in Authorization are replaced. The key is
+ * not available via `getSecret({ platform: "openAiApiKey" })` — only via this
+ * rewrite path.
+ *
+ * Binding-only: no REST AI Gateway rewrite and no direct-OpenAI platform-key
+ * ladder (those paths 401'd under Authenticated Gateway without a Run token).
  */
 
 import type { AppConfig } from "../../config.ts";
@@ -50,17 +58,53 @@ export async function applyOpenAiAiGatewayCacheHeaders(input: {
   }
 }
 
+/**
+ * Headers for `AI.gateway().run` on the OpenAI provider path.
+ * Injects the platform key, BYOK-parity collect-log flags, project metadata,
+ * and allowlisted caller headers (OpenAI-* / Accept) for Codex and SDKs.
+ */
+export function openAiAiGatewayBindingHeaders(input: {
+  openaiApiKey: string;
+  projectId: string;
+  requestHeaders: Headers;
+}): Record<string, string> {
+  const caller =
+    input.requestHeaders.get("x-iterate-sandbox") ??
+    input.requestHeaders.get("x-iterate-agent") ??
+    undefined;
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${input.openaiApiKey}`,
+    "content-type": "application/json",
+    // Same collect-log posture as agent BYOK in workers-ai-transport.ts.
+    "cf-aig-collect-log": "true",
+    "cf-aig-collect-log-payload": "true",
+    "cf-aig-metadata": JSON.stringify({
+      projectId: input.projectId,
+      source: "project-egress",
+      ...(caller !== undefined ? { caller } : {}),
+    }),
+  };
+  for (const [name, value] of input.requestHeaders.entries()) {
+    const lower = name.toLowerCase();
+    if (lower === "authorization" || lower === "content-type" || lower === "host") continue;
+    if (lower.startsWith("openai-") || lower === "accept") {
+      headers[lower] = value;
+    }
+  }
+  return headers;
+}
+
 /** Pull binding-path inputs from typed AppConfig; null when routing is impossible. */
 export function openAiAiGatewayRoutingFromConfig(config: AppConfig): {
   gatewayId: string;
   openaiApiKey: string;
   responseCacheTtlSeconds?: number;
 } | null {
-  // accountId is not required for the Workers AI binding path.
+  // The Workers AI binding does not need accountId in the URL, but we still
+  // require a deployed-shaped config (ARTIFACTS_ACCOUNT_ID → cloudflare.accountId
+  // on preview/prd) so local miniflare without CF account does not call a
+  // missing/half-wired gateway binding with the real platform key.
   if (config.cloudflare.accountId === undefined || config.cloudflare.accountId.length === 0) {
-    // Still require a deployed-shaped config so local miniflare without CF account
-    // does not accidentally try to call a missing gateway binding with real keys.
-    // Preview/prd always set ARTIFACTS_ACCOUNT_ID → cloudflare.accountId.
     return null;
   }
   return {

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -51,7 +51,6 @@ import {
   isOpenAiPublicApiRequest,
   openAiAiGatewayRoutingFromConfig,
   openAiGatewayBindingEndpoint,
-  rewriteOpenAiRequestToAiGateway,
 } from "./openai-ai-gateway-egress.ts";
 import { ProjectProcessorContract } from "./project-processor-contract.ts";
 import { ProjectProcessor } from "./project-processor-implementation.ts";
@@ -604,115 +603,56 @@ export class ProjectDurableObject extends DurableObject<Env> {
   }
 
   /**
-   * Route `api.openai.com` through Cloudflare AI Gateway with the platform
-   * OpenAI key + project metadata. Prefer the Workers AI gateway binding
-   * (pre-authenticated on this account — works when Authenticated Gateway is
-   * on). Otherwise rewrite to the provider-native REST gateway URL; if that
-   * 401s (missing AI Gateway Run token), fall back to direct OpenAI with the
-   * platform key so sandboxes still work. Returns null when config cannot
-   * route (caller falls through to normal egress).
+   * Route JSON POST/PUT to `api.openai.com` through Cloudflare AI Gateway via
+   * the Workers AI binding only (same door as agent BYOK). Returns null when
+   * the request is not binding-shaped (GET, non-JSON, missing gateway) so
+   * normal egress applies — no REST rewrite and no direct-OpenAI platform-key
+   * ladder.
    */
   async #egressOpenAiViaAiGateway(request: Request): Promise<Response | null> {
+    if (request.method !== "POST" && request.method !== "PUT") return null;
+
     const config = parseConfig(this.env);
     const routing = openAiAiGatewayRoutingFromConfig(config);
     if (routing === null) return null;
 
-    const metadata = {
-      projectId: this.#name.projectId,
-      source: "project-egress" as const,
-      caller:
-        request.headers.get("x-iterate-sandbox") ??
-        request.headers.get("x-iterate-agent") ??
-        undefined,
-    };
-
-    // Parse JSON once so binding + REST share the same cache-key body.
-    let parsedBody: unknown | undefined;
-    if (request.method === "POST" || request.method === "PUT") {
-      try {
-        parsedBody = await request.clone().json();
-      } catch {
-        parsedBody = undefined;
-      }
-    }
-
-    // Binding path: same door agent BYOK uses. Endpoint = path after /v1/ + query.
-    const endpoint = openAiGatewayBindingEndpoint(request.url);
     const gateway = this.env.AI?.gateway?.(routing.gatewayId);
-    if (
-      gateway !== undefined &&
-      parsedBody !== undefined &&
-      endpoint.replace(/\?.*$/, "").length > 0
-    ) {
-      try {
-        const headers: Record<string, string> = {
-          authorization: `Bearer ${routing.openaiApiKey}`,
-          "content-type": "application/json",
-          "cf-aig-metadata": JSON.stringify({
-            projectId: metadata.projectId,
-            source: metadata.source,
-            ...(metadata.caller !== undefined ? { caller: metadata.caller } : {}),
-          }),
-        };
-        await applyOpenAiAiGatewayCacheHeaders({
-          headers,
-          body: parsedBody,
-          responseCacheTtlSeconds: routing.responseCacheTtlSeconds,
-        });
-        const bindingResponse = await gateway.run({
-          provider: "openai",
-          endpoint,
-          headers,
-          query: parsedBody,
-        });
-        // 401 from the binding is treated like REST gateway auth failure so we
-        // still try the REST rewrite / direct OpenAI ladder (parity with GET).
-        if (bindingResponse.status !== 401) return bindingResponse;
-        console.warn("openai AI gateway binding returned 401; trying REST rewrite", {
-          projectId: this.#name.projectId,
-          endpoint,
-        });
-      } catch (error) {
-        console.warn("openai AI gateway binding path failed; trying REST rewrite", {
-          projectId: this.#name.projectId,
-          endpoint,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
+    if (gateway === undefined) return null;
+
+    const endpoint = openAiGatewayBindingEndpoint(request.url);
+    if (endpoint.replace(/\?.*$/, "").length === 0) return null;
+
+    let body: unknown;
+    try {
+      body = await request.clone().json();
+    } catch {
+      return null;
     }
 
-    // Provider-native REST rewrite (GET /models, non-JSON, binding failure/401).
-    const rewritten = await rewriteOpenAiRequestToAiGateway({
-      request,
-      accountId: routing.accountId,
-      gatewayId: routing.gatewayId,
-      openaiApiKey: routing.openaiApiKey,
-      metadata,
-      cfAigAuthorization: routing.cfAigAuthorization,
-      responseCacheTtlSeconds: routing.responseCacheTtlSeconds,
-      bodyForCacheKey: parsedBody ?? null,
-    });
-    const gatewayResponse = await fetch(rewritten);
-    if (gatewayResponse.status !== 401) return gatewayResponse;
-
-    // Authenticated Gateway without a Run-capable token → last resort: direct
-    // OpenAI with the platform key (still never the container dummy).
-    console.warn("openai AI gateway REST rewrite unauthorized; falling back to direct OpenAI", {
-      projectId: this.#name.projectId,
-    });
-    const headers = new Headers(request.headers);
-    headers.set("Authorization", `Bearer ${routing.openaiApiKey}`);
-    headers.delete("host");
-    const init: RequestInit & { duplex?: "half" } = {
-      method: request.method,
-      headers,
-      redirect: "manual",
+    const caller =
+      request.headers.get("x-iterate-sandbox") ??
+      request.headers.get("x-iterate-agent") ??
+      undefined;
+    const headers: Record<string, string> = {
+      authorization: `Bearer ${routing.openaiApiKey}`,
+      "content-type": "application/json",
+      "cf-aig-metadata": JSON.stringify({
+        projectId: this.#name.projectId,
+        source: "project-egress",
+        ...(caller !== undefined ? { caller } : {}),
+      }),
     };
-    if (request.method !== "GET" && request.method !== "HEAD") {
-      init.body = request.body;
-      if (request.body !== null) init.duplex = "half";
-    }
-    return fetch(new Request(request.url, init));
+    await applyOpenAiAiGatewayCacheHeaders({
+      headers,
+      body,
+      responseCacheTtlSeconds: routing.responseCacheTtlSeconds,
+    });
+    return gateway.run({
+      provider: "openai",
+      endpoint,
+      headers,
+      query: body,
+    });
   }
 
   interceptEgress(handler: ProjectEgressInterceptor): ProjectEgressIntercept {

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -46,6 +46,11 @@ import {
   type EgressRule,
   type HumanApprovalRequestedPayload,
 } from "./egress-approvals.ts";
+import {
+  isOpenAiPublicApiRequest,
+  openAiAiGatewayRoutingFromConfig,
+  rewriteOpenAiRequestToAiGateway,
+} from "./openai-ai-gateway-egress.ts";
 import { ProjectProcessorContract } from "./project-processor-contract.ts";
 import { ProjectProcessor } from "./project-processor-implementation.ts";
 import { StreamDatabase, type TouchInput } from "./stream-database.ts";
@@ -543,6 +548,16 @@ export class ProjectDurableObject extends DurableObject<Env> {
 
   /** The egress lanes proper: platform references, secret substitution, bare fetch. */
   async #egress(request: Request): Promise<Response> {
+    // Sandbox coding agents (Codex, etc.) call api.openai.com with a placeholder
+    // or dummy key. Route them through Cloudflare AI Gateway with the platform
+    // OpenAI key + project metadata — same BYOK/observability posture as agent DO
+    // turns, without exposing openAiApiKey via getSecret({ platform }).
+    if (isOpenAiPublicApiRequest(request)) {
+      const routed = await this.#egressOpenAiViaAiGateway(request);
+      if (routed !== null) return routed;
+      // Fall through when accountId/gateway config is missing (local/dev edge).
+    }
+
     let secretPaths: string[];
     try {
       // Placeholders live in the request envelope: headers, or the URL for
@@ -584,6 +599,76 @@ export class ProjectDurableObject extends DurableObject<Env> {
         path: secretPaths[0]!,
       }),
     ).fetch(request);
+  }
+
+  /**
+   * Route `api.openai.com` through Cloudflare AI Gateway with the platform
+   * OpenAI key + project metadata. Prefer the Workers AI gateway binding
+   * (pre-authenticated on this account — works when Authenticated Gateway is
+   * on). Fall back to a provider-native REST rewrite for GET/non-JSON and when
+   * the binding is unavailable. Returns null when config cannot route (caller
+   * falls through to normal egress).
+   */
+  async #egressOpenAiViaAiGateway(request: Request): Promise<Response | null> {
+    const config = parseConfig(this.env);
+    const routing = openAiAiGatewayRoutingFromConfig(config);
+    if (routing === null) return null;
+
+    const metadata = {
+      projectId: this.#name.projectId,
+      source: "project-egress" as const,
+      caller:
+        request.headers.get("x-iterate-sandbox") ??
+        request.headers.get("x-iterate-agent") ??
+        undefined,
+    };
+
+    // Binding path: same door agent BYOK uses. Endpoint is the path after /v1/.
+    const endpoint = new URL(request.url).pathname.replace(/^\/v1\/?/, "");
+    const gateway = this.env.AI?.gateway?.(routing.gatewayId);
+    if (
+      gateway !== undefined &&
+      (request.method === "POST" || request.method === "PUT") &&
+      endpoint.length > 0
+    ) {
+      try {
+        const query: unknown = await request.clone().json();
+        const headers: Record<string, string> = {
+          authorization: `Bearer ${routing.openaiApiKey}`,
+          "content-type": "application/json",
+          "cf-aig-metadata": JSON.stringify({
+            projectId: metadata.projectId,
+            source: metadata.source,
+            ...(metadata.caller !== undefined ? { caller: metadata.caller } : {}),
+          }),
+        };
+        if (routing.skipCache) headers["cf-aig-skip-cache"] = "true";
+        return await gateway.run({
+          provider: "openai",
+          endpoint,
+          headers,
+          query,
+        });
+      } catch (error) {
+        // Non-JSON body or binding failure → REST rewrite below.
+        console.warn("openai AI gateway binding path failed; trying REST rewrite", {
+          projectId: this.#name.projectId,
+          endpoint,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    const rewritten = rewriteOpenAiRequestToAiGateway({
+      request,
+      accountId: routing.accountId,
+      gatewayId: routing.gatewayId,
+      openaiApiKey: routing.openaiApiKey,
+      metadata,
+      cfAigAuthorization: routing.cfAigAuthorization,
+      skipCache: routing.skipCache,
+    });
+    return fetch(rewritten);
   }
 
   interceptEgress(handler: ProjectEgressInterceptor): ProjectEgressIntercept {

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -624,6 +624,10 @@ export class ProjectDurableObject extends DurableObject<Env> {
     };
 
     // Binding path: same door agent BYOK uses. Endpoint is the path after /v1/.
+    // Prefer this for POST/PUT JSON (chat/completions, responses) — pre-auth on
+    // Authenticated Gateway. GET (e.g. /v1/models) has no binding `run` shape,
+    // so we inject the platform key and hit OpenAI directly (still never uses
+    // the container's dummy key).
     const endpoint = new URL(request.url).pathname.replace(/^\/v1\/?/, "");
     const gateway = this.env.AI?.gateway?.(routing.gatewayId);
     if (
@@ -650,8 +654,8 @@ export class ProjectDurableObject extends DurableObject<Env> {
           query,
         });
       } catch (error) {
-        // Non-JSON body or binding failure → REST rewrite below.
-        console.warn("openai AI gateway binding path failed; trying REST rewrite", {
+        // Non-JSON body or binding failure → inject key + direct OpenAI below.
+        console.warn("openai AI gateway binding path failed; falling back to direct OpenAI", {
           projectId: this.#name.projectId,
           endpoint,
           error: error instanceof Error ? error.message : String(error),
@@ -659,16 +663,22 @@ export class ProjectDurableObject extends DurableObject<Env> {
       }
     }
 
-    const rewritten = rewriteOpenAiRequestToAiGateway({
-      request,
-      accountId: routing.accountId,
-      gatewayId: routing.gatewayId,
-      openaiApiKey: routing.openaiApiKey,
-      metadata,
-      cfAigAuthorization: routing.cfAigAuthorization,
-      skipCache: routing.skipCache,
-    });
-    return fetch(rewritten);
+    // Direct OpenAI with platform key (GET/models, or binding fallback). Prefer
+    // this over the provider-native REST gateway URL: Authenticated Gateway
+    // requires an AI Gateway Run token our Doppler CF tokens often lack.
+    const headers = new Headers(request.headers);
+    headers.set("Authorization", `Bearer ${routing.openaiApiKey}`);
+    headers.delete("host");
+    const init: RequestInit & { duplex?: "half" } = {
+      method: request.method,
+      headers,
+      redirect: "manual",
+    };
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      init.body = request.body;
+      if (request.body !== null) init.duplex = "half";
+    }
+    return fetch(new Request(request.url, init));
   }
 
   interceptEgress(handler: ProjectEgressInterceptor): ProjectEgressIntercept {

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -49,6 +49,7 @@ import {
 import {
   applyOpenAiAiGatewayCacheHeaders,
   isOpenAiPublicApiRequest,
+  openAiAiGatewayBindingHeaders,
   openAiAiGatewayRoutingFromConfig,
   openAiGatewayBindingEndpoint,
 } from "./openai-ai-gateway-egress.ts";
@@ -629,19 +630,11 @@ export class ProjectDurableObject extends DurableObject<Env> {
       return null;
     }
 
-    const caller =
-      request.headers.get("x-iterate-sandbox") ??
-      request.headers.get("x-iterate-agent") ??
-      undefined;
-    const headers: Record<string, string> = {
-      authorization: `Bearer ${routing.openaiApiKey}`,
-      "content-type": "application/json",
-      "cf-aig-metadata": JSON.stringify({
-        projectId: this.#name.projectId,
-        source: "project-egress",
-        ...(caller !== undefined ? { caller } : {}),
-      }),
-    };
+    const headers = openAiAiGatewayBindingHeaders({
+      openaiApiKey: routing.openaiApiKey,
+      projectId: this.#name.projectId,
+      requestHeaders: request.headers,
+    });
     await applyOpenAiAiGatewayCacheHeaders({
       headers,
       body,

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -626,16 +626,25 @@ export class ProjectDurableObject extends DurableObject<Env> {
         undefined,
     };
 
+    // Parse JSON once so binding + REST share the same cache-key body.
+    let parsedBody: unknown | undefined;
+    if (request.method === "POST" || request.method === "PUT") {
+      try {
+        parsedBody = await request.clone().json();
+      } catch {
+        parsedBody = undefined;
+      }
+    }
+
     // Binding path: same door agent BYOK uses. Endpoint = path after /v1/ + query.
     const endpoint = openAiGatewayBindingEndpoint(request.url);
     const gateway = this.env.AI?.gateway?.(routing.gatewayId);
     if (
       gateway !== undefined &&
-      (request.method === "POST" || request.method === "PUT") &&
+      parsedBody !== undefined &&
       endpoint.replace(/\?.*$/, "").length > 0
     ) {
       try {
-        const query: unknown = await request.clone().json();
         const headers: Record<string, string> = {
           authorization: `Bearer ${routing.openaiApiKey}`,
           "content-type": "application/json",
@@ -647,14 +656,21 @@ export class ProjectDurableObject extends DurableObject<Env> {
         };
         await applyOpenAiAiGatewayCacheHeaders({
           headers,
-          body: query,
+          body: parsedBody,
           responseCacheTtlSeconds: routing.responseCacheTtlSeconds,
         });
-        return await gateway.run({
+        const bindingResponse = await gateway.run({
           provider: "openai",
           endpoint,
           headers,
-          query,
+          query: parsedBody,
+        });
+        // 401 from the binding is treated like REST gateway auth failure so we
+        // still try the REST rewrite / direct OpenAI ladder (parity with GET).
+        if (bindingResponse.status !== 401) return bindingResponse;
+        console.warn("openai AI gateway binding returned 401; trying REST rewrite", {
+          projectId: this.#name.projectId,
+          endpoint,
         });
       } catch (error) {
         console.warn("openai AI gateway binding path failed; trying REST rewrite", {
@@ -665,7 +681,7 @@ export class ProjectDurableObject extends DurableObject<Env> {
       }
     }
 
-    // Provider-native REST rewrite (GET /models, non-JSON, binding failure).
+    // Provider-native REST rewrite (GET /models, non-JSON, binding failure/401).
     const rewritten = await rewriteOpenAiRequestToAiGateway({
       request,
       accountId: routing.accountId,
@@ -674,6 +690,7 @@ export class ProjectDurableObject extends DurableObject<Env> {
       metadata,
       cfAigAuthorization: routing.cfAigAuthorization,
       responseCacheTtlSeconds: routing.responseCacheTtlSeconds,
+      bodyForCacheKey: parsedBody ?? null,
     });
     const gatewayResponse = await fetch(rewritten);
     if (gatewayResponse.status !== 401) return gatewayResponse;

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -47,8 +47,10 @@ import {
   type HumanApprovalRequestedPayload,
 } from "./egress-approvals.ts";
 import {
+  applyOpenAiAiGatewayCacheHeaders,
   isOpenAiPublicApiRequest,
   openAiAiGatewayRoutingFromConfig,
+  openAiGatewayBindingEndpoint,
   rewriteOpenAiRequestToAiGateway,
 } from "./openai-ai-gateway-egress.ts";
 import { ProjectProcessorContract } from "./project-processor-contract.ts";
@@ -605,9 +607,10 @@ export class ProjectDurableObject extends DurableObject<Env> {
    * Route `api.openai.com` through Cloudflare AI Gateway with the platform
    * OpenAI key + project metadata. Prefer the Workers AI gateway binding
    * (pre-authenticated on this account — works when Authenticated Gateway is
-   * on). Fall back to a provider-native REST rewrite for GET/non-JSON and when
-   * the binding is unavailable. Returns null when config cannot route (caller
-   * falls through to normal egress).
+   * on). Otherwise rewrite to the provider-native REST gateway URL; if that
+   * 401s (missing AI Gateway Run token), fall back to direct OpenAI with the
+   * platform key so sandboxes still work. Returns null when config cannot
+   * route (caller falls through to normal egress).
    */
   async #egressOpenAiViaAiGateway(request: Request): Promise<Response | null> {
     const config = parseConfig(this.env);
@@ -623,17 +626,13 @@ export class ProjectDurableObject extends DurableObject<Env> {
         undefined,
     };
 
-    // Binding path: same door agent BYOK uses. Endpoint is the path after /v1/.
-    // Prefer this for POST/PUT JSON (chat/completions, responses) — pre-auth on
-    // Authenticated Gateway. GET (e.g. /v1/models) has no binding `run` shape,
-    // so we inject the platform key and hit OpenAI directly (still never uses
-    // the container's dummy key).
-    const endpoint = new URL(request.url).pathname.replace(/^\/v1\/?/, "");
+    // Binding path: same door agent BYOK uses. Endpoint = path after /v1/ + query.
+    const endpoint = openAiGatewayBindingEndpoint(request.url);
     const gateway = this.env.AI?.gateway?.(routing.gatewayId);
     if (
       gateway !== undefined &&
       (request.method === "POST" || request.method === "PUT") &&
-      endpoint.length > 0
+      endpoint.replace(/\?.*$/, "").length > 0
     ) {
       try {
         const query: unknown = await request.clone().json();
@@ -646,7 +645,11 @@ export class ProjectDurableObject extends DurableObject<Env> {
             ...(metadata.caller !== undefined ? { caller: metadata.caller } : {}),
           }),
         };
-        if (routing.skipCache) headers["cf-aig-skip-cache"] = "true";
+        await applyOpenAiAiGatewayCacheHeaders({
+          headers,
+          body: query,
+          responseCacheTtlSeconds: routing.responseCacheTtlSeconds,
+        });
         return await gateway.run({
           provider: "openai",
           endpoint,
@@ -654,8 +657,7 @@ export class ProjectDurableObject extends DurableObject<Env> {
           query,
         });
       } catch (error) {
-        // Non-JSON body or binding failure → inject key + direct OpenAI below.
-        console.warn("openai AI gateway binding path failed; falling back to direct OpenAI", {
+        console.warn("openai AI gateway binding path failed; trying REST rewrite", {
           projectId: this.#name.projectId,
           endpoint,
           error: error instanceof Error ? error.message : String(error),
@@ -663,9 +665,24 @@ export class ProjectDurableObject extends DurableObject<Env> {
       }
     }
 
-    // Direct OpenAI with platform key (GET/models, or binding fallback). Prefer
-    // this over the provider-native REST gateway URL: Authenticated Gateway
-    // requires an AI Gateway Run token our Doppler CF tokens often lack.
+    // Provider-native REST rewrite (GET /models, non-JSON, binding failure).
+    const rewritten = await rewriteOpenAiRequestToAiGateway({
+      request,
+      accountId: routing.accountId,
+      gatewayId: routing.gatewayId,
+      openaiApiKey: routing.openaiApiKey,
+      metadata,
+      cfAigAuthorization: routing.cfAigAuthorization,
+      responseCacheTtlSeconds: routing.responseCacheTtlSeconds,
+    });
+    const gatewayResponse = await fetch(rewritten);
+    if (gatewayResponse.status !== 401) return gatewayResponse;
+
+    // Authenticated Gateway without a Run-capable token → last resort: direct
+    // OpenAI with the platform key (still never the container dummy).
+    console.warn("openai AI gateway REST rewrite unauthorized; falling back to direct OpenAI", {
+      projectId: this.#name.projectId,
+    });
     const headers = new Headers(request.headers);
     headers.set("Authorization", `Bearer ${routing.openaiApiKey}`);
     headers.delete("host");


### PR DESCRIPTION
## Summary

- Project DO egress rewrites JSON **POST/PUT** to `api.openai.com` through the **Workers AI gateway binding only** (`env.AI.gateway(id).run`) — same door as agent BYOK.
- Injects the **platform** OpenAI key and `cf-aig-metadata` (`projectId`, `source: project-egress`) plus BYOK-parity `cf-aig-collect-log` headers. Forwards caller `OpenAI-*` and `Accept`.
- **Scope:** all project egress (sandbox MITM, worker `egress.fetch`, …), not sandbox-only. Sandboxes plant a dummy `OPENAI_API_KEY`; real keys never need to enter the container. Caller Authorization is replaced with the platform key.
- **Not in this PR:** REST AI Gateway rewrite, direct-OpenAI platform-key ladder, GET `/v1/models` rewrite (those fall through to normal egress).

## Why

Sandbox Codex was calling OpenAI via project-secret placeholders. We want gateway routing + metadata for every sandbox OpenAI call without teaching every CLI about gateway URLs, and without exposing `openAiApiKey` via `getSecret({ platform })`.

## How to verify

```bash
pnpm --dir apps/os exec vitest run src/domains/projects/openai-ai-gateway-egress.test.ts
```

After deploy (preview or prd):

1. Sandbox: `OPENAI_API_KEY=anything` and `curl` / `codex exec` against `https://api.openai.com/v1/...` (JSON POST)
2. Confirm AI Gateway logs for gateway `default` show requests with metadata `projectId` / `source=project-egress`
3. Confirm chat/completions or responses succeed (binding path)

## Policy notes

- Platform key is **always** used for rewritten OpenAI JSON POST/PUT (customer Authorization discarded).
- Key is still **not** available via `getSecret({ platform: "openAiApiKey" })` — only via this rewrite.
- GET/non-JSON still use normal project egress (dummy key → OpenAI 401).

## Follow-ups (not in this PR)

- herdr-remote web UI terminal width issues if any remain after proof
- WebSocket Responses API through container MITM (Codex may fall back to HTTPS)

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +188 -0 | +125 -0 🟩🟩🟩🟩🟩 |
| Tests | +136 -0 | +127 -0 🟩🟩🟩🟩🟩 |
| Docs | +13 -0 | +11 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+337 -0** | **+263 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between d7b8b78 and 63538c6, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-13T18:01:45.803Z",
      "headSha": "63538c6119fa1bd523a0e0c6b8f3d8b70a499343",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/343388796129309",
      "shortSha": "63538c6",
      "cleanupDurationMs": 9327,
      "deployDurationMs": 88804,
      "testDurationMs": 184637,
      "testRetries": "4 retried: provided integrations > a project mounts ocado into the collection; connections + secret confinement hold (vitest x1) · itx > Agent scripts can send web-chat messages (with file attachments) and call project tools (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page replays already appended events after reload (specs x1)",
      "workerSizeKib": 16107.61,
      "workerGzipKib": 4345.54,
      "mainWorkerGzipKib": 4352.64
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-13T18:01:39.257Z",
      "headSha": "63538c6119fa1bd523a0e0c6b8f3d8b70a499343",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/343388796129309",
      "shortSha": "63538c6",
      "cleanupDurationMs": 2779,
      "deployDurationMs": 20141,
      "testDurationMs": 679,
      "testRetries": null,
      "workerSizeKib": 4033.03,
      "workerGzipKib": 819.94,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `63538c6` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 819.9 KiB | 20.1s | 679ms |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/343388796129309) | 2026-07-13T18:01:39.257Z | Preview app released. |
| OS | released | `63538c6` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 4.24 MiB (-7.1 KiB vs main) | 88.8s | 184.6s | 4 retried: provided integrations > a project mounts ocado into the collection; connections + secret confinement hold (vitest x1) · itx > Agent scripts can send web-chat messages (with file attachments) and call project tools (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page replays already appended events after reload (specs x1) | 9.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/343388796129309) | 2026-07-13T18:01:45.803Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->