### PR TITLE
Move task column add button below the cards

### DIFF
--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -598,15 +598,6 @@ function TaskColumn({
         </header>
       ) : null}
       <div className="flex min-h-0 flex-1 flex-col px-2 pb-2">
-        <Button
-          variant="ghost"
-          className="mb-2 h-10 w-full shrink-0 border border-dashed border-border/70 text-muted-foreground/60 hover:bg-muted/70 hover:text-muted-foreground"
-          title={`Add task to ${creationLabel}`}
-          aria-label={`Add task to ${creationLabel}`}
-          onClick={onCreate}
-        >
-          <PlusIcon data-icon="inline-start" />
-        </Button>
         <div className="flex flex-col gap-2">
           {tasks.map((task) => (
             <TaskCard
@@ -618,6 +609,15 @@ function TaskColumn({
             />
           ))}
         </div>
+        <Button
+          variant="ghost"
+          className="mt-2 h-10 w-full shrink-0 border border-dashed border-border/70 text-muted-foreground/60 hover:bg-muted/70 hover:text-muted-foreground"
+          title={`Add task to ${creationLabel}`}
+          aria-label={`Add task to ${creationLabel}`}
+          onClick={onCreate}
+        >
+          <PlusIcon data-icon="inline-start" />
+        </Button>
       </div>
     </section>
   );


### PR DESCRIPTION
## What

In the task board, each status column rendered its **"Add task"** button *above* the cards. That pushed the existing cards down and made the add affordance read like a column header.

Move the button to **below the last card**, where "add another" naturally belongs, and flip its separating margin from `mb-2` to `mt-2`.

Pure JSX reorder within `TaskColumn` — no logic, props, or behavior change.

## Before / After

```
Before:            After:
[ + Add task ]     [ card ]
[ card ]           [ card ]
[ card ]           [ + Add task ]
```

## Testing

- `pnpm typecheck` ✓ · `pnpm oxlint` ✓ · `pnpm format` ✓ · repo-tasks unit tests ✓
- No test asserts the button's DOM position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational reorder in one component with no behavior or data-path changes.
> 
> **Overview**
> In **`TaskColumn`** on the repo task board, the dashed **Add task** control is rendered **after** the task card list instead of before it, so it reads as “add another” at the bottom of the column rather than a header above existing cards.
> 
> Spacing is updated from **`mb-2`** to **`mt-2`** on that button. **`onClick`**, labels, and drag/drop layout are unchanged—only JSX order and margin class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 369f1c56fbd7c17c8c5082c574d9c4c565b19bfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-14T12:56:10.435Z",
      "headSha": "369f1c56fbd7c17c8c5082c574d9c4c565b19bfa",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/158977504954463",
      "shortSha": "369f1c5",
      "cleanupDurationMs": 2431,
      "deployDurationMs": 24867,
      "testDurationMs": 295,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.91,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-14T12:56:08.679Z",
      "headSha": "369f1c56fbd7c17c8c5082c574d9c4c565b19bfa",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/158977504954463",
      "shortSha": "369f1c5",
      "cleanupDurationMs": 656,
      "deployDurationMs": 18762,
      "testDurationMs": 17273,
      "testRetries": null,
      "workerSizeKib": 5116.03,
      "workerGzipKib": 1458.12,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-14T12:56:06.902Z",
      "headSha": "369f1c56fbd7c17c8c5082c574d9c4c565b19bfa",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/158977504954463",
      "shortSha": "369f1c5",
      "cleanupDurationMs": 155089,
      "deployDurationMs": 115121,
      "testDurationMs": 183041,
      "testRetries": "4 retried: itx > Live capabilities reject the removed target spelling (vitest x1) · itx > Top-level RpcTarget live capabilities dispatch by member path (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page delivers an appended event to another open tab (specs x1)",
      "workerSizeKib": 16762.45,
      "workerGzipKib": 4485.12,
      "mainWorkerGzipKib": 4485.2
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-14T12:53:32.345Z",
      "headSha": "369f1c56fbd7c17c8c5082c574d9c4c565b19bfa",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/158977504954463",
      "shortSha": "369f1c5",
      "cleanupDurationMs": 529,
      "deployDurationMs": 13496,
      "testDurationMs": 5346,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `369f1c5` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 819.9 KiB | 24.9s | 295ms |  | 2.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/158977504954463) | 2026-07-14T12:56:10.435Z | Preview app released. |
| OS | released | `369f1c5` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 4.38 MiB (-0.1 KiB vs main) | 115.1s | 183.0s | 4 retried: itx > Live capabilities reject the removed target spelling (vitest x1) · itx > Top-level RpcTarget live capabilities dispatch by member path (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page delivers an appended event to another open tab (specs x1) | 155.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/158977504954463) | 2026-07-14T12:56:06.902Z | Preview app released. |
| Semaphore | released | `369f1c5` | [https://semaphore.iterate-preview-9.com](https://semaphore.iterate-preview-9.com) | 440.8 KiB | 13.5s | 5.3s |  | 529ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/158977504954463) | 2026-07-14T12:53:32.345Z | Preview app released. |
| Streams Example App | released | `369f1c5` | [https://streams.iterate-preview-9.com](https://streams.iterate-preview-9.com) | 1.42 MiB | 18.8s | 17.3s |  | 656ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/158977504954463) | 2026-07-14T12:56:08.679Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +9 -9 | +9 -9 🟩🟩🟩🟥🟥 |
| **Total** | **+9 -9** | **+9 -9** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between db8917f and 369f1c5, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->