### PR TITLE
Keep task add controls below cards

### DIFF
--- a/apps/os/src/components/repo-ide/repo-task-editor-state.ts
+++ b/apps/os/src/components/repo-ide/repo-task-editor-state.ts
@@ -1,0 +1,11 @@
+export type EditorPathOverride = {
+  source: string | undefined;
+  target: string | undefined;
+};
+
+export function reconcileEditorPathOverride(
+  override: EditorPathOverride | undefined,
+  selectedPath: string | undefined,
+) {
+  return override !== undefined && override.source === selectedPath ? override : undefined;
+}

--- a/apps/os/src/components/repo-ide/repo-tasks-view.test.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { createElement, Fragment } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { expect, test, vi } from "vitest";
+import type { RepoTask } from "./repo-tasks.ts";
+
+vi.mock("@dnd-kit/react", () => ({
+  DragDropProvider: Fragment,
+  useDraggable: () => ({ ref: undefined, isDragging: false }),
+  useDroppable: () => ({ ref: undefined, isDropTarget: false }),
+}));
+
+const task = (path: string, title: string): RepoTask => ({
+  path,
+  taskDirectoryPath: "tasks",
+  folderPath: "/",
+  title,
+  description: "",
+  state: "todo",
+  labels: [],
+  agent: undefined,
+  comments: [],
+  content: `---\nstate: todo\n---\n\n# ${title}\n`,
+});
+
+test("the cell add button is always immediately below its task cards", async () => {
+  const { TaskColumn } = await import("./repo-tasks-view.tsx");
+  const html = renderToStaticMarkup(
+    createElement(TaskColumn, {
+      state: "todo",
+      rowKey: "folder:/",
+      rowLabel: "/",
+      tasks: [task("tasks/first.md", "First"), task("tasks/second.md", "Second")],
+      visibleProperties: { folder: false, state: false, labels: true },
+      showHeader: true,
+      onOpen: vi.fn(),
+      onCreate: vi.fn(),
+    }),
+  );
+  const container = document.createElement("div");
+  container.innerHTML = html;
+  const cell = container.querySelector("[data-task-cell]");
+  const cards = cell?.querySelectorAll("[data-task-path]");
+  const addButton = cell?.querySelector('[aria-label="Add task to Todo in /"]');
+
+  expect(cards).toHaveLength(2);
+  expect(addButton).not.toBeNull();
+  expect(cards?.item(1).compareDocumentPosition(addButton!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  expect(addButton?.parentElement?.firstElementChild?.contains(cards?.item(0) ?? null)).toBe(true);
+  expect(addButton?.previousElementSibling?.contains(cards?.item(1) ?? null)).toBe(true);
+});
+
+test("an empty cell still renders its add button", async () => {
+  const { TaskColumn } = await import("./repo-tasks-view.tsx");
+  const html = renderToStaticMarkup(
+    createElement(TaskColumn, {
+      state: "in-review",
+      rowKey: "folder:/apps/os",
+      rowLabel: "/apps/os",
+      tasks: [],
+      visibleProperties: { folder: false, state: false, labels: true },
+      showHeader: false,
+      onOpen: vi.fn(),
+      onCreate: vi.fn(),
+    }),
+  );
+  const container = document.createElement("div");
+  container.innerHTML = html;
+
+  expect(
+    container.querySelector('[aria-label="Add task to In review in /apps/os"]'),
+  ).not.toBeNull();
+});
+
+test("an editor path override expires after router selection advances", async () => {
+  const { reconcileEditorPathOverride } = await import("./repo-task-editor-state.ts");
+  const pending = { source: "tasks/first.md", target: "tasks/second.md" };
+
+  expect(reconcileEditorPathOverride(pending, "tasks/first.md")).toEqual(pending);
+  const settled = reconcileEditorPathOverride(pending, "tasks/second.md");
+  expect(settled).toBeUndefined();
+  expect(reconcileEditorPathOverride(settled, "tasks/first.md")).toBeUndefined();
+});

--- a/apps/os/src/components/repo-ide/repo-tasks-view.tsx
+++ b/apps/os/src/components/repo-ide/repo-tasks-view.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import { DragDropProvider, useDraggable, useDroppable } from "@dnd-kit/react";
 import { Link } from "@tanstack/react-router";
 import {
@@ -82,6 +82,7 @@ import {
   type FileEntry,
   type WorkingTreeChanges,
 } from "./staged-changes.ts";
+import { reconcileEditorPathOverride, type EditorPathOverride } from "./repo-task-editor-state.ts";
 import { useItxQuery } from "~/itx/itx-react.tsx";
 import { linkOptionsForStreamPath } from "~/lib/stream-routes.ts";
 
@@ -119,11 +120,11 @@ export function RepoTasksView({
   onAssignAgent: (task: RepoTask, renamedFromPath?: string) => Promise<string | undefined>;
 }) {
   const [draft, setDraft] = useState<RepoTask | undefined>();
-  const [editorPath, setEditorPath] = useState(selectedPath);
-  const draftRef = useRef(draft);
-  const onSetWorkingRef = useRef(onSetWorking);
-  draftRef.current = draft;
-  onSetWorkingRef.current = onSetWorking;
+  const [editorPathOverride, setEditorPathOverride] = useState<EditorPathOverride>();
+  const editorPath =
+    editorPathOverride !== undefined && editorPathOverride.source === selectedPath
+      ? editorPathOverride.target
+      : selectedPath;
   const renameOrigins = useRef(new Map<string, string>());
   const lastCreationContext = useRef<{
     state: string;
@@ -179,8 +180,11 @@ export function RepoTasksView({
   const columns = taskStateColumns(tasks);
   const selectedTask = tasks.find((task) => task.path === editorPath);
   const editorTask = draft ?? selectedTask;
-  const editorTaskRef = useRef(editorTask);
-  editorTaskRef.current = editorTask;
+
+  useEffect(() => {
+    setEditorPathOverride((override) => reconcileEditorPathOverride(override, selectedPath));
+  }, [selectedPath]);
+
   const writeTask = (task: RepoTask, content: string) => {
     const baseline = textContentForEntry(changes.get(task.path)?.staged) ?? headContents[task.path];
     onSetWorking(task.path, content === baseline ? undefined : { type: "write", content });
@@ -188,7 +192,7 @@ export function RepoTasksView({
   const selectTask = (path: string | undefined) => {
     // Keep the editor bound to its destination synchronously. Working-tree
     // renames update the task list before router navigation can update the URL.
-    setEditorPath(path);
+    setEditorPathOverride({ source: selectedPath, target: path });
     onPatchSearch({ file: path, diff: undefined, preview: undefined, staged: undefined });
   };
   const persistDraft = (task = draft) => {
@@ -299,40 +303,35 @@ export function RepoTasksView({
     selectTask(undefined);
   };
 
-  useEffect(
-    () => () => {
-      const pendingDraft = draftRef.current;
-      if (pendingDraft === undefined) return;
-      onSetWorkingRef.current(pendingDraft.path, {
-        type: "write",
-        content: pendingDraft.content,
-      });
-    },
-    [],
-  );
+  const persistDraftOnUnmount = useEffectEvent(() => {
+    if (draft === undefined) return;
+    onSetWorking(draft.path, { type: "write", content: draft.content });
+  });
 
-  useEffect(() => setEditorPath(selectedPath), [selectedPath]);
+  const createTaskFromKeyboard = useEffectEvent((event: KeyboardEvent) => {
+    const target = event.target;
+    if (
+      event.key.toLocaleLowerCase() !== "c" ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.altKey ||
+      editorTask !== undefined ||
+      (target instanceof HTMLElement &&
+        (target.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName)))
+    )
+      return;
+    event.preventDefault();
+    const context = lastCreationContext.current;
+    createTask(context.state, context.folderPath, context.labels);
+  });
+
+  useEffect(() => () => persistDraftOnUnmount(), []);
 
   useEffect(() => {
-    const createFromKeyboard = (event: KeyboardEvent) => {
-      const target = event.target;
-      if (
-        event.key.toLocaleLowerCase() !== "c" ||
-        event.metaKey ||
-        event.ctrlKey ||
-        event.altKey ||
-        editorTaskRef.current !== undefined ||
-        (target instanceof HTMLElement &&
-          (target.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName)))
-      )
-        return;
-      event.preventDefault();
-      const context = lastCreationContext.current;
-      createTask(context.state, context.folderPath, context.labels);
-    };
+    const createFromKeyboard = (event: KeyboardEvent) => createTaskFromKeyboard(event);
     window.addEventListener("keydown", createFromKeyboard);
     return () => window.removeEventListener("keydown", createFromKeyboard);
-  });
+  }, []);
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1">
@@ -562,7 +561,7 @@ function BoardDisplaySettings({
   );
 }
 
-function TaskColumn({
+export function TaskColumn({
   state,
   rowKey,
   rowLabel,
@@ -604,15 +603,6 @@ function TaskColumn({
         </header>
       ) : null}
       <div className="flex min-h-0 flex-1 flex-col px-2 pb-2">
-        <Button
-          variant="ghost"
-          className="mb-2 h-10 w-full shrink-0 border border-dashed border-border/70 text-muted-foreground/60 hover:bg-muted/70 hover:text-muted-foreground"
-          title={`Add task to ${creationLabel}`}
-          aria-label={`Add task to ${creationLabel}`}
-          onClick={onCreate}
-        >
-          <PlusIcon data-icon="inline-start" />
-        </Button>
         <div className="flex flex-col gap-2">
           {tasks.map((task) => (
             <TaskCard
@@ -624,6 +614,15 @@ function TaskColumn({
             />
           ))}
         </div>
+        <Button
+          variant="ghost"
+          className="mt-2 h-10 w-full shrink-0 border border-dashed border-border/70 text-muted-foreground/60 hover:bg-muted/70 hover:text-muted-foreground"
+          title={`Add task to ${creationLabel}`}
+          aria-label={`Add task to ${creationLabel}`}
+          onClick={onCreate}
+        >
+          <PlusIcon data-icon="inline-start" />
+        </Button>
       </div>
     </section>
   );
@@ -744,7 +743,7 @@ function TaskEditorSheet({
   const editorRef = useRef<HTMLTextAreaElement>(null);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [pathValue, setPathValue] = useState("");
-  const [pathWasEdited, setPathWasEdited] = useState(false);
+  const pathWasEditedRef = useRef(false);
   const [assigning, setAssigning] = useState(false);
   const [assignedAgent, setAssignedAgent] = useState<string | undefined>();
   const editorSessionOpenRef = useRef(false);
@@ -754,13 +753,13 @@ function TaskEditorSheet({
   useEffect(() => {
     if (taskPath === undefined) {
       editorSessionOpenRef.current = false;
-      setPathWasEdited(false);
+      pathWasEditedRef.current = false;
       return;
     }
     setPathValue(`/${taskPath}`);
     if (editorSessionOpenRef.current) return;
     editorSessionOpenRef.current = true;
-    setPathWasEdited(false);
+    pathWasEditedRef.current = false;
     const focusEditor = () => {
       const editor = editorRef.current;
       if (editor === null) return;
@@ -781,15 +780,15 @@ function TaskEditorSheet({
 
   const resolvePath = () => {
     if (task === undefined) return undefined;
-    if (!pathWasEdited) return task;
+    if (!pathWasEditedRef.current) return task;
     const resolved = onResolvePath(pathValue);
     if (resolved === undefined) {
       setPathValue(`/${task.path}`);
-      setPathWasEdited(false);
+      pathWasEditedRef.current = false;
       return undefined;
     }
     setPathValue(`/${resolved.path}`);
-    setPathWasEdited(false);
+    pathWasEditedRef.current = false;
     return resolved;
   };
 
@@ -820,7 +819,7 @@ function TaskEditorSheet({
               aria-label="Task file path"
               className="h-6 rounded-none border-0 px-0 font-mono text-xs text-muted-foreground shadow-none focus-visible:ring-0"
               onChange={(event) => {
-                setPathWasEdited(true);
+                pathWasEditedRef.current = true;
                 setPathValue(event.currentTarget.value);
               }}
               onKeyDown={(event) => {
@@ -830,7 +829,7 @@ function TaskEditorSheet({
                   event.currentTarget.blur();
                 } else if (event.key === "Escape") {
                   setPathValue(`/${task.path}`);
-                  setPathWasEdited(false);
+                  pathWasEditedRef.current = false;
                   event.currentTarget.blur();
                 }
               }}
@@ -907,7 +906,9 @@ function TaskEditorSheet({
                     className="shrink-0 text-muted-foreground hover:text-destructive"
                     title="Delete task"
                     aria-label="Delete task"
-                    onClick={() => withResolvedPath(() => setDeleteOpen(true))}
+                    onClick={() => {
+                      if (resolvePath() !== undefined) setDeleteOpen(true);
+                    }}
                   >
                     <Trash2Icon data-icon="inline-start" />
                   </Button>
@@ -920,7 +921,7 @@ function TaskEditorSheet({
             aria-label={`Edit ${task.title} Markdown`}
             value={task.content}
             onChange={(event) =>
-              onChangeContent(event.currentTarget.value, isNew && !pathWasEdited)
+              onChangeContent(event.currentTarget.value, isNew && !pathWasEditedRef.current)
             }
             onKeyDown={(event) => {
               if (


### PR DESCRIPTION
## Summary

- keep the always-visible dashed add control immediately below the final task card in every row × status cell
- preserve empty-cell add controls and the cell-specific status/folder creation context
- replace render-time ref mutation and mirrored state with React 19 Effect Events and derived editor-path state
- add a DOM-order regression test for populated and empty cells

## Root cause

PR #1985 followed a contradictory earlier instruction and moved the add controls back above each list, undoing #1982. The clarified behavior is below the last card in each individual cell.

## Validation

- React Doctor: 100/100, 0 diagnostics for changed files
- `pnpm typecheck`
- `pnpm lint` (0 warnings, 0 errors)
- `pnpm test` (OS: 1,407 passed, 2 skipped; all workspace suites green)
- focused task suites: 23 passed
- browser-verified desktop and 390×844 mobile layouts
- browser-verified cell context, selected initial heading, automatic path slugging, and Cmd+Return creation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped repo task board UI and local editor state; no auth, persistence APIs, or security-sensitive paths.
> 
> **Overview**
> Moves each board cell’s dashed **Add task** control from above the card list to **immediately below** the last task card (empty cells still show the button). **`TaskColumn`** is exported so layout can be asserted in tests.
> 
> Task selection during renames no longer mirrors URL in separate `editorPath` state: a short-lived **`editorPathOverride`** (`source` → `target`) drives the open editor until `selectedPath` catches up, via **`reconcileEditorPathOverride`**.
> 
> Draft persistence on unmount and the **`c`** keyboard shortcut use React 19 **`useEffectEvent`** instead of render-time ref updates; the sheet’s “path was edited” flag is a ref. Delete only opens the confirm dialog when **`resolvePath()`** succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c27faff4894b50c73b5ef5eefec04c1c4148114a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +70 -58 | +66 -58 🟩🟩🟩🟥🟥 |
| Tests | +83 -0 | +74 -0 🟩🟩🟩⬜⬜ |
| **Total** | **+153 -58** | **+140 -58** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 985e5d1 and c27faff, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "cleanup-failed",
      "updatedAt": "2026-07-14T14:28:54.793Z",
      "headSha": "c27faff4894b50c73b5ef5eefec04c1c4148114a",
      "message": "CloudflareApiError: Cloudflare API POST /accounts/376ef7ed81b0573f93524de763666c15/d1/database/2017a0b9-ebd5-482c-b2b8-894a27733dbc/query failed (429): [{\"code\":971,\"message\":\"Please wait and consider throttling your request speed\"}]\n    at cfV4 (/home/runner/work/iterate/iterate/scripts/lib/env-context.ts:108:13)\n    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)\n    at async wipeD1Tables (/home/runner/work/iterate/iterate/scripts/lib/deploy-helpers.ts:312:5)\n    at async eraseData (/home/runner/work/iterate/iterate/apps/auth/scripts/erase-data.ts:44:3)\n    at async Command.<anonymous> (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:416:32)\n    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)\n    at async Command.<anonymous> (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:457:21)\n    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)\n    at async Object.run (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:527:9) {\n  method: 'POST',\n  path: '/accounts/376ef7ed81b0573f93524de763666c15/d1/database/2017a0b9-ebd5-482c-b2b8-894a27733dbc/query',\n  status: 429\n}\n\n\n> @iterate-com/auth@0.0.0-dev destroy /home/runner/work/iterate/iterate/apps/auth\n> tsx ./scripts/erase-data.ts --env preview_3\n\nErasing all data in preview_3 (auth D1 2017a0b9-ebd5-482c-b2b8-894a27733dbc)\n ELIFECYCLE  Command failed with exit code 1.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/502549181171889",
      "shortSha": "c27faff",
      "cleanupDurationMs": 1717,
      "deployDurationMs": 18633,
      "testDurationMs": 206,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.73,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-14T14:28:51.823Z",
      "headSha": "c27faff4894b50c73b5ef5eefec04c1c4148114a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/502549181171889",
      "shortSha": "c27faff",
      "cleanupDurationMs": 12523,
      "deployDurationMs": 85199,
      "testDurationMs": 222049,
      "testRetries": "3 retried: agent answers after llm model is selected (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · hydrates the client-only integrations route without rebuilding the shell (specs x1)",
      "workerSizeKib": 16356.25,
      "workerGzipKib": 4411.67,
      "mainWorkerGzipKib": 4411.66
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-14T14:28:53.810Z",
      "headSha": "c27faff4894b50c73b5ef5eefec04c1c4148114a",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/502549181171889",
      "shortSha": "c27faff",
      "cleanupDurationMs": 731,
      "deployDurationMs": 17377,
      "testDurationMs": 20199,
      "testRetries": null,
      "workerSizeKib": 5119.59,
      "workerGzipKib": 1459.29,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-14T14:28:39.798Z",
      "headSha": "c27faff4894b50c73b5ef5eefec04c1c4148114a",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/502549181171889",
      "shortSha": "c27faff",
      "cleanupDurationMs": 496,
      "deployDurationMs": 14632,
      "testDurationMs": 6297,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_3",
    "slug": "preview-3"
  },
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>Slot: preview-3 | Doppler config: preview_3</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | cleanup failed | `c27faff` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 819.7 KiB | 18.6s | 206ms |  | 1.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/502549181171889) | 2026-07-14T14:28:54.793Z | CloudflareApiError: Cloudflare API POST /accounts/376ef7ed81b0573f93524de763666c15/d1/database/2017a0b9-ebd5-482c-b2b8-894a27733dbc/query failed (429): [{"code":971,"message":"Ple... |
| OS | released | `c27faff` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.31 MiB (+0.0 KiB vs main) | 85.2s | 222.0s | 3 retried: agent answers after llm model is selected (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · hydrates the client-only integrations route without rebuilding the shell (specs x1) | 12.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/502549181171889) | 2026-07-14T14:28:51.823Z | Preview app released. |
| Semaphore | released | `c27faff` | [https://semaphore.iterate-preview-3.com](https://semaphore.iterate-preview-3.com) | 440.8 KiB | 14.6s | 6.3s |  | 496ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/502549181171889) | 2026-07-14T14:28:39.798Z | Preview app released. |
| Streams Example App | released | `c27faff` | [https://streams.iterate-preview-3.com](https://streams.iterate-preview-3.com) | 1.43 MiB | 17.4s | 20.2s |  | 731ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/502549181171889) | 2026-07-14T14:28:53.810Z | Preview app released. |

</details>

<details>
<summary>Auth failure details</summary>

<pre>CloudflareApiError: Cloudflare API POST /accounts/376ef7ed81b0573f93524de763666c15/d1/database/2017a0b9-ebd5-482c-b2b8-894a27733dbc/query failed (429): [{"code":971,"message":"Please wait and consider throttling your request speed"}]
    at cfV4 (/home/runner/work/iterate/iterate/scripts/lib/env-context.ts:108:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async wipeD1Tables (/home/runner/work/iterate/iterate/scripts/lib/deploy-helpers.ts:312:5)
    at async eraseData (/home/runner/work/iterate/iterate/apps/auth/scripts/erase-data.ts:44:3)
    at async Command.&lt;anonymous&gt; (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:416:32)
    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)
    at async Command.&lt;anonymous&gt; (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:457:21)
    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)
    at async Object.run (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:527:9) {
  method: 'POST',
  path: '/accounts/376ef7ed81b0573f93524de763666c15/d1/database/2017a0b9-ebd5-482c-b2b8-894a27733dbc/query',
  status: 429
}


&gt; @iterate-com/auth@0.0.0-dev destroy /home/runner/work/iterate/iterate/apps/auth
&gt; tsx ./scripts/erase-data.ts --env preview_3

Erasing all data in preview_3 (auth D1 2017a0b9-ebd5-482c-b2b8-894a27733dbc)
 ELIFECYCLE  Command failed with exit code 1.</pre>

</details>
<!-- /CLOUDFLARE_PREVIEW -->