### PR TITLE
Fix stream-page hydration mismatch

### DIFF
--- a/apps/os/src/lib/route-breadcrumbs.test.ts
+++ b/apps/os/src/lib/route-breadcrumbs.test.ts
@@ -1,0 +1,25 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const appSourceRoot = resolve(import.meta.dirname, "..");
+const appRoutesRoot = resolve(appSourceRoot, "routes/_app");
+
+function routeFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) return routeFiles(path);
+    return entry.isFile() && entry.name.endsWith(".tsx") ? [path] : [];
+  });
+}
+
+describe("stream page route metadata", () => {
+  it("marks every stream-breadcrumb route before its client-only loader runs", () => {
+    const missingStaticMarker = routeFiles(appRoutesRoot)
+      .filter((path) => readFileSync(path, "utf8").includes("streamBreadcrumb("))
+      .filter((path) => !readFileSync(path, "utf8").includes("staticData: streamPageStaticData()"))
+      .map((path) => relative(appSourceRoot, path));
+
+    expect(missingStaticMarker).toEqual([]);
+  });
+});

--- a/apps/os/src/routes/_app/projects/$projectSlug/agents/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/agents/index.tsx
@@ -4,7 +4,11 @@ import { buttonVariants } from "@iterate-com/ui/components/button";
 import { ItxBoundary } from "~/components/itx-boundary.tsx";
 import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import { StreamTree } from "~/components/stream-tree.tsx";
-import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
+import {
+  breadcrumbLoaderData,
+  streamBreadcrumb,
+  streamPageStaticData,
+} from "~/lib/route-breadcrumbs.ts";
 import { linkOptionsForStreamPath } from "~/lib/stream-routes.ts";
 import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 import { useItx } from "~/itx/itx-react.tsx";
@@ -12,6 +16,7 @@ import { useItx } from "~/itx/itx-react.tsx";
 const AGENTS_ROOT = "/agents";
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/agents/")({
+  staticData: streamPageStaticData(),
   // Agents ARE streams: this page is the /agents catalogue stream's view, with
   // the live agent tree in the side panel. useItx never SSRs (it throws on the
   // server), and the tree paints from its own live subscriptions once the

--- a/apps/os/src/routes/_app/projects/$projectSlug/agents/streams/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/agents/streams/$.tsx
@@ -4,11 +4,16 @@ import { ItxBoundary } from "~/components/itx-boundary.tsx";
 import { ONBOARDING_AGENT_PATH } from "~/lib/onboarding-agent.ts";
 import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import { connectItxBrowser } from "~/itx/itx-react.tsx";
-import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
+import {
+  breadcrumbLoaderData,
+  streamBreadcrumb,
+  streamPageStaticData,
+} from "~/lib/route-breadcrumbs.ts";
 import { streamPathFromSplat, streamPathToSplat } from "~/lib/stream-links.ts";
 import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/agents/streams/$")({
+  staticData: streamPageStaticData(),
   params: {
     parse: (raw) => ({
       _splat: streamPathFromSplat(raw._splat),

--- a/apps/os/src/routes/_app/projects/$projectSlug/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/index.tsx
@@ -9,7 +9,11 @@ import { ProjectSettingsPanel } from "~/components/project-settings-panel.tsx";
 import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import { ONBOARDING_AGENT_PATH, isOnboardingActive } from "~/lib/onboarding-agent.ts";
 import { getPublicRouteConfig } from "~/lib/public-route-config.ts";
-import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
+import {
+  breadcrumbLoaderData,
+  streamBreadcrumb,
+  streamPageStaticData,
+} from "~/lib/route-breadcrumbs.ts";
 import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 import { useLiveState } from "~/itx/itx-react.tsx";
 
@@ -20,6 +24,7 @@ const HomeSearch = StreamViewSearch.extend({
 });
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/")({
+  staticData: streamPageStaticData(),
   validateSearch: HomeSearch,
   ssr: false,
   loader: async ({ context }) =>

--- a/apps/os/src/routes/_app/projects/$projectSlug/repos/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/repos/$.tsx
@@ -4,7 +4,11 @@ import { InfoRow } from "~/components/info-row.tsx";
 import { ItxBoundary } from "~/components/itx-boundary.tsx";
 import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import { RepoIde } from "~/components/repo-ide/repo-ide.lazy.tsx";
-import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
+import {
+  breadcrumbLoaderData,
+  streamBreadcrumb,
+  streamPageStaticData,
+} from "~/lib/route-breadcrumbs.ts";
 import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 import { useLiveState } from "~/itx/itx-react.tsx";
 
@@ -24,6 +28,7 @@ const RepoDetailSearch = StreamViewSearch.extend({
 });
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/repos/$")({
+  staticData: streamPageStaticData(),
   validateSearch: RepoDetailSearch,
   ssr: false,
   loader: ({ context, params }) =>

--- a/apps/os/src/routes/_app/projects/$projectSlug/repos/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/repos/index.tsx
@@ -30,7 +30,11 @@ import { RepoArtifactNameCodec } from "~/domains/repos/utils.ts";
 import { buildCloudflareArtifactDashboardUrl } from "~/lib/artifact-viewer-url.ts";
 import { formatTimeAgo } from "~/lib/format-relative-time.ts";
 import { getPublicRouteConfig } from "~/lib/public-route-config.ts";
-import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
+import {
+  breadcrumbLoaderData,
+  streamBreadcrumb,
+  streamPageStaticData,
+} from "~/lib/route-breadcrumbs.ts";
 import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 import { useItx, useLiveState } from "~/itx/itx-react.tsx";
 
@@ -50,6 +54,7 @@ type SortKey = "path" | "createdAt";
 type SortDirection = "asc" | "desc";
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/repos/")({
+  staticData: streamPageStaticData(),
   validateSearch: StreamViewSearch,
   ssr: false,
   loader: async ({ context }) =>

--- a/apps/os/src/routes/_app/projects/$projectSlug/sandboxes/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/sandboxes/index.tsx
@@ -11,7 +11,11 @@ import {
   inferOsDopplerConfigForWorkerName,
 } from "~/lib/cloudflare-containers-dashboard-url.ts";
 import { getPublicRouteConfig, type PublicRouteConfig } from "~/lib/public-route-config.ts";
-import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
+import {
+  breadcrumbLoaderData,
+  streamBreadcrumb,
+  streamPageStaticData,
+} from "~/lib/route-breadcrumbs.ts";
 import { linkOptionsForStreamPath } from "~/lib/stream-routes.ts";
 import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 import { useItx } from "~/itx/itx-react.tsx";
@@ -19,6 +23,7 @@ import { useItx } from "~/itx/itx-react.tsx";
 const SANDBOXES_ROOT = "/sandboxes";
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/sandboxes/")({
+  staticData: streamPageStaticData(),
   // Sandboxes ARE streams (a sandbox lives at /sandboxes/<name>):
   // this page is the /sandboxes catalogue stream's view, with the live
   // sandbox tree in the side panel.

--- a/apps/os/src/routes/_app/projects/$projectSlug/scheduler.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/scheduler.tsx
@@ -16,11 +16,16 @@ import { ItxBoundary } from "~/components/itx-boundary.tsx";
 import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import { SCHEDULER_PRIMARY_PATH } from "~/domains/scheduler/utils.ts";
 import { formatRelativeTime, formatTimeAgo } from "~/lib/format-relative-time.ts";
-import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
+import {
+  breadcrumbLoaderData,
+  streamBreadcrumb,
+  streamPageStaticData,
+} from "~/lib/route-breadcrumbs.ts";
 import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 import { useItx, useItxQuery } from "~/itx/itx-react.tsx";
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/scheduler")({
+  staticData: streamPageStaticData(),
   validateSearch: StreamViewSearch,
   ssr: false,
   loader: ({ context }) =>

--- a/apps/os/src/routes/_app/projects/$projectSlug/secrets/$secretId.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/secrets/$secretId.tsx
@@ -17,7 +17,11 @@ import type { SecretDescription, SecretUpdateInput } from "../../../../../domain
 import { InfoRow } from "~/components/info-row.tsx";
 import { ItxBoundary } from "~/components/itx-boundary.tsx";
 import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
-import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
+import {
+  breadcrumbLoaderData,
+  streamBreadcrumb,
+  streamPageStaticData,
+} from "~/lib/route-breadcrumbs.ts";
 import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 import { useItx, useLiveState } from "~/itx/itx-react.tsx";
 
@@ -27,6 +31,7 @@ const UpdateSecretForm = z.object({
 });
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/secrets/$secretId")({
+  staticData: streamPageStaticData(),
   validateSearch: StreamViewSearch,
   ssr: false,
   loader: ({ context, params }) =>

--- a/apps/os/src/routes/_app/projects/$projectSlug/secrets/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/secrets/index.tsx
@@ -28,7 +28,11 @@ import { Textarea } from "@iterate-com/ui/components/textarea";
 import { ItxBoundary } from "~/components/itx-boundary.tsx";
 import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import { formatTimeAgo } from "~/lib/format-relative-time.ts";
-import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
+import {
+  breadcrumbLoaderData,
+  streamBreadcrumb,
+  streamPageStaticData,
+} from "~/lib/route-breadcrumbs.ts";
 import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 import { useItx, useLiveState } from "~/itx/itx-react.tsx";
 
@@ -62,6 +66,7 @@ const parseEgressUrls = (raw: string): string[] =>
     .filter((url) => url !== "");
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/secrets/")({
+  staticData: streamPageStaticData(),
   validateSearch: StreamViewSearch,
   ssr: false,
   loader: ({ context }) =>

--- a/apps/os/src/routes/_app/projects/$projectSlug/streams/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/streams/$.tsx
@@ -2,11 +2,16 @@ import { createFileRoute } from "@tanstack/react-router";
 import { ItxBoundary } from "~/components/itx-boundary.tsx";
 import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import { useItx } from "~/itx/itx-react.tsx";
-import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
+import {
+  breadcrumbLoaderData,
+  streamBreadcrumb,
+  streamPageStaticData,
+} from "~/lib/route-breadcrumbs.ts";
 import { streamPathFromSplat, streamPathToSplat } from "~/lib/stream-links.ts";
 import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/streams/$")({
+  staticData: streamPageStaticData(),
   params: {
     parse: (raw) => ({
       _splat: streamPathFromSplat(raw._splat),

--- a/apps/os/src/routes/_app/projects/$projectSlug/streams/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/streams/index.tsx
@@ -1,10 +1,15 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { ItxBoundary } from "~/components/itx-boundary.tsx";
 import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
-import { breadcrumbLoaderData, streamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
+import {
+  breadcrumbLoaderData,
+  streamBreadcrumb,
+  streamPageStaticData,
+} from "~/lib/route-breadcrumbs.ts";
 import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/streams/")({
+  staticData: streamPageStaticData(),
   // The project root stream, full width. Stream NAVIGATION is ⌘K's job — the
   // pill in the header opens the one stream explorer; no tree panel here.
   validateSearch: StreamViewSearch,


### PR DESCRIPTION
## Summary

- mark every client-only stream route with the existing static `streamPage` route metadata
- keep the SSR shell and first client render in agreement before stream loaders run
- add a route-invariant test so any future `streamBreadcrumb` route must carry the static marker

## Production finding

Real-browser verification after #1952 exposed repeatable React error 418 on production project pages. The unminified local reproduction showed the server rendered the fallback shell header while the first client render omitted it for the same stream route. This follow-up fixes the route metadata rather than suppressing React errors or delaying hydration.

## Verification

- dedicated Chromium, production before fix: authenticated project rendered but emitted React hydration error 418
- dedicated Chromium, local after fix: project root and onboarding stream both rendered with zero page errors
- sibling-project navigation under a project-scoped production operator session rendered only the generic not-found boundary
- `pnpm test` (OS: 1,377 passed, 1 skipped; all workspaces green)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm knip`
- rebased onto current `origin/main` and reran the focused test, typecheck, and browser repro

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only route config plus a filesystem scan test; no auth, data, or stream logic changes.
> 
> **Overview**
> Fixes **React hydration error 418** on production project pages by ensuring the app shell agrees with the client on stream-page layout **before** client-only loaders run.
> 
> Every project route that uses `streamBreadcrumb` now sets **`staticData: streamPageStaticData()`** (`streamPage: true`). The `_app` layout already treats that flag like loader `streamBreadcrumb` data when deciding whether to render the generic shell header vs letting the stream view own the header—without the marker, SSR showed the fallback header while the first client paint did not.
> 
> A new **route invariant test** (`route-breadcrumbs.test.ts`) fails CI if any `routes/_app` file calls `streamBreadcrumb(` without `staticData: streamPageStaticData()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1783c34a362b613427202ef168220a029df82636. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +66 -11 | +66 -11 🟩🟩🟩🟩🟥 |
| Tests | +25 -0 | +21 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+91 -11** | **+87 -11** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 14122dc and 1783c34, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-14T10:52:54.033Z",
      "headSha": "1783c34a362b613427202ef168220a029df82636",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/452061436142733",
      "shortSha": "1783c34",
      "cleanupDurationMs": 2258,
      "deployDurationMs": 21614,
      "testDurationMs": 606,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.73,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-14T10:52:50.829Z",
      "headSha": "1783c34a362b613427202ef168220a029df82636",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/452061436142733",
      "shortSha": "1783c34",
      "cleanupDurationMs": 195186,
      "deployDurationMs": 89894,
      "testDurationMs": 174645,
      "testRetries": "3 retried: agent answers after llm model is selected (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page repaints from a stream subscription after a page action (specs x1)",
      "workerSizeKib": 16319.42,
      "workerGzipKib": 4402.46,
      "mainWorkerGzipKib": 4404.08
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `1783c34` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 819.7 KiB | 21.6s | 606ms |  | 2.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/452061436142733) | 2026-07-14T10:52:54.033Z | Preview app released. |
| OS | released | `1783c34` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 4.30 MiB (-1.6 KiB vs main) | 89.9s | 174.6s | 3 retried: agent answers after llm model is selected (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page repaints from a stream subscription after a page action (specs x1) | 195.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/452061436142733) | 2026-07-14T10:52:50.829Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->