### PR TITLE
Always show all raw events; drop feed preset pills

### DIFF
--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -46,11 +46,7 @@ import {
   type StreamMessageComposer,
 } from "~/components/stream-view-composer.tsx";
 import { StreamModeTabs, StreamViewHeader } from "~/components/stream-view-header.tsx";
-import {
-  defaultPresetForMode,
-  feedItemsFilterFromSearch,
-  presetsForStream,
-} from "~/lib/stream-feed-filters.ts";
+import { feedItemsFilterFromSearch } from "~/lib/stream-feed-filters.ts";
 import { NULL_DURABLE_OBJECT_PROJECT_ID } from "~/lib/stream-navigation.ts";
 import { connectItxBrowser, evictItxSocket, evictItxSocketIfCurrent } from "~/itx/itx-react.tsx";
 import { useBrowserStreamMetrics } from "~/lib/stream-presence.ts";
@@ -223,12 +219,6 @@ export function ProjectStreamView({
   const panels = useStreamViewPanels();
   const activeMode = streamViewMode(search, streamPath);
   const caps = modeCapabilities(search, streamPath);
-  // Feed-items presets apply whenever the mode shows raw feed_items.
-  const presets = useMemo(() => presetsForStream(streamPath), [streamPath]);
-  const defaultPreset = defaultPresetForMode(streamPath, activeMode);
-  const activePreset = caps.rawPresets
-    ? (presets.find((preset) => preset.id === search.preset) ?? defaultPreset)
-    : defaultPreset;
   // Trimmed: a whitespace-only query must read as "no filter", not a LIKE
   // pattern of spaces that hides every row.
   const feedSearch = (search.q ?? "").trim();
@@ -286,11 +276,9 @@ export function ProjectStreamView({
   const filterRow =
     search.filter !== true ? null : (
       <StreamFeedFilterRow
-        activePreset={activePreset}
         eventCount={eventCount}
         connectionStatus={snapshot.connectionStatus}
         feedDatabase={feedStore.streamDatabase}
-        presets={presets}
         streamPath={streamPath}
       />
     );

--- a/apps/os/src/components/stream-feed-filters.tsx
+++ b/apps/os/src/components/stream-feed-filters.tsx
@@ -4,14 +4,7 @@ import { Button } from "@iterate-com/ui/components/button";
 import { cn } from "@iterate-com/ui/lib/utils";
 import type { StreamBrowserDatabase } from "~/domains/streams/client-libraries/browser/stream-browser-db.ts";
 import { useStreamQuery } from "~/domains/streams/client-libraries/browser/hooks/use-stream-query.ts";
-import {
-  buildFeedItemsFilter,
-  defaultPresetForMode,
-  FEED_TYPE_EXPRESSION,
-  shortComponent,
-  shortEventType,
-  type StreamFeedPreset,
-} from "~/lib/stream-feed-filters.ts";
+import { FEED_TYPE_EXPRESSION, shortComponent, shortEventType } from "~/lib/stream-feed-filters.ts";
 import {
   modeCapabilities,
   streamViewMode,
@@ -28,24 +21,19 @@ import {
  *   2) Raw event types (`types`)
  */
 export function StreamFeedFilterRow({
-  activePreset,
   eventCount,
   connectionStatus,
   feedDatabase,
-  presets,
   streamPath,
 }: {
-  activePreset: StreamFeedPreset;
   eventCount: number;
   connectionStatus: string;
   feedDatabase: StreamBrowserDatabase;
-  presets: readonly StreamFeedPreset[];
   streamPath: string;
 }) {
   const { search, setSearch } = useStreamViewSearch();
   const mode = streamViewMode(search, streamPath);
   const caps = modeCapabilities(search, streamPath);
-  const defaultPreset = defaultPresetForMode(streamPath, mode);
   const focusOnMount = useCallback((element: HTMLInputElement | null) => element?.focus(), []);
   const [typesOpen, setTypesOpen] = useState(false);
   const showTypePanel = caps.rawComponents || caps.rawEventTypes;
@@ -59,43 +47,6 @@ export function StreamFeedFilterRow({
   return (
     <div className="flex shrink-0 flex-col gap-2 px-4 pb-1.5 pt-1">
       <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-        {caps.rawPresets && presets.length > 1 ? (
-          <div
-            className="flex flex-wrap items-center gap-1.5"
-            role="radiogroup"
-            aria-label="Feed preset"
-            data-testid="stream-feed-preset"
-          >
-            {presets.map((preset) => {
-              const active = preset.id === activePreset.id;
-              return (
-                <button
-                  key={preset.id}
-                  type="button"
-                  role="radio"
-                  aria-checked={active}
-                  onClick={() =>
-                    setSearch({
-                      preset: preset.id === defaultPreset.id ? undefined : preset.id,
-                      types: undefined,
-                      components: undefined,
-                      from: undefined,
-                      to: undefined,
-                    })
-                  }
-                  className={cn(
-                    "rounded-full border px-2.5 py-1 text-xs transition-colors",
-                    active
-                      ? "border-transparent bg-foreground text-background"
-                      : "border-border text-muted-foreground hover:bg-muted hover:text-foreground",
-                  )}
-                >
-                  {preset.label}
-                </button>
-              );
-            })}
-          </div>
-        ) : null}
         {caps.search ? (
           <div className="flex h-8 min-w-0 max-w-xs flex-1 items-center gap-2 rounded-full bg-muted px-3">
             <SearchIcon className="size-3.5 shrink-0 text-muted-foreground" />
@@ -157,7 +108,6 @@ export function StreamFeedFilterRow({
       {showTypePanel && typesOpen ? (
         <TypeFilterPanel
           database={feedDatabase}
-          eventTypePrefix={activePreset.eventTypePrefix ?? null}
           components={search.components ?? null}
           eventTypes={search.types ?? null}
           onComponentsChange={(components) => setSearch({ components: components ?? undefined })}
@@ -170,21 +120,19 @@ export function StreamFeedFilterRow({
 
 function TypeFilterPanel({
   database,
-  eventTypePrefix,
   components,
   eventTypes,
   onComponentsChange,
   onEventTypesChange,
 }: {
   database: StreamBrowserDatabase;
-  eventTypePrefix: string | null;
   components: readonly string[] | null;
   eventTypes: readonly string[] | null;
   onComponentsChange: (components: string[] | null) => void;
   onEventTypesChange: (eventTypes: string[] | null) => void;
 }) {
   const componentOptions = useComponentOptions(database);
-  const eventTypeOptions = useEventTypeOptions(database, eventTypePrefix);
+  const eventTypeOptions = useEventTypeOptions(database);
 
   return (
     <div className="rounded-xl border bg-muted/20 p-3" data-testid="stream-feed-types-panel">
@@ -353,21 +301,13 @@ function useComponentOptions(database: StreamBrowserDatabase) {
   );
 }
 
-function useEventTypeOptions(database: StreamBrowserDatabase, eventTypePrefix: string | null) {
-  const filter = buildFeedItemsFilter({
-    eventTypePrefix,
-    eventTypes: null,
-    components: null,
-    searchQuery: null,
-    offsetFrom: null,
-    offsetTo: null,
-  });
+function useEventTypeOptions(database: StreamBrowserDatabase) {
   const result = useStreamQuery(
     database,
     `SELECT ${FEED_TYPE_EXPRESSION} AS event_type, SUM(event_count) AS total
-     FROM feed_items WHERE kind LIKE 'raw.%'${filter == null ? "" : ` AND ${filter.whereSql}`}
+     FROM feed_items WHERE kind LIKE 'raw.%'
      GROUP BY event_type ORDER BY event_type`,
-    filter?.params ?? [],
+    [],
   );
   return result.data.flatMap((row) =>
     typeof row.event_type === "string"

--- a/apps/os/src/components/stream-feed-view.tsx
+++ b/apps/os/src/components/stream-feed-view.tsx
@@ -206,7 +206,6 @@ export function StreamFeedView({
     filter.raw != null &&
     (filter.raw.eventTypes != null ||
       filter.raw.components != null ||
-      filter.raw.eventTypePrefix != null ||
       filter.raw.searchQuery != null ||
       filter.raw.offsetFrom != null ||
       filter.raw.offsetTo != null);

--- a/apps/os/src/components/stream-view-header.tsx
+++ b/apps/os/src/components/stream-view-header.tsx
@@ -224,7 +224,6 @@ export function StreamModeTabs({ streamPath }: { streamPath: string }) {
           components: undefined,
           from: undefined,
           to: undefined,
-          preset: undefined,
         });
       }}
     >

--- a/apps/os/src/lib/stream-feed-filters.test.ts
+++ b/apps/os/src/lib/stream-feed-filters.test.ts
@@ -2,39 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   buildFeedItemsFilter,
   buildStreamFeedWhere,
-  defaultPresetForMode,
   feedFiltersActive,
   feedItemsFilterFromSearch,
-  presetsForStream,
   shortEventType,
 } from "./stream-feed-filters.ts";
-
-describe("presetsForStream", () => {
-  it("puts the domain default first and Everything last", () => {
-    expect(presetsForStream("/agents/slack/general").map((preset) => preset.id)).toEqual([
-      "agent-events",
-      "everything",
-    ]);
-    expect(presetsForStream("/secrets/OPENAI_API_KEY").map((preset) => preset.id)).toEqual([
-      "secret-events",
-      "everything",
-    ]);
-  });
-
-  it("offers only the unfiltered feed on undomained streams", () => {
-    expect(presetsForStream("/sandboxes").map((preset) => preset.id)).toEqual(["everything"]);
-  });
-});
-
-describe("defaultPresetForMode", () => {
-  it("uses Everything for pretty-raw so the raw rail is unscoped", () => {
-    expect(defaultPresetForMode("/agents/x", "pretty-raw").id).toBe("everything");
-  });
-
-  it("uses the domain family for raw", () => {
-    expect(defaultPresetForMode("/agents/x", "raw").id).toBe("agent-events");
-  });
-});
 
 describe("buildFeedItemsFilter", () => {
   it("returns null when nothing narrows the feed", () => {
@@ -42,7 +13,6 @@ describe("buildFeedItemsFilter", () => {
       buildFeedItemsFilter({
         eventTypes: null,
         components: null,
-        eventTypePrefix: null,
         searchQuery: null,
         offsetFrom: null,
         offsetTo: null,
@@ -50,20 +20,18 @@ describe("buildFeedItemsFilter", () => {
     ).toBeNull();
   });
 
-  it("composes prefix, event types, raw kinds, search, and offset bounds", () => {
+  it("composes event types, raw kinds, search, and offset bounds", () => {
     const filter = buildFeedItemsFilter({
       eventTypes: ["events.iterate.com/agent/input-added", "events.iterate.com/agent/turn-ended"],
       components: ["raw.group", "raw.stream.woken"],
-      eventTypePrefix: "events.iterate.com/agent/",
       searchQuery: "hello",
       offsetFrom: 10,
       offsetTo: 99,
     });
     expect(filter?.whereSql).toMatchInlineSnapshot(
-      `"COALESCE(json_extract(data, '$.eventType'), json_extract(data, '$.events[0].type')) LIKE ? AND COALESCE(json_extract(data, '$.eventType'), json_extract(data, '$.events[0].type')) IN (?, ?) AND kind IN (?, ?) AND json(data) LIKE ? AND last_offset >= ? AND first_offset <= ?"`,
+      `"COALESCE(json_extract(data, '$.eventType'), json_extract(data, '$.events[0].type')) IN (?, ?) AND kind IN (?, ?) AND json(data) LIKE ? AND last_offset >= ? AND first_offset <= ?"`,
     );
     expect(filter?.params).toEqual([
-      "events.iterate.com/agent/%",
       "events.iterate.com/agent/input-added",
       "events.iterate.com/agent/turn-ended",
       "raw.group",
@@ -78,7 +46,6 @@ describe("buildFeedItemsFilter", () => {
     const filter = buildFeedItemsFilter({
       eventTypes: null,
       components: null,
-      eventTypePrefix: null,
       searchQuery: null,
       offsetFrom: 10,
       offsetTo: null,
@@ -90,7 +57,6 @@ describe("buildFeedItemsFilter", () => {
 describe("feedItemsFilterFromSearch", () => {
   it("encodes pretty-raw defaults as unscoped everything", () => {
     expect(feedItemsFilterFromSearch({ mode: "pretty-raw" }, "/agents/x")).toMatchObject({
-      eventTypePrefix: null,
       eventTypes: null,
       components: null,
     });
@@ -111,14 +77,13 @@ describe("feedItemsFilterFromSearch", () => {
     ).toEqual({
       eventTypes: ["events.iterate.com/stream/woken"],
       components: ["raw.stream.woken"],
-      eventTypePrefix: null,
       searchQuery: null,
       offsetFrom: null,
       offsetTo: null,
     });
   });
 
-  it("honors components + types from the URL in raw mode", () => {
+  it("shows the whole stream unscoped in raw mode, honoring URL components + types", () => {
     expect(
       feedItemsFilterFromSearch(
         {
@@ -128,10 +93,12 @@ describe("feedItemsFilterFromSearch", () => {
         },
         "/agents/x",
       ),
-    ).toMatchObject({
+    ).toEqual({
       components: ["raw.stream.woken"],
       eventTypes: ["events.iterate.com/stream/woken"],
-      eventTypePrefix: "events.iterate.com/agent/",
+      searchQuery: null,
+      offsetFrom: null,
+      offsetTo: null,
     });
   });
 });
@@ -140,7 +107,6 @@ describe("buildStreamFeedWhere", () => {
   const unscopedRaw = {
     eventTypes: null,
     components: null,
-    eventTypePrefix: null,
     searchQuery: null,
     offsetFrom: null,
     offsetTo: null,
@@ -196,8 +162,12 @@ describe("feedFiltersActive", () => {
     expect(feedFiltersActive({ types: ["a"], from: 1, to: 9 }, agentPath)).toBe(false);
   });
 
+  it("is inactive on an unscoped raw feed with no filters", () => {
+    expect(feedFiltersActive({ mode: "raw" }, agentPath)).toBe(false);
+  });
+
   it("signals raw filter deviations including components", () => {
-    expect(feedFiltersActive({ mode: "raw", preset: "everything" }, agentPath)).toBe(true);
+    expect(feedFiltersActive({ mode: "raw", types: ["a"] }, agentPath)).toBe(true);
     expect(feedFiltersActive({ mode: "raw", q: "boom" }, agentPath)).toBe(true);
     expect(feedFiltersActive({ mode: "pretty-raw", components: ["raw.group"] }, agentPath)).toBe(
       true,

--- a/apps/os/src/lib/stream-feed-filters.ts
+++ b/apps/os/src/lib/stream-feed-filters.ts
@@ -8,13 +8,15 @@
 //   - Pretty        — agent rows only (minus debug kinds), search over them.
 //   - Pretty + raw  — agent rows PLUS the raw rows the raw filters select,
 //                     one list; search narrows only the agent rows.
-//   - Raw           — raw rows only, with presets/types/offsets/search.
+//   - Raw           — raw rows only, with types/offsets/search. The raw feed is
+//                     always unscoped: every event on the stream is shown, and
+//                     the type/offset controls narrow from there.
 //
-// Filter model (URL + mode presets):
+// Filter model (URL):
 //   - `types`      — primary event types inside a raw feed item (group
 //                    eventType or singleton events[0].type)
 //   - `components` — raw feed_items.kind values (raw.group, raw.stream.woken, …)
-//   - `q`/`from`/`to`/`preset` as before
+//   - `q`/`from`/`to` as before
 // A raw row matches when it satisfies ALL active constraints. Modes decide
 // which of these controls are shown (Pretty: search only; Pretty+raw / Raw:
 // full).
@@ -31,109 +33,18 @@ import {
 } from "~/lib/stream-view-search.ts";
 
 /**
- * One named configuration of the raw side of the feed. Modes that show raw
- * feed_items pick a default; Pretty ignores these.
- */
-export type StreamFeedPreset = { id: string; label: string } & {
-  kind: "feed-items";
-  eventTypePrefix?: string;
-  /** Optional default raw-kind allowlist encoded by this preset. */
-  components?: readonly string[];
-};
-
-const EVERYTHING_PRESET: StreamFeedPreset = {
-  id: "everything",
-  label: "Everything",
-  kind: "feed-items",
-};
-
-/** Domain-specific event-type prefix presets, keyed by stream-path prefix. */
-const DOMAIN_PRESETS: { pathPrefix: string; preset: StreamFeedPreset }[] = [
-  {
-    pathPrefix: "/agents/",
-    preset: {
-      id: "agent-events",
-      label: "Agent events",
-      kind: "feed-items",
-      eventTypePrefix: "events.iterate.com/agent/",
-    },
-  },
-  {
-    pathPrefix: "/secrets/",
-    preset: {
-      id: "secret-events",
-      label: "Secret events",
-      kind: "feed-items",
-      eventTypePrefix: "events.iterate.com/secret/",
-    },
-  },
-  {
-    pathPrefix: "/repos/",
-    preset: {
-      id: "repo-events",
-      label: "Repo events",
-      kind: "feed-items",
-      eventTypePrefix: "events.iterate.com/repo/",
-    },
-  },
-  {
-    pathPrefix: "/integrations/slack",
-    preset: {
-      id: "slack-events",
-      label: "Slack events",
-      kind: "feed-items",
-      eventTypePrefix: "events.iterate.com/slack/",
-    },
-  },
-];
-
-/**
- * Feed-items presets for Raw. FIRST is the domain default. Pretty+raw starts
- * from Everything, then applies explicit kind/event-type selections.
- */
-export function presetsForStream(streamPath: string): StreamFeedPreset[] {
-  const presets: StreamFeedPreset[] = [];
-  for (const { pathPrefix, preset } of DOMAIN_PRESETS) {
-    if (streamPath.startsWith(pathPrefix)) presets.push(preset);
-  }
-  presets.push(EVERYTHING_PRESET);
-  return presets;
-}
-
-/**
- * Default feed-items preset for a mode. Pretty+raw is unscoped (Everything) so
- * its raw rows start from the full stream; Raw uses the domain default.
- */
-export function defaultPresetForMode(
-  streamPath: string,
-  mode: ReturnType<typeof streamViewMode>,
-): StreamFeedPreset {
-  const presets = presetsForStream(streamPath);
-  if (mode === "pretty-raw") {
-    return presets.find((preset) => preset.id === "everything") ?? presets[presets.length - 1]!;
-  }
-  return presets[0]!;
-}
-
-/**
  * Whether any feed filter deviates from the stream/mode defaults — drives the
  * header filter-toggle dot.
  */
 export function feedFiltersActive(search: StreamViewSearch, streamPath: string): boolean {
-  const mode = streamViewMode(search, streamPath);
   const caps = modeCapabilities(search, streamPath);
   const hasQuery = (search.q ?? "") !== "";
   if (!caps.rawFeed) {
     return caps.search && hasQuery;
   }
 
-  const defaultPreset = defaultPresetForMode(streamPath, mode);
-  const activePreset =
-    presetsForStream(streamPath).find((preset) => preset.id === search.preset) ?? defaultPreset;
-
   return (
     (caps.search && hasQuery) ||
-    (caps.rawPresets && activePreset.id !== defaultPreset.id) ||
     (caps.rawEventTypes && (search.types?.length ?? 0) > 0) ||
     (caps.rawComponents && (search.components?.length ?? 0) > 0) ||
     (caps.rawOffsets && (search.from != null || search.to != null))
@@ -148,16 +59,14 @@ export const FEED_TYPE_EXPRESSION = `COALESCE(json_extract(data, '$.eventType'),
 
 /**
  * How the raw side of the feed is narrowed. Modes and URL params map into
- * this; `eventTypePrefix` comes from the active preset, `components` (raw
- * kinds) and `eventTypes` from the filter panel.
+ * this; `components` (raw kinds) and `eventTypes` come from the filter panel.
+ * The raw feed itself is always unscoped — there is no domain prefix.
  */
 export type FeedItemsFilterInput = {
   /** Exact primary event types (any-of); null = all. */
   eventTypes: readonly string[] | null;
   /** Raw feed_items.kind values (any-of); null = all. */
   components: readonly string[] | null;
-  /** Active preset's event-type family; null = unscoped. */
-  eventTypePrefix: string | null;
   searchQuery: string | null;
   offsetFrom: number | null;
   offsetTo: number | null;
@@ -169,10 +78,6 @@ type SqlFilter = { whereSql: string; params: SqlValue[] };
 export function buildFeedItemsFilter(input: FeedItemsFilterInput): SqlFilter | null {
   const clauses: string[] = [];
   const params: SqlValue[] = [];
-  if (input.eventTypePrefix != null) {
-    clauses.push(`${FEED_TYPE_EXPRESSION} LIKE ?`);
-    params.push(`${input.eventTypePrefix}%`);
-  }
   if (input.eventTypes != null && input.eventTypes.length > 0) {
     clauses.push(`${FEED_TYPE_EXPRESSION} IN (${input.eventTypes.map(() => "?").join(", ")})`);
     params.push(...input.eventTypes);
@@ -258,19 +163,14 @@ export function feedItemsFilterFromSearch(
     return {
       eventTypes: search.types ?? null,
       components: search.components ?? null,
-      eventTypePrefix: null,
       searchQuery: null,
       offsetFrom: null,
       offsetTo: null,
     };
   }
-  const defaultPreset = defaultPresetForMode(streamPath, mode);
-  const activePreset =
-    presetsForStream(streamPath).find((preset) => preset.id === search.preset) ?? defaultPreset;
   return {
     eventTypes: search.types ?? null,
-    components: search.components ?? activePreset.components ?? null,
-    eventTypePrefix: activePreset.eventTypePrefix ?? null,
+    components: search.components ?? null,
     searchQuery: (search.q ?? "").trim() === "" ? null : (search.q ?? "").trim(),
     offsetFrom: search.from ?? null,
     offsetTo: search.to ?? null,

--- a/apps/os/src/lib/stream-view-search.ts
+++ b/apps/os/src/lib/stream-view-search.ts
@@ -22,8 +22,6 @@ export const StreamViewSearch = z.object({
    * otherwise).
    */
   mode: StreamViewModeRaw.optional().catch(undefined),
-  /** Feed-items domain preset id; omitted on default. */
-  preset: z.string().optional().catch(undefined),
   /** Text query (agent feed and/or feed_items, depending on mode). */
   q: z.string().optional().catch(undefined),
   /**
@@ -70,8 +68,6 @@ type StreamModeCapabilities = {
   filters: boolean;
   /** Search box in the filter row. */
   search: boolean;
-  /** Domain feed-items preset pills. */
-  rawPresets: boolean;
   /** Event-type multi-select (types inside feed items). */
   rawEventTypes: boolean;
   /** Raw kind multi-select (feed_items.kind, raw.* family). */
@@ -87,7 +83,6 @@ const PRETTY_CAPS: StreamModeCapabilities = {
   eventInspector: false,
   filters: true,
   search: true,
-  rawPresets: false,
   rawEventTypes: false,
   rawComponents: false,
   rawOffsets: false,
@@ -100,7 +95,6 @@ const PRETTY_RAW_CAPS: StreamModeCapabilities = {
   eventInspector: true,
   filters: true,
   search: true,
-  rawPresets: false,
   rawEventTypes: true,
   rawComponents: true,
   rawOffsets: false,
@@ -113,7 +107,6 @@ const RAW_CAPS: StreamModeCapabilities = {
   eventInspector: true,
   filters: true,
   search: true,
-  rawPresets: true,
   rawEventTypes: true,
   rawComponents: true,
   rawOffsets: true,

--- a/apps/os/src/routes/_app/projects/$projectSlug/integrations.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/integrations.tsx
@@ -101,7 +101,6 @@ const STREAM_VIEW_SEARCH_RESET = {
   from: undefined,
   mode: undefined,
   panel: undefined,
-  preset: undefined,
   processor: undefined,
   q: undefined,
   to: undefined,


### PR DESCRIPTION
## What

The raw-events panel (the funnel-icon feed that pops open over a stream) defaulted each domain stream to a **scoped preset** — e.g. on `/repos/*` it showed only `events.iterate.com/repo/*` and offered "Repo events" / "Everything" toggle pills next to the filter bar. We always want the full stream there.

This removes the preset concept entirely rather than just hiding the pills (which would leave the feed silently scoped with no way to widen it):

- Delete `StreamFeedPreset`, `DOMAIN_PRESETS`, `presetsForStream`, `defaultPresetForMode`, the `preset` URL search param, and the `rawPresets` capability.
- Drop `eventTypePrefix` scoping from the feed filter (`buildFeedItemsFilter` / `feedItemsFilterFromSearch`) — the raw feed is now always unscoped; the Types multi-select, offset bounds, and search still narrow from there.
- Remove the pill radiogroup from `StreamFeedFilterRow` and the `activePreset`/`presets` plumbing in `project-stream-view`.

Applies to every raw feed (repos, agents, secrets, slack), matching the ask to fix "other views" too.

## Before / after

Before: `/repos/iterate` opened filtered to just repo events, with "Repo events | Everything" pills.
After: the panel shows every event on the stream; the row starts at the search box.

## Verification

- `pnpm test:unit stream-feed-filters.test.ts` → 17/17 pass (updated to the unscoped behavior)
- `pnpm --filter @iterate-com/os typecheck` → clean
- `oxlint` on touched files → 0 warnings / 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Stream-view filtering and URL search shape only; no auth or data writes. Default raw feeds show more events, which is the intended behavior change.
> 
> **Overview**
> **Raw event feeds now default to the entire stream** instead of domain-scoped presets (e.g. repo-only on `/repos/*`). The preset model is removed end-to-end: `StreamFeedPreset`, `presetsForStream`, `defaultPresetForMode`, the `?preset=` search param, and the `rawPresets` mode capability.
> 
> **Filtering** no longer applies an `eventTypePrefix` from presets in `buildFeedItemsFilter` / `feedItemsFilterFromSearch`. Raw mode shows all `raw.*` rows unless the user narrows with **Types**, offset bounds, or search. The filter row drops the preset pill radiogroup; `feedFiltersActive` treats unscoped raw with no URL filters as inactive (no filter-dot).
> 
> **UI plumbing** in `project-stream-view` and `StreamFeedFilterRow` no longer passes `activePreset` / `presets`. The Types panel lists all event types in the mirror (not preset-scoped). Mode tab changes and integration feed search resets no longer touch `preset`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01f72d8bac53a87ac1a090a087779ca1324b4c24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +8 -116 | +1 -88 🟥🟥🟥🟥🟥 |
| UI components | +6 -80 | +6 -79 🟥🟥🟥🟥🟥 |
| Tests | +12 -42 | +11 -38 🟩🟥🟥⬜⬜ |
| **Total** | **+26 -238** | **+18 -205** 🟥🟥🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 10287fb and 01f72d8, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-14T11:32:41.574Z",
      "headSha": "01f72d8bac53a87ac1a090a087779ca1324b4c24",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/314364873161540",
      "shortSha": "01f72d8",
      "cleanupDurationMs": 2286,
      "deployDurationMs": 19893,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.91,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-14T11:32:39.975Z",
      "headSha": "01f72d8bac53a87ac1a090a087779ca1324b4c24",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/314364873161540",
      "shortSha": "01f72d8",
      "cleanupDurationMs": 685,
      "deployDurationMs": 41915,
      "workerSizeKib": 5107.33,
      "workerGzipKib": 1455.97,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No active environment config lease.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `01f72d8` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 819.9 KiB | 19.9s |  |  | 2.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/314364873161540) | 2026-07-14T11:32:41.574Z | Preview app released. |
| Streams Example App | released | `01f72d8` | [https://streams.iterate-preview-9.com](https://streams.iterate-preview-9.com) | 1.42 MiB | 41.9s |  |  | 685ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/314364873161540) | 2026-07-14T11:32:39.975Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->