### PR TITLE
Repair stale integration router subscriptions

### DIFF
--- a/apps/os/src/domains/integrations/connect-flows.ts
+++ b/apps/os/src/domains/integrations/connect-flows.ts
@@ -25,7 +25,6 @@
 
 import { itxEnv } from "../../env.ts";
 import { DurableObjectNameCodec } from "../durable-object-names.ts";
-import { buildDurableObjectProcessorSubscriptionConfiguredEvent } from "../streams/utils.ts";
 import type { SecretRefresh } from "../secrets/types.ts";
 import type {
   CompleteConnectResult,
@@ -43,6 +42,7 @@ import {
 import {
   appendConnectionDirectoryEvent,
   appendConnectionDirectoryEvents,
+  buildIntegrationRouterSubscriptionConfiguredEvent,
   integrationStreamStub,
   latestStreamEventOfTypes,
   lookupConnectionClaim,
@@ -292,9 +292,6 @@ async function recordConnection(input: {
    * route inbound events). Connect time is THE arming point — connection
    * streams are born here, not at project create. */
   processorSubscription?: {
-    idempotencyKey: string;
-    /** Itx expression to the router's processor node (see the subscription builder). */
-    processor: (string | [string, ...unknown[]])[];
     processorSlug: string;
   };
   /** Claim this connection's external id in the deployment-wide directory
@@ -321,14 +318,11 @@ async function recordConnection(input: {
   await integrationStreamStub(input.projectId, streamPath).append(
     ...(input.processorSubscription
       ? [
-          buildDurableObjectProcessorSubscriptionConfiguredEvent({
-            durableObjectName: DurableObjectNameCodec.stringify({
-              projectId: input.projectId,
-              path: streamPath,
-            }),
-            idempotencyKey: input.processorSubscription.idempotencyKey,
-            processor: input.processorSubscription.processor,
+          buildIntegrationRouterSubscriptionConfiguredEvent({
+            connection: input.connection,
+            projectId: input.projectId,
             processorSlug: input.processorSubscription.processorSlug,
+            slug: input.slug,
           }),
         ]
       : []),
@@ -463,8 +457,6 @@ async function recordSlackConnection(input: {
       },
     },
     processorSubscription: {
-      idempotencyKey: `slack-router-subscription:${input.projectId}:${input.connection}`,
-      processor: ["integrations", "slack", ["get", input.connection], "processor"],
       processorSlug: SlackProcessorContract.slug,
     },
     directoryClaim: { externalId: input.teamId },
@@ -858,8 +850,6 @@ export async function connectTelegram(input: {
       },
     },
     processorSubscription: {
-      idempotencyKey: `telegram-router-subscription:${input.projectId}:${connection}`,
-      processor: ["integrations", "telegram", ["get", connection], "processor"],
       processorSlug: TelegramProcessorContract.slug,
     },
     directoryClaim: {

--- a/apps/os/src/domains/integrations/integration-router-reconciliation.test.ts
+++ b/apps/os/src/domains/integrations/integration-router-reconciliation.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { DurableObjectNameCodec } from "../durable-object-names.ts";
+import { integrationConnectionStreamPath } from "./utils.ts";
+
+const network = vi.hoisted(() => {
+  type StoredEvent = {
+    idempotencyKey?: string;
+    offset: number;
+    payload?: Record<string, unknown>;
+    type: string;
+  };
+  const streams = new Map<string, StoredEvent[]>();
+  const appendBatches: Array<{ inputs: Omit<StoredEvent, "offset">[]; name: string }> = [];
+  return {
+    STREAM: {
+      getByName(name: string) {
+        const stored = streams.get(name) ?? [];
+        streams.set(name, stored);
+        return {
+          append(...inputs: Omit<StoredEvent, "offset">[]) {
+            appendBatches.push({ inputs, name });
+            return inputs.map((input) => {
+              const existing = input.idempotencyKey
+                ? stored.find((event) => event.idempotencyKey === input.idempotencyKey)
+                : undefined;
+              if (existing) return existing;
+              const event = { ...input, offset: stored.length + 1 };
+              stored.push(event);
+              return event;
+            });
+          },
+          getEvents(input: { afterOffset?: number; limit?: number } = {}) {
+            const { afterOffset = 0, limit = 500 } = input;
+            return stored.filter((event) => event.offset > afterOffset).slice(0, limit);
+          },
+        };
+      },
+    },
+    reset() {
+      streams.clear();
+      appendBatches.length = 0;
+    },
+    appendBatches,
+    streams,
+  };
+});
+
+vi.mock("../../env.ts", () => ({ itxEnv: { STREAM: network.STREAM } }));
+
+const { appendConnectionDirectoryEvent, integrationStreamStub, routeIntegrationWebhook } =
+  await import("./integration-streams.ts");
+
+const PROJECT_ID = "prj_test";
+const CONNECTION = "acme";
+const SUBSCRIPTION_KEY = `${DurableObjectNameCodec.stringify({
+  projectId: PROJECT_ID,
+  path: integrationConnectionStreamPath("slack", CONNECTION),
+})}#slack`;
+
+describe("webhook router subscription reconciliation", () => {
+  afterEach(() => network.reset());
+
+  test("a webhook replaces a stale property-walk subscription before routing, once", async () => {
+    await appendConnectionDirectoryEvent({
+      claimed: true,
+      connection: CONNECTION,
+      externalId: "T1",
+      projectId: PROJECT_ID,
+      slug: "slack",
+    });
+    await integrationStreamStub(
+      PROJECT_ID,
+      integrationConnectionStreamPath("slack", CONNECTION),
+    ).append({
+      idempotencyKey: `slack-router-subscription:${PROJECT_ID}:${CONNECTION}`,
+      payload: {
+        subscriptionKey: SUBSCRIPTION_KEY,
+        delivery: {
+          mode: "wake",
+          expression: ["integrations", "slack", CONNECTION, "processor", "wakeStreamSubscriber"],
+          processorSlug: "slack",
+        },
+      },
+      type: "events.iterate.com/stream/subscription-configured",
+    });
+
+    await routeIntegrationWebhook({
+      event: {
+        idempotencyKey: "slack-webhook:one",
+        payload: { body: { event_id: "one" } },
+        type: "events.iterate.com/slack/webhook-received",
+      },
+      externalId: "T1",
+      routerProcessorSlug: "slack",
+      slug: "slack",
+    });
+    await routeIntegrationWebhook({
+      event: {
+        idempotencyKey: "slack-webhook:two",
+        payload: { body: { event_id: "two" } },
+        type: "events.iterate.com/slack/webhook-received",
+      },
+      externalId: "T1",
+      routerProcessorSlug: "slack",
+      slug: "slack",
+    });
+
+    const streamName = DurableObjectNameCodec.stringify({
+      projectId: PROJECT_ID,
+      path: integrationConnectionStreamPath("slack", CONNECTION),
+    });
+    const events = network.streams.get(streamName)!;
+    const firstWebhookBatch = network.appendBatches.find(({ inputs }) =>
+      inputs.some((event) => event.idempotencyKey === "slack-webhook:one"),
+    );
+    expect(firstWebhookBatch?.inputs.map((event) => event.type)).toEqual([
+      "events.iterate.com/stream/subscription-configured",
+      "events.iterate.com/slack/webhook-received",
+    ]);
+    const configurations = events.filter(
+      (event) => event.type === "events.iterate.com/stream/subscription-configured",
+    );
+    expect(configurations).toHaveLength(2);
+    expect(configurations[1]).toMatchObject({
+      payload: {
+        subscriptionKey: SUBSCRIPTION_KEY,
+        delivery: {
+          mode: "wake",
+          expression: [
+            "integrations",
+            "slack",
+            ["get", CONNECTION],
+            "processor",
+            "wakeStreamSubscriber",
+          ],
+          processorSlug: "slack",
+        },
+      },
+    });
+    expect(events.map((event) => event.idempotencyKey)).toEqual([
+      `slack-router-subscription:${PROJECT_ID}:${CONNECTION}`,
+      expect.stringContaining("integration-router-subscription:"),
+      "slack-webhook:one",
+      "slack-webhook:two",
+    ]);
+  });
+});

--- a/apps/os/src/domains/integrations/integration-streams.ts
+++ b/apps/os/src/domains/integrations/integration-streams.ts
@@ -6,8 +6,10 @@
 // authority; caller-facing confinement stays in rpc-targets.ts.
 
 import { itxEnv } from "../../env.ts";
+import type { ItxExpression } from "../../itx/expression.ts";
 import { DurableObjectNameCodec } from "../durable-object-names.ts";
 import type { StreamEvent } from "../streams/schemas.ts";
+import { buildDurableObjectProcessorSubscriptionConfiguredEvent } from "../streams/utils.ts";
 import {
   CONNECTION_CLAIMED_EVENT_TYPE,
   CONNECTION_UNCLAIMED_EVENT_TYPE,
@@ -128,6 +130,44 @@ export async function lookupConnectionClaim(
   return foldConnectionDirectory(events).get(directoryKey(slug, externalId)) ?? null;
 }
 
+/**
+ * The desired durable subscription from an integration connection journal to
+ * its router processor. Both connect and ingress use this one builder: connect
+ * arms a fresh stream, while every webhook idempotently reconciles connections
+ * that predate the current itx expression shape.
+ *
+ * The idempotency key fingerprints the persisted capability name itself. A
+ * future expression or processor-slug change therefore appends one replacement
+ * configuration per connection automatically, without a hand-written data
+ * migration. The key is stream-local, so it needs no project/path prefix.
+ */
+export function buildIntegrationRouterSubscriptionConfiguredEvent(input: {
+  connection: string;
+  processorSlug: string;
+  projectId: string;
+  slug: string;
+}) {
+  const streamPath = integrationConnectionStreamPath(input.slug, input.connection);
+  const processor = [
+    "integrations",
+    input.slug,
+    ["get", input.connection],
+    "processor",
+  ] satisfies ItxExpression;
+  return buildDurableObjectProcessorSubscriptionConfiguredEvent({
+    durableObjectName: DurableObjectNameCodec.stringify({
+      projectId: input.projectId,
+      path: streamPath,
+    }),
+    idempotencyKey: `integration-router-subscription:${JSON.stringify({
+      processor,
+      processorSlug: input.processorSlug,
+    })}`,
+    processor,
+    processorSlug: input.processorSlug,
+  });
+}
+
 /** The outcome of routing one inbound webhook: delivered to a connection, or
  * `ignored` because no project has claimed its external id (the caller ACKs the
  * ignored case with a 200 — see the webhook handlers' cardinal rule). */
@@ -138,7 +178,10 @@ type RouteIntegrationWebhookResult =
 /**
  * Route one validly-signed webhook to the project + connection that claimed its
  * `(slug, externalId)`, by appending a provider-shaped event to that
- * connection's stream. `ignored` (no live claim) lets the door ACK-and-drop.
+ * connection's stream. Providers with a connection-stream router also supply
+ * its processor slug: the same append then reconciles the desired durable
+ * subscription BEFORE the webhook fact, so old parked connections repair on
+ * their next delivery. `ignored` (no live claim) lets the door ACK-and-drop.
  * This is the generic core of the webhook door (D4): per-provider code does
  * only the signature verify, external-id extract, and event shaping; routing is
  * one function for every integration.
@@ -146,14 +189,25 @@ type RouteIntegrationWebhookResult =
 export async function routeIntegrationWebhook(input: {
   event: { idempotencyKey: string; payload: Record<string, unknown>; type: string };
   externalId: string;
+  routerProcessorSlug?: string;
   slug: string;
 }): Promise<RouteIntegrationWebhookResult> {
   const claim = await lookupConnectionClaim(input.slug, input.externalId);
   if (claim === null) return { ignored: "external-id-not-claimed", ok: true };
-  await integrationStreamStub(
-    claim.projectId,
-    integrationConnectionStreamPath(input.slug, claim.connection),
-  ).append(input.event);
+  const streamPath = integrationConnectionStreamPath(input.slug, claim.connection);
+  await integrationStreamStub(claim.projectId, streamPath).append(
+    ...(input.routerProcessorSlug === undefined
+      ? []
+      : [
+          buildIntegrationRouterSubscriptionConfiguredEvent({
+            connection: claim.connection,
+            processorSlug: input.routerProcessorSlug,
+            projectId: claim.projectId,
+            slug: input.slug,
+          }),
+        ]),
+    input.event,
+  );
   return { connection: claim.connection, ok: true, projectId: claim.projectId };
 }
 

--- a/apps/os/src/domains/integrations/integration-webhook-api.test.ts
+++ b/apps/os/src/domains/integrations/integration-webhook-api.test.ts
@@ -164,6 +164,7 @@ describe("handleIntegrationWebhookApiRequest (slack + routing)", () => {
     const call = routeIntegrationWebhook.mock.calls[0]![0];
     expect(call.slug).toBe("slack");
     expect(call.externalId).toBe("T42");
+    expect(call.routerProcessorSlug).toBe("slack");
     expect(call.event.type).toBe("events.iterate.com/slack/webhook-received");
     expect(call.event.idempotencyKey).toBe("slack-webhook:Ev1");
     expect(call.event.payload).toMatchObject({ slackTeamId: "T42" });

--- a/apps/os/src/domains/integrations/slack-webhook.ts
+++ b/apps/os/src/domains/integrations/slack-webhook.ts
@@ -21,6 +21,7 @@
 // flood us with writes.
 
 import { routeIntegrationWebhook } from "./integration-streams.ts";
+import { SlackProcessorContract } from "./slack-processor-contract.ts";
 import { verifySlackSignature } from "./slack-signature.ts";
 import { parseJsonRecord, readString, SLACK_WEBHOOK_RECEIVED_EVENT_TYPE } from "./utils.ts";
 import type { AppConfig } from "~/config.ts";
@@ -77,6 +78,7 @@ export async function fetchSlackWebhook(input: {
       type: SLACK_WEBHOOK_RECEIVED_EVENT_TYPE,
     },
     externalId: teamId,
+    routerProcessorSlug: SlackProcessorContract.slug,
     slug: "slack",
   });
   if ("ignored" in result) return Response.json({ ignored: result.ignored, ok: true });

--- a/apps/os/src/domains/integrations/telegram-webhook.test.ts
+++ b/apps/os/src/domains/integrations/telegram-webhook.test.ts
@@ -27,6 +27,7 @@ describe("fetchTelegramWebhook", () => {
     expect(routed[0]).toMatchObject({
       slug: "telegram",
       externalId: BOT_ID,
+      routerProcessorSlug: "telegram",
       event: {
         idempotencyKey: `telegram-webhook:${BOT_ID}:1001`,
         type: "events.iterate.com/telegram/webhook-received",

--- a/apps/os/src/domains/integrations/telegram-webhook.ts
+++ b/apps/os/src/domains/integrations/telegram-webhook.ts
@@ -20,6 +20,7 @@
 import { itxEnv } from "../../env.ts";
 import { timingSafeStringEqual } from "../secrets/utils.ts";
 import { routeIntegrationWebhook } from "./integration-streams.ts";
+import { TelegramProcessorContract } from "./telegram-processor-contract.ts";
 import {
   TELEGRAM_WEBHOOK_RECEIVED_EVENT_TYPE,
   parseJsonRecord,
@@ -76,6 +77,7 @@ export function createTelegramWebhookFetch(deps: TelegramWebhookDeps) {
         type: TELEGRAM_WEBHOOK_RECEIVED_EVENT_TYPE,
       },
       externalId: botId,
+      routerProcessorSlug: TelegramProcessorContract.slug,
       slug: "telegram",
     });
     if ("ignored" in result) return Response.json({ ignored: result.ignored, ok: true });


### PR DESCRIPTION
## Incident

The production Slack message at https://iterate-com.slack.com/archives/C08R1SMTZGD/p1784009512176919 was signed, accepted with HTTP 200, and appended to the iterate project connection journal, but never reached its Slack-backed agent stream.

The existing router subscription was parked at offset 438 after 15 attempts with:

```
The RPC receiver does not implement the method "t0675psn873".
```

PR #1942 correctly changed collection access from a property walk to an explicit get call, but connect-time subscription configuration reused the old idempotency key. Existing connection journals therefore retained the stale persisted expression and were not migrated. This was not a Slack token refresh failure.

Production trace: https://dash.cloudflare.com/04b3b57291ef2626c6a8daa9d47065a7/observability/traces/6b1a4c2cfbc7c44cdebadb06589a8a97

## Fix

- Build Slack and Telegram router subscriptions through one desired-state helper.
- Fingerprint the actual processor expression and processor slug in the configuration idempotency key, so future expression changes create one replacement configuration automatically.
- Reconcile that desired configuration in the same append, before every routed webhook. Existing parked connections therefore self-migrate on their next event, while normal events dedupe the configuration.
- Use the same builder when a connection is first recorded.
- Add a regression that starts with the exact stale production expression, routes two webhooks, and proves one replacement configuration is committed atomically before the first webhook.

## Production repair

I appended the corrected subscription configuration to the affected iterate Slack connection. It replayed the two missed mentions, cleared the parked state, routed the reported message, and Slack echoed the posted reply: “Got it — the answer is 57.” The bot also added its eyes reaction, confirming the stored bot token is valid.

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- 139 integration-domain tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches inbound webhook routing and stream subscription configuration for Slack/Telegram; behavior is additive (extra idempotent append) but affects live message delivery paths.
> 
> **Overview**
> Fixes integration webhooks that were journaled but never reached agents because **stale** `subscription-configured` events kept an old processor **itx expression** (property walk) after connect reused a fixed idempotency key.
> 
> Introduces **`buildIntegrationRouterSubscriptionConfiguredEvent`**, shared by connect and routing, with the desired `["get", connection]` expression and an idempotency key that **fingerprints** the processor expression + slug so expression changes append a replacement config without a migration.
> 
> **`routeIntegrationWebhook`** optionally takes `routerProcessorSlug`; Slack and Telegram pass it so each routed webhook **atomically** appends subscription reconciliation **before** the webhook fact—stale connections self-repair on the next event, with dedupe on later deliveries. Connect flows only pass `processorSlug` now (no hand-built processor/idempotency at each provider).
> 
> Adds a regression test for stale property-walk → one replacement config on first webhook, plus webhook API test expectations for `routerProcessorSlug`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b80021e75704e6b67989048006e0f28f4095ebb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +68 -20 | +52 -18 🟩🟥⬜⬜⬜ |
| Tests | +149 -0 | +141 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+217 -20** | **+193 -18** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 36ad445 and 6b80021, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->