### PR TITLE
Harden OS observability from production traces

### DIFF
--- a/.agents/skills/cloudflare-traces/EXAMPLES.md
+++ b/.agents/skills/cloudflare-traces/EXAMPLES.md
@@ -1,83 +1,100 @@
-# Cloudflare Trace Query Examples
+# Cloudflare Observability Query Examples
 
-## Exact Trace Lookup
+Pass each function as the `code` argument to the general Cloudflare MCP
+`execute` tool. Replace the placeholders and pass the account as `account_id`.
 
-This query returned trace `250178b64271952ffb1ed1711133cf78` from
-`os-preview-2` with 686 spans. It first asks for the trace summary, then asks for
-the underlying span events and counts them by span name.
+## Correlate a call ID across logs and spans
 
 ```ts
-mcp__cloudflare_api__.execute({
-  account_id: "376ef7ed81b0573f93524de763666c15",
-  code: `async () => {
-    const traceId = "250178b64271952ffb1ed1711133cf78";
-    const timeframe = {
-      from: Date.parse("2026-05-06T15:37:00.000Z"),
-      to: Date.parse("2026-05-06T15:40:00.000Z"),
-    };
-
-    const traceSummary = await cloudflare.request({
-      method: "POST",
-      path: \`/accounts/\${accountId}/workers/observability/telemetry/query\`,
-      body: {
-        queryId: "trace-summary",
-        timeframe,
-        view: "traces",
-        limit: 20,
-        parameters: {
-          datasets: ["otel"],
-          filters: [{ key: "traceId", operation: "eq", type: "string", value: traceId }],
-        },
+async () => {
+  const value = "log_<call-id>";
+  return cloudflare.request({
+    method: "POST",
+    path: `/accounts/${accountId}/workers/observability/telemetry/query`,
+    body: {
+      queryId: "correlate-call-id",
+      timeframe: {
+        from: Date.parse("<from-utc>"),
+        to: Date.parse("<to-utc>"),
       },
-    });
-
-    const spanEvents = await cloudflare.request({
-      method: "POST",
-      path: \`/accounts/\${accountId}/workers/observability/telemetry/query\`,
-      body: {
-        queryId: "trace-events",
-        timeframe,
-        view: "events",
-        limit: 2000,
-        parameters: {
-          datasets: ["otel"],
-          filters: [{ key: "traceId", operation: "eq", type: "string", value: traceId }],
-        },
+      view: "events",
+      limit: 100,
+      parameters: {
+        datasets: [],
+        needle: { value, matchCase: true },
+        filters: [
+          {
+            key: "$metadata.service",
+            operation: "eq",
+            type: "string",
+            value: "<service>",
+          },
+        ],
       },
-    });
-
-    const events = spanEvents.result?.events?.events ?? [];
-    const byName = Object.fromEntries(
-      Object.entries(events.reduce((acc, event) => {
-        const name = event.source?.name ?? event.$metadata?.spanName ?? "unknown";
-        acc[name] = (acc[name] ?? 0) + 1;
-        return acc;
-      }, {})).sort((a, b) => b[1] - a[1]),
-    );
-
-    return {
-      traceSummary: traceSummary.result?.traces,
-      eventCount: events.length,
-      byName,
-    };
-  }`,
-});
+    },
+  });
+};
 ```
 
-Expected high-signal output for this trace:
+Normally the `cloudflare-workers` row supplies the bounded structured log and
+the `otel` row supplies `traceId`, span IDs, and span attributes. Construct the
+dashboard link from the account and trace IDs. Treat those dataset names as the
+current API mapping, not a stable schema.
 
-```json
-{
-  "eventCount": 686,
-  "byName": {
-    "durable_object_storage_exec": 247,
-    "jsrpc": 205,
-    "durable_object_subrequest": 199,
-    "durable_object_storage_kv_get": 22,
-    "durable_object_storage_kv_put": 8,
-    "d1_batch": 3,
-    "fetch": 1,
-    "GET": 1
-  }
-}
+## Fetch and summarize an exact trace
+
+```ts
+async () => {
+  const traceId = "<trace-id>";
+  const response = await cloudflare.request({
+    method: "POST",
+    path: `/accounts/${accountId}/workers/observability/telemetry/query`,
+    body: {
+      queryId: "exact-trace",
+      timeframe: {
+        from: Date.parse("<from-utc>"),
+        to: Date.parse("<to-utc>"),
+      },
+      view: "events",
+      limit: 2000,
+      parameters: {
+        datasets: ["otel"],
+        filters: [{ key: "traceId", operation: "eq", type: "string", value: traceId }],
+      },
+    },
+  });
+  const events = response.result?.events?.events ?? [];
+  return events.map((event) => ({
+    name: event.source?.name ?? event.$metadata?.spanName,
+    spanId: event.source?.spanId ?? event.$metadata?.spanId,
+    parentSpanId: event.source?.parentSpanId ?? event.$metadata?.parentSpanId,
+    start: event.source?.startTime ?? event.$metadata?.startTime,
+    end: event.source?.endTime ?? event.$metadata?.endTime,
+    durationMS: event.source?.durationMS,
+    outcome: event.source?.itx?.outcome ?? event.source?.outcome,
+  }));
+};
 ```
+
+## Fetch one structured operation log
+
+```ts
+async () =>
+  cloudflare.request({
+    method: "POST",
+    path: `/accounts/${accountId}/workers/observability/telemetry/query`,
+    body: {
+      queryId: "operation-log",
+      timeframe: { from: Date.parse("<from-utc>"), to: Date.parse("<to-utc>") },
+      view: "events",
+      limit: 20,
+      parameters: {
+        datasets: ["cloudflare-workers"],
+        filters: [{ key: "log.id", operation: "eq", type: "string", value: "log_<id>" }],
+      },
+    },
+  });
+```
+
+Use `log.parentId` to walk to the parent operation and `itx.sessionId` to find
+other calls from the same long-running ITX WebSocket.

--- a/.agents/skills/cloudflare-traces/SKILL.md
+++ b/.agents/skills/cloudflare-traces/SKILL.md
@@ -1,98 +1,70 @@
 ---
 name: cloudflare-traces
-description: Query and analyze Cloudflare Workers traces through the general Cloudflare API MCP server. Use when diagnosing Workers traces, distributed tracing spans, observability events, subrequest chains, or when an agent needs Cloudflare trace data programmatically.
+description: Query and audit Cloudflare Workers traces and logs through the general Cloudflare API MCP server. Use when diagnosing distributed traces, custom spans, Durable Object or Workers RPC chains, console logs, or correlation IDs.
 ---
 
 # Cloudflare Traces
 
-Use Cloudflare's general API MCP server only:
+Use Cloudflare's general API MCP server (`https://mcp.cloudflare.com/mcp`), not
+a product-specific observability endpoint.
 
-- MCP URL: `https://mcp.cloudflare.com/mcp`
-- MCP server name: `cloudflare-api` or `cloudflare`
-- Do not configure a separate product-specific observability endpoint.
+## Current API mapping
 
-Docs: https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/
+- `otel` normally returns trace summaries and spans, including custom spans.
+- `cloudflare-workers` normally returns invocation and structured `console` logs.
+- `[]` searches all current datasets; use it to correlate a shared ID.
 
-## MCP Tools
+These are observed Workers Observability API dataset names, not a permanent
+public schema. An `otel`-only query cannot prove a log is missing. Query the
+keys/values endpoints when a dataset, field, or value is uncertain.
 
-Use the general Cloudflare MCP tools:
+## Workflow
 
-- `mcp__cloudflare_api__.search`
-- `mcp__cloudflare_api__.execute`
+1. Use the MCP OpenAPI search tool to verify the Workers Observability
+   `telemetry/query`, `keys`, and `values` endpoints.
+2. Select the account explicitly when more than one is available.
+3. Start with the narrowest known UTC timeframe and service name.
+4. Search all datasets for a known call/log/session/request ID.
+5. Follow a returned `traceId` in `otel`; follow `log.id` or `log.parentId` in
+   `cloudflare-workers`.
+6. Widen the timeframe before adding complicated filters.
+7. Return compact fields and aggregates rather than thousands of raw events.
 
-`execute` requires `account_id` when the token can see multiple accounts. Pass it
-as the tool argument, not in the MCP URL.
+See [EXAMPLES.md](EXAMPLES.md) for reusable query blocks.
 
-## Codemode Blocks
+## Trace audit
 
-Use these as the `code` strings passed to `mcp__cloudflare_api__.execute`.
+For every semantic span report:
 
-1. Verify trace keys:
+- `name`, `traceId`, `spanId`, `parentSpanId`;
+- start, end, and duration;
+- outcome/error attributes;
+- script service/version; and
+- whether the parent exists and how their time ranges overlap.
 
-```ts
-async () => {
-  return cloudflare.request({
-    method: "POST",
-    path: `/accounts/${accountId}/workers/observability/telemetry/keys`,
-    body: {
-      datasets: ["otel"],
-      from: Date.parse("2026-05-06T15:37:00.000Z"),
-      to: Date.parse("2026-05-06T15:40:00.000Z"),
-      keyNeedle: { value: "trace", matchCase: false },
-      limit: 50,
-    },
-  });
-};
-```
+[OpenTelemetry permits a child to outlive its parent](https://opentelemetry.io/docs/specs/otel/trace/api/).
+Judge timing against the application span's declared scope and code ordering:
+flag a mismatch only when that contract says the parent must contain the child.
+Treat automatic native spans separately. [Cloudflare documents beta tracing
+limitations](https://developers.cloudflare.com/workers/observability/traces/known-limitations/),
+including 0ms non-I/O spans and incomplete attributes. Iterate also observed
+native offsets that violated known code ordering on 2026-07-13; treat that as a
+dated product observation and corroborate it with application attributes and a
+controlled reproduction.
 
-2. Fetch a trace summary with `view: "traces"`:
+Observed on 2026-07-13: a failed custom ITX span's presentation message ended
+in `OK` while `source.itx.outcome` was `error`. Treat message suffixes and level
+as presentation metadata. Use explicit application outcome attributes; for ITX,
+a correlated error-level log is useful corroboration.
 
-```ts
-async () => {
-  return cloudflare.request({
-    method: "POST",
-    path: `/accounts/${accountId}/workers/observability/telemetry/query`,
-    body: {
-      queryId: "trace-summary",
-      timeframe: {
-        from: Date.parse("2026-05-06T15:37:00.000Z"),
-        to: Date.parse("2026-05-06T15:40:00.000Z"),
-      },
-      view: "traces",
-      limit: 20,
-      parameters: {
-        datasets: ["otel"],
-        filters: [
-          {
-            key: "traceId",
-            operation: "eq",
-            type: "string",
-            value: "250178b64271952ffb1ed1711133cf78",
-          },
-        ],
-      },
-    },
-  });
-};
-```
+## Dashboard link
 
-3. Fetch spans with `view: "events"` and the same exact `traceId` filter.
+Once the account and trace are known:
 
-4. Summarize span events by `source.name` and `$metadata.transactionName`.
-
-## Working Query
-
-See [EXAMPLES.md](EXAMPLES.md) for the exact codemode block that returned
-trace `250178b64271952ffb1ed1711133cf78` from `os-preview-2` with 686 spans.
-
-If this returns no rows:
-
-- try filter key `$metadata.traceId` as well as `traceId`
-- widen the timeframe by a few minutes
-- confirm `account_id` matches the worker's account
-- query `view: "events"` with `needle: { value: traceId }` as a fallback
+`https://dash.cloudflare.com/<account-id>/observability/traces/<trace-id>`
 
 ## Report
 
-Include trace id, service/script name, timeframe, request URL, span counts,
-error spans, longest repeated chain, and whether the failure surfaced to the caller.
+Include the account/service, UTC timeframe, trace deep link, script version,
+span/log counts, semantic chain, correlation IDs, failures, span-contract
+violations, and the exact query that established each conclusion.

--- a/.agents/skills/debug-os-worker/SKILL.md
+++ b/.agents/skills/debug-os-worker/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: debug-os-worker
+description: Debug OS production and preview failures with Cloudflare traces plus operation-wide logs. Use when diagnosing ITX calls, agent conversations, scheduler alarms, dynamic workers, Durable Objects, or a reported OS correlation ID.
+---
+
+# Debug OS Worker
+
+Read [../cloudflare-traces/SKILL.md](../cloudflare-traces/SKILL.md) first. Use
+the general Cloudflare API MCP server and its Workers Observability endpoints.
+
+## Scope
+
+- Production service: `os-prd`; derive account IDs and preview service names
+  from `envs.ts` rather than guessing.
+- Current trace/custom-span dataset: `otel`.
+- Current wide-log/invocation dataset: `cloudflare-workers`.
+- Wide-log schema: `iterate.wide-log.v1`.
+
+## Fast path
+
+1. Capture UTC time, environment, operation, and any `log_`, trace, session,
+   request, execution, or Ray ID from the report.
+2. Search `datasets: []` for a known ID. For a Cap'n Web `itxCallId`, normally
+   expect one `cloudflare-workers` log and one `otel` span; retention, quota,
+   or invocation log truncation can remove one side.
+3. Query the exact `traceId` in `otel` and the exact `log.id` in
+   `cloudflare-workers`.
+4. Walk `log.parentId` to the WebSocket handshake operation. Search
+   `itx.sessionId` to reconstruct other calls on the same connection.
+5. Give a trace deep link and name the next source path to inspect.
+
+## ITX and agents
+
+- Semantic spans are named `itx <Target>.<method>`; use `rpc.method`,
+  `itx.call.id`, `itx.session.id`, `itx.transport`, and `itx.outcome`.
+- Logs use stable message `itx_rpc` with `itx.method`, `itx.callId`, and the
+  same session ID.
+- For a real agent turn, find `itx Agent.ask`, then inspect descendant
+  `dynamic_worker.project_config.call` and native DO/RPC spans.
+- Do not expect prompts, scripts, arguments, results, raw errors, or trusted
+  project identity in telemetry; the privacy contract intentionally omits them.
+
+Observed on 2026-07-13, Cloudflare rendered a failing custom span's metadata
+message with an `OK` suffix. Treat the suffix as presentation metadata;
+`source.itx.outcome` is the semantic result and the correlated error-level wide
+log corroborates it.
+
+## Scheduler and alarms
+
+- Search `iterate.scheduler.execution_id` or `scheduler action invocation`.
+- The action invocation span's contract is the dynamic call itself: expect it
+  to contain `dynamic_worker.scheduler_action.call` and inspect
+  `iterate.scheduler.action_outcome`.
+- A cold-alarm proof must: set a one-shot schedule, explicitly kill the
+  Scheduler DO before due time, observe the durable result after due time, and
+  validate the resulting trace tree.
+- OpenTelemetry permits a child to outlive its parent. Reject a timing tree only
+  when it violates the named span's intended scope or known code ordering.
+
+## Error triage
+
+- Filter `cloudflare-workers` on `$metadata.level == "error"`, then group by
+  stable `message`; do not group by user-controlled text.
+- An invoked Cap'n Web ITX target failure is normalized to a caller-visible
+  Error with an authoritative `itxCallId`; use it as the direct lookup key.
+  Dispatch/protocol failures before the target hook may not have one.
+- Do not expect arbitrary Error properties to survive native Workers RPC or
+  Durable Object RPC; [that transport preserves a different error shape](https://developers.cloudflare.com/workers/runtime-apis/rpc/error-handling/).
+- Check `$workers.truncated`; a truncated long-lived WebSocket invocation is
+  incomplete evidence.
+
+## Report
+
+Return the user-visible symptom, product outcome, trace deep link, script
+version, semantic chain and timings, log correlation, span-contract audit,
+privacy limitations, root cause, and a proved remediation or next experiment.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ from your machine, and when you need a public callback URL. Doppler/Cloudflare/d
 - [Task system](docs/task-system.md)
 - [Task grooming](docs/tasks-grooming.md)
 - [Writing agent docs](docs/writing-agent-docs.md)
+- [Cloudflare trace queries](.agents/skills/cloudflare-traces/SKILL.md) — MCP dataset selection, correlation, and span-tree audits
+- [Debugging the OS worker](.agents/skills/debug-os-worker/SKILL.md) — ITX, agents, scheduler alarms, dynamic workers, and error lookup
 
 ### App-specific
 

--- a/apps/os/src/domains/scheduler/scheduler-durable-object.ts
+++ b/apps/os/src/domains/scheduler/scheduler-durable-object.ts
@@ -1,4 +1,4 @@
-import { DurableObject, tracing } from "cloudflare:workers";
+import { DurableObject } from "cloudflare:workers";
 import { workerVersion, type Env } from "../../env.ts";
 import { trustedInternalAuthContext } from "../../auth.ts";
 import { createStreamProcessorHost } from "../streams/stream-processor-host.ts";
@@ -81,27 +81,19 @@ export class SchedulerDurableObject extends DurableObject<Env> {
     // scheduler's, or both — run both handlers; each is idempotent and
     // re-derives its own next fire time.
     await this.#processorHost.handleAlarm(alarmInfo);
-    await tracing.enterSpan("alarm scheduler trigger due", async (span) => {
-      span.setAttribute("iterate.alarm.kind", "scheduler_trigger_due");
-      if (alarmInfo !== undefined) {
-        span.setAttribute("iterate.alarm.is_retry", alarmInfo.isRetry);
-        span.setAttribute("iterate.alarm.retry_count", alarmInfo.retryCount);
-      }
-      try {
-        await this.#processorHost.catchUp(PROCESSOR_SLUG);
-        const { requested } = await this.#schedulerProcessor.triggerDue();
-        span.setAttribute("iterate.scheduler.requested", requested);
-        await this.#processorHost.catchUp(PROCESSOR_SLUG);
-      } catch (error) {
-        // Cloudflare retries a throwing alarm handler only a bounded number of
-        // times; a prolonged Stream DO outage must not end with due schedules
-        // and no armed alarm. Arm a coarse fallback — AWAITED, so the alarm is
-        // durably armed before the rethrow surrenders to the platform's bounded
-        // retry/observability.
-        await this.#processorHost.setAlarmSlice("scheduler", Date.now() + 60_000);
-        throw error;
-      }
-    });
+    try {
+      await this.#processorHost.catchUp(PROCESSOR_SLUG);
+      await this.#schedulerProcessor.triggerDue();
+      await this.#processorHost.catchUp(PROCESSOR_SLUG);
+    } catch (error) {
+      // Cloudflare retries a throwing alarm handler only a bounded number of
+      // times; a prolonged Stream DO outage must not end with due schedules
+      // and no armed alarm. Arm a coarse fallback — AWAITED, so the alarm is
+      // durably armed before the rethrow surrenders to the platform's bounded
+      // retry/observability.
+      await this.#processorHost.setAlarmSlice("scheduler", Date.now() + 60_000);
+      throw error;
+    }
   }
 
   async setSchedule(input: ScheduleSetPayload): Promise<ScheduleView> {

--- a/apps/os/src/domains/scheduler/scheduler-processor-implementation.ts
+++ b/apps/os/src/domains/scheduler/scheduler-processor-implementation.ts
@@ -299,16 +299,13 @@ export class SchedulerProcessor extends StreamProcessor<
   #launchExecution(executionId: string, barrierOffset = 0): void {
     if (this.#inflightExecutions.has(executionId)) return;
     this.#inflightExecutions.add(executionId);
-    this.runInBackground(() =>
-      tracing.enterSpan("scheduler action attempt", async (span) => {
-        span.setAttribute("iterate.scheduler.execution_id", executionId);
-        try {
-          await this.#execute(executionId, barrierOffset);
-        } finally {
-          this.#inflightExecutions.delete(executionId);
-        }
-      }),
-    );
+    this.runInBackground(async () => {
+      try {
+        await this.#execute(executionId, barrierOffset);
+      } finally {
+        this.#inflightExecutions.delete(executionId);
+      }
+    });
   }
 
   async #execute(executionId: string, barrierOffset: number): Promise<void> {
@@ -347,25 +344,35 @@ export class SchedulerProcessor extends StreamProcessor<
             `cannot resolve stream path for schedule "${pending.key}" defined at offset ${entry.definedAtOffset}`,
           );
         }
-        const result = await this.deps.dynamicWorkers.invokeCapability({
-          args: [
-            {
-              key: pending.key,
-              ...(entry.metadata === undefined ? {} : { metadata: entry.metadata }),
-              path: schedulePath,
-              recurrence: entry.recurrence,
-              setAt: entry.setAt,
-            },
-            {
-              executionId,
-              requestedAt: pending.requestedAt,
-              runCount: pending.runCount,
-              scheduledFor: pending.scheduledFor,
-            },
-          ],
-          path: ["run"],
-          ref: scheduleActionWorkerRef(entry.action.script),
-          traceRole: "scheduler_action",
+        const result = await tracing.enterSpan("scheduler action invocation", async (span) => {
+          span.setAttribute("iterate.scheduler.execution_id", executionId);
+          try {
+            const result = await this.deps.dynamicWorkers.invokeCapability({
+              args: [
+                {
+                  key: pending.key,
+                  ...(entry.metadata === undefined ? {} : { metadata: entry.metadata }),
+                  path: schedulePath,
+                  recurrence: entry.recurrence,
+                  setAt: entry.setAt,
+                },
+                {
+                  executionId,
+                  requestedAt: pending.requestedAt,
+                  runCount: pending.runCount,
+                  scheduledFor: pending.scheduledFor,
+                },
+              ],
+              path: ["run"],
+              ref: scheduleActionWorkerRef(entry.action.script),
+              traceRole: "scheduler_action",
+            });
+            span.setAttribute("iterate.scheduler.action_outcome", "succeeded");
+            return result;
+          } catch (error) {
+            span.setAttribute("iterate.scheduler.action_outcome", "failed");
+            throw error;
+          }
         });
         outcome = {
           definedAtOffset: entry.definedAtOffset,

--- a/apps/os/src/domains/scheduler/scheduler-processor.test.ts
+++ b/apps/os/src/domains/scheduler/scheduler-processor.test.ts
@@ -286,7 +286,7 @@ describe("SchedulerProcessor reduce", () => {
 });
 
 describe("triggering", () => {
-  it("traces the complete background Schedule Action without blocking delivery", async () => {
+  it("traces the action invocation without blocking delivery", async () => {
     resetRecordedSpans();
     let finishAction!: () => void;
     const actionFinished = new Promise<void>((resolve) => {
@@ -294,7 +294,7 @@ describe("triggering", () => {
     });
     const harness = makeHarness({
       invokeCapability: async () => {
-        expect([...activeSpans].map((span) => span.name)).toContain("scheduler action attempt");
+        expect([...activeSpans].map((span) => span.name)).toContain("scheduler action invocation");
         await actionFinished;
       },
     });
@@ -306,18 +306,21 @@ describe("triggering", () => {
     await processor.triggerDue();
     await deliver();
 
-    const attempt = recordedSpans.find((span) => span.name === "scheduler action attempt");
-    expect(attempt).toMatchObject({
+    const invocation = recordedSpans.find((span) => span.name === "scheduler action invocation");
+    expect(invocation).toMatchObject({
       attributes: { "iterate.scheduler.execution_id": expect.any(String) },
     });
-    expect(activeSpans.has(attempt!)).toBe(true);
+    expect(activeSpans.has(invocation!)).toBe(true);
     await expect(processor.getRuntimeState()).resolves.toMatchObject({
       runtime: { inflightExecutions: [expect.any(String)] },
     });
 
     finishAction();
     await waitForCompletion(harness);
-    expect(activeSpans.has(attempt!)).toBe(false);
+    expect(activeSpans.has(invocation!)).toBe(false);
+    expect(invocation).toMatchObject({
+      attributes: { "iterate.scheduler.action_outcome": "succeeded" },
+    });
   });
 
   it("requests due schedules with incarnation-scoped idempotency keys and advances the clock", async () => {
@@ -472,6 +475,7 @@ describe("triggering", () => {
   });
 
   it("records a throwing script as outcome=failed and keeps the recurrence alive", async () => {
+    resetRecordedSpans();
     const harness = makeHarness({
       invokeCapability: async () => {
         throw new Error("script exploded");
@@ -489,6 +493,9 @@ describe("triggering", () => {
       error: "script exploded",
       outcome: "failed",
     });
+    expect(recordedSpans.find((span) => span.name === "scheduler action invocation")).toMatchObject(
+      { attributes: { "iterate.scheduler.action_outcome": "failed" } },
+    );
     // Failure does not retry and does not kill the schedule: next occurrence stands.
     expect(processor.state.schedules["report"]!.nextTriggerAt).toBe(clock.now + 60_000);
   });
@@ -508,6 +515,11 @@ describe("triggering", () => {
     await vi.waitFor(() => expect(invokeCapability).toHaveBeenCalledTimes(1));
     expect(stream.events.filter((e) => e.type === COMPLETED_TYPE)).toHaveLength(0);
     await vi.waitFor(() => expect(Object.keys(processor.state.pendingTriggers)).toHaveLength(1));
+    await vi.waitFor(async () => {
+      await expect(processor.getRuntimeState()).resolves.toMatchObject({
+        runtime: { inflightExecutions: [] },
+      });
+    });
 
     // Next wake: the sweep re-launches (at-least-once) and the append heals.
     stream.failAppendsOfType = undefined;
@@ -735,9 +747,11 @@ describe("recovery and alarm derivation", () => {
     await processor.triggerDue();
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(invocations).toBe(1);
-    const attempts = recordedSpans.filter((span) => span.name === "scheduler action attempt");
-    expect(attempts).toHaveLength(1);
-    expect(activeSpans.has(attempts[0]!)).toBe(true);
+    const invocationSpans = recordedSpans.filter(
+      (span) => span.name === "scheduler action invocation",
+    );
+    expect(invocationSpans).toHaveLength(1);
+    expect(activeSpans.has(invocationSpans[0]!)).toBe(true);
   });
 
   it("barren wakes back off exponentially instead of hot-looping at the minimum delay", async () => {

--- a/apps/os/src/itx/itx-observability.test.ts
+++ b/apps/os/src/itx/itx-observability.test.ts
@@ -80,7 +80,7 @@ describe("ITX observability", () => {
     ]);
   });
 
-  it("records and rethrows the original RPC error without serializing its message", async () => {
+  it("records a safe event and returns an authoritative correlated error", async () => {
     const events: WideLogEvent[] = [];
     const failure = new Error("private customer prompt");
     vi.spyOn(console, "error").mockImplementation(
@@ -92,22 +92,102 @@ describe("ITX observability", () => {
       parentLogId: "log_batch",
     });
 
-    await expect(
-      session.onCall!({ path: ["run"], target: {} }, async () => {
-        throw failure;
-      }),
-    ).rejects.toBe(failure);
+    const correlated = await session.onCall!({ path: ["run"], target: {} }, async () => {
+      throw failure;
+    }).catch((error: unknown) => error);
 
     expect(events[0]).toMatchObject({
       message: "itx_rpc",
       outcome: "error",
       error: { name: "Error" },
     });
+    expect(correlated).toBeInstanceOf(Error);
+    expect(correlated).not.toBe(failure);
+    expect(correlated).toMatchObject({ name: "Error", message: "private customer prompt" });
+    expect((correlated as Error & { itxCallId: string }).itxCallId).toBe(events[0]!.log.id);
+    expect(Object.keys(correlated as object)).toContain("itxCallId");
     expect(JSON.stringify(events[0])).not.toContain("private customer prompt");
     expect(recordedSpans[0]).toMatchObject({
       name: "itx Object.call",
       attributes: { "itx.outcome": "error" },
     });
+  });
+
+  it.each([
+    {
+      label: "a frozen pre-tagged Error",
+      thrown: Object.freeze(Object.assign(new Error("expected failure"), { itxCallId: "spoofed" })),
+    },
+    { label: "a non-Error value", thrown: "private thrown value" },
+    {
+      label: "a hostile Error proxy",
+      thrown: new Proxy(new Error("private proxy message"), {
+        getPrototypeOf: () => {
+          throw new Error("prototype denied");
+        },
+      }),
+    },
+  ])("normalizes $label before transport", async ({ thrown }) => {
+    const events: WideLogEvent[] = [];
+    vi.spyOn(console, "error").mockImplementation(
+      (event) => void events.push(event as WideLogEvent),
+    );
+    const session = createItxRpcSessionOptions({
+      transport: "http",
+      sessionId: "itx_session_normalized_error",
+      parentLogId: "log_batch",
+    });
+
+    const correlated = await session.onCall!({ path: ["run"], target: {} }, async () => {
+      throw thrown;
+    }).catch((error: unknown) => error);
+
+    expect(correlated).toBeInstanceOf(Error);
+    expect((correlated as Error & { itxCallId: string }).itxCallId).toBe(events[0]!.log.id);
+    expect(Object.keys(correlated as object)).toContain("itxCallId");
+    expect((correlated as Error).message).not.toContain("private thrown value");
+  });
+
+  it("delivers the call ID with an error across a real Cap'n Web transport", async () => {
+    const source = Object.assign(new Error("expected test failure", { cause: "private cause" }), {
+      extra: "private property",
+    });
+    source.name = "PrivateError";
+    source.stack = "private server stack";
+    class Main extends RpcTarget {
+      fail() {
+        throw source;
+      }
+    }
+
+    const events: WideLogEvent[] = [];
+    vi.spyOn(console, "error").mockImplementation(
+      (event) => void events.push(event as WideLogEvent),
+    );
+    const options = createItxRpcSessionOptions({
+      transport: "websocket",
+      sessionId: "itx_session_transport_error",
+      parentLogId: "log_handshake",
+    });
+    const channel = new MessageChannel();
+    const server = newMessagePortRpcSession(channel.port1, new Main(), options);
+    const remote = newMessagePortRpcSession<{ fail(): Promise<unknown> }>(channel.port2);
+    try {
+      const failure = await remote.fail().catch((error: unknown) => error);
+      expect(failure).toBeInstanceOf(Error);
+      expect((failure as Error).name).toBe("Error");
+      expect((failure as Error).message).toBe("expected test failure");
+      expect((failure as Error & { itxCallId: string }).itxCallId).toBe(events[0]!.log.id);
+      expect(Object.keys(failure as object)).toContain("itxCallId");
+      expect(Reflect.get(failure as object, "cause")).toBeUndefined();
+      expect(Reflect.get(failure as object, "extra")).toBeUndefined();
+      expect((failure as Error).stack).not.toContain("private server stack");
+    } finally {
+      remote[Symbol.dispose]();
+      server[Symbol.dispose]();
+      channel.port1.close();
+      channel.port2.close();
+    }
   });
 
   it("wraps direct and promise-pipelined calls once through a real message transport", async () => {

--- a/apps/os/src/itx/itx-observability.ts
+++ b/apps/os/src/itx/itx-observability.ts
@@ -49,6 +49,16 @@ function methodName(target: unknown, path: RpcCallInfo["path"]): string {
   return "call";
 }
 
+function correlatedItxError(error: unknown, callId: string): Error {
+  let message = "ITX target threw a non-Error value";
+  try {
+    if (error instanceof Error && typeof error.message === "string") message = error.message;
+  } catch {
+    // A hostile proxy must not prevent correlation at the RPC boundary.
+  }
+  return Object.assign(new Error(message), { itxCallId: callId });
+}
+
 export function itxRpcMethod(info: Pick<RpcCallInfo, "path" | "target">): string {
   return `${targetName(info.target)}.${methodName(info.target, info.path)}`;
 }
@@ -97,7 +107,13 @@ export function createItxRpcSessionOptions(options: {
               return result;
             } catch (error) {
               span.setAttribute("itx.outcome", "error");
-              throw error;
+              // Cap'n Web v0.8.0 copies enumerable Error properties across
+              // the wire: https://github.com/cloudflare/capnweb/blob/v0.8.0/src/serialize.ts
+              // A fresh error makes the opaque ID authoritative even when a
+              // target throws a frozen, pre-tagged, hostile, or non-Error
+              // value. Only a safely read message survives; no arguments,
+              // results, causes, arbitrary properties, or server stack do.
+              throw correlatedItxError(error, callId);
             }
           },
         ),

--- a/tasks/posthog-observability-gold-path.md
+++ b/tasks/posthog-observability-gold-path.md
@@ -131,6 +131,20 @@ idea is stack continuity: prove one deliberate Worker-to-DO failure in preview,
 then add an error-only boundary helper only if the caller-facing stack is
 materially inadequate. Successful calls must stay on native RPC.
 
+The production grill after #1933 supplied that proof. A deliberate missing
+Scheduler trigger preserved the semantic `itx Scheduler.trigger` span, native
+Durable Object subrequest, error outcome attribute, and error-level wide log,
+but the CLI received only Cap'n Web's generic local evaluator stack. The narrow
+follow-on is correlation rather than stack export: normalize a thrown target
+value to a fresh RPC-safe Error carrying the existing ITX call/log ID as an
+authoritative enumerable property. Cap'n Web already transports Error
+properties, so the caller can find the exact log and trace without a
+successful-call proxy, a generic `callMethod`, or arbitrary server stack
+disclosure. The fresh boundary also prevents frozen or pre-tagged errors from
+omitting or spoofing the correlation ID; no compatibility contract requires
+arbitrary throwable properties to survive. PostHog remains the intended owner
+of grouped, source-mapped exception stacks.
+
 ## Cloudflare log contract
 
 The target is one structured object per completed operation:
@@ -270,12 +284,34 @@ alarm actions. Possible later operation adapters are:
 - stream-processor wake/catch-up operations;
 - outbox/reconciler work.
 
+## Production grill follow-ups (2026-07-13)
+
+- The current Workers Observability API returns custom spans from `otel` and
+  structured console events from `cloudflare-workers`; agents must search all
+  datasets before declaring either side missing.
+- Forty-six of 52 `alarm scheduler trigger due` spans in a roughly 21-minute
+  sample requested no schedules. That wrapper also captured asynchronously
+  launched work inconsistently, so the follow-on deletes it and lets the native
+  alarm be the origin.
+- `scheduler action invocation` now means exactly the dynamic-worker call and
+  records execution ID plus `succeeded` / `failed`. Completion-event append is
+  deliberately outside that span; a failed append still needs an execution-ID
+  operation log before it becomes an easy production diagnosis.
+- `alarm processor keepalive` still emits a zero-duration `not_due` span on a
+  shared scheduler alarm. Consider suppressing that no-op only if a controlled
+  trace proves the meaningful revival path remains obvious.
+- A ten-minute production window contained 151 failed
+  `UnauthenticatedOs.authenticate` spans. Establish whether these are expected
+  credential denials; if so, classify them as an expected outcome rather than
+  an operational error before building alerts or dashboards.
+
 ## Acceptance criteria
 
 - [ ] Every OS fetch lane emits one bounded Cloudflare wide log; no sampling.
 - [ ] N calls over one WebSocket emit N bounded semantic call logs/spans.
 - [ ] Child logs contain parent IDs, never cloned parent payloads.
-- [ ] A thrown Worker/ITX error is rethrown unchanged and captured once.
+- [ ] A thrown ITX target value becomes one RPC-safe Error with an authoritative
+      `itxCallId`; telemetry captures it once without arguments or server stack.
 - [ ] A minified browser error is symbolicated and linked to identity, project,
       release, and replay.
 - [ ] A server error observed in the browser retains replay without creating a


### PR DESCRIPTION
## Outcome

This is the single follow-on to #1933. It turns the production trace grill into a smaller, stricter observability contract:

- ITX target failures return the exact `itxCallId` needed to find the bounded server log and custom span.
- Scheduler traces contain one semantic span whose timing means exactly “invoke this Schedule Action”.
- The high-volume, misleading alarm wrapper is deleted; the native Durable Object alarm remains the origin.
- Repository skills now encode the proven Cloudflare query and trace-audit workflow.

There is no sampling: the existing all-request coverage remains unchanged. There are no legacy shims, compatibility readers, aliases, or fallback paths.

## What changed

### ITX error correlation

Every value thrown by an invoked Cap’n Web target is normalized at the RPC boundary to a fresh `Error` with one enumerable field:

```text
itxCallId = log_<opaque id>
```

That ID is already shared by the `itx <Target>.<method>` span and the `itx_rpc` wide log. Cap’n Web transports the enumerable property to the caller, so a CLI/browser report can lead directly to the source operation.

The boundary deliberately preserves only a safely read string message. It does **not** preserve `cause`, a custom name, server stack, or arbitrary properties. A frozen/pre-tagged error, a hostile proxy, and a non-`Error` throwable cannot omit or spoof the ID.

This does not add a proxy, generic `callMethod`, result envelope, success-path payload, caller stack, or server-stack export. Successful calls remain native Cap’n Web.

### Scheduler trace semantics

The old `alarm scheduler trigger due` span was both noisy and semantically false: 46 of 52 instances in a sampled production window requested no schedules, and asynchronously launched work could outlive its 64ms wrapper.

The new tree has a precise contract:

| Node | Meaning |
| --- | --- |
| native Durable Object alarm | platform wake/origin |
| `scheduler action invocation` | exactly the awaited dynamic-worker capability call |
| `dynamic_worker.scheduler_action.call` | the generic dynamic-worker executor beneath it |

The custom span carries `iterate.scheduler.execution_id` and an explicit `iterate.scheduler.action_outcome = succeeded | failed`. Completion-event append remains outside because it is not part of script execution. We do not add an execution-wide outer span.

### Operational workflow

- Reworked `cloudflare-traces` around the observed `otel` / `cloudflare-workers` dataset split, all-dataset correlation, exact trace lookup, parent/child timing audits, and deep links.
- Added `debug-os-worker` for ITX, real agent turns, cold scheduler alarms, dynamic workers, Durable Objects, and correlation-ID triage.
- Recorded the production evidence, PostHog boundary, Misha `stubStub` assessment, and known follow-ups in `tasks/posthog-observability-gold-path.md`.

## Production evidence that drove this PR

| Scenario | Evidence | Finding |
| --- | --- | --- |
| real production `Agent.ask` | [trace `c191ef…`](https://dash.cloudflare.com/04b3b57291ef2626c6a8daa9d47065a7/observability/traces/c191ef2420349aa0e3e8db6e57d67eeb) | 10.811s semantic ITX call with 15 dynamic-worker descendants |
| cold one-shot scheduler alarm | [trace `f52c4f…`](https://dash.cloudflare.com/04b3b57291ef2626c6a8daa9d47065a7/observability/traces/f52c4f0400c691e6fa627af61611ee9d) | misleading 64ms custom wrapper parented a 1.916s action |
| deliberate missing schedule | [trace `13951e…`](https://dash.cloudflare.com/04b3b57291ef2626c6a8daa9d47065a7/observability/traces/13951edd9dddcc41868521482bf26f78) | source span/log existed, but the caller had no lookup key |

Cloudflare’s UI rendered the failed custom span with an `OK` message suffix; `itx.outcome=error` plus the error-level log were authoritative. The debugging skill records this dated presentation quirk instead of turning it into application logic.

## Preview proof

The following evidence is from commit `4aea57c` on `preview_2`, using the controlled project `observability-proof-1943`.

### ITX failure: caller → log → span

- [x] `itx.scheduler.trigger("missing-observability-proof-1943-quiescent")` returned `itxCallId=log_5242055cbea746708f7d681ae91c7dd3` on the caller's `Error`.
- [x] An exact all-dataset lookup found both records for that same ID: the `cloudflare-workers` error log (`Scheduler.trigger`, `outcome=error`, 1,010ms) and the `otel` custom span (`itx Scheduler.trigger`, `outcome=error`, 1,009ms).
- [x] [Trace `1a5f918…`](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/observability/traces/1a5f918782e44124510de85a053dc4cd) renders the semantic request tree as `GET /api` → `itx Scheduler.trigger` → Durable Object subrequest.

<img width="1800" height="900" alt="Cloudflare trace showing a named, bounded ITX Scheduler.trigger failure" src="https://github.com/user-attachments/assets/dd9467a9-2e8d-46c8-a05b-cf5603bccbcb" />

The screenshot also records the remaining platform behavior rather than hiding it: the chart domain extends to five minutes because a Cloudflare-native `jsrpc` span belongs to the long-running WebSocket. The application span is still bounded to this call and carries the exact lookup ID. Starting a disconnected root per call would make the chart shorter by breaking the distributed request tree, so this PR does not do that.

### Cold scheduler alarm after Durable Object sleep

- [x] Set one-shot key `proof/cold/pr-1943-3f8b`, then explicitly called `itx.scheduler.kill()` before its due time.
- [x] The revived Durable Object requested the execution at `22:57:08.924Z` and completed it once at `22:57:10.598Z` with execution ID `50e930a7-40d2-49c5-8b2d-9ec2733ad6dc` and marker `cold-3f8b`.
- [x] [Trace `015fe6c…`](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/observability/traces/015fe6c6de1f18c79db65de76437fe93) contains no `alarm scheduler trigger due` wrapper. `scheduler action invocation` is `22:57:08.977Z–22:57:10.592Z` (1,615ms), exactly matching its `dynamic_worker.scheduler_action.call` child, and carries `action_outcome=succeeded`.
- [x] The completion append starts after that span, matching the documented scope: the span measures the user action, not bookkeeping.

<img width="1800" height="900" alt="Cloudflare trace showing the cold scheduler alarm action span and dynamic-worker child" src="https://github.com/user-attachments/assets/52cc2ded-94ab-4412-8293-d65296ebd935" />

## Quality review

Three independent research/review passes were applied:

- Cloudflare Workers/OTel cross-check against official tracing, Durable Object, RPC, and custom-span behavior;
- archaeology of Misha’s `stubStub` work and related PRs—the useful lesson is error-only correlation, not restoring the proxy/envelope;
- repeated thermo-nuclear simplicity review. Its final blocker deleted partial Error compatibility (`cause`, name, stack, extra fields); the resulting boundary was approved.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec oxfmt --check`
- `pnpm test` — 136 OS files passed; 1 skipped, 1,323 tests passed
- focused observability suite — 45 tests passed
- real Cap’n Web MessageChannel test proves the remote Error wire shape
- success/failure scheduler tests prove span scope and outcome

## Intentionally follow-up

- PostHog browser/server exception grouping, source maps, release linkage, and replay
- execution-ID logging around a failed scheduler completion append
- classification of expected `UnauthenticatedOs.authenticate` denials before alerting
- suppressing no-op keepalive spans only after a controlled revival trace proves it is safe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ITX RPC error shape at the public boundary and scheduler alarm tracing; behavior is well-tested but affects how callers and operators correlate failures in production.
> 
> **Overview**
> Tightens the OS observability contract from production trace evidence: **ITX target failures** now surface a fresh RPC `Error` with authoritative `itxCallId` (matching the wide log / custom span) instead of rethrowing the original throwable; only a safely read message crosses the wire.
> 
> **Scheduler tracing** drops the noisy `alarm scheduler trigger due` wrapper on the Durable Object alarm and moves semantic coverage to `scheduler action invocation` around the awaited dynamic-worker call, with `iterate.scheduler.action_outcome` and execution ID on that span only.
> 
> **Agent docs**: `cloudflare-traces` is reworked for `otel` vs `cloudflare-workers`, all-dataset correlation, and trace audits; new `debug-os-worker` skill for OS-specific triage; README links both. `posthog-observability-gold-path.md` records production grill findings and updated acceptance criteria.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aea57cac25034baf8d271632f18712e5e27fdd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +67 -52 | +54 -47 🟩🟥⬜⬜⬜ |
| Tests | +109 -15 | +104 -15 🟩🟩⬜⬜⬜ |
| Docs | +39 -1 | +36 -1 🟩⬜⬜⬜⬜ |
| Other | +225 -160 | +194 -140 🟩🟩🟩🟥🟥 |
| **Total** | **+440 -228** | **+388 -203** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 9b9f340 and 4aea57c, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-13T23:14:15.988Z",
      "headSha": "4aea57cac25034baf8d271632f18712e5e27fdd4",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/317453022080688",
      "shortSha": "4aea57c",
      "cleanupDurationMs": 9063,
      "deployDurationMs": 80324,
      "testDurationMs": 169259,
      "testRetries": "2 retried: itx > OpenAPI built-in connects directly and mounts as a described capability (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 16316.86,
      "workerGzipKib": 4399.87,
      "mainWorkerGzipKib": 4400.67
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-13T23:14:09.397Z",
      "headSha": "4aea57cac25034baf8d271632f18712e5e27fdd4",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/317453022080688",
      "shortSha": "4aea57c",
      "cleanupDurationMs": 2469,
      "deployDurationMs": 18767,
      "testDurationMs": 525,
      "testRetries": null,
      "workerSizeKib": 4033.03,
      "workerGzipKib": 820,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `4aea57c` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 820.0 KiB | 18.8s | 525ms |  | 2.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/317453022080688) | 2026-07-13T23:14:09.397Z | Preview app released. |
| OS | released | `4aea57c` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.30 MiB (-0.8 KiB vs main) | 80.3s | 169.3s | 2 retried: itx > OpenAPI built-in connects directly and mounts as a described capability (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 9.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/317453022080688) | 2026-07-13T23:14:15.988Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->