### PR TITLE
pnpm e2e auto-starts the local dev server (sibling-lane ergonomics)

### DIFF
--- a/apps/os/e2e/test-support/global-setup.ts
+++ b/apps/os/e2e/test-support/global-setup.ts
@@ -1,0 +1,123 @@
+/**
+ * Vitest globalSetup: give `pnpm e2e` the same dev-server ergonomics as the
+ * root Playwright lane (`pnpm spec`), whose webServer block this mirrors:
+ *
+ * - `APP_CONFIG_BASE_URL` set (a deployed target — always the case in CI):
+ *   strict no-op, exactly like Playwright skipping its webServer block.
+ * - A LIVE local dev server is discoverable (`.dev-server/dev-server.json`
+ *   with its pid still running): reuse it, like Playwright's
+ *   `reuseExistingServer: !CI`.
+ * - Otherwise: start one detached via scripts/dev.ts — the same
+ *   `start --detach` lane Playwright's webServer command drives — and wait
+ *   for `/api/health`. The server deliberately outlives the run (Playwright's
+ *   `--keep-alive` wrapper leaves the detached vite behind too): the next
+ *   `pnpm e2e` / `pnpm spec` reuses it, and `pnpm dev kill` stops it.
+ * - `CI` set without a base URL: never boot a server on a CI runner. The
+ *   suites keep failing with their existing clear "APP_CONFIG_BASE_URL is
+ *   required" error.
+ *
+ * Runs once per vitest run: listed on both projects (vitest reads
+ * `globalSetup` per project, like `retry`), deduped via a globalThis promise
+ * because each project loads its own instance of this module.
+ */
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { setTimeout as sleep } from "node:timers/promises";
+import startDevServer, { localOsDevServer } from "../../scripts/dev.ts";
+import { devServerLogPath } from "../../scripts/lib/dev-server-info.ts";
+
+type LocalOsDevTarget = Awaited<ReturnType<typeof localOsDevServer.resolveTarget>>;
+
+const appRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+// Symbol.for-keyed globalThis stashes: vitest.config.ts (vite's bundled
+// config eval) and this setup file (vite-node) get separate module
+// instances, but share the process.
+const TARGET_KEY: unique symbol = Symbol.for("iterate.osE2e.localDevTarget");
+const ENSURE_KEY: unique symbol = Symbol.for("iterate.osE2e.ensureDevServer");
+const stash = globalThis as typeof globalThis & {
+  [TARGET_KEY]?: Promise<LocalOsDevTarget>;
+  [ENSURE_KEY]?: Promise<void>;
+};
+
+/**
+ * The local target `pnpm e2e` uses when `APP_CONFIG_BASE_URL` is unset: the
+ * live dev server, or the port a to-be-started one will listen on. Resolved
+ * once per process so vitest.config.ts (the browser project's `define`) and
+ * the globalSetup below agree on the port even when nothing is running yet —
+ * the same way playwright.config.ts bakes `--port N` into its webServer
+ * command.
+ */
+export function resolveLocalOsDevTargetOnce(): Promise<LocalOsDevTarget> {
+  return (stash[TARGET_KEY] ??= localOsDevServer.resolveTarget());
+}
+
+export default async function globalSetup(): Promise<void> {
+  await (stash[ENSURE_KEY] ??= ensureOsUnderTest());
+}
+
+async function ensureOsUnderTest(): Promise<void> {
+  const configured = process.env.APP_CONFIG_BASE_URL?.trim();
+  if (configured) {
+    console.log(`[e2e] deployed target ${configured} — no local dev server involved.`);
+    return;
+  }
+  if (process.env.CI) {
+    // Playwright never reuses a server in CI; we go further and never boot
+    // one either — CI lanes always provide APP_CONFIG_BASE_URL, so reaching
+    // this line is a lane misconfiguration, not a reason to start vite on a
+    // CI runner.
+    console.log("[e2e] CI without APP_CONFIG_BASE_URL — refusing to start a dev server.");
+    return;
+  }
+
+  const live = localOsDevServer.readLive();
+  if (live) {
+    await waitForHealth(live);
+    console.log(`[e2e] reusing dev server at ${live.baseUrl} (pid ${live.pid}).`);
+    return;
+  }
+
+  const target = await resolveLocalOsDevTargetOnce();
+  const started = await startDevServer({ detach: true, port: target.port });
+  const { baseUrl, pid, startedAt } = started;
+  if (!baseUrl || !pid || !startedAt) {
+    throw new Error(`Dev server start reported "${started.status}" — see ${logPath()}.`);
+  }
+  await waitForHealth({ baseUrl, pid, startedAt });
+  console.log(
+    `[e2e] started dev server at ${baseUrl} (pid ${pid}) — ` +
+      `it stays up for reuse; \`pnpm dev kill\` stops it.`,
+  );
+}
+
+/**
+ * Poll `${baseUrl}/api/health` until it answers 200, on the same budget as
+ * the Playwright webServer timeout in playwright.config.ts: at least 10s,
+ * and up to 180s measured from the server's own startedAt — a freshly
+ * started server gets its full boot window, a long-lived one must answer
+ * near-instantly.
+ */
+async function waitForHealth(server: { baseUrl: string; pid: number; startedAt: string }) {
+  const url = `${server.baseUrl.replace(/\/+$/, "")}/api/health`;
+  const deadline = Math.max(Date.now() + 10_000, new Date(server.startedAt).getTime() + 180_000);
+  let lastFailure = "";
+  do {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+      lastFailure = `status ${response.status}`;
+    } catch (error) {
+      lastFailure = error instanceof Error ? error.message : String(error);
+    }
+    await sleep(250);
+  } while (Date.now() < deadline);
+  throw new Error(
+    `Dev server at ${server.baseUrl} (pid ${server.pid}) never became healthy ` +
+      `(${url} → ${lastFailure}) — investigate ${logPath()} or \`pnpm dev kill\` it.`,
+  );
+}
+
+function logPath() {
+  return devServerLogPath(appRoot);
+}

--- a/apps/os/e2e/test-support/global-setup.ts
+++ b/apps/os/e2e/test-support/global-setup.ts
@@ -71,14 +71,25 @@ async function ensureOsUnderTest(): Promise<void> {
     return;
   }
 
+  // The stashed target is what the browser project's `define` already baked
+  // in at config eval — reuse is only sound against exactly that URL, the
+  // same way Playwright's reuseExistingServer probes its one predetermined
+  // target. A live server on any other port is split-brain, not a reuse.
+  const target = await resolveLocalOsDevTargetOnce();
   const live = localOsDevServer.readLive();
   if (live) {
+    if (live.baseUrl !== target.baseUrl) {
+      throw new Error(
+        `A dev server appeared at ${live.baseUrl} after this run resolved its target ` +
+          `${target.baseUrl}. Re-run so config eval and globalSetup agree on one server, ` +
+          `or \`pnpm dev kill\` the stray one.`,
+      );
+    }
     await waitForHealth(live);
     console.log(`[e2e] reusing dev server at ${live.baseUrl} (pid ${live.pid}).`);
     return;
   }
 
-  const target = await resolveLocalOsDevTargetOnce();
   const started = await startDevServer({ detach: true, port: target.port });
   const { baseUrl, pid, startedAt } = started;
   if (!baseUrl || !pid || !startedAt) {
@@ -104,7 +115,9 @@ async function waitForHealth(server: { baseUrl: string; pid: number; startedAt: 
   let lastFailure = "";
   do {
     try {
-      const response = await fetch(url);
+      // Per-probe abort so a socket that connects but never answers can't
+      // outlive the deadline check below.
+      const response = await fetch(url, { signal: AbortSignal.timeout(1_000) });
       if (response.ok) return;
       lastFailure = `status ${response.status}`;
     } catch (error) {

--- a/apps/os/e2e/test-support/global-setup.ts
+++ b/apps/os/e2e/test-support/global-setup.ts
@@ -26,8 +26,6 @@ import { setTimeout as sleep } from "node:timers/promises";
 import startDevServer, { localOsDevServer } from "../../scripts/dev.ts";
 import { devServerLogPath } from "../../scripts/lib/dev-server-info.ts";
 
-type LocalOsDevTarget = Awaited<ReturnType<typeof localOsDevServer.resolveTarget>>;
-
 const appRoot = fileURLToPath(new URL("../..", import.meta.url));
 
 // Symbol.for-keyed globalThis stashes: vitest.config.ts (vite's bundled
@@ -36,7 +34,7 @@ const appRoot = fileURLToPath(new URL("../..", import.meta.url));
 const TARGET_KEY: unique symbol = Symbol.for("iterate.osE2e.localDevTarget");
 const ENSURE_KEY: unique symbol = Symbol.for("iterate.osE2e.ensureDevServer");
 const stash = globalThis as typeof globalThis & {
-  [TARGET_KEY]?: Promise<LocalOsDevTarget>;
+  [TARGET_KEY]?: ReturnType<typeof localOsDevServer.resolveTarget>;
   [ENSURE_KEY]?: Promise<void>;
 };
 
@@ -48,7 +46,7 @@ const stash = globalThis as typeof globalThis & {
  * the same way playwright.config.ts bakes `--port N` into its webServer
  * command.
  */
-export function resolveLocalOsDevTargetOnce(): Promise<LocalOsDevTarget> {
+export function resolveLocalOsDevTargetOnce(): ReturnType<typeof localOsDevServer.resolveTarget> {
   return (stash[TARGET_KEY] ??= localOsDevServer.resolveTarget());
 }
 

--- a/apps/os/e2e/vitest.config.ts
+++ b/apps/os/e2e/vitest.config.ts
@@ -17,7 +17,7 @@ import {
 } from "@iterate-com/shared/test-support/e2e-policy";
 import { E2E_REPO_ROOT_KEY, E2E_RUN_SLUG_KEY } from "./test-support/provide-keys.ts";
 import { createVitestRunSlug } from "./test-support/vitest-naming.ts";
-import { resolveBaseUrl } from "./test-support/dev-server.ts";
+import { resolveLocalOsDevTargetOnce } from "./test-support/global-setup.ts";
 
 const appRoot = fileURLToPath(new URL("..", import.meta.url));
 const e2eRoot = fileURLToPath(new URL(".", import.meta.url));
@@ -25,7 +25,14 @@ const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
 
 const vitestRunSlug = createVitestRunSlug();
 const vitestRunRoot = createVitestRunRoot("os-e2e-");
-const baseUrl = resolveBaseUrl(appRoot) ?? "";
+// The deployed target wins; otherwise resolve the local dev target ONCE —
+// the live dev server, or the exact port the globalSetup will start one on —
+// mirroring how playwright.config.ts bakes `--port N` into its webServer
+// command. CI never targets a local dev server (see global-setup.ts).
+const configuredOsBaseUrl = process.env.APP_CONFIG_BASE_URL?.trim().replace(/\/+$/, "");
+const localOsTarget =
+  configuredOsBaseUrl || process.env.CI ? null : await resolveLocalOsDevTargetOnce();
+const baseUrl = configuredOsBaseUrl || localOsTarget?.baseUrl || "";
 
 console.log(`[vitest-artifacts] run root: ${vitestRunRoot}`);
 console.log(`[vitest] run slug: ${vitestRunSlug}`);
@@ -136,6 +143,13 @@ export default defineConfig({
           // The engine e2e suites and the itx catalogue matrix are both node
           // black boxes against the deployed slot — one lane.
           include: ["./e2e/vitest/**/*.test.ts", "./e2e/examples/*.e2e.test.ts"],
+          // Ensure the target exists before any test runs: no-op against a
+          // deployed APP_CONFIG_BASE_URL, otherwise reuse-or-start the local
+          // dev server — the `pnpm spec` webServer contract (see
+          // global-setup.ts). Listed on each project because vitest reads
+          // globalSetup per project (like `retry` below); the setup dedupes
+          // itself, so it still runs once per `pnpm e2e`.
+          globalSetup: ["./e2e/test-support/global-setup.ts"],
           setupFiles: ["./e2e/vitest/setup.ts"],
           provide: sharedProvide,
           // #1601 fixed cold-slot creates to ~3-5s per saga under 4-way load
@@ -167,6 +181,8 @@ export default defineConfig({
         test: {
           name: "browser",
           include: ["./e2e/examples/examples-browser.test.ts"],
+          // See the node project: per-project on purpose, dedupes itself.
+          globalSetup: ["./e2e/test-support/global-setup.ts"],
           provide: sharedProvide,
           testTimeout: 45_000,
           hookTimeout: 45_000,

--- a/apps/os/e2e/vitest.config.ts
+++ b/apps/os/e2e/vitest.config.ts
@@ -149,7 +149,9 @@ export default defineConfig({
           // global-setup.ts). Listed on each project because vitest reads
           // globalSetup per project (like `retry` below); the setup dedupes
           // itself, so it still runs once per `pnpm e2e`.
-          globalSetup: ["./e2e/test-support/global-setup.ts"],
+          // Absolute so vitest (project-root-relative) and knip
+          // (config-dir-relative) agree on where this file lives.
+          globalSetup: [resolve(e2eRoot, "test-support/global-setup.ts")],
           setupFiles: ["./e2e/vitest/setup.ts"],
           provide: sharedProvide,
           // #1601 fixed cold-slot creates to ~3-5s per saga under 4-way load
@@ -182,7 +184,9 @@ export default defineConfig({
           name: "browser",
           include: ["./e2e/examples/examples-browser.test.ts"],
           // See the node project: per-project on purpose, dedupes itself.
-          globalSetup: ["./e2e/test-support/global-setup.ts"],
+          // Absolute so vitest (project-root-relative) and knip
+          // (config-dir-relative) agree on where this file lives.
+          globalSetup: [resolve(e2eRoot, "test-support/global-setup.ts")],
           provide: sharedProvide,
           testTimeout: 45_000,
           hookTimeout: 45_000,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "knip": "knip --workspace apps/os --workspace apps/semaphore --workspace apps/streams-example-app --workspace packages/shared --workspace packages/ui --workspace packages/iterate",
     "prepare": "is-ci || husky",
     "spec": "playwright test --config playwright.config.ts",
+    "e2e": "pnpm --dir apps/os e2e",
     "vitest": "pnpm --dir apps/os test",
     "test": "pnpm -r --parallel --filter '!iterate' test",
     "test:onboarding": "pnpm -r --parallel --filter '!iterate' test:onboarding",

--- a/specs/AGENTS.md
+++ b/specs/AGENTS.md
@@ -1,3 +1,7 @@
+# Product specs
+
+These live at the repo root — not under `apps/os` — because product specs span workers: signup drives the real auth app's UI, not just os. The sibling `apps/os/e2e` lane proves the os engine surface through the itx API; this lane proves what a user actually gets in a browser.
+
 ## Writing playwright tests
 
 Think of these as _specs_ as well as tests. The idea is that a human or agent can read a test and go "I see how this aspect of the product is supposed to work now".


### PR DESCRIPTION
## What

`pnpm e2e` (apps/os vitest e2e, API surface) and `pnpm spec` (root Playwright, browser surface) are sibling lanes with an identical operational contract — but only `pnpm spec` knew how to ensure a local dev server (`webServer` block); `pnpm e2e` just failed unless `pnpm dev` was already running. A vitest globalSetup (`apps/os/e2e/test-support/global-setup.ts`) now gives `pnpm e2e` the root `playwright.config.ts` webServer semantics exactly.

## Semantics

| Situation | Behavior |
|---|---|
| `APP_CONFIG_BASE_URL` set (deployed target — always the case in preview CI) | **Strict no-op.** Zero added latency, zero side effects. `[e2e] deployed target <url> — no local dev server involved.` |
| Live dev server discoverable (`apps/os/.dev-server/dev-server.json`, pid alive) | **Reuse** — Playwright's `reuseExistingServer: !CI`. `[e2e] reusing dev server at <url> (pid N).` |
| Nothing running, not CI | **Start** one detached via `scripts/dev.ts start --detach` (the same lane Playwright's webServer command drives), wait for `/api/health` on Playwright's budget (≥10s, ≤180s from the server's `startedAt`). The server deliberately outlives the run for reuse; `pnpm dev kill` stops it. |
| `CI` set without a base URL | **Never boots a server on a CI runner.** The suites keep failing with their existing clear `APP_CONFIG_BASE_URL is required` error. |

How it mirrors the Playwright webServer contract:

- **Same target resolution.** `localOsDevServer.resolveTarget()` runs once at config eval — the live server, or the exact port a to-be-started one will use — so the browser project's `define`d base URL is port-coherent with the server the globalSetup starts, the same way `playwright.config.ts` bakes `--port N` into its webServer command. Config eval and the globalSetup share the resolved target via a `Symbol.for` globalThis stash (separate module instances, same process).
- **Same start lane.** `scripts/dev.ts start --detach`, imported rather than shelled — the detached vite outlives the run exactly like it does under Playwright's `--keep-alive` wrapper.
- **Same startup budget.** `max(10s, startedAt + 180s − now)` against `/api/health`.
- **No new env vars** (docs/testing.md doctrine): only the existing `APP_CONFIG_BASE_URL` and `CI` change behavior. The globalSetup is listed on both vitest projects (vitest reads `globalSetup` per project, like `retry`) and dedupes itself, so it runs once per `pnpm e2e`.

Also:

- Root invocation symmetry: `"e2e": "pnpm --dir apps/os e2e"` beside the existing `"spec"` / `"vitest"` aliases.
- `specs/AGENTS.md` now states why `specs/` lives at the repo root (product specs span workers; `apps/os/e2e` proves the os engine surface).

## Live verification (shared dev config, fresh worktree)

- **Cold start** (no discovery file at all): `doppler run --config dev -- pnpm e2e itx-core -t "Unauthenticated itx can't do anything"` → `[e2e] started dev server at http://localhost:59699 (pid 22896)`, 1 passed, 18.3s total including server boot.
- **Reuse**: same command again → `[e2e] reusing dev server at http://localhost:59699 (pid 22896)`, 1 passed, 160ms — the server outlived the previous run.
- **Reuse of a hand-started server**: `pnpm dev kill`, then `pnpm dev start --detach`, then e2e → `[e2e] reusing dev server ... (pid 23772)`, passed.
- **Deployed-target no-op**: `APP_CONFIG_BASE_URL=http://127.0.0.1:9` → `[e2e] deployed target http://127.0.0.1:9 — no local dev server involved.`, zero start/reuse lines, nothing booted.
- **CI posture**: `CI=true` without a base URL → `[e2e] CI without APP_CONFIG_BASE_URL — refusing to start a dev server.`, run exits 1 with the existing `itx e2e needs APP_CONFIG_BASE_URL` error.
- **Browser-project port coherence**: cold `pnpm e2e --project browser` (stale discovery file) → auto-start + **26/26** browser-catalogue tests green in real chromium, proving the config-time `define` URL and the started server agree on the port.
- **Cold start over a stale discovery file**: kept the worktree's stable port (recorded-port preference), authenticated itx test passed.
- `pnpm typecheck`, `pnpm lint`, `pnpm format` and the `scripts/preview/e2e-policy.test.ts` guard (9/9) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to local/CI test orchestration and docs; deployed CI paths stay no-op when `APP_CONFIG_BASE_URL` is set.
> 
> **Overview**
> **`pnpm e2e`** no longer assumes a dev server is already running locally. A new Vitest **`globalSetup`** (`apps/os/e2e/test-support/global-setup.ts`) mirrors root Playwright’s **`webServer`** contract: **no-op** when `APP_CONFIG_BASE_URL` is set, **reuse** a live server from `.dev-server/dev-server.json`, **start detached** via `scripts/dev.ts` and wait on `/api/health` otherwise, and **refuse to boot** on CI without a base URL.
> 
> **`vitest.config.ts`** resolves the local target once (shared with setup via `Symbol.for` on `globalThis`) so the browser project’s injected `baseUrl` matches the port the setup will start or reuse; **`globalSetup`** is wired on both node and browser projects with process-level deduplication.
> 
> Root **`package.json`** adds **`"e2e": "pnpm --dir apps/os e2e"`** beside **`spec`** / **`vitest`**. **`specs/AGENTS.md`** briefly explains why product specs live at the repo root vs `apps/os/e2e`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b5372e9b9cf5365e66241eab61e16f8e192229a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +156 -2 | +82 -2 🟩🟩🟩🟩🟩 |
| Config | +1 -0 | +1 -0 🟩⬜⬜⬜⬜ |
| Docs | +4 -0 | +2 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+161 -2** | **+85 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between b635a97 and 5b5372e, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "cleanup-failed",
      "updatedAt": "2026-07-14T14:48:44.559Z",
      "headSha": "5b5372e9b9cf5365e66241eab61e16f8e192229a",
      "message": "CloudflareApiError: Cloudflare API POST /accounts/376ef7ed81b0573f93524de763666c15/d1/database/ebf149cb-d3ed-48c5-a2d0-010166b25033/query failed (429): [{\"code\":971,\"message\":\"Please wait and consider throttling your request speed\"}]\n    at cfV4 (/home/runner/work/iterate/iterate/scripts/lib/env-context.ts:108:13)\n    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)\n    at async wipeD1Tables (/home/runner/work/iterate/iterate/scripts/lib/deploy-helpers.ts:312:5)\n    at async eraseData (/home/runner/work/iterate/iterate/apps/auth/scripts/erase-data.ts:44:3)\n    at async Command.<anonymous> (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:416:32)\n    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)\n    at async Command.<anonymous> (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:457:21)\n    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)\n    at async Object.run (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:527:9) {\n  method: 'POST',\n  path: '/accounts/376ef7ed81b0573f93524de763666c15/d1/database/ebf149cb-d3ed-48c5-a2d0-010166b25033/query',\n  status: 429\n}\n\n\n> @iterate-com/auth@0.0.0-dev destroy /home/runner/work/iterate/iterate/apps/auth\n> tsx ./scripts/erase-data.ts --env preview_9\n\nErasing all data in preview_9 (auth D1 ebf149cb-d3ed-48c5-a2d0-010166b25033)\n ELIFECYCLE  Command failed with exit code 1.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/212107988448126",
      "shortSha": "5b5372e",
      "cleanupDurationMs": 2998,
      "deployDurationMs": 21196,
      "testDurationMs": 685,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.81,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-14T14:48:42.983Z",
      "headSha": "f624e0a2b673bca9bac0e3b9584b21281b267c10",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/224111137524351",
      "shortSha": "f624e0a",
      "cleanupDurationMs": 1420,
      "deployDurationMs": 16141,
      "testDurationMs": 19230,
      "testRetries": null,
      "workerSizeKib": 5117.13,
      "workerGzipKib": 1458.43,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-14T14:48:40.392Z",
      "headSha": "5b5372e9b9cf5365e66241eab61e16f8e192229a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/212107988448126",
      "shortSha": "5b5372e",
      "cleanupDurationMs": 220493,
      "deployDurationMs": 91067,
      "testDurationMs": 327067,
      "testRetries": "5 retried: catalogue example \"scheduler-basics\" runs identically across runtimes (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · is MITM-intercepted and routed through project egress with secret substitution (vitest x1) · reactivity page appends a batch and renders every delivered marker (specs x1) · reactivity page replays already appended events after reload (specs x1)",
      "workerSizeKib": 16350.78,
      "workerGzipKib": 4410.15,
      "mainWorkerGzipKib": 4411.67
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-14T14:45:00.425Z",
      "headSha": "f624e0a2b673bca9bac0e3b9584b21281b267c10",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/224111137524351",
      "shortSha": "f624e0a",
      "cleanupDurationMs": 522,
      "deployDurationMs": 13734,
      "testDurationMs": 5823,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_9",
    "slug": "preview-9"
  },
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>Slot: preview-9 | Doppler config: preview_9</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | cleanup failed | `5b5372e` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 819.8 KiB | 21.2s | 685ms |  | 3.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/212107988448126) | 2026-07-14T14:48:44.559Z | CloudflareApiError: Cloudflare API POST /accounts/376ef7ed81b0573f93524de763666c15/d1/database/ebf149cb-d3ed-48c5-a2d0-010166b25033/query failed (429): [{"code":971,"message":"Ple... |
| OS | released | `5b5372e` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 4.31 MiB (-1.5 KiB vs main) | 91.1s | 327.1s | 5 retried: catalogue example "scheduler-basics" runs identically across runtimes (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · is MITM-intercepted and routed through project egress with secret substitution (vitest x1) · reactivity page appends a batch and renders every delivered marker (specs x1) · reactivity page replays already appended events after reload (specs x1) | 220.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/212107988448126) | 2026-07-14T14:48:40.392Z | Preview app released. |
| Semaphore | released | `f624e0a` | [https://semaphore.iterate-preview-9.com](https://semaphore.iterate-preview-9.com) | 440.8 KiB | 13.7s | 5.8s |  | 522ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/224111137524351) | 2026-07-14T14:45:00.425Z | Preview app released. |
| Streams Example App | released | `f624e0a` | [https://streams.iterate-preview-9.com](https://streams.iterate-preview-9.com) | 1.42 MiB | 16.1s | 19.2s |  | 1.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/224111137524351) | 2026-07-14T14:48:42.983Z | Preview app released. |

</details>

<details>
<summary>Auth failure details</summary>

<pre>CloudflareApiError: Cloudflare API POST /accounts/376ef7ed81b0573f93524de763666c15/d1/database/ebf149cb-d3ed-48c5-a2d0-010166b25033/query failed (429): [{"code":971,"message":"Please wait and consider throttling your request speed"}]
    at cfV4 (/home/runner/work/iterate/iterate/scripts/lib/env-context.ts:108:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async wipeD1Tables (/home/runner/work/iterate/iterate/scripts/lib/deploy-helpers.ts:312:5)
    at async eraseData (/home/runner/work/iterate/iterate/apps/auth/scripts/erase-data.ts:44:3)
    at async Command.&lt;anonymous&gt; (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:416:32)
    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)
    at async Command.&lt;anonymous&gt; (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:457:21)
    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)
    at async Object.run (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:527:9) {
  method: 'POST',
  path: '/accounts/376ef7ed81b0573f93524de763666c15/d1/database/ebf149cb-d3ed-48c5-a2d0-010166b25033/query',
  status: 429
}


&gt; @iterate-com/auth@0.0.0-dev destroy /home/runner/work/iterate/iterate/apps/auth
&gt; tsx ./scripts/erase-data.ts --env preview_9

Erasing all data in preview_9 (auth D1 ebf149cb-d3ed-48c5-a2d0-010166b25033)
 ELIFECYCLE  Command failed with exit code 1.</pre>

</details>
<!-- /CLOUDFLARE_PREVIEW -->