### PR TITLE
Retry Artifact creation after deletion

### DIFF
--- a/apps/os/src/domains/repos/artifact-replacement.test.ts
+++ b/apps/os/src/domains/repos/artifact-replacement.test.ts
@@ -59,6 +59,28 @@ describe("replaceArtifactWithEmptyRepo", () => {
     expect(artifacts.create).not.toHaveBeenCalled();
   });
 
+  it("retries creation when the read plane sees deletion before the create plane releases the name", async () => {
+    const sleep = vi.fn(async () => {});
+    const artifacts = {
+      create: vi
+        .fn<Artifacts["create"]>()
+        .mockRejectedValueOnce(artifactsError("ALREADY_EXISTS"))
+        .mockResolvedValueOnce({} as ArtifactsCreateRepoResult),
+      delete: vi.fn(async () => true),
+      get: vi.fn<Artifacts["get"]>(async () => {
+        throw artifactsError("NOT_FOUND");
+      }),
+    };
+
+    await replaceArtifactWithEmptyRepo(artifacts, "repo", {
+      pollIntervalMs: 17,
+      sleep,
+    });
+
+    expect(artifacts.create).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(17);
+  });
+
   it("creates immediately when the artifact was already absent", async () => {
     const artifacts = {
       create: vi.fn(async () => ({}) as ArtifactsCreateRepoResult),
@@ -102,5 +124,26 @@ describe("replaceArtifactWithEmptyRepo", () => {
       }),
     ).rejects.toThrow('Timed out waiting for Artifacts repository "repo" deletion');
     expect(artifacts.create).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the create plane never releases the deleted name", async () => {
+    const artifacts = {
+      create: vi.fn<Artifacts["create"]>(async () => {
+        throw artifactsError("ALREADY_EXISTS");
+      }),
+      delete: vi.fn(async () => true),
+      get: vi.fn<Artifacts["get"]>(async () => {
+        throw artifactsError("NOT_FOUND");
+      }),
+    };
+
+    await expect(
+      replaceArtifactWithEmptyRepo(artifacts, "repo", {
+        pollAttempts: 2,
+        pollIntervalMs: 0,
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow('Timed out waiting for Artifacts repository "repo" name to become reusable');
+    expect(artifacts.create).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/os/src/domains/repos/artifact-replacement.ts
+++ b/apps/os/src/domains/repos/artifact-replacement.ts
@@ -17,15 +17,16 @@ export async function replaceArtifactWithEmptyRepo(
     sleep?: (ms: number) => Promise<void>;
   } = {},
 ): Promise<void> {
+  const pollAttempts = options.pollAttempts ?? DELETE_POLL_ATTEMPTS;
+  const pollIntervalMs = options.pollIntervalMs ?? DELETE_POLL_INTERVAL_MS;
+  const sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+
   // Callers must invalidate any cached view of the old repository before the
   // remote deletion begins. Keep this inside the helper's boundary so a
   // future refactor cannot accidentally move invalidation after the delete.
   options.beforeDelete?.();
   const deleted = await artifacts.delete(name);
   if (deleted) {
-    const pollAttempts = options.pollAttempts ?? DELETE_POLL_ATTEMPTS;
-    const pollIntervalMs = options.pollIntervalMs ?? DELETE_POLL_INTERVAL_MS;
-    const sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
     let deletionApplied = false;
 
     for (let attempt = 0; attempt < pollAttempts; attempt++) {
@@ -46,5 +47,22 @@ export async function replaceArtifactWithEmptyRepo(
     }
   }
 
-  await artifacts.create(name, { setDefaultBranch: "main" });
+  // Artifacts' read and create paths are not one consistency boundary. In
+  // production, get() reported NOT_FOUND for the deleted repo while create()
+  // still rejected the same name with ALREADY_EXISTS. Keep the stronger
+  // NOT_FOUND barrier above (it protects the replacement from the queued
+  // delete), then wait for the create plane to release the name as well.
+  for (let attempt = 0; attempt < pollAttempts; attempt++) {
+    try {
+      await artifacts.create(name, { setDefaultBranch: "main" });
+      return;
+    } catch (error) {
+      if ((error as { code?: unknown })?.code !== "ALREADY_EXISTS") throw error;
+      if (attempt + 1 < pollAttempts) await sleep(pollIntervalMs);
+    }
+  }
+
+  throw new Error(
+    `Timed out waiting for Artifacts repository "${name}" name to become reusable after deletion.`,
+  );
 }


### PR DESCRIPTION
## Outcome

Fixes the production reset edge case where Artifacts get() reports NOT_FOUND before create() releases the deleted repository name.

## Production evidence

- resetFromGithub failed on worker version 0407403c with call log_5ec0065e999a40d5ade645920eefe7f0
- correlated trace: https://dash.cloudflare.com/04b3b57291ef2626c6a8daa9d47065a7/observability/traces/7c3a8403afacb629e2fcb8421e92e0f0
- semantic Repo.resetFromGithub span: 5.98s, outcome error, untruncated wide log
- caller error: canonical repo name still ALREADY_EXISTS after the NOT_FOUND deletion barrier

## Fix

Retain the NOT_FOUND deletion-complete barrier, then retry only ALREADY_EXISTS from create() until the create plane releases the name. Every other create error still fails immediately; bounded exhaustion fails closed.

## Verification

- artifact replacement tests: 7 passed
- OS typecheck
- changed-file formatting
- changed-file lint: zero warnings/errors

After merge and production deploy I will rerun the hard reset and verify the Artifact head, symlink-safe file traversal, repo UI, and emitted repo events.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches repo replacement used in reset flows; behavior change is narrow (retry only ALREADY_EXISTS) but affects critical artifact lifecycle timing.
> 
> **Overview**
> Fixes a production race in **`replaceArtifactWithEmptyRepo`** where the Artifacts read path already reports **`NOT_FOUND`** after delete, but **`create`** still returns **`ALREADY_EXISTS`** for the same repository name.
> 
> The existing **`NOT_FOUND`** polling barrier is unchanged. **`create`** is now retried with the same bounded **`pollAttempts`** / **`pollIntervalMs`** when only **`ALREADY_EXISTS`** occurs; other create errors still fail immediately, and exhaustion throws a new timeout about the name not becoming reusable.
> 
> Tests cover successful retry after **`ALREADY_EXISTS`**, sleep between attempts, and fail-closed behavior when the create plane never releases the name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c685a6a49a56351f6c04c9773c11a699fff5334e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +22 -4 | +15 -4 🟩🟩🟥⬜⬜ |
| Tests | +43 -0 | +38 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+65 -4** | **+53 -4** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 32a2097 and c685a6a, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-14T10:44:30.014Z",
      "headSha": "c685a6a49a56351f6c04c9773c11a699fff5334e",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/445660014131197",
      "shortSha": "c685a6a",
      "cleanupDurationMs": 2789,
      "deployDurationMs": 20988,
      "testDurationMs": 511,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.73,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-14T10:44:26.011Z",
      "headSha": "c685a6a49a56351f6c04c9773c11a699fff5334e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/445660014131197",
      "shortSha": "c685a6a",
      "cleanupDurationMs": 70193,
      "deployDurationMs": 98120,
      "testDurationMs": 168267,
      "testRetries": "1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 16327.61,
      "workerGzipKib": 4404.14,
      "mainWorkerGzipKib": 4404.08
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `c685a6a` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 819.7 KiB | 21.0s | 511ms |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/445660014131197) | 2026-07-14T10:44:30.014Z | Preview app released. |
| OS | released | `c685a6a` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.30 MiB (+0.1 KiB vs main) | 98.1s | 168.3s | 1 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 70.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/445660014131197) | 2026-07-14T10:44:26.011Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->