### PR TITLE
Restore top task add controls and add event canary task

### DIFF
--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -604,6 +604,15 @@ function TaskColumn({
         </header>
       ) : null}
       <div className="flex min-h-0 flex-1 flex-col px-2 pb-2">
+        <Button
+          variant="ghost"
+          className="mb-2 h-10 w-full shrink-0 border border-dashed border-border/70 text-muted-foreground/60 hover:bg-muted/70 hover:text-muted-foreground"
+          title={`Add task to ${creationLabel}`}
+          aria-label={`Add task to ${creationLabel}`}
+          onClick={onCreate}
+        >
+          <PlusIcon data-icon="inline-start" />
+        </Button>
         <div className="flex flex-col gap-2">
           {tasks.map((task) => (
             <TaskCard
@@ -615,15 +624,6 @@ function TaskColumn({
             />
           ))}
         </div>
-        <Button
-          variant="ghost"
-          className="mt-2 h-10 w-full shrink-0 border border-dashed border-border/70 text-muted-foreground/60 hover:bg-muted/70 hover:text-muted-foreground"
-          title={`Add task to ${creationLabel}`}
-          aria-label={`Add task to ${creationLabel}`}
-          onClick={onCreate}
-        >
-          <PlusIcon data-icon="inline-start" />
-        </Button>
       </div>
     </section>
   );

--- a/tasks/github-task-event-ingress-production-canary.md
+++ b/tasks/github-task-event-ingress-production-canary.md
@@ -1,0 +1,15 @@
+---
+status: todo
+---
+
+# Automate the GitHub task-event production canary
+
+Turn the 2026-07-14 manual production proof into a non-destructive scheduled
+canary. A default-branch GitHub task-file change should be imported into the
+Cloudflare Artifact and emit `repo/commit-completed` plus the corresponding
+`repo/task-created`, `repo/task-updated`, or `repo/task-deleted` event from the
+Artifact queue consumer.
+
+The canary should verify the Artifact and GitHub commit OIDs converge and
+record enough event metadata to distinguish webhook receipt, import, and queue
+processing without creating a permanent task on every run.


### PR DESCRIPTION
## Summary

- restore the always-visible task-column add control to the top after parallel PR #1982 moved it below the cards
- add a real repo task for automating the manual GitHub-to-Artifact task-event canary
- use this task creation itself as the post-deploy production ingress proof

## Verification

- `pnpm --dir apps/os test -- repo-tasks.test.ts`
- `pnpm --dir apps/os typecheck`
- `git diff --check`
- commit-hook formatting passed
- after merge, verify GitHub and Artifact commit OIDs converge and capture `repo/github-import-requested`, import completion, `repo/cloudflare-artifact-event-received`, `repo/commit-completed`, and `repo/task-created` from the production repo stream

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +9 -9 | +9 -9 🟩🟩🟩🟥🟥 |
| Docs | +15 -0 | +12 -0 🟩🟩🟩⬜⬜ |
| **Total** | **+24 -9** | **+21 -9** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between b635a97 and 5460f56, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "cleanup-failed",
      "updatedAt": "2026-07-14T13:30:44.043Z",
      "headSha": "5460f5635fc6ee25f4244bfff13fecca9e7e7caf",
      "message": "CloudflareApiError: Cloudflare API POST /accounts/376ef7ed81b0573f93524de763666c15/d1/database/f8542574-48e3-4374-910f-3186293137f0/query failed (429): [{\"code\":971,\"message\":\"Please wait and consider throttling your request speed\"}]\n    at cfV4 (/home/runner/work/iterate/iterate/scripts/lib/env-context.ts:108:13)\n    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)\n    at async wipeD1Tables (/home/runner/work/iterate/iterate/scripts/lib/deploy-helpers.ts:312:5)\n    at async eraseData (/home/runner/work/iterate/iterate/apps/auth/scripts/erase-data.ts:44:3)\n    at async Command.<anonymous> (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:416:32)\n    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)\n    at async Command.<anonymous> (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:457:21)\n    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)\n    at async Object.run (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:527:9) {\n  method: 'POST',\n  path: '/accounts/376ef7ed81b0573f93524de763666c15/d1/database/f8542574-48e3-4374-910f-3186293137f0/query',\n  status: 429\n}\n\n\n> @iterate-com/auth@0.0.0-dev destroy /home/runner/work/iterate/iterate/apps/auth\n> tsx ./scripts/erase-data.ts --env preview_5\n\nErasing all data in preview_5 (auth D1 f8542574-48e3-4374-910f-3186293137f0)\n ELIFECYCLE  Command failed with exit code 1.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/248817276106274",
      "shortSha": "5460f56",
      "cleanupDurationMs": 1525,
      "deployDurationMs": 22534,
      "testDurationMs": 228,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.73,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-14T13:30:41.486Z",
      "headSha": "5460f5635fc6ee25f4244bfff13fecca9e7e7caf",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/248817276106274",
      "shortSha": "5460f56",
      "cleanupDurationMs": 222467,
      "deployDurationMs": 84014,
      "testDurationMs": 273605,
      "testRetries": "4 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · a new user can create a project through the UI form (specs x1) · reactivity page repaints from a stream subscription after a page action (specs x1) · toggle an html file between Code and its sandboxed Preview (specs x1)",
      "workerSizeKib": 16350.78,
      "workerGzipKib": 4410.14,
      "mainWorkerGzipKib": 4410.15
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-14T13:30:43.034Z",
      "headSha": "5460f5635fc6ee25f4244bfff13fecca9e7e7caf",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/248817276106274",
      "shortSha": "5460f56",
      "cleanupDurationMs": 514,
      "deployDurationMs": 15016,
      "testDurationMs": 21452,
      "testRetries": null,
      "workerSizeKib": 5117.13,
      "workerGzipKib": 1458.43,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-14T13:26:59.586Z",
      "headSha": "5460f5635fc6ee25f4244bfff13fecca9e7e7caf",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/248817276106274",
      "shortSha": "5460f56",
      "cleanupDurationMs": 564,
      "deployDurationMs": 14162,
      "testDurationMs": 15001,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_5",
    "slug": "preview-5"
  },
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>Slot: preview-5 | Doppler config: preview_5</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | cleanup failed | `5460f56` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 819.7 KiB | 22.5s | 228ms |  | 1.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/248817276106274) | 2026-07-14T13:30:44.043Z | CloudflareApiError: Cloudflare API POST /accounts/376ef7ed81b0573f93524de763666c15/d1/database/f8542574-48e3-4374-910f-3186293137f0/query failed (429): [{"code":971,"message":"Ple... |
| OS | released | `5460f56` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 4.31 MiB (±0 vs main) | 84.0s | 273.6s | 4 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · a new user can create a project through the UI form (specs x1) · reactivity page repaints from a stream subscription after a page action (specs x1) · toggle an html file between Code and its sandboxed Preview (specs x1) | 222.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/248817276106274) | 2026-07-14T13:30:41.486Z | Preview app released. |
| Semaphore | released | `5460f56` | [https://semaphore.iterate-preview-5.com](https://semaphore.iterate-preview-5.com) | 440.8 KiB | 14.2s | 15.0s |  | 564ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/248817276106274) | 2026-07-14T13:26:59.586Z | Preview app released. |
| Streams Example App | released | `5460f56` | [https://streams.iterate-preview-5.com](https://streams.iterate-preview-5.com) | 1.42 MiB | 15.0s | 21.5s |  | 514ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/248817276106274) | 2026-07-14T13:30:43.034Z | Preview app released. |

</details>

<details>
<summary>Auth failure details</summary>

<pre>CloudflareApiError: Cloudflare API POST /accounts/376ef7ed81b0573f93524de763666c15/d1/database/f8542574-48e3-4374-910f-3186293137f0/query failed (429): [{"code":971,"message":"Please wait and consider throttling your request speed"}]
    at cfV4 (/home/runner/work/iterate/iterate/scripts/lib/env-context.ts:108:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async wipeD1Tables (/home/runner/work/iterate/iterate/scripts/lib/deploy-helpers.ts:312:5)
    at async eraseData (/home/runner/work/iterate/iterate/apps/auth/scripts/erase-data.ts:44:3)
    at async Command.&lt;anonymous&gt; (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:416:32)
    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)
    at async Command.&lt;anonymous&gt; (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:457:21)
    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)
    at async Object.run (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:527:9) {
  method: 'POST',
  path: '/accounts/376ef7ed81b0573f93524de763666c15/d1/database/f8542574-48e3-4374-910f-3186293137f0/query',
  status: 429
}


&gt; @iterate-com/auth@0.0.0-dev destroy /home/runner/work/iterate/iterate/apps/auth
&gt; tsx ./scripts/erase-data.ts --env preview_5

Erasing all data in preview_5 (auth D1 f8542574-48e3-4374-910f-3186293137f0)
 ELIFECYCLE  Command failed with exit code 1.</pre>

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI reorder in `TaskColumn` plus documentation-style task markdown; no auth, data, or pipeline logic changes in this diff.
> 
> **Overview**
> Moves the **Add task** dashed control in each repo task board column back **above** the task cards (with `mb-2` instead of `mt-2`), reversing a layout change that had placed it below the list.
> 
> Adds a repo task file **`tasks/github-task-event-ingress-production-canary.md`** that tracks automating the manual GitHub→Artifact task-event production canary: scheduled, non-destructive checks that default-branch task-file changes import correctly and emit the expected `repo/*` events, with OID convergence and enough metadata to separate webhook, import, and queue stages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5460f5635fc6ee25f4244bfff13fecca9e7e7caf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->