### PR TITLE
Harden Auth RPC preview migration audit

### DIFF
--- a/scripts/ci/migrate-os-auth-preview-fleet.test.ts
+++ b/scripts/ci/migrate-os-auth-preview-fleet.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import {
   cutoverLeaseRequest,
   drainLegacyPreviewChecks,
+  listPreviewChecksForRefs,
   migratePreviewFleet,
   previewFleetTargets,
+  withGitHubSecondaryRateLimitRetry,
   type PreviewFleetMigrationDependencies,
 } from "./migrate-os-auth-preview-fleet.ts";
 
@@ -114,6 +116,58 @@ describe("cutoverLeaseRequest", () => {
       holder: "main-auth-rpc-security-cutover",
       force: true,
     });
+  });
+});
+
+describe("GitHub check discovery", () => {
+  it("deduplicates refs, keeps one request in flight, and honors Retry-After", async () => {
+    const calls: string[] = [];
+    const sleep = vi.fn(async () => undefined);
+    let active = 0;
+    let maxActive = 0;
+    let firstRefAttempts = 0;
+
+    const checks = await listPreviewChecksForRefs({
+      refs: ["first", "first", "second"],
+      sleep,
+      listChecksForRef: async (ref) => {
+        calls.push(ref);
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        try {
+          if (ref === "first" && firstRefAttempts++ === 0) {
+            throw Object.assign(new Error("You have exceeded a secondary rate limit."), {
+              status: 403,
+              response: { headers: { "retry-after": "1" } },
+            });
+          }
+          await Promise.resolve();
+          return [{ id: calls.length, name: ref, status: "completed" }];
+        } finally {
+          active -= 1;
+        }
+      },
+    });
+
+    expect(calls).toEqual(["first", "first", "second"]);
+    expect(maxActive).toBe(1);
+    expect(sleep).toHaveBeenCalledExactlyOnceWith(1_000);
+    expect(checks.map((check) => check.name)).toEqual(["first", "second"]);
+  });
+
+  it("does not retry an ordinary authorization failure", async () => {
+    const forbidden = Object.assign(new Error("Resource not accessible by integration"), {
+      status: 403,
+      response: { headers: {} },
+    });
+    const operation = vi.fn(async () => {
+      throw forbidden;
+    });
+    const sleep = vi.fn(async () => undefined);
+
+    await expect(withGitHubSecondaryRateLimitRetry(operation, { sleep })).rejects.toBe(forbidden);
+    expect(operation).toHaveBeenCalledOnce();
+    expect(sleep).not.toHaveBeenCalled();
   });
 });
 

--- a/scripts/ci/migrate-os-auth-preview-fleet.ts
+++ b/scripts/ci/migrate-os-auth-preview-fleet.ts
@@ -42,6 +42,8 @@ const CUTOVER_HOLDER = "main-auth-rpc-security-cutover";
 const CUTOVER_LEASE_MS = 3 * 60 * 60_000;
 const CHECK_DRAIN_TIMEOUT_MS = 12 * 60_000;
 const CHECK_DRAIN_POLL_MS = 5_000;
+const GITHUB_RATE_LIMIT_MAX_ATTEMPTS = 5;
+const GITHUB_RATE_LIMIT_MAX_DELAY_MS = 30_000;
 
 export type PreviewFleetTarget = {
   envName: Extract<EnvName, `preview_${number}`>;
@@ -53,11 +55,76 @@ export const previewFleetTargets = environmentConfigLeaseInventory.map((resource
   slug: resource.slug,
 })) satisfies PreviewFleetTarget[];
 
-type PreviewCheck = {
+export type PreviewCheck = {
   id: number;
   name: string;
   status: string;
 };
+
+type GitHubRequestError = {
+  status?: number;
+  message?: string;
+  response?: {
+    headers?: Record<string, string | undefined>;
+  };
+};
+
+function secondaryRateLimitDelayMs(error: unknown, attempt: number) {
+  if (!error || typeof error !== "object") return undefined;
+  const requestError = error as GitHubRequestError;
+  if (requestError.status !== 403 && requestError.status !== 429) return undefined;
+
+  const retryAfter = requestError.response?.headers?.["retry-after"];
+  const isSecondaryLimit = requestError.message?.toLowerCase().includes("secondary rate limit");
+  if (!isSecondaryLimit && retryAfter === undefined) return undefined;
+
+  const retryAfterSeconds = Number(retryAfter);
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
+    return Math.min(Math.max(1_000, retryAfterSeconds * 1_000), GITHUB_RATE_LIMIT_MAX_DELAY_MS);
+  }
+  return Math.min(2 ** (attempt - 1) * 1_000, GITHUB_RATE_LIMIT_MAX_DELAY_MS);
+}
+
+export async function withGitHubSecondaryRateLimitRetry<T>(
+  operation: () => Promise<T>,
+  options: {
+    maxAttempts?: number;
+    sleep?: (ms: number) => Promise<void>;
+  } = {},
+) {
+  const maxAttempts = options.maxAttempts ?? GITHUB_RATE_LIMIT_MAX_ATTEMPTS;
+  const sleep =
+    options.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      const delayMs = secondaryRateLimitDelayMs(error, attempt);
+      if (delayMs === undefined || attempt === maxAttempts) throw error;
+      console.warn(
+        `GitHub secondary rate limit; retrying in ${delayMs}ms (attempt ${attempt + 1}/${maxAttempts})`,
+      );
+      await sleep(delayMs);
+    }
+  }
+  throw new Error("GitHub request retry loop exhausted without returning or throwing.");
+}
+
+export async function listPreviewChecksForRefs(input: {
+  refs: Iterable<string>;
+  listChecksForRef: (ref: string) => Promise<PreviewCheck[]>;
+  sleep?: (ms: number) => Promise<void>;
+}) {
+  const checks: PreviewCheck[] = [];
+  for (const ref of new Set(input.refs)) {
+    checks.push(
+      ...(await withGitHubSecondaryRateLimitRetry(() => input.listChecksForRef(ref), {
+        sleep: input.sleep,
+      })),
+    );
+  }
+  return checks;
+}
 
 export type PreviewFleetMigrationDependencies = {
   acquireSlot: (target: PreviewFleetTarget) => Promise<{ leaseId: string }>;
@@ -173,25 +240,30 @@ export async function drainLegacyPreviewChecks(input: {
 async function listRecentPreviewChecks(): Promise<PreviewCheck[]> {
   const octokit = getOctokit();
   const repo = getRepo();
-  const openPulls = await octokit.paginate(octokit.rest.pulls.list, {
-    ...repo,
-    state: "open",
-    per_page: 100,
-  });
-  const recentClosed = (
-    await octokit.rest.pulls.list({
+  const openPulls = await withGitHubSecondaryRateLimitRetry(() =>
+    octokit.paginate(octokit.rest.pulls.list, {
       ...repo,
-      state: "closed",
-      sort: "updated",
-      direction: "desc",
+      state: "open",
       per_page: 100,
-    })
+    }),
+  );
+  const recentClosed = (
+    await withGitHubSecondaryRateLimitRetry(() =>
+      octokit.rest.pulls.list({
+        ...repo,
+        state: "closed",
+        sort: "updated",
+        direction: "desc",
+        per_page: 100,
+      }),
+    )
   ).data;
   const headShas = [
     ...new Set([...openPulls, ...recentClosed].map((pullRequest) => pullRequest.head.sha)),
   ];
-  const checks = await Promise.all(
-    headShas.map(async (ref) => {
+  return listPreviewChecksForRefs({
+    refs: headShas,
+    listChecksForRef: async (ref) => {
       const response = await octokit.rest.checks.listForRef({
         ...repo,
         ref,
@@ -202,9 +274,8 @@ async function listRecentPreviewChecks(): Promise<PreviewCheck[]> {
         name: check.name,
         status: check.status,
       }));
-    }),
-  );
-  return checks.flat();
+    },
+  });
 }
 
 function createDependencies(): PreviewFleetMigrationDependencies {
@@ -236,7 +307,9 @@ function createDependencies(): PreviewFleetMigrationDependencies {
       return drainLegacyPreviewChecks({
         listBlockingChecks: listRecentPreviewChecks,
         readCheck: async (id) => {
-          const response = await octokit.rest.checks.get({ ...repo, check_run_id: id });
+          const response = await withGitHubSecondaryRateLimitRetry(() =>
+            octokit.rest.checks.get({ ...repo, check_run_id: id }),
+          );
           return {
             id: response.data.id,
             name: response.data.name,


### PR DESCRIPTION
## Problem

The one-time Auth RPC preview-fleet migration failed before lease acquisition because its drain audit requested check runs for roughly 100 PR heads concurrently. GitHub returned a secondary-rate-limit 403 with Retry-After even though the primary quota remained healthy.

## Change

- Discover check runs sequentially, with duplicate head SHAs removed, so the maintenance workflow has at most one check-list request in flight.
- Retry only GitHub secondary-rate-limit responses (403/429 with the secondary-limit signal or Retry-After), honor Retry-After, cap delay at 30 seconds, and fail after five attempts.
- Apply the same bounded retry to pull discovery and check polling.
- Continue failing closed for ordinary authorization failures.

No worker code, service-binding configuration, lease semantics, or token-retirement ordering changes in this PR. The failed migration acquired no preview lease and deployed no worker.

## Verification

- `pnpm --dir scripts test -- migrate-os-auth-preview-fleet.test.ts` (131 passed)
- `pnpm typecheck`
- `pnpm lint` (0 warnings, 0 errors)
- `pnpm format:check`

Regression coverage proves ref deduplication, one in-flight lookup, Retry-After handling, successful retry, and no retry for an ordinary 403.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the one-off CI migration script’s GitHub client behavior and tests; no worker deploy, leases, or token-retirement logic is altered.
> 
> **Overview**
> The Auth RPC preview-fleet migration script’s **pre-cutover drain audit** no longer fans out ~100 concurrent `checks.listForRef` calls. Check discovery now **deduplicates head SHAs** and lists check runs **one ref at a time**, which avoids triggering GitHub’s secondary rate limit before lease acquisition.
> 
> New helpers **`withGitHubSecondaryRateLimitRetry`** and **`listPreviewChecksForRefs`** centralize that behavior. Retries apply only to **secondary-limit** signals (403/429 with “secondary rate limit” or `Retry-After`), sleep per `Retry-After` (capped at 30s) or exponential backoff, and stop after **five attempts**; ordinary 403s (e.g. integration access) still **fail immediately**. The same wrapper is used for open/closed PR listing and per-check polling during drain.
> 
> Tests cover ref deduplication, single in-flight lookup, `Retry-After` on retry, and no retry on a normal authorization failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 515ea0f51b3cfc7b911b9514b2043a5c72f600fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +54 -0 | +49 -0 🟩🟩⬜⬜⬜ |
| CI & scripts | +91 -18 | +85 -18 🟩🟩🟩🟩🟥 |
| **Total** | **+145 -18** | **+134 -18** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between ce18a7d and 515ea0f, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->