### PR TITLE
Fix production task board loading

### DIFF
--- a/apps/os/src/domains/repos/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/repo-durable-object.ts
@@ -198,7 +198,16 @@ export class RepoDurableObject extends DurableObject<Env> {
       input.exclude === undefined &&
       input.include === undefined;
     if (cacheable) {
-      return this.#headFilesSnapshot.get(() => this.#loadFilesSnapshot({ ...input, branch }));
+      return this.#headFilesSnapshot.get(
+        () => this.#loadFilesSnapshot({ ...input, branch }),
+        (snapshot) => {
+          // #checkout deliberately returns its last clone after the bounded
+          // eventual-consistency retries. Let current callers use that result,
+          // but never retain it when it still trails the last observed push.
+          const pushed = this.ctx.storage.kv.get<string>(repoPushedHeadStorageKey(branch));
+          return typeof pushed !== "string" || pushed === snapshot.commitOid;
+        },
+      );
     }
     return this.#loadFilesSnapshot(input);
   }

--- a/apps/os/src/domains/repos/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/repo-durable-object.ts
@@ -59,6 +59,7 @@ import {
 import { projectRepoSeedFiles } from "./project-repo-seed.ts";
 import { RepoProcessor } from "./repo-processor-implementation.ts";
 import { diffRepoTaskFiles, type RepoCommittedFileChange } from "./repo-task-events.ts";
+import { SingleFlightValue } from "./single-flight-value.ts";
 
 const REPO_DEFAULT_BRANCH = "main";
 
@@ -190,6 +191,26 @@ export class RepoDurableObject extends DurableObject<Env> {
       include?: string[];
     } = {},
   ): Promise<{ commitOid: string; files: Record<string, string> }> {
+    const branch = input.branch ?? REPO_DEFAULT_BRANCH;
+    const cacheable =
+      branch === REPO_DEFAULT_BRANCH &&
+      input.commitOid === undefined &&
+      input.exclude === undefined &&
+      input.include === undefined;
+    if (cacheable) {
+      return this.#headFilesSnapshot.get(() => this.#loadFilesSnapshot({ ...input, branch }));
+    }
+    return this.#loadFilesSnapshot(input);
+  }
+
+  async #loadFilesSnapshot(
+    input: {
+      branch?: string;
+      commitOid?: string;
+      exclude?: string[];
+      include?: string[];
+    } = {},
+  ): Promise<{ commitOid: string; files: Record<string, string> }> {
     const { filesystem, head } = await this.#checkout(input);
 
     // Mask paths BEFORE reading contents: an excluded tree (a committed
@@ -312,6 +333,15 @@ export class RepoDurableObject extends DurableObject<Env> {
   // success result. All writes funnel through this one DO by design, which
   // is exactly what makes a local chain a sufficient lock.
   #writeChain: Promise<unknown> = Promise.resolve();
+  // Secondary repos have no root-workspace cache. Their HEAD reads otherwise
+  // clone the complete Artifact once per call; a task board opening 42 files
+  // concurrently therefore launched 42 full monorepo clones and reset this
+  // isolate for exceeding memory. Share one immutable HEAD snapshot until a
+  // write or queue-observed external push invalidates it.
+  readonly #headFilesSnapshot = new SingleFlightValue<{
+    commitOid: string;
+    files: Record<string, string>;
+  }>();
 
   #serializeWrite<T>(write: () => Promise<T>): Promise<T> {
     const result = this.#writeChain.then(write, write);
@@ -412,6 +442,11 @@ export class RepoDurableObject extends DurableObject<Env> {
     beforeCommitOid: string | null;
     branch: string;
   }): Promise<RepoCommittedFileChange[]> {
+    // This method is reached from the Cloudflare Artifacts queue for pushes
+    // made outside this DO too (for example from a developer's computer).
+    // Invalidate before pinned diff reads so the next unpinned HEAD read
+    // cannot reuse the pre-push snapshot.
+    this.#headFilesSnapshot.clear();
     const previous =
       input.beforeCommitOid === null
         ? {}
@@ -436,10 +471,12 @@ export class RepoDurableObject extends DurableObject<Env> {
    */
   #recordPushedHead(result: { branch: string; commitOid: string; noChanges?: boolean }) {
     if (result.noChanges) return;
+    if (result.branch === REPO_DEFAULT_BRANCH) this.#headFilesSnapshot.clear();
     this.ctx.storage.kv.put(repoPushedHeadStorageKey(result.branch), result.commitOid);
   }
 
   #invalidateArtifactState(branch: string) {
+    if (branch === REPO_DEFAULT_BRANCH) this.#headFilesSnapshot.clear();
     this.#artifactTokenPromise = undefined;
     this.ctx.storage.kv.delete(repoHeadStorageKey(branch));
     this.ctx.storage.kv.delete(repoPushedHeadStorageKey(branch));
@@ -1188,6 +1225,7 @@ export class RepoDurableObject extends DurableObject<Env> {
         token,
       }),
     );
+    this.#headFilesSnapshot.clear();
     this.ctx.storage.kv.put(repoHeadStorageKey(defaultBranch), {
       commitOid: seeded.commitOid,
       contentHash: seeded.contentHash,

--- a/apps/os/src/domains/repos/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/repo-durable-object.ts
@@ -444,9 +444,15 @@ export class RepoDurableObject extends DurableObject<Env> {
   }): Promise<RepoCommittedFileChange[]> {
     // This method is reached from the Cloudflare Artifacts queue for pushes
     // made outside this DO too (for example from a developer's computer).
-    // Invalidate before pinned diff reads so the next unpinned HEAD read
-    // cannot reuse the pre-push snapshot.
-    this.#headFilesSnapshot.clear();
+    // Record the queue-observed head before pinned diff reads. Artifacts can
+    // briefly clone the previous tip even after emitting its push event; the
+    // recorded oid makes #checkout retry that stale clone instead of letting
+    // it repopulate the just-cleared unpinned HEAD snapshot.
+    if (input.afterCommitOid === null) {
+      this.#headFilesSnapshot.clear();
+    } else {
+      this.#recordPushedHead({ branch: input.branch, commitOid: input.afterCommitOid });
+    }
     const previous =
       input.beforeCommitOid === null
         ? {}

--- a/apps/os/src/domains/repos/single-flight-value.test.ts
+++ b/apps/os/src/domains/repos/single-flight-value.test.ts
@@ -30,6 +30,22 @@ describe("SingleFlightValue", () => {
     expect(load).toHaveBeenCalledTimes(2);
   });
 
+  it("serves but does not retain a value rejected by cache admission", async () => {
+    const cache = new SingleFlightValue<string>();
+    const load = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce("stale snapshot")
+      .mockResolvedValueOnce("fresh snapshot");
+
+    await expect(cache.get(load, (value) => value === "fresh snapshot")).resolves.toBe(
+      "stale snapshot",
+    );
+    await expect(cache.get(load, (value) => value === "fresh snapshot")).resolves.toBe(
+      "fresh snapshot",
+    );
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
   it("does not let an old rejected load clear a newer value after invalidation", async () => {
     const cache = new SingleFlightValue<string>();
     let rejectOld!: (error: Error) => void;
@@ -42,6 +58,27 @@ describe("SingleFlightValue", () => {
     await expect(cache.get(async () => "new snapshot")).resolves.toBe("new snapshot");
     rejectOld(new Error("old clone failed"));
     await expect(first).rejects.toThrow("old clone failed");
+
+    const shouldNotRun = vi.fn(async () => "wrong");
+    await expect(cache.get(shouldNotRun)).resolves.toBe("new snapshot");
+    expect(shouldNotRun).not.toHaveBeenCalled();
+  });
+
+  it("does not let an old admission rejection clear a newer value after invalidation", async () => {
+    const cache = new SingleFlightValue<string>();
+    let resolveOld!: (value: string) => void;
+    const oldLoad = new Promise<string>((resolve) => {
+      resolveOld = resolve;
+    });
+    const first = cache.get(
+      () => oldLoad,
+      () => false,
+    );
+
+    cache.clear();
+    await expect(cache.get(async () => "new snapshot")).resolves.toBe("new snapshot");
+    resolveOld("old snapshot");
+    await expect(first).resolves.toBe("old snapshot");
 
     const shouldNotRun = vi.fn(async () => "wrong");
     await expect(cache.get(shouldNotRun)).resolves.toBe("new snapshot");

--- a/apps/os/src/domains/repos/single-flight-value.test.ts
+++ b/apps/os/src/domains/repos/single-flight-value.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { SingleFlightValue } from "./single-flight-value.ts";
+
+describe("SingleFlightValue", () => {
+  it("shares one in-flight load across concurrent callers", async () => {
+    const cache = new SingleFlightValue<string>();
+    let resolve!: (value: string) => void;
+    const pending = new Promise<string>((done) => {
+      resolve = done;
+    });
+    const load = vi.fn(() => pending);
+
+    const first = cache.get(load);
+    const second = cache.get(load);
+
+    expect(load).toHaveBeenCalledTimes(1);
+    resolve("snapshot");
+    await expect(Promise.all([first, second])).resolves.toEqual(["snapshot", "snapshot"]);
+  });
+
+  it("drops a failed load so the next caller can retry", async () => {
+    const cache = new SingleFlightValue<string>();
+    const load = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("clone failed"))
+      .mockResolvedValueOnce("recovered");
+
+    await expect(cache.get(load)).rejects.toThrow("clone failed");
+    await expect(cache.get(load)).resolves.toBe("recovered");
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let an old rejected load clear a newer value after invalidation", async () => {
+    const cache = new SingleFlightValue<string>();
+    let rejectOld!: (error: Error) => void;
+    const oldLoad = new Promise<string>((_resolve, reject) => {
+      rejectOld = reject;
+    });
+    const first = cache.get(() => oldLoad);
+
+    cache.clear();
+    await expect(cache.get(async () => "new snapshot")).resolves.toBe("new snapshot");
+    rejectOld(new Error("old clone failed"));
+    await expect(first).rejects.toThrow("old clone failed");
+
+    const shouldNotRun = vi.fn(async () => "wrong");
+    await expect(cache.get(shouldNotRun)).resolves.toBe("new snapshot");
+    expect(shouldNotRun).not.toHaveBeenCalled();
+  });
+});

--- a/apps/os/src/domains/repos/single-flight-value.ts
+++ b/apps/os/src/domains/repos/single-flight-value.ts
@@ -6,12 +6,20 @@
 export class SingleFlightValue<T> {
   #promise: Promise<T> | undefined;
 
-  get(load: () => Promise<T>): Promise<T> {
+  get(load: () => Promise<T>, retain: (value: T) => boolean = () => true): Promise<T> {
     if (this.#promise !== undefined) return this.#promise;
-    const promise = load().catch((error: unknown) => {
-      if (this.#promise === promise) this.#promise = undefined;
-      throw error;
-    });
+    const promise = load()
+      .then((value) => {
+        // A value can be useful to the current callers but unsafe to retain
+        // after state changed while it loaded. Generation-fence the eviction
+        // so an invalidated older load cannot clear its replacement.
+        if (!retain(value) && this.#promise === promise) this.#promise = undefined;
+        return value;
+      })
+      .catch((error: unknown) => {
+        if (this.#promise === promise) this.#promise = undefined;
+        throw error;
+      });
     this.#promise = promise;
     return promise;
   }

--- a/apps/os/src/domains/repos/single-flight-value.ts
+++ b/apps/os/src/domains/repos/single-flight-value.ts
@@ -1,0 +1,22 @@
+/**
+ * One invalidatable async value. Concurrent callers share the same load and a
+ * rejected load is never retained. `clear()` generation-fences older loads so
+ * their late rejection cannot evict the replacement value.
+ */
+export class SingleFlightValue<T> {
+  #promise: Promise<T> | undefined;
+
+  get(load: () => Promise<T>): Promise<T> {
+    if (this.#promise !== undefined) return this.#promise;
+    const promise = load().catch((error: unknown) => {
+      if (this.#promise === promise) this.#promise = undefined;
+      throw error;
+    });
+    this.#promise = promise;
+    return promise;
+  }
+
+  clear(): void {
+    this.#promise = undefined;
+  }
+}

--- a/apps/os/src/domains/streams/client-libraries/browser/catch-up-page.test.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/catch-up-page.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { readCatchUpPage } from "./catch-up-page.ts";
+
+describe("readCatchUpPage", () => {
+  it("halves an oversized RPC page until it fits", async () => {
+    const read = vi.fn(async (limit: number) => {
+      if (limit > 125) {
+        throw new Error(
+          "Serialized RPC arguments or return values are limited to 32 MiB, but the size of this value was: 35669548 bytes.",
+        );
+      }
+      return [{ offset: 1 }];
+    });
+
+    await expect(readCatchUpPage(500, read)).resolves.toEqual({
+      limit: 125,
+      page: [{ offset: 1 }],
+    });
+    expect(read.mock.calls.map(([limit]) => limit)).toEqual([500, 250, 125]);
+  });
+
+  it("does not retry unrelated failures", async () => {
+    const read = vi.fn(async () => {
+      throw new Error("stream unavailable");
+    });
+
+    await expect(readCatchUpPage(500, read)).rejects.toThrow("stream unavailable");
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when one event is too large", async () => {
+    const error = new Error(
+      "Serialized RPC arguments or return values are limited to 32 MiB, but the size of this value was: 40000000 bytes.",
+    );
+    const read = vi.fn(async () => {
+      throw error;
+    });
+
+    await expect(readCatchUpPage(1, read)).rejects.toBe(error);
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/os/src/domains/streams/client-libraries/browser/catch-up-page.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/catch-up-page.ts
@@ -1,0 +1,26 @@
+const SERIALIZED_RPC_VALUE_TOO_LARGE = "Serialized RPC arguments or return values are limited";
+
+/**
+ * Read one catch-up page, reducing only an RPC-oversized page until it fits.
+ * A single oversized event and every unrelated failure still fail closed.
+ */
+export async function readCatchUpPage<T>(
+  limit: number,
+  read: (limit: number) => Promise<T[]>,
+): Promise<{ limit: number; page: T[] }> {
+  let nextLimit = limit;
+  for (;;) {
+    try {
+      return { limit: nextLimit, page: await read(nextLimit) };
+    } catch (error) {
+      if (
+        nextLimit <= 1 ||
+        !(error instanceof Error) ||
+        !error.message.includes(SERIALIZED_RPC_VALUE_TOO_LARGE)
+      ) {
+        throw error;
+      }
+      nextLimit = Math.max(1, Math.floor(nextLimit / 2));
+    }
+  }
+}

--- a/apps/os/src/domains/streams/client-libraries/browser/stream-browser-store.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/stream-browser-store.ts
@@ -31,6 +31,7 @@ import {
   type SqlClient,
   type StreamDatabaseInfo,
 } from "./stream-browser-db.ts";
+import { readCatchUpPage } from "./catch-up-page.ts";
 
 const LIVE_PROGRESS_NOTIFICATION_MS = 16;
 const DEFAULT_STREAM_PROJECT_ID = "default";
@@ -921,6 +922,7 @@ function createStreamRuntime(
         // page failure just reconnects and resumes from the checkpoint.
         let catchUpOffset = checkpoint.offset;
         let serverHead = serverMaxOffset;
+        let catchUpPageLimit = CATCHUP_PAGE_LIMIT;
         if (serverHead - catchUpOffset > CATCHUP_THRESHOLD_EVENTS) {
           console.info(
             `[stream ${args.streamPath} ${slug}] mirror is ${serverHead - catchUpOffset} events behind; pull-paging before subscribing`,
@@ -939,18 +941,29 @@ function createStreamRuntime(
               serverHead = parseBrowserCoreProcessorState(rawHeadState).maxOffset;
               if (serverHead - catchUpOffset <= CATCHUP_THRESHOLD_EVENTS) break;
             }
-            const page = (await withDeadline(
-              "catch-up page read",
-              election.connection.getEvents({
-                afterOffset: catchUpOffset,
-                // The mirror stores ephemeral rows too (the subscription lane
-                // delivers them); a default read here would skip every chunk
-                // run — losing streamed text the mirror promises to keep and
-                // false-firing the raw-events gap detector on each one.
-                includeEphemeral: true,
-                limit: CATCHUP_PAGE_LIMIT,
-              }),
-            )) as StreamEvent[];
+            const result = await readCatchUpPage(
+              catchUpPageLimit,
+              async (limit) =>
+                (await withDeadline(
+                  "catch-up page read",
+                  election.connection.getEvents({
+                    afterOffset: catchUpOffset,
+                    // The mirror stores ephemeral rows too (the subscription lane
+                    // delivers them); a default read here would skip every chunk
+                    // run — losing streamed text the mirror promises to keep and
+                    // false-firing the raw-events gap detector on each one.
+                    includeEphemeral: true,
+                    limit,
+                  }),
+                )) as StreamEvent[],
+            );
+            if (result.limit < catchUpPageLimit) {
+              console.warn(
+                `[stream ${args.streamPath} ${slug}] catch-up page exceeded the RPC byte limit; reducing page size from ${catchUpPageLimit} to ${result.limit}`,
+              );
+            }
+            catchUpPageLimit = result.limit;
+            const page = result.page;
             if (!ownsRuntime()) return undefined;
             if (page.length === 0) break; // server truth moved (reset?); subscribe reconciles
             deliveryArrivals += 1;


### PR DESCRIPTION
## Outcome

Makes the production task board load safely for large secondary repos and lets cold browser stream mirrors recover when an event page exceeds Cap'n Web's byte limit.

## Production reproduction

On `https://os.iterate.com/projects/iterate/repos/iterate` after the Artifact reset:

- the repo itself is healthy at GitHub main (`30e944b`, 1,428 files)
- Tasks remained on `Loading tasks…`
- 42 concurrent task reads reset the Repo Durable Object for exceeding its memory limit (`log_3c3adf88f3a34bc3ac28a0bb9fccbcb3`)
- one secondary-repo `readFile` took about 19 seconds because it cloned the whole repo
- browser stream catch-up repeatedly attempted a 35.7 MB response over Cap'n Web's 32 MiB value limit

## Fix

- coalesce and retain one invalidatable default-branch HEAD snapshot per Repo DO, so secondary-repo `listFiles` and concurrent task reads share one clone
- invalidate it for local writes, reset/sync replacement, seeding, and Cloudflare Artifacts queue-observed external pushes
- adaptively halve a catch-up page only for the precise serialized-RPC-size error; unrelated failures and an individually oversized event still fail closed

## Verification

- red/green regression tests for concurrent snapshot loads, failure retry, and generation-fenced invalidation
- red/green regression tests for `500 → 250 → 125` catch-up page reduction and fail-closed behavior
- full OS unit suite
- OS typecheck
- changed-file formatting and zero-warning lint

After preview CI I will reproduce the authenticated repo and Tasks views, merge, follow the production deploy, and repeat the proof on the original URL.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot paths for repo HEAD reads and external-push task diffs (staleness/invalidation semantics) plus browser stream catch-up; mistakes could serve stale files or wedge mirrors, but scope is bounded and covered by new unit tests.
> 
> **Overview**
> Fixes production task board stalls on large **secondary** repos (no root-workspace cache) and browser stream mirrors that die when a catch-up `getEvents` page exceeds Cap'n Web’s **32 MiB** RPC limit.
> 
> **Repo Durable Object:** Unpinned default-branch `getFilesSnapshot` calls now share one in-flight load via new `SingleFlightValue`, so many concurrent reads (e.g. dozens of task files) trigger **one** full clone instead of one per call. Snapshots are not kept when they still trail the last recorded push; the cache is cleared on local writes, seeding, artifact invalidation, and Artifacts queue–observed external pushes (with pushed-head recorded before pinned task diffs so stale clones cannot refill the cache).
> 
> **Browser stream mirror:** Catch-up paging uses `readCatchUpPage`, which halves the page size only on the serialized-RPC-size error and remembers the smaller limit; other errors and a single oversized event still fail closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a6e3ac474d3f634eb73032c611b9e431e852567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +134 -12 | +100 -8 🟩🟩🟩🟩🟩 |
| Tests | +129 -0 | +110 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+263 -12** | **+210 -8** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 0702ed3 and 6a6e3ac, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-14T11:18:53.314Z",
      "headSha": "6a6e3ac474d3f634eb73032c611b9e431e852567",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/523559472814309",
      "shortSha": "6a6e3ac",
      "cleanupDurationMs": 1897,
      "deployDurationMs": 19159,
      "testDurationMs": 497,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.82,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-14T11:18:51.821Z",
      "headSha": "71f87b8652d70726e4d6808b08d9e169c8aa15b8",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/226551561080084",
      "shortSha": "71f87b8",
      "cleanupDurationMs": 403,
      "deployDurationMs": 16815,
      "workerSizeKib": 5106.22,
      "workerGzipKib": 1455.51,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-14T11:18:50.432Z",
      "headSha": "6a6e3ac474d3f634eb73032c611b9e431e852567",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/523559472814309",
      "shortSha": "6a6e3ac",
      "cleanupDurationMs": 69695,
      "deployDurationMs": 83371,
      "testDurationMs": 174308,
      "testRetries": "3 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · ephemeral subscriptions cannot reuse a configured subscription key (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1)",
      "workerSizeKib": 16329.94,
      "workerGzipKib": 4404.74,
      "mainWorkerGzipKib": 4404.54
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `6a6e3ac` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 819.8 KiB | 19.2s | 497ms |  | 1.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/523559472814309) | 2026-07-14T11:18:53.314Z | Preview app released. |
| OS | released | `6a6e3ac` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 4.30 MiB (+0.2 KiB vs main) | 83.4s | 174.3s | 3 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · ephemeral subscriptions cannot reuse a configured subscription key (vitest x1) · onboarding agent replies to a chat message in the feed (specs x1) | 69.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/523559472814309) | 2026-07-14T11:18:50.432Z | Preview app released. |
| Streams Example App | released | `71f87b8` | [https://streams.iterate-preview-6.com](https://streams.iterate-preview-6.com) | 1.42 MiB | 16.8s |  |  | 403ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/226551561080084) | 2026-07-14T11:18:51.821Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->