### PR TITLE
Prove GitHub agent body mentions through sandbox Git

### DIFF
--- a/docs/github-agent-body-mention-sandbox-proof.md
+++ b/docs/github-agent-body-mention-sandbox-proof.md
@@ -1,3 +1,3 @@
 # GitHub agent body-mention sandbox proof
 
-status: pending
+status: completed by iterate

--- a/docs/github-agent-body-mention-sandbox-proof.md
+++ b/docs/github-agent-body-mention-sandbox-proof.md
@@ -1,0 +1,3 @@
+# GitHub agent body-mention sandbox proof
+
+status: pending


### PR DESCRIPTION
@iterate this is a production dogfood of body-only mention activation; the title deliberately contains no mention.

Use a sandbox Git clone and normal edit, commit, and push commands—not the Octokit contents write endpoint—to edit only docs/github-agent-body-mention-sandbox-proof.md. Replace status: pending with status: completed by iterate. Push to this PR branch, then leave a PR comment with what changed and the exact pushed head SHA. A successful push is authoritative; if you need one verification read, use the branch ref. Do not merge or close this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds **`docs/github-agent-body-mention-sandbox-proof.md`** as a dogfood check that the GitHub agent can be activated from a **body-only** `@iterate` mention (title has no mention).
> 
> The file records **`status: completed by iterate`**, showing the agent updated it via a **sandbox Git clone** (edit/commit/push), not the Octokit contents API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aa9305a4b29f9923f6302672c94c4060efb4e04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Docs | +3 -0 | +2 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+3 -0** | **+2 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between ea4b286 and 7aa9305, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->