### PR TITLE
Keep task column add buttons visible

### DIFF
--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -584,7 +584,7 @@ function TaskColumn({
       ref={ref}
       data-task-cell={dropId}
       className={cn(
-        "group/task-column flex min-h-36 min-w-[calc(100vw-3.5rem)] flex-1 basis-72 snap-start flex-col pb-4 transition-colors sm:min-w-72",
+        "flex min-h-36 min-w-[calc(100vw-3.5rem)] flex-1 basis-72 snap-start flex-col pb-4 transition-colors sm:min-w-72",
         isDropTarget && "rounded-lg bg-accent/40",
       )}
     >
@@ -597,6 +597,15 @@ function TaskColumn({
         </header>
       ) : null}
       <div className="flex min-h-0 flex-1 flex-col px-2 pb-2">
+        <Button
+          variant="ghost"
+          className="mb-2 h-10 w-full shrink-0 border border-dashed border-border/70 text-muted-foreground/60 hover:bg-muted/70 hover:text-muted-foreground"
+          title={`Add task to ${creationLabel}`}
+          aria-label={`Add task to ${creationLabel}`}
+          onClick={onCreate}
+        >
+          <PlusIcon data-icon="inline-start" />
+        </Button>
         <div className="flex flex-col gap-2">
           {tasks.map((task) => (
             <TaskCard
@@ -607,17 +616,6 @@ function TaskColumn({
               onOpen={onOpen}
             />
           ))}
-        </div>
-        <div className="group/task-add mt-auto min-h-14 pt-4">
-          <Button
-            variant="ghost"
-            className="h-10 w-full shrink-0 border border-dashed border-border/70 text-muted-foreground/60 opacity-0 transition-opacity group-hover/task-add:opacity-100 focus-visible:opacity-100 hover:bg-muted/70 hover:text-muted-foreground [@media(hover:none)]:opacity-100"
-            title={`Add task to ${creationLabel}`}
-            aria-label={`Add task to ${creationLabel}`}
-            onClick={onCreate}
-          >
-            <PlusIcon data-icon="inline-start" />
-          </Button>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

- move each task-column add button above its cards
- keep the muted dashed button permanently visible on pointer and touch devices
- preserve one add target per grouped row/column section

## Verification

- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/os exec vitest run src/components/repo-ide/repo-tasks.test.ts`
- `pnpm lint`
- focused formatting check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and visibility change in `TaskColumn` with no logic or data-path changes.
> 
> **Overview**
> **Task board columns** now show the dashed “add task” control at the **top** of each status cell, above the task cards, instead of pinned to the bottom of the column.
> 
> The add action is **always visible** (muted dashed ghost button). The previous hover-only / `mt-auto` footer wrapper and related `group/task-column` styling are removed; `onCreate`, titles, and aria-labels are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 766f2329676eba241ca36dcfdd3c8c52241dfcbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +10 -12 | +10 -12 🟩🟩🟥🟥🟥 |
| **Total** | **+10 -12** | **+10 -12** 🟩🟩🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 36ad445 and 766f232, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-14T06:56:59.695Z",
      "headSha": "766f2329676eba241ca36dcfdd3c8c52241dfcbd",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/67859765153810",
      "shortSha": "766f232",
      "cleanupDurationMs": 2131,
      "deployDurationMs": 28065,
      "testDurationMs": 301,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.84,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-14T06:56:56.584Z",
      "headSha": "766f2329676eba241ca36dcfdd3c8c52241dfcbd",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/67859765153810",
      "shortSha": "766f232",
      "cleanupDurationMs": 232665,
      "deployDurationMs": 74030,
      "testDurationMs": 248457,
      "testRetries": "2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · itx repo history > log, commitDetails and pinned readFile over a few commits (vitest x1)",
      "workerSizeKib": 16309.78,
      "workerGzipKib": 4399.18,
      "mainWorkerGzipKib": 4399.19
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `766f232` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 819.8 KiB | 28.1s | 301ms |  | 2.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/67859765153810) | 2026-07-14T06:56:59.695Z | Preview app released. |
| OS | released | `766f232` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.30 MiB (±0 vs main) | 74.0s | 248.5s | 2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · itx repo history > log, commitDetails and pinned readFile over a few commits (vitest x1) | 232.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/67859765153810) | 2026-07-14T06:56:56.584Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->