### PR TITLE
fix(os): dismiss mobile sidebar on navigation

### DIFF
--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -64,9 +64,8 @@ import {
   SidebarSeparator,
   useSidebar,
 } from "@iterate-com/ui/components/sidebar";
-import { CloseMobileSidebarOnNavigate } from "~/components/close-mobile-sidebar-on-navigate.tsx";
 import type { ProjectListEntry } from "../project-deployment-status.ts";
-import { StreamPath, type StreamPath as StreamPathType } from "~/lib/stream-links.ts";
+import { CloseMobileSidebarOnNavigate } from "~/components/close-mobile-sidebar-on-navigate.tsx";
 import type { AppConfig } from "~/config.ts";
 import { buildProjectWorkerUrl } from "~/lib/project-host-routing.ts";
 import {
@@ -75,6 +74,7 @@ import {
   projectsListStaleTime,
 } from "~/lib/projects-query.ts";
 import type { PublicRouteConfig } from "~/lib/public-route-config.ts";
+import { StreamPath, type StreamPath as StreamPathType } from "~/lib/stream-links.ts";
 
 type PublicConfig = PublicAppConfig<AppConfig>;
 

--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -94,26 +94,30 @@ export function AppSidebar({ routeConfig }: { routeConfig: PublicRouteConfig }) 
 
   // Sidebar composition follows shadcn sidebar blocks 07/08:
   // https://ui.shadcn.com/blocks/sidebar
+  // CloseMobileSidebarOnNavigate must sit outside <Sidebar>: on mobile, Sidebar
+  // children live inside a Sheet that remounts when opened.
   return (
-    <Sidebar collapsible="icon">
+    <>
       <CloseMobileSidebarOnNavigate />
-      {/* Collapsed: nudge the logo down 4px (pt-2 → pt-3) so its center lines up
+      <Sidebar collapsible="icon">
+        {/* Collapsed: nudge the logo down 4px (pt-2 → pt-3) so its center lines up
           with the stream path pill in the page header (h-9 pill, pt-2.5 → center 28px).
           Transition padding with Tailwind's default timing — the same curve the
           SidebarMenuButton uses for its width/height/padding — so the padding offset
           and the button's height change move the logo together instead of drifting. */}
-      <SidebarHeader className="transition-[padding] group-data-[collapsible=icon]:pt-3">
-        <AppSidebarHeader projects={projects} />
-      </SidebarHeader>
-      <SidebarContent>
-        <AppSidebarNav routeConfig={routeConfig} />
-      </SidebarContent>
-      <SidebarFooter>
-        <AppSidebarCollapseButton />
-        <AppSidebarUser />
-      </SidebarFooter>
-      <SidebarRail />
-    </Sidebar>
+        <SidebarHeader className="transition-[padding] group-data-[collapsible=icon]:pt-3">
+          <AppSidebarHeader projects={projects} />
+        </SidebarHeader>
+        <SidebarContent>
+          <AppSidebarNav routeConfig={routeConfig} />
+        </SidebarContent>
+        <SidebarFooter>
+          <AppSidebarCollapseButton />
+          <AppSidebarUser />
+        </SidebarFooter>
+        <SidebarRail />
+      </Sidebar>
+    </>
   );
 }
 

--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -64,6 +64,7 @@ import {
   SidebarSeparator,
   useSidebar,
 } from "@iterate-com/ui/components/sidebar";
+import { CloseMobileSidebarOnNavigate } from "~/components/close-mobile-sidebar-on-navigate.tsx";
 import type { ProjectListEntry } from "../project-deployment-status.ts";
 import { StreamPath, type StreamPath as StreamPathType } from "~/lib/stream-links.ts";
 import type { AppConfig } from "~/config.ts";
@@ -95,6 +96,7 @@ export function AppSidebar({ routeConfig }: { routeConfig: PublicRouteConfig }) 
   // https://ui.shadcn.com/blocks/sidebar
   return (
     <Sidebar collapsible="icon">
+      <CloseMobileSidebarOnNavigate />
       {/* Collapsed: nudge the logo down 4px (pt-2 → pt-3) so its center lines up
           with the stream path pill in the page header (h-9 pill, pt-2.5 → center 28px).
           Transition padding with Tailwind's default timing — the same curve the

--- a/apps/os/src/components/close-mobile-sidebar-on-navigate.tsx
+++ b/apps/os/src/components/close-mobile-sidebar-on-navigate.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+import { useRouterState } from "@tanstack/react-router";
+import { useSidebar } from "@iterate-com/ui/components/sidebar";
+
+/**
+ * Idiomatic shadcn mobile sidebar: dismiss the Sheet when the route changes.
+ *
+ * Stock Sidebar exposes `setOpenMobile` for this (docs) but does not auto-close
+ * on navigation — see https://github.com/shadcn-ui/ui/issues/5561. In-sheet
+ * link buttons are handled by `SidebarMenuButton`; this covers portaled menu
+ * items (project switcher, account menu) that navigate outside the Sheet DOM.
+ */
+export function CloseMobileSidebarOnNavigate() {
+  const { setOpenMobile } = useSidebar();
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+
+  useEffect(() => {
+    setOpenMobile(false);
+  }, [pathname, setOpenMobile]);
+
+  return null;
+}

--- a/apps/os/src/components/close-mobile-sidebar-on-navigate.tsx
+++ b/apps/os/src/components/close-mobile-sidebar-on-navigate.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useRouterState } from "@tanstack/react-router";
 import { useSidebar } from "@iterate-com/ui/components/sidebar";
 
@@ -9,12 +9,19 @@ import { useSidebar } from "@iterate-com/ui/components/sidebar";
  * on navigation — see https://github.com/shadcn-ui/ui/issues/5561. In-sheet
  * link buttons are handled by `SidebarMenuButton`; this covers portaled menu
  * items (project switcher, account menu) that navigate outside the Sheet DOM.
+ *
+ * Only close when `pathname` actually changes — not on mount. The mobile
+ * sidebar renders children inside a Sheet that remounts when opened; an
+ * unconditional mount effect would dismiss the sheet as soon as it opens.
  */
 export function CloseMobileSidebarOnNavigate() {
   const { setOpenMobile } = useSidebar();
   const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const previousPathnameRef = useRef(pathname);
 
   useEffect(() => {
+    if (previousPathnameRef.current === pathname) return;
+    previousPathnameRef.current = pathname;
     setOpenMobile(false);
   }, [pathname, setOpenMobile]);
 

--- a/apps/os/src/routes/admin.tsx
+++ b/apps/os/src/routes/admin.tsx
@@ -146,85 +146,92 @@ function AdminSidebar() {
   const pathname = useRouterState({ select: (state) => state.location.pathname });
 
   return (
-    <Sidebar collapsible="icon">
+    <>
+      {/* Outside <Sidebar>: mobile Sheet remounts its children when opened. */}
       <CloseMobileSidebarOnNavigate />
-      <SidebarHeader>
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton size="lg" tooltip="Iterate Admin" render={<Link to="/admin" />}>
-              <div className="flex aspect-square size-8 items-center justify-center rounded-md bg-sidebar-primary text-sidebar-primary-foreground">
-                <ShieldIcon aria-hidden="true" />
-              </div>
-              <div className="grid flex-1 text-left text-sm leading-tight">
-                <span className="truncate font-medium">Iterate Admin</span>
-                <span className="truncate text-xs text-sidebar-foreground/70">Platform tools</span>
-              </div>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-        </SidebarMenu>
-      </SidebarHeader>
-      <SidebarContent>
-        <SidebarGroup>
-          <SidebarGroupLabel>Admin</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  tooltip="Streams explorer"
-                  isActive={pathname.startsWith("/admin/streams")}
-                  render={<Link to="/admin/streams" />}
-                >
-                  <WaypointsIcon aria-hidden="true" />
-                  <span>Streams explorer</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  tooltip="Projects"
-                  isActive={pathname.startsWith("/admin/projects")}
-                  render={<Link to="/admin/projects" />}
-                >
-                  <FolderKanbanIcon aria-hidden="true" />
-                  <span>Projects</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  tooltip="Repl"
-                  isActive={pathname.startsWith("/admin/repl")}
-                  render={<Link to="/admin/repl" />}
-                >
-                  <SquareTerminalIcon aria-hidden="true" />
-                  <span>Repl</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-        <SidebarGroup>
-          <SidebarGroupLabel>Shortcuts</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  tooltip="Global streams"
-                  isActive={pathname.startsWith(`/admin/streams/${NULL_DURABLE_OBJECT_PROJECT_ID}`)}
-                  render={
-                    <Link
-                      to="/admin/streams/$projectId"
-                      params={{ projectId: NULL_DURABLE_OBJECT_PROJECT_ID }}
-                    />
-                  }
-                >
-                  <RadioTowerIcon aria-hidden="true" />
-                  <span>Global streams</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-      </SidebarContent>
-      <SidebarRail />
-    </Sidebar>
+      <Sidebar collapsible="icon">
+        <SidebarHeader>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton size="lg" tooltip="Iterate Admin" render={<Link to="/admin" />}>
+                <div className="flex aspect-square size-8 items-center justify-center rounded-md bg-sidebar-primary text-sidebar-primary-foreground">
+                  <ShieldIcon aria-hidden="true" />
+                </div>
+                <div className="grid flex-1 text-left text-sm leading-tight">
+                  <span className="truncate font-medium">Iterate Admin</span>
+                  <span className="truncate text-xs text-sidebar-foreground/70">
+                    Platform tools
+                  </span>
+                </div>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarHeader>
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupLabel>Admin</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    tooltip="Streams explorer"
+                    isActive={pathname.startsWith("/admin/streams")}
+                    render={<Link to="/admin/streams" />}
+                  >
+                    <WaypointsIcon aria-hidden="true" />
+                    <span>Streams explorer</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    tooltip="Projects"
+                    isActive={pathname.startsWith("/admin/projects")}
+                    render={<Link to="/admin/projects" />}
+                  >
+                    <FolderKanbanIcon aria-hidden="true" />
+                    <span>Projects</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    tooltip="Repl"
+                    isActive={pathname.startsWith("/admin/repl")}
+                    render={<Link to="/admin/repl" />}
+                  >
+                    <SquareTerminalIcon aria-hidden="true" />
+                    <span>Repl</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+          <SidebarGroup>
+            <SidebarGroupLabel>Shortcuts</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    tooltip="Global streams"
+                    isActive={pathname.startsWith(
+                      `/admin/streams/${NULL_DURABLE_OBJECT_PROJECT_ID}`,
+                    )}
+                    render={
+                      <Link
+                        to="/admin/streams/$projectId"
+                        params={{ projectId: NULL_DURABLE_OBJECT_PROJECT_ID }}
+                      />
+                    }
+                  >
+                    <RadioTowerIcon aria-hidden="true" />
+                    <span>Global streams</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+        <SidebarRail />
+      </Sidebar>
+    </>
   );
 }

--- a/apps/os/src/routes/admin.tsx
+++ b/apps/os/src/routes/admin.tsx
@@ -30,6 +30,7 @@ import {
   SidebarRail,
   SidebarTrigger,
 } from "@iterate-com/ui/components/sidebar";
+import { CloseMobileSidebarOnNavigate } from "~/components/close-mobile-sidebar-on-navigate.tsx";
 import { GlobalCommandPalette } from "~/components/global-command-palette.tsx";
 import { NULL_DURABLE_OBJECT_PROJECT_ID } from "~/lib/stream-navigation.ts";
 import { useItx } from "~/itx/itx-react.tsx";
@@ -146,6 +147,7 @@ function AdminSidebar() {
 
   return (
     <Sidebar collapsible="icon">
+      <CloseMobileSidebarOnNavigate />
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -476,6 +476,26 @@ const sidebarMenuButtonVariants = cva(
   },
 );
 
+/**
+ * Stock shadcn leaves the mobile Sheet open after in-sheet navigation
+ * (https://github.com/shadcn-ui/ui/issues/5561). When a menu control is a
+ * same-tab link, dismiss the sheet so the destination is visible immediately.
+ * Real `<button>` triggers (collapse, dropdown openers) are left alone.
+ */
+function dismissMobileSidebarOnLinkClick(
+  event: React.SyntheticEvent<HTMLElement>,
+  isMobile: boolean,
+  setOpenMobile: (open: boolean) => void,
+) {
+  if (!isMobile) return;
+  const el = event.currentTarget;
+  if (!(el instanceof HTMLAnchorElement)) return;
+  if (el.hasAttribute("download")) return;
+  const target = el.getAttribute("target");
+  if (target && target !== "_self") return;
+  setOpenMobile(false);
+}
+
 function SidebarMenuButton({
   render,
   isActive = false,
@@ -489,12 +509,15 @@ function SidebarMenuButton({
     isActive?: boolean;
     tooltip?: string | React.ComponentProps<typeof TooltipContent>;
   } & VariantProps<typeof sidebarMenuButtonVariants>) {
-  const { isMobile, state } = useSidebar();
+  const { isMobile, state, setOpenMobile } = useSidebar();
   const comp = useRender({
     defaultTagName: "button",
     props: mergeProps<"button">(
       {
         className: cn(sidebarMenuButtonVariants({ variant, size }), className),
+        onClick(event) {
+          dismissMobileSidebarOnLinkClick(event, isMobile, setOpenMobile);
+        },
       },
       props,
     ),
@@ -643,6 +666,7 @@ function SidebarMenuSubButton({
     size?: "sm" | "md";
     isActive?: boolean;
   }) {
+  const { isMobile, setOpenMobile } = useSidebar();
   return useRender({
     defaultTagName: "a",
     props: mergeProps<"a">(
@@ -651,6 +675,9 @@ function SidebarMenuSubButton({
           "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
           className,
         ),
+        onClick(event) {
+          dismissMobileSidebarOnLinkClick(event, isMobile, setOpenMobile);
+        },
       },
       props,
     ),

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -481,9 +481,10 @@ const sidebarMenuButtonVariants = cva(
  * (https://github.com/shadcn-ui/ui/issues/5561). When a menu control is a
  * same-tab link, dismiss the sheet so the destination is visible immediately.
  * Real `<button>` triggers (collapse, dropdown openers) are left alone.
+ * Modifier / middle-click navigation opens another tab and must not dismiss.
  */
 function dismissMobileSidebarOnLinkClick(
-  event: React.SyntheticEvent<HTMLElement>,
+  event: React.MouseEvent<HTMLElement>,
   isMobile: boolean,
   setOpenMobile: (open: boolean) => void,
 ) {
@@ -493,6 +494,10 @@ function dismissMobileSidebarOnLinkClick(
   if (el.hasAttribute("download")) return;
   const target = el.getAttribute("target");
   if (target && target !== "_self") return;
+  // Keep the sheet open when the browser will not navigate this tab.
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) {
+    return;
+  }
   setOpenMobile(false);
 }
 


### PR DESCRIPTION
## Summary

- On mobile, the shadcn `Sidebar` is a `Sheet`. Stock behavior leaves that sheet open after you click a nav link ([shadcn-ui/ui#5561](https://github.com/shadcn-ui/ui/issues/5561)); the destination page stays covered.
- **Idiomatic fix** using the documented `setOpenMobile` API from `useSidebar`:
  1. `SidebarMenuButton` / `SidebarMenuSubButton` dismiss the sheet on same-tab link clicks (not real buttons like collapse/dropdown triggers, not `target=_blank` / download links).
  2. `CloseMobileSidebarOnNavigate` dismisses on pathname change so portaled menus (project switcher, account) also close.
- Wired into both the app sidebar and admin sidebar. Stays as close as possible to base-ui shadcn composition; no custom drawer.

## Test plan

- [ ] Open OS on a mobile viewport (or narrow browser), open the sidebar sheet
- [ ] Tap a project nav link (e.g. Settings, /agents) → sheet closes and page is visible
- [ ] Open sidebar → project switcher → pick a project → sheet closes
- [ ] Open sidebar → account menu → Admin (if applicable) → sheet closes
- [ ] Open sidebar → Homepage (`target=_blank`) → sheet stays open (new tab)
- [ ] Desktop: collapse/expand and link navigation still work; no unexpected sheet behavior
- [ ] Admin mobile sidebar links dismiss the sheet

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped mobile sidebar UX in shared UI click handlers plus a small OS navigation listener; no auth, data, or API changes.
> 
> **Overview**
> Fixes mobile navigation UX where the shadcn **Sidebar** `Sheet` stayed open after tapping nav links, covering the new page ([shadcn-ui/ui#5561](https://github.com/shadcn-ui/ui/issues/5561)).
> 
> In **`packages/ui`**, `SidebarMenuButton` and `SidebarMenuSubButton` now call `setOpenMobile(false)` on same-tab anchor clicks on mobile, while skipping real buttons, `target="_blank"` / download links, and modifier or non–left-click opens.
> 
> OS adds **`CloseMobileSidebarOnNavigate`**, which closes the sheet when the route **pathname** changes (for portaled project switcher and account menus). It is mounted **outside** `<Sidebar>` in the main app sidebar and admin layout so Sheet remounts do not fire a bogus close on open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a33f2a490caf3f18a3ee82b63228ffafcdf2cf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +88 -79 | +88 -79 🟩🟩🟩🟥🟥 |
| UI components | +83 -16 | +57 -16 🟩🟩⬜⬜⬜ |
| **Total** | **+171 -95** | **+145 -95** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 5415bbc and 4a33f2a, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "cleanup-failed",
      "updatedAt": "2026-07-14T13:35:23.803Z",
      "headSha": "4a33f2a490caf3f18a3ee82b63228ffafcdf2cf8",
      "message": "CloudflareApiError: Cloudflare API POST /accounts/376ef7ed81b0573f93524de763666c15/d1/database/c5a24ab5-e10b-4ca5-a2f2-2451803bc146/query failed (429): [{\"code\":971,\"message\":\"Please wait and consider throttling your request speed\"}]\n    at cfV4 (/home/runner/work/iterate/iterate/scripts/lib/env-context.ts:108:13)\n    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)\n    at async wipeD1Tables (/home/runner/work/iterate/iterate/scripts/lib/deploy-helpers.ts:312:5)\n    at async eraseData (/home/runner/work/iterate/iterate/apps/auth/scripts/erase-data.ts:44:3)\n    at async Command.<anonymous> (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:416:32)\n    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)\n    at async Command.<anonymous> (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:457:21)\n    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)\n    at async Object.run (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:527:9) {\n  method: 'POST',\n  path: '/accounts/376ef7ed81b0573f93524de763666c15/d1/database/c5a24ab5-e10b-4ca5-a2f2-2451803bc146/query',\n  status: 429\n}\n\n\n> @iterate-com/auth@0.0.0-dev destroy /home/runner/work/iterate/iterate/apps/auth\n> tsx ./scripts/erase-data.ts --env preview_2\n\nErasing all data in preview_2 (auth D1 c5a24ab5-e10b-4ca5-a2f2-2451803bc146)\n ELIFECYCLE  Command failed with exit code 1.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/196435219590824",
      "shortSha": "4a33f2a",
      "cleanupDurationMs": 1777,
      "deployDurationMs": 18107,
      "testDurationMs": 525,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.78,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-14T13:35:22.653Z",
      "headSha": "d7dd0d1154712f4e56688e319619bcfb33c95ae5",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/579794954451178",
      "shortSha": "d7dd0d1",
      "cleanupDurationMs": 625,
      "deployDurationMs": 16533,
      "testDurationMs": 18374,
      "testRetries": null,
      "workerSizeKib": 5117.13,
      "workerGzipKib": 1458.43,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-14T13:35:20.783Z",
      "headSha": "4a33f2a490caf3f18a3ee82b63228ffafcdf2cf8",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/196435219590824",
      "shortSha": "4a33f2a",
      "cleanupDurationMs": 216392,
      "deployDurationMs": 74173,
      "testDurationMs": 218769,
      "testRetries": "6 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · creates a project and uses project streams through v4 itx (vitest x1) · state-only stream subscribe pushes initial state immediately, then state after appends (vitest x1) · hydrates the client-only integrations route without rebuilding the shell (specs x1) · reactivity page appends a batch and renders every delivered marker (specs x1) · runs \"ephemeral-events\" through the project REPL (specs x1)",
      "workerSizeKib": 16353.42,
      "workerGzipKib": 4410.78,
      "mainWorkerGzipKib": 4410.15
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-14T13:31:44.813Z",
      "headSha": "d7dd0d1154712f4e56688e319619bcfb33c95ae5",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/579794954451178",
      "shortSha": "d7dd0d1",
      "cleanupDurationMs": 418,
      "deployDurationMs": 22047,
      "testDurationMs": 7864,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_2",
    "slug": "preview-2"
  },
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>Slot: preview-2 | Doppler config: preview_2</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | cleanup failed | `4a33f2a` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 819.8 KiB | 18.1s | 525ms |  | 1.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/196435219590824) | 2026-07-14T13:35:23.803Z | CloudflareApiError: Cloudflare API POST /accounts/376ef7ed81b0573f93524de763666c15/d1/database/c5a24ab5-e10b-4ca5-a2f2-2451803bc146/query failed (429): [{"code":971,"message":"Ple... |
| OS | released | `4a33f2a` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.31 MiB (+0.6 KiB vs main) | 74.2s | 218.8s | 6 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · creates a project and uses project streams through v4 itx (vitest x1) · state-only stream subscribe pushes initial state immediately, then state after appends (vitest x1) · hydrates the client-only integrations route without rebuilding the shell (specs x1) · reactivity page appends a batch and renders every delivered marker (specs x1) · runs "ephemeral-events" through the project REPL (specs x1) | 216.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/196435219590824) | 2026-07-14T13:35:20.783Z | Preview app released. |
| Semaphore | released | `d7dd0d1` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 440.8 KiB | 22.0s | 7.9s |  | 418ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/579794954451178) | 2026-07-14T13:31:44.813Z | Preview app released. |
| Streams Example App | released | `d7dd0d1` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 1.42 MiB | 16.5s | 18.4s |  | 625ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/579794954451178) | 2026-07-14T13:35:22.653Z | Preview app released. |

</details>

<details>
<summary>Auth failure details</summary>

<pre>CloudflareApiError: Cloudflare API POST /accounts/376ef7ed81b0573f93524de763666c15/d1/database/c5a24ab5-e10b-4ca5-a2f2-2451803bc146/query failed (429): [{"code":971,"message":"Please wait and consider throttling your request speed"}]
    at cfV4 (/home/runner/work/iterate/iterate/scripts/lib/env-context.ts:108:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async wipeD1Tables (/home/runner/work/iterate/iterate/scripts/lib/deploy-helpers.ts:312:5)
    at async eraseData (/home/runner/work/iterate/iterate/apps/auth/scripts/erase-data.ts:44:3)
    at async Command.&lt;anonymous&gt; (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:416:32)
    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)
    at async Command.&lt;anonymous&gt; (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:457:21)
    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)
    at async Object.run (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:527:9) {
  method: 'POST',
  path: '/accounts/376ef7ed81b0573f93524de763666c15/d1/database/c5a24ab5-e10b-4ca5-a2f2-2451803bc146/query',
  status: 429
}


&gt; @iterate-com/auth@0.0.0-dev destroy /home/runner/work/iterate/iterate/apps/auth
&gt; tsx ./scripts/erase-data.ts --env preview_2

Erasing all data in preview_2 (auth D1 c5a24ab5-e10b-4ca5-a2f2-2451803bc146)
 ELIFECYCLE  Command failed with exit code 1.</pre>

</details>
<!-- /CLOUDFLARE_PREVIEW -->