### PR TITLE
Default browser testing to visible sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ Before PRs:
 pnpm install && pnpm typecheck && pnpm lint && pnpm format && pnpm test
 ```
 
-**Browser testing:** use an isolated `agent-browser` Chrome for Testing session,
-headless by default. "Let me watch" means show that isolated browser with
-`--headed`; it does not mean attach to a developer's actual Chrome. See
+**Browser testing:** use an isolated, headed `agent-browser` Chrome for Testing
+session by default so the developer can watch it. Give every concurrent agent
+a unique session; use headless mode only when explicitly requested or in CI.
+This does not mean attach to a developer's actual Chrome. See
 [Browser testing](docs/browser-testing.md). Keep the CLI and its corresponding
 agent skills up to date.
 
@@ -111,8 +112,8 @@ pnpm test && pnpm typecheck && pnpm lint && pnpm format
 
 How do I…? — **[Dev environments](docs/dev-environments.md)** answers: run
 local dev (fully local, random port, `localhost` plus project
-`<slug>.localhost` hosts), be any user or an admin (minting), point a browser
-(headless golden path) at local dev or a preview, create a preview environment
+`<slug>.localhost` hosts), be any user or an admin (minting), point an isolated
+visible browser at local dev or a preview, create a preview environment
 from your machine, and when you need a public callback URL. Doppler/Cloudflare/deploy details:
 `docs/devops-cloudflare-doppler.md`.
 

--- a/docs/browser-testing.md
+++ b/docs/browser-testing.md
@@ -1,20 +1,23 @@
 # Browser testing
 
-Use `agent-browser` with its own isolated Chrome for Testing. It is headless by
-default, so normal agent work neither opens windows nor touches a developer's
-Chrome profiles, tabs, cookies, or logins.
+Use `agent-browser` with its own isolated, headed Chrome for Testing. On a local
+interactive machine it is visible by default so the developer can watch each
+agent work. Every concurrent agent uses a unique session and therefore gets a
+distinct browser window and tab-switcher entry without touching a developer's
+Chrome profiles, tabs, cookies, or logins. Use headless mode only when the
+developer explicitly asks for no windows or in a non-interactive/CI environment.
 
-| Request                                                | Browser mode                                  | Permission granted                     |
-| ------------------------------------------------------ | --------------------------------------------- | -------------------------------------- |
-| Normal browser task                                    | Headless Chrome for Testing                   | Isolated agent session only            |
-| "Let me watch", "show me the browser", or "watch mode" | Headed Chrome for Testing                     | Show the isolated agent session        |
-| "Use my Chrome profile/login state"                    | Chrome for Testing with a personal-state copy | Exceptional, current-task-only import  |
-| "Use my actual Chrome"                                 | Existing developer Chrome                     | Exceptional, current-task-only control |
+| Request                             | Browser mode                                  | Permission granted                     |
+| ----------------------------------- | --------------------------------------------- | -------------------------------------- |
+| Normal local browser task           | Headed Chrome for Testing                     | Visible isolated agent session         |
+| "No windows", "run headless", or CI | Headless Chrome for Testing                   | Isolated background agent session      |
+| "Use my Chrome profile/login state" | Chrome for Testing with a personal-state copy | Exceptional, current-task-only import  |
+| "Use my actual Chrome"              | Existing developer Chrome                     | Exceptional, current-task-only control |
 
-Watch mode is still the agent's isolated browser; `--headed` merely gives it a
-visible **Google Chrome for Testing** window. It does not authorize Chrome
-DevTools MCP, `--auto-connect`, `--cdp`, or a named personal profile such as
-`Default` or `Profile 1`.
+Watch mode is the normal local default and creates a visible **Google Chrome
+for Testing** window. It does not authorize Chrome DevTools MCP,
+`--auto-connect`, `--cdp`, or a named personal profile such as `Default` or
+`Profile 1`.
 
 ## Profile and session model
 
@@ -55,15 +58,18 @@ agent-browser --session "$SESSION" snapshot -i
 agent-browser --session "$SESSION" close
 ```
 
-For watch mode, add `--headed` to the command that launches the browser:
+The machine-level `~/.agent-browser/config.json` sets `"headed": true`, so the
+commands above open a visible window without an extra flag. For explicit
+headless operation, override that default:
 
 ```bash
-agent-browser --session "$SESSION" --headed open "$URL"
+agent-browser --session "$SESSION" --headed false open "$URL"
 agent-browser --session "$SESSION" snapshot -i
 ```
 
-An already-running headless browser cannot become a window in place. Close it
-and relaunch the same restored session or dedicated profile with `--headed`.
+An already-running browser cannot switch between headed and headless in place.
+Close it and relaunch the same restored session or dedicated profile with the
+desired setting.
 If a human clicks or types in the watched window, the agent must take a new
 snapshot before continuing because its previous element references may be
 stale.
@@ -91,7 +97,7 @@ SESSION="$(agent-browser session id --scope worktree --prefix iterate-login)"
 agent-browser --session "$SESSION" --profile "$PROFILE" --headed open <login-url>
 agent-browser --session "$SESSION" close
 
-# Later automation reuses that isolated login headlessly.
+# Later automation reuses that isolated login in the normal visible mode.
 agent-browser --session "$SESSION" --profile "$PROFILE" open <url>
 ```
 

--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -308,9 +308,10 @@ environment). Generate a fresh forge key with
 
 ## Browsers: the golden path for agents
 
-See [Browser testing](browser-testing.md) for the isolated, headless default;
-visible Chrome for Testing watch mode; reusable test logins; and the explicit
-permission required before attaching to a developer's actual Chrome.
+See [Browser testing](browser-testing.md) for the isolated, visible Chrome for
+Testing default; unique concurrent-agent windows; explicit headless operation;
+reusable test logins; and the permission required before attaching to a
+developer's actual Chrome.
 
 ## Preview environments
 


### PR DESCRIPTION
## What changed

- make isolated headed Chrome for Testing the normal local browser-testing mode
- require a unique agent-browser session for every concurrent agent/window
- document explicit headless overrides for CI or when no windows are requested
- preserve the explicit permission boundary around personal profiles and actual Chrome

## Why

Visible isolated browsers make agent activity observable in the tab switcher without exposing the developer's real Chrome. The prior headless-default wording no longer matches the machine-level agent-browser configuration.

## Validation

- `oxfmt --check README.md docs/browser-testing.md docs/dev-environments.md`
- `git diff --check`
- launched two independent headed Chrome for Testing sessions; one was launched without `--headed` to verify the global default

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to browser-testing guidance; no runtime or security logic changes.
> 
> **Overview**
> **Docs now treat isolated, headed Chrome for Testing as the normal local `agent-browser` mode**, aligned with machine-level `~/.agent-browser/config.json` (`"headed": true`), instead of headless-by-default.
> 
> **README** and **dev-environments** call out unique `--session` per concurrent agent (separate tab-switcher windows) and reserve headless for explicit requests or CI. **browser-testing** flips the permission table so normal local work is headed/visible and headless is the opt-in; disposable-session examples no longer require `--headed` to show a window, and use `--headed false` to override. Watch mode is described as the default local behavior, not a special “let me watch” mode. Personal-profile and actual-Chrome boundaries are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1b1e3503e700f1d5d00a2b4254ad2c67c9c687f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Docs | +36 -28 | +34 -26 🟩🟩🟩🟥🟥 |
| **Total** | **+36 -28** | **+34 -26** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 6500eaf and b1b1e35, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->