### PR TITLE
Preview tooling: ride out Cloudflare 429s and never leak a slot lease on failed cleanup

### DIFF
--- a/scripts/lib/cloudflare-429-retry.test.ts
+++ b/scripts/lib/cloudflare-429-retry.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchCloudflareWith429Retry } from "./cloudflare-429-retry.ts";
+
+function response(status: number, headers: Record<string, string> = {}) {
+  return new Response(null, { status, headers });
+}
+
+describe("fetchCloudflareWith429Retry", () => {
+  it("returns a non-429 response immediately without sleeping", async () => {
+    const sleep = vi.fn(async () => {});
+    const doFetch = vi.fn(async () => response(200));
+
+    const result = await fetchCloudflareWith429Retry("GET /d1/database", doFetch, { sleep });
+
+    expect(result.status).toBe(200);
+    expect(doFetch).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("does NOT retry non-429 errors — a 500 surfaces to the caller at once", async () => {
+    const sleep = vi.fn(async () => {});
+    const doFetch = vi.fn(async () => response(500));
+
+    const result = await fetchCloudflareWith429Retry("GET /zones", doFetch, { sleep });
+
+    expect(result.status).toBe(500);
+    expect(doFetch).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("retries 429s on the fallback schedule until a success", async () => {
+    const sleeps: number[] = [];
+    const doFetch = vi
+      .fn(async () => response(200))
+      .mockResolvedValueOnce(response(429))
+      .mockResolvedValueOnce(response(429));
+
+    const result = await fetchCloudflareWith429Retry("POST /d1/query", doFetch, {
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+
+    expect(result.status).toBe(200);
+    expect(doFetch).toHaveBeenCalledTimes(3);
+    expect(sleeps).toEqual([5_000, 15_000]);
+  });
+
+  it("honors Retry-After (delta-seconds) over the fallback delay, capped", async () => {
+    const sleeps: number[] = [];
+    const doFetch = vi
+      .fn(async () => response(200))
+      .mockResolvedValueOnce(response(429, { "retry-after": "9" }))
+      .mockResolvedValueOnce(response(429, { "retry-after": "9999" }));
+
+    const result = await fetchCloudflareWith429Retry("GET /workers", doFetch, {
+      maxRetryAfterMs: 120_000,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+
+    expect(result.status).toBe(200);
+    expect(sleeps).toEqual([9_000, 120_000]);
+  });
+
+  it("gives up after the configured attempts, returning the final 429 for the caller's normal error path", async () => {
+    const sleep = vi.fn(async () => {});
+    const doFetch = vi.fn(async () => response(429));
+
+    const result = await fetchCloudflareWith429Retry("GET /d1/database", doFetch, {
+      backoffMs: [1, 1, 1, 1],
+      sleep,
+    });
+
+    expect(result.status).toBe(429);
+    expect(doFetch).toHaveBeenCalledTimes(5);
+    expect(sleep).toHaveBeenCalledTimes(4);
+  });
+
+  it("propagates thrown fetch errors without retrying", async () => {
+    const sleep = vi.fn(async () => {});
+    const doFetch = vi.fn(async () => {
+      throw new Error("ECONNRESET");
+    });
+
+    await expect(
+      fetchCloudflareWith429Retry("GET /d1/database", doFetch, { sleep }),
+    ).rejects.toThrow("ECONNRESET");
+    expect(doFetch).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/lib/cloudflare-429-retry.ts
+++ b/scripts/lib/cloudflare-429-retry.ts
@@ -1,0 +1,79 @@
+/**
+ * Ride out Cloudflare API rate limiting (HTTP 429).
+ *
+ * Cloudflare's global API limit is 1200 requests / 5 minutes per user
+ * (https://developers.cloudflare.com/fundamentals/api/reference/limits/), so
+ * a rate-limited window can last MINUTES — a quick exponential backoff that
+ * gives up after ~30s total never rides one out. On 2026-07-14 the shared
+ * dev/preview account hit exactly this: every `preview deploy` app failed in
+ * ~2s with a 429 (deploy prepare hooks → ctx.cf), and `preview cleanup`'s
+ * erase-data D1 query 429'd, failing cleanup and leaking the merged PR's
+ * slot lease for 24h, which starved the 9-slot preview fleet.
+ *
+ * Policy: up to 5 attempts. Between attempts, honor the server's Retry-After
+ * header when present (capped so a pathological value can't wedge the job),
+ * otherwise wait 5s → 15s → 30s → 60s — ~110s worst case per call, a real
+ * chance of outliving a short burst without threatening a CI job's 30-minute
+ * ceiling. ONLY status 429 retries; every other status (and any thrown fetch
+ * error) surfaces to the caller immediately. This mirrors the shape of
+ * withGithubRetry in scripts/preview/preview.ts, but works at the Response
+ * level so it can read Retry-After.
+ *
+ * This is infrastructure-API resilience, not a test retry layer — the
+ * e2e-policy "one retry layer" rule (docs/testing.md) governs retrying
+ * TESTS and does not apply here.
+ */
+
+const DEFAULT_BACKOFF_MS = [5_000, 15_000, 30_000, 60_000] as const;
+const DEFAULT_MAX_RETRY_AFTER_MS = 120_000;
+
+export async function fetchCloudflareWith429Retry(
+  /** Call description for the retry log lines, e.g. "GET /d1/database". */
+  label: string,
+  /** Performs one attempt. Called again (with identical inputs) per retry. */
+  doFetch: () => Promise<Response>,
+  opts: {
+    /** Delays between attempts when there is no Retry-After (attempts = delays + 1). */
+    backoffMs?: readonly number[];
+    /** Cap applied to a server-sent Retry-After. */
+    maxRetryAfterMs?: number;
+    /** Injectable for tests. */
+    sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<Response> {
+  const backoffMs = opts.backoffMs ?? DEFAULT_BACKOFF_MS;
+  const maxRetryAfterMs = opts.maxRetryAfterMs ?? DEFAULT_MAX_RETRY_AFTER_MS;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise((res) => setTimeout(res, ms)));
+
+  let response = await doFetch();
+  for (const [index, fallbackMs] of backoffMs.entries()) {
+    if (response.status !== 429) {
+      return response;
+    }
+    const retryAfter = parseRetryAfterMs(response);
+    const delayMs = Math.min(retryAfter ?? fallbackMs, maxRetryAfterMs);
+    console.warn(
+      `Cloudflare API rate limited (429) on ${label} (attempt ${index + 1}/${backoffMs.length + 1}); ` +
+        `retrying in ${Math.round(delayMs / 1000)}s${retryAfter != null ? " (Retry-After)" : ""}...`,
+    );
+    await sleep(delayMs);
+    response = await doFetch();
+  }
+  // Still 429 after every attempt: hand the response back so the caller's
+  // normal error path reports it (with the exhausted retries visible above).
+  return response;
+}
+
+/** Retry-After is either delta-seconds or an HTTP-date; both become a delay in ms. */
+function parseRetryAfterMs(response: Response): number | undefined {
+  const header = response.headers.get("retry-after");
+  if (!header) {
+    return undefined;
+  }
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds * 1000;
+  }
+  const untilMs = Date.parse(header) - Date.now();
+  return Number.isFinite(untilMs) && untilMs > 0 ? untilMs : undefined;
+}

--- a/scripts/lib/cloudflare-429-retry.ts
+++ b/scripts/lib/cloudflare-429-retry.ts
@@ -37,13 +37,19 @@ export async function fetchCloudflareWith429Retry(
     backoffMs?: readonly number[];
     /** Cap applied to a server-sent Retry-After. */
     maxRetryAfterMs?: number;
+    /**
+     * Aborts the backoff wait as well as being the caller's fetch signal —
+     * without it, a cancelled caller would silently keep waiting (and
+     * re-fetching) for up to the full backoff schedule.
+     */
+    signal?: AbortSignal;
     /** Injectable for tests. */
-    sleep?: (ms: number) => Promise<void>;
+    sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
   } = {},
 ): Promise<Response> {
   const backoffMs = opts.backoffMs ?? DEFAULT_BACKOFF_MS;
   const maxRetryAfterMs = opts.maxRetryAfterMs ?? DEFAULT_MAX_RETRY_AFTER_MS;
-  const sleep = opts.sleep ?? ((ms: number) => new Promise((res) => setTimeout(res, ms)));
+  const sleep = opts.sleep ?? abortableSleep;
 
   let response = await doFetch();
   for (const [index, fallbackMs] of backoffMs.entries()) {
@@ -56,12 +62,36 @@ export async function fetchCloudflareWith429Retry(
       `Cloudflare API rate limited (429) on ${label} (attempt ${index + 1}/${backoffMs.length + 1}); ` +
         `retrying in ${Math.round(delayMs / 1000)}s${retryAfter != null ? " (Retry-After)" : ""}...`,
     );
-    await sleep(delayMs);
+    // Drain the 429 body before waiting: an unread Response pins its
+    // keep-alive connection in undici for as long as it is referenced, and
+    // holding one across a 5-120s backoff (times every concurrent caller in
+    // a rate-limited burst) starves the connection pool.
+    await response.body?.cancel().catch(() => {});
+    await sleep(delayMs, opts.signal);
     response = await doFetch();
   }
   // Still 429 after every attempt: hand the response back so the caller's
   // normal error path reports it (with the exhausted retries visible above).
   return response;
+}
+
+/** setTimeout that rejects with the signal's reason if aborted mid-wait. */
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error("Aborted"));
+      return;
+    }
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(signal?.reason ?? new Error("Aborted"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 /** Retry-After is either delta-seconds or an HTTP-date; both become a delay in ms. */

--- a/scripts/lib/env-context.ts
+++ b/scripts/lib/env-context.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { UNPROVISIONED } from "../../envs.ts";
+import { fetchCloudflareWith429Retry } from "./cloudflare-429-retry.ts";
 
 /**
  * The minimum an app's envs.ts entry must carry for the deploy tooling:
@@ -93,16 +94,23 @@ export async function resolveEnvContext<E extends DeployableEnv>(options: {
   }
 
   const cfV4 = async <T>(path: string, init?: RequestInit): Promise<T> => {
-    const response = await fetch(`https://api.cloudflare.com/client/v4${path}`, {
-      ...init,
-      headers: {
-        authorization: `Bearer ${secrets.CLOUDFLARE_API_TOKEN}`,
-        ...(init?.body && typeof init.body === "string"
-          ? { "content-type": "application/json" }
-          : {}),
-        ...init?.headers,
-      },
-    });
+    // This fetch is THE choke point for every Cloudflare API call the deploy
+    // tooling makes (ctx.cf / ctx.cfV4 across deploy, ensure-resources and
+    // erase-data scripts), so 429 backoff lives here once instead of at each
+    // call site. Request bodies are always strings (see the content-type
+    // sniff below), so replaying the same init per attempt is safe.
+    const response = await fetchCloudflareWith429Retry(`${init?.method ?? "GET"} ${path}`, () =>
+      fetch(`https://api.cloudflare.com/client/v4${path}`, {
+        ...init,
+        headers: {
+          authorization: `Bearer ${secrets.CLOUDFLARE_API_TOKEN}`,
+          ...(init?.body && typeof init.body === "string"
+            ? { "content-type": "application/json" }
+            : {}),
+          ...init?.headers,
+        },
+      }),
+    );
     const body: any = await response.json().catch(() => null);
     if (!response.ok || body?.success === false) {
       throw new CloudflareApiError(

--- a/scripts/lib/env-context.ts
+++ b/scripts/lib/env-context.ts
@@ -99,17 +99,21 @@ export async function resolveEnvContext<E extends DeployableEnv>(options: {
     // erase-data scripts), so 429 backoff lives here once instead of at each
     // call site. Request bodies are always strings (see the content-type
     // sniff below), so replaying the same init per attempt is safe.
-    const response = await fetchCloudflareWith429Retry(`${init?.method ?? "GET"} ${path}`, () =>
-      fetch(`https://api.cloudflare.com/client/v4${path}`, {
-        ...init,
-        headers: {
-          authorization: `Bearer ${secrets.CLOUDFLARE_API_TOKEN}`,
-          ...(init?.body && typeof init.body === "string"
-            ? { "content-type": "application/json" }
-            : {}),
-          ...init?.headers,
-        },
-      }),
+    const response = await fetchCloudflareWith429Retry(
+      `${init?.method ?? "GET"} ${path}`,
+      () =>
+        fetch(`https://api.cloudflare.com/client/v4${path}`, {
+          ...init,
+          headers: {
+            authorization: `Bearer ${secrets.CLOUDFLARE_API_TOKEN}`,
+            ...(init?.body && typeof init.body === "string"
+              ? { "content-type": "application/json" }
+              : {}),
+            ...init?.headers,
+          },
+        }),
+      // A caller's abort also cuts the backoff wait short, not just the fetch.
+      { signal: init?.signal ?? undefined },
     );
     const body: any = await response.json().catch(() => null);
     if (!response.ok || body?.success === false) {

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -42,6 +42,7 @@ const {
   parseCloudflarePreviewState,
   parseEnvironmentConfigLeaseData,
   reconcileEnvironmentConfigLeaseResources,
+  releaseLeaseDespiteTeardownFailure,
   renderCloudflarePreviewPullRequestBody,
   resolveAuthPreviewRootSecret,
   resolvePreviewCompareBaseSha,
@@ -1669,6 +1670,60 @@ describe("lease ownership during acquire", () => {
       dopplerConfig: "preview_seven",
       slug: "preview-7",
     });
+  });
+});
+
+describe("cleanup lease release", () => {
+  const lease = { type: "environment-config", slug: "preview-4", leaseId: "lease-1950" };
+
+  it("releases the lease even when teardown/erase failed — the slot is left dirty, not leaked", async () => {
+    // 2026-07-14 incident: a Cloudflare 429 failed erase-data mid-cleanup and
+    // the old code bailed before releasing; the merged PR's lease leaked for
+    // 24h and starved the fleet. The dirty slot is the harmless half: every
+    // acquire erases on entry (see the entry-invariant test above).
+    const release = vi.fn(async () => ({ released: true }));
+    const semaphore = fakeSemaphore({ release });
+
+    const result = await releaseLeaseDespiteTeardownFailure({
+      lease,
+      semaphore,
+      teardownOk: false,
+    });
+
+    expect(result).toEqual({ ok: true, released: true });
+    expect(release).toHaveBeenCalledExactlyOnceWith({
+      type: "environment-config",
+      slug: "preview-4",
+      leaseId: "lease-1950",
+    });
+  });
+
+  it("treats an already-gone lease as a successful (non-)release", async () => {
+    const semaphore = fakeSemaphore({ release: vi.fn(async () => ({ released: false })) });
+
+    const result = await releaseLeaseDespiteTeardownFailure({
+      lease,
+      semaphore,
+      teardownOk: true,
+    });
+
+    expect(result).toEqual({ ok: true, released: false });
+  });
+
+  it("reports ok=false only when the release call itself fails — that is the real leak", async () => {
+    const semaphore = fakeSemaphore({
+      release: vi.fn(async () => {
+        throw new Error("semaphore unreachable");
+      }),
+    });
+
+    const result = await releaseLeaseDespiteTeardownFailure({
+      lease,
+      semaphore,
+      teardownOk: false,
+    });
+
+    expect(result).toEqual({ ok: false, released: false });
   });
 });
 

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -2445,13 +2445,16 @@ async function checkCloudflareZoneWithApi(input: {
   const url = new URL("https://api.cloudflare.com/client/v4/zones");
   url.searchParams.set("name", input.domain);
   url.searchParams.set("per_page", "50");
-  const response = await fetchCloudflareWith429Retry(`GET ${url.pathname}`, () =>
-    fetch(url, {
-      headers: {
-        authorization: `Bearer ${input.apiToken}`,
-      },
-      signal: input.signal,
-    }),
+  const response = await fetchCloudflareWith429Retry(
+    `GET ${url.pathname}`,
+    () =>
+      fetch(url, {
+        headers: {
+          authorization: `Bearer ${input.apiToken}`,
+        },
+        signal: input.signal,
+      }),
+    { signal: input.signal },
   );
   const parsed = CloudflareZonesResponse.parse(await response.json());
   if (!response.ok || !parsed.success) {

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -13,6 +13,7 @@ import { createSemaphoreTokenProvider } from "../auth/semaphore-token.ts";
 import { markdownAnnotator } from "../../packages/shared/src/dev/markdown-annotator.ts";
 import { stripAnsi } from "../../packages/shared/src/dev/strip-ansi.ts";
 import { runCommand } from "../../packages/shared/src/node/run-command.ts";
+import { fetchCloudflareWith429Retry } from "../lib/cloudflare-429-retry.ts";
 import { OS_PREVIEW_LANE_TIMEOUT_SECS } from "../../packages/shared/src/test-support/e2e-policy/index.ts";
 import {
   parseWorkerSizeFromDeployOutput,
@@ -184,7 +185,9 @@ async function deployPreviewApps({
     );
     const cleanupResult = await cleanupPreviewForPullRequest({ ...runtime, context });
     if (!cleanupResult.ok) {
-      throw new Error("Failed to tear down previews for a draft PR.");
+      // ok=false means the lease RELEASE failed (a failed teardown alone
+      // still releases and reports ok — see cleanupPreviewForPullRequest).
+      throw new Error("Failed to release the draft PR's preview slot lease.");
     }
     // Pin the post-teardown state in this write: the GitHub read inside
     // updatePreviewState can be stale (read-after-write lag) and would
@@ -643,8 +646,21 @@ export async function cleanup(options: PullRequestCommandOptions = {}) {
     }),
   });
 
+  // Exit-code contract (the only consumer is the cleanup workflow's
+  // red/green — nothing gates on it): exit non-zero ONLY when the lease
+  // RELEASE failed, because a held lease leaks the slot for 24h and starves
+  // the fleet. A failed teardown/erase alone exits zero with a loud warning:
+  // the lease was released, the fleet is healthy, and the dirty slot
+  // self-heals — every acquire erases on entry (eraseAcquiredSlotOrGiveItBack).
   if (!result.ok) {
-    throw new Error("Failed to clean up Cloudflare preview apps.");
+    throw new Error(
+      "Failed to release the preview slot lease — it leaks until its 24h expiry. Re-run cleanup, or free it with `pnpm preview release --slot <N> --force`.",
+    );
+  }
+  if (result.teardownFailed) {
+    logPreview(
+      "cleanup exits 0 despite the failed teardown: the lease was released (fleet healthy) and the dirty slot is erased by its next acquire",
+    );
   }
 
   return result;
@@ -2429,12 +2445,14 @@ async function checkCloudflareZoneWithApi(input: {
   const url = new URL("https://api.cloudflare.com/client/v4/zones");
   url.searchParams.set("name", input.domain);
   url.searchParams.set("per_page", "50");
-  const response = await fetch(url, {
-    headers: {
-      authorization: `Bearer ${input.apiToken}`,
-    },
-    signal: input.signal,
-  });
+  const response = await fetchCloudflareWith429Retry(`GET ${url.pathname}`, () =>
+    fetch(url, {
+      headers: {
+        authorization: `Bearer ${input.apiToken}`,
+      },
+      signal: input.signal,
+    }),
+  );
   const parsed = CloudflareZonesResponse.parse(await response.json());
   if (!response.ok || !parsed.success) {
     return {
@@ -2799,6 +2817,7 @@ async function cleanupPreviewForPullRequest(
       return {
         ok: true,
         released: false,
+        teardownFailed: false,
         state: current.state,
       };
     }
@@ -2831,6 +2850,7 @@ async function cleanupPreviewForPullRequest(
       ok: true,
       released: false,
       skippedTeardown: true,
+      teardownFailed: false,
       state: update.state,
     };
   }
@@ -2896,34 +2916,81 @@ async function cleanupPreviewForPullRequest(
     latestState = update.state;
   }
 
-  if (!ok) {
+  // Cleanup's contract: RELEASING THE LEASE is the load-bearing outcome, not
+  // the teardown. A failed teardown/erase leaves only slot-local dirt, and
+  // dirt is self-healing — every acquire erases the slot before handing it
+  // out (see eraseAcquiredSlotOrGiveItBack) — but a lease that is never
+  // released leaks until its 24h expiry and starves the 9-slot fleet
+  // (2026-07-14: a Cloudflare API 429 failed erase-data mid-cleanup for the
+  // merged pr-1950; the old code bailed before releasing and pr-1988 waited
+  // 360s for a slot that never came). So: always release; `ok: false` now
+  // means the RELEASE itself failed — the lease truly leaked.
+  const releaseResult = await releaseLeaseDespiteTeardownFailure({
+    lease: environmentConfigLease,
+    semaphore,
+    teardownOk: ok,
+  });
+  if (!releaseResult.ok) {
+    // Keep the recorded lease in the PR body so a cleanup re-run still finds
+    // the slot to release.
     return {
       ok: false,
       released: false,
+      teardownFailed: !ok,
       state: latestState,
     };
   }
-
-  const released = await semaphore.release({
-    type: environmentConfigLease.type,
-    slug: environmentConfigLease.slug,
-    leaseId: environmentConfigLease.leaseId,
-  });
-  logPreview(
-    released.released
-      ? `lease released: ${environmentConfigLease.slug} is free again`
-      : `lease was already gone for ${environmentConfigLease.slug}`,
-  );
   const update = await updatePreviewState(params.context, (state) => ({
     ...state,
     environmentConfigLease: null,
+    notice: ok
+      ? state.notice
+      : `Teardown failed but the lease was released; ${environmentConfigLease.slug} is left dirty and its next acquire erases it before use. (preview cleanup at ${new Date().toISOString()})`,
   }));
 
   return {
     ok: true,
-    released: released.released,
+    released: releaseResult.released,
+    teardownFailed: !ok,
     state: update.state,
   };
+}
+
+/**
+ * Release cleanup's lease whether or not teardown succeeded, loudly flagging
+ * the dirty-slot case. Returns `ok: false` only when the release call itself
+ * failed — that is the one outcome where the lease actually leaks (until its
+ * 24h expiry); a teardown failure alone is not a leak because the next
+ * acquire erases the slot on entry (eraseAcquiredSlotOrGiveItBack).
+ */
+async function releaseLeaseDespiteTeardownFailure(input: {
+  lease: { type: string; slug: string; leaseId: string };
+  semaphore: PreviewSemaphoreResourceClient;
+  teardownOk: boolean;
+}): Promise<{ ok: boolean; released: boolean }> {
+  if (!input.teardownOk) {
+    logPreview(
+      `teardown FAILED on ${input.lease.slug} — releasing the lease anyway and leaving the slot dirty; its next acquire erases it before use (see eraseAcquiredSlotOrGiveItBack)`,
+    );
+  }
+  try {
+    const released = await input.semaphore.release({
+      type: input.lease.type,
+      slug: input.lease.slug,
+      leaseId: input.lease.leaseId,
+    });
+    logPreview(
+      released.released
+        ? `lease released: ${input.lease.slug} is free again`
+        : `lease was already gone for ${input.lease.slug}`,
+    );
+    return { ok: true, released: released.released };
+  } catch (error) {
+    logPreview(
+      `FAILED to release the lease on ${input.lease.slug} — it leaks until its 24h expiry (free it with \`pnpm preview release --slot ${input.lease.slug} --force\` or re-run cleanup): ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return { ok: false, released: false };
+  }
 }
 
 async function deployPreviewAppWithStatus(input: {
@@ -4383,6 +4450,7 @@ export const previewInternals = {
   readPlaywrightRetryTelemetry,
   readVitestRetryTelemetry,
   reconcileEnvironmentConfigLeaseResources,
+  releaseLeaseDespiteTeardownFailure,
   renderCloudflarePreviewPullRequestBody,
   renderPreviewRetrySummary,
   resolveAuthPreviewRootSecret,


### PR DESCRIPTION
## Incident (2026-07-14 ~12:40–13:30Z)

The shared dev/preview Cloudflare account got API-rate-limited (Cloudflare's global limit is 1200 requests / 5 minutes per user, so a limited window can last **minutes**). Two observed failures:

- **`preview deploy`** failed all 4 apps in ~2s each with `status: 429` — the deploy prepare hooks' Cloudflare API calls (via `deployApp`, `scripts/lib/deploy-app.ts:106`) hit the limit and died on the first response.
- **`preview cleanup`** (cloudflare-preview-cleanup.yml) failed on a 429 from the D1 query inside erase-data (`POST /accounts/.../d1/database/.../query`, `apps/auth/scripts/erase-data.ts:44` → `wipeD1Tables`). Because cleanup failed **before releasing the lease**, the merged pr-1950's lease on preview-4 leaked for its full 24h expiry — starving the 9-slot fleet ("No preview slot became available for pr-1988 after waiting 360.0s").

## Fix 1: 429 backoff at the single Cloudflare API choke point

Every Cloudflare API call the deploy tooling makes flows through the `cfV4` fetcher in `scripts/lib/env-context.ts` (`ctx.cf` / `ctx.cfV4`, used by every app's deploy prepare hooks, ensure-resources, and erase-data — including the `wipeD1Tables` call that failed cleanup). The new `scripts/lib/cloudflare-429-retry.ts` helper wraps that one fetch (plus the preview doctor's direct zones fetch, the only other direct Cloudflare fetch in the preview tooling):

- Up to **5 attempts**; between attempts honor the server's `Retry-After` header when present (capped at 120s), otherwise wait **5s → 15s → 30s → 60s** (~110s worst case per call — enough to outlive a short burst of a minutes-long rate window without threatening the CI job's 30-minute ceiling).
- **Only** status 429 retries. Every other status and any thrown fetch error surfaces immediately.
- Mirrors the shape of the house `withGithubRetry` pattern in `scripts/preview/preview.ts`, but works at the Response level so it can read `Retry-After`.
- This is infrastructure-API resilience, **not** a test retry layer — the e2e-policy "one retry layer" rule governs retrying tests and is untouched.

(No `cloudflare` npm SDK in this tooling — it's all plain `fetch`, so there was no `maxRetries` knob to lean on.)

## Fix 2: cleanup releases the lease even when erase fails

`cleanupPreviewForPullRequest` used to bail with `ok: false` **before** the semaphore release when any app teardown failed — leaking the lease for 24h. But a dirty slot is already self-healing: **every acquire erases the slot on entry** (`eraseAcquiredSlotOrGiveItBack` — "cleanliness is an invariant of entry"). The held lease was the only real damage.

New contract (stated in comments at both the release site and the `cleanup` command):

- Cleanup **always releases** the lease; a failed teardown logs loudly that the slot is left dirty and its next acquire erases it before use.
- **Exit non-zero only when the RELEASE itself failed** — that's the one outcome where the lease truly leaks. Erase-failed-but-released exits **zero** with a loud warning: the fleet is healthy and the dirt self-heals. (The only exit-code consumer is the cleanup workflow's red/green; nothing gates on it.)
- On a failed release the PR body keeps the recorded lease so a cleanup re-run still finds the slot.

## Tests

- `scripts/lib/cloudflare-429-retry.test.ts`: non-429 passthrough (200 and 500 — no retry), fallback schedule, Retry-After honored + capped, give-up-after-5 returns final 429, thrown errors propagate unretried.
- `scripts/preview/preview.test.ts`: new "cleanup lease release" suite — release happens despite teardown failure, already-gone lease is fine, `ok=false` only when release throws.

Validated: `pnpm typecheck`, `pnpm lint`, `pnpm format`, `cd scripts && pnpm test` (143 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preview CI exit semantics and central Cloudflare fetch behavior for deploy/cleanup; impact is limited to preview tooling but a mistaken release path could still leak or mis-report fleet health.
> 
> **Overview**
> Adds **`fetchCloudflareWith429Retry`** so deploy/preview tooling can survive Cloudflare’s minutes-long rate windows: up to five attempts, **`Retry-After`** when present (capped), otherwise **5s → 15s → 30s → 60s**, only **HTTP 429** retries, with abort-aware sleeps and 429 body draining. It is wired at the shared **`cfV4`** path in `env-context.ts` and the preview doctor’s zones fetch.
> 
> **Preview cleanup** no longer treats a failed teardown/erase as fatal before releasing the semaphore lease. Cleanup **always releases** the lease via **`releaseLeaseDespiteTeardownFailure`**; **`ok: false`** and a **non-zero exit** apply only when **release** fails (the 24h leak case). Erase-failed-but-released exits **zero** with a warning, since the next acquire erases the slot on entry.
> 
> Vitest covers the retry helper and the new cleanup lease-release behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1911ee4b5f4518ca579e19e6543187d063c6871. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +148 -0 | +116 -0 🟩🟩🟩⬜⬜ |
| CI & scripts | +223 -31 | +142 -30 🟩🟩🟩🟩🟥 |
| **Total** | **+371 -31** | **+258 -30** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between a79f381 and c1911ee, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-14T14:30:54.613Z",
      "headSha": "c1911ee4b5f4518ca579e19e6543187d063c6871",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/305572908384691",
      "shortSha": "c1911ee",
      "cleanupDurationMs": 2503,
      "deployDurationMs": 17860,
      "testDurationMs": 600,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.97,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-14T14:30:52.580Z",
      "headSha": "c1911ee4b5f4518ca579e19e6543187d063c6871",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/305572908384691",
      "shortSha": "c1911ee",
      "cleanupDurationMs": 468,
      "deployDurationMs": 22364,
      "testDurationMs": 16815,
      "testRetries": null,
      "workerSizeKib": 5117.13,
      "workerGzipKib": 1458.43,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-14T14:30:50.902Z",
      "headSha": "c1911ee4b5f4518ca579e19e6543187d063c6871",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/305572908384691",
      "shortSha": "c1911ee",
      "cleanupDurationMs": 455347,
      "deployDurationMs": 91608,
      "testDurationMs": 203761,
      "testRetries": "6 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · delivery expressions must end in a property step, rejected before commit (vitest x1) · global streams reject webhook subscriptions before commit (vitest x1) · creates a project and uses project streams through v4 itx (vitest x1) · project REPL accepts a forged session (specs x1) · reactivity page delivers an appended event to another open tab (specs x1)",
      "workerSizeKib": 16353.42,
      "workerGzipKib": 4410.78,
      "mainWorkerGzipKib": 4411.66
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-14T14:23:16.095Z",
      "headSha": "c1911ee4b5f4518ca579e19e6543187d063c6871",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/305572908384691",
      "shortSha": "c1911ee",
      "cleanupDurationMs": 537,
      "deployDurationMs": 13698,
      "testDurationMs": 6006,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `c1911ee` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 820.0 KiB | 17.9s | 600ms |  | 2.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/305572908384691) | 2026-07-14T14:30:54.613Z | Preview app released. |
| OS | released | `c1911ee` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.31 MiB (-0.9 KiB vs main) | 91.6s | 203.8s | 6 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · delivery expressions must end in a property step, rejected before commit (vitest x1) · global streams reject webhook subscriptions before commit (vitest x1) · creates a project and uses project streams through v4 itx (vitest x1) · project REPL accepts a forged session (specs x1) · reactivity page delivers an appended event to another open tab (specs x1) | 455.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/305572908384691) | 2026-07-14T14:30:50.902Z | Preview app released. |
| Semaphore | released | `c1911ee` | [https://semaphore.iterate-preview-1.com](https://semaphore.iterate-preview-1.com) | 440.8 KiB | 13.7s | 6.0s |  | 537ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/305572908384691) | 2026-07-14T14:23:16.095Z | Preview app released. |
| Streams Example App | released | `c1911ee` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.42 MiB | 22.4s | 16.8s |  | 468ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/305572908384691) | 2026-07-14T14:30:52.580Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->