### PR TITLE
Harden Depot mainline runner reliability

### DIFF
--- a/.depot/workflows/autofix.yml
+++ b/.depot/workflows/autofix.yml
@@ -6,11 +6,15 @@ on:
       - main
       - "**/*autofix*"
       - "*autofix*"
+concurrency:
+  group: autofix-${{ github.head_ref || github.ref_name || github.run_id }}
+  cancel-in-progress: true
 jobs:
   autofix:
     runs-on:
-      size: 8x32
+      size: 2x8
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.depot/workflows/build-preview-ci-image.yml
+++ b/.depot/workflows/build-preview-ci-image.yml
@@ -2,12 +2,11 @@ name: Build Preview CI Image
 
 on:
   schedule:
-    # Weekly (Mondays 04:17 UTC). This image has no consumer today — the
-    # preview workflow runs on Depot CI's standard runners, not this snapshot
-    # — so a daily bake was spending compute on an unused artifact. Weekly
-    # keeps it available and reasonably fresh; make it daily again (or delete
-    # this workflow) only once something actually consumes the image. See
-    # docs/ci-preview-performance.md.
+    # Weekly (Mondays 04:17 UTC). Mainline checks and production deploys use
+    # this snapshot; preview deploy/e2e uses Depot's standard runners. The
+    # reconcile step in each consumer validates the baked workspace against
+    # the checked-out lockfile, so weekly baking keeps startup fast without a
+    # daily image build. See docs/depot-ci.md.
     - cron: "17 4 * * 1"
   workflow_dispatch: {}
 

--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -2,16 +2,30 @@ name: CI
 permissions:
   contents: read
   deployments: write
+concurrency:
+  # Every run updates the same production Worker. Let an active deployment
+  # finish, while allowing Depot to coalesce queued runs to the newest commit.
+  group: deploy-iterate-com-production
+  cancel-in-progress: false
 on:
   push:
     branches:
       - main
+    paths:
+      - .depot/workflows/ci.yml
+      - .agents/skills/**
+      - apps/iterate-com/**
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - patches/**
   workflow_dispatch: {}
 jobs:
   deploy-iterate-com:
     runs-on:
-      size: 8x32
+      size: 2x8
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -33,8 +47,9 @@ jobs:
       - deploy-iterate-com
     if: always() && contains(needs.*.result, 'failure')
     runs-on:
-      size: 8x32
+      size: 2x8
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    timeout-minutes: 10
     env:
       NEEDS: ${{ toJson(needs) }}
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}

--- a/.depot/workflows/deploy-auth.yml
+++ b/.depot/workflows/deploy-auth.yml
@@ -3,8 +3,10 @@ permissions:
   contents: read
   deployments: write
 concurrency:
-  group: auth-dev-global-${{ github.ref_name || 'dev_global' }}
-  cancel-in-progress: true
+  # Every ref deploys to the same dev_global Worker. Never interrupt a
+  # credentialed deployment midway through its rollout.
+  group: deploy-auth-dev-global
+  cancel-in-progress: false
 on:
   push:
     branches:
@@ -28,8 +30,9 @@ on:
 jobs:
   deploy-dev-global:
     runs-on:
-      size: 8x32
+      size: 2x8
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.depot/workflows/deploy-os.yml
+++ b/.depot/workflows/deploy-os.yml
@@ -35,8 +35,9 @@ on:
 jobs:
   deploy:
     runs-on:
-      size: 8x32
+      size: 4x16
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    timeout-minutes: 45
     outputs:
       public_url: ${{ steps.metadata.outputs.public_url }}
     steps:
@@ -105,8 +106,9 @@ jobs:
       - deploy
     if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on:
-      size: 8x32
+      size: 2x8
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    timeout-minutes: 10
     env:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
     steps:

--- a/.depot/workflows/deploy-semaphore.yml
+++ b/.depot/workflows/deploy-semaphore.yml
@@ -3,8 +3,10 @@ permissions:
   contents: read
   deployments: write
 concurrency:
-  group: semaphore-${{ github.ref_name || 'prd' }}
-  cancel-in-progress: true
+  # Every ref deploys to the same production Worker. Never interrupt a
+  # credentialed deployment midway through its rollout.
+  group: deploy-semaphore-production
+  cancel-in-progress: false
 on:
   push:
     branches:
@@ -13,6 +15,8 @@ on:
       - .depot/workflows/deploy-semaphore.yml
       - envs.ts
       - scripts/lib/**
+      - apps/auth/**
+      - apps/auth-contract/**
       - apps/semaphore/**
       - packages/shared/**
       - packages/ui/**
@@ -26,8 +30,9 @@ on:
 jobs:
   deploy:
     runs-on:
-      size: 8x32
+      size: 2x8
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    timeout-minutes: 20
     outputs:
       public_url: ${{ steps.metadata.outputs.public_url }}
     steps:
@@ -62,8 +67,9 @@ jobs:
       - deploy
     if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (needs.deploy.result == 'success' || needs.deploy.result == 'failure')
     runs-on:
-      size: 8x32
+      size: 2x8
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    timeout-minutes: 10
     env:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
     steps:

--- a/.depot/workflows/deploy-streams-example-app.yml
+++ b/.depot/workflows/deploy-streams-example-app.yml
@@ -3,8 +3,10 @@ permissions:
   contents: read
   deployments: write
 concurrency:
-  group: streams-example-app-${{ github.ref_name || 'prd' }}
-  cancel-in-progress: true
+  # Every ref deploys to the same production Worker. Never interrupt a
+  # credentialed deployment midway through its rollout.
+  group: deploy-streams-example-app-production
+  cancel-in-progress: false
 on:
   push:
     branches:
@@ -13,6 +15,8 @@ on:
       - .depot/workflows/deploy-streams-example-app.yml
       - envs.ts
       - scripts/lib/**
+      - apps/auth/**
+      - apps/auth-contract/**
       - apps/streams-example-app/**
       - apps/os/src/domains/streams/**
       - packages/shared/**
@@ -27,8 +31,9 @@ on:
 jobs:
   deploy:
     runs-on:
-      size: 8x32
+      size: 2x8
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    timeout-minutes: 20
     outputs:
       public_url: ${{ steps.metadata.outputs.public_url }}
     steps:
@@ -63,8 +68,9 @@ jobs:
       - deploy
     if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (needs.deploy.result == 'success' || needs.deploy.result == 'failure')
     runs-on:
-      size: 8x32
+      size: 2x8
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    timeout-minutes: 10
     env:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
     steps:

--- a/.depot/workflows/deploy-tunnels.yml
+++ b/.depot/workflows/deploy-tunnels.yml
@@ -3,13 +3,16 @@ permissions:
   contents: read
   deployments: write
 concurrency:
-  group: tunnels-${{ github.ref_name || 'prd' }}
-  cancel-in-progress: true
+  # Every ref deploys to the same production Worker. Never interrupt a
+  # credentialed deployment midway through its rollout.
+  group: deploy-tunnels-production
+  cancel-in-progress: false
 on:
   push:
     branches:
       - main
     paths:
+      - .depot/workflows/deploy-tunnels.yml
       - apps/tunnels/**
       - envs.ts
       - scripts/lib/**
@@ -25,8 +28,9 @@ on:
 jobs:
   deploy:
     runs-on:
-      size: 8x32
+      size: 2x8
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.depot/workflows/lint-typecheck.yml
+++ b/.depot/workflows/lint-typecheck.yml
@@ -5,16 +5,17 @@ on:
       - main
   pull_request: {}
   workflow_dispatch: {}
-# Cancel a PR's in-flight run when a newer commit supersedes it (see test.yml).
-# head_ref is empty on main pushes, so run_id keeps those runs distinct.
+# Cancel a branch's in-flight run when a newer commit supersedes it. PRs use
+# head_ref; main and manual runs use ref_name.
 concurrency:
-  group: lint-typecheck-${{ github.head_ref || github.run_id }}
+  group: lint-typecheck-${{ github.head_ref || github.ref_name || github.run_id }}
   cancel-in-progress: true
 jobs:
   lint-typecheck:
     runs-on:
       size: 8x32
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.depot/workflows/test.yml
+++ b/.depot/workflows/test.yml
@@ -4,18 +4,17 @@ on:
     branches:
       - main
   pull_request: {}
-# Rapid pushes to a PR supersede each other: cancel the in-flight run for the
-# same branch so a new commit doesn't leave a stale run burning CI. Keyed by
-# head_ref (the PR's source branch) so PRs cancel per-branch; on main pushes
-# head_ref is empty and run_id is unique, so main runs never cancel each other.
+# Rapid pushes to a branch supersede each other. On PRs, head_ref identifies
+# the source branch; on main, ref_name keeps only the newest validation run.
 concurrency:
-  group: test-${{ github.head_ref || github.run_id }}
+  group: test-${{ github.head_ref || github.ref_name || github.run_id }}
   cancel-in-progress: true
 jobs:
   test:
     runs-on:
       size: 8x32
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/docs/depot-ci.md
+++ b/docs/depot-ci.md
@@ -68,7 +68,7 @@ Fetch logs and diagnostics:
 ```bash
 depot ci logs <attempt-id> --org 0p91s0lz49
 depot ci logs <job-id> --org 0p91s0lz49 --follow
-depot ci metrics <run-id> --org 0p91s0lz49
+depot ci metrics --run <run-id> --org 0p91s0lz49
 depot ci diagnose <run-id> --org 0p91s0lz49
 depot ci summary <attempt-id> --org 0p91s0lz49
 ```
@@ -228,17 +228,52 @@ Use Depot-specific features where they make the workflow clearer:
 - independent checks can use Depot `parallel:` blocks with `fail-fast: false`;
 - workflow runtime logic belongs in `scripts/ci`, not in long YAML strings.
 
+### Reliability defaults
+
+Mainline workflows deliberately separate deployment safety from validation
+freshness:
+
+- A credentialed deploy uses one fixed concurrency group named for its actual
+  destination, such as `deploy-auth-os-production`. It always sets
+  `cancel-in-progress: false`. The checked-out branch is not the destination,
+  so it must not appear in that group name. An active rollout finishes; if
+  several newer commits queue behind it, Depot keeps the newest pending run.
+- Tests, lint/typecheck, and autofix use the source branch (falling back to
+  `ref_name`) and `cancel-in-progress: true`. A newer commit makes an older
+  validation result obsolete, including on `main`.
+- Every mainline job has `timeout-minutes`. This is a watchdog, not a retry:
+  jobs fail at the outer edge and an operator decides whether a rerun is safe.
+  Auth + OS gets 45 minutes because its bounded worst case includes both
+  deployments, JWKS propagation, and four sequential smoke probes.
+- Runner size follows observed peak CPU and memory, with headroom. Lint stays
+  on `8x32`; Auth + OS deploy uses `4x16`; short deploy, notification, and
+  autofix jobs use `2x8`. Re-check with `depot ci metrics --run <run-id>` before
+  increasing a size.
+
+These defaults keep a normal all-app main push to 32 requested vCPUs before
+notification jobs, down from 72, without reducing the parallel lint lane that
+uses the larger machine. Path filters avoid deploying iterate.com for unrelated
+monorepo changes.
+
+If an attempt receives a sandbox but produces no logs or metrics before
+failing, inspect `depot ci status`, `logs`, `metrics`, and `diagnose`. When the
+same commit and image pass on rerun, treat that as runner provisioning evidence,
+not an application failure. Do not add automatic workflow retries: deployment
+reruns can repeat external side effects and need an operator decision.
+
 ## Custom Image
 
 The baked image is built by `.depot/workflows/build-preview-ci-image.yml` using
 `scripts/depot-ci/bake-preview-ci-image.sh`.
 
 It contains Node, pnpm, workspace dependencies, Doppler CLI, and the preview
-browser. Jobs that consume it must keep:
+browser. A snapshot is independent of sandbox size: choose `2x8`, `4x16`, or
+`8x32` from measured workload demand. Jobs that consume it must keep the image
+and checkout behavior:
 
 ```yaml
 runs-on:
-  size: 8x32
+  size: 2x8 # workload-specific
   image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
 steps:
   - uses: actions/checkout@v4

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -179,17 +179,17 @@ only on genuine infra wedges).
 
 ### The ladder
 
-| What it bounds             | Knob                                  | Where                                                                | Value                          | On expiry                   |
-| -------------------------- | ------------------------------------- | -------------------------------------------------------------------- | ------------------------------ | --------------------------- |
-| One UI action              | `actionTimeout` + spinner-waiter      | `playwright.config.ts` ← `SPEC_ACTION_TIMEOUT_MS`                    | 750ms (→ ~30s with spinner)    | fail the attempt            |
-| One assertion              | `expect.timeout`                      | `playwright.config.ts` ← `SPEC_EXPECT_TIMEOUT_MS`                    | 15s                            | fail the attempt            |
-| One Playwright spec        | `timeout`                             | `playwright.config.ts` ← `SPEC_TEST_TIMEOUT_MS`                      | 90s                            | retry once (CI)             |
-| One vitest e2e test/hook   | `testTimeout` / `hookTimeout`         | `apps/os/e2e/vitest.config.ts` ← `E2E_TEST_TIMEOUT_MS`               | 120s                           | retry once (CI)             |
-| A container-cold-boot test | per-test `{ timeout }`                | individual tests, capped at `E2E_HEAVY_TEST_TIMEOUT_MS`              | ≤ 240s                         | retry once (CI)             |
-| The onboarding smoke gate  | attempt loop                          | `apps/os/e2e/vitest/onboarding-smoke.ts`                             | 90s greeting wait              | one more attempt, then fail |
-| The preview vitest lane    | `timeout N pnpm e2e`                  | `scripts/preview/preview.ts` ← `OS_PREVIEW_VITEST_LANE_TIMEOUT_SECS` | 360s                           | **fail — never retry**      |
-| One whole preview run      | `RUN_TIMEOUT_SECS` kill-tree watchdog | `scripts/preview/flake-hunt-loop.sh` ← `PREVIEW_RUN_WATCHDOG_SECS`   | 600s                           | **kill — never retry**      |
-| The Depot CI job           | `timeout-minutes`                     | `.depot/workflows/*.yml`                                             | 30 (previews) / 300 (marathon) | outer edge: re-run button   |
+| What it bounds             | Knob                                  | Where                                                                | Value                                     | On expiry                   |
+| -------------------------- | ------------------------------------- | -------------------------------------------------------------------- | ----------------------------------------- | --------------------------- |
+| One UI action              | `actionTimeout` + spinner-waiter      | `playwright.config.ts` ← `SPEC_ACTION_TIMEOUT_MS`                    | 750ms (→ ~30s with spinner)               | fail the attempt            |
+| One assertion              | `expect.timeout`                      | `playwright.config.ts` ← `SPEC_EXPECT_TIMEOUT_MS`                    | 15s                                       | fail the attempt            |
+| One Playwright spec        | `timeout`                             | `playwright.config.ts` ← `SPEC_TEST_TIMEOUT_MS`                      | 90s                                       | retry once (CI)             |
+| One vitest e2e test/hook   | `testTimeout` / `hookTimeout`         | `apps/os/e2e/vitest.config.ts` ← `E2E_TEST_TIMEOUT_MS`               | 120s                                      | retry once (CI)             |
+| A container-cold-boot test | per-test `{ timeout }`                | individual tests, capped at `E2E_HEAVY_TEST_TIMEOUT_MS`              | ≤ 240s                                    | retry once (CI)             |
+| The onboarding smoke gate  | attempt loop                          | `apps/os/e2e/vitest/onboarding-smoke.ts`                             | 90s greeting wait                         | one more attempt, then fail |
+| The preview vitest lane    | `timeout N pnpm e2e`                  | `scripts/preview/preview.ts` ← `OS_PREVIEW_VITEST_LANE_TIMEOUT_SECS` | 360s                                      | **fail — never retry**      |
+| One whole preview run      | `RUN_TIMEOUT_SECS` kill-tree watchdog | `scripts/preview/flake-hunt-loop.sh` ← `PREVIEW_RUN_WATCHDOG_SECS`   | 600s                                      | **kill — never retry**      |
+| The Depot CI job           | `timeout-minutes`                     | `.depot/workflows/*.yml`                                             | 10–45 (mainline/preview) / 300 (marathon) | outer edge: re-run button   |
 
 The ladder is strictly ordered and the guard test asserts it stays that way.
 Note the deliberate rule-3 consequence: the 360s lane watchdog does _not_

--- a/scripts/ci/depot-workflows.test.ts
+++ b/scripts/ci/depot-workflows.test.ts
@@ -1,0 +1,169 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+type WorkflowJob = {
+  "runs-on": {
+    image?: string;
+    size?: string;
+  };
+  "timeout-minutes"?: number;
+};
+
+type Workflow = {
+  concurrency?: {
+    group: string;
+    "cancel-in-progress": boolean;
+  };
+  jobs: Record<string, WorkflowJob>;
+  on?: {
+    push?: {
+      paths?: string[];
+    };
+  };
+};
+
+function loadWorkflow(file: string): Workflow {
+  return parseYaml(readFileSync(resolve(repoRoot, file), "utf8")) as Workflow;
+}
+
+const deploymentWorkflows = [
+  {
+    file: ".depot/workflows/ci.yml",
+    group: "deploy-iterate-com-production",
+    jobs: {
+      "deploy-iterate-com": { size: "2x8", timeoutMinutes: 20 },
+      slack_failure: { size: "2x8", timeoutMinutes: 10 },
+    },
+  },
+  {
+    file: ".depot/workflows/deploy-auth.yml",
+    group: "deploy-auth-dev-global",
+    jobs: {
+      "deploy-dev-global": { size: "2x8", timeoutMinutes: 20 },
+    },
+  },
+  {
+    file: ".depot/workflows/deploy-os.yml",
+    group: "deploy-auth-os-production",
+    jobs: {
+      deploy: { size: "4x16", timeoutMinutes: 45 },
+      notify: { size: "2x8", timeoutMinutes: 10 },
+    },
+  },
+  {
+    file: ".depot/workflows/deploy-semaphore.yml",
+    group: "deploy-semaphore-production",
+    jobs: {
+      deploy: { size: "2x8", timeoutMinutes: 20 },
+      notify: { size: "2x8", timeoutMinutes: 10 },
+    },
+  },
+  {
+    file: ".depot/workflows/deploy-streams-example-app.yml",
+    group: "deploy-streams-example-app-production",
+    jobs: {
+      deploy: { size: "2x8", timeoutMinutes: 20 },
+      notify: { size: "2x8", timeoutMinutes: 10 },
+    },
+  },
+  {
+    file: ".depot/workflows/deploy-tunnels.yml",
+    group: "deploy-tunnels-production",
+    jobs: {
+      deploy: { size: "2x8", timeoutMinutes: 20 },
+    },
+  },
+] as const;
+
+describe("Depot deployment safety", () => {
+  it.each(deploymentWorkflows)(
+    "$file serializes the destination without cancelling an active deploy",
+    ({ file, group, jobs }) => {
+      const workflow = loadWorkflow(file);
+
+      expect(workflow.concurrency).toEqual({
+        group,
+        "cancel-in-progress": false,
+      });
+      expect(Object.keys(workflow.jobs).sort()).toEqual(Object.keys(jobs).sort());
+
+      for (const [jobId, expected] of Object.entries(jobs)) {
+        const job = workflow.jobs[jobId];
+        expect(job, `${file} is missing job ${jobId}`).toBeDefined();
+        expect(job["runs-on"].size).toBe(expected.size);
+        expect(job["runs-on"].image).toBe(
+          "0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree",
+        );
+        expect(job["timeout-minutes"]).toBe(expected.timeoutMinutes);
+      }
+    },
+  );
+
+  it("deploys iterate.com only for inputs that can change its artifact", () => {
+    const workflow = loadWorkflow(".depot/workflows/ci.yml");
+
+    expect(workflow.on?.push?.paths).toEqual([
+      ".depot/workflows/ci.yml",
+      ".agents/skills/**",
+      "apps/iterate-com/**",
+      "package.json",
+      "pnpm-lock.yaml",
+      "pnpm-workspace.yaml",
+      "patches/**",
+    ]);
+  });
+
+  it("redeploys tunnels when its workflow changes", () => {
+    const workflow = loadWorkflow(".depot/workflows/deploy-tunnels.yml");
+
+    expect(workflow.on?.push?.paths).toContain(".depot/workflows/deploy-tunnels.yml");
+  });
+
+  it.each([
+    ".depot/workflows/deploy-semaphore.yml",
+    ".depot/workflows/deploy-streams-example-app.yml",
+  ])("$file redeploys when its bundled Auth workspace code changes", (file) => {
+    const workflow = loadWorkflow(file);
+
+    expect(workflow.on?.push?.paths).toEqual(
+      expect.arrayContaining(["apps/auth/**", "apps/auth-contract/**"]),
+    );
+  });
+});
+
+describe("Depot validation capacity", () => {
+  it.each([
+    {
+      file: ".depot/workflows/test.yml",
+      group: "test-${{ github.head_ref || github.ref_name || github.run_id }}",
+      jobId: "test",
+      size: "8x32",
+      timeoutMinutes: 20,
+    },
+    {
+      file: ".depot/workflows/lint-typecheck.yml",
+      group: "lint-typecheck-${{ github.head_ref || github.ref_name || github.run_id }}",
+      jobId: "lint-typecheck",
+      size: "8x32",
+      timeoutMinutes: 20,
+    },
+    {
+      file: ".depot/workflows/autofix.yml",
+      group: "autofix-${{ github.head_ref || github.ref_name || github.run_id }}",
+      jobId: "autofix",
+      size: "2x8",
+      timeoutMinutes: 15,
+    },
+  ])("$file coalesces superseded branch runs", ({ file, group, jobId, size, timeoutMinutes }) => {
+    const workflow = loadWorkflow(file);
+    const job = workflow.jobs[jobId];
+
+    expect(workflow.concurrency).toEqual({ group, "cancel-in-progress": true });
+    expect(job["runs-on"].size).toBe(size);
+    expect(job["timeout-minutes"]).toBe(timeoutMinutes);
+  });
+});


### PR DESCRIPTION
## Summary

- right-size mainline Depot jobs from a burst of nine `8x32` sandboxes to workload-appropriate `2x8`, `4x16`, and `8x32` shapes
- serialize credentialed deploys by their real destination with `cancel-in-progress: false`; coalesce superseded test, lint/typecheck, and autofix runs by branch
- add explicit job watchdogs, narrow iterate.com deploy triggers, and repair missing tunnels/Auth/skills trigger dependencies
- add structured YAML invariants and document the operating model and provisioning-failure diagnosis

## Why

A main push requested 72 vCPUs / 288 GB across nine independent custom-image jobs. Seven first attempts received Depot sandbox IDs but produced no logs or metrics before `Sandbox terminated before worker reported completion`; retries of the same commit and image passed. Successful-run metrics showed the small deploy and notification jobs using roughly 0.4-1.5 cores and 1.3-2.1 GB, while only lint materially used the `8x32` machine.

This reduces the initial all-app burst to 32 vCPUs while preserving the lint lane's measured parallelism. It does not add automatic retries: deployment reruns can repeat external side effects and remain an operator decision.

## Deployment safety

- concurrency groups are fixed per destination, never per source ref
- active credentialed deploys are never cancelled
- Auth + OS keeps a 45-minute outer watchdog because its bounded worst case includes both deploys, JWKS propagation, and four sequential smoke probes
- iterate.com now tracks `.agents/skills/**`
- Semaphore and Streams redeploy for bundled Auth/Auth Contract changes

## Verification

- `pnpm test`: 143 OS test files passed, 1 skipped; 1,376 tests passed, 1 skipped, plus all other workspace suites
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm knip`
- `pnpm --dir scripts exec vitest run ci/depot-workflows.test.ts`: 13 passed
- live Depot custom-image probe on `2x8`: run `6f9djhsdt0`, first-attempt success; workspace reconcile 6.5s, peak CPU 27%, peak memory 12%

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +169 -0 | +153 -0 🟩🟩🟩🟩🟩 |
| CI & scripts | +72 -33 | +72 -33 🟩🟩🟥⬜⬜ |
| Docs | +49 -14 | +44 -14 🟩🟩⬜⬜⬜ |
| **Total** | **+290 -47** | **+269 -47** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 7736693 and a2b4d85, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->